### PR TITLE
feat(rust, python): accept expressions in `repeat`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/functions/range.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions/range.rs
@@ -259,7 +259,7 @@ pub fn time_range(start: Expr, end: Expr, every: Duration, closed: ClosedWindow)
 /// Create a column of length `n` containing `n` copies of the literal `value`. Generally you won't need this function,
 /// as `lit(value)` already represents a column containing only `value` whose length is automatically set to the correct
 /// number of rows.
-pub fn repeat<L: Literal>(value: L, n: Expr) -> Expr {
+pub fn repeat<E: Into<Expr>>(value: E, n: Expr) -> Expr {
     let function = |s: Series, n: Series| {
         polars_ensure!(
             n.dtype().is_integer(),
@@ -271,5 +271,5 @@ pub fn repeat<L: Literal>(value: L, n: Expr) -> Expr {
         )?;
         Ok(Some(s.new_from_index(0, n)))
     };
-    apply_binary(lit(value), n, function, GetOutput::same_type()).alias("repeat")
+    apply_binary(value.into(), n, function, GetOutput::same_type()).alias("repeat")
 }

--- a/polars/polars-lazy/src/tests/aggregations.rs
+++ b/polars/polars-lazy/src/tests/aggregations.rs
@@ -236,8 +236,8 @@ fn test_binary_agg_context_0() -> PolarsResult<()> {
         .lazy()
         .groupby_stable([col("groups")])
         .agg([when(col("vals").first().neq(lit(1)))
-            .then(repeat("a", count()))
-            .otherwise(repeat("b", count()))
+            .then(repeat(lit("a"), count()))
+            .otherwise(repeat(lit("b"), count()))
             .alias("foo")])
         .collect()
         .unwrap();

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -873,7 +873,9 @@ class ExprListNameSpace:
         ...         "b": [[2, 3, 4], [3], [3, 4, None], [6, 8]],
         ...     }
         ... )
-        >>> df.with_columns(pl.col("a").list.difference("b"))
+        >>> df.with_columns(
+        ...     difference=pl.col("a").list.difference("b"),
+        ... )
         shape: (4, 3)
         ┌───────────┬──────────────┬────────────┐
         │ a         ┆ b            ┆ difference │

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, overload
 
 from polars import functions as F
 from polars.datatypes import Float64
+from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
 from polars.utils.various import find_stacklevel
 
@@ -17,7 +18,11 @@ if TYPE_CHECKING:
     import sys
 
     from polars import Expr, Series
-    from polars.type_aliases import PolarsDataType, PolarsExprType, PythonLiteral
+    from polars.type_aliases import (
+        IntoExpr,
+        PolarsDataType,
+        PolarsExprType,
+    )
 
     if sys.version_info >= (3, 8):
         from typing import Literal
@@ -27,7 +32,7 @@ if TYPE_CHECKING:
 
 @overload
 def repeat(
-    value: PythonLiteral | None,
+    value: IntoExpr | None,
     n: int | PolarsExprType,
     *,
     dtype: PolarsDataType | None = ...,
@@ -39,7 +44,7 @@ def repeat(
 
 @overload
 def repeat(
-    value: PythonLiteral | None,
+    value: IntoExpr | None,
     n: int | PolarsExprType,
     *,
     dtype: PolarsDataType | None = ...,
@@ -51,7 +56,7 @@ def repeat(
 
 @overload
 def repeat(
-    value: PythonLiteral | None,
+    value: IntoExpr | None,
     n: int | PolarsExprType,
     *,
     dtype: PolarsDataType | None = ...,
@@ -62,7 +67,7 @@ def repeat(
 
 
 def repeat(
-    value: PythonLiteral | None,
+    value: IntoExpr | None,
     n: int | PolarsExprType,
     *,
     dtype: PolarsDataType | None = None,
@@ -134,6 +139,7 @@ def repeat(
 
     if isinstance(n, int):
         n = F.lit(n)
+    value = parse_as_expression(value, str_as_lit=True)
     expr = wrap_expr(plr.repeat(value, n._pyexpr, dtype))
     if name is not None:
         expr = expr.alias(name)

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -401,38 +401,25 @@ pub fn reduce(lambda: PyObject, exprs: Vec<PyExpr>) -> PyExpr {
 }
 
 #[pyfunction]
-pub fn repeat(value: Wrap<AnyValue>, n: PyExpr, dtype: Option<Wrap<DataType>>) -> PyResult<PyExpr> {
-    let value = value.0;
+pub fn repeat(value: PyExpr, n: PyExpr, dtype: Option<Wrap<DataType>>) -> PyResult<PyExpr> {
+    let mut value = value.inner;
     let n = n.inner;
-    let dtype = dtype.map(|wrap| wrap.0);
 
-    let target_dtype = match dtype {
-        Some(dtype) => dtype,
-        None => match value.dtype() {
-            // Integer inputs that fit in Int32 are parsed as such
-            DataType::Int64 => {
-                let int_value: i64 = value.try_extract().unwrap();
-                if int_value >= i32::MIN as i64 && int_value <= i32::MAX as i64 {
-                    DataType::Int32
-                } else {
-                    DataType::Int64
-                }
-            }
-            DataType::Unknown => DataType::Null,
-            _ => value.dtype(),
-        },
-    };
-
-    let lit_value = LiteralValue::try_from(value).map_err(PyPolarsErr::from)?;
-    let must_cast = lit_value.get_datatype() != target_dtype;
-
-    let mut expr = dsl::repeat(lit_value, n);
-
-    if must_cast {
-        expr = expr.cast(target_dtype);
+    if let Some(dtype) = dtype {
+        value = value.cast(dtype.0);
     }
 
-    Ok(expr.into())
+    if let Expr::Literal(lv) = &value {
+        let av = lv.to_anyvalue().unwrap();
+        // Integer inputs that fit in Int32 are parsed as such
+        if let DataType::Int64 = av.dtype() {
+            let int_value = av.try_extract::<i64>().unwrap();
+            if int_value >= i32::MIN as i64 && int_value <= i32::MAX as i64 {
+                value = value.cast(DataType::Int32);
+            }
+        }
+    }
+    Ok(dsl::repeat(value, n).into())
 }
 
 #[pyfunction]

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -55,6 +55,9 @@ def test_repeat_expr_input_lazy() -> None:
     expected = pl.Series("repeat", [1, 1, 1], dtype=pl.Int32)
     assert_series_equal(result, expected)
 
+    df = pl.DataFrame({"a": [3, 2, 1]})
+    assert df.select(pl.repeat(pl.sum("a"), n=2)).to_series().to_list() == [6, 6]
+
 
 def test_repeat_n_zero() -> None:
     assert pl.repeat(1, n=0, eager=True).len() == 0


### PR DESCRIPTION
I wanted to repeat the result of an expression, but couldn't. Now I can :)