### PR TITLE
feat(python): Native implementation of dataframe interchange protocol

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -16,7 +16,6 @@ from polars import api
 from polars.config import Config
 from polars.convert import (
     from_arrow,
-    from_dataframe,
     from_dict,
     from_dicts,
     from_numpy,
@@ -148,6 +147,7 @@ from polars.functions import (
     when,
     zeros,
 )
+from polars.interchange.from_dataframe import from_dataframe
 from polars.io import (
     read_avro,
     read_csv,

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -15,12 +15,11 @@ from polars.datatypes import (
     Struct,
     Utf8,
 )
-from polars.dependencies import _PYARROW_AVAILABLE
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoDataError
 from polars.io import read_csv
-from polars.utils.various import _cast_repr_strings_with_schema, parse_version
+from polars.utils.various import _cast_repr_strings_with_schema
 
 if TYPE_CHECKING:
     from polars import DataFrame, Series
@@ -726,80 +725,3 @@ def from_pandas(
         )
     else:
         raise ValueError(f"Expected pandas DataFrame or Series, got {type(data)}.")
-
-
-def from_dataframe(df: Any, *, allow_copy: bool = True) -> DataFrame:
-    """
-    Build a Polars DataFrame from any dataframe supporting the interchange protocol.
-
-    Parameters
-    ----------
-    df
-        Object supporting the dataframe interchange protocol, i.e. must have implemented
-        the ``__dataframe__`` method.
-    allow_copy
-        Allow memory to be copied to perform the conversion. If set to False, causes
-        conversions that are not zero-copy to fail.
-
-    Notes
-    -----
-    Details on the dataframe interchange protocol:
-    https://data-apis.org/dataframe-protocol/latest/index.html
-
-    Using a dedicated function like :func:`from_pandas` or :func:`from_arrow` is a more
-    efficient method of conversion.
-
-    Polars currently relies on pyarrow's implementation of the dataframe interchange
-    protocol. Therefore, pyarrow>=11.0.0 is required for this function to work.
-
-    Because Polars can not currently guarantee zero-copy conversion from Arrow for
-    categorical columns, ``allow_copy=False`` will not work if the dataframe contains
-    categorical data.
-
-    """
-    if isinstance(df, pl.DataFrame):
-        return df
-    if not hasattr(df, "__dataframe__"):
-        raise TypeError(
-            f"`df` of type {type(df)} does not support the dataframe interchange protocol."
-        )
-
-    pa_table = _df_to_pyarrow_table(df, allow_copy=allow_copy)
-    return from_arrow(pa_table, rechunk=allow_copy)  # type: ignore[return-value]
-
-
-def _df_to_pyarrow_table(df: Any, *, allow_copy: bool = False) -> pa.Table:
-    if not _PYARROW_AVAILABLE or parse_version(pa.__version__) < parse_version("11"):
-        raise ImportError(
-            "pyarrow>=11.0.0 is required for converting a dataframe interchange object"
-            " to a Polars dataframe."
-        )
-
-    import pyarrow.interchange  # noqa: F401
-
-    if not allow_copy:
-        return _df_to_pyarrow_table_zero_copy(df)
-
-    return pa.interchange.from_dataframe(df, allow_copy=True)
-
-
-def _df_to_pyarrow_table_zero_copy(df: Any) -> pa.Table:
-    dfi = df.__dataframe__(allow_copy=False)
-    if _dfi_contains_categorical_data(dfi):
-        raise TypeError(
-            "Polars can not currently guarantee zero-copy conversion from Arrow for "
-            " categorical columns. Set `allow_copy=True` or cast categorical columns to"
-            " string first."
-        )
-
-    if isinstance(df, pa.Table):
-        return df
-    elif isinstance(df, pa.RecordBatch):
-        return pa.Table.from_batches([df])
-    else:
-        return pa.interchange.from_dataframe(dfi, allow_copy=False)
-
-
-def _dfi_contains_categorical_data(dfi: Any) -> bool:
-    CATEGORICAL_DTYPE = 23
-    return any(c.dtype[0] == CATEGORICAL_DTYPE for c in dfi.get_columns())

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -45,7 +45,7 @@ class DataTypeClass(type):
     def _string_repr(cls) -> str:
         return _dtype_str_repr(cls)
 
-    def base_type(cls) -> PolarsDataType:
+    def base_type(cls) -> DataTypeClass:
         """Return the base type."""
         return cls
 

--- a/py-polars/polars/interchange/__init__.py
+++ b/py-polars/polars/interchange/__init__.py
@@ -1,0 +1,6 @@
+"""
+Module containing the implementation of the Python dataframe interchange protocol.
+
+Details on the protocol:
+https://data-apis.org/dataframe-protocol/latest/index.html
+"""

--- a/py-polars/polars/interchange/buffer.py
+++ b/py-polars/polars/interchange/buffer.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from polars.interchange.protocol import DlpackDeviceType, DtypeKind
+from polars.interchange.utils import polars_dtype_to_dtype
+
+if TYPE_CHECKING:
+    from typing import NoReturn
+
+    from polars import Series
+
+
+class PolarsBuffer:
+    """A buffer backed by a Polars Series consisting of a single chunk."""
+
+    def __init__(self, data: Series, *, allow_copy: bool = True):
+        if data.n_chunks() > 1:
+            if not allow_copy:
+                raise RuntimeError(
+                    "non-contiguous buffer must be made contiguous, which is not zero-copy"
+                )
+            data = data.rechunk()
+
+        self._data = data
+
+    @property
+    def bufsize(self) -> int:
+        """Buffer size in bytes."""
+        dtype = polars_dtype_to_dtype(self._data.dtype)
+
+        if dtype[0] == DtypeKind.STRING:
+            return self._data.str.lengths().sum()  # type: ignore[return-value]
+
+        n_bits = self._data.len() * dtype[1]
+
+        result, rest = divmod(n_bits, 8)
+        # Round up to the nearest byte
+        if rest:
+            return result + 1
+        else:
+            return result
+
+    @property
+    def ptr(self) -> int:
+        """Pointer to start of the buffer as an integer."""
+        _offset, _length, pointer = self._data._s.get_ptr()
+        return pointer
+
+    def __dlpack__(self) -> NoReturn:
+        """Represent this structure as DLPack interface."""
+        raise NotImplementedError("__dlpack__")
+
+    def __dlpack_device__(self) -> tuple[DlpackDeviceType, None]:
+        """Device type and device ID for where the data in the buffer resides."""
+        return (DlpackDeviceType.CPU, None)
+
+    def __repr__(self) -> str:
+        bufsize = self.bufsize
+        ptr = self.ptr
+        device = self.__dlpack_device__()[0].name
+        return f"PolarsBuffer(bufsize={bufsize}, ptr={ptr}, device={device!r})"

--- a/py-polars/polars/interchange/buffer.py
+++ b/py-polars/polars/interchange/buffer.py
@@ -12,7 +12,18 @@ if TYPE_CHECKING:
 
 
 class PolarsBuffer:
-    """A buffer backed by a Polars Series consisting of a single chunk."""
+    """
+    A buffer object backed by a Polars Series consisting of a single chunk.
+
+    Parameters
+    ----------
+    data
+        The Polars Series backing the buffer object.
+    allow_copy
+        Allow data to be copied during operations on this column. If set to ``False``,
+        a RuntimeError will be raised if data would be copied.
+
+    """
 
     def __init__(self, data: Series, *, allow_copy: bool = True):
         if data.n_chunks() > 1:

--- a/py-polars/polars/interchange/column.py
+++ b/py-polars/polars/interchange/column.py
@@ -17,7 +17,18 @@ if TYPE_CHECKING:
 
 
 class PolarsColumn:
-    """A column backed by a Polars Series."""
+    """
+    A column object backed by a Polars Series.
+
+    Parameters
+    ----------
+    column
+        The Polars Series backing the column object.
+    allow_copy
+        Allow data to be copied during operations on this column. If set to ``False``,
+        a RuntimeError will be raised if data would be copied.
+
+    """
 
     def __init__(self, column: Series, *, allow_copy: bool = True):
         if column.dtype == Categorical and not column.cat.is_local():
@@ -91,7 +102,23 @@ class PolarsColumn:
         return self._col.n_chunks()
 
     def get_chunks(self, n_chunks: int | None = None) -> Iterator[PolarsColumn]:
-        """Return an iterator yielding the column chunks."""
+        """
+        Return an iterator yielding the column chunks.
+
+        Parameters
+        ----------
+        n_chunks
+            The number of chunks to return. Must be a multiple of the number of chunks
+            in the column.
+
+        Notes
+        -----
+        When ``n_chunks`` is higher than the number of chunks in the column, a slice
+        must be performed that is not on the chunk boundary. This will trigger some
+        compute if the column contains null values or if the column is of data type
+        boolean.
+
+        """
         total_n_chunks = self.num_chunks()
         chunks = self._col.get_chunks()
 

--- a/py-polars/polars/interchange/column.py
+++ b/py-polars/polars/interchange/column.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from polars.datatypes import Boolean, Categorical, Int64, UInt32
+from polars.interchange.buffer import PolarsBuffer
+from polars.interchange.protocol import ColumnNullType, DtypeKind
+from polars.interchange.utils import polars_dtype_to_dtype
+from polars.utils._wrap import wrap_s
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import Any
+
+    from polars import Series
+    from polars.interchange.protocol import CategoricalDescription, ColumnBuffers, Dtype
+
+
+class PolarsColumn:
+    """A column backed by a Polars Series."""
+
+    def __init__(self, column: Series, *, allow_copy: bool = True):
+        if column.dtype == Categorical and not column.cat.is_local():
+            if not allow_copy:
+                raise RuntimeError(
+                    f"column {column.name!r} must be converted to a local categorical,"
+                    " which is not zero-copy"
+                )
+            column = column.cat.to_local()
+
+        self._col = column
+        self._allow_copy = allow_copy
+
+    def size(self) -> int:
+        """Size of the column in elements."""
+        return self._col.len()
+
+    @property
+    def offset(self) -> int:
+        """Offset of the first element with respect to the start of the underlying buffer."""  # noqa: W505
+        offset, _length, _pointer = self._col._s.get_ptr()
+        return offset
+
+    @property
+    def dtype(self) -> Dtype:
+        """Data type of the column."""
+        pl_dtype = self._col.dtype
+        return polars_dtype_to_dtype(pl_dtype)
+
+    @property
+    def describe_categorical(self) -> CategoricalDescription:
+        """
+        Description of the categorical data type of the column.
+
+        Raises
+        ------
+        TypeError
+            If the data type of the column is not categorical.
+
+        """
+        if self.dtype[0] != DtypeKind.CATEGORICAL:
+            raise TypeError("`describe_categorical` only works on categorical columns")
+
+        categories = self._col.cat.get_categories()
+        return {
+            "is_ordered": not self._col.cat.uses_lexical_ordering(),
+            "is_dictionary": True,
+            "categories": PolarsColumn(categories, allow_copy=self._allow_copy),
+        }
+
+    @property
+    def describe_null(self) -> tuple[ColumnNullType, int | None]:
+        """Description of the null representation the column uses."""
+        if self.null_count == 0:
+            return ColumnNullType.NON_NULLABLE, None
+        else:
+            return ColumnNullType.USE_BITMASK, 0
+
+    @property
+    def null_count(self) -> int:
+        """The number of null elements."""
+        return self._col.null_count()
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """The metadata for the column."""
+        return {}
+
+    def num_chunks(self) -> int:
+        """Return the number of chunks the column consists of."""
+        return self._col.n_chunks()
+
+    def get_chunks(self, n_chunks: int | None = None) -> Iterator[PolarsColumn]:
+        """Return an iterator yielding the column chunks."""
+        total_n_chunks = self.num_chunks()
+        chunks = self._col.get_chunks()
+
+        if (n_chunks is None) or (n_chunks == total_n_chunks):
+            for chunk in chunks:
+                yield PolarsColumn(chunk, allow_copy=self._allow_copy)
+
+        elif (n_chunks <= 0) or (n_chunks % total_n_chunks != 0):
+            raise ValueError(
+                "`n_chunks` must be a multiple of the number of chunks of this column"
+                f" ({total_n_chunks})"
+            )
+
+        else:
+            subchunks_per_chunk = n_chunks // total_n_chunks
+            for chunk in chunks:
+                size = len(chunk)
+                step = size // subchunks_per_chunk
+                if size % subchunks_per_chunk != 0:
+                    step += 1
+                for start in range(0, step * subchunks_per_chunk, step):
+                    yield PolarsColumn(
+                        chunk[start : start + step], allow_copy=self._allow_copy
+                    )
+
+    def get_buffers(self) -> ColumnBuffers:
+        """Return a dictionary containing the underlying buffers."""
+        return {
+            "data": self._get_data_buffer(),
+            "validity": self._get_validity_buffer(),
+            "offsets": self._get_offsets_buffer(),
+        }
+
+    def _get_data_buffer(self) -> tuple[PolarsBuffer, Dtype]:
+        if self.dtype[0] == DtypeKind.CATEGORICAL:
+            dtype = polars_dtype_to_dtype(UInt32)
+        else:
+            dtype = self.dtype
+
+        s = wrap_s(self._col._s.get_buffer(0))
+        buffer = PolarsBuffer(s, allow_copy=self._allow_copy)
+        return buffer, dtype
+
+    def _get_validity_buffer(self) -> tuple[PolarsBuffer, Dtype] | None:
+        buffer = self._col._s.get_buffer(1)
+        if buffer is None:
+            return None
+
+        s = wrap_s(buffer)
+        buffer = PolarsBuffer(s, allow_copy=self._allow_copy)
+        dtype = polars_dtype_to_dtype(Boolean)
+        return buffer, dtype
+
+    def _get_offsets_buffer(self) -> tuple[PolarsBuffer, Dtype] | None:
+        buffer = self._col._s.get_buffer(2)
+        if buffer is None:
+            return None
+
+        s = wrap_s(buffer)
+        buffer = PolarsBuffer(s, allow_copy=self._allow_copy)
+        dtype = polars_dtype_to_dtype(Int64)
+        return buffer, dtype

--- a/py-polars/polars/interchange/dataframe.py
+++ b/py-polars/polars/interchange/dataframe.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from itertools import accumulate
+from typing import TYPE_CHECKING
+
+from polars.interchange.column import PolarsColumn
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import Any
+
+    from polars import DataFrame
+
+
+class PolarsDataFrame:
+    """A dataframe object backed by a Polars DataFrame."""
+
+    def __init__(self, df: DataFrame, *, allow_copy: bool = True):
+        self._df = df
+        self._allow_copy = allow_copy
+
+    def __dataframe__(
+        self, nan_as_null: bool = False, allow_copy: bool = True
+    ) -> PolarsDataFrame:
+        """
+        Construct a new dataframe object, potentially changing the parameters.
+
+        Parameters
+        ----------
+        nan_as_null
+            Overwrite null values in the data with ``NaN``.
+
+            .. warning::
+                This functionality has not been implemented and the parameter will be
+                removed in a future version.
+                Setting this to ``True`` will raise a ``NotImplementedError``.
+        allow_copy
+            Allow memory to be copied to perform the conversion. If set to ``False``,
+            causes conversions that are not zero-copy to fail.
+
+        """
+        if nan_as_null:
+            raise NotImplementedError(
+                "functionality for `nan_as_null` has not been implemented and the"
+                " parameter will be removed in a future version."
+                " Use the default `nan_as_null=False`."
+            )
+        return PolarsDataFrame(self._df, allow_copy=allow_copy)
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        """The metadata for the dataframe."""
+        return {}
+
+    def num_columns(self) -> int:
+        """Return the number of columns in the dataframe."""
+        return self._df.width
+
+    def num_rows(self) -> int:
+        """Return the number of rows in the dataframe."""
+        return self._df.height
+
+    def num_chunks(self) -> int:
+        """
+        Return the number of chunks the dataframe consists of.
+
+        It is possible for a Polars dataframe to consist of columns with a varying
+        number of chunks. This method returns the number of chunks of the first
+        column.
+
+        See Also
+        --------
+        polars.dataframe.frame.DataFrame.n_chunks
+
+        """
+        return self._df.n_chunks("first")
+
+    def column_names(self) -> list[str]:
+        """Return the column names."""
+        return self._df.columns
+
+    def get_column(self, i: int) -> PolarsColumn:
+        """Return the column at the indicated position."""
+        s = self._df.to_series(i)
+        return PolarsColumn(s, allow_copy=self._allow_copy)
+
+    def get_column_by_name(self, name: str) -> PolarsColumn:
+        """Return the column with the given name."""
+        s = self._df.get_column(name)
+        return PolarsColumn(s, allow_copy=self._allow_copy)
+
+    def get_columns(self) -> Iterator[PolarsColumn]:
+        """Return an iterator yielding the columns."""
+        for column in self._df.get_columns():
+            yield PolarsColumn(column, allow_copy=self._allow_copy)
+
+    def select_columns(self, indices: Sequence[int]) -> PolarsDataFrame:
+        """Create a new DataFrame by selecting a subset of columns by index."""
+        if not isinstance(indices, Sequence):
+            raise TypeError("`indices` is not a sequence")
+        if not isinstance(indices, list):
+            indices = list(indices)
+
+        return PolarsDataFrame(
+            self._df[:, indices],
+            allow_copy=self._allow_copy,
+        )
+
+    def select_columns_by_name(self, names: Sequence[str]) -> PolarsDataFrame:
+        """Create a new dataframe by selecting a subset of columns by name."""
+        if not isinstance(names, Sequence):
+            raise TypeError("`names` is not a sequence")
+
+        return PolarsDataFrame(
+            self._df.select(names),
+            allow_copy=self._allow_copy,
+        )
+
+    def get_chunks(self, n_chunks: int | None = None) -> Iterator[PolarsDataFrame]:
+        """Return an iterator yielding the chunks of the dataframe."""
+        total_n_chunks = self.num_chunks()
+        chunks = self._get_chunks_from_col_chunks()
+
+        if (n_chunks is None) or (n_chunks == total_n_chunks):
+            for chunk in chunks:
+                yield PolarsDataFrame(chunk, allow_copy=self._allow_copy)
+
+        elif (n_chunks <= 0) or (n_chunks % total_n_chunks != 0):
+            raise ValueError(
+                "`n_chunks` must be a multiple of the number of chunks of this"
+                f" dataframe ({total_n_chunks})"
+            )
+
+        else:
+            subchunks_per_chunk = n_chunks // total_n_chunks
+            for chunk in chunks:
+                size = len(chunk)
+                step = size // subchunks_per_chunk
+                if size % subchunks_per_chunk != 0:
+                    step += 1
+                for start in range(0, step * subchunks_per_chunk, step):
+                    yield PolarsDataFrame(
+                        chunk[start : start + step, :],
+                        allow_copy=self._allow_copy,
+                    )
+
+    def _get_chunks_from_col_chunks(self) -> Iterator[DataFrame]:
+        """
+        Return chunks of this dataframe according to the chunks of the first column.
+
+        If columns are not all chunked identically, they will be rechunked like the
+        first column. If copy is not allowed, this raises a RuntimeError.
+        """
+        col_chunks = self.get_column(0).get_chunks()
+        chunk_sizes = [chunk.size() for chunk in col_chunks]
+        starts = [0] + list(accumulate(chunk_sizes))
+
+        for i in range(len(starts) - 1):
+            start, end = starts[i : i + 2]
+            chunk = self._df[start:end, :]
+
+            if not all(x == 1 for x in chunk.n_chunks("all")):
+                if not self._allow_copy:
+                    raise RuntimeError(
+                        "unevenly chunked columns must be rechunked, which is not zero-copy"
+                    )
+                chunk = chunk.rechunk()
+
+            yield chunk

--- a/py-polars/polars/interchange/from_dataframe.py
+++ b/py-polars/polars/interchange/from_dataframe.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import polars._reexport as pl
+from polars.convert import from_arrow
+from polars.dependencies import _PYARROW_AVAILABLE
+from polars.dependencies import pyarrow as pa
+from polars.utils.various import parse_version
+
+if TYPE_CHECKING:
+    from polars import DataFrame
+
+
+def from_dataframe(df: Any, *, allow_copy: bool = True) -> DataFrame:
+    """
+    Build a Polars DataFrame from any dataframe supporting the interchange protocol.
+
+    Parameters
+    ----------
+    df
+        Object supporting the dataframe interchange protocol, i.e. must have implemented
+        the ``__dataframe__`` method.
+    allow_copy
+        Allow memory to be copied to perform the conversion. If set to False, causes
+        conversions that are not zero-copy to fail.
+
+    Notes
+    -----
+    Details on the Python dataframe interchange protocol:
+    https://data-apis.org/dataframe-protocol/latest/index.html
+
+    Using a dedicated function like :func:`from_pandas` or :func:`from_arrow` is a more
+    efficient method of conversion.
+
+    Polars currently relies on pyarrow's implementation of the dataframe interchange
+    protocol. Therefore, pyarrow>=11.0.0 is required for this function to work.
+
+    Because Polars can not currently guarantee zero-copy conversion from Arrow for
+    categorical columns, ``allow_copy=False`` will not work if the dataframe contains
+    categorical data.
+
+    Examples
+    --------
+    Convert a pandas dataframe to Polars through the interchange protocol.
+
+    >>> import pandas as pd
+    >>> df_pd = pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0], "c": ["x", "y"]})
+    >>> dfi = df_pd.__dataframe__()
+    >>> pl.from_dataframe(dfi)
+    shape: (2, 3)
+    ┌─────┬─────┬─────┐
+    │ a   ┆ b   ┆ c   │
+    │ --- ┆ --- ┆ --- │
+    │ i64 ┆ f64 ┆ str │
+    ╞═════╪═════╪═════╡
+    │ 1   ┆ 3.0 ┆ x   │
+    │ 2   ┆ 4.0 ┆ y   │
+    └─────┴─────┴─────┘
+
+    """
+    if isinstance(df, pl.DataFrame):
+        return df
+    if not hasattr(df, "__dataframe__"):
+        raise TypeError(
+            f"`df` of type {type(df)} does not support the dataframe interchange protocol."
+        )
+
+    pa_table = _df_to_pyarrow_table(df, allow_copy=allow_copy)
+    return from_arrow(pa_table, rechunk=allow_copy)  # type: ignore[return-value]
+
+
+def _df_to_pyarrow_table(df: Any, *, allow_copy: bool = False) -> pa.Table:
+    if not _PYARROW_AVAILABLE or parse_version(pa.__version__) < parse_version("11"):
+        raise ImportError(
+            "pyarrow>=11.0.0 is required for converting a dataframe interchange object"
+            " to a Polars dataframe."
+        )
+
+    import pyarrow.interchange  # noqa: F401
+
+    if not allow_copy:
+        return _df_to_pyarrow_table_zero_copy(df)
+
+    return pa.interchange.from_dataframe(df, allow_copy=True)
+
+
+def _df_to_pyarrow_table_zero_copy(df: Any) -> pa.Table:
+    dfi = df.__dataframe__(allow_copy=False)
+    if _dfi_contains_categorical_data(dfi):
+        raise TypeError(
+            "Polars can not currently guarantee zero-copy conversion from Arrow for "
+            " categorical columns. Set `allow_copy=True` or cast categorical columns to"
+            " string first."
+        )
+
+    if isinstance(df, pa.Table):
+        return df
+    elif isinstance(df, pa.RecordBatch):
+        return pa.Table.from_batches([df])
+    else:
+        return pa.interchange.from_dataframe(dfi, allow_copy=False)
+
+
+def _dfi_contains_categorical_data(dfi: Any) -> bool:
+    CATEGORICAL_DTYPE = 23
+    return any(c.dtype[0] == CATEGORICAL_DTYPE for c in dfi.get_columns())

--- a/py-polars/polars/interchange/protocol.py
+++ b/py-polars/polars/interchange/protocol.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import TYPE_CHECKING, Literal, Tuple, TypedDict
+
+if TYPE_CHECKING:
+    import sys
+
+    from polars.interchange.buffer import PolarsBuffer
+    from polars.interchange.column import PolarsColumn
+
+    if sys.version_info >= (3, 10):
+        from typing import TypeAlias
+    else:
+        from typing_extensions import TypeAlias
+
+
+class DtypeKind(IntEnum):
+    """
+    Integer enum for data types.
+
+    Attributes
+    ----------
+    INT : int
+        Matches to signed integer data type.
+    UINT : int
+        Matches to unsigned integer data type.
+    FLOAT : int
+        Matches to floating point data type.
+    BOOL : int
+        Matches to boolean data type.
+    STRING : int
+        Matches to string data type (UTF-8 encoded).
+    DATETIME : int
+        Matches to datetime data type.
+    CATEGORICAL : int
+        Matches to categorical data type.
+    """
+
+    INT = 0
+    UINT = 1
+    FLOAT = 2
+    BOOL = 20
+    STRING = 21  # UTF-8
+    DATETIME = 22
+    CATEGORICAL = 23
+
+
+Dtype: TypeAlias = Tuple[DtypeKind, int, str, str]  # see Column.dtype
+
+
+class ColumnNullType(IntEnum):
+    """
+    Integer enum for null type representation.
+
+    Attributes
+    ----------
+    NON_NULLABLE : int
+        Non-nullable column.
+    USE_NAN : int
+        Use explicit float NaN value.
+    USE_SENTINEL : int
+        Sentinel value besides NaN.
+    USE_BITMASK : int
+        The bit is set/unset representing a null on a certain position.
+    USE_BYTEMASK : int
+        The byte is set/unset representing a null on a certain position.
+    """
+
+    NON_NULLABLE = 0
+    USE_NAN = 1
+    USE_SENTINEL = 2
+    USE_BITMASK = 3
+    USE_BYTEMASK = 4
+
+
+class ColumnBuffers(TypedDict):
+    """Buffers backing a column."""
+
+    # first element is a buffer containing the column data;
+    # second element is the data buffer's associated dtype
+    data: tuple[PolarsBuffer, Dtype]
+
+    # first element is a buffer containing mask values indicating missing data;
+    # second element is the mask value buffer's associated dtype.
+    # None if the null representation is not a bit or byte mask
+    validity: tuple[PolarsBuffer, Dtype] | None
+
+    # first element is a buffer containing the offset values for
+    # variable-size binary data (e.g., variable-length strings);
+    # second element is the offsets buffer's associated dtype.
+    # None if the data buffer does not have an associated offsets buffer
+    offsets: tuple[PolarsBuffer, Dtype] | None
+
+
+class CategoricalDescription(TypedDict):
+    """Description of a categorical column."""
+
+    # whether the ordering of dictionary indices is semantically meaningful
+    is_ordered: bool
+    # whether a dictionary-style mapping of categorical values to other objects exists
+    is_dictionary: Literal[True]
+    # Python-level only (e.g. ``{int: str}``).
+    # None if not a dictionary-style categorical.
+    categories: PolarsColumn
+
+
+class DlpackDeviceType(IntEnum):
+    """Integer enum for device type codes matching DLPack."""
+
+    CPU = 1
+    CUDA = 2
+    CPU_PINNED = 3
+    OPENCL = 4
+    VULKAN = 7
+    METAL = 8
+    VPI = 9
+    ROCM = 10
+
+
+class Endianness:
+    """Enum indicating the byte-order of a data type."""
+
+    LITTLE = "<"
+    BIG = ">"
+    NATIVE = "="
+    NA = "|"

--- a/py-polars/polars/interchange/utils.py
+++ b/py-polars/polars/interchange/utils.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+from polars.interchange.protocol import DtypeKind, Endianness
+
+if TYPE_CHECKING:
+    from polars.interchange.protocol import Dtype
+    from polars.type_aliases import PolarsDataType
+
+
+def polars_dtype_to_dtype(dtype: PolarsDataType) -> Dtype:
+    """Convert Polars data type to interchange protocol data type."""
+    if dtype == pl.Int8:
+        return DtypeKind.INT, 8, "c", Endianness.NATIVE
+    elif dtype == pl.Int16:
+        return DtypeKind.INT, 16, "s", Endianness.NATIVE
+    elif dtype == pl.Int32:
+        return DtypeKind.INT, 32, "i", Endianness.NATIVE
+    elif dtype == pl.Int64:
+        return DtypeKind.INT, 64, "l", Endianness.NATIVE
+    elif dtype == pl.UInt8:
+        return DtypeKind.UINT, 8, "C", Endianness.NATIVE
+    elif dtype == pl.UInt16:
+        return DtypeKind.UINT, 16, "S", Endianness.NATIVE
+    elif dtype == pl.UInt32:
+        return DtypeKind.UINT, 32, "I", Endianness.NATIVE
+    elif dtype == pl.UInt64:
+        return DtypeKind.UINT, 64, "L", Endianness.NATIVE
+    elif dtype == pl.Float32:
+        return DtypeKind.FLOAT, 32, "f", Endianness.NATIVE
+    elif dtype == pl.Float64:
+        return DtypeKind.FLOAT, 64, "g", Endianness.NATIVE
+    elif dtype == pl.Boolean:
+        return DtypeKind.BOOL, 1, "b", Endianness.NATIVE
+    elif dtype == pl.Utf8:
+        return DtypeKind.STRING, 8, "U", Endianness.NATIVE
+    elif dtype == pl.Date:
+        return DtypeKind.DATETIME, 32, "tdD", Endianness.NATIVE
+    elif dtype == pl.Time:
+        return DtypeKind.DATETIME, 64, "ttu", Endianness.NATIVE
+    elif dtype == pl.Datetime:
+        tu = dtype.time_unit[0] if dtype.time_unit is not None else "u"  # type: ignore[union-attr]
+        tz = dtype.time_zone if dtype.time_zone is not None else ""  # type: ignore[union-attr]
+        arrow_c_type = f"ts{tu}:{tz}"
+        return DtypeKind.DATETIME, 64, arrow_c_type, Endianness.NATIVE
+    elif dtype == pl.Duration:
+        tu = dtype.time_unit[0] if dtype.time_unit is not None else "u"  # type: ignore[union-attr]
+        arrow_c_type = f"tD{tu}"
+        return DtypeKind.DATETIME, 64, arrow_c_type, Endianness.NATIVE
+    elif dtype == pl.Categorical:
+        return DtypeKind.CATEGORICAL, 32, "I", Endianness.NATIVE
+    else:
+        raise ValueError(f"data type {dtype} not supported by interchange protocol")

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3677,3 +3677,13 @@ def test_flags() -> None:
         "a": {"SORTED_ASC": True, "SORTED_DESC": False},
         "b": {"SORTED_ASC": False, "SORTED_DESC": False},
     }
+
+
+def test_interchange() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0], "c": ["foo", "bar"]})
+    dfi = df.__dataframe__()
+
+    # Testing some random properties to make sure conversion happened correctly
+    assert dfi.num_rows() == 2
+    assert dfi.get_column(0).dtype[1] == 64
+    assert dfi.get_column_by_name("c").get_buffers()["data"][0].bufsize == 6

