### PR TITLE
refactor(python): Improve expression parsing utils

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -90,7 +90,7 @@ from polars.utils._construction import (
     sequence_to_pydf,
     series_to_pydf,
 )
-from polars.utils._parse_expr_input import parse_single_expression_input
+from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_ldf, wrap_s
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias
@@ -7902,7 +7902,7 @@ class DataFrame:
             subset = [subset]
 
         if isinstance(subset, Sequence) and len(subset) == 1:
-            expr = parse_single_expression_input(subset[0])
+            expr = parse_as_expression(subset[0])
         else:
             struct_fields = F.all() if (subset is None) else subset
             expr = F.struct(struct_fields)  # type: ignore[call-overload]

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -335,8 +335,8 @@ class ExprDateTimeNameSpace:
             raise TypeError(
                 f"expected 'time' to be a python time or polars expression, found {time!r}"
             )
-        time = parse_as_expression(time)
-        return wrap_expr(self._pyexpr.dt_combine(time._pyexpr, time_unit))
+        time = parse_as_expression(time)._pyexpr
+        return wrap_expr(self._pyexpr.dt_combine(time, time_unit))
 
     def to_string(self, format: str) -> Expr:
         """

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import polars._reexport as pl
 from polars import functions as F
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
-from polars.utils._parse_expr_input import parse_single_expression_input
+from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias
@@ -335,7 +335,7 @@ class ExprDateTimeNameSpace:
             raise TypeError(
                 f"expected 'time' to be a python time or polars expression, found {time!r}"
             )
-        time = parse_single_expression_input(time)
+        time = parse_as_expression(time)
         return wrap_expr(self._pyexpr.dt_combine(time._pyexpr, time_unit))
 
     def to_string(self, format: str) -> Expr:

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1244,8 +1244,8 @@ class Expr:
         └─────┴──────┘
 
         """
-        other = parse_as_expression(other)
-        return self._from_pyexpr(self._pyexpr.append(other._pyexpr, upcast))
+        other = parse_as_expression(other)._pyexpr
+        return self._from_pyexpr(self._pyexpr.append(other, upcast))
 
     def rechunk(self) -> Self:
         """
@@ -1678,8 +1678,8 @@ class Expr:
         └─────┘
 
         """
-        other = parse_as_expression(other)
-        return self._from_pyexpr(self._pyexpr.dot(other._pyexpr))
+        other = parse_as_expression(other)._pyexpr
+        return self._from_pyexpr(self._pyexpr.dot(other))
 
     def mode(self) -> Self:
         """
@@ -2049,8 +2049,8 @@ class Expr:
         └──────┴───────┴─────┘
 
         """
-        element = parse_as_expression(element)
-        return self._from_pyexpr(self._pyexpr.search_sorted(element._pyexpr, side))
+        element = parse_as_expression(element)._pyexpr
+        return self._from_pyexpr(self._pyexpr.search_sorted(element, side))
 
     def sort_by(
         self,
@@ -2296,10 +2296,8 @@ class Expr:
         └─────┘
 
         """
-        fill_value = parse_as_expression(fill_value, str_as_lit=True)
-        return self._from_pyexpr(
-            self._pyexpr.shift_and_fill(periods, fill_value._pyexpr)
-        )
+        fill_value = parse_as_expression(fill_value, str_as_lit=True)._pyexpr
+        return self._from_pyexpr(self._pyexpr.shift_and_fill(periods, fill_value))
 
     def fill_null(
         self,
@@ -2376,8 +2374,8 @@ class Expr:
             )
 
         if value is not None:
-            value = parse_as_expression(value, str_as_lit=True)
-            return self._from_pyexpr(self._pyexpr.fill_null(value._pyexpr))
+            value = parse_as_expression(value, str_as_lit=True)._pyexpr
+            return self._from_pyexpr(self._pyexpr.fill_null(value))
         else:
             return self._from_pyexpr(
                 self._pyexpr.fill_null_with_strategy(strategy, limit)
@@ -2408,8 +2406,8 @@ class Expr:
         └──────┴──────┘
 
         """
-        fill_value = parse_as_expression(value, str_as_lit=True)
-        return self._from_pyexpr(self._pyexpr.fill_nan(fill_value._pyexpr))
+        fill_value = parse_as_expression(value, str_as_lit=True)._pyexpr
+        return self._from_pyexpr(self._pyexpr.fill_nan(fill_value))
 
     def forward_fill(self, limit: int | None = None) -> Self:
         """
@@ -3171,8 +3169,8 @@ class Expr:
         └─────┘
 
         """
-        quantile = parse_as_expression(quantile)
-        return self._from_pyexpr(self._pyexpr.quantile(quantile._pyexpr, interpolation))
+        quantile = parse_as_expression(quantile)._pyexpr
+        return self._from_pyexpr(self._pyexpr.quantile(quantile, interpolation))
 
     def filter(self, predicate: Expr) -> Self:
         """
@@ -4222,8 +4220,8 @@ class Expr:
         └─────┴───────┴────────────┘
 
         """
-        exponent = parse_as_expression(exponent)
-        return self._from_pyexpr(self._pyexpr.pow(exponent._pyexpr))
+        exponent = parse_as_expression(exponent)._pyexpr
+        return self._from_pyexpr(self._pyexpr.pow(exponent))
 
     def xor(self, other: Any) -> Self:
         """
@@ -4357,8 +4355,8 @@ class Expr:
         └─────────────────┘
 
         """
-        by = parse_as_expression(by)
-        return self._from_pyexpr(self._pyexpr.repeat_by(by._pyexpr))
+        by = parse_as_expression(by)._pyexpr
+        return self._from_pyexpr(self._pyexpr.repeat_by(by))
 
     def is_between(
         self,

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -43,8 +43,8 @@ from polars.expr.meta import ExprMetaNameSpace
 from polars.expr.string import ExprStringNameSpace
 from polars.expr.struct import ExprStructNameSpace
 from polars.utils._parse_expr_input import (
+    parse_as_list_of_expressions,
     parse_single_expression_input,
-    selection_to_pyexpr_list,
 )
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias
@@ -231,7 +231,7 @@ class Expr:
                     "Numpy ufunc with more than one expression can only be used if all non-expression inputs are provided as keyword arguments only"
                 )
 
-            exprs = selection_to_pyexpr_list(inputs)
+            exprs = parse_as_list_of_expressions(inputs)
             return self._from_pyexpr(pyreduce(partial(ufunc, **kwargs), exprs))
 
         def function(s: Series) -> Series:  # pragma: no cover
@@ -2176,9 +2176,7 @@ class Expr:
         └───────┴────────┴────────┘
 
         """
-        by = selection_to_pyexpr_list(by)
-        if more_by:
-            by.extend(selection_to_pyexpr_list(more_by))
+        by = parse_as_list_of_expressions(by, *more_by)
         if isinstance(descending, bool):
             descending = [descending]
         elif len(by) != len(descending):
@@ -3029,9 +3027,7 @@ class Expr:
         └─────┴─────┴─────┴───────┘
 
         """
-        exprs = selection_to_pyexpr_list(expr)
-        if more_exprs:
-            exprs.extend(selection_to_pyexpr_list(more_exprs))
+        exprs = parse_as_list_of_expressions(expr, *more_exprs)
         return self._from_pyexpr(self._pyexpr.over(exprs, mapping_strategy))
 
     def is_unique(self) -> Self:

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -43,8 +43,8 @@ from polars.expr.meta import ExprMetaNameSpace
 from polars.expr.string import ExprStringNameSpace
 from polars.expr.struct import ExprStructNameSpace
 from polars.utils._parse_expr_input import (
+    parse_as_expression,
     parse_as_list_of_expressions,
-    parse_single_expression_input,
 )
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias
@@ -191,7 +191,7 @@ class Expr:
         return self.pow(power)
 
     def __rpow__(self, base: int | float | Expr) -> Expr:
-        return parse_single_expression_input(base) ** self
+        return parse_as_expression(base) ** self
 
     def __sub__(self, other: Any) -> Self:
         return self._from_pyexpr(self._pyexpr - self._to_pyexpr(other))
@@ -1244,7 +1244,7 @@ class Expr:
         └─────┴──────┘
 
         """
-        other = parse_single_expression_input(other)
+        other = parse_as_expression(other)
         return self._from_pyexpr(self._pyexpr.append(other._pyexpr, upcast))
 
     def rechunk(self) -> Self:
@@ -1678,7 +1678,7 @@ class Expr:
         └─────┘
 
         """
-        other = parse_single_expression_input(other)
+        other = parse_as_expression(other)
         return self._from_pyexpr(self._pyexpr.dot(other._pyexpr))
 
     def mode(self) -> Self:
@@ -2049,7 +2049,7 @@ class Expr:
         └──────┴───────┴─────┘
 
         """
-        element = parse_single_expression_input(element)
+        element = parse_as_expression(element)
         return self._from_pyexpr(self._pyexpr.search_sorted(element._pyexpr, side))
 
     def sort_by(
@@ -2232,7 +2232,7 @@ class Expr:
         ):
             indices_lit = F.lit(pl.Series("", indices, dtype=UInt32))
         else:
-            indices_lit = parse_single_expression_input(indices)  # type: ignore[arg-type]
+            indices_lit = parse_as_expression(indices)  # type: ignore[arg-type]
         return self._from_pyexpr(self._pyexpr.take(indices_lit._pyexpr))
 
     def shift(self, periods: int = 1) -> Self:
@@ -2296,7 +2296,7 @@ class Expr:
         └─────┘
 
         """
-        fill_value = parse_single_expression_input(fill_value, str_as_lit=True)
+        fill_value = parse_as_expression(fill_value, str_as_lit=True)
         return self._from_pyexpr(
             self._pyexpr.shift_and_fill(periods, fill_value._pyexpr)
         )
@@ -2376,7 +2376,7 @@ class Expr:
             )
 
         if value is not None:
-            value = parse_single_expression_input(value, str_as_lit=True)
+            value = parse_as_expression(value, str_as_lit=True)
             return self._from_pyexpr(self._pyexpr.fill_null(value._pyexpr))
         else:
             return self._from_pyexpr(
@@ -2408,7 +2408,7 @@ class Expr:
         └──────┴──────┘
 
         """
-        fill_value = parse_single_expression_input(value, str_as_lit=True)
+        fill_value = parse_as_expression(value, str_as_lit=True)
         return self._from_pyexpr(self._pyexpr.fill_nan(fill_value._pyexpr))
 
     def forward_fill(self, limit: int | None = None) -> Self:
@@ -3171,7 +3171,7 @@ class Expr:
         └─────┘
 
         """
-        quantile = parse_single_expression_input(quantile)
+        quantile = parse_as_expression(quantile)
         return self._from_pyexpr(self._pyexpr.quantile(quantile._pyexpr, interpolation))
 
     def filter(self, predicate: Expr) -> Self:
@@ -3617,7 +3617,7 @@ class Expr:
         └─────┘
 
         """
-        offset = -parse_single_expression_input(n)
+        offset = -parse_as_expression(n)
         return self.slice(offset, n)
 
     def limit(self, n: int | Expr = 10) -> Self:
@@ -4222,7 +4222,7 @@ class Expr:
         └─────┴───────┴────────────┘
 
         """
-        exponent = parse_single_expression_input(exponent)
+        exponent = parse_as_expression(exponent)
         return self._from_pyexpr(self._pyexpr.pow(exponent._pyexpr))
 
     def xor(self, other: Any) -> Self:
@@ -4316,7 +4316,7 @@ class Expr:
                 other = sorted(other)
             other = F.lit(None) if len(other) == 0 else F.lit(pl.Series(other))
         else:
-            other = parse_single_expression_input(other)
+            other = parse_as_expression(other)
         return self._from_pyexpr(self._pyexpr.is_in(other._pyexpr))
 
     def repeat_by(self, by: pl.Series | Expr | str | int) -> Self:
@@ -4357,7 +4357,7 @@ class Expr:
         └─────────────────┘
 
         """
-        by = parse_single_expression_input(by)
+        by = parse_as_expression(by)
         return self._from_pyexpr(self._pyexpr.repeat_by(by._pyexpr))
 
     def is_between(
@@ -4443,8 +4443,8 @@ class Expr:
         └─────┴────────────┘
 
         """
-        lower_bound = parse_single_expression_input(lower_bound)
-        upper_bound = parse_single_expression_input(upper_bound)
+        lower_bound = parse_as_expression(lower_bound)
+        upper_bound = parse_as_expression(upper_bound)
 
         if closed == "none":
             return (self > lower_bound) & (self < upper_bound)

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 import polars._reexport as pl
 from polars import functions as F
-from polars.utils._parse_expr_input import parse_single_expression_input
+from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
 from polars.utils.decorators import deprecated_alias
 
@@ -295,7 +295,7 @@ class ExprListNameSpace:
         └──────┘
 
         """
-        index = parse_single_expression_input(index)._pyexpr
+        index = parse_as_expression(index)._pyexpr
         return wrap_expr(self._pyexpr.list_get(index))
 
     def take(
@@ -323,7 +323,7 @@ class ExprListNameSpace:
         """
         if isinstance(index, list):
             index = pl.Series(index)
-        index = parse_single_expression_input(index)._pyexpr
+        index = parse_as_expression(index)._pyexpr
         return wrap_expr(self._pyexpr.list_take(index, null_on_oob))
 
     def first(self) -> Expr:
@@ -403,7 +403,7 @@ class ExprListNameSpace:
         """
         return wrap_expr(
             self._pyexpr.list_contains(
-                parse_single_expression_input(item, str_as_lit=True)._pyexpr
+                parse_as_expression(item, str_as_lit=True)._pyexpr
             )
         )
 
@@ -596,8 +596,8 @@ class ExprListNameSpace:
         ]
 
         """
-        offset = parse_single_expression_input(offset)._pyexpr
-        length = parse_single_expression_input(length)._pyexpr
+        offset = parse_as_expression(offset)._pyexpr
+        length = parse_as_expression(length)._pyexpr
         return wrap_expr(self._pyexpr.list_slice(offset, length))
 
     def head(self, n: int | str | Expr = 5) -> Expr:
@@ -644,7 +644,7 @@ class ExprListNameSpace:
         ]
 
         """
-        n = parse_single_expression_input(n)
+        n = parse_as_expression(n)
         return wrap_expr(self._pyexpr.list_tail(n._pyexpr))
 
     def explode(self) -> Expr:
@@ -709,7 +709,7 @@ class ExprListNameSpace:
         """
         return wrap_expr(
             self._pyexpr.list_count_match(
-                parse_single_expression_input(element, str_as_lit=True)._pyexpr
+                parse_as_expression(element, str_as_lit=True)._pyexpr
             )
         )
 

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -401,11 +401,8 @@ class ExprListNameSpace:
         └───────┘
 
         """
-        return wrap_expr(
-            self._pyexpr.list_contains(
-                parse_as_expression(item, str_as_lit=True)._pyexpr
-            )
-        )
+        item = parse_as_expression(item, str_as_lit=True)._pyexpr
+        return wrap_expr(self._pyexpr.list_contains(item))
 
     def join(self, separator: str) -> Expr:
         """
