### PR TITLE
feat(python): streamline `adbc` connectivity, adding snowflake support

### DIFF
--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import re
+import sys
+from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 from polars.convert import from_arrow
@@ -27,7 +30,8 @@ def read_database(
     query
         Raw SQL query (or queries).
     connection_uri
-        A connectorx compatible connection uri, for example
+        A connectorx (or adbc) connection URI that starts with the backend's
+        driver name, for example:
 
         * "postgresql://username:password@server:port/database"
     partition_on
@@ -48,13 +52,13 @@ def read_database(
           please see the connectorx docs:
 
           * https://github.com/sfu-db/connector-x#supported-sources--destinations
-        * ``'adbc'``
-          Currently just PostgreSQL and SQLite are supported and these are both in
-          development. When flight_sql is further in development and widely adopted
-          this will make this significantly better. For an up-to-date list
-          please see the adbc docs:
 
-          * https://arrow.apache.org/adbc/0.1.0/driver/cpp/index.html
+        * ``'adbc'``
+          Currently there is limited support for this engine, with a relatively small
+          number of drivers available, most of which are still in development. For
+          an up-to-date list of drivers please see the ADBC docs:
+
+          * https://arrow.apache.org/adbc/
 
     Notes
     -----
@@ -143,25 +147,18 @@ def _read_sql_adbc(query: str, connection_uri: str) -> DataFrame:
 
 
 def _open_adbc_connection(connection_uri: str) -> Any:
-    if connection_uri.startswith("sqlite"):
-        try:
-            import adbc_driver_sqlite.dbapi as adbc_sqlite
-        except ImportError:
-            raise ImportError(
-                "ADBC sqlite driver not detected. Please run `pip install "
-                "adbc_driver_sqlite pyarrow`."
-            ) from None
-        connection_uri = connection_uri.replace(r"sqlite:///", "")
-        return adbc_sqlite.connect(connection_uri)
+    driver_name = connection_uri.split(":", 1)[0].lower()
+    try:
+        import_module(f"adbc_driver_{driver_name}.dbapi")
+        adbc_driver = sys.modules[f"adbc_driver_{driver_name}.dbapi"]
+    except ImportError:
+        raise ImportError(
+            f"ADBC {driver_name} driver not detected; if ADBC supports this database, "
+            f"please run `pip install adbc_driver_{driver_name} pyarrow`"
+        ) from None
 
-    elif connection_uri.startswith("postgres"):
-        try:
-            import adbc_driver_postgresql.dbapi as adbc_postgres
-        except ImportError:
-            raise ImportError(
-                "ADBC postgresql driver not detected. Please run `pip install "
-                "adbc_driver_postgresql pyarrow`."
-            ) from None
-        return adbc_postgres.connect(connection_uri)
+    # some backends require the driver name to be stripped from the URI
+    if driver_name in ("sqlite", "snowflake"):
+        connection_uri = re.sub(f"^{driver_name}:/{{,3}}", "", connection_uri)
 
-    raise ValueError("ADBC does not currently support this database.")
+    return adbc_driver.connect(connection_uri)

--- a/py-polars/tests/unit/io/test_database.py
+++ b/py-polars/tests/unit/io/test_database.py
@@ -123,12 +123,13 @@ def test_read_database(
 
 
 @pytest.mark.parametrize(
-    ("engine", "query", "database", "err"),
+    ("engine", "query", "database", "errclass", "err"),
     [
         pytest.param(
             "not_engine",
             "SELECT * FROM test_data",
             "sqlite",
+            ValueError,
             "Engine is not implemented, try either connectorx or adbc.",
             id="Not an available sql engine",
         ),
@@ -136,22 +137,29 @@ def test_read_database(
             "adbc",
             ["SELECT * FROM test_data", "SELECT * FROM test_data"],
             "sqlite",
+            ValueError,
             "Only a single SQL query string is accepted for adbc.",
-            id="Unavailable list of queries for adbc.",
+            id="Unavailable list of queries for adbc",
         ),
         pytest.param(
             "adbc",
             "SELECT * FROM test_data",
             "mysql",
-            "ADBC does not currently support this database.",
-            id="Unavailable database for adbc.",
+            ImportError,
+            "ADBC mysql driver not detected",
+            id="Unavailable adbc driver",
         ),
     ],
 )
 def test_read_database_exceptions(
-    engine: DbReadEngine, query: str, database: str, err: str, tmp_path: Path
+    engine: DbReadEngine,
+    query: str,
+    database: str,
+    errclass: type,
+    err: str,
+    tmp_path: Path,
 ) -> None:
-    with pytest.raises(ValueError, match=err):
+    with pytest.raises(errclass, match=err):
         pl.read_database(
             connection_uri=f"{database}://test",
             query=query,


### PR DESCRIPTION
Should close #9569, by better generalising `adbc` module inference/connection. 

(Will need confirmation about snowflake, as I don't actually have access to an instance, but our existing support for postgres/sqlite are confirmed to work with the streamlined code as I spun-up a local docker postgres image to validate).