### PR TITLE
feat(rust, python)!: propagate null in equality comparisons

### DIFF
--- a/polars/polars-core/src/chunked_array/comparison/mod.rs
+++ b/polars/polars-core/src/chunked_array/comparison/mod.rs
@@ -224,47 +224,10 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
         match (self.len(), rhs.len()) {
             (_, 1) => {
                 if let Some(value) = rhs.get(0) {
-                    match value {
-                        true => {
-                            if self.null_count() == 0 {
-                                self.clone()
-                            } else {
-                                let chunks = self
-                                    .downcast_iter()
-                                    .map(|arr| {
-                                        if let Some(validity) = arr.validity() {
-                                            Box::new(BooleanArray::from_data_default(
-                                                arr.values() & validity,
-                                                None,
-                                            ))
-                                                as ArrayRef
-                                        } else {
-                                            Box::new(arr.clone())
-                                        }
-                                    })
-                                    .collect();
-                                unsafe { BooleanChunked::from_chunks("", chunks) }
-                            }
-                        }
-                        false => {
-                            if self.null_count() == 0 {
-                                self.not()
-                            } else {
-                                let chunks = self
-                                    .downcast_iter()
-                                    .map(|arr| {
-                                        let bitmap = if let Some(validity) = arr.validity() {
-                                            arr.values() ^ validity
-                                        } else {
-                                            arr.values().not()
-                                        };
-                                        Box::new(BooleanArray::from_data_default(bitmap, None))
-                                            as ArrayRef
-                                    })
-                                    .collect();
-                                unsafe { BooleanChunked::from_chunks("", chunks) }
-                            }
-                        }
+                    if value {
+                        self.clone()
+                    } else {
+                        self.not()
                     }
                 } else {
                     BooleanChunked::full_null("", self.len())
@@ -284,45 +247,10 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
         match (self.len(), rhs.len()) {
             (_, 1) => {
                 if let Some(value) = rhs.get(0) {
-                    match value {
-                        true => {
-                            if self.null_count() == 0 {
-                                self.not()
-                            } else {
-                                let chunks = self
-                                    .downcast_iter()
-                                    .map(|arr| {
-                                        let bitmap = if let Some(validity) = arr.validity() {
-                                            (arr.values() & validity).not()
-                                        } else {
-                                            arr.values().not()
-                                        };
-                                        Box::new(BooleanArray::from_data_default(bitmap, None))
-                                            as ArrayRef
-                                    })
-                                    .collect();
-                                unsafe { BooleanChunked::from_chunks("", chunks) }
-                            }
-                        }
-                        false => {
-                            if self.null_count() == 0 {
-                                self.clone()
-                            } else {
-                                let chunks = self
-                                    .downcast_iter()
-                                    .map(|arr| {
-                                        let bitmap = if let Some(validity) = arr.validity() {
-                                            (arr.values() ^ validity).not()
-                                        } else {
-                                            arr.values().clone()
-                                        };
-                                        Box::new(BooleanArray::from_data_default(bitmap, None))
-                                            as ArrayRef
-                                    })
-                                    .collect();
-                                unsafe { BooleanChunked::from_chunks("", chunks) }
-                            }
-                        }
+                    if value {
+                        self.not()
+                    } else {
+                        self.clone()
                     }
                 } else {
                     BooleanChunked::full_null("", self.len())
@@ -1176,22 +1104,22 @@ mod test {
         let all_true = BooleanChunked::from_slice("", &[true, true, true]);
         let all_false = BooleanChunked::from_slice("", &[false, false, false]);
         let out = a.equal(&true_);
-        assert_eq!(Vec::from(&out), &[Some(true), Some(false), Some(false)]);
+        assert_eq!(Vec::from(&out), &[Some(true), Some(false), None]);
         let out = a.not_equal(&true_);
-        assert_eq!(Vec::from(&out), &[Some(false), Some(true), Some(true)]);
+        assert_eq!(Vec::from(&out), &[Some(false), Some(true), None]);
 
         let out = a.equal(&all_true);
-        assert_eq!(Vec::from(&out), &[Some(true), Some(false), Some(false)]);
+        assert_eq!(Vec::from(&out), &[Some(true), Some(false), None]);
         let out = a.not_equal(&all_true);
-        assert_eq!(Vec::from(&out), &[Some(false), Some(true), Some(true)]);
+        assert_eq!(Vec::from(&out), &[Some(false), Some(true), None]);
         let out = a.equal(&false_);
-        assert_eq!(Vec::from(&out), &[Some(false), Some(true), Some(false)]);
+        assert_eq!(Vec::from(&out), &[Some(false), Some(true), None]);
         let out = a.not_equal(&false_);
-        assert_eq!(Vec::from(&out), &[Some(true), Some(false), Some(true)]);
+        assert_eq!(Vec::from(&out), &[Some(true), Some(false), None]);
         let out = a.equal(&all_false);
-        assert_eq!(Vec::from(&out), &[Some(false), Some(true), Some(false)]);
+        assert_eq!(Vec::from(&out), &[Some(false), Some(true), None]);
         let out = a.not_equal(&all_false);
-        assert_eq!(Vec::from(&out), &[Some(true), Some(false), Some(true)]);
+        assert_eq!(Vec::from(&out), &[Some(true), Some(false), None]);
     }
 
     #[test]

--- a/polars/polars-core/src/chunked_array/comparison/scalar.rs
+++ b/polars/polars-core/src/chunked_array/comparison/scalar.rs
@@ -76,10 +76,18 @@ where
 {
     type Item = BooleanChunked;
     fn equal(&self, rhs: Rhs) -> BooleanChunked {
+        self.primitive_compare_scalar(rhs, |l, rhs| comparison::eq_scalar(l, rhs))
+    }
+
+    fn equal_missing(&self, rhs: Rhs) -> BooleanChunked {
         self.primitive_compare_scalar(rhs, |l, rhs| comparison::eq_scalar_and_validity(l, rhs))
     }
 
     fn not_equal(&self, rhs: Rhs) -> BooleanChunked {
+        self.primitive_compare_scalar(rhs, |l, rhs| comparison::neq_scalar(l, rhs))
+    }
+
+    fn not_equal_missing(&self, rhs: Rhs) -> BooleanChunked {
         self.primitive_compare_scalar(rhs, |l, rhs| comparison::neq_scalar_and_validity(l, rhs))
     }
 
@@ -177,9 +185,18 @@ impl BinaryChunked {
 impl ChunkCompare<&[u8]> for BinaryChunked {
     type Item = BooleanChunked;
     fn equal(&self, rhs: &[u8]) -> BooleanChunked {
+        self.binary_compare_scalar(rhs, |l, rhs| comparison::eq_scalar(l, rhs))
+    }
+
+    fn equal_missing(&self, rhs: &[u8]) -> BooleanChunked {
         self.binary_compare_scalar(rhs, |l, rhs| comparison::eq_scalar_and_validity(l, rhs))
     }
+
     fn not_equal(&self, rhs: &[u8]) -> BooleanChunked {
+        self.binary_compare_scalar(rhs, |l, rhs| comparison::neq_scalar(l, rhs))
+    }
+
+    fn not_equal_missing(&self, rhs: &[u8]) -> BooleanChunked {
         self.binary_compare_scalar(rhs, |l, rhs| comparison::neq_scalar_and_validity(l, rhs))
     }
 

--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -425,8 +425,14 @@ pub trait ChunkCompare<Rhs> {
     /// Check for equality.
     fn equal(&self, rhs: Rhs) -> Self::Item;
 
+    /// Check for equality where `None == None`.
+    fn equal_missing(&self, rhs: Rhs) -> Self::Item;
+
     /// Check for inequality.
     fn not_equal(&self, rhs: Rhs) -> Self::Item;
+
+    /// Check for inequality where `None == None`.
+    fn not_equal_missing(&self, rhs: Rhs) -> Self::Item;
 
     /// Greater than comparison.
     fn gt(&self, rhs: Rhs) -> Self::Item;

--- a/polars/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -170,7 +170,7 @@ where
                         ))
                     }
                 } else {
-                    let mask = self.not_equal(&self.shift(1));
+                    let mask = self.not_equal_and_validity(&self.shift(1));
                     self.filter(&mask)
                 }
             }

--- a/polars/polars-core/src/series/comparison.rs
+++ b/polars/polars-core/src/series/comparison.rs
@@ -165,6 +165,62 @@ impl ChunkCompare<&Series> for Series {
         Ok(out)
     }
 
+    /// Create a boolean mask by checking for equality.
+    fn equal_missing(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
+        validate_types(self.dtype(), rhs.dtype())?;
+        use DataType::*;
+        let mut out = match (self.dtype(), rhs.dtype(), self.len(), rhs.len()) {
+            #[cfg(feature = "dtype-categorical")]
+            (Categorical(_), Utf8, _, 1) => {
+                return compare_cat_to_str_series(
+                    self,
+                    rhs,
+                    self.name(),
+                    |s, idx| s.equal_missing(idx),
+                    false,
+                );
+            }
+            #[cfg(feature = "dtype-categorical")]
+            (Utf8, Categorical(_), 1, _) => {
+                return compare_cat_to_str_series(
+                    rhs,
+                    self,
+                    self.name(),
+                    |s, idx| s.equal_missing(idx),
+                    false,
+                );
+            }
+            #[cfg(feature = "dtype-categorical")]
+            (Categorical(Some(rev_map_l)), Categorical(Some(rev_map_r)), _, _) => {
+                if rev_map_l.same_src(rev_map_r) {
+                    let rhs = rhs.categorical().unwrap().logical();
+
+                    // first check the rev-map
+                    if rhs.len() == 1 && rhs.null_count() == 0 {
+                        let rhs = rhs.get(0).unwrap();
+                        if rev_map_l.get_optional(rhs).is_none() {
+                            return Ok(BooleanChunked::full(self.name(), false, self.len()));
+                        }
+                    }
+
+                    self.categorical().unwrap().logical().equal_missing(rhs)
+                } else {
+                    polars_bail!(
+                        ComputeError:
+                        "cannot compare categoricals originating from different sources; \
+                        consider setting a global string cache"
+                    );
+                }
+            }
+            (Null, Null, _, _) => BooleanChunked::full(self.name(), true, self.len()),
+            _ => {
+                impl_compare!(self, rhs, equal_missing)
+            }
+        };
+        out.rename(self.name());
+        Ok(out)
+    }
+
     /// Create a boolean mask by checking for inequality.
     fn not_equal(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
         validate_types(self.dtype(), rhs.dtype())?;
@@ -212,9 +268,65 @@ impl ChunkCompare<&Series> for Series {
                     );
                 }
             }
-            (Null, Null, _, _) => BooleanChunked::full(self.name(), false, self.len()),
+            (Null, Null, _, _) => BooleanChunked::full_null(self.name(), self.len()),
             _ => {
                 impl_compare!(self, rhs, not_equal)
+            }
+        };
+        out.rename(self.name());
+        Ok(out)
+    }
+
+    /// Create a boolean mask by checking for inequality.
+    fn not_equal_missing(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
+        validate_types(self.dtype(), rhs.dtype())?;
+        use DataType::*;
+        let mut out = match (self.dtype(), rhs.dtype(), self.len(), rhs.len()) {
+            #[cfg(feature = "dtype-categorical")]
+            (Categorical(_), Utf8, _, 1) => {
+                return compare_cat_to_str_series(
+                    self,
+                    rhs,
+                    self.name(),
+                    |s, idx| s.not_equal_missing(idx),
+                    true,
+                );
+            }
+            #[cfg(feature = "dtype-categorical")]
+            (Utf8, Categorical(_), 1, _) => {
+                return compare_cat_to_str_series(
+                    rhs,
+                    self,
+                    self.name(),
+                    |s, idx| s.not_equal_missing(idx),
+                    true,
+                );
+            }
+            #[cfg(feature = "dtype-categorical")]
+            (Categorical(Some(rev_map_l)), Categorical(Some(rev_map_r)), _, _) => {
+                if rev_map_l.same_src(rev_map_r) {
+                    let rhs = rhs.categorical().unwrap().logical();
+
+                    // first check the rev-map
+                    if rhs.len() == 1 && rhs.null_count() == 0 {
+                        let rhs = rhs.get(0).unwrap();
+                        if rev_map_l.get_optional(rhs).is_none() {
+                            return Ok(BooleanChunked::full(self.name(), true, self.len()));
+                        }
+                    }
+
+                    self.categorical().unwrap().logical().not_equal_missing(rhs)
+                } else {
+                    polars_bail!(
+                        ComputeError:
+                        "cannot compare categoricals originating from different sources; \
+                        consider setting a global string cache"
+                    );
+                }
+            }
+            (Null, Null, _, _) => BooleanChunked::full(self.name(), false, self.len()),
+            _ => {
+                impl_compare!(self, rhs, not_equal_missing)
             }
         };
         out.rename(self.name());
@@ -266,10 +378,20 @@ where
         Ok(apply_method_physical_numeric!(&s, equal, rhs))
     }
 
+    fn equal_missing(&self, _rhs: Rhs) -> Self::Item {
+        // we are not doing this
+        unimplemented!()
+    }
+
     fn not_equal(&self, rhs: Rhs) -> PolarsResult<BooleanChunked> {
         validate_types(self.dtype(), &DataType::Int8)?;
         let s = self.to_physical_repr();
         Ok(apply_method_physical_numeric!(&s, not_equal, rhs))
+    }
+
+    fn not_equal_missing(&self, _rhs: Rhs) -> Self::Item {
+        // we are not doing this
+        unimplemented!()
     }
 
     fn gt(&self, rhs: Rhs) -> PolarsResult<BooleanChunked> {
@@ -326,6 +448,11 @@ impl ChunkCompare<&str> for Series {
         }
     }
 
+    fn equal_missing(&self, _rhs: &str) -> Self::Item {
+        // we are not doing this
+        unimplemented!()
+    }
+
     fn not_equal(&self, rhs: &str) -> PolarsResult<BooleanChunked> {
         validate_types(self.dtype(), &DataType::Utf8)?;
         use DataType::*;
@@ -341,6 +468,11 @@ impl ChunkCompare<&str> for Series {
             ),
             _ => Ok(BooleanChunked::full(self.name(), false, self.len())),
         }
+    }
+
+    fn not_equal_missing(&self, _rhs: &str) -> Self::Item {
+        // we are not doing this
+        unimplemented!()
     }
 
     fn gt(&self, rhs: &str) -> PolarsResult<BooleanChunked> {

--- a/polars/polars-core/src/series/comparison.rs
+++ b/polars/polars-core/src/series/comparison.rs
@@ -156,7 +156,7 @@ impl ChunkCompare<&Series> for Series {
                     );
                 }
             }
-            (Null, Null, _, _) => BooleanChunked::full(self.name(), true, self.len()),
+            (Null, Null, _, _) => BooleanChunked::full_null(self.name(), self.len()),
             _ => {
                 impl_compare!(self, rhs, equal)
             }

--- a/polars/polars-core/src/testing.rs
+++ b/polars/polars-core/src/testing.rs
@@ -179,7 +179,7 @@ impl PartialEq for DataFrame {
                 .columns
                 .iter()
                 .zip(other.columns.iter())
-                .all(|(s1, s2)| s1 == s2)
+                .all(|(s1, s2)| s1.series_equal_missing(s2))
     }
 }
 

--- a/polars/polars-core/src/testing.rs
+++ b/polars/polars-core/src/testing.rs
@@ -206,23 +206,6 @@ mod test {
     }
 
     #[test]
-    fn test_series_partialeq() {
-        let s1 = Series::new("a", &[1_i32, 2_i32, 3_i32]);
-        let s1_bis = Series::new("b", &[1_i32, 2_i32, 3_i32]);
-        let s1_ter = Series::new("a", &[1.0_f64, 2.0_f64, 3.0_f64]);
-        let s2 = Series::new("", &[Some(1), Some(0)]);
-        let s3 = Series::new("", &[Some(1), None]);
-        let s4 = Series::new("", &[1.0, f64::NAN]);
-
-        assert_eq!(s1, s1);
-        assert_ne!(s1, s1_bis);
-        assert_ne!(s1, s1_ter);
-        assert_eq!(s2, s2);
-        assert_ne!(s2, s3);
-        assert_ne!(s4, s4);
-    }
-
-    #[test]
     fn test_df_partialeq() {
         let df1 = df!("a" => &[1, 2, 3],
                       "b" => &[4, 5, 6])

--- a/polars/polars-core/src/testing.rs
+++ b/polars/polars-core/src/testing.rs
@@ -68,16 +68,7 @@ impl Series {
 
 impl PartialEq for Series {
     fn eq(&self, other: &Self) -> bool {
-        self.len() == other.len()
-            && self.field() == other.field()
-            && self.null_count() == other.null_count()
-            && self
-                .equal(other)
-                .unwrap()
-                .sum()
-                .map(|s| s as usize)
-                .unwrap_or(0)
-                == self.len()
+        self.series_equal_missing(other)
     }
 }
 

--- a/polars/polars-lazy/polars-plan/src/dsl/expr.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/expr.rs
@@ -451,7 +451,9 @@ impl Expr {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Operator {
     Eq,
+    EqValidity,
     NotEq,
+    NotEqValidity,
     Lt,
     LtEq,
     Gt,
@@ -473,7 +475,9 @@ impl Display for Operator {
         use Operator::*;
         let tkn = match self {
             Eq => "==",
+            EqValidity => "==v",
             NotEq => "!=",
+            NotEqValidity => "!=v",
             Lt => "<",
             LtEq => "<=",
             Gt => ">",
@@ -506,6 +510,8 @@ impl Operator {
                 | Self::And
                 | Self::Or
                 | Self::Xor
+                | Self::EqValidity
+                | Self::NotEqValidity
         )
     }
 

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -105,9 +105,19 @@ impl Expr {
         binary_expr(self, Operator::Eq, other.into())
     }
 
+    /// Compare `Expr` with other `Expr` on equality where `None == None`
+    pub fn eq_missing<E: Into<Expr>>(self, other: E) -> Expr {
+        binary_expr(self, Operator::EqValidity, other.into())
+    }
+
     /// Compare `Expr` with other `Expr` on non-equality
     pub fn neq<E: Into<Expr>>(self, other: E) -> Expr {
         binary_expr(self, Operator::NotEq, other.into())
+    }
+
+    /// Compare `Expr` with other `Expr` on non-equality where `None == None`
+    pub fn neq_missing<E: Into<Expr>>(self, other: E) -> Expr {
+        binary_expr(self, Operator::NotEqValidity, other.into())
     }
 
     /// Check if `Expr` < `Expr`

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -530,17 +530,17 @@ impl OptimizationRule for SimplifyExprRule {
                             None
                         }
                     }
-                    FloorDivide => None,
                     Modulus => eval_binary_same_type!(left_aexpr, %, right_aexpr),
                     Lt => eval_binary_bool_type!(left_aexpr, <, right_aexpr),
                     Gt => eval_binary_bool_type!(left_aexpr, >, right_aexpr),
-                    Eq => eval_binary_bool_type!(left_aexpr, ==, right_aexpr),
-                    NotEq => eval_binary_bool_type!(left_aexpr, !=, right_aexpr),
+                    Eq | EqValidity => eval_binary_bool_type!(left_aexpr, ==, right_aexpr),
+                    NotEq | NotEqValidity => eval_binary_bool_type!(left_aexpr, !=, right_aexpr),
                     GtEq => eval_binary_bool_type!(left_aexpr, >=, right_aexpr),
                     LtEq => eval_binary_bool_type!(left_aexpr, <=, right_aexpr),
                     And => eval_bitwise(left_aexpr, right_aexpr, |l, r| l & r),
                     Or => eval_bitwise(left_aexpr, right_aexpr, |l, r| l | r),
                     Xor => eval_bitwise(left_aexpr, right_aexpr, |l, r| l ^ r),
+                    FloorDivide => None,
                 };
                 if out.is_some() {
                     return Ok(out);

--- a/polars/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -73,6 +73,8 @@ pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> PolarsResu
         Operator::Or => left.bitor(right),
         Operator::Xor => left.bitxor(right),
         Operator::Modulus => Ok(left % right),
+        Operator::EqValidity => left.equal_missing(right).map(|ca| ca.into_series()),
+        Operator::NotEqValidity => left.not_equal_missing(right).map(|ca| ca.into_series()),
     }
 }
 

--- a/polars/tests/it/lazy/predicate_queries.rs
+++ b/polars/tests/it/lazy/predicate_queries.rs
@@ -39,7 +39,15 @@ fn filter_true_lit() -> PolarsResult<()> {
         .with_predicate_pushdown(false)
         .with_projection_pushdown(false)
         .collect()?;
+    let with_null = df
+        .clone()
+        .lazy()
+        .filter(col("a").is_null())
+        .with_predicate_pushdown(false)
+        .with_projection_pushdown(false)
+        .collect()?;
     let res = with_true.vstack(&with_not_true)?;
+    let res = res.vstack(&with_null)?;
     assert!(res.frame_equal_missing(&df));
     Ok(())
 }

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3772,6 +3772,20 @@ class Expr:
         """
         return self.__eq__(other)
 
+    def eq_missing(self, other: Any) -> Self:
+        """
+        Method equivalent of equality operator ``expr == other`` where `None` == None`.
+
+        This differs from default ``eq`` where null values are propagated.
+
+        Parameters
+        ----------
+        other
+            A literal or expression value to compare with.
+
+        """
+        return self._from_pyexpr(self._pyexpr.eq_missing(self._to_expr(other)._pyexpr))
+
     def ge(self, other: Any) -> Self:
         """
         Method equivalent of "greater than or equal" operator ``expr >= other``.
@@ -3946,6 +3960,20 @@ class Expr:
 
         """
         return self.__ne__(other)
+
+    def ne_missing(self, other: Any) -> Self:
+        """
+        Method equivalent of equality operator ``expr != other`` where `None` == None`.
+
+        This differs from default ``ne`` where null values are propagated.
+
+        Parameters
+        ----------
+        other
+            A literal or expression value to compare with.
+
+        """
+        return self._from_pyexpr(self._pyexpr.neq_missing(self._to_expr(other)._pyexpr))
 
     def add(self, other: Any) -> Self:
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -589,9 +589,51 @@ class Series:
         """Method equivalent of operator expression ``series == other``."""
         return self.__eq__(other)
 
+    @overload
+    def eq_missing(self, other: Any) -> Self:
+        ...
+
+    @overload
+    def eq_missing(self, other: Expr) -> Expr:  # type: ignore[misc]
+        ...
+
+    def eq_missing(self, other: Any) -> Self | Expr:
+        """
+        Method equivalent of equality operator ``expr == other`` where `None` == None`.
+
+        This differs from default ``ne`` where null values are propagated.
+
+        Parameters
+        ----------
+        other
+            A literal or expression value to compare with.
+
+        """
+
     def ne(self, other: Any) -> Self | Expr:
         """Method equivalent of operator expression ``series != other``."""
         return self.__ne__(other)
+
+    @overload
+    def ne_missing(self, other: Expr) -> Expr:  # type: ignore[misc]
+        ...
+
+    @overload
+    def ne_missing(self, other: Any) -> Self:
+        ...
+
+    def ne_missing(self, other: Any) -> Self | Expr:
+        """
+        Method equivalent of equality operator ``expr != other`` where `None` == None`.
+
+        This differs from default ``ne`` where null values are propagated.
+
+        Parameters
+        ----------
+        other
+            A literal or expression value to compare with.
+
+        """
 
     def ge(self, other: Any) -> Self | Expr:
         """Method equivalent of operator expression ``series >= other``."""

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -332,7 +332,7 @@ def _assert_series_inner(
         )
 
     # create mask of which (if any) values are unequal
-    unequal = left != right
+    unequal = left.ne_missing(right)
 
     # handle NaN values (which compare unequal to themselves)
     comparing_float_dtypes = left.dtype in FLOAT_DTYPES and right.dtype in FLOAT_DTYPES

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -326,6 +326,11 @@ def _assert_series_inner(
     if check_dtype and left.dtype != right.dtype:
         raise_assert_detail("Series", "Dtype mismatch", left.dtype, right.dtype)
 
+    if left.null_count() != right.null_count():
+        raise_assert_detail(
+            "Series", "null_count is not equal", left.null_count(), right.null_count()
+        )
+
     # create mask of which (if any) values are unequal
     unequal = left != right
 

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -51,8 +51,15 @@ impl PyExpr {
     fn eq(&self, other: Self) -> Self {
         self.clone().inner.eq(other.inner).into()
     }
+
+    fn eq_missing(&self, other: Self) -> Self {
+        self.clone().inner.eq_missing(other.inner).into()
+    }
     fn neq(&self, other: Self) -> Self {
         self.clone().inner.neq(other.inner).into()
+    }
+    fn neq_missing(&self, other: Self) -> Self {
+        self.clone().inner.neq_missing(other.inner).into()
     }
     fn gt(&self, other: Self) -> Self {
         self.clone().inner.gt(other.inner).into()

--- a/py-polars/tests/benchmark/run_h2oai_benchmark.py
+++ b/py-polars/tests/benchmark/run_h2oai_benchmark.py
@@ -293,7 +293,7 @@ assert out.shape == (9999995, 8)
 # but it triggers other code paths so the checksums assertion
 # are a sort of integration tests
 out = (
-    x.filter(pl.col("id1") == pl.lit("id046"))
+    x.filter(pl.col("id1").eq_missing(pl.lit("id046")))
     .select([pl.sum("id6"), pl.sum("v3")])
     .collect()
 )
@@ -302,7 +302,7 @@ assert np.isclose(out["v3"].to_list(), 4.724150165888001e6).all()
 print(out)
 
 out = (
-    x.filter(~(pl.col("id1") == pl.lit("id046")))
+    x.filter(~(pl.col("id1").eq_missing(pl.lit("id046"))))
     .select([pl.sum("id6"), pl.sum("v3")])
     .collect()
 )

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -177,7 +177,7 @@ def test_diff_datetime() -> None:
             pl.col("timestamp").str.strptime(pl.Date, format="%Y-%m-%d"),
         ).with_columns(pl.col("timestamp").diff().over("char", mapping_strategy="join"))
     )["timestamp"]
-    assert (out[0] == out[1]).all()
+    assert_series_equal(out[0], out[1])
 
 
 def test_from_pydatetime() -> None:

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1106,7 +1106,7 @@ def test_csv_categorical_lifetime() -> None:
         "b": ["b", "b", None],
     }
 
-    assert (df["a"] == df["b"]).to_list() == [False, False, False]
+    assert (df["a"] == df["b"]).to_list() == [False, False, None]
 
 
 def test_csv_categorical_categorical_merge() -> None:

--- a/py-polars/tests/unit/operations/test_comparison.py
+++ b/py-polars/tests/unit/operations/test_comparison.py
@@ -43,8 +43,8 @@ def test_comparison_nulls_single() -> None:
             "c": pl.Series([None], dtype=pl.Boolean),
         }
     )
-    assert (df1 == df2).row(0) == (True, True, True)
-    assert (df1 != df2).row(0) == (False, False, False)
+    assert (df1 == df2).row(0) == (None, None, None)
+    assert (df1 != df2).row(0) == (None, None, None)
 
 
 def test_comparison_series_expr() -> None:

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -2504,8 +2504,8 @@ def test_ptr() -> None:
 
 def test_null_comparisons() -> None:
     s = pl.Series("s", [None, "str", "a"])
-    assert (s.shift() == s).null_count() == 0
-    assert (s.shift() != s).null_count() == 0
+    assert (s.shift() == s).null_count() == 2
+    assert (s.shift() != s).null_count() == 2
 
 
 def test_min_max_agg_on_str() -> None:

--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -98,35 +98,33 @@ def test_compare_series_nulls() -> None:
     srs2 = pl.Series([1, None, None])
     assert_series_not_equal(srs1, srs2)
 
-    with pytest.raises(AssertionError, match="Value mismatch"):
+    with pytest.raises(AssertionError, match="null_count is not equal"):
         assert_series_equal(srs1, srs2)
-    with pytest.raises(AssertionError, match="Exact value mismatch"):
-        assert_series_equal(srs1, srs2, check_exact=True)
 
 
 def test_series_cmp_fast_paths() -> None:
     assert (
         pl.Series([None], dtype=pl.Int32) != pl.Series([1, 2], dtype=pl.Int32)
-    ).to_list() == [True, True]
+    ).to_list() == [None, None]
     assert (
         pl.Series([None], dtype=pl.Int32) == pl.Series([1, 2], dtype=pl.Int32)
-    ).to_list() == [False, False]
+    ).to_list() == [None, None]
 
     assert (
         pl.Series([None], dtype=pl.Utf8) != pl.Series(["a", "b"], dtype=pl.Utf8)
-    ).to_list() == [True, True]
+    ).to_list() == [None, None]
     assert (
         pl.Series([None], dtype=pl.Utf8) == pl.Series(["a", "b"], dtype=pl.Utf8)
-    ).to_list() == [False, False]
+    ).to_list() == [None, None]
 
     assert (
         pl.Series([None], dtype=pl.Boolean)
         != pl.Series([True, False], dtype=pl.Boolean)
-    ).to_list() == [True, True]
+    ).to_list() == [None, None]
     assert (
         pl.Series([None], dtype=pl.Boolean)
         == pl.Series([False, False], dtype=pl.Boolean)
-    ).to_list() == [False, False]
+    ).to_list() == [None, None]
 
 
 def test_compare_series_value_mismatch_string() -> None:


### PR DESCRIPTION
closes #8182

Was a bit strange to propagate null values in order comparisons `<, <=`, but not in equality. Now we follow the same rules for all comparisons and we do what (most?) database engines do.