### PR TITLE
feat(rust, python)!: formalize implode -> explode relation

### DIFF
--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -342,12 +342,11 @@ impl Series {
             .and_then(|s| s.f64().unwrap().get(0).and_then(T::from))
     }
 
-    /// Explode a list or utf8 Series. This expands every item to a new row..
+    /// Explode a list Series. This expands every item to a new row..
     pub fn explode(&self) -> PolarsResult<Series> {
         match self.dtype() {
             DataType::List(_) => self.list().unwrap().explode(),
-            DataType::Utf8 => self.utf8().unwrap().explode(),
-            _ => polars_bail!(opq = explode, self.dtype()),
+            _ => Ok(self.clone()),
         }
     }
 

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -534,6 +534,7 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "string_from_radix")]
             FromRadix(radix, strict) => map!(strings::from_radix, radix, strict),
             Slice(start, length) => map!(strings::str_slice, start, length),
+            Explode => map!(strings::explode),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -63,6 +63,7 @@ pub enum StringFunction {
     #[cfg(feature = "string_from_radix")]
     FromRadix(u32, bool),
     Slice(i64, Option<u64>),
+    Explode,
 }
 
 impl StringFunction {
@@ -88,6 +89,7 @@ impl StringFunction {
             }
             #[cfg(feature = "string_from_radix")]
             FromRadix { .. } => mapper.with_dtype(DataType::Int32),
+            Explode => mapper.with_same_dtype(),
         }
     }
 }
@@ -125,6 +127,7 @@ impl Display for StringFunction {
             #[cfg(feature = "string_from_radix")]
             StringFunction::FromRadix { .. } => "from_radix",
             StringFunction::Slice(_, _) => "str_slice",
+            StringFunction::Explode => "explode",
         };
 
         write!(f, "str.{s}")
@@ -641,4 +644,9 @@ pub(super) fn from_radix(s: &Series, radix: u32, strict: bool) -> PolarsResult<S
 pub(super) fn str_slice(s: &Series, start: i64, length: Option<u64>) -> PolarsResult<Series> {
     let ca = s.utf8()?;
     ca.str_slice(start, length).map(|ca| ca.into_series())
+}
+
+pub(super) fn explode(s: &Series) -> PolarsResult<Series> {
+    let ca = s.utf8()?;
+    ca.explode()
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/string.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/string.rs
@@ -457,4 +457,9 @@ impl StringNameSpace {
                 start, length,
             )))
     }
+
+    pub fn explode(self) -> Expr {
+        self.0
+            .apply_private(FunctionExpr::StringExpr(StringFunction::Explode))
+    }
 }

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1539,7 +1539,7 @@ class ExprStringNameSpace:
         └─────┘
 
         """
-        return wrap_expr(self._pyexpr.explode())
+        return wrap_expr(self._pyexpr.str_explode())
 
     def parse_int(self, radix: int = 2, *, strict: bool = True) -> Expr:
         """

--- a/py-polars/src/expr/string.rs
+++ b/py-polars/src/expr/string.rs
@@ -72,6 +72,10 @@ impl PyExpr {
         self.inner.clone().str().str_slice(start, length).into()
     }
 
+    fn str_explode(&self) -> Self {
+        self.inner.clone().str().explode().into()
+    }
+
     fn str_to_uppercase(&self) -> Self {
         self.inner.clone().str().to_uppercase().into()
     }

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -33,7 +33,7 @@ def test_groupby_flatten_list() -> None:
 
 def test_groupby_flatten_string() -> None:
     df = pl.DataFrame({"group": ["a", "b", "b"], "values": ["foo", "bar", "baz"]})
-    result = df.groupby("group", maintain_order=True).agg(pl.col("values").flatten())
+    result = df.groupby("group", maintain_order=True).agg(pl.col("values").str.explode())
 
     expected = pl.DataFrame(
         {

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1995,7 +1995,7 @@ def test_groupby_cat_list() -> None:
         .agg([pl.col("cat_column")])["cat_column"]
     )
 
-    out = grouped.str.explode()
+    out = grouped.explode()
     assert out.dtype == pl.Categorical
     assert out[0] == "a"
 


### PR DESCRIPTION
This was discussed earlier, but we were blocked on `Utf8`'s explode.

This formalizes `explode` as the opposite of `implode`.

- `implode` -> inceases nesting by 1 level
- `explode` -> decreases nesting by 1 level

## Breaking 1
This PR also changes the behavior of `explode` on a non-nested `Series`. In this case the non-nested state is the minimal nested level and seen as the identity. Previously we would error.

## Breaking 2
`explode` on a `Series` of dtype `Utf8` will now do nothing and return the same `Series` as the identity. To get the old behavor where a string `"foo"` was exploded to `"f", "o", "o"`, use `str.explode`.

