### PR TITLE
fix(rust, python): parquet + categorical

### DIFF
--- a/polars/polars-core/src/frame/mod.rs
+++ b/polars/polars-core/src/frame/mod.rs
@@ -919,7 +919,7 @@ impl DataFrame {
             .zip(other.columns.iter())
             .try_for_each::<_, PolarsResult<_>>(|(left, right)| {
                 ensure_can_extend(left, right)?;
-                left.append(right).expect("should not fail");
+                left.append(right)?;
                 Ok(())
             })?;
         Ok(self)

--- a/polars/polars-io/src/parquet/read_impl.rs
+++ b/polars/polars-io/src/parquet/read_impl.rs
@@ -9,7 +9,7 @@ use arrow::io::parquet::read;
 use arrow::io::parquet::read::{ArrayIter, FileMetaData, RowGroupMetaData};
 use polars_core::prelude::*;
 use polars_core::utils::{accumulate_dataframes_vertical, split_df};
-use polars_core::{IUseStringCache, POOL};
+use polars_core::POOL;
 use rayon::prelude::*;
 
 use super::mmap::ColumnStore;
@@ -253,7 +253,14 @@ pub fn read_parquet<R: MmapBytesReader>(
     // we need a string cache
     // we keep it alive until the end of the function
     let _string_cache = if n_row_groups > 1 {
-        Some(IUseStringCache::new())
+        #[cfg(feature = "dtype-categorical")]
+        {
+            Some(polars_core::IUseStringCache::new())
+        }
+        #[cfg(not(feature = "dtype-categorical"))]
+        {
+            Some(0u8)
+        }
     } else {
         None
     };


### PR DESCRIPTION
If a parquet file has multiple row groups we cannot concat them without setting string cache. This PR automatically sets the string cache when the file has multiple row groups.

fixes #9349