### PR TITLE
feat(rust, python): cse for groupby.agg and reduced cse collisions

### DIFF
--- a/crates/polars-lazy/src/physical_plan/executors/groupby.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/groupby.rs
@@ -11,10 +11,8 @@ pub(super) fn evaluate_aggs(
     POOL.install(|| {
         aggs.par_iter()
             .map(|expr| {
-                let mut agg = expr.evaluate_on_groups(df, groups, state)?.finalize();
+                let agg = expr.evaluate_on_groups(df, groups, state)?.finalize();
                 polars_ensure!(agg.len() == groups.len(), agg_len = agg.len(), groups.len());
-
-                rename_cse_tmp_series(&mut agg);
                 Ok(agg)
             })
             .collect::<PolarsResult<Vec<_>>>()

--- a/crates/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
@@ -346,12 +346,7 @@ impl PartitionGroupByExec {
                 .zip(&df.get_columns()[self.phys_keys.len()..])
                 .map(|(expr, partitioned_s)| {
                     let agg_expr = expr.as_partitioned_aggregator().unwrap();
-                    agg_expr
-                        .finalize(partitioned_s.clone(), groups, state)
-                        .map(|mut s| {
-                            rename_cse_tmp_series(&mut s);
-                            s
-                        })
+                    agg_expr.finalize(partitioned_s.clone(), groups, state)
                 })
                 .collect();
 

--- a/crates/polars-lazy/src/physical_plan/executors/projection_utils.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/projection_utils.rs
@@ -163,16 +163,10 @@ pub(super) fn evaluate_physical_expressions(
         unsafe {
             df.hstack_mut_unchecked(&tmp_cols);
         }
-        let mut result = expr_runner(df, exprs, state)?;
+        let result = expr_runner(df, exprs, state)?;
         // restore original df
         unsafe {
             df.get_columns_mut().truncate(width);
-        }
-
-        // the replace CSE has a temporary name
-        // we don't want this name in the result
-        for s in result.iter_mut() {
-            rename_cse_tmp_series(s);
         }
 
         result

--- a/crates/polars-pipe/src/executors/operators/projection.rs
+++ b/crates/polars-pipe/src/executors/operators/projection.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use polars_core::error::PolarsResult;
 use polars_core::frame::DataFrame;
 use polars_core::schema::SchemaRef;
-use polars_plan::utils::rename_cse_tmp_series;
 
 use crate::expressions::PhysicalPipedExpr;
 use crate::operators::{DataChunk, Operator, OperatorResult, PExecutionContext};
@@ -77,11 +76,6 @@ impl Operator for ProjectionOperator {
                 #[allow(unused_mut)]
                 let mut s = e.evaluate(chunk, context.execution_state.as_any())?;
 
-                // correct the cse name
-                if self.cse_exprs.is_some() {
-                    rename_cse_tmp_series(&mut s);
-                }
-
                 has_literals |= s.len() == 1;
                 has_empty |= s.len() == 0;
 
@@ -151,18 +145,7 @@ impl Operator for HstackOperator {
         let projected = self
             .exprs
             .iter()
-            .map(|e| {
-                #[allow(unused_mut)]
-                let mut res = e.evaluate(chunk, context.execution_state.as_any());
-
-                if self.cse_exprs.is_some() {
-                    res = res.map(|mut s| {
-                        rename_cse_tmp_series(&mut s);
-                        s
-                    })
-                }
-                res
-            })
+            .map(|e| e.evaluate(chunk, context.execution_state.as_any()))
             .collect::<PolarsResult<Vec<_>>>()?;
 
         let mut df = DataFrame::new_no_checks(chunk.data.get_columns()[..width].to_vec());

--- a/crates/polars-plan/src/logical_plan/visitor/expr.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/expr.rs
@@ -1,3 +1,4 @@
+use polars_core::prelude::{Field, Schema};
 use super::*;
 use crate::prelude::*;
 
@@ -103,6 +104,13 @@ impl AexprNode {
 
     pub fn to_expr(&self) -> Expr {
         self.with_arena(|arena| node_to_expr(self.node, arena))
+    }
+
+    pub fn to_field(&self, schema: &Schema) -> PolarsResult<Field> {
+        self.with_arena(|arena| {
+            let ae = arena.get(self.node);
+            ae.to_field(schema, Context::Default, arena)
+        })
     }
 
     // traverses all nodes and does a full equality check

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -422,10 +422,12 @@ pub fn rename_cse_tmp_series(s: &mut Series) {
     if s.name().starts_with(CSE_REPLACED) {
         let field = s.field().into_owned();
         let name = &field.name;
-        let pat = r#"col("#;
-        let offset = name.rfind(pat).unwrap() + pat.len();
-        // -1 is `)` of `col(foo)`
-        let name = &name[offset..name.len() - 1];
+        let pat = "_POLARS_START";
+        let offset = name.find(pat).unwrap() + pat.len();
+        let pat = "_POLARS_END";
+        let offset2 = name.find(pat).unwrap();
+        let name = &name[offset..offset2];
+        dbg!(name);
         s.rename(name);
     }
 }

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -6,7 +6,6 @@ use std::vec::IntoIter;
 use polars_core::prelude::*;
 use smartstring::alias::String as SmartString;
 
-use crate::constants::CSE_REPLACED;
 use crate::logical_plan::iterator::ArenaExprIter;
 use crate::logical_plan::Context;
 use crate::prelude::names::COUNT;
@@ -416,18 +415,4 @@ pub fn expr_is_projected_upstream(
         .unwrap();
     let output_name = output_field.name();
     projected_names.contains(output_name.as_str())
-}
-
-pub fn rename_cse_tmp_series(s: &mut Series) {
-    if s.name().starts_with(CSE_REPLACED) {
-        let field = s.field().into_owned();
-        let name = &field.name;
-        let pat = "_POLARS_START";
-        let offset = name.find(pat).unwrap() + pat.len();
-        let pat = "_POLARS_END";
-        let offset2 = name.find(pat).unwrap();
-        let name = &name[offset..offset2];
-        dbg!(name);
-        s.rename(name);
-    }
 }


### PR DESCRIPTION
This activates `cse` for groupbys again.

It also improves the Identifier such that we have less collisions between non-equal expressions. This is an intermediate solution, I will follow up with a identifier based on a hash, so that we don't have to allocate.

Another improvement is that we drop the hacky solution for determining the output name of an expression that refers to a `tmp` cse. Those expressions now get a proper `alias` (if they have none), determined by the schema.