### PR TITLE
feat(python): improved inference from type annotations

### DIFF
--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -400,18 +400,14 @@ def test_dataclasses_initvar_typing() -> None:
     class ABC:
         x: date
         y: float
-        z: dataclasses.InitVar[str] = None
+        z: dataclasses.InitVar[list[str]] = None
 
+    # should be able to parse the initvar typing...
     abc = ABC(x=date(1999, 12, 31), y=100.0)
     df = pl.DataFrame([abc])
 
-    assert_frame_equal(
-        pl.DataFrame(
-            {"x": [date(1999, 12, 31)], "y": [100.0], "z": [None]},
-            schema_overrides={"z": pl.Utf8},
-        ),
-        df,
-    )
+    # ...but should not load the initvar field into the DataFrame
+    assert dataclasses.asdict(abc) == df.rows(named=True)[0]
 
 
 def test_init_ndarray(monkeypatch: Any) -> None:


### PR DESCRIPTION
Closes #8885 (supersedes #8878).

* Further improve Python-side type inference (eg: nested annotations such as `list[str]`). 
* Do not include `InitVar` fields in frames loaded from `dataclasses`.
* Fallback for `get_type_hints` (retrieve annotations "as-is").
* Added test coverage for the above.