### PR TITLE
chore(rust): unswap from_tz and to_tz in replace_timezone

### DIFF
--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -106,7 +106,7 @@ impl DatetimeChunked {
             let chunks = self
                 .downcast_iter()
                 .map(|arr| {
-                    replace_timezone(arr, self.time_unit().to_arrow(), to, from, use_earliest)
+                    replace_timezone(arr, self.time_unit().to_arrow(), from, to, use_earliest)
                 })
                 .collect::<PolarsResult<_>>()?;
             let out = unsafe { ChunkedArray::from_chunks(self.name(), chunks) };

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "ahash",
  "built",


### PR DESCRIPTION
I find the way it's currently written is quite confusing, as `from_tz` and `to_tz` are swapped