--- a/py-polars/tests/unit/interchange/test_buffer.py
+++ b/py-polars/tests/unit/interchange/test_buffer.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+
+import polars as pl
+from polars.interchange.buffer import PolarsBuffer
+from polars.interchange.protocol import DlpackDeviceType
+
+
+@pytest.mark.parametrize(
+    ("data", "allow_copy"),
+    [
+        (pl.Series([1, 2]), True),
+        (pl.Series([1, 2]), False),
+        (pl.concat([pl.Series([1, 2]), pl.Series([1, 2])], rechunk=False), True),
+    ],
+)
+def test_init(data: pl.Series, allow_copy: bool) -> None:
+    buffer = PolarsBuffer(data, allow_copy=allow_copy)
+    assert buffer._data.n_chunks() == 1
+
+
+def test_init_invalid_input() -> None:
+    s = pl.Series([1, 2])
+    data = pl.concat([s, s], rechunk=False)
+
+    with pytest.raises(RuntimeError):
+        PolarsBuffer(data, allow_copy=False)
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (pl.Series([1, 2], dtype=pl.Int8), 2),
+        (pl.Series([1, 2], dtype=pl.Int64), 16),
+        (pl.Series([1.4, 2.9, 3.0], dtype=pl.Float32), 12),
+        (pl.Series(["a", "bc", "éâç"], dtype=pl.Utf8), 9),
+        (pl.Series(["a", "b", "a", "c", "a"], dtype=pl.Categorical), 20),
+        (pl.Series([True, False], dtype=pl.Boolean), 1),
+        (pl.Series([True] * 9, dtype=pl.Boolean), 2),
+    ],
+)
+def test_bufsize(data: pl.Series, expected: int) -> None:
+    buffer = PolarsBuffer(data)
+    assert buffer.bufsize == expected
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pl.Series([1, 2]),
+        pl.Series([1, 2, 3], dtype=pl.UInt8),
+        pl.Series([1.2, 2.9, 3.0]),
+        pl.Series([True, False]),
+        pl.Series([date(2022, 1, 1), date(2022, 2, 1)]),
+        pl.Series([datetime(2022, 1, 1), datetime(2022, 2, 1)]),
+        pl.Series(["a", "b", "a"]),
+        pl.Series(["a", "b", "a"], dtype=pl.Categorical),
+        pl.Series([]),
+    ],
+)
+def test_ptr(data: pl.Series) -> None:
+    buffer = PolarsBuffer(data)
+    result = buffer.ptr
+    # Memory address is unpredictable - so we just check if an integer is returned
+    assert isinstance(result, int)
+
+
+def test__dlpack__() -> None:
+    data = pl.Series([1, 2])
+    buffer = PolarsBuffer(data)
+    with pytest.raises(NotImplementedError):
+        buffer.__dlpack__()
+
+
+def test__dlpack_device__() -> None:
+    data = pl.Series([1, 2])
+    buffer = PolarsBuffer(data)
+    assert buffer.__dlpack_device__() == (DlpackDeviceType.CPU, None)
+
+
+def test__repr__() -> None:
+    data = pl.Series([True, False, True])
+    buffer = PolarsBuffer(data)
+    print(buffer.__repr__())

