### PR TITLE
fix(rust, python): validate time zone in cast and from_arrow operations

### DIFF
--- a/polars/polars-core/src/chunked_array/cast.rs
+++ b/polars/polars-core/src/chunked_array/cast.rs
@@ -5,6 +5,8 @@ use arrow::compute::cast::CastOptions;
 
 #[cfg(feature = "dtype-categorical")]
 use crate::chunked_array::categorical::CategoricalChunkedBuilder;
+#[cfg(feature = "timezones")]
+use crate::chunked_array::temporal::validate_time_zone;
 use crate::prelude::*;
 
 pub(crate) fn cast_chunks(
@@ -40,7 +42,14 @@ fn cast_impl_inner(
     use DataType::*;
     let out = match dtype {
         Date => out.into_date(),
-        Datetime(tu, tz) => out.into_datetime(*tu, tz.clone()),
+        Datetime(tu, tz) => match tz {
+            #[cfg(feature = "timezones")]
+            Some(tz) => {
+                validate_time_zone(tz)?;
+                out.into_datetime(*tu, Some(tz.clone()))
+            }
+            _ => out.into_datetime(*tu, None),
+        },
         Duration(tu) => out.into_duration(*tu),
         #[cfg(feature = "dtype-time")]
         Time => out.into_time(),

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -13,16 +13,10 @@ use polars_arrow::kernels::replace_timezone;
 
 use super::conversion::{datetime_to_timestamp_ms, datetime_to_timestamp_ns};
 use super::*;
+#[cfg(feature = "timezones")]
+use crate::chunked_array::temporal::validate_time_zone;
 use crate::prelude::DataType::Datetime;
 use crate::prelude::*;
-
-#[cfg(feature = "timezones")]
-fn validate_time_zone(tz: TimeZone) -> PolarsResult<()> {
-    match tz.parse::<Tz>() {
-        Ok(_) => Ok(()),
-        Err(_) => polars_bail!(ComputeError: "unable to parse time zone: '{}'", tz),
-    }
-}
 
 fn apply_datefmt_f<'a>(
     arr: &PrimitiveArray<i64>,
@@ -262,7 +256,7 @@ impl DatetimeChunked {
     /// Change the underlying [`TimeZone`]. This does not modify the data.
     #[cfg(feature = "timezones")]
     pub fn set_time_zone(&mut self, time_zone: TimeZone) -> PolarsResult<()> {
-        validate_time_zone(time_zone.to_string())?;
+        validate_time_zone(&time_zone)?;
         self.2 = Some(Datetime(self.time_unit(), Some(time_zone)));
         Ok(())
     }

--- a/polars/polars-core/src/chunked_array/temporal/mod.rs
+++ b/polars/polars-core/src/chunked_array/temporal/mod.rs
@@ -13,11 +13,25 @@ use chrono::NaiveDate;
 use chrono::NaiveDateTime;
 #[cfg(any(feature = "dtype-time", feature = "dtype-date"))]
 use chrono::NaiveTime;
+#[cfg(feature = "timezones")]
+use chrono_tz::Tz;
 #[cfg(feature = "dtype-time")]
 pub use time::time_to_time64ns;
 
 pub use self::conversion::*;
+#[cfg(feature = "timezones")]
+use crate::prelude::{polars_bail, PolarsResult};
 
 pub fn unix_time() -> NaiveDateTime {
     NaiveDateTime::from_timestamp_opt(0, 0).unwrap()
+}
+
+#[cfg(feature = "timezones")]
+pub(crate) fn validate_time_zone(tz: &str) -> PolarsResult<()> {
+    match tz.parse::<Tz>() {
+        Ok(_) => Ok(()),
+        Err(_) => {
+            polars_bail!(ComputeError: "unable to parse time zone: '{}'. Please check the Time Zone Database for a list of available time zones", tz)
+        }
+    }
 }

--- a/polars/polars-core/src/series/from.rs
+++ b/polars/polars-core/src/series/from.rs
@@ -17,6 +17,8 @@ use crate::chunked_array::cast::cast_chunks;
 use crate::chunked_array::object::extension::polars_extension::PolarsExtension;
 #[cfg(feature = "object")]
 use crate::chunked_array::object::extension::EXTENSION_NAME;
+#[cfg(feature = "timezones")]
+use crate::chunked_array::temporal::validate_time_zone;
 #[cfg(all(feature = "dtype-decimal", feature = "python"))]
 use crate::config::decimal_is_active;
 use crate::config::verbose;
@@ -199,7 +201,10 @@ impl Series {
                 if tz.as_deref() == Some("") {
                     tz = None;
                 }
-                // we still drop timezone for now
+                if let Some(_tz) = &tz {
+                    #[cfg(feature = "timezones")]
+                    validate_time_zone(_tz)?;
+                }
                 let chunks = cast_chunks(&chunks, &DataType::Int64, false).unwrap();
                 let s = Int64Chunked::from_chunks(name, chunks)
                     .into_datetime(tu.into(), tz)

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -527,6 +527,12 @@ def test_err_on_time_datetime_cast() -> None:
         s.cast(pl.Datetime)
 
 
+def test_err_on_invalid_time_zone_cast() -> None:
+    s = pl.Series([datetime(2021, 1, 1)])
+    with pytest.raises(pl.ComputeError, match=r"unable to parse time zone: 'qwerty'"):
+        s.cast(pl.Datetime("us", "qwerty"))
+
+
 def test_invalid_inner_type_cast_list() -> None:
     s = pl.Series([[-1, 1]])
     with pytest.raises(

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -12,6 +12,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -1110,3 +1111,11 @@ def test_sliced_struct_from_arrow() -> None:
     assert pl.from_arrow(tbl.slice(1, 1)).to_dict(False) == {
         "struct_col": [{"a": 2, "b": "bar"}]
     }
+
+
+def test_from_arrow_invalid_time_zone() -> None:
+    arr = pa.array(
+        [datetime(2021, 1, 1, 0, 0, 0, 0)], type=pa.timestamp("ns", tz="+01:00")
+    )
+    with pytest.raises(ComputeError, match=r"unable to parse time zone: '\+01:00'"):
+        pl.from_arrow(arr)


### PR DESCRIPTION
closes #9595 
xref #9586 (not totally sure this closes it, but it at least prevents users from getting invalid results)