### PR TITLE
feat(python, rust): Adds sql `CASE` statement expressions 

### DIFF
--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -436,7 +436,7 @@ impl SqlExprVisitor<'_> {
                 let first_then = self.visit_expr(first.1)?;
                 let expr = when(first_cond).then(first_then);
                 let next = when_thens.next();
-    
+
                 let mut when_then = if let Some((cond, res)) = next {
                     let second_operand_expr = self.visit_expr(operand_expr)?;
                     let cond = second_operand_expr.eq(self.visit_expr(cond)?);
@@ -445,14 +445,14 @@ impl SqlExprVisitor<'_> {
                 } else {
                     return Ok(expr.otherwise(else_res));
                 };
-    
+
                 for (cond, res) in when_thens {
                     let new_operand_expr = self.visit_expr(operand_expr)?;
                     let cond = new_operand_expr.eq(self.visit_expr(cond)?);
                     let res = self.visit_expr(res)?;
                     when_then = when_then.when(cond).then(res);
                 }
-    
+
                 return Ok(when_then.otherwise(else_res));
             }
 

--- a/polars/polars-sql/src/sql_expr.rs
+++ b/polars/polars-sql/src/sql_expr.rs
@@ -406,10 +406,6 @@ impl SqlExprVisitor<'_> {
             else_result,
         } = expr
         {
-            if operand.is_some() {
-                polars_bail!(ComputeError: "CASE operand is not yet supported");
-            }
-
             polars_ensure!(
                 conditions.len() == results.len(),
                 ComputeError: "WHEN and THEN expressions must have the same length"
@@ -431,6 +427,34 @@ impl SqlExprVisitor<'_> {
                 Some(else_res) => self.visit_expr(else_res)?,
                 None => polars_bail!(ComputeError: "ELSE expression is required"),
             };
+
+            if let Some(operand_expr) = operand {
+                let first_operand_expr = self.visit_expr(operand_expr)?;
+
+                let first = first.unwrap();
+                let first_cond = first_operand_expr.eq(self.visit_expr(first.0)?);
+                let first_then = self.visit_expr(first.1)?;
+                let expr = when(first_cond).then(first_then);
+                let next = when_thens.next();
+    
+                let mut when_then = if let Some((cond, res)) = next {
+                    let second_operand_expr = self.visit_expr(operand_expr)?;
+                    let cond = second_operand_expr.eq(self.visit_expr(cond)?);
+                    let res = self.visit_expr(res)?;
+                    expr.when(cond).then(res)
+                } else {
+                    return Ok(expr.otherwise(else_res));
+                };
+    
+                for (cond, res) in when_thens {
+                    let new_operand_expr = self.visit_expr(operand_expr)?;
+                    let cond = new_operand_expr.eq(self.visit_expr(cond)?);
+                    let res = self.visit_expr(res)?;
+                    when_then = when_then.when(cond).then(res);
+                }
+    
+                return Ok(when_then.otherwise(else_res));
+            }
 
             let first = first.unwrap();
             let first_cond = self.visit_expr(first.0)?;

--- a/polars/polars-sql/tests/simple_exprs.rs
+++ b/polars/polars-sql/tests/simple_exprs.rs
@@ -545,7 +545,7 @@ fn test_case_expr_with_expression() {
     let case_expr = when((col("b") % lit(2)).eq(lit(0)))
         .then(lit("even"))
         .when((col("b") % lit(2)).eq(lit(1)))
-        .then(lit("odd_"))
+        .then(lit("odd"))
         .otherwise(lit("No?"))
         .alias("parity");
     let df_pl = df.lazy().select(&[case_expr]).collect().unwrap();

--- a/polars/polars-sql/tests/simple_exprs.rs
+++ b/polars/polars-sql/tests/simple_exprs.rs
@@ -529,6 +529,30 @@ fn test_case_expr() {
 }
 
 #[test]
+fn test_case_expr_with_expression() {
+    let df = create_sample_df().unwrap();
+    let mut context = SQLContext::new();
+    context.register("df", df.clone().lazy());
+    let sql = r#"
+        SELECT
+            CASE b%2
+                WHEN 0 THEN 'even'
+                WHEN 1 THEN 'odd'
+                ELSE 'No?'
+            END AS parity
+        FROM df"#;
+    let df_sql = context.execute(sql).unwrap().collect().unwrap();
+    let case_expr = when((col("b") % lit(2)).eq(lit(0)))
+        .then(lit("even"))
+        .when((col("b") % lit(2)).eq(lit(1)))
+        .then(lit("odd_"))
+        .otherwise(lit("No?"))
+        .alias("parity");
+    let df_pl = df.lazy().select(&[case_expr]).collect().unwrap();
+    assert!(df_sql.frame_equal(&df_pl));
+}
+
+#[test]
 fn test_sql_expr() {
     let df = create_sample_df().unwrap();
     let expr = sql_expr("MIN(a)").unwrap();


### PR DESCRIPTION
Adds a new form of the `CASE` SQL statement. We have this:
```
CASE 
      WHEN condition_1  THEN result_1
      WHEN condition_2  THEN result_2
      [WHEN ...]
      ELSE else_result
END
```
This PR adds this form:
```
CASE **expression**
   WHEN value_1 THEN result_1
   WHEN value_2 THEN result_2 
   [WHEN ...]
   ELSE else_result
END
```