### PR TITLE
ci(python): Enable parallelization in Python Windows tests

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -117,7 +117,7 @@ jobs:
           pip install target/wheels/polars-*.whl
 
       - name: Run tests
-        run: pytest -m "not benchmark"
+        run: pytest -n auto --dist worksteal -m "not benchmark"
 
       - name: Check import without optional dependencies
         run: |


### PR DESCRIPTION
Since #9206 this should be stable.

Shaves about a minute off the workflow. Which is nice, since it's often the slowest running job on Python PRs.