### PR TITLE
Implementation for #9104

### DIFF
--- a/polars/polars-lazy/Cargo.toml
+++ b/polars/polars-lazy/Cargo.toml
@@ -23,7 +23,7 @@ polars-io = { version = "0.30.0", path = "../polars-io", features = ["lazy", "cs
 polars-json = { version = "0.30.0", path = "../polars-json", optional = true }
 polars-ops = { version = "0.30.0", path = "../polars-ops", default-features = false }
 polars-pipe = { version = "0.30.0", path = "./polars-pipe", optional = true }
-polars-plan = { version = "0.30.0", path = "./polars-plan" }
+polars-plan = { version = "0.30.0", path = "./polars-plan", features = ["regex"] }
 polars-time = { version = "0.30.0", path = "../polars-time", optional = true }
 polars-utils = { version = "0.30.0", path = "../polars-utils" }
 pyo3 = { version = "0.19", optional = true }

--- a/polars/polars-sql/src/functions.rs
+++ b/polars/polars-sql/src/functions.rs
@@ -168,6 +168,12 @@ pub(crate) enum PolarsSqlFunctions {
     /// SELECT RTRIM(column_1) from df;
     /// ```
     RTrim,
+    /// SQL 'contains' function
+    /// ```sql
+    /// SELECT contains(column_1, 'a') from df;
+    /// SELECT column_2 from df WHERE contains(column_1, 'a');
+    /// ```
+    Contains,
     /// SQL 'starts_with' function
     /// ```sql
     /// SELECT STARTS_WITH(column_1, 'a') from df;
@@ -327,6 +333,7 @@ impl PolarsSqlFunctions {
             "avg",
             "ceil",
             "ceiling",
+            "contains",
             "cos",
             "cosd",
             "cot",
@@ -411,6 +418,7 @@ impl TryFrom<&'_ SQLFunction> for PolarsSqlFunctions {
             "lower" => Self::Lower,
             "ltrim" => Self::LTrim,
             "rtrim" => Self::RTrim,
+            "contains" => Self::Contains,
             "starts_with" => Self::StartsWith,
             "upper" => Self::Upper,
             // ----
@@ -497,6 +505,7 @@ impl SqlFunctionVisitor<'_> {
             // ----
             // String functions
             // ----
+            Contains => self.visit_binary(|e, s| e.str().contains(s, false)),
             EndsWith => self.visit_binary(|e, s| e.str().ends_with(s)),
             Lower => self.visit_unary(|e| e.str().to_lowercase()),
             LTrim => match function.args.len() {

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -362,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "6.2.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e959d788268e3bf9d35ace83e81b124190378e4c91c9067524675e33394b8ba"
+checksum = "9ab77dbd8adecaf3f0db40581631b995f312a8a5ae3aa9993188bb8f23d83a5b"
 dependencies = [
  "crossterm",
  "strum",
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.18.5"
+version = "0.18.6"
 dependencies = [
  "ahash",
  "built",


### PR DESCRIPTION
There was already a `contains` function, similar to the `starts_with` and `ends_with` functions, it just wasn't exposed to the SQL API. I don't know if this was intentional, or an oversight, but in any case, I exposed it, and wrote some tests to show that it works. 

The only thing I'm not sure about is the change to `polars/polars-lazy/Cargo.toml`, where I enabled the `regex` feature. In order for the `contains` function to get compiled in, this feature must be enabled, so this seems like a reasonable change, but I don't know what the reason was for not enabling it to begin with. 
