### PR TITLE
feat(rust, python): rewrite correlation functions to expression architecture

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/correlation.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/correlation.rs
@@ -1,0 +1,203 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use super::*;
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum CorrelationMethod {
+    Pearson,
+    #[cfg(all(feature = "rank", feature = "propagate_nans"))]
+    SpearmanRank(bool),
+    Covariance,
+}
+
+impl Display for CorrelationMethod {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use CorrelationMethod::*;
+        let s = match self {
+            Pearson => "pearson",
+            #[cfg(all(feature = "rank", feature = "propagate_nans"))]
+            SpearmanRank(_) => "spearman_rank",
+            Covariance => return write!(f, "covariance"),
+        };
+        write!(f, "{}_correlation", s)
+    }
+}
+
+pub(super) fn corr(s: &[Series], ddof: u8, method: CorrelationMethod) -> PolarsResult<Series> {
+    match method {
+        CorrelationMethod::Pearson => pearson_corr(s, ddof),
+        #[cfg(all(feature = "rank", feature = "propagate_nans"))]
+        CorrelationMethod::SpearmanRank(propagate_nans) => {
+            spearman_rank_corr(s, ddof, propagate_nans)
+        }
+        CorrelationMethod::Covariance => covariance(s),
+    }
+}
+
+fn covariance(s: &[Series]) -> PolarsResult<Series> {
+    let a = &s[0];
+    let b = &s[1];
+    let name = "cov";
+
+    let s = match a.dtype() {
+        DataType::Float32 => {
+            let ca_a = a.f32().unwrap();
+            let ca_b = b.f32().unwrap();
+            Series::new(name, &[polars_core::functions::cov_f(ca_a, ca_b)])
+        }
+        DataType::Float64 => {
+            let ca_a = a.f64().unwrap();
+            let ca_b = b.f64().unwrap();
+            Series::new(name, &[polars_core::functions::cov_f(ca_a, ca_b)])
+        }
+        DataType::Int32 => {
+            let ca_a = a.i32().unwrap();
+            let ca_b = b.i32().unwrap();
+            Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
+        }
+        DataType::Int64 => {
+            let ca_a = a.i64().unwrap();
+            let ca_b = b.i64().unwrap();
+            Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
+        }
+        DataType::UInt32 => {
+            let ca_a = a.u32().unwrap();
+            let ca_b = b.u32().unwrap();
+            Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
+        }
+        DataType::UInt64 => {
+            let ca_a = a.u64().unwrap();
+            let ca_b = b.u64().unwrap();
+            Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
+        }
+        _ => {
+            let a = a.cast(&DataType::Float64)?;
+            let b = b.cast(&DataType::Float64)?;
+            let ca_a = a.f64().unwrap();
+            let ca_b = b.f64().unwrap();
+            Series::new(name, &[polars_core::functions::cov_f(ca_a, ca_b)])
+        }
+    };
+    Ok(s)
+}
+
+fn pearson_corr(s: &[Series], ddof: u8) -> PolarsResult<Series> {
+    let a = &s[0];
+    let b = &s[1];
+    let name = "pearson_corr";
+
+    let s = match a.dtype() {
+        DataType::Float32 => {
+            let ca_a = a.f32().unwrap();
+            let ca_b = b.f32().unwrap();
+            Series::new(
+                name,
+                &[polars_core::functions::pearson_corr_f(ca_a, ca_b, ddof)],
+            )
+        }
+        DataType::Float64 => {
+            let ca_a = a.f64().unwrap();
+            let ca_b = b.f64().unwrap();
+            Series::new(
+                name,
+                &[polars_core::functions::pearson_corr_f(ca_a, ca_b, ddof)],
+            )
+        }
+        DataType::Int32 => {
+            let ca_a = a.i32().unwrap();
+            let ca_b = b.i32().unwrap();
+            Series::new(
+                name,
+                &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
+            )
+        }
+        DataType::Int64 => {
+            let ca_a = a.i64().unwrap();
+            let ca_b = b.i64().unwrap();
+            Series::new(
+                name,
+                &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
+            )
+        }
+        DataType::UInt32 => {
+            let ca_a = a.u32().unwrap();
+            let ca_b = b.u32().unwrap();
+            Series::new(
+                name,
+                &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
+            )
+        }
+        DataType::UInt64 => {
+            let ca_a = a.u64().unwrap();
+            let ca_b = b.u64().unwrap();
+            Series::new(
+                name,
+                &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
+            )
+        }
+        _ => {
+            let a = a.cast(&DataType::Float64)?;
+            let b = b.cast(&DataType::Float64)?;
+            let ca_a = a.f64().unwrap();
+            let ca_b = b.f64().unwrap();
+            Series::new(
+                name,
+                &[polars_core::functions::pearson_corr_f(ca_a, ca_b, ddof)],
+            )
+        }
+    };
+    Ok(s)
+}
+
+#[cfg(all(feature = "rank", feature = "propagate_nans"))]
+fn spearman_rank_corr(s: &[Series], ddof: u8, propagate_nans: bool) -> PolarsResult<Series> {
+    use polars_core::utils::coalesce_nulls_series;
+    use polars_ops::chunked_array::nan_propagating_aggregate::nan_max_s;
+    let a = &s[0];
+    let b = &s[1];
+
+    let (a, b) = coalesce_nulls_series(a, b);
+
+    let name = "spearman_rank_correlation";
+    if propagate_nans && a.dtype().is_float() {
+        for s in [&a, &b] {
+            if nan_max_s(s, "")
+                .get(0)
+                .unwrap()
+                .extract::<f64>()
+                .unwrap()
+                .is_nan()
+            {
+                return Ok(Series::new(name, &[f64::NAN]));
+            }
+        }
+    }
+
+    // drop nulls so that they are excluded
+    let a = a.drop_nulls();
+    let b = b.drop_nulls();
+
+    let a_idx = a.rank(
+        RankOptions {
+            method: RankMethod::Min,
+            ..Default::default()
+        },
+        None,
+    );
+    let b_idx = b.rank(
+        RankOptions {
+            method: RankMethod::Min,
+            ..Default::default()
+        },
+        None,
+    );
+    let a_idx = a_idx.idx().unwrap();
+    let b_idx = b_idx.idx().unwrap();
+
+    Ok(Series::new(
+        name,
+        &[polars_core::functions::pearson_corr_i(a_idx, b_idx, ddof)],
+    ))
+}

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -12,6 +12,7 @@ mod cat;
 #[cfg(feature = "round_series")]
 mod clip;
 mod concat;
