### PR TITLE
feat(python): enable "inefficient apply" warnings from `Series`

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4576,16 +4576,14 @@ class Series:
         Series
 
         """
-        # TODO:
-        # from polars.utils.udfs import warn_on_inefficient_apply
-        # warn_on_inefficient_apply(
-        #     function, columns=[self.name], apply_target="series"
-        # )
+        from polars.utils.udfs import warn_on_inefficient_apply
 
         if return_dtype is None:
             pl_return_dtype = None
         else:
             pl_return_dtype = py_type_to_dtype(return_dtype)
+
+        warn_on_inefficient_apply(function, columns=[self.name], apply_target="series")
         return self._from_pyseries(
             self._s.apply_lambda(function, pl_return_dtype, skip_nulls)
         )

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -202,6 +202,7 @@ class BytecodeParser:
                 while True:
                     name = f"srs{next(n)}"
                     if not re.search(rf"\b{name}\b", search_expr):
+                        self._apply_target_name = name
                         return name
 
         raise NotImplementedError(f"TODO: apply_target = {self._apply_target!r}")

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,4 +1,4 @@
-black[d]==23.7.0
+black==23.7.0
 blackdoc==0.3.8
 mypy==1.4.1
 ruff==0.0.278

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,4 +1,4 @@
-black==23.7.0
+black[d]==23.7.0
 blackdoc==0.3.8
 mypy==1.4.1
 ruff==0.0.278

--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -118,6 +118,13 @@ TEST_CASES = [
     ("c", lambda x: json.loads(x), 'pl.col("c").str.json_extract()'),
 ]
 
+NOOP_TEST_CASES = [
+    lambda x: x,
+    lambda x, y: x + y,
+    lambda x: x[0] + 1,
+    lambda x: np.sin(1) + x,
+]
+
 
 @pytest.mark.parametrize(
     ("col", "func", "expected"),
@@ -130,3 +137,12 @@ def test_bytecode_parser_expression(
     bytecode_parser = udfs.BytecodeParser(func, apply_target="expr")
     result = bytecode_parser.to_expression(col)
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    "func",
+    NOOP_TEST_CASES,
+)
+def test_bytecode_parser_expression_noop(func: Callable[[Any], Any]) -> None:
+    udfs = pytest.importorskip("udfs")
+    assert not udfs.BytecodeParser(func, apply_target="expr").can_rewrite()

--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -122,7 +122,6 @@ NOOP_TEST_CASES = [
     lambda x: x,
     lambda x, y: x + y,
     lambda x: x[0] + 1,
-    lambda x: np.sin(1) + x,
 ]
 
 

--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -66,6 +66,11 @@ TEST_CASES = [
     ("a", lambda x: 0 + numpy.cbrt(x), '0 + pl.col("a").cbrt()'),
     ("a", lambda x: np.sin(x) + 1, 'pl.col("a").sin() + 1'),
     (
+        "a",  # note: functions operate on consts
+        lambda x: np.sin(3.14159265358979) + (x - 1) + abs(-3),
+        '(np.sin(3.14159265358979) + (pl.col("a") - 1)) + abs(-3)',
+    ),
+    (
         "a",
         lambda x: (float(x) * int(x)) // 2,
         '(pl.col("a").cast(pl.Float64) * pl.col("a").cast(pl.Int64)) // 2',

--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -30,7 +30,7 @@ TEST_CASES = [
     ("a", lambda x: x // 1 % 2, '(pl.col("a") // 1) % 2'),
     ("a", lambda x: x & True, 'pl.col("a") & True'),
     ("a", lambda x: x | False, 'pl.col("a") | False'),
-    ("a", lambda x: x != 3, 'pl.col("a") != 3'),
+    ("a", lambda x: abs(x) != 3, 'pl.col("a").abs() != 3'),
     ("a", lambda x: int(x) > 1, 'pl.col("a").cast(pl.Int64) > 1'),
     ("a", lambda x: not (x > 1) or x == 2, '~(pl.col("a") > 1) | (pl.col("a") == 2)'),
     ("a", lambda x: x is None, 'pl.col("a") is None'),

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -10,16 +10,12 @@ import polars as pl
 from polars.exceptions import PolarsInefficientApplyWarning
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.utils.udfs import _NUMPY_FUNCTIONS, BytecodeParser
-from tests.test_udfs import MY_CONSTANT, TEST_CASES
+from tests.test_udfs import MY_CONSTANT, NOOP_TEST_CASES, TEST_CASES
 
 
 @pytest.mark.parametrize(
     "func",
-    [
-        lambda x: x,
-        lambda x, y: x + y,
-        lambda x: x[0] + 1,
-    ],
+    NOOP_TEST_CASES,
 )
 def test_parse_invalid_function(func: Callable[[Any], Any]) -> None:
     # functions we don't offer suggestions for (at all, or just not yet)

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -125,6 +125,17 @@ def test_parse_apply_miscellaneous() -> None:
     ).to_expression(col="colx")
     assert suggested_expression is None
 
+    # literals as method parameters
+    with pytest.warns(
+        PolarsInefficientApplyWarning,
+        match=r"\(np\.cos\(3\) \+ s\) - abs\(-1\)",
+    ):
+        s = pl.Series("srs", [0, 1, 2, 3, 4])
+        assert_series_equal(
+            s.apply(lambda x: numpy.cos(3) + x - abs(-1)),
+            numpy.cos(3) + s - 1,
+        )
+
 
 @pytest.mark.parametrize(
     ("data", "func", "expr_repr"),

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -12,13 +12,15 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from polars.utils.udfs import _NUMPY_FUNCTIONS, BytecodeParser
 from tests.test_udfs import MY_CONSTANT, NOOP_TEST_CASES, TEST_CASES
 
+EVAL_ENVIRONMENT = {"np": numpy, "pl": pl, "MY_CONSTANT": MY_CONSTANT}
+
 
 @pytest.mark.parametrize(
     "func",
     NOOP_TEST_CASES,
 )
 def test_parse_invalid_function(func: Callable[[Any], Any]) -> None:
-    # functions we don't offer suggestions for (at all, or just not yet)
+    # functions we don't (yet?) offer suggestions for
     assert not BytecodeParser(func, apply_target="expr").can_rewrite()
 
 
@@ -45,7 +47,7 @@ def test_parse_apply_functions(
         )
         result_frame = df.select(
             x=col,
-            y=eval(suggested_expression),
+            y=eval(suggested_expression, EVAL_ENVIRONMENT),
         )
         expected_frame = df.select(
             x=pl.col(col),

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -990,13 +990,11 @@ def test_apply() -> None:
         b = a.apply(lambda x: x + "py")
         assert list(b) == ["foopy", "barpy", None]
 
-    with pytest.warns(PolarsInefficientApplyWarning):
-        b = a.apply(lambda x: len(x), return_dtype=pl.Int32)
-        assert list(b) == [3, 3, None]
+    b = a.apply(lambda x: len(x), return_dtype=pl.Int32)
+    assert list(b) == [3, 3, None]
 
-    with pytest.warns(PolarsInefficientApplyWarning):
-        b = a.apply(lambda x: len(x))
-        assert list(b) == [3, 3, None]
+    b = a.apply(lambda x: len(x))
+    assert list(b) == [3, 3, None]
 
     # just check that it runs (somehow problem with conditional compilation)
     a = pl.Series("a", [2, 2, 3]).cast(pl.Datetime)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -23,7 +23,7 @@ from polars.datatypes import (
     UInt64,
     Unknown,
 )
-from polars.exceptions import ShapeError
+from polars.exceptions import PolarsInefficientApplyWarning, ShapeError
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.utils._construction import iterable_to_pyseries
 
@@ -980,19 +980,23 @@ def test_fill_nan() -> None:
 
 
 def test_apply() -> None:
-    a = pl.Series("a", [1, 2, None])
-    b = a.apply(lambda x: x**2)
-    assert list(b) == [1, 4, None]
+    with pytest.warns(PolarsInefficientApplyWarning):
+        a = pl.Series("a", [1, 2, None])
+        b = a.apply(lambda x: x**2)
+        assert list(b) == [1, 4, None]
 
-    a = pl.Series("a", ["foo", "bar", None])
-    b = a.apply(lambda x: x + "py")
-    assert list(b) == ["foopy", "barpy", None]
+    with pytest.warns(PolarsInefficientApplyWarning):
+        a = pl.Series("a", ["foo", "bar", None])
+        b = a.apply(lambda x: x + "py")
+        assert list(b) == ["foopy", "barpy", None]
 
-    b = a.apply(lambda x: len(x), return_dtype=pl.Int32)
-    assert list(b) == [3, 3, None]
+    with pytest.warns(PolarsInefficientApplyWarning):
+        b = a.apply(lambda x: len(x), return_dtype=pl.Int32)
+        assert list(b) == [3, 3, None]
 
-    b = a.apply(lambda x: len(x))
-    assert list(b) == [3, 3, None]
+    with pytest.warns(PolarsInefficientApplyWarning):
+        b = a.apply(lambda x: len(x))
+        assert list(b) == [3, 3, None]
 
     # just check that it runs (somehow problem with conditional compilation)
     a = pl.Series("a", [2, 2, 3]).cast(pl.Datetime)


### PR DESCRIPTION
Ref: #9968.

* Extends warnings about inefficient `Expr.apply` to `Series.apply`.
* Adds parsing recognition for additional builtin: `abs`.

## Example

```python
import polars as pl

srs = pl.Series( 
    name = "s", 
    values = [-20, -12, -5, 0, 5, 12, 20] 
).apply( 
    lambda x: (abs(x) != 12) and (x > 10 or x < -10 or x == 0) 
)

# PolarsInefficientApplyWarning: 
# Series.apply is significantly slower than the native series API.
# Only use if you absolutely CANNOT implement your logic otherwise.
# In this case, you can replace your `apply` with the following:
#   -  s.apply(lambda x: ...)
#   +  (s.abs() != 12) & ((s > 10) | ((s < -10) | (s == 0)))
```