### PR TITLE
docs(python): Add 'nearest' in Expr.interpolation docstring with an example

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5011,18 +5011,17 @@ class Expr:
 
     def interpolate(self, method: InterpolationMethod = "linear") -> Self:
         """
-        Fill nulls with linear or nearest interpolation over missing values.
-
-        Can also be used to regrid data to a new grid - see examples below.
+        Fill null values using interpolation.
 
         Parameters
         ----------
         method : {'linear', 'nearest'}
-            Interpolation method
+            Interpolation method.
 
         Examples
         --------
-        >>> # Fill nulls with linear interpolation
+        Fill null values using linear interpolation.
+
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [1, None, 3],
@@ -5040,13 +5039,9 @@ class Expr:
         │ 2   ┆ NaN │
         │ 3   ┆ 3.0 │
         └─────┴─────┘
-        >>> # Fill nulls with nearest interpolation
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "a": [1, None, 3],
-        ...         "b": [1.0, float("nan"), 3.0],
-        ...     }
-        ... )
+
+        Fill null values using nearest interpolation.
+
         >>> df.select(pl.all().interpolate("nearest"))
         shape: (3, 2)
         ┌─────┬─────┐
@@ -5058,6 +5053,9 @@ class Expr:
         │ 3   ┆ NaN │
         │ 3   ┆ 3.0 │
         └─────┴─────┘
+
+        Regrid data to a new grid.
+
         >>> df_original_grid = pl.DataFrame(
         ...     {
         ...         "grid_points": [1, 3, 10],

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5011,13 +5011,13 @@ class Expr:
 
     def interpolate(self, method: InterpolationMethod = "linear") -> Self:
         """
-        Fill nulls with linear interpolation over missing values.
+        Fill nulls with linear or nearest interpolation over missing values.
 
         Can also be used to regrid data to a new grid - see examples below.
 
         Parameters
         ----------
-        method : {'linear', 'linear'}
+        method : {'linear', 'nearest'}
             Interpolation method
 
         Examples
@@ -5038,6 +5038,24 @@ class Expr:
         ╞═════╪═════╡
         │ 1   ┆ 1.0 │
         │ 2   ┆ NaN │
+        │ 3   ┆ 3.0 │
+        └─────┴─────┘
+        >>> # Fill nulls with nearest interpolation
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [1, None, 3],
+        ...         "b": [1.0, float("nan"), 3.0],
+        ...     }
+        ... )
+        >>> df.select(pl.all().interpolate("nearest"))
+        shape: (3, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ i64 ┆ f64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 1.0 │
+        │ 3   ┆ NaN │
         │ 3   ┆ 3.0 │
         └─────┴─────┘
         >>> df_original_grid = pl.DataFrame(

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5363,12 +5363,12 @@ class Series:
 
     def interpolate(self, method: InterpolationMethod = "linear") -> Series:
         """
-        Interpolate intermediate values. The interpolation method is linear.
+        Fill null values using interpolation.
 
         Parameters
         ----------
         method : {'linear', 'nearest'}
-            Interpolation method
+            Interpolation method.
 
         Examples
         --------


### PR DESCRIPTION
Fixes #9934.

Updated docstring to include also one example with nearest interpolation.