### PR TITLE
feat(python,rust): missing column width can be set exactly (not as a lower bound)

### DIFF
--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -466,8 +466,6 @@ impl Display for DataFrame {
                 |l: usize| ColumnConstraint::Absolute(comfy_table::Width::Fixed(l as u16));
             let col_width_lower_bound =
                 |l: usize| ColumnConstraint::LowerBoundary(comfy_table::Width::Fixed(l as u16));
-            // let col_width_upper_bound =
-            //     |l: usize| ColumnConstraint::UpperBoundary(comfy_table::Width::Fixed(l as u16));
 
             let mut constraints = Vec::with_capacity(n_first + n_last + reduce_columns as usize);
             let fields = self.fields();

--- a/polars/polars-core/src/fmt.rs
+++ b/polars/polars-core/src/fmt.rs
@@ -461,24 +461,29 @@ impl Display for DataFrame {
                 };
                 (s, lower_bounds)
             };
-            let tbl_lower_bounds =
+
+            let col_width_exact =
+                |l: usize| ColumnConstraint::Absolute(comfy_table::Width::Fixed(l as u16));
+            let col_width_lower_bound =
                 |l: usize| ColumnConstraint::LowerBoundary(comfy_table::Width::Fixed(l as u16));
+            // let col_width_upper_bound =
+            //     |l: usize| ColumnConstraint::UpperBoundary(comfy_table::Width::Fixed(l as u16));
 
             let mut constraints = Vec::with_capacity(n_first + n_last + reduce_columns as usize);
             let fields = self.fields();
             for field in fields[0..n_first].iter() {
                 let (s, l) = field_to_str(field);
                 names.push(s);
-                constraints.push(tbl_lower_bounds(l));
+                constraints.push(col_width_lower_bound(l));
             }
             if reduce_columns {
                 names.push("…".into());
-                constraints.push(tbl_lower_bounds(3));
+                constraints.push(col_width_exact(3));
             }
             for field in fields[self.width() - n_last..].iter() {
                 let (s, l) = field_to_str(field);
                 names.push(s);
-                constraints.push(tbl_lower_bounds(l));
+                constraints.push(col_width_lower_bound(l));
             }
             let (preset, is_utf8) = match std::env::var(FMT_TABLE_FORMATTING)
                 .as_deref()


### PR DESCRIPTION
While investigating column width changes in the latest comfy-table (ref: https://github.com/pola-rs/polars/pull/9656) I saw that we can set the "missing column" width exactly as it is always a fixed/exact width; this will ensure that it doesn't get allocated any extraneous potential width from the table's total width budget.

This is a very minor update; a more comprehensive update of our comfy-table constraints will follow later, which should improve width determination and table repr in the general case, reducing instances of unnecessary/premature column/text wrapping. Currently we only set _lower_ bound constraints, but there are places we should also set _upper_ bound constraints (such as date columns, since we know that a date cannot exceed `yyyy-mm-dd` chars), or even absolute constraints in a few cases.

(Actual impact - where we omit some columns, an extra character or two will be available for assignment into the _other_ columns' potential width buckets).