--- a/py-polars/tests/unit/interchange/test_column.py
+++ b/py-polars/tests/unit/interchange/test_column.py
@@ -1,0 +1,295 @@
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+from polars.interchange.column import PolarsColumn
+from polars.interchange.protocol import ColumnNullType, DtypeKind
+from polars.testing import assert_series_equal
+
+
+def test_init_global_categorical_zero_copy_fails() -> None:
+    with pl.StringCache():
+        s = pl.Series("a", ["x"], dtype=pl.Categorical)
+
+    with pytest.raises(
+        RuntimeError, match="column 'a' must be converted to a local categorical"
+    ):
+        PolarsColumn(s, allow_copy=False)
+
+
+def test_size() -> None:
+    s = pl.Series([1, 2, 3])
+    col = PolarsColumn(s)
+    assert col.size() == 3
+
+
+def test_offset() -> None:
+    s = pl.Series([1, 2, 3])
+    col = PolarsColumn(s)
+    assert col.offset == 0
+
+
+def test_dtype_int() -> None:
+    s = pl.Series([1, 2, 3], dtype=pl.Int32)
+    col = PolarsColumn(s)
+    assert col.dtype == (DtypeKind.INT, 32, "i", "=")
+
+
+def test_dtype_categorical() -> None:
+    s = pl.Series(["a", "b", "a"], dtype=pl.Categorical)
+    col = PolarsColumn(s)
+    assert col.dtype == (DtypeKind.CATEGORICAL, 32, "I", "=")
+
+
+def test_describe_categorical() -> None:
+    s = pl.Series(["b", "a", "a", "c", None, "b"], dtype=pl.Categorical)
+    col = PolarsColumn(s)
+
+    out = col.describe_categorical
+
+    assert out["is_ordered"] is True
+    assert out["is_dictionary"] is True
+
+    expected_categories = pl.Series(["b", "a", "c"])
+    assert_series_equal(out["categories"]._col, expected_categories)
+
+
+def test_describe_categorical_lexical_ordering() -> None:
+    s = pl.Series(["b", "a", "a", "c", None, "b"], dtype=pl.Categorical)
+    s = s.cat.set_ordering("lexical")
+    col = PolarsColumn(s)
+
+    out = col.describe_categorical
+
+    assert out["is_ordered"] is False
+
+
+def test_describe_categorical_other_dtype() -> None:
+    s = pl.Series(["a", "b", "a"], dtype=pl.Utf8)
+    col = PolarsColumn(s)
+    with pytest.raises(TypeError):
+        col.describe_categorical
+
+
+def test_describe_null() -> None:
+    s = pl.Series([1, 2, None])
+    col = PolarsColumn(s)
+    assert col.describe_null == (ColumnNullType.USE_BITMASK, 0)
+
+
+def test_describe_null_no_null_values() -> None:
+    s = pl.Series([1, 2, 3])
+    col = PolarsColumn(s)
+    assert col.describe_null == (ColumnNullType.NON_NULLABLE, None)
+
+
+def test_null_count() -> None:
+    s = pl.Series([None, 2, None])
+    col = PolarsColumn(s)
+    assert col.null_count == 2
+
+
+def test_metadata() -> None:
+    s = pl.Series([1, 2])
+    col = PolarsColumn(s)
+    assert col.metadata == {}
+
+
+def test_num_chunks() -> None:
+    s = pl.Series([1, 2])
+    col = PolarsColumn(s)
+    assert col.num_chunks() == 1
+
+    s2 = pl.concat([s, s], rechunk=False)
+    col2 = s2.to_frame().__dataframe__().get_column(0)
+    assert col2.num_chunks() == 2
+
+
+@pytest.mark.parametrize("n_chunks", [None, 2])
+def test_get_chunks(n_chunks: int | None) -> None:
+    s1 = pl.Series([1, 2, 3])
+    s2 = pl.Series([4, 5])
+    s = pl.concat([s1, s2], rechunk=False)
+    col = PolarsColumn(s)
+
+    out = col.get_chunks(n_chunks)
+
+    expected = [s1, s2]
+    for o, e in zip(out, expected):
+        assert_series_equal(o._col, e)
+
+
+def test_get_chunks_invalid_input() -> None:
+    s1 = pl.Series([1, 2, 3])
+    s2 = pl.Series([4, 5])
+    s = pl.concat([s1, s2], rechunk=False)
+    col = PolarsColumn(s)
+
+    with pytest.raises(ValueError):
+        next(col.get_chunks(0))
+
+    with pytest.raises(ValueError):
+        next(col.get_chunks(3))
+
+
+def test_get_chunks_subdivided_chunks() -> None:
+    s1 = pl.Series([1, 2, 3])
+    s2 = pl.Series([4, 5])
+    s = pl.concat([s1, s2], rechunk=False)
+    col = PolarsColumn(s)
+
+    out = col.get_chunks(4)
+
+    chunk1 = next(out)
+    expected1 = pl.Series([1, 2])
+    assert_series_equal(chunk1._col, expected1)
+
+    chunk2 = next(out)
+    expected2 = pl.Series([3])
+    assert_series_equal(chunk2._col, expected2)
+
+    chunk3 = next(out)
+    expected3 = pl.Series([4])
+    assert_series_equal(chunk3._col, expected3)
+
+    chunk4 = next(out)
+    expected4 = pl.Series([5])
+    assert_series_equal(chunk4._col, expected4)
+
+    with pytest.raises(StopIteration):
+        next(out)
+
+
+def test_get_buffers() -> None:
+    s = pl.Series([1, 2, 3], dtype=pl.Int8)
+    col = PolarsColumn(s)
+
+    out = col.get_buffers()
+
+    data_buffer, data_dtype = out["data"]
+    assert_series_equal(data_buffer._data, s)
+    assert data_dtype == (DtypeKind.INT, 8, "c", "=")
+
+    assert out["validity"] is None
+    assert out["offsets"] is None
+
+
+def test_get_buffers_with_validity_and_offsets() -> None:
+    s = pl.Series(["a", "bc", None, "éâç"])
+    col = PolarsColumn(s)
+
+    out = col.get_buffers()
+
+    data_buffer, data_dtype = out["data"]
+    expected = pl.Series([97, 98, 99, 195, 169, 195, 162, 195, 167], dtype=pl.UInt8)
+    assert_series_equal(data_buffer._data, expected)
+    assert data_dtype == (DtypeKind.STRING, 8, "U", "=")
+
+    validity = out["validity"]
+    assert validity is not None
+    val_buffer, val_dtype = validity
+    expected = pl.Series([True, True, False, True])
+    assert_series_equal(val_buffer._data, expected)
+    assert val_dtype == (DtypeKind.BOOL, 1, "b", "=")
+
+    offsets = out["offsets"]
+    assert offsets is not None
+    offsets_buffer, offsets_dtype = offsets
+    expected = pl.Series([0, 1, 3, 3, 9], dtype=pl.Int64)
+    assert_series_equal(offsets_buffer._data, expected)
+    assert offsets_dtype == (DtypeKind.INT, 64, "l", "=")
+
+
+def test_get_buffers_chunked_bitmask() -> None:
+    s = pl.Series([True, False], dtype=pl.Boolean)
+    s_chunked = pl.concat([s[:1], s[1:]], rechunk=False)
+    col = PolarsColumn(s_chunked)
+
+    chunks = list(col.get_chunks())
+    assert chunks[0].get_buffers()["data"][0]._data.item() is True
+    assert chunks[1].get_buffers()["data"][0]._data.item() is False
+
+
+def test_get_buffers_chunked_zero_copy_fails() -> None:
+    s1 = pl.Series([1, 2, 3])
+    s = pl.concat([s1, s1], rechunk=False)
+    col = PolarsColumn(s, allow_copy=False)
+
+    with pytest.raises(RuntimeError):
+        col.get_buffers()
+
+
+def test_get_data_buffer() -> None:
+    s = pl.Series([1, None, 3], dtype=pl.Int16)
+    col = PolarsColumn(s)
+
+    result_buffer, result_dtype = col._get_data_buffer()
+
+    expected = pl.Series([1, 0, 3], dtype=pl.Int16)
+    assert_series_equal(result_buffer._data, expected)
+    assert result_dtype == (DtypeKind.INT, 16, "s", "=")
+
+
+def test_get_data_buffer_categorical() -> None:
+    s = pl.Series(["a", "b", "a"], dtype=pl.Categorical)
+    col = PolarsColumn(s)
+
+    result_buffer, result_dtype = col._get_data_buffer()
+
+    expected = pl.Series([0, 1, 0], dtype=pl.UInt32)
+    assert_series_equal(result_buffer._data, expected)
+    assert result_dtype == (DtypeKind.UINT, 32, "I", "=")
+
+
+def test_get_validity_buffer() -> None:
+    s = pl.Series(["a", None, "b"])
+    col = PolarsColumn(s)
+
+    validity = col._get_validity_buffer()
+
+    assert validity is not None
+
+    result_buffer, result_dtype = validity
+    expected = pl.Series([True, False, True])
+    assert_series_equal(result_buffer._data, expected)
+    assert result_dtype == (DtypeKind.BOOL, 1, "b", "=")
+
+
+def test_get_validity_buffer_no_nulls() -> None:
+    s = pl.Series([1.0, 3.0, 2.0])
+    col = PolarsColumn(s)
+
+    assert col._get_validity_buffer() is None
+
+
+def test_get_offsets_buffer() -> None:
+    s = pl.Series(["a", "bc", None, "éâç"])
+    col = PolarsColumn(s)
+
+    offsets = col._get_offsets_buffer()
+
+    assert offsets is not None
+
+    result_buffer, result_dtype = offsets
+    expected = pl.Series([0, 1, 3, 3, 9], dtype=pl.Int64)
+    assert_series_equal(result_buffer._data, expected)
+    assert result_dtype == (DtypeKind.INT, 64, "l", "=")
+
+
+def test_get_offsets_buffer_nonstring_dtype() -> None:
+    s = pl.Series([1, 2, 3], dtype=pl.Int32)
+    col = PolarsColumn(s)
+    assert col._get_validity_buffer() is None
+
+
+def test_column_unsupported_types() -> None:
+    s = pl.Series("a", [[4], [5, 6]])
+    col = PolarsColumn(s)
+
+    # Certain column operations work
+    assert col.num_chunks() == 1
+
+    # Error is raised when unsupported operations are requested
+    with pytest.raises(ValueError, match="not supported"):
+        col.dtype

