### PR TITLE
chore(python): remove false "eager=True" from date_range tests

### DIFF
--- a/py-polars/tests/unit/functions/test_range.py
+++ b/py-polars/tests/unit/functions/test_range.py
@@ -225,7 +225,6 @@ def test_date_range_lazy_with_expressions(
             low,
             high,
             interval="1d",
-            eager=True,
         ).alias("dts")
     ).to_dict(
         False
@@ -248,7 +247,6 @@ def test_date_range_lazy_with_expressions(
             low,
             high,
             interval="1d",
-            eager=True,
         ).alias("dts")
     ).to_dict(
         False

--- a/py-polars/tests/unit/functions/test_range.py
+++ b/py-polars/tests/unit/functions/test_range.py
@@ -225,7 +225,7 @@ def test_date_range_lazy_with_expressions(
             low,
             high,
             interval="1d",
-            eager=False,
+            eager=True,
         ).alias("dts")
     ).to_dict(
         False
@@ -248,7 +248,7 @@ def test_date_range_lazy_with_expressions(
             low,
             high,
             interval="1d",
-            eager=False,
+            eager=True,
         ).alias("dts")
     ).to_dict(
         False

--- a/py-polars/tests/unit/functions/test_range.py
+++ b/py-polars/tests/unit/functions/test_range.py
@@ -225,7 +225,7 @@ def test_date_range_lazy_with_expressions(
             low,
             high,
             interval="1d",
-            eager=True,
+            eager=False,
         ).alias("dts")
     ).to_dict(
         False
@@ -248,7 +248,7 @@ def test_date_range_lazy_with_expressions(
             low,
             high,
             interval="1d",
-            eager=True,
+            eager=False,
         ).alias("dts")
     ).to_dict(
         False


### PR DESCRIPTION
In `date_range`, there is

https://github.com/pola-rs/polars/blob/5c39152b5e623d2e7ea075993d68133a67871ef3/py-polars/polars/functions/range.py#L359-L369

So in effect, currently, if `start` or `end` are expressions, then an expression will be returned, and `eager=True` takes no effect (as is technically a lie?)

Noticed this while working on https://github.com/pola-rs/polars/issues/9019, this'll help reduce the diff