### PR TITLE
feat(rust, python): Expr.cat.get_categories expression

### DIFF
--- a/polars/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/polars/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -92,12 +92,17 @@ impl RevMapping {
         !self.is_global()
     }
 
+    /// Get the categories in this RevMapping
+    pub fn get_categories(&self) -> &Utf8Array<i64> {
+        match self {
+            Self::Global(_, a, _) => a,
+            Self::Local(a) => a,
+        }
+    }
+
     /// Get the length of the [`RevMapping`]
     pub fn len(&self) -> usize {
-        match self {
-            Self::Global(_, a, _) => a.len(),
-            Self::Local(a) => a.len(),
-        }
+        self.get_categories().len()
     }
 
     /// Categorical to str

--- a/polars/polars-lazy/polars-plan/src/dsl/cat.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/cat.rs
@@ -20,4 +20,9 @@ impl CategoricalNameSpace {
         self.0
             .map_private(CategoricalFunction::SetOrdering { lexical }.into())
     }
+
+    pub fn get_categories(self) -> Expr {
+        self.0
+            .map_private(CategoricalFunction::GetCategories.into())
+    }
 }

--- a/py-polars/docs/source/reference/expressions/categories.rst
+++ b/py-polars/docs/source/reference/expressions/categories.rst
@@ -9,4 +9,5 @@ The following methods are available under the `expr.cat` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
+    Expr.cat.get_categories
     Expr.cat.set_ordering

--- a/py-polars/docs/source/reference/series/categories.rst
+++ b/py-polars/docs/source/reference/series/categories.rst
@@ -9,4 +9,5 @@ The following methods are available under the `Series.cat` attribute.
    :toctree: api/
    :template: autosummary/accessor_method.rst
 
+    Series.cat.get_categories
     Series.cat.set_ordering

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -55,3 +55,27 @@ class ExprCatNameSpace:
 
         """
         return wrap_expr(self._pyexpr.cat_set_ordering(ordering))
+
+    def get_categories(self) -> Expr:
+        """
+        Get the categories stored in this data type.
+
+        Examples
+        --------
+        >>> df = pl.Series(
+        ...     "cats", ["foo", "bar", "foo", "foo", "ham"], dtype=pl.Categorical
+        ... ).to_frame()
+        >>> df.select(pl.col("cats").cat.get_categories())
+        shape: (3, 1)
+        ┌──────┐
+        │ cats │
+        │ ---  │
+        │ str  │
+        ╞══════╡
+        │ foo  │
+        │ bar  │
+        │ ham  │
+        └──────┘
+
+        """
+        return wrap_expr(self._pyexpr.cat_get_categories())

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -56,3 +56,21 @@ class CatNameSpace:
         └──────┴──────┘
 
         """
+
+    def get_categories(self) -> Series:
+        """
+        Get the categories stored in this data type.
+
+        Examples
+        --------
+        >>> s = pl.Series(["foo", "bar", "foo", "foo", "ham"], dtype=pl.Categorical)
+        >>> s.cat.get_categories()
+        shape: (3,)
+        Series: '' [str]
+        [
+            "foo"
+            "bar"
+            "ham"
+        ]
+
+        """

--- a/py-polars/src/expr/categorical.rs
+++ b/py-polars/src/expr/categorical.rs
@@ -9,4 +9,8 @@ impl PyExpr {
     fn cat_set_ordering(&self, ordering: Wrap<CategoricalOrdering>) -> Self {
         self.inner.clone().cat().set_ordering(ordering.0).into()
     }
+
+    fn cat_get_categories(&self) -> Self {
+        self.inner.clone().cat().get_categories().into()
+    }
 }

--- a/py-polars/tests/unit/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/namespaces/test_categorical.py
@@ -72,3 +72,9 @@ def test_sort_categoricals_6014() -> None:
     assert out.to_dict(False) == {"key": ["bbb", "aaa", "ccc"]}
     out = df2.sort("key")
     assert out.to_dict(False) == {"key": ["aaa", "bbb", "ccc"]}
+
+
+def test_categorical_get_categories() -> None:
+    assert pl.Series(
+        "cats", ["foo", "bar", "foo", "foo", "ham"], dtype=pl.Categorical
+    ).cat.get_categories().to_list() == ["foo", "bar", "ham"]


### PR DESCRIPTION
Get the underlying categories of a `Categorical` data type.