### PR TITLE
perf(python): speed up python object to AnyValue construction

### DIFF
--- a/polars/polars-core/src/frame/row/mod.rs
+++ b/polars/polars-core/src/frame/row/mod.rs
@@ -93,14 +93,15 @@ fn is_nested_null(av: &AnyValue) -> bool {
     }
 }
 
-pub fn any_values_to_dtype(column: &[AnyValue]) -> PolarsResult<DataType> {
+pub fn any_values_to_dtype(column: &[AnyValue]) -> PolarsResult<(DataType, usize)> {
     // we need an index-map as the order of dtypes influences how the
     // struct fields are constructed.
     let mut types_set = PlIndexSet::new();
     for val in column.iter() {
         types_set.insert(val.into());
     }
-    types_set_to_dtype(types_set)
+    let n_types = types_set.len();
+    Ok((types_set_to_dtype(types_set)?, n_types))
 }
 
 fn types_set_to_dtype(types_set: PlIndexSet<DataType>) -> PolarsResult<DataType> {

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -20,7 +20,9 @@ use pyo3::basic::CompareOp;
 use pyo3::conversion::{FromPyObject, IntoPy};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyBool, PyBytes, PyDict, PyFloat, PyList, PySequence, PyString, PyTuple};
+use pyo3::types::{
+    PyBool, PyBytes, PyDict, PyFloat, PyList, PySequence, PyString, PyTuple, PyType,
+};
 use pyo3::{PyAny, PyResult};
 use smartstring::alias::String as SmartString;
 
@@ -605,23 +607,6 @@ fn abs_decimal_from_digits(
     (v <= MAX_ABS_DEC).then_some((v, scale))
 }
 
-fn materialize_list(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
-    if ob.is_empty()? {
-        Ok(Wrap(AnyValue::List(Series::new_empty("", &DataType::Null))))
-    } else {
-        let avs = ob.extract::<Wrap<Row>>()?.0 .0;
-        // use first `n` values to infer datatype
-        // this value is not too large as this will be done with every
-        // anyvalue that has to be converted, which can be many
-        let n = 25;
-        let dtype =
-            any_values_to_dtype(&avs[..std::cmp::min(avs.len(), n)]).map_err(PyPolarsErr::from)?;
-        let s =
-            Series::from_any_values_and_dtype("", &avs, &dtype, true).map_err(PyPolarsErr::from)?;
-        Ok(Wrap(AnyValue::List(s)))
-    }
-}
-
 fn convert_date(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
     Python::with_gil(|py| {
         let date = UTILS
@@ -662,21 +647,36 @@ fn convert_datetime(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
     })
 }
 
+type TypeObjectPtr = usize;
+type InitFn = fn(&PyAny) -> PyResult<Wrap<AnyValue<'_>>>;
+pub(crate) static LUT: crate::gil_once_cell::GILOnceCell<PlHashMap<TypeObjectPtr, InitFn>> =
+    crate::gil_once_cell::GILOnceCell::new();
+
 impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
     fn extract(ob: &'s PyAny) -> PyResult<Self> {
-        if ob.is_instance_of::<PyBool>() {
+        // conversion functions
+        fn get_bool(ob: &PyAny) -> PyResult<Wrap<AnyValue<'_>>> {
             Ok(AnyValue::Boolean(ob.extract::<bool>().unwrap()).into())
-        } else if let Ok(value) = ob.extract::<i64>() {
-            Ok(AnyValue::Int64(value).into())
-        } else if ob.is_instance_of::<PyFloat>() {
-            let value = ob.extract::<f64>().unwrap();
-            Ok(AnyValue::Float64(value).into())
-        } else if ob.is_instance_of::<PyString>() {
-            let value = ob.extract::<&'s str>().unwrap();
+        }
+
+        fn get_int(ob: &PyAny) -> PyResult<Wrap<AnyValue<'_>>> {
+            // can overflow
+            match ob.extract::<i64>() {
+                Ok(v) => Ok(AnyValue::Int64(v).into()),
+                Err(_) => Ok(AnyValue::UInt64(ob.extract::<u64>()?).into()),
+            }
+        }
+
+        fn get_float(ob: &PyAny) -> PyResult<Wrap<AnyValue<'_>>> {
+            Ok(AnyValue::Float64(ob.extract::<f64>().unwrap()).into())
+        }
+
+        fn get_str(ob: &PyAny) -> PyResult<Wrap<AnyValue<'_>>> {
+            let value = ob.extract::<&str>().unwrap();
             Ok(AnyValue::Utf8(value).into())
-        } else if ob.is_none() {
-            Ok(AnyValue::Null.into())
-        } else if ob.is_instance_of::<PyDict>() {
+        }
+
+        fn get_struct(ob: &PyAny) -> PyResult<Wrap<AnyValue<'_>>> {
             let dict = ob.downcast::<PyDict>().unwrap();
             let len = dict.len();
             let mut keys = Vec::with_capacity(len);
