### PR TITLE
perf(rust, python): bytes row format for streaming groupby/unique keys `>3.5x`

### DIFF
--- a/polars/polars-core/src/hashing/vector_hasher.rs
+++ b/polars/polars-core/src/hashing/vector_hasher.rs
@@ -175,16 +175,14 @@ pub fn _hash_binary_array(arr: &BinaryArray<i64>, random_state: RandomState, buf
             None => null_h,
         }))
     }
-
 }
 
 impl VecHash for BinaryChunked {
     fn vec_hash(&self, random_state: RandomState, buf: &mut Vec<u64>) {
         buf.clear();
         buf.reserve(self.len());
-        self.downcast_iter().for_each(|arr| {
-            _hash_binary_array(arr, random_state.clone(), buf)
-        });
+        self.downcast_iter()
+            .for_each(|arr| _hash_binary_array(arr, random_state.clone(), buf));
     }
 
     fn vec_hash_combine(&self, random_state: RandomState, hashes: &mut [u64]) {

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -419,6 +419,20 @@ impl Series {
             #[cfg(feature = "dtype-categorical")]
             Categorical(_) => Cow::Owned(self.cast(&UInt32).unwrap()),
             List(inner) => Cow::Owned(self.cast(&List(Box::new(inner.to_physical()))).unwrap()),
+            #[cfg(feature = "dtype-struct")]
+            Struct(_) => {
+                let arr = self.struct_().unwrap();
+                let fields = arr
+                    .fields()
+                    .iter()
+                    .map(|s| s.to_physical_repr().into_owned())
+                    .collect::<Vec<_>>();
+                Cow::Owned(
+                    StructChunked::new(self.name(), &fields)
+                        .unwrap()
+                        .into_series(),
+                )
+            }
             _ => Cow::Borrowed(self),
         }
     }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/eval.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/eval.rs
@@ -1,21 +1,25 @@
 use std::cell::UnsafeCell;
+use polars_arrow::export::arrow::array::BinaryArray;
 
 use polars_core::export::ahash::RandomState;
+use polars_row::SortField;
 
 use super::*;
-use crate::executors::sinks::utils::hash_series;
+use crate::executors::sinks::utils::{hash_rows};
 use crate::expressions::PhysicalPipedExpr;
 
 pub(super) struct Eval {
     // the keys that will be aggregated on
-    key_columns: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
+    key_columns_expr: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
     // the columns that will be aggregated
-    aggregation_columns: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
+    aggregation_columns_expr: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
     hb: RandomState,
     // amortize allocations
     aggregation_series: UnsafeCell<Vec<Series>>,
-    keys_series: UnsafeCell<Vec<Series>>,
+    keys_columns: UnsafeCell<Vec<ArrayRef>>,
     hashes: Vec<u64>,
+    key_fields: Vec<SortField>,
+    keys_array: Option<BinaryArray<i64>>
 }
 
 impl Eval {
@@ -25,31 +29,36 @@ impl Eval {
     ) -> Self {
         let hb = RandomState::default();
         Self {
-            key_columns,
-            aggregation_columns,
+            key_columns_expr: key_columns,
+            aggregation_columns_expr: aggregation_columns,
             hb,
             aggregation_series: Default::default(),
-            keys_series: Default::default(),
+            keys_columns: Default::default(),
             hashes: Default::default(),
+            key_fields: Default::default(),
+            keys_array: None
         }
     }
     pub(super) fn split(&self) -> Self {
         Self {
-            key_columns: self.key_columns.clone(),
-            aggregation_columns: self.aggregation_columns.clone(),
+            key_columns_expr: self.key_columns_expr.clone(),
+            aggregation_columns_expr: self.aggregation_columns_expr.clone(),
             hb: self.hb.clone(),
             aggregation_series: Default::default(),
-            keys_series: Default::default(),
+            keys_columns: Default::default(),
             hashes: Default::default(),
+            key_fields: vec![Default::default(); self.key_columns_expr.len()],
+            keys_array: None
         }
     }
 
     pub(super) unsafe fn clear(&mut self) {
-        let keys_series = &mut *self.keys_series.get();
+        let keys_series = &mut *self.keys_columns.get();
         let aggregation_series = &mut *self.aggregation_series.get();
         keys_series.clear();
         aggregation_series.clear();
         self.hashes.clear();
+        self.keys_array = None;
     }
 
     pub(super) unsafe fn evaluate_keys_aggs_and_hashes(
@@ -57,28 +66,33 @@ impl Eval {
         context: &PExecutionContext,
         chunk: &DataChunk,
     ) -> PolarsResult<()> {
-        let keys_series = &mut *self.keys_series.get();
+        let keys_columns = &mut *self.keys_columns.get();
         let aggregation_series = &mut *self.aggregation_series.get();
 
-        for phys_e in self.aggregation_columns.iter() {
+        for phys_e in self.aggregation_columns_expr.iter() {
             let s = phys_e.evaluate(chunk, context.execution_state.as_any())?;
             let s = s.to_physical_repr();
             aggregation_series.push(s.rechunk());
         }
-        for phys_e in self.key_columns.iter() {
+        for phys_e in self.key_columns_expr.iter() {
             let s = phys_e.evaluate(chunk, context.execution_state.as_any())?;
-            let s = s.to_physical_repr();
-            keys_series.push(s.rechunk());
+            let s = s.to_physical_repr().rechunk();
+            keys_columns.push(s.to_arrow(0));
         }
 
+        let key_rows = polars_row::convert_columns(&keys_columns, &self.key_fields);
+        let keys_array = key_rows.into_array();
+        // drop the series, all data is in the rows encoding now
+        keys_columns.clear();
+
         // write the hashes to self.hashes buffer
-        hash_series(keys_series, &mut self.hashes, &self.hb);
+        hash_rows(&keys_array, &mut self.hashes, &self.hb);
+        self.keys_array = Some(keys_array);
         Ok(())
     }
 
-    pub(super) unsafe fn get_keys_iters(&self) -> Vec<SeriesPhysIter> {
-        let keys_series = &*self.keys_series.get();
-        keys_series.iter().map(|s| s.phys_iter()).collect()
+    pub(super) fn get_keys_iter(&self) -> &BinaryArray<i64> {
+        self.keys_array.as_ref().unwrap()
     }
     pub(super) unsafe fn get_aggs_iters(&self) -> Vec<SeriesPhysIter> {
         let aggregation_series = &*self.aggregation_series.get();

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/global.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/global.rs
@@ -131,35 +131,32 @@ impl GlobalTable {
         hash_map: &mut AggHashTable<false>,
         hashes: &[u64],
         chunk_indexes: &[IdxSize],
-        keys: &[Series],
+        keys: &BinaryArray<i64>,
         agg_cols: &[Series],
     ) {
         debug_assert_eq!(hashes.len(), chunk_indexes.len());
-        debug_assert_eq!(hashes.len(), keys[0].len());
+        debug_assert_eq!(hashes.len(), keys.len());
 
-        todo!()
         // let mut keys_iters = keys.iter().map(|s| s.phys_iter()).collect::<Vec<_>>();
-        // let mut agg_cols_iters = agg_cols.iter().map(|s| s.phys_iter()).collect::<Vec<_>>();
-        //
-        // // amortize loop counter
-        // for i in 0..hashes.len() {
-        //     unsafe {
-        //         let hash = *hashes.get_unchecked(i);
-        //         let chunk_index = *chunk_indexes.get_unchecked(i);
-        //
-        //         // safety: keys_iters and cols_iters are not depleted
-        //         let out = hash_map.insert(hash, &mut keys_iters, &mut agg_cols_iters, chunk_index);
-        //         // should never overflow
-        //         debug_assert!(out.is_none());
-        //     }
-        // }
+        let mut agg_cols_iters = agg_cols.iter().map(|s| s.phys_iter()).collect::<Vec<_>>();
+
+        // amortize loop counter
+        for (i, row) in keys.values_iter().enumerate() {
+            unsafe {
+                let hash = *hashes.get_unchecked(i);
+                let chunk_index = *chunk_indexes.get_unchecked(i);
+
+                // safety: keys_iters and cols_iters are not depleted
+                let overflow = hash_map.insert(hash, row, &mut agg_cols_iters, chunk_index);
+                // should never overflow
+                debug_assert!(!overflow);
+            }
+        }
     }
 
     pub(super) fn process_partition_from_dumped(&self, partition: usize, spilled: &DataFrame) {
         let mut hash_map = self.inner_maps[partition].lock().unwrap();
-        let (hashes, chunk_indexes, keys_and_aggs) = SpillPayload::spilled_to_columns(spilled);
-        let keys = &keys_and_aggs[..hash_map.num_keys];
-        let aggs = &keys_and_aggs[hash_map.num_keys..];
+        let (hashes, chunk_indexes, keys, aggs) = SpillPayload::spilled_to_columns(spilled);
         self.process_partition_impl(&mut hash_map, hashes, chunk_indexes, keys, aggs);
     }
 

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/global.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/global.rs
@@ -137,21 +137,22 @@ impl GlobalTable {
         debug_assert_eq!(hashes.len(), chunk_indexes.len());
         debug_assert_eq!(hashes.len(), keys[0].len());
 
-        let mut keys_iters = keys.iter().map(|s| s.phys_iter()).collect::<Vec<_>>();
-        let mut agg_cols_iters = agg_cols.iter().map(|s| s.phys_iter()).collect::<Vec<_>>();
-
-        // amortize loop counter
-        for i in 0..hashes.len() {
-            unsafe {
-                let hash = *hashes.get_unchecked(i);
-                let chunk_index = *chunk_indexes.get_unchecked(i);
-
-                // safety: keys_iters and cols_iters are not depleted
-                let out = hash_map.insert(hash, &mut keys_iters, &mut agg_cols_iters, chunk_index);
-                // should never overflow
-                debug_assert!(out.is_none());
-            }
-        }
+        todo!()
+        // let mut keys_iters = keys.iter().map(|s| s.phys_iter()).collect::<Vec<_>>();
+        // let mut agg_cols_iters = agg_cols.iter().map(|s| s.phys_iter()).collect::<Vec<_>>();
+        //
+        // // amortize loop counter
+        // for i in 0..hashes.len() {
+        //     unsafe {
+        //         let hash = *hashes.get_unchecked(i);
+        //         let chunk_index = *chunk_indexes.get_unchecked(i);
+        //
+        //         // safety: keys_iters and cols_iters are not depleted
+        //         let out = hash_map.insert(hash, &mut keys_iters, &mut agg_cols_iters, chunk_index);
+        //         // should never overflow
+        //         debug_assert!(out.is_none());
+        //     }
+        // }
     }
 
     pub(super) fn process_partition_from_dumped(&self, partition: usize, spilled: &DataFrame) {

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/hash_table.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/hash_table.rs
@@ -1,5 +1,3 @@
-use std::cell::UnsafeCell;
-
 use polars_arrow::trusted_len::PushUnchecked;
 use polars_core::hashing::partition::this_partition;
 
@@ -8,17 +6,14 @@ use crate::pipeline::PARTITION_SIZE;
 
 pub(super) struct AggHashTable<const FIXED: bool> {
     inner_map: PlIdHashMap<Key, IdxSize>,
-    keys: Vec<AnyValue<'static>>,
+    // row data of the keys
+    keys: Vec<u8>,
     // the aggregation that are in process
     // the index the hashtable points to the start of the aggregations of that key/group
     running_aggregations: Vec<AggregateFunction>,
     // n aggregation function constructors
     // The are used to create new running aggregators
     agg_constructors: Arc<[AggregateFunction]>,
-    // amortize alloc
-    // lifetime is tied to self, so we use static
-    // to ensure bck to leave us be
-    keys_scratch: UnsafeCell<Vec<AnyValue<'static>>>,
     output_schema: SchemaRef,
     pub num_keys: usize,
     spill_size: usize,
@@ -37,7 +32,6 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
             keys: Default::default(),
             running_aggregations: Default::default(),
             agg_constructors,
-            keys_scratch: UnsafeCell::new(Vec::with_capacity(key_dtypes.len())),
             num_keys: key_dtypes.len(),
             spill_size: spill_size.unwrap_or(usize::MAX),
             output_schema,
@@ -50,16 +44,15 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
             keys: Default::default(),
             running_aggregations: Default::default(),
             agg_constructors: self.agg_constructors.iter().map(|c| c.split()).collect(),
-            keys_scratch: UnsafeCell::new(Vec::with_capacity(self.num_keys)),
             num_keys: self.num_keys,
             spill_size: self.spill_size,
             output_schema: self.output_schema.clone(),
         }
     }
 
-    unsafe fn get_keys(&self, idx: IdxSize) -> &[AnyValue] {
-        let start = idx as usize;
-        let end = start + self.num_keys;
+    unsafe fn get_keys_row(&self, key: &Key) -> &[u8] {
+        let start = key.offset as usize;
+        let end = start + key.len as usize;
         self.keys.get_unchecked(start..end)
     }
 
@@ -70,61 +63,31 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
     fn get_entry(
         &mut self,
         hash: u64,
-        tuples: &[AnyValue],
+        row: &[u8],
     ) -> RawEntryMut<Key, IdxSize, IdBuildHasher> {
+        let keys = self.keys.as_ptr();
+
         self.inner_map
             .raw_entry_mut()
             .from_hash(hash, |hash_map_key| {
                 hash_map_key.hash == hash && {
-                    let idx = hash_map_key.idx as usize;
-                    if tuples.len() > 1 {
-                        tuples.iter().enumerate().all(|(i, key)| unsafe {
-                            self.keys.get_unchecked_release(i + idx) == key
-                        })
-                    } else {
-                        unsafe {
-                            self.keys.get_unchecked_release(idx) == tuples.get_unchecked_release(0)
-                        }
+                    let offset = hash_map_key.offset as usize;
+                    let len = hash_map_key.len as usize;
+
+                    unsafe {
+                        std::slice::from_raw_parts(keys.add(offset), len) == row
                     }
                 }
             })
     }
 
-    /// # Safety
-    /// Caller must ensure that `keys` and `agg_iters` are not depleted.
-    /// # Returns &keys
-    pub(super) unsafe fn insert<'a>(
-        &'a mut self,
-        hash: u64,
-        keys: &mut [SeriesPhysIter],
-        agg_iters: &mut [SeriesPhysIter],
-        chunk_index: IdxSize,
-    ) -> Option<&[AnyValue]> {
-        // safety: no references
-        let keys_scratch = unsafe { &mut *self.keys_scratch.get() };
+    fn insert_key<'a>(&'a mut self, hash: u64, row: &[u8]) -> Option<IdxSize> {
+        let entry = self.get_entry(hash, row);
 
-        unsafe {
-            // safety:
-            // this scratch is set with borrowed anyvalues, so we don't have to drop
-            // them as they only borrow data
-            keys_scratch.set_len(0);
-        }
-        for key in keys {
-            unsafe {
-                // safety: this function should never be called if iterator is depleted
-                let key = key.next().unwrap_unchecked_release();
-                // safety: the static is temporary, we will never access them outside of this function
-                let key = std::mem::transmute::<AnyValue<'_>, AnyValue<'static>>(key);
-                // safety: we amortized n_keys
-                keys_scratch.push_unchecked(key)
-            }
-        }
-
-        let entry = self.get_entry(hash, keys_scratch);
-
-        let agg_idx = match entry {
-            RawEntryMut::Occupied(entry) => *entry.get(),
+        match entry {
+            RawEntryMut::Occupied(entry) => Some(*entry.get()),
             RawEntryMut::Vacant(entry) => {
+
                 // bchk shenanigans:
                 // it does not allow us to hold a `raw entry` and in the meantime
                 // have &self access to get the length of keys
@@ -143,13 +106,14 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
                             borrow as *const RawVacantEntryMut<'a, Key, IdxSize, IdBuildHasher>;
                         let _entry = std::ptr::read(borrow);
                     }
-                    return Some(keys_scratch);
+                    return None;
                 }
 
                 let aggregation_idx = self.running_aggregations.len() as IdxSize;
-                let key_idx = self.keys.len() as IdxSize;
+                let key_offset = self.keys.len() as u32;
+                let key_len = row.len() as u32;
+                let key = Key::new(hash, key_offset, key_len);
 
-                let key = Key::new(hash, key_idx);
                 unsafe {
                     // take a hold of the entry again and ensure it gets dropped
                     let borrow =
@@ -162,15 +126,26 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
                     self.running_aggregations.push(agg.split())
                 }
 
-                unsafe {
-                    self.keys.extend(
-                        keys_scratch
-                            .iter()
-                            .map(|av| av.clone().into_static().unwrap_unchecked_release()),
-                    );
-                }
-                aggregation_idx
+                self.keys.extend_from_slice(row);
+                Some(aggregation_idx)
             }
+        }
+    }
+
+    /// # Safety
+    /// Caller must ensure that `keys` and `agg_iters` are not depleted.
+    /// # Returns &keys
+    pub(super) unsafe fn insert<'a>(
+        &'a mut self,
+        hash: u64,
+        row: &[u8],
+        agg_iters: &mut [SeriesPhysIter],
+        chunk_index: IdxSize,
+    ) -> bool {
+        let agg_idx = match self.insert_key(hash, row) {
+            // overflow
+            None => return true,
+            Some(agg_idx) => agg_idx
         };
 
         // apply the aggregation
@@ -180,7 +155,8 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
 
             agg_fn.pre_agg(chunk_index, agg_iter.as_mut())
         }
-        None
+        // no overflow
+        false
     }
 
     pub(super) fn combine(&mut self, other: &mut Self) {
@@ -207,52 +183,15 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
     where
         C: Fn(u64) -> bool,
     {
+        let spill_size = self.spill_size;
+        self.spill_size = usize::MAX;
         for (key_other, agg_idx_other) in other.inner_map.iter() {
             // safety: idx is from the hashmap, so is in bounds
-            let keys = unsafe { other.get_keys(key_other.idx) };
+            let row = unsafe { other.get_keys_row(key_other) };
 
             if on_condition(key_other.hash) {
-                let entry = self.get_entry(key_other.hash, keys);
-                let agg_idx_self = match entry {
-                    RawEntryMut::Occupied(entry) => *entry.get(),
-                    RawEntryMut::Vacant(entry) => {
-                        let borrow = &entry;
-                        let borrow = borrow as *const RawVacantEntryMut<_, _, _> as usize;
-                        // ensure the bck forgets this guy
-                        #[allow(clippy::forget_non_drop)]
-                        std::mem::forget(entry);
-
-                        let key_idx = self.keys.len() as IdxSize;
-                        let aggregation_idx = self.running_aggregations.len() as IdxSize;
-
-                        let key = Key::new(key_other.hash, key_idx);
-                        for agg in self.agg_constructors.as_ref() {
-                            self.running_aggregations.push(agg.split())
-                        }
-
-                        // take a hold of the entry again and ensure it gets dropped
-                        unsafe {
-                            let borrow =
-                                borrow as *const RawVacantEntryMut<'_, Key, IdxSize, IdBuildHasher>;
-                            let entry = std::ptr::read(borrow);
-                            entry.insert(key, aggregation_idx);
-                        }
-                        // update the keys
-                        unsafe {
-                            let start = key_other.idx as usize;
-                            let end = start + self.num_keys;
-                            let keys = other.keys.get_unchecked_release_mut(start..end);
-
-                            for key in keys {
-                                let mut owned_key = AnyValue::Null;
-                                // this prevents cloning a string
-                                std::mem::swap(&mut owned_key, key);
-                                self.keys.push(owned_key)
-                            }
-                        }
-                        aggregation_idx
-                    }
-                };
+                // safety: will not overflow as we set it to usize::MAX;
+                let agg_idx_self = unsafe { self.insert_key(key_other.hash, row).unwrap_unchecked_release() };
                 let start = *agg_idx_other as usize;
                 let end = start + self.agg_constructors.len();
                 let aggs_other =
@@ -273,6 +212,7 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
                 }
             }
         }
+        self.spill_size = spill_size;
     }
 
     pub(super) fn finalize(&mut self, slice: &mut Option<(i64, usize)>) -> DataFrame {
@@ -291,13 +231,7 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
             (0, local_len)
         };
         let inner_map = std::mem::take(&mut self.inner_map);
-
-        let mut key_builders = self
-            .output_schema
-            .iter_dtypes()
-            .take(self.num_keys)
-            .map(|dtype| AnyValueBufferTrusted::new(&dtype.to_physical(), take_len))
-            .collect::<Vec<_>>();
+        let mut running_aggregations = std::mem::take(&mut self.running_aggregations);
 
         let mut agg_builders = self
             .agg_constructors
@@ -305,33 +239,22 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
             .map(|ac| AnyValueBufferTrusted::new(&ac.dtype(), take_len))
             .collect::<Vec<_>>();
         let num_aggs = self.agg_constructors.len();
+        let mut key_rows = Vec::with_capacity(take_len);
 
         inner_map
             .into_iter()
             .skip(skip_len)
             .take(take_len)
             .for_each(|(k, agg_offset)| {
-                let keys_offset = k.idx as usize;
-                let keys = unsafe {
-                    self.keys
-                        .get_unchecked_release(keys_offset..keys_offset + self.num_keys)
-                };
-
-                // amortize loop counter
-                for i in 0..self.num_keys {
-                    unsafe {
-                        let key = keys.get_unchecked_release(i);
-                        let key_builder = key_builders.get_unchecked_release_mut(i);
-                        // safety: we own the keys
-                        key_builder.add_unchecked_owned_physical(key);
-                    }
+                unsafe {
+                    key_rows.push_unchecked(unsafe { self.get_keys_row(&k) }) ;
                 }
 
                 let start = agg_offset as usize;
                 let end = start + num_aggs;
                 for (i, buffer) in (start..end).zip(agg_builders.iter_mut()) {
                     unsafe {
-                        let running_agg = self.running_aggregations.get_unchecked_release_mut(i);
+                        let running_agg = running_aggregations.get_unchecked_release_mut(i);
                         let av = running_agg.finalize();
                         // safety: finalize creates owned anyvalues
                         buffer.add_unchecked_owned_physical(&av);
@@ -339,8 +262,18 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
                 }
             });
 
+        let key_dtypes = self
+            .output_schema
+            .iter_dtypes()
+            .take(self.num_keys)
+            .map(|dtype| dtype.to_physical().to_arrow()).collect::<Vec<_>>();
+        let fields = vec![Default::default(); self.num_keys];
+        let key_columns = unsafe {
+            polars_row::decode::decode_rows(&mut key_rows, &fields, &key_dtypes)
+        };
+
         let mut cols = Vec::with_capacity(self.num_keys + self.agg_constructors.len());
-        cols.extend(key_builders.into_iter().map(|buf| buf.into_series()));
+        cols.extend(key_columns.into_iter().map(|arr| Series::try_from(("", arr)).unwrap()));
         cols.extend(agg_builders.into_iter().map(|buf| buf.into_series()));
         physical_agg_to_logical(&mut cols, &self.output_schema);
         DataFrame::new_no_checks(cols)

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/mod.rs
@@ -13,6 +13,7 @@ use std::sync::Mutex;
 use eval::Eval;
 use hash_table::AggHashTable;
 use hashbrown::hash_map::{RawEntryMut, RawVacantEntryMut};
+use polars_arrow::export::arrow::array::BinaryArray;
 use polars_core::frame::row::AnyValueBufferTrusted;
 use polars_core::series::SeriesPhysIter;
 use polars_core::IdBuildHasher;
@@ -34,24 +35,25 @@ type IOThreadRef = Arc<Mutex<Option<IOThread>>>;
 struct SpillPayload {
     hashes: Vec<u64>,
     chunk_idx: Vec<IdxSize>,
-    keys_and_aggs: Vec<Series>,
-    num_keys: usize,
+    keys: BinaryArray<i64>,
+    aggs: Vec<Series>,
 }
 
 static HASH_COL: &str = "__POLARS_h";
 static INDEX_COL: &str = "__POLARS_idx";
+static KEYS_COL: &str = "__POLARS_keys";
 
 impl SpillPayload {
     fn hashes(&self) -> &[u64] {
         &self.hashes
     }
 
-    fn keys(&self) -> &[Series] {
-        &self.keys_and_aggs[..self.num_keys]
+    fn keys(&self) -> &BinaryArray<i64> {
+        &self.keys
     }
 
     fn cols(&self) -> &[Series] {
-        &self.keys_and_aggs[self.num_keys..]
+        &self.aggs
     }
 
     fn chunk_index(&self) -> &[IdxSize] {
@@ -59,10 +61,11 @@ impl SpillPayload {
     }
 
     fn get_schema(&self) -> Schema {
-        let mut schema = Schema::with_capacity(self.keys_and_aggs.len() + 2);
+        let mut schema = Schema::with_capacity(self.aggs.len() + 2);
         schema.with_column(HASH_COL.into(), DataType::UInt64);
         schema.with_column(INDEX_COL.into(), IDX_DTYPE);
-        for s in &self.keys_and_aggs {
+        schema.with_column(KEYS_COL.into(), DataType::Binary);
+        for s in &self.aggs {
             schema.with_column(s.name().into(), s.dtype().clone());
         }
         schema
@@ -70,25 +73,32 @@ impl SpillPayload {
 
     fn into_df(self) -> DataFrame {
         debug_assert_eq!(self.hashes.len(), self.chunk_idx.len());
-        debug_assert_eq!(self.hashes.len(), self.keys_and_aggs[0].len());
+        debug_assert_eq!(self.hashes.len(), self.keys.len());
 
         let hashes = UInt64Chunked::from_vec(HASH_COL, self.hashes).into_series();
         let chunk_idx = IdxCa::from_vec(INDEX_COL, self.chunk_idx).into_series();
-        let mut cols = Vec::with_capacity(self.keys_and_aggs.len() + 2);
+        let keys = Series::try_from((KEYS_COL, Box::new(self.keys) as ArrayRef)).unwrap();
+
+        let mut cols = Vec::with_capacity(self.aggs.len() + 3);
         cols.push(hashes);
         cols.push(chunk_idx);
-        cols.extend(self.keys_and_aggs);
+        cols.push(keys);
+        cols.extend(self.aggs);
         DataFrame::new_no_checks(cols)
     }
 
-    fn spilled_to_columns(spilled: &DataFrame) -> (&[u64], &[IdxSize], &[Series]) {
+    fn spilled_to_columns(
+        spilled: &DataFrame,
+    ) -> (&[u64], &[IdxSize], &BinaryArray<i64>, &[Series]) {
         let cols = spilled.get_columns();
         let hashes = cols[0].u64().unwrap();
         let hashes = hashes.cont_slice().unwrap();
         let chunk_indexes = cols[1].idx().unwrap();
         let chunk_indexes = chunk_indexes.cont_slice().unwrap();
-        let keys_and_aggs = &cols[2..];
-        (hashes, chunk_indexes, keys_and_aggs)
+        let keys = cols[2].binary().unwrap();
+        let keys = keys.downcast_iter().next().unwrap();
+        let aggs = &cols[3..];
+        (hashes, chunk_indexes, keys, aggs)
     }
 }
 
@@ -97,7 +107,7 @@ impl SpillPayload {
 pub(super) struct Key {
     pub(super) hash: u64,
     pub(super) offset: u32,
-    pub(super) len: u32
+    pub(super) len: u32,
 }
 
 impl Key {

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/mod.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/mod.rs
@@ -96,13 +96,14 @@ impl SpillPayload {
 #[derive(Copy, Clone)]
 pub(super) struct Key {
     pub(super) hash: u64,
-    pub(super) idx: IdxSize,
+    pub(super) offset: u32,
+    pub(super) len: u32
 }
 
 impl Key {
     #[inline]
-    pub(super) fn new(hash: u64, idx: IdxSize) -> Self {
-        Self { hash, idx }
+    pub(super) fn new(hash: u64, offset: u32, len: u32) -> Self {
+        Self { hash, offset, len }
     }
 }
 

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/sink.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/sink.rs
@@ -64,8 +64,7 @@ impl Sink for GenericGroupby2 {
             // safety: we don't hold mutable refs
             self.eval.evaluate_keys_aggs_and_hashes(context, &chunk)?;
         }
-        // safety: we don't hold mutable refs
-        let mut keys = unsafe { self.eval.get_keys_iters() };
+        let keys = self.eval.get_keys_iter();
         // safety: we don't hold mutable refs
         let mut aggs = unsafe { self.eval.get_aggs_iters() };
 
@@ -74,9 +73,9 @@ impl Sink for GenericGroupby2 {
             // safety: the mutable borrows are not aliasing
             let table = &mut *self.thread_local_table.get();
 
-            for hash in self.eval.hashes() {
+            for (hash, row) in self.eval.hashes().iter().zip(keys.values_iter()) {
                 if let Some((partition, spill_payload)) =
-                    table.insert(*hash, &mut keys, &mut aggs, chunk_idx)
+                    table.insert(*hash, row, &mut aggs, chunk_idx)
                 {
                     self.global_table.spill(partition, spill_payload)
                 }
@@ -85,7 +84,6 @@ impl Sink for GenericGroupby2 {
 
         // clear memory
         unsafe {
-            drop(keys);
             drop(aggs);
             // safety: we don't hold mutable refs, we just dropped them
             self.eval.clear()

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/sink.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/sink.rs
@@ -64,7 +64,8 @@ impl Sink for GenericGroupby2 {
             // safety: we don't hold mutable refs
             self.eval.evaluate_keys_aggs_and_hashes(context, &chunk)?;
         }
-        let keys = self.eval.get_keys_iter();
+        // safety: eval is alive for the duration of keys
+        let keys = unsafe { self.eval.get_keys_iter() };
         // safety: we don't hold mutable refs
         let mut aggs = unsafe { self.eval.get_aggs_iters() };
 

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/thread_local.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/thread_local.rs
@@ -292,13 +292,14 @@ impl ThreadLocalTable {
     pub(super) unsafe fn insert(
         &mut self,
         hash: u64,
-        keys: &mut [SeriesPhysIter],
+        keys_row: &[u8],
         agg_iters: &mut [SeriesPhysIter],
         chunk_index: IdxSize,
     ) -> Option<(usize, SpillPayload)> {
-        if let Some(keys) = self.inner_map.insert(hash, keys, agg_iters, chunk_index) {
-            self.spill_partitions
-                .insert(hash, chunk_index, keys, agg_iters)
+        if self.inner_map.insert(hash, keys_row, agg_iters, chunk_index) {
+            // self.spill_partitions
+            //     .insert(hash, chunk_index, keys, agg_iters)
+            todo!()
         } else {
             None
         }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/thread_local.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/groupby/generic/thread_local.rs
@@ -1,4 +1,5 @@
 use once_cell::sync::Lazy;
+use polars_arrow::export::arrow::array::MutableBinaryArray;
 use polars_core::export::once_cell;
 
 use super::*;
@@ -16,10 +17,10 @@ static SPILL_SIZE: Lazy<usize> = Lazy::new(|| {
 struct SpillPartitions {
     // outer vec: partitions (factor of 2)
     // inner vec: number of keys + number of aggregated columns
-    keys_aggs_partitioned: PartitionVec<Vec<AnyValueBufferTrusted<'static>>>,
+    keys_partitioned: PartitionVec<MutableBinaryArray<i64>>,
+    aggs_partitioned: PartitionVec<Vec<AnyValueBufferTrusted<'static>>>,
     hash_partitioned: PartitionVec<Vec<u64>>,
     chunk_index_partitioned: PartitionVec<Vec<IdxSize>>,
-    num_keys: usize,
     spilled: bool,
     // this only fills during the reduce phase IFF
     // there are spilled tuples
@@ -36,10 +37,10 @@ impl SpillPartitions {
 
         // construct via split so that pre-allocation succeeds
         Self {
-            keys_aggs_partitioned: vec![],
+            keys_partitioned: vec![],
+            aggs_partitioned: vec![],
             hash_partitioned,
             chunk_index_partitioned,
-            num_keys: keys.as_ref().len(),
             spilled: false,
             finished_payloads: vec![],
             keys_dtypes: keys,
@@ -50,15 +51,11 @@ impl SpillPartitions {
     }
 
     fn split(&self) -> Self {
-        let n_columns = self.keys_dtypes.as_ref().len() + self.agg_dtypes.as_ref().len();
+        let n_columns = self.agg_dtypes.as_ref().len();
 
-        let keys_aggs_partitioned = (0..PARTITION_SIZE)
+        let aggs_partitioned = (0..PARTITION_SIZE)
             .map(|_| {
                 let mut buf = Vec::with_capacity(n_columns);
-                for dtype in self.keys_dtypes.as_ref() {
-                    let builder = AnyValueBufferTrusted::new(&dtype.to_physical(), OB_SIZE);
-                    buf.push(builder);
-                }
                 for dtype in self.agg_dtypes.as_ref() {
                     let builder = AnyValueBufferTrusted::new(&dtype.to_physical(), OB_SIZE);
                     buf.push(builder);
@@ -67,14 +64,18 @@ impl SpillPartitions {
             })
             .collect();
 
+        let keys_partitioned = (0..PARTITION_SIZE)
+            .map(|_| MutableBinaryArray::with_capacity(OB_SIZE))
+            .collect();
+
         let hash_partitioned = vec![Vec::with_capacity(OB_SIZE); PARTITION_SIZE];
         let chunk_index_partitioned = vec![Vec::with_capacity(OB_SIZE); PARTITION_SIZE];
 
         Self {
-            keys_aggs_partitioned,
+            keys_partitioned,
+            aggs_partitioned,
             hash_partitioned,
             chunk_index_partitioned,
-            num_keys: self.num_keys,
             spilled: false,
             finished_payloads: vec![],
             keys_dtypes: self.keys_dtypes.clone(),
@@ -85,79 +86,50 @@ impl SpillPartitions {
 }
 
 impl SpillPartitions {
-    fn pre_alloc(&mut self) {
-        if !self.spilled {
-            let n_columns = self.keys_dtypes.as_ref().len() + self.agg_dtypes.as_ref().len();
-
-            self.keys_aggs_partitioned = (0..PARTITION_SIZE)
-                .map(|_| {
-                    let mut buf = Vec::with_capacity(n_columns);
-                    for dtype in self.keys_dtypes.as_ref() {
-                        let builder = AnyValueBufferTrusted::new(&dtype.to_physical(), OB_SIZE);
-                        buf.push(builder);
-                    }
-                    for dtype in self.agg_dtypes.as_ref() {
-                        let builder = AnyValueBufferTrusted::new(&dtype.to_physical(), OB_SIZE);
-                        buf.push(builder);
-                    }
-                    buf
-                })
-                .collect();
-
-            self.hash_partitioned = vec![Vec::with_capacity(OB_SIZE); PARTITION_SIZE];
-            self.chunk_index_partitioned = vec![Vec::with_capacity(OB_SIZE); PARTITION_SIZE];
-        }
-    }
     /// Returns (partition, overflowing hashes, chunk_indexes, keys and aggs)
     fn insert(
         &mut self,
         hash: u64,
         chunk_idx: IdxSize,
-        keys: &[AnyValue<'_>],
-        aggs: &mut [SeriesPhysIter],
+        row: &[u8],
+        agg_iters: &mut [SeriesPhysIter],
     ) -> Option<(usize, SpillPayload)> {
-        self.pre_alloc();
-        let partition = hash_to_partition(hash, self.keys_aggs_partitioned.len());
+        let partition = hash_to_partition(hash, self.aggs_partitioned.len());
         self.spilled = true;
         unsafe {
-            let keys_aggs = self
-                .keys_aggs_partitioned
-                .get_unchecked_release_mut(partition);
+            let agg_values = self.aggs_partitioned.get_unchecked_release_mut(partition);
             let hashes = self.hash_partitioned.get_unchecked_release_mut(partition);
             let chunk_indexes = self
                 .chunk_index_partitioned
                 .get_unchecked_release_mut(partition);
+            let key_builder = self.keys_partitioned.get_unchecked_mut(partition);
 
             hashes.push(hash);
             chunk_indexes.push(chunk_idx);
 
             // amortize the loop counter
-            for i in 0..keys.len() {
-                let av = keys.get_unchecked(i);
-                let buf = keys_aggs.get_unchecked_mut(i);
-                // safety: we can trust the input types to be of consistent dtype
-                buf.add_unchecked_borrowed_physical(av);
-            }
-            let mut i = keys.len();
-            for agg in aggs {
+            key_builder.push(Some(row));
+            for (i, agg) in agg_iters.iter_mut().enumerate() {
                 let av = agg.next().unwrap_unchecked_release();
-                let buf = keys_aggs.get_unchecked_mut(i);
+                let buf = agg_values.get_unchecked_mut(i);
                 buf.add_unchecked_borrowed_physical(&av);
-                i += 1;
             }
 
             if hashes.len() >= OB_SIZE {
                 let mut new_hashes = Vec::with_capacity(OB_SIZE);
                 let mut new_chunk_indexes = Vec::with_capacity(OB_SIZE);
+                let mut new_keys_builder = MutableBinaryArray::with_capacity(OB_SIZE);
                 std::mem::swap(&mut new_hashes, hashes);
                 std::mem::swap(&mut new_chunk_indexes, chunk_indexes);
+                std::mem::swap(&mut new_keys_builder, key_builder);
 
                 Some((
                     partition,
                     SpillPayload {
                         hashes: new_hashes,
                         chunk_idx: new_chunk_indexes,
-                        keys_and_aggs: keys_aggs
+                        keys: new_keys_builder.into(),
+                        aggs: agg_values
                             .iter_mut()
                             .zip(self.output_schema.iter_names())
                             .map(|(b, name)| {
@@ -166,7 +138,6 @@ impl SpillPartitions {
                                 s
                             })
                             .collect(),
-                        num_keys: self.num_keys,
                     },
                 ))
             } else {
@@ -223,13 +194,13 @@ impl SpillPartitions {
 
         (0..PARTITION_SIZE)
             .map(|partition| unsafe {
-                let keys_aggs = self
-                    .keys_aggs_partitioned
-                    .get_unchecked_release_mut(partition);
+                let spilled_aggs = self.aggs_partitioned.get_unchecked_release_mut(partition);
                 let hashes = self.hash_partitioned.get_unchecked_release_mut(partition);
                 let chunk_indexes = self
                     .chunk_index_partitioned
                     .get_unchecked_release_mut(partition);
+                let keys_builder =
+                    std::mem::take(self.keys_partitioned.get_unchecked_mut(partition));
                 let hashes = std::mem::take(hashes);
                 let chunk_idx = std::mem::take(chunk_indexes);
 
@@ -238,8 +209,8 @@ impl SpillPartitions {
                     SpillPayload {
                         hashes,
                         chunk_idx,
-                        keys_and_aggs: keys_aggs.iter_mut().map(|b| b.reset(0)).collect(),
-                        num_keys: self.num_keys,
+                        keys: keys_builder.into(),
+                        aggs: spilled_aggs.iter_mut().map(|b| b.reset(0)).collect(),
                     },
                 )
             })
@@ -296,10 +267,12 @@ impl ThreadLocalTable {
         agg_iters: &mut [SeriesPhysIter],
         chunk_index: IdxSize,
     ) -> Option<(usize, SpillPayload)> {
-        if self.inner_map.insert(hash, keys_row, agg_iters, chunk_index) {
-            // self.spill_partitions
-            //     .insert(hash, chunk_index, keys, agg_iters)
-            todo!()
+        if self
+            .inner_map
+            .insert(hash, keys_row, agg_iters, chunk_index)
+        {
+            self.spill_partitions
+                .insert(hash, chunk_index, keys_row, agg_iters)
         } else {
             None
         }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/utils.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/utils.rs
@@ -1,4 +1,6 @@
+use polars_arrow::export::arrow::array::BinaryArray;
 use polars_core::export::ahash::RandomState;
+use polars_core::hashing::_hash_binary_array;
 use polars_core::prelude::*;
 
 pub(super) fn hash_series(columns: &[Series], buf: &mut Vec<u64>, hb: &RandomState) {
@@ -9,6 +11,11 @@ pub(super) fn hash_series(columns: &[Series], buf: &mut Vec<u64>, hb: &RandomSta
     for other_key in col_iter {
         other_key.vec_hash_combine(hb.clone(), buf).unwrap();
     }
+}
+
+pub(super) fn hash_rows(columns: &BinaryArray<i64>, buf: &mut Vec<u64>, hb: &RandomState) {
+    debug_assert!(buf.is_empty());
+    _hash_binary_array(columns, hb.clone(), buf);
 }
 
 pub(super) fn load_vec<T, F: Fn() -> T>(partitions: usize, item: F) -> Vec<T> {

--- a/polars/polars-row/src/decode.rs
+++ b/polars/polars-row/src/decode.rs
@@ -40,6 +40,13 @@ unsafe fn decode(rows: &mut [&[u8]], field: &SortField, data_type: &DataType) ->
             )
             .to_boxed()
         }
+        DataType::Struct(fields) => {
+            let values = fields
+                .iter()
+                .map(|struct_fld| decode(rows, field, struct_fld.data_type()))
+                .collect();
+            StructArray::new(data_type.clone(), values, None).to_boxed()
+        }
         dt => {
             with_match_arrow_primitive_type!(dt, |$T| {
                 decode_primitive::<$T>(rows, field).to_boxed()

--- a/polars/polars-row/src/encode.rs
+++ b/polars/polars-row/src/encode.rs
@@ -80,6 +80,7 @@ pub fn encoded_size(data_type: &ArrowDataType) -> usize {
         Int64 => i64::ENCODED_LEN,
         Float32 => f32::ENCODED_LEN,
         Float64 => f64::ENCODED_LEN,
+        Boolean => bool::ENCODED_LEN,
         _ => unimplemented!(),
     }
 }

--- a/polars/polars-row/src/fixed.rs
+++ b/polars/polars-row/src/fixed.rs
@@ -164,7 +164,7 @@ pub(crate) fn encode_slice<T: FixedLengthEncoding>(
     field: &SortField,
 ) {
     for (offset, value) in out.offsets.iter_mut().skip(1).zip(input) {
-        encode_value(value, offset, field.descending, &mut out.buf);
+        encode_value(value, offset, field.descending, &mut out.values);
     }
 }
 
@@ -184,9 +184,9 @@ pub(crate) fn encode_iter<I: Iterator<Item = Option<T>>, T: FixedLengthEncoding>
 ) {
     for (offset, opt_value) in out.offsets.iter_mut().skip(1).zip(input) {
         if let Some(value) = opt_value {
-            encode_value(&value, offset, field.descending, &mut out.buf);
+            encode_value(&value, offset, field.descending, &mut out.values);
         } else {
-            unsafe { *out.buf.get_unchecked_release_mut(*offset) = get_null_sentinel(field) };
+            unsafe { *out.values.get_unchecked_release_mut(*offset) = get_null_sentinel(field) };
             let end_offset = *offset + T::ENCODED_LEN;
             *offset = end_offset;
         }

--- a/polars/polars-row/src/fixed.rs
+++ b/polars/polars-row/src/fixed.rs
@@ -208,8 +208,9 @@ where
         .iter()
         .map(|row| {
             has_nulls |= *row.get_unchecked(0) == null_sentinel;
+            // skip null sentinel
             let start = 1;
-            let end = start + T::ENCODED_LEN;
+            let end = start + T::ENCODED_LEN - 1;
             let slice = row.get_unchecked(start..end);
             let bytes = T::Encoded::from_slice(slice);
             T::decode(bytes)
@@ -224,7 +225,7 @@ where
     };
 
     // validity byte and data length
-    let increment_len = 1 + T::ENCODED_LEN;
+    let increment_len = T::ENCODED_LEN;
 
     increment_row_counter(rows, increment_len);
     PrimitiveArray::new(data_type, values.into(), validity)
@@ -238,8 +239,9 @@ pub(super) unsafe fn decode_bool(rows: &mut [&[u8]], field: &SortField) -> Boole
         .iter()
         .map(|row| {
             has_nulls |= *row.get_unchecked(0) == null_sentinel;
+            // skip null sentinel
             let start = 1;
-            let end = start + bool::ENCODED_LEN;
+            let end = start + bool::ENCODED_LEN - 1;
             let slice = row.get_unchecked(start..end);
             let bytes = <bool as FixedLengthEncoding>::Encoded::from_slice(slice);
             bool::decode(bytes)
@@ -253,7 +255,7 @@ pub(super) unsafe fn decode_bool(rows: &mut [&[u8]], field: &SortField) -> Boole
     };
 
     // validity byte and data length
-    let increment_len = 1 + bool::ENCODED_LEN;
+    let increment_len = bool::ENCODED_LEN;
 
     increment_row_counter(rows, increment_len);
     BooleanArray::new(DataType::Boolean, values, validity)

--- a/polars/polars-row/src/lib.rs
+++ b/polars/polars-row/src/lib.rs
@@ -266,6 +266,8 @@
 //! [COBS]: https://en.wikipedia.org/wiki/Consistent_Overhead_Byte_Stuffing
 //! [byte stuffing]: https://en.wikipedia.org/wiki/High-Level_Data_Link_Control#Asynchronous_framing
 
+extern crate core;
+
 pub mod decode;
 pub mod encode;
 pub(crate) mod fixed;
@@ -276,5 +278,5 @@ pub(crate) mod variable;
 use arrow::array::*;
 pub type ArrayRef = Box<dyn Array>;
 
-pub use encode::convert_columns;
+pub use encode::{convert_columns, convert_columns_amortized};
 pub use row::{RowsEncoded, SortField};

--- a/polars/polars-row/src/row.rs
+++ b/polars/polars-row/src/row.rs
@@ -1,6 +1,7 @@
 use arrow::array::BinaryArray;
 use arrow::datatypes::DataType;
-use arrow::offset::Offsets;
+use arrow::ffi::mmap;
+use arrow::offset::{Offsets, OffsetsBuffer};
 
 #[derive(Clone, Default)]
 pub struct SortField {
@@ -10,14 +11,39 @@ pub struct SortField {
     pub nulls_last: bool,
 }
 
+#[derive(Default)]
 pub struct RowsEncoded {
-    pub(crate) buf: Vec<u8>,
+    pub(crate) values: Vec<u8>,
     pub(crate) offsets: Vec<usize>,
 }
 
+fn checks(offsets: &[usize]) {
+    assert_eq!(
+        std::mem::size_of::<usize>(),
+        std::mem::size_of::<i64>(),
+        "only supported on 64bit arch"
+    );
+    assert!(
+        (*offsets.last().unwrap() as u64) < i64::MAX as u64,
+        "overflow"
+    );
+}
+
+unsafe fn rows_to_array(buf: Vec<u8>, offsets: Vec<usize>) -> BinaryArray<i64> {
+    checks(&offsets);
+
+    // Safety: we checked overflow
+    let offsets = std::mem::transmute::<Vec<usize>, Vec<i64>>(offsets);
+
+    // Safety: monotonically increasing
+    let offsets = Offsets::new_unchecked(offsets);
+
+    BinaryArray::new(DataType::LargeBinary, offsets.into(), buf.into(), None)
+}
+
 impl RowsEncoded {
-    pub(crate) fn new(buf: Vec<u8>, offsets: Vec<usize>) -> Self {
-        RowsEncoded { buf, offsets }
+    pub(crate) fn new(values: Vec<u8>, offsets: Vec<usize>) -> Self {
+        RowsEncoded { values, offsets }
     }
 
     pub fn iter(&self) -> RowsEncodedIter {
@@ -26,42 +52,44 @@ impl RowsEncoded {
         RowsEncodedIter {
             offset,
             end: iter,
-            buf: &self.buf,
+            values: &self.values,
+        }
+    }
+
+    /// Borrows the buffers and returns a [`BinaryArray`].
+    ///
+    /// # Safety
+    /// The lifetime of that `BinaryArray` is tight to the lifetime of
+    /// `Self`. The caller must ensure that both stay alive for the same time.
+    pub unsafe fn borrow_array(&self) -> BinaryArray<i64> {
+        checks(&self.offsets);
+
+        unsafe {
+            let (_, values, _) = mmap::slice(&self.values).into_inner();
+            let offsets = std::mem::transmute::<&[usize], &[i64]>(self.offsets.as_slice());
+            let (_, offsets, _) = mmap::slice(offsets).into_inner();
+            let offsets = OffsetsBuffer::new_unchecked(offsets);
+
+            BinaryArray::new(DataType::LargeBinary, offsets, values, None)
         }
     }
 
     pub fn into_array(self) -> BinaryArray<i64> {
-        assert_eq!(
-            std::mem::size_of::<usize>(),
-            std::mem::size_of::<i64>(),
-            "only supported on 64bit arch"
-        );
-        assert!(
-            (*self.offsets.last().unwrap() as u64) < i64::MAX as u64,
-            "overflow"
-        );
-
-        // Safety: we checked overflow
-        let offsets = unsafe { std::mem::transmute::<Vec<usize>, Vec<i64>>(self.offsets) };
-
-        // Safety: monotonically increasing
-        let offsets = unsafe { Offsets::new_unchecked(offsets) };
-
-        BinaryArray::new(DataType::LargeBinary, offsets.into(), self.buf.into(), None)
+        unsafe { rows_to_array(self.values, self.offsets) }
     }
 
     #[cfg(test)]
     pub fn get(&self, i: usize) -> &[u8] {
         let start = self.offsets[i];
         let end = self.offsets[i + 1];
-        &self.buf[start..end]
+        &self.values[start..end]
     }
 }
 
 pub struct RowsEncodedIter<'a> {
     offset: usize,
     end: std::slice::Iter<'a, usize>,
-    buf: &'a [u8],
+    values: &'a [u8],
 }
 
 impl<'a> Iterator for RowsEncodedIter<'a> {
@@ -69,7 +97,7 @@ impl<'a> Iterator for RowsEncodedIter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let new_offset = *self.end.next()?;
-        let payload = unsafe { self.buf.get_unchecked(self.offset..new_offset) };
+        let payload = unsafe { self.values.get_unchecked(self.offset..new_offset) };
         self.offset = new_offset;
         Some(payload)
     }

--- a/polars/polars-row/src/row.rs
+++ b/polars/polars-row/src/row.rs
@@ -2,7 +2,7 @@ use arrow::array::BinaryArray;
 use arrow::datatypes::DataType;
 use arrow::offset::Offsets;
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct SortField {
     /// Whether to sort in descending order
     pub descending: bool,

--- a/polars/polars-row/src/variable.rs
+++ b/polars/polars-row/src/variable.rs
@@ -236,7 +236,7 @@ pub(super) unsafe fn decode_binary(rows: &mut [&[u8]], field: &SortField) -> Bin
     }
 
     BinaryArray::new(
-        DataType::Binary,
+        DataType::LargeBinary,
         Offsets::new_unchecked(offsets).into(),
         values.into(),
         validity,

--- a/polars/polars-row/src/variable.rs
+++ b/polars/polars-row/src/variable.rs
@@ -133,7 +133,7 @@ pub(crate) unsafe fn encode_iter<'a, I: Iterator<Item = Option<&'a [u8]>>>(
     field: &SortField,
 ) {
     for (offset, opt_value) in out.offsets.iter_mut().skip(1).zip(input) {
-        let dst = out.buf.get_unchecked_release_mut(*offset..);
+        let dst = out.values.get_unchecked_release_mut(*offset..);
         let written_len = encode_one(dst, opt_value, field);
         *offset += written_len;
     }

--- a/polars/polars-utils/src/lib.rs
+++ b/polars/polars-utils/src/lib.rs
@@ -24,5 +24,6 @@ pub mod aliases;
 pub mod fmt;
 pub mod iter;
 pub mod macros;
+pub mod vec;
 #[cfg(target_family = "wasm")]
 pub mod wasm;

--- a/polars/polars-utils/src/vec.rs
+++ b/polars/polars-utils/src/vec.rs
@@ -1,0 +1,17 @@
+pub trait IntoRawParts<T> {
+    fn into_raw_parts(self) -> (*mut T, usize, usize);
+
+    // doesn't take ownership
+    fn raw_parts(&self) -> (*mut T, usize, usize);
+}
+
+impl<T> IntoRawParts<T> for Vec<T> {
+    fn into_raw_parts(self) -> (*mut T, usize, usize) {
+        let mut me = std::mem::ManuallyDrop::new(self);
+        (me.as_mut_ptr(), me.len(), me.capacity())
+    }
+
+    fn raw_parts(&self) -> (*mut T, usize, usize) {
+        (self.as_ptr() as *mut T, self.len(), self.capacity())
+    }
+}

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.1"
-source = "git+https://github.com/jorgecarleitao/arrow2?rev=f46e26cfef09f6355e22af2e13c82fb07859d29f#f46e26cfef09f6355e22af2e13c82fb07859d29f"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=2d2e7053f9a50810bfe9cecff25ab39089aef98e#2d2e7053f9a50810bfe9cecff25ab39089aef98e"
 dependencies = [
  "ahash",
  "arrow-format",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -172,8 +172,8 @@ name = "polars"
 crate-type = ["cdylib"]
 
 [profile.release]
-#codegen-units = 1
-#lto = "fat"
+codegen-units = 1
+lto = "fat"
 
 # This is ignored here; would be set in .cargo/config.toml.
 # Should not be used when packaging

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -172,8 +172,8 @@ name = "polars"
 crate-type = ["cdylib"]
 
 [profile.release]
-codegen-units = 1
-lto = "fat"
+#codegen-units = 1
+#lto = "fat"
 
 # This is ignored here; would be set in .cargo/config.toml.
 # Should not be used when packaging


### PR DESCRIPTION
This looks very promising. The first naive solution which doesn't reuse buffers yet already shows to be 3.7 times faster on a db-benchmark query. 

This query groups by 2 integer keys. I expect the benchmark on strings to perform even better as we elide the string indirection cache misses.

## main
```
 Performance counter stats for './bin/0_18_1 /home/ritchie46/code/db-benchmark/data/G1_1e8_1e2_0_0.ipc 12 true':

         23.026,27 msec task-clock                       #    9,969 CPUs utilized             
             1.486      context-switches                 #   64,535 /sec                      
               108      cpu-migrations                   #    4,690 /sec                      
           867.597      page-faults                      #   37,679 K/sec                     
    81.954.648.691      cpu_core/cycles/                 #    3,559 G/sec                       (39,44%)
    68.795.644.229      cpu_atom/cycles/                 #    2,988 G/sec                       (64,04%)
   107.438.026.937      cpu_core/instructions/           #    4,666 G/sec                       (39,44%)
    91.380.257.702      cpu_atom/instructions/           #    3,969 G/sec                       (64,04%)
    14.752.392.664      cpu_core/branches/               #  640,676 M/sec                       (39,44%)
    12.459.702.825      cpu_atom/branches/               #  541,108 M/sec                       (64,04%)
       106.063.183      cpu_core/branch-misses/          #    4,606 M/sec                       (39,44%)
        93.445.771      cpu_atom/branch-misses/          #    4,058 M/sec                       (64,04%)
   491.727.892.146      cpu_core/slots/                  #   21,355 G/sec                       (39,44%)
   109.368.087.119      cpu_core/topdown-retiring/       #     22,3% Retiring                   (39,44%)
    44.100.356.779      cpu_core/topdown-bad-spec/       #      9,0% Bad Speculation            (39,44%)
    19.172.138.703      cpu_core/topdown-fe-bound/       #      3,9% Frontend Bound             (39,44%)
   318.249.101.705      cpu_core/topdown-be-bound/       #     64,8% Backend Bound              (39,44%)
     7.531.842.616      cpu_core/topdown-heavy-ops/      #      1,5% Heavy Operations          #     20,7% Light Operations           (39,44%)
    19.338.115.002      cpu_core/topdown-br-mispredict/  #      3,9% Branch Mispredict         #      5,0% Machine Clears             (39,44%)
     8.532.895.399      cpu_core/topdown-fetch-lat/      #      1,7% Fetch Latency             #      2,2% Fetch Bandwidth            (39,44%)
   305.363.100.619      cpu_core/topdown-mem-bound/      #     62,2% Memory Bound              #      2,6% Core Bound                 (39,44%)

       2,309736890 seconds time elapsed

      21,821341000 seconds user
       1,207631000 seconds sys
```

## PR

```
 Performance counter stats for './bin/dev /home/ritchie46/code/db-benchmark/data/G1_1e8_1e2_0_0.ipc 12 true':

          5.730,44 msec task-clock                       #    9,156 CPUs utilized             
               485      context-switches                 #   84,636 /sec                      
                40      cpu-migrations                   #    6,980 /sec                      
           660.508      page-faults                      #  115,263 K/sec                     
    22.011.372.603      cpu_core/cycles/                 #    3,841 G/sec                       (38,85%)
    15.849.037.670      cpu_atom/cycles/                 #    2,766 G/sec                       (67,75%)
    56.962.131.133      cpu_core/instructions/           #    9,940 G/sec                       (38,85%)
    21.983.432.578      cpu_atom/instructions/           #    3,836 G/sec                       (67,75%)
     8.505.348.900      cpu_core/branches/               #    1,484 G/sec                       (38,85%)
     3.288.282.193      cpu_atom/branches/               #  573,827 M/sec                       (67,75%)
        27.987.163      cpu_core/branch-misses/          #    4,884 M/sec                       (38,85%)
         6.626.732      cpu_atom/branch-misses/          #    1,156 M/sec                       (67,75%)
   132.068.235.621      cpu_core/slots/                  #   23,047 G/sec                       (38,85%)
    56.565.527.163      cpu_core/topdown-retiring/       #     43,0% Retiring                   (38,85%)
     9.488.750.852      cpu_core/topdown-bad-spec/       #      7,2% Bad Speculation            (38,85%)
     5.650.653.088      cpu_core/topdown-fe-bound/       #      4,3% Frontend Bound             (38,85%)
    59.785.548.749      cpu_core/topdown-be-bound/       #     45,5% Backend Bound              (38,85%)
     3.612.581.335      cpu_core/topdown-heavy-ops/      #      2,7% Heavy Operations          #     40,3% Light Operations           (38,85%)
     8.319.156.615      cpu_core/topdown-br-mispredict/  #      6,3% Branch Mispredict         #      0,9% Machine Clears             (38,85%)
     2.631.928.038      cpu_core/topdown-fetch-lat/      #      2,0% Fetch Latency             #      2,3% Fetch Bandwidth            (38,85%)
    27.896.206.958      cpu_core/topdown-mem-bound/      #     21,2% Memory Bound              #     24,3% Core Bound                 (38,85%)

       0,625867225 seconds time elapsed

       4,535275000 seconds user
       1,198751000 seconds sys
 ```