### PR TITLE
docs(python): Clean up doctests for rolling

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4952,7 +4952,7 @@ class Expr:
         └────────┴─────────────────────┘
         >>> df_temporal.with_columns(
         ...     rolling_row_min=pl.col("row_nr").rolling_min(
-        ...         window_size="2h", by="date"
+        ...         window_size="2h", by="date", closed = "left"
         ...     )
         ... )
         shape: (25, 3)
@@ -5161,7 +5161,7 @@ class Expr:
 
         >>> df_temporal.with_columns(
         ...     rolling_row_max=pl.col("row_nr").rolling_max(
-        ...         window_size="2h", by="date"
+        ...         window_size="2h", by="date", closed = "left"
         ...     )
         ... )
         shape: (25, 3)
@@ -5231,7 +5231,7 @@ class Expr:
 
         A window of length `window_size` will traverse the array. The values that fill
         this window will (optionally) be multiplied with the weights given by the
-        `weight` vector. The resulting values will be aggregated to their sum.
+        `weight` vector. The resulting values will be aggregated to their mean.
 
         If ``by`` has not been specified (the default), the window at a given row will
         include the row itself, and the `window_size - 1` elements before it.
@@ -5394,7 +5394,7 @@ class Expr:
 
         >>> df_temporal.with_columns(
         ...     rolling_row_mean=pl.col("row_nr").rolling_mean(
-        ...         window_size="2h", by="date"
+        ...         window_size="2h", by="date", closed = "left"
         ...     )
         ... )
         shape: (25, 3)
@@ -5511,8 +5511,8 @@ class Expr:
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
         weights
-            An optional slice with the same length of the window that will be multiplied
-            elementwise with the values in the window.
+            An optional slice with the same length as the window that determines the
+            relative contribution of each value in a window to the output.
         min_periods
             The number of values in the window that should be non-null before computing
             a result. If None, it will be set equal to window size.
@@ -5627,7 +5627,7 @@ class Expr:
 
         >>> df_temporal.with_columns(
         ...     rolling_row_sum=pl.col("row_nr").rolling_sum(
-        ...         window_size="2h", by="date"
+        ...         window_size="2h", by="date", closed = "left"
         ...     )
         ... )
         shape: (25, 3)
@@ -5696,10 +5696,6 @@ class Expr:
         """
         Compute a rolling standard deviation.
 
-        A window of length `window_size` will traverse the array. The values that fill
-        this window will (optionally) be multiplied with the weights given by the
-        `weight` vector. The resulting values will be aggregated to their sum.
-
         If ``by`` has not been specified (the default), the window at a given row will
         include the row itself, and the `window_size - 1` elements before it.
 
@@ -5745,8 +5741,8 @@ class Expr:
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
         weights
-            An optional slice with the same length as the window that will be multiplied
-            elementwise with the values in the window.
+            An optional slice with the same length as the window that determines the
+            relative contribution of each value in a window to the output.
         min_periods
             The number of values in the window that should be non-null before computing
             a result. If None, it will be set equal to window size.
@@ -5807,11 +5803,11 @@ class Expr:
         │ f64 ┆ f64         │
         ╞═════╪═════════════╡
         │ 1.0 ┆ null        │
-        │ 2.0 ┆ 0.883883    │
-        │ 3.0 ┆ 1.237437    │
-        │ 4.0 ┆ 1.59099     │
-        │ 5.0 ┆ 1.944544    │
-        │ 6.0 ┆ 2.298097    │
+        │ 2.0 ┆ 0.433013    │
+        │ 3.0 ┆ 0.433013    │
+        │ 4.0 ┆ 0.433013    │
+        │ 5.0 ┆ 0.433013    │
+        │ 6.0 ┆ 0.433013    │
         └─────┴─────────────┘
 
         Center the values in the window
@@ -5863,7 +5859,7 @@ class Expr:
 
         >>> df_temporal.with_columns(
         ...     rolling_row_std=pl.col("row_nr").rolling_std(
-        ...         window_size="2h", by="date"
+        ...         window_size="2h", by="date", closed = "left"
         ...     )
         ... )
         shape: (25, 3)
@@ -5931,10 +5927,6 @@ class Expr:
     ) -> Self:
         """
         Compute a rolling variance.
-
-        A window of length `window_size` will traverse the array. The values that fill
-        this window will (optionally) be multiplied with the weights given by the
-        `weight` vector. The resulting values will be aggregated to their sum.
 
         If ``by`` has not been specified (the default), the window at a given row will
         include the row itself, and the `window_size - 1` elements before it.
@@ -6043,11 +6035,11 @@ class Expr:
         │ f64 ┆ f64         │
         ╞═════╪═════════════╡
         │ 1.0 ┆ null        │
