### PR TITLE
fix(rust, python): make null chunking behavior equal to other dtypes

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/polars/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -133,7 +133,7 @@ impl StructChunked {
                 .iter()
                 .map(|s| match s.dtype() {
                     #[cfg(feature = "object")]
-                    DataType::Object(_) => s.to_arrow(0),
+                    DataType::Object(_) => s.to_arrow(i),
                     _ => s.chunks()[i].clone(),
                 })
                 .collect::<Vec<_>>();

--- a/polars/polars-core/src/series/implementations/null.rs
+++ b/polars/polars-core/src/series/implementations/null.rs
@@ -118,7 +118,7 @@ impl SeriesTrait for NullChunked {
     }
 
     fn rechunk(&self) -> Series {
-        self.clone().into_series()
+        NullChunked::new(self.name.clone(), self.len()).into_series()
     }
 
     fn cast(&self, data_type: &DataType) -> PolarsResult<Series> {
@@ -165,12 +165,16 @@ impl SeriesTrait for NullChunked {
     }
 
     fn append(&mut self, other: &Series) -> PolarsResult<()> {
-        *self = NullChunked::new(self.name.clone(), self.len() + other.len());
+        polars_ensure!(other.dtype() == &DataType::Null, ComputeError: "expected null dtype");
+        // we don't create a new null array to keep probability of aligned chunks higher
+        self.chunks.extend(other.chunks().iter().cloned());
+        self.length += other.len() as IdxSize;
         Ok(())
     }
 
     fn extend(&mut self, other: &Series) -> PolarsResult<()> {
-        self.append(other)
+        *self = NullChunked::new(self.name.clone(), self.len() + other.len());
+        Ok(())
     }
 
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -415,3 +415,15 @@ def test_list_null_list_categorical_cast() -> None:
     s = pl.Series([[]], dtype=pl.List(pl.Null)).cast(expected)
     assert s.dtype == expected
     assert s.to_list() == [[]]
+
+
+def test_struct_with_nulls_as_list() -> None:
+    df = pl.DataFrame([[{"a": 1, "b": 2}], [{"c": 3, "d": None}]])
+    assert df.select(pl.concat_list(pl.all()).alias("as_list")).to_dict(False) == {
+        "as_list": [
+            [
+                {"a": 1, "b": 2, "c": None, "d": None},
+                {"a": None, "b": None, "c": 3, "d": None},
+            ]
+        ]
+    }


### PR DESCRIPTION
fixes #9169