@@ -689,86 +689,162 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                 vals.push(val)
             }
             Ok(Wrap(AnyValue::StructOwned(Box::new((vals, keys)))))
-        } else if ob.is_instance_of::<PyList>() || ob.is_instance_of::<PyTuple>() {
-            materialize_list(ob)
-        } else if let Ok(value) = ob.extract::<u64>() {
-            Ok(AnyValue::UInt64(value).into())
-        } else if ob.hasattr("_s")? {
+        }
+
+        fn get_list(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
+            if ob.is_empty()? {
+                Ok(Wrap(AnyValue::List(Series::new_empty("", &DataType::Null))))
+            } else {
+                let avs = ob.extract::<Wrap<Row>>()?.0 .0;
+                // use first `n` values to infer datatype
+                // this value is not too large as this will be done with every
+                // anyvalue that has to be converted, which can be many
+                let n = 25;
+                let dtype = any_values_to_dtype(&avs[..std::cmp::min(avs.len(), n)])
+                    .map_err(PyPolarsErr::from)?;
+                let s = Series::from_any_values_and_dtype("", &avs, &dtype, true)
+                    .map_err(PyPolarsErr::from)?;
+                Ok(Wrap(AnyValue::List(s)))
+            }
+        }
+
+        fn get_series_el(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
             let py_pyseries = ob.getattr("_s").unwrap();
             let series = py_pyseries.extract::<PySeries>().unwrap().series;
             Ok(Wrap(AnyValue::List(series)))
-        } else if let Ok(v) = ob.extract::<&'s [u8]>() {
-            Ok(AnyValue::Binary(v).into())
-        } else {
-            let type_name = ob.get_type().name()?;
-            match type_name {
-                "datetime" => convert_datetime(ob),
-                "date" => convert_date(ob),
-                "timedelta" => Python::with_gil(|py| {
-                    let td = UTILS
-                        .as_ref(py)
-                        .getattr("_timedelta_to_pl_timedelta")
-                        .unwrap()
-                        .call1((ob, "us"))
-                        .unwrap();
-                    let v = td.extract::<i64>().unwrap();
-                    Ok(Wrap(AnyValue::Duration(v, TimeUnit::Microseconds)))
-                }),
-                "time" => Python::with_gil(|py| {
-                    let time = UTILS
-                        .as_ref(py)
-                        .getattr("_time_to_pl_time")
-                        .unwrap()
-                        .call1((ob,))
-                        .unwrap();
-                    let v = time.extract::<i64>().unwrap();
-                    Ok(Wrap(AnyValue::Time(v)))
-                }),
-                "Decimal" => {
-                    let (sign, digits, exp): (i8, Vec<u8>, i32) =
-                        ob.call_method0("as_tuple").unwrap().extract().unwrap();
-                    // note: using Vec<u8> is not the most efficient thing here (input is a tuple)
-                    let (mut v, scale) = abs_decimal_from_digits(digits, exp).ok_or_else(|| {
-                        PyErr::from(PyPolarsErr::Other(
-                            "Decimal is too large to fit in Decimal128".into(),
-                        ))
-                    })?;
-                    if sign > 0 {
-                        v = -v; // won't overflow since -i128::MAX > i128::MIN
-                    }
-                    Ok(Wrap(AnyValue::Decimal(v, scale)))
-                }
-                "range" => materialize_list(ob),
-                _ => {
-                    // special branch for np.float as this fails isinstance float
-                    if let Ok(value) = ob.extract::<f64>() {
-                        return Ok(AnyValue::Float64(value).into());
-                    }
-
-                    // Can't use pyo3::types::PyDateTime with abi3-py37 feature,
-                    // so need this workaround instead of `isinstance(ob, datetime)`.
-                    let bases = ob.get_type().getattr("__bases__")?.iter()?;
-                    for base in bases {
-                        let parent_type = base.unwrap().str().unwrap().to_str().unwrap();
-                        match parent_type {
-                            "<class 'datetime.datetime'>" => {
-                                // `datetime.datetime` is a subclass of `datetime.date`,
-                                // so need to check `datetime.datetime` first
-                                return convert_datetime(ob);
-                            }
-                            "<class 'datetime.date'>" => {
-                                return convert_date(ob);
-                            }
-                            _ => (),
-                        }
-                    }
-
-                    // this is slow, but hey don't use objects
-                    let v = &ObjectValue { inner: ob.into() };
-                    Ok(Wrap(AnyValue::ObjectOwned(OwnedObject(v.to_boxed()))))
-                }
-            }
         }
