### PR TITLE
refactor(rust, python): simplify `take_every`

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -113,12 +113,6 @@ pub trait ChunkCumAgg<T: PolarsDataType> {
     }
 }
 
-/// Traverse and collect every nth element
-pub trait ChunkTakeEvery<T: PolarsDataType> {
-    /// Traverse and collect every nth element in a new array.
-    fn take_every(&self, n: usize) -> ChunkedArray<T>;
-}
-
 /// Explode/ flatten a List or Utf8 Series
 pub trait ChunkExplode {
     fn explode(&self) -> PolarsResult<Series> {

--- a/polars/polars-core/src/chunked_array/ops/take/take_every.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_every.rs
@@ -1,79 +1,11 @@
 use crate::prelude::*;
-use crate::utils::NoNull;
 
-impl<T> ChunkTakeEvery<T> for ChunkedArray<T>
-where
-    T: PolarsNumericType,
-{
-    fn take_every(&self, n: usize) -> ChunkedArray<T> {
-        let mut ca = if !self.has_validity() {
-            let a: NoNull<_> = self.into_no_null_iter().step_by(n).collect();
-            a.into_inner()
-        } else {
-            self.into_iter().step_by(n).collect()
-        };
-        ca.rename(self.name());
-        ca
-    }
-}
-
-impl ChunkTakeEvery<BooleanType> for BooleanChunked {
-    fn take_every(&self, n: usize) -> BooleanChunked {
-        let mut ca: Self = if !self.has_validity() {
-            self.into_no_null_iter().step_by(n).collect()
-        } else {
-            self.into_iter().step_by(n).collect()
-        };
-        ca.rename(self.name());
-        ca
-    }
-}
-
-impl ChunkTakeEvery<Utf8Type> for Utf8Chunked {
-    fn take_every(&self, n: usize) -> Utf8Chunked {
-        unsafe { self.as_binary().take_every(n).to_utf8() }
-    }
-}
-
-impl ChunkTakeEvery<BinaryType> for BinaryChunked {
-    fn take_every(&self, n: usize) -> BinaryChunked {
-        let mut ca: Self = if !self.has_validity() {
-            self.into_no_null_iter().step_by(n).collect()
-        } else {
-            self.into_iter().step_by(n).collect()
-        };
-        ca.rename(self.name());
-        ca
-    }
-}
-
-impl ChunkTakeEvery<ListType> for ListChunked {
-    fn take_every(&self, n: usize) -> ListChunked {
-        let mut ca: Self = if !self.has_validity() {
-            self.into_no_null_iter().step_by(n).collect()
-        } else {
-            self.into_iter().step_by(n).collect()
-        };
-        ca.rename(self.name());
-        ca
-    }
-}
-
-#[cfg(feature = "dtype-array")]
-impl ChunkTakeEvery<FixedSizeListType> for ArrayChunked {
-    fn take_every(&self, n: usize) -> ArrayChunked {
-        let idx = (0 as IdxSize..(self.len() as IdxSize))
-            .step_by(n)
-            .collect::<Vec<_>>();
+impl Series {
+    /// Traverse and collect every nth element in a new array.
+    pub fn take_every(&self, n: usize) -> Series {
+        let mut idx = (0..self.len()).step_by(n);
 
         // safety: we are in bounds
-        unsafe { self.take_unchecked((&idx).into()) }
-    }
-}
-
-#[cfg(feature = "object")]
-impl<T: PolarsObject> ChunkTakeEvery<ObjectType<T>> for ObjectChunked<T> {
-    fn take_every(&self, _n: usize) -> ObjectChunked<T> {
-        todo!()
+        unsafe { self.take_iter_unchecked(&mut idx) }
     }
 }

--- a/polars/polars-core/src/series/implementations/binary.rs
+++ b/polars/polars-core/src/series/implementations/binary.rs
@@ -165,10 +165,6 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
         Ok(ChunkTake::take(&self.0, iter.into())?.into_series())
     }
 
-    fn take_every(&self, n: usize) -> Series {
-        self.0.take_every(n).into_series()
-    }
-
     unsafe fn take_iter_unchecked(&self, iter: &mut dyn TakeIterator) -> Series {
         ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
     }

--- a/polars/polars-core/src/series/implementations/boolean.rs
+++ b/polars/polars-core/src/series/implementations/boolean.rs
@@ -197,10 +197,6 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         Ok(ChunkTake::take(&self.0, iter.into())?.into_series())
     }
 
-    fn take_every(&self, n: usize) -> Series {
-        self.0.take_every(n).into_series()
-    }
-
     unsafe fn take_iter_unchecked(&self, iter: &mut dyn TakeIterator) -> Series {
         ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
     }

--- a/polars/polars-core/src/series/implementations/categorical.rs
+++ b/polars/polars-core/src/series/implementations/categorical.rs
@@ -235,11 +235,6 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         Ok(self.finish_with_state(false, cats).into_series())
     }
 
-    fn take_every(&self, n: usize) -> Series {
-        self.with_state(true, |cats| cats.take_every(n))
-            .into_series()
-    }
-
     unsafe fn take_iter_unchecked(&self, iter: &mut dyn TakeIterator) -> Series {
         let cats = self.0.logical().take_unchecked(iter.into());
         self.finish_with_state(false, cats).into_series()

--- a/polars/polars-core/src/series/implementations/dates_time.rs
+++ b/polars/polars-core/src/series/implementations/dates_time.rs
@@ -244,10 +244,6 @@ macro_rules! impl_dyn_series {
                     .map(|ca| ca.$into_logical().into_series())
             }
 
-            fn take_every(&self, n: usize) -> Series {
-                self.0.take_every(n).$into_logical().into_series()
-            }
-
             unsafe fn take_iter_unchecked(&self, iter: &mut dyn TakeIterator) -> Series {
                 ChunkTake::take_unchecked(self.0.deref(), iter.into())
                     .$into_logical()

--- a/polars/polars-core/src/series/implementations/datetime.rs
+++ b/polars/polars-core/src/series/implementations/datetime.rs
@@ -261,13 +261,6 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
         })
     }
 
