### PR TITLE
fix(rust, python): fix row-encode of 32 byte payloads

### DIFF
--- a/polars/polars-row/src/encode.rs
+++ b/polars/polars-row/src/encode.rs
@@ -298,7 +298,6 @@ pub fn allocate_rows_buf(
 #[cfg(test)]
 mod test {
     use arrow::array::{Int32Array, Utf8Array};
-    use arrow::datatypes::Field;
 
     use super::*;
     use crate::variable::{decode_binary, BLOCK_SIZE, EMPTY_SENTINEL, NON_EMPTY_SENTINEL};

--- a/polars/polars-row/src/encode.rs
+++ b/polars/polars-row/src/encode.rs
@@ -298,9 +298,10 @@ pub fn allocate_rows_buf(
 #[cfg(test)]
 mod test {
     use arrow::array::{Int32Array, Utf8Array};
+    use arrow::datatypes::Field;
 
     use super::*;
-    use crate::variable::{BLOCK_SIZE, EMPTY_SENTINEL, NON_EMPTY_SENTINEL};
+    use crate::variable::{decode_binary, BLOCK_SIZE, EMPTY_SENTINEL, NON_EMPTY_SENTINEL};
 
     #[test]
     fn test_fixed_and_variable_encode() {
@@ -361,5 +362,28 @@ mod test {
         let row5 = rows_encoded.get(4);
         let expected = &[0u8];
         assert_eq!(row5, expected);
+    }
+
+    #[test]
+    fn test_str_encode_block_size() {
+        // create a key of exactly block size
+        // and check the round trip
+        let mut val = String::new();
+        for i in 0..BLOCK_SIZE {
+            val.push(char::from_u32(i as u32).unwrap())
+        }
+
+        let a = [val.as_str(), val.as_str(), val.as_str()];
+
+        let field = SortField {
+            descending: false,
+            nulls_last: false,
+        };
+        let arr = BinaryArray::<i64>::from_iter_values(a.iter());
+        let rows_encoded = convert_columns_no_order(&[arr.clone().boxed()]);
+
+        let mut rows = rows_encoded.iter().collect::<Vec<_>>();
+        let decoded = unsafe { decode_binary(&mut rows, &field) };
+        assert_eq!(decoded, arr);
     }
 }


### PR DESCRIPTION
We use a block size of 32 bytes in our row-encoding. By accident we overwrote the final block if `size % 32 == 0`. This ensures we don't.

fixes #9837