### PR TITLE
fix(python): undo regression in scan_parquet from s3

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1699,6 +1699,7 @@ dependencies = [
  "hashbrown 0.14.0",
  "num-traits",
  "once_cell",
+ "polars-error",
  "rayon",
  "smartstring",
  "sysinfo",

--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -88,8 +88,8 @@ def _prepare_file_arg(
         finally:
             pass
 
-    has_non_utf8_non_utf8_lossy_encoding = (
-        encoding not in {"utf8", "utf8-lossy"} if encoding else False
+    has_utf8_utf8_lossy_encoding = (
+        encoding in {"utf8", "utf8-lossy"} if encoding else True
     )
     encoding_str = encoding if encoding else "utf8"
 
@@ -98,7 +98,7 @@ def _prepare_file_arg(
     check_not_dir = not use_pyarrow
 
     if isinstance(file, bytes):
-        if has_non_utf8_non_utf8_lossy_encoding:
+        if not has_utf8_utf8_lossy_encoding:
             return _check_empty(
                 BytesIO(file.decode(encoding_str).encode("utf8")),
                 context="bytes",
@@ -114,7 +114,7 @@ def _prepare_file_arg(
         )
 
     if isinstance(file, BytesIO):
-        if has_non_utf8_non_utf8_lossy_encoding:
+        if not has_utf8_utf8_lossy_encoding:
             return _check_empty(
                 BytesIO(file.read().decode(encoding_str).encode("utf8")),
                 context="BytesIO",
@@ -129,7 +129,7 @@ def _prepare_file_arg(
         )
 
     if isinstance(file, Path):
-        if has_non_utf8_non_utf8_lossy_encoding:
+        if not has_utf8_utf8_lossy_encoding:
             return _check_empty(
                 BytesIO(file.read_bytes().decode(encoding_str).encode("utf8")),
                 context=f"Path ({file!r})",
@@ -145,25 +145,33 @@ def _prepare_file_arg(
         if _FSSPEC_AVAILABLE:
             from fsspec.utils import infer_storage_options
 
-            if not has_non_utf8_non_utf8_lossy_encoding:
-                if "*" in file:
-                    raise ValueError(
-                        "globbing patterns not supported when scanning non-local files"
-                    )
-                if infer_storage_options(file)["protocol"] == "file":
+            # check if it is a local file
+            if infer_storage_options(file)["protocol"] == "file":
+                # (lossy) utf8
+                if has_utf8_utf8_lossy_encoding:
                     return managed_file(normalise_filepath(file, check_not_dir))
+                # decode first
+                with Path(file).open(encoding=encoding_str) as f:
+                    return _check_empty(
+                        BytesIO(f.read().encode("utf8")), context=f"{file!r}"
+                    )
+            # non-local file
+            if "*" in file:
+                raise ValueError(
+                    "globbing patterns not supported when scanning non-local files"
+                )
             kwargs["encoding"] = encoding
             return fsspec.open(file, **kwargs)
-        else:
-            # todo! add azure/ gcp/ ?
-            if file.startswith("s3://"):
-                raise ImportError("fsspec needs to be installed to read files from s3")
+
+        # todo! add azure/ gcp/ ?
+        if file.startswith("s3://"):
+            raise ImportError("fsspec needs to be installed to read files from s3")
 
     if isinstance(file, list) and bool(file) and all(isinstance(f, str) for f in file):
         if _FSSPEC_AVAILABLE:
             from fsspec.utils import infer_storage_options
 
-            if not has_non_utf8_non_utf8_lossy_encoding:
+            if has_utf8_utf8_lossy_encoding:
                 if all(infer_storage_options(f)["protocol"] == "file" for f in file):
                     return managed_file(
                         [normalise_filepath(f, check_not_dir) for f in file]
@@ -173,7 +181,7 @@ def _prepare_file_arg(
 
     if isinstance(file, str):
         file = normalise_filepath(file, check_not_dir)
-        if has_non_utf8_non_utf8_lossy_encoding:
+        if not has_utf8_utf8_lossy_encoding:
             with Path(file).open(encoding=encoding_str) as f:
                 return _check_empty(
                     BytesIO(f.read().encode("utf8")), context=f"{file!r}"

--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -146,10 +146,18 @@ def _prepare_file_arg(
             from fsspec.utils import infer_storage_options
 
             if not has_non_utf8_non_utf8_lossy_encoding:
+                if "*" in file:
+                    raise ValueError(
+                        "globbing patterns not supported when scanning non-local files"
+                    )
                 if infer_storage_options(file)["protocol"] == "file":
                     return managed_file(normalise_filepath(file, check_not_dir))
             kwargs["encoding"] = encoding
             return fsspec.open(file, **kwargs)
+        else:
+            # todo! add azure/ gcp/ ?
+            if file.startswith("s3://"):
+                raise ImportError("fsspec needs to be installed to read files from s3")
 
     if isinstance(file, list) and bool(file) and all(isinstance(f, str) for f in file):
         if _FSSPEC_AVAILABLE:

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -186,8 +186,10 @@ def normalise_filepath(path: str | Path, check_not_directory: bool = True) -> st
     # don't use pathlib here as it modifies slashes (s3:// -> s3:/)
     path = os.path.expanduser(path)  # noqa: PTH111
     if (
-        check_not_directory and os.path.exists(path) and os.path.isdir(path)
-    ):  # noqa: PTH110 PTH112
+        check_not_directory
+        and os.path.exists(path)
+        and os.path.isdir(path)  # noqa: PTH110 PTH112
+    ):
         raise IsADirectoryError(f"Expected a file path; {path!r} is a directory")
     return path
 

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -187,8 +187,8 @@ def normalise_filepath(path: str | Path, check_not_directory: bool = True) -> st
     path = os.path.expanduser(path)  # noqa: PTH111
     if (
         check_not_directory
-        and os.path.exists(path)
-        and os.path.isdir(path)  # noqa: PTH110 PTH112
+        and os.path.exists(path)  # noqa: PTH110
+        and os.path.isdir(path)  # noqa: PTH112
     ):
         raise IsADirectoryError(f"Expected a file path; {path!r} is a directory")
     return path

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -183,10 +183,13 @@ def can_create_dicts_with_pyarrow(dtypes: Sequence[PolarsDataType]) -> bool:
 
 def normalise_filepath(path: str | Path, check_not_directory: bool = True) -> str:
     """Create a string path, expanding the home directory if present."""
-    path = Path(path).expanduser()
-    if check_not_directory and path.exists() and path.is_dir():
+    # don't use pathlib here as it modifies slashes (s3:// -> s3:/)
+    path = os.path.expanduser(path)  # noqa: PTH111
+    if (
+        check_not_directory and os.path.exists(path) and os.path.isdir(path)
+    ):  # noqa: PTH110 PTH112
         raise IsADirectoryError(f"Expected a file path; {path!r} is a directory")
-    return str(path)
+    return path
 
 
 def parse_version(version: Sequence[str | int]) -> tuple[int, ...]:

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -18,6 +18,7 @@ XlsxWriter
 adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'
 connectorx==0.3.2a7  # Latest full release is broken - unpin when 0.3.2 released
 cloudpickle
+fsspec
 
 # Tooling
 hypothesis==6.82.0

--- a/py-polars/tests/unit/io/test_cloud.py
+++ b/py-polars/tests/unit/io/test_cloud.py
@@ -1,0 +1,13 @@
+import pytest
+
+import polars as pl
+
+
+def test_err_on_s3_glob() -> None:
+    with pytest.raises(
+        ValueError,
+        match=r"globbing patterns not supported when scanning non-local files",
+    ):
+        pl.scan_parquet(
+            "s3://saturn-public-data/nyc-taxi/data/yellow_tripdata_2019-1.*.parquet"
+        )


### PR DESCRIPTION
Also error if a glob pattern is passed as fsspec doesn't handle those.

fixes #10008