### PR TITLE
chore(rust): Fix LICENSE symlink for moved crates

### DIFF
--- a/crates/polars-pipe/LICENSE
+++ b/crates/polars-pipe/LICENSE
@@ -1,1 +1,1 @@
-../../../LICENSE
+../../LICENSE

--- a/crates/polars-plan/LICENSE
+++ b/crates/polars-plan/LICENSE
@@ -1,1 +1,1 @@
-../../../LICENSE
+../../LICENSE

--- a/crates/polars/LICENSE
+++ b/crates/polars/LICENSE
@@ -1,1 +1,1 @@
-../LICENSE
+../../LICENSE


### PR DESCRIPTION
I missed these in the refactor of #10141