### PR TITLE
chore(rust): Fix `make integration-tests` command

### DIFF
--- a/crates/Makefile
+++ b/crates/Makefile
@@ -57,7 +57,7 @@ test:  ## Run tests
 
 .PHONY: integration-tests
 integration-tests:  ## Run integration tests
-	cargo test --all-features --test it
+	cargo test --all-features --test it -p polars
 
 .PHONY: test-doc
 test-doc:  ## Run doc examples


### PR DESCRIPTION
Partially addresses #10199

Specifying `-p polars` makes the `make integration-tests` command behave exactly like before (since the Makefile used to be in the `polars` crate`). This has to do with how Cargo workspaces behave.

The failing integration tests mentioned in the linked issue are actually not new - this already happened in the old setup when running from the project root. We have to figure out exactly what happens there. I had looked at it before but had not figured it out yet.