### PR TITLE
docs(python): Address ignored Ruff doc rules

### DIFF
--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -235,14 +235,14 @@ def _minify_classpaths(s: str) -> str:
     )
 
 
-def process_signature(app, what, name, obj, opts, sig, ret):
+def process_signature(app, what, name, obj, opts, sig, ret):  # noqa: D103
     return (
         _minify_classpaths(sig) if sig else sig,
         _minify_classpaths(ret) if ret else ret,
     )
 
 
-def setup(app):
+def setup(app):  # noqa: D103
     # TODO: a handful of methods do not seem to trigger the event for
     #  some reason (possibly @overloads?) - investigate further...
     app.connect("autodoc-process-signature", process_signature)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3306,9 +3306,9 @@ class DataFrame:
         ... )  # doctest: +SKIP
 
         """
-        from polars.io.delta import check_if_delta_available, resolve_delta_lake_uri
+        from polars.io.delta import _check_if_delta_available, _resolve_delta_lake_uri
 
-        check_if_delta_available()
+        _check_if_delta_available()
 
         from deltalake.writer import (
             try_get_deltatable,
@@ -3319,7 +3319,7 @@ class DataFrame:
             delta_write_options = {}
 
         if isinstance(target, (str, Path)):
-            target = resolve_delta_lake_uri(str(target), strict=False)
+            target = _resolve_delta_lake_uri(str(target), strict=False)
 
         unsupported_cols = {}
         unsupported_types = [Time, Categorical, Null]

--- a/py-polars/polars/dataframe/groupby.py
+++ b/py-polars/polars/dataframe/groupby.py
@@ -845,6 +845,19 @@ class RollingGroupBy:
         *aggs: IntoExpr | Iterable[IntoExpr],
         **named_aggs: IntoExpr,
     ) -> DataFrame:
+        """
+        Compute aggregations for each group of a groupby operation.
+
+        Parameters
+        ----------
+        *aggs
+            Aggregations to compute for each group of the groupby operation,
+            specified as positional arguments.
+            Accepts expression input. Strings are parsed as column names.
+        **named_aggs
+            Additional aggregations, specified as keyword arguments.
+            The resulting columns will be renamed to the keyword used.
+        """
         return (
             self.df.lazy()
             .groupby_rolling(
@@ -1046,6 +1059,19 @@ class DynamicGroupBy:
         *aggs: IntoExpr | Iterable[IntoExpr],
         **named_aggs: IntoExpr,
     ) -> DataFrame:
+        """
+        Compute aggregations for each group of a groupby operation.
+
+        Parameters
+        ----------
+        *aggs
+            Aggregations to compute for each group of the groupby operation,
+            specified as positional arguments.
+            Accepts expression input. Strings are parsed as column names.
+        **named_aggs
+            Additional aggregations, specified as keyword arguments.
+            The resulting columns will be renamed to the keyword used.
+        """
         return (
             self.df.lazy()
             .groupby_dynamic(

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -186,7 +186,7 @@ class DataTypeGroup(frozenset):  # type: ignore[type-arg]
                 raise TypeError(
                     f"DataTypeGroup items must be dtypes; found {type(it).__name__!r}"
                 )
-        dtype_group = super().__new__(cls, items)
+        dtype_group = super().__new__(cls, items)  # type: ignore[arg-type]
         dtype_group._match_base_type = match_base_type
         return dtype_group
 

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 from datetime import timezone
 from inspect import isclass
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Mapping, Sequence
 
 import polars.datatypes
 
@@ -31,7 +31,7 @@ class classproperty:
     def __get__(self, instance: Any, cls: type | None = None) -> Any:
         return self.fget(cls)  # type: ignore[misc]
 
-    def getter(self, method: Callable[..., Any]) -> Any:
+    def getter(self, method: Callable[..., Any]) -> Any:  # noqa: D102
         self.fget = method
         return self
 
@@ -46,25 +46,29 @@ class DataTypeClass(type):
         return _dtype_str_repr(cls)
 
     def base_type(cls) -> PolarsDataType:
+        """Return the base type."""
         return cls
 
     @classproperty
     def is_nested(self) -> bool:
+        """Check if this data type is nested."""
         return False
 
     @classmethod
     def is_(cls, other: PolarsDataType) -> bool:
+        """Check if this DataType is the same as another DataType."""
         return cls == other and hash(cls) == hash(other)
 
     @classmethod
     def is_not(cls, other: PolarsDataType) -> bool:
+        """Check if this DataType is NOT the same as another DataType."""
         return not cls.is_(other)
 
 
 class DataType(metaclass=DataTypeClass):
     """Base class for all Polars data types."""
 
-    def __new__(cls, *args: Any, **kwargs: Any) -> PolarsDataType:  # type: ignore[misc]
+    def __new__(cls, *args: Any, **kwargs: Any) -> PolarsDataType:  # type: ignore[misc]  # noqa: D102
         # this formulation allows for equivalent use of "pl.Type" and "pl.Type()", while
         # still respecting types that take initialisation params (eg: Duration/Datetime)
         if args or kwargs:
@@ -95,6 +99,7 @@ class DataType(metaclass=DataTypeClass):
 
     @classproperty
     def is_nested(self) -> bool:
+        """Check if this data type is nested."""
         return False
 
     @classinstmethod  # type: ignore[arg-type]
@@ -158,9 +163,24 @@ def _custom_reconstruct(
 
 
 class DataTypeGroup(frozenset):  # type: ignore[type-arg]
+    """Group of data types."""
+
     _match_base_type: bool
 
-    def __new__(cls, items: Any, *, match_base_type: bool = True) -> DataTypeGroup:
+    def __new__(
+        cls, items: Iterable[DataType | DataTypeClass], *, match_base_type: bool = True
+    ) -> DataTypeGroup:
+        """
+        Construct a DataTypeGroup.
+
+        Parameters
+        ----------
+        items :
+            iterable of data types
+        match_base_type:
+            match the base type
+
+        """
         for it in items:
             if not isinstance(it, (DataType, DataTypeClass)):
                 raise TypeError(
@@ -201,6 +221,7 @@ class NestedType(DataType):
 
     @classproperty
     def is_nested(self) -> bool:
+        """Check if this data type is nested."""
         return True
 
 
@@ -406,6 +427,8 @@ class Unknown(DataType):
 
 
 class List(NestedType):
+    """Nested list/array type with variable length of inner lists."""
+
     inner: PolarsDataType | None = None
 
     def __init__(self, inner: PolarsDataType | PythonDataType):
@@ -466,6 +489,8 @@ class List(NestedType):
 
 
 class Array(NestedType):
+    """Nested list/array type with fixed length of inner arrays."""
+
     inner: PolarsDataType | None = None
     width: int
 
@@ -524,6 +549,8 @@ class Array(NestedType):
 
 
 class Field:
+    """Definition of a single field within a `Struct` DataType."""
+
     def __init__(self, name: str, dtype: PolarsDataType):
         """
         Definition of a single field within a `Struct` DataType.
