### PR TITLE
feat(python): utility to get buffers and pointers

### DIFF
--- a/py-polars/src/series/buffers.rs
+++ b/py-polars/src/series/buffers.rs
@@ -117,8 +117,8 @@ fn get_buffer_from_nested(s: &Series, index: usize) -> PyResult<Option<PySeries>
                     .into(),
             ))
         }
-        1 => get_offsets(s).map(Some),
-        2 => Ok(get_bitmap(s)),
+        1 => Ok(get_bitmap(s)),
+        2 => get_offsets(s).map(Some),
         _ => raise_err!("expected an index <= 2", ComputeError),
     }
 }

--- a/py-polars/src/series/buffers.rs
+++ b/py-polars/src/series/buffers.rs
@@ -6,23 +6,7 @@ use super::*;
 #[pymethods]
 impl PySeries {
     fn offset_buffers(&self) -> PyResult<Self> {
-        let buffers: Box<dyn Iterator<Item = &OffsetsBuffer<i64>>> = match self.series.dtype() {
-            DataType::List(_) => {
-                let ca = self.series.list().unwrap();
-                Box::new(ca.downcast_iter().map(|arr| arr.offsets()))
-            }
-            DataType::Utf8 => {
-                let ca = self.series.utf8().unwrap();
-                Box::new(ca.downcast_iter().map(|arr| arr.offsets()))
-            }
-            _ => return Err(PyValueError::new_err("expected list/utf8")),
-        };
-        let buffers = buffers
-            .map(|arr| PrimitiveArray::from_data_default(arr.buffer().clone(), None).boxed())
-            .collect::<Vec<_>>();
-        Ok(Series::try_from((self.name(), buffers))
-            .map_err(PyPolarsErr::from)?
-            .into())
+        get_offsets(&self.series)
     }
 
     fn get_ptr(&self) -> PyResult<usize> {
@@ -50,11 +34,121 @@ impl PySeries {
                 let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
                 get_ptr(ca)
             })),
+            DataType::Utf8 => {
+                let ca = s.utf8().unwrap();
+                let arr = ca.downcast_iter().next().unwrap();
+                Ok(arr.values().as_ptr() as usize)
+            }
+            DataType::Binary => {
+                let ca = s.binary().unwrap();
+                let arr = ca.downcast_iter().next().unwrap();
+                Ok(arr.values().as_ptr() as usize)
+            }
             _ => {
-                let msg = "Cannot take pointer of nested type";
+                let msg = "Cannot take pointer of nested type, try to first select a buffer";
                 raise_err!(msg, ComputeError);
             }
         }
+    }
+
+    fn get_buffer(&self, index: usize) -> PyResult<Self> {
+        match self.series.dtype().to_physical() {
+            dt if dt.is_numeric() => get_buffer_from_primitive(&self.series, index),
+            DataType::Boolean => get_buffer_from_primitive(&self.series, index),
+            DataType::Utf8 | DataType::List(_) | DataType::Binary => {
+                get_buffer_from_nested(&self.series, index)
+            }
+            DataType::Array(_, _) => {
+                let ca = self.series.array().unwrap();
+                match index {
+                    0 => {
+                        let buffers = ca
+                            .downcast_iter()
+                            .map(|arr| arr.values().clone())
+                            .collect::<Vec<_>>();
+                        Ok(Series::try_from((self.series.name(), buffers))
+                            .map_err(PyPolarsErr::from)?
+                            .into())
+                    }
+                    1 => Ok(self.series.is_not_null().into_series().into()),
+                    _ => raise_err!("expected an index <= 1", ComputeError),
+                }
+            }
+            _ => todo!(),
+        }
+    }
+}
+
+fn get_buffer_from_nested(s: &Series, index: usize) -> PyResult<PySeries> {
+    match index {
+        0 => {
+            let buffers: Box<dyn Iterator<Item = ArrayRef>> = match s.dtype() {
+                DataType::List(_) => {
+                    let ca = s.list().unwrap();
+                    Box::new(ca.downcast_iter().map(|arr| arr.values().clone()))
+                }
+                DataType::Utf8 => {
+                    let ca = s.utf8().unwrap();
+                    Box::new(ca.downcast_iter().map(|arr| {
+                        PrimitiveArray::from_data_default(arr.values().clone(), None).boxed()
+                    }))
+                }
+                DataType::Binary => {
+                    let ca = s.binary().unwrap();
+                    Box::new(ca.downcast_iter().map(|arr| {
+                        PrimitiveArray::from_data_default(arr.values().clone(), None).boxed()
+                    }))
+                }
+                dt => {
+                    let msg = format!("{dt} not yet supported as nested buffer access");
+                    raise_err!(msg, ComputeError);
+                }
+            };
+            let buffers = buffers.collect::<Vec<_>>();
+            Ok(Series::try_from((s.name(), buffers))
+                .map_err(PyPolarsErr::from)?
+                .into())
+        }
+        1 => get_offsets(s),
+        2 => Ok(s.is_not_null().into_series().into()),
+        _ => raise_err!("expected an index <= 2", ComputeError),
+    }
+}
+
+fn get_offsets(s: &Series) -> PyResult<PySeries> {
+    let buffers: Box<dyn Iterator<Item = &OffsetsBuffer<i64>>> = match s.dtype() {
+        DataType::List(_) => {
+            let ca = s.list().unwrap();
+            Box::new(ca.downcast_iter().map(|arr| arr.offsets()))
+        }
+        DataType::Utf8 => {
+            let ca = s.utf8().unwrap();
+            Box::new(ca.downcast_iter().map(|arr| arr.offsets()))
+        }
+        _ => return Err(PyValueError::new_err("expected list/utf8")),
+    };
+    let buffers = buffers
+        .map(|arr| PrimitiveArray::from_data_default(arr.buffer().clone(), None).boxed())
+        .collect::<Vec<_>>();
+    Ok(Series::try_from((s.name(), buffers))
+        .map_err(PyPolarsErr::from)?
+        .into())
+}
+
+fn get_buffer_from_primitive(s: &Series, index: usize) -> PyResult<PySeries> {
+    match index {
+        0 => {
+            let chunks = s
+                .chunks()
+                .iter()
+                .map(|arr| arr.with_validity(None))
+                .collect::<Vec<_>>();
+            Ok(Series::try_from((s.name(), chunks))
+                .map_err(PyPolarsErr::from)?
+                .into())
+        }
+        1 => Ok(s.is_not_null().into_series().into()),
+        _ => raise_err!("expected an index <= 1", ComputeError),
     }
 }
 


### PR DESCRIPTION
@stinodego this should give you the control you need.

Added

* pointer access for binary and utf8 (this will ignore the validity and offset buffer and just get the values pointer).
* buffer access for primitive data
    - index 0: values buffer
    - index 1: validity buffer
* buffer access for nested data
    - index 0: values buffer (can hold other nested data)
    - index 1: validity buffer
    - index 2: offset buffer
* buffer access for array data
    - index 0: values buffer (can hold other nested data)
    - index 1: validity buffer