### PR TITLE
feat(python): add mean, median and quantile to Expr.dt

### DIFF
--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from datetime import timedelta
 
     from polars import Expr
-    from polars.type_aliases import EpochTimeUnit, TimeUnit
+    from polars.type_aliases import EpochTimeUnit, RollingInterpolationMethod, TimeUnit
 
 
 class ExprDateTimeNameSpace:
@@ -1935,3 +1935,31 @@ class ExprDateTimeNameSpace:
         └─────────────────────┘
         """
         return wrap_expr(self._pyexpr.dt_month_end())
+
+    def mean(self) -> Expr:
+        return wrap_expr(self._pyexpr.to_physical().mean().cast(Date, True))
+
+    def median(self) -> Expr:
+        return wrap_expr(self._pyexpr.to_physical().median().cast(Date, True))
+
+    def quantile(
+        self,
+        quantile: float | Expr,
+        interpolation: RollingInterpolationMethod = "nearest",
+    ) -> Expr:
+        """
+        Aggregate the columns of this DataFrame to their quantile value.
+
+        Parameters
+        ----------
+        quantile
+            Quantile between 0.0 and 1.0.
+        interpolation : {'nearest', 'higher', 'lower', 'midpoint', 'linear'}
+            Interpolation method.
+        """
+        quantile = expr_to_lit_or_expr(quantile, str_to_lit=False)
+        return wrap_expr(
+            self._pyexpr.to_physical()
+            .quantile(quantile._pyexpr, interpolation)
+            .cast(Date, True)
+        )

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -601,3 +601,45 @@ def test_median(values: list[date | None], expected_median: date | None) -> None
 def test_mean(values: list[date | None], expected_mean: date | None) -> None:
     result = pl.Series(values).cast(pl.Date).dt.mean()
     assert result == expected_mean
+
+
+def test_mean_date_expr() -> None:
+    df = pl.DataFrame(
+        {"dt": [date(2022, 1, 1), date(2022, 1, 2), date(2024, 5, 15), None]}
+    )
+    assert df.select(pl.col("dt").dt.mean()).item() == date(2022, 10, 16)
+
+    # if the average falls in between two dates, it will be rounded down
+    df = pl.DataFrame({"dt": [date(2022, 1, 1), date(2022, 1, 2)]})
+    assert df.select(pl.col("dt").dt.mean()).item() == date(2022, 1, 1)
+
+
+def test_median_date_expr() -> None:
+    df = pl.DataFrame(
+        {"dt": [date(2022, 1, 1), date(2022, 1, 2), date(2024, 5, 15), None]}
+    )
+    assert df.select(pl.col("dt").dt.median()).item() == date(2022, 1, 2)
+
+    # if the median falls in between two dates, it will be rounded down
+    df = pl.DataFrame({"dt": [date(2022, 1, 1), date(2022, 1, 2)]})
+    assert df.select(pl.col("dt").dt.median()).item() == date(2022, 1, 1)
+
+
+def test_quantile_date_expr() -> None:
+    df = pl.DataFrame(
+        {"dt": [date(2022, 1, 1), date(2022, 1, 2), date(2024, 5, 15), None]}
+    )
+    assert df.select(pl.col("dt").dt.quantile(0.5)).item() == date(2022, 1, 2)
+
+
+def test_mean_datetime_expr() -> None:
+    df = pl.DataFrame(
+        {
+            "dt": [
+                datetime(2022, 12, 31, 1, 2, 3, 456000),
+                datetime(2023, 12, 31, 1, 2, 3),
+                None,
+            ]
+        }
+    )
+    assert df.select(pl.col("dt").dt.mean()).item() == date(2022, 10, 16)


### PR DESCRIPTION
Related to https://github.com/pola-rs/polars/issues/8729.

Currently, Expr.min() and Expr.max(), for date and datetime dtypes, return the minimum and maximum. However, for mean, median and quantile, null is returned. This PR adds these methods in DateTime namespace, similar to what has been done for `Series`.

One problem I run into is that the cast to physical type is easy, but then on the way out how to figure out what the dtype should be? Right now I have hard-coded `Date`, meaning this only works for dates at the moment. Is there a way to get the dtype from an expression? @ritchie46