### PR TITLE
chore(rust)!: remove deprecate tz_localize, name CastTimezone to ReplaceTimeZone

### DIFF
--- a/polars/polars-arrow/src/kernels/mod.rs
+++ b/polars/polars-arrow/src/kernels/mod.rs
@@ -23,7 +23,7 @@ pub mod take_agg;
 mod time;
 
 #[cfg(feature = "timezones")]
-pub use time::replace_timezone;
+pub use time::replace_time_zone;
 
 /// Internal state of [SlicesIterator]
 #[derive(Debug, PartialEq)]

--- a/polars/polars-arrow/src/kernels/time.rs
+++ b/polars/polars-arrow/src/kernels/time.rs
@@ -91,7 +91,7 @@ fn convert_to_timestamp(
 }
 
 #[cfg(feature = "timezones")]
-pub fn replace_timezone(
+pub fn replace_time_zone(
     arr: &PrimitiveArray<i64>,
     tu: TimeUnit,
     from: &str,

--- a/polars/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/polars/polars-core/src/chunked_array/temporal/datetime.rs
@@ -9,7 +9,7 @@ use chrono::TimeZone as TimeZoneTrait;
 #[cfg(feature = "timezones")]
 use chrono_tz::Tz;
 #[cfg(feature = "timezones")]
-use polars_arrow::kernels::replace_timezone;
+use polars_arrow::kernels::replace_time_zone;
 
 use super::conversion::{datetime_to_timestamp_ms, datetime_to_timestamp_ns};
 use super::*;
@@ -106,7 +106,7 @@ impl DatetimeChunked {
             let chunks = self
                 .downcast_iter()
                 .map(|arr| {
-                    replace_timezone(arr, self.time_unit().to_arrow(), from, to, use_earliest)
+                    replace_time_zone(arr, self.time_unit().to_arrow(), from, to, use_earliest)
                 })
                 .collect::<PolarsResult<_>>()?;
             let out = unsafe { ChunkedArray::from_chunks(self.name(), chunks) };

--- a/polars/polars-lazy/polars-plan/src/dsl/dt.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/dt.rs
@@ -93,17 +93,6 @@ impl DateLikeNameSpace {
         )
     }
 
-    /// Localize tz-naive Datetime Series to tz-aware Datetime Series.
-    //
-    // This method takes a naive Datetime Series and makes this time zone aware.
-    // It does not move the time to another time zone.
-    #[cfg(feature = "timezones")]
-    #[deprecated(note = "use replace_time_zone")]
-    pub fn tz_localize(self, tz: TimeZone) -> Expr {
-        self.0
-            .map_private(FunctionExpr::TemporalExpr(TemporalFunction::TzLocalize(tz)))
-    }
-
     /// Get the year of a Date/Datetime
     pub fn year(self) -> Expr {
         self.0
@@ -283,11 +272,9 @@ impl DateLikeNameSpace {
         time_zone: Option<TimeZone>,
         use_earliest: Option<bool>,
     ) -> Expr {
-        self.0
-            .map_private(FunctionExpr::TemporalExpr(TemporalFunction::CastTimezone(
-                time_zone,
-                use_earliest,
-            )))
+        self.0.map_private(FunctionExpr::TemporalExpr(
+            TemporalFunction::ReplaceTimeZone(time_zone, use_earliest),
+        ))
     }
 
     pub fn combine(self, time: Expr, tu: TimeUnit) -> Expr {

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/mod.rs
@@ -709,7 +709,6 @@ impl From<BinaryFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
 }
 
 #[cfg(feature = "temporal")]
-#[allow(deprecated)] // tz_localize
 impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
     fn from(func: TemporalFunction) -> Self {
         use TemporalFunction::*;
@@ -746,11 +745,9 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             DSTOffset => map!(datetime::dst_offset),
             Round(every, offset) => map!(datetime::round, &every, &offset),
             #[cfg(feature = "timezones")]
-            CastTimezone(tz, use_earliest) => {
-                map!(datetime::replace_timezone, tz.as_deref(), use_earliest)
+            ReplaceTimeZone(tz, use_earliest) => {
+                map!(datetime::replace_time_zone, tz.as_deref(), use_earliest)
             }
-            #[cfg(feature = "timezones")]
-            TzLocalize(tz) => map!(datetime::tz_localize, &tz),
             Combine(tu) => map_as_slice!(temporal::combine, tu),
             DateRange {
                 every,

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -58,11 +58,9 @@ impl FunctionExpr {
                     DSTOffset => DataType::Duration(TimeUnit::Milliseconds),
                     Round(..) => mapper.with_same_dtype().unwrap().dtype,
                     #[cfg(feature = "timezones")]
-                    CastTimezone(tz, _use_earliest) => {
+                    ReplaceTimeZone(tz, _use_earliest) => {
                         return mapper.map_datetime_dtype_timezone(tz.as_ref())
                     }
-                    #[cfg(feature = "timezones")]
-                    TzLocalize(tz) => return mapper.map_datetime_dtype_timezone(Some(tz)),
                     DateRange {
                         every,
                         closed: _,

--- a/py-polars/src/expr/datetime.rs
+++ b/py-polars/src/expr/datetime.rs
@@ -50,12 +50,6 @@ impl PyExpr {
             .into()
     }
 
-    #[cfg(feature = "timezones")]
-    #[allow(deprecated)]
-    fn dt_tz_localize(&self, time_zone: String) -> Self {
-        self.inner.clone().dt().tz_localize(time_zone).into()
-    }
-
     fn dt_truncate(&self, every: String, offset: String, use_earliest: Option<bool>) -> Self {
         self.inner
             .clone()

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1891,7 +1891,7 @@ def test_iso_year() -> None:
     assert pl.Series([date(2022, 1, 1)]).dt.iso_year()[0] == 2021
 
 
-def test_replace_timezone() -> None:
+def test_replace_time_zone() -> None:
     ny = ZoneInfo("America/New_York")
     assert pl.DataFrame({"a": [datetime(2022, 9, 25, 14)]}).with_columns(
         pl.col("a").dt.replace_time_zone("America/New_York").alias("b")
@@ -1910,7 +1910,7 @@ def test_replace_timezone() -> None:
 )
 @pytest.mark.parametrize("from_tz", ["Asia/Seoul", None])
 @pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
-def test_replace_timezone_from_to(
+def test_replace_time_zone_from_to(
     from_tz: str,
     to_tz: str,
     tzinfo: timezone | ZoneInfo,


### PR DESCRIPTION
A few chores:

- `tz_localize` was already removed from the Python side in https://github.com/pola-rs/polars/pull/7860 - OK to remove it from the Rust side too?
- rename `CastTimezone` to `ReplaceTimeZone` (leftover old name which never got renamed during the original deprecations)
- some functions are `replace_timezone`, others `replace_time_zone` - standardise to the latter