### PR TITLE
fix(sql): allow proper aliasing when joining

### DIFF
--- a/polars/polars-sql/src/context.rs
+++ b/polars/polars-sql/src/context.rs
@@ -428,7 +428,10 @@ impl SQLContext {
                 }
                 let tbl_name = name.0.get(0).unwrap().value.as_str();
                 if let Some(lf) = self.get_table_from_current_scope(tbl_name) {
-                    Ok((tbl_name.to_string(), lf))
+                    match alias {
+                        Some(alias) => Ok((alias.to_string(), lf)),
+                        None => Ok((tbl_name.to_string(), lf)),
+                    }
                 } else {
                     polars_bail!(ComputeError: "relation '{}' was not found", tbl_name);
                 }

--- a/polars/polars-sql/tests/statements.rs
+++ b/polars/polars-sql/tests/statements.rs
@@ -159,3 +159,25 @@ fn test_drop_table() {
     let res = ctx.execute("SELECT * FROM df");
     assert!(res.is_err());
 }
+
+#[test]
+fn iss_9560_join_as() {
+    let df1 = df! {"id"=> [1, 2, 3, 4], "ano"=> [2, 3, 4, 5]}.unwrap();
+    let df2 = df! {"id"=> [1, 2, 3, 4], "ano"=> [2, 3, 4, 5]}.unwrap();
+    let mut ctx = SQLContext::new();
+    ctx.register("df1", df1.lazy());
+    ctx.register("df2", df2.lazy());
+    let sql = r#"
+        SELECT * FROM df1 AS t1 JOIN df2 AS t2 ON t1.id = t2.id
+    "#;
+    let actual = ctx.execute(sql).unwrap().collect().unwrap();
+
+    let expected = df! {
+        "id" => [1, 2, 3, 4],
+        "ano" => [2, 3, 4, 5],
+        "ano_right" => [2, 3, 4, 5],
+    }
+    .unwrap();
+
+    assert!(actual.frame_equal(&expected));
+}


### PR DESCRIPTION
closes #9560. 

we weren't applying the alias when we were resolving the table name. 