### PR TITLE
fix(python): fix import error when writing parquet with pyarrow

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3095,8 +3095,9 @@ class DataFrame:
 
             tbl = pa.table(data)
 
-            # do not remove this
+            # do not remove this import!
             # needed below
+            import pyarrow.parquet  # noqa: F401
 
             pa.parquet.write_table(
                 table=tbl,

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.dataset as ds
-import pyarrow.parquet as pq
 import pytest
 
 import polars as pl
@@ -32,6 +31,17 @@ COMPRESSIONS = [
     "brotli",
     "zstd",
 ]
+
+
+def test_write_parquet_using_pyarrow_9753(tmpdir: Path) -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    df.write_parquet(
+        tmpdir / "test.parquet",
+        compression="zstd",
+        statistics=True,
+        use_pyarrow=True,
+        pyarrow_options={"coerce_timestamps": "us"},
+    )
 
 
 @pytest.fixture()
@@ -354,6 +364,8 @@ def test_parquet_nested_dictionaries_6217() -> None:
         df = pl.from_arrow(table)
 
         f = io.BytesIO()
+        import pyarrow.parquet as pq
+
         pq.write_table(table, f, compression="snappy")
         f.seek(0)
         read = pl.read_parquet(f)


### PR DESCRIPTION
closes #9753 