### PR TITLE
refactor(python): Refactor `WhenThen` / `WhenThenThen`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/arity.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/arity.rs
@@ -8,38 +8,37 @@ pub struct When {
 
 /// Intermediate state of `when(..).then(..).otherwise(..)` expr.
 #[derive(Clone)]
-pub struct WhenThen {
+pub struct Then {
     predicate: Expr,
     then: Expr,
 }
 
-/// Intermediate state of chain when then exprs.
-///
-/// ```text
-/// when(..).then(..)
-/// when(..).then(..)
-/// when(..).then(..)
-/// .otherwise(..)`
-/// ```
+/// Intermediate state of `when(..).then(..).otherwise(..)` expr.
 #[derive(Clone)]
-#[must_use]
-pub struct WhenThenThen {
+pub struct ChainedWhen {
+    predicates: Vec<Expr>,
+    thens: Vec<Expr>,
+}
+
+/// Intermediate state of `when(..).then(..).otherwise(..)` expr.
+#[derive(Clone)]
+pub struct ChainedThen {
     predicates: Vec<Expr>,
     thens: Vec<Expr>,
 }
 
 impl When {
-    pub fn then<E: Into<Expr>>(self, expr: E) -> WhenThen {
-        WhenThen {
+    pub fn then<E: Into<Expr>>(self, expr: E) -> Then {
+        Then {
             predicate: self.predicate,
             then: expr.into(),
         }
     }
 }
 
-impl WhenThen {
-    pub fn when<E: Into<Expr>>(self, predicate: E) -> WhenThenThen {
-        WhenThenThen {
+impl Then {
+    pub fn when<E: Into<Expr>>(self, predicate: E) -> ChainedWhen {
+        ChainedWhen {
             predicates: vec![self.predicate, predicate.into()],
             thens: vec![self.then],
         }
@@ -54,38 +53,47 @@ impl WhenThen {
     }
 }
 
-impl WhenThenThen {
-    pub fn then(mut self, expr: Expr) -> Self {
-        self.thens.push(expr);
-        self
+impl ChainedWhen {
+    pub fn then<E: Into<Expr>>(mut self, expr: E) -> ChainedThen {
+        self.thens.push(expr.into());
+        ChainedThen {
+            predicates: self.predicates,
+            thens: self.thens,
+        }
+    }
+}
+
+impl ChainedThen {
+    pub fn when<E: Into<Expr>>(mut self, predicate: E) -> ChainedWhen {
+        self.predicates.push(predicate.into());
+
+        ChainedWhen {
+            predicates: self.predicates,
+            thens: self.thens,
+        }
     }
 
-    pub fn when(mut self, predicate: Expr) -> Self {
-        self.predicates.push(predicate);
-        self
-    }
-
-    pub fn otherwise(self, expr: Expr) -> Expr {
+    pub fn otherwise<E: Into<Expr>>(self, expr: E) -> Expr {
         // we iterate the preds/ exprs last in first out
         // and nest them.
         //
         // // this expr:
         //   when((col('x') == 'a')).then(1)
-        //         .when(col('x') == 'a').then(2)
-        //         .when(col('x') == 'b').then(3)
+        //         .when(col('x') == 'b').then(2)
+        //         .when(col('x') == 'c').then(3)
         //         .otherwise(4)
         //
         // needs to become:
         //       when((col('x') == 'a')).then(1)                        -
         //         .otherwise(                                           |
-        //             when(col('x') == 'a').then(2)            -        |
+        //             when(col('x') == 'b').then(2)            -        |
         //             .otherwise(                               |       |
-        //                 pl.when(col('x') == 'b').then(3)      |       |
+        //                 pl.when(col('x') == 'c').then(3)      |       |
         //                 .otherwise(4)                         | inner | outer
         //             )                                         |       |
         //         )                                            _|      _|
         //
-        // by iterating lifo we first create
+        // by iterating LIFO we first create
         // `inner` and then assign that to `otherwise`,
         // which will be used in the next layer `outer`
         //
@@ -93,7 +101,7 @@ impl WhenThenThen {
         let pred_iter = self.predicates.into_iter().rev();
         let mut then_iter = self.thens.into_iter().rev();
 
-        let mut otherwise = expr;
+        let mut otherwise = expr.into();
 
         for e in pred_iter {
             otherwise = Expr::Ternary {
@@ -106,12 +114,7 @@ impl WhenThenThen {
                 falsy: Box::new(otherwise),
             }
         }
-        if then_iter.next().is_some() {
-            panic!(
-                "this expr is not properly constructed. \
-            Every `when` should have an accompanied `then` call."
-            )
-        }
+
         otherwise
     }
 }

--- a/polars/polars-lazy/polars-plan/src/dsl/arity.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/arity.rs
@@ -1,26 +1,26 @@
 use super::*;
 
-/// Intermediate state of `when(..).then(..).otherwise(..)` expr.
+/// Intermediate state of `when(..).then(..).otherwise(..)` expression.
 #[derive(Clone)]
 pub struct When {
     predicate: Expr,
 }
 
-/// Intermediate state of `when(..).then(..).otherwise(..)` expr.
+/// Intermediate state of `when(..).then(..).otherwise(..)` expression.
 #[derive(Clone)]
 pub struct Then {
     predicate: Expr,
     then: Expr,
 }
 
-/// Intermediate state of `when(..).then(..).otherwise(..)` expr.
+/// Intermediate state of a chained `when(..).then(..).otherwise(..)` expression.
 #[derive(Clone)]
 pub struct ChainedWhen {
     predicates: Vec<Expr>,
     thens: Vec<Expr>,
 }
 
-/// Intermediate state of `when(..).then(..).otherwise(..)` expr.
+/// Intermediate state of a chained `when(..).then(..).otherwise(..)` expression.
 #[derive(Clone)]
 pub struct ChainedThen {
     predicates: Vec<Expr>,
@@ -119,7 +119,7 @@ impl ChainedThen {
     }
 }
 
-/// Start a when-then-otherwise expression
+/// Start a `when(..).then(..).otherwise(..)` expression
 pub fn when<E: Into<Expr>>(predicate: E) -> When {
     When {
         predicate: predicate.into(),

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1699,6 +1699,7 @@ dependencies = [
  "hashbrown 0.14.0",
  "num-traits",
  "once_cell",
+ "polars-error",
  "rayon",
  "smartstring",
  "sysinfo",

--- a/py-polars/polars/_reexport.py
+++ b/py-polars/polars/_reexport.py
@@ -1,7 +1,7 @@
 """Re-export Polars functionality to avoid cyclical imports."""
 
 from polars.dataframe import DataFrame
-from polars.expr import Expr
+from polars.expr import Expr, When
 from polars.lazyframe import LazyFrame
 from polars.series import Series
 
@@ -10,4 +10,5 @@ __all__ = [
     "Expr",
     "LazyFrame",
     "Series",
+    "When",
 ]

--- a/py-polars/polars/dataframe/groupby.py
+++ b/py-polars/polars/dataframe/groupby.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Callable, Iterable, Iterator
 
 import polars._reexport as pl
 from polars import functions as F
-from polars.functions.whenthen import WhenThen, WhenThenThen
 from polars.utils.convert import _timedelta_to_pl_duration
 
 if TYPE_CHECKING:
@@ -108,10 +107,7 @@ class GroupBy:
         # When grouping by a single column, group name is a single value
         # When grouping by multiple columns, group name is a tuple of values
         self._group_names: Iterator[object] | Iterator[tuple[object, ...]]
-        if (
-            isinstance(self.by, (str, pl.Expr, WhenThen, WhenThenThen))
-            and not self.more_by
-        ):
+        if isinstance(self.by, (str, pl.Expr)) and not self.more_by:
             self._group_names = iter(group_names.to_series())
         else:
             self._group_names = group_names.iter_rows()

--- a/py-polars/polars/dataframe/groupby.py
+++ b/py-polars/polars/dataframe/groupby.py
@@ -322,7 +322,7 @@ class GroupBy:
 
         if isinstance(self.by, str):
             by = [self.by]
-        elif isinstance(self.by, Iterable) and all(isinstance(c, str) for c in self.by):  # type: ignore[union-attr]
+        elif isinstance(self.by, Iterable) and all(isinstance(c, str) for c in self.by):
             by = list(self.by)  # type: ignore[arg-type]
         else:
             raise TypeError("Cannot call `apply` when grouping by an expression.")

--- a/py-polars/polars/expr/__init__.py
+++ b/py-polars/polars/expr/__init__.py
@@ -1,5 +1,7 @@
 from polars.expr.expr import Expr
+from polars.expr.whenthen import When
 
 __all__ = [
     "Expr",
+    "When",
 ]

--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import polars.functions as F
+from polars.expr.expr import Expr
+from polars.utils._parse_expr_input import parse_as_expression
+from polars.utils._wrap import wrap_expr
+
+if TYPE_CHECKING:
+    from polars.polars import PyExpr
+    from polars.type_aliases import IntoExpr
+
+
+class When:
+    """Utility class. See the `when` function."""
+
+    def __init__(self, pywhen: Any):
+        self._pywhen = pywhen
+
+    def then(self, expr: IntoExpr) -> WhenThen:
+        """
+        Values to return in case of the predicate being `True`.
+
+        See Also
+        --------
+        pl.when : Documentation for `when, then, otherwise`
+
+        """
+        expr = parse_as_expression(expr, str_as_lit=True)
+        pywhenthen = self._pywhen.then(expr)
+        return WhenThen(pywhenthen)
+
+
+class WhenThen(Expr):
+    """Utility class. See the `when` function."""
+
+    def __init__(self, pywhenthen: Any):
+        self._pywhenthen = pywhenthen
+
+    @classmethod
+    def _from_pyexpr(cls, pyexpr: PyExpr) -> Expr:
+        return wrap_expr(pyexpr)
+
+    @property
+    def _pyexpr(self) -> PyExpr:
+        return self._pywhenthen.otherwise(F.lit(None)._pyexpr)
+
+    def when(self, predicate: IntoExpr) -> WhenThenThen:
+        """Start another "when, then, otherwise" layer."""
+        predicate = parse_as_expression(predicate)
+        return WhenThenThen(self._pywhenthen.when(predicate))
+
+    def otherwise(self, expr: IntoExpr) -> Expr:
+        """
+        Values to return in case of the predicate being `False`.
+
+        See Also
+        --------
+        pl.when : Documentation for `when, then, otherwise`
+
+        """
+        expr = parse_as_expression(expr, str_as_lit=True)
+        return wrap_expr(self._pywhenthen.otherwise(expr))
+
+
+class WhenThenThen(Expr):
+    """Utility class. See the `when` function."""
+
+    def __init__(self, pywhenthenthen: Any):
+        self._pywhenthenthen = pywhenthenthen
+
+    @classmethod
+    def _from_pyexpr(cls, pyexpr: PyExpr) -> Expr:
+        return wrap_expr(pyexpr)
+
+    @property
+    def _pyexpr(self) -> PyExpr:
+        return self._pywhenthenthen.otherwise(F.lit(None)._pyexpr)
+
+    # @_pyexpr.setter
+    # def _pyexpr(self) -> PyExpr:
+
+    def when(self, predicate: IntoExpr) -> WhenThenThen:
+        """Start another "when, then, otherwise" layer."""
+        predicate = parse_as_expression(predicate)
+        return WhenThenThen(self._pywhenthenthen.when(predicate))
+
+    def then(self, expr: IntoExpr) -> WhenThenThen:
+        """
+        Values to return in case of the predicate being `True`.
+
+        See Also
+        --------
+        pl.when : Documentation for `when, then, otherwise`
+
+        """
+        expr = parse_as_expression(expr, str_as_lit=True)
+        return WhenThenThen(self._pywhenthenthen.then(expr))
+
+    def otherwise(self, expr: IntoExpr) -> Expr:
+        """
+        Values to return in case of the predicate being `False`.
+
+        See Also
+        --------
+        pl.when : Documentation for `when, then, otherwise`
+
+        """
+        expr = parse_as_expression(expr, str_as_lit=True)
+        return wrap_expr(self._pywhenthenthen.otherwise(expr))

--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -39,7 +39,7 @@ class WhenThen(Expr):
         self._pywhenthen = pywhenthen
 
     @classmethod
-    def _from_pyexpr(cls, pyexpr: PyExpr) -> Expr:
+    def _from_pyexpr(cls, pyexpr: PyExpr) -> Expr:  # type: ignore[override]
         return wrap_expr(pyexpr)
 
     @property
@@ -71,7 +71,7 @@ class WhenThenThen(Expr):
         self._pywhenthenthen = pywhenthenthen
 
     @classmethod
-    def _from_pyexpr(cls, pyexpr: PyExpr) -> Expr:
+    def _from_pyexpr(cls, pyexpr: PyExpr) -> Expr:  # type: ignore[override]
         return wrap_expr(pyexpr)
 
     @property

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -18,17 +18,13 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from polars import Expr, Series
-    from polars.type_aliases import (
-        IntoExpr,
-        PolarsDataType,
-        PolarsExprType,
-    )
+    from polars.type_aliases import IntoExpr, PolarsDataType
 
 
 @overload
 def repeat(
     value: IntoExpr | None,
-    n: int | PolarsExprType,
+    n: int | Expr,
     *,
     dtype: PolarsDataType | None = ...,
     eager: Literal[False] = ...,
@@ -40,7 +36,7 @@ def repeat(
 @overload
 def repeat(
     value: IntoExpr | None,
-    n: int | PolarsExprType,
+    n: int | Expr,
     *,
     dtype: PolarsDataType | None = ...,
     eager: Literal[True],
@@ -52,7 +48,7 @@ def repeat(
 @overload
 def repeat(
     value: IntoExpr | None,
-    n: int | PolarsExprType,
+    n: int | Expr,
     *,
     dtype: PolarsDataType | None = ...,
     eager: bool,
@@ -63,7 +59,7 @@ def repeat(
 
 def repeat(
     value: IntoExpr | None,
-    n: int | PolarsExprType,
+    n: int | Expr,
     *,
     dtype: PolarsDataType | None = None,
     eager: bool = False,
@@ -145,7 +141,7 @@ def repeat(
 
 @overload
 def ones(
-    n: int | PolarsExprType,
+    n: int | Expr,
     dtype: PolarsDataType = ...,
     *,
     eager: Literal[False] = ...,
@@ -155,7 +151,7 @@ def ones(
 
 @overload
 def ones(
-    n: int | PolarsExprType,
+    n: int | Expr,
     dtype: PolarsDataType = ...,
     *,
     eager: Literal[True],
@@ -165,7 +161,7 @@ def ones(
 
 @overload
 def ones(
-    n: int | PolarsExprType,
+    n: int | Expr,
     dtype: PolarsDataType = ...,
     *,
     eager: bool,
@@ -174,7 +170,7 @@ def ones(
 
 
 def ones(
-    n: int | PolarsExprType,
+    n: int | Expr,
     dtype: PolarsDataType = Float64,
     *,
     eager: bool = False,
@@ -221,7 +217,7 @@ def ones(
 
 @overload
 def zeros(
-    n: int | PolarsExprType,
+    n: int | Expr,
     dtype: PolarsDataType = ...,
     *,
     eager: Literal[False] = ...,
@@ -231,7 +227,7 @@ def zeros(
 
 @overload
 def zeros(
-    n: int | PolarsExprType,
+    n: int | Expr,
     dtype: PolarsDataType = ...,
     *,
     eager: Literal[True],
@@ -241,7 +237,7 @@ def zeros(
 
 @overload
 def zeros(
-    n: int | PolarsExprType,
+    n: int | Expr,
     dtype: PolarsDataType = ...,
     *,
     eager: bool,
@@ -250,7 +246,7 @@ def zeros(
 
 
 def zeros(
-    n: int | PolarsExprType,
+    n: int | Expr,
     dtype: PolarsDataType = Float64,
     *,
     eager: bool = False,

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -91,6 +91,5 @@ def when(expr: IntoExpr) -> pl.When:
 
 
     """
-    expr = parse_as_expression(expr)
-    pywhen = plr.when(expr)
-    return pl.When(pywhen)
+    pyexpr = parse_as_expression(expr)
+    return pl.When(plr.when(pyexpr))

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import polars._reexport as pl
 from polars.utils._parse_expr_input import parse_as_expression
-from polars.utils._wrap import wrap_expr
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
 
 if TYPE_CHECKING:
-    from polars import Expr
     from polars.type_aliases import IntoExpr
 
 
-def when(expr: IntoExpr) -> When:
+def when(expr: IntoExpr) -> pl.When:
     """
     Start a "when, then, otherwise" expression.
 
@@ -95,86 +93,4 @@ def when(expr: IntoExpr) -> When:
     """
     expr = parse_as_expression(expr)
     pywhen = plr.when(expr)
-    return When(pywhen)
-
-
-class When:
-    """Utility class. See the `when` function."""
-
-    def __init__(self, pywhen: Any):
-        self._pywhen = pywhen
-
-    def then(self, expr: IntoExpr) -> WhenThen:
-        """
-        Values to return in case of the predicate being `True`.
-
-        See Also
-        --------
-        pl.when : Documentation for `when, then, otherwise`
-
-        """
-        expr = parse_as_expression(expr, str_as_lit=True)
-        pywhenthen = self._pywhen.then(expr)
-        return pl.WhenThen(pywhenthen)
-
-
-class WhenThen(pl.Expr):
-    """Utility class. See the `when` function."""
-
-    def __init__(self, pywhenthen: Any):
-        self._pywhenthen = pywhenthen
-        self._pyexpr = pywhenthen.otherwise(None)
-
-    def when(self, predicate: IntoExpr) -> WhenThenThen:
-        """Start another "when, then, otherwise" layer."""
-        predicate = parse_as_expression(predicate)
-        return WhenThenThen(self._pywhenthen.when(predicate))
-
-    def otherwise(self, expr: IntoExpr) -> Expr:
-        """
-        Values to return in case of the predicate being `False`.
-
-        See Also
-        --------
-        pl.when : Documentation for `when, then, otherwise`
-
-        """
-        expr = parse_as_expression(expr, str_as_lit=True)
-        return wrap_expr(self._pywhenthen.otherwise(expr))
-
-
-class WhenThenThen(pl.Expr):
-    """Utility class. See the `when` function."""
-
-    def __init__(self, pywhenthenthen: Any):
-        self.pywhenthenthen = pywhenthenthen
-        self._pyexpr = pywhenthenthen.otherwise(None)
-
-    def when(self, predicate: IntoExpr) -> WhenThenThen:
-        """Start another "when, then, otherwise" layer."""
-        predicate = parse_as_expression(predicate)
-        return WhenThenThen(self.pywhenthenthen.when(predicate))
-
-    def then(self, expr: IntoExpr) -> WhenThenThen:
-        """
-        Values to return in case of the predicate being `True`.
-
-        See Also
-        --------
-        pl.when : Documentation for `when, then, otherwise`
-
-        """
-        expr = parse_as_expression(expr, str_as_lit=True)
-        return WhenThenThen(self.pywhenthenthen.then(expr))
-
-    def otherwise(self, expr: IntoExpr) -> Expr:
-        """
-        Values to return in case of the predicate being `False`.
-
-        See Also
-        --------
-        pl.when : Documentation for `when, then, otherwise`
-
-        """
-        expr = parse_as_expression(expr, str_as_lit=True)
-        return wrap_expr(self.pywhenthenthen.otherwise(expr))
+    return pl.When(pywhen)

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from polars.dependencies import numpy as np
     from polars.dependencies import pandas as pd
     from polars.dependencies import pyarrow as pa
-    from polars.functions.whenthen import WhenThen, WhenThenThen
     from polars.selectors import _selector_proxy_
 
     if sys.version_info >= (3, 10):
@@ -61,15 +60,12 @@ SchemaDefinition: TypeAlias = Union[
 ]
 SchemaDict: TypeAlias = Mapping[str, PolarsDataType]
 
-# Types that qualify as expressions (eg: for use in 'select', 'with_columns'...)
-PolarsExprType: TypeAlias = Union["Expr", "WhenThen", "WhenThenThen"]
-
 # literal types that are allowed in expressions (auto-converted to pl.lit)
 PythonLiteral: TypeAlias = Union[
     str, int, float, bool, date, time, datetime, timedelta, bytes, Decimal, List[Any]
 ]
 
-IntoExpr: TypeAlias = Union[PolarsExprType, PythonLiteral, "Series", None]
+IntoExpr: TypeAlias = Union["Expr", PythonLiteral, "Series", None]
 ComparisonOperator: TypeAlias = Literal["eq", "neq", "gt", "lt", "gt_eq", "lt_eq"]
 
 # selector type

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -132,8 +132,6 @@ def parse_as_expression(
     elif isinstance(input, list):
         expr = F.lit(pl.Series("", [input]))
         structify = False
-    elif isinstance(input, (F.whenthen.WhenThen, F.whenthen.WhenThenThen)):
-        expr = input.otherwise(None)  # implicitly add the null branch.
     else:
         raise TypeError(
             f"did not expect value {input!r} of type {type(input)}, maybe disambiguate with"

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -5,22 +5,6 @@ import numpy as np
 import polars as pl
 
 
-def test_object_when_then_4702() -> None:
-    # please don't ever do this
-    x = pl.DataFrame({"Row": [1, 2], "Type": [pl.Date, pl.UInt8]})
-
-    assert x.with_columns(
-        pl.when(pl.col("Row") == 1)
-        .then(pl.lit(pl.UInt16, allow_object=True))
-        .otherwise(pl.lit(pl.UInt8, allow_object=True))
-        .alias("New_Type")
-    ).to_dict(False) == {
-        "Row": [1, 2],
-        "Type": [pl.Date, pl.UInt8],
-        "New_Type": [pl.UInt16, pl.UInt8],
-    }
-
-
 def test_object_empty_filter_5911() -> None:
     df = pl.DataFrame(
         data=[

--- a/py-polars/tests/unit/functions/test_whenthen.py
+++ b/py-polars/tests/unit/functions/test_whenthen.py
@@ -1,0 +1,159 @@
+from datetime import datetime
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+
+def test_when_then_implicit_none() -> None:
+    df = pl.DataFrame(
+        {
+            "team": ["A", "A", "A", "B", "B", "C"],
+            "points": [11, 8, 10, 6, 6, 5],
+        }
+    )
+
+    assert df.select(
+        pl.when(pl.col("points") > 7).then("Foo"),
+        pl.when(pl.col("points") > 7).then("Foo").alias("bar"),
+    ).to_dict(False) == {
+        "literal": ["Foo", "Foo", "Foo", None, None, None],
+        "bar": ["Foo", "Foo", "Foo", None, None, None],
+    }
+
+
+def test_when_then_empty_list_5547() -> None:
+    out = pl.DataFrame({"a": []}).select([pl.when(pl.col("a") > 1).then([1])])
+    assert out.shape == (0, 1)
+    assert out.dtypes == [pl.List(pl.Int64)]
+
+
+def test_nested_when_then_and_wildcard_expansion_6284() -> None:
+    df = pl.DataFrame(
+        {
+            "1": ["a", "b"],
+            "2": ["c", "d"],
+        }
+    )
+
+    out0 = df.with_columns(
+        pl.when(pl.any_horizontal(pl.all() == "a"))
+        .then("a")
+        .otherwise(
+            pl.when(pl.any_horizontal(pl.all() == "d")).then("d").otherwise(None)
+        )
+        .alias("result")
+    )
+
+    out1 = df.with_columns(
+        pl.when(pl.any_horizontal(pl.all() == "a"))
+        .then("a")
+        .when(pl.any_horizontal(pl.all() == "d"))
+        .then("d")
+        .otherwise(None)
+        .alias("result")
+    )
+
+    assert_frame_equal(out0, out1)
+    assert out0.to_dict(False) == {
+        "1": ["a", "b"],
+        "2": ["c", "d"],
+        "result": ["a", "d"],
+    }
+
+
+def test_list_zip_with_logical_type() -> None:
+    df = pl.DataFrame(
+        {
+            "start": [datetime(2023, 1, 1, 1, 1, 1), datetime(2023, 1, 1, 1, 1, 1)],
+            "stop": [datetime(2023, 1, 1, 1, 3, 1), datetime(2023, 1, 1, 1, 4, 1)],
+            "use": [1, 0],
+        }
+    )
+
+    df = df.with_columns(
+        pl.date_ranges(
+            pl.col("start"), pl.col("stop"), interval="1h", eager=False, closed="left"
+        ).alias("interval_1"),
+        pl.date_ranges(
+            pl.col("start"), pl.col("stop"), interval="1h", eager=False, closed="left"
+        ).alias("interval_2"),
+    )
+
+    out = df.select(
+        pl.when(pl.col("use") == 1)
+        .then(pl.col("interval_2"))
+        .otherwise(pl.col("interval_1"))
+        .alias("interval_new")
+    )
+    assert out.dtypes == [pl.List(pl.Datetime(time_unit="us", time_zone=None))]
+
+
+def test_type_coercion_when_then_otherwise_2806() -> None:
+    out = (
+        pl.DataFrame({"names": ["foo", "spam", "spam"], "nrs": [1, 2, 3]})
+        .select(
+            [
+                pl.when(pl.col("names") == "spam")
+                .then(pl.col("nrs") * 2)
+                .otherwise(pl.lit("other"))
+                .alias("new_col"),
+            ]
+        )
+        .to_series()
+    )
+    expected = pl.Series("new_col", ["other", "4", "6"])
+    assert out.to_list() == expected.to_list()
+
+    # test it remains float32
+    assert (
+        pl.Series("a", [1.0, 2.0, 3.0], dtype=pl.Float32)
+        .to_frame()
+        .select(pl.when(pl.col("a") > 2.0).then(pl.col("a")).otherwise(0.0))
+    ).to_series().dtype == pl.Float32
+
+
+def test_when_then_edge_cases_3994() -> None:
+    df = pl.DataFrame(data={"id": [1, 1], "type": [2, 2]})
+
+    # this tests if lazy correctly assigns the list schema to the column aggregation
+    assert (
+        df.lazy()
+        .groupby(["id"])
+        .agg(pl.col("type"))
+        .with_columns(
+            pl.when(pl.col("type").list.lengths() == 0)
+            .then(pl.lit(None))
+            .otherwise(pl.col("type"))
+            .keep_name()
+        )
+        .collect()
+    ).to_dict(False) == {"id": [1], "type": [[2, 2]]}
+
+    # this tests ternary with an empty argument
+    assert (
+        df.filter(pl.col("id") == 42)
+        .groupby(["id"])
+        .agg(pl.col("type"))
+        .with_columns(
+            pl.when(pl.col("type").list.lengths() == 0)
+            .then(pl.lit(None))
+            .otherwise(pl.col("type"))
+            .keep_name()
+        )
+    ).to_dict(False) == {"id": [], "type": []}
+
+
+def test_object_when_then_4702() -> None:
+    # please don't ever do this
+    x = pl.DataFrame({"Row": [1, 2], "Type": [pl.Date, pl.UInt8]})
+
+    assert x.with_columns(
+        pl.when(pl.col("Row") == 1)
+        .then(pl.lit(pl.UInt16, allow_object=True))
+        .otherwise(pl.lit(pl.UInt8, allow_object=True))
+        .alias("New_Type")
+    ).to_dict(False) == {
+        "Row": [1, 2],
+        "Type": [pl.Date, pl.UInt8],
+        "New_Type": [pl.UInt16, pl.UInt8],
+    }

--- a/py-polars/tests/unit/test_arity.py
+++ b/py-polars/tests/unit/test_arity.py
@@ -1,41 +1,4 @@
-from datetime import datetime
-
 import polars as pl
-from polars.testing import assert_frame_equal
-
-
-def test_nested_when_then_and_wildcard_expansion_6284() -> None:
-    df = pl.DataFrame(
-        {
-            "1": ["a", "b"],
-            "2": ["c", "d"],
-        }
-    )
-
-    out0 = df.with_columns(
-        pl.when(pl.any_horizontal(pl.all() == "a"))
-        .then("a")
-        .otherwise(
-            pl.when(pl.any_horizontal(pl.all() == "d")).then("d").otherwise(None)
-        )
-        .alias("result")
-    )
-
-    out1 = df.with_columns(
-        pl.when(pl.any_horizontal(pl.all() == "a"))
-        .then("a")
-        .when(pl.any_horizontal(pl.all() == "d"))
-        .then("d")
-        .otherwise(None)
-        .alias("result")
-    )
-
-    assert_frame_equal(out0, out1)
-    assert out0.to_dict(False) == {
-        "1": ["a", "b"],
-        "2": ["c", "d"],
-        "result": ["a", "d"],
-    }
 
 
 def test_expression_literal_series_order() -> None:
@@ -44,30 +7,3 @@ def test_expression_literal_series_order() -> None:
 
     assert df.select(pl.col("a") + s).to_dict(False) == {"a": [2, 4, 6]}
     assert df.select(pl.lit(s) + pl.col("a")).to_dict(False) == {"": [2, 4, 6]}
-
-
-def test_list_zip_with_logical_type() -> None:
-    df = pl.DataFrame(
-        {
-            "start": [datetime(2023, 1, 1, 1, 1, 1), datetime(2023, 1, 1, 1, 1, 1)],
-            "stop": [datetime(2023, 1, 1, 1, 3, 1), datetime(2023, 1, 1, 1, 4, 1)],
-            "use": [1, 0],
-        }
-    )
-
-    df = df.with_columns(
-        pl.date_ranges(
-            pl.col("start"), pl.col("stop"), interval="1h", eager=False, closed="left"
-        ).alias("interval_1"),
-        pl.date_ranges(
-            pl.col("start"), pl.col("stop"), interval="1h", eager=False, closed="left"
-        ).alias("interval_2"),
-    )
-
-    out = df.select(
-        pl.when(pl.col("use") == 1)
-        .then(pl.col("interval_2"))
-        .otherwise(pl.col("interval_1"))
-        .alias("interval_new")
-    )
-    assert out.dtypes == [pl.List(pl.Datetime(time_unit="us", time_zone=None))]

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -24,23 +24,6 @@ def test_predicate_4906() -> None:
     ).collect().to_dict(False) == {"dt": [date(2022, 9, 10), date(2022, 9, 20)]}
 
 
-def test_when_then_implicit_none() -> None:
-    df = pl.DataFrame(
-        {
-            "team": ["A", "A", "A", "B", "B", "C"],
-            "points": [11, 8, 10, 6, 6, 5],
-        }
-    )
-
-    assert df.select(
-        pl.when(pl.col("points") > 7).then("Foo"),
-        pl.when(pl.col("points") > 7).then("Foo").alias("bar"),
-    ).to_dict(False) == {
-        "literal": ["Foo", "Foo", "Foo", None, None, None],
-        "bar": ["Foo", "Foo", "Foo", None, None, None],
-    }
-
-
 def test_predicate_null_block_asof_join() -> None:
     left = (
         pl.DataFrame(
@@ -106,12 +89,6 @@ def test_streaming_empty_df() -> None:
     )
 
     assert result.to_dict(False) == {"a": [], "b": [], "b_right": []}
-
-
-def test_when_then_empty_list_5547() -> None:
-    out = pl.DataFrame({"a": []}).select([pl.when(pl.col("a") > 1).then([1])])
-    assert out.shape == (0, 1)
-    assert out.dtypes == [pl.List(pl.Int64)]
 
 
 def test_predicate_strptime_6558() -> None:


### PR DESCRIPTION
Closes #9031 

**Syntax for end users remains unchanged.**

Changes:
* Renamed `WhenThen` to `Then`
* Split `WhenThenThen` into `ChainedWhen` and `ChainedThen`.
  * This allows us to enforce a valid when-then chain and have nice auto-completion!
  * Technically, we could have only `ChainedWhen` and `ChainedThen` - we don't need `When`/`Then`. But I figured I would keep them to avoid allocating a vector for the most common case which is single when/then without a chain.
* Make `Then` and `ChainedThen` inherit from `Expr`.
  * This replaces the `getattr` hack
  * You now get nice auto-completion on these objects.
  * These objects now pass `isinstance` checks for `Expr`, which is great and will solve a lot of hidden bugs.