### PR TITLE
refactor(rust,python)!: Rename list namespace accesor from `.arr` to `.list`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/list.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/list.rs
@@ -22,7 +22,7 @@ impl ListNameSpace {
         };
         self.0
             .map(function, GetOutput::from_type(IDX_DTYPE))
-            .with_fmt("arr.len")
+            .with_fmt("list.len")
     }
 
     /// Compute the maximum of the items in every sublist.
@@ -39,7 +39,7 @@ impl ListNameSpace {
                     }
                 }),
             )
-            .with_fmt("arr.max")
+            .with_fmt("list.max")
     }
 
     /// Compute the minimum of the items in every sublist.
@@ -56,7 +56,7 @@ impl ListNameSpace {
                     }
                 }),
             )
-            .with_fmt("arr.min")
+            .with_fmt("list.min")
     }
 
     /// Compute the sum the items in every sublist.
@@ -72,7 +72,7 @@ impl ListNameSpace {
                 |s| Ok(Some(s.list()?.lst_mean().into_series())),
                 GetOutput::from_type(DataType::Float64),
             )
-            .with_fmt("arr.mean")
+            .with_fmt("list.mean")
     }
 
     /// Sort every sublist.
@@ -82,7 +82,7 @@ impl ListNameSpace {
                 move |s| Ok(Some(s.list()?.lst_sort(options).into_series())),
                 GetOutput::same_type(),
             )
-            .with_fmt("arr.sort")
+            .with_fmt("list.sort")
     }
 
     /// Reverse every sublist
@@ -92,7 +92,7 @@ impl ListNameSpace {
                 move |s| Ok(Some(s.list()?.lst_reverse().into_series())),
                 GetOutput::same_type(),
             )
-            .with_fmt("arr.reverse")
+            .with_fmt("list.reverse")
     }
 
     /// Keep only the unique values in every sublist.
@@ -102,7 +102,7 @@ impl ListNameSpace {
                 move |s| Ok(Some(s.list()?.lst_unique()?.into_series())),
                 GetOutput::same_type(),
             )
-            .with_fmt("arr.unique")
+            .with_fmt("list.unique")
     }
 
     /// Keep only the unique values in every sublist.
@@ -112,7 +112,7 @@ impl ListNameSpace {
                 move |s| Ok(Some(s.list()?.lst_unique_stable()?.into_series())),
                 GetOutput::same_type(),
             )
-            .with_fmt("arr.unique_stable")
+            .with_fmt("list.unique_stable")
     }
 
     /// Get items in every sublist by index.
@@ -159,7 +159,7 @@ impl ListNameSpace {
                 },
                 GetOutput::from_type(DataType::Utf8),
             )
-            .with_fmt("arr.join")
+            .with_fmt("list.join")
     }
 
     /// Return the index of the minimal value of every sublist
@@ -169,7 +169,7 @@ impl ListNameSpace {
                 |s| Ok(Some(s.list()?.lst_arg_min().into_series())),
                 GetOutput::from_type(IDX_DTYPE),
             )
-            .with_fmt("arr.arg_min")
+            .with_fmt("list.arg_min")
     }
 
     /// Return the index of the maximum value of every sublist
@@ -179,7 +179,7 @@ impl ListNameSpace {
                 |s| Ok(Some(s.list()?.lst_arg_max().into_series())),
                 GetOutput::from_type(IDX_DTYPE),
             )
-            .with_fmt("arr.arg_max")
+            .with_fmt("list.arg_max")
     }
 
     /// Diff every sublist.
@@ -190,7 +190,7 @@ impl ListNameSpace {
                 move |s| Ok(Some(s.list()?.lst_diff(n, null_behavior)?.into_series())),
                 GetOutput::same_type(),
             )
-            .with_fmt("arr.diff")
+            .with_fmt("list.diff")
     }
 
     /// Shift every sublist.
@@ -200,7 +200,7 @@ impl ListNameSpace {
                 move |s| Ok(Some(s.list()?.lst_shift(periods).into_series())),
                 GetOutput::same_type(),
             )
-            .with_fmt("arr.shift")
+            .with_fmt("list.shift")
     }
 
     /// Slice every sublist.
@@ -275,7 +275,7 @@ impl ListNameSpace {
                     }
                 }),
             )
