### PR TITLE
feat(python): Add `categorical_as_str` parameter to testing utils

### DIFF
--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -12,6 +12,7 @@ from polars.datatypes import (
     DataTypeClass,
     List,
     Struct,
+    Utf8,
     dtype_to_py_type,
     unpack_dtypes,
 )
@@ -24,13 +25,14 @@ def assert_frame_equal(
     left: DataFrame | LazyFrame,
     right: DataFrame | LazyFrame,
     *,
+    check_row_order: bool = True,
+    check_column_order: bool = True,
     check_dtype: bool = True,
     check_exact: bool = False,
     rtol: float = 1.0e-5,
     atol: float = 1.0e-8,
     nans_compare_equal: bool = True,
-    check_column_order: bool = True,
-    check_row_order: bool = True,
+    categorical_as_str: bool = False,
 ) -> None:
     """
     Raise detailed AssertionError if `left` does NOT equal `right`.
@@ -41,6 +43,13 @@ def assert_frame_equal(
         the dataframe to compare.
     right
         the dataframe to compare with.
+    check_row_order
+        if False, frames will compare equal if the required rows are present,
+        irrespective of the order in which they appear; as this requires
+        sorting, you cannot set on frames that contain unsortable columns.
+    check_column_order
+        if False, frames will compare equal if the required columns are present,
+        irrespective of the order in which they appear.
     check_dtype
         if True, data types need to match exactly.
     check_exact
@@ -52,13 +61,9 @@ def assert_frame_equal(
         absolute tolerance for inexact checking.
     nans_compare_equal
         if your assert/test requires float NaN != NaN, set this to False.
-    check_column_order
-        if False, frames will compare equal if the required columns are present,
-        irrespective of the order in which they appear.
-    check_row_order
-        if False, frames will compare equal if the required rows are present,
-        irrespective of the order in which they appear; as this requires
-        sorting, you cannot set on frames that contain unsortable columns.
+    categorical_as_str
+        Cast categorical columns to string before comparing. Enabling this helps
+        compare dataframes that do not share the same string cache.
 
     Examples
     --------
@@ -110,11 +115,12 @@ def assert_frame_equal(
             _assert_series_inner(
                 left[c],  # type: ignore[arg-type, index]
                 right[c],  # type: ignore[arg-type, index]
-                check_dtype,
-                check_exact,
-                nans_compare_equal,
-                atol,
-                rtol,
+                check_dtype=check_dtype,
+                check_exact=check_exact,
+                atol=atol,
+                rtol=rtol,
+                nans_compare_equal=nans_compare_equal,
+                categorical_as_str=categorical_as_str,
             )
         except AssertionError as exc:
             msg = f"Values for column {c!r} are different."
@@ -125,13 +131,14 @@ def assert_frame_not_equal(
     left: DataFrame | LazyFrame,
     right: DataFrame | LazyFrame,
     *,
+    check_row_order: bool = True,
+    check_column_order: bool = True,
     check_dtype: bool = True,
     check_exact: bool = False,
     rtol: float = 1.0e-5,
     atol: float = 1.0e-8,
     nans_compare_equal: bool = True,
-    check_column_order: bool = True,
-    check_row_order: bool = True,
+    categorical_as_str: bool = False,
 ) -> None:
     """
     Raise AssertionError if `left` DOES equal `right`.
@@ -142,6 +149,13 @@ def assert_frame_not_equal(
         the dataframe to compare.
     right
         the dataframe to compare with.
+    check_row_order
+        if False, frames will compare equal if the required rows are present,
+        irrespective of the order in which they appear; as this requires
+        sorting, you cannot set on frames that contain unsortable columns.
+    check_column_order
+        if False, frames will compare equal if the required columns are present,
+        irrespective of the order in which they appear.
     check_dtype
         if True, data types need to match exactly.
     check_exact
@@ -153,13 +167,9 @@ def assert_frame_not_equal(
         absolute tolerance for inexact checking.
     nans_compare_equal
         if your assert/test requires float NaN != NaN, set this to False.
-    check_column_order
-        if False, frames will compare equal if the required columns are present,
-        irrespective of the order in which they appear.
-    check_row_order
-        if False, frames will compare equal if the required rows are present,
-        irrespective of the order in which they appear; as this requires
-        sorting, you cannot set on frames that contain unsortable columns.
+    categorical_as_str
+        Cast categorical columns to string before comparing. Enabling this helps
+        compare dataframes that do not share the same string cache.
 
     Examples
     --------
@@ -173,13 +183,14 @@ def assert_frame_not_equal(
         assert_frame_equal(
             left=left,
             right=right,
+            check_column_order=check_column_order,
+            check_row_order=check_row_order,
             check_dtype=check_dtype,
             check_exact=check_exact,
             rtol=rtol,
             atol=atol,
             nans_compare_equal=nans_compare_equal,
-            check_column_order=check_column_order,
-            check_row_order=check_row_order,
+            categorical_as_str=categorical_as_str,
         )
     except AssertionError:
         return
@@ -197,6 +208,7 @@ def assert_series_equal(
     rtol: float = 1.0e-5,
     atol: float = 1.0e-8,
     nans_compare_equal: bool = True,
+    categorical_as_str: bool = False,
 ) -> None:
     """
     Raise detailed AssertionError if `left` does NOT equal `right`.
@@ -220,6 +232,9 @@ def assert_series_equal(
         absolute tolerance for inexact checking.
     nans_compare_equal
         if your assert/test requires float NaN != NaN, set this to False.
+    categorical_as_str
+        Cast categorical columns to string before comparing. Enabling this helps
+        compare dataframes that do not share the same string cache.
 
     Examples
     --------
@@ -242,7 +257,14 @@ def assert_series_equal(
         raise_assert_detail("Series", "Name mismatch", left.name, right.name)
 
     _assert_series_inner(
-        left, right, check_dtype, check_exact, nans_compare_equal, atol, rtol
+        left,
+        right,
+        check_dtype=check_dtype,
+        check_exact=check_exact,
+        atol=atol,
+        rtol=rtol,
+        nans_compare_equal=nans_compare_equal,
+        categorical_as_str=categorical_as_str,
     )
 
 
@@ -256,6 +278,7 @@ def assert_series_not_equal(
     rtol: float = 1.0e-5,
     atol: float = 1.0e-8,
     nans_compare_equal: bool = True,
+    categorical_as_str: bool = False,
 ) -> None:
     """
     Raise AssertionError if `left` DOES equal `right`.
@@ -279,6 +302,9 @@ def assert_series_not_equal(
         absolute tolerance for inexact checking.
     nans_compare_equal
         if your assert/test requires float NaN != NaN, set this to False.
+    categorical_as_str
+        Cast categorical columns to string before comparing. Enabling this helps
+        compare dataframes that do not share the same string cache.
 
     Examples
     --------
@@ -298,6 +324,7 @@ def assert_series_not_equal(
             rtol=rtol,
             atol=atol,
             nans_compare_equal=nans_compare_equal,
+            categorical_as_str=categorical_as_str,
         )
     except AssertionError:
         return
@@ -308,11 +335,13 @@ def assert_series_not_equal(
 def _assert_series_inner(
     left: Series,
     right: Series,
+    *,
     check_dtype: bool,
     check_exact: bool,
-    nans_compare_equal: bool,
     atol: float,
     rtol: float,
+    nans_compare_equal: bool,
+    categorical_as_str: bool,
 ) -> None:
     """Compare Series dtype + values."""
     if check_dtype and left.dtype != right.dtype:
@@ -322,6 +351,10 @@ def _assert_series_inner(
         raise_assert_detail(
             "Series", "null_count is not equal", left.null_count(), right.null_count()
         )
+
+    if categorical_as_str and left.dtype == Categorical:
+        left = left.cast(Utf8)
+        right = right.cast(Utf8)
 
     # create mask of which (if any) values are unequal
     unequal = left.ne_missing(right)
@@ -342,9 +375,10 @@ def _assert_series_inner(
             right=right.filter(unequal),
             check_dtype=check_dtype,
             check_exact=check_exact,
-            nans_compare_equal=nans_compare_equal,
             atol=atol,
             rtol=rtol,
+            nans_compare_equal=nans_compare_equal,
+            categorical_as_str=categorical_as_str,
         ):
             return
 
@@ -407,9 +441,10 @@ def _assert_series_nested(
     right: Series,
     check_dtype: bool,
     check_exact: bool,
-    nans_compare_equal: bool,
     atol: float,
     rtol: float,
+    nans_compare_equal: bool,
+    categorical_as_str: bool,
 ) -> bool:
     # check that float values exist at _some_ level of nesting
     if not any(tp in FLOAT_DTYPES for tp in unpack_dtypes(left.dtype, right.dtype)):
@@ -440,9 +475,10 @@ def _assert_series_nested(
                 s2,
                 check_dtype=check_dtype,
                 check_exact=check_exact,
-                nans_compare_equal=nans_compare_equal,
                 atol=atol,
                 rtol=rtol,
+                nans_compare_equal=nans_compare_equal,
+                categorical_as_str=categorical_as_str,
             )
         return True
 
@@ -466,9 +502,10 @@ def _assert_series_nested(
                 s2,
                 check_dtype=check_dtype,
                 check_exact=check_exact,
-                nans_compare_equal=nans_compare_equal,
                 atol=atol,
                 rtol=rtol,
+                nans_compare_equal=nans_compare_equal,
+                categorical_as_str=categorical_as_str,
             )
         return True
     else:

--- a/py-polars/polars/testing/asserts.py
+++ b/py-polars/polars/testing/asserts.py
@@ -19,6 +19,7 @@ from polars.datatypes import (
 from polars.exceptions import ComputeError, InvalidAssert
 from polars.lazyframe import LazyFrame
 from polars.series import Series
+from polars.utils.deprecation import deprecate_function
 
 
 def assert_frame_equal(
@@ -546,6 +547,10 @@ def is_categorical_dtype(data_type: Any) -> bool:
     )
 
 
+@deprecate_function(
+    "Use `assert_frame_equal` instead and pass `categorical_as_str=True`.",
+    version="0.18.13",
+)
 def assert_frame_equal_local_categoricals(df_a: DataFrame, df_b: DataFrame) -> None:
     """Assert frame equal for frames containing categoricals."""
     for (a_name, a_value), (b_name, b_value) in zip(

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -13,11 +13,7 @@ import pytest
 
 import polars as pl
 from polars.exceptions import ComputeError, NoDataError
-from polars.testing import (
-    assert_frame_equal,
-    assert_frame_equal_local_categoricals,
-    assert_series_equal,
-)
+from polars.testing import assert_frame_equal, assert_series_equal
 from polars.utils.various import normalise_filepath
 
 if TYPE_CHECKING:
@@ -54,9 +50,9 @@ def test_to_from_buffer(df_no_lists: pl.DataFrame) -> None:
     read_df = read_df.with_columns(
         [pl.col("cat").cast(pl.Categorical), pl.col("time").cast(pl.Time)]
     )
-    assert_frame_equal_local_categoricals(df, read_df)
+    assert_frame_equal(df, read_df, categorical_as_str=True)
     with pytest.raises(AssertionError):
-        assert_frame_equal_local_categoricals(df.select(["time", "cat"]), read_df)
+        assert_frame_equal(df.select("time", "cat"), read_df, categorical_as_str=True)
 
 
 @pytest.mark.write_disk()
@@ -72,7 +68,7 @@ def test_to_from_file(df_no_lists: pl.DataFrame, tmp_path: Path) -> None:
     read_df = read_df.with_columns(
         [pl.col("cat").cast(pl.Categorical), pl.col("time").cast(pl.Time)]
     )
-    assert_frame_equal_local_categoricals(df, read_df)
+    assert_frame_equal(df, read_df, categorical_as_str=True)
 
 
 def test_normalise_filepath(io_files_path: Path) -> None:

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_frame_equal_local_categoricals
+from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -18,7 +18,7 @@ def test_to_from_buffer(df: pl.DataFrame, buf: io.IOBase) -> None:
     df.write_json(buf)
     buf.seek(0)
     read_df = pl.read_json(buf)
-    assert_frame_equal_local_categoricals(df, read_df)
+    assert_frame_equal(df, read_df, categorical_as_str=True)
 
 
 @pytest.mark.write_disk()
@@ -29,7 +29,7 @@ def test_to_from_file(df: pl.DataFrame, tmp_path: Path) -> None:
     df.write_json(file_path)
     out = pl.read_json(file_path)
 
-    assert_frame_equal_local_categoricals(df, out)
+    assert_frame_equal(df, out, categorical_as_str=True)
 
 
 def test_write_json_to_string() -> None:

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -12,11 +12,7 @@ import pyarrow.dataset as ds
 import pytest
 
 import polars as pl
-from polars.testing import (
-    assert_frame_equal,
-    assert_frame_equal_local_categoricals,
-    assert_series_equal,
-)
+from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
     from polars.type_aliases import ParquetCompression
@@ -84,7 +80,7 @@ def test_to_from_buffer(
     df.write_parquet(buf, compression=compression, use_pyarrow=use_pyarrow)
     buf.seek(0)
     read_df = pl.read_parquet(buf, use_pyarrow=use_pyarrow)
-    assert_frame_equal_local_categoricals(df, read_df)
+    assert_frame_equal(df, read_df, categorical_as_str=True)
 
 
 def test_to_from_buffer_lzo(df: pl.DataFrame) -> None:
@@ -117,7 +113,7 @@ def test_to_from_file(
     file_path = tmp_path / "small.avro"
     df.write_parquet(file_path, compression=compression)
     read_df = pl.read_parquet(file_path)
-    assert_frame_equal_local_categoricals(df, read_df)
+    assert_frame_equal(df, read_df, categorical_as_str=True)
 
 
 @pytest.mark.write_disk()

--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -998,3 +998,20 @@ def test_assert_series_equal_raises_assertion_error(
     with pytest.raises(AssertionError):
         assert_series_equal(s1, s2, **kwargs)
     assert_series_not_equal(s1, s2, **kwargs)
+
+
+def test_assert_series_equal_categorical() -> None:
+    s1 = pl.Series(["a", "b", "a"], dtype=pl.Categorical)
+    s2 = pl.Series(["a", "b", "a"], dtype=pl.Categorical)
+    with pytest.raises(pl.ComputeError, match="cannot compare categoricals"):
+        assert_series_equal(s1, s2)
+
+    assert_series_equal(s1, s2, categorical_as_str=True)
+
+
+def test_assert_series_equal_categorical_vs_str() -> None:
+    s1 = pl.Series(["a", "b", "a"], dtype=pl.Categorical)
+    s2 = pl.Series(["a", "b", "a"], dtype=pl.Utf8)
+
+    with pytest.raises(AssertionError, match="Dtype mismatch"):
+        assert_series_equal(s1, s2, categorical_as_str=True)

--- a/py-polars/tests/unit/test_testing.py
+++ b/py-polars/tests/unit/test_testing.py
@@ -10,6 +10,7 @@ import polars as pl
 from polars.exceptions import InvalidAssert
 from polars.testing import (
     assert_frame_equal,
+    assert_frame_equal_local_categoricals,
     assert_frame_not_equal,
     assert_series_equal,
     assert_series_not_equal,
@@ -1015,3 +1016,10 @@ def test_assert_series_equal_categorical_vs_str() -> None:
 
     with pytest.raises(AssertionError, match="Dtype mismatch"):
         assert_series_equal(s1, s2, categorical_as_str=True)
+
+
+def test_assert_frame_equal_local_categoricals_deprecated() -> None:
+    df = pl.Series(["a", "b", "a"], dtype=pl.Categorical).to_frame()
+
+    with pytest.deprecated_call():
+        assert_frame_equal_local_categoricals(df, df)


### PR DESCRIPTION
Changes:
* Add the `categorical_as_str` parameter to the existing testing utils (`assert_frame_equal`, `assert_series_equal`, etc.). This will cast categorical columns to their string representation before comparing their contents. This is useful when it's not possible to construct both frames under the same string cache, or just for convenience sake.
* Deprecate the `assert_frame_equal_local_categoricals` function in favor of `assert_frame_equal(categorical_as_str=True)`.