### PR TITLE
feat(rust): access `OptState` in `LazyFrame` to unit-test optimization toggle methods.

### DIFF
--- a/polars/polars-lazy/polars-plan/src/frame/opt_state.rs
+++ b/polars/polars-lazy/polars-plan/src/frame/opt_state.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 /// State of the allowed optimizations
 pub struct OptState {
     pub projection_pushdown: bool,

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -99,7 +99,7 @@ impl LazyFrame {
         LogicalPlanBuilder::from(self.logical_plan)
     }
 
-    fn get_opt_state(&self) -> OptState {
+    pub fn get_opt_state(&self) -> OptState {
         self.opt_state
     }
 
@@ -108,6 +108,11 @@ impl LazyFrame {
             logical_plan,
             opt_state,
         }
+    }
+
+    /// Get current optimizations
+    pub fn get_current_optimizations(&self) -> OptState {
+        self.opt_state
     }
 
     /// Set allowed optimizations

--- a/polars/polars-lazy/src/frame/mod.rs
+++ b/polars/polars-lazy/src/frame/mod.rs
@@ -99,7 +99,7 @@ impl LazyFrame {
         LogicalPlanBuilder::from(self.logical_plan)
     }
 
-    pub fn get_opt_state(&self) -> OptState {
+    fn get_opt_state(&self) -> OptState {
         self.opt_state
     }
 


### PR DESCRIPTION
rust-polars `LazyFrame` is wrapped in e.g. py-polars r-polars nodejs-polars and many other rust projects. 
It is difficult to unit-test optimizations switches in `OptState` are set right, because there is no public getter-method.
Setting such states [has had a bug in the past](https://github.com/pola-rs/polars/pull/8617).

With `get_current_optimizations()` in rust-polars, it is straight forward to unit-test optimization choices.

If PR is OK I can also add unit-tests for py-polars