### PR TITLE
refactor(python): deprecate `rename` "in_place" parameter

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -606,7 +606,7 @@ def from_arrow(
             schema=schema,
             schema_overrides=schema_overrides,
         ).to_series()
-        return s if (name or schema or schema_overrides) else s.rename("")
+        return s if (name or schema or schema_overrides) else s.alias("")
 
     if isinstance(data, pa.RecordBatch):
         data = [data]

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -606,9 +606,7 @@ def from_arrow(
             schema=schema,
             schema_overrides=schema_overrides,
         ).to_series()
-        return (
-            s if (name or schema or schema_overrides) else s.rename("", in_place=True)
-        )
+        return s if (name or schema or schema_overrides) else s.rename("")
 
     if isinstance(data, pa.RecordBatch):
         data = [data]

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1290,7 +1290,7 @@ class DataFrame:
 
         elif not isinstance(other, DataFrame):
             s = _prepare_other_arg(other, length=len(self))
-            other = DataFrame([s.rename(f"n{i}") for i in range(len(self.columns))])
+            other = DataFrame([s.alias(f"n{i}") for i in range(len(self.columns))])
 
         orig_dtypes = other.dtypes
         other = self._cast_all_from_to(other, INTEGER_DTYPES, Float64)

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3407,7 +3407,7 @@ class Expr:
 
             def wrap_f(x: Series) -> Series:  # pragma: no cover
                 def inner(s: Series) -> Series:  # pragma: no cover
-                    return function(s.rename(x.name))
+                    return function(s.alias(x.name))
 
                 return x.apply(inner, return_dtype=return_dtype, skip_nulls=skip_nulls)
 

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3407,8 +3407,7 @@ class Expr:
 
             def wrap_f(x: Series) -> Series:  # pragma: no cover
                 def inner(s: Series) -> Series:  # pragma: no cover
