### PR TITLE
feat(python): Update LazyFrame.__repr__

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7051,7 +7051,7 @@ class DataFrame:
         ...     }
         ... )
         >>> df.lazy()  # doctest: +ELLIPSIS
-        <polars.LazyFrame object at ...>
+        <LazyFrame [3 cols, {"a": Int64 … "c": Boolean}] at ...>
 
         """
         return wrap_ldf(self._df.lazy())

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -675,7 +675,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def __repr__(self) -> str:
         # don't expose internal/private classpath
-        return f"<{self.__class__.__name__} [{self.width} cols] at 0x{id(self):X}>"
+        width = self.width
+        cols_str = "{} col{}".format(width, "" if width == 1 else "s")
+        schema_max_2 = (item for i, item in enumerate(self.schema.items()) if i in (0, width - 1))
+        schema_str = (", " if width == 2 else " … ").join((f'"{k}": {v}' for k, v in schema_max_2))
+        return f"<{self.__class__.__name__} [{cols_str}, {{{schema_str}}}] at 0x{id(self):X}>"
 
     def _repr_html_(self) -> str:
         try:
@@ -1010,7 +1014,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     .inspect()  # print the node before the filter
         ...     .filter(pl.col("bar") == pl.col("foo"))
         ... )  # doctest: +ELLIPSIS
-        <polars.LazyFrame object at ...>
+        <LazyFrame [1 col, {"bar": Int64}] at ...>
 
         """
 
@@ -1782,7 +1786,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     }
         ... )
         >>> lf.lazy()  # doctest: +ELLIPSIS
-        <polars.LazyFrame object at ...>
+        <LazyFrame [3 cols, {"a": Int64 … "c": Boolean}] at ...>
 
         """
         return self
@@ -1857,7 +1861,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     }
         ... )
         >>> lf.clone()  # doctest: +ELLIPSIS
-        <polars.LazyFrame object at ...>
+        <LazyFrame [3 cols, {"a": Int64 … "c": Boolean}] at ...>
 
         """
         return self._from_pyldf(self._ldf.clone())

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -677,8 +677,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         # don't expose internal/private classpath
         width = self.width
         cols_str = "{} col{}".format(width, "" if width == 1 else "s")
-        schema_max_2 = (item for i, item in enumerate(self.schema.items()) if i in (0, width - 1))
-        schema_str = (", " if width == 2 else " … ").join((f'"{k}": {v}' for k, v in schema_max_2))
+        schema_max_2 = (
+            item for i, item in enumerate(self.schema.items()) if i in (0, width - 1)
+        )
+        schema_str = (", " if width == 2 else " … ").join(
+            (f'"{k}": {v}' for k, v in schema_max_2)
+        )
         return f"<{self.__class__.__name__} [{cols_str}, {{{schema_str}}}] at 0x{id(self):X}>"
 
     def _repr_html_(self) -> str:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -675,7 +675,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def __repr__(self) -> str:
         # don't expose internal/private classpath
-        return f"<polars.{self.__class__.__name__} object at 0x{id(self):X}>"
+        return f"<{self.__class__.__name__} [{self.width} cols] at 0x{id(self):X}>"
 
     def _repr_html_(self) -> str:
         try:

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -55,6 +55,11 @@ def test_lazy() -> None:
     assert profiling_info[1].columns == ["node", "start", "end"]
 
 
+def test_repr() -> None:
+    ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
+    assert repr(ldf).startswith("<LazyFrame [2 cols] at ")
+
+
 def test_lazyframe_membership_operator() -> None:
     ldf = pl.LazyFrame({"name": ["Jane", "John"], "age": [20, 30]})
     assert "name" in ldf

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -56,15 +56,15 @@ def test_lazy() -> None:
 
 
 @pytest.mark.parametrize(
-        ("data", "repr_"),
-        [
-            ({}, "0 cols, {}"),
-            ({"a": [1]}, '1 col, {"a": Int64}'),
-            ({"a": [1], "b": ["B"]}, '2 cols, {"a": Int64, "b": Utf8}'),
-            ({"a": [1], "b": ["B"], "c": [0.]}, '3 cols, {"a": Int64 … "c": Float64}'),
-        ],
+    ("data", "repr_"),
+    [
+        ({}, "0 cols, {}"),
+        ({"a": [1]}, '1 col, {"a": Int64}'),
+        ({"a": [1], "b": ["B"]}, '2 cols, {"a": Int64, "b": Utf8}'),
+        ({"a": [1], "b": ["B"], "c": [0.0]}, '3 cols, {"a": Int64 … "c": Float64}'),
+    ],
 )
-def test_repr(data: dict, repr_: str) -> None:
+def test_repr(data: dict[str, list[Any]], repr_: str) -> None:
     ldf = pl.LazyFrame(data)
     assert repr(ldf).startswith(f"<LazyFrame [{repr_}] at ")
 

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -55,9 +55,18 @@ def test_lazy() -> None:
     assert profiling_info[1].columns == ["node", "start", "end"]
 
 
-def test_repr() -> None:
-    ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
-    assert repr(ldf).startswith("<LazyFrame [2 cols] at ")
+@pytest.mark.parametrize(
+        ("data", "repr_"),
+        [
+            ({}, "0 cols, {}"),
+            ({"a": [1]}, '1 col, {"a": Int64}'),
+            ({"a": [1], "b": ["B"]}, '2 cols, {"a": Int64, "b": Utf8}'),
+            ({"a": [1], "b": ["B"], "c": [0.]}, '3 cols, {"a": Int64 … "c": Float64}'),
+        ],
+)
+def test_repr(data: dict, repr_: str) -> None:
+    ldf = pl.LazyFrame(data)
+    assert repr(ldf).startswith(f"<LazyFrame [{repr_}] at ")
 
 
 def test_lazyframe_membership_operator() -> None:


### PR DESCRIPTION
Closes #9100

@alexander-beedie I implemented the simpler of the options you proposed. Feels like it's difficult to provide too much information about the schema, unless the output of `__repr__` is very long (or the dataframe has just one or two columns). But happy to update the PR if another option is preferred.