+mod correlation;
 mod cum;
 #[cfg(feature = "temporal")]
 mod datetime;
@@ -51,6 +52,7 @@ use std::fmt::{Display, Formatter};
 
 #[cfg(feature = "dtype-array")]
 pub(super) use array::ArrayFunction;
+pub(crate) use correlation::CorrelationMethod;
 #[cfg(feature = "fused")]
 pub(crate) use fused::FusedOperator;
 pub(super) use list::ListFunction;
@@ -180,6 +182,10 @@ pub enum FunctionExpr {
     #[cfg(feature = "fused")]
     Fused(fused::FusedOperator),
     ConcatExpr(bool),
+    Correlation {
+        method: correlation::CorrelationMethod,
+        ddof: u8,
+    },
 }
 
 impl Display for FunctionExpr {
@@ -271,6 +277,7 @@ impl Display for FunctionExpr {
             #[cfg(feature = "dtype-array")]
             ArrayExpr(af) => return Display::fmt(af, f),
             ConcatExpr(_) => "concat_expr",
+            Correlation { method, .. } => return Display::fmt(method, f),
         };
         write!(f, "{s}")
     }
@@ -488,6 +495,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "fused")]
             Fused(op) => map_as_slice!(fused::fused, op),
             ConcatExpr(rechunk) => map_as_slice!(concat::concat_expr, rechunk),
