### PR TITLE
feat(rust, python): add `struct.prefix` and `.struct.suffix`

### DIFF
--- a/crates/polars-plan/src/dsl/struct_.rs
+++ b/crates/polars-plan/src/dsl/struct_.rs
@@ -66,7 +66,7 @@ impl StructNameSpace {
                     // The types will be incorrect, but its better than nothing
                     // we can get an incorrect type with python lambdas, because we only know return type when running
                     // the query
-                    _ => dt.clone()
+                    _ => dt.clone(),
                 }),
             )
             .with_fmt("struct.prefix")
@@ -151,7 +151,7 @@ impl StructNameSpace {
                     // The types will be incorrect, but its better than nothing
                     // we can get an incorrect type with python lambdas, because we only know return type when running
                     // the query
-                    _ => dt.clone()
+                    _ => dt.clone(),
                 }),
             )
             .with_fmt("struct.suffix")

--- a/crates/polars-plan/src/dsl/struct_.rs
+++ b/crates/polars-plan/src/dsl/struct_.rs
@@ -147,7 +147,7 @@ impl StructNameSpace {
                             })
                             .collect();
                         DataType::Struct(fields)
-                    }
+                    },
                     // The types will be incorrect, but its better than nothing
                     // we can get an incorrect type with python lambdas, because we only know return type when running
                     // the query

--- a/crates/polars-plan/src/dsl/struct_.rs
+++ b/crates/polars-plan/src/dsl/struct_.rs
@@ -62,7 +62,7 @@ impl StructNameSpace {
                             })
                             .collect();
                         DataType::Struct(fields)
-                    }
+                    },
                     // The types will be incorrect, but its better than nothing
                     // we can get an incorrect type with python lambdas, because we only know return type when running
                     // the query
@@ -100,7 +100,7 @@ impl StructNameSpace {
                             .map(|(fld, name)| Field::new(name, fld.data_type().clone()))
                             .collect();
                         DataType::Struct(fields)
-                    }
+                    },
                     // The types will be incorrect, but its better than nothing
                     // we can get an incorrect type with python lambdas, because we only know return type when running
                     // the query

--- a/py-polars/docs/source/reference/expressions/struct.rst
+++ b/py-polars/docs/source/reference/expressions/struct.rst
@@ -10,4 +10,6 @@ The following methods are available under the `expr.struct` attribute.
    :template: autosummary/accessor_method.rst
 
     Expr.struct.field
+    Expr.struct.prefix
     Expr.struct.rename_fields
+    Expr.struct.suffix

--- a/py-polars/docs/source/reference/series/struct.rst
+++ b/py-polars/docs/source/reference/series/struct.rst
@@ -10,7 +10,9 @@ The following methods are available under the `Series.struct` attribute.
    :template: autosummary/accessor_method.rst
 
     Series.struct.field
+    Series.struct.prefix
     Series.struct.rename_fields
+    Series.struct.suffix
     Series.struct.unnest
 
 .. autosummary::

--- a/py-polars/polars/expr/struct.py
+++ b/py-polars/polars/expr/struct.py
@@ -150,3 +150,71 @@ class ExprStructNameSpace:
 
         """
         return wrap_expr(self._pyexpr.struct_rename_fields(names))
+
+    def prefix(self, prefix: str) -> Expr:
+        """
+        Add a prefix to the fields of the struct.
+
+        Parameters
+        ----------
+        prefix
+            Prefix to add to the struct's fields
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [{"x": 1, "y": 10}, {"x": 2, "y": 20}],
+        ...         "b": [{"x": 3, "y": 30}, {"x": 4, "y": 40}],
+        ...     }
+        ... )
+        >>> df.with_columns(
+        ...     pl.col("a").struct.prefix("a_"),
+        ...     pl.col("b").struct.prefix("b_"),
+        ... ).unnest("a", "b")
+        shape: (2, 4)
+        ┌─────┬─────┬─────┬─────┐
+        │ a_x ┆ a_y ┆ b_x ┆ b_y │
+        │ --- ┆ --- ┆ --- ┆ --- │
+        │ i64 ┆ i64 ┆ i64 ┆ i64 │
+        ╞═════╪═════╪═════╪═════╡
+        │ 1   ┆ 10  ┆ 3   ┆ 30  │
+        │ 2   ┆ 20  ┆ 4   ┆ 40  │
+        └─────┴─────┴─────┴─────┘
+
+        """
+        return wrap_expr(self._pyexpr.struct_prefix(prefix))
+
+    def suffix(self, suffix: str) -> Expr:
+        """
+        Add a suffix to the fields of the struct.
+
+        Parameters
+        ----------
+        suffix
+            Suffix to add to the struct's fields
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [{"x": 1, "y": 10}, {"x": 2, "y": 20}],
+        ...         "b": [{"x": 3, "y": 30}, {"x": 4, "y": 40}],
+        ...     }
+        ... )
+        >>> df.with_columns(
+        ...     pl.col("a").struct.suffix("_a"),
+        ...     pl.col("b").struct.suffix("_b"),
+        ... ).unnest("a", "b")
+        shape: (2, 4)
+        ┌─────┬─────┬─────┬─────┐
+        │ x_a ┆ y_a ┆ x_b ┆ y_b │
+        │ --- ┆ --- ┆ --- ┆ --- │
+        │ i64 ┆ i64 ┆ i64 ┆ i64 │
+        ╞═════╪═════╪═════╪═════╡
+        │ 1   ┆ 10  ┆ 3   ┆ 30  │
+        │ 2   ┆ 20  ┆ 4   ┆ 40  │
+        └─────┴─────┴─────┴─────┘
+
+        """
+        return wrap_expr(self._pyexpr.struct_suffix(suffix))

--- a/py-polars/polars/series/struct.py
+++ b/py-polars/polars/series/struct.py
@@ -53,6 +53,17 @@ class StructNameSpace:
 
         """
 
