### PR TITLE
Remove extra multiplication and division operation for rounding for a specific case.

### DIFF
--- a/polars/polars-core/src/series/ops/round.rs
+++ b/polars/polars-core/src/series/ops/round.rs
@@ -21,11 +21,16 @@ impl Series {
             }
         }
         if let Ok(ca) = self.f64() {
-            let multiplier = 10.0.pow(decimals as f64);
-            let s = ca
-                .apply(|val| (val * multiplier).round() / multiplier)
-                .into_series();
-            return Ok(s);
+            if decimals == 0 {
+                let s = ca.apply(|val| val.round()).into_series();
+                return Ok(s);
+            } else {
+                let multiplier = 10.0.pow(decimals as f64);
+                let s = ca
+                    .apply(|val| (val * multiplier).round() / multiplier)
+                    .into_series();
+                return Ok(s);
+            }
         }
         polars_bail!(opq = round, self.dtype());
     }


### PR DESCRIPTION
This change avoids additional multiplication and division for an f64 Series when the decimals parameter for rounding is 0.

This is already done in the case when the series is for a f32, but not in the case for an f64.