### PR TITLE
fix(python,rust): Simplify offsets_to_indexes, fix empty offsets edge cases

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/explode.rs
+++ b/polars/polars-core/src/chunked_array/ops/explode.rs
@@ -639,7 +639,15 @@ mod test {
     #[test]
     fn test_empty_row_offsets() {
         let offsets = &[0, 0];
-        let out = offsets_to_indexes(offsets, 5);
-        assert_eq!(out, &[0, 1, 1, 1, 1]);
+        let out = offsets_to_indexes(offsets, 0);
+        let expected: Vec<IdxSize> = Vec::new();
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn test_row_offsets_over_capacity() {
+        let offsets = &[0, 1, 1, 2, 2];
+        let out = offsets_to_indexes(offsets, 2);
+        assert_eq!(out, &[0, 1]);
     }
 }


### PR DESCRIPTION
Fixes this issue: #8919 

The rewrite guarantees that the output is always a vec of size `capacity`, regardless of how many empty offset ranges appear in `offsets`. This mainly addresses the edge case where `offsets` is `[0, 0]` and `capacity` is `0`, which would previously cause a subtraction underflow, but sometimes comes up in practice when dealing with empty slices.