### PR TITLE
feat(python): adds `SQRT`, `CBRT`, `PI` functions to `SQLContext`

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/arithmetic.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/arithmetic.rs
@@ -53,12 +53,22 @@ impl Expr {
     pub fn pow<E: Into<Expr>>(self, exponent: E) -> Self {
         Expr::Function {
             input: vec![self, exponent.into()],
-            function: FunctionExpr::Pow,
+            function: FunctionExpr::Pow(PowFunction::Generic),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
                 ..Default::default()
             },
         }
+    }
+
+    /// Compute the square root of the given expression
+    pub fn sqrt(self) -> Self {
+        self.map_private(FunctionExpr::Pow(PowFunction::Sqrt))
+    }
+
+    /// Compute the cube root of the given expression
+    pub fn cbrt(self) -> Self {
+        self.map_private(FunctionExpr::Pow(PowFunction::Cbrt))
     }
 
     /// Compute the cosine of the given expression

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -79,6 +79,7 @@ pub use self::boolean::BooleanFunction;
 pub(crate) use self::cat::CategoricalFunction;
 #[cfg(feature = "temporal")]
 pub(super) use self::datetime::TemporalFunction;
+pub(super) use self::pow::PowFunction;
 #[cfg(feature = "range")]
 pub(super) use self::range::RangeFunction;
 #[cfg(feature = "strings")]
@@ -95,7 +96,7 @@ pub enum FunctionExpr {
     #[cfg(feature = "abs")]
     Abs,
     NullCount,
-    Pow,
+    Pow(PowFunction),
     #[cfg(feature = "row_hash")]
     Hash(u64, u64, u64, u64),
     #[cfg(feature = "arg_where")]
@@ -241,7 +242,7 @@ impl Display for FunctionExpr {
             #[cfg(feature = "abs")]
             Abs => "abs",
             NullCount => "null_count",
-            Pow => "pow",
+            Pow(func) => return write!(f, "{func}"),
             #[cfg(feature = "row_hash")]
             Hash(_, _, _, _) => "hash",
             #[cfg(feature = "arg_where")]
@@ -428,9 +429,11 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                 };
                 wrap!(f)
             }
