### PR TITLE
chore(rust): ensure date-range integration test runs in CI

### DIFF
--- a/polars/tests/it/main.rs
+++ b/polars/tests/it/main.rs
@@ -4,5 +4,6 @@ mod joins;
 #[cfg(feature = "lazy")]
 mod lazy;
 mod schema;
+mod time;
 
 pub static FOODS_CSV: &str = "../examples/datasets/foods1.csv";

--- a/polars/tests/it/time/date_range.rs
+++ b/polars/tests/it/time/date_range.rs
@@ -1,34 +1,29 @@
-use polars::time::date_range;
-use chrono::NaiveDate;
-
-use super::*;
+use polars::export::chrono::NaiveDate;
+use polars::prelude::*;
+use polars::time::{date_range, ClosedWindow, Duration};
 
 #[test]
-fn date_range() {
-
-    use super::*;
-    #[test]
-    fn test_date_range_9413() {
-        let start = NaiveDate::from_ymd_opt(2022, 1, 1)
-            .unwrap()
-            .and_hms_opt(0, 0, 0)
-            .unwrap();
-        let stop = NaiveDate::from_ymd_opt(2022, 1, 5)
-            .unwrap()
-            .and_hms_opt(0, 0, 0)
-            .unwrap();
-        let actual = date_range(
-            "date",
-            start,
-            stop,
-            Duration::parse("1d"),
-            ClosedWindow::Both,
-            TimeUnit::Milliseconds,
-            None,
-        )
-        .map(|date_range| date_range.into_series());
-        let result = format!("{:?}", actual);
-        let expected = r#"Ok(shape: (5,)
+fn test_time_units_9413() {
+    let start = NaiveDate::from_ymd_opt(2022, 1, 1)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap();
+    let stop = NaiveDate::from_ymd_opt(2022, 1, 5)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap();
+    let actual = date_range(
+        "date",
+        start,
+        stop,
+        Duration::parse("1d"),
+        ClosedWindow::Both,
+        TimeUnit::Milliseconds,
+        None,
+    )
+    .map(|date_range| date_range.into_series());
+    let result = format!("{:?}", actual);
+    let expected = r#"Ok(shape: (5,)
 Series: 'date' [datetime[ms]]
 [
 	2022-01-01 00:00:00
@@ -37,19 +32,19 @@ Series: 'date' [datetime[ms]]
 	2022-01-04 00:00:00
 	2022-01-05 00:00:00
 ])"#;
-        assert_eq!(result, expected);
-        let actual = date_range(
-            "date",
-            start,
-            stop,
-            Duration::parse("1d"),
-            ClosedWindow::Both,
-            TimeUnit::Microseconds,
-            None,
-        )
-        .map(|date_range| date_range.into_series());
-        let result = format!("{:?}", actual);
-        let expected = r#"Ok(shape: (5,)
+    assert_eq!(result, expected);
+    let actual = date_range(
+        "date",
+        start,
+        stop,
+        Duration::parse("1d"),
+        ClosedWindow::Both,
+        TimeUnit::Microseconds,
+        None,
+    )
+    .map(|date_range| date_range.into_series());
+    let result = format!("{:?}", actual);
+    let expected = r#"Ok(shape: (5,)
 Series: 'date' [datetime[μs]]
 [
 	2022-01-01 00:00:00
@@ -58,19 +53,19 @@ Series: 'date' [datetime[μs]]
 	2022-01-04 00:00:00
 	2022-01-05 00:00:00
 ])"#;
-        assert_eq!(result, expected);
-        let actual = date_range(
-            "date",
-            start,
-            stop,
-            Duration::parse("1d"),
-            ClosedWindow::Both,
-            TimeUnit::Nanoseconds,
-            None,
-        )
-        .map(|date_range| date_range.into_series());
-        let result = format!("{:?}", actual);
-        let expected = r#"Ok(shape: (5,)
+    assert_eq!(result, expected);
+    let actual = date_range(
+        "date",
+        start,
+        stop,
+        Duration::parse("1d"),
+        ClosedWindow::Both,
+        TimeUnit::Nanoseconds,
+        None,
+    )
+    .map(|date_range| date_range.into_series());
+    let result = format!("{:?}", actual);
+    let expected = r#"Ok(shape: (5,)
 Series: 'date' [datetime[ns]]
 [
 	2022-01-01 00:00:00
@@ -79,6 +74,6 @@ Series: 'date' [datetime[ns]]
 	2022-01-04 00:00:00
 	2022-01-05 00:00:00
 ])"#;
