### PR TITLE
fix(rust, python): raise if to_datetime would have parsed input incorrectly

### DIFF
--- a/polars/polars-time/src/chunkedarray/utf8/strptime.rs
+++ b/polars/polars-time/src/chunkedarray/utf8/strptime.rs
@@ -8,7 +8,7 @@ use regex::Regex;
 
 use crate::chunkedarray::{polars_bail, PolarsResult};
 
-static HOUR_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"%[_-]?[HIl]").unwrap());
+static HOUR_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"%[_-]?[HkIl]").unwrap());
 static MINUTE_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"%[_-]?M").unwrap());
 static SECOND_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"%[_-]?S").unwrap());
 static TWELVE_HOUR_PATTERN: Lazy<Regex> = Lazy::new(|| Regex::new(r"%[_-]?[Il]").unwrap());

--- a/py-polars/polars/testing/parametric/strategies.py
+++ b/py-polars/polars/testing/parametric/strategies.py
@@ -28,6 +28,7 @@ from hypothesis.strategies import (
     integers,
     lists,
     sampled_from,
+    sets,
     text,
     timedeltas,
     times,
@@ -128,6 +129,40 @@ def strategy_decimal(draw: DrawFn) -> PyDecimal:
             places=places,
         )
     )
+
+
+@composite
+def strategy_datetime_format(draw: DrawFn) -> str:
+    """Draw a random datetime format string."""
+    fmt = draw(
+        sets(
+            sampled_from(
+                [
+                    "%m",
+                    "%b",
+                    "%B",
+                    "%d",
+                    "%j",
+                    "%a",
+                    "%A",
+                    "%w",
+                    "%H",
+                    "%I",
+                    "%p",
+                    "%M",
+                    "%S",
+                    "%U",
+                    "%W",
+                    "%%",
+                ]
+            ),
+        )
+    )
+
+    # Make sure year is always present
+    fmt.add("%Y")
+
+    return " ".join(fmt)
 
 
 class StrategyLookup(MutableMapping[PolarsDataType, SearchStrategy[Any]]):

--- a/py-polars/tests/parametric/time_series/test_to_datetime.py
+++ b/py-polars/tests/parametric/time_series/test_to_datetime.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+import hypothesis.strategies as st
+from hypothesis import given
+
+import polars as pl
+from polars.exceptions import ComputeError
+from polars.testing.parametric.strategies import strategy_datetime_format
+
+
+@given(
+    datetimes=st.datetimes(
+        min_value=datetime(2000, 1, 1), max_value=datetime(9999, 12, 31)
+    ),
+    fmt=strategy_datetime_format(),
+)
+def test_to_datetime(datetimes: datetime, fmt: str) -> None:
+    input = datetimes.strftime(fmt)
+    expected = datetime.strptime(input, fmt)
+    try:
+        result = pl.Series([input]).str.to_datetime(format=fmt).item()
+    except ComputeError as exc:
+        # If there's an exception, check that it's either:
+        # - something which polars can't parse at all: missing day or month
+        # - something on which polars intentionally raises
+        assert (  # noqa: PT017
+            (
+                (("%H" in fmt) ^ ("%M" in fmt))
+                or (("%I" in fmt) ^ ("%M" in fmt))
+                or ("%S" in fmt and "%H" not in fmt)
+                or ("%S" in fmt and "%I" not in fmt)
+                or (("%I" in fmt) ^ ("%p" in fmt))
+                or (("%H" in fmt) ^ ("%p" in fmt))
+            )
+            and "Invalid format string" in str(exc)
+        ) or (
+            (
+                not any(day in fmt for day in ("%d", "%j"))
+                or not any(month in fmt for month in ("%b", "%B", "%m"))
+            )
+            and "strict conversion to datetimes failed" in str(exc)
+        )
+    else:
+        assert result == expected

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -532,7 +532,7 @@ def test_strptime_subseconds_datetime(data: str, format: str, expected: time) ->
     ("string", "fmt"),
     [
         pytest.param("2023-05-04|7", "%Y-%m-%d|%H", id="hour but no minute"),
-        pytest.param("2023-05-04|7", "%Y-%m-%d|%I", id="padded hour but no minute"),
+        pytest.param("2023-05-04|7", "%Y-%m-%d|%k", id="padded hour but no minute"),
         pytest.param("2023-05-04|10", "%Y-%m-%d|%M", id="minute but no hour"),
         pytest.param("2023-05-04|10", "%Y-%m-%d|%S", id="second but no hour"),
         pytest.param(


### PR DESCRIPTION
closes #9673 