### PR TITLE
feat(rust, python): allow to specify index order in `to_numpy`

### DIFF
--- a/polars/polars-core/src/chunked_array/mod.rs
+++ b/polars/polars-core/src/chunked_array/mod.rs
@@ -19,7 +19,7 @@ pub mod float;
 pub mod iterator;
 pub mod kernels;
 #[cfg(feature = "ndarray")]
-mod ndarray;
+pub(crate) mod ndarray;
 
 #[cfg(feature = "dtype-array")]
 pub(crate) mod array;

--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -17,6 +17,8 @@ pub use crate::chunked_array::builder::{
 pub use crate::chunked_array::iterator::PolarsIterator;
 #[cfg(feature = "dtype-categorical")]
 pub use crate::chunked_array::logical::categorical::*;
+#[cfg(feature = "ndarray")]
+pub use crate::chunked_array::ndarray::IndexOrder;
 #[cfg(feature = "object")]
 pub use crate::chunked_array::object::PolarsObject;
 pub use crate::chunked_array::ops::aggregate::*;

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3090,7 +3090,6 @@ class DataFrame:
 
             # do not remove this
             # needed below
-            import pyarrow.parquet
 
             pa.parquet.write_table(
                 table=tbl,

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -86,6 +86,7 @@ FillNullStrategy: TypeAlias = Literal[
     "forward", "backward", "min", "max", "mean", "zero", "one"
 ]
 FloatFmt: TypeAlias = Literal["full", "mixed"]
+IndexOrder: TypeAlias = Literal["c", "fortran"]
 IpcCompression: TypeAlias = Literal["uncompressed", "lz4", "zstd"]
 JoinValidation: TypeAlias = Literal["m:m", "m:1", "1:m", "1:1"]
 NullBehavior: TypeAlias = Literal["ignore", "drop"]

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -13,7 +13,7 @@ use polars::prelude::AnyValue;
 use polars::series::ops::NullBehavior;
 use polars_core::frame::hash_join::JoinValidation;
 use polars_core::frame::row::any_values_to_dtype;
-use polars_core::prelude::QuantileInterpolOptions;
+use polars_core::prelude::{IndexOrder, QuantileInterpolOptions};
 use polars_core::utils::arrow::types::NativeType;
 use polars_lazy::prelude::*;
 use pyo3::basic::CompareOp;
@@ -1144,6 +1144,21 @@ impl FromPyObject<'_> for Wrap<ParallelStrategy> {
             v => {
                 return Err(PyValueError::new_err(format!(
                     "parallel must be one of {{'auto', 'columns', 'row_groups', 'none'}}, got {v}",
+                )))
+            }
+        };
+        Ok(Wrap(parsed))
+    }
+}
+
+impl FromPyObject<'_> for Wrap<IndexOrder> {
+    fn extract(ob: &PyAny) -> PyResult<Self> {
+        let parsed = match ob.extract::<&str>()? {
+            "fortran" => IndexOrder::Fortran,
+            "c" => IndexOrder::C,
+            v => {
+                return Err(PyValueError::new_err(format!(
+                    "order must be one of {{'fortran', 'c'}}, got {v}",
                 )))
             }
         };

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -13,7 +13,7 @@ use polars::prelude::*;
 use polars_core::export::arrow::datatypes::IntegerType;
 use polars_core::frame::explode::MeltArgs;
 use polars_core::frame::*;
-use polars_core::prelude::QuantileInterpolOptions;
+use polars_core::prelude::{IndexOrder, QuantileInterpolOptions};
 use polars_core::utils::arrow::compute::cast::CastOptions;
 use polars_core::utils::try_get_supertype;
 #[cfg(feature = "pivot")]
@@ -648,7 +648,7 @@ impl PyDataFrame {
         })
     }
 
