### PR TITLE
chore(rust): simplify slow datetime parser

### DIFF
--- a/polars/polars-io/src/csv/buffer.rs
+++ b/polars/polars-io/src/csv/buffer.rs
@@ -423,37 +423,27 @@ where
         return Ok(());
     };
 
-    match &buf.compiled {
-        Some(compiled) => match DatetimeInfer::<T::Native>::try_from(compiled.pattern) {
-            Ok(mut infer) => {
-                let parsed = infer.parse(val);
-                buf.compiled = Some(infer);
-                buf.builder.append_option(parsed);
-                Ok(())
-            }
-            Err(_) => {
-                buf.builder.append_null();
-                Ok(())
-            }
-        },
+    let pattern = match &buf.compiled {
+        Some(compiled) => compiled.pattern,
         None => match infer_pattern_single(val) {
+            Some(pattern) => pattern,
             None => {
                 buf.builder.append_null();
-                Ok(())
+                return Ok(());
             }
-            Some(pattern) => match DatetimeInfer::<T::Native>::try_from(pattern) {
-                Ok(mut infer) => {
-                    let parsed = infer.parse(val);
-                    buf.compiled = Some(infer);
-                    buf.builder.append_option(parsed);
-                    Ok(())
-                }
-                Err(_) => {
-                    buf.builder.append_null();
-                    Ok(())
-                }
-            },
         },
+    };
+    match DatetimeInfer::<T::Native>::try_from(pattern) {
+        Ok(mut infer) => {
+            let parsed = infer.parse(val);
+            buf.compiled = Some(infer);
+            buf.builder.append_option(parsed);
+            Ok(())
+        }
+        Err(_) => {
+            buf.builder.append_null();
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
~drive by: simplify part of the slow datetime parser, which I'd made more complicated than necessary last time round (would normally keep them separate, but they're both very small - is this OK?)~ EDIT: naah, keeping that to a separate PR, easier to revert (if necessary) this way