### PR TITLE
chore(rust): remove unreachable code

### DIFF
--- a/polars/polars-time/src/chunkedarray/rolling_window/mod.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/mod.rs
@@ -247,7 +247,6 @@ fn rolling_agg<T>(
         &dyn Fn(
             &[T::Native],
             Duration,
-            Duration,
             &[i64],
             ClosedWindow,
             TimeUnit,
@@ -297,8 +296,6 @@ where
         let tu = options.tu.unwrap();
         let by = options.by.unwrap();
         let closed_window = options.closed_window.expect("closed window  must be set");
-        let mut offset = duration;
-        offset.negative = true;
         let func = rolling_agg_fn_dynamic.expect(
             "'rolling by' not yet supported for this expression, consider using 'groupby_rolling'",
         );
@@ -306,7 +303,6 @@ where
         func(
             values,
             duration,
-            offset,
             by,
             closed_window,
             tu,

--- a/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
@@ -51,7 +51,6 @@ where
 pub(crate) fn rolling_min<T>(
     values: &[T],
     period: Duration,
-    offset: Duration,
     time: &[i64],
     closed_window: ClosedWindow,
     tu: TimeUnit,
@@ -63,15 +62,8 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => groupby_values_iter(
-            period,
-            offset,
-            time,
-            closed_window,
-            tu,
-            tz.parse::<Tz>().ok(),
-        ),
-        _ => groupby_values_iter(period, offset, time, closed_window, tu, None),
+        Some(tz) => groupby_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
+        _ => groupby_values_iter(period, time, closed_window, tu, None),
     };
     rolling_apply_agg_window::<no_nulls::MinWindow<_>, _, _>(values, offset_iter, None)
 }
@@ -80,7 +72,6 @@ where
 pub(crate) fn rolling_max<T>(
     values: &[T],
     period: Duration,
-    offset: Duration,
     time: &[i64],
     closed_window: ClosedWindow,
     tu: TimeUnit,
@@ -92,15 +83,8 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => groupby_values_iter(
-            period,
-            offset,
-            time,
-            closed_window,
-            tu,
-            tz.parse::<Tz>().ok(),
-        ),
-        _ => groupby_values_iter(period, offset, time, closed_window, tu, None),
+        Some(tz) => groupby_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
+        _ => groupby_values_iter(period, time, closed_window, tu, None),
     };
     rolling_apply_agg_window::<no_nulls::MaxWindow<_>, _, _>(values, offset_iter, None)
 }
@@ -109,7 +93,6 @@ where
 pub(crate) fn rolling_sum<T>(
     values: &[T],
     period: Duration,
-    offset: Duration,
     time: &[i64],
     closed_window: ClosedWindow,
     tu: TimeUnit,
@@ -121,15 +104,8 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => groupby_values_iter(
-            period,
-            offset,
-            time,
-            closed_window,
-            tu,
-            tz.parse::<Tz>().ok(),
-        ),
-        _ => groupby_values_iter(period, offset, time, closed_window, tu, None),
+        Some(tz) => groupby_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
+        _ => groupby_values_iter(period, time, closed_window, tu, None),
     };
     rolling_apply_agg_window::<no_nulls::SumWindow<_>, _, _>(values, offset_iter, None)
 }
@@ -138,7 +114,6 @@ where
 pub(crate) fn rolling_mean<T>(
     values: &[T],
     period: Duration,
-    offset: Duration,
     time: &[i64],
     closed_window: ClosedWindow,
     tu: TimeUnit,
@@ -150,15 +125,8 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => groupby_values_iter(
-            period,
-            offset,
-            time,
-            closed_window,
-            tu,
-            tz.parse::<Tz>().ok(),
-        ),
-        _ => groupby_values_iter(period, offset, time, closed_window, tu, None),
+        Some(tz) => groupby_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
+        _ => groupby_values_iter(period, time, closed_window, tu, None),
     };
     rolling_apply_agg_window::<no_nulls::MeanWindow<_>, _, _>(values, offset_iter, None)
 }
@@ -167,7 +135,6 @@ where
 pub(crate) fn rolling_var<T>(
     values: &[T],
     period: Duration,
-    offset: Duration,
     time: &[i64],
     closed_window: ClosedWindow,
     tu: TimeUnit,
@@ -179,15 +146,8 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => groupby_values_iter(
-            period,
-            offset,
-            time,
-            closed_window,
-            tu,
-            tz.parse::<Tz>().ok(),
-        ),
-        _ => groupby_values_iter(period, offset, time, closed_window, tu, None),
+        Some(tz) => groupby_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
+        _ => groupby_values_iter(period, time, closed_window, tu, None),
     };
     rolling_apply_agg_window::<no_nulls::VarWindow<_>, _, _>(values, offset_iter, params)
 }
@@ -196,7 +156,6 @@ where
 pub(crate) fn rolling_std<T>(
     values: &[T],
     period: Duration,
-    offset: Duration,
     time: &[i64],
     closed_window: ClosedWindow,
     tu: TimeUnit,
@@ -218,15 +177,8 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => groupby_values_iter(
-            period,
-            offset,
-            time,
-            closed_window,
-            tu,
-            tz.parse::<Tz>().ok(),
-        ),
-        _ => groupby_values_iter(period, offset, time, closed_window, tu, None),
+        Some(tz) => groupby_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
+        _ => groupby_values_iter(period, time, closed_window, tu, None),
     };
     rolling_apply_agg_window::<no_nulls::StdWindow<_>, _, _>(values, offset_iter, params)
 }


### PR DESCRIPTION
`rolling_*` functions don't let you specify `offset`, but just `period` - so, there's more arguments than necessary in many of these internal functions, and a fair bit can be simplified / cleaned up