### PR TITLE
refactor(python): Clean up `repeat`/`ones`/`zeros`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -1300,7 +1300,7 @@ pub fn as_struct(exprs: &[Expr]) -> Expr {
 /// Create a column of length `n` containing `n` copies of the literal `value`. Generally you won't need this function,
 /// as `lit(value)` already represents a column containing only `value` whose length is automatically set to the correct
 /// number of rows.
-pub fn repeat<L: Literal>(value: L, n_times: Expr) -> Expr {
+pub fn repeat<L: Literal>(value: L, n: Expr) -> Expr {
     let function = |s: Series, n: Series| {
         let n =
             n.get(0).unwrap().extract::<usize>().ok_or_else(
@@ -1308,7 +1308,7 @@ pub fn repeat<L: Literal>(value: L, n_times: Expr) -> Expr {
             )?;
         Ok(Some(s.new_from_index(0, n)))
     };
-    apply_binary(lit(value), n_times, function, GetOutput::same_type())
+    apply_binary(lit(value), n, function, GetOutput::same_type())
 }
 
 #[cfg(feature = "arg_where")]

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -70,17 +70,8 @@ from polars.exceptions import (
     StructFieldNotFoundError,
 )
 from polars.expr import Expr
-from polars.functions.eager import (
+from polars.functions import (
     align_frames,
-    concat,
-    cut,
-    date_range,
-    get_dummies,
-    ones,
-    time_range,
-    zeros,
-)
-from polars.functions.lazy import (
     all,
     any,
     apply,
@@ -92,6 +83,7 @@ from polars.functions.lazy import (
     coalesce,
     col,
     collect_all,
+    concat,
     concat_list,
     concat_str,
     corr,
@@ -100,6 +92,8 @@ from polars.functions.lazy import (
     cumfold,
     cumreduce,
     cumsum,
+    cut,
+    date_range,
     duration,
     element,
     exclude,
@@ -107,6 +101,7 @@ from polars.functions.lazy import (
     fold,
     format,
     from_epoch,
+    get_dummies,
     groups,
     head,
     implode,
@@ -118,6 +113,7 @@ from polars.functions.lazy import (
     median,
     min,
     n_unique,
+    ones,
     pearson_corr,
     quantile,
     reduce,
@@ -130,7 +126,9 @@ from polars.functions.lazy import (
     struct,
     sum,
     tail,
+    time_range,
     var,
+    zeros,
 )
 from polars.functions.lazy import date_ as date
 from polars.functions.lazy import datetime_ as datetime

--- a/py-polars/polars/functions/__init__.py
+++ b/py-polars/polars/functions/__init__.py
@@ -4,9 +4,7 @@ from polars.functions.eager import (
     cut,
     date_range,
     get_dummies,
-    ones,
     time_range,
-    zeros,
 )
 from polars.functions.lazy import (
     all,
@@ -49,7 +47,6 @@ from polars.functions.lazy import (
     pearson_corr,
     quantile,
     reduce,
-    repeat,
     rolling_corr,
     rolling_cov,
     select,
@@ -64,6 +61,7 @@ from polars.functions.lazy import date_ as date
 from polars.functions.lazy import datetime_ as datetime
 from polars.functions.lazy import list_ as list
 from polars.functions.lazy import time_ as time
+from polars.functions.repeat import ones, repeat, zeros
 from polars.functions.whenthen import when
 
 __all__ = [

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
         ClosedInterval,
         ConcatMethod,
         JoinStrategy,
-        PolarsDataType,
         PolarsType,
         TimeUnit,
     )
@@ -929,75 +928,3 @@ def align_frames(
     return cast(
         List[FrameType], F.collect_all(aligned_frames) if eager else aligned_frames
     )
-
-
-def ones(n: int, dtype: PolarsDataType | None = None) -> Series:
-    """
-    Return a new Series of given length and type, filled with ones.
-
-    Parameters
-    ----------
-    n
-        Number of elements in the ``Series``
-    dtype
-        DataType of the elements, defaults to ``polars.Float64``
-
-    Notes
-    -----
-    In the lazy API you should probably not use this, but use ``lit(1)``
-    instead.
-
-    Examples
-    --------
-    >>> pl.ones(5, pl.Int64)
-    shape: (5,)
-    Series: '' [i64]
-    [
-        1
-        1
-        1
-        1
-        1
-    ]
-
-    """
-    s = pl.Series([1.0])
-    if dtype:
-        s = s.cast(dtype)
-    return s.new_from_index(0, n)
-
-
-def zeros(n: int, dtype: PolarsDataType | None = None) -> Series:
-    """
-    Return a new Series of given length and type, filled with zeros.
-
-    Parameters
-    ----------
-    n
-        Number of elements in the ``Series``
-    dtype
-        DataType of the elements, defaults to ``polars.Float64``
-
-    Notes
-    -----
-    In the lazy API you should probably not use this, but use ``lit(0)``
-    instead.
-
-    Examples
-    --------
-    >>> pl.zeros(5, pl.Int64)
-    shape: (5,)
-    Series: '' [i64]
-    [
-        0
-        0
-        0
-        0
-        0
-    ]
-
-    """
-    s = pl.Series([0.0])
-    if dtype:
-        s = s.cast(dtype)
-    return s.new_from_index(0, n)

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import warnings
 from datetime import date, datetime, time, timedelta
-from typing import TYPE_CHECKING, Any, Callable, Iterable, NoReturn, Sequence, overload
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, overload
 
 import polars._reexport as pl
 from polars.datatypes import (
@@ -3107,123 +3107,6 @@ def struct(
     if eager:
         return select(expr).to_series()
     else:
-        return expr
-
-
-@overload
-def repeat(
-    value: PythonLiteral | None,
-    n: Expr | int,
-    *,
-    eager: Literal[False] = ...,
-    name: str | None = ...,
-    dtype: PolarsDataType | None = ...,
-) -> Expr:
-    ...
-
-
-@overload
-def repeat(
-    value: PythonLiteral | None,
-    n: Expr,
-    *,
-    eager: Literal[True],
-    name: str | None = ...,
-    dtype: PolarsDataType | None = ...,
-) -> NoReturn:
-    ...
-
-
-@overload
-def repeat(
-    value: PythonLiteral | None,
-    n: int,
-    *,
-    eager: Literal[True],
-    name: str | None = ...,
-    dtype: PolarsDataType | None = ...,
-) -> Series:
-    ...
-
-
-@overload
-def repeat(
-    value: PythonLiteral | None,
-    n: Expr | int,
-    *,
-    eager: bool,
-    name: str | None,
-    dtype: PolarsDataType | None = ...,
-) -> Expr | Series:
-    ...
-
-
-def repeat(
-    value: PythonLiteral | None,
-    n: Expr | int,
-    *,
-    eager: bool = False,
-    name: str | None = None,
-    dtype: PolarsDataType | None = None,
-) -> Expr | Series:
-    """
-    Construct a column with the given value repeated `n` times.
-
-    Parameters
-    ----------
-    value
-        Value to repeat.
-    n
-        Length of the resulting column.
-    eager
-        Evaluate immediately and return a ``Series``. If set to ``False`` (default),
-        return an expression instead.
-    name
-        Name of the resulting column.
-    dtype
-        Data type of the resulting column. If set to ``None`` (default), data type is
-        inferred from the given value. Defaults to Int32 for integer values, unless
-        Int64 is required to fit the given value. Defaults to Float64 for float values.
-
-    Examples
-    --------
-    Construct a column with a repeated value in a lazy context.
-
-    >>> pl.select(pl.repeat("z", n=3)).to_series()
-    shape: (3,)
-    Series: 'literal' [str]
-    [
-            "z"
-            "z"
-            "z"
-    ]
-
-    Generate a Series directly by setting ``eager=True``.
-
-    >>> pl.repeat(3, n=3, eager=True, name="three", dtype=pl.Int8)
-    shape: (3,)
-    Series: 'three' [i8]
-    [
-            3
-            3
-            3
-    ]
-
-    """
-    if eager:
-        if not isinstance(n, int):
-            raise ValueError(
-                "`n` must be an integer when using `repeat` in an eager context."
-            )
-        return pl.Series._repeat(value, n, name=name, dtype=dtype)
-    else:
-        if isinstance(n, int):
-            n = lit(n)
-        expr = wrap_expr(plr.repeat(value, n._pyexpr))
-        if name is not None:
-            expr = expr.alias(name)
-        if dtype is not None:
-            expr = expr.cast(dtype)
         return expr
 
 

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, NoReturn, overload
+
+import polars._reexport as pl
+from polars import functions as F
+from polars.datatypes import Float64
+from polars.utils._wrap import wrap_expr
+
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    import polars.polars as plr
+
+
+if TYPE_CHECKING:
+    import sys
+
+    from polars import Expr, Series
+    from polars.type_aliases import PolarsDataType, PythonLiteral
+
+    if sys.version_info >= (3, 8):
+        from typing import Literal
+    else:
+        from typing_extensions import Literal
+
+
+@overload
+def repeat(
+    value: PythonLiteral | None,
+    n: Expr | int,
+    *,
+    dtype: PolarsDataType | None = ...,
+    name: str | None = ...,
+    eager: Literal[False] = ...,
+) -> Expr:
+    ...
+
+
+@overload
+def repeat(
+    value: PythonLiteral | None,
+    n: int,
+    *,
+    dtype: PolarsDataType | None = ...,
+    name: str | None = ...,
+    eager: Literal[True],
+) -> Series:
+    ...
+
+
+@overload
+def repeat(
+    value: PythonLiteral | None,
+    n: Expr,
+    *,
+    dtype: PolarsDataType | None = ...,
+    name: str | None = ...,
+    eager: Literal[True],
+) -> NoReturn:
+    ...
+
+
+@overload
+def repeat(
+    value: PythonLiteral | None,
+    n: Expr | int,
+    *,
+    dtype: PolarsDataType | None = ...,
+    name: str | None,
+    eager: bool,
+) -> Expr | Series:
+    ...
+
+
+def repeat(
+    value: PythonLiteral | None,
+    n: Expr | int,
+    *,
+    dtype: PolarsDataType | None = None,
+    name: str | None = None,
+    eager: bool = False,
+) -> Expr | Series:
+    """
+    Construct a column of length `n` filled with the given value.
+
+    Parameters
+    ----------
+    value
+        Value to repeat.
+    n
+        Length of the resulting column.
+    dtype
+        Data type of the resulting column. If set to ``None`` (default), data type is
+        inferred from the given value. Defaults to Int32 for integer values, unless
+        Int64 is required to fit the given value. Defaults to Float64 for float values.
+    name
+        Name of the resulting column.
+    eager
+        Evaluate immediately and return a ``Series``. If set to ``False`` (default),
+        return an expression instead.
+
+    Notes
+    -----
+    If you want to construct a column in lazy mode and do not need a pre-determined
+    length, use :func:`lit` instead.
+
+    See Also
+    --------
+    lit
+
+    Examples
+    --------
+    Construct a column with a repeated value in a lazy context.
+
+    >>> pl.select(pl.repeat("z", n=3)).to_series()
+    shape: (3,)
+    Series: 'literal' [str]
+    [
+            "z"
+            "z"
+            "z"
+    ]
+
+    Generate a Series directly by setting ``eager=True``.
+
+    >>> pl.repeat(3, n=3, eager=True, name="three", dtype=pl.Int8)
+    shape: (3,)
+    Series: 'three' [i8]
+    [
+            3
+            3
+            3
+    ]
+
+    """
+    if eager:
+        if not isinstance(n, int):
+            raise ValueError(
+                "`n` must be an integer when using `repeat` in an eager context."
+            )
+        return pl.Series._repeat(value, n, name=name, dtype=dtype)
+    else:
+        return _repeat_lazy(value, n, dtype=dtype, name=name)
+
+
+def _repeat_lazy(
+    value: PythonLiteral | None,
+    n: Expr | int,
+    *,
+    dtype: PolarsDataType | None = None,
+    name: str | None = None,
+) -> Expr:
+    if isinstance(n, int):
+        n = F.lit(n)
+    expr = wrap_expr(plr.repeat(value, n._pyexpr))
+    if name is not None:
+        expr = expr.alias(name)
+    if dtype is not None:
+        expr = expr.cast(dtype)
+    return expr
+
+
+def ones(
+    n: int,
+    dtype: PolarsDataType = Float64,
+    *,
+    name: str | None = None,
+    eager: bool = True,
+) -> Series:
+    """
+    Construct a column of length `n` filled with ones.
+
+    Syntactic sugar for ``repeat(1.0, ...)``.
+
+    Parameters
+    ----------
+    n
+        Length of the resulting column.
+    dtype
+        Data type of the resulting column. Defaults to Float64.
+    name
+        Name of the resulting column.
+    eager
+        Evaluate immediately and return a ``Series``. If set to ``False`` (default),
+        return an expression instead.
+
+    Notes
+    -----
+    If you want to construct a column in lazy mode and do not need a pre-determined
+    length, use :func:`lit` instead.
+
+    See Also
+    --------
+    repeat
+    lit
+
+    Examples
+    --------
+    >>> pl.ones(3, pl.Int8, eager=True)
+    shape: (3,)
+    Series: '' [i8]
+    [
+        1
+        1
+        1
+    ]
+
+    """
+    return repeat(1.0, n=n, dtype=dtype, name=name, eager=eager)
+
+
+def zeros(
+    n: int,
+    dtype: PolarsDataType = Float64,
+    *,
+    name: str | None = None,
+    eager: bool = True,
+) -> Series:
+    """
+    Construct a column of length `n` filled with zeros.
+
+    Syntactic sugar for ``repeat(0.0, ...)``.
+
+    Parameters
+    ----------
+    n
+        Length of the resulting column.
+    dtype
+        Data type of the resulting column. Defaults to Float64.
+    name
+        Name of the resulting column.
+    eager
+        Evaluate immediately and return a ``Series``. If set to ``False`` (default),
+        return an expression instead.
+
+    Notes
+    -----
+    If you want to construct a column in lazy mode and do not need a pre-determined
+    length, use :func:`lit` instead.
+
+    See Also
+    --------
+    repeat
+    lit
+
+    Examples
+    --------
+    >>> pl.zeros(3, pl.Int8, eager=True)
+    shape: (3,)
+    Series: '' [i8]
+    [
+        0
+        0
+        0
+    ]
+
+    """
+    return repeat(0.0, n=n, dtype=dtype, name=name, eager=eager)

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import contextlib
+import warnings
 from typing import TYPE_CHECKING, NoReturn, overload
 
 import polars._reexport as pl
 from polars import functions as F
 from polars.datatypes import Float64
+from polars.utils import no_default
 from polars.utils._wrap import wrap_expr
+from polars.utils.various import find_stacklevel
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -17,6 +20,7 @@ if TYPE_CHECKING:
 
     from polars import Expr, Series
     from polars.type_aliases import PolarsDataType, PythonLiteral
+    from polars.utils import NoDefault
 
     if sys.version_info >= (3, 8):
         from typing import Literal
@@ -66,7 +70,7 @@ def repeat(
     n: Expr | int,
     *,
     dtype: PolarsDataType | None = ...,
-    name: str | None,
+    name: str | None = ...,
     eager: bool,
 ) -> Expr | Series:
     ...
@@ -160,13 +164,46 @@ def _repeat_lazy(
     return expr
 
 
+@overload
+def ones(
+    n: int,
+    dtype: PolarsDataType = ...,
+    *,
+    name: str | None = ...,
+    eager: Literal[False],
+) -> Expr:
+    ...
+
+
+@overload
+def ones(
+    n: int,
+    dtype: PolarsDataType = ...,
+    *,
+    name: str | None = ...,
+    eager: Literal[True] = ...,
+) -> Series:
+    ...
+
+
+@overload
+def ones(
+    n: int,
+    dtype: PolarsDataType = ...,
+    *,
+    name: str | None = ...,
+    eager: bool,
+) -> Expr | Series:
+    ...
+
+
 def ones(
     n: int,
     dtype: PolarsDataType = Float64,
     *,
     name: str | None = None,
-    eager: bool = True,
-) -> Series:
+    eager: bool | NoDefault = no_default,
+) -> Expr | Series:
     """
     Construct a column of length `n` filled with ones.
 
@@ -181,7 +218,7 @@ def ones(
     name
         Name of the resulting column.
     eager
-        Evaluate immediately and return a ``Series``. If set to ``False`` (default),
+        Evaluate immediately and return a ``Series``. If set to ``False``,
         return an expression instead.
 
     Notes
@@ -206,7 +243,50 @@ def ones(
     ]
 
     """
+    if eager is no_default:
+        warnings.warn(
+            "In a future version, the default behaviour for `ones` will change from `eager=True` to `eager=False`. "
+            "To silence this warning, please:\n"
+            "- set `eager=False` to opt in to the new default behaviour, or\n"
+            "- set `eager=True` to retain the old one.",
+            FutureWarning,
+            stacklevel=find_stacklevel(),
+        )
+        eager = True
     return repeat(1.0, n=n, dtype=dtype, name=name, eager=eager)
+
+
+@overload
+def zeros(
+    n: int,
+    dtype: PolarsDataType = ...,
+    *,
+    name: str | None = ...,
+    eager: Literal[False],
+) -> Expr:
+    ...
+
+
+@overload
+def zeros(
+    n: int,
+    dtype: PolarsDataType = ...,
+    *,
+    name: str | None = ...,
+    eager: Literal[True] = ...,
+) -> Series:
+    ...
+
+
+@overload
+def zeros(
+    n: int,
+    dtype: PolarsDataType = ...,
+    *,
+    name: str | None = ...,
+    eager: bool,
+) -> Expr | Series:
+    ...
 
 
 def zeros(
@@ -214,8 +294,8 @@ def zeros(
     dtype: PolarsDataType = Float64,
     *,
     name: str | None = None,
-    eager: bool = True,
-) -> Series:
+    eager: bool | NoDefault = no_default,
+) -> Expr | Series:
     """
     Construct a column of length `n` filled with zeros.
 
@@ -230,7 +310,7 @@ def zeros(
     name
         Name of the resulting column.
     eager
-        Evaluate immediately and return a ``Series``. If set to ``False`` (default),
+        Evaluate immediately and return a ``Series``. If set to ``False``,
         return an expression instead.
 
     Notes
@@ -255,4 +335,14 @@ def zeros(
     ]
 
     """
+    if eager is no_default:
+        warnings.warn(
+            "In a future version, the default behaviour for `ones` will change from `eager=True` to `eager=False`. "
+            "To silence this warning, please:\n"
+            "- set `eager=False` to opt in to the new default behaviour, or\n"
+            "- set `eager=True` to retain the old one.",
+            FutureWarning,
+            stacklevel=find_stacklevel(),
+        )
+        eager = True
     return repeat(0.0, n=n, dtype=dtype, name=name, eager=eager)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -343,16 +343,6 @@ class Series:
         name: str | None = None,
         dtype: PolarsDataType | None = None,
     ) -> Self:
-        if name is None:
-            name = ""
-        if dtype is None:
-            dtype = py_type_to_dtype(type(value))
-            if (
-                dtype == Int64
-                and isinstance(value, int)
-                and -(2**31) <= value <= 2**31 - 1
-            ):
-                dtype = Int32
         return cls._from_pyseries(PySeries.repeat(value, n, name, dtype))
 
     def _get_ptr(self) -> int:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -334,17 +334,6 @@ class Series:
             pandas_to_pyseries(name, values, nan_to_null=nan_to_null)
         )
 
-    @classmethod
-    def _repeat(
-        cls,
-        value: PythonLiteral | None,
-        n: int,
-        *,
-        name: str | None = None,
-        dtype: PolarsDataType | None = None,
-    ) -> Self:
-        return cls._from_pyseries(PySeries.repeat(value, n, name, dtype))
-
     def _get_ptr(self) -> int:
         """
         Get a pointer to the start of the values buffer of a numeric Series.

--- a/py-polars/src/functions/eager.rs
+++ b/py-polars/src/functions/eager.rs
@@ -140,10 +140,7 @@ pub fn repeat_eager(
             _ => value.dtype(),
         },
     };
-    let name = match name {
-        Some(name) => name,
-        None => "",
-    };
+    let name = name.unwrap_or("");
 
     Ok(Series::new(name, &[value])
         .cast(&dtype)

--- a/py-polars/src/functions/eager.rs
+++ b/py-polars/src/functions/eager.rs
@@ -1,6 +1,6 @@
 use polars::{functions, time};
 use polars_core::datatypes::{TimeUnit, TimeZone};
-use polars_core::prelude::{DataFrame, IntoSeries};
+use polars_core::prelude::*;
 use pyo3::prelude::*;
 
 use crate::conversion::{get_df, get_series, Wrap};
@@ -115,6 +115,41 @@ pub fn hor_concat_df(dfs: &PyAny) -> PyResult<PyDataFrame> {
 
     let df = functions::hor_concat_df(&dfs).map_err(PyPolarsErr::from)?;
     Ok(df.into())
+}
+
+#[pyfunction]
+pub fn repeat_eager(
+    value: Wrap<AnyValue>,
+    n: usize,
+    dtype: Option<Wrap<DataType>>,
+    name: Option<&str>,
+) -> PyResult<PySeries> {
+    let value = value.0;
+    let dtype = match dtype.map(|wrap| wrap.0) {
+        Some(dtype) => dtype,
+        None => match value.dtype() {
+            // Integer inputs that fit in Int32 are parsed as such
+            DataType::Int64 => {
+                let int_value: i64 = value.extract().unwrap();
+                if int_value >= i32::MIN as i64 && int_value <= i32::MAX as i64 {
+                    DataType::Int32
+                } else {
+                    DataType::Int64
+                }
+            }
+            _ => value.dtype(),
+        },
+    };
+    let name = match name {
+        Some(name) => name,
+        None => "",
+    };
+
+    Ok(Series::new(name, &[value])
+        .cast(&dtype)
+        .map_err(PyPolarsErr::from)?
+        .new_from_index(0, n)
+        .into())
 }
 
 #[pyfunction]

--- a/py-polars/src/functions/eager.rs
+++ b/py-polars/src/functions/eager.rs
@@ -130,13 +130,14 @@ pub fn repeat_eager(
         None => match value.dtype() {
             // Integer inputs that fit in Int32 are parsed as such
             DataType::Int64 => {
-                let int_value: i64 = value.extract().unwrap();
+                let int_value: i64 = value.try_extract().unwrap();
                 if int_value >= i32::MIN as i64 && int_value <= i32::MAX as i64 {
                     DataType::Int32
                 } else {
                     DataType::Int64
                 }
             }
+            DataType::Unknown => DataType::Null,
             _ => value.dtype(),
         },
     };

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -382,7 +382,7 @@ pub fn reduce(lambda: PyObject, exprs: Vec<PyExpr>) -> PyExpr {
 }
 
 #[pyfunction]
-pub fn repeat(value: &PyAny, n: PyExpr) -> PyResult<PyExpr> {
+pub fn repeat_lazy(value: &PyAny, n: PyExpr) -> PyResult<PyExpr> {
     if let Ok(true) = value.is_instance_of::<PyBool>() {
         let val = value.extract::<bool>().unwrap();
         Ok(dsl::repeat(val, n.inner).into())

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -87,6 +87,8 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::eager::hor_concat_df))
         .unwrap();
+    m.add_wrapped(wrap_pyfunction!(functions::eager::repeat_eager))
+        .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::eager::time_range))
         .unwrap();
 
@@ -153,7 +155,7 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::reduce))
         .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::lazy::repeat))
+    m.add_wrapped(wrap_pyfunction!(functions::lazy::repeat_lazy))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::spearman_rank_corr))
         .unwrap();

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -233,41 +233,6 @@ impl PySeries {
     }
 
     #[staticmethod]
-    fn repeat(
-        value: Wrap<AnyValue>,
-        n: usize,
-        name: Option<&str>,
-        dtype: Option<Wrap<DataType>>,
-    ) -> PyResult<Self> {
-        let value = value.0;
-        let name = match name {
-            Some(name) => name,
-            None => "",
-        };
-        let dtype = match dtype.map(|wrap| wrap.0) {
-            Some(dtype) => dtype,
-            None => match value.dtype() {
-                // Integer inputs that fit in Int32 are parsed as such
-                DataType::Int64 => {
-                    let int_value: i64 = value.extract().unwrap();
-                    if int_value >= i32::MIN as i64 && int_value <= i32::MAX as i64 {
-                        DataType::Int32
-                    } else {
-                        DataType::Int64
-                    }
-                }
-                _ => value.dtype(),
-            },
-        };
-
-        Ok(Series::new(name, &[value])
-            .cast(&dtype)
-            .map_err(PyPolarsErr::from)?
-            .new_from_index(0, n)
-            .into())
-    }
-
-    #[staticmethod]
     fn from_arrow(name: &str, array: &PyAny) -> PyResult<Self> {
         let arr = array_to_rust(array)?;
 

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -236,12 +236,32 @@ impl PySeries {
     fn repeat(
         value: Wrap<AnyValue>,
         n: usize,
-        name: &str,
-        dtype: Wrap<DataType>,
+        name: Option<&str>,
+        dtype: Option<Wrap<DataType>>,
     ) -> PyResult<Self> {
-        let av = value.0;
-        Ok(Series::new(name, &[av])
-            .cast(&dtype.0)
+        let value = value.0;
+        let name = match name {
+            Some(name) => name,
+            None => "",
+        };
+        let dtype = match dtype.map(|wrap| wrap.0) {
+            Some(dtype) => dtype,
+            None => match value.dtype() {
+                // Integer inputs that fit in Int32 are parsed as such
+                DataType::Int64 => {
+                    let int_value: i64 = value.extract().unwrap();
+                    if int_value >= i32::MIN as i64 && int_value <= i32::MAX as i64 {
+                        DataType::Int32
+                    } else {
+                        DataType::Int64
+                    }
+                }
+                _ => value.dtype(),
+            },
+        };
+
+        Ok(Series::new(name, &[value])
+            .cast(&dtype)
             .map_err(PyPolarsErr::from)?
             .new_from_index(0, n)
             .into())

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -439,50 +439,6 @@ def test_fill_null_unknown_output_type() -> None:
     }
 
 
-def test_repeat() -> None:
-    s = pl.select(pl.repeat(2**31 - 1, 3)).to_series()
-    assert s.dtype == pl.Int32
-    assert s.len() == 3
-    assert s.to_list() == [2**31 - 1] * 3
-    s = pl.select(pl.repeat(-(2**31), 4)).to_series()
-    assert s.dtype == pl.Int32
-    assert s.len() == 4
-    assert s.to_list() == [-(2**31)] * 4
-    s = pl.select(pl.repeat(2**31, 5)).to_series()
-    assert s.dtype == pl.Int64
-    assert s.len() == 5
-    assert s.to_list() == [2**31] * 5
-    s = pl.select(pl.repeat(-(2**31) - 1, 3)).to_series()
-    assert s.dtype == pl.Int64
-    assert s.len() == 3
-    assert s.to_list() == [-(2**31) - 1] * 3
-    s = pl.select(pl.repeat("foo", 2)).to_series()
-    assert s.dtype == pl.Utf8
-    assert s.len() == 2
-    assert s.to_list() == ["foo"] * 2
-    s = pl.select(pl.repeat(1.0, 5)).to_series()
-    assert s.dtype == pl.Float64
-    assert s.len() == 5
-    assert s.to_list() == [1.0] * 5
-    s = pl.select(pl.repeat(True, 4)).to_series()
-    assert s.dtype == pl.Boolean
-    assert s.len() == 4
-    assert s.to_list() == [True] * 4
-    s = pl.select(pl.repeat(None, 7)).to_series()
-    assert s.dtype == pl.Null
-    assert s.len() == 7
-    assert s.to_list() == [None] * 7
-    s = pl.select(pl.repeat(0, 0)).to_series()
-    assert s.dtype == pl.Int32
-    assert s.len() == 0
-
-
-def test_repeat_dtype() -> None:
-    s = pl.select(pl.repeat(1, n=3, dtype=pl.Int8)).to_series()
-    assert s.dtype == pl.Int8
-    assert s.len() == 3
-
-
 def test_min_alias_for_series_min() -> None:
     s = pl.Series([1, 2, 3])
     assert pl.min(s) == s.min()

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -384,24 +384,6 @@ def test_coalesce() -> None:
     assert_frame_equal(result, expected)
 
 
-def test_ones_zeros() -> None:
-    ones = pl.ones(5)
-    assert ones.dtype == pl.Float64
-    assert ones.to_list() == [1.0, 1.0, 1.0, 1.0, 1.0]
-
-    ones = pl.ones(3, dtype=pl.UInt8)
-    assert ones.dtype == pl.UInt8
-    assert ones.to_list() == [1, 1, 1]
-
-    zeros = pl.zeros(5)
-    assert zeros.dtype == pl.Float64
-    assert zeros.to_list() == [0.0, 0.0, 0.0, 0.0, 0.0]
-
-    zeros = pl.zeros(3, dtype=pl.UInt8)
-    assert zeros.dtype == pl.UInt8
-    assert zeros.to_list() == [0, 0, 0]
-
-
 def test_overflow_diff() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -1,0 +1,96 @@
+from datetime import datetime
+
+import polars as pl
+
+
+def test_repeat_lazy() -> None:
+    s = pl.select(pl.repeat(2**31 - 1, 3)).to_series()
+    assert s.dtype == pl.Int32
+    assert s.len() == 3
+    assert s.to_list() == [2**31 - 1] * 3
+    s = pl.select(pl.repeat(-(2**31), 4)).to_series()
+    assert s.dtype == pl.Int32
+    assert s.len() == 4
+    assert s.to_list() == [-(2**31)] * 4
+    s = pl.select(pl.repeat(2**31, 5)).to_series()
+    assert s.dtype == pl.Int64
+    assert s.len() == 5
+    assert s.to_list() == [2**31] * 5
+    s = pl.select(pl.repeat(-(2**31) - 1, 3)).to_series()
+    assert s.dtype == pl.Int64
+    assert s.len() == 3
+    assert s.to_list() == [-(2**31) - 1] * 3
+    s = pl.select(pl.repeat("foo", 2)).to_series()
+    assert s.dtype == pl.Utf8
+    assert s.len() == 2
+    assert s.to_list() == ["foo"] * 2
+    s = pl.select(pl.repeat(1.0, 5)).to_series()
+    assert s.dtype == pl.Float64
+    assert s.len() == 5
+    assert s.to_list() == [1.0] * 5
+    s = pl.select(pl.repeat(True, 4)).to_series()
+    assert s.dtype == pl.Boolean
+    assert s.len() == 4
+    assert s.to_list() == [True] * 4
+    s = pl.select(pl.repeat(None, 7)).to_series()
+    assert s.dtype == pl.Null
+    assert s.len() == 7
+    assert s.to_list() == [None] * 7
+    s = pl.select(pl.repeat(0, 0)).to_series()
+    assert s.dtype == pl.Int32
+    assert s.len() == 0
+
+
+def test_repeat_lazy_dtype() -> None:
+    s = pl.select(pl.repeat(1, n=3, dtype=pl.Int8)).to_series()
+    assert s.dtype == pl.Int8
+    assert s.len() == 3
+
+
+def test_repeat_eager() -> None:
+    s = pl.repeat(2**31 - 1, 3, eager=True)
+    assert s.dtype == pl.Int32
+    assert s.len() == 3
+    assert s.to_list() == [2**31 - 1] * 3
+    s = pl.repeat(-(2**31), 4, eager=True)
+    assert s.dtype == pl.Int32
+    assert s.len() == 4
+    assert s.to_list() == [-(2**31)] * 4
+    s = pl.repeat(2**31, 5, eager=True)
+    assert s.dtype == pl.Int64
+    assert s.len() == 5
+    assert s.to_list() == [2**31] * 5
+    s = pl.repeat(-(2**31) - 1, 3, eager=True)
+    assert s.dtype == pl.Int64
+    assert s.len() == 3
+    assert s.to_list() == [-(2**31) - 1] * 3
+    s = pl.repeat("foo", 2, eager=True)
+    assert s.dtype == pl.Utf8
+    assert s.len() == 2
+    assert s.to_list() == ["foo"] * 2
+    s = pl.repeat(1.0, 5, eager=True)
+    assert s.dtype == pl.Float64
+    assert s.len() == 5
+    assert s.to_list() == [1.0] * 5
+    s = pl.repeat(True, 4, eager=True)
+    assert s.dtype == pl.Boolean
+    assert s.len() == 4
+    assert s.to_list() == [True] * 4
+    s = pl.repeat(None, 7, eager=True)
+    assert s.dtype == pl.Null
+    assert s.len() == 7
+    assert s.to_list() == [None] * 7
+    s = pl.repeat(0, 0, eager=True)
+    assert s.dtype == pl.Int32
+    assert s.len() == 0
+    assert pl.repeat(datetime(2023, 2, 2), 3, eager=True).to_list() == [
+        datetime(2023, 2, 2, 0, 0),
+        datetime(2023, 2, 2, 0, 0),
+        datetime(2023, 2, 2, 0, 0),
+    ]
+
+
+def test_repeat_eager_dtype() -> None:
+    s = pl.repeat(1, n=3, eager=True, dtype=pl.Int8)
+    assert s.dtype == pl.Int8
+    assert s.len() == 3

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -94,3 +94,21 @@ def test_repeat_eager_dtype() -> None:
     s = pl.repeat(1, n=3, eager=True, dtype=pl.Int8)
     assert s.dtype == pl.Int8
     assert s.len() == 3
+
+
+def test_ones_zeros_eager() -> None:
+    ones = pl.ones(5, eager=True)
+    assert ones.dtype == pl.Float64
+    assert ones.to_list() == [1.0, 1.0, 1.0, 1.0, 1.0]
+
+    ones = pl.ones(3, dtype=pl.UInt8, eager=True)
+    assert ones.dtype == pl.UInt8
+    assert ones.to_list() == [1, 1, 1]
+
+    zeros = pl.zeros(5, eager=True)
+    assert zeros.dtype == pl.Float64
+    assert zeros.to_list() == [0.0, 0.0, 0.0, 0.0, 0.0]
+
+    zeros = pl.zeros(3, dtype=pl.UInt8, eager=True)
+    assert zeros.dtype == pl.UInt8
+    assert zeros.to_list() == [0, 0, 0]

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -1097,55 +1097,6 @@ def test_object() -> None:
     assert a[1] == "foo"
 
 
-def test_repeat() -> None:
-    s = pl.repeat(2**31 - 1, 3, eager=True)
-    assert s.dtype == pl.Int32
-    assert s.len() == 3
-    assert s.to_list() == [2**31 - 1] * 3
-    s = pl.repeat(-(2**31), 4, eager=True)
-    assert s.dtype == pl.Int32
-    assert s.len() == 4
-    assert s.to_list() == [-(2**31)] * 4
-    s = pl.repeat(2**31, 5, eager=True)
-    assert s.dtype == pl.Int64
-    assert s.len() == 5
-    assert s.to_list() == [2**31] * 5
-    s = pl.repeat(-(2**31) - 1, 3, eager=True)
-    assert s.dtype == pl.Int64
-    assert s.len() == 3
-    assert s.to_list() == [-(2**31) - 1] * 3
-    s = pl.repeat("foo", 2, eager=True)
-    assert s.dtype == pl.Utf8
-    assert s.len() == 2
-    assert s.to_list() == ["foo"] * 2
-    s = pl.repeat(1.0, 5, eager=True)
-    assert s.dtype == pl.Float64
-    assert s.len() == 5
-    assert s.to_list() == [1.0] * 5
-    s = pl.repeat(True, 4, eager=True)
-    assert s.dtype == pl.Boolean
-    assert s.len() == 4
-    assert s.to_list() == [True] * 4
-    s = pl.repeat(None, 7, eager=True)
-    assert s.dtype == pl.Null
-    assert s.len() == 7
-    assert s.to_list() == [None] * 7
-    s = pl.repeat(0, 0, eager=True)
-    assert s.dtype == pl.Int32
-    assert s.len() == 0
-    assert pl.repeat(datetime(2023, 2, 2), 3, eager=True).to_list() == [
-        datetime(2023, 2, 2, 0, 0),
-        datetime(2023, 2, 2, 0, 0),
-        datetime(2023, 2, 2, 0, 0),
-    ]
-
-
-def test_repeat_dtype() -> None:
-    s = pl.repeat(1, n=3, eager=True, dtype=pl.Int8)
-    assert s.dtype == pl.Int8
-    assert s.len() == 3
-
-
 def test_shape() -> None:
     s = pl.Series([1, 2, 3])
     assert s.shape == (3,)


### PR DESCRIPTION
Changes:
* Move some of the parsing logic from Python to the Rust bindings
* Dispatch `ones` and `zeros` to `repeat` and set up a separate Python module for these (`functions/lazy.py` is way too long).
* Remove `Series._repeat` classmethod - construct the Series directly out of the called function. I see no good reason for these private classmethods to exist.

I'm not actually sure these should default to lazy mode. `lit` is recommended for lazy contexts, most users will use these methods with `eager=True`. Shall we default to that?

TO DO next PR:
* Refactor the `repeat_lazy` in the Rust bindings to use AnyValue
* Update tests to use parametrize / hypothesis (should be a good candidate for parametrized testing)