### PR TITLE
feat(python): add a "restore_defaults" kwarg to `Config` init

### DIFF
--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -84,7 +84,7 @@ class Config:
 
     _original_state: str = ""
 
-    def __init__(self, **options: Any) -> None:
+    def __init__(self, *, restore_defaults: bool = False, **options: Any) -> None:
         """
         Initialise a Config object instance for context manager usage.
 
@@ -93,6 +93,9 @@ class Config:
 
         Parameters
         ----------
+        restore_defaults
+            set all options to their default values (this is applied before
+            setting any other options).
         options
             keyword args that will set the option; equivalent to calling the
             named "set_<option>" method with the given value.
@@ -109,6 +112,9 @@ class Config:
         """
         # save original state _before_ any changes are made
         self._original_state = self.save()
+
+        if restore_defaults:
+            self.restore_defaults()
 
         for opt, value in options.items():
             if not hasattr(self, opt) and not opt.startswith("set_"):

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -12,8 +12,8 @@ from polars.testing import assert_frame_equal
 
 @pytest.fixture(autouse=True)
 def _environ() -> Iterator[None]:
-    """Fixture to restore the environment variables/state after the test."""
-    with pl.StringCache(), pl.Config():
+    """Fixture to restore the environment after/during tests."""
+    with pl.StringCache(), pl.Config(restore_defaults=True):
         yield
 
 

--- a/py-polars/tests/unit/test_fmt.py
+++ b/py-polars/tests/unit/test_fmt.py
@@ -1,8 +1,15 @@
-from typing import Any, List
+from typing import Any, Iterator, List
 
 import pytest
 
 import polars as pl
+
+
+@pytest.fixture(autouse=True)
+def _environ() -> Iterator[None]:
+    """Fixture to ensure we run with default Config settings during tests."""
+    with pl.Config(restore_defaults=True):
+        yield
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Allows a given scope to run with default settings 
(but restores any custom configuration on scope exit).

## Example
Apply custom settings:
```python
pl.Config.set_tbl_width_chars(205)
pl.Config.set_tbl_cols(5)

print( pl.Config.state(if_set=True) )
# {'POLARS_FMT_MAX_COLS': '5', 
#  'POLARS_TABLE_WIDTH': '205', 
#  'set_fmt_float': 'mixed'}
```
Set everything back to default for duration of the given scope:
```python
with pl.Config( restore_defaults=True ) as cfg:
    print( cfg.state(if_set=True) )
    # {'set_fmt_float': 'mixed'}
```
On scope exit the custom settings should be restored:
```python
print( pl.Config.state(if_set=True) )
# {'POLARS_FMT_MAX_COLS': '5', 
#  'POLARS_TABLE_WIDTH': '205', 
#  'set_fmt_float': 'mixed'}
```