### PR TITLE
fix(rust, python): fix lazy schema of temporal_range functions when no alias is provided

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -59,8 +59,13 @@ impl FunctionExpr {
                     }
                     #[cfg(feature = "timezones")]
                     TzLocalize(tz) => return mapper.map_datetime_dtype_timezone(Some(tz)),
-                    DateRange { .. } => return mapper.map_to_list_supertype(),
-                    TimeRange { .. } => DataType::List(Box::new(DataType::Time)),
+                    DateRange { .. } => {
+                        let res = mapper.map_to_list_supertype()?;
+                        return Ok(Field::new("date", res.dtype));
+                    }
+                    TimeRange { .. } => {
+                        return Ok(Field::new("time", DataType::List(Box::new(DataType::Time))));
+                    }
                     Combine(tu) => match mapper.with_same_dtype().unwrap().dtype {
                         DataType::Datetime(_, tz) => DataType::Datetime(*tu, tz),
                         DataType::Date => DataType::Datetime(*tu, None),

--- a/py-polars/tests/unit/functions/test_range.py
+++ b/py-polars/tests/unit/functions/test_range.py
@@ -583,11 +583,33 @@ def test_date_range_schema() -> None:
     assert result.collect().schema == expected_schema
 
 
+def test_date_range_no_alias_schema_9037() -> None:
+    df = pl.DataFrame(
+        {"start": [datetime(2020, 1, 1)], "end": [datetime(2020, 1, 2)]}
+    ).lazy()
+    result = df.with_columns(pl.date_range(pl.col("start"), pl.col("end")))
+    expected_schema = {
+        "start": pl.Datetime(time_unit="us", time_zone=None),
+        "end": pl.Datetime(time_unit="us", time_zone=None),
+        "date": pl.List(pl.Datetime(time_unit="us", time_zone=None)),
+    }
+    assert result.schema == expected_schema
+    assert result.collect().schema == expected_schema
+
+
 def test_time_range_schema() -> None:
     df = pl.DataFrame({"start": [time(1)], "end": [time(1, 30)]}).lazy()
     result = df.with_columns(
         pl.time_range(pl.col("start"), pl.col("end")).alias("time_range")
     )
     expected_schema = {"start": pl.Time, "end": pl.Time, "time_range": pl.List(pl.Time)}
+    assert result.schema == expected_schema
+    assert result.collect().schema == expected_schema
+
+
+def test_time_range_no_alias_schema_9037() -> None:
+    df = pl.DataFrame({"start": [time(1)], "end": [time(1, 30)]}).lazy()
+    result = df.with_columns(pl.time_range(pl.col("start"), pl.col("end")))
+    expected_schema = {"start": pl.Time, "end": pl.Time, "time": pl.List(pl.Time)}
     assert result.schema == expected_schema
     assert result.collect().schema == expected_schema


### PR DESCRIPTION
closes #9037