### PR TITLE
refactor(python): fix type hint

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2549,11 +2549,13 @@ class DataFrame:
         hidden_columns: Sequence[str] | None = None,
         hide_gridlines: bool = False,
         sheet_zoom: int | None = None,
-        freeze_panes: str
-        | tuple[str, int, int]
-        | tuple[int, int]
-        | tuple[int, int, int, int]
-        | None = None,
+        freeze_panes: (
+            str
+            | tuple[int, int]
+            | tuple[str, int, int]
+            | tuple[int, int, int, int]
+            | None
+        ) = None,
     ) -> Workbook:
         """
         Write frame data to a table in an Excel workbook/worksheet.


### PR DESCRIPTION
PyCharm (and maybe other IDEs?) requires that multi-line type hints are parenthesised.