### PR TITLE
depr(python): Rename first `qcut` parameter to `quantiles`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3363,10 +3363,11 @@ class Expr:
             self._pyexpr.cut(breaks, labels, left_closed, include_breaks)
         )
 
-    @deprecate_renamed_parameter("probs", "q", version="0.18.8")
+    @deprecate_renamed_parameter("probs", "quantiles", version="0.18.8")
+    @deprecate_renamed_parameter("q", "quantiles", version="0.18.12")
     def qcut(
         self,
-        q: list[float] | int,
+        quantiles: list[float] | int,
         labels: list[str] | None = None,
         left_closed: bool = False,
         allow_duplicates: bool = False,
@@ -3377,7 +3378,7 @@ class Expr:
 
         Parameters
         ----------
-        q
+        quantiles
             Either a list of quantile probabilities between 0 and 1 or a positive
             integer determining the number of evenly spaced probabilities to use.
         labels
@@ -3392,7 +3393,6 @@ class Expr:
         include_breaks
             Include the the right endpoint of the bin each observation falls in.
             If True, the resulting column will be a Struct.
-
 
         Examples
         --------
@@ -3484,9 +3484,13 @@ class Expr:
         │ b   ┆ 9   ┆ {inf,"(4.5, inf]"}    │
         └─────┴─────┴───────────────────────┘
         """
-        expr_f = self._pyexpr.qcut_uniform if isinstance(q, int) else self._pyexpr.qcut
+        expr_f = (
+            self._pyexpr.qcut_uniform
+            if isinstance(quantiles, int)
+            else self._pyexpr.qcut
+        )
         return self._from_pyexpr(
-            expr_f(q, labels, left_closed, allow_duplicates, include_breaks)
+            expr_f(quantiles, labels, left_closed, allow_duplicates, include_breaks)
         )
 
     def rle(self) -> Self:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1740,10 +1740,10 @@ class Series:
             return res.struct.rename_fields([break_point_label, category_label])
         return res
 
-    @deprecate_renamed_parameter("quantiles", "q", version="0.18.8")
+    @deprecate_renamed_parameter("q", "quantiles", version="0.18.12")
     def qcut(
         self,
-        q: list[float] | int,
+        quantiles: list[float] | int,
         *,
         labels: list[str] | None = None,
         break_point_label: str = "break_point",
@@ -1758,7 +1758,7 @@ class Series:
 
         Parameters
         ----------
-        q
+        quantiles
             Either a list of quantile probabilities between 0 and 1 or a positive
             integer determining the number of evenly spaced probabilities to use.
         labels
@@ -1857,7 +1857,7 @@ class Series:
                 self.to_frame()
                 .with_columns(
                     F.col(n)
-                    .qcut(q, labels, left_closed, allow_duplicates, True)
+                    .qcut(quantiles, labels, left_closed, allow_duplicates, True)
                     .alias(n + "_bin")
                 )
                 .unnest(n + "_bin")
@@ -1866,7 +1866,9 @@ class Series:
         res = (
             self.to_frame()
             .select(
-                F.col(n).qcut(q, labels, left_closed, allow_duplicates, include_breaks)
+                F.col(n).qcut(
+                    quantiles, labels, left_closed, allow_duplicates, include_breaks
+                )
             )
             .to_series()
         )


### PR DESCRIPTION
These were recently renamed to `q`, but that does not match our naming policy. Fortunately, it's a simple fix.