### PR TITLE
depr(python): Deprecate functions series input

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -468,8 +468,6 @@ def mean(column: str | Series) -> Expr | float | None:
     ╞═════╡
     │ 4.0 │
     └─────┘
-    >>> pl.mean(df["a"])
-    4.0
 
     """
     if isinstance(column, pl.Series):
@@ -508,8 +506,6 @@ def avg(column: str | Series) -> Expr | float:
     ╞═════╡
     │ 4.0 │
     └─────┘
-    >>> pl.avg(df["a"])
-    4.0
 
     """
     return mean(column)
@@ -541,8 +537,6 @@ def median(column: str | Series) -> Expr | float | int | None:
     ╞═════╡
     │ 3.0 │
     └─────┘
-    >>> pl.median(df["a"])
-    3.0
 
     """
     if isinstance(column, pl.Series):
@@ -581,8 +575,6 @@ def n_unique(column: str | Series) -> Expr | int:
     ╞═════╡
     │ 2   │
     └─────┘
-    >>> pl.n_unique(df["a"])
-    2
 
     """
     if isinstance(column, pl.Series):
@@ -675,8 +667,6 @@ def first(column: str | Series | None = None) -> Expr | Any:
     ╞═════╡
     │ 1   │
     └─────┘
-    >>> pl.first(df["a"])
-    1
 
     """
     if column is None:
@@ -743,8 +733,6 @@ def last(column: str | Series | None = None) -> Expr:
     ╞═════╡
     │ 3   │
     └─────┘
-    >>> pl.last(df["a"])
-    3
 
     """
     if column is None:
@@ -808,13 +796,6 @@ def head(column: str | Series, n: int = 10) -> Expr | Series:
     │ 1   │
     │ 8   │
     └─────┘
-    >>> pl.head(df["a"], 2)
-    shape: (2,)
-    Series: 'a' [i64]
-    [
-        1
-        8
-    ]
 
     """
     if isinstance(column, pl.Series):
@@ -872,13 +853,6 @@ def tail(column: str | Series, n: int = 10) -> Expr | Series:
     │ 8   │
     │ 3   │
     └─────┘
-    >>> pl.tail(df["a"], 2)
-    shape: (2,)
-    Series: 'a' [i64]
-    [
-        8
-        3
-    ]
 
     """
     if isinstance(column, pl.Series):

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import warnings
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, overload
 
@@ -26,6 +27,7 @@ from polars.utils.convert import (
     _time_to_pl_time,
     _timedelta_to_pl_timedelta,
 )
+from polars.utils.various import find_stacklevel
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -320,6 +322,11 @@ def count(column: str | Series | None = None) -> Expr | int:
         return wrap_expr(plr.count())
 
     if isinstance(column, pl.Series):
