### PR TITLE
feat(python): support bytecode identification/mapping of python string-case functions in UDFs

### DIFF
--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -29,45 +29,52 @@ def test_non_simple_function(func: Callable[[Any], Any]) -> None:
 
 
 @pytest.mark.parametrize(
-    "func",
+    ("col", "func"),
     [
-        lambda x: x + 1 - (2 / 3),
-        lambda x: x // 1 % 2,
-        lambda x: x & True,
-        lambda x: x | False,
-        lambda x: x != 3,
-        lambda x: x > 1,
-        lambda x: not (x > 1) or x == 2,
-        lambda x: x is None,
-        lambda x: x is not None,
-        lambda x: ((x * -x) ** x) * 1.0,
-        lambda x: 1.0 * (x * (x**x)),
-        lambda x: (x / x) + ((x * x) - x),
-        lambda x: (10 - x) / (((x * 4) - x) // (2 + (x * (x - 1)))),
-        lambda x: x in (2, 3, 4),
-        lambda x: x not in (2, 3, 4),
-        lambda x: x in (1, 2, 3, 4, 3) and x % 2 == 0 and x > 0,
-        lambda x: MY_CONSTANT + x,
-        lambda x: 0 + numpy.cbrt(x),
-        lambda x: np.sin(x) + 1,
+        ("a", lambda x: x + 1 - (2 / 3)),
+        ("a", lambda x: x // 1 % 2),
+        ("a", lambda x: x & True),
+        ("a", lambda x: x | False),
+        ("a", lambda x: x != 3),
+        ("a", lambda x: x > 1),
+        ("a", lambda x: not (x > 1) or x == 2),
+        ("a", lambda x: x is None),
+        ("a", lambda x: x is not None),
+        ("a", lambda x: ((x * -x) ** x) * 1.0),
+        ("a", lambda x: 1.0 * (x * (x**x))),
+        ("a", lambda x: (x / x) + ((x * x) - x)),
+        ("a", lambda x: (10 - x) / (((x * 4) - x) // (2 + (x * (x - 1))))),
+        ("a", lambda x: x in (2, 3, 4)),
+        ("a", lambda x: x not in (2, 3, 4)),
+        ("a", lambda x: x in (1, 2, 3, 4, 3) and x % 2 == 0 and x > 0),
+        ("a", lambda x: MY_CONSTANT + x),
+        ("a", lambda x: 0 + numpy.cbrt(x)),
+        ("a", lambda x: np.sin(x) + 1),
+        ("b", lambda x: x.title()),
+        ("b", lambda x: x.lower() + x.upper()),
     ],
 )
-def test_expr_apply_produces_warning(func: Callable[[Any], Any]) -> None:
+def test_expr_apply_produces_warning(col: str, func: Callable[[Any], Any]) -> None:
     with pytest.warns(
         PolarsInefficientApplyWarning, match="In this case, you can replace"
     ):
         parser = BytecodeParser(func, apply_target="expr")
-        suggested_expression = parser.to_expression(col="a")
+        suggested_expression = parser.to_expression(col=col)
         assert suggested_expression is not None
 
-        df = pl.DataFrame({"a": [1, 2, 3]})
+        df = pl.DataFrame(
+            {
+                "a": [1, 2, 3],
+                "b": ["AB", "cd", "eF"],
+            }
+        )
         result = df.select(
-            x="a",
+            x=col,
             y=eval(suggested_expression),
         )
         expected = df.select(
-            x=pl.col("a"),
-            y=pl.col("a").apply(func),
+            x=pl.col(col),
+            y=pl.col(col).apply(func),
         )
         assert_frame_equal(result, expected)
 


### PR DESCRIPTION
Ref: #9968.

Support identification of python string-case functions in UDFs, alongside translation to a native expression. Can look at extending this to functions that take parameters (such as `endswith` or `startswith`) if that is desirable...

## Example
```python
import polars as pl

df = pl.DataFrame({
    "abc": ["AB", "cd", "eF"],
})

fn = lambda x: x.lower() + x.upper()
df.with_columns(
    val = pl.col("abc").apply(fn),
)

# PolarsInefficientApplyWarning: 
# Expr.apply is significantly slower than the native expressions API.
# Only use if you absolutely CANNOT implement your logic otherwise.
# In this case, you can replace your `apply` with an expression:
#   -  pl.col("abc").apply(lambda x: ...)
#   +  pl.col("abc").str.to_lowercase() + pl.col("abc").str.to_uppercase()
```