### PR TITLE
feat(rust, python): add `.struct.field()` expression expansion

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -85,7 +85,7 @@ pub(super) use self::range::RangeFunction;
 #[cfg(feature = "strings")]
 pub(crate) use self::strings::StringFunction;
 #[cfg(feature = "dtype-struct")]
-pub(super) use self::struct_::StructFunction;
+pub(crate) use self::struct_::StructFunction;
 #[cfg(feature = "trigonometry")]
 pub(super) use self::trigonometry::TrigonometricFunction;
 use super::*;

--- a/crates/polars-plan/src/dsl/function_expr/struct_.rs
+++ b/crates/polars-plan/src/dsl/function_expr/struct_.rs
@@ -13,8 +13,8 @@ impl Display for StructFunction {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use self::*;
         match self {
-            StructFunction::FieldByIndex(_) => write!(f, "struct.field_by_name"),
-            StructFunction::FieldByName(_) => write!(f, "struct.field_by_index"),
+            StructFunction::FieldByIndex(idx) => write!(f, "struct.field_by_index({idx})"),
+            StructFunction::FieldByName(name) => write!(f, "struct.field_by_name(\"{name}\")"),
         }
     }
 }

--- a/crates/polars-plan/src/logical_plan/projection.rs
+++ b/crates/polars-plan/src/logical_plan/projection.rs
@@ -225,7 +225,7 @@ fn replace_regex(
     }
     if regex.is_none() {
         #[cfg(feature = "dtype-struct")]
-        if !replace_struct_wildcard(&expr, result, schema) {
+        if !replace_struct_wildcard(expr, result, schema) {
             let expr = rewrite_special_aliases(expr.clone())?;
             result.push(expr);
         }

--- a/crates/polars-plan/src/logical_plan/projection.rs
+++ b/crates/polars-plan/src/logical_plan/projection.rs
@@ -134,16 +134,14 @@ fn replace_struct_wildcard(expr: &Expr, result: &mut Vec<Expr>, schema: &Schema)
         {
             if &**name == "*" {
                 let col = &input[0];
-                let col_name = expr_to_leaf_column_name(&col).unwrap();
+                let col_name = expr_to_leaf_column_name(col).unwrap();
                 // we don't yet know if we have a valid column name
-                if let Some(struct_schema) = schema.get(&col_name) {
-                    if let DataType::Struct(fields) = struct_schema {
-                        has_struct_wildcard = true;
-                        for fld in fields.iter() {
-                            let new_expr = rename_struct_field(expr.clone(), fld.name());
-                            let new_expr = rewrite_special_aliases(new_expr).unwrap();
-                            result.push(new_expr)
-                        }
+                if let Some(DataType::Struct(fields)) = schema.get(&col_name) {
+                    has_struct_wildcard = true;
+                    for fld in fields.iter() {
+                        let new_expr = rename_struct_field(expr.clone(), fld.name());
+                        let new_expr = rewrite_special_aliases(new_expr).unwrap();
+                        result.push(new_expr)
                     }
                 }
             }


### PR DESCRIPTION
Attempts to resolve #3859 

This probably needs to be done by someone with more knowledge but I was curious to figure out how this works.

It just handles the `"*"` case currently.

I added to `get_single_leaf()` to use the field name if a `.struct.field()` call is present which lets you use `.prefix`, `.suffix`, which is interesting but I'm not sure of any potential negative consequences of that (or if it is desired).

It doesn't seem to have broken any of the current tests.
```python
pl.Config(tbl_cols=13)

df = pl.LazyFrame({"A": ["one two 3", "4 five 6.0"]})

df.with_columns(
   a = pl.all().str.extract_groups(r"(\S+) (\S+) (\S+)"),
   b = pl.all().str.extract_groups(r"(?<group_1>\S+) (\S+) (?<last_group>\S+)")
).with_columns(
   pl.col("a").struct.field("*").prefix("a_"),
   pl.col("b").struct.field("*").suffix("_b"),
   pl.col("b").struct.field("*").map_alias(lambda name: f"{name=}")
).collect()

# shape: (2, 12)
# ┌────────────┬────────────────────┬────────────────────┬─────┬──────┬─────┬───────────┬──────┬──────────────┬────────────────┬──────────┬───────────────────┐
# │ A          ┆ a                  ┆ b                  ┆ a_1 ┆ a_2  ┆ a_3 ┆ group_1_b ┆ 2_b  ┆ last_group_b ┆ name='group_1' ┆ name='2' ┆ name='last_group' │
# │ ---        ┆ ---                ┆ ---                ┆ --- ┆ ---  ┆ --- ┆ ---       ┆ ---  ┆ ---          ┆ ---            ┆ ---      ┆ ---               │
# │ str        ┆ struct[3]          ┆ struct[3]          ┆ str ┆ str  ┆ str ┆ str       ┆ str  ┆ str          ┆ str            ┆ str      ┆ str               │
# ╞════════════╪════════════════════╪════════════════════╪═════╪══════╪═════╪═══════════╪══════╪══════════════╪════════════════╪══════════╪═══════════════════╡
# │ one two 3  ┆ {"one","two","3"}  ┆ {"one","two","3"}  ┆ one ┆ two  ┆ 3   ┆ one       ┆ two  ┆ 3            ┆ one            ┆ two      ┆ 3                 │
# │ 4 five 6.0 ┆ {"4","five","6.0"} ┆ {"4","five","6.0"} ┆ 4   ┆ five ┆ 6.0 ┆ 4         ┆ five ┆ 6.0          ┆ 4              ┆ five     ┆ 6.0               │
# └────────────┴────────────────────┴────────────────────┴─────┴──────┴─────┴───────────┴──────┴──────────────┴────────────────┴──────────┴───────────────────┘
```
```python
df = pl.DataFrame({"str": ["""{"foo": 1, "bar": 2, "baz": ["three"]}"""]})

(df.with_columns(pl.col("str").str.json_extract())
   .with_columns(pl.col("str").struct.field("*").prefix("json."))
)

# shape: (1, 4)
# ┌─────────────────┬──────────┬──────────┬───────────┐
# │ str             ┆ json.foo ┆ json.bar ┆ json.baz  │
# │ ---             ┆ ---      ┆ ---      ┆ ---       │
# │ struct[3]       ┆ i64      ┆ i64      ┆ list[str] │
# ╞═════════════════╪══════════╪══════════╪═══════════╡
# │ {1,2,["three"]} ┆ 1        ┆ 2        ┆ ["three"] │
# └─────────────────┴──────────┴──────────┴───────────┘
```
