### PR TITLE
fix(python): handle dictionary init with unsized iterators that also hits the scalar-expansion fast path

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -13,6 +13,7 @@ from typing import (
     Callable,
     Generator,
     Iterable,
+    Iterator,
     Mapping,
     MutableMapping,
     Sequence,
@@ -264,7 +265,7 @@ def iterable_to_pyseries(
     chunk_size: int = 1_000_000,
 ) -> PySeries:
     """Construct a PySeries from an iterable/generator."""
-    if not isinstance(values, Generator):
+    if not isinstance(values, (Generator, Iterator)):
         values = iter(values)
 
     def to_series_chunk(values: list[Any], dtype: PolarsDataType | None) -> Series:
@@ -683,6 +684,23 @@ def _unpack_schema(
     )
 
 
+def _expand_dict_data(
+    data: Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | Series],
+    dtypes: SchemaDict,
+) -> Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | Series]:
+    """
+    Expand any unsized generators/iterators.
+
+    (Note that `range` is sized, and will take a fast-path on Series init).
+    """
+    expanded_data = {}
+    for name, val in data.items():
+        expanded_data[name] = (
+            pl.Series(name, val, dtypes.get(name)) if _is_generator(val) else val
+        )
+    return expanded_data
+
+
 def _expand_dict_scalars(
     data: Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | Series],
     schema_overrides: SchemaDict | None = None,
@@ -693,6 +711,7 @@ def _expand_dict_scalars(
     updated_data = {}
     if data:
         dtypes = schema_overrides or {}
+        data = _expand_dict_data(data, dtypes)
         array_len = max((arrlen(val) or 0) for val in data.values())
         if array_len > 0:
             for name, val in data.items():

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -455,6 +455,17 @@ def test_from_dict_with_scalars() -> None:
     assert dfx[-10:-5].rows() == dfx[-5:].rows()
     assert dfx.row(n_range // 2, named=True) == mixed_dtype_data
 
+    # misc generators/iterables
+    df9 = pl.DataFrame(
+        {
+            "a": iter([0, 1, 2]),
+            "b": (2, 1, 0).__iter__(),
+            "c": (v for v in (0, 0, 0)),
+            "d": "x",
+        }
+    )
+    assert df9.rows() == [(0, 2, 0, "x"), (1, 1, 0, "x"), (2, 0, 0, "x")]
+
 
 def test_dataframe_membership_operator() -> None:
     # cf. issue #4032


### PR DESCRIPTION
Closes #9587.

We already handle DataFrame/Series init from iterators/generators; this PR just links up the existing code a little better when we are given _unsized_ generators/iterators that are _also_ taking the scalar-expansion fast path (if they are sized, like `range`, or there is no scalar expansion, everything already works).