+    def prefix(self, prefix: str) -> Series:
+        """
+        Add a prefix to the fields of the struct.
+
+        Parameters
+        ----------
+        prefix
+            Prefix to add to the struct's fields
+
+        """
+
     def rename_fields(self, names: Sequence[str]) -> Series:
         """
         Rename the fields of the struct.
@@ -61,6 +72,17 @@ class StructNameSpace:
         ----------
         names
             New names in the order of the struct's fields
+
+        """
+
+    def suffix(self, suffix: str) -> Series:
+        """
+        Add a suffix to the fields of the struct.
+
+        Parameters
+        ----------
+        suffix
+            Suffix to add to the struct's fields
 
         """
 

--- a/py-polars/src/expr/struct.rs
+++ b/py-polars/src/expr/struct.rs
@@ -12,7 +12,15 @@ impl PyExpr {
         self.inner.clone().struct_().field_by_name(name).into()
     }
 
+    fn struct_prefix(&self, prefix: String) -> Self {
+        self.inner.clone().struct_().prefix(prefix).into()
+    }
+
     fn struct_rename_fields(&self, names: Vec<String>) -> Self {
         self.inner.clone().struct_().rename_fields(names).into()
+    }
+
+    fn struct_suffix(&self, suffix: String) -> Self {
+        self.inner.clone().struct_().suffix(suffix).into()
     }
 }

--- a/py-polars/tests/unit/namespaces/test_struct.py
+++ b/py-polars/tests/unit/namespaces/test_struct.py
@@ -28,3 +28,23 @@ def test_rename_fields() -> None:
         "a",
         "b",
     ]
+
+
+def test_struct_prefix_suffix() -> None:
+    df = pl.DataFrame(
+        {"int": [1, 2], "str": ["a", "b"], "bool": [True, None], "list": [[1, 2], [3]]}
+    )
+    s = df.to_struct("my_struct")
+
+    assert s.struct.prefix("pref_").struct.fields == [
+        "pref_int",
+        "pref_str",
+        "pref_bool",
+        "pref_list",
+    ]
+    assert s.struct.suffix("_suff").struct.fields == [
+        "int_suff",
+        "str_suff",
+        "bool_suff",
+        "list_suff",
+    ]


### PR DESCRIPTION
Attempts to resolve #5169

I've just used the existing `.rename_fields()` as a template 

https://github.com/pola-rs/polars/blob/42a4347cc84fd304fd72405a2277751b8c51e04e/crates/polars-plan/src/dsl/struct_.rs#L32

I'm not sure what case this handles:

https://github.com/pola-rs/polars/blob/42a4347cc84fd304fd72405a2277751b8c51e04e/crates/polars-plan/src/dsl/struct_.rs#L51-L71

<strike>if I replace it with `GetOutput::map_dtype(move |dt| dt.clone())` all tests still pass and everything seems to "work" - but it's possible I'm lacking understanding here?</strike>

---

**Update:** I think I understand now, it wasn't noticeable because I was not testing chained calls.

Without it the schema is not immediately updated, so a chained call fails as the name does not yet exist:
```python
df = pl.DataFrame({"my.struct": {"A": {"name": "a"}, "B": {"name": "b"} }})

df.select(
   pl.col("my.struct").struct.field("A").struct.prefix("my.").struct.field("my.name")
)

# StructFieldNotFoundError: my.name
```
Whereas with it:
```python
shape: (1, 1)
┌─────────┐
│ my.name │
│ ---     │
│ str     │
╞═════════╡
│ a       │
└─────────┘
```