### PR TITLE
chore(python): Update autolabeler

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,8 +1,10 @@
 categories:
   - title: 🏆 Highlights
     labels: highlight
-  - title: ⚠️ Breaking changes
+  - title: 💥 Breaking changes
     labels: breaking
+  - title: ⚠️ Deprecations
+    labels: deprecation
   - title: 🚀 Performance improvements
     labels: performance
   - title: ✨ Enhancements
@@ -28,7 +30,7 @@ change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&'
 replacers:
   # Remove conventional commits from titles
-  - search: '/- (build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)(\(.*\))?(\!)?\: /g'
+  - search: '/- (build|chore|ci|depr|docs|feat|fix|perf|refactor|release|revert|style|test)(\(.*\))?(\!)?\: /g'
     replace: '- '
 
 version-resolver:
@@ -39,13 +41,13 @@ version-resolver:
 autolabeler:
   - label: rust
     title:
-      - '/^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)\(.*rust.*\)/'
+      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|revert|style|test)\(.*rust.*\)/'
   - label: python
     title:
-      - '/^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)\(.*python.*\)/'
+      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|revert|style|test)\(.*python.*\)/'
   - label: breaking
     title:
-      - '/^(build|chore|ci|docs|feat|fix|perf|refactor|release|revert|style|test)(\(.*\))?\!\: /'
+      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|revert|style|test)(\(.*\))?\!\: /'
   - label: build
     title:
       - '/^build/'
@@ -55,6 +57,9 @@ autolabeler:
   - label: ci
     title:
       - '/^ci/'
+  - label: deprecation
+    title:
+      - '/^depr/'
   - label: documentation
     title:
       - '/^docs/'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -14,8 +14,8 @@ categories:
   - title: 🛠️ Other improvements
     labels:
       - build
-      - chore
       - documentation
+      - internal
 
 exclude-labels:
   - skip-changelog
@@ -49,7 +49,7 @@ autolabeler:
   - label: build
     title:
       - '/^build/'
-  - label: chore
+  - label: internal
     title:
       - '/^chore/'
   - label: deprecation

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -15,12 +15,7 @@ categories:
     labels:
       - build
       - chore
-      - ci
       - documentation
-      - refactor
-      - revert
-      - style
-      - test
 
 exclude-labels:
   - skip-changelog
@@ -30,7 +25,7 @@ change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&'
 replacers:
   # Remove conventional commits from titles
-  - search: '/- (build|chore|ci|depr|docs|feat|fix|perf|refactor|release|revert|style|test)(\(.*\))?(\!)?\: /g'
+  - search: '/- (build|chore|depr|docs|feat|fix|perf|release)(\(.*\))?(\!)?\: /g'
     replace: '- '
 
 version-resolver:
@@ -41,22 +36,19 @@ version-resolver:
 autolabeler:
   - label: rust
     title:
-      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|revert|style|test)\(.*rust.*\)/'
+      - '/^(build|chore|depr|docs|feat|fix|perf|release)\(.*rust.*\)/'
   - label: python
     title:
-      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|revert|style|test)\(.*python.*\)/'
+      - '/^(build|chore|depr|docs|feat|fix|perf|release)\(.*python.*\)/'
   - label: breaking
     title:
-      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|revert|style|test)(\(.*\))?\!\: /'
+      - '/^(build|chore|depr|docs|feat|fix|perf|release)(\(.*\))?\!\: /'
   - label: build
     title:
       - '/^build/'
   - label: chore
     title:
       - '/^chore/'
-  - label: ci
-    title:
-      - '/^ci/'
   - label: deprecation
     title:
       - '/^depr/'
@@ -72,21 +64,9 @@ autolabeler:
   - label: performance
     title:
       - '/^perf/'
-  - label: refactor
-    title:
-      - '/^refactor/'
   - label: release
     title:
       - '/^release/'
-  - label: revert
-    title:
-      - '/^revert/'
-  - label: style
-    title:
-      - '/^style/'
-  - label: test
-    title:
-      - '/^test/'
 
 template: |
   $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -36,13 +36,13 @@ version-resolver:
 autolabeler:
   - label: rust
     title:
-      - '/^(build|chore|depr|docs|feat|fix|perf|release)\(.*rust.*\)/'
+      - '/^(build|chore|depr|docs|feat|fix|perf|release)(\(.*rust.*\))?\!?\:) /'
   - label: python
     title:
-      - '/^(build|chore|depr|docs|feat|fix|perf|release)\(.*python.*\)/'
+      - '/^(build|chore|depr|docs|feat|fix|perf|release)(\(.*python.*\))?\!?\:) /'
   - label: cli
     title:
-      - '/^(build|chore|depr|docs|feat|fix|perf|release)\(.*cli.*\)/'
+      - '/^(build|chore|depr|docs|feat|fix|perf|release)(\(.*cli.*\))?\!?\:) /'
   - label: breaking
     title:
       - '/^(build|chore|depr|docs|feat|fix|perf|release)(\(.*\))?\!\: /'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -42,7 +42,7 @@ autolabeler:
       - '/^(build|chore|depr|docs|feat|fix|perf|release)(\(.*python.*\))?\!?\:) /'
   - label: cli
     title:
-      - '/^(build|chore|depr|docs|feat|fix|perf|release)(\(.*cli.*\))?\!?\:) /'
+      - '/^(build|chore|depr|docs|feat|fix|perf|release)\(.*cli.*\)\!?\:) /'  # CLI tag not in global scope
   - label: breaking
     title:
       - '/^(build|chore|depr|docs|feat|fix|perf|release)(\(.*\))?\!\: /'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -40,6 +40,9 @@ autolabeler:
   - label: python
     title:
       - '/^(build|chore|depr|docs|feat|fix|perf|release)\(.*python.*\)/'
+  - label: cli
+    title:
+      - '/^(build|chore|depr|docs|feat|fix|perf|release)\(.*cli.*\)/'
   - label: breaking
     title:
       - '/^(build|chore|depr|docs|feat|fix|perf|release)(\(.*\))?\!\: /'


### PR DESCRIPTION
Changes:
* Add the `cli` scope. If you add this scope, it will get the `cli` label. Example:
  * `fix(cli): Fix thing` -> gets the `cli` label
* Add a 'global scope' - if you do not specify a scope, it will automatically get the `rust` and `python` labels. Note that the `cli` scope is not included. Example:
  * `feat: Cool new thing` -> gets the `rust` and `python` labels
* Add the `depr` label. Deprecations now get their own section in the changelog. Tag your PR with `depr` to add the `deprecation` tag. Example:
  * `depr(python): Thing is now deprecated` -> gets the `deprecation` label
* Removed the `ci`, `refactor`, `revert`, `style`, and `test` tags. These are all internal improvements and can be tagged with `chore`. They will get the label `internal`.
  * `ci(python): Improve lint workflow` -> rewrite as `chore(python): Improve CI lint workflow` -> gets the label `internal`

Some notes:
* I considered adding a SQL scope, but I decided against it. It's just a type of functionality, not a scope. We also don't have a `lazy` scope or a `io` scope. Add the `sql` label to your PR manually if you so please.
* To be honest, the `cli` feels misplaced in this repo. I added the scope for now, but I think it makes more sense to have it in a separate repo. Or to release it along with the other Rust crates. I'll think on this some more and post in https://github.com/pola-rs/polars/issues/8772 .

Let's hope I didn't mess up my regex 😅 