@@ -551,6 +578,8 @@ class Field:
 
 
 class Struct(NestedType):
+    """Struct composite type."""
+
     def __init__(self, fields: Sequence[Field] | SchemaDict):
         """
         Struct composite type.

--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -73,7 +73,7 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-def cache(function: Callable[..., T]) -> T:
+def cache(function: Callable[..., T]) -> T:  # noqa: D103
     # need this to satisfy mypy issue with "@property/@cache combination"
     # See: https://github.com/python/mypy/issues/5858
     return functools.lru_cache()(function)  # type: ignore[return-value]
@@ -98,7 +98,10 @@ PY_STR_TO_DTYPE: SchemaDict = {
 
 
 @functools.lru_cache(16)
-def map_py_type_to_dtype(python_dtype: PythonDataType | type[object]) -> PolarsDataType:
+def _map_py_type_to_dtype(
+    python_dtype: PythonDataType | type[object],
+) -> PolarsDataType:
+    """Convert Python data type to Polars data type."""
     if python_dtype is float:
         return Float64
     if python_dtype is int:
@@ -134,14 +137,14 @@ def map_py_type_to_dtype(python_dtype: PythonDataType | type[object]) -> PolarsD
     if hasattr(python_dtype, "__origin__") and hasattr(python_dtype, "__args__"):
         base_type = python_dtype.__origin__
         if base_type is not None:
-            dtype = map_py_type_to_dtype(base_type)
+            dtype = _map_py_type_to_dtype(base_type)
             nested = python_dtype.__args__
             if len(nested) == 1:
                 nested = nested[0]
             return (
                 dtype
                 if nested is None
-                else dtype(map_py_type_to_dtype(nested))  # type: ignore[operator]
+                else dtype(_map_py_type_to_dtype(nested))  # type: ignore[operator]
             )
 
     raise TypeError("Invalid type")
@@ -424,7 +427,7 @@ def py_type_to_dtype(
         if is_polars_dtype(data_type):
             return data_type
     try:
-        return map_py_type_to_dtype(data_type)
+        return _map_py_type_to_dtype(data_type)
     except (KeyError, TypeError):  # pragma: no cover
         if not raise_unmatched:
             return None

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -875,12 +875,39 @@ class ExprDateTimeNameSpace:
         return wrap_expr(self._pyexpr.dt_ordinal_day())
 
     def time(self) -> Expr:
+        """
+        Extract time.
+
+        Applies to Datetime columns only; fails on Date.
+
+        Returns
+        -------
+        Time
+        """
         return wrap_expr(self._pyexpr.dt_time())
 
     def date(self) -> Expr:
+        """
+        Extract date from date(time).
+
+        Applies to Date and Datetime columns.
+
+        Returns
+        -------
+        Date
+        """
         return wrap_expr(self._pyexpr.dt_date())
 
     def datetime(self) -> Expr:
+        """
+        Return datetime.
+
+        Applies to Datetime columns.
+
+        Returns
+        -------
+        Datetime
+        """
         return wrap_expr(self._pyexpr.dt_datetime())
 
     def hour(self) -> Expr:

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -75,7 +75,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Date/Datetime series
+        Expression of data type `Date`/`Datetime`
 
         Examples
         --------
@@ -199,7 +199,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Date/Datetime series
+        Expression of data type `Date`/`Datetime`
 
         Warnings
         --------
@@ -882,7 +882,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Time
+        Expression of data type `Time`
         """
         return wrap_expr(self._pyexpr.dt_time())
 
