### PR TITLE
fix(python): address schema edge-case with scalar-expanded data that resolves to an empty frame 

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -804,7 +804,13 @@ def dict_to_pydf(
         ]
 
     data_series = _handle_columns_arg(data_series, columns=column_names, from_dict=True)
-    return PyDataFrame(data_series)
+    pydf = PyDataFrame(data_series)
+
+    if schema_overrides and pydf.dtypes() != list(schema_overrides.values()):
+        pydf = _post_apply_columns(
+            pydf, column_names, schema_overrides=schema_overrides
+        )
+    return pydf
 
 
 def sequence_to_pydf(

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -1015,6 +1015,14 @@ def test_from_dicts_schema() -> None:
             "c": [None, None, None],
         }
 
+    # provide data that resolves to an empty frame (ref: scalar
+    # expansion shortcut), with schema/override hints
+    schema = {"colx": pl.Utf8, "coly": pl.Int32}
+
+    for param in ("schema", "schema_overrides"):
+        df = pl.DataFrame({"colx": [], "coly": 0}, **{param: schema})  # type: ignore[arg-type]
+        assert df.schema == schema
+
 
 def test_nested_read_dict_4143() -> None:
     assert pl.from_dicts(


### PR DESCRIPTION
Closes #9588.