### PR TITLE
feat(python): round instead of truncate in downcasted time conversions

### DIFF
--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -101,7 +101,7 @@ def _datetime_to_pl_timestamp(dt: datetime, time_unit: TimeUnit | None) -> int:
         micros = dt.microsecond
         return _timestamp_in_seconds(dt) * 1_000_000 + micros
     elif time_unit == "ms":
-        millis = dt.microsecond // 1000
+        millis = dt.microsecond // 1000 + (dt.microsecond % 1000 >= 500)
         return _timestamp_in_seconds(dt) * 1_000 + millis
     else:
         raise ValueError(
@@ -144,13 +144,16 @@ def _to_python_time(value: int) -> time:
         minutes, seconds = divmod(seconds, 60)
         hours, minutes = divmod(minutes, 60)
         return time(
-            hour=hours, minute=minutes, second=seconds, microsecond=nanoseconds // 1000
+            hour=hours,
+            minute=minutes,
+            second=seconds,
+            microsecond=nanoseconds // 1000 + (nanoseconds % 1000 >= 500),
         )
 
 
 def _to_python_timedelta(value: int | float, time_unit: TimeUnit = "ns") -> timedelta:
     if time_unit == "ns":
-        return timedelta(microseconds=value // 1e3)
+        return timedelta(microseconds=value // 1000 + (value % 1000 >= 500))
     elif time_unit == "us":
         return timedelta(microseconds=value)
     elif time_unit == "ms":
@@ -177,7 +180,7 @@ def _to_python_datetime(
         if time_unit == "us":
             return EPOCH + timedelta(microseconds=value)
         elif time_unit == "ns":
-            return EPOCH + timedelta(microseconds=value // 1000)
+            return EPOCH + timedelta(microseconds=value // 1000 + (value % 1000 >= 500))
         elif time_unit == "ms":
             return EPOCH + timedelta(milliseconds=value)
         else:
@@ -188,7 +191,9 @@ def _to_python_datetime(
         if time_unit == "us":
             dt = EPOCH_UTC + timedelta(microseconds=value)
         elif time_unit == "ns":
-            dt = EPOCH_UTC + timedelta(microseconds=value // 1000)
+            dt = EPOCH_UTC + timedelta(
+                microseconds=value // 1000 + (value % 1000 >= 500)
+            )
         elif time_unit == "ms":
             dt = EPOCH_UTC + timedelta(milliseconds=value)
         else:

--- a/py-polars/tests/parametric/test_lit.py
+++ b/py-polars/tests/parametric/test_lit.py
@@ -27,5 +27,6 @@ def test_datetime_us(value: datetime) -> None:
 @given(value=strategy_datetime_ms)
 def test_datetime_ms(value: datetime) -> None:
     result = pl.select(pl.lit(value, dtype=pl.Datetime("ms")))["literal"][0]
-    expected_microsecond = (value.microsecond // 1000 + (value % 1000 >= 500)) * 1000
+    ms = value.microsecond
+    expected_microsecond = (ms // 1000 + (ms % 1000 >= 500)) * 1000
     assert result == value.replace(microsecond=expected_microsecond)

--- a/py-polars/tests/parametric/test_lit.py
+++ b/py-polars/tests/parametric/test_lit.py
@@ -27,5 +27,5 @@ def test_datetime_us(value: datetime) -> None:
 @given(value=strategy_datetime_ms)
 def test_datetime_ms(value: datetime) -> None:
     result = pl.select(pl.lit(value, dtype=pl.Datetime("ms")))["literal"][0]
-    expected_microsecond = value.microsecond // 1000 * 1000
+    expected_microsecond = (value.microsecond // 1000 + (value % 1000 >= 500)) * 1000
     assert result == value.replace(microsecond=expected_microsecond)

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2684,6 +2684,13 @@ def test_misc_precision_any_value_conversion(time_zone: Any, warn: bool) -> None
         assert pl.Series([dt]).cast(pl.Datetime("ns", time_zone)).to_list() == [dt]
 
 
+def test_ns_rounding() -> None:
+    # ns rounding
+    assert pl.Series(
+        [1646058685919897849], dtype=pl.Datetime(time_unit="ns")
+    ).to_list() == [datetime(2022, 2, 28, 14, 31, 25, 919898)]
+
+
 @pytest.mark.parametrize(
     "tm",
     [

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -807,7 +807,7 @@ def test_lit_dtypes() -> None:
         return pl.select(pl.lit(value, dtype=dtype)).to_series()
 
     d = datetime(2049, 10, 5, 1, 2, 3, 987654)
-    d_ms = datetime(2049, 10, 5, 1, 2, 3, 987000)
+    d_ms = datetime(2049, 10, 5, 1, 2, 3, 988000)
     d_tz = datetime(2049, 10, 5, 1, 2, 3, 987654, tzinfo=ZoneInfo("Asia/Kathmandu"))
 
     td = timedelta(days=942, hours=6, microseconds=123456)


### PR DESCRIPTION
Resolves #9774

Note that we can't simply use `round(x/1000)` because `x` is too large for floating-point arithmetic to be accurate. Instead I resorted to using `x // 1000 + (x % 1000 >= 500)`.

See the issue discussion: I'm not sure we should be rounding instead of truncating. I made this PR just in case.