### PR TITLE
feat(rust, python): immediately flatten nested unions

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/delay_rechunk.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/delay_rechunk.rs
@@ -32,8 +32,6 @@ impl OptimizationRule for DelayRechunk {
 
                 use ALogicalPlan::*;
                 let mut input_node = None;
-                let mut union_parent = None;
-                let mut previous_node = *input;
                 for (node, lp) in (&*lp_arena).iter(*input) {
                     match lp {
                         // we get the input node
@@ -52,12 +50,14 @@ impl OptimizationRule for DelayRechunk {
                             input_node = Some(node);
                             break;
                         }
-                        Union { .. } => union_parent = Some(previous_node),
+                        Union { .. } => {
+                            input_node = Some(node);
+                            break;
+                        }
                         // don't delay rechunk if there is a join first
                         Join { .. } => break,
                         _ => {}
                     }
-                    previous_node = node;
                 }
 
                 if let Some(node) = input_node {
@@ -72,20 +72,12 @@ impl OptimizationRule for DelayRechunk {
                         IpcScan { options, .. } => {
                             options.rechunk = false;
                         }
+                        Union { options, .. } => {
+                            options.rechunk = false;
+                        }
                         _ => unreachable!(),
                     }
                 };
-                if let Some(parent_node) = union_parent {
-                    // remove the rechunk function
-                    if let MapFunction {
-                        input,
-                        function: FunctionNode::Rechunk,
-                        ..
-                    } = lp_arena.get(parent_node)
-                    {
-                        lp_arena.swap(*input, parent_node)
-                    }
-                }
 
                 None
             }

--- a/polars/polars-lazy/polars-plan/src/logical_plan/options.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/options.rs
@@ -127,6 +127,7 @@ pub struct UnionOptions {
     pub rows: (Option<usize>, usize),
     pub from_partitioned_ds: bool,
     pub flattened_by_opt: bool,
+    pub rechunk: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]

--- a/polars/polars-lazy/src/dsl/functions.rs
+++ b/polars/polars-lazy/src/dsl/functions.rs
@@ -15,38 +15,55 @@ pub(crate) fn concat_impl<L: AsRef<[LazyFrame]>>(
     from_partitioned_ds: bool,
 ) -> PolarsResult<LazyFrame> {
     let mut inputs = inputs.as_ref().to_vec();
-    let lf = std::mem::take(
+
+    let mut lf = std::mem::take(
         inputs
             .get_mut(0)
             .ok_or_else(|| polars_err!(NoData: "empty container given"))?,
     );
-    let mut opt_state = lf.opt_state;
-    let mut lps = Vec::with_capacity(inputs.len());
-    lps.push(lf.logical_plan);
 
-    for lf in &mut inputs[1..] {
-        // ensure we enable file caching if any lf has it enabled
-        opt_state.file_caching |= lf.opt_state.file_caching;
-        let lp = std::mem::take(&mut lf.logical_plan);
-        lps.push(lp)
-    }
+    let mut opt_state = lf.opt_state;
     let options = UnionOptions {
         parallel,
         from_partitioned_ds,
+        rechunk,
         ..Default::default()
     };
 
-    let lp = LogicalPlan::Union {
-        inputs: lps,
-        options,
-    };
-    let mut lf = LazyFrame::from(lp);
-    lf.opt_state = opt_state;
+    match &mut lf.logical_plan {
+        // re-use the same union
+        LogicalPlan::Union {
+            inputs: existing_inputs,
+            options: opts,
+        } if opts == &options => {
+            for lf in &mut inputs[1..] {
+                // ensure we enable file caching if any lf has it enabled
+                opt_state.file_caching |= lf.opt_state.file_caching;
+                let lp = std::mem::take(&mut lf.logical_plan);
+                existing_inputs.push(lp)
+            }
+            Ok(lf)
+        }
+        _ => {
+            let mut lps = Vec::with_capacity(inputs.len());
+            lps.push(lf.logical_plan);
 
-    if rechunk {
-        Ok(lf.map_private(FunctionNode::Rechunk))
-    } else {
-        Ok(lf)
+            for lf in &mut inputs[1..] {
+                // ensure we enable file caching if any lf has it enabled
+                opt_state.file_caching |= lf.opt_state.file_caching;
+                let lp = std::mem::take(&mut lf.logical_plan);
+                lps.push(lp)
+            }
+
+            let lp = LogicalPlan::Union {
+                inputs: lps,
+                options,
+            };
+            let mut lf = LazyFrame::from(lp);
+            lf.opt_state = opt_state;
+
+            Ok(lf)
+        }
     }
 }
 

--- a/polars/polars-lazy/src/physical_plan/executors/union.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/union.rs
@@ -105,5 +105,11 @@ impl Executor for UnionExec {
 
             concat_df(out?.iter().flat_map(|dfs| dfs.iter()))
         }
+        .map(|mut df| {
+            if self.options.rechunk {
+                df.as_single_chunk_par();
+            }
+            df
+        })
     }
 }

--- a/py-polars/tests/unit/functions/test_concat.py
+++ b/py-polars/tests/unit/functions/test_concat.py
@@ -10,3 +10,13 @@ def test_concat_expressions_stack_overflow() -> None:
 
     df = pl.select(e)
     assert df.shape == (n, 1)
+
+
+@pytest.mark.slow()
+def test_concat_lf_stack_overflow() -> None:
+    n = 1000
+    bar = pl.DataFrame({"a": 0}).lazy()
+
+    for i in range(n):
+        bar = pl.concat([bar, pl.DataFrame({"a": i}).lazy()])
+    assert bar.collect().shape == (1001, 1)


### PR DESCRIPTION
This will prevent SO's on nested `concat` calls. Which are clearly bad queries, but they will occur in the wild.

fixes #6585