### PR TITLE
fix(rust, python): fmt unknown dtype

### DIFF
--- a/polars/polars-core/src/datatypes/dtype.rs
+++ b/polars/polars-core/src/datatypes/dtype.rs
@@ -332,7 +332,7 @@ impl Display for DataType {
             DataType::Categorical(_) => "cat",
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(fields) => return write!(f, "struct[{}]", fields.len()),
-            DataType::Unknown => unreachable!(),
+            DataType::Unknown => "unknown",
         };
         f.write_str(s)
     }


### PR DESCRIPTION
closes #9871