### PR TITLE
refactor(python): Small improvement for PySeries.get_buffer

### DIFF
--- a/py-polars/src/series/buffers.rs
+++ b/py-polars/src/series/buffers.rs
@@ -69,7 +69,8 @@ impl PySeries {
                         ))
                     }
                     1 => Ok(get_bitmap(&self.series)),
-                    _ => raise_err!("expected an index <= 1", ComputeError),
+                    2 => Ok(None),
+                    _ => raise_err!("expected an index <= 2", ComputeError),
                 }
             }
             _ => todo!(),
@@ -158,7 +159,8 @@ fn get_buffer_from_primitive(s: &Series, index: usize) -> PyResult<Option<PySeri
             ))
         }
         1 => Ok(get_bitmap(s)),
-        _ => raise_err!("expected an index <= 1", ComputeError),
+        2 => Ok(None),
+        _ => raise_err!("expected an index <= 2", ComputeError),
     }
 }
 

--- a/py-polars/src/series/buffers.rs
+++ b/py-polars/src/series/buffers.rs
@@ -70,7 +70,7 @@ impl PySeries {
                     }
                     1 => Ok(get_bitmap(&self.series)),
                     2 => Ok(None),
-                    _ => raise_err!("expected an index <= 2", ComputeError),
+                    _ => Err(PyValueError::new_err("expected an index <= 2")),
                 }
             }
             _ => todo!(),
@@ -120,7 +120,7 @@ fn get_buffer_from_nested(s: &Series, index: usize) -> PyResult<Option<PySeries>
         }
         1 => Ok(get_bitmap(s)),
         2 => get_offsets(s).map(Some),
-        _ => raise_err!("expected an index <= 2", ComputeError),
+        _ => Err(PyValueError::new_err("expected an index <= 2")),
     }
 }
 
@@ -160,7 +160,7 @@ fn get_buffer_from_primitive(s: &Series, index: usize) -> PyResult<Option<PySeri
         }
         1 => Ok(get_bitmap(s)),
         2 => Ok(None),
-        _ => raise_err!("expected an index <= 2", ComputeError),
+        _ => Err(PyValueError::new_err("expected an index <= 2")),
     }
 }
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -27,6 +27,7 @@ from polars.datatypes import (
 from polars.exceptions import PolarsInefficientApplyWarning, ShapeError
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.utils._construction import iterable_to_pyseries
+from polars.utils._wrap import wrap_s
 
 if TYPE_CHECKING:
     from polars.type_aliases import EpochTimeUnit, PolarsDataType, TimeUnit
@@ -2454,6 +2455,38 @@ def test_ptr() -> None:
         polars.datatypes.INTEGER_DTYPES
     ):
         assert pl.Series([1, 2, 3], dtype=dtype)._s.get_ptr() > 0
+
+
+def test_get_buffer() -> None:
+    s = pl.Series(["a", "bc", None, "éâç", ""])
+
+    data = s._s.get_buffer(0)
+    expected = pl.Series([97, 98, 99, 195, 169, 195, 162, 195, 167], dtype=pl.UInt8)
+    assert_series_equal(wrap_s(data), expected)
+
+    validity = s._s.get_buffer(1)
+    expected = pl.Series([True, True, False, True, True])
+    assert_series_equal(wrap_s(validity), expected)
+
+    offsets = s._s.get_buffer(2)
+    expected = pl.Series([0, 1, 3, 3, 9, 9], dtype=pl.Int64)
+    assert_series_equal(wrap_s(offsets), expected)
+
+
+def test_get_buffer_no_validity_or_offsets() -> None:
+    s = pl.Series([1, 2, 3])
+
+    validity = s._s.get_buffer(1)
+    assert validity is None
+
+    offsets = s._s.get_buffer(2)
+    assert offsets is None
+
+
+def test_get_buffer_invalid_index() -> None:
+    s = pl.Series([1, None, 3])
+    with pytest.raises(ValueError):
+        s._s.get_buffer(3)
 
 
 def test_null_comparisons() -> None:


### PR DESCRIPTION
Changes:
* `get_buffer(2)` always returns None if the offsets does not exist, rather than raise an error.
* Invalid indices now raise a ValueError rather than a ComputeError.