@@ -644,8 +641,8 @@ class ExprListNameSpace:
         ]
 
         """
-        n = parse_as_expression(n)
-        return wrap_expr(self._pyexpr.list_tail(n._pyexpr))
+        n = parse_as_expression(n)._pyexpr
+        return wrap_expr(self._pyexpr.list_tail(n))
 
     def explode(self) -> Expr:
         """
@@ -707,11 +704,8 @@ class ExprListNameSpace:
         └────────────────┘
 
         """
-        return wrap_expr(
-            self._pyexpr.list_count_match(
-                parse_as_expression(element, str_as_lit=True)._pyexpr
-            )
-        )
+        element = parse_as_expression(element, str_as_lit=True)._pyexpr
+        return wrap_expr(self._pyexpr.list_count_match(element))
 
     @deprecated_alias(name_generator="fields")
     def to_struct(

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 from polars.datatypes import Date, Datetime, Time, py_type_to_dtype
 from polars.exceptions import ChronoFormatWarning
-from polars.utils._parse_expr_input import parse_single_expression_input
+from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
 from polars.utils.decorators import deprecated_alias
 from polars.utils.various import find_stacklevel
@@ -736,7 +736,7 @@ class ExprStringNameSpace:
         ends_with : Check if string values end with a substring.
 
         """
-        pattern = parse_single_expression_input(pattern, str_as_lit=True)._pyexpr
+        pattern = parse_as_expression(pattern, str_as_lit=True)._pyexpr
         return wrap_expr(self._pyexpr.str_contains(pattern, literal, strict))
 
     def ends_with(self, suffix: str | Expr) -> Expr:
@@ -783,7 +783,7 @@ class ExprStringNameSpace:
         starts_with : Check if string values start with a substring.
 
         """
-        suffix = parse_single_expression_input(suffix, str_as_lit=True)._pyexpr
+        suffix = parse_as_expression(suffix, str_as_lit=True)._pyexpr
         return wrap_expr(self._pyexpr.str_ends_with(suffix))
 
     def starts_with(self, prefix: str | Expr) -> Expr:
@@ -830,7 +830,7 @@ class ExprStringNameSpace:
         ends_with : Check if string values end with a substring.
 
         """
-        prefix = parse_single_expression_input(prefix, str_as_lit=True)._pyexpr
+        prefix = parse_as_expression(prefix, str_as_lit=True)._pyexpr
         return wrap_expr(self._pyexpr.str_starts_with(prefix))
 
     def json_extract(self, dtype: PolarsDataType | None = None) -> Expr:
@@ -1134,7 +1134,7 @@ class ExprStringNameSpace:
         └────────────────┘
 
         '''
-        pattern = parse_single_expression_input(pattern, str_as_lit=True)
+        pattern = parse_as_expression(pattern, str_as_lit=True)
         return wrap_expr(self._pyexpr.str_extract_all(pattern._pyexpr))
 
     def count_match(self, pattern: str) -> Expr:
@@ -1410,8 +1410,8 @@ class ExprStringNameSpace:
         └─────┴────────┘
 
         """
-        pattern = parse_single_expression_input(pattern, str_as_lit=True)
-        value = parse_single_expression_input(value, str_as_lit=True)
+        pattern = parse_as_expression(pattern, str_as_lit=True)
+        value = parse_as_expression(value, str_as_lit=True)
         return wrap_expr(
             self._pyexpr.str_replace_n(pattern._pyexpr, value._pyexpr, literal, n)
         )
@@ -1451,8 +1451,8 @@ class ExprStringNameSpace:
         └─────┴─────────┘
 
         """
-        pattern = parse_single_expression_input(pattern, str_as_lit=True)
-        value = parse_single_expression_input(value, str_as_lit=True)
+        pattern = parse_as_expression(pattern, str_as_lit=True)
+        value = parse_as_expression(value, str_as_lit=True)
         return wrap_expr(
             self._pyexpr.str_replace_all(pattern._pyexpr, value._pyexpr, literal)
         )

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1134,8 +1134,8 @@ class ExprStringNameSpace:
         └────────────────┘
 
         '''
-        pattern = parse_as_expression(pattern, str_as_lit=True)
-        return wrap_expr(self._pyexpr.str_extract_all(pattern._pyexpr))
+        pattern = parse_as_expression(pattern, str_as_lit=True)._pyexpr
+        return wrap_expr(self._pyexpr.str_extract_all(pattern))
 
     def count_match(self, pattern: str) -> Expr:
         r"""
@@ -1410,11 +1410,9 @@ class ExprStringNameSpace:
         └─────┴────────┘
 
         """
