### PR TITLE
docs(python): fix inconsistency in `.list.difference()` example

### DIFF
--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -873,9 +873,7 @@ class ExprListNameSpace:
         ...         "b": [[2, 3, 4], [3], [3, 4, None], [6, 8]],
         ...     }
         ... )
-        >>> df.with_columns(
-        ...     difference=pl.col("a").list.difference("b"),
-        ... )
+        >>> df.with_columns(pl.col("a").list.difference("b").alias("difference"))
         shape: (4, 3)
         ┌───────────┬──────────────┬────────────┐
         │ a         ┆ b            ┆ difference │

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -560,7 +560,7 @@ class ListNameSpace:
         ----------
         other
             Right hand side of the set operation.
-            
+
         Examples
         --------
         >>> a = pl.Series([[1, 2, 3], [], [None, 3], [5, 6, 7]])

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -560,7 +560,7 @@ class ListNameSpace:
         ----------
         other
             Right hand side of the set operation.
-
+            
         Examples
         --------
         >>> a = pl.Series([[1, 2, 3], [], [None, 3], [5, 6, 7]])


### PR DESCRIPTION
Sorry @alexander-beedie, didn't catch this inconsistency!