### PR TITLE
fix(python): handle `InitVar` typing declarations on `dataclass` objects

### DIFF
--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -398,6 +398,8 @@ def py_type_to_dtype(
             if isinstance(annotation, str)  # type: ignore[redundant-expr]
             else annotation
         )
+    elif type(data_type).__name__ == "InitVar":
+        data_type = data_type.type
 
     if is_polars_dtype(data_type):
         return data_type
@@ -410,7 +412,10 @@ def py_type_to_dtype(
             data_type = possible_types[0]
 
     elif isinstance(data_type, str):
-        data_type = DataTypeMappings.REPR_TO_DTYPE.get(data_type, data_type)
+        data_type = DataTypeMappings.REPR_TO_DTYPE.get(
+            re.sub(r"^(?:dataclasses\.)?InitVar\[(.+)\]$", r"\1", data_type),
+            data_type,
+        )
         if is_polars_dtype(data_type):
             return data_type
     try:

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -395,6 +395,25 @@ def test_init_structured_objects_nested() -> None:
             )
 
 
+def test_dataclasses_initvar_typing() -> None:
+    @dataclasses.dataclass
+    class ABC:
+        x: date
+        y: float
+        z: dataclasses.InitVar[str] = None
+
+    abc = ABC(x=date(1999, 12, 31), y=100.0)
+    df = pl.DataFrame([abc])
+
+    assert_frame_equal(
+        pl.DataFrame(
+            {"x": [date(1999, 12, 31)], "y": [100.0], "z": [None]},
+            schema_overrides={"z": pl.Utf8},
+        ),
+        df,
+    )
+
+
 def test_init_ndarray(monkeypatch: Any) -> None:
     # Empty array
     df = pl.DataFrame(np.array([]))


### PR DESCRIPTION
Closes #8854.

Improves type inference from `dataclass` field signatures (now accounts for `InitVar`).

## Example

```python
from dataclasses import dataclass, InitVar
import polars as pl

@dataclass
class ABC:
    x: date
    y: float
    z: InitVar[str] = None
    
abc = ABC( x=date(1999,12,31), y=100.0 )

df = pl.DataFrame( [abc] )
# shape: (1, 3)
# ┌────────────┬───────┬──────┐
# │ x          ┆ y     ┆ z    │
# │ ---        ┆ ---   ┆ ---  │
# │ date       ┆ f64   ┆ str  │
# ╞════════════╪═══════╪══════╡
# │ 1999-12-31 ┆ 100.0 ┆ null │
# └────────────┴───────┴──────┘
```