### PR TITLE
chore(python): Set Ruff docstyle

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2020,7 +2020,7 @@ class DataFrame:
 
         return out
 
-    def to_pandas(  # noqa: D417
+    def to_pandas(
         self,
         *args: Any,
         use_pyarrow_extension_array: bool = False,

--- a/py-polars/polars/io/ipc/anonymous_scan.py
+++ b/py-polars/polars/io/ipc/anonymous_scan.py
@@ -26,7 +26,7 @@ def _scan_ipc_fsspec(
     return pl.LazyFrame._scan_python_function(schema, func_serialized)
 
 
-def _scan_ipc_impl(  # noqa: D417
+def _scan_ipc_impl(
     source: str,
     columns: list[str] | None,
     predicate: str | None,

--- a/py-polars/polars/io/parquet/anonymous_scan.py
+++ b/py-polars/polars/io/parquet/anonymous_scan.py
@@ -26,7 +26,7 @@ def _scan_parquet_fsspec(
     return pl.LazyFrame._scan_python_function(schema, func_serialized)
 
 
-def _scan_parquet_impl(  # noqa: D417
+def _scan_parquet_impl(
     source: str,
     columns: list[str] | None,
     predicate: str | None,

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3605,7 +3605,7 @@ class Series:
         """
         return self._s.to_arrow()
 
-    def to_pandas(  # noqa: D417
+    def to_pandas(
         self, *args: Any, use_pyarrow_extension_array: bool = False, **kwargs: Any
     ) -> pd.Series[Any]:
         """

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -139,7 +139,7 @@ ignore = [
   "D102",
   "D104",
   "D101",
-  "D401",  # First line of docstring should be in imperative mood
+  "D401", # First line of docstring should be in imperative mood
 ]
 
 [tool.ruff.pycodestyle]

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -124,22 +124,13 @@ select = [
 ignore = [
   # Line length regulated by black
   "E501",
-  # pydocstyle: http://www.pydocstyle.org/en/stable/error_codes.html
-  # numpy convention with a few additional lints
-  "D107",
-  "D203",
-  "D212",
-  "D401",
-  "D402",
-  "D415",
-  "D416",
   # flake8-pytest-style:
   "PT011", # pytest.raises({exception}) is too broad, set the match parameter or use a more specific exception
   # flake8-simplify
   "SIM102", # Use a single `if` statement instead of nested `if` statements
   # ruff
   "RUF005", # unpack-instead-of-concatenating-to-collection-literal
-  # pycodestyle
+  # pydocstyle
   # TODO: Remove errors below to further improve docstring linting
   # Ordered from most common to least common errors.
   "D105",
@@ -148,10 +139,14 @@ ignore = [
   "D102",
   "D104",
   "D101",
+  "D401",  # First line of docstring should be in imperative mood
 ]
 
 [tool.ruff.pycodestyle]
 max-doc-length = 88
+
+[tool.ruff.pydocstyle]
+convention = "numpy"
 
 [tool.ruff.flake8-tidy-imports]
 ban-relative-imports = "all"


### PR DESCRIPTION
See https://beta.ruff.rs/docs/faq/#does-ruff-support-numpy-or-google-style-docstrings. Turns off automatically the irrelevant rules, so we can clean up the ignore list. We satisfy all except D401.