### PR TITLE
feat(rust, python): support ternary expressions in streaming

### DIFF
--- a/polars/polars-lazy/src/physical_plan/streaming/checks.rs
+++ b/polars/polars-lazy/src/physical_plan/streaming/checks.rs
@@ -26,7 +26,10 @@ pub(super) fn is_streamable(node: Node, expr_arena: &Arena<AExpr>, context: Cont
             seen_column = true;
             true
         }
-        AExpr::BinaryExpr { .. } | AExpr::Alias(_, _) | AExpr::Cast { .. } => true,
+        AExpr::Ternary { .. }
+        | AExpr::BinaryExpr { .. }
+        | AExpr::Alias(_, _)
+        | AExpr::Cast { .. } => true,
         AExpr::Literal(lv) => match lv {
             LiteralValue::Series(_) | LiteralValue::Range { .. } => {
                 seen_lit_range = true;

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.1"
-source = "git+https://github.com/jorgecarleitao/arrow2?rev=fb5e4d591c7149df590a330365fae55d2370962f#fb5e4d591c7149df590a330365fae55d2370962f"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=f46e26cfef09f6355e22af2e13c82fb07859d29f#f46e26cfef09f6355e22af2e13c82fb07859d29f"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -331,6 +331,18 @@ def test_streaming_apply(monkeypatch: Any, capfd: Any) -> None:
     assert "df -> projection -> ordered_sink" in err
 
 
+def test_streaming_ternary() -> None:
+    q = pl.LazyFrame({"a": [1, 2, 3]})
+
+    assert (
+        q.with_columns(
+            pl.when(pl.col("a") >= 2).then(pl.col("a")).otherwise(None).alias("b"),
+        )
+        .explain(streaming=True)
+        .startswith("--- PIPELINE")
+    )
+
+
 def test_streaming_unique(monkeypatch: Any, capfd: Any) -> None:
     monkeypatch.setenv("POLARS_VERBOSE", "1")
     df = pl.DataFrame({"a": [1, 2, 2, 2], "b": [3, 4, 4, 4], "c": [5, 6, 7, 7]})


### PR DESCRIPTION
closes #9337