### PR TITLE
feat(python): suggest map_dict instead of apply lambda x: dict[x]

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -192,6 +192,20 @@ def _can_rewrite_as_expression(
                 or ops[i - 2][0] not in ("LOAD_GLOBAL", "LOAD_DEREF")
             ):
                 return False
+            import inspect
+
+            dict_name = ops[i - 2][1]
+            for frameinfo in inspect.stack(0):
+                if dict_name in frameinfo.frame.f_locals:
+                    if isinstance(frameinfo.frame.f_locals[dict_name], dict):
+                        return True
+                elif dict_name in frameinfo.frame.f_globals:
+                    if isinstance(frameinfo.frame.f_globals[dict_name], dict):
+                        return True
+            else:
+                # Couldn't find the dict_name variable,
+                # or found it but it's not a dict.
+                return False
         elif op[0] not in simple_ops:
             return False
         elif op[0] in _LOGICAL_OPCODES:

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -78,7 +78,9 @@ class BytecodeParser:
 
     _can_rewrite: dict[str, bool]
 
-    def __init__(self, function: Callable[[Any], Any], apply_target: str, stacklevel: int):
+    def __init__(
+        self, function: Callable[[Any], Any], apply_target: str, stacklevel: int
+    ):
         self._can_rewrite = {}
         self._apply_target = apply_target
         self._param_name = self._get_param_name(function)
@@ -228,7 +230,8 @@ class BytecodeParser:
                         if (
                             i < 2
                             or self._instructions[i - 1].argval != self._param_name
-                            or self._instructions[i - 2].opname not in ("LOAD_GLOBAL", "LOAD_DEREF")
+                            or self._instructions[i - 2].opname
+                            not in ("LOAD_GLOBAL", "LOAD_DEREF")
                         ):
                             return False
 
@@ -237,8 +240,14 @@ class BytecodeParser:
                         dict_name = self._instructions[i - 2].argval
                         frame = inspect.stack(0)[self._stacklevel]
                         if not (
-                            (dict_name in frame.frame.f_locals and isinstance(frame.frame.f_locals[dict_name], dict))
-                            or (dict_name in frame.frame.f_globals and isinstance(frame.frame.f_globals[dict_name], dict))
+                            (
+                                dict_name in frame.frame.f_locals
+                                and isinstance(frame.frame.f_locals[dict_name], dict)
+                            )
+                            or (
+                                dict_name in frame.frame.f_globals
+                                and isinstance(frame.frame.f_globals[dict_name], dict)
+                            )
                         ):
                             return False
                     elif op.opname not in _SIMPLE_EXPR_OPS:
@@ -345,7 +354,7 @@ class BytecodeParser:
                 "In this case, you can replace your `apply` with an expression:\n"
                 f"{before_after_suggestion}",
                 PolarsInefficientApplyWarning,
-                stacklevel=self._stacklevel+1,
+                stacklevel=self._stacklevel + 1,
             )
 
 

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -222,7 +222,13 @@ def _get_bytecode_ops(function: Callable[[Any], Any]) -> list[ByteCodeInfo]:
         return [
             _upgrade_instruction(inst.opname, inst.argrepr, inst.argval, inst.offset)
             for idx, inst in enumerate(instructions)
-            if (idx, inst.opname) not in ((0, "RESUME"), (idx_last, "RETURN_VALUE"))
+            if (idx, inst.opname)
+            not in (
+                (0, "COPY_FREE_VARS"),
+                (0, "RESUME"),
+                (1, "RESUME"),
+                (idx_last, "RETURN_VALUE"),
+            )
         ]
     except TypeError:
         # in case we hit something that can't be disassembled (eg: code object

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -100,7 +100,7 @@ def test_map_dict() -> None:
     my_local_dict = {"1": 1, "2": 2, "3": 3}
     for func in [
         lambda x: my_local_dict[x],
-        # lambda x: MY_GLOBAL_DICT[x],
+        lambda x: MY_GLOBAL_DICT[x],
     ]:
         suggestion = _get_suggestion(func, "a", "expr", "x")
         assert suggestion is not None

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -7,7 +7,6 @@ import pytest
 
 import polars as pl
 from polars.exceptions import PolarsInefficientApplyWarning
-from polars.utils.various import find_stacklevel
 from polars.utils.udfs import BytecodeParser
 
 MY_CONSTANT = 3
@@ -85,7 +84,9 @@ def test_expr_apply_parsing_misc() -> None:
 
     # note: all constants - should not create a warning/suggestion
     suggested_expression = BytecodeParser(
-        lambda x: MY_CONSTANT + 42, apply_target="expr", stacklevel=2,
+        lambda x: MY_CONSTANT + 42,
+        apply_target="expr",
+        stacklevel=2,
     ).to_expression(col="colx")
     assert suggested_expression is None
 
@@ -96,7 +97,9 @@ def test_map_dict() -> None:
         lambda x: my_local_dict[x],
         lambda x: MY_GLOBAL_DICT[x],
     ]:
