### PR TITLE
fix(rust, python): clipy window_size to length in rolling_apply

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/polars/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -70,7 +70,7 @@ mod inner_mod {
         fn rolling_apply(
             &self,
             f: &dyn Fn(&Series) -> Series,
-            options: RollingOptionsFixedWindow,
+            mut options: RollingOptionsFixedWindow,
         ) -> PolarsResult<Series> {
             check_input(options.window_size, options.min_periods)?;
 
@@ -82,9 +82,7 @@ mod inner_mod {
                 return s.rolling_apply(f, options);
             }
 
-            if options.window_size > self.len() {
-                return Ok(Self::full_null(self.name(), self.len()).into_series());
-            }
+            options.window_size = std::cmp::min(self.len(), options.window_size);
 
             let len = self.len();
             let arr = ca.downcast_iter().next().unwrap();

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -655,3 +655,6 @@ def test_rolling_window_size_9160() -> None:
     assert pl.Series([1, 5]).rolling_apply(
         lambda x: sum(x), window_size=2, min_periods=1
     ).to_list() == [1, 6]
+    assert pl.Series([1]).rolling_apply(
+        lambda x: sum(x), window_size=2, min_periods=1
+    ).to_list() == [1]


### PR DESCRIPTION
fixes #9191