### PR TITLE
fix(rust, python): Correct weighted rolling quantile definition

### DIFF
--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/quantile.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/quantile.rs
@@ -267,11 +267,10 @@ where
     // odd but it's the equivalent of taking h = p * (n - 1) + 1 if your data is indexed from 1.
     let h: f64 = p * (wsum - buf[0].1) + buf[0].1;
     for &(v, w) in buf.iter().filter(|(_, w)| *w != 0.0) {
-        vk = v; // We need the "next" value if we break.
         if s > h {
             break;
         }
-        (s_old, v_old) = (s, v);
+        (s_old, v_old, vk) = (s, vk, v);
         s += w;
     }
     match (h == s_old, interp) {

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/quantile.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/quantile.rs
@@ -201,7 +201,7 @@ where
                 window_size,
                 min_periods,
                 offset_fn,
-                &weights,
+                weights,
                 wsum,
             ))
         }
@@ -246,7 +246,7 @@ where
 }
 
 #[inline]
-fn compute_wq<T>(buf: &Vec<(T, f64)>, p: f64, wsum: f64, interp: QuantileInterpolOptions) -> T
+fn compute_wq<T>(buf: &[(T, f64)], p: f64, wsum: f64, interp: QuantileInterpolOptions) -> T
 where
     T: Debug
         + NativeType

--- a/polars/polars-time/src/chunkedarray/rolling_window/floats.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/floats.rs
@@ -119,7 +119,8 @@ where
                 options.min_periods,
                 options.center,
                 options.weights.as_deref(),
-            ).unwrap(),
+            )
+            .unwrap(),
             _ => rolling::nulls::rolling_quantile(
                 arr,
                 quantile,

--- a/polars/polars-time/src/chunkedarray/rolling_window/floats.rs
+++ b/polars/polars-time/src/chunkedarray/rolling_window/floats.rs
@@ -119,7 +119,7 @@ where
                 options.min_periods,
                 options.center,
                 options.weights.as_deref(),
-            ),
+            ).unwrap(),
             _ => rolling::nulls::rolling_quantile(
                 arr,
                 quantile,

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6447,12 +6447,15 @@ class Expr:
         │ 5.0 ┆ 3.0              │
         │ 6.0 ┆ 4.0              │
         └─────┴──────────────────┘
-        
+
         Specify weights and interpolation method
-        
+
         >>> df.with_columns(
         ...     rolling_quantile=pl.col("A").rolling_quantile(
-        ...         quantile=0.25, window_size=4, weights=[0.2, 0.4, 0.4, 0.2], interpolation='linear'
+        ...         quantile=0.25,
+        ...         window_size=4,
+        ...         weights=[0.2, 0.4, 0.4, 0.2],
+        ...         interpolation="linear",
         ...     ),
         ... )
         shape: (6, 2)

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -6264,7 +6264,7 @@ class Expr:
         │ 6.0 ┆ 5.5            │
         └─────┴────────────────┘
 
-        Specify weights to multiply the values in the window with:
+        Specify weights for the values in each window:
 
         >>> df.with_columns(
         ...     rolling_median=pl.col("A").rolling_median(
@@ -6278,11 +6278,11 @@ class Expr:
         │ f64 ┆ f64            │
         ╞═════╪════════════════╡
         │ 1.0 ┆ null           │
-        │ 2.0 ┆ 0.875          │
-        │ 3.0 ┆ 1.375          │
-        │ 4.0 ┆ 1.875          │
-        │ 5.0 ┆ 2.375          │
-        │ 6.0 ┆ 2.875          │
+        │ 2.0 ┆ 1.5            │
+        │ 3.0 ┆ 2.5            │
+        │ 4.0 ┆ 3.5            │
+        │ 5.0 ┆ 4.5            │
+        │ 6.0 ┆ 5.5            │
         └─────┴────────────────┘
 
         Center the values in the window
@@ -6427,7 +6427,7 @@ class Expr:
         │ 6.0 ┆ 4.0              │
         └─────┴──────────────────┘
 
-        Specify weights to multiply the values in the window with:
+        Specify weights for the values in each window:
 
         >>> df.with_columns(
         ...     rolling_quantile=pl.col("A").rolling_quantile(
@@ -6443,9 +6443,30 @@ class Expr:
         │ 1.0 ┆ null             │
         │ 2.0 ┆ null             │
         │ 3.0 ┆ null             │
-        │ 4.0 ┆ 0.8              │
-        │ 5.0 ┆ 1.0              │
-        │ 6.0 ┆ 1.2              │
+        │ 4.0 ┆ 2.0              │
+        │ 5.0 ┆ 3.0              │
+        │ 6.0 ┆ 4.0              │
+        └─────┴──────────────────┘
+        
+        Specify weights and interpolation method
+        
+        >>> df.with_columns(
+        ...     rolling_quantile=pl.col("A").rolling_quantile(
+        ...         quantile=0.25, window_size=4, weights=[0.2, 0.4, 0.4, 0.2], interpolation='linear'
+        ...     ),
+        ... )
+        shape: (6, 2)
+        ┌─────┬──────────────────┐
+        │ A   ┆ rolling_quantile │
+        │ --- ┆ ---              │
+        │ f64 ┆ f64              │
+        ╞═════╪══════════════════╡
+        │ 1.0 ┆ null             │
+        │ 2.0 ┆ null             │
+        │ 3.0 ┆ null             │
+        │ 4.0 ┆ 1.625            │
+        │ 5.0 ┆ 2.625            │
+        │ 6.0 ┆ 3.625            │
         └─────┴──────────────────┘
 
         Center the values in the window


### PR DESCRIPTION
The weighted rolling quantile calculation was incorrect. This reimplements it using a common definition. In principle it could be made faster in the future with a weighted quickselect.