### PR TITLE
ci(rust): Separate workflow for Rust lints

### DIFF
--- a/.github/workflows/build-test-rust.yml
+++ b/.github/workflows/build-test-rust.yml
@@ -44,43 +44,6 @@ jobs:
       - name: Run cargo hack
         working-directory: polars
         run: cargo hack check --each-feature --no-dev-deps
-  lint:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: polars
-
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Rust
-        run: rustup component add rustfmt clippy miri
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: polars
-
-      - name: Run rustfmt
-        run: cargo fmt --all -- --check
-
-      - name: Run clippy
-        env:
-          RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
-        run : |
-          cargo clippy --all-features \
-            -p polars-core \
-            -p polars-io \
-            -p polars-lazy \
-            -p polars-sql \
-            -- -D warnings
-          cargo clippy -- -D warnings
-
-      - name: Run miri
-        run: |
-          cargo miri setup
-          cargo clean
-          make miri
 
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -1,0 +1,53 @@
+name: Lint Rust
+
+on:
+  pull_request:
+    paths:
+      - polars/**
+      - polars-cli/**
+      - examples/**
+      - Cargo.toml
+      - .github/workflows/lint-rust.yml
+  push:
+    branches:
+      - main
+    paths:
+      - polars/**
+      - polars-cli/**
+      - examples/**
+      - Cargo.toml
+      - .github/workflows/lint-rust.yml
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Rust
+        run: rustup component add rustfmt clippy miri
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref_name == 'main' }}
+
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check
+
+      - name: Run cargo clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Run cargo clippy on all features
+        run: cargo clippy --all-features -- -D warnings
+
+      - name: Run miri
+        working-directory: polars
+        run: |
+          cargo miri setup
+          cargo clean
+          make miri

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -22,6 +22,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  RUSTFLAGS: -C debuginfo=0  # Do not produce debug symbols to keep memory usage down
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -55,7 +55,7 @@ jobs:
         if: ${{ github.ref_name != 'main' }}
         working-directory: polars
         env:
-          MIRIFLAGS: -Z miri-disable-isolation -Z miri-ignore-leaks -Z miri-disable-stacked-borrows
+          MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks -Zmiri-disable-stacked-borrows
           POLARS_ALLOW_EXTENSION: '1'
         run: |
           cargo miri test \

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -39,15 +39,28 @@ jobs:
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
 
-      - name: Run cargo clippy
-        run: cargo clippy -- -D warnings
-
       - name: Run cargo clippy on all features
         run: cargo clippy --all-features -- -D warnings
 
-      - name: Run miri
+      - name: Run cargo clippy
+        if: ${{ github.ref_name != 'main' }}
+        run: cargo clippy -- -D warnings
+
+      - name: Set up miri
+        if: ${{ github.ref_name != 'main' }}
         working-directory: polars
+        run: cargo miri setup
+
+      - name: Run miri
+        if: ${{ github.ref_name != 'main' }}
+        working-directory: polars
+        env:
+          MIRIFLAGS: -Z miri-disable-isolation -Z miri-ignore-leaks -Z miri-disable-stacked-borrows
+          POLARS_ALLOW_EXTENSION: '1'
         run: |
-          cargo miri setup
-          cargo clean
-          make miri
+          cargo miri test \
+          --no-default-features \
+          --features object \
+          -p polars-core \
+          -p polars-arrow
+

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -37,6 +37,7 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Run cargo fmt
+        if: ${{ github.ref_name != 'main' }}
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy on all features

--- a/polars-cli/src/main.rs
+++ b/polars-cli/src/main.rs
@@ -53,7 +53,7 @@ impl OutputMode {
                     if matches!(self, OutputMode::Table | OutputMode::Markdown) {
                         let max_rows = std::env::var("POLARS_FMT_MAX_ROWS")
                             .unwrap_or("20".into())
-                            .parse::<u32>()
+                            .parse::<IdxSize>()
                             .unwrap_or(20);
                         lf.limit(max_rows).collect()
                     } else {

--- a/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
@@ -229,6 +229,11 @@ impl PartitionGroupByExec {
         state: &mut ExecutionState,
         original_df: DataFrame,
     ) -> Option<PolarsResult<DataFrame>> {
+        #[allow(clippy::needless_update)]
+        let groupby_options = GroupbyOptions {
+            slice: self.slice,
+            ..Default::default()
+        };
         let lp = LogicalPlan::Aggregate {
             input: Box::new(original_df.lazy().logical_plan),
             keys: Arc::new(std::mem::take(&mut self.keys)),
@@ -236,10 +241,7 @@ impl PartitionGroupByExec {
             schema: self.output_schema.clone(),
             apply: None,
             maintain_order: false,
-            options: GroupbyOptions {
-                slice: self.slice,
-                ..Default::default()
-            },
+            options: groupby_options,
         };
         let mut expr_arena = Default::default();
         let mut lp_arena = Default::default();


### PR DESCRIPTION
Changes:
* Separate workflow for linting to take advantage of caching.
* Run clippy from workspace root, rather than from `polars` directory.
  * This caught an error in `polars-cli` that is fixed in this PR.
  * Also fixed a clippy warning that popped up.