### PR TITLE
fix(python): ensure `from_dicts` drops columns explicitly omitted from schema

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -110,8 +110,8 @@ def from_dicts(
 
         If you want to drop some of the fields found in the input dictionaries, a
         _partial_ schema can be declared, in which case omitted fields will not be
-        loaded. Similarly you can extend the loaded frame with empty columns by adding
-        them to the schema.
+        loaded. Similarly, you can extend the loaded frame with empty columns by
+        adding them to the schema.
     schema_overrides : dict, default None
         Support override of inferred types for one or more columns.
     infer_schema_length

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1036,14 +1036,9 @@ def _sequence_of_dict_to_pydf(
     )
     pydf = PyDataFrame.read_dicts(data, infer_schema_length, dicts_schema)
 
-    if column_names:
-        if len(column_names) < len(pydf.columns()):
-            schema_cols = set(column_names)
-            column_names = [c for c in pydf.columns() if c in schema_cols]
-        elif set(column_names).intersection(pydf.columns()):
-            column_names = []
-
-    if column_names or schema_overrides:
+    if not schema_overrides and set(pydf.columns()) == set(column_names):
+        pass
+    elif column_names or schema_overrides:
         pydf = _post_apply_columns(
             pydf,
             columns=column_names,

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1036,8 +1036,13 @@ def _sequence_of_dict_to_pydf(
     )
     pydf = PyDataFrame.read_dicts(data, infer_schema_length, dicts_schema)
 
-    if column_names and set(column_names).intersection(pydf.columns()):
-        column_names = []
+    if column_names:
+        if len(column_names) < len(pydf.columns()):
+            schema_cols = set(column_names)
+            column_names = [c for c in pydf.columns() if c in schema_cols]
+        elif set(column_names).intersection(pydf.columns()):
+            column_names = []
+
     if column_names or schema_overrides:
         pydf = _post_apply_columns(
             pydf,

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -13,7 +13,7 @@ import pytest
 
 import polars as pl
 from polars.dependencies import _ZONEINFO_AVAILABLE, dataclasses, pydantic
-from polars.exceptions import TimeZoneAwareConstructorWarning
+from polars.exceptions import ShapeError, TimeZoneAwareConstructorWarning
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.utils._construction import type_hints
 
@@ -958,6 +958,10 @@ def test_from_dicts_missing_columns() -> None:
     # missing columns in the schema; only load the declared keys
     data = [{"a": 1, "b": 2}]
     assert pl.from_dicts(data, schema=["a"]).to_dict(False) == {"a": [1]}
+
+    # invalid
+    with pytest.raises(ShapeError):
+        pl.from_dicts([{"a": 1, "b": 2}], schema=["xyz"])
 
 
 @no_type_check

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -948,12 +948,16 @@ def test_u64_lit_5031() -> None:
 
 
 def test_from_dicts_missing_columns() -> None:
+    # missing columns from some of the data dicts
     data = [
         {"a": 1},
         {"b": 2},
     ]
-
     assert pl.from_dicts(data).to_dict(False) == {"a": [1, None], "b": [None, 2]}
+
+    # missing columns in the schema; only load the declared keys
+    data = [{"a": 1, "b": 2}]
+    assert pl.from_dicts(data, schema=["a"]).to_dict(False) == {"a": [1]}
 
 
 @no_type_check


### PR DESCRIPTION
Closes #9570; ensures consistent behaviour between dict/list schema.