### PR TITLE
feat(rust, python): respect and allow more options in eager json parsing

### DIFF
--- a/polars/polars-core/src/schema.rs
+++ b/polars/polars-core/src/schema.rs
@@ -195,6 +195,13 @@ impl Schema {
             .ok_or_else(|| polars_err!(SchemaFieldNotFound: "{}", name))
     }
 
+    /// Get a mutable reference to the dtype of the field named `name`, or `Err(PolarsErr)` if the field doesn't exist
+    pub fn try_get_mut(&mut self, name: &str) -> PolarsResult<&mut DataType> {
+        self.inner
+            .get_mut(name)
+            .ok_or_else(|| polars_err!(SchemaFieldNotFound: "{}", name))
+    }
+
     /// Return all data about the field named `name`: its index in the schema, its name, and its dtype
     ///
     /// Returns `Some((index, &name, &dtype))` if the field exists, `None` if it doesn't.

--- a/polars/polars-io/src/json/mod.rs
+++ b/polars/polars-io/src/json/mod.rs
@@ -271,7 +271,7 @@ where
 {
     /// Set the JSON file's schema
     pub fn with_schema(mut self, schema: SchemaRef) -> Self {
-        self.schema = Some(schema.clone());
+        self.schema = Some(schema);
         self
     }
 

--- a/polars/polars-io/src/utils.rs
+++ b/polars/polars-io/src/utils.rs
@@ -106,6 +106,17 @@ pub(crate) fn update_row_counts2(dfs: &mut [DataFrame], offset: IdxSize) {
     }
 }
 
