### PR TITLE
feat(python): add lazy `time` expression

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -134,6 +134,7 @@ from polars.functions.lazy import (
 from polars.functions.lazy import date_ as date
 from polars.functions.lazy import datetime_ as datetime
 from polars.functions.lazy import list_ as list
+from polars.functions.lazy import time_ as time
 from polars.functions.whenthen import when
 from polars.io import (
     read_avro,
@@ -330,6 +331,7 @@ __all__ = [
     "struct",
     "sum",
     "tail",
+    "time",  # named time_, see import above
     "var",
     # polars.convert
     "from_arrow",

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -2612,13 +2612,13 @@ def datetime_(
     day
         column or literal, ranging from 1-31.
     hour
-        column or literal, ranging from 1-23.
+        column or literal, ranging from 0-23.
     minute
-        column or literal, ranging from 1-59.
+        column or literal, ranging from 0-59.
     second
-        column or literal, ranging from 1-59.
+        column or literal, ranging from 0-59.
     microsecond
-        column or literal, ranging from 1-999999.
+        column or literal, ranging from 0-999999.
 
     Returns
     -------
@@ -2674,6 +2674,39 @@ def date_(
 
     """
     return datetime_(year, month, day).cast(Date).alias("date")
+
+
+def time_(
+    hour: Expr | str | int | None = None,
+    minute: Expr | str | int | None = None,
+    second: Expr | str | int | None = None,
+    microsecond: Expr | str | int | None = None,
+) -> Expr:
+    """
+    Create a Polars literal expression of type Date.
+
+    Parameters
+    ----------
+    hour
+        column or literal, ranging from 0-23.
+    minute
+        column or literal, ranging from 0-59.
+    second
+        column or literal, ranging from 0-59.
+    microsecond
+        column or literal, ranging from 0-999999.
+
+    Returns
+    -------
+    Expr of type pl.Date
+
+    """
+    epoch_start = (1970, 1, 1)
+    return (
+        datetime_(*epoch_start, hour, minute, second, microsecond)
+        .cast(Time)
+        .alias("time")
+    )
 
 
 def concat_str(

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -21,14 +21,34 @@ def test_date_datetime() -> None:
         }
     )
     out = df.select(
-        [
-            pl.all(),
-            pl.datetime("year", "month", "day", "hour").dt.hour().cast(int).alias("h2"),
-            pl.date("year", "month", "day").dt.day().cast(int).alias("date"),
-        ]
+        pl.all(),
+        pl.datetime("year", "month", "day", "hour").dt.hour().cast(int).alias("h2"),
+        pl.date("year", "month", "day").dt.day().cast(int).alias("date"),
     )
     assert_series_equal(out["date"], df["day"].rename("date"))
     assert_series_equal(out["h2"], df["hour"].rename("h2"))
+
+
+def test_time() -> None:
+    df = pl.DataFrame(
+        {
+            "hour": [7, 14, 21],
+            "min": [10, 20, 30],
+            "sec": [15, 30, 45],
+            "micro": [123456, 555555, 987654],
+        }
+    )
+    out = df.select(
+        pl.all(),
+        pl.time("hour", "min", "sec", "micro").dt.hour().cast(int).alias("h2"),
+        pl.time("hour", "min", "sec", "micro").dt.minute().cast(int).alias("m2"),
+        pl.time("hour", "min", "sec", "micro").dt.second().cast(int).alias("s2"),
+        pl.time("hour", "min", "sec", "micro").dt.microsecond().cast(int).alias("ms2"),
+    )
+    assert_series_equal(out["h2"], df["hour"].rename("h2"))
+    assert_series_equal(out["m2"], df["min"].rename("m2"))
+    assert_series_equal(out["s2"], df["sec"].rename("s2"))
+    assert_series_equal(out["ms2"], df["micro"].rename("ms2"))
 
 
 def test_diag_concat() -> None:


### PR DESCRIPTION
Allows lazy `time` to be built from expressions (as we already support for `datetime` and `date`).

## Example
```python
import polars as pl

pl.DataFrame({ 
    "h":[11,23],
    "m":[30,45],
    "s":[10,50],
    "us":[123456,987654],
}).with_columns( 
    tm = pl.time("h","m","s","us") 
)

# shape: (2, 5)
# ┌─────┬─────┬─────┬────────┬─────────────────┐
# │ h   ┆ m   ┆ s   ┆ us     ┆ tm              │
# │ --- ┆ --- ┆ --- ┆ ---    ┆ ---             │
# │ i64 ┆ i64 ┆ i64 ┆ i64    ┆ time            │
# ╞═════╪═════╪═════╪════════╪═════════════════╡
# │ 11  ┆ 30  ┆ 10  ┆ 123456 ┆ 11:30:10.123456 │
# │ 23  ┆ 45  ┆ 50  ┆ 987654 ┆ 23:45:50.987654 │
# └─────┴─────┴─────┴────────┴─────────────────┘
```