### PR TITLE
refactor(python): Convert between Vec of Series/Pyseries using trait

### DIFF
--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -765,18 +765,6 @@ impl<'s> FromPyObject<'s> for Wrap<Row<'s>> {
     }
 }
 
-pub(crate) trait ToSeries {
-    fn to_series(self) -> Vec<Series>;
-}
-
-impl ToSeries for Vec<PySeries> {
-    fn to_series(self) -> Vec<Series> {
-        // Safety:
-        // transparent repr
-        unsafe { std::mem::transmute(self) }
-    }
-}
-
 impl FromPyObject<'_> for Wrap<Schema> {
     fn extract(ob: &PyAny) -> PyResult<Self> {
         let dict = ob.extract::<&PyDict>()?;

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -31,7 +31,7 @@ use crate::conversion::{ObjectValue, Wrap};
 use crate::error::PyPolarsErr;
 use crate::file::{get_either_file, get_file_like, get_mmap_bytes_reader, EitherRustPythonFile};
 use crate::prelude::{dicts_to_rows, strings_to_smartstrings};
-use crate::series::{to_pyseries_collection, to_series_collection, PySeries};
+use crate::series::{PySeries, ToPySeries, ToSeries};
 use crate::{arrow_interop, py_modules, PyExpr, PyLazyFrame};
 
 #[pyclass]
@@ -113,7 +113,7 @@ impl PyDataFrame {
 
     #[new]
     pub fn __init__(columns: Vec<PySeries>) -> PyResult<Self> {
-        let columns = to_series_collection(columns);
+        let columns = columns.to_series();
         let df = DataFrame::new(columns).map_err(PyPolarsErr::from)?;
         Ok(PyDataFrame::new(df))
     }
@@ -878,7 +878,7 @@ impl PyDataFrame {
 
     pub fn get_columns(&self) -> Vec<PySeries> {
         let cols = self.df.get_columns().to_vec();
-        to_pyseries_collection(cols)
+        cols.to_pyseries()
     }
 
     /// Get column names
@@ -920,13 +920,13 @@ impl PyDataFrame {
     }
 
     pub fn hstack_mut(&mut self, columns: Vec<PySeries>) -> PyResult<()> {
-        let columns = to_series_collection(columns);
+        let columns = columns.to_series();
         self.df.hstack_mut(&columns).map_err(PyPolarsErr::from)?;
         Ok(())
     }
 
     pub fn hstack(&self, columns: Vec<PySeries>) -> PyResult<Self> {
-        let columns = to_series_collection(columns);
+        let columns = columns.to_series();
         let df = self.df.hstack(&columns).map_err(PyPolarsErr::from)?;
         Ok(df.into())
     }

--- a/py-polars/src/expr.rs
+++ b/py-polars/src/expr.rs
@@ -31,8 +31,7 @@ pub(crate) trait ToExprs {
 impl ToExprs for Vec<PyExpr> {
     fn to_exprs(self) -> Vec<Expr> {
         // Safety
-        // repr is transparent
-        // and has only got one inner field`
+        // repr is transparent and has only got one inner field`
         unsafe { std::mem::transmute(self) }
     }
 }
@@ -44,8 +43,7 @@ pub(crate) trait ToPyExprs {
 impl ToPyExprs for Vec<Expr> {
     fn to_pyexprs(self) -> Vec<PyExpr> {
         // Safety
-        // repr is transparent
-        // and has only got one inner field`
+        // repr is transparent and has only got one inner field`
         unsafe { std::mem::transmute(self) }
     }
 }

--- a/py-polars/src/expr.rs
+++ b/py-polars/src/expr.rs
@@ -31,7 +31,7 @@ pub(crate) trait ToExprs {
 impl ToExprs for Vec<PyExpr> {
     fn to_exprs(self) -> Vec<Expr> {
         // Safety
-        // repr is transparent and has only got one inner field`
+        // repr is transparent
         unsafe { std::mem::transmute(self) }
     }
 }
@@ -43,7 +43,7 @@ pub(crate) trait ToPyExprs {
 impl ToPyExprs for Vec<Expr> {
     fn to_pyexprs(self) -> Vec<PyExpr> {
         // Safety
-        // repr is transparent and has only got one inner field`
+        // repr is transparent
         unsafe { std::mem::transmute(self) }
     }
 }

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -48,7 +48,7 @@ pub(crate) trait ToSeries {
 impl ToSeries for Vec<PySeries> {
     fn to_series(self) -> Vec<Series> {
         // Safety
-        // repr is transparent and has only got one inner field`
+        // repr is transparent
         unsafe { std::mem::transmute(self) }
     }
 }
@@ -60,7 +60,7 @@ pub(crate) trait ToPySeries {
 impl ToPySeries for Vec<Series> {
     fn to_pyseries(self) -> Vec<PySeries> {
         // Safety
-        // repr is transparent and has only got one inner field`
+        // repr is transparent
         unsafe { std::mem::transmute(self) }
     }
 }

--- a/py-polars/src/series.rs
+++ b/py-polars/src/series.rs
@@ -47,16 +47,9 @@ pub(crate) trait ToSeries {
 
 impl ToSeries for Vec<PySeries> {
     fn to_series(self) -> Vec<Series> {
-        // prevent destruction of ps
-        let mut ps = std::mem::ManuallyDrop::new(self);
-
-        // get mutable pointer and reinterpret as Series
-        let p = ps.as_mut_ptr() as *mut Series;
-        let len = ps.len();
-        let cap = ps.capacity();
-
-        // The pointer ownership will be transferred to Vec and this will be responsible for dealloc
-        unsafe { Vec::from_raw_parts(p, len, cap) }
+        // Safety
+        // repr is transparent and has only got one inner field`
+        unsafe { std::mem::transmute(self) }
     }
 }
 
@@ -66,13 +59,9 @@ pub(crate) trait ToPySeries {
 
 impl ToPySeries for Vec<Series> {
     fn to_pyseries(self) -> Vec<PySeries> {
-        let mut s = std::mem::ManuallyDrop::new(self);
-
-        let p = s.as_mut_ptr() as *mut PySeries;
-        let len = s.len();
-        let cap = s.capacity();
-
-        unsafe { Vec::from_raw_parts(p, len, cap) }
+        // Safety
+        // repr is transparent and has only got one inner field`
+        unsafe { std::mem::transmute(self) }
     }
 }
 

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -7,7 +7,7 @@ use crate::arrow_interop::to_rust::array_to_rust;
 use crate::conversion::{slice_extract_wrapped, Wrap};
 use crate::error::PyPolarsErr;
 use crate::prelude::ObjectValue;
-use crate::series::to_series_collection;
+use crate::series::ToSeries;
 use crate::PySeries;
 
 // Init with numpy arrays
@@ -216,8 +216,8 @@ impl PySeries {
     }
 
     #[staticmethod]
-    fn new_series_list(name: &str, val: Vec<Self>, _strict: bool) -> Self {
-        let series_vec = to_series_collection(val);
+    fn new_series_list(name: &str, val: Vec<PySeries>, _strict: bool) -> Self {
+        let series_vec = val.to_series();
         Series::new(name, &series_vec).into()
     }
 


### PR DESCRIPTION
There were two competing implementations of conversion between `Vec<Series>` and `Vec<PySeries>`:
* Using a `trait` implementation
* Using a dedicated function

And both had different implementations. I converted to the trait implementation everywhere, since this feels more Rust-y and is analogous to how we do it for Expr.