### PR TITLE
feat(python): support bytecode identification of `numpy` functions in UDFs that we can map to native expressions

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -139,7 +139,7 @@ class BytecodeParser:
                     and instruction_buffer[1].opname.startswith("LOAD_")
                     and instruction_buffer[2].opname.startswith("CALL")
                 ):
-                    # note: we map synthetic POALRS_EXPRESSION as a unary op
+                    # note: we map synthetic POLARS_EXPRESSION as a unary op
                     expr_name = instruction_buffer[0].argval
                     synthetic_call = inst._replace(
                         opname="POLARS_EXPRESSION", argval=expr_name, argrepr=expr_name

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -140,12 +140,18 @@ class BytecodeParser:
                     and instruction_buffer[1].opname.startswith("LOAD_")
                     and instruction_buffer[2].opname.startswith("CALL")
                 ):
-                    # note: we map synthetic POLARS_EXPRESSION as a unary op
+                    # note: we map the synthetic POLARS_EXPRESSION as a unary
+                    # op, so we switch the instruction order on injection
                     expr_name = instruction_buffer[0].argval
+                    offsets = inst.offset, instruction_buffer[1].offset
                     synthetic_call = inst._replace(
-                        opname="POLARS_EXPRESSION", argval=expr_name, argrepr=expr_name
+                        opname="POLARS_EXPRESSION",
+                        argval=expr_name,
+                        argrepr=expr_name,
+                        offset=offsets[1],
                     )
-                    updated_instructions.extend((instruction_buffer[1], synthetic_call))
+                    operand = instruction_buffer[1]._replace(offset=offsets[0])
+                    updated_instructions.extend((operand, synthetic_call))
                 else:
                     updated_instructions.extend(instruction_buffer)
             else:

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -75,6 +75,7 @@ _SIMPLE_EXPR_OPS = {
 }
 _SIMPLE_EXPR_OPS |= set(_UNARY_OPCODES) | set(_LOGICAL_OPCODES) | _SYNTHETIC_OPS
 _SIMPLE_FRAME_OPS = _SIMPLE_EXPR_OPS | {"BINARY_SUBSCR"}
+_UNARY_OPCODE_VALUES = set(_UNARY_OPCODES.values())
 _UPGRADE_BINARY_OPS = sys.version_info < (3, 11)
 
 # whitelist numpy functions that we can map directly to a native expression
@@ -201,7 +202,7 @@ class BytecodeParser:
             op = value.operator
             e1 = cls._expr(value.left_operand, col, param_name, depth + 1)
             if value.operator_arity == 1:
-                if op.isidentifier():
+                if op not in _UNARY_OPCODE_VALUES:
                     return f"{e1}.{op}()"
                 return f"{op}{e1}"
             else:

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -7,7 +7,8 @@ import warnings
 from collections import defaultdict
 from dis import get_instructions
 from inspect import signature
-from typing import TYPE_CHECKING, Any, Callable, Literal, NamedTuple, Union
+from itertools import islice
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, NamedTuple, Union
 
 from polars.exceptions import PolarsInefficientApplyWarning
 from polars.utils.various import find_stacklevel, in_terminal_that_supports_colour
@@ -58,6 +59,9 @@ _UNARY_OPCODES = {
     "UNARY_POSITIVE": "+",
     "UNARY_NOT": "~",
 }
+_SYNTHETIC_OPS = {
+    "POLARS_EXPRESSION",
+}
 _SIMPLE_EXPR_OPS = {
     "BINARY_OP",
     "COMPARE_OP",
@@ -67,10 +71,15 @@ _SIMPLE_EXPR_OPS = {
     "LOAD_FAST",
     "LOAD_GLOBAL",
     "LOAD_DEREF",
+    "UNARY_CALL",  # synthetic opcode
 }
-_SIMPLE_EXPR_OPS |= set(_UNARY_OPCODES) | set(_LOGICAL_OPCODES)
+_SIMPLE_EXPR_OPS |= set(_UNARY_OPCODES) | set(_LOGICAL_OPCODES) | _SYNTHETIC_OPS
 _SIMPLE_FRAME_OPS = _SIMPLE_EXPR_OPS | {"BINARY_SUBSCR"}
 _UPGRADE_BINARY_OPS = sys.version_info < (3, 11)
+
+# whitelist numpy functions that we can map directly to a native expression
+_NUMPY_MODULE_ALIASES = {"np", "numpy"}
+_NUMPY_FUNCTIONS = {"cbrt", "cos", "cosh", "sin", "sinh", "sqrt", "tan", "tanh"}
 
 
 class BytecodeParser:
@@ -88,11 +97,12 @@ class BytecodeParser:
     def _get_instructions(self, function: Callable[[Any], Any]) -> list[Instruction]:
         """Return disassembled bytecode ops, arg-repr, and arg-specific value/flag."""
         try:
-            return [
+            return self._inject_synthetic_calls(
                 self._upgrade_instruction(inst)
                 for inst in get_instructions(function)
-                if inst.opname not in ("COPY_FREE_VARS", "RESUME", "RETURN_VALUE")
-            ]
+                if inst.opname
+                not in ("COPY_FREE_VARS", "PRECALL", "RESUME", "RETURN_VALUE")
+            )
         except TypeError:
             # in case we hit something that can't be disassembled (eg: code object
             # unavailable, like a bare numpy ufunc that isn't in a lambda/function)
@@ -112,6 +122,35 @@ class BytecodeParser:
         except ValueError:
             return None
 
+    def _inject_synthetic_calls(
+        self, instructions: Iterator[Instruction]
+    ) -> list[Instruction]:
+        """Transform supported calls into synthetic POLARS_EXPRESSION ops."""
+        updated_instructions = []
+        for inst in instructions:
+            if inst.opname != "LOAD_GLOBAL":
+                updated_instructions.append(inst)
+
+            elif inst.argval in _NUMPY_MODULE_ALIASES:
+                instruction_buffer = list(islice(instructions, 3))
+                if (
+                    len(instruction_buffer) == 3
+                    and instruction_buffer[0].argval in _NUMPY_FUNCTIONS
+                    and instruction_buffer[1].opname.startswith("LOAD_")
+                    and instruction_buffer[2].opname.startswith("CALL")
+                ):
+                    # note: we map synthetic POALRS_EXPRESSION as a unary op
+                    expr_name = instruction_buffer[0].argval
+                    synthetic_call = inst._replace(
+                        opname="POLARS_EXPRESSION", argval=expr_name, argrepr=expr_name
+                    )
+                    updated_instructions.extend((instruction_buffer[1], synthetic_call))
+                else:
+                    updated_instructions.extend(instruction_buffer)
+            else:
+                updated_instructions.append(inst)
+        return updated_instructions
+
     def _to_intermediate_stack(self, instructions: list[Instruction]) -> StackEntry:
         """Take postfix bytecode and convert to an intermediate natural-order stack."""
         if self._apply_target == "expr":
@@ -127,7 +166,10 @@ class BytecodeParser:
                             left_operand=stack.pop(),  # type: ignore[arg-type]
                             right_operand=None,  # type: ignore[arg-type]
                         )
