### PR TITLE
docs(python): clarify how the windows are formed in the rolling_* functions

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4775,7 +4775,7 @@ class DataFrame:
         individual values and are not of constant intervals. For constant intervals use
         *groupby_dynamic*.
 
-        If you have a time series ``[t_0, t_1, ..., t_n]``, then by default the
+        If you have a time series ``<t_0, t_1, ..., t_n>``, then by default the
         windows created will be
 
             * (t_0 - period, t_0]

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4769,13 +4769,19 @@ class DataFrame:
         check_sorted: bool = True,
     ) -> RollingGroupBy:
         """
-        Create rolling groups based on a time column.
-
-        Also works for index values of type Int32 or Int64.
+        Create rolling groups based on a time, Int32, or Int64 column.
 
         Different from a ``dynamic_groupby`` the windows are now determined by the
         individual values and are not of constant intervals. For constant intervals use
-        *groupby_dynamic*
+        *groupby_dynamic*.
+
+        If you have a time series ``[t_0, t_1, ..., t_n]``, then by default the
+        windows created will be
+
+            * (t_0 - period, t_0]
+            * (t_1 - period, t_1]
+            * ...
+            * (t_n - period, t_n]
 
         The `period` and `offset` arguments are created either from a timedelta, or
         by using the following string language:

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4656,7 +4656,7 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -4767,7 +4767,7 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -4878,7 +4878,7 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -4989,7 +4989,7 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -5100,7 +5100,7 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -5211,7 +5211,7 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -5318,7 +5318,7 @@ class Expr:
         """
         Compute a rolling median.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -5427,7 +5427,7 @@ class Expr:
         """
         Compute a rolling quantile.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -5553,16 +5553,7 @@ class Expr:
             * rolling_mean
             * rolling_sum
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
-        windows will be:
-
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
-            - ...
-            - [t_n - window_size, t_n)
-
-        Otherwise, the window at a given row will include the `window_size`
-        elements before it.
+        The window at a given row will include the `window_size` elements before it.
 
         Parameters
         ----------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5553,7 +5553,7 @@ class Expr:
             * rolling_mean
             * rolling_sum
 
-        The window at a given row will the row itself and the `window_size - 1`
+        The window at a given row will include the row itself and the `window_size - 1`
         elements before it.
 
         Parameters

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5553,7 +5553,8 @@ class Expr:
             * rolling_mean
             * rolling_sum
 
-        The window at a given row will include the `window_size` elements before it.
+        The window at a given row will the row itself and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4664,8 +4664,8 @@ class Expr:
             - ...
             - [t_n - window_size, t_n)
 
-        Otherwise, the window at a given row will include the `window_size`
-        elements before it.
+        Otherwise, the window at a given row will include the row itself, and the
+        `window_size - 1` elements before it.
 
         Parameters
         ----------
@@ -4775,8 +4775,8 @@ class Expr:
             - ...
             - [t_n - window_size, t_n)
 
-        Otherwise, the window at a given row will include the `window_size`
-        elements before it.
+        Otherwise, the window at a given row will include the row itself, and the
+        `window_size - 1` elements before it.
 
         Parameters
         ----------
@@ -4886,8 +4886,8 @@ class Expr:
             - ...
             - [t_n - window_size, t_n)
 
-        Otherwise, the window at a given row will include the `window_size`
-        elements before it.
+        Otherwise, the window at a given row will include the row itself, and the
+        `window_size - 1` elements before it.
 
         Parameters
         ----------
@@ -4997,8 +4997,8 @@ class Expr:
             - ...
             - [t_n - window_size, t_n)
 
-        Otherwise, the window at a given row will include the `window_size`
-        elements before it.
+        Otherwise, the window at a given row will include the row itself, and the
+        `window_size - 1` elements before it.
 
         Parameters
         ----------
@@ -5108,8 +5108,8 @@ class Expr:
             - ...
             - [t_n - window_size, t_n)
 
-        Otherwise, the window at a given row will include the `window_size`
-        elements before it.
+        Otherwise, the window at a given row will include the row itself, and the
+        `window_size - 1` elements before it.
 
         Parameters
         ----------
@@ -5219,8 +5219,8 @@ class Expr:
             - ...
             - [t_n - window_size, t_n)
 
-        Otherwise, the window at a given row will include the `window_size`
-        elements before it.
+        Otherwise, the window at a given row will include the row itself, and the
+        `window_size - 1` elements before it.
 
         Parameters
         ----------
@@ -5326,8 +5326,8 @@ class Expr:
             - ...
             - [t_n - window_size, t_n)
 
-        Otherwise, the window at a given row will include the `window_size`
-        elements before it.
+        Otherwise, the window at a given row will include the row itself, and the
+        `window_size - 1` elements before it.
 
         Parameters
         ----------
@@ -5435,8 +5435,8 @@ class Expr:
             - ...
             - [t_n - window_size, t_n)
 
-        Otherwise, the window at a given row will include the `window_size`
-        elements before it.
+        Otherwise, the window at a given row will include the row itself, and the
+        `window_size - 1` elements before it.
 
         Parameters
         ----------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4656,6 +4656,17 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
+
         Parameters
         ----------
         window_size
@@ -4755,6 +4766,17 @@ class Expr:
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
+
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
 
         Parameters
         ----------
@@ -4856,6 +4878,17 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
+
         Parameters
         ----------
         window_size
@@ -4955,6 +4988,17 @@ class Expr:
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
+
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
 
         Parameters
         ----------
@@ -5056,6 +5100,17 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
+
         Parameters
         ----------
         window_size
@@ -5156,6 +5211,17 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
+
         Parameters
         ----------
         window_size
@@ -5251,6 +5317,17 @@ class Expr:
     ) -> Self:
         """
         Compute a rolling median.
