### PR TITLE
feat(rust, python): add `encoding` parameter to `write_csv`

### DIFF
--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = { version = "0.1.59", optional = true }
 bytes = "1.3.0"
 chrono = { version = "0.4", default-features = false, features = ["std"], optional = true }
 chrono-tz = { version = "0.8.1", optional = true }
+encoding_rs = { version = "0.8.32", features = ["simd-accel"], optional = true }
 fast-float = { version = "0.2.0", optional = true }
 flate2 = { version = "1", optional = true, default-features = false }
 futures = { version = "0.3.25", optional = true }
@@ -64,6 +65,7 @@ ipc_streaming = ["arrow/io_ipc", "arrow/io_ipc_compression"]
 # support for arrow avro parsing
 avro = ["arrow/io_avro", "arrow/io_avro_compression"]
 csv = ["memmap", "lexical", "polars-core/rows", "lexical-core", "fast-float", "simdutf8"]
+csv-encoding = ["encoding_rs"]
 decompress = ["flate2/miniz_oxide"]
 decompress-fast = ["flate2/zlib-ng"]
 dtype-categorical = ["polars-core/dtype-categorical"]

--- a/crates/polars-io/src/csv/mod.rs
+++ b/crates/polars-io/src/csv/mod.rs
@@ -46,6 +46,8 @@ pub mod read_impl;
 
 mod read;
 pub(super) mod splitfields;
+#[cfg(feature = "csv-encoding")]
+mod transcoding;
 pub mod utils;
 mod write;
 pub(super) mod write_impl;

--- a/crates/polars-io/src/csv/transcoding.rs
+++ b/crates/polars-io/src/csv/transcoding.rs
@@ -1,0 +1,64 @@
+use std::io::Write;
+
+use encoding_rs::{Encoder, EncoderResult, Encoding};
+
+pub(super) struct TranscodingWriter<'a, W> {
+    sink: &'a mut W,
+    encoder: Encoder,
+    buffer: [u8; 1024],
+}
+
+impl<'a, W> TranscodingWriter<'a, W>
+where
+    W: Write,
+{
+    pub(super) fn new(sink: &'a mut W, encoding: &'static Encoding) -> Self {
+        return Self {
+            sink,
+            encoder: encoding.new_encoder(),
+            buffer: [0; 1024],
+        };
+    }
+}
+
+impl<'a, W> Write for TranscodingWriter<'a, W>
+where
+    W: Write,
+{
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        // safety: provided buffer is known to be UTF8
+        let src = unsafe { std::str::from_utf8_unchecked(buf) };
+        let (result, n_bytes_read, n_bytes_written) = self
+            .encoder
+            .encode_from_utf8_without_replacement(src, &mut self.buffer, false);
+        match result {
+            EncoderResult::InputEmpty | EncoderResult::OutputFull => self
+                .sink
+                .write_all(&mut self.buffer[..n_bytes_written])
+                .and(Ok(n_bytes_read)),
+            EncoderResult::Unmappable(c) => Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("failed to encode character '{}'", c),
+            )),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        if self.encoder.has_pending_state() {
+            let (result, _, _) =
+                self.encoder
+                    .encode_from_utf8_without_replacement("", &mut self.buffer, true);
+            match result {
+                EncoderResult::OutputFull => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("failed to finalize encoding"),
+                    ))
+                }
+                _ => {}
+            };
+            self.sink.write_all(&mut self.buffer[..])?;
+        }
+        self.sink.flush()
+    }
+}

--- a/crates/polars-io/src/csv/write_impl.rs
+++ b/crates/polars-io/src/csv/write_impl.rs
@@ -371,7 +371,7 @@ pub(crate) fn write<W: Write>(
 
         for buf in result_buf.drain(..) {
             let mut buf = buf?;
-            let _ = writer.write(&buf)?;
+            let _ = writer.write_all(&buf)?;
             buf.clear();
             write_buffer_pool.set(buf);
         }

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -80,7 +80,7 @@ ipc_streaming = ["polars-io", "polars-io/ipc_streaming", "polars-lazy/ipc"]
 avro = ["polars-io", "polars-io/avro"]
 
 # support for arrows csv file parsing
-csv = ["polars-io", "polars-io/csv", "polars-lazy/csv", "polars-sql/csv"]
+csv = ["polars-io", "polars-io/csv", "polars-io/csv-encoding", "polars-lazy/csv", "polars-sql/csv"]
 
 # slower builds
 performant = [

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -517,6 +517,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+ "packed_simd_2",
+]
+
+[[package]]
 name = "enum_dispatch"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,6 +1030,12 @@ dependencies = [
 
 [[package]]
 name = "libm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
+name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
@@ -1225,7 +1241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
- "libm",
+ "libm 0.2.7",
 ]
 
 [[package]]
@@ -1267,6 +1283,16 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "packed_simd_2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
+dependencies = [
+ "cfg-if",
+ "libm 0.1.4",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1518,6 +1544,7 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
+ "encoding_rs",
  "fast-float",
  "flate2",
  "futures",

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2373,6 +2373,7 @@ class DataFrame:
         time_format: str | None = ...,
         float_precision: int | None = ...,
         null_value: str | None = ...,
+        encoding: str | None = ...,
     ) -> str:
         ...
 
@@ -2390,6 +2391,7 @@ class DataFrame:
         time_format: str | None = ...,
         float_precision: int | None = ...,
         null_value: str | None = ...,
+        encoding: str | None = ...,
     ) -> None:
         ...
 
