### PR TITLE
fix(rust, python): dont preserve sortedness in offset_by for tz-aware non-constant durations

### DIFF
--- a/polars/polars-time/src/windows/duration.rs
+++ b/polars/polars-time/src/windows/duration.rs
@@ -338,6 +338,10 @@ impl Duration {
         self.days
     }
 
+    pub fn is_constant_duration(&self) -> bool {
+        self.months == 0 && self.weeks == 0 && self.days == 0
+    }
+
     /// Returns the nanoseconds from the `Duration` without the weeks or months part.
     pub fn nanoseconds(&self) -> i64 {
         self.nsecs

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -139,6 +139,32 @@ def test_local_time_sortedness(time_zone: str | None) -> None:
     assert result.flags["SORTED_DESC"] is False
 
 
+@pytest.mark.parametrize(
+    ("time_zone", "offset", "expected"),
+    [
+        (None, "1d", True),
+        ("Asia/Kathmandu", "1d", False),
+        ("UTC", "1d", True),
+        (None, "1mo", True),
+        ("Asia/Kathmandu", "1mo", False),
+        ("UTC", "1mo", True),
+        (None, "1w", True),
+        ("Asia/Kathmandu", "1w", False),
+        ("UTC", "1w", True),
+        (None, "1h", True),
+        ("Asia/Kathmandu", "1h", True),
+        ("UTC", "1h", True),
+    ],
+)
+def test_offset_by_sortedness(
+    time_zone: str | None, offset: str, expected: bool
+) -> None:
+    ser = (pl.Series([datetime(2022, 1, 1, 23)]).dt.replace_time_zone(time_zone)).sort()
+    result = ser.dt.offset_by(offset)
+    assert result.flags["SORTED_ASC"] == expected
+    assert result.flags["SORTED_DESC"] is False
+
+
 def test_dt_datetime_date_time_invalid() -> None:
     with pytest.raises(ComputeError, match="expected Datetime"):
         pl.Series([date(2021, 1, 2)]).dt.datetime()


### PR DESCRIPTION
Example of the issue:

```python
In [22]: ser = pl.date_range(datetime(2020, 10, 25), datetime(2020, 10, 25, 3), '30m', time_zone='Europe/London', eager=True)

In [23]: ser.dt.offset_by('1d')
Out[23]:
shape: (9,)
Series: 'date' [datetime[μs, Europe/London]]
[
        2020-10-26 00:00:00 GMT
        2020-10-26 00:30:00 GMT
        2020-10-26 01:00:00 GMT
        2020-10-26 01:30:00 GMT
        2020-10-26 01:00:00 GMT
        2020-10-26 01:30:00 GMT
        2020-10-26 02:00:00 GMT
        2020-10-26 02:30:00 GMT
        2020-10-26 03:00:00 GMT
]

In [24]: ser.dt.offset_by('1d').flags  # SORTED_ASC should not be set here
Out[24]: {'SORTED_ASC': True, 'SORTED_DESC': False}
```