### PR TITLE
docs(python): Move `sink_*` methods to IO chapter

### DIFF
--- a/py-polars/docs/source/reference/io.rst
+++ b/py-polars/docs/source/reference/io.rst
@@ -24,6 +24,7 @@ Feather/ IPC
    scan_ipc
    read_ipc_schema
    DataFrame.write_ipc
+   LazyFrame.sink_ipc
 
 Parquet
 ~~~~~~~
@@ -34,6 +35,7 @@ Parquet
    scan_parquet
    read_parquet_schema
    DataFrame.write_parquet
+   LazyFrame.sink_parquet
 
 Database
 ~~~~~~~~

--- a/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
@@ -13,9 +13,6 @@ Miscellaneous
     LazyFrame.map
     LazyFrame.pipe
     LazyFrame.profile
-    LazyFrame.sink_ipc
-    LazyFrame.sink_parquet
-
 
 Read/write logical plan
 -----------------------


### PR DESCRIPTION
Closes #9928 