+#[cfg(feature = "json")]
+pub(crate) fn overwrite_schema(
+    schema: &mut Schema,
+    overwriting_schema: &Schema,
+) -> PolarsResult<()> {
+    for (k, value) in overwriting_schema.iter() {
+        *schema.try_get_mut(k)? = value.clone();
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;

--- a/polars/polars-lazy/src/physical_plan/executors/scan/ndjson.rs
+++ b/polars/polars-lazy/src/physical_plan/executors/scan/ndjson.rs
@@ -10,7 +10,7 @@ impl AnonymousScan for LazyJsonLineReader {
     fn scan(&self, scan_opts: AnonymousScanOptions) -> PolarsResult<DataFrame> {
         let schema = scan_opts.output_schema.unwrap_or(scan_opts.schema);
         JsonLineReader::from_path(&self.path)?
-            .with_schema(&schema)
+            .with_schema(schema)
             .with_rechunk(self.rechunk)
             .with_chunk_size(self.batch_size)
             .low_memory(self.low_memory)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -991,7 +991,12 @@ class DataFrame:
         return self
 
     @classmethod
-    def _read_json(cls, source: str | Path | IOBase | bytes) -> Self:
+    def _read_json(
+        cls,
+        source: str | Path | IOBase | bytes,
+        *,
+        schema: SchemaDefinition | None = None,
+    ) -> Self:
         """
         Read into a DataFrame from a JSON file.
 
@@ -1008,11 +1013,17 @@ class DataFrame:
             source = normalise_filepath(source)
 
         self = cls.__new__(cls)
-        self._df = PyDataFrame.read_json(source, False)
+        self._df = PyDataFrame.read_json(source, schema=schema)
         return self
 
     @classmethod
-    def _read_ndjson(cls, source: str | Path | IOBase | bytes) -> Self:
+    def _read_ndjson(
+        cls,
+        source: str | Path | IOBase | bytes,
+        *,
+        schema: SchemaDefinition | None = None,
+        ignore_errors: bool = False,
+    ) -> Self:
         """
         Read into a DataFrame from a newline delimited JSON file.
 
@@ -1029,7 +1040,9 @@ class DataFrame:
             source = normalise_filepath(source)
 
         self = cls.__new__(cls)
-        self._df = PyDataFrame.read_ndjson(source)
+        self._df = PyDataFrame.read_ndjson(
+            source, ignore_errors=ignore_errors, schema=schema
+        )
         return self
 
     @property

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -996,6 +996,7 @@ class DataFrame:
         source: str | Path | IOBase | bytes,
         *,
         schema: SchemaDefinition | None = None,
+        schema_overrides: SchemaDefinition | None = None,
     ) -> Self:
         """
         Read into a DataFrame from a JSON file.
@@ -1013,7 +1014,9 @@ class DataFrame:
             source = normalise_filepath(source)
 
         self = cls.__new__(cls)
-        self._df = PyDataFrame.read_json(source, schema=schema)
+        self._df = PyDataFrame.read_json(
+            source, schema=schema, schema_overrides=schema_overrides
+        )
         return self
 
     @classmethod
@@ -1022,6 +1025,7 @@ class DataFrame:
         source: str | Path | IOBase | bytes,
         *,
         schema: SchemaDefinition | None = None,
+        schema_overrides: SchemaDefinition | None = None,
         ignore_errors: bool = False,
     ) -> Self:
         """
@@ -1041,7 +1045,10 @@ class DataFrame:
 
         self = cls.__new__(cls)
         self._df = PyDataFrame.read_ndjson(
-            source, ignore_errors=ignore_errors, schema=schema
+            source,
+            ignore_errors=ignore_errors,
+            schema=schema,
+            schema_overrides=schema_overrides,
         )
         return self
 

--- a/py-polars/polars/io/json.py
+++ b/py-polars/polars/io/json.py
@@ -9,9 +9,14 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from polars import DataFrame
+    from polars.type_aliases import SchemaDefinition
 
 
-def read_json(source: str | Path | IOBase | bytes) -> DataFrame:
+def read_json(
+    source: str | Path | IOBase | bytes,
+    *,
+    schema: SchemaDefinition | None = None,
+) -> DataFrame:
     """
     Read into a DataFrame from a JSON file.
 
@@ -19,10 +24,20 @@ def read_json(source: str | Path | IOBase | bytes) -> DataFrame:
     ----------
     source
         Path to a file or a file-like object.
+    schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
+        The DataFrame schema may be declared in several ways:
+
+        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a list of column names; in this case types are automatically inferred.
+        * As a list of (name,type) pairs; this is equivalent to the dictionary form.
+
+        If you supply a list of column names that does not match the names in the
+        underlying data, the names given here will overwrite them. The number
+        of names given in the schema should match the underlying data dimensions.
 
     See Also
     --------
     read_ndjson
 
     """
-    return pl.DataFrame._read_json(source)
+    return pl.DataFrame._read_json(source, schema=schema)

--- a/py-polars/polars/io/json.py
+++ b/py-polars/polars/io/json.py
@@ -16,6 +16,7 @@ def read_json(
     source: str | Path | IOBase | bytes,
     *,
     schema: SchemaDefinition | None = None,
+    schema_overrides: SchemaDefinition | None = None,
 ) -> DataFrame:
     """
     Read into a DataFrame from a JSON file.
@@ -34,10 +35,16 @@ def read_json(
         If you supply a list of column names that does not match the names in the
         underlying data, the names given here will overwrite them. The number
         of names given in the schema should match the underlying data dimensions.
+    schema_overrides : dict, default None
+        Support type specification or override of one or more columns; note that
+        any dtypes inferred from the schema param will be overridden.
+        underlying data, the names given here will overwrite them.
 
     See Also
     --------
     read_ndjson
 
     """
-    return pl.DataFrame._read_json(source, schema=schema)
+    return pl.DataFrame._read_json(
+        source, schema=schema, schema_overrides=schema_overrides
+    )

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -11,9 +11,15 @@ if TYPE_CHECKING:
     from io import IOBase
 
     from polars import DataFrame, LazyFrame
+    from polars.type_aliases import SchemaDefinition
 
 
-def read_ndjson(source: str | Path | IOBase | bytes) -> DataFrame:
+def read_ndjson(
+    source: str | Path | IOBase | bytes,
+    *,
+    schema: SchemaDefinition | None = None,
+    ignore_errors: bool = False,
+) -> DataFrame:
     """
     Read into a DataFrame from a newline delimited JSON file.
 
@@ -21,9 +27,21 @@ def read_ndjson(source: str | Path | IOBase | bytes) -> DataFrame:
     ----------
     source
         Path to a file or a file-like object.
+    schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
+        The DataFrame schema may be declared in several ways:
+
+        * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
+        * As a list of column names; in this case types are automatically inferred.
+        * As a list of (name,type) pairs; this is equivalent to the dictionary form.
+
+        If you supply a list of column names that does not match the names in the
+        underlying data, the names given here will overwrite them. The number
+        of names given in the schema should match the underlying data dimensions.
+    ignore_errors
+        Return `Null` if parsing fails because of schema mismatches.
 
     """
-    return pl.DataFrame._read_ndjson(source)
+    return pl.DataFrame._read_ndjson(source, schema=schema, ignore_errors=ignore_errors)
 
 
 def scan_ndjson(

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -18,6 +18,7 @@ def read_ndjson(
     source: str | Path | IOBase | bytes,
     *,
     schema: SchemaDefinition | None = None,
+    schema_overrides: SchemaDefinition | None = None,
     ignore_errors: bool = False,
 ) -> DataFrame:
     """
@@ -37,11 +38,20 @@ def read_ndjson(
         If you supply a list of column names that does not match the names in the
         underlying data, the names given here will overwrite them. The number
         of names given in the schema should match the underlying data dimensions.
+    schema_overrides : dict, default None
+        Support type specification or override of one or more columns; note that
+        any dtypes inferred from the schema param will be overridden.
+        underlying data, the names given here will overwrite them.
     ignore_errors
         Return `Null` if parsing fails because of schema mismatches.
 
     """
-    return pl.DataFrame._read_ndjson(source, schema=schema, ignore_errors=ignore_errors)
+    return pl.DataFrame._read_ndjson(
+        source,
+        schema=schema,
+        schema_overrides=schema_overrides,
+        ignore_errors=ignore_errors,
+    )
 
 
 def scan_ndjson(

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -351,41 +351,38 @@ impl PyDataFrame {
 
     #[staticmethod]
     #[cfg(feature = "json")]
-    pub fn read_json(py_f: &PyAny, json_lines: bool) -> PyResult<Self> {
+    pub fn read_json(py_f: &PyAny, schema: Option<Wrap<Schema>>) -> PyResult<Self> {
+        // memmap the file first
         let mmap_bytes_r = get_mmap_bytes_reader(py_f)?;
-        if json_lines {
-            let out = JsonReader::new(mmap_bytes_r)
-                .with_json_format(JsonFormat::JsonLines)
-                .finish()
-                .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
-            Ok(out.into())
-        } else {
-            // memmap the file first
-            let mmap_bytes_r = get_mmap_bytes_reader(py_f)?;
-            let mmap_read: ReaderBytes = (&mmap_bytes_r).into();
-            let bytes = mmap_read.deref();
+        let mmap_read: ReaderBytes = (&mmap_bytes_r).into();
+        let bytes = mmap_read.deref();
 
-            // Happy path is our column oriented json as that is most performant
-            // on failure we try
-            match serde_json::from_slice::<DataFrame>(bytes) {
-                Ok(df) => Ok(df.into()),
-                Err(e) => {
-                    let msg = format!("{e}");
-                    // parsing succeeded, but the dataframe was invalid
-                    if msg.contains("successful parse invalid data") {
-                        let e = PyPolarsErr::from(PolarsError::ComputeError(msg.into()));
-                        Err(PyErr::from(e))
+        // Happy path is our column oriented json as that is most performant
+        // on failure we try
+        match serde_json::from_slice::<DataFrame>(bytes) {
+            Ok(df) => Ok(df.into()),
+            Err(e) => {
+                let msg = format!("{e}");
+                // parsing succeeded, but the dataframe was invalid
+                if msg.contains("successful parse invalid data") {
+                    let e = PyPolarsErr::from(PolarsError::ComputeError(msg.into()));
+                    Err(PyErr::from(e))
+                }
+                // parsing error
+                // try arrow json reader instead
+                // this is row oriented
+                else {
+                    let mut builder =
+                        JsonReader::new(mmap_bytes_r).with_json_format(JsonFormat::Json);
+
+                    if let Some(schema) = schema {
+                        builder = builder.with_schema(Arc::new(schema.0));
                     }
-                    // parsing error
-                    // try arrow json reader instead
-                    // this is row oriented
-                    else {
-                        let out = JsonReader::new(mmap_bytes_r)
-                            .with_json_format(JsonFormat::Json)
-                            .finish()
-                            .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
-                        Ok(out.into())
-                    }
+
+                    let out = builder
+                        .finish()
+                        .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
+                    Ok(out.into())
                 }
             }
         }
@@ -393,11 +390,22 @@ impl PyDataFrame {
 
     #[staticmethod]
     #[cfg(feature = "json")]
-    pub fn read_ndjson(py_f: &PyAny) -> PyResult<Self> {
+    pub fn read_ndjson(
+        py_f: &PyAny,
+        ignore_errors: bool,
+        schema: Option<Wrap<Schema>>,
+    ) -> PyResult<Self> {
         let mmap_bytes_r = get_mmap_bytes_reader(py_f)?;
 
-        let out = JsonReader::new(mmap_bytes_r)
+        let mut builder = JsonReader::new(mmap_bytes_r)
             .with_json_format(JsonFormat::JsonLines)
+            .with_ignore_errors(ignore_errors);
+
+        if let Some(schema) = schema {
+            builder = builder.with_schema(Arc::new(schema.0));
+        }
+
+        let out = builder
             .finish()
             .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
         Ok(out.into())

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -152,3 +152,38 @@ def test_json_deserialize_9687() -> None:
     result = pl.read_json(json.dumps(response).encode())
 
     assert result.to_dict(False) == {k: [v] for k, v in response.items()}
+
+
+def test_ndjson_ignore_errors() -> None:
+    # this schema is inconsistent as "value" is string and object
+    jsonl = r"""{"Type":"insert","Key":[1],"SeqNo":1,"Timestamp":1,"Fields":[{"Name":"added_id","Value":2},{"Name":"body","Value":{"a": 1}}]}
+    {"Type":"insert","Key":[1],"SeqNo":1,"Timestamp":1,"Fields":[{"Name":"added_id","Value":2},{"Name":"body","Value":{"a": 1}}]}"""
+
+    buf = io.BytesIO(jsonl.encode())
+
+    # check if we can replace with nulls
+    assert pl.read_ndjson(buf, ignore_errors=True).to_dict(False) == {
+        "Type": ["insert", "insert"],
+        "Key": [[1], [1]],
+        "SeqNo": [1, 1],
+        "Timestamp": [1, 1],
+        "Fields": [
+            [{"Name": "added_id", "Value": "2"}, {"Name": "body", "Value": None}],
+            [{"Name": "added_id", "Value": "2"}, {"Name": "body", "Value": None}],
+        ],
+    }
+
+    # checks if we can overwrite object schemas
+    # this doesn't yet work for primitive types
+    assert pl.read_ndjson(
+        buf,
+        schema={
+            "Fields": pl.List(
+                pl.Struct([pl.Field("Name", pl.Utf8), pl.Field("Value", pl.Int64)])
+            )
+        },
+        ignore_errors=True,
+    )["Fields"].to_list() == [
+        [{"Name": "added_id", "Value": 2}, {"Name": "body", "Value": None}],
+        [{"Name": "added_id", "Value": 2}, {"Name": "body", "Value": None}],
+    ]


### PR DESCRIPTION
Accept a `schema` and `schema_override` argument and an option to return `null` on failure. 

#9733