### PR TITLE
test(python): Fix OOC tests

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Run tests and report coverage
         if: github.ref_name != 'main'
-        run: pytest --cov -n auto --dist worksteal -m "not benchmark"
+        run: pytest --cov -n auto --dist loadgroup -m "not benchmark"
 
       - name: Run doctests
         if: github.ref_name != 'main'
@@ -125,7 +125,7 @@ jobs:
 
       - name: Run tests
         if: github.ref_name != 'main'
-        run: pytest -n auto --dist worksteal -m "not benchmark"
+        run: pytest -n auto --dist loadgroup -m "not benchmark"
 
       - name: Check import without optional dependencies
         if: github.ref_name != 'main'

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -49,7 +49,7 @@ pre-commit: fmt clippy  ## Run all code quality checks
 
 .PHONY: test
 test: .venv build  ## Run fast unittests
-	$(VENV_BIN)/pytest -n auto --dist worksteal
+	$(VENV_BIN)/pytest -n auto --dist loadgroup
 
 .PHONY: doctest
 doctest: .venv build  ## Run doctests
@@ -57,12 +57,12 @@ doctest: .venv build  ## Run doctests
 
 .PHONY: test-all
 test-all: .venv build  ## Run all tests
-	$(VENV_BIN)/pytest -n auto --dist worksteal -m "slow or not slow"
+	$(VENV_BIN)/pytest -n auto --dist loadgroup -m "slow or not slow"
 	$(VENV_BIN)/python tests/docs/run_doctest.py
 
 .PHONY: coverage
 coverage: .venv build  ## Run tests and report coverage
-	$(VENV_BIN)/pytest --cov -n auto --dist worksteal -m "not benchmark"
+	$(VENV_BIN)/pytest --cov -n auto --dist loadgroup -m "not benchmark"
 
 .PHONY: clean
 clean:  ## Clean up caches and build artifacts

--- a/py-polars/tests/benchmark/test_release.py
+++ b/py-polars/tests/benchmark/test_release.py
@@ -17,7 +17,7 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 # Mark all tests in this module as benchmark tests
-pytestmark = pytest.mark.benchmark
+pytestmark = pytest.mark.benchmark()
 
 
 @pytest.mark.skipif(

--- a/py-polars/tests/unit/conftest.py
+++ b/py-polars/tests/unit/conftest.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import random
+import string
 from typing import List, cast
 
+import numpy as np
 import pytest
 
 import polars as pl
@@ -56,6 +59,25 @@ def fruits_cars() -> pl.DataFrame:
         },
         schema_overrides={"A": pl.Int64, "B": pl.Int64},
     )
+
+
+@pytest.fixture()
+def str_ints_df() -> pl.DataFrame:
+    n = 1000
+
+    strs = pl.Series("strs", random.choices(string.ascii_lowercase, k=n))
+    strs = pl.select(
+        pl.when(strs == "a")
+        .then("")
+        .when(strs == "b")
+        .then(None)
+        .otherwise(strs)
+        .alias("strs")
+    ).to_series()
+
+    vals = pl.Series("vals", np.random.rand(n))
+
+    return pl.DataFrame([vals, strs])
 
 
 ISO8601_FORMATS_DATETIME = []

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1,11 +1,7 @@
 from __future__ import annotations
 
-import random
-import string
 from datetime import date, datetime
-from typing import Any
 
-import numpy as np
 import pytest
 
 import polars as pl
@@ -509,28 +505,11 @@ def test_sort_type_coercion_6892() -> None:
     }
 
 
-def get_str_ints_df(n: int) -> pl.DataFrame:
-    strs = pl.Series("strs", random.choices(string.ascii_lowercase, k=n))
-    strs = pl.select(
-        pl.when(strs == "a")
-        .then("")
-        .when(strs == "b")
-        .then(None)
-        .otherwise(strs)
-        .alias("strs")
-    ).to_series()
-
-    vals = pl.Series("vals", np.random.rand(n))
-
-    return pl.DataFrame([vals, strs])
-
-
 @pytest.mark.slow()
-def test_sort_row_fmt() -> None:
+def test_sort_row_fmt(str_ints_df: pl.DataFrame) -> None:
     # we sort nulls_last as this will always dispatch
     # to row_fmt and is the default in pandas