-    fn take_every(&self, n: usize) -> Series {
-        self.0
-            .take_every(n)
-            .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
-            .into_series()
-    }
-
     unsafe fn take_iter_unchecked(&self, iter: &mut dyn TakeIterator) -> Series {
         ChunkTake::take_unchecked(self.0.deref(), iter.into())
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())

--- a/polars/polars-core/src/series/implementations/decimal.rs
+++ b/polars/polars-core/src/series/implementations/decimal.rs
@@ -143,13 +143,6 @@ impl SeriesTrait for SeriesWrap<DecimalChunked> {
             .into_series()
     }
 
-    fn take_every(&self, n: usize) -> Series {
-        self.0
-            .take_every(n)
-            .into_decimal_unchecked(self.0.precision(), self.0.scale())
-            .into_series()
-    }
-
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         self.0
             .new_from_index(index, length)

--- a/polars/polars-core/src/series/implementations/duration.rs
+++ b/polars/polars-core/src/series/implementations/duration.rs
@@ -290,13 +290,6 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
             .map(|ca| ca.into_duration(self.0.time_unit()).into_series())
     }
 
-    fn take_every(&self, n: usize) -> Series {
-        self.0
-            .take_every(n)
-            .into_duration(self.0.time_unit())
-            .into_series()
-    }
-
     unsafe fn take_iter_unchecked(&self, iter: &mut dyn TakeIterator) -> Series {
         ChunkTake::take_unchecked(self.0.deref(), iter.into())
             .into_duration(self.0.time_unit())

--- a/polars/polars-core/src/series/implementations/fixed_size_list.rs
+++ b/polars/polars-core/src/series/implementations/fixed_size_list.rs
@@ -106,10 +106,6 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
         Ok(ChunkTake::take(&self.0, iter.into())?.into_series())
     }
 
-    fn take_every(&self, n: usize) -> Series {
-        self.0.take_every(n).into_series()
-    }
-
     unsafe fn take_iter_unchecked(&self, iter: &mut dyn TakeIterator) -> Series {
         ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
     }

