### PR TITLE
chore(python): get test_udfs running on all python versions again

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -1,9 +1,8 @@
 """Utilities related to user defined functions (such as those passed to `apply`)."""
 from __future__ import annotations
-import inspect
-from pathlib import Path
 
 import dis
+import inspect
 import re
 import sys
 import warnings
@@ -12,6 +11,7 @@ from collections import defaultdict
 from dis import get_instructions
 from inspect import signature
 from itertools import count, zip_longest
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, NamedTuple, Union
 
 if TYPE_CHECKING:

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -1,5 +1,7 @@
 """Utilities related to user defined functions (such as those passed to `apply`)."""
 from __future__ import annotations
+import inspect
+from pathlib import Path
 
 import dis
 import re
@@ -11,8 +13,6 @@ from dis import get_instructions
 from inspect import signature
 from itertools import count, zip_longest
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, NamedTuple, Union
-
-from polars.utils.various import get_all_caller_variables
 
 if TYPE_CHECKING:
     from dis import Instruction
@@ -100,6 +100,23 @@ _PYTHON_METHODS_MAP = {
     "upper": "str.to_uppercase",
 }
 
+def _get_all_caller_variables() -> dict[str, Any]:
+    """Get all local and global variables from caller's frame."""
+    pkg_dir = Path(__file__).parent.parent
+
+    # https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
+    frame = inspect.currentframe()
+    n = 0
+    while frame:
+        fname = inspect.getfile(frame)
+        if fname.startswith(str(pkg_dir)):
+            frame = frame.f_back
+            n += 1
+        else:
+            break
+    if frame is None:
+        return {}
+    return {**frame.f_locals, **frame.f_globals}
 
 class BytecodeParser:
     """Introspect UDF bytecode and determine if we can rewrite as native expression."""
@@ -591,7 +608,7 @@ class RewrittenInstructions:
             argvals=[],
         ):
             inst1, inst2 = matching_instructions[:2]
-            variables = get_all_caller_variables()
+            variables = _get_all_caller_variables()
             if isinstance(variables.get(argval := inst1.argval, None), dict):
                 argval = f"map_dict({inst1.argval})"
             else:

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -100,6 +100,7 @@ _PYTHON_METHODS_MAP = {
     "upper": "str.to_uppercase",
 }
 
+
 def _get_all_caller_variables() -> dict[str, Any]:
     """Get all local and global variables from caller's frame."""
     pkg_dir = Path(__file__).parent.parent
@@ -117,6 +118,7 @@ def _get_all_caller_variables() -> dict[str, Any]:
     if frame is None:
         return {}
     return {**frame.f_locals, **frame.f_globals}
+
 
 class BytecodeParser:
     """Introspect UDF bytecode and determine if we can rewrite as native expression."""

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -358,20 +358,19 @@ NoDefault = Literal[_NoDefault.no_default]
 
 def find_stacklevel() -> int:
     """
-    Find the first place in the stack that is not inside polars (tests notwithstanding).
+    Find the first place in the stack that is not inside polars.
 
     Taken from:
     https://github.com/pandas-dev/pandas/blob/ab89c53f48df67709a533b6a95ce3d911871a0a8/pandas/util/_exceptions.py#L30-L51
     """
     pkg_dir = Path(pl.__file__).parent
-    test_dir = pkg_dir / "tests"
 
     # https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
     frame = inspect.currentframe()
     n = 0
     while frame:
         fname = inspect.getfile(frame)
-        if fname.startswith(str(pkg_dir)) and not fname.startswith(str(test_dir)):
+        if fname.startswith(str(pkg_dir)):
             frame = frame.f_back
             n += 1
         else:
@@ -455,22 +454,3 @@ def in_terminal_that_supports_colour() -> bool:
         ) or os.environ.get("PYCHARM_HOSTED") == "1"
     return False
 
