### PR TITLE
feat(python): Add pyarrow write_to_dataset to write_parquet function

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3066,6 +3066,8 @@ class DataFrame:
             Use ``pyarrow.parquet.write_to_dataset`` instead of pyarrow.write_table.
             Enable features like writing partitioned datasets.
             Use pyarrow_options to pass arguments to ``parquet.write_to_dataset``.
+            This function will always write the dataset to a directory.
+            Similar to Spark's partitioned datasets.
         pyarrow_options
             Arguments passed to ``pyarrow.parquet.write_table``.
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3088,8 +3088,9 @@ class DataFrame:
         other rows to ../watermark=2/*.parquet.
 
         >>> df = pl.DataFrame({"a": [1, 2, 3], "watermark": [1, 2, 2]})
+        >>> path: pathlib.Path = dirpath / "partitioned_object"
         >>> df.write_parquet(
-        ...     tmpdir / "test.parquet",
+        ...     path,
         ...     use_pyarrow=True,
         ...     use_pyarrow_write_to_dataset=True,
         ...     pyarrow_options={"partition_cols": ["watermark"]},

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3065,6 +3065,7 @@ class DataFrame:
         use_pyarrow_write_to_dataset
             Use ``pyarrow.parquet.write_to_dataset`` instead of pyarrow.write_table.
             Enable features like writing partitioned datasets.
+            Use pyarrow_options to pass arguments to ``parquet.write_to_dataset``.
         pyarrow_options
             Arguments passed to ``pyarrow.parquet.write_table``.
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3070,7 +3070,6 @@ class DataFrame:
 
         Examples
         --------
-
         >>> import pathlib
         >>>
         >>> df = pl.DataFrame(
@@ -3083,16 +3082,17 @@ class DataFrame:
         >>> path: pathlib.Path = dirpath / "new_file.parquet"
         >>> df.write_parquet(path)
 
-        We can use pyarrow with use_pyarrow_write_to_dataset=True to write partitioned datasets.
-        The following example will write the first row to ../watermark=1/*.parquet and the
+        We can use pyarrow with use_pyarrow_write_to_dataset=True
+        to write partitioned datasets. The following example will
+        write the first row to ../watermark=1/*.parquet and the
         other rows to ../watermark=2/*.parquet.
 
         >>> df = pl.DataFrame({"a": [1, 2, 3], "watermark": [1, 2, 2]})
         >>> df.write_parquet(
-        ...    tmpdir / "test.parquet",
-        ...    use_pyarrow=True,
-        ...    use_pyarrow_write_to_dataset=True,
-        ...    pyarrow_options={"partition_cols": ["watermark"]},
+        ...     tmpdir / "test.parquet",
+        ...     use_pyarrow=True,
+        ...     use_pyarrow_write_to_dataset=True,
+        ...     pyarrow_options={"partition_cols": ["watermark"]},
         ... )
 
         """

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3122,6 +3122,15 @@ class DataFrame:
             import pyarrow.parquet  # noqa: F401
 
             if use_pyarrow_write_to_dataset:
+                if pyarrow_options is None:
+                    pyarrow_options = {}
+                pyarrow_options["compression"] = (
+                    None if compression == "uncompressed" else compression
+                )
+                pyarrow_options["compression_level"] = compression_level
+                pyarrow_options["write_statistics"] = statistics
+                pyarrow_options["row_group_size"] = row_group_size
+
                 pa.parquet.write_to_dataset(
                     table=tbl,
                     root_path=file,

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -46,21 +46,23 @@ def test_write_parquet_using_pyarrow_9753(tmpdir: Path) -> None:
     )
 
 
-def test_write_parquet_using_pyarrow_write_to_dataset(tmpdir: Path) -> None:
+def test_write_parquet_using_pyarrow_write_to_dataset(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
     df = pl.DataFrame({"a": [1, 2, 3]})
     df.write_parquet(
-        tmpdir / "test.parquet",
+        tmp_path / "test.parquet",
         use_pyarrow=True,
         use_pyarrow_write_to_dataset=True,
     )
 
 
 def test_write_parquet_using_pyarrow_write_to_dataset_with_partitioning(
-    tmpdir: Path,
+    tmp_path: Path,
 ) -> None:
+    tmp_path.mkdir(exist_ok=True)
     df = pl.DataFrame({"a": [1, 2, 3], "watermark": [1, 2, 2]})
     df.write_parquet(
-        tmpdir / "test.parquet",
+        tmp_path / "test.parquet",
         use_pyarrow=True,
         use_pyarrow_write_to_dataset=True,
         pyarrow_options={"partition_cols": ["watermark"]},

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -56,16 +56,20 @@ def test_write_parquet_using_pyarrow_write_to_dataset(tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.parametrize("compression", COMPRESSIONS)
 def test_write_parquet_using_pyarrow_write_to_dataset_with_partitioning(
     tmp_path: Path,
+    compression: ParquetCompression,
 ) -> None:
     tmp_path.mkdir(exist_ok=True)
     df = pl.DataFrame({"a": [1, 2, 3], "watermark": [1, 2, 2]})
     df.write_parquet(
         tmp_path / "test.parquet",
+        statistics=True,
         use_pyarrow=True,
+        row_group_size=128,
         use_pyarrow_write_to_dataset=True,
-        pyarrow_options={"partition_cols": ["watermark"]},
+        pyarrow_options={"partition_cols": ["watermark"], "compression": compression},
     )
 
 

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -46,16 +46,6 @@ def test_write_parquet_using_pyarrow_9753(tmpdir: Path) -> None:
     )
 
 
-def test_write_parquet_using_pyarrow_write_to_dataset(tmp_path: Path) -> None:
-    tmp_path.mkdir(exist_ok=True)
-    df = pl.DataFrame({"a": [1, 2, 3]})
-    df.write_parquet(
-        tmp_path / "test.parquet",
-        use_pyarrow=True,
-        use_pyarrow_write_to_dataset=True,
-    )
-
-
 @pytest.mark.parametrize("compression", COMPRESSIONS)
 def test_write_parquet_using_pyarrow_write_to_dataset_with_partitioning(
     tmp_path: Path,
@@ -68,7 +58,6 @@ def test_write_parquet_using_pyarrow_write_to_dataset_with_partitioning(
         statistics=True,
         use_pyarrow=True,
         row_group_size=128,
-        use_pyarrow_write_to_dataset=True,
         pyarrow_options={"partition_cols": ["watermark"], "compression": compression},
     )
 

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -46,6 +46,27 @@ def test_write_parquet_using_pyarrow_9753(tmpdir: Path) -> None:
     )
 
 
+def test_write_parquet_using_pyarrow_write_to_dataset(tmpdir: Path) -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    df.write_parquet(
+        tmpdir / "test.parquet",
+        use_pyarrow=True,
+        use_pyarrow_write_to_dataset=True,
+    )
+
+
+def test_write_parquet_using_pyarrow_write_to_dataset_with_partitioning(
+    tmpdir: Path,
+) -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "watermark": [1, 2, 2]})
+    df.write_parquet(
+        tmpdir / "test.parquet",
+        use_pyarrow=True,
+        use_pyarrow_write_to_dataset=True,
+        pyarrow_options={"partition_cols": ["watermark"]},
+    )
+
+
 @pytest.fixture()
 def small_parquet_path(io_files_path: Path) -> Path:
     return io_files_path / "small.parquet"


### PR DESCRIPTION
Implements [#9812](https://github.com/pola-rs/polars/issues/9812)

Currently Polars uses _pyarrow.write_table()_ to write parquets with pyarrow. The _pyarrow.write_to_dataset()_ funtion is not used. 
_pyarrow.write_to_dataset()_ does support more features than _write_table()_. Important features like writing partitioned parquet files.
Therefore, I added _pyarrow.write_to_dataset()_ using a new parameter in write_parquet(), namely "use_pyarrow_write_to_dataset".

I added two tests and an example in the docstring.
Currently some parameters like statistics or compressions are not used when calling _write_to_dataset()_ as these are not supported in _write_to_dataset()_.

Links:

- https://arrow.apache.org/docs/python/generated/pyarrow.parquet.write_to_dataset.html