### PR TITLE
feat(rust, python): default to checking sortedness in groupby_rolling…

### DIFF
--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -680,6 +680,7 @@ mod test {
                         period: Duration::parse("2d"),
                         offset: Duration::parse("-2d"),
                         closed_window: ClosedWindow::Right,
+                        ..Default::default()
                     },
                 )
                 .unwrap();
@@ -720,6 +721,7 @@ mod test {
                     period: Duration::parse("2d"),
                     offset: Duration::parse("-2d"),
                     closed_window: ClosedWindow::Right,
+                    ..Default::default()
                 },
             )
             .unwrap();
@@ -801,6 +803,7 @@ mod test {
                     include_boundaries: true,
                     closed_window: ClosedWindow::Both,
                     start_by: Default::default(),
+                    ..Default::default()
                 },
             )
             .unwrap();
@@ -915,6 +918,7 @@ mod test {
                     include_boundaries: true,
                     closed_window: ClosedWindow::Both,
                     start_by: Default::default(),
+                    ..Default::default()
                 },
             )
             .unwrap();

--- a/polars/polars-time/src/groupby/dynamic.rs
+++ b/polars/polars-time/src/groupby/dynamic.rs
@@ -132,8 +132,9 @@ impl Wrap<&DataFrame> {
         options: &RollingGroupOptions,
     ) -> PolarsResult<(Series, Vec<Series>, GroupsProxy)> {
         let time = self.0.column(&options.index_column)?.clone();
-        if by.is_empty() && !options.period.parsed_int {
+        if by.is_empty() {
             // if by is given, the column must be sorted in the 'by' arg, which we can not check now
+            // this will be checked when the groups are materialized
             ensure_sorted_arg(&time, "groupby_rolling")?;
         }
         let time_type = time.dtype();
@@ -207,8 +208,9 @@ impl Wrap<&DataFrame> {
         }
 
         let time = self.0.column(&options.index_column)?.rechunk();
-        if by.is_empty() && !options.period.parsed_int {
+        if by.is_empty() {
             // if by is given, the column must be sorted in the 'by' arg, which we can not check now
+            // this will be checked when the groups are materialized
             ensure_sorted_arg(&time, "groupby_dynamic")?;
         }
         let time_type = time.dtype();

--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -244,15 +244,10 @@ pub(crate) fn groupby_values_iter_full_lookbehind<'a>(
     };
 
     let mut last_lookbehind_i = 0;
-    let mut last = i64::MIN;
     time[start_offset..]
         .iter()
         .enumerate()
         .map(move |(mut i, lower)| {
-            if *lower < last {
-                panic!("index column of 'groupby_rolling' must be sorted in ascending order!")
-            }
-            last = *lower;
             i += start_offset;
             let lower = add(&offset, *lower, tz.as_ref())?;
             let upper = add(&period, lower, tz.as_ref())?;

--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -1,10 +1,7 @@
-use std::cmp::Ordering;
-
 #[cfg(feature = "timezones")]
 use chrono_tz::Tz;
 use polars_arrow::time_zone::PolarsTimeZone;
 use polars_arrow::trusted_len::TrustedLen;
-use polars_arrow::utils::CustomIterTools;
 use polars_core::export::rayon::prelude::*;
 use polars_core::prelude::*;
 use polars_core::utils::_split_offsets;
@@ -416,16 +413,6 @@ pub(crate) fn groupby_values_iter_full_lookahead<'a>(
         })
 }
 
-pub(crate) fn partially_check_sorted(time: &[i64]) {
-    // check sortedness of a small subslice.
-    if time.len() > 1 {
-        assert!(time[..std::cmp::min(time.len(), 10)].windows(2).filter_map(|w| match w[0].cmp(&w[1]) {
-            Ordering::Equal => None,
-            t => Some(t)
-        }).all_equal(), "Subslice check showed that the values in `groupby_rolling/groupby_dynamic` were not sorted. Pleasure ensure the index column is sorted.");
-    }
-}
-
 #[cfg(feature = "rolling_window")]
 pub(crate) fn groupby_values_iter<'a>(
     period: Duration,
@@ -435,7 +422,6 @@ pub(crate) fn groupby_values_iter<'a>(
     tu: TimeUnit,
     tz: Option<impl PolarsTimeZone + 'a>,
 ) -> Box<dyn TrustedLen<Item = PolarsResult<(IdxSize, IdxSize)>> + 'a> {
