### PR TITLE
doc(python): Remove setting behavior from LazyFrame.columns

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -563,7 +563,7 @@ class LazyFrame:
     @property
     def columns(self) -> list[str]:
         """
-        Get or set column names.
+        Get column names.
 
         Examples
         --------


### PR DESCRIPTION
Fixing docstring, columns not implemented with @property.setter in LazyFrame class