### PR TITLE
fix(rust, python): rolling_groupy was returning incorrect results when offset was positive

### DIFF
--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -355,7 +355,7 @@ pub(crate) fn groupby_values_iter_partial_lookbehind<'a>(
         let b = Bounds::new(lower, upper);
 
         for &t in &time[lagging_offset..] {
-            if b.is_member(t, closed_window) || lagging_offset == i {
+            if b.is_member(t, closed_window) || (offset.negative && lagging_offset == i) {
                 break;
             }
             lagging_offset += 1;
@@ -408,7 +408,7 @@ pub(crate) fn groupby_values_iter_full_lookahead<'a>(
                 i += 1;
             }
             if i >= time.len() {
-                return Ok((0, 0));
+                return Ok((i as IdxSize, 0));
             }
             let slice = unsafe { time.get_unchecked(i..) };
             let len = slice.partition_point(|v| b.is_member(*v, closed_window));

--- a/polars/polars-time/src/windows/groupby.rs
+++ b/polars/polars-time/src/windows/groupby.rs
@@ -400,7 +400,16 @@ pub(crate) fn groupby_values_iter_full_lookahead<'a>(
 
             let b = Bounds::new(lower, upper);
 
-            debug_assert!(i < time.len());
+            // find starting point of window
+            for &t in &time[i..] {
+                if b.is_member(t, closed_window) {
+                    break;
+                }
+                i += 1;
+            }
+            if i >= time.len() {
+                return Ok((0, 0));
+            }
             let slice = unsafe { time.get_unchecked(i..) };
             let len = slice.partition_point(|v| b.is_member(*v, closed_window));
 

--- a/polars/polars-time/src/windows/test.rs
+++ b/polars/polars-time/src/windows/test.rs
@@ -690,15 +690,15 @@ fn test_rolling_lookback() {
     )
     .unwrap();
     assert_eq!(dates.len(), groups.len());
-    assert_eq!(groups[0], [0, 5]);
-    assert_eq!(groups[1], [1, 5]);
-    assert_eq!(groups[2], [2, 5]);
-    assert_eq!(groups[3], [3, 5]);
-    assert_eq!(groups[4], [4, 5]);
-    assert_eq!(groups[5], [5, 4]);
-    assert_eq!(groups[6], [6, 3]);
-    assert_eq!(groups[7], [7, 2]);
-    assert_eq!(groups[8], [8, 0]);
+    assert_eq!(groups[0], [1, 4]); // (00:00, 02:00]
+    assert_eq!(groups[1], [2, 4]); // (00:30, 02:30]
+    assert_eq!(groups[2], [3, 4]); // (01:00, 03:00]
+    assert_eq!(groups[3], [4, 4]); // (01:30, 03:30]
+    assert_eq!(groups[4], [5, 4]); // (02:00, 04:00]
+    assert_eq!(groups[5], [6, 3]); // (02:30, 04:30]
+    assert_eq!(groups[6], [7, 2]); // (03:00, 05:00]
+    assert_eq!(groups[7], [8, 1]); // (03:30, 05:30]
+    assert_eq!(groups[8], [9, 0]); // (04:00, 06:00]
 
     let period = Duration::parse("2h");
     let tu = TimeUnit::Milliseconds;

--- a/polars/polars-time/src/windows/test.rs
+++ b/polars/polars-time/src/windows/test.rs
@@ -708,31 +708,6 @@ fn test_rolling_lookback() {
         ClosedWindow::Both,
         ClosedWindow::None,
     ] {
-        let offset = Duration::parse("0h");
-        let g0 = groupby_values_iter_full_lookahead(
-            period,
-            offset,
-            &dates,
-            closed_window,
-            tu,
-            NO_TIMEZONE.copied(),
-            0,
-            None,
-        )
-        .collect::<PolarsResult<Vec<_>>>()
-        .unwrap();
-        let g1 = groupby_values_iter_partial_lookbehind(
-            period,
-            offset,
-            &dates,
-            closed_window,
-            tu,
-            NO_TIMEZONE.copied(),
-        )
-        .collect::<PolarsResult<Vec<_>>>()
-        .unwrap();
-        assert_eq!(g0, g1);
-
         let offset = Duration::parse("-2h");
         let g0 = groupby_values_iter_full_lookbehind(
             period,

--- a/py-polars/tests/unit/operations/test_groupby_rolling.py
+++ b/py-polars/tests/unit/operations/test_groupby_rolling.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.type_aliases import ClosedInterval
 
 
 def bad_agg_parameters() -> list[Any]:
@@ -193,7 +196,7 @@ def test_groupby_rolling_negative_offset_crossing_dst(time_zone: str | None) -> 
 def test_groupby_rolling_non_negative_offset_9077(
     time_zone: str | None,
     offset: str,
-    closed: str,
+    closed: ClosedInterval,
     expected_values: list[list[int]],
 ) -> None:
     df = pl.DataFrame(

--- a/py-polars/tests/unit/operations/test_groupby_rolling.py
+++ b/py-polars/tests/unit/operations/test_groupby_rolling.py
@@ -176,6 +176,40 @@ def test_groupby_rolling_negative_offset_crossing_dst(time_zone: str | None) -> 
     assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("time_zone", [None, "US/Central"])
+def test_groupby_rolling_positive_offset_crossing_dst_9077(
+    time_zone: str | None,
+) -> None:
+    df = pl.DataFrame(
+        {
+            "datetime": pl.date_range(
+                datetime(2021, 11, 6),
+                datetime(2021, 11, 9),
+                "1d",
+                time_zone=time_zone,
+                eager=True,
+            ),
+            "value": [1, 4, 9, 155],
+        }
+    )
+    result = df.groupby_rolling(index_column="datetime", period="2d", offset="1d").agg(
+        pl.col("value")
+    )
+    expected = pl.DataFrame(
+        {
+            "datetime": pl.date_range(
+                datetime(2021, 11, 6),
+                datetime(2021, 11, 9),
+                "1d",
+                time_zone=time_zone,
+                eager=True,
+            ),
+            "value": [[9, 155], [155], [], []],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
 def test_groupby_rolling_dynamic_sortedness_check() -> None:
     # when the by argument is passed, the sortedness flag
     # will be unset as the take shuffles data, so we must explicitly


### PR DESCRIPTION
There's room for optimisation, but this at least closes #9077 (besides, rolling windows looking into the future don't strike me as a common use-case)