### PR TITLE
chore(cli): Move `profile` config to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,9 @@ features = [
 [patch.crates-io]
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }
 # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
+
+[profile.release.package.polars-cli]
+strip = true
+# Below settings cannot be specified due to Cargo workspace restrictions, see: https://github.com/rust-lang/cargo/issues/9330
+# lto = true
+# panic = "abort"

--- a/polars-cli/Cargo.toml
+++ b/polars-cli/Cargo.toml
@@ -32,8 +32,3 @@ default = ["highlight", "parquet", "json", "ipc"]
 parquet = ["polars/parquet"]
 json = ["polars/json"]
 ipc = ["polars/ipc"]
-
-[profile.release]
-strip = true
-lto = true
-panic = "abort"

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.18.11"
+version = "0.18.12"
 dependencies = [
  "ahash",
  "built",


### PR DESCRIPTION
Any `cargo build` in the workspace would result in the following warning:
```
warning: profiles for the non root package will be ignored, specify profiles at the workspace root:
package:   /home/stijn/code/polars/polars-cli/Cargo.toml
workspace: /home/stijn/code/polars/Cargo.toml
```

So the profile config wasn't doing anything. Moving the profile definition to the workspace fixes the warning. However, the `lto` and `panick` keys are not supported. See https://github.com/rust-lang/cargo/issues/9330

For now, this at least enables the `strip` option and removes the warning.

@universalmind303 Do you have any input here?