### PR TITLE
feat(python, rust): improve err msg parsing `time`, `date`, `datetime`

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -417,15 +417,22 @@ fn to_date(s: &Series, options: &StrptimeOptions) -> PolarsResult<Series> {
         }
     };
 
-    if options.strict {
-        polars_ensure!(
-            out.null_count() == ca.null_count(),
+    if options.strict && ca.null_count() != out.null_count() {
+        let failure_mask = !ca.is_null() & out.is_null();
+        let all_failures = ca.filter(&failure_mask)?;
+        let n_failures = all_failures.len();
+        let first_failures = all_failures.unique()?.slice(0, 10).sort(false);
+        let n_failures_unique = all_failures.n_unique()?;
+        polars_bail!(
             ComputeError:
-            "strict conversion to dates failed.\n\
+            "strict date parsing failed for {} value(s) ({} unique): {}\n\
             \n\
             You might want to try:\n\
             - setting `strict=False`\n\
-            - explicitly specifying a `format`"
+            - explicitly specifying a `format`",
+            n_failures,
+            n_failures_unique,
+            first_failures.into_series().fmt_list(),
         );
     }
     Ok(out.into_series())
@@ -468,15 +475,22 @@ fn to_datetime(
             .into_series()
     };
 
-    if options.strict {
-        polars_ensure!(
-            out.null_count() == ca.null_count(),
+    if options.strict && ca.null_count() != out.null_count() {
+        let failure_mask = !ca.is_null() & out.is_null();
+        let all_failures = ca.filter(&failure_mask)?;
+        let n_failures = all_failures.len();
+        let first_failures = all_failures.unique()?.slice(0, 10).sort(false);
+        let n_failures_unique = all_failures.n_unique()?;
+        polars_bail!(
             ComputeError:
-            "strict conversion to datetimes failed.\n\
+            "strict datetime parsing failed for {} value(s) ({} unique): {}\n\
             \n\
             You might want to try:\n\
             - setting `strict=False`\n\
-            - explicitly specifying a `format`"
+            - explicitly specifying a `format`",
+            n_failures,
+            n_failures_unique,
+            first_failures.into_series().fmt_list(),
         );
     }
     Ok(out.into_series())
@@ -493,15 +507,22 @@ fn to_time(s: &Series, options: &StrptimeOptions) -> PolarsResult<Series> {
         .as_time(options.format.as_deref(), options.cache)?
         .into_series();
 
-    if options.strict {
-        polars_ensure!(
-            out.null_count() == ca.null_count(),
+    if options.strict && ca.null_count() != out.null_count() {
+        let failure_mask = !ca.is_null() & out.is_null();
+        let all_failures = ca.filter(&failure_mask)?;
+        let n_failures = all_failures.len();
+        let first_failures = all_failures.unique()?.slice(0, 10).sort(false);
+        let n_failures_unique = all_failures.n_unique()?;
+        polars_bail!(
             ComputeError:
-            "strict conversion to times failed.\n\
+            "strict time parsing failed for {} value(s) ({} unique): {}\n\
             \n\
             You might want to try:\n\
             - setting `strict=False`\n\
-            - explicitly specifying a `format`"
+            - explicitly specifying a `format`",
+            n_failures,
+            n_failures_unique,
+            first_failures.into_series().fmt_list(),
         );
     }
     Ok(out.into_series())

--- a/py-polars/tests/parametric/time_series/test_to_datetime.py
+++ b/py-polars/tests/parametric/time_series/test_to_datetime.py
@@ -38,7 +38,7 @@ def test_to_datetime(datetimes: datetime, fmt: str) -> None:
                 not any(day in fmt for day in ("%d", "%j"))
                 or not any(month in fmt for month in ("%b", "%B", "%m"))
             )
-            and "strict conversion to datetimes failed" in str(exc)
+            and "strict datetime parsing failed" in str(exc)
         )
     else:
         assert result == expected

--- a/py-polars/tests/parametric/time_series/test_to_datetime.py
+++ b/py-polars/tests/parametric/time_series/test_to_datetime.py
@@ -38,7 +38,7 @@ def test_to_datetime(datetimes: datetime, fmt: str) -> None:
                 not any(day in fmt for day in ("%d", "%j"))
                 or not any(month in fmt for month in ("%b", "%B", "%m"))
             )
-            and "strict datetime parsing failed" in str(exc)
+            and "strict datetime[μs] parsing failed" in str(exc)
         )
     else:
         assert result == expected

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -145,7 +145,7 @@ def test_to_date_non_exact_strptime() -> None:
     ],
 )
 def test_non_exact_short_elements_10223(value: str, attr: str) -> None:
-    with pytest.raises(pl.ComputeError, match="strict (date|datetime) parsing failed"):
+    with pytest.raises(pl.ComputeError, match="strict .* parsing failed"):
         getattr(pl.Series(["2019-01-01", value]).str, attr)(exact=False)
 
 

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -145,7 +145,7 @@ def test_to_date_non_exact_strptime() -> None:
     ],
 )
 def test_non_exact_short_elements_10223(value: str, attr: str) -> None:
-    with pytest.raises(pl.ComputeError, match="strict conversion to .* failed"):
+    with pytest.raises(pl.ComputeError, match="strict (date|datetime) parsing failed"):
         getattr(pl.Series(["2019-01-01", value]).str, attr)(exact=False)
 
 


### PR DESCRIPTION
improve error message when parsing `time`, `date` or `datetime`. (inspired by `str.parse_int`)

### Time
```python
pl.Series(
    name='time',
    values=['15:15:15', 'a', 'b', 'c', '16:16:16', '17:17:17'],
).str.to_time(strict=True)

# OLD:
# ComputeError: strict conversion to times failed.

# NEW:
# ComputeError: strict time parsing failed for 3 value(s) (3 unique): ["a", "b", "c"]
```

### Date
```python
pl.Series(
    name='date',
    values=['2019-01-01', 'a', 'b', '2019-01-02', '2019-01-03', 'c', 'd', 'e', 'a', 'a'],
).str.to_date(exact=False)

# OLD:
# ComputeError: strict conversion to dates failed.

# NEW:
# ComputeError: strict date parsing failed for 7 value(s) (5 unique): ["a", "b", … "e"]
```

### Datetime
```python
pl.Series(
    name='datetime',
    values=[' 2019-01-01 00:00:00', 'XXX', '2019-01-01 00:00:00', 'XXX', 'XXX'],
).str.to_datetime(exact=False)

# OLD:
# ComputeError: strict conversion to datetimes failed.

# NEW:
# ComputeError: strict datetime parsing failed for 3 value(s) (1 unique): ["XXX"]
```