### PR TITLE
fix(rust, python): raise on unsupported transpose and object types

### DIFF
--- a/polars/polars-core/src/frame/row/transpose.rs
+++ b/polars/polars-core/src/frame/row/transpose.rs
@@ -20,6 +20,11 @@ impl DataFrame {
             DataType::UInt64 => numeric_transpose::<UInt64Type>(&self.columns),
             DataType::Float32 => numeric_transpose::<Float32Type>(&self.columns),
             DataType::Float64 => numeric_transpose::<Float64Type>(&self.columns),
+            #[cfg(feature = "object")]
+            DataType::Object(_) => {
+                // this requires to support `Object` in Series::iter which we don't yet
+                polars_bail!(InvalidOperation: "Object dtype not supported in 'transpose'")
+            }
             _ => {
                 let phys_dtype = dtype.to_physical();
                 let mut buffers = (0..new_width)

--- a/polars/polars-core/src/series/iterator.rs
+++ b/polars/polars-core/src/series/iterator.rs
@@ -66,6 +66,11 @@ impl Series {
     /// This will panic if the array is not rechunked first.
     pub fn iter(&self) -> SeriesIter<'_> {
         let dtype = self.dtype();
+        #[cfg(feature = "object")]
+        assert!(
+            !matches!(dtype, DataType::Object(_)),
+            "object dtype not supported in Series.iter"
+        );
         assert_eq!(self.chunks().len(), 1, "impl error");
         let arr = &*self.chunks()[0];
         let len = arr.len();
@@ -83,6 +88,11 @@ impl Series {
 
         assert_eq!(dtype, &phys_dtype, "impl error");
         assert_eq!(self.chunks().len(), 1, "impl error");
+        #[cfg(feature = "object")]
+        assert!(
+            !matches!(dtype, DataType::Object(_)),
+            "object dtype not supported in Series.iter"
+        );
         let arr = &*self.chunks()[0];
 
         if phys_dtype.is_numeric() {

--- a/py-polars/tests/unit/operations/test_transpose.py
+++ b/py-polars/tests/unit/operations/test_transpose.py
@@ -150,5 +150,8 @@ def test_transpose_logical_data() -> None:
 
 
 def test_err_transpose_object() -> None:
+    class CustomObject:
+        pass
+
     with pytest.raises(pl.InvalidOperationError):
-        pl.DataFrame([object()]).transpose()
+        pl.DataFrame([CustomObject()]).transpose()

--- a/py-polars/tests/unit/operations/test_transpose.py
+++ b/py-polars/tests/unit/operations/test_transpose.py
@@ -147,3 +147,8 @@ def test_transpose_logical_data() -> None:
         }
     )
     assert_frame_equal(result, expected)
+
+
+def test_err_transpose_object() -> None:
+    with pytest.raises(pl.InvalidOperationError):
+        pl.DataFrame([object()]).transpose()


### PR DESCRIPTION
We don't have the architecture in place yet to support objects. Let's raise for now.

fixes #9927 