### PR TITLE
fix(python): if already in an active virtual environment, use it (do not force/assume ".venv")

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -2,7 +2,13 @@
 
 PYTHONPATH=
 SHELL=/bin/bash
-VENV = .venv
+VENV_DEFAULT=.venv
+
+ifeq ($(VIRTUAL_ENV), )
+	VENV=VENV_DEFAULT
+else
+	VENV=$(VIRTUAL_ENV)
+endif
 
 ifeq ($(OS),Windows_NT)
 	VENV_BIN=$(VENV)/Scripts

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -16,9 +16,15 @@ else
 	VENV_BIN=$(VENV)/bin
 endif
 
+
 .venv:  ## Set up virtual environment and install requirements
 	python3 -m venv $(VENV)
 	$(MAKE) requirements
+
+
+testing:  ## stuff
+    ## https://gist.github.com/rueycheng/42e355d1480fd7a33ee81c866c7fdf78
+	@echo $(dir $(VENV_BIN))
 
 .PHONY: requirements
 requirements: .venv  ## Install/refresh all project requirements


### PR DESCRIPTION
With all the bytecode introspection going on recently I've been switching between `3.9` and `3.11` Python venvs a lot, and noticed that we don't account for the possibility of being in a  non-default venv in the Makefile; while in my `.venv_39` environment I ran `make requirements` and realised that it was updating packages in the default `.venv` directory instead.

This PR makes a small update to the Makefile definition such that if we are _already_ in a venv we will use it, otherwise we continue to default to the standard `.venv`.