### PR TITLE
feat(python,rust,cli): add SQL support for regular expression operators (`~`, `!~`, `~*`, and `!~*`)

### DIFF
--- a/py-polars/tests/unit/test_sql.py
+++ b/py-polars/tests/unit/test_sql.py
@@ -265,6 +265,11 @@ def test_sql_regex_error() -> None:
             pl.ComputeError, match="Invalid pattern for '~' operator: 12345"
         ):
             ctx.execute("SELECT * FROM df WHERE sval ~ 12345")
+        with pytest.raises(
+            pl.ComputeError,
+            match=r"""Invalid pattern for '!~\*' operator: col\("abcde"\)""",
+        ):
+            ctx.execute("SELECT * FROM df WHERE sval !~* abcde")
 
 
 def test_sql_trim(foods_ipc_path: Path) -> None:


### PR DESCRIPTION
Adds SQL support for the full set of postgres posix regex operators:

_(ref: https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP)._

* `~` → contains pattern (case-sensitive)
* `~*` → contains pattern (case-INsensitive)
* `!~` → does not contain pattern (case-sensitive)
* `!~*` → does not contain pattern (case-INsensitive)

## Example
```python
import polars as pl

df = pl.LazyFrame({
    "n": [1, 2, 3, 4, 5],
    "sval": ["ABC","abc","000","A0C","a0c"],
})
ctx = pl.SQLContext(df=df, eager_execution=True )

ctx.execute( "SELECT * FROM df WHERE sval ~ '\d'" )
# shape: (3, 2)
# ┌─────┬──────┐
# │ n   ┆ sval │
# │ --- ┆ ---  │
# │ i64 ┆ str  │
# ╞═════╪══════╡
# │ 3   ┆ 000  │
# │ 4   ┆ A0C  │
# │ 5   ┆ a0c  │
# └─────┴──────┘

ctx.execute( "SELECT * FROM df WHERE sval !~* '^a0'" )
# shape: (3, 2)
# ┌─────┬──────┐
# │ n   ┆ sval │
# │ --- ┆ ---  │
# │ i64 ┆ str  │
# ╞═════╪══════╡
# │ 1   ┆ ABC  │
# │ 2   ┆ abc  │
# │ 3   ┆ 000  │
# └─────┴──────┘
```