### PR TITLE
feat(rust, python)!: in Series constructor, if inputs are time-zone-aware datetimes, convert to UTC

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.17.14"
+version = "0.17.15"
 dependencies = [
  "ahash",
  "built",

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -78,7 +78,7 @@ def _get_annotations(obj: type) -> dict[str, Any]:
     return getattr(obj, "__annotations__", {})
 
 
-if version_info >= (3, 11):
+if version_info >= (3, 10):
 
     def type_hints(obj: type) -> dict[str, Any]:
         try:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -347,10 +347,9 @@ def test_datetime_consistency() -> None:
         datetime(3099, 12, 31, 23, 59, 59, 123456, tzinfo=ZoneInfo("Asia/Kathmandu")),
         datetime(9999, 12, 31, 23, 59, 59, 999999, tzinfo=ZoneInfo("Asia/Kathmandu")),
     ]
-    with pytest.warns(TimeZoneAwareConstructorWarning, match=r"UTC time zone"):
-        ddf = pl.DataFrame({"dtm": test_data}).with_columns(
-            pl.col("dtm").dt.nanosecond().alias("ns")
-        )
+    ddf = pl.DataFrame({"dtm": test_data}).with_columns(
+        pl.col("dtm").dt.nanosecond().alias("ns")
+    )
     assert ddf.rows() == [
         (test_data[0], 555555000),
         (test_data[1], 986754000),
@@ -364,8 +363,9 @@ def test_datetime_consistency() -> None:
         datetime(2021, 11, 7, 1, 0, fold=1, tzinfo=ZoneInfo("US/Central")),
         datetime(2021, 11, 7, 2, 0, tzinfo=ZoneInfo("US/Central")),
     ]
-    with pytest.warns(TimeZoneAwareConstructorWarning, match=r"UTC time zone"):
-        ddf = pl.DataFrame({"dtm": test_data})
+    ddf = pl.DataFrame({"dtm": test_data}).select(
+        pl.col("dtm").dt.convert_time_zone("US/Central")
+    )
     assert ddf.rows() == [
         (test_data[0],),
         (test_data[1],),
@@ -2285,9 +2285,8 @@ def test_tz_datetime_duration_arithm_5221() -> None:
 
 def test_auto_infer_time_zone() -> None:
     dt = datetime(2022, 10, 17, 10, tzinfo=ZoneInfo("Asia/Shanghai"))
-    with pytest.warns(TimeZoneAwareConstructorWarning, match=r"UTC time zone"):
-        s = pl.Series([dt])
-    assert s.dtype == pl.Datetime("us", "Asia/Shanghai")
+    s = pl.Series([dt])
+    assert s.dtype == pl.Datetime("us", "UTC")
     assert s[0] == dt
 
 
@@ -3113,27 +3112,17 @@ def test_series_is_temporal() -> None:
 )
 def test_misc_precision_any_value_conversion(time_zone: Any, warn: bool) -> None:
     tz = ZoneInfo(time_zone) if isinstance(time_zone, str) else time_zone
-    context_manager: contextlib.AbstractContextManager[pytest.WarningsRecorder | None]
-    msg = r"UTC time zone"
-    if warn:
-        context_manager = pytest.warns(TimeZoneAwareConstructorWarning, match=msg)
-    else:
-        context_manager = contextlib.nullcontext()
-
     # default precision (μs)
     dt = datetime(2514, 5, 30, 1, 53, 4, 986754, tzinfo=tz)
-    with context_manager:
-        assert pl.Series([dt]).to_list() == [dt]
+    assert pl.Series([dt]).to_list() == [dt]
 
     # ms precision
     dt = datetime(2243, 1, 1, 0, 0, 0, 1000, tzinfo=tz)
-    with context_manager:
-        assert pl.Series([dt]).cast(pl.Datetime("ms", time_zone)).to_list() == [dt]
+    assert pl.Series([dt]).cast(pl.Datetime("ms", time_zone)).to_list() == [dt]
 
     # ns precision
     dt = datetime(2256, 1, 1, 0, 0, 0, 1, tzinfo=tz)
-    with context_manager:
-        assert pl.Series([dt]).cast(pl.Datetime("ns", time_zone)).to_list() == [dt]
+    assert pl.Series([dt]).cast(pl.Datetime("ns", time_zone)).to_list() == [dt]
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import contextlib
 import io
 from datetime import date, datetime, time, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast, no_type_check
@@ -16,7 +15,6 @@ from polars.exceptions import (
     ArrowError,
     ComputeError,
     PolarsPanicError,
-    TimeZoneAwareConstructorWarning,
 )
 from polars.testing import (
     assert_frame_equal,

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -14,7 +14,6 @@ import pytest
 
 import polars as pl
 from polars.dependencies import _ZONEINFO_AVAILABLE, dataclasses, pydantic
-from polars.exceptions import TimeZoneAwareConstructorWarning
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.utils._construction import type_hints
 
@@ -675,18 +674,16 @@ def test_init_1d_sequence() -> None:
         [datetime(2020, 1, 1, tzinfo=timezone.utc)], schema={"ts": pl.Datetime("ms")}
     )
     assert df.schema == {"ts": pl.Datetime("ms", "UTC")}
-    with pytest.warns(TimeZoneAwareConstructorWarning, match=r"UTC time zone"):
-        df = pl.DataFrame(
-            [datetime(2020, 1, 1, tzinfo=timezone(timedelta(hours=1)))],
-            schema={"ts": pl.Datetime("ms")},
-        )
-    assert df.schema == {"ts": pl.Datetime("ms", "+01:00")}
-    with pytest.warns(TimeZoneAwareConstructorWarning, match=r"UTC time zone"):
-        df = pl.DataFrame(
-            [datetime(2020, 1, 1, tzinfo=ZoneInfo("Asia/Kathmandu"))],
-            schema={"ts": pl.Datetime("ms")},
-        )
-    assert df.schema == {"ts": pl.Datetime("ms", "Asia/Kathmandu")}
+    df = pl.DataFrame(
+        [datetime(2020, 1, 1, tzinfo=timezone(timedelta(hours=1)))],
+        schema={"ts": pl.Datetime("ms")},
+    )
+    assert df.schema == {"ts": pl.Datetime("ms", "UTC")}
+    df = pl.DataFrame(
+        [datetime(2020, 1, 1, tzinfo=ZoneInfo("Asia/Kathmandu"))],
+        schema={"ts": pl.Datetime("ms")},
+    )
+    assert df.schema == {"ts": pl.Datetime("ms", "UTC")}
 
 
 def test_init_pandas(monkeypatch: Any) -> None:


### PR DESCRIPTION
towards https://github.com/pola-rs/polars/issues/8860