### PR TITLE
feat(rust,python,cli): add `LEFT` string function for SQL

### DIFF
--- a/polars/polars-sql/src/functions.rs
+++ b/polars/polars-sql/src/functions.rs
@@ -155,6 +155,11 @@ pub(crate) enum PolarsSqlFunctions {
     /// SELECT column_2 from df WHERE ENDS_WITH(column_1, 'a');
     /// ```
     EndsWith,
+    /// SQL 'left' function
+    /// ```sql
+    /// SELECT LEFT(column_1, 3) from df;
+    /// ```
+    Left,
     /// SQL 'lower' function
     /// ```sql
     /// SELECT LOWER(column_1) from df;
@@ -178,7 +183,7 @@ pub(crate) enum PolarsSqlFunctions {
     StartsWith,
     /// SQL 'substr' function
     /// ```sql
-    /// SELECT SUBSTR(column_1) from df;
+    /// SELECT SUBSTR(column_1, 3, 5) from df;
     /// ```
     Substring,
     /// SQL 'upper' function
@@ -417,6 +422,7 @@ impl TryFrom<&'_ SQLFunction> for PolarsSqlFunctions {
             // String functions
             // ----
             "ends_with" => Self::EndsWith,
+            "left" => Self::Left,
             "lower" => Self::Lower,
             "ltrim" => Self::LTrim,
             "rtrim" => Self::RTrim,
@@ -511,6 +517,14 @@ impl SqlFunctionVisitor<'_> {
             // String functions
             // ----
             EndsWith => self.visit_binary(|e, s| e.str().ends_with(s)),
+            Left => self.try_visit_binary(|e, length| {
+                Ok(e.str().str_slice(0, match length {
+                    Expr::Literal(LiteralValue::Int64(n)) => Some(n as u64),
+                    _ => {
+                        polars_bail!(InvalidOperation: "Invalid 'length' for Left: {}", function.args[1]);
+                    }
+                }))
+            }),
             Lower => self.visit_unary(|e| e.str().to_lowercase()),
             LTrim => match function.args.len() {
                 1 => self.visit_unary(|e| e.str().lstrip(None)),

--- a/py-polars/tests/unit/test_sql.py
+++ b/py-polars/tests/unit/test_sql.py
@@ -436,6 +436,26 @@ def test_sql_groupby(foods_ipc_path: Path) -> None:
     assert out.to_dict(False) == {"grp": ["c"], "n_dist_attr": [2]}
 
 
+def test_sql_left() -> None:
+    df = pl.DataFrame({"scol": ["abcde", "abc", "a", None]})
+    ctx = pl.SQLContext(df=df)
+    res = ctx.execute(
+        'SELECT scol, LEFT(scol,2) AS "scol:left2" FROM df',
+    ).collect()
+
+    assert res.to_dict(False) == {
+        "scol": ["abcde", "abc", "a", None],
+        "scol:left2": ["ab", "ab", "a", None],
+    }
+    with pytest.raises(
+        pl.InvalidOperationError,
+        match="Invalid 'length' for Left: 'xyz'",
+    ):
+        ctx.execute(
+            """SELECT scol, LEFT(scol,'xyz') AS "scol:left2" FROM df"""
+        ).collect()
+
+
 def test_sql_limit_offset() -> None:
     n_values = 11
     lf = pl.LazyFrame({"a": range(n_values), "b": reversed(range(n_values))})


### PR DESCRIPTION
Adds SQL support for the string `left` function, and associated unit tests.

## Example

```python
import polars as pl
df = pl.DataFrame({
    "scol": ["abcde", "abc", "a", None],
})
with pl.SQLContext( frame=df ) as ctx:
    res = ctx.execute(
        'SELECT scol, LEFT(scol,2) AS "scol:left2" FROM frame',
    ).collect()
    
# shape: (4, 2)
# ┌───────┬────────────┐
# │ scol  ┆ scol:left2 │
# │ ---   ┆ ---        │
# │ str   ┆ str        │
# ╞═══════╪════════════╡
# │ abcde ┆ ab         │
# │ abc   ┆ ab         │
# │ a     ┆ a          │
# │ null  ┆ null       │
# └───────┴────────────┘
```