### PR TITLE
feat(python): BytecodeParser can now handle mixed/nested `and/or` control flow

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -162,6 +162,7 @@ strict = true
 "polars/datatypes.py" = ["B019"]
 "tests/**/*.py" = ["D100", "D103", "B018"]
 "polars/utils/show_versions.py" = ["D301"]
+"polars/utils/udfs.py" = ["RUF012"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -23,7 +23,9 @@ MY_CONSTANT = 3
 
 # column_name, function, expected_suggestion
 TEST_CASES = [
+    # ---------------------------------------------
     # numeric expr: math, comparison, logic ops
+    # ---------------------------------------------
     ("a", lambda x: x + 1 - (2 / 3), '(pl.col("a") + 1) - 0.6666666666666666'),
     ("a", lambda x: x // 1 % 2, '(pl.col("a") // 1) % 2'),
     ("a", lambda x: x & True, 'pl.col("a") & True'),
@@ -68,7 +70,9 @@ TEST_CASES = [
         lambda x: (float(x) * int(x)) // 2,
         '(pl.col("a").cast(pl.Float64) * pl.col("a").cast(pl.Int64)) // 2',
     ),
+    # ---------------------------------------------
     # logical 'and/or' (validate nesting levels)
+    # ---------------------------------------------
     (
         "a",
         lambda x: x > 1 or (x == 1 and x == 2),
@@ -94,14 +98,18 @@ TEST_CASES = [
         lambda x: x > 1 and (x != 2 or x % 2 == 0) and x < 3,
         '(pl.col("a") > 1) & ((pl.col("a") != 2) | ((pl.col("a") % 2) == 0)) & (pl.col("a") < 3)',
     ),
+    # ---------------------------------------------
     # string expr: case/cast ops
+    # ---------------------------------------------
     ("b", lambda x: str(x).title(), 'pl.col("b").cast(pl.Utf8).str.to_titlecase()'),
     (
         "b",
         lambda x: x.lower() + ":" + x.upper() + ":" + x.title(),
         '(((pl.col("b").str.to_lowercase() + \':\') + pl.col("b").str.to_uppercase()) + \':\') + pl.col("b").str.to_titlecase()',
     ),
+    # ---------------------------------------------
     # json expr: load/extract
+    # ---------------------------------------------
     ("c", lambda x: json.loads(x), 'pl.col("c").str.json_extract()'),
 ]
 

--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -68,6 +68,32 @@ TEST_CASES = [
         lambda x: (float(x) * int(x)) // 2,
         '(pl.col("a").cast(pl.Float64) * pl.col("a").cast(pl.Int64)) // 2',
     ),
+    # logical 'and/or' (validate nesting levels)
+    (
+        "a",
+        lambda x: x > 1 or (x == 1 and x == 2),
+        '(pl.col("a") > 1) | (pl.col("a") == 1) & (pl.col("a") == 2)',
+    ),
+    (
+        "a",
+        lambda x: (x > 1 or x == 1) and x == 2,
+        '((pl.col("a") > 1) | (pl.col("a") == 1)) & (pl.col("a") == 2)',
+    ),
+    (
+        "a",
+        lambda x: x > 2 or x != 3 and x not in (0, 1, 4),
+        '(pl.col("a") > 2) | (pl.col("a") != 3) & ~pl.col("a").is_in((0, 1, 4))',
+    ),
+    (
+        "a",
+        lambda x: x > 1 and x != 2 or x % 2 == 0 and x < 3,
+        '(pl.col("a") > 1) & (pl.col("a") != 2) | ((pl.col("a") % 2) == 0) & (pl.col("a") < 3)',
+    ),
+    (
+        "a",
+        lambda x: x > 1 and (x != 2 or x % 2 == 0) and x < 3,
+        '(pl.col("a") > 1) & ((pl.col("a") != 2) | ((pl.col("a") % 2) == 0)) & (pl.col("a") < 3)',
+    ),
     # string expr: case/cast ops
     ("b", lambda x: str(x).title(), 'pl.col("b").cast(pl.Utf8).str.to_titlecase()'),
     (

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -19,7 +19,6 @@ from tests.test_udfs import MY_CONSTANT, TEST_CASES
         lambda x: x,
         lambda x, y: x + y,
         lambda x: x[0] + 1,
-        lambda x: x > 0 and (x < 100 or (x % 2 == 0)),
     ],
 )
 def test_parse_invalid_function(func: Callable[[Any], Any]) -> None:


### PR DESCRIPTION
Ref: #9968.

This was a fun one... enables two additional ops (`POP_JUMP_FORWARD_IF_FALSE` and `POP_JUMP_FORWARD_IF_TRUE` if Python >= 3.11, and `POP_JUMP_IF_FALSE` and `POP_JUMP_IF_TRUE` for earlier versions) in order to support _mixed_ `and/or` chains (previously only supported _all_ `and` or _all_ `or`) with, crucially, nesting resolution being determined from jump offsets.

## Example
```python
from polars.utils.udfs import BytecodeParser

fn = lambda x: x > 1 and x != 2 or x % 2 == 0 and x < 3
BytecodeParser( fn,"expr" ).to_expression( col="x" )
# (pl.col("x") > 1) & (pl.col("x") != 2) | ((pl.col("x") % 2) == 0) & (pl.col("x") < 3)
```
Notice that we maintain the parenthesised inner `or` block:
```python
fn = lambda x: x > 1 and (x != 2 or x % 2 == 0) and x < 3
BytecodeParser( fn,"expr" ).to_expression( col="x" )
# (pl.col("x") > 1) & ((pl.col("x") != 2) | ((pl.col("x") % 2) == 0)) & (pl.col("x") < 3)
```

**Also**: 
* Tidied-up the loose opname-related sets/dicts/etc; all now bundled within a single `OpNames` class.