--- a/py-polars/tests/unit/interchange/test_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_dataframe.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+from polars.interchange.dataframe import PolarsDataFrame
+from polars.testing import assert_frame_equal, assert_series_equal
+
+
+def test_dataframe_dunder() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    dfi = PolarsDataFrame(df)
+
+    assert_frame_equal(dfi._df, df)
+    assert dfi._allow_copy is True
+
+    dfi_new = dfi.__dataframe__(allow_copy=False)
+
+    assert_frame_equal(dfi_new._df, df)
+    assert dfi_new._allow_copy is False
+
+
+def test_dataframe_dunder_nan_as_null_not_implemented() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    dfi = PolarsDataFrame(df)
+
+    with pytest.raises(NotImplementedError, match="has not been implemented"):
+        df.__dataframe__(nan_as_null=True)
+
+    with pytest.raises(NotImplementedError, match="has not been implemented"):
+        dfi.__dataframe__(nan_as_null=True)
+
+
+def test_metadata() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    dfi = PolarsDataFrame(df)
+    assert dfi.metadata == {}
+
+
+def test_num_columns() -> None:
+    df = pl.DataFrame({"a": [1], "b": [2]})
+    dfi = PolarsDataFrame(df)
+    assert dfi.num_columns() == 2
+
+
+def test_num_rows() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    dfi = PolarsDataFrame(df)
+    assert dfi.num_rows() == 2
+
+
+def test_num_chunks() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    dfi = PolarsDataFrame(df)
+    assert dfi.num_chunks() == 1
+
+    df2 = pl.concat([df, df], rechunk=False)
+    dfi2 = df2.__dataframe__()
+    assert dfi2.num_chunks() == 2
+
+
+def test_column_names() -> None:
+    df = pl.DataFrame({"a": [1], "b": [2]})
+    dfi = PolarsDataFrame(df)
+    assert dfi.column_names() == ["a", "b"]
+
+
+def test_get_column() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    dfi = PolarsDataFrame(df)
+
+    out = dfi.get_column(1)
+
+    expected = pl.Series("b", [3, 4])
+    assert_series_equal(out._col, expected)
+
+
+def test_get_column_by_name() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    dfi = PolarsDataFrame(df)
+
+    out = dfi.get_column_by_name("b")
+
+    expected = pl.Series("b", [3, 4])
+    assert_series_equal(out._col, expected)
+
+
+def test_get_columns() -> None:
+    s1 = pl.Series("a", [1, 2])
+    s2 = pl.Series("b", [3, 4])
+    df = pl.DataFrame([s1, s2])
+    dfi = PolarsDataFrame(df)
+
+    out = dfi.get_columns()
+
+    expected = [s1, s2]
+    for o, e in zip(out, expected):
+        assert_series_equal(o._col, e)
+
+
+def test_select_columns() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    dfi = PolarsDataFrame(df)
+
+    out = dfi.select_columns([0, 2])
+
+    expected = pl.DataFrame({"a": [1, 2], "c": [5, 6]})
+    assert_frame_equal(out._df, expected)
+
+
+def test_select_columns_nonlist_input() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    dfi = PolarsDataFrame(df)
+
+    out = dfi.select_columns((2,))
+
+    expected = pl.DataFrame({"c": [5, 6]})
+    assert_frame_equal(out._df, expected)
+
+
+def test_select_columns_invalid_input() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    dfi = PolarsDataFrame(df)
+
+    with pytest.raises(TypeError):
+        dfi.select_columns(1)  # type: ignore[arg-type]
+
+
+def test_select_columns_by_name() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    dfi = PolarsDataFrame(df)
+
+    out = dfi.select_columns_by_name(["a", "c"])
+
+    expected = pl.DataFrame({"a": [1, 2], "c": [5, 6]})
+    assert_frame_equal(out._df, expected)
+
+
+def test_select_columns_by_name_invalid_input() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]})
+    dfi = PolarsDataFrame(df)
+
+    with pytest.raises(TypeError):
+        dfi.select_columns_by_name(1)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("n_chunks", [None, 2])
+def test_get_chunks(n_chunks: int | None) -> None:
+    df1 = pl.DataFrame({"a": [1, 2], "b": [4, 5]})
+    df2 = pl.DataFrame({"a": [3], "b": [6]})
+    df = pl.concat([df1, df2], rechunk=False)
+    dfi = PolarsDataFrame(df)
+
+    out = dfi.get_chunks(n_chunks)
+
+    expected = dfi._get_chunks_from_col_chunks()
+    for o, e in zip(out, expected):
+        assert_frame_equal(o._df, e)
+
+
+def test_get_chunks_invalid_input() -> None:
+    df1 = pl.DataFrame({"a": [1, 2], "b": [4, 5]})
+    df2 = pl.DataFrame({"a": [3], "b": [6]})
+    df = pl.concat([df1, df2], rechunk=False)
+
+    dfi = PolarsDataFrame(df)
+
+    with pytest.raises(ValueError):
+        next(dfi.get_chunks(0))
+
+    with pytest.raises(ValueError):
+        next(dfi.get_chunks(3))
+
+
+def test_get_chunks_subdivided_chunks() -> None:
+    df1 = pl.DataFrame({"a": [1, 2, 3], "b": [6, 7, 8]})
+    df2 = pl.DataFrame({"a": [4, 5], "b": [9, 0]})
+    df = pl.concat([df1, df2], rechunk=False)
+
+    dfi = PolarsDataFrame(df)
+    out = dfi.get_chunks(4)
+
+    chunk1 = next(out)
+    expected1 = pl.DataFrame({"a": [1, 2], "b": [6, 7]})
+    assert_frame_equal(chunk1._df, expected1)
+
+    chunk2 = next(out)
+    expected2 = pl.DataFrame({"a": [3], "b": [8]})
+    assert_frame_equal(chunk2._df, expected2)
+
+    chunk3 = next(out)
+    expected3 = pl.DataFrame({"a": [4], "b": [9]})
+    assert_frame_equal(chunk3._df, expected3)
+
+    chunk4 = next(out)
+    expected4 = pl.DataFrame({"a": [5], "b": [0]})
+    assert_frame_equal(chunk4._df, expected4)
+
+    with pytest.raises(StopIteration):
+        next(out)
+
+
+def test_get_chunks_zero_copy_fail() -> None:
+    col1 = pl.Series([1, 2])
+    col2 = pl.concat([pl.Series([3]), pl.Series([4])], rechunk=False)
+    df = pl.DataFrame({"a": col1, "b": col2})
+
+    dfi = PolarsDataFrame(df, allow_copy=False)
+
+    with pytest.raises(RuntimeError):
+        next(dfi.get_chunks())
+
+
+@pytest.mark.parametrize("allow_copy", [True, False])
+def test_get_chunks_from_col_chunks_single_chunk(allow_copy: bool) -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+
+    dfi = PolarsDataFrame(df, allow_copy=allow_copy)
+    out = dfi._get_chunks_from_col_chunks()
+
+    chunk1 = next(out)
+    assert_frame_equal(chunk1, df)
+
+    with pytest.raises(StopIteration):
+        next(out)
+
+
+@pytest.mark.parametrize("allow_copy", [True, False])
+def test_get_chunks_from_col_chunks_even_chunks(allow_copy: bool) -> None:
+    df1 = pl.DataFrame({"a": [1, 2], "b": [4, 5]})
+    df2 = pl.DataFrame({"a": [3], "b": [6]})
+    df = pl.concat([df1, df2], rechunk=False)
+
+    dfi = PolarsDataFrame(df, allow_copy=allow_copy)
+    out = dfi._get_chunks_from_col_chunks()
+
+    chunk1 = next(out)
+    assert_frame_equal(chunk1, df1)
+
+    chunk2 = next(out)
+    assert_frame_equal(chunk2, df2)
+
+    with pytest.raises(StopIteration):
+        next(out)
+
+
+def test_get_chunks_from_col_chunks_uneven_chunks_allow_copy() -> None:
+    col1 = pl.concat([pl.Series([1, 2]), pl.Series([3, 4, 5])], rechunk=False)
+    col2 = pl.concat(
+        [pl.Series([6, 7]), pl.Series([8]), pl.Series([9, 0])], rechunk=False
+    )
+    df = pl.DataFrame({"a": col1, "b": col2})
+
+    dfi = PolarsDataFrame(df, allow_copy=True)
+    out = dfi._get_chunks_from_col_chunks()
+
+    expected1 = pl.DataFrame({"a": [1, 2], "b": [6, 7]})
+    chunk1 = next(out)
+    assert_frame_equal(chunk1, expected1)
+
+    expected2 = pl.DataFrame({"a": [3, 4, 5], "b": [8, 9, 0]})
+    chunk2 = next(out)
+    assert_frame_equal(chunk2, expected2)
+
+    with pytest.raises(StopIteration):
+        next(out)
+
+
+def test_get_chunks_from_col_chunks_uneven_chunks_zero_copy_fails() -> None:
+    col1 = pl.concat([pl.Series([1, 2]), pl.Series([3, 4, 5])], rechunk=False)
+    col2 = pl.concat(
+        [pl.Series([6, 7]), pl.Series([8]), pl.Series([9, 0])], rechunk=False
+    )
+    df = pl.DataFrame({"a": col1, "b": col2})
+
+    dfi = PolarsDataFrame(df, allow_copy=False)
+    out = dfi._get_chunks_from_col_chunks()
+
+    # First chunk can be yielded zero copy
+    expected1 = pl.DataFrame({"a": [1, 2], "b": [6, 7]})
+    chunk1 = next(out)
+    assert_frame_equal(chunk1, expected1)
+
+    # Second chunk requires a rechunk of the second column
+    with pytest.raises(RuntimeError, match="columns must be rechunked"):
+        next(out)
+
+
+def test_dataframe_unsupported_types() -> None:
+    df = pl.DataFrame({"a": [[4], [5, 6]]})
+    dfi = PolarsDataFrame(df)
+
+    # Generic dataframe operations work fine
+    assert dfi.num_rows() == 2
+
+    # Certain column operations also work
+    col = dfi.get_column_by_name("a")
+    assert col.num_chunks() == 1
+
+    # Error is raised when unsupported operations are requested
+    with pytest.raises(ValueError, match="not supported"):
+        col.dtype

