### PR TITLE
fix(python): don't allow silent init of `Series` declared as int/temporal with floating point values

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -22,7 +22,10 @@ from typing import (
 import polars._reexport as pl
 from polars import functions as F
 from polars.datatypes import (
+    FLOAT_DTYPES,
+    INTEGER_DTYPES,
     N_INFER_DEFAULT,
+    TEMPORAL_DTYPES,
     Boolean,
     Categorical,
     Date,
@@ -299,6 +302,7 @@ def _construct_series_with_fallbacks(
     constructor: Callable[[str, Sequence[Any], bool], PySeries],
     name: str,
     values: Sequence[Any],
+    target_dtype: PolarsDataType | None,
     strict: bool,
 ) -> PySeries:
     """Construct Series, with fallbacks for basic type mismatch (eg: bool/int)."""
@@ -306,28 +310,33 @@ def _construct_series_with_fallbacks(
         try:
             return constructor(name, values, strict)
         except TypeError as exc:
-            str_val = str(exc)
+            str_exc = str(exc)
 
             # from x to float
             # error message can be:
             #   - integers: "'float' object cannot be interpreted as an integer"
-            if "'float'" in str_val:
+            if "'float'" in str_exc and (
+                # we do not accept float values as int/temporal, as it causes silent
+                # information loss; the caller should explicitly cast in this case.
+                target_dtype
+                not in (INTEGER_DTYPES | TEMPORAL_DTYPES)
+            ):
                 constructor = py_type_to_constructor(float)
 
             # from x to string
             # error message can be:
             #   - integers: "'str' object cannot be interpreted as an integer"
             #   - floats: "must be real number, not str"
-            elif "'str'" in str_val or str_val == "must be real number, not str":
+            elif "'str'" in str_exc or str_exc == "must be real number, not str":
                 constructor = py_type_to_constructor(str)
 
             # from x to int
             # error message can be:
             #   - bools: "'int' object cannot be converted to 'PyBool'"
-            elif str_val == "'int' object cannot be converted to 'PyBool'":
+            elif str_exc == "'int' object cannot be converted to 'PyBool'":
                 constructor = py_type_to_constructor(int)
 
-            elif "decimal.Decimal" in str_val:
+            elif "decimal.Decimal" in str_exc:
                 constructor = py_type_to_constructor(PyDecimal)
             else:
                 raise exc
@@ -374,6 +383,7 @@ def sequence_to_pyseries(
             # * if the values are integer, we take the physical branch.
             # * if the values are python types, take the temporal branch.
             # * if the values are ISO-8601 strings, init then convert via strptime.
+            # * if the values are floats/other dtypes, this is an error.
             if dtype in py_temporal_types and isinstance(value, int):
                 dtype = py_type_to_dtype(dtype)  # construct from integer
             elif (
@@ -390,8 +400,9 @@ def sequence_to_pyseries(
         and (python_dtype is None)
     ):
         constructor = polars_type_to_constructor(dtype)
-        pyseries = _construct_series_with_fallbacks(constructor, name, values, strict)
-
+        pyseries = _construct_series_with_fallbacks(
+            constructor, name, values, dtype, strict
+        )
         if dtype in (Date, Datetime, Duration, Time, Categorical, Boolean):
             if pyseries.dtype() != dtype:
                 pyseries = pyseries.cast(dtype, True)
@@ -414,7 +425,7 @@ def sequence_to_pyseries(
                     dtype_if_empty if dtype_if_empty else Float32
                 )
                 return _construct_series_with_fallbacks(
-                    constructor, name, values, strict
+                    constructor, name, values, dtype, strict
                 )
 
             # generic default dtype
@@ -426,11 +437,23 @@ def sequence_to_pyseries(
                 dtype = py_type_to_dtype(python_dtype)  # construct from integer
             elif dtype in py_temporal_types:
                 dtype = py_type_to_dtype(dtype)
-            time_unit = getattr(dtype, "time_unit", None)
+
+            values_dtype = (
+                None
+                if value is None
+                else py_type_to_dtype(type(value), raise_unmatched=False)
+            )
+            if values_dtype in FLOAT_DTYPES:
+                raise TypeError(
+                    # we do not accept float values as temporal; if this is
+                    # required, the caller should explicitly cast to int first.
+                    f"'float' object cannot be interpreted as a {python_dtype.__name__}"
+                )
 
             # we use anyvalue builder to create the datetime array
             # we store the values internally as UTC and set the timezone
             py_series = PySeries.new_from_anyvalues(name, values, strict)
+            time_unit = getattr(dtype, "time_unit", None)
             if time_unit is None:
                 s = wrap_s(py_series)
             else:
@@ -499,7 +522,9 @@ def sequence_to_pyseries(
                 except RuntimeError:
                     return sequence_from_anyvalue_or_object(name, values)
 
-            return _construct_series_with_fallbacks(constructor, name, values, strict)
+            return _construct_series_with_fallbacks(
+                constructor, name, values, dtype, strict
+            )
 
 
 def _pandas_series_to_arrow(

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.datatypes.convert import dtype_to_py_type
 
 
 def test_error_on_empty_groupby() -> None:
@@ -57,6 +58,21 @@ def test_error_on_invalid_by_in_asof_join() -> None:
     df2 = df1.with_columns(pl.col("a").cast(pl.Categorical))
     with pytest.raises(pl.ComputeError):
         df1.join_asof(df2, on="b", by=["a", "c"])
+
+
+def test_error_on_invalid_series_init() -> None:
+    for dtype in pl.TEMPORAL_DTYPES:
+        py_type = dtype_to_py_type(dtype)
+        with pytest.raises(
+            TypeError,
+            match=f"'float' object cannot be interpreted as a {py_type.__name__}",
+        ):
+            pl.Series([1.5, 2.0, 3.75], dtype=dtype)
+
+    with pytest.raises(
+        TypeError, match="'float' object cannot be interpreted as an integer"
+    ):
+        pl.Series([1.5, 2.0, 3.75], dtype=pl.Int32)
 
 
 def test_error_on_invalid_struct_field() -> None:

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -804,7 +804,7 @@ def test_map_dict() -> None:
 
     with pytest.raises(
         pl.ComputeError,
-        match="Remapping keys for map_dict could not be converted to Int16: ",
+        match=".*'float' object cannot be interpreted as an integer",
     ):
         df.with_columns(pl.col("int").map_dict(float_dict))
 


### PR DESCRIPTION
Closes #8985.

Ensure that we do not silently fail to respect the declared dtype when calling `Series` init with the float values; this occurs because `_construct_series_with_fallbacks` will pass-through to the float constructor on initial failure which isn't really valid in these cases (and `PySeries.new_from_anyvalues` will do something somewhat similar).


## Example
**Before:**
```python
pl.Series( "x", [1.5, 2.5], dtype=pl.Int32 )
# shape: (2,)
# Series: 'x' [f64]
# [
# 	1.5
# 	2.5
# ]
```
```python
pl.Series( "y", [3.5, 4.5], dtype=pl.Date )
# shape: (2,)
# Series: 'y' [f64]
# [
# 	3.5
# 	4.5
# ]
```
**After:**
```python
pl.Series( "x", [1.5, 2.5], dtype=pl.Int32 )
# TypeError: 'float' object cannot be interpreted as an integer
```
```python
pl.Series( "y", [3.5, 4.5], dtype=pl.Date )
# TypeError: 'float' object cannot be interpreted as a date
```

---

**Note:** there seems to be special behaviour relating to declaring String/Categorical dtypes, whereby we return `null` values instead of raising an error - if I recall correctly, that may be connected to the loading of mixed-type data, so I have not modified this (though there is a case to be made that this should also raise an error; either way, it's established behaviour, so am letting it be ;)
