### PR TITLE
refactor(python): Update expr parsing util to return `PyExpr`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -91,7 +91,7 @@ from polars.utils._construction import (
     series_to_pydf,
 )
 from polars.utils._parse_expr_input import parse_as_expression
-from polars.utils._wrap import wrap_ldf, wrap_s
+from polars.utils._wrap import wrap_expr, wrap_ldf, wrap_s
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias
 from polars.utils.meta import get_index_type
@@ -7910,7 +7910,7 @@ class DataFrame:
             subset = [subset]
 
         if isinstance(subset, Sequence) and len(subset) == 1:
-            expr = parse_as_expression(subset[0])
+            expr = wrap_expr(parse_as_expression(subset[0]))
         else:
             struct_fields = F.all() if (subset is None) else subset
             expr = F.struct(struct_fields)  # type: ignore[call-overload]

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -337,7 +337,7 @@ class ExprDateTimeNameSpace:
             raise TypeError(
                 f"expected 'time' to be a python time or polars expression, found {time!r}"
             )
-        time = parse_as_expression(time)._pyexpr
+        time = parse_as_expression(time)
         return wrap_expr(self._pyexpr.dt_combine(time, time_unit))
 
     def to_string(self, format: str) -> Expr:

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -295,7 +295,7 @@ class ExprListNameSpace:
         └──────┘
 
         """
-        index = parse_as_expression(index)._pyexpr
+        index = parse_as_expression(index)
         return wrap_expr(self._pyexpr.list_get(index))
 
     def take(
@@ -323,7 +323,7 @@ class ExprListNameSpace:
         """
         if isinstance(index, list):
             index = pl.Series(index)
-        index = parse_as_expression(index)._pyexpr
+        index = parse_as_expression(index)
         return wrap_expr(self._pyexpr.list_take(index, null_on_oob))
 
     def first(self) -> Expr:
@@ -401,7 +401,7 @@ class ExprListNameSpace:
         └───────┘
 
         """
-        item = parse_as_expression(item, str_as_lit=True)._pyexpr
+        item = parse_as_expression(item, str_as_lit=True)
         return wrap_expr(self._pyexpr.list_contains(item))
 
     def join(self, separator: str) -> Expr:
@@ -593,8 +593,8 @@ class ExprListNameSpace:
         ]
 
         """
-        offset = parse_as_expression(offset)._pyexpr
-        length = parse_as_expression(length)._pyexpr
+        offset = parse_as_expression(offset)
+        length = parse_as_expression(length)
         return wrap_expr(self._pyexpr.list_slice(offset, length))
 
     def head(self, n: int | str | Expr = 5) -> Expr:
@@ -641,7 +641,7 @@ class ExprListNameSpace:
         ]
 
         """
-        n = parse_as_expression(n)._pyexpr
+        n = parse_as_expression(n)
         return wrap_expr(self._pyexpr.list_tail(n))
 
     def explode(self) -> Expr:
@@ -704,7 +704,7 @@ class ExprListNameSpace:
         └────────────────┘
 
         """
-        element = parse_as_expression(element, str_as_lit=True)._pyexpr
+        element = parse_as_expression(element, str_as_lit=True)
         return wrap_expr(self._pyexpr.list_count_match(element))
 
     @deprecated_alias(name_generator="fields")

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -796,7 +796,7 @@ class ExprStringNameSpace:
         ends_with : Check if string values end with a substring.
 
         """
-        pattern = parse_as_expression(pattern, str_as_lit=True)._pyexpr
+        pattern = parse_as_expression(pattern, str_as_lit=True)
         return wrap_expr(self._pyexpr.str_contains(pattern, literal, strict))
 
     def ends_with(self, suffix: str | Expr) -> Expr:
@@ -843,7 +843,7 @@ class ExprStringNameSpace:
         starts_with : Check if string values start with a substring.
 
         """
-        suffix = parse_as_expression(suffix, str_as_lit=True)._pyexpr
+        suffix = parse_as_expression(suffix, str_as_lit=True)
         return wrap_expr(self._pyexpr.str_ends_with(suffix))
 
     def starts_with(self, prefix: str | Expr) -> Expr:
@@ -890,7 +890,7 @@ class ExprStringNameSpace:
         ends_with : Check if string values end with a substring.
 
         """
-        prefix = parse_as_expression(prefix, str_as_lit=True)._pyexpr
+        prefix = parse_as_expression(prefix, str_as_lit=True)
         return wrap_expr(self._pyexpr.str_starts_with(prefix))
 
     def json_extract(self, dtype: PolarsDataType | None = None) -> Expr:
@@ -1194,7 +1194,7 @@ class ExprStringNameSpace:
         └────────────────┘
 
         '''
-        pattern = parse_as_expression(pattern, str_as_lit=True)._pyexpr
+        pattern = parse_as_expression(pattern, str_as_lit=True)
         return wrap_expr(self._pyexpr.str_extract_all(pattern))
 
     def count_match(self, pattern: str) -> Expr:
@@ -1470,8 +1470,8 @@ class ExprStringNameSpace:
         └─────┴────────┘
 
         """
-        pattern = parse_as_expression(pattern, str_as_lit=True)._pyexpr
-        value = parse_as_expression(value, str_as_lit=True)._pyexpr
+        pattern = parse_as_expression(pattern, str_as_lit=True)
+        value = parse_as_expression(value, str_as_lit=True)
         return wrap_expr(self._pyexpr.str_replace_n(pattern, value, literal, n))
 
     def replace_all(
@@ -1509,8 +1509,8 @@ class ExprStringNameSpace:
         └─────┴─────────┘
 
         """
-        pattern = parse_as_expression(pattern, str_as_lit=True)._pyexpr
-        value = parse_as_expression(value, str_as_lit=True)._pyexpr
+        pattern = parse_as_expression(pattern, str_as_lit=True)
+        value = parse_as_expression(value, str_as_lit=True)
         return wrap_expr(self._pyexpr.str_replace_all(pattern, value, literal))
 
     def slice(self, offset: int, length: int | None = None) -> Expr:

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -61,18 +61,18 @@ def datetime_(
     Expr of type `pl.Datetime`
 
     """
-    year_expr = parse_as_expression(year)._pyexpr
-    month_expr = parse_as_expression(month)._pyexpr
-    day_expr = parse_as_expression(day)._pyexpr
+    year_expr = parse_as_expression(year)
+    month_expr = parse_as_expression(month)
+    day_expr = parse_as_expression(day)
 
     if hour is not None:
-        hour = parse_as_expression(hour)._pyexpr
+        hour = parse_as_expression(hour)
     if minute is not None:
-        minute = parse_as_expression(minute)._pyexpr
+        minute = parse_as_expression(minute)
     if second is not None:
-        second = parse_as_expression(second)._pyexpr
+        second = parse_as_expression(second)
     if microsecond is not None:
-        microsecond = parse_as_expression(microsecond)._pyexpr
+        microsecond = parse_as_expression(microsecond)
 
     return wrap_expr(
         plr.datetime(
@@ -203,21 +203,21 @@ def duration(
 
     """  # noqa: W505
     if hours is not None:
-        hours = parse_as_expression(hours)._pyexpr
+        hours = parse_as_expression(hours)
     if minutes is not None:
-        minutes = parse_as_expression(minutes)._pyexpr
+        minutes = parse_as_expression(minutes)
     if seconds is not None:
-        seconds = parse_as_expression(seconds)._pyexpr
+        seconds = parse_as_expression(seconds)
     if milliseconds is not None:
-        milliseconds = parse_as_expression(milliseconds)._pyexpr
+        milliseconds = parse_as_expression(milliseconds)
     if microseconds is not None:
-        microseconds = parse_as_expression(microseconds)._pyexpr
+        microseconds = parse_as_expression(microseconds)
     if nanoseconds is not None:
-        nanoseconds = parse_as_expression(nanoseconds)._pyexpr
+        nanoseconds = parse_as_expression(nanoseconds)
     if days is not None:
-        days = parse_as_expression(days)._pyexpr
+        days = parse_as_expression(days)
     if weeks is not None:
-        weeks = parse_as_expression(weeks)._pyexpr
+        weeks = parse_as_expression(weeks)
 
     return wrap_expr(
         plr.duration(
@@ -499,7 +499,7 @@ def format(f_string: str, *args: Expr | str) -> Expr:
     arguments = iter(args)
     for i, s in enumerate(f_string.split("{}")):
         if i > 0:
-            e = parse_as_expression(next(arguments))
+            e = wrap_expr(parse_as_expression(next(arguments)))
             exprs.append(e)
 
         if len(s) > 0:

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1358,10 +1358,10 @@ def cumsum(
         elif isinstance(exprs, str):
             return col(exprs).cumsum()
 
-    exprs = parse_as_list_of_expressions(exprs, *more_exprs)
+    pyexprs = parse_as_list_of_expressions(exprs, *more_exprs)
+    exprs_wrapped = [wrap_expr(e) for e in pyexprs]
 
     # (Expr): use u32 as that will not cast to float as eagerly
-    exprs_wrapped = [wrap_expr(e) for e in exprs]
     return cumfold(lit(0).cast(UInt32), lambda a, b: a + b, exprs_wrapped).alias(
         "cumsum"
     )
@@ -1715,7 +1715,7 @@ def fold(
     └─────┴─────┘
     """
     # in case of pl.col("*")
-    acc = parse_as_expression(acc, str_as_lit=True)._pyexpr
+    acc = parse_as_expression(acc, str_as_lit=True)
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
@@ -1856,7 +1856,7 @@ def cumfold(
 
     """  # noqa: W505
     # in case of pl.col("*")
-    acc = parse_as_expression(acc, str_as_lit=True)._pyexpr
+    acc = parse_as_expression(acc, str_as_lit=True)
     if isinstance(exprs, pl.Expr):
         exprs = [exprs]
 
@@ -2010,9 +2010,9 @@ def any(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | b
         elif isinstance(exprs, str):
             return col(exprs).any()
 
-    exprs = parse_as_list_of_expressions(exprs, *more_exprs)
+    pyexprs = parse_as_list_of_expressions(exprs, *more_exprs)
+    exprs_wrapped = [wrap_expr(e) for e in pyexprs]
 
-    exprs_wrapped = [wrap_expr(e) for e in exprs]
     return fold(
         lit(False), lambda a, b: a.cast(bool) | b.cast(bool), exprs_wrapped
     ).alias("any")
@@ -2099,9 +2099,9 @@ def all(
         elif isinstance(exprs, str):
             return col(exprs).all()
 
-    exprs = parse_as_list_of_expressions(exprs, *more_exprs)
+    pyexprs = parse_as_list_of_expressions(exprs, *more_exprs)
+    exprs_wrapped = [wrap_expr(e) for e in pyexprs]
 
-    exprs_wrapped = [wrap_expr(e) for e in exprs]
     return fold(
         lit(True), lambda a, b: a.cast(bool) & b.cast(bool), exprs_wrapped
     ).alias("all")
@@ -2446,7 +2446,7 @@ def arg_where(condition: Expr | Series, *, eager: bool = False) -> Expr | Series
             )
         return condition.to_frame().select(arg_where(col(condition.name))).to_series()
     else:
-        condition = parse_as_expression(condition)._pyexpr
+        condition = parse_as_expression(condition)
         return wrap_expr(plr.arg_where(condition))
 
 

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -124,8 +124,8 @@ def arange(
     └───────────┘
 
     """
-    start = parse_as_expression(start)._pyexpr
-    end = parse_as_expression(end)._pyexpr
+    start = parse_as_expression(start)
+    end = parse_as_expression(end)
     range_expr = wrap_expr(plr.arange(start, end, step))
 
     if dtype is not None and dtype != Int64:
@@ -327,8 +327,8 @@ def date_range(
         or isinstance(start, (str, pl.Expr))
         or isinstance(end, (str, pl.Expr))
     ):
-        start = parse_as_expression(start)._pyexpr
-        end = parse_as_expression(end)._pyexpr
+        start = parse_as_expression(start)
+        end = parse_as_expression(end)
         expr = wrap_expr(plr.date_range_lazy(start, end, interval, closed, time_zone))
         if name is not None:
             expr = expr.alias(name)
@@ -536,12 +536,14 @@ def time_range(
         or isinstance(end, (str, pl.Expr))
     ):
         start_expr = (
-            F.lit(default_start) if start is None else parse_as_expression(start)
-        )._pyexpr
+            F.lit(default_start)._pyexpr
+            if start is None
+            else parse_as_expression(start)
+        )
 
         end_expr = (
-            F.lit(default_end) if end is None else parse_as_expression(end)
-        )._pyexpr
+            F.lit(default_end)._pyexpr if end is None else parse_as_expression(end)
+        )
 
         tm_expr = wrap_expr(plr.time_range_lazy(start_expr, end_expr, interval, closed))
         if name is not None:

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -93,7 +93,7 @@ def when(expr: IntoExpr) -> When:
 
 
     """
-    expr = parse_as_expression(expr)._pyexpr
+    expr = parse_as_expression(expr)
     pywhen = _when(expr)
     return When(pywhen)
 
@@ -113,7 +113,7 @@ class When:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_as_expression(expr, str_as_lit=True)._pyexpr
+        expr = parse_as_expression(expr, str_as_lit=True)
         pywhenthen = self._pywhen.then(expr)
         return WhenThen(pywhenthen)
 
@@ -126,7 +126,7 @@ class WhenThen:
 
     def when(self, predicate: IntoExpr) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
-        predicate = parse_as_expression(predicate)._pyexpr
+        predicate = parse_as_expression(predicate)
         return WhenThenThen(self._pywhenthen.when(predicate))
 
     def otherwise(self, expr: IntoExpr) -> Expr:
@@ -138,7 +138,7 @@ class WhenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_as_expression(expr, str_as_lit=True)._pyexpr
+        expr = parse_as_expression(expr, str_as_lit=True)
         return wrap_expr(self._pywhenthen.otherwise(expr))
 
     @typing.no_type_check
@@ -155,7 +155,7 @@ class WhenThenThen:
 
     def when(self, predicate: IntoExpr) -> WhenThenThen:
         """Start another "when, then, otherwise" layer."""
-        predicate = parse_as_expression(predicate)._pyexpr
+        predicate = parse_as_expression(predicate)
         return WhenThenThen(self.pywhenthenthen.when(predicate))
 
     def then(self, expr: IntoExpr) -> WhenThenThen:
@@ -167,7 +167,7 @@ class WhenThenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_as_expression(expr, str_as_lit=True)._pyexpr
+        expr = parse_as_expression(expr, str_as_lit=True)
         return WhenThenThen(self.pywhenthenthen.then(expr))
 
     def otherwise(self, expr: IntoExpr) -> Expr:
@@ -179,7 +179,7 @@ class WhenThenThen:
         pl.when : Documentation for `when, then, otherwise`
 
         """
-        expr = parse_as_expression(expr, str_as_lit=True)._pyexpr
+        expr = parse_as_expression(expr, str_as_lit=True)
         return wrap_expr(self.pywhenthenthen.otherwise(expr))
 
     @typing.no_type_check

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1920,9 +1920,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if isinstance(predicate, list):
             predicate = pl.Series(predicate)
 
-        return self._from_pyldf(
-            self._ldf.filter(parse_as_expression(predicate)._pyexpr)
-        )
+        predicate = parse_as_expression(predicate)
+        return self._from_pyldf(self._ldf.filter(predicate))
 
     def select(
         self,
@@ -2268,7 +2267,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────────┴───────┴───────┴───────┘
 
         """
-        index_column = parse_as_expression(index_column)._pyexpr
+        index_column = parse_as_expression(index_column)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(period)}"
 
@@ -2581,7 +2580,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────────────┴─────────────────┴─────┴─────────────────┘
 
         """  # noqa: W505
-        index_column = parse_as_expression(index_column)._pyexpr
+        index_column = parse_as_expression(index_column)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(every)}" if period is None else "0ns"
 
@@ -4145,7 +4144,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┘
 
         """
-        quantile = parse_as_expression(quantile)._pyexpr
+        quantile = parse_as_expression(quantile)
         return self._from_pyldf(self._ldf.quantile(quantile, interpolation))
 
     def explode(
@@ -4639,6 +4638,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Whether the columns are sorted in descending order.
         """
         columns = parse_as_list_of_expressions(column, *more_columns)
+
         return self.with_columns(
             [wrap_expr(e).set_sorted(descending=descending) for e in columns]
         )

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -42,6 +42,7 @@ def parse_as_list_of_expressions(
 
 def _parse_regular_inputs(
     inputs: tuple[IntoExpr | Iterable[IntoExpr], ...],
+    *,
     structify: bool = False,
 ) -> list[PyExpr]:
     if not inputs:
@@ -49,7 +50,7 @@ def _parse_regular_inputs(
 
     input_list = _first_input_to_list(inputs[0])
     input_list.extend(inputs[1:])  # type: ignore[arg-type]
-    return [parse_as_expression(e, structify=structify)._pyexpr for e in input_list]
+    return [parse_as_expression(e, structify=structify) for e in input_list]
 
 
 def _first_input_to_list(
@@ -64,17 +65,20 @@ def _first_input_to_list(
 
 
 def _parse_named_inputs(
-    named_inputs: dict[str, IntoExpr], structify: bool = False
+    named_inputs: dict[str, IntoExpr], *, structify: bool = False
 ) -> Iterable[PyExpr]:
     return (
-        parse_as_expression(input, structify=structify).alias(name)._pyexpr
+        parse_as_expression(input, structify=structify).alias(name)
         for name, input in named_inputs.items()
     )
 
 
 def parse_as_expression(
-    input: IntoExpr, *, str_as_lit: bool = False, structify: bool = False
-) -> Expr:
+    input: IntoExpr,
+    *,
+    str_as_lit: bool = False,
+    structify: bool = False,
+) -> PyExpr | Expr:
     """
     Parse a single input into an expression.
 
@@ -87,6 +91,8 @@ def parse_as_expression(
         strings are parsed as column names.
     structify
         Convert multi-column expressions to a single struct expression.
+    wrap
+        Return an ``Expr`` object rather than a ``PyExpr`` object.
 
     """
     if isinstance(input, pl.Expr):
@@ -114,7 +120,7 @@ def parse_as_expression(
     if structify:
         expr = _structify_expression(expr)
 
-    return expr
+    return expr._pyexpr
 
 
 def _structify_expression(expr: Expr) -> Expr:

--- a/py-polars/tests/unit/utils/test_parse_expr_input.py
+++ b/py-polars/tests/unit/utils/test_parse_expr_input.py
@@ -8,6 +8,7 @@ import pytest
 import polars as pl
 from polars.testing import assert_frame_equal
 from polars.utils._parse_expr_input import _first_input_to_list, parse_as_expression
+from polars.utils._wrap import wrap_expr
 
 
 def assert_expr_equal(result: pl.Expr, expected: pl.Expr) -> None:
@@ -44,20 +45,20 @@ def test_first_input_to_list_multiple(input: Any) -> None:
 
 @pytest.mark.parametrize("input", [5, 2.0, pl.Series([1, 2, 3]), date(2022, 1, 1)])
 def test_parse_as_expression_lit(input: Any) -> None:
-    result = parse_as_expression(input)
+    result = wrap_expr(parse_as_expression(input))
     expected = pl.lit(input)
     assert_expr_equal(result, expected)
 
 
 def test_parse_as_expression_col() -> None:
-    result = parse_as_expression("a")
+    result = wrap_expr(parse_as_expression("a"))
     expected = pl.col("a")
     assert_expr_equal(result, expected)
 
 
 @pytest.mark.parametrize("input", [pl.lit(4), pl.col("a")])
 def test_parse_as_expression_expr(input: pl.Expr) -> None:
-    result = parse_as_expression(input)
+    result = wrap_expr(parse_as_expression(input))
     expected = input
     assert_expr_equal(result, expected)
 
@@ -66,24 +67,24 @@ def test_parse_as_expression_expr(input: pl.Expr) -> None:
     "input", [pl.when(True).then(1), pl.when(True).then(1).when(False).then(0)]
 )
 def test_parse_as_expression_whenthen(input: Any) -> None:
-    result = parse_as_expression(input)
+    result = wrap_expr(parse_as_expression(input))
     expected = input.otherwise(None)
     assert_expr_equal(result, expected)
 
 
 def test_parse_as_expression_list() -> None:
-    result = parse_as_expression([1, 2, 3])
+    result = wrap_expr(parse_as_expression([1, 2, 3]))
     expected = pl.lit(pl.Series([[1, 2, 3]]))
     assert_expr_equal(result, expected)
 
 
 def test_parse_as_expression_str_as_lit() -> None:
-    result = parse_as_expression("a", str_as_lit=True)
+    result = wrap_expr(parse_as_expression("a", str_as_lit=True))
     expected = pl.lit("a")
     assert_expr_equal(result, expected)
 
 
 def test_parse_as_expression_structify() -> None:
-    result = parse_as_expression(pl.col("a", "b"), structify=True)
+    result = wrap_expr(parse_as_expression(pl.col("a", "b"), structify=True))
     expected = pl.struct("a", "b")
     assert_expr_equal(result, expected)


### PR DESCRIPTION
The `parse_as_expr` util returned an `Expr`, and in almost all cases, `._pyexpr` was immediately called to get the inner `PyExpr` before passing it to Rust. This PR updates the util to return `PyExpr` directly - making it in line with the `parse_as_list_of_expressions` util.

You can call `wrap_expr` on the result if you need an `Expr`. This happens mostly in utility functions that are implemented in pure Python rather than in Rust.

Removes a bunch of duplication!