### PR TITLE
feat(rust,python): Trim leading and trailing whitespaces while read_csv

### DIFF
--- a/crates/polars-io/src/csv/read.rs
+++ b/crates/polars-io/src/csv/read.rs
@@ -132,6 +132,7 @@ where
     skip_rows_after_header: usize,
     try_parse_dates: bool,
     row_count: Option<RowCount>,
+    trim_whitespaces: bool,
 }
 
 impl<'a, R> CsvReader<'a, R>
@@ -317,6 +318,11 @@ where
         self.predicate = predicate;
         self
     }
+
+    pub fn with_trim_whitespaces(mut self, trim: bool) -> Self {
+        self.trim_whitespaces = trim;
+        self
+    }
 }
 
 impl<'a> CsvReader<'a, File> {
@@ -366,6 +372,7 @@ impl<'a, R: MmapBytesReader + 'a> CsvReader<'a, R> {
             self.skip_rows_after_header,
             std::mem::take(&mut self.row_count),
             self.try_parse_dates,
+            self.trim_whitespaces,
         )
     }
 
@@ -547,6 +554,7 @@ where
             skip_rows_after_header: 0,
             try_parse_dates: false,
             row_count: None,
+            trim_whitespaces: false,
         }
     }
 

--- a/crates/polars-io/src/csv/read_impl/batched_mmap.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_mmap.rs
@@ -165,6 +165,7 @@ impl<'a> CoreReader<'a> {
             encoding: self.encoding,
             delimiter: self.delimiter,
             schema: self.schema,
+            trim_whitespaces: self.trim_whitespaces,
             rows_read: 0,
             _cat_lock,
         })
@@ -193,6 +194,7 @@ pub struct BatchedCsvReaderMmap<'a> {
     delimiter: u8,
     schema: SchemaRef,
     rows_read: IdxSize,
+    trim_whitespaces: bool,
     #[cfg(feature = "dtype-categorical")]
     _cat_lock: Option<polars_core::IUseStringCache>,
     #[cfg(not(feature = "dtype-categorical"))]
@@ -247,6 +249,7 @@ impl<'a> BatchedCsvReaderMmap<'a> {
                         self.chunk_size,
                         stop_at_nbytes,
                         self.starting_point_offset,
+                        self.trim_whitespaces,
                     )?;
 
                     cast_columns(&mut df, &self.to_cast, false)?;

--- a/crates/polars-io/src/csv/read_impl/batched_read.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_read.rs
@@ -248,6 +248,7 @@ impl<'a> CoreReader<'a> {
             encoding: self.encoding,
             delimiter: self.delimiter,
             schema: self.schema,
+            trim_whitespaces: self.trim_whitespaces,
             rows_read: 0,
             _cat_lock,
         })
@@ -276,6 +277,7 @@ pub struct BatchedCsvReaderRead<'a> {
     delimiter: u8,
     schema: SchemaRef,
     rows_read: IdxSize,
+    trim_whitespaces: bool,
     #[cfg(feature = "dtype-categorical")]
     _cat_lock: Option<polars_core::IUseStringCache>,
     #[cfg(not(feature = "dtype-categorical"))]
@@ -344,6 +346,7 @@ impl<'a> BatchedCsvReaderRead<'a> {
                         self.chunk_size,
                         stop_at_n_bytes,
                         self.starting_point_offset,
+                        self.trim_whitespaces,
                     )?;
 
                     cast_columns(&mut df, &self.to_cast, false)?;

--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -103,6 +103,7 @@ pub(crate) struct CoreReader<'a> {
     predicate: Option<Arc<dyn PhysicalIoExpr>>,
     to_cast: Vec<Field>,
     row_count: Option<RowCount>,
+    trim_whitespaces: bool,
 }
 
 impl<'a> fmt::Debug for CoreReader<'a> {
@@ -193,6 +194,7 @@ impl<'a> CoreReader<'a> {
         skip_rows_after_header: usize,
         row_count: Option<RowCount>,
         try_parse_dates: bool,
+        trim_whitespaces: bool,
     ) -> PolarsResult<CoreReader<'a>> {
         #[cfg(any(feature = "decompress", feature = "decompress-fast"))]
         let mut reader_bytes = reader_bytes;
@@ -289,6 +291,7 @@ impl<'a> CoreReader<'a> {
             predicate,
             to_cast,
             row_count,
+            trim_whitespaces,
         })
     }
 
