### PR TITLE
fix(python): dont show wrong inefficient apply warning when taking numpy func of constant

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -542,7 +542,10 @@ class RewrittenInstructions:
         if matching_instructions := self._matches(
             idx,
             opnames=["LOAD_GLOBAL", "LOAD_*", "LOAD_*", OpNames.CALL],
-            argvals=[_NUMPY_MODULE_ALIASES | {"json"}, _NUMPY_FUNCTIONS | {"loads"}],
+            argvals=[
+                _NUMPY_MODULE_ALIASES | {"json"},
+                _NUMPY_FUNCTIONS | {"loads"},
+            ],
             param_name_index=2,
         ):
             inst1, inst2, inst3 = matching_instructions[:3]

--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -113,6 +113,13 @@ TEST_CASES = [
     ("c", lambda x: json.loads(x), 'pl.col("c").str.json_extract()'),
 ]
 
+NOOP_TEST_CASES = [
+    lambda x: x,
+    lambda x, y: x + y,
+    lambda x: x[0] + 1,
+    lambda x: np.sin(1) + x,
+]
+
 
 @pytest.mark.parametrize(
     ("col", "func", "expected"),
@@ -125,3 +132,12 @@ def test_bytecode_parser_expression(
     bytecode_parser = udfs.BytecodeParser(func, apply_target="expr")
     result = bytecode_parser.to_expression(col)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "func",
+    NOOP_TEST_CASES,
+)
+def test_bytecode_parser_expression_noop(func: Callable[[Any], Any]) -> None:
+    udfs = pytest.importorskip("udfs")
+    assert not udfs.BytecodeParser(func, apply_target="expr").can_rewrite()

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -19,6 +19,7 @@ from tests.test_udfs import MY_CONSTANT, TEST_CASES
         lambda x: x,
         lambda x, y: x + y,
         lambda x: x[0] + 1,
+        lambda x: numpy.sin(1) + x,
     ],
 )
 def test_parse_invalid_function(func: Callable[[Any], Any]) -> None:

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -10,17 +10,12 @@ import polars as pl
 from polars.exceptions import PolarsInefficientApplyWarning
 from polars.testing import assert_frame_equal
 from polars.utils.udfs import _NUMPY_FUNCTIONS, BytecodeParser
-from tests.test_udfs import MY_CONSTANT, TEST_CASES
+from tests.test_udfs import MY_CONSTANT, NOOP_TEST_CASES, TEST_CASES
 
 
 @pytest.mark.parametrize(
     "func",
-    [
-        lambda x: x,
-        lambda x, y: x + y,
-        lambda x: x[0] + 1,
-        lambda x: numpy.sin(1) + x,
-    ],
+    NOOP_TEST_CASES,
 )
 def test_parse_invalid_function(func: Callable[[Any], Any]) -> None:
     # functions we don't offer suggestions for (at all, or just not yet)


### PR DESCRIPTION
I'd missed this when reviewing, but a "nonsense" warning is currently shown in some cases:
```python
df = pl.DataFrame({"a": [1, 2, 3]})
df.select(pl.col("a").apply(lambda x: np.sin(3) + x))
```
shows
```diff
-  pl.col("a").apply(lambda x: ...)
+  3.sin() + pl.col("a")
```

I think we need to be extra-defensive here, and match as explicitly as we can - I've added `param_name_index` to the function so we can check that parameter name is exactly in the position we expect it to be

---

with this PR, the code above wouldn't display any warning, as `np.sin(3)` isn't a simple-enough constant to be considered (yet!)