### PR TITLE
feat(python): enhance `selectors` expansion function, so it can operate on a schema as well as a frame

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8813,10 +8813,10 @@ class DataFrame:
         iter_rows : Row iterator over frame data (does not materialise all rows).
 
         """
-        from polars.selectors import is_selector, selector_column_names
+        from polars.selectors import expand_selector, is_selector
 
         if is_selector(key):
-            key_tuple = selector_column_names(frame=self, selector=key)  # type: ignore[type-var]
+            key_tuple = expand_selector(target=self, selector=key)  # type: ignore[type-var]
         elif not isinstance(key, str):
             key_tuple = tuple(key)  # type: ignore[arg-type]
         else:

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -110,23 +110,6 @@ def selector_column_names(
     selector
         An arbitrary polars selector (or compound selector).
 
-    Examples
-    --------
-    >>> from polars.selectors import selector_column_names
-    >>> import polars.selectors as cs
-    >>> df = pl.DataFrame(
-    ...     {
-    ...         "colx": ["x", "y"],
-    ...         "coly": [123, 456],
-    ...         "colz": [2.0, 5.5],
-    ...     }
-    ... )
-    >>> selector_column_names(df, cs.numeric())
-    ('coly', 'colz')
-    >>> selector_column_names(df, cs.first() | cs.last())
-    ('colx', 'colz')
-    >>> selector_column_names(df, ~(cs.first() | cs.last()))
-    ('coly',)
     """
     return expand_selector(target=frame, selector=selector)
 

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -84,8 +84,6 @@ def expand_selector(
         from polars.dataframe import DataFrame
 
         target = DataFrame(schema=target)
-    else:
-        target = target.clear()
 
     return tuple(target.select(selector).columns)
 

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from datetime import timezone
-from typing import TYPE_CHECKING, Any, Collection, TypeVar
+from typing import TYPE_CHECKING, Any, Collection, Mapping, TypeVar
 
 from polars import functions as F
 from polars.datatypes import (
@@ -17,6 +17,7 @@ from polars.datatypes import (
     is_polars_dtype,
 )
 from polars.expr import Expr
+from polars.utils.deprecation import deprecate_function
 
 if TYPE_CHECKING:
     import sys
@@ -31,11 +32,110 @@ if TYPE_CHECKING:
         from typing_extensions import Self
 
 
+def is_selector(obj: Any) -> bool:
+    """
+    Indicate whether the given object/expression is a selector.
+
+    Examples
+    --------
+    >>> from polars.selectors import is_selector
+    >>> import polars.selectors as cs
+    >>> is_selector(pl.col("colx"))
+    False
+    >>> is_selector(cs.first() | cs.last())
+    True
+    """
+    # note: don't want to expose the "_selector_proxy_" object
+    return isinstance(obj, _selector_proxy_)
+
+
+def expand_selector(
+    target: DataFrame | LazyFrame | Mapping[str, PolarsDataType], selector: SelectorType
+) -> tuple[str, ...]:
+    """
+    Expand a selector to column names with respect to a specific frame or schema target.
+
+    Parameters
+    ----------
+    target
+        A polars DataFrame, LazyFrame or schema.
+    selector
+        An arbitrary polars selector (or compound selector).
+
+    Examples
+    --------
+    >>> from polars.selectors import expand_selector
+    >>> import polars.selectors as cs
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "colx": ["x", "y"],
+    ...         "coly": [123, 456],
+    ...         "colz": [2.0, 5.5],
+    ...     }
+    ... )
+    >>> expand_selector(df, cs.numeric())
+    ('coly', 'colz')
+    >>> expand_selector(df, cs.first() | cs.last())
+    ('colx', 'colz')
+    >>> expand_selector(df, ~(cs.first() | cs.last()))
+    ('coly',)
+    """
+    if isinstance(target, Mapping):
+        from polars.dataframe import DataFrame
+
+        target = DataFrame(schema=target)
+    else:
+        target = target.clear()
+
+    return tuple(target.select(selector).columns)
+
+
+@deprecate_function(
+    message="This function has been superseded by `expand_selector`; please update accordingly",
+    version="0.18.13",
+)
+def selector_column_names(
+    frame: DataFrame | LazyFrame, selector: SelectorType
+) -> tuple[str, ...]:
+    """
+    Return the column names that would be selected from the given frame.
+
+    .. deprecated:: 0.18.13
+       Use :func:`expand_selector` instead.
+
+    Parameters
+    ----------
+    frame
+        A polars DataFrame or LazyFrame.
+    selector
+        An arbitrary polars selector (or compound selector).
+
+    Examples
+    --------
+    >>> from polars.selectors import selector_column_names
+    >>> import polars.selectors as cs
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "colx": ["x", "y"],
+    ...         "coly": [123, 456],
+    ...         "colz": [2.0, 5.5],
+    ...     }
+    ... )
+    >>> selector_column_names(df, cs.numeric())
+    ('coly', 'colz')
+    >>> selector_column_names(df, cs.first() | cs.last())
+    ('colx', 'colz')
+    >>> selector_column_names(df, ~(cs.first() | cs.last()))
+    ('coly',)
+    """
+    return expand_selector(target=frame, selector=selector)
+
+
 def _expand_selectors(
     frame: DataFrame | LazyFrame, items: Any, *more_items: Any
 ) -> list[Any]:
     """
-    Expand any selectors to column names in the given input.
+    Internal function that expands any selectors to column names in the given input.
 
     Non-selector values are left as-is.
 
@@ -67,62 +167,11 @@ def _expand_selectors(
         *more_items,
     ):
         if is_selector(item):
-            selector_cols = selector_column_names(frame, item)
+            selector_cols = expand_selector(frame, item)
             expanded.extend(selector_cols)
         else:
             expanded.append(item)
     return expanded
-
-
-def is_selector(obj: Any) -> bool:
-    """
-    Indicate whether the given object/expression is a selector.
-
-    Examples
-    --------
-    >>> from polars.selectors import is_selector
-    >>> import polars.selectors as cs
-    >>> is_selector(pl.col("colx"))
-    False
-    >>> is_selector(cs.first() | cs.last())
-    True
-    """
-    # note: don't want to expose the "_selector_proxy_" object
-    return isinstance(obj, _selector_proxy_)
-
-
-def selector_column_names(
-    frame: DataFrame | LazyFrame, selector: SelectorType
-) -> tuple[str, ...]:
-    """
-    Return the column names that would be selected from the given frame.
-
-    Parameters
-    ----------
-    frame
-        A polars DataFrame or LazyFrame.
-    selector
-        An arbitrary polars selector (or compound selector).
-
-    Examples
-    --------
-    >>> from polars.selectors import selector_column_names
-    >>> import polars.selectors as cs
-    >>> df = pl.DataFrame(
-    ...     {
-    ...         "colx": ["x", "y"],
-    ...         "coly": [123, 456],
-    ...         "colz": [2.0, 5.5],
-    ...     }
-    ... )
-    >>> selector_column_names(df, cs.numeric())
-    ('coly', 'colz')
-    >>> selector_column_names(df, cs.first() | cs.last())
-    ('colx', 'colz')
-    >>> selector_column_names(df, ~(cs.first() | cs.last()))
-    ('coly',)
-    """
-    return tuple(frame.clear().select(selector).columns)
 
 
 class _selector_proxy_(Expr):
@@ -1408,6 +1457,6 @@ __all__ = [
     "temporal",
     "string",
     "is_selector",
-    "selector_column_names",
+    "expand_selector",
     "SelectorType",
 ]

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -2,7 +2,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
-from polars.selectors import selector_column_names
+from polars.selectors import expand_selector
 from polars.testing import assert_frame_equal
 
 
@@ -174,7 +174,7 @@ def test_selector_drop(df: pl.DataFrame) -> None:
 def test_selector_duration(df: pl.DataFrame) -> None:
     assert df.select(cs.duration("ms")).columns == []
     assert df.select(cs.duration(["ms", "ns"])).columns == []
-    assert selector_column_names(df, cs.duration()) == ("Lmn",)
+    assert expand_selector(df, cs.duration()) == ("Lmn",)
 
     df = pl.DataFrame(
         schema={
@@ -183,9 +183,9 @@ def test_selector_duration(df: pl.DataFrame) -> None:
             "d3": pl.Duration("ms"),
         },
     )
-    assert selector_column_names(df, cs.duration()) == ("d1", "d2", "d3")
-    assert selector_column_names(df, cs.duration("us")) == ("d2",)
-    assert selector_column_names(df, cs.duration(["ms", "ns"])) == ("d1", "d3")
+    assert expand_selector(df, cs.duration()) == ("d1", "d2", "d3")
+    assert expand_selector(df, cs.duration("us")) == ("d2",)
+    assert expand_selector(df, cs.duration(["ms", "ns"])) == ("d1", "d3")
 
 
 def test_selector_ends_with(df: pl.DataFrame) -> None:


### PR DESCRIPTION
Ref: https://github.com/pola-rs/polars/pull/10255#issuecomment-1667790606

* **New**: allows selector expansion function to take a bare schema dictionary.
* Deprecates the old name `selector_column_names` for the clearer `expand_selector`.

## Example

```python
import polars.selectors as cs
import polars as pl

df = pl.DataFrame({
    "foo": ["a", "a", "b", "b", "b"],
    "baz": [100, 200, 300, 400, 500],
    "bar": ["x", "x", "x", "y", "z"],
})
```
From frame -
```python
cs.expand_selector( df, cs.string() )
# ('foo', 'bar') 
```
From schema dict _(new)_ -
```python
schema = { "colx":pl.Utf8, "coly":pl.Int8, "colz":pl.Float64 }
cs.expand_selector( schema, cs.numeric() )
# ('coly', 'colz')
```