### PR TITLE
feat(rust, python): improve datetime parsing error message

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -200,7 +200,7 @@ on startup."#.trim_start())
     };
     (parse_fmt_idk = $dtype:expr) => {
         polars_err!(
-            ComputeError: "could not find an appropriate format to parse {}s, please define a fmt",
+            ComputeError: "could not find an appropriate format to parse {}s, please define a format",
             $dtype,
         )
     };

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1974,7 +1974,7 @@ def test_utc_deprecation() -> None:
 def test_strptime_unguessable_format() -> None:
     with pytest.raises(
         ComputeError,
-        match="could not find an appropriate format to parse dates, please define a fmt",
+        match="could not find an appropriate format to parse dates, please define a format",
     ):
         pl.Series(["foobar"]).str.strptime(pl.Datetime)
 


### PR DESCRIPTION
Demo

On `main`:
```python-traceback
In [1]: pl.Series(['2020-01-01', '2020-01-o2']).str.to_date()
---------------------------------------------------------------------------
ComputeError: strict date parsing failed for 1 value(s) (1 unique): ["2020-01-o2"]

You might want to try:
- setting `strict=False`
- explicitly specifying a `format`

In [2]: pl.Series(['2020-01-01', '2020-01-o2']).str.to_date(format='%Y-%m-%d')
---------------------------------------------------------------------------
ComputeError: strict date parsing failed for 1 value(s) (1 unique): ["2020-01-o2"]

You might want to try:
- setting `strict=False`
- explicitly specifying a `format`

In [3]: pl.Series(['00:00', '00:0l']).str.to_time(format='%H:%M')
---------------------------------------------------------------------------
ComputeError: strict time parsing failed for 1 value(s) (1 unique): ["00:0l"]

You might want to try:
- setting `strict=False`
- explicitly specifying a `format`
```

Here:
```python-traceback
In [1]: pl.Series(['2020-01-01', '2020-01-o2']).str.to_date()
---------------------------------------------------------------------------
ComputeError: strict date parsing failed for 1 value(s) (1 unique): ["2020-01-o2"]

You might want to try:
- setting `strict=False`
- setting `exact=False` (note: this is much slower!)
- explicitly specifying `format`

In [2]: pl.Series(['2020-01-01', '2020-01-o2']).str.to_date(format='%Y-%m-%d')
---------------------------------------------------------------------------
ComputeError: strict date parsing failed for 1 value(s) (1 unique): ["2020-01-o2"]

You might want to try:
- setting `strict=False`
- setting `exact=False` (note: this is much slower!)
- checking whether the format provided ('%Y-%m-%d') is correct

In [3]: pl.Series(['00:00', '00:0l']).str.to_time(format='%H:%M')
---------------------------------------------------------------------------
ComputeError: strict time parsing failed for 1 value(s) (1 unique): ["00:0l"]

You might want to try:
- setting `strict=False`
- checking whether the format provided ('%H:%M') is correct
```