### PR TITLE
ci(python): Cache Rust build on main branch

### DIFF
--- a/.github/workflows/cache-rust.yml
+++ b/.github/workflows/cache-rust.yml
@@ -1,0 +1,39 @@
+name: Cache Rust
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+    - py-polars/**
+    - polars/**
+    - .github/workflows/cache-rust.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  cache-rust:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Rust
+        run: rustup show
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: shared-${{ matrix.os }}
+          workspaces: py-polars
+
+      - name: Run cargo build
+        working-directory: py-polars
+        env:
+          RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
+        run: cargo build

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -30,8 +30,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
-          cache-dependency-path: 'py-polars/requirements-dev.txt'
 
       - name: Create virtual environment
         run: |
@@ -49,7 +47,9 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: shared-ubuntu-latest
           workspaces: py-polars
+          save-if: false
 
       - name: Install Polars
         env:
@@ -96,8 +96,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: py-polars/requirements-dev.txt
 
       - name: Install Python dependencies
         run: |
@@ -110,7 +108,9 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
+          shared-key: shared-windows-latest
           workspaces: py-polars
+          save-if: false
 
       - name: Install Polars
         shell: bash


### PR DESCRIPTION
Changes:
* A cache of the Rust build process is stored on the `main` branch. This cache is shared with all pull request branches.
* Pull request branches no longer store Rust caches. They use what is available for the `main` branch.
* Python dependencies are also no longer cached. This is not worth it - costs a few seconds on the first run, saves a few seconds on subsequent runs - takes up cache storage.

Currently, only the `test-python` workflow is affected.

In my testing, this speeds up the CI for PRs quite nicely. This is at the cost of running an additional workflow after every merge. I think it's worth it - let's see.

If this works well, I will try to do something similar for the other workflows that could benefit from caching.