### PR TITLE
perf(python): Use `pyo3::intern` to avoid needlessly recreating PyString

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "ahash",
  "built",


### PR DESCRIPTION
See https://docs.rs/pyo3/latest/pyo3/macro.intern.html