### PR TITLE
perf(rust, python): improve parallel work distribution of sort expression `~4x`

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -476,6 +476,14 @@ pub struct SortOptions {
     pub multithreaded: bool,
 }
 
+#[derive(Clone)]
+#[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
+pub struct SortMultipleOptions {
+    pub other: Vec<Series>,
+    pub descending: Vec<bool>,
+    pub multithreaded: bool,
+}
+
 impl Default for SortOptions {
     fn default() -> Self {
         Self {
@@ -498,7 +506,7 @@ pub trait ChunkSort<T: PolarsDataType> {
     fn arg_sort(&self, options: SortOptions) -> IdxCa;
 
     /// Retrieve the indexes need to sort this and the other arrays.
-    fn arg_sort_multiple(&self, _other: &[Series], _descending: &[bool]) -> PolarsResult<IdxCa> {
+    fn arg_sort_multiple(&self, _options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
         polars_bail!(opq = arg_sort_multiple, T::get_dtype());
     }
 }

--- a/polars/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -25,11 +25,12 @@ pub(crate) fn args_validate<T: PolarsDataType>(
 
 pub(crate) fn arg_sort_multiple_impl<T: PartialOrd + Send + IsFloat + Copy>(
     mut vals: Vec<(IdxSize, T)>,
-    other: &[Series],
-    descending: &[bool],
+    options: &SortMultipleOptions,
 ) -> PolarsResult<IdxCa> {
-    assert_eq!(descending.len() - 1, other.len());
-    let compare_inner: Vec<_> = other
+    let descending = &options.descending;
+    debug_assert_eq!(descending.len() - 1, options.other.len());
+    let compare_inner: Vec<_> = options
+        .other
         .iter()
         .map(|s| s.into_partial_ord_inner())
         .collect_trusted();

--- a/polars/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -289,21 +289,34 @@ where
 
 fn arg_sort_multiple_numeric<T: PolarsNumericType>(
     ca: &ChunkedArray<T>,
-    other: &[Series],
-    descending: &[bool],
+    options: &SortMultipleOptions,
 ) -> PolarsResult<IdxCa> {
-    args_validate(ca, other, descending)?;
+    args_validate(ca, &options.other, &options.descending)?;
     let mut count: IdxSize = 0;
-    let vals: Vec<_> = ca
-        .into_iter()
-        .map(|v| {
-            let i = count;
-            count += 1;
-            (i, v)
-        })
-        .collect_trusted();
 
-    arg_sort_multiple_impl(vals, other, descending)
+    let no_nulls = ca.null_count() == 0;
+
+    if no_nulls {
+        let mut vals = Vec::with_capacity(ca.len());
+        for arr in ca.downcast_iter() {
+            vals.extend_trusted_len(arr.values().as_slice().iter().map(|v| {
+                let i = count;
+                count += 1;
+                (i, *v)
+            }))
+        }
+        arg_sort_multiple_impl(vals, options)
+    } else {
+        let mut vals = Vec::with_capacity(ca.len());
+        for arr in ca.downcast_iter() {
+            vals.extend_trusted_len(arr.into_iter().map(|v| {
+                let i = count;
+                count += 1;
+                (i, v.copied())
+            }));
+        }
+        arg_sort_multiple_impl(vals, options)
+    }
 }
 
 impl<T> ChunkSort<T> for ChunkedArray<T>
@@ -330,8 +343,8 @@ where
     ///
     /// This function is very opinionated.
     /// We assume that all numeric `Series` are of the same type, if not it will panic
-    fn arg_sort_multiple(&self, other: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-        arg_sort_multiple_numeric(self, other, descending)
+    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        arg_sort_multiple_numeric(self, options)
     }
 }
 
@@ -355,8 +368,8 @@ impl ChunkSort<Float32Type> for Float32Chunked {
     ///
     /// This function is very opinionated.
     /// We assume that all numeric `Series` are of the same type, if not it will panic
-    fn arg_sort_multiple(&self, other: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-        arg_sort_multiple_numeric(self, other, descending)
+    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        arg_sort_multiple_numeric(self, options)
     }
 }
 
@@ -380,8 +393,8 @@ impl ChunkSort<Float64Type> for Float64Chunked {
     ///
     /// This function is very opinionated.
     /// We assume that all numeric `Series` are of the same type, if not it will panic
-    fn arg_sort_multiple(&self, other: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-        arg_sort_multiple_numeric(self, other, descending)
+    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        arg_sort_multiple_numeric(self, options)
     }
 }
 
@@ -519,8 +532,8 @@ impl ChunkSort<Utf8Type> for Utf8Chunked {
     /// In this case we assume that all numeric `Series` are `f64` types. The caller needs to
     /// uphold this contract. If not, it will panic.
     ///
-    fn arg_sort_multiple(&self, other: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-        self.as_binary().arg_sort_multiple(other, descending)
+    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.as_binary().arg_sort_multiple(options)
     }
 }
 
@@ -644,8 +657,8 @@ impl ChunkSort<BinaryType> for BinaryChunked {
     /// In this case we assume that all numeric `Series` are `f64` types. The caller needs to
     /// uphold this contract. If not, it will panic.
     ///
-    fn arg_sort_multiple(&self, other: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-        args_validate(self, other, descending)?;
+    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        args_validate(self, &options.other, &options.descending)?;
 
         let mut count: IdxSize = 0;
         let vals: Vec<_> = self
@@ -656,7 +669,7 @@ impl ChunkSort<BinaryType> for BinaryChunked {
                 (i, v)
             })
             .collect_trusted();
-        arg_sort_multiple_impl(vals, other, descending)
+        arg_sort_multiple_impl(vals, options)
     }
 }
 

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -1866,8 +1866,13 @@ impl DataFrame {
                 if nulls_last || has_struct || std::env::var("POLARS_ROW_FMT_SORT").is_ok() {
                     argsort_multiple_row_fmt(&by_column, descending, nulls_last, parallel)?
                 } else {
-                    let (first, by_column, descending) = prepare_arg_sort(by_column, descending)?;
-                    first.arg_sort_multiple(&by_column, &descending)?
+                    let (first, other, descending) = prepare_arg_sort(by_column, descending)?;
+                    let options = SortMultipleOptions {
+                        other,
+                        descending,
+                        multithreaded: parallel,
+                    };
+                    first.arg_sort_multiple(&options)?
                 }
             }
         };

--- a/polars/polars-core/src/functions.rs
+++ b/polars/polars-core/src/functions.rs
@@ -12,7 +12,6 @@ use num_traits::{Float, NumCast, ToPrimitive};
 #[cfg(feature = "concat_str")]
 use polars_arrow::prelude::ValueSize;
 
-use crate::chunked_array::ops::sort::prepare_arg_sort;
 use crate::prelude::*;
 use crate::utils::coalesce_nulls;
 #[cfg(feature = "diagonal_concat")]
@@ -91,20 +90,6 @@ where
     let b = b.as_ref();
 
     Some(cov_f(a, b)? / (a.std(ddof)? * b.std(ddof)?))
-}
-
-/// Find the indexes that would sort these series in order of appearance.
-/// That means that the first `Series` will be used to determine the ordering
-/// until duplicates are found. Once duplicates are found, the next `Series` will
-/// be used and so on.
-pub fn arg_sort_by(by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-    polars_ensure!(
-        by.len() == descending.len(),
-        ComputeError: "the number of ordering booleans: {} does not match the number of series: {}",
-        descending.len(), by.len()
-    );
-    let (first, by, descending) = prepare_arg_sort(by.to_vec(), descending.to_vec()).unwrap();
-    first.arg_sort_multiple(&by, &descending)
 }
 
 // utility to be able to also add literals to concat_str function

--- a/polars/polars-core/src/series/implementations/binary.rs
+++ b/polars/polars-core/src/series/implementations/binary.rs
@@ -87,8 +87,8 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(by, descending)
+    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(options)
     }
 }
 

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -98,8 +98,8 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(by, descending)
+    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(options)
     }
 }
 

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -148,8 +148,8 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         }
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(by, descending)
+    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(options)
     }
 }
 

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -154,8 +154,8 @@ macro_rules! impl_dyn_series {
                 self.0.group_tuples(multithreaded, sorted)
             }
 
