### PR TITLE
refactor(rust): Use Zero trait for cumulative function state initialization

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/cum_agg.rs
+++ b/polars/polars-core/src/chunked_array/ops/cum_agg.rs
@@ -1,7 +1,7 @@
 use std::iter::FromIterator;
 use std::ops::{Add, AddAssign, Mul};
 
-use num_traits::{Bounded, Zero};
+use num_traits::{Bounded, One, Zero};
 
 use crate::prelude::*;
 use crate::utils::CustomIterTools;
@@ -114,7 +114,7 @@ where
     }
 
     fn cumprod(&self, reverse: bool) -> ChunkedArray<T> {
-        let init = <<T as datatypes::PolarsNumericType>::Native as Zero>::zero();
+        let init = <<T as datatypes::PolarsNumericType>::Native as One>::one();
         let mut ca: Self = match reverse {
             false => self.into_iter().scan(init, det_prod).collect_trusted(),
             true => self

--- a/polars/polars-core/src/datatypes/mod.rs
+++ b/polars/polars-core/src/datatypes/mod.rs
@@ -30,7 +30,7 @@ use arrow::types::simd::Simd;
 use arrow::types::NativeType;
 pub use dtype::*;
 pub use field::*;
-use num_traits::{Bounded, FromPrimitive, Num, NumCast, Zero};
+use num_traits::{Bounded, FromPrimitive, Num, NumCast, One, Zero};
 use polars_arrow::data_types::IsFloat;
 #[cfg(feature = "serde")]
 use serde::de::{EnumAccess, Error, Unexpected, VariantAccess, Visitor};
@@ -186,6 +186,7 @@ pub trait NumericNative:
     + Num
     + NumCast
     + Zero
+    + One
     + Simd
     + Simd8
     + std::iter::Sum<Self>


### PR DESCRIPTION
This also makes it so that these functions have the same signatures as `det_min` and `det_max` within the same module