### PR TITLE
chore: Update autolabeler again

### DIFF
--- a/.github/release-drafter-python.yml
+++ b/.github/release-drafter-python.yml
@@ -6,3 +6,10 @@ tag-prefix: py-
 
 include-labels:
   - python
+
+version-resolver:
+  minor:
+    labels:
+      - breaking
+      - breaking python
+  default: patch

--- a/.github/release-drafter-rust.yml
+++ b/.github/release-drafter-rust.yml
@@ -6,3 +6,10 @@ tag-prefix: rs-
 
 include-labels:
   - rust
+
+version-resolver:
+  minor:
+    labels:
+      - breaking
+      - breaking rust
+  default: patch

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -18,40 +18,47 @@ categories:
       - internal
 
 exclude-labels:
-  - skip-changelog
+  - skip changelog
   - release
 
 change-template: '- $TITLE (#$NUMBER)'
 change-title-escapes: '\<*_&'
 replacers:
   # Remove conventional commits from titles
-  - search: '/- (build|chore|depr|docs|feat|fix|perf|release)(\(.*\))?(\!)?\: /g'
+  - search: '/- (build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)(\(.*\))?(\!)?\: /g'
     replace: '- '
-
-version-resolver:
-  minor:
-    labels: breaking
-  default: patch
 
 autolabeler:
   - label: rust
     title:
-      - '/^(build|chore|depr|docs|feat|fix|perf|release)(\(.*rust.*\))?\!?\: /'
+      # Example: feat(rust): ...
+      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)(\(.*rust.*\))?\!?\: /'
   - label: python
     title:
-      - '/^(build|chore|depr|docs|feat|fix|perf|release)(\(.*python.*\))?\!?\: /'
+      # Example: feat(python): ...
+      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)(\(.*python.*\))?\!?\: /'
   - label: cli
     title:
-      - '/^(build|chore|depr|docs|feat|fix|perf|release)\(.*cli.*\)\!?\: /'  # CLI tag not in global scope
+      # Example: feat(cli): ...
+      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)\(.*cli.*\)\!?\: /'  # CLI tag not in global scope
   - label: breaking
     title:
-      - '/^(build|chore|depr|docs|feat|fix|perf|release)(\(.*\))?\!\: /'
+      # Example: feat!: ...
+      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)(\(.*\))?\!\: /'
+  - label: breaking rust
+    title:
+      # Example: feat(rust!, python): ...
+      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)\(.*rust\!.*\)\: /'
+  - label: breaking python
+    title:
+      # Example: feat(python!): ...
+      - '/^(build|chore|ci|depr|docs|feat|fix|perf|refactor|release|test)\(.*python\!.*\)\: /'
   - label: build
     title:
       - '/^build/'
   - label: internal
     title:
-      - '/^chore/'
+      - '/^(chore|ci|refactor|test)/'
   - label: deprecation
     title:
       - '/^depr/'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Please describe the behavior you want and why, and provide examples of how Polar
 ### Picking an issue
 
 Pick an issue by going through the [issue tracker](https://github.com/pola-rs/polars/issues) and finding an issue you would like to work on.
-Feel free to pick any issue that is not already assigned.
+Feel free to pick any issue with an [accepted](https://github.com/pola-rs/polars/issues?q=is%3Aopen+is%3Aissue+label%3Aaccepted) label that is not already assigned.
 We use the [help wanted](https://github.com/pola-rs/polars/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) label to indicate issues that are high on our wishlist.
 
 If you are a first time contributor, you might want to look for issues labeled [good first issue](https://github.com/pola-rs/polars/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).


### PR DESCRIPTION
Changes:
* Re-introduce `ci` / `refactor` / `test` types. The resulting label will be `internal`.
* Add `breaking rust` and `breaking python` labels. This is useful for PRs that break one side but not the other. Use it by adding an exclamation point to the scope, e.g. `feat(rust!, python): New feature`
* Add a note to the Contributing guide about the `accepted` label.