### PR TITLE
refactor(python,rust): More cleanup around `arange`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_python.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_python.yml
@@ -41,7 +41,7 @@ body:
 
         pl.DataFrame({
             "foo": [None, 1, 2],
-            "bar": np.int_range(3)
+            "bar": np.arange(3)
         })
 
         ...

--- a/.github/ISSUE_TEMPLATE/bug_report_python.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_python.yml
@@ -41,7 +41,7 @@ body:
 
         pl.DataFrame({
             "foo": [None, 1, 2],
-            "bar": np.arange(3)
+            "bar": np.int_range(3)
         })
 
         ...
@@ -70,7 +70,7 @@ body:
         ```
         Replace this line with the output of pl.show_versions(), leave the backticks in place
         ```
-        
+
         </details>
     validations:
       required: true

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/range.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/range.rs
@@ -121,7 +121,7 @@ pub(super) fn int_ranges(s: &[Series], step: i64) -> PolarsResult<Series> {
             polars_bail!(
                 ComputeError:
                 "lengths of `start`: {} and `end`: {} arguments `\
-                cannot be matched in the `arange` expression",
+                cannot be matched in the `int_ranges` expression",
                 start.len(), end.len()
             );
         }

--- a/polars/polars-lazy/polars-plan/src/dsl/functions/index.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/functions/index.rs
@@ -9,7 +9,7 @@ use super::*;
 pub fn arg_sort_by<E: AsRef<[Expr]>>(by: E, descending: &[bool]) -> Expr {
     let e = &by.as_ref()[0];
     let name = expr_output_name(e).unwrap();
-    arange(lit(0 as IdxSize), count().cast(IDX_DTYPE), 1)
+    int_range(lit(0 as IdxSize), count().cast(IDX_DTYPE), 1)
         .sort_by(by, descending)
         .alias(name.as_ref())
 }

--- a/polars/tests/it/lazy/expressions/apply.rs
+++ b/polars/tests/it/lazy/expressions/apply.rs
@@ -2,17 +2,17 @@ use super::*;
 
 #[test]
 #[cfg(feature = "range")]
