### PR TITLE
fix(rust, python): raise groupby apply on empty frame

### DIFF
--- a/polars/polars-core/src/frame/groupby/mod.rs
+++ b/polars/polars-core/src/frame/groupby/mod.rs
@@ -774,6 +774,7 @@ impl<'df> GroupBy<'df> {
     }
 
     fn prepare_apply(&self) -> PolarsResult<DataFrame> {
+        polars_ensure!(self.df.height() > 0, ComputeError: "cannot groupby + apply on empty 'DataFrame'");
         if let Some(agg) = &self.selected_agg {
             if agg.is_empty() {
                 Ok(self.df.clone())

--- a/py-polars/tests/unit/test_empty.py
+++ b/py-polars/tests/unit/test_empty.py
@@ -70,3 +70,11 @@ def test_empty_9137() -> None:
     )
     assert out.shape == (0, 2)
     assert out.dtypes == [pl.Float32, pl.Float32]
+
+
+def test_empty_groupby_apply_err() -> None:
+    df = pl.DataFrame(schema={"x": pl.Int64})
+    with pytest.raises(
+        pl.ComputeError, match=r"cannot groupby \+ apply on empty 'DataFrame'"
+    ):
+        df.groupby("x").apply(lambda x: x)


### PR DESCRIPTION
fixes #9348