### PR TITLE
depr(python): deprecate "connection_uri" → "connection" param in read/write database methods

### DIFF
--- a/py-polars/tests/unit/io/test_database.py
+++ b/py-polars/tests/unit/io/test_database.py
@@ -106,7 +106,7 @@ def test_read_database(
     create_temp_sqlite_db(test_db)
 
     df = pl.read_database(
-        connection_uri=f"sqlite:///{test_db}",
+        connection=f"sqlite:///{test_db}",
         query="SELECT * FROM test_data",
         engine=engine,
     )
@@ -154,7 +154,7 @@ def test_read_database_exceptions(
 ) -> None:
     with pytest.raises(errclass, match=err):
         pl.read_database(
-            connection_uri=f"{database}://test",
+            connection=f"{database}://test",
             query=query,
             engine=engine,
         )
@@ -198,7 +198,6 @@ def test_write_database(
     engine: DbWriteEngine, mode: DbWriteMode, sample_df: pl.DataFrame, tmp_path: Path
 ) -> None:
     tmp_path.mkdir(exist_ok=True)
-
     tmp_db = f"test_{engine}.db"
     test_db = str(tmp_path / tmp_db)
 
@@ -208,22 +207,20 @@ def test_write_database(
 
     sample_df.write_database(
         table_name=f"main.{tbl_name}",
-        connection_uri=f"sqlite:///{test_db}",
+        connection=f"sqlite:///{test_db}",
         if_exists="replace",
         engine=engine,
     )
-
     if mode == "append":
         sample_df.write_database(
             table_name=f'"main".{tbl_name}',
-            connection_uri=f"sqlite:///{test_db}",
+            connection=f"sqlite:///{test_db}",
             if_exists="append",
             engine=engine,
         )
         sample_df = pl.concat([sample_df, sample_df])
 
     result = pl.read_database(f"SELECT * FROM {tbl_name}", f"sqlite:///{test_db}")
-
     sample_df = sample_df.with_columns(pl.col("date").cast(pl.Utf8))
     assert_frame_equal(sample_df, result)
 
@@ -234,7 +231,7 @@ def test_write_database(
     ):
         with pytest.raises(ValueError):
             sample_df.write_database(
-                connection_uri=f"sqlite:///{test_db}",
+                connection=f"sqlite:///{test_db}",
                 engine=engine,
                 **invalid_params,  # type: ignore[arg-type]
             )


### PR DESCRIPTION
Ref: #10121.

This is a bit of prep before expanding capabilities - no new support (aside from opening ADBC connections via context manger). Deprecates "connection_uri" in favour of "connection", so we can use it for accepting user-created connection objects later.