### PR TITLE
fix(rust, python): don't SO on concat(expressions)

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/concat.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/concat.rs
@@ -1,0 +1,13 @@
+use super::*;
+
+pub(super) fn concat_expr(s: &[Series], rechunk: bool) -> PolarsResult<Series> {
+    let mut first = s[0].clone();
+
+    for s in &s[1..] {
+        first.append(s)?;
+    }
+    if rechunk {
+        first = first.rechunk()
+    }
+    Ok(first)
+}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -11,6 +11,7 @@ mod bounds;
 mod cat;
 #[cfg(feature = "round_series")]
 mod clip;
+mod concat;
 mod cum;
 #[cfg(feature = "temporal")]
 mod datetime;
@@ -178,6 +179,7 @@ pub enum FunctionExpr {
     LowerBound,
     #[cfg(feature = "fused")]
     Fused(fused::FusedOperator),
+    ConcatExpr(bool),
 }
 
 impl Display for FunctionExpr {
@@ -268,6 +270,7 @@ impl Display for FunctionExpr {
             Fused(fused) => return Display::fmt(fused, f),
             #[cfg(feature = "dtype-array")]
             ArrayExpr(af) => return Display::fmt(af, f),
+            ConcatExpr(_) => "concat_expr",
         };
         write!(f, "{s}")
     }
@@ -484,6 +487,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             LowerBound => map!(bounds::lower_bound),
             #[cfg(feature = "fused")]
             Fused(op) => map_as_slice!(fused::fused, op),
+            ConcatExpr(rechunk) => map_as_slice!(concat::concat_expr, rechunk),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -200,6 +200,7 @@ impl FunctionExpr {
             UpperBound | LowerBound => mapper.with_same_dtype(),
             #[cfg(feature = "fused")]
             Fused(_) => mapper.map_to_supertype(),
+            ConcatExpr(_) => mapper.map_to_supertype(),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/functions/concat.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions/concat.rs
@@ -60,7 +60,24 @@ pub fn concat_list<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> PolarsResult
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
             input_wildcard_expansion: true,
-            fmt_str: "concat_list",
+            ..Default::default()
+        },
+    })
+}
+
+pub fn concat_expr<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(
+    s: E,
+    rechunk: bool,
+) -> PolarsResult<Expr> {
+    let s: Vec<_> = s.as_ref().iter().map(|e| e.clone().into()).collect();
+    polars_ensure!(!s.is_empty(), ComputeError: "`concat_expr` needs one or more expressions");
+
+    Ok(Expr::Function {
+        input: s,
+        function: FunctionExpr::ConcatExpr(rechunk),
+        options: FunctionOptions {
+            collect_groups: ApplyOptions::ApplyGroups,
+            input_wildcard_expansion: true,
             ..Default::default()
         },
     })

--- a/polars/polars-lazy/polars-plan/src/dsl/functions/concat.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions/concat.rs
@@ -78,6 +78,7 @@ pub fn concat_expr<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
             input_wildcard_expansion: true,
+            cast_to_supertypes: true,
             ..Default::default()
         },
     })

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Iterable, List, Sequence, cast
 import polars._reexport as pl
 from polars import functions as F
 from polars.type_aliases import FrameType
-from polars.utils._wrap import wrap_df, wrap_ldf, wrap_s
+from polars.utils._wrap import wrap_df, wrap_expr, wrap_ldf, wrap_s
 from polars.utils.various import ordered_unique
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -187,9 +187,7 @@ def concat(
             raise ValueError("'Series' only allows {'vertical'} concat strategy.")
 
     elif isinstance(first, pl.Expr):
-        out = first
-        for e in elems[1:]:
-            out = out.append(e)
+        return wrap_expr(plr.concat_expr([e._pyexpr for e in elems], rechunk))
     else:
         raise ValueError(f"did not expect type: {type(first)} in 'pl.concat'.")
 

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -229,6 +229,13 @@ pub fn diag_concat_lf(lfs: &PyAny, rechunk: bool, parallel: bool) -> PyResult<Py
 }
 
 #[pyfunction]
+pub fn concat_expr(e: Vec<PyExpr>, rechunk: bool) -> PyResult<PyExpr> {
+    let e = e.to_exprs();
+    let e = dsl::functions::concat_expr(e, rechunk).map_err(PyPolarsErr::from)?;
+    Ok(e.into())
+}
+
+#[pyfunction]
 pub fn dtype_cols(dtypes: Vec<Wrap<DataType>>) -> PyResult<PyExpr> {
     let dtypes = vec_extract_wrapped(dtypes);
     Ok(dsl::dtype_cols(dtypes).into())

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -127,6 +127,8 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::diag_concat_lf))
         .unwrap();
+    m.add_wrapped(wrap_pyfunction!(functions::lazy::concat_expr))
+        .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::dtype_cols))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::duration))

--- a/py-polars/tests/unit/functions/test_concat.py
+++ b/py-polars/tests/unit/functions/test_concat.py
@@ -1,0 +1,12 @@
+import pytest
+
+import polars as pl
+
+
+@pytest.mark.slow()
+def test_concat_expressions_stack_overflow() -> None:
+    n = 10000
+    e = pl.concat([pl.lit(x) for x in range(0, n)])
+
+    df = pl.select(e)
+    assert df.shape == (n, 1)


### PR DESCRIPTION
The `concat` function recursively called `e.append()` which ofcourse SO's near ~1000 elements. 

We now dispatch to a dedicated expression passing a flat vec of expressions.

fixes #8459