-    partially_check_sorted(time);
     // we have a (partial) lookbehind window
     if offset.negative {
         // only lookbehind
@@ -478,7 +464,6 @@ pub fn groupby_values<'a>(
     tu: TimeUnit,
     tz: Option<impl PolarsTimeZone + 'a>,
 ) -> PolarsResult<GroupsSlice> {
-    partially_check_sorted(time);
     let thread_offsets = _split_offsets(time.len(), POOL.current_num_threads());
 
     // we have a (partial) lookbehind window

--- a/polars/polars-utils/src/slice.rs
+++ b/polars/polars-utils/src/slice.rs
@@ -18,6 +18,29 @@ impl<T: PartialOrd> Extrema<T> for [T] {
     }
 }
 
+pub trait SortedSlice<T> {
+    fn is_sorted_ascending(&self) -> bool;
+}
+
+impl<T: PartialOrd + Copy> SortedSlice<T> for [T] {
+    fn is_sorted_ascending(&self) -> bool {
+        if self.is_empty() {
+            true
+        } else {
+            let mut previous = self[0];
+            let mut sorted = true;
+
+            // don't early stop or branch
+            // so it autovectorizes
+            for &v in &self[1..] {
+                sorted &= previous <= v;
+                previous = v;
+            }
+            sorted
+        }
+    }
+}
+
 pub trait GetSaferUnchecked<T> {
     /// # Safety
     ///

--- a/polars/tests/it/lazy/queries.rs
+++ b/polars/tests/it/lazy/queries.rs
@@ -43,6 +43,7 @@ fn test_special_groupby_schemas() -> PolarsResult<()> {
     let out = df
         .clone()
         .lazy()
+        .with_column(col("a").set_sorted_flag(IsSorted::Ascending))
         .groupby_rolling(
             col("a"),
             [],
@@ -67,6 +68,7 @@ fn test_special_groupby_schemas() -> PolarsResult<()> {
 
     let out = df
         .lazy()
+        .with_column(col("a").set_sorted_flag(IsSorted::Ascending))
         .groupby_dynamic(
             col("a"),
             [],

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4763,6 +4763,7 @@ class DataFrame:
         offset: str | timedelta | None = None,
         closed: ClosedInterval = "right",
         by: IntoExpr | Iterable[IntoExpr] | None = None,
+        check_sorted: bool = True,
     ) -> RollingGroupBy:
         """
         Create rolling groups based on a time column.
@@ -4819,6 +4820,12 @@ class DataFrame:
             Define which sides of the temporal interval are closed (inclusive).
         by
             Also group by this column/these columns
+        check_sorted
+            When the ``by`` argument is given, polars can not check sortedness
+            by the metadata and has to do a full scan on the index column to
+            verify data is sorted. This is expensive. If you are sure the
+            data within the by groups is sorted, you can set this to ``False``.
+            Doing so incorrectly will lead to incorrect output
 
         Returns
         -------
@@ -4870,7 +4877,9 @@ class DataFrame:
         └─────────────────────┴───────┴───────┴───────┘
 
         """
-        return RollingGroupBy(self, index_column, period, offset, closed, by)
+        return RollingGroupBy(
+            self, index_column, period, offset, closed, by, check_sorted
+        )
 
     def groupby_dynamic(
         self,
@@ -4884,6 +4893,7 @@ class DataFrame:
         closed: ClosedInterval = "left",
         by: IntoExpr | Iterable[IntoExpr] | None = None,
         start_by: StartBy = "window",
+        check_sorted: bool = True,
     ) -> DynamicGroupBy:
         """
         Group based on a time value (or index value of type Int32, Int64).
@@ -4966,6 +4976,12 @@ class DataFrame:
             - 'tuesday': Start the window on the tuesday before the first data point.
             - ...
             - 'sunday': Start the window on the sunday before the first data point.
+        check_sorted
+            When the ``by`` argument is given, polars can not check sortedness
+            by the metadata and has to do a full scan on the index column to
+            verify data is sorted. This is expensive. If you are sure the
+            data within the by groups is sorted, you can set this to ``False``.
+            Doing so incorrectly will lead to incorrect output
 
         Returns
         -------
@@ -5171,6 +5187,7 @@ class DataFrame:
             closed,
             by,
             start_by,
+            check_sorted,
         )
 
     def upsample(

--- a/py-polars/polars/dataframe/groupby.py
+++ b/py-polars/polars/dataframe/groupby.py
@@ -765,6 +765,7 @@ class RollingGroupBy:
         offset: str | timedelta | None,
         closed: ClosedInterval,
         by: IntoExpr | Iterable[IntoExpr] | None,
+        check_sorted: bool,
     ):
         period = _timedelta_to_pl_duration(period)
         offset = _timedelta_to_pl_duration(offset)
@@ -775,6 +776,7 @@ class RollingGroupBy:
         self.offset = offset
         self.closed = closed
         self.by = by
+        self.check_sorted = check_sorted
 
     def __iter__(self) -> Self:
         temp_col = "__POLARS_GB_GROUP_INDICES"
@@ -787,6 +789,7 @@ class RollingGroupBy:
                 offset=self.offset,
                 closed=self.closed,
                 by=self.by,
+                check_sorted=self.check_sorted,
             )
             .agg(F.col(temp_col))
             .collect(no_optimization=True)
@@ -833,6 +836,7 @@ class RollingGroupBy:
                 offset=self.offset,
                 closed=self.closed,
                 by=self.by,
+                check_sorted=self.check_sorted,
             )
             .agg(aggs, *more_aggs, **named_aggs)
             .collect(no_optimization=True)
@@ -927,6 +931,7 @@ class RollingGroupBy:
                 offset=self.offset,
                 closed=self.closed,
                 by=self.by,
+                check_sorted=self.check_sorted,
             )
             .apply(function, schema)
             .collect(no_optimization=True)
@@ -953,6 +958,7 @@ class DynamicGroupBy:
         closed: ClosedInterval,
         by: IntoExpr | Iterable[IntoExpr] | None,
         start_by: StartBy,
+        check_sorted: bool,
     ):
         period = _timedelta_to_pl_duration(period)
         offset = _timedelta_to_pl_duration(offset)
@@ -968,6 +974,7 @@ class DynamicGroupBy:
         self.closed = closed
         self.by = by
         self.start_by = start_by
+        self.check_sorted = check_sorted
 
     def __iter__(self) -> Self:
         temp_col = "__POLARS_GB_GROUP_INDICES"
@@ -984,6 +991,7 @@ class DynamicGroupBy:
                 closed=self.closed,
                 by=self.by,
                 start_by=self.start_by,
+                check_sorted=self.check_sorted,
             )
             .agg(F.col(temp_col))
             .collect(no_optimization=True)
@@ -1034,6 +1042,7 @@ class DynamicGroupBy:
                 closed=self.closed,
                 by=self.by,
                 start_by=self.start_by,
+                check_sorted=self.check_sorted,
             )
             .agg(aggs, *more_aggs, **named_aggs)
             .collect(no_optimization=True)
@@ -1132,6 +1141,7 @@ class DynamicGroupBy:
                 closed=self.closed,
                 by=self.by,
                 start_by=self.start_by,
+                check_sorted=self.check_sorted,
             )
             .apply(function, schema)
             .collect(no_optimization=True)

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3505,7 +3505,7 @@ class Expr:
 
     def explode(self) -> Self:
         """
-        Explode a list or utf8 Series.
+        Explode a list Series.
 
         This means that every item is expanded to a new row.
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2157,6 +2157,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         offset: str | timedelta | None = None,
         closed: ClosedInterval = "right",
         by: IntoExpr | Iterable[IntoExpr] | None = None,
+        check_sorted: bool = True,
     ) -> LazyGroupBy:
         """
         Create rolling groups based on a time column.
@@ -2213,6 +2214,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Define which sides of the temporal interval are closed (inclusive).
         by
             Also group by this column/these columns
+        check_sorted
+            When the ``by`` argument is given, polars can not check sortedness
+            by the metadata and has to do a full scan on the index column to
+            verify data is sorted. This is expensive. If you are sure the
+            data within the by groups is sorted, you can set this to ``False``.
+            Doing so incorrectly will lead to incorrect output
 
         Returns
         -------
@@ -2277,7 +2284,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         offset = _timedelta_to_pl_duration(offset)
 
         lgb = self._ldf.groupby_rolling(
-            index_column._pyexpr, period, offset, closed, pyexprs_by
+            index_column._pyexpr, period, offset, closed, pyexprs_by, check_sorted
         )
         return LazyGroupBy(lgb)
 
@@ -2293,6 +2300,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         closed: ClosedInterval = "left",
         by: IntoExpr | Iterable[IntoExpr] | None = None,
         start_by: StartBy = "window",
+        check_sorted: bool = True,
     ) -> LazyGroupBy:
         """
         Group based on a time value (or index value of type Int32, Int64).
@@ -2375,6 +2383,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             * 'tuesday': Start the window on the tuesday before the first data point.
             * ...
             * 'sunday': Start the window on the sunday before the first data point.
+        check_sorted
+            When the ``by`` argument is given, polars can not check sortedness
+            by the metadata and has to do a full scan on the index column to
+            verify data is sorted. This is expensive. If you are sure the
+            data within the by groups is sorted, you can set this to ``False``.
+            Doing so incorrectly will lead to incorrect output
 
         Returns
         -------
@@ -2595,6 +2609,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             closed,
             pyexprs_by,
             start_by,
+            check_sorted,
         )
         return LazyGroupBy(lgb)
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2900,7 +2900,7 @@ class Series:
 
     def explode(self) -> Series:
         """
-        Explode a list or utf8 Series.
+        Explode a list Series.
 
         This means that every item is expanded to a new row.
 

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -510,6 +510,7 @@ impl PyLazyFrame {
         offset: &str,
         closed: Wrap<ClosedWindow>,
         by: Vec<PyExpr>,
+        check_sorted: bool,
     ) -> PyLazyGroupBy {
         let closed_window = closed.0;
         let ldf = self.ldf.clone();
@@ -525,6 +526,7 @@ impl PyLazyFrame {
                 period: Duration::parse(period),
                 offset: Duration::parse(offset),
                 closed_window,
+                check_sorted,
             },
         );
 
@@ -543,6 +545,7 @@ impl PyLazyFrame {
         closed: Wrap<ClosedWindow>,
         by: Vec<PyExpr>,
         start_by: Wrap<StartBy>,
+        check_sorted: bool,
     ) -> PyLazyGroupBy {
         let closed_window = closed.0;
         let by = by
@@ -561,6 +564,7 @@ impl PyLazyFrame {
                 include_boundaries,
                 closed_window,
                 start_by: start_by.0,
+                check_sorted,
                 ..Default::default()
             },
         );

--- a/py-polars/tests/unit/operations/test_groupby_rolling.py
+++ b/py-polars/tests/unit/operations/test_groupby_rolling.py
@@ -27,7 +27,7 @@ def test_groupby_rolling_apply() -> None:
             "a": [1, 2, 3, 4, 5],
             "b": [1, 2, 3, 4, 5],
         }
-    )
+    ).set_sorted("a")
 
     def apply(df: pl.DataFrame) -> pl.DataFrame:
         return df.select(
@@ -193,6 +193,20 @@ def test_groupby_rolling_dynamic_sortedness_check() -> None:
         )
 
     with pytest.raises(pl.ComputeError, match=r"input data is not sorted"):
-        df.groupby_rolling("idx", period="2i", by="group", check_sorted=False).agg(
+        df.groupby_rolling("idx", period="2i", by="group").agg(
             pl.col("idx").alias("idx1")
         )
+
+    # no `by` argument
+    with pytest.raises(
+        pl.InvalidOperationError,
+        match=r"argument in operation 'groupby_dynamic' is not explicitly sorted",
+    ):
+        df.groupby_dynamic("idx", every="2i").agg(pl.col("idx").alias("idx1"))
+
+    # no `by` argument
+    with pytest.raises(
+        pl.InvalidOperationError,
+        match=r"argument in operation 'groupby_rolling' is not explicitly sorted",
+    ):
+        df.groupby_rolling("idx", period="2i").agg(pl.col("idx").alias("idx1"))


### PR DESCRIPTION
…/dynamic with by arg


Drive bys:

- faster materialization groupby_rolling/dynamic
- more integers to integer casts keep sortedness info
