### PR TITLE
fix(python): silence Series.apply inefficient apply warning when calling Expr.apply

### DIFF
--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -191,8 +191,10 @@ def test_expr_exact_warning_message() -> None:
         '  - pl.col("a").apply(lambda x: ...)\n'
         '  + pl.col("a") + 1\n'
     )
-    # Check the EXACT warning message.
-    # Make sure to keep the `^` and `$`.
-    with pytest.warns(PolarsInefficientApplyWarning, match=f"^{msg}$"):
+    # Check the EXACT warning message. If modifying the message in the future,
+    # please make sure to keep the `^` and `$`,
+    # and to keep the assertion on `len(warnings)`.
+    with pytest.warns(PolarsInefficientApplyWarning, match=rf"^{msg}$") as warnings:
         df = pl.DataFrame({"a": [1, 2, 3]})
         df.select(pl.col("a").apply(lambda x: x + 1))
+    assert len(warnings) == 1

--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from typing import Any, Callable
 
 import numpy
@@ -179,3 +180,19 @@ def test_parse_apply_series(
         expected_series = s.apply(func)
         result_series = eval(suggested_expression)
         assert_series_equal(expected_series, result_series)
+
+
+def test_expr_exact_warning_message() -> None:
+    msg = re.escape(
+        "\n"
+        "Expr.apply is significantly slower than the native expressions API.\n"
+        "Only use if you absolutely CANNOT implement your logic otherwise.\n"
+        "In this case, you can replace your `apply` with the following:\n"
+        '  - pl.col("a").apply(lambda x: ...)\n'
+        '  + pl.col("a") + 1\n'
+    )
+    # Check the EXACT warning message.
+    # Make sure to keep the `^` and `$`.
+    with pytest.warns(PolarsInefficientApplyWarning, match=f"^{msg}$"):
+        df = pl.DataFrame({"a": [1, 2, 3]})
+        df.select(pl.col("a").apply(lambda x: x + 1))


### PR DESCRIPTION
The warning's currently being shown twice, once from `Expr.apply` and once from `Series.apply` :

```python
In [1]: my_dict = {1: "1", 2: "2", 3: "3"}
   ...: df = pl.DataFrame({"a": [1, 2, 3]})
   ...: df.select(pl.col("a").apply(lambda x: x**2))
   ...: 
<ipython-input-1-2741e0b26152>:3: PolarsInefficientApplyWarning: 
Expr.apply is significantly slower than the native expressions API.
Only use if you absolutely CANNOT implement your logic otherwise.
In this case, you can replace your `apply` with the following:
  -  pl.col("a").apply(lambda x: ...)
  +  pl.col("a") ** 2

  df.select(pl.col("a").apply(lambda x: x**2))
sys:1: PolarsInefficientApplyWarning: 
Series.apply is significantly slower than the native series API.
Only use if you absolutely CANNOT implement your logic otherwise.
In this case, you can replace your `apply` with the following:
  -  s.apply(lambda x: ...)
  +  s ** 2

Out[1]: 
shape: (3, 1)
┌─────┐
│ a   │
│ --- │
│ i64 │
╞═════╡
│ 1   │
│ 4   │
│ 9   │
└─────┘
```

Adding a test to check the exact warning message so this doesn't happen again