### PR TITLE
feat(python): support `selectors` in additional frame methods

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -15,6 +15,7 @@ from typing import (
     BinaryIO,
     Callable,
     ClassVar,
+    Collection,
     Generator,
     Iterable,
     Iterator,
@@ -126,8 +127,7 @@ if TYPE_CHECKING:
         AsofJoinStrategy,
         AvroCompression,
         ClosedInterval,
-        ColumnNameOrSelectorCollection,
-        ColumnNameOrSelectorSequence,
+        ColumnNameOrSelector,
         ColumnTotalsDefinition,
         ComparisonOperator,
         ConditionalFormatDict,
@@ -4540,7 +4540,7 @@ class DataFrame:
 
     def drop_nulls(
         self,
-        subset: ColumnNameOrSelectorCollection | None = None,
+        subset: ColumnNameOrSelector | Collection[ColumnNameOrSelector] | None = None,
     ) -> DataFrame:
         """
         Drop all rows that contain null values.
@@ -6054,7 +6054,7 @@ class DataFrame:
 
     def drop(
         self,
-        columns: ColumnNameOrSelectorCollection,
+        columns: ColumnNameOrSelector | Collection[ColumnNameOrSelector],
         *more_columns: str | SelectorType,
     ) -> DataFrame:
         """
@@ -6559,9 +6559,9 @@ class DataFrame:
 
     def pivot(
         self,
-        values: ColumnNameOrSelectorSequence | None,
-        index: ColumnNameOrSelectorSequence | None,
-        columns: ColumnNameOrSelectorSequence | None,
+        values: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None,
+        index: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None,
+        columns: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None,
         aggregate_function: PivotAgg | Expr | None | NoDefault = no_default,
         *,
         maintain_order: bool = True,
@@ -6791,7 +6791,7 @@ class DataFrame:
         self,
         step: int,
         how: UnstackDirection = "vertical",
-        columns: ColumnNameOrSelectorSequence | None = None,
+        columns: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
         fill_values: list[Any] | None = None,
     ) -> DataFrame:
         """
@@ -6933,7 +6933,7 @@ class DataFrame:
     @overload
     def partition_by(
         self,
-        by: ColumnNameOrSelectorSequence,
+        by: ColumnNameOrSelector | Sequence[ColumnNameOrSelector],
         *more_by: str,
         maintain_order: bool = ...,
         include_key: bool = ...,
@@ -6944,7 +6944,7 @@ class DataFrame:
     @overload
     def partition_by(
         self,
-        by: ColumnNameOrSelectorSequence,
+        by: ColumnNameOrSelector | Sequence[ColumnNameOrSelector],
         *more_by: str,
         maintain_order: bool = ...,
         include_key: bool = ...,
@@ -6954,7 +6954,7 @@ class DataFrame:
 
     def partition_by(
         self,
-        by: ColumnNameOrSelectorSequence,
+        by: ColumnNameOrSelector | Sequence[ColumnNameOrSelector],
         *more_by: str | SelectorType,
         maintain_order: bool = True,
         include_key: bool = True,
@@ -8022,7 +8022,7 @@ class DataFrame:
 
     def to_dummies(
         self,
-        columns: ColumnNameOrSelectorSequence | None = None,
+        columns: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
         *,
         separator: str = "_",
         drop_first: bool = False,
@@ -8101,7 +8101,7 @@ class DataFrame:
 
     def unique(
         self,
-        subset: ColumnNameOrSelectorCollection | None = None,
+        subset: ColumnNameOrSelector | Collection[ColumnNameOrSelector] | None = None,
         *,
         keep: UniqueKeepStrategy = "any",
         maintain_order: bool = False,
@@ -9118,7 +9118,7 @@ class DataFrame:
 
     def unnest(
         self,
-        columns: ColumnNameOrSelectorCollection,
+        columns: ColumnNameOrSelector | Collection[ColumnNameOrSelector],
         *more_columns: str | SelectorType,
     ) -> Self:
         """

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -15,7 +15,6 @@ from typing import (
     BinaryIO,
     Callable,
     ClassVar,
-    Collection,
     Generator,
     Iterable,
     Iterator,
@@ -72,6 +71,7 @@ from polars.io.excel._write_utils import (
     _xl_unique_table_name,
     _XLFormatCache,
 )
+from polars.selectors import _expand_selectors
 from polars.slice import PolarsSlice
 from polars.utils import no_default
 from polars.utils._construction import (
@@ -126,6 +126,8 @@ if TYPE_CHECKING:
         AsofJoinStrategy,
         AvroCompression,
         ClosedInterval,
+        ColumnNameOrSelectorCollection,
+        ColumnNameOrSelectorSequence,
         ColumnTotalsDefinition,
         ComparisonOperator,
         ConditionalFormatDict,
@@ -4536,7 +4538,10 @@ class DataFrame:
         """
         return self.head(n)
 
-    def drop_nulls(self, subset: str | Collection[str] | None = None) -> DataFrame:
+    def drop_nulls(
+        self,
+        subset: ColumnNameOrSelectorCollection | None = None,
+    ) -> DataFrame:
         """
         Drop all rows that contain null values.
 
@@ -4554,24 +4559,41 @@ class DataFrame:
         ...     {
         ...         "foo": [1, 2, 3],
         ...         "bar": [6, None, 8],
-        ...         "ham": ["a", "b", "c"],
+        ...         "ham": ["a", "b", None],
         ...     }
         ... )
+
+        The default behavior of this method is to drop rows where any single
+        value of the row is null.
+
         >>> df.drop_nulls()
-        shape: (2, 3)
+        shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
         │ --- ┆ --- ┆ --- │
         │ i64 ┆ i64 ┆ str │
         ╞═════╪═════╪═════╡
         │ 1   ┆ 6   ┆ a   │
-        │ 3   ┆ 8   ┆ c   │
         └─────┴─────┴─────┘
 
-        This method drops rows where any single value of the row is null.
+        This behaviour can be constrained to consider only a subset of columns, as
+        defined by name or with a selector. For example, dropping rows if there is
+        a null in any of the integer columns:
 
-        Below are some example snippets that show how you could drop null values based
-        on other conditions
+        >>> import polars.selectors as cs
+        >>> df.drop_nulls(subset=cs.integer())
+        shape: (2, 3)
+        ┌─────┬─────┬──────┐
+        │ foo ┆ bar ┆ ham  │
+        │ --- ┆ --- ┆ ---  │
+        │ i64 ┆ i64 ┆ str  │
+        ╞═════╪═════╪══════╡
+        │ 1   ┆ 6   ┆ a    │
+        │ 3   ┆ 8   ┆ null │
+        └─────┴─────┴──────┘
+
+        Below are some additional examples that show how to drop null
+        values based on other conditions.
 
         >>> df = pl.DataFrame(
         ...     {
@@ -6030,14 +6052,19 @@ class DataFrame:
                 raise exc
         return self
 
-    def drop(self, columns: str | Collection[str], *more_columns: str) -> DataFrame:
+    def drop(
+        self,
+        columns: ColumnNameOrSelectorCollection,
+        *more_columns: str | SelectorType,
+    ) -> DataFrame:
         """
         Remove columns from the dataframe.
 
         Parameters
         ----------
         columns
-            Name of the column(s) that should be removed from the dataframe.
+            Names of the columns that should be removed from the dataframe, or
+            a selector that determines the columns to drop.
         *more_columns
             Additional columns to drop, specified as positional arguments.
 
@@ -6078,9 +6105,10 @@ class DataFrame:
         │ 3   │
         └─────┘
 
-        Or use positional arguments to drop multiple columns in the same way.
+        Drop multiple columns by passing a selector.
 
-        >>> df.drop("foo", "bar")
+        >>> import polars.selectors as cs
+        >>> df.drop(cs.numeric())
         shape: (3, 1)
         ┌─────┐
         │ ham │
@@ -6090,6 +6118,20 @@ class DataFrame:
         │ a   │
         │ b   │
         │ c   │
+        └─────┘
+
+        Use positional arguments to drop multiple columns.
+
+        >>> df.drop("foo", "ham")
+        shape: (3, 1)
+        ┌─────┐
+        │ bar │
+        │ --- │
+        │ f64 │
+        ╞═════╡
+        │ 6.0 │
+        │ 7.0 │
+        │ 8.0 │
         └─────┘
 
         """
@@ -6457,7 +6499,7 @@ class DataFrame:
 
     def explode(
         self,
-        columns: str | Sequence[str] | Expr | Sequence[Expr],
+        columns: str | Expr | Sequence[str | Expr],
         *more_columns: str | Expr,
     ) -> DataFrame:
         """
@@ -6466,8 +6508,8 @@ class DataFrame:
         Parameters
         ----------
         columns
-            Name of the column(s) to explode. Columns must be of datatype List or Utf8.
-            Accepts ``col`` expressions as input as well.
+            Column names, expressions, or a selector defining them. The underlying
+            columns being exploded must be of List or Utf8 datatype.
         *more_columns
             Additional names of columns to explode, specified as positional arguments.
 
@@ -6517,9 +6559,9 @@ class DataFrame:
 
     def pivot(
         self,
-        values: Sequence[str] | str,
-        index: Sequence[str] | str,
-        columns: Sequence[str] | str,
+        values: ColumnNameOrSelectorSequence | None,
+        index: ColumnNameOrSelectorSequence | None,
+        columns: ColumnNameOrSelectorSequence | None,
         aggregate_function: PivotAgg | Expr | None | NoDefault = no_default,
         *,
         maintain_order: bool = True,
@@ -6562,23 +6604,45 @@ class DataFrame:
         --------
         >>> df = pl.DataFrame(
         ...     {
-        ...         "foo": ["one", "one", "one", "two", "two", "two"],
-        ...         "bar": ["A", "B", "C", "A", "B", "C"],
+        ...         "foo": ["one", "one", "two", "two", "one", "two"],
+        ...         "bar": ["y", "y", "y", "x", "x", "x"],
         ...         "baz": [1, 2, 3, 4, 5, 6],
         ...     }
         ... )
+        >>> df.pivot(values="baz", index="foo", columns="bar", aggregate_function="sum")
+        shape: (2, 3)
+        ┌─────┬─────┬─────┐
+        │ foo ┆ y   ┆ x   │
+        │ --- ┆ --- ┆ --- │
+        │ str ┆ i64 ┆ i64 │
+        ╞═════╪═════╪═════╡
+        │ one ┆ 3   ┆ 5   │
+        │ two ┆ 3   ┆ 10  │
+        └─────┴─────┴─────┘
+
+        Pivot using selectors to determine the index/values/columns:
+
+        >>> import polars.selectors as cs
         >>> df.pivot(
-        ...     values="baz", index="foo", columns="bar", aggregate_function="first"
+        ...     values=cs.numeric(),
+        ...     index=cs.string(),
+        ...     columns=cs.string(),
+        ...     aggregate_function="sum",
+        ...     sort_columns=True,
+        ... ).sort(
+        ...     by=cs.string(),
         ... )
-        shape: (2, 4)
-        ┌─────┬─────┬─────┬─────┐
-        │ foo ┆ A   ┆ B   ┆ C   │
-        │ --- ┆ --- ┆ --- ┆ --- │
-        │ str ┆ i64 ┆ i64 ┆ i64 │
-        ╞═════╪═════╪═════╪═════╡
-        │ one ┆ 1   ┆ 2   ┆ 3   │
-        │ two ┆ 4   ┆ 5   ┆ 6   │
-        └─────┴─────┴─────┴─────┘
+        shape: (4, 6)
+        ┌─────┬─────┬──────┬──────┬──────┬──────┐
+        │ foo ┆ bar ┆ one  ┆ two  ┆ x    ┆ y    │
+        │ --- ┆ --- ┆ ---  ┆ ---  ┆ ---  ┆ ---  │
+        │ str ┆ str ┆ i64  ┆ i64  ┆ i64  ┆ i64  │
+        ╞═════╪═════╪══════╪══════╪══════╪══════╡
+        │ one ┆ x   ┆ 5    ┆ null ┆ 5    ┆ null │
+        │ one ┆ y   ┆ 3    ┆ null ┆ null ┆ 3    │
+        │ two ┆ x   ┆ null ┆ 10   ┆ 10   ┆ null │
+        │ two ┆ y   ┆ null ┆ 3    ┆ null ┆ 3    │
+        └─────┴─────┴──────┴──────┴──────┴──────┘
 
         Run an expression as aggregation function
 
@@ -6606,12 +6670,9 @@ class DataFrame:
         └──────┴──────────┴──────────┘
 
         """  # noqa: W505
-        if isinstance(values, str):
-            values = [values]
-        if isinstance(index, str):
-            index = [index]
-        if isinstance(columns, str):
-            columns = [columns]
+        values = _expand_selectors(self, values)
+        index = _expand_selectors(self, index)
+        columns = _expand_selectors(self, columns)
 
         if aggregate_function is no_default:
             issue_deprecation_warning(
@@ -6730,7 +6791,7 @@ class DataFrame:
         self,
         step: int,
         how: UnstackDirection = "vertical",
-        columns: str | Sequence[str] | None = None,
+        columns: ColumnNameOrSelectorSequence | None = None,
         fill_values: list[Any] | None = None,
     ) -> DataFrame:
         """
@@ -6750,7 +6811,7 @@ class DataFrame:
         how : { 'vertical', 'horizontal' }
             Direction of the unstack.
         columns
-            Name of the column(s) to include in the operation.
+            Column name(s) or selector(s) to include in the operation.
             If set to ``None`` (default), use all columns.
         fill_values
             Fill values that don't fit the new size with this value.
@@ -6760,49 +6821,66 @@ class DataFrame:
         >>> from string import ascii_uppercase
         >>> df = pl.DataFrame(
         ...     {
-        ...         "col1": list(ascii_uppercase[0:9]),
-        ...         "col2": pl.int_range(0, 9, eager=True),
+        ...         "x": list(ascii_uppercase[0:8]),
+        ...         "y": pl.int_range(1, 9, eager=True),
         ...     }
+        ... ).with_columns(
+        ...     z=pl.int_ranges(pl.col("y"), pl.col("y") + 2, dtype=pl.UInt8),
         ... )
         >>> df
-        shape: (9, 2)
-        ┌──────┬──────┐
-        │ col1 ┆ col2 │
-        │ ---  ┆ ---  │
-        │ str  ┆ i64  │
-        ╞══════╪══════╡
-        │ A    ┆ 0    │
-        │ B    ┆ 1    │
-        │ C    ┆ 2    │
-        │ D    ┆ 3    │
-        │ E    ┆ 4    │
-        │ F    ┆ 5    │
-        │ G    ┆ 6    │
-        │ H    ┆ 7    │
-        │ I    ┆ 8    │
-        └──────┴──────┘
-        >>> df.unstack(step=3, how="vertical")
-        shape: (3, 6)
-        ┌────────┬────────┬────────┬────────┬────────┬────────┐
-        │ col1_0 ┆ col1_1 ┆ col1_2 ┆ col2_0 ┆ col2_1 ┆ col2_2 │
-        │ ---    ┆ ---    ┆ ---    ┆ ---    ┆ ---    ┆ ---    │
-        │ str    ┆ str    ┆ str    ┆ i64    ┆ i64    ┆ i64    │
-        ╞════════╪════════╪════════╪════════╪════════╪════════╡
-        │ A      ┆ D      ┆ G      ┆ 0      ┆ 3      ┆ 6      │
-        │ B      ┆ E      ┆ H      ┆ 1      ┆ 4      ┆ 7      │
-        │ C      ┆ F      ┆ I      ┆ 2      ┆ 5      ┆ 8      │
-        └────────┴────────┴────────┴────────┴────────┴────────┘
-        >>> df.unstack(step=3, how="horizontal")
-        shape: (3, 6)
-        ┌────────┬────────┬────────┬────────┬────────┬────────┐
-        │ col1_0 ┆ col1_1 ┆ col1_2 ┆ col2_0 ┆ col2_1 ┆ col2_2 │
-        │ ---    ┆ ---    ┆ ---    ┆ ---    ┆ ---    ┆ ---    │
-        │ str    ┆ str    ┆ str    ┆ i64    ┆ i64    ┆ i64    │
-        ╞════════╪════════╪════════╪════════╪════════╪════════╡
-        │ A      ┆ B      ┆ C      ┆ 0      ┆ 1      ┆ 2      │
-        │ D      ┆ E      ┆ F      ┆ 3      ┆ 4      ┆ 5      │
-        │ G      ┆ H      ┆ I      ┆ 6      ┆ 7      ┆ 8      │
-        └────────┴────────┴────────┴────────┴────────┴────────┘
+        shape: (8, 3)
+        ┌─────┬─────┬──────────┐
+        │ x   ┆ y   ┆ z        │
+        │ --- ┆ --- ┆ ---      │
+        │ str ┆ i64 ┆ list[u8] │
+        ╞═════╪═════╪══════════╡
+        │ A   ┆ 1   ┆ [1, 2]   │
+        │ B   ┆ 2   ┆ [2, 3]   │
+        │ C   ┆ 3   ┆ [3, 4]   │
+        │ D   ┆ 4   ┆ [4, 5]   │
+        │ E   ┆ 5   ┆ [5, 6]   │
+        │ F   ┆ 6   ┆ [6, 7]   │
+        │ G   ┆ 7   ┆ [7, 8]   │
+        │ H   ┆ 8   ┆ [8, 9]   │
+        └─────┴─────┴──────────┘
+        >>> df.unstack(step=4, how="vertical")
+        shape: (4, 6)
+        ┌─────┬─────┬─────┬─────┬──────────┬──────────┐
+        │ x_0 ┆ x_1 ┆ y_0 ┆ y_1 ┆ z_0      ┆ z_1      │
+        │ --- ┆ --- ┆ --- ┆ --- ┆ ---      ┆ ---      │
+        │ str ┆ str ┆ i64 ┆ i64 ┆ list[u8] ┆ list[u8] │
+        ╞═════╪═════╪═════╪═════╪══════════╪══════════╡
+        │ A   ┆ E   ┆ 1   ┆ 5   ┆ [1, 2]   ┆ [5, 6]   │
+        │ B   ┆ F   ┆ 2   ┆ 6   ┆ [2, 3]   ┆ [6, 7]   │
+        │ C   ┆ G   ┆ 3   ┆ 7   ┆ [3, 4]   ┆ [7, 8]   │
+        │ D   ┆ H   ┆ 4   ┆ 8   ┆ [4, 5]   ┆ [8, 9]   │
+        └─────┴─────┴─────┴─────┴──────────┴──────────┘
+        >>> df.unstack(step=2, how="horizontal")
+        shape: (4, 6)
+        ┌─────┬─────┬─────┬─────┬──────────┬──────────┐
+        │ x_0 ┆ x_1 ┆ y_0 ┆ y_1 ┆ z_0      ┆ z_1      │
+        │ --- ┆ --- ┆ --- ┆ --- ┆ ---      ┆ ---      │
+        │ str ┆ str ┆ i64 ┆ i64 ┆ list[u8] ┆ list[u8] │
+        ╞═════╪═════╪═════╪═════╪══════════╪══════════╡
+        │ A   ┆ B   ┆ 1   ┆ 2   ┆ [1, 2]   ┆ [2, 3]   │
+        │ C   ┆ D   ┆ 3   ┆ 4   ┆ [3, 4]   ┆ [4, 5]   │
+        │ E   ┆ F   ┆ 5   ┆ 6   ┆ [5, 6]   ┆ [6, 7]   │
+        │ G   ┆ H   ┆ 7   ┆ 8   ┆ [7, 8]   ┆ [8, 9]   │
+        └─────┴─────┴─────┴─────┴──────────┴──────────┘
+        >>> import polars.selectors as cs
+        >>> df.unstack(step=5, columns=cs.numeric(), fill_values=0)
+        shape: (5, 2)
+        ┌─────┬─────┐
+        │ y_0 ┆ y_1 │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ 6   │
+        │ 2   ┆ 7   │
+        │ 3   ┆ 8   │
+        │ 4   ┆ 0   │
+        │ 5   ┆ 0   │
+        └─────┴─────┘
 
         """
         import math
@@ -6855,7 +6933,7 @@ class DataFrame:
     @overload
     def partition_by(
         self,
-        by: str | Iterable[str],
+        by: ColumnNameOrSelectorSequence,
         *more_by: str,
         maintain_order: bool = ...,
         include_key: bool = ...,
@@ -6866,7 +6944,7 @@ class DataFrame:
     @overload
     def partition_by(
         self,
-        by: str | Iterable[str],
+        by: ColumnNameOrSelectorSequence,
         *more_by: str,
         maintain_order: bool = ...,
         include_key: bool = ...,
@@ -6876,8 +6954,8 @@ class DataFrame:
 
     def partition_by(
         self,
-        by: str | Iterable[str],
-        *more_by: str,
+        by: ColumnNameOrSelectorSequence,
+        *more_by: str | SelectorType,
         maintain_order: bool = True,
         include_key: bool = True,
         as_dict: bool = False,
@@ -6888,7 +6966,7 @@ class DataFrame:
         Parameters
         ----------
         by
-            Name of the column(s) to group by.
+            Column name(s) or selector(s) to group by.
         *more_by
             Additional names of columns to group by, specified as positional arguments.
         maintain_order
@@ -6979,7 +7057,8 @@ class DataFrame:
 
         Return the partitions as a dictionary by specifying ``as_dict=True``.
 
-        >>> df.partition_by("a", as_dict=True)  # doctest: +IGNORE_RESULT
+        >>> import polars.selectors as cs
+        >>> df.partition_by(cs.string(), as_dict=True)  # doctest: +IGNORE_RESULT
         {'a': shape: (2, 3)
         ┌─────┬─────┬─────┐
         │ a   ┆ b   ┆ c   │
@@ -7008,13 +7087,7 @@ class DataFrame:
         └─────┴─────┴─────┘}
 
         """
-        if isinstance(by, str):
-            by = [by]
-        elif not isinstance(by, list):
-            by = list(by)
-        if more_by:
-            by.extend(more_by)
-
+        by = _expand_selectors(self, by, *more_by)
         partitions = [
             self._from_pydf(_df)
             for _df in self._df.partition_by(by, maintain_order, include_key)
@@ -7949,7 +8022,7 @@ class DataFrame:
 
     def to_dummies(
         self,
-        columns: str | Sequence[str] | None = None,
+        columns: ColumnNameOrSelectorSequence | None = None,
         *,
         separator: str = "_",
         drop_first: bool = False,
@@ -7960,8 +8033,8 @@ class DataFrame:
         Parameters
         ----------
         columns
-            Name of the column(s) that should be converted to dummy variables.
-            If set to ``None`` (default), convert all columns.
+            Column name(s) or selector(s) that should be converted to dummy
+            variables. If set to ``None`` (default), convert all columns.
         separator
             Separator/delimiter used when generating column names.
         drop_first
@@ -7987,14 +8060,48 @@ class DataFrame:
         │ 0     ┆ 1     ┆ 0     ┆ 1     ┆ 0     ┆ 1     │
         └───────┴───────┴───────┴───────┴───────┴───────┘
 
+        >>> df.to_dummies(drop_first=True)
+        shape: (2, 3)
+        ┌───────┬───────┬───────┐
+        │ foo_2 ┆ bar_4 ┆ ham_b │
+        │ ---   ┆ ---   ┆ ---   │
+        │ u8    ┆ u8    ┆ u8    │
+        ╞═══════╪═══════╪═══════╡
+        │ 0     ┆ 0     ┆ 0     │
+        │ 1     ┆ 1     ┆ 1     │
+        └───────┴───────┴───────┘
+
+        >>> import polars.selectors as cs
+        >>> df.to_dummies(cs.integer(), separator=":")
+        shape: (2, 5)
+        ┌───────┬───────┬───────┬───────┬─────┐
+        │ foo:1 ┆ foo:2 ┆ bar:3 ┆ bar:4 ┆ ham │
+        │ ---   ┆ ---   ┆ ---   ┆ ---   ┆ --- │
+        │ u8    ┆ u8    ┆ u8    ┆ u8    ┆ str │
+        ╞═══════╪═══════╪═══════╪═══════╪═════╡
+        │ 1     ┆ 0     ┆ 1     ┆ 0     ┆ a   │
+        │ 0     ┆ 1     ┆ 0     ┆ 1     ┆ b   │
+        └───────┴───────┴───────┴───────┴─────┘
+
+        >>> df.to_dummies(cs.integer(), drop_first=True, separator=":")
+        shape: (2, 3)
+        ┌───────┬───────┬─────┐
+        │ foo:2 ┆ bar:4 ┆ ham │
+        │ ---   ┆ ---   ┆ --- │
+        │ u8    ┆ u8    ┆ str │
+        ╞═══════╪═══════╪═════╡
+        │ 0     ┆ 0     ┆ a   │
+        │ 1     ┆ 1     ┆ b   │
+        └───────┴───────┴─────┘
+
         """
-        if isinstance(columns, str):
-            columns = [columns]
+        if columns is not None:
+            columns = _expand_selectors(self, columns)
         return self._from_pydf(self._df.to_dummies(columns, separator, drop_first))
 
     def unique(
         self,
-        subset: str | Sequence[str] | None = None,
+        subset: ColumnNameOrSelectorCollection | None = None,
         *,
         keep: UniqueKeepStrategy = "any",
         maintain_order: bool = False,
@@ -8005,8 +8112,8 @@ class DataFrame:
         Parameters
         ----------
         subset
-            Column name(s) to consider when identifying duplicates.
-            If set to ``None`` (default), use all columns.
+            Column name(s) or selector(s), to consider when identifying
+            duplicate rows. If set to ``None`` (default), use all columns.
         keep : {'first', 'last', 'any', 'none'}
             Which of the duplicate rows to keep.
 
@@ -9009,7 +9116,11 @@ class DataFrame:
         """
         return wrap_s(self._df.to_struct(name))
 
-    def unnest(self, columns: str | Sequence[str], *more_columns: str) -> Self:
+    def unnest(
+        self,
+        columns: ColumnNameOrSelectorCollection,
+        *more_columns: str | SelectorType,
+    ) -> Self:
         """
         Decompose struct columns into separate columns for each of their fields.
 
@@ -9057,11 +9168,7 @@ class DataFrame:
         └────────┴─────┴─────┴──────┴───────────┴───────┘
 
         """
-        if isinstance(columns, str):
-            columns = [columns]
-        if more_columns:
-            columns = list(columns)
-            columns.extend(more_columns)
+        columns = _expand_selectors(self, columns, *more_columns)
         return self._from_pydf(self._df.unnest(columns))
 
     def corr(self, **kwargs: Any) -> DataFrame:

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -37,7 +37,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 
 if TYPE_CHECKING:
-    from typing import Literal
+    from typing import Collection, Literal
 
     from polars import DataFrame, Expr, LazyFrame, Series
     from polars.type_aliases import (
@@ -1648,7 +1648,7 @@ def arctan2d(y: str | Expr, x: str | Expr) -> Expr:
 
 
 def exclude(
-    columns: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
+    columns: str | PolarsDataType | Collection[str] | Collection[PolarsDataType],
     *more_columns: str | PolarsDataType,
 ) -> Expr:
     """

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -10,6 +10,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
+    Collection,
     Iterable,
     NoReturn,
     Sequence,
@@ -81,8 +82,7 @@ if TYPE_CHECKING:
     from polars.type_aliases import (
         AsofJoinStrategy,
         ClosedInterval,
-        ColumnNameOrSelectorCollection,
-        ColumnNameOrSelectorSequence,
+        ColumnNameOrSelector,
         CsvEncoding,
         FillNullStrategy,
         FrameInitTypes,
@@ -3344,7 +3344,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def drop(
         self,
-        columns: ColumnNameOrSelectorCollection,
+        columns: ColumnNameOrSelector | Collection[ColumnNameOrSelector],
         *more_columns: str | SelectorType,
     ) -> Self:
         """
@@ -4390,7 +4390,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def unique(
         self,
-        subset: ColumnNameOrSelectorCollection | None = None,
+        subset: ColumnNameOrSelector | Collection[ColumnNameOrSelector] | None = None,
         *,
         keep: UniqueKeepStrategy = "any",
         maintain_order: bool = False,
@@ -4475,7 +4475,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def drop_nulls(
         self,
-        subset: ColumnNameOrSelectorCollection | None = None,
+        subset: ColumnNameOrSelector | Collection[ColumnNameOrSelector] | None = None,
     ) -> Self:
         """
         Drop all rows that contain null values.
@@ -4573,8 +4573,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def melt(
         self,
-        id_vars: ColumnNameOrSelectorSequence | None = None,
-        value_vars: ColumnNameOrSelectorSequence | None = None,
+        id_vars: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
+        value_vars: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
         variable_name: str | None = None,
         value_name: str | None = None,
         *,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -95,7 +95,6 @@ if TYPE_CHECKING:
         RollingInterpolationMethod,
         SchemaDefinition,
         SchemaDict,
-        SelectorType,
         StartBy,
         UniqueKeepStrategy,
     )
@@ -3345,7 +3344,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     def drop(
         self,
         columns: ColumnNameOrSelector | Collection[ColumnNameOrSelector],
-        *more_columns: str | SelectorType,
+        *more_columns: ColumnNameOrSelector,
     ) -> Self:
         """
         Remove columns from the dataframe.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -10,7 +10,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Collection,
     Iterable,
     NoReturn,
     Sequence,
@@ -47,6 +46,7 @@ from polars.io._utils import _is_local_file
 from polars.io.ipc.anonymous_scan import _scan_ipc_fsspec
 from polars.io.parquet.anonymous_scan import _scan_parquet_fsspec
 from polars.lazyframe.groupby import LazyGroupBy
+from polars.selectors import _expand_selectors
 from polars.slice import LazyPolarsSlice
 from polars.utils._parse_expr_input import (
     parse_as_expression,
@@ -81,6 +81,8 @@ if TYPE_CHECKING:
     from polars.type_aliases import (
         AsofJoinStrategy,
         ClosedInterval,
+        ColumnNameOrSelectorCollection,
+        ColumnNameOrSelectorSequence,
         CsvEncoding,
         FillNullStrategy,
         FrameInitTypes,
@@ -93,6 +95,7 @@ if TYPE_CHECKING:
         RollingInterpolationMethod,
         SchemaDefinition,
         SchemaDict,
+        SelectorType,
         StartBy,
         UniqueKeepStrategy,
     )
@@ -3339,7 +3342,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self._from_pyldf(self._ldf.with_context([lf._ldf for lf in other]))
 
-    def drop(self, columns: str | Collection[str], *more_columns: str) -> Self:
+    def drop(
+        self,
+        columns: ColumnNameOrSelectorCollection,
+        *more_columns: str | SelectorType,
+    ) -> Self:
         """
         Remove columns from the dataframe.
 
@@ -3373,23 +3380,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 3   ┆ 8.0 │
         └─────┴─────┘
 
-        Drop multiple columns by passing a list of column names.
+        Drop multiple columns by passing a selector.
 
-        >>> lf.drop(["bar", "ham"]).collect()
-        shape: (3, 1)
-        ┌─────┐
-        │ foo │
-        │ --- │
-        │ i64 │
-        ╞═════╡
-        │ 1   │
-        │ 2   │
-        │ 3   │
-        └─────┘
-
-        Or use positional arguments to drop multiple columns in the same way.
-
-        >>> lf.drop("foo", "bar").collect()
+        >>> import polars.selectors as cs
+        >>> lf.drop(cs.numeric()).collect()
         shape: (3, 1)
         ┌─────┐
         │ ham │
@@ -3401,10 +3395,23 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ c   │
         └─────┘
 
+        Use positional arguments to drop multiple columns.
+
+        >>> lf.drop("foo", "ham").collect()
+        shape: (3, 1)
+        ┌─────┐
+        │ bar │
+        │ --- │
+        │ f64 │
+        ╞═════╡
+        │ 6.0 │
+        │ 7.0 │
+        │ 8.0 │
+        └─────┘
+
         """
-        if isinstance(columns, str):
-            columns = [columns]
-        return self._from_pyldf(self._ldf.drop([*columns, *more_columns]))
+        drop_cols = _expand_selectors(self, columns, *more_columns)
+        return self._from_pyldf(self._ldf.drop(drop_cols))
 
     def rename(self, mapping: dict[str, str]) -> Self:
         """
@@ -4336,7 +4343,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def explode(
         self,
-        columns: str | Sequence[str] | Expr | Sequence[Expr],
+        columns: str | Expr | Sequence[str | Expr],
         *more_columns: str | Expr,
     ) -> Self:
         """
@@ -4345,8 +4352,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Parameters
         ----------
         columns
-            Name of the column(s) to explode. Columns must be of datatype List or Utf8.
-            Accepts ``col`` expressions as input as well.
+            Column names, expressions, or a selector defining them. The underlying
+            columns being exploded must be of List or Utf8 datatype.
         *more_columns
             Additional names of columns to explode, specified as positional arguments.
 
@@ -4376,12 +4383,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────────┴─────────┘
 
         """
-        columns = parse_as_list_of_expressions(columns, *more_columns)
+        columns = parse_as_list_of_expressions(
+            *_expand_selectors(self, columns, *more_columns)
+        )
         return self._from_pyldf(self._ldf.explode(columns))
 
     def unique(
         self,
-        subset: str | Sequence[str] | None = None,
+        subset: ColumnNameOrSelectorCollection | None = None,
         *,
         keep: UniqueKeepStrategy = "any",
         maintain_order: bool = False,
@@ -4392,8 +4401,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Parameters
         ----------
         subset
-            Column name(s) to consider when identifying duplicates.
-            If set to ``None`` (default), use all columns.
+            Column name(s) or selector(s), to consider when identifying
+            duplicate rows. If set to ``None`` (default), use all columns.
         keep : {'first', 'last', 'any', 'none'}
             Which of the duplicate rows to keep.
 
@@ -4460,11 +4469,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┴─────┘
 
         """
-        if isinstance(subset, str):
-            subset = [subset]
+        if subset is not None:
+            subset = _expand_selectors(self, subset)
         return self._from_pyldf(self._ldf.unique(maintain_order, subset, keep))
 
-    def drop_nulls(self, subset: str | Collection[str] | None = None) -> Self:
+    def drop_nulls(
+        self,
+        subset: ColumnNameOrSelectorCollection | None = None,
+    ) -> Self:
         """
         Drop all rows that contain null values.
 
@@ -4482,24 +4494,43 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     {
         ...         "foo": [1, 2, 3],
         ...         "bar": [6, None, 8],
-        ...         "ham": ["a", "b", "c"],
+        ...         "ham": ["a", "b", None],
         ...     }
         ... )
+
+        The default behavior of this method is to drop rows where any single
+        value of the row is null.
+
         >>> lf.drop_nulls().collect()
-        shape: (2, 3)
+        shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
         │ --- ┆ --- ┆ --- │
         │ i64 ┆ i64 ┆ str │
         ╞═════╪═════╪═════╡
         │ 1   ┆ 6   ┆ a   │
-        │ 3   ┆ 8   ┆ c   │
         └─────┴─────┴─────┘
+
+        This behaviour can be constrained to consider only a subset of columns, as
+        defined by name or with a selector. For example, dropping rows if there is
+        a null in any of the integer columns:
+
+        >>> import polars.selectors as cs
+        >>> lf.drop_nulls(subset=cs.integer()).collect()
+        shape: (2, 3)
+        ┌─────┬─────┬──────┐
+        │ foo ┆ bar ┆ ham  │
+        │ --- ┆ --- ┆ ---  │
+        │ i64 ┆ i64 ┆ str  │
+        ╞═════╪═════╪══════╡
+        │ 1   ┆ 6   ┆ a    │
+        │ 3   ┆ 8   ┆ null │
+        └─────┴─────┴──────┘
 
         This method drops a row if any single value of the row is null.
 
-        Below are some example snippets that show how you could drop null values based
-        on other conditions:
+        Below are some example snippets that show how you could drop null
+        values based on other conditions:
 
         >>> lf = pl.LazyFrame(
         ...     {
@@ -4537,15 +4568,13 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         """
         if subset is not None:
-            if isinstance(subset, str):
-                subset = [subset]
-            subset = list(subset)
+            subset = _expand_selectors(self, subset)
         return self._from_pyldf(self._ldf.drop_nulls(subset))
 
     def melt(
         self,
-        id_vars: str | list[str] | None = None,
-        value_vars: str | list[str] | None = None,
+        id_vars: ColumnNameOrSelectorSequence | None = None,
+        value_vars: ColumnNameOrSelectorSequence | None = None,
         variable_name: str | None = None,
         value_name: str | None = None,
         *,
@@ -4557,17 +4586,17 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Optionally leaves identifiers set.
 
         This function is useful to massage a DataFrame into a format where one or more
-        columns are identifier variables (id_vars), while all other columns, considered
-        measured variables (value_vars), are "unpivoted" to the row axis, leaving just
+        columns are identifier variables (id_vars) while all other columns, considered
+        measured variables (value_vars), are "unpivoted" to the row axis leaving just
         two non-identifier columns, 'variable' and 'value'.
 
         Parameters
         ----------
         id_vars
-            Columns to use as identifier variables.
+            Column(s) or selector(s) to use as identifier variables.
         value_vars
-            Values to use as identifier variables.
-            If `value_vars` is empty all columns that are not in `id_vars` will be used.
+            Column(s) or selector(s) to use as values variables; if `value_vars`
+            is empty all columns that are not in `id_vars` will be used.
         variable_name
             Name to give to the `variable` column. Defaults to "variable"
         value_name
@@ -4586,7 +4615,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...         "c": [2, 4, 6],
         ...     }
         ... )
-        >>> lf.melt(id_vars="a", value_vars=["b", "c"]).collect()
+        >>> import polars.selectors as cs
+        >>> lf.melt(id_vars="a", value_vars=cs.numeric()).collect()
         shape: (6, 3)
         ┌─────┬──────────┬───────┐
         │ a   ┆ variable ┆ value │
@@ -4602,14 +4632,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴──────────┴───────┘
 
         """
-        if isinstance(value_vars, str):
-            value_vars = [value_vars]
-        if isinstance(id_vars, str):
-            id_vars = [id_vars]
-        if value_vars is None:
-            value_vars = []
-        if id_vars is None:
-            id_vars = []
+        value_vars = [] if value_vars is None else _expand_selectors(self, value_vars)
+        id_vars = [] if id_vars is None else _expand_selectors(self, id_vars)
+
         return self._from_pyldf(
             self._ldf.melt(id_vars, value_vars, value_name, variable_name, streamable)
         )

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -68,8 +68,14 @@ PythonLiteral: TypeAlias = Union[
 IntoExpr: TypeAlias = Union["Expr", PythonLiteral, "Series", None]
 ComparisonOperator: TypeAlias = Literal["eq", "neq", "gt", "lt", "gt_eq", "lt_eq"]
 
-# selector type
+# selector type, and related collection/sequence
 SelectorType: TypeAlias = "_selector_proxy_"
+ColumnNameOrSelectorCollection: TypeAlias = Union[
+    str, SelectorType, Collection[Union[str, SelectorType]]
+]
+ColumnNameOrSelectorSequence: TypeAlias = Union[
+    str, SelectorType, Sequence[Union[str, SelectorType]]
+]
 
 # User-facing string literal types
 # The following all have an equivalent Rust enum with the same name

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -70,12 +70,7 @@ ComparisonOperator: TypeAlias = Literal["eq", "neq", "gt", "lt", "gt_eq", "lt_eq
 
 # selector type, and related collection/sequence
 SelectorType: TypeAlias = "_selector_proxy_"
-ColumnNameOrSelectorCollection: TypeAlias = Union[
-    str, SelectorType, Collection[Union[str, SelectorType]]
-]
-ColumnNameOrSelectorSequence: TypeAlias = Union[
-    str, SelectorType, Sequence[Union[str, SelectorType]]
-]
+ColumnNameOrSelector: TypeAlias = Union[str, SelectorType]
 
 # User-facing string literal types
 # The following all have an equivalent Rust enum with the same name

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+import polars.selectors as cs
 from polars.testing import assert_frame_equal
 
 
@@ -71,6 +72,7 @@ def test_drop() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": ["a", "b", "c"], "c": [1, 2, 3]})
     df = df.drop(columns="a")
     assert df.shape == (3, 2)
+
     df = pl.DataFrame({"a": [2, 1, 3], "b": ["a", "b", "c"], "c": [1, 2, 3]})
     s = df.drop_in_place("a")
     assert s.name == "a"
@@ -87,9 +89,15 @@ def test_drop_nulls_lazy() -> None:
     result = df.lazy().drop_nulls().collect()
     assert_frame_equal(result, expected)
 
+    result = df.drop_nulls(cs.contains("a"))
+    assert_frame_equal(result, expected)
+
 
 def test_drop_columns() -> None:
-    out = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).lazy().drop(["a", "b"])
+    out = pl.LazyFrame({"a": [1], "b": [2], "c": [3]}).drop(["a", "b"])
+    assert out.columns == ["c"]
+
+    out = pl.LazyFrame({"a": [1], "b": [2], "c": [3]}).drop(~cs.starts_with("c"))
     assert out.columns == ["c"]
 
     out = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).lazy().drop("a")

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -4,6 +4,7 @@ import pyarrow as pa
 import pytest
 
 import polars as pl
+import polars.selectors as cs
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -19,6 +20,7 @@ def test_explode_multiple() -> None:
     df = pl.DataFrame({"a": [[1, 2], [3, 4]], "b": [[5, 6], [7, 8]]})
 
     expected = pl.DataFrame({"a": [1, 2, 3, 4], "b": [5, 6, 7, 8]})
+    assert_frame_equal(df.explode(cs.all()), expected)
     assert_frame_equal(df.explode(["a", "b"]), expected)
     assert_frame_equal(df.explode("a", "b"), expected)
 
@@ -305,11 +307,11 @@ def test_explode_inner_null() -> None:
 
 
 def test_explode_array() -> None:
-    out = pl.DataFrame(
+    df = pl.LazyFrame(
         {"a": [[1, 2], [2, 3]], "b": [1, 2]},
         schema_overrides={"a": pl.Array(2, inner=pl.Int64)},
-    ).explode("a")
-
+    )
     expected = pl.DataFrame({"a": [1, 2, 2, 3], "b": [1, 1, 2, 2]})
-
-    assert_frame_equal(out, expected)
+    for ex in ("a", ~cs.integer()):
+        out = df.explode(ex).collect()  # type: ignore[arg-type]
+        assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import polars as pl
+import polars.selectors as cs
 from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
@@ -169,12 +170,21 @@ def test_pivot_multiple_values_column_names_5116() -> None:
 
 def test_pivot_duplicate_names_7731() -> None:
     df = pl.DataFrame(
-        {"a": [1, 4], "b": [1, 2], "c": ["x", "x"], "d": [7, 8], "e": ["x", "y"]}
+        {
+            "a": [1, 4],
+            "b": [1.5, 2.5],
+            "c": ["x", "x"],
+            "d": [7, 8],
+            "e": ["x", "y"],
+        }
     )
     assert df.pivot(
-        values=["a", "d"], index="b", columns=["c", "e"], aggregate_function="first"
+        values=cs.integer(),
+        index=cs.float(),
+        columns=cs.string(),
+        aggregate_function="first",
     ).to_dict(False) == {
-        "b": [1, 2],
+        "b": [1.5, 2.5],
         "a_c_x": [1, 4],
         "d_c_x": [7, 8],
         "a_e_x": [1, None],

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -870,7 +870,7 @@ def test_exclude(input: tuple[Any, ...], expected: list[str]) -> None:
     assert df.select(pl.all().exclude(*input)).columns == expected
 
 
-@pytest.mark.parametrize("input", [(5,), (["a"], "b"), (pl.Int64, "a")])
+@pytest.mark.parametrize("input", [(5,), (["a"], date.today()), (pl.Int64, "a")])
 def test_exclude_invalid_input(input: tuple[Any, ...]) -> None:
     df = pl.DataFrame(schema=["a", "b", "c"])
     with pytest.raises(TypeError):

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -166,6 +166,11 @@ def test_selector_datetime(df: pl.DataFrame) -> None:
     )
 
 
+def test_selector_drop(df: pl.DataFrame) -> None:
+    dfd = df.drop(cs.numeric(), cs.temporal())
+    assert dfd.columns == ["eee", "fgg", "qqR"]
+
+
 def test_selector_duration(df: pl.DataFrame) -> None:
     assert df.select(cs.duration("ms")).columns == []
     assert df.select(cs.duration(["ms", "ns"])).columns == []
@@ -326,11 +331,12 @@ def test_selector_expansion() -> None:
 
 
 def test_selector_repr() -> None:
-    assert repr(cs.all() - cs.first()) == "cs.all() - cs.first()"
+    assert repr(cs.all() - cs.first()) == "(cs.all() - cs.first())"
     assert repr(~cs.starts_with("a", "b")) == "~cs.starts_with('a', 'b')"
-    assert repr(cs.float() | cs.by_name("x")) == "cs.float() | cs.by_name('x')"
+    assert repr(cs.float() | cs.by_name("x")) == "(cs.float() | cs.by_name('x'))"
     assert (
-        repr(cs.integer() & cs.matches("z")) == "cs.integer() & cs.matches(pattern='z')"
+        repr(cs.integer() & cs.matches("z"))
+        == "(cs.integer() & cs.matches(pattern='z'))"
     )
 
 


### PR DESCRIPTION
~It's nice to be able to pass selectors into drop (and likely other methods; we should have a run through and see where else we can take advantage of this).~

(**Updated:** many additional methods now supported, after having just started with `drop`).

---

It's good ergonomics to be able to pass selectors into frame methods that currently only take one or more string column names. This PR adds selector support to all of the following methods:

 * `drop`
 * `drop_nulls`
 * `explode`
 * `melt`
 * `partition_by`
 * `pivot`
 * `unique`
 * `unnest`
 * `unstack`
 * `to_dummies`

## Example
```python
import polars as pl
import polars.selectors as cs

df = pl.DataFrame(
    {
        "foo": [1, 2, 3],
        "bar": [6.0, 7.0, 8.0],
        "ham": ["a", "b", "c"],
    }
)
df.drop( cs.numeric() )
# shape: (3, 1)
# ┌─────┐
# │ ham │
# │ --- │
# │ str │
# ╞═════╡
# │ a   │
# │ b   │
# │ c   │
# └─────┘
```