### PR TITLE
feat(python): add `DataFrame.collect` (no-op)

### DIFF
--- a/py-polars/docs/source/reference/dataframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/dataframe/miscellaneous.rst
@@ -7,6 +7,7 @@ Miscellaneous
    :toctree: api/
 
     DataFrame.apply
+    DataFrame.collect
     DataFrame.corr
     DataFrame.frame_equal
     DataFrame.lazy

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7026,7 +7026,7 @@ class DataFrame:
         """
         return wrap_ldf(self._df.lazy())
 
-    def collect(self, **kwargs) -> Self:
+    def collect(self, **kwargs: Any) -> Self:
         """
         Do nothing and return the :class:`DataFrame`.
 
@@ -7040,7 +7040,7 @@ class DataFrame:
 
         Notes
         -----
-        It is prefered to write your code such that you always know whether you are
+        It is preferred to write your code such that you always know whether you are
         operating on a :class:`DataFrame` or a :class:`LazyFrame`. Avoid using this
         method if you can.
 
@@ -7049,7 +7049,6 @@ class DataFrame:
         >>> def print_frame_height(frame: pl.DataFrame | pl.LazyFrame) -> None:
         ...     df = frame.collect()
         ...     print(df.height)
-        ...
         >>> df = pl.DataFrame({"a": [1, 2, 3]})
         >>> print_frame_height(df)
         3

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7026,6 +7026,40 @@ class DataFrame:
         """
         return wrap_ldf(self._df.lazy())
 
+    def collect(self, **kwargs) -> Self:
+        """
+        Do nothing and return the :class:`DataFrame`.
+
+        Useful for writing code that expects either a :class:`DataFrame` or
+        :class:`LazyFrame`.
+
+        Parameters
+        ----------
+        **kwargs
+            All keyword arguments are accepted and will be ignored.
+
+        Notes
+        -----
+        It is prefered to write your code such that you always know whether you are
+        operating on a :class:`DataFrame` or a :class:`LazyFrame`. Avoid using this
+        method if you can.
+
+        Examples
+        --------
+        >>> def print_frame_height(frame: pl.DataFrame | pl.LazyFrame) -> None:
+        ...     df = frame.collect()
+        ...     print(df.height)
+        ...
+        >>> df = pl.DataFrame({"a": [1, 2, 3]})
+        >>> print_frame_height(df)
+        3
+        >>> lf = pl.LazyFrame({"a": [1, 2, 3]})
+        >>> print_frame_height(lf)
+        3
+
+        """
+        return self
+
     def select(
         self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
     ) -> DataFrame:

--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -359,7 +359,7 @@ def align_frames(
     # we just subselect out the columns representing the component frames)
     eager = isinstance(frames[0], pl.DataFrame)
     alignment_frame: LazyFrame = (
-        reduce(  # type: ignore[attr-defined]
+        reduce(
             lambda x, y: x.lazy().join(  # type: ignore[arg-type, return-value]
                 y.lazy(), how=how, on=align_on, suffix=str(id(y))
             ),

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1779,7 +1779,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Notes
         -----
-        It is prefered to write your code such that you always know whether you are
+        It is preferred to write your code such that you always know whether you are
         operating on a :class:`DataFrame` or a :class:`LazyFrame`. Avoid using this
         method if you can.
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1772,14 +1772,16 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def lazy(self) -> Self:
         """
-        Return lazy representation, i.e. itself.
+        Do nothing and return the :class:`LazyFrame`.
 
         Useful for writing code that expects either a :class:`DataFrame` or
         :class:`LazyFrame`.
 
-        Returns
-        -------
-        LazyFrame
+        Notes
+        -----
+        It is prefered to write your code such that you always know whether you are
+        operating on a :class:`DataFrame` or a :class:`LazyFrame`. Avoid using this
+        method if you can.
 
         Examples
         --------

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -194,15 +194,13 @@ def test_groupby_agg_input_types(lazy: bool) -> None:
     for bad_param in bad_agg_parameters():
         with pytest.raises(TypeError):  # noqa: PT012
             result = df_or_lazy.groupby("a").agg(bad_param)
-            if lazy:
-                result.collect()  # type: ignore[union-attr]
+            result.collect()
 
     expected = pl.DataFrame({"a": [1, 2], "b": [3, 7]})
 
     for good_param in good_agg_parameters():
         result = df_or_lazy.groupby("a", maintain_order=True).agg(good_param)
-        if lazy:
-            result = result.collect()  # type: ignore[union-attr]
+        result = result.collect()
         assert_frame_equal(result, expected)
 
 
@@ -218,8 +216,7 @@ def test_groupby_dynamic_agg_input_types(lazy: bool) -> None:
             result = df_or_lazy.groupby_dynamic(
                 index_column="index_column", every="2i", closed="right"
             ).agg(bad_param)
-            if lazy:
-                result.collect()  # type: ignore[union-attr]
+            result.collect()
 
     expected = pl.DataFrame({"index_column": [-2, 0, 2], "b": [1, 4, 2]})
 
@@ -227,8 +224,7 @@ def test_groupby_dynamic_agg_input_types(lazy: bool) -> None:
         result = df_or_lazy.groupby_dynamic(
             index_column="index_column", every="2i", closed="right"
         ).agg(good_param)
-        if lazy:
-            result = result.collect()  # type: ignore[union-attr]
+        result = result.collect()
         assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/operations/test_groupby_rolling.py
+++ b/py-polars/tests/unit/operations/test_groupby_rolling.py
@@ -89,8 +89,7 @@ def test_groupby_rolling_agg_input_types(lazy: bool) -> None:
             result = df_or_lazy.groupby_rolling(
                 index_column="index_column", period="2i"
             ).agg(bad_param)
-            if lazy:
-                result.collect()  # type: ignore[union-attr]
+            result.collect()
 
     expected = pl.DataFrame({"index_column": [0, 1, 2, 3], "b": [1, 4, 4, 3]})
 
@@ -98,8 +97,7 @@ def test_groupby_rolling_agg_input_types(lazy: bool) -> None:
         result = df_or_lazy.groupby_rolling(
             index_column="index_column", period="2i"
         ).agg(good_param)
-        if lazy:
-            result = result.collect()  # type: ignore[union-attr]
+        result.collect()
         assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/operations/test_groupby_rolling.py
+++ b/py-polars/tests/unit/operations/test_groupby_rolling.py
@@ -97,7 +97,7 @@ def test_groupby_rolling_agg_input_types(lazy: bool) -> None:
         result = df_or_lazy.groupby_rolling(
             index_column="index_column", period="2i"
         ).agg(good_param)
-        result.collect()
+        result = result.collect()
         assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -3822,3 +3822,8 @@ def test_sum_empty_column_names() -> None:
         {"x": [0], "y": [0]}, schema={"x": pl.UInt32, "y": pl.UInt32}
     )
     assert_frame_equal(df.sum(), expected)
+
+
+def test_df_collect() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    assert_frame_equal(df, df.collect())


### PR DESCRIPTION
Closes #7882

Analogous to `LazyFrame.lazy`, this allows users to more easily write code that is "agnostic" on whether it operates on LazyFrames or DataFrames.

This is somewhat of an anti-pattern, but I have seen good use-cases for this. I have added a note to reflect this.