### PR TITLE
refactor(python): Track version in deprecation utils

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6551,7 +6551,8 @@ class DataFrame:
             issue_deprecation_warning(
                 "In a future version of polars, the default `aggregate_function` "
                 "will change from `'first'` to `None`. Please pass `'first'` to keep the "
-                "current behaviour, or `None` to accept the new one."
+                "current behaviour, or `None` to accept the new one.",
+                version="0.16.16",
             )
             aggregate_function = "first"
 

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -8565,16 +8565,20 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.shrink_dtype())
 
-    @deprecated("Since version 0.8.9 'cache' is a no-op")
+    @deprecated(
+        "This method now does nothing. It has been superseded by the"
+        " `comm_subexpr_elim` setting on `LazyFrame.collect`, which automatically"
+        " caches expressions that are equal.",
+        version="0.18.9",
+    )
     def cache(self) -> Self:
         """
-        A no-op.
+        Cache this expression so that it only is executed once per context.
 
-        Don't use this, it does nothing. Activate `comm_subexpr_elim` to automatically
-        cache expression that are equal.
-
-        .. deprecated:: 0.8.9
-            Since version this method doesn't do anything.
+        .. deprecated:: 0.18.9
+            This method now does nothing. It has been superseded by the
+            `comm_subexpr_elim` setting on `LazyFrame.collect`, which automatically
+            caches expressions that are equal.
 
         """
         return self

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -141,7 +141,8 @@ class ExprStringNameSpace:
                 "You can safely remove it. "
                 "Offset-naive strings are parsed as ``pl.Datetime(time_unit)``, "
                 "and offset-aware strings are converted to "
-                '``pl.Datetime(time_unit, "UTC")``.'
+                '``pl.Datetime(time_unit, "UTC")``.',
+                version="0.17.15",
             )
         return wrap_expr(
             self._pyexpr.str_to_datetime(

--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -182,5 +182,6 @@ class ChainedThen(Expr):
 def _warn_for_deprecated_string_input_behavior(input: str) -> None:
     issue_deprecation_warning(
         "in a future version, string input will be parsed as a column name rather than a string literal."
-        f" To silence this warning, pass the input as an expression instead: `pl.lit({input!r})`"
+        f" To silence this warning, pass the input as an expression instead: `pl.lit({input!r})`",
+        version="0.18.9",
     )

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -90,7 +90,8 @@ def all(
             return F.col("*")
         elif isinstance(exprs, pl.Series):
             issue_deprecation_warning(
-                "passing a Series to `all` is deprecated. Use `Series.all()` instead."
+                "passing a Series to `all` is deprecated. Use `Series.all()` instead.",
+                version="0.18.7",
             )
             return exprs.all()
         elif isinstance(exprs, str):
@@ -160,7 +161,8 @@ def any(
     if not more_exprs:
         if isinstance(exprs, pl.Series):
             issue_deprecation_warning(
-                "passing a Series to `any` is deprecated. Use `Series.any()` instead."
+                "passing a Series to `any` is deprecated. Use `Series.any()` instead.",
+                version="0.18.7",
             )
             return exprs.any()
         elif isinstance(exprs, str):
@@ -252,7 +254,8 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
     if not more_exprs:
         if isinstance(exprs, pl.Series):
             issue_deprecation_warning(
-                "passing a Series to `max` is deprecated. Use `Series.max()` instead."
+                "passing a Series to `max` is deprecated. Use `Series.max()` instead.",
+                version="0.18.7",
             )
             return exprs.max()
         elif isinstance(exprs, str):
@@ -346,7 +349,8 @@ def min(
     if not more_exprs:
         if isinstance(exprs, pl.Series):
             issue_deprecation_warning(
-                "passing a Series to `min` is deprecated. Use `Series.min()` instead."
+                "passing a Series to `min` is deprecated. Use `Series.min()` instead.",
+                version="0.18.7",
             )
             return exprs.min()
         elif isinstance(exprs, str):
@@ -441,7 +445,8 @@ def sum(
     if not more_exprs:
         if isinstance(exprs, pl.Series):
             issue_deprecation_warning(
-                "passing a Series to `sum` is deprecated. Use `Series.sum()` instead."
+                "passing a Series to `sum` is deprecated. Use `Series.sum()` instead.",
+                version="0.18.7",
             )
             return exprs.sum()
         elif isinstance(exprs, str):
@@ -513,7 +518,8 @@ def cumsum(
     if not more_exprs:
         if isinstance(exprs, pl.Series):
             issue_deprecation_warning(
-                "passing a Series to `cumsum` is deprecated. Use `Series.cumsum()` instead."
+                "passing a Series to `cumsum` is deprecated. Use `Series.cumsum()` instead.",
+                version="0.18.7",
             )
             return exprs.cumsum()
         elif isinstance(exprs, str):
@@ -525,5 +531,6 @@ def cumsum(
 
 def _warn_for_deprecated_horizontal_use(name: str) -> None:
     issue_deprecation_warning(
-        f"using `{name}` for horizontal computation is deprecated. Use `{name}_horizontal` instead."
+        f"using `{name}` for horizontal computation is deprecated. Use `{name}_horizontal` instead.",
+        version="0.18.7",
     )

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -377,7 +377,8 @@ def struct(
     if "exprs" in named_exprs:
         issue_deprecation_warning(
             "passing expressions to `struct` using the keyword argument `exprs` is"
-            " deprecated. Use positional syntax instead."
+            " deprecated. Use positional syntax instead.",
+            version="0.18.1",
         )
         first_input = named_exprs.pop("exprs")
         pyexprs = parse_as_list_of_expressions(first_input, *exprs, **named_exprs)

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -322,7 +322,8 @@ def count(column: str | Series | None = None) -> Expr | int:
 
     if isinstance(column, pl.Series):
         issue_deprecation_warning(
-            "passing a Series to `count` is deprecated. Use `Series.len()` instead."
+            "passing a Series to `count` is deprecated. Use `Series.len()` instead.",
+            version="0.18.8",
         )
         return column.len()
     return col(column).count()
@@ -382,7 +383,8 @@ def std(column: str | Series, ddof: int = 1) -> Expr | float | None:
     """
     if isinstance(column, pl.Series):
         issue_deprecation_warning(
-            "passing a Series to `std` is deprecated. Use `Series.std()` instead."
+            "passing a Series to `std` is deprecated. Use `Series.std()` instead.",
+            version="0.18.8",
         )
         return column.std(ddof)
     return col(column).std(ddof)
@@ -429,7 +431,8 @@ def var(column: str | Series, ddof: int = 1) -> Expr | float | None:
     """
     if isinstance(column, pl.Series):
         issue_deprecation_warning(
-            "passing a Series to `var` is deprecated. Use `Series.var()` instead."
+            "passing a Series to `var` is deprecated. Use `Series.var()` instead.",
+            version="0.18.8",
         )
         return column.var(ddof)
     return col(column).var(ddof)
@@ -465,7 +468,8 @@ def mean(column: str | Series) -> Expr | float | None:
     """
     if isinstance(column, pl.Series):
         issue_deprecation_warning(
-            "passing a Series to `mean` is deprecated. Use `Series.mean()` instead."
+            "passing a Series to `mean` is deprecated. Use `Series.mean()` instead.",
+            version="0.18.8",
         )
         return column.mean()
     return col(column).mean()
@@ -532,7 +536,8 @@ def median(column: str | Series) -> Expr | float | int | None:
     """
     if isinstance(column, pl.Series):
         issue_deprecation_warning(
-            "passing a Series to `median` is deprecated. Use `Series.median()` instead."
+            "passing a Series to `median` is deprecated. Use `Series.median()` instead.",
+            version="0.18.8",
         )
         return column.median()
     return col(column).median()
@@ -568,7 +573,8 @@ def n_unique(column: str | Series) -> Expr | int:
     """
     if isinstance(column, pl.Series):
         issue_deprecation_warning(
-            "passing a Series to `n_unique` is deprecated. Use `Series.n_unique()` instead."
+            "passing a Series to `n_unique` is deprecated. Use `Series.n_unique()` instead.",
+            version="0.18.8",
         )
         return column.n_unique()
     return col(column).n_unique()
@@ -661,7 +667,8 @@ def first(column: str | Series | None = None) -> Expr | Any:
 
     if isinstance(column, pl.Series):
         issue_deprecation_warning(
-            "passing a Series to `first` is deprecated. Use `series[0]` instead."
+            "passing a Series to `first` is deprecated. Use `series[0]` instead.",
+            version="0.18.8",
         )
         if column.len() > 0:
             return column[0]
@@ -725,7 +732,8 @@ def last(column: str | Series | None = None) -> Expr:
 
     if isinstance(column, pl.Series):
         issue_deprecation_warning(
-            "passing a Series to `last` is deprecated. Use `series[-1]` instead."
+            "passing a Series to `last` is deprecated. Use `series[-1]` instead.",
+            version="0.18.8",
         )
         if column.len() > 0:
             return column[-1]
@@ -783,7 +791,8 @@ def head(column: str | Series, n: int = 10) -> Expr | Series:
     """
     if isinstance(column, pl.Series):
         issue_deprecation_warning(
-            "passing a Series to `head` is deprecated. Use `Series.head()` instead."
+            "passing a Series to `head` is deprecated. Use `Series.head()` instead.",
+            version="0.18.8",
         )
         return column.head(n)
     return col(column).head(n)
@@ -838,7 +847,8 @@ def tail(column: str | Series, n: int = 10) -> Expr | Series:
     """
     if isinstance(column, pl.Series):
         issue_deprecation_warning(
-            "passing a Series to `tail` is deprecated. Use `Series.tail()` instead."
+            "passing a Series to `tail` is deprecated. Use `Series.tail()` instead.",
+            version="0.18.8",
         )
         return column.tail(n)
     return col(column).tail(n)

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -122,7 +122,8 @@ def arange(
             " `int_range` for generating a single range,"
             " and `int_ranges` for generating a list column with multiple ranges."
             " `arange` will remain available as an alias for `int_range`, which means its behaviour will change."
-            " To silence this warning, use either of the new functions."
+            " To silence this warning, use either of the new functions.",
+            version="0.18.5",
         )
 
     start = parse_as_expression(start)
@@ -531,7 +532,8 @@ def date_range(
     """
     if name is not None:
         issue_deprecation_warning(
-            "the `name` argument is deprecated. Use the `alias` method instead."
+            "the `name` argument is deprecated. Use the `alias` method instead.",
+            version="0.18.0",
         )
 
     interval = _parse_interval_argument(interval)
@@ -790,7 +792,8 @@ def time_range(
     """
     if name is not None:
         issue_deprecation_warning(
-            "the `name` argument is deprecated. Use the `alias` method instead."
+            "the `name` argument is deprecated. Use the `alias` method instead.",
+            version="0.18.0",
         )
 
     interval = _parse_interval_argument(interval)
@@ -953,7 +956,8 @@ def _warn_for_deprecation_date_range() -> None:
     issue_deprecation_warning(
         "behavior of `date_range` will change in a future version."
         " The result will be a single range of type Date or Datetime instead of List."
-        " Use the new `date_ranges` function to retain the old functionality and silence this warning."
+        " Use the new `date_ranges` function to retain the old functionality and silence this warning.",
+        version="0.18.9",
     )
 
 
@@ -961,5 +965,6 @@ def _warn_for_deprecation_time_range() -> None:
     issue_deprecation_warning(
         "behavior of `time_range` will change in a future version."
         " The result will be a single range of type Time instead of List."
-        " Use the new `date_ranges` function to retain the old functionality and silence this warning."
+        " Use the new `date_ranges` function to retain the old functionality and silence this warning.",
+        version="0.18.9",
     )

--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -122,7 +122,8 @@ def repeat(
     """
     if name is not None:
         issue_deprecation_warning(
-            "the `name` argument is deprecated. Use the `alias` method instead."
+            "the `name` argument is deprecated. Use the `alias` method instead.",
+            version="0.18.0",
         )
 
     if isinstance(n, int):

--- a/py-polars/polars/io/pyarrow_dataset/functions.py
+++ b/py-polars/polars/io/pyarrow_dataset/functions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from polars.io.pyarrow_dataset.anonymous_scan import _scan_pyarrow_dataset
-from polars.utils.deprecation import issue_deprecation_warning
+from polars.utils.deprecation import deprecated_name
 
 if TYPE_CHECKING:
     from polars import LazyFrame
@@ -55,6 +55,7 @@ def scan_pyarrow_dataset(
     return _scan_pyarrow_dataset(source, allow_pyarrow_filter=allow_pyarrow_filter)
 
 
+@deprecated_name(new_name="scan_pyarrow_dataset", version="0.16.10")
 def scan_ds(ds: pa.dataset.Dataset, *, allow_pyarrow_filter: bool = True) -> LazyFrame:
     """
     Scan a pyarrow dataset.
@@ -95,8 +96,4 @@ def scan_ds(ds: pa.dataset.Dataset, *, allow_pyarrow_filter: bool = True) -> Laz
     └───────┴────────┴────────────┘
 
     """
-    issue_deprecation_warning(
-        "`scan_ds` has been renamed; this"
-        " redirect is temporary, please use `scan_pyarrow_dataset` instead"
-    )
     return scan_pyarrow_dataset(ds, allow_pyarrow_filter=allow_pyarrow_filter)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2089,7 +2089,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if "exprs" in named_exprs:
             issue_deprecation_warning(
                 "passing expressions to `select` using the keyword argument `exprs` is"
-                " deprecated. Use positional syntax instead."
+                " deprecated. Use positional syntax instead.",
+                version="0.18.1",
             )
             first_input = named_exprs.pop("exprs")
             pyexprs = parse_as_list_of_expressions(
@@ -3214,7 +3215,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if "exprs" in named_exprs:
             issue_deprecation_warning(
                 "passing expressions to `with_columns` using the keyword argument"
-                " `exprs` is deprecated. Use positional syntax instead."
+                " `exprs` is deprecated. Use positional syntax instead.",
+                version="0.18.1",
             )
             first_input = named_exprs.pop("exprs")
             pyexprs = parse_as_list_of_expressions(

--- a/py-polars/polars/lazyframe/groupby.py
+++ b/py-polars/polars/lazyframe/groupby.py
@@ -143,7 +143,8 @@ class LazyGroupBy:
         if "aggs" in named_aggs:
             issue_deprecation_warning(
                 "passing expressions to `agg` using the keyword argument `aggs` is"
-                " deprecated. Use positional syntax instead."
+                " deprecated. Use positional syntax instead.",
+                version="0.18.1",
             )
             first_input = named_aggs.pop("aggs")
             pyexprs = parse_as_list_of_expressions(first_input, *aggs, **named_aggs)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -412,7 +412,8 @@ class Series:
         """Get the time unit of underlying Datetime Series as {"ns", "us", "ms"}."""
         issue_deprecation_warning(
             "`Series.time_unit` is deprecated and will be removed in a future version,"
-            " please use `Series.dtype.time_unit` instead"
+            " please use `Series.dtype.time_unit` instead",
+            version="0.17.5",
         )
         return self._s.time_unit()
 
@@ -2155,7 +2156,8 @@ class Series:
             issue_deprecation_warning(
                 "the `in_place` parameter is deprecated and will be removed in a future"
                 " version; note that renaming is a shallow-copy operation with"
-                " essentially zero cost."
+                " essentially zero cost.",
+                version="0.17.15",
             )
         if in_place:
             self._s.rename(name)
@@ -2407,7 +2409,8 @@ class Series:
             issue_deprecation_warning(
                 "the `append_chunks` argument will be removed and `append` will change"
                 " to always behave like `append_chunks=True` (the previous default)."
-                " For the behavior of `append_chunks=False`, use `Series.extend`."
+                " For the behavior of `append_chunks=False`, use `Series.extend`.",
+                version="0.18.8",
             )
         else:
             append_chunks = True

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -265,7 +265,8 @@ class StringNameSpace:
                 "You can safely remove it. "
                 "Offset-naive strings are parsed as ``pl.Datetime(time_unit)``, "
                 "and offset-aware strings are converted to "
-                '``pl.Datetime(time_unit, "UTC")``.'
+                '``pl.Datetime(time_unit, "UTC")``.',
+                version="0.17.15",
             )
         s = wrap_s(self._s)
         return (

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING
 
-from polars.utils.deprecation import issue_deprecation_warning
+from polars.utils.deprecation import deprecated_name
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import enable_string_cache as _enable_string_cache
@@ -118,6 +118,7 @@ def enable_string_cache(enable: bool) -> None:
     _enable_string_cache(enable)
 
 
+@deprecated_name(new_name="enable_string_cache", version="0.17.0")
 def toggle_string_cache(toggle: bool) -> None:
     """
     Enable (or disable) the global string cache.
@@ -128,10 +129,6 @@ def toggle_string_cache(toggle: bool) -> None:
     .. deprecated:: 0.17.0
 
     """
-    issue_deprecation_warning(
-        "`toggle_string_cache` has been renamed;"
-        " this redirect is temporary, please use `enable_string_cache` instead"
-    )
     enable_string_cache(toggle)
 
 

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -57,7 +57,8 @@ def _parse_regular_inputs(
         issue_deprecation_warning(
             "In the next breaking release, combining list input and positional input will result in an error."
             " To silence this warning, either unpack the list , or append the positional inputs to the list first."
-            " The resulting behavior will be identical"
+            " The resulting behavior will be identical",
+            version="0.18.4",
         )
 
     input_list = _first_input_to_list(inputs[0])
@@ -73,7 +74,8 @@ def _first_input_to_list(
             "In the next breaking release, passing `None` as the first expression input will evaluate to `lit(None)`,"
             " rather than be ignored."
             " To silence this warning, either pass no arguments or an empty list to retain the current behavior,"
-            " or pass `lit(None)` to opt into the new behavior."
+            " or pass `lit(None)` to opt into the new behavior.",
+            version="0.18.0",
         )
         return []
     elif not isinstance(inputs, Iterable) or isinstance(inputs, (str, pl.Series)):

--- a/py-polars/polars/utils/deprecation.py
+++ b/py-polars/polars/utils/deprecation.py
@@ -71,13 +71,14 @@ def deprecated_name(
 
 def deprecated_alias(**aliases: str) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """
-    Deprecate a function or method argument.
+    Decorator to mark function arguments as deprecated due to being renamed.
 
-    Decorator for deprecated function and method arguments. Use as follows:
+    Use as follows::
 
-    @deprecated_alias(old_arg='new_arg')
-    def myfunc(new_arg):
-        ...
+        @deprecated_alias(old_arg='new_arg')
+        def myfunc(new_arg):
+            ...
+
     """
 
     def deco(function: Callable[P, T]) -> Callable[P, T]:
@@ -99,14 +100,15 @@ def _rename_kwargs(
     """
     Rename the keyword arguments of a function.
 
-    Helper function for deprecating function and method arguments.
+    Helper function for deprecating function arguments.
+
     """
     for alias, new in aliases.items():
         if alias in kwargs:
             if new in kwargs:
                 raise TypeError(
-                    f"{func_name} received both {alias} and {new} as arguments!"
-                    f" {alias} is deprecated, use {new} instead."
+                    f"`{func_name}` received both `{alias}` and `{new}` as arguments."
+                    f" `{alias}` is deprecated, use `{new}` instead."
                 )
             issue_deprecation_warning(
                 f"`{alias}` is deprecated as an argument to `{func_name}`;"
@@ -116,41 +118,44 @@ def _rename_kwargs(
             kwargs[new] = kwargs.pop(alias)
 
 
-def warn_closed_future_change() -> Callable[[Callable[P, T]], Callable[P, T]]:
+def redirect(
+    from_to: dict[str, str | tuple[str, dict[str, Any]]]
+) -> Callable[[type[T]], type[T]]:
     """
-    Warn that user should pass in 'closed' as default value will change.
+    Class decorator allowing deprecation/transition from one method name to another.
 
-    Decorator for rolling function. Use as follows:
+    The parameters must be the same (unless they are being renamed, in which case
+    you can use this in conjunction with @deprecated_alias). If you need to redirect
+    with custom kwargs, can redirect to a method name and associated kwargs dict.
 
-    @warn_closed_future_change()
-    def myfunc():
-        ...
     """
 
-    def deco(function: Callable[P, T]) -> Callable[P, T]:
-        @wraps(function)
-        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-            # we only warn if 'by' is passed in, otherwise 'closed' is not used
-            if (kwargs.get("by") is not None) and ("closed" not in kwargs):
-                warnings.warn(
-                    message=(
-                        "The default argument for closed, 'left', will be changed to 'right' in the future."
-                        "Fix this warning by explicitly passing in a value for closed"
-                    ),
-                    category=FutureWarning,
-                    stacklevel=find_stacklevel(),
-                )
+    def _redirecting_getattr_(obj: T, item: Any) -> Any:
+        if isinstance(item, str) and item in from_to:
+            new_item = from_to[item]
+            new_item_name = new_item if isinstance(new_item, str) else new_item[0]
+            issue_deprecation_warning(
+                f"`{type(obj).__name__}.{item}` has been renamed;"
+                f" this redirect is temporary, please use `.{new_item_name}` instead",
+                version="",
+            )
+            item = new_item_name
 
-            return function(*args, **kwargs)
+        attr = obj.__getattribute__(item)
+        if isinstance(new_item, tuple):
+            attr = partial(attr, **new_item[1])
+        return attr
 
-        return wrapper
+    def _cls_(cls: type[T]) -> type[T]:
+        # note: __getattr__ is only invoked if item isn't found on the class
+        cls.__getattr__ = _redirecting_getattr_  # type: ignore[attr-defined]
+        return cls
 
-    return deco
+    return _cls_
 
 
 def deprecate_nonkeyword_arguments(
-    allowed_args: list[str] | None = None,
-    message: str | None = None,
+    allowed_args: list[str] | None = None, message: str | None = None, *, version: str
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """
     Decorator to deprecate the use of non-keyword arguments of a function.
@@ -164,6 +169,11 @@ def deprecate_nonkeyword_arguments(
         default value.
     message
         Optionally overwrite the default warning message.
+    version
+        The Polars version number in which the warning is first issued.
+        This argument is used to help developers determine when to remove the
+        deprecated functionality.
+
     """
 
     def decorate(function: Callable[P, T]) -> Callable[P, T]:
@@ -205,7 +215,7 @@ def deprecate_nonkeyword_arguments(
         @wraps(function)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             if len(args) > num_allowed_args:
-                issue_deprecation_warning(msg, version="")
+                issue_deprecation_warning(msg, version=version)
             return function(*args, **kwargs)
 
         wrapper.__signature__ = new_sig  # type: ignore[attr-defined]
@@ -231,36 +241,34 @@ def _format_argument_list(allowed_args: list[str]) -> str:
         return f" except for {args} and {last!r}"
 
 
-def redirect(
-    from_to: dict[str, str | tuple[str, dict[str, Any]]]
-) -> Callable[[type[T]], type[T]]:
+def warn_closed_future_change() -> Callable[[Callable[P, T]], Callable[P, T]]:
     """
-    Class decorator allowing deprecation/transition from one method name to another.
+    Warn that user should pass in 'closed' as default value will change.
 
-    The parameters must be the same (unless they are being renamed, in which case
-    you can use this in conjunction with @deprecated_alias). If you need to redirect
-    with custom kwargs, can redirect to a method name and associated kwargs dict.
+    Decorator for rolling function. Use as follows::
+
+        @warn_closed_future_change()
+        def myfunc():
+            ...
+
     """
 
-    def _redirecting_getattr_(obj: T, item: Any) -> Any:
-        if isinstance(item, str) and item in from_to:
-            new_item = from_to[item]
-            new_item_name = new_item if isinstance(new_item, str) else new_item[0]
-            issue_deprecation_warning(
-                f"`{type(obj).__name__}.{item}` has been renamed;"
-                f" this redirect is temporary, please use `.{new_item_name}` instead",
-                version="",
-            )
-            item = new_item_name
+    def deco(function: Callable[P, T]) -> Callable[P, T]:
+        @wraps(function)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            # we only warn if 'by' is passed in, otherwise 'closed' is not used
+            if (kwargs.get("by") is not None) and ("closed" not in kwargs):
+                warnings.warn(
+                    message=(
+                        "The default argument for closed, 'left', will be changed to 'right' in the future."
+                        "Fix this warning by explicitly passing in a value for closed"
+                    ),
+                    category=FutureWarning,
+                    stacklevel=find_stacklevel(),
+                )
 
-        attr = obj.__getattribute__(item)
-        if isinstance(new_item, tuple):
-            attr = partial(attr, **new_item[1])
-        return attr
+            return function(*args, **kwargs)
 
-    def _cls_(cls: type[T]) -> type[T]:
-        # note: __getattr__ is only invoked if item isn't found on the class
-        cls.__getattr__ = _redirecting_getattr_  # type: ignore[attr-defined]
-        return cls
+        return wrapper
 
-    return _cls_
+    return deco

--- a/py-polars/polars/utils/deprecation.py
+++ b/py-polars/polars/utils/deprecation.py
@@ -63,7 +63,7 @@ def deprecated_name(
 
     Notes
     -----
-    For deprecating renamed class methods, use the `redirect` class decorator instead.
+    For deprecating renamed class methods, use the ``redirect`` class decorator instead.
 
     """
     return deprecated(f"It has been renamed to `{new_name}`.", version=version)

--- a/py-polars/polars/utils/meta.py
+++ b/py-polars/polars/utils/meta.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING
 
-from polars.utils.deprecation import issue_deprecation_warning
+from polars.utils.deprecation import deprecated_name
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import get_index_type as _get_index_type
@@ -27,12 +27,9 @@ def get_index_type() -> DataTypeClass:
     return _get_index_type()
 
 
+@deprecated_name(new_name="get_index_type", version="16.12")
 def get_idx_type() -> DataTypeClass:
     """Get the datatype used for Polars indexing."""
-    issue_deprecation_warning(
-        "`get_idx_type` has been renamed; this"
-        " redirect is temporary, please use `get_index_type` instead"
-    )
     return get_index_type()
 
 

--- a/py-polars/tests/unit/utils/test_deprecation.py
+++ b/py-polars/tests/unit/utils/test_deprecation.py
@@ -16,7 +16,7 @@ def test_issue_deprecation_warning() -> None:
 
 
 class Foo:  # noqa: D101
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "baz"])
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "baz"], version="0.1.2")
     def bar(  # noqa: D102
         self, baz: str, ham: str | None = None, foobar: str | None = None
     ) -> None:

--- a/py-polars/tests/unit/utils/test_deprecation.py
+++ b/py-polars/tests/unit/utils/test_deprecation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import inspect
 import warnings
 
@@ -66,9 +68,7 @@ class Foo:  # noqa: D101
 
 def test_deprecate_nonkeyword_arguments_method_signature() -> None:
     # Note the added star indicating keyword-only arguments after 'baz'
-    expected = (
-        "(self, baz: str, *, ham: str | None = None, foobar: str | None = None) -> None"
-    )
+    expected = "(self, baz: 'str', *, ham: 'str | None' = None, foobar: 'str | None' = None) -> 'None'"
     assert str(inspect.signature(Foo.bar)) == expected
 
 

--- a/py-polars/tests/unit/utils/test_deprecation.py
+++ b/py-polars/tests/unit/utils/test_deprecation.py
@@ -1,0 +1,61 @@
+import inspect
+import warnings
+
+import pytest
+
+from polars.utils.deprecation import (
+    deprecate_nonkeyword_arguments,
+    issue_deprecation_warning,
+    redirect,
+)
+
+
+def test_issue_deprecation_warning() -> None:
+    with pytest.deprecated_call():
+        issue_deprecation_warning("deprecated", version="0.1.2")
+
+
+class Foo:  # noqa: D101
+    @deprecate_nonkeyword_arguments(allowed_args=["self", "baz"])
+    def bar(  # noqa: D102
+        self, baz: str, ham: str | None = None, foobar: str | None = None
+    ) -> None:
+        ...
+
+
+def test_deprecate_nonkeyword_arguments_method_signature() -> None:
+    # Note the added star indicating keyword-only arguments after 'baz'
+    expected = (
+        "(self, baz: str, *, ham: str | None = None, foobar: str | None = None) -> None"
+    )
+    assert str(inspect.signature(Foo.bar)) == expected
+
+
+def test_deprecate_nonkeyword_arguments_method_warning() -> None:
+    msg = (
+        r"All arguments of Foo\.bar except for \'baz\' will be keyword-only in the next breaking release."
+        r" Use keyword arguments to silence this warning."
+    )
+    with pytest.deprecated_call(match=msg):
+        Foo().bar("qux", "quox")
+
+
+def test_redirect() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+
+        # one-to-one redirection
+        @redirect({"foo": "bar"})
+        class DemoClass1:
+            def bar(self, upper: bool = False) -> str:
+                return "BAZ" if upper else "baz"
+
+        assert DemoClass1().foo() == "baz"  # type: ignore[attr-defined]
+
+        # redirection with **kwargs
+        @redirect({"foo": ("bar", {"upper": True})})
+        class DemoClass2:
+            def bar(self, upper: bool = False) -> str:
+                return "BAZ" if upper else "baz"
+
+        assert DemoClass2().foo() == "BAZ"  # type: ignore[attr-defined]

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import inspect
-import warnings
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -15,7 +13,6 @@ from polars.utils.convert import (
     _timedelta_to_pl_duration,
     _timedelta_to_pl_timedelta,
 )
-from polars.utils.deprecation import deprecate_nonkeyword_arguments, redirect
 from polars.utils.meta import get_idx_type
 from polars.utils.various import _in_notebook, parse_version
 
@@ -117,50 +114,6 @@ def test_estimated_size() -> None:
 def test_parse_version(v1: Any, v2: Any) -> None:
     assert parse_version(v1) > parse_version(v2)
     assert parse_version(v2) < parse_version(v1)
-
-
-class Foo:  # noqa: D101
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "baz"])
-    def bar(  # noqa: D102
-        self, baz: str, ham: str | None = None, foobar: str | None = None
-    ) -> None:
-        ...
-
-
-def test_deprecate_nonkeyword_arguments_method_signature() -> None:
-    # Note the added star indicating keyword-only arguments after 'baz'
-    expected = "(self, baz: 'str', *, ham: 'str | None' = None, foobar: 'str | None' = None) -> 'None'"
-    assert str(inspect.signature(Foo.bar)) == expected
-
-
-def test_deprecate_nonkeyword_arguments_method_warning() -> None:
-    msg = (
-        r"All arguments of Foo\.bar except for \'baz\' will be keyword-only in the next breaking release."
-        r" Use keyword arguments to silence this warning."
-    )
-    with pytest.deprecated_call(match=msg):
-        Foo().bar("qux", "quox")
-
-
-def test_redirect() -> None:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", DeprecationWarning)
-
-        # one-to-one redirection
-        @redirect({"foo": "bar"})
-        class DemoClass1:
-            def bar(self, upper: bool = False) -> str:
-                return "BAZ" if upper else "baz"
-
-        assert DemoClass1().foo() == "baz"  # type: ignore[attr-defined]
-
-        # redirection with **kwargs
-        @redirect({"foo": ("bar", {"upper": True})})
-        class DemoClass2:
-            def bar(self, upper: bool = False) -> str:
-                return "BAZ" if upper else "baz"
-
-        assert DemoClass2().foo() == "BAZ"  # type: ignore[attr-defined]
 
 
 def test_get_idx_type_deprecation() -> None:


### PR DESCRIPTION
Partially addresses #8004

Changes:
* Deprecation utils now have a mandatory `version` argument. This helps us determine when it's appropriate to remove the functionality.
  * `deprecated_alias` and `redirect` are not included yet - these are a little more complicated.
* Some related refactoring / add some tests.