### PR TITLE
chore(python): Remove _tempdir module references

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -87,10 +87,6 @@ module = [
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
-module = ["polars.testing._tempdir"]
-ignore_errors = true
-
-[[tool.mypy.overrides]]
 module = ["IPython.*"]
 follow_imports = "skip"
 

--- a/py-polars/scripts/check_stacklevels.py
+++ b/py-polars/scripts/check_stacklevels.py
@@ -11,7 +11,7 @@ from ast import NodeVisitor
 # Files in which it's OK to set the stacklevel manually.
 # `git ls-files` lists files with forwards-slashes
 # even on Windows, so it's OK to list them like that.
-EXCLUDE = frozenset(["polars/utils/polars_version.py", "polars/testing/_tempdir.py"])
+EXCLUDE = frozenset(["polars/utils/polars_version.py"])
 
 
 class StackLevelChecker(NodeVisitor):


### PR DESCRIPTION
The module `polars.testing._tempdir` does no longer exists, so we can remove the mypy and stacklevel references made to it.