### PR TITLE
refactor(python): Clean up `date_range`/`time_range`

### DIFF
--- a/py-polars/src/functions/eager.rs
+++ b/py-polars/src/functions/eager.rs
@@ -1,10 +1,9 @@
-use polars::{functions, time};
+use polars::functions;
 use polars_core::prelude::*;
 use pyo3::prelude::*;
 
-use crate::conversion::{get_df, get_series, Wrap};
+use crate::conversion::{get_df, get_series};
 use crate::error::PyPolarsErr;
-use crate::prelude::{ClosedWindow, Duration};
 use crate::{PyDataFrame, PySeries};
 
 #[pyfunction]
@@ -91,16 +90,4 @@ pub fn hor_concat_df(dfs: &PyAny) -> PyResult<PyDataFrame> {
 
     let df = functions::hor_concat_df(&dfs).map_err(PyPolarsErr::from)?;
     Ok(df.into())
-}
-
-#[pyfunction]
-pub fn time_range_eager(
-    start: i64,
-    stop: i64,
-    every: &str,
-    closed: Wrap<ClosedWindow>,
-) -> PyResult<PySeries> {
-    let time_range = time::time_range_impl("time", start, stop, Duration::parse(every), closed.0)
-        .map_err(PyPolarsErr::from)?;
-    Ok(time_range.into_series().into())
 }

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -1,7 +1,6 @@
 use polars::lazy::dsl;
 use polars::lazy::dsl::Expr;
 use polars::prelude::*;
-use polars_core::datatypes::TimeZone;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyFloat, PyInt, PyString};
@@ -9,9 +8,7 @@ use pyo3::types::{PyBool, PyBytes, PyFloat, PyInt, PyString};
 use crate::apply::lazy::binary_lambda;
 use crate::conversion::{get_lf, Wrap};
 use crate::expr::ToExprs;
-use crate::prelude::{
-    vec_extract_wrapped, ClosedWindow, DataType, DatetimeArgs, Duration, DurationArgs, ObjectValue,
-};
+use crate::prelude::{vec_extract_wrapped, DataType, DatetimeArgs, DurationArgs, ObjectValue};
 use crate::{apply, PyDataFrame, PyExpr, PyLazyFrame, PyPolarsErr, PySeries};
 
 macro_rules! set_unwrapped_or_0 {
@@ -177,29 +174,6 @@ pub fn cumreduce(lambda: PyObject, exprs: Vec<PyExpr>) -> PyExpr {
 
     let func = move |a: Series, b: Series| binary_lambda(&lambda, a, b);
     dsl::cumreduce_exprs(func, exprs).into()
-}
-
-#[pyfunction]
-pub fn date_range_lazy(
-    start: PyExpr,
-    end: PyExpr,
-    every: &str,
-    closed: Wrap<ClosedWindow>,
-    time_unit: Option<Wrap<TimeUnit>>,
-    time_zone: Option<TimeZone>,
-) -> PyExpr {
-    let start = start.inner;
-    let end = end.inner;
-    let every = Duration::parse(every);
-    dsl::functions::date_range(
-        start,
-        end,
-        every,
-        closed.0,
-        time_unit.map(|x| x.0),
-        time_zone,
-    )
-    .into()
 }
 
 #[pyfunction]
@@ -424,19 +398,6 @@ pub fn spearman_rank_corr(a: PyExpr, b: PyExpr, ddof: u8, propagate_nans: bool) 
     {
         panic!("activate 'propagate_nans'")
     }
-}
-
-#[pyfunction]
-pub fn time_range_lazy(
-    start: PyExpr,
-    end: PyExpr,
-    every: &str,
-    closed: Wrap<ClosedWindow>,
-) -> PyExpr {
-    let start = start.inner;
-    let end = end.inner;
-    let every = Duration::parse(every);
-    dsl::functions::time_range(start, end, every, closed.0).into()
 }
 
 #[pyfunction]

--- a/py-polars/src/functions/range.rs
+++ b/py-polars/src/functions/range.rs
@@ -34,3 +34,29 @@ pub fn int_ranges(start: PyExpr, end: PyExpr, step: i64, dtype: Wrap<DataType>) 
 
     result.into()
 }
+
+#[pyfunction]
+pub fn date_range(
+    start: PyExpr,
+    end: PyExpr,
+    every: &str,
+    closed: Wrap<ClosedWindow>,
+    time_unit: Option<Wrap<TimeUnit>>,
+    time_zone: Option<TimeZone>,
+) -> PyExpr {
+    let start = start.inner;
+    let end = end.inner;
+    let every = Duration::parse(every);
+    let closed = closed.0;
+    let time_unit = time_unit.map(|x| x.0);
+    dsl::date_range(start, end, every, closed, time_unit, time_zone).into()
+}
+
+#[pyfunction]
+pub fn time_range(start: PyExpr, end: PyExpr, every: &str, closed: Wrap<ClosedWindow>) -> PyExpr {
+    let start = start.inner;
+    let end = end.inner;
+    let every = Duration::parse(every);
+    let closed = closed.0;
+    dsl::time_range(start, end, every, closed).into()
+}

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -88,8 +88,6 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::eager::hor_concat_df))
         .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::eager::time_range_eager))
-        .unwrap();
 
     // Functions - range
     m.add_wrapped(wrap_pyfunction!(functions::range::arange))
@@ -97,6 +95,10 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(functions::range::int_range))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::range::int_ranges))
+        .unwrap();
+    m.add_wrapped(wrap_pyfunction!(functions::range::date_range))
+        .unwrap();
+    m.add_wrapped(wrap_pyfunction!(functions::range::time_range))
         .unwrap();
 
     // Functions - aggregation
@@ -140,8 +142,6 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::cumreduce))
         .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::lazy::date_range_lazy))
-        .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::datetime))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::diag_concat_lf))
@@ -173,8 +173,6 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(functions::lazy::repeat))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::lazy::spearman_rank_corr))
-        .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::lazy::time_range_lazy))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::whenthen::when))
         .unwrap();

--- a/py-polars/tests/unit/functions/test_range.py
+++ b/py-polars/tests/unit/functions/test_range.py
@@ -234,11 +234,11 @@ def test_date_range_precision(time_unit: TimeUnit | None, expected_micros: int) 
 
 
 def test_range_invalid_unit() -> None:
-    with pytest.raises(pl.PolarsPanicError, match="'D' not supported"):
+    with pytest.raises(pl.PolarsPanicError, match="'x' not supported"):
         pl.date_range(
             start=datetime(2021, 12, 16),
             end=datetime(2021, 12, 16, 3),
-            interval="1D",
+            interval="1X",
             eager=True,
         )
 


### PR DESCRIPTION
I am working on a non-breaking version of https://github.com/pola-rs/polars/pull/9653. Figured I'd clean up these functions before reworking them.