-        assert_eq!(result, expected);
-    }
+    assert_eq!(result, expected);
+    assert_eq!(result, expected);
 }

--- a/polars/tests/it/time/mod.rs
+++ b/polars/tests/it/time/mod.rs
@@ -1,0 +1,1 @@
+mod date_range;


### PR DESCRIPTION
I added a rust test in https://github.com/pola-rs/polars/pull/9413/files, but it looks like it hasn't actually been running in CI 🙈  This PR should fix that 

----

seems to have worked 🎉 CI logs show:
```
running 191 tests
test core::date_like::test_agg_list_type ... ok
test core::date_like::test_arithmetic_dispatch ... ok
test core::date_like::test_datelike_methods ... ok
test core::date_like::test_duration ... ok
test core::date_like::test_datelike_join ... ok
test core::groupby::test_sorted_groupby ... ok
test core::joins::empty_df_join ... ok
test core::joins::test_4_threads_bit_offset ... ok
test core::joins::test_chunked_left_join ... ok
test core::joins::test_inner_join ... ok
test core::joins::test_join_categorical ... ok
test core::joins::test_join_err ... ok
test core::joins::test_join_floats ... ok
test core::joins::test_join_nulls ... ok
test core::joins::test_join_with_nulls ... ok
test core::joins::test_joins_with_duplicates ... ok
test core::joins::test_join_multiple_columns ... ok
test core::joins::test_multi_joins_with_duplicates ... ok
test core::joins::test_outer_join ... ok
test core::joins::unit_df_join ... ok
test core::list::test_to_list_logical ... ok
test core::ops::take::test_list_take_nulls_and_empty ... ok
test core::pivot::test_pivot_2 ... ok
test core::pivot::test_pivot_categorical ... ok
test core::pivot::test_pivot_date ... ok
test core::pivot::test_pivot_datetime ... ok
test core::joins::test_left_join ... ok
test core::pivot::test_pivot_new ... ok
test core::rolling_window::test_median_quantile_types ... ok
test core::rolling_window::test_rolling ... ok
test core::rolling_window::test_rolling_apply ... ok
test core::pivot::test_pivot_old ... ok
test core::rolling_window::test_rolling_min_periods ... ok
test core::rolling_window::test_rolling_var ... ok
test core::series::test_aggregates ... ok
test core::rolling_window::test_rolling_mean ... ok
test core::series::test_min_max_sorted_asc ... ok
test core::series::test_min_max_sorted_desc ... ok
test core::series::test_series_arithmetic ... ok
test core::utils::test_df_macro_trailing_commas ... ok
test io::csv::test_automatic_datetime_parsing_default_formats ... ok
test io::csv::test_automatic_datetime_parsing ... ok
test io::csv::test_carriage_return ... ok
test io::csv::test_comma_separated_field_in_tsv ... ok
test io::csv::test_empty_bytes_to_dataframe ... ok
test io::csv::test_comment_lines ... ok
test io::csv::test_empty_csv ... ok
test io::csv::test_empty_string_cols ... ok
test io::csv::test_escape_2 ... ok
test io::csv::test_escape_comma ... ok
test io::csv::test_escape_double_quotes ... ok
test io::csv::test_escaping_quotes ... ok
test io::csv::test_header_inference ... ok
test io::csv::test_header_only ... ok
test io::csv::test_header_with_comments ... ok
test io::csv::test_ignore_parse_dates ... ok
test io::csv::test_infer_schema_0_rows ... ok
test io::csv::test_infer_schema_eol ... ok
test io::csv::test_last_line_incomplete ... ok
test io::csv::test_leading_whitespace_with_quote ... ok
test io::csv::test_missing_data ... ok
test io::csv::test_missing_fields ... ok
test io::csv::test_missing_value ... ok
test io::csv::test_new_line_escape ... ok
test io::csv::test_newline_in_custom_quote_char ... ok
test io::csv::test_new_line_escape_on_header ... ok
test io::csv::test_no_newline_at_end ... ok
test io::csv::test_no_quotes ... ok
test io::csv::test_null_values_infer_schema ... ok
test io::csv::test_null_values_argument ... ok
test io::csv::test_nulls_parser ... ok
test io::csv::test_parser ... ok
test io::csv::test_projection ... ok
test io::csv::test_projection_idx ... ok
test io::csv::test_projection_and_quoting ... ok
test io::csv::test_quoted_bool_ints ... ok
test io::csv::test_quoted_numeric ... ok
test io::csv::test_quoted_projection ... ok
test io::csv::test_read_csv_file ... ok
test io::csv::test_scientific_floats ... ok
test io::csv::test_skip_inference ... ok
test io::csv::test_skip_rows ... ok
test io::csv::test_trailing_empty_string_cols ... ok
test io::csv::test_tab_sep ... ok
test io::csv::test_try_parse_dates ... ok
test io::csv::test_try_parse_dates_3380 ... ok
test io::csv::test_tsv_header_offset ... ok
test io::csv::test_utf8 ... ok
test io::csv::test_very_long_utf8 ... ok
test io::csv::test_whitespace_skipping ... ok
test io::csv::test_whitespace_delimiters ... ok
test io::csv::test_with_dtype ... ok
test io::csv::test_with_row_count ... ok
test io::csv::write_csv ... ok
test io::ipc_stream::test::test_read_invalid_stream ... ok
test io::ipc_stream::test::test_read_ipc_stream_with_columns ... ok
test io::ipc_stream::test::test_read_ipc_stream_with_projection ... ok
test io::ipc_stream::test::test_write_with_compression ... ok
test io::ipc_stream::test::write_and_read_ipc_stream ... ok
test io::ipc_stream::test::write_and_read_ipc_stream_empty_series ... ok
test io::json::read_json ... ok
test io::json::read_json_with_escapes ... ok
test io::json::read_json_with_whitespace ... ok
test io::json::read_ndjson_with_trailing_newline ... ok
test io::json::read_unordered_json ... ok
test io::json::test_read_ndjson_iss_5875 ... ok
test io::json::test_read_ndjson_iss_5875_part2 ... ok
test io::json::test_read_ndjson_iss_5875_part3 ... ok
test io::json::test_read_ndjson_iss_6148 ... ok
test io::parquet::test_vstack_empty_3220 ... ok
test joins::join_empty_datasets ... ok
test lazy::aggregation::test_apply_multiple_error - should panic ... ok
test joins::join_nans_outer ... ok
test lazy::aggregation::test_lazy_agg ... ok
test lazy::aggregation::test_lazy_df_aggregations ... ok
test lazy::explodes::test_explode_row_numbers ... ok
test lazy::cse::test_cse_union_schema_6504 ... ok
test lazy::expressions::apply::test_arange_agg ... ok
test lazy::expressions::apply::test_apply_groups_empty ... ok
test lazy::expressions::apply::test_expand_list ... ok
test lazy::expressions::apply::test_groups_update_binary_shift_log ... ok
test lazy::expressions::apply::test_groups_update ... ok
test lazy::expressions::arity::includes_null_predicate_3038 ... ok
test lazy::expressions::arity::ternary_expand_sizes ... ok
test lazy::expressions::arity::test_binary_group_consistency ... ok
test lazy::expressions::arity::test_list_broadcast ... ok
test lazy::expressions::arity::test_null_commutativity ... ok
test lazy::expressions::arity::test_binary_over_3930 ... ok
test lazy::expressions::arity::test_update_groups_in_cast ... ok
test lazy::expressions::arity::test_ternary_aggregation_set_literals ... ok
test lazy::expressions::arity::test_when_then_otherwise_cats ... ok
test lazy::expressions::arity::test_when_then_otherwise_sum_in_agg ... ok
test lazy::expressions::expand::test_expand_datetimes_3042 ... ok
test lazy::expressions::arity::test_when_then_otherwise_single_bool ... ok
test lazy::expressions::is_in::test_is_in ... ok
test lazy::expressions::filter::test_filter_in_groupby_agg ... ok
test lazy::expressions::slice::test_slice_args ... ok
test lazy::expressions::window::test_exploded_window_function ... ok
test lazy::expressions::window::test_lazy_window_functions ... ok
test lazy::expressions::window::test_literal_window_fn ... ok
test lazy::expressions::window::test_reverse_in_groups ... ok
test lazy::expressions::window::test_sort_by_in_groups ... ok
test lazy::expressions::window::test_window_exprs_any_all ... ok
test lazy::expressions::window::test_window_exprs_in_binary_exprs ... ok
test lazy::expressions::window::test_window_map_empty_df_3542 ... ok
test lazy::expressions::window::test_shift_and_fill_window_function ... ok
test lazy::expressions::window::test_window_mapping ... ok
test lazy::expressions::window::test_window_naive_any ... ok
test lazy::groupby::test_filter_after_tail ... ok
test lazy::folds::test_fold_wildcard ... ok
test lazy::groupby::test_filter_aggregated_expression ... ok
test lazy::groupby::test_filter_sort_diff_2984 ... ok
test lazy::groupby::test_filter_diff_arithmetic ... ok
test lazy::groupby::test_groupby_lit_agg ... ok
test lazy::groupby::test_groupby_agg_list_with_not_aggregated ... ok
test lazy::groupby::test_logical_mean_partitioned_groupby_block ... ok
test lazy::groupby_dynamic::test_groupby_dynamic_week_bounds ... ok
test lazy::predicate_queries::filter_true_lit ... ok
test lazy::predicate_queries::test_count_blocked_at_union_3963 ... ok
test lazy::predicate_queries::test_filter_block_join ... ok
test lazy::predicate_queries::test_filter_no_combine ... ok
test lazy::predicate_queries::test_is_in_categorical_3420 ... ok
test lazy::predicate_queries::test_predicate_after_renaming ... ok
test lazy::predicate_queries::test_predicate_on_join_select_4884 ... ok
test lazy::predicate_queries::test_many_filters ... ok
test lazy::projection_queries::test_err_no_found ... ok
test lazy::predicate_queries::test_predicate_pushdown_blocked_by_outer_join ... ok
test lazy::projection_queries::test_join_duplicate_7314 ... ok
test lazy::projection_queries::test_outer_join_with_column_2988 ... ok
test lazy::projection_queries::test_many_aliasing_projections_5070 ... ok
test lazy::projection_queries::test_projection_5086 ... ok
test lazy::projection_queries::test_swap_rename ... ok
test lazy::projection_queries::test_sum_after_filter ... ok
test lazy::projection_queries::test_unnest_pushdown ... ok
test lazy::queries::test_alias_before_cast ... ok
test lazy::queries::max_on_empty_df_3027 ... ok
test lazy::queries::test_drop ... ok
test lazy::queries::test_apply_multiple_columns ... ok
test lazy::queries::test_sorted_path ... ok
test lazy::queries::test_groupby_on_lists ... ok
test lazy::queries::test_special_groupby_schemas ... ok
test lazy::queries::test_sorted_path_joins ... ok
test lazy::queries::test_unknown_supertype_ignore ... ok
test lazy::queries::test_with_duplicate_column_empty_df ... ok
test schema::test_getters ... ok
test schema::test_removal ... ok
test schema::test_schema_insert_at_index ... ok
test schema::test_schema_rename ... ok
test schema::test_set_dtype ... ok
test schema::test_with_column ... ok
test time::date_range::test_time_units_9413 ... ok

test result: ok. 191 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s
```

whereas previously it said "190 passed", without `test time::date_range`