### PR TITLE
fix(rust, python): redo weighted rolling var

### DIFF
--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
@@ -112,20 +112,15 @@ fn compute_var_weights<T>(vals: &[T], weights: &[T]) -> T
 where
     T: Float + std::ops::AddAssign,
 {
-    let weighted_iter = vals.iter().zip(weights).map(|(x, y)| *x * *y);
+    // Assumes the weights have already been standardized to 1
+    let (wssq, wmean) = vals
+        .iter()
+        .zip(weights)
+        .fold((T::zero(), T::zero()), |(wssq, wsum), (&v, &w)| {
+            (wssq + v * v * w, wsum + v * w)
+        });
 
-    let mut sum = T::zero();
-    let mut sum_of_squares = T::zero();
-
-    for val in weighted_iter {
-        sum += val;
-        sum_of_squares += val * val;
-    }
-    let count = NumCast::from(vals.len()).unwrap();
-
-    let mean = sum / count;
-    // apply Bessel's correction
-    ((sum_of_squares / count) - mean * mean) / (count - T::one()) * count
+    wssq - wmean * wmean
 }
 
 pub(crate) fn compute_sum_weights<T>(values: &[T], weights: &[T]) -> T

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/mod.rs
@@ -113,6 +113,10 @@ where
     T: Float + std::ops::AddAssign,
 {
     // Assumes the weights have already been standardized to 1
+    debug_assert!(
+        weights.iter().fold(T::zero(), |acc, x| acc + *x) == T::one(),
+        "Rolling weighted variance Weights don't sum to 1"
+    );
     let (wssq, wmean) = vals
         .iter()
         .zip(weights)

--- a/polars/polars-arrow/src/kernels/rolling/no_nulls/variance.rs
+++ b/polars/polars-arrow/src/kernels/rolling/no_nulls/variance.rs
@@ -168,11 +168,13 @@ where
             params,
         ),
         Some(weights) => {
+            // Validate and standardize the weights like we do for the mean. This definition is fine
+            // because frequency weights and unbiasing don't make sense for rolling operations.
             let mut wts = no_nulls::coerce_weights(weights);
             let wsum = wts.iter().fold(T::zero(), |acc, x| acc + *x);
             polars_ensure!(
                 wsum != T::zero(),
-                ComputeError: "Weighted mean is undefined if weights sum to 0"
+                ComputeError: "Weighted variance is undefined if weights sum to 0"
             );
             wts.iter_mut().for_each(|w| *w = *w / wsum);
             super::rolling_apply_weights(

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -3692,9 +3692,7 @@ def test_rolling_apply() -> None:
         center=False,
     )
 
-    roll_std = s.rolling_std(
-        window_size=4, min_periods=3, center=False
-    )
+    roll_std = s.rolling_std(window_size=4, min_periods=3, center=False)
 
     assert (roll_app_std - roll_std).abs().sum() < 0.0001
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -3688,13 +3688,12 @@ def test_rolling_apply() -> None:
     roll_app_std = s.rolling_apply(
         function=lambda s: s.std(),
         window_size=4,
-        weights=[1.0, 2.0, 3.0, 0.1],
         min_periods=3,
         center=False,
     )
 
     roll_std = s.rolling_std(
-        window_size=4, weights=[1.0, 2.0, 3.0, 0.1], min_periods=3, center=False
+        window_size=4, min_periods=3, center=False
     )
 
     assert (roll_app_std - roll_std).abs().sum() < 0.0001


### PR DESCRIPTION
This corrects how weights are handled for the rolling weighted variance as was done for the mean recently.
The failing test points out that weights can't be uniformly applied to every function the same way in a UDF. It's possible we may just want to remove that option since weighting means different things for different functions so the user could be better off just baking it in to the function they're passing.