### PR TITLE
fix(rust, python): Fix rolling min/max when window is empty

### DIFF
--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
@@ -139,14 +139,14 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNoNulls<'a, T> fo
 
         let entering_start = std::cmp::max(old_last_end, start);
         let entering = get_max_and_idx(self.slice, entering_start, end);
-        let emtpy_overlap = old_last_end < start;
+        let empty_overlap = old_last_end < start;
 
-        if entering.is_some_and(|em| compare_fn_nan_max(&self.max, em.1).is_le() || emtpy_overlap) {
+        if entering.is_some_and(|em| compare_fn_nan_max(&self.max, em.1).is_le() || empty_overlap) {
             // If the entering max >= the current max return early, since no value in the overlap can be larger than either.
             self.max = *entering.unwrap().1;
             self.max_idx = entering_start + entering.unwrap().0;
             return self.max;
-        } else if self.max_idx >= start || emtpy_overlap {
+        } else if self.max_idx >= start || empty_overlap {
             // If the entering max isn't the largest but the current max is between start and end we can still ignore the overlap
             return self.max;
         }

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
@@ -42,12 +42,8 @@ pub struct MinWindow<'a, T: NativeType + PartialOrd + IsFloat> {
 
 impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNoNulls<'a, T> for MinWindow<'a, T> {
     fn new(slice: &'a [T], start: usize, end: usize, _params: DynArgs) -> Self {
-        let (idx, min) = slice[start..end]
-            .iter()
-            .enumerate()
-            .rev()
-            .min_by(|&a, &b| compare_fn_nan_min(a.1, b.1))
-            .unwrap_or((0, &slice[start]));
+        let (idx, min) =
+            unsafe { get_min_and_idx(slice, start, end).unwrap_or((0, &slice[start])) };
         Self {
             slice,
             min: *min,
@@ -71,7 +67,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNoNulls<'a, T> fo
             self.min = *entering.unwrap().1;
             self.min_idx = entering_start + entering.unwrap().0;
             return self.min;
-        } else if self.min_idx >= start {
+        } else if self.min_idx >= start || old_last_end < start {
             // If the entering min isn't the smallest but the current min is between start and end we can still ignore the overlap
             return self.min;
         }
@@ -124,11 +120,8 @@ pub struct MaxWindow<'a, T: NativeType> {
 
 impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNoNulls<'a, T> for MaxWindow<'a, T> {
     fn new(slice: &'a [T], start: usize, end: usize, _params: DynArgs) -> Self {
-        let (idx, max) = slice[start..end]
-            .iter()
-            .enumerate()
-            .max_by(|&a, &b| compare_fn_nan_max(a.1, b.1))
-            .unwrap_or((0, &slice[start]));
+        let (idx, max) =
+            unsafe { get_max_and_idx(slice, start, end).unwrap_or((0, &slice[start])) };
         Self {
             slice,
             max: *max,
@@ -151,7 +144,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNoNulls<'a, T> fo
             self.max = *entering.unwrap().1;
             self.max_idx = entering_start + entering.unwrap().0;
             return self.max;
-        } else if self.max_idx >= start {
+        } else if self.max_idx >= start || old_last_end < start {
             // If the entering max isn't the largest but the current max is between start and end we can still ignore the overlap
             return self.max;
         }

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
@@ -61,13 +61,14 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNoNulls<'a, T> fo
 
         let entering_start = std::cmp::max(old_last_end, start);
         let entering = get_min_and_idx(self.slice, entering_start, end);
+        let empty_overlap = old_last_end <= start;
 
-        if entering.is_some_and(|em| compare_fn_nan_min(&self.min, em.1).is_ge()) {
+        if entering.is_some_and(|em| compare_fn_nan_min(&self.min, em.1).is_ge() || empty_overlap) {
             // If the entering min <= the current min return early, since no value in the overlap can be smaller than either.
             self.min = *entering.unwrap().1;
             self.min_idx = entering_start + entering.unwrap().0;
             return self.min;
-        } else if self.min_idx >= start || old_last_end < start {
+        } else if self.min_idx >= start || empty_overlap {
             // If the entering min isn't the smallest but the current min is between start and end we can still ignore the overlap
             return self.min;
         }
@@ -138,13 +139,14 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNoNulls<'a, T> fo
 
         let entering_start = std::cmp::max(old_last_end, start);
         let entering = get_max_and_idx(self.slice, entering_start, end);
+        let emtpy_overlap = old_last_end < start;
 
-        if entering.is_some_and(|em| compare_fn_nan_max(&self.max, em.1).is_le()) {
+        if entering.is_some_and(|em| compare_fn_nan_max(&self.max, em.1).is_le() || emtpy_overlap) {
             // If the entering max >= the current max return early, since no value in the overlap can be larger than either.
             self.max = *entering.unwrap().1;
             self.max_idx = entering_start + entering.unwrap().0;
             return self.max;
-        } else if self.max_idx >= start || old_last_end < start {
+        } else if self.max_idx >= start || emtpy_overlap {
             // If the entering max isn't the largest but the current max is between start and end we can still ignore the overlap
             return self.max;
         }

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -658,3 +658,23 @@ def test_rolling_window_size_9160() -> None:
     assert pl.Series([1]).rolling_apply(
         lambda x: sum(x), window_size=2, min_periods=1
     ).to_list() == [1]
+
+def test_rolling_empty_window_9406() -> None:
+    datecol = pl.Series("d", [datetime(2019, 1, x) for x in [16, 17, 18, 22, 23]],
+                        dtype=pl.Datetime(time_unit='us', time_zone=None))
+    rawdata = pl.Series("x", [1.1, 1.2, 1.3, 1.15, 1.25], dtype=pl.Float64)
+    rmin = pl.Series("x", [None, 1.1, 1.1, None, 1.15], dtype=pl.Float64)
+    rmax = pl.Series("x", [None, 1.1, 1.2, None, 1.15], dtype=pl.Float64)
+    df = pl.DataFrame([datecol, rawdata])
+    
+    assert_frame_equal(
+        pl.DataFrame([datecol, rmax]),
+        df.select([pl.col("d"), pl.col("x").rolling_max(by='d', window_size='3d', closed = 'left')])
+    )
+    assert_frame_equal(
+        pl.DataFrame([datecol, rmin]),
+        df.select([pl.col("d"), pl.col("x").rolling_min(by='d', window_size='3d', closed = 'left')])
+    )
+    
+
+    

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -659,22 +659,33 @@ def test_rolling_window_size_9160() -> None:
         lambda x: sum(x), window_size=2, min_periods=1
     ).to_list() == [1]
 
+
 def test_rolling_empty_window_9406() -> None:
-    datecol = pl.Series("d", [datetime(2019, 1, x) for x in [16, 17, 18, 22, 23]],
-                        dtype=pl.Datetime(time_unit='us', time_zone=None))
+    datecol = pl.Series(
+        "d",
+        [datetime(2019, 1, x) for x in [16, 17, 18, 22, 23]],
+        dtype=pl.Datetime(time_unit="us", time_zone=None),
+    )
     rawdata = pl.Series("x", [1.1, 1.2, 1.3, 1.15, 1.25], dtype=pl.Float64)
     rmin = pl.Series("x", [None, 1.1, 1.1, None, 1.15], dtype=pl.Float64)
     rmax = pl.Series("x", [None, 1.1, 1.2, None, 1.15], dtype=pl.Float64)
     df = pl.DataFrame([datecol, rawdata])
-    
+
     assert_frame_equal(
         pl.DataFrame([datecol, rmax]),
-        df.select([pl.col("d"), pl.col("x").rolling_max(by='d', window_size='3d', closed = 'left')])
+        df.select(
+            [
+                pl.col("d"),
+                pl.col("x").rolling_max(by="d", window_size="3d", closed="left"),
+            ]
+        ),
     )
     assert_frame_equal(
         pl.DataFrame([datecol, rmin]),
-        df.select([pl.col("d"), pl.col("x").rolling_min(by='d', window_size='3d', closed = 'left')])
+        df.select(
+            [
+                pl.col("d"),
+                pl.col("x").rolling_min(by="d", window_size="3d", closed="left"),
+            ]
+        ),
     )
-    
-
-    


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/9403
When the window to compute over was empty, rolling min and max could segfault by calling `get_unchecked` for a range where the left endpoint was larger than the right.