### PR TITLE
perf(rust, python): don't parallelize literal expressions

### DIFF
--- a/crates/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -254,7 +254,7 @@ impl PhysicalExpr for ApplyExpr {
 
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
         let f = |e: &Arc<dyn PhysicalExpr>| e.evaluate(df, state);
-        let mut inputs = if self.allow_threading {
+        let mut inputs = if self.allow_threading && self.inputs.len() > 1 {
             POOL.install(|| {
                 self.inputs
                     .par_iter()


### PR DESCRIPTION
There is overhead in calling `par_iter` or `rayon::join`. This is not worth it on literals as they are essentially free.

#10316 