### PR TITLE
perf(rust, python): Rolling min/max with nulls

### DIFF
--- a/crates/polars-arrow/src/kernels/rolling/nulls/min_max.rs
+++ b/crates/polars-arrow/src/kernels/rolling/nulls/min_max.rs
@@ -3,126 +3,200 @@ use nulls::{rolling_apply_agg_window, RollingAggWindowNulls};
 
 use super::*;
 
-#[inline]
-fn new_is_min<T: NativeType + IsFloat + PartialOrd>(old: &T, new: &T) -> bool {
-    compare_fn_nan_min(old, new).is_ge()
+pub struct MinMaxWindow<'a, T: NativeType + PartialOrd + IsFloat> {
+    slice: &'a [T],
+    validity: &'a Bitmap,
+    m: Option<T>,
+    m_idx: usize,
+    sorted_to: usize,
+    last_start: usize,
+    last_end: usize,
+    null_count: usize,
+    sort_end_order: Ordering,
 }
 
-#[inline]
-fn new_is_max<T: NativeType + IsFloat + PartialOrd>(old: &T, new: &T) -> bool {
-    compare_fn_nan_max(old, new).is_le()
-}
+impl<'a, T: NativeType + PartialOrd + IsFloat> MinMaxWindow<'a, T> {
 
-// Identify runs of sorted values, either increasing or decreasing. It lets us avoid unnecessary
-// comparisons when the extremum keeps dropping off the front of the window
-macro_rules! fn_n_sorted_past {
-    ($name:ident, $cmp_f:ident, $stop_ord:ident) => {
-        #[inline]
-        unsafe fn $name<T: NativeType + IsFloat + PartialOrd>(
-            slice: &[T],
-            validity: &Bitmap,
-            m_idx: usize,
-        ) -> usize {
-            let (mut last_val, mut n) = (slice.get_unchecked(m_idx), 0);
-            for i in (m_idx + 1)..slice.len() {
-                n += 1;
-                if validity.get_bit_unchecked(i) {
-                    let val = slice.get_unchecked(i);
-                    if $cmp_f(last_val, val) == Ordering::$stop_ord {
-                        break;
-                    }
-                    last_val = val;
+    #[inline]
+    unsafe fn cmp_f(&self, a: &T, b: &T) -> Ordering {
+        // Seems like it's faster to directly put this here instead of having a field in the window
+        // that gets called dynamically
+        if T::is_float() {
+            match (a.is_nan(), b.is_nan()) {
+                // safety: we checked nans
+                (false, false) => a.partial_cmp(b).unwrap_unchecked() ,
+                (true, true) => Ordering::Equal,
+                (true, false) => self.sort_end_order.reverse(),
+                (false, true) => self.sort_end_order,
+            }
+        } else {
+            a.partial_cmp(b).unwrap_unchecked()
+        }
+    }
+    #[inline]
+    unsafe fn new_is_m(&self, old: &T, new: &T) -> bool {
+        self.cmp_f(new, old) != self.sort_end_order
+    }
+
+    #[inline]
+    unsafe fn update_sorted_to(&mut self) {
+        let mut last_val = self.m.unwrap();
+        for i in (self.m_idx + 1)..self.slice.len() {
+            self.sorted_to = i;
+            if self.validity.get_bit_unchecked(i) {
+                let val = self.slice.get_unchecked(i);
+                if self.cmp_f(&last_val, val) == self.sort_end_order {
+                    break;
+                }
+                last_val = *val;
+            }
+        }
+    }
+
+    #[inline]
+    unsafe fn get_m_m_idx_and_null_count(
+        &self,
+        start: usize,
+        end: usize,
+    ) -> (Option<(usize, &'a T)>, usize) {
+        let ilen = end - start;
+        let leading_nc = self
+            .validity
+            .iter()
+            .skip(start)
+            .take(ilen)
+            .position(|x| x)
+            .unwrap_or(ilen);
+        if leading_nc == ilen {
+            return (None, ilen);
+        }
+        let vstart = start + leading_nc; // First _V_alid entry start
+        let (mut m, mut m_idx) = (self.slice.get_unchecked(vstart), vstart);
+        if self.sorted_to >= end {
+            let remaining_nc = self.validity.null_count_range(vstart, end - vstart);
+            (Some((m_idx, m)), leading_nc + remaining_nc)
+        } else {
+            let tstart = (vstart + 1).max(self.sorted_to); // _T_ail elements to check
+            let mut remaining_nc = self.validity.null_count_range(vstart, tstart - vstart);
+            for i in tstart..end {
+                if !self.validity.get_bit_unchecked(i) {
+                    remaining_nc += 1;
+                    continue;
+                }
+                let newval = self.slice.get_unchecked(i);
+                if self.new_is_m(m, newval) {
+                    (m, m_idx) = (newval, i);
                 }
             }
-            n + m_idx
+            (Some((m_idx, m)), remaining_nc + leading_nc)
         }
-    };
-}
-fn_n_sorted_past!(n_sorted_past_min, compare_fn_nan_min, Greater);
-fn_n_sorted_past!(n_sorted_past_max, compare_fn_nan_max, Less);
+    }
 
-// Min and max really are the same thing up to a difference in comparison direction, as represented
-// here by helpers we pass in. Making both with a macro helps keep behavior synchronized
-macro_rules! minmax_window {
-    ($m_window:tt, $new_is_m:ident, $n_sorted_past:ident, $rolling_fn:ident) => {
-        pub struct $m_window<'a, T: NativeType + PartialOrd + IsFloat> {
-            slice: &'a [T],
-            validity: &'a Bitmap,
-            m: Option<T>,
-            m_idx: usize,
-            sorted_to: usize,
-            last_start: usize,
-            last_end: usize,
-            null_count: usize,
+    #[inline]
+    unsafe fn update_m_and_m_idx(&mut self, m_and_idx: (usize, &T)) {
+        self.m = Some(*m_and_idx.1);
+        self.m_idx = m_and_idx.0;
+        if self.sorted_to <= self.m_idx {
+            // Track how far past the current extremum values are sorted. Direction depends on min/max
+            // Tracking sorted ranges lets us only do comparisons when we have to.
+            self.update_sorted_to();
         }
+    }
 
-        impl<'a, T: NativeType + IsFloat + PartialOrd> $m_window<'a, T> {
-            #[inline]
-            unsafe fn init_get_m_m_idx_and_null_count(
-                slice: &'a [T],
-                validity: &'a Bitmap,
-                start: usize,
-                end: usize,
-                sorted_to: usize,
-            ) -> (Option<(usize, &'a T)>, usize) {
-                let ilen = end - start;
-                let leading_nc = validity
-                    .iter()
-                    .skip(start)
-                    .take(ilen)
-                    .position(|x| x)
-                    .unwrap_or(ilen);
-                if leading_nc == ilen {
-                    return (None, ilen);
-                }
-                let vstart = start + leading_nc; // First _V_alid entry start
-                let (mut m, mut m_idx) = (slice.get_unchecked(vstart), vstart);
-                if sorted_to >= end {
-                    let remaining_nc = validity.null_count_range(vstart, end - vstart);
-                    (Some((m_idx, m)), leading_nc + remaining_nc)
-                } else {
-                    let tstart = (vstart + 1).max(sorted_to); // _T_ail elements to check
-                    let mut remaining_nc = validity.null_count_range(vstart, tstart - vstart);
-                    for i in tstart..end {
-                        if !validity.get_bit_unchecked(i) {
-                            remaining_nc += 1;
-                            continue;
-                        }
-                        let newval = slice.get_unchecked(i);
-                        if $new_is_m(m, newval) {
-                            (m, m_idx) = (newval, i);
-                        }
-                    }
-                    (Some((m_idx, m)), remaining_nc + leading_nc)
-                }
-            }
+    unsafe fn new(
+        slice: &'a [T],
+        validity: &'a Bitmap,
+        start: usize,
+        end: usize,
+        sort_end_order: Ordering,
+    ) -> Self {
+        let mut out = Self {
+            slice,
+            validity,
+            m: None,
+            m_idx: 0,
+            sorted_to: 1,
+            last_start: start,
+            last_end: end,
+            null_count: 0,
+            sort_end_order,
+        };
+        let (m_idx, null_count) = out.get_m_m_idx_and_null_count(start, end);
+        let (m, idx) = (m_idx.map(|x| x.1), m_idx.map_or(0, |x| x.0));
+        (out.m, out.m_idx, out.null_count) = (m.cloned(), idx, null_count);
+        if out.m.is_some() {
+            out.update_sorted_to();
+        }
+        out
+    }
 
-            #[inline]
-            unsafe fn get_m_m_idx_and_null_count(
-                &self,
-                start: usize,
-                end: usize,
-            ) -> (Option<(usize, &'a T)>, usize) {
-                // Make it a little more convenient to call from within an update
-                $m_window::init_get_m_m_idx_and_null_count(
-                    self.slice,
-                    self.validity,
-                    start,
-                    end,
-                    self.sorted_to,
+    unsafe fn update(&mut self, start: usize, end: usize) -> Option<T> {
+        //For details see: https://github.com/pola-rs/polars/pull/9277#issuecomment-1581401692
+        let leaving_nc = self
+            .validity
+            .null_count_range(self.last_start, start - self.last_start);
+        self.last_start = start; // Don't care where the last one started now
+        let old_last_end = self.last_end; // But we need this
+        self.last_end = end;
+        let entering_start = std::cmp::max(old_last_end, start);
+        let (entering, entering_nc) = if end - entering_start == 1 {
+            // Faster in the special, but common, case of a fixed window rolling by one
+            if self.validity.get_bit_unchecked(entering_start) {
+                (
+                    Some((entering_start, self.slice.get_unchecked(entering_start))),
+                    0,
                 )
+            } else {
+                (None, 1)
             }
+        } else {
+            self.get_m_m_idx_and_null_count(entering_start, end)
+        };
+        let empty_overlap = old_last_end <= start;
+        self.null_count = (self.null_count + entering_nc) - leaving_nc;
 
-            #[inline]
-            unsafe fn update_m_and_m_idx(&mut self, m_and_idx: (usize, &T)) {
-                self.m = Some(*m_and_idx.1);
-                self.m_idx = m_and_idx.0;
-                if self.sorted_to <= self.m_idx {
-                    // Track how far past the current extremum values are sorted. Direction depends on min/max
-                    // Tracking sorted ranges lets us only do comparisons when we have to.
-                    self.sorted_to = $n_sorted_past(&self.slice, self.validity, self.m_idx);
+        if entering.is_some_and(|em| {
+            self.m.is_none() || empty_overlap || self.new_is_m(&self.m.unwrap(), em.1)
+        }) {
+            // The entering extremum "beats" the previous extremum so we can ignore the overlap
+            self.update_m_and_m_idx(entering.unwrap());
+            return self.m;
+        } else if self.m_idx >= start || empty_overlap {
+            // The previous extremum didn't drop off. Keep it
+            return self.m;
+        }
+        // Otherwise get the min of the overlapping window and the entering extremum
+        // If the last value was None, the value in the overlapping window will be too
+        let (previous, _) = match self.m {
+            None => (None, 0),
+            Some(_) => self.get_m_m_idx_and_null_count(start, old_last_end),
+        };
+        match (previous, entering) {
+            (Some(pm), Some(em)) => {
+                if self.new_is_m(pm.1, em.1) {
+                    self.update_m_and_m_idx(em);
+                } else {
+                    self.update_m_and_m_idx(pm);
                 }
             }
+            (Some(pm), None) => self.update_m_and_m_idx(pm),
+            (None, Some(em)) => self.update_m_and_m_idx(em),
+            // Both the entering and previous windows are empty or all null
+            (None, None) => self.m = None,
+        }
+
+        self.m
+    }
+    fn is_valid(&self, min_periods: usize) -> bool {
+        ((self.last_end - self.last_start) - self.null_count) >= min_periods
+    }
+}
+
+// This counts as dispatch
+macro_rules! minmax_window {
+    ($m_window:tt, $rolling_fn:ident, $sort_end_order:ident) => {
+        pub struct $m_window<'a, T: NativeType + PartialOrd + IsFloat> {
+            the_window: MinMaxWindow<'a, T>,
         }
 
         impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNulls<'a, T>
@@ -135,81 +209,22 @@ macro_rules! minmax_window {
                 end: usize,
                 _params: DynArgs,
             ) -> Self {
-                let (m_idx, null_count) =
-                    $m_window::init_get_m_m_idx_and_null_count(slice, validity, start, end, 0);
-                let (m, idx) = (m_idx.map(|x| x.1), m_idx.map_or(0, |x| x.0));
-                let sorted_to = m_idx.map_or(1, |x| $n_sorted_past(&slice, validity, x.0));
                 Self {
-                    slice,
-                    validity,
-                    m: m.copied(),
-                    m_idx: idx,
-                    sorted_to,
-                    last_start: start,
-                    last_end: end,
-                    null_count,
+                    the_window: MinMaxWindow::new(
+                        slice,
+                        validity,
+                        start,
+                        end,
+                        //$cmp_f,
+                        Ordering::$sort_end_order,
+                    ),
                 }
             }
-
             unsafe fn update(&mut self, start: usize, end: usize) -> Option<T> {
-                //For details see: https://github.com/pola-rs/polars/pull/9277#issuecomment-1581401692
-                let leaving_nc = self
-                    .validity
-                    .null_count_range(self.last_start, start - self.last_start);
-                self.last_start = start; // Don't care where the last one started now
-                let old_last_end = self.last_end; // But we need this
-                self.last_end = end;
-                let entering_start = std::cmp::max(old_last_end, start);
-                let (entering, entering_nc) = if end - entering_start == 1 {
-                    // Faster in the special, but common, case of a fixed window rolling by one
-                    if self.validity.get_bit_unchecked(entering_start) {
-                        (
-                            Some((entering_start, self.slice.get_unchecked(entering_start))),
-                            0,
-                        )
-                    } else {
-                        (None, 1)
-                    }
-                } else {
-                    self.get_m_m_idx_and_null_count(entering_start, end)
-                };
-                let empty_overlap = old_last_end <= start;
-                self.null_count = (self.null_count + entering_nc) - leaving_nc;
-
-                if entering.is_some_and(|em| {
-                    self.m.is_none() || empty_overlap || $new_is_m(&self.m.unwrap(), em.1)
-                }) {
-                    // The entering extremum "beats" the previous extremum so we can ignore the overlap
-                    self.update_m_and_m_idx(entering.unwrap());
-                    return self.m;
-                } else if self.m_idx >= start || empty_overlap {
-                    // The previous extremum didn't drop off. Keep it
-                    return self.m;
-                }
-                // Otherwise get the min of the overlapping window and the entering extremum
-                // If the last value was None, the value in the overlapping window will be too
-                let (previous, _) = match self.m {
-                    None => (None, 0),
-                    Some(_) => self.get_m_m_idx_and_null_count(start, old_last_end),
-                };
-                match (previous, entering) {
-                    (Some(pm), Some(em)) => {
-                        if $new_is_m(pm.1, em.1) {
-                            self.update_m_and_m_idx(em);
-                        } else {
-                            self.update_m_and_m_idx(pm);
-                        }
-                    }
-                    (Some(pm), None) => self.update_m_and_m_idx(pm),
-                    (None, Some(em)) => self.update_m_and_m_idx(em),
-                    // Both the entering and previous windows are empty or all null
-                    (None, None) => self.m = None,
-                }
-
-                self.m
+                self.the_window.update(start, end)
             }
             fn is_valid(&self, min_periods: usize) -> bool {
-                ((self.last_end - self.last_start) - self.null_count) >= min_periods
+                self.the_window.is_valid(min_periods)
             }
         }
 
@@ -243,5 +258,5 @@ macro_rules! minmax_window {
     };
 }
 
-minmax_window!(MinWindow, new_is_min, n_sorted_past_min, rolling_min);
-minmax_window!(MaxWindow, new_is_max, n_sorted_past_max, rolling_max);
+minmax_window!(MinWindow, rolling_min, Greater);
+minmax_window!(MaxWindow, rolling_max, Less);

--- a/crates/polars-arrow/src/kernels/rolling/nulls/min_max.rs
+++ b/crates/polars-arrow/src/kernels/rolling/nulls/min_max.rs
@@ -1,9 +1,7 @@
-//use arrow::bitmap::utils::{count_zeros, ZipValidityIter};
 use nulls;
 use nulls::{rolling_apply_agg_window, RollingAggWindowNulls};
 
 use super::*;
-
 
 #[inline]
 fn new_is_min<T: NativeType + IsFloat + PartialOrd>(old: &T, new: &T) -> bool {
@@ -15,46 +13,8 @@ fn new_is_max<T: NativeType + IsFloat + PartialOrd>(old: &T, new: &T) -> bool {
     compare_fn_nan_max(old, new).is_le()
 }
 
-
-// #[inline]
-// unsafe fn get_max_idx_and_null_count<'a, T>(
-//     slice: &'a [T],
-//     validity: &'a Bitmap,
-//     start: usize,
-//     end: usize,
-//     sorted_to: usize,
-// ) -> (Option<(usize, &'a T)>, usize)
-// where
-//     T: NativeType + IsFloat + PartialOrd,
-// {
-//     let ilen = end - start;
-//     let leading_nc = validity.iter().skip(start).take(ilen).position(|x| x).unwrap_or(ilen);
-//     if leading_nc == ilen {
-//         return (None, ilen);
-//     }
-//     let start = start + leading_nc;
-//     let (mut m, mut m_idx) = (slice.get_unchecked(start), start);
-//     if sorted_to >= end {
-//         let remaining_nc = validity.null_count_range(start, end - start);
-//         (Some((m_idx, m)), leading_nc + remaining_nc)
-//     } else {
-//         let start = (start+1).max(sorted_to);
-//         let mut remaining_nc = 0;
-//         for i in start..end {
-//             if !validity.get_bit_unchecked(i) {
-//                 remaining_nc += 1;
-//                 continue;
-//             }
-//             let newval = slice.get_unchecked(i);
-//             if new_is_max(m, newval) {
-//                 (m, m_idx) = (newval, i);
-//             }
-//         }
-//         (Some((m_idx, m)), remaining_nc + leading_nc)
-//     }
-// }
-
-
+// Identify runs of sorted values, either increasing or decreasing. It lets us avoid unnecessary
+// comparisons when the extremum keeps dropping off the front of the window
 macro_rules! fn_n_sorted_past {
     ($name:ident, $cmp_f:ident, $stop_ord:ident) => {
         #[inline]
@@ -65,18 +25,18 @@ macro_rules! fn_n_sorted_past {
         ) -> usize {
             let (mut last_val, mut n) = (slice.get_unchecked(m_idx), 0);
             for i in (m_idx + 1)..slice.len() {
+                n += 1;
                 if validity.get_bit_unchecked(i) {
                     let val = slice.get_unchecked(i);
-                    if matches!($cmp_f(last_val, val), Ordering::$stop_ord) {
+                    if $cmp_f(last_val, val) == Ordering::$stop_ord {
                         break;
                     }
                     last_val = val;
                 }
-                n += 1;
             }
-            n
+            n + m_idx
         }
-    }
+    };
 }
 fn_n_sorted_past!(n_sorted_past_min, compare_fn_nan_min, Greater);
 fn_n_sorted_past!(n_sorted_past_max, compare_fn_nan_max, Less);
@@ -84,7 +44,7 @@ fn_n_sorted_past!(n_sorted_past_max, compare_fn_nan_max, Less);
 // Min and max really are the same thing up to a difference in comparison direction, as represented
 // here by helpers we pass in. Making both with a macro helps keep behavior synchronized
 macro_rules! minmax_window {
-    ($m_window:tt, $new_is_m:ident, $n_sorted_past:ident) => {
+    ($m_window:tt, $new_is_m:ident, $n_sorted_past:ident, $rolling_fn:ident) => {
         pub struct $m_window<'a, T: NativeType + PartialOrd + IsFloat> {
             slice: &'a [T],
             validity: &'a Bitmap,
@@ -93,7 +53,7 @@ macro_rules! minmax_window {
             sorted_to: usize,
             last_start: usize,
             last_end: usize,
-            null_count: usize
+            null_count: usize,
         }
 
         impl<'a, T: NativeType + IsFloat + PartialOrd> $m_window<'a, T> {
@@ -106,7 +66,12 @@ macro_rules! minmax_window {
                 sorted_to: usize,
             ) -> (Option<(usize, &'a T)>, usize) {
                 let ilen = end - start;
-                let leading_nc = validity.iter().skip(start).take(ilen).position(|x| x).unwrap_or(ilen);
+                let leading_nc = validity
+                    .iter()
+                    .skip(start)
+                    .take(ilen)
+                    .position(|x| x)
+                    .unwrap_or(ilen);
                 if leading_nc == ilen {
                     return (None, ilen);
                 }
@@ -116,7 +81,7 @@ macro_rules! minmax_window {
                     let remaining_nc = validity.null_count_range(vstart, end - vstart);
                     (Some((m_idx, m)), leading_nc + remaining_nc)
                 } else {
-                    let tstart = (vstart+1).max(sorted_to); // _T_ail elements to check
+                    let tstart = (vstart + 1).max(sorted_to); // _T_ail elements to check
                     let mut remaining_nc = validity.null_count_range(vstart, tstart - vstart);
                     for i in tstart..end {
                         if !validity.get_bit_unchecked(i) {
@@ -133,18 +98,29 @@ macro_rules! minmax_window {
             }
 
             #[inline]
-            unsafe fn get_m_m_idx_and_null_count(&self, start: usize, end: usize) -> (Option<(usize, &'a T)>, usize){
-                $m_window::init_get_m_m_idx_and_null_count(self.slice, self.validity, start, end, self.sorted_to)
+            unsafe fn get_m_m_idx_and_null_count(
+                &self,
+                start: usize,
+                end: usize,
+            ) -> (Option<(usize, &'a T)>, usize) {
+                // Make it a little more convenient to call from within an update
+                $m_window::init_get_m_m_idx_and_null_count(
+                    self.slice,
+                    self.validity,
+                    start,
+                    end,
+                    self.sorted_to,
+                )
             }
 
             #[inline]
             unsafe fn update_m_and_m_idx(&mut self, m_and_idx: (usize, &T)) {
                 self.m = Some(*m_and_idx.1);
                 self.m_idx = m_and_idx.0;
-                if self.sorted_to <= self.m_idx && self.m.is_some() {
+                if self.sorted_to <= self.m_idx {
                     // Track how far past the current extremum values are sorted. Direction depends on min/max
                     // Tracking sorted ranges lets us only do comparisons when we have to.
-                    self.sorted_to = self.m_idx + 1 + $n_sorted_past(&self.slice, self.validity, self.m_idx);
+                    self.sorted_to = $n_sorted_past(&self.slice, self.validity, self.m_idx);
                 }
             }
         }
@@ -152,16 +128,23 @@ macro_rules! minmax_window {
         impl<'a, T: NativeType + IsFloat + PartialOrd> RollingAggWindowNulls<'a, T>
             for $m_window<'a, T>
         {
-            unsafe fn new(slice: &'a [T], validity: &'a Bitmap, start: usize, end: usize, _params: DynArgs) -> Self {
+            unsafe fn new(
+                slice: &'a [T],
+                validity: &'a Bitmap,
+                start: usize,
+                end: usize,
+                _params: DynArgs,
+            ) -> Self {
                 let (m_idx, null_count) =
                     $m_window::init_get_m_m_idx_and_null_count(slice, validity, start, end, 0);
                 let (m, idx) = (m_idx.map(|x| x.1), m_idx.map_or(0, |x| x.0));
+                let sorted_to = m_idx.map_or(1, |x| $n_sorted_past(&slice, validity, x.0));
                 Self {
                     slice,
                     validity,
                     m: m.copied(),
                     m_idx: idx,
-                    sorted_to: idx + 1 + $n_sorted_past(&slice, validity, idx),
+                    sorted_to: sorted_to,
                     last_start: start,
                     last_end: end,
                     null_count,
@@ -170,7 +153,9 @@ macro_rules! minmax_window {
 
             unsafe fn update(&mut self, start: usize, end: usize) -> Option<T> {
                 //For details see: https://github.com/pola-rs/polars/pull/9277#issuecomment-1581401692
-                let leaving_nc = self.validity.null_count_range(self.last_start, start - self.last_start);
+                let leaving_nc = self
+                    .validity
+                    .null_count_range(self.last_start, start - self.last_start);
                 self.last_start = start; // Don't care where the last one started now
                 let old_last_end = self.last_end; // But we need this
                 self.last_end = end;
@@ -178,22 +163,22 @@ macro_rules! minmax_window {
                 let (entering, entering_nc) = if end - entering_start == 1 {
                     // Faster in the special, but common, case of a fixed window rolling by one
                     if self.validity.get_bit_unchecked(entering_start) {
-                        (Some((entering_start, self.slice.get_unchecked(entering_start))), 0)
+                        (
+                            Some((entering_start, self.slice.get_unchecked(entering_start))),
+                            0,
+                        )
                     } else {
                         (None, 1)
                     }
-                } else if old_last_end == end {
-                    // Edge case for shrinking windows
-                    (None, 0)
                 } else {
                     self.get_m_m_idx_and_null_count(entering_start, end)
                 };
                 let empty_overlap = old_last_end <= start;
-                //println!("start: {}, end: {}, nc: {}, entering_nc: {}, leaving_nc: {}",
-                //         start, end, self.null_count, entering_nc, leaving_nc);
                 self.null_count = (self.null_count + entering_nc) - leaving_nc;
 
-                if entering.is_some_and(|em| self.m.is_none() || empty_overlap ||$new_is_m(&self.m.unwrap(), em.1)) {
+                if entering.is_some_and(|em| {
+                    self.m.is_none() || empty_overlap || $new_is_m(&self.m.unwrap(), em.1)
+                }) {
                     // The entering extremum "beats" the previous extremum so we can ignore the overlap
                     self.update_m_and_m_idx(entering.unwrap());
                     return self.m;
@@ -201,10 +186,11 @@ macro_rules! minmax_window {
                     // The previous extremum didn't drop off. Keep it
                     return self.m;
                 }
-                // Otherwise get the min of the overlapping window and the entering min
+                // Otherwise get the min of the overlapping window and the entering extremum
+                // If the last value was None, the value in the overlapping window will be too
                 let (previous, _) = match self.m {
                     None => (None, 0),
-                    Some(_) => self.get_m_m_idx_and_null_count(start, old_last_end)
+                    Some(_) => self.get_m_m_idx_and_null_count(start, old_last_end),
                 };
                 match (previous, entering) {
                     (Some(pm), Some(em)) => {
@@ -217,9 +203,7 @@ macro_rules! minmax_window {
                     (Some(pm), None) => self.update_m_and_m_idx(pm),
                     (None, Some(em)) => self.update_m_and_m_idx(em),
                     // Both the entering and previous windows are empty or all null
-                    (None, None) => {
-                        self.m = None
-                    },
+                    (None, None) => self.m = None,
                 }
 
                 self.m
@@ -228,65 +212,36 @@ macro_rules! minmax_window {
                 ((self.last_end - self.last_start) - self.null_count) >= min_periods
             }
         }
+
+        pub fn $rolling_fn<T>(
+            arr: &PrimitiveArray<T>,
+            window_size: usize,
+            min_periods: usize,
+            center: bool,
+            weights: Option<&[f64]>,
+            _params: DynArgs,
+        ) -> ArrayRef
+        where
+            T: NativeType + Zero + Copy + PartialOrd + Bounded + IsFloat,
+        {
+            if weights.is_some() {
+                panic!("weights not yet supported on array with null values")
+            }
+            let offset_fn = match center {
+                true => det_offsets_center,
+                false => det_offsets,
+            };
+            rolling_apply_agg_window::<$m_window<_>, _, _>(
+                arr.values().as_slice(),
+                arr.validity().as_ref().unwrap(),
+                window_size,
+                min_periods,
+                offset_fn,
+                None,
+            )
+        }
     };
 }
 
-minmax_window!(MinWindow, new_is_min, n_sorted_past_min);
-minmax_window!(MaxWindow, new_is_max, n_sorted_past_max);
-
-
-pub fn rolling_min<T>(
-    arr: &PrimitiveArray<T>,
-    window_size: usize,
-    min_periods: usize,
-    center: bool,
-    weights: Option<&[f64]>,
-    _params: DynArgs,
-) -> ArrayRef
-where
-    T: NativeType + std::iter::Sum + Zero + AddAssign + Copy + PartialOrd + Bounded + IsFloat,
-{
-    if weights.is_some() {
-        panic!("weights not yet supported on array with null values")
-    }
-    let offset_fn = match center {
-        true => det_offsets_center,
-        false => det_offsets,
-    };
-    rolling_apply_agg_window::<MinWindow<_>, _, _>(
-        arr.values().as_slice(),
-        arr.validity().as_ref().unwrap(),
-        window_size,
-        min_periods,
-        offset_fn,
-        None,
-        )
-}
-
-pub fn rolling_max<T>(
-    arr: &PrimitiveArray<T>,
-    window_size: usize,
-    min_periods: usize,
-    center: bool,
-    weights: Option<&[f64]>,
-    _params: DynArgs,
-) -> ArrayRef
-where
-    T: NativeType + std::iter::Sum + Zero + AddAssign + Copy + PartialOrd + Bounded + IsFloat,
-{
-    if weights.is_some() {
-        panic!("weights not yet supported on array with null values")
-    }
-    let offset_fn = match center {
-        true => det_offsets_center,
-        false => det_offsets,
-    };
-    rolling_apply_agg_window::<MaxWindow<_>, _, _>(
-        arr.values().as_slice(),
-        arr.validity().as_ref().unwrap(),
-        window_size,
-        min_periods,
-        offset_fn,
-        None,
-        )
-}
+minmax_window!(MinWindow, new_is_min, n_sorted_past_min, rolling_min);
+minmax_window!(MaxWindow, new_is_max, n_sorted_past_max, rolling_max);

--- a/crates/polars-arrow/src/kernels/rolling/nulls/min_max.rs
+++ b/crates/polars-arrow/src/kernels/rolling/nulls/min_max.rs
@@ -144,7 +144,7 @@ macro_rules! minmax_window {
                     validity,
                     m: m.copied(),
                     m_idx: idx,
-                    sorted_to: sorted_to,
+                    sorted_to,
                     last_start: start,
                     last_end: end,
                     null_count,


### PR DESCRIPTION
Brings the rolling extremum improvements for sequences with partially sorted runs to the case where null values are present.

Code to generate benchmarking data and performance tables below. I tested on series with 0.1% random nulls (lo), ~40% random nulls (hi), and ~2.25% nulls as one long run in the middle (run). Timings are for 50 runs.

It's substantially faster on data with long runs (p2) as well as for a minimum on ascending data (it turns out this special case was missing). It also performs better in dynamic groupbys. Other than that, its performance is similar when using "normal" rolling windows that increment by one. It's a little slower for short window lengths and I don't know how to shrink this gap, or if it's possible, but it's small and worth the other improvements.

<details>
<summary>Data generation code</summary>

```python
ds = pl.date_range(datetime(2013, 1, 1), datetime(2022, 12, 31), '1h', eager = True).alias('ds')
def generate_data(ds, null_idxs, N = 50):
    np.random.seed(100)
    cols = [pl.Series('d', ds.to_numpy().repeat(N)),
        pl.Series('v', np.random.standard_normal(N * len(ds))),
        pl.Series('x', np.random.randint(0, 50, len(ds)).repeat(N)),
        pl.Series('s', range(len(ds) * N)),
        pl.Series('r', range(len(ds) * N)).reverse(),
        pl.Series('p', (list(range(125)) + list(range(125, 0, -1))) * (701 * N//2)),
        pl.Series('p2', (list(range(17525)) + list(range(17525, 0, -1))) * (5 * N//2))
    ]
    for c in cols[1:]:
        c.set_at_idx(null_idxs, None)
    dat = pl.DataFrame(cols)
    return dat.set_sorted('d')

np.random.seed(100)
nulls = {
    'lo': np.random.choice(ds.len() * N, round(0.001 * ds.len() * N)),
    # I meant to sample without replacement here, oops.
    # But this still makes about 40% of the values null. Good enough
    'hi': np.random.choice(ds.len() * N, round(0.5 * ds.len() * N)),
    'run': range(100000, 200000)
}

dats = {k: generate_data(ds, v) for k, v in nulls.items()}
```

</details>

<details>
<summary>Rolling by one performance</summary>

|nulls |variable | window|op  |  current|    new|
|:-----|:--------|------:|:---|--------:|------:|
|lo    |x        |      5|min |    3.233|  3.076|
|lo    |x        |      5|max |    3.082|  3.191|
|lo    |x        |    250|min |    3.894|  3.874|
|lo    |x        |    250|max |    3.747|  3.903|
|lo    |x        |   7500|min |    3.962|  3.071|
|lo    |x        |   7500|max |    3.729|  3.140|
|lo    |v        |      5|min |    4.642|  5.281|
|lo    |v        |      5|max |    4.626|  5.498|
|lo    |v        |    250|min |    4.205|  3.521|
|lo    |v        |    250|max |    4.184|  3.831|
|lo    |v        |   7500|min |    4.247|  3.556|
|lo    |v        |   7500|max |    4.173|  3.826|
|lo    |s        |      5|min |    5.916|  5.822|
|lo    |s        |      5|max |    3.175|  3.210|
|lo    |s        |    250|min |  127.216|  8.475|
|lo    |s        |    250|max |    3.191|  3.257|
|lo    |s        |   7500|min | 3670.713| 21.678|
|lo    |s        |   7500|max |    3.174|  3.362|
|lo    |r        |      5|min |    3.369|  3.313|
|lo    |r        |      5|max |    4.894|  5.837|
|lo    |r        |    250|min |    3.369|  3.328|
|lo    |r        |    250|max |    4.944|  8.561|
|lo    |r        |   7500|min |    3.438|  3.375|
|lo    |r        |   7500|max |    5.014| 21.732|
|lo    |p        |      5|min |    4.584|  4.556|
|lo    |p        |      5|max |    4.377|  4.559|
|lo    |p        |    250|min |    3.391|  3.090|
|lo    |p        |    250|max |    3.189|  3.086|
|lo    |p        |   7500|min |    3.474|  3.165|
|lo    |p        |   7500|max |    3.230|  3.229|
|lo    |p2       |      5|min |    4.632|  4.575|
|lo    |p2       |      5|max |    4.424|  4.558|
|lo    |p2       |    250|min |   64.875|  5.935|
|lo    |p2       |    250|max |   64.628|  5.926|
|lo    |p2       |   7500|min | 1447.343| 45.077|
|lo    |p2       |   7500|max | 1444.542| 44.799|
|hi    |x        |      5|min |    4.793|  4.735|
|hi    |x        |      5|max |    4.561|  4.883|
|hi    |x        |    250|min |    6.004|  5.457|
|hi    |x        |    250|max |    5.760|  5.466|
|hi    |x        |   7500|min |    6.111|  4.076|
|hi    |x        |   7500|max |    5.823|  4.054|
|hi    |v        |      5|min |    6.103|  6.588|
|hi    |v        |      5|max |    6.026|  6.676|
|hi    |v        |    250|min |    6.213|  4.969|
|hi    |v        |    250|max |    6.048|  5.207|
|hi    |v        |   7500|min |    6.128|  4.825|
|hi    |v        |   7500|max |    6.032|  5.120|
|hi    |s        |      5|min |    5.523|  7.220|
|hi    |s        |      5|max |    4.183|  4.242|
|hi    |s        |    250|min |   76.968|  8.740|
|hi    |s        |    250|max |    4.732|  4.169|
|hi    |s        |   7500|min | 4161.749| 17.031|
|hi    |s        |   7500|max |    4.726|  4.166|
|hi    |r        |      5|min |    4.404|  4.204|
|hi    |r        |      5|max |    6.528|  7.226|
|hi    |r        |    250|min |    5.032|  4.124|
|hi    |r        |    250|max |    6.434|  8.736|
|hi    |r        |   7500|min |    5.035|  4.121|
|hi    |r        |   7500|max |    6.504| 17.012|
|hi    |p        |      5|min |    5.194|  5.868|
|hi    |p        |      5|max |    4.969|  5.964|
|hi    |p        |    250|min |    5.455|  4.469|
|hi    |p        |    250|max |    5.155|  4.482|
|hi    |p        |   7500|min |    5.447|  4.144|
|hi    |p        |   7500|max |    5.144|  4.133|
|hi    |p2       |      5|min |    5.035|  5.779|
|hi    |p2       |      5|max |    4.803|  5.864|
|hi    |p2       |    250|min |   40.767|  6.497|
|hi    |p2       |    250|max |   40.589|  6.570|
|hi    |p2       |   7500|min | 1643.001| 52.595|
|hi    |p2       |   7500|max | 1630.685| 53.946|
|run   |x        |      5|min |    3.191|  3.061|
|run   |x        |      5|max |    3.048|  3.191|
|run   |x        |    250|min |    3.842|  3.809|
|run   |x        |    250|max |    3.669|  3.829|
|run   |x        |   7500|min |    3.894|  2.996|
|run   |x        |   7500|max |    3.629|  2.953|
|run   |v        |      5|min |    4.583|  5.224|
|run   |v        |      5|max |    4.546|  5.438|
|run   |v        |    250|min |    4.121|  3.501|
|run   |v        |    250|max |    4.079|  3.781|
|run   |v        |   7500|min |    4.050|  3.408|
|run   |v        |   7500|max |    3.977|  3.692|
|run   |s        |      5|min |    5.822|  5.744|
|run   |s        |      5|max |    3.118|  3.206|
|run   |s        |    250|min |  124.151|  8.335|
|run   |s        |    250|max |    3.111|  3.199|
|run   |s        |   7500|min | 3579.154| 21.089|
|run   |s        |   7500|max |    3.122|  3.198|
|run   |r        |      5|min |    3.421|  3.253|
|run   |r        |      5|max |    4.884|  5.776|
|run   |r        |    250|min |    3.416|  3.249|
|run   |r        |    250|max |    5.902|  8.411|
|run   |r        |   7500|min |    3.391|  3.263|
|run   |r        |   7500|max |   33.131| 21.218|
|run   |p        |      5|min |    4.528|  4.520|
|run   |p        |      5|max |    4.328|  4.530|
|run   |p        |    250|min |    3.438|  3.059|
|run   |p        |    250|max |    3.136|  3.033|
|run   |p        |   7500|min |    3.414|  3.068|
|run   |p        |   7500|max |    3.177|  3.048|
|run   |p2       |      5|min |    4.604|  4.522|
|run   |p2       |      5|max |    4.364|  4.515|
|run   |p2       |    250|min |   63.324|  5.814|
|run   |p2       |    250|max |   63.116|  5.822|
|run   |p2       |   7500|min | 1410.123| 43.794|
|run   |p2       |   7500|max | 1409.879| 43.512|

</details>

<details>
<summary>Dynamic groupby performance</summary>

|nulls |variable |window                    |op  | current|    new|
|:-----|:--------|:-------------------------|:---|-------:|------:|
|lo    |x        |(every = 1h; period = 2h) |min |   1.814|  1.264|
|lo    |x        |(every = 1h; period = 2h) |max |   1.818|  1.252|
|lo    |v        |(every = 1h; period = 2h) |min |   2.402|  1.852|
|lo    |v        |(every = 1h; period = 2h) |max |   2.521|  1.866|
|lo    |s        |(every = 1h; period = 2h) |min |   1.852|  1.444|
|lo    |s        |(every = 1h; period = 2h) |max |   1.935|  1.199|
|lo    |r        |(every = 1h; period = 2h) |min |   1.906|  1.199|
|lo    |r        |(every = 1h; period = 2h) |max |   1.825|  1.433|
|lo    |p        |(every = 1h; period = 2h) |min |   1.893|  1.318|
|lo    |p        |(every = 1h; period = 2h) |max |   1.835|  1.232|
|lo    |p2       |(every = 1h; period = 2h) |min |   1.859|  1.273|
|lo    |p2       |(every = 1h; period = 2h) |max |   1.865|  1.234|
|lo    |x        |(every = 1d; period = 5d) |min |   2.203|  1.262|
|lo    |x        |(every = 1d; period = 5d) |max |   2.210|  1.261|
|lo    |v        |(every = 1d; period = 5d) |min |   2.777|  1.749|
|lo    |v        |(every = 1d; period = 5d) |max |   2.872|  1.755|
|lo    |s        |(every = 1d; period = 5d) |min |   3.515|  1.258|
|lo    |s        |(every = 1d; period = 5d) |max |   2.125|  1.243|
|lo    |r        |(every = 1d; period = 5d) |min |   2.124|  1.250|
|lo    |r        |(every = 1d; period = 5d) |max |   3.512|  1.263|
|lo    |p        |(every = 1d; period = 5d) |min |   1.588|  1.252|
|lo    |p        |(every = 1d; period = 5d) |max |   1.600|  1.241|
|lo    |p2       |(every = 1d; period = 5d) |min |   2.723|  1.298|
|lo    |p2       |(every = 1d; period = 5d) |max |   2.730|  1.258|
|lo    |x        |(every = 1h; period = 5d) |min |  19.656| 12.760|
|lo    |x        |(every = 1h; period = 5d) |max |  19.659| 12.747|
|lo    |v        |(every = 1h; period = 5d) |min |  20.311| 13.512|
|lo    |v        |(every = 1h; period = 5d) |max |  20.418| 13.525|
|lo    |s        |(every = 1h; period = 5d) |min |  76.977| 13.164|
|lo    |s        |(every = 1h; period = 5d) |max |  19.193| 12.723|
|lo    |r        |(every = 1h; period = 5d) |min |  19.217| 12.728|
|lo    |r        |(every = 1h; period = 5d) |max |  77.020| 13.194|
|lo    |p        |(every = 1h; period = 5d) |min |  19.106| 12.816|
|lo    |p        |(every = 1h; period = 5d) |max |  19.160| 12.749|
|lo    |p2       |(every = 1h; period = 5d) |min |  43.235| 13.352|
|lo    |p2       |(every = 1h; period = 5d) |max |  43.235| 13.317|
|hi    |x        |(every = 1h; period = 2h) |min |   2.918|  1.959|
|hi    |x        |(every = 1h; period = 2h) |max |   2.921|  1.885|
|hi    |v        |(every = 1h; period = 2h) |min |   3.470|  2.535|
|hi    |v        |(every = 1h; period = 2h) |max |   3.552|  2.606|
|hi    |s        |(every = 1h; period = 2h) |min |   3.068|  1.987|
|hi    |s        |(every = 1h; period = 2h) |max |   3.104|  1.847|
|hi    |r        |(every = 1h; period = 2h) |min |   3.105|  1.873|
|hi    |r        |(every = 1h; period = 2h) |max |   3.068|  2.020|
|hi    |p        |(every = 1h; period = 2h) |min |   3.082|  2.141|
|hi    |p        |(every = 1h; period = 2h) |max |   3.016|  1.926|
|hi    |p2       |(every = 1h; period = 2h) |min |   3.085|  1.944|
|hi    |p2       |(every = 1h; period = 2h) |max |   3.093|  1.823|
|hi    |x        |(every = 1d; period = 5d) |min |   3.502|  1.985|
|hi    |x        |(every = 1d; period = 5d) |max |   3.516|  1.953|
|hi    |v        |(every = 1d; period = 5d) |min |   4.067|  2.555|
|hi    |v        |(every = 1d; period = 5d) |max |   4.151|  2.673|
|hi    |s        |(every = 1d; period = 5d) |min |   6.176|  1.732|
|hi    |s        |(every = 1d; period = 5d) |max |   3.309|  1.820|
|hi    |r        |(every = 1d; period = 5d) |min |   3.307|  1.824|
|hi    |r        |(every = 1d; period = 5d) |max |   6.200|  1.722|
|hi    |p        |(every = 1d; period = 5d) |min |   2.369|  1.914|
|hi    |p        |(every = 1d; period = 5d) |max |   2.389|  1.866|
|hi    |p2       |(every = 1d; period = 5d) |min |   4.553|  1.939|
|hi    |p2       |(every = 1d; period = 5d) |max |   4.564|  1.834|
|hi    |x        |(every = 1h; period = 5d) |min |  21.425| 13.562|
|hi    |x        |(every = 1h; period = 5d) |max |  21.431| 13.529|
|hi    |v        |(every = 1h; period = 5d) |min |  21.742| 14.473|
|hi    |v        |(every = 1h; period = 5d) |max |  21.855| 14.706|
|hi    |s        |(every = 1h; period = 5d) |min | 122.575| 13.857|
|hi    |s        |(every = 1h; period = 5d) |max |  20.407| 13.419|
|hi    |r        |(every = 1h; period = 5d) |min |  20.404| 13.391|
|hi    |r        |(every = 1h; period = 5d) |max | 123.651| 13.853|
|hi    |p        |(every = 1h; period = 5d) |min |  20.648| 13.496|
|hi    |p        |(every = 1h; period = 5d) |max |  20.718| 13.377|
|hi    |p2       |(every = 1h; period = 5d) |min |  62.987| 14.526|
|hi    |p2       |(every = 1h; period = 5d) |max |  63.431| 14.439|
|run   |x        |(every = 1h; period = 2h) |min |   1.778|  1.529|
|run   |x        |(every = 1h; period = 2h) |max |   1.798|  1.253|
|run   |v        |(every = 1h; period = 2h) |min |   2.355|  1.816|
|run   |v        |(every = 1h; period = 2h) |max |   2.471|  1.829|
|run   |s        |(every = 1h; period = 2h) |min |   1.827|  1.382|
|run   |s        |(every = 1h; period = 2h) |max |   1.965|  1.193|
|run   |r        |(every = 1h; period = 2h) |min |   1.970|  1.197|
|run   |r        |(every = 1h; period = 2h) |max |   1.933|  1.383|
|run   |p        |(every = 1h; period = 2h) |min |   1.902|  1.307|
|run   |p        |(every = 1h; period = 2h) |max |   2.067|  1.240|
|run   |p2       |(every = 1h; period = 2h) |min |   2.184|  1.271|
|run   |p2       |(every = 1h; period = 2h) |max |   1.997|  1.237|
|run   |x        |(every = 1d; period = 5d) |min |   2.384|  1.254|
|run   |x        |(every = 1d; period = 5d) |max |   2.278|  1.260|
|run   |v        |(every = 1d; period = 5d) |min |   2.770|  1.735|
|run   |v        |(every = 1d; period = 5d) |max |   2.927|  1.737|
|run   |s        |(every = 1d; period = 5d) |min |   3.539|  1.257|
|run   |s        |(every = 1d; period = 5d) |max |   2.408|  1.245|
|run   |r        |(every = 1d; period = 5d) |min |   2.211|  1.245|
|run   |r        |(every = 1d; period = 5d) |max |   3.697|  1.257|
|run   |p        |(every = 1d; period = 5d) |min |   1.684|  1.256|
|run   |p        |(every = 1d; period = 5d) |max |   1.596|  1.251|
|run   |p2       |(every = 1d; period = 5d) |min |   2.693|  1.312|
|run   |p2       |(every = 1d; period = 5d) |max |   2.696|  1.267|
|run   |x        |(every = 1h; period = 5d) |min |  19.626| 12.769|
|run   |x        |(every = 1h; period = 5d) |max |  19.630| 12.750|
|run   |v        |(every = 1h; period = 5d) |min |  20.259| 13.517|
|run   |v        |(every = 1h; period = 5d) |max |  20.368| 13.584|
|run   |s        |(every = 1h; period = 5d) |min |  75.429| 13.231|
|run   |s        |(every = 1h; period = 5d) |max |  19.185| 12.966|
|run   |r        |(every = 1h; period = 5d) |min |  19.172| 12.868|
|run   |r        |(every = 1h; period = 5d) |max |  75.443| 13.802|
|run   |p        |(every = 1h; period = 5d) |min |  19.068| 12.790|
|run   |p        |(every = 1h; period = 5d) |max |  19.128| 12.747|
|run   |p2       |(every = 1h; period = 5d) |min |  42.541| 13.385|
|run   |p2       |(every = 1h; period = 5d) |max |  42.602| 13.283|

</details>