### PR TITLE
fix(python): match missing Array and Struct classes in FromPyObject

### DIFF
--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -384,12 +384,14 @@ impl FromPyObject<'_> for Wrap<DataType> {
                     "Float64" => DataType::Float64,
                     #[cfg(feature = "object")]
                     "Object" => DataType::Object(OBJECT_NAME),
+                    "Array" => DataType::Array(Box::new(DataType::Null), 0),
                     "List" => DataType::List(Box::new(DataType::Null)),
+                    "Struct" => DataType::Struct(vec![]),
                     "Null" => DataType::Null,
                     "Unknown" => DataType::Unknown,
                     dt => {
                         return Err(PyValueError::new_err(format!(
-                            "{dt} is not a correct polars DataType.",
+                            "{dt} is not a recognised polars DataType.",
                         )))
                     }
                 }
@@ -434,7 +436,7 @@ impl FromPyObject<'_> for Wrap<DataType> {
             }
             dt => {
                 return Err(PyTypeError::new_err(format!(
-                    "A {dt} object is not a correct polars DataType. \
+                    "A {dt} object is not a recognised polars DataType. \
                     Hint: use the class without instantiating it.",
                 )))
             }


### PR DESCRIPTION
Consistency: if given uninstantiated `Array` or `Struct` "DataTypeClass", match them with an empty/default of the same (as we already do with `List` and `Object`). Marginal utility, but better than an error :)