### PR TITLE
chore(skip-ci): add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# default owner for all unmatched paths
+@ritchie46
+
+/polars-cli/ @universalmind303
+/polars/polars-sql/ @universalmind303


### PR DESCRIPTION
LMK if you want anyone else added to any sub-crates or dirs. 

it just uses a path pattern like `.gitignore` followed by the user name(s)

