### PR TITLE
feat(python,rust,cli): add SQL `round` support

### DIFF
--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -139,7 +139,6 @@ impl SqlExprVisitor<'_> {
             UnaryOperator::Plus => lit(0) + expr,
             UnaryOperator::Minus => lit(0) - expr,
             UnaryOperator::Not => expr.not(),
-            UnaryOperator::PGSquareRoot => expr.pow(0.5),
             other => polars_bail!(InvalidOperation: "Unary operator {:?} is not supported", other),
         })
     }

--- a/py-polars/tests/unit/test_sql.py
+++ b/py-polars/tests/unit/test_sql.py
@@ -332,7 +332,7 @@ def test_sql_round_ndigits(decimals: int, expected: list[float]) -> None:
 def test_sql_round_ndigits_errors() -> None:
     df = pl.DataFrame({"n": [99.999]})
     with pl.SQLContext(df=df, eager_execution=True) as ctx, pytest.raises(
-        pl.PolarsPanicError, match="Invalid 'decimals' for round: -1"
+        pl.PolarsPanicError, match="Invalid 'decimals' for Round: -1"
     ):
         ctx.execute("SELECT ROUND(n,-1) AS n FROM df")
 

--- a/py-polars/tests/unit/test_sql.py
+++ b/py-polars/tests/unit/test_sql.py
@@ -332,7 +332,7 @@ def test_sql_round_ndigits(decimals: int, expected: list[float]) -> None:
 def test_sql_round_ndigits_errors() -> None:
     df = pl.DataFrame({"n": [99.999]})
     with pl.SQLContext(df=df, eager_execution=True) as ctx, pytest.raises(
-        pl.PolarsPanicError, match="Invalid 'decimals' for Round: -1"
+        pl.InvalidOperationError, match="Invalid 'decimals' for Round: -1"
     ):
         ctx.execute("SELECT ROUND(n,-1) AS n FROM df")
 


### PR DESCRIPTION
Add SQL support for `ROUND` function:

```python
import polars as pl

df = pl.DataFrame( 
    {"n": [-8.499, 20.45678, 3.59901, 82.5001]} 
)
with pl.SQLContext( frame_data=df ) as ctx:
    print(
        ctx.execute("""
          SELECT 
            n,
            ROUND(n) AS n0,
            ROUND(n,1) AS n1,
            ROUND(n,2) AS n2, 
            ROUND(n,3) AS n3, 
          FROM
            frame_data
        """).collect()
    )
    
# shape: (4, 5)
# ┌──────────┬──────┬──────┬───────┬────────┐
# │ n        ┆ n0   ┆ n1   ┆ n2    ┆ n3     │
# │ ---      ┆ ---  ┆ ---  ┆ ---   ┆ ---    │
# │ f64      ┆ f64  ┆ f64  ┆ f64   ┆ f64    │
# ╞══════════╪══════╪══════╪═══════╪════════╡
# │ -8.499   ┆ -8.0 ┆ -8.5 ┆ -8.5  ┆ -8.499 │
# │ 20.45678 ┆ 20.0 ┆ 20.5 ┆ 20.46 ┆ 20.457 │
# │ 3.59901  ┆ 4.0  ┆ 3.6  ┆ 3.6   ┆ 3.599  │
# │ 82.5001  ┆ 83.0 ┆ 82.5 ┆ 82.5  ┆ 82.5   │
# └──────────┴──────┴──────┴───────┴────────┘
```