### PR TITLE
refactor(python): Change eager path for `repeat`

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -2056,8 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "sqlparser"
-version = "0.33.0"
-source = "git+https://github.com/sqlparser-rs/sqlparser-rs.git?rev=ae3b5844c839072c235965fe0d1bddc473dced87#ae3b5844c839072c235965fe0d1bddc473dced87"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37d3706eefb17039056234df6b566b0014f303f867f2656108334a55b8096f59"
 dependencies = [
  "log",
 ]

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import warnings
-from typing import TYPE_CHECKING, NoReturn, overload
+from typing import TYPE_CHECKING, overload
 
 from polars import functions as F
 from polars.datatypes import Float64
@@ -40,24 +40,12 @@ def repeat(
 @overload
 def repeat(
     value: PythonLiteral | None,
-    n: int,
+    n: int | PolarsExprType,
     *,
     dtype: PolarsDataType | None = ...,
     eager: Literal[True],
     name: str | None = ...,
 ) -> Series:
-    ...
-
-
-@overload
-def repeat(
-    value: PythonLiteral | None,
-    n: PolarsExprType,
-    *,
-    dtype: PolarsDataType | None = ...,
-    eager: Literal[True],
-    name: str | None = ...,
-) -> NoReturn:
     ...
 
 
@@ -144,19 +132,13 @@ def repeat(
             stacklevel=find_stacklevel(),
         )
 
-    n_pyexpr = F.lit(n)._pyexpr if isinstance(n, int) else n._pyexpr
-    expr = wrap_expr(plr.repeat(value, n_pyexpr, dtype))
-
+    if isinstance(n, int):
+        n = F.lit(n)
+    expr = wrap_expr(plr.repeat(value, n._pyexpr, dtype))
     if name is not None:
         expr = expr.alias(name)
-
     if eager:
-        if not isinstance(n, int):
-            raise TypeError(
-                "`n` must be an integer when using `repeat` in an eager context."
-            )
         return F.select(expr).to_series()
-
     return expr
 
 
@@ -172,21 +154,11 @@ def ones(
 
 @overload
 def ones(
-    n: int,
+    n: int | PolarsExprType,
     dtype: PolarsDataType = ...,
     *,
     eager: Literal[True],
 ) -> Series:
-    ...
-
-
-@overload
-def ones(
-    n: PolarsExprType,
-    dtype: PolarsDataType = ...,
-    *,
-    eager: Literal[True],
-) -> NoReturn:
     ...
 
 
@@ -258,21 +230,11 @@ def zeros(
 
 @overload
 def zeros(
-    n: int,
+    n: int | PolarsExprType,
     dtype: PolarsDataType = ...,
     *,
     eager: Literal[True],
 ) -> Series:
-    ...
-
-
-@overload
-def zeros(
-    n: PolarsExprType,
-    dtype: PolarsDataType = ...,
-    *,
-    eager: Literal[True],
-) -> NoReturn:
     ...
 
 

--- a/py-polars/src/functions/eager.rs
+++ b/py-polars/src/functions/eager.rs
@@ -117,37 +117,6 @@ pub fn hor_concat_df(dfs: &PyAny) -> PyResult<PyDataFrame> {
 }
 
 #[pyfunction]
-pub fn repeat_eager(
-    value: Wrap<AnyValue>,
-    n: usize,
-    dtype: Option<Wrap<DataType>>,
-) -> PyResult<PySeries> {
-    let value = value.0;
-    let dtype = match dtype.map(|wrap| wrap.0) {
-        Some(dtype) => dtype,
-        None => match value.dtype() {
-            // Integer inputs that fit in Int32 are parsed as such
-            DataType::Int64 => {
-                let int_value: i64 = value.try_extract().unwrap();
-                if int_value >= i32::MIN as i64 && int_value <= i32::MAX as i64 {
-                    DataType::Int32
-                } else {
-                    DataType::Int64
-                }
-            }
-            DataType::Unknown => DataType::Null,
-            _ => value.dtype(),
-        },
-    };
-
-    Ok(Series::new("repeat", &[value])
-        .cast(&dtype)
-        .map_err(PyPolarsErr::from)?
-        .new_from_index(0, n)
-        .into())
-}
-
-#[pyfunction]
 pub fn time_range_eager(
     start: i64,
     stop: i64,

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -381,11 +381,7 @@ pub fn reduce(lambda: PyObject, exprs: Vec<PyExpr>) -> PyExpr {
 }
 
 #[pyfunction]
-pub fn repeat_lazy(
-    value: Wrap<AnyValue>,
-    n: PyExpr,
-    dtype: Option<Wrap<DataType>>,
-) -> PyResult<PyExpr> {
+pub fn repeat(value: Wrap<AnyValue>, n: PyExpr, dtype: Option<Wrap<DataType>>) -> PyResult<PyExpr> {
     let value = value.0;
     let n = n.inner;
     let dtype = dtype.map(|wrap| wrap.0);

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -87,8 +87,6 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::eager::hor_concat_df))
         .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::eager::repeat_eager))
-        .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::eager::time_range_eager))
         .unwrap();
 
@@ -155,7 +153,7 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::reduce))
         .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::lazy::repeat_lazy))
+    m.add_wrapped(wrap_pyfunction!(functions::lazy::repeat))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::spearman_rank_corr))
         .unwrap();

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -44,12 +44,14 @@ def test_repeat(
 
 
 def test_repeat_expr_input_eager() -> None:
-    with pytest.raises(TypeError):
-        pl.repeat(1, n=pl.lit(3), eager=True)
+    result = pl.select(pl.repeat(1, n=pl.lit(3), eager=True)).to_series()
+    expected = pl.Series("repeat", [1, 1, 1], dtype=pl.Int32)
+    assert_series_equal(result, expected)
 
 
 def test_repeat_expr_input_lazy() -> None:
-    result = pl.select(pl.repeat(1, n=pl.lit(3))).to_series()
+    df = pl.DataFrame({"a": [3, 2, 1]})
+    result = df.select(pl.repeat(1, n=pl.col("a"))).to_series()
     expected = pl.Series("repeat", [1, 1, 1], dtype=pl.Int32)
     assert_series_equal(result, expected)
 


### PR DESCRIPTION
Cleans up nicely!

EDIT: Had some story here but it didn't make much sense 😅 

`repeat` now also works with some `Expr` input, for example:

```
>>> pl.repeat(3, n=pl.lit(2), eager=True)
shape: (2,)
Series: 'repeat' [i32]
[
        3
        3
]
```

When running it in a context (e.g. `df.select`), then just set `eager=False` to make things work properly.