-    pub fn to_numpy(&self, py: Python) -> Option<PyObject> {
+    pub fn to_numpy(&self, py: Python, order: Wrap<IndexOrder>) -> Option<PyObject> {
         let mut st = None;
         for s in self.df.iter() {
             let dt_i = s.dtype();
@@ -664,32 +664,32 @@ impl PyDataFrame {
         match st {
             DataType::UInt32 => self
                 .df
-                .to_ndarray::<UInt32Type>()
+                .to_ndarray::<UInt32Type>(order.0)
                 .ok()
                 .map(|arr| arr.into_pyarray(py).into_py(py)),
             DataType::UInt64 => self
                 .df
-                .to_ndarray::<UInt64Type>()
+                .to_ndarray::<UInt64Type>(order.0)
                 .ok()
                 .map(|arr| arr.into_pyarray(py).into_py(py)),
             DataType::Int32 => self
                 .df
-                .to_ndarray::<Int32Type>()
+                .to_ndarray::<Int32Type>(order.0)
                 .ok()
                 .map(|arr| arr.into_pyarray(py).into_py(py)),
             DataType::Int64 => self
                 .df
-                .to_ndarray::<Int64Type>()
+                .to_ndarray::<Int64Type>(order.0)
                 .ok()
                 .map(|arr| arr.into_pyarray(py).into_py(py)),
             DataType::Float32 => self
                 .df
-                .to_ndarray::<Float32Type>()
+                .to_ndarray::<Float32Type>(order.0)
                 .ok()
                 .map(|arr| arr.into_pyarray(py).into_py(py)),
             DataType::Float64 => self
                 .df
-                .to_ndarray::<Float64Type>()
+                .to_ndarray::<Float64Type>(order.0)
                 .ok()
                 .map(|arr| arr.into_pyarray(py).into_py(py)),
             _ => None,

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -25,7 +25,7 @@ from polars.testing.parametric import columns
 from polars.utils._construction import iterable_to_pydf
 
 if TYPE_CHECKING:
-    from polars.type_aliases import JoinStrategy, UniqueKeepStrategy
+    from polars.type_aliases import IndexOrder, JoinStrategy, UniqueKeepStrategy
 
 if sys.version_info >= (3, 9):
     from zoneinfo import ZoneInfo
@@ -1432,20 +1432,26 @@ def test_assign() -> None:
     assert list(df["a"]) == [2, 4, 6]
 
 
-def test_to_numpy() -> None:
+@pytest.mark.parametrize(
+    ("order", "f_contiguous", "c_contiguous"),
+    [("fortran", True, False), ("c", False, True)]
+)
+def test_to_numpy(order: IndexOrder, f_contiguous: bool, c_contiguous: bool) -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
 
-    out_array = df.to_numpy()
+    out_array = df.to_numpy(order=order)
     expected_array = np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]], dtype=np.float64)
     assert_array_equal(out_array, expected_array)
-    assert out_array.flags["F_CONTIGUOUS"] is True
+    assert out_array.flags["F_CONTIGUOUS"] == f_contiguous
+    assert out_array.flags["C_CONTIGUOUS"] == c_contiguous
 
-    structured_array = df.to_numpy(structured=True)
+    structured_array = df.to_numpy(structured=True, order=order)
     expected_array = np.array(
         [(1, 1.0), (2, 2.0), (3, 3.0)], dtype=[("a", "<i8"), ("b", "<f8")]
     )
     assert_array_equal(structured_array, expected_array)
-    assert structured_array.flags["F_CONTIGUOUS"] is True
+    assert structured_array.flags["F_CONTIGUOUS"]
+    assert out_array.flags["F_CONTIGUOUS"]
 
 
 def test_to_numpy_structured() -> None:

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -1434,7 +1434,7 @@ def test_assign() -> None:
 
 @pytest.mark.parametrize(
     ("order", "f_contiguous", "c_contiguous"),
-    [("fortran", True, False), ("c", False, True)]
+    [("fortran", True, False), ("c", False, True)],
 )
 def test_to_numpy(order: IndexOrder, f_contiguous: bool, c_contiguous: bool) -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})


### PR DESCRIPTION
# Motivation

The dataframe method `to_numpy` always returns Fortran-contiguous NumPy arrays. This is an issue when downstream applications (such as LightGBM) reshape the NumPy array, assuming a C-contiguous representation to prevent additional re-allocations of the data. This is particularly problematic if the dataframe is large and a third allocation of the data is prohibitively expensive (first allocation: dataframe, second allocation: NumPy array, third allocation: reshaped array).

To fix this issue, this PR introduces a new kw-only argument to the `to_numpy` dataframe method which allows to specify the index order (either `fortran` or `c`), defaulting to the current implicit default `fortran`.