### PR TITLE
feat(python): detect and warn about bare `numpy` functions passed to `apply`

### DIFF
--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -9,7 +9,7 @@ import pytest
 import polars as pl
 from polars.exceptions import PolarsInefficientApplyWarning
 from polars.testing import assert_frame_equal
-from polars.utils.udfs import BytecodeParser
+from polars.utils.udfs import _NUMPY_FUNCTIONS, BytecodeParser
 
 MY_CONSTANT = 3
 
@@ -17,20 +17,21 @@ MY_CONSTANT = 3
 @pytest.mark.parametrize(
     "func",
     [
-        np.sin,
+        lambda x: x,
         lambda x, y: x + y,
         lambda x: x[0] + 1,
-        lambda x: x,
         lambda x: x > 0 and (x < 100 or (x % 2 == 0)),
     ],
 )
-def test_non_simple_function(func: Callable[[Any], Any]) -> None:
+def test_parse_invalid_function(func: Callable[[Any], Any]) -> None:
+    # functions we don't offer suggestions for (at all, or just not yet)
     assert not BytecodeParser(func, apply_target="expr").can_rewrite()
 
 
 @pytest.mark.parametrize(
     ("col", "func"),
     [
+        # numeric cols: math, comparison, logic ops
         ("a", lambda x: x + 1 - (2 / 3)),
         ("a", lambda x: x // 1 % 2),
         ("a", lambda x: x & True),
@@ -50,17 +51,18 @@ def test_non_simple_function(func: Callable[[Any], Any]) -> None:
         ("a", lambda x: MY_CONSTANT + x),
         ("a", lambda x: 0 + numpy.cbrt(x)),
         ("a", lambda x: np.sin(x) + 1),
+        # string cols
         ("b", lambda x: x.title()),
-        ("b", lambda x: x.lower() + x.upper()),
+        ("b", lambda x: x.lower() + ":" + x.upper()),
     ],
 )
-def test_expr_apply_produces_warning(col: str, func: Callable[[Any], Any]) -> None:
+def test_parse_apply_functions(col: str, func: Callable[[Any], Any]) -> None:
     with pytest.warns(
         PolarsInefficientApplyWarning, match="In this case, you can replace"
     ):
         parser = BytecodeParser(func, apply_target="expr")
-        suggested_expression = parser.to_expression(col=col)
-        assert suggested_expression is not None
+        suggested_expression = parser.to_expression(col)
+        assert isinstance(suggested_expression, str)
 
         df = pl.DataFrame(
             {
@@ -79,7 +81,26 @@ def test_expr_apply_produces_warning(col: str, func: Callable[[Any], Any]) -> No
         assert_frame_equal(result, expected)
 
 
-def test_expr_apply_parsing_misc() -> None:
+def test_parse_apply_numpy_raw() -> None:
+    lf = pl.LazyFrame({"a": [1, 2, 3]})
+
+    for func_name in _NUMPY_FUNCTIONS:
+        func = getattr(numpy, func_name)
+
+        # note: we can't parse/rewrite raw numpy functions...
+        parser = BytecodeParser(func, apply_target="expr")
+        assert not parser.can_rewrite()
+
+        # ...but we ARE still able to warn
+        with pytest.warns(
+            PolarsInefficientApplyWarning, match="In this case, you can replace"
+        ):
+            df1 = lf.select(pl.col("a").apply(func)).collect()
+            df2 = lf.select(getattr(pl.col("a"), func_name)()).collect()
+            assert_frame_equal(df1, df2)
+
+
+def test_parse_apply_miscellaneous() -> None:
     # note: can also identify inefficient functions and methods as well as lambdas
     class Test:
         def x10(self, x: pl.Expr) -> pl.Expr:


### PR DESCRIPTION
Ref: #9968.

While we can't parse/rewrite bare `numpy` function bytecode (as there isn't any), this PR enables detection of such functions and generates an equivalent warning:

```python
import numpy as np
import polars as pl

df = pl.DataFrame( {"abc": [16, 25, 36]} )
df.with_columns(
    val = pl.col("abc").apply( np.sqrt ),
)

# PolarsInefficientApplyWarning: 
# Expr.apply is significantly slower than the native expressions API.
# Only use if you absolutely CANNOT implement your logic otherwise.
# In this case, you can replace your `apply` with an expression:
#   -  pl.col("abc").apply(np.sqrt)
#   +  pl.col("abc").sqrt()
```