@@ -894,7 +894,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Date
+        Expression of data type `Date`
         """
         return wrap_expr(self._pyexpr.dt_date())
 
@@ -906,7 +906,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Datetime
+        Expression of data type `Datetime`
         """
         return wrap_expr(self._pyexpr.dt_datetime())
 
@@ -1268,7 +1268,7 @@ class ExprDateTimeNameSpace:
 
     def with_time_unit(self, time_unit: TimeUnit) -> Expr:
         """
-        Set time unit of a Series of dtype Datetime or Duration.
+        Set time unit of an expression of dtype Datetime or Duration.
 
         This does not modify underlying data, and should be used to fix an incorrect
         time unit.
@@ -1276,7 +1276,7 @@ class ExprDateTimeNameSpace:
         Parameters
         ----------
         time_unit : {'ns', 'us', 'ms'}
-            Unit of time for the ``Datetime`` Series.
+            Unit of time for the ``Datetime`` expression.
 
         Examples
         --------
@@ -1319,7 +1319,7 @@ class ExprDateTimeNameSpace:
         Parameters
         ----------
         time_unit : {'ns', 'us', 'ms'}
-            Time unit for the ``Datetime`` Series.
+            Time unit for the ``Datetime`` expression.
 
         Examples
         --------
@@ -1354,12 +1354,12 @@ class ExprDateTimeNameSpace:
 
     def convert_time_zone(self, time_zone: str) -> Expr:
         """
-        Convert to given time zone for a Series of type Datetime.
+        Convert to given time zone for an expression of type Datetime.
 
         Parameters
         ----------
         time_zone
