### PR TITLE
feat(python,rust): add drop_first parameter for to_dummies (issue #8246) 

### DIFF
--- a/polars/polars-ops/src/frame/mod.rs
+++ b/polars/polars-ops/src/frame/mod.rs
@@ -44,7 +44,7 @@ pub trait DataFrameOps: IntoDf {
     ///       "code" => &["X1", "X2", "X3", "X3", "X2", "X2", "X1", "X1"]
     ///   }.unwrap();
     ///
-    ///   let dummies = df.to_dummies().unwrap();
+    ///   let dummies = df.to_dummies(None, false).unwrap();
     ///   dbg!(dummies);
     /// # }
     /// ```
@@ -73,8 +73,8 @@ pub trait DataFrameOps: IntoDf {
     ///  +------+------+------+--------+--------+--------+---------+---------+---------+
     /// ```
     #[cfg(feature = "to_dummies")]
-    fn to_dummies(&self, separator: Option<&str>) -> PolarsResult<DataFrame> {
-        self._to_dummies(None, separator)
+    fn to_dummies(&self, separator: Option<&str>, drop_first: bool) -> PolarsResult<DataFrame> {
+        self._to_dummies(None, separator, drop_first)
     }
 
     #[cfg(feature = "to_dummies")]
@@ -82,8 +82,9 @@ pub trait DataFrameOps: IntoDf {
         &self,
         columns: Vec<&str>,
         separator: Option<&str>,
+        drop_first: bool,
     ) -> PolarsResult<DataFrame> {
-        self._to_dummies(Some(columns), separator)
+        self._to_dummies(Some(columns), separator, drop_first)
     }
 
     #[cfg(feature = "to_dummies")]
@@ -91,6 +92,7 @@ pub trait DataFrameOps: IntoDf {
         &self,
         columns: Option<Vec<&str>>,
         separator: Option<&str>,
+        drop_first: bool,
     ) -> PolarsResult<DataFrame> {
         let df = self.to_df();
 
@@ -101,7 +103,7 @@ pub trait DataFrameOps: IntoDf {
             df.get_columns()
                 .par_iter()
                 .map(|s| match set.contains(s.name()) {
-                    true => s.to_dummies(separator),
+                    true => s.to_dummies(separator, drop_first),
                     false => Ok(s.clone().into_frame()),
                 })
                 .collect::<PolarsResult<Vec<_>>>()

--- a/polars/polars-ops/src/series/ops/to_dummies.rs
+++ b/polars/polars-ops/src/series/ops/to_dummies.rs
@@ -20,17 +20,11 @@ impl ToDummies for Series {
     fn to_dummies(&self, separator: Option<&str>, drop_first: bool) -> PolarsResult<DataFrame> {
         let sep = separator.unwrap_or("_");
         let col_name = self.name();
-        let groups = self.group_tuples(true, false)?;
+        let groups = self.group_tuples(true, drop_first)?;
 
         // safety: groups are in bounds
         let columns = unsafe { self.agg_first(&groups) };
-
-        let columns = if drop_first {
-            columns.iter().zip(groups.iter()).skip(1)
-        } else {
-            columns.iter().zip(groups.iter()).skip(0)
-        };
-
+        let columns = columns.iter().zip(groups.iter()).skip(drop_first as usize);
         let columns = columns
             .map(|(av, group)| {
                 // strings are formatted with extra \" \" in polars, so we

--- a/polars/polars-ops/src/series/ops/to_dummies.rs
+++ b/polars/polars-ops/src/series/ops/to_dummies.rs
@@ -13,19 +13,25 @@ type DummyType = i32;
 type DummyCa = Int32Chunked;
 
 pub trait ToDummies {
-    fn to_dummies(&self, separator: Option<&str>) -> PolarsResult<DataFrame>;
+    fn to_dummies(&self, separator: Option<&str>, drop_first: bool) -> PolarsResult<DataFrame>;
 }
 
 impl ToDummies for Series {
-    fn to_dummies(&self, separator: Option<&str>) -> PolarsResult<DataFrame> {
+    fn to_dummies(&self, separator: Option<&str>, drop_first: bool) -> PolarsResult<DataFrame> {
         let sep = separator.unwrap_or("_");
         let col_name = self.name();
         let groups = self.group_tuples(true, false)?;
 
         // safety: groups are in bounds
-        let columns = unsafe { self.agg_first(&groups) }
-            .iter()
-            .zip(groups.iter())
+        let columns = unsafe { self.agg_first(&groups) };
+
+        let columns = if drop_first {
+            columns.iter().zip(groups.iter()).skip(1)
+        } else {
+            columns.iter().zip(groups.iter()).skip(0)
+        };
+
+        let columns = columns
             .map(|(av, group)| {
                 // strings are formatted with extra \" \" in polars, so we
                 // extract the string

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7697,7 +7697,8 @@ class DataFrame:
         return self._from_pydf(self._df.quantile(quantile, interpolation))
 
     def to_dummies(
-        self, columns: str | Sequence[str] | None = None, *, separator: str = "_"
+        self, columns: str | Sequence[str] | None = None, *, separator: str =
+        "_", drop_first: bool = False
     ) -> Self:
         """
         Convert categorical variables into dummy/indicator variables.
@@ -7733,7 +7734,8 @@ class DataFrame:
         """
         if isinstance(columns, str):
             columns = [columns]
-        return self._from_pydf(self._df.to_dummies(columns, separator))
+        return self._from_pydf(self._df.to_dummies(columns, separator,
+                                                   drop_first))
 
     def unique(
         self,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7697,8 +7697,11 @@ class DataFrame:
         return self._from_pydf(self._df.quantile(quantile, interpolation))
 
     def to_dummies(
-        self, columns: str | Sequence[str] | None = None, *, separator: str =
-        "_", drop_first: bool = False
+        self,
+        columns: str | Sequence[str] | None = None,
+        *,
+        separator: str = "_",
+        drop_first: bool = False,
     ) -> Self:
         """
         Convert categorical variables into dummy/indicator variables.
@@ -7710,6 +7713,8 @@ class DataFrame:
             If set to ``None`` (default), convert all columns.
         separator
             Separator/delimiter used when generating column names.
+        drop_first
+            Remove the first category from the variables being encoded.
 
         Examples
         --------
@@ -7734,8 +7739,7 @@ class DataFrame:
         """
         if isinstance(columns, str):
             columns = [columns]
-        return self._from_pydf(self._df.to_dummies(columns, separator,
-                                                   drop_first))
+        return self._from_pydf(self._df.to_dummies(columns, separator, drop_first))
 
     def unique(
         self,

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1235,6 +1235,7 @@ impl PyDataFrame {
         Ok(df.into())
     }
 
+    #[pyo3(signature = (columns, separator, drop_first=false))]
     pub fn to_dummies(
         &self,
         columns: Option<Vec<String>>,
@@ -1242,9 +1243,11 @@ impl PyDataFrame {
         drop_first: bool,
     ) -> PyResult<Self> {
         let df = match columns {
-            Some(cols) => self
-                .df
-                .columns_to_dummies(cols.iter().map(|x| x as &str).collect(), separator, drop_first),
+            Some(cols) => self.df.columns_to_dummies(
+                cols.iter().map(|x| x as &str).collect(),
+                separator,
+                drop_first,
+            ),
             None => self.df.to_dummies(separator, drop_first),
         }
         .map_err(PyPolarsErr::from)?;

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1239,12 +1239,13 @@ impl PyDataFrame {
         &self,
         columns: Option<Vec<String>>,
         separator: Option<&str>,
+        drop_first: bool,
     ) -> PyResult<Self> {
         let df = match columns {
             Some(cols) => self
                 .df
-                .columns_to_dummies(cols.iter().map(|x| x as &str).collect(), separator),
-            None => self.df.to_dummies(separator),
+                .columns_to_dummies(cols.iter().map(|x| x as &str).collect(), separator, drop_first),
+            None => self.df.to_dummies(separator, drop_first),
         }
         .map_err(PyPolarsErr::from)?;
         Ok(df.into())

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -538,6 +538,7 @@ impl PySeries {
         Ok(s.into())
     }
 
+    #[pyo3(signature = (separator, drop_first=false))]
     fn to_dummies(&self, separator: Option<&str>, drop_first: bool) -> PyResult<PyDataFrame> {
         let df = self
             .series

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -538,10 +538,10 @@ impl PySeries {
         Ok(s.into())
     }
 
-    fn to_dummies(&self, separator: Option<&str>) -> PyResult<PyDataFrame> {
+    fn to_dummies(&self, separator: Option<&str>, drop_first: bool) -> PyResult<PyDataFrame> {
         let df = self
             .series
-            .to_dummies(separator)
+            .to_dummies(separator, drop_first)
             .map_err(PyPolarsErr::from)?;
         Ok(df.into())
     }


### PR DESCRIPTION
(Closes #8246).

The fix add the "drop_first" parameter to the `to_dummies` function.  See issue #8246: "to_dummies implementation may be incorrect".  The changes were made in-line with py/pandas.  The parameter is a `bool` with a default value `false`.  The default value is `False`; consistent with py/pandas.

I updated the current tests where applicable by including the additional parameter set to `false`.  I did not create new tests with the parameter set to `true` (or `True` in py).  

However, I did test the changes in the rust code on my local machine.  The reason for not adding a new test was only because several unrelated tests were not passing And I was not familiar with the testing structure. 