### PR TITLE
feat(rust,python,cli): add `LENGTH` and `OCTET_LENGTH` string functions for SQL

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -618,6 +618,9 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
         match func {
             #[cfg(feature = "regex")]
             Contains { literal, strict } => map_as_slice!(strings::contains, literal, strict),
+            CountMatch(pat) => {
+                map!(strings::count_match, &pat)
+            }
             EndsWith { .. } => map_as_slice!(strings::ends_with),
             StartsWith { .. } => map_as_slice!(strings::starts_with),
             Extract { pat, group_index } => {
@@ -626,9 +629,8 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             ExtractAll => {
                 map_as_slice!(strings::extract_all)
             }
-            CountMatch(pat) => {
-                map!(strings::count_match, &pat)
-            }
+            NChars => map!(strings::n_chars),
+            Length => map!(strings::lengths),
             #[cfg(feature = "string_justify")]
             Zfill(alignment) => {
                 map!(strings::zfill, alignment)

--- a/polars/polars-lazy/polars-plan/src/dsl/string.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/string.rs
@@ -456,12 +456,24 @@ impl StringNameSpace {
     }
 
     #[cfg(feature = "string_from_radix")]
-    /// Parse string in base radix into decimal
+    /// Parse string in base radix into decimal.
     pub fn from_radix(self, radix: u32, strict: bool) -> Expr {
         self.0
             .map_private(FunctionExpr::StringExpr(StringFunction::FromRadix(
                 radix, strict,
             )))
+    }
+
+    /// Return the number of characters in the string (not bytes).
+    pub fn n_chars(self) -> Expr {
+        self.0
+            .map_private(FunctionExpr::StringExpr(StringFunction::NChars))
+    }
+
+    /// Return the number of bytes in the string (not characters).
+    pub fn lengths(self) -> Expr {
+        self.0
+            .map_private(FunctionExpr::StringExpr(StringFunction::Length))
     }
 
     /// Slice the string values.

--- a/polars/polars-sql/src/functions.rs
+++ b/polars/polars-sql/src/functions.rs
@@ -161,6 +161,11 @@ pub(crate) enum PolarsSqlFunctions {
     /// SELECT LEFT(column_1, 3) from df;
     /// ```
     Left,
+    /// SQL 'length' function (characters)
+    /// ```sql
+    /// SELECT LENGTH(column_1) from df;
+    /// ```
+    Length,
     /// SQL 'lower' function
     /// ```sql
     /// SELECT LOWER(column_1) from df;
@@ -171,6 +176,11 @@ pub(crate) enum PolarsSqlFunctions {
     /// SELECT LTRIM(column_1) from df;
     /// ```
     LTrim,
+    /// SQL 'octet_length' function (bytes)
+    /// ```sql
+    /// SELECT OCTET_LENGTH(column_1) from df;
+    /// ```
+    OctetLength,
     /// SQL 'regexp_like' function
     /// ```sql
     /// SELECT REGEXP_LIKE(column_1,'xyz', 'i') from df;
@@ -368,6 +378,7 @@ impl PolarsSqlFunctions {
             "ltrim",
             "max",
             "min",
+            "octet_length",
             "pow",
             "radians",
             "round",
@@ -428,9 +439,11 @@ impl TryFrom<&'_ SQLFunction> for PolarsSqlFunctions {
             // String functions
             // ----
             "ends_with" => Self::EndsWith,
+            "length" => Self::Length,
             "left" => Self::Left,
             "lower" => Self::Lower,
             "ltrim" => Self::LTrim,
+            "octet_length" => Self::OctetLength,
             "regexp_like" => Self::RegexpLike,
             "rtrim" => Self::RTrim,
             "starts_with" => Self::StartsWith,
@@ -532,6 +545,7 @@ impl SqlFunctionVisitor<'_> {
                     }
                 }))
             }),
+            Length => self.visit_unary(|e| e.str().n_chars()),
             Lower => self.visit_unary(|e| e.str().to_lowercase()),
             LTrim => match function.args.len() {
                 1 => self.visit_unary(|e| e.str().lstrip(None)),
@@ -541,6 +555,7 @@ impl SqlFunctionVisitor<'_> {
                     function.args.len()
                 ),
             },
+            OctetLength => self.visit_unary(|e| e.str().lengths()),
             RegexpLike => match function.args.len() {
                 2 => self.visit_binary(|e, s| e.str().contains(s, true)),
                 3 => self.try_visit_ternary(|e, pat, flags| {

--- a/py-polars/src/expr/string.rs
+++ b/py-polars/src/expr/string.rs
@@ -89,27 +89,11 @@ impl PyExpr {
     }
 
     fn str_lengths(&self) -> Self {
-        let function = |s: Series| {
-            let ca = s.utf8()?;
-            Ok(Some(ca.str_lengths().into_series()))
-        };
-        self.clone()
-            .inner
-            .map(function, GetOutput::from_type(DataType::UInt32))
-            .with_fmt("str.lengths")
-            .into()
+        self.inner.clone().str().lengths().into()
     }
 
     fn str_n_chars(&self) -> Self {
-        let function = |s: Series| {
-            let ca = s.utf8()?;
-            Ok(Some(ca.str_n_chars().into_series()))
-        };
-        self.clone()
-            .inner
-            .map(function, GetOutput::from_type(DataType::UInt32))
-            .with_fmt("str.n_chars")
-            .into()
+        self.inner.clone().str().n_chars().into()
     }
 
     #[cfg(feature = "lazy_regex")]

--- a/py-polars/tests/unit/test_sql.py
+++ b/py-polars/tests/unit/test_sql.py
@@ -682,6 +682,27 @@ def test_sql_round_ndigits_errors() -> None:
         ctx.execute("SELECT ROUND(n,-1) AS n FROM df")
 
 
+def test_sql_string_lengths() -> None:
+    df = pl.DataFrame({"words": ["Café", None, "東京"]})
+
+    with pl.SQLContext(frame=df) as ctx:
+        res = ctx.execute(
+            """
+            SELECT
+              words,
+              LENGTH(words) AS n_chars,
+              OCTET_LENGTH(words) AS n_bytes
+            FROM frame
+            """
+        ).collect()
+
+    assert res.to_dict(False) == {
+        "words": ["Café", None, "東京"],
+        "n_chars": [4, None, 2],
+        "n_bytes": [5, None, 6],
+    }
+
+
 def test_sql_substr() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
Support for SQL string length functions, in terms of both characters (`length`) and bytes (`octet_length`).

Also:
* adds the related functions into `StringNameSpace` on the Rust side.
*  sorts some string function definitions for clarity).

## Example

```python
import polars as pl

df = pl.DataFrame({
    "words": ["Café", None, "東京"],
})

with pl.SQLContext( frame=df ) as ctx:
    res = ctx.execute(
        """
        SELECT
          words,
          LENGTH(words) AS n_chars,
          OCTET_LENGTH(words) AS n_bytes
        FROM frame
        """
    ).collect()

# shape: (3, 3)
# ┌───────┬─────────┬─────────┐
# │ words ┆ n_chars ┆ n_bytes │
# │ ---   ┆ ---     ┆ ---     │
# │ str   ┆ u32     ┆ u32     │
# ╞═══════╪═════════╪═════════╡
# │ Café  ┆ 4       ┆ 5       │
# │ null  ┆ null    ┆ null    │
# │ 東京  ┆ 2       ┆ 6       │
# └───────┴─────────┴─────────┘
```