### PR TITLE
feat(rust, python): dont error for time-zone-aware parsing if time zone is UTC

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/strings.rs
@@ -406,12 +406,14 @@ fn to_datetime(
         Some(format) => TZ_AWARE_RE.is_match(format),
         _ => false,
     };
-    if let (Some(_), true) = (time_zone, tz_aware) {
-        polars_bail!(
-            ComputeError:
-            "cannot use strptime with both a tz-aware format and a tz-aware dtype, \
-            please drop time zone from the dtype"
-        )
+    if let (Some(tz), true) = (time_zone, tz_aware) {
+        if tz != "UTC" {
+            polars_bail!(
+                ComputeError:
+                "if using strftime/to_datetime with a time-zone-aware format, the output will be in UTC. Please either drop the time zone from the function call, or set it to UTC. \
+                If you are trying to convert the output to a different time zone, please use `convert_time_zone`."
+            )
+        }
     };
 
     let ca = s.utf8()?;

--- a/polars/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/infer.rs
@@ -458,8 +458,13 @@ pub(crate) fn to_datetime(
                 (TimeUnit::Microseconds, _) => infer.transform = transform_datetime_us,
                 (TimeUnit::Milliseconds, _) => infer.transform = transform_datetime_ms,
             }
-            if tz.is_some() && pattern == Pattern::DatetimeYMDZ {
-                polars_bail!(ComputeError: "cannot parse tz-aware values with tz-aware dtype - please drop the time zone from the dtype.")
+            if pattern == Pattern::DatetimeYMDZ
+                && tz.is_some()
+                && tz.map(|x| x.as_str()) != Some("UTC")
+            {
+                polars_bail!(ComputeError: "offset-aware datetimes are converted to UTC. \
+                    Please either drop the time zone from the function call, or set it to UTC. \
+                    To convert to a different time zone, please use `convert_time_zone`.")
             }
             match pattern {
                 #[cfg(feature = "timezones")]

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1211,10 +1211,13 @@ def lit(
             if getattr(dtype, "time_zone", None) is None
             else getattr(dtype, "time_zone", None)
         )
-        if value.tzinfo is not None and getattr(dtype, "time_zone", None) is not None:
+        if (
+            value.tzinfo is not None
+            and getattr(dtype, "time_zone", None) is not None
+            and dtype.time_zone != str(value.tzinfo)  # type: ignore[union-attr]
+        ):
             raise TypeError(
-                "Cannot cast tz-aware value to tz-aware dtype. "
-                "Please drop the time zone from the dtype."
+                f"Time zone of dtype ({dtype.time_zone}) differs from time zone of value ({value.tzinfo})."  # type: ignore[union-attr]
             )
         e = lit(_datetime_to_pl_timestamp(value, time_unit)).cast(Datetime(time_unit))
         if time_zone is not None:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1929,7 +1929,7 @@ def test_strptime_with_invalid_tz() -> None:
         pl.Series(["2020-01-01 03:00:00"]).str.strptime(pl.Datetime("us", "foo"))
     with pytest.raises(
         ComputeError,
-        match="cannot use strptime with both a tz-aware format and a tz-aware dtype",
+        match="Please either drop the time zone from the function call, or set it to UTC",
     ):
         pl.Series(["2020-01-01 03:00:00+01:00"]).str.strptime(
             pl.Datetime("us", "foo"), "%Y-%m-%d %H:%M:%S%z"

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -269,11 +269,37 @@ def test_infer_tz_aware_with_utc(time_unit: TimeUnit) -> None:
 
 
 def test_infer_tz_aware_raises() -> None:
-    msg = "cannot parse tz-aware values with tz-aware dtype - please drop the time zone from the dtype"
+    msg = "Please either drop the time zone from the function call, or set it to UTC"
     with pytest.raises(ComputeError, match=msg):
         pl.Series(["2020-01-02T04:00:00+02:00"]).str.to_datetime(
             time_unit="us", time_zone="Europe/Vienna"
         )
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        pl.Series(["2020-01-01T00:00:00+00:00"]).str.strptime(
+            pl.Datetime("us", "UTC"), format="%Y-%m-%dT%H:%M:%S%z"
+        ),
+        pl.Series(["2020-01-01T00:00:00+00:00"]).str.strptime(
+            pl.Datetime("us"), format="%Y-%m-%dT%H:%M:%S%z"
+        ),
+        pl.Series(["2020-01-01T00:00:00+00:00"]).str.strptime(pl.Datetime("us", "UTC")),
+        pl.Series(["2020-01-01T00:00:00+00:00"]).str.strptime(pl.Datetime("us")),
+        pl.Series(["2020-01-01T00:00:00+00:00"]).str.to_datetime(
+            time_zone="UTC", format="%Y-%m-%dT%H:%M:%S%z"
+        ),
+        pl.Series(["2020-01-01T00:00:00+00:00"]).str.to_datetime(
+            format="%Y-%m-%dT%H:%M:%S%z"
+        ),
+        pl.Series(["2020-01-01T00:00:00+00:00"]).str.to_datetime(time_zone="UTC"),
+        pl.Series(["2020-01-01T00:00:00+00:00"]).str.to_datetime(),
+    ],
+)
+def test_parsing_offset_aware_with_utc_dtype(result: pl.Series) -> None:
+    expected = pl.Series([datetime(2020, 1, 1, tzinfo=timezone.utc)])
+    assert_series_equal(result, expected)
 
 
 def test_datetime_strptime_patterns_consistent() -> None:


### PR DESCRIPTION
Improving ergonomics a bit, following up on this comment https://github.com/pola-rs/polars/pull/9171#discussion_r1213751236

In short:

latest release:
```python
In [2]: print(pl.Series(["2020-01-01T00:00:00+00:00"]).str.strptime(pl.Datetime("us", "UTC")))
---------------------------------------------------------------------------
ComputeError: cannot parse tz-aware values with tz-aware dtype - please drop the time zone from the dtype.
```

here:
```python
In [1]: print(pl.Series(["2020-01-01T00:00:00+00:00"]).str.strptime(pl.Datetime("us", "UTC")))
shape: (1,)
Series: '' [datetime[μs, UTC]]
[
        2020-01-01 00:00:00 UTC
]
```