+        warnings.warn(
+            "passing a Series to `count` is deprecated. Use `Series.len()` instead.",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
         return column.len()
     return col(column).count()
 
@@ -377,6 +384,11 @@ def std(column: str | Series, ddof: int = 1) -> Expr | float | None:
 
     """
     if isinstance(column, pl.Series):
+        warnings.warn(
+            "passing a Series to `std` is deprecated. Use `Series.std()` instead.",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
         return column.std(ddof)
     return col(column).std(ddof)
 
@@ -421,6 +433,11 @@ def var(column: str | Series, ddof: int = 1) -> Expr | float | None:
 
     """
     if isinstance(column, pl.Series):
+        warnings.warn(
+            "passing a Series to `var` is deprecated. Use `Series.var()` instead.",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
         return column.var(ddof)
     return col(column).var(ddof)
 
@@ -456,6 +473,11 @@ def mean(column: str | Series) -> Expr | float | None:
 
     """
     if isinstance(column, pl.Series):
+        warnings.warn(
+            "passing a Series to `mean` is deprecated. Use `Series.mean()` instead.",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
         return column.mean()
     return col(column).mean()
 
@@ -524,6 +546,11 @@ def median(column: str | Series) -> Expr | float | int | None:
 
     """
     if isinstance(column, pl.Series):
+        warnings.warn(
+            "passing a Series to `median` is deprecated. Use `Series.median()` instead.",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
         return column.median()
     return col(column).median()
 
@@ -559,6 +586,11 @@ def n_unique(column: str | Series) -> Expr | int:
 
     """
     if isinstance(column, pl.Series):
+        warnings.warn(
+            "passing a Series to `n_unique` is deprecated. Use `Series.n_unique()` instead.",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
         return column.n_unique()
     return col(column).n_unique()
 
@@ -651,6 +683,11 @@ def first(column: str | Series | None = None) -> Expr | Any:
         return wrap_expr(plr.first())
 
     if isinstance(column, pl.Series):
+        warnings.warn(
+            "passing a Series to `first` is deprecated. Use `series[0]` instead.",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
         if column.len() > 0:
             return column[0]
         else:
@@ -714,6 +751,11 @@ def last(column: str | Series | None = None) -> Expr:
         return wrap_expr(plr.last())
 
     if isinstance(column, pl.Series):
+        warnings.warn(
+            "passing a Series to `last` is deprecated. Use `series[-1]` instead.",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
         if column.len() > 0:
             return column[-1]
         else:
@@ -776,6 +818,11 @@ def head(column: str | Series, n: int = 10) -> Expr | Series:
 
     """
     if isinstance(column, pl.Series):
+        warnings.warn(
+            "passing a Series to `head` is deprecated. Use `Series.head()` instead.",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
         return column.head(n)
     return col(column).head(n)
 
@@ -835,6 +882,11 @@ def tail(column: str | Series, n: int = 10) -> Expr | Series:
 
     """
     if isinstance(column, pl.Series):
+        warnings.warn(
+            "passing a Series to `tail` is deprecated. Use `Series.tail()` instead.",
+            DeprecationWarning,
+            stacklevel=find_stacklevel(),
+        )
         return column.tail(n)
     return col(column).tail(n)
 

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_concat_align() -> None:
@@ -375,7 +375,8 @@ def test_lazy_functions() -> None:
     df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
     out = df.select(pl.count("a"))
     assert list(out["a"]) == [3]
-    assert pl.count(df["a"]) == 3
+    with pytest.deprecated_call():
+        assert pl.count(df["a"]) == 3
     out = df.select(
         [
             pl.var("b").alias("1"),
@@ -392,10 +393,12 @@ def test_lazy_functions() -> None:
     )
     expected = 1.0
     assert np.isclose(out.to_series(0), expected)
-    assert np.isclose(pl.var(df["b"]), expected)  # type: ignore[arg-type]
+    with pytest.deprecated_call():
+        assert np.isclose(pl.var(df["b"]), expected)  # type: ignore[arg-type]
     expected = 1.0
     assert np.isclose(out.to_series(1), expected)
-    assert np.isclose(pl.std(df["b"]), expected)  # type: ignore[arg-type]
+    with pytest.deprecated_call():
+        assert np.isclose(pl.std(df["b"]), expected)  # type: ignore[arg-type]
     expected = 3
     assert np.isclose(out.to_series(2), expected)
     with pytest.deprecated_call():
@@ -410,19 +413,24 @@ def test_lazy_functions() -> None:
         assert np.isclose(pl.sum(df["b"]), expected)
     expected = 2
     assert np.isclose(out.to_series(5), expected)
-    assert np.isclose(pl.mean(df["b"]), expected)
+    with pytest.deprecated_call():
+        assert np.isclose(pl.mean(df["b"]), expected)
     expected = 2
     assert np.isclose(out.to_series(6), expected)
-    assert np.isclose(pl.median(df["b"]), expected)
+    with pytest.deprecated_call():
+        assert np.isclose(pl.median(df["b"]), expected)
     expected = 3
     assert np.isclose(out.to_series(7), expected)
-    assert np.isclose(pl.n_unique(df["b"]), expected)
+    with pytest.deprecated_call():
+        assert np.isclose(pl.n_unique(df["b"]), expected)
     expected = 1
     assert np.isclose(out.to_series(8), expected)
-    assert np.isclose(pl.first(df["b"]), expected)
+    with pytest.deprecated_call():
+        assert np.isclose(pl.first(df["b"]), expected)
     expected = 3
     assert np.isclose(out.to_series(9), expected)
-    assert np.isclose(pl.last(df["b"]), expected)
+    with pytest.deprecated_call():
+        assert np.isclose(pl.last(df["b"]), expected)
 
     # regex selection
     out = df.select(
@@ -435,3 +443,19 @@ def test_lazy_functions() -> None:
     assert out.rows() == [
         ({"a": "foo", "b": 3}, {"b": 1, "c": 1.0}, {"a": None, "c": 6.0})
     ]
+
+
+def test_head_tail(fruits_cars: pl.DataFrame) -> None:
+    res_expr = fruits_cars.select([pl.head("A", 2)])
+    with pytest.deprecated_call():
+        res_series = pl.head(fruits_cars["A"], 2)
+    expected = pl.Series("A", [1, 2])
+    assert_series_equal(res_expr.to_series(0), expected)
+    assert_series_equal(res_series, expected)
+
+    res_expr = fruits_cars.select([pl.tail("A", 2)])
+    with pytest.deprecated_call():
+        res_series = pl.tail(fruits_cars["A"], 2)
+    expected = pl.Series("A", [4, 5])
+    assert_series_equal(res_expr.to_series(0), expected)
+    assert_series_equal(res_series, expected)

--- a/py-polars/tests/unit/test_df.py
+++ b/py-polars/tests/unit/test_df.py
@@ -2967,20 +2967,6 @@ def test_fill_null_limits() -> None:
     }
 
 
-def test_head_tail(fruits_cars: pl.DataFrame) -> None:
-    res_expr = fruits_cars.select([pl.head("A", 2)])
-    res_series = pl.head(fruits_cars["A"], 2)
-    expected = pl.Series("A", [1, 2])
-    assert_series_equal(res_expr.to_series(0), expected)
-    assert_series_equal(res_series, expected)
-
-    res_expr = fruits_cars.select([pl.tail("A", 2)])
-    res_series = pl.tail(fruits_cars["A"], 2)
-    expected = pl.Series("A", [4, 5])
-    assert_series_equal(res_expr.to_series(0), expected)
-    assert_series_equal(res_series, expected)
-
-
 def test_lower_bound_upper_bound(fruits_cars: pl.DataFrame) -> None:
     res_expr = fruits_cars.select(pl.col("A").lower_bound())
     assert res_expr.item() == -9223372036854775808


### PR DESCRIPTION
Just like in https://github.com/pola-rs/polars/pull/9752

Changes:
* Deprecate the functionality for passing Series into `mean`, `head`, etc. Users should simply use Series.mean() and similar.