### PR TITLE
feat(rust!,python): Extend `datetime` expression function with time zone/time unit parameters

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/crates/polars-plan/src/dsl/function_expr/datetime.rs
@@ -64,6 +64,11 @@ pub enum TemporalFunction {
         closed: ClosedWindow,
     },
     Combine(TimeUnit),
+    #[cfg(feature = "timezones")]
+    DatetimeFunction {
+        time_unit: TimeUnit,
+        time_zone: Option<TimeZone>,
+    },
 }
 
 impl Display for TemporalFunction {
@@ -105,6 +110,8 @@ impl Display for TemporalFunction {
             DateRanges { .. } => return write!(f, "date_ranges"),
             TimeRange { .. } => return write!(f, "time_range"),
             TimeRanges { .. } => return write!(f, "time_ranges"),
+            #[cfg(feature = "timezones")]
+            DatetimeFunction { .. } => return write!(f, "datetime"),
             Combine(_) => "combine",
         };
         write!(f, "dt.{s}")

--- a/crates/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/crates/polars-plan/src/dsl/function_expr/datetime.rs
@@ -64,7 +64,6 @@ pub enum TemporalFunction {
         closed: ClosedWindow,
     },
     Combine(TimeUnit),
-    #[cfg(feature = "timezones")]
     DatetimeFunction {
         time_unit: TimeUnit,
         time_zone: Option<TimeZone>,
@@ -110,7 +109,6 @@ impl Display for TemporalFunction {
             DateRanges { .. } => return write!(f, "date_ranges"),
             TimeRange { .. } => return write!(f, "time_range"),
             TimeRanges { .. } => return write!(f, "time_ranges"),
-            #[cfg(feature = "timezones")]
             DatetimeFunction { .. } => return write!(f, "datetime"),
             Combine(_) => "combine",
         };

--- a/crates/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/crates/polars-plan/src/dsl/function_expr/datetime.rs
@@ -67,6 +67,7 @@ pub enum TemporalFunction {
     DatetimeFunction {
         time_unit: TimeUnit,
         time_zone: Option<TimeZone>,
+        use_earliest: Option<bool>,
     },
 }
 

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -799,6 +799,13 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
                     None
                 )
             }
+            #[cfg(feature = "timezones")]
+            DatetimeFunction {
+                time_unit,
+                time_zone,
+            } => {
+                map_as_slice!(temporal::datetime, &time_unit, time_zone.as_deref())
+            }
         }
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -799,7 +799,6 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
                     None
                 )
             }
-            #[cfg(feature = "timezones")]
             DatetimeFunction {
                 time_unit,
                 time_zone,

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -802,8 +802,14 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             DatetimeFunction {
                 time_unit,
                 time_zone,
+                use_earliest,
             } => {
-                map_as_slice!(temporal::datetime, &time_unit, time_zone.as_deref())
+                map_as_slice!(
+                    temporal::datetime,
+                    &time_unit,
+                    time_zone.as_deref(),
+                    use_earliest
+                )
             }
         }
     }

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -96,6 +96,16 @@ impl FunctionExpr {
                             DataType::List(Box::new(DataType::Time)),
                         ));
                     }
+                    #[cfg(feature = "timezones")]
+                    DatetimeFunction {
+                        time_unit,
+                        time_zone,
+                    } => {
+                        return Ok(Field::new(
+                            "datetime",
+                            DataType::Datetime(*time_unit, time_zone.clone()),
+                        ));
+                    }
                     Combine(tu) => match mapper.with_same_dtype().unwrap().dtype {
                         DataType::Datetime(_, tz) => DataType::Datetime(*tu, tz),
                         DataType::Date => DataType::Datetime(*tu, None),

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -96,7 +96,6 @@ impl FunctionExpr {
                             DataType::List(Box::new(DataType::Time)),
                         ));
                     }
