### PR TITLE
chore(python): Fix some more type hints

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -74,7 +74,7 @@ if TYPE_CHECKING:
 
     import pyarrow as pa
 
-    from polars import DataFrame, Expr, Series
+    from polars import DataFrame, Expr
     from polars.type_aliases import (
         AsofJoinStrategy,
         ClosedInterval,
@@ -1866,7 +1866,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         return self._from_pyldf(self._ldf.clone())
 
-    def filter(self, predicate: Expr | str | Series | list[bool]) -> Self:
+    def filter(self, predicate: IntoExpr) -> Self:
         """
         Filter the rows in the LazyFrame based on a predicate expression.
 

--- a/py-polars/tests/parametric/test_series.py
+++ b/py-polars/tests/parametric/test_series.py
@@ -3,8 +3,7 @@
 # -------------------------------------------------
 from __future__ import annotations
 
-# from decimal import Decimal as D
-from typing import no_type_check
+from typing import Any
 
 import numpy as np
 from hypothesis import given, settings
@@ -41,7 +40,6 @@ def alpha_guard(**decay_param: float) -> bool:
     adjust=booleans(),
     bias=booleans(),
 )
-@no_type_check
 def test_ewm_methods(
     s: pl.Series,
     com: float | None,
@@ -52,7 +50,7 @@ def test_ewm_methods(
     bias: bool,
 ) -> None:
     # validate a large set of varied EWM calculations
-    for decay_param in ({"com": com}, {"span": span}, {"half_life": half_life}):
+    for decay_param in [{"com": com}, {"span": span}, {"half_life": half_life}]:
         alpha = _prepare_alpha(**decay_param)
 
         # convert parametrically-generated series to pandas, then use that as a
@@ -63,7 +61,7 @@ def test_ewm_methods(
         # https://github.com/pola-rs/polars/issues/5006#issuecomment-1259477178
         for mp in range(2, len(s), len(s) // 3):
             # consolidate ewm parameters
-            pl_params = {
+            pl_params: dict[str, Any] = {
                 "min_periods": mp,
                 "adjust": adjust,
                 "ignore_nulls": ignore_nulls,

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import io
 from datetime import date, datetime, time, timedelta, timezone
-from typing import TYPE_CHECKING, Any, cast, no_type_check
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
@@ -1461,16 +1461,17 @@ def test_agg_logical() -> None:
     assert s.min() == dates[0]
 
 
-@no_type_check
 def test_from_time_arrow() -> None:
     pa_times = pa.table([pa.array([10, 20, 30], type=pa.time32("s"))], names=["times"])
 
-    assert pl.from_arrow(pa_times).to_series().to_list() == [
+    result: pl.DataFrame = pl.from_arrow(pa_times)  # type: ignore[assignment]
+
+    assert result.to_series().to_list() == [
         time(0, 0, 10),
         time(0, 0, 20),
         time(0, 0, 30),
     ]
-    assert pl.from_arrow(pa_times).rows() == [
+    assert result.rows() == [
         (time(0, 0, 10),),
         (time(0, 0, 20),),
         (time(0, 0, 30),),

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import typing
 from datetime import timedelta
 from typing import Any, cast
 
@@ -349,7 +348,6 @@ def test_overflow_diff() -> None:
     }
 
 
-@typing.no_type_check
 def test_fill_null_unknown_output_type() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import typing
 from datetime import date, datetime
 
 import numpy as np
@@ -255,7 +254,6 @@ def test_list_slice() -> None:
     }
 
 
-@typing.no_type_check
 def test_list_sliced_get_5186() -> None:
     # https://github.com/pola-rs/polars/issues/5186
     n = 30

--- a/py-polars/tests/unit/operations/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/test_arithmetic.py
@@ -1,4 +1,3 @@
-import typing
 from datetime import date, datetime, timedelta
 
 import numpy as np
@@ -111,7 +110,6 @@ def test_simd_float_sum_determinism() -> None:
     ]
 
 
-@typing.no_type_check
 def test_floor_division_float_int_consistency() -> None:
     a = np.random.randn(10) * 10
 

--- a/py-polars/tests/unit/operations/test_comparison.py
+++ b/py-polars/tests/unit/operations/test_comparison.py
@@ -1,5 +1,3 @@
-import typing
-
 import polars as pl
 from polars.testing import assert_frame_equal
 
@@ -122,7 +120,6 @@ def test_comparison_expr_series() -> None:
     )
 
 
-@typing.no_type_check
 def test_offset_handling_arg_where_7863() -> None:
     df_check = pl.DataFrame({"a": [0, 1]})
     df_check.select((pl.lit(0).append(pl.col("a")).append(0)) != 0)

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-import typing
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 import pandas as pd
@@ -361,7 +360,6 @@ def test_sorted_flag_after_joins() -> None:
     assert not joined["a"].flags["SORTED_ASC"]
 
 
-@typing.no_type_check
 def test_jit_sort_joins() -> None:
     n = 200
     # Explicitly specify numpy dtype because of different defaults on Windows
@@ -382,9 +380,10 @@ def test_jit_sort_joins() -> None:
     dfa_pl = pl.from_pandas(dfa).sort("a")
     dfb_pl = pl.from_pandas(dfb)
 
-    for how in ["left", "inner"]:
+    join_strategies: list[Literal["left", "inner"]] = ["left", "inner"]
+    for how in join_strategies:
         pd_result = dfa.merge(dfb, on="a", how=how)
-        pd_result.columns = ["a", "b", "b_right"]
+        pd_result.columns = pd.Index(["a", "b", "b_right"])
 
         # left key sorted right is not
         pl_result = dfa_pl.join(dfb_pl, on="a", how=how).sort(["a", "b"])
@@ -395,7 +394,7 @@ def test_jit_sort_joins() -> None:
 
         # left key sorted right is not
         pd_result = dfb.merge(dfa, on="a", how=how)
-        pd_result.columns = ["a", "b", "b_right"]
+        pd_result.columns = pd.Index(["a", "b", "b_right"])
         pl_result = dfb_pl.join(dfa_pl, on="a", how=how).sort(["a", "b"])
 
         a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
@@ -403,7 +402,6 @@ def test_jit_sort_joins() -> None:
         assert pl_result["a"].flags["SORTED_ASC"]
 
 
-@typing.no_type_check
 def test_streaming_joins() -> None:
     n = 100
     dfa = pd.DataFrame(
@@ -423,9 +421,10 @@ def test_streaming_joins() -> None:
     dfa_pl = pl.from_pandas(dfa).sort("a")
     dfb_pl = pl.from_pandas(dfb)
 
-    for how in ["inner", "left"]:
+    join_strategies: list[Literal["inner", "left"]] = ["inner", "left"]
+    for how in join_strategies:
         pd_result = dfa.merge(dfb, on="a", how=how)
-        pd_result.columns = ["a", "b", "b_right"]
+        pd_result.columns = pd.Index(["a", "b", "b_right"])
 
         pl_result = (
             dfa_pl.lazy()
@@ -557,12 +556,11 @@ def test_join_sorted_fast_paths_null() -> None:
     }
 
 
-@typing.no_type_check
 def test_outer_join_list_() -> None:
     schema = {"id": pl.Int64, "vals": pl.List(pl.Float64)}
 
-    df1 = pl.DataFrame({"id": [1], "vals": [[]]}, schema=schema)
-    df2 = pl.DataFrame({"id": [2, 3], "vals": [[], [4]]}, schema=schema)
+    df1 = pl.DataFrame({"id": [1], "vals": [[]]}, schema=schema)  # type: ignore[arg-type]
+    df2 = pl.DataFrame({"id": [2, 3], "vals": [[], [4]]}, schema=schema)  # type: ignore[arg-type]
     assert df1.join(df2, on="id", how="outer").to_dict(False) == {
         "id": [2, 3, 1],
         "vals": [None, None, []],

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -632,7 +632,7 @@ def test_streaming_generic_left_and_inner_join_from_disk(tmp_path: Path) -> None
     lf0 = pl.scan_parquet(p0)
     lf1 = pl.scan_parquet(p1).select(pl.all().suffix("_r"))
 
-    hows: list[JoinStrategy] = ["left", "inner"]
-    for how in hows:
+    join_strategies: list[JoinStrategy] = ["left", "inner"]
+    for how in join_strategies:
         q = lf0.join(lf1, left_on="id", right_on="id_r", how=how)
         assert_frame_equal(q.collect(streaming=True), q.collect(streaming=False))

--- a/py-polars/tests/unit/test_api.py
+++ b/py-polars/tests/unit/test_api.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import no_type_check
-
 import polars as pl
 from polars.testing import assert_frame_equal
 
@@ -42,7 +40,6 @@ def test_custom_df_namespace() -> None:
     ]
 
 
-@no_type_check
 def test_custom_expr_namespace() -> None:
     @pl.api.register_expr_namespace("power")
     class PowersOfN:
@@ -62,9 +59,9 @@ def test_custom_expr_namespace() -> None:
     assert df.select(
         [
             pl.col("n"),
-            pl.col("n").power.next(p=2).alias("next_pow2"),
-            pl.col("n").power.previous(p=2).alias("prev_pow2"),
-            pl.col("n").power.nearest(p=2).alias("nearest_pow2"),
+            pl.col("n").power.next(p=2).alias("next_pow2"),  # type: ignore[attr-defined]
+            pl.col("n").power.previous(p=2).alias("prev_pow2"),  # type: ignore[attr-defined]
+            pl.col("n").power.nearest(p=2).alias("nearest_pow2"),  # type: ignore[attr-defined]
         ]
     ).rows() == [
         (1.4, 2, 1, 1),
@@ -74,7 +71,6 @@ def test_custom_expr_namespace() -> None:
     ]
 
 
-@no_type_check
 def test_custom_lazy_namespace() -> None:
     @pl.api.register_lazyframe_namespace("split")
     class SplitFrame:
@@ -92,7 +88,7 @@ def test_custom_lazy_namespace() -> None:
         orient="row",
     ).lazy()
 
-    df1, df2 = (d.collect() for d in ldf.split.by_column_dtypes())
+    df1, df2 = (d.collect() for d in ldf.split.by_column_dtypes())  # type: ignore[attr-defined]
     assert_frame_equal(
         df1, pl.DataFrame([("xx",), ("xy",), ("yy",), ("yz",)], schema=["a1"])
     )

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pickle
-import typing
 from datetime import datetime, timedelta
 
 import pytest
@@ -120,7 +119,6 @@ def test_repr(dtype: pl.PolarsDataType, representation: str) -> None:
     assert repr(dtype) == representation
 
 
-@typing.no_type_check
 def test_conversion_dtype() -> None:
     df = (
         pl.DataFrame(
@@ -147,9 +145,9 @@ def test_conversion_dtype() -> None:
         .agg([pl.col(["struct"])])
     )
 
-    df = pl.from_arrow(df.to_arrow())
+    df = pl.from_arrow(df.to_arrow())  # type: ignore[assignment]
     # the assertion is not the real test
-    # this tests if dtype as bubbled up correctly in conversion
+    # this tests if dtype has bubbled up correctly in conversion
     # if not we would UB
     assert df.to_dict(False) == {
         "some_partition_column": ["partition_1", "partition_2"],

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import io
-import typing
 from datetime import date, datetime, time, timedelta
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
 import polars as pl
 from polars.datatypes.convert import dtype_to_py_type
+
+if TYPE_CHECKING:
+    from polars.type_aliases import ConcatMethod
 
 
 def test_error_on_empty_groupby() -> None:
@@ -102,7 +105,6 @@ def test_panic_error() -> None:
         pl.Series("a", [1, 2, 3]).reshape(())
 
 
-@typing.no_type_check
 def test_join_lazy_on_df() -> None:
     df_left = pl.DataFrame(
         {
@@ -116,13 +118,13 @@ def test_join_lazy_on_df() -> None:
         TypeError,
         match="Expected 'other' .* to be a LazyFrame.* not a DataFrame",
     ):
-        df_left.lazy().join(df_right, on="Id")
+        df_left.lazy().join(df_right, on="Id")  # type: ignore[arg-type]
 
     with pytest.raises(
         TypeError,
         match="Expected 'other' .* to be a LazyFrame.* not a DataFrame",
     ):
-        df_left.lazy().join_asof(df_right, on="Id")
+        df_left.lazy().join_asof(df_right, on="Id")  # type: ignore[arg-type]
 
 
 def test_projection_update_schema_missing_column() -> None:
@@ -150,7 +152,6 @@ def test_not_found_on_rename() -> None:
         df.select(pl.col("does_not_exist").alias("new_name"))
 
 
-@typing.no_type_check
 def test_getitem_errs() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
 
@@ -159,7 +160,7 @@ def test_getitem_errs() -> None:
         match=r"Cannot __getitem__ on DataFrame with item: "
         r"'{'some'}' of type: '<class 'set'>'.",
     ):
-        df[{"some"}]
+        df[{"some"}]  # type: ignore[call-overload]
 
     with pytest.raises(
         ValueError,
@@ -167,7 +168,7 @@ def test_getitem_errs() -> None:
         r"'Int64' with argument: "
         r"'{'strange'}' of type: '<class 'set'>'.",
     ):
-        df["a"][{"strange"}]
+        df["a"][{"strange"}]  # type: ignore[call-overload]
 
     with pytest.raises(
         ValueError,
@@ -176,7 +177,7 @@ def test_getitem_errs() -> None:
         r"type: '<class 'set'>' and value: "
         r"'foo' of type: '<class 'str'>'",
     ):
-        df[{"some"}] = "foo"
+        df[{"some"}] = "foo"  # type: ignore[index]
 
 
 def test_err_bubbling_up_to_lit() -> None:
@@ -280,7 +281,6 @@ def test_window_expression_different_group_length() -> None:
         assert "output: 'shape:" in msg
 
 
-@typing.no_type_check
 def test_lazy_concat_err() -> None:
     df1 = pl.DataFrame(
         {
@@ -303,15 +303,14 @@ def test_lazy_concat_err() -> None:
         pl.concat([df1.lazy(), df2.lazy()], how="horizontal").collect()
 
 
-@typing.no_type_check
-def test_series_concat_err() -> None:
+@pytest.mark.parametrize("how", ["horizontal", "diagonal"])
+def test_series_concat_err(how: ConcatMethod) -> None:
     s = pl.Series([1, 2, 3])
-    for how in ("horizontal", "diagonal"):
-        with pytest.raises(
-            ValueError,
-            match="'Series' only allows {'vertical'} concat strategy.",
-        ):
-            pl.concat([s, s], how=how)
+    with pytest.raises(
+        ValueError,
+        match="'Series' only allows {'vertical'} concat strategy.",
+    ):
+        pl.concat([s, s], how=how)
 
 
 def test_invalid_sort_by() -> None:
@@ -354,13 +353,12 @@ def test_datetime_time_add_err() -> None:
         pl.Series([datetime(1970, 1, 1, 0, 0, 1)]) + pl.Series([time(0, 0, 2)])
 
 
-@typing.no_type_check
 def test_invalid_dtype() -> None:
     with pytest.raises(
         ValueError,
         match=r"Given dtype: 'mayonnaise' is not a valid Polars data type and cannot be converted into one",
     ):
-        pl.Series([1, 2], dtype="mayonnaise")
+        pl.Series([1, 2], dtype="mayonnaise")  # type: ignore[arg-type]
 
 
 def test_arr_eval_named_cols() -> None:
@@ -585,12 +583,11 @@ def test_window_size_validation() -> None:
         df.with_columns(trailing_min=pl.col("x").rolling_min(window_size=-3))
 
 
-@typing.no_type_check
 def test_invalid_getitem_key_err() -> None:
     df = pl.DataFrame({"x": [1.0], "y": [1.0]})
 
     with pytest.raises(KeyError, match=r"('x', 'y')"):
-        df["x", "y"]
+        df["x", "y"]  # type: ignore[index]
 
 
 def test_invalid_groupby_arg() -> None:

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sys
-import typing
 from datetime import date, datetime, time, timedelta, timezone
 from itertools import permutations
 from typing import Any, cast
@@ -428,15 +427,14 @@ def test_unique_empty() -> None:
         assert_series_equal(s.unique(), s)
 
 
-@typing.no_type_check
 def test_search_sorted() -> None:
     for seed in [1, 2, 3]:
         np.random.seed(seed)
-        a = np.sort(np.random.randn(10) * 100)
-        s = pl.Series(a)
+        arr = np.sort(np.random.randn(10) * 100)
+        s = pl.Series(arr)
 
-        for v in range(int(np.min(a)), int(np.max(a)), 20):
-            assert np.searchsorted(a, v) == s.search_sorted(v)
+        for v in range(int(np.min(arr)), int(np.max(arr)), 20):
+            assert np.searchsorted(arr, v) == s.search_sorted(v)
 
     a = pl.Series([1, 2, 3])
     b = pl.Series([1, 2, 2, -1])

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -1,4 +1,3 @@
-import typing
 from datetime import date, datetime, timedelta
 
 import numpy as np
@@ -90,7 +89,6 @@ def test_predicate_null_block_asof_join() -> None:
     }
 
 
-@typing.no_type_check
 def test_streaming_empty_df() -> None:
     df = pl.DataFrame(
         [
@@ -99,9 +97,14 @@ def test_streaming_empty_df() -> None:
         ]
     )
 
-    assert df.lazy().join(df.lazy(), on="a", how="inner").filter(2 == 1).collect(
-        streaming=True
-    ).to_dict(False) == {"a": [], "b": [], "b_right": []}
+    result = (
+        df.lazy()
+        .join(df.lazy(), on="a", how="inner")
+        .filter(False)
+        .collect(streaming=True)
+    )
+
+    assert result.to_dict(False) == {"a": [], "b": [], "b_right": []}
 
 
 def test_when_then_empty_list_5547() -> None:

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -1,5 +1,3 @@
-import typing
-
 import numpy as np
 
 import polars as pl
@@ -158,7 +156,6 @@ def test_double_projection_union() -> None:
     }
 
 
-@typing.no_type_check
 def test_asof_join_projection_() -> None:
     lf1 = (
         pl.DataFrame(


### PR DESCRIPTION
Let's avoid the `no_type_check` decorator. Better to just use a bunch of `type: ignore` statements. That way, `mypy` will notify us if anything changes in the types.