### PR TITLE
feat(rust): serialize flags

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -83,6 +83,21 @@ impl CategoricalChunked {
         out
     }
 
+    pub(crate) fn get_flags(&self) -> u8 {
+        self.bit_settings.bits
+    }
+
+    /// Set flags for the Chunked Array
+    ///
+    /// # Safety
+    /// The caller must ensure the flags are correct for the underlying chunks
+    pub(crate) unsafe fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        let settings = BitSettings::from_bits(flags)
+            .ok_or(polars_err!(ComputeError : "Corrupt flags {} for {}",flags,self.dtype()))?;
+        self.bit_settings = settings;
+        Ok(())
+    }
+
     /// Build a categorical from an original RevMap. That means that the number of categories in the `RevMapping == self.unique().len()`.
     pub(crate) fn from_chunks_original(
         name: &str,

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -93,7 +93,7 @@ impl CategoricalChunked {
     /// The caller must ensure the flags are correct for the underlying chunks
     pub(crate) unsafe fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         let settings = BitSettings::from_bits(flags)
-            .ok_or(polars_err!(ComputeError : "Corrupt flags {} for {}",flags,self.dtype()))?;
+            .ok_or(polars_err!(ComputeError : "corrupt flags {} for {}",flags,self.dtype()))?;
         self.bit_settings = settings;
         Ok(())
     }

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -97,7 +97,6 @@ impl CategoricalChunked {
             })
             .map(|settings| {
                 self.bit_settings = settings;
-                ()
             })
     }
 

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -90,11 +90,9 @@ impl CategoricalChunked {
     /// Set flags for the Chunked Array
     pub(crate) fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         BitSettings::from_bits(flags)
-            .ok_or_else(|| {
-                PolarsError::ComputeError(
-                    format!("corrupt flags {} for {}", flags, self.dtype()).into(),
-                )
-            })
+            .ok_or_else(
+                || polars_err!(ComputeError: "corrupt flags {} for {}", flags, self.dtype()),
+            )
             .map(|settings| {
                 self.bit_settings = settings;
             })

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -84,7 +84,7 @@ impl CategoricalChunked {
     }
 
     pub(crate) fn get_flags(&self) -> u8 {
-        self.bit_settings.bits
+        self.bit_settings.bits()
     }
 
     /// Set flags for the Chunked Array

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -199,7 +199,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     /// The caller must ensure the flags are correct for the underlying chunks
     pub(crate) unsafe fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         let settings = Settings::from_bits(flags)
-            .ok_or(polars_err!(ComputeError : "Corrupt flags {} for {}",flags,self.dtype()))?;
+            .ok_or(polars_err!(ComputeError : "corrupt flags {} for {}",flags,self.dtype()))?;
         self.bit_settings = settings;
         Ok(())
     }

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -176,6 +176,14 @@ impl Settings {
 }
 
 impl<T: PolarsDataType> ChunkedArray<T> {
+
+    pub(crate) fn set_flags(&mut self, flags: u8){
+        match Settings::from_bits(flags){
+            None => polars_warn!("Ignoring incorrect bit settings for {}: {}",self.dtype(),flags),
+            Some(s) => {self.bit_settings = s}
+        }
+    }
+
     pub(crate) fn is_sorted_ascending_flag(&self) -> bool {
         self.bit_settings.contains(Settings::SORTED_ASC)
     }

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -177,13 +177,6 @@ impl Settings {
 
 impl<T: PolarsDataType> ChunkedArray<T> {
 
-    pub(crate) fn set_flags(&mut self, flags: u8){
-        match Settings::from_bits(flags){
-            None => polars_warn!("Ignoring incorrect bit settings for {}: {}",self.dtype(),flags),
-            Some(s) => {self.bit_settings = s}
-        }
-    }
-
     pub(crate) fn is_sorted_ascending_flag(&self) -> bool {
         self.bit_settings.contains(Settings::SORTED_ASC)
     }
@@ -196,8 +189,13 @@ impl<T: PolarsDataType> ChunkedArray<T> {
         self.bit_settings.remove(Settings::FAST_EXPLODE_LIST)
     }
 
-    pub(crate) fn clear_settings(&mut self) {
-        self.bit_settings.clear()
+
+    /// Set flags for the Chunked Array
+    pub(crate) fn set_flags(&mut self, flags: u8) -> PolarsResult<()>{
+        match Settings::from_bits(flags){
+            None => Err(polars_err!(ComputeError : "Corrupt flags {} for {}",flags,self.dtype())),
+            Some(s) => {self.bit_settings = s; Ok(())}
+        }
     }
 
     pub fn is_sorted_flag(&self) -> IsSorted {

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -189,6 +189,11 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     }
 
 
+    pub(crate) fn get_flags(&self) -> u8 {
+        self.bit_settings.bits
+    }
+
+    /// Set flags for the Chunked Array
     ///
     /// # Safety
     /// The caller must ensure the flags are correct for the underlying chunks

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -194,14 +194,17 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     }
 
     /// Set flags for the Chunked Array
-    ///
-    /// # Safety
-    /// The caller must ensure the flags are correct for the underlying chunks
-    pub(crate) unsafe fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
-        let settings = Settings::from_bits(flags)
-            .ok_or(polars_err!(ComputeError : "corrupt flags {} for {}",flags,self.dtype()))?;
-        self.bit_settings = settings;
-        Ok(())
+    pub(crate) fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        Settings::from_bits(flags)
+            .ok_or_else(|| {
+                PolarsError::ComputeError(
+                    format!("corrupt flags {} for {}", flags, self.dtype()).into(),
+                )
+            })
+            .map(|settings| {
+                self.bit_settings = settings;
+                ()
+            })
     }
 
     pub fn is_sorted_flag(&self) -> IsSorted {

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -203,7 +203,6 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             })
             .map(|settings| {
                 self.bit_settings = settings;
-                ()
             })
     }
 

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -169,12 +169,6 @@ bitflags! {
     }
 }
 
