### PR TITLE
fix(rust, python): fix sum consistency

### DIFF
--- a/polars/polars-core/src/chunked_array/ops/mod.rs
+++ b/polars/polars-core/src/chunked_array/ops/mod.rs
@@ -354,7 +354,8 @@ pub trait ChunkApply<'a, A, B> {
 /// Aggregation operations
 pub trait ChunkAgg<T> {
     /// Aggregate the sum of the ChunkedArray.
-    /// Returns `None` if the array is empty or only contains null values.
+    /// Returns `None` if not implemented for `T`.
+    /// If the array is empty, `0` is returned
     fn sum(&self) -> Option<T> {
         None
     }

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -265,3 +265,11 @@ def test_mapped_literal_to_literal_9217() -> None:
     assert df.groupby(True).agg(
         pl.struct(pl.lit("unique_id").alias("unique_id"))
     ).to_dict(False) == {"literal": [True], "unique_id": [{"unique_id": "unique_id"}]}
+
+
+def test_sum_empty_and_null_set() -> None:
+    series = pl.Series("a", [])
+    assert series.sum() == 0
+
+    series = pl.Series("a", [None])
+    assert series.sum() == 0

--- a/py-polars/tests/unit/test_series.py
+++ b/py-polars/tests/unit/test_series.py
@@ -371,16 +371,6 @@ def test_arithmetic(s: pl.Series) -> None:
         +a
 
 
-def test_arithmetic_empty() -> None:
-    series = pl.Series("a", [])
-    assert series.sum() == 0
-
-
-def test_arithmetic_null() -> None:
-    series = pl.Series("a", [None])
-    assert series.sum() is None
-
-
 def test_power() -> None:
     a = pl.Series([1, 2], dtype=Int64)
     b = pl.Series([None, 2.0], dtype=Float64)


### PR DESCRIPTION
empty set and null set should sum to `0`. Fixes #9558