### PR TITLE
feat(rust!,python): Add `Series.cat.uses_lexical_ordering`

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -17,7 +17,7 @@ bitflags! {
     #[derive(Default)]
     struct BitSettings: u8 {
         const ORIGINAL = 0x01;
-        const LEXICAL_SORT = 0x02;
+        const LEXICAL_ORDERING = 0x02;
     }
 }
 
@@ -76,18 +76,18 @@ impl CategoricalChunked {
         }
     }
 
-    pub fn set_lexical_sorted(&mut self, toggle: bool) {
+    pub fn set_lexical_ordering(&mut self, toggle: bool) {
         if toggle {
-            self.bit_settings.insert(BitSettings::LEXICAL_SORT);
+            self.bit_settings.insert(BitSettings::LEXICAL_ORDERING);
         } else {
-            self.bit_settings.remove(BitSettings::LEXICAL_SORT);
+            self.bit_settings.remove(BitSettings::LEXICAL_ORDERING);
         }
     }
 
     /// Return whether or not the [`CategoricalChunked`] uses the lexical order
     /// of the string values when sorting.
-    pub fn uses_lexical_sort(&self) -> bool {
-        self.bit_settings.contains(BitSettings::LEXICAL_SORT)
+    pub fn uses_lexical_ordering(&self) -> bool {
+        self.bit_settings.contains(BitSettings::LEXICAL_ORDERING)
     }
 
     /// Create a [`CategoricalChunked`] from an array of `idx` and an existing [`RevMapping`]:  `rev_map`.

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -84,9 +84,9 @@ impl CategoricalChunked {
         }
     }
 
-    /// Return whether the [`CategoricalChunked`] uses the lexical order of
-    /// the string values when sorting.
-    pub(crate) fn uses_lexical_sort(&self) -> bool {
+    /// Return whether or not the [`CategoricalChunked`] uses the lexical order
+    /// of the string values when sorting.
+    pub fn uses_lexical_sort(&self) -> bool {
         self.bit_settings.contains(BitSettings::LEXICAL_SORT)
     }
 

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -16,9 +16,10 @@ use crate::prelude::*;
 bitflags! {
     #[derive(Default)]
     struct BitSettings: u8 {
-    const ORIGINAL = 0x01;
-    const LEXICAL_SORT = 0x02;
-}}
+        const ORIGINAL = 0x01;
+        const LEXICAL_SORT = 0x02;
+    }
+}
 
 #[derive(Clone)]
 pub struct CategoricalChunked {
@@ -83,7 +84,9 @@ impl CategoricalChunked {
         }
     }
 
