### PR TITLE
feat(python): add entry point to the Consortium DataFrame API

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1235,6 +1235,26 @@ class DataFrame:
             )
         return self.to_arrow().__dataframe__(nan_as_null, allow_copy)
 
+    def __dataframe_consortium_standard__(
+        self, /, *, api_version: str | None = None
+    ) -> Any:
+        """
+        Provide entry point to the Consortium DataFrame Standard API.
+
+        This is developed and maintained outside of polars.
+        Please report any issues to https://github.com/data-apis/dataframe-api-compat.
+        """
+        try:
+            from dataframe_api_compat import polars_standard  # type: ignore[import]
+        except ModuleNotFoundError:
+            raise ImportError(
+                "`dataframe-api-compat` package is required for using the "
+                "Consortium DataFrame Standard API."
+            ) from None
+        return polars_standard.convert_to_standard_compliant_dataframe(
+            self, api_version=api_version
+        )
+
     def _comp(self, other: Any, op: ComparisonOperator) -> DataFrame:
         """Compare a DataFrame with another object."""
         if isinstance(other, DataFrame):

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -49,11 +49,11 @@ from polars.datatypes import (
     py_type_to_dtype,
 )
 from polars.dependencies import (
-    _DATAFRAME_API_COMPAT_AVAILABLE,
     _PYARROW_AVAILABLE,
     _check_for_numpy,
     _check_for_pandas,
     _check_for_pyarrow,
+    dataframe_api_compat,
 )
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
@@ -1245,14 +1245,7 @@ class DataFrame:
         This is developed and maintained outside of polars.
         Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
