### PR TITLE
fix(rust): make json feature depend on "dtype-struct" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "polars/polars-row",
   "polars/polars-json",
   "examples/read_csv",
+  "examples/read_json",
   "examples/read_parquet",
   "examples/read_parquet_cloud",
   "examples/string_filter",

--- a/examples/read_json/Cargo.toml
+++ b/examples/read_json/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "read_json"
+version = "0.1.0"
 edition = "2021"
-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/examples/read_json/Cargo.toml
+++ b/examples/read_json/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "read_json"
+edition = "2021"
+version.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+polars = { path = "../../polars", features = ["json"] }

--- a/examples/read_json/src/main.rs
+++ b/examples/read_json/src/main.rs
@@ -1,0 +1,18 @@
+use std::io::Cursor;
+
+use polars::prelude::*;
+
+fn main() {
+    let data = r#"[
+        {"date": "1996-12-16T00:00:00.000", "open": 16.86, "close": 16.86, "high": 16.86, "low": 16.86, "volume": 62442.0, "turnover": 105277000.0},
+        {"date": "1996-12-17T00:00:00.000", "open": 15.17, "close": 15.17, "high": 16.79, "low": 15.17, "volume": 463675.0, "turnover": 718902016.0},
+        {"date": "1996-12-18T00:00:00.000", "open": 15.28, "close": 16.69, "high": 16.69, "low": 15.18, "volume": 445380.0, "turnover": 719400000.0},
+        {"date": "1996-12-19T00:00:00.000", "open": 17.01, "close": 16.4, "high": 17.9, "low": 15.99, "volume": 572946.0, "turnover": 970124992.0}
+    ]"#;
+
+    let res = JsonReader::new(Cursor::new(data)).finish();
+    println!("{:?}", res);
+    assert!(res.is_ok());
+    let df = res.unwrap();
+    println!("{:?}", df);
+}

--- a/polars/Cargo.toml
+++ b/polars/Cargo.toml
@@ -46,7 +46,7 @@ strings = ["polars-core/strings", "polars-lazy/strings", "polars-ops/strings"]
 object = ["polars-core/object", "polars-lazy/object", "polars-io/object"]
 
 # support for arrows json parsing
-json = ["polars-io", "polars-io/json", "polars-lazy/json", "polars-sql/json"]
+json = ["polars-io", "polars-io/json", "polars-lazy/json", "polars-sql/json", "dtype-struct"]
 
 # support for arrows ipc file parsing
 ipc = ["polars-io", "polars-io/ipc", "polars-lazy/ipc", "polars-sql/ipc"]


### PR DESCRIPTION
closes #9584

due to how the json parser is implemented, it uses the `Struct` dtype. As a result, the `json` feature had an implicit dependency on `dtype-struct` & would not parse anything without having that feature enabled. 

### Solution
added `dtype-struct` to the json feature dependencies
I also added a MWE in the examples dir. 