### PR TITLE
feat(python): add "batch_size" to `scan_pyarrow_dataset` parameters

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3065,7 +3065,7 @@ class DataFrame:
         statistics: bool = False,
         row_group_size: int | None = None,
         use_pyarrow: bool = False,
-        pyarrow_options: dict[str, object] | None = None,
+        pyarrow_options: dict[str, Any] | None = None,
     ) -> None:
         """
         Write to Apache Parquet file.

--- a/py-polars/polars/io/pyarrow_dataset/functions.py
+++ b/py-polars/polars/io/pyarrow_dataset/functions.py
@@ -11,7 +11,10 @@ if TYPE_CHECKING:
 
 
 def scan_pyarrow_dataset(
-    source: pa.dataset.Dataset, *, allow_pyarrow_filter: bool = True
+    source: pa.dataset.Dataset,
+    *,
+    allow_pyarrow_filter: bool = True,
+    batch_size: int | None = None,
 ) -> LazyFrame:
     """
     Scan a pyarrow dataset.
@@ -26,6 +29,8 @@ def scan_pyarrow_dataset(
         Allow predicates to be pushed down to pyarrow. This can lead to different
         results if comparisons are done with null values as pyarrow handles this
         different than polars does.
+    batch_size
+        The maximum row count for scanned pyarrow record batches.
 
     Warnings
     --------
@@ -52,7 +57,11 @@ def scan_pyarrow_dataset(
     └───────┴────────┴────────────┘
 
     """
-    return _scan_pyarrow_dataset(source, allow_pyarrow_filter=allow_pyarrow_filter)
+    return _scan_pyarrow_dataset(
+        source,
+        allow_pyarrow_filter=allow_pyarrow_filter,
+        batch_size=batch_size,
+    )
 
 
 @deprecate_renamed_function(new_name="scan_pyarrow_dataset", version="0.16.10")


### PR DESCRIPTION
Closes #10162. 

Can have an outsize impact on performance in certain cases; definitely useful to expose it to the caller so they can adjust it as needed.