### PR TITLE
chore: Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,7 @@ updates:
         update-types: ['version-update:semver-patch']
     commit-message:
       prefix: ci
-    labels: [skip-changelog]
-    reviewers: [stinodego]
+    labels: ['skip changelog']
 
   # Rust Polars
   - package-ecosystem: cargo
@@ -24,7 +23,7 @@ updates:
     commit-message:
       prefix: build(rust)
       prefix-development: chore(rust)
-    labels: [skip-changelog]
+    labels: ['skip changelog']
 
   # Python Polars
   - package-ecosystem: pip
@@ -36,8 +35,7 @@ updates:
         update-types: ['version-update:semver-patch']
     commit-message:
       prefix: chore(python)
-    labels: [skip-changelog]
-    reviewers: [stinodego]
+    labels: ['skip changelog']
 
   - package-ecosystem: cargo
     directory: py-polars
@@ -49,4 +47,4 @@ updates:
     commit-message:
       prefix: build(python)
       prefix-development: chore(python)
-    labels: [skip-changelog]
+    labels: ['skip changelog']

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1718,7 +1718,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.18.10"
+version = "0.18.11"
 dependencies = [
  "ahash",
  "built",


### PR DESCRIPTION
I changed the `skip changelog` label, forgot to update Dependabot.