### PR TITLE
feat(python): Add `dtype` argument for `repeat`

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -11,13 +11,11 @@ from polars.datatypes import (
     Date,
     Datetime,
     Duration,
-    Int32,
     Int64,
     Struct,
     Time,
     UInt32,
     is_polars_dtype,
-    py_type_to_dtype,
 )
 from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
@@ -3164,26 +3162,16 @@ def repeat(
     name
         Name of the resulting column.
     dtype
-        Data type of the resulting column.
+        Data type of the resulting column. If set to ``None`` (default), data type is
+        inferred from the given value.
 
     """
     if eager:
-        if name is None:
-            name = ""
-        if dtype is None:
-            dtype = py_type_to_dtype(type(value))
-            if (
-                dtype == Int64
-                and isinstance(value, int)
-                and -(2**31) <= value <= 2**31 - 1
-            ):
-                dtype = Int32
-        s = pl.Series._repeat(name, value, n, dtype)  # type: ignore[arg-type]
-        return s
+        return pl.Series._repeat(value, n, name=name, dtype=dtype)
     else:
         if isinstance(n, int):
             n = lit(n)
-        expr = wrap_expr(plr.repeat(value, n._pyexpr))
+        expr = wrap_expr(plr.repeat(value, n._pyexpr, dtype))
         if name is not None:
             expr = expr.alias(name)
         return expr

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -3168,7 +3168,7 @@ def repeat(
 
     Examples
     --------
-    >>> pl.repeat(1, n=3, eager=True, name='ones')
+    >>> pl.repeat(1, n=3, eager=True, name="ones")
     shape: (3,)
     Series: 'ones' [i32]
     [
@@ -3179,7 +3179,7 @@ def repeat(
 
     """
     if eager:
-        return pl.Series._repeat(value, n, name=name, dtype=dtype)
+        return pl.Series._repeat(value, n, name=name, dtype=dtype)  # type: ignore[arg-type]
     else:
         if isinstance(n, int):
             n = lit(n)

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -3155,7 +3155,7 @@ def repeat(
     value
         Value to repeat.
     n
-        repeat `n` times
+        Length of the resulting column.
     eager
         Evaluate immediately and return a ``Series``. If set to ``False`` (default),
         return an expression instead.
@@ -3163,7 +3163,19 @@ def repeat(
         Name of the resulting column.
     dtype
         Data type of the resulting column. If set to ``None`` (default), data type is
-        inferred from the given value.
+        inferred from the given value. Integer values default to Int32, unless Int64 is
+        required to fit the given value.
+
+    Examples
+    --------
+    >>> pl.repeat(1, n=3, eager=True, name='ones')
+    shape: (3,)
+    Series: 'ones' [i32]
+    [
+            1
+            1
+            1
+    ]
 
     """
     if eager:
@@ -3171,9 +3183,11 @@ def repeat(
     else:
         if isinstance(n, int):
             n = lit(n)
-        expr = wrap_expr(plr.repeat(value, n._pyexpr, dtype))
+        expr = wrap_expr(plr.repeat(value, n._pyexpr))
         if name is not None:
             expr = expr.alias(name)
+        if dtype is not None:
+            expr = expr.cast(dtype)
         return expr
 
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -336,9 +336,24 @@ class Series:
 
     @classmethod
     def _repeat(
-        cls, name: str, val: PythonLiteral, n: int, dtype: PolarsDataType
+        cls,
+        value: PythonLiteral | None,
+        n: int,
+        *,
+        name: str | None = None,
+        dtype: PolarsDataType | None = None,
     ) -> Self:
-        return cls._from_pyseries(PySeries.repeat(name, val, n, dtype))
+        if name is None:
+            name = ""
+        if dtype is None:
+            dtype = py_type_to_dtype(type(value))
+            if (
+                dtype == Int64
+                and isinstance(value, int)
+                and -(2**31) <= value <= 2**31 - 1
+            ):
+                dtype = Int32
+        return cls._from_pyseries(PySeries.repeat(value, n, name, dtype))
 
     def _get_ptr(self) -> int:
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -336,7 +336,7 @@ class Series:
 
     @classmethod
     def _repeat(
-        cls, name: str, val: int | float | str | bool, n: int, dtype: PolarsDataType
+        cls, name: str, val: PythonLiteral, n: int, dtype: PolarsDataType
     ) -> Self:
         return cls._from_pyseries(PySeries.repeat(name, val, n, dtype))
 

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -382,7 +382,16 @@ pub fn reduce(lambda: PyObject, exprs: Vec<PyExpr>) -> PyExpr {
 }
 
 #[pyfunction]
-pub fn repeat(value: &PyAny, n_times: PyExpr) -> PyResult<PyExpr> {
+pub fn repeat(value: &PyAny, n_times: PyExpr, dtype: Option<Wrap<DataType>>) -> PyResult<PyExpr> {
+    let dtype = dtype.map(|dt| dt.0);
+
+    if let Some(dt) = dtype {
+        // TODO: try to cast value to given dtype
+        let val = value.cast(dtype).unwrap();
+
+        return Ok(dsl::repeat(val, n_times.inner).into());
+    }
+
     if let Ok(true) = value.is_instance_of::<PyBool>() {
         let val = value.extract::<bool>().unwrap();
         Ok(dsl::repeat(val, n_times.inner).into())

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -382,37 +382,28 @@ pub fn reduce(lambda: PyObject, exprs: Vec<PyExpr>) -> PyExpr {
 }
 
 #[pyfunction]
-pub fn repeat(value: &PyAny, n_times: PyExpr, dtype: Option<Wrap<DataType>>) -> PyResult<PyExpr> {
-    let dtype = dtype.map(|dt| dt.0);
-
-    if let Some(dt) = dtype {
-        // TODO: try to cast value to given dtype
-        let val = value.cast(dtype).unwrap();
-
-        return Ok(dsl::repeat(val, n_times.inner).into());
-    }
-
+pub fn repeat(value: &PyAny, n: PyExpr) -> PyResult<PyExpr> {
     if let Ok(true) = value.is_instance_of::<PyBool>() {
         let val = value.extract::<bool>().unwrap();
-        Ok(dsl::repeat(val, n_times.inner).into())
+        Ok(dsl::repeat(val, n.inner).into())
     } else if let Ok(int) = value.downcast::<PyInt>() {
         let val = int.extract::<i64>().unwrap();
 
         if val >= i32::MIN as i64 && val <= i32::MAX as i64 {
-            Ok(dsl::repeat(val as i32, n_times.inner).into())
+            Ok(dsl::repeat(val as i32, n.inner).into())
         } else {
-            Ok(dsl::repeat(val, n_times.inner).into())
+            Ok(dsl::repeat(val, n.inner).into())
         }
     } else if let Ok(float) = value.downcast::<PyFloat>() {
         let val = float.extract::<f64>().unwrap();
-        Ok(dsl::repeat(val, n_times.inner).into())
+        Ok(dsl::repeat(val, n.inner).into())
     } else if let Ok(pystr) = value.downcast::<PyString>() {
         let val = pystr
             .to_str()
             .expect("could not transform Python string to Rust Unicode");
-        Ok(dsl::repeat(val, n_times.inner).into())
+        Ok(dsl::repeat(val, n.inner).into())
     } else if value.is_none() {
-        Ok(dsl::repeat(Null {}, n_times.inner).into())
+        Ok(dsl::repeat(Null {}, n.inner).into())
     } else {
         Err(PyValueError::new_err(format!(
             "could not convert value {:?} as a Literal",

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -233,8 +233,13 @@ impl PySeries {
     }
 
     #[staticmethod]
-    fn repeat(name: &str, val: Wrap<AnyValue>, n: usize, dtype: Wrap<DataType>) -> PyResult<Self> {
-        let av = val.0;
+    fn repeat(
+        value: Wrap<AnyValue>,
+        n: usize,
+        name: &str,
+        dtype: Wrap<DataType>,
+    ) -> PyResult<Self> {
+        let av = value.0;
         Ok(Series::new(name, &[av])
             .cast(&dtype.0)
             .map_err(PyPolarsErr::from)?

--- a/py-polars/tests/unit/test_functions.py
+++ b/py-polars/tests/unit/test_functions.py
@@ -477,6 +477,12 @@ def test_repeat() -> None:
     assert s.len() == 0
 
 
+def test_repeat_dtype() -> None:
+    s = pl.select(pl.repeat(1, n=3, dtype=pl.Int8)).to_series()
+    assert s.dtype == pl.Int8
+    assert s.len() == 3
+
+
 def test_min_alias_for_series_min() -> None:
     s = pl.Series([1, 2, 3])
     assert pl.min(s) == s.min()

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1140,6 +1140,12 @@ def test_repeat() -> None:
     ]
 
 
+def test_repeat_dtype() -> None:
+    s = pl.repeat(1, n=3, eager=True, dtype=pl.Int8)
+    assert s.dtype == pl.Int8
+    assert s.len() == 3
+
+
 def test_shape() -> None:
     s = pl.Series([1, 2, 3])
     assert s.shape == (3,)


### PR DESCRIPTION
Closes #8771

Not sure this is the right way to go, since we're now casting after the `repeat` call. But then again, this is also how `Series.repeat` was already implemented, and also similar to `lit(dtype=...)`.

In the issue, @ritchie46  you mentioned to "cast the anyvalue before you expand", but I'm not sure how that would work.

I also made `repeat(name=...)` work for expressions; no reason it shouldn't.

As a side note, I don't see the point of the `n` argument supporting `Expr` input - it creates the expectation that the following will somehow work, but it doesn't:

```python
df = pl.DataFrame({'n': [1, 2, 3]})
df.select(pl.repeat(5, n=pl.col('n')))
```

Results in:

```
shape: (1, 1)
┌─────────┐
│ literal │
│ ---     │
│ i32     │
╞═════════╡
│ 5       │
└─────────┘
```

Apparently only the very first value of the expression is considered? This is unexpected.