### PR TITLE
feat(rust, python)!: Cut label formatting

### DIFF
--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -62,7 +62,7 @@ const MAX_PRECISION: usize = 32;
 
 fn find_label_precision(sorted_breaks: &[f64], precision: usize, scientific: bool) -> usize {
     // Find a level of precision such that the numbers printed in labels are distinct.
-    if !sorted_breaks.is_empty() {
+    if sorted_breaks.is_empty() {
         return precision;
     }
     // The following finds a level of precision such that every break has a unique string
@@ -73,23 +73,28 @@ fn find_label_precision(sorted_breaks: &[f64], precision: usize, scientific: boo
         false => |b, p| format!("{0:.1$}", b, p),
         true => |b, p| format!("{0:.1$e}", b, p),
     };
-    let mut precision = precision;
-    'outer: while precision < MAX_PRECISION {
-        let mut last_str = format_fn(sorted_breaks[0], precision);
+    let mut precision_out = precision;
+    'outer: while precision_out < MAX_PRECISION {
+        let mut last_str = format_fn(sorted_breaks[0], precision_out);
         for b in sorted_breaks.iter().skip(1) {
-            let b_str: String = format_fn(*b, precision);
+            let b_str: String = format_fn(*b, precision_out);
             if b_str == last_str {
-                precision += 1;
+                precision_out += 1;
                 continue 'outer;
             }
             last_str = b_str;
         }
         break;
     }
-    precision
+    precision_out
 }
 
-fn make_labels(sorted_breaks: &[f64], left_closed: bool, precision: usize, scientific: bool) -> Vec<String> {
+fn make_labels(
+    sorted_breaks: &[f64],
+    left_closed: bool,
+    precision: usize,
+    scientific: bool,
+) -> Vec<String> {
     let precision = find_label_precision(sorted_breaks, precision, scientific);
     // This seems to be the most straightforward way to get rid of trailing zeros.
     let (re, replacement) = match scientific {
@@ -185,7 +190,23 @@ pub fn qcut(
             }
         };
         qbreaks.dedup();
-        return cut(&s, qbreaks, lfilt, left_closed, include_breaks, precision, scientific);
+        return cut(
+            &s,
+            qbreaks,
+            lfilt,
+            left_closed,
+            include_breaks,
+            precision,
+            scientific,
+        );
     }
-    cut(&s, qbreaks, labels, left_closed, include_breaks, precision, scientific)
+    cut(
+        &s,
+        qbreaks,
+        labels,
+        left_closed,
+        include_breaks,
+        precision,
+        scientific,
+    )
 }

--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -143,12 +143,13 @@ pub fn cut(
             polars_ensure!(ll.len() == sorted_breaks.len() + 1, ShapeMismatch: "Provide nbreaks + 1 labels");
             ll
         }
-        None => make_labels(&sorted_breaks, left_closed, precision, scientific),
+        None => make_labels(sorted_breaks, left_closed, precision, scientific),
     };
 
     map_cats(s, &cutlabs, sorted_breaks, left_closed, include_breaks)
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn qcut(
     s: &Series,
     probs: Vec<f64>,

--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -1,6 +1,7 @@
 use std::cmp::PartialOrd;
 use std::iter::once;
 
+use polars_core::export::regex::Regex;
 use polars_core::prelude::*;
 
 fn map_cats(
@@ -57,39 +58,87 @@ fn map_cats(
     }
 }
 
+const MAX_PRECISION: usize = 32;
+
+fn find_label_precision(sorted_breaks: &[f64], precision: usize, scientific: bool) -> usize {
+    // Find a level of precision such that the numbers printed in labels are distinct.
+    if !sorted_breaks.is_empty() {
+        return precision;
+    }
+    // The following finds a level of precision such that every break has a unique string
+    // representation. While a little half-assed, it's also what everyone else does. We could
+    // possibly speed this up with "clever" floating point operations, but that's more complex and
+    // error prone. And unless you have millions of categories it isn't remotely an issue.
+    let format_fn = match scientific {
+        false => |b, p| format!("{0:.1$}", b, p),
+        true => |b, p| format!("{0:.1$e}", b, p),
+    };
+    let mut precision = precision;
+    'outer: while precision < MAX_PRECISION {
+        let mut last_str = format_fn(sorted_breaks[0], precision);
+        for b in sorted_breaks.iter().skip(1) {
+            let b_str: String = format_fn(*b, precision);
+            if b_str == last_str {
+                precision += 1;
+                continue 'outer;
+            }
+            last_str = b_str;
+        }
+        break;
+    }
+    precision
+}
+
+fn make_labels(sorted_breaks: &[f64], left_closed: bool, precision: usize, scientific: bool) -> Vec<String> {
+    let precision = find_label_precision(sorted_breaks, precision, scientific);
+    // This seems to be the most straightforward way to get rid of trailing zeros.
+    let (re, replacement) = match scientific {
+        true => (Regex::new(r"(\.?0+)e").unwrap(), "e"),
+        false => (Regex::new(r"(\.?0+)$").unwrap(), ""),
+    };
+    // Rust doesn't like returning these closures as part of the tuple above.
+    let format_fn = match scientific {
+        true => |v, p| format!("{0:.1$e}", v, p),
+        false => |v, p| format!("{0:.1$}", v, p),
+    };
+
+    let mut out = Vec::with_capacity(sorted_breaks.len() + 2);
+    let mut last_break_str = format!("{}", f64::NEG_INFINITY);
+    for v in sorted_breaks.iter().chain(once(&f64::INFINITY)) {
+        let raw_break_str = format_fn(v, precision);
+        let break_str = re.replace(&raw_break_str, replacement).to_string();
+        if left_closed {
+            out.push(format!("[{}, {})", last_break_str, break_str));
+        } else {
+            out.push(format!("({}, {}]", last_break_str, break_str))
+        }
+        last_break_str = break_str;
+    }
+    out
+}
+
 pub fn cut(
     s: &Series,
     breaks: Vec<f64>,
     labels: Option<Vec<String>>,
     left_closed: bool,
     include_breaks: bool,
+    precision: usize,
+    scientific: bool,
 ) -> PolarsResult<Series> {
-    polars_ensure!(!breaks.iter().any(|x| x.is_nan()), ComputeError: "Breaks cannot be NaN");
+    polars_ensure!(breaks.iter().all(|x| x.is_finite()), ComputeError: "Don't include NaN, Inf, or -Inf in breaks");
     // Breaks must be sorted to cut inputs properly.
     let mut breaks = breaks;
     let sorted_breaks = breaks.as_mut_slice();
     sorted_breaks.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
     polars_ensure!(sorted_breaks.windows(2).all(|x| x[0] != x[1]), Duplicate: "Breaks are not unique");
-    if !sorted_breaks.is_empty() {
-        polars_ensure!(sorted_breaks[0] > f64::NEG_INFINITY, ComputeError: "Don't include -inf in breaks");
-        polars_ensure!(sorted_breaks[sorted_breaks.len() - 1] < f64::INFINITY, ComputeError: "Don't include inf in breaks");
-    }
 
     let cutlabs = match labels {
         Some(ll) => {
             polars_ensure!(ll.len() == sorted_breaks.len() + 1, ShapeMismatch: "Provide nbreaks + 1 labels");
             ll
         }
-        None => (once(&f64::NEG_INFINITY).chain(sorted_breaks.iter()))
-            .zip(sorted_breaks.iter().chain(once(&f64::INFINITY)))
-            .map(|v| {
-                if left_closed {
-                    format!("[{}, {})", v.0, v.1)
-                } else {
-                    format!("({}, {}]", v.0, v.1)
-                }
-            })
-            .collect::<Vec<String>>(),
+        None => make_labels(&sorted_breaks, left_closed, precision, scientific),
     };
 
     map_cats(s, &cutlabs, sorted_breaks, left_closed, include_breaks)
@@ -102,6 +151,8 @@ pub fn qcut(
     left_closed: bool,
     allow_duplicates: bool,
     include_breaks: bool,
+    precision: usize,
+    scientific: bool,
 ) -> PolarsResult<Series> {
     let s = s.cast(&DataType::Float64)?;
     let s2 = s.sort(false);
@@ -134,7 +185,7 @@ pub fn qcut(
             }
         };
         qbreaks.dedup();
-        return cut(&s, qbreaks, lfilt, left_closed, include_breaks);
+        return cut(&s, qbreaks, lfilt, left_closed, include_breaks, precision, scientific);
     }
-    cut(&s, qbreaks, labels, left_closed, include_breaks)
+    cut(&s, qbreaks, labels, left_closed, include_breaks, precision, scientific)
 }

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -211,7 +211,7 @@ pub enum FunctionExpr {
         labels: Option<Vec<String>>,
         left_closed: bool,
         include_breaks: bool,
-        precision: usize,
+        precision: Option<usize>,
         scientific: bool,
     },
     #[cfg(feature = "cutqcut")]
@@ -221,7 +221,7 @@ pub enum FunctionExpr {
         left_closed: bool,
         allow_duplicates: bool,
         include_breaks: bool,
-        precision: usize,
+        precision: Option<usize>,
         scientific: bool,
     },
     #[cfg(feature = "rle")]

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -211,6 +211,8 @@ pub enum FunctionExpr {
         labels: Option<Vec<String>>,
         left_closed: bool,
         include_breaks: bool,
+        precision: usize,
+        scientific: bool,
     },
     #[cfg(feature = "cutqcut")]
     QCut {
@@ -219,6 +221,8 @@ pub enum FunctionExpr {
         left_closed: bool,
         allow_duplicates: bool,
         include_breaks: bool,
+        precision: usize,
+        scientific: bool,
     },
     #[cfg(feature = "rle")]
     RLE,
@@ -582,12 +586,16 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                 labels,
                 left_closed,
                 include_breaks,
+                precision,
+                scientific,
             } => map!(
                 cut,
                 breaks.clone(),
                 labels.clone(),
                 left_closed,
                 include_breaks
+                precision,
+                scientific,
             ),
             #[cfg(feature = "cutqcut")]
             QCut {
@@ -596,13 +604,17 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                 left_closed,
                 allow_duplicates,
                 include_breaks,
+                precision,
+                scientific,
             } => map!(
                 qcut,
                 probs.clone(),
                 labels.clone(),
                 left_closed,
                 allow_duplicates,
-                include_breaks
+                include_breaks,
+                precision,
+                scientific,
             ),
             #[cfg(feature = "rle")]
             RLE => map!(rle),

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -593,9 +593,9 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                 breaks.clone(),
                 labels.clone(),
                 left_closed,
-                include_breaks
+                include_breaks,
                 precision,
-                scientific,
+                scientific
             ),
             #[cfg(feature = "cutqcut")]
             QCut {
@@ -614,7 +614,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                 allow_duplicates,
                 include_breaks,
                 precision,
-                scientific,
+                scientific
             ),
             #[cfg(feature = "rle")]
             RLE => map!(rle),

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1461,7 +1461,7 @@ impl Expr {
         labels: Option<Vec<String>>,
         left_closed: bool,
         include_breaks: bool,
-        precision: usize,
+        precision: Option<usize>,
         scientific: bool,
     ) -> Expr {
         self.apply_private(FunctionExpr::Cut {
@@ -1483,7 +1483,7 @@ impl Expr {
         left_closed: bool,
         allow_duplicates: bool,
         include_breaks: bool,
-        precision: usize,
+        precision: Option<usize>,
         scientific: bool,
     ) -> Expr {
         self.apply_private(FunctionExpr::QCut {
@@ -1506,7 +1506,7 @@ impl Expr {
         left_closed: bool,
         allow_duplicates: bool,
         include_breaks: bool,
-        precision: usize,
+        precision: Option<usize>,
         scientific: bool,
     ) -> Expr {
         let probs = (1..n_bins).map(|b| b as f64 / n_bins as f64).collect();

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1461,12 +1461,16 @@ impl Expr {
         labels: Option<Vec<String>>,
         left_closed: bool,
         include_breaks: bool,
+        precision: usize,
+        scientific: bool,
     ) -> Expr {
         self.apply_private(FunctionExpr::Cut {
             breaks,
             labels,
             left_closed,
             include_breaks,
+            precision,
+            scientific,
         })
     }
 
@@ -1478,6 +1482,8 @@ impl Expr {
         left_closed: bool,
         allow_duplicates: bool,
         include_breaks: bool,
+        precision: usize,
+        scientific: bool,
     ) -> Expr {
         self.apply_private(FunctionExpr::QCut {
             probs,
@@ -1485,6 +1491,8 @@ impl Expr {
             left_closed,
             allow_duplicates,
             include_breaks,
+            precision,
+            scientific,
         })
     }
 
@@ -1496,6 +1504,8 @@ impl Expr {
         left_closed: bool,
         allow_duplicates: bool,
         include_breaks: bool,
+        precision: usize,
+        scientific: bool,
     ) -> Expr {
         let probs = (1..n_bins).map(|b| b as f64 / n_bins as f64).collect();
         self.apply_private(FunctionExpr::QCut {
@@ -1504,6 +1514,8 @@ impl Expr {
             left_closed,
             allow_duplicates,
             include_breaks,
+            precision,
+            scientific,
         })
     }
 

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1497,6 +1497,7 @@ impl Expr {
     }
 
     #[cfg(feature = "cutqcut")]
+    #[allow(clippy::too_many_arguments)]
     pub fn qcut_uniform(
         self,
         n_bins: usize,

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1475,6 +1475,7 @@ impl Expr {
     }
 
     #[cfg(feature = "cutqcut")]
+    #[allow(clippy::too_many_arguments)]
     pub fn qcut(
         self,
         probs: Vec<f64>,

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3304,6 +3304,8 @@ class Expr:
         labels: list[str] | None = None,
         left_closed: bool = False,
         include_breaks: bool = False,
+        precision: int = 3,
+        scientific: bool = False,
     ) -> Self:
         """
         Bin continuous values into discrete categories.
@@ -3360,7 +3362,7 @@ class Expr:
         └─────┴─────┴───────────┘
         """
         return self._from_pyexpr(
-            self._pyexpr.cut(breaks, labels, left_closed, include_breaks)
+            self._pyexpr.cut(breaks, labels, left_closed, include_breaks, precision, scientific)
         )
 
     @deprecate_renamed_parameter("probs", "quantiles", version="0.18.8")
@@ -3372,6 +3374,8 @@ class Expr:
         left_closed: bool = False,
         allow_duplicates: bool = False,
         include_breaks: bool = False,
+        precision: int = 3,
+        scientific: bool = False,
     ) -> Self:
         """
         Bin continuous values into discrete categories based on their quantiles.
@@ -3490,7 +3494,7 @@ class Expr:
             else self._pyexpr.qcut
         )
         return self._from_pyexpr(
-            expr_f(quantiles, labels, left_closed, allow_duplicates, include_breaks)
+            expr_f(q, labels, left_closed, allow_duplicates, include_breaks, precision, scientific)
         )
 
     def rle(self) -> Self:

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3371,7 +3371,9 @@ class Expr:
         └─────┴─────┴───────────┘
         """
         return self._from_pyexpr(
-            self._pyexpr.cut(breaks, labels, left_closed, include_breaks, precision, scientific)
+            self._pyexpr.cut(
+                breaks, labels, left_closed, include_breaks, precision, scientific
+            )
         )
 
     @deprecate_renamed_parameter("probs", "quantiles", version="0.18.8")
@@ -3512,7 +3514,15 @@ class Expr:
             else self._pyexpr.qcut
         )
         return self._from_pyexpr(
-            expr_f(q, labels, left_closed, allow_duplicates, include_breaks, precision, scientific)
+            expr_f(
+                q,
+                labels,
+                left_closed,
+                allow_duplicates,
+                include_breaks,
+                precision,
+                scientific,
+            )
         )
 
     def rle(self) -> Self:

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3304,7 +3304,7 @@ class Expr:
         labels: list[str] | None = None,
         left_closed: bool = False,
         include_breaks: bool = False,
-        precision: int = 3,
+        precision: int | None = None,
         scientific: bool = False,
     ) -> Self:
         """
@@ -3385,7 +3385,7 @@ class Expr:
         left_closed: bool = False,
         allow_duplicates: bool = False,
         include_breaks: bool = False,
-        precision: int = 3,
+        precision: int | None = None,
         scientific: bool = False,
     ) -> Self:
         """

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3321,6 +3321,15 @@ class Expr:
         include_breaks
             Include the the right endpoint of the bin each observation falls in.
             If True, the resulting column will be a Struct.
+        precision
+            Determines the number of digits past the decimal point to display when
+            formatting break numbers if labels are not provided. If this is too small
+            for unique breaks to have unique string representations, it will increase
+            until they can. Trailing zeros, however, will be dropped.
+        scientific
+            If True and labels are not provided, format break numbers using scientific
+            notation. Note that precision will now refer to significant figures and not
+            what is after the decimal point in the original number.
 
         Examples
         --------
@@ -3397,6 +3406,15 @@ class Expr:
         include_breaks
             Include the the right endpoint of the bin each observation falls in.
             If True, the resulting column will be a Struct.
+        precision
+            Determines the number of digits past the decimal point to display when
+            formatting break numbers if labels are not provided. If this is too small
+            for unique breaks to have unique string representations, it will increase
+            until they can. Trailing zeros, however, will be dropped.
+        scientific
+            If True and labels are not provided, format break numbers using scientific
+            notation. Note that precision will now refer to significant figures and not
+            what is after the decimal point in the original number.
 
         Examples
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1751,14 +1751,20 @@ class Series:
             return (
                 self.to_frame()
                 .with_columns(
-                    F.col(n).cut(breaks, labels, left_closed, True, precision, scientific).alias(n + "_bin")
+                    F.col(n)
+                    .cut(breaks, labels, left_closed, True, precision, scientific)
+                    .alias(n + "_bin")
                 )
                 .unnest(n + "_bin")
                 .rename({"brk": break_point_label, n + "_bin": category_label})
             )
         res = (
             self.to_frame()
-            .select(F.col(n).cut(breaks, labels, left_closed, include_breaks, precision, scientific))
+            .select(
+                F.col(n).cut(
+                    breaks, labels, left_closed, include_breaks, precision, scientific
+                )
+            )
             .to_series()
         )
         if include_breaks:
@@ -1893,7 +1899,15 @@ class Series:
                 self.to_frame()
                 .with_columns(
                     F.col(n)
-                    .qcut(q, labels, left_closed, allow_duplicates, True, precision, scientific)
+                    .qcut(
+                        q,
+                        labels,
+                        left_closed,
+                        allow_duplicates,
+                        True,
+                        precision,
+                        scientific,
+                    )
                     .alias(n + "_bin")
                 )
                 .unnest(n + "_bin")
@@ -1902,7 +1916,15 @@ class Series:
         res = (
             self.to_frame()
             .select(
-                F.col(n).qcut(q, labels, left_closed, allow_duplicates, include_breaks, precision, scientific)
+                F.col(n).qcut(
+                    q,
+                    labels,
+                    left_closed,
+                    allow_duplicates,
+                    include_breaks,
+                    precision,
+                    scientific,
+                )
             )
             .to_series()
         )

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1649,7 +1649,7 @@ class Series:
         series: bool = True,
         left_closed: bool = False,
         include_breaks: bool = False,
-        precision: int = 3,
+        precision: int | None = None,
         scientific: bool = False,
     ) -> DataFrame | Series:
         """
@@ -1783,7 +1783,7 @@ class Series:
         left_closed: bool = False,
         allow_duplicates: bool = False,
         include_breaks: bool = False,
-        precision: int = 3,
+        precision: int | None = None,
         scientific: bool = False,
     ) -> DataFrame | Series:
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1675,6 +1675,15 @@ class Series:
             Include the the right endpoint of the bin each observation falls in.
             If returning a DataFrame, it will be a column, and if returning a Series
             it will be a field in a Struct
+        precision
+            Determines the number of digits past the decimal point to display when
+            formatting break numbers if labels are not provided. If this is too small
+            for unique breaks to have unique string representations, it will increase
+            until they can. Trailing zeros, however, will be dropped.
+        scientific
+            If True and labels are not provided, format break numbers using scientific
+            notation. Note that precision will now refer to significant figures and not
+            what is after the decimal point in the original number.
 
         Returns
         -------
@@ -1799,6 +1808,15 @@ class Series:
             Include the the right endpoint of the bin each observation falls in.
             If returning a DataFrame, it will be a column, and if returning a Series
             it will be a field in a Struct
+        precision
+            Determines the number of digits past the decimal point to display when
+            formatting break numbers if labels are not provided. If this is too small
+            for unique breaks to have unique string representations, it will increase
+            until they can. Trailing zeros, however, will be dropped.
+        scientific
+            If True and labels are not provided, format break numbers using scientific
+            notation. Note that precision will now refer to significant figures and not
+            what is after the decimal point in the original number.
 
         Returns
         -------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1649,6 +1649,8 @@ class Series:
         series: bool = True,
         left_closed: bool = False,
         include_breaks: bool = False,
+        precision: int = 3,
+        scientific: bool = False,
     ) -> DataFrame | Series:
         """
         Bin continuous values into discrete categories.
@@ -1740,14 +1742,14 @@ class Series:
             return (
                 self.to_frame()
                 .with_columns(
-                    F.col(n).cut(breaks, labels, left_closed, True).alias(n + "_bin")
+                    F.col(n).cut(breaks, labels, left_closed, True, precision, scientific).alias(n + "_bin")
                 )
                 .unnest(n + "_bin")
                 .rename({"brk": break_point_label, n + "_bin": category_label})
             )
         res = (
             self.to_frame()
-            .select(F.col(n).cut(breaks, labels, left_closed, include_breaks))
+            .select(F.col(n).cut(breaks, labels, left_closed, include_breaks, precision, scientific))
             .to_series()
         )
         if include_breaks:
@@ -1766,6 +1768,8 @@ class Series:
         left_closed: bool = False,
         allow_duplicates: bool = False,
         include_breaks: bool = False,
+        precision: int = 3,
+        scientific: bool = False,
     ) -> DataFrame | Series:
         """
         Discretize continuous values into discrete categories based on their quantiles.
@@ -1871,7 +1875,7 @@ class Series:
                 self.to_frame()
                 .with_columns(
                     F.col(n)
-                    .qcut(quantiles, labels, left_closed, allow_duplicates, True)
+                    .qcut(q, labels, left_closed, allow_duplicates, True, precision, scientific)
                     .alias(n + "_bin")
                 )
                 .unnest(n + "_bin")
@@ -1880,9 +1884,7 @@ class Series:
         res = (
             self.to_frame()
             .select(
-                F.col(n).qcut(
-                    quantiles, labels, left_closed, allow_duplicates, include_breaks
-                )
+                F.col(n).qcut(q, labels, left_closed, allow_duplicates, include_breaks, precision, scientific)
             )
             .to_series()
         )

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -178,7 +178,7 @@ impl PyExpr {
             .into()
     }
 
-    #[pyo3(signature = (breaks, labels, left_closed, include_breaks))]
+    #[pyo3(signature = (breaks, labels, left_closed, include_breaks, precision, scientific))]
     #[cfg(feature = "cutqcut")]
     fn cut(
         &self,
@@ -186,13 +186,16 @@ impl PyExpr {
         labels: Option<Vec<String>>,
         left_closed: bool,
         include_breaks: bool,
+        precision: usize,
+        scientific: bool,
     ) -> Self {
         self.inner
             .clone()
-            .cut(breaks, labels, left_closed, include_breaks)
+            .cut(breaks, labels, left_closed, include_breaks, precision, scientific)
             .into()
     }
-    #[pyo3(signature = (probs, labels, left_closed, allow_duplicates, include_breaks))]
+    #[pyo3(signature = (probs, labels, left_closed, allow_duplicates, include_breaks, precision, scientific))]
+    #[allow(clippy::too_many_arguments)]
     #[cfg(feature = "cutqcut")]
     fn qcut(
         &self,
@@ -201,13 +204,15 @@ impl PyExpr {
         left_closed: bool,
         allow_duplicates: bool,
         include_breaks: bool,
+        precision: usize,
+        scientific: bool,
     ) -> Self {
         self.inner
             .clone()
-            .qcut(probs, labels, left_closed, allow_duplicates, include_breaks)
+            .qcut(probs, labels, left_closed, allow_duplicates, include_breaks, precision, scientific)
             .into()
     }
-    #[pyo3(signature = (n_bins, labels, left_closed, allow_duplicates, include_breaks))]
+    #[pyo3(signature = (n_bins, labels, left_closed, allow_duplicates, include_breaks, precision, scientific))]
     #[cfg(feature = "cutqcut")]
     fn qcut_uniform(
         &self,
@@ -216,6 +221,8 @@ impl PyExpr {
         left_closed: bool,
         allow_duplicates: bool,
         include_breaks: bool,
+        precision: usize,
+        scientific: bool,
     ) -> Self {
         self.inner
             .clone()
@@ -225,6 +232,8 @@ impl PyExpr {
                 left_closed,
                 allow_duplicates,
                 include_breaks,
+                precision,
+                scientific,
             )
             .into()
     }

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -191,7 +191,14 @@ impl PyExpr {
     ) -> Self {
         self.inner
             .clone()
-            .cut(breaks, labels, left_closed, include_breaks, precision, scientific)
+            .cut(
+                breaks,
+                labels,
+                left_closed,
+                include_breaks,
+                precision,
+                scientific,
+            )
             .into()
     }
     #[pyo3(signature = (probs, labels, left_closed, allow_duplicates, include_breaks, precision, scientific))]
@@ -209,11 +216,20 @@ impl PyExpr {
     ) -> Self {
         self.inner
             .clone()
-            .qcut(probs, labels, left_closed, allow_duplicates, include_breaks, precision, scientific)
+            .qcut(
+                probs,
+                labels,
+                left_closed,
+                allow_duplicates,
+                include_breaks,
+                precision,
+                scientific,
+            )
             .into()
     }
     #[pyo3(signature = (n_bins, labels, left_closed, allow_duplicates, include_breaks, precision, scientific))]
     #[cfg(feature = "cutqcut")]
+    #[allow(clippy::too_many_arguments)]
     fn qcut_uniform(
         &self,
         n_bins: usize,

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -186,7 +186,7 @@ impl PyExpr {
         labels: Option<Vec<String>>,
         left_closed: bool,
         include_breaks: bool,
-        precision: usize,
+        precision: Option<usize>,
         scientific: bool,
     ) -> Self {
         self.inner
@@ -211,7 +211,7 @@ impl PyExpr {
         left_closed: bool,
         allow_duplicates: bool,
         include_breaks: bool,
-        precision: usize,
+        precision: Option<usize>,
         scientific: bool,
     ) -> Self {
         self.inner
@@ -237,7 +237,7 @@ impl PyExpr {
         left_closed: bool,
         allow_duplicates: bool,
         include_breaks: bool,
-        precision: usize,
+        precision: Option<usize>,
         scientific: bool,
     ) -> Self {
         self.inner

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -148,16 +148,32 @@ def test_cut_null_values() -> None:
         }
     )
     assert_frame_equal(
-        cast(pl.DataFrame, s.qcut([0.2, 0.3], series=False)),
+        cast(pl.DataFrame, s.qcut([0.2, 0.3], series=False, precision=16)),
         exp,
         check_dtype=False,
     )
     assert_series_equal(
-        cast(pl.Series, s.qcut([0.2, 0.3], series=True)),
+        cast(pl.Series, s.qcut([0.2, 0.3], series=True, precision=16)),
         exp.get_column("category"),
         check_dtype=False,
         check_names=False,
     )
+
+def test_cut_precision_scientific() -> None:
+    s = pl.Series([-1, 0, 1, 4, 5])
+    cut_p_1 = s.qcut([.3333, .754321], precision = 1)
+    cut_p_4 = s.qcut([.3333, .754321], precision = 4)
+    res_p_1 = pl.Series(["(-inf, 0.3]", "(-inf, 0.3]", "[0.3, 4)", "[0.3, 4)", "[4, inf)"])
+    res_p_4 = pl.Series([
+        "[-inf, 0.3332)"
+        "[-inf, 0.3332)"
+        "[0.3332, 4.0173)"
+        "[0.3332, 4.0173)"
+        "[4.0173, inf)"
+    ])
+
+    assert_series_equal(cut_p_1, res_p_1, check_dtype=False, check_names=False)
+    assert_series_equal(cut_p_4, res_p_4, check_dtype=False, check_names=False)
 
 
 def test_median_quantile_duration() -> None:


### PR DESCRIPTION
Labels in cut and qcut can now be formatted with variable precision. They can also optionally use scientific notation. Technically this is breaking since I had to pick a default for precision and set it at 3, but I don't think anyone actually wanted the old behavior anyway.

If there's a way to make the string processing on the Rust side better I'd love to hear it. Because string formatting in Rust is torture and I tried but couldn't find anything easier than what I ended up with.