### PR TITLE
docs(rust): correct example in API reference

### DIFF
--- a/polars/polars-lazy/src/lib.rs
+++ b/polars/polars-lazy/src/lib.rs
@@ -101,8 +101,8 @@
 //!     df.lazy()
 //!     .groupby([col("date")])
 //!     .agg([
-//!         col("rain").min(),
-//!         col("rain").sum(),
+//!         col("rain").min().alias("min_rain"),
+//!         col("rain").sum().alias("max_rain"),
 //!         col("rain").quantile(lit(0.5), QuantileInterpolOptions::Nearest).alias("median_rain"),
 //!     ])
 //!     .sort("date", Default::default())

--- a/polars/polars-lazy/src/lib.rs
+++ b/polars/polars-lazy/src/lib.rs
@@ -102,7 +102,7 @@
 //!     .groupby([col("date")])
 //!     .agg([
 //!         col("rain").min().alias("min_rain"),
-//!         col("rain").sum().alias("max_rain"),
+//!         col("rain").sum().alias("sum_rain"),
 //!         col("rain").quantile(lit(0.5), QuantileInterpolOptions::Nearest).alias("median_rain"),
 //!     ])
 //!     .sort("date", Default::default())


### PR DESCRIPTION
Correct an erroneous example in API reference.
This example will return a Duplicate Err as "column with name 'rain' has more than one occurrences"