### PR TITLE
feat(rust, python): `polars_warn!` macro

### DIFF
--- a/polars/polars-core/src/prelude.rs
+++ b/polars/polars-core/src/prelude.rs
@@ -32,7 +32,9 @@ pub use crate::chunked_array::temporal::conversion::*;
 pub use crate::chunked_array::ChunkedArray;
 pub(crate) use crate::chunked_array::{to_array, ChunkIdIter};
 pub use crate::datatypes::*;
-pub use crate::error::{polars_bail, polars_ensure, polars_err, PolarsError, PolarsResult};
+pub use crate::error::{
+    polars_bail, polars_ensure, polars_err, polars_warn, PolarsError, PolarsResult,
+};
 #[cfg(feature = "asof_join")]
 pub use crate::frame::asof_join::*;
 pub use crate::frame::explode::MeltArgs;

--- a/polars/polars-error/src/lib.rs
+++ b/polars/polars-error/src/lib.rs
@@ -1,8 +1,12 @@
+mod warning;
+
 use std::borrow::Cow;
 use std::error::Error;
 use std::fmt::{self, Display, Formatter};
 use std::ops::Deref;
 use std::{env, io};
+
+pub use warning::*;
 
 #[derive(Debug)]
 pub struct ErrString(Cow<'static, str>);

--- a/polars/polars-error/src/warning.rs
+++ b/polars/polars-error/src/warning.rs
@@ -1,0 +1,32 @@
+type WarningFunction = fn(&str);
+static mut WARNING_FUNCTION: Option<WarningFunction> = None;
+
+/// Set the function that will be called by the `polars_warn!` macro.
+/// You can use this to set logging in polars.
+///
+/// # Safety
+/// The caller must ensure there is no other thread accessing this function
+/// or calling `polars_warn!`.
+pub unsafe fn set_warning_function(function: WarningFunction) {
+    WARNING_FUNCTION = Some(function)
+}
+
+fn eprintln(fmt: &str) {
+    eprintln!("{}", fmt);
+}
+
+pub fn get_warning_function() -> WarningFunction {
+    unsafe { WARNING_FUNCTION.unwrap_or(eprintln) }
+}
+#[macro_export]
+macro_rules! polars_warn {
+    ($fmt:literal, $($arg:tt)+) => {
+        {{
+        let func = $crate::get_warning_function();
+        func(format!($fmt, $($arg)+).as_ref())
+        }}
+    };
+    ($($arg:tt)+) => {
+        polars_warn!("{}", $($arg)+);
+    };
+}

--- a/polars/polars-lazy/polars-plan/src/dsl/string.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/string.rs
@@ -1,4 +1,3 @@
-use polars_arrow::array::ValueSize;
 #[cfg(feature = "dtype-struct")]
 use polars_arrow::export::arrow::array::{MutableArray, MutableUtf8Array};
 #[cfg(feature = "dtype-struct")]

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -482,7 +482,7 @@ impl LazyFrame {
         let streaming = self.opt_state.streaming;
         #[cfg(feature = "cse")]
         if streaming && self.opt_state.common_subplan_elimination {
-            eprintln!("Cannot combine 'streaming' with 'common_subplan_elimination'. CSE will be turned off.");
+            polars_warn!("Cannot combine 'streaming' with 'common_subplan_elimination'. CSE will be turned off.");
             opt_state.common_subplan_elimination = false;
         }
         let lp_top = optimize(self.logical_plan, opt_state, lp_arena, expr_arena, scratch)?;

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -30,6 +30,7 @@ pub(crate) use count::*;
 pub(crate) use filter::*;
 pub(crate) use literal::*;
 use polars_arrow::utils::CustomIterTools;
+use polars_core::error::polars_warn;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use polars_io::predicates::PhysicalIoExpr;
@@ -402,7 +403,7 @@ impl<'a> AggregationContext<'a> {
                 #[cfg(debug_assertions)]
                 {
                     if self.groups.len() > s.len() {
-                        eprintln!("groups may be out of bounds; more groups than elements in a series is only possible in dynamic groupby")
+                        polars_warn!("groups may be out of bounds; more groups than elements in a series is only possible in dynamic groupby")
                     }
                 }
 

--- a/polars/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/polars/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -30,7 +30,6 @@ pub(crate) use count::*;
 pub(crate) use filter::*;
 pub(crate) use literal::*;
 use polars_arrow::utils::CustomIterTools;
-use polars_core::error::polars_warn;
 use polars_core::frame::groupby::GroupsProxy;
 use polars_core::prelude::*;
 use polars_io::predicates::PhysicalIoExpr;

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1733,6 +1733,7 @@ dependencies = [
  "polars",
  "polars-algo",
  "polars-core",
+ "polars-error",
  "polars-lazy",
  "pyo3",
  "pyo3-built",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -24,6 +24,7 @@ numpy = "0.19"
 once_cell = "1"
 polars-algo = { path = "../polars/polars-algo", default-features = false }
 polars-core = { path = "../polars/polars-core", features = ["python"], default-features = false }
+polars-error = { path = "../polars/polars-error" }
 polars-lazy = { path = "../polars/polars-lazy", features = ["python"], default-features = false }
 pyo3 = { version = "0.19", features = ["abi3-py38", "extension-module", "multiple-pymethods"] }
 pyo3-built = { version = "0.4", optional = true }

--- a/py-polars/polars/utils/__init__.py
+++ b/py-polars/polars/utils/__init__.py
@@ -19,7 +19,7 @@ from polars.utils.convert import (
 )
 from polars.utils.meta import get_idx_type, get_index_type, threadpool_size
 from polars.utils.show_versions import show_versions
-from polars.utils.various import NoDefault, no_default, _polars_warn
+from polars.utils.various import NoDefault, _polars_warn, no_default
 
 __all__ = [
     "NoDefault",

--- a/py-polars/polars/utils/__init__.py
+++ b/py-polars/polars/utils/__init__.py
@@ -19,7 +19,7 @@ from polars.utils.convert import (
 )
 from polars.utils.meta import get_idx_type, get_index_type, threadpool_size
 from polars.utils.show_versions import show_versions
-from polars.utils.various import NoDefault, no_default
+from polars.utils.various import NoDefault, no_default, _polars_warn
 
 __all__ = [
     "NoDefault",
@@ -41,4 +41,5 @@ __all__ = [
     "_to_python_timedelta",
     "_datetime_for_anyvalue",
     "_datetime_for_anyvalue_windows",
+    "_polars_warn",
 ]

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -4,10 +4,10 @@ import inspect
 import os
 import re
 import sys
+import warnings
 from collections.abc import MappingView, Sized
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Generator, Iterable, Literal, Sequence, TypeVar
-import warnings
 
 import polars as pl
 from polars import functions as F
@@ -408,7 +408,7 @@ def _get_stack_locals(
 
 
 # this is called from rust
-def _polars_warn(msg: str):
+def _polars_warn(msg: str) -> None:
     warnings.warn(
         msg,
         stacklevel=find_stacklevel(),

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -7,6 +7,7 @@ import sys
 from collections.abc import MappingView, Sized
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Generator, Iterable, Literal, Sequence, TypeVar
+import warnings
 
 import polars as pl
 from polars import functions as F
@@ -404,3 +405,11 @@ def _get_stack_locals(
                     return objects
         stack_frame = stack_frame.f_back
     return objects
+
+
+# this is called from rust
+def _polars_warn(msg: str):
+    warnings.warn(
+        msg,
+        stacklevel=find_stacklevel(),
+    )

--- a/py-polars/src/on_startup.rs
+++ b/py-polars/src/on_startup.rs
@@ -8,12 +8,13 @@ use polars_core::chunked_array::object::registry::AnonymousObjectBuilder;
 use polars_core::error::PolarsError::ComputeError;
 use polars_core::error::PolarsResult;
 use polars_core::frame::DataFrame;
+use pyo3::intern;
 use pyo3::prelude::*;
 
 use crate::apply::lazy::{call_lambda_with_series, ToSeries};
 use crate::dataframe::PyDataFrame;
 use crate::prelude::{python_udf, ObjectValue};
-use crate::py_modules::POLARS;
+use crate::py_modules::{POLARS, UTILS};
 use crate::Wrap;
 
 fn python_function_caller_series(s: Series, lambda: &PyObject) -> PolarsResult<Series> {
@@ -56,6 +57,19 @@ fn python_function_caller_df(df: DataFrame, lambda: &PyObject) -> PolarsResult<D
     })
 }
 
+fn warning_function(msg: &str) {
+    Python::with_gil(|py| {
+        let warn_fn = UTILS
+            .as_ref(py)
+            .getattr(intern!(py, "_polars_warn"))
+            .unwrap();
+
+        if let Err(e) = warn_fn.call1((msg,)) {
+            eprintln!("{e}")
+        }
+    });
+}
+
 #[pyfunction]
 pub fn __register_startup_deps() {
     if !registry::is_object_builder_registered() {
@@ -77,9 +91,11 @@ pub fn __register_startup_deps() {
         unsafe { python_udf::CALL_SERIES_UDF_PYTHON = Some(python_function_caller_series) }
         // register DATAFRAME UDF
         unsafe { python_udf::CALL_DF_UDF_PYTHON = Some(python_function_caller_df) }
+        // register warning function for `polars_warn!`
+        unsafe { polars_error::set_warning_function(warning_function) };
         Python::with_gil(|py| {
             // init AnyValue LUT
             crate::conversion::LUT.set(py, Default::default()).unwrap();
-        })
+        });
     }
 }


### PR DESCRIPTION
This allows us to raise python warnings on the rust side and they will be silenceable. In a later PR we can follow up supporting different types of warning. I want to have a `PolarsWarning` enum on the rust side that maps to different python warnings.