### PR TITLE
fix(rust, python): don't pass predicates referring to renamed literal…

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/format.rs
@@ -137,7 +137,8 @@ impl LogicalPlan {
                 )
             }
             Selection { predicate, input } => {
-                write!(f, "{:indent$}FILTER {predicate:?} FROM", "")?;
+                // this one is writeln because we don't increase indent (which inserts a line)
+                writeln!(f, "{:indent$}FILTER {predicate:?} FROM", "")?;
                 input._format(f, indent)
             }
             DataFrameScan {

--- a/polars/tests/it/lazy/predicate_queries.rs
+++ b/polars/tests/it/lazy/predicate_queries.rs
@@ -235,3 +235,21 @@ fn test_predicate_on_join_select_4884() -> PolarsResult<()> {
     assert_eq!(out, expected);
     Ok(())
 }
+
+#[test]
+fn test_predicate_pushdown_block_8847() -> PolarsResult<()> {
+    let ldf = df![
+        "A" => [1, 2, 3]
+    ]?
+    .lazy();
+
+    let q = ldf
+        .with_column(lit(1).strict_cast(DataType::Int32).alias("B"))
+        .drop_nulls(None)
+        .filter(col("B").eq(lit(1)));
+
+    let out = q.collect()?;
+    assert_eq!(out.get_column_names(), &["A", "B"]);
+
+    Ok(())
+}


### PR DESCRIPTION
…s in predicate pushdown

fixes #8847