### PR TITLE
perf(python): speedup datetime conversion

### DIFF
--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -215,9 +215,12 @@ def _localize(dt: datetime, time_zone: str) -> datetime:
 
 def _datetime_for_anyvalue(dt: datetime) -> tuple[float, int]:
     """Used in pyo3 anyvalue conversion."""
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
     # returns (s, ms)
+    if dt.tzinfo is None:
+        return (
+            dt.replace(tzinfo=timezone.utc, microsecond=0).timestamp(),
+            dt.microsecond,
+        )
     return (dt.replace(microsecond=0).timestamp(), dt.microsecond)
 
 


### PR DESCRIPTION
```python
In [1]: from datetime import datetime, timezone

In [2]: def _datetime_for_anyvalue(dt: datetime) -> tuple[float, int]:
   ...:     """Used in pyo3 anyvalue conversion."""
   ...:     if dt.tzinfo is None:
   ...:         dt = dt.replace(tzinfo=timezone.utc)
   ...:     # returns (s, ms)
   ...:     return (dt.replace(microsecond=0).timestamp(), dt.microsecond)
   ...:

In [3]: def _datetime_for_anyvalue_new(dt: datetime) -> tuple[float, int]:
   ...:     """Used in pyo3 anyvalue conversion."""
   ...:     # returns (s, ms)
   ...:     if dt.tzinfo is None:
   ...:         return (dt.replace(tzinfo=timezone.utc, microsecond=0).timestamp(), dt.microsecond)
   ...:     return (dt.replace(microsecond=0).timestamp(), dt.microsecond)
   ...:

In [4]: now = datetime.now()

In [5]: now
Out[5]: datetime.datetime(2023, 6, 19, 16, 24, 33, 903576)

In [6]: %timeit _datetime_for_anyvalue(now)
1.09 µs ± 40.2 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [7]: %timeit _datetime_for_anyvalue_new(now)
696 ns ± 13.9 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```