### PR TITLE
refactor(python): Deprecate some expr input parsing behavior

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2285,7 +2285,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if offset is None:
             offset = f"-{_timedelta_to_pl_duration(period)}"
 
-        pyexprs_by = parse_as_list_of_expressions(by)
+        pyexprs_by = parse_as_list_of_expressions(by) if by is not None else []
         period = _timedelta_to_pl_duration(period)
         offset = _timedelta_to_pl_duration(offset)
 
@@ -2628,7 +2628,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         offset = _timedelta_to_pl_duration(offset)
         every = _timedelta_to_pl_duration(every)
 
-        pyexprs_by = parse_as_list_of_expressions(by)
+        pyexprs_by = parse_as_list_of_expressions(by) if by is not None else []
         lgb = self._ldf.groupby_dynamic(
             index_column,
             every,

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import warnings
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Iterable
 
 import polars._reexport as pl
 from polars import functions as F
 from polars.exceptions import ComputeError
+from polars.utils.various import find_stacklevel
 
 if TYPE_CHECKING:
     from polars import Expr
@@ -48,15 +50,36 @@ def _parse_regular_inputs(
     if not inputs:
         return []
 
+    if (
+        len(inputs) > 1
+        and isinstance(inputs[0], Iterable)
+        and not isinstance(inputs[0], (str, pl.Series))
+    ):
+        warnings.warn(
+            "In the next breaking release, combining list input and positional input will result in an error."
+            " To silence this warning, either unpack the list , or append the positional inputs to the list first."
+            " The resulting behavior will be identical",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
+
     input_list = _first_input_to_list(inputs[0])
     input_list.extend(inputs[1:])  # type: ignore[arg-type]
     return [parse_as_expression(e, structify=structify) for e in input_list]
 
 
 def _first_input_to_list(
-    inputs: IntoExpr | Iterable[IntoExpr] | None,
+    inputs: IntoExpr | Iterable[IntoExpr],
 ) -> list[IntoExpr]:
     if inputs is None:
+        warnings.warn(
+            "In the next breaking release, passing `None` as the first expression input will evaluate to `lit(None)`,"
+            " rather than be ignored."
+            " To silence this warning, either pass no arguments or an empty list to retain the current behavior,"
+            " or pass `lit(None)` to opt into the new behavior.",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
         return []
     elif not isinstance(inputs, Iterable) or isinstance(inputs, (str, pl.Series)):
         return [inputs]

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -123,7 +123,8 @@ def test_groupby_args() -> None:
     # With keyword argument
     assert df.groupby("a", "b", maintain_order=True).agg("c").columns == expected
     # Mixed
-    assert df.groupby(["a"], "b", maintain_order=True).agg("c").columns == expected
+    with pytest.deprecated_call():
+        assert df.groupby(["a"], "b", maintain_order=True).agg("c").columns == expected
     # Multiple aggregations as list
     assert df.groupby("a").agg(["b", "c"]).columns == expected
     # Multiple aggregations as positional arguments

--- a/py-polars/tests/unit/operations/test_select.py
+++ b/py-polars/tests/unit/operations/test_select.py
@@ -34,13 +34,29 @@ def test_select_args_kwargs() -> None:
     assert_frame_equal(result, expected)
 
     # Mixed
-    result = ldf.select(["bar"], "foo", oof="foo")
+    result = ldf.select("bar", "foo", oof="foo")
     expected = pl.LazyFrame({"bar": [3, 4], "foo": [1, 2], "oof": [1, 2]})
+    assert_frame_equal(result, expected)
+
+
+def test_select_mixed_deprecated() -> None:
+    ldf = pl.LazyFrame({"foo": [1, 2], "bar": [3, 4], "ham": ["a", "b"]})
+
+    with pytest.deprecated_call():
+        result = ldf.select(["bar"], "foo")
+    expected = pl.LazyFrame({"bar": [3, 4], "foo": [1, 2]})
     assert_frame_equal(result, expected)
 
 
 def test_select_empty() -> None:
     result = pl.select()
+    expected = pl.DataFrame()
+    assert_frame_equal(result, expected)
+
+
+def test_select_none() -> None:
+    with pytest.deprecated_call():
+        result = pl.select(None)
     expected = pl.DataFrame()
     assert_frame_equal(result, expected)
 

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -492,7 +492,8 @@ def test_sort_args() -> None:
     assert_frame_equal(result, expected)
 
     # Mixed
-    result = df.sort(["a"], "b")
+    with pytest.deprecated_call():
+        result = df.sort(["a"], "b")
     assert_frame_equal(result, expected)
 
     # nulls_last

--- a/py-polars/tests/unit/operations/test_with_columns.py
+++ b/py-polars/tests/unit/operations/test_with_columns.py
@@ -79,17 +79,18 @@ def test_with_columns() -> None:
     assert_frame_equal(dx, expected)
 
     # mixed
-    dx = df.with_columns(
-        [(pl.col("a") * pl.col("b")).alias("d")],
-        ~pl.col("c").alias("e"),
-        f=srs_unnamed,
-        g=True,
-        h=1,
-        i=3.2,
-        j="a",  # Note: string interpreted as column name, resolves to `pl.col("a")`
-        k=None,
-        l=datetime.datetime(2001, 1, 1, 0, 0),
-    )
+    with pytest.deprecated_call():
+        dx = df.with_columns(
+            [(pl.col("a") * pl.col("b")).alias("d")],
+            ~pl.col("c").alias("e"),
+            f=srs_unnamed,
+            g=True,
+            h=1,
+            i=3.2,
+            j="a",  # Note: string interpreted as column name, resolves to `pl.col("a")`
+            k=None,
+            l=datetime.datetime(2001, 1, 1, 0, 0),
+        )
     assert_frame_equal(dx, expected)
 
     # automatically upconvert multi-output expressions to struct

--- a/py-polars/tests/unit/utils/test_parse_expr_input.py
+++ b/py-polars/tests/unit/utils/test_parse_expr_input.py
@@ -22,9 +22,13 @@ def assert_expr_equal(result: pl.Expr, expected: pl.Expr) -> None:
     assert_frame_equal(df.select(result), df.select(expected))
 
 
-@pytest.mark.parametrize("input", [None, []])
-def test_first_input_to_list_empty(input: Any) -> None:
-    assert _first_input_to_list(input) == []
+def test_first_input_to_list_empty() -> None:
+    assert _first_input_to_list([]) == []
+
+
+def test_first_input_to_list_none() -> None:
+    with pytest.deprecated_call():
+        assert _first_input_to_list(None) == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Deprecate two behaviors:
* Passing `None` as the first input will be parsed as a literal in the future. Current behaviour is to ignore the first input if it's None.
* Combining list input and positional input (e.g. `pl.select(['a'], 'b')`) will raise an error. You must either pass a list OR positional arguments. Named keywords are still allowed for either. This change will make behavior more predictable.

This PR will be followed up with the breaking changes.