### PR TITLE
refactor(python): much cleaner `concat` typing

### DIFF
--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
         ClosedInterval,
         ConcatMethod,
         PolarsDataType,
+        PolarsType,
         TimeUnit,
     )
     from polars.utils.various import NoDefault
@@ -94,59 +95,13 @@ def get_dummies(
     return df.to_dummies(columns=columns, separator=separator)
 
 
-@overload
 def concat(
-    items: Iterable[DataFrame],
-    *,
-    how: ConcatMethod = ...,
-    rechunk: bool = ...,
-    parallel: bool = ...,
-) -> DataFrame:
-    ...
-
-
-@overload
-def concat(
-    items: Iterable[Series],
-    *,
-    how: ConcatMethod = ...,
-    rechunk: bool = ...,
-    parallel: bool = ...,
-) -> Series:
-    ...
-
-
-@overload
-def concat(
-    items: Iterable[LazyFrame],
-    *,
-    how: ConcatMethod = ...,
-    rechunk: bool = ...,
-    parallel: bool = ...,
-) -> LazyFrame:
-    ...
-
-
-@overload
-def concat(
-    items: Iterable[Expr],
-    *,
-    how: ConcatMethod = ...,
-    rechunk: bool = ...,
-    parallel: bool = ...,
-) -> Expr:
-    ...
-
-
-def concat(
-    items: (
-        Iterable[DataFrame] | Iterable[Series] | Iterable[LazyFrame] | Iterable[Expr]
-    ),
+    items: Iterable[PolarsType],
     *,
     how: ConcatMethod = "vertical",
     rechunk: bool = True,
     parallel: bool = True,
-) -> DataFrame | Series | LazyFrame | Expr:
+) -> PolarsType:
     """
     Aggregate multiple Dataframes/Series to a single DataFrame/Series.
 
@@ -281,7 +236,7 @@ def concat(
     elif isinstance(first, pl.Expr):
         out = first
         for e in elems[1:]:
-            out = out.append(e)  # type: ignore[arg-type]
+            out = out.append(e)
     else:
         raise ValueError(f"did not expect type: {type(first)} in 'pl.concat'.")
 

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -6,12 +6,12 @@ from typing import (
     Collection,
     Generic,
     Mapping,
-    TypeVar,
     overload,
 )
 
 from polars.dataframe import DataFrame
 from polars.lazyframe import LazyFrame
+from polars.type_aliases import FrameType
 from polars.utils._wrap import wrap_ldf
 from polars.utils.decorators import deprecated_alias, redirect
 from polars.utils.various import _get_stack_locals
@@ -33,11 +33,8 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
 
-_FrameType = TypeVar("_FrameType", DataFrame, LazyFrame)
-
-
 @redirect({"query": ("execute", {"eager": True})})
-class SQLContext(Generic[_FrameType]):
+class SQLContext(Generic[FrameType]):
     """
     Run a SQL query against a LazyFrame.
 

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -13,6 +13,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
+    TypeVar,
     Union,
 )
 
@@ -22,7 +23,7 @@ else:
     from typing_extensions import Literal
 
 if TYPE_CHECKING:
-    from polars import Expr, Series
+    from polars import DataFrame, Expr, LazyFrame, Series
     from polars.datatypes import DataType, DataTypeClass, TemporalType
     from polars.dependencies import numpy as np
     from polars.dependencies import pandas as pd
@@ -175,3 +176,7 @@ RowTotalsDefinition: TypeAlias = Union[
 
 # standard/named hypothesis profiles used for parametric testing
 ParametricProfileNames: TypeAlias = Literal["fast", "balanced", "expensive"]
+
+# typevars for core polars types
+PolarsType = TypeVar("PolarsType", "DataFrame", "LazyFrame", "Series", "Expr")
+FrameType = TypeVar("FrameType", "DataFrame", "LazyFrame")

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -870,7 +870,7 @@ def test_concat() -> None:
         _ = pl.concat([])
 
     with pytest.raises(ValueError):
-        pl.concat([df1, df1], how="rubbish")  # type: ignore[call-overload]
+        pl.concat([df1, df1], how="rubbish")  # type: ignore[arg-type]
 
 
 def test_concat_str() -> None:


### PR DESCRIPTION
Noticed that we can replace a large block of `@overload` decorators with a single `TypeVar`.