### PR TITLE
feat(python)!: Set default name for expression output of some functions

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -7159,7 +7159,9 @@ class Expr:
         the rest of the fields are the other columns used in the default expression.
 
         >>> df.with_columns(
-        ...     pl.struct(pl.col(["country_code", "row_nr"])).map_dict(
+        ...     pl.struct("country_code", "row_nr")
+        ...     .alias("country_code")
+        ...     .map_dict(
         ...         remapping=country_code_dict,
         ...         default=pl.col("row_nr").cast(pl.Utf8),
         ...     )

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -263,8 +263,9 @@ class ExprListNameSpace:
         other_list: list[Expr | str | Series]
         other_list = [other] if not isinstance(other, list) else copy.copy(other)  # type: ignore[arg-type]
 
-        other_list.insert(0, wrap_expr(self._pyexpr))
-        return F.concat_list(other_list)
+        original_expr = wrap_expr(self._pyexpr)
+        other_list.insert(0, original_expr)
+        return F.concat_list(other_list).alias(original_expr.meta.output_name())
 
     def get(self, index: int | Expr | str) -> Expr:
         """

--- a/py-polars/src/functions/as_datatype.rs
+++ b/py-polars/src/functions/as_datatype.rs
@@ -1,0 +1,94 @@
+use polars::lazy::dsl;
+use pyo3::prelude::*;
+
+use crate::expr::ToExprs;
+use crate::prelude::{DatetimeArgs, DurationArgs};
+use crate::{PyExpr, PyPolarsErr};
+
+macro_rules! set_unwrapped_or_0 {
+    ($($var:ident),+ $(,)?) => {
+        $(let $var = $var.map(|e| e.inner).unwrap_or(dsl::lit(0));)+
+    };
+}
+
+#[pyfunction]
+pub fn datetime(
+    year: PyExpr,
+    month: PyExpr,
+    day: PyExpr,
+    hour: Option<PyExpr>,
+    minute: Option<PyExpr>,
+    second: Option<PyExpr>,
+    microsecond: Option<PyExpr>,
+) -> PyExpr {
+    let year = year.inner;
+    let month = month.inner;
+    let day = day.inner;
+
+    set_unwrapped_or_0!(hour, minute, second, microsecond);
+
+    let args = DatetimeArgs {
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        microsecond,
+    };
+    dsl::datetime(args).into()
+}
+
+#[allow(clippy::too_many_arguments)]
+#[pyfunction]
+pub fn duration(
+    days: Option<PyExpr>,
+    seconds: Option<PyExpr>,
+    nanoseconds: Option<PyExpr>,
+    microseconds: Option<PyExpr>,
+    milliseconds: Option<PyExpr>,
+    minutes: Option<PyExpr>,
+    hours: Option<PyExpr>,
+    weeks: Option<PyExpr>,
+) -> PyExpr {
+    set_unwrapped_or_0!(
+        days,
+        seconds,
+        nanoseconds,
+        microseconds,
+        milliseconds,
+        minutes,
+        hours,
+        weeks,
+    );
+    let args = DurationArgs {
+        days,
+        seconds,
+        nanoseconds,
+        microseconds,
+        milliseconds,
+        minutes,
+        hours,
+        weeks,
+    };
+    dsl::duration(args).into()
+}
+
+#[pyfunction]
+pub fn concat_list(exprs: Vec<PyExpr>) -> PyResult<PyExpr> {
+    let exprs = exprs.to_exprs();
+    let expr = dsl::concat_list(exprs).map_err(PyPolarsErr::from)?;
+    Ok(expr.into())
+}
+
+#[pyfunction]
+pub fn as_struct(exprs: Vec<PyExpr>) -> PyExpr {
+    let exprs = exprs.to_exprs();
+    dsl::as_struct(&exprs).into()
+}
+
+#[pyfunction]
+pub fn concat_str(exprs: Vec<PyExpr>, separator: &str) -> PyExpr {
+    let exprs = exprs.to_exprs();
+    dsl::concat_str(exprs, separator).into()
+}

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -9,16 +9,8 @@ use pyo3::types::{PyBool, PyBytes, PyFloat, PyInt, PyString};
 use crate::apply::lazy::binary_lambda;
 use crate::conversion::{get_lf, Wrap};
 use crate::expr::ToExprs;
-use crate::prelude::{
-    vec_extract_wrapped, ClosedWindow, DataType, DatetimeArgs, Duration, DurationArgs, ObjectValue,
-};
+use crate::prelude::{vec_extract_wrapped, ClosedWindow, DataType, Duration, ObjectValue};
 use crate::{apply, PyDataFrame, PyExpr, PyLazyFrame, PyPolarsErr, PySeries};
-
-macro_rules! set_unwrapped_or_0 {
-    ($($var:ident),+ $(,)?) => {
-        $(let $var = $var.map(|e| e.inner).unwrap_or(dsl::lit(0));)+
-    };
-}
 
 #[pyfunction]
 pub fn arange(start: PyExpr, end: PyExpr, step: i64) -> PyExpr {
@@ -77,12 +69,6 @@ pub fn arg_where(condition: PyExpr) -> PyExpr {
 }
 
 #[pyfunction]
-pub fn as_struct(exprs: Vec<PyExpr>) -> PyExpr {
-    let exprs = exprs.to_exprs();
-    dsl::as_struct(&exprs).into()
-}
-
-#[pyfunction]
 pub fn coalesce(exprs: Vec<PyExpr>) -> PyExpr {
     let exprs = exprs.to_exprs();
     dsl::coalesce(&exprs).into()
@@ -133,19 +119,6 @@ pub fn concat_lf(seq: &PyAny, rechunk: bool, parallel: bool) -> PyResult<PyLazyF
 }
 
 #[pyfunction]
-pub fn concat_list(s: Vec<PyExpr>) -> PyResult<PyExpr> {
-    let s = s.into_iter().map(|e| e.inner).collect::<Vec<_>>();
-    let expr = dsl::concat_list(s).map_err(PyPolarsErr::from)?;
-    Ok(expr.into())
-}
-
-#[pyfunction]
-pub fn concat_str(s: Vec<PyExpr>, separator: &str) -> PyExpr {
-    let s = s.into_iter().map(|e| e.inner).collect::<Vec<_>>();
-    dsl::concat_str(s, separator).into()
-}
-
-#[pyfunction]
 pub fn count() -> PyExpr {
     dsl::count().into()
 }
@@ -186,34 +159,6 @@ pub fn date_range_lazy(
 }
 
 #[pyfunction]
-pub fn datetime(
-    year: PyExpr,
-    month: PyExpr,
-    day: PyExpr,
-    hour: Option<PyExpr>,
-    minute: Option<PyExpr>,
-    second: Option<PyExpr>,
-    microsecond: Option<PyExpr>,
-) -> PyExpr {
-    let year = year.inner;
-    let month = month.inner;
-    let day = day.inner;
-
-    set_unwrapped_or_0!(hour, minute, second, microsecond);
-
-    let args = DatetimeArgs {
-        year,
-        month,
-        day,
-        hour,
-        minute,
-        second,
-        microsecond,
-    };
-    dsl::datetime(args).into()
-}
-
-#[pyfunction]
 pub fn diag_concat_lf(lfs: &PyAny, rechunk: bool, parallel: bool) -> PyResult<PyLazyFrame> {
     let iter = lfs.iter()?;
 
@@ -232,41 +177,6 @@ pub fn diag_concat_lf(lfs: &PyAny, rechunk: bool, parallel: bool) -> PyResult<Py
 pub fn dtype_cols(dtypes: Vec<Wrap<DataType>>) -> PyResult<PyExpr> {
     let dtypes = vec_extract_wrapped(dtypes);
     Ok(dsl::dtype_cols(dtypes).into())
-}
-
-#[allow(clippy::too_many_arguments)]
-#[pyfunction]
-pub fn duration(
-    days: Option<PyExpr>,
-    seconds: Option<PyExpr>,
-    nanoseconds: Option<PyExpr>,
-    microseconds: Option<PyExpr>,
-    milliseconds: Option<PyExpr>,
-    minutes: Option<PyExpr>,
-    hours: Option<PyExpr>,
-    weeks: Option<PyExpr>,
-) -> PyExpr {
-    set_unwrapped_or_0!(
-        days,
-        seconds,
-        nanoseconds,
-        microseconds,
-        milliseconds,
-        minutes,
-        hours,
-        weeks,
-    );
-    let args = DurationArgs {
-        days,
-        seconds,
-        nanoseconds,
-        microseconds,
-        milliseconds,
-        minutes,
-        hours,
-        weeks,
-    };
-    dsl::duration(args).into()
 }
 
 #[pyfunction]

--- a/py-polars/src/functions/mod.rs
+++ b/py-polars/src/functions/mod.rs
@@ -1,3 +1,4 @@
+pub mod as_datatype;
 pub mod eager;
 pub mod io;
 pub mod lazy;

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -97,8 +97,6 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::arg_where))
         .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::lazy::as_struct))
-        .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::coalesce))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::col))
@@ -108,10 +106,6 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(functions::lazy::cols))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::concat_lf))
-        .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::lazy::concat_list))
-        .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::lazy::concat_str))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::count))
         .unwrap();
@@ -123,13 +117,9 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::date_range_lazy))
         .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::lazy::datetime))
-        .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::diag_concat_lf))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::dtype_cols))
-        .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::lazy::duration))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::first))
         .unwrap();
@@ -162,6 +152,18 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(functions::lazy::time_range_lazy))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::whenthen::when))
+        .unwrap();
+
+    // Functions - As datatype
+    m.add_wrapped(wrap_pyfunction!(functions::as_datatype::datetime))
+        .unwrap();
+    m.add_wrapped(wrap_pyfunction!(functions::as_datatype::duration))
+        .unwrap();
+    m.add_wrapped(wrap_pyfunction!(functions::as_datatype::concat_str))
+        .unwrap();
+    m.add_wrapped(wrap_pyfunction!(functions::as_datatype::concat_list))
+        .unwrap();
+    m.add_wrapped(wrap_pyfunction!(functions::as_datatype::as_struct))
         .unwrap();
 
     // Functions - I/O

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -351,7 +351,7 @@ def test_struct_categorical_nesting() -> None:
         {"cats": ["Value1", "Value2", "Value1"]},
         schema_overrides={"cats": pl.Categorical},
     )
-    s = df.select(pl.struct(pl.col("cats")))["cats"].implode()
+    s = df.select(pl.struct(pl.col("cats"))).to_series().implode()
     assert s.dtype == pl.List(pl.Struct([pl.Field("cats", pl.Categorical)]))
     # triggers recursive conversion
     assert s.to_list() == [[{"cats": "Value1"}, {"cats": "Value2"}, {"cats": "Value1"}]]

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -243,9 +243,9 @@ def test_fast_explode_on_list_struct_6208() -> None:
 def test_flat_aggregation_to_list_conversion_6918() -> None:
     df = pl.DataFrame({"a": [1, 2, 2], "b": [[0, 1], [2, 3], [4, 5]]})
 
-    assert df.groupby("a", maintain_order=True).agg(
-        pl.concat_list([pl.col("b").list.get(i).mean().implode() for i in range(2)])
-    ).to_dict(False) == {"a": [1, 2], "b": [[[0.0, 1.0]], [[3.0, 4.0]]]}
+    exprs = [pl.col("b").list.get(i).mean().implode() for i in range(2)]
+    result = df.groupby("a", maintain_order=True).agg(pl.concat_list(exprs))
+    assert result.to_dict(False) == {"a": [1, 2], "list": [[[0.0, 1.0]], [[3.0, 4.0]]]}
 
 
 def test_list_count_match() -> None:
@@ -347,7 +347,7 @@ def test_logical_type_struct_agg_list() -> None:
         pl.Int32,
         pl.List(pl.Struct([pl.Field("cats", pl.Categorical)])),
     ]
-    assert out["cats"].to_list() == [
+    assert out["struct"].to_list() == [
         [{"cats": "Value1"}, {"cats": "Value2"}, {"cats": "Value1"}]
     ]
 

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -95,6 +95,22 @@ def test_list_concat() -> None:
     assert out_s[0].to_list() == [1, 2, 4, 1]
 
 
+def test_list_concat2() -> None:
+    s0 = pl.Series("a", [[1, 2]])
+    s1 = pl.Series("b", [[3, 4, 5]])
+    expected = pl.Series("a", [[1, 2, 3, 4, 5]])
+
+    out = s0.list.concat([s1])
+    assert_series_equal(out, expected)
+
+    out = s0.list.concat(s1)
+    assert_series_equal(out, expected)
+
+    df = pl.DataFrame([s0, s1])
+    assert_series_equal(df.select(pl.col("a").list.concat("b")).to_series(), expected)
+    assert_series_equal(df.select(pl.col("a").list.concat(["b"])).to_series(), expected)
+
+
 def test_list_arr_empty() -> None:
     df = pl.DataFrame({"cars": [[1, 2, 3], [2, 3], [4], []]})
 

--- a/py-polars/tests/unit/operations/test_apply.py
+++ b/py-polars/tests/unit/operations/test_apply.py
@@ -228,8 +228,8 @@ def test_empty_list_in_apply() -> None:
     )
 
     assert df.select(
-        pl.struct(["a", "b"]).apply(lambda row: list(set(row["a"]) & set(row["b"])))
-    ).to_dict(False) == {"a": [[], [1, 2], [], [5]]}
+        pl.struct("a", "b").apply(lambda row: list(set(row["a"]) & set(row["b"])))
+    ).to_dict(False) == {"struct": [[], [1, 2], [], [5]]}
 
 
 def test_apply_skip_nulls() -> None:

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -17,10 +17,10 @@ def test_drop_explode_6641() -> None:
     ).lazy()
 
     assert (
-        df.explode(["identifier", "alternate"])
-        .with_columns(pl.struct(["identifier", "alternate"]).alias("test"))
-        .drop(["identifier", "alternate"])
-        .select(pl.concat_list([pl.col("test"), pl.col("test")]))
+        df.explode("identifier", "alternate")
+        .with_columns(pl.struct("identifier", "alternate").alias("test"))
+        .drop("identifier", "alternate")
+        .select(pl.concat_list(pl.col("test"), pl.col("test")).alias("test"))
         .collect()
     ).to_dict(False) == {
         "test": [

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -290,7 +290,7 @@ def test_logical_explode() -> None:
             schema_overrides={"cats": pl.Categorical},
         )
         .groupby(1)
-        .agg(pl.struct("cats"))
+        .agg(pl.struct("cats").alias("cats"))
         .explode("cats")
         .unnest("cats")
     )

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -289,7 +289,7 @@ def test_is_first() -> None:
     ldf = pl.LazyFrame({"a": [1, 2, 3, 2, None, 2, 1], "b": [0, 2, 3, 2, None, 2, 0]})
 
     assert ldf.select(pl.struct(["a", "b"]).is_first()).collect().to_dict(False) == {
-        "a": [True, True, True, False, True, False, False]
+        "struct": [True, True, True, False, True, False, False]
     }
 
 


### PR DESCRIPTION
Partially addresses #8972

Changes:
* For the following functions, the name of the output expression is now set to a default, rather than set to the name left-most input expression.
  * `concat_list` -> `"list"`
  * `struct` -> `"struct"`
  * `concat_str` -> `"string"`
  * `format` -> `"string"`

This can break your workflow if you rely on the default name. Consider the following code:

```python
df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
result = df.with_columns(pl.struct("a", "b"))
print(result)
```

Result before:
```
shape: (2, 2)
┌───────────┬─────┐
│ a         ┆ b   │
│ ---       ┆ --- │
│ struct[2] ┆ i64 │
╞═══════════╪═════╡
│ {1,3}     ┆ 3   │
│ {2,4}     ┆ 4   │
└───────────┴─────┘
```

Result after:
```
shape: (2, 3)
┌─────┬─────┬───────────┐
│ a   ┆ b   ┆ struct    │
│ --- ┆ --- ┆ ---       │
│ i64 ┆ i64 ┆ struct[2] │
╞═════╪═════╪═══════════╡
│ 1   ┆ 3   ┆ {1,3}     │
│ 2   ┆ 4   ┆ {2,4}     │
└─────┴─────┴───────────┘
```

It is recommended to explicitly call `alias` on the expression if you want to overwrite the default name.

I think this should be mentioned explicitly in the `0.18.0` changelog. We can include the text above.