### PR TITLE
fix(rust, python): clear hashes buffer in generic streaming joins

### DIFF
--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/joins/generic_build.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/joins/generic_build.rs
@@ -142,8 +142,7 @@ impl GenericBuild {
         context: &PExecutionContext,
         chunk: &DataChunk,
     ) -> PolarsResult<&BinaryArray<i64>> {
-        self.join_columns.clear();
-
+        debug_assert!(self.join_columns.is_empty());
         for phys_e in self.join_columns_left.iter() {
             let s = phys_e.evaluate(chunk, context.execution_state.as_any())?;
             let arr = s.to_physical_repr().rechunk().array_ref(0).clone();
@@ -206,6 +205,11 @@ impl Sink for GenericBuild {
 
             current_df_idx += 1;
         }
+
+        // clear memory
+        self.hashes.clear();
+        self.join_columns.clear();
+
         self.chunks.push(chunk);
         Ok(SinkResult::CanHaveMoreInput)
     }

--- a/polars/polars-lazy/polars-pipe/src/executors/sinks/joins/inner_left.rs
+++ b/polars/polars-lazy/polars-pipe/src/executors/sinks/joins/inner_left.rs
@@ -119,7 +119,7 @@ impl GenericJoinProbe {
         context: &PExecutionContext,
         chunk: &DataChunk,
     ) -> PolarsResult<BinaryArray<i64>> {
-        self.join_columns.clear();
+        debug_assert!(self.join_columns.is_empty());
 
         let determine_idx = !self.swapped_or_left && self.join_column_idx.is_none();
         let mut names = vec![];
@@ -221,6 +221,10 @@ impl GenericJoinProbe {
             },
         };
 
+        // clear memory
+        self.join_columns.clear();
+        self.hashes.clear();
+
         Ok(OperatorResult::Finished(chunk.with_data(out)))
     }
 
@@ -299,6 +303,10 @@ impl GenericJoinProbe {
                 a
             }
         };
+
+        // clear memory
+        self.join_columns.clear();
+        self.hashes.clear();
 
         Ok(OperatorResult::Finished(chunk.with_data(out)))
     }


### PR DESCRIPTION
fixes #9605