### PR TITLE
feat(python): add an `align` option to `pl.concat`

### DIFF
--- a/py-polars/polars/api.py
+++ b/py-polars/polars/api.py
@@ -296,7 +296,7 @@ def register_lazyframe_namespace(name: str) -> Callable[[type[NS]], type[NS]]:
     │ yy  ┆ 5   ┆ 6   ┆ 7   │
     │ yz  ┆ 6   ┆ 7   ┆ 8   │
     └─────┴─────┴─────┴─────┘
-    >>> [ldf.collect() for ldf in ldf.types.split_by_column_dtypes()]
+    >>> pl.collect_all(ldf.types.split_by_column_dtypes())
     [shape: (4, 1)
     ┌─────┐
     │ a1  │

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -4,6 +4,7 @@ import contextlib
 import warnings
 from datetime import datetime, time, timedelta
 from functools import reduce
+from itertools import chain
 from typing import TYPE_CHECKING, Iterable, List, Sequence, cast, overload
 
 import polars._reexport as pl
@@ -19,11 +20,10 @@ from polars.utils.convert import (
     _tzinfo_to_str,
 )
 from polars.utils.decorators import deprecated_alias
-from polars.utils.various import find_stacklevel, no_default
+from polars.utils.various import find_stacklevel, no_default, ordered_unique
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
-
 
 if TYPE_CHECKING:
     import sys
@@ -104,23 +104,27 @@ def concat(
     parallel: bool = True,
 ) -> PolarsType:
     """
-    Aggregate multiple Dataframes/Series to a single DataFrame/Series.
+    Combine multiple DataFrames, LazyFrames, or Series into a single object.
 
     Parameters
     ----------
     items
-        DataFrames/Series/LazyFrames to concatenate.
-    how : {'vertical', 'diagonal', 'horizontal'}
-        Series only supports the `vertical` strategy.
-        LazyFrames only supports `vertical` and `diagonal` strategy.
+        DataFrames, LazyFrames, or Series to concatenate.
+    how : {'vertical', 'diagonal', 'horizontal', 'align'}
+        Series only support the `vertical` strategy.
+        LazyFrames do not support the `horizontal` strategy.
 
-        - Vertical: applies multiple `vstack` operations.
-        - Diagonal: finds a union between the column schemas and fills missing column
-            values with null.
-        - Horizontal: stacks Series from DataFrames horizontally and fills with nulls
-            if the lengths don't match.
+        * vertical: Applies multiple `vstack` operations.
+        * diagonal: Finds a union between the column schemas and fills missing column
+          values with ``null``.
+        * horizontal: Stacks Series from DataFrames horizontally and fills with ``null``
+          if the lengths don't match.
+        * align: Combines frames horizontally, auto-determining the common columns and
+          aligning rows using the same logic as ``align_frames``; this behaviour is
+          patterned after a full outer join, but does not handle column-name collision.
+          (If you need more control, you should use a suitable join method instead).
     rechunk
-        Make sure that all data is in contiguous memory.
+        Make sure that the result data is in contiguous memory.
     parallel
         Only relevant for LazyFrames. This determines if the concatenated
         lazy computations may be executed in parallel.
@@ -200,14 +204,44 @@ def concat(
     └─────┴──────┴──────┘
 
     """
-    # unpack/standardise (offers simple support for generator input)
+    # unpack/standardise (handles generator input)
     elems = list(items)
 
     if not len(elems) > 0:
         raise ValueError("cannot concat empty list")
+    elif len(elems) == 1 and isinstance(
+        elems[0], (pl.DataFrame, pl.Series, pl.LazyFrame)
+    ):
+        return elems[0]
+
+    if how == "align":
+        if not isinstance(elems[0], (pl.DataFrame, pl.LazyFrame)):
+            raise RuntimeError(
+                f"'align' strategy is not supported for {type(elems[0]).__name__}"
+            )
+
+        # establish common columns, maintaining the order in which they appear
+        all_columns = list(chain.from_iterable(e.columns for e in elems))
+        key = {v: k for k, v in enumerate(ordered_unique(all_columns))}
+        common_cols = sorted(
+            reduce(
+                lambda x, y: set(x) & set(y),  # type: ignore[arg-type, return-value]
+                chain(e.columns for e in elems),
+            ),
+            key=lambda k: key.get(k, 0),
+        )
+        # align the frame data using an outer join with no suffix-resolution
+        # (so we raise an error in case of column collision, like "horizontal")
+        df = reduce(
+            lambda x, y: x.join(y, how="outer", on=common_cols, suffix=""),
+            [df.lazy() for df in elems],
+        ).sort(by=common_cols)
+
+        return df.collect() if isinstance(elems[0], pl.DataFrame) else df  # type: ignore[redundant-expr]
 
     out: Series | DataFrame | LazyFrame | Expr
     first = elems[0]
+
     if isinstance(first, pl.DataFrame):
         if how == "vertical":
             out = wrap_df(plr.concat_df(elems))
@@ -217,8 +251,8 @@ def concat(
             out = wrap_df(plr.hor_concat_df(elems))
         else:
             raise ValueError(
-                f"how must be one of {{'vertical', 'diagonal', 'horizontal'}}, "
-                f"got {how}"
+                f"`how` must be one of {{'vertical','diagonal','horizontal','align'}}, "
+                f"got {how!r}"
             )
     elif isinstance(first, pl.LazyFrame):
         if how == "vertical":
@@ -227,13 +261,14 @@ def concat(
             return wrap_ldf(plr.diag_concat_lf(elems, rechunk, parallel))
         else:
             raise ValueError(
-                "'LazyFrame' only allows {{'vertical', 'diagonal'}} concat strategy."
+                "'LazyFrame' only allows {'vertical','diagonal','align'} concat strategies."
             )
     elif isinstance(first, pl.Series):
         if how == "vertical":
             out = wrap_s(plr.concat_series(elems))
         else:
-            raise ValueError("'Series' only allows {{'vertical'}} concat strategy.")
+            raise ValueError("'Series' only allows {'vertical'} concat strategy.")
+
     elif isinstance(first, pl.Expr):
         out = first
         for e in elems[1:]:
@@ -734,7 +769,7 @@ def align_frames(
     descending: bool | Sequence[bool] = False,
 ) -> list[FrameType]:
     r"""
-    Align a sequence of frames using the unique values from one or more columns as a key.
+    Align a sequence of frames using common values from one or more columns as a key.
 
     Frames that do not contain the given key values have rows injected (with nulls
     filling the non-key columns), and each resulting frame is sorted by the key.

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -136,7 +136,7 @@ ToStructStrategy: TypeAlias = Literal[
 ]  # ListToStructWidthStrategy
 
 # The following have no equivalent on the Rust side
-ConcatMethod = Literal["vertical", "diagonal", "horizontal"]
+ConcatMethod = Literal["vertical", "diagonal", "horizontal", "align"]
 EpochTimeUnit = Literal["ns", "us", "ms", "s", "d"]
 Orientation: TypeAlias = Literal["col", "row"]
 SearchSortedSide: TypeAlias = Literal["any", "left", "right"]

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -191,6 +191,13 @@ def parse_version(version: Sequence[str | int]) -> tuple[int, ...]:
     return tuple(int(re.sub(r"\D", "", str(v))) for v in version)
 
 
+def ordered_unique(values: Sequence[Any]) -> list[Any]:
+    """Return unique list of sequence values, maintaining their order of appearance."""
+    seen: set[Any] = set()
+    add_ = seen.add
+    return [v for v in values if not (v in seen or add_(v))]
+
+
 def scale_bytes(sz: int, unit: SizeUnit) -> int | float:
     """Scale size in bytes to other size units (eg: "kb", "mb", "gb", "tb")."""
     if unit in {"b", "bytes"}:

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -282,22 +282,20 @@ def test_lazy_concat_err() -> None:
             "bar": [8, 9],
         }
     )
-
-    for how in ["horizontal"]:
-        with pytest.raises(
-            ValueError,
-            match="'LazyFrame' only allows {{'vertical', 'diagonal'}} concat strategy.",
-        ):
-            pl.concat([df1.lazy(), df2.lazy()], how=how).collect()
+    with pytest.raises(
+        ValueError,
+        match="'LazyFrame' only allows {'vertical','diagonal','align'} concat strategies.",
+    ):
+        pl.concat([df1.lazy(), df2.lazy()], how="horizontal").collect()
 
 
 @typing.no_type_check
 def test_series_concat_err() -> None:
     s = pl.Series([1, 2, 3])
-    for how in ["horizontal", "diagonal"]:
+    for how in ("horizontal", "diagonal"):
         with pytest.raises(
             ValueError,
-            match="'Series' only allows {{'vertical'}} concat strategy.",
+            match="'Series' only allows {'vertical'} concat strategy.",
         ):
             pl.concat([s, s], how=how)
 

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing
 from datetime import timedelta
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 import pytest
@@ -51,7 +51,35 @@ def test_time() -> None:
     assert_series_equal(out["ms2"], df["micro"].rename("ms2"))
 
 
-def test_diag_concat() -> None:
+def test_concat_align() -> None:
+    a = pl.DataFrame({"a": ["a", "b", "d", "e", "e"], "b": [1, 2, 4, 5, 6]})
+    b = pl.DataFrame({"a": ["a", "b", "c"], "c": [5.5, 6.0, 7.5]})
+    c = pl.DataFrame({"a": ["a", "b", "c", "d", "e"], "d": ["w", "x", "y", "z", None]})
+
+    expected = cast(
+        pl.DataFrame,
+        pl.from_repr(
+            """
+            shape: (6, 4)
+            ┌─────┬──────┬──────┬──────┐
+            │ a   ┆ b    ┆ c    ┆ d    │
+            │ --- ┆ ---  ┆ ---  ┆ ---  │
+            │ str ┆ i64  ┆ f64  ┆ str  │
+            ╞═════╪══════╪══════╪══════╡
+            │ a   ┆ 1    ┆ 5.5  ┆ w    │
+            │ b   ┆ 2    ┆ 6.0  ┆ x    │
+            │ c   ┆ null ┆ 7.5  ┆ y    │
+            │ d   ┆ 4    ┆ null ┆ z    │
+            │ e   ┆ 5    ┆ null ┆ null │
+            │ e   ┆ 6    ┆ null ┆ null │
+            └─────┴──────┴──────┴──────┘
+            """
+        ),
+    )
+    assert_frame_equal(pl.concat([a, b, c], how="align"), expected)
+
+
+def test_concat_diagonal() -> None:
     a = pl.DataFrame({"a": [1, 2]})
     b = pl.DataFrame({"b": ["a", "b"], "c": [1, 2]})
     c = pl.DataFrame({"a": [5, 7], "c": [1, 2], "d": [1, 2]})
@@ -68,7 +96,6 @@ def test_diag_concat() -> None:
                 "d": [None, None, None, None, 1, 2],
             }
         )
-
         assert_frame_equal(out, expected)
 
 
@@ -87,6 +114,34 @@ def test_concat_horizontal() -> None:
         }
     )
     assert_frame_equal(out, expected)
+
+
+def test_concat_vertical() -> None:
+    a = pl.DataFrame({"a": ["a", "b"], "b": [1, 2]})
+    b = pl.DataFrame({"a": ["c", "d", "e"], "b": [3, 4, 5]})
+
+    out = pl.concat([a, b], how="vertical")
+    expected = cast(
+        pl.DataFrame,
+        pl.from_repr(
+            """
+            shape: (5, 2)
+            ┌─────┬─────┐
+            │ a   ┆ b   │
+            │ --- ┆ --- │
+            │ str ┆ i64 │
+            ╞═════╪═════╡
+            │ a   ┆ 1   │
+            │ b   ┆ 2   │
+            │ c   ┆ 3   │
+            │ d   ┆ 4   │
+            │ e   ┆ 5   │
+            └─────┴─────┘
+            """
+        ),
+    )
+    assert_frame_equal(out, expected)
+    assert out.rows() == [("a", 1), ("b", 2), ("c", 3), ("d", 4), ("e", 5)]
 
 
 def test_all_any_horizontally() -> None:


### PR DESCRIPTION
Closes #8807.

Adds a new "align" option for `pl.concat` that is patterned after the existing `align_frames` function (which in turn is patterned after a full outer join). 

The new mode auto-determines the common columns from all of the input frames (maintaining order of appearance), and sets up a full outer join that does _not_ attempt to resolve any column name collisions (much like "horizontal"). 

This streamlines the common case _without_ adding any extra API complexity to `pl.concat` (eg: no extra parameters, etc). If you want more control you can use an explicit join instead (and the docstring suggests that you do so in this case).

## Example
```python
import polars as pl

df1 = pl.DataFrame({
    "key": [1, 2, 3],
    "a": [4, 5, 6],
})
df2 = pl.DataFrame({
    "key": [1, 4, 3],
    "b": [7, 9, 8],
})

pl.concat( [df1, df2], how="align" )

# ┌─────┬─────┐   ┌─────┬─────┐    ┌─────┬──────┬──────┐    
# │ key ┆ a   │   │ key ┆ b   │    │ key ┆ a    ┆ b    │
# │ --- ┆ --- │   │ --- ┆ --- │    │ --- ┆ ---  ┆ ---  │
# │ i64 ┆ i64 │   │ i64 ┆ i64 │    │ i64 ┆ i64  ┆ i64  │
# ╞═════╪═════╡ + ╞═════╪═════╡ => ╞═════╪══════╪══════╡
# │ 1   ┆ 4   │   │ 1   ┆ 7   │    │ 1   ┆ 4    ┆ 7    │
# │ 2   ┆ 5   │   │ 4   ┆ 9   │    │ 2   ┆ 5    ┆ null │
# │ 3   ┆ 6   │   │ 3   ┆ 8   │    │ 3   ┆ 6    ┆ 8    │
# └─────┴─────┘   └─────┴─────┘    │ 4   ┆ null ┆ 9    │
#                                  └─────┴──────┴──────┘ 
```