### PR TITLE
feat(python): add a new `rows_by_key` method, returning a keyed-dictionary of row data

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8205,7 +8205,7 @@ class DataFrame:
         See Also
         --------
         iter_rows : Row iterator over frame data (does not materialise all rows).
-        rows : Materialise all frame data as a list of rows.
+        rows : Materialise all frame data as a list of rows (potentially expensive).
         item: Return dataframe element as a scalar.
 
         """
@@ -8306,6 +8306,7 @@ class DataFrame:
         See Also
         --------
         iter_rows : Row iterator over frame data (does not materialise all rows).
+        rows_by_key : Materialises frame data as a key-indexed dictionary.
 
         """
         if named:
@@ -8326,11 +8327,17 @@ class DataFrame:
         """
         Returns DataFrame data as a keyed dictionary of python-native values.
 
+        Note that this method should not be used in place of native operations, due to
+        the high cost of materialising all frame data into a dictionary; it should be
+        used only when you need to move the values out into a Python data structure
+        or other object that cannot operate directly with Polars/Arrow.
+
         Parameters
         ----------
         key
             The column(s) to use as the key for the returned dictionary. If multiple
-            columns are specified, the key will be a tuple of those values.
+            columns are specified, the key will be a tuple of those values, otherwise
+            it will be a string.
         named
             Return dictionary rows instead of tuples, mapping column name to row value.
         include_key
@@ -8402,7 +8409,7 @@ class DataFrame:
 
         See Also
         --------
-        rows : Materialise all frame data as a list of rows.
+        rows : Materialise all frame data as a list of rows (potentially expensive).
         iter_rows : Row iterator over frame data (does not materialise all rows).
 
         """
@@ -8533,7 +8540,8 @@ class DataFrame:
 
         See Also
         --------
-        rows : Materialises all frame data as a list of rows.
+        rows : Materialises all frame data as a list of rows (potentially expensive).
+        rows_by_key : Materialises frame data as a key-indexed dictionary.
 
         """
         # load into the local namespace for a (minor) performance boost in the hot loops

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8328,8 +8328,8 @@ class DataFrame:
         Returns DataFrame data as a keyed dictionary of python-native values.
 
         Note that this method should not be used in place of native operations, due to
-        the high cost of materialising all frame data into a dictionary; it should be
-        used only when you need to move the values out into a Python data structure
+        the high cost of materialising all frame data out into a dictionary; it should
+        be used only when you need to move the values out into a Python data structure
         or other object that cannot operate directly with Polars/Arrow.
 
         Parameters

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8324,7 +8324,7 @@ class DataFrame:
         unique: bool = False,
     ) -> dict[Any, Iterable[Any]]:
         """
-        Returns DataFrame data as a keyed-dictionary of python-native values.
+        Returns DataFrame data as a keyed dictionary of python-native values.
 
         Parameters
         ----------
@@ -8436,7 +8436,7 @@ class DataFrame:
         # returning a list of rows for each key, so append into a defaultdict.
         rows: dict[Any, Any] = {} if unique else defaultdict(list)
 
-        # return named values (key -> dict / list of dicts), eg:
+        # return named values (key -> dict | list of dicts), eg:
         # "{(key,): [{col:val, col:val, ...}],
         #   (key,): [{col:val, col:val, ...}],}"
         if named:
@@ -8453,7 +8453,7 @@ class DataFrame:
                     else:
                         rows[k].append(d)
 
-        # return values (key -> tuple / list of tuples), eg:
+        # return values (key -> tuple | list of tuples), eg:
         # "{(key,): [(val, val, ...)],
         #   (key,): [(val, val, ...)], ...}"
         elif unique:
@@ -8462,9 +8462,12 @@ class DataFrame:
                 if include_key
                 else {get_key(row): get_data(row) for row in self.iter_rows()}
             )
+        elif include_key:
+            for row in self.iter_rows(named=False):
+                rows[get_key(row)].append(row)
         else:
             for row in self.iter_rows(named=False):
-                rows[get_key(row)].append(row if include_key else get_data(row))
+                rows[get_key(row)].append(get_data(row))
 
         return rows
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6,8 +6,10 @@ import os
 import random
 import typing
 import warnings
+from collections import defaultdict
 from collections.abc import Sized
 from io import BytesIO, StringIO
