### PR TITLE
feat(rust, python): allow sequential runners in select/with_columns

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -701,11 +701,23 @@ impl LazyFrame {
     /// }
     /// ```
     pub fn select<E: AsRef<[Expr]>>(self, exprs: E) -> Self {
+        let exprs = exprs.as_ref().to_vec();
+        self.select_impl(exprs, ProjectionOptions { run_parallel: true })
+    }
+
+    pub fn select_seq<E: AsRef<[Expr]>>(self, exprs: E) -> Self {
+        let exprs = exprs.as_ref().to_vec();
+        self.select_impl(
+            exprs,
+            ProjectionOptions {
+                run_parallel: false,
+            },
+        )
+    }
+
+    fn select_impl(self, exprs: Vec<Expr>, options: ProjectionOptions) -> Self {
         let opt_state = self.get_opt_state();
-        let lp = self
-            .get_plan_builder()
-            .project(exprs.as_ref().to_vec())
-            .build();
+        let lp = self.get_plan_builder().project(exprs, options).build();
         Self::from_logical_plan(lp, opt_state)
     }
 
@@ -999,7 +1011,15 @@ impl LazyFrame {
     /// ```
     pub fn with_column(self, expr: Expr) -> LazyFrame {
         let opt_state = self.get_opt_state();
-        let lp = self.get_plan_builder().with_columns(vec![expr]).build();
+        let lp = self
+            .get_plan_builder()
+            .with_columns(
+                vec![expr],
+                ProjectionOptions {
+                    run_parallel: false,
+                },
+            )
+            .build();
         Self::from_logical_plan(lp, opt_state)
     }
 
@@ -1019,8 +1039,23 @@ impl LazyFrame {
     /// ```
     pub fn with_columns<E: AsRef<[Expr]>>(self, exprs: E) -> LazyFrame {
         let exprs = exprs.as_ref().to_vec();
+        self.with_columns_impl(exprs, ProjectionOptions { run_parallel: true })
+    }
+
+    /// Add multiple columns to a DataFrame, but evaluate them sequentially.
+    pub fn with_columns_seq<E: AsRef<[Expr]>>(self, exprs: E) -> LazyFrame {
+        let exprs = exprs.as_ref().to_vec();
+        self.with_columns_impl(
+            exprs,
+            ProjectionOptions {
+                run_parallel: false,
+            },
+        )
+    }
+
+    fn with_columns_impl(self, exprs: Vec<Expr>, options: ProjectionOptions) -> LazyFrame {
         let opt_state = self.get_opt_state();
-        let lp = self.get_plan_builder().with_columns(exprs).build();
+        let lp = self.get_plan_builder().with_columns(exprs, options).build();
         Self::from_logical_plan(lp, opt_state)
     }
 

--- a/crates/polars-lazy/src/physical_plan/executors/projection.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/projection.rs
@@ -10,6 +10,7 @@ pub struct ProjectionExec {
     pub(crate) input_schema: SchemaRef,
     #[cfg(test)]
     pub(crate) schema: SchemaRef,
+    pub(crate) options: ProjectionOptions,
 }
 
 impl ProjectionExec {
@@ -25,6 +26,7 @@ impl ProjectionExec {
             &self.expr,
             state,
             self.has_windows,
+            self.options.run_parallel,
         )?;
         #[allow(unused_mut)]
         let mut df = check_expand_literals(selected_cols, df.height() == 0)?;

--- a/crates/polars-lazy/src/physical_plan/executors/stack.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/stack.rs
@@ -6,6 +6,7 @@ pub struct StackExec {
     pub(crate) cse_exprs: Vec<Arc<dyn PhysicalExpr>>,
     pub(crate) exprs: Vec<Arc<dyn PhysicalExpr>>,
     pub(crate) input_schema: SchemaRef,
+    pub(crate) options: ProjectionOptions,
 }
 
 impl StackExec {
@@ -20,6 +21,7 @@ impl StackExec {
             &self.exprs,
             state,
             self.has_windows,
+            self.options.run_parallel,
         )?;
         state.clear_window_expr_cache();
 

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -232,6 +232,7 @@ pub fn create_physical_plan(
             expr,
             input,
             schema: _schema,
+            options,
             ..
         } => {
             let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
@@ -259,6 +260,7 @@ pub fn create_physical_plan(
                 input_schema,
                 #[cfg(test)]
                 schema: _schema,
+                options,
             }))
         }
         LocalProjection {
@@ -286,6 +288,7 @@ pub fn create_physical_plan(
                 input_schema,
                 #[cfg(test)]
                 schema: _schema,
+                options: Default::default(),
             }))
         }
         DataFrameScan {
@@ -519,6 +522,7 @@ pub fn create_physical_plan(
             input,
             exprs,
             schema: _schema,
+            options,
         } => {
             let input_schema = lp_arena.get(input).schema(lp_arena).into_owned();
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
@@ -547,6 +551,7 @@ pub fn create_physical_plan(
                 cse_exprs,
                 exprs: phys_exprs,
                 input_schema,
+                options,
             }))
         }
         MapFunction {

--- a/crates/polars-plan/src/logical_plan/alp.rs
+++ b/crates/polars-plan/src/logical_plan/alp.rs
@@ -58,6 +58,7 @@ pub enum ALogicalPlan {
         input: Node,
         expr: ProjectionExprs,
         schema: SchemaRef,
+        options: ProjectionOptions,
     },
     LocalProjection {
         expr: Vec<Node>,
@@ -95,6 +96,7 @@ pub enum ALogicalPlan {
         input: Node,
         exprs: ProjectionExprs,
         schema: SchemaRef,
+        options: ProjectionOptions,
     },
     Distinct {
         input: Node,
@@ -252,10 +254,13 @@ impl ALogicalPlan {
                 expr: exprs,
                 schema: schema.clone(),
             },
-            Projection { schema, .. } => Projection {
+            Projection {
+                schema, options, ..
+            } => Projection {
                 input: inputs[0],
                 expr: ProjectionExprs::new(exprs),
                 schema: schema.clone(),
+                options: *options,
             },
             Aggregate {
                 keys,
@@ -302,10 +307,13 @@ impl ALogicalPlan {
                 input: inputs[0],
                 options: options.clone(),
             },
-            HStack { schema, .. } => HStack {
+            HStack {
+                schema, options, ..
+            } => HStack {
                 input: inputs[0],
                 exprs: ProjectionExprs::new(exprs),
                 schema: schema.clone(),
+                options: *options,
             },
             Scan {
                 path,

--- a/crates/polars-plan/src/logical_plan/builder_alp.rs
+++ b/crates/polars-plan/src/logical_plan/builder_alp.rs
@@ -52,7 +52,7 @@ impl<'a> ALogicalPlanBuilder<'a> {
         self.add_alp(lp)
     }
 
-    pub fn project(self, exprs: Vec<Node>) -> Self {
+    pub fn project(self, exprs: Vec<Node>, options: ProjectionOptions) -> Self {
         let input_schema = self.lp_arena.get(self.root).schema(self.lp_arena);
         let schema = aexprs_to_schema(&exprs, &input_schema, Context::Default, self.expr_arena);
 
@@ -62,6 +62,7 @@ impl<'a> ALogicalPlanBuilder<'a> {
                 expr: exprs.into(),
                 input: self.root,
                 schema: Arc::new(schema),
+                options,
             };
             let node = self.lp_arena.add(lp);
             ALogicalPlanBuilder::new(node, self.expr_arena, self.lp_arena)
@@ -82,7 +83,7 @@ impl<'a> ALogicalPlanBuilder<'a> {
         self.lp_arena.get(self.root).schema(self.lp_arena)
     }
 
-    pub(crate) fn with_columns(self, exprs: Vec<Node>) -> Self {
+    pub(crate) fn with_columns(self, exprs: Vec<Node>, options: ProjectionOptions) -> Self {
         let schema = self.schema();
         let mut new_schema = (**schema).clone();
 
@@ -100,6 +101,7 @@ impl<'a> ALogicalPlanBuilder<'a> {
             input: self.root,
             exprs: ProjectionExprs::new(exprs),
             schema: Arc::new(new_schema),
+            options,
         };
         self.add_alp(lp)
     }

--- a/crates/polars-plan/src/logical_plan/conversion.rs
+++ b/crates/polars-plan/src/logical_plan/conversion.rs
@@ -234,6 +234,7 @@ pub fn to_alp(
             expr,
             input,
             schema,
+            options,
         } => {
             let expr = expr.into_iter().map(|x| to_aexpr(x, expr_arena)).collect();
             let i = to_alp(*input, expr_arena, lp_arena)?;
@@ -241,6 +242,7 @@ pub fn to_alp(
                 expr,
                 input: i,
                 schema,
+                options,
             }
         }
         LogicalPlan::LocalProjection {
@@ -335,6 +337,7 @@ pub fn to_alp(
             input,
             exprs,
             schema,
+            options,
         } => {
             let exp = exprs.into_iter().map(|x| to_aexpr(x, expr_arena)).collect();
             let input = to_alp(*input, expr_arena, lp_arena)?;
@@ -342,6 +345,7 @@ pub fn to_alp(
                 input,
                 exprs: exp,
                 schema,
+                options,
             }
         }
         LogicalPlan::Distinct { input, options } => {
@@ -689,6 +693,7 @@ impl ALogicalPlan {
                 expr,
                 input,
                 schema,
+                options,
             } => {
                 let i = convert_to_lp(input, lp_arena);
 
@@ -696,6 +701,7 @@ impl ALogicalPlan {
                     expr: nodes_to_exprs(&expr, expr_arena),
                     input: Box::new(i),
                     schema,
+                    options,
                 }
             }
             ALogicalPlan::LocalProjection {
@@ -772,6 +778,7 @@ impl ALogicalPlan {
                 input,
                 exprs,
                 schema,
+                options,
             } => {
                 let i = convert_to_lp(input, lp_arena);
 
@@ -779,6 +786,7 @@ impl ALogicalPlan {
                     input: Box::new(i),
                     exprs: nodes_to_exprs(&exprs, expr_arena),
                     schema,
+                    options,
                 }
             }
             ALogicalPlan::Distinct { input, options } => {

--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -190,6 +190,7 @@ pub enum LogicalPlan {
         expr: Vec<Expr>,
         input: Box<LogicalPlan>,
         schema: SchemaRef,
+        options: ProjectionOptions,
     },
     /// Groupby aggregation
     Aggregate {
@@ -216,6 +217,7 @@ pub enum LogicalPlan {
         input: Box<LogicalPlan>,
         exprs: Vec<Expr>,
         schema: SchemaRef,
+        options: ProjectionOptions,
     },
     /// Remove duplicates from the table
     Distinct {

--- a/crates/polars-plan/src/logical_plan/optimizer/cache_states.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cache_states.rs
@@ -164,7 +164,7 @@ pub(super) fn set_cache_states(
 
                         let new_child = lp_arena.add(child_lp);
                         let lp = ALogicalPlanBuilder::new(new_child, expr_arena, lp_arena)
-                            .project(projection.clone())
+                            .project(projection.clone(), Default::default())
                             .build();
 
                         let lp = pd.optimize(lp, lp_arena, expr_arena).unwrap();

--- a/crates/polars-plan/src/logical_plan/optimizer/cse_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cse_expr.rs
@@ -498,6 +498,7 @@ impl<'a> RewritingVisitor for CommonSubExprOptimizer<'a> {
                 input,
                 expr,
                 schema,
+                options,
             } => {
                 if let Some(expr) =
                     self.find_cse(expr, &mut expr_arena, &mut id_array_offsets, false)?
@@ -506,6 +507,7 @@ impl<'a> RewritingVisitor for CommonSubExprOptimizer<'a> {
                         input: *input,
                         expr,
                         schema: schema.clone(),
+                        options: *options,
                     };
                     node.replace(lp);
                 }
@@ -514,6 +516,7 @@ impl<'a> RewritingVisitor for CommonSubExprOptimizer<'a> {
                 input,
                 exprs,
                 schema,
+                options,
             } => {
                 if let Some(exprs) =
                     self.find_cse(exprs, &mut expr_arena, &mut id_array_offsets, false)?
@@ -522,6 +525,7 @@ impl<'a> RewritingVisitor for CommonSubExprOptimizer<'a> {
                         input: *input,
                         exprs,
                         schema: schema.clone(),
+                        options: *options,
                     };
                     node.replace(lp);
                 }
@@ -620,11 +624,10 @@ mod test {
         let e = col("a").sum();
 
         let lp = LogicalPlanBuilder::from_existing_df(df)
-            .project(vec![
-                e.clone() * col("b"),
-                e.clone() * col("b") + e,
-                col("b"),
-            ])
+            .project(
+                vec![e.clone() * col("b"), e.clone() * col("b") + e, col("b")],
+                Default::default(),
+            )
             .build();
 
         let (node, mut lp_arena, mut expr_arena) = lp.to_alp().unwrap();

--- a/crates/polars-plan/src/logical_plan/optimizer/file_caching.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/file_caching.rs
@@ -172,7 +172,7 @@ impl FileCacher {
                     .collect();
 
                 lp = ALogicalPlanBuilder::new(node, expr_arena, lp_arena)
-                    .project(projections)
+                    .project(projections, Default::default())
                     .build();
             }
         }

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/functions/melt.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/functions/melt.rs
@@ -53,7 +53,7 @@ pub(super) fn process_melt(
             Ok(lp)
         } else {
             Ok(ALogicalPlanBuilder::from_lp(lp, expr_arena, lp_arena)
-                .project(local_projections)
+                .project(local_projections, Default::default())
                 .build())
         }
     }

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/functions/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/functions/mod.rs
@@ -112,12 +112,12 @@ pub(super) fn process_functions(
                     // if we would project, we would remove pushed down predicates
                     if local_projections.len() < original_acc_projection_len {
                         Ok(ALogicalPlanBuilder::from_lp(lp, expr_arena, lp_arena)
-                            .with_columns(local_projections)
+                            .with_columns(local_projections, Default::default())
                             .build())
                         // all projections are local
                     } else {
                         Ok(ALogicalPlanBuilder::from_lp(lp, expr_arena, lp_arena)
-                            .project(local_projections)
+                            .project(local_projections, Default::default())
                             .build())
                     }
                 }

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/generic.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/generic.rs
@@ -46,7 +46,7 @@ pub(super) fn process_generic(
             // so we ensure we do the 'a' projection again before we concatenate
             if !acc_projections.is_empty() && inputs.len() > 1 {
                 alp = ALogicalPlanBuilder::from_lp(alp, expr_arena, lp_arena)
-                    .project(acc_projections.clone())
+                    .project(acc_projections.clone(), Default::default())
                     .build()
             }
             lp_arena.replace(node, alp);

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/hstack.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/hstack.rs
@@ -5,6 +5,7 @@ pub(super) fn process_hstack(
     proj_pd: &mut ProjectionPushDown,
     input: Node,
     mut exprs: Vec<Node>,
+    options: ProjectionOptions,
     mut acc_projections: Vec<Node>,
     mut projected_names: PlHashSet<Arc<str>>,
     projections_seen: usize,
@@ -82,7 +83,7 @@ pub(super) fn process_hstack(
         expr_arena,
     )?;
     let lp = ALogicalPlanBuilder::new(input, expr_arena, lp_arena)
-        .with_columns(exprs)
+        .with_columns(exprs, options)
         .build();
     Ok(lp)
 }

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
@@ -202,7 +202,9 @@ impl ProjectionPushDown {
         builder: ALogicalPlanBuilder,
     ) -> ALogicalPlan {
         if !local_projections.is_empty() {
-            builder.project(local_projections).build()
+            builder
+                .project(local_projections, Default::default())
+                .build()
         } else {
             builder.build()
         }
@@ -629,10 +631,16 @@ impl ProjectionPushDown {
                     expr_arena,
                 ),
             },
-            HStack { input, exprs, .. } => process_hstack(
+            HStack {
+                input,
+                exprs,
+                options,
+                ..
+            } => process_hstack(
                 self,
                 input,
                 exprs.exprs(),
+                options,
                 acc_projections,
                 projected_names,
                 projections_seen,
@@ -721,7 +729,7 @@ impl ProjectionPushDown {
                 } else {
                     Ok(
                         ALogicalPlanBuilder::from_lp(logical_plan, expr_arena, lp_arena)
-                            .project(acc_projections)
+                            .project(acc_projections, Default::default())
                             .build(),
                     )
                 }

--- a/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -333,17 +333,17 @@ impl SlicePushDown {
                 self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
             }
             // there is state, inspect the projection to determine how to deal with it
-            (Projection {input, expr, schema}, Some(_)) => {
+            (Projection {input, expr, schema, options}, Some(_)) => {
                 // The slice operation may only pass on simple projections. col("foo").alias("bar")
                 if expr.iter().all(|root|  {
                     aexpr_is_elementwise(*root, expr_arena)
                 }) {
-                    let lp = Projection {input, expr, schema};
+                    let lp = Projection {input, expr, schema, options};
                     self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
                 }
                 // don't push down slice, but restart optimization
                 else {
-                    let lp = Projection {input, expr, schema};
+                    let lp = Projection {input, expr, schema, options};
                     self.no_pushdown_restart_opt(lp, state, lp_arena, expr_arena)
                 }
             }

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -301,3 +301,15 @@ pub enum FileType {
     Ipc(IpcWriterOptions),
     Memory,
 }
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Copy, Debug)]
+pub struct ProjectionOptions {
+    pub run_parallel: bool,
+}
+
+impl Default for ProjectionOptions {
+    fn default() -> Self {
+        Self { run_parallel: true }
+    }
+}

--- a/py-polars/docs/source/reference/dataframe/modify_select.rst
+++ b/py-polars/docs/source/reference/dataframe/modify_select.rst
@@ -48,6 +48,7 @@ Manipulation/selection
     DataFrame.rows_by_key
     DataFrame.sample
     DataFrame.select
+    DataFrame.select_seq
     DataFrame.set_sorted
     DataFrame.shift
     DataFrame.shift_and_fill
@@ -67,4 +68,5 @@ Manipulation/selection
     DataFrame.upsample
     DataFrame.vstack
     DataFrame.with_columns
+    DataFrame.with_columns_seq
     DataFrame.with_row_count

--- a/py-polars/docs/source/reference/lazyframe/modify_select.rst
+++ b/py-polars/docs/source/reference/lazyframe/modify_select.rst
@@ -31,6 +31,7 @@ Manipulation/selection
     LazyFrame.rename
     LazyFrame.reverse
     LazyFrame.select
+    LazyFrame.select_seq
     LazyFrame.set_sorted
     LazyFrame.shift
     LazyFrame.shift_and_fill
@@ -43,5 +44,6 @@ Manipulation/selection
     LazyFrame.unnest
     LazyFrame.update
     LazyFrame.with_columns
+    LazyFrame.with_columns_seq
     LazyFrame.with_context
     LazyFrame.with_row_count

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7338,6 +7338,34 @@ class DataFrame:
         """
         return self.lazy().select(*exprs, **named_exprs).collect(no_optimization=True)
 
+    def select_seq(
+        self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
+    ) -> DataFrame:
+        """
+        Select columns from this LazyFrame.
+
+        This will run all expression sequential instead of in parallel.
+        Use this when the work per expression is cheap.
+
+        Parameters
+        ----------
+        *exprs
+            Column(s) to select, specified as positional arguments.
+            Accepts expression input. Strings are parsed as column names,
+            other non-expression inputs are parsed as literals.
+        **named_exprs
+            Additional columns to select, specified as keyword arguments.
+            The columns will be renamed to the keyword used.
+
+        See Also
+        --------
+        select
+
+        """
+        return (
+            self.lazy().select_seq(*exprs, **named_exprs).collect(no_optimization=True)
+        )
+
     def with_columns(
         self,
         *exprs: IntoExpr | Iterable[IntoExpr],
@@ -7489,6 +7517,45 @@ class DataFrame:
         return (
             self.lazy()
             .with_columns(*exprs, **named_exprs)
+            .collect(no_optimization=True)
+        )
+
+    def with_columns_seq(
+        self,
+        *exprs: IntoExpr | Iterable[IntoExpr],
+        **named_exprs: IntoExpr,
+    ) -> DataFrame:
+        """
+        Add columns to this DataFrame.
+
+        Added columns will replace existing columns with the same name.
+
+        This will run all expression sequential instead of in parallel.
+        Use this when the work per expression is cheap.
+
+        Parameters
+        ----------
+        *exprs
+            Column(s) to add, specified as positional arguments.
+            Accepts expression input. Strings are parsed as column names, other
+            non-expression inputs are parsed as literals.
+        **named_exprs
+            Additional columns to add, specified as keyword arguments.
+            The columns will be renamed to the keyword used.
+
+        Returns
+        -------
+        LazyFrame
+            A new LazyFrame with the columns added.
+
+        See Also
+        --------
+        with_columns
+
+        """
+        return (
+            self.lazy()
+            .with_columns_seq(*exprs, **named_exprs)
             .collect(no_optimization=True)
         )
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7344,7 +7344,7 @@ class DataFrame:
         """
         Select columns from this LazyFrame.
 
-        This will run all expression sequential instead of in parallel.
+        This will run all expression sequentially instead of in parallel.
         Use this when the work per expression is cheap.
 
         Parameters
@@ -7530,7 +7530,7 @@ class DataFrame:
 
         Added columns will replace existing columns with the same name.
 
-        This will run all expression sequential instead of in parallel.
+        This will run all expression sequentially instead of in parallel.
         Use this when the work per expression is cheap.
 
         Parameters

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2170,7 +2170,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Select columns from this LazyFrame.
 
-        This will run all expression sequential instead of in parallel.
+        This will run all expression sequentially instead of in parallel.
         Use this when the work per expression is cheap.
 
         Parameters
@@ -3311,7 +3311,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Added columns will replace existing columns with the same name.
 
-        This will run all expression sequential instead of in parallel.
+        This will run all expression sequentially instead of in parallel.
         Use this when the work per expression is cheap.
 
         Parameters

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -69,7 +69,6 @@ from polars.utils.various import (
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyLazyFrame
 
-
 if TYPE_CHECKING:
     import sys
     from io import IOBase
@@ -78,6 +77,7 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
     from polars import DataFrame, Expr
+    from polars.polars import PyExpr
     from polars.type_aliases import (
         AsofJoinStrategy,
         ClosedInterval,
@@ -109,6 +109,29 @@ if TYPE_CHECKING:
 
     T = TypeVar("T")
     P = ParamSpec("P")
+
+
+def _prepare_select(
+    *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
+) -> list[PyExpr]:
+    structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
+
+    if "exprs" in named_exprs:
+        issue_deprecation_warning(
+            "passing expressions to `select` using the keyword argument `exprs` is"
+            " deprecated. Use positional syntax instead.",
+            version="0.18.1",
+        )
+        first_input = named_exprs.pop("exprs")
+        pyexprs = parse_as_list_of_expressions(
+            first_input, *exprs, **named_exprs, __structify=structify
+        )
+    else:
+        pyexprs = parse_as_list_of_expressions(
+            *exprs, **named_exprs, __structify=structify
+        )
+
+    return pyexprs
 
 
 @deprecate_renamed_methods(
@@ -2138,24 +2161,35 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └───────────┘
 
         """
-        structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
-
-        if "exprs" in named_exprs:
-            issue_deprecation_warning(
-                "passing expressions to `select` using the keyword argument `exprs` is"
-                " deprecated. Use positional syntax instead.",
-                version="0.18.1",
-            )
-            first_input = named_exprs.pop("exprs")
-            pyexprs = parse_as_list_of_expressions(
-                first_input, *exprs, **named_exprs, __structify=structify
-            )
-        else:
-            pyexprs = parse_as_list_of_expressions(
-                *exprs, **named_exprs, __structify=structify
-            )
-
+        pyexprs = _prepare_select(*exprs, **named_exprs)
         return self._from_pyldf(self._ldf.select(pyexprs))
+
+    def select_seq(
+        self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
+    ) -> Self:
+        """
+        Select columns from this LazyFrame.
+
+        This will run all expression sequential instead of in parallel.
+        Use this when the work per expression is cheap.
+
+        Parameters
+        ----------
+        *exprs
+            Column(s) to select, specified as positional arguments.
+            Accepts expression input. Strings are parsed as column names,
+            other non-expression inputs are parsed as literals.
+        **named_exprs
+            Additional columns to select, specified as keyword arguments.
+            The columns will be renamed to the keyword used.
+
+        See Also
+        --------
+        select
+
+        """
+        pyexprs = _prepare_select(*exprs, **named_exprs)
+        return self._from_pyldf(self._ldf.select_seq(pyexprs))
 
     def groupby(
         self,
@@ -3264,24 +3298,44 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴──────┴─────────────┘
 
         """
-        structify = bool(int(os.environ.get("POLARS_AUTO_STRUCTIFY", 0)))
-
-        if "exprs" in named_exprs:
-            issue_deprecation_warning(
-                "passing expressions to `with_columns` using the keyword argument"
-                " `exprs` is deprecated. Use positional syntax instead.",
-                version="0.18.1",
-            )
-            first_input = named_exprs.pop("exprs")
-            pyexprs = parse_as_list_of_expressions(
-                first_input, *exprs, **named_exprs, __structify=structify
-            )
-        else:
-            pyexprs = parse_as_list_of_expressions(
-                *exprs, **named_exprs, __structify=structify
-            )
-
+        pyexprs = _prepare_select(*exprs, **named_exprs)
         return self._from_pyldf(self._ldf.with_columns(pyexprs))
+
+    def with_columns_seq(
+        self,
+        *exprs: IntoExpr | Iterable[IntoExpr],
+        **named_exprs: IntoExpr,
+    ) -> Self:
+        """
+        Add columns to this DataFrame.
+
+        Added columns will replace existing columns with the same name.
+
+        This will run all expression sequential instead of in parallel.
+        Use this when the work per expression is cheap.
+
+        Parameters
+        ----------
+        *exprs
+            Column(s) to add, specified as positional arguments.
+            Accepts expression input. Strings are parsed as column names, other
+            non-expression inputs are parsed as literals.
+        **named_exprs
+            Additional columns to add, specified as keyword arguments.
+            The columns will be renamed to the keyword used.
+
+        Returns
+        -------
+        LazyFrame
+            A new LazyFrame with the columns added.
+
+        See Also
+        --------
+        with_columns
+
+        """
+        pyexprs = _prepare_select(*exprs, **named_exprs)
+        return self._from_pyldf(self._ldf.with_columns_seq(pyexprs))
 
     def with_context(self, other: Self | list[Self]) -> Self:
         """

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -516,6 +516,12 @@ impl PyLazyFrame {
         ldf.select(exprs).into()
     }
 
+    fn select_seq(&mut self, exprs: Vec<PyExpr>) -> Self {
+        let ldf = self.ldf.clone();
+        let exprs = exprs.to_exprs();
+        ldf.select_seq(exprs).into()
+    }
+
     fn groupby(&mut self, by: Vec<PyExpr>, maintain_order: bool) -> PyLazyGroupBy {
         let ldf = self.ldf.clone();
         let by = by.to_exprs();
@@ -687,6 +693,11 @@ impl PyLazyFrame {
     fn with_columns(&mut self, exprs: Vec<PyExpr>) -> Self {
         let ldf = self.ldf.clone();
         ldf.with_columns(exprs.to_exprs()).into()
+    }
+
+    fn with_columns_seq(&mut self, exprs: Vec<PyExpr>) -> Self {
+        let ldf = self.ldf.clone();
+        ldf.with_columns_seq(exprs.to_exprs()).into()
     }
 
     fn rename(&mut self, existing: Vec<String>, new: Vec<String>) -> Self {

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -68,7 +68,7 @@ def test_lazyframe_membership_operator() -> None:
 
 def test_apply() -> None:
     ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
-    new = ldf.with_columns(pl.col("a").map(lambda s: s * 2).alias("foo"))
+    new = ldf.with_columns_seq(pl.col("a").map(lambda s: s * 2).alias("foo"))
 
     expected = ldf.clone().with_columns((pl.col("a") * 2).alias("foo"))
     assert_frame_equal(new, expected)
@@ -172,7 +172,7 @@ def test_filter_str() -> None:
     )
 
     # last row based on a filter
-    result = ldf.filter(pl.col("bools")).select(pl.last("*")).collect()
+    result = ldf.filter(pl.col("bools")).select_seq(pl.last("*")).collect()
     expected = pl.DataFrame({"time": ["11:13:00"], "bools": [True]})
     assert_frame_equal(result, expected)
 


### PR DESCRIPTION
Semantics remain the same. Expressions cannot access columns generated in the context. This serves merely as an optimization on small data, when parallelism overhead is too costly.