-            .with_fmt("arr.to_struct")
+            .with_fmt("list.to_struct")
     }
 
     #[cfg(feature = "is_in")]

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -1751,17 +1751,21 @@ impl Expr {
     pub fn dt(self) -> dt::DateLikeNameSpace {
         dt::DateLikeNameSpace(self)
     }
-    pub fn arr(self) -> list::ListNameSpace {
+
+    pub fn list(self) -> list::ListNameSpace {
         list::ListNameSpace(self)
     }
+
     #[cfg(feature = "dtype-categorical")]
     pub fn cat(self) -> cat::CategoricalNameSpace {
         cat::CategoricalNameSpace(self)
     }
+
     #[cfg(feature = "dtype-struct")]
     pub fn struct_(self) -> struct_::StructNameSpace {
         struct_::StructNameSpace(self)
     }
+
     #[cfg(feature = "meta")]
     pub fn meta(self) -> meta::MetaNameSpace {
         meta::MetaNameSpace(self)

--- a/polars/polars-sql/src/functions.rs
+++ b/polars/polars-sql/src/functions.rs
@@ -403,15 +403,15 @@ impl SqlFunctionVisitor<'_> {
             // ----
             // Array functions
             // ----
-            ArrayContains => self.visit_binary::<Expr>(|e, s| e.arr().contains(s)),
-            ArrayGet => self.visit_binary(|e, i| e.arr().get(i)),
-            ArrayLength => self.visit_unary(|e| e.arr().lengths()),
-            ArrayMax => self.visit_unary(|e| e.arr().max()),
-            ArrayMean => self.visit_unary(|e| e.arr().mean()),
-            ArrayMin => self.visit_unary(|e| e.arr().min()),
-            ArrayReverse => self.visit_unary(|e| e.arr().reverse()),
-            ArraySum => self.visit_unary(|e| e.arr().sum()),
-            ArrayUnique => self.visit_unary(|e| e.arr().unique()),
+            ArrayContains => self.visit_binary::<Expr>(|e, s| e.list().contains(s)),
+            ArrayGet => self.visit_binary(|e, i| e.list().get(i)),
+            ArrayLength => self.visit_unary(|e| e.list().lengths()),
+            ArrayMax => self.visit_unary(|e| e.list().max()),
+            ArrayMean => self.visit_unary(|e| e.list().mean()),
+            ArrayMin => self.visit_unary(|e| e.list().min()),
+            ArrayReverse => self.visit_unary(|e| e.list().reverse()),
+            ArraySum => self.visit_unary(|e| e.list().sum()),
+            ArrayUnique => self.visit_unary(|e| e.list().unique()),
             Explode => self.visit_unary(|e| e.explode()),
         }
     }

--- a/py-polars/docs/source/reference/expressions/list.rst
+++ b/py-polars/docs/source/reference/expressions/list.rst
@@ -2,36 +2,36 @@
 List
 ====
 
-The following methods are available under the `expr.arr` attribute.
+The following methods are available under the `expr.list` attribute.
 
 .. currentmodule:: polars
 .. autosummary::
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
-    Expr.arr.arg_max
-    Expr.arr.arg_min
-    Expr.arr.concat
-    Expr.arr.contains
-    Expr.arr.count_match
-    Expr.arr.diff
-    Expr.arr.eval
-    Expr.arr.explode
-    Expr.arr.first
-    Expr.arr.get
-    Expr.arr.head
-    Expr.arr.join
-    Expr.arr.last
-    Expr.arr.lengths
-    Expr.arr.max
-    Expr.arr.mean
-    Expr.arr.min
-    Expr.arr.reverse
-    Expr.arr.shift
-    Expr.arr.slice
-    Expr.arr.sort
-    Expr.arr.sum
-    Expr.arr.tail
-    Expr.arr.take
-    Expr.arr.to_struct
-    Expr.arr.unique
+    Expr.list.arg_max
+    Expr.list.arg_min
+    Expr.list.concat
+    Expr.list.contains
+    Expr.list.count_match
+    Expr.list.diff
+    Expr.list.eval
+    Expr.list.explode
+    Expr.list.first
+    Expr.list.get
+    Expr.list.head
+    Expr.list.join
+    Expr.list.last
+    Expr.list.lengths
+    Expr.list.max
+    Expr.list.mean
+    Expr.list.min
+    Expr.list.reverse
+    Expr.list.shift
+    Expr.list.slice
+    Expr.list.sort
+    Expr.list.sum
+    Expr.list.tail
+    Expr.list.take
+    Expr.list.to_struct
+    Expr.list.unique

--- a/py-polars/docs/source/reference/series/attributes.rst
+++ b/py-polars/docs/source/reference/series/attributes.rst
@@ -6,11 +6,11 @@ Attributes
 .. autosummary::
    :toctree: api/
 
-   Series.arr
    Series.cat
    Series.dt
    Series.dtype
    Series.inner_dtype
+   Series.list
    Series.name
    Series.shape
    Series.str

--- a/py-polars/docs/source/reference/series/list.rst
+++ b/py-polars/docs/source/reference/series/list.rst
@@ -2,36 +2,36 @@
 List
 ====
 
-The following methods are available under the `Series.arr` attribute.
+The following methods are available under the `Series.list` attribute.
 
 .. currentmodule:: polars
 .. autosummary::
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
-    Series.arr.arg_max
-    Series.arr.arg_min
-    Series.arr.concat
-    Series.arr.contains
-    Series.arr.count_match
-    Series.arr.diff
-    Series.arr.eval
-    Series.arr.explode
-    Series.arr.first
-    Series.arr.get
-    Series.arr.head
-    Series.arr.join
-    Series.arr.last
-    Series.arr.lengths
-    Series.arr.max
-    Series.arr.mean
-    Series.arr.min
-    Series.arr.reverse
-    Series.arr.shift
-    Series.arr.slice
-    Series.arr.sort
-    Series.arr.sum
-    Series.arr.tail
-    Series.arr.take
-    Series.arr.to_struct
-    Series.arr.unique
+    Series.list.arg_max
+    Series.list.arg_min
+    Series.list.concat
+    Series.list.contains
+    Series.list.count_match
+    Series.list.diff
+    Series.list.eval
+    Series.list.explode
+    Series.list.first
+    Series.list.get
+    Series.list.head
+    Series.list.join
+    Series.list.last
+    Series.list.lengths
+    Series.list.max
+    Series.list.mean
+    Series.list.min
+    Series.list.reverse
+    Series.list.shift
+    Series.list.slice
+    Series.list.sort
+    Series.list.sum
+    Series.list.tail
+    Series.list.take
+    Series.list.to_struct
+    Series.list.unique

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -7434,16 +7434,6 @@ class Expr:
         return self.map(func)
 
     @property
-    def arr(self) -> ExprListNameSpace:
-        """
-        Create an object namespace of all list related methods.
-
-        See the individual method pages for full details
-
-        """
-        return ExprListNameSpace(self)
-
-    @property
     def bin(self) -> ExprBinaryNameSpace:
         """
         Create an object namespace of all binary related methods.
@@ -7483,6 +7473,19 @@ class Expr:
         """Create an object namespace of all datetime related methods."""
         return ExprDateTimeNameSpace(self)
 
+    # Keep the `list` and `str` properties below at the end of the definition of Expr,
+    # as to not confuse mypy with the type annotation `str` and `list`
+
+    @property
+    def list(self) -> ExprListNameSpace:
+        """
+        Create an object namespace of all list related methods.
+
+        See the individual method pages for full details
+
+        """
+        return ExprListNameSpace(self)
+
     @property
     def meta(self) -> ExprMetaNameSpace:
         """
@@ -7492,9 +7495,6 @@ class Expr:
 
         """
         return ExprMetaNameSpace(self)
-
-    # Keep the `str` property below at the end of the definition of Expr,
-    # as to not confuse mypy with the type annotation `str`
 
     @property
     def str(self) -> ExprStringNameSpace:

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -88,7 +88,7 @@ class Expr:
     """Expressions that can be used in various contexts."""
 
     _pyexpr: PyExpr = None
-    _accessors: set[str] = {"arr", "cat", "dt", "meta", "str", "bin", "struct"}
+    _accessors: set[str] = {"cat", "dt", "list", "meta", "str", "bin", "struct"}
 
     @classmethod
     def _from_pyexpr(cls, pyexpr: PyExpr) -> Self:

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 class ExprListNameSpace:
     """Namespace for list related expressions."""
 
-    _accessor = "arr"
+    _accessor = "list"
 
     def __init__(self, expr: Expr):
         self._pyexpr = expr._pyexpr

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -34,7 +34,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"foo": [1, 2], "bar": [["a", "b"], ["c"]]})
-        >>> df.select(pl.col("bar").arr.lengths())
+        >>> df.select(pl.col("bar").list.lengths())
         shape: (2, 1)
         ┌─────┐
         │ bar │
@@ -55,7 +55,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"values": [[1], [2, 3]]})
-        >>> df.select(pl.col("values").arr.sum())
+        >>> df.select(pl.col("values").list.sum())
         shape: (2, 1)
         ┌────────┐
         │ values │
@@ -76,7 +76,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"values": [[1], [2, 3]]})
-        >>> df.select(pl.col("values").arr.max())
+        >>> df.select(pl.col("values").list.max())
         shape: (2, 1)
         ┌────────┐
         │ values │
@@ -97,7 +97,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"values": [[1], [2, 3]]})
-        >>> df.select(pl.col("values").arr.min())
+        >>> df.select(pl.col("values").list.min())
         shape: (2, 1)
         ┌────────┐
         │ values │
@@ -118,7 +118,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"values": [[1], [2, 3]]})
-        >>> df.select(pl.col("values").arr.mean())
+        >>> df.select(pl.col("values").list.mean())
         shape: (2, 1)
         ┌────────┐
         │ values │
@@ -148,7 +148,7 @@ class ExprListNameSpace:
         ...         "a": [[3, 2, 1], [9, 1, 2]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").arr.sort())
+        >>> df.select(pl.col("a").list.sort())
         shape: (2, 1)
         ┌───────────┐
         │ a         │
@@ -158,7 +158,7 @@ class ExprListNameSpace:
         │ [1, 2, 3] │
         │ [1, 2, 9] │
         └───────────┘
-        >>> df.select(pl.col("a").arr.sort(descending=True))
+        >>> df.select(pl.col("a").list.sort(descending=True))
         shape: (2, 1)
         ┌───────────┐
         │ a         │
@@ -183,7 +183,7 @@ class ExprListNameSpace:
         ...         "a": [[3, 2, 1], [9, 1, 2]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").arr.reverse())
+        >>> df.select(pl.col("a").list.reverse())
         shape: (2, 1)
         ┌───────────┐
         │ a         │
@@ -213,7 +213,7 @@ class ExprListNameSpace:
         ...         "a": [[1, 1, 2]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").arr.unique())
+        >>> df.select(pl.col("a").list.unique())
         shape: (1, 1)
         ┌───────────┐
         │ a         │
@@ -243,7 +243,7 @@ class ExprListNameSpace:
         ...         "b": [["b", "c"], ["y", "z"]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").arr.concat("b"))
+        >>> df.select(pl.col("a").list.concat("b"))
         shape: (2, 1)
         ┌─────────────────┐
         │ a               │
@@ -282,7 +282,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"foo": [[3, 2, 1], [], [1, 2]]})
-        >>> df.select(pl.col("foo").arr.get(0))
+        >>> df.select(pl.col("foo").list.get(0))
         shape: (3, 1)
         ┌──────┐
         │ foo  │
@@ -333,7 +333,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"foo": [[3, 2, 1], [], [1, 2]]})
-        >>> df.select(pl.col("foo").arr.first())
+        >>> df.select(pl.col("foo").list.first())
         shape: (3, 1)
         ┌──────┐
         │ foo  │
@@ -355,7 +355,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"foo": [[3, 2, 1], [], [1, 2]]})
-        >>> df.select(pl.col("foo").arr.last())
+        >>> df.select(pl.col("foo").list.last())
         shape: (3, 1)
         ┌──────┐
         │ foo  │
@@ -388,7 +388,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"foo": [[3, 2, 1], [], [1, 2]]})
-        >>> df.select(pl.col("foo").arr.contains(1))
+        >>> df.select(pl.col("foo").list.contains(1))
         shape: (3, 1)
         ┌───────┐
         │ foo   │
@@ -421,7 +421,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"s": [["a", "b", "c"], ["x", "y"]]})
-        >>> df.select(pl.col("s").arr.join(" "))
+        >>> df.select(pl.col("s").list.join(" "))
         shape: (2, 1)
         ┌───────┐
         │ s     │
@@ -450,7 +450,7 @@ class ExprListNameSpace:
         ...         "a": [[1, 2], [2, 1]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").arr.arg_min())
+        >>> df.select(pl.col("a").list.arg_min())
         shape: (2, 1)
         ┌─────┐
         │ a   │
@@ -479,7 +479,7 @@ class ExprListNameSpace:
         ...         "a": [[1, 2], [2, 1]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").arr.arg_max())
+        >>> df.select(pl.col("a").list.arg_max())
         shape: (2, 1)
         ┌─────┐
         │ a   │
@@ -507,7 +507,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"n": [[1, 2, 3, 4], [10, 2, 1]]})
-        >>> df.select(pl.col("n").arr.diff())
+        >>> df.select(pl.col("n").list.diff())
         shape: (2, 1)
         ┌────────────────┐
         │ n              │
@@ -518,7 +518,7 @@ class ExprListNameSpace:
         │ [null, -8, -1] │
         └────────────────┘
 
-        >>> df.select(pl.col("n").arr.diff(n=2))
+        >>> df.select(pl.col("n").list.diff(n=2))
         shape: (2, 1)
         ┌───────────────────┐
         │ n                 │
@@ -529,7 +529,7 @@ class ExprListNameSpace:
         │ [null, null, -9]  │
         └───────────────────┘
 
-        >>> df.select(pl.col("n").arr.diff(n=2, null_behavior="drop"))
+        >>> df.select(pl.col("n").list.diff(n=2, null_behavior="drop"))
         shape: (2, 1)
         ┌───────────┐
         │ n         │
@@ -555,7 +555,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
-        >>> s.arr.shift()
+        >>> s.list.shift()
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -583,7 +583,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
-        >>> s.arr.slice(1, 2)
+        >>> s.list.slice(1, 2)
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -608,7 +608,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
-        >>> s.arr.head(2)
+        >>> s.list.head(2)
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -631,7 +631,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
-        >>> s.arr.tail(2)
+        >>> s.list.tail(2)
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -658,7 +658,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [[1, 2, 3], [4, 5, 6]]})
-        >>> df.select(pl.col("a").arr.explode())
+        >>> df.select(pl.col("a").list.explode())
         shape: (6, 1)
         ┌─────┐
         │ a   │
@@ -690,7 +690,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"listcol": [[0], [1], [1, 2, 3, 2], [1, 2, 1], [4, 4]]})
-        >>> df.select(pl.col("listcol").arr.count_match(2).alias("number_of_twos"))
+        >>> df.select(pl.col("listcol").list.count_match(2).alias("number_of_twos"))
         shape: (5, 1)
         ┌────────────────┐
         │ number_of_twos │
@@ -749,7 +749,7 @@ class ExprListNameSpace:
         Convert list to struct with default field name assignment:
 
         >>> df = pl.DataFrame({"n": [[0, 1, 2], [0, 1]]})
-        >>> df.select(pl.col("n").arr.to_struct())
+        >>> df.select(pl.col("n").list.to_struct())
         shape: (2, 1)
         ┌────────────┐
         │ n          │
@@ -762,14 +762,14 @@ class ExprListNameSpace:
 
         Convert list to struct with field name assignment by function/index:
 
-        >>> df.select(pl.col("n").arr.to_struct(fields=lambda idx: f"n{idx}")).rows(
+        >>> df.select(pl.col("n").list.to_struct(fields=lambda idx: f"n{idx}")).rows(
         ...     named=True
         ... )
         [{'n': {'n0': 0, 'n1': 1, 'n2': 2}}, {'n': {'n0': 0, 'n1': 1, 'n2': None}}]
 
         Convert list to struct with field name assignment by index from a list of names:
 
-        >>> df.select(pl.col("n").arr.to_struct(fields=["one", "two", "three"])).rows(
+        >>> df.select(pl.col("n").list.to_struct(fields=["one", "two", "three"])).rows(
         ...     named=True
         ... )
         [{'n': {'one': 0, 'two': 1, 'three': 2}},
@@ -806,7 +806,7 @@ class ExprListNameSpace:
         --------
         >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
         >>> df.with_columns(
-        ...     pl.concat_list(["a", "b"]).arr.eval(pl.element().rank()).alias("rank")
+        ...     pl.concat_list(["a", "b"]).list.eval(pl.element().rank()).alias("rank")
         ... )
         shape: (3, 3)
         ┌─────┬─────┬────────────┐

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1095,7 +1095,7 @@ class ExprStringNameSpace:
         ...         +           # 'one or more' quantifier
         ...         """
         ...     )
