### PR TITLE
docs(python): Properly format `Returns` sections of docstrings

### DIFF
--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -204,7 +204,9 @@ class Config(contextlib.ContextDecorator):
 
         Returns
         -------
-        str : json string containing current Config options, or filepath where saved.
+        str
+            JSON string containing current Config options, or the path to the file where
+            the options are saved.
 
         """
         environment_vars = {

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -60,7 +60,7 @@ def from_dict(
 
     Returns
     -------
-    :class:`DataFrame`
+    DataFrame
 
     Examples
     --------
@@ -120,7 +120,7 @@ def from_dicts(
 
     Returns
     -------
-    :class:`DataFrame`
+    DataFrame
 
     Examples
     --------
@@ -224,7 +224,7 @@ def from_records(
 
     Returns
     -------
-    :class:`DataFrame`
+    DataFrame
 
     Examples
     --------
@@ -488,7 +488,7 @@ def from_numpy(
 
     Returns
     -------
-    :class:`DataFrame`
+    DataFrame
 
     Examples
     --------
@@ -559,7 +559,7 @@ def from_arrow(
 
     Returns
     -------
-    :class:`DataFrame` or :class:`Series`
+    DataFrame or Series
 
     Examples
     --------
@@ -679,7 +679,7 @@ def from_pandas(
 
     Returns
     -------
-    :class:`DataFrame`
+    DataFrame
 
     Examples
     --------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -455,10 +455,6 @@ class DataFrame:
           Support type specification or override of one or more columns; note that
           any dtypes inferred from the columns param will be overridden.
 
-        Returns
-        -------
-        DataFrame
-
         """
         return cls._from_pydf(
             dict_to_pydf(data, schema=schema, schema_overrides=schema_overrides)
@@ -500,10 +496,6 @@ class DataFrame:
             this does not yield conclusive results, column orientation is used.
         infer_schema_length
             How many rows to scan to determine the column type.
-
-        Returns
-        -------
-        DataFrame
 
         """
         return cls._from_pydf(
@@ -550,10 +542,6 @@ class DataFrame:
             the orientation is inferred by matching the columns and data dimensions. If
             this does not yield conclusive results, column orientation is used.
 
-        Returns
-        -------
-        DataFrame
-
         """
         return cls._from_pydf(
             numpy_to_pydf(
@@ -595,10 +583,6 @@ class DataFrame:
             any dtypes inferred from the columns param will be overridden.
         rechunk : bool, default True
             Make sure that all data is in contiguous memory.
-
-        Returns
-        -------
-        DataFrame
 
         """
         return cls._from_pydf(
@@ -647,10 +631,6 @@ class DataFrame:
             If the data contains NaN values they will be converted to null/None.
         include_index : bool, default False
             Load any non-default pandas indexes as columns.
-
-        Returns
-        -------
-        DataFrame
 
         """
         return cls._from_pydf(
@@ -895,10 +875,6 @@ class DataFrame:
         n_rows
             Stop reading from Apache Avro file after reading ``n_rows``.
 
-        Returns
-        -------
-        DataFrame
-
         """
         if isinstance(source, (str, Path)):
             source = normalise_filepath(source)
@@ -941,10 +917,6 @@ class DataFrame:
             Make sure that all data is contiguous.
         memory_map
             Memory map the file
-
-        Returns
-        -------
-        DataFrame
 
         """
         if isinstance(source, (str, Path)):
@@ -2052,7 +2024,7 @@ class DataFrame:
             of null values. Subsequent operations on the resulting pandas DataFrame may
             trigger conversion to NumPy arrays if that operation is not supported by
             pyarrow compute functions.
-        kwargs
+        **kwargs
             Arguments will be sent to :meth:`pyarrow.Table.to_pandas`.
 
         Returns
@@ -5637,7 +5609,7 @@ class DataFrame:
 
         Returns
         -------
-            Joined DataFrame
+        DataFrame
 
         See Also
         --------
@@ -6084,7 +6056,8 @@ class DataFrame:
 
         Returns
         -------
-        The dropped column.
+        Series
+            The dropped column.
 
         Examples
         --------
@@ -6312,6 +6285,7 @@ class DataFrame:
 
         Returns
         -------
+        DataFrame
             DataFrame with None values replaced by the filling strategy.
 
         See Also
@@ -6391,11 +6365,12 @@ class DataFrame:
         Parameters
         ----------
         value
-            Value to fill NaN with.
+            Value with which to replace NaN values.
 
         Returns
         -------
-            DataFrame with NaN replaced with fill_value
+        DataFrame
+            DataFrame with NaN values replaced by the given value.
 
         Warnings
         --------
@@ -7336,7 +7311,8 @@ class DataFrame:
 
         Returns
         -------
-        A new DataFrame with the columns added.
+        DataFrame
+            A new DataFrame with the columns added.
 
         Notes
         -----
@@ -7998,7 +7974,8 @@ class DataFrame:
 
         Returns
         -------
-        DataFrame with unique rows.
+        DataFrame
+            DataFrame with unique rows.
 
         Warnings
         --------
@@ -8360,7 +8337,7 @@ class DataFrame:
 
         Returns
         -------
-        Tuple (default) or dictionary of row values.
+        tuple (default) or dictionary of row values
 
         Notes
         -----
@@ -8484,7 +8461,7 @@ class DataFrame:
 
         Returns
         -------
-        A list of tuples (default) or dictionaries of row values.
+        list of tuples (default) or dictionaries of row values
 
         Examples
         --------
@@ -8725,7 +8702,7 @@ class DataFrame:
 
         Returns
         -------
-        An iterator of tuples (default) or dictionaries (if named) of python row values.
+        iterator of tuples (default) or dictionaries (if named) of python row values
 
         Examples
         --------

--- a/py-polars/polars/dataframe/groupby.py
+++ b/py-polars/polars/dataframe/groupby.py
@@ -64,9 +64,7 @@ class GroupBy:
         """
         Allows iteration over the groups of the groupby operation.
 
-        Returns
-        -------
-        Iterator returning tuples of (name, data) for each group.
+        Each group is represented by a tuple of (name, data).
 
         Examples
         --------

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -116,8 +116,9 @@ def _lazy_import(module_name: str) -> tuple[ModuleType, bool]:
 
     Returns
     -------
-    tuple[Module, bool]: a lazy-loading module and a boolean indicating if the
-    requested/underlying module exists (if not, the returned module is a proxy).
+    tuple of (Module, bool)
+        A lazy-loading module and a boolean indicating if the requested/underlying
+        module exists (if not, the returned module is a proxy).
 
     """
     # check if module is LOADED

--- a/py-polars/polars/expr/binary.py
+++ b/py-polars/polars/expr/binary.py
@@ -28,7 +28,8 @@ class ExprBinaryNameSpace:
 
         Returns
         -------
-        Boolean mask
+        Expr
+            Expression of data type :class:`Boolean`.
 
         See Also
         --------
@@ -74,7 +75,8 @@ class ExprBinaryNameSpace:
 
         Returns
         -------
-        Boolean mask
+        Expr
+            Expression of data type :class:`Boolean`.
 
         See Also
         --------
@@ -120,7 +122,8 @@ class ExprBinaryNameSpace:
 
         Returns
         -------
-        Boolean mask
+        Expr
+            Expression of data type :class:`Boolean`.
 
         See Also
         --------
@@ -188,7 +191,9 @@ class ExprBinaryNameSpace:
 
         Returns
         -------
-        Binary array with values encoded using provided encoding
+        Expr
+            Expression of data type :class:`Utf8` with values encoded using provided
+            encoding.
 
         Examples
         --------
@@ -211,6 +216,7 @@ class ExprBinaryNameSpace:
         │ yellow ┆ [binary data] ┆ ffff00           │
         │ blue   ┆ [binary data] ┆ 0000ff           │
         └────────┴───────────────┴──────────────────┘
+
         """
         if encoding == "hex":
             return wrap_expr(self._pyexpr.bin_hex_encode())

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -82,7 +82,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Expression of data type `Date`/`Datetime`
+        Expr
+            Expression of data type :class:`Date` or :class:`Datetime`.
 
         Examples
         --------
@@ -257,7 +258,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Expression of data type `Date`/`Datetime`
+        Expr
+            Expression of data type :class:`Date` or :class:`Datetime`.
 
         Warnings
         --------
@@ -505,7 +507,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Year as Int32
+        Expr
+            Expression of data type :class:`Int32`.
 
         Examples
         --------
@@ -551,7 +554,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Leap year info as Boolean
+        Expr
+            Expression of data type :class:`Boolean`.
 
         Examples
         --------
@@ -598,7 +602,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        ISO Year as Int32
+        Expr
+            Expression of data type :class:`Int32`.
 
         Examples
         --------
@@ -644,7 +649,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Quarter as UInt32
+        Expr
+            Expression of data type :class:`UInt32`.
 
         Examples
         --------
@@ -691,7 +697,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Month as UInt32
+        Expr
+            Expression of data type :class:`UInt32`.
 
         Examples
         --------
@@ -738,7 +745,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Week number as UInt32
+        Expr
+            Expression of data type :class:`UInt32`.
 
         Examples
         --------
@@ -784,7 +792,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Week day as UInt32
+        Expr
+            Expression of data type :class:`UInt32`.
 
         See Also
         --------
@@ -842,7 +851,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Day as UInt32
+        Expr
+            Expression of data type :class:`UInt32`.
 
         See Also
         --------
@@ -900,7 +910,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Day as UInt32
+        Expr
+            Expression of data type :class:`UInt32`.
 
         See Also
         --------
@@ -955,7 +966,9 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Expression of data type `Time`
+        Expr
+            Expression of data type :class:`Time`.
+
         """
         return wrap_expr(self._pyexpr.dt_time())
 
@@ -967,7 +980,9 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Expression of data type `Date`
+        Expr
+            Expression of data type :class:`Date`.
+
         """
         return wrap_expr(self._pyexpr.dt_date())
 
@@ -979,7 +994,9 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Expression of data type `Datetime`
+        Expr
+            Expression of data type :class:`Datetime`.
+
         """
         return wrap_expr(self._pyexpr.dt_datetime())
 
@@ -993,7 +1010,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Hour as UInt32
+        Expr
+            Expression of data type :class:`UInt32`.
 
         Examples
         --------
@@ -1039,7 +1057,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Minute as UInt32
+        Expr
+            Expression of data type :class:`UInt32`.
 
         Examples
         --------
@@ -1092,7 +1111,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Second as UInt32 (or Float64)
+        Expr
+            Expression of data type :class:`UInt32` or :class:`Float64`.
 
         Examples
         --------
@@ -1187,7 +1207,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Milliseconds as UInt32
+        Expr
+            Expression of data type :class:`UInt32`.
 
         """
         return wrap_expr(self._pyexpr.dt_millisecond())
@@ -1200,7 +1221,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Microseconds as UInt32
+        Expr
+            Expression of data type :class:`UInt32`.
 
         Examples
         --------
@@ -1249,7 +1271,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Nanoseconds as UInt32
+        Expr
+            Expression of data type :class:`UInt32`.
 
         """
         return wrap_expr(self._pyexpr.dt_nanosecond())
@@ -1573,7 +1596,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Expression of data type Int64
+        Expr
+            Expression of data type :class:`Int64`.
 
         Examples
         --------
@@ -1611,7 +1635,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Expression of data type Int64
+        Expr
+            Expression of data type :class:`Int64`.
 
         Examples
         --------
@@ -1650,7 +1675,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Expression of data type Int64
+        Expr
+            Expression of data type :class:`Int64`.
 
         Examples
         --------
@@ -1689,7 +1715,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Expression of data type `Int64`
+        Expr
+            Expression of data type :class:`Int64`.
 
         Examples
         --------
@@ -1732,7 +1759,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Expression of data type Int64
+        Expr
+            Expression of data type :class:`Int64`.
 
         Examples
         --------
@@ -1779,7 +1807,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Expression of data type Int64
+        Expr
+            Expression of data type :class:`Int64`.
 
         Examples
         --------
@@ -1826,7 +1855,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Expression of data type Int64
+        Expr
+            Expression of data type :class:`Int64`.
 
         Examples
         --------
@@ -1903,7 +1933,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Date/Datetime expression
+        Expr
+            Expression of data type :class:`Date` or :class:`Datetime`.
 
         Examples
         --------
@@ -1965,7 +1996,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Date/Datetime expression
+        Expr
+            Expression of data type :class:`Date` or :class:`Datetime`.
 
         Notes
         -----
@@ -2011,7 +2043,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Date/Datetime expression
+        Expr
+            Expression of data type :class:`Date` or :class:`Datetime`.
 
         Notes
         -----
@@ -2061,7 +2094,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Duration expression
+        Expr
+            Expression of data type :class:`Duration`.
 
         See Also
         --------
@@ -2095,7 +2129,8 @@ class ExprDateTimeNameSpace:
 
         Returns
         -------
-        Duration expression
+        Expr
+            Expression of data type :class:`Duration`.
 
         See Also
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -323,7 +323,8 @@ class Expr:
 
         Returns
         -------
-        Boolean literal
+        Expr
+            Expression of data type :class:`Boolean`.
 
         Examples
         --------
@@ -375,7 +376,8 @@ class Expr:
 
         Returns
         -------
-        Boolean literal
+        Expr
+            Expression of data type :class:`Boolean`.
 
         Examples
         --------
@@ -1046,8 +1048,8 @@ class Expr:
 
         Returns
         -------
-        out
-            Series of type Boolean
+        Expr
+            Expression of data type :class:`Boolean`.
 
         Examples
         --------
@@ -1077,8 +1079,8 @@ class Expr:
 
         Returns
         -------
-        out
-            Series of type Boolean
+        Expr
+            Expression of data type :class:`Boolean`.
 
         Examples
         --------
@@ -2018,7 +2020,7 @@ class Expr:
         Returns
         -------
         Expr
-            Series of dtype UInt32.
+            Expression of data type :class:`UInt32`.
 
         Examples
         --------
@@ -2280,7 +2282,8 @@ class Expr:
 
         Returns
         -------
-        Values taken by index
+        Expr
+            Expression of the same data type.
 
         Examples
         --------
@@ -3173,7 +3176,8 @@ class Expr:
 
         Returns
         -------
-        Boolean Series
+        Expr
+            Expression of data type :class:`Boolean`.
 
         Examples
         --------
@@ -3486,7 +3490,8 @@ class Expr:
 
         Returns
         -------
-            A Struct Series containing "lengths" and "values" Fields
+        Expr
+            Expression of data type :class:`Struct` with Fields "lengths" and "values".
 
         Examples
         --------
@@ -3892,13 +3897,14 @@ class Expr:
 
     def explode(self) -> Self:
         """
-        Explode a list Series.
+        Explode a list expression.
 
         This means that every item is expanded to a new row.
 
         Returns
         -------
-        Exploded Series of same dtype
+        Expr
+            Expression with the data type of the list elements.
 
         See Also
         --------
@@ -4755,7 +4761,8 @@ class Expr:
 
         Returns
         -------
-        Expr that evaluates to a Boolean Series.
+        Expr
+            Expression of data type :class:`Boolean`.
 
         Examples
         --------
@@ -4799,7 +4806,9 @@ class Expr:
 
         Returns
         -------
-        Series of type List
+        Expr
+            Expression of data type :class:`List`, where the inner data type is equal
+            to the original data type.
 
         Examples
         --------
@@ -4847,7 +4856,8 @@ class Expr:
 
         Returns
         -------
-        Expr that evaluates to a Boolean Series.
+        Expr
+            Expression of data type :class:`Boolean`.
 
         Examples
         --------
@@ -7449,7 +7459,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7473,7 +7484,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7497,7 +7509,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7521,7 +7534,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7545,7 +7559,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7569,7 +7584,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7593,7 +7609,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7617,7 +7634,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7641,7 +7659,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7665,7 +7684,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7689,7 +7709,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7713,7 +7734,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7737,7 +7759,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7769,7 +7792,8 @@ class Expr:
 
         Returns
         -------
-        Series of dtype Float64
+        Expr
+            Expression of data type :class:`Float64`.
 
         Examples
         --------
@@ -7807,9 +7831,10 @@ class Expr:
         Returns
         -------
         Expr
-            If a single dimension is given, results in a flat Series of shape (len,).
-            If a multiple dimensions are given, results in a Series of Lists with shape
-            (rows, cols).
+            If a single dimension is given, results in an expression of the original
+            data type.
+            If a multiple dimensions are given, results in an expression of data type
+            :class:`List` with shape (rows, cols).
 
         Examples
         --------
@@ -8258,7 +8283,8 @@ class Expr:
 
         Returns
         -------
-        Dtype Struct
+        Expr
+            Expression of data type :class:`Struct`.
 
         Examples
         --------

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -437,7 +437,8 @@ class ExprListNameSpace:
 
         Returns
         -------
-        Boolean mask
+        Expr
+            Expression of data type :class:`Boolean`.
 
         Examples
         --------
@@ -471,7 +472,8 @@ class ExprListNameSpace:
 
         Returns
         -------
-        Series of dtype Utf8
+        Expr
+            Expression of data type :class:`Utf8`.
 
         Examples
         --------
@@ -496,7 +498,9 @@ class ExprListNameSpace:
 
         Returns
         -------
-        Series of dtype UInt32/UInt64 (depending on compilation)
+        Expr
+            Expression of data type :class:`UInt32` or :class:`UInt64`
+            (depending on compilation).
 
         Examples
         --------
@@ -525,7 +529,9 @@ class ExprListNameSpace:
 
         Returns
         -------
-        Series of dtype UInt32/UInt64 (depending on compilation)
+        Expr
+            Expression of data type :class:`UInt32` or :class:`UInt64`
+            (depending on compilation).
 
         Examples
         --------
@@ -704,7 +710,8 @@ class ExprListNameSpace:
 
         Returns
         -------
-        Exploded column with the datatype of the list elements.
+        Expr
+            Expression with the data type of the list elements.
 
         See Also
         --------

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -59,9 +59,10 @@ class ExprMetaNameSpace:
 
         Returns
         -------
-        A list of expressions which in most cases will have a unit length.
-        This is not the case when an expression has multiple inputs.
-        For instance in a ``fold`` expression.
+        list of Expr
+            A list of expressions which in most cases will have a unit length.
+            This is not the case when an expression has multiple inputs.
+            For instance in a ``fold`` expression.
 
         """
         return [wrap_expr(e) for e in self._pyexpr.meta_pop()]

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -431,7 +431,8 @@ class ExprStringNameSpace:
 
         Returns
         -------
-        Series of dtype Utf8
+        Expr
+            Expression of data type :class:`Utf8`.
 
         Examples
         --------
@@ -989,10 +990,11 @@ class ExprStringNameSpace:
 
     def json_path_match(self, json_path: str) -> Expr:
         """
-        Extract the first match of json string with provided JSONPath expression.
+        Extract the first match of JSON string with the provided JSONPath expression.
 
-        Throw errors if encounter invalid json strings.
-        All return value will be casted to Utf8 regardless of the original value.
+        Throws errors if invalid JSON strings are encountered.
+        All return values will be cast to :class:`Utf8` regardless of the original
+        value.
 
         Documentation on JSONPath standard can be found
         `here <https://goessner.net/articles/JsonPath/>`_.
@@ -1004,8 +1006,9 @@ class ExprStringNameSpace:
 
         Returns
         -------
-        Utf8 array. Contain null if original value is null or the json_path return
-        nothing.
+        Expr
+            Expression of data type :class:`Utf8`. Contains null values if original
+            value is null or the json_path returns nothing.
 
         Examples
         --------
@@ -1062,7 +1065,8 @@ class ExprStringNameSpace:
 
         Returns
         -------
-        Utf8 array with values encoded using provided encoding
+        Expr
+            Expression of data type :class:`Utf8`.
 
         Examples
         --------
@@ -1135,7 +1139,9 @@ class ExprStringNameSpace:
 
         Returns
         -------
-        Utf8 array. Contain null if original value is null or regex capture nothing.
+        Expr
+            Expression of data type :class:`Utf8`. Contains null values if original
+            value is null or the regex captures nothing.
 
         Examples
         --------
@@ -1229,7 +1235,8 @@ class ExprStringNameSpace:
 
         Returns
         -------
-        List[Utf8]
+        Expr
+            Expression of data type ``List(Utf8)``.
 
         Examples
         --------
@@ -1263,7 +1270,9 @@ class ExprStringNameSpace:
 
         Returns
         -------
-        UInt32 array. Contain null if original value is null or regex capture nothing.
+        Expr
+            Expression of data type :class:`UInt32`. Contains null values if the
+            original value is null or the regex captures nothing.
 
         Examples
         --------
@@ -1312,7 +1321,8 @@ class ExprStringNameSpace:
 
         Returns
         -------
-        List of Utf8 type
+        Expr
+            Expression of data type :class:`Utf8`.
 
         """
         if inclusive:
@@ -1335,6 +1345,12 @@ class ExprStringNameSpace:
             Number of splits to make.
         inclusive
             If True, include the split character/string in the results.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`Struct` with fields of data type
+            :class:`Utf8`.
 
         Examples
         --------
@@ -1378,10 +1394,6 @@ class ExprStringNameSpace:
         │ d_4  ┆ d          ┆ 4           │
         └──────┴────────────┴─────────────┘
 
-        Returns
-        -------
-        Struct of Utf8 type
-
         """
         if inclusive:
             return wrap_expr(self._pyexpr.str_split_exact_inclusive(by, n))
@@ -1401,6 +1413,12 @@ class ExprStringNameSpace:
             Substring to split by.
         n
             Max number of items to return.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`Struct` with fields of data type
+            :class:`Utf8`.
 
         Examples
         --------
@@ -1440,10 +1458,6 @@ class ExprStringNameSpace:
         │ foo-bar     ┆ foo-bar    ┆ null        │
         │ foo bar baz ┆ foo        ┆ bar baz     │
         └─────────────┴────────────┴─────────────┘
-
-        Returns
-        -------
-        Struct of Utf8 type
 
         """
         return wrap_expr(self._pyexpr.str_splitn(by, n))
@@ -1582,7 +1596,7 @@ class ExprStringNameSpace:
         Returns
         -------
         Expr
-            Series of dtype Utf8.
+            Expression of data type :class:`Utf8`.
 
         Examples
         --------
@@ -1628,7 +1642,8 @@ class ExprStringNameSpace:
 
         Returns
         -------
-        Exploded column with string datatype.
+        Expr
+            Expression of data type :class:`Utf8`.
 
         Examples
         --------
@@ -1669,7 +1684,8 @@ class ExprStringNameSpace:
 
         Returns
         -------
-        Expr : Series of parsed integers in i32 format
+        Expr
+            Expression of data type :class:`Int32`.
 
         Examples
         --------

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -55,7 +55,8 @@ def datetime_(
 
     Returns
     -------
-    Expr of type `pl.Datetime`
+    Expr
+        Expression of data type :class:`Datetime`.
 
     """
     year_expr = parse_as_expression(year)
@@ -103,7 +104,8 @@ def date_(
 
     Returns
     -------
-    Expr of type pl.Date
+    Expr
+        Expression of data type :class:`Date`.
 
     """
     return datetime_(year, month, day).cast(Date).alias("date")
@@ -131,7 +133,8 @@ def time_(
 
     Returns
     -------
-    Expr of type pl.Date
+    Expr
+        Expression of data type :class:`Date`.
 
     """
     epoch_start = (1970, 1, 1)
@@ -158,7 +161,8 @@ def duration(
 
     Returns
     -------
-    Expr of type `pl.Duration`
+    Expr
+        Expression of data type :class:`Duration`.
 
     Examples
     --------

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1115,6 +1115,7 @@ def map(
     Returns
     -------
     Expr
+        Expression with the data type given by ``return_dtype``.
 
     Examples
     --------
@@ -1191,6 +1192,7 @@ def apply(
     Returns
     -------
     Expr
+        Expression with the data type given by ``return_dtype``.
 
     Examples
     --------
@@ -1766,7 +1768,7 @@ def collect_all(
 
     Returns
     -------
-    List[DataFrame]
+    list of DataFrames
         The collected DataFrames, returned in the same order as the input LazyFrames.
 
     """

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -205,7 +205,7 @@ def int_range(
     Returns
     -------
     Expr or Series
-        Column of data type ``Int64``.
+        Column of data type :class:`Int64`.
 
     See Also
     --------
@@ -424,7 +424,7 @@ def date_range(
     Returns
     -------
     Expr or Series
-        Column of data type ``Date`` or ``Datetime``.
+        Column of data type :class:`Date` or :class:`Datetime`.
 
     Notes
     -----
@@ -770,7 +770,7 @@ def time_range(
     Returns
     -------
     Expr or Series
-        Column of data type ``Time``.
+        Column of data type `:class:Time`.
 
     See Also
     --------

--- a/py-polars/polars/io/csv/batched_reader.py
+++ b/py-polars/polars/io/csv/batched_reader.py
@@ -128,7 +128,7 @@ class BatchedCsvReader:
 
         Returns
         -------
-        Sequence of DataFrames
+        list of DataFrames
 
         """
         batches = self._reader.next_batches(n)

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -285,16 +285,12 @@ def _get_delta_lake_table(
     delta_table_options: dict[str, Any] | None = None,
 ) -> deltalake.DeltaTable:
     """
-    Initialise a Delta lake table for use in read and scan operations.
+    Initialize a Delta lake table for use in read and scan operations.
 
     Notes
     -----
     Make sure to install deltalake>=0.8.0. Read the documentation
     `here <https://delta-io.github.io/delta-rs/python/installation.html>`_.
-
-    Returns
-    -------
-    DeltaTable
 
     """
     _check_if_delta_available()

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -121,7 +121,8 @@ def read_ipc_schema(source: str | BinaryIO | Path | bytes) -> dict[str, PolarsDa
 
     Returns
     -------
-    Dictionary mapping column names to datatypes
+    dict
+        Dictionary mapping column names to datatypes
 
     """
     if isinstance(source, (str, Path)):

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -146,7 +146,8 @@ def read_parquet_schema(
 
     Returns
     -------
-    Dictionary mapping column names to datatypes
+    dict
+        Dictionary mapping column names to datatypes
 
     """
     if isinstance(source, (str, Path)):

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3087,7 +3087,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Returns
         -------
-        A new LazyFrame with the columns added.
+        LazyFrame
+            A new LazyFrame with the columns added.
 
         Notes
         -----
@@ -4361,7 +4362,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Returns
         -------
-        DataFrame with unique rows.
+        LazyFrame
+            LazyFrame with unique rows.
 
         Warnings
         --------

--- a/py-polars/polars/series/_numpy.py
+++ b/py-polars/polars/series/_numpy.py
@@ -46,7 +46,8 @@ def _ptr_to_numpy(ptr: int, len: int, ptr_type: Any) -> np.ndarray[Any, Any]:
 
     Returns
     -------
-    View of memory block as numpy array.
+    numpy.ndarray
+        View of memory block as numpy array.
 
     """
     ptr_ctype = ctypes.cast(ptr, ctypes.POINTER(ptr_type))

--- a/py-polars/polars/series/binary.py
+++ b/py-polars/polars/series/binary.py
@@ -30,7 +30,8 @@ class BinaryNameSpace:
 
         Returns
         -------
-        Boolean mask
+        Series
+            Series of data type :class:`Boolean`.
 
         """
 
@@ -81,6 +82,7 @@ class BinaryNameSpace:
 
         Returns
         -------
-        Binary array with values encoded using provided encoding
+        Series
+            Series of data type :class:`Boolean`.
 
         """

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -221,7 +221,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Year part as Int32
+        Series
+            Series of data type :class:`Int32`.
 
         Examples
         --------
@@ -254,7 +255,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Leap year info as Boolean
+        Series
+            Series of data type :class:`Boolean`.
 
         Examples
         --------
@@ -292,7 +294,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        ISO year as Int32
+        Series
+            Series of data type :class:`Int32`.
 
         Examples
         --------
@@ -317,7 +320,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Quarter as UInt32
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -357,7 +361,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Month part as UInt32
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -397,7 +402,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Week number as UInt32
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -436,7 +442,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Weekday as UInt32
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -482,7 +489,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Day part as UInt32
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -524,7 +532,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Ordinal day as UInt32
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -559,7 +568,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Time Series
+        Series
+            Series of data type :class:`Time`.
 
         Examples
         --------
@@ -589,7 +599,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Date Series
+        Series
+            Series of data type :class:`Date`.
 
         Examples
         --------
@@ -619,7 +630,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Datetime Series
+        Series
+            Series of data type :class:`Datetime`.
 
         Examples
         --------
@@ -651,7 +663,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Hour part as UInt32
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -690,7 +703,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Minute part as UInt32
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -734,7 +748,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Second part as UInt32 (or Float64)
+        Series
+            Series of data type :class:`UInt32` or :class:`Float64`.
 
         Examples
         --------
@@ -795,7 +810,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Millisecond part as UInt32
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -842,7 +858,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Microsecond part as UInt32
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -889,7 +906,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Nanosecond part as UInt32
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -1228,7 +1246,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Series
+            Series of data type :class:`Int64`.
 
         Examples
         --------
@@ -1261,7 +1280,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Series
+            Series of data type :class:`Int64`.
 
         Examples
         --------
@@ -1296,7 +1316,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Series
+            Series of data type :class:`Int64`.
 
         Examples
         --------
@@ -1331,7 +1352,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Series
+            Series of data type :class:`Int64`.
 
         Examples
         --------
@@ -1368,7 +1390,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Series
+            Series of data type :class:`Int64`.
 
         Examples
         --------
@@ -1404,7 +1427,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Series
+            Series of data type :class:`Int64`.
 
         Examples
         --------
@@ -1440,7 +1464,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        A series of dtype Int64
+        Series
+            Series of data type :class:`Int64`.
 
         Examples
         --------
@@ -1507,7 +1532,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Date/Datetime expression
+        Series
+            Series of data type :class:`Date` or :class:`Datetime`.
 
         Examples
         --------
@@ -1620,7 +1646,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Date/Datetime series
+        Series
+            Series of data type :class:`Date` or :class:`Datetime`.
 
         Examples
         --------
@@ -1778,7 +1805,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Date/Datetime series
+        Series
+            Series of data type :class:`Date` or :class:`Datetime`.
 
         Warnings
         --------
@@ -1877,7 +1905,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Date/Datetime series
+        Series
+            Series of data type :class:`Date` or :class:`Datetime`.
 
         Notes
         -----
@@ -1907,7 +1936,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Date/Datetime series.
+        Series
+            Series of data type :class:`Date` or :class:`Datetime`.
 
         Notes
         -----
@@ -1941,7 +1971,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Duration Series
+        Series
+            Series of data type :class:`Duration`.
 
         See Also
         --------
@@ -1979,7 +2010,8 @@ class DateTimeNameSpace:
 
         Returns
         -------
-        Duration Series
+        Series
+            Series of data type :class:`Duration`.
 
         See Also
         --------

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -211,7 +211,8 @@ class ListNameSpace:
 
         Returns
         -------
-        Series of dtype Utf8
+        Series
+            Series of data type :class:`Utf8`.
 
         Examples
         --------
@@ -243,7 +244,8 @@ class ListNameSpace:
 
         Returns
         -------
-        Boolean mask
+        Series
+            Series of data type :class:`Boolean`.
 
         """
 
@@ -253,7 +255,9 @@ class ListNameSpace:
 
         Returns
         -------
-        Series of dtype UInt32/UInt64 (depending on compilation)
+        Series
+            Series of data type :class:`UInt32` or :class:`UInt64`
+            (depending on compilation).
 
         """
 
@@ -263,7 +267,9 @@ class ListNameSpace:
 
         Returns
         -------
-        Series of dtype UInt32/UInt64 (depending on compilation)
+        Series
+            Series of data type :class:`UInt32` or :class:`UInt64`
+            (depending on compilation).
 
         """
 
@@ -404,7 +410,8 @@ class ListNameSpace:
 
         Returns
         -------
-        Exploded column with the datatype of the list elements.
+        Series
+            Series with the data type of the list elements.
 
         See Also
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -377,6 +377,7 @@ class Series:
         -------
         dict
             Dictionary containing the flag name and the value
+
         """
         out = {
             "SORTED_ASC": self._s.is_sorted_ascending_flag(),
@@ -1218,7 +1219,8 @@ class Series:
 
         Returns
         -------
-        Boolean literal
+        Series
+            Series of data type :class:`Boolean`.
 
         """
         return self.to_frame().select(F.col(self.name).any(drop_nulls)).to_series()[0]
@@ -1229,7 +1231,8 @@ class Series:
 
         Returns
         -------
-        Boolean literal
+        Series
+            Series of data type :class:`Boolean`.
 
         """
         return self.to_frame().select(F.col(self.name).all(drop_nulls)).to_series()[0]
@@ -1314,7 +1317,8 @@ class Series:
 
         Returns
         -------
-        Dictionary with summary statistics of a Series.
+        DataFrame
+            Mapping with summary statistics of a Series.
 
         Examples
         --------
@@ -1648,7 +1652,7 @@ class Series:
         category_label
             Name given to the category column. Only used if series == False
         series
-            If True, return the a categorical series in the data's original order.
+            If True, return a categorical Series in the data's original order.
         left_closed
             Whether intervals should be [) instead of (]
         include_breaks
@@ -1766,7 +1770,7 @@ class Series:
         category_label
             Name given to the category column. Only used if series == False.
         series
-            If True, return a categorical series in the data's original order
+            If True, return a categorical Series in the data's original order
         left_closed
             Whether intervals should be [) instead of (]
         allow_duplicates
@@ -1876,7 +1880,8 @@ class Series:
 
         Returns
         -------
-            A Struct Series containing "lengths" and "values" Fields
+        Series
+            Series of data type :class:`Struct` with Fields "lengths" and "values".
 
         Examples
         --------
@@ -1908,8 +1913,11 @@ class Series:
 
         Returns
         -------
-            Series
+        Series
 
+        See Also
+        --------
+        rle
 
         Examples
         --------
@@ -2789,7 +2797,7 @@ class Series:
 
         Returns
         -------
-        Integer
+        int
 
         Examples
         --------
@@ -2806,7 +2814,7 @@ class Series:
 
         Returns
         -------
-        Integer
+        int
 
         Examples
         --------
@@ -2947,7 +2955,8 @@ class Series:
 
         Returns
         -------
-        Boolean Series
+        Series
+            Series of data type :class:`Boolean`.
 
         Examples
         --------
@@ -2970,7 +2979,8 @@ class Series:
 
         Returns
         -------
-        Boolean Series
+        Series
+            Series of data type :class:`Boolean`.
 
         Examples
         --------
@@ -2993,7 +3003,8 @@ class Series:
 
         Returns
         -------
-        Boolean Series
+        Series
+            Series of data type :class:`Boolean`.
 
         Examples
         --------
@@ -3016,7 +3027,8 @@ class Series:
 
         Returns
         -------
-        Boolean Series
+        Series
+            Series of data type :class:`Boolean`.
 
         Examples
         --------
@@ -3039,7 +3051,8 @@ class Series:
 
         Returns
         -------
-        Boolean Series
+        Series
+            Series of data type :class:`Boolean`.
 
         Examples
         --------
@@ -3063,7 +3076,8 @@ class Series:
 
         Returns
         -------
-        Boolean Series
+        Series
+            Series of data type :class:`Boolean`.
 
         Examples
         --------
@@ -3087,7 +3101,8 @@ class Series:
 
         Returns
         -------
-        Boolean Series
+        Series
+            Series of data type :class:`Boolean`.
 
         Examples
         --------
@@ -3137,7 +3152,8 @@ class Series:
 
         Returns
         -------
-        UInt32 Series
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -3158,7 +3174,8 @@ class Series:
 
         Returns
         -------
-        Boolean Series
+        Series
+            Series of data type :class:`Boolean`.
 
         Examples
         --------
@@ -3181,7 +3198,8 @@ class Series:
 
         Returns
         -------
-        Boolean Series
+        Series
+            Series of data type :class:`Boolean`.
 
         """
 
@@ -3191,7 +3209,8 @@ class Series:
 
         Returns
         -------
-        Boolean Series
+        Series
+            Series of data type :class:`Boolean`.
 
         Examples
         --------
@@ -3216,7 +3235,8 @@ class Series:
 
         Returns
         -------
-        Exploded Series of same dtype
+        Series
+            Series with the data type of the list elements.
 
         See Also
         --------
@@ -3924,7 +3944,8 @@ class Series:
 
         Returns
         -------
-        the series mutated
+        Series
+            The mutated series.
 
         Notes
         -----
@@ -4625,7 +4646,7 @@ class Series:
 
         Returns
         -------
-        New Series
+        Series
 
         Examples
         --------
@@ -5877,9 +5898,10 @@ class Series:
         Returns
         -------
         Series
-            If a single dimension is given, results in a flat Series of shape (len,).
-            If a multiple dimensions are given, results in a Series of Lists with shape
-            (rows, cols).
+            If a single dimension is given, results in a Series of the original
+            data type.
+            If a multiple dimensions are given, results in a Series of data type
+            :class:`List` with shape (rows, cols).
 
         See Also
         --------

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -331,7 +331,8 @@ class StringNameSpace:
 
         Returns
         -------
-        Series[u32]
+        Series
+            Series of data type :class:`UInt32`.
 
         Examples
         --------
@@ -354,7 +355,8 @@ class StringNameSpace:
 
         Returns
         -------
-        Series[u32]
+        Series
+            Series of data type :class:`UInt32`.
 
         Notes
         -----
@@ -387,7 +389,8 @@ class StringNameSpace:
 
         Returns
         -------
-        Series of dtype Utf8
+        Series
+            Series of data type :class:`Utf8`.
 
         Examples
         --------
@@ -436,7 +439,8 @@ class StringNameSpace:
 
         Returns
         -------
-        Boolean mask
+        Series
+            Series of data type :class:`Boolean`.
 
         Examples
         --------
@@ -543,7 +547,8 @@ class StringNameSpace:
 
         Returns
         -------
-        Utf8 array with values encoded using provided encoding
+        Series
+            Series of data type :class:`Utf8`.
 
         Examples
         --------
@@ -612,8 +617,9 @@ class StringNameSpace:
 
         Returns
         -------
-        Utf8 array. Contain null if original value is null or the json_path return
-        nothing.
+        Series
+            Series of data type :class:`Utf8`. Contains null values if the original
+            value is null or the json_path returns nothing.
 
         Examples
         --------
@@ -647,6 +653,12 @@ class StringNameSpace:
             Group 0 mean the whole pattern, first group begin at index 1
             Default to the first capture group
 
+        Returns
+        -------
+        Series
+            Series of data type :class:`Utf8`. Contains null values if the original
+            value is null or regex captures nothing.
+
         Notes
         -----
         To modify regular expression behaviour (such as multi-line matching)
@@ -670,10 +682,6 @@ class StringNameSpace:
         See the regex crate's section on `grouping and flags
         <https://docs.rs/regex/latest/regex/#grouping-and-flags>`_ for
         additional information about the use of inline expression modifiers.
-
-        Returns
-        -------
-        Utf8 array. Contain null if original value is null or regex capture nothing.
 
         Examples
         --------
@@ -749,7 +757,8 @@ class StringNameSpace:
 
         Returns
         -------
-        List[Utf8]
+        Series
+            Series of data type ``List(Utf8)``.
 
         Examples
         --------
@@ -776,7 +785,9 @@ class StringNameSpace:
 
         Returns
         -------
-        UInt32 array. Contain null if original value is null or regex capture nothing.
+        Series
+            Series of data type :class:`UInt32`. Contains null values if the original
+            value is null or if the regex captures nothing.
 
         Examples
         --------
@@ -805,7 +816,8 @@ class StringNameSpace:
 
         Returns
         -------
-        List of Utf8 type
+        Series
+            Series of data type ``List(Utf8)``.
 
         """
 
@@ -864,7 +876,8 @@ class StringNameSpace:
 
         Returns
         -------
-        Struct of Utf8 type
+        Series
+            Series of data type :class:`Struct` with fields of data type :class:`Utf8`.
 
         """
 
@@ -921,7 +934,8 @@ class StringNameSpace:
 
         Returns
         -------
-        Struct of Utf8 type
+        Series
+            Series of data type :class:`Struct` with fields of data type :class:`Utf8`.
 
         """
         s = wrap_s(self._s)
@@ -1268,7 +1282,7 @@ class StringNameSpace:
         Returns
         -------
         Series
-            Series of dtype Utf8.
+            Series of data type :class:`Struct` with fields of data type :class:`Utf8`.
 
         Examples
         --------
@@ -1303,7 +1317,8 @@ class StringNameSpace:
 
         Returns
         -------
-        Exploded column with string datatype.
+        Series
+            Series of data type :class:`Utf8`.
 
         Examples
         --------
@@ -1340,7 +1355,8 @@ class StringNameSpace:
 
         Returns
         -------
-        Series of parsed integers in i32 format
+        Series
+            Series of data type :class:`Int32`.
 
         Examples
         --------

--- a/py-polars/polars/series/utils.py
+++ b/py-polars/polars/series/utils.py
@@ -138,7 +138,7 @@ def get_ffi_func(
     name: str, dtype: PolarsDataType, obj: PySeries
 ) -> Callable[..., Any] | None:
     """
-    Dynamically obtain the proper ffi function/ method.
+    Dynamically obtain the proper FFI function/ method.
 
     Parameters
     ----------
@@ -153,7 +153,8 @@ def get_ffi_func(
 
     Returns
     -------
-    ffi function, or None if not found
+    callable or None
+        FFI function, or None if not found.
 
     """
     ffi_name = dtype_to_ffiname(dtype)

--- a/py-polars/polars/utils/meta.py
+++ b/py-polars/polars/utils/meta.py
@@ -21,7 +21,8 @@ def get_index_type() -> DataTypeClass:
 
     Returns
     -------
-    UInt32 in regular Polars, UInt64 in bigidx Polars.
+    DataType
+        :class:`UInt32` in regular Polars, :class:`UInt64` in bigidx Polars.
 
     """
     return _get_index_type()


### PR DESCRIPTION
A lot of our Returns sections were not properly formatted according to [numpy docstyle](https://numpydoc.readthedocs.io/en/latest/format.html#returns), resulting in broken Sphinx formatting.

This PR updates all existing Returns sections to conform to the required formatting.

#### Example before
<img src="https://github.com/pola-rs/polars/assets/3502351/61bbe2a7-cf0f-4ae8-85c4-88172c867cf6" width="400" >

#### Example after
_(I know this one doesn't make sense, it's just to show the formatting)_
<img src="https://github.com/pola-rs/polars/assets/3502351/f1b48918-7648-42b0-a288-e3c4e2af1fe6" width="400" >
