### PR TITLE
fix(rust, python): categorical construction from null values

### DIFF
--- a/polars/polars-core/src/series/any_value.rs
+++ b/polars/polars-core/src/series/any_value.rs
@@ -331,7 +331,7 @@ impl Series {
             DataType::Categorical(_) => {
                 let ca = if let Some(single_av) = av.first() {
                     match single_av {
-                        AnyValue::Utf8(_) | AnyValue::Utf8Owned(_) => {
+                        AnyValue::Utf8(_) | AnyValue::Utf8Owned(_) | AnyValue::Null => {
                             any_values_to_utf8(av, strict)?
                         }
                         _ => polars_bail!(

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -393,3 +393,12 @@ def test_fast_unique_flag_from_arrow() -> None:
 
     filtered = df.to_arrow().filter([True, False, True, True, False, True, True, True])
     assert pl.from_arrow(filtered).select(pl.col("colB").n_unique()).item() == 4
+
+
+def test_construct_with_null():
+    # Example from https://github.com/pola-rs/polars/issues/7188
+    df = pl.from_dicts([{"A": None}, {"A": "foo"}], schema={"A": pl.Categorical})
+    assert df.to_series().to_list() == [None, "foo"]
+
+    s = pl.Series([{"struct_A": None}], dtype=pl.Struct({"struct_A": pl.Categorical}))
+    assert s.to_list() == [{"struct_A": None}]

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -395,7 +395,7 @@ def test_fast_unique_flag_from_arrow() -> None:
     assert pl.from_arrow(filtered).select(pl.col("colB").n_unique()).item() == 4
 
 
-def test_construct_with_null():
+def test_construct_with_null() -> None:
     # Example from https://github.com/pola-rs/polars/issues/7188
     df = pl.from_dicts([{"A": None}, {"A": "foo"}], schema={"A": pl.Categorical})
     assert df.to_series().to_list() == [None, "foo"]


### PR DESCRIPTION
Closes #7188 and #9098