### PR TITLE
refactor(python): Deprecate `name` argument for `repeat`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/functions.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions.rs
@@ -1308,7 +1308,7 @@ pub fn repeat<L: Literal>(value: L, n: Expr) -> Expr {
             )?;
         Ok(Some(s.new_from_index(0, n)))
     };
-    apply_binary(lit(value), n, function, GetOutput::same_type())
+    apply_binary(lit(value), n, function, GetOutput::same_type()).alias("repeat")
 }
 
 #[cfg(feature = "arg_where")]

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1256,18 +1256,18 @@ class Expr:
 
         >>> df.select(pl.repeat(None, 3).append(pl.col("a")).rechunk())
         shape: (6, 1)
-        ┌─────────┐
-        │ literal │
-        │ ---     │
-        │ i64     │
-        ╞═════════╡
-        │ null    │
-        │ null    │
-        │ null    │
-        │ 1       │
-        │ 1       │
-        │ 2       │
-        └─────────┘
+        ┌────────┐
+        │ repeat │
+        │ ---    │
+        │ i64    │
+        ╞════════╡
+        │ null   │
+        │ null   │
+        │ null   │
+        │ 1      │
+        │ 1      │
+        │ 2      │
+        └────────┘
 
         """
         return self._from_pyexpr(self._pyexpr.rechunk())

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, NoReturn, overload
 
 from polars import functions as F
 from polars.datatypes import Float64
-from polars.utils import no_default
 from polars.utils._wrap import wrap_expr, wrap_s
 from polars.utils.various import find_stacklevel
 
@@ -19,7 +18,6 @@ if TYPE_CHECKING:
 
     from polars import Expr, Series
     from polars.type_aliases import PolarsDataType, PythonLiteral
-    from polars.utils import NoDefault
 
     if sys.version_info >= (3, 8):
         from typing import Literal
@@ -200,7 +198,7 @@ def ones(
     n: int,
     dtype: PolarsDataType = Float64,
     *,
-    eager: bool | NoDefault = no_default,
+    eager: bool | None = None,
 ) -> Expr | Series:
     """
     Construct a column of length `n` filled with ones.
@@ -239,7 +237,7 @@ def ones(
     ]
 
     """
-    if eager is no_default:
+    if eager is None:
         warnings.warn(
             "In a future version, the default behaviour for `ones` will change from `eager=True` to `eager=False`. "
             "To silence this warning, please:\n"
@@ -286,7 +284,7 @@ def zeros(
     n: int,
     dtype: PolarsDataType = Float64,
     *,
-    eager: bool | NoDefault = no_default,
+    eager: bool | None = None,
 ) -> Expr | Series:
     """
     Construct a column of length `n` filled with zeros.
@@ -325,7 +323,7 @@ def zeros(
     ]
 
     """
-    if eager is no_default:
+    if eager is None:
         warnings.warn(
             "In a future version, the default behaviour for `ones` will change from `eager=True` to `eager=False`. "
             "To silence this warning, please:\n"

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -156,9 +156,7 @@ def repeat(
     else:
         if isinstance(n, int):
             n = F.lit(n)
-        expr = wrap_expr(plr.repeat_lazy(value, n._pyexpr))
-        if dtype is not None:
-            expr = expr.cast(dtype)
+        expr = wrap_expr(plr.repeat_lazy(value, n._pyexpr, dtype))
         if name is not None:
             expr = expr.alias(name)
         return expr

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -158,7 +158,6 @@ def ones(
     n: int,
     dtype: PolarsDataType = ...,
     *,
-    name: str | None = ...,
     eager: Literal[False],
 ) -> Expr:
     ...
@@ -169,7 +168,6 @@ def ones(
     n: int,
     dtype: PolarsDataType = ...,
     *,
-    name: str | None = ...,
     eager: Literal[True] = ...,
 ) -> Series:
     ...
@@ -180,7 +178,6 @@ def ones(
     n: int,
     dtype: PolarsDataType = ...,
     *,
-    name: str | None = ...,
     eager: bool,
 ) -> Expr | Series:
     ...
@@ -190,7 +187,6 @@ def ones(
     n: int,
     dtype: PolarsDataType = Float64,
     *,
-    name: str | None = None,
     eager: bool | NoDefault = no_default,
 ) -> Expr | Series:
     """