--- a/py-polars/tests/unit/interchange/test_from_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_from_dataframe.py
@@ -112,11 +112,16 @@ def test_from_dataframe_data_type_not_implemented_by_arrow(
         pl.from_dataframe(dfi)
 
 
-@pytest.mark.parametrize("dtype", [pl.Boolean])
-def test_from_dataframe_data_type_not_yet_implemented_by_arrow(
-    dtype: pl.PolarsDataType,
-) -> None:
-    df = pl.Series(dtype=dtype).to_frame()
-    dfi = df.__dataframe__()
-    with pytest.raises(NotImplementedError, match="not yet supported"):
-        pl.from_dataframe(dfi)
+# Remove xfail marker when the issue is fixed:
+# https://github.com/apache/arrow/issues/37050
+@pytest.mark.xfail(
+    reason="Bug in pyarrow's implementation of the interchange protocol."
+)
+def test_from_dataframe_empty_arrow_interchange_object() -> None:
+    df = pl.Series("a", dtype=pl.Int8).to_frame()
+    df_pa = df.to_arrow()
+    dfi = df_pa.__dataframe__()
+
+    result = pl.from_dataframe(dfi)
+
+    assert_frame_equal(result, df)

--- a/py-polars/tests/unit/interchange/test_from_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_from_dataframe.py
@@ -1,62 +1,13 @@
+from __future__ import annotations
+
 from typing import Any
 
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal
-
-
-def test_interchange() -> None:
-    df = pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0], "c": ["foo", "bar"]})
-    dfi = df.__dataframe__()
-
-    # Testing some random properties to make sure conversion happened correctly
-    assert dfi.num_rows() == 2
-    assert dfi.get_column(0).dtype[1] == 64
-    assert dfi.get_column_by_name("c").get_buffers()["data"][0].bufsize == 6
-
-
-def test_interchange_pyarrow_required(monkeypatch: Any) -> None:
-    monkeypatch.setattr(pl.dataframe.frame, "_PYARROW_AVAILABLE", False)
-
-    df = pl.DataFrame({"a": [1, 2]})
-    with pytest.raises(ImportError, match="pyarrow"):
-        df.__dataframe__()
-
-
-def test_interchange_pyarrow_min_version(monkeypatch: Any) -> None:
-    monkeypatch.setattr(
-        pl.dataframe.frame.pa,  # type: ignore[attr-defined]
-        "__version__",
-        "10.0.0",
-    )
-
-    df = pl.DataFrame({"a": [1, 2]})
-    with pytest.raises(ImportError, match="pyarrow"):
-        df.__dataframe__()
-
-
-def test_interchange_categorical() -> None:
-    df = pl.DataFrame({"a": ["foo", "bar"]}, schema={"a": pl.Categorical})
-
-    # Conversion requires copy
-    dfi = df.__dataframe__(allow_copy=True)
-    assert dfi.get_column_by_name("a").dtype[0] == 23  # 23 signifies categorical dtype
-
-    # If copy not allowed, throws an error
-    with pytest.raises(TypeError, match="categorical"):
-        df.__dataframe__(allow_copy=False)
-
-
-def test_interchange_nested_categorical() -> None:
-    df = pl.DataFrame(
-        {"a": [1, 2], "b": ["a", "b"], "c": [["q"], ["x"]]},
-        schema_overrides={"c": pl.List(pl.Categorical)},
-    )
-
-    with pytest.raises(TypeError, match="categorical"):
-        df.__dataframe__(allow_copy=False)
 
 
 def test_from_dataframe_polars() -> None:
@@ -84,6 +35,26 @@ def test_from_dataframe_pandas() -> None:
     assert_frame_equal(result, expected)
 
 
+def test_from_dataframe_pyarrow_table_zero_copy() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0], "c": ["foo", "bar"]})
+    df_pa = df.to_arrow()
+
+    result = pl.from_dataframe(df_pa, allow_copy=False)
+    assert_frame_equal(result, df)
+
+
+def test_from_dataframe_pyarrow_recordbatch_zero_copy() -> None:
+    a = pa.array([1, 2])
+    b = pa.array([3.0, 4.0])
+    c = pa.array(["foo", "bar"])
+    batch = pa.record_batch([a, b, c], names=["a", "b", "c"])
+
+    result = pl.from_dataframe(batch, allow_copy=False)
+
+    expected = pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0], "c": ["foo", "bar"]})
+    assert_frame_equal(result, expected)
+
+
 def test_from_dataframe_allow_copy() -> None:
     # Zero copy only allowed when input is already a Polars dataframe
     df = pl.DataFrame({"a": [1, 2]})
@@ -107,7 +78,7 @@ def test_from_dataframe_invalid_type() -> None:
 
 
 def test_from_dataframe_pyarrow_required(monkeypatch: Any) -> None:
-    monkeypatch.setattr(pl.convert, "_PYARROW_AVAILABLE", False)
+    monkeypatch.setattr(pl.interchange.from_dataframe, "_PYARROW_AVAILABLE", False)
 
     df = pl.DataFrame({"a": [1, 2]})
     with pytest.raises(ImportError, match="pyarrow"):