+
+        fn get_bin(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
+            let value = ob.extract::<&[u8]>().unwrap();
+            Ok(AnyValue::Binary(value).into())
+        }
+
+        fn get_null(_ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
+            Ok(AnyValue::Null.into())
+        }
+
+        fn get_timedelta(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
+            Python::with_gil(|py| {
+                let td = UTILS
+                    .as_ref(py)
+                    .getattr("_timedelta_to_pl_timedelta")
+                    .unwrap()
+                    .call1((ob, "us"))
+                    .unwrap();
+                let v = td.extract::<i64>().unwrap();
+                Ok(Wrap(AnyValue::Duration(v, TimeUnit::Microseconds)))
+            })
+        }
+
+        fn get_time(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
+            Python::with_gil(|py| {
+                let time = UTILS
+                    .as_ref(py)
+                    .getattr("_time_to_pl_time")
+                    .unwrap()
+                    .call1((ob,))
+                    .unwrap();
+                let v = time.extract::<i64>().unwrap();
+                Ok(Wrap(AnyValue::Time(v)))
+            })
+        }
+
+        fn get_decimal(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
+            let (sign, digits, exp): (i8, Vec<u8>, i32) =
+                ob.call_method0("as_tuple").unwrap().extract().unwrap();
+            // note: using Vec<u8> is not the most efficient thing here (input is a tuple)
+            let (mut v, scale) = abs_decimal_from_digits(digits, exp).ok_or_else(|| {
+                PyErr::from(PyPolarsErr::Other(
+                    "Decimal is too large to fit in Decimal128".into(),
+                ))
+            })?;
+            if sign > 0 {
+                v = -v; // won't overflow since -i128::MAX > i128::MIN
+            }
+            Ok(Wrap(AnyValue::Decimal(v, scale)))
+        }
+
+        fn get_object(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
+            // this is slow, but hey don't use objects
+            let v = &ObjectValue { inner: ob.into() };
+            Ok(Wrap(AnyValue::ObjectOwned(OwnedObject(v.to_boxed()))))
+        }
+
+        // TYPE key
+        let type_object_ptr = PyType::as_type_ptr(ob.get_type()) as usize;
+
+        Python::with_gil(|py| {
+            LUT.with_gil(py, |lut| {
+                // get the conversion function
+                let convert_fn = lut.entry(type_object_ptr).or_insert_with(
+                    // This only runs if type is not in LUT
+                    || {
+                        if ob.is_instance_of::<PyBool>() {
+                            get_bool
+                            // TODO: this heap allocs on failure
+                        } else if ob.extract::<i64>().is_ok() {
+                            get_int
+                        } else if ob.is_instance_of::<PyFloat>() {
+                            get_float
+                        } else if ob.is_instance_of::<PyString>() {
+                            get_str
+                        } else if ob.is_instance_of::<PyDict>() {
+                            get_struct
+                        } else if ob.is_instance_of::<PyList>() || ob.is_instance_of::<PyTuple>() {
+                            get_list
+                        } else if ob.hasattr("_s").unwrap() {
+                            get_series_el
+                        }
+                        // TODO: this heap allocs on failure
+                        else if ob.extract::<&'s [u8]>().is_ok() {
+                            get_bin
+                        } else if ob.is_none() {
+                            get_null
+                        } else {
+                            let type_name = ob.get_type().name().unwrap();
+                            match type_name {
+                                "datetime" => convert_datetime,
+                                "date" => convert_date,
+                                "timedelta" => get_timedelta,
+                                "time" => get_time,
+                                "Decimal" => get_decimal,
+                                "range" => get_list,
+                                _ => {
+                                    // special branch for np.float as this fails isinstance float
+                                    if ob.extract::<f64>().is_ok() {
+                                        return get_float;
+                                    }
+
+                                    // Can't use pyo3::types::PyDateTime with abi3-py37 feature,
+                                    // so need this workaround instead of `isinstance(ob, datetime)`.
+                                    let bases =
+                                        ob.get_type().getattr("__bases__").unwrap().iter().unwrap();
+                                    for base in bases {
+                                        let parent_type =
+                                            base.unwrap().str().unwrap().to_str().unwrap();
+                                        match parent_type {
+                                            "<class 'datetime.datetime'>" => {
+                                                // `datetime.datetime` is a subclass of `datetime.date`,
+                                                // so need to check `datetime.datetime` first
+                                                return convert_datetime;
+                                            }
+                                            "<class 'datetime.date'>" => {
+                                                return convert_date;
+                                            }
+                                            _ => (),
+                                        }
+                                    }
+
+                                    get_object
+                                }
+                            }
+                        }
+                    },
+                );
+
+                convert_fn(ob)
+            })
+        })
     }
 }
 

