### PR TITLE
ci: Do not keep history in `gh-pages` branch

### DIFF
--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -48,6 +48,7 @@ jobs:
         with:
           folder: py-polars/docs/build/html
           target-folder: py-polars/dev
+          single-commit: true
 
       - name: Deploy Python docs for latest release version
         if: ${{ github.ref_type == 'tag' }}
@@ -56,3 +57,4 @@ jobs:
           folder: py-polars/docs/build/html
           # Keeping the html subfolder here for backwards compatibility
           target-folder: py-polars/html
+          single-commit: true

--- a/.github/workflows/docs-rust.yml
+++ b/.github/workflows/docs-rust.yml
@@ -47,6 +47,7 @@ jobs:
         with:
           folder: target/doc
           clean-exclude: py-polars/**
+          single-commit: true
 
       # Make sure documentation artifacts are not cached
       - name: Clean up documentation artifacts


### PR DESCRIPTION
The `gh-pages` branch has ballooned the size of the repository. We do not need to keep the history here, only keeping the latest commit is fine.

Changes:
* Set `single-commit: true` for the GitHub Actions publishing our docs. See config explanation [here](https://github.com/JamesIves/github-pages-deploy-action#configuration-).

I wonder if this works well with multiple workflows trying to publish docs at the same time. We will find out!