### PR TITLE
[python] Add adbc_db_kwargs to pl.read_database

### DIFF
--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -160,8 +160,12 @@ def _read_sql_connectorx(
     return from_arrow(tbl)  # type: ignore[return-value]
 
 
-def _read_sql_adbc(query: str, connection_uri: str, db_kwargs: dict[str, str] | None) -> DataFrame:
-    with _open_adbc_connection(connection_uri, db_kwargs=db_kwargs) as conn, conn.cursor() as cursor:
+def _read_sql_adbc(
+    query: str, connection_uri: str, db_kwargs: dict[str, str] | None
+) -> DataFrame:
+    with _open_adbc_connection(
+        connection_uri, db_kwargs=db_kwargs
+    ) as conn, conn.cursor() as cursor:
         cursor.execute(query)
         tbl = cursor.fetch_arrow_table()
     return from_arrow(tbl)  # type: ignore[return-value]


### PR DESCRIPTION
In order to pass certain options to the database on is reading from, we need to pass db_kwargs to adbc. For instance, in order to cache MFA tokens (so that one doesn't need to validate every single query), we pass `"adbc.snowflake.sql.auth_type": "auth_mfa"`. [Here are all the options](https://arrow.apache.org/adbc/main/driver/snowflake.html#client-options).

See [this issue for context](https://github.com/apache/arrow-adbc/issues/918#issuecomment-1653170247).

I've tested it with our Snowflake connection, and passing e.g.:
```python
df = pl.read_database(query = query, connection_uri=uri, engine="adbc", adbc_db_kwargs={"adbc.snowflake.sql.auth_type": "auth_mfa"})
```
I no longer need to MFA verify every single call.


I'm really liking the adbc support, it lets me avoid the heavy `snowflake-connector-python` as long as I don't need to upload to snowflake from Python.