### PR TITLE
chore(python): Bump some dependencies

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Lint Markdown and TOML
         uses: dprint/check@v2.2
       - name: Spell Check with Typos
-        uses: crate-ci/typos@v1.15.9
+        uses: crate-ci/typos@v1.16.1

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -16,12 +16,11 @@ SQLAlchemy
 xlsx2csv
 XlsxWriter
 adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'
-connectorx==0.3.2a5; python_version >= '3.8'  # Latest full release is broken - unpin when 0.3.2 released
+connectorx==0.3.2a7  # Latest full release is broken - unpin when 0.3.2 released
 cloudpickle
 
 # Tooling
-hypothesis==6.79.4; python_version < '3.8'
-hypothesis==6.80.0; python_version >= '3.8'
+hypothesis==6.82.0
 maturin==1.1.0
 patchelf; platform_system == 'Linux'  # Extra dependency for maturin, only for Linux
 pytest==7.4.0

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,5 +1,5 @@
-black==23.3.0
+black==23.7.0
 blackdoc==0.3.8
 mypy==1.4.1
-ruff==0.0.275
-typos==1.15.9
+ruff==0.0.278
+typos==1.16.1


### PR DESCRIPTION
Noticed we could drop some of the special cases for Python 3.7. Then I went ahead and bumped some dependency versions while I was at it.