+
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
 
         Parameters
         ----------
@@ -5349,6 +5426,17 @@ class Expr:
     ) -> Self:
         """
         Compute a rolling quantile.
+
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
 
         Parameters
         ----------
@@ -5465,6 +5553,17 @@ class Expr:
             * rolling_mean
             * rolling_sum
 
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
+
         Parameters
         ----------
         function
@@ -5518,12 +5617,36 @@ class Expr:
         """
         Compute a rolling skew.
 
+        The window at a given row includes the row itself and the
+        `window_size - 1` elements before it.
+
         Parameters
         ----------
         window_size
             Integer size of the rolling window.
         bias
             If False, the calculations are corrected for statistical bias.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": [1, 4, 2, 9]})
+        >>> df.select(pl.col("a").rolling_skew(3))
+        shape: (4, 1)
+        ┌──────────┐
+        │ a        │
+        │ ---      │
+        │ f64      │
+        ╞══════════╡
+        │ null     │
+        │ null     │
+        │ 0.381802 │
+        │ 0.47033  │
+        └──────────┘
+
+        Note how the values match the following:
+
+        >>> pl.Series([1, 4, 2]).skew(), pl.Series([4, 2, 9]).skew()
+        (0.38180177416060584, 0.47033046033698594)
 
         """
         return self._from_pyexpr(self._pyexpr.rolling_skew(window_size, bias))

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4656,7 +4656,7 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
+        If you pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -4767,7 +4767,7 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
+        If you pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -4878,7 +4878,7 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
+        If you pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -4989,7 +4989,7 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
+        If you pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -5100,7 +5100,7 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
+        If you pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -5211,7 +5211,7 @@ class Expr:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
+        If you pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -5318,7 +5318,7 @@ class Expr:
         """
         Compute a rolling median.
 
