### PR TITLE
perf(python): further optimize datetime conversion

### DIFF
--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -209,15 +209,20 @@ def _localize(dt: datetime, time_zone: str) -> datetime:
     return dt.astimezone(_tzinfo)
 
 
-def _datetime_for_anyvalue(dt: datetime) -> tuple[float, int]:
+def _timestamp_in_seconds(dt: datetime) -> int:
+    du = dt - EPOCH_UTC
+    return du.days * 86400 + du.seconds
+
+
+def _datetime_for_anyvalue(dt: datetime) -> tuple[int, int]:
     """Used in pyo3 anyvalue conversion."""
     # returns (s, ms)
     if dt.tzinfo is None:
         return (
-            dt.replace(tzinfo=timezone.utc, microsecond=0).timestamp(),
+            _timestamp_in_seconds(dt.replace(tzinfo=timezone.utc)),
             dt.microsecond,
         )
-    return (dt.replace(microsecond=0).timestamp(), dt.microsecond)
+    return (_timestamp_in_seconds(dt), dt.microsecond)
 
 
 def _datetime_for_anyvalue_windows(dt: datetime) -> tuple[float, int]:
@@ -225,7 +230,7 @@ def _datetime_for_anyvalue_windows(dt: datetime) -> tuple[float, int]:
     if dt.tzinfo is None:
         dt = _localize(dt, "UTC")
     # returns (s, ms)
-    return (dt.replace(microsecond=0).timestamp(), dt.microsecond)
+    return (_timestamp_in_seconds(dt), dt.microsecond)
 
 
 # cache here as we have a single tz per column

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -641,7 +641,7 @@ fn convert_datetime(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
         let (seconds, microseconds) = {
             let convert = UTILS.getattr(py, "_datetime_for_anyvalue_windows").unwrap();
             let out = convert.call1(py, (ob,)).unwrap();
-            let out: (f64, i64) = out.extract(py).unwrap();
+            let out: (i64, i64) = out.extract(py).unwrap();
             out
         };
         // unix
@@ -649,12 +649,12 @@ fn convert_datetime(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
         let (seconds, microseconds) = {
             let convert = UTILS.getattr(py, "_datetime_for_anyvalue").unwrap();
             let out = convert.call1(py, (ob,)).unwrap();
-            let out: (f64, i64) = out.extract(py).unwrap();
+            let out: (i64, i64) = out.extract(py).unwrap();
             out
         };
 
         // s to us
-        let mut v = (seconds as i64) * 1_000_000;
+        let mut v = seconds * 1_000_000;
         v += microseconds;
 
         // choose "us" as that is python's default unit


### PR DESCRIPTION
This basically avoids replacing `microsecond` to 0 and multiply `10**6` then divide by `10**6` again.

https://github.com/python/cpython/blob/7f97c8e367869e2aebe9f28bc5f8d4ce36448878/Lib/_pydatetime.py#L732-L735

On my Apple M2 MacBook Air:

```python
In [1]: from datetime import datetime, timezone

In [2]: def _datetime_for_anyvalue_main(dt: datetime) -> tuple[float, int]:
   ...:     """Used in pyo3 anyvalue conversion."""
   ...:     # returns (s, ms)
   ...:     if dt.tzinfo is None:
   ...:         return (
   ...:             dt.replace(tzinfo=timezone.utc, microsecond=0).timestamp(),
   ...:             dt.microsecond,
   ...:         )
   ...:     return (dt.replace(microsecond=0).timestamp(), dt.microsecond)
   ...:

In [3]: EPOCH_UTC = datetime(1970, 1, 1, tzinfo=timezone.utc)

In [4]: def _timestamp_in_seconds(dt: datetime) -> int:
   ...:     du = dt - EPOCH_UTC
   ...:     return du.days * 86400 + du.seconds
   ...:
   ...:
   ...: def _datetime_for_anyvalue(dt: datetime) -> tuple[int, int]:
   ...:     """Used in pyo3 anyvalue conversion."""
   ...:     # returns (s, ms)
   ...:     if dt.tzinfo is None:
   ...:         return (
   ...:             _timestamp_in_seconds(dt.replace(tzinfo=timezone.utc)),
   ...:             dt.microsecond,
   ...:         )
   ...:     return (_timestamp_in_seconds(dt), dt.microsecond)
   ...:

In [5]: now = datetime.now()

In [6]: %timeit _datetime_for_anyvalue_main(now)
614 ns ± 11.3 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [7]: %timeit _datetime_for_anyvalue(now)
604 ns ± 6.9 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [8]: now_utc = now.replace(tzinfo=timezone.utc)

In [9]: %timeit _datetime_for_anyvalue_main(now_utc)
562 ns ± 4.54 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [10]: %timeit _datetime_for_anyvalue(now_utc)
145 ns ± 1.65 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)
```