### PR TITLE
docs(python): add logo `link` entry to sphinx conf and factor-out website root paths

### DIFF
--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -90,18 +90,26 @@ copybutton_prompt_is_regexp = True
 autosummary_generate = True
 numpydoc_show_class_members = False
 
+# key site root paths
+static_assets_root = "https://raw.githubusercontent.com/pola-rs/polars-static/master"
+github_root = "https://github.com/pola-rs/polars"
+web_root = "https://pola-rs.github.io"
+
 html_theme_options = {
     "external_links": [
         {
             "name": "User Guide",
-            "url": "https://pola-rs.github.io/polars-book/user-guide/index.html",
+            "url": f"{web_root}/polars-book/user-guide/index.html",
         },
-        {"name": "Powered by Xomnia", "url": "https://www.xomnia.com/"},
+        {
+            "name": "Powered by Xomnia",
+            "url": "https://www.xomnia.com/",
+        },
     ],
     "icon_links": [
         {
             "name": "GitHub",
-            "url": "https://github.com/pola-rs/polars",
+            "url": github_root,
             "icon": "fa-brands fa-github",
         },
         {
@@ -116,8 +124,9 @@ html_theme_options = {
         },
     ],
     "logo": {
-        "image_light": "https://raw.githubusercontent.com/pola-rs/polars-static/master/logos/polars-logo-dark-medium.png",
-        "image_dark": "https://raw.githubusercontent.com/pola-rs/polars-static/master/logos/polars-logo-dimmed-medium.png",
+        "image_light": f"{static_assets_root}/logos/polars-logo-dark-medium.png",
+        "image_dark": f"{static_assets_root}/logos/polars-logo-dimmed-medium.png",
+        "link": f"{web_root}/polars/py-polars/html/reference/index.html",
     },
 }
 
@@ -125,12 +134,12 @@ favicons = [
     {
         "rel": "icon",
         "sizes": "32x32",
-        "href": "https://raw.githubusercontent.com/pola-rs/polars-static/master/icons/favicon-32x32.png",
+        "href": f"{static_assets_root}/icons/favicon-32x32.png",
     },
     {
         "rel": "apple-touch-icon",
         "sizes": "180x180",
-        "href": "https://raw.githubusercontent.com/pola-rs/polars-static/master/icons/touchicon-180x180.png",
+        "href": f"{static_assets_root}/icons/touchicon-180x180.png",
     },
 ]
 
@@ -195,10 +204,7 @@ def linkcode_resolve(domain, info):
     polars_root = os.path.abspath(f"{conf_dir_path}/../../polars")
 
     fn = os.path.relpath(fn, start=polars_root)
-
-    return (
-        f"https://github.com/pola-rs/polars/blob/main/py-polars/polars/{fn}{linespec}"
-    )
+    return f"{github_root}/blob/main/py-polars/polars/{fn}{linespec}"
 
 
 def _minify_classpaths(s: str) -> str:


### PR DESCRIPTION
Closes #9399.

Digging around in the Sphinx docs led me to `logo_url`, and then onto the pydata-specific `link`[^1] which actually worked, so we can now repoint the page reached when clicking the top-left titlebar logo to the _actual_ API reference landing page instead of the dead-end/empty index page..

* Before: https://pola-rs.github.io/polars/py-polars/html/index.html
* After: https://pola-rs.github.io/polars/py-polars/html/reference/index.html

Also: minor refactor to pull-out the various website root paths into top-level constants:
```python
static_assets_root = "https://raw.githubusercontent.com/pola-rs/polars-static/master"
github_root = "https://github.com/pola-rs/polars"
web_root = "https://pola-rs.github.io"
```

[^1]: Customize logo link: https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/branding.html#customize-logo-link