### PR TITLE
Add align_on parameter to pl.concat(how="horizontal")

### DIFF
--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from collections.abc import Reversible
     from pathlib import Path
 
-    from polars import DataFrame, Series
+    from polars import DataFrame, Expr, LazyFrame, Series
     from polars.type_aliases import PolarsDataType, SizeUnit
 
     if sys.version_info >= (3, 10):
@@ -62,6 +62,22 @@ def _is_generator(val: object) -> bool:
         or isinstance(val, MappingView)
         or (sys.version_info >= (3, 11) and isinstance(val, _reverse_mapping_views))
     )
+
+
+def is_df_sequence(val: Iterable[object]) -> TypeGuard[Sequence[DataFrame]]:
+    return isinstance(val, Sequence) and all(isinstance(x, pl.DataFrame) for x in val)
+
+
+def is_ldf_sequence(val: Iterable[object]) -> TypeGuard[Sequence[LazyFrame]]:
+    return isinstance(val, Sequence) and all(isinstance(x, pl.LazyFrame) for x in val)
+
+
+def is_series_sequence(val: Iterable[object]) -> TypeGuard[Sequence[Series]]:
+    return isinstance(val, Sequence) and all(isinstance(x, pl.Series) for x in val)
+
+
+def is_expr_sequence(val: Iterable[object]) -> TypeGuard[Sequence[Expr]]:
+    return isinstance(val, Sequence) and all(isinstance(x, pl.Expr) for x in val)
 
 
 def _is_iterable_of(val: Iterable[object], eltype: type | tuple[type, ...]) -> bool:

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -89,6 +89,27 @@ def test_concat_horizontal() -> None:
     assert_frame_equal(out, expected)
 
 
+def test_concat_horizontal_with_keys() -> None:
+    df1 = pl.DataFrame(
+        {
+            "key": [1, 2, 3],
+            "a": [4, 5, 6],
+        }
+    )
+
+    df2 = pl.DataFrame(
+        {
+            "key": [1, 3, 4],
+            "b": [7, 8, 9],
+        }
+    )
+
+    assert_frame_equal(
+        pl.concat([df1, df2], how="horizontal", align_on=["key"]),
+        pl.DataFrame({"key": [1, 2, 3, 4], "a": [4, 5, 6, None], "b": [7, None, 8, 9]}),
+    )
+
+
 def test_all_any_horizontally() -> None:
     df = pl.DataFrame(
         [


### PR DESCRIPTION
resolves #8807. Willing to discuss better syntax.

```python
import polars as pl

df1 = pl.DataFrame({
    "key": [1, 2, 3],
    'a': [4, 5, 6],
})

df2 = pl.DataFrame({
    "key": [1, 3, 4],
    'b': [7, 8, 9],
})

df3 = pl.concat([df1, df2], how="horizontal", align_on="key")

     df1                   df2                       df3
┌─────┬──────┐        ┌─────┬──────┐        ┌─────┬──────┬──────┐
│ key ┆ a    │        │ key ┆ b    │        │ key ┆ a    ┆ b    │
╞═════╪══════╡        ╞═════╪══════╡        ╞═════╪══════╪══════╡
│ 1   ┆ 4    │        │ 1   ┆ 7    │        │ 1   ┆ 4    ┆ 7    │
│ 2   ┆ 5    │        │ 3   ┆ 8    │  --->  │ 2   ┆ 5    ┆ null │
│ 3   ┆ 6    │        │ 4   ┆ 9    │        │ 3   ┆ 6    ┆ 8    │
└─────┴──────┘        └─────┴──────┘        │ 4   ┆ null ┆ 9    │
                                            └─────┴──────┴──────┘
```