-        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
+        If you pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)
@@ -5427,7 +5427,7 @@ class Expr:
         """
         Compute a rolling quantile.
 
-        If you have pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
+        If you pass a ``by`` column ``<t_0, t_1, ..., t_2>``, then by default the
         windows will be:
 
             - [t_0 - window_size, t_0)

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4665,7 +4665,7 @@ class Expr:
             - [t_n - window_size, t_n)
 
         Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        elements before it.
 
         Parameters
         ----------
@@ -4703,7 +4703,7 @@ class Expr:
         by
             If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
-            be of dtype `{Date, Datetime}`
+            be of dtype Datetime.
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive).
 
@@ -4776,7 +4776,7 @@ class Expr:
             - [t_n - window_size, t_n)
 
         Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        elements before it.
 
         Parameters
         ----------
@@ -4814,7 +4814,7 @@ class Expr:
         by
             If the `window_size` is temporal, for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
-            be of dtype `{Date, Datetime}`
+            be of dtype Datetime.
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive).
 
@@ -4887,7 +4887,7 @@ class Expr:
             - [t_n - window_size, t_n)
 
         Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        elements before it.
 
         Parameters
         ----------
@@ -4925,7 +4925,7 @@ class Expr:
         by
             If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
-            be of dtype `{Date, Datetime}`
+            be of dtype Datetime.
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive).
 
@@ -4998,7 +4998,7 @@ class Expr:
             - [t_n - window_size, t_n)
 
         Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        elements before it.
 
         Parameters
         ----------
@@ -5109,7 +5109,7 @@ class Expr:
             - [t_n - window_size, t_n)
 
         Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        elements before it.
 
         Parameters
         ----------
@@ -5147,7 +5147,7 @@ class Expr:
         by
             If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
-            be of dtype `{Date, Datetime}`
+            be of dtype Datetime.
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive).
 
@@ -5220,7 +5220,7 @@ class Expr:
             - [t_n - window_size, t_n)
 
         Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        elements before it.
 
         Parameters
         ----------
@@ -5258,7 +5258,7 @@ class Expr:
         by
             If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
-            be of dtype `{Date, Datetime}`
+            be of dtype Datetime.
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive).
 
@@ -5327,7 +5327,7 @@ class Expr:
             - [t_n - window_size, t_n)
 
         Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        elements before it.
 
         Parameters
         ----------
@@ -5365,7 +5365,7 @@ class Expr:
         by
             If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
-            be of dtype `{Date, Datetime}`
+            be of dtype Datetime.
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive).
 
@@ -5436,7 +5436,7 @@ class Expr:
             - [t_n - window_size, t_n)
 
         Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        elements before it.
 
         Parameters
         ----------
@@ -5478,7 +5478,7 @@ class Expr:
         by
             If the `window_size` is temporal for instance `"5h"` or `"3s"`, you must
             set the column that will be used to determine the windows. This column must
-            be of dtype `{Date, Datetime}`
+            be of dtype Datetime.
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive).
 
@@ -5562,7 +5562,7 @@ class Expr:
             - [t_n - window_size, t_n)
 
         Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        elements before it.
 
         Parameters
         ----------

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -2587,6 +2587,9 @@ def rolling_cov(
     """
     Compute the rolling covariance between two columns/ expressions.
 
+    The window at a given row includes the row itself and the
+    `window_size - 1` elements before it.
+
     Parameters
     ----------
     a
@@ -2624,6 +2627,9 @@ def rolling_corr(
 ) -> Expr:
     """
     Compute the rolling correlation between two columns/ expressions.
+
+    The window at a given row includes the row itself and the
+    `window_size - 1` elements before it.
 
     Parameters
     ----------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2158,7 +2158,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         individual values and are not of constant intervals. For constant intervals
         use *groupby_dynamic*.
 
-        If you have a time series ``[t_0, t_1, ..., t_n]``, then by default the
+        If you have a time series ``<t_0, t_1, ..., t_n>``, then by default the
         windows created will be
 
             * (t_0 - period, t_0]

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2152,13 +2152,19 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         check_sorted: bool = True,
     ) -> LazyGroupBy:
         """
-        Create rolling groups based on a time column.
-
-        Also works for index values of type Int32 or Int64.
+        Create rolling groups based on a time, Int32, or Int64 column.
 
         Different from a ``dynamic_groupby`` the windows are now determined by the
         individual values and are not of constant intervals. For constant intervals
         use *groupby_dynamic*.
+
+        If you have a time series ``[t_0, t_1, ..., t_n]``, then by default the
+        windows created will be
+
+            * (t_0 - period, t_0]
+            * (t_1 - period, t_1]
+            * ...
+            * (t_n - period, t_n]
 
         The `period` and `offset` arguments are created either from a timedelta, or
         by using the following string language:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4389,7 +4389,8 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        The window at a given row will include the `window_size` elements before it.
+        The window at a given row will the row itself and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
@@ -4444,7 +4445,8 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        The window at a given row will include the `window_size` elements before it.
+        The window at a given row will the row itself and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
@@ -4499,7 +4501,8 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        The window at a given row will include the `window_size` elements before it.
+        The window at a given row will the row itself and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
@@ -4554,7 +4557,8 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        The window at a given row will include the `window_size` elements before it.
+        The window at a given row will the row itself and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
@@ -4609,7 +4613,8 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        The window at a given row will include the `window_size` elements before it.
+        The window at a given row will the row itself and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
@@ -4665,7 +4670,8 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        The window at a given row will include the `window_size` elements before it.
+        The window at a given row will the row itself and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
@@ -4725,7 +4731,8 @@ class Series:
             * rolling_mean
             * rolling_sum
 
-        The window at a given row will include the `window_size` elements before it.
+        The window at a given row will the row itself and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------
@@ -4783,7 +4790,8 @@ class Series:
         center
             Set the labels at the center of the window
 
-        The window at a given row will include the `window_size` elements before it.
+        The window at a given row will the row itself and the `window_size - 1`
+        elements before it.
 
         Examples
         --------
