### PR TITLE
chore(rust): Fix itoap dependency specification

### DIFF
--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -157,7 +157,7 @@ comfy-table = { version = "6.1.4", optional = true, default_features = false }
 either.workspace = true
 hashbrown.workspace = true
 indexmap.workspace = true
-itoap = { version = "1", optional = true, feature = ["simd"] }
+itoap = { version = "1", optional = true, features = ["simd"] }
 ndarray = { version = "0.15", optional = true, default_features = false }
 num-traits.workspace = true
 object_store = { version = "0.6.0", default-features = false, optional = true }


### PR DESCRIPTION
Took me a while to figure out where this warning came from:

```
warning: /home/stijn/code/polars-fork/polars/polars-core/Cargo.toml: unused manifest key: dependencies.itoap.feature
```

Turns out it's just a typo. So this PR is literally 1 character long 😅 