### PR TITLE
chore(rust): Remove dbg statement from CoreJsonReader

### DIFF
--- a/polars/polars-io/src/ndjson/core.rs
+++ b/polars/polars-io/src/ndjson/core.rs
@@ -159,7 +159,6 @@ impl<'a> CoreJsonReader<'a> {
                 let mut cursor = Cursor::new(bytes);
 
                 let data_type = polars_json::ndjson::infer(&mut cursor, infer_schema_len)?;
-                dbg!(&data_type);
                 let schema = StructArray::get_fields(&data_type).iter().collect();
 
                 Cow::Owned(schema)


### PR DESCRIPTION
Removes `dbg!` statement included in 0.30.0.

```text
[/Users/user/.cargo/registry/src/github.com-1ecc6299db9ec823/polars-io-0.30.0/src/ndjson/core.rs:162] &data_type = Struct(
    [
        Field {
            name: "a",
            data_type: Int64,
            is_nullable: true,
            metadata: {},
        },
        Field {
            name: "b",
            data_type: LargeUtf8,
            is_nullable: true,
            metadata: {},
        },
    ],
)
```