### PR TITLE
ci: temporarily turn off fail-fast so that ubuntu tests run

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -27,7 +27,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
 


### PR DESCRIPTION
I don't know what the windows CI failure is. Until we have fixed that, this ensures we at least run the linux tests.