-            fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-                self.0.deref().arg_sort_multiple(by, descending)
+            fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+                self.0.deref().arg_sort_multiple(options)
             }
         }
 

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -162,8 +162,8 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
         self.0.group_tuples(multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-        self.0.deref().arg_sort_multiple(by, descending)
+    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.deref().arg_sort_multiple(options)
     }
 }
 

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -198,8 +198,8 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
         self.0.group_tuples(multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-        self.0.deref().arg_sort_multiple(by, descending)
+    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.deref().arg_sort_multiple(options)
     }
 }
 

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -137,8 +137,8 @@ macro_rules! impl_dyn_series {
                 IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
             }
 
-            fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-                self.0.arg_sort_multiple(by, descending)
+            fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+                self.0.arg_sort_multiple(options)
             }
         }
 

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -200,8 +200,8 @@ macro_rules! impl_dyn_series {
                 IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
             }
 
-            fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-                self.0.arg_sort_multiple(by, descending)
+            fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+                self.0.arg_sort_multiple(options)
             }
         }
 

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -95,8 +95,8 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         IntoGroupsProxy::group_tuples(&self.0, multithreaded, sorted)
     }
 
-    fn arg_sort_multiple(&self, by: &[Series], descending: &[bool]) -> PolarsResult<IdxCa> {
-        self.0.arg_sort_multiple(by, descending)
+    fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
+        self.0.arg_sort_multiple(options)
     }
 }
 

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -178,7 +178,7 @@ pub(crate) mod private {
             invalid_operation_panic!(zip_with_same_type, self)
         }
 
