### PR TITLE
feat(cli,rust,python): multiple enhancements for `SQLContext`

### DIFF
--- a/polars-cli/src/main.rs
+++ b/polars-cli/src/main.rs
@@ -134,8 +134,7 @@ impl From<&'_ mut SQLContext> for SerializableContext {
 
 impl From<SerializableContext> for SQLContext {
     fn from(ctx: SerializableContext) -> Self {
-        SQLContext::new_from_tables_and_map(
-            ctx.tables,
+        SQLContext::new_from_table_map(
             ctx.table_map
                 .into_iter()
                 .map(|(k, v)| (k, v.into()))

--- a/py-polars/docs/source/reference/sql.rst
+++ b/py-polars/docs/source/reference/sql.rst
@@ -4,14 +4,12 @@ SQL
 ===
 .. currentmodule:: polars
 
-.. autosummary::
-   :toctree: api/
-
-
 .. py:class:: SQLContext
     :canonical: polars.sql.SQLContext
 
-    Run SQL query against a LazyFrame.
+    Run SQL queries against DataFrame/LazyFrame data.
+
+    .. automethod:: __init__
 
 Methods
 -------
@@ -24,3 +22,4 @@ Methods
     SQLContext.register_globals
     SQLContext.register_many
     SQLContext.unregister
+    SQLContext.tables

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 @redirect({"query": ("execute", {"eager": True})})
 class SQLContext(Generic[FrameType]):
     """
-    Run a SQL query against a LazyFrame.
+    Run SQL queries against DataFrame/LazyFrame data.
 
     Warnings
     --------
@@ -211,6 +211,8 @@ class SQLContext(Generic[FrameType]):
 
         Examples
         --------
+        Declare frame data and register with a SQLContext:
+
         >>> df = pl.DataFrame(
         ...     data=[
         ...         ("The Godfather", 1972, 6_000_000, 134_821_952, 9.2),
@@ -222,6 +224,9 @@ class SQLContext(Generic[FrameType]):
         ...     schema=["title", "release_year", "budget", "gross", "imdb_score"],
         ... )
         >>> ctx = pl.SQLContext(films=df)
+
+        Execute a SQL query against the registered frame data:
+
         >>> ctx.execute(
         ...     '''
         ...     SELECT title, release_year, imdb_score
@@ -242,6 +247,9 @@ class SQLContext(Generic[FrameType]):
         │ Schindler's List         ┆ 1993         ┆ 8.9        │
         │ Pulp Fiction             ┆ 1994         ┆ 8.9        │
         └──────────────────────────┴──────────────┴────────────┘
+
+        Execute a GROUP BY query:
+
         >>> ctx.execute(
         ...     '''
         ...     SELECT

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -21,6 +21,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     import sys
+    from types import TracebackType
 
     if sys.version_info >= (3, 8):
         from typing import Final, Literal
@@ -40,17 +41,20 @@ class SQLContext(Generic[FrameType]):
 
     Warnings
     --------
-    This feature is experimental and may change without it being considered breaking.
+    This feature is stabilising, but is still considered experimental and
+    changes may be made without them necessarily being considered breaking.
 
     """
 
     _ctxt: PySQLContext
     _eager_execution: Final[bool]
+    _tables_scope_stack: list[set[str]]
 
     # note: the type-overloaded methods are required to support accurate typing
     # of the frame return from "execute" (which may be DataFrame or LazyFrame),
     # as that is influenced by both the "eager_execution" flag at init-time AND
-    # the "eager" flag at query-time.
+    # the "eager" flag at query-time (if anyone can find a lighter-weight set
+    # of annotations that successfully resolves this, please go for it... ;)
 
     @overload
     def __init__(
@@ -132,6 +136,27 @@ class SQLContext(Generic[FrameType]):
         if frames or named_frames:
             self.register_many(frames, **named_frames)
 
+    def __enter__(self) -> SQLContext[FrameType]:
+        """Note currently registered tables on scope entry; supports nested scopes."""
+        self._tables_scope_stack = getattr(self, "_tables_scope_stack", [])
+        self._tables_scope_stack.append(set(self.tables()))
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Unregister any tables created within the given scope on exit."""
+        self.unregister(
+            names=(set(self.tables()) - self._tables_scope_stack.pop()),
+        )
+
+    def __repr__(self) -> str:
+        n_tables = len(self.tables())
+        return f"<SQLContext [tables:{n_tables}] at 0x{id(self):x}>"
+
     # these overloads are necessary to cover the possible permutations
     # of the init-time "eager_execution" param, and the "eager" param.
 
@@ -173,7 +198,7 @@ class SQLContext(Generic[FrameType]):
 
     def execute(self, query: str, eager: bool | None = None) -> LazyFrame | DataFrame:
         """
-        Parse the given SQL query and execute it against the underlying frame data.
+        Parse the given SQL query and execute it against the registered frame data.
 
         Parameters
         ----------
@@ -184,6 +209,61 @@ class SQLContext(Generic[FrameType]):
             If unset, the value of the init-time parameter "eager_execution" will be
             used (default is False).
 
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     data=[
+        ...         ("The Godfather", 1972, 6_000_000, 134_821_952, 9.2),
+        ...         ("The Dark Knight", 2008, 185_000_000, 533_316_061, 9.0),
+        ...         ("Schindler's List", 1993, 22_000_000, 96_067_179, 8.9),
+        ...         ("Pulp Fiction", 1994, 8_000_000, 107_930_000, 8.9),
+        ...         ("The Shawshank Redemption", 1994, 25_000_000, 28_341_469, 9.3),
+        ...     ],
+        ...     schema=["title", "release_year", "budget", "gross", "imdb_score"],
+        ... )
+        >>> ctx = pl.SQLContext(films=df)
+        >>> ctx.execute(
+        ...     '''
+        ...     SELECT title, release_year, imdb_score
+        ...     FROM films
+        ...     WHERE release_year > 1990
+        ...     ORDER BY imdb_score DESC
+        ...     ''',
+        ...     eager=True,
+        ... )
+        shape: (4, 3)
+        ┌──────────────────────────┬──────────────┬────────────┐
+        │ title                    ┆ release_year ┆ imdb_score │
+        │ ---                      ┆ ---          ┆ ---        │
+        │ str                      ┆ i64          ┆ f64        │
+        ╞══════════════════════════╪══════════════╪════════════╡
+        │ The Shawshank Redemption ┆ 1994         ┆ 9.3        │
+        │ The Dark Knight          ┆ 2008         ┆ 9.0        │
+        │ Schindler's List         ┆ 1993         ┆ 8.9        │
+        │ Pulp Fiction             ┆ 1994         ┆ 8.9        │
+        └──────────────────────────┴──────────────┴────────────┘
+        >>> ctx.execute(
+        ...     '''
+        ...     SELECT
+        ...         MAX(release_year / 10) * 10 AS decade,
+        ...         SUM(gross) AS total_gross,
+        ...         COUNT(title) AS n_films,
+        ...     FROM films
+        ...     GROUP BY (release_year / 10) -- decade
+        ...     ORDER BY total_gross DESC
+        ...     ''',
+        ...     eager=True,
+        ... )
+        shape: (3, 3)
+        ┌────────┬─────────────┬─────────┐
+        │ decade ┆ total_gross ┆ n_films │
+        │ ---    ┆ ---         ┆ ---     │
+        │ i64    ┆ i64         ┆ u32     │
+        ╞════════╪═════════════╪═════════╡
+        │ 2000   ┆ 533316061   ┆ 1       │
+        │ 1990   ┆ 232338648   ┆ 3       │
+        │ 1970   ┆ 134821952   ┆ 1       │
+        └────────┴─────────────┴─────────┘
         """
         res = wrap_ldf(self._ctxt.execute(query))
         return res.collect() if (eager or self._eager_execution) else res
@@ -191,14 +271,28 @@ class SQLContext(Generic[FrameType]):
     @deprecated_alias(lf="frame")
     def register(self, name: str, frame: DataFrame | LazyFrame) -> Self:
         """
-        Register a ``LazyFrame`` in this ``SQLContext`` under a given ``name``.
+        Register a single frame as a table, using the given name.
 
         Parameters
         ----------
         name
             Name of the table.
         frame
-            LazyFrame to add as this table name.
+            eager/lazy frame to associate with this table name.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"hello": ["world"]})
+        >>> ctx = pl.SQLContext()
+        >>> ctx.register("frame_data", df).execute("SELECT * FROM frame_data").collect()
+        shape: (1, 1)
+        ┌───────┐
+        │ hello │
+        │ ---   │
+        │ str   │
+        ╞═══════╡
+        │ world │
+        └───────┘
 
         """
         if isinstance(frame, DataFrame):
@@ -208,22 +302,30 @@ class SQLContext(Generic[FrameType]):
 
     def register_globals(self, n: int | None = None) -> Self:
         """
-        Register ``LazyFrame`` objects present in the current globals scope.
+        Register all frames (lazy or eager) found in the current globals scope.
 
         Automatically maps variable names to table names.
 
         Parameters
         ----------
         n
-            Register only the most recent "n" ``LazyFrame`` objects.
+            Register only the most recent "n" frames.
 
         Examples
         --------
-        >>> lf1 = pl.LazyFrame({"a": [1, 2, 3], "b": ["x", None, "z"]})
-        >>> lf2 = pl.LazyFrame({"a": [2, 3, 4], "c": ["t", "w", "v"]})
-        >>>
-        >>> pl.SQLContext(register_globals=True).execute(
-        ...     "SELECT a, b, c FROM lf1 LEFT JOIN lf2 USING (a) ORDER BY a DESC"
+        >>> df1 = pl.DataFrame({"a": [1, 2, 3], "b": ["x", None, "z"]})
+        >>> df2 = pl.DataFrame({"a": [2, 3, 4], "c": ["t", "w", "v"]})
+
+        Register frames directly from variables found in the current globals scope:
+
+        >>> ctx = pl.SQLContext(register_globals=True)
+        >>> ctx.tables()
+        ['df1', 'df2']
+
+        Query using the register variable/frame names
+
+        >>> ctx.execute(
+        ...     "SELECT a, b, c FROM df1 LEFT JOIN df2 USING (a) ORDER BY a DESC"
         ... ).collect()
         shape: (3, 3)
         ┌─────┬──────┬──────┐
@@ -247,31 +349,67 @@ class SQLContext(Generic[FrameType]):
         **named_frames: DataFrame | LazyFrame,
     ) -> Self:
         """
-        Register multiple named ``LazyFrame`` objects in this ``SQLContext``.
+        Register multiple eager/lazy frames as tables, using the associated names.
 
         Parameters
         ----------
         frames
-            A ``{name:lazyframe, ...}`` mapping.
+            A ``{name:frame, ...}`` mapping.
         **named_frames
-            Named ``LazyFrame`` objects, provided as kwargs.
+            Named eager/lazy frames, provided as kwargs.
+
+        Examples
+        --------
+        >>> lf1 = pl.LazyFrame({"a": [1, 2, 3], "b": ["m", "n", "o"]})
+        >>> lf2 = pl.LazyFrame({"a": [2, 3, 4], "c": ["p", "q", "r"]})
+        >>> lf3 = pl.LazyFrame({"a": [3, 4, 5], "b": ["s", "t", "u"]})
+        >>> lf4 = pl.LazyFrame({"a": [4, 5, 6], "c": ["v", "w", "x"]})
+
+        Register multiple frames at once, either by passing in as a dict...
+
+        >>> ctx = pl.SQLContext().register_many({"tbl1": lf1, "tbl2": lf2})
+        >>> ctx.tables()
+        ['tbl1', 'tbl2']
+
+        ...or using keyword args:
+
+        >>> ctx.register_many(tbl3=lf3, tbl4=lf4).tables()
+        ['tbl1', 'tbl2', 'tbl3', 'tbl4']
 
         """
         frames = dict(frames or {})
         frames.update(named_frames)
-
         for name, frame in frames.items():
             self.register(name, frame)
         return self
 
     def unregister(self, names: str | Collection[str]) -> Self:
         """
-        Unregister one or more table names from this ``SQLContext``.
+        Unregister one or more eager/lazy frames by name.
 
         Parameters
         ----------
         names
             Names of the tables to unregister.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"ints": [9, 8, 7, 6, 5]})
+        >>> lf1 = pl.LazyFrame({"text": ["a", "b", "c"]})
+        >>> lf2 = pl.LazyFrame({"misc": ["testing1234"]})
+
+        Register with a SQLContext object:
+
+        >>> ctx = pl.SQLContext(test1=df, test2=lf1, test3=lf2)
+        >>> ctx.tables()
+        ['test1', 'test2', 'test3']
+
+        Unregister one or more of the tables:
+
+        >>> ctx.unregister(["test1", "test3"]).tables()
+        ['test2']
+        >>> ctx.unregister("test2").tables()
+        []
 
         """
         if isinstance(names, str):
@@ -279,3 +417,18 @@ class SQLContext(Generic[FrameType]):
         for nm in names:
             self._ctxt.unregister(nm)
         return self
+
+    def tables(self) -> list[str]:
+        """
+        Return a list of the registered table names.
+
+        Examples
+        --------
+        >>> hello_data = pl.DataFrame({"hello": ["world"]})
+        >>> foo_bar = pl.DataFrame({"foo": ["bar", "baz"]})
+        >>> ctx = pl.SQLContext(register_globals=True)
+        >>> ctx.tables()
+        ['foo_bar', 'hello_data']
+
+        """
+        return sorted(self._ctxt.get_tables())

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -400,15 +400,38 @@ class SQLContext(Generic[FrameType]):
         names
             Names of the tables to unregister.
 
+        Notes
+        -----
+        You can also control table registration lifetime by using ``SQLContext`` as a
+        context manager; this can often be more useful when such control is wanted:
+
+        >>> df0 = pl.DataFrame({"colx": [0, 1, 2]})
+        >>> df1 = pl.DataFrame({"colx": [1, 2, 3]})
+        >>> df2 = pl.DataFrame({"colx": [2, 3, 4]})
+
+        Frames registered in-scope are automatically unregistered on scope-exit. Note
+        that frames registered on construction will persist through subsequent scopes.
+
+        >>> # register one frame at construction time, and the other two in-scope
+        >>> with pl.SQLContext(tbl0=df0) as ctx:
+        ...     ctx.register_many(tbl1=df1, tbl2=df2).tables()
+        ...
+        ['tbl0', 'tbl1', 'tbl2']
+
+        After scope exit, none of the tables registered in-scope remain:
+
+        >>> ctx.tables()
+        ['tbl0']
+
         Examples
         --------
-        >>> df = pl.DataFrame({"ints": [9, 8, 7, 6, 5]})
+        >>> df0 = pl.DataFrame({"ints": [9, 8, 7, 6, 5]})
         >>> lf1 = pl.LazyFrame({"text": ["a", "b", "c"]})
         >>> lf2 = pl.LazyFrame({"misc": ["testing1234"]})
 
         Register with a SQLContext object:
 
-        >>> ctx = pl.SQLContext(test1=df, test2=lf1, test3=lf2)
+        >>> ctx = pl.SQLContext(test1=df0, test2=lf1, test3=lf2)
         >>> ctx.tables()
         ['test1', 'test2', 'test3']
 

--- a/py-polars/src/sql.rs
+++ b/py-polars/src/sql.rs
@@ -33,6 +33,10 @@ impl PySQLContext {
             .into())
     }
 
+    pub fn get_tables(&self) -> PyResult<Vec<String>> {
+        Ok(self.context.get_tables())
+    }
+
     pub fn register(&mut self, name: &str, lf: PyLazyFrame) {
         self.context.register(name, lf.ldf)
     }


### PR DESCRIPTION
### Fixes

* Track tables registered with `SQLContext` using just the internal table→frame map instead of the table map _and_ a table vec (simplifies things a bit and fixes a duplicate table name bug with "SHOW TABLES", as tables were being pushed onto the vec without checking if the name was already present).

  ```python
  import polars as pl  

  df = pl.DataFrame({"hello": ["world"]})
  ctx = pl.SQLContext()

  for _ in range(3):
      ctx.register('frame_data',df)
  
  ctx.execute("SHOW TABLES", eager=True)

  # BEFORE (dupes)     AFTER (fixed)
  # ┌────────────┐    ┌────────────┐
  # │ name       │    │ name       │
  # │ ---        │    │ ---        │
  # │ str        │ >> │ str        │
  # ╞════════════╡ >> ╞════════════╡
  # │ frame_data │    │ frame_data │
  # │ frame_data │    └────────────┘
  # │ frame_data │
  # └────────────┘
  ```

### Features

* Expose the "tables" method to Python (useful to know what tables are registered with a given `SQLContext` without having to execute a "SHOW TABLES" sql query).

  ```python
  hello_world = pl.DataFrame({"hello": ["world"]})
  foo_bar = pl.DataFrame({"foo": ["bar","baz"]})

  ctx = pl.SQLContext(register_globals=True)
  ctx.tables()
  # ['foo_bar', 'hello_world']
  ```

* Support usage of `SQLContext` as a context manager - tables created within the scope are unregistered on scope exit (supports arbitrary levels of nesting).

  ```python 
  with pl.SQLContext() as ctx:
      ctx.register_many(
        hello_world = pl.DataFrame({"hello": ["world"]}),
        foo_bar = pl.DataFrame({"foo": ["bar","baz"]})
      )
      ctx.tables()
      # ['foo_bar', 'hello_world']
      
  ctx.tables()
  # []
  ```
* Minor `repr` improvement; now includes the number of registered tables, eg:
  ```
  <SQLContext [tables:6] at 0x103673850>
  ``` 

* We now sort the results from "SHOW TABLES" (observationally most databases do this, so makes sense to follow suit).

### Docs

* Plenty of new examples and detail to the `SQLContext` method docstrings.

* Updated Sphinx docs entry so that `SQLContext` init details are included.

### Tests

* Added tests for all of the new features/options.
