### PR TITLE
fix(python,rust,cli): preserve expression aliases when parsing SQL with `pl.sql_expr`

### DIFF
--- a/polars/polars-sql/src/functions.rs
+++ b/polars/polars-sql/src/functions.rs
@@ -380,6 +380,7 @@ impl PolarsSqlFunctions {
             "min",
             "octet_length",
             "pow",
+            "power",
             "radians",
             "round",
             "rtrim",
@@ -432,7 +433,7 @@ impl TryFrom<&'_ SQLFunction> for PolarsSqlFunctions {
             "log10" => Self::Log10,
             "log1p" => Self::Log1p,
             "log2" => Self::Log2,
-            "pow" => Self::Pow,
+            "pow" | "power" => Self::Pow,
             "round" => Self::Round,
 
             // ----

--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -540,6 +540,6 @@ pub fn sql_expr<S: AsRef<str>>(s: S) -> PolarsResult<Expr> {
             expr.alias(&alias.value)
         }
         SelectItem::UnnamedExpr(expr) => parse_sql_expr(expr, &ctx)?,
-        _ => polars_bail!(InvalidOperation: "Unable to parse {} as Expr", s.as_ref()),
+        _ => polars_bail!(InvalidOperation: "Unable to parse '{}' as Expr", s.as_ref()),
     })
 }

--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -536,9 +536,9 @@ pub fn sql_expr<S: AsRef<str>>(s: S) -> PolarsResult<Expr> {
 
     Ok(match &expr {
         SelectItem::ExprWithAlias { expr, alias } => {
-            let expr = parse_sql_expr(&expr, &ctx)?;
+            let expr = parse_sql_expr(expr, &ctx)?;
             expr.alias(&alias.value)
-        },
+        }
         SelectItem::UnnamedExpr(expr) => parse_sql_expr(expr, &ctx)?,
         _ => polars_bail!(InvalidOperation: "Unable to parse {} as Expr", s.as_ref()),
     })

--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -5,8 +5,8 @@ use polars_lazy::prelude::*;
 use polars_plan::prelude::{col, lit, when};
 use sqlparser::ast::{
     ArrayAgg, BinaryOperator as SQLBinaryOperator, BinaryOperator, DataType as SQLDataType,
-    Expr as SqlExpr, Function as SQLFunction, JoinConstraint, OrderByExpr, TrimWhereField,
-    UnaryOperator, Value as SqlValue,
+    Expr as SqlExpr, Function as SQLFunction, JoinConstraint, OrderByExpr, SelectItem,
+    TrimWhereField, UnaryOperator, Value as SqlValue,
 };
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::{Parser, ParserOptions};
@@ -532,8 +532,14 @@ pub fn sql_expr<S: AsRef<str>>(s: S) -> PolarsResult<Expr> {
     });
 
     let mut ast = parser.try_with_sql(s.as_ref()).map_err(to_compute_err)?;
+    let expr = ast.parse_select_item().map_err(to_compute_err)?;
 
-    let expr = ast.parse_expr().map_err(to_compute_err)?;
-
-    parse_sql_expr(&expr, &ctx)
+    Ok(match &expr {
+        SelectItem::ExprWithAlias { expr, alias } => {
+            let expr = parse_sql_expr(&expr, &ctx)?;
+            expr.alias(&alias.value)
+        },
+        SelectItem::UnnamedExpr(expr) => parse_sql_expr(expr, &ctx)?,
+        _ => polars_bail!(InvalidOperation: "Unable to parse {} as Expr", s.as_ref()),
+    })
 }

--- a/py-polars/tests/unit/test_sql.py
+++ b/py-polars/tests/unit/test_sql.py
@@ -780,3 +780,10 @@ def test_sql_expr() -> None:
         {"a": [1, 1, 1], "aa": [1, 4, 27], "b2": ["yz", "bc", None]}
     )
     assert df.select(sql_exprs).frame_equal(expected)
+
+    # expect expressions that can't reasonably be parsed as expressions to raise
+    # (for example: those that explicitly reference tables and/or use wildcards)
+    with pytest.raises(
+        pl.InvalidOperationError, match=r"Unable to parse 'xyz\.\*' as Expr"
+    ):
+        pl.sql_expr("xyz.*")

--- a/py-polars/tests/unit/test_sql.py
+++ b/py-polars/tests/unit/test_sql.py
@@ -773,7 +773,10 @@ def test_sql_expr() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": ["xyz", "abcde", None]})
     sql_exprs = (
         pl.sql_expr("MIN(a)"),
-        pl.sql_expr("SUBSTR(b,1,2)"),
+        pl.sql_expr("POWER(a,a) AS aa"),
+        pl.sql_expr("SUBSTR(b,1,2) AS b2"),
     )
-    expected = pl.DataFrame({"a": [1, 1, 1], "b": ["yz", "bc", None]})
+    expected = pl.DataFrame(
+        {"a": [1, 1, 1], "aa": [1, 4, 27], "b2": ["yz", "bc", None]}
+    )
     assert df.select(sql_exprs).frame_equal(expected)


### PR DESCRIPTION
Coming at you from several kilometres up in the skies, somewhere over (I think?) Bosnia... :)

![aerial_pull_request](https://github.com/pola-rs/polars/assets/2613171/498b5275-4165-4369-8642-7bf0ffc7845c)

---

Aliases were getting silently eaten when parsing SQL strings to Polars expressions; parsing as `SelectItem` instead of bare `Expr` allows any (optional) aliases to be captured and translated along with the underlying expression itself.

# Example

**Before:**
```python
pl.sql_expr( "MIN(a) as min_a" )
# col("a").min()
```

**After:**
```python
pl.sql_expr( "MIN(a) as min_a" )
# col("a").min().alias("min_a")
```

**Also:**

Recognise `power` as an alias for `pow` ("power" is the usual PostgreSQL syntax, but I believe both are allowed).