### PR TITLE
perf(rust, python): add optimizer passes and change initial order

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/aexpr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/aexpr/mod.rs
@@ -228,6 +228,12 @@ impl AExpr {
             Nth(_) => Leaf,
         }
     }
+    pub(crate) fn is_leaf(&self) -> bool {
+        matches!(
+            self,
+            AExpr::Column(_) | AExpr::Literal(_) | AExpr::Count | AExpr::Nth(_)
+        )
+    }
 }
 
 impl AAggExpr {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/mod.rs
@@ -73,8 +73,6 @@ pub fn optimize(
     let opt = StackOptimizer {};
     let mut rules: Vec<Box<dyn OptimizationRule>> = Vec::with_capacity(8);
 
-    if simplify_expr {}
-
     // during debug we check if the optimizations have not modified the final schema
     #[cfg(debug_assertions)]
     let prev_schema = logical_plan.schema()?.into_owned();
@@ -94,9 +92,9 @@ pub fn optimize(
 
     // we do simplification
     if simplify_expr {
+        rules.push(Box::new(SimplifyExprRule {}));
         #[cfg(feature = "fused")]
         rules.push(Box::new(fused::FusedArithmetic {}));
-        rules.push(Box::new(SimplifyExprRule {}));
     }
 
     // should be run before predicate pushdown

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -458,7 +458,7 @@ impl OptimizationRule for SimplifyExprRule {
                 // lit(left) + lit(right) => lit(left + right)
                 #[allow(clippy::manual_map)]
                 let out = match op {
-                    Operator::Plus => {
+                    Plus => {
                         match eval_binary_same_type!(left_aexpr, +, right_aexpr) {
                             Some(new) => Some(new),
                             None => {
@@ -482,10 +482,10 @@ impl OptimizationRule for SimplifyExprRule {
                             }
                         }
                     }
-                    Operator::Minus => eval_binary_same_type!(left_aexpr, -, right_aexpr),
-                    Operator::Multiply => eval_binary_same_type!(left_aexpr, *, right_aexpr),
-                    Operator::Divide => eval_binary_same_type!(left_aexpr, /, right_aexpr),
-                    Operator::TrueDivide => {
+                    Minus => eval_binary_same_type!(left_aexpr, -, right_aexpr),
+                    Multiply => eval_binary_same_type!(left_aexpr, *, right_aexpr),
+                    Divide => eval_binary_same_type!(left_aexpr, /, right_aexpr),
+                    TrueDivide => {
                         if let (AExpr::Literal(lit_left), AExpr::Literal(lit_right)) =
                             (left_aexpr, right_aexpr)
                         {
@@ -530,17 +530,17 @@ impl OptimizationRule for SimplifyExprRule {
                             None
                         }
                     }
-                    Operator::FloorDivide => None,
-                    Operator::Modulus => eval_binary_same_type!(left_aexpr, %, right_aexpr),
-                    Operator::Lt => eval_binary_bool_type!(left_aexpr, <, right_aexpr),
-                    Operator::Gt => eval_binary_bool_type!(left_aexpr, >, right_aexpr),
-                    Operator::Eq => eval_binary_bool_type!(left_aexpr, ==, right_aexpr),
-                    Operator::NotEq => eval_binary_bool_type!(left_aexpr, !=, right_aexpr),
-                    Operator::GtEq => eval_binary_bool_type!(left_aexpr, >=, right_aexpr),
-                    Operator::LtEq => eval_binary_bool_type!(left_aexpr, <=, right_aexpr),
-                    Operator::And => eval_bitwise(left_aexpr, right_aexpr, |l, r| l & r),
-                    Operator::Or => eval_bitwise(left_aexpr, right_aexpr, |l, r| l | r),
-                    Operator::Xor => eval_bitwise(left_aexpr, right_aexpr, |l, r| l ^ r),
+                    FloorDivide => None,
+                    Modulus => eval_binary_same_type!(left_aexpr, %, right_aexpr),
+                    Lt => eval_binary_bool_type!(left_aexpr, <, right_aexpr),
+                    Gt => eval_binary_bool_type!(left_aexpr, >, right_aexpr),
+                    Eq => eval_binary_bool_type!(left_aexpr, ==, right_aexpr),
+                    NotEq => eval_binary_bool_type!(left_aexpr, !=, right_aexpr),
+                    GtEq => eval_binary_bool_type!(left_aexpr, >=, right_aexpr),
+                    LtEq => eval_binary_bool_type!(left_aexpr, <=, right_aexpr),
+                    And => eval_bitwise(left_aexpr, right_aexpr, |l, r| l & r),
+                    Or => eval_bitwise(left_aexpr, right_aexpr, |l, r| l | r),
+                    Xor => eval_bitwise(left_aexpr, right_aexpr, |l, r| l ^ r),
                 };
                 if out.is_some() {
                     return Ok(out);

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/stack_opt.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/stack_opt.rs
@@ -21,6 +21,7 @@ impl StackOptimizer {
 
         // nodes of expressions and lp node from which the expressions are a member of
         let mut exprs = Vec::with_capacity(32);
+        let mut scratch = vec![];
 
         // run loop until reaching fixed point
         while changed {
@@ -40,8 +41,21 @@ impl StackOptimizer {
                 let plan = lp_arena.get(current_node);
 
                 // traverse subplans and expressions and add to the stack
-                plan.copy_exprs(&mut exprs);
+                plan.copy_exprs(&mut scratch);
                 plan.copy_inputs(&mut plans);
+
+                // first do a single pass to ensure we process
+                // from leaves to root.
+                // this ensures for instance
+                // that we first do constant folding on operands
+                // before we decide that multiple binary expression
+                // can be replaced with a fused operator
+                while let Some(expr_node) = scratch.pop() {
+                    exprs.push(expr_node);
+                    // traverse all subexpressions and add to the stack
+                    let expr = expr_arena.get(expr_node);
+                    expr.nodes(&mut exprs);
+                }
 
                 // process the expressions on the stack and apply optimizations.
                 while let Some(current_expr_node) = exprs.pop() {
@@ -58,9 +72,16 @@ impl StackOptimizer {
                         }
                     }
 
-                    // traverse subexpressions and add to the stack
+                    // traverse subexpressions and add some to the stack
+                    // we only push arity expressions for the second
+                    // pass to save some iterations
                     let expr = expr_arena.get(current_expr_node);
-                    expr.nodes(&mut exprs);
+
+                    expr.nodes(&mut scratch);
+                    if scratch.len() > 1 {
+                        exprs.extend_from_slice(&scratch);
+                    }
+                    scratch.clear();
                 }
             }
         }

--- a/polars/polars-utils/src/arena.rs
+++ b/polars/polars-utils/src/arena.rs
@@ -1,4 +1,5 @@
 use crate::error::*;
+use crate::slice::GetSaferUnchecked;
 
 unsafe fn index_of_unchecked<T>(slice: &[T], item: &T) -> usize {
     (item as *const _ as usize - slice.as_ptr() as usize) / std::mem::size_of::<T>()
@@ -78,6 +79,13 @@ impl<T> Arena<T> {
     #[inline]
     pub fn get(&self, idx: Node) -> &T {
         self.items.get(idx.0).unwrap()
+    }
+
+    #[inline]
+    /// # Safety
+    /// Doesn't do any bound checks
+    pub unsafe fn get_unchecked(&self, idx: Node) -> &T {
+        self.items.get_unchecked_release(idx.0)
     }
 
     #[inline]

--- a/py-polars/tests/unit/operations/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/test_arithmetic.py
@@ -167,6 +167,10 @@ def test_fused_arithm() -> None:
     assert """col("a").fms([col("b"), col("c")])""" in q.explain()
     assert q.collect()["a"].to_list() == [5, 35, 85]
 
+    # check if we constant fold instead of fma
+    q = df.lazy().select(pl.lit(1) * pl.lit(2) - pl.col("c"))
+    assert """(2) - (col("c")""" in q.explain()
+
     # 8752
     df = pl.DataFrame({"x": pl.Series(values=[0, 0])})
     q = df.lazy().with_columns((0 + 2.5 * (0.5 + pl.col("x"))).alias("compute"))


### PR DESCRIPTION
The stack optimizer passes expression from root to leafs. 

That means that this expression:

`lit(1) * lit(2) + col("a")` 

would be exposed to the optimizer in this order:

1. `lit(1) * lit(2) + col("a")` 
2. `lit(1) * lit(2)`
3. `lit(1)`
4. `lit(2)`
5. `col("a")`

And that **fused multiply add** optimization already triggers on **1** before **constant folding** can be triggered on **2**.

So this PR changes the initial traversal of the expressions so that the stack will first traversed in order `5, 4, .. 1`, meaning that smaller argument optimizations can be triggered first.

This will increase the amount of passes we take, but hopefully the extra triggered optimizations will be worth it.