### PR TITLE
refactor(python): ignore deltalake subpackage typing stubs in the toml, rather than inline

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3326,7 +3326,7 @@ class DataFrame:
 
         check_if_delta_available()
 
-        from deltalake.writer import (  # type: ignore[import]
+        from deltalake.writer import (
             try_get_deltatable,
             write_deltalake,
         )
@@ -3361,7 +3361,7 @@ class DataFrame:
         data_schema = data.schema
 
         # Workaround to prevent manual casting of large types
-        table = try_get_deltatable(target, storage_options)
+        table = try_get_deltatable(target, storage_options)  # type: ignore[arg-type]
 
         if table is not None:
             table_schema = table.schema()

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -73,7 +73,7 @@ module = [
   "IPython.*",
   "backports",
   "connectorx",
-  "deltalake",
+  "deltalake.*",
   "fsspec.*",
   "matplotlib.*",
   "polars.polars",

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -5,7 +5,7 @@
 --prefer-binary
 
 # Dependencies
-deltalake >= 0.8.0
+deltalake >= 0.10.0
 numpy
 pandas
 pyarrow


### PR DESCRIPTION
Fixes some lint errors associated with latest deltalake package (0.10.0).