### PR TITLE
fix(python): map 'postgres' URI prefix to ADBC 'postgresql' module

### DIFF
--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -165,9 +165,10 @@ def _read_sql_adbc(query: str, connection_uri: str) -> DataFrame:
 def _open_adbc_connection(connection_uri: str) -> Any:
     driver_name = connection_uri.split(":", 1)[0].lower()
 
-    # note: existing URI driver prefixes currently map 1:1 with
-    # the adbc module suffix; update this map if that changes.
-    module_suffix_map: dict[str, str] = {}
+    # map uri prefix to module when not 1:1
+    module_suffix_map: dict[str, str] = {
+        "postgres": "postgresql",
+    }
     try:
         module_suffix = module_suffix_map.get(driver_name, driver_name)
         module_name = f"adbc_driver_{module_suffix}.dbapi"


### PR DESCRIPTION
Closes #10015.

The PostgreSQL docs [explicitly allow](https://www.postgresql.org/docs/current/libpq-connect.html#id-1.7.3.8.3.6) both `postgresql://` _and_ `postgres://` URI prefixes[^1]; we can easily handle this with an entry in the `module_suffix_map` lookup.

[^1]: _...URI scheme designator can be either "postgresql://" or "postgres://"..._