-impl Settings {
-    pub fn clear(&mut self) {
-        *self.0.bits_mut() = 0;
-    }
-}
-
 impl<T: PolarsDataType> ChunkedArray<T> {
     pub(crate) fn is_sorted_ascending_flag(&self) -> bool {
         self.bit_settings.contains(Settings::SORTED_ASC)
@@ -188,9 +182,8 @@ impl<T: PolarsDataType> ChunkedArray<T> {
         self.bit_settings.remove(Settings::FAST_EXPLODE_LIST)
     }
 
-
     pub(crate) fn get_flags(&self) -> u8 {
-        self.bit_settings.bits
+        self.bit_settings.bits()
     }
 
     /// Set flags for the Chunked Array

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -196,11 +196,9 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     /// Set flags for the Chunked Array
     pub(crate) fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         Settings::from_bits(flags)
-            .ok_or_else(|| {
-                PolarsError::ComputeError(
-                    format!("corrupt flags {} for {}", flags, self.dtype()).into(),
-                )
-            })
+            .ok_or_else(
+                || polars_err!(ComputeError: "corrupt flags {} for {}", flags, self.dtype()),
+            )
             .map(|settings| {
                 self.bit_settings = settings;
             })

--- a/crates/polars-core/src/serde/chunked_array.rs
+++ b/crates/polars-core/src/serde/chunked_array.rs
@@ -2,8 +2,8 @@ use std::cell::RefCell;
 
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
-use crate::chunked_array::Settings;
 
+use crate::chunked_array::Settings;
 use crate::prelude::*;
 
 pub struct IterSer<I>
@@ -58,7 +58,7 @@ where
     let mut state = serializer.serialize_map(Some(4))?;
     state.serialize_entry("name", name)?;
     state.serialize_entry("datatype", dtype)?;
-    state.serialize_entry("bit_settings",&bit_settings.bits())?;
+    state.serialize_entry("bit_settings", &bit_settings.bits())?;
     state.serialize_entry("values", &IterSer::new(ca.into_iter()))?;
     state.end()
 }
@@ -75,7 +75,13 @@ where
     where
         S: Serializer,
     {
-        serialize_impl(serializer, self.name(), self.dtype(),&self.bit_settings, self)
+        serialize_impl(
+            serializer,
+            self.name(),
+            self.dtype(),
+            &self.bit_settings,
+            self,
+        )
     }
 }
 