@@ -603,6 +606,7 @@ impl<'a> CoreReader<'a> {
                                 chunk_size,
                                 self.schema.len(),
                                 &self.schema,
+                                self.trim_whitespaces,
                             )?;
 
                             let mut local_df = DataFrame::new_no_checks(
@@ -672,6 +676,7 @@ impl<'a> CoreReader<'a> {
                             usize::MAX,
                             stop_at_nbytes,
                             starting_point_offset,
+                            self.trim_whitespaces,
                         )?;
 
                         // update the running str bytes statistics
@@ -719,6 +724,7 @@ impl<'a> CoreReader<'a> {
                                 remaining_rows - 1,
                                 self.schema.len(),
                                 self.schema.as_ref(),
+                                self.trim_whitespaces,
                             )?;
 
                             DataFrame::new_no_checks(
@@ -800,6 +806,7 @@ fn read_chunk(
     chunk_size: usize,
     stop_at_nbytes: usize,
     starting_point_offset: Option<usize>,
+    trim_whitespaces: bool,
 ) -> PolarsResult<DataFrame> {
     let mut read = bytes_offset_thread;
     let mut buffers = init_buffers(
@@ -836,6 +843,7 @@ fn read_chunk(
             chunk_size,
             schema.len(),
             schema,
+            trim_whitespaces,
         )?;
     }
 

--- a/crates/polars-lazy/src/frame/csv.rs
+++ b/crates/polars-lazy/src/frame/csv.rs
@@ -32,6 +32,7 @@ pub struct LazyCsvReader<'a> {
     encoding: CsvEncoding,
     row_count: Option<RowCount>,
     try_parse_dates: bool,
+    trim_whitespaces: bool,
 }
 
 #[cfg(feature = "csv")]
@@ -59,6 +60,7 @@ impl<'a> LazyCsvReader<'a> {
             encoding: CsvEncoding::Utf8,
             row_count: None,
             try_parse_dates: false,
+            trim_whitespaces: false,
         }
     }
 
@@ -242,6 +244,11 @@ impl<'a> LazyCsvReader<'a> {
         }
 
         Ok(self.with_schema(Arc::new(schema)))
+    }
+
+    pub fn with_trim_whitespaces(mut self, trim: bool) -> Self {
+        self.trim_whitespaces = trim;
+        self
     }
 }
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -680,6 +680,7 @@ class DataFrame:
         row_count_offset: int = 0,
         sample_size: int = 1024,
         eol_char: str = "\n",
+        trim_whitespaces: bool = False,
     ) -> DataFrame:
         """
         Read a CSV file into a DataFrame.
@@ -789,6 +790,7 @@ class DataFrame:
             _prepare_row_count_args(row_count_name, row_count_offset),
             sample_size=sample_size,
             eol_char=eol_char,
+            trim_whitespaces=trim_whitespaces,
         )
         return self
 

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -54,6 +54,7 @@ def read_csv(
     row_count_offset: int = 0,
     sample_size: int = 1024,
     eol_char: str = "\n",
+    trim_whitespaces: bool = False,
 ) -> DataFrame:
     """
     Read a CSV file into a DataFrame.
