### PR TITLE
build(python): Add patchelf extra to maturin

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -23,6 +23,7 @@ cloudpickle
 hypothesis==6.79.4; python_version < '3.8'
 hypothesis==6.80.0; python_version >= '3.8'
 maturin==1.1.0
+patchelf; platform_system == 'Linux'  # Extra dependency for maturin, only for Linux
 pytest==7.4.0
 pytest-cov==4.1.0
 pytest-xdist==3.3.1


### PR DESCRIPTION
When building the Rust bindings, `maturin` loves to complain:

```
⚠️ Warning: Failed to set rpath for /home/stijn/code/polars/py-polars/target/debug/libpolars.so: Failed to execute 'patchelf', did you install it? Hint: Try `pip install maturin[patchelf]` (or just `pip install patchelf`)
```

Apparently it's executing this part of the code, which tries to "Add library search paths in Cargo target directory rpath when building in editable mode".
https://github.com/PyO3/maturin/blob/99a2a5a84443345943aececdf0bf854c49c26110/src/build_context.rs#L330-L355

Not exactly sure what this does, to be honest. But the warning is annoying, and adding this small extra dev dependency fixes it. So I think it's fine to add it.