### PR TITLE
feat(cli,rust,python): add sql CASE

### DIFF
--- a/polars/polars-sql/src/keywords.rs
+++ b/polars/polars-sql/src/keywords.rs
@@ -56,6 +56,9 @@ pub fn all_keywords() -> Vec<&'static str> {
         keywords::VARCHAR,
         keywords::WHERE,
         keywords::WITH,
+        keywords::CASE,
+        keywords::WHEN,
+        keywords::THEN,
     ];
     keywords.extend_from_slice(sql_keywords);
     keywords

--- a/polars/polars-sql/tests/simple_exprs.rs
+++ b/polars/polars-sql/tests/simple_exprs.rs
@@ -500,3 +500,27 @@ fn test_groupby_2() -> PolarsResult<()> {
     assert!(df_sql.frame_equal(&expected));
     Ok(())
 }
+
+#[test]
+fn test_case_expr() {
+    let df = create_sample_df().unwrap().head(Some(10));
+    let mut context = SQLContext::new();
+    context.register("df", df.clone().lazy());
+    let sql = r#"
+        SELECT
+            CASE
+                WHEN (a > 5 AND a < 8) THEN 'gt_5 and lt_8'
+                WHEN a <= 5 THEN 'lteq_5'
+                ELSE 'no match'
+            END AS sign
+        FROM df"#;
+    let df_sql = context.execute(sql).unwrap().collect().unwrap();
+    let case_expr = when(col("a").gt(lit(5)).and(col("a").lt(lit(8))))
+        .then(lit("gt_5 and lt_8"))
+        .when(col("a").lt_eq(lit(5)))
+        .then(lit("lteq_5"))
+        .otherwise(lit("no match"))
+        .alias("sign");
+    let df_pl = df.lazy().select(&[case_expr]).collect().unwrap();
+    assert!(df_sql.frame_equal(&df_pl));
+}

--- a/polars/polars-sql/tests/statements.rs
+++ b/polars/polars-sql/tests/statements.rs
@@ -1,0 +1,25 @@
+use polars_core::prelude::*;
+use polars_lazy::prelude::*;
+use polars_sql::*;
+
+fn create_ctx() -> SQLContext {
+    let a = Series::new("a", (1..10i64).map(|i| i / 100).collect::<Vec<_>>());
+    let b = Series::new("b", 1..10i64);
+    let df = DataFrame::new(vec![a, b]).unwrap().lazy();
+    let mut ctx = SQLContext::new();
+    ctx.register("df", df);
+    ctx
+}
+
+#[test]
+fn trailing_commas_allowed() {
+    let mut ctx = create_ctx();
+    let sql = r#"
+    SELECT
+        a,
+        b,
+    FROM df
+    "#;
+    let actual = ctx.execute(sql);
+    assert!(actual.is_ok());
+}


### PR DESCRIPTION
adds sql `CASE WHEN THEN` exprs. 

partially implements #8889


Also adds support for trailing commas in select statements
`SELECT a,b,c, FROM df`
