### PR TITLE
WIP: fix issue with dirtiest of hacks

### DIFF
--- a/polars/polars-lazy/src/physical_plan/expressions/take.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/take.rs
@@ -57,6 +57,7 @@ impl PhysicalExpr for TakeExpr {
     ) -> PolarsResult<AggregationContext<'a>> {
         let mut ac = self.phys_expr.evaluate_on_groups(df, groups, state)?;
         let mut idx = self.idx.evaluate_on_groups(df, groups, state)?;
+        eprintln!("idx: {:?}", idx);
 
         let idx =
             match idx.state {
@@ -125,7 +126,8 @@ impl PhysicalExpr for TakeExpr {
                     let idx = s.cast(&IDX_DTYPE)?;
                     let idx = idx.idx().unwrap();
 
-                    return if idx.len() == 1 {
+                    return if (idx.len() == 1) & (s.name() != "") {
+                        eprintln!("idx.len == 1, idx: {:?} and series {:?} and series.name {:?}", idx, s, s.name());
                         match idx.get(0) {
                             None => polars_bail!(ComputeError: "cannot take by a null"),
                             Some(idx) => {
@@ -161,6 +163,8 @@ impl PhysicalExpr for TakeExpr {
                             }
                         }
                     } else {
+                        eprintln!("idx.len != 1");
+                        //eprintln!("these are the idx: {:?}", idx);
                         let out = ac
                             .aggregated()
                             .list()

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1557,3 +1557,10 @@ def test_compare_aggregation_between_lazy_and_eager_6904(
     dtype_eager = result_eager["x"].dtype
     result_lazy = df.lazy().select(func.over("y")).select(pl.col(dtype_eager)).collect()
     assert result_eager.frame_equal(result_lazy)
+
+
+def test_take_after_groupby_schema():
+    ldf = pl.LazyFrame({"A": [1, 2, 3, 4], "B": [1, 1, 2, 2]})
+    assert ldf.groupby("B").agg(pl.col("A").take(0)).collect().schema == {'B': pl.Int64, 'A': pl.Int64}
+    assert ldf.groupby("B").agg(pl.col("A").take([0])).collect().schema == {'B': pl.Int64, 'A': pl.List(pl.Int64)}
+    assert ldf.groupby("B").agg(pl.col("A").take([0, 1])).collect().schema == {'B': pl.Int64, 'A': pl.List(pl.Int64)}


### PR DESCRIPTION
fixes #8683 

Note: this is not the change I suggest, I just created this PR to make sure where the problem lies.

The point is that on main both cases
`ldf.groupby("B").agg(pl.col("A").take(0)).collect()` and `ldf.groupby("B").agg(pl.col("A").take([0])).collect()` are running through [the if case](https://github.com/pola-rs/polars/blob/main/polars/polars-lazy/src/physical_plan/expressions/take.rs#L128) but we would the latter actually need to run through [the else case](https://github.com/pola-rs/polars/blob/main/polars/polars-lazy/src/physical_plan/expressions/take.rs#L164). The only obvious distinction I found was the series name, but this is just a dirty hack. Maybe we would need to add an extra argument for `GroupsIdx` like `is_list_type` or something which we check instead of the series name
