### PR TITLE
feat(rust, python): Optional three-valued logic for any/all

### DIFF
--- a/polars/polars-core/src/chunked_array/comparison/mod.rs
+++ b/polars/polars-core/src/chunked_array/comparison/mod.rs
@@ -1004,6 +1004,23 @@ impl BooleanChunked {
     pub fn any(&self) -> bool {
         self.downcast_iter().any(compute::boolean::any)
     }
+
+    // Three-valued versions which can return None
+    pub fn all_3val(&self, drop_nulls: bool) -> Option<bool> {
+        if drop_nulls || self.null_count() == 0 {
+            Some(self.downcast_iter().all(compute::boolean::all))
+        } else {
+            None
+        }
+    }
+    pub fn any_3val(&self, drop_nulls: bool) -> Option<bool> {
+        let res = self.downcast_iter().any(compute::boolean::any);
+        if drop_nulls || res {
+            Some(res)
+        } else {
+            None
+        }
+    }
 }
 
 // private

--- a/polars/polars-core/src/chunked_array/comparison/mod.rs
+++ b/polars/polars-core/src/chunked_array/comparison/mod.rs
@@ -1008,13 +1008,13 @@ impl BooleanChunked {
     // Three-valued versions which can return None
     pub fn all_3val(&self, drop_nulls: bool) -> Option<bool> {
         if drop_nulls || self.null_count() == 0 {
-            Some(self.downcast_iter().all(compute::boolean::all))
+            Some(self.all())
         } else {
             None
         }
     }
     pub fn any_3val(&self, drop_nulls: bool) -> Option<bool> {
-        let res = self.downcast_iter().any(compute::boolean::any);
+        let res = self.any();
         if drop_nulls || res {
             Some(res)
         } else {

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/boolean.rs
@@ -8,8 +8,8 @@ use crate::wrap;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 pub enum BooleanFunction {
-    All,
-    Any,
+    All { drop_nulls: bool },
+    Any { drop_nulls: bool },
     IsNot,
     IsNull,
     IsNotNull,
@@ -37,8 +37,8 @@ impl Display for BooleanFunction {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use BooleanFunction::*;
         let s = match self {
-            All => "all",
-            Any => "any",
+            All { .. } => "all",
+            Any { .. } => "any",
             IsNot => "is_not",
             IsNull => "is_null",
             IsNotNull => "is_not_null",
@@ -63,8 +63,8 @@ impl From<BooleanFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
     fn from(func: BooleanFunction) -> Self {
         use BooleanFunction::*;
         match func {
-            All => map!(all),
-            Any => map!(any),
+            All { drop_nulls} => map!(all, drop_nulls),
+            Any { drop_nulls}=> map!(any, drop_nulls),
             IsNot => map!(is_not),
             IsNull => map!(is_null),
             IsNotNull => map!(is_not_null),
@@ -90,22 +90,14 @@ impl From<BooleanFunction> for FunctionExpr {
     }
 }
 
-fn all(s: &Series) -> PolarsResult<Series> {
+fn all(s: &Series, drop_nulls: bool) -> PolarsResult<Series> {
     let boolean = s.bool()?;
-    if boolean.all() {
-        Ok(Series::new(s.name(), [true]))
-    } else {
-        Ok(Series::new(s.name(), [false]))
-    }
+    Ok(Series::new(s.name(), [boolean.all_3val(drop_nulls)]))
 }
 
-fn any(s: &Series) -> PolarsResult<Series> {
+fn any(s: &Series, drop_nulls: bool) -> PolarsResult<Series> {
     let boolean = s.bool()?;
-    if boolean.any() {
-        Ok(Series::new(s.name(), [true]))
-    } else {
-        Ok(Series::new(s.name(), [false]))
-    }
+    Ok(Series::new(s.name(), [boolean.any_3val(drop_nulls)]))
 }
 
 fn is_not(s: &Series) -> PolarsResult<Series> {

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/boolean.rs
@@ -8,8 +8,12 @@ use crate::wrap;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 pub enum BooleanFunction {
-    All { drop_nulls: bool },
-    Any { drop_nulls: bool },
+    All {
+        drop_nulls: bool,
+    },
+    Any {
+        drop_nulls: bool,
+    },
     IsNot,
     IsNull,
     IsNotNull,
@@ -63,8 +67,8 @@ impl From<BooleanFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
     fn from(func: BooleanFunction) -> Self {
         use BooleanFunction::*;
         match func {
-            All { drop_nulls} => map!(all, drop_nulls),
-            Any { drop_nulls}=> map!(any, drop_nulls),
+            All { drop_nulls } => map!(all, drop_nulls),
+            Any { drop_nulls } => map!(any, drop_nulls),
             IsNot => map!(is_not),
             IsNull => map!(is_null),
             IsNotNull => map!(is_not_null),

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -1635,8 +1635,8 @@ impl Expr {
     }
 
     /// Check if any boolean value is `true`
-    pub fn any(self) -> Self {
-        self.apply_private(BooleanFunction::Any.into())
+    pub fn any(self, drop_nulls: bool) -> Self {
+        self.apply_private(BooleanFunction::Any { drop_nulls }.into())
             .with_function_options(|mut opt| {
                 opt.auto_explode = true;
                 opt
@@ -1651,8 +1651,8 @@ impl Expr {
     }
 
     /// Check if all boolean values are `true`
-    pub fn all(self) -> Self {
-        self.apply_private(BooleanFunction::All.into())
+    pub fn all(self, drop_nulls: bool) -> Self {
+        self.apply_private(BooleanFunction::All { drop_nulls }.into())
             .with_function_options(|mut opt| {
                 opt.auto_explode = true;
                 opt

--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -60,8 +60,8 @@ pub(crate) struct SqlExprVisitor<'a> {
 impl SqlExprVisitor<'_> {
     fn visit_expr(&self, expr: &SqlExpr) -> PolarsResult<Expr> {
         match expr {
-            SqlExpr::AllOp(_) => Ok(self.visit_expr(expr)?.all()),
-            SqlExpr::AnyOp(expr) => Ok(self.visit_expr(expr)?.any()),
+            SqlExpr::AllOp(_) => Ok(self.visit_expr(expr)?.all(true)),
+            SqlExpr::AnyOp(expr) => Ok(self.visit_expr(expr)?.any(true)),
             SqlExpr::ArrayAgg(expr) => self.visit_arr_agg(expr),
             SqlExpr::Between {
                 expr,

--- a/polars/tests/it/lazy/expressions/window.rs
+++ b/polars/tests/it/lazy/expressions/window.rs
@@ -365,8 +365,8 @@ fn test_window_exprs_any_all() -> PolarsResult<()> {
     ]?
     .lazy()
     .select([
-        col("var2").any().over([col("var1")]).alias("any"),
-        col("var2").all().over([col("var1")]).alias("all"),
+        col("var2").any(true).over([col("var1")]).alias("any"),
+        col("var2").all(true).over([col("var1")]).alias("all"),
     ])
     .collect()?;
 

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -315,6 +315,11 @@ class Expr:
         """
         Check if any boolean value in a Boolean column is `True`.
 
+        Parameters
+        ----------
+        drop_nulls
+            If False, return None if there are nulls but no Trues.
+
         Returns
         -------
         Boolean literal
@@ -331,6 +336,25 @@ class Expr:
         ╞══════╪═══════╡
         │ true ┆ false │
         └──────┴───────┘
+        >>> df = pl.DataFrame(dict(x=[None, False], y=[None, True]))
+        >>> df.select(pl.col('x').any(True), pl.col('y').any(True))
+        shape: (1, 2)
+        ┌───────┬──────┐
+        │ x     ┆ y    │
+        │ ---   ┆ ---  │
+        │ bool  ┆ bool │
+        ╞═══════╪══════╡
+        │ false ┆ true │
+        └───────┴──────┘
+        >>> df.select(pl.col('x').any(False), pl.col('y').any(False))
+        shape: (1, 2)
+        ┌──────┬──────┐
+        │ x    ┆ y    │
+        │ ---  ┆ ---  │
+        │ bool ┆ bool │
+        ╞══════╪══════╡
+        │ null ┆ true │
+        └──────┴──────┘
 
         """
         return self._from_pyexpr(self._pyexpr.any(drop_nulls))
@@ -342,6 +366,11 @@ class Expr:
         This method is an expression - not to be confused with
         :func:`polars.all` which is a function to select all columns.
 
+        Parameters
+        ----------
+        drop_nulls
+            If False, return None if there are any nulls.
+            
         Returns
         -------
         Boolean literal
@@ -360,6 +389,25 @@ class Expr:
         ╞══════╪═══════╪═══════╡
         │ true ┆ false ┆ false │
         └──────┴───────┴───────┘
+        >>> df = pl.DataFrame(dict(x=[None, False], y=[None, True]))
+        >>> df.select(pl.col('x').all(True), pl.col('y').all(True))
+        shape: (1, 2)
+        ┌───────┬───────┐
+        │ x     ┆ y     │
+        │ ---   ┆ ---   │
+        │ bool  ┆ bool  │
+        ╞═══════╪═══════╡
+        │ false ┆ false │
+        └───────┴───────┘
+        >>> df.select(pl.col('x').all(False), pl.col('y').all(False))
+        shape: (1, 2)
+        ┌──────┬──────┐
+        │ x    ┆ y    │
+        │ ---  ┆ ---  │
+        │ bool ┆ bool │
+        ╞══════╪══════╡
+        │ null ┆ null │
+        └──────┴──────┘
 
         """
         return self._from_pyexpr(self._pyexpr.all(drop_nulls))

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -311,7 +311,7 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.to_physical())
 
-    def any(self) -> Self:
+    def any(self, drop_nulls: bool = True) -> Self:
         """
         Check if any boolean value in a Boolean column is `True`.
 
@@ -333,9 +333,9 @@ class Expr:
         └──────┴───────┘
 
         """
-        return self._from_pyexpr(self._pyexpr.any())
+        return self._from_pyexpr(self._pyexpr.any(drop_nulls))
 
-    def all(self) -> Self:
+    def all(self, drop_nulls: bool = True) -> Self:
         """
         Check if all boolean values in a Boolean column are `True`.
 
@@ -362,7 +362,7 @@ class Expr:
         └──────┴───────┴───────┘
 
         """
-        return self._from_pyexpr(self._pyexpr.all())
+        return self._from_pyexpr(self._pyexpr.all(drop_nulls))
 
     def arg_true(self) -> Self:
         """

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -337,7 +337,7 @@ class Expr:
         │ true ┆ false │
         └──────┴───────┘
         >>> df = pl.DataFrame(dict(x=[None, False], y=[None, True]))
-        >>> df.select(pl.col('x').any(True), pl.col('y').any(True))
+        >>> df.select(pl.col("x").any(True), pl.col("y").any(True))
         shape: (1, 2)
         ┌───────┬──────┐
         │ x     ┆ y    │
@@ -346,7 +346,7 @@ class Expr:
         ╞═══════╪══════╡
         │ false ┆ true │
         └───────┴──────┘
-        >>> df.select(pl.col('x').any(False), pl.col('y').any(False))
+        >>> df.select(pl.col("x").any(False), pl.col("y").any(False))
         shape: (1, 2)
         ┌──────┬──────┐
         │ x    ┆ y    │
@@ -370,7 +370,8 @@ class Expr:
         ----------
         drop_nulls
             If False, return None if there are any nulls.
-            
+
+
         Returns
         -------
         Boolean literal
@@ -390,7 +391,7 @@ class Expr:
         │ true ┆ false ┆ false │
         └──────┴───────┴───────┘
         >>> df = pl.DataFrame(dict(x=[None, False], y=[None, True]))
-        >>> df.select(pl.col('x').all(True), pl.col('y').all(True))
+        >>> df.select(pl.col("x").all(True), pl.col("y").all(True))
         shape: (1, 2)
         ┌───────┬───────┐
         │ x     ┆ y     │
@@ -399,7 +400,7 @@ class Expr:
         ╞═══════╪═══════╡
         │ false ┆ false │
         └───────┴───────┘
-        >>> df.select(pl.col('x').all(False), pl.col('y').all(False))
+        >>> df.select(pl.col("x").all(False), pl.col("y").all(False))
         shape: (1, 2)
         ┌──────┬──────┐
         │ x    ┆ y    │

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -28,7 +28,7 @@ def all(
 @deprecated_alias(columns="exprs")
 def all(
     exprs: IntoExpr | Iterable[IntoExpr] | None = None, *more_exprs: IntoExpr
-) -> Expr | bool:
+) -> Expr | bool | None:
     """
     Either return an expression representing all columns, or evaluate a bitwise AND operation.
 
@@ -115,7 +115,9 @@ def any(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
 
 
 @deprecated_alias(columns="exprs")
-def any(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | bool:
+def any(
+    exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr
+) -> Expr | bool | None:
     """
     Evaluate a bitwise OR operation.
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1196,7 +1196,7 @@ class Series:
 
         """
 
-    def any(self) -> bool:
+    def any(self, drop_nulls: bool = True) -> bool:
         """
         Check if any boolean value in the column is `True`.
 
@@ -1205,9 +1205,9 @@ class Series:
         Boolean literal
 
         """
-        return self.to_frame().select(F.col(self.name).any()).to_series()[0]
+        return self.to_frame().select(F.col(self.name).any(drop_nulls)).to_series()[0]
 
-    def all(self) -> bool:
+    def all(self, drop_nulls: bool = True) -> bool:
         """
         Check if all boolean values in the column are `True`.
 
@@ -1216,7 +1216,7 @@ class Series:
         Boolean literal
 
         """
-        return self.to_frame().select(F.col(self.name).all()).to_series()[0]
+        return self.to_frame().select(F.col(self.name).all(drop_nulls)).to_series()[0]
 
     def log(self, base: float = math.e) -> Series:
         """Compute the logarithm to a given base."""

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1196,7 +1196,7 @@ class Series:
 
         """
 
-    def any(self, drop_nulls: bool = True) -> bool:
+    def any(self, drop_nulls: bool = True) -> bool | None:
         """
         Check if any boolean value in the column is `True`.
 
@@ -1207,7 +1207,7 @@ class Series:
         """
         return self.to_frame().select(F.col(self.name).any(drop_nulls)).to_series()[0]
 
-    def all(self, drop_nulls: bool = True) -> bool:
+    def all(self, drop_nulls: bool = True) -> bool | None:
         """
         Check if all boolean values in the column are `True`.
 

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -1098,12 +1098,12 @@ impl PyExpr {
             .with_fmt("extend")
             .into()
     }
-    fn any(&self) -> Self {
-        self.inner.clone().any().into()
+    fn any(&self, drop_nulls: bool) -> Self {
+        self.inner.clone().any(drop_nulls).into()
     }
 
-    fn all(&self) -> Self {
-        self.inner.clone().all().into()
+    fn all(&self, drop_nulls: bool) -> Self {
+        self.inner.clone().all(drop_nulls).into()
     }
 
     fn log(&self, base: f64) -> Self {


### PR DESCRIPTION
Resolves https://github.com/pola-rs/polars/issues/9472
Adds a drop_nulls parameter to allow null propagation in any and all.