### PR TITLE
feat(python): allow easy load/save of polars `Config` options to/from file

### DIFF
--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -161,7 +161,9 @@ class Config(contextlib.ContextDecorator):
 
         """
         options = json.loads(
-            Path(normalise_filepath(cfg)).read_text() if os.path.exists(cfg) else cfg
+            Path(normalise_filepath(cfg)).read_text()
+            if os.path.exists(cfg) or isinstance(cfg, Path)
+            else cfg
         )
         os.environ.update(options.get("environment", {}))
         for cfg_methodname, value in options.get("direct", {}).items():

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import contextlib
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from polars.dependencies import json
+from polars.utils.various import normalise_filepath
 
 
 # dummy func required (so docs build)
@@ -19,6 +21,7 @@ with contextlib.suppress(ImportError):
 
 if TYPE_CHECKING:
     import sys
+    from io import IOBase
     from types import TracebackType
 
     from polars.type_aliases import FloatFmt
@@ -147,17 +150,19 @@ class Config(contextlib.ContextDecorator):
         self._original_state = ""
 
     @classmethod
-    def load(cls, cfg: str) -> type[Config]:
+    def load(cls, cfg: Path | str) -> type[Config]:
         """
-        Load and set previously saved (or shared) Config options.
+        Load and set previously saved (or shared) Config options from json/file.
 
         Parameters
         ----------
         cfg : str
-            json string produced by ``Config.save()``.
+            json string produced by ``Config.save()``, or a filepath to the same.
 
         """
-        options = json.loads(cfg)
+        options = json.loads(
+            Path(normalise_filepath(cfg)).read_text() if os.path.exists(cfg) else cfg
+        )
         os.environ.update(options.get("environment", {}))
         for cfg_methodname, value in options.get("direct", {}).items():
             if hasattr(cls, cfg_methodname):
@@ -188,13 +193,22 @@ class Config(contextlib.ContextDecorator):
         return cls
 
     @classmethod
-    def save(cls) -> str:
+    def save(cls, file: IOBase | Path | str | None = None) -> str:
         """
-        Save the current set of Config options as a json string.
+        Save the current set of Config options as a json string or file.
+
+        Parameters
+        ----------
+        file
+            optional path to a file into which the json string will be written.
 
         Examples
         --------
         >>> cfg = pl.Config.save()
+
+        Returns
+        -------
+        str : json string containing current Config options, or filepath where saved.
 
         """
         environment_vars = {
@@ -206,10 +220,16 @@ class Config(contextlib.ContextDecorator):
             cfg_methodname: get_value()
             for cfg_methodname, get_value in _POLARS_CFG_DIRECT_VARS.items()
         }
-        return json.dumps(
+        options = json.dumps(
             {"environment": environment_vars, "direct": direct_vars},
             separators=(",", ":"),
         )
+        if isinstance(file, (str, Path)):
+            file = os.path.abspath(normalise_filepath(file))
+            Path(file).write_text(options)
+            return file
+
+        return options
 
     @classmethod
     def state(


### PR DESCRIPTION
Allows the existing `load` and `save` methods to take a filepath.

## Example

```python
import polars as pl

pl.Config.state(True)
# {'POLARS_FMT_MAX_COLS': '12',
#  'POLARS_TABLE_WIDTH': '205',
#  'set_fmt_float': 'mixed'}

saved_config = pl.Config.save("polars.config")
# '/Users/.../polars/polars.config'

pl.Config.load( saved_config )
# polars.config.Config
```
```python
with open(saved_config) as cfg:
    print( cfg.read() )
    
# {"environment":{"POLARS_FMT_MAX_COLS":"12","POLARS_TABLE_WIDTH":"205"},"direct":{"set_fmt_float":"mixed"}}
```