### PR TITLE
fix(python): Improve read_parquet missing column error message

### DIFF
--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -60,10 +60,9 @@ pub(crate) fn columns_to_projection(
 
         for column in columns.iter() {
             let Some(&i) = column_names.get(column.as_str()) else {
-                let valid_columns: Vec<String> = schema.fields.iter().map(|f| f.name.clone()).collect();
                 polars_bail!(
                     ColumnNotFound:
-                    "unable to find column {:?}; valid columns: {:?}", column, valid_columns,
+                    "unable to find column {:?}; valid columns: {:?}", column, schema.get_names(),
                 );
             };
             prj.push(i);

--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -63,7 +63,7 @@ pub(crate) fn columns_to_projection(
                 let valid_columns: Vec<String> = schema.fields.iter().map(|f| f.name.clone()).collect();
                 polars_bail!(
                     ColumnNotFound:
-                    "unable to find {:?}; valid columns: {:?}", column, valid_columns,
+                    "unable to find column {:?}; valid columns: {:?}", column, valid_columns,
                 );
             };
             prj.push(i);


### PR DESCRIPTION
Currently, if you use `read_parquet(columns=...)` with a list of <= 100 columns, and a column is missing from the Parquet file, you will get an error like:

```
SchemaError: unable to get field 'abc' from schema: Schema { fields: [Field { name: "x", data_type: Int64, is_nullable: true, metadata: {} }], metadata: {} }
```

If the schema has many fields, this will result in an error message spanning multiple display pages.

If you pass more than 100 columns, you will get:

```
ColumnNotFoundError: unable to find "abc"; valid columns: ["x"]
```

With this PR, I changed the former case to also return the shorter message.