### PR TITLE
fix(rust, python): Fix erroneous warning in `hist`

### DIFF
--- a/polars/polars-algo/src/algo.rs
+++ b/polars/polars-algo/src/algo.rs
@@ -70,12 +70,11 @@ pub fn hist(s: &Series, bins: Option<&Series>, bin_count: Option<usize>) -> Resu
             .alias(category_str),
         )
         .collect()?;
-
     let cuts = cuts_df
         .lazy()
         .with_columns([
             col(category_str).cast(DataType::Categorical(None)),
-            col(breakpoint_str).cast(s.dtype().to_owned()),
+            col(breakpoint_str).cast(s.dtype().to_owned()).set_sorted_flag(IsSorted::Ascending),
         ])
         .collect()?;
 

--- a/polars/polars-algo/src/algo.rs
+++ b/polars/polars-algo/src/algo.rs
@@ -75,7 +75,9 @@ pub fn hist(s: &Series, bins: Option<&Series>, bin_count: Option<usize>) -> Resu
         .lazy()
         .with_columns([
             col(category_str).cast(DataType::Categorical(None)),
-            col(breakpoint_str).cast(s.dtype().to_owned()).set_sorted_flag(IsSorted::Ascending),
+            col(breakpoint_str)
+                .cast(s.dtype().to_owned())
+                .set_sorted_flag(IsSorted::Ascending),
         ])
         .collect()?;
 

--- a/polars/polars-algo/src/algo.rs
+++ b/polars/polars-algo/src/algo.rs
@@ -70,6 +70,7 @@ pub fn hist(s: &Series, bins: Option<&Series>, bin_count: Option<usize>) -> Resu
             .alias(category_str),
         )
         .collect()?;
+
     let cuts = cuts_df
         .lazy()
         .with_columns([


### PR DESCRIPTION
closes #8978