### PR TITLE
perf(rust, python): increase streaming groupby spill size from 256 to 10_000

### DIFF
--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/thread_local.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/thread_local.rs
@@ -258,7 +258,7 @@ impl ThreadLocalTable {
                 agg_constructors,
                 key_dtypes.as_ref(),
                 output_schema,
-                Some(256),
+                Some(10_000),
             ),
             spill_partitions,
         }


### PR DESCRIPTION
This is ~30% faster on ~10K cardinality and 2% slower on extreme cardinalities. So optimizes for the default cases.

And there is still much to improve ones we spill.