-        │ 2.0 ┆ 0.78125     │
-        │ 3.0 ┆ 1.53125     │
-        │ 4.0 ┆ 2.53125     │
-        │ 5.0 ┆ 3.78125     │
-        │ 6.0 ┆ 5.28125     │
+        │ 2.0 ┆ 0.1875      │
+        │ 3.0 ┆ 0.1875      │
+        │ 4.0 ┆ 0.1875      │
+        │ 5.0 ┆ 0.1875      │
+        │ 6.0 ┆ 0.1875      │
         └─────┴─────────────┘
 
         Center the values in the window
@@ -6099,7 +6091,7 @@ class Expr:
 
         >>> df_temporal.with_columns(
         ...     rolling_row_var=pl.col("row_nr").rolling_var(
-        ...         window_size="2h", by="date"
+        ...         window_size="2h", by="date", closed = "left"
         ...     )
         ... )
         shape: (25, 3)
@@ -6218,8 +6210,8 @@ class Expr:
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
         weights
-            An optional slice with the same length as the window that will be multiplied
-            elementwise with the values in the window.
+            An optional slice with the same length as the window that determines the
+            relative contribution of each value in a window to the output.
         min_periods
             The number of values in the window that should be non-null before computing
             a result. If None, it will be set equal to window size.
@@ -6379,8 +6371,8 @@ class Expr:
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
         weights
-            An optional slice with the same length as the window that will be
-            multiplied elementwise with the values in the window.
+            An optional slice with the same length as the window that determines the
+            relative contribution of each value in a window to the output.
         min_periods
             The number of values in the window that should be non-null before computing
             a result. If None, it will be set equal to window size.

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4952,7 +4952,7 @@ class Expr:
         └────────┴─────────────────────┘
         >>> df_temporal.with_columns(
         ...     rolling_row_min=pl.col("row_nr").rolling_min(
-        ...         window_size="2h", by="date", closed = "left"
+        ...         window_size="2h", by="date", closed="left"
         ...     )
         ... )
         shape: (25, 3)
@@ -5161,7 +5161,7 @@ class Expr:
 
         >>> df_temporal.with_columns(
         ...     rolling_row_max=pl.col("row_nr").rolling_max(
-        ...         window_size="2h", by="date", closed = "left"
+        ...         window_size="2h", by="date", closed="left"
         ...     )
         ... )
         shape: (25, 3)
@@ -5394,7 +5394,7 @@ class Expr:
 
         >>> df_temporal.with_columns(
         ...     rolling_row_mean=pl.col("row_nr").rolling_mean(
-        ...         window_size="2h", by="date", closed = "left"
+        ...         window_size="2h", by="date", closed="left"
         ...     )
         ... )
         shape: (25, 3)
@@ -5511,8 +5511,8 @@ class Expr:
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
         weights
-            An optional slice with the same length as the window that determines the
-            relative contribution of each value in a window to the output.
+            An optional slice with the same length as the window that will be multiplied
+            elementwise with the values in the window.
         min_periods
             The number of values in the window that should be non-null before computing
             a result. If None, it will be set equal to window size.
@@ -5627,7 +5627,7 @@ class Expr:
 
         >>> df_temporal.with_columns(
         ...     rolling_row_sum=pl.col("row_nr").rolling_sum(
-        ...         window_size="2h", by="date", closed = "left"
+        ...         window_size="2h", by="date", closed="left"
         ...     )
         ... )
         shape: (25, 3)
@@ -5859,7 +5859,7 @@ class Expr:
 
         >>> df_temporal.with_columns(
         ...     rolling_row_std=pl.col("row_nr").rolling_std(
-        ...         window_size="2h", by="date", closed = "left"
+        ...         window_size="2h", by="date", closed="left"
         ...     )
         ... )
         shape: (25, 3)
@@ -5973,8 +5973,8 @@ class Expr:
             If a timedelta or the dynamic string language is used, the `by`
             and `closed` arguments must also be set.
         weights
-            An optional slice with the same length as the window that will be multiplied
-            elementwise with the values in the window.
+            An optional slice with the same length as the window that determines the
+            relative contribution of each value in a window to the output.
         min_periods
             The number of values in the window that should be non-null before computing
             a result. If None, it will be set equal to window size.
@@ -6091,7 +6091,7 @@ class Expr:
 
         >>> df_temporal.with_columns(
         ...     rolling_row_var=pl.col("row_nr").rolling_var(
-        ...         window_size="2h", by="date", closed = "left"
+        ...         window_size="2h", by="date", closed="left"
         ...     )
         ... )
         shape: (25, 3)


### PR DESCRIPTION
As requested in https://github.com/pola-rs/polars/pull/9617
I missed updated a few doctests for rolling sd/var. Also cleans up the documentation a little and fixes the future warnings for rolling temporal windows.