@@ -4827,7 +4835,8 @@ class Series:
         """
         Compute a rolling quantile.
 
-        The window at a given row will include the `window_size` elements before it.
+        The window at a given row will the row itself and the `window_size - 1`
+        elements before it.
 
         Parameters
         ----------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4389,7 +4389,7 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        The window at a given row will the row itself and the `window_size - 1`
+        The window at a given row will include the row itself and the `window_size - 1`
         elements before it.
 
         Parameters
@@ -4445,7 +4445,7 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        The window at a given row will the row itself and the `window_size - 1`
+        The window at a given row will include the row itself and the `window_size - 1`
         elements before it.
 
         Parameters
@@ -4501,7 +4501,7 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        The window at a given row will the row itself and the `window_size - 1`
+        The window at a given row will include the row itself and the `window_size - 1`
         elements before it.
 
         Parameters
@@ -4557,7 +4557,7 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        The window at a given row will the row itself and the `window_size - 1`
+        The window at a given row will include the row itself and the `window_size - 1`
         elements before it.
 
         Parameters
@@ -4613,7 +4613,7 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        The window at a given row will the row itself and the `window_size - 1`
+        The window at a given row will include the row itself and the `window_size - 1`
         elements before it.
 
         Parameters
@@ -4670,7 +4670,7 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        The window at a given row will the row itself and the `window_size - 1`
+        The window at a given row will include the row itself and the `window_size - 1`
         elements before it.
 
         Parameters
@@ -4731,7 +4731,7 @@ class Series:
             * rolling_mean
             * rolling_sum
 
-        The window at a given row will the row itself and the `window_size - 1`
+        The window at a given row will include the row itself and the `window_size - 1`
         elements before it.
 
         Parameters
@@ -4790,7 +4790,7 @@ class Series:
         center
             Set the labels at the center of the window
 
-        The window at a given row will the row itself and the `window_size - 1`
+        The window at a given row will include the row itself and the `window_size - 1`
         elements before it.
 
         Examples
@@ -4835,7 +4835,7 @@ class Series:
         """
         Compute a rolling quantile.
 
-        The window at a given row will the row itself and the `window_size - 1`
+        The window at a given row will include the row itself and the `window_size - 1`
         elements before it.
 
         Parameters

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4389,16 +4389,7 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
-        windows will be:
-
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
-            - ...
-            - [t_n - window_size, t_n)
-
-        Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        The window at a given row will include the `window_size` elements before it.
 
         Parameters
         ----------
@@ -4453,16 +4444,7 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
-        windows will be:
-
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
-            - ...
-            - [t_n - window_size, t_n)
-
-        Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        The window at a given row will include the `window_size` elements before it.
 
         Parameters
         ----------
@@ -4517,16 +4499,7 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
-        windows will be:
-
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
-            - ...
-            - [t_n - window_size, t_n)
-
-        Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        The window at a given row will include the `window_size` elements before it.
 
         Parameters
         ----------
@@ -4581,16 +4554,7 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
-        windows will be:
-
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
-            - ...
-            - [t_n - window_size, t_n)
-
-        Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        The window at a given row will include the `window_size` elements before it.
 
         Parameters
         ----------
@@ -4645,16 +4609,7 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
-        windows will be:
-
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
-            - ...
-            - [t_n - window_size, t_n)
-
-        Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        The window at a given row will include the `window_size` elements before it.
 
         Parameters
         ----------
@@ -4710,16 +4665,7 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
-        windows will be:
-
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
-            - ...
-            - [t_n - window_size, t_n)
-
-        Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        The window at a given row will include the `window_size` elements before it.
 
         Parameters
         ----------
@@ -4779,16 +4725,7 @@ class Series:
             * rolling_mean
             * rolling_sum
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
-        windows will be:
-
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
-            - ...
-            - [t_n - window_size, t_n)
-
-        Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        The window at a given row will include the `window_size` elements before it.
 
         Parameters
         ----------
@@ -4846,16 +4783,7 @@ class Series:
         center
             Set the labels at the center of the window
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
-        windows will be:
-
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
-            - ...
-            - [t_n - window_size, t_n)
-
-        Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        The window at a given row will include the `window_size` elements before it.
 
         Examples
         --------