-
-def get_all_caller_variables() -> dict[str, Any]:
-    """Get all local and global variables from caller's frame."""
-    pkg_dir = Path(pl.__file__).parent
-    test_dir = pkg_dir / "tests"
-
-    # https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
-    frame = inspect.currentframe()
-    n = 0
-    while frame:
-        fname = inspect.getfile(frame)
-        if fname.startswith(str(pkg_dir)) and not fname.startswith(str(test_dir)):
-            frame = frame.f_back
-            n += 1
-        else:
-            break
-    if frame is None:
-        return {}
-    return {**frame.f_locals, **frame.f_globals}

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -453,4 +453,3 @@ def in_terminal_that_supports_colour() -> bool:
             )
         ) or os.environ.get("PYCHARM_HOSTED") == "1"
     return False
-

--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -140,7 +140,15 @@ NOOP_TEST_CASES = [
 def test_bytecode_parser_expression(
     col: str, func: Callable[[Any], Any], expected: str
 ) -> None:
-    udfs = pytest.importorskip("udfs")
+    try:
+        import udfs
+    except ModuleNotFoundError as exc:
+        assert "No module named 'udfs'" in str(exc)
+        # Skip test if udfs can't be imported because it's not in the path.
+        # Prefer this over importorskip, so that if `udfs` can't be
+        # imported for some other reason, then the test
+        # won't be skipped.
+        return
     bytecode_parser = udfs.BytecodeParser(func, apply_target="expr")
     result = bytecode_parser.to_expression(col)
     assert result == expected
@@ -151,5 +159,13 @@ def test_bytecode_parser_expression(
     NOOP_TEST_CASES,
 )
 def test_bytecode_parser_expression_noop(func: Callable[[Any], Any]) -> None:
-    udfs = pytest.importorskip("udfs")
+    try:
+        import udfs
+    except ModuleNotFoundError as exc:
+        assert "No module named 'udfs'" in str(exc)
+        # Skip test if udfs can't be imported because it's not in the path.
+        # Prefer this over importorskip, so that if `udfs` can't be
+        # imported for some other reason, then the test
+        # won't be skipped.
+        return
     assert not udfs.BytecodeParser(func, apply_target="expr").can_rewrite()

--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -143,7 +143,7 @@ def test_bytecode_parser_expression(
     try:
         import udfs
     except ModuleNotFoundError as exc:
-        assert "No module named 'udfs'" in str(exc)
+        assert "No module named 'udfs'" in str(exc)  # noqa: PT017
         # Skip test if udfs can't be imported because it's not in the path.
         # Prefer this over importorskip, so that if `udfs` can't be
         # imported for some other reason, then the test
@@ -162,7 +162,7 @@ def test_bytecode_parser_expression_noop(func: Callable[[Any], Any]) -> None:
     try:
         import udfs
     except ModuleNotFoundError as exc:
-        assert "No module named 'udfs'" in str(exc)
+        assert "No module named 'udfs'" in str(exc)  # noqa: PT017
         # Skip test if udfs can't be imported because it's not in the path.
         # Prefer this over importorskip, so that if `udfs` can't be
         # imported for some other reason, then the test

--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -141,7 +141,7 @@ def test_bytecode_parser_expression(
     col: str, func: Callable[[Any], Any], expected: str
 ) -> None:
     try:
-        import udfs
+        import udfs  # type: ignore[import]
     except ModuleNotFoundError as exc:
         assert "No module named 'udfs'" in str(exc)  # noqa: PT017
         # Skip test if udfs can't be imported because it's not in the path.


### PR DESCRIPTION
the bytecode parser tests stopped running in CI after #10123

This is because `udfs` imported `polars`, but that couldn't be found in the `no-polars-installed` environment, so the test was being skipped
I've changed the test so it's only skipped if `udfs` itself can't be imported (because it's not in the path) so this doesn't happen again

---

EDIT ok this worked, it's running again

============================= test session starts ==============================
platform linux -- Python 3.8.17, pytest-7.4.0, pluggy-1.2.0
rootdir: /home/runner/work/polars/polars/py-polars
configfile: pyproject.toml
collected 35 items

tests/test_udfs.py ...................................                   [100%]

============================== 35 passed in 0.14s ==============================