### PR TITLE
fix(rust, python): respect time zone in strptime/to_datetime when exact=False

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -425,7 +425,7 @@ fn to_datetime(
         )?
         .into_series()
     } else {
-        ca.as_datetime_not_exact(options.format.as_deref(), *time_unit, time_zone)?
+        ca.as_datetime_not_exact(options.format.as_deref(), *time_unit, tz_aware, time_zone)?
             .into_series()
     };
 

--- a/polars/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/mod.rs
@@ -321,12 +321,7 @@ pub trait Utf8Methods: AsUtf8 {
             #[cfg(feature = "timezones")]
             (false, Some(tz)) => ca.into_datetime(tu, None).replace_time_zone(Some(tz), None),
             #[cfg(feature = "timezones")]
-            (true, None) => Ok(ca.into_datetime(tu, Some("UTC".to_string()))),
-            (true, Some(_)) => {
-                // Can't use tz-aware format with tz-aware dtype, this would already have
-                // errored earlier.
-                unreachable!()
-            }
+            (true, _) => Ok(ca.into_datetime(tu, Some("UTC".to_string()))),
             _ => Ok(ca.into_datetime(tu, None)),
         }
     }


### PR DESCRIPTION
closes (part of) #9102 

addressing the rest of that issue will require a bit of a refactor (I think) - gonna be pretty busy over the next week, but I'll try to get to it