### PR TITLE
depr(python): Deprecate parsing string inputs as literals for `when-then-otherwise`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -8598,6 +8598,7 @@ class Expr:
             Dictionary containing the before/after values to map.
         default
             Value to use when the remapping dict does not contain the lookup value.
+            Accepts expression input. Non-expression inputs are parsed as literals.
             Use ``pl.first()``, to keep the original value.
         return_dtype
             Set return dtype to override automatic return dtype determination.
@@ -8923,6 +8924,9 @@ class Expr:
                     is_keys=False,
                 )
 
+            default_parsed = self._from_pyexpr(
+                parse_as_expression(default, str_as_lit=True)
+            )
             return (
                 (
                     df.lazy()
@@ -8942,7 +8946,7 @@ class Expr:
                     .select(
                         F.when(F.col(is_remapped_column).is_not_null())
                         .then(F.col(remap_value_column))
-                        .otherwise(default)
+                        .otherwise(default_parsed)
                         .alias(column)
                     )
                 )

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 import polars._reexport as pl
 from polars.utils._parse_expr_input import parse_as_expression
+from polars.utils.decorators import deprecated_alias
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -13,9 +14,10 @@ if TYPE_CHECKING:
     from polars.type_aliases import IntoExpr
 
 
-def when(expr: IntoExpr) -> pl.When:
+@deprecated_alias(expr="condition")
+def when(condition: IntoExpr) -> pl.When:
     """
-    Start a "when, then, otherwise" expression.
+    Start a `when-then-otherwise` expression.
 
     Expression similar to an `if-else` statement in Python. Always initiated by a
     `pl.when(<condition>).then(<value if condition>)`. Optionally followed by chaining
@@ -23,6 +25,12 @@ def when(expr: IntoExpr) -> pl.When:
     are `True`, an optional `.otherwise(<value if all statements are false>)` can be
     appended at the end. If not appended, and none of the conditions are `True`, `None`
     will be returned.
+
+    Parameters
+    ----------
+    condition
+        The condition for applying the subsequent statement.
+        Accepts a boolean expression. String input is parsed as a column name.
 
     Examples
     --------
@@ -89,7 +97,6 @@ def when(expr: IntoExpr) -> pl.When:
     │ 4   ┆ 0   ┆ 1    │
     └─────┴─────┴──────┘
 
-
     """
-    pyexpr = parse_as_expression(expr)
-    return pl.When(plr.when(pyexpr))
+    condition_pyexpr = parse_as_expression(condition)
+    return pl.When(plr.when(condition_pyexpr))

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4562,7 +4562,7 @@ class Series:
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3])
-        >>> s.apply(lambda x: x + 10)
+        >>> s.apply(lambda x: x + 10)  # doctest: +SKIP
         shape: (3,)
         Series: 'a' [i64]
         [

--- a/py-polars/src/functions/whenthen.rs
+++ b/py-polars/src/functions/whenthen.rs
@@ -4,9 +4,9 @@ use pyo3::prelude::*;
 use crate::PyExpr;
 
 #[pyfunction]
-pub fn when(predicate: PyExpr) -> PyWhen {
+pub fn when(condition: PyExpr) -> PyWhen {
     PyWhen {
-        inner: dsl::when(predicate.inner),
+        inner: dsl::when(condition.inner),
     }
 }
 
@@ -36,44 +36,44 @@ pub struct PyChainedThen {
 
 #[pymethods]
 impl PyWhen {
-    fn then(&self, expr: PyExpr) -> PyThen {
+    fn then(&self, statement: PyExpr) -> PyThen {
         PyThen {
-            inner: self.inner.clone().then(expr.inner),
+            inner: self.inner.clone().then(statement.inner),
         }
     }
 }
 
 #[pymethods]
 impl PyThen {
-    fn when(&self, predicate: PyExpr) -> PyChainedWhen {
+    fn when(&self, condition: PyExpr) -> PyChainedWhen {
         PyChainedWhen {
-            inner: self.inner.clone().when(predicate.inner),
+            inner: self.inner.clone().when(condition.inner),
         }
     }
 
-    fn otherwise(&self, expr: PyExpr) -> PyExpr {
-        self.inner.clone().otherwise(expr.inner).into()
+    fn otherwise(&self, statement: PyExpr) -> PyExpr {
+        self.inner.clone().otherwise(statement.inner).into()
     }
 }
 
 #[pymethods]
 impl PyChainedWhen {
-    fn then(&self, expr: PyExpr) -> PyChainedThen {
+    fn then(&self, statement: PyExpr) -> PyChainedThen {
         PyChainedThen {
-            inner: self.inner.clone().then(expr.inner),
+            inner: self.inner.clone().then(statement.inner),
         }
     }
 }
 
 #[pymethods]
 impl PyChainedThen {
-    fn when(&self, predicate: PyExpr) -> PyChainedWhen {
+    fn when(&self, condition: PyExpr) -> PyChainedWhen {
         PyChainedWhen {
-            inner: self.inner.clone().when(predicate.inner),
+            inner: self.inner.clone().when(condition.inner),
         }
     }
 
-    fn otherwise(&self, expr: PyExpr) -> PyExpr {
-        self.inner.clone().otherwise(expr.inner).into()
+    fn otherwise(&self, statement: PyExpr) -> PyExpr {
+        self.inner.clone().otherwise(statement.inner).into()
     }
 }

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -77,20 +77,6 @@ def test_cat_to_dummies() -> None:
     }
 
 
-def test_comp_categorical_lit_dtype() -> None:
-    df = pl.DataFrame(
-        data={"column": ["a", "b", "e"], "values": [1, 5, 9]},
-        schema=[("column", pl.Categorical), ("more", pl.Int32)],
-    )
-
-    assert df.with_columns(
-        pl.when(pl.col("column") == "e")
-        .then("d")
-        .otherwise(pl.col("column"))
-        .alias("column")
-    ).dtypes == [pl.Categorical, pl.Int32]
-
-
 def test_categorical_describe_3487() -> None:
     # test if we don't err
     df = pl.DataFrame({"cats": ["a", "b"]})

--- a/py-polars/tests/unit/functions/test_whenthen.py
+++ b/py-polars/tests/unit/functions/test_whenthen.py
@@ -28,7 +28,12 @@ def test_when_then() -> None:
 def test_when_then_chained() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
 
-    expr = pl.when(pl.col("a") < 3).then(pl.lit("x")).when(pl.col("a") > 4).then("z")
+    expr = (
+        pl.when(pl.col("a") < 3)
+        .then(pl.lit("x"))
+        .when(pl.col("a") > 4)
+        .then(pl.lit("z"))
+    )
 
     result = df.select(
         expr.otherwise(pl.lit("y")).alias("a"),
@@ -48,19 +53,17 @@ def test_when_then_invalid_chains() -> None:
     with pytest.raises(AttributeError):
         pl.when("a").when("b")  # type: ignore[attr-defined]
     with pytest.raises(AttributeError):
-        pl.when("a").otherwise("b")  # type: ignore[attr-defined]
+        pl.when("a").otherwise(2)  # type: ignore[attr-defined]
     with pytest.raises(AttributeError):
-        pl.when("a").then("b").then("c")  # type: ignore[attr-defined]
+        pl.when("a").then(1).then(2)  # type: ignore[attr-defined]
     with pytest.raises(AttributeError):
-        pl.when("a").then("b").otherwise("c").otherwise("d")  # type: ignore[attr-defined]
+        pl.when("a").then(1).otherwise(2).otherwise(3)  # type: ignore[attr-defined]
     with pytest.raises(AttributeError):
-        pl.when("a").then("b").otherwise("c").otherwise("d")  # type: ignore[attr-defined]
+        pl.when("a").then(1).when("b").when("c")  # type: ignore[attr-defined]
     with pytest.raises(AttributeError):
-        pl.when("a").then("b").when("c").when("d")  # type: ignore[attr-defined]
+        pl.when("a").then(1).when("b").otherwise("2")  # type: ignore[attr-defined]
     with pytest.raises(AttributeError):
-        pl.when("a").then("b").when("c").otherwise("d")  # type: ignore[attr-defined]
-    with pytest.raises(AttributeError):
-        pl.when("a").then("b").when("c").then("d").when("e").when("f")  # type: ignore[attr-defined]
+        pl.when("a").then(1).when("b").then(2).when("c").when("d")  # type: ignore[attr-defined]
 
 
 def test_when_then_implicit_none() -> None:
@@ -72,8 +75,8 @@ def test_when_then_implicit_none() -> None:
     )
 
     result = df.select(
-        pl.when(pl.col("points") > 7).then("Foo"),
-        pl.when(pl.col("points") > 7).then("Foo").alias("bar"),
+        pl.when(pl.col("points") > 7).then(pl.lit("Foo")),
+        pl.when(pl.col("points") > 7).then(pl.lit("Foo")).alias("bar"),
     )
 
     expected = pl.DataFrame(
@@ -101,18 +104,20 @@ def test_nested_when_then_and_wildcard_expansion_6284() -> None:
 
     out0 = df.with_columns(
         pl.when(pl.any_horizontal(pl.all() == "a"))
-        .then("a")
+        .then(pl.lit("a"))
         .otherwise(
-            pl.when(pl.any_horizontal(pl.all() == "d")).then("d").otherwise(None)
+            pl.when(pl.any_horizontal(pl.all() == "d"))
+            .then(pl.lit("d"))
+            .otherwise(None)
         )
         .alias("result")
     )
 
     out1 = df.with_columns(
         pl.when(pl.any_horizontal(pl.all() == "a"))
-        .then("a")
+        .then(pl.lit("a"))
         .when(pl.any_horizontal(pl.all() == "d"))
-        .then("d")
+        .then(pl.lit("d"))
         .otherwise(None)
         .alias("result")
     )
@@ -221,3 +226,17 @@ def test_object_when_then_4702() -> None:
         "Type": [pl.Date, pl.UInt8],
         "New_Type": [pl.UInt16, pl.UInt8],
     }
+
+
+def test_comp_categorical_lit_dtype() -> None:
+    df = pl.DataFrame(
+        data={"column": ["a", "b", "e"], "values": [1, 5, 9]},
+        schema=[("column", pl.Categorical), ("more", pl.Int32)],
+    )
+
+    assert df.with_columns(
+        pl.when(pl.col("column") == "e")
+        .then(pl.lit("d"))
+        .otherwise(pl.col("column"))
+        .alias("column")
+    ).dtypes == [pl.Categorical, pl.Int32]

--- a/py-polars/tests/unit/functions/test_whenthen.py
+++ b/py-polars/tests/unit/functions/test_whenthen.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_when_then() -> None:
@@ -240,3 +240,19 @@ def test_comp_categorical_lit_dtype() -> None:
         .otherwise(pl.col("column"))
         .alias("column")
     ).dtypes == [pl.Categorical, pl.Int32]
+
+
+def test_when_then_deprecated_string_input() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [True, False],
+            "b": [1, 2],
+            "c": [3, 4],
+        }
+    )
+
+    with pytest.deprecated_call():
+        result = df.select(pl.when("a").then("b").otherwise("c").alias("when"))
+
+    expected = pl.Series("when", ["b", "c"])
+    assert_series_equal(result.to_series(), expected)

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -513,7 +513,7 @@ def get_str_ints_df(n: int) -> pl.DataFrame:
     strs = pl.Series("strs", random.choices(string.ascii_lowercase, k=n))
     strs = pl.select(
         pl.when(strs == "a")
-        .then("")
+        .then(pl.lit(""))
         .when(strs == "b")
         .then(None)
         .otherwise(strs)
@@ -534,7 +534,7 @@ def test_sort_row_fmt() -> None:
     df_pd = df.to_pandas()
 
     for descending in [True, False]:
-        pl.testing.assert_frame_equal(
+        assert_frame_equal(
             df.sort(["strs", "vals"], nulls_last=True, descending=descending),
             pl.from_pandas(
                 df_pd.sort_values(["strs", "vals"], ascending=not descending)


### PR DESCRIPTION
Changes:
* Deprecate parsing string inputs as literals for `when-then-otherwise`. These should be parsed as column names to be consistent with the rest of the API.
* Rename input args to `condition` / `statement`. 
* Expand docstrings