-                        if inst.opname in _UNARY_OPCODES
+                        if (
+                            inst.opname in _UNARY_OPCODES
+                            or inst.opname in _SYNTHETIC_OPS
+                        )
                         else StackValue(
                             operator=self._op(inst),
                             operator_arity=2,
@@ -159,6 +201,8 @@ class BytecodeParser:
             op = value.operator
             e1 = cls._expr(value.left_operand, col, param_name, depth + 1)
             if value.operator_arity == 1:
+                if op.isidentifier():
+                    return f"{e1}.{op}()"
                 return f"{op}{e1}"
             else:
                 e2 = cls._expr(value.right_operand, col, param_name, depth + 1)
@@ -220,7 +264,7 @@ class BytecodeParser:
                     if self._apply_target == "frame"
                     else _SIMPLE_EXPR_OPS
                 )
-                if len(self._instructions) >= 3 and all(
+                if len(self._instructions) >= 2 and all(
                     inst.opname in simple_ops for inst in self._instructions
                 ):
                     # can (currently) only handle logical 'and'/'or' if they not mixed
@@ -244,7 +288,7 @@ class BytecodeParser:
 
     @property
     def instructions(self) -> list[Instruction]:
-        """The bytecode instructions disassembled from the function being parsed."""
+        """The (adjusted) bytecode instructions from the function we are parsing."""
         return self._instructions
 
     @property


### PR DESCRIPTION
Ref: #9968.
Can now identify `numpy` calls in `apply` function bytecode and offer a native polars translation... :)

Understands both direct _"numpy.func(x)"_ calls and the standard _"np.func(x)"_ alias.

Note that I have only whitelisted a handful of numpy functions to start with; it's trivial to add more (literally just add the function name to the whitelist), but each one needs verification that we are indeed doing exactly the same thing in the default case - I'll whitelist additional functions as I confirm this.

## Example

```python
import polars as pl
import numpy as np

df = pl.DataFrame({"abc": [27, 64, 125]})
fn = lambda x: 1 + np.cbrt(x) / 3

df.with_columns(
    val = pl.col("abc").apply(fn),
)

# PolarsInefficientApplyWarning: 
# Expr.apply is significantly slower than the native expressions API.
# Only use if you absolutely CANNOT implement your logic otherwise.
# In this case, you can replace your `apply` with an expression:
#   -  pl.col("abc").apply(lambda x: ...)
#   +  1 + (pl.col("abc").cbrt() / 3)
```
Underlying function bytecode...
```python
import dis
dis.dis( fn )
# 1           0 RESUME                   0
#             2 LOAD_CONST               1 (1)
#             4 LOAD_GLOBAL              0 (np)
#            16 LOAD_METHOD              1 (cbrt)
#            38 LOAD_FAST                0 (x)
#            40 PRECALL                  1
#            44 CALL                     1
#            54 LOAD_CONST               2 (3)
#            56 BINARY_OP               11 (/)
#            60 BINARY_OP                0 (+)
#            64 RETURN_VALUE
```
These instructions get rewritten on initial disassembly with a new synthetic `POLARS_EXPRESSION` which is treated as a special-case unary operator during normal parsing:
```python
# Instruction(opname='LOAD_CONST', opcode=100, arg=1, argval=1, argrepr='1', offset=2, ...
# Instruction(opname='LOAD_FAST', opcode=124, arg=0, argval='x', argrepr='x', offset=26, ...
# Instruction(opname='POLARS_EXPRESSION', opcode=116, arg=1, argval='cbrt', argrepr='cbrt', ...
# Instruction(opname='LOAD_CONST', opcode=100, arg=2, argval=3, argrepr='3', offset=42, ...
# Instruction(opname='BINARY_OP', opcode=122, arg=11, argval=11, argrepr='/', offset=44, ...
# Instruction(opname='BINARY_OP', opcode=122, arg=0, argval=0, argrepr='+', offset=48, ...
```
Limitation: currently only works on single-parameter calls.