### PR TITLE
docs(python): fix docstring for `time()`

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -2684,7 +2684,7 @@ def time_(
     microsecond: Expr | str | int | None = None,
 ) -> Expr:
     """
-    Create a Polars literal expression of type Date.
+    Create a Polars literal expression of type Time.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixes #8938.