### PR TITLE
feat(python, rust): clearer message when stringcache-related errors occur

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/categorical/ops/append.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/ops/append.rs
@@ -32,7 +32,7 @@ Alternatively, if the performance cost is acceptable, you could just set:
 
     pl.enable_string_cache(True)
 
-on startup."
+on startup.
 "#.trim_start()
             );
         } else {

--- a/polars/polars-core/src/chunked_array/logical/categorical/ops/append.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/ops/append.rs
@@ -17,7 +17,7 @@ impl CategoricalChunked {
             };
 
         if is_local_different_source {
-            polars_bail!(op = string_cache_mismatch);
+            polars_bail!(string_cache_mismatch);
         } else {
             let len = self.len();
             let new_rev_map = self.merge_categorical_map(other)?;

--- a/polars/polars-core/src/chunked_array/logical/categorical/ops/append.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/ops/append.rs
@@ -18,8 +18,22 @@ impl CategoricalChunked {
 
         if is_local_different_source {
             polars_bail!(
-                ComputeError:
-                "cannot concat categoricals coming from a different source; consider setting a global StringCache"
+            ComputeError: r#"
+cannot concat categoricals coming from a different source, consider setting a global StringCache.
+
+Help: if you're using Python, this may look something like:
+
+    with pl.StringCache():
+        df1 = pl.DataFrame({'a': ['1', '2']}, schema={'a': pl.Categorical})
+        df2 = pl.DataFrame({'a': ['1', '3']}, schema={'a': pl.Categorical})
+        pl.concat([df1, df2])
+
+Alternatively, if the performance cost is acceptable, you could just set:
+
+    pl.enable_string_cache(True)
+
+on startup."
+"#.trim_start()
             );
         } else {
             let len = self.len();

--- a/polars/polars-core/src/chunked_array/logical/categorical/ops/append.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/ops/append.rs
@@ -17,23 +17,7 @@ impl CategoricalChunked {
             };
 
         if is_local_different_source {
-            polars_bail!(
-            ComputeError: r#"
-cannot concat categoricals coming from a different source, consider setting a global StringCache.
-
-Help: if you're using Python, this may look something like:
-
-    with pl.StringCache():
-        df1 = pl.DataFrame({'a': ['1', '2']}, schema={'a': pl.Categorical})
-        df2 = pl.DataFrame({'a': ['1', '3']}, schema={'a': pl.Categorical})
-        pl.concat([df1, df2])
-
-Alternatively, if the performance cost is acceptable, you could just set:
-
-    pl.enable_string_cache(True)
-
-on startup."#.trim_start()
-            );
+            polars_bail!(op = string_cache_mismatch);
         } else {
             let len = self.len();
             let new_rev_map = self.merge_categorical_map(other)?;

--- a/polars/polars-core/src/chunked_array/logical/categorical/ops/append.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/ops/append.rs
@@ -32,8 +32,7 @@ Alternatively, if the performance cost is acceptable, you could just set:
 
     pl.enable_string_cache(True)
 
-on startup.
-"#.trim_start()
+on startup."#.trim_start()
             );
         } else {
             let len = self.len();

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -93,7 +93,7 @@ use crate::series::IsSorted;
 #[cfg(feature = "dtype-categorical")]
 pub fn _check_categorical_src(l: &DataType, r: &DataType) -> PolarsResult<()> {
     if let (DataType::Categorical(Some(l)), DataType::Categorical(Some(r))) = (l, r) {
-        polars_ensure!(l.same_src(r), op = string_cache_mismatch);
+        polars_ensure!(l.same_src(r), string_cache_mismatch);
     }
     Ok(())
 }

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -95,22 +95,7 @@ pub fn _check_categorical_src(l: &DataType, r: &DataType) -> PolarsResult<()> {
     if let (DataType::Categorical(Some(l)), DataType::Categorical(Some(r))) = (l, r) {
         polars_ensure!(
             l.same_src(r),
-            ComputeError: r#"
-joins/or comparisons on categoricals can only happen
-if they were created under the same global string cache.
-
-Help: if you're using Python, this may look something like:
-
-    with pl.StringCache():
-        df1 = pl.DataFrame({'a': ['1', '2']}, schema={'a': pl.Categorical})
-        df2 = pl.DataFrame({'a': ['1', '3']}, schema={'a': pl.Categorical})
-        df1.join(df2, on='a')
-
-Alternatively, if the performance cost is acceptable, you could just set:
-
-    pl.enable_string_cache(True)
-
-on startup."#.trim_start()
+            op = string_cache_mismatch
         );
     }
     Ok(())

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -93,10 +93,7 @@ use crate::series::IsSorted;
 #[cfg(feature = "dtype-categorical")]
 pub fn _check_categorical_src(l: &DataType, r: &DataType) -> PolarsResult<()> {
     if let (DataType::Categorical(Some(l)), DataType::Categorical(Some(r))) = (l, r) {
-        polars_ensure!(
-            l.same_src(r),
-            op = string_cache_mismatch
-        );
+        polars_ensure!(l.same_src(r), op = string_cache_mismatch);
     }
     Ok(())
 }

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -110,7 +110,7 @@ Alternatively, if the performance cost is acceptable, you could just set:
 
     pl.enable_string_cache(True)
 
-on startup."
+on startup.
 "#.trim_start()
         );
     }

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -95,8 +95,23 @@ pub fn _check_categorical_src(l: &DataType, r: &DataType) -> PolarsResult<()> {
     if let (DataType::Categorical(Some(l)), DataType::Categorical(Some(r))) = (l, r) {
         polars_ensure!(
             l.same_src(r),
-            ComputeError: "joins/or comparisons on categoricals can only happen if they were \
-            created under the same global string cache"
+            ComputeError: r#"
+joins/or comparisons on categoricals can only happen
+if they were created under the same global string cache.
+
+Help: if you're using Python, this may look something like:
+
+    with pl.StringCache():
+        df1 = pl.DataFrame({'a': ['1', '2']}, schema={'a': pl.Categorical})
+        df2 = pl.DataFrame({'a': ['1', '3']}, schema={'a': pl.Categorical})
+        df1.join(df2, on='a')
+
+Alternatively, if the performance cost is acceptable, you could just set:
+
+    pl.enable_string_cache(True)
+
+on startup."
+"#.trim_start()
         );
     }
     Ok(())

--- a/polars/polars-core/src/frame/hash_join/mod.rs
+++ b/polars/polars-core/src/frame/hash_join/mod.rs
@@ -110,8 +110,7 @@ Alternatively, if the performance cost is acceptable, you could just set:
 
     pl.enable_string_cache(True)
 
-on startup.
-"#.trim_start()
+on startup."#.trim_start()
         );
     }
     Ok(())

--- a/polars/polars-error/src/lib.rs
+++ b/polars/polars-error/src/lib.rs
@@ -163,7 +163,7 @@ macro_rules! polars_err {
     };
     (op = string_cache_mismatch) => {
         polars_err!(StringCacheMismatch: r#"
-cannot compare categoricals coming from a different source, consider setting a global StringCache.
+cannot compare categoricals coming from different sources, consider setting a global StringCache.
 
 Help: if you're using Python, this may look something like:
 

--- a/polars/polars-error/src/lib.rs
+++ b/polars/polars-error/src/lib.rs
@@ -56,6 +56,8 @@ pub enum PolarsError {
     SchemaMismatch(ErrString),
     #[error("lengths don't match: {0}")]
     ShapeMismatch(ErrString),
+    #[error("string caches don't match: {0}")]
+    StringCacheMismatch(ErrString),
     #[error("field not found: {0}")]
     StructFieldNotFound(ErrString),
 }
@@ -91,6 +93,7 @@ impl PolarsError {
             SchemaFieldNotFound(msg) => SchemaFieldNotFound(func(msg).into()),
             SchemaMismatch(msg) => SchemaMismatch(func(msg).into()),
             ShapeMismatch(msg) => ShapeMismatch(func(msg).into()),
+            StringCacheMismatch(msg) => StringCacheMismatch(func(msg).into()),
             StructFieldNotFound(msg) => StructFieldNotFound(func(msg).into()),
         }
     }
@@ -157,6 +160,24 @@ macro_rules! polars_err {
     };
     (unpack) => {
         polars_err!(SchemaMismatch: "cannot unpack series, data types don't match")
+    };
+    (op = string_cache_mismatch) => {
+        polars_err!(StringCacheMismatch: r#"
+cannot compare categoricals coming from a different source, consider setting a global StringCache.
+
+Help: if you're using Python, this may look something like:
+
+    with pl.StringCache():
+        df1 = pl.DataFrame({'a': ['1', '2']}, schema={'a': pl.Categorical})
+        df2 = pl.DataFrame({'a': ['1', '3']}, schema={'a': pl.Categorical})
+        pl.concat([df1, df2])
+
+Alternatively, if the performance cost is acceptable, you could just set:
+
+    import polars as pl
+    pl.enable_string_cache(True)
+
+on startup."#.trim_start())
     };
     (duplicate = $name:expr) => {
         polars_err!(Duplicate: "column with name '{}' has more than one occurrences", $name)

--- a/polars/polars-error/src/lib.rs
+++ b/polars/polars-error/src/lib.rs
@@ -161,15 +161,17 @@ macro_rules! polars_err {
     (unpack) => {
         polars_err!(SchemaMismatch: "cannot unpack series, data types don't match")
     };
-    (op = string_cache_mismatch) => {
+    (string_cache_mismatch) => {
         polars_err!(StringCacheMismatch: r#"
 cannot compare categoricals coming from different sources, consider setting a global StringCache.
 
 Help: if you're using Python, this may look something like:
 
     with pl.StringCache():
+        # Initialize Categoricals.
         df1 = pl.DataFrame({'a': ['1', '2']}, schema={'a': pl.Categorical})
         df2 = pl.DataFrame({'a': ['1', '3']}, schema={'a': pl.Categorical})
+        # Your operations go here.
         pl.concat([df1, df2])
 
 Alternatively, if the performance cost is acceptable, you could just set:

--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -10,6 +10,7 @@ try:
         SchemaError,
         SchemaFieldNotFoundError,
         ShapeError,
+        StringCacheMismatchError,
         StructFieldNotFoundError,
     )
 except ImportError:

--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -43,6 +43,9 @@ except ImportError:
     class ShapeError(Exception):  # type: ignore[no-redef]
         """Exception raised when trying to combine data structures with incompatible shapes."""  # noqa: W505
 
+    class StringCacheMismatchError(Exception):  # type: ignore[no-redef]
+        """Exception raised when string caches come from different sources."""
+
     class StructFieldNotFoundError(Exception):  # type: ignore[no-redef]
         """Exception raised when a specified schema field is not found."""
 
@@ -96,6 +99,7 @@ __all__ = [
     "SchemaError",
     "SchemaFieldNotFoundError",
     "ShapeError",
+    "StringCacheMismatchError",
     "StructFieldNotFoundError",
     "TooManyRowsReturnedError",
 ]

--- a/py-polars/src/error.rs
+++ b/py-polars/src/error.rs
@@ -45,6 +45,7 @@ impl std::convert::From<PyPolarsErr> for PyErr {
                 }
                 PolarsError::SchemaMismatch(err) => SchemaError::new_err(err.to_string()),
                 PolarsError::ShapeMismatch(err) => ShapeError::new_err(err.to_string()),
+                PolarsError::StringCacheMismatch(err) => StringCacheMismatchError::new_err(err.to_string()),
                 PolarsError::StructFieldNotFound(name) => {
                     StructFieldNotFoundError::new_err(name.to_string())
                 }
@@ -75,6 +76,7 @@ create_exception!(exceptions, NoDataError, PyException);
 create_exception!(exceptions, SchemaError, PyException);
 create_exception!(exceptions, SchemaFieldNotFoundError, PyException);
 create_exception!(exceptions, ShapeError, PyException);
+create_exception!(exceptions, StringCacheMismatchError, PyException);
 create_exception!(exceptions, StructFieldNotFoundError, PyException);
 
 #[macro_export]

--- a/py-polars/src/error.rs
+++ b/py-polars/src/error.rs
@@ -45,7 +45,9 @@ impl std::convert::From<PyPolarsErr> for PyErr {
                 }
                 PolarsError::SchemaMismatch(err) => SchemaError::new_err(err.to_string()),
                 PolarsError::ShapeMismatch(err) => ShapeError::new_err(err.to_string()),
-                PolarsError::StringCacheMismatch(err) => StringCacheMismatchError::new_err(err.to_string()),
+                PolarsError::StringCacheMismatch(err) => {
+                    StringCacheMismatchError::new_err(err.to_string())
+                }
                 PolarsError::StructFieldNotFound(name) => {
                     StructFieldNotFoundError::new_err(name.to_string())
                 }

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -232,6 +232,8 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     .unwrap();
     m.add("ShapeError", py.get_type::<crate::error::ShapeError>())
         .unwrap();
+    m.add("StringCacheMismatchError", py.get_type::<crate::error::StringCacheMismatchError>())
+        .unwrap();
     m.add(
         "StructFieldNotFoundError",
         py.get_type::<StructFieldNotFoundError>(),

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -232,8 +232,11 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     .unwrap();
     m.add("ShapeError", py.get_type::<crate::error::ShapeError>())
         .unwrap();
-    m.add("StringCacheMismatchError", py.get_type::<crate::error::StringCacheMismatchError>())
-        .unwrap();
+    m.add(
+        "StringCacheMismatchError",
+        py.get_type::<crate::error::StringCacheMismatchError>(),
+    )
+    .unwrap();
     m.add(
         "StructFieldNotFoundError",
         py.get_type::<StructFieldNotFoundError>(),

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -302,7 +302,7 @@ def test_err_on_categorical_asof_join_by_arg() -> None:
     )
     with pytest.raises(
         pl.ComputeError,
-        match=r"joins/or comparisons on categoricals can only happen if they were created under the same global string cache",
+        match=r"joins/or comparisons on categoricals can only happen\nif they were created under the same global string cache",
     ):
         df1.join_asof(df2, on=pl.col("time").set_sorted(), by="cat")
 

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -7,6 +7,7 @@ import pytest
 
 import polars as pl
 from polars import StringCache
+from polars.exceptions import StringCacheMismatchError
 from polars.testing import assert_frame_equal
 
 
@@ -301,8 +302,8 @@ def test_err_on_categorical_asof_join_by_arg() -> None:
         ]
     )
     with pytest.raises(
-        pl.ComputeError,
-        match=r"joins/or comparisons on categoricals can only happen\nif they were created under the same global string cache",
+        StringCacheMismatchError,
+        match="cannot compare categoricals coming from different sources",
     ):
         df1.join_asof(df2, on=pl.col("time").set_sorted(), by="cat")
 

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -7,6 +7,7 @@ import pytest
 
 import polars as pl
 from polars.config import _get_float_fmt
+from polars.exceptions import StringCacheMismatchError
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
@@ -481,7 +482,7 @@ def test_string_cache() -> None:
 
     df1a = df1.with_columns(pl.col("a").cast(pl.Categorical))
     df2a = df2.with_columns(pl.col("a").cast(pl.Categorical))
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(StringCacheMismatchError):
         _ = df1a.join(df2a, on="a", how="inner")
 
     # now turn on the cache


### PR DESCRIPTION
related to https://github.com/pola-rs/polars/issues/9106 (debatable whether it closes it)

Demo:

**latest release**

```python
In [2]: df1 = pl.DataFrame({"a": ["1", "2"]}, schema={"a": pl.Categorical})
   ...: df2 = pl.DataFrame({"a": ["1", "2"]}, schema={"a": pl.Categorical})
   ...: df1.join(df2, on='a')
---------------------------------------------------------------------------
ComputeError: joins/or comparisons on categoricals can only happen if they were created under the same global string cache
```

```python
In [3]: df1 = pl.DataFrame({"a": ["1", "2"]}, schema={"a": pl.Categorical})
   ...: df2 = pl.DataFrame({"a": ["3", "4"]}, schema={"a": pl.Categorical})
   ...: pl.concat([df1, df2])
---------------------------------------------------------------------------
ComputeError: cannot concat categoricals coming from a different source; consider setting a global StringCache
```

**here**

```python
In [1]: df1 = pl.DataFrame({"a": ["1", "2"]}, schema={"a": pl.Categorical})
   ...: df2 = pl.DataFrame({"a": ["1", "2"]}, schema={"a": pl.Categorical})
   ...: df1.join(df2, on='a')
---------------------------------------------------------------------------
ComputeError: joins/or comparisons on categoricals can only happen
if they were created under the same global string cache.

Help: if you're using Python, this may look something like:

    with pl.StringCache():
        df1 = pl.DataFrame({'a': ['1', '2']}, schema={'a': pl.Categorical})
        df2 = pl.DataFrame({'a': ['1', '3']}, schema={'a': pl.Categorical})
        df1.join(df2, on='a')

Alternatively, if the performance cost is acceptable, you could just set:

    pl.enable_string_cache(True)

on startup.
```

```python
In [2]: df1 = pl.DataFrame({"a": ["1", "2"]}, schema={"a": pl.Categorical})
   ...: df2 = pl.DataFrame({"a": ["3", "4"]}, schema={"a": pl.Categorical})
   ...: pl.concat([df1, df2])
---------------------------------------------------------------------------
ComputeError: cannot concat categoricals coming from a different source, consider setting a global StringCache.

Help: if you're using Python, this may look something like:

    with pl.StringCache():
        df1 = pl.DataFrame({'a': ['1', '2']}, schema={'a': pl.Categorical})
        df2 = pl.DataFrame({'a': ['1', '3']}, schema={'a': pl.Categorical})
        pl.concat([df1, df2])

Alternatively, if the performance cost is acceptable, you could just set:

    pl.enable_string_cache(True)

on startup.
```