### PR TITLE
fix(rust, python): predicate pushdown #10058

### DIFF
--- a/polars/polars-core/src/frame/explode.rs
+++ b/polars/polars-core/src/frame/explode.rs
@@ -37,6 +37,7 @@ pub struct MeltArgs {
 
 impl DataFrame {
     pub fn explode_impl(&self, mut columns: Vec<Series>) -> PolarsResult<DataFrame> {
+        polars_ensure!(!columns.is_empty(), InvalidOperation: "no columns provided in explode");
         let mut df = self.clone();
         if self.height() == 0 {
             for s in &columns {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
@@ -11,12 +11,17 @@ fn should_block_join_specific(ae: &AExpr, how: &JoinType) -> bool {
                 | FunctionExpr::FillNull { .. },
             ..
         } => join_produces_null(how),
+        // joins can produce duplicates
         #[cfg(feature = "is_unique")]
         Function {
             function:
                 FunctionExpr::Boolean(BooleanFunction::IsUnique)
-                | FunctionExpr::Boolean(BooleanFunction::IsDuplicated)
-                | FunctionExpr::Boolean(BooleanFunction::IsFirst),
+                | FunctionExpr::Boolean(BooleanFunction::IsDuplicated),
+            ..
+        } => true,
+        #[cfg(feature = "is_first")]
+        Function {
+            function: FunctionExpr::Boolean(BooleanFunction::IsFirst),
             ..
         } => true,
         // any operation that checks for equality or ordering can be wrong because

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
@@ -22,7 +22,7 @@ fn should_block_join_specific(ae: &AExpr, how: &JoinType) -> bool {
         // any operation that checks for equality or ordering can be wrong because
         // the join can produce null values
         // TODO! check if we can be less conservative here
-        BinaryExpr { op, .. } => !matches!(op, Operator::NotEq),
+        BinaryExpr { op, .. } => !matches!(op, Operator::NotEq) && join_produces_null(how),
         _ => false,
     }
 }
@@ -58,8 +58,8 @@ pub(super) fn process_join(
     let schema_left = lp_arena.get(input_left).schema(lp_arena);
     let schema_right = lp_arena.get(input_right).schema(lp_arena);
 
-    let mut pushdown_left = optimizer::init_hashmap(Some(acc_predicates.len()));
-    let mut pushdown_right = optimizer::init_hashmap(Some(acc_predicates.len()));
+    let mut pushdown_left = init_hashmap(Some(acc_predicates.len()));
+    let mut pushdown_right = init_hashmap(Some(acc_predicates.len()));
     let mut local_predicates = Vec::with_capacity(acc_predicates.len());
 
     for (_, predicate) in acc_predicates {

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
@@ -1,0 +1,123 @@
+use super::*;
+
+fn should_block_join_specific(ae: &AExpr, how: &JoinType) -> bool {
+    use AExpr::*;
+    match ae {
+        // joins can produce null values
+        Function {
+            function:
+                FunctionExpr::Boolean(BooleanFunction::IsNotNull)
+                | FunctionExpr::Boolean(BooleanFunction::IsNull)
+                | FunctionExpr::FillNull { .. },
+            ..
+        } => join_produces_null(how),
+        #[cfg(feature = "is_unique")]
+        Function {
+            function:
+                FunctionExpr::Boolean(BooleanFunction::IsUnique)
+                | FunctionExpr::Boolean(BooleanFunction::IsDuplicated)
+                | FunctionExpr::Boolean(BooleanFunction::IsFirst),
+            ..
+        } => true,
+        // any operation that checks for equality or ordering can be wrong because
+        // the join can produce null values
+        // TODO! check if we can be less conservative here
+        BinaryExpr { op, .. } => !matches!(op, Operator::NotEq),
+        _ => false,
+    }
+}
+
+fn join_produces_null(how: &JoinType) -> bool {
+    #[cfg(feature = "asof_join")]
+    {
+        matches!(
+            how,
+            JoinType::Left | JoinType::Outer | JoinType::Cross | JoinType::AsOf(_)
+        )
+    }
+    #[cfg(not(feature = "asof_join"))]
+    {
+        matches!(how, JoinType::Left | JoinType::Outer | JoinType::Cross)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn process_join(
+    opt: &PredicatePushDown,
+    lp_arena: &mut Arena<ALogicalPlan>,
+    expr_arena: &mut Arena<AExpr>,
+    input_left: Node,
+    input_right: Node,
+    left_on: Vec<Node>,
+    right_on: Vec<Node>,
+    schema: SchemaRef,
+    options: Arc<JoinOptions>,
+    acc_predicates: PlHashMap<Arc<str>, Node>,
+) -> PolarsResult<ALogicalPlan> {
+    use ALogicalPlan::*;
+    let schema_left = lp_arena.get(input_left).schema(lp_arena);
+    let schema_right = lp_arena.get(input_right).schema(lp_arena);
+
+    let mut pushdown_left = optimizer::init_hashmap(Some(acc_predicates.len()));
+    let mut pushdown_right = optimizer::init_hashmap(Some(acc_predicates.len()));
+    let mut local_predicates = Vec::with_capacity(acc_predicates.len());
+
+    for (_, predicate) in acc_predicates {
+        // check if predicate can pass the joins node
+        if has_aexpr(predicate, expr_arena, |ae| {
+            should_block_join_specific(ae, &options.args.how)
+        }) {
+            local_predicates.push(predicate);
+            continue;
+        }
+        // these indicate to which tables we are going to push down the predicate
+        let mut filter_left = false;
+        let mut filter_right = false;
+
+        // predicate should not have an aggregation or window function as that would
+        // be influenced by join
+        #[allow(clippy::suspicious_else_formatting)]
+        if !predicate_is_pushdown_boundary(predicate, expr_arena) {
+            if check_input_node(predicate, &schema_left, expr_arena) {
+                insert_and_combine_predicate(&mut pushdown_left, predicate, expr_arena);
+                filter_left = true;
+            }
+            // this is `else if` because if the predicate is in the left hand side
+            // the right hand side should be renamed with the suffix.
+            // in that case we should not push down as the user wants to filter on `x`
+            // not on `x_rhs`.
+            else if check_input_node(predicate, &schema_right, expr_arena) {
+                insert_and_combine_predicate(&mut pushdown_right, predicate, expr_arena);
+                filter_right = true;
+            }
+        }
+        match (filter_left, filter_right, &options.args.how) {
+            // if not pushed down on one of the tables we have to do it locally.
+            (false, false, _) |
+            // if left join and predicate only available in right table,
+            // 'we should not filter right, because that would lead to
+            // invalid results.
+            // see: #2057
+            (false, true, JoinType::Left)
+            => {
+                local_predicates.push(predicate);
+                continue;
+            },
+            // business as usual
+            _ => {}
+        }
+    }
+
+    opt.pushdown_and_assign(input_left, pushdown_left, lp_arena, expr_arena)?;
+    opt.pushdown_and_assign(input_right, pushdown_right, lp_arena, expr_arena)?;
+
+    let lp = Join {
+        input_left,
+        input_right,
+        left_on,
+        right_on,
+        schema,
+        options,
+    };
+    Ok(opt.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
+}

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -169,3 +169,15 @@ def test_predicate_pushdown_cumsum_9566() -> None:
     q = df.lazy().sort(["B", "A"]).filter(pl.col("A").is_in([8, 2]).cumsum() == 1)
 
     assert q.collect()["A"].to_list() == [8, 9, 0, 1]
+
+
+def test_predicate_pushdown_join_fill_null_10058() -> None:
+    ids = pl.LazyFrame({"id": [0, 1, 2]})
+    filters = pl.LazyFrame({"id": [0, 1], "filter": [True, False]})
+
+    assert (
+        ids.join(filters, how="left", on="id")
+        .filter(pl.col("filter").fill_null(True))
+        .collect()
+        .to_dict(False)["id"]
+    ) == [0, 2]


### PR DESCRIPTION
Block predicate pushdown at a join node when the
predicate contains a `fill_null` as the join
can produce nulls.

fixes #10058