-            Time zone for the `Datetime` Series.
+            Time zone for the `Datetime` expression.
 
         Examples
         --------
@@ -1400,7 +1400,7 @@ class ExprDateTimeNameSpace:
         self, time_zone: str | None, *, use_earliest: bool | None = None
     ) -> Expr:
         """
-        Replace time zone for a Series of type Datetime.
+        Replace time zone for an expression of type Datetime.
 
         Different from ``convert_time_zone``, this will also modify
         the underlying timestamp and will ignore the original time zone.
@@ -1408,7 +1408,7 @@ class ExprDateTimeNameSpace:
         Parameters
         ----------
         time_zone
-            Time zone for the `Datetime` Series. Pass `None` to unset time zone.
+            Time zone for the `Datetime` expression. Pass `None` to unset time zone.
         use_earliest
             If localizing an ambiguous datetime (say, due to daylight saving time),
             determine whether to localize to the earliest datetime or not.
@@ -1499,7 +1499,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Expression of data type Int64
 
         Examples
         --------
@@ -1537,7 +1537,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Expression of data type Int64
 
         Examples
         --------
@@ -1576,7 +1576,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Expression of data type Int64
 
         Examples
         --------
@@ -1615,7 +1615,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Expression of data type `Int64`
 
         Examples
         --------
@@ -1658,7 +1658,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Expression of data type Int64
 
         Examples
         --------
@@ -1705,7 +1705,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Expression of data type Int64
 
         Examples
         --------
@@ -1752,7 +1752,7 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Expression of data type Int64
 
         Examples
         --------

--- a/py-polars/polars/io/csv/batched_reader.py
+++ b/py-polars/polars/io/csv/batched_reader.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 
 
 class BatchedCsvReader:
+    """Read a CSV file in batches."""
+
     def __init__(
         self,
         source: str | Path,

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -126,7 +126,7 @@ def read_delta(
     if pyarrow_options is None:
         pyarrow_options = {}
 
-    resolved_uri = resolve_delta_lake_uri(source)
+    resolved_uri = _resolve_delta_lake_uri(source)
 
     dl_tbl = _get_delta_lake_table(
         table_path=resolved_uri,
@@ -254,7 +254,7 @@ def scan_delta(
     if pyarrow_options is None:
         pyarrow_options = {}
 
-    resolved_uri = resolve_delta_lake_uri(source)
+    resolved_uri = _resolve_delta_lake_uri(source)
     dl_tbl = _get_delta_lake_table(
         table_path=resolved_uri,
         version=version,
@@ -266,7 +266,7 @@ def scan_delta(
     return scan_pyarrow_dataset(pa_ds)
 
 
-def resolve_delta_lake_uri(table_uri: str, strict: bool = True) -> str:
+def _resolve_delta_lake_uri(table_uri: str, strict: bool = True) -> str:
     parsed_result = urlparse(table_uri)
 
     resolved_uri = str(
@@ -297,7 +297,7 @@ def _get_delta_lake_table(
     DeltaTable
 
     """
-    check_if_delta_available()
+    _check_if_delta_available()
 
     if delta_table_options is None:
         delta_table_options = {}
