### PR TITLE
doc(python): Fix sample output show_versions

### DIFF
--- a/py-polars/polars/utils/show_versions.py
+++ b/py-polars/polars/utils/show_versions.py
@@ -18,7 +18,7 @@ def show_versions() -> None:
     Index type:  UInt32
     Platform:    Linux-5.15.90.1-microsoft-standard-WSL2-x86_64-with-glibc2.35
     Python:      3.11.3 (main, Apr 15 2023, 14:44:51) [GCC 11.3.0]
-
+    \b
     ----Optional dependencies----
     numpy:       1.24.2
     pandas:      2.0.0

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -165,6 +165,7 @@ strict = true
 [tool.ruff.per-file-ignores]
 "polars/datatypes.py" = ["B019"]
 "tests/**/*.py" = ["D100", "D103", "B018"]
+"polars/utils/show_versions.py" = ["D301"]
 
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
The empty line of the output is interpreted as the end of the output block, which leads to a broken docstring: https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.show_versions.html

Using a backspace \b works around this (newline and tab did not work).