### PR TITLE
fix(rust,python): fix supertype detection

### DIFF
--- a/polars/polars-core/src/schema.rs
+++ b/polars/polars-core/src/schema.rs
@@ -389,7 +389,7 @@ impl Schema {
             polars_ensure!(k == other_k, ComputeError: "schema names differ: got {}, expected {}", k, other_k);
 
             let st = try_get_supertype(dt, other_dt)?;
-            changed |= &st != dt;
+            changed |= (&st != dt) || (&st != other_dt);
             *dt = st
         }
         Ok(changed)

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -468,24 +468,38 @@ def test_schema_ne_missing_9256() -> None:
 
 def test_concat_vertically_relaxed() -> None:
     a = pl.DataFrame(
-        {
-            "a": [1, 2, 3],
-            "b": [True, False, None],
-        },
+        data={"a": [1, 2, 3], "b": [True, False, None]},
         schema={"a": pl.Int8, "b": pl.Boolean},
     )
-
     b = pl.DataFrame(
-        {
-            "a": [43, 2, 3],
-            "b": [32, 1, None],
-        },
+        data={"a": [43, 2, 3], "b": [32, 1, None]},
         schema={"a": pl.Int16, "b": pl.Int64},
     )
-
     out = pl.concat([a, b], how="vertical_relaxed")
     assert out.schema == {"a": pl.Int16, "b": pl.Int64}
     assert out.to_dict(False) == {
         "a": [1, 2, 3, 43, 2, 3],
         "b": [1, 0, None, 32, 1, None],
+    }
+    out = pl.concat([b, a], how="vertical_relaxed")
+    assert out.schema == {"a": pl.Int16, "b": pl.Int64}
+    assert out.to_dict(False) == {
+        "a": [43, 2, 3, 1, 2, 3],
+        "b": [32, 1, None, 1, 0, None],
+    }
+
+    c = pl.DataFrame({"a": [1, 2], "b": [2, 1]})
+    d = pl.DataFrame({"a": [1.0, 0.2], "b": [None, 0.1]})
+
+    out = pl.concat([c, d], how="vertical_relaxed")
+    assert out.schema == {"a": pl.Float64, "b": pl.Float64}
+    assert out.to_dict(False) == {
+        "a": [1.0, 2.0, 1.0, 0.2],
+        "b": [2.0, 1.0, None, 0.1],
+    }
+    out = pl.concat([d, c], how="vertical_relaxed")
+    assert out.schema == {"a": pl.Float64, "b": pl.Float64}
+    assert out.to_dict(False) == {
+        "a": [1.0, 0.2, 1.0, 2.0],
+        "b": [None, 0.1, 2.0, 1.0],
     }


### PR DESCRIPTION
Closes #9751.

Supertype detection was inadvertently order-dependent.
(eg: we would spot if B was a supertype of A, but not if A was a supertype of B).