@@ -170,6 +171,8 @@ def read_csv(
         allocation needed.
     eol_char
         Single byte end of line character.
+    trim_whitespaces
+        Trim leading and trailing whitespaces.
 
     Returns
     -------
@@ -376,6 +379,7 @@ def read_csv(
             row_count_offset=row_count_offset,
             sample_size=sample_size,
             eol_char=eol_char,
+            trim_whitespaces=trim_whitespaces,
         )
 
     if new_columns:
@@ -702,6 +706,7 @@ def scan_csv(
     try_parse_dates: bool = False,
     eol_char: str = "\n",
     new_columns: Sequence[str] | None = None,
+    trim_whitespaces: bool = False,
 ) -> LazyFrame:
     """
     Lazily read from a CSV file or multiple files via glob patterns.
@@ -783,6 +788,8 @@ def scan_csv(
         Provide an explicit list of string column names to use (for example, when
         scanning a headerless CSV file). Note that unlike ``read_csv`` it is considered
         an error to provide fewer column names than there are columns in the file.
+    trim_whitespaces
+        Trim leading and trailing whitespaces.
 
     Returns
     -------
@@ -895,4 +902,5 @@ def scan_csv(
         row_count_offset=row_count_offset,
         try_parse_dates=try_parse_dates,
         eol_char=eol_char,
+        trim_whitespaces=trim_whitespaces,
     )

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -331,6 +331,7 @@ class LazyFrame:
         row_count_offset: int = 0,
         try_parse_dates: bool = False,
         eol_char: str = "\n",
+        trim_whitespaces: bool = False,
     ) -> Self:
         """
         Lazily read from a CSV file or multiple files via glob patterns.
@@ -372,6 +373,7 @@ class LazyFrame:
             _prepare_row_count_args(row_count_name, row_count_offset),
             try_parse_dates,
             eol_char=eol_char,
+            trim_whitespaces=trim_whitespaces,
         )
         return self
 

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -139,7 +139,7 @@ impl PyDataFrame {
         skip_rows, projection, separator, rechunk, columns, encoding, n_threads, path,
         overwrite_dtype, overwrite_dtype_slice, low_memory, comment_char, quote_char,
         null_values, missing_utf8_is_empty_string, try_parse_dates, skip_rows_after_header,
-        row_count, sample_size, eol_char)
+        row_count, sample_size, eol_char, trim_whitespaces)
     )]
     pub fn read_csv(
         py_f: &PyAny,
@@ -168,6 +168,7 @@ impl PyDataFrame {
         row_count: Option<(String, IdxSize)>,
         sample_size: usize,
         eol_char: &str,
+        trim_whitespaces: bool,
     ) -> PyResult<Self> {
         let null_values = null_values.map(|w| w.0);
         let comment_char = comment_char.map(|s| s.as_bytes()[0]);
@@ -226,6 +227,7 @@ impl PyDataFrame {
             .with_end_of_line_char(eol_char)
             .with_skip_rows_after_header(skip_rows_after_header)
             .with_row_count(row_count)
+            .with_trim_whitespaces(trim_whitespaces)
             .sample_size(sample_size)
             .finish()
             .map_err(PyPolarsErr::from)?;

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -147,7 +147,7 @@ impl PyLazyFrame {
     #[pyo3(signature = (path, separator, has_header, ignore_errors, skip_rows, n_rows, cache, overwrite_dtype,
         low_memory, comment_char, quote_char, null_values, missing_utf8_is_empty_string,
         infer_schema_length, with_schema_modify, rechunk, skip_rows_after_header,
-        encoding, row_count, try_parse_dates, eol_char,
+        encoding, row_count, try_parse_dates, eol_char, trim_whitespaces,
     )
     )]
     fn new_from_csv(
@@ -172,6 +172,7 @@ impl PyLazyFrame {
         row_count: Option<(String, IdxSize)>,
         try_parse_dates: bool,
         eol_char: &str,
+        trim_whitespaces: bool,
     ) -> PyResult<Self> {
         let null_values = null_values.map(|w| w.0);
         let comment_char = comment_char.map(|s| s.as_bytes()[0]);
@@ -205,7 +206,8 @@ impl PyLazyFrame {
             .with_row_count(row_count)
             .with_try_parse_dates(try_parse_dates)
             .with_null_values(null_values)
-            .with_missing_is_null(!missing_utf8_is_empty_string);
+            .with_missing_is_null(!missing_utf8_is_empty_string)
+            .with_trim_whitespaces(trim_whitespaces);
 
         if let Some(lambda) = with_schema_modify {
             let f = |schema: Schema| {

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1377,3 +1377,16 @@ def test_csv_9929() -> None:
     f.seek(0)
     with pytest.raises(pl.NoDataError):
         pl.read_csv(f, skip_rows=10**6)
+
+
+def test_read_csv_trim_whitespaces() -> None:
+    csv = textwrap.dedent(
+        """\
+        a,b,c
+        a , b , c
+        """
+    )
+
+    f = io.StringIO(csv)
+    df = pl.read_csv(f, trim_whitespaces=True)
+    assert df.rows() == [("a", "b", "c")]


### PR DESCRIPTION
closes https://github.com/pola-rs/polars/pull/3365

It looks like this👆 PR was too long in the past, so I picked it up again :)

TODO
- [x] Python API
- [x] lazy scanner support