@@ -128,4 +99,24 @@ def test_from_dataframe_pyarrow_min_version(monkeypatch: Any) -> None:
     )
 
     with pytest.raises(ImportError, match="pyarrow"):
+        pl.from_dataframe(dfi)
+
+
+@pytest.mark.parametrize("dtype", [pl.Date, pl.Time, pl.Duration])
+def test_from_dataframe_data_type_not_implemented_by_arrow(
+    dtype: pl.PolarsDataType,
+) -> None:
+    df = pl.Series(dtype=dtype).to_frame()
+    dfi = df.__dataframe__()
+    with pytest.raises(NotImplementedError, match="not supported"):
+        pl.from_dataframe(dfi)
+
+
+@pytest.mark.parametrize("dtype", [pl.Boolean])
+def test_from_dataframe_data_type_not_yet_implemented_by_arrow(
+    dtype: pl.PolarsDataType,
+) -> None:
+    df = pl.Series(dtype=dtype).to_frame()
+    dfi = df.__dataframe__()
+    with pytest.raises(NotImplementedError, match="not yet supported"):
         pl.from_dataframe(dfi)

--- a/py-polars/tests/unit/interchange/test_roundtrip.py
+++ b/py-polars/tests/unit/interchange/test_roundtrip.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.interchange
+import pytest
+from hypothesis import given, note
+
+import polars as pl
+from polars.testing import assert_frame_equal
+from polars.testing.parametric import dataframes
+
+protocol_dtypes = [
+    pl.Int8,
+    pl.Int16,
+    pl.Int32,
+    pl.Int64,
+    pl.UInt8,
+    pl.UInt16,
+    pl.UInt32,
+    pl.UInt64,
+    pl.Float32,
+    pl.Float64,
+    pl.Boolean,
+    pl.Utf8,
+    pl.Datetime,
+    pl.Categorical,
+]
+
+
+@given(dataframes(allowed_dtypes=protocol_dtypes, excluded_dtypes=[pl.Boolean]))
+def test_roundtrip_polars_parametric(df: pl.DataFrame) -> None:
+    dfi = df.__dataframe__()
+    with pl.StringCache():
+        result = pl.from_dataframe(dfi)
+    assert_frame_equal(result, df, categorical_as_str=True)
+
+
+@given(
+    dataframes(
+        allowed_dtypes=protocol_dtypes,
+        excluded_dtypes=[pl.Boolean, pl.Categorical],
+        chunked=False,
+    )
+)
+def test_roundtrip_polars_zero_copy_parametric(df: pl.DataFrame) -> None:
+    dfi = df.__dataframe__(allow_copy=False)
+    result = pl.from_dataframe(dfi, allow_copy=False)
+    assert_frame_equal(result, df, categorical_as_str=True)
+
+
+@given(dataframes(allowed_dtypes=protocol_dtypes, excluded_dtypes=[pl.Boolean]))
+def test_roundtrip_pyarrow_parametric(df: pl.DataFrame) -> None:
+    dfi = df.__dataframe__()
+    note(f"n_chunks: {dfi.num_chunks()}")
+    df_pa = pa.interchange.from_dataframe(dfi)
+    with pl.StringCache():
+        result: pl.DataFrame = pl.from_arrow(df_pa)  # type: ignore[assignment]
+    assert_frame_equal(result, df, categorical_as_str=True)
+
+
+@given(
+    dataframes(
+        allowed_dtypes=protocol_dtypes,
+        excluded_dtypes=[pl.Boolean, pl.Categorical],
+        chunked=False,
+    )
+)
+def test_roundtrip_pyarrow_zero_copy_parametric(df: pl.DataFrame) -> None:
+    dfi = df.__dataframe__(allow_copy=False)
+    note(f"n_chunks: {dfi.num_chunks()}")
+    df_pa = pa.interchange.from_dataframe(dfi, allow_copy=False)
+    result: pl.DataFrame = pl.from_arrow(df_pa)  # type: ignore[assignment]
+    assert_frame_equal(result, df, categorical_as_str=True)
+
+
+@given(dataframes(allowed_dtypes=protocol_dtypes))
+@pytest.mark.filterwarnings(
+    "ignore:.*PEP3118 format string that does not match its itemsize:RuntimeWarning"
+)
+def test_roundtrip_pandas_parametric(df: pl.DataFrame) -> None:
+    dfi = df.__dataframe__()
+    df_pd = pd.api.interchange.from_dataframe(dfi)
+    result = pl.from_pandas(df_pd, nan_to_null=False)
+    assert_frame_equal(result, df, categorical_as_str=True)
+
+
+@given(
+    dataframes(
+        allowed_dtypes=protocol_dtypes,
+        excluded_dtypes=[pl.Categorical],
+        chunked=False,
+    )
+)
+@pytest.mark.filterwarnings(
+    "ignore:.*PEP3118 format string that does not match its itemsize:RuntimeWarning"
+)
+def test_roundtrip_pandas_zero_copy_parametric(df: pl.DataFrame) -> None:
+    dfi = df.__dataframe__(allow_copy=False)
+    df_pd = pd.api.interchange.from_dataframe(dfi, allow_copy=False)
+    result = pl.from_pandas(df_pd, nan_to_null=False)
+    assert_frame_equal(result, df, categorical_as_str=True)
+
+
+def test_roundtrip_pandas_boolean_subchunks() -> None:
+    df = pl.Series("a", [False, False]).to_frame()
+    df_chunked = pl.concat([df[0, :], df[1, :]], rechunk=False)
+    dfi = df_chunked.__dataframe__()
+
+    df_pd = pd.api.interchange.from_dataframe(dfi)
+    result = pl.from_pandas(df_pd, nan_to_null=False)
+
+    assert_frame_equal(result, df)
+
+
+# Remove xfail marker when support is implemented,
+# or we write our own `from_dataframe` implementation.
+# https://github.com/apache/arrow/issues/33982#issuecomment-1669278644
+@pytest.mark.xfail(
+    reason="Boolean support not yet implemented in pyarrow's implementation of `from_dataframe`."
+)
+def test_roundtrip_pyarrow_boolean() -> None:
+    df = pl.Series("a", [True, False], dtype=pl.Boolean).to_frame()
+    dfi = df.__dataframe__()
+
+    df_pa = pa.interchange.from_dataframe(dfi)
+    result: pl.DataFrame = pl.from_arrow(df_pa)  # type: ignore[assignment]
+
+    assert_frame_equal(result, df)

