### PR TITLE
fix(python): Handle `DataFrame.vstack` stacking itself

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2358,12 +2358,12 @@ class Series:
                 self._s.append(other._s)
             else:
                 self._s.extend(other._s)
+            return self
         except RuntimeError as exc:
             if str(exc) == "Already mutably borrowed":
-                self.append(other.clone(), append_chunks=append_chunks)
+                return self.append(other.clone(), append_chunks=append_chunks)
             else:
                 raise exc
-        return self
 
     def filter(self, predicate: Series | list[bool]) -> Self:
         """

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -940,31 +940,31 @@ impl PyDataFrame {
         self.df.width()
     }
 
-    pub fn hstack_mut(&mut self, columns: Vec<PySeries>) -> PyResult<()> {
-        let columns = columns.to_series();
-        self.df.hstack_mut(&columns).map_err(PyPolarsErr::from)?;
-        Ok(())
-    }
-
     pub fn hstack(&self, columns: Vec<PySeries>) -> PyResult<Self> {
         let columns = columns.to_series();
         let df = self.df.hstack(&columns).map_err(PyPolarsErr::from)?;
         Ok(df.into())
     }
 
-    pub fn extend(&mut self, df: &PyDataFrame) -> PyResult<()> {
-        self.df.extend(&df.df).map_err(PyPolarsErr::from)?;
+    pub fn hstack_mut(&mut self, columns: Vec<PySeries>) -> PyResult<()> {
+        let columns = columns.to_series();
+        self.df.hstack_mut(&columns).map_err(PyPolarsErr::from)?;
         Ok(())
     }
 
-    pub fn vstack_mut(&mut self, df: &PyDataFrame) -> PyResult<()> {
-        self.df.vstack_mut(&df.df).map_err(PyPolarsErr::from)?;
-        Ok(())
-    }
-
-    pub fn vstack(&mut self, df: &PyDataFrame) -> PyResult<Self> {
-        let df = self.df.vstack(&df.df).map_err(PyPolarsErr::from)?;
+    pub fn vstack(&self, other: &PyDataFrame) -> PyResult<Self> {
+        let df = self.df.vstack(&other.df).map_err(PyPolarsErr::from)?;
         Ok(df.into())
+    }
+
+    pub fn vstack_mut(&mut self, other: &PyDataFrame) -> PyResult<()> {
+        self.df.vstack_mut(&other.df).map_err(PyPolarsErr::from)?;
+        Ok(())
+    }
+
+    pub fn extend(&mut self, other: &PyDataFrame) -> PyResult<()> {
+        self.df.extend(&other.df).map_err(PyPolarsErr::from)?;
+        Ok(())
     }
 
     pub fn drop_in_place(&mut self, name: &str) -> PyResult<PySeries> {

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -704,22 +704,6 @@ def test_hstack_dataframe(in_place: bool) -> None:
         assert_frame_equal(df_out, expected)
 
 
-@pytest.mark.parametrize("in_place", [True, False])
-def test_vstack(in_place: bool) -> None:
-    df1 = pl.DataFrame({"foo": [1, 2], "bar": [6, 7], "ham": ["a", "b"]})
-    df2 = pl.DataFrame({"foo": [3, 4], "bar": [8, 9], "ham": ["c", "d"]})
-
-    expected = pl.DataFrame(
-        {"foo": [1, 2, 3, 4], "bar": [6, 7, 8, 9], "ham": ["a", "b", "c", "d"]}
-    )
-
-    out = df1.vstack(df2, in_place=in_place)
-    if in_place:
-        assert_frame_equal(df1, expected)
-    else:
-        assert_frame_equal(out, expected)
-
-
 def test_extend() -> None:
     with pl.StringCache():
         df1 = pl.DataFrame(

--- a/py-polars/tests/unit/dataframe/test_vstack.py
+++ b/py-polars/tests/unit/dataframe/test_vstack.py
@@ -23,7 +23,7 @@ def test_vstack(df1: pl.DataFrame, df2: pl.DataFrame) -> None:
 
 
 def test_vstack_in_place(df1: pl.DataFrame, df2: pl.DataFrame) -> None:
-    df1.vstack(df2)
+    df1.vstack(df2, in_place=True)
     expected = pl.DataFrame(
         {"foo": [1, 2, 3, 4], "bar": [6, 7, 8, 9], "ham": ["a", "b", "c", "d"]}
     )
@@ -39,7 +39,7 @@ def test_vstack_self(df1: pl.DataFrame) -> None:
 
 
 def test_vstack_self_in_place(df1: pl.DataFrame) -> None:
-    df1.vstack(df1)
+    df1.vstack(df1, in_place=True)
     expected = pl.DataFrame(
         {"foo": [1, 2, 1, 2], "bar": [6, 7, 6, 7], "ham": ["a", "b", "a", "b"]}
     )

--- a/py-polars/tests/unit/dataframe/test_vstack.py
+++ b/py-polars/tests/unit/dataframe/test_vstack.py
@@ -1,0 +1,46 @@
+import pytest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+
+@pytest.fixture()
+def df1() -> pl.DataFrame:
+    return pl.DataFrame({"foo": [1, 2], "bar": [6, 7], "ham": ["a", "b"]})
+
+
+@pytest.fixture()
+def df2() -> pl.DataFrame:
+    return pl.DataFrame({"foo": [3, 4], "bar": [8, 9], "ham": ["c", "d"]})
+
+
+def test_vstack(df1: pl.DataFrame, df2: pl.DataFrame) -> None:
+    result = df1.vstack(df2)
+    expected = pl.DataFrame(
+        {"foo": [1, 2, 3, 4], "bar": [6, 7, 8, 9], "ham": ["a", "b", "c", "d"]}
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_vstack_in_place(df1: pl.DataFrame, df2: pl.DataFrame) -> None:
+    df1.vstack(df2)
+    expected = pl.DataFrame(
+        {"foo": [1, 2, 3, 4], "bar": [6, 7, 8, 9], "ham": ["a", "b", "c", "d"]}
+    )
+    assert_frame_equal(df1, expected)
+
+
+def test_vstack_self(df1: pl.DataFrame) -> None:
+    result = df1.vstack(df1)
+    expected = pl.DataFrame(
+        {"foo": [1, 2, 1, 2], "bar": [6, 7, 6, 7], "ham": ["a", "b", "a", "b"]}
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_vstack_self_in_place(df1: pl.DataFrame) -> None:
+    df1.vstack(df1)
+    expected = pl.DataFrame(
+        {"foo": [1, 2, 1, 2], "bar": [6, 7, 6, 7], "ham": ["a", "b", "a", "b"]}
+    )
+    assert_frame_equal(df1, expected)

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1099,7 +1099,7 @@ def test_lazy_concat(df: pl.DataFrame) -> None:
 
     out = pl.concat([df.lazy(), df.lazy()]).collect()
     assert out.shape == shape
-    assert_frame_equal(out, df.vstack(df.clone()))
+    assert_frame_equal(out, df.vstack(df))
 
 
 def test_self_join() -> None:


### PR DESCRIPTION
Doing `df.vstack(df)` would lead to a mysterious "RuntimeError: Already mutably borrowed". This handles it nicely.

Changes:
* Remove the mutability requirement from regular `vstack`. This is not required as there is a `clone` on the Rust implementation. This now allows `df.vstack(df)` without problems.
* Added a try/catch for the in-place variant. If we get the "already mutably borrowed" message, we add a `.clone()` on the input. This is the same strategy as employed in `Series.append`. _(An alternative strategy would be to throw a better error message here.)_
* Renamed the input parameter `df` to `other`, to be more consistent with similar methods.