### PR TITLE
fix(python): Fix incorrect type hint for `arange`

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -2351,7 +2351,8 @@ def arange(
     end: int | Expr | Series,
     step: int = ...,
     *,
-    eager: Literal[False],
+    eager: Literal[False] = ...,
+    dtype: PolarsDataType | None = ...,
 ) -> Expr:
     ...
 

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -123,7 +123,7 @@ def test_window_function_cache() -> None:
 
 def test_arange_no_rows() -> None:
     df = pl.DataFrame({"x": [5, 5, 4, 4, 2, 2]})
-    expr = pl.arange(0, pl.count()).over("x")  # type: ignore[union-attr]
+    expr = pl.arange(0, pl.count()).over("x")
     out = df.with_columns(expr)
     assert_frame_equal(
         out, pl.DataFrame({"x": [5, 5, 4, 4, 2, 2], "arange": [0, 1, 0, 1, 0, 1]})


### PR DESCRIPTION
Closes #8791

We should really take a closer look at all our overloaded functions. I bet a lot of them are not quite correct.