### PR TITLE
fix(rust, python): don't check sortedness in asof by

### DIFF
--- a/polars/polars-core/src/frame/asof_join/groups.rs
+++ b/polars/polars-core/src/frame/asof_join/groups.rs
@@ -652,7 +652,11 @@ impl DataFrame {
         let right_asof_name = right_asof.name();
         let left_asof_name = left_asof.name();
 
-        check_asof_columns(&left_asof, &right_asof)?;
+        check_asof_columns(
+            &left_asof,
+            &right_asof,
+            left_by.is_empty() && right_by.is_empty(),
+        )?;
 
         let mut left_by = self.select(left_by)?;
         let mut right_by = other.select(right_by)?;

--- a/polars/polars-core/src/frame/asof_join/mod.rs
+++ b/polars/polars-core/src/frame/asof_join/mod.rs
@@ -27,7 +27,7 @@ pub struct AsOfOptions {
     pub right_by: Option<Vec<SmartString>>,
 }
 
-fn check_asof_columns(a: &Series, b: &Series) -> PolarsResult<()> {
+fn check_asof_columns(a: &Series, b: &Series, check_sorted: bool) -> PolarsResult<()> {
     let dtype_a = a.dtype();
     let dtype_b = b.dtype();
     polars_ensure!(
@@ -39,8 +39,10 @@ fn check_asof_columns(a: &Series, b: &Series) -> PolarsResult<()> {
         a.null_count() == 0 && b.null_count() == 0,
         ComputeError: "asof join must not have null values in 'on' arguments"
     );
-    ensure_sorted_arg(a, "asof_join");
-    ensure_sorted_arg(b, "asof_join");
+    if check_sorted {
+        ensure_sorted_arg(a, "asof_join");
+        ensure_sorted_arg(b, "asof_join");
+    }
     Ok(())
 }
 
@@ -115,7 +117,7 @@ impl DataFrame {
         let left_key = self.column(left_on)?;
         let right_key = other.column(right_on)?;
 
-        check_asof_columns(left_key, right_key)?;
+        check_asof_columns(left_key, right_key, true)?;
         let left_key = left_key.to_physical_repr();
         let right_key = right_key.to_physical_repr();
 


### PR DESCRIPTION
fixes #8875