-        suggestion = BytecodeParser(func, apply_target="expr", stacklevel=2).to_expression(col='a')
+        suggestion = BytecodeParser(
+            func, apply_target="expr", stacklevel=2
+        ).to_expression(col="a")
         assert suggestion is not None
 
         df = pl.DataFrame({"a": [1, 2, 3]})

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -8,6 +8,7 @@ import pytest
 import polars as pl
 from polars.exceptions import PolarsInefficientApplyWarning
 from polars.utils.udfs import BytecodeParser
+from polars.utils.various import find_stacklevel
 
 MY_CONSTANT = 3
 MY_GLOBAL_DICT = {1: 2, 2: 3, 3: 1}
@@ -56,7 +57,7 @@ def test_expr_apply_produces_warning(func: Callable[[Any], Any]) -> None:
     with pytest.warns(
         PolarsInefficientApplyWarning, match="In this case, you can replace"
     ):
-        parser = BytecodeParser(func, apply_target="expr", stacklevel=2)
+        parser = BytecodeParser(func, apply_target="expr", stacklevel=find_stacklevel())
         suggested_expression = parser.to_expression(col="a")
         assert suggested_expression is not None
 

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -13,6 +13,7 @@ from polars.utils.udfs import (
     _get_bytecode_ops,
     _param_name_from_signature,
 )
+from polars.utils.various import find_stacklevel
 
 MY_CONSTANT = 3
 MY_GLOBAL_DICT = {1: 2, 2: 3, 3: 1}
@@ -40,8 +41,12 @@ def _get_suggestion(
     ],
 )
 def test_non_simple_function(func: Callable[[Any], Any]) -> None:
+    stacklevel = find_stacklevel()
     assert not _param_name_from_signature(func) or not _can_rewrite_as_expression(
-        _get_bytecode_ops(func), apply_target="expr", param_name="x", function=func
+        _get_bytecode_ops(func),
+        apply_target="expr",
+        param_name="x",
+        stacklevel=stacklevel + 1,
     )
 
 

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -15,7 +15,8 @@ from polars.utils.udfs import (
 )
 
 MY_CONSTANT = 3
-MY_GLOBAL_DICT = {"1": 1, "2": 2, "3": 3}
+MY_GLOBAL_DICT = {1: 2, 2: 3, 3: 1}
+MY_GLOBAL_ARRAY = [1, 2, 3]
 
 
 def _get_suggestion(
@@ -35,6 +36,7 @@ def _get_suggestion(
         lambda x: x[0] + 1,
         lambda x: x,
         lambda x: x > 0 and (x < 100 or (x % 2 == 0)),
+        lambda x: MY_GLOBAL_ARRAY[x],
     ],
 )
 def test_non_simple_function(func: Callable[[Any], Any]) -> None:
@@ -97,7 +99,7 @@ def test_expr_apply_produces_warning_misc() -> None:
 
 
 def test_map_dict() -> None:
-    my_local_dict = {"1": 1, "2": 2, "3": 3}
+    my_local_dict = {1: 2, 2: 3, 3: 1}
     for func in [
         lambda x: my_local_dict[x],
         lambda x: MY_GLOBAL_DICT[x],
@@ -105,7 +107,7 @@ def test_map_dict() -> None:
         suggestion = _get_suggestion(func, "a", "expr", "x")
         assert suggestion is not None
 
-        df = pl.DataFrame({"a": ["1", "2", "3"]})
+        df = pl.DataFrame({"a": [1, 2, 3]})
         result = df.select(
             x="a",
             y=eval(suggestion),

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -41,7 +41,7 @@ def _get_suggestion(
 )
 def test_non_simple_function(func: Callable[[Any], Any]) -> None:
     assert not _param_name_from_signature(func) or not _can_rewrite_as_expression(
-        _get_bytecode_ops(func), apply_target="expr", param_name="x"
+        _get_bytecode_ops(func), apply_target="expr", param_name="x", function=func
     )
 
 

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -96,11 +96,11 @@ def test_expr_apply_produces_warning_misc() -> None:
     assert suggestion == 'pl.col("colx") * 10'
 
 
-def test_map_dict_local_dict() -> None:
+def test_map_dict() -> None:
     my_local_dict = {"1": 1, "2": 2, "3": 3}
     for func in [
         lambda x: my_local_dict[x],
-        lambda x: MY_GLOBAL_DICT[x],
+        # lambda x: MY_GLOBAL_DICT[x],
     ]:
         suggestion = _get_suggestion(func, "a", "expr", "x")
         assert suggestion is not None

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -43,7 +43,8 @@ def _get_suggestion(
 def test_non_simple_function(func: Callable[[Any], Any]) -> None:
     stacklevel = find_stacklevel()
     assert not _param_name_from_signature(func) or not _can_rewrite_as_expression(
-        _get_bytecode_instructions(func), apply_target="expr",
+        _get_bytecode_instructions(func),
+        apply_target="expr",
         param_name="x",
         stacklevel=stacklevel + 1,
     )


### PR DESCRIPTION
work in progress of a suggestion for a very simple `apply` case (spotted here: https://www.kaggle.com/code/radek1/polars-proof-of-concept-lgbm-ranker)

EDIT: this one can probably be combined with the other binary operations, so
```python
pl.col('a').apply(lambda x: my_dict[x] + 1)
```
gets rewritten as
```python
pl.col('a').map_dict(my_dict) + 1
```