### PR TITLE
feat(python): raise `TypeError` for all LazyFrame comparison operators

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -661,10 +661,7 @@ class LazyFrame:
         )
 
     def _comparison_error(self, other: Any) -> NoReturn:
-        raise TypeError(
-            "Cannot compare ambiguous LazyFrame structures; call .collect() "
-            "to materialize to DataFrame before comparison."
-        )
+        raise TypeError("Cannot compare LazyFrames; call .collect() to materialize.")
 
     __eq__ = _comparison_error
     __ne__ = _comparison_error

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -661,7 +661,7 @@ class LazyFrame:
         )
 
     def _comparison_error(self, other: Any) -> NoReturn:
-        raise TypeError("Cannot compare LazyFrames; call .collect() to materialize.")
+        raise TypeError("Cannot compare LazyFrames.")
 
     __eq__ = _comparison_error
     __ne__ = _comparison_error

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -80,7 +80,6 @@ if TYPE_CHECKING:
     from polars.type_aliases import (
         AsofJoinStrategy,
         ClosedInterval,
-        ComparisonOperator,
         CsvEncoding,
         FillNullStrategy,
         FrameInitTypes,
@@ -636,68 +635,6 @@ class LazyFrame:
             self, api_version=api_version
         )
 
-    def _comp(self, other: Any, op: ComparisonOperator) -> LazyFrame:
-        """Compare a DataFrame with another object."""
-        if isinstance(other, LazyFrame):
-            return self._compare_to_other_df(other, op)
-        else:
-            return self._compare_to_non_df(other, op)
-
-    def _compare_to_other_df(
-        self,
-        other: LazyFrame,
-        op: ComparisonOperator,
-    ) -> LazyFrame:
-        """Compare a DataFrame with another DataFrame."""
-        if self.columns != other.columns:
-            raise ValueError("DataFrame columns do not match")
-        # if self.shape != other.shape:
-        #     raise ValueError("DataFrame dimensions do not match")
-
-        suffix = "__POLARS_CMP_OTHER"
-        other_renamed = other.select(F.all().suffix(suffix))
-
-        # we must join on row count, since we cannot concatenate two lazy frames
-        combined = self.with_context(other_renamed)
-
-        if op == "eq":
-            expr = [F.col(n) == F.col(f"{n}{suffix}") for n in self.columns]
-        elif op == "neq":
-            expr = [F.col(n) != F.col(f"{n}{suffix}") for n in self.columns]
-        elif op == "gt":
-            expr = [F.col(n) > F.col(f"{n}{suffix}") for n in self.columns]
-        elif op == "lt":
-            expr = [F.col(n) < F.col(f"{n}{suffix}") for n in self.columns]
-        elif op == "gt_eq":
-            expr = [F.col(n) >= F.col(f"{n}{suffix}") for n in self.columns]
-        elif op == "lt_eq":
-            expr = [F.col(n) <= F.col(f"{n}{suffix}") for n in self.columns]
-        else:
-            raise ValueError(f"got unexpected comparison operator: {op}")
-
-        return combined.select(expr)
-
-    def _compare_to_non_df(
-        self,
-        other: Any,
-        op: ComparisonOperator,
-    ) -> LazyFrame:
-        """Compare a DataFrame with a non-DataFrame object."""
-        if op == "eq":
-            return self.select(F.all() == other)
-        elif op == "neq":
-            return self.select(F.all() != other)
-        elif op == "gt":
-            return self.select(F.all() > other)
-        elif op == "lt":
-            return self.select(F.all() < other)
-        elif op == "gt_eq":
-            return self.select(F.all() >= other)
-        elif op == "lt_eq":
-            return self.select(F.all() <= other)
-        else:
-            raise ValueError(f"got unexpected comparison operator: {op}")
-
     @property
     def width(self) -> int:
         """
@@ -723,23 +660,29 @@ class LazyFrame:
             "cannot be used in boolean context with and/or/not operators. "
         )
 
-    def __eq__(self, other: Any) -> LazyFrame:  # type: ignore[override]
-        return self._comp(other, "eq")
+    def _comparison_error(self) -> NoReturn:
+        raise TypeError(
+            "Cannot compare ambiguous LazyFrame structures; call .collect() "
+            "to materialize to DataFrame before comparison."
+        )
 
-    def __ne__(self, other: Any) -> LazyFrame:  # type: ignore[override]
-        return self._comp(other, "neq")
+    def __eq__(self, other: Any) -> NoReturn:
+        self._comparison_error()
 
-    def __gt__(self, other: Any) -> LazyFrame:
-        return self._comp(other, "gt")
+    def __ne__(self, other: Any) -> NoReturn:
+        self._comparison_error()
 
-    def __lt__(self, other: Any) -> LazyFrame:
-        return self._comp(other, "lt")
+    def __gt__(self, other: Any) -> NoReturn:
+        self._comparison_error()
 
-    def __ge__(self, other: Any) -> LazyFrame:
-        return self._comp(other, "gt_eq")
+    def __lt__(self, other: Any) -> NoReturn:
+        self._comparison_error()
 
-    def __le__(self, other: Any) -> LazyFrame:
-        return self._comp(other, "lt_eq")
+    def __ge__(self, other: Any) -> NoReturn:
+        self._comparison_error()
+
+    def __le__(self, other: Any) -> NoReturn:
+        self._comparison_error()
 
     def __contains__(self, key: str) -> bool:
         return key in self.columns

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -660,15 +660,26 @@ class LazyFrame:
             "cannot be used in boolean context with and/or/not operators. "
         )
 
-    def _comparison_error(self, other: Any) -> NoReturn:
-        raise TypeError("Cannot compare LazyFrames.")
+    def _comparison_error(self, operator: str) -> NoReturn:
+        raise TypeError(f'"{operator}" comparison not supported for LazyFrame objects.')
 
-    __eq__ = _comparison_error
-    __ne__ = _comparison_error
-    __gt__ = _comparison_error
-    __lt__ = _comparison_error
-    __ge__ = _comparison_error
-    __le__ = _comparison_error
+    def __eq__(self, other: Any) -> NoReturn:
+        self._comparison_error("==")
+
+    def __ne__(self, other: Any) -> NoReturn:
+        self._comparison_error("!=")
+
+    def __gt__(self, other: Any) -> NoReturn:
+        self._comparison_error(">")
+
+    def __lt__(self, other: Any) -> NoReturn:
+        self._comparison_error("<")
+
+    def __ge__(self, other: Any) -> NoReturn:
+        self._comparison_error(">=")
+
+    def __le__(self, other: Any) -> NoReturn:
+        self._comparison_error("<=")
 
     def __contains__(self, key: str) -> bool:
         return key in self.columns

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -660,29 +660,18 @@ class LazyFrame:
             "cannot be used in boolean context with and/or/not operators. "
         )
 
-    def _comparison_error(self) -> NoReturn:
+    def _comparison_error(self, other: Any) -> NoReturn:
         raise TypeError(
             "Cannot compare ambiguous LazyFrame structures; call .collect() "
             "to materialize to DataFrame before comparison."
         )
 
-    def __eq__(self, other: Any) -> NoReturn:
-        self._comparison_error()
-
-    def __ne__(self, other: Any) -> NoReturn:
-        self._comparison_error()
-
-    def __gt__(self, other: Any) -> NoReturn:
-        self._comparison_error()
-
-    def __lt__(self, other: Any) -> NoReturn:
-        self._comparison_error()
-
-    def __ge__(self, other: Any) -> NoReturn:
-        self._comparison_error()
-
-    def __le__(self, other: Any) -> NoReturn:
-        self._comparison_error()
+    __eq__ = _comparison_error
+    __ne__ = _comparison_error
+    __gt__ = _comparison_error
+    __lt__ = _comparison_error
+    __ge__ = _comparison_error
+    __le__ = _comparison_error
 
     def __contains__(self, key: str) -> bool:
         return key in self.columns

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1462,22 +1462,22 @@ def test_compare_aggregation_between_lazy_and_eager_6904(
 
 
 @pytest.mark.parametrize(
-    "compare",
+    "comparators",
     [
-        pl.LazyFrame.__eq__,
-        pl.LazyFrame.__ne__,
-        pl.LazyFrame.__gt__,
-        pl.LazyFrame.__lt__,
-        pl.LazyFrame.__ge__,
-        pl.LazyFrame.__le__,
+        ("==", pl.LazyFrame.__eq__),
+        ("!=", pl.LazyFrame.__ne__),
+        (">", pl.LazyFrame.__gt__),
+        ("<", pl.LazyFrame.__lt__),
+        (">=", pl.LazyFrame.__ge__),
+        ("<=", pl.LazyFrame.__le__),
     ],
 )
 def test_lazy_comparison_operators(
-    compare: Callable[[pl.LazyFrame, pl.LazyFrame], NoReturn]
+    comparators: Callable[[pl.LazyFrame, pl.LazyFrame], NoReturn]
 ) -> None:
     # we cannot compare lazy frames, so all should raise a TypeError
     with pytest.raises(
         TypeError,
-        match="Cannot compare LazyFrames.",
+        match=f'"{comparators[0]}" comparison not supported for LazyFrame objects',
     ):
-        compare(pl.LazyFrame(), pl.LazyFrame())
+        comparators[1](pl.LazyFrame(), pl.LazyFrame())

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1478,6 +1478,6 @@ def test_lazy_comparison_operators(
     # we cannot compare lazy frames, so all should raise a TypeError
     with pytest.raises(
         TypeError,
-        match="Cannot compare ambiguous LazyFrame structures",
+        match="Cannot compare LazyFrames.",
     ):
         compare(pl.LazyFrame(), pl.LazyFrame())

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1473,7 +1473,7 @@ def test_compare_aggregation_between_lazy_and_eager_6904(
     ],
 )
 def test_lazy_comparison_operators(
-    comparators: Callable[[pl.LazyFrame, pl.LazyFrame], NoReturn]
+    comparators: tuple[str, Callable[[pl.LazyFrame, Any], NoReturn]]
 ) -> None:
     # we cannot compare lazy frames, so all should raise a TypeError
     with pytest.raises(


### PR DESCRIPTION
Resolves #10274

**Update**: we now simply raise a `TypeError` whenever a comparison operator is called on a lazy frame.

---

~~@MarcoGorelli I mimicked the DataFrame comparison operators, with a couple of notes:~~

~~1. We can still immediately raise when columns do not match.~~
~~2. For value and/or height differences, we cannot detect until `collect()` is called.~~
~~3. Regular DataFrame comparison operator uses `pl.concat("horizontal")` which isn't supported for lazy frames, so instead I did a quick drop-in of `df1.with_context(df2)`. This works well because it will error out when the heights don't match and will still raise a height/dtype difference exception when `collect` is called.~~
~~4. The returned dataframe is still a boolean frame.~~

~~We may need more unit tests than I provided, but I wanted to get this out there for feedback.~~