### PR TITLE
refactor(python, rust): change decimal inference and argument order

### DIFF
--- a/polars/polars-arrow/src/compute/decimal.rs
+++ b/polars/polars-arrow/src/compute/decimal.rs
@@ -15,27 +15,9 @@ fn split_decimal_bytes(bytes: &[u8]) -> (Option<&[u8]>, Option<&[u8]>) {
     (lhs, rhs)
 }
 
-pub fn infer_params(bytes: &[u8]) -> Option<(u8, u8)> {
-    let (lhs, rhs) = split_decimal_bytes(bytes);
-    match (lhs, rhs) {
-        (Some(lhs), Some(rhs)) => {
-            let lhs_s = significant_digits(lhs);
-            let rhs_s = significant_digits(rhs);
-
-            let precision = lhs_s + rhs_s;
-            let scale = rhs_s;
-            Some((precision, scale))
-        }
-        (None, Some(rhs)) => {
-            let precision = rhs.len() as u8;
-            Some((precision, precision))
-        }
-        (Some(lhs), None) => {
-            let precision = lhs.len() as u8;
-            Some((precision, 0))
-        }
-        (None, None) => None,
-    }
+pub fn infer_scale(bytes: &[u8]) -> Option<u8> {
+    let (_lhs, rhs) = split_decimal_bytes(bytes);
+    rhs.map(significant_digits)
 }
 
 /// Deserializes bytes to a single i128 representing a decimal

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -254,7 +254,7 @@ class Decimal(FractionalType):
     precision: int | None
     scale: int
 
-    def __init__(self, precision: int | None, scale: int):
+    def __init__(self, scale: int, precision: int | None = None):
         self.precision = precision
         self.scale = scale
 

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -297,7 +297,7 @@ impl ToPyObject for Wrap<DataType> {
             DataType::Decimal(precision, scale) => pl
                 .getattr("Decimal")
                 .unwrap()
-                .call1((*precision, *scale))
+                .call1((*scale, *precision))
                 .unwrap()
                 .into(),
             DataType::Boolean => pl.getattr("Boolean").unwrap().into(),

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -26,7 +26,7 @@ def test_series_from_pydecimal_and_ints() -> None:
     # TODO: check what happens if there are strings, floats arrow scalars in the list
     for data in permutations_int_dec_none():
         s = pl.Series("name", data)
-        assert s.dtype == pl.Decimal(None, 7)  # inferred scale = 7, precision = None
+        assert s.dtype == pl.Decimal(7)  # inferred scale = 7, precision = None
         assert s.name == "name"
         assert s.null_count() == 1
         for i, d in enumerate(data):
@@ -50,7 +50,7 @@ def test_frame_from_pydecimal_and_ints(monkeypatch: Any) -> None:
             for ctor in (pl.DataFrame, pl.from_records):
                 df = ctor(data=list(map(cls, data)))  # type: ignore[operator]
                 assert df.schema == {
-                    "a": pl.Decimal(None, 7),
+                    "a": pl.Decimal(7),
                 }
                 assert df.rows() == row_data
 
@@ -107,7 +107,7 @@ def test_utf8_to_decimal() -> None:
     s = pl.Series(
         ["40.12", "3420.13", "120134.19", "3212.98", "12.90", "143.09", "143.9"]
     ).str.to_decimal()
-    assert s.dtype == pl.Decimal(8, 2)
+    assert s.dtype == pl.Decimal(2)
 
     assert s.to_list() == [
         D("40.12"),
@@ -127,12 +127,12 @@ def test_read_csv_decimal(monkeypatch: Any) -> None:
     1.1,a
     0.01,a"""
 
-    df = pl.read_csv(csv.encode(), dtypes={"a": pl.Decimal})
-    assert df.dtypes == [pl.Decimal(None, 20), pl.Utf8]
+    df = pl.read_csv(csv.encode(), dtypes={"a": pl.Decimal(scale=2)})
+    assert df.dtypes == [pl.Decimal(2, None), pl.Utf8]
     assert df["a"].to_list() == [
-        D("123.12000000000000000000"),
-        D("1.10000000000000000000"),
-        D("0.01000000000000000000"),
+        D("123.12"),
+        D("1.10"),
+        D("0.01"),
     ]
 
 

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -216,7 +216,7 @@ def test_init_structured_objects(monkeypatch: Any) -> None:
             assert df.schema == {
                 "timestamp": pl.Datetime("us"),
                 "ticker": pl.Utf8,
-                "price": pl.Decimal(None, 1),
+                "price": pl.Decimal(1),
                 "size": pl.Int64,
             }
             assert df.rows() == raw_data
@@ -229,7 +229,7 @@ def test_init_structured_objects(monkeypatch: Any) -> None:
             assert df.schema == {
                 "timestamp": pl.Datetime("ms"),
                 "ticker": pl.Utf8,
-                "price": pl.Decimal(None, 1),
+                "price": pl.Decimal(1),
                 "size": pl.Int32,
             }
 
@@ -239,14 +239,14 @@ def test_init_structured_objects(monkeypatch: Any) -> None:
             schema=[
                 ("ts", pl.Datetime("ms")),
                 ("tk", pl.Categorical),
-                ("pc", pl.Decimal(None, 1)),
+                ("pc", pl.Decimal(1)),
                 ("sz", pl.UInt16),
             ],
         )
         assert df.schema == {
             "ts": pl.Datetime("ms"),
             "tk": pl.Categorical,
-            "pc": pl.Decimal(None, 1),
+            "pc": pl.Decimal(1),
             "sz": pl.UInt16,
         }
         assert df.rows() == raw_data

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -217,7 +217,7 @@ def test_from_arrow(monkeypatch: Any) -> None:
         "c": pl.Datetime("us"),
         "d": pl.Datetime("ns"),
         "e": pl.Int32,
-        "decimal1": pl.Decimal(2, 1),
+        "decimal1": pl.Decimal(1, 2),
     }
     expected_data = [
         (

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -494,7 +494,7 @@ def test_series_dtype_is() -> None:
     s = pl.Series("s", ["testing..."])
     assert s.is_utf8()
 
-    s = pl.Series("s", [], dtype=pl.Decimal(20, 15))
+    s = pl.Series("s", [], dtype=pl.Decimal(scale=15, precision=20))
     assert not s.is_float()
     assert s.is_numeric()
     assert s.is_empty()


### PR DESCRIPTION
This breaks the `Decimal` datatype constructor on the python side. But we clearly state decimal to be in alpha, so users should expect these changes.