### PR TITLE
feat(python,rust,cli): add SQL support for null-aware equality checks

### DIFF
--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -75,6 +75,12 @@ impl SqlExprVisitor<'_> {
                 list,
                 negated,
             } => self.visit_is_in(expr, list, *negated),
+            SqlExpr::IsDistinctFrom(e1, e2) => {
+                Ok(self.visit_expr(e1)?.neq_missing(self.visit_expr(e2)?))
+            }
+            SqlExpr::IsNotDistinctFrom(e1, e2) => {
+                Ok(self.visit_expr(e1)?.eq_missing(self.visit_expr(e2)?))
+            }
             SqlExpr::IsFalse(expr) => Ok(self.visit_expr(expr)?.eq(lit(false))),
             SqlExpr::IsNotFalse(expr) => Ok(self.visit_expr(expr)?.eq(lit(false)).not()),
             SqlExpr::IsNotNull(expr) => Ok(self.visit_expr(expr)?.is_not_null()),
@@ -171,6 +177,7 @@ impl SqlExprVisitor<'_> {
             SQLBinaryOperator::NotEq => left.eq(right).not(),
             SQLBinaryOperator::Or => left.or(right),
             SQLBinaryOperator::Plus => left + right,
+            SQLBinaryOperator::Spaceship => left.eq_missing(right),
             SQLBinaryOperator::StringConcat => {
                 left.cast(DataType::Utf8) + right.cast(DataType::Utf8)
             }


### PR DESCRIPTION
Now that we have expressions that distinguish between null-aware/unaware comparison, we can integrate the same into our SQL support; this PR covers both the [spaceship operator](https://en.wikipedia.org/wiki/Three-way_comparison#Spaceship_operator) `<=>`, and [is [not] distinct from](https://modern-sql.com/feature/is-distinct-from) expressions.

## Example

```python
import polars as pl

df = pl.DataFrame({
    "a": [1, None, 3, 6, 5], 
    "b": [1, None, 3, 4, None],
})

with pl.SQLContext( frame_data=df ) as ctx:
    out = ctx.execute(
        """
        SELECT
          -- not null-aware
          (a = b)  as "1_eq_unaware",
          (a != b) as "2_neq_unaware",
          -- null-aware
          (a <=> b) as "3_eq_aware",
          (a IS NOT DISTINCT FROM b) as "4_eq_aware",
          (a IS DISTINCT FROM b) as "5_neq_aware",
        FROM frame_data
        """
    ).collect()

# shape: (5, 5)
# ┌──────────────┬───────────────┬────────────┬────────────┬─────────────┐
# │ 1_eq_unaware ┆ 2_neq_unaware ┆ 3_eq_aware ┆ 4_eq_aware ┆ 5_neq_aware │
# │ ---          ┆ ---           ┆ ---        ┆ ---        ┆ ---         │
# │ bool         ┆ bool          ┆ bool       ┆ bool       ┆ bool        │
# ╞══════════════╪═══════════════╪════════════╪════════════╪═════════════╡
# │ true         ┆ false         ┆ true       ┆ true       ┆ false       │
# │ null         ┆ null          ┆ true       ┆ true       ┆ false       │
# │ true         ┆ false         ┆ true       ┆ true       ┆ false       │
# │ false        ┆ true          ┆ false      ┆ false      ┆ true        │
# │ null         ┆ null          ┆ false      ┆ false      ┆ true        │
# └──────────────┴───────────────┴────────────┴────────────┴─────────────┘
```