+from operator import itemgetter
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -45,7 +47,6 @@ from polars.datatypes import (
     Time,
     Utf8,
     py_type_to_dtype,
-    unpack_dtypes,
 )
 from polars.dependencies import (
     _PYARROW_AVAILABLE,
@@ -89,6 +90,7 @@ from polars.utils.decorators import deprecated_alias
 from polars.utils.various import (
     _prepare_row_count_args,
     _process_null_values,
+    can_create_dicts_with_pyarrow,
     find_stacklevel,
     handle_projection_columns,
     is_bool_sequence,
@@ -141,6 +143,7 @@ if TYPE_CHECKING:
         RowTotalsDefinition,
         SchemaDefinition,
         SchemaDict,
+        SelectorType,
         SizeUnit,
         StartBy,
         UniqueKeepStrategy,
@@ -6695,7 +6698,8 @@ class DataFrame:
         ╞═════╪═════╪═════╡
         │ a   ┆ 1   ┆ 5   │
         │ a   ┆ 1   ┆ 3   │
-        └─────┴─────┴─────┘, shape: (2, 3)
+        └─────┴─────┴─────┘,
+        shape: (2, 3)
         ┌─────┬─────┬─────┐
         │ a   ┆ b   ┆ c   │
         │ --- ┆ --- ┆ --- │
@@ -6703,7 +6707,8 @@ class DataFrame:
         ╞═════╪═════╪═════╡
         │ b   ┆ 2   ┆ 4   │
         │ b   ┆ 3   ┆ 2   │
-        └─────┴─────┴─────┘, shape: (1, 3)
+        └─────┴─────┴─────┘,
+        shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ a   ┆ b   ┆ c   │
         │ --- ┆ --- ┆ --- │
@@ -6724,21 +6729,24 @@ class DataFrame:
         ╞═════╪═════╪═════╡
         │ a   ┆ 1   ┆ 5   │
         │ a   ┆ 1   ┆ 3   │
-        └─────┴─────┴─────┘, shape: (1, 3)
+        └─────┴─────┴─────┘,
+        shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ a   ┆ b   ┆ c   │
         │ --- ┆ --- ┆ --- │
         │ str ┆ i64 ┆ i64 │
         ╞═════╪═════╪═════╡
         │ b   ┆ 2   ┆ 4   │
-        └─────┴─────┴─────┘, shape: (1, 3)
+        └─────┴─────┴─────┘,
+        shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ a   ┆ b   ┆ c   │
         │ --- ┆ --- ┆ --- │
         │ str ┆ i64 ┆ i64 │
         ╞═════╪═════╪═════╡
         │ b   ┆ 3   ┆ 2   │
-        └─────┴─────┴─────┘, shape: (1, 3)
+        └─────┴─────┴─────┘,
+        shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ a   ┆ b   ┆ c   │
         │ --- ┆ --- ┆ --- │
@@ -6758,7 +6766,8 @@ class DataFrame:
         ╞═════╪═════╪═════╡
         │ a   ┆ 1   ┆ 5   │
         │ a   ┆ 1   ┆ 3   │
-        └─────┴─────┴─────┘, 'b': shape: (2, 3)
+        └─────┴─────┴─────┘,
+        'b': shape: (2, 3)
         ┌─────┬─────┬─────┐
         │ a   ┆ b   ┆ c   │
         │ --- ┆ --- ┆ --- │
@@ -6766,7 +6775,8 @@ class DataFrame:
         ╞═════╪═════╪═════╡
         │ b   ┆ 2   ┆ 4   │
         │ b   ┆ 3   ┆ 2   │
-        └─────┴─────┴─────┘, 'c': shape: (1, 3)
+        └─────┴─────┴─────┘,
+        'c': shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ a   ┆ b   ┆ c   │
         │ --- ┆ --- ┆ --- │
@@ -7901,11 +7911,10 @@ class DataFrame:
 
         """
         if isinstance(subset, str):
-            subset = [F.col(subset)]
+            expr = F.col(subset)
         elif isinstance(subset, pl.Expr):
-            subset = [subset]
-
-        if isinstance(subset, Sequence) and len(subset) == 1:
+            expr = subset
+        elif isinstance(subset, Sequence) and len(subset) == 1:
             expr = wrap_expr(parse_as_expression(subset[0]))
         else:
             struct_fields = F.all() if (subset is None) else subset
@@ -8196,7 +8205,7 @@ class DataFrame:
         See Also
         --------
         iter_rows : Row iterator over frame data (does not materialise all rows).
-        rows : Materialises all frame data as a list of rows.
+        rows : Materialise all frame data as a list of rows.
         item: Return dataframe element as a scalar.
 
         """
@@ -8264,12 +8273,14 @@ class DataFrame:
         -----
         If you have ``ns``-precision temporal values you should be aware that python
         natively only supports up to ``us``-precision; if this matters you should export
-        to a different format.
+        to a different format, as this method returns only python-native values.
 
         Warnings
         --------
         Row-iteration is not optimal as the underlying data is stored in columnar form;
         where possible, prefer export via one of the dedicated export/output methods.
+        Where possible you should also consider using ``iter_rows`` instead to avoid
+        materialising all the data at once.
 
         Returns
         -------
@@ -8279,14 +8290,18 @@ class DataFrame:
         --------
         >>> df = pl.DataFrame(
         ...     {
-        ...         "a": [1, 3, 5],
-        ...         "b": [2, 4, 6],
+        ...         "x": ["a", "b", "b", "a"],
+        ...         "y": [1, 2, 3, 4],
+        ...         "z": [0, 3, 6, 9],
         ...     }
         ... )
         >>> df.rows()
-        [(1, 2), (3, 4), (5, 6)]
+        [('a', 1, 0), ('b', 2, 3), ('b', 3, 6), ('a', 4, 9)]
         >>> df.rows(named=True)
-        [{'a': 1, 'b': 2}, {'a': 3, 'b': 4}, {'a': 5, 'b': 6}]
+        [{'x': 'a', 'y': 1, 'z': 0},
+         {'x': 'b', 'y': 2, 'z': 3},
+         {'x': 'b', 'y': 3, 'z': 6},
+         {'x': 'a', 'y': 4, 'z': 9}]
 
         See Also
         --------
@@ -8299,6 +8314,159 @@ class DataFrame:
             return [dict_(zip_(columns, row)) for row in self._df.row_tuples()]
         else:
             return self._df.row_tuples()
+
+    def rows_by_key(
+        self,
+        key: str | Sequence[str] | SelectorType,
+        *,
+        named: bool = False,
+        include_key: bool = False,
+        unique: bool = False,
+    ) -> dict[Any, Iterable[Any]]:
+        """
+        Returns DataFrame data as a keyed-dictionary of python-native values.
+
+        Parameters
+        ----------
+        key
+            The column(s) to use as the key for the returned dictionary. If multiple
+            columns are specified, the key will be a tuple of those values.
+        named
+            Return dictionary rows instead of tuples, mapping column name to row value.
+        include_key
+            Include key values inline with the associated data (by default the key
+            values are omitted as a memory/performance optimisation, as they can be
+            reoconstructed from the key).
+        unique
+            Indicate that the key is unique; this will result in a 1:1 mapping from
+            key to a single associated row. Note that if the key is *not* actually
+            unique the last row with the given key will be returned.
+
+        Notes
+        -----
+        If you have ``ns``-precision temporal values you should be aware that python
+        natively only supports up to ``us``-precision; if this matters you should export
+        to a different format, as this method returns only python-native values.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "w": ["a", "b", "b", "a"],
+        ...         "x": ["q", "q", "q", "k"],
+        ...         "y": [1.0, 2.5, 3.0, 4.5],
+        ...         "z": [9, 8, 7, 6],
+        ...     }
+        ... )
+
+        Group rows by the given key column(s):
+
+        >>> df.rows_by_key(key=["w"])
+        defaultdict(<class 'list'>,
+            {'a': [('q', 1.0, 9), ('k', 4.5, 6)],
+             'b': [('q', 2.5, 8), ('q', 3.0, 7)]})
+
+        Return the same row groupings as dictionaries:
+
+        >>> df.rows_by_key(key=["w"], named=True)
+        defaultdict(<class 'list'>,
+            {'a': [{'x': 'q', 'y': 1.0, 'z': 9},
+                   {'x': 'k', 'y': 4.5, 'z': 6}],
+             'b': [{'x': 'q', 'y': 2.5, 'z': 8},
+                   {'x': 'q', 'y': 3.0, 'z': 7}]})
+
+        Return row groupings, assuming keys are unique:
+
+        >>> df.rows_by_key(key=["z"], unique=True)
+        {9: ('a', 'q', 1.0),
+         8: ('b', 'q', 2.5),
+         7: ('b', 'q', 3.0),
+         6: ('a', 'k', 4.5)}
+
+        Return row groupings as dictionaries, assuming keys are unique:
+
+        >>> df.rows_by_key(key=["z"], named=True, unique=True)
+        {9: {'w': 'a', 'x': 'q', 'y': 1.0},
+         8: {'w': 'b', 'x': 'q', 'y': 2.5},
+         7: {'w': 'b', 'x': 'q', 'y': 3.0},
+         6: {'w': 'a', 'x': 'k', 'y': 4.5}}
+
+        Return dictionary rows grouped by a compound key, including key values:
+
+        >>> df.rows_by_key(key=["w", "x"], named=True, include_key=True)
+        defaultdict(<class 'list'>,
+            {('a', 'q'): [{'w': 'a', 'x': 'q', 'y': 1.0, 'z': 9}],
+             ('b', 'q'): [{'w': 'b', 'x': 'q', 'y': 2.5, 'z': 8},
+                          {'w': 'b', 'x': 'q', 'y': 3.0, 'z': 7}],
+             ('a', 'k'): [{'w': 'a', 'x': 'k', 'y': 4.5, 'z': 6}]})
+
+        See Also
+        --------
+        rows : Materialise all frame data as a list of rows.
+        iter_rows : Row iterator over frame data (does not materialise all rows).
+
+        """
+        from polars.selectors import is_selector, selector_column_names
+
+        if is_selector(key):
+            key = selector_column_names(frame=self, selector=key)  # type: ignore[type-var]
+        elif not isinstance(key, str):
+            key = tuple(key)  # type: ignore[arg-type]
+        else:
+            key = (key,)
+
+        # establish index or name-based getters for the key and data values
+        data_cols = [k for k in self.schema if k not in key]
+        if named:
+            get_data = itemgetter(*data_cols)
+            get_key = itemgetter(*key)
+        else:
+            data_idxs, index_idxs = [], []
+            for idx, c in enumerate(self.columns):
+                if c in key:
+                    index_idxs.append(idx)
+                else:
+                    data_idxs.append(idx)
+            if not index_idxs:
+                raise ValueError(f"No columns found for key: {key!r}")
+            get_data = itemgetter(*data_idxs)  # type: ignore[assignment]
+            get_key = itemgetter(*index_idxs)  # type: ignore[assignment]
+
+        # if unique, we expect to write just one entry per key; otherwise, we're
+        # returning a list of rows for each key, so append into a defaultdict.
+        rows: dict[Any, Any] = {} if unique else defaultdict(list)
+
+        # return named values (key -> dict / list of dicts), eg:
+        # "{(key,): [{col:val, col:val, ...}],
+        #   (key,): [{col:val, col:val, ...}],}"
+        if named:
+            if unique and include_key:
+                rows = {get_key(row): row for row in self.iter_rows(named=True)}
+            else:
+                for d in self.iter_rows(named=True):
+                    k = get_key(d)
+                    if not include_key:
+                        for ix in key:
+                            del d[ix]
+                    if unique:
+                        rows[k] = d
+                    else:
+                        rows[k].append(d)
+
+        # return values (key -> tuple / list of tuples), eg:
+        # "{(key,): [(val, val, ...)],
+        #   (key,): [(val, val, ...)], ...}"
+        elif unique:
+            rows = (
+                {get_key(row): row for row in self.iter_rows()}
+                if include_key
+                else {get_key(row): get_data(row) for row in self.iter_rows()}
+            )
+        else:
+            for row in self.iter_rows(named=False):
+                rows[get_key(row)].append(row if include_key else get_data(row))
+
+        return rows
 
     @overload
     def iter_rows(
@@ -8365,25 +8533,16 @@ class DataFrame:
         rows : Materialises all frame data as a list of rows.
 
         """
-        # load into the local namespace for a modest performance boost in the hot loops
+        # load into the local namespace for a (minor) performance boost in the hot loops
         columns, get_row, dict_, zip_ = self.columns, self.row, dict, zip
         has_object = Object in self.dtypes
 
         # note: buffering rows results in a 2-4x speedup over individual calls
         # to ".row(i)", so it should only be disabled in extremely specific cases.
         if buffer_size and not has_object:
-            load_pyarrow_dicts = (
-                named
-                and _PYARROW_AVAILABLE
-                # note: 'ns' precision instantiates values as pandas types - avoid
-                and not any(
-                    (getattr(tp, "time_unit", None) == "ns")
-                    for tp in unpack_dtypes(*self.dtypes)
-                )
-            )
             for offset in range(0, self.height, buffer_size):
                 zerocopy_slice = self.slice(offset, buffer_size)
-                if load_pyarrow_dicts:
+                if named and can_create_dicts_with_pyarrow(self.dtypes):
                     yield from zerocopy_slice.to_arrow().to_pylist()
                 else:
                     rows_chunk = zerocopy_slice.rows(named=False)

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -130,7 +130,6 @@ def _read_sql_connectorx(
         partition_num=partition_num,
         protocol=protocol,
     )
-
     return from_arrow(tbl)  # type: ignore[return-value]
 
 
@@ -146,21 +145,23 @@ def _read_sql_adbc(query: str, connection_uri: str) -> DataFrame:
 def _open_adbc_connection(connection_uri: str) -> Any:
     if connection_uri.startswith("sqlite"):
         try:
-            import adbc_driver_sqlite.dbapi as adbc  # type: ignore[import]
+            import adbc_driver_sqlite.dbapi as adbc_sqlite
         except ImportError:
             raise ImportError(
                 "ADBC sqlite driver not detected. Please run `pip install "
                 "adbc_driver_sqlite pyarrow`."
             ) from None
         connection_uri = connection_uri.replace(r"sqlite:///", "")
+        return adbc_sqlite.connect(connection_uri)
+
     elif connection_uri.startswith("postgres"):
         try:
-            import adbc_driver_postgresql.dbapi as adbc  # type: ignore[import]
+            import adbc_driver_postgresql.dbapi as adbc_postgres
         except ImportError:
             raise ImportError(
                 "ADBC postgresql driver not detected. Please run `pip install "
                 "adbc_driver_postgresql pyarrow`."
             ) from None
-    else:
-        raise ValueError("ADBC does not currently support this database.")
-    return adbc.connect(connection_uri)
+        return adbc_postgres.connect(connection_uri)
+
+    raise ValueError("ADBC does not currently support this database.")

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from polars.dependencies import pandas as pd
     from polars.dependencies import pyarrow as pa
     from polars.functions.whenthen import WhenThen, WhenThenThen
+    from polars.selectors import _selector_proxy_
 
     if sys.version_info >= (3, 10):
         from typing import TypeAlias
@@ -72,6 +73,9 @@ PythonLiteral: TypeAlias = Union[
 
 IntoExpr: TypeAlias = Union[PolarsExprType, PythonLiteral, "Series", None]
 ComparisonOperator: TypeAlias = Literal["eq", "neq", "gt", "lt", "gt_eq", "lt_eq"]
+
+# selector type
+SelectorType: TypeAlias = "_selector_proxy_"
 
 # User-facing string literal types
 # The following all have an equivalent Rust enum with the same name

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -19,7 +19,9 @@ from polars.datatypes import (
     Time,
     Utf8,
     is_polars_dtype,
+    unpack_dtypes,
 )
+from polars.dependencies import _PYARROW_AVAILABLE
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -174,6 +176,18 @@ def arrlen(obj: Any) -> int | None:
         return None if isinstance(obj, str) else len(obj)
     except TypeError:
         return None
+
+
+def can_create_dicts_with_pyarrow(dtypes: Sequence[PolarsDataType]) -> bool:
+    """Check if the given dtypes can be used to create dicts with pyarrow fast path."""
+    # TODO: have our own fast-path for dict iteration in Rust
+    return (
+        _PYARROW_AVAILABLE
+        # note: 'ns' precision instantiates values as pandas types - avoid
+        and not any(
+            (getattr(tp, "time_unit", None) == "ns") for tp in unpack_dtypes(*dtypes)
+        )
+    )
 
 
 def normalise_filepath(path: str | Path, check_not_directory: bool = True) -> str:

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -71,6 +71,8 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = [
   "IPython.*",
+  "adbc_driver_postgresql.*",
+  "adbc_driver_sqlite.*",
   "backports",
   "connectorx",
   "deltalake.*",

--- a/py-polars/tests/unit/test_rows.py
+++ b/py-polars/tests/unit/test_rows.py
@@ -69,6 +69,98 @@ def test_rows() -> None:
     ]
 
 
+def test_rows_by_key() -> None:
+    df = pl.DataFrame(
+        {
+            "w": ["a", "b", "b", "a"],
+            "x": ["q", "q", "q", "k"],
+            "y": [1.0, 2.5, 3.0, 4.5],
+            "z": [9, 8, 7, 6],
+        }
+    )
+
+    # tuple (unnamed) rows
+    assert df.rows_by_key("w") == {
+        "a": [("q", 1.0, 9), ("k", 4.5, 6)],
+        "b": [("q", 2.5, 8), ("q", 3.0, 7)],
+    }
+    assert df.rows_by_key("w", unique=True) == {
+        "a": ("k", 4.5, 6),
+        "b": ("q", 3.0, 7),
+    }
+    assert df.rows_by_key("w", include_key=True) == {
+        "a": [("a", "q", 1.0, 9), ("a", "k", 4.5, 6)],
+        "b": [("b", "q", 2.5, 8), ("b", "q", 3.0, 7)],
+    }
+    assert df.rows_by_key("w", include_key=True) == {
+        key: grp.rows() for key, grp in df.groupby("w")
+    }
+    assert df.rows_by_key("w", include_key=True, unique=True) == {
+        "a": ("a", "k", 4.5, 6),
+        "b": ("b", "q", 3.0, 7),
+    }
+    assert df.rows_by_key(["x", "w"]) == {
+        ("a", "q"): [(1.0, 9)],
+        ("b", "q"): [(2.5, 8), (3.0, 7)],
+        ("a", "k"): [(4.5, 6)],
+    }
+    assert df.rows_by_key(["w", "x"], include_key=True) == {
+        ("a", "q"): [("a", "q", 1.0, 9)],
+        ("a", "k"): [("a", "k", 4.5, 6)],
+        ("b", "q"): [("b", "q", 2.5, 8), ("b", "q", 3.0, 7)],
+    }
+    assert df.rows_by_key(["w", "x"], include_key=True, unique=True) == {
+        ("a", "q"): ("a", "q", 1.0, 9),
+        ("b", "q"): ("b", "q", 3.0, 7),
+        ("a", "k"): ("a", "k", 4.5, 6),
+    }
+
+    # dict (named) rows
+    assert df.rows_by_key("w", named=True) == {
+        "a": [{"x": "q", "y": 1.0, "z": 9}, {"x": "k", "y": 4.5, "z": 6}],
+        "b": [{"x": "q", "y": 2.5, "z": 8}, {"x": "q", "y": 3.0, "z": 7}],
+    }
+    assert df.rows_by_key("w", named=True, unique=True) == {
+        "a": {"x": "k", "y": 4.5, "z": 6},
+        "b": {"x": "q", "y": 3.0, "z": 7},
+    }
+    assert df.rows_by_key("w", named=True, include_key=True) == {
+        "a": [
+            {"w": "a", "x": "q", "y": 1.0, "z": 9},
+            {"w": "a", "x": "k", "y": 4.5, "z": 6},
+        ],
+        "b": [
+            {"w": "b", "x": "q", "y": 2.5, "z": 8},
+            {"w": "b", "x": "q", "y": 3.0, "z": 7},
+        ],
+    }
+    assert df.rows_by_key("w", named=True, include_key=True) == {
+        key: grp.rows(named=True) for key, grp in df.groupby("w")
+    }
+    assert df.rows_by_key("w", named=True, include_key=True, unique=True) == {
+        "a": {"w": "a", "x": "k", "y": 4.5, "z": 6},
+        "b": {"w": "b", "x": "q", "y": 3.0, "z": 7},
+    }
+    assert df.rows_by_key(["x", "w"], named=True) == {
+        ("q", "a"): [{"y": 1.0, "z": 9}],
+        ("q", "b"): [{"y": 2.5, "z": 8}, {"y": 3.0, "z": 7}],
+        ("k", "a"): [{"y": 4.5, "z": 6}],
+    }
+    assert df.rows_by_key(["w", "x"], named=True, include_key=True) == {
+        ("a", "q"): [{"w": "a", "x": "q", "y": 1.0, "z": 9}],
+        ("a", "k"): [{"w": "a", "x": "k", "y": 4.5, "z": 6}],
+        ("b", "q"): [
+            {"w": "b", "x": "q", "y": 2.5, "z": 8},
+            {"w": "b", "x": "q", "y": 3.0, "z": 7},
+        ],
+    }
+    assert df.rows_by_key(["w", "x"], named=True, include_key=True, unique=True) == {
+        ("a", "q"): {"w": "a", "x": "q", "y": 1.0, "z": 9},
+        ("b", "q"): {"w": "b", "x": "q", "y": 3.0, "z": 7},
+        ("a", "k"): {"w": "a", "x": "k", "y": 4.5, "z": 6},
+    }
+
+
 def test_iter_rows() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
Offers multiple ways of retrieving key-partitioned python native values out of a DataFrame, grouping by a given key (similar to `df.partition_by`, but efficiently returning the raw data instead of frames). Operates in a single pass through the data (mediated by `iter_rows`), irrespective of how many columns there are in the key or in which order they appear.

**Options** (in addition to specifying the partition key):

* `named`: return dictionary data instead of tuples.
* `include_key`: key values are omitted from data values by default; include them.
* `unique`: assume that only one value is returned per-key, returning a single tuple/dict instead of a list of such (if that is not actually the case then the last matching value is picked). 

**Misc**:

* Also contains a fix for some new lint in `io.database` (something in CI may have updated 🤔).

## Examples

Note that the function supports setting the key using selectors -as demonstrated below- as well as the usual column names (I'm going to look over the API to see if/where there are other functions that currently only take column names as strings that would benefit from the same capability).

```python
import polars.selectors as cs
import polars as pl

df = pl.DataFrame(
    {
        "w": ["a", "b", "b", "a"],
        "x": ["q", "q", "q", "k"],
        "y": [1.0, 2.5, 3.0, 4.5],
        "z": [9, 8, 7, 6],
    }
)

df.rows_by_key( key="w" )
# defaultdict(<class 'list'>, {
#     'a': [('q', 1.0, 9), ('k', 4.5, 6)],
#     'b': [('q', 2.5, 8), ('q', 3.0, 7)],
# })

df.rows_by_key( key=cs.string() )  # << equivalent to key=["w","x"]
# defaultdict(<class 'list'>, {
#     ('a', 'q'): [(1.0, 9)], 
#     ('b', 'q'): [(2.5, 8), (3.0, 7)], 
#     ('a', 'k'): [(4.5, 6)],
# })

df.rows_by_key( key=["w","x"], named=True )
# defaultdict(<class 'list'>, {
#     ('a', 'q'): [{'y': 1.0, 'z': 9}], 
#     ('b', 'q'): [{'y': 2.5, 'z': 8}, {'y': 3.0, 'z': 7}], 
#     ('a', 'k'): [{'y': 4.5, 'z': 6}].
# })

df.rows_by_key( key=["w","x"], named=True, include_key=True )
# defaultdict(<class 'list'>, {
#     ('a', 'q'): [{'w': 'a', 'x': 'q', 'y': 1.0, 'z': 9}], 
#     ('b', 'q'): [{'w': 'b', 'x': 'q', 'y': 2.5, 'z': 8}, 
#                  {'w': 'b', 'x': 'q', 'y': 3.0, 'z': 7}],
#     ('a', 'k'): [{'w': 'a', 'x': 'k', 'y': 4.5, 'z': 6}],
# })

df.rows_by_key( key="z", named=True, include_key=True, unique=True )
# {9: {'w': 'a', 'x': 'q', 'y': 1.0, 'z': 9}, 
#  8: {'w': 'b', 'x': 'q', 'y': 2.5, 'z': 8}, 
#  7: {'w': 'b', 'x': 'q', 'y': 3.0, 'z': 7}, 
#  6: {'w': 'a', 'x': 'k', 'y': 4.5, 'z': 6}}
```

## Note

The same (basic) result is achievable by iterating over the keys & frames returned from a `groupby` object; however (in addition to `rows_by_key` having more options) the overhead involved in iterating over constructed frames vs a single-iteration fast path becomes evident as soon as cardinality becomes non-trivial:

<picture>
  <source media="(prefers-color-scheme: light)" srcset="https://github.com/pola-rs/polars/assets/2613171/491b9b5c-3c97-4fa6-a1ad-6d780bcfa26a">
  <img src="https://github.com/pola-rs/polars/assets/2613171/a707b492-5b5e-4334-b840-edac5c3883ff">
</picture>

* _performance values derived from testing against a 100,000 row x 13 col dataframe._

The following are equivalent (but the newer method is stable and faster):
* `res1 = df.rows_by_key( key, include_key=True ) `
* `res2 = { cols: grp.rows() for cols, grp in df.groupby(key) }`