### PR TITLE
perf(rust): Remove fused arithmetic from expressions with literals

### DIFF
--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/fused.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/fused.rs
@@ -35,7 +35,12 @@ fn check_eligible(
         .get(*right)
         .get_type(&schema, Context::Default, expr_arena)?;
     let type_left = &field_left.dtype;
-    if type_left.is_numeric() && type_right.is_numeric() {
+    // Exclude literals for now as these will not result in fused operation downstream
+    if type_left.is_numeric()
+        && type_right.is_numeric()
+        && !has_aexpr_literal(*left, expr_arena)
+        && !has_aexpr_literal(*right, expr_arena)
+    {
         Ok((Some(true), Some(field_left)))
     } else {
         Ok((Some(false), None))

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/fused.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/fused.rs
@@ -35,7 +35,9 @@ fn check_eligible(
         .get(*right)
         .get_type(&schema, Context::Default, expr_arena)?;
     let type_left = &field_left.dtype;
-    // Exclude literals for now as these will not result in fused operation downstream
+    // Exclude literals for now as these will not benefit from fused operations downstream #9857
+    // This optimization would also interfere with the `col -> lit` type-coercion rules
+    // And it might also interfere with constant folding which is a more suitable optimizations here
     if type_left.is_numeric()
         && type_right.is_numeric()
         && !has_aexpr_literal(*left, expr_arena)

--- a/polars/polars-lazy/polars-plan/src/utils.rs
+++ b/polars/polars-lazy/polars-plan/src/utils.rs
@@ -95,7 +95,7 @@ pub(crate) fn aexpr_is_simple_projection(current_node: Node, arena: &Arena<AExpr
         .all(|(_node, e)| matches!(e, AExpr::Column(_) | AExpr::Alias(_, _)))
 }
 
-pub(crate) fn aexpr_is_elementwise(current_node: Node, arena: &Arena<AExpr>) -> bool {
+pub fn aexpr_is_elementwise(current_node: Node, arena: &Arena<AExpr>) -> bool {
     arena.iter(current_node).all(|(_node, e)| {
         use AExpr::*;
         match e {
@@ -122,6 +122,10 @@ where
 
 pub fn has_aexpr_window(current_node: Node, arena: &Arena<AExpr>) -> bool {
     has_aexpr(current_node, arena, |e| matches!(e, AExpr::Window { .. }))
+}
+
+pub fn has_aexpr_literal(current_node: Node, arena: &Arena<AExpr>) -> bool {
+    has_aexpr(current_node, arena, |e| matches!(e, AExpr::Literal(_)))
 }
 
 /// Can check if an expression tree has a matching_expr. This

--- a/polars/polars-lazy/polars-plan/src/utils.rs
+++ b/polars/polars-lazy/polars-plan/src/utils.rs
@@ -95,7 +95,7 @@ pub(crate) fn aexpr_is_simple_projection(current_node: Node, arena: &Arena<AExpr
         .all(|(_node, e)| matches!(e, AExpr::Column(_) | AExpr::Alias(_, _)))
 }
 
-pub fn aexpr_is_elementwise(current_node: Node, arena: &Arena<AExpr>) -> bool {
+pub(crate) fn aexpr_is_elementwise(current_node: Node, arena: &Arena<AExpr>) -> bool {
     arena.iter(current_node).all(|(_node, e)| {
         use AExpr::*;
         match e {

--- a/py-polars/tests/unit/operations/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/test_arithmetic.py
@@ -185,6 +185,18 @@ def test_fused_arithm() -> None:
         ), f"Fused Arithmetic applied on literal {expr}: {q.explain()}"
 
 
+def test_literal_no_upcast() -> None:
+    df = pl.DataFrame({
+        'a': pl.Series([1, 2, 3], dtype=pl.Float32)
+    })
+
+    q= df.lazy().select(
+        (pl.col('a')*-5 + 2).alias("fma"),
+        (2 - pl.col('a') * 5).alias("fsm"),
+        (pl.col('a') * 5 - 2).alias("fms"),
+    ).collect()
+    assert set(q.schema.values()) == {pl.Float32}, "Literal * Column (Float32) should not lead upcast"
+
 def test_boolean_addition() -> None:
     s = pl.DataFrame({"a": [True, False, False], "b": [True, False, True]}).sum(axis=1)
 

--- a/py-polars/tests/unit/operations/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/test_arithmetic.py
@@ -170,7 +170,7 @@ def test_fused_arithm() -> None:
     q = df.lazy().select(pl.lit(1) * pl.lit(2) - pl.col("c"))
     assert """(2) - (col("c")""" in q.explain()
 
-    # Check if fused is turned off for literals
+    # Check if fused is turned off for literals see: #9857
     for expr in [
         pl.col("c") * 2 + 5,
         pl.col("c") * 2 + pl.col("c"),

--- a/py-polars/tests/unit/operations/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/test_arithmetic.py
@@ -186,16 +186,21 @@ def test_fused_arithm() -> None:
 
 
 def test_literal_no_upcast() -> None:
-    df = pl.DataFrame({
-        'a': pl.Series([1, 2, 3], dtype=pl.Float32)
-    })
+    df = pl.DataFrame({"a": pl.Series([1, 2, 3], dtype=pl.Float32)})
 
-    q= df.lazy().select(
-        (pl.col('a')*-5 + 2).alias("fma"),
-        (2 - pl.col('a') * 5).alias("fsm"),
-        (pl.col('a') * 5 - 2).alias("fms"),
-    ).collect()
-    assert set(q.schema.values()) == {pl.Float32}, "Literal * Column (Float32) should not lead upcast"
+    q = (
+        df.lazy()
+        .select(
+            (pl.col("a") * -5 + 2).alias("fma"),
+            (2 - pl.col("a") * 5).alias("fsm"),
+            (pl.col("a") * 5 - 2).alias("fms"),
+        )
+        .collect()
+    )
+    assert set(q.schema.values()) == {
+        pl.Float32
+    }, "Literal * Column (Float32) should not lead upcast"
+
 
 def test_boolean_addition() -> None:
     s = pl.DataFrame({"a": [True, False, False], "b": [True, False, True]}).sum(axis=1)

--- a/py-polars/tests/unit/operations/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/test_arithmetic.py
@@ -170,19 +170,19 @@ def test_fused_arithm() -> None:
     q = df.lazy().select(pl.lit(1) * pl.lit(2) - pl.col("c"))
     assert """(2) - (col("c")""" in q.explain()
 
-    # 8752
-    df = pl.DataFrame({"x": pl.Series(values=[0, 0])})
-    q = df.lazy().with_columns((0 + 2.5 * (0.5 + pl.col("x"))).alias("compute"))
-    assert q.collect()["compute"][0] == 1.25
-    assert "0.0.fma" in q.explain()
-
-
-def test_fused_arithm_9009() -> None:
-    q = pl.LazyFrame({"a": [1, 2], "b": [3, 4]})
-    q = q.select((pl.col("b") * 2 + 3).over("a"))
-
-    assert """3.fma([col("b"), 2]).alias("b")""" in q.explain()
-    assert q.collect()["b"].to_list() == [9, 11]
+    # Check if fused is turned off for literals
+    for expr in [
+        pl.col("c") * 2 + 5,
+        pl.col("c") * 2 + pl.col("c"),
+        pl.col("c") * 2 - 5,
+        pl.col("c") * 2 - pl.col("c"),
+        5 - pl.col("c") * 2,
+        pl.col("c") - pl.col("c") * 2,
+    ]:
+        q = df.lazy().select(expr)
+        assert all(
+            el not in q.explain() for el in ["fms", "fsm", "fma"]
+        ), f"Fused Arithmetic applied on literal {expr}: {q.explain()}"
 
 
 def test_boolean_addition() -> None:


### PR DESCRIPTION
The current implementation of fused arithmetic does not lead to fused operations when literals are involved.

fix #9857 