### PR TITLE
feat(rust): Move transpose naming to Rust

### DIFF
--- a/polars/polars-core/src/frame/row/transpose.rs
+++ b/polars/polars-core/src/frame/row/transpose.rs
@@ -26,19 +26,19 @@ impl DataFrame {
         let cols = &self.columns;
         match dtype {
             #[cfg(feature = "dtype-i8")]
-            DataType::Int8 => numeric_transpose::<Int8Type>(&cols, names_t, &mut cols_t),
+            DataType::Int8 => numeric_transpose::<Int8Type>(cols, names_t, &mut cols_t),
             #[cfg(feature = "dtype-i16")]
-            DataType::Int16 => numeric_transpose::<Int16Type>(&cols, names_t, &mut cols_t),
-            DataType::Int32 => numeric_transpose::<Int32Type>(&cols, names_t, &mut cols_t),
-            DataType::Int64 => numeric_transpose::<Int64Type>(&cols, names_t, &mut cols_t),
+            DataType::Int16 => numeric_transpose::<Int16Type>(cols, names_t, &mut cols_t),
+            DataType::Int32 => numeric_transpose::<Int32Type>(cols, names_t, &mut cols_t),
+            DataType::Int64 => numeric_transpose::<Int64Type>(cols, names_t, &mut cols_t),
             #[cfg(feature = "dtype-u8")]
-            DataType::UInt8 => numeric_transpose::<UInt8Type>(&cols, names_t, &mut cols_t),
+            DataType::UInt8 => numeric_transpose::<UInt8Type>(cols, names_t, &mut cols_t),
             #[cfg(feature = "dtype-u16")]
-            DataType::UInt16 => numeric_transpose::<UInt16Type>(&cols, names_t, &mut cols_t),
-            DataType::UInt32 => numeric_transpose::<UInt32Type>(&cols, names_t, &mut cols_t),
-            DataType::UInt64 => numeric_transpose::<UInt64Type>(&cols, names_t, &mut cols_t),
-            DataType::Float32 => numeric_transpose::<Float32Type>(&cols, names_t, &mut cols_t),
-            DataType::Float64 => numeric_transpose::<Float64Type>(&cols, names_t, &mut cols_t),
+            DataType::UInt16 => numeric_transpose::<UInt16Type>(cols, names_t, &mut cols_t),
+            DataType::UInt32 => numeric_transpose::<UInt32Type>(cols, names_t, &mut cols_t),
+            DataType::UInt64 => numeric_transpose::<UInt64Type>(cols, names_t, &mut cols_t),
+            DataType::Float32 => numeric_transpose::<Float32Type>(cols, names_t, &mut cols_t),
+            DataType::Float64 => numeric_transpose::<Float64Type>(cols, names_t, &mut cols_t),
             #[cfg(feature = "object")]
             DataType::Object(_) => {
                 // this requires to support `Object` in Series::iter which we don't yet
@@ -224,8 +224,11 @@ where
     });
 
     cols_t.par_extend(POOL.install(|| {
-        values_buf.into_par_iter().zip(validity_buf).zip(names_t).map(
-            |((mut values, validity), name)| {
+        values_buf
+            .into_par_iter()
+            .zip(validity_buf)
+            .zip(names_t)
+            .map(|((mut values, validity), name)| {
                 // Safety:
                 // all values are written we can now set len
                 unsafe {
@@ -249,11 +252,10 @@ where
                     validity,
                 );
                 unsafe {
-                    ChunkedArray::<T>::from_chunks(&name, vec![Box::new(arr) as ArrayRef])
+                    ChunkedArray::<T>::from_chunks(name, vec![Box::new(arr) as ArrayRef])
                         .into_series()
                 }
-            },
-        )
+            })
     }));
 }
 

