### PR TITLE
refactor(python): Improve deprecation utils

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -86,7 +86,10 @@ from polars.utils._construction import (
 from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr, wrap_ldf, wrap_s
 from polars.utils.convert import _timedelta_to_pl_duration
-from polars.utils.deprecation import deprecated_alias, issue_deprecation_warning
+from polars.utils.deprecation import (
+    deprecate_renamed_parameter,
+    issue_deprecation_warning,
+)
 from polars.utils.various import (
     _prepare_row_count_args,
     _process_null_values,
@@ -3180,7 +3183,7 @@ class DataFrame:
                 file, compression, compression_level, statistics, row_group_size
             )
 
-    @deprecated_alias(connection_uri="connection")
+    @deprecate_renamed_parameter("connection_uri", "connection", version="0.18.9")
     def write_database(
         self,
         table_name: str,
@@ -5878,7 +5881,7 @@ class DataFrame:
         else:
             return self._from_pydf(self._df.hstack([s._s for s in columns]))
 
-    @deprecated_alias(df="other")
+    @deprecate_renamed_parameter("df", "other", version="0.18.8")
     def vstack(self, other: DataFrame, *, in_place: bool = False) -> Self:
         """
         Grow this DataFrame vertically by stacking a DataFrame to it.
@@ -8153,7 +8156,7 @@ class DataFrame:
         """
         return self._from_pydf(self._df.null_count())
 
-    @deprecated_alias(frac="fraction")
+    @deprecate_renamed_parameter("frac", "fraction", version="0.17.0")
     def sample(
         self,
         n: int | None = None,

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -9,7 +9,7 @@ from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
 from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
 from polars.utils.convert import _timedelta_to_pl_duration
-from polars.utils.deprecation import deprecated_alias
+from polars.utils.deprecation import deprecate_renamed_parameter
 
 if TYPE_CHECKING:
     from datetime import timedelta
@@ -445,7 +445,7 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.dt_to_string(format))
 
-    @deprecated_alias(fmt="format")
+    @deprecate_renamed_parameter("fmt", "format", version="0.17.3")
     def strftime(self, format: str) -> Expr:
         """
         Convert a Date/Time/Datetime column into a Utf8 column with the given format.

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -51,8 +51,8 @@ from polars.utils._parse_expr_input import (
 )
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.deprecation import (
-    deprecated,
-    deprecated_alias,
+    deprecate_function,
+    deprecate_renamed_parameter,
     warn_closed_future_change,
 )
 from polars.utils.meta import threadpool_size
@@ -3363,7 +3363,7 @@ class Expr:
             self._pyexpr.cut(breaks, labels, left_closed, include_breaks)
         )
 
-    @deprecated_alias(probs="q")
+    @deprecate_renamed_parameter("probs", "q", version="0.18.8")
     def qcut(
         self,
         q: list[float] | int,
@@ -7904,7 +7904,7 @@ class Expr:
             seed = random.randint(0, 10000)
         return self._from_pyexpr(self._pyexpr.shuffle(seed, fixed_seed))
 
-    @deprecated_alias(frac="fraction")
+    @deprecate_renamed_parameter("frac", "fraction", version="0.17.0")
     def sample(
         self,
         n: int | None = None,
@@ -8565,7 +8565,7 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.shrink_dtype())
 
-    @deprecated(
+    @deprecate_function(
         "This method now does nothing. It has been superseded by the"
         " `comm_subexpr_elim` setting on `LazyFrame.collect`, which automatically"
         " caches expressions that are equal.",

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -7,7 +7,10 @@ import polars._reexport as pl
 from polars import functions as F
 from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
-from polars.utils.deprecation import deprecated_alias, redirect
+from polars.utils.deprecation import (
+    deprecate_renamed_methods,
+    deprecate_renamed_parameter,
+)
 
 if TYPE_CHECKING:
     from datetime import date, datetime, time
@@ -16,14 +19,19 @@ if TYPE_CHECKING:
     from polars.type_aliases import IntoExpr, NullBehavior, ToStructStrategy
 
 
-@redirect(
+@deprecate_renamed_methods(
     {
         "difference": "set_difference",
         "symmetric_difference": "set_symmetric_difference",
         "intersection": "set_intersection",
         "union": "set_union",
     },
-    version="0.18.10",
+    versions={
+        "difference": "0.18.10",
+        "symmetric_difference": "0.18.10",
+        "intersection": "0.18.10",
+        "union": "0.18.10",
+    },
 )
 class ExprListNameSpace:
     """Namespace for list related expressions."""
@@ -777,7 +785,7 @@ class ExprListNameSpace:
         element = parse_as_expression(element, str_as_lit=True)
         return wrap_expr(self._pyexpr.list_count_match(element))
 
-    @deprecated_alias(name_generator="fields")
+    @deprecate_renamed_parameter("name_generator", "fields", version="0.17.12")
     def to_struct(
         self,
         n_field_strategy: ToStructStrategy = "first_non_null",

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -7,7 +7,10 @@ from polars.datatypes import Date, Datetime, Time, py_type_to_dtype
 from polars.exceptions import ChronoFormatWarning
 from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
-from polars.utils.deprecation import deprecated_alias, issue_deprecation_warning
+from polars.utils.deprecation import (
+    deprecate_renamed_parameter,
+    issue_deprecation_warning,
+)
 from polars.utils.various import find_stacklevel
 
 if TYPE_CHECKING:
@@ -193,7 +196,8 @@ class ExprStringNameSpace:
         _validate_format_argument(format)
         return wrap_expr(self._pyexpr.str_to_time(format, strict, cache))
 
-    @deprecated_alias(datatype="dtype", fmt="format")
+    @deprecate_renamed_parameter("datatype", "dtype", version="0.17.3")
+    @deprecate_renamed_parameter("fmt", "format", version="0.17.3")
     def strptime(
         self,
         dtype: PolarsTemporalType,

--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -6,7 +6,10 @@ import polars.functions as F
 from polars.expr.expr import Expr
 from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
-from polars.utils.deprecation import deprecated_alias, issue_deprecation_warning
+from polars.utils.deprecation import (
+    deprecate_renamed_parameter,
+    issue_deprecation_warning,
+)
 
 if TYPE_CHECKING:
     from polars.polars import PyExpr
@@ -26,7 +29,7 @@ class When:
     def __init__(self, when: Any):
         self._when = when
 
-    @deprecated_alias(expr="statement")
+    @deprecate_renamed_parameter("expr", "statement", version="0.18.9")
     def then(self, statement: IntoExpr) -> Then:
         """
         Attach a statement to the corresponding condition.
@@ -63,7 +66,7 @@ class Then(Expr):
     def _pyexpr(self) -> PyExpr:
         return self._then.otherwise(F.lit(None)._pyexpr)
 
-    @deprecated_alias(predicate="condition")
+    @deprecate_renamed_parameter("predicate", "condition", version="0.18.9")
     def when(self, condition: IntoExpr) -> ChainedWhen:
         """
         Add a condition to the `when-then-otherwise` expression.
@@ -78,7 +81,7 @@ class Then(Expr):
         condition_pyexpr = parse_as_expression(condition)
         return ChainedWhen(self._then.when(condition_pyexpr))
 
-    @deprecated_alias(expr="statement")
+    @deprecate_renamed_parameter("expr", "statement", version="0.18.9")
     def otherwise(self, statement: IntoExpr) -> Expr:
         """
         Define a default for the `when-then-otherwise` expression.
@@ -109,7 +112,7 @@ class ChainedWhen(Expr):
     def __init__(self, chained_when: Any):
         self._chained_when = chained_when
 
-    @deprecated_alias(expr="statement")
+    @deprecate_renamed_parameter("expr", "statement", version="0.18.9")
     def then(self, statement: IntoExpr) -> ChainedThen:
         """
         Attach a statement to the corresponding condition.
@@ -146,7 +149,7 @@ class ChainedThen(Expr):
     def _pyexpr(self) -> PyExpr:
         return self._chained_then.otherwise(F.lit(None)._pyexpr)
 
-    @deprecated_alias(predicate="condition")
+    @deprecate_renamed_parameter("predicate", "condition", version="0.18.9")
     def when(self, condition: IntoExpr) -> ChainedWhen:
         """
         Add another condition to the `when-then-otherwise` expression.
@@ -161,7 +164,7 @@ class ChainedThen(Expr):
         condition_pyexpr = parse_as_expression(condition)
         return ChainedWhen(self._chained_then.when(condition_pyexpr))
 
-    @deprecated_alias(expr="statement")
+    @deprecate_renamed_parameter("expr", "statement", version="0.18.9")
     def otherwise(self, statement: IntoExpr) -> Expr:
         """
         Define a default for the `when-then-otherwise` expression.

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -4,7 +4,10 @@ from typing import TYPE_CHECKING, Any, Iterable, overload
 
 import polars._reexport as pl
 import polars.functions as F
-from polars.utils.deprecation import deprecated_alias, issue_deprecation_warning
+from polars.utils.deprecation import (
+    deprecate_renamed_parameter,
+    issue_deprecation_warning,
+)
 
 if TYPE_CHECKING:
     from polars import Expr, Series
@@ -23,7 +26,7 @@ def all(
     ...
 
 
-@deprecated_alias(columns="exprs")
+@deprecate_renamed_parameter("columns", "exprs", version="0.18.7")
 def all(
     exprs: IntoExpr | Iterable[IntoExpr] | None = None, *more_exprs: IntoExpr
 ) -> Expr | bool | None:
@@ -111,7 +114,7 @@ def any(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
     ...
 
 
-@deprecated_alias(columns="exprs")
+@deprecate_renamed_parameter("columns", "exprs", version="0.18.7")
 def any(
     exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr
 ) -> Expr | bool | None:
@@ -370,7 +373,7 @@ def sum(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
     ...
 
 
-@deprecated_alias(column="exprs")
+@deprecate_renamed_parameter("column", "exprs", version="0.18.7")
 def sum(
     exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr
 ) -> Expr | int | float:
@@ -466,7 +469,7 @@ def cumsum(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
     ...
 
 
-@deprecated_alias(column="exprs")
+@deprecate_renamed_parameter("column", "exprs", version="0.18.7")
 def cumsum(
     exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr
 ) -> Expr | Series:

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -26,7 +26,10 @@ from polars.utils.convert import (
     _time_to_pl_time,
     _timedelta_to_pl_timedelta,
 )
-from polars.utils.deprecation import deprecated_alias, issue_deprecation_warning
+from polars.utils.deprecation import (
+    deprecate_renamed_parameter,
+    issue_deprecation_warning,
+)
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -1806,7 +1809,9 @@ def arg_sort_by(
     return wrap_expr(plr.arg_sort_by(exprs, descending))
 
 
-@deprecated_alias(common_subplan_elimination="comm_subplan_elim")
+@deprecate_renamed_parameter(
+    "common_subplan_elimination", "comm_subplan_elim", version="0.18.9"
+)
 def collect_all(
     lazy_frames: Sequence[LazyFrame],
     *,

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -11,7 +11,10 @@ from polars.utils._wrap import wrap_expr
 from polars.utils.convert import (
     _timedelta_to_pl_duration,
 )
-from polars.utils.deprecation import deprecated_alias, issue_deprecation_warning
+from polars.utils.deprecation import (
+    deprecate_renamed_parameter,
+    issue_deprecation_warning,
+)
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -66,7 +69,8 @@ def arange(
     ...
 
 
-@deprecated_alias(low="start", high="end")
+@deprecate_renamed_parameter("low", "start", version="0.18.0")
+@deprecate_renamed_parameter("high", "end", version="0.18.0")
 def arange(
     start: int | IntoExpr,
     end: int | IntoExpr,
@@ -370,7 +374,8 @@ def date_range(
     ...
 
 
-@deprecated_alias(low="start", high="end")
+@deprecate_renamed_parameter("low", "start", version="0.18.0")
+@deprecate_renamed_parameter("high", "end", version="0.18.0")
 def date_range(
     start: date | datetime | IntoExpr,
     end: date | datetime | IntoExpr,

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import polars._reexport as pl
 from polars.utils._parse_expr_input import parse_as_expression
-from polars.utils.deprecation import deprecated_alias
+from polars.utils.deprecation import deprecate_renamed_parameter
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from polars.type_aliases import IntoExpr
 
 
-@deprecated_alias(expr="condition")
+@deprecate_renamed_parameter("expr", "condition", version="0.18.9")
 def when(condition: IntoExpr) -> pl.When:
     """
     Start a `when-then-otherwise` expression.

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -6,14 +6,14 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any
 
 from polars.convert import from_arrow
-from polars.utils.deprecation import deprecated_alias
+from polars.utils.deprecation import deprecate_renamed_parameter
 
 if TYPE_CHECKING:
     from polars import DataFrame
     from polars.type_aliases import DbReadEngine
 
 
-@deprecated_alias(connection_uri="connection")
+@deprecate_renamed_parameter("connection_uri", "connection", version="0.18.9")
 def read_database(
     query: list[str] | str,
     connection: str,

--- a/py-polars/polars/io/pyarrow_dataset/functions.py
+++ b/py-polars/polars/io/pyarrow_dataset/functions.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from polars.io.pyarrow_dataset.anonymous_scan import _scan_pyarrow_dataset
-from polars.utils.deprecation import deprecated_name
+from polars.utils.deprecation import deprecate_renamed_function
 
 if TYPE_CHECKING:
     from polars import LazyFrame
@@ -55,7 +55,7 @@ def scan_pyarrow_dataset(
     return _scan_pyarrow_dataset(source, allow_pyarrow_filter=allow_pyarrow_filter)
 
 
-@deprecated_name(new_name="scan_pyarrow_dataset", version="0.16.10")
+@deprecate_renamed_function(new_name="scan_pyarrow_dataset", version="0.16.10")
 def scan_ds(ds: pa.dataset.Dataset, *, allow_pyarrow_filter: bool = True) -> LazyFrame:
     """
     Scan a pyarrow dataset.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -54,7 +54,10 @@ from polars.utils._parse_expr_input import (
 )
 from polars.utils._wrap import wrap_df, wrap_expr
 from polars.utils.convert import _timedelta_to_pl_duration
-from polars.utils.deprecation import deprecated_alias, issue_deprecation_warning
+from polars.utils.deprecation import (
+    deprecate_renamed_parameter,
+    issue_deprecation_warning,
+)
 from polars.utils.various import (
     _in_notebook,
     _prepare_row_count_args,
@@ -823,7 +826,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         return function(self, *args, **kwargs)
 
-    @deprecated_alias(common_subplan_elimination="comm_subplan_elim")
+    @deprecate_renamed_parameter(
+        "common_subplan_elimination", "comm_subplan_elim", version="0.18.9"
+    )
     def explain(
         self,
         *,
@@ -893,7 +898,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             return ldf.describe_optimized_plan()
         return self._ldf.describe_plan()
 
-    @deprecated_alias(common_subplan_elimination="comm_subplan_elim")
+    @deprecate_renamed_parameter(
+        "common_subplan_elimination", "comm_subplan_elim", version="0.18.9"
+    )
     def show_graph(
         self,
         *,
@@ -1312,7 +1319,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             self._ldf.bottom_k(k, by, descending, nulls_last, maintain_order)
         )
 
-    @deprecated_alias(common_subplan_elimination="comm_subplan_elim")
+    @deprecate_renamed_parameter(
+        "common_subplan_elimination", "comm_subplan_elim", version="0.18.9"
+    )
     def profile(
         self,
         *,
@@ -1460,7 +1469,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return df, timings
 
-    @deprecated_alias(common_subplan_elimination="comm_subplan_elim")
+    @deprecate_renamed_parameter(
+        "common_subplan_elimination", "comm_subplan_elim", version="0.18.9"
+    )
     def collect(
         self,
         *,
@@ -1722,7 +1733,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             maintain_order=maintain_order,
         )
 
-    @deprecated_alias(common_subplan_elimination="comm_subplan_elim")
+    @deprecate_renamed_parameter(
+        "common_subplan_elimination", "comm_subplan_elim", version="0.18.9"
+    )
     def fetch(
         self,
         n_rows: int = 500,

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -6,7 +6,7 @@ from polars.datatypes import Date
 from polars.series.utils import expr_dispatch
 from polars.utils._wrap import wrap_s
 from polars.utils.convert import _to_python_date, _to_python_datetime
-from polars.utils.deprecation import deprecated_alias
+from polars.utils.deprecation import deprecate_renamed_parameter
 
 if TYPE_CHECKING:
     import datetime as dt
@@ -171,7 +171,7 @@ class DateTimeNameSpace:
 
         """
 
-    @deprecated_alias(fmt="format")
+    @deprecate_renamed_parameter("fmt", "format", version="0.17.12")
     def strftime(self, format: str) -> Series:
         """
         Convert a Date/Time/Datetime column into a Utf8 column with the given format.

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -5,7 +5,10 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence
 from polars import functions as F
 from polars.series.utils import expr_dispatch
 from polars.utils._wrap import wrap_s
-from polars.utils.deprecation import deprecated_alias, redirect
+from polars.utils.deprecation import (
+    deprecate_renamed_methods,
+    deprecate_renamed_parameter,
+)
 
 if TYPE_CHECKING:
     from datetime import date, datetime, time
@@ -16,14 +19,19 @@ if TYPE_CHECKING:
 
 
 @expr_dispatch
-@redirect(
+@deprecate_renamed_methods(
     {
         "difference": "set_difference",
         "symmetric_difference": "set_symmetric_difference",
         "intersection": "set_intersection",
         "union": "set_union",
     },
-    version="0.18.10",
+    versions={
+        "difference": "0.18.10",
+        "symmetric_difference": "0.18.10",
+        "intersection": "0.18.10",
+        "union": "0.18.10",
+    },
 )
 class ListNameSpace:
     """Namespace for list related methods."""
@@ -456,7 +464,7 @@ class ListNameSpace:
 
         """
 
-    @deprecated_alias(name_generator="fields")
+    @deprecate_renamed_parameter("name_generator", "fields", version="0.17.12")
     def to_struct(
         self,
         n_field_strategy: ToStructStrategy = "first_non_null",

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -88,7 +88,10 @@ from polars.utils.convert import (
     _datetime_to_pl_timestamp,
     _time_to_pl_time,
 )
-from polars.utils.deprecation import deprecated_alias, issue_deprecation_warning
+from polars.utils.deprecation import (
+    deprecate_renamed_parameter,
+    issue_deprecation_warning,
+)
 from polars.utils.meta import get_index_type
 from polars.utils.various import (
     _is_generator,
@@ -1621,7 +1624,7 @@ class Series:
         """
         return wrap_df(self._s.to_dummies(separator))
 
-    @deprecated_alias(bins="breaks")
+    @deprecate_renamed_parameter("bins", "breaks", version="0.18.8")
     def cut(
         self,
         breaks: list[float],
@@ -1737,7 +1740,7 @@ class Series:
             return res.struct.rename_fields([break_point_label, category_label])
         return res
 
-    @deprecated_alias(quantiles="q")
+    @deprecate_renamed_parameter("quantiles", "q", version="0.18.8")
     def qcut(
         self,
         q: list[float] | int,
@@ -5244,7 +5247,7 @@ class Series:
 
         """
 
-    @deprecated_alias(frac="fraction")
+    @deprecate_renamed_parameter("frac", "fraction", version="0.17.0")
     def sample(
         self,
         n: int | None = None,

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -5,7 +5,10 @@ from typing import TYPE_CHECKING
 from polars import functions as F
 from polars.series.utils import expr_dispatch
 from polars.utils._wrap import wrap_s
-from polars.utils.deprecation import deprecated_alias, issue_deprecation_warning
+from polars.utils.deprecation import (
+    deprecate_renamed_parameter,
+    issue_deprecation_warning,
+)
 
 if TYPE_CHECKING:
     from polars import Expr, Series
@@ -168,7 +171,8 @@ class StringNameSpace:
 
         """
 
-    @deprecated_alias(datatype="dtype", fmt="format")
+    @deprecate_renamed_parameter("datatype", "dtype", version="0.17.3")
+    @deprecate_renamed_parameter("fmt", "format", version="0.17.3")
     def strptime(
         self,
         dtype: PolarsTemporalType,

--- a/py-polars/polars/sql/context.py
+++ b/py-polars/polars/sql/context.py
@@ -13,7 +13,10 @@ from polars.dataframe import DataFrame
 from polars.lazyframe import LazyFrame
 from polars.type_aliases import FrameType
 from polars.utils._wrap import wrap_ldf
-from polars.utils.deprecation import deprecated_alias, redirect
+from polars.utils.deprecation import (
+    deprecate_renamed_methods,
+    deprecate_renamed_parameter,
+)
 from polars.utils.various import _get_stack_locals
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -30,7 +33,9 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
 
-@redirect({"query": ("execute", {"eager": True})}, version="0.17.13")
+@deprecate_renamed_methods(
+    {"query": ("execute", {"eager": True})}, versions={"query": "0.17.13"}
+)
 class SQLContext(Generic[FrameType]):
     """
     Run SQL queries against DataFrame/LazyFrame data.
@@ -282,7 +287,7 @@ class SQLContext(Generic[FrameType]):
         res = wrap_ldf(self._ctxt.execute(query))
         return res.collect() if (eager or self._eager_execution) else res
 
-    @deprecated_alias(lf="frame")
+    @deprecate_renamed_parameter("lf", "frame", version="0.17.13")
     def register(self, name: str, frame: DataFrame | LazyFrame) -> Self:
         """
         Register a single frame as a table, using the given name.

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING
 
-from polars.utils.deprecation import deprecated_name
+from polars.utils.deprecation import deprecate_renamed_function
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import enable_string_cache as _enable_string_cache
@@ -118,7 +118,7 @@ def enable_string_cache(enable: bool) -> None:
     _enable_string_cache(enable)
 
 
-@deprecated_name(new_name="enable_string_cache", version="0.17.0")
+@deprecate_renamed_function(new_name="enable_string_cache", version="0.17.0")
 def toggle_string_cache(toggle: bool) -> None:
     """
     Enable (or disable) the global string cache.

--- a/py-polars/polars/utils/meta.py
+++ b/py-polars/polars/utils/meta.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING
 
-from polars.utils.deprecation import deprecated_name
+from polars.utils.deprecation import deprecate_renamed_function
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import get_index_type as _get_index_type
@@ -27,7 +27,7 @@ def get_index_type() -> DataTypeClass:
     return _get_index_type()
 
 
-@deprecated_name(new_name="get_index_type", version="16.12")
+@deprecate_renamed_function(new_name="get_index_type", version="16.12")
 def get_idx_type() -> DataTypeClass:
     """Get the datatype used for Polars indexing."""
     return get_index_type()

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from datetime import date, datetime
 from functools import reduce
 from inspect import signature
@@ -689,27 +688,6 @@ def test_rolling(fruits_cars: pl.DataFrame) -> None:
 
     assert cast(float, out_single_val_variance[0, "std"]) == 0.0
     assert cast(float, out_single_val_variance[0, "var"]) == 0.0
-
-
-def test_rolling_closed_decorator() -> None:
-    # no warning if we do not use by
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        _ = pl.col("a").rolling_min(2)
-
-    # if we pass in a by, but no closed, we expect a warning
-    with pytest.warns(FutureWarning):
-        _ = pl.col("a").rolling_min(2, by="b")
-
-    # if we pass in a by and a closed, we expect no warning
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        _ = pl.col("a").rolling_min(2, by="b", closed="left")
-
-    # regardless of the value
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        _ = pl.col("a").rolling_min(2, by="b", closed="right")
 
 
 def test_arr_namespace(fruits_cars: pl.DataFrame) -> None:


### PR DESCRIPTION
Partially addresses https://github.com/pola-rs/polars/issues/8004

Followup of #10147

Changes:
* Refactor the `deprecated_alias` util
  * Renamed to ~`deprecate_argument_name`~ `deprecate_renamed_parameter`
  * Only renames a single argument. Stack multiple decorators to rename multiple arguments.
  * Requires a `version` keyword argument to specify when the deprecation happened.
* Rename the `redirect` util to `deprecate_renamed_methods`. Now requires a `versions` keyword argument.
* Rename some other utils and improve docstrings.

I think this now gives us quite a solid set of utils for doing deprecations:
* `issue_deprecation_warning`
* `deprecate_function`
* `deprecate_renamed_function`
* `deprecate_renamed_parameter`
* `deprecate_renamed_methods`
* `deprecate_nonkeyword_arguments`

@alexander-beedie I would appreciate your input on these changes, as I know you've originally written most of these utils!

EDIT: ~Actually, probably the `deprecate_renamed_methods` decorator should also be a 'stacking' decorator redirecting only 1 method. Putting this on 'draft' for now until I have time to update.~ I can't figure this one out - I don't think it can be done in the current setup as a class decorator overwriting the `__getattr__` dunder. Let's leave it like this until we come up with a better approach.