### PR TITLE
docs(python): fix typo in `Series.qcut`

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1716,7 +1716,7 @@ class Series:
         Parameters
         ----------
         quantiles
-            Quaniles to create.
+            List of quantiles to create.
             We expect quantiles ``0.0 <= quantile <= 1``
         labels
             Labels to assign to the quantiles. If given the length of labels must be


### PR DESCRIPTION
Replace `Quaniles` with `List of quantiles`.