-            Pow => {
-                wrap!(pow::pow)
-            }
+            Pow(func) => match func {
+                PowFunction::Generic => wrap!(pow::pow),
+                PowFunction::Sqrt => map!(pow::sqrt),
+                PowFunction::Cbrt => map!(pow::cbrt),
+            },
             #[cfg(feature = "row_hash")]
             Hash(k0, k1, k2, k3) => {
                 map!(row_hash::row_hash, k0, k1, k2, k3)

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -14,7 +14,7 @@ impl FunctionExpr {
             #[cfg(feature = "abs")]
             Abs => mapper.with_same_dtype(),
             NullCount => mapper.with_dtype(IDX_DTYPE),
-            Pow => mapper.map_to_float_dtype(),
+            Pow(_) => mapper.map_to_float_dtype(),
             Coalesce => mapper.map_to_supertype(),
             #[cfg(feature = "row_hash")]
             Hash(..) => mapper.with_dtype(DataType::UInt64),

--- a/polars/polars-lazy/polars-plan/src/dsl/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/mod.rs
@@ -821,6 +821,12 @@ impl Expr {
         self.map_private(FunctionExpr::Floor)
     }
 
+    /// Constant Pi
+    #[cfg(feature = "round_series")]
+    pub fn pi() -> Self {
+        lit(std::f64::consts::PI)
+    }
+
     /// Ceil underlying floating point array to the highest integers smaller or equal to the float value.
     #[cfg(feature = "round_series")]
     pub fn ceil(self) -> Self {

--- a/polars/polars-sql/tests/functions_math.rs
+++ b/polars/polars-sql/tests/functions_math.rs
@@ -50,9 +50,11 @@ fn test_math_functions() {
             col("a").log1p().alias("log1p"),
             col("a").pow(2.0).alias("pow"),
             col("a").sqrt().alias("sqrt"),
-            col("a").pow(1 / 3).alias("cbrt"),
+            col("a").cbrt().alias("cbrt"),
         ])
         .collect()
         .unwrap();
+    println!("{}", df_pl.head(Some(10)));
+    println!("{}", df_sql.head(Some(10)));
     assert!(df_sql.frame_equal_missing(&df_pl));
 }

--- a/polars/polars-sql/tests/functions_math.rs
+++ b/polars/polars-sql/tests/functions_math.rs
@@ -1,5 +1,4 @@
 use polars_core::prelude::*;
-use polars_core::utils::rayon::iter::repeat;
 use polars_lazy::prelude::*;
 use polars_sql::*;
 

--- a/polars/polars-sql/tests/functions_math.rs
+++ b/polars/polars-sql/tests/functions_math.rs
@@ -1,4 +1,5 @@
 use polars_core::prelude::*;
+use polars_core::utils::rayon::iter::repeat;
 use polars_lazy::prelude::*;
 use polars_sql::*;
 
@@ -17,6 +18,7 @@ fn test_math_functions() {
             ACOS(a) AS acos,
             ASIN(a) AS asin,
             ATAN(a) AS atan,
+            PI() AS pi,
             CEIL(a) AS ceil,
             EXP(a) AS exp,
             FLOOR(a) AS floor,
@@ -25,7 +27,9 @@ fn test_math_functions() {
             LOG10(a) AS log10,
             LOG(a, 5) AS log5,
             LOG1P(a) AS log1p,
-            POW(a, 2) AS pow
+            POW(a, 2) AS pow,
+            SQRT(a) AS sqrt,
+            CBRT(a) AS cbrt
         FROM df"#;
     let df_sql = context.execute(sql).unwrap().collect().unwrap();
     let df_pl = df
@@ -36,6 +40,7 @@ fn test_math_functions() {
             col("a").arccos().alias("acos"),
             col("a").arcsin().alias("asin"),
             col("a").arctan().alias("atan"),
+            lit(std::f64::consts::PI).alias("pi"),
             col("a").ceil().alias("ceil"),
             col("a").exp().alias("exp"),
             col("a").floor().alias("floor"),
@@ -45,6 +50,8 @@ fn test_math_functions() {
             col("a").log(5.0).alias("log5"),
             col("a").log1p().alias("log1p"),
             col("a").pow(2.0).alias("pow"),
+            col("a").sqrt().alias("sqrt"),
+            col("a").pow(1 / 3).alias("cbrt"),
         ])
         .collect()
         .unwrap();

--- a/py-polars/docs/source/reference/expressions/computation.rst
+++ b/py-polars/docs/source/reference/expressions/computation.rst
@@ -15,6 +15,7 @@ Computation
     Expr.arctan
     Expr.arctanh
     Expr.arg_unique
+    Expr.cbrt
     Expr.cos
     Expr.cosh
     Expr.cumcount
@@ -58,7 +59,6 @@ Computation
     Expr.sinh
     Expr.skew
     Expr.sqrt
-    Expr.cbrt
     Expr.tan
     Expr.tanh
     Expr.unique

--- a/py-polars/docs/source/reference/expressions/computation.rst
+++ b/py-polars/docs/source/reference/expressions/computation.rst
@@ -58,6 +58,7 @@ Computation
     Expr.sinh
     Expr.skew
     Expr.sqrt
+    Expr.cbrt
     Expr.tan
     Expr.tanh
     Expr.unique

--- a/py-polars/docs/source/reference/series/computation.rst
+++ b/py-polars/docs/source/reference/series/computation.rst
@@ -15,6 +15,7 @@ Computation
     Series.arctanh
     Series.arg_true
     Series.arg_unique
+    Series.cbrt
     Series.cos
     Series.cosh
     Series.cummax
@@ -56,6 +57,5 @@ Computation
     Series.sinh
     Series.skew
     Series.sqrt
-    Series.cbrt
     Series.tan
     Series.tanh

--- a/py-polars/docs/source/reference/series/computation.rst
+++ b/py-polars/docs/source/reference/series/computation.rst
@@ -56,5 +56,6 @@ Computation
     Series.sinh
     Series.skew
     Series.sqrt
+    Series.cbrt
     Series.tan
     Series.tanh

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -464,7 +464,29 @@ class Expr:
         └──────────┘
 
         """
-        return self**0.5
+        return self._from_pyexpr(self._pyexpr.sqrt())
+
+    def cbrt(self) -> Self:
+        """
+        Compute the cube root of the elements.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"values": [1.0, 2.0, 4.0]})
+        >>> df.select(pl.col("values").cbrt())
+        shape: (3, 1)
+        ┌──────────┐
+        │ values   │
+        │ ---      │
+        │ f64      │
+        ╞══════════╡
+        │ 1.0      │
+        │ 1.259921 │
+        │ 1.587401 │
+        └──────────┘
+
+        """
+        return self._from_pyexpr(self._pyexpr.cbrt())
 
     def log10(self) -> Self:
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1196,6 +1196,22 @@ class Series:
 
         """
 
+    def cbrt(self) -> Series:
+        """
+        Compute the cube root of the elements.
+
+        Optimization for
+
+        >>> pl.Series([1, 2]) ** (1.0 / 3)
+        shape: (2,)
+        Series: '' [f64]
+        [
+            1.0
+            1.259921
+        ]
+
+        """
+
     def any(self, drop_nulls: bool = True) -> bool | None:
         """
         Check if any boolean value in the column is `True`.

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -556,6 +556,14 @@ impl PyExpr {
         self.clone().inner.pow(exponent.inner).into()
     }
 
+    fn sqrt(&self) -> Self {
+        self.clone().inner.sqrt().into()
+    }
+
+    fn cbrt(&self) -> Self {
+        self.clone().inner.cbrt().into()
+    }
+
     fn cumsum(&self, reverse: bool) -> Self {
         self.clone().inner.cumsum(reverse).into()
     }

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1366,6 +1366,15 @@ def test_sqrt() -> None:
     )
 
 
+def test_cbrt() -> None:
+    s = pl.Series("a", [1, 2])
+    assert_series_equal(s.cbrt(), pl.Series("a", [1.0, np.cbrt(2)]))
+    df = pl.DataFrame([s])
+    assert_series_equal(
+        df.select(pl.col("a").cbrt())["a"], pl.Series("a", [1.0, np.cbrt(2)])
+    )
+
+
 def test_range() -> None:
     s1 = pl.Series("a", [1, 2, 3, 2, 2, 3, 0])
     assert_series_equal(s1[2:5], s1[range(2, 5)])


### PR DESCRIPTION
Adds three functions to `SQLContext`, as shown below:

I'm grabbing suggestions for SQL features from https://github.com/pola-rs/polars/issues/7227. I threw `PI()` into this pr at the last moment, but I could split it out if needed. 

![image](https://github.com/pola-rs/polars/assets/37670616/56639334-cefa-42b4-902f-7f7d15214f24)
