### PR TITLE
perf(rust, python): Improve explodes: `offsets_to_indexes` performance

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/explode.rs
+++ b/polars/polars-core/src/chunked_array/ops/explode.rs
@@ -679,4 +679,11 @@ mod test {
         let out = offsets_to_indexes(offsets, 2);
         assert_eq!(out, &[0, 1]);
     }
+
+    #[test]
+    fn test_row_offsets_nonzero_first_offset() {
+        let offsets = &[3, 6, 8];
+        let out = offsets_to_indexes(offsets, 10);
+        assert_eq!(out, &[0, 0, 0, 1, 1, 2, 2, 2, 2, 2]);
+    }
 }

--- a/polars/polars-core/src/chunked_array/ops/explode.rs
+++ b/polars/polars-core/src/chunked_array/ops/explode.rs
@@ -307,32 +307,26 @@ pub(crate) fn offsets_to_indexes(offsets: &[i64], capacity: usize) -> Vec<IdxSiz
     if offsets.is_empty() {
         return vec![];
     }
+
     let mut idx = Vec::with_capacity(capacity);
 
-    // `value_count` counts the taken values from the list values
-    // and are the same unit as `offsets`
-    // we also add the start offset as a list can be sliced
-    let mut value_count = offsets[0];
     let mut last_idx = 0;
-
-    for offset in &offsets[1..] {
-        // this get all the elements up till offsets
-        while value_count < *offset {
-            value_count += 1;
-            idx.push(last_idx)
+    for (offset_start, offset_end) in offsets.iter().zip(offsets.iter().skip(1)) {
+        if idx.len() >= capacity {
+            // significant speed-up in edge cases with many offsets,
+            // no measurable overhead in typical case due to branch prediction
+            break;
         }
 
-        // then we compute the previous offsets
-        // Safety:
-        // we started iterating from 1, so there is always a previous offset
-        // we take the pointer to the previous element and deref that to get
-        // the previous offset
-        let previous_offset = unsafe { *(offset as *const i64).offset(-1) };
-
-        // if the previous offset is equal to the current offset we have an empty
-        // list and we duplicate previous index
-        if previous_offset == *offset {
+        if offset_start == offset_end {
+            // if the previous offset is equal to the current offset, we have an empty
+            // list and we duplicate the previous index
             idx.push(last_idx);
+        } else {
+            let width = (offset_end - offset_start) as usize;
+            for _ in 0..width {
+                idx.push(last_idx);
+            }
         }
 
         last_idx += 1;

--- a/polars/polars-core/src/chunked_array/ops/explode.rs
+++ b/polars/polars-core/src/chunked_array/ops/explode.rs
@@ -311,7 +311,7 @@ pub(crate) fn offsets_to_indexes(offsets: &[i64], capacity: usize) -> Vec<IdxSiz
     let mut idx = Vec::with_capacity(capacity);
 
     let mut last_idx = 0;
-    for (offset_start, offset_end) in offsets.iter().zip(offsets.iter().skip(1)) {
+    for (offset_start, offset_end) in offsets.iter().zip(offsets[1..].iter()) {
         if idx.len() >= capacity {
             // significant speed-up in edge cases with many offsets,
             // no measurable overhead in typical case due to branch prediction


### PR DESCRIPTION
I refactored offsets_to_indexes to remove the manual pointer arithmetic and value_count counter, which results in a typical 8-15% speedup for large arrays (1,000 to 10,000,000 elements) and reasonable numbers of randomly generated offsets (between 1% and 50% of the capacity). For small arrays and small numbers of offsets, performance is not significantly impacted. I also added a criterion to the main loop which exits early when the indexes array is already larger than capacity, which results in an arbitrarily large speedup when capacity is exceeded and does not impact performance in typical cases.

I have uploaded my benchmark script [here](https://gist.github.com/kpberry/5e1c72ee4519d021d5a3e0601caea412), in case you want to verify the performance improvement.