### PR TITLE
fix(rust, python): block predicate pushdown is_in and null producing …

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
@@ -11,6 +11,11 @@ fn should_block_join_specific(ae: &AExpr, how: &JoinType) -> bool {
                 | FunctionExpr::FillNull { .. },
             ..
         } => join_produces_null(how),
+        #[cfg(feature = "is_in")]
+        Function {
+            function: FunctionExpr::Boolean(BooleanFunction::IsIn),
+            ..
+        } => join_produces_null(how),
         // joins can produce duplicates
         #[cfg(feature = "is_unique")]
         Function {


### PR DESCRIPTION
…join

fixes #10181
fixes #10193