### PR TITLE
fix(python): raise error when expr from dict provided

### DIFF
--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Iterable
 
@@ -59,6 +60,8 @@ def _parse_regular_inputs(
 def _inputs_to_list(inputs: IntoExpr | Iterable[IntoExpr] | None) -> list[IntoExpr]:
     if inputs is None:
         return []
+    elif isinstance(inputs, Mapping):
+        raise TypeError(f"cannot create expression from {type(inputs)}.")
     elif not isinstance(inputs, Iterable) or isinstance(inputs, (str, pl.Series)):
         return [inputs]
     else:


### PR DESCRIPTION
Resolves #9109 

Not sure if this warrants further discussion about strictness of input args. The [`_inputs_to_list()`](https://github.com/pola-rs/polars/pull/9111/files#diff-a103af384a872670b4e87328a71a5017078a706d332600a7c4cd0e982d994b96R60) function simply uses a standard iterator to build an expression list. I added a check to raise an error if the argument is a `collections.abc.Mapping`, which covers dict-like objects. Normally I don't think we should check for invalid datatypes and let the errors bubble up where they may, but in this case no error is raised and the result is behavior that's probably unexpected to the user.