### PR TITLE
docs: add readmes to all sub crates

### DIFF
--- a/polars-cli/README.md
+++ b/polars-cli/README.md
@@ -62,3 +62,13 @@ shape: (27, 1)
 │ fruit      │
 └────────────┘
 ```
+
+## Features
+
+| Feature   | Description                                               |
+| --------- | --------------------------------------------------------- |
+| highlight | Provides syntax highlighting                              |
+| default   | The default feature set that includes all other features. |
+| parquet   | Enables reading and writing of Apache Parquet files.      |
+| json      | Enables reading and writing of JSON files.                |
+| ipc       | Enables reading and writing of IPC/Apache Arrow files     |

--- a/polars/polars-algo/README.md
+++ b/polars/polars-algo/README.md
@@ -1,0 +1,3 @@
+# polars-algo
+
+`polars-algo` is a submodule of Polars that contains algorithms built upon Polars primitives.

--- a/polars/polars-arrow/README.md
+++ b/polars/polars-arrow/README.md
@@ -1,0 +1,17 @@
+# polars-arrow
+
+`polars-arrow` is a submodule of Polars that provides Arrow interfaces for the Polars.
+
+## Features
+
+| Feature    | Description                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------- |
+| nightly    | Enables the use of unstable and experimental features that are only available on the nightly version of Rust. |
+| strings    | string operations.                                                                                            |
+| compute    | compute functions.                                                                                            |
+| temporal   | support for temporal data types: `Datetime`, `Date`, and `Time`.                                              |
+| bigidx     | support for large arrays and indexes in the code.                                                             |
+| performant | optimizations for performance _(at the expense of compile time)_                                              |
+| like       | `like` operations.                                                                                            |
+| timezones  | timezone parsing                                                                                              |
+| simd       | the use of SIMD instructions for faster processing.                                                           |

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -78,7 +78,7 @@ semi_anti_join = []
 chunked_ids = []
 describe = []
 timezones = ["chrono-tz", "arrow/chrono-tz", "polars-arrow/timezones"]
-dynamic_groupby = ["dtype-datetime", "dtype-date"]
+dynamic_groupby = ["dtype-datetime", "dtype-date", "polars-lazy/dynamic_groupby"]
 
 # opt-in datatypes for Series
 dtype-date = ["temporal"]

--- a/polars/polars-core/README.md
+++ b/polars/polars-core/README.md
@@ -1,0 +1,75 @@
+# Polars Core
+
+This crate is a submodule of Polars. It contains the core functionality for the Polars DataFrame library.
+
+# Features
+
+| Feature              | Description                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------- |
+| simd                 | Enables the use of SIMD instructions to accelerate computations.                                              |
+| nightly              | Enables the use of unstable and experimental features that are only available on the nightly version of Rust. |
+| avx512               | Enables the use of AVX-512 instructions to accelerate computations.                                           |
+| docs                 | Includes documentation-related features.                                                                      |
+| temporal             | temporal data types: `Datetime`, `Date`, `Duration` and `Time`.                                               |
+| random               | the `Random` RankMethod                                                                                       |
+| default              | Includes default features (docs, temporal, and private).                                                      |
+| lazy                 | lazy evaluation.                                                                                              |
+| performant           | Provides faster operations at the expense of compilation time.                                                |
+| strings              | Provides extra utilities for Utf8Chunked.                                                                     |
+| object               | ObjectChunked<T> (downcastable Series of any type).                                                           |
+| fmt                  | Pretty formatting of DataFrames                                                                               |
+| fmt_no_tty           | Pretty formatting of DataFrames without tty.                                                                  |
+| sort_multiple        | sorting by multiple columns.                                                                                  |
+| rows                 | Enables the creation of a DataFrame from row values and includes `pivot` operation.                           |
+| is_in                | `is_in` operation.                                                                                            |
+| zip_with             | Enables the use of `hmin, hmax, zip_with, zip_with_same_type` operations.                                     |
+| round_series         | Enables the use of rounding operations: (`round, floor, ceil, clip, clip_max, clip_min`)                      |
+| checked_arithmetic   | Enables checked arithmetic (addition, subtraction, multiplication, and division) for integer data types.      |
+| repeat_by            | `repeat_by` operation.                                                                                        |
+| is_first             | `is_first` operation.                                                                                         |
+| is_last              | `is_last` operation.                                                                                          |
+| asof_join            | Enables the `AsOf` Join Type.                                                                                 |
+| cross_join           | Enables the `Cross` Join Type.                                                                                |
+| dot_product          | `dot` operation.                                                                                              |
+| concat_str           | `concat_str` operation.                                                                                       |
+| row_hash             | `row_hash` operation.                                                                                         |
+| mode                 | `mode` operation.                                                                                             |
+| cum_agg              | Enables cumulative aggregation (cumsum, cummin, etc.).                                                        |
+| rolling_window       | Enables the use of rolling window functions.                                                                  |
+| diff                 | `diff` operation.                                                                                             |
+| moment               | `moment` operation.                                                                                           |
+| diagonal_concat      | `diagonal_concat` operation.                                                                                  |
+| horizontal_concat    | `horizontal_concat` operation.                                                                                |
+| abs                  | `abs` operation.                                                                                              |
+| ewma                 | Enables exponential weighted moving average (EWMA) support.                                                   |
+| dataframe_arithmetic | Enables arithmetic operations between DataFrames.                                                             |
+| product              | `product` operation.                                                                                          |
+| unique_counts        | `unique_counts` operation.                                                                                    |
+| partition_by         | `partition_by` operation.                                                                                     |
+| semi_anti_join       | `semi_anti_join` operation.                                                                                   |
+| chunked_ids          | `chunked_ids` operation.                                                                                      |
+| describe             | `describe` operation.                                                                                         |
+| timezones            | Enables timezone parsing via chrono-tz                                                                        |
+| dynamic_groupby      | `dynamic_groupby` operation                                                                                   |
+| dtype-date           | `Date` DataType                                                                                               |
+| dtype-datetime       | `Datetime` DataType                                                                                           |
+| dtype-time           | `Time` DataType.                                                                                              |
+| dtype-i8             | `Int8` DataType                                                                                               |
+| dtype-i16            | `Int16` DataType                                                                                              |
+| dtype-u8             | `UInt8` DataType                                                                                              |
+| dtype-u16            | `UInt16` DataType                                                                                             |
+| dtype-decimal        | `Decimal` DataType                                                                                            |
+| dtype-categorical    | `Categorical` DataType                                                                                        |
+| dtype-struct         | `Struct` DataType                                                                                             |
+| parquet              | Enables reading & writing for Parquet files.                                                                  |
+| bigidx               | large arrays and indexes in the code.                                                                         |
+| python               | Python integration.                                                                                           |
+| serde                | (de)serialization of Polars types                                                                             |
+| serde-lazy           | (de)serialization LazyFrames & Exprs                                                                          |
+| async                | async support.                                                                                                |
+| aws                  | reading from AWS S3 object store.                                                                             |
+| azure                | reading from Azure Blob Storage.                                                                              |
+| gcp                  | reading from Google Cloud Storage.                                                                            |
+| private              | Enables private APIs. <sup>[1](#footnote1)</sup>                                                              |
+
+<sup><a name="footnote1">1</a></sup> Private APIs in `polars` are not intended for public use and may change without notice. Use at your own risk.

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -724,7 +724,7 @@ pub trait IsFirst<T: PolarsDataType> {
     }
 }
 
-#[cfg(feature = "is_first")]
+#[cfg(feature = "is_last")]
 /// Mask the last unique values as `true`
 pub trait IsLast<T: PolarsDataType> {
     fn is_last(&self) -> PolarsResult<BooleanChunked> {

--- a/polars/polars-core/src/utils/mod.rs
+++ b/polars/polars-core/src/utils/mod.rs
@@ -661,7 +661,7 @@ where
 
 #[allow(clippy::type_complexity)]
 #[cfg(feature = "zip_with")]
-pub fn align_chunks_ternary<'a, A, B, C>(
+pub(crate) fn align_chunks_ternary<'a, A, B, C>(
     a: &'a ChunkedArray<A>,
     b: &'a ChunkedArray<B>,
     c: &'a ChunkedArray<C>,

--- a/polars/polars-error/README.md
+++ b/polars/polars-error/README.md
@@ -1,0 +1,3 @@
+# polars-error
+
+`polars-error` is a submodule of Polars that provides Error definitions for the Polars DataFrame library.

--- a/polars/polars-io/Cargo.toml
+++ b/polars/polars-io/Cargo.toml
@@ -18,7 +18,6 @@ ipc = ["arrow/io_ipc", "arrow/io_ipc_compression", "memmap"]
 ipc_streaming = ["arrow/io_ipc", "arrow/io_ipc_compression"]
 # support for arrow avro parsing
 avro = ["arrow/io_avro", "arrow/io_avro_compression"]
-# ipc = []
 csv = ["memmap", "lexical", "polars-core/rows", "lexical-core", "fast-float", "simdutf8"]
 decompress = ["flate2/miniz_oxide"]
 decompress-fast = ["flate2/zlib-ng"]

--- a/polars/polars-io/README.md
+++ b/polars/polars-io/README.md
@@ -2,10 +2,6 @@
 
 `polars-io` is a submodule of polars-lazy that provides IO functionality.
 
-## License
-
-This project is licensed under the MIT License.
-
 ## Repository
 
 The source code for this crate can be found on GitHub: [https://github.com/pola-rs/polars](https://github.com/pola-rs/polars)

--- a/polars/polars-io/README.md
+++ b/polars/polars-io/README.md
@@ -1,0 +1,42 @@
+# Polars IO
+
+`polars-io` is a submodule of polars-lazy that provides IO functionality.
+
+## License
+
+This project is licensed under the MIT License.
+
+## Repository
+
+The source code for this crate can be found on GitHub: [https://github.com/pola-rs/polars](https://github.com/pola-rs/polars)
+
+## Features
+
+| Feature           | Description                                          |
+| ----------------- | ---------------------------------------------------- |
+| json              | reading & writing for JSON files.                    |
+| parquet           | reading & writing for Parquet files.                 |
+| ipc               | reading & writing for IPC/Arrow files.               |
+| ipc_streaming     | Arrow's streaming IPC file parsing support           |
+| avro              | Arrow's Avro parsing support                         |
+| csv               | reading & writing for CSV files                      |
+| decompress        | decompression support                                |
+| decompress-fast   | faster decompression                                 |
+| dtype-categorical | `Categorical` data type                              |
+| dtype-date        | `Date` data type                                     |
+| dtype-datetime    | `Datetime` data type                                 |
+| dtype-time        | `Time` data type.                                    |
+| dtype-struct      | `Struct` data type                                   |
+| timezones         | timezone parsing via chrono-tz                       |
+| fmt               | pretty formatting of dataframes                      |
+| lazy              | Reserved for future use.                             |
+| async             | async support.                                       |
+| aws               | reading from AWS S3 object store.                    |
+| azure             | reading from Azure Blob Storage.                     |
+| gcp               | reading from Google Cloud Storage.                   |
+| partition         | partitioned writing                                  |
+| temporal          | temporal data types: `Datetime`, `Date`, and `Time`. |
+| simd              | Reserved for future use.                             |
+| private           | private APIs. <sup>[1](#footnote1)</sup>             |
+
+<sup><a name="footnote1">1</a></sup> Private APIs in `polars` are not intended for public use and may change without notice. Use at your own risk.

--- a/polars/polars-lazy/README.md
+++ b/polars/polars-lazy/README.md
@@ -1,0 +1,91 @@
+# polars-lazy
+
+`polars-lazy` is a lazy query engine for the Polars DataFrame library. It allows you to perform operations on DataFrames in a lazy manner, only executing them when necessary. This can lead to significant performance improvements for large datasets.
+
+## Features
+
+| Feature         | Description                                      |
+| --------------- | ------------------------------------------------ | --- | --- |
+| nightly         | Enable nightly features                          |
+| compile         | Features required to compile                     |
+| streaming       | Enable streaming data processing                 |
+| default         | Enable default features                          |
+| parquet         | Enable Parquet file format support               |
+| async           | Enable asynchronous data processing              |
+| ipc             | Enable IPC (Inter-process communication) support |
+| json            | Enable JSON file format support                  |
+| csv             | Enable CSV file format support                   |
+| temporal        | temporal data types                              |
+| fmt             | formatting DataFrames                            |
+| strings         | string processing                                |
+| dtype-\*        | various data types (e.g., dtype-u8)              |
+| object          | object data types                                |
+| date_offset     | date offsets                                     |
+| trigonometry    | `trigonometry` operations                        |
+| sign            | `sign` operations                                |
+| timezones       | `timezone-aware` operations                      |
+| list\_\*        | various list operations (e.g., list_take)        |
+| true_div        | true division                                    |
+| approx_unique   | approximate unique operation                     |
+| is_in           | `is_in` operation                                |
+| repeat_by       | `repeat_by` operation                            |
+| round_series    | `round_series` operation                         |
+| is_first        | `is_first` operation                             |
+| is_unique       | `is_unique` operation                            |
+| cross_join      | `cross_join` operation                           |
+| asof_join       | `asof_join` operation                            |
+| concat_str      | `concat_str` operation                           |
+| arange          | `arange` operation                               |
+| mode            | `mode` operation                                 |
+| cum_agg         | `cum_agg` operation                              |
+| interpolate     | `interpolate` operation                          |
+| rolling_window  | `rolling_window` operation                       |
+| rank            | `rank` operation                                 |
+| diff            | `diff` operation                                 |
+| pct_change      | `pct_change` operation                           |
+| moment          | `moment` operation                               |
+| abs             | `abs` operation                                  |
+| random          | `random` operation                               |
+| dynamic_groupby | `dynamic_groupby` operation                      |
+| ewma            | `ewma` operation                                 |
+| dot_diagram     | `dot_diagram` operation                          |
+| unique_counts   | `unique_counts` operation                        |
+| log             | `log` operation                                  |
+| search_sorted   | `search_sorted` operation                        |
+| merge_sorted    | `merge_sorted` operation                         |
+| pivot           | `pivot` operation                                |
+| top_k           | `top_k` operation                                |
+| semi_anti_join  | semi/anti join operations                        |
+| cse             | common subexpression elimination                 |
+| propagate_nans  | NaN propagation                                  |
+| coalesce        | coalesce operation                               |
+| regex           | regular expressions                              |     | n   |
+| python          | PyO3 Python bindings                             |
+| row_hash        | row hashing                                      |
+| string\_\*      | various string operations                        |
+| arg_where       | arg_where operation                              |
+| search_sorted   | search_sorted operation                          |
+| merge_sorted    | merge_sorted operation                           |
+| meta            | metadata processing                              |
+| pivot           | pivot operation                                  |
+| top_k           | top_k operation                                  |
+| semi_anti_join  | semi/anti join operations                        |
+| cse             | common subexpression elimination                 |
+| propagate_nans  | NaN propagation                                  |
+| coalesce        | coalesce operation                               |
+| regex           | regular expressions                              |
+| serde           | Serde serialization                              |
+| fused           | fused operations                                 |
+| binary_encoding | binary encoding                                  |
+| bigidx          | big indices                                      |
+| panic_on_schema | Enable panic on schema mismatch                  |
+| private         | Enables private APIs. <sup>[1](#footnote1)</sup> |
+
+To enable a specific operation, add it to the `features` section of your `Cargo.toml` file:
+
+```toml
+[dependencies]
+polars-lazy = { version = "0.29.0", features = ["csv", "parquet", "json", "is_in", "repeat_by", "round_series"] }
+```
+
+<sup><a name="footnote1">1</a></sup> Private APIs in `polars` are not intended for public use and may change without notice. Use at your own risk.

--- a/polars/polars-lazy/polars-pipe/README.md
+++ b/polars/polars-lazy/polars-pipe/README.md
@@ -1,0 +1,22 @@
+# Polars Pipe
+
+`polars-pipe` is a submodule of polars-lazy that provides streaming support for the planner
+
+## Features
+
+| Feature           | Description                                      |
+| ----------------- | ------------------------------------------------ |
+| compile           | Features required to compile                     |
+| ipc               | Enable IPC (Inter-process communication) support |
+| csv               | Enable CSV file format support                   |
+| parquet           | Enable Parquet file format support               |
+| async             | async support                                    |
+| nightly           | Enable nightly features                          |
+| cross_join        | cross join                                       |
+| dtype-i8          | `Int8` DataType                                  |
+| dtype-i16         | `Int16` DataType                                 |
+| dtype-u8          | `UInt8` DataType                                 |
+| dtype-u16         | `UInt16` DataType                                |
+| dtype-decimal     | `Decimal` DataType                               |
+| dtype-categorical | `Categorical` DataType                           |
+| trigger_ooc       | This feature is reserved for future use.         |

--- a/polars/polars-ops/README.md
+++ b/polars/polars-ops/README.md
@@ -1,0 +1,54 @@
+# polars-ops
+
+`polars-ops` is a submodule of Polars that provides more operations on Polars data structures.
+
+## Features
+
+| Feature           | Description                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| simd              | Enables SIMD support for some mathematical operations                                                         |
+| nightly           | Enables the use of unstable and experimental features that are only available on the nightly version of Rust. |
+| dtype-categorical | Enables the categorical data type                                                                             |
+| dtype-date        | Enables the date data type                                                                                    |
+| dtype-datetime    | Enables the datetime data type                                                                                |
+| dtype-time        | Enables the time data type                                                                                    |
+| dtype-duration    | Enables the duration data type                                                                                |
+| dtype-struct      | Enables the struct data type                                                                                  |
+| dtype-u8          | Enables the unsigned 8-bit integer data type                                                                  |
+| dtype-u16         | Enables the unsigned 16-bit integer data type                                                                 |
+| dtype-i8          | Enables the signed 8-bit integer data type                                                                    |
+| dtype-i16         | Enables the signed 16-bit integer data type                                                                   |
+| dtype-decimal     | Enables the decimal data type                                                                                 |
+| object            | Enables the object data type                                                                                  |
+| propagate_nans    | Enables NaN propagation                                                                                       |
+| performant        | Enables performant operations                                                                                 |
+| big_idx           | Enables big index support                                                                                     |
+| round_series      | Enables the round series operation                                                                            |
+| is_first          | Enables the is_first operation                                                                                |
+| is_unique         | Enables the is_unique operation                                                                               |
+| approx_unique     | Enables the approx_unique operation                                                                           |
+| fused             | Enables fused operations                                                                                      |
+| binary_encoding   | Enables binary encoding support                                                                               |
+| string_encoding   | Enables string encoding support                                                                               |
+| to_dummies        | Enables the to_dummies operation                                                                              |
+| interpolate       | Enables the interpolate operation                                                                             |
+| list_to_struct    | Enables the list_to_struct operation                                                                          |
+| list_count        | Enables the list_count operation                                                                              |
+| diff              | Enables the diff operation                                                                                    |
+| strings           | Enables string operations                                                                                     |
+| string_justify    | Enables the string justify operation                                                                          |
+| string_from_radix | Enables the string from radix operation                                                                       |
+| extract_jsonpath  | Enables the extract_jsonpath operation                                                                        |
+| log               | Enables the log operation                                                                                     |
+| hash              | Enables the hash operation                                                                                    |
+| rolling_window    | Enables the rolling_window operation                                                                          |
+| moment            | Enables the moment operation                                                                                  |
+| search_sorted     | Enables the search_sorted operation                                                                           |
+| merge_sorted      | Enables the merge_sorted operation                                                                            |
+| top_k             | Enables the top_k operation                                                                                   |
+| pivot             | Enables the pivot operation                                                                                   |
+| cross_join        | Enables the cross_join operation                                                                              |
+| chunked_ids       | Enables the chunked_ids operation                                                                             |
+| asof_join         | Enables the asof_join operation                                                                               |
+| semi_anti_join    | Enables the semi_anti_join operation                                                                          |
+| list_take         | Enables the list_take operation                                                                               |

--- a/polars/polars-row/README.md
+++ b/polars/polars-row/README.md
@@ -1,0 +1,3 @@
+# polars-row
+
+`polars-row` is a submodule of Polars that provides row encodings for the Polars DataFrame library.

--- a/polars/polars-sql/README.md
+++ b/polars/polars-sql/README.md
@@ -1,0 +1,33 @@
+# Polars SQL
+
+`polars-sql` is a Rust crate that provides an SQL transpiler for Polars. It can convert SQL queries to Polars logical plans.
+
+## Usage
+
+To use `polars-sql`, add it as a dependency to your Rust project's `Cargo.toml` file:
+
+```toml
+[dependencies]
+polars-sql = "0.29.0"
+```
+
+You can then import the crate in your Rust code using:
+
+```rust
+use polars_sql::*;
+```
+
+## Features
+
+`polars-sql` has the following features:
+
+| Feature | Description                                      |
+| ------- | ------------------------------------------------ |
+| csv     | Enables support for CSV files.                   |
+| json    | Enables support for JSON files.                  |
+| default | The default feature set for Polars.              |
+| ipc     | Enables support for IPC/Arrow files.             |
+| parquet | Enables support for Parquet files.               |
+| private | Enables private APIs. <sup>[1](#footnote1)</sup> |
+
+<sup><a name="footnote1">1</a></sup> Private APIs in `polars` are not intended for public use and may change without notice. Use at your own risk.

--- a/polars/polars-time/README.md
+++ b/polars/polars-time/README.md
@@ -1,0 +1,21 @@
+# polars-time
+
+`polars-time` is a Rust crate that provides time-related code for the Polars dataframe library.
+
+## Features
+
+`polars-time` has the following features:
+
+| Feature        | Description                                              |
+| -------------- | -------------------------------------------------------- |
+| dtype-date     | Enables `Date` data type                                 |
+| dtype-datetime | Enables `Datetime` data type                             |
+| dtype-time     | Enables `Time` data type.                                |
+| dtype-duration | Enables `Duration` data type.                            |
+| rolling_window | Enables support for rolling window operations in Polars. |
+| fmt            | Enables pretty formatting of dataframes                  |
+| timezones      | Enables timezone parsing via chrono-tz                   |
+| default        | The default feature set for polars-time.                 |
+| private        | Enables private APIs. <sup>[1](#footnote1)</sup>         |
+
+<sup><a name="footnote1">1</a></sup> Private APIs in `polars` are not intended for public use and may change without notice. Use at your own risk.

--- a/polars/polars-utils/README.md
+++ b/polars/polars-utils/README.md
@@ -1,0 +1,8 @@
+# Polars-utils
+private utils for the polars dataframe library
+
+## Features
+| Feature | Description |
+| ------- | ----------- |
+| bigidx  | Enables support for large arrays and indexes in the code. |
+| nightly | Enables the use of unstable and experimental features that are only available on the nightly version of Rust. |


### PR DESCRIPTION
add readmes to submodules with tables of available features for each crate. 

Most of this was generated using the toml file & generative ai. 

I did my best to proofread & double check that these descriptions are accurate, but there are **A LOT** of them, so I apologize if there are any typos, incorrect descriptions, or other inconsistencies. 