### PR TITLE
feat(python): add `INITCAP` string function for SQL

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -182,6 +182,11 @@ pub(crate) enum PolarsSqlFunctions {
     /// SELECT column_2 from df WHERE ENDS_WITH(column_1, 'a');
     /// ```
     EndsWith,
+    /// SQL 'initcap' function
+    /// ```sql
+    /// SELECT INITCAP(column_1) from df;
+    /// ```
+    InitCap,
     /// SQL 'left' function
     /// ```sql
     /// SELECT LEFT(column_1, 3) from df;
@@ -499,6 +504,7 @@ impl PolarsSqlFunctions {
             // String functions
             // ----
             "ends_with" => Self::EndsWith,
+            "initcap" => Self::InitCap,
             "length" => Self::Length,
             "left" => Self::Left,
             "lower" => Self::Lower,
@@ -616,6 +622,7 @@ impl SqlFunctionVisitor<'_> {
             // String functions
             // ----
             EndsWith => self.visit_binary(|e, s| e.str().ends_with(s)),
+            InitCap => self.visit_unary(|e| e.str().to_titlecase()),
             Left => self.try_visit_binary(|e, length| {
                 Ok(e.str().str_slice(0, match length {
                     Expr::Literal(LiteralValue::Int64(n)) => Some(n as u64),

--- a/py-polars/tests/unit/sql/test_sql.py
+++ b/py-polars/tests/unit/sql/test_sql.py
@@ -750,6 +750,29 @@ def test_sql_round_ndigits_errors() -> None:
         ctx.execute("SELECT ROUND(n,-1) AS n FROM df")
 
 
+def test_sql_string_case() -> None:
+    df = pl.DataFrame({"words": ["Test SOME words"]})
+
+    with pl.SQLContext(frame=df) as ctx:
+        res = ctx.execute(
+            """
+            SELECT
+              words,
+              INITCAP(words) as cap,
+              UPPER(words) as upper,
+              LOWER(words) as lower,
+            FROM frame
+            """
+        ).collect()
+
+        assert res.to_dict(False) == {
+            "words": ["Test SOME words"],
+            "cap": ["Test Some Words"],
+            "upper": ["TEST SOME WORDS"],
+            "lower": ["test some words"],
+        }
+
+
 def test_sql_string_lengths() -> None:
     df = pl.DataFrame({"words": ["Café", None, "東京"]})
 


### PR DESCRIPTION
Adds support for the SQL equivalent of `to_titlecase` (to which this maps).

## Example

```python
import polars as pl
df = pl.DataFrame( { "words": ["Test SOME words"] } )

with pl.SQLContext( frame=df ) as ctx:
    res = ctx.execute(
        """
        SELECT
          words,
          INITCAP(words) as cap,
          UPPER(words) as upper,
          LOWER(words) as lower,
        FROM frame
        """
    ).collect()
    
# shape: (1, 4)
# ┌─────────────────┬─────────────────┬─────────────────┬─────────────────┐
# │ words           ┆ cap             ┆ upper           ┆ lower           │
# │ ---             ┆ ---             ┆ ---             ┆ ---             │
# │ str             ┆ str             ┆ str             ┆ str             │
# ╞═════════════════╪═════════════════╪═════════════════╪═════════════════╡
# │ Test SOME words ┆ Test Some Words ┆ TEST SOME WORDS ┆ test some words │
# └─────────────────┴─────────────────┴─────────────────┴─────────────────┘
```