### PR TITLE
feat(python,rust): support `//` integer floordiv operator in the SQL engine

### DIFF
--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -158,6 +158,7 @@ impl SqlExprVisitor<'_> {
         Ok(match op {
             SQLBinaryOperator::And => left.and(right),
             SQLBinaryOperator::Divide => left / right,
+            SQLBinaryOperator::DuckIntegerDivide => left.floor_div(right).cast(DataType::Int64),
             SQLBinaryOperator::Eq => left.eq(right),
             SQLBinaryOperator::Gt => left.gt(right),
             SQLBinaryOperator::GtEq => left.gt_eq(right),

--- a/py-polars/tests/unit/test_sql.py
+++ b/py-polars/tests/unit/test_sql.py
@@ -48,6 +48,35 @@ def test_sql_distinct() -> None:
         c.execute("SELECT * FROM df")
 
 
+def test_sql_div() -> None:
+    df = pl.LazyFrame(
+        {
+            "a": [10.0, 20.0, 30.0, 40.0, 50.0],
+            "b": [-100.5, 7.0, 2.5, None, -3.14],
+        }
+    )
+    with pl.SQLContext(df=df, eager_execution=True) as ctx:
+        res = ctx.execute(
+            """
+            SELECT
+              a / b AS a_div_b,
+              a // b AS a_floordiv_b
+            FROM df
+            """
+        )
+
+    assert_frame_equal(
+        pl.DataFrame(
+            [
+                [-0.0995024875621891, 2.85714285714286, 12.0, None, -15.92356687898089],
+                [-1, 2, 12, None, -16],
+            ],
+            schema=["a_div_b", "a_floordiv_b"],
+        ),
+        res,
+    )
+
+
 def test_sql_groupby(foods_ipc_path: Path) -> None:
     lf = pl.scan_ipc(foods_ipc_path)
 


### PR DESCRIPTION
DuckDB introduced a nice `//` integer division operator for SQL recently (in their 0.8.0 release) and it's proving a popular addition. A little digging showed that `sqlparser-rs` added support for it last month (see: https://github.com/sqlparser-rs/sqlparser-rs/issues/873), so I've integrated it on our side too:

```python
import polars as pl

df = pl.LazyFrame({
    "a": [ 10.0, 30.0, 50.0],
    "b": [-100.5, 7.0,  3.2],
})

with pl.SQLContext( df=df, eager_execution=True ) as ctx:
    ctx.execute( "SELECT  a / b AS a_div_b, a // b AS a_floordiv_b FROM df" )

# shape: (3, 2)
# ┌───────────┬──────────────┐
# │ a_div_b   ┆ a_floordiv_b │
# │ ---       ┆ ---          │
# │ f64       ┆ i64          │
# ╞═══════════╪══════════════╡
# │ -0.099502 ┆ -1           │
# │ 4.285714  ┆ 4            │
# │ 15.625    ┆ 15           │
# └───────────┴──────────────┘
```
Does _not_ change the existing behaviour of `/`, it just allows you to enforce integer/floordiv with the new `//`.