### PR TITLE
chore(python): Address Ruff per file ignores

### DIFF
--- a/py-polars/polars/utils/show_versions.py
+++ b/py-polars/polars/utils/show_versions.py
@@ -7,7 +7,7 @@ from polars.utils.polars_version import get_polars_version
 
 
 def show_versions() -> None:
-    """
+    r"""
     Print out version of Polars and dependencies to stdout.
 
     Examples

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -12,8 +12,16 @@ from dis import get_instructions
 from inspect import signature
 from itertools import count, zip_longest
 from pathlib import Path
-from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, NamedTuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Iterator,
+    Literal,
+    NamedTuple,
+    Union,
+)
 
 if TYPE_CHECKING:
     from dis import Instruction
@@ -38,22 +46,23 @@ _MIN_PY311 = sys.version_info >= (3, 11)
 
 
 class OpNames:
-    BINARY = MappingProxyType(
-        {
-            "BINARY_ADD": "+",
-            "BINARY_AND": "&",
-            "BINARY_FLOOR_DIVIDE": "//",
-            "BINARY_MODULO": "%",
-            "BINARY_MULTIPLY": "*",
-            "BINARY_OR": "|",
-            "BINARY_POWER": "**",
-            "BINARY_SUBTRACT": "-",
-            "BINARY_TRUE_DIVIDE": "/",
-            "BINARY_XOR": "^",
-        }
+    BINARY: ClassVar[dict[str, str]] = {
+        "BINARY_ADD": "+",
+        "BINARY_AND": "&",
+        "BINARY_FLOOR_DIVIDE": "//",
+        "BINARY_MODULO": "%",
+        "BINARY_MULTIPLY": "*",
+        "BINARY_OR": "|",
+        "BINARY_POWER": "**",
+        "BINARY_SUBTRACT": "-",
+        "BINARY_TRUE_DIVIDE": "/",
+        "BINARY_XOR": "^",
+    }
+
+    CALL: ClassVar[set[str]] = (
+        {"CALL"} if _MIN_PY311 else {"CALL_FUNCTION", "CALL_METHOD"}
     )
-    CALL = {"CALL"} if _MIN_PY311 else {"CALL_FUNCTION", "CALL_METHOD"}
-    CONTROL_FLOW = (
+    CONTROL_FLOW: ClassVar[dict[str, str]] = (
         {
             "POP_JUMP_FORWARD_IF_FALSE": "&",
             "POP_JUMP_FORWARD_IF_TRUE": "|",
@@ -69,20 +78,19 @@ class OpNames:
         }
     )
     LOAD_VALUES = frozenset(("LOAD_CONST", "LOAD_DEREF", "LOAD_FAST", "LOAD_GLOBAL"))
-    LOAD_ATTR = {"LOAD_METHOD", "LOAD_ATTR"} if _MIN_PY311 else {"LOAD_METHOD"}
+    LOAD_ATTR: ClassVar[set[str]] = (
+        {"LOAD_METHOD", "LOAD_ATTR"} if _MIN_PY311 else {"LOAD_METHOD"}
+    )
     LOAD = LOAD_VALUES | {"LOAD_METHOD", "LOAD_ATTR"}
-    SYNTHETIC = MappingProxyType(
-        {
-            "POLARS_EXPRESSION": 1,
-        }
-    )
-    UNARY = MappingProxyType(
-        {
-            "UNARY_NEGATIVE": "-",
-            "UNARY_POSITIVE": "+",
-            "UNARY_NOT": "~",
-        }
-    )
+    SYNTHETIC: ClassVar[dict[str, int]] = {
+        "POLARS_EXPRESSION": 1,
+    }
+    UNARY: ClassVar[dict[str, str]] = {
+        "UNARY_NEGATIVE": "-",
+        "UNARY_POSITIVE": "+",
+        "UNARY_NOT": "~",
+    }
+
     PARSEABLE_OPS = (
         {"BINARY_OP", "BINARY_SUBSCR", "COMPARE_OP", "CONTAINS_OP", "IS_OP"}
         | set(UNARY)

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -12,6 +12,7 @@ from dis import get_instructions
 from inspect import signature
 from itertools import count, zip_longest
 from pathlib import Path
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, NamedTuple, Union
 
 if TYPE_CHECKING:
@@ -37,18 +38,20 @@ _MIN_PY311 = sys.version_info >= (3, 11)
 
 
 class OpNames:
-    BINARY = {
-        "BINARY_ADD": "+",
-        "BINARY_AND": "&",
-        "BINARY_FLOOR_DIVIDE": "//",
-        "BINARY_MODULO": "%",
-        "BINARY_MULTIPLY": "*",
-        "BINARY_OR": "|",
-        "BINARY_POWER": "**",
-        "BINARY_SUBTRACT": "-",
-        "BINARY_TRUE_DIVIDE": "/",
-        "BINARY_XOR": "^",
-    }
+    BINARY = MappingProxyType(
+        {
+            "BINARY_ADD": "+",
+            "BINARY_AND": "&",
+            "BINARY_FLOOR_DIVIDE": "//",
+            "BINARY_MODULO": "%",
+            "BINARY_MULTIPLY": "*",
+            "BINARY_OR": "|",
+            "BINARY_POWER": "**",
+            "BINARY_SUBTRACT": "-",
+            "BINARY_TRUE_DIVIDE": "/",
+            "BINARY_XOR": "^",
+        }
+    )
     CALL = {"CALL"} if _MIN_PY311 else {"CALL_FUNCTION", "CALL_METHOD"}
     CONTROL_FLOW = (
         {
@@ -68,14 +71,18 @@ class OpNames:
     LOAD_VALUES = frozenset(("LOAD_CONST", "LOAD_DEREF", "LOAD_FAST", "LOAD_GLOBAL"))
     LOAD_ATTR = {"LOAD_METHOD", "LOAD_ATTR"} if _MIN_PY311 else {"LOAD_METHOD"}
     LOAD = LOAD_VALUES | {"LOAD_METHOD", "LOAD_ATTR"}
-    SYNTHETIC = {
-        "POLARS_EXPRESSION": 1,
-    }
-    UNARY = {
-        "UNARY_NEGATIVE": "-",
-        "UNARY_POSITIVE": "+",
-        "UNARY_NOT": "~",
-    }
+    SYNTHETIC = MappingProxyType(
+        {
+            "POLARS_EXPRESSION": 1,
+        }
+    )
+    UNARY = MappingProxyType(
+        {
+            "UNARY_NEGATIVE": "-",
+            "UNARY_POSITIVE": "+",
+            "UNARY_NOT": "~",
+        }
+    )
     PARSEABLE_OPS = (
         {"BINARY_OP", "BINARY_SUBSCR", "COMPARE_OP", "CONTAINS_OP", "IS_OP"}
         | set(UNARY)

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -159,10 +159,7 @@ ban-relative-imports = "all"
 strict = true
 
 [tool.ruff.per-file-ignores]
-"polars/datatypes.py" = ["B019"]
 "tests/**/*.py" = ["D100", "D103", "B018"]
-"polars/utils/show_versions.py" = ["D301"]
-"polars/utils/udfs.py" = ["RUF012"]
 
 [tool.pytest.ini_options]
 addopts = [

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1157,7 +1157,6 @@ def test_describe() -> None:
     date_s = pl.Series([date(2021, 1, 1), date(2021, 1, 2), date(2021, 1, 3)])
     empty_s = pl.Series(np.empty(0))
 
-    pl.DataFrame
     assert dict(num_s.describe().rows()) == {  # type: ignore[arg-type]
         "count": 3.0,
         "mean": 2.0,


### PR DESCRIPTION
Docstrings for tests is the only (reasonable imo) exception left.

Most exceptions were easy fixes or ignores, the only somewhat useful exception would be to allow statements with no effect for `with pytest.raises( ... )` checks (assign to underscore per convention), but I also found a genuine mistake by removing the exception to the rule here.