### PR TITLE
fix(rust,python): Fix as-of join when `by` groups are interleaved

### DIFF
--- a/polars/polars-core/src/frame/asof_join/groups.rs
+++ b/polars/polars-core/src/frame/asof_join/groups.rs
@@ -152,26 +152,26 @@ pub(super) unsafe fn join_asof_nearest_with_indirection<
     if offsets.is_empty() {
         return (None, 0);
     }
-    let max_value = <T as Bounded>::max_value();
-    let mut dist: T = max_value;
+    let max_possible_dist = <T as Bounded>::max_value();
+    let mut dist: T = max_possible_dist;
+    let mut prev_offset: u32 = 0;
     for (idx, &offset) in offsets.iter().enumerate() {
         let val_r = *right.get_unchecked(offset as usize);
-        if val_r >= val_l {
-            // This is (val_r - val_l).abs(), but works on strings/dates
-            let dist_curr = if val_r > val_l {
-                val_r - val_l
-            } else {
-                val_l - val_r
-            };
-            if dist_curr <= dist {
-                // candidate for match
-                dist = dist_curr;
-            } else {
-                // note for a nearest-match, we can re-match on the same val_r next time,
-                // so we need to rewind the idx by 1
-                return (Some(offset - 1), idx - 1);
-            }
+        // This is (val_r - val_l).abs(), but works on strings/dates
+        let dist_curr = if val_r > val_l {
+            val_r - val_l
+        } else {
+            val_l - val_r
+        };
+        if dist_curr <= dist {
+            // candidate for match
+            dist = dist_curr;
+        } else {
+            // note for a nearest-match, we can re-match on the same val_r next time,
+            // so we need to rewind the idx by 1
+            return (Some(prev_offset), idx - 1);
         }
+        prev_offset = offset;
     }
 
     // if we've reached the end with nearest and haven't returned, it means that the last item was the closest

--- a/polars/polars-core/src/frame/asof_join/groups.rs
+++ b/polars/polars-core/src/frame/asof_join/groups.rs
@@ -154,7 +154,7 @@ pub(super) unsafe fn join_asof_nearest_with_indirection<
     }
     let max_possible_dist = <T as Bounded>::max_value();
     let mut dist: T = max_possible_dist;
-    let mut prev_offset: u32 = 0;
+    let mut prev_offset: IdxSize = 0;
     for (idx, &offset) in offsets.iter().enumerate() {
         let val_r = *right.get_unchecked(offset as usize);
         // This is (val_r - val_l).abs(), but works on strings/dates

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -441,6 +441,31 @@ def test_asof_join_nearest_by() -> None:
     out = df1.join_asof(df2, on="asof_key", by="group", strategy="nearest")
     assert_frame_equal(out, expected)
 
+    a = pl.DataFrame(
+        {
+            "code": [676, 35, 676, 676, 676],
+            "time": [364360, 364370, 364380, 365400, 367440],
+        }
+    )
+    b = pl.DataFrame(
+        {
+            "code": [676, 676, 35, 676, 676],
+            "time": [364000, 365000, 365000, 366000, 367000],
+            "price": [1.0, 2.0, 50, 3.0, None],
+        }
+    )
+
+    expected = pl.DataFrame(
+        {
+            "code": [676, 35, 676, 676, 676],
+            "time": [364360, 364370, 364380, 365400, 367440],
+            "price": [1.0, 50.0, 1.0, 2.0, None],
+        }
+    )
+
+    out = a.join_asof(b, by="code", on="time", strategy="nearest")
+    assert_frame_equal(out, expected)
+
 
 def test_asof_join_nearest_by_date() -> None:
     df1 = pl.DataFrame(


### PR DESCRIPTION
Resolves #9930.