### PR TITLE
feat(rust, python): inline `lit(Series).cast(..)` to -> `lit(Series.cast(..))`

### DIFF
--- a/polars/polars-core/src/datatypes/any_value.rs
+++ b/polars/polars-core/src/datatypes/any_value.rs
@@ -4,6 +4,7 @@ use arrow::temporal_conversions::{
 use arrow::types::PrimitiveType;
 #[cfg(feature = "dtype-struct")]
 use polars_arrow::trusted_len::TrustedLenPush;
+use polars_utils::format_smartstring;
 #[cfg(feature = "dtype-struct")]
 use polars_utils::slice::GetSaferUnchecked;
 #[cfg(feature = "dtype-categorical")]
@@ -456,6 +457,7 @@ impl<'a> AnyValue<'a> {
                     DataType::Duration(tu) => AnyValue::Duration($av as i64, *tu),
                     #[cfg(feature="dtype-time")]
                     DataType::Time => AnyValue::Time($av as i64),
+                    DataType::Utf8 => AnyValue::Utf8Owned(format_smartstring!("{}", $av)),
                     _ => polars_bail!(
                         ComputeError: "cannot cast any-value {:?} to dtype '{}'", self, dtype,
                     ),

--- a/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/polars/polars-lazy/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -700,7 +700,7 @@ fn inline_cast(input: &AExpr, dtype: &DataType, strict: bool) -> PolarsResult<Op
                         let out = { av.cast(dtype)? };
                         #[cfg(not(debug_assertions))]
                         let out = {
-                            match av.cast(&DataType) {
+                            match av.cast(&dtype) {
                                 Ok(out) => out,
                                 Err(_) => return Ok(None),
                             }


### PR DESCRIPTION
This cleans up literal casts created by the type-coercion pass.