### PR TITLE
feat(rust,python): Improve error handling for `repeat`

### DIFF
--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -56,6 +56,30 @@ def test_repeat_expr_input_lazy() -> None:
     assert_series_equal(result, expected)
 
 
+def test_repeat_n_zero() -> None:
+    assert pl.repeat(1, n=0, eager=True).len() == 0
+
+
+@pytest.mark.parametrize(
+    "n",
+    [1.5, 2.0, date(1971, 1, 2), "hello"],
+)
+def test_repeat_n_non_integer(n: Any) -> None:
+    with pytest.raises(pl.SchemaError, match="expected expression of dtype 'integer'"):
+        pl.repeat(1, n=pl.lit(n), eager=True)
+
+
+def test_repeat_n_empty() -> None:
+    df = pl.DataFrame(schema={"a": pl.Int32})
+    with pytest.raises(pl.ComputeError, match="index 0 is out of bounds"):
+        df.select(pl.repeat(1, n=pl.col("a")))
+
+
+def test_repeat_n_negative() -> None:
+    with pytest.raises(pl.ComputeError, match="could not parse value '-1' as a size"):
+        pl.repeat(1, n=-1, eager=True)
+
+
 @pytest.mark.parametrize(
     ("n", "dtype", "expected_dtype"),
     [


### PR DESCRIPTION
I ran into the following fun edge case:

```python
>>> pl.repeat(1, n=pl.lit(datetime(2023,1,1)), eager=True)
memory allocation of 13380249600000000 bytes failed
Aborted
```

Turns out, the datetime is parsed as a `usize` and then used as the size for the Series being created.

Changes:
* The input for `n` is now checked to be an integer. No other dtypes allowed.
* Getting the first value can fail if the dataframe is empty, so `unwrap` could panic. Properly handled this now.
* Extracting a usize can still fail if the integer is negative. This error message used to print the whole series, now it only prints the value it has extracted.

By now you might think I am obsessed with this relative unimportant feature, but I am just trying to get this perfect and apply the emerging concepts (like AnyValue conversion) to other code 😄 