### PR TITLE
docs(rust): avoid outputting docs of dependencies

### DIFF
--- a/crates/Makefile
+++ b/crates/Makefile
@@ -83,15 +83,15 @@ bench-cmp:  ## Run benchmark and compare
 
 .PHONY: doctest
 doctest:  ## Check that documentation builds
-	cargo doc --all-features -p polars-arrow
-	cargo doc --all-features -p polars-utils
-	cargo doc --features=docs-selection -p polars-core
-	cargo doc -p polars-time
-	cargo doc -p polars-ops
-	cargo doc --all-features -p polars-io
-	cargo doc --all-features -p polars-lazy
-	cargo doc --features=docs-selection -p polars
-	cargo doc --all-features -p polars-sql
+	cargo doc --no-deps --all-features -p polars-arrow
+	cargo doc --no-deps --all-features -p polars-utils
+	cargo doc --no-deps --features=docs-selection -p polars-core
+	cargo doc --no-deps -p polars-time
+	cargo doc --no-deps -p polars-ops
+	cargo doc --no-deps --all-features -p polars-io
+	cargo doc --no-deps --all-features -p polars-lazy
+	cargo doc --no-deps --features=docs-selection -p polars
+	cargo doc --no-deps --all-features -p polars-sql
 
 .PHONY: publish
 publish:  ## Publish Polars crates


### PR DESCRIPTION
Right now our Rust API docs are much larger and harder to skim than necessary because we include the full docs of all our dependencies in our `doc` build. This patch removes that.

Before:
![image](https://github.com/pola-rs/polars/assets/202547/6b8fd174-a946-424f-8356-e35aa3c6571f)

After:
![image](https://github.com/pola-rs/polars/assets/202547/1c31e171-6177-43ec-b46d-3acad5ef1d4c)
