### PR TITLE
fix(rust, python)!: fix truncate for sub-daily durations

### DIFF
--- a/polars/polars-time/src/windows/duration.rs
+++ b/polars/polars-time/src/windows/duration.rs
@@ -438,26 +438,12 @@ impl Duration {
             (0, 0, 0, 0) => polars_bail!(ComputeError: "duration cannot be zero"),
             // truncate by ns/us/ms
             (0, 0, 0, _) => {
-                let t = match tz {
-                    #[cfg(feature = "timezones")]
-                    Some(tz) => {
-                        datetime_to_timestamp(unlocalize_datetime(timestamp_to_datetime(t), tz))
-                    }
-                    _ => t,
-                };
                 let duration = nsecs_to_unit(self.nsecs);
                 let mut remainder = t % duration;
                 if remainder < 0 {
                     remainder += duration
                 }
-                match tz {
-                    #[cfg(feature = "timezones")]
-                    Some(tz) => Ok(datetime_to_timestamp(localize_datetime(
-                        timestamp_to_datetime(t - remainder),
-                        tz,
-                    )?)),
-                    _ => Ok(t - remainder),
-                }
+                Ok(t - remainder)
             }
             // truncate by weeks
             (0, _, 0, 0) => {

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -49,7 +49,9 @@ class ExprDateTimeNameSpace:
         every
             Every interval start and period length
         offset
-            Offset the window
+            Offset the window. This may be useful if you're working with a time zone
+            which has a non-round offset (such as Asia/Kathmandu, which is +05:45) and
+            your `every` is hourly.
 
         Notes
         -----

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1574,7 +1574,9 @@ class DateTimeNameSpace:
         every
             Every interval start and period length
         offset
-            Offset the window
+            Offset the window. This may be useful if you're working with a time zone
+            which has a non-round offset (such as Asia/Kathmandu, which is +05:45) and
+            your `every` is hourly.
 
         Notes
         -----

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2399,6 +2399,24 @@ def test_truncate_by_multiple_weeks() -> None:
     }
 
 
+def test_sub_daily_crossing_dst_9491() -> None:
+    df = pl.DataFrame(
+        {
+            "timestamp": pl.date_range(
+                datetime(2017, 4, 2),
+                datetime(2017, 4, 3),
+                timedelta(minutes=15),
+                time_zone="Australia/Sydney",
+                time_unit="ms",
+                eager=True,
+            ),
+        }
+    )
+    freq = "15m"
+    result = df.with_columns(pl.col("timestamp").dt.truncate(freq))
+    assert_frame_equal(result, df)
+
+
 def test_round_by_week() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -474,8 +474,16 @@ def test_groupby_when_then_with_binary_and_agg_in_pred_6202() -> None:
 
 
 @pytest.mark.parametrize("every", ["1h", timedelta(hours=1)])
-@pytest.mark.parametrize("tzinfo", [None, ZoneInfo("Asia/Kathmandu")])
-def test_groupby_dynamic_iter(every: str | timedelta, tzinfo: ZoneInfo | None) -> None:
+@pytest.mark.parametrize(
+    ("tzinfo", "offset"),
+    [
+        (None, None),
+        (ZoneInfo("Asia/Kathmandu"), "-45m"),
+    ],
+)
+def test_groupby_dynamic_iter(
+    every: str | timedelta, tzinfo: ZoneInfo | None, offset: str | None
+) -> None:
     time_zone = tzinfo.key if tzinfo is not None else None
     df = pl.DataFrame(
         {
@@ -493,7 +501,9 @@ def test_groupby_dynamic_iter(every: str | timedelta, tzinfo: ZoneInfo | None) -
     # Without 'by' argument
     result1 = [
         (name, data.shape)
-        for name, data in df.groupby_dynamic("datetime", every=every, closed="left")
+        for name, data in df.groupby_dynamic(
+            "datetime", every=every, closed="left", offset=offset
+        )
     ]
     expected1 = [
         (datetime(2020, 1, 1, 10, tzinfo=tzinfo), (2, 3)),
@@ -505,7 +515,7 @@ def test_groupby_dynamic_iter(every: str | timedelta, tzinfo: ZoneInfo | None) -
     result2 = [
         (name, data.shape)
         for name, data in df.groupby_dynamic(
-            "datetime", every=every, closed="left", by="a"
+            "datetime", every=every, closed="left", by="a", offset=offset
         )
     ]
     expected2 = [
@@ -517,8 +527,16 @@ def test_groupby_dynamic_iter(every: str | timedelta, tzinfo: ZoneInfo | None) -
 
 
 @pytest.mark.parametrize("every", ["1h", timedelta(hours=1)])
-@pytest.mark.parametrize("tzinfo", [None, ZoneInfo("Asia/Kathmandu")])
-def test_groupby_dynamic_lazy(every: str | timedelta, tzinfo: ZoneInfo | None) -> None:
+@pytest.mark.parametrize(
+    ("tzinfo", "offset"),
+    [
+        (None, None),
+        (ZoneInfo("Asia/Kathmandu"), "-45m"),
+    ],
+)
+def test_groupby_dynamic_lazy(
+    every: str | timedelta, tzinfo: ZoneInfo | None, offset: str | None
+) -> None:
     ldf = pl.LazyFrame(
         {
             "time": pl.date_range(
@@ -531,7 +549,7 @@ def test_groupby_dynamic_lazy(every: str | timedelta, tzinfo: ZoneInfo | None) -
         }
     )
     df = (
-        ldf.groupby_dynamic("time", every=every, closed="right")
+        ldf.groupby_dynamic("time", every=every, closed="right", offset=offset)
         .agg(
             [
                 pl.col("time").min().alias("time_min"),


### PR DESCRIPTION
closes #9491 

This affects what happens when truncating by sub-daily durations

Say one needs to truncate `2020-10-25 01:00:00 BST` by `'2h'`.

The current logic (on `main`) is:
- remove the time zone: `2020-10-25 01:00:00`
- truncate by `'2h'`: `2020-10-25 00:00:00`
- put the time zone back: `2020-10-25 00:00:00 BST`

Unfortunately, this creates issues when trying to truncate `2020-10-25 01:00:00 GMT` by `'1h'`, which results in
```python
ComputeError: datetime '2020-10-25 01:00:00' is ambiguous in time zone 'Europe/London'. Ambiguous datetimes are not yet supported
```

The revised logic (this branch) is much simpler: divide time since the UNIX Epoch into `'2h'` chunks, and truncate to the start of the window. So then, the above calculation would give `2020-10-25 01:00:00 GMT`, which seems expected.

Implications:
- for anyone in a time zone with a non-round offset (such as `'Asia/Kathmandu'`, which is `+05:45`), then the result of truncating by `'1h'` will change
- for anyone in a time zone with a round offset (i.e. almost all time zones), then truncating by `'1h'` will no longer unnecessarily throw `ComputeError`

Workaround for those affected:
- use the `offset` argument. This is very simple, as shown in this test: if you're in `Asia/Kathmandu`, you can just pass `offset='-45min'` and your results will be the same as before

---

NOTE: for calendar-aware durations (such as `'1d'`, `'1w'`, etc.) then the current logic is unaffected. This only affects what happens for sub-daily durations (e.g. `'15m'`), which represent a fixed duration in time which is not dependent on time zones