### PR TITLE
perf(rust, python): remove sort columns on multiple-key OOC sort

### DIFF
--- a/polars/polars-core/src/schema.rs
+++ b/polars/polars-core/src/schema.rs
@@ -276,6 +276,16 @@ impl Schema {
         self.inner.shift_remove(name)
     }
 
+    /// Remove a field by name, preserving order, and, if the field existed, return its dtype
+    ///
+    /// If the field does not exist, the schema is not modified and `None` is returned.
+    ///
+    /// This method does a `shift_remove`, which preserves the order of the fields in the schema but **is O(n)**. For a
+    /// faster, but not order-preserving, method, use [`remove`][Self::remove].
+    pub fn shift_remove_index(&mut self, index: usize) -> Option<(SmartString, DataType)> {
+        self.inner.shift_remove_index(index)
+    }
+
     /// Whether the schema contains a field named `name`
     pub fn contains(&self, name: &str) -> bool {
         self.get(name).is_some()

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
@@ -27,10 +27,15 @@ fn get_sort_fields(sort_idx: &[usize], sort_args: &SortArguments) -> Vec<SortFie
         .collect()
 }
 
+#[cfg(feature = "dtype-categorical")]
 fn sort_column_can_be_decoded(schema: &Schema, sort_idx: &[usize]) -> bool {
     !sort_idx
         .iter()
         .any(|i| matches!(schema.get_at_index(*i).unwrap().1, DataType::Categorical(_)))
+}
+#[cfg(not(feature = "dtype-categorical"))]
+fn sort_column_can_be_decoded(_schema: &Schema, _sort_idx: &[usize]) -> bool {
+    true
 }
 
 fn sort_by_idx<V: Clone>(values: &[V], idx: &[usize]) -> Vec<V> {

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
@@ -5,6 +5,7 @@ use polars_core::prelude::sort::arg_sort_multiple::_get_rows_encoded_compat_arra
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
 use polars_plan::prelude::*;
+use polars_row::decode::decode_rows_from_binary;
 use polars_row::SortField;
 
 use super::*;
@@ -25,11 +26,38 @@ fn get_sort_fields(sort_idx: &[usize], sort_args: &SortArguments) -> Vec<SortFie
         .collect()
 }
 