@@ -204,8 +200,6 @@ def ones(
         Length of the resulting column.
     dtype
         Data type of the resulting column. Defaults to Float64.
-    name
-        Name of the resulting column.
     eager
         Evaluate immediately and return a ``Series``. If set to ``False``,
         return an expression instead.
@@ -242,7 +236,7 @@ def ones(
             stacklevel=find_stacklevel(),
         )
         eager = True
-    return repeat(1.0, n=n, dtype=dtype, name=name, eager=eager)
+    return repeat(1.0, n=n, dtype=dtype, eager=eager).alias("ones")
 
 
 @overload
@@ -250,7 +244,6 @@ def zeros(
     n: int,
     dtype: PolarsDataType = ...,
     *,
-    name: str | None = ...,
     eager: Literal[False],
 ) -> Expr:
     ...
@@ -261,7 +254,6 @@ def zeros(
     n: int,
     dtype: PolarsDataType = ...,
     *,
-    name: str | None = ...,
     eager: Literal[True] = ...,
 ) -> Series:
     ...
@@ -272,7 +264,6 @@ def zeros(
     n: int,
     dtype: PolarsDataType = ...,
     *,
-    name: str | None = ...,
     eager: bool,
 ) -> Expr | Series:
     ...
@@ -282,7 +273,6 @@ def zeros(
     n: int,
     dtype: PolarsDataType = Float64,
     *,
-    name: str | None = None,
     eager: bool | NoDefault = no_default,
 ) -> Expr | Series:
     """
@@ -296,8 +286,6 @@ def zeros(
         Length of the resulting column.
     dtype
         Data type of the resulting column. Defaults to Float64.
-    name
-        Name of the resulting column.
     eager
         Evaluate immediately and return a ``Series``. If set to ``False``,
         return an expression instead.
@@ -334,4 +322,4 @@ def zeros(
             stacklevel=find_stacklevel(),
         )
         eager = True
-    return repeat(0.0, n=n, dtype=dtype, name=name, eager=eager)
+    return repeat(0.0, n=n, dtype=dtype, eager=eager).alias("zeros")

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -227,7 +227,7 @@ def ones(
     --------
     >>> pl.ones(3, pl.Int8, eager=True)
     shape: (3,)
-    Series: '' [i8]
+    Series: 'ones' [i8]
     [
         1
         1
@@ -313,7 +313,7 @@ def zeros(
     --------
     >>> pl.zeros(3, pl.Int8, eager=True)
     shape: (3,)
-    Series: '' [i8]
+    Series: 'zeros' [i8]
     [
         0
         0

--- a/py-polars/src/functions/eager.rs
+++ b/py-polars/src/functions/eager.rs
@@ -122,7 +122,6 @@ pub fn repeat_eager(
     value: Wrap<AnyValue>,
     n: usize,
     dtype: Option<Wrap<DataType>>,
-    name: Option<&str>,
 ) -> PyResult<PySeries> {
     let value = value.0;
     let dtype = match dtype.map(|wrap| wrap.0) {
@@ -141,9 +140,8 @@ pub fn repeat_eager(
             _ => value.dtype(),
         },
     };
-    let name = name.unwrap_or("");
 
-    Ok(Series::new(name, &[value])
+    Ok(Series::new("repeat", &[value])
         .cast(&dtype)
         .map_err(PyPolarsErr::from)?
         .new_from_index(0, n)

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -382,34 +382,43 @@ pub fn reduce(lambda: PyObject, exprs: Vec<PyExpr>) -> PyExpr {
 }
 
 #[pyfunction]
-pub fn repeat_lazy(value: &PyAny, n: PyExpr) -> PyResult<PyExpr> {
-    if let Ok(true) = value.is_instance_of::<PyBool>() {
+pub fn repeat_lazy(value: &PyAny, n: PyExpr, dtype: Option<Wrap<DataType>>) -> PyResult<PyExpr> {
+    let dtype = dtype.map(|wrap| wrap.0);
+
+    let mut expr = if let Ok(true) = value.is_instance_of::<PyBool>() {
         let val = value.extract::<bool>().unwrap();
-        Ok(dsl::repeat(val, n.inner).into())
+        dsl::repeat(val, n.inner)
     } else if let Ok(int) = value.downcast::<PyInt>() {
         let val = int.extract::<i64>().unwrap();
 
         if val >= i32::MIN as i64 && val <= i32::MAX as i64 {
-            Ok(dsl::repeat(val as i32, n.inner).into())
+            dsl::repeat(val as i32, n.inner)
         } else {
-            Ok(dsl::repeat(val, n.inner).into())
+            dsl::repeat(val, n.inner)
         }
     } else if let Ok(float) = value.downcast::<PyFloat>() {
         let val = float.extract::<f64>().unwrap();
-        Ok(dsl::repeat(val, n.inner).into())
+        dsl::repeat(val, n.inner)
     } else if let Ok(pystr) = value.downcast::<PyString>() {
         let val = pystr
             .to_str()
             .expect("could not transform Python string to Rust Unicode");
-        Ok(dsl::repeat(val, n.inner).into())
+        dsl::repeat(val, n.inner)
     } else if value.is_none() {
-        Ok(dsl::repeat(Null {}, n.inner).into())
+        dsl::repeat(Null {}, n.inner)
     } else {
-        Err(PyValueError::new_err(format!(
+        return Err(PyValueError::new_err(format!(
             "could not convert value {:?} as a Literal",
             value.str()?
-        )))
-    }
+        )));
+    };
+
+    expr = match dtype {
+        Some(dtype) => expr.cast(dtype),
+        None => expr,
+    };
+
+    Ok(expr.into())
 }
 
 #[pyfunction]

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -61,7 +61,7 @@ def test_repeat_expansion_in_groupby() -> None:
         .agg(pl.repeat(1, pl.count()).cumsum())
         .to_dict(False)
     )
-    assert out == {"g": [1, 2, 3], "literal": [[1], [1, 2], [1, 2, 3]]}
+    assert out == {"g": [1, 2, 3], "repeat": [[1], [1, 2], [1, 2, 3]]}
 
 
 def test_agg_after_head() -> None:


### PR DESCRIPTION
Related to https://github.com/pola-rs/polars/issues/8972

Changes:
* Remove `name` argument from `ones` and `zeros` (these weren't released yet). Add default name `zeros`/`ones`.
* Deprecate `name` argument for `repeat`. Change default name to `repeat`.