### PR TITLE
fix(python): ignore versioned `venv` dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,6 @@ data/
 node_modules/
 polars/vendor
 target/
-venv/
-.venv/
+venv*/
+.venv*/
 .vim


### PR DESCRIPTION
When testing against multiple/different Python versions, it's common to suffix the `venv` dir with a version number; this is just a minor tweak to the `.gitignore` to ensure that such dirs are also ignored.

Noticed this when my `.venv310` directory almost committed itself... :)