### PR TITLE
refactor(rust): Remove StdWindow in rolling

### DIFF
--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/variance.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/variance.rs
@@ -194,7 +194,6 @@ where
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/polars/polars-core/src/frame/groupby/aggregations/mod.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations/mod.rs
@@ -8,7 +8,7 @@ use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::types::simd::Simd;
 use arrow::types::NativeType;
 use num_traits::pow::Pow;
-use num_traits::{Bounded, Num, NumCast, ToPrimitive, Zero, Float};
+use num_traits::{Bounded, Float, Num, NumCast, ToPrimitive, Zero};
 use polars_arrow::data_types::IsFloat;
 use polars_arrow::kernels::rolling;
 use polars_arrow::kernels::rolling::no_nulls::{
@@ -797,7 +797,7 @@ where
                             )
                         }
                     };
-                    
+
                     let mut ca = ChunkedArray::<T>::from_chunks("", vec![arr]);
                     ca.apply_mut(|v| v.powf(NumCast::from(0.5).unwrap()));
                     ca.into_series()

--- a/polars/polars-core/src/frame/groupby/aggregations/mod.rs
+++ b/polars/polars-core/src/frame/groupby/aggregations/mod.rs
@@ -8,11 +8,11 @@ use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::types::simd::Simd;
 use arrow::types::NativeType;
 use num_traits::pow::Pow;
-use num_traits::{Bounded, Num, NumCast, ToPrimitive, Zero};
+use num_traits::{Bounded, Num, NumCast, ToPrimitive, Zero, Float};
 use polars_arrow::data_types::IsFloat;
 use polars_arrow::kernels::rolling;
 use polars_arrow::kernels::rolling::no_nulls::{
-    MaxWindow, MeanWindow, MinWindow, RollingAggWindowNoNulls, StdWindow, SumWindow, VarWindow,
+    MaxWindow, MeanWindow, MinWindow, RollingAggWindowNoNulls, SumWindow, VarWindow,
 };
 use polars_arrow::kernels::rolling::nulls::RollingAggWindowNulls;
 use polars_arrow::kernels::rolling::{DynArgs, RollingVarParams};