--- a/py-polars/tests/unit/interchange/test_utils.py
+++ b/py-polars/tests/unit/interchange/test_utils.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import polars as pl
+from polars.interchange.protocol import DtypeKind, Endianness
+from polars.interchange.utils import polars_dtype_to_dtype
+
+if TYPE_CHECKING:
+    from polars.interchange.protocol import Dtype
+
+NE = Endianness.NATIVE
+
+
+@pytest.mark.parametrize(
+    ("polars_dtype", "dtype"),
+    [
+        (pl.Int8, (DtypeKind.INT, 8, "c", NE)),
+        (pl.Int16, (DtypeKind.INT, 16, "s", NE)),
+        (pl.Int32, (DtypeKind.INT, 32, "i", NE)),
+        (pl.Int64, (DtypeKind.INT, 64, "l", NE)),
+        (pl.UInt8, (DtypeKind.UINT, 8, "C", NE)),
+        (pl.UInt16, (DtypeKind.UINT, 16, "S", NE)),
+        (pl.UInt32, (DtypeKind.UINT, 32, "I", NE)),
+        (pl.UInt64, (DtypeKind.UINT, 64, "L", NE)),
+        (pl.Float32, (DtypeKind.FLOAT, 32, "f", NE)),
+        (pl.Float64, (DtypeKind.FLOAT, 64, "g", NE)),
+        (pl.Boolean, (DtypeKind.BOOL, 1, "b", NE)),
+        (pl.Utf8, (DtypeKind.STRING, 8, "U", NE)),
+        (pl.Date, (DtypeKind.DATETIME, 32, "tdD", NE)),
+        (pl.Time, (DtypeKind.DATETIME, 64, "ttu", NE)),
+        (pl.Categorical, (DtypeKind.CATEGORICAL, 32, "I", NE)),
+        (pl.Duration, (DtypeKind.DATETIME, 64, "tDu", NE)),
+        (pl.Duration(time_unit="ns"), (DtypeKind.DATETIME, 64, "tDn", NE)),
+        (pl.Datetime, (DtypeKind.DATETIME, 64, "tsu:", NE)),
+        (pl.Datetime(time_unit="ms"), (DtypeKind.DATETIME, 64, "tsm:", NE)),
+        (
+            pl.Datetime(time_zone="Amsterdam/Europe"),
+            (DtypeKind.DATETIME, 64, "tsu:Amsterdam/Europe", NE),
+        ),
+        (
+            pl.Datetime(time_unit="ns", time_zone="Asia/Seoul"),
+            (DtypeKind.DATETIME, 64, "tsn:Asia/Seoul", NE),
+        ),
+    ],
+)
+def test_polars_dtype_to_dtype(polars_dtype: pl.DataType, dtype: Dtype) -> None:
+    assert polars_dtype_to_dtype(polars_dtype) == dtype
+
+
+def test_polars_dtype_to_dtype_unsupported_type() -> None:
+    with pytest.raises(ValueError, match="not supported"):
+        polars_dtype_to_dtype(pl.List)


### PR DESCRIPTION
Closes #10035

Changes:
* Implement `DataFrame.__dataframe__` natively, rather than relying on pyarrow.
* Move existing `from_dataframe` implementation to the new `interchange` module. For this function, we still rely on pyarrow's implementation (for now).