### PR TITLE
fix(rust, python): respect `null_on_oob=False` in `list.take` when pa…

### DIFF
--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/list.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/list.rs
@@ -226,15 +226,7 @@ pub(super) fn take(args: &[Series], null_on_oob: bool) -> PolarsResult<Series> {
     let idx = &args[1];
     let ca = ca.list()?;
 
-    if idx.len() == 1 {
-        // fast path
-        let idx = idx.get(0)?.try_extract::<i64>()?;
-        let out = ca.lst_get(idx)?;
-        // make sure we return a list
-        out.reshape(&[-1, 1])
-    } else {
-        ca.lst_take(idx, null_on_oob)
-    }
+    ca.lst_take(idx, null_on_oob)
 }
 
 #[cfg(feature = "list_count")]

--- a/polars/polars-lazy/polars-plan/src/dsl/function_expr/list.rs
+++ b/polars/polars-lazy/polars-plan/src/dsl/function_expr/list.rs
@@ -226,7 +226,15 @@ pub(super) fn take(args: &[Series], null_on_oob: bool) -> PolarsResult<Series> {
     let idx = &args[1];
     let ca = ca.list()?;
 
-    ca.lst_take(idx, null_on_oob)
+    if idx.len() == 1 && null_on_oob {
+        // fast path
+        let idx = idx.get(0)?.try_extract::<i64>()?;
+        let out = ca.lst_get(idx)?;
+        // make sure we return a list
+        out.reshape(&[-1, 1])
+    } else {
+        ca.lst_take(idx, null_on_oob)
+    }
 }
 
 #[cfg(feature = "list_count")]

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -508,3 +508,14 @@ def test_list_set_operations() -> None:
     exp = [[2, 3], [3, 1], [3]]
     assert r1 == exp
     assert r2 == exp
+
+
+def test_list_take_oob_10079() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [[1, 2, 3], [], [None, 3], [5, 6, 7]],
+            "b": [["2"], ["3"], [None], ["3", "Hi"]],
+        }
+    )
+    with pytest.raises(pl.ComputeError, match="take indices are out of bounds"):
+        df.select(pl.col("a").take(999))


### PR DESCRIPTION
…ssed a single index

Attempts to fix #10079

There was a fast path check for `len == 1` which dispatched to `lst_get()` but this does not take `null_on_oob` into consideration.

I have just removed the fast path check/branch and defaulted to always dispatching to `lst_take()`