### PR TITLE
docs(python): Use sphinx' `maximum_signature_line_length`

### DIFF
--- a/py-polars/docs/source/_static/css/custom.css
+++ b/py-polars/docs/source/_static/css/custom.css
@@ -1,17 +1,3 @@
-/* source: https://github.com/sphinx-doc/sphinx/issues/1514#issuecomment-742703082 */
-
-/* Newlines (\a) and spaces (\20) before each parameter */
-.sig-param::before {
-    content: "\a\20\20\20\20";
-    white-space: pre;
-}
-
-/* Newline after the last parameter (so the closing bracket is on a new line) */
-dt em.sig-param:last-of-type::after {
-    content: "\a";
-    white-space: pre;
-}
-
 /* To have blue background of width of the block (instead of width of content) */
 dl.class > dt:first-of-type {
     display: block !important;

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -60,6 +60,8 @@ extensions = [
     "sphinx_favicon",
 ]
 
+maximum_signature_line_length = 88
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
 


### PR DESCRIPTION
sphinx-doc/sphinx#11011 introduced a sphinx-native way to display parameters on separate lines, setting the value of [`maximum_signature_line_length`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-maximum_signature_line_length) in `conf.py`.

Merging would enable to remove the CSS hack introduced in #2207, and to have short signatures rendered on a single line.

Feel free to change the number of characters set by `maximum_signature_line_length`, I just set it to 88 because it's a common convention in python code files, but I have no strong opinion on what would be the "perfect" number.
 