### PR TITLE
fix(rust, python): prevent re-ordering of dict keys inside `.apply`

### DIFF
--- a/py-polars/tests/unit/operations/test_apply.py
+++ b/py-polars/tests/unit/operations/test_apply.py
@@ -381,3 +381,8 @@ def test_apply_shifted_chunks() -> None:
         "column_0": ["test", "test123", "tests"],
         "column_1": [None, "test", "test123"],
     }
+
+
+def test_apply_dict_order_10128() -> None:
+    df = pl.select(pl.lit("").apply(lambda x: {"c": 1, "b": 2, "a": 3}))
+    assert df.to_dict(False) == {"literal": [{"c": 1, "b": 2, "a": 3}]}


### PR DESCRIPTION
Attempts to fix #10128