### PR TITLE
docs(rust): fix dead links in Rust documentation

### DIFF
--- a/crates/polars-core/src/chunked_array/object/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/mod.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 
 use arrow::bitmap::Bitmap;
 
-pub use crate::prelude::*;
+use crate::prelude::*;
 
 pub mod builder;
 #[cfg(feature = "object")]

--- a/crates/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/crates/polars-core/src/chunked_array/ops/fill_null.rs
@@ -22,7 +22,7 @@ impl Series {
     /// * Max fill (replace None with the maximum of the whole array)
     ///
     /// *NOTE: If you want to fill the Nones with a value use the
-    /// [`fill_null` operation on `ChunkedArray<T>`](crate::chunked_array::ops::ChunkFillNull)*.
+    /// [`fill_null` operation on `ChunkedArray<T>`](crate::chunked_array::ops::ChunkFillNullValue)*.
     ///
     /// # Example
     ///

--- a/crates/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/crates/polars-core/src/chunked_array/ops/fill_null.rs
@@ -22,7 +22,7 @@ impl Series {
     /// * Max fill (replace None with the maximum of the whole array)
     ///
     /// *NOTE: If you want to fill the Nones with a value use the
-    /// [`fill_null` operation on `ChunkedArray<T>`](../chunked_array/ops/trait.ChunkFillNull.html)*.
+    /// [`fill_null` operation on `ChunkedArray<T>`](crate::chunked_array::ops::ChunkFillNull)*.
     ///
     /// # Example
     ///

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -4,7 +4,7 @@ use polars_arrow::prelude::QuantileInterpolOptions;
 
 pub use self::take::*;
 #[cfg(feature = "object")]
-use crate::chunked_array::object::ObjectType;
+use crate::datatypes::ObjectType;
 use crate::prelude::*;
 
 #[cfg(feature = "abs")]
@@ -284,7 +284,7 @@ pub trait ChunkSet<'a, A, B> {
 
 /// Cast `ChunkedArray<T>` to `ChunkedArray<N>`
 pub trait ChunkCast {
-    /// Cast a `[ChunkedArray]` to `[DataType]`
+    /// Cast a [`ChunkedArray`] to [`DataType`]
     fn cast(&self, data_type: &DataType) -> PolarsResult<Series>;
 
     /// Does not check if the cast is a valid one and may over/underflow
@@ -417,8 +417,7 @@ pub trait ChunkVar<T> {
     }
 }
 
-/// Compare [Series](series/series/enum.Series.html)
-/// and [ChunkedArray](series/chunked_array/struct.ChunkedArray.html)'s and get a `boolean` mask that
+/// Compare [`Series`] and [`ChunkedArray`]'s and get a `boolean` mask that
 /// can be used to filter rows.
 ///
 /// # Example

--- a/crates/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -6,7 +6,7 @@ use std::hash::Hash;
 use arrow::bitmap::MutableBitmap;
 
 #[cfg(feature = "object")]
-use crate::chunked_array::object::ObjectType;
+use crate::datatypes::ObjectType;
 use crate::datatypes::PlHashSet;
 use crate::frame::groupby::hashing::HASHMAP_INIT_SIZE;
 use crate::frame::groupby::GroupsProxy;

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -2507,7 +2507,7 @@ impl DataFrame {
     /// * Min fill (replace None with the minimum of the whole array)
     /// * Max fill (replace None with the maximum of the whole array)
     ///
-    /// See the method on [Series](crate::series::SeriesTrait::fill_null) for more info on the `fill_null` operation.
+    /// See the method on [Series](crate::series::Series::fill_null) for more info on the `fill_null` operation.
     pub fn fill_null(&self, strategy: FillNullStrategy) -> PolarsResult<Self> {
         let col = self.try_apply_columns_par(&|s| s.fill_null(strategy))?;
 

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -2492,7 +2492,7 @@ impl DataFrame {
     /// Shift the values by a given period and fill the parts that will be empty due to this operation
     /// with `Nones`.
     ///
-    /// See the method on [Series](../series/trait.SeriesTrait.html#method.shift) for more info on the `shift` operation.
+    /// See the method on [Series](crate::series::SeriesTrait::shift) for more info on the `shift` operation.
     #[must_use]
     pub fn shift(&self, periods: i64) -> Self {
         let col = self.apply_columns_par(&|s| s.shift(periods));
@@ -2507,7 +2507,7 @@ impl DataFrame {
     /// * Min fill (replace None with the minimum of the whole array)
     /// * Max fill (replace None with the maximum of the whole array)
     ///
-    /// See the method on [Series](../series/trait.SeriesTrait.html#method.fill_null) for more info on the `fill_null` operation.
+    /// See the method on [Series](crate::series::SeriesTrait::fill_null) for more info on the `fill_null` operation.
     pub fn fill_null(&self, strategy: FillNullStrategy) -> PolarsResult<Self> {
         let col = self.try_apply_columns_par(&|s| s.fill_null(strategy))?;
 

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -3,8 +3,8 @@ use std::borrow::Cow;
 
 use ahash::RandomState;
 
-use crate::chunked_array::object::compare_inner::{IntoPartialEqInner, PartialEqInner};
 use crate::chunked_array::object::PolarsObjectSafe;
+use crate::chunked_array::ops::compare_inner::{IntoPartialEqInner, PartialEqInner};
 use crate::frame::groupby::{GroupsProxy, IntoGroupsProxy};
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -40,7 +40,7 @@ use crate::POOL;
 /// Most of the available functions are defined in the [SeriesTrait trait](crate::series::SeriesTrait).
 ///
 /// The `Series` struct consists
-/// of typed [ChunkedArray](../chunked_array/struct.ChunkedArray.html)'s. To quickly cast
+/// of typed [ChunkedArray](crate::chunked_array::ChunkedArray)'s. To quickly cast
 /// a `Series` to a `ChunkedArray` you can call the method with the name of the type:
 ///
 /// ```
@@ -92,10 +92,10 @@ use crate::POOL;
 ///     .all(|(a, b)| a == *b))
 /// ```
 ///
-/// See all the comparison operators in the [CmpOps trait](../chunked_array/comparison/trait.CmpOps.html)
+/// See all the comparison operators in the [CmpOps trait](crate::chunked_array::ops::ChunkCompare)
 ///
 /// ## Iterators
-/// The Series variants contain differently typed [ChunkedArray's](../chunked_array/struct.ChunkedArray.html).
+/// The Series variants contain differently typed [ChunkedArray's](crate::chunked_array::ChunkedArray).
 /// These structs can be turned into iterators, making it possible to use any function/ closure you want
 /// on a Series.
 ///

--- a/crates/polars/src/docs/eager.rs
+++ b/crates/polars/src/docs/eager.rs
@@ -22,7 +22,7 @@
 //!     - [pivot](#pivot)
 //! * [Melt](#melt)
 //! * [Explode](#explode)
-//! * [IO](#IO)
+//! * [IO](#io)
 //!     - [Read CSV](#read-csv)
 //!     - [Write CSV](#write-csv)
 //!     - [Read IPC](#read-ipc)
@@ -30,8 +30,8 @@
 //!     - [Read Parquet](#read-parquet)
 //!     - [Write Parquet](#write-parquet)
 //! * [Various](#various)
-//!     - [Replace NaN](#replace-nan)
-//!     * [Extracting data](#extracting-data)
+//!     - [Replace NaN with Missing](#replace-nan-with-missing)
+//!     - [Extracting data](#extracting-data)
 //!
 //! ## Creation of Data structures
 //!

--- a/crates/polars/src/lib.rs
+++ b/crates/polars/src/lib.rs
@@ -150,7 +150,7 @@
 //! Unlock full potential with lazy computation. This allows query optimizations and provides Polars
 //! the full query context so that the fastest algorithm can be chosen.
 //!
-//! **[Read more in the lazy module.](polars_lazy)**
+//! **[Read more in the lazy module.](crate::lazy)**
 //!
 //! ## Compile times
 //! A DataFrame library typically consists of
@@ -374,6 +374,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(ambiguous_glob_reexports)]
 pub mod docs;
+#[doc(hidden)]
 pub mod export;
 pub mod prelude;
 #[cfg(feature = "sql")]


### PR DESCRIPTION
Almost entirely solves https://github.com/pola-rs/polars/issues/10246, the only remaining dead links are due to overly aggressive prelude exports from other crates / the standard library.