--- a/polars/polars-core/src/frame/row/transpose.rs
+++ b/polars/polars-core/src/frame/row/transpose.rs
@@ -7,7 +7,7 @@ impl DataFrame {
         &self,
         dtype: &DataType,
         keep_names_as: Option<&str>,
-        colnames: &Vec<String>,
+        colnames: &[String],
     ) -> PolarsResult<DataFrame> {
         let new_width = self.height();
         let new_height = self.width();
@@ -69,7 +69,7 @@ impl DataFrame {
         out.set_column_names(colnames)?;
         match keep_names_as {
             Some(cn) => {
-                let namecol = Utf8Chunked::new(&cn, self.get_column_names());
+                let namecol = Utf8Chunked::new(cn, self.get_column_names());
                 out.insert_at_idx_no_name_check(0, namecol.into()).cloned()
             }
             None => Ok(out),
@@ -101,13 +101,10 @@ impl DataFrame {
                 }
             },
         };
-        match keep_names_as {
+        if let Some(cn) = keep_names_as {
             // Check that the column name we're using for the original column names is unique before
             // wasting time transposing
-            Some(cn) => {
-                polars_ensure!(!colnames_t.contains(&cn.to_owned()), Duplicate: "{} is already in output column names", cn)
-            }
-            None => {}
+            polars_ensure!(!colnames_t.contains(&cn.to_owned()), Duplicate: "{} is already in output column names", cn)
         }
         polars_ensure!(
             df.height() != 0 && df.width() != 0,

--- a/polars/polars-core/src/frame/row/transpose.rs
+++ b/polars/polars-core/src/frame/row/transpose.rs
@@ -91,10 +91,10 @@ impl DataFrame {
         let names_t = match new_col_names {
             None => (0..self.height()).map(|i| format!("column_{i}")).collect(),
             Some(cn) => match cn {
-                Either::Left(cname) => {
-                    let new_names = self.column(&cname).and_then(|x| x.utf8())?;
+                Either::Left(name) => {
+                    let new_names = self.column(&name).and_then(|x| x.utf8())?;
                     polars_ensure!(!new_names.has_validity(), ComputeError: "Column with new names can't have null values");
-                    df = Cow::Owned(self.drop(&cname)?);
+                    df = Cow::Owned(self.drop(&name)?);
                     new_names
                         .into_no_null_iter()
                         .map(|s| s.to_owned())

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1724,6 +1724,7 @@ dependencies = [
  "ahash",
  "built",
  "ciborium",
+ "either",
  "jemallocator",
  "lexical-core",
  "libc",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -16,6 +16,7 @@ jemallocator = { version = "0.5", features = ["disable_initial_exec_tls"] }
 [dependencies]
 ahash = "0.8"
 ciborium = "0.2.0"
+either = "1.8"
 lexical-core = "0.8"
 # todo: unfix when compilation problem is solved
 libc = "0.2"

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3547,23 +3547,10 @@ class DataFrame:
         │ col2   ┆ 3   ┆ 4   ┆ 6   │
         └────────┴─────┴─────┴─────┘
         """
-        pydf = self._df
-        if isinstance(column_names, str):
-            pydf = self.drop(column_names)._df
-            column_names = self._df.column(column_names).to_list()
-        df = self._from_pydf(pydf.transpose(include_header, header_name))
-        if column_names is not None:
-            names = []
-            n = df.width
-            if include_header:
-                names.append(header_name)
-                n -= 1
-
-            column_names = iter(column_names)
-            for _ in range(n):
-                names.append(next(column_names))
-            df.columns = names
-        return df
+        keep_names_as = header_name if include_header else None
+        if isinstance(column_names, Generator):
+            column_names = [next(column_names) for _ in range(self.height)]
+        return self._from_pydf(self._df.transpose(keep_names_as, column_names))
 
     def reverse(self) -> DataFrame:
         """

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1359,7 +1359,6 @@ impl PyDataFrame {
 
     #[pyo3(signature = (keep_names_as, column_names))]
     pub fn transpose(&self, keep_names_as: Option<&str>, column_names: &PyAny) -> PyResult<Self> {
-        // It doesn't automatically translate Python types to Either :-(
         let new_col_names = if let Ok(name) = column_names.extract::<Vec<String>>() {
             Some(Either::Right(name))
         } else if let Ok(name) = column_names.extract::<String>() {

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1,6 +1,7 @@
 use std::io::BufWriter;
 use std::ops::Deref;
 
+use either::Either;
 use numpy::IntoPyArray;
 use polars::frame::row::{rows_to_schema_supertypes, Row};
 #[cfg(feature = "avro")]
@@ -1356,17 +1357,21 @@ impl PyDataFrame {
         Ok(hash.into_series().into())
     }
 
-    pub fn transpose(&self, include_header: bool, names: &str) -> PyResult<Self> {
-        let mut df = self.df.transpose().map_err(PyPolarsErr::from)?;
-        if include_header {
-            let s = Utf8Chunked::from_iter_values(
-                names,
-                self.df.get_columns().iter().map(|s| s.name()),
-            )
-            .into_series();
-            df.insert_at_idx(0, s).unwrap();
-        }
-        Ok(df.into())
+    #[pyo3(signature = (keep_names_as, column_names))]
+    pub fn transpose(&self, keep_names_as: Option<&str>, column_names: &PyAny) -> PyResult<Self> {
+        // It doesn't automatically translate Python types to Either :-(
+        let cnames = if let Ok(cn) = column_names.extract::<Vec<String>>() {
+            Some(Either::Right(cn))
+        } else if let Ok(cn) = column_names.extract::<String>() {
+            Some(Either::Left(cn))
+        } else {
+            None
+        };
+        Ok(self
+            .df
+            .transpose(keep_names_as, cnames)
+            .map_err(PyPolarsErr::from)?
+            .into())
     }
     pub fn upsample(
         &self,

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1360,16 +1360,16 @@ impl PyDataFrame {
     #[pyo3(signature = (keep_names_as, column_names))]
     pub fn transpose(&self, keep_names_as: Option<&str>, column_names: &PyAny) -> PyResult<Self> {
         // It doesn't automatically translate Python types to Either :-(
-        let cnames = if let Ok(cn) = column_names.extract::<Vec<String>>() {
-            Some(Either::Right(cn))
-        } else if let Ok(cn) = column_names.extract::<String>() {
-            Some(Either::Left(cn))
+        let new_col_names = if let Ok(name) = column_names.extract::<Vec<String>>() {
+            Some(Either::Right(name))
+        } else if let Ok(name) = column_names.extract::<String>() {
+            Some(Either::Left(name))
         } else {
             None
         };
         Ok(self
             .df
-            .transpose(keep_names_as, cnames)
+            .transpose(keep_names_as, new_col_names)
             .map_err(PyPolarsErr::from)?
             .into())
     }


### PR DESCRIPTION
Moves the functionality to customize the names of a transposed DataFrame and keep its column names as a new column into Rust.