### PR TITLE
chore(rust): Fix unused import warning in release build

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install Polars release build
         env:
-          RUSTFLAGS: -C embed-bitcode
+          RUSTFLAGS: -C embed-bitcode -D warnings
         working-directory: py-polars
         run: |
           source activate

--- a/polars/polars-lazy/src/physical_plan/streaming/tree.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/tree.rs
@@ -1,8 +1,11 @@
 use std::collections::BTreeSet;
 use std::fmt::Debug;
 
+#[cfg(debug_assertions)]
 use polars_plan::prelude::*;
-use polars_utils::arena::{Arena, Node};
+#[cfg(debug_assertions)]
+use polars_utils::arena::Arena;
+use polars_utils::arena::Node;
 
 #[derive(Copy, Clone, Debug)]
 pub(super) enum PipelineNode {


### PR DESCRIPTION
Noticed this while working on the CI. Added a `-D warnings` flag so these warning are caught in the CI next time.