--- a/py-polars/src/gil_once_cell.rs
+++ b/py-polars/src/gil_once_cell.rs
@@ -1,0 +1,49 @@
+use std::cell::UnsafeCell;
+
+use pyo3::{PyResult, Python};
+
+// Adapted from PYO3 with the only change that
+// we allow mutable access with when the GIL is held
+
+pub struct GILOnceCell<T>(UnsafeCell<Option<T>>);
+
+// T: Send is needed for Sync because the thread which drops the GILOnceCell can be different
+// to the thread which fills it.
+unsafe impl<T: Send + Sync> Sync for GILOnceCell<T> {}
+unsafe impl<T: Send> Send for GILOnceCell<T> {}
+
+impl<T> GILOnceCell<T> {
+    /// Create a `GILOnceCell` which does not yet contain a value.
+    pub const fn new() -> Self {
+        Self(UnsafeCell::new(None))
+    }
+
+    /// as long as we have the GIL we can mutate
+    /// this creates a context that checks that.
+    pub fn with_gil<F, O>(&self, _py: Python<'_>, mut op: F) -> PyResult<O>
+    where
+        F: FnMut(&mut T) -> PyResult<O>,
+    {
+        // Safe because GIL is held, so no other thread can be writing to this cell concurrently.
+        let inner = unsafe { &mut *self.0.get() }
+            .as_mut()
+            .expect("not yet initialized");
+
+        op(inner)
+    }
+
+    /// Set the value in the cell.
+    ///
+    /// If the cell has already been written, `Err(value)` will be returned containing the new
+    /// value which was not written.
+    pub fn set(&self, _py: Python<'_>, value: T) -> Result<(), T> {
+        // Safe because GIL is held, so no other thread can be writing to this cell concurrently.
+        let inner = unsafe { &mut *self.0.get() };
+        if inner.is_some() {
+            return Err(value);
+        }
+
+        *inner = Some(value);
+        Ok(())
+    }
+}

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -23,6 +23,7 @@ pub mod error;
 pub mod expr;
 pub mod file;
 pub mod functions;
+pub(crate) mod gil_once_cell;
 pub mod lazyframe;
 pub mod lazygroupby;
 #[cfg(feature = "object")]


### PR DESCRIPTION
Speeds up #9806 by ~5.8x on my local machine.

by having a lookup table for types; this saves:

- a lot of heap allocations if conversion to int fails
- many branches

The second optimization is using the dedicated series constructor if we have a single primitive type in the series. 