### PR TITLE
fix(rust): modify join error

### DIFF
--- a/polars/polars-ops/src/frame/join/mod.rs
+++ b/polars/polars-ops/src/frame/join/mod.rs
@@ -165,7 +165,17 @@ pub trait DataFrameJoinOps: IntoDf {
             .iter()
             .zip(&selected_right)
             .all(|(l, r)| l.dtype() == r.dtype()),
-            ComputeError: "datatypes of join keys don't match"
+            ComputeError: {
+                let (l, r) = selected_left
+                .iter()
+                .zip(&selected_right)
+                .find(|(l, r)| l.dtype() != r.dtype())
+                .unwrap();
+                format!(
+                    "datatypes of join keys don't match - `{}`: {} on left does not match `{}`: {} on right",
+                    l.name(), l.dtype(), r.name(), r.dtype()
+                )
+            }
         );
 
         #[cfg(feature = "dtype-categorical")]

--- a/polars/polars-ops/src/frame/join/mod.rs
+++ b/polars/polars-ops/src/frame/join/mod.rs
@@ -158,7 +158,7 @@ pub trait DataFrameJoinOps: IntoDf {
 
         polars_ensure!(
             selected_left.len() == selected_right.len(),
-            ComputeError: "the number of columns given as join key should be equal"
+            ComputeError: format!("the number of columns given as join key (left: {}, right:{}) should be equal", selected_left.len(), selected_right.len())
         );
         polars_ensure!(
             selected_left

--- a/polars/polars-ops/src/frame/join/mod.rs
+++ b/polars/polars-ops/src/frame/join/mod.rs
@@ -160,23 +160,20 @@ pub trait DataFrameJoinOps: IntoDf {
             selected_left.len() == selected_right.len(),
             ComputeError: format!("the number of columns given as join key (left: {}, right:{}) should be equal", selected_left.len(), selected_right.len())
         );
-        polars_ensure!(
-            selected_left
+
+        if let Some((l, r)) = selected_left
             .iter()
             .zip(&selected_right)
-            .all(|(l, r)| l.dtype() == r.dtype()),
-            ComputeError: {
-                let (l, r) = selected_left
-                .iter()
-                .zip(&selected_right)
-                .find(|(l, r)| l.dtype() != r.dtype())
-                .unwrap();
-                format!(
-                    "datatypes of join keys don't match - `{}`: {} on left does not match `{}`: {} on right",
-                    l.name(), l.dtype(), r.name(), r.dtype()
-                )
-            }
-        );
+            .find(|(l, r)| l.dtype() != r.dtype())
+        {
+            polars_bail!(
+                ComputeError:
+                    format!(
+                        "datatypes of join keys don't match - `{}`: {} on left does not match `{}`: {} on right",
+                        l.name(), l.dtype(), r.name(), r.dtype()
+                    )
+            );
+        };
 
         #[cfg(feature = "dtype-categorical")]
         for (l, r) in selected_left.iter().zip(&selected_right) {


### PR DESCRIPTION
### Why
To address https://github.com/pola-rs/polars/issues/8766

AsIs: `exceptions.ComputeError: datatypes of join keys don't match`
ToBe: ``exceptions.ComputeError: datatypes of join keys don't match - `x1`: i64 on left does not match `x1`: str on right``
