### PR TITLE
chore(python): remove deprecation warning of already-enforced valid timezones change

### DIFF
--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime as dt
-import warnings
 from typing import TYPE_CHECKING
 
 import polars._reexport as pl
@@ -11,18 +10,12 @@ from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.decorators import deprecated_alias
-from polars.utils.various import find_stacklevel
 
 if TYPE_CHECKING:
     from datetime import timedelta
 
     from polars import Expr
     from polars.type_aliases import EpochTimeUnit, TimeUnit
-
-TIME_ZONE_DEPRECATION_MESSAGE = (
-    "In a future version of polars, time zones other than those in `zoneinfo.available_timezones()` "
-    "will no longer be supported. Please use one of them instead."
-)
 
 
 class ExprDateTimeNameSpace:
@@ -1374,14 +1367,6 @@ class ExprDateTimeNameSpace:
         │ 2020-05-01 00:00:00 UTC ┆ 2020-05-01 01:00:00 BST     │
         └─────────────────────────┴─────────────────────────────┘
         """
-        from polars.dependencies import zoneinfo
-
-        if time_zone not in zoneinfo.available_timezones():
-            warnings.warn(
-                TIME_ZONE_DEPRECATION_MESSAGE,
-                DeprecationWarning,
-                stacklevel=find_stacklevel(),
-            )
         return wrap_expr(self._pyexpr.dt_convert_time_zone(time_zone))
 
     def replace_time_zone(
@@ -1479,14 +1464,6 @@ class ExprDateTimeNameSpace:
         └─────────────────────┴───────┴───────────────────────────────┘
 
         """
-        from polars.dependencies import zoneinfo
-
-        if time_zone is not None and time_zone not in zoneinfo.available_timezones():
-            warnings.warn(
-                TIME_ZONE_DEPRECATION_MESSAGE,
-                DeprecationWarning,
-                stacklevel=find_stacklevel(),
-            )
         return wrap_expr(self._pyexpr.dt_replace_time_zone(time_zone, use_earliest))
 
     def days(self) -> Expr:

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, overload
 import polars._reexport as pl
 from polars import functions as F
 from polars.datatypes import Date, Int64
-from polars.expr.datetime import TIME_ZONE_DEPRECATION_MESSAGE
 from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr, wrap_s
 from polars.utils.convert import (
@@ -348,15 +347,6 @@ def date_range(
     if name is not None:
         warnings.warn(
             "the `name` argument is deprecated. Use the `alias` method instead.",
-            DeprecationWarning,
-            stacklevel=find_stacklevel(),
-        )
-
-    from polars.dependencies import zoneinfo
-
-    if time_zone is not None and time_zone not in zoneinfo.available_timezones():
-        warnings.warn(
-            TIME_ZONE_DEPRECATION_MESSAGE,
             DeprecationWarning,
             stacklevel=find_stacklevel(),
         )

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1920,12 +1920,7 @@ def test_strptime_empty(time_unit: TimeUnit, time_zone: str | None) -> None:
 
 
 def test_strptime_with_invalid_tz() -> None:
-    with pytest.raises(
-        ComputeError, match="unable to parse time zone: 'foo'"
-    ), pytest.warns(
-        FutureWarning,
-        match="time zones other than those in `zoneinfo.available_timezones",
-    ):
+    with pytest.raises(ComputeError, match="unable to parse time zone: 'foo'"):
         pl.Series(["2020-01-01 03:00:00"]).str.strptime(pl.Datetime("us", "foo"))
     with pytest.raises(
         ComputeError,
@@ -1963,12 +1958,7 @@ def test_strptime_unguessable_format() -> None:
 
 def test_convert_time_zone_invalid() -> None:
     ts = pl.Series(["2020-01-01"]).str.strptime(pl.Datetime)
-    with pytest.raises(
-        ComputeError, match="unable to parse time zone: 'foo'"
-    ), pytest.warns(
-        FutureWarning,
-        match="time zones other than those in `zoneinfo.available_timezones",
-    ):
+    with pytest.raises(ComputeError, match="unable to parse time zone: 'foo'"):
         ts.dt.replace_time_zone("UTC").dt.convert_time_zone("foo")
 
 

--- a/py-polars/tests/unit/functions/test_range.py
+++ b/py-polars/tests/unit/functions/test_range.py
@@ -290,12 +290,7 @@ def test_date_range_single_row_lazy_7110() -> None:
 
 
 def test_date_range_invalid_time_zone() -> None:
-    with pytest.raises(
-        pl.ComputeError, match="unable to parse time zone: 'foo'"
-    ), pytest.warns(
-        DeprecationWarning,
-        match="time zones other than those in `zoneinfo.available_timezones",
-    ):
+    with pytest.raises(pl.ComputeError, match="unable to parse time zone: 'foo'"):
         pl.date_range(
             datetime(2001, 1, 1),
             datetime(2001, 1, 3),

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -443,12 +443,7 @@ def test_invalid_date_parsing_4898() -> None:
 
 def test_strptime_invalid_timezone() -> None:
     ts = pl.Series(["2020-01-01 00:00:00+01:00"]).str.to_datetime("%Y-%m-%d %H:%M:%S%z")
-    with pytest.raises(
-        ComputeError, match=r"unable to parse time zone: 'foo'"
-    ), pytest.warns(
-        DeprecationWarning,
-        match="time zones other than those in `zoneinfo.available_timezones",
-    ):
+    with pytest.raises(ComputeError, match=r"unable to parse time zone: 'foo'"):
         ts.dt.replace_time_zone("foo")
 
 


### PR DESCRIPTION
Removing the deprecation warning from the python side, as it's already been enforced

Clarifying the error message on the Rust side too