### PR TITLE
Fix type in Selectors documentation

### DIFF
--- a/py-polars/docs/source/reference/selectors.rst
+++ b/py-polars/docs/source/reference/selectors.rst
@@ -29,7 +29,7 @@ Importing
               "z": ["a", "b", "a", "b", "b"],
           },
       )
-      df.groupby(by=cs.string()).agg(s.numeric().sum())
+      df.groupby(by=cs.string()).agg(cs.numeric().sum())
 
 Set operations
 --------------


### PR DESCRIPTION
Fix typo, `s.` -> `cs.`