@@ -312,7 +312,7 @@ def _get_delta_lake_table(
     return dl_tbl
 
 
-def check_if_delta_available() -> None:
+def _check_if_delta_available() -> None:
     if not _DELTALAKE_AVAILABLE:
         raise ImportError(
             "deltalake is not installed. Please run `pip install deltalake>=0.9.0`."

--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -30,13 +30,13 @@ if TYPE_CHECKING:
     elif _ZONEINFO_AVAILABLE:
         from backports.zoneinfo._zoneinfo import ZoneInfo
 
-    def get_zoneinfo(key: str) -> ZoneInfo:
+    def get_zoneinfo(key: str) -> ZoneInfo:  # noqa: D103
         pass
 
 else:
 
     @lru_cache(None)
-    def get_zoneinfo(key: str) -> ZoneInfo:
+    def get_zoneinfo(key: str) -> ZoneInfo:  # noqa: D103
         return zoneinfo.ZoneInfo(key)
 
 

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -320,7 +320,7 @@ def _cast_repr_strings_with_schema(
 NS = TypeVar("NS")
 
 
-class sphinx_accessor(property):
+class sphinx_accessor(property):  # noqa: D101
     def __get__(  # type: ignore[override]
         self,
         instance: Any,

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -143,12 +143,9 @@ ignore = [
   # pycodestyle
   # TODO: Remove errors below to further improve docstring linting
   # Ordered from most common to least common errors.
-  "D105",
-  "D100",
-  "D103",
-  "D102",
-  "D104",
-  "D101",
+  "D105", # Missing docstring in magic method
+  "D100", # Missing docstring in public module
+  "D104", # Missing docstring in public package
 ]
 
 [tool.ruff.pycodestyle]

--- a/py-polars/scripts/check_stacklevels.py
+++ b/py-polars/scripts/check_stacklevels.py
@@ -15,12 +15,12 @@ from pathlib import Path
 EXCLUDE = frozenset(["polars/utils/polars_version.py"])
 
 
-class StackLevelChecker(NodeVisitor):
+class StackLevelChecker(NodeVisitor):  # noqa: D101
     def __init__(self, file) -> None:
         self.file = file
         self.violations = set()
 
-    def visit_Call(self, node: ast.Call) -> None:
+    def visit_Call(self, node: ast.Call) -> None:  # noqa: D102
         for keyword in node.keywords:
             if keyword.arg == "stacklevel" and isinstance(keyword.value, ast.Constant):
                 self.violations.add(

--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -75,8 +75,11 @@ if __name__ == "__main__":
 
     OutputChecker = doctest.OutputChecker
 
-    class CustomOutputChecker(OutputChecker):
+    class IgnoreResultOutputChecker(OutputChecker):
+        """Python doctest output checker with support for IGNORE_RESULT."""
+
         def check_output(self, want: str, got: str, optionflags: Any) -> bool:
+            """Return True iff the actual output from an example matches the output."""
             if IGNORE_RESULT_ALL:
                 return True
             if IGNORE_RESULT & optionflags:
@@ -84,7 +87,7 @@ if __name__ == "__main__":
             else:
                 return OutputChecker.check_output(self, want, got, optionflags)
 
-    doctest.OutputChecker = CustomOutputChecker  # type: ignore[misc]
+    doctest.OutputChecker = IgnoreResultOutputChecker  # type: ignore[misc]
 
     # We want to be relaxed about whitespace, but strict on True vs 1
     doctest.NORMALIZE_WHITESPACE = True

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -121,9 +121,9 @@ def test_parse_version(v1: Any, v2: Any) -> None:
 
 class Foo:  # noqa: D101
     @deprecate_nonkeyword_arguments(allowed_args=["self", "baz"])
-    def bar(
+    def bar(  # noqa: D102
         self, baz: str, ham: str | None = None, foobar: str | None = None
-    ) -> None:  # noqa: D102
+    ) -> None:
         ...
 
 

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -119,9 +119,11 @@ def test_parse_version(v1: Any, v2: Any) -> None:
     assert parse_version(v2) < parse_version(v1)
 
 
-class Foo:
+class Foo:  # noqa: D101
     @deprecate_nonkeyword_arguments(allowed_args=["self", "baz"])
-    def bar(self, baz: str, ham: str | None = None, foobar: str | None = None) -> None:
+    def bar(
+        self, baz: str, ham: str | None = None, foobar: str | None = None
+    ) -> None:  # noqa: D102
         ...
 
 


### PR DESCRIPTION
D101, D102 & D103 are all useful rules, so have added docstrings where possible. On some internal utils, I have marked private and/or used a noqa. This should stop us from adding undocumented public functions.

D100 & D104: we are not using module and package docstrings at all, is this something we want/need? As it is in the list of "remove errors" in pyproject.toml.

D105: we should probably do this, but there are a lot here.