@@ -92,7 +98,13 @@ where
     where
         S: Serializer,
     {
-        serialize_impl(serializer, self.name(), self.dtype(),&self.bit_settings, self)
+        serialize_impl(
+            serializer,
+            self.name(),
+            self.dtype(),
+            &self.bit_settings,
+            self,
+        )
     }
 }
 
@@ -109,7 +121,7 @@ macro_rules! impl_serialize {
                 let mut state = serializer.serialize_map(Some(4))?;
                 state.serialize_entry("name", self.name())?;
                 state.serialize_entry("datatype", self.dtype())?;
-                state.serialize_entry("bit_settings",&self.bit_settings.bits())?;
+                state.serialize_entry("bit_settings", &self.bit_settings.bits())?;
                 state.serialize_entry("values", &IterSer::new(self.into_iter()))?;
                 state.end()
             }

--- a/crates/polars-core/src/serde/chunked_array.rs
+++ b/crates/polars-core/src/serde/chunked_array.rs
@@ -2,6 +2,7 @@ use std::cell::RefCell;
 
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
+use crate::chunked_array::Settings;
 
 use crate::prelude::*;
 
@@ -46,6 +47,7 @@ fn serialize_impl<T, S>(
     serializer: S,
     name: &str,
     dtype: &DataType,
+    bit_settings: &Settings,
     ca: &ChunkedArray<T>,
 ) -> std::result::Result<<S as Serializer>::Ok, <S as Serializer>::Error>
 where
@@ -53,9 +55,10 @@ where
     T::Native: Serialize,
     S: Serializer,
 {
-    let mut state = serializer.serialize_map(Some(3))?;
+    let mut state = serializer.serialize_map(Some(4))?;
     state.serialize_entry("name", name)?;
     state.serialize_entry("datatype", dtype)?;
+    state.serialize_entry("bit_settings",&bit_settings.bits())?;
     state.serialize_entry("values", &IterSer::new(ca.into_iter()))?;
     state.end()
 }
@@ -72,7 +75,7 @@ where
     where
         S: Serializer,
     {
-        serialize_impl(serializer, self.name(), self.dtype(), self)
+        serialize_impl(serializer, self.name(), self.dtype(),&self.bit_settings, self)
     }
 }
 
@@ -89,7 +92,7 @@ where
     where
         S: Serializer,
     {
-        serialize_impl(serializer, self.name(), self.dtype(), self)
+        serialize_impl(serializer, self.name(), self.dtype(),&self.bit_settings, self)
     }
 }
 
