### PR TITLE
fix(python): Restore functionality of `name` arg for `date_range`

### DIFF
--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -329,7 +329,10 @@ def date_range(
     ):
         start = parse_as_expression(start)._pyexpr
         end = parse_as_expression(end)._pyexpr
-        return wrap_expr(plr.date_range_lazy(start, end, interval, closed, time_zone))
+        expr = wrap_expr(plr.date_range_lazy(start, end, interval, closed, time_zone))
+        if name is not None:
+            expr = expr.alias(name)
+        return expr
 
     start, start_is_date = _ensure_datetime(start)
     end, end_is_date = _ensure_datetime(end)
@@ -370,6 +373,8 @@ def date_range(
     ):
         dt_range = dt_range.cast(Date)
 
+    if name is not None:
+        dt_range = dt_range.alias(name)
     return dt_range
 
 

--- a/py-polars/tests/unit/functions/test_range.py
+++ b/py-polars/tests/unit/functions/test_range.py
@@ -544,3 +544,24 @@ def test_time_range_name() -> None:
 
     result_lazy = pl.select(pl.time_range(time(10), time(12), eager=False)).to_series()
     assert result_lazy.name == expected_name
+
+
+def test_deprecated_name_arg() -> None:
+    name = "x"
+    with pytest.deprecated_call():
+        result_lazy = pl.date_range(date(2023, 1, 1), date(2023, 1, 3), name=name)
+        assert result_lazy.meta.output_name() == name
+
+    with pytest.deprecated_call():
+        result_eager = pl.date_range(
+            date(2023, 1, 1), date(2023, 1, 3), name=name, eager=True
+        )
+        assert result_eager.name == name
+
+    with pytest.deprecated_call():
+        result_lazy = pl.time_range(time(10), time(12), name=name)
+        assert result_lazy.meta.output_name() == name
+
+    with pytest.deprecated_call():
+        result_eager = pl.time_range(time(10), time(12), name=name, eager=True)
+        assert result_eager.name == name


### PR DESCRIPTION
Polars `0.18.0` deprecates the `name` argument for `date_range`. Unfortunately, I completely broke it while doing the deprecation.

Lesson for me to keep tests for deprecated functionality around until the functionality is actually removed.

On the bright side, this was the only regression I spotted when upgrading our code base to 0.18.0 :relieved: