### PR TITLE
fix(rust, python): parse offset-aware strings as UTC in read_csv when try_parse_dates=True

### DIFF
--- a/polars/polars-io/src/csv/buffer.rs
+++ b/polars/polars-io/src/csv/buffer.rs
@@ -427,7 +427,8 @@ where
         Some(compiled) => {
             match DatetimeInfer::<T::Native>::try_from(compiled.pattern_with_offset.pattern) {
                 Ok(mut infer) => {
-                    let parsed = infer.parse(val, compiled.pattern_with_offset.offset);
+                    infer.utc = true;
+                    let parsed = infer.parse(val, None);
                     buf.compiled = Some(infer);
                     buf.builder.append_option(parsed);
                     Ok(())
@@ -446,7 +447,8 @@ where
             Some(pattern_with_offset) => {
                 match DatetimeInfer::<T::Native>::try_from(pattern_with_offset.pattern) {
                     Ok(mut infer) => {
-                        let parsed = infer.parse(val, pattern_with_offset.offset);
+                        infer.utc = true;
+                        let parsed = infer.parse(val, None);
                         buf.compiled = Some(infer);
                         buf.builder.append_option(parsed);
                         Ok(())

--- a/polars/polars-io/src/csv/utils.rs
+++ b/polars/polars-io/src/csv/utils.rs
@@ -123,8 +123,7 @@ fn infer_field_schema(string: &str, try_parse_dates: bool) -> DataType {
                         PatternWithOffset {
                             pattern: Pattern::DatetimeYMDZ,
                             offset: _,
-                        } => DataType::Utf8, // TODO: support tz-aware,
-                                             // need to keep track of offset
+                        } => DataType::Datetime(TimeUnit::Microseconds, Some("UTC".to_string())),
                     },
                     None => DataType::Utf8,
                 }
@@ -160,8 +159,7 @@ fn infer_field_schema(string: &str, try_parse_dates: bool) -> DataType {
                     PatternWithOffset {
                         pattern: Pattern::DatetimeYMDZ,
                         offset: _,
-                    } => DataType::Utf8, // TODO: support tz-aware,
-                                         // need to keep track of offset
+                    } => DataType::Datetime(TimeUnit::Microseconds, Some("UTC".to_string())),
                 },
                 None => DataType::Utf8,
             }

--- a/polars/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/infer.rs
@@ -214,7 +214,7 @@ pub struct DatetimeInfer<T> {
     transform_bytes: StrpTimeState,
     fmt_len: u16,
     pub logical_type: DataType,
-    utc: bool,
+    pub utc: bool,
 }
 
 #[cfg(feature = "dtype-datetime")]

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -2126,9 +2126,8 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db67dc6ef36edb658196c3fef0464a80b53dbbc194a904e81f9bd4190f9ecc5b"
+version = "0.33.0"
+source = "git+https://github.com/sqlparser-rs/sqlparser-rs.git?rev=ae3b5844c839072c235965fe0d1bddc473dced87#ae3b5844c839072c235965fe0d1bddc473dced87"
 dependencies = [
  "log",
 ]

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -747,26 +747,27 @@ def test_fallback_chrono_parser() -> None:
     assert df.null_count().row(0) == (0, 0)
 
 
-@pytest.mark.xfail(reason="Not yet supported, GH8213", strict=True)
 def test_tz_aware_try_parse_dates() -> None:
     data = (
         "a,b,c,d\n"
-        "2020-01-01T01:00:00+01:00,2021-04-28T00:00:00+02:00,2021-03-28T00:00:00+01:00,2\n"
-        "2020-01-01T02:00:00+01:00,2021-04-29T00:00:00+02:00,2021-03-29T00:00:00+02:00,3\n"
+        "2020-01-01T02:00:00+01:00,2021-04-28T00:00:00+02:00,2021-03-28T00:00:00+01:00,2\n"
+        "2020-01-01T03:00:00+01:00,2021-04-29T00:00:00+02:00,2021-03-29T00:00:00+02:00,3\n"
     )
     result = pl.read_csv(io.StringIO(data), try_parse_dates=True)
     expected = pl.DataFrame(
         {
             "a": [
-                datetime(2020, 1, 1, 1, tzinfo=timezone(timedelta(hours=1))),
-                datetime(2020, 1, 1, 2, tzinfo=timezone(timedelta(hours=1))),
+                datetime(2020, 1, 1, 1, tzinfo=timezone.utc),
+                datetime(2020, 1, 1, 2, tzinfo=timezone.utc),
             ],
             "b": [
-                datetime(2021, 4, 28, tzinfo=timezone(timedelta(hours=2))),
-                datetime(2021, 4, 29, tzinfo=timezone(timedelta(hours=2))),
+                datetime(2021, 4, 27, 22, tzinfo=timezone.utc),
+                datetime(2021, 4, 28, 22, tzinfo=timezone.utc),
             ],
-            # column 'c' has mixed offsets, so `try_parse_dates`  can't parse it
-            "c": ["2021-03-28T00:00:00+01:00", "2021-03-29T00:00:00+02:00"],
+            "c": [
+                datetime(2021, 3, 27, 23, tzinfo=timezone.utc),
+                datetime(2021, 3, 28, 22, tzinfo=timezone.utc),
+            ],
             "d": [2, 3],
         }
     )


### PR DESCRIPTION
towards https://github.com/pola-rs/polars/issues/8860

Current behaviour: (column isn't parsed as it left as str)
```python
In [2]: print(
   ...:     pl.read_csv(
   ...:         io.StringIO("date\n2020-01-01T00:00:00+01:00\n2020-01-01T00:01:00+01:00"),
   ...:         try_parse_dates=True,
   ...:     )
   ...: )
   ...:
shape: (2, 1)
┌───────────────────────────┐
│ date                      │
│ ---                       │
│ str                       │
╞═══════════════════════════╡
│ 2020-01-01T00:00:00+01:00 │
│ 2020-01-01T00:01:00+01:00 │
└───────────────────────────┘
```

Here: (column is parsed as datetime[us, UTC])
```python
In [1]: 
   ...: print(
   ...:     pl.read_csv(
   ...:         io.StringIO("date\n2020-01-01T00:00:00+01:00\n2020-01-01T00:01:00+01:00"),
   ...:         try_parse_dates=True,
   ...:     )
   ...: )
shape: (2, 1)
┌─────────────────────────┐
│ date                    │
│ ---                     │
│ datetime[μs, UTC]       │
╞═════════════════════════╡
│ 2019-12-31 23:00:00 UTC │
│ 2019-12-31 23:01:00 UTC │
└─────────────────────────┘
```