### PR TITLE
feat(rust): Add feature to compare two dataframes elementwise

### DIFF
--- a/polars/polars-core/src/frame/comparison.rs
+++ b/polars/polars-core/src/frame/comparison.rs
@@ -29,6 +29,6 @@ impl DataFrame {
         impl_compare!(self, rhf, gt_eq)
     }
     pub fn lt_eq(&self, rhf: &DataFrame) -> PolarsResult<Self> {
-        impl_compare!(self, rhf, gt_eq)
+        impl_compare!(self, rhf, lt_eq)
     }
 }

--- a/polars/polars-core/src/frame/comparison.rs
+++ b/polars/polars-core/src/frame/comparison.rs
@@ -1,0 +1,34 @@
+use crate::prelude::*;
+
+macro_rules! impl_compare {
+    ($self:expr, $rhf:expr, $method:ident) => {{
+        DataFrame::new(
+            $self
+                .iter()
+                .zip($rhf.iter())
+                .map(|(lhs, rhs)| lhs.$method(rhs).unwrap())
+                .collect(),
+        )
+    }};
+}
+
+impl DataFrame {
+    pub fn equal(&self, rhf: &DataFrame) -> PolarsResult<Self> {
+        impl_compare!(self, rhf, equal)
+    }
+    pub fn not_equal(&self, rhf: &DataFrame) -> PolarsResult<Self> {
+        impl_compare!(self, rhf, not_equal)
+    }
+    pub fn gt(&self, rhf: &DataFrame) -> PolarsResult<Self> {
+        impl_compare!(self, rhf, gt)
+    }
+    pub fn lt(&self, rhf: &DataFrame) -> PolarsResult<Self> {
+        impl_compare!(self, rhf, lt)
+    }
+    pub fn gt_eq(&self, rhf: &DataFrame) -> PolarsResult<Self> {
+        impl_compare!(self, rhf, gt_eq)
+    }
+    pub fn lt_eq(&self, rhf: &DataFrame) -> PolarsResult<Self> {
+        impl_compare!(self, rhf, gt_eq)
+    }
+}

--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -18,6 +18,7 @@ mod arithmetic;
 #[cfg(feature = "asof_join")]
 pub(crate) mod asof_join;
 mod chunks;
+mod comparison;
 #[cfg(feature = "cross_join")]
 pub(crate) mod cross_join;
 pub mod explode;


### PR DESCRIPTION
Implements #5767 

```rust
let df_a = df!("a" => &[1, 2, 3], "b" => &[4, 5, 6]).unwrap();
let df_b = df!("a" => &[0, 2, 4], "b" => &[5, 5, 5]).unwrap();

df_a.gt_eq(&df_b)

Ok(
    shape: (3, 2)
    ┌───────┬───────┐
    │ a     ┆ b     │
    │ ---   ┆ ---   │
    │ bool  ┆ bool  │
    ╞═══════╪═══════╡
    │ true  ┆ false │
    │ true  ┆ true  │
    │ false ┆ true  │
    └───────┴───────┘,
)

```


Not sure if this is the accepted way to implement this, I followed the example of the Series level implementation..