### PR TITLE
fix Series::new panics when created with a vector containing an empty series

### DIFF
--- a/polars/polars-core/src/named_from.rs
+++ b/polars/polars-core/src/named_from.rs
@@ -122,7 +122,9 @@ impl<T: AsRef<[Series]>> NamedFrom<T, ListType> for Series {
     fn new(name: &str, s: T) -> Self {
         let series_slice = s.as_ref();
         let list_cap = series_slice.len();
-
+        if list_cap <= 0 {
+            panic!("series slice should have more than one item!");
+        }
         let dt = series_slice[0].dtype();
 
         // inner type is also list so we need the anonymous builder

--- a/polars/polars-core/src/series/mod.rs
+++ b/polars/polars-core/src/series/mod.rs
@@ -1159,4 +1159,10 @@ mod test {
         let ca = out.f64().unwrap();
         assert_eq!(ca.get(0), Some(1.0));
     }
+
+    #[test]
+    fn test_empty_series() {
+        let series = Series::new("test", Vec::<Series>::new());
+        assert_eq!(series.len(), 0);
+    }
 }


### PR DESCRIPTION
closed #9182 

It is my first PR for polars. I think it has the nicer way to fix this panic.