### PR TITLE
feat(rust): add extra build profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,15 +235,14 @@ This can be done by going through the following steps in sequence:
 
 1. Install the latest [Rust compiler](https://www.rust-lang.org/tools/install)
 2. Install [maturin](https://maturin.rs/): `pip install maturin`
-3. Choose any of:
-   - Fastest binary, very long compile times:
-     ```sh
-     $ cd py-polars && maturin develop --release -- -C target-cpu=native
-     ```
-   - Fast binary, Shorter compile times:
-     ```sh
-     $ cd py-polars && maturin develop --release -- -C codegen-units=16 -C lto=thin -C target-cpu=native
-     ```
+3. `cd py-polars` and choose one of the following:
+   - `make build-release`, fastest binary, very long compile times
+   - `make build-opt`, fast binary with debug symbols, long compile times
+   - `make build-debug-opt`, medium-speed binary with debug assertions and symbols, medium compile times
+   - `make build`, slow binary with debug assertions and symbols, fast compile times
+
+   Append `-native` (e.g. `make build-release-native`) to enable further optimizations specific to
+   your CPU. This produces a non-portable binary/wheel however.
 
 Note that the Rust crate implementing the Python bindings is called `py-polars` to distinguish from the wrapped
 Rust crate `polars` itself. However, both the Python package and the Python module are named `polars`, so you

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -181,6 +181,17 @@ features = [
 name = "polars"
 crate-type = ["cdylib"]
 
+[profile.opt-dev]
+inherits = "dev"
+opt-level = 1
+
+[profile.debug-release]
+inherits = "release"
+debug = true
+incremental = true
+codegen-units = 16
+lto = "thin"
+
 [profile.release]
 codegen-units = 1
 lto = "fat"

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -25,9 +25,35 @@ requirements: .venv  ## Install/refresh all project requirements
 build: .venv  ## Compile and install Polars for development
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop
 
+.PHONY: build-debug-opt
+build-debug-opt: .venv  ## Compile and install Polars for development, with minimal optimizations turned on
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --profile opt-dev
+
+.PHONY: build-opt
+build-opt: .venv  ## Compile and install Polars for performance-sensitive development, with nearly \
+	                 full optimization on and debug assertions turned off, but with debug symbols on
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --profile debug-release
+
 .PHONY: build-release
-build-release: .venv  ## Compile and install a faster Polars binary
+build-release: .venv  ## Compile and install a faster Polars binary with full optimizations
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --release
+	
+.PHONY: build-native
+build-native: .venv  ## Same as build, except with native CPU optimizations turned on
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -- -C target-cpu=native
+
+.PHONY: build-debug-opt-native
+build-debug-opt-native: .venv  ## Same as build-debug-opt, except with native CPU optimizations turned on
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --profile opt-dev -- -C target-cpu=native
+
+.PHONY: build-opt-native
+build-opt-native: .venv  ## Same as build-opt, except with native CPU optimizations turned on
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --profile debug-release -- -C target-cpu=native
+
+.PHONY: build-release-native
+build-release-native: .venv  ## Same as build-release, except with native CPU optimizations turned on
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --release -- -C target-cpu=native
+	
 
 .PHONY: fmt
 fmt: .venv  ## Run autoformatting and linting


### PR DESCRIPTION
This provides more performant options (in terms of build time) for release mode through `make build-opt` and more performant options (in terms of runtime) for debug mode through `make build-debug-opt`.

They're also directly available from the Rust side under the profiles `debug-release` and `opt-dev` respectively.