### PR TITLE
fix(rust, python): struct `is_in` should upcast numeric types

### DIFF
--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -836,9 +836,10 @@ def test_struct_unique_df() -> None:
 
 
 def test_struct_is_in() -> None:
+    # The dtype casts below test that struct is_in upcasts dtypes.
     s1 = (
         pl.DataFrame({"x": [4, 3, 4, 9], "y": [0, 4, 6, 2]})
-        .select(pl.struct(["x", "y"]))
+        .select(pl.struct(schema={"x": pl.Int8, "y": pl.Float32}))
         .to_series()
     )
     s2 = (


### PR DESCRIPTION
Fixes #8949