@@ -783,13 +783,13 @@ where
                     let values = arr.values().as_slice();
                     let offset_iter = groups.iter().map(|[first, len]| (*first, *len));
                     let arr = match arr.validity() {
-                        None => _rolling_apply_agg_window_no_nulls::<StdWindow<_>, _, _>(
+                        None => _rolling_apply_agg_window_no_nulls::<VarWindow<_>, _, _>(
                             values,
                             offset_iter,
                             Some(Arc::new(RollingVarParams { ddof })),
                         ),
                         Some(validity) => {
-                            _rolling_apply_agg_window_nulls::<rolling::nulls::StdWindow<_>, _, _>(
+                            _rolling_apply_agg_window_nulls::<rolling::nulls::VarWindow<_>, _, _>(
                                 values,
                                 validity,
                                 offset_iter,
@@ -797,7 +797,10 @@ where
                             )
                         }
                     };
-                    ChunkedArray::<T>::from_chunks("", vec![arr]).into_series()
+                    
+                    let mut ca = ChunkedArray::<T>::from_chunks("", vec![arr]);
+                    ca.apply_mut(|v| v.powf(NumCast::from(0.5).unwrap()));
+                    ca.into_series()
                 } else {
                     _agg_helper_slice::<T, _>(groups, |[first, len]| {
                         debug_assert!(len <= self.len() as IdxSize);

--- a/polars/polars-time/src/chunkedarray/rolling_window/floats.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/floats.rs
@@ -154,7 +154,8 @@ where
             &rolling::no_nulls::rolling_var,
             &rolling::nulls::rolling_var,
             Some(&super::rolling_kernels::no_nulls::rolling_var),
-        ).map(|mut s| {
+        )
+        .map(|mut s| {
             match s.dtype().clone() {
                 DataType::Float32 => {
                     let ca: &mut ChunkedArray<Float32Type> = s._get_inner_mut().as_mut();
@@ -168,6 +169,5 @@ where
             }
             s
         })
-    
     }
 }

--- a/polars/polars-time/src/chunkedarray/rolling_window/floats.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/floats.rs
@@ -148,40 +148,26 @@ where
     /// will (optionally) be multiplied with the weights given by the `weights` vector. The resulting
     /// values will be aggregated to their std.
     fn rolling_std(&self, options: RollingOptionsImpl) -> PolarsResult<Series> {
-        if options.window_size.parsed_int {
-            let options_fixed: RollingOptionsFixedWindow = options.clone().into();
-            check_input(options_fixed.window_size, options.min_periods)?;
-        }
-
-        // weights is only implemented by var kernel
-        if options.weights.is_some() {
-            return self
-                .0
-                .clone()
-                .into_series()
-                .rolling_var(options)
-                .map(|mut s| {
-                    match s.dtype().clone() {
-                        DataType::Float32 => {
-                            let ca: &mut ChunkedArray<Float32Type> = s._get_inner_mut().as_mut();
-                            ca.apply_mut(|v| v.powf(0.5))
-                        }
-                        DataType::Float64 => {
-                            let ca: &mut ChunkedArray<Float64Type> = s._get_inner_mut().as_mut();
-                            ca.apply_mut(|v| v.powf(0.5))
-                        }
-                        _ => unreachable!(),
-                    }
-                    s
-                });
-        }
-
         rolling_agg(
             &self.0,
             options,
-            &rolling::no_nulls::rolling_std,
-            &rolling::nulls::rolling_std,
-            Some(&super::rolling_kernels::no_nulls::rolling_std),
-        )
+            &rolling::no_nulls::rolling_var,
+            &rolling::nulls::rolling_var,
+            Some(&super::rolling_kernels::no_nulls::rolling_var),
+        ).map(|mut s| {
+            match s.dtype().clone() {
+                DataType::Float32 => {
+                    let ca: &mut ChunkedArray<Float32Type> = s._get_inner_mut().as_mut();
+                    ca.apply_mut(|v| v.powf(0.5))
+                }
+                DataType::Float64 => {
+                    let ca: &mut ChunkedArray<Float64Type> = s._get_inner_mut().as_mut();
+                    ca.apply_mut(|v| v.powf(0.5))
+                }
+                _ => unreachable!(),
+            }
+            s
+        })
+    
     }
 }

--- a/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/mod.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/mod.rs
@@ -1,6 +1,6 @@
 pub(super) mod no_nulls;
 use std::fmt::Debug;
-use std::ops::{AddAssign, Div, Mul, Sub, SubAssign};
+use std::ops::{AddAssign, Mul, SubAssign};
 
 use arrow::array::PrimitiveArray;
 use arrow::types::NativeType;
@@ -8,7 +8,7 @@ use polars_arrow::data_types::IsFloat;
 use polars_arrow::export::arrow;
 use polars_arrow::index::IdxSize;
 use polars_arrow::trusted_len::TrustedLen;
-use polars_core::export::num::{Bounded, Float, NumCast, One};
+use polars_core::export::num::{Bounded, Float, NumCast};
 use polars_core::prelude::*;
 
 use crate::prelude::*;

--- a/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
@@ -150,4 +150,3 @@ where
     };
     rolling_apply_agg_window::<no_nulls::VarWindow<_>, _, _>(values, offset_iter, params)
 }
-

--- a/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "timezones")]
 use chrono_tz::Tz;
 use polars_arrow::kernels::rolling::no_nulls::{self, RollingAggWindowNoNulls};
-use polars_core::export::num;
 
 use super::*;
 
@@ -152,33 +151,3 @@ where
     rolling_apply_agg_window::<no_nulls::VarWindow<_>, _, _>(values, offset_iter, params)
 }
 
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn rolling_std<T>(
-    values: &[T],
-    period: Duration,
-    time: &[i64],
-    closed_window: ClosedWindow,
-    tu: TimeUnit,
-    tz: Option<&TimeZone>,
-    params: DynArgs,
-) -> PolarsResult<ArrayRef>
-where
-    T: NativeType
-        + Float
-        + IsFloat
-        + std::iter::Sum
-        + AddAssign
-        + SubAssign
-        + Div<Output = T>
-        + NumCast
-        + One
-        + Sub<Output = T>
-        + num::pow::Pow<T, Output = T>,
-{
-    let offset_iter = match tz {
-        #[cfg(feature = "timezones")]
-        Some(tz) => groupby_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
-        _ => groupby_values_iter(period, time, closed_window, tu, None),
-    };
-    rolling_apply_agg_window::<no_nulls::StdWindow<_>, _, _>(values, offset_iter, params)
-}


### PR DESCRIPTION
Simplifies the code by using VarWindow and taking the sqrt in place any time the rolling StdWindow would have been used. I tested the performance and it's either the same or even a little better in some cases(faster to take the sqrt of contiguous numbers all at once rather than one at at time?)