### PR TITLE
fix(rust, python): read_csv was parsing dates incorrectly when the dtype was overridden

### DIFF
--- a/polars/polars-io/src/csv/buffer.rs
+++ b/polars/polars-io/src/csv/buffer.rs
@@ -60,10 +60,10 @@ trait ParsedBuffer {
     fn parse_bytes(
         &mut self,
         bytes: &[u8],
-        time_unit: Option<TimeUnit>,
         ignore_errors: bool,
         _needs_escaping: bool,
         _missing_is_null: bool,
+        _time_unit: Option<TimeUnit>,
     ) -> PolarsResult<()>;
 }
 
@@ -75,10 +75,10 @@ where
     fn parse_bytes(
         &mut self,
         bytes: &[u8],
-        _time_unit: Option<TimeUnit>,
         ignore_errors: bool,
         needs_escaping: bool,
         _missing_is_null: bool,
+        _time_unit: Option<TimeUnit>,
     ) -> PolarsResult<()> {
         if bytes.is_empty() {
             self.append_null()
@@ -101,10 +101,10 @@ where
                         let bytes = skip_whitespace(bytes);
                         return self.parse_bytes(
                             bytes,
-                            None,
                             ignore_errors,
                             false, // escaping was already done
                             _missing_is_null,
+                            None,
                         );
                     }
                     polars_ensure!(
@@ -171,10 +171,10 @@ impl ParsedBuffer for Utf8Field {
     fn parse_bytes(
         &mut self,
         bytes: &[u8],
-        _time_unit: Option<TimeUnit>,
         ignore_errors: bool,
         needs_escaping: bool,
         missing_is_null: bool,
+        _time_unit: Option<TimeUnit>,
     ) -> PolarsResult<()> {
         if bytes.is_empty() {
             // append null
@@ -280,10 +280,10 @@ impl<'a> CategoricalField<'a> {
     fn parse_bytes(
         &mut self,
         bytes: &'a [u8],
-        _time_unit: Option<TimeUnit>,
         ignore_errors: bool,
         needs_escaping: bool,
         _missing_is_null: bool,
+        _time_unit: Option<TimeUnit>,
     ) -> PolarsResult<()> {
         if bytes.is_empty() {
             self.builder.append_null();
@@ -364,10 +364,10 @@ impl ParsedBuffer for BooleanChunkedBuilder {
     fn parse_bytes(
         &mut self,
         bytes: &[u8],
-        _time_unit: Option<TimeUnit>,
         ignore_errors: bool,
         needs_escaping: bool,
         _missing_is_null: bool,
+        _time_unit: Option<TimeUnit>,
     ) -> PolarsResult<()> {
         let bytes = if needs_escaping {
             &bytes[1..bytes.len() - 1]
@@ -466,10 +466,10 @@ where
     fn parse_bytes(
         &mut self,
         mut bytes: &[u8],
-        time_unit: Option<TimeUnit>,
         ignore_errors: bool,
         needs_escaping: bool,
         _missing_is_null: bool,
+        time_unit: Option<TimeUnit>,
     ) -> PolarsResult<()> {
         if needs_escaping && bytes.len() > 2 {
             bytes = &bytes[1..bytes.len() - 1]
@@ -734,92 +734,92 @@ impl<'a> Buffer<'a> {
             Boolean(buf) => <BooleanChunkedBuilder as ParsedBuffer>::parse_bytes(
                 buf,
                 bytes,
-                None,
                 ignore_errors,
                 needs_escaping,
                 missing_is_null,
+                None,
             ),
             Int32(buf) => <PrimitiveChunkedBuilder<Int32Type> as ParsedBuffer>::parse_bytes(
                 buf,
                 bytes,
-                None,
                 ignore_errors,
                 needs_escaping,
                 missing_is_null,
+                None,
             ),
             Int64(buf) => <PrimitiveChunkedBuilder<Int64Type> as ParsedBuffer>::parse_bytes(
                 buf,
                 bytes,
-                None,
                 ignore_errors,
                 needs_escaping,
                 missing_is_null,
+                None,
             ),
             UInt64(buf) => <PrimitiveChunkedBuilder<UInt64Type> as ParsedBuffer>::parse_bytes(
                 buf,
                 bytes,
-                None,
                 ignore_errors,
                 needs_escaping,
                 missing_is_null,
+                None,
             ),
             UInt32(buf) => <PrimitiveChunkedBuilder<UInt32Type> as ParsedBuffer>::parse_bytes(
                 buf,
                 bytes,
-                None,
                 ignore_errors,
                 needs_escaping,
                 missing_is_null,
+                None,
             ),
             Float32(buf) => <PrimitiveChunkedBuilder<Float32Type> as ParsedBuffer>::parse_bytes(
                 buf,
                 bytes,
-                None,
                 ignore_errors,
                 needs_escaping,
                 missing_is_null,
+                None,
             ),
             Float64(buf) => <PrimitiveChunkedBuilder<Float64Type> as ParsedBuffer>::parse_bytes(
                 buf,
                 bytes,
-                None,
                 ignore_errors,
                 needs_escaping,
                 missing_is_null,
+                None,
             ),
             Utf8(buf) => <Utf8Field as ParsedBuffer>::parse_bytes(
                 buf,
                 bytes,
-                None,
                 ignore_errors,
                 needs_escaping,
                 missing_is_null,
+                None,
             ),
             #[cfg(feature = "dtype-datetime")]
             Datetime { buf, time_unit, .. } => {
                 <DatetimeField<Int64Type> as ParsedBuffer>::parse_bytes(
                     buf,
                     bytes,
-                    Some(*time_unit),
                     ignore_errors,
                     needs_escaping,
                     missing_is_null,
+                    Some(*time_unit),
                 )
             }
             #[cfg(feature = "dtype-date")]
             Date(buf) => <DatetimeField<Int32Type> as ParsedBuffer>::parse_bytes(
                 buf,
                 bytes,
-                None,
                 ignore_errors,
                 needs_escaping,
                 missing_is_null,
+                None,
             ),
             #[allow(unused_variables)]
             Categorical(buf) => {
                 #[cfg(feature = "dtype-categorical")]
                 {
-                    buf.parse_bytes(bytes, None, ignore_errors, needs_escaping, missing_is_null)
+                    buf.parse_bytes(bytes, ignore_errors, needs_escaping, missing_is_null, None)
                 }
 
                 #[cfg(not(feature = "dtype-categorical"))]

--- a/polars/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/infer.rs
@@ -146,7 +146,7 @@ impl StrpTimeParser<i64> for DatetimeInfer<i64> {
         if self.fmt_len == 0 {
             self.fmt_len = strptime::fmt_len(self.latest_fmt.as_bytes())?;
         }
-        let transform_fn = match time_unit {
+        let transform = match time_unit {
             Some(TimeUnit::Nanoseconds) => datetime_to_timestamp_ns,
             Some(TimeUnit::Microseconds) => datetime_to_timestamp_us,
             Some(TimeUnit::Milliseconds) => datetime_to_timestamp_ms,
@@ -155,7 +155,7 @@ impl StrpTimeParser<i64> for DatetimeInfer<i64> {
         unsafe {
             self.transform_bytes
                 .parse(val, self.latest_fmt.as_bytes(), self.fmt_len)
-                .map(transform_fn)
+                .map(transform)
                 .or_else(|| {
                     // TODO! this will try all patterns.
                     // somehow we must early escape if value is invalid

--- a/polars/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/infer.rs
@@ -137,19 +137,25 @@ impl Pattern {
 }
 
 pub trait StrpTimeParser<T> {
-    fn parse_bytes(&mut self, val: &[u8]) -> Option<T>;
+    fn parse_bytes(&mut self, val: &[u8], time_unit: Option<TimeUnit>) -> Option<T>;
 }
 
 #[cfg(feature = "dtype-datetime")]
 impl StrpTimeParser<i64> for DatetimeInfer<i64> {
-    fn parse_bytes(&mut self, val: &[u8]) -> Option<i64> {
+    fn parse_bytes(&mut self, val: &[u8], time_unit: Option<TimeUnit>) -> Option<i64> {
         if self.fmt_len == 0 {
             self.fmt_len = strptime::fmt_len(self.latest_fmt.as_bytes())?;
         }
+        let transform_fn = match time_unit {
+            Some(TimeUnit::Nanoseconds) => datetime_to_timestamp_ns,
+            Some(TimeUnit::Microseconds) => datetime_to_timestamp_us,
+            Some(TimeUnit::Milliseconds) => datetime_to_timestamp_ms,
+            _ => unreachable!(), // time_unit has to be provided for datetime
+        };
         unsafe {
             self.transform_bytes
                 .parse(val, self.latest_fmt.as_bytes(), self.fmt_len)
-                .map(datetime_to_timestamp_us)
+                .map(transform_fn)
                 .or_else(|| {
                     // TODO! this will try all patterns.
                     // somehow we must early escape if value is invalid
@@ -174,7 +180,7 @@ impl StrpTimeParser<i64> for DatetimeInfer<i64> {
 
 #[cfg(feature = "dtype-date")]
 impl StrpTimeParser<i32> for DatetimeInfer<i32> {
-    fn parse_bytes(&mut self, val: &[u8]) -> Option<i32> {
+    fn parse_bytes(&mut self, val: &[u8], _time_unit: Option<TimeUnit>) -> Option<i32> {
         if self.fmt_len == 0 {
             self.fmt_len = strptime::fmt_len(self.latest_fmt.as_bytes())?;
         }
@@ -215,13 +221,28 @@ pub struct DatetimeInfer<T> {
     pub logical_type: DataType,
 }
 
+pub trait TryFromWithUnit<T>: Sized {
+    type Error;
+    fn try_from_with_unit(pattern: T, unit: Option<TimeUnit>) -> PolarsResult<Self>;
+}
+
 #[cfg(feature = "dtype-datetime")]
-impl TryFrom<Pattern> for DatetimeInfer<i64> {
+impl TryFromWithUnit<Pattern> for DatetimeInfer<i64> {
     type Error = PolarsError;
 
-    fn try_from(value: Pattern) -> PolarsResult<Self> {
-        match value {
-            Pattern::DatetimeDMY => Ok(DatetimeInfer {
+    fn try_from_with_unit(value: Pattern, time_unit: Option<TimeUnit>) -> PolarsResult<Self> {
+        let time_unit = time_unit.expect("time_unit must be provided for datetime");
+        match (value, time_unit) {
+            (Pattern::DatetimeDMY, TimeUnit::Milliseconds) => Ok(DatetimeInfer {
+                pattern: Pattern::DatetimeDMY,
+                patterns: patterns::DATETIME_D_M_Y,
+                latest_fmt: patterns::DATETIME_D_M_Y[0],
+                transform: transform_datetime_ms,
+                transform_bytes: StrpTimeState::default(),
+                fmt_len: 0,
+                logical_type: DataType::Datetime(TimeUnit::Milliseconds, None),
+            }),
+            (Pattern::DatetimeDMY, TimeUnit::Microseconds) => Ok(DatetimeInfer {
                 pattern: Pattern::DatetimeDMY,
                 patterns: patterns::DATETIME_D_M_Y,
                 latest_fmt: patterns::DATETIME_D_M_Y[0],
@@ -230,7 +251,25 @@ impl TryFrom<Pattern> for DatetimeInfer<i64> {
                 fmt_len: 0,
                 logical_type: DataType::Datetime(TimeUnit::Microseconds, None),
             }),
-            Pattern::DatetimeYMD => Ok(DatetimeInfer {
+            (Pattern::DatetimeDMY, TimeUnit::Nanoseconds) => Ok(DatetimeInfer {
+                pattern: Pattern::DatetimeDMY,
+                patterns: patterns::DATETIME_D_M_Y,
+                latest_fmt: patterns::DATETIME_D_M_Y[0],
+                transform: transform_datetime_ns,
+                transform_bytes: StrpTimeState::default(),
+                fmt_len: 0,
+                logical_type: DataType::Datetime(TimeUnit::Nanoseconds, None),
+            }),
+            (Pattern::DatetimeYMD, TimeUnit::Milliseconds) => Ok(DatetimeInfer {
+                pattern: Pattern::DatetimeYMD,
+                patterns: patterns::DATETIME_Y_M_D,
+                latest_fmt: patterns::DATETIME_Y_M_D[0],
+                transform: transform_datetime_ms,
+                transform_bytes: StrpTimeState::default(),
+                fmt_len: 0,
+                logical_type: DataType::Datetime(TimeUnit::Milliseconds, None),
+            }),
+            (Pattern::DatetimeYMD, TimeUnit::Microseconds) => Ok(DatetimeInfer {
                 pattern: Pattern::DatetimeYMD,
                 patterns: patterns::DATETIME_Y_M_D,
                 latest_fmt: patterns::DATETIME_Y_M_D[0],
@@ -239,7 +278,25 @@ impl TryFrom<Pattern> for DatetimeInfer<i64> {
                 fmt_len: 0,
                 logical_type: DataType::Datetime(TimeUnit::Microseconds, None),
             }),
-            Pattern::DatetimeYMDZ => Ok(DatetimeInfer {
+            (Pattern::DatetimeYMD, TimeUnit::Nanoseconds) => Ok(DatetimeInfer {
+                pattern: Pattern::DatetimeYMD,
+                patterns: patterns::DATETIME_Y_M_D,
+                latest_fmt: patterns::DATETIME_Y_M_D[0],
+                transform: transform_datetime_ns,
+                transform_bytes: StrpTimeState::default(),
+                fmt_len: 0,
+                logical_type: DataType::Datetime(TimeUnit::Nanoseconds, None),
+            }),
+            (Pattern::DatetimeYMDZ, TimeUnit::Milliseconds) => Ok(DatetimeInfer {
+                pattern: Pattern::DatetimeYMDZ,
+                patterns: patterns::DATETIME_Y_M_D_Z,
+                latest_fmt: patterns::DATETIME_Y_M_D_Z[0],
+                transform: transform_tzaware_datetime_ms,
+                transform_bytes: StrpTimeState::default(),
+                fmt_len: 0,
+                logical_type: DataType::Datetime(TimeUnit::Milliseconds, None),
+            }),
+            (Pattern::DatetimeYMDZ, TimeUnit::Microseconds) => Ok(DatetimeInfer {
                 pattern: Pattern::DatetimeYMDZ,
                 patterns: patterns::DATETIME_Y_M_D_Z,
                 latest_fmt: patterns::DATETIME_Y_M_D_Z[0],
@@ -248,16 +305,25 @@ impl TryFrom<Pattern> for DatetimeInfer<i64> {
                 fmt_len: 0,
                 logical_type: DataType::Datetime(TimeUnit::Microseconds, None),
             }),
+            (Pattern::DatetimeYMDZ, TimeUnit::Nanoseconds) => Ok(DatetimeInfer {
+                pattern: Pattern::DatetimeYMDZ,
+                patterns: patterns::DATETIME_Y_M_D_Z,
+                latest_fmt: patterns::DATETIME_Y_M_D_Z[0],
+                transform: transform_tzaware_datetime_ns,
+                transform_bytes: StrpTimeState::default(),
+                fmt_len: 0,
+                logical_type: DataType::Datetime(TimeUnit::Nanoseconds, None),
+            }),
             _ => polars_bail!(ComputeError: "could not convert pattern"),
         }
     }
 }
 
 #[cfg(feature = "dtype-date")]
-impl TryFrom<Pattern> for DatetimeInfer<i32> {
+impl TryFromWithUnit<Pattern> for DatetimeInfer<i32> {
     type Error = PolarsError;
 
-    fn try_from(value: Pattern) -> PolarsResult<Self> {
+    fn try_from_with_unit(value: Pattern, _time_unit: Option<TimeUnit>) -> PolarsResult<Self> {
         match value {
             Pattern::DateDMY => Ok(DatetimeInfer {
                 pattern: Pattern::DateDMY,
@@ -443,21 +509,7 @@ pub(crate) fn to_datetime(
                 .into_iter()
                 .find_map(|opt_val| opt_val.and_then(infer_pattern_datetime_single))
                 .ok_or_else(|| polars_err!(parse_fmt_idk = "date"))?;
-            let mut infer = DatetimeInfer::<i64>::try_from(pattern)?;
-            match (tu, pattern) {
-                (TimeUnit::Nanoseconds, Pattern::DatetimeYMDZ) => {
-                    infer.transform = transform_tzaware_datetime_ns
-                }
-                (TimeUnit::Microseconds, Pattern::DatetimeYMDZ) => {
-                    infer.transform = transform_tzaware_datetime_us
-                }
-                (TimeUnit::Milliseconds, Pattern::DatetimeYMDZ) => {
-                    infer.transform = transform_tzaware_datetime_ms
-                }
-                (TimeUnit::Nanoseconds, _) => infer.transform = transform_datetime_ns,
-                (TimeUnit::Microseconds, _) => infer.transform = transform_datetime_us,
-                (TimeUnit::Milliseconds, _) => infer.transform = transform_datetime_ms,
-            }
+            let mut infer = DatetimeInfer::<i64>::try_from_with_unit(pattern, Some(tu))?;
             if tz.is_some() && pattern == Pattern::DatetimeYMDZ {
                 polars_bail!(ComputeError: "cannot parse tz-aware values with tz-aware dtype - please drop the time zone from the dtype.")
             }
@@ -491,7 +543,7 @@ pub(crate) fn to_date(ca: &Utf8Chunked) -> PolarsResult<DateChunked> {
                 .into_iter()
                 .find_map(|opt_val| opt_val.and_then(infer_pattern_date_single))
                 .ok_or_else(|| polars_err!(parse_fmt_idk = "date"))?;
-            let mut infer = DatetimeInfer::<i32>::try_from(pattern).unwrap();
+            let mut infer = DatetimeInfer::<i32>::try_from_with_unit(pattern, None).unwrap();
             infer.coerce_utf8(ca).date().cloned()
         }
     }

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -776,6 +776,36 @@ def test_tz_aware_try_parse_dates() -> None:
     assert_frame_equal(result, expected)
 
 
+@pytest.mark.parametrize("try_parse_dates", [True, False])
+@pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
+def test_csv_overwrite_datetime_dtype(
+    try_parse_dates: bool, time_unit: TimeUnit
+) -> None:
+    data = """\
+    a
+    2020-1-1T00:00:00.123456789
+    2020-1-2T00:00:00.987654321
+    2020-1-3T00:00:00.132547698
+    """
+    result = pl.read_csv(
+        io.StringIO(data),
+        try_parse_dates=try_parse_dates,
+        dtypes={"a": pl.Datetime(time_unit)},
+    )
+    expected = pl.DataFrame(
+        {
+            "a": pl.Series(
+                [
+                    "2020-01-01T00:00:00.123456789",
+                    "2020-01-02T00:00:00.987654321",
+                    "2020-01-03T00:00:00.132547698",
+                ]
+            ).str.to_datetime(time_unit=time_unit)
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
 def test_csv_string_escaping() -> None:
     df = pl.DataFrame({"a": ["Free trip to A,B", '''Special rate "1.79"''']})
     f = io.BytesIO()


### PR DESCRIPTION
closes #9102 

The main idea here is:
- instead of using `try_from(pattern)`, use `try_from_with_unit(pattern, unit)`

Then, instead of having to do
```rust
infer = try_from(pattern);
infer.transform = match time_unit {
    ...
}
```
you can just do
```rust
infer = try_from_with_unit(pattern, time_unit);
```

It also means you can pass the `time_unit` forwards within the `slow_datetime_parser`

To get the `time_unit`, it needs to be an argument of `parse_bytes`. I've made it of type `Option<TimeUnit>`, so that when parsing non-datetime type (e.g. Utf8), then `time_unit` can be set to `None`, and for `datetime`, it can either be the default `Microsecond` or whatever the user overrid it with