### PR TITLE
chore(python, rust): Remove stray `arr.eval` references

### DIFF
--- a/polars/polars-lazy/src/dsl/list.rs
+++ b/polars/polars-lazy/src/dsl/list.rs
@@ -156,14 +156,14 @@ pub trait ListNameSpaceExtension: IntoListNameSpace + Sized {
                         ..
                     } => {
                         polars_bail!(
-                            ComputeError: "casting to categorical not allowed in `arr.eval`"
+                            ComputeError: "casting to categorical not allowed in `list.eval`"
                         )
                     }
                     Expr::Column(name) => {
                         polars_ensure!(
                             name.is_empty(),
                             ComputeError:
-                            "named columns are not allowed in `arr.eval`; consider using `element` or `col(\"\")`"
+                            "named columns are not allowed in `list.eval`; consider using `element` or `col(\"\")`"
                         );
                     }
                     _ => {}

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -240,7 +240,7 @@ def test_cast_inner_categorical() -> None:
     assert out.to_list() == [["a"], ["a", "b"]]
 
     with pytest.raises(
-        pl.ComputeError, match=r"casting to categorical not allowed in `arr.eval`"
+        pl.ComputeError, match=r"casting to categorical not allowed in `list.eval`"
     ):
         pl.Series("foo", [["a", "b"], ["a", "b"]]).list.eval(
             pl.element().cast(pl.Categorical)


### PR DESCRIPTION
Just something that popped up during some work I was doing. Let me know if my tags are wrong - wasn't sure where to put them.