### PR TITLE
feat(python): allow set column list input to 'drop' and 'drop_nulls'

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -14,6 +14,7 @@ from typing import (
     Any,
     BinaryIO,
     Callable,
+    Collection,
     Generator,
     Iterable,
     Iterator,
@@ -3411,7 +3412,7 @@ class DataFrame:
         *,
         include_header: bool = False,
         header_name: str = "column",
-        column_names: Iterator[str] | Sequence[str] | None = None,
+        column_names: Iterable[str] | None = None,
     ) -> Self:
         """
         Transpose a DataFrame over the diagonal.
@@ -3424,7 +3425,7 @@ class DataFrame:
             If `include_header` is set, this determines the name of the column that will
             be inserted.
         column_names
-            Optional generator/iterator that yields column names. Will be used to
+            Optional iterable that yields column names. Will be used to
             replace the columns in the DataFrame.
 
         Notes
@@ -4433,7 +4434,7 @@ class DataFrame:
         """
         return self.head(n)
 
-    def drop_nulls(self, subset: str | Sequence[str] | None = None) -> Self:
+    def drop_nulls(self, subset: str | Collection[str] | None = None) -> Self:
         """
         Drop all rows that contain null values.
 
@@ -5796,7 +5797,7 @@ class DataFrame:
         self._df.extend(other._df)
         return self
 
-    def drop(self, columns: str | Sequence[str], *more_columns: str) -> Self:
+    def drop(self, columns: str | Collection[str], *more_columns: str) -> Self:
         """
         Remove columns from the dataframe.
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -11,6 +11,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
     Iterable,
     NoReturn,
     Sequence,
@@ -3249,7 +3250,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self._from_pyldf(self._ldf.with_context([lf._ldf for lf in other]))
 
-    def drop(self, columns: str | Sequence[str], *more_columns: str) -> Self:
+    def drop(self, columns: str | Collection[str], *more_columns: str) -> Self:
         """
         Remove columns from the dataframe.
 
@@ -3314,10 +3315,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         if isinstance(columns, str):
             columns = [columns]
-        if more_columns:
-            columns = list(columns)
-            columns.extend(more_columns)
-        return self._from_pyldf(self._ldf.drop(columns))
+        return self._from_pyldf(self._ldf.drop([*columns, *more_columns]))
 
     def rename(self, mapping: dict[str, str]) -> Self:
         """
@@ -4378,7 +4376,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             subset = [subset]
         return self._from_pyldf(self._ldf.unique(maintain_order, subset, keep))
 
-    def drop_nulls(self, subset: str | Sequence[str] | None = None) -> Self:
+    def drop_nulls(self, subset: str | Collection[str] | None = None) -> Self:
         """
         Drop all rows that contain null values.
 
@@ -4450,8 +4448,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └──────┴─────┴──────┘
 
         """
-        if isinstance(subset, str):
-            subset = [subset]
+        if subset is not None:
+            if isinstance(subset, str):
+                subset = [subset]
+            subset = list(subset)
         return self._from_pyldf(self._ldf.drop_nulls(subset))
 
     def melt(

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -1,3 +1,7 @@
+from typing import Any
+
+import pytest
+
 import polars as pl
 from polars.testing import assert_frame_equal
 
@@ -32,7 +36,15 @@ def test_drop_explode_6641() -> None:
     }
 
 
-def test_drop_nulls() -> None:
+@pytest.mark.parametrize(
+    "subset",
+    [
+        "foo",
+        ["foo"],
+        {"foo"},
+    ],
+)
+def test_drop_nulls(subset: Any) -> None:
     df = pl.DataFrame(
         {
             "foo": [1, 2, 3],
@@ -51,7 +63,7 @@ def test_drop_nulls() -> None:
     assert_frame_equal(result, expected)
 
     # below we only drop entries if they are null in the column 'foo'
-    result = df.drop_nulls("foo")
+    result = df.drop_nulls(subset)
     assert_frame_equal(result, df)
 
 
@@ -82,6 +94,12 @@ def test_drop_columns() -> None:
 
     out = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).lazy().drop("a")
     assert out.columns == ["b", "c"]
+
+    out2 = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).drop("a", "b")
+    assert out2.columns == ["c"]
+
+    out2 = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).drop({"a"}, "b", "c")
+    assert out2.columns == []
 
 
 def test_drop_nan_ignore_null_3525() -> None:


### PR DESCRIPTION
Allow `df.drop({"col1", "col2"})` and `df.drop_nulls({"col1", "col2"})`.

In principle we could allow set inputs for column lists in other places, but I'm not sure it's a good idea because IIUC the order of those column name lists will be taken as the order in the output data frame (eg. `read_parquet`).

Technically we could even make the `Collection` an `Iterable` because all we need to be able is to convert to a list. But I'm not sure we want this from a user experience point of view.