-        ...     .arr.to_struct(fields=["name", "domain"])
+        ...     .list.to_struct(fields=["name", "domain"])
         ...     .alias("email_parts")
         ... ).unnest("email_parts")
         shape: (3, 3)

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -234,7 +234,7 @@ def element() -> Expr:
 
     >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
     >>> df.with_columns(
-    ...     pl.concat_list(["a", "b"]).arr.eval(pl.element().rank()).alias("rank")
+    ...     pl.concat_list(["a", "b"]).list.eval(pl.element().rank()).alias("rank")
     ... )
     shape: (3, 3)
     ┌─────┬─────┬────────────┐
@@ -251,7 +251,7 @@ def element() -> Expr:
 
     >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
     >>> df.with_columns(
-    ...     pl.concat_list(["a", "b"]).arr.eval(pl.element() * 2).alias("a_b_doubled")
+    ...     pl.concat_list(["a", "b"]).list.eval(pl.element() * 2).alias("a_b_doubled")
     ... )
     shape: (3, 3)
     ┌─────┬─────┬─────────────┐

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -17,9 +17,9 @@ if TYPE_CHECKING:
 
 @expr_dispatch
 class ListNameSpace:
-    """Series.arr namespace."""
+    """Namespace for list related methods."""
 
-    _accessor = "arr"
+    _accessor = "list"
 
     def __init__(self, series: Series):
         self._s: PySeries = series._s

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -31,7 +31,7 @@ class ListNameSpace:
         Examples
         --------
         >>> s = pl.Series([[1, 2, 3], [5]])
-        >>> s.arr.lengths()
+        >>> s.list.lengths()
         shape: (2,)
         Series: '' [u32]
         [
@@ -65,14 +65,14 @@ class ListNameSpace:
         Examples
         --------
         >>> s = pl.Series("a", [[3, 2, 1], [9, 1, 2]])
-        >>> s.arr.sort()
+        >>> s.list.sort()
         shape: (2,)
         Series: 'a' [list[i64]]
         [
                 [1, 2, 3]
                 [1, 2, 9]
         ]
-        >>> s.arr.sort(descending=True)
+        >>> s.list.sort(descending=True)
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -164,7 +164,7 @@ class ListNameSpace:
         Examples
         --------
         >>> s = pl.Series([["foo", "bar"], ["hello", "world"]])
-        >>> s.arr.join(separator="-")
+        >>> s.list.join(separator="-")
         shape: (2,)
         Series: '' [str]
         [
@@ -229,7 +229,7 @@ class ListNameSpace:
         Examples
         --------
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
-        >>> s.arr.diff()
+        >>> s.list.diff()
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -237,7 +237,7 @@ class ListNameSpace:
             [null, -8, -1]
         ]
 
-        >>> s.arr.diff(n=2)
+        >>> s.list.diff(n=2)
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -245,7 +245,7 @@ class ListNameSpace:
             [null, null, -9]
         ]
 
-        >>> s.arr.diff(n=2, null_behavior="drop")
+        >>> s.list.diff(n=2, null_behavior="drop")
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -267,7 +267,7 @@ class ListNameSpace:
         Examples
         --------
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
-        >>> s.arr.shift()
+        >>> s.list.shift()
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -292,7 +292,7 @@ class ListNameSpace:
         Examples
         --------
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
-        >>> s.arr.slice(1, 2)
+        >>> s.list.slice(1, 2)
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -314,7 +314,7 @@ class ListNameSpace:
         Examples
         --------
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
-        >>> s.arr.head(2)
+        >>> s.list.head(2)
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -336,7 +336,7 @@ class ListNameSpace:
         Examples
         --------
         >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