-fn test_arange_agg() -> PolarsResult<()> {
+fn test_int_range_agg() -> PolarsResult<()> {
     let df = df![
         "x" => [5, 5, 4, 4, 2, 2]
     ]?;
 
     let out = df
         .lazy()
-        .with_columns([arange(lit(0i32), count(), 1).over([col("x")])])
+        .with_columns([int_range(lit(0i32), count(), 1).over([col("x")])])
         .collect()?;
     assert_eq!(
-        Vec::from_iter(out.column("arange")?.i64()?.into_no_null_iter()),
+        Vec::from_iter(out.column("int")?.i64()?.into_no_null_iter()),
         &[0, 1, 0, 1, 0, 1]
     );
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "ahash",
  "built",

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5143,7 +5143,7 @@ class DataFrame:
 
         >>> df = pl.DataFrame(
         ...     {
-        ...         "idx": pl.arange(0, 6, eager=True),
+        ...         "idx": pl.int_range(0, 6, eager=True),
         ...         "A": ["A", "A", "B", "B", "B", "C"],
         ...     }
         ... )
@@ -6562,7 +6562,7 @@ class DataFrame:
         >>> df = pl.DataFrame(
         ...     {
         ...         "col1": list(ascii_uppercase[0:9]),
-        ...         "col2": pl.arange(0, 9, eager=True),
+        ...         "col2": pl.int_range(0, 9, eager=True),
         ...     }
         ... )
         >>> df
@@ -6634,7 +6634,7 @@ class DataFrame:
         if how == "horizontal":
             df = (
                 df.with_columns(
-                    (F.arange(0, n_cols * n_rows, eager=True) % n_cols).alias(
+                    (F.int_range(0, n_cols * n_rows, eager=True) % n_cols).alias(
                         "__sort_order"
                     ),
                 )

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -99,6 +99,11 @@ def arange(
         Evaluate immediately and return a ``Series``. If set to ``False`` (default),
         return an expression instead.
 
+    See Also
+    --------
+    int_range :
+    int_ranges : Generate a range of integers for each row of the input columns.
+
     Examples
     --------
     >>> pl.arange(0, 3, eager=True)
@@ -141,6 +146,7 @@ def int_range(
     end: int | IntoExpr,
     step: int = ...,
     *,
+    dtype: PolarsIntegerType = ...,
     eager: Literal[False] = ...,
 ) -> Expr:
     ...
@@ -152,6 +158,7 @@ def int_range(
     end: int | IntoExpr,
     step: int = ...,
     *,
+    dtype: PolarsIntegerType = ...,
     eager: Literal[True],
 ) -> Series:
     ...
@@ -163,6 +170,7 @@ def int_range(
     end: int | IntoExpr,
     step: int = ...,
     *,
+    dtype: PolarsIntegerType = ...,
     eager: bool,
 ) -> Expr | Series:
     ...
@@ -173,6 +181,7 @@ def int_range(
     end: int | IntoExpr,
     step: int = 1,
     *,
+    dtype: PolarsIntegerType = Int64,
     eager: bool = False,
 ) -> Expr | Series:
     """
@@ -186,6 +195,8 @@ def int_range(
         Upper bound of the range (exclusive).
     step
         Step size of the range.
+    dtype
+        Data type of the range. Defaults to ``Int64``.
     eager
         Evaluate immediately and return a ``Series``. If set to ``False`` (default),
         return an expression instead.
@@ -208,7 +219,7 @@ def int_range(
     """
     start = parse_as_expression(start)
     end = parse_as_expression(end)
-    result = wrap_expr(plr.int_range(start, end, step))
+    result = wrap_expr(plr.int_range(start, end, step, dtype))
 
     if eager:
         return F.select(result).to_series()

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -82,8 +82,11 @@ def arange(
     """
     Generate a range of integers.
 
-    This can be used in a ``select``, ``with_columns`` etc. Be sure that the resulting
-    range size is equal to the length of the DataFrame you are collecting.
+    .. deprecated:: 0.18.5
+        ``arange`` has been replaced by two new functions: ``int_range`` for generating
+        a single range, and ``int_ranges`` for generating a list column with multiple
+        ranges. ``arange`` will remain available as an alias for `int_range`, which
+        means it will lose the functionality to generate multiple ranges.
 
     Parameters
     ----------
@@ -101,7 +104,7 @@ def arange(
 
     See Also
     --------
-    int_range :
+    int_range : Generate a range of integers.
     int_ranges : Generate a range of integers for each row of the input columns.
 
     Examples
@@ -205,6 +208,10 @@ def int_range(
     -------
     Column of data type ``Int64``.
 
+    See Also
+    --------
+    int_ranges : Generate a range of integers for each row of the input columns.
+
     Examples
     --------
     >>> pl.int_range(0, 3, eager=True)
@@ -291,6 +298,10 @@ def int_ranges(
     Returns
     -------
     Column of data type ``List(dtype)``.
+
+    See Also
+    --------
+    int_range : Generate a single range of integers.
 
     Examples
     --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2607,7 +2607,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         >>> lf = pl.LazyFrame(
         ...     {
-        ...         "idx": pl.arange(0, 6, eager=True),
+        ...         "idx": pl.int_range(0, 6, eager=True),
         ...         "A": ["A", "A", "B", "B", "B", "C"],
         ...     }
         ... )

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -270,7 +270,7 @@ class Series:
             self._s = series_to_pyseries(name, values)
 
         elif isinstance(values, range):
-            self._s = range_to_series(name, values, dtype=dtype)._s
+            self._s = range_to_series(name, values, dtype=dtype)._s  # type: ignore[arg-type]
 
         elif isinstance(values, Sequence):
             self._s = sequence_to_pyseries(

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from polars import DataFrame, Series
-    from polars.type_aliases import PolarsDataType, SizeUnit
+    from polars.type_aliases import PolarsDataType, PolarsIntegerType, SizeUnit
 
     if sys.version_info >= (3, 10):
         from typing import ParamSpec, TypeGuard
@@ -96,10 +96,11 @@ def is_str_sequence(
 
 
 def range_to_series(
-    name: str, rng: range, dtype: PolarsDataType | None = None
+    name: str, rng: range, dtype: PolarsIntegerType | None = None
 ) -> Series:
     """Fast conversion of the given range to a Series."""
-    return F.arange(
+    dtype = dtype or Int64
+    return F.int_range(
         start=rng.start,
         end=rng.stop,
         step=rng.step,

--- a/py-polars/src/functions/range.rs
+++ b/py-polars/src/functions/range.rs
@@ -10,8 +10,16 @@ pub fn arange(start: PyExpr, end: PyExpr, step: i64) -> PyExpr {
 }
 
 #[pyfunction]
-pub fn int_range(start: PyExpr, end: PyExpr, step: i64) -> PyExpr {
-    dsl::int_range(start.inner, end.inner, step).into()
+pub fn int_range(start: PyExpr, end: PyExpr, step: i64, dtype: Wrap<DataType>) -> PyExpr {
+    let dtype = dtype.0;
+
+    let mut result = dsl::int_range(start.inner, end.inner, step);
+
+    if dtype != DataType::Int64 {
+        result = result.cast(dtype)
+    }
+
+    result.into()
 }
 
 #[pyfunction]


### PR DESCRIPTION
Changes:
* Add `dtype` argument for `int_range`. Right now it's just a cast after the fact - but I will try to implement this later such that the Series gets materialized in the right data type.
* Use `int_range` instead of `arange` internally.
* Update `arange` docs with a proper deprecation message and "See Also" section.