### PR TITLE
depr(python): Deprecate `avg` alias for `mean`

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -496,6 +496,9 @@ def avg(column: str | Series) -> Expr | float:
     """
     Alias for mean.
 
+    .. deprecated:: 0.18.12
+        Use ``mean`` instead.
+
     Examples
     --------
     >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -502,7 +502,7 @@ def avg(column: str | Series) -> Expr | float:
     Examples
     --------
     >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
-    >>> df.select(pl.avg("a"))
+    >>> df.select(pl.avg("a"))  # doctest: +SKIP
     shape: (1, 1)
     ┌─────┐
     │ a   │

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -27,6 +27,7 @@ from polars.utils.convert import (
     _timedelta_to_pl_timedelta,
 )
 from polars.utils.deprecation import (
+    deprecate_function,
     deprecate_renamed_parameter,
     issue_deprecation_warning,
 )
@@ -488,6 +489,9 @@ def avg(column: Series) -> float:
     ...
 
 
+@deprecate_function(
+    "Please use `mean` instead, for which `avg` is an alias.", version="0.18.12"
+)
 def avg(column: str | Series) -> Expr | float:
     """
     Alias for mean.


### PR DESCRIPTION
Closes #6204