-    pub(crate) fn use_lexical_sort(&self) -> bool {
+    /// Return whether the [`CategoricalChunked`] uses the lexical order of
+    /// the string values when sorting.
+    pub(crate) fn uses_lexical_sort(&self) -> bool {
         self.bit_settings.contains(BitSettings::LEXICAL_SORT)
     }
 

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -72,7 +72,7 @@ pub fn _get_rows_encoded_compat_array(by: &Series) -> PolarsResult<ArrayRef> {
         #[cfg(feature = "dtype-categorical")]
         DataType::Categorical(_) => {
             let ca = by.categorical().unwrap();
-            if ca.uses_lexical_sort() {
+            if ca.uses_lexical_ordering() {
                 by.to_arrow(0)
             } else {
                 ca.logical().chunks[0].clone()

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -72,7 +72,7 @@ pub fn _get_rows_encoded_compat_array(by: &Series) -> PolarsResult<ArrayRef> {
         #[cfg(feature = "dtype-categorical")]
         DataType::Categorical(_) => {
             let ca = by.categorical().unwrap();
-            if ca.use_lexical_sort() {
+            if ca.uses_lexical_sort() {
                 by.to_arrow(0)
             } else {
                 ca.logical().chunks[0].clone()

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -29,7 +29,7 @@ impl CategoricalChunked {
             "null last not yet supported for categorical dtype"
         );
 
-        if self.use_lexical_sort() {
+        if self.uses_lexical_sort() {
             let mut vals = self
                 .logical()
                 .into_no_null_iter()
@@ -78,7 +78,7 @@ impl CategoricalChunked {
 
     /// Retrieve the indexes needed to sort this array.
     pub fn arg_sort(&self, options: SortOptions) -> IdxCa {
-        if self.use_lexical_sort() {
+        if self.uses_lexical_sort() {
             let iters = [self.iter_str()];
             arg_sort::arg_sort(
                 self.name(),
@@ -95,7 +95,7 @@ impl CategoricalChunked {
     /// Retrieve the indexes need to sort this and the other arrays.
 
     pub(crate) fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
-        if self.use_lexical_sort() {
+        if self.uses_lexical_sort() {
             args_validate(self.logical(), &options.other, &options.descending)?;
             let mut count: IdxSize = 0;
 

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -29,7 +29,7 @@ impl CategoricalChunked {
             "null last not yet supported for categorical dtype"
         );
 
-        if self.uses_lexical_sort() {
+        if self.uses_lexical_ordering() {
             let mut vals = self
                 .logical()
                 .into_no_null_iter()
@@ -78,7 +78,7 @@ impl CategoricalChunked {
 
     /// Retrieve the indexes needed to sort this array.
     pub fn arg_sort(&self, options: SortOptions) -> IdxCa {
-        if self.uses_lexical_sort() {
+        if self.uses_lexical_ordering() {
             let iters = [self.iter_str()];
             arg_sort::arg_sort(
                 self.name(),
@@ -95,7 +95,7 @@ impl CategoricalChunked {
     /// Retrieve the indexes need to sort this and the other arrays.
 
     pub(crate) fn arg_sort_multiple(&self, options: &SortMultipleOptions) -> PolarsResult<IdxCa> {
-        if self.uses_lexical_sort() {
+        if self.uses_lexical_ordering() {
             args_validate(self.logical(), &options.other, &options.descending)?;
             let mut count: IdxSize = 0;
 
@@ -139,7 +139,7 @@ mod test {
             let s = Series::new("", init).cast(&DataType::Categorical(None))?;
             let ca = s.categorical()?;
             let mut ca_lexical = ca.clone();
-            ca_lexical.set_lexical_sorted(true);
+            ca_lexical.set_lexical_ordering(true);
 
             let out = ca_lexical.sort(false);
             assert_order(&out, &["a", "b", "c", "d"]);
@@ -167,7 +167,7 @@ mod test {
             let s = Series::new("", init).cast(&DataType::Categorical(None))?;
             let ca = s.categorical()?;
             let mut ca_lexical: CategoricalChunked = ca.clone();
-            ca_lexical.set_lexical_sorted(true);
+            ca_lexical.set_lexical_ordering(true);
 
             let series = ca_lexical.into_series();
 

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -29,7 +29,7 @@ impl SeriesWrap<CategoricalChunked> {
         if keep_fast_unique && self.0.can_fast_unique() {
             out.set_fast_unique(true)
         }
-        out.set_lexical_sorted(self.0.use_lexical_sort());
+        out.set_lexical_sorted(self.0.uses_lexical_sort());
         out
     }
 
@@ -91,7 +91,7 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
             .map(|ca| ca.into_series())
     }
     fn into_partial_ord_inner<'a>(&'a self) -> Box<dyn PartialOrdInner + 'a> {
-        if self.0.use_lexical_sort() {
+        if self.0.uses_lexical_sort() {
             (&self.0).into_partial_ord_inner()
         } else {
             self.0.logical().into_partial_ord_inner()

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -29,7 +29,7 @@ impl SeriesWrap<CategoricalChunked> {
         if keep_fast_unique && self.0.can_fast_unique() {
             out.set_fast_unique(true)
         }
-        out.set_lexical_sorted(self.0.uses_lexical_sort());
+        out.set_lexical_ordering(self.0.uses_lexical_ordering());
         out
     }
 
@@ -91,7 +91,7 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
             .map(|ca| ca.into_series())
     }
     fn into_partial_ord_inner<'a>(&'a self) -> Box<dyn PartialOrdInner + 'a> {
-        if self.0.uses_lexical_sort() {
+        if self.0.uses_lexical_ordering() {
             (&self.0).into_partial_ord_inner()
         } else {
             self.0.logical().into_partial_ord_inner()

--- a/crates/polars-plan/src/dsl/function_expr/cat.rs
+++ b/crates/polars-plan/src/dsl/function_expr/cat.rs
@@ -47,7 +47,7 @@ impl From<CategoricalFunction> for FunctionExpr {
 
 fn set_ordering(s: &Series, lexical: bool) -> PolarsResult<Series> {
     let mut ca = s.categorical()?.clone();
-    ca.set_lexical_sorted(lexical);
+    ca.set_lexical_ordering(lexical);
     Ok(ca.into_series())
 }
 

--- a/py-polars/docs/source/reference/series/categories.rst
+++ b/py-polars/docs/source/reference/series/categories.rst
@@ -11,4 +11,4 @@ The following methods are available under the `Series.cat` attribute.
 
     Series.cat.get_categories
     Series.cat.set_ordering
-    Series.cat.uses_lexical_sort
+    Series.cat.uses_lexical_ordering

--- a/py-polars/docs/source/reference/series/categories.rst
+++ b/py-polars/docs/source/reference/series/categories.rst
@@ -11,3 +11,4 @@ The following methods are available under the `Series.cat` attribute.
 
     Series.cat.get_categories
     Series.cat.set_ordering
+    Series.cat.uses_lexical_sort

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -88,10 +88,10 @@ class CatNameSpace:
         Examples
         --------
         >>> s = pl.Series(["b", "a", "b"]).cast(pl.Categorical)
-        >>> s.uses_lexical_sort()
+        >>> s.cat.uses_lexical_sort()
         False
-        >>> s = s.set_ordering("lexical")
-        >>> s.uses_lexical_sort()
+        >>> s = s.cat.set_ordering("lexical")
+        >>> s.cat.uses_lexical_sort()
         True
 
         """

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -75,7 +75,7 @@ class CatNameSpace:
 
         """
 
-    def uses_lexical_sort(self) -> bool:
+    def uses_lexical_ordering(self) -> bool:
         """
         Return whether or not the series uses lexical ordering.
 
@@ -93,11 +93,11 @@ class CatNameSpace:
         Examples
         --------
         >>> s = pl.Series(["b", "a", "b"]).cast(pl.Categorical)
-        >>> s.cat.uses_lexical_sort()
+        >>> s.cat.uses_lexical_ordering()
         False
         >>> s = s.cat.set_ordering("lexical")
-        >>> s.cat.uses_lexical_sort()
+        >>> s.cat.uses_lexical_ordering()
         True
 
         """
-        return self._s.cat_uses_lexical_sort()
+        return self._s.cat_uses_lexical_ordering()

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -81,6 +81,11 @@ class CatNameSpace:
 
         This can be set using :func:`set_ordering`.
 
+        Warnings
+        --------
+        This API is experimental and may change without it being considered a breaking
+        change.
+
         See Also
         --------
         set_ordering

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -74,3 +74,25 @@ class CatNameSpace:
         ]
 
         """
+
+    def uses_lexical_sort(self) -> bool:
+        """
+        Return whether or not the series uses lexical ordering.
+
+        This can be set using :func:`set_ordering`.
+
+        See Also
+        --------
+        set_ordering
+
+        Examples
+        --------
+        >>> s = pl.Series(["b", "a", "b"]).cast(pl.Categorical)
+        >>> s.uses_lexical_sort()
+        False
+        >>> s = s.set_ordering("lexical")
+        >>> s.uses_lexical_sort()
+        True
+
+        """
+        return self._s.cat_uses_lexical_sort()

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -94,9 +94,9 @@ impl PySeries {
         }
     }
 
-    pub fn cat_uses_lexical_sort(&self) -> PyResult<bool> {
+    pub fn cat_uses_lexical_ordering(&self) -> PyResult<bool> {
         let ca = self.series.categorical().map_err(PyPolarsErr::from)?;
-        Ok(ca.uses_lexical_sort())
+        Ok(ca.uses_lexical_ordering())
     }
 
     fn estimated_size(&self) -> usize {

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -94,6 +94,11 @@ impl PySeries {
         }
     }
 
+    pub fn cat_uses_lexical_sort(&self) -> PyResult<bool> {
+        let ca = self.series.categorical().map_err(PyPolarsErr::from)?;
+        Ok(ca.uses_lexical_sort())
+    }
+
     fn estimated_size(&self) -> usize {
         self.series.estimated_size()
     }

--- a/py-polars/tests/unit/series/test_categorical.py
+++ b/py-polars/tests/unit/series/test_categorical.py
@@ -1,12 +1,12 @@
 import polars as pl
 
 
-def test_cat_uses_lexical_sort() -> None:
+def test_cat_uses_lexical_ordering() -> None:
     s = pl.Series(["a", "b", None, "b"]).cast(pl.Categorical)
-    assert s.cat.uses_lexical_sort() is False
+    assert s.cat.uses_lexical_ordering() is False
 
     s = s.cat.set_ordering("lexical")
-    assert s.cat.uses_lexical_sort() is True
+    assert s.cat.uses_lexical_ordering() is True
 
     s = s.cat.set_ordering("physical")
-    assert s.cat.uses_lexical_sort() is False
+    assert s.cat.uses_lexical_ordering() is False

--- a/py-polars/tests/unit/series/test_categorical.py
+++ b/py-polars/tests/unit/series/test_categorical.py
@@ -1,0 +1,12 @@
+import polars as pl
+
+
+def test_cat_uses_lexical_sort() -> None:
+    s = pl.Series(["a", "b", None, "b"]).cast(pl.Categorical)
+    assert s.cat.uses_lexical_sort() is False
+
+    s = s.cat.set_ordering("lexical")
+    assert s.cat.uses_lexical_sort() is True
+
+    s = s.cat.set_ordering("physical")
+    assert s.cat.uses_lexical_sort() is False


### PR DESCRIPTION
Closes #5671, supersedes #5705, blocker for #10267

I didn't want to rebase the existing PR, so here's a fresh PR.

**WARNING: This functionality is considered experimental for now.**

Changes:
* On the Rust side:
  * Rename `set_lexical_sorted` to `set_lexical_ordering`.
  * Rename bit setting `LEXICAL_SORT` to `LEXICAL_ORDERING`.
  * Rename `use_lexical_sort` to `uses_lexical_ordering` and make it public outside the crate
* On the Python side:
  * Expose the `uses_lexical_ordering` method for categorical Series.

~I am really looking for a better name for this method, but I'm struggling to come up with something good. Help is appreciated!~
~I initially thought `is_ordered` would be appropriate. That would be the reverse of this - an ordered categorical sorts by physical type rather than lexical.~ -> Chose a sensible name for now and marked as experimental.
