### PR TITLE
feat(python): raise a better error message from `read_database` if not passed a string URI

### DIFF
--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -22,17 +22,17 @@ def read_database(
     partition_range: tuple[int, int] | None = None,
     partition_num: int | None = None,
     protocol: str | None = None,
-    engine: DbReadEngine = "connectorx",
+    engine: DbReadEngine | None = None,
 ) -> DataFrame:
     """
-    Read a SQL query into a DataFrame.
+    Read the results of a SQL query into a DataFrame.
 
     Parameters
     ----------
     query
         Raw SQL query (or queries).
     connection
-        A connectorx or ADBC connection URI that starts with the backend's
+        A connectorx or ADBC connection URI string that starts with the backend's
         driver name, for example:
 
         * "postgresql://user:pass@server:port/database"
@@ -47,7 +47,7 @@ def read_database(
         Backend-specific transfer protocol directive (connectorx); see connectorx
         documentation for more details.
     engine : {'connectorx', 'adbc'}
-        Selects the engine used for reading the database:
+        Selects the engine used for reading the database (defaulting to connectorx):
 
         * ``'connectorx'``
           Supports a range of databases, such as PostgreSQL, Redshift, MySQL, MariaDB,
@@ -111,6 +111,13 @@ def read_database(
     ... )  # doctest: +SKIP
 
     """  # noqa: W505
+    if not isinstance(connection, str):
+        raise ValueError(
+            f"Expect connection to be a URI string; found {type(connection)}"
+        )
+    elif engine is None:
+        engine = "connectorx"
+
     if engine == "connectorx":
         return _read_sql_connectorx(
             query,

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -112,7 +112,7 @@ def read_database(
 
     """  # noqa: W505
     if not isinstance(connection, str):
-        raise ValueError(
+        raise TypeError(
             f"Expect connection to be a URI string; found {type(connection)}"
         )
     elif engine is None:

--- a/py-polars/tests/unit/io/test_database.py
+++ b/py-polars/tests/unit/io/test_database.py
@@ -4,7 +4,7 @@ import sqlite3
 import sys
 from datetime import date
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -154,7 +154,7 @@ def test_read_database(
 def test_read_database_exceptions(
     engine: DbReadEngine,
     query: str,
-    database: str,
+    database: Any,
     errclass: type,
     err: str,
     tmp_path: Path,


### PR DESCRIPTION
Closes #10177.

Make sure it is clear that we are currently only supporting URI strings for the `connection` param. (Connection _objects_ are coming in the near future).

Also, sets the default engine value to `None` (while continuing to default to `connectorx`). This is prep for accepting user-instantiated connections, as we will be able to infer the engine directly where relevant (and having "engine='connectorx'" in won't make sense in conjunction with a user-supplied connection object).