### PR TITLE
feat(rust): added gcs to gcp cloud schema in polars-core::cloud #10206.

### DIFF
--- a/crates/polars-core/src/cloud.rs
+++ b/crates/polars-core/src/cloud.rs
@@ -79,7 +79,7 @@ impl FromStr for CloudType {
         Ok(match parsed.scheme() {
             "s3" => Self::Aws,
             "az" | "adl" | "abfs" => Self::Azure,
-            "gs" | "gcp" => Self::Gcp,
+            "gs" | "gcp" | "gcs" => Self::Gcp,
             "file" => Self::File,
             _ => polars_bail!(ComputeError: "unknown url scheme"),
         })


### PR DESCRIPTION
Closes #10206

Added gcs to cloud options parser.

```rust
        Ok(match parsed.scheme() {
            "s3" => Self::Aws,
            "az" | "adl" | "abfs" => Self::Azure,
            "gs" | "gcp" | "gcs" => Self::Gcp,
            "file" => Self::File,
            _ => polars_bail!(ComputeError: "unknown url scheme"),
        })
```

This does not fail on passing gcs as the schema and allows ParquetReader to treat it as a cloud option.