### PR TITLE
fix(rust, python): raise in to_datetime/strptime if format contains hour but not minute directive

### DIFF
--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -311,7 +311,7 @@ pub trait Utf8Methods: AsUtf8 {
             None => return infer::to_date(utf8_ca),
         };
         let cache = cache && utf8_ca.len() > 50;
-        let fmt = strptime::compile_fmt(fmt);
+        let fmt = strptime::compile_fmt(fmt)?;
         let mut cache_map = PlHashMap::new();
 
         // we can use the fast parser
@@ -393,7 +393,7 @@ pub trait Utf8Methods: AsUtf8 {
             Some(fmt) => fmt,
             None => return infer::to_datetime(utf8_ca, tu, tz),
         };
-        let fmt = strptime::compile_fmt(fmt);
+        let fmt = strptime::compile_fmt(fmt)?;
         let cache = cache && utf8_ca.len() > 50;
 
         let func = match tu {

--- a/polars/polars-time/src/chunkedarray/utf8/strptime.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/strptime.rs
@@ -2,7 +2,14 @@
 //!
 use atoi::FromRadix10;
 use chrono::{NaiveDate, NaiveDateTime};
+use once_cell::sync::Lazy;
 use polars_utils::slice::GetSaferUnchecked;
+use regex::Regex;
+
+use crate::chunkedarray::{polars_bail, PolarsResult};
+
+static HOUR_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"%[HI]").unwrap());
+static MINUTE_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"%M").unwrap());
 
 #[inline]
 fn update_and_parse<T: atoi::FromRadix10>(
@@ -44,12 +51,20 @@ fn parse_month_abbrev(val: &[u8], offset: usize) -> Option<(u32, usize)> {
 /// Tries to convert a chrono `fmt` to a `fmt` that the polars parser consumes.
 /// E.g. chrono supports single letter date identifiers like %F, whereas polars only consumes
 /// year, day, month distinctively with %Y, %d, %m.
-pub(super) fn compile_fmt(fmt: &str) -> String {
-    fmt.replace("%D", "%m/%d/%y")
+pub(super) fn compile_fmt(fmt: &str) -> PolarsResult<String> {
+    if HOUR_PATTERN.is_match(fmt) & !MINUTE_PATTERN.is_match(fmt) {
+        // (hopefully) temporary hack. Ideally, chrono would return a ParseKindError indicating
+        // if `fmt` is too long for NaiveDate. If that's implemented, then this check could
+        // be removed, and that error could be matched against in `transform_datetime_*s`
+        // See https://github.com/chronotope/chrono/issues/1075.
+        polars_bail!(ComputeError: "Invalid format string: found hour, but not minute directive");
+    }
+    Ok(fmt
+        .replace("%D", "%m/%d/%y")
         .replace("%R", "%H:%M")
         .replace("%T", "%H:%M:%S")
         .replace("%X", "%H:%M:%S")
-        .replace("%F", "%Y-%m-%d")
+        .replace("%F", "%Y-%m-%d"))
 }
 
 #[derive(Default, Clone)]

--- a/polars/polars-time/src/chunkedarray/utf8/strptime.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/strptime.rs
@@ -57,7 +57,8 @@ pub(super) fn compile_fmt(fmt: &str) -> PolarsResult<String> {
         // if `fmt` is too long for NaiveDate. If that's implemented, then this check could
         // be removed, and that error could be matched against in `transform_datetime_*s`
         // See https://github.com/chronotope/chrono/issues/1075.
-        polars_bail!(ComputeError: "Invalid format string: found hour, but not minute directive");
+        polars_bail!(ComputeError: "Invalid format string: found hour, but no minute directive. \
+            Please either specify both or neither.");
     }
     Ok(fmt
         .replace("%D", "%m/%d/%y")

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -447,6 +447,14 @@ def test_strptime_subseconds_datetime(data: str, format: str, expected: time) ->
     assert result == expected
 
 
+def test_strptime_hour_without_minute_8849() -> None:
+    with pytest.raises(
+        ComputeError,
+        match="Invalid format string: found hour, but not minute directive",
+    ):
+        pl.Series(["2023-05-04|7", "2023-05-04|10"]).str.to_datetime("%Y-%m-%d|%H")
+
+
 @pytest.mark.parametrize(
     ("data", "format", "expected"),
     [

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -450,7 +450,7 @@ def test_strptime_subseconds_datetime(data: str, format: str, expected: time) ->
 def test_strptime_hour_without_minute_8849() -> None:
     with pytest.raises(
         ComputeError,
-        match="Invalid format string: found hour, but not minute directive",
+        match="Invalid format string: found hour, but no minute directive",
     ):
         pl.Series(["2023-05-04|7", "2023-05-04|10"]).str.to_datetime("%Y-%m-%d|%H")
 


### PR DESCRIPTION
closes #8849 

alternative (and hopefully temporary) solution to https://github.com/pola-rs/polars/pull/8850