### PR TITLE
refactor(python): refactor DataFrame.describe

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3855,7 +3855,7 @@ class DataFrame:
         string = F.all().exclude(NUMERIC_DTYPES | {Boolean} | {Date})
 
         # determine metrics (optional/additional percentiles)
-        metrics: dict[str, F.expr] = {
+        metrics = {
             "count": F.struct(
                 num_or_bool.count().cast(float),
                 date.count().cast(str),
@@ -3868,7 +3868,7 @@ class DataFrame:
             ),
             "mean": F.struct(
                 num_or_bool.mean().cast(float),
-                date.dt.mean().cast(str),
+                date.mean().cast(str),
                 string.mean().cast(str),
             ),
             "std": F.struct(

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7909,7 +7909,7 @@ class DataFrame:
             expr = expr_to_lit_or_expr(subset[0], str_to_lit=False)
         else:
             struct_fields = F.all() if (subset is None) else subset
-            expr = (struct_fields)  # type: ignore[call-overload]
+            expr = F.struct(struct_fields)  # type: ignore[call-overload]
 
         df = self.lazy().select(expr.n_unique()).collect()
         return 0 if df.is_empty() else df.row(0)[0]


### PR DESCRIPTION
Ground work for #8729.

Changes:
* Avoid nested python list (incl the indexing) by levering struct + unnest
* Avoid keeping track of column and row names manually. This would become tricky when we evaluate columns grouped by data type, as we do here, rather than in the original order.
* Cast outputs to right format using Polars directly, no Python involved.

Strictly speaking, `Date` does not have to be separate at the moment, but that is part of the groundwork for #8729.