### PR TITLE
feat(python): Add `Expr.to_series` for evaluating literal expressions

### DIFF
--- a/py-polars/docs/source/reference/expressions/miscellaneous.rst
+++ b/py-polars/docs/source/reference/expressions/miscellaneous.rst
@@ -9,3 +9,4 @@ Miscellaneous
     Expr.cache
     Expr.from_json
     Expr.set_sorted
+    Expr.to_series

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -257,6 +257,24 @@ class Expr:
         expr._pyexpr = PyExpr.meta_read_json(value)
         return expr
 
+    def to_series(self) -> Series:
+        """
+        Evaluate the expression without a context and return a ``Series``.
+
+        Examples
+        --------
+        >>> pl.arange(0, 3).to_series()
+        shape: (3,)
+        Series: 'arange' [i64]
+        [
+                0
+                1
+                2
+        ]
+
+        """
+        return F.select(self).to_series()
+
     def to_physical(self) -> Self:
         """
         Cast to physical representation of the logical dtype.

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -34,6 +34,7 @@ from polars.datatypes import (
 )
 from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
+from polars.exceptions import ColumnNotFoundError, InvalidOperationError
 from polars.expr.array import ExprArrayNameSpace
 from polars.expr.binary import ExprBinaryNameSpace
 from polars.expr.categorical import ExprCatNameSpace
@@ -273,7 +274,12 @@ class Expr:
         ]
 
         """
-        return F.select(self).to_series()
+        try:
+            return F.select(self).to_series()
+        except ColumnNotFoundError as exc:
+            raise InvalidOperationError(
+                "`to_series` only works on literal expressions."
+            ) from exc
 
     def to_physical(self) -> Self:
         """

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -399,9 +399,9 @@ def struct(
         expr = expr.cast(Struct(schema), strict=False)
 
     if eager:
-        return F.select(expr).to_series()
-    else:
-        return expr
+        return expr.to_series()
+
+    return expr
 
 
 def concat_str(

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -135,7 +135,7 @@ def arange(
     if dtype is not None and dtype != Int64:
         result = result.cast(dtype)
     if eager:
-        return F.select(result).to_series()
+        return result.to_series()
 
     return result
 

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -138,7 +138,7 @@ def repeat(
     if name is not None:
         expr = expr.alias(name)
     if eager:
-        return F.select(expr).to_series()
+        return expr.to_series()
     return expr
 
 

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -1135,3 +1135,9 @@ def test_extend_constant_arr(const: Any, dtype: pl.PolarsDataType) -> None:
     expected = pl.Series("s", [[const, const, const, const]], dtype=pl.List(dtype))
 
     assert_series_equal(s.list.eval(pl.element().extend_constant(const, 3)), expected)
+
+
+def test_expr_to_series() -> None:
+    result = pl.arange(0, 3).alias("x").to_series()
+    expected = pl.Series("x", [0, 1, 2], dtype=pl.Int64)
+    assert_series_equal(result, expected)

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -1141,3 +1141,8 @@ def test_expr_to_series() -> None:
     result = pl.arange(0, 3).alias("x").to_series()
     expected = pl.Series("x", [0, 1, 2], dtype=pl.Int64)
     assert_series_equal(result, expected)
+
+
+def test_expr_to_series_not_literal() -> None:
+    with pytest.raises(pl.InvalidOperationError):
+        pl.col("a").to_series()


### PR DESCRIPTION
I was looking at `arange` and I am unhappy with all functions having an `eager` argument. I think it's much cleaner if we introduce a `to_series` method on the `Expr` class to allow users to evaluate literal expressions.

Before:
`pl.arange(0, 3, eager=True)`
After:
`pl.arange(0, 3).to_series()`

Advantages:
* The expression functions become much cleaner: single return type and one less argument.
* The resulting syntax is easier to read and more transparent.
* It's in line with the Polars philosophy of offering a set of building blocks, rather than big monolithic functions with many arguments.

Previously, we decided to remove the `name` argument, as users can simply call `alias` on the result instead. This change is in the same line of thought.

If you agree with this approach, I will follow up with a PR for deprecating `eager=True` arguments for some functions.