-        fn arg_sort_multiple(&self, _by: &[Series], _descending: &[bool]) -> PolarsResult<IdxCa> {
+        fn arg_sort_multiple(&self, _options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
             polars_bail!(opq = arg_sort_multiple, self._dtype());
         }
     }

--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -240,23 +240,13 @@ pub fn spearman_rank_corr(a: Expr, b: Expr, ddof: u8, propagate_nans: bool) -> E
 /// That means that the first `Series` will be used to determine the ordering
 /// until duplicates are found. Once duplicates are found, the next `Series` will
 /// be used and so on.
+#[cfg(feature = "arange")]
 pub fn arg_sort_by<E: AsRef<[Expr]>>(by: E, descending: &[bool]) -> Expr {
-    let descending = descending.to_vec();
-    let function = SpecialEq::new(Arc::new(move |by: &mut [Series]| {
-        polars_core::functions::arg_sort_by(by, &descending).map(|ca| Some(ca.into_series()))
-    }) as Arc<dyn SeriesUdf>);
-
-    Expr::AnonymousFunction {
-        input: by.as_ref().to_vec(),
-        function,
-        output_type: GetOutput::from_type(IDX_DTYPE),
-        options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
-            input_wildcard_expansion: true,
-            fmt_str: "arg_sort_by",
-            ..Default::default()
-        },
-    }
+    let e = &by.as_ref()[0];
+    let name = expr_output_name(e).unwrap();
+    arange(lit(0u32), count().cast(IDX_DTYPE), 1)
+        .sort_by(by, descending)
+        .alias(name.as_ref())
 }
 
 #[cfg(all(feature = "concat_str", feature = "strings"))]
@@ -325,6 +315,34 @@ pub fn concat_list<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> PolarsResult
     })
 }
 
+#[cfg(feature = "arange")]
+fn arange_impl<T>(start: T::Native, end: T::Native, step: i64) -> PolarsResult<Option<Series>>
+where
+    T: PolarsNumericType,
+    ChunkedArray<T>: IntoSeries,
+    std::ops::Range<T::Native>: Iterator<Item = T::Native>,
+    std::ops::RangeInclusive<T::Native>: DoubleEndedIterator<Item = T::Native>,
+{
+    let mut ca = match step {
+        1 => ChunkedArray::<T>::from_iter_values("arange", start..end),
+        2.. => ChunkedArray::<T>::from_iter_values("arange", (start..end).step_by(step as usize)),
+        _ => {
+            polars_ensure!(start > end, InvalidOperation: "range must be decreasing if 'step' is negative");
+            ChunkedArray::<T>::from_iter_values(
+                "arange",
+                (end..=start).rev().step_by(step.unsigned_abs() as usize),
+            )
+        }
+    };
+    let is_sorted = if end < start {
+        IsSorted::Descending
+    } else {
+        IsSorted::Ascending
+    };
+    ca.set_sorted_flag(is_sorted);
+    Ok(Some(ca.into_series()))
+}
+
 /// Create list entries that are range arrays
 /// - if `start` and `end` are a column, every element will expand into an array in a list column.
 /// - if `start` and `end` are literals the output will be of `Int64`.