-
-    df = get_str_ints_df(1000)
+    df = str_ints_df
     df_pd = df.to_pandas()
 
     for descending in [True, False]:
@@ -540,21 +519,6 @@ def test_sort_row_fmt() -> None:
                 df_pd.sort_values(["strs", "vals"], ascending=not descending)
             ),
         )
-
-
-@pytest.mark.slow()
-def test_streaming_sort_multiple_columns(monkeypatch: Any, capfd: Any) -> None:
-    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
-    monkeypatch.setenv("POLARS_VERBOSE", "1")
-    df = get_str_ints_df(1000)
-
-    out = df.lazy().sort(["strs", "vals"]).collect(streaming=True)
-    assert_frame_equal(out, out.sort(["strs", "vals"]))
-    err = capfd.readouterr().err
-    assert "OOC sort forced" in err
-    assert "RUN STREAMING PIPELINE" in err
-    assert "df -> sort_multiple" in err
-    assert out.columns == ["vals", "strs"]
 
 
 def test_sort_by_logical() -> None:

--- a/py-polars/tests/unit/streaming/test_ooc.py
+++ b/py-polars/tests/unit/streaming/test_ooc.py
@@ -1,9 +1,184 @@
 from pathlib import Path
 from typing import Any
 
+import numpy as np
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal, assert_series_equal
+
+pytestmark = [
+    # OOC tests always write to disk
+    pytest.mark.write_disk(),
+    # OOC tests must run on the same worker due to garbage collection
+    pytest.mark.xdist_group("ooc"),
+]
+
+
+def test_streaming_sort(monkeypatch: Any, capfd: Any) -> None:
+    monkeypatch.setenv("POLARS_VERBOSE", "1")
+    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
+
+    # this creates a lot of duplicate partitions and triggers: #7568
+    assert (
+        pl.Series(np.random.randint(0, 100, 100))
+        .to_frame("s")
+        .lazy()
+        .sort("s")
+        .collect(streaming=True)["s"]
+        .is_sorted()
+    )
+    (_, err) = capfd.readouterr()
+    assert "df -> sort" in err
+
+
+@pytest.fixture(scope="module")
+def random_integers() -> pl.Series:
+    np.random.seed(1)
+    return pl.Series("a", np.random.randint(0, 10, 100), dtype=pl.Int64)
+
+
+def test_streaming_groupby_ooc_q1(monkeypatch: Any, random_integers: pl.Series) -> None:
+    s = random_integers
+    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
+
+    result = (
+        s.to_frame()
+        .lazy()
+        .groupby("a")
+        .agg(pl.first("a").alias("a_first"), pl.last("a").alias("a_last"))
+        .sort("a")
+        .collect(streaming=True)
+    )
+
+    expected = pl.DataFrame(
+        {
+            "a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "a_first": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "a_last": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_streaming_groupby_ooc_q2(monkeypatch: Any, random_integers: pl.Series) -> None:
+    s = random_integers
+    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
+
+    result = (
+        s.cast(str)
+        .to_frame()
+        .lazy()
+        .groupby("a")
+        .agg(pl.first("a").alias("a_first"), pl.last("a").alias("a_last"))
+        .sort("a")
+        .collect(streaming=True)
+    )
+
+    expected = pl.DataFrame(
+        {
+            "a": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            "a_first": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+            "a_last": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_streaming_groupby_ooc_q3(monkeypatch: Any, random_integers: pl.Series) -> None:
+    s = random_integers
+    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
+
+    result = (
+        pl.DataFrame({"a": s, "b": s})
+        .lazy()
+        .groupby(["a", "b"])
+        .agg(pl.first("a").alias("a_first"), pl.last("a").alias("a_last"))
+        .sort("a")
+        .collect(streaming=True)
+    )
+
+    expected = pl.DataFrame(
+        {
+            "a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "b": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "a_first": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            "a_last": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_out_of_core_sort_9503(monkeypatch: Any) -> None:
+    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
+    np.random.seed(0)
+
+    num_rows = 1_00_000
+    num_columns = 2
+    num_tables = 10
+
+    # ensure we create many chunks
+    # this will ensure we create more files
+    # and that creates contention while dumping
+    q = pl.concat(
+        [
+            pl.DataFrame(
+                [
+                    pl.Series(np.random.randint(0, 10000, size=num_rows))
+                    for _ in range(num_columns)
+                ]
+            )
+            for _ in range(num_tables)
+        ],
+        rechunk=False,
+    ).lazy()
+    q = q.sort(q.columns)
+    df = q.collect(streaming=True)
+    assert df.shape == (1_000_000, 2)
+    assert df["column_0"].flags["SORTED_ASC"]
+    assert df.head(20).to_dict(False) == {
+        "column_0": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        "column_1": [
+            242,
+            245,
+            588,
+            618,
+            732,
+            902,
+            925,
+            945,
+            1009,
+            1161,
+            1352,
+            1365,
+            1451,
+            1581,
+            1778,
+            1836,
+            1976,
+            2091,
+            2120,
+            2124,
+        ],
+    }
+
+
+@pytest.mark.slow()
+def test_streaming_sort_multiple_columns(
+    monkeypatch: Any, capfd: Any, str_ints_df: pl.DataFrame
+) -> None:
+    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
+    monkeypatch.setenv("POLARS_VERBOSE", "1")
+
+    df = str_ints_df
+
+    out = df.lazy().sort(["strs", "vals"]).collect(streaming=True)
+    assert_frame_equal(out, out.sort(["strs", "vals"]))
+    err = capfd.readouterr().err
+    assert "OOC sort forced" in err
+    assert "RUN STREAMING PIPELINE" in err
+    assert "df -> sort_multiple" in err
+    assert out.columns == ["vals", "strs"]
 
 
 @pytest.mark.slow()
@@ -13,6 +188,7 @@ def test_streaming_out_of_core_unique(
     monkeypatch.setenv("POLARS_FORCE_OOC", "1")
     monkeypatch.setenv("POLARS_VERBOSE", "1")
     monkeypatch.setenv("POLARS_STREAMING_GROUPBY_SPILL_SIZE", "256")
+
     df = pl.read_csv(io_files_path / "foods*.csv")
     # this creates 10M rows
     q = df.lazy()
@@ -25,3 +201,19 @@ def test_streaming_out_of_core_unique(
     assert df1.shape == df2.shape
     err = capfd.readouterr().err
     assert "OOC groupby started" in err
+
+
+@pytest.mark.slow()
+def test_ooc_sort(monkeypatch: Any) -> None:
+    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
+
+    s = pl.arange(0, 100_000, eager=True).rename("idx")
+
+    df = s.shuffle().to_frame()
+
+    for descending in [True, False]:
+        out = (
+            df.lazy().sort("idx", descending=descending).collect(streaming=True)
+        ).to_series()
+
+        assert_series_equal(out, s.sort(descending=descending))

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -240,22 +240,6 @@ def test_cross_join_stack() -> None:
     assert (t1 - t0) < 0.5
 
 
-@pytest.mark.slow()
-def test_ooc_sort(monkeypatch: Any) -> None:
-    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
-
-    s = pl.arange(0, 100_000, eager=True).rename("idx")
-
-    df = s.shuffle().to_frame()
-
-    for descending in [True, False]:
-        out = (
-            df.lazy().sort("idx", descending=descending).collect(streaming=True)
-        ).to_series()
-
-        assert_series_equal(out, s.sort(descending=descending))
-
-
 def test_streaming_literal_expansion() -> None:
     df = pl.DataFrame(
         {
@@ -362,103 +346,6 @@ def test_streaming_unique(monkeypatch: Any, capfd: Any) -> None:
     assert_frame_equal(q.collect(streaming=True), q.collect(streaming=False))
     (_, err) = capfd.readouterr()
     assert "df -> re-project-sink -> sort_multiple" in err
-
-
-@pytest.mark.write_disk()
-def test_streaming_sort(monkeypatch: Any, capfd: Any) -> None:
-    monkeypatch.setenv("POLARS_VERBOSE", "1")
-    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
-    # this creates a lot of duplicate partitions and triggers: #7568
-    assert (
-        pl.Series(np.random.randint(0, 100, 100))
-        .to_frame("s")
-        .lazy()
-        .sort("s")
-        .collect(streaming=True)["s"]
-        .is_sorted()
-    )
-    (_, err) = capfd.readouterr()
-    assert "df -> sort" in err
-
-
-@pytest.fixture(scope="module")
-def random_integers() -> pl.Series:
-    np.random.seed(1)
-    return pl.Series("a", np.random.randint(0, 10, 100), dtype=pl.Int64)
-
-
-@pytest.mark.write_disk()
-def test_streaming_groupby_ooc_q1(monkeypatch: Any, random_integers: pl.Series) -> None:
-    s = random_integers
-    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
-
-    result = (
-        s.to_frame()
-        .lazy()
-        .groupby("a")
-        .agg(pl.first("a").alias("a_first"), pl.last("a").alias("a_last"))
-        .sort("a")
-        .collect(streaming=True)
-    )
-
-    expected = pl.DataFrame(
-        {
-            "a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            "a_first": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            "a_last": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-        }
-    )
-    assert_frame_equal(result, expected)
-
-
-@pytest.mark.write_disk()
-def test_streaming_groupby_ooc_q2(monkeypatch: Any, random_integers: pl.Series) -> None:
-    s = random_integers
-    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
-
-    result = (
-        s.cast(str)
-        .to_frame()
-        .lazy()
-        .groupby("a")
-        .agg(pl.first("a").alias("a_first"), pl.last("a").alias("a_last"))
-        .sort("a")
-        .collect(streaming=True)
-    )
-
-    expected = pl.DataFrame(
-        {
-            "a": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
-            "a_first": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
-            "a_last": ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"],
-        }
-    )
-    assert_frame_equal(result, expected)
-
-
-@pytest.mark.write_disk()
-def test_streaming_groupby_ooc_q3(monkeypatch: Any, random_integers: pl.Series) -> None:
-    s = random_integers
-    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
-
-    result = (
-        pl.DataFrame({"a": s, "b": s})
-        .lazy()
-        .groupby(["a", "b"])
-        .agg(pl.first("a").alias("a_first"), pl.last("a").alias("a_last"))
-        .sort("a")
-        .collect(streaming=True)
-    )
-
-    expected = pl.DataFrame(
-        {
-            "a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            "b": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            "a_first": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-            "a_last": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-        }
-    )
-    assert_frame_equal(result, expected)
 
 
 def test_streaming_groupby_struct_key() -> None:
@@ -574,61 +461,6 @@ def test_streaming_sortedness_propagation_9494() -> None:
         .agg(pl.col("what").sum())
         .collect(streaming=True)
     ).to_dict(False) == {"when": [date(2023, 5, 1), date(2023, 6, 1)], "what": [3, 3]}
-
-
-@pytest.mark.write_disk()
-def test_out_of_core_sort_9503(monkeypatch: Any) -> None:
-    monkeypatch.setenv("POLARS_FORCE_OOC", "1")
-    np.random.seed(0)
-
-    num_rows = 1_00_000
-    num_columns = 2
-    num_tables = 10
-
-    # ensure we create many chunks
-    # this will ensure we create more files
-    # and that creates contention while dumping
-    q = pl.concat(
-        [
-            pl.DataFrame(
-                [
-                    pl.Series(np.random.randint(0, 10000, size=num_rows))
-                    for _ in range(num_columns)
-                ]
-            )
-            for _ in range(num_tables)
-        ],
-        rechunk=False,
-    ).lazy()
-    q = q.sort(q.columns)
-    df = q.collect(streaming=True)
-    assert df.shape == (1_000_000, 2)
-    assert df["column_0"].flags["SORTED_ASC"]
-    assert df.head(20).to_dict(False) == {
-        "column_0": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        "column_1": [
-            242,
-            245,
-            588,
-            618,
-            732,
-            902,
-            925,
-            945,
-            1009,
-            1161,
-            1352,
-            1365,
-            1451,
-            1581,
-            1778,
-            1836,
-            1976,
-            2091,
-            2120,
-            2124,
-        ],
-    }
 
 
 @pytest.mark.write_disk()


### PR DESCRIPTION
Closes #9122 

Changes:
* Move all OOC tests to the same module.
* Make sure all OOC tests are run on the same worker.

NOTE: This causes some tests to fail. There might be some underlying issue in the streaming garbage collection. See discussion in #9823