### PR TITLE
fix(python): Create delta compatible schema during writing

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3386,7 +3386,11 @@ class DataFrame:
         ... )  # doctest: +SKIP
 
         """
-        from polars.io.delta import _check_if_delta_available, _resolve_delta_lake_uri, _create_delta_compatible_schema
+        from polars.io.delta import (
+            _check_if_delta_available,
+            _create_delta_compatible_schema,
+            _resolve_delta_lake_uri,
+        )
 
         _check_if_delta_available()
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3315,7 +3315,13 @@ class DataFrame:
         Write DataFrame as delta table.
 
         Note: Some polars data types like `Null`, `Categorical` and `Time` are
-        not supported by the delta protocol specification.
+        not supported by the delta protocol specification. Other unsupported datatypes
+        are casted to their respective `primitive types <https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types>`__. See list below.
+        - `uint` -> `int`
+        - `timestamp(ns)` -> `timestamp(us)`
+        - `timestamp(ms)` -> `timestamp(us)`
+        - `largestring` -> `string`
+        - `largelist` -> `list`
 
         Parameters
         ----------
@@ -3436,18 +3442,14 @@ class DataFrame:
             data_schema = delta_schema
 
             if table is not None:
-                table_schema = table.schema()
-
-                if data_schema == table_schema.to_pyarrow(as_large_types=True):
-                    data_schema = table_schema.to_pyarrow()
+                if data_schema == table.schema().to_pyarrow(as_large_types=True):
+                    data_schema = table.schema().to_pyarrow()
             else:
                 data = data.cast(data_schema)
         else:
             if table is not None:
-                table_schema = table.schema()
-
-                if data_schema == table_schema.to_pyarrow(as_large_types=True):
-                    data_schema = table_schema.to_pyarrow()
+                if data_schema == table.schema().to_pyarrow(as_large_types=True):
+                    data_schema = table.schema().to_pyarrow()
 
         write_deltalake(
             table_or_uri=target,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3386,7 +3386,7 @@ class DataFrame:
         ... )  # doctest: +SKIP
 
         """
-        from polars.io.delta import _check_if_delta_available, _resolve_delta_lake_uri
+        from polars.io.delta import _check_if_delta_available, _resolve_delta_lake_uri, _create_delta_compatible_schema
 
         _check_if_delta_available()
 
@@ -3423,6 +3423,7 @@ class DataFrame:
 
         data = self.to_arrow()
         data_schema = data.schema
+        data_schema = _create_delta_compatible_schema(data_schema)
 
         # Workaround to prevent manual casting of large types
         table = try_get_deltatable(target, storage_options)  # type: ignore[arg-type]

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -37,7 +37,6 @@ from polars.datatypes import (
     N_INFER_DEFAULT,
     NUMERIC_DTYPES,
     Boolean,
-    Categorical,
     DataTypeClass,
     Float64,
     Object,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3416,7 +3416,7 @@ class DataFrame:
         from polars.io.delta import (
             _check_for_unsupported_types,
             _check_if_delta_available,
-            _create_delta_compatible_schema,
+            _convert_pa_schema_to_delta,
             _resolve_delta_lake_uri,
         )
 
@@ -3430,13 +3430,13 @@ class DataFrame:
         if isinstance(target, (str, Path)):
             target = _resolve_delta_lake_uri(str(target), strict=False)
 
-        _check_for_unsupported_types(self.schema)
+        _check_for_unsupported_types(self.dtypes)
 
         data = self.to_arrow()
 
         schema = delta_write_options.get("schema")
         if schema is None:
-            schema = _create_delta_compatible_schema(data.schema)
+            schema = _convert_pa_schema_to_delta(data.schema)
 
         data = data.cast(schema)
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -40,11 +40,7 @@ from polars.datatypes import (
     Categorical,
     DataTypeClass,
     Float64,
-    List,
-    Null,
     Object,
-    Struct,
-    Time,
     Utf8,
     py_type_to_dtype,
 )
@@ -3307,29 +3303,12 @@ class DataFrame:
         target: str | Path | deltalake.DeltaTable,
         *,
         mode: Literal["error", "append", "overwrite", "ignore"] = "error",
-        schema: pa.schema = None,
         overwrite_schema: bool = False,
         storage_options: dict[str, str] | None = None,
         delta_write_options: dict[str, Any] | None = None,
     ) -> None:
         """
         Write DataFrame as delta table.
-
-        Note: Some polars data types like `Null`, `Categorical` and `Time` are
-        not supported by the delta protocol specification. Other unsupported datatypes
-        are casted to their respective `primitive types
-        <https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types>`__.
-        See list below:
-
-        - `uint` -> `int`
-        - `timestamp(ns)` -> `timestamp(us)`
-        - `timestamp(ms)` -> `timestamp(us)`
-        - `largestring` -> `string`
-        - `largelist` -> `list`
-
-        Polars only has dtypes that are nullable, if one wants to write data in a delta
-        table with non-nullable columns, a custom pyarrow schema has to be passed to the
-        delta_write_options, see last example below.
 
         Parameters
         ----------
@@ -3342,8 +3321,6 @@ class DataFrame:
             * If 'append', will add new data.
             * If 'overwrite', will replace table with new data.
             * If 'ignore', will not write anything if table already exists.
-        schema
-            Optional PyArrow schema to use while writing the data
         overwrite_schema
             If True, allows updating the schema of the table.
         storage_options
@@ -3357,9 +3334,35 @@ class DataFrame:
             Additional keyword arguments while writing a Delta lake Table.
             See a list of supported write options `here <https://github.com/delta-io/delta-rs/blob/395d48b47ea638b70415899dc035cc895b220e55/python/deltalake/writer.py#L65>`__.
 
+        Raises
+        ------
+        TypeError
+            If the DataFrame contains unsupported data types.
+        ArrowInvalidError
+            If the DataFrame contains data types that could not be cast to their
+            primitive type.
+
+        Notes
+        -----
+        The Polars data types :class:`Null`, :class:`Categorical` and :class:`Time`
+        are not supported by the delta protocol specification and will raise a
+        TypeError.
+
+        Some other data types are not supported but have an associated `primitive type
+        <https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types>`__
+        to which they can be cast. This affects the following data types:
+
+        - Unsigned integers
+        - :class:`Datetime` types with millisecond or nanosecond precision
+        - :class:`Utf8`, :class:`Binary`, and :class:`List` ('large' types)
+
+        Polars columns are always nullable. To write data to a delta table with
+        non-nullable columns, a custom pyarrow schema has to be passed to the
+        `delta_write_options`. See the last example below.
+
         Examples
         --------
-        Instantiate a basic dataframe:
+        Write a dataframe to the local filesystem as a Delta Lake table.
 
         >>> df = pl.DataFrame(
         ...     {
@@ -3368,28 +3371,25 @@ class DataFrame:
         ...         "ham": ["a", "b", "c", "d", "e"],
         ...     }
         ... )
-
-        Write DataFrame as a Delta Lake table on local filesystem.
-
         >>> table_path = "/path/to/delta-table/"
         >>> df.write_delta(table_path)  # doctest: +SKIP
 
-        Append data to an existing Delta Lake table on local filesystem.
-        Note: This will fail if schema of the new data does not match the
-        schema of existing table.
+        Append data to an existing Delta Lake table on the local filesystem.
+        Note that this will fail if the schema of the new data does not match the
+        schema of the existing table.
 
         >>> df.write_delta(table_path, mode="append")  # doctest: +SKIP
 
         Overwrite a Delta Lake table as a new version.
-        Note: If the schema of the new and old data is same,
-        then setting `overwrite_schema` is not required.
+        If the schemas of the new and old data are the same, setting
+        `overwrite_schema` is not required.
 
         >>> existing_table_path = "/path/to/delta-table/"
         >>> df.write_delta(
         ...     existing_table_path, mode="overwrite", overwrite_schema=True
         ... )  # doctest: +SKIP
 
-        Write DataFrame as a Delta Lake table on cloud object store like S3.
+        Write a dataframe as a Delta Lake table to a cloud object store like S3.
 
         >>> table_path = "s3://bucket/prefix/to/delta-table/"
         >>> df.write_delta(
@@ -3401,20 +3401,20 @@ class DataFrame:
         ...     },
         ... )  # doctest: +SKIP
 
-
-        Write DataFrame as a Delta Lake table with non-nullable columns
+        Write DataFrame as a Delta Lake table with non-nullable columns.
 
         >>> import pyarrow as pa
         >>> existing_table_path = "/path/to/delta-table/"
         >>> df.write_delta(
         ...     existing_table_path,
         ...     delta_write_options={
-        ...         "schema": pa.schema([pa.field("col", pa.int64(), nullable=False)])
+        ...         "schema": pa.schema([pa.field("foo", pa.int64(), nullable=False)])
         ...     },
         ... )  # doctest: +SKIP
 
         """
         from polars.io.delta import (
+            _check_for_unsupported_types,
             _check_if_delta_available,
             _create_delta_compatible_schema,
             _resolve_delta_lake_uri,
@@ -3422,9 +3422,7 @@ class DataFrame:
 
         _check_if_delta_available()
 
-        from deltalake.writer import (
-            write_deltalake,
-        )
+        from deltalake.writer import write_deltalake
 
         if delta_write_options is None:
             delta_write_options = {}
@@ -3432,30 +3430,13 @@ class DataFrame:
         if isinstance(target, (str, Path)):
             target = _resolve_delta_lake_uri(str(target), strict=False)
 
-        unsupported_cols = {}
-        unsupported_types = [Time, Categorical, Null]
-
-        def check_unsupported_types(n: str, t: PolarsDataType | None) -> None:
-            if t is None or t in unsupported_types:
-                unsupported_cols[n] = t
-            elif isinstance(t, Struct):
-                for i in t.fields:
-                    check_unsupported_types(f"{n}.{i.name}", i.dtype)
-            elif isinstance(t, List):
-                check_unsupported_types(n, t.inner)
-
-        for name, data_type in self.schema.items():
-            check_unsupported_types(name, data_type)
-
-        if len(unsupported_cols) != 0:
-            raise TypeError(
-                f"Column(s) in {unsupported_cols} have unsupported data types."
-            )
+        _check_for_unsupported_types(self.schema)
 
         data = self.to_arrow()
+
+        schema = delta_write_options.get("schema")
         if schema is None:
             schema = _create_delta_compatible_schema(data.schema)
-            #! This will raise ArrowInvalidError if user has to big uints to cast in int
 
         data = data.cast(schema)
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3437,7 +3437,7 @@ class DataFrame:
 
             if table is not None:
                 table_schema = table.schema()
-                
+
                 if data_schema == table_schema.to_pyarrow(as_large_types=True):
                     data_schema = table_schema.to_pyarrow()
             else:
@@ -3445,7 +3445,7 @@ class DataFrame:
         else:
             if table is not None:
                 table_schema = table.schema()
-                
+
                 if data_schema == table_schema.to_pyarrow(as_large_types=True):
                     data_schema = table_schema.to_pyarrow()
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3456,9 +3456,8 @@ class DataFrame:
         if schema is None:
             schema = _create_delta_compatible_schema(data.schema)
             #! This will raise ArrowInvalidError if user has to big uints to cast in int
-    
-        data = data.cast(schema)
 
+        data = data.cast(schema)
 
         write_deltalake(
             table_or_uri=target,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3388,8 +3388,8 @@ class DataFrame:
         """
         from polars.io.delta import (
             _check_if_delta_available,
-            _create_delta_compatible_schema,
             _resolve_delta_lake_uri,
+            _create_delta_compatible_schema,
         )
 
         _check_if_delta_available()
@@ -3426,8 +3426,7 @@ class DataFrame:
             )
 
         data = self.to_arrow()
-        data_schema = data.schema
-        data_schema = _create_delta_compatible_schema(data_schema)
+        data_schema = _create_delta_compatible_schema(data.schema)
 
         # Workaround to prevent manual casting of large types
         table = try_get_deltatable(target, storage_options)  # type: ignore[arg-type]

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3316,7 +3316,9 @@ class DataFrame:
 
         Note: Some polars data types like `Null`, `Categorical` and `Time` are
         not supported by the delta protocol specification. Other unsupported datatypes
-        are casted to their respective `primitive types <https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types>`__. See list below.
+        are casted to their respective `primitive types
+        <https://github.com/delta-io/delta/blob/master/PROTOCOL.md#primitive-types>`__.
+        See list below:
         - `uint` -> `int`
         - `timestamp(ns)` -> `timestamp(us)`
         - `timestamp(ms)` -> `timestamp(us)`
@@ -3401,7 +3403,6 @@ class DataFrame:
         _check_if_delta_available()
 
         from deltalake.writer import (
-            try_get_deltatable,
             write_deltalake,
         )
 
@@ -3434,9 +3435,9 @@ class DataFrame:
         data = self.to_arrow()
         data_schema = data.schema
         delta_schema = _create_delta_compatible_schema(data_schema)
-        
+
         #! This will raise ArrowInvalidError if user has to big uints to cast in int
-        data = data.cast(delta_schema) 
+        data = data.cast(delta_schema)
 
         write_deltalake(
             table_or_uri=target,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3388,8 +3388,8 @@ class DataFrame:
         """
         from polars.io.delta import (
             _check_if_delta_available,
-            _resolve_delta_lake_uri,
             _create_delta_compatible_schema,
+            _resolve_delta_lake_uri,
         )
 
         _check_if_delta_available()

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -336,10 +336,14 @@ def _reconstruct_field_type(
         if reconstructed_field is None:
             return pa.field(
                 name=field.name,
-                type=pa.timestamp("us", tz=field.type.tz),
+                type=pa.timestamp("us"
+                                #   , tz=field.type.tz
+                                  ),
             )
         else:
-            reconstructed_field.append(pa.timestamp("us", tz=field.type.tz))
+            reconstructed_field.append(pa.timestamp("us", 
+                                                    # tz=field.type.tz
+                                                    ))
             return pa.field(
                 name=field_head.name,
                 type=reduce(lambda x, y: y(x), reversed(reconstructed_field)),
@@ -396,10 +400,7 @@ def _create_delta_compatible_schema(schema: pa.schema) -> pa.Schema:
     Returns:
         pa.Schema: delta compatible schema
     """
-    if any(dtype in str(schema.types) for dtype in ['uint', 'timestamp[ms]', 'timestamp[ns]']):
-        schema_out = [*map(_reconstruct_field_type, schema, schema)]
-    else:
-        schema_out = schema
+    schema_out = [*map(_reconstruct_field_type, schema, schema)]
     schema = pa.schema(schema_out, metadata=schema.metadata)
 
     return schema

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -355,9 +355,8 @@ def _reconstruct_field_type(
 
     if reconstructed_field is None:
         if isinstance(field.type, pa.LargeListType):
-            reconstructed_field = [pa.list_]
             return _reconstruct_field_type(
-                field.type.value_field, field_head, reconstructed_field
+                field.type.value_field, field_head, [pa.list_]
             )
         elif isinstance(field.type, pa.StructType):
             return pa.field(

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -408,18 +408,6 @@ def _reconstruct_field_type(
                     name=field_head.name,
                     type=reduce(lambda x, y: y(x), reversed(reconstructed_field)),
             )
-                
-    else:
-        if reconstructed_field is None:
-            return field
-        else:
-            reconstructed_field.append(field.type)
-            return pa.field(
-                name=field_head.name,
-                type=reduce(lambda x, y: y(x), reversed(reconstructed_field)),
-            )
-
-
 
 def _create_delta_compatible_schema(schema: pa.schema) -> pa.Schema:
     """

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
-import pyarrow as pa
+from polars.dependencies import pyarrow as pa
 
 from polars.convert import from_arrow
 from polars.dependencies import _DELTALAKE_AVAILABLE, deltalake

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -318,6 +318,10 @@ def _check_if_delta_available() -> None:
         )
 
 
+def _create_nested_type(type_list: list[pa.DataType]) -> pa.DataType:
+    return reduce(lambda x, y: y(x), reversed(type_list))
+
+
 def _reconstruct_field_type(
     field: pa.Field,
     field_head: pa.Field,
@@ -383,7 +387,7 @@ def _reconstruct_field_type(
             )
             return pa.field(
                 name=field_head.name,
-                type=reduce(lambda x, y: y(x), reversed(reconstructed_field)),
+                type=_create_nested_type(reconstructed_field),
             )
         elif isinstance(field.type, pa.DataType) and not isinstance(
             field.type, (pa.LargeListType, pa.StructType)
@@ -393,13 +397,13 @@ def _reconstruct_field_type(
                     reconstructed_field.append(primitive_type)
                     return pa.field(
                         name=field_head.name,
-                        type=reduce(lambda x, y: y(x), reversed(reconstructed_field)),
+                        type=_create_nested_type(reconstructed_field),
                     )
             else:
                 reconstructed_field.append(field.type)
                 return pa.field(
                     name=field_head.name,
-                    type=reduce(lambda x, y: y(x), reversed(reconstructed_field)),
+                    type=_create_nested_type(reconstructed_field),
                 )
 
 

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -5,10 +5,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
-from polars.dependencies import pyarrow as pa
-
 from polars.convert import from_arrow
 from polars.dependencies import _DELTALAKE_AVAILABLE, deltalake
+from polars.dependencies import pyarrow as pa
 from polars.io.pyarrow_dataset import scan_pyarrow_dataset
 
 if TYPE_CHECKING:

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -353,10 +353,12 @@ def _reconstruct_field_type(
         if reconstructed_field is None:
             return pa.field(
                 name=field.name,
-                type=pa.timestamp("us"),  # TODO: Check TZ issue with delta-rs team
+                type=pa.timestamp(
+                    unit="us", tz="UTC"
+                ),  # Always cast to UTC, since Delta-rs does not support other timezones yet
             )
         else:
-            reconstructed_field.append(pa.timestamp("us"))
+            reconstructed_field.append(pa.timestamp(unit="us", tz="UTC"))
             return pa.field(
                 name=field_head.name,
                 type=reduce(lambda x, y: y(x), reversed(reconstructed_field)),

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -407,7 +407,8 @@ def _reconstruct_field_type(
                 return pa.field(
                     name=field_head.name,
                     type=reduce(lambda x, y: y(x), reversed(reconstructed_field)),
-            )
+                )
+
 
 def _create_delta_compatible_schema(schema: pa.schema) -> pa.Schema:
     """

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -354,11 +354,11 @@ def _reconstruct_field_type(
             return pa.field(
                 name=field.name,
                 type=pa.timestamp(
-                    unit="us", tz="UTC"
-                ),  # Always cast to UTC, since Delta-rs does not support other timezones yet
+                    unit="us"
+                ),  # Always cast to no timezone, since Delta-rs does not support UTC yet, once fixed upstream, add tz=field.type.tz
             )
         else:
-            reconstructed_field.append(pa.timestamp(unit="us", tz="UTC"))
+            reconstructed_field.append(pa.timestamp(unit="us"))
             return pa.field(
                 name=field_head.name,
                 type=reduce(lambda x, y: y(x), reversed(reconstructed_field)),

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -346,7 +346,7 @@ def _reconstruct_field_type(
         pa.uint32(): pa.int32(),
         pa.uint64(): pa.int64(),
         pa.large_string(): pa.string(),
-        pa.large_binary(): pa.binary()
+        pa.large_binary(): pa.binary(),
     }
 
     if isinstance(field.type, pa.TimestampType):

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -211,11 +211,7 @@ def test_write_delta(df: pl.DataFrame, tmp_path: Path) -> None:
                     datetime(2010, 1, 2, 0, 0),
                 ]
             ],
-            dtype=pl.List(
-                pl.Datetime(
-                    time_unit="ns",
-                )
-            ),
+            dtype=pl.List(pl.Datetime(time_unit="ns")),
         ),
         pl.Series(
             "list_date_us",
@@ -225,11 +221,7 @@ def test_write_delta(df: pl.DataFrame, tmp_path: Path) -> None:
                     datetime(2010, 1, 2, 0, 0),
                 ]
             ],
-            dtype=pl.List(
-                pl.Datetime(
-                    time_unit="ms",
-                )
-            ),
+            dtype=pl.List(pl.Datetime(time_unit="ms")),
         ),
         pl.Series(
             "nested_list_date",
@@ -241,13 +233,7 @@ def test_write_delta(df: pl.DataFrame, tmp_path: Path) -> None:
                     ]
                 ]
             ],
-            dtype=pl.List(
-                pl.List(
-                    pl.Datetime(
-                        time_unit="ns",
-                    )
-                )
-            ),
+            dtype=pl.List(pl.List(pl.Datetime(time_unit="ns"))),
         ),
         pl.Series(
             "struct_with_list",

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pyarrow.fs
 import pytest
+from deltalake import DeltaTable
 
 import polars as pl
 from polars.testing import assert_frame_equal, assert_frame_not_equal
@@ -104,8 +105,6 @@ def test_read_delta_relative(delta_table_path: Path) -> None:
 
 @pytest.mark.write_disk()
 def test_write_delta(df: pl.DataFrame, tmp_path: Path) -> None:
-    from deltalake import DeltaTable
-
     v0 = df.select(pl.col(pl.Utf8))
     v1 = df.select(pl.col(pl.Int64))
     df_supported = df.drop(["cat", "time"])
@@ -340,9 +339,7 @@ def test_write_delta(df: pl.DataFrame, tmp_path: Path) -> None:
     ],
 )
 def test_write_delta_w_compatible_schema(series: pl.Series, tmp_path: Path) -> None:
-    from deltalake import DeltaTable
-
-    df = pl.DataFrame(series)
+    df = series.to_frame()
 
     # Create table
     df.write_delta(tmp_path, mode="append")
@@ -351,5 +348,4 @@ def test_write_delta_w_compatible_schema(series: pl.Series, tmp_path: Path) -> N
     df.write_delta(tmp_path, mode="append")
 
     tbl = DeltaTable(tmp_path)
-
     assert tbl.version() == 1


### PR DESCRIPTION
Closes #10153  
Closes #10154 

- Casts all uints to ints with the same bitsize
- Cast all timestamps to 'us' precision


Keep getting this type-arg error, but I don't know exactly which dtypes will come from pyArrow, I am just treating it as a black box ( :
`polars/io/delta.py:324: error: Missing type parameters for generic type "list"  [type-arg`]