### PR TITLE
feat(rust, python): Add hint to use _saturating on overflow

### DIFF
--- a/polars/polars-time/src/windows/duration.rs
+++ b/polars/polars-time/src/windows/duration.rs
@@ -582,7 +582,11 @@ impl Duration {
                 polars_err!(
                     ComputeError: format!(
                         "cannot advance '{}' by {} month(s). \
-                         If you were trying to get the last day of each month, you may want to try `.dt.month_end`", ts, if d.negative {-d.months} else {d.months})
+                         If you were trying to get the last day of each month, you may want to try `.dt.month_end` \
+                         or append \"_saturating\" to your duration string.",
+                         ts,
+                         if d.negative {-d.months} else {d.months}
+                    )
                 ),
             )?;
             new_t = match tz {


### PR DESCRIPTION
Resolves #8800

```python
from datetime import date
import polars as pl

pl.Series([date(2023, 1, 31)]).dt.offset_by("1mo")
```
```
exceptions.ComputeError: cannot advance '2023-01-31 00:00:00' by 1 month(s). If you were trying to get the last day of each month, you may want to try `.dt.month_end` or append "_saturating" to your duration string.
```