### PR TITLE
feat(python): Use schema keys to define the columns if only the schema is provided to `pl.struct`

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -3038,7 +3038,8 @@ def struct(
         Evaluate immediately and return a ``Series``. If set to ``False`` (default),
         return an expression instead.
     schema
-        Optional schema that explicitly defines the struct field dtypes.
+        Optional schema that explicitly defines the struct field dtypes. If no columns
+        or expressions are provided, schema keys are used to define columns.
     **named_exprs
         Additional columns to collect into the struct column, specified as keyword
         arguments. The columns will be renamed to the keyword used.
@@ -3096,7 +3097,13 @@ def struct(
         )
 
     expr = wrap_expr(plr.as_struct(exprs))
+
     if schema:
+        if not exprs:
+            # no columns or expressions provided; create one from schema keys
+            expr = wrap_expr(
+                plr.as_struct(selection_to_pyexpr_list(list(schema.keys())))
+            )
         expr = expr.cast(Struct(schema), strict=False)
 
     if eager:

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing
 from dataclasses import dataclass
-from datetime import datetime, time
+from datetime import date, datetime, time
 
 import pandas as pd
 import pyarrow as pa
@@ -1021,3 +1021,113 @@ def test_struct_lit_cast() -> None:
             {"a": 2, "b": None},
             {"a": 3, "b": None},
         ]
+
+
+def test_struct_from_schema_only() -> None:
+    """Create struct supplying only schema."""
+    # we create a dataframe with default types
+    df = pl.DataFrame(
+        {
+            "str": ["a", "b", "c", "d", "e"],
+            "u8": [1, 2, 3, 4, 5],
+            "i32": [1, 2, 3, 4, 5],
+            "f64": [1, 2, 3, 4, 5],
+            "cat": ["a", "b", "c", "d", "e"],
+            "datetime": pl.Series(
+                [
+                    date(2023, 1, 1),
+                    date(2023, 1, 2),
+                    date(2023, 1, 3),
+                    date(2023, 1, 4),
+                    date(2023, 1, 5),
+                ]
+            ),
+            "bool": [1, 0, 1, 1, 0],
+            # note: the following conversion of list[i64] -> list[u8] fails
+            "list[u8]": [[1], [2], [3], [4], [5]],
+        }
+    )
+
+    # specify a schema with specific dtypes
+    s = df.select(
+        pl.struct(
+            schema={
+                "str": pl.Utf8,
+                "u8": pl.UInt8,
+                "i32": pl.Int32,
+                "f64": pl.Float64,
+                "cat": pl.Categorical,
+                "datetime": pl.Datetime("ms"),
+                "bool": pl.Boolean,
+                "list[u8]": pl.List(pl.UInt8),
+            }
+        ).alias("s")
+    )["s"]
+
+    # check dtypes
+    assert s.dtype == pl.Struct(
+        [
+            pl.Field("str", pl.Utf8),
+            pl.Field("u8", pl.UInt8),
+            pl.Field("i32", pl.Int32),
+            pl.Field("f64", pl.Float64),
+            pl.Field("cat", pl.Categorical),
+            pl.Field("datetime", pl.Datetime("ms")),
+            pl.Field("bool", pl.Boolean),
+            pl.Field("list[u8]", pl.List(pl.UInt8)),
+        ]
+    )
+
+    # check values
+    assert s.to_list() == [
+        {
+            "str": "a",
+            "u8": 1,
+            "i32": 1,
+            "f64": 1.0,
+            "cat": "a",
+            "datetime": datetime(2023, 1, 1, 0, 0),
+            "bool": True,
+            "list[u8]": [1],
+        },
+        {
+            "str": "b",
+            "u8": 2,
+            "i32": 2,
+            "f64": 2.0,
+            "cat": "b",
+            "datetime": datetime(2023, 1, 2, 0, 0),
+            "bool": False,
+            "list[u8]": [2],
+        },
+        {
+            "str": "c",
+            "u8": 3,
+            "i32": 3,
+            "f64": 3.0,
+            "cat": "c",
+            "datetime": datetime(2023, 1, 3, 0, 0),
+            "bool": True,
+            "list[u8]": [3],
+        },
+        {
+            "str": "d",
+            "u8": 4,
+            "i32": 4,
+            "f64": 4.0,
+            "cat": "d",
+            "datetime": datetime(2023, 1, 4, 0, 0),
+            "bool": True,
+            "list[u8]": [4],
+        },
+        {
+            "str": "e",
+            "u8": 5,
+            "i32": 5,
+            "f64": 5.0,
+            "cat": "e",
+            "datetime": datetime(2023, 1, 5, 0, 0),
+            "bool": False,
+            "list[u8]": [5],
+        },
+    ]


### PR DESCRIPTION
Resolve #8951.

When calling `pl.struct(...)` with a schema, the user shouldn't have to redundantly supply the column names if the schema defines the struct by itself:

```python
# this fails, but it shouldn't
import polars as pl

df = pl.DataFrame(
    {
        "a": [1, 2, 3],
        "b": [4, 5, 6],
    }
).select(
    pl.struct(schema={
        "a": pl.UInt8,
        "b": pl.Float32,
    }).alias("struct")
)
```

I think we should still keep the `schema` keyword as required, otherwise our `exprs` argument will have to have a bunch of additional type logic and it'll get messy.