-                    s.rename(x.name, in_place=True)
-                    return function(s)
+                    return function(s.rename(x.name))
 
                 return x.apply(inner, return_dtype=return_dtype, skip_nulls=skip_nulls)
 

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -2422,12 +2422,7 @@ def arange(
     if not eager:
         return range_expr
     else:
-        return (
-            pl.DataFrame()
-            .select(range_expr)
-            .to_series()
-            .rename("arange", in_place=True)
-        )
+        return pl.DataFrame().select(range_expr.alias("arange")).to_series()
 
 
 def arg_sort_by(

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1941,6 +1941,9 @@ class Series:
 
         """
         if in_place is not None:
+            # if 'in_place' is not None, this indicates that the parameter was
+            # explicitly set by the caller, and we should warn against it (use
+            # of NoDefault only applies when one of the valid values is None).
             warnings.warn(
                 "the `in_place` parameter is deprecated and will be removed in a future"
                 " version; note that renaming is a shallow-copy operation with"
@@ -5454,7 +5457,7 @@ class Series:
 
         Remap, setting a default for unrecognised values...
 
-        >>> s.map_dict(country_lookup, default="Unspecified").rename("country_name")
+        >>> s.map_dict(country_lookup, default="Unspecified").alias("country_name")
         shape: (4,)
         Series: 'country_name' [str]
         [
@@ -5466,7 +5469,7 @@ class Series:
 
         ...or keep the original value, by making use of ``pl.first()``:
 
-        >>> s.map_dict(country_lookup, default=pl.first()).rename("country_name")
+        >>> s.map_dict(country_lookup, default=pl.first()).alias("country_name")
         shape: (4,)
         Series: 'country_name' [str]
         [
@@ -5478,7 +5481,7 @@ class Series:
 
         ...or keep the original value, by assigning the input series:
 
-        >>> s.map_dict(country_lookup, default=s).rename("country_name")
+        >>> s.map_dict(country_lookup, default=s).alias("country_name")
         shape: (4,)
         Series: 'country_name' [str]
         [

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4,6 +4,7 @@ import contextlib
 import math
 import os
 import typing
+import warnings
 from datetime import date, datetime, time, timedelta
 from typing import (
     TYPE_CHECKING,
@@ -91,6 +92,7 @@ from polars.utils.decorators import deprecated_alias
 from polars.utils.meta import get_index_type
 from polars.utils.various import (
     _is_generator,
+    find_stacklevel,
     is_int_sequence,
     parse_version,
     range_to_series,
@@ -1914,7 +1916,7 @@ class Series:
         s._s.rename(name)
         return s
 
-    def rename(self, name: str, *, in_place: bool = False) -> Series:
+    def rename(self, name: str, *, in_place: bool | None = None) -> Series:
         """
         Rename this Series.
 
@@ -1938,6 +1940,14 @@ class Series:
         ]
 
         """
+        if in_place is not None:
+            warnings.warn(
+                "the `in_place` parameter is deprecated and will be removed in a future"
+                " version; note that renaming is a shallow-copy operation with"
+                " essentially zero cost.",
+                category=DeprecationWarning,
+                stacklevel=find_stacklevel(),
+            )
         if in_place:
             self._s.rename(name)
             return self

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -820,7 +820,7 @@ def _sequence_of_series_to_pydf(
     data_series: list[PySeries] = []
     for i, s in enumerate(data):
         if not s.name:
-            s = s.rename(column_names[i])
+            s = s.alias(column_names[i])
         new_dtype = schema_overrides.get(column_names[i])
         if new_dtype and new_dtype != s.dtype:
             s = s.cast(new_dtype)

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -151,8 +151,9 @@ def nt_unpack(obj: Any) -> Any:
 
 def series_to_pyseries(name: str, values: Series) -> PySeries:
     """Construct a PySeries from a Polars Series."""
-    values.rename(name, in_place=True)
-    return values._s
+    py_s = values._s
+    py_s.rename(name)
+    return py_s
 
 
 def arrow_to_pyseries(name: str, values: pa.Array, rechunk: bool = True) -> PySeries:
@@ -676,7 +677,7 @@ def _expand_dict_scalars(
                     updated_data[name] = pl.DataFrame(val).to_struct(name)
 
                 elif isinstance(val, pl.Series):
-                    s = val.rename(name, in_place=False) if name != val.name else val
+                    s = val.rename(name) if name != val.name else val
                     if dtype and dtype != s.dtype:
                         s = s.cast(dtype)
                     updated_data[name] = s
@@ -819,7 +820,7 @@ def _sequence_of_series_to_pydf(
     data_series: list[PySeries] = []
     for i, s in enumerate(data):
         if not s.name:
-            s = s.rename(column_names[i], in_place=False)
+            s = s.rename(column_names[i])
         new_dtype = schema_overrides.get(column_names[i])
         if new_dtype and new_dtype != s.dtype:
             s = s.cast(new_dtype)

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -108,7 +108,7 @@ def range_to_series(
         step=rng.step,
         eager=True,
         dtype=dtype,
-    ).rename(name, in_place=True)
+    ).rename(name)
 
 
 def range_to_slice(rng: range) -> slice:

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -339,7 +339,10 @@ class _NoDefault(Enum):
         return "<no_default>"
 
 
-no_default = _NoDefault.no_default  # Sentinel indicating the default value.
+# 'NoDefault' is a sentinel indicating that no default value has been set; note that
+# this should typically be used only when one of the valid parameter values is also
+# None, as otherwise we cannot determine if the caller has explicitly set that value.
+no_default = _NoDefault.no_default
 NoDefault = Literal[_NoDefault.no_default]
 
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -451,7 +451,7 @@ def test_various() -> None:
     assert a.is_null().sum() == 0
     assert a.name == "a"
 
-    a.rename("b", in_place=True)
+    a = a.rename("b")
     assert a.name == "b"
     assert a.len() == 2
     assert len(a) == 2


### PR DESCRIPTION
As per https://github.com/pola-rs/polars/pull/8956#discussion_r1199695987, this deprecates the `rename` method's "in_place" parameter; there is no cost difference between in_place=True/False, and three minor bugs with inadvertent in-place renames were squashed just in the last week, so...👋 

## Example
Shows the deprecation message raised if `in_place=True` or  `in_place=False` are set; the default is now `None`, which matches the current behaviour, but can be distinguished from explicit usage (consequently default usage will not generate the warning).

```python
import polars as pl

s = pl.Series( [1,2,3] )
s.rename( "s", in_place=True )

# DeprecationWarning: the `in_place` parameter is deprecated and will be removed in a
# future version; note that renaming is a shallow-copy operation with essentially zero cost.
```

---

Other methods with `in_place` params are:

* `rechunk`
* `shrink_to_fit`
* `sort`
* `vstack`

We should remove the `in_place` param from some (all?) of these too...