-                    #[cfg(feature = "timezones")]
                     DatetimeFunction {
                         time_unit,
                         time_zone,

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -99,6 +99,7 @@ impl FunctionExpr {
                     DatetimeFunction {
                         time_unit,
                         time_zone,
+                        use_earliest: _,
                     } => {
                         return Ok(Field::new(
                             "datetime",

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -6,6 +6,100 @@ use polars_time::prelude::*;
 
 use super::*;
 
+#[cfg(feature = "timezones")]
+pub(super) fn datetime(
+    s: &[Series],
+    time_unit: &TimeUnit,
+    time_zone: Option<&str>,
+) -> PolarsResult<Series> {
+    use polars_core::export::chrono::NaiveDate;
+    use polars_core::utils::CustomIterTools;
+
+    let year = &s[0];
+    let month = &s[1];
+    let day = &s[2];
+    let hour = &s[3];
+    let minute = &s[4];
+    let second = &s[5];
+    let microsecond = &s[6];
+
+    let max_len = s.iter().map(|s| s.len()).max().unwrap();
+
+    let mut year = year.cast(&DataType::Int32)?;
+    if year.len() < max_len {
+        year = year.new_from_index(0, max_len)
+    }
+    let year = year.i32()?;
+
+    let mut month = month.cast(&DataType::UInt32)?;
+    if month.len() < max_len {
+        month = month.new_from_index(0, max_len);
+    }
+    let month = month.u32()?;
+
+    let mut day = day.cast(&DataType::UInt32)?;
+    if day.len() < max_len {
+        day = day.new_from_index(0, max_len);
+    }
+    let day = day.u32()?;
+
+    let mut hour = hour.cast(&DataType::UInt32)?;
+    if hour.len() < max_len {
+        hour = hour.new_from_index(0, max_len);
+    }
+    let hour = hour.u32()?;
+
+    let mut minute = minute.cast(&DataType::UInt32)?;
+    if minute.len() < max_len {
+        minute = minute.new_from_index(0, max_len);
+    }
+    let minute = minute.u32()?;
+
+    let mut second = second.cast(&DataType::UInt32)?;
+    if second.len() < max_len {
+        second = second.new_from_index(0, max_len);
+    }
+    let second = second.u32()?;
+
+    let mut microsecond = microsecond.cast(&DataType::UInt32)?;
+    if microsecond.len() < max_len {
+        microsecond = microsecond.new_from_index(0, max_len);
+    }
+    let microsecond = microsecond.u32()?;
+
+    let ca: Int64Chunked = year
+        .into_iter()
+        .zip(month)
+        .zip(day)
+        .zip(hour)
+        .zip(minute)
+        .zip(second)
+        .zip(microsecond)
+        .map(|((((((y, m), d), h), mnt), s), us)| {
+            if let (Some(y), Some(m), Some(d), Some(h), Some(mnt), Some(s), Some(us)) =
+                (y, m, d, h, mnt, s, us)
+            {
+                NaiveDate::from_ymd_opt(y, m, d)
+                    .and_then(|nd| nd.and_hms_micro_opt(h, mnt, s, us))
+                    .map(|ndt| match time_unit {
+                        TimeUnit::Milliseconds => ndt.timestamp_millis(),
+                        TimeUnit::Microseconds => ndt.timestamp_micros(),
+                        TimeUnit::Nanoseconds => ndt.timestamp_nanos(),
+                    })
+            } else {
+                None
+            }
+        })
+        .collect_trusted();
+
+    let mut ca = ca.into_datetime(*time_unit, None);
+    ca = replace_time_zone(&ca, time_zone, None)?;
+
+    let mut s = ca.into_series();
+    s.rename("datetime");
+    Ok(s)
+}
+
 #[cfg(feature = "date_offset")]
 pub(super) fn date_offset(s: Series, offset: Duration) -> PolarsResult<Series> {
     let preserve_sortedness: bool;

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -6,7 +6,6 @@ use polars_time::prelude::*;
 
 use super::*;
 
-#[cfg(feature = "timezones")]
 pub(super) fn datetime(
     s: &[Series],
     time_unit: &TimeUnit,
@@ -92,8 +91,15 @@ pub(super) fn datetime(
         })
         .collect_trusted();
 
-    let mut ca = ca.into_datetime(*time_unit, None);
-    ca = replace_time_zone(&ca, time_zone, None)?;
+    let ca = match time_zone {
+        #[cfg(feature = "timezones")]
+        Some(_) => {
+            let mut ca = ca.into_datetime(*time_unit, None);
+            ca = replace_time_zone(&ca, time_zone, None)?;
+            ca
+        }
+        _ => ca.into_datetime(*time_unit, None),
+    };
 
     let mut s = ca.into_series();
     s.rename("datetime");

--- a/crates/polars-plan/src/dsl/functions/temporal.rs
+++ b/crates/polars-plan/src/dsl/functions/temporal.rs
@@ -103,11 +103,8 @@ impl DatetimeArgs {
 }
 
 /// Construct a column of `Datetime` from the provided [`DatetimeArgs`].
-#[cfg(feature = "temporal")]
+#[cfg(all(feature = "timezones", feature = "temporal"))]
 pub fn datetime(args: DatetimeArgs) -> Expr {
-    use polars_core::export::chrono::NaiveDate;
-    use polars_core::utils::CustomIterTools;
-
     let year = args.year;
     let month = args.month;
     let day = args.day;
@@ -115,79 +112,17 @@ pub fn datetime(args: DatetimeArgs) -> Expr {
     let minute = args.minute;
     let second = args.second;
     let microsecond = args.microsecond;
+    let time_unit = args.time_unit;
+    let time_zone = args.time_zone;
 
-    let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
-        assert_eq!(s.len(), 7);
-        let max_len = s.iter().map(|s| s.len()).max().unwrap();
-        let mut year = s[0].cast(&DataType::Int32)?;
-        if year.len() < max_len {
-            year = year.new_from_index(0, max_len)
-        }
-        let year = year.i32()?;
-        let mut month = s[1].cast(&DataType::UInt32)?;
-        if month.len() < max_len {
-            month = month.new_from_index(0, max_len);
-        }
-        let month = month.u32()?;
-        let mut day = s[2].cast(&DataType::UInt32)?;
-        if day.len() < max_len {
-            day = day.new_from_index(0, max_len);
-        }
-        let day = day.u32()?;
-        let mut hour = s[3].cast(&DataType::UInt32)?;
-        if hour.len() < max_len {
-            hour = hour.new_from_index(0, max_len);
-        }
-        let hour = hour.u32()?;
+    let input = vec![year, month, day, hour, minute, second, microsecond];
 
-        let mut minute = s[4].cast(&DataType::UInt32)?;
-        if minute.len() < max_len {
-            minute = minute.new_from_index(0, max_len);
-        }
-        let minute = minute.u32()?;
-
-        let mut second = s[5].cast(&DataType::UInt32)?;
-        if second.len() < max_len {
-            second = second.new_from_index(0, max_len);
-        }
-        let second = second.u32()?;
-
-        let mut microsecond = s[6].cast(&DataType::UInt32)?;
-        if microsecond.len() < max_len {
-            microsecond = microsecond.new_from_index(0, max_len);
-        }
-        let microsecond = microsecond.u32()?;
-
-        let ca: Int64Chunked = year
-            .into_iter()
-            .zip(month)
-            .zip(day)
-            .zip(hour)
-            .zip(minute)
-            .zip(second)
-            .zip(microsecond)
-            .map(|((((((y, m), d), h), mnt), s), us)| {
-                if let (Some(y), Some(m), Some(d), Some(h), Some(mnt), Some(s), Some(us)) =
-                    (y, m, d, h, mnt, s, us)
-                {
-                    NaiveDate::from_ymd_opt(y, m, d)
-                        .and_then(|nd| nd.and_hms_micro_opt(h, mnt, s, us))
-                        .map(|ndt| ndt.timestamp_micros())
-                } else {
-                    None
-                }
-            })
-            .collect_trusted();
-
-        let mut s = ca.into_datetime(TimeUnit::Microseconds, None).into_series();
-        s.rename("datetime");
-        Ok(Some(s))
-    }) as Arc<dyn SeriesUdf>);
-
-    Expr::AnonymousFunction {
-        input: vec![year, month, day, hour, minute, second, microsecond],
-        function,
-        output_type: GetOutput::from_type(DataType::Datetime(TimeUnit::Microseconds, None)),
+    Expr::Function {
+        input,
+        function: FunctionExpr::TemporalExpr(TemporalFunction::DatetimeFunction {
+            time_unit,
+            time_zone,
+        }),
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             allow_rename: true,

--- a/crates/polars-plan/src/dsl/functions/temporal.rs
+++ b/crates/polars-plan/src/dsl/functions/temporal.rs
@@ -38,6 +38,7 @@ pub struct DatetimeArgs {
     pub microsecond: Expr,
     pub time_unit: TimeUnit,
     pub time_zone: Option<TimeZone>,
+    pub use_earliest: Option<bool>,
 }
 
 impl Default for DatetimeArgs {
@@ -52,6 +53,7 @@ impl Default for DatetimeArgs {
             microsecond: lit(0),
             time_unit: TimeUnit::Microseconds,
             time_zone: None,
+            use_earliest: None,
         }
     }
 }
@@ -101,6 +103,13 @@ impl DatetimeArgs {
     pub fn with_time_zone(self, time_zone: Option<TimeZone>) -> Self {
         Self { time_zone, ..self }
     }
+    #[cfg(feature = "timezones")]
+    pub fn with_use_earliest(self, use_earliest: Option<bool>) -> Self {
+        Self {
+            use_earliest,
+            ..self
+        }
+    }
 }
 
 /// Construct a column of `Datetime` from the provided [`DatetimeArgs`].
@@ -115,6 +124,7 @@ pub fn datetime(args: DatetimeArgs) -> Expr {
     let microsecond = args.microsecond;
     let time_unit = args.time_unit;
     let time_zone = args.time_zone;
+    let use_earliest = args.use_earliest;
 
     let input = vec![year, month, day, hour, minute, second, microsecond];
 
@@ -123,6 +133,7 @@ pub fn datetime(args: DatetimeArgs) -> Expr {
         function: FunctionExpr::TemporalExpr(TemporalFunction::DatetimeFunction {
             time_unit,
             time_zone,
+            use_earliest,
         }),
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,

--- a/crates/polars-plan/src/dsl/functions/temporal.rs
+++ b/crates/polars-plan/src/dsl/functions/temporal.rs
@@ -97,13 +97,14 @@ impl DatetimeArgs {
     pub fn with_time_unit(self, time_unit: TimeUnit) -> Self {
         Self { time_unit, ..self }
     }
+    #[cfg(feature = "timezones")]
     pub fn with_time_zone(self, time_zone: Option<TimeZone>) -> Self {
         Self { time_zone, ..self }
     }
 }
 
 /// Construct a column of `Datetime` from the provided [`DatetimeArgs`].
-#[cfg(all(feature = "timezones", feature = "temporal"))]
+#[cfg(feature = "temporal")]
 pub fn datetime(args: DatetimeArgs) -> Expr {
     let year = args.year;
     let month = args.month;

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -47,9 +47,10 @@ class ExprDateTimeNameSpace:
             Offset the window
         use_earliest
             Determine how to deal with ambiguous datetimes:
-            - None (default): raise;
-            - True: use the earliest datetime;
-            - False: use the latest datetime.
+
+            - ``None`` (default): raise
+            - ``True``: use the earliest datetime
+            - ``False``: use the latest datetime
 
         Notes
         -----
@@ -1507,9 +1508,10 @@ class ExprDateTimeNameSpace:
             Time zone for the `Datetime` expression. Pass `None` to unset time zone.
         use_earliest
             Determine how to deal with ambiguous datetimes:
-            - None (default): raise;
-            - True: use the earliest datetime;
-            - False: use the latest datetime.
+
+            - ``None`` (default): raise
+            - ``True``: use the earliest datetime
+            - ``False``: use the latest datetime
 
         Examples
         --------

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -20,17 +20,20 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from polars import Expr, Series
-    from polars.type_aliases import IntoExpr, SchemaDict
+    from polars.type_aliases import IntoExpr, SchemaDict, TimeUnit
 
 
 def datetime_(
-    year: Expr | str | int,
-    month: Expr | str | int,
-    day: Expr | str | int,
-    hour: Expr | str | int | None = None,
-    minute: Expr | str | int | None = None,
-    second: Expr | str | int | None = None,
-    microsecond: Expr | str | int | None = None,
+    year: int | IntoExpr,
+    month: int | IntoExpr,
+    day: int | IntoExpr,
+    hour: int | IntoExpr | None = None,
+    minute: int | IntoExpr | None = None,
+    second: int | IntoExpr | None = None,
+    microsecond: int | IntoExpr | None = None,
+    *,
+    time_unit: TimeUnit = "us",
+    time_zone: str | None = None,
 ) -> Expr:
     """
     Create a Polars literal expression of type Datetime.
@@ -38,19 +41,23 @@ def datetime_(
     Parameters
     ----------
     year
-        column or literal.
+        Column or literal.
     month
-        column or literal, ranging from 1-12.
+        Column or literal, ranging from 1-12.
     day
-        column or literal, ranging from 1-31.
+        Column or literal, ranging from 1-31.
     hour
-        column or literal, ranging from 0-23.
+        Column or literal, ranging from 0-23.
     minute
-        column or literal, ranging from 0-59.
+        Column or literal, ranging from 0-59.
     second
-        column or literal, ranging from 0-59.
+        Column or literal, ranging from 0-59.
     microsecond
-        column or literal, ranging from 0-999999.
+        Column or literal, ranging from 0-999999.
+    time_unit : {'us', 'ms', 'ns'}
+        Time unit of the resulting expression.
+    time_zone,
+        Time zone of the resulting expression.
 
     Returns
     -------
@@ -80,6 +87,8 @@ def datetime_(
             minute,
             second,
             microsecond,
+            time_unit,
+            time_zone,
         )
     )
 

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -34,6 +34,7 @@ def datetime_(
     *,
     time_unit: TimeUnit = "us",
     time_zone: str | None = None,
+    use_earliest: bool | None = None,
 ) -> Expr:
     """
     Create a Polars literal expression of type Datetime.
@@ -56,8 +57,15 @@ def datetime_(
         Column or literal, ranging from 0-999999.
     time_unit : {'us', 'ms', 'ns'}
         Time unit of the resulting expression.
-    time_zone,
+    time_zone
         Time zone of the resulting expression.
+    use_earliest
+        Determine how to deal with ambiguous datetimes:
+
+        - ``None`` (default): raise
+        - ``True``: use the earliest datetime
+        - ``False``: use the latest datetime
+
 
     Returns
     -------
@@ -89,6 +97,7 @@ def datetime_(
             microsecond,
             time_unit,
             time_zone,
+            use_earliest,
         )
     )
 

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1158,9 +1158,10 @@ class DateTimeNameSpace:
             Time zone for the `Datetime` Series. Pass `None` to unset time zone.
         use_earliest
             Determine how to deal with ambiguous datetimes:
-            - None (default): raise;
-            - True: use the earliest datetime;
-            - False: use the latest datetime.
+
+            - ``None`` (default): raise
+            - ``True``: use the earliest datetime
+            - ``False``: use the latest datetime
 
         Examples
         --------
@@ -1611,9 +1612,10 @@ class DateTimeNameSpace:
             Offset the window
         use_earliest
             Determine how to deal with ambiguous datetimes:
-            - None (default): raise;
-            - True: use the earliest datetime;
-            - False: use the latest datetime.
+
+            - ``None`` (default): raise
+            - ``True``: use the earliest datetime
+            - ``False``: use the latest datetime
 
         Notes
         -----

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -188,7 +188,7 @@ pub fn cumreduce(lambda: PyObject, exprs: Vec<PyExpr>) -> PyExpr {
 
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
-#[pyo3(signature = (year, month, day, hour=None, minute=None, second=None, microsecond=None, time_unit=Wrap(TimeUnit::Microseconds), time_zone=None))]
+#[pyo3(signature = (year, month, day, hour=None, minute=None, second=None, microsecond=None, time_unit=Wrap(TimeUnit::Microseconds), time_zone=None, use_earliest=None))]
 pub fn datetime(
     year: PyExpr,
     month: PyExpr,
@@ -199,6 +199,7 @@ pub fn datetime(
     microsecond: Option<PyExpr>,
     time_unit: Wrap<TimeUnit>,
     time_zone: Option<TimeZone>,
+    use_earliest: Option<bool>,
 ) -> PyExpr {
     let year = year.inner;
     let month = month.inner;
@@ -216,6 +217,7 @@ pub fn datetime(
         microsecond,
         time_unit,
         time_zone,
+        use_earliest,
     };
     dsl::datetime(args).into()
 }

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -186,7 +186,9 @@ pub fn cumreduce(lambda: PyObject, exprs: Vec<PyExpr>) -> PyExpr {
     dsl::cumreduce_exprs(func, exprs).into()
 }
 
+#[allow(clippy::too_many_arguments)]
 #[pyfunction]
+#[pyo3(signature = (year, month, day, hour=None, minute=None, second=None, microsecond=None, time_unit=Wrap(TimeUnit::Microseconds), time_zone=None))]
 pub fn datetime(
     year: PyExpr,
     month: PyExpr,
@@ -195,12 +197,14 @@ pub fn datetime(
     minute: Option<PyExpr>,
     second: Option<PyExpr>,
     microsecond: Option<PyExpr>,
+    time_unit: Wrap<TimeUnit>,
+    time_zone: Option<TimeZone>,
 ) -> PyExpr {
     let year = year.inner;
     let month = month.inner;
     let day = day.inner;
-
     set_unwrapped_or_0!(hour, minute, second, microsecond);
+    let time_unit = time_unit.0;
 
     let args = DatetimeArgs {
         year,
@@ -210,6 +214,8 @@ pub fn datetime(
         minute,
         second,
         microsecond,
+        time_unit,
+        time_zone,
     };
     dsl::datetime(args).into()
 }

--- a/py-polars/tests/unit/functions/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/test_as_datatype.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import sys
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
@@ -9,14 +8,12 @@ import pytest
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
-if sys.version_info >= (3, 9):
-    from zoneinfo import ZoneInfo
-else:
-    # Import from submodule due to typing issue with backports.zoneinfo package:
-    # https://github.com/pganssle/zoneinfo/issues/125
-    from backports.zoneinfo._zoneinfo import ZoneInfo
 if TYPE_CHECKING:
+    from zoneinfo import ZoneInfo
+
     from polars.type_aliases import TimeUnit
+else:
+    from polars.utils.convert import get_zoneinfo as ZoneInfo
 
 
 def test_date_datetime() -> None:

--- a/py-polars/tests/unit/functions/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/test_as_datatype.py
@@ -1,9 +1,15 @@
+from __future__ import annotations
+
 from datetime import date, datetime
+from typing import TYPE_CHECKING
 
 import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.type_aliases import TimeUnit
 
 
 def test_date_datetime() -> None:
@@ -22,6 +28,25 @@ def test_date_datetime() -> None:
     )
     assert_series_equal(out["date"], df["day"].rename("date"))
     assert_series_equal(out["h2"], df["hour"].rename("h2"))
+
+
+@pytest.mark.parametrize("time_unit", ["ms", "us", "ns"])
+def test_datetime_time_unit(time_unit: TimeUnit) -> None:
+    result = pl.datetime(2022, 1, 2, time_unit=time_unit)
+
+    assert pl.select(result.dt.year()).item() == 2022
+    assert pl.select(result.dt.month()).item() == 1
+    assert pl.select(result.dt.day()).item() == 2
+
+
+@pytest.mark.parametrize("time_zone", [None, "Europe/Amsterdam", "UTC"])
+def test_datetime_time_zone(time_zone: str | None) -> None:
+    result = pl.datetime(2022, 1, 2, 10, time_zone=time_zone)
+
+    assert pl.select(result.dt.year()).item() == 2022
+    assert pl.select(result.dt.month()).item() == 1
+    assert pl.select(result.dt.day()).item() == 2
+    assert pl.select(result.dt.hour()).item() == 10
 
 
 def test_time() -> None:


### PR DESCRIPTION
Closes [#7416](https://github.com/pola-rs/polars/issues/7416)

Changes:
* Add `time_unit`, `time_zone` and `use_earliest` arguments to the `datetime` expression function
* On the Rust side, move everything into the standard expression architecture.

Paging @MarcoGorelli for a review 😄 