### PR TITLE
feat(python): Support more data types in lazy `repeat`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/lit.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/lit.rs
@@ -291,6 +291,12 @@ impl Literal for Series {
     }
 }
 
+impl Literal for LiteralValue {
+    fn lit(self) -> Expr {
+        Expr::Literal(self)
+    }
+}
+
 /// Create a Literal Expression from `L`. A literal expression behaves like a column that contains a single distinct
 /// value.
 ///

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime, time, timedelta
 from typing import Any
 
 import pytest
@@ -19,14 +19,13 @@ from polars.testing import assert_series_equal
         (True, 4, None, pl.Boolean),
         (None, 7, None, pl.Null),
         (0, 0, None, pl.Int32),
+        (datetime(2023, 2, 2), 3, None, pl.Datetime),
+        (date(2023, 2, 2), 3, None, pl.Date),
+        (time(10, 15), 1, None, pl.Time),
+        (timedelta(hours=3), 10, None, pl.Duration),
         (8, 2, pl.UInt8, pl.UInt8),
-        pytest.param(
-            datetime(2023, 2, 2),
-            3,
-            None,
-            pl.Datetime,
-            marks=pytest.mark.skip("Not implemented properly yet for lazy"),
-        ),
+        (date(2023, 2, 2), 3, pl.Datetime, pl.Datetime),
+        (7.5, 5, pl.UInt16, pl.UInt16),
     ],
 )
 def test_repeat(
@@ -35,7 +34,7 @@ def test_repeat(
     dtype: pl.PolarsDataType,
     expected_dtype: pl.PolarsDataType,
 ) -> None:
-    expected = pl.Series("repeat", [value] * n, dtype=expected_dtype)
+    expected = pl.Series("repeat", [value] * n).cast(expected_dtype)
 
     result_eager = pl.repeat(value, n=n, dtype=dtype, eager=True)
     assert_series_equal(result_eager, expected)


### PR DESCRIPTION
Changes:
* Rewrote the Rust bindings for `repeat_lazy` to use `AnyValue` conversion. Now it supports many more inputs, like temporal values for example.
* Extended test suite

Do we still need a separate eager implementation? We can also just do `pl.select(...).to_series()` on the lazy result. Would there be a difference in performance?