### PR TITLE
feat(python)!: Improve consistency of parsing expression input

### DIFF
--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -10,7 +10,6 @@ from polars.utils._parse_expr_input import (
     parse_as_list_of_expressions,
 )
 from polars.utils._wrap import wrap_expr
-from polars.utils.deprecation import issue_deprecation_warning
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -392,17 +391,7 @@ def struct(
     {'my_struct': Struct([Field('p', Int64), Field('q', Boolean)])}
 
     """
-    if "exprs" in named_exprs:
-        issue_deprecation_warning(
-            "passing expressions to `struct` using the keyword argument `exprs` is"
-            " deprecated. Use positional syntax instead.",
-            version="0.18.1",
-        )
-        first_input = named_exprs.pop("exprs")
-        pyexprs = parse_as_list_of_expressions(first_input, *exprs, **named_exprs)
-    else:
-        pyexprs = parse_as_list_of_expressions(*exprs, **named_exprs)
-
+    pyexprs = parse_as_list_of_expressions(*exprs, **named_exprs)
     expr = wrap_expr(plr.as_struct(pyexprs))
 
     if schema:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -60,7 +60,6 @@ from polars.utils.deprecation import (
     deprecate_renamed_function,
     deprecate_renamed_methods,
     deprecate_renamed_parameter,
-    issue_deprecation_warning,
 )
 from polars.utils.various import (
     _in_notebook,
@@ -80,7 +79,6 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
     from polars import DataFrame, Expr
-    from polars.polars import PyExpr
     from polars.type_aliases import (
         AsofJoinStrategy,
         ClosedInterval,
@@ -113,29 +111,6 @@ if TYPE_CHECKING:
 
     T = TypeVar("T")
     P = ParamSpec("P")
-
-
-def _prepare_select(
-    *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
-) -> list[PyExpr]:
-    structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
-
-    if "exprs" in named_exprs:
-        issue_deprecation_warning(
-            "passing expressions to `select` using the keyword argument `exprs` is"
-            " deprecated. Use positional syntax instead.",
-            version="0.18.1",
-        )
-        first_input = named_exprs.pop("exprs")
-        pyexprs = parse_as_list_of_expressions(
-            first_input, *exprs, **named_exprs, __structify=structify
-        )
-    else:
-        pyexprs = parse_as_list_of_expressions(
-            *exprs, **named_exprs, __structify=structify
-        )
-
-    return pyexprs
 
 
 @deprecate_renamed_methods(
@@ -2233,7 +2208,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └───────────┘
 
         """
-        pyexprs = _prepare_select(*exprs, **named_exprs)
+        structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
+
+        pyexprs = parse_as_list_of_expressions(
+            *exprs, **named_exprs, __structify=structify
+        )
         return self._from_pyldf(self._ldf.select(pyexprs))
 
     def select_seq(
@@ -2260,7 +2239,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         select
 
         """
-        pyexprs = _prepare_select(*exprs, **named_exprs)
+        structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
+
+        pyexprs = parse_as_list_of_expressions(
+            *exprs, **named_exprs, __structify=structify
+        )
         return self._from_pyldf(self._ldf.select_seq(pyexprs))
 
     def groupby(
@@ -3368,7 +3351,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴──────┴─────────────┘
 
         """
-        pyexprs = _prepare_select(*exprs, **named_exprs)
+        structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
+
+        pyexprs = parse_as_list_of_expressions(
+            *exprs, **named_exprs, __structify=structify
+        )
         return self._from_pyldf(self._ldf.with_columns(pyexprs))
 
     def with_columns_seq(
@@ -3404,7 +3391,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         with_columns
 
         """
-        pyexprs = _prepare_select(*exprs, **named_exprs)
+        structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
+
+        pyexprs = parse_as_list_of_expressions(
+            *exprs, **named_exprs, __structify=structify
+        )
         return self._from_pyldf(self._ldf.with_columns_seq(pyexprs))
 
     def with_context(self, other: Self | list[Self]) -> Self:

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING, Callable, Iterable
 from polars import functions as F
 from polars.utils._parse_expr_input import parse_as_list_of_expressions
 from polars.utils._wrap import wrap_ldf
-from polars.utils.deprecation import issue_deprecation_warning
 
 if TYPE_CHECKING:
     from polars import DataFrame, LazyFrame
@@ -140,17 +139,7 @@ class LazyGroupBy:
                 " of the `agg` method."
             )
 
-        if "aggs" in named_aggs:
-            issue_deprecation_warning(
-                "passing expressions to `agg` using the keyword argument `aggs` is"
-                " deprecated. Use positional syntax instead.",
-                version="0.18.1",
-            )
-            first_input = named_aggs.pop("aggs")
-            pyexprs = parse_as_list_of_expressions(first_input, *aggs, **named_aggs)
-        else:
-            pyexprs = parse_as_list_of_expressions(*aggs, **named_aggs)
-
+        pyexprs = parse_as_list_of_expressions(*aggs, **named_aggs)
         return wrap_ldf(self.lgb.agg(pyexprs))
 
     def apply(

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -69,16 +69,7 @@ def _parse_regular_inputs(
 def _first_input_to_list(
     inputs: IntoExpr | Iterable[IntoExpr],
 ) -> list[IntoExpr]:
-    if inputs is None:
-        issue_deprecation_warning(
-            "In the next breaking release, passing `None` as the first expression input will evaluate to `lit(None)`,"
-            " rather than be ignored."
-            " To silence this warning, either pass no arguments or an empty list to retain the current behavior,"
-            " or pass `lit(None)` to opt into the new behavior.",
-            version="0.18.0",
-        )
-        return []
-    elif not isinstance(inputs, Iterable) or isinstance(inputs, (str, pl.Series)):
+    if not isinstance(inputs, Iterable) or isinstance(inputs, (str, pl.Series)):
         return [inputs]
     else:
         return list(inputs)

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -58,7 +58,9 @@ def _parse_regular_inputs(
 
 
 def _is_iterable(input: IntoExpr | Iterable[IntoExpr]) -> bool:
-    return isinstance(input, Iterable) and not isinstance(input, (str, pl.Series))
+    return isinstance(input, Iterable) and not isinstance(
+        input, (str, bytes, pl.Series)
+    )
 
 
 def _parse_named_inputs(
@@ -98,7 +100,9 @@ def parse_as_expression(
         expr = F.col(input)
         structify = False
     elif (
-        isinstance(input, (int, float, str, pl.Series, datetime, date, time, timedelta))
+        isinstance(
+            input, (int, float, str, bytes, pl.Series, datetime, date, time, timedelta)
+        )
         or input is None
     ):
         expr = F.lit(input)

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -107,8 +107,8 @@ def parse_as_expression(
     ):
         expr = F.lit(input)
         structify = False
-    elif isinstance(input, list):
-        expr = F.lit(pl.Series("", [input]))
+    elif isinstance(input, (list, tuple)):
+        expr = F.lit(pl.Series("literal", [input]))
         structify = False
     else:
         raise TypeError(

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -112,8 +112,8 @@ def parse_as_expression(
         structify = False
     else:
         raise TypeError(
-            f"did not expect value {input!r} of type {type(input).__name__!r}, maybe disambiguate with"
-            " pl.lit or pl.col"
+            f"did not expect value {input!r} of type {type(input).__name__!r}"
+            "\n\nTry disambiguating with `lit` or `col`."
         )
 
     if structify:

--- a/py-polars/tests/unit/functions/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/test_as_datatype.py
@@ -509,14 +509,3 @@ def test_format() -> None:
 
     out = df.select([pl.format("foo_{}_bar_{}", pl.col("a"), "b").alias("fmt")])
     assert out["fmt"].to_list() == ["foo_a_bar_1", "foo_b_bar_2", "foo_c_bar_3"]
-
-
-def test_struct_deprecation_exprs_keyword() -> None:
-    with pytest.deprecated_call():
-        result = pl.select(pl.struct(exprs=1.0))
-
-    expected = pl.DataFrame(
-        {"literal": [{"literal": 1.0}]},
-        schema={"literal": pl.Struct({"literal": pl.Float64})},
-    )
-    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -173,7 +173,7 @@ def test_groupby_iteration() -> None:
 
 def bad_agg_parameters() -> list[Any]:
     """Currently, IntoExpr and Iterable[IntoExpr] are supported."""
-    return [[("b", "sum")], [("b", ["sum"])], str, "b".join]
+    return [str, "b".join]
 
 
 def good_agg_parameters() -> list[pl.Expr | list[pl.Expr]]:

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -122,9 +122,6 @@ def test_groupby_args() -> None:
     assert df.groupby("a", "b").agg("c").columns == expected
     # With keyword argument
     assert df.groupby("a", "b", maintain_order=True).agg("c").columns == expected
-    # Mixed
-    with pytest.deprecated_call():
-        assert df.groupby(["a"], "b", maintain_order=True).agg("c").columns == expected
     # Multiple aggregations as list
     assert df.groupby("a").agg(["b", "c"]).columns == expected
     # Multiple aggregations as positional arguments

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -833,16 +833,6 @@ def test_perfect_hash_table_null_values_8663() -> None:
     }
 
 
-def test_groupby_agg_deprecation_aggs_keyword() -> None:
-    df = pl.DataFrame({"a": [1, 1, 2], "b": [3, 4, 5]})
-
-    with pytest.deprecated_call():
-        result = df.groupby("a", maintain_order=True).agg(aggs="b")
-
-    expected = pl.DataFrame({"a": [1, 2], "b": [[3, 4], [5]]})
-    assert_frame_equal(result, expected)
-
-
 def test_groupby_partitioned_ending_cast(monkeypatch: Any) -> None:
     monkeypatch.setenv("POLARS_FORCE_PARTITION", "1")
     df = pl.DataFrame({"a": [1] * 5, "b": [1] * 5})

--- a/py-polars/tests/unit/operations/test_groupby_rolling.py
+++ b/py-polars/tests/unit/operations/test_groupby_rolling.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 def bad_agg_parameters() -> list[Any]:
     """Currently, IntoExpr and Iterable[IntoExpr] are supported."""
-    return [[("b", "sum")], [("b", ["sum"])], str, "b".join]
+    return [str, "b".join]
 
 
 def good_agg_parameters() -> list[pl.Expr | list[pl.Expr]]:

--- a/py-polars/tests/unit/operations/test_select.py
+++ b/py-polars/tests/unit/operations/test_select.py
@@ -55,9 +55,20 @@ def test_select_empty() -> None:
 
 
 def test_select_none() -> None:
-    with pytest.deprecated_call():
-        result = pl.select(None)
-    expected = pl.DataFrame()
+    result = pl.select(None)
+    expected = pl.select(pl.lit(None))
+    assert_frame_equal(result, expected)
+
+
+def test_select_none_combined() -> None:
+    other = pl.lit(1).alias("one")
+
+    result = pl.select(None, other)
+    expected = pl.select(pl.lit(None), other)
+    assert_frame_equal(result, expected)
+
+    result = pl.select(other, None)
+    expected = pl.select(other, pl.lit(None))
     assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/operations/test_select.py
+++ b/py-polars/tests/unit/operations/test_select.py
@@ -1,5 +1,3 @@
-import pytest
-
 import polars as pl
 from polars.testing import assert_frame_equal
 
@@ -72,12 +70,4 @@ def test_select_empty_list() -> None:
 def test_select_named_inputs_reserved() -> None:
     result = pl.select(inputs=1.0, structify=pl.lit("x"))
     expected = pl.DataFrame({"inputs": [1.0], "structify": ["x"]})
-    assert_frame_equal(result, expected)
-
-
-def test_select_deprecation_exprs_keyword() -> None:
-    with pytest.deprecated_call():
-        result = pl.select(exprs=1.0)
-
-    expected = pl.DataFrame({"literal": [1.0]})
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_select.py
+++ b/py-polars/tests/unit/operations/test_select.py
@@ -39,15 +39,6 @@ def test_select_args_kwargs() -> None:
     assert_frame_equal(result, expected)
 
 
-def test_select_mixed_deprecated() -> None:
-    ldf = pl.LazyFrame({"foo": [1, 2], "bar": [3, 4], "ham": ["a", "b"]})
-
-    with pytest.deprecated_call():
-        result = ldf.select(["bar"], "foo")
-    expected = pl.LazyFrame({"bar": [3, 4], "foo": [1, 2]})
-    assert_frame_equal(result, expected)
-
-
 def test_select_empty() -> None:
     result = pl.select()
     expected = pl.DataFrame()

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -486,11 +486,6 @@ def test_sort_args() -> None:
     result = df.sort("a", "b")
     assert_frame_equal(result, expected)
 
-    # Mixed
-    with pytest.deprecated_call():
-        result = df.sort(["a"], "b")
-    assert_frame_equal(result, expected)
-
     # nulls_last
     result = df.sort("a", nulls_last=True)
     assert_frame_equal(result, df)

--- a/py-polars/tests/unit/operations/test_with_columns.py
+++ b/py-polars/tests/unit/operations/test_with_columns.py
@@ -1,5 +1,3 @@
-import pytest
-
 import polars as pl
 from polars.testing import assert_frame_equal
 
@@ -151,13 +149,3 @@ def test_with_columns_single_series() -> None:
 
     expected = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     assert_frame_equal(result.collect(), expected)
-
-
-def test_with_columns_deprecation_exprs_keyword() -> None:
-    df = pl.DataFrame({"a": [1, 2]})
-
-    with pytest.deprecated_call():
-        result = df.with_columns(exprs=1.0)
-
-    expected = pl.DataFrame({"a": [1, 2], "literal": [1.0, 1.0]})
-    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_with_columns.py
+++ b/py-polars/tests/unit/operations/test_with_columns.py
@@ -79,18 +79,17 @@ def test_with_columns() -> None:
     assert_frame_equal(dx, expected)
 
     # mixed
-    with pytest.deprecated_call():
-        dx = df.with_columns(
-            [(pl.col("a") * pl.col("b")).alias("d")],
-            ~pl.col("c").alias("e"),
-            f=srs_unnamed,
-            g=True,
-            h=1,
-            i=3.2,
-            j="a",  # Note: string interpreted as column name, resolves to `pl.col("a")`
-            k=None,
-            l=datetime.datetime(2001, 1, 1, 0, 0),
-        )
+    dx = df.with_columns(
+        (pl.col("a") * pl.col("b")).alias("d"),
+        ~pl.col("c").alias("e"),
+        f=srs_unnamed,
+        g=True,
+        h=1,
+        i=3.2,
+        j="a",  # Note: string interpreted as column name, resolves to `pl.col("a")`
+        k=None,
+        l=datetime.datetime(2001, 1, 1, 0, 0),
+    )
     assert_frame_equal(dx, expected)
 
     # automatically upconvert multi-output expressions to struct

--- a/py-polars/tests/unit/utils/test_parse_expr_input.py
+++ b/py-polars/tests/unit/utils/test_parse_expr_input.py
@@ -22,7 +22,9 @@ def assert_expr_equal(result: pl.Expr, expected: pl.Expr) -> None:
     assert_frame_equal(df.select(result), df.select(expected))
 
 
-@pytest.mark.parametrize("input", [5, 2.0, pl.Series([1, 2, 3]), date(2022, 1, 1)])
+@pytest.mark.parametrize(
+    "input", [5, 2.0, pl.Series([1, 2, 3]), date(2022, 1, 1), b"hi"]
+)
 def test_parse_as_expression_lit(input: Any) -> None:
     result = wrap_expr(parse_as_expression(input))
     expected = pl.lit(input)

--- a/py-polars/tests/unit/utils/test_parse_expr_input.py
+++ b/py-polars/tests/unit/utils/test_parse_expr_input.py
@@ -53,9 +53,10 @@ def test_parse_as_expression_whenthen(input: Any) -> None:
     assert_expr_equal(result, expected)
 
 
-def test_parse_as_expression_list() -> None:
-    result = wrap_expr(parse_as_expression([1, 2, 3]))
-    expected = pl.lit(pl.Series([[1, 2, 3]]))
+@pytest.mark.parametrize("input", [[1, 2, 3], (1, 2)])
+def test_parse_as_expression_list(input: Any) -> None:
+    result = wrap_expr(parse_as_expression(input))
+    expected = pl.lit(pl.Series("literal", [input]))
     assert_expr_equal(result, expected)
 
 

--- a/py-polars/tests/unit/utils/test_parse_expr_input.py
+++ b/py-polars/tests/unit/utils/test_parse_expr_input.py
@@ -26,14 +26,9 @@ def test_first_input_to_list_empty() -> None:
     assert _first_input_to_list([]) == []
 
 
-def test_first_input_to_list_none() -> None:
-    with pytest.deprecated_call():
-        assert _first_input_to_list(None) == []
-
-
 @pytest.mark.parametrize(
     "input",
-    [5, 2.0, "a", pl.Series([1, 2, 3]), pl.lit(4)],
+    [5, 2.0, "a", pl.Series([1, 2, 3]), pl.lit(4), None],
 )
 def test_first_input_to_list_single(input: Any) -> None:
     assert _first_input_to_list(input) == [input]

--- a/py-polars/tests/unit/utils/test_parse_expr_input.py
+++ b/py-polars/tests/unit/utils/test_parse_expr_input.py
@@ -7,7 +7,7 @@ import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal
-from polars.utils._parse_expr_input import _first_input_to_list, parse_as_expression
+from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
 
 
@@ -20,26 +20,6 @@ def assert_expr_equal(result: pl.Expr, expected: pl.Expr) -> None:
     """
     df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     assert_frame_equal(df.select(result), df.select(expected))
-
-
-def test_first_input_to_list_empty() -> None:
-    assert _first_input_to_list([]) == []
-
-
-@pytest.mark.parametrize(
-    "input",
-    [5, 2.0, "a", pl.Series([1, 2, 3]), pl.lit(4), None],
-)
-def test_first_input_to_list_single(input: Any) -> None:
-    assert _first_input_to_list(input) == [input]
-
-
-@pytest.mark.parametrize(
-    "input",
-    [[5], ["a", "b"], (1, 2, 3), ["a", 5, 3.2]],
-)
-def test_first_input_to_list_multiple(input: Any) -> None:
-    assert _first_input_to_list(input) == list(input)
 
 
 @pytest.mark.parametrize("input", [5, 2.0, pl.Series([1, 2, 3]), date(2022, 1, 1)])


### PR DESCRIPTION
**!! BREAKING !!**

These are some improvements aimed at better handling inputs for `select`/`with_columns` and other methods that take expression inputs. These have already been deprecated - this is the PR that actually changes the behaviour.

Changes:
* Passing `None` as the first input is now parsed as `lit(None)` rather than be ignored.
* Passing an iterable (e.g. `select(["a", "b"])`) is still supported, but can no longer be combined with other positional parameters. If multiple positional parameters are supplied, the first argument is always assumed to be an expression input, rather than a list of expression inputs.
* Methods that accept named expression inputs (`select`, `with_columns`, `agg`, `struct`) no longer have a separate argument for  the first expression input. This means that `select(exprs="a")` now renames the column "a" to "exprs".