### PR TITLE
chore(python,rust): Remove outdated badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@
 </h1>
 
 <div align="center">
-  <a href="https://docs.rs/polars/latest/polars/">
-    <img src="https://docs.rs/polars/badge.svg" alt="rust docs"/>
-  </a>
-  <a href="https://github.com/pola-rs/polars/actions">
-    <img src="https://github.com/pola-rs/polars/workflows/Build%20and%20test/badge.svg" alt="Build and test"/>
-  </a>
   <a href="https://crates.io/crates/polars">
     <img src="https://img.shields.io/crates/v/polars.svg"/>
   </a>
@@ -31,7 +25,7 @@
   <b>Documentation</b>:
   <a href="https://pola-rs.github.io/polars/py-polars/html/reference/index.html">Python</a>
   -
-  <a href="https://pola-rs.github.io/polars/polars/index.html">Rust</a>
+  <a href="https://docs.rs/polars/latest/polars/">Rust</a>
   -
   <a href="https://pola-rs.github.io/nodejs-polars/index.html">Node.js</a>
   -


### PR DESCRIPTION
Changes:
* Remove the GitHub Actions badge `Build and test: failing`. It was pointing to a workflow that no longer existed. Since there's already a 'green tick' in the CI, there is no real added benefit of a badge like this. So I removed it entirely.
* Remove the `docs: passing` badge with a link to the Rust docs at `docs.rs`. Directly below the badges there is already a link to each documentation page. I updated the Rust link there to use the `docs.rs` link (latest release) rather than our own GitHub pages (master branch). This is in line with the other docs links (e.g. the Python doc link links to the docs of the latest release).