### PR TITLE
fix(rust): fix error message from cast-timezone to replace-time-zone

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/schema.rs
@@ -452,7 +452,7 @@ impl<'a> FieldsMapper<'a> {
             if let DataType::Datetime(tu, _) = dt {
                 Ok(DataType::Datetime(*tu, tz.cloned()))
             } else {
-                polars_bail!(op = "cast-timezone", got = dt, expected = "Datetime");
+                polars_bail!(op = "replace-time-zone", got = dt, expected = "Datetime");
             }
         })
     }


### PR DESCRIPTION
another one that got forgotten during the deprecation 😳 