### PR TITLE
perf(rust, python): speed up write_csv for time-zone-aware columns

### DIFF
--- a/polars/polars-time/src/windows/test.rs
+++ b/polars/polars-time/src/windows/test.rs
@@ -636,7 +636,6 @@ fn test_rolling_lookback() {
         None,
     )
     .unwrap(); // unwrapping as we pass None as the time zone
-    println!("dates: {:?}", dates);
 
     // full lookbehind
     let groups = groupby_values(

--- a/polars/polars-time/src/windows/test.rs
+++ b/polars/polars-time/src/windows/test.rs
@@ -636,6 +636,7 @@ fn test_rolling_lookback() {
         None,
     )
     .unwrap(); // unwrapping as we pass None as the time zone
+    println!("dates: {:?}", dates);
 
     // full lookbehind
     let groups = groupby_values(


### PR DESCRIPTION
I'd expect this to improve performance, as it means that the time zone doesn't need to be parsed for each element, but I'm running a timing test to check, will post results when it's done

EDIT timing test on 2.5 million rows: https://www.kaggle.com/code/marcogorelli/polars-timing?scriptVersionId=131434660

here:
- 4.8 s ± 158 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
- 2.48 s ± 102 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

upstream/main:
- 5.19 s ± 671 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
- 2.57 s ± 168 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)