-        >>> s.arr.tail(2)
+        >>> s.list.tail(2)
         shape: (2,)
         Series: 'a' [list[i64]]
         [
@@ -361,7 +361,7 @@ class ListNameSpace:
         Examples
         --------
         >>> s = pl.Series("a", [[1, 2, 3], [4, 5, 6]])
-        >>> s.arr.explode()
+        >>> s.list.explode()
         shape: (6,)
         Series: 'a' [i64]
         [
@@ -417,7 +417,7 @@ class ListNameSpace:
         Convert list to struct with default field name assignment:
 
         >>> s1 = pl.Series("n", [[0, 1, 2], [0, 1]])
-        >>> s2 = s1.arr.to_struct()
+        >>> s2 = s1.list.to_struct()
         >>> s2
         shape: (2,)
         Series: 'n' [struct[3]]
@@ -430,13 +430,13 @@ class ListNameSpace:
 
         Convert list to struct with field name assignment by function/index:
 
-        >>> s3 = s1.arr.to_struct(fields=lambda idx: f"n{idx:02}")
+        >>> s3 = s1.list.to_struct(fields=lambda idx: f"n{idx:02}")
         >>> s3.struct.fields
         ['n00', 'n01', 'n02']
 
         Convert list to struct with field name assignment by index from a list of names:
 
-        >>> s1.arr.to_struct(fields=["one", "two", "three"]).struct.unnest()
+        >>> s1.list.to_struct(fields=["one", "two", "three"]).struct.unnest()
         shape: (2, 3)
         ┌─────┬─────┬───────┐
         │ one ┆ two ┆ three │
@@ -452,7 +452,7 @@ class ListNameSpace:
         return (
             s.to_frame()
             .select(
-                F.col(s.name).arr.to_struct(
+                F.col(s.name).list.to_struct(
                     # note: in eager mode, 'upper_bound' is always zero, as (unlike
                     # in lazy mode) there is no need to determine/track the schema.
                     n_field_strategy,
@@ -483,7 +483,7 @@ class ListNameSpace:
         --------
         >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
         >>> df.with_columns(
-        ...     pl.concat_list(["a", "b"]).arr.eval(pl.element().rank()).alias("rank")
+        ...     pl.concat_list(["a", "b"]).list.eval(pl.element().rank()).alias("rank")
         ... )
         shape: (3, 3)
         ┌─────┬─────┬────────────┐

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -218,7 +218,7 @@ class Series:
     """
 
     _s: PySeries = None
-    _accessors: set[str] = {"arr", "cat", "dt", "str", "bin", "struct"}
+    _accessors: set[str] = {"cat", "dt", "list", "str", "bin", "struct"}
 
     def __init__(
         self,

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5854,13 +5854,8 @@ class Series:
     def implode(self) -> Self:
         """Aggregate values into a list."""
 
-    # Below are the namespaces defined. Do not move these up in the definition of
-    # Series, as it confuses mypy between the type annotation `str` and the
-    # namespace `str`
-    @property
-    def arr(self) -> ListNameSpace:
-        """Create an object namespace of all list related methods."""
-        return ListNameSpace(self)
+    # Keep the `list` and `str` properties below at the end of the definition of Series,
+    # as to not confuse mypy with the type annotation `str` and `list`
 
     @property
     def bin(self) -> BinaryNameSpace:
@@ -5876,6 +5871,11 @@ class Series:
     def dt(self) -> DateTimeNameSpace:
         """Create an object namespace of all datetime related methods."""
         return DateTimeNameSpace(self)
+
+    @property
+    def list(self) -> ListNameSpace:
+        """Create an object namespace of all list related methods."""
+        return ListNameSpace(self)
 
     @property
     def str(self) -> StringNameSpace:

--- a/py-polars/src/expr/list.rs
+++ b/py-polars/src/expr/list.rs
@@ -52,7 +52,7 @@ impl PyExpr {
     }
 
     fn list_mean(&self) -> Self {
-        self.inner.clone().arr().mean().with_fmt("arr.mean").into()
+        self.inner.clone().arr().mean().with_fmt("list.mean").into()
     }
 
     fn list_min(&self) -> Self {
@@ -83,12 +83,12 @@ impl PyExpr {
                 descending,
                 ..Default::default()
             })
-            .with_fmt("arr.sort")
+            .with_fmt("list.sort")
             .into()
     }
 
     fn list_sum(&self) -> Self {
-        self.inner.clone().arr().sum().with_fmt("arr.sum").into()
+        self.inner.clone().arr().sum().with_fmt("list.sum").into()
     }
 
     #[cfg(feature = "list_take")]

--- a/py-polars/src/expr/list.rs
+++ b/py-polars/src/expr/list.rs
@@ -10,61 +10,66 @@ use crate::PyExpr;
 #[pymethods]
 impl PyExpr {
     fn list_arg_max(&self) -> Self {
-        self.inner.clone().arr().arg_max().into()
+        self.inner.clone().list().arg_max().into()
     }
 
     fn list_arg_min(&self) -> Self {
-        self.inner.clone().arr().arg_min().into()
+        self.inner.clone().list().arg_min().into()
     }
 
     #[cfg(feature = "is_in")]
     fn list_contains(&self, other: PyExpr) -> Self {
-        self.inner.clone().arr().contains(other.inner).into()
+        self.inner.clone().list().contains(other.inner).into()
     }
 
     #[cfg(feature = "list_count")]
     fn list_count_match(&self, expr: PyExpr) -> Self {
-        self.inner.clone().arr().count_match(expr.inner).into()
+        self.inner.clone().list().count_match(expr.inner).into()
     }
 
     fn list_diff(&self, n: i64, null_behavior: Wrap<NullBehavior>) -> PyResult<Self> {
-        Ok(self.inner.clone().arr().diff(n, null_behavior.0).into())
+        Ok(self.inner.clone().list().diff(n, null_behavior.0).into())
     }
 
     fn list_eval(&self, expr: PyExpr, parallel: bool) -> Self {
-        self.inner.clone().arr().eval(expr.inner, parallel).into()
+        self.inner.clone().list().eval(expr.inner, parallel).into()
     }
 
     fn list_get(&self, index: PyExpr) -> Self {
-        self.inner.clone().arr().get(index.inner).into()
+        self.inner.clone().list().get(index.inner).into()
     }
 
     fn list_join(&self, separator: &str) -> Self {
-        self.inner.clone().arr().join(separator).into()
+        self.inner.clone().list().join(separator).into()
     }
 
     fn list_lengths(&self) -> Self {
-        self.inner.clone().arr().lengths().into()
+        self.inner.clone().list().lengths().into()
     }
 
     fn list_max(&self) -> Self {
-        self.inner.clone().arr().max().into()
+        self.inner.clone().list().max().into()
     }
 
     fn list_mean(&self) -> Self {
-        self.inner.clone().arr().mean().with_fmt("list.mean").into()
+        self.inner
+            .clone()
+            .list()
+            .mean()
+            .with_fmt("list.mean")
+            .into()
     }
 
     fn list_min(&self) -> Self {
-        self.inner.clone().arr().min().into()
+        self.inner.clone().list().min().into()
     }
 
     fn list_reverse(&self) -> Self {
-        self.inner.clone().arr().reverse().into()
+        self.inner.clone().list().reverse().into()
     }
 
     fn list_shift(&self, periods: i64) -> Self {
-        self.inner.clone().arr().shift(periods).into()
+        self.inner.clone().list().shift(periods).into()
     }
 
     fn list_slice(&self, offset: PyExpr, length: Option<PyExpr>) -> Self {
@@ -72,13 +77,13 @@ impl PyExpr {
             Some(i) => i.inner,
             None => lit(i64::MAX),
         };
-        self.inner.clone().arr().slice(offset.inner, length).into()
+        self.inner.clone().list().slice(offset.inner, length).into()
     }
 
     fn list_sort(&self, descending: bool) -> Self {
         self.inner
             .clone()
-            .arr()
+            .list()
             .sort(SortOptions {
                 descending,
                 ..Default::default()
@@ -88,14 +93,14 @@ impl PyExpr {
     }
 
     fn list_sum(&self) -> Self {
-        self.inner.clone().arr().sum().with_fmt("list.sum").into()
+        self.inner.clone().list().sum().with_fmt("list.sum").into()
     }
 
     #[cfg(feature = "list_take")]
     fn list_take(&self, index: PyExpr, null_on_oob: bool) -> Self {
         self.inner
             .clone()
-            .arr()
+            .list()
             .take(index.inner, null_on_oob)
             .into()
     }
@@ -120,7 +125,7 @@ impl PyExpr {
         Ok(self
             .inner
             .clone()
-            .arr()
+            .list()
             .to_struct(width_strat.0, name_gen, upper_bound)
             .into())
     }
@@ -129,9 +134,9 @@ impl PyExpr {
         let e = self.inner.clone();
 
         if maintain_order {
-            e.arr().unique_stable().into()
+            e.list().unique_stable().into()
         } else {
-            e.arr().unique().into()
+            e.list().unique().into()
         }
     }
 }

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -251,7 +251,7 @@ def test_cast_inner_categorical() -> None:
     with pytest.raises(
         pl.ComputeError, match=r"casting to categorical not allowed in `arr.eval`"
     ):
-        pl.Series("foo", [["a", "b"], ["a", "b"]]).arr.eval(
+        pl.Series("foo", [["a", "b"], ["a", "b"]]).list.eval(
             pl.element().cast(pl.Categorical)
         )
 
@@ -333,7 +333,7 @@ def test_nested_categorical_aggregation_7848() -> None:
     ).with_columns([pl.col("letter").cast(pl.Categorical)]).groupby(
         maintain_order=True, by=["group"]
     ).all().with_columns(
-        [pl.col("letter").arr.lengths().alias("c_group")]
+        [pl.col("letter").list.lengths().alias("c_group")]
     ).groupby(
         by=["c_group"], maintain_order=True
     ).agg(

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -312,14 +312,14 @@ def test_from_dicts_struct() -> None:
 
 def test_list_to_struct() -> None:
     df = pl.DataFrame({"a": [[1, 2, 3], [1, 2]]})
-    assert df.select([pl.col("a").arr.to_struct()]).to_series().to_list() == [
+    assert df.select([pl.col("a").list.to_struct()]).to_series().to_list() == [
         {"field_0": 1, "field_1": 2, "field_2": 3},
         {"field_0": 1, "field_1": 2, "field_2": None},
     ]
 
     df = pl.DataFrame({"a": [[1, 2], [1, 2, 3]]})
     assert df.select(
-        [pl.col("a").arr.to_struct(fields=lambda idx: f"col_name_{idx}")]
+        [pl.col("a").list.to_struct(fields=lambda idx: f"col_name_{idx}")]
     ).to_series().to_list() == [
         {"col_name_0": 1, "col_name_1": 2},
         {"col_name_0": 1, "col_name_1": 2},
@@ -327,7 +327,7 @@ def test_list_to_struct() -> None:
 
     df = pl.DataFrame({"a": [[1, 2], [1, 2, 3]]})
     assert df.select(
-        [pl.col("a").arr.to_struct(n_field_strategy="max_width")]
+        [pl.col("a").list.to_struct(n_field_strategy="max_width")]
     ).to_series().to_list() == [
         {"field_0": 1, "field_1": 2, "field_2": None},
         {"field_0": 1, "field_1": 2, "field_2": 3},
@@ -335,7 +335,7 @@ def test_list_to_struct() -> None:
 
     # set upper bound
     df = pl.DataFrame({"lists": [[1, 1, 1], [0, 1, 0], [1, 0, 0]]})
-    assert df.lazy().select(pl.col("lists").arr.to_struct(upper_bound=3)).unnest(
+    assert df.lazy().select(pl.col("lists").list.to_struct(upper_bound=3)).unnest(
         "lists"
     ).sum().collect().columns == ["field_0", "field_1", "field_2"]
 
@@ -357,8 +357,8 @@ def test_struct_list_head_tail() -> None:
         }
     ).with_columns(
         [
-            pl.col("list_of_struct").arr.head(1).alias("head"),
-            pl.col("list_of_struct").arr.tail(1).alias("tail"),
+            pl.col("list_of_struct").list.head(1).alias("head"),
+            pl.col("list_of_struct").list.tail(1).alias("tail"),
         ]
     ).to_dict(
         False
@@ -419,13 +419,13 @@ def test_struct_arr_methods() -> None:
             ],
         }
     )
-    assert df.select([pl.col("list_struct").arr.first()]).to_dict(False) == {
+    assert df.select([pl.col("list_struct").list.first()]).to_dict(False) == {
         "list_struct": [{"a": 1, "b": 2}, {"a": 1, "b": 2}, {"a": 1, "b": 2}]
     }
-    assert df.select([pl.col("list_struct").arr.last()]).to_dict(False) == {
+    assert df.select([pl.col("list_struct").list.last()]).to_dict(False) == {
         "list_struct": [{"a": 5, "b": 6}, {"a": 3, "b": 4}, {"a": 1, "b": 2}]
     }
-    assert df.select([pl.col("list_struct").arr.get(0)]).to_dict(False) == {
+    assert df.select([pl.col("list_struct").list.get(0)]).to_dict(False) == {
         "list_struct": [{"a": 1, "b": 2}, {"a": 1, "b": 2}, {"a": 1, "b": 2}]
     }
 
@@ -442,7 +442,9 @@ def test_struct_concat_list() -> None:
                 [{"a": 6, "b": 7}],
             ],
         }
-    ).with_columns([pl.col("list_struct1").arr.concat("list_struct2").alias("result")])[
+    ).with_columns(
+        [pl.col("list_struct1").list.concat("list_struct2").alias("result")]
+    )[
         "result"
     ].to_list() == [
         [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 6, "b": 7}, {"a": 8, "b": 9}],
@@ -458,7 +460,7 @@ def test_struct_arr_reverse() -> None:
                 [{"a": 30, "b": 40}, {"a": 10, "b": 20}, {"a": 50, "b": 60}],
             ],
         }
-    ).with_columns([pl.col("list_struct").arr.reverse()]).to_dict(False) == {
+    ).with_columns([pl.col("list_struct").list.reverse()]).to_dict(False) == {
         "list_struct": [
             [{"a": 5, "b": 6}, {"a": 3, "b": 4}, {"a": 1, "b": 2}],
             [{"a": 50, "b": 60}, {"a": 10, "b": 20}, {"a": 30, "b": 40}],
@@ -580,7 +582,7 @@ def test_struct_arr_eval() -> None:
         {"col_struct": [[{"a": 1, "b": 11}, {"a": 2, "b": 12}, {"a": 1, "b": 11}]]}
     )
     assert df.with_columns(
-        pl.col("col_struct").arr.eval(pl.element().first()).alias("first")
+        pl.col("col_struct").list.eval(pl.element().first()).alias("first")
     ).to_dict(False) == {
         "col_struct": [[{"a": 1, "b": 11}, {"a": 2, "b": 12}, {"a": 1, "b": 11}]],
         "first": [[{"a": 1, "b": 11}]],
@@ -593,7 +595,7 @@ def test_arr_unique() -> None:
         {"col_struct": [[{"a": 1, "b": 11}, {"a": 2, "b": 12}, {"a": 1, "b": 11}]]}
     )
     # the order is unpredictable
-    unique = df.with_columns(pl.col("col_struct").arr.unique().alias("unique"))[
+    unique = df.with_columns(pl.col("col_struct").list.unique().alias("unique"))[
         "unique"
     ].to_list()
     assert len(unique) == 1

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2060,10 +2060,10 @@ def test_date_arr_concat() -> None:
 
     # type date
     df = pl.DataFrame({"d": [date(2000, 1, 1)]})
-    assert df.select(pl.col("d").arr.concat(pl.col("d"))).to_dict(False) == expected
+    assert df.select(pl.col("d").list.concat(pl.col("d"))).to_dict(False) == expected
     # type list[date]
     df = pl.DataFrame({"d": [[date(2000, 1, 1)]]})
-    assert df.select(pl.col("d").arr.concat(pl.col("d"))).to_dict(False) == expected
+    assert df.select(pl.col("d").list.concat(pl.col("d"))).to_dict(False) == expected
 
 
 def test_date_timedelta() -> None:

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -12,34 +12,34 @@ from polars.testing import assert_frame_equal, assert_series_equal
 
 def test_list_arr_get() -> None:
     a = pl.Series("a", [[1, 2, 3], [4, 5], [6, 7, 8, 9]])
-    out = a.arr.get(0)
+    out = a.list.get(0)
     expected = pl.Series("a", [1, 4, 6])
     assert_series_equal(out, expected)
-    out = a.arr[0]
+    out = a.list[0]
     expected = pl.Series("a", [1, 4, 6])
     assert_series_equal(out, expected)
-    out = a.arr.first()
+    out = a.list.first()
     assert_series_equal(out, expected)
-    out = pl.select(pl.lit(a).arr.first()).to_series()
+    out = pl.select(pl.lit(a).list.first()).to_series()
     assert_series_equal(out, expected)
 
-    out = a.arr.get(-1)
+    out = a.list.get(-1)
     expected = pl.Series("a", [3, 5, 9])
     assert_series_equal(out, expected)
-    out = a.arr.last()
+    out = a.list.last()
     assert_series_equal(out, expected)
-    out = pl.select(pl.lit(a).arr.last()).to_series()
+    out = pl.select(pl.lit(a).list.last()).to_series()
     assert_series_equal(out, expected)
 
     a = pl.Series("a", [[1, 2, 3], [4, 5], [6, 7, 8, 9]])
-    out = a.arr.get(-3)
+    out = a.list.get(-3)
     expected = pl.Series("a", [1, None, 7])
     assert_series_equal(out, expected)
 
     assert pl.DataFrame(
         {"a": [[1], [2], [3], [4, 5, 6], [7, 8, 9], [None, 11]]}
     ).with_columns(
-        [pl.col("a").arr.get(i).alias(f"get_{i}") for i in range(4)]
+        [pl.col("a").list.get(i).alias(f"get_{i}") for i in range(4)]
     ).to_dict(
         False
     ) == {
@@ -53,7 +53,7 @@ def test_list_arr_get() -> None:
     # get by indexes where some are out of bounds
     df = pl.DataFrame({"cars": [[1, 2, 3], [2, 3], [4], []], "indexes": [-2, 1, -3, 0]})
 
-    assert df.select([pl.col("cars").arr.get("indexes")]).to_dict(False) == {
+    assert df.select([pl.col("cars").list.get("indexes")]).to_dict(False) == {
         "cars": [2, 3, None, None]
     }
     # exact on oob boundary
@@ -64,34 +64,34 @@ def test_list_arr_get() -> None:
         }
     )
 
-    assert df.select(pl.col("lists").arr.get(3)).to_dict(False) == {
+    assert df.select(pl.col("lists").list.get(3)).to_dict(False) == {
         "lists": [None, None, 4]
     }
-    assert df.select(pl.col("lists").arr.get(pl.col("index"))).to_dict(False) == {
+    assert df.select(pl.col("lists").list.get(pl.col("index"))).to_dict(False) == {
         "lists": [None, None, 4]
     }
 
 
 def test_contains() -> None:
     a = pl.Series("a", [[1, 2, 3], [2, 5], [6, 7, 8, 9]])
-    out = a.arr.contains(2)
+    out = a.list.contains(2)
     expected = pl.Series("a", [True, True, False])
     assert_series_equal(out, expected)
 
-    out = pl.select(pl.lit(a).arr.contains(2)).to_series()
+    out = pl.select(pl.lit(a).list.contains(2)).to_series()
     assert_series_equal(out, expected)
 
 
 def test_list_concat() -> None:
     df = pl.DataFrame({"a": [[1, 2], [1], [1, 2, 3]]})
 
-    out = df.select([pl.col("a").arr.concat(pl.Series([[1, 2]]))])
+    out = df.select([pl.col("a").list.concat(pl.Series([[1, 2]]))])
     assert out["a"][0].to_list() == [1, 2, 1, 2]
 
-    out = df.select([pl.col("a").arr.concat([1, 4])])
+    out = df.select([pl.col("a").list.concat([1, 4])])
     assert out["a"][0].to_list() == [1, 2, 1, 4]
 
-    out_s = df["a"].arr.concat([4, 1])
+    out_s = df["a"].list.concat([4, 1])
     assert out_s[0].to_list() == [1, 2, 4, 1]
 
 
@@ -100,10 +100,10 @@ def test_list_arr_empty() -> None:
 
     out = df.select(
         [
-            pl.col("cars").arr.first().alias("cars_first"),
-            pl.when(pl.col("cars").arr.first() == 2)
+            pl.col("cars").list.first().alias("cars_first"),
+            pl.when(pl.col("cars").list.first() == 2)
             .then(1)
-            .when(pl.col("cars").arr.contains(2))
+            .when(pl.col("cars").list.contains(2))
             .then(2)
             .otherwise(3)
             .alias("cars_literal"),
@@ -119,31 +119,31 @@ def test_list_arr_empty() -> None:
 def test_list_argminmax() -> None:
     s = pl.Series("a", [[1, 2], [3, 2, 1]])
     expected = pl.Series("a", [0, 2], dtype=pl.UInt32)
-    assert_series_equal(s.arr.arg_min(), expected)
+    assert_series_equal(s.list.arg_min(), expected)
     expected = pl.Series("a", [1, 0], dtype=pl.UInt32)
-    assert_series_equal(s.arr.arg_max(), expected)
+    assert_series_equal(s.list.arg_max(), expected)
 
 
 def test_list_shift() -> None:
     s = pl.Series("a", [[1, 2], [3, 2, 1]])
     expected = pl.Series("a", [[None, 1], [None, 3, 2]])
-    assert s.arr.shift().to_list() == expected.to_list()
+    assert s.list.shift().to_list() == expected.to_list()
 
 
 def test_list_diff() -> None:
     s = pl.Series("a", [[1, 2], [10, 2, 1]])
     expected = pl.Series("a", [[None, 1], [None, -8, -1]])
-    assert s.arr.diff().to_list() == expected.to_list()
+    assert s.list.diff().to_list() == expected.to_list()
 
 
 def test_slice() -> None:
     vals = [[1, 2, 3, 4], [10, 2, 1]]
     s = pl.Series("a", vals)
-    assert s.arr.head(2).to_list() == [[1, 2], [10, 2]]
-    assert s.arr.tail(2).to_list() == [[3, 4], [2, 1]]
-    assert s.arr.tail(200).to_list() == vals
-    assert s.arr.head(200).to_list() == vals
-    assert s.arr.slice(1, 2).to_list() == [[2, 3], [2, 1]]
+    assert s.list.head(2).to_list() == [[1, 2], [10, 2]]
+    assert s.list.tail(2).to_list() == [[3, 4], [2, 1]]
+    assert s.list.tail(200).to_list() == vals
+    assert s.list.head(200).to_list() == vals
+    assert s.list.slice(1, 2).to_list() == [[2, 3], [2, 1]]
 
 
 def test_list_eval_dtype_inference() -> None:
@@ -158,15 +158,15 @@ def test_list_eval_dtype_inference() -> None:
 
     rank_pct = pl.col("").rank(descending=True) / pl.col("").count().cast(pl.UInt16)
 
-    # the .arr.first() would fail if .arr.eval did not correctly infer the output type
+    # the .list.first() would fail if .list.eval did not correctly infer the output type
     assert grades.with_columns(
         pl.concat_list(pl.all().exclude("student")).alias("all_grades")
     ).select(
         [
             pl.col("all_grades")
-            .arr.eval(rank_pct, parallel=True)
+            .list.eval(rank_pct, parallel=True)
             .alias("grades_rank")
-            .arr.first()
+            .list.first()
         ]
     ).to_series().to_list() == [
         0.3333333432674408,
@@ -186,7 +186,7 @@ def test_list_ternary_concat() -> None:
 
     assert df.with_columns(
         pl.when(pl.col("list1").is_null())
-        .then(pl.col("list1").arr.concat(pl.col("list2")))
+        .then(pl.col("list1").list.concat(pl.col("list2")))
         .otherwise(pl.col("list2"))
         .alias("result")
     ).to_dict(False) == {
@@ -198,7 +198,7 @@ def test_list_ternary_concat() -> None:
     assert df.with_columns(
         pl.when(pl.col("list1").is_null())
         .then(pl.col("list2"))
-        .otherwise(pl.col("list1").arr.concat(pl.col("list2")))
+        .otherwise(pl.col("list1").list.concat(pl.col("list2")))
         .alias("result")
     ).to_dict(False) == {
         "list1": [["123", "456"], None],
@@ -213,7 +213,7 @@ def test_arr_contains_categorical() -> None:
     ).lazy()
     df = df.with_columns(pl.col("str").cast(pl.Categorical))
     df_groups = df.groupby("group").agg([pl.col("str").alias("str_list")])
-    assert df_groups.filter(pl.col("str_list").arr.contains("C")).collect().to_dict(
+    assert df_groups.filter(pl.col("str_list").list.contains("C")).collect().to_dict(
         False
     ) == {"group": [2], "str_list": [["A", "C"]]}
 
@@ -229,7 +229,7 @@ def test_list_eval_type_coercion() -> None:
     assert df.select(
         [
             pl.col("array_cols")
-            .arr.eval(last_non_null_value, parallel=False)
+            .list.eval(last_non_null_value, parallel=False)
             .alias("col_last")
         ]
     ).to_dict(False) == {"col_last": [[3]]}
@@ -244,13 +244,13 @@ def test_list_slice() -> None:
         }
     )
 
-    assert df.select([pl.col("lst").arr.slice("offset", "len")]).to_dict(False) == {
+    assert df.select([pl.col("lst").list.slice("offset", "len")]).to_dict(False) == {
         "lst": [[2, 3, 4], [1]]
     }
-    assert df.select([pl.col("lst").arr.slice("offset", 1)]).to_dict(False) == {
+    assert df.select([pl.col("lst").list.slice("offset", 1)]).to_dict(False) == {
         "lst": [[2], [1]]
     }
-    assert df.select([pl.col("lst").arr.slice(-2, "len")]).to_dict(False) == {
+    assert df.select([pl.col("lst").list.slice(-2, "len")]).to_dict(False) == {
         "lst": [[3, 4], [2, 1]]
     }
 
@@ -268,8 +268,8 @@ def test_list_sliced_get_5186() -> None:
 
     exprs = [
         "ind",
-        pl.col("inds").arr.first().alias("first_element"),
-        pl.col("inds").arr.last().alias("last_element"),
+        pl.col("inds").list.first().alias("first_element"),
+        pl.col("inds").list.last().alias("last_element"),
     ]
     out1 = df.select(exprs)[10:20]
     out2 = df[10:20].select(exprs)
@@ -285,7 +285,7 @@ def test_empty_eval_dtype_5546() -> None:
     assert (
         df.limit(0).with_columns(
             pl.col("a")
-            .arr.eval(pl.element().filter(pl.first().struct.field("name") == 1))
+            .list.eval(pl.element().filter(pl.first().struct.field("name") == 1))
             .alias("a_filtered")
         )
     ).dtypes == [dtype, dtype]
@@ -293,44 +293,44 @@ def test_empty_eval_dtype_5546() -> None:
 
 def test_list_amortized_apply_explode_5812() -> None:
     s = pl.Series([None, [1, 3], [0, -3], [1, 2, 2]])
-    assert s.arr.sum().to_list() == [None, 4, -3, 5]
-    assert s.arr.min().to_list() == [None, 1, -3, 1]
-    assert s.arr.max().to_list() == [None, 3, 0, 2]
-    assert s.arr.arg_min().to_list() == [None, 0, 1, 0]
-    assert s.arr.arg_max().to_list() == [None, 1, 0, 1]
+    assert s.list.sum().to_list() == [None, 4, -3, 5]
+    assert s.list.min().to_list() == [None, 1, -3, 1]
+    assert s.list.max().to_list() == [None, 3, 0, 2]
+    assert s.list.arg_min().to_list() == [None, 0, 1, 0]
+    assert s.list.arg_max().to_list() == [None, 1, 0, 1]
 
 
 def test_list_slice_5866() -> None:
     vals = [[1, 2, 3, 4], [10, 2, 1]]
     s = pl.Series("a", vals)
-    assert s.arr.slice(1).to_list() == [[2, 3, 4], [2, 1]]
+    assert s.list.slice(1).to_list() == [[2, 3, 4], [2, 1]]
 
 
 def test_list_take() -> None:
     s = pl.Series("a", [[1, 2, 3], [4, 5], [6, 7, 8]])
     # mypy: we make it work, but idomatic is `arr.get`.
-    assert s.arr.take(0).to_list() == [[1], [4], [6]]  # type: ignore[arg-type]
-    assert s.arr.take([0, 1]).to_list() == [[1, 2], [4, 5], [6, 7]]
+    assert s.list.take(0).to_list() == [[1], [4], [6]]  # type: ignore[arg-type]
+    assert s.list.take([0, 1]).to_list() == [[1, 2], [4, 5], [6, 7]]
 
-    assert s.arr.take([-1, 1]).to_list() == [[3, 2], [5, 5], [8, 7]]
+    assert s.list.take([-1, 1]).to_list() == [[3, 2], [5, 5], [8, 7]]
 
     # use another list to make sure negative indices are respected
     taker = pl.Series([[-1, 1], [-1, 1], [-1, -2]])
-    assert s.arr.take(taker).to_list() == [[3, 2], [5, 5], [8, 7]]
+    assert s.list.take(taker).to_list() == [[3, 2], [5, 5], [8, 7]]
     with pytest.raises(pl.ComputeError, match=r"take indices are out of bounds"):
-        s.arr.take([1, 2])
+        s.list.take([1, 2])
     s = pl.Series(
         [["A", "B", "C"], ["A"], ["B"], ["1", "2"], ["e"]],
     )
 
-    assert s.arr.take([0, 2], null_on_oob=True).to_list() == [
+    assert s.list.take([0, 2], null_on_oob=True).to_list() == [
         ["A", "C"],
         ["A", None],
         ["B", None],
         ["1", None],
         ["e", None],
     ]
-    assert s.arr.take([0, 1, 2], null_on_oob=True).to_list() == [
+    assert s.list.take([0, 1, 2], null_on_oob=True).to_list() == [
         ["A", "B", "C"],
         ["A", None, None],
         ["B", None, None],
@@ -340,9 +340,9 @@ def test_list_take() -> None:
     s = pl.Series([[42, 1, 2], [5, 6, 7]])
 
     with pytest.raises(pl.ComputeError, match=r"take indices are out of bounds"):
-        s.arr.take([[0, 1, 2, 3], [0, 1, 2, 3]])
+        s.list.take([[0, 1, 2, 3], [0, 1, 2, 3]])
 
-    assert s.arr.take([0, 1, 2, 3], null_on_oob=True).to_list() == [
+    assert s.list.take([0, 1, 2, 3], null_on_oob=True).to_list() == [
         [42, 1, 2, None],
         [5, 6, 7, None],
     ]
@@ -353,7 +353,7 @@ def test_list_eval_all_null() -> None:
         pl.col("bar").cast(pl.List(pl.Utf8))
     )
 
-    assert df.select(pl.col("bar").arr.eval(pl.element())).to_dict(False) == {
+    assert df.select(pl.col("bar").list.eval(pl.element())).to_dict(False) == {
         "bar": [None, None, None]
     }
 
@@ -368,9 +368,9 @@ def test_list_function_group_awareness() -> None:
 
     assert df.groupby("group").agg(
         [
-            pl.col("a").implode().arr.get(0).alias("get"),
-            pl.col("a").implode().arr.take([0]).alias("take"),
-            pl.col("a").implode().arr.slice(0, 3).alias("slice"),
+            pl.col("a").implode().list.get(0).alias("get"),
+            pl.col("a").implode().list.take([0]).alias("take"),
+            pl.col("a").implode().list.slice(0, 3).alias("slice"),
         ]
     ).sort("group").to_dict(False) == {
         "group": [0, 1, 2],
@@ -388,7 +388,7 @@ def test_list_get_logical_types() -> None:
         }
     )
 
-    assert df.select(pl.all().arr.get(1).suffix("_element_1")).to_dict(False) == {
+    assert df.select(pl.all().list.get(1).suffix("_element_1")).to_dict(False) == {
         "date_col_element_1": [date(2023, 2, 2)],
         "datetime_col_element_1": [datetime(2023, 2, 2, 0, 0)],
     }
@@ -410,7 +410,7 @@ def test_list_take_logical_type() -> None:
 def test_list_unique() -> None:
     assert (
         pl.Series([[1, 1, 2, 2, 3], [3, 3, 3, 2, 1, 2]])
-        .arr.unique(maintain_order=True)
+        .list.unique(maintain_order=True)
         .series_equal(pl.Series([[1, 2, 3], [3, 2, 1]]))
     )
 
@@ -418,19 +418,19 @@ def test_list_unique() -> None:
 def test_list_to_struct() -> None:
     df = pl.DataFrame({"n": [[0, 1, 2], [0, 1]]})
 
-    assert df.select(pl.col("n").arr.to_struct()).rows(named=True) == [
+    assert df.select(pl.col("n").list.to_struct()).rows(named=True) == [
         {"n": {"field_0": 0, "field_1": 1, "field_2": 2}},
         {"n": {"field_0": 0, "field_1": 1, "field_2": None}},
     ]
 
-    assert df.select(pl.col("n").arr.to_struct(fields=lambda idx: f"n{idx}")).rows(
+    assert df.select(pl.col("n").list.to_struct(fields=lambda idx: f"n{idx}")).rows(
         named=True
     ) == [
         {"n": {"n0": 0, "n1": 1, "n2": 2}},
         {"n": {"n0": 0, "n1": 1, "n2": None}},
     ]
 
-    assert df.select(pl.col("n").arr.to_struct(fields=["one", "two", "three"])).rows(
+    assert df.select(pl.col("n").list.to_struct(fields=["one", "two", "three"])).rows(
         named=True
     ) == [
         {"n": {"one": 0, "two": 1, "three": 2}},
@@ -440,5 +440,5 @@ def test_list_to_struct() -> None:
 
 def test_list_arr_get_8810() -> None:
     assert pl.DataFrame(pl.Series("a", [None], pl.List(pl.Int64))).select(
-        pl.col("a").arr.get(0)
+        pl.col("a").list.get(0)
     ).to_dict(False) == {"a": [None]}

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -123,22 +123,22 @@ def test_explode_correct_for_slice() -> None:
 
 def test_sliced_null_explode() -> None:
     s = pl.Series("", [[1], [2], [3], [4], [], [6]])
-    assert s.slice(2, 4).arr.explode().to_list() == [3, 4, None, 6]
-    assert s.slice(2, 2).arr.explode().to_list() == [3, 4]
+    assert s.slice(2, 4).list.explode().to_list() == [3, 4, None, 6]
+    assert s.slice(2, 2).list.explode().to_list() == [3, 4]
     assert pl.Series("", [[1], [2], None, [4], [], [6]]).slice(
         2, 4
-    ).arr.explode().to_list() == [None, 4, None, 6]
+    ).list.explode().to_list() == [None, 4, None, 6]
 
     s = pl.Series("", [["a"], ["b"], ["c"], ["d"], [], ["e"]])
-    assert s.slice(2, 4).arr.explode().to_list() == ["c", "d", None, "e"]
-    assert s.slice(2, 2).arr.explode().to_list() == ["c", "d"]
+    assert s.slice(2, 4).list.explode().to_list() == ["c", "d", None, "e"]
+    assert s.slice(2, 2).list.explode().to_list() == ["c", "d"]
     assert pl.Series("", [["a"], ["b"], None, ["d"], [], ["e"]]).slice(
         2, 4
-    ).arr.explode().to_list() == [None, "d", None, "e"]
+    ).list.explode().to_list() == [None, "d", None, "e"]
 
     s = pl.Series("", [[False], [False], [True], [False], [], [True]])
-    assert s.slice(2, 2).arr.explode().to_list() == [True, False]
-    assert s.slice(2, 4).arr.explode().to_list() == [True, False, None, True]
+    assert s.slice(2, 2).list.explode().to_list() == [True, False]
+    assert s.slice(2, 4).list.explode().to_list() == [True, False, None, True]
 
 
 def test_utf8_explode() -> None:
@@ -229,7 +229,7 @@ def test_explode_inner_lists_3985() -> None:
     assert (
         df.groupby("id")
         .agg(pl.col("categories"))
-        .with_columns(pl.col("categories").arr.eval(pl.element().arr.explode()))
+        .with_columns(pl.col("categories").list.eval(pl.element().list.explode()))
     ).collect().to_dict(False) == {"id": [1], "categories": [["a", "b", "a", "c"]]}
 
 
@@ -245,7 +245,7 @@ def test_list_struct_explode_6905() -> None:
             ]
         },
         schema={"group": pl.List(pl.Struct([pl.Field("params", pl.List(pl.Int32))]))},
-    )["group"].arr.explode().to_list() == [
+    )["group"].list.explode().to_list() == [
         {"params": None},
         {"params": [1]},
         {"params": []},
@@ -255,7 +255,7 @@ def test_list_struct_explode_6905() -> None:
 def test_explode_binary() -> None:
     assert pl.Series([[1, 2], [3]]).cast(
         pl.List(pl.Binary)
-    ).arr.explode().to_list() == [
+    ).list.explode().to_list() == [
         b"1",
         b"2",
         b"3",
@@ -265,7 +265,7 @@ def test_explode_binary() -> None:
 def test_explode_null_list() -> None:
     assert pl.Series([["a"], None], dtype=pl.List(pl.Utf8))[
         1:2
-    ].arr.min().to_list() == [None]
+    ].list.min().to_list() == [None]
 
 
 def test_explode_invalid_element_count() -> None:

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -380,7 +380,7 @@ def test_cached_windows_sync_8803() -> None:
             ]
         )
         .with_columns(
-            a=pl.col("is_valid").implode().arr.contains(True).over("id"),
+            a=pl.col("is_valid").implode().list.contains(True).over("id"),
             b=pl.col("is_valid").sum().gt(0).over("id"),
         )
         .sum()

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2074,12 +2074,12 @@ def test_extension() -> None:
 
     out = df.groupby("groups", maintain_order=True).agg(pl.col("a").alias("a"))
     assert sys.getrefcount(foos[0]) == base_count + 2
-    s = out["a"].arr.explode()
+    s = out["a"].list.explode()
     assert sys.getrefcount(foos[0]) == base_count + 3
     del s
     assert sys.getrefcount(foos[0]) == base_count + 2
 
-    assert out["a"].arr.explode().to_list() == foos
+    assert out["a"].list.explode().to_list() == foos
     assert sys.getrefcount(foos[0]) == base_count + 2
     del out
     assert sys.getrefcount(foos[0]) == base_count + 1
@@ -3622,7 +3622,7 @@ def test_deadlocks_3409() -> None:
         pl.DataFrame({"col1": [[1, 2, 3]]})
         .with_columns(
             [
-                pl.col("col1").arr.eval(
+                pl.col("col1").list.eval(
                     pl.element().apply(lambda x: x, return_dtype=pl.Int64)
                 )
             ]

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -355,7 +355,7 @@ def test_arr_eval_named_cols() -> None:
     with pytest.raises(
         pl.ComputeError,
     ):
-        df.select(pl.col("B").arr.eval(pl.element().append(pl.col("A"))))
+        df.select(pl.col("B").list.eval(pl.element().append(pl.col("A"))))
 
 
 def test_alias_in_join_keys() -> None:

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -139,7 +139,7 @@ def test_min_nulls_consistency() -> None:
 def test_list_join_strings() -> None:
     s = pl.Series("a", [["ab", "c", "d"], ["e", "f"], ["g"], []])
     expected = pl.Series("a", ["ab-c-d", "e-f", "g", ""])
-    assert_series_equal(s.arr.join("-"), expected)
+    assert_series_equal(s.list.join("-"), expected)
 
 
 def test_count_expr() -> None:
@@ -334,7 +334,7 @@ def test_list_eval_expression() -> None:
     for parallel in [True, False]:
         assert df.with_columns(
             pl.concat_list(["a", "b"])
-            .arr.eval(pl.first().rank(), parallel=parallel)
+            .list.eval(pl.first().rank(), parallel=parallel)
             .alias("rank")
         ).to_dict(False) == {
             "a": [1, 8, 3],
@@ -342,7 +342,7 @@ def test_list_eval_expression() -> None:
             "rank": [[1.0, 2.0], [2.0, 1.0], [2.0, 1.0]],
         }
 
-        assert df["a"].reshape((1, -1)).arr.eval(
+        assert df["a"].reshape((1, -1)).list.eval(
             pl.first(), parallel=parallel
         ).to_list() == [[1, 8, 3]]
 
@@ -426,7 +426,7 @@ def test_arr_contains() -> None:
         }
     )
     assert df_groups.lazy().filter(
-        pl.col("str_list").arr.contains("cat")
+        pl.col("str_list").list.contains("cat")
     ).collect().to_dict(False) == {
         "str_list": [["cat", "mouse", "dog"], ["dog", "mouse", "cat"]]
     }
@@ -1118,4 +1118,4 @@ def test_extend_constant_arr(const: Any, dtype: pl.PolarsDataType) -> None:
 
     expected = pl.Series("s", [[const, const, const, const]], dtype=pl.List(dtype))
 
-    assert_series_equal(s.arr.eval(pl.element().extend_constant(const, 3)), expected)
+    assert_series_equal(s.list.eval(pl.element().extend_constant(const, 3)), expected)

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -774,7 +774,7 @@ def test_arr_namespace(fruits_cars: pl.DataFrame) -> None:
             "fruits",
             pl.col("B")
             .over("fruits", mapping_strategy="join")
-            .arr.min()
+            .list.min()
             .alias("B_by_fruits_min1"),
             pl.col("B")
             .min()
@@ -782,7 +782,7 @@ def test_arr_namespace(fruits_cars: pl.DataFrame) -> None:
             .alias("B_by_fruits_min2"),
             pl.col("B")
             .over("fruits", mapping_strategy="join")
-            .arr.max()
+            .list.max()
             .alias("B_by_fruits_max1"),
             pl.col("B")
             .max()
@@ -790,7 +790,7 @@ def test_arr_namespace(fruits_cars: pl.DataFrame) -> None:
             .alias("B_by_fruits_max2"),
             pl.col("B")
             .over("fruits", mapping_strategy="join")
-            .arr.sum()
+            .list.sum()
             .alias("B_by_fruits_sum1"),
             pl.col("B")
             .sum()
@@ -798,7 +798,7 @@ def test_arr_namespace(fruits_cars: pl.DataFrame) -> None:
             .alias("B_by_fruits_sum2"),
             pl.col("B")
             .over("fruits", mapping_strategy="join")
-            .arr.mean()
+            .list.mean()
             .alias("B_by_fruits_mean1"),
             pl.col("B")
             .mean()

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -133,7 +133,7 @@ def test_predicate_arr_first_6573() -> None:
     assert (
         df.lazy()
         .with_columns(pl.col("a").implode())
-        .with_columns(pl.col("a").arr.first())
+        .with_columns(pl.col("a").list.first())
         .filter(pl.col("a") == pl.col("b"))
         .collect()
     ).to_dict(False) == {"a": [1], "b": [1]}

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -102,7 +102,7 @@ def test_unnest_columns_available() -> None:
     q = df.with_columns(
         pl.col("genres")
         .str.split("|")
-        .arr.to_struct(n_field_strategy="max_width", fields=lambda i: f"genre{i+1}")
+        .list.to_struct(n_field_strategy="max_width", fields=lambda i: f"genre{i+1}")
     ).unnest("genres")
 
     out = q.collect()

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -309,7 +309,7 @@ def test_when_then_edge_cases_3994() -> None:
         .groupby(["id"])
         .agg(pl.col("type"))
         .with_columns(
-            pl.when(pl.col("type").arr.lengths() == 0)
+            pl.when(pl.col("type").list.lengths() == 0)
             .then(pl.lit(None))
             .otherwise(pl.col("type"))
             .keep_name()
@@ -323,7 +323,7 @@ def test_when_then_edge_cases_3994() -> None:
         .groupby(["id"])
         .agg(pl.col("type"))
         .with_columns(
-            pl.when(pl.col("type").arr.lengths() == 0)
+            pl.when(pl.col("type").list.lengths() == 0)
             .then(pl.lit(None))
             .otherwise(pl.col("type"))
             .keep_name()

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -302,7 +302,7 @@ def test_all_null_cast_5826() -> None:
 def test_empty_list_eval_schema_5734() -> None:
     df = pl.DataFrame({"a": [[{"b": 1, "c": 2}]]})
     assert df.filter(False).select(
-        pl.col("a").arr.eval(pl.element().struct.field("b"))
+        pl.col("a").list.eval(pl.element().struct.field("b"))
     ).schema == {"a": pl.List(pl.Int64)}
 
 

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -601,13 +601,13 @@ def test_to_python() -> None:
 def test_to_struct() -> None:
     s = pl.Series("nums", ["12 34", "56 78", "90 00"]).str.extract_all(r"\d+")
 
-    assert s.arr.to_struct().struct.fields == ["field_0", "field_1"]
-    assert s.arr.to_struct(fields=lambda idx: f"n{idx:02}").struct.fields == [
+    assert s.list.to_struct().struct.fields == ["field_0", "field_1"]
+    assert s.list.to_struct(fields=lambda idx: f"n{idx:02}").struct.fields == [
         "n00",
         "n01",
     ]
     assert_frame_equal(
-        s.arr.to_struct(fields=["one", "two"]).struct.unnest(),
+        s.list.to_struct(fields=["one", "two"]).struct.unnest(),
         pl.DataFrame({"one": ["12", "56", "90"], "two": ["34", "78", "00"]}),
     )
 
@@ -1373,30 +1373,30 @@ def test_kurtosis() -> None:
 
 def test_arr_lengths() -> None:
     s = pl.Series("a", [[1, 2], [1, 2, 3]])
-    assert_series_equal(s.arr.lengths(), pl.Series("a", [2, 3], dtype=UInt32))
+    assert_series_equal(s.list.lengths(), pl.Series("a", [2, 3], dtype=UInt32))
     df = pl.DataFrame([s])
     assert_series_equal(
-        df.select(pl.col("a").arr.lengths())["a"], pl.Series("a", [2, 3], dtype=UInt32)
+        df.select(pl.col("a").list.lengths())["a"], pl.Series("a", [2, 3], dtype=UInt32)
     )
 
 
 def test_arr_arithmetic() -> None:
     s = pl.Series("a", [[1, 2], [1, 2, 3]])
-    assert_series_equal(s.arr.sum(), pl.Series("a", [3, 6]))
-    assert_series_equal(s.arr.mean(), pl.Series("a", [1.5, 2.0]))
-    assert_series_equal(s.arr.max(), pl.Series("a", [2, 3]))
-    assert_series_equal(s.arr.min(), pl.Series("a", [1, 1]))
+    assert_series_equal(s.list.sum(), pl.Series("a", [3, 6]))
+    assert_series_equal(s.list.mean(), pl.Series("a", [1.5, 2.0]))
+    assert_series_equal(s.list.max(), pl.Series("a", [2, 3]))
+    assert_series_equal(s.list.min(), pl.Series("a", [1, 1]))
 
 
 def test_arr_ordering() -> None:
     s = pl.Series("a", [[2, 1], [1, 3, 2]])
-    assert_series_equal(s.arr.sort(), pl.Series("a", [[1, 2], [1, 2, 3]]))
-    assert_series_equal(s.arr.reverse(), pl.Series("a", [[1, 2], [2, 3, 1]]))
+    assert_series_equal(s.list.sort(), pl.Series("a", [[1, 2], [1, 2, 3]]))
+    assert_series_equal(s.list.reverse(), pl.Series("a", [[1, 2], [2, 3, 1]]))
 
 
 def test_arr_unique() -> None:
     s = pl.Series("a", [[2, 1], [1, 2, 2]])
-    result = s.arr.unique()
+    result = s.list.unique()
     assert len(result) == 2
     assert sorted(result[0]) == [1, 2]
     assert sorted(result[1]) == [1, 2]
@@ -1446,19 +1446,19 @@ def test_list_concat() -> None:
     s1 = pl.Series("b", [[3, 4, 5]])
     expected = pl.Series("a", [[1, 2, 3, 4, 5]])
 
-    out = s0.arr.concat([s1])
+    out = s0.list.concat([s1])
     assert_series_equal(out, expected)
 
-    out = s0.arr.concat(s1)
+    out = s0.list.concat(s1)
     assert_series_equal(out, expected)
 
     df = pl.DataFrame([s0, s1])
     assert_series_equal(df.select(pl.concat_list(["a", "b"]).alias("a"))["a"], expected)
     assert_series_equal(
-        df.select(pl.col("a").arr.concat("b").alias("a"))["a"], expected
+        df.select(pl.col("a").list.concat("b").alias("a"))["a"], expected
     )
     assert_series_equal(
-        df.select(pl.col("a").arr.concat(["b"]).alias("a"))["a"], expected
+        df.select(pl.col("a").list.concat(["b"]).alias("a"))["a"], expected
     )
 
 


### PR DESCRIPTION
Changes:
* Rename list namespace accessor from `.arr` to `.list`, both on Python and on Rust side.