### PR TITLE
docs(python): fix see also broken links

### DIFF
--- a/py-polars/docs/Makefile
+++ b/py-polars/docs/Makefile
@@ -5,7 +5,7 @@ export BUILDING_SPHINX_DOCS = 1
 
 # You can set these variables from the command line, and also
 # from the environment for the first two.
-SPHINXOPTS    ?= -j auto
+SPHINXOPTS    ?= -j auto -W
 SPHINXBUILD   ?= sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -380,7 +380,7 @@ class Expr:
         See Also
         --------
         Series.arg_true : Return indices where Series is True
-        pl.arg_where
+        polars.arg_where
 
         """
         return self._from_pyexpr(py_arg_where(self._pyexpr))
@@ -3572,8 +3572,8 @@ class Expr:
 
         See Also
         --------
-        ExprListNameSpace.explode : Explode a list column.
-        ExprStringNameSpace.explode : Explode a string column.
+        Expr.list.explode : Explode a list column.
+        Expr.str.explode : Explode a string column.
 
         Examples
         --------
@@ -7426,7 +7426,7 @@ class Expr:
 
         See Also
         --------
-        ExprListNameSpace.explode : Explode a list column.
+        Expr.list.explode : Explode a list column.
 
         """
         return self._from_pyexpr(self._pyexpr.reshape(dimensions))

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1669,7 +1669,7 @@ class ExprStringNameSpace:
 
         Returns
         -------
-        Expr: Series of parsed integers in i32 format
+        Expr : Series of parsed integers in i32 format
 
         Examples
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2902,8 +2902,8 @@ class Series:
 
         See Also
         --------
-        ListNameSpace.explode : Explode a list column.
-        StringNameSpace.explode : Explode a string column.
+        Series.list.explode : Explode a list column.
+        Series.str.explode : Explode a string column.
 
         """
 
@@ -5555,7 +5555,7 @@ class Series:
 
         See Also
         --------
-        ListNameSpace.explode : Explode a list column.
+        Series.list.explode : Explode a list column.
 
         Examples
         --------


### PR DESCRIPTION
Fixing broken links in the `See Also` section. See for example here: https://pola-rs.github.io/polars/py-polars/html/reference/series/api/polars.Series.explode.html

Also, I added the `-W` flag to the sphinx build, which will make it fail if any warning is found (the broken links didn't generate a warning). There is also a missing space in a `Returns` statement making the whole description being rendered as if it was the type (all in bold, while only the type is intended to be bold).