### PR TITLE
docs(python): Mention func_horizontal on deprecated func docstrings

### DIFF
--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -50,6 +50,10 @@ def all(
     *more_exprs
         Additional columns to use in the aggregation, specified as positional arguments.
 
+    See Also
+    --------
+    all_horizontal
+
     Examples
     --------
     Selecting all columns.
@@ -128,6 +132,10 @@ def any(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | b
     columns.
     **This functionality is deprecated**, use ``pl.any_horizontal`` instead.
 
+    See Also
+    --------
+    any_horizontal
+
     Parameters
     ----------
     exprs
@@ -204,6 +212,10 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
         parsed as column names, other non-expression inputs are parsed as literals.
     *more_exprs
         Additional columns to use in the aggregation, specified as positional arguments.
+
+    See Also
+    --------
+    max_horizontal
 
     Examples
     --------
@@ -301,6 +313,10 @@ def min(
     *more_exprs
         Additional columns to use in the aggregation, specified as positional arguments.
 
+    See Also
+    --------
+    min_horizontal
+
     Examples
     --------
     Get the minimum value of a column by passing a single column name.
@@ -396,6 +412,10 @@ def sum(
         parsed as column names, other non-expression inputs are parsed as literals.
     *more_exprs
         Additional columns to use in the aggregation, specified as positional arguments.
+
+    See Also
+    --------
+    sum_horizontal
 
     Examples
     --------
@@ -494,6 +514,10 @@ def cumsum(
         parsed as column names, other non-expression inputs are parsed as literals.
     *more_exprs
         Additional columns to use in the aggregation, specified as positional arguments.
+
+    See Also
+    --------
+    cumsum_horizontal
 
     Examples
     --------

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -40,7 +40,7 @@ def all(
 
     Otherwise, this function computes the bitwise AND horizontally across multiple
     columns.
-    **This functionality is deprecated**.
+    **This functionality is deprecated**, use ``pl.all_horizontal`` instead.
 
     Parameters
     ----------
@@ -126,7 +126,7 @@ def any(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | b
 
     Otherwise, this function computes the bitwise OR horizontally across multiple
     columns.
-    **This functionality is deprecated**.
+    **This functionality is deprecated**, use ``pl.any_horizontal`` instead.
 
     Parameters
     ----------
@@ -195,7 +195,7 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
 
     Otherwise, this function computes the maximum value horizontally across multiple
     columns.
-    **This functionality is deprecated**.
+    **This functionality is deprecated**, use ``pl.max_horizontal`` instead.
 
     Parameters
     ----------
@@ -291,7 +291,7 @@ def min(
 
     Otherwise, this function computes the minimum value horizontally across multiple
     columns.
-    **This functionality is deprecated**.
+    **This functionality is deprecated**, use ``pl.min_horizontal`` instead.
 
     Parameters
     ----------
@@ -387,7 +387,7 @@ def sum(
     **This functionality is deprecated**.
 
     Otherwise, this function computes the sum horizontally across multiple columns.
-    **This functionality is deprecated**.
+    **This functionality is deprecated**, use ``pl.sum_horizontal`` instead.
 
     Parameters
     ----------
@@ -485,7 +485,7 @@ def cumsum(
 
     Otherwise, this function computes the cumulative sum horizontally across multiple
     columns.
-    **This functionality is deprecated**.
+    **This functionality is deprecated**, use ``pl.cumsum_horizontal`` instead.
 
     Parameters
     ----------


### PR DESCRIPTION
Following #9752's new horizontal methods, the usage of the previous one's was deprecated without it being clear what the new function names were. I just stepped through the instances of `**This functionality is deprecated**` and added the new function name after them.