### PR TITLE
chore(python): refactor tzinfo-related tests

### DIFF
--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -563,17 +563,19 @@ def test_groupby_when_then_with_binary_and_agg_in_pred_6202() -> None:
 @pytest.mark.parametrize("every", ["1h", timedelta(hours=1)])
 @pytest.mark.parametrize("tzinfo", [None, ZoneInfo("Asia/Kathmandu")])
 def test_groupby_dynamic_iter(every: str | timedelta, tzinfo: ZoneInfo | None) -> None:
+    time_zone = tzinfo.key if tzinfo is not None else None
     df = pl.DataFrame(
         {
             "datetime": [
-                datetime(2020, 1, 1, 10, 0, tzinfo=tzinfo),
-                datetime(2020, 1, 1, 10, 50, tzinfo=tzinfo),
-                datetime(2020, 1, 1, 11, 10, tzinfo=tzinfo),
+                datetime(2020, 1, 1, 10, 0),
+                datetime(2020, 1, 1, 10, 50),
+                datetime(2020, 1, 1, 11, 10),
             ],
             "a": [1, 2, 2],
             "b": [4, 5, 6],
         }
     ).set_sorted("datetime")
+    df = df.with_columns(pl.col("datetime").dt.replace_time_zone(time_zone))
 
     # Without 'by' argument
     result1 = [

--- a/py-polars/tests/unit/operations/test_transpose.py
+++ b/py-polars/tests/unit/operations/test_transpose.py
@@ -1,20 +1,11 @@
-import sys
 from datetime import date, datetime
 from typing import Iterator
 
 import pytest
 
 import polars as pl
-from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
-
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-elif _ZONEINFO_AVAILABLE:
-    # Import from submodule due to typing issue with backports.zoneinfo package:
-    # https://github.com/pganssle/zoneinfo/issues/125
-    from backports.zoneinfo._zoneinfo import ZoneInfo
 
 
 def test_transpose_supertype() -> None:
@@ -34,9 +25,10 @@ def test_transpose_tz_naive_and_tz_aware() -> None:
     df = pl.DataFrame(
         {
             "a": [datetime(2020, 1, 1)],
-            "b": [datetime(2020, 1, 1, tzinfo=ZoneInfo("Asia/Kathmandu"))],
+            "b": [datetime(2020, 1, 1)],
         }
     )
+    df = df.with_columns(pl.col("b").dt.replace_time_zone("Asia/Kathmandu"))
     with pytest.raises(
         ComputeError,
         match=r"failed to determine supertype of datetime\[μs\] and datetime\[μs, Asia/Kathmandu\]",


### PR DESCRIPTION
This doesn't change anything user-facing, it would just make the diff in https://github.com/pola-rs/polars/pull/8881 much smaller and easier to read

Summary of the changes: instead of putting the `tzinfo` in the Python `datetime` objects, I'm just setting the time zone after having constructed the Series (`.dt.replace_time_zone`)