### PR TITLE
refactor(python): Refactor expression input parsing util

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -90,7 +90,7 @@ from polars.utils._construction import (
     sequence_to_pydf,
     series_to_pydf,
 )
-from polars.utils._parse_expr_input import expr_to_lit_or_expr
+from polars.utils._parse_expr_input import parse_single_expression_input
 from polars.utils._wrap import wrap_ldf, wrap_s
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias
@@ -7902,7 +7902,7 @@ class DataFrame:
             subset = [subset]
 
         if isinstance(subset, Sequence) and len(subset) == 1:
-            expr = expr_to_lit_or_expr(subset[0], str_to_lit=False)
+            expr = parse_single_expression_input(subset[0], str_to_lit=False)
         else:
             struct_fields = F.all() if (subset is None) else subset
             expr = F.struct(struct_fields)  # type: ignore[call-overload]

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7902,7 +7902,7 @@ class DataFrame:
             subset = [subset]
 
         if isinstance(subset, Sequence) and len(subset) == 1:
-            expr = parse_single_expression_input(subset[0], str_to_lit=False)
+            expr = parse_single_expression_input(subset[0], str_as_lit=False)
         else:
             struct_fields = F.all() if (subset is None) else subset
             expr = F.struct(struct_fields)  # type: ignore[call-overload]

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7902,7 +7902,7 @@ class DataFrame:
             subset = [subset]
 
         if isinstance(subset, Sequence) and len(subset) == 1:
-            expr = parse_single_expression_input(subset[0], str_as_lit=False)
+            expr = parse_single_expression_input(subset[0])
         else:
             struct_fields = F.all() if (subset is None) else subset
             expr = F.struct(struct_fields)  # type: ignore[call-overload]

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import polars._reexport as pl
 from polars import functions as F
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
-from polars.utils._parse_expr_input import expr_to_lit_or_expr
+from polars.utils._parse_expr_input import parse_single_expression_input
 from polars.utils._wrap import wrap_expr
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias
@@ -335,7 +335,7 @@ class ExprDateTimeNameSpace:
             raise TypeError(
                 f"expected 'time' to be a python time or polars expression, found {time!r}"
             )
-        time = expr_to_lit_or_expr(time)
+        time = parse_single_expression_input(time)
         return wrap_expr(self._pyexpr.dt_combine(time._pyexpr, time_unit))
 
     def to_string(self, format: str) -> Expr:

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -18,7 +18,6 @@ from typing import (
     Sequence,
     Set,
     TypeVar,
-    cast,
 )
 
 import polars._reexport as pl
@@ -2233,10 +2232,9 @@ class Expr:
         if isinstance(indices, list) or (
             _check_for_numpy(indices) and isinstance(indices, np.ndarray)
         ):
-            indices = cast("np.ndarray[Any, Any]", indices)
             indices_lit = F.lit(pl.Series("", indices, dtype=UInt32))
         else:
-            indices_lit = parse_single_expression_input(indices, str_to_lit=False)
+            indices_lit = parse_single_expression_input(indices, str_to_lit=False)  # type: ignore[arg-type]
         return self._from_pyexpr(self._pyexpr.take(indices_lit._pyexpr))
 
     def shift(self, periods: int = 1) -> Self:
@@ -2269,7 +2267,7 @@ class Expr:
 
     def shift_and_fill(
         self,
-        fill_value: int | float | bool | str | Expr | list[Any],
+        fill_value: IntoExpr,
         *,
         periods: int = 1,
     ) -> Self:

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1678,7 +1678,7 @@ class Expr:
         └─────┘
 
         """
-        other = parse_single_expression_input(other, str_to_lit=False)
+        other = parse_single_expression_input(other, str_as_lit=False)
         return self._from_pyexpr(self._pyexpr.dot(other._pyexpr))
 
     def mode(self) -> Self:
@@ -2049,7 +2049,7 @@ class Expr:
         └──────┴───────┴─────┘
 
         """
-        element = parse_single_expression_input(element, str_to_lit=False)
+        element = parse_single_expression_input(element, str_as_lit=False)
         return self._from_pyexpr(self._pyexpr.search_sorted(element._pyexpr, side))
 
     def sort_by(
@@ -2234,7 +2234,7 @@ class Expr:
         ):
             indices_lit = F.lit(pl.Series("", indices, dtype=UInt32))
         else:
-            indices_lit = parse_single_expression_input(indices, str_to_lit=False)  # type: ignore[arg-type]
+            indices_lit = parse_single_expression_input(indices, str_as_lit=False)  # type: ignore[arg-type]
         return self._from_pyexpr(self._pyexpr.take(indices_lit._pyexpr))
 
     def shift(self, periods: int = 1) -> Self:
@@ -2298,7 +2298,7 @@ class Expr:
         └─────┘
 
         """
-        fill_value = parse_single_expression_input(fill_value, str_to_lit=True)
+        fill_value = parse_single_expression_input(fill_value, str_as_lit=True)
         return self._from_pyexpr(
             self._pyexpr.shift_and_fill(periods, fill_value._pyexpr)
         )
@@ -2378,7 +2378,7 @@ class Expr:
             )
 
         if value is not None:
-            value = parse_single_expression_input(value, str_to_lit=True)
+            value = parse_single_expression_input(value, str_as_lit=True)
             return self._from_pyexpr(self._pyexpr.fill_null(value._pyexpr))
         else:
             return self._from_pyexpr(
@@ -2410,7 +2410,7 @@ class Expr:
         └──────┴──────┘
 
         """
-        fill_value = parse_single_expression_input(value, str_to_lit=True)
+        fill_value = parse_single_expression_input(value, str_as_lit=True)
         return self._from_pyexpr(self._pyexpr.fill_nan(fill_value._pyexpr))
 
     def forward_fill(self, limit: int | None = None) -> Self:
@@ -3175,7 +3175,7 @@ class Expr:
         └─────┘
 
         """
-        quantile = parse_single_expression_input(quantile, str_to_lit=False)
+        quantile = parse_single_expression_input(quantile, str_as_lit=False)
         return self._from_pyexpr(self._pyexpr.quantile(quantile._pyexpr, interpolation))
 
     def filter(self, predicate: Expr) -> Self:
@@ -3621,7 +3621,7 @@ class Expr:
         └─────┘
 
         """
-        offset = -parse_single_expression_input(n, str_to_lit=False)
+        offset = -parse_single_expression_input(n, str_as_lit=False)
         return self.slice(offset, n)
 
     def limit(self, n: int | Expr = 10) -> Self:
@@ -4320,7 +4320,7 @@ class Expr:
                 other = sorted(other)
             other = F.lit(None) if len(other) == 0 else F.lit(pl.Series(other))
         else:
-            other = parse_single_expression_input(other, str_to_lit=False)
+            other = parse_single_expression_input(other, str_as_lit=False)
         return self._from_pyexpr(self._pyexpr.is_in(other._pyexpr))
 
     def repeat_by(self, by: pl.Series | Expr | str | int) -> Self:
@@ -4361,7 +4361,7 @@ class Expr:
         └─────────────────┘
 
         """
-        by = parse_single_expression_input(by, str_to_lit=False)
+        by = parse_single_expression_input(by, str_as_lit=False)
         return self._from_pyexpr(self._pyexpr.repeat_by(by._pyexpr))
 
     def is_between(
@@ -4447,8 +4447,8 @@ class Expr:
         └─────┴────────────┘
 
         """
-        lower_bound = parse_single_expression_input(lower_bound, str_to_lit=False)
-        upper_bound = parse_single_expression_input(upper_bound, str_to_lit=False)
+        lower_bound = parse_single_expression_input(lower_bound, str_as_lit=False)
+        upper_bound = parse_single_expression_input(upper_bound, str_as_lit=False)
 
         if closed == "none":
             return (self > lower_bound) & (self < upper_bound)

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1678,7 +1678,7 @@ class Expr:
         └─────┘
 
         """
-        other = parse_single_expression_input(other, str_as_lit=False)
+        other = parse_single_expression_input(other)
         return self._from_pyexpr(self._pyexpr.dot(other._pyexpr))
 
     def mode(self) -> Self:
@@ -2049,7 +2049,7 @@ class Expr:
         └──────┴───────┴─────┘
 
         """
-        element = parse_single_expression_input(element, str_as_lit=False)
+        element = parse_single_expression_input(element)
         return self._from_pyexpr(self._pyexpr.search_sorted(element._pyexpr, side))
 
     def sort_by(
@@ -2234,7 +2234,7 @@ class Expr:
         ):
             indices_lit = F.lit(pl.Series("", indices, dtype=UInt32))
         else:
-            indices_lit = parse_single_expression_input(indices, str_as_lit=False)  # type: ignore[arg-type]
+            indices_lit = parse_single_expression_input(indices)  # type: ignore[arg-type]
         return self._from_pyexpr(self._pyexpr.take(indices_lit._pyexpr))
 
     def shift(self, periods: int = 1) -> Self:
@@ -3175,7 +3175,7 @@ class Expr:
         └─────┘
 
         """
-        quantile = parse_single_expression_input(quantile, str_as_lit=False)
+        quantile = parse_single_expression_input(quantile)
         return self._from_pyexpr(self._pyexpr.quantile(quantile._pyexpr, interpolation))
 
     def filter(self, predicate: Expr) -> Self:
@@ -3621,7 +3621,7 @@ class Expr:
         └─────┘
 
         """
-        offset = -parse_single_expression_input(n, str_as_lit=False)
+        offset = -parse_single_expression_input(n)
         return self.slice(offset, n)
 
     def limit(self, n: int | Expr = 10) -> Self:
@@ -4320,7 +4320,7 @@ class Expr:
                 other = sorted(other)
             other = F.lit(None) if len(other) == 0 else F.lit(pl.Series(other))
         else:
-            other = parse_single_expression_input(other, str_as_lit=False)
+            other = parse_single_expression_input(other)
         return self._from_pyexpr(self._pyexpr.is_in(other._pyexpr))
 
     def repeat_by(self, by: pl.Series | Expr | str | int) -> Self:
@@ -4361,7 +4361,7 @@ class Expr:
         └─────────────────┘
 
         """
-        by = parse_single_expression_input(by, str_as_lit=False)
+        by = parse_single_expression_input(by)
         return self._from_pyexpr(self._pyexpr.repeat_by(by._pyexpr))
 
     def is_between(
@@ -4447,8 +4447,8 @@ class Expr:
         └─────┴────────────┘
 
         """
-        lower_bound = parse_single_expression_input(lower_bound, str_as_lit=False)
-        upper_bound = parse_single_expression_input(upper_bound, str_as_lit=False)
+        lower_bound = parse_single_expression_input(lower_bound)
+        upper_bound = parse_single_expression_input(upper_bound)
 
         if closed == "none":
             return (self > lower_bound) & (self < upper_bound)

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -43,7 +43,10 @@ from polars.expr.list import ExprListNameSpace
 from polars.expr.meta import ExprMetaNameSpace
 from polars.expr.string import ExprStringNameSpace
 from polars.expr.struct import ExprStructNameSpace
-from polars.utils._parse_expr_input import expr_to_lit_or_expr, selection_to_pyexpr_list
+from polars.utils._parse_expr_input import (
+    parse_single_expression_input,
+    selection_to_pyexpr_list,
+)
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias
 from polars.utils.meta import threadpool_size
@@ -189,7 +192,7 @@ class Expr:
         return self.pow(power)
 
     def __rpow__(self, base: int | float | Expr) -> Expr:
-        return expr_to_lit_or_expr(base) ** self
+        return parse_single_expression_input(base) ** self
 
     def __sub__(self, other: Any) -> Self:
         return self._from_pyexpr(self._pyexpr - self._to_pyexpr(other))
@@ -1242,7 +1245,7 @@ class Expr:
         └─────┴──────┘
 
         """
-        other = expr_to_lit_or_expr(other)
+        other = parse_single_expression_input(other)
         return self._from_pyexpr(self._pyexpr.append(other._pyexpr, upcast))
 
     def rechunk(self) -> Self:
@@ -1676,7 +1679,7 @@ class Expr:
         └─────┘
 
         """
-        other = expr_to_lit_or_expr(other, str_to_lit=False)
+        other = parse_single_expression_input(other, str_to_lit=False)
         return self._from_pyexpr(self._pyexpr.dot(other._pyexpr))
 
     def mode(self) -> Self:
@@ -2047,7 +2050,7 @@ class Expr:
         └──────┴───────┴─────┘
 
         """
-        element = expr_to_lit_or_expr(element, str_to_lit=False)
+        element = parse_single_expression_input(element, str_to_lit=False)
         return self._from_pyexpr(self._pyexpr.search_sorted(element._pyexpr, side))
 
     def sort_by(
@@ -2233,7 +2236,7 @@ class Expr:
             indices = cast("np.ndarray[Any, Any]", indices)
             indices_lit = F.lit(pl.Series("", indices, dtype=UInt32))
         else:
-            indices_lit = expr_to_lit_or_expr(indices, str_to_lit=False)
+            indices_lit = parse_single_expression_input(indices, str_to_lit=False)
         return self._from_pyexpr(self._pyexpr.take(indices_lit._pyexpr))
 
     def shift(self, periods: int = 1) -> Self:
@@ -2297,7 +2300,7 @@ class Expr:
         └─────┘
 
         """
-        fill_value = expr_to_lit_or_expr(fill_value, str_to_lit=True)
+        fill_value = parse_single_expression_input(fill_value, str_to_lit=True)
         return self._from_pyexpr(
             self._pyexpr.shift_and_fill(periods, fill_value._pyexpr)
         )
@@ -2377,7 +2380,7 @@ class Expr:
             )
 
         if value is not None:
-            value = expr_to_lit_or_expr(value, str_to_lit=True)
+            value = parse_single_expression_input(value, str_to_lit=True)
             return self._from_pyexpr(self._pyexpr.fill_null(value._pyexpr))
         else:
             return self._from_pyexpr(
@@ -2409,7 +2412,7 @@ class Expr:
         └──────┴──────┘
 
         """
-        fill_value = expr_to_lit_or_expr(value, str_to_lit=True)
+        fill_value = parse_single_expression_input(value, str_to_lit=True)
         return self._from_pyexpr(self._pyexpr.fill_nan(fill_value._pyexpr))
 
     def forward_fill(self, limit: int | None = None) -> Self:
@@ -3174,7 +3177,7 @@ class Expr:
         └─────┘
 
         """
-        quantile = expr_to_lit_or_expr(quantile, str_to_lit=False)
+        quantile = parse_single_expression_input(quantile, str_to_lit=False)
         return self._from_pyexpr(self._pyexpr.quantile(quantile._pyexpr, interpolation))
 
     def filter(self, predicate: Expr) -> Self:
@@ -3620,7 +3623,7 @@ class Expr:
         └─────┘
 
         """
-        offset = -expr_to_lit_or_expr(n, str_to_lit=False)
+        offset = -parse_single_expression_input(n, str_to_lit=False)
         return self.slice(offset, n)
 
     def limit(self, n: int | Expr = 10) -> Self:
@@ -4225,7 +4228,7 @@ class Expr:
         └─────┴───────┴────────────┘
 
         """
-        exponent = expr_to_lit_or_expr(exponent)
+        exponent = parse_single_expression_input(exponent)
         return self._from_pyexpr(self._pyexpr.pow(exponent._pyexpr))
 
     def xor(self, other: Any) -> Self:
@@ -4319,7 +4322,7 @@ class Expr:
                 other = sorted(other)
             other = F.lit(None) if len(other) == 0 else F.lit(pl.Series(other))
         else:
-            other = expr_to_lit_or_expr(other, str_to_lit=False)
+            other = parse_single_expression_input(other, str_to_lit=False)
         return self._from_pyexpr(self._pyexpr.is_in(other._pyexpr))
 
     def repeat_by(self, by: pl.Series | Expr | str | int) -> Self:
@@ -4360,7 +4363,7 @@ class Expr:
         └─────────────────┘
 
         """
-        by = expr_to_lit_or_expr(by, False)
+        by = parse_single_expression_input(by, str_to_lit=False)
         return self._from_pyexpr(self._pyexpr.repeat_by(by._pyexpr))
 
     def is_between(
@@ -4446,8 +4449,8 @@ class Expr:
         └─────┴────────────┘
 
         """
-        lower_bound = expr_to_lit_or_expr(lower_bound, str_to_lit=False)
-        upper_bound = expr_to_lit_or_expr(upper_bound, str_to_lit=False)
+        lower_bound = parse_single_expression_input(lower_bound, str_to_lit=False)
+        upper_bound = parse_single_expression_input(upper_bound, str_to_lit=False)
 
         if closed == "none":
             return (self > lower_bound) & (self < upper_bound)

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 import polars._reexport as pl
 from polars import functions as F
-from polars.utils._parse_expr_input import expr_to_lit_or_expr
+from polars.utils._parse_expr_input import parse_single_expression_input
 from polars.utils._wrap import wrap_expr
 from polars.utils.decorators import deprecated_alias
 
@@ -295,7 +295,7 @@ class ExprListNameSpace:
         └──────┘
 
         """
-        index = expr_to_lit_or_expr(index, str_to_lit=False)._pyexpr
+        index = parse_single_expression_input(index, str_to_lit=False)._pyexpr
         return wrap_expr(self._pyexpr.list_get(index))
 
     def take(
@@ -323,7 +323,7 @@ class ExprListNameSpace:
         """
         if isinstance(index, list):
             index = pl.Series(index)
-        index = expr_to_lit_or_expr(index, str_to_lit=False)._pyexpr
+        index = parse_single_expression_input(index, str_to_lit=False)._pyexpr
         return wrap_expr(self._pyexpr.list_take(index, null_on_oob))
 
     def first(self) -> Expr:
@@ -401,7 +401,9 @@ class ExprListNameSpace:
         └───────┘
 
         """
-        return wrap_expr(self._pyexpr.list_contains(expr_to_lit_or_expr(item)._pyexpr))
+        return wrap_expr(
+            self._pyexpr.list_contains(parse_single_expression_input(item)._pyexpr)
+        )
 
     def join(self, separator: str) -> Expr:
         """
@@ -592,8 +594,8 @@ class ExprListNameSpace:
         ]
 
         """
-        offset = expr_to_lit_or_expr(offset, str_to_lit=False)._pyexpr
-        length = expr_to_lit_or_expr(length, str_to_lit=False)._pyexpr
+        offset = parse_single_expression_input(offset, str_to_lit=False)._pyexpr
+        length = parse_single_expression_input(length, str_to_lit=False)._pyexpr
         return wrap_expr(self._pyexpr.list_slice(offset, length))
 
     def head(self, n: int | str | Expr = 5) -> Expr:
@@ -640,7 +642,7 @@ class ExprListNameSpace:
         ]
 
         """
-        offset = -expr_to_lit_or_expr(n, str_to_lit=False)
+        offset = -parse_single_expression_input(n, str_to_lit=False)
         return self.slice(offset, n)
 
     def explode(self) -> Expr:
@@ -706,7 +708,9 @@ class ExprListNameSpace:
 
         """
         return wrap_expr(
-            self._pyexpr.list_count_match(expr_to_lit_or_expr(element)._pyexpr)
+            self._pyexpr.list_count_match(
+                parse_single_expression_input(element)._pyexpr
+            )
         )
 
     @deprecated_alias(name_generator="fields")

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from datetime import date, datetime, time
 
     from polars import Expr, Series
-    from polars.type_aliases import NullBehavior, ToStructStrategy
+    from polars.type_aliases import IntoExpr, NullBehavior, ToStructStrategy
 
 
 class ExprListNameSpace:
@@ -295,7 +295,7 @@ class ExprListNameSpace:
         └──────┘
 
         """
-        index = parse_single_expression_input(index, str_as_lit=False)._pyexpr
+        index = parse_single_expression_input(index)._pyexpr
         return wrap_expr(self._pyexpr.list_get(index))
 
     def take(
@@ -323,7 +323,7 @@ class ExprListNameSpace:
         """
         if isinstance(index, list):
             index = pl.Series(index)
-        index = parse_single_expression_input(index, str_as_lit=False)._pyexpr
+        index = parse_single_expression_input(index)._pyexpr
         return wrap_expr(self._pyexpr.list_take(index, null_on_oob))
 
     def first(self) -> Expr:
@@ -402,7 +402,9 @@ class ExprListNameSpace:
 
         """
         return wrap_expr(
-            self._pyexpr.list_contains(parse_single_expression_input(item)._pyexpr)
+            self._pyexpr.list_contains(
+                parse_single_expression_input(item, str_as_lit=True)._pyexpr
+            )
         )
 
     def join(self, separator: str) -> Expr:
@@ -594,8 +596,8 @@ class ExprListNameSpace:
         ]
 
         """
-        offset = parse_single_expression_input(offset, str_as_lit=False)._pyexpr
-        length = parse_single_expression_input(length, str_as_lit=False)._pyexpr
+        offset = parse_single_expression_input(offset)._pyexpr
+        length = parse_single_expression_input(length)._pyexpr
         return wrap_expr(self._pyexpr.list_slice(offset, length))
 
     def head(self, n: int | str | Expr = 5) -> Expr:
@@ -642,7 +644,7 @@ class ExprListNameSpace:
         ]
 
         """
-        offset = -parse_single_expression_input(n, str_as_lit=False)
+        offset = -parse_single_expression_input(n)
         return self.slice(offset, n)
 
     def explode(self) -> Expr:
@@ -678,9 +680,7 @@ class ExprListNameSpace:
         """
         return wrap_expr(self._pyexpr.explode())
 
-    def count_match(
-        self, element: float | str | bool | int | date | datetime | time | Expr
-    ) -> Expr:
+    def count_match(self, element: IntoExpr) -> Expr:
         """
         Count how often the value produced by ``element`` occurs.
 
@@ -709,7 +709,7 @@ class ExprListNameSpace:
         """
         return wrap_expr(
             self._pyexpr.list_count_match(
-                parse_single_expression_input(element)._pyexpr
+                parse_single_expression_input(element, str_as_lit=True)._pyexpr
             )
         )
 

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -295,7 +295,7 @@ class ExprListNameSpace:
         └──────┘
 
         """
-        index = parse_single_expression_input(index, str_to_lit=False)._pyexpr
+        index = parse_single_expression_input(index, str_as_lit=False)._pyexpr
         return wrap_expr(self._pyexpr.list_get(index))
 
     def take(
@@ -323,7 +323,7 @@ class ExprListNameSpace:
         """
         if isinstance(index, list):
             index = pl.Series(index)
-        index = parse_single_expression_input(index, str_to_lit=False)._pyexpr
+        index = parse_single_expression_input(index, str_as_lit=False)._pyexpr
         return wrap_expr(self._pyexpr.list_take(index, null_on_oob))
 
     def first(self) -> Expr:
@@ -594,8 +594,8 @@ class ExprListNameSpace:
         ]
 
         """
-        offset = parse_single_expression_input(offset, str_to_lit=False)._pyexpr
-        length = parse_single_expression_input(length, str_to_lit=False)._pyexpr
+        offset = parse_single_expression_input(offset, str_as_lit=False)._pyexpr
+        length = parse_single_expression_input(length, str_as_lit=False)._pyexpr
         return wrap_expr(self._pyexpr.list_slice(offset, length))
 
     def head(self, n: int | str | Expr = 5) -> Expr:
@@ -642,7 +642,7 @@ class ExprListNameSpace:
         ]
 
         """
-        offset = -parse_single_expression_input(n, str_to_lit=False)
+        offset = -parse_single_expression_input(n, str_as_lit=False)
         return self.slice(offset, n)
 
     def explode(self) -> Expr:

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from polars.datatypes import Date, Datetime, Time, py_type_to_dtype
 from polars.exceptions import ChronoFormatWarning
-from polars.utils._parse_expr_input import expr_to_lit_or_expr
+from polars.utils._parse_expr_input import parse_single_expression_input
 from polars.utils._wrap import wrap_expr
 from polars.utils.decorators import deprecated_alias
 from polars.utils.various import find_stacklevel
@@ -736,7 +736,7 @@ class ExprStringNameSpace:
         ends_with : Check if string values end with a substring.
 
         """
-        pattern = expr_to_lit_or_expr(pattern, str_to_lit=True)._pyexpr
+        pattern = parse_single_expression_input(pattern, str_to_lit=True)._pyexpr
         return wrap_expr(self._pyexpr.str_contains(pattern, literal, strict))
 
     def ends_with(self, suffix: str | Expr) -> Expr:
@@ -783,7 +783,7 @@ class ExprStringNameSpace:
         starts_with : Check if string values start with a substring.
 
         """
-        suffix = expr_to_lit_or_expr(suffix, str_to_lit=True)._pyexpr
+        suffix = parse_single_expression_input(suffix, str_to_lit=True)._pyexpr
         return wrap_expr(self._pyexpr.str_ends_with(suffix))
 
     def starts_with(self, prefix: str | Expr) -> Expr:
@@ -830,7 +830,7 @@ class ExprStringNameSpace:
         ends_with : Check if string values end with a substring.
 
         """
-        prefix = expr_to_lit_or_expr(prefix, str_to_lit=True)._pyexpr
+        prefix = parse_single_expression_input(prefix, str_to_lit=True)._pyexpr
         return wrap_expr(self._pyexpr.str_starts_with(prefix))
 
     def json_extract(self, dtype: PolarsDataType | None = None) -> Expr:
@@ -1134,7 +1134,7 @@ class ExprStringNameSpace:
         └────────────────┘
 
         '''
-        pattern = expr_to_lit_or_expr(pattern, str_to_lit=True)
+        pattern = parse_single_expression_input(pattern, str_to_lit=True)
         return wrap_expr(self._pyexpr.str_extract_all(pattern._pyexpr))
 
     def count_match(self, pattern: str) -> Expr:
@@ -1410,8 +1410,8 @@ class ExprStringNameSpace:
         └─────┴────────┘
 
         """
-        pattern = expr_to_lit_or_expr(pattern, str_to_lit=True)
-        value = expr_to_lit_or_expr(value, str_to_lit=True)
+        pattern = parse_single_expression_input(pattern, str_to_lit=True)
+        value = parse_single_expression_input(value, str_to_lit=True)
         return wrap_expr(
             self._pyexpr.str_replace_n(pattern._pyexpr, value._pyexpr, literal, n)
         )
@@ -1451,8 +1451,8 @@ class ExprStringNameSpace:
         └─────┴─────────┘
 
         """
-        pattern = expr_to_lit_or_expr(pattern, str_to_lit=True)
-        value = expr_to_lit_or_expr(value, str_to_lit=True)
+        pattern = parse_single_expression_input(pattern, str_to_lit=True)
+        value = parse_single_expression_input(value, str_to_lit=True)
         return wrap_expr(
             self._pyexpr.str_replace_all(pattern._pyexpr, value._pyexpr, literal)
         )

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -736,7 +736,7 @@ class ExprStringNameSpace:
         ends_with : Check if string values end with a substring.
 
         """
-        pattern = parse_single_expression_input(pattern, str_to_lit=True)._pyexpr
+        pattern = parse_single_expression_input(pattern, str_as_lit=True)._pyexpr
         return wrap_expr(self._pyexpr.str_contains(pattern, literal, strict))
 
     def ends_with(self, suffix: str | Expr) -> Expr:
@@ -783,7 +783,7 @@ class ExprStringNameSpace:
         starts_with : Check if string values start with a substring.
 
         """
-        suffix = parse_single_expression_input(suffix, str_to_lit=True)._pyexpr
+        suffix = parse_single_expression_input(suffix, str_as_lit=True)._pyexpr
         return wrap_expr(self._pyexpr.str_ends_with(suffix))
 
     def starts_with(self, prefix: str | Expr) -> Expr:
@@ -830,7 +830,7 @@ class ExprStringNameSpace:
         ends_with : Check if string values end with a substring.
 
         """
-        prefix = parse_single_expression_input(prefix, str_to_lit=True)._pyexpr
+        prefix = parse_single_expression_input(prefix, str_as_lit=True)._pyexpr
         return wrap_expr(self._pyexpr.str_starts_with(prefix))
 
     def json_extract(self, dtype: PolarsDataType | None = None) -> Expr:
@@ -1134,7 +1134,7 @@ class ExprStringNameSpace:
         └────────────────┘
 
         '''
-        pattern = parse_single_expression_input(pattern, str_to_lit=True)
+        pattern = parse_single_expression_input(pattern, str_as_lit=True)
         return wrap_expr(self._pyexpr.str_extract_all(pattern._pyexpr))
 
     def count_match(self, pattern: str) -> Expr:
@@ -1410,8 +1410,8 @@ class ExprStringNameSpace:
         └─────┴────────┘
 
         """
-        pattern = parse_single_expression_input(pattern, str_to_lit=True)
-        value = parse_single_expression_input(value, str_to_lit=True)
+        pattern = parse_single_expression_input(pattern, str_as_lit=True)
+        value = parse_single_expression_input(value, str_as_lit=True)
         return wrap_expr(
             self._pyexpr.str_replace_n(pattern._pyexpr, value._pyexpr, literal, n)
         )
@@ -1451,8 +1451,8 @@ class ExprStringNameSpace:
         └─────┴─────────┘
 
         """
-        pattern = parse_single_expression_input(pattern, str_to_lit=True)
-        value = parse_single_expression_input(value, str_to_lit=True)
+        pattern = parse_single_expression_input(pattern, str_as_lit=True)
+        value = parse_single_expression_input(value, str_as_lit=True)
         return wrap_expr(
             self._pyexpr.str_replace_all(pattern._pyexpr, value._pyexpr, literal)
         )

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -384,7 +384,7 @@ def struct(
         exprs.extend(selection_to_pyexpr_list(more_exprs))
     if named_exprs:
         exprs.extend(
-            expr_to_lit_or_expr(expr, name=name, str_to_lit=False)._pyexpr
+            expr_to_lit_or_expr(expr, str_to_lit=False).alias(name)._pyexpr
             for name, expr in named_exprs.items()
         )
 

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -5,7 +5,10 @@ from typing import TYPE_CHECKING, Iterable, overload
 
 from polars import functions as F
 from polars.datatypes import Date, Struct, Time
-from polars.utils._parse_expr_input import expr_to_lit_or_expr, selection_to_pyexpr_list
+from polars.utils._parse_expr_input import (
+    parse_single_expression_input,
+    selection_to_pyexpr_list,
+)
 from polars.utils._wrap import wrap_expr
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -58,18 +61,20 @@ def datetime_(
     Expr of type `pl.Datetime`
 
     """
-    year_expr = expr_to_lit_or_expr(year, str_to_lit=False)
-    month_expr = expr_to_lit_or_expr(month, str_to_lit=False)
-    day_expr = expr_to_lit_or_expr(day, str_to_lit=False)
+    year_expr = parse_single_expression_input(year, str_to_lit=False)
+    month_expr = parse_single_expression_input(month, str_to_lit=False)
+    day_expr = parse_single_expression_input(day, str_to_lit=False)
 
     if hour is not None:
-        hour = expr_to_lit_or_expr(hour, str_to_lit=False)._pyexpr
+        hour = parse_single_expression_input(hour, str_to_lit=False)._pyexpr
     if minute is not None:
-        minute = expr_to_lit_or_expr(minute, str_to_lit=False)._pyexpr
+        minute = parse_single_expression_input(minute, str_to_lit=False)._pyexpr
     if second is not None:
-        second = expr_to_lit_or_expr(second, str_to_lit=False)._pyexpr
+        second = parse_single_expression_input(second, str_to_lit=False)._pyexpr
     if microsecond is not None:
-        microsecond = expr_to_lit_or_expr(microsecond, str_to_lit=False)._pyexpr
+        microsecond = parse_single_expression_input(
+            microsecond, str_to_lit=False
+        )._pyexpr
 
     return wrap_expr(
         plr.datetime(
@@ -200,21 +205,27 @@ def duration(
 
     """  # noqa: W505
     if hours is not None:
-        hours = expr_to_lit_or_expr(hours, str_to_lit=False)._pyexpr
+        hours = parse_single_expression_input(hours, str_to_lit=False)._pyexpr
     if minutes is not None:
-        minutes = expr_to_lit_or_expr(minutes, str_to_lit=False)._pyexpr
+        minutes = parse_single_expression_input(minutes, str_to_lit=False)._pyexpr
     if seconds is not None:
-        seconds = expr_to_lit_or_expr(seconds, str_to_lit=False)._pyexpr
+        seconds = parse_single_expression_input(seconds, str_to_lit=False)._pyexpr
     if milliseconds is not None:
-        milliseconds = expr_to_lit_or_expr(milliseconds, str_to_lit=False)._pyexpr
+        milliseconds = parse_single_expression_input(
+            milliseconds, str_to_lit=False
+        )._pyexpr
     if microseconds is not None:
-        microseconds = expr_to_lit_or_expr(microseconds, str_to_lit=False)._pyexpr
+        microseconds = parse_single_expression_input(
+            microseconds, str_to_lit=False
+        )._pyexpr
     if nanoseconds is not None:
-        nanoseconds = expr_to_lit_or_expr(nanoseconds, str_to_lit=False)._pyexpr
+        nanoseconds = parse_single_expression_input(
+            nanoseconds, str_to_lit=False
+        )._pyexpr
     if days is not None:
-        days = expr_to_lit_or_expr(days, str_to_lit=False)._pyexpr
+        days = parse_single_expression_input(days, str_to_lit=False)._pyexpr
     if weeks is not None:
-        weeks = expr_to_lit_or_expr(weeks, str_to_lit=False)._pyexpr
+        weeks = parse_single_expression_input(weeks, str_to_lit=False)._pyexpr
 
     return wrap_expr(
         plr.duration(
@@ -384,7 +395,7 @@ def struct(
         exprs.extend(selection_to_pyexpr_list(more_exprs))
     if named_exprs:
         exprs.extend(
-            expr_to_lit_or_expr(expr, str_to_lit=False).alias(name)._pyexpr
+            parse_single_expression_input(expr, str_to_lit=False).alias(name)._pyexpr
             for name, expr in named_exprs.items()
         )
 
@@ -508,7 +519,7 @@ def format(f_string: str, *args: Expr | str) -> Expr:
     arguments = iter(args)
     for i, s in enumerate(f_string.split("{}")):
         if i > 0:
-            e = expr_to_lit_or_expr(next(arguments), str_to_lit=False)
+            e = parse_single_expression_input(next(arguments), str_to_lit=False)
             exprs.append(e)
 
         if len(s) > 0:

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -61,20 +61,18 @@ def datetime_(
     Expr of type `pl.Datetime`
 
     """
-    year_expr = parse_single_expression_input(year, str_as_lit=False)
-    month_expr = parse_single_expression_input(month, str_as_lit=False)
-    day_expr = parse_single_expression_input(day, str_as_lit=False)
+    year_expr = parse_single_expression_input(year)
+    month_expr = parse_single_expression_input(month)
+    day_expr = parse_single_expression_input(day)
 
     if hour is not None:
-        hour = parse_single_expression_input(hour, str_as_lit=False)._pyexpr
+        hour = parse_single_expression_input(hour)._pyexpr
     if minute is not None:
-        minute = parse_single_expression_input(minute, str_as_lit=False)._pyexpr
+        minute = parse_single_expression_input(minute)._pyexpr
     if second is not None:
-        second = parse_single_expression_input(second, str_as_lit=False)._pyexpr
+        second = parse_single_expression_input(second)._pyexpr
     if microsecond is not None:
-        microsecond = parse_single_expression_input(
-            microsecond, str_as_lit=False
-        )._pyexpr
+        microsecond = parse_single_expression_input(microsecond)._pyexpr
 
     return wrap_expr(
         plr.datetime(
@@ -205,27 +203,21 @@ def duration(
 
     """  # noqa: W505
     if hours is not None:
-        hours = parse_single_expression_input(hours, str_as_lit=False)._pyexpr
+        hours = parse_single_expression_input(hours)._pyexpr
     if minutes is not None:
-        minutes = parse_single_expression_input(minutes, str_as_lit=False)._pyexpr
+        minutes = parse_single_expression_input(minutes)._pyexpr
     if seconds is not None:
-        seconds = parse_single_expression_input(seconds, str_as_lit=False)._pyexpr
+        seconds = parse_single_expression_input(seconds)._pyexpr
     if milliseconds is not None:
-        milliseconds = parse_single_expression_input(
-            milliseconds, str_as_lit=False
-        )._pyexpr
+        milliseconds = parse_single_expression_input(milliseconds)._pyexpr
     if microseconds is not None:
-        microseconds = parse_single_expression_input(
-            microseconds, str_as_lit=False
-        )._pyexpr
+        microseconds = parse_single_expression_input(microseconds)._pyexpr
     if nanoseconds is not None:
-        nanoseconds = parse_single_expression_input(
-            nanoseconds, str_as_lit=False
-        )._pyexpr
+        nanoseconds = parse_single_expression_input(nanoseconds)._pyexpr
     if days is not None:
-        days = parse_single_expression_input(days, str_as_lit=False)._pyexpr
+        days = parse_single_expression_input(days)._pyexpr
     if weeks is not None:
-        weeks = parse_single_expression_input(weeks, str_as_lit=False)._pyexpr
+        weeks = parse_single_expression_input(weeks)._pyexpr
 
     return wrap_expr(
         plr.duration(
@@ -395,7 +387,7 @@ def struct(
         exprs.extend(selection_to_pyexpr_list(more_exprs))
     if named_exprs:
         exprs.extend(
-            parse_single_expression_input(expr, str_as_lit=False).alias(name)._pyexpr
+            parse_single_expression_input(expr).alias(name)._pyexpr
             for name, expr in named_exprs.items()
         )
 
@@ -519,7 +511,7 @@ def format(f_string: str, *args: Expr | str) -> Expr:
     arguments = iter(args)
     for i, s in enumerate(f_string.split("{}")):
         if i > 0:
-            e = parse_single_expression_input(next(arguments), str_as_lit=False)
+            e = parse_single_expression_input(next(arguments))
             exprs.append(e)
 
         if len(s) > 0:

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -61,19 +61,19 @@ def datetime_(
     Expr of type `pl.Datetime`
 
     """
-    year_expr = parse_single_expression_input(year, str_to_lit=False)
-    month_expr = parse_single_expression_input(month, str_to_lit=False)
-    day_expr = parse_single_expression_input(day, str_to_lit=False)
+    year_expr = parse_single_expression_input(year, str_as_lit=False)
+    month_expr = parse_single_expression_input(month, str_as_lit=False)
+    day_expr = parse_single_expression_input(day, str_as_lit=False)
 
     if hour is not None:
-        hour = parse_single_expression_input(hour, str_to_lit=False)._pyexpr
+        hour = parse_single_expression_input(hour, str_as_lit=False)._pyexpr
     if minute is not None:
-        minute = parse_single_expression_input(minute, str_to_lit=False)._pyexpr
+        minute = parse_single_expression_input(minute, str_as_lit=False)._pyexpr
     if second is not None:
-        second = parse_single_expression_input(second, str_to_lit=False)._pyexpr
+        second = parse_single_expression_input(second, str_as_lit=False)._pyexpr
     if microsecond is not None:
         microsecond = parse_single_expression_input(
-            microsecond, str_to_lit=False
+            microsecond, str_as_lit=False
         )._pyexpr
 
     return wrap_expr(
@@ -205,27 +205,27 @@ def duration(
 
     """  # noqa: W505
     if hours is not None:
-        hours = parse_single_expression_input(hours, str_to_lit=False)._pyexpr
+        hours = parse_single_expression_input(hours, str_as_lit=False)._pyexpr
     if minutes is not None:
-        minutes = parse_single_expression_input(minutes, str_to_lit=False)._pyexpr
+        minutes = parse_single_expression_input(minutes, str_as_lit=False)._pyexpr
     if seconds is not None:
-        seconds = parse_single_expression_input(seconds, str_to_lit=False)._pyexpr
+        seconds = parse_single_expression_input(seconds, str_as_lit=False)._pyexpr
     if milliseconds is not None:
         milliseconds = parse_single_expression_input(
-            milliseconds, str_to_lit=False
+            milliseconds, str_as_lit=False
         )._pyexpr
     if microseconds is not None:
         microseconds = parse_single_expression_input(
-            microseconds, str_to_lit=False
+            microseconds, str_as_lit=False
         )._pyexpr
     if nanoseconds is not None:
         nanoseconds = parse_single_expression_input(
-            nanoseconds, str_to_lit=False
+            nanoseconds, str_as_lit=False
         )._pyexpr
     if days is not None:
-        days = parse_single_expression_input(days, str_to_lit=False)._pyexpr
+        days = parse_single_expression_input(days, str_as_lit=False)._pyexpr
     if weeks is not None:
-        weeks = parse_single_expression_input(weeks, str_to_lit=False)._pyexpr
+        weeks = parse_single_expression_input(weeks, str_as_lit=False)._pyexpr
 
     return wrap_expr(
         plr.duration(
@@ -395,7 +395,7 @@ def struct(
         exprs.extend(selection_to_pyexpr_list(more_exprs))
     if named_exprs:
         exprs.extend(
-            parse_single_expression_input(expr, str_to_lit=False).alias(name)._pyexpr
+            parse_single_expression_input(expr, str_as_lit=False).alias(name)._pyexpr
             for name, expr in named_exprs.items()
         )
 
@@ -519,7 +519,7 @@ def format(f_string: str, *args: Expr | str) -> Expr:
     arguments = iter(args)
     for i, s in enumerate(f_string.split("{}")):
         if i > 0:
-            e = parse_single_expression_input(next(arguments), str_to_lit=False)
+            e = parse_single_expression_input(next(arguments), str_as_lit=False)
             exprs.append(e)
 
         if len(s) > 0:

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -2460,7 +2460,7 @@ def arg_where(condition: Expr | Series, *, eager: bool = False) -> Expr | Series
             )
         return condition.to_frame().select(arg_where(col(condition.name))).to_series()
     else:
-        condition = parse_single_expression_input(condition, str_as_lit=True)
+        condition = parse_single_expression_input(condition)
         return wrap_expr(plr.arg_where(condition._pyexpr))
 
 

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1723,7 +1723,7 @@ def fold(
     └─────┴─────┘
     """
     # in case of pl.col("*")
-    acc = parse_single_expression_input(acc, str_to_lit=True)
+    acc = parse_single_expression_input(acc, str_as_lit=True)
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
@@ -1864,7 +1864,7 @@ def cumfold(
 
     """  # noqa: W505
     # in case of pl.col("*")
-    acc = parse_single_expression_input(acc, str_to_lit=True)
+    acc = parse_single_expression_input(acc, str_as_lit=True)
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
@@ -2460,7 +2460,7 @@ def arg_where(condition: Expr | Series, *, eager: bool = False) -> Expr | Series
             )
         return condition.to_frame().select(arg_where(col(condition.name))).to_series()
     else:
-        condition = parse_single_expression_input(condition, str_to_lit=True)
+        condition = parse_single_expression_input(condition, str_as_lit=True)
         return wrap_expr(plr.arg_where(condition._pyexpr))
 
 

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -17,7 +17,10 @@ from polars.datatypes import (
 )
 from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
-from polars.utils._parse_expr_input import expr_to_lit_or_expr, selection_to_pyexpr_list
+from polars.utils._parse_expr_input import (
+    parse_single_expression_input,
+    selection_to_pyexpr_list,
+)
 from polars.utils._wrap import wrap_df, wrap_expr
 from polars.utils.convert import (
     _datetime_to_pl_timestamp,
@@ -1720,7 +1723,7 @@ def fold(
     └─────┴─────┘
     """
     # in case of pl.col("*")
-    acc = expr_to_lit_or_expr(acc, str_to_lit=True)
+    acc = parse_single_expression_input(acc, str_to_lit=True)
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
@@ -1861,7 +1864,7 @@ def cumfold(
 
     """  # noqa: W505
     # in case of pl.col("*")
-    acc = expr_to_lit_or_expr(acc, str_to_lit=True)
+    acc = parse_single_expression_input(acc, str_to_lit=True)
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
@@ -2457,7 +2460,7 @@ def arg_where(condition: Expr | Series, *, eager: bool = False) -> Expr | Series
             )
         return condition.to_frame().select(arg_where(col(condition.name))).to_series()
     else:
-        condition = expr_to_lit_or_expr(condition, str_to_lit=True)
+        condition = parse_single_expression_input(condition, str_to_lit=True)
         return wrap_expr(plr.arg_where(condition._pyexpr))
 
 

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -124,8 +124,8 @@ def arange(
     └───────────┘
 
     """
-    start = parse_single_expression_input(start, str_as_lit=False)
-    end = parse_single_expression_input(end, str_as_lit=False)
+    start = parse_single_expression_input(start)
+    end = parse_single_expression_input(end)
     range_expr = wrap_expr(plr.arange(start._pyexpr, end._pyexpr, step))
 
     if dtype is not None and dtype != Int64:
@@ -327,8 +327,8 @@ def date_range(
         or isinstance(start, (str, pl.Expr))
         or isinstance(end, (str, pl.Expr))
     ):
-        start = parse_single_expression_input(start, str_as_lit=False)._pyexpr
-        end = parse_single_expression_input(end, str_as_lit=False)._pyexpr
+        start = parse_single_expression_input(start)._pyexpr
+        end = parse_single_expression_input(end)._pyexpr
         return wrap_expr(plr.date_range_lazy(start, end, interval, closed, time_zone))
 
     start, start_is_date = _ensure_datetime(start)
@@ -533,13 +533,11 @@ def time_range(
         start_expr = (
             F.lit(default_start)
             if start is None
-            else parse_single_expression_input(start, str_as_lit=False)
+            else parse_single_expression_input(start)
         )._pyexpr
 
         end_expr = (
-            F.lit(default_end)
-            if end is None
-            else parse_single_expression_input(end, str_as_lit=False)
+            F.lit(default_end) if end is None else parse_single_expression_input(end)
         )._pyexpr
 
         tm_expr = wrap_expr(plr.time_range_lazy(start_expr, end_expr, interval, closed))

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -9,7 +9,7 @@ import polars._reexport as pl
 from polars import functions as F
 from polars.datatypes import Date, Int64
 from polars.expr.datetime import TIME_ZONE_DEPRECATION_MESSAGE
-from polars.utils._parse_expr_input import expr_to_lit_or_expr
+from polars.utils._parse_expr_input import parse_single_expression_input
 from polars.utils._wrap import wrap_expr, wrap_s
 from polars.utils.convert import (
     _datetime_to_pl_timestamp,
@@ -124,8 +124,8 @@ def arange(
     └───────────┘
 
     """
-    start = expr_to_lit_or_expr(start, str_to_lit=False)
-    end = expr_to_lit_or_expr(end, str_to_lit=False)
+    start = parse_single_expression_input(start, str_to_lit=False)
+    end = parse_single_expression_input(end, str_to_lit=False)
     range_expr = wrap_expr(plr.arange(start._pyexpr, end._pyexpr, step))
 
     if dtype is not None and dtype != Int64:
@@ -327,8 +327,8 @@ def date_range(
         or isinstance(start, (str, pl.Expr))
         or isinstance(end, (str, pl.Expr))
     ):
-        start = expr_to_lit_or_expr(start, str_to_lit=False)._pyexpr
-        end = expr_to_lit_or_expr(end, str_to_lit=False)._pyexpr
+        start = parse_single_expression_input(start, str_to_lit=False)._pyexpr
+        end = parse_single_expression_input(end, str_to_lit=False)._pyexpr
         return wrap_expr(plr.date_range_lazy(start, end, interval, closed, time_zone))
 
     start, start_is_date = _ensure_datetime(start)
@@ -533,13 +533,13 @@ def time_range(
         start_expr = (
             F.lit(default_start)
             if start is None
-            else expr_to_lit_or_expr(start, str_to_lit=False)
+            else parse_single_expression_input(start, str_to_lit=False)
         )._pyexpr
 
         end_expr = (
             F.lit(default_end)
             if end is None
-            else expr_to_lit_or_expr(end, str_to_lit=False)
+            else parse_single_expression_input(end, str_to_lit=False)
         )._pyexpr
 
         tm_expr = wrap_expr(plr.time_range_lazy(start_expr, end_expr, interval, closed))

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -124,8 +124,8 @@ def arange(
     └───────────┘
 
     """
-    start = parse_single_expression_input(start, str_to_lit=False)
-    end = parse_single_expression_input(end, str_to_lit=False)
+    start = parse_single_expression_input(start, str_as_lit=False)
+    end = parse_single_expression_input(end, str_as_lit=False)
     range_expr = wrap_expr(plr.arange(start._pyexpr, end._pyexpr, step))
 
     if dtype is not None and dtype != Int64:
@@ -327,8 +327,8 @@ def date_range(
         or isinstance(start, (str, pl.Expr))
         or isinstance(end, (str, pl.Expr))
     ):
-        start = parse_single_expression_input(start, str_to_lit=False)._pyexpr
-        end = parse_single_expression_input(end, str_to_lit=False)._pyexpr
+        start = parse_single_expression_input(start, str_as_lit=False)._pyexpr
+        end = parse_single_expression_input(end, str_as_lit=False)._pyexpr
         return wrap_expr(plr.date_range_lazy(start, end, interval, closed, time_zone))
 
     start, start_is_date = _ensure_datetime(start)
@@ -533,13 +533,13 @@ def time_range(
         start_expr = (
             F.lit(default_start)
             if start is None
-            else parse_single_expression_input(start, str_to_lit=False)
+            else parse_single_expression_input(start, str_as_lit=False)
         )._pyexpr
 
         end_expr = (
             F.lit(default_end)
             if end is None
-            else parse_single_expression_input(end, str_to_lit=False)
+            else parse_single_expression_input(end, str_as_lit=False)
         )._pyexpr
 
         tm_expr = wrap_expr(plr.time_range_lazy(start_expr, end_expr, interval, closed))

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import typing
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any
 
 from polars.utils._parse_expr_input import parse_single_expression_input
 from polars.utils._wrap import wrap_expr
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from polars.type_aliases import IntoExpr
 
 
-def when(expr: IntoExpr | Iterable[IntoExpr]) -> When:
+def when(expr: IntoExpr) -> When:
     """
     Start a "when, then, otherwise" expression.
 
@@ -104,7 +104,7 @@ class When:
     def __init__(self, pywhen: Any):
         self._pywhen = pywhen
 
-    def then(self, expr: IntoExpr | Iterable[IntoExpr]) -> WhenThen:
+    def then(self, expr: IntoExpr) -> WhenThen:
         """
         Values to return in case of the predicate being `True`.
 
@@ -124,12 +124,12 @@ class WhenThen:
     def __init__(self, pywhenthen: Any):
         self._pywhenthen = pywhenthen
 
-    def when(self, predicate: IntoExpr | Iterable[IntoExpr]) -> WhenThenThen:
+    def when(self, predicate: IntoExpr) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
         predicate = parse_single_expression_input(predicate)
         return WhenThenThen(self._pywhenthen.when(predicate._pyexpr))
 
-    def otherwise(self, expr: IntoExpr | Iterable[IntoExpr]) -> Expr:
+    def otherwise(self, expr: IntoExpr) -> Expr:
         """
         Values to return in case of the predicate being `False`.
 
@@ -153,12 +153,12 @@ class WhenThenThen:
     def __init__(self, pywhenthenthen: Any):
         self.pywhenthenthen = pywhenthenthen
 
-    def when(self, predicate: IntoExpr | Iterable[IntoExpr]) -> WhenThenThen:
+    def when(self, predicate: IntoExpr) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
         predicate = parse_single_expression_input(predicate)
         return WhenThenThen(self.pywhenthenthen.when(predicate._pyexpr))
 
-    def then(self, expr: IntoExpr | Iterable[IntoExpr]) -> WhenThenThen:
+    def then(self, expr: IntoExpr) -> WhenThenThen:
         """
         Values to return in case of the predicate being `True`.
 
@@ -170,7 +170,7 @@ class WhenThenThen:
         expr_ = parse_single_expression_input(expr)
         return WhenThenThen(self.pywhenthenthen.then(expr_._pyexpr))
 
-    def otherwise(self, expr: IntoExpr | Iterable[IntoExpr]) -> Expr:
+    def otherwise(self, expr: IntoExpr) -> Expr:
         """
         Values to return in case of the predicate being `False`.
 

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -4,7 +4,7 @@ import contextlib
 import typing
 from typing import TYPE_CHECKING, Any, Iterable
 
-from polars.utils._parse_expr_input import expr_to_lit_or_expr
+from polars.utils._parse_expr_input import parse_single_expression_input
 from polars.utils._wrap import wrap_expr
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -93,7 +93,7 @@ def when(expr: IntoExpr | Iterable[IntoExpr]) -> When:
 
 
     """
-    expr = expr_to_lit_or_expr(expr)
+    expr = parse_single_expression_input(expr)
     pywhen = _when(expr._pyexpr)
     return When(pywhen)
 
@@ -113,7 +113,7 @@ class When:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = expr_to_lit_or_expr(expr)
+        expr = parse_single_expression_input(expr)
         pywhenthen = self._pywhen.then(expr._pyexpr)
         return WhenThen(pywhenthen)
 
@@ -126,7 +126,7 @@ class WhenThen:
 
     def when(self, predicate: IntoExpr | Iterable[IntoExpr]) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
-        predicate = expr_to_lit_or_expr(predicate)
+        predicate = parse_single_expression_input(predicate)
         return WhenThenThen(self._pywhenthen.when(predicate._pyexpr))
 
     def otherwise(self, expr: IntoExpr | Iterable[IntoExpr]) -> Expr:
@@ -138,7 +138,7 @@ class WhenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = expr_to_lit_or_expr(expr)
+        expr = parse_single_expression_input(expr)
         return wrap_expr(self._pywhenthen.otherwise(expr._pyexpr))
 
     @typing.no_type_check
@@ -155,7 +155,7 @@ class WhenThenThen:
 
     def when(self, predicate: IntoExpr | Iterable[IntoExpr]) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
-        predicate = expr_to_lit_or_expr(predicate)
+        predicate = parse_single_expression_input(predicate)
         return WhenThenThen(self.pywhenthenthen.when(predicate._pyexpr))
 
     def then(self, expr: IntoExpr | Iterable[IntoExpr]) -> WhenThenThen:
@@ -167,7 +167,7 @@ class WhenThenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr_ = expr_to_lit_or_expr(expr)
+        expr_ = parse_single_expression_input(expr)
         return WhenThenThen(self.pywhenthenthen.then(expr_._pyexpr))
 
     def otherwise(self, expr: IntoExpr | Iterable[IntoExpr]) -> Expr:
@@ -179,7 +179,7 @@ class WhenThenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = expr_to_lit_or_expr(expr)
+        expr = parse_single_expression_input(expr)
         return wrap_expr(self.pywhenthenthen.otherwise(expr._pyexpr))
 
     @typing.no_type_check

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -113,7 +113,7 @@ class When:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_single_expression_input(expr)
+        expr = parse_single_expression_input(expr, str_as_lit=True)
         pywhenthen = self._pywhen.then(expr._pyexpr)
         return WhenThen(pywhenthen)
 
@@ -138,7 +138,7 @@ class WhenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_single_expression_input(expr)
+        expr = parse_single_expression_input(expr, str_as_lit=True)
         return wrap_expr(self._pywhenthen.otherwise(expr._pyexpr))
 
     @typing.no_type_check
@@ -167,7 +167,7 @@ class WhenThenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr_ = parse_single_expression_input(expr)
+        expr_ = parse_single_expression_input(expr, str_as_lit=True)
         return WhenThenThen(self.pywhenthenthen.then(expr_._pyexpr))
 
     def otherwise(self, expr: IntoExpr) -> Expr:
@@ -179,7 +179,7 @@ class WhenThenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_single_expression_input(expr)
+        expr = parse_single_expression_input(expr, str_as_lit=True)
         return wrap_expr(self.pywhenthenthen.otherwise(expr._pyexpr))
 
     @typing.no_type_check

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1924,7 +1924,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self._from_pyldf(
             self._ldf.filter(
-                parse_single_expression_input(predicate, str_to_lit=False)._pyexpr
+                parse_single_expression_input(predicate, str_as_lit=False)._pyexpr
             )
         )
 
@@ -2047,7 +2047,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if named_exprs:
             exprs.extend(
                 parse_single_expression_input(
-                    expr, structify=structify, str_to_lit=False
+                    expr, structify=structify, str_as_lit=False
                 )
                 .alias(name)
                 ._pyexpr
@@ -2282,7 +2282,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────────┴───────┴───────┴───────┘
 
         """
-        index_column = parse_single_expression_input(index_column, str_to_lit=False)
+        index_column = parse_single_expression_input(index_column, str_as_lit=False)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(period)}"
 
@@ -2594,7 +2594,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────┴─────────────────┴─────┴─────────────────┘
 
         """  # noqa: W505
-        index_column = parse_single_expression_input(index_column, str_to_lit=False)
+        index_column = parse_single_expression_input(index_column, str_as_lit=False)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(every)}" if period is None else "0ns"
 
@@ -3106,7 +3106,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if named_exprs:
             exprs.extend(
                 parse_single_expression_input(
-                    expr, structify=structify, str_to_lit=False
+                    expr, structify=structify, str_as_lit=False
                 )
                 .alias(name)
                 ._pyexpr
@@ -4166,7 +4166,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┘
 
         """
-        quantile = parse_single_expression_input(quantile, str_to_lit=False)
+        quantile = parse_single_expression_input(quantile, str_as_lit=False)
         return self._from_pyldf(self._ldf.quantile(quantile._pyexpr, interpolation))
 
     def explode(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1923,9 +1923,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             predicate = pl.Series(predicate)
 
         return self._from_pyldf(
-            self._ldf.filter(
-                parse_single_expression_input(predicate, str_as_lit=False)._pyexpr
-            )
+            self._ldf.filter(parse_single_expression_input(predicate)._pyexpr)
         )
 
     def select(
@@ -2046,9 +2044,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             exprs.extend(selection_to_pyexpr_list(more_exprs, structify=structify))
         if named_exprs:
             exprs.extend(
-                parse_single_expression_input(
-                    expr, structify=structify, str_as_lit=False
-                )
+                parse_single_expression_input(expr, structify=structify)
                 .alias(name)
                 ._pyexpr
                 for name, expr in named_exprs.items()
@@ -2282,7 +2278,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────────┴───────┴───────┴───────┘
 
         """
-        index_column = parse_single_expression_input(index_column, str_as_lit=False)
+        index_column = parse_single_expression_input(index_column)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(period)}"
 
@@ -2594,7 +2590,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────┴─────────────────┴─────┴─────────────────┘
 
         """  # noqa: W505
-        index_column = parse_single_expression_input(index_column, str_as_lit=False)
+        index_column = parse_single_expression_input(index_column)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(every)}" if period is None else "0ns"
 
@@ -3105,9 +3101,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             exprs.extend(selection_to_pyexpr_list(more_exprs, structify=structify))
         if named_exprs:
             exprs.extend(
-                parse_single_expression_input(
-                    expr, structify=structify, str_as_lit=False
-                )
+                parse_single_expression_input(expr, structify=structify)
                 .alias(name)
                 ._pyexpr
                 for name, expr in named_exprs.items()
@@ -4166,7 +4160,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┘
 
         """
-        quantile = parse_single_expression_input(quantile, str_as_lit=False)
+        quantile = parse_single_expression_input(quantile)
         return self._from_pyldf(self._ldf.quantile(quantile._pyexpr, interpolation))
 
     def explode(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -48,7 +48,10 @@ from polars.io.ipc.anonymous_scan import _scan_ipc_fsspec
 from polars.io.parquet.anonymous_scan import _scan_parquet_fsspec
 from polars.lazyframe.groupby import LazyGroupBy
 from polars.slice import LazyPolarsSlice
-from polars.utils._parse_expr_input import expr_to_lit_or_expr, selection_to_pyexpr_list
+from polars.utils._parse_expr_input import (
+    parse_single_expression_input,
+    selection_to_pyexpr_list,
+)
 from polars.utils._wrap import wrap_df, wrap_expr
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.various import (
@@ -1920,7 +1923,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             predicate = pl.Series(predicate)
 
         return self._from_pyldf(
-            self._ldf.filter(expr_to_lit_or_expr(predicate, str_to_lit=False)._pyexpr)
+            self._ldf.filter(
+                parse_single_expression_input(predicate, str_to_lit=False)._pyexpr
+            )
         )
 
     def select(
@@ -2041,7 +2046,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             exprs.extend(selection_to_pyexpr_list(more_exprs, structify=structify))
         if named_exprs:
             exprs.extend(
-                expr_to_lit_or_expr(expr, structify=structify, str_to_lit=False)
+                parse_single_expression_input(
+                    expr, structify=structify, str_to_lit=False
+                )
                 .alias(name)
                 ._pyexpr
                 for name, expr in named_exprs.items()
@@ -2275,7 +2282,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────────┴───────┴───────┴───────┘
 
         """
-        index_column = expr_to_lit_or_expr(index_column, str_to_lit=False)
+        index_column = parse_single_expression_input(index_column, str_to_lit=False)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(period)}"
 
@@ -2587,7 +2594,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────┴─────────────────┴─────┴─────────────────┘
 
         """  # noqa: W505
-        index_column = expr_to_lit_or_expr(index_column, str_to_lit=False)
+        index_column = parse_single_expression_input(index_column, str_to_lit=False)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(every)}" if period is None else "0ns"
 
@@ -3098,7 +3105,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             exprs.extend(selection_to_pyexpr_list(more_exprs, structify=structify))
         if named_exprs:
             exprs.extend(
-                expr_to_lit_or_expr(expr, structify=structify, str_to_lit=False)
+                parse_single_expression_input(
+                    expr, structify=structify, str_to_lit=False
+                )
                 .alias(name)
                 ._pyexpr
                 for name, expr in named_exprs.items()
@@ -4157,7 +4166,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┘
 
         """
-        quantile = expr_to_lit_or_expr(quantile, str_to_lit=False)
+        quantile = parse_single_expression_input(quantile, str_to_lit=False)
         return self._from_pyldf(self._ldf.quantile(quantile._pyexpr, interpolation))
 
     def explode(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2041,9 +2041,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             exprs.extend(selection_to_pyexpr_list(more_exprs, structify=structify))
         if named_exprs:
             exprs.extend(
-                expr_to_lit_or_expr(
-                    expr, structify=structify, name=name, str_to_lit=False
-                )._pyexpr
+                expr_to_lit_or_expr(expr, structify=structify, str_to_lit=False)
+                .alias(name)
+                ._pyexpr
                 for name, expr in named_exprs.items()
             )
 
@@ -3098,9 +3098,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             exprs.extend(selection_to_pyexpr_list(more_exprs, structify=structify))
         if named_exprs:
             exprs.extend(
-                expr_to_lit_or_expr(
-                    expr, structify=structify, name=name, str_to_lit=False
-                )._pyexpr
+                expr_to_lit_or_expr(expr, structify=structify, str_to_lit=False)
+                .alias(name)
+                ._pyexpr
                 for name, expr in named_exprs.items()
             )
 

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, Iterable
 
 from polars import functions as F
-from polars.utils._parse_expr_input import expr_to_lit_or_expr, selection_to_pyexpr_list
+from polars.utils._parse_expr_input import (
+    parse_single_expression_input,
+    selection_to_pyexpr_list,
+)
 from polars.utils._wrap import wrap_ldf
 
 if TYPE_CHECKING:
@@ -128,7 +131,9 @@ class LazyGroupBy:
             exprs.extend(selection_to_pyexpr_list(more_aggs))
         if named_aggs:
             exprs.extend(
-                expr_to_lit_or_expr(expr, str_to_lit=False).alias(name)._pyexpr
+                parse_single_expression_input(expr, str_to_lit=False)
+                .alias(name)
+                ._pyexpr
                 for name, expr in named_aggs.items()
             )
 

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -131,7 +131,7 @@ class LazyGroupBy:
             exprs.extend(selection_to_pyexpr_list(more_aggs))
         if named_aggs:
             exprs.extend(
-                parse_single_expression_input(expr, str_to_lit=False)
+                parse_single_expression_input(expr, str_as_lit=False)
                 .alias(name)
                 ._pyexpr
                 for name, expr in named_aggs.items()

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -128,7 +128,7 @@ class LazyGroupBy:
             exprs.extend(selection_to_pyexpr_list(more_aggs))
         if named_aggs:
             exprs.extend(
-                expr_to_lit_or_expr(expr, name=name, str_to_lit=False)._pyexpr
+                expr_to_lit_or_expr(expr, str_to_lit=False).alias(name)._pyexpr
                 for name, expr in named_aggs.items()
             )
 

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -131,9 +131,7 @@ class LazyGroupBy:
             exprs.extend(selection_to_pyexpr_list(more_aggs))
         if named_aggs:
             exprs.extend(
-                parse_single_expression_input(expr, str_as_lit=False)
-                .alias(name)
-                ._pyexpr
+                parse_single_expression_input(expr).alias(name)._pyexpr
                 for name, expr in named_aggs.items()
             )
 

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -67,7 +67,7 @@ PolarsExprType: TypeAlias = Union["Expr", "WhenThen", "WhenThenThen"]
 
 # literal types that are allowed in expressions (auto-converted to pl.lit)
 PythonLiteral: TypeAlias = Union[
-    str, int, float, bool, date, time, datetime, timedelta, bytes, Decimal
+    str, int, float, bool, date, time, datetime, timedelta, bytes, Decimal, List[Any]
 ]
 
 IntoExpr: TypeAlias = Union[PolarsExprType, PythonLiteral, "Series", None]

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -25,12 +25,12 @@ def selection_to_pyexpr_list(
     ) or not isinstance(exprs, Iterable):
         return [
             parse_single_expression_input(
-                exprs, str_to_lit=False, structify=structify
+                exprs, str_as_lit=False, structify=structify
             )._pyexpr,
         ]
 
     return [
-        parse_single_expression_input(e, str_to_lit=False, structify=structify)._pyexpr
+        parse_single_expression_input(e, str_as_lit=False, structify=structify)._pyexpr
         for e in exprs  # type: ignore[union-attr]
     ]
 
@@ -38,7 +38,7 @@ def selection_to_pyexpr_list(
 def parse_single_expression_input(
     input: IntoExpr,
     *,
-    str_to_lit: bool = True,
+    str_as_lit: bool = True,
     structify: bool = False,
 ) -> Expr:
     """
@@ -48,7 +48,7 @@ def parse_single_expression_input(
     ----------
     input
         The input to be parsed as an expression.
-    str_to_lit
+    str_as_lit
         Interpret string input as a string literal. If set to ``False``, strings are
         parsed as column names.
     structify
@@ -57,7 +57,7 @@ def parse_single_expression_input(
     """
     if isinstance(input, pl.Expr):
         expr = input
-    elif isinstance(input, str) and not str_to_lit:
+    elif isinstance(input, str) and not str_as_lit:
         expr = F.col(input)
         structify = False
     elif (

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -73,7 +73,7 @@ def parse_single_expression_input(
         expr = input.otherwise(None)  # implicitly add the null branch.
     else:
         raise TypeError(
-            f"did not expect value {input} of type {type(input)}, maybe disambiguate with"
+            f"did not expect value {input!r} of type {type(input)}, maybe disambiguate with"
             " pl.lit or pl.col"
         )
 

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -24,13 +24,11 @@ def selection_to_pyexpr_list(
         exprs, (str, pl.Expr, pl.Series, F.whenthen.WhenThen, F.whenthen.WhenThenThen)
     ) or not isinstance(exprs, Iterable):
         return [
-            parse_single_expression_input(
-                exprs, str_as_lit=False, structify=structify
-            )._pyexpr,
+            parse_single_expression_input(exprs, structify=structify)._pyexpr,
         ]
 
     return [
-        parse_single_expression_input(e, str_as_lit=False, structify=structify)._pyexpr
+        parse_single_expression_input(e, structify=structify)._pyexpr
         for e in exprs  # type: ignore[union-attr]
     ]
 
@@ -38,7 +36,7 @@ def selection_to_pyexpr_list(
 def parse_single_expression_input(
     input: IntoExpr,
     *,
-    str_as_lit: bool = True,
+    str_as_lit: bool = False,
     structify: bool = False,
 ) -> Expr:
     """
@@ -49,8 +47,8 @@ def parse_single_expression_input(
     input
         The input to be parsed as an expression.
     str_as_lit
-        Interpret string input as a string literal. If set to ``False``, strings are
-        parsed as column names.
+        Interpret string input as a string literal. If set to ``False`` (default),
+        strings are parsed as column names.
     structify
         Convert multi-column expressions to a single struct expression.
 

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -13,31 +13,6 @@ if TYPE_CHECKING:
     from polars.type_aliases import IntoExpr
 
 
-def parse_multiple_expression_inputs(
-    exprs: IntoExpr | Iterable[IntoExpr],
-    *more_exprs: IntoExpr,
-    structify: bool = False,
-    **named_exprs: IntoExpr,
-) -> list[PyExpr]:
-    exprs = selection_to_pyexpr_list(exprs, structify=structify)
-    if more_exprs:
-        exprs.extend(selection_to_pyexpr_list(more_exprs, structify=structify))
-    if named_exprs:
-        exprs.extend(
-            expr_to_lit_or_expr(
-                expr, structify=structify, name=name, str_to_lit=False
-            )._pyexpr
-            for name, expr in named_exprs.items()
-        )
-    return exprs
-
-
-def parse_single_expression_input(
-    exprs: IntoExpr,
-) -> list[PyExpr]:
-    pass
-
-
 def selection_to_pyexpr_list(
     exprs: IntoExpr | Iterable[IntoExpr],
     structify: bool = False,
@@ -49,74 +24,72 @@ def selection_to_pyexpr_list(
         exprs, (str, pl.Expr, pl.Series, F.whenthen.WhenThen, F.whenthen.WhenThenThen)
     ) or not isinstance(exprs, Iterable):
         return [
-            expr_to_lit_or_expr(exprs, str_to_lit=False, structify=structify)._pyexpr,
+            parse_single_expression_input(
+                exprs, str_to_lit=False, structify=structify
+            )._pyexpr,
         ]
 
     return [
-        expr_to_lit_or_expr(e, str_to_lit=False, structify=structify)._pyexpr
+        parse_single_expression_input(e, str_to_lit=False, structify=structify)._pyexpr
         for e in exprs  # type: ignore[union-attr]
     ]
 
 
-def expr_to_lit_or_expr(
-    expr: IntoExpr | Iterable[IntoExpr],
+def parse_single_expression_input(
+    input: IntoExpr,
+    *,
     str_to_lit: bool = True,
     structify: bool = False,
 ) -> Expr:
     """
-    Convert args to expressions.
+    Parse a single input into an expression.
 
     Parameters
     ----------
-    expr
-        Any argument.
+    input
+        The input to be parsed as an expression.
     str_to_lit
-        If True string argument `"foo"` will be converted to `lit("foo")`.
-        If False it will be converted to `col("foo")`.
+        Interpret string input as a string literal. If set to ``False``, strings are
+        parsed as column names.
     structify
-        If the final unaliased expression has multiple output names,
-        automatically convert it to struct.
-
-    Returns
-    -------
-    Expr
+        Convert multi-column expressions to a single struct expression.
 
     """
-    if isinstance(expr, pl.Expr):
-        pass
-    elif isinstance(expr, str) and not str_to_lit:
-        expr = F.col(expr)
+    if isinstance(input, pl.Expr):
+        expr = input
+    elif isinstance(input, str) and not str_to_lit:
+        expr = F.col(input)
+        structify = False
     elif (
-        isinstance(expr, (int, float, str, pl.Series, datetime, date, time, timedelta))
-        or expr is None
+        isinstance(input, (int, float, str, pl.Series, datetime, date, time, timedelta))
+        or input is None
     ):
-        expr = F.lit(expr)
+        expr = F.lit(input)
         structify = False
-    elif isinstance(expr, list):
-        expr = F.lit(pl.Series("", [expr]))
+    elif isinstance(input, list):
+        expr = F.lit(pl.Series("", [input]))
         structify = False
-    elif isinstance(expr, (F.whenthen.WhenThen, F.whenthen.WhenThenThen)):
-        expr = expr.otherwise(None)  # implicitly add the null branch.
+    elif isinstance(input, (F.whenthen.WhenThen, F.whenthen.WhenThenThen)):
+        expr = input.otherwise(None)  # implicitly add the null branch.
     else:
         raise TypeError(
-            f"did not expect value {expr} of type {type(expr)}, maybe disambiguate with"
+            f"did not expect value {input} of type {type(input)}, maybe disambiguate with"
             " pl.lit or pl.col"
         )
 
     if structify:
-        unaliased_expr = expr.meta.undo_aliases()
-        if unaliased_expr.meta.has_multiple_outputs():
-            expr_name = _expr_output_name(expr)
-            if expr_name is None:
-                expr = F.struct(expr)
-            else:
-                expr = F.struct(unaliased_expr).alias(expr_name)
+        expr = _structify_expression(expr)
 
     return expr
 
 
-def _expr_output_name(expr: Expr) -> str | None:
-    try:
-        return expr.meta.output_name()
-    except ComputeError:
-        return None
+def _structify_expression(expr: Expr) -> Expr:
+    unaliased_expr = expr.meta.undo_aliases()
+    if unaliased_expr.meta.has_multiple_outputs():
+        try:
+            expr_name = expr.meta.output_name()
+        except ComputeError:
+            expr = F.struct(expr)
+        else:
+            expr = F.struct(unaliased_expr).alias(expr_name)
+    return expr

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -246,9 +246,7 @@ def test_window_functions_list_types() -> None:
     # that's why we don't add it to the allowed types.
     assert (
         df.select(
-            pl.col("col_list")
-            .shift_and_fill(None, periods=1)  # type: ignore[arg-type]
-            .alias("list_shifted")
+            pl.col("col_list").shift_and_fill(None, periods=1).alias("list_shifted")
         )
     )["list_shifted"].to_list() == [None, [1], [1], [2]]
 

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -33,10 +33,8 @@ def test_when_then_implicit_none() -> None:
     )
 
     assert df.select(
-        [
-            pl.when(pl.col("points") > 7).then("Foo"),
-            pl.when(pl.col("points") > 7).then("Foo").alias("bar"),
-        ]
+        pl.when(pl.col("points") > 7).then("Foo"),
+        pl.when(pl.col("points") > 7).then("Foo").alias("bar"),
     ).to_dict(False) == {
         "literal": ["Foo", "Foo", "Foo", None, None, None],
         "bar": ["Foo", "Foo", "Foo", None, None, None],

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -394,7 +394,7 @@ def test_power() -> None:
     assert_series_equal(a**b, pl.Series([None, 4.0], dtype=Float64))
     with pytest.raises(ValueError):
         c**2
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(pl.ColumnNotFoundError):
         a ** "hi"  # type: ignore[operator]
 
     # rpow
@@ -402,7 +402,7 @@ def test_power() -> None:
     assert_series_equal(2**b, pl.Series("literal", [None, 4.0], dtype=Float64))
     with pytest.raises(ValueError):
         2**c
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(pl.ColumnNotFoundError):
         "hi" ** a
 
     # Series.pow() method


### PR DESCRIPTION
Changes:
* Rename util `expr_to_lit_or_expr` -> `parse_single_expression_input`
* Remove the `name` argument - it was rarely used and you can just call `alias` on the result
* Rename argument `str_to_lit` -> `str_as_lit`  and change the default from `True` to `False` (it was set to `False` in most cases already).
* Fix some type hints

I will continue refactoring the expression parsing utils as there is a lot of duplication - but I'm sending this PR already as it's quite big.