### PR TITLE
Add the ability to read Arrow IPC files containing extension types.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,10 @@ either = "1.8"
 
 [workspace.dependencies.arrow]
 package = "arrow2"
-git = "https://github.com/jorgecarleitao/arrow2"
+# git = "https://github.com/jorgecarleitao/arrow2"
 # git = "https://github.com/ritchie46/arrow2"
-rev = "2d2e7053f9a50810bfe9cecff25ab39089aef98e"
+git = "https://github.com/GPSnoopy/arrow2"
+rev = "2078857f4350df7c8b72d3f62c671e291976a2c2"
 # path = "../arrow2"
 # branch = "polars_2023-05-25"
 version = "0.17"

--- a/polars/polars-core/src/chunked_array/from.rs
+++ b/polars/polars-core/src/chunked_array/from.rs
@@ -90,7 +90,10 @@ where
         #[cfg(debug_assertions)]
         {
             if !chunks.is_empty() && dtype.is_primitive() {
-                assert_eq!(chunks[0].data_type().to_logical_type(), &dtype.to_physical().to_arrow())
+                assert_eq!(
+                    chunks[0].data_type().to_logical_type(),
+                    &dtype.to_physical().to_arrow()
+                )
             }
         }
         let field = Arc::new(Field::new(name, dtype));

--- a/polars/polars-core/src/chunked_array/from.rs
+++ b/polars/polars-core/src/chunked_array/from.rs
@@ -90,7 +90,7 @@ where
         #[cfg(debug_assertions)]
         {
             if !chunks.is_empty() && dtype.is_primitive() {
-                assert_eq!(chunks[0].data_type(), &dtype.to_physical().to_arrow())
+                assert_eq!(chunks[0].data_type().to_logical_type(), &dtype.to_physical().to_arrow())
             }
         }
         let field = Arc::new(Field::new(name, dtype));

--- a/polars/polars-core/src/datatypes/field.rs
+++ b/polars/polars-core/src/datatypes/field.rs
@@ -153,6 +153,7 @@ impl From<&ArrowDataType> for DataType {
                     panic!("activate the 'object' feature to be able to load POLARS_EXTENSION_TYPE")
                 }
             }
+            ArrowDataType::Extension(_, parent_type, _) => parent_type.as_ref().into(),
             #[cfg(feature = "dtype-decimal")]
             ArrowDataType::Decimal(precision, scale) => DataType::Decimal(Some(*precision), Some(*scale)),
             dt => panic!("Arrow datatype {dt:?} not supported by Polars. You probably need to activate that data-type feature."),

--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -331,7 +331,7 @@ impl Series {
                 Ok(s)
             }
             ArrowDataType::Extension(_, parent_type, _) => {
-                try_from_arrow_unchecked(name, chunks, parent_type.as_ref())
+                Self::try_from_arrow_unchecked(name, chunks, parent_type.as_ref())
             }
             #[cfg(feature = "dtype-struct")]
             ArrowDataType::Struct(logical_fields) => {

--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -330,6 +330,9 @@ impl Series {
                 };
                 Ok(s)
             }
+            ArrowDataType::Extension(_, parent_type, _) => {
+                try_from_arrow_unchecked(name, chunks, parent_type.as_ref())
+            }
             #[cfg(feature = "dtype-struct")]
             ArrowDataType::Struct(logical_fields) => {
                 // We don't have to convert inner types, as that already


### PR DESCRIPTION
Fixes #9373.

This depends on https://github.com/jorgecarleitao/arrow2/pull/1508, which ought to be merged first such that this PR can be amended with the correct git dependencies.

Probably ought to have at least some unit tests? Happy to do so if pointed in the right direction (as a separate PR or as part of this PR).