### PR TITLE
fix(rust, python): Loosen restrictions on cut expressions and add docs

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -1471,10 +1471,6 @@ impl Expr {
             labels,
             left_closed,
         })
-        .with_function_options(|mut opt| {
-            opt.allow_group_aware = false;
-            opt
-        })
     }
 
     #[cfg(feature = "cutqcut")]
@@ -1485,6 +1481,10 @@ impl Expr {
         left_closed: bool,
         allow_duplicates: bool,
     ) -> Expr {
+        // For now, we can't qcut over groups without creating consistent labels. The generated
+        // labels would be based on per-group quantiles, and per-group label differences caused
+        // problems when combining into a single categorical Series
+        let group_ok = labels.is_some();
         self.apply_private(FunctionExpr::QCut {
             probs,
             labels,
@@ -1492,7 +1492,7 @@ impl Expr {
             allow_duplicates,
         })
         .with_function_options(|mut opt| {
-            opt.allow_group_aware = false;
+            opt.allow_group_aware = group_ok;
             opt
         })
     }

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3252,6 +3252,44 @@ class Expr:
         left_closed
             Whether intervals should be [) instead of the default of (]
 
+        Examples
+        --------
+        >>> g = pl.repeat("a", 5, eager=True).append(pl.repeat("b", 5, eager=True))
+        >>> df = pl.DataFrame(dict(g=g, x=range(10)))
+        >>> df.with_columns(q=pl.col("x").cut([2, 5]))
+        shape: (10, 3)
+        ┌─────┬─────┬───────────┐
+        │ g   ┆ x   ┆ q         │
+        │ --- ┆ --- ┆ ---       │
+        │ str ┆ i64 ┆ cat       │
+        ╞═════╪═════╪═══════════╡
+        │ a   ┆ 0   ┆ (-inf, 2] │
+        │ a   ┆ 1   ┆ (-inf, 2] │
+        │ a   ┆ 2   ┆ (-inf, 2] │
+        │ a   ┆ 3   ┆ (2, 5]    │
+        │ …   ┆ …   ┆ …         │
+        │ b   ┆ 6   ┆ (5, inf]  │
+        │ b   ┆ 7   ┆ (5, inf]  │
+        │ b   ┆ 8   ┆ (5, inf]  │
+        │ b   ┆ 9   ┆ (5, inf]  │
+        └─────┴─────┴───────────┘
+        >>> df.with_columns(q=pl.col("x").cut([2, 5], left_closed=True))
+        shape: (10, 3)
+        ┌─────┬─────┬───────────┐
+        │ g   ┆ x   ┆ q         │
+        │ --- ┆ --- ┆ ---       │
+        │ str ┆ i64 ┆ cat       │
+        ╞═════╪═════╪═══════════╡
+        │ a   ┆ 0   ┆ [-inf, 2) │
+        │ a   ┆ 1   ┆ [-inf, 2) │
+        │ a   ┆ 2   ┆ [2, 5)    │
+        │ a   ┆ 3   ┆ [2, 5)    │
+        │ …   ┆ …   ┆ …         │
+        │ b   ┆ 6   ┆ [5, inf)  │
+        │ b   ┆ 7   ┆ [5, inf)  │
+        │ b   ┆ 8   ┆ [5, inf)  │
+        │ b   ┆ 9   ┆ [5, inf)  │
+        └─────┴─────┴───────────┘
         """
         return self._from_pyexpr(self._pyexpr.cut(breaks, labels, left_closed))
 
@@ -3272,13 +3310,70 @@ class Expr:
             For p in probs, we assume 0 <= p <= 1
         labels
             Labels to assign to bins. If given, the length must be len(probs) + 1.
-            If computing over a grouping variable we recommend this be set.
+            If computing over groups this must be set for now.
         left_closed
             Whether intervals should be [) instead of the default of (]
         allow_duplicates
             If True, the resulting quantile breaks don't have to be unique. This can
             happen even with unique probs depending on the data. Duplicates will be
             dropped, resulting in fewer bins.
+
+
+        Examples
+        --------
+        >>> g = pl.repeat("a", 5, eager=True).append(pl.repeat("b", 5, eager=True))
+        >>> df = pl.DataFrame(dict(g=g, x=range(10)))
+        >>> df.with_columns(q=pl.col("x").qcut([0.5]))
+        shape: (10, 3)
+        ┌─────┬─────┬─────────────┐
+        │ g   ┆ x   ┆ q           │
+        │ --- ┆ --- ┆ ---         │
+        │ str ┆ i64 ┆ cat         │
+        ╞═════╪═════╪═════════════╡
+        │ a   ┆ 0   ┆ (-inf, 4.5] │
+        │ a   ┆ 1   ┆ (-inf, 4.5] │
+        │ a   ┆ 2   ┆ (-inf, 4.5] │
+        │ a   ┆ 3   ┆ (-inf, 4.5] │
+        │ …   ┆ …   ┆ …           │
+        │ b   ┆ 6   ┆ (4.5, inf]  │
+        │ b   ┆ 7   ┆ (4.5, inf]  │
+        │ b   ┆ 8   ┆ (4.5, inf]  │
+        │ b   ┆ 9   ┆ (4.5, inf]  │
+        └─────┴─────┴─────────────┘
+        >>> df.with_columns(q=pl.col("x").qcut([0.5], ["lo", "hi"]).over("g"))
+        shape: (10, 3)
+        ┌─────┬─────┬─────┐
+        │ g   ┆ x   ┆ q   │
+        │ --- ┆ --- ┆ --- │
+        │ str ┆ i64 ┆ cat │
+        ╞═════╪═════╪═════╡
+        │ a   ┆ 0   ┆ lo  │
+        │ a   ┆ 1   ┆ lo  │
+        │ a   ┆ 2   ┆ lo  │
+        │ a   ┆ 3   ┆ hi  │
+        │ …   ┆ …   ┆ …   │
+        │ b   ┆ 6   ┆ lo  │
+        │ b   ┆ 7   ┆ lo  │
+        │ b   ┆ 8   ┆ hi  │
+        │ b   ┆ 9   ┆ hi  │
+        └─────┴─────┴─────┘
+        >>> df.with_columns(q=pl.col("x").qcut([0.5], ["lo", "hi"], True).over("g"))
+        shape: (10, 3)
+        ┌─────┬─────┬─────┐
+        │ g   ┆ x   ┆ q   │
+        │ --- ┆ --- ┆ --- │
+        │ str ┆ i64 ┆ cat │
+        ╞═════╪═════╪═════╡
+        │ a   ┆ 0   ┆ lo  │
+        │ a   ┆ 1   ┆ lo  │
+        │ a   ┆ 2   ┆ hi  │
+        │ a   ┆ 3   ┆ hi  │
+        │ …   ┆ …   ┆ …   │
+        │ b   ┆ 6   ┆ lo  │
+        │ b   ┆ 7   ┆ hi  │
+        │ b   ┆ 8   ┆ hi  │
+        │ b   ┆ 9   ┆ hi  │
+        └─────┴─────┴─────┘
 
         """
         return self._from_pyexpr(

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1653,7 +1653,40 @@ class Series:
         │ 2.0  ┆ inf         ┆ (1.0, inf]   │
         │ 2.5  ┆ inf         ┆ (1.0, inf]   │
         └──────┴─────────────┴──────────────┘
-
+        >>> a.cut([-1, 1], series=True)
+        shape: (12,)
+        Series: 'a' [cat]
+        [
+            "(-inf, -1]"
+            "(-inf, -1]"
+            "(-inf, -1]"
+            "(-inf, -1]"
+            "(-inf, -1]"
+            "(-1, 1]"
+            "(-1, 1]"
+            "(-1, 1]"
+            "(-1, 1]"
+            "(1, inf]"
+            "(1, inf]"
+            "(1, inf]"
+        ]
+        >>> a.cut([-1, 1], series=True, left_closed=True)
+        shape: (12,)
+        Series: 'a' [cat]
+        [
+            "[-inf, -1)"
+            "[-inf, -1)"
+            "[-inf, -1)"
+            "[-inf, -1)"
+            "[-1, 1)"
+            "[-1, 1)"
+            "[-1, 1)"
+            "[-1, 1)"
+            "[1, inf)"
+            "[1, inf)"
+            "[1, inf)"
+            "[1, inf)"
+        ]
         """
         if series:
             return (
@@ -1695,13 +1728,13 @@ class Series:
             Labels to assign to the quantiles. If given the length of labels must be
             len(bins) + 1.
         break_point_label
-            Name given to the breakpoint column.
+            Name given to the breakpoint column. Only used if series == False.
         category_label
-            Name given to the category column.
+            Name given to the category column. Only used if series == False.
         maintain_order
-            Keep the order of the original `Series`.
+            Keep the order of the original `Series`. Only used if series == False.
         series
-            If True, return the a categorical series in the data's original order
+            If True, return a categorical series in the data's original order
         left_closed
             Whether intervals should be [) instead of (]
         allow_duplicates
@@ -1737,7 +1770,32 @@ class Series:
         │ 1.0  ┆ inf         ┆ (0.25, inf]   │
         │ 2.0  ┆ inf         ┆ (0.25, inf]   │
         └──────┴─────────────┴───────────────┘
-
+        >>> a.qcut([0.0, 0.25, 0.75], series=True)
+        shape: (8,)
+        Series: 'a' [cat]
+        [
+            "(-inf, -5]"
+            "(-5, -3.25]"
+            "(-3.25, 0.25]"
+            "(-3.25, 0.25]"
+            "(-3.25, 0.25]"
+            "(-3.25, 0.25]"
+            "(0.25, inf]"
+            "(0.25, inf]"
+        ]
+        >>> a.qcut([0.0, 0.25, 0.75], series=True, left_closed=True)
+        shape: (8,)
+        Series: 'a' [cat]
+        [
+            "[-5, -3.25)"
+            "[-5, -3.25)"
+            "[-3.25, 0.25)"
+            "[-3.25, 0.25)"
+            "[-3.25, 0.25)"
+            "[-3.25, 0.25)"
+            "[0.25, inf)"
+            "[0.25, inf)"
+        ]
         """
         if series:
             return (


### PR DESCRIPTION
The issue with `qcut` categoricals only manifests when explicit names aren't provided and the per-group labels are inconsistent. This allows `qcut` to be used in windows when labels are provided. It also removes the restriction on using `cut` in windows since the breaks will always be uniform which shouldn't trigger the bug. Finally, it adds some documentation and examples for the new functionality.