### PR TITLE
feat(python): Pass through stdin/stderr buffer in to_csv

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8,7 +8,7 @@ import typing
 import warnings
 from collections import defaultdict
 from collections.abc import Sized
-from io import BytesIO, StringIO
+from io import BytesIO, StringIO, TextIOWrapper
 from operator import itemgetter
 from pathlib import Path
 from typing import (
@@ -24,6 +24,7 @@ from typing import (
     NoReturn,
     Sequence,
     TypeVar,
+    cast,
     overload,
 )
 
@@ -2341,7 +2342,7 @@ class DataFrame:
     @overload
     def write_csv(
         self,
-        file: BytesIO | str | Path,
+        file: BytesIO | TextIOWrapper | str | Path,
         *,
         has_header: bool = ...,
         separator: str = ...,
@@ -2357,7 +2358,7 @@ class DataFrame:
 
     def write_csv(
         self,
-        file: BytesIO | str | Path | None = None,
+        file: BytesIO | TextIOWrapper | str | Path | None = None,
         *,
         has_header: bool = True,
         separator: str = ",",
@@ -2445,6 +2446,8 @@ class DataFrame:
 
         if isinstance(file, (str, Path)):
             file = normalise_filepath(file)
+        elif isinstance(file, TextIOWrapper):
+            file = cast(TextIOWrapper, file.buffer)
 
         self._df.write_csv(
             file,


### PR DESCRIPTION
Resolves #9618.

This allows `sys.stdin` and `sys.stderr` to be written directly to via `write_csv`. This is a python workaround, and I'm not 100% sure it's the best solution, but it is quite simple. Note that `sys.stdin` and `sys.stderr` are type [`TextIOBase`](https://docs.python.org/3/library/io.html#io.TextIOBase) which inherits from [`IOBase`](https://docs.python.org/3/library/io.html#io.IOBase), and has all of the prequisite methods (read/write/seek/etc.) but for some reason is being rejected by the polars code as invalid. My guess is there is something in the pyo3 code that isn't detecting this as a writable buffer stream and so instead is trying to create a file from it:

```
OSError: write() argument must be str, not bytes
```

The quick workaround here is to simply check to see if `file` is a `TextIOBase` and, if so, pass `file.buffer` to `write_csv` instead.