### PR TITLE
feat(python): warn about inefficient apply json.loads if json is local import

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -527,7 +527,9 @@ class RewrittenInstructions:
     from the identification of expression translation opportunities.
     """
 
-    _ignored_ops = frozenset(["COPY_FREE_VARS", "PRECALL", "RESUME", "RETURN_VALUE"])
+    _ignored_ops = frozenset(
+        ["COPY_FREE_VARS", "PRECALL", "PUSH_NULL", "RESUME", "RETURN_VALUE"]
+    )
 
     def __init__(self, instructions: Iterator[Instruction]):
         self._original_instructions = list(instructions)
@@ -636,7 +638,7 @@ class RewrittenInstructions:
         if matching_instructions := self._matches(
             idx,
             opnames=[
-                {"LOAD_GLOBAL"},
+                {"LOAD_GLOBAL", "LOAD_DEREF"},
                 OpNames.LOAD_ATTR,
                 {"LOAD_FAST", "LOAD_CONST"},
                 OpNames.CALL,

--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -178,3 +178,17 @@ def test_bytecode_parser_expression_noop(func: Callable[[Any], Any]) -> None:
 
     parser = udfs.BytecodeParser(func, apply_target="expr")
     assert not parser.can_attempt_rewrite() or not parser.to_expression("x")
+
+
+def test_local_imports() -> None:
+    try:
+        import udfs
+    except ModuleNotFoundError as exc:
+        assert "No module named 'udfs'" in str(exc)  # noqa: PT017
+        return
+    import json
+
+    bytecode_parser = udfs.BytecodeParser(lambda x: json.loads(x), apply_target="expr")
+    result = bytecode_parser.to_expression("x")
+    expected = 'pl.col("x").str.json_extract()'
+    assert result == expected


### PR DESCRIPTION
The following doesn't raise on `main`:
```python
def func():
    import json

    df = pl.DataFrame({'a': '{"a":[1,2,3]}'}).select(pl.col('a').apply(lambda x: json.loads(x)))


func()
```