### PR TITLE
fix(rust, python): respect startby in groupby_dynamic when every is greater than 1d

### DIFF
--- a/polars/tests/it/lazy/groupby_dynamic.rs
+++ b/polars/tests/it/lazy/groupby_dynamic.rs
@@ -50,6 +50,7 @@ fn test_groupby_dynamic_week_bounds() -> PolarsResult<()> {
                 closed_window: ClosedWindow::Left,
                 truncate: false,
                 include_boundaries: true,
+                start_by: StartBy::DataPoint,
                 ..Default::default()
             },
         )

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4989,13 +4989,14 @@ class DataFrame:
             The strategy to determine the start of the first window by.
 
             * 'window': Truncate the start of the window with the 'every' argument.
+              Note that weekly windows start on Monday.
             * 'datapoint': Start from the first encountered data point.
             * a day of the week (only takes effect if `every` contains ``'w'``):
 
-              * 'monday': Start the window on the monday before the first data point.
-              * 'tuesday': Start the window on the tuesday before the first data point.
+              * 'monday': Start the window on the Monday before the first data point.
+              * 'tuesday': Start the window on the Tuesday before the first data point.
               * ...
-              * 'sunday': Start the window on the sunday before the first data point.
+              * 'sunday': Start the window on the Sunday before the first data point.
         check_sorted
             When the ``by`` argument is given, polars can not check sortedness
             by the metadata and has to do a full scan on the index column to

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -41,7 +41,8 @@ class ExprDateTimeNameSpace:
         """
         Divide the date/datetime range into buckets.
 
-        Each date/datetime is mapped to the start of its bucket.
+        Each date/datetime is mapped to the start of its bucket. Note that weekly
+        buckets start on Monday.
 
         Parameters
         ----------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2385,13 +2385,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             The strategy to determine the start of the first window by.
 
             * 'window': Truncate the start of the window with the 'every' argument.
+              Note that weekly windows start on Monday.
             * 'datapoint': Start from the first encountered data point.
             * a day of the week (only takes effect if `every` contains ``'w'``):
 
-              * 'monday': Start the window on the monday before the first data point.
-              * 'tuesday': Start the window on the tuesday before the first data point.
+              * 'monday': Start the window on the Monday before the first data point.
+              * 'tuesday': Start the window on the Tuesday before the first data point.
               * ...
-              * 'sunday': Start the window on the sunday before the first data point.
+              * 'sunday': Start the window on the Sunday before the first data point.
         check_sorted
             When the ``by`` argument is given, polars can not check sortedness
             by the metadata and has to do a full scan on the index column to

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1566,7 +1566,8 @@ class DateTimeNameSpace:
         """
         Divide the date/ datetime range into buckets.
 
-        Each date/datetime is mapped to the start of its bucket.
+        Each date/datetime is mapped to the start of its bucket. Note that weekly
+        buckets start on Monday.
 
         Parameters
         ----------

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -887,23 +887,21 @@ def test_default_negative_every_offset_dynamic_groupby(time_zone: str | None) ->
 
 
 @pytest.mark.parametrize(
-    ("rule", "offset", "start_by"),
+    ("rule", "offset"),
     [
-        ("1h", timedelta(hours=2), "window"),
-        ("1d", timedelta(days=2), "window"),
-        ("1w", timedelta(weeks=2), "sunday"),
+        ("1h", timedelta(hours=2)),
+        ("1d", timedelta(days=2)),
+        ("1w", timedelta(weeks=2)),
     ],
 )
-def test_groupby_dynamic_crossing_dst(
-    rule: str, offset: timedelta, start_by: StartBy
-) -> None:
+def test_groupby_dynamic_crossing_dst(rule: str, offset: timedelta) -> None:
     start_dt = datetime(2021, 11, 7)
     end_dt = start_dt + offset
     date_range = pl.date_range(
         start_dt, end_dt, rule, time_zone="US/Central", eager=True
     )
     df = pl.DataFrame({"time": date_range, "value": range(len(date_range))})
-    result = df.groupby_dynamic("time", every=rule, start_by=start_by).agg(
+    result = df.groupby_dynamic("time", every=rule, start_by="datapoint").agg(
         pl.col("value").mean()
     )
     expected = pl.DataFrame(


### PR DESCRIPTION
closes #9333 

The if-then condition was introduced in https://github.com/pola-rs/polars/pull/2711 - but, as far as I can tell, that was when `groupby_dynamic` didn't have the option to specify `start_by`.
Since `groupby_dynamic` has `start_by`, I think it's a lot simpler to just truncate to the start of the window for `start_by='window'` (and to document what exactly that means for weeks, i.e. Monday) - if anyone wants to start by the first datapoint, as the original poster did in https://github.com/pola-rs/polars/issues/2683, then they can just pass `start_by='datapoint'`