@@ -367,43 +385,54 @@ pub fn arange(start: Expr, end: Expr, step: i64) -> Expr {
     if (literal_start || literal_end) && !any_column_no_agg {
         let f = move |sa: Series, sb: Series| {
             polars_ensure!(step != 0, InvalidOperation: "step must not be zero");
-            let sa = sa.cast(&DataType::Int64)?;
-            let sb = sb.cast(&DataType::Int64)?;
-            let start = sa
-                .i64()?
-                .get(0)
-                .ok_or_else(|| polars_err!(NoData: "no data in `start` evaluation"))?;
-            let end = sb
-                .i64()?
-                .get(0)
-                .ok_or_else(|| polars_err!(NoData: "no data in `end` evaluation"))?;
 
-            let mut ca = match step {
-                1 => Int64Chunked::from_iter_values("arange", start..end),
-                2.. => {
-                    Int64Chunked::from_iter_values("arange", (start..end).step_by(step as usize))
+            match sa.dtype() {
+                dt if dt == &IDX_DTYPE => {
+                    let start = sa
+                        .idx()?
+                        .get(0)
+                        .ok_or_else(|| polars_err!(NoData: "no data in `start` evaluation"))?;
+                    let sb = sb.cast(&IDX_DTYPE)?;
+                    let end = sb
+                        .idx()?
+                        .get(0)
+                        .ok_or_else(|| polars_err!(NoData: "no data in `end` evaluation"))?;
+                    #[cfg(feature = "bigidx")]
+                    {
+                        arange_impl::<UInt64Type>(start, end, step)
+                    }
+                    #[cfg(not(feature = "bigidx"))]
+                    {
+                        arange_impl::<UInt32Type>(start, end, step)
+                    }
                 }
                 _ => {
-                    polars_ensure!(start > end, InvalidOperation: "range must be decreasing if 'step' is negative");
-                    Int64Chunked::from_iter_values(
-                        "arange",
-                        (end..=start).rev().step_by(step.unsigned_abs() as usize),
-                    )
+                    let sa = sa.cast(&DataType::Int64)?;
+                    let sb = sb.cast(&DataType::Int64)?;
+                    let start = sa
+                        .i64()?
+                        .get(0)
+                        .ok_or_else(|| polars_err!(NoData: "no data in `start` evaluation"))?;
+                    let end = sb
+                        .i64()?
+                        .get(0)
+                        .ok_or_else(|| polars_err!(NoData: "no data in `end` evaluation"))?;
+                    arange_impl::<Int64Type>(start, end, step)
                 }
-            };
-            let is_sorted = if end < start {
-                IsSorted::Descending
-            } else {
-                IsSorted::Ascending
-            };
-            ca.set_sorted_flag(is_sorted);
-            Ok(Some(ca.into_series()))
+            }
         };
         apply_binary(
             start,
             end,
             f,
-            GetOutput::map_field(|_| Field::new("arange", DataType::Int64)),
+            GetOutput::map_field(|input| {
+                let dtype = if input.data_type() == &IDX_DTYPE {
+                    IDX_DTYPE
+                } else {
+                    input.data_type().clone()
+                };
+                Field::new("arange", dtype)
+            }),
         )
     } else {
         let f = move |sa: Series, sb: Series| {

--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -343,6 +343,7 @@ where
     Ok(Some(ca.into_series()))
 }
 
+// TODO! rewrite this with the apply_private architecture
 /// Create list entries that are range arrays
 /// - if `start` and `end` are a column, every element will expand into an array in a list column.
 /// - if `start` and `end` are literals the output will be of `Int64`.
@@ -429,7 +430,7 @@ pub fn arange(start: Expr, end: Expr, step: i64) -> Expr {
                 let dtype = if input.data_type() == &IDX_DTYPE {
                     IDX_DTYPE
                 } else {
-                    input.data_type().clone()
+                    DataType::Int64
                 };
                 Field::new("arange", dtype)
             }),

--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -244,7 +244,7 @@ pub fn spearman_rank_corr(a: Expr, b: Expr, ddof: u8, propagate_nans: bool) -> E
 pub fn arg_sort_by<E: AsRef<[Expr]>>(by: E, descending: &[bool]) -> Expr {
     let e = &by.as_ref()[0];
     let name = expr_output_name(e).unwrap();
-    arange(lit(0u32), count().cast(IDX_DTYPE), 1)
+    arange(lit(0 as IdxSize), count().cast(IDX_DTYPE), 1)
         .sort_by(by, descending)
         .alias(name.as_ref())
 }

--- a/polars/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -74,7 +74,12 @@ impl PhysicalExpr for SortByExpr {
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;
 
-                s_sort_by[0].arg_sort_multiple(&s_sort_by[1..], &descending)
+                let options = SortMultipleOptions {
+                    other: s_sort_by[1..].to_vec(),
+                    descending,
+                    multithreaded: true,
+                };
+                s_sort_by[0].arg_sort_multiple(&options)
             };
             POOL.install(|| rayon::join(series_f, sorted_idx_f))
         };
@@ -117,27 +122,28 @@ impl PhysicalExpr for SortByExpr {
             let mut s = s.list().unwrap().clone();
 
             let descending = self.descending[0];
-            let mut ca: ListChunked = s
-                .par_iter_indexed()
-                .zip(sort_by.par_iter_indexed())
-                .map(|(opt_s, s_sort_by)| match (opt_s, s_sort_by) {
-                    (Some(s), Some(s_sort_by)) => {
-                        if s.len() != s_sort_by.len() {
-                            invalid.store(true, Ordering::Relaxed);
-                            None
-                        } else {
-                            let idx = s_sort_by.arg_sort(SortOptions {
-                                descending,
-                                // we are already in par iter.
-                                multithreaded: false,
-                                ..Default::default()
-                            });
-                            Some(unsafe { s.take_unchecked(&idx).unwrap() })
+            let mut ca: ListChunked = POOL.install(|| {
+                s.par_iter_indexed()
+                    .zip(sort_by.par_iter_indexed())
+                    .map(|(opt_s, s_sort_by)| match (opt_s, s_sort_by) {
+                        (Some(s), Some(s_sort_by)) => {
+                            if s.len() != s_sort_by.len() {
+                                invalid.store(true, Ordering::Relaxed);
+                                None
+                            } else {
+                                let idx = s_sort_by.arg_sort(SortOptions {
+                                    descending,
+                                    // we are already in par iter.
+                                    multithreaded: false,
+                                    ..Default::default()
+                                });
+                                Some(unsafe { s.take_unchecked(&idx).unwrap() })
+                            }
                         }
-                    }
-                    _ => None,
-                })
-                .collect();
+                        _ => None,
+                    })
+                    .collect()
+            });
             ca.rename(s.name());
             let s = ca.into_series();
             ac_in.with_series(s, true, Some(&self.expr))?;
@@ -158,41 +164,44 @@ impl PhysicalExpr for SortByExpr {
                 );
                 let groups = ac_sort_by.groups();
 
-                let groups = groups
-                    .par_iter()
-                    .map(|indicator| {
-                        let new_idx = match indicator {
-                            GroupsIndicator::Idx((_, idx)) => {
-                                // Safety:
-                                // Group tuples are always in bounds
-                                let group = unsafe {
-                                    sort_by_s
-                                        .take_iter_unchecked(&mut idx.iter().map(|i| *i as usize))
-                                };
+                let groups = POOL.install(|| {
+                    groups
+                        .par_iter()
+                        .map(|indicator| {
+                            let new_idx = match indicator {
+                                GroupsIndicator::Idx((_, idx)) => {
+                                    // Safety:
+                                    // Group tuples are always in bounds
+                                    let group = unsafe {
+                                        sort_by_s.take_iter_unchecked(
+                                            &mut idx.iter().map(|i| *i as usize),
+                                        )
+                                    };
 
-                                let sorted_idx = group.arg_sort(SortOptions {
-                                    descending: descending[0],
-                                    // we are already in par iter.
-                                    multithreaded: false,
-                                    ..Default::default()
-                                });
-                                map_sorted_indices_to_group_idx(&sorted_idx, idx)
-                            }
-                            GroupsIndicator::Slice([first, len]) => {
-                                let group = sort_by_s.slice(first as i64, len as usize);
-                                let sorted_idx = group.arg_sort(SortOptions {
-                                    descending: descending[0],
-                                    // we are already in par iter.
-                                    multithreaded: false,
-                                    ..Default::default()
-                                });
-                                map_sorted_indices_to_group_slice(&sorted_idx, first)
-                            }
-                        };
+                                    let sorted_idx = group.arg_sort(SortOptions {
+                                        descending: descending[0],
+                                        // we are already in par iter.
+                                        multithreaded: false,
+                                        ..Default::default()
+                                    });
+                                    map_sorted_indices_to_group_idx(&sorted_idx, idx)
+                                }
+                                GroupsIndicator::Slice([first, len]) => {
+                                    let group = sort_by_s.slice(first as i64, len as usize);
+                                    let sorted_idx = group.arg_sort(SortOptions {
+                                        descending: descending[0],
+                                        // we are already in par iter.
+                                        multithreaded: false,
+                                        ..Default::default()
+                                    });
+                                    map_sorted_indices_to_group_slice(&sorted_idx, first)
+                                }
+                            };
 
-                        (new_idx[0], new_idx)
-                    })
-                    .collect();
+                            (new_idx[0], new_idx)
+                        })
+                        .collect()
+                });
 
                 (GroupsProxy::Idx(groups), ordered_by_group_operation)
             } else {
@@ -226,40 +235,52 @@ impl PhysicalExpr for SortByExpr {
                 );
                 let groups = ac_sort_by[0].groups();
 
-                let groups = groups
-                    .par_iter()
-                    .map(|indicator| {
-                        let new_idx = match indicator {
-                            GroupsIndicator::Idx((_first, idx)) => {
-                                // Safety:
-                                // Group tuples are always in bounds
-                                let groups = sort_by_s
-                                    .iter()
-                                    .map(|s| unsafe {
-                                        s.take_iter_unchecked(&mut idx.iter().map(|i| *i as usize))
-                                    })
-                                    .collect::<Vec<_>>();
+                let groups = POOL.install(|| {
+                    groups
+                        .par_iter()
+                        .map(|indicator| {
+                            let new_idx = match indicator {
+                                GroupsIndicator::Idx((_first, idx)) => {
+                                    // Safety:
+                                    // Group tuples are always in bounds
+                                    let groups = sort_by_s
+                                        .iter()
+                                        .map(|s| unsafe {
+                                            s.take_iter_unchecked(
+                                                &mut idx.iter().map(|i| *i as usize),
+                                            )
+                                        })
+                                        .collect::<Vec<_>>();
 
-                                let sorted_idx = groups[0]
-                                    .arg_sort_multiple(&groups[1..], &descending)
-                                    .unwrap();
-                                map_sorted_indices_to_group_idx(&sorted_idx, idx)
-                            }
-                            GroupsIndicator::Slice([first, len]) => {
-                                let groups = sort_by_s
-                                    .iter()
-                                    .map(|s| s.slice(first as i64, len as usize))
-                                    .collect::<Vec<_>>();
-                                let sorted_idx = groups[0]
-                                    .arg_sort_multiple(&groups[1..], &descending)
-                                    .unwrap();
-                                map_sorted_indices_to_group_slice(&sorted_idx, first)
-                            }
-                        };
+                                    let options = SortMultipleOptions {
+                                        other: groups[1..].to_vec(),
+                                        descending: descending.clone(),
+                                        multithreaded: false,
+                                    };
 
-                        (new_idx[0], new_idx)
-                    })
-                    .collect();
+                                    let sorted_idx = groups[0].arg_sort_multiple(&options).unwrap();
+                                    map_sorted_indices_to_group_idx(&sorted_idx, idx)
+                                }
+                                GroupsIndicator::Slice([first, len]) => {
+                                    let groups = sort_by_s
+                                        .iter()
+                                        .map(|s| s.slice(first as i64, len as usize))
+                                        .collect::<Vec<_>>();
+
+                                    let options = SortMultipleOptions {
+                                        other: groups[1..].to_vec(),
+                                        descending: descending.clone(),
+                                        multithreaded: false,
+                                    };
+                                    let sorted_idx = groups[0].arg_sort_multiple(&options).unwrap();
+                                    map_sorted_indices_to_group_slice(&sorted_idx, first)
+                                }
+                            };
+
+                            (new_idx[0], new_idx)
+                        })
+                        .collect()
+                });
 
                 (GroupsProxy::Idx(groups), ordered_by_group_operation)
             };

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -131,6 +131,7 @@ def test_arange_no_rows() -> None:
 
     df = pl.DataFrame({"x": []})
     out = df.with_columns(expr)
+    print(out)
     expected = pl.DataFrame(
         {"x": [], "arange": []}, schema={"x": pl.Float32, "arange": pl.Int64}
     )


### PR DESCRIPTION
Using `sort` expression during groupby and window functions now parallelizes over the groups instead of over the group items. This saves a lot of overhead and will reduce rayons stack size.

Also ensured we respect the `multithreaded` argument when sorthing by multiple columns. And finally also made the sort by non-null values a bit faster as we now compare `T` instead of `Option<T>` and thus save some bytes on the cache lines and cmp function and memmoves.