### PR TITLE
chore(rust): Exclude examples from workspace default

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -40,7 +40,7 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Run cargo clippy with all features enabled
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   # Default feature set should compile on the stable toolchain
   clippy-stable:
@@ -60,7 +60,7 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Run cargo clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   rustfmt:
     if: github.ref_name != 'main'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,10 @@ members = [
   "contribution/*",
   "examples/*",
 ]
+default-members = [
+  "crates/*",
+  "polars-cli",
+]
 exclude = [
   "examples/datasets",
 ]

--- a/crates/Makefile
+++ b/crates/Makefile
@@ -10,15 +10,15 @@ fmt:  ## Run rustfmt and dprint
 
 .PHONY: check
 check:  ## Run cargo check with all features
-	cargo check --all-targets --all-features
+	cargo check --workspace --all-targets --all-features
 
 .PHONY: clippy
 clippy:  ## Run clippy with all features
-	cargo clippy --all-targets --all-features
+	cargo clippy --workspace --all-targets --all-features
 
 .PHONY: clippy-default
 clippy-default:  ## Run clippy with default features
-	cargo clippy --all-targets
+	cargo clippy --workspace --all-targets
 
 .PHONY: pre-commit
 pre-commit: fmt clippy clippy-default  ## Run autoformatting and linting


### PR DESCRIPTION
This way, we're not building the examples by default every time. You can pass `--workspace` to cargo commands to include the examples.

This is relevant because the example `python_rust_compiled_function` causes a linker error when running `cargo test` in the workspace. See [PyO3 docs](https://pyo3.rs/main/faq#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror).