### PR TITLE
refactor(python): Deprecate `exprs=...` input for `select`/`with_columns`/`agg`/`struct`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7119,8 +7119,7 @@ class DataFrame:
 
     def with_columns(
         self,
-        exprs: IntoExpr | Iterable[IntoExpr] | None = None,
-        *more_exprs: IntoExpr,
+        *exprs: IntoExpr | Iterable[IntoExpr],
         **named_exprs: IntoExpr,
     ) -> DataFrame:
         """
@@ -7130,14 +7129,13 @@ class DataFrame:
 
         Parameters
         ----------
-        exprs
-            Column or columns to add. Accepts expression input. Strings are parsed
-            as column names, other non-expression inputs are parsed as literals.
-        *more_exprs
-            Additional columns to add, specified as positional arguments.
+        *exprs
+            Column(s) to add, specified as positional arguments.
+            Accepts expression input. Strings are parsed as column names, other
+            non-expression inputs are parsed as literals.
         **named_exprs
-            Additional columns to add, specified as keyword arguments. The columns
-            will be renamed to the keyword used.
+            Additional columns to add, specified as keyword arguments.
+            The columns will be renamed to the keyword used.
 
         Returns
         -------
@@ -7268,7 +7266,7 @@ class DataFrame:
         """
         return (
             self.lazy()
-            .with_columns(exprs, *more_exprs, **named_exprs)
+            .with_columns(*exprs, **named_exprs)
             .collect(no_optimization=True)
         )
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7014,24 +7014,20 @@ class DataFrame:
         return wrap_ldf(self._df.lazy())
 
     def select(
-        self,
-        exprs: IntoExpr | Iterable[IntoExpr] | None = None,
-        *more_exprs: IntoExpr,
-        **named_exprs: IntoExpr,
+        self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
     ) -> DataFrame:
         """
         Select columns from this DataFrame.
 
         Parameters
         ----------
-        exprs
-            Column(s) to select. Accepts expression input. Strings are parsed as column
-            names, other non-expression inputs are parsed as literals.
-        *more_exprs
-            Additional columns to select, specified as positional arguments.
+        *exprs
+            Column(s) to select, specified as positional arguments.
+            Accepts expression input. Strings are parsed as column names,
+            other non-expression inputs are parsed as literals.
         **named_exprs
-            Additional columns to select, specified as keyword arguments. The columns
-            will be renamed to the keyword used.
+            Additional columns to select, specified as keyword arguments.
+            The columns will be renamed to the keyword used.
 
         Examples
         --------
@@ -7119,11 +7115,7 @@ class DataFrame:
         └───────────┘
 
         """
-        return (
-            self.lazy()
-            .select(exprs, *more_exprs, **named_exprs)
-            .collect(no_optimization=True)
-        )
+        return self.lazy().select(*exprs, **named_exprs).collect(no_optimization=True)
 
     def with_columns(
         self,

--- a/py-polars/polars/dataframe/groupby.py
+++ b/py-polars/polars/dataframe/groupby.py
@@ -137,8 +137,7 @@ class GroupBy:
 
     def agg(
         self,
-        aggs: IntoExpr | Iterable[IntoExpr] | None = None,
-        *more_aggs: IntoExpr,
+        *aggs: IntoExpr | Iterable[IntoExpr],
         **named_aggs: IntoExpr,
     ) -> DataFrame:
         """
@@ -146,14 +145,13 @@ class GroupBy:
 
         Parameters
         ----------
-        aggs
-            Aggregations to compute for each group of the groupby operation.
+        *aggs
+            Aggregations to compute for each group of the groupby operation,
+            specified as positional arguments.
             Accepts expression input. Strings are parsed as column names.
-        *more_aggs
-            Additional aggregations, specified as positional arguments.
         **named_aggs
-            Additional aggregations, specified as keyword arguments. The resulting
-            columns will be renamed to the keyword used.
+            Additional aggregations, specified as keyword arguments.
+            The resulting columns will be renamed to the keyword used.
 
         Examples
         --------
@@ -230,7 +228,7 @@ class GroupBy:
         return (
             self.df.lazy()
             .groupby(self.by, *self.more_by, maintain_order=self.maintain_order)
-            .agg(aggs, *more_aggs, **named_aggs)
+            .agg(*aggs, **named_aggs)
             .collect(no_optimization=True)
         )
 
@@ -824,8 +822,7 @@ class RollingGroupBy:
 
     def agg(
         self,
-        aggs: IntoExpr | Iterable[IntoExpr] | None = None,
-        *more_aggs: IntoExpr,
+        *aggs: IntoExpr | Iterable[IntoExpr],
         **named_aggs: IntoExpr,
     ) -> DataFrame:
         return (
@@ -838,7 +835,7 @@ class RollingGroupBy:
                 by=self.by,
                 check_sorted=self.check_sorted,
             )
-            .agg(aggs, *more_aggs, **named_aggs)
+            .agg(*aggs, **named_aggs)
             .collect(no_optimization=True)
         )
 
@@ -1026,8 +1023,7 @@ class DynamicGroupBy:
 
     def agg(
         self,
-        aggs: IntoExpr | Iterable[IntoExpr] | None = None,
-        *more_aggs: IntoExpr,
+        *aggs: IntoExpr | Iterable[IntoExpr],
         **named_aggs: IntoExpr,
     ) -> DataFrame:
         return (
@@ -1044,7 +1040,7 @@ class DynamicGroupBy:
                 start_by=self.start_by,
                 check_sorted=self.check_sorted,
             )
-            .agg(aggs, *more_aggs, **named_aggs)
+            .agg(*aggs, **named_aggs)
             .collect(no_optimization=True)
         )
 

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -384,11 +384,11 @@ def struct(
             stacklevel=find_stacklevel(),
         )
         first_input = named_exprs.pop("exprs")
-        exprs = parse_as_list_of_expressions(first_input, *exprs, **named_exprs)
+        pyexprs = parse_as_list_of_expressions(first_input, *exprs, **named_exprs)
     else:
-        exprs = parse_as_list_of_expressions(*exprs, **named_exprs)
+        pyexprs = parse_as_list_of_expressions(*exprs, **named_exprs)
 
-    expr = wrap_expr(plr.as_struct(exprs))
+    expr = wrap_expr(plr.as_struct(pyexprs))
 
     if schema:
         if not exprs:

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import warnings
 from typing import TYPE_CHECKING, Iterable, overload
 
 from polars import functions as F
@@ -10,6 +11,7 @@ from polars.utils._parse_expr_input import (
     parse_as_list_of_expressions,
 )
 from polars.utils._wrap import wrap_expr
+from polars.utils.various import find_stacklevel
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -278,10 +280,9 @@ def concat_list(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> 
 
 @overload
 def struct(
-    exprs: IntoExpr | Iterable[IntoExpr] = ...,
-    *more_exprs: IntoExpr,
-    eager: Literal[False] = ...,
+    *exprs: IntoExpr | Iterable[IntoExpr],
     schema: SchemaDict | None = ...,
+    eager: Literal[False] = ...,
     **named_exprs: IntoExpr,
 ) -> Expr:
     ...
@@ -289,10 +290,9 @@ def struct(
 
 @overload
 def struct(
-    exprs: IntoExpr | Iterable[IntoExpr] = ...,
-    *more_exprs: IntoExpr,
-    eager: Literal[True],
+    *exprs: IntoExpr | Iterable[IntoExpr],
     schema: SchemaDict | None = ...,
+    eager: Literal[True],
     **named_exprs: IntoExpr,
 ) -> Series:
     ...
@@ -300,20 +300,18 @@ def struct(
 
 @overload
 def struct(
-    exprs: IntoExpr | Iterable[IntoExpr] = ...,
-    *more_exprs: IntoExpr,
-    eager: bool,
+    *exprs: IntoExpr | Iterable[IntoExpr],
     schema: SchemaDict | None = ...,
+    eager: bool,
     **named_exprs: IntoExpr,
 ) -> Expr | Series:
     ...
 
 
 def struct(
-    exprs: IntoExpr | Iterable[IntoExpr] = None,
-    *more_exprs: IntoExpr,
-    eager: bool = False,
+    *exprs: IntoExpr | Iterable[IntoExpr],
     schema: SchemaDict | None = None,
+    eager: bool = False,
     **named_exprs: IntoExpr,
 ) -> Expr | Series:
     """
@@ -321,18 +319,16 @@ def struct(
 
     Parameters
     ----------
-    exprs
-        Column(s) to collect into a struct column. Accepts expression input. Strings are
-        parsed as column names, other non-expression inputs are parsed as literals.
-    *more_exprs
-        Additional columns to collect into the struct column, specified as positional
-        arguments.
-    eager
-        Evaluate immediately and return a ``Series``. If set to ``False`` (default),
-        return an expression instead.
+    *exprs
+        Column(s) to collect into a struct column, specified as positional arguments.
+        Accepts expression input. Strings are parsed as column names,
+        other non-expression inputs are parsed as literals.
     schema
         Optional schema that explicitly defines the struct field dtypes. If no columns
         or expressions are provided, schema keys are used to define columns.
+    eager
+        Evaluate immediately and return a ``Series``. If set to ``False`` (default),
+        return an expression instead.
     **named_exprs
         Additional columns to collect into the struct column, specified as keyword
         arguments. The columns will be renamed to the keyword used.
@@ -380,7 +376,18 @@ def struct(
     {'my_struct': Struct([Field('p', Int64), Field('q', Boolean)])}
 
     """
-    exprs = parse_as_list_of_expressions(exprs, *more_exprs, **named_exprs)
+    if "exprs" in named_exprs:
+        warnings.warn(
+            "passing expressions to `struct` using the keyword argument `exprs` is"
+            " deprecated. Use positional syntax instead.",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
+        first_input = named_exprs.pop("exprs")
+        exprs = parse_as_list_of_expressions(first_input, *exprs, **named_exprs)
+    else:
+        exprs = parse_as_list_of_expressions(*exprs, **named_exprs)
+
     expr = wrap_expr(plr.as_struct(exprs))
 
     if schema:

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -2347,11 +2347,7 @@ def collect_all(
     return result
 
 
-def select(
-    exprs: IntoExpr | Iterable[IntoExpr] | None = None,
-    *more_exprs: IntoExpr,
-    **named_exprs: IntoExpr,
-) -> DataFrame:
+def select(*exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr) -> DataFrame:
     """
     Run polars expressions without a context.
 
@@ -2359,13 +2355,13 @@ def select(
 
     Parameters
     ----------
-    exprs
-        Expression or expressions to run.
-    *more_exprs
-        Additional expressions to run, specified as positional arguments.
+    *exprs
+        Column(s) to select, specified as positional arguments.
+        Accepts expression input. Strings are parsed as column names,
+        other non-expression inputs are parsed as literals.
     **named_exprs
-        Additional expressions to run, specified as keyword arguments. The expressions
-        will be renamed to the keyword used.
+        Additional columns to select, specified as keyword arguments.
+        The columns will be renamed to the keyword used.
 
     Returns
     -------
@@ -2388,7 +2384,7 @@ def select(
     └─────┘
 
     """
-    return pl.DataFrame().select(exprs, *more_exprs, **named_exprs)
+    return pl.DataFrame().select(*exprs, **named_exprs)
 
 
 @overload

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2039,15 +2039,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 stacklevel=find_stacklevel(),
             )
             first_input = named_exprs.pop("exprs")
-            exprs = parse_as_list_of_expressions(
+            pyexprs = parse_as_list_of_expressions(
                 first_input, *exprs, **named_exprs, __structify=structify
             )
         else:
-            exprs = parse_as_list_of_expressions(
+            pyexprs = parse_as_list_of_expressions(
                 *exprs, **named_exprs, __structify=structify
             )
 
-        return self._from_pyldf(self._ldf.select(exprs))
+        return self._from_pyldf(self._ldf.select(pyexprs))
 
     def groupby(
         self,
@@ -3103,15 +3103,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 stacklevel=find_stacklevel(),
             )
             first_input = named_exprs.pop("exprs")
-            exprs = parse_as_list_of_expressions(
+            pyexprs = parse_as_list_of_expressions(
                 first_input, *exprs, **named_exprs, __structify=structify
             )
         else:
-            exprs = parse_as_list_of_expressions(
+            pyexprs = parse_as_list_of_expressions(
                 *exprs, **named_exprs, __structify=structify
             )
 
-        return self._from_pyldf(self._ldf.with_columns(exprs))
+        return self._from_pyldf(self._ldf.with_columns(pyexprs))
 
     @typing.no_type_check
     def with_context(self, other: Self | list[Self]) -> Self:

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Callable, Iterable
 
 from polars import functions as F
 from polars.utils._parse_expr_input import parse_as_list_of_expressions
 from polars.utils._wrap import wrap_ldf
+from polars.utils.various import find_stacklevel
 
 if TYPE_CHECKING:
     from polars import DataFrame, LazyFrame
@@ -24,8 +26,7 @@ class LazyGroupBy:
 
     def agg(
         self,
-        aggs: IntoExpr | Iterable[IntoExpr] | None = None,
-        *more_aggs: IntoExpr,
+        *aggs: IntoExpr | Iterable[IntoExpr],
         **named_aggs: IntoExpr,
     ) -> LazyFrame:
         """
@@ -33,14 +34,13 @@ class LazyGroupBy:
 
         Parameters
         ----------
-        aggs
-            Aggregations to compute for each group of the groupby operation.
+        *aggs
+            Aggregations to compute for each group of the groupby operation,
+            specified as positional arguments.
             Accepts expression input. Strings are parsed as column names.
-        *more_aggs
-            Additional aggregations, specified as positional arguments.
         **named_aggs
-            Additional aggregations, specified as keyword arguments. The resulting
-            columns will be renamed to the keyword used.
+            Additional aggregations, specified as keyword arguments.
+            The resulting columns will be renamed to the keyword used.
 
         Examples
         --------
@@ -116,12 +116,24 @@ class LazyGroupBy:
         └─────┴───────┴────────────────┘
 
         """
-        if isinstance(aggs, dict):
+        if aggs and isinstance(aggs[0], dict):
             raise ValueError(
-                f"'aggs' argument should be one or multiple expressions, got: '{aggs}'."
+                "specifying aggregations as a dictionary is not supported."
+                " Try unpacking the dictionary to take advantage of the keyword syntax"
+                " of the `agg` method."
             )
 
-        exprs = parse_as_list_of_expressions(aggs, *more_aggs, **named_aggs)
+        if "aggs" in named_aggs:
+            warnings.warn(
+                "passing expressions to `select` using the keyword argument `exprs` is"
+                " deprecated. Use positional syntax instead.",
+                DeprecationWarning,
+                stacklevel=find_stacklevel(),
+            )
+            first_input = named_aggs.pop("aggs")
+            exprs = parse_as_list_of_expressions(first_input, *aggs, **named_aggs)
+        else:
+            exprs = parse_as_list_of_expressions(*aggs, **named_aggs)
 
         return wrap_ldf(self.lgb.agg(exprs))
 

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -131,11 +131,11 @@ class LazyGroupBy:
                 stacklevel=find_stacklevel(),
             )
             first_input = named_aggs.pop("aggs")
-            exprs = parse_as_list_of_expressions(first_input, *aggs, **named_aggs)
+            pyexprs = parse_as_list_of_expressions(first_input, *aggs, **named_aggs)
         else:
-            exprs = parse_as_list_of_expressions(*aggs, **named_aggs)
+            pyexprs = parse_as_list_of_expressions(*aggs, **named_aggs)
 
-        return wrap_ldf(self.lgb.agg(exprs))
+        return wrap_ldf(self.lgb.agg(pyexprs))
 
     def apply(
         self,

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -125,7 +125,7 @@ class LazyGroupBy:
 
         if "aggs" in named_aggs:
             warnings.warn(
-                "passing expressions to `select` using the keyword argument `exprs` is"
+                "passing expressions to `agg` using the keyword argument `aggs` is"
                 " deprecated. Use positional syntax instead.",
                 DeprecationWarning,
                 stacklevel=find_stacklevel(),

--- a/py-polars/tests/unit/functions/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/test_as_datatype.py
@@ -456,3 +456,14 @@ def test_format() -> None:
 
     out = df.select([pl.format("foo_{}_bar_{}", pl.col("a"), "b").alias("fmt")])
     assert out["fmt"].to_list() == ["foo_a_bar_1", "foo_b_bar_2", "foo_c_bar_3"]
+
+
+def test_struct_deprecation_exprs_keyword() -> None:
+    with pytest.deprecated_call():
+        result = pl.select(pl.struct(exprs=1.0))
+
+    expected = pl.DataFrame(
+        {"literal": [{"literal": 1.0}]},
+        schema={"literal": pl.Struct({"literal": pl.Float64})},
+    )
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -850,3 +850,13 @@ def test_perfect_hash_table_null_values_8663() -> None:
             [None, None, None],
         ],
     }
+
+
+def test_groupby_agg_deprecation_aggs_keyword() -> None:
+    df = pl.DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]})
+
+    with pytest.deprecated_call():
+        result = df.groupby("a").agg(aggs="b")
+
+    expected = pl.DataFrame({"a": [1, 2], "b": [[3, 4], [5]]})
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -856,7 +856,7 @@ def test_groupby_agg_deprecation_aggs_keyword() -> None:
     df = pl.DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]})
 
     with pytest.deprecated_call():
-        result = df.groupby("a").agg(aggs="b")
+        result = df.groupby("a", maintain_order=True).agg(aggs="b")
 
     expected = pl.DataFrame({"a": [1, 2], "b": [[3, 4], [5]]})
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_select.py
+++ b/py-polars/tests/unit/operations/test_select.py
@@ -1,3 +1,5 @@
+import pytest
+
 import polars as pl
 from polars.testing import assert_frame_equal
 
@@ -52,4 +54,12 @@ def test_select_empty_list() -> None:
 def test_select_named_inputs_reserved() -> None:
     result = pl.select(inputs=1.0, structify=pl.lit("x"))
     expected = pl.DataFrame({"inputs": [1.0], "structify": ["x"]})
+    assert_frame_equal(result, expected)
+
+
+def test_select_deprecation_exprs_keyword() -> None:
+    with pytest.deprecated_call():
+        result = pl.select(exprs=1.0)
+
+    expected = pl.DataFrame({"literal": [1.0]})
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_with_columns.py
+++ b/py-polars/tests/unit/operations/test_with_columns.py
@@ -1,3 +1,5 @@
+import pytest
+
 import polars as pl
 from polars.testing import assert_frame_equal
 
@@ -149,3 +151,13 @@ def test_with_columns_single_series() -> None:
 
     expected = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     assert_frame_equal(result.collect(), expected)
+
+
+def test_with_columns_deprecation_exprs_keyword() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+
+    with pytest.deprecated_call():
+        result = df.with_columns(exprs=1.0)
+
+    expected = pl.DataFrame({"a": [1, 2], "literal": [1.0, 1.0]})
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -583,8 +583,7 @@ def test_invalid_getitem_key_err() -> None:
 def test_invalid_groupby_arg() -> None:
     df = pl.DataFrame({"a": [1]})
     with pytest.raises(
-        ValueError,
-        match=r"'aggs' argument should be one or multiple expressions, got: '{'a': 'sum'}'",
+        ValueError, match="specifying aggregations as a dictionary is not supported"
     ):
         df.groupby(1).agg({"a": "sum"})
 

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1098,11 +1098,9 @@ def test_self_join() -> None:
     out = (
         ldf.join(other=ldf, left_on="manager_id", right_on="employee_id", how="left")
         .select(
-            exprs=[
-                pl.col("employee_id"),
-                pl.col("employee_name"),
-                pl.col("employee_name_right").alias("manager_name"),
-            ]
+            pl.col("employee_id"),
+            pl.col("employee_name"),
+            pl.col("employee_name_right").alias("manager_name"),
         )
         .fetch()
     )

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1098,9 +1098,11 @@ def test_self_join() -> None:
     out = (
         ldf.join(other=ldf, left_on="manager_id", right_on="employee_id", how="left")
         .select(
-            pl.col("employee_id"),
-            pl.col("employee_name"),
-            pl.col("employee_name_right").alias("manager_name"),
+            [
+                pl.col("employee_id"),
+                pl.col("employee_name"),
+                pl.col("employee_name_right").alias("manager_name"),
+            ]
         )
         .fetch()
     )


### PR DESCRIPTION
The deprecated syntax:
```python
df.select(exprs=["a", "b"])
```
...should be replaced by:
```python
df.select(["a", "b"])
```
...or by using *args syntax:
```python
df.select("a", "b")
```

Reason for the change is two-fold:
1. These methods take `**named_exprs` input as well. `exprs=...` overlaps with the named expression input, e.g. the user could expect a column named `exprs`.
2. Because of possible `**named_exprs` input, the `exprs` argument needed a default value `None`. This leads to some unexpected behaviour when the user inputs `None` as the first argument. Consider the behaviour below. This change will enable me to address this in a followup PR.

```
>>> pl.select(None)
shape: (0, 0)
┌┐
╞╡
└┘
>>> pl.select(None, 1)
shape: (1, 1)
┌─────────┐
│ literal │
│ ---     │
│ i32     │
╞═════════╡
│ 1       │
└─────────┘
>>> pl.select(1, None)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/stijn/code/polars/py-polars/polars/functions/lazy.py", line 2387, in select
    return pl.DataFrame().select(*exprs, **named_exprs)
  File "/home/stijn/code/polars/py-polars/polars/dataframe/frame.py", line 7112, in select
    return self.lazy().select(*exprs, **named_exprs).collect(no_optimization=True)
  File "/home/stijn/code/polars/py-polars/polars/lazyframe/frame.py", line 1503, in collect
    return wrap_df(ldf.collect())
exceptions.DuplicateError: column with name 'literal' has more than one occurrences
```