### PR TITLE
fix(python): Handle edge cases of named `select` input

### DIFF
--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -380,7 +380,7 @@ def struct(
     {'my_struct': Struct([Field('p', Int64), Field('q', Boolean)])}
 
     """
-    exprs = parse_as_list_of_expressions(exprs, *more_exprs, **named_exprs)  # type: ignore[arg-type]
+    exprs = parse_as_list_of_expressions(exprs, *more_exprs, **named_exprs)
     expr = wrap_expr(plr.as_struct(exprs))
 
     if schema:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2038,7 +2038,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
 
         exprs = parse_as_list_of_expressions(
-            exprs, *more_exprs, **named_exprs, structify=structify
+            exprs, *more_exprs, **named_exprs, __structify=structify
         )
 
         return self._from_pyldf(self._ldf.select(exprs))
@@ -3089,7 +3089,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
 
         exprs = parse_as_list_of_expressions(
-            exprs, *more_exprs, **named_exprs, structify=structify
+            exprs, *more_exprs, **named_exprs, __structify=structify
         )
 
         return self._from_pyldf(self._ldf.with_columns(exprs))

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -123,7 +123,7 @@ class LazyGroupBy:
         if aggs is None and not named_aggs:
             raise ValueError("Expected at least one of 'aggs' or '**named_aggs'")
 
-        exprs = parse_as_list_of_expressions(aggs, *more_aggs, **named_aggs)  # type: ignore[arg-type]
+        exprs = parse_as_list_of_expressions(aggs, *more_aggs, **named_aggs)
 
         return wrap_ldf(self.lgb.agg(exprs))
 

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 def parse_as_list_of_expressions(
     *inputs: IntoExpr | Iterable[IntoExpr],
-    structify: bool = False,
+    __structify: bool = False,
     **named_inputs: IntoExpr,
 ) -> list[PyExpr]:
     """
@@ -28,13 +28,13 @@ def parse_as_list_of_expressions(
     **named_inputs
         Additional inputs to be parsed as expressions, specified as keyword arguments.
         The expressions will be renamed to the keyword used.
-    structify
+    __structify
         Convert multi-column expressions to a single struct expression.
 
     """
-    exprs = _parse_regular_inputs(inputs, structify=structify)
+    exprs = _parse_regular_inputs(inputs, structify=__structify)
     if named_inputs:
-        named_exprs = _parse_named_inputs(named_inputs, structify=structify)
+        named_exprs = _parse_named_inputs(named_inputs, structify=__structify)
         exprs.extend(named_exprs)
 
     return exprs

--- a/py-polars/tests/unit/operations/test_select.py
+++ b/py-polars/tests/unit/operations/test_select.py
@@ -1,5 +1,3 @@
-import pytest
-
 import polars as pl
 from polars.testing import assert_frame_equal
 
@@ -36,13 +34,6 @@ def test_select_args_kwargs() -> None:
     # Mixed
     result = ldf.select(["bar"], "foo", oof="foo")
     expected = pl.LazyFrame({"bar": [3, 4], "foo": [1, 2], "oof": [1, 2]})
-    assert_frame_equal(result, expected)
-
-
-@pytest.mark.skip("Does not work yet - refactor needed.")
-def test_select_no_input() -> None:
-    result = pl.select()
-    expected = pl.DataFrame()
     assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/operations/test_select.py
+++ b/py-polars/tests/unit/operations/test_select.py
@@ -53,6 +53,6 @@ def test_select_empty_list() -> None:
 
 
 def test_select_named_inputs_reserved() -> None:
-    result = pl.select(inputs=1)
-    expected = pl.Series("inputs", [1], dtype=pl.Int32).to_frame()
+    result = pl.select(inputs=1.0, structify=pl.lit("x"))
+    expected = pl.DataFrame({"inputs": [1.0], "structify": ["x"]})
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_select.py
+++ b/py-polars/tests/unit/operations/test_select.py
@@ -1,0 +1,58 @@
+import pytest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+
+def test_select_by_col_list(fruits_cars: pl.DataFrame) -> None:
+    ldf = fruits_cars.lazy()
+    result = ldf.select(pl.col(["A", "B"]).sum())
+    expected = pl.LazyFrame({"A": 15, "B": 15})
+    assert_frame_equal(result, expected)
+
+
+def test_select_args_kwargs() -> None:
+    ldf = pl.LazyFrame({"foo": [1, 2], "bar": [3, 4], "ham": ["a", "b"]})
+
+    # Single column name
+    result = ldf.select("foo")
+    expected = pl.LazyFrame({"foo": [1, 2]})
+    assert_frame_equal(result, expected)
+
+    # Column names as list
+    result = ldf.select(["foo", "bar"])
+    expected = pl.LazyFrame({"foo": [1, 2], "bar": [3, 4]})
+    assert_frame_equal(result, expected)
+
+    # Column names as positional arguments
+    result, expected = ldf.select("foo", "bar", "ham"), ldf
+    assert_frame_equal(result, expected)
+
+    # Keyword arguments
+    result = ldf.select(oof="foo")
+    expected = pl.LazyFrame({"oof": [1, 2]})
+    assert_frame_equal(result, expected)
+
+    # Mixed
+    result = ldf.select(["bar"], "foo", oof="foo")
+    expected = pl.LazyFrame({"bar": [3, 4], "foo": [1, 2], "oof": [1, 2]})
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.skip("Does not work yet - refactor needed.")
+def test_select_no_input() -> None:
+    result = pl.select()
+    expected = pl.DataFrame()
+    assert_frame_equal(result, expected)
+
+
+def test_select_empty_list() -> None:
+    result = pl.select([])
+    expected = pl.DataFrame()
+    assert_frame_equal(result, expected)
+
+
+def test_select_named_inputs_reserved() -> None:
+    result = pl.select(inputs=1)
+    expected = pl.Series("inputs", [1], dtype=pl.Int32).to_frame()
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -664,41 +664,6 @@ def test_backward_fill() -> None:
     assert_series_equal(col_a_backward_fill, pl.Series("a", [1, 3, 3]).cast(pl.Float64))
 
 
-def test_select_by_col_list(fruits_cars: pl.DataFrame) -> None:
-    ldf = fruits_cars.lazy()
-    result = ldf.select(pl.col(["A", "B"]).sum())
-    expected = pl.LazyFrame({"A": 15, "B": 15})
-    assert_frame_equal(result, expected)
-
-
-def test_select_args_kwargs() -> None:
-    ldf = pl.LazyFrame({"foo": [1, 2], "bar": [3, 4], "ham": ["a", "b"]})
-
-    # Single column name
-    result = ldf.select("foo")
-    expected = pl.LazyFrame({"foo": [1, 2]})
-    assert_frame_equal(result, expected)
-
-    # Column names as list
-    result = ldf.select(["foo", "bar"])
-    expected = pl.LazyFrame({"foo": [1, 2], "bar": [3, 4]})
-    assert_frame_equal(result, expected)
-
-    # Column names as positional arguments
-    result, expected = ldf.select("foo", "bar", "ham"), ldf
-    assert_frame_equal(result, expected)
-
-    # Keyword arguments
-    result = ldf.select(oof="foo")
-    expected = pl.LazyFrame({"oof": [1, 2]})
-    assert_frame_equal(result, expected)
-
-    # Mixed
-    result = ldf.select(["bar"], "foo", oof="foo")
-    expected = pl.LazyFrame({"bar": [3, 4], "foo": [1, 2], "oof": [1, 2]})
-    assert_frame_equal(result, expected)
-
-
 def test_rolling(fruits_cars: pl.DataFrame) -> None:
     ldf = fruits_cars.lazy()
     out = ldf.select(

--- a/py-polars/tests/unit/utils/test_parse_expr_input.py
+++ b/py-polars/tests/unit/utils/test_parse_expr_input.py
@@ -7,7 +7,7 @@ import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal
-from polars.utils._parse_expr_input import _inputs_to_list, parse_as_expression
+from polars.utils._parse_expr_input import _first_input_to_list, parse_as_expression
 
 
 def assert_expr_equal(result: pl.Expr, expected: pl.Expr) -> None:
@@ -22,24 +22,24 @@ def assert_expr_equal(result: pl.Expr, expected: pl.Expr) -> None:
 
 
 @pytest.mark.parametrize("input", [None, []])
-def test_inputs_to_list_empty(input: Any) -> None:
-    assert _inputs_to_list(input) == []
+def test_first_input_to_list_empty(input: Any) -> None:
+    assert _first_input_to_list(input) == []
 
 
 @pytest.mark.parametrize(
     "input",
     [5, 2.0, "a", pl.Series([1, 2, 3]), pl.lit(4)],
 )
-def test_inputs_to_list_single(input: Any) -> None:
-    assert _inputs_to_list(input) == [input]
+def test_first_input_to_list_single(input: Any) -> None:
+    assert _first_input_to_list(input) == [input]
 
 
 @pytest.mark.parametrize(
     "input",
     [[5], ["a", "b"], (1, 2, 3), ["a", 5, 3.2]],
 )
-def test_inputs_to_list_multiple(input: Any) -> None:
-    assert _inputs_to_list(input) == list(input)
+def test_first_input_to_list_multiple(input: Any) -> None:
+    assert _first_input_to_list(input) == list(input)
 
 
 @pytest.mark.parametrize("input", [5, 2.0, pl.Series([1, 2, 3]), date(2022, 1, 1)])


### PR DESCRIPTION
There were some column names that were reserved due to the way we processed input. This could cause errors if the users tried to use those as column names:

```
>>> pl.select(inputs=1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/stijn/code/polars/py-polars/polars/functions/lazy.py", line 2391, in select
    return pl.DataFrame().select(exprs, *more_exprs, **named_exprs)
  File "/home/stijn/code/polars/py-polars/polars/dataframe/frame.py", line 7111, in select
    self.lazy()
  File "/home/stijn/code/polars/py-polars/polars/lazyframe/frame.py", line 2040, in select
    exprs = parse_as_list_of_expressions(
TypeError: parse_as_list_of_expressions() got multiple values for argument 'inputs'
```

Now it works correctly:

```
>>> pl.select(inputs=1)
shape: (1, 1)
┌────────┐
│ inputs │
│ ---    │
│ i32    │
╞════════╡
│ 1      │
└────────┘
```

Also moved dedicated `select` tests to their own module.

There are a lot more edge cases to address, more coming soon...