### PR TITLE
refactor(python): use original `Instruction` objects during bytecode translation

### DIFF
--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -8,9 +8,9 @@ import pytest
 import polars as pl
 from polars.exceptions import PolarsInefficientApplyWarning
 from polars.utils.udfs import (
-    _bytecode_to_expression,
     _can_rewrite_as_expression,
-    _get_bytecode_ops,
+    _get_bytecode_instructions,
+    _instructions_to_expression,
     _param_name_from_signature,
 )
 
@@ -20,8 +20,8 @@ MY_CONSTANT = 3
 def _get_suggestion(
     func: Callable[[Any], Any], col: str, apply_target: str, param_name: str
 ) -> str | None:
-    return _bytecode_to_expression(
-        _get_bytecode_ops(func), col, apply_target, param_name
+    return _instructions_to_expression(
+        _get_bytecode_instructions(func), col, apply_target, param_name
     )
 
 
@@ -39,7 +39,7 @@ def _get_suggestion(
 )
 def test_non_simple_function(func: Callable[[Any], Any]) -> None:
     assert not _param_name_from_signature(func) or not _can_rewrite_as_expression(
-        _get_bytecode_ops(func), apply_target="expr"
+        _get_bytecode_instructions(func), apply_target="expr"
     )
 
 


### PR DESCRIPTION
@MarcoGorelli, as promised... updated to use the original/underlying bytecode `Instruction` objects _directly_, so we can use the named properties and avoid "mystery meat" references like `op[0]`, `op[2]` and so forth... 

**Also:**
* Makes `StackValue` a NamedTuple to improve clarity of usage.
* More error information if an unidentified operation is found where it shouldn't be.
