### PR TITLE
perf(rust,python): avoid quadratic `exclude` behaviour when selecting against dtypes and/or wildcards

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/projection.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/projection.rs
@@ -56,11 +56,11 @@ fn rewrite_special_aliases(expr: Expr) -> PolarsResult<Expr> {
 fn replace_wildcard(
     expr: &Expr,
     result: &mut Vec<Expr>,
-    exclude: &[Arc<str>],
+    exclude: &PlHashSet<Arc<str>>,
     schema: &Schema,
 ) -> PolarsResult<()> {
     for name in schema.iter_names() {
-        if !exclude.iter().any(|excluded| &**excluded == name) {
+        if !exclude.contains(name.as_str()) {
             let new_expr = replace_wildcard_with_column(expr.clone(), Arc::from(name.as_str()));
             let new_expr = rewrite_special_aliases(new_expr)?;
             result.push(new_expr)
@@ -201,15 +201,15 @@ fn expand_dtypes(
     result: &mut Vec<Expr>,
     schema: &Schema,
     dtypes: &[DataType],
-    exclude: &[Arc<str>],
+    exclude: &PlHashSet<Arc<str>>,
 ) -> PolarsResult<()> {
     // note: we loop over the schema to guarantee that we return a stable
     // field-order, irrespective of which dtypes are filtered against
-    for field in schema.iter_fields().filter(|f| dtypes.contains(&f.dtype)) {
+    for field in schema
+        .iter_fields()
+        .filter(|f| (dtypes.contains(&f.dtype) && !exclude.contains(f.name().as_str())))
+    {
         let name = field.name();
-        if exclude.iter().any(|excl| excl.as_ref() == name.as_str()) {
-            continue; // skip excluded names
-        }
         let new_expr = expr.clone();
         let new_expr = replace_dtype_with_column(new_expr, Arc::from(name.as_str()));
         let new_expr = rewrite_special_aliases(new_expr)?;
@@ -220,8 +220,12 @@ fn expand_dtypes(
 
 // schema is not used if regex not activated
 #[allow(unused_variables)]
-fn prepare_excluded(expr: &Expr, schema: &Schema, keys: &[Expr]) -> PolarsResult<Vec<Arc<str>>> {
-    let mut exclude = vec![];
+fn prepare_excluded(
+    expr: &Expr,
+    schema: &Schema,
+    keys: &[Expr],
+) -> PolarsResult<PlHashSet<Arc<str>>> {
+    let mut exclude = PlHashSet::new();
     for e in expr {
         if let Expr::Exclude(_, to_exclude) = e {
             #[cfg(feature = "regex")]
@@ -239,14 +243,14 @@ fn prepare_excluded(expr: &Expr, schema: &Schema, keys: &[Expr]) -> PolarsResult
                             // we cannot loop because of bchck
                             while let Some(col) = buf.pop() {
                                 if let Expr::Column(name) = col {
-                                    exclude.push(name)
+                                    exclude.insert(name);
                                 }
                             }
                         }
                         Excluded::Dtype(dt) => {
                             for fld in schema.iter_fields() {
                                 if fld.data_type() == dt {
-                                    exclude.push(Arc::from(fld.name().as_ref()))
+                                    exclude.insert(Arc::from(fld.name().as_ref()));
                                 }
                             }
                         }
@@ -258,11 +262,13 @@ fn prepare_excluded(expr: &Expr, schema: &Schema, keys: &[Expr]) -> PolarsResult
             {
                 for to_exclude_single in to_exclude {
                     match to_exclude_single {
-                        Excluded::Name(name) => exclude.push(name.clone()),
+                        Excluded::Name(name) => {
+                            exclude.insert(name.clone());
+                        }
                         Excluded::Dtype(dt) => {
                             for (name, dtype) in schema.iter() {
                                 if matches!(dtype, dt) {
-                                    exclude.push(Arc::from(name.as_str()))
+                                    exclude.insert(Arc::from(name.as_str()));
                                 }
                             }
                         }
@@ -276,7 +282,7 @@ fn prepare_excluded(expr: &Expr, schema: &Schema, keys: &[Expr]) -> PolarsResult
         loop {
             match expr {
                 Expr::Column(name) => {
-                    exclude.push(name.clone());
+                    exclude.insert(name.clone());
                     break;
                 }
                 Expr::Alias(e, _) => {


### PR DESCRIPTION
Closes #8947.

_Huge_ speedup when excluding on wide frames; multiple orders of magnitude as the number of cols gets large. (Even though it's not noticeable on smaller frames, the quadratic behaviour really catches up with you as you head into the tens of thousands of columns 😅).

Changed `prepare_excluded` to return a HashSet as the number of items it can hold may be large, so we want the `O(1)` lookup; the `dtypes` param doesn't need the same treatment as even in the most extreme case there can only be a handful of them. Also moved the exclusion-match (inside `expand_dtypes`) up into the iter_fields filter.

## Example

```python
from codetiming import Timer
import polars as pl

for n in ( 
    # fast enough not to notice
    100,
    500,
    1_000,
    2_500,
    5_000,
    7_500,
    10_000,
    # "highway to the danger zone"
    50_000,
    75_000,
    100_000,
    175_000,
    250_000,
    500_000,
    1_000_000,
):
    df = pl.DataFrame( schema={f"c{i}":pl.Int32 for i in range(n)} )
    with Timer():
        _ = df.select( pl.exclude(pl.NUMERIC_DTYPES) )
```

## Results

**Timings:**

Hardware: _Apple Silicon M2 Max Pro_
Compiled with: _`maturin develop --release -- -C target-cpu=native `_

n cols | this pr | main | speedup
--: | --: | --: | :--:
100 | 0.0001 | 0.0001 | 1x
500 | 0.0002 | 0.0006 | 3x
1,000 | 0.0004 | 0.0022 | 5x
2,500 | 0.0008 | 0.0089 | 11x
5,000 | 0.0015 | 0.0423 | 28x
7,500 | 0.0018 | 0.0845 | 46x
10,000 | 0.0022 | 0.1555 | 70x
50,000 | 0.0113 | 3.3557 | 296x
75,000 | 0.0187 | 8.2587 | 441x
100,000 | 0.0248 | 14.9413 | 602x
175,000 | 0.0418 | 30.139 | 721x
250,000 | 0.0688 | 65.9686 | 958x
500,000 | 0.1478 | 333.4362 | 2255x
1,000,000 | 0.3226 | 1527.7112 | 4735x

**Plot:**

Orange: current `main`.
Blue: this `pr`.

<picture>
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/pola-rs/polars/assets/2613171/4b731941-e894-4ae1-9f60-f8eb40081d4e">
  <img src="https://github.com/pola-rs/polars/assets/2613171/c88f0f05-f1b4-4425-ac27-8e48f10a0f7c">
</picture>