-        pattern = parse_as_expression(pattern, str_as_lit=True)
-        value = parse_as_expression(value, str_as_lit=True)
-        return wrap_expr(
-            self._pyexpr.str_replace_n(pattern._pyexpr, value._pyexpr, literal, n)
-        )
+        pattern = parse_as_expression(pattern, str_as_lit=True)._pyexpr
+        value = parse_as_expression(value, str_as_lit=True)._pyexpr
+        return wrap_expr(self._pyexpr.str_replace_n(pattern, value, literal, n))
 
     def replace_all(
         self, pattern: str | Expr, value: str | Expr, *, literal: bool = False
@@ -1451,11 +1449,9 @@ class ExprStringNameSpace:
         └─────┴─────────┘
 
         """
-        pattern = parse_as_expression(pattern, str_as_lit=True)
-        value = parse_as_expression(value, str_as_lit=True)
-        return wrap_expr(
-            self._pyexpr.str_replace_all(pattern._pyexpr, value._pyexpr, literal)
-        )
+        pattern = parse_as_expression(pattern, str_as_lit=True)._pyexpr
+        value = parse_as_expression(value, str_as_lit=True)._pyexpr
+        return wrap_expr(self._pyexpr.str_replace_all(pattern, value, literal))
 
     def slice(self, offset: int, length: int | None = None) -> Expr:
         """

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING, Iterable, overload
 from polars import functions as F
 from polars.datatypes import Date, Struct, Time
 from polars.utils._parse_expr_input import (
+    parse_as_expression,
     parse_as_list_of_expressions,
-    parse_single_expression_input,
 )
 from polars.utils._wrap import wrap_expr
 
@@ -61,18 +61,18 @@ def datetime_(
     Expr of type `pl.Datetime`
 
     """
-    year_expr = parse_single_expression_input(year)
-    month_expr = parse_single_expression_input(month)
-    day_expr = parse_single_expression_input(day)
+    year_expr = parse_as_expression(year)
+    month_expr = parse_as_expression(month)
+    day_expr = parse_as_expression(day)
 
     if hour is not None:
-        hour = parse_single_expression_input(hour)._pyexpr
+        hour = parse_as_expression(hour)._pyexpr
     if minute is not None:
-        minute = parse_single_expression_input(minute)._pyexpr
+        minute = parse_as_expression(minute)._pyexpr
     if second is not None:
-        second = parse_single_expression_input(second)._pyexpr
+        second = parse_as_expression(second)._pyexpr
     if microsecond is not None:
-        microsecond = parse_single_expression_input(microsecond)._pyexpr
+        microsecond = parse_as_expression(microsecond)._pyexpr
 
     return wrap_expr(
         plr.datetime(
@@ -203,21 +203,21 @@ def duration(
 
     """  # noqa: W505
     if hours is not None:
-        hours = parse_single_expression_input(hours)._pyexpr
+        hours = parse_as_expression(hours)._pyexpr
     if minutes is not None:
-        minutes = parse_single_expression_input(minutes)._pyexpr
+        minutes = parse_as_expression(minutes)._pyexpr
     if seconds is not None:
-        seconds = parse_single_expression_input(seconds)._pyexpr
+        seconds = parse_as_expression(seconds)._pyexpr
     if milliseconds is not None:
-        milliseconds = parse_single_expression_input(milliseconds)._pyexpr
+        milliseconds = parse_as_expression(milliseconds)._pyexpr
     if microseconds is not None:
-        microseconds = parse_single_expression_input(microseconds)._pyexpr
+        microseconds = parse_as_expression(microseconds)._pyexpr
     if nanoseconds is not None:
-        nanoseconds = parse_single_expression_input(nanoseconds)._pyexpr
+        nanoseconds = parse_as_expression(nanoseconds)._pyexpr
     if days is not None:
-        days = parse_single_expression_input(days)._pyexpr
+        days = parse_as_expression(days)._pyexpr
     if weeks is not None:
-        weeks = parse_single_expression_input(weeks)._pyexpr
+        weeks = parse_as_expression(weeks)._pyexpr
 
     return wrap_expr(
         plr.duration(
@@ -499,7 +499,7 @@ def format(f_string: str, *args: Expr | str) -> Expr:
     arguments = iter(args)
     for i, s in enumerate(f_string.split("{}")):
         if i > 0:
-            e = parse_single_expression_input(next(arguments))
+            e = parse_as_expression(next(arguments))
             exprs.append(e)
 
         if len(s) > 0:

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -61,9 +61,9 @@ def datetime_(
     Expr of type `pl.Datetime`
 
     """
-    year_expr = parse_as_expression(year)
-    month_expr = parse_as_expression(month)
-    day_expr = parse_as_expression(day)
+    year_expr = parse_as_expression(year)._pyexpr
+    month_expr = parse_as_expression(month)._pyexpr
+    day_expr = parse_as_expression(day)._pyexpr
 
     if hour is not None:
         hour = parse_as_expression(hour)._pyexpr
@@ -76,9 +76,9 @@ def datetime_(
 
     return wrap_expr(
         plr.datetime(
-            year_expr._pyexpr,
-            month_expr._pyexpr,
-            day_expr._pyexpr,
+            year_expr,
+            month_expr,
+            day_expr,
             hour,
             minute,
             second,

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1715,12 +1715,12 @@ def fold(
     └─────┴─────┘
     """
     # in case of pl.col("*")
-    acc = parse_as_expression(acc, str_as_lit=True)
+    acc = parse_as_expression(acc, str_as_lit=True)._pyexpr
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
     exprs = parse_as_list_of_expressions(exprs)
-    return wrap_expr(plr.fold(acc._pyexpr, function, exprs))
+    return wrap_expr(plr.fold(acc, function, exprs))
 
 
 def reduce(
@@ -1856,12 +1856,12 @@ def cumfold(
 
     """  # noqa: W505
     # in case of pl.col("*")
-    acc = parse_as_expression(acc, str_as_lit=True)
+    acc = parse_as_expression(acc, str_as_lit=True)._pyexpr
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
     exprs = parse_as_list_of_expressions(exprs)
-    return wrap_expr(plr.cumfold(acc._pyexpr, function, exprs, include_init))
+    return wrap_expr(plr.cumfold(acc, function, exprs, include_init))
 
 
 def cumreduce(
@@ -2446,8 +2446,8 @@ def arg_where(condition: Expr | Series, *, eager: bool = False) -> Expr | Series
             )
         return condition.to_frame().select(arg_where(col(condition.name))).to_series()
     else:
-        condition = parse_as_expression(condition)
-        return wrap_expr(plr.arg_where(condition._pyexpr))
+        condition = parse_as_expression(condition)._pyexpr
+        return wrap_expr(plr.arg_where(condition))
 
 
 def coalesce(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -18,8 +18,8 @@ from polars.datatypes import (
 from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
 from polars.utils._parse_expr_input import (
+    parse_as_expression,
     parse_as_list_of_expressions,
-    parse_single_expression_input,
 )
 from polars.utils._wrap import wrap_df, wrap_expr
 from polars.utils.convert import (
@@ -1715,7 +1715,7 @@ def fold(
     └─────┴─────┘
     """
     # in case of pl.col("*")
-    acc = parse_single_expression_input(acc, str_as_lit=True)
+    acc = parse_as_expression(acc, str_as_lit=True)
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
@@ -1856,7 +1856,7 @@ def cumfold(
 
     """  # noqa: W505
     # in case of pl.col("*")
-    acc = parse_single_expression_input(acc, str_as_lit=True)
+    acc = parse_as_expression(acc, str_as_lit=True)
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
@@ -2446,7 +2446,7 @@ def arg_where(condition: Expr | Series, *, eager: bool = False) -> Expr | Series
             )
         return condition.to_frame().select(arg_where(col(condition.name))).to_series()
     else:
-        condition = parse_single_expression_input(condition)
+        condition = parse_as_expression(condition)
         return wrap_expr(plr.arg_where(condition._pyexpr))
 
 

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -18,8 +18,8 @@ from polars.datatypes import (
 from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
 from polars.utils._parse_expr_input import (
+    parse_as_list_of_expressions,
     parse_single_expression_input,
-    selection_to_pyexpr_list,
 )
 from polars.utils._wrap import wrap_df, wrap_expr
 from polars.utils.convert import (
@@ -525,9 +525,7 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
         elif isinstance(exprs, str):
             return col(exprs).max()
 
-    exprs = selection_to_pyexpr_list(exprs)
-    if more_exprs:
-        exprs.extend(selection_to_pyexpr_list(more_exprs))
+    exprs = parse_as_list_of_expressions(exprs, *more_exprs)
     return wrap_expr(plr.max_exprs(exprs))
 
 
@@ -625,9 +623,7 @@ def min(
         elif isinstance(exprs, str):
             return col(exprs).min()
 
-    exprs = selection_to_pyexpr_list(exprs)
-    if more_exprs:
-        exprs.extend(selection_to_pyexpr_list(more_exprs))
+    exprs = parse_as_list_of_expressions(exprs, *more_exprs)
     return wrap_expr(plr.min_exprs(exprs))
 
 
@@ -741,9 +737,7 @@ def sum(
         elif isinstance(exprs, str):
             return col(exprs).sum()
 
-    exprs = selection_to_pyexpr_list(exprs)
-    if more_exprs:
-        exprs.extend(selection_to_pyexpr_list(more_exprs))
+    exprs = parse_as_list_of_expressions(exprs, *more_exprs)
     return wrap_expr(plr.sum_exprs(exprs))
 
 
@@ -1364,9 +1358,7 @@ def cumsum(
         elif isinstance(exprs, str):
             return col(exprs).cumsum()
 
-    exprs = selection_to_pyexpr_list(exprs)
-    if more_exprs:
-        exprs.extend(selection_to_pyexpr_list(more_exprs))
+    exprs = parse_as_list_of_expressions(exprs, *more_exprs)
 
     # (Expr): use u32 as that will not cast to float as eagerly
     exprs_wrapped = [wrap_expr(e) for e in exprs]
@@ -1534,7 +1526,7 @@ def map(
     │ 4   ┆ 7   ┆ 12    │
     └─────┴─────┴───────┘
     """
-    exprs = selection_to_pyexpr_list(exprs)
+    exprs = parse_as_list_of_expressions(exprs)
     return wrap_expr(
         plr.map_mul(
             exprs, function, return_dtype, apply_groups=False, returns_scalar=False
@@ -1611,7 +1603,7 @@ def apply(
     │ 4   ┆ 7   ┆ 16        │
     └─────┴─────┴───────────┘
     """
-    exprs = selection_to_pyexpr_list(exprs)
+    exprs = parse_as_list_of_expressions(exprs)
     return wrap_expr(
         plr.map_mul(
             exprs,
@@ -1727,7 +1719,7 @@ def fold(
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
-    exprs = selection_to_pyexpr_list(exprs)
+    exprs = parse_as_list_of_expressions(exprs)
     return wrap_expr(plr.fold(acc._pyexpr, function, exprs))
 
 
@@ -1791,7 +1783,7 @@ def reduce(
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
-    exprs = selection_to_pyexpr_list(exprs)
+    exprs = parse_as_list_of_expressions(exprs)
     return wrap_expr(plr.reduce(function, exprs))
 
 
@@ -1868,7 +1860,7 @@ def cumfold(
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
-    exprs = selection_to_pyexpr_list(exprs)
+    exprs = parse_as_list_of_expressions(exprs)
     return wrap_expr(plr.cumfold(acc._pyexpr, function, exprs, include_init))
 
 
@@ -1930,7 +1922,7 @@ def cumreduce(
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
-    exprs = selection_to_pyexpr_list(exprs)
+    exprs = parse_as_list_of_expressions(exprs)
     return wrap_expr(plr.cumreduce(function, exprs))
 
 
@@ -2018,9 +2010,7 @@ def any(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | b
         elif isinstance(exprs, str):
             return col(exprs).any()
 
-    exprs = selection_to_pyexpr_list(exprs)
-    if more_exprs:
-        exprs.extend(selection_to_pyexpr_list(more_exprs))
+    exprs = parse_as_list_of_expressions(exprs, *more_exprs)
 
     exprs_wrapped = [wrap_expr(e) for e in exprs]
     return fold(
@@ -2109,9 +2099,7 @@ def all(
         elif isinstance(exprs, str):
             return col(exprs).all()
 
-    exprs = selection_to_pyexpr_list(exprs)
-    if more_exprs:
-        exprs.extend(selection_to_pyexpr_list(more_exprs))
+    exprs = parse_as_list_of_expressions(exprs, *more_exprs)
 
     exprs_wrapped = [wrap_expr(e) for e in exprs]
     return fold(
@@ -2277,9 +2265,7 @@ def arg_sort_by(
     └─────┘
 
     """
-    exprs = selection_to_pyexpr_list(exprs)
-    if more_exprs:
-        exprs.extend(selection_to_pyexpr_list(more_exprs))
+    exprs = parse_as_list_of_expressions(exprs, *more_exprs)
 
     if isinstance(descending, bool):
         descending = [descending] * len(exprs)
@@ -2511,9 +2497,7 @@ def coalesce(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Exp
     └──────┴──────┴──────┴──────┘
 
     """
-    exprs = selection_to_pyexpr_list(exprs)
-    if more_exprs:
-        exprs.extend(selection_to_pyexpr_list(more_exprs))
+    exprs = parse_as_list_of_expressions(exprs, *more_exprs)
     return wrap_expr(plr.coalesce(exprs))
 
 

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -124,9 +124,9 @@ def arange(
     └───────────┘
 
     """
-    start = parse_as_expression(start)
-    end = parse_as_expression(end)
-    range_expr = wrap_expr(plr.arange(start._pyexpr, end._pyexpr, step))
+    start = parse_as_expression(start)._pyexpr
+    end = parse_as_expression(end)._pyexpr
+    range_expr = wrap_expr(plr.arange(start, end, step))
 
     if dtype is not None and dtype != Int64:
         range_expr = range_expr.cast(dtype)

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -9,7 +9,7 @@ import polars._reexport as pl
 from polars import functions as F
 from polars.datatypes import Date, Int64
 from polars.expr.datetime import TIME_ZONE_DEPRECATION_MESSAGE
-from polars.utils._parse_expr_input import parse_single_expression_input
+from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr, wrap_s
 from polars.utils.convert import (
     _datetime_to_pl_timestamp,
@@ -124,8 +124,8 @@ def arange(
     └───────────┘
 
     """
-    start = parse_single_expression_input(start)
-    end = parse_single_expression_input(end)
+    start = parse_as_expression(start)
+    end = parse_as_expression(end)
     range_expr = wrap_expr(plr.arange(start._pyexpr, end._pyexpr, step))
 
     if dtype is not None and dtype != Int64:
@@ -327,8 +327,8 @@ def date_range(
         or isinstance(start, (str, pl.Expr))
         or isinstance(end, (str, pl.Expr))
     ):
-        start = parse_single_expression_input(start)._pyexpr
-        end = parse_single_expression_input(end)._pyexpr
+        start = parse_as_expression(start)._pyexpr
+        end = parse_as_expression(end)._pyexpr
         return wrap_expr(plr.date_range_lazy(start, end, interval, closed, time_zone))
 
     start, start_is_date = _ensure_datetime(start)
@@ -531,13 +531,11 @@ def time_range(
         or isinstance(end, (str, pl.Expr))
     ):
         start_expr = (
-            F.lit(default_start)
-            if start is None
-            else parse_single_expression_input(start)
+            F.lit(default_start) if start is None else parse_as_expression(start)
         )._pyexpr
 
         end_expr = (
-            F.lit(default_end) if end is None else parse_single_expression_input(end)
+            F.lit(default_end) if end is None else parse_as_expression(end)
         )._pyexpr
 
         tm_expr = wrap_expr(plr.time_range_lazy(start_expr, end_expr, interval, closed))

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -93,8 +93,8 @@ def when(expr: IntoExpr) -> When:
 
 
     """
-    expr = parse_as_expression(expr)
-    pywhen = _when(expr._pyexpr)
+    expr = parse_as_expression(expr)._pyexpr
+    pywhen = _when(expr)
     return When(pywhen)
 
 
@@ -113,8 +113,8 @@ class When:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_as_expression(expr, str_as_lit=True)
-        pywhenthen = self._pywhen.then(expr._pyexpr)
+        expr = parse_as_expression(expr, str_as_lit=True)._pyexpr
+        pywhenthen = self._pywhen.then(expr)
         return WhenThen(pywhenthen)
 
 
@@ -126,8 +126,8 @@ class WhenThen:
 
     def when(self, predicate: IntoExpr) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
-        predicate = parse_as_expression(predicate)
-        return WhenThenThen(self._pywhenthen.when(predicate._pyexpr))
+        predicate = parse_as_expression(predicate)._pyexpr
+        return WhenThenThen(self._pywhenthen.when(predicate))
 
     def otherwise(self, expr: IntoExpr) -> Expr:
         """
@@ -138,8 +138,8 @@ class WhenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_as_expression(expr, str_as_lit=True)
-        return wrap_expr(self._pywhenthen.otherwise(expr._pyexpr))
+        expr = parse_as_expression(expr, str_as_lit=True)._pyexpr
+        return wrap_expr(self._pywhenthen.otherwise(expr))
 
     @typing.no_type_check
     def __getattr__(self, item) -> Expr:
@@ -155,8 +155,8 @@ class WhenThenThen:
 
     def when(self, predicate: IntoExpr) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
-        predicate = parse_as_expression(predicate)
-        return WhenThenThen(self.pywhenthenthen.when(predicate._pyexpr))
+        predicate = parse_as_expression(predicate)._pyexpr
+        return WhenThenThen(self.pywhenthenthen.when(predicate))
 
     def then(self, expr: IntoExpr) -> WhenThenThen:
         """
@@ -167,8 +167,8 @@ class WhenThenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr_ = parse_as_expression(expr, str_as_lit=True)
-        return WhenThenThen(self.pywhenthenthen.then(expr_._pyexpr))
+        expr = parse_as_expression(expr, str_as_lit=True)._pyexpr
+        return WhenThenThen(self.pywhenthenthen.then(expr))
 
     def otherwise(self, expr: IntoExpr) -> Expr:
         """
@@ -179,8 +179,8 @@ class WhenThenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_as_expression(expr, str_as_lit=True)
-        return wrap_expr(self.pywhenthenthen.otherwise(expr._pyexpr))
+        expr = parse_as_expression(expr, str_as_lit=True)._pyexpr
+        return wrap_expr(self.pywhenthenthen.otherwise(expr))
 
     @typing.no_type_check
     def __getattr__(self, item) -> Expr:

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -4,7 +4,7 @@ import contextlib
 import typing
 from typing import TYPE_CHECKING, Any
 
-from polars.utils._parse_expr_input import parse_single_expression_input
+from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -93,7 +93,7 @@ def when(expr: IntoExpr) -> When:
 
 
     """
-    expr = parse_single_expression_input(expr)
+    expr = parse_as_expression(expr)
     pywhen = _when(expr._pyexpr)
     return When(pywhen)
 
@@ -113,7 +113,7 @@ class When:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_single_expression_input(expr, str_as_lit=True)
+        expr = parse_as_expression(expr, str_as_lit=True)
         pywhenthen = self._pywhen.then(expr._pyexpr)
         return WhenThen(pywhenthen)
 
@@ -126,7 +126,7 @@ class WhenThen:
 
     def when(self, predicate: IntoExpr) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
-        predicate = parse_single_expression_input(predicate)
+        predicate = parse_as_expression(predicate)
         return WhenThenThen(self._pywhenthen.when(predicate._pyexpr))
 
     def otherwise(self, expr: IntoExpr) -> Expr:
@@ -138,7 +138,7 @@ class WhenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_single_expression_input(expr, str_as_lit=True)
+        expr = parse_as_expression(expr, str_as_lit=True)
         return wrap_expr(self._pywhenthen.otherwise(expr._pyexpr))
 
     @typing.no_type_check
@@ -155,7 +155,7 @@ class WhenThenThen:
 
     def when(self, predicate: IntoExpr) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
-        predicate = parse_single_expression_input(predicate)
+        predicate = parse_as_expression(predicate)
         return WhenThenThen(self.pywhenthenthen.when(predicate._pyexpr))
 
     def then(self, expr: IntoExpr) -> WhenThenThen:
@@ -167,7 +167,7 @@ class WhenThenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr_ = parse_single_expression_input(expr, str_as_lit=True)
+        expr_ = parse_as_expression(expr, str_as_lit=True)
         return WhenThenThen(self.pywhenthenthen.then(expr_._pyexpr))
 
     def otherwise(self, expr: IntoExpr) -> Expr:
@@ -179,7 +179,7 @@ class WhenThenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_single_expression_input(expr, str_as_lit=True)
+        expr = parse_as_expression(expr, str_as_lit=True)
         return wrap_expr(self.pywhenthenthen.otherwise(expr._pyexpr))
 
     @typing.no_type_check

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -49,8 +49,8 @@ from polars.io.parquet.anonymous_scan import _scan_parquet_fsspec
 from polars.lazyframe.groupby import LazyGroupBy
 from polars.slice import LazyPolarsSlice
 from polars.utils._parse_expr_input import (
+    parse_as_list_of_expressions,
     parse_single_expression_input,
-    selection_to_pyexpr_list,
 )
 from polars.utils._wrap import wrap_df, wrap_expr
 from polars.utils.convert import _timedelta_to_pl_duration
@@ -1110,9 +1110,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if isinstance(by, str) and not more_by:
             return self._from_pyldf(self._ldf.sort(by, descending, nulls_last))
 
-        by = selection_to_pyexpr_list(by)
-        if more_by:
-            by.extend(selection_to_pyexpr_list(more_by))
+        by = parse_as_list_of_expressions(by, *more_by)
 
         if isinstance(descending, bool):
             descending = [descending]
@@ -1192,7 +1190,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┘
 
         """
-        by = selection_to_pyexpr_list(by)
+        by = parse_as_list_of_expressions(by)
         if isinstance(descending, bool):
             descending = [descending]
         elif len(by) != len(descending):
@@ -1271,7 +1269,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┘
 
         """
-        by = selection_to_pyexpr_list(by)
+        by = parse_as_list_of_expressions(by)
         if isinstance(descending, bool):
             descending = [descending]
         return self._from_pyldf(self._ldf.bottom_k(k, by, descending, nulls_last))
@@ -2039,16 +2037,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
 
-        exprs = selection_to_pyexpr_list(exprs, structify=structify)
-        if more_exprs:
-            exprs.extend(selection_to_pyexpr_list(more_exprs, structify=structify))
-        if named_exprs:
-            exprs.extend(
-                parse_single_expression_input(expr, structify=structify)
-                .alias(name)
-                ._pyexpr
-                for name, expr in named_exprs.items()
-            )
+        exprs = parse_as_list_of_expressions(
+            exprs, *more_exprs, **named_exprs, structify=structify
+        )
 
         return self._from_pyldf(self._ldf.select(exprs))
 
@@ -2146,9 +2137,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┴─────┘
 
         """
-        exprs = selection_to_pyexpr_list(by)
-        if more_by:
-            exprs.extend(selection_to_pyexpr_list(more_by))
+        exprs = parse_as_list_of_expressions(by, *more_by)
         lgb = self._ldf.groupby(exprs, maintain_order)
         return LazyGroupBy(lgb)
 
@@ -2282,7 +2271,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(period)}"
 
-        pyexprs_by = [] if by is None else selection_to_pyexpr_list(by)
+        pyexprs_by = parse_as_list_of_expressions(by)
         period = _timedelta_to_pl_duration(period)
         offset = _timedelta_to_pl_duration(offset)
 
@@ -2601,7 +2590,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         offset = _timedelta_to_pl_duration(offset)
         every = _timedelta_to_pl_duration(every)
 
-        pyexprs_by = [] if by is None else selection_to_pyexpr_list(by)
+        pyexprs_by = parse_as_list_of_expressions(by)
         lgb = self._ldf.groupby_dynamic(
             index_column._pyexpr,
             every,
@@ -2921,12 +2910,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             )
 
         if on is not None:
-            pyexprs = selection_to_pyexpr_list(on)
+            pyexprs = parse_as_list_of_expressions(on)
             pyexprs_left = pyexprs
             pyexprs_right = pyexprs
         elif left_on is not None and right_on is not None:
-            pyexprs_left = selection_to_pyexpr_list(left_on)
-            pyexprs_right = selection_to_pyexpr_list(right_on)
+            pyexprs_left = parse_as_list_of_expressions(left_on)
+            pyexprs_right = parse_as_list_of_expressions(right_on)
         else:
             raise ValueError("must specify `on` OR `left_on` and `right_on`")
 
@@ -3096,16 +3085,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
 
-        exprs = selection_to_pyexpr_list(exprs, structify=structify)
-        if more_exprs:
-            exprs.extend(selection_to_pyexpr_list(more_exprs, structify=structify))
-        if named_exprs:
-            exprs.extend(
-                parse_single_expression_input(expr, structify=structify)
-                .alias(name)
-                ._pyexpr
-                for name, expr in named_exprs.items()
-            )
+        exprs = parse_as_list_of_expressions(
+            exprs, *more_exprs, **named_exprs, structify=structify
+        )
 
         return self._from_pyldf(self._ldf.with_columns(exprs))
 
@@ -4205,9 +4187,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────┴─────────┘
 
         """
-        columns = selection_to_pyexpr_list(columns)
-        if more_columns:
-            columns.extend(selection_to_pyexpr_list(more_columns))
+        columns = parse_as_list_of_expressions(columns, *more_columns)
         return self._from_pyldf(self._ldf.explode(columns))
 
     def unique(
@@ -4655,9 +4635,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         descending
             Whether the columns are sorted in descending order.
         """
-        columns = selection_to_pyexpr_list(column)
-        if more_columns:
-            columns.extend(selection_to_pyexpr_list(more_columns))
+        columns = parse_as_list_of_expressions(column, *more_columns)
         return self.with_columns(
             [wrap_expr(e).set_sorted(descending=descending) for e in columns]
         )

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2267,7 +2267,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────────┴───────┴───────┴───────┘
 
         """
-        index_column = parse_as_expression(index_column)
+        index_column = parse_as_expression(index_column)._pyexpr
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(period)}"
 
@@ -2276,7 +2276,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         offset = _timedelta_to_pl_duration(offset)
 
         lgb = self._ldf.groupby_rolling(
-            index_column._pyexpr, period, offset, closed, pyexprs_by, check_sorted
+            index_column, period, offset, closed, pyexprs_by, check_sorted
         )
         return LazyGroupBy(lgb)
 
@@ -2579,7 +2579,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────┴─────────────────┴─────┴─────────────────┘
 
         """  # noqa: W505
-        index_column = parse_as_expression(index_column)
+        index_column = parse_as_expression(index_column)._pyexpr
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(every)}" if period is None else "0ns"
 
@@ -2592,7 +2592,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         pyexprs_by = parse_as_list_of_expressions(by)
         lgb = self._ldf.groupby_dynamic(
-            index_column._pyexpr,
+            index_column,
             every,
             period,
             offset,
@@ -4142,8 +4142,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┘
 
         """
-        quantile = parse_as_expression(quantile)
-        return self._from_pyldf(self._ldf.quantile(quantile._pyexpr, interpolation))
+        quantile = parse_as_expression(quantile)._pyexpr
+        return self._from_pyldf(self._ldf.quantile(quantile, interpolation))
 
     def explode(
         self,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -49,8 +49,8 @@ from polars.io.parquet.anonymous_scan import _scan_parquet_fsspec
 from polars.lazyframe.groupby import LazyGroupBy
 from polars.slice import LazyPolarsSlice
 from polars.utils._parse_expr_input import (
+    parse_as_expression,
     parse_as_list_of_expressions,
-    parse_single_expression_input,
 )
 from polars.utils._wrap import wrap_df, wrap_expr
 from polars.utils.convert import _timedelta_to_pl_duration
@@ -1921,7 +1921,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             predicate = pl.Series(predicate)
 
         return self._from_pyldf(
-            self._ldf.filter(parse_single_expression_input(predicate)._pyexpr)
+            self._ldf.filter(parse_as_expression(predicate)._pyexpr)
         )
 
     def select(
@@ -2267,7 +2267,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────────┴───────┴───────┴───────┘
 
         """
-        index_column = parse_single_expression_input(index_column)
+        index_column = parse_as_expression(index_column)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(period)}"
 
@@ -2579,7 +2579,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────┴─────────────────┴─────┴─────────────────┘
 
         """  # noqa: W505
-        index_column = parse_single_expression_input(index_column)
+        index_column = parse_as_expression(index_column)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(every)}" if period is None else "0ns"
 
@@ -4142,7 +4142,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┘
 
         """
-        quantile = parse_single_expression_input(quantile)
+        quantile = parse_as_expression(quantile)
         return self._from_pyldf(self._ldf.quantile(quantile._pyexpr, interpolation))
 
     def explode(

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, Iterable
 
 from polars import functions as F
-from polars.utils._parse_expr_input import (
-    parse_single_expression_input,
-    selection_to_pyexpr_list,
-)
+from polars.utils._parse_expr_input import parse_as_list_of_expressions
 from polars.utils._wrap import wrap_ldf
 
 if TYPE_CHECKING:
@@ -126,14 +123,7 @@ class LazyGroupBy:
         if aggs is None and not named_aggs:
             raise ValueError("Expected at least one of 'aggs' or '**named_aggs'")
 
-        exprs = selection_to_pyexpr_list(aggs)
-        if more_aggs:
-            exprs.extend(selection_to_pyexpr_list(more_aggs))
-        if named_aggs:
-            exprs.extend(
-                parse_single_expression_input(expr).alias(name)._pyexpr
-                for name, expr in named_aggs.items()
-            )
+        exprs = parse_as_list_of_expressions(aggs, *more_aggs, **named_aggs)  # type: ignore[arg-type]
 
         return wrap_ldf(self.lgb.agg(exprs))
 

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -13,7 +13,24 @@ if TYPE_CHECKING:
     from polars.type_aliases import IntoExpr
 
 
-def selection_to_pyexpr_list(
+def parse_as_list_of_expressions(
+    inputs: IntoExpr | Iterable[IntoExpr],
+    *more_inputs: IntoExpr,
+    structify: bool = False,
+    **named_inputs: IntoExpr,
+) -> list[PyExpr]:
+    exprs = _selection_to_pyexpr_list(inputs, structify=structify)
+    if more_inputs:
+        exprs.extend(_selection_to_pyexpr_list(more_inputs, structify=structify))
+    if named_inputs:
+        exprs.extend(
+            parse_single_expression_input(expr, structify=structify).alias(name)._pyexpr
+            for name, expr in named_inputs.items()
+        )
+    return exprs
+
+
+def _selection_to_pyexpr_list(
     exprs: IntoExpr | Iterable[IntoExpr],
     structify: bool = False,
 ) -> list[PyExpr]:

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -24,7 +24,7 @@ def parse_as_list_of_expressions(
         exprs.extend(_selection_to_pyexpr_list(more_inputs, structify=structify))
     if named_inputs:
         exprs.extend(
-            parse_single_expression_input(expr, structify=structify).alias(name)._pyexpr
+            parse_as_expression(expr, structify=structify).alias(name)._pyexpr
             for name, expr in named_inputs.items()
         )
     return exprs
@@ -41,16 +41,16 @@ def _selection_to_pyexpr_list(
         exprs, (str, pl.Expr, pl.Series, F.whenthen.WhenThen, F.whenthen.WhenThenThen)
     ) or not isinstance(exprs, Iterable):
         return [
-            parse_single_expression_input(exprs, structify=structify)._pyexpr,
+            parse_as_expression(exprs, structify=structify)._pyexpr,
         ]
 
     return [
-        parse_single_expression_input(e, structify=structify)._pyexpr
+        parse_as_expression(e, structify=structify)._pyexpr
         for e in exprs  # type: ignore[union-attr]
     ]
 
 
-def parse_single_expression_input(
+def parse_as_expression(
     input: IntoExpr,
     *,
     str_as_lit: bool = False,

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -19,7 +19,23 @@ def parse_as_list_of_expressions(
     structify: bool = False,
     **named_inputs: IntoExpr,
 ) -> list[PyExpr]:
-    """Parse multiple inputs into a list of expressions."""
+    """
+    Parse multiple inputs into a list of expressions.
+
+    Parameters
+    ----------
+    inputs
+        Inputs to be parsed as expressions.
+    *more_inputs
+        Additional inputs to be parsed as expressions, specified as positional
+        arguments.
+    **named_inputs
+        Additional inputs to be parsed as expressions, specified as keyword arguments.
+        The expressions will be renamed to the keyword used.
+    structify
+        Convert multi-column expressions to a single struct expression.
+
+    """
     exprs = _parse_regular_inputs(inputs, more_inputs, structify=structify)
 
     if named_inputs:

--- a/py-polars/tests/unit/utils/test_parse_expr_input.py
+++ b/py-polars/tests/unit/utils/test_parse_expr_input.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+import pytest
+
+import polars as pl
+from polars.utils._parse_expr_input import _inputs_to_list
+
+
+@pytest.mark.parametrize("input", [None, []])
+def test_inputs_to_list_empty(input: Any) -> None:
+    assert _inputs_to_list(input) == []
+
+
+@pytest.mark.parametrize(
+    "input",
+    [5, 2.0, "a", pl.Series([1, 2, 3]), pl.lit(4)],
+)
+def test_inputs_to_list_single(input: Any) -> None:
+    assert _inputs_to_list(input) == [input]
+
+
+@pytest.mark.parametrize(
+    "input",
+    [[5], ["a", "b"], (1, 2, 3), ["a", 5, 3.2]],
+)
+def test_inputs_to_list_multiple(input: Any) -> None:
+    assert _inputs_to_list(input) == list(input)

--- a/py-polars/tests/unit/utils/test_parse_expr_input.py
+++ b/py-polars/tests/unit/utils/test_parse_expr_input.py
@@ -1,9 +1,24 @@
+from __future__ import annotations
+
+from datetime import date
 from typing import Any
 
 import pytest
 
 import polars as pl
-from polars.utils._parse_expr_input import _inputs_to_list
+from polars.testing import assert_frame_equal
+from polars.utils._parse_expr_input import _inputs_to_list, parse_as_expression
+
+
+def assert_expr_equal(result: pl.Expr, expected: pl.Expr) -> None:
+    """
+    Evaluate the given expressions in a simple context to assert equality.
+
+    WARNING: This is not a fully featured function - it's just to evaluate the tests in
+    this module. Do not use it elsewhere.
+    """
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    assert_frame_equal(df.select(result), df.select(expected))
 
 
 @pytest.mark.parametrize("input", [None, []])
@@ -25,3 +40,50 @@ def test_inputs_to_list_single(input: Any) -> None:
 )
 def test_inputs_to_list_multiple(input: Any) -> None:
     assert _inputs_to_list(input) == list(input)
+
+
+@pytest.mark.parametrize("input", [5, 2.0, pl.Series([1, 2, 3]), date(2022, 1, 1)])
+def test_parse_as_expression_lit(input: Any) -> None:
+    result = parse_as_expression(input)
+    expected = pl.lit(input)
+    assert_expr_equal(result, expected)
+
+
+def test_parse_as_expression_col() -> None:
+    result = parse_as_expression("a")
+    expected = pl.col("a")
+    assert_expr_equal(result, expected)
+
+
+@pytest.mark.parametrize("input", [pl.lit(4), pl.col("a")])
+def test_parse_as_expression_expr(input: pl.Expr) -> None:
+    result = parse_as_expression(input)
+    expected = input
+    assert_expr_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "input", [pl.when(True).then(1), pl.when(True).then(1).when(False).then(0)]
+)
+def test_parse_as_expression_whenthen(input: pl.WhenThen | pl.WhenThenThen) -> None:
+    result = parse_as_expression(input)
+    expected = input.otherwise(None)
+    assert_expr_equal(result, expected)
+
+
+def test_parse_as_expression_list() -> None:
+    result = parse_as_expression([1, 2, 3])
+    expected = pl.lit(pl.Series([[1, 2, 3]]))
+    assert_expr_equal(result, expected)
+
+
+def test_parse_as_expression_str_as_lit() -> None:
+    result = parse_as_expression("a", str_as_lit=True)
+    expected = pl.lit("a")
+    assert_expr_equal(result, expected)
+
+
+def test_parse_as_expression_structify() -> None:
+    result = parse_as_expression(pl.col("a", "b"), structify=True)
+    expected = pl.struct("a", "b")
+    assert_expr_equal(result, expected)

--- a/py-polars/tests/unit/utils/test_parse_expr_input.py
+++ b/py-polars/tests/unit/utils/test_parse_expr_input.py
@@ -65,7 +65,7 @@ def test_parse_as_expression_expr(input: pl.Expr) -> None:
 @pytest.mark.parametrize(
     "input", [pl.when(True).then(1), pl.when(True).then(1).when(False).then(0)]
 )
-def test_parse_as_expression_whenthen(input: pl.WhenThen | pl.WhenThenThen) -> None:
+def test_parse_as_expression_whenthen(input: Any) -> None:
     result = parse_as_expression(input)
     expected = input.otherwise(None)
     assert_expr_equal(result, expected)


### PR DESCRIPTION
**Purely a refactor, no functional changes.**

Eliminated some duplication.

There are now two main utils used across the code base:
* `parse_as_expression` -> parse an input as a single expression
* `parse_as_list_of_expressions` -> parse multiple inputs as a list of expressions

Still one more related PR to go to handle all those `._pyexpr` calls littering the code base.