### PR TITLE
ci(python,rust): bump "typos" package to match what's currently running on CI

### DIFF
--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -2,4 +2,4 @@ black==23.3.0
 blackdoc==0.3.8
 mypy==1.3.0
 ruff==0.0.270
-typos==1.14.11
+typos==1.15


### PR DESCRIPTION
Match package requirements to the `typos` version now running in our CI action (upgraded itself last night).