+            Correlation { method, ddof } => map_as_slice!(correlation::corr, ddof, method),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -201,6 +201,7 @@ impl FunctionExpr {
             #[cfg(feature = "fused")]
             Fused(_) => mapper.map_to_supertype(),
             ConcatExpr(_) => mapper.map_to_supertype(),
+            Correlation { .. } => mapper.map_to_float_dtype(),
         }
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/functions/correlation.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions/correlation.rs
@@ -2,151 +2,44 @@ use super::*;
 
 /// Compute the covariance between two columns.
 pub fn cov(a: Expr, b: Expr) -> Expr {
-    let name = "cov";
-    let function = move |a: Series, b: Series| {
-        let s = match a.dtype() {
-            DataType::Float32 => {
-                let ca_a = a.f32().unwrap();
-                let ca_b = b.f32().unwrap();
-                Series::new(name, &[polars_core::functions::cov_f(ca_a, ca_b)])
-            }
-            DataType::Float64 => {
-                let ca_a = a.f64().unwrap();
-                let ca_b = b.f64().unwrap();
-                Series::new(name, &[polars_core::functions::cov_f(ca_a, ca_b)])
-            }
-            DataType::Int32 => {
-                let ca_a = a.i32().unwrap();
-                let ca_b = b.i32().unwrap();
-                Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
-            }
-            DataType::Int64 => {
-                let ca_a = a.i64().unwrap();
-                let ca_b = b.i64().unwrap();
-                Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
-            }
-            DataType::UInt32 => {
-                let ca_a = a.u32().unwrap();
-                let ca_b = b.u32().unwrap();
-                Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
-            }
-            DataType::UInt64 => {
-                let ca_a = a.u64().unwrap();
-                let ca_b = b.u64().unwrap();
-                Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
-            }
-            _ => {
-                let a = a.cast(&DataType::Float64)?;
-                let b = b.cast(&DataType::Float64)?;
-                let ca_a = a.f64().unwrap();
-                let ca_b = b.f64().unwrap();
-                Series::new(name, &[polars_core::functions::cov_f(ca_a, ca_b)])
-            }
-        };
-        Ok(Some(s))
+    let input = vec![a, b];
+    let function = FunctionExpr::Correlation {
+        method: CorrelationMethod::Covariance,
+        ddof: 0,
     };
-    apply_binary(
-        a,
-        b,
+    Expr::Function {
+        input,
         function,
-        GetOutput::map_dtype(|dt| {
-            if matches!(dt, DataType::Float32) {
-                DataType::Float32
-            } else {
-                DataType::Float64
-            }
-        }),
-    )
-    .with_function_options(|mut options| {
-        options.auto_explode = true;
-        options.fmt_str = "cov";
-        options
-    })
+        options: FunctionOptions {
+            collect_groups: ApplyOptions::ApplyGroups,
+            cast_to_supertypes: true,
+            auto_explode: true,
+            ..Default::default()
+        },
+    }
 }
 
 /// Compute the pearson correlation between two columns.
+///
+/// # Arguments
+/// * ddof
+///     Delta degrees of freedom
 pub fn pearson_corr(a: Expr, b: Expr, ddof: u8) -> Expr {
-    let name = "pearson_corr";
-    let function = move |a: Series, b: Series| {
-        let s = match a.dtype() {
-            DataType::Float32 => {
-                let ca_a = a.f32().unwrap();
-                let ca_b = b.f32().unwrap();
-                Series::new(
-                    name,
-                    &[polars_core::functions::pearson_corr_f(ca_a, ca_b, ddof)],
-                )
-            }
-            DataType::Float64 => {
-                let ca_a = a.f64().unwrap();
-                let ca_b = b.f64().unwrap();
-                Series::new(
-                    name,
-                    &[polars_core::functions::pearson_corr_f(ca_a, ca_b, ddof)],
-                )
-            }
-            DataType::Int32 => {
-                let ca_a = a.i32().unwrap();
-                let ca_b = b.i32().unwrap();
-                Series::new(
-                    name,
-                    &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
-                )
-            }
-            DataType::Int64 => {
-                let ca_a = a.i64().unwrap();
-                let ca_b = b.i64().unwrap();
-                Series::new(
-                    name,
-                    &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
-                )
-            }
-            DataType::UInt32 => {
-                let ca_a = a.u32().unwrap();
-                let ca_b = b.u32().unwrap();
-                Series::new(
-                    name,
-                    &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
-                )
-            }
-            DataType::UInt64 => {
-                let ca_a = a.u64().unwrap();
-                let ca_b = b.u64().unwrap();
-                Series::new(
-                    name,
-                    &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
-                )
-            }
-            _ => {
-                let a = a.cast(&DataType::Float64)?;
-                let b = b.cast(&DataType::Float64)?;
-                let ca_a = a.f64().unwrap();
-                let ca_b = b.f64().unwrap();
-                Series::new(
-                    name,
-                    &[polars_core::functions::pearson_corr_f(ca_a, ca_b, ddof)],
-                )
-            }
-        };
-        Ok(Some(s))
+    let input = vec![a, b];
+    let function = FunctionExpr::Correlation {
+        method: CorrelationMethod::Pearson,
+        ddof,
     };
-    apply_binary(
-        a,
-        b,
+    Expr::Function {
+        input,
         function,
-        GetOutput::map_dtype(|dt| {
-            if matches!(dt, DataType::Float32) {
-                DataType::Float32
-            } else {
-                DataType::Float64
-            }
-        }),
-    )
-    .with_function_options(|mut options| {
-        options.auto_explode = true;
-        options.fmt_str = "pearson_corr";
-        options
-    })
+        options: FunctionOptions {
+            collect_groups: ApplyOptions::ApplyGroups,
+            cast_to_supertypes: true,
+            auto_explode: true,
+            ..Default::default()
+        },
+    }
 }
 
 /// Compute the spearman rank correlation between two columns.
@@ -160,61 +53,21 @@ pub fn pearson_corr(a: Expr, b: Expr, ddof: u8) -> Expr {
 ///     and thus lead to the highest rank.
 #[cfg(all(feature = "rank", feature = "propagate_nans"))]
 pub fn spearman_rank_corr(a: Expr, b: Expr, ddof: u8, propagate_nans: bool) -> Expr {
-    use polars_core::utils::coalesce_nulls_series;
-    use polars_ops::prelude::nan_propagating_aggregate::nan_max_s;
-
-    let function = move |a: Series, b: Series| {
-        let (a, b) = coalesce_nulls_series(&a, &b);
-
-        let name = "spearman_rank_correlation";
-        if propagate_nans && a.dtype().is_float() {
-            for s in [&a, &b] {
-                if nan_max_s(s, "")
-                    .get(0)
-                    .unwrap()
-                    .extract::<f64>()
-                    .unwrap()
-                    .is_nan()
-                {
-                    return Ok(Some(Series::new(name, &[f64::NAN])));
-                }
-            }
-        }
-
-        // drop nulls so that they are excluded
-        let a = a.drop_nulls();
-        let b = b.drop_nulls();
-
-        let a_idx = a.rank(
-            RankOptions {
-                method: RankMethod::Min,
-                ..Default::default()
-            },
-            None,
-        );
-        let b_idx = b.rank(
-            RankOptions {
-                method: RankMethod::Min,
-                ..Default::default()
-            },
-            None,
-        );
-        let a_idx = a_idx.idx().unwrap();
-        let b_idx = b_idx.idx().unwrap();
-
-        Ok(Some(Series::new(
-            name,
-            &[polars_core::functions::pearson_corr_i(a_idx, b_idx, ddof)],
-        )))
+    let input = vec![a, b];
+    let function = FunctionExpr::Correlation {
+        method: CorrelationMethod::SpearmanRank(propagate_nans),
+        ddof,
     };
-
-    apply_binary(a, b, function, GetOutput::from_type(DataType::Float64)).with_function_options(
-        |mut options| {
-            options.auto_explode = true;
-            options.fmt_str = "spearman_rank_correlation";
-            options
+    Expr::Function {
+        input,
+        function,
+        options: FunctionOptions {
+            collect_groups: ApplyOptions::ApplyGroups,
+            cast_to_supertypes: true,
+            auto_explode: true,
+            ..Default::default()
         },
-    )
+    }
 }
 
 #[cfg(feature = "rolling_window")]

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -103,3 +103,9 @@ def test_median_quantile_duration() -> None:
     assert df.select(pl.col("A").quantile(0.5, interpolation="linear")).to_dict(
         False
     ) == {"A": [timedelta(seconds=43200)]}
+
+
+def test_correlation_cast_supertype() -> None:
+    df = pl.DataFrame({"a": [1, 8, 3], "b": [4.0, 5.0, 2.0]})
+    df = df.with_columns(pl.col("b"))
+    assert df.select(pl.corr("a", "b")).to_dict(False) == {"a": [0.5447047794019223]}


### PR DESCRIPTION
Makes them serializable and ensures they are cast to supertypes.

closes #9255