@@ -2406,6 +2408,7 @@ class DataFrame:
         time_format: str | None = None,
         float_precision: int | None = None,
         null_value: str | None = None,
+        encoding: str | None = None,
     ) -> str | None:
         """
         Write to comma-separated values (CSV) file.
@@ -2442,6 +2445,9 @@ class DataFrame:
             ``Float64`` datatypes.
         null_value
             A string representing null values (defaulting to the empty string).
+        encoding
+            A string representing the encoding to use in the CSV file. Defaults to
+            'utf-8'.
 
         Examples
         --------
@@ -2478,8 +2484,9 @@ class DataFrame:
                 time_format,
                 float_precision,
                 null_value,
+                encoding,
             )
-            return str(buffer.getvalue(), encoding="utf-8")
+            return str(buffer.getvalue(), encoding=encoding or "utf-8")
 
         if isinstance(file, (str, Path)):
             file = normalise_filepath(file)
@@ -2497,6 +2504,7 @@ class DataFrame:
             time_format,
             float_precision,
             null_value,
+            encoding,
         )
         return None
 

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -553,6 +553,7 @@ impl PyDataFrame {
         time_format: Option<String>,
         float_precision: Option<usize>,
         null_value: Option<String>,
+        encoding: Option<String>,
     ) -> PyResult<()> {
         let null = null_value.unwrap_or_default();
 
@@ -570,6 +571,8 @@ impl PyDataFrame {
                     .with_time_format(time_format)
                     .with_float_precision(float_precision)
                     .with_null_value(null)
+                    .with_encoding(encoding)
+                    .map_err(PyPolarsErr::from)?
                     .finish(&mut self.df)
                     .map_err(PyPolarsErr::from)
             })?;
@@ -585,6 +588,8 @@ impl PyDataFrame {
                 .with_time_format(time_format)
                 .with_float_precision(float_precision)
                 .with_null_value(null)
+                .with_encoding(encoding)
+                .map_err(PyPolarsErr::from)?
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         }

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1377,3 +1377,18 @@ def test_csv_9929() -> None:
     f.seek(0)
     with pytest.raises(pl.NoDataError):
         pl.read_csv(f, skip_rows=10**6)
+
+
+def test_write_csv_encoding():
+    df = pl.DataFrame({"a": ["test", "\u201etest\u201d"]})
+
+    utf8_out = io.BytesIO()
+    df.write_csv(utf8_out)
+    utf8_buf = utf8_out.getvalue()
+
+    cp1252_out = io.BytesIO()
+    df.write_csv(cp1252_out, encoding="cp1252")
+    cp1252_buf = cp1252_out.getvalue()
+
+    assert utf8_buf != cp1252_buf
+    assert utf8_buf.decode() == cp1252_buf.decode("cp1252")


### PR DESCRIPTION
# Motivation

In some circumstances, a CSV file should have an encoding other than `utf-8`. An example use case is a CSV file that is used to bulk-insert data into SQL Server where a more efficient single-byte encoding (e.g. Windows-1252) allows for smaller columns.

# Changes

- Add a new `encoding` parameter to `write_csv` which allows for all values that [`encoding_rs`](https://docs.rs/encoding_rs/latest/encoding_rs/) supports
- Add a new `TranscodingWriter` which implements the `Write` trait and allows to transcode a UTF-8 stream into another character encoding
- Add a simple test case to the Python tests

# Benchmark

Encoding to anything but UTF-8 is rather slow. Transcoding itself incurs a performance penalty of ~50% (i.e. if explicitly transcoding from UTF-8 to UTF-8). Encoding to Windows-1252 takes 8x longer than encoding to UTF-8.
