### PR TITLE
chore(python): bump ruff

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -31,9 +31,9 @@ build-release: .venv  ## Compile and install a faster Polars binary
 
 .PHONY: fmt
 fmt: .venv  ## Run autoformatting and linting
+	$(VENV_BIN)/ruff .
 	$(VENV_BIN)/black .
 	$(VENV_BIN)/blackdoc .
-	$(VENV_BIN)/ruff .
 	$(VENV_BIN)/typos ..
 	$(VENV_BIN)/python scripts/check_stacklevels.py
 	cargo fmt --all

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -16,6 +16,7 @@ from typing import (
     Any,
     BinaryIO,
     Callable,
+    ClassVar,
     Collection,
     Generator,
     Iterable,
@@ -336,7 +337,7 @@ class DataFrame:
 
     """
 
-    _accessors: set[str] = set()
+    _accessors: ClassVar[set[str]] = set()
 
     def __init__(
         self,

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from importlib import import_module
 from importlib.util import find_spec
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Hashable, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Hashable, cast
 
 _DELTALAKE_AVAILABLE = True
 _FSSPEC_AVAILABLE = True
@@ -32,7 +32,7 @@ class _LazyModule(ModuleType):
 
     __lazy__ = True
 
-    _mod_pfx: dict[str, str] = {
+    _mod_pfx: ClassVar[dict[str, str]] = {
         "numpy": "np.",
         "pandas": "pd.",
         "pyarrow": "pa.",

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -11,6 +11,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ClassVar,
     Collection,
     FrozenSet,
     Iterable,
@@ -93,7 +94,16 @@ class Expr:
     """Expressions that can be used in various contexts."""
 
     _pyexpr: PyExpr = None
-    _accessors: set[str] = {"arr", "cat", "dt", "list", "meta", "str", "bin", "struct"}
+    _accessors: ClassVar[set[str]] = {
+        "arr",
+        "cat",
+        "dt",
+        "list",
+        "meta",
+        "str",
+        "bin",
+        "struct",
+    }
 
     @classmethod
     def _from_pyexpr(cls, pyexpr: PyExpr) -> Self:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -11,6 +11,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ClassVar,
     Collection,
     Iterable,
     NoReturn,
@@ -262,7 +263,7 @@ class LazyFrame:
     """
 
     _ldf: PyLazyFrame
-    _accessors: set[str] = set()
+    _accessors: ClassVar[set[str]] = set()
 
     def __init__(
         self,

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -10,6 +10,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ClassVar,
     Collection,
     Generator,
     Iterable,
@@ -218,7 +219,15 @@ class Series:
     """
 
     _s: PySeries = None
-    _accessors: set[str] = {"arr", "cat", "dt", "list", "str", "bin", "struct"}
+    _accessors: ClassVar[set[str]] = {
+        "arr",
+        "cat",
+        "dt",
+        "list",
+        "str",
+        "bin",
+        "struct",
+    }
 
     def __init__(
         self,

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -171,7 +171,7 @@ class SQLContext(Generic[FrameType]):
 
     @overload
     def execute(
-        self: SQLContext[DataFrame], query: str, eager: Literal[None] | None = None
+        self: SQLContext[DataFrame], query: str, eager: None = ...
     ) -> DataFrame:
         ...
 
@@ -189,7 +189,7 @@ class SQLContext(Generic[FrameType]):
 
     @overload
     def execute(
-        self: SQLContext[LazyFrame], query: str, eager: Literal[None] | None = None
+        self: SQLContext[LazyFrame], query: str, eager: None = ...
     ) -> LazyFrame:
         ...
 

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -171,7 +171,7 @@ class SQLContext(Generic[FrameType]):
 
     @overload
     def execute(
-        self: SQLContext[DataFrame], query: str, eager: Literal[None] = None
+        self: SQLContext[DataFrame], query: str, eager: Literal[None] | None = None
     ) -> DataFrame:
         ...
 
@@ -189,7 +189,7 @@ class SQLContext(Generic[FrameType]):
 
     @overload
     def execute(
-        self: SQLContext[LazyFrame], query: str, eager: Literal[None] = None
+        self: SQLContext[LazyFrame], query: str, eager: Literal[None] | None = None
     ) -> LazyFrame:
         ...
 

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,5 +1,5 @@
 black==23.3.0
 blackdoc==0.3.8
 mypy==1.4.1
-ruff==0.0.270
+ruff==0.0.275
 typos==1.15.9


### PR DESCRIPTION
Also run `ruff` BEFORE `black` in the `make` command. Sometimes, running `ruff` will break `black` formatting and require a re-run. This way, it should work a bit better.