### PR TITLE
chore: Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 *  @ritchie46
 
+/.github/ @ritchie46 @stinodego
 /polars/polars-sql/  @ritchie46 @universalmind303
 /polars/polars-time/  @ritchie46 @MarcoGorelli
 /polars-cli/  @ritchie46 @universalmind303

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,6 @@
-# default owner for all unmatched paths
-@ritchie46
+*  @ritchie46
 
-/polars-cli/ @universalmind303
-/polars/polars-sql/ @universalmind303
-/polars/py-polars/ @stinodego @alexander-beedie 
-/polars/polars-time/ @MarcoGorelli
+/polars/polars-sql/  @ritchie46 @universalmind303
+/polars/polars-time/  @ritchie46 @MarcoGorelli
+/polars-cli/  @ritchie46 @universalmind303
+/py-polars/  @ritchie46 @stinodego @alexander-beedie


### PR DESCRIPTION
Path for `py-polars` was incorrect, and Ritchie is owner of all code so he should be added to all entries.

Also added myself as owner for the `.github` folder, mostly for CI stuff and chores.