### PR TITLE
perf(rust): use par_iter over entire concat input

### DIFF
--- a/polars/polars-lazy/src/physical_plan/executors/union.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/union.rs
@@ -20,7 +20,7 @@ impl Executor for UnionExec {
         if _is_fetch_query() {
             self.options.parallel = false;
         }
-        let mut inputs = std::mem::take(&mut self.inputs);
+        let inputs = std::mem::take(&mut self.inputs);
 
         let sliced_path = if let Some((offset, _)) = self.options.slice {
             offset >= 0
@@ -82,28 +82,19 @@ impl Executor for UnionExec {
                 println!("UNION: union is run in parallel")
             }
 
-            // we don't use par_iter directly because the LP may also start threads for every LP (for instance scan_csv)
-            // this might then lead to a rayon SO. So we take a multitude of the threads to keep work stealing
-            // within bounds
-            let out = POOL.install(|| {
+            let dfs = POOL.install(|| {
                 inputs
-                    .chunks_mut(POOL.current_num_threads() * 3)
-                    .map(|chunk| {
-                        chunk
-                            .into_par_iter()
-                            .enumerate()
-                            .map(|(idx, input)| {
-                                let mut input = std::mem::take(input);
-                                let mut state = state.split();
-                                state.branch_idx += idx;
-                                input.execute(&mut state)
-                            })
-                            .collect::<PolarsResult<Vec<_>>>()
+                    .into_par_iter()
+                    .enumerate()
+                    .map(|(idx, mut input)| {
+                        let mut state = state.split();
+                        state.branch_idx += idx;
+                        input.execute(&mut state)
                     })
                     .collect::<PolarsResult<Vec<_>>>()
             });
 
-            concat_df(out?.iter().flat_map(|dfs| dfs.iter()))
+            concat_df(dfs.iter().flatten())
         }
     }
 }


### PR DESCRIPTION
Wondering if this could be possibly simplified now that `scan_csv` uses the global thread pool #8441 and so does pretty much everything else. Are there other thread spawning risks to make this worth keeping around?

Not heavily invested in this change. So if you don't think it's worth the risk, no worries. We can just close it out. Thanks!