### PR TITLE
fix(python): Add hint on PyArrow to ADBC import error

### DIFF
--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -248,7 +248,7 @@ def _open_adbc_connection(connection_uri: str) -> Any:
         except ImportError:
             raise ImportError(
                 "ADBC sqlite driver not detected. Please run `pip install "
-                "adbc_driver_sqlite` (requires pyarrow)."
+                "adbc_driver_sqlite pyarrow`."
             ) from None
         connection_uri = connection_uri.replace(r"sqlite:///", "")
     elif connection_uri.startswith("postgres"):
@@ -257,7 +257,7 @@ def _open_adbc_connection(connection_uri: str) -> Any:
         except ImportError:
             raise ImportError(
                 "ADBC postgresql driver not detected. Please run `pip install "
-                "adbc_driver_postgresql` (requires pyarrow)."
+                "adbc_driver_postgresql pyarrow`."
             ) from None
     else:
         raise ValueError("ADBC does not currently support this database.")

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -248,7 +248,7 @@ def _open_adbc_connection(connection_uri: str) -> Any:
         except ImportError:
             raise ImportError(
                 "ADBC sqlite driver not detected. Please run `pip install "
-                "adbc_driver_sqlite`."
+                "adbc_driver_sqlite` (requires pyarrow)."
             ) from None
         connection_uri = connection_uri.replace(r"sqlite:///", "")
     elif connection_uri.startswith("postgres"):
@@ -257,7 +257,7 @@ def _open_adbc_connection(connection_uri: str) -> Any:
         except ImportError:
             raise ImportError(
                 "ADBC postgresql driver not detected. Please run `pip install "
-                "adbc_driver_postgresql`."
+                "adbc_driver_postgresql` (requires pyarrow)."
             ) from None
     else:
         raise ValueError("ADBC does not currently support this database.")


### PR DESCRIPTION
If `write_database(..., engine="adbc")` is called without the ADBC driver then an `ImportError` will be raised telling you to install it. This is very good, except you may then hit an `ImportError` from the ADBC driver code about PyArrow, which is unfortunately swallowed here and converted to a message about the ADBC driver. From the user's point of view it looks like installing the ADBC driver didn't help at all, which is very confusing.

My very basic solution here is to add a hint about PyArrow to the missing ADBC driver error message.