-        if _DATAFRAME_API_COMPAT_AVAILABLE:
-            from dataframe_api_compat import polars_standard  # type: ignore[import]
-        else:
-            raise ModuleNotFoundError(
-                "`dataframe-api-compat` package is required for using the "
-                "Consortium DataFrame Standard API."
-            ) from None
-        return polars_standard.convert_to_standard_compliant_dataframe(
+        return dataframe_api_compat.polars_standard.convert_to_standard_compliant_dataframe(
             self, api_version=api_version
         )
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1237,7 +1237,7 @@ class DataFrame:
         return self.to_arrow().__dataframe__(nan_as_null, allow_copy)
 
     def __dataframe_consortium_standard__(
-        self, /, *, api_version: str | None = None
+        self, *, api_version: str | None = None
     ) -> Any:
         """
         Provide entry point to the Consortium DataFrame Standard API.

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -49,6 +49,7 @@ from polars.datatypes import (
     py_type_to_dtype,
 )
 from polars.dependencies import (
+    _DATAFRAME_API_COMPAT_AVAILABLE,
     _PYARROW_AVAILABLE,
     _check_for_numpy,
     _check_for_pandas,
@@ -1244,10 +1245,10 @@ class DataFrame:
         This is developed and maintained outside of polars.
         Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
-        try:
+        if _DATAFRAME_API_COMPAT_AVAILABLE:
             from dataframe_api_compat import polars_standard  # type: ignore[import]
-        except ModuleNotFoundError:
-            raise ImportError(
+        else:
+            raise ModuleNotFoundError(
                 "`dataframe-api-compat` package is required for using the "
                 "Consortium DataFrame Standard API."
             ) from None

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -151,6 +151,7 @@ if TYPE_CHECKING:
     import pickle
     import subprocess
 
+    import dataframe_api_compat
     import deltalake
     import fsspec
     import hypothesis

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -8,6 +8,7 @@ from importlib.util import find_spec
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, ClassVar, Hashable, cast
 
+_DATAFRAME_API_COMPAT_AVAILABLE = True
 _DELTALAKE_AVAILABLE = True
 _FSSPEC_AVAILABLE = True
 _HYPOTHESIS_AVAILABLE = True
@@ -171,6 +172,9 @@ else:
     subprocess, _ = _lazy_import("subprocess")
 
     # heavy/optional third party libs
+    dataframe_api_compat, _DATAFRAME_API_COMPAT_AVAILABLE = _lazy_import(
+        "dataframe-api-compat"
+    )
     deltalake, _DELTALAKE_AVAILABLE = _lazy_import("deltalake")
     fsspec, _FSSPEC_AVAILABLE = _lazy_import("fsspec")
     hypothesis, _HYPOTHESIS_AVAILABLE = _lazy_import("hypothesis")
@@ -219,6 +223,7 @@ __all__ = [
     "pickle",
     "subprocess",
     # lazy-load third party libs
+    "dataframe_api_compat",
     "deltalake",
     "fsspec",
     "numpy",

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -173,7 +173,7 @@ else:
 
     # heavy/optional third party libs
     dataframe_api_compat, _DATAFRAME_API_COMPAT_AVAILABLE = _lazy_import(
-        "dataframe-api-compat"
+        "dataframe_api_compat"
     )
     deltalake, _DELTALAKE_AVAILABLE = _lazy_import("deltalake")
     fsspec, _FSSPEC_AVAILABLE = _lazy_import("fsspec")

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -623,7 +623,7 @@ class LazyFrame:
         return self._ldf.schema()
 
     def __dataframe_consortium_standard__(
-        self, /, *, api_version: str | None = None
+        self, *, api_version: str | None = None
     ) -> Any:
         """
         Provide entry point to the Consortium DataFrame Standard API.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -622,6 +622,26 @@ class LazyFrame:
         """
         return self._ldf.schema()
 
+    def __dataframe_consortium_standard__(
+        self, /, *, api_version: str | None = None
+    ) -> Any:
+        """
+        Provide entry point to the Consortium DataFrame Standard API.
+
+        This is developed and maintained outside of polars.
+        Please report any issues to https://github.com/data-apis/dataframe-api-compat.
+        """
+        try:
+            from dataframe_api_compat import polars_standard  # type: ignore[import]
+        except ModuleNotFoundError:
+            raise ImportError(
+                "`dataframe-api-compat` package is required for using the "
+                "Consortium DataFrame Standard API."
+            ) from None
+        return polars_standard.convert_to_standard_compliant_dataframe(
+            self, api_version=api_version
+        )
+
     @property
     def width(self) -> int:
         """

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -42,7 +42,7 @@ from polars.datatypes import (
     Utf8,
     py_type_to_dtype,
 )
-from polars.dependencies import _DATAFRAME_API_COMPAT_AVAILABLE, subprocess
+from polars.dependencies import dataframe_api_compat, subprocess
 from polars.io._utils import _is_local_file
 from polars.io.ipc.anonymous_scan import _scan_ipc_fsspec
 from polars.io.parquet.anonymous_scan import _scan_parquet_fsspec
@@ -631,14 +631,7 @@ class LazyFrame:
         This is developed and maintained outside of polars.
         Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
-        if _DATAFRAME_API_COMPAT_AVAILABLE:
-            from dataframe_api_compat import polars_standard  # type: ignore[import]
-        else:
-            raise ModuleNotFoundError(
-                "`dataframe-api-compat` package is required for using the "
-                "Consortium DataFrame Standard API."
-            ) from None
-        return polars_standard.convert_to_standard_compliant_dataframe(
+        return dataframe_api_compat.polars_standard.convert_to_standard_compliant_dataframe(
             self, api_version=api_version
         )
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -42,7 +42,7 @@ from polars.datatypes import (
     Utf8,
     py_type_to_dtype,
 )
-from polars.dependencies import subprocess
+from polars.dependencies import _DATAFRAME_API_COMPAT_AVAILABLE, subprocess
 from polars.io._utils import _is_local_file
 from polars.io.ipc.anonymous_scan import _scan_ipc_fsspec
 from polars.io.parquet.anonymous_scan import _scan_parquet_fsspec
@@ -631,10 +631,10 @@ class LazyFrame:
         This is developed and maintained outside of polars.
         Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
-        try:
+        if _DATAFRAME_API_COMPAT_AVAILABLE:
             from dataframe_api_compat import polars_standard  # type: ignore[import]
-        except ModuleNotFoundError:
-            raise ImportError(
+        else:
+            raise ModuleNotFoundError(
                 "`dataframe-api-compat` package is required for using the "
                 "Consortium DataFrame Standard API."
             ) from None

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -55,6 +55,7 @@ from polars.datatypes import (
     supported_numpy_char_code,
 )
 from polars.dependencies import (
+    _DATAFRAME_API_COMPAT_AVAILABLE,
     _PYARROW_AVAILABLE,
     _check_for_numpy,
     _check_for_pandas,
@@ -1128,10 +1129,10 @@ class Series:
         This is developed and maintained outside of polars.
         Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
-        try:
+        if _DATAFRAME_API_COMPAT_AVAILABLE:
             from dataframe_api_compat import polars_standard  # type: ignore[import]
-        except ModuleNotFoundError:
-            raise ImportError(
+        else:
+            raise ModuleNotFoundError(
                 "`dataframe-api-compat` package is required for using the "
                 "Consortium DataFrame Standard API."
             ) from None

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -55,11 +55,11 @@ from polars.datatypes import (
     supported_numpy_char_code,
 )
 from polars.dependencies import (
-    _DATAFRAME_API_COMPAT_AVAILABLE,
     _PYARROW_AVAILABLE,
     _check_for_numpy,
     _check_for_pandas,
     _check_for_pyarrow,
+    dataframe_api_compat,
 )
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
@@ -1127,15 +1127,10 @@ class Series:
         This is developed and maintained outside of polars.
         Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
-        if _DATAFRAME_API_COMPAT_AVAILABLE:
-            from dataframe_api_compat import polars_standard  # type: ignore[import]
-        else:
-            raise ModuleNotFoundError(
-                "`dataframe-api-compat` package is required for using the "
-                "Consortium DataFrame Standard API."
-            ) from None
-        return polars_standard.convert_to_standard_compliant_column(
-            self, api_version=api_version
+        return (
+            dataframe_api_compat.polars_standard.convert_to_standard_compliant_column(
+                self, api_version=api_version
+            )
         )
 
     def _repr_html_(self) -> str:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1121,7 +1121,7 @@ class Series:
             )
 
     def __column_consortium_standard__(
-        self, /, *, api_version: str | None = None
+        self, *, api_version: str | None = None
     ) -> Any:
         """
         Provide entry point to the Consortium DataFrame Standard API.

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1119,6 +1119,26 @@ class Series:
                 f" `{method}`."
             )
 
+    def __column_consortium_standard__(
+        self, /, *, api_version: str | None = None
+    ) -> Any:
+        """
+        Provide entry point to the Consortium DataFrame Standard API.
+
+        This is developed and maintained outside of polars.
+        Please report any issues to https://github.com/data-apis/dataframe-api-compat.
+        """
+        try:
+            from dataframe_api_compat import polars_standard  # type: ignore[import]
+        except ModuleNotFoundError:
+            raise ImportError(
+                "`dataframe-api-compat` package is required for using the "
+                "Consortium DataFrame Standard API."
+            ) from None
+        return polars_standard.convert_to_standard_compliant_column(
+            self, api_version=api_version
+        )
+
     def _repr_html_(self) -> str:
         """Format output data in HTML for display in Jupyter Notebooks."""
         return self.to_frame()._repr_html_(from_series=True)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1120,9 +1120,7 @@ class Series:
                 f" `{method}`."
             )
 
-    def __column_consortium_standard__(
-        self, *, api_version: str | None = None
-    ) -> Any:
+    def __column_consortium_standard__(self, *, api_version: str | None = None) -> Any:
         """
         Provide entry point to the Consortium DataFrame Standard API.
 

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -5,6 +5,7 @@
 --prefer-binary
 
 # Dependencies
+dataframe-api-compat
 deltalake >= 0.10.0
 numpy
 pandas

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -5,7 +5,7 @@
 --prefer-binary
 
 # Dependencies
-dataframe-api-compat
+dataframe-api-compat >= 0.1.6
 deltalake >= 0.10.0
 numpy
 pandas

--- a/py-polars/tests/unit/test_consortium_standard.py
+++ b/py-polars/tests/unit/test_consortium_standard.py
@@ -4,11 +4,7 @@ Test some basic methods of the dataframe consortium standard.
 Full testing is done at https://github.com/data-apis/dataframe-api-compat,
 this is just to check that the entry point works as expected.
 """
-import pytest
-
 import polars as pl
-
-pytest.importorskip("dataframe_api_compat")
 
 
 def test_dataframe() -> None:

--- a/py-polars/tests/unit/test_consortium_standard.py
+++ b/py-polars/tests/unit/test_consortium_standard.py
@@ -8,20 +8,20 @@ import pytest
 
 import polars as pl
 
-pytest.importorskip("dataframe-api-compat")
+pytest.importorskip("dataframe_api_compat")
 
 
 def test_dataframe() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    df = df.__dataframe_consortium_standard__()
+    df_pl = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df = df_pl.__dataframe_consortium_standard__()
     result = df.get_column_names()
     expected = ["a", "b"]
     assert result == expected
 
 
 def test_lazyframe() -> None:
-    df = pl.LazyFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
-    df = df.__dataframe_consortium_standard__()
+    df_pl = pl.LazyFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df = df_pl.__dataframe_consortium_standard__()
     result = df.get_column_names()
     expected = ["a", "b"]
     assert result == expected
@@ -29,7 +29,7 @@ def test_lazyframe() -> None:
 
 def test_series() -> None:
     ser = pl.Series([1, 2, 3])
-    ser = ser.__column_consortium_standard__()
-    result = ser.get_value(1)
+    col = ser.__column_consortium_standard__()
+    result = col.get_value(1)
     expected = 2
     assert result == expected

--- a/py-polars/tests/unit/test_consortium_standard.py
+++ b/py-polars/tests/unit/test_consortium_standard.py
@@ -1,0 +1,35 @@
+"""
+Test some basic methods of the dataframe consortium standard.
+
+Full testing is done at https://github.com/data-apis/dataframe-api-compat,
+this is just to check that the entry point works as expected.
+"""
+import pytest
+
+import polars as pl
+
+pytest.importorskip("dataframe-api-compat")
+
+
+def test_dataframe() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df = df.__dataframe_consortium_standard__()
+    result = df.get_column_names()
+    expected = ["a", "b"]
+    assert result == expected
+
+
+def test_lazyframe() -> None:
+    df = pl.LazyFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df = df.__dataframe_consortium_standard__()
+    result = df.get_column_names()
+    expected = ["a", "b"]
+    assert result == expected
+
+
+def test_series() -> None:
+    ser = pl.Series([1, 2, 3])
+    ser = ser.__column_consortium_standard__()
+    result = ser.get_value(1)
+    expected = 2
+    assert result == expected


### PR DESCRIPTION
Here's an entry point to the Consortium's DataFrame API Standard

It enables dataframe-consuming libraries to just check for a `__dataframe_consortium_standard__` attribute on a dataframe they receive - then, so long as they stick to the spec defined in https://data-apis.org/dataframe-api/draft/index.html, then their code should work the same way, regardless of what the original backing dataframe library was

Use-case: currently, scikit-learn is very keen on using this, as they're not keen on having to depend on pyarrow (which will become required in pandas), and the interchange protocol only goes so far (e.g. a way to convert to ndarray is out-of-scope for that). If we can get this to work there, then other use cases may emerge

**Maintenance burden on polars: none** (unless, once it gains traction, you want it upstreamed). The compat package will be developed, maintained, and tested by the consortium and community of libraries which use it. It is up to consuming libraries to set a minimum version of the dataframe-api-compat package

The current spec should be enough for scikit-learn, and having this entry point makes it easier to move forwards with development (without monkey-patching / special-casing)