### PR TITLE
fix(python): improve/fix `write_database` handling of db schema and quoted table names

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3179,11 +3179,13 @@ class DataFrame:
             # the table name may also include the db schema; ensure that we identify
             # both components and pass them through unquoted (sqlalachemy will quote)
             table_ident = next(delimited_read([table_name], delimiter="."))
-            if len(table_ident) > 1:
-                db_schema = table_ident[0].strip('"')
-                table_name = table_ident[1].strip('"')
+            if len(table_ident) > 2:
+                raise ValueError(f"table_name appears to be invalid: {table_name!r}")
+            elif len(table_ident) > 1:
+                db_schema = table_ident[0]
+                table_name = table_ident[1]
             else:
-                table_name = table_ident[0].strip('"')
+                table_name = table_ident[0]
                 db_schema = None
 
             # ensure conversion to pandas uses the pyarrow extension array option

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -12,6 +12,7 @@ pyarrow
 pydantic
 backports.zoneinfo; python_version < '3.9'
 tzdata; platform_system == 'Windows'
+SQLAlchemy
 xlsx2csv
 XlsxWriter
 adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'

--- a/py-polars/tests/unit/io/test_database.py
+++ b/py-polars/tests/unit/io/test_database.py
@@ -205,8 +205,8 @@ def test_write_database(
     tmp_db = f"test_{engine}.db"
     test_db = str(tmp_path / tmp_db)
 
-    # note: explicitly test a table name that requires quotes to
-    # ensure that we handle it correctly (also use a db schema)
+    # note: test a table name that requires quotes to ensure that we handle
+    # it correctly (also supply an explicit db schema with/without quotes)
     tbl_name = '"test-data"'
 
     sample_df.write_database(
@@ -218,7 +218,7 @@ def test_write_database(
 
     if mode == "append":
         sample_df.write_database(
-            table_name=f"main.{tbl_name}",
+            table_name=f'"main".{tbl_name}',
             connection_uri=f"sqlite:///{test_db}",
             if_exists="append",
             engine=engine,

--- a/py-polars/tests/unit/io/test_database.py
+++ b/py-polars/tests/unit/io/test_database.py
@@ -229,3 +229,15 @@ def test_write_database(
 
     sample_df = sample_df.with_columns(pl.col("date").cast(pl.Utf8))
     assert_frame_equal(sample_df, result)
+
+    # check that some invalid parameters raise errors
+    for invalid_params in (
+        {"table_name": "w.x.y.z"},
+        {"if_exists": "crunk", "table_name": f"main.{tbl_name}"},
+    ):
+        with pytest.raises(ValueError):
+            sample_df.write_database(
+                connection_uri=f"sqlite:///{test_db}",
+                engine=engine,
+                **invalid_params,  # type: ignore[arg-type]
+            )

--- a/py-polars/tests/unit/io/test_database.py
+++ b/py-polars/tests/unit/io/test_database.py
@@ -170,7 +170,7 @@ def test_read_database_exceptions(
         pytest.param(
             "adbc",
             "create",
-            id="create",
+            id="adbc_create",
             marks=pytest.mark.skipif(
                 sys.version_info < (3, 9) or sys.platform == "win32",
                 reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
@@ -179,11 +179,21 @@ def test_read_database_exceptions(
         pytest.param(
             "adbc",
             "append",
-            id="append",
+            id="adbc_append",
             marks=pytest.mark.skipif(
                 sys.version_info < (3, 9) or sys.platform == "win32",
                 reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
             ),
+        ),
+        pytest.param(
+            "sqlalchemy",
+            "create",
+            id="sa_create",
+        ),
+        pytest.param(
+            "sqlalchemy",
+            "append",
+            id="sa_append",
         ),
     ],
 )
@@ -192,10 +202,15 @@ def test_write_database(
 ) -> None:
     tmp_path.mkdir(exist_ok=True)
 
-    test_db = str(tmp_path / "test.db")
+    tmp_db = f"test_{engine}.db"
+    test_db = str(tmp_path / tmp_db)
+
+    # note: explicitly test a table name that requires quotes to
+    # ensure that we handle it correctly (also use a db schema)
+    tbl_name = '"test-data"'
 
     sample_df.write_database(
-        table_name="test_data",
+        table_name=f"main.{tbl_name}",
         connection_uri=f"sqlite:///{test_db}",
         if_exists="replace",
         engine=engine,
@@ -203,14 +218,14 @@ def test_write_database(
 
     if mode == "append":
         sample_df.write_database(
-            table_name="test_data",
+            table_name=f"main.{tbl_name}",
             connection_uri=f"sqlite:///{test_db}",
             if_exists="append",
             engine=engine,
         )
         sample_df = pl.concat([sample_df, sample_df])
 
-    result = pl.read_database("SELECT * FROM test_data", f"sqlite:///{test_db}")
+    result = pl.read_database(f"SELECT * FROM {tbl_name}", f"sqlite:///{test_db}")
 
     sample_df = sample_df.with_columns(pl.col("date").cast(pl.Utf8))
     assert_frame_equal(sample_df, result)


### PR DESCRIPTION
Closes #9548.

* Fixes use of db schema with table names when using the sqlalchemy engine (eg: `schema_name.table_name`).
* Fixes use of quoted table names when using the sqlalchemy engine (eg: `schema_name."table-name"`).
* Handles independently quoted schema / table name (eg: `"schema_name"."table-name"`).
* Adds new `sqlalchemy` engine unit test coverage for all of the above.