### PR TITLE
feat(python): allow use of `StringCache` object as a function decorator

### DIFF
--- a/polars/polars-core/src/frame/row/av_buffer.rs
+++ b/polars/polars-core/src/frame/row/av_buffer.rs
@@ -293,7 +293,7 @@ impl From<(&DataType, usize)> for AnyValueBuffer<'_> {
     }
 }
 
-/// An `AnyValyeBuffer` that should be used when we trust the builder
+/// An `AnyValueBuffer` that should be used when we trust the builder
 #[derive(Clone)]
 pub enum AnyValueBufferTrusted<'a> {
     Boolean(BooleanChunkedBuilder),

--- a/polars/tests/it/core/rolling_window.rs
+++ b/polars/tests/it/core/rolling_window.rs
@@ -269,7 +269,7 @@ fn test_rolling_var() {
         .unwrap();
     let out = out.f64().unwrap().to_vec();
 
-    let expres = &[
+    let exp_res = &[
         None,
         Some(17.333333333333332),
         Some(11.583333333333334),
@@ -277,15 +277,15 @@ fn test_rolling_var() {
         Some(24.666666666666668),
         Some(34.33333333333334),
     ];
-    let testres = out.iter().zip(expres.iter()).all(|(&a, &b)| match (a, b) {
+    let test_res = out.iter().zip(exp_res.iter()).all(|(&a, &b)| match (a, b) {
         (None, None) => true,
         (Some(a), Some(b)) => (a - b).abs() < 1e-12,
         (_, _) => false,
     });
     assert!(
-        testres,
+        test_res,
         "{:?} is not approximately equal to {:?}",
-        out, expres
+        out, exp_res
     );
 }
 

--- a/py-polars/docs/source/reference/functions.rst
+++ b/py-polars/docs/source/reference/functions.rst
@@ -45,8 +45,13 @@ Parallelization
 
 StringCache
 ~~~~~~~~~~~
+
+Note that the `StringCache` can be used as both a context manager
+and a decorator, in order to explicitly scope cache lifetime.
+
 .. autosummary::
    :toctree: api/
 
-    enable_string_cache
     StringCache
+    enable_string_cache
+    using_string_cache

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -504,7 +504,19 @@ class ExprStringNameSpace:
 
         Examples
         --------
-        >>> df = pl.DataFrame({"foo": [" hello ", "\tworld"]})
+        >>> df = pl.DataFrame({"foo": [" hello", "\nworld"]})
+        >>> df
+        shape: (2, 1)
+        ┌────────┐
+        │ foo    │
+        │ ---    │
+        │ str    │
+        ╞════════╡
+        │  hello │
+        │        │
+        │ world  │
+        └────────┘
+
         >>> df.select(pl.col("foo").str.strip())
         shape: (2, 1)
         ┌───────┐
@@ -517,18 +529,19 @@ class ExprStringNameSpace:
         └───────┘
 
         Characters can be stripped by passing a string as argument. Note that whitespace
-        will not be stripped automatically when doing so.
+        will not be stripped automatically when doing so, unless that whitespace is
+        also included in the string.
 
-        >>> df.select(pl.col("foo").str.strip("od\t"))
+        >>> df.select(pl.col("foo").str.strip("ow\n"))
         shape: (2, 1)
-        ┌─────────┐
-        │ foo     │
-        │ ---     │
-        │ str     │
-        ╞═════════╡
-        │  hello  │
-        │ worl    │
-        └─────────┘
+        ┌───────┐
+        │ foo   │
+        │ ---   │
+        │ str   │
+        ╞═══════╡
+        │  hell │
+        │ rld   │
+        └───────┘
 
         """
         return wrap_expr(self._pyexpr.str_strip(characters))
@@ -588,7 +601,18 @@ class ExprStringNameSpace:
 
         Examples
         --------
-        >>> df = pl.DataFrame({"foo": [" hello ", "world\t"]})
+        >>> df = pl.DataFrame({"foo": [" hello", "world\n"]})
+        >>> df
+        shape: (2, 1)
+        ┌────────┐
+        │ foo    │
+        │ ---    │
+        │ str    │
+        ╞════════╡
+        │  hello │
+        │ world  │
+        │        │
+        └────────┘
         >>> df.select(pl.col("foo").str.rstrip())
         shape: (2, 1)
         ┌────────┐
@@ -601,18 +625,20 @@ class ExprStringNameSpace:
         └────────┘
 
         Characters can be stripped by passing a string as argument. Note that whitespace
-        will not be stripped automatically when doing so.
+        will not be stripped automatically when doing so, unless that whitespace is
+        also included in the string.
 
-        >>> df.select(pl.col("foo").str.rstrip("wod\t"))
+        >>> df.select(pl.col("foo").str.rstrip("oldw "))
         shape: (2, 1)
-        ┌─────────┐
-        │ foo     │
-        │ ---     │
-        │ str     │
-        ╞═════════╡
-        │  hello  │
-        │ worl    │
-        └─────────┘
+        ┌───────┐
+        │ foo   │
+        │ ---   │
+        │ str   │
+        ╞═══════╡
+        │  he   │
+        │ world │
+        │       │
+        └───────┘
 
         """
         return wrap_expr(self._pyexpr.str_rstrip(characters))

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1038,14 +1038,15 @@ class StringNameSpace:
         ]
 
         Characters can be stripped by passing a string as argument. Note that whitespace
-        will not be stripped automatically when doing so.
+        will not be stripped automatically when doing so, unless that whitespace is
+        also included in the string.
 
-        >>> s.str.strip("od\t")
+        >>> s.str.strip("o ")
         shape: (2,)
         Series: '' [str]
         [
-                " hello "
-                "worl"
+            "hell"
+            "	world"
         ]
 
         """
@@ -1110,12 +1111,12 @@ class StringNameSpace:
         Characters can be stripped by passing a string as argument. Note that whitespace
         will not be stripped automatically when doing so.
 
-        >>> s.str.rstrip("wod\t")
+        >>> s.str.rstrip("orld\t")
         shape: (2,)
         Series: '' [str]
         [
-                " hello "
-                "worl"
+            " hello "
+            "w"
         ]
 
         """

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from types import TracebackType
 
 
-class StringCache:
+class StringCache(contextlib.ContextDecorator):
     """
     Context manager that allows data sources to share the same categorical features.
 

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -7,48 +7,48 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars import StringCache
 from polars.testing import assert_frame_equal
 
 
+@StringCache()
 def test_categorical_outer_join() -> None:
-    with pl.StringCache():
-        df1 = pl.DataFrame(
-            [
-                pl.Series("key1", [42]),
-                pl.Series("key2", ["bar"], dtype=pl.Categorical),
-                pl.Series("val1", [1]),
-            ]
-        ).lazy()
+    df1 = pl.DataFrame(
+        [
+            pl.Series("key1", [42]),
+            pl.Series("key2", ["bar"], dtype=pl.Categorical),
+            pl.Series("val1", [1]),
+        ]
+    ).lazy()
 
-        df2 = pl.DataFrame(
-            [
-                pl.Series("key1", [42]),
-                pl.Series("key2", ["bar"], dtype=pl.Categorical),
-                pl.Series("val2", [2]),
-            ]
-        ).lazy()
+    df2 = pl.DataFrame(
+        [
+            pl.Series("key1", [42]),
+            pl.Series("key2", ["bar"], dtype=pl.Categorical),
+            pl.Series("val2", [2]),
+        ]
+    ).lazy()
 
-        expected = pl.DataFrame(
-            {"key1": [42], "key2": ["bar"], "val1": [1], "val2": [2]},
-            schema_overrides={"key2": pl.Categorical},
-        )
+    expected = pl.DataFrame(
+        {"key1": [42], "key2": ["bar"], "val1": [1], "val2": [2]},
+        schema_overrides={"key2": pl.Categorical},
+    )
 
     out = df1.join(df2, on=["key1", "key2"], how="outer").collect()
     assert_frame_equal(out, expected)
 
-    with pl.StringCache():
-        dfa = pl.DataFrame(
-            [
-                pl.Series("key", ["foo", "bar"], dtype=pl.Categorical),
-                pl.Series("val1", [3, 1]),
-            ]
-        )
-        dfb = pl.DataFrame(
-            [
-                pl.Series("key", ["bar", "baz"], dtype=pl.Categorical),
-                pl.Series("val2", [6, 8]),
-            ]
-        )
+    dfa = pl.DataFrame(
+        [
+            pl.Series("key", ["foo", "bar"], dtype=pl.Categorical),
+            pl.Series("val1", [3, 1]),
+        ]
+    )
+    dfb = pl.DataFrame(
+        [
+            pl.Series("key", ["bar", "baz"], dtype=pl.Categorical),
+            pl.Series("val2", [6, 8]),
+        ]
+    )
 
     df = dfa.join(dfb, on="key", how="outer")
     # the cast is important to test the rev map
@@ -98,38 +98,38 @@ def test_categorical_describe_3487() -> None:
     df.describe()
 
 
+@StringCache()
 def test_categorical_is_in_list() -> None:
     # this requires type coercion to cast.
     # we should not cast within the function as this would be expensive within a groupby
     # context that would be a cast per group
-    with pl.StringCache():
-        df = pl.DataFrame(
-            {"a": [1, 2, 3, 1, 2], "b": ["a", "b", "c", "d", "e"]}
-        ).with_columns(pl.col("b").cast(pl.Categorical))
+    df = pl.DataFrame(
+        {"a": [1, 2, 3, 1, 2], "b": ["a", "b", "c", "d", "e"]}
+    ).with_columns(pl.col("b").cast(pl.Categorical))
 
-        cat_list = ("a", "b", "c")
-        assert df.filter(pl.col("b").is_in(cat_list)).to_dict(False) == {
-            "a": [1, 2, 3],
-            "b": ["a", "b", "c"],
-        }
+    cat_list = ("a", "b", "c")
+    assert df.filter(pl.col("b").is_in(cat_list)).to_dict(False) == {
+        "a": [1, 2, 3],
+        "b": ["a", "b", "c"],
+    }
 
 
+@StringCache()
 def test_unset_sorted_on_append() -> None:
-    with pl.StringCache():
-        df1 = pl.DataFrame(
-            [
-                pl.Series("key", ["a", "b", "a", "b"], dtype=pl.Categorical),
-                pl.Series("val", [1, 2, 3, 4]),
-            ]
-        ).sort("key")
-        df2 = pl.DataFrame(
-            [
-                pl.Series("key", ["a", "b", "a", "b"], dtype=pl.Categorical),
-                pl.Series("val", [5, 6, 7, 8]),
-            ]
-        ).sort("key")
-        df = pl.concat([df1, df2], rechunk=False)
-        assert df.groupby("key").count()["count"].to_list() == [4, 4]
+    df1 = pl.DataFrame(
+        [
+            pl.Series("key", ["a", "b", "a", "b"], dtype=pl.Categorical),
+            pl.Series("val", [1, 2, 3, 4]),
+        ]
+    ).sort("key")
+    df2 = pl.DataFrame(
+        [
+            pl.Series("key", ["a", "b", "a", "b"], dtype=pl.Categorical),
+            pl.Series("val", [5, 6, 7, 8]),
+        ]
+    ).sort("key")
+    df = pl.concat([df1, df2], rechunk=False)
+    assert df.groupby("key").count()["count"].to_list() == [4, 4]
 
 
 def test_categorical_error_on_local_cmp() -> None:
@@ -165,24 +165,24 @@ def test_shift_and_fill() -> None:
     assert s.to_list() == ["c", "a"]
 
 
+@StringCache()
 def test_merge_lit_under_global_cache_4491() -> None:
-    with pl.StringCache():
-        df = pl.DataFrame(
-            [
-                pl.Series("label", ["foo", "bar"], dtype=pl.Categorical),
-                pl.Series("value", [3, 9]),
-            ]
-        )
-        assert df.with_columns(
-            pl.when(pl.col("value") > 5)
-            .then(pl.col("label"))
-            .otherwise(pl.lit(None, pl.Categorical))
-        ).to_dict(False) == {"label": [None, "bar"], "value": [3, 9]}
+    df = pl.DataFrame(
+        [
+            pl.Series("label", ["foo", "bar"], dtype=pl.Categorical),
+            pl.Series("value", [3, 9]),
+        ]
+    )
+    assert df.with_columns(
+        pl.when(pl.col("value") > 5)
+        .then(pl.col("label"))
+        .otherwise(pl.lit(None, pl.Categorical))
+    ).to_dict(False) == {"label": [None, "bar"], "value": [3, 9]}
 
 
 def test_nested_cache_composition() -> None:
     # very artificial example/test, but validates the behaviour
-    # of  ested StringCache scopes, which we want to play well
+    # of nested StringCache scopes, which we want to play well
     # with each other when composing more complex pipelines.
 
     assert pl.using_string_cache() is False
@@ -190,7 +190,7 @@ def test_nested_cache_composition() -> None:
     # function representing a composable stage of a pipeline; it implements
     # an inner scope for the case where it is called by itself, but when
     # called as part of a larger series of ops it should not invalidate
-    # the string cache (the outermost scope should be respected).
+    # the string cache (eg: the outermost scope should be respected).
     def create_lazy(data: dict) -> pl.LazyFrame:  # type: ignore[type-arg]
         with pl.StringCache():
             df = pl.DataFrame({"a": ["foo", "bar", "ham"], "b": [1, 2, 3]})
@@ -251,7 +251,7 @@ def test_cast_inner_categorical() -> None:
 def test_stringcache() -> None:
     N = 1_500
     with pl.StringCache():
-        # create a reasonable sized columns so the categorical map is reallocated
+        # create a large enough column that the categorical map is reallocated
         df = pl.DataFrame({"cats": pl.arange(0, N, eager=True)}).select(
             [pl.col("cats").cast(pl.Utf8).cast(pl.Categorical)]
         )
@@ -260,17 +260,17 @@ def test_stringcache() -> None:
         }
 
 
+@StringCache()
 def test_categorical_sort_order(monkeypatch: Any) -> None:
-    with pl.StringCache():
-        # create the categorical ordering first
-        pl.Series(["foo", "bar", "baz"], dtype=pl.Categorical)
-        df = pl.DataFrame(
-            {
-                "n": [0, 0, 0],
-                # use same categories in different order
-                "x": pl.Series(["baz", "bar", "foo"], dtype=pl.Categorical),
-            }
-        )
+    # create the categorical ordering first
+    pl.Series(["foo", "bar", "baz"], dtype=pl.Categorical)
+    df = pl.DataFrame(
+        {
+            "n": [0, 0, 0],
+            # use same categories in different order
+            "x": pl.Series(["baz", "bar", "foo"], dtype=pl.Categorical),
+        }
+    )
 
     assert df.sort(["n", "x"])["x"].to_list() == ["foo", "bar", "baz"]
     assert df.with_columns(pl.col("x").cat.set_ordering("lexical")).sort(["n", "x"])[
@@ -371,13 +371,13 @@ def test_categorical_fill_null_existing_category() -> None:
     }
 
 
+@StringCache()
 def test_categorical_fill_null_stringcache() -> None:
-    with pl.StringCache():
-        df = pl.LazyFrame(
-            {"index": [1, 2, 3], "cat": ["a", "b", None]},
-            schema={"index": pl.Int64(), "cat": pl.Categorical()},
-        )
-        a = df.select(pl.col("cat").fill_null("hi")).collect()
+    df = pl.LazyFrame(
+        {"index": [1, 2, 3], "cat": ["a", "b", None]},
+        schema={"index": pl.Int64(), "cat": pl.Categorical()},
+    )
+    a = df.select(pl.col("cat").fill_null("hi")).collect()
 
     assert a.to_dict(False) == {"cat": ["a", "b", "hi"]}
     assert a.dtypes == [pl.Categorical]

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -138,8 +138,8 @@ def test_parquet_datetime(compression: ParquetCompression, use_pyarrow: bool) ->
             1618354620000,
             1618354560000,
         ],
-        "laf_max": [73.1999969482, 71.0999984741, 74.5, 69.5999984741, 69.6999969482],
-        "laf_eq": [59.5999984741, 61.0, 62.2999992371, 56.9000015259, 60.0],
+        "value1": [73.1999969482, 71.0999984741, 74.5, 69.5999984741, 69.6999969482],
+        "value2": [59.5999984741, 61.0, 62.2999992371, 56.9000015259, 60.0],
     }
     df = pl.DataFrame(data)
     df = df.with_columns(df["datetime"].cast(pl.Datetime))

--- a/py-polars/tests/unit/namespaces/test_string.py
+++ b/py-polars/tests/unit/namespaces/test_string.py
@@ -189,8 +189,8 @@ def test_str_strip() -> None:
     expected = pl.Series(["hello", "world"])
     assert_series_equal(s.str.strip(), expected)
 
-    expected = pl.Series(["hello", "worl"])
-    assert_series_equal(s.str.strip().str.strip("d"), expected)
+    expected = pl.Series(["hell", "world"])
+    assert_series_equal(s.str.strip().str.strip("o"), expected)
 
     expected = pl.Series(["ell", "rld\t"])
     assert_series_equal(s.str.strip(" hwo"), expected)

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1574,7 +1574,7 @@ def test_to_html() -> None:
 
 def test_rename(df: pl.DataFrame) -> None:
     out = df.rename({"strings": "bars", "int": "foos"})
-    # check if wel can select these new columns
+    # check if we can select these new columns
     _ = out[["foos", "bars"]]
 
 


### PR DESCRIPTION
Ref: #9307. 

The same trick (upgrading our context manager to do double-duty as a decorator) works nicely here too...

```python
import polars as pl

@pl.StringCache()
def lets_get_schwifty() -> pl.DataFrame:
    df1 = pl.LazyFrame([
        pl.Series("key", ["bar"], dtype=pl.Categorical),
        pl.Series("val", [1]),
    ])
    df2 = pl.LazyFrame([
        pl.Series("key", ["bar"], dtype=pl.Categorical),
        pl.Series("val", [2]),
    ])
    return df1.join(df2, on=["key"], how="outer").collect()

print( lets_get_schwifty() )
# shape: (1, 3)
# ┌─────┬─────┬───────────┐
# │ key ┆ val ┆ val_right │
# │ --- ┆ --- ┆ ---       │
# │ cat ┆ i64 ┆ i64       │
# ╞═════╪═════╪═══════════╡
# │ bar ┆ 1   ┆ 2         │
# └─────┴─────┴───────────┘
```