### PR TITLE
feat(python): implement add() for frame/lazyframe

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9175,9 +9175,6 @@ class DataFrame:
         │ 5   ┆ 105 ┆ 10  ┆ *FILL_C*e ┆ ee        │
         └─────┴─────┴─────┴───────────┴───────────┘
         """
-        if fill_value is None and on is None:
-            return self.__add__(other)
-
         return (
             self.lazy().add(other.lazy(), on, fill_value).collect(no_optimization=True)
         )

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9087,8 +9087,8 @@ class DataFrame:
     def add(
         self,
         other: DataFrame,
-        on: str | Sequence[str] | None = None,
         fill_value: int | float | str | Mapping[str, int | float | str] | None = None,
+        on: str | Sequence[str] | None = None,
     ) -> pl.DataFrame:
         """
         Add aligned dataframes with element-wise and filling missing values.
@@ -9176,7 +9176,7 @@ class DataFrame:
         └─────┴─────┴─────┴───────────┴───────────┘
         """
         return (
-            self.lazy().add(other.lazy(), on, fill_value).collect(no_optimization=True)
+            self.lazy().add(other.lazy(), fill_value, on).collect(no_optimization=True)
         )
 
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import os
 import warnings
+from collections.abc import Mapping
 from datetime import date, datetime, time, timedelta
 from io import BytesIO, StringIO
 from pathlib import Path
@@ -4893,6 +4894,164 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             )
             .drop([name + tmp_name for name in right_added_names])
         )
+        if row_count_used:
+            result = result.drop(row_count_name)
+
+        return self._from_pyldf(result._ldf)
+
+    def add(
+        self: LazyFrame,
+        other: LazyFrame,
+        on: str | Sequence[str] | None = None,
+        fill_value: int | float | str | Mapping[str, int | float | str] | None = None,
+    ) -> pl.LazyFrame:
+        """
+        Add aligned dataframes with element-wise and filling missing values.
+
+        Notes
+        -----
+        This is syntactic sugar for an outer join + add
+
+
+        Parameters
+        ----------
+        other
+            DataFrame to be added.
+        on
+            Column names that will be joined on. If none given the row count is used.
+        fill_value:
+            Value used when left or right dataframe does not have corresponding element
+            in opposite frame.
+
+
+        Examples
+        --------
+        >>> df1 = pl.DataFrame(
+        ...     {
+        ...         "key": [1, 2, 3, 4, 5],
+        ...         "a": [1, 2, 3, 4, None],
+        ...         "b": [1, 2, 3, None, 5],
+        ...         "c": ["a", "b", "c", "d", None],
+        ...         "d": ["a", "b", "c", None, "e"],
+        ...     }
+        ... )
+        >>> df1
+        shape: (5, 5)
+        ┌─────┬──────┬──────┬──────┬──────┐
+        │ key ┆ a    ┆ b    ┆ c    ┆ d    │
+        │ --- ┆ ---  ┆ ---  ┆ ---  ┆ ---  │
+        │ i64 ┆ i64  ┆ i64  ┆ str  ┆ str  │
+        ╞═════╪══════╪══════╪══════╪══════╡
+        │ 1   ┆ 1    ┆ 1    ┆ a    ┆ a    │
+        │ 2   ┆ 2    ┆ 2    ┆ b    ┆ b    │
+        │ 3   ┆ 3    ┆ 3    ┆ c    ┆ c    │
+        │ 4   ┆ 4    ┆ null ┆ d    ┆ null │
+        │ 5   ┆ null ┆ 5    ┆ null ┆ e    │
+        └─────┴──────┴──────┴──────┴──────┘
+
+        >>> df2 = pl.DataFrame(
+        ...     {
+        ...         "key": [1, 2, 3, 4, 5],
+        ...         "a": [1, None, 3, 4, 5],
+        ...         "b": [1, 2, None, 4, 5],
+        ...         "c": ["a", None, "c", "d", "e"],
+        ...         "d": ["a", "b", None, "d", "e"],
+        ...     }
+        ... )
+        >>> df2
+        shape: (5, 5)
+        ┌─────┬──────┬──────┬──────┬──────┐
+        │ key ┆ a    ┆ b    ┆ c    ┆ d    │
+        │ --- ┆ ---  ┆ ---  ┆ ---  ┆ ---  │
+        │ i64 ┆ i64  ┆ i64  ┆ str  ┆ str  │
+        ╞═════╪══════╪══════╪══════╪══════╡
+        │ 1   ┆ 1    ┆ 1    ┆ a    ┆ a    │
+        │ 2   ┆ null ┆ 2    ┆ null ┆ b    │
+        │ 3   ┆ 3    ┆ null ┆ c    ┆ null │
+        │ 4   ┆ 4    ┆ 4    ┆ d    ┆ d    │
+        │ 5   ┆ 5    ┆ 5    ┆ e    ┆ e    │
+        └─────┴──────┴──────┴──────┴──────┘
+
+        >>> new_df = df1.add(
+        ...     df2,
+        ...     fill_value={"a": 100, "b": 0, "c": "*FILL_C*", "d": "*FILL_D*"},
+        ...     on="key",
+        ... )
+        >>> new_df
+        shape: (5, 5)
+        ┌─────┬─────┬─────┬───────────┬───────────┐
+        │ key ┆ a   ┆ b   ┆ c         ┆ d         │
+        │ --- ┆ --- ┆ --- ┆ ---       ┆ ---       │
+        │ i64 ┆ i64 ┆ i64 ┆ str       ┆ str       │
+        ╞═════╪═════╪═════╪═══════════╪═══════════╡
+        │ 1   ┆ 2   ┆ 2   ┆ aa        ┆ aa        │
+        │ 2   ┆ 102 ┆ 4   ┆ b*FILL_C* ┆ bb        │
+        │ 3   ┆ 6   ┆ 3   ┆ cc        ┆ c*FILL_D* │
+        │ 4   ┆ 8   ┆ 4   ┆ dd        ┆ *FILL_D*d │
+        │ 5   ┆ 105 ┆ 10  ┆ *FILL_C*e ┆ ee        │
+        └─────┴─────┴─────┴───────────┴───────────┘
+        """
+        row_count_used = False
+        if on is None:
+            row_count_used = True
+            row_count_name = "__POLARS_ROW_COUNT"
+            self = self.with_row_count(row_count_name)
+            other = other.with_row_count(row_count_name)
+            on = row_count_name
+
+        left_names = set(self.columns)
+        right_names = set(other.columns)
+        union_names = left_names & right_names
+        missing_left = left_names - right_names
+        missing_right = right_names - left_names
+
+        if isinstance(on, str):
+            on = [on]
+        remaining_names = union_names - set(on)
+
+        # ensure we have a fill value for each column not in the join key
+        if fill_value is not None:
+            if not isinstance(fill_value, Mapping):
+                # single value, fill all frames directly
+                self = self.with_columns(F.col(remaining_names).fill_null(fill_value))
+                other = other.with_columns(F.col(remaining_names).fill_null(fill_value))
+                fill_value = {name: fill_value for name in remaining_names}
+            else:
+                self = self.with_columns(
+                    F.col(name).fill_null(fill_value[name]) for name in fill_value
+                )
+                other = other.with_columns(
+                    F.col(name).fill_null(fill_value[name]) for name in fill_value
+                )
+
+        # for any columns not found in right or left, add to the other with the
+        # specified fill value
+        if missing_left:
+            other = other.with_columns(
+                F.lit(fill_value[name]).alias(name) for name in missing_left  # type: ignore[index]
+            )
+        if missing_right:
+            self = self.with_columns(
+                F.lit(fill_value[name]).alias(name) for name in missing_right  # type: ignore[index]
+            )
+
+        # make sure our columns are found in both frames
+        for name in on:
+            if name not in left_names:
+                raise ValueError(f"On column {name} not found in left frame.")
+            if name not in right_names:
+                raise ValueError(f"On column {name} not found in right frame.")
+
+        # perform an outer join
+        tmp_name = "__POLARS_RIGHT"
+        result = (
+            self.join(other, on=on, how="outer", suffix=tmp_name)
+            .with_columns(
+                F.col(name) + F.col(f"{name}{tmp_name}") for name in remaining_names
+            )
+            .drop([f"{name}{tmp_name}" for name in remaining_names])
+        )
+
         if row_count_used:
             result = result.drop(row_count_name)
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -532,14 +532,14 @@ def test_add_missing() -> None:
         }
     )
 
-    # test basic addition
     assert_frame_equal(df1 + df2, df1.add(df2))
 
-    # test basic addition with only fill value
-    assert_frame_equal(df1 + df2, df1.add(df2, fill_value=0))
+    df2 = df2.with_columns(pl.Series([1, 2, 3, 4, 5]).alias("e"))
 
     out = df1.add(
-        df2, fill_value={"a": 100, "b": 0, "c": "*FILL_C*", "d": "*FILL_D*"}, on="key"
+        df2,
+        fill_value={"a": 100, "b": 0, "c": "*FILL_C*", "d": "*FILL_D*", "e": 0},
+        on="key",
     )
 
     expected = pl.DataFrame(
@@ -555,6 +555,7 @@ def test_add_missing() -> None:
                 "*FILL_D*d",
                 "ee",
             ],
+            "e": [1, 2, 3, 4, 5],
         }
     )
 


### PR DESCRIPTION
Implements #9804

I've implemented this for `add`. If we want this for the API I'll go ahead and implement this for all other arithmetic functions as well, which will involve a bit more abstraction but this is more or less a demonstration of the functionality.

This addition-with-missing-values paradigm is used most commonly when frames are aggregated in batches and added: if two aggregations don't have all the same groups, you can't add them together directly: this functionality lets you do that easily. In other words, you can do the following:

```python
df1 = df1.groupby(idx).agg(...)
df2 = df2.groupby(idx).agg(...)
df1.add(df2, on=idx)                # doesn't matter if our rows don't perfectly match, this will align
df1.add(df2, fill_value=0, on=idx)  # set None to 0 first instead, so unaligned rows retain their values
```

...without having to worry that all of your resulting groups are the same.

One other option is to call this `add_missing`, since it's sort of similar to the `eq_missing` series of functions and makes it a bit more obvious what the function is meant for.