### PR TITLE
chore(rust): Use workspace package info / organize dependencies section

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ exclude = [
 
 [workspace.package]
 version = "0.31.1"
+authors = ["Ritchie Vink <ritchie46@gmail.com>"]
+edition = "2021"
+homepage = "https://www.pola.rs/"
+repository = "https://github.com/pola-rs/polars"
+license = "MIT"
 
 [workspace.dependencies]
 rayon = "1.6"

--- a/contribution/polars_ops_multiple_arguments/Cargo.toml
+++ b/contribution/polars_ops_multiple_arguments/Cargo.toml
@@ -3,8 +3,6 @@ name = "polars_ops_multiple_arguments"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 polars = { path = "../../crates/polars" }
 polars-core = { path = "../../crates/polars-core" }

--- a/crates/polars-algo/Cargo.toml
+++ b/crates/polars-algo/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "polars-algo"
-version.workspace = true
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/pola-rs/polars"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "Algorithms built upon Polars primitives"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/polars-algo/Cargo.toml
+++ b/crates/polars-algo/Cargo.toml
@@ -8,8 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "Algorithms built upon Polars primitives"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 polars-core = { version = "0.31.1", path = "../polars-core", features = ["dtype-categorical", "asof_join"], default-features = false }
 polars-lazy = { version = "0.31.1", path = "../polars-lazy", features = ["asof_join", "concat_str", "strings"] }

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -8,8 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "Arrow interfaces for Polars DataFrame library"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 arrow.workspace = true
 atoi = { version = "2.0.0", optional = true }

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "polars-arrow"
-version.workspace = true
-authors = ["ritchie46 <ritchie46@gmail.com>"]
-edition = "2021"
-license = "MIT"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "Arrow interfaces for Polars DataFrame library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -9,6 +9,8 @@ repository = { workspace = true }
 description = "Arrow interfaces for Polars DataFrame library"
 
 [dependencies]
+polars-error = { version = "0.31.1", path = "../polars-error" }
+
 arrow.workspace = true
 atoi = { version = "2.0.0", optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
@@ -17,7 +19,6 @@ ethnum = { version = "1.3.2", optional = true }
 hashbrown.workspace = true
 multiversion.workspace = true
 num-traits.workspace = true
-polars-error = { version = "0.31.1", path = "../polars-error" }
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror.workspace = true
 

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -8,8 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "Core of the Polars DataFrame library"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 simd = ["arrow/simd", "polars-arrow/simd"]
 nightly = ["simd", "hashbrown/nightly", "polars-utils/nightly", "polars-arrow/nightly"]

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -8,6 +8,48 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "Core of the Polars DataFrame library"
 
+[dependencies]
+polars-arrow = { version = "0.31.1", path = "../polars-arrow", features = ["compute"] }
+polars-error = { version = "0.31.1", path = "../polars-error" }
+polars-row = { version = "0.31.1", path = "../polars-row" }
+polars-utils = { version = "0.31.1", path = "../polars-utils" }
+
+ahash.workspace = true
+arrow.workspace = true
+bitflags.workspace = true
+chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
+chrono-tz = { version = "0.8", optional = true }
+comfy-table = { version = "7.0.1", optional = true, default_features = false }
+either.workspace = true
+hashbrown.workspace = true
+indexmap.workspace = true
+itoap = { version = "1", optional = true, features = ["simd"] }
+ndarray = { version = "0.15", optional = true, default_features = false }
+num-traits.workspace = true
+object_store = { version = "0.6.0", default-features = false, optional = true }
+once_cell.workspace = true
+rand = { version = "0.8", optional = true, features = ["small_rng", "std"] }
+rand_distr = { version = "0.4", optional = true }
+rayon.workspace = true
+regex = { version = "1.6", optional = true }
+# activate if you want serde support for Series and DataFrames
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
+smartstring.workspace = true
+thiserror.workspace = true
+url = { version = "2.3.1", optional = true }
+xxhash-rust.workspace = true
+
+[dev-dependencies]
+bincode = "1"
+serde_json = "1"
+
+[build-dependencies]
+version_check = { workspace = true }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+wasm-timer = "0.2.5"
+
 [features]
 simd = ["arrow/simd", "polars-arrow/simd"]
 nightly = ["simd", "hashbrown/nightly", "polars-utils/nightly", "polars-arrow/nightly"]
@@ -146,47 +188,6 @@ docs-selection = [
 "aws" = ["async", "object_store/aws"]
 "azure" = ["async", "object_store/azure"]
 "gcp" = ["async", "object_store/gcp"]
-
-[dependencies]
-ahash.workspace = true
-arrow.workspace = true
-bitflags.workspace = true
-chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
-chrono-tz = { version = "0.8", optional = true }
-comfy-table = { version = "7.0.1", optional = true, default_features = false }
-either.workspace = true
-hashbrown.workspace = true
-indexmap.workspace = true
-itoap = { version = "1", optional = true, features = ["simd"] }
-ndarray = { version = "0.15", optional = true, default_features = false }
-num-traits.workspace = true
-object_store = { version = "0.6.0", default-features = false, optional = true }
-once_cell.workspace = true
-polars-arrow = { version = "0.31.1", path = "../polars-arrow", features = ["compute"] }
-polars-error = { version = "0.31.1", path = "../polars-error" }
-polars-row = { version = "0.31.1", path = "../polars-row" }
-polars-utils = { version = "0.31.1", path = "../polars-utils" }
-rand = { version = "0.8", optional = true, features = ["small_rng", "std"] }
-rand_distr = { version = "0.4", optional = true }
-rayon.workspace = true
-regex = { version = "1.6", optional = true }
-# activate if you want serde support for Series and DataFrames
-serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", optional = true }
-smartstring.workspace = true
-thiserror.workspace = true
-url = { version = "2.3.1", optional = true }
-xxhash-rust.workspace = true
-
-[target.'cfg(target_family = "wasm")'.dependencies]
-wasm-timer = "0.2.5"
-
-[dev-dependencies]
-bincode = "1"
-serde_json = "1"
-
-[build-dependencies]
-version_check = { workspace = true }
 
 [package.metadata.docs.rs]
 # not all because arrow 4.3 does not compile with simd

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "polars-core"
-version.workspace = true
-authors = ["ritchie46 <ritchie46@gmail.com>"]
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/pola-rs/polars"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "Core of the Polars DataFrame library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/polars-error/Cargo.toml
+++ b/crates/polars-error/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "polars-error"
-version.workspace = true
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/pola-rs/polars"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "Error definitions for the Polars DataFrame library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/polars-error/Cargo.toml
+++ b/crates/polars-error/Cargo.toml
@@ -8,8 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "Error definitions for the Polars DataFrame library"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 arrow.workspace = true
 regex = { version = "1.6", optional = true }

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "polars-io"
-version.workspace = true
-authors = ["ritchie46 <ritchie46@gmail.com>"]
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/pola-rs/polars"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "IO related logic for the Polars DataFrame library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -8,6 +8,43 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "IO related logic for the Polars DataFrame library"
 
+[dependencies]
+polars-arrow = { version = "0.31.1", path = "../polars-arrow" }
+polars-core = { version = "0.31.1", path = "../polars-core", features = [], default-features = false }
+polars-error = { version = "0.31.1", path = "../polars-error", default-features = false }
+polars-json = { version = "0.31.1", optional = true, path = "../polars-json" }
+polars-time = { version = "0.31.1", path = "../polars-time", features = [], default-features = false, optional = true }
+polars-utils = { version = "0.31.1", path = "../polars-utils" }
+
+ahash.workspace = true
+arrow.workspace = true
+async-trait = { version = "0.1.59", optional = true }
+bytes = "1.3.0"
+chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
+chrono-tz = { version = "0.8.1", optional = true }
+fast-float = { version = "0.2.0", optional = true }
+flate2 = { version = "1", optional = true, default-features = false }
+futures = { version = "0.3.25", optional = true }
+home = "0.5.4"
+lexical = { version = "6", optional = true, default-features = false, features = ["std", "parse-integers"] }
+lexical-core = { version = "0.8", optional = true }
+memchr.workspace = true
+memmap = { package = "memmap2", version = "0.5.2", optional = true }
+num-traits.workspace = true
+object_store = { version = "0.6.0", default-features = false, optional = true }
+once_cell = "1"
+rayon.workspace = true
+regex = "1.6"
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true, default-features = false, features = ["alloc", "raw_value"] }
+simd-json = { version = "0.10", optional = true, features = ["allow-non-simd", "known-key"] }
+simdutf8 = { version = "0.1", optional = true }
+tokio = { version = "1.26.0", features = ["net"], optional = true }
+url = { version = "2.3.1", optional = true }
+
+[dev-dependencies]
+tempdir = "0.3.7"
+
 [features]
 # support for arrows json parsing
 json = [
@@ -56,42 +93,6 @@ gcp = ["object_store/gcp", "cloud", "polars-core/gcp"]
 partition = ["polars-core/partition_by"]
 temporal = ["dtype-datetime", "dtype-date", "dtype-time"]
 simd = []
-
-[dependencies]
-ahash.workspace = true
-arrow.workspace = true
-async-trait = { version = "0.1.59", optional = true }
-bytes = "1.3.0"
-chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
-chrono-tz = { version = "0.8.1", optional = true }
-fast-float = { version = "0.2.0", optional = true }
-flate2 = { version = "1", optional = true, default-features = false }
-futures = { version = "0.3.25", optional = true }
-home = "0.5.4"
-lexical = { version = "6", optional = true, default-features = false, features = ["std", "parse-integers"] }
-lexical-core = { version = "0.8", optional = true }
-memchr.workspace = true
-memmap = { package = "memmap2", version = "0.5.2", optional = true }
-num-traits.workspace = true
-object_store = { version = "0.6.0", default-features = false, optional = true }
-once_cell = "1"
-polars-arrow = { version = "0.31.1", path = "../polars-arrow" }
-polars-core = { version = "0.31.1", path = "../polars-core", features = [], default-features = false }
-polars-error = { version = "0.31.1", path = "../polars-error", default-features = false }
-polars-json = { version = "0.31.1", optional = true, path = "../polars-json" }
-polars-time = { version = "0.31.1", path = "../polars-time", features = [], default-features = false, optional = true }
-polars-utils = { version = "0.31.1", path = "../polars-utils" }
-rayon.workspace = true
-regex = "1.6"
-serde = { version = "1", features = ["derive"], optional = true }
-serde_json = { version = "1", optional = true, default-features = false, features = ["alloc", "raw_value"] }
-simd-json = { version = "0.10", optional = true, features = ["allow-non-simd", "known-key"] }
-simdutf8 = { version = "0.1", optional = true }
-tokio = { version = "1.26.0", features = ["net"], optional = true }
-url = { version = "2.3.1", optional = true }
-
-[dev-dependencies]
-tempdir = "0.3.7"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -8,8 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "IO related logic for the Polars DataFrame library"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 # support for arrows json parsing
 json = [

--- a/crates/polars-json/Cargo.toml
+++ b/crates/polars-json/Cargo.toml
@@ -9,13 +9,14 @@ repository = { workspace = true }
 description = "JSON related logic for the Polars DataFrame library"
 
 [dependencies]
+polars-arrow = { version = "0.31.1", path = "../polars-arrow", default-features = false }
+polars-error = { version = "0.31.1", path = "../polars-error" }
+polars-utils = { version = "0.31.1", path = "../polars-utils" }
+
 ahash.workspace = true
 arrow.workspace = true
 fallible-streaming-iterator = "0.1"
 hashbrown.workspace = true
 indexmap.workspace = true
 num-traits.workspace = true
-polars-arrow = { version = "0.31.1", path = "../polars-arrow", default-features = false }
-polars-error = { version = "0.31.1", path = "../polars-error" }
-polars-utils = { version = "0.31.1", path = "../polars-utils" }
 simd-json = { version = "0.10", features = ["allow-non-simd", "known-key"] }

--- a/crates/polars-json/Cargo.toml
+++ b/crates/polars-json/Cargo.toml
@@ -8,8 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "JSON related logic for the Polars DataFrame library"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 ahash.workspace = true
 arrow.workspace = true

--- a/crates/polars-json/Cargo.toml
+++ b/crates/polars-json/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "polars-json"
-version.workspace = true
-authors = ["ritchie46 <ritchie46@gmail.com>"]
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/pola-rs/polars"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "JSON related logic for the Polars DataFrame library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -8,8 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "Lazy query engine for the Polars DataFrame library"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dev-dependencies]
 serde_json = "1"
 

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -8,14 +8,7 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "Lazy query engine for the Polars DataFrame library"
 
-[dev-dependencies]
-serde_json = "1"
-
 [dependencies]
-ahash.workspace = true
-bitflags.workspace = true
-glob = "0.3"
-once_cell = "1"
 polars-arrow = { version = "0.31.1", path = "../polars-arrow" }
 polars-core = { version = "0.31.1", path = "../polars-core", features = ["lazy", "zip_with", "random"], default-features = false }
 polars-io = { version = "0.31.1", path = "../polars-io", features = ["lazy", "csv"], default-features = false }
@@ -25,9 +18,17 @@ polars-pipe = { version = "0.31.1", path = "../polars-pipe", optional = true }
 polars-plan = { version = "0.31.1", path = "../polars-plan" }
 polars-time = { version = "0.31.1", path = "../polars-time", optional = true }
 polars-utils = { version = "0.31.1", path = "../polars-utils" }
+
+ahash.workspace = true
+bitflags.workspace = true
+glob = "0.3"
+once_cell = "1"
 pyo3 = { version = "0.19", optional = true }
 rayon.workspace = true
 smartstring.workspace = true
+
+[dev-dependencies]
+serde_json = "1"
 
 [build-dependencies]
 version_check = { workspace = true }

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "polars-lazy"
-version.workspace = true
-authors = ["ritchie46 <ritchie46@gmail.com>"]
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/pola-rs/polars"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "Lazy query engine for the Polars DataFrame library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/polars-ops/Cargo.toml
+++ b/crates/polars-ops/Cargo.toml
@@ -9,6 +9,11 @@ repository = { workspace = true }
 description = "More operations on Polars data structures"
 
 [dependencies]
+polars-arrow = { version = "0.31.1", path = "../polars-arrow", default-features = false }
+polars-core = { version = "0.31.1", path = "../polars-core", features = [], default-features = false }
+polars-json = { version = "0.31.1", optional = true, path = "../polars-json", default-features = false }
+polars-utils = { version = "0.31.1", path = "../polars-utils", default-features = false }
+
 argminmax = { version = "0.6.1", default-features = false, features = ["float"] }
 arrow.workspace = true
 base64 = { version = "0.21", optional = true }
@@ -19,10 +24,6 @@ hex = { version = "0.4", optional = true }
 indexmap.workspace = true
 jsonpath_lib = { version = "0.3.0", optional = true, git = "https://github.com/ritchie46/jsonpath", branch = "improve_compiled" }
 memchr.workspace = true
-polars-arrow = { version = "0.31.1", path = "../polars-arrow", default-features = false }
-polars-core = { version = "0.31.1", path = "../polars-core", features = [], default-features = false }
-polars-json = { version = "0.31.1", optional = true, path = "../polars-json", default-features = false }
-polars-utils = { version = "0.31.1", path = "../polars-utils", default-features = false }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 smartstring.workspace = true

--- a/crates/polars-ops/Cargo.toml
+++ b/crates/polars-ops/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "polars-ops"
-version.workspace = true
-authors = ["ritchie46 <ritchie46@gmail.com>"]
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/pola-rs/polars"
-description = "More operations on polars data structures"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+description = "More operations on Polars data structures"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/polars-ops/Cargo.toml
+++ b/crates/polars-ops/Cargo.toml
@@ -8,8 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "More operations on Polars data structures"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 argminmax = { version = "0.6.1", default-features = false, features = ["float"] }
 arrow.workspace = true

--- a/crates/polars-pipe/Cargo.toml
+++ b/crates/polars-pipe/Cargo.toml
@@ -9,11 +9,6 @@ repository = { workspace = true }
 description = "Lazy query engine for the Polars DataFrame library"
 
 [dependencies]
-crossbeam-channel = { version = "0.5", optional = true }
-crossbeam-queue = { version = "0.3", optional = true }
-enum_dispatch = "0.3"
-hashbrown.workspace = true
-num-traits.workspace = true
 polars-arrow = { version = "0.31.1", path = "../polars-arrow", default-features = false }
 polars-core = { version = "0.31.1", path = "../polars-core", features = ["lazy", "zip_with", "random"], default-features = false }
 polars-io = { version = "0.31.1", path = "../polars-io", default-features = false, features = ["ipc", "async"] }
@@ -21,6 +16,12 @@ polars-ops = { version = "0.31.1", path = "../polars-ops", features = ["search_s
 polars-plan = { version = "0.31.1", path = "../polars-plan", default-features = false, features = ["compile"] }
 polars-row = { version = "0.31.1", path = "../polars-row" }
 polars-utils = { version = "0.31.1", path = "../polars-utils", features = ["sysinfo"] }
+
+crossbeam-channel = { version = "0.5", optional = true }
+crossbeam-queue = { version = "0.3", optional = true }
+enum_dispatch = "0.3"
+hashbrown.workspace = true
+num-traits.workspace = true
 rayon.workspace = true
 smartstring = { version = "1" }
 

--- a/crates/polars-pipe/Cargo.toml
+++ b/crates/polars-pipe/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "polars-pipe"
-version.workspace = true
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/pola-rs/polars"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "Lazy query engine for the Polars DataFrame library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/polars-pipe/Cargo.toml
+++ b/crates/polars-pipe/Cargo.toml
@@ -8,8 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "Lazy query engine for the Polars DataFrame library"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 crossbeam-channel = { version = "0.5", optional = true }
 crossbeam-queue = { version = "0.3", optional = true }

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -12,6 +12,13 @@ description = "Lazy query engine for the Polars DataFrame library"
 doctest = false
 
 [dependencies]
+polars-arrow = { version = "0.31.1", path = "../polars-arrow" }
+polars-core = { version = "0.31.1", path = "../polars-core", features = ["lazy", "zip_with", "random"], default-features = false }
+polars-io = { version = "0.31.1", path = "../polars-io", features = ["lazy", "csv"], default-features = false }
+polars-ops = { version = "0.31.1", path = "../polars-ops", default-features = false }
+polars-time = { version = "0.31.1", path = "../polars-time", optional = true }
+polars-utils = { version = "0.31.1", path = "../polars-utils" }
+
 ahash.workspace = true
 arrow.workspace = true
 chrono = { version = "0.4", optional = true }
@@ -19,12 +26,6 @@ chrono-tz = { version = "0.8", optional = true }
 ciborium = { version = "0.2", optional = true }
 futures = { version = "0.3.25", optional = true }
 once_cell.workspace = true
-polars-arrow = { version = "0.31.1", path = "../polars-arrow" }
-polars-core = { version = "0.31.1", path = "../polars-core", features = ["lazy", "zip_with", "random"], default-features = false }
-polars-io = { version = "0.31.1", path = "../polars-io", features = ["lazy", "csv"], default-features = false }
-polars-ops = { version = "0.31.1", path = "../polars-ops", default-features = false }
-polars-time = { version = "0.31.1", path = "../polars-time", optional = true }
-polars-utils = { version = "0.31.1", path = "../polars-utils" }
 pyo3 = { version = "0.19", optional = true }
 rayon.workspace = true
 regex = { version = "1.6", optional = true }

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -11,8 +11,6 @@ description = "Lazy query engine for the Polars DataFrame library"
 [lib]
 doctest = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 ahash.workspace = true
 arrow.workspace = true

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "polars-plan"
-version.workspace = true
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/pola-rs/polars"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "Lazy query engine for the Polars DataFrame library"
 
 [lib]

--- a/crates/polars-row/Cargo.toml
+++ b/crates/polars-row/Cargo.toml
@@ -8,8 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "Row encodings for the Polars DataFrame library"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 arrow.workspace = true
 polars-error = { version = "0.31.1", path = "../polars-error" }

--- a/crates/polars-row/Cargo.toml
+++ b/crates/polars-row/Cargo.toml
@@ -9,6 +9,7 @@ repository = { workspace = true }
 description = "Row encodings for the Polars DataFrame library"
 
 [dependencies]
-arrow.workspace = true
 polars-error = { version = "0.31.1", path = "../polars-error" }
 polars-utils = { version = "0.31.1", path = "../polars-utils" }
+
+arrow.workspace = true

--- a/crates/polars-row/Cargo.toml
+++ b/crates/polars-row/Cargo.toml
@@ -1,9 +1,11 @@
 [package]
 name = "polars-row"
-version.workspace = true
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/pola-rs/polars"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "Row encodings for the Polars DataFrame library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/polars-sql/Cargo.toml
+++ b/crates/polars-sql/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "polars-sql"
-version.workspace = true
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/pola-rs/polars"
-description = "SQL transpiler for polars. Converts SQL to polars logical plans"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+description = "SQL transpiler for Polars. Converts SQL to Polars logical plans"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/crates/polars-sql/Cargo.toml
+++ b/crates/polars-sql/Cargo.toml
@@ -8,19 +8,20 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "SQL transpiler for Polars. Converts SQL to Polars logical plans"
 
+[dependencies]
+polars-arrow = { version = "0.31.1", path = "../polars-arrow", features = ["like"] }
+polars-core = { version = "0.31.1", path = "../polars-core", features = [] }
+polars-lazy = { version = "0.31.1", path = "../polars-lazy", features = ["compile", "strings", "cross_join", "trigonometry", "abs", "round_series", "log", "regex", "is_in", "meta", "cum_agg"] }
+polars-plan = { version = "0.31.1", path = "../polars-plan", features = ["compile"] }
+
+serde = "1"
+serde_json = { version = "1" }
+# sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs.git", rev = "ae3b5844c839072c235965fe0d1bddc473dced87" }
+sqlparser = "0.34"
+
 [features]
 csv = ["polars-lazy/csv"]
 json = ["polars-lazy/json"]
 default = []
 ipc = ["polars-lazy/ipc"]
 parquet = ["polars-lazy/parquet"]
-
-[dependencies]
-polars-arrow = { version = "0.31.1", path = "../polars-arrow", features = ["like"] }
-polars-core = { version = "0.31.1", path = "../polars-core", features = [] }
-polars-lazy = { version = "0.31.1", path = "../polars-lazy", features = ["compile", "strings", "cross_join", "trigonometry", "abs", "round_series", "log", "regex", "is_in", "meta", "cum_agg"] }
-polars-plan = { version = "0.31.1", path = "../polars-plan", features = ["compile"] }
-serde = "1"
-serde_json = { version = "1" }
-# sqlparser = { git = "https://github.com/sqlparser-rs/sqlparser-rs.git", rev = "ae3b5844c839072c235965fe0d1bddc473dced87" }
-sqlparser = "0.34"

--- a/crates/polars-sql/Cargo.toml
+++ b/crates/polars-sql/Cargo.toml
@@ -8,7 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "SQL transpiler for Polars. Converts SQL to Polars logical plans"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
 csv = ["polars-lazy/csv"]
 json = ["polars-lazy/json"]

--- a/crates/polars-time/Cargo.toml
+++ b/crates/polars-time/Cargo.toml
@@ -9,16 +9,17 @@ repository = { workspace = true }
 description = "Time related code for the Polars DataFrame library"
 
 [dependencies]
+polars-arrow = { version = "0.31.1", path = "../polars-arrow", features = ["compute", "temporal"] }
+polars-core = { version = "0.31.1", path = "../polars-core", default-features = false, features = ["dtype-datetime", "dtype-duration", "dtype-time", "dtype-date"] }
+polars-ops = { version = "0.31.1", path = "../polars-ops" }
+polars-utils = { version = "0.31.1", path = "../polars-utils" }
+
 arrow.workspace = true
 atoi = "2.0.0"
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 chrono-tz = { version = "0.8", optional = true }
 now = "0.1"
 once_cell.workspace = true
-polars-arrow = { version = "0.31.1", path = "../polars-arrow", features = ["compute", "temporal"] }
-polars-core = { version = "0.31.1", path = "../polars-core", default-features = false, features = ["dtype-datetime", "dtype-duration", "dtype-time", "dtype-date"] }
-polars-ops = { version = "0.31.1", path = "../polars-ops" }
-polars-utils = { version = "0.31.1", path = "../polars-utils" }
 regex = "1.7.1"
 serde = { version = "1", features = ["derive"], optional = true }
 smartstring.workspace = true

--- a/crates/polars-time/Cargo.toml
+++ b/crates/polars-time/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "polars-time"
-version.workspace = true
-authors = ["ritchie46 <ritchie46@gmail.com>"]
-edition = "2021"
-license = "MIT"
-description = "Time related code for the polars dataframe library"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+description = "Time related code for the Polars DataFrame library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/polars-time/Cargo.toml
+++ b/crates/polars-time/Cargo.toml
@@ -8,8 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "Time related code for the Polars DataFrame library"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 arrow.workspace = true
 atoi = "2.0.0"

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -9,11 +9,12 @@ repository = { workspace = true }
 description = "Private utils for the Polars DataFrame library"
 
 [dependencies]
+polars-error = { version = "0.31.1", path = "../polars-error" }
+
 ahash.workspace = true
 hashbrown.workspace = true
 num-traits.workspace = true
 once_cell.workspace = true
-polars-error = { version = "0.31.1", path = "../polars-error" }
 rayon.workspace = true
 smartstring.workspace = true
 sysinfo = { version = "0.29", default-features = false, optional = true }

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -8,8 +8,6 @@ license = { workspace = true }
 repository = { workspace = true }
 description = "Private utils for the Polars DataFrame library"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 ahash.workspace = true
 hashbrown.workspace = true

--- a/crates/polars-utils/Cargo.toml
+++ b/crates/polars-utils/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "polars-utils"
-version.workspace = true
-authors = ["ritchie46 <ritchie46@gmail.com>"]
-edition = "2021"
-license = "MIT"
-description = "private utils for the polars dataframe library"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+description = "Private utils for the Polars DataFrame library"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "polars"
-version.workspace = true
-authors = ["ritchie46 <ritchie46@gmail.com>"]
-edition = "2021"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
 keywords = ["dataframe", "query-engine", "arrow"]
-license = "MIT"
-readme = "../README.md"
-repository = "https://github.com/pola-rs/polars"
-description = "DataFrame Library based on Apache Arrow"
+license = { workspace = true }
+readme = "../../README.md"
+repository = { workspace = true }
+description = "DataFrame library based on Apache Arrow"
 
 [features]
 sql = ["polars-sql"]

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -10,6 +10,27 @@ readme = "../../README.md"
 repository = { workspace = true }
 description = "DataFrame library based on Apache Arrow"
 
+[dependencies]
+polars-algo = { version = "0.31.1", path = "../polars-algo", optional = true }
+polars-core = { version = "0.31.1", path = "../polars-core", features = ["docs"], default-features = false }
+polars-io = { version = "0.31.1", path = "../polars-io", features = [], default-features = false, optional = true }
+polars-lazy = { version = "0.31.1", path = "../polars-lazy", features = [], default-features = false, optional = true }
+polars-ops = { version = "0.31.1", path = "../polars-ops" }
+polars-sql = { version = "0.31.1", path = "../polars-sql", default-features = false, optional = true }
+polars-time = { version = "0.31.1", path = "../polars-time", default-features = false, optional = true }
+
+[dev-dependencies]
+ahash = "0.8"
+rand = "0.8"
+
+[build-dependencies]
+version_check = { workspace = true }
+
+# enable js feature for getrandom to work in wasm
+[target.'cfg(target_family = "wasm")'.dependencies.getrandom]
+version = "0.2"
+features = ["js"]
+
 [features]
 sql = ["polars-sql"]
 rows = ["polars-core/rows"]
@@ -311,27 +332,6 @@ docs-selection = [
 bench = [
   "lazy",
 ]
-
-[dependencies]
-polars-algo = { version = "0.31.1", path = "../polars-algo", optional = true }
-polars-core = { version = "0.31.1", path = "../polars-core", features = ["docs"], default-features = false }
-polars-io = { version = "0.31.1", path = "../polars-io", features = [], default-features = false, optional = true }
-polars-lazy = { version = "0.31.1", path = "../polars-lazy", features = [], default-features = false, optional = true }
-polars-ops = { version = "0.31.1", path = "../polars-ops" }
-polars-sql = { version = "0.31.1", path = "../polars-sql", default-features = false, optional = true }
-polars-time = { version = "0.31.1", path = "../polars-time", default-features = false, optional = true }
-
-# enable js feature for getrandom to work in wasm
-[target.'cfg(target_family = "wasm")'.dependencies.getrandom]
-version = "0.2"
-features = ["js"]
-
-[dev-dependencies]
-ahash = "0.8"
-rand = "0.8"
-
-[build-dependencies]
-version_check = { workspace = true }
 
 [package.metadata.docs.rs]
 # all-features = true

--- a/examples/python_rust_compiled_function/Cargo.toml
+++ b/examples/python_rust_compiled_function/Cargo.toml
@@ -3,7 +3,6 @@ name = "python_rust_compiled_function"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 name = "my_polars_functions"
 crate-type = ["cdylib"]

--- a/examples/read_csv/Cargo.toml
+++ b/examples/read_csv/Cargo.toml
@@ -3,9 +3,9 @@ name = "read_csv"
 version = "0.1.0"
 edition = "2021"
 
+[dependencies]
+polars = { path = "../../crates/polars", features = ["lazy", "csv", "ipc"] }
+
 [features]
 write_output = ["polars/ipc", "polars/parquet"]
 default = ["write_output"]
-
-[dependencies]
-polars = { path = "../../crates/polars", features = ["lazy", "csv", "ipc"] }

--- a/examples/read_csv/Cargo.toml
+++ b/examples/read_csv/Cargo.toml
@@ -3,8 +3,6 @@ name = "read_csv"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [features]
 write_output = ["polars/ipc", "polars/parquet"]
 default = ["write_output"]

--- a/examples/read_json/Cargo.toml
+++ b/examples/read_json/Cargo.toml
@@ -3,7 +3,5 @@ name = "read_json"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 polars = { path = "../../crates/polars", features = ["json"] }

--- a/examples/read_parquet/Cargo.toml
+++ b/examples/read_parquet/Cargo.toml
@@ -3,7 +3,5 @@ name = "read_parquet"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 polars = { path = "../../crates/polars", features = ["lazy", "parquet"] }

--- a/examples/read_parquet_cloud/Cargo.toml
+++ b/examples/read_parquet_cloud/Cargo.toml
@@ -3,8 +3,6 @@ name = "read_parquet_cloud"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 aws-creds = "0.35.0"
 polars = { path = "../../crates/polars", features = ["lazy", "aws"] }

--- a/examples/read_parquet_cloud/Cargo.toml
+++ b/examples/read_parquet_cloud/Cargo.toml
@@ -4,5 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-aws-creds = "0.35.0"
 polars = { path = "../../crates/polars", features = ["lazy", "aws"] }
+
+aws-creds = "0.35.0"

--- a/examples/string_filter/Cargo.toml
+++ b/examples/string_filter/Cargo.toml
@@ -3,7 +3,5 @@ name = "string_filter"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 polars = { path = "../../crates/polars", features = ["strings", "lazy"] }

--- a/polars-cli/Cargo.toml
+++ b/polars-cli/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "polars-cli"
 version = "0.3.0"
-edition = "2021"
-license = "MIT"
-repository = "https://github.com/pola-rs/polars"
+edition = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "CLI interface for running SQL queries via Polars"
 
 [[bin]]

--- a/polars-cli/Cargo.toml
+++ b/polars-cli/Cargo.toml
@@ -10,18 +10,6 @@ description = "CLI interface for running SQL queries via Polars"
 name = "polars"
 path = "src/main.rs"
 
-[profile.release]
-strip = true
-lto = true
-panic = "abort"
-
-[features]
-highlight = ["nu-ansi-term"]
-default = ["highlight", "parquet", "json", "ipc"]
-parquet = ["polars/parquet"]
-json = ["polars/json"]
-ipc = ["polars/ipc"]
-
 [dependencies]
 polars = { version = "0.31.1", path = "../crates/polars", features = ["lazy", "sql", "dtype-full", "serde-lazy"] }
 
@@ -37,3 +25,15 @@ tmp_env = "0.1.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 jemallocator = { version = "0.5.0", features = ["disable_initial_exec_tls"] }
+
+[features]
+highlight = ["nu-ansi-term"]
+default = ["highlight", "parquet", "json", "ipc"]
+parquet = ["polars/parquet"]
+json = ["polars/json"]
+ipc = ["polars/ipc"]
+
+[profile.release]
+strip = true
+lto = true
+panic = "abort"

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -3,8 +3,6 @@ name = "py-polars"
 version = "0.18.11"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [workspace]
 # prevents package from thinking it's in the workspace
 [target.'cfg(any(not(target_os = "linux"), use_mimalloc))'.dependencies]


### PR DESCRIPTION
Changes:
* Define shared `package` info on the workspace level and use it across our crates
* Move the `dependencies` section before the `features` section everywhere (this was inconsistent) according to the [manifest format](https://doc.rust-lang.org/cargo/reference/manifest.html).

This doesn't impact anything except for being a bit nicer to look at. I'd like to move some dependency version definitions to the workspace level as well - I'll do that in a separate PR.