### PR TITLE
chore(rust): Clean up workspace definition

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -60,7 +60,7 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Run cargo clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets -- -D warnings
 
   rustfmt:
     if: github.ref_name != 'main'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,25 +3,12 @@ resolver = "2"
 members = [
   "polars",
   "polars-cli",
-  "polars/polars-core",
-  "polars/polars-io",
-  "polars/polars-time",
-  "polars/polars-utils",
-  "polars/polars-ops",
-  "polars/polars-algo",
-  "polars/polars-lazy",
-  "polars/polars-lazy/polars-plan",
-  "polars/polars-lazy/polars-pipe",
-  "polars/polars-sql",
-  "polars/polars-error",
-  "polars/polars-row",
-  "polars/polars-json",
-  "examples/read_csv",
-  "examples/read_json",
-  "examples/read_parquet",
-  "examples/read_parquet_cloud",
-  "examples/string_filter",
-  "examples/python_rust_compiled_function",
+  "polars/polars-*",
+  "polars/polars-lazy/polars-*",
+  "examples/*",
+]
+exclude = [
+  "examples/datasets",
 ]
 
 [workspace.package]

--- a/polars/polars-core/Cargo.toml
+++ b/polars/polars-core/Cargo.toml
@@ -183,6 +183,7 @@ wasm-timer = "0.2.5"
 
 [dev-dependencies]
 bincode = "1"
+serde_json = "1"
 
 [package.metadata.docs.rs]
 # not all because arrow 4.3 does not compile with simd

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.18.6"
+version = "0.18.7"
 dependencies = [
  "ahash",
  "built",


### PR DESCRIPTION
Changes:
* Use wildcards to define workspace members
* Add a missing dev dependency for polars-core
* Update CI so clippy stable runs on `--all-targets`

My goal is to make everything run from the workspace root, but there's still some ways to go for the test suite to behave nicely.