### PR TITLE
feat(python): support numpy datetime64 units (from 'ns' to 'Y') in polars.from_numpy

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.2.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e959d788268e3bf9d35ace83e81b124190378e4c91c9067524675e33394b8ba"
+checksum = "9ab77dbd8adecaf3f0db40581631b995f312a8a5ae3aa9993188bb8f23d83a5b"
 dependencies = [
  "crossterm",
  "strum",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "ahash",
  "built",

--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -102,10 +102,19 @@ def numpy_values_and_dtype(
         values = values.astype(np.float32)
         dtype = values.dtype.type
     elif dtype == np.datetime64:
-        if np.datetime_data(values.dtype)[0] in dt.DTYPE_TEMPORAL_UNITS:
+        time_unit = np.datetime_data(values.dtype)[0]
+        if time_unit in dt.DTYPE_TEMPORAL_UNITS:
             values = values.astype(np.int64)
+        elif time_unit in {"s", "m", "h"}:
+            values = values.astype("datetime64[ms]").astype(np.int64)
+        elif time_unit == "D":
+            values = values.astype(np.int64)
+        elif time_unit in {"W", "M", "Y"}:
+            values = values.astype("datetime64[D]").astype(np.int64)
         else:
-            dtype = object
+            raise ValueError(
+                "Expected 'Y', 'M', 'W', 'D', 'h', 'm', 's', 'ms', 'us', or 'ns'. Please cast to the closest supported unit."
+            )
     return values, dtype
 
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -6072,6 +6072,8 @@ def _resolve_datetime_dtype(
             dtype = Datetime("ns")
         elif time_unit == "us":
             dtype = Datetime("us")
-        elif time_unit == "ms":
+        elif time_unit in {"ms", "s", "m", "h"}:
             dtype = Datetime("ms")
+        elif time_unit in {"D", "W", "M", "Y"}:
+            dtype = Date
     return dtype


### PR DESCRIPTION
closes #9779 