-fn finalize_dataframe(df: &mut DataFrame, sort_idx: &[usize], sort_args: &SortArguments) {
+fn sort_column_can_be_decoded(schema: &Schema, sort_idx: &[usize]) -> bool {
+    !sort_idx
+        .iter()
+        .any(|i| matches!(schema.get_at_index(*i).unwrap().1, DataType::Categorical(_)))
+}
+
+fn finalize_dataframe(
+    df: &mut DataFrame,
+    sort_idx: &[usize],
+    sort_args: &SortArguments,
+    can_decode: bool,
+    sort_dtypes: Option<&[ArrowDataType]>,
+    rows: &mut Vec<usize>,
+    sort_fields: &[SortField],
+) {
     unsafe {
         let cols = df.get_columns_mut();
         // pop the encoded sort column
-        let _ = cols.pop();
+        let encoded = cols.pop().unwrap();
+
+        if can_decode {
+            // safety:
+            // lifetime bound to this scope
+            // usize matches pointer/reference alignment and size
+            let rows = std::mem::transmute::<&mut Vec<usize>, &mut Vec<&'_ [u8]>>(rows);
+
+            let sort_dtypes = sort_dtypes.expect("should be set");
+            let encoded = encoded.binary().unwrap();
+            assert_eq!(encoded.chunks().len(), 1);
+            let arr = encoded.downcast_iter().next().unwrap();
+            decode_rows_from_binary(arr, sort_fields, sort_dtypes, rows);
+        }
 
         let first_sort_col = &mut cols[sort_idx[0]];
         let flag = if sort_args.descending[0] {
@@ -54,13 +82,30 @@ pub struct SortSinkMultiple {
     sort_args: SortArguments,
     // Needed for encoding
     sort_fields: Arc<[SortField]>,
+    sort_dtypes: Option<Arc<[DataType]>>,
     // amortize allocs
     sort_column: Vec<ArrayRef>,
+    // if we can decode the sort columns, we will remove those
+    // columns and decode the binary row-format to restore the
+    // original columns. This ensures we don't need to keep
+    // redundant data around in memory or on disk
+    can_decode: bool,
 }
 
 impl SortSinkMultiple {
     pub(crate) fn new(sort_args: SortArguments, schema: &Schema, sort_idx: Vec<usize>) -> Self {
+        let can_decode = sort_column_can_be_decoded(schema, &sort_idx);
         let mut schema = schema.clone();
+
+        let mut sort_dtypes = None;
+        if can_decode {
+            let mut dtypes = Vec::with_capacity(sort_idx.len());
+            // remove the sort indices as we will encode them into the sort binary
+            for i in &sort_idx {
+                dtypes.push(schema.shift_remove_index(*i).unwrap().1);
+            }
+            sort_dtypes = Some(dtypes.into());
+        }
         schema.with_column(POLARS_SORT_COLUMN.into(), DataType::Binary);
         let sort_fields = get_sort_fields(&sort_idx, &sort_args);
 
@@ -82,13 +127,15 @@ impl SortSinkMultiple {
             sort_args,
             sort_idx: Arc::from(sort_idx),
             sort_fields: Arc::from(sort_fields),
+            sort_dtypes,
             sort_column: vec![],
+            can_decode,
         }
     }
 
     fn encode(&mut self, chunk: &mut DataChunk) -> PolarsResult<()> {
-        let df = &chunk.data;
-        let cols = df.get_columns();
+        let df = &mut chunk.data;
+        let cols = unsafe { df.get_columns_mut() };
 
         self.sort_column.clear();
 
@@ -97,6 +144,23 @@ impl SortSinkMultiple {
             let arr = _get_rows_encoded_compat_array(s)?;
             self.sort_column.push(arr);
         }
+
+        if self.can_decode {
+            // we remove columns by index, but then the aren't correct anymore
+            // so we do it in the proper order and keep track of the indices removed
+            let mut sorted_sort_idx = self.sort_idx.to_vec();
+            sorted_sort_idx.sort_unstable();
+
+            sorted_sort_idx
+                .into_iter()
+                .enumerate()
+                .for_each(|(i, sort_idx)| {
+                    // shifts all columns right from removed one to the left so
+                    // therefore we subtract `i` as the shifted count
+                    let _ = cols.remove(sort_idx - i);
+                })
+        }
+
         let rows_encoded = polars_row::convert_columns(&self.sort_column, &self.sort_fields);
         let column = unsafe {
             Series::from_chunks_and_dtype_unchecked(
@@ -135,22 +199,41 @@ impl Sink for SortSinkMultiple {
             sort_fields: self.sort_fields.clone(),
             sort_args: self.sort_args.clone(),
             sort_column: vec![],
+            can_decode: self.can_decode,
+            sort_dtypes: self.sort_dtypes.clone(),
         })
     }
 
     fn finalize(&mut self, context: &PExecutionContext) -> PolarsResult<FinalizedSink> {
         let out = self.sort_sink.finalize(context)?;
 
+        let sort_dtypes = self
+            .sort_dtypes
+            .take()
+            .map(|arr| arr.iter().map(|dt| dt.to_arrow()).collect::<Vec<_>>());
+
         // we must adapt the finalized sink result so that the sort encoded column is dropped
         match out {
             FinalizedSink::Finished(mut df) => {
-                finalize_dataframe(&mut df, self.sort_idx.as_ref(), &self.sort_args);
+                finalize_dataframe(
+                    &mut df,
+                    self.sort_idx.as_ref(),
+                    &self.sort_args,
+                    self.can_decode,
+                    sort_dtypes.as_deref(),
+                    &mut vec![],
+                    self.sort_fields.as_ref(),
+                );
                 Ok(FinalizedSink::Finished(df))
             }
             FinalizedSink::Source(source) => Ok(FinalizedSink::Source(Box::new(DropEncoded {
                 source,
                 sort_idx: self.sort_idx.clone(),
                 sort_args: std::mem::take(&mut self.sort_args),
+                can_decode: self.can_decode,
+                sort_dtypes,
+                rows: vec![],
+                sort_fields: self.sort_fields.clone(),
             }))),
             // SortSink should not produce this branch
             FinalizedSink::Operator(_) => unreachable!(),
@@ -170,6 +253,10 @@ struct DropEncoded {
     source: Box<dyn Source>,
     sort_idx: Arc<[usize]>,
     sort_args: SortArguments,
+    can_decode: bool,
+    sort_dtypes: Option<Vec<ArrowDataType>>,
+    rows: Vec<usize>,
+    sort_fields: Arc<[SortField]>,
 }
 
 impl Source for DropEncoded {
@@ -177,7 +264,15 @@ impl Source for DropEncoded {
         let mut result = self.source.get_batches(context);
         if let Ok(SourceResult::GotMoreData(data)) = &mut result {
             for chunk in data {
-                finalize_dataframe(&mut chunk.data, self.sort_idx.as_ref(), &self.sort_args)
+                finalize_dataframe(
+                    &mut chunk.data,
+                    self.sort_idx.as_ref(),
+                    &self.sort_args,
+                    self.can_decode,
+                    self.sort_dtypes.as_deref(),
+                    &mut self.rows,
+                    self.sort_fields.as_ref(),
+                )
             }
         };
         result

--- a/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
+++ b/polars/polars-lazy/polars-pipe/src/pipeline/convert.rs
@@ -220,7 +220,7 @@ where
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;
 
-                let sort_sink = SortSinkMultiple::new(args.clone(), &input_schema, sort_idx);
+                let sort_sink = SortSinkMultiple::new(args.clone(), input_schema, sort_idx);
                 Box::new(sort_sink) as Box<dyn Sink>
             }
         }

--- a/polars/polars-row/src/decode.rs
+++ b/polars/polars-row/src/decode.rs
@@ -8,6 +8,22 @@ use crate::variable::decode_binary;
 /// # Safety
 /// This will not do any bound checks. Caller must ensure the `rows` are valid
 /// encodings.
+pub unsafe fn decode_rows_from_binary<'a>(
+    arr: &'a BinaryArray<i64>,
+    fields: &[SortField],
+    data_types: &[DataType],
+    rows: &mut Vec<&'a [u8]>,
+) -> Vec<ArrayRef> {
+    assert_eq!(arr.null_count(), 0);
+    rows.clear();
+    rows.extend(arr.values_iter());
+    decode_rows(rows, fields, data_types)
+}
+
+/// Decode `rows` into a arrow format
+/// # Safety
+/// This will not do any bound checks. Caller must ensure the `rows` are valid
+/// encodings.
 pub unsafe fn decode_rows(
     // the rows will be updated while the data is decoded
     rows: &mut [&[u8]],

--- a/polars/polars-row/src/fixed.rs
+++ b/polars/polars-row/src/fixed.rs
@@ -216,11 +216,11 @@ where
     let values = rows
         .iter()
         .map(|row| {
-            has_nulls |= *row.get_unchecked(0) == null_sentinel;
+            has_nulls |= *row.get_unchecked_release(0) == null_sentinel;
             // skip null sentinel
             let start = 1;
             let end = start + T::ENCODED_LEN - 1;
-            let slice = row.get_unchecked(start..end);
+            let slice = row.get_unchecked_release(start..end);
             let bytes = T::Encoded::from_slice(slice);
             T::decode(bytes)
         })
@@ -247,11 +247,11 @@ pub(super) unsafe fn decode_bool(rows: &mut [&[u8]], field: &SortField) -> Boole
     let values = rows
         .iter()
         .map(|row| {
-            has_nulls |= *row.get_unchecked(0) == null_sentinel;
+            has_nulls |= *row.get_unchecked_release(0) == null_sentinel;
             // skip null sentinel
             let start = 1;
             let end = start + bool::ENCODED_LEN - 1;
-            let slice = row.get_unchecked(start..end);
+            let slice = row.get_unchecked_release(start..end);
             let bytes = <bool as FixedLengthEncoding>::Encoded::from_slice(slice);
             bool::decode(bytes)
         })
@@ -271,12 +271,12 @@ pub(super) unsafe fn decode_bool(rows: &mut [&[u8]], field: &SortField) -> Boole
 }
 unsafe fn increment_row_counter(rows: &mut [&[u8]], fixed_size: usize) {
     for row in rows {
-        *row = row.get_unchecked(fixed_size..);
+        *row = row.get_unchecked_release(fixed_size..);
     }
 }
 
 pub(super) unsafe fn decode_nulls(rows: &[&[u8]], null_sentinel: u8) -> Bitmap {
     rows.iter()
-        .map(|row| *row.get_unchecked(0) != null_sentinel)
+        .map(|row| *row.get_unchecked_release(0) != null_sentinel)
         .collect()
 }


### PR DESCRIPTION
Out of core sort encodes the sort columns. This encoding is revertible. Currently the original columns were still around. This made the sort and especially the IO's more expensive.

Now they are removed and restored once the sort is finished.