### PR TITLE
fix(rust): json_extract on empty series

### DIFF
--- a/polars/polars-json/src/ndjson/deserialize.rs
+++ b/polars/polars-json/src/ndjson/deserialize.rs
@@ -20,7 +20,9 @@ pub fn deserialize_iter<'a>(
         buf.push_str(row);
         buf.push(',')
     }
-    let _ = buf.pop();
+    if buf.len() > 1 {
+        let _ = buf.pop();
+    }
     buf.push(']');
     let slice = unsafe { buf.as_bytes_mut() };
     let out = simd_json::to_borrowed_value(slice)

--- a/py-polars/tests/unit/namespaces/test_string.py
+++ b/py-polars/tests/unit/namespaces/test_string.py
@@ -266,6 +266,11 @@ def test_json_extract_series() -> None:
     dtype2 = pl.Struct([pl.Field("a", pl.Int64)])
     assert_series_equal(s.str.json_extract(dtype2), expected)
 
+    s = pl.Series([], dtype=pl.Utf8)
+    expected = pl.Series([], dtype=pl.List(pl.Int64))
+    dtype = pl.List(pl.Int64)
+    assert_series_equal(s.str.json_extract(dtype), expected)
+
 
 def test_json_extract_lazy_expr() -> None:
     dtype = pl.Struct([pl.Field("a", pl.Int64), pl.Field("b", pl.Boolean)])


### PR DESCRIPTION
Regression from #8858 (which looks pretty nice btw). Fixes empty series parsing by ensuring the opening `[` isn't popped off.