### PR TITLE
feat(rust, python): Add cloudpickle for serializing python UDFs

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/python_udf.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/python_udf.rs
@@ -56,7 +56,8 @@ impl Serialize for PythonFunction {
         S: Serializer,
     {
         Python::with_gil(|py| {
-            let pickle = PyModule::import(py, "cloudpickle").or(PyModule::import(py, "pickle"))
+            let pickle = PyModule::import(py, "cloudpickle")
+                .or(PyModule::import(py, "pickle"))
                 .expect("Unable to import 'cloudpickle' or 'pickle'")
                 .getattr("dumps")
                 .unwrap();
@@ -83,7 +84,8 @@ impl<'a> Deserialize<'a> for PythonFunction {
         let bytes = Vec::<u8>::deserialize(deserializer)?;
 
         Python::with_gil(|py| {
-            let pickle = PyModule::import(py, "cloudpickle").or(PyModule::import(py, "pickle"))
+            let pickle = PyModule::import(py, "cloudpickle")
+                .or(PyModule::import(py, "pickle"))
                 .expect("Unable to import 'pickle'")
                 .getattr("loads")
                 .unwrap();
@@ -122,7 +124,8 @@ impl PythonUdfExpression {
         let remainder = &buf[reader.position() as usize..];
 
         Python::with_gil(|py| {
-            let pickle = PyModule::import(py, "cloudpickle").or(PyModule::import(py, "pickle"))
+            let pickle = PyModule::import(py, "cloudpickle")
+                .or(PyModule::import(py, "pickle"))
                 .expect("Unable to import 'pickle'")
                 .getattr("loads")
                 .unwrap();
@@ -169,7 +172,8 @@ impl SeriesUdf for PythonUdfExpression {
         ciborium::ser::into_writer(&self.output_type, &mut *buf).unwrap();
 
         Python::with_gil(|py| {
-            let pickle = PyModule::import(py, "cloudpickle").or(PyModule::import(py, "pickle"))
+            let pickle = PyModule::import(py, "cloudpickle")
+                .or(PyModule::import(py, "pickle"))
                 .expect("Unable to import 'pickle'")
                 .getattr("dumps")
                 .unwrap();

--- a/polars/polars-lazy/polars-plan/src/dsl/python_udf.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/python_udf.rs
@@ -56,8 +56,8 @@ impl Serialize for PythonFunction {
         S: Serializer,
     {
         Python::with_gil(|py| {
-            let pickle = PyModule::import(py, "pickle")
-                .expect("Unable to import 'pickle'")
+            let pickle = PyModule::import(py, "cloudpickle").or(PyModule::import(py, "pickle"))
+                .expect("Unable to import 'cloudpickle' or 'pickle'")
                 .getattr("dumps")
                 .unwrap();
 
@@ -83,7 +83,7 @@ impl<'a> Deserialize<'a> for PythonFunction {
         let bytes = Vec::<u8>::deserialize(deserializer)?;
 
         Python::with_gil(|py| {
-            let pickle = PyModule::import(py, "pickle")
+            let pickle = PyModule::import(py, "cloudpickle").or(PyModule::import(py, "pickle"))
                 .expect("Unable to import 'pickle'")
                 .getattr("loads")
                 .unwrap();
@@ -122,7 +122,7 @@ impl PythonUdfExpression {
         let remainder = &buf[reader.position() as usize..];
 
         Python::with_gil(|py| {
-            let pickle = PyModule::import(py, "pickle")
+            let pickle = PyModule::import(py, "cloudpickle").or(PyModule::import(py, "pickle"))
                 .expect("Unable to import 'pickle'")
                 .getattr("loads")
                 .unwrap();
@@ -169,7 +169,7 @@ impl SeriesUdf for PythonUdfExpression {
         ciborium::ser::into_writer(&self.output_type, &mut *buf).unwrap();
 
         Python::with_gil(|py| {
-            let pickle = PyModule::import(py, "pickle")
+            let pickle = PyModule::import(py, "cloudpickle").or(PyModule::import(py, "pickle"))
                 .expect("Unable to import 'pickle'")
                 .getattr("dumps")
                 .unwrap();

--- a/py-polars/polars/utils/show_versions.py
+++ b/py-polars/polars/utils/show_versions.py
@@ -59,6 +59,7 @@ def _get_dependency_info() -> dict[str, str]:
     # see the list of dependencies in pyproject.toml
     opt_deps = [
         "adbc_driver_sqlite",
+        "cloudpickle",
         "connectorx",
         "deltalake",
         "fsspec",

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -51,8 +51,9 @@ pydantic = ["pydantic"]
 sqlalchemy = ["sqlalchemy", "pandas"]
 xlsxwriter = ["xlsxwriter"]
 adbc = ["adbc_driver_sqlite"]
+cloudpickle = ["cloudpickle"]
 all = [
-  "polars[pyarrow,pandas,numpy,fsspec,connectorx,xlsx2csv,deltalake,timezone,matplotlib,pydantic,sqlalchemy,xlsxwriter,adbc]",
+  "polars[pyarrow,pandas,numpy,fsspec,connectorx,xlsx2csv,deltalake,timezone,matplotlib,pydantic,sqlalchemy,xlsxwriter,adbc,cloudpickle]",
 ]
 
 [tool.mypy]

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -17,6 +17,7 @@ xlsx2csv
 XlsxWriter
 adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'
 connectorx==0.3.2a5; python_version >= '3.8'  # Latest full release is broken - unpin when 0.3.2 released
+cloudpickle
 
 # Tooling
 hypothesis==6.79.4; python_version < '3.8'

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -153,8 +153,9 @@ def test_pickle_lazyframe_udf() -> None:
     q = pickle.loads(b)
     assert q.collect()["a"].to_list() == [2, 4, 6]
 
+
 def test_pickle_lazyframe_nested_function_udf() -> None:
-    df = pl.DataFrame({"a": [1,2,3]})
+    df = pl.DataFrame({"a": [1, 2, 3]})
 
     # NOTE: This is only possible when we're using cloudpickle.
     def inner_df_times2(df: pl.DataFrame) -> pl.DataFrame:
@@ -162,7 +163,6 @@ def test_pickle_lazyframe_nested_function_udf() -> None:
 
     q = df.lazy().map(inner_df_times2)
     b = pickle.dumps(q)
-    
+
     q = pickle.loads(b)
     assert q.collect()["a"].to_list() == [2, 4, 6]
-

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -152,3 +152,17 @@ def test_pickle_lazyframe_udf() -> None:
 
     q = pickle.loads(b)
     assert q.collect()["a"].to_list() == [2, 4, 6]
+
+def test_pickle_lazyframe_nested_function_udf() -> None:
+    df = pl.DataFrame({"a": [1,2,3]})
+
+    # NOTE: This is only possible when we're using cloudpickle.
+    def inner_df_times2(df: pl.DataFrame) -> pl.DataFrame:
+        return df.select(pl.all() * 2)
+
+    q = df.lazy().map(inner_df_times2)
+    b = pickle.dumps(q)
+    
+    q = pickle.loads(b)
+    assert q.collect()["a"].to_list() == [2, 4, 6]
+


### PR DESCRIPTION
Currently we use the default `pickle` module to serialize python UDF's. There are various shortcomings of using `pickle` to serialize arbitrary functions which cloudpickle can overcome (mostly because pickle serializes by reference vs. cloudpickle can serialize by value). Here's a quick example with nested functions:

Cloudpickle can do this:
```
import cloudpickle
def f():
    def g():
        return 5
    return cloudpickle.dumps(g)
f()

gives:

b'\x80\x05\x95\xc3\x01\x00\x00\x00\x00\x00\x00\x8c\x17cloudpickle.cloudpickle\x94\x8c\x0e_make_function\x94\x93\x94(h\x00\x8c\r_builtin_type\x94\x93\x94\x8c\x08CodeType\x94\x85\x94R\x94(K\x00K\x00K\x00K\x00K\x01KSC\x04d\x01S\x00\x94NK\x05\x86\x94))\x8c"/tmp/ipykernel_37771/1247407800.py\x94\x8c\x01g\x94K\x03C\x02\x04\x01\x94))t\x94R\x94}\x94(\x8c\x0b__package__\x94N\x8c\x08__name__\x94\x8c\x08__main__\x94uNNNt\x94R\x94\x8c\x1ccloudpickle.cloudpickle_fast\x94\x8c\x12_function_setstate\x94\x93\x94h\x14}\x94}\x94(h\x11h\x0b\x8c\x0c__qualname__\x94\x8c\x0cf.<locals>.g\x94\x8c\x0f__annotations__\x94}\x94\x8c\x0e__kwdefaults__\x94N\x8c\x0c__defaults__\x94N\x8c\n__module__\x94h\x12\x8c\x07__doc__\x94N\x8c\x0b__closure__\x94N\x8c\x17_cloudpickle_submodules\x94]\x94\x8c\x0b__globals__\x94}\x94u\x86\x94\x86R0.'
```

Pickle cannot do this:
```
import pickle
def f():
    def g():
        return 5
    return pickle.dumps(g)
f()

gives:


---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[10], line 6
      4         return 5
      5     return pickle.dumps(g)
----> 6 f()

Cell In[10], line 5, in f()
      3 def g():
      4     return 5
----> 5 return pickle.dumps(g)

AttributeError: Can't pickle local object 'f.<locals>.g'
```

Note that this isn't anything super crazy - pyspark already ships with a copy of cloudpickle in order to serialize its UDFs, and many other projects have done the same.