### PR TITLE
fix(rust, python): maintain sortedness flags on append/extend

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/extend.rs
+++ b/polars/polars-core/src/chunked_array/ops/extend.rs
@@ -36,6 +36,7 @@ where
     /// when you read in multiple files and when to store them in a single `DataFrame`.
     /// In the latter case finish the sequence of `append` operations with a [`rechunk`](Self::rechunk).
     pub fn extend(&mut self, other: &Self) {
+        self.update_sorted_flag_before_append(other);
         // all to a single chunk
         if self.chunks.len() > 1 {
             self.append(other);
@@ -82,7 +83,6 @@ where
             }
         }
         self.compute_len();
-        self.set_sorted_flag(IsSorted::Not);
     }
 }
 

--- a/polars/polars-core/src/chunked_array/ops/extend.rs
+++ b/polars/polars-core/src/chunked_array/ops/extend.rs
@@ -1,6 +1,7 @@
 use arrow::compute::concatenate::concatenate;
 use arrow::Either;
 
+use crate::prelude::append::update_sorted_flag_before_append;
 use crate::prelude::*;
 use crate::series::IsSorted;
 
@@ -36,7 +37,7 @@ where
     /// when you read in multiple files and when to store them in a single `DataFrame`.
     /// In the latter case finish the sequence of `append` operations with a [`rechunk`](Self::rechunk).
     pub fn extend(&mut self, other: &Self) {
-        self.update_sorted_flag_before_append(other);
+        update_sorted_flag_before_append(self, other);
         // all to a single chunk
         if self.chunks.len() > 1 {
             self.append(other);
@@ -89,6 +90,7 @@ where
 #[doc(hidden)]
 impl Utf8Chunked {
     pub fn extend(&mut self, other: &Self) {
+        update_sorted_flag_before_append(self, other);
         if self.chunks.len() > 1 {
             self.append(other);
             *self = self.rechunk();
@@ -127,6 +129,7 @@ impl Utf8Chunked {
 #[doc(hidden)]
 impl BinaryChunked {
     pub fn extend(&mut self, other: &Self) {
+        update_sorted_flag_before_append(self, other);
         if self.chunks.len() > 1 {
             self.append(other);
             *self = self.rechunk();
@@ -164,6 +167,7 @@ impl BinaryChunked {
 #[doc(hidden)]
 impl BooleanChunked {
     pub fn extend(&mut self, other: &Self) {
+        update_sorted_flag_before_append(self, other);
         // make sure that we are a single chunk already
         if self.chunks.len() > 1 {
             self.append(other);

--- a/polars/polars-core/src/chunked_array/ops/take/take_single.rs
+++ b/polars/polars-core/src/chunked_array/ops/take/take_single.rs
@@ -95,6 +95,24 @@ impl TakeRandom for BooleanChunked {
         // Out of bounds is checked and downcast is of correct type
         unsafe { impl_take_random_get!(self, index, BooleanArray) }
     }
+    #[inline]
+    unsafe fn get_unchecked(&self, index: usize) -> Option<Self::Item> {
+        impl_take_random_get_unchecked!(self, index, BooleanArray)
+    }
+}
+
+impl<'a> TakeRandom for &'a BooleanChunked {
+    type Item = bool;
+
+    #[inline]
+    fn get(&self, index: usize) -> Option<Self::Item> {
+        (*self).get(index)
+    }
+
+    #[inline]
+    unsafe fn get_unchecked(&self, index: usize) -> Option<Self::Item> {
+        (*self).get_unchecked(index)
+    }
 }
 
 impl<'a> TakeRandom for &'a Utf8Chunked {


### PR DESCRIPTION
fixes #9494 

Will add the other dtypes as well.