### PR TITLE
docs(python): fixup options for `validate` arg in `join`

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1682,7 +1682,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "ahash",
  "built",

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -138,6 +138,7 @@ if TYPE_CHECKING:
         IntoExpr,
         IpcCompression,
         JoinStrategy,
+        JoinValidation,
         NullStrategy,
         OneOrMoreDataTypes,
         Orientation,
@@ -5475,7 +5476,7 @@ class DataFrame:
         left_on: str | Expr | Sequence[str | Expr] | None = None,
         right_on: str | Expr | Sequence[str | Expr] | None = None,
         suffix: str = "_right",
-        validate: str = "m:m",
+        validate: JoinValidation = "m:m",
     ) -> DataFrame:
         """
         Join in SQL-like fashion.
@@ -5494,7 +5495,7 @@ class DataFrame:
             Name(s) of the right join column(s).
         suffix
             Suffix to append to columns with a duplicate name.
-        validate: {'m:m', 'm:1', '1:m', 'm:m'}
+        validate: {'m:m', 'm:1', '1:m', '1:1'}
             Checks if join is of specified type.
 
                 * *many_to_many*

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
         FrameInitTypes,
         IntoExpr,
         JoinStrategy,
+        JoinValidation,
         Orientation,
         ParallelStrategy,
         PolarsDataType,
@@ -2811,7 +2812,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         left_on: str | Expr | Sequence[str | Expr] | None = None,
         right_on: str | Expr | Sequence[str | Expr] | None = None,
         suffix: str = "_right",
-        validate: str = "m:m",
+        validate: JoinValidation = "m:m",
         allow_parallel: bool = True,
         force_parallel: bool = False,
     ) -> Self:
@@ -2833,7 +2834,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Join column of the right DataFrame.
         suffix
             Suffix to append to columns with a duplicate name.
-        validate: {'m:m', 'm:1', '1:m', 'm:m'}
+        validate: {'m:m', 'm:1', '1:m', '1:1'}
             Checks if join is of specified type.
 
                 * *many_to_many*

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -83,6 +83,7 @@ FillNullStrategy: TypeAlias = Literal[
 ]
 FloatFmt: TypeAlias = Literal["full", "mixed"]
 IpcCompression: TypeAlias = Literal["uncompressed", "lz4", "zstd"]
+JoinValidation: TypeAlias = Literal["m:m", "m:1", "1:m", "1:1"]
 NullBehavior: TypeAlias = Literal["ignore", "drop"]
 NullStrategy: TypeAlias = Literal["ignore", "propagate"]
 ParallelStrategy: TypeAlias = Literal["auto", "columns", "row_groups", "none"]


### PR DESCRIPTION
`'m:m'` was repeated

adding a type alias while I'm here