--- a/polars/polars-core/src/series/implementations/floats.rs
+++ b/polars/polars-core/src/series/implementations/floats.rs
@@ -231,10 +231,6 @@ macro_rules! impl_dyn_series {
                 Ok(ChunkTake::take(&self.0, iter.into())?.into_series())
             }
 
-            fn take_every(&self, n: usize) -> Series {
-                self.0.take_every(n).into_series()
-            }
-
             unsafe fn take_iter_unchecked(&self, iter: &mut dyn TakeIterator) -> Series {
                 ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
             }

--- a/polars/polars-core/src/series/implementations/list.rs
+++ b/polars/polars-core/src/series/implementations/list.rs
@@ -106,10 +106,6 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         Ok(ChunkTake::take(&self.0, iter.into())?.into_series())
     }
 
-    fn take_every(&self, n: usize) -> Series {
-        self.0.take_every(n).into_series()
-    }
-
     unsafe fn take_iter_unchecked(&self, iter: &mut dyn TakeIterator) -> Series {
         ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
     }

--- a/polars/polars-core/src/series/implementations/mod.rs
+++ b/polars/polars-core/src/series/implementations/mod.rs
@@ -326,10 +326,6 @@ macro_rules! impl_dyn_series {
                 Ok(ChunkTake::take(&self.0, iter.into())?.into_series())
             }
 
-            fn take_every(&self, n: usize) -> Series {
-                self.0.take_every(n).into_series()
-            }
-
             unsafe fn take_iter_unchecked(&self, iter: &mut dyn TakeIterator) -> Series {
                 ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
             }

--- a/polars/polars-core/src/series/implementations/null.rs
+++ b/polars/polars-core/src/series/implementations/null.rs
@@ -113,10 +113,6 @@ impl SeriesTrait for NullChunked {
         self.length as usize
     }
 
-    fn take_every(&self, n: usize) -> Series {
-        NullChunked::new(self.name.clone(), self.len() / n).into_series()
-    }
-
     fn has_validity(&self) -> bool {
         true
     }

--- a/polars/polars-core/src/series/implementations/object.rs
+++ b/polars/polars-core/src/series/implementations/object.rs
@@ -159,10 +159,6 @@ where
         self.rechunk_object().into_series()
     }
 
-    fn take_every(&self, n: usize) -> Series {
-        self.0.take_every(n).into_series()
-    }
-
     fn new_from_index(&self, index: usize, length: usize) -> Series {
         ChunkExpandAtIndex::new_from_index(&self.0, index, length).into_series()
     }

--- a/polars/polars-core/src/series/implementations/struct_.rs
+++ b/polars/polars-core/src/series/implementations/struct_.rs
@@ -83,10 +83,6 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
         self.0.rename(name)
     }
 
-    fn take_every(&self, n: usize) -> Series {
-        self.0.apply_fields(|s| s.take_every(n)).into_series()
-    }
-
     fn has_validity(&self) -> bool {
         self.0.fields().iter().any(|s| s.has_validity())
     }

--- a/polars/polars-core/src/series/implementations/utf8.rs
+++ b/polars/polars-core/src/series/implementations/utf8.rs
@@ -179,10 +179,6 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         Ok(ChunkTake::take(&self.0, iter.into())?.into_series())
     }
 
-    fn take_every(&self, n: usize) -> Series {
-        self.0.take_every(n).into_series()
-    }
-
     unsafe fn take_iter_unchecked(&self, iter: &mut dyn TakeIterator) -> Series {
         ChunkTake::take_unchecked(&self.0, iter.into()).into_series()
     }

--- a/polars/polars-core/src/series/series_trait.rs
+++ b/polars/polars-core/src/series/series_trait.rs
@@ -310,9 +310,6 @@ pub trait SeriesTrait:
     /// Aggregate all chunks to a contiguous array of memory.
     fn rechunk(&self) -> Series;
 
-    /// Take every nth value as a new Series
-    fn take_every(&self, n: usize) -> Series;
-
     /// Drop all null values and return a new Series.
     fn drop_nulls(&self) -> Series {
         if self.null_count() == 0 {


### PR DESCRIPTION
Save compiler bloat.