### PR TITLE
perf(rust, python) Improve rolling min and max for nonulls

### DIFF
--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
@@ -96,7 +96,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNoNulls<'a, T> fo
             (None, None) => {}
         }
 
-        return self.min;
+        self.min;
     }
 }
 
@@ -176,7 +176,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNoNulls<'a, T> fo
             (None, None) => {}
         }
 
-        return self.max;
+        self.max;
     }
 }
 

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
@@ -96,7 +96,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNoNulls<'a, T> fo
             (None, None) => {}
         }
 
-        self.min;
+        self.min
     }
 }
 
@@ -176,7 +176,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNoNulls<'a, T> fo
             (None, None) => {}
         }
 
-        self.max;
+        self.max
     }
 }
 


### PR DESCRIPTION
This PR speeds up rolling min and max for the case when there are no nulls. It also makes the code clearer and more concise (in my opinion anyway). I've verified that it produces the same results and is faster on some sample data.

The data was generated as
```python
np.random.seed(100)
ds = pl.date_range(datetime(2013, 1, 1), datetime(2023, 1, 1), '1h', eager = True)
vs = pl.Series(np.random.standard_normal(200 * len(ds)))
xs = pl.Series(np.random.randint(0, 50, len(ds)).repeat(200))

dat = pl.DataFrame(dict(d = ds.to_numpy().repeat(200), v = vs, x = xs))
dat = dat.set_sorted('d')
```
The test was plain rolling windows of lengths 5 and 7500 on each of the two series, as well as a groupby_dynamic that computed the max and min for each over every window with the listed `every` and `period` parameters.

Timings for 100 repetitions (in seconds). New is first, current is second:
```
(x, 5, min): 8.73, 13.35
(x, 5, max): 6.55, 12.77
(x, 7500, min): 8.90, 15.07
(x, 7500, max): 7.35, 15.73
(v, 5, min): 18.66, 27.17
(v, 5, max): 23.29, 27.42
(v, 7500, min): 18.39, 22.17
(v, 7500, max): 18.06, 22.13
(every = 1h, period = 2h): 15.27, 19.15
(every = 1d, period = 5d): 18.85, 25.66
(every = 1h, period = 5d): 128.04, 192.90
```
