### PR TITLE
docs(python): update documentation on deprecated argument name

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7818,7 +7818,7 @@ class DataFrame:
             `fraction` is None.
         fraction
             Fraction of items to return. Cannot be used with `n`.
-            .. note:: This parameter is renamed to `frac`.
+            .. note:: This parameter has been renamed to `frac`.
         with_replacement
             Allow values to be sampled more than once.
         shuffle

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7818,6 +7818,7 @@ class DataFrame:
             `fraction` is None.
         fraction
             Fraction of items to return. Cannot be used with `n`.
+            .. note:: This parameter is renamed to `frac`.
         with_replacement
             Allow values to be sampled more than once.
         shuffle

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6325,7 +6325,7 @@ class Expr:
             `fraction` is None.
         fraction
             Fraction of items to return. Cannot be used with `n`.
-            .. note:: This parameter is renamed to `frac`.
+            .. note:: This parameter has been renamed to `frac`.
         with_replacement
             Allow values to be sampled more than once.
         shuffle

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6325,6 +6325,7 @@ class Expr:
             `fraction` is None.
         fraction
             Fraction of items to return. Cannot be used with `n`.
+            .. note:: This parameter is renamed to `frac`.
         with_replacement
             Allow values to be sampled more than once.
         shuffle

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4854,6 +4854,7 @@ class Series:
             `fraction` is None.
         fraction
             Fraction of items to return. Cannot be used with `n`.
+            .. note:: This parameter is renamed to `frac`.
         with_replacement
             Allow values to be sampled more than once.
         shuffle

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4854,7 +4854,7 @@ class Series:
             `fraction` is None.
         fraction
             Fraction of items to return. Cannot be used with `n`.
-            .. note:: This parameter is renamed to `frac`.
+            .. note:: This parameter has been renamed to `frac`.
         with_replacement
             Allow values to be sampled more than once.
         shuffle


### PR DESCRIPTION
Add notes to inform argument name changes

Renaming function arguments using `@deprecated_alias(old_arg='new_arg')` leaves user uninformed of the change. This leads to TypeError due to unexpected keyword argument when calling the api with document-specified args.

I added notes in the api documentation to inform that the argument name has been updated.