@@ -4899,16 +4827,7 @@ class Series:
         """
         Compute a rolling quantile.
 
-        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
-        windows will be:
-
-            - [t_0 - window_size, t_0)
-            - [t_1 - window_size, t_1)
-            - ...
-            - [t_n - window_size, t_n)
-
-        Otherwise, the window at a given row will include the `window_size`
-        elements before that given row.
+        The window at a given row will include the `window_size` elements before it.
 
         Parameters
         ----------
@@ -4998,7 +4917,7 @@ class Series:
             0.47033
         ]
 
-        Note how the values match the following:
+        Note how the values match
 
         >>> pl.Series([1, 4, 2]).skew(), pl.Series([4, 2, 9]).skew()
         (0.38180177416060584, 0.47033046033698594)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4389,6 +4389,17 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
+
         Parameters
         ----------
         window_size
@@ -4441,6 +4452,17 @@ class Series:
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
+
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
 
         Parameters
         ----------
@@ -4495,6 +4517,17 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
+
         Parameters
         ----------
         window_size
@@ -4547,6 +4580,17 @@ class Series:
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
+
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
 
         Parameters
         ----------
@@ -4601,6 +4645,17 @@ class Series:
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
 
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
+
         Parameters
         ----------
         window_size
@@ -4654,6 +4709,17 @@ class Series:
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
         `weight` vector. The resulting values will be aggregated to their sum.
+
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
 
         Parameters
         ----------
@@ -4713,6 +4779,17 @@ class Series:
             * rolling_mean
             * rolling_sum
 
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
+
         Parameters
         ----------
         function
@@ -4769,6 +4846,17 @@ class Series:
         center
             Set the labels at the center of the window
 
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
+
         Examples
         --------
         >>> s = pl.Series("a", [1.0, 2.0, 3.0, 4.0, 6.0, 8.0])
@@ -4810,6 +4898,17 @@ class Series:
     ) -> Series:
         """
         Compute a rolling quantile.
+
+        If you have pass a ``by`` column ``[t_0, t_1, ..., t_2]``, then by default the
+        windows will be:
+
+            - [t_0 - window_size, t_0)
+            - [t_1 - window_size, t_1)
+            - ...
+            - [t_n - window_size, t_n)
+
+        Otherwise, the window at a given row will include the `window_size`
+        elements before that given row.
 
         Parameters
         ----------
@@ -4877,6 +4976,9 @@ class Series:
         """
         Compute a rolling skew.
 
+        The window at a given row includes the row itself and the
+        `window_size - 1` elements before it.
+
         Parameters
         ----------
         window_size
@@ -4886,18 +4988,20 @@ class Series:
 
         Examples
         --------
-        >>> s = pl.Series("a", [1.0, 2.0, 3.0, 4.0, 6.0, 8.0])
-        >>> s.rolling_skew(window_size=3)
-        shape: (6,)
-        Series: 'a' [f64]
+        >>> pl.Series([1, 4, 2, 9]).rolling_skew(3)
+        shape: (4,)
+        Series: '' [f64]
         [
-                null
-                null
-                0.0
-                0.0
-                0.381802
-                0.0
+            null
+            null
+            0.381802
+            0.47033
         ]
+
+        Note how the values match the following:
+
+        >>> pl.Series([1, 4, 2]).skew(), pl.Series([4, 2, 9]).skew()
+        (0.38180177416060584, 0.47033046033698594)
 
         """
 


### PR DESCRIPTION
Writing this, I noticed that `rolling_groupby` defaults to `closed='right'`, while `rolling_mean` defaults to `closed='left'` - slightly unintuitive, as then to get them to match, one needs to do explicitly pass `closed` in one of them:
```python
In [128]: df.groupby_rolling('ts', period='3d', closed='left').agg(pl.col('a').mean())
Out[128]: 
shape: (5, 2)
┌─────────────────────┬──────┐
│ ts                  ┆ a    │
│ ---                 ┆ ---  │
│ datetime[μs]        ┆ f64  │
╞═════════════════════╪══════╡
│ 2020-01-01 00:00:00 ┆ null │
│ 2020-01-02 00:00:00 ┆ 1.0  │
│ 2020-01-03 00:00:00 ┆ 1.5  │
│ 2020-01-04 00:00:00 ┆ 2.0  │
│ 2020-01-05 00:00:00 ┆ 3.0  │
└─────────────────────┴──────┘

In [129]: df.with_columns(pl.col('a').rolling_mean('3d', by='ts'))
Out[129]: 
shape: (5, 2)
┌─────────────────────┬──────┐
│ ts                  ┆ a    │
│ ---                 ┆ ---  │
│ datetime[μs]        ┆ f64  │
╞═════════════════════╪══════╡
│ 2020-01-01 00:00:00 ┆ null │
│ 2020-01-02 00:00:00 ┆ 1.0  │
│ 2020-01-03 00:00:00 ┆ 1.5  │
│ 2020-01-04 00:00:00 ┆ 2.0  │
│ 2020-01-05 00:00:00 ┆ 3.0  │
└─────────────────────┴──────┘
```
but I'll look into the history, there's probably a good reason for this which I'm missing