### PR TITLE
feat(python): support bytecode translation to `map_dict` where the lookup key is an expression

### DIFF
--- a/py-polars/tests/unit/operations/test_inefficient_apply.py
+++ b/py-polars/tests/unit/operations/test_inefficient_apply.py
@@ -29,7 +29,8 @@ EVAL_ENVIRONMENT = {
 )
 def test_parse_invalid_function(func: Callable[[Any], Any]) -> None:
     # functions we don't (yet?) offer suggestions for
-    assert not BytecodeParser(func, apply_target="expr").can_rewrite()
+    parser = BytecodeParser(func, apply_target="expr")
+    assert not parser.can_attempt_rewrite() or not parser.to_expression("x")
 
 
 @pytest.mark.parametrize(
@@ -74,7 +75,7 @@ def test_parse_apply_raw_functions() -> None:
 
         # note: we can't parse/rewrite raw numpy functions...
         parser = BytecodeParser(func, apply_target="expr")
-        assert not parser.can_rewrite()
+        assert not parser.can_attempt_rewrite()
 
         # ...but we ARE still able to warn
         with pytest.warns(


### PR DESCRIPTION
Integrates `BINARY_SUBSCR` into the generic binary operator translation path so that we can support suggestions where the key is itself an expression.

This enables new suggestions for `apply` functions that use lookups, such as...
```python
import polars as pl

ascii = { o:chr(o) for o in range(127) }

df = pl.DataFrame({
    "ord": [40,50,60,70,80,90,100,110],
}).with_columns(
    prev_chr = pl.col('ord').apply( lambda x: ascii[x-1] ),
    next_chr = pl.col('ord').apply( lambda x: ascii[x+1] ),
)
```
...which will now generate the following:
```
PolarsInefficientApplyWarning: 
Expr.apply is significantly slower than the native expressions API.
Only use if you absolutely CANNOT implement your logic otherwise.
In this case, you can replace your `apply` with the following:
  - pl.col("ord").apply(lambda x: ...)
  + (pl.col("ord") - 1).map_dict(ascii)

PolarsInefficientApplyWarning: 
Expr.apply is significantly slower than the native expressions API.
Only use if you absolutely CANNOT implement your logic otherwise.
In this case, you can replace your `apply` with the following:
  - pl.col("ord").apply(lambda x: ...)
  + (pl.col("ord") + 1).map_dict(ascii)
```
Also: renamed BytecodeParser's `can_rewrite` method to `can_attempt_rewrite`, as we do not know if bytecode containing `BINARY_SUBSCR` _is_ rewritable until we check frame variables during expression translation.

---

(For the curious...)
```python
df.with_columns(
    chr = pl.col("ord").map_dict(ascii),
    prev_chr = (pl.col("ord") - 1).map_dict(ascii),
    next_chr = (pl.col("ord") + 1).map_dict(ascii),
)
# shape: (8, 4)
# ┌─────┬─────┬──────────┬──────────┐
# │ ord ┆ chr ┆ prev_chr ┆ next_chr │
# │ --- ┆ --- ┆ ---      ┆ ---      │
# │ i64 ┆ str ┆ str      ┆ str      │
# ╞═════╪═════╪══════════╪══════════╡
# │ 40  ┆ (   ┆ '        ┆ )        │
# │ 50  ┆ 2   ┆ 1        ┆ 3        │
# │ 60  ┆ <   ┆ ;        ┆ =        │
# │ 70  ┆ F   ┆ E        ┆ G        │
# │ 80  ┆ P   ┆ O        ┆ Q        │
# │ 90  ┆ Z   ┆ Y        ┆ [        │
# │ 100 ┆ d   ┆ c        ┆ e        │
# │ 110 ┆ n   ┆ m        ┆ o        │
# └─────┴─────┴──────────┴──────────┘
```