### PR TITLE
fix(python): avoid false positives from multiple `RETURN_VALUE` ops when checking `apply` lambdas/functions

### DIFF
--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -130,6 +130,7 @@ NOOP_TEST_CASES = [
     lambda x: x[0] + 1,
     lambda x: MY_LIST[x],
     lambda x: MY_DICT[1],
+    lambda x: "first" if x == 1 else "not first",
 ]
 
 


### PR DESCRIPTION
Closes #10210.

In Python <= 3.10 `if/else` constructs are modelled in the bytecode using multiple `RETURN_VALUE` ops; we don't support translation of such bytecode yet (and in Python >= 3.11 we spot `if/else` constructs differently, because of the `JUMP_FORWARD` op).

I have generically fixed this class of false positives, as we don't support translation of _any_ functions containing the type of branching implied by multiple `RETURN_VALUE` ops (`if/else` or otherwise).