@@ -103,9 +106,10 @@ macro_rules! impl_serialize {
             where
                 S: Serializer,
             {
-                let mut state = serializer.serialize_map(Some(3))?;
+                let mut state = serializer.serialize_map(Some(4))?;
                 state.serialize_entry("name", self.name())?;
                 state.serialize_entry("datatype", self.dtype())?;
+                state.serialize_entry("bit_settings",&self.bit_settings.bits())?;
                 state.serialize_entry("values", &IterSer::new(self.into_iter()))?;
                 state.end()
             }

--- a/crates/polars-core/src/serde/mod.rs
+++ b/crates/polars-core/src/serde/mod.rs
@@ -39,7 +39,7 @@ mod test {
 
     #[test]
     fn test_serde_flags() {
-        let mut ca = UInt32Chunked::new("foo", &[Some(2), Some(1), None]);
+        let mut ca = Series::new("foo", &[Some(2), Some(1), None]);
         ca.set_sorted_flag(IsSorted::Descending);
 
         let json = serde_json::to_string(&ca).unwrap();

--- a/crates/polars-core/src/serde/mod.rs
+++ b/crates/polars-core/src/serde/mod.rs
@@ -4,6 +4,7 @@ pub mod series;
 
 #[cfg(test)]
 mod test {
+    use crate::chunked_array::Settings;
     use crate::prelude::*;
     use crate::series::IsSorted;
 
@@ -37,17 +38,6 @@ mod test {
         assert!(ca.into_series().series_equal_missing(&out));
     }
 
-    #[test]
-    fn test_serde_flags() {
-        let mut ca = Series::new("foo", &[Some(2), Some(1), None]);
-        ca.set_sorted_flag(IsSorted::Descending);
-
-        let json = serde_json::to_string(&ca).unwrap();
-        let out = serde_json::from_reader::<_, Series>(json.as_bytes()).unwrap();
-
-        assert!(&ca.bit_settings.eq(&out.u32().unwrap().bit_settings));
-    }
-
     fn sample_dataframe() -> DataFrame {
         let s1 = Series::new("foo", &[1, 2, 3]);
         let s2 = Series::new("bar", &[Some(true), None, Some(false)]);
@@ -55,6 +45,20 @@ mod test {
         let s_list = Series::new("list", &[s1.clone(), s1.clone(), s1.clone()]);
 
         DataFrame::new(vec![s1, s2, s3, s_list]).unwrap()
+    }
+
+    #[test]
+    fn test_serde_flags() {
+        let df = sample_dataframe();
+
+        for mut column in df.columns {
+            column.set_sorted_flag(IsSorted::Descending);
+            let json = serde_json::to_string(&column).unwrap();
+            let out = serde_json::from_reader::<_, Series>(json.as_bytes()).unwrap();
+            let f = out.get_flags();
+            assert_ne!(f, 0u8);
+            assert_eq!(column.get_flags(), out.get_flags());
+        }
     }
 
     #[test]

--- a/crates/polars-core/src/serde/mod.rs
+++ b/crates/polars-core/src/serde/mod.rs
@@ -4,7 +4,6 @@ pub mod series;
 
 #[cfg(test)]
 mod test {
-    use crate::chunked_array::Settings;
     use crate::prelude::*;
     use crate::series::IsSorted;
 

--- a/crates/polars-core/src/serde/mod.rs
+++ b/crates/polars-core/src/serde/mod.rs
@@ -5,6 +5,7 @@ pub mod series;
 #[cfg(test)]
 mod test {
     use crate::prelude::*;
+    use crate::series::IsSorted;
 
     #[test]
     fn test_serde() -> PolarsResult<()> {
@@ -34,6 +35,17 @@ mod test {
 
         let out = serde_json::from_reader::<_, Series>(json.as_bytes()).unwrap(); // uses `DeserializeOwned`
         assert!(ca.into_series().series_equal_missing(&out));
+    }
+
+    #[test]
+    fn test_serde_flags() {
+        let mut ca = UInt32Chunked::new("foo", &[Some(2), Some(1), None]);
+        ca.set_sorted_flag(IsSorted::Descending);
+
+        let json = serde_json::to_string(&ca).unwrap();
+        let out = serde_json::from_reader::<_, Series>(json.as_bytes()).unwrap();
+
+        assert!(&ca.bit_settings.eq(&out.u32().unwrap().bit_settings));
     }
 
     fn sample_dataframe() -> DataFrame {

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -230,13 +230,10 @@ impl<'de> Deserialize<'de> for Series {
                 }?;
 
                 if let Some(f) = bit_settings {
-                    unsafe {
-                        s.set_flags(f)
-                            .map_or(Err(de::Error::custom("bit flags are corrupt")), |_| Ok(s))
-                    }
-                } else {
-                    Ok(s)
+                    s.set_flags(f)
+                        .map_err(|_| de::Error::custom("bit flags are corrupt"))?
                 }
+                Ok(s)
             }
         }
 

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -230,9 +230,9 @@ impl<'de> Deserialize<'de> for Series {
                 }?;
 
                 if let Some(f) = bit_settings {
-                    match unsafe { s.set_flags(f) } {
-                        Ok(_) => Ok(s),
-                        Err(_) => Err(de::Error::custom("Bit flags are corrupt")),
+                    unsafe {
+                        s.set_flags(f)
+                            .map_or(Err(de::Error::custom("bit flags are corrupt")), |_| Ok(s))
                     }
                 } else {
                     Ok(s)

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -85,7 +85,7 @@ impl<'de> Deserialize<'de> for Series {
 
             fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
                 formatter
-                    .write_str("struct {name: <name>, datatype: <dtype>,bit_settings?: <settings>, values: <values array>}")
+                    .write_str("struct {name: <name>, datatype: <dtype>, bit_settings?: <settings>, values: <values array>}")
             }
 
             fn visit_map<A>(self, mut map: A) -> std::result::Result<Self::Value, A::Error>

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -25,7 +25,7 @@ impl private::PrivateSeries for SeriesWrap<ArrayChunked> {
         self.0.get_flags()
     }
 
-    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -20,8 +20,8 @@ impl private::PrivateSeries for SeriesWrap<ArrayChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _clear_settings(&mut self) {
-        self.0.clear_settings()
+    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        self.0.set_flags(flags)
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -20,9 +20,15 @@ impl private::PrivateSeries for SeriesWrap<ArrayChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
+
+    fn _get_flags(&self) -> u8 {
+        self.0.get_flags()
+    }
+
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }
+
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
     }

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -24,6 +24,9 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
+    fn _get_flags(&self) -> u8 {
+        self.0.get_flags()
+    }
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -27,7 +27,7 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
     fn _get_flags(&self) -> u8 {
         self.0.get_flags()
     }
-    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -24,8 +24,8 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _clear_settings(&mut self) {
-        self.0.clear_settings()
+    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        self.0.set_flags(flags)
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -25,10 +25,9 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _clear_settings(&mut self) {
-        self.0.clear_settings()
+    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        self.0.set_flags(flags)
     }
-
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
     }

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -28,7 +28,7 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     fn _get_flags(&self) -> u8 {
         self.0.get_flags()
     }
-    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -25,6 +25,9 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
+    fn _get_flags(&self) -> u8 {
+        self.0.get_flags()
+    }
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -64,8 +64,9 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-    fn _clear_settings(&mut self) {
-        self.0.logical_mut().clear_settings()
+
+    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        self.0.logical_mut.set_flags(flags)
     }
 
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -64,7 +64,9 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-
+    fn _get_flags(&self) -> u8 {
+        self.0.logical_mut.get_flags()
+    }
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.logical_mut.set_flags(flags)
     }

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -65,10 +65,10 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
         self.0.dtype()
     }
     fn _get_flags(&self) -> u8 {
-        self.0.logical_mut.get_flags()
+        self.0.get_flags()
     }
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
-        self.0.logical_mut.set_flags(flags)
+        self.0.set_flags(flags)
     }
 
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -67,7 +67,7 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
     fn _get_flags(&self) -> u8 {
         self.0.get_flags()
     }
-    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/implementations/dates_time.rs
+++ b/crates/polars-core/src/series/implementations/dates_time.rs
@@ -39,6 +39,9 @@ macro_rules! impl_dyn_series {
             fn _dtype(&self) -> &DataType {
                 self.0.dtype()
             }
+            fn _get_flags(&self) -> u8{
+                self.0.get_flags()
+            }
             unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
                 self.0.set_flags(flags)
             }

--- a/crates/polars-core/src/series/implementations/dates_time.rs
+++ b/crates/polars-core/src/series/implementations/dates_time.rs
@@ -42,7 +42,7 @@ macro_rules! impl_dyn_series {
             fn _get_flags(&self) -> u8{
                 self.0.get_flags()
             }
-            unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+            fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
                 self.0.set_flags(flags)
             }
 

--- a/crates/polars-core/src/series/implementations/dates_time.rs
+++ b/crates/polars-core/src/series/implementations/dates_time.rs
@@ -39,8 +39,8 @@ macro_rules! impl_dyn_series {
             fn _dtype(&self) -> &DataType {
                 self.0.dtype()
             }
-            fn _clear_settings(&mut self) {
-                self.0.clear_settings()
+            unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+                self.0.set_flags(flags)
             }
 
             fn explode_by_offsets(&self, offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -35,8 +35,9 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-    fn _clear_settings(&mut self) {
-        self.0.clear_settings()
+
+    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        self.0.set_flags(flags)
     }
 
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -38,7 +38,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
     fn _get_flags(&self) -> u8 {
         self.0.get_flags()
     }
-    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -35,7 +35,9 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-
+    fn _get_flags(&self) -> u8 {
+        self.0.get_flags()
+    }
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -54,7 +54,7 @@ impl private::PrivateSeries for SeriesWrap<DecimalChunked> {
     fn _get_flags(&self) -> u8 {
         self.0.get_flags()
     }
-    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -51,8 +51,11 @@ impl private::PrivateSeries for SeriesWrap<DecimalChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-    fn _clear_settings(&mut self) {
-        self.0.clear_settings()
+    fn _get_flags(&self) -> u8 {
+        self.0.get_flags()
+    }
+    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        self.0.set_flags(flags)
     }
 
     #[cfg(feature = "zip_with")]

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -60,7 +60,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
-    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.deref_mut().set_flags(flags)
     }
     fn _get_flags(&self) -> u8 {

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -63,6 +63,9 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.deref_mut().set_flags(flags)
     }
+    fn _get_flags(&self) -> u8 {
+        self.0.deref().get_flags()
+    }
 
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
         self.0.equal_element(idx_self, idx_other, other)

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -36,9 +36,6 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-    fn _clear_settings(&mut self) {
-        self.0.clear_settings()
-    }
 
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0
@@ -63,8 +60,8 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
-    fn _set_sorted_flag(&mut self, is_sorted: IsSorted) {
-        self.0.deref_mut().set_sorted_flag(is_sorted)
+    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        self.0.deref_mut().set_flags(flags)
     }
 
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -33,7 +33,9 @@ macro_rules! impl_dyn_series {
             unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
                 self.0.set_flags(flags)
             }
-
+            fn _get_flags(&self) -> u8 {
+                self.0.get_flags()
+            }
             fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
                 self.0.explode_by_offsets(offsets)
             }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -29,8 +29,9 @@ macro_rules! impl_dyn_series {
             fn _dtype(&self) -> &DataType {
                 self.0.ref_field().data_type()
             }
-            fn _clear_settings(&mut self) {
-                self.0.clear_settings()
+
+            unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()>{
+                self.0.set_flags(flags)
             }
 
             fn explode_by_offsets(&self, offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -30,7 +30,7 @@ macro_rules! impl_dyn_series {
                 self.0.ref_field().data_type()
             }
 
-            unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()>{
+            unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
                 self.0.set_flags(flags)
             }
 

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -30,7 +30,7 @@ macro_rules! impl_dyn_series {
                 self.0.ref_field().data_type()
             }
 
-            unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+            fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
                 self.0.set_flags(flags)
             }
             fn _get_flags(&self) -> u8 {

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -20,9 +20,11 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _clear_settings(&mut self) {
-        self.0.clear_settings()
+    
+    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        self.0.set_flags(flags)
     }
+
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
     }

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -20,7 +20,7 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    
+
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -20,7 +20,9 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-
+    fn _get_flags(&self) -> u8 {
+        self.0.get_flags()
+    }
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -23,7 +23,7 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
     fn _get_flags(&self) -> u8 {
         self.0.get_flags()
     }
-    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -95,7 +95,7 @@ macro_rules! impl_dyn_series {
                 self.0.get_flags()
             }
 
-            unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+            fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
                 self.0.set_flags(flags)
             }
 

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -91,8 +91,8 @@ macro_rules! impl_dyn_series {
                 self.0.ref_field().data_type()
             }
 
-            fn _clear_settings(&mut self) {
-                self.0.clear_settings()
+            unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+                self.0.set_flags(flags)
             }
 
             fn explode_by_offsets(&self, offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -91,6 +91,10 @@ macro_rules! impl_dyn_series {
                 self.0.ref_field().data_type()
             }
 
+            fn _get_flags(&self) -> u8 {
+                self.0.get_flags()
+            }
+
             unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
                 self.0.set_flags(flags)
             }

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -48,8 +48,10 @@ impl PrivateSeries for NullChunked {
     fn _field(&self) -> Cow<Field> {
         Cow::Owned(Field::new(self.name(), DataType::Null))
     }
-    fn _clear_settings(&mut self) {
-        // no-op
+
+    #[allow(unused)]
+    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        Ok(())
     }
 
     fn _dtype(&self) -> &DataType {

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -65,6 +65,10 @@ impl PrivateSeries for NullChunked {
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         ExplodeByOffsets::explode_by_offsets(self, offsets)
     }
+
+    fn _get_flags(&self) -> u8 {
+        0u8
+    }
 }
 
 impl SeriesTrait for NullChunked {

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -50,7 +50,7 @@ impl PrivateSeries for NullChunked {
     }
 
     #[allow(unused)]
-    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         Ok(())
     }
 

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -39,7 +39,7 @@ where
         self.0.dtype()
     }
 
-    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }
     fn _get_flags(&self) -> u8 {

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -38,8 +38,9 @@ where
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-    fn _clear_settings(&mut self) {
-        self.0.clear_settings()
+
+    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        self.0.set_flags(flags)
     }
 
     unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -42,7 +42,9 @@ where
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }
-
+    fn _get_flags(&self) -> u8 {
+        self.0.get_flags()
+    }
     unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
         self.0.agg_list(groups)
     }

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -25,6 +25,7 @@ impl private::PrivateSeries for SeriesWrap<StructChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
+    #[allow(unused)]
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         Ok(())
     }

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -28,6 +28,9 @@ impl private::PrivateSeries for SeriesWrap<StructChunked> {
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         Ok(())
     }
+    fn _get_flags(&self) -> u8 {
+        0u8
+    }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0
             .apply_fields(|s| s.explode_by_offsets(offsets))

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -26,7 +26,7 @@ impl private::PrivateSeries for SeriesWrap<StructChunked> {
         self.0.ref_field().data_type()
     }
     #[allow(unused)]
-    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         Ok(())
     }
     fn _get_flags(&self) -> u8 {

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -25,8 +25,8 @@ impl private::PrivateSeries for SeriesWrap<StructChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _clear_settings(&mut self) {
-        // no-op
+    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        Ok(())
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0

--- a/crates/polars-core/src/series/implementations/utf8.rs
+++ b/crates/polars-core/src/series/implementations/utf8.rs
@@ -24,9 +24,11 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _clear_settings(&mut self) {
-        self.0.clear_settings()
+
+    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        self.0.set_flags(flags)
     }
+
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
     }

--- a/crates/polars-core/src/series/implementations/utf8.rs
+++ b/crates/polars-core/src/series/implementations/utf8.rs
@@ -25,7 +25,7 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         self.0.ref_field().data_type()
     }
 
-    unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }
     fn _get_flags(&self) -> u8 {

--- a/crates/polars-core/src/series/implementations/utf8.rs
+++ b/crates/polars-core/src/series/implementations/utf8.rs
@@ -28,7 +28,9 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
     unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         self.0.set_flags(flags)
     }
-
+    fn _get_flags(&self) -> u8 {
+        self.0.get_flags()
+    }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
     }

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -199,7 +199,8 @@ impl Series {
 
     pub(crate) fn clear_settings(&mut self) {
         let inner = self._get_inner_mut();
-        inner._clear_settings()
+        // Safety: No flags set should not fail when parsing u8 into Bitflags object
+        unsafe { let _ = inner._set_flags(0u8); }
     }
 
     pub fn into_frame(self) -> DataFrame {

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -198,19 +198,15 @@ impl Series {
     }
 
     pub(crate) fn clear_settings(&mut self) {
-        // Safety: No flags set should not fail when parsing u8 into Bitflags object
-        unsafe {
-            let _ = self.set_flags(0u8);
-        }
+        let _ = self.set_flags(0u8);
     }
     #[allow(dead_code)]
     pub(crate) fn get_flags(&self) -> u8 {
         self.0._get_flags()
     }
 
-    pub(crate) unsafe fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
-        let inner = self._get_inner_mut();
-        unsafe { inner._set_flags(flags) }
+    pub(crate) fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        self._get_inner_mut()._set_flags(flags)
     }
 
     pub fn into_frame(self) -> DataFrame {

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -204,6 +204,10 @@ impl Series {
         }
     }
 
+    pub(crate) fn get_flags(&self) -> u8 {
+        self.0._get_flags()
+    }
+
     pub(crate) unsafe fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
         let inner = self._get_inner_mut();
         unsafe { inner._set_flags(flags) }

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -198,9 +198,15 @@ impl Series {
     }
 
     pub(crate) fn clear_settings(&mut self) {
-        let inner = self._get_inner_mut();
         // Safety: No flags set should not fail when parsing u8 into Bitflags object
-        unsafe { let _ = inner._set_flags(0u8); }
+        unsafe {
+            let _ = self.set_flags(0u8);
+        }
+    }
+
+    pub(crate) unsafe fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+        let inner = self._get_inner_mut();
+        unsafe { inner._set_flags(flags) }
     }
 
     pub fn into_frame(self) -> DataFrame {

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -203,7 +203,7 @@ impl Series {
             let _ = self.set_flags(0u8);
         }
     }
-
+    #[allow(dead_code)]
     pub(crate) fn get_flags(&self) -> u8 {
         self.0._get_flags()
     }

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -81,7 +81,7 @@ pub(crate) mod private {
 
         fn _get_flags(&self) -> u8;
 
-        unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()>;
+        fn _set_flags(&mut self, flags: u8) -> PolarsResult<()>;
 
         fn explode_by_offsets(&self, _offsets: &[i64]) -> Series {
             invalid_operation_panic!(explode_by_offsets, self)

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -79,6 +79,8 @@ pub(crate) mod private {
 
         fn compute_len(&mut self);
 
+        fn _get_flags(&self) -> u8;
+
         unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()>;
 
         fn explode_by_offsets(&self, _offsets: &[i64]) -> Series {

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -77,9 +77,9 @@ pub(crate) mod private {
 
         fn _dtype(&self) -> &DataType;
 
-        fn _clear_settings(&mut self);
-
         fn compute_len(&mut self);
+
+        unsafe fn _set_flags(&mut self, flags: u8) -> PolarsResult<()>;
 
         fn explode_by_offsets(&self, _offsets: &[i64]) -> Series {
             invalid_operation_panic!(explode_by_offsets, self)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2292,7 +2292,7 @@ class DataFrame:
         ...     }
         ... )
         >>> df.write_json()
-        '{"columns":[{"name":"foo","datatype":"Int64","values":[1,2,3]},{"name":"bar","datatype":"Int64","values":[6,7,8]}]}'
+        '{"columns":[{"name":"foo","datatype":"Int64","bit_settings":0,"values":[1,2,3]},{"name":"bar","datatype":"Int64","bit_settings":0,"values":[6,7,8]}]}'
         >>> df.write_json(row_oriented=True)
         '[{"foo":1,"bar":6},{"foo":2,"bar":7},{"foo":3,"bar":8}]'
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -846,7 +846,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         >>> lf = pl.LazyFrame({"a": [1, 2, 3]}).sum()
         >>> json = lf.serialize()
         >>> json
-        '{"LocalProjection":{"expr":[{"Agg":{"Sum":{"Column":"a"}}}],"input":{"DataFrameScan":{"df":{"columns":[{"name":"a","datatype":"Int64","values":[1,2,3]}]},"schema":{"inner":{"a":"Int64"}},"output_schema":null,"projection":null,"selection":null}},"schema":{"inner":{"a":"Int64"}}}}'
+        '{"LocalProjection":{"expr":[{"Agg":{"Sum":{"Column":"a"}}}],"input":{"DataFrameScan":{"df":{"columns":[{"name":"a","datatype":"Int64","bit_settings":0,"values":[1,2,3]}]},"schema":{"inner":{"a":"Int64"}},"output_schema":null,"projection":null,"selection":null}},"schema":{"inner":{"a":"Int64"}}}}'
 
         The logical plan can later be deserialized back into a LazyFrame.
 

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -35,7 +35,7 @@ def test_to_from_file(df: pl.DataFrame, tmp_path: Path) -> None:
 def test_write_json_to_string() -> None:
     # Tests if it runs if no arg given
     df = pl.DataFrame({"a": [1, 2, 3]})
-    expected_str = '{"columns":[{"name":"a","datatype":"Int64","values":[1,2,3]}]}'
+    expected_str = '{"columns":[{"name":"a","datatype":"Int64","bit_settings":0,"values":[1,2,3]}]}'
     assert df.write_json() == expected_str
 
 


### PR DESCRIPTION
fix #9956 

Very much work in progress, but wanted to get feedback before going further. Serializing the flags is straightforward as we can add them to the map. 

Deserialization however not so much:

- The bit flags can be of different types (ChunkedArray<T> / CategoricalChunked) hence we would need a common ground or create a temporary representation (e.g. Enum of all bitsettings). I choose the first, but this exposes u8 to the outside.

- Where to implement setting the flags. I choose to not do it on the series directly as not all ChunkedXXX implementations necessarily have flags. This would slightly complicate deserialization as we have to first construct the chunkedarray, alter the bit flags and then call `.into_series`