### PR TITLE
refactor(rust): implement ChunkArray::(try_)from_chunk_iter

### DIFF
--- a/crates/polars-arrow/src/array/utf8.rs
+++ b/crates/polars-arrow/src/array/utf8.rs
@@ -55,13 +55,13 @@ impl<T: AsRef<str>> AsRef<[u8]> for StrAsBytes<T> {
 
 pub trait Utf8FromIter {
     #[inline]
-    fn from_values_iter<I, S>(iter: I, len: usize, value_cap: usize) -> Utf8Array<i64>
+    fn from_values_iter<I, S>(iter: I, len: usize, size_hint: usize) -> Utf8Array<i64>
     where
         S: AsRef<str>,
         I: Iterator<Item = S>,
     {
         let iter = iter.map(StrAsBytes);
-        let (offsets, values) = unsafe { fill_offsets_and_values(iter, value_cap, len) };
+        let (offsets, values) = unsafe { fill_offsets_and_values(iter, size_hint, len) };
         unsafe {
             Utf8Array::new_unchecked(DataType::LargeUtf8, offsets.into(), values.into(), None)
         }

--- a/crates/polars-arrow/src/kernels/time.rs
+++ b/crates/polars-arrow/src/kernels/time.rs
@@ -5,16 +5,12 @@ use arrow::error::{Error as ArrowError, Result};
 use arrow::temporal_conversions::{
     timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
 };
-#[cfg(feature = "timezones")]
 use chrono::{LocalResult, NaiveDateTime, TimeZone};
-#[cfg(feature = "timezones")]
 use chrono_tz::Tz;
 use polars_error::polars_bail;
 
 use crate::error::PolarsResult;
-use crate::prelude::ArrayRef;
 
-#[cfg(feature = "timezones")]
 fn convert_to_naive_local(
     from_tz: &Tz,
     to_tz: &Tz,
@@ -41,68 +37,55 @@ fn convert_to_naive_local(
     }
 }
 
-#[cfg(feature = "timezones")]
 fn convert_to_timestamp(
     from_tz: Tz,
     to_tz: Tz,
     arr: &PrimitiveArray<i64>,
     tu: TimeUnit,
     use_earliest: Option<bool>,
-) -> PolarsResult<ArrayRef> {
-    match tu {
-        TimeUnit::Millisecond => {
-            let data = try_unary(
-                arr,
-                |value| {
-                    let ndt = timestamp_ms_to_datetime(value);
-                    Ok(convert_to_naive_local(&from_tz, &to_tz, ndt, use_earliest)?
-                        .timestamp_millis())
-                },
-                ArrowDataType::Int64,
-            )?;
-            Ok(Box::new(data))
-        }
-        TimeUnit::Microsecond => {
-            let data = try_unary(
-                arr,
-                |value| {
-                    let ndt = timestamp_us_to_datetime(value);
-                    Ok(convert_to_naive_local(&from_tz, &to_tz, ndt, use_earliest)?
-                        .timestamp_micros())
-                },
-                ArrowDataType::Int64,
-            )?;
-            Ok(Box::new(data))
-        }
-        TimeUnit::Nanosecond => {
-            let data = try_unary(
-                arr,
-                |value| {
-                    let ndt = timestamp_ns_to_datetime(value);
-                    Ok(convert_to_naive_local(&from_tz, &to_tz, ndt, use_earliest)?
-                        .timestamp_nanos())
-                },
-                ArrowDataType::Int64,
-            )?;
-            Ok(Box::new(data))
-        }
+) -> PolarsResult<PrimitiveArray<i64>> {
+    let res = match tu {
+        TimeUnit::Millisecond => try_unary(
+            arr,
+            |value| {
+                let ndt = timestamp_ms_to_datetime(value);
+                Ok(convert_to_naive_local(&from_tz, &to_tz, ndt, use_earliest)?.timestamp_millis())
+            },
+            ArrowDataType::Int64,
+        ),
+        TimeUnit::Microsecond => try_unary(
+            arr,
+            |value| {
+                let ndt = timestamp_us_to_datetime(value);
+                Ok(convert_to_naive_local(&from_tz, &to_tz, ndt, use_earliest)?.timestamp_micros())
+            },
+            ArrowDataType::Int64,
+        ),
+        TimeUnit::Nanosecond => try_unary(
+            arr,
+            |value| {
+                let ndt = timestamp_ns_to_datetime(value);
+                Ok(convert_to_naive_local(&from_tz, &to_tz, ndt, use_earliest)?.timestamp_nanos())
+            },
+            ArrowDataType::Int64,
+        ),
         _ => unreachable!(),
-    }
+    };
+    Ok(res?)
 }
 
-#[cfg(feature = "timezones")]
 pub fn replace_time_zone(
     arr: &PrimitiveArray<i64>,
     tu: TimeUnit,
     from: &str,
     to: &str,
     use_earliest: Option<bool>,
-) -> PolarsResult<ArrayRef> {
-    Ok(match from.parse::<chrono_tz::Tz>() {
+) -> PolarsResult<PrimitiveArray<i64>> {
+    match from.parse::<chrono_tz::Tz>() {
         Ok(from_tz) => match to.parse::<chrono_tz::Tz>() {
-            Ok(to_tz) => convert_to_timestamp(from_tz, to_tz, arr, tu, use_earliest)?,
+            Ok(to_tz) => convert_to_timestamp(from_tz, to_tz, arr, tu, use_earliest),
             Err(_) => polars_bail!(ComputeError: "unable to parse time zone: '{}'", to),
         },
         Err(_) => polars_bail!(ComputeError: "unable to parse time zone: '{}'", from),
-    })
+    }
 }

--- a/crates/polars-arrow/src/lib.rs
+++ b/crates/polars-arrow/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(
     feature = "nightly",
     allow(clippy::incorrect_partial_ord_impl_on_ord_type)
-)] // remove once stable
+)] // Remove once stable.
 pub mod array;
 pub mod bit_util;
 pub mod bitmap;

--- a/crates/polars-core/src/chunked_array/bitwise.rs
+++ b/crates/polars-core/src/chunked_array/bitwise.rs
@@ -77,10 +77,8 @@ impl BitOr for &BooleanChunked {
         let chunks = lhs
             .downcast_iter()
             .zip(rhs.downcast_iter())
-            .map(|(lhs, rhs)| Box::new(compute::boolean_kleene::or(lhs, rhs)) as ArrayRef)
-            .collect();
-        // safety: same type
-        unsafe { BooleanChunked::from_chunks(self.name(), chunks) }
+            .map(|(lhs, rhs)| compute::boolean_kleene::or(lhs, rhs));
+        BooleanChunked::from_chunk_iter(self.name(), chunks)
     }
 }
 
@@ -132,14 +130,9 @@ impl BitXor for &BooleanChunked {
             .map(|(l_arr, r_arr)| {
                 let validity = combine_validities_and(l_arr.validity(), r_arr.validity());
                 let values = l_arr.values() ^ r_arr.values();
-
-                let arr = BooleanArray::from_data_default(values, validity);
-                Box::new(arr) as ArrayRef
-            })
-            .collect::<Vec<_>>();
-
-        // safety: same type
-        unsafe { ChunkedArray::from_chunks(self.name(), chunks) }
+                BooleanArray::from_data_default(values, validity)
+            });
+        ChunkedArray::from_chunk_iter(self.name(), chunks)
     }
 }
 
@@ -180,10 +173,8 @@ impl BitAnd for &BooleanChunked {
         let chunks = lhs
             .downcast_iter()
             .zip(rhs.downcast_iter())
-            .map(|(lhs, rhs)| Box::new(compute::boolean_kleene::and(lhs, rhs)) as ArrayRef)
-            .collect();
-        // safety: same type
-        unsafe { BooleanChunked::from_chunks(self.name(), chunks) }
+            .map(|(lhs, rhs)| compute::boolean_kleene::and(lhs, rhs));
+        BooleanChunked::from_chunk_iter(self.name(), chunks)
     }
 }
 

--- a/crates/polars-core/src/chunked_array/builder/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/mod.rs
@@ -22,6 +22,7 @@ pub use list::*;
 pub use primitive::*;
 pub use utf8::*;
 
+use crate::chunked_array::to_primitive;
 use crate::prelude::*;
 use crate::utils::{get_iter_capacity, NoNull};
 
@@ -46,11 +47,10 @@ where
     T: PolarsNumericType,
 {
     fn from_iter<I: IntoIterator<Item = (Vec<T::Native>, Option<Bitmap>)>>(iter: I) -> Self {
-        // SAFETY: all same type.
         let chunks = iter
             .into_iter()
-            .map(|(values, opt_buffer)| to_array::<T>(values, opt_buffer));
-        unsafe { ChunkedArray::from_chunks("from_iter", chunks.collect()) }
+            .map(|(values, opt_buffer)| to_primitive::<T>(values, opt_buffer));
+        ChunkedArray::from_chunk_iter("from_iter", chunks)
     }
 }
 
@@ -70,9 +70,8 @@ where
     T: PolarsNumericType,
 {
     fn from_slice(name: &str, v: &[T::Native]) -> Self {
-        // SAFETY: all same type.
-        let arr = PrimitiveArray::<T::Native>::from_slice(v).to(T::get_dtype().to_arrow());
-        unsafe { ChunkedArray::from_chunks(name, vec![Box::new(arr)]) }
+        let arr = PrimitiveArray::from_slice(v).to(T::get_dtype().to_arrow());
+        ChunkedArray::from_chunk_iter(name, Some(arr))
     }
 
     fn from_slice_options(name: &str, opt_v: &[Option<T::Native>]) -> Self {
@@ -129,13 +128,10 @@ where
 {
     fn from_slice(name: &str, v: &[S]) -> Self {
         let values_size = v.iter().fold(0, |acc, s| acc + s.as_ref().len());
-
         let mut builder = MutableUtf8Array::<i64>::with_capacities(v.len(), values_size);
         builder.extend_trusted_len_values(v.iter().map(|s| s.as_ref()));
-
-        let chunks = vec![builder.as_box()];
-        // safety: same type
-        unsafe { ChunkedArray::from_chunks(name, chunks) }
+        let imm: Utf8Array<i64> = builder.into();
+        ChunkedArray::from_chunk_iter(name, Some(imm))
     }
 
     fn from_slice_options(name: &str, opt_v: &[Option<S>]) -> Self {
@@ -145,10 +141,8 @@ where
         });
         let mut builder = MutableUtf8Array::<i64>::with_capacities(opt_v.len(), values_size);
         builder.extend_trusted_len(opt_v.iter().map(|s| s.as_ref()));
-
-        let chunks = vec![builder.as_box()];
-        // safety: same type
-        unsafe { ChunkedArray::from_chunks(name, chunks) }
+        let imm: Utf8Array<i64> = builder.into();
+        ChunkedArray::from_chunk_iter(name, Some(imm))
     }
 
     fn from_iter_options(name: &str, it: impl Iterator<Item = Option<S>>) -> Self {
@@ -173,13 +167,10 @@ where
 {
     fn from_slice(name: &str, v: &[B]) -> Self {
         let values_size = v.iter().fold(0, |acc, s| acc + s.as_ref().len());
-
         let mut builder = MutableBinaryArray::<i64>::with_capacities(v.len(), values_size);
         builder.extend_trusted_len_values(v.iter().map(|s| s.as_ref()));
-
-        let chunks = vec![builder.as_box()];
-        // safety: same type
-        unsafe { ChunkedArray::from_chunks(name, chunks) }
+        let imm: BinaryArray<i64> = builder.into();
+        ChunkedArray::from_chunk_iter(name, Some(imm))
     }
 
     fn from_slice_options(name: &str, opt_v: &[Option<B>]) -> Self {
@@ -189,10 +180,8 @@ where
         });
         let mut builder = MutableBinaryArray::<i64>::with_capacities(opt_v.len(), values_size);
         builder.extend_trusted_len(opt_v.iter().map(|s| s.as_ref()));
-
-        let chunks = vec![builder.as_box()];
-        // safety: same type
-        unsafe { ChunkedArray::from_chunks(name, chunks) }
+        let imm: BinaryArray<i64> = builder.into();
+        ChunkedArray::from_chunk_iter(name, Some(imm))
     }
 
     fn from_iter_options(name: &str, it: impl Iterator<Item = Option<B>>) -> Self {
@@ -231,7 +220,7 @@ mod test {
         let mut builder =
             ListPrimitiveChunkedBuilder::<Int32Type>::new("a", 10, 5, DataType::Int32);
 
-        // create a series containing two chunks
+        // Create a series containing two chunks.
         let mut s1 = Int32Chunked::from_slice("a", &[1, 2, 3]).into_series();
         let s2 = Int32Chunked::from_slice("b", &[4, 5, 6]).into_series();
         s1.append(&s2).unwrap();
@@ -250,7 +239,8 @@ mod test {
         } else {
             panic!()
         }
-        // test list collect
+
+        // Test list collect.
         let out = [&s1, &s2].iter().copied().collect::<ListChunked>();
         assert_eq!(out.get(0).unwrap().len(), 6);
         assert_eq!(out.get(1).unwrap().len(), 3);

--- a/crates/polars-core/src/chunked_array/builder/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/mod.rs
@@ -71,7 +71,7 @@ where
 {
     fn from_slice(name: &str, v: &[T::Native]) -> Self {
         let arr = PrimitiveArray::from_slice(v).to(T::get_dtype().to_arrow());
-        ChunkedArray::from_chunk_iter(name, Some(arr))
+        ChunkedArray::from_chunk_iter(name, [arr])
     }
 
     fn from_slice_options(name: &str, opt_v: &[Option<T::Native>]) -> Self {
@@ -131,7 +131,7 @@ where
         let mut builder = MutableUtf8Array::<i64>::with_capacities(v.len(), values_size);
         builder.extend_trusted_len_values(v.iter().map(|s| s.as_ref()));
         let imm: Utf8Array<i64> = builder.into();
-        ChunkedArray::from_chunk_iter(name, Some(imm))
+        ChunkedArray::from_chunk_iter(name, [imm])
     }
 
     fn from_slice_options(name: &str, opt_v: &[Option<S>]) -> Self {
@@ -142,7 +142,7 @@ where
         let mut builder = MutableUtf8Array::<i64>::with_capacities(opt_v.len(), values_size);
         builder.extend_trusted_len(opt_v.iter().map(|s| s.as_ref()));
         let imm: Utf8Array<i64> = builder.into();
-        ChunkedArray::from_chunk_iter(name, Some(imm))
+        ChunkedArray::from_chunk_iter(name, [imm])
     }
 
     fn from_iter_options(name: &str, it: impl Iterator<Item = Option<S>>) -> Self {
@@ -170,7 +170,7 @@ where
         let mut builder = MutableBinaryArray::<i64>::with_capacities(v.len(), values_size);
         builder.extend_trusted_len_values(v.iter().map(|s| s.as_ref()));
         let imm: BinaryArray<i64> = builder.into();
-        ChunkedArray::from_chunk_iter(name, Some(imm))
+        ChunkedArray::from_chunk_iter(name, [imm])
     }
 
     fn from_slice_options(name: &str, opt_v: &[Option<B>]) -> Self {
@@ -181,7 +181,7 @@ where
         let mut builder = MutableBinaryArray::<i64>::with_capacities(opt_v.len(), values_size);
         builder.extend_trusted_len(opt_v.iter().map(|s| s.as_ref()));
         let imm: BinaryArray<i64> = builder.into();
-        ChunkedArray::from_chunk_iter(name, Some(imm))
+        ChunkedArray::from_chunk_iter(name, [imm])
     }
 
     fn from_iter_options(name: &str, it: impl Iterator<Item = Option<B>>) -> Self {

--- a/crates/polars-core/src/chunked_array/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/list/mod.rs
@@ -68,7 +68,14 @@ impl ListChunked {
         let inner_dtype = self.inner_dtype().to_arrow();
 
         let chunks = ca.downcast_iter().map(|arr| {
-            let elements = unsafe { Series::try_from_arrow_unchecked(self.name(), vec![(*arr.values()).clone()], &inner_dtype).unwrap() } ;
+            let elements = unsafe {
+                Series::try_from_arrow_unchecked(
+                    self.name(),
+                    vec![(*arr.values()).clone()],
+                    &inner_dtype,
+                )
+                .unwrap()
+            };
 
             let expected_len = elements.len();
             let out: Series = func(elements)?;
@@ -86,9 +93,9 @@ impl ListChunked {
                 values,
                 arr.validity().cloned(),
             );
-            Ok(Box::new(arr) as ArrayRef)
-        }).collect::<PolarsResult<Vec<_>>>()?;
+            Ok(arr)
+        });
 
-        unsafe { Ok(ListChunked::from_chunks(self.name(), chunks)) }
+        ListChunked::try_from_chunk_iter(self.name(), chunks)
     }
 }

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -215,15 +215,15 @@ impl<T: PolarsDataType> ChunkedArray<T> {
                     .remove(Settings::SORTED_ASC | Settings::SORTED_DSC);
             }
             IsSorted::Ascending => {
-                // // unset descending sorted
+                // Unset descending sorted.
                 self.bit_settings.remove(Settings::SORTED_DSC);
-                // set ascending sorted
+                // Set ascending sorted.
                 self.bit_settings.insert(Settings::SORTED_ASC)
             }
             IsSorted::Descending => {
-                // unset ascending sorted
+                // Unset ascending sorted.
                 self.bit_settings.remove(Settings::SORTED_ASC);
-                // set descending sorted
+                // Set descending sorted.
                 self.bit_settings.insert(Settings::SORTED_DSC)
             }
         }

--- a/crates/polars-core/src/chunked_array/ops/bit_repr.rs
+++ b/crates/polars-core/src/chunked_array/ops/bit_repr.rs
@@ -2,63 +2,36 @@ use arrow::buffer::Buffer;
 
 use crate::prelude::*;
 
+/// Reinterprets the type of a ChunkedArray. T and U must have the same size
+/// and alignment.
+fn reinterpret_chunked_array<T: PolarsNumericType, U: PolarsNumericType>(ca: &ChunkedArray<T>) -> ChunkedArray<U> {
+    assert!(std::mem::size_of::<T::Native>() == std::mem::size_of::<U::Native>());
+    assert!(std::mem::align_of::<T::Native>() == std::mem::align_of::<U::Native>());
+
+    let chunks = ca
+        .downcast_iter()
+        .map(|array| {
+            let buf = array.values().clone();
+            // SAFETY: we checked that the size and alignment matches.
+            #[allow(clippy::transmute_undefined_repr)]
+            let reinterpreted_buf = unsafe { std::mem::transmute::<Buffer<T::Native>, Buffer<U::Native>>(buf) };
+            PrimitiveArray::from_data_default(reinterpreted_buf, array.validity().cloned())
+        });
+    
+    ChunkedArray::from_chunk_iter(ca.name(), chunks)
+}
+
 #[cfg(feature = "performant")]
 impl Int16Chunked {
     pub(crate) fn reinterpret_unsigned(&self) -> UInt16Chunked {
-        let chunks = self
-            .downcast_iter()
-            .map(|array| {
-                let buf = array.values().clone();
-                // Safety
-                // same bit length i16 <-> u16
-                // The fields can still be reordered between generic types
-                // so we do some extra assertions
-                let len = buf.len();
-                let offset = buf.offset();
-                let ptr = buf.as_slice().as_ptr() as usize;
-                #[allow(clippy::transmute_undefined_repr)]
-                let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<u16>>(buf) };
-                debug_assert_eq!(reinterpreted_buf.len(), len);
-                debug_assert_eq!(reinterpreted_buf.offset(), offset);
-                debug_assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
-                Box::new(PrimitiveArray::new(
-                    ArrowDataType::UInt16,
-                    reinterpreted_buf,
-                    array.validity().cloned(),
-                )) as ArrayRef
-            })
-            .collect::<Vec<_>>();
-        unsafe { UInt16Chunked::from_chunks(self.name(), chunks) }
+        reinterpret_chunked_array(self)
     }
 }
 
 #[cfg(feature = "performant")]
 impl Int8Chunked {
     pub(crate) fn reinterpret_unsigned(&self) -> UInt8Chunked {
-        let chunks = self
-            .downcast_iter()
-            .map(|array| {
-                let buf = array.values().clone();
-                // Safety
-                // same bit length i8 <-> u8
-                // The fields can still be reordered between generic types
-                // so we do some extra assertions
-                let len = buf.len();
-                let offset = buf.offset();
-                let ptr = buf.as_slice().as_ptr() as usize;
-                #[allow(clippy::transmute_undefined_repr)]
-                let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<u8>>(buf) };
-                debug_assert_eq!(reinterpreted_buf.len(), len);
-                debug_assert_eq!(reinterpreted_buf.offset(), offset);
-                debug_assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
-                Box::new(PrimitiveArray::new(
-                    ArrowDataType::UInt8,
-                    reinterpreted_buf,
-                    array.validity().cloned(),
-                )) as ArrayRef
-            })
-            .collect::<Vec<_>>();
-        unsafe { UInt8Chunked::from_chunks(self.name(), chunks) }
+        reinterpret_chunked_array(self)
     }
 }
 
@@ -74,33 +47,10 @@ where
         if std::mem::size_of::<T::Native>() == 8 {
             if matches!(self.dtype(), DataType::UInt64) {
                 let ca = self.clone();
-                // convince the compiler we are this type. This keeps flags
+                // Convince the compiler we are this type. This keeps flags.
                 return unsafe { std::mem::transmute(ca) };
             }
-            let chunks = self
-                .downcast_iter()
-                .map(|array| {
-                    let buf = array.values().clone();
-                    // Safety:
-                    // we just check the size of T::Native to be 64 bits
-                    // The fields can still be reordered between generic types
-                    // so we do some extra assertions
-                    let len = buf.len();
-                    let offset = buf.offset();
-                    let ptr = buf.as_slice().as_ptr() as usize;
-                    #[allow(clippy::transmute_undefined_repr)]
-                    let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<u64>>(buf) };
-                    assert_eq!(reinterpreted_buf.len(), len);
-                    assert_eq!(reinterpreted_buf.offset(), offset);
-                    assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
-                    Box::new(PrimitiveArray::new(
-                        ArrowDataType::UInt64,
-                        reinterpreted_buf,
-                        array.validity().cloned(),
-                    )) as ArrayRef
-                })
-                .collect::<Vec<_>>();
-            unsafe { UInt64Chunked::from_chunks(self.name(), chunks) }
+            reinterpret_chunked_array(self)
         } else {
             unreachable!()
         }
@@ -110,34 +60,13 @@ where
         if std::mem::size_of::<T::Native>() == 4 {
             if matches!(self.dtype(), DataType::UInt32) {
                 let ca = self.clone();
-                // convince the compiler we are this type. This keeps flags
+                // Convince the compiler we are this type. This preserves flags.
                 return unsafe { std::mem::transmute(ca) };
             }
-            let chunks = self
-                .downcast_iter()
-                .map(|array| {
-                    let buf = array.values().clone();
-                    // Safety:
-                    // we just check the size of T::Native to be 32 bits
-                    // The fields can still be reordered between generic types
-                    // so we do some extra assertions
-                    let len = buf.len();
-                    let offset = buf.offset();
-                    let ptr = buf.as_slice().as_ptr() as usize;
-                    #[allow(clippy::transmute_undefined_repr)]
-                    let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<u32>>(buf) };
-                    assert_eq!(reinterpreted_buf.len(), len);
-                    assert_eq!(reinterpreted_buf.offset(), offset);
-                    assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
-                    Box::new(PrimitiveArray::new(
-                        ArrowDataType::UInt32,
-                        reinterpreted_buf,
-                        array.validity().cloned(),
-                    )) as ArrayRef
-                })
-                .collect::<Vec<_>>();
-            unsafe { UInt32Chunked::from_chunks(self.name(), chunks) }
+            reinterpret_chunked_array(self)
         } else {
+            // SAFETY: an unchecked cast to uint32 (which has no invariants) is
+            // always sound.
             unsafe {
                 self.cast_unchecked(&DataType::UInt32)
                     .unwrap()
@@ -152,30 +81,8 @@ where
 #[cfg(feature = "reinterpret")]
 impl Reinterpret for UInt64Chunked {
     fn reinterpret_signed(&self) -> Series {
-        let chunks = self
-            .downcast_iter()
-            .map(|array| {
-                let buf = array.values().clone();
-                // Safety
-                // same bit length u64 <-> i64
-                // The fields can still be reordered between generic types
-                // so we do some extra assertions
-                let len = buf.len();
-                let offset = buf.offset();
-                let ptr = buf.as_slice().as_ptr() as usize;
-                #[allow(clippy::transmute_undefined_repr)]
-                let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<i64>>(buf) };
-                assert_eq!(reinterpreted_buf.len(), len);
-                assert_eq!(reinterpreted_buf.offset(), offset);
-                assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
-                Box::new(PrimitiveArray::new(
-                    ArrowDataType::Int64,
-                    reinterpreted_buf,
-                    array.validity().cloned(),
-                )) as ArrayRef
-            })
-            .collect::<Vec<_>>();
-        unsafe { Int64Chunked::from_chunks(self.name(), chunks).into_series() }
+        let signed: Int64Chunked = reinterpret_chunked_array(self);
+        signed.into_series()
     }
 
     fn reinterpret_unsigned(&self) -> Series {
@@ -196,30 +103,8 @@ impl Reinterpret for Int64Chunked {
 #[cfg(feature = "reinterpret")]
 impl Reinterpret for UInt32Chunked {
     fn reinterpret_signed(&self) -> Series {
-        let chunks = self
-            .downcast_iter()
-            .map(|array| {
-                let buf = array.values().clone();
-                // Safety
-                // same bit length u32 <-> i32
-                // The fields can still be reordered between generic types
-                // so we do some extra assertions
-                let len = buf.len();
-                let offset = buf.offset();
-                let ptr = buf.as_slice().as_ptr() as usize;
-                #[allow(clippy::transmute_undefined_repr)]
-                let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<i32>>(buf) };
-                assert_eq!(reinterpreted_buf.len(), len);
-                assert_eq!(reinterpreted_buf.offset(), offset);
-                assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
-                Box::new(PrimitiveArray::new(
-                    ArrowDataType::Int32,
-                    reinterpreted_buf,
-                    array.validity().cloned(),
-                )) as ArrayRef
-            })
-            .collect::<Vec<_>>();
-        unsafe { Int32Chunked::from_chunks(self.name(), chunks).into_series() }
+        let signed: Int32Chunked = reinterpret_chunked_array(self);
+        signed.into_series()
     }
 
     fn reinterpret_unsigned(&self) -> Series {
@@ -241,59 +126,13 @@ impl Reinterpret for Int32Chunked {
 impl UInt64Chunked {
     #[doc(hidden)]
     pub fn _reinterpret_float(&self) -> Float64Chunked {
-        let chunks = self
-            .downcast_iter()
-            .map(|array| {
-                let buf = array.values().clone();
-                // Safety
-                // same bit length u64 <-> f64
-                // The fields can still be reordered between generic types
-                // so we do some extra assertions
-                let len = buf.len();
-                let offset = buf.offset();
-                let ptr = buf.as_slice().as_ptr() as usize;
-                #[allow(clippy::transmute_undefined_repr)]
-                let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<f64>>(buf) };
-                assert_eq!(reinterpreted_buf.len(), len);
-                assert_eq!(reinterpreted_buf.offset(), offset);
-                assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
-                Box::new(PrimitiveArray::new(
-                    ArrowDataType::Float64,
-                    reinterpreted_buf,
-                    array.validity().cloned(),
-                )) as ArrayRef
-            })
-            .collect::<Vec<_>>();
-        unsafe { Float64Chunked::from_chunks(self.name(), chunks) }
+        reinterpret_chunked_array(self)
     }
 }
 impl UInt32Chunked {
     #[doc(hidden)]
     pub fn _reinterpret_float(&self) -> Float32Chunked {
-        let chunks = self
-            .downcast_iter()
-            .map(|array| {
-                let buf = array.values().clone();
-                // Safety
-                // same bit length u32 <-> f32
-                // The fields can still be reordered between generic types
-                // so we do some extra assertions
-                let len = buf.len();
-                let offset = buf.offset();
-                let ptr = buf.as_slice().as_ptr() as usize;
-                #[allow(clippy::transmute_undefined_repr)]
-                let reinterpreted_buf = unsafe { std::mem::transmute::<_, Buffer<f32>>(buf) };
-                assert_eq!(reinterpreted_buf.len(), len);
-                assert_eq!(reinterpreted_buf.offset(), offset);
-                assert_eq!(reinterpreted_buf.as_slice().as_ptr() as usize, ptr);
-                Box::new(PrimitiveArray::new(
-                    ArrowDataType::Float32,
-                    reinterpreted_buf,
-                    array.validity().cloned(),
-                )) as ArrayRef
-            })
-            .collect::<Vec<_>>();
-        unsafe { Float32Chunked::from_chunks(self.name(), chunks) }
+        reinterpret_chunked_array(self)
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/concat_str.rs
+++ b/crates/polars-core/src/chunked_array/ops/concat_str.rs
@@ -33,7 +33,7 @@ where
     let buf = buf.into_bytes();
     let offsets = vec![0, buf.len() as i64];
     let arr = unsafe { Utf8Array::from_data_unchecked_default(offsets.into(), buf.into(), None) };
-    unsafe { Utf8Chunked::from_chunks(name, vec![Box::new(arr)]) }
+    Utf8Chunked::from_chunk_iter(name, [arr])
 }
 
 impl<T> StrConcat for ChunkedArray<T>

--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -22,7 +22,7 @@ where
     T: PolarsNumericType,
 {
     fn filter(&self, filter: &BooleanChunked) -> PolarsResult<ChunkedArray<T>> {
-        // broadcast
+        // Broadcast.
         if filter.len() == 1 {
             return match filter.get(0) {
                 Some(true) => Ok(self.clone()),
@@ -43,7 +43,7 @@ where
 
 impl ChunkFilter<BooleanType> for BooleanChunked {
     fn filter(&self, filter: &BooleanChunked) -> PolarsResult<ChunkedArray<BooleanType>> {
-        // broadcast
+        // Broadcast.
         if filter.len() == 1 {
             return match filter.get(0) {
                 Some(true) => Ok(self.clone()),
@@ -71,7 +71,7 @@ impl ChunkFilter<Utf8Type> for Utf8Chunked {
 
 impl ChunkFilter<BinaryType> for BinaryChunked {
     fn filter(&self, filter: &BooleanChunked) -> PolarsResult<ChunkedArray<BinaryType>> {
-        // broadcast
+        // Broadcast.
         if filter.len() == 1 {
             return match filter.get(0) {
                 Some(true) => Ok(self.clone()),
@@ -93,16 +93,14 @@ impl ChunkFilter<BinaryType> for BinaryChunked {
 
 impl ChunkFilter<ListType> for ListChunked {
     fn filter(&self, filter: &BooleanChunked) -> PolarsResult<ListChunked> {
-        // broadcast
+        // Broadcast.
         if filter.len() == 1 {
             return match filter.get(0) {
                 Some(true) => Ok(self.clone()),
-                _ => unsafe {
-                    Ok(ListChunked::from_chunks(
-                        self.name(),
-                        vec![new_empty_array(self.dtype().to_arrow())],
-                    ))
-                },
+                _ => Ok(ListChunked::from_chunk_iter(
+                    self.name(),
+                    [ListArray::new_empty(self.dtype().to_arrow())],
+                )),
             };
         }
         let (left, filter) = align_chunks_binary(self, filter);
@@ -124,16 +122,14 @@ impl ChunkFilter<ListType> for ListChunked {
 #[cfg(feature = "dtype-array")]
 impl ChunkFilter<FixedSizeListType> for ArrayChunked {
     fn filter(&self, filter: &BooleanChunked) -> PolarsResult<ArrayChunked> {
-        // broadcast
+        // Broadcast.
         if filter.len() == 1 {
             return match filter.get(0) {
                 Some(true) => Ok(self.clone()),
-                _ => unsafe {
-                    Ok(ChunkedArray::from_chunks(
-                        self.name(),
-                        vec![new_empty_array(self.dtype().to_arrow())],
-                    ))
-                },
+                _ => Ok(ArrayChunked::from_chunk_iter(
+                    self.name(),
+                    [FixedSizeListArray::new_empty(self.dtype().to_arrow())],
+                )),
             };
         }
         let (left, filter) = align_chunks_binary(self, filter);
@@ -161,7 +157,7 @@ where
     where
         Self: Sized,
     {
-        // broadcast
+        // Broadcast.
         if filter.len() == 1 {
             return match filter.get(0) {
                 Some(true) => Ok(self.clone()),

--- a/crates/polars-core/src/chunked_array/ops/full.rs
+++ b/crates/polars-core/src/chunked_array/ops/full.rs
@@ -1,6 +1,4 @@
 use arrow::bitmap::MutableBitmap;
-use arrow::compute::comparison::Simd8Lanes;
-use arrow::types::PrimitiveType;
 use polars_arrow::array::default_arrays::FromData;
 
 use crate::chunked_array::builder::get_list_builder;

--- a/crates/polars-core/src/chunked_array/ops/full.rs
+++ b/crates/polars-core/src/chunked_array/ops/full.rs
@@ -1,4 +1,6 @@
 use arrow::bitmap::MutableBitmap;
+use arrow::compute::comparison::Simd8Lanes;
+use arrow::types::PrimitiveType;
 use polars_arrow::array::default_arrays::FromData;
 
 use crate::chunked_array::builder::get_list_builder;
@@ -22,8 +24,8 @@ where
     T: PolarsNumericType,
 {
     fn full_null(name: &str, length: usize) -> Self {
-        let arr = new_null_array(T::get_dtype().to_arrow(), length);
-        unsafe { ChunkedArray::from_chunks(name, vec![arr]) }
+        let arr = PrimitiveArray::new_null(T::get_dtype().to_arrow(), length);
+        ChunkedArray::from_chunk_iter(name, [arr])
     }
 }
 impl ChunkFull<bool> for BooleanChunked {
@@ -39,8 +41,8 @@ impl ChunkFull<bool> for BooleanChunked {
 
 impl ChunkFullNull for BooleanChunked {
     fn full_null(name: &str, length: usize) -> Self {
-        let arr = new_null_array(DataType::Boolean.to_arrow(), length);
-        unsafe { BooleanChunked::from_chunks(name, vec![arr]) }
+        let arr = BooleanArray::new_null(DataType::Boolean.to_arrow(), length);
+        ChunkedArray::from_chunk_iter(name, [arr])
     }
 }
 
@@ -59,8 +61,8 @@ impl<'a> ChunkFull<&'a str> for Utf8Chunked {
 
 impl ChunkFullNull for Utf8Chunked {
     fn full_null(name: &str, length: usize) -> Self {
-        let arr = new_null_array(DataType::Utf8.to_arrow(), length);
-        unsafe { Utf8Chunked::from_chunks(name, vec![arr]) }
+        let arr = Utf8Array::new_null(DataType::Utf8.to_arrow(), length);
+        ChunkedArray::from_chunk_iter(name, [arr])
     }
 }
 
@@ -79,8 +81,8 @@ impl<'a> ChunkFull<&'a [u8]> for BinaryChunked {
 
 impl ChunkFullNull for BinaryChunked {
     fn full_null(name: &str, length: usize) -> Self {
-        let arr = new_null_array(DataType::Binary.to_arrow(), length);
-        unsafe { BinaryChunked::from_chunks(name, vec![arr]) }
+        let arr = BinaryArray::new_null(DataType::Binary.to_arrow(), length);
+        ChunkedArray::from_chunk_iter(name, [arr])
     }
 }
 
@@ -109,14 +111,14 @@ impl ArrayChunked {
         inner_dtype: &DataType,
         width: usize,
     ) -> ArrayChunked {
-        let arr = new_null_array(
+        let arr = FixedSizeListArray::new_null(
             ArrowDataType::FixedSizeList(
                 Box::new(ArrowField::new("item", inner_dtype.to_arrow(), true)),
                 width,
             ),
             length,
         );
-        unsafe { ArrayChunked::from_chunks(name, vec![arr]) }
+        ChunkedArray::from_chunk_iter(name, [arr])
     }
 }
 
@@ -133,9 +135,8 @@ impl ChunkFull<&Series> for ArrayChunked {
             Box::new(ArrowField::new("item", values.data_type().clone(), true)),
             width,
         );
-
-        let arr = Box::new(FixedSizeListArray::new(data_type, values, None)) as ArrayRef;
-        unsafe { ArrayChunked::from_chunks(name, vec![arr]) }
+        let arr = FixedSizeListArray::new(data_type, values, None);
+        ChunkedArray::from_chunk_iter(name, [arr])
     }
 }
 
@@ -148,7 +149,7 @@ impl ChunkFullNull for ArrayChunked {
 
 impl ListChunked {
     pub fn full_null_with_dtype(name: &str, length: usize, inner_dtype: &DataType) -> ListChunked {
-        let arr = new_null_array(
+        let arr = ListArray::new_null(
             ArrowDataType::LargeList(Box::new(ArrowField::new(
                 "item",
                 inner_dtype.to_arrow(),
@@ -156,7 +157,7 @@ impl ListChunked {
             ))),
             length,
         );
-        unsafe { ListChunked::from_chunks(name, vec![arr]) }
+        ChunkedArray::from_chunk_iter(name, [arr])
     }
 }
 #[cfg(feature = "dtype-struct")]

--- a/crates/polars-core/src/chunked_array/ops/min_max_binary.rs
+++ b/crates/polars-core/src/chunked_array/ops/min_max_binary.rs
@@ -1,6 +1,5 @@
 use arrow::array::PrimitiveArray;
 use polars_arrow::prelude::FromData;
-use polars_row::ArrayRef;
 
 use crate::datatypes::PolarsNumericType;
 use crate::prelude::*;
@@ -23,14 +22,11 @@ where
                 .zip(right.values().iter())
                 .map(|(l, r)| op(*l, *r))
                 .collect::<Vec<_>>();
-            let arr = PrimitiveArray::from_data_default(values.into(), None);
-
-            Box::new(arr) as ArrayRef
-        })
-        .collect();
-
-    unsafe { ChunkedArray::from_chunks(left.name(), chunks) }
+            PrimitiveArray::from_data_default(values.into(), None)
+        });
+    ChunkedArray::from_chunk_iter(left.name(), chunks)
 }
+
 fn min_binary<T>(left: &ChunkedArray<T>, right: &ChunkedArray<T>) -> ChunkedArray<T>
 where
     T: PolarsNumericType,

--- a/crates/polars-core/src/chunked_array/ops/tile.rs
+++ b/crates/polars-core/src/chunked_array/ops/tile.rs
@@ -1,5 +1,4 @@
 use polars_arrow::compute::tile;
-use polars_row::ArrayRef;
 
 use crate::datatypes::PolarsNumericType;
 use crate::prelude::ChunkedArray;
@@ -8,8 +7,7 @@ impl<T: PolarsNumericType> ChunkedArray<T> {
     pub fn tile(&self, n: usize) -> Self {
         let ca = self.rechunk();
         let arr = ca.downcast_iter().next().unwrap();
-
-        let arr = Box::new(tile::tile_primitive(arr, n)) as ArrayRef;
-        unsafe { ChunkedArray::from_chunks(self.name(), vec![arr]) }
+        let arr = tile::tile_primitive(arr, n);
+        ChunkedArray::from_chunk_iter(self.name(), [arr])
     }
 }

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -294,8 +294,6 @@ impl PolarsFloatType for Float64Type {}
 // Provide options to cloud providers (credentials, region).
 pub type CloudOptions = PlHashMap<String, String>;
 
-
-
 /// SAFETY: the underlying physical type of the data structure on which this is
 /// implemented must always match the given PolarsDataType.
 pub unsafe trait StaticallyMatchesPolarsType<T: PolarsDataType> {}

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -303,6 +303,7 @@ pub type CloudOptions = PlHashMap<String, String>;
 pub unsafe trait StaticallyMatchesPolarsType<T: PolarsDataType> {}
 
 unsafe impl<T: PolarsNumericType> StaticallyMatchesPolarsType<T> for PrimitiveArray<T::Native> {}
+unsafe impl StaticallyMatchesPolarsType<CategoricalType> for PrimitiveArray<u32> {}
 unsafe impl StaticallyMatchesPolarsType<Utf8Type> for Utf8Array<i64> {}
 unsafe impl StaticallyMatchesPolarsType<BinaryType> for BinaryArray<i64> {}
 unsafe impl StaticallyMatchesPolarsType<BooleanType> for BooleanArray {}

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -308,4 +308,5 @@ unsafe impl StaticallyMatchesPolarsType<Utf8Type> for Utf8Array<i64> {}
 unsafe impl StaticallyMatchesPolarsType<BinaryType> for BinaryArray<i64> {}
 unsafe impl StaticallyMatchesPolarsType<BooleanType> for BooleanArray {}
 unsafe impl StaticallyMatchesPolarsType<ListType> for ListArray<i64> {}
+#[cfg(feature = "dtype-array")]
 unsafe impl StaticallyMatchesPolarsType<FixedSizeListType> for FixedSizeListArray {}

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -308,3 +308,4 @@ unsafe impl StaticallyMatchesPolarsType<Utf8Type> for Utf8Array<i64> {}
 unsafe impl StaticallyMatchesPolarsType<BinaryType> for BinaryArray<i64> {}
 unsafe impl StaticallyMatchesPolarsType<BooleanType> for BooleanArray {}
 unsafe impl StaticallyMatchesPolarsType<ListType> for ListArray<i64> {}
+unsafe impl StaticallyMatchesPolarsType<FixedSizeListType> for FixedSizeListArray {}

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -27,7 +27,7 @@ use arrow::compute::comparison::Simd8;
 use arrow::datatypes::IntegerType;
 pub use arrow::datatypes::{DataType as ArrowDataType, TimeUnit as ArrowTimeUnit};
 use arrow::types::simd::Simd;
-use arrow::types::{NativeType, Offset};
+use arrow::types::NativeType;
 pub use dtype::*;
 pub use field::*;
 use num_traits::{Bounded, FromPrimitive, Num, NumCast, Zero};
@@ -107,7 +107,7 @@ impl PolarsDataType for Utf8Type {
     }
 }
 
-unsafe impl<O: Offset> StaticallyMatchesPolarsType<Utf8Type> for Utf8Array<O> {}
+unsafe impl StaticallyMatchesPolarsType<Utf8Type> for Utf8Array<i64> {}
 
 impl PolarsDataType for BinaryType {
     fn get_dtype() -> DataType {
@@ -115,7 +115,7 @@ impl PolarsDataType for BinaryType {
     }
 }
 
-unsafe impl<O: Offset> StaticallyMatchesPolarsType<BinaryType> for BinaryArray<O> {}
+unsafe impl StaticallyMatchesPolarsType<BinaryType> for BinaryArray<i64> {}
 
 pub struct BooleanType {}
 
@@ -134,7 +134,7 @@ impl PolarsDataType for ListType {
     }
 }
 
-unsafe impl<O: Offset> StaticallyMatchesPolarsType<ListType> for ListArray<O> {}
+unsafe impl StaticallyMatchesPolarsType<ListType> for ListArray<i64> {}
 
 #[cfg(feature = "dtype-array")]
 impl PolarsDataType for FixedSizeListType {

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -63,6 +63,8 @@ pub trait PolarsDataType: Send + Sync {
         Self: Sized;
 }
 
+/// SAFETY: the underlying physical type of the data structure on which this is
+/// implemented must always match the given PolarsDataType.
 pub unsafe trait StaticallyMatchesPolarsType<T: PolarsDataType> {}
 
 macro_rules! impl_polars_datatype {
@@ -131,6 +133,8 @@ impl PolarsDataType for ListType {
         DataType::List(Box::new(DataType::Null))
     }
 }
+
+unsafe impl<O: Offset> StaticallyMatchesPolarsType<ListType> for ListArray<O> {}
 
 #[cfg(feature = "dtype-array")]
 impl PolarsDataType for FixedSizeListType {

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -295,7 +295,7 @@ impl PolarsFloatType for Float64Type {}
 pub type CloudOptions = PlHashMap<String, String>;
 
 /// Used to safely match the underlying type of Polars data structures.
-/// 
+///
 /// # Safety
 ///
 /// The underlying physical type of the data structure on which this

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -294,8 +294,12 @@ impl PolarsFloatType for Float64Type {}
 // Provide options to cloud providers (credentials, region).
 pub type CloudOptions = PlHashMap<String, String>;
 
-/// SAFETY: the underlying physical type of the data structure on which this is
-/// implemented must always match the given PolarsDataType.
+/// Used to safely match the underlying type of Polars data structures.
+/// 
+/// # Safety
+///
+/// The underlying physical type of the data structure on which this
+/// is implemented must always match the given PolarsDataType.
 pub unsafe trait StaticallyMatchesPolarsType<T: PolarsDataType> {}
 
 unsafe impl<T: PolarsNumericType> StaticallyMatchesPolarsType<T> for PrimitiveArray<T::Native> {}

--- a/crates/polars-core/src/frame/row/transpose.rs
+++ b/crates/polars-core/src/frame/row/transpose.rs
@@ -251,10 +251,7 @@ where
                     values.into(),
                     validity,
                 );
-                unsafe {
-                    ChunkedArray::<T>::from_chunks(name, vec![Box::new(arr) as ArrayRef])
-                        .into_series()
-                }
+                ChunkedArray::from_chunk_iter(name, [arr]).into_series()
             })
     }));
 }

--- a/crates/polars-core/src/series/into.rs
+++ b/crates/polars-core/src/series/into.rs
@@ -33,8 +33,7 @@ impl Series {
                 let new_values = if let DataType::Null = &**inner {
                     arr.values().clone()
                 } else {
-                    // we pass physical arrays
-                    // and cast to logical before we convert to arrow
+                    // We pass physical arrays and cast to logical before we convert to arrow.
                     let s = unsafe {
                         Series::from_chunks_and_dtype_unchecked(
                             "",
@@ -61,10 +60,10 @@ impl Series {
             DataType::Categorical(_) => {
                 let ca = self.categorical().unwrap();
                 let arr = ca.logical().chunks()[chunk_idx].clone();
+                // SAFETY: categoricals are always u32's.
                 let cats = unsafe { UInt32Chunked::from_chunks("", vec![arr]) };
 
-                // safety:
-                // we only take a single chunk and change nothing about the index/rev_map mapping
+                // SAFETY: we only take a single chunk and change nothing about the index/rev_map mapping.
                 let new = unsafe {
                     CategoricalChunked::from_cats_and_rev_map_unchecked(
                         cats,

--- a/crates/polars-io/src/csv/buffer.rs
+++ b/crates/polars-io/src/csv/buffer.rs
@@ -392,7 +392,7 @@ impl ParsedBuffer for BooleanChunkedBuilder {
 
 #[cfg(any(feature = "dtype-datetime", feature = "dtype-date"))]
 pub(crate) struct DatetimeField<T: PolarsNumericType> {
-    compiled: Option<DatetimeInfer<T::Native>>,
+    compiled: Option<DatetimeInfer<T>>,
     builder: PrimitiveChunkedBuilder<T>,
 }
 
@@ -416,7 +416,7 @@ fn slow_datetime_parser<T>(
 ) -> PolarsResult<()>
 where
     T: PolarsNumericType,
-    DatetimeInfer<T::Native>: TryFromWithUnit<Pattern>,
+    DatetimeInfer<T>: TryFromWithUnit<Pattern>,
 {
     let val = if bytes.is_ascii() {
         // Safety:
@@ -442,7 +442,7 @@ where
             }
         },
     };
-    match DatetimeInfer::<T::Native>::try_from_with_unit(pattern, time_unit) {
+    match DatetimeInfer::try_from_with_unit(pattern, time_unit) {
         Ok(mut infer) => {
             let parsed = infer.parse(val);
             buf.compiled = Some(infer);
@@ -460,7 +460,7 @@ where
 impl<T> ParsedBuffer for DatetimeField<T>
 where
     T: PolarsNumericType,
-    DatetimeInfer<T::Native>: TryFromWithUnit<Pattern> + StrpTimeParser<T::Native>,
+    DatetimeInfer<T>: TryFromWithUnit<Pattern> + StrpTimeParser<T::Native>,
 {
     #[inline]
     fn parse_bytes(

--- a/crates/polars-io/src/ndjson/buffer.rs
+++ b/crates/polars-io/src/ndjson/buffer.rs
@@ -167,8 +167,7 @@ where
         _ => return None,
     };
     infer_pattern_single(val).and_then(|pattern| {
-        match DatetimeInfer::try_from_with_unit(pattern, Some(TimeUnit::Microseconds))
-        {
+        match DatetimeInfer::try_from_with_unit(pattern, Some(TimeUnit::Microseconds)) {
             Ok(mut infer) => infer.parse(val),
             Err(_) => None,
         }

--- a/crates/polars-io/src/ndjson/buffer.rs
+++ b/crates/polars-io/src/ndjson/buffer.rs
@@ -160,14 +160,14 @@ fn deserialize_number<T: NativeType + NumCast>(value: &Value) -> Option<T> {
 fn deserialize_datetime<T>(value: &Value) -> Option<T::Native>
 where
     T: PolarsNumericType,
-    DatetimeInfer<T::Native>: TryFromWithUnit<Pattern>,
+    DatetimeInfer<T>: TryFromWithUnit<Pattern>,
 {
     let val = match value {
         Value::String(s) => s,
         _ => return None,
     };
     infer_pattern_single(val).and_then(|pattern| {
-        match DatetimeInfer::<T::Native>::try_from_with_unit(pattern, Some(TimeUnit::Microseconds))
+        match DatetimeInfer::try_from_with_unit(pattern, Some(TimeUnit::Microseconds))
         {
             Ok(mut infer) => infer.parse(val),
             Err(_) => None,

--- a/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -445,17 +445,14 @@ impl PartitionedAggregation for AggregationExpr {
                 let values = concatenate(&vals).unwrap();
 
                 let data_type = ListArray::<i64>::default_datatype(values.data_type().clone());
-                // Safety:
-                // offsets are monotonically increasing
-                let arr = unsafe {
-                    Box::new(ListArray::<i64>::new(
-                        data_type,
-                        Offsets::new_unchecked(offsets).into(),
-                        values,
-                        None,
-                    )) as ArrayRef
-                };
-                let mut ca = unsafe { ListChunked::from_chunks(&new_name, vec![arr]) };
+                // SAFETY: offsets are monotonically increasing.
+                let arr = ListArray::<i64>::new(
+                    data_type,
+                    unsafe { Offsets::new_unchecked(offsets).into() },
+                    values,
+                    None,
+                );
+                let mut ca = ListChunked::from_chunk_iter(&new_name, [arr]);
                 if can_fast_explode {
                     ca.set_fast_explode()
                 }

--- a/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
+++ b/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
@@ -9,13 +9,10 @@ pub fn replace_time_zone(
     let out: PolarsResult<_> = {
         let from = ca.time_zone().as_deref().unwrap_or("UTC");
         let to = time_zone.unwrap_or("UTC");
-        let chunks = ca
-            .downcast_iter()
-            .map(|arr| {
-                replace_time_zone_kernel(arr, ca.time_unit().to_arrow(), from, to, use_earliest)
-            })
-            .collect::<PolarsResult<_>>()?;
-        let out = unsafe { ChunkedArray::from_chunks(ca.name(), chunks) };
+        let chunks = ca.downcast_iter().map(|arr| {
+            replace_time_zone_kernel(arr, ca.time_unit().to_arrow(), from, to, use_earliest)
+        });
+        let out = ChunkedArray::try_from_chunk_iter(ca.name(), chunks)?;
         Ok(out.into_datetime(ca.time_unit(), time_zone.map(|x| x.to_string())))
     };
     let mut out = out?;

--- a/crates/polars-ops/src/chunked_array/interpolate.rs
+++ b/crates/polars-ops/src/chunked_array/interpolate.rs
@@ -88,17 +88,17 @@ where
     T: PolarsNumericType,
     I: Fn(T::Native, T::Native, IdxSize, T::Native, &mut Vec<T::Native>),
 {
-    // This implementation differs from pandas as that boundary None's are not removed
-    // this prevents a lot of errors due to expressions leading to different lengths
+    // This implementation differs from pandas as that boundary None's are not removed.
+    // This prevents a lot of errors due to expressions leading to different lengths.
     if !chunked_arr.has_validity() || chunked_arr.null_count() == chunked_arr.len() {
         return chunked_arr.clone();
     }
 
-    // we first find the first and last so that we can set the null buffer
+    // We first find the first and last so that we can set the null buffer.
     let first = chunked_arr.first_non_null().unwrap();
     let last = chunked_arr.last_non_null().unwrap() + 1;
 
-    // fill av with first
+    // Fill av with first.
     let mut av = Vec::with_capacity(chunked_arr.len());
     let mut iter = chunked_arr.into_iter();
     for _ in 0..first {
@@ -115,18 +115,14 @@ where
             }
             Some(None) => {
                 match low_val {
-                    // not a non-null value encountered yet
-                    // so we skip
-                    None => continue,
+                    None => continue, // Not a non-null value encountered yet so we skip.
                     Some(low) => {
                         let mut steps = 1 as IdxSize;
                         loop {
                             steps += 1;
                             match iter.next() {
-                                // end of iterator, break
-                                None => break,
-                                // another null
-                                Some(None) => {}
+                                None => break,   // End of iterator, break.
+                                Some(None) => {} // Another null.
                                 Some(Some(high)) => {
                                     let steps_n: T::Native = NumCast::from(steps).unwrap();
                                     interpolation_branch(low, high, steps, steps_n, &mut av);
@@ -159,7 +155,7 @@ where
 
         let array =
             PrimitiveArray::new(T::get_dtype().to_arrow(), av.into(), Some(validity.into()));
-        unsafe { ChunkedArray::from_chunks(chunked_arr.name(), vec![Box::new(array)]) }
+        ChunkedArray::from_chunk_iter(chunked_arr.name(), Some(array))
     } else {
         ChunkedArray::from_vec(chunked_arr.name(), av)
     }

--- a/crates/polars-ops/src/chunked_array/interpolate.rs
+++ b/crates/polars-ops/src/chunked_array/interpolate.rs
@@ -155,7 +155,7 @@ where
 
         let array =
             PrimitiveArray::new(T::get_dtype().to_arrow(), av.into(), Some(validity.into()));
-        ChunkedArray::from_chunk_iter(chunked_arr.name(), Some(array))
+        ChunkedArray::from_chunk_iter(chunked_arr.name(), [array])
     } else {
         ChunkedArray::from_vec(chunked_arr.name(), av)
     }

--- a/crates/polars-ops/src/chunked_array/list/any_all.rs
+++ b/crates/polars-ops/src/chunked_array/list/any_all.rs
@@ -1,8 +1,9 @@
 use arrow::array::{BooleanArray, ListArray};
+use arrow::bitmap::MutableBitmap;
 
 use super::*;
 
-fn list_all_any<F>(arr: &ListArray<i64>, op: F, is_all: bool) -> PolarsResult<ArrayRef>
+fn list_all_any<F>(arr: &ListArray<i64>, op: F, is_all: bool) -> PolarsResult<BooleanArray>
 where
     F: Fn(&BooleanArray) -> bool,
 {
@@ -14,13 +15,12 @@ where
     let values = values.as_any().downcast_ref::<BooleanArray>().unwrap();
     let validity = arr.validity().cloned();
 
-    // fast path where all values set
-    // all is free
+    // Fast path where all values set (all is free).
     let all_set = arrow::compute::boolean::all(values);
     if all_set && is_all {
-        return Ok(BooleanChunked::full("", true, arr.len()).chunks()[0]
-            .clone()
-            .with_validity(validity));
+        let mut bits = MutableBitmap::with_capacity(arr.len());
+        bits.extend_constant(arr.len(), true);
+        return Ok(BooleanArray::from_data_default(bits.into(), None).with_validity(validity));
     }
 
     let mut start = offsets[0] as usize;
@@ -28,31 +28,26 @@ where
         let end = end as usize;
         let len = end - start;
         // TODO!
-        // we can speed this upp if the boolean array doesn't have nulls
+        // We can speed this upp if the boolean array doesn't have nulls
         // Then we can work directly on the byte slice.
         let val = unsafe { values.clone().sliced_unchecked(start, len) };
         start = end;
         op(&val)
     });
 
-    Ok(Box::new(
-        BooleanArray::from_trusted_len_values_iter(iter).with_validity(validity),
-    ))
+    Ok(BooleanArray::from_trusted_len_values_iter(iter).with_validity(validity))
 }
 
 pub(super) fn list_all(ca: &ListChunked) -> PolarsResult<Series> {
     let chunks = ca
         .downcast_iter()
-        .map(|arr| list_all_any(arr, arrow::compute::boolean::all, true))
-        .collect::<PolarsResult<Vec<_>>>()?;
-
-    unsafe { Ok(BooleanChunked::from_chunks(ca.name(), chunks).into_series()) }
+        .map(|arr| list_all_any(arr, arrow::compute::boolean::all, true));
+    Ok(BooleanChunked::try_from_chunk_iter(ca.name(), chunks)?.into_series())
 }
+
 pub(super) fn list_any(ca: &ListChunked) -> PolarsResult<Series> {
     let chunks = ca
         .downcast_iter()
-        .map(|arr| list_all_any(arr, arrow::compute::boolean::any, false))
-        .collect::<PolarsResult<Vec<_>>>()?;
-
-    unsafe { Ok(BooleanChunked::from_chunks(ca.name(), chunks).into_series()) }
+        .map(|arr| list_all_any(arr, arrow::compute::boolean::any, false));
+    Ok(BooleanChunked::try_from_chunk_iter(ca.name(), chunks)?.into_series())
 }

--- a/crates/polars-ops/src/chunked_array/nan_propagating_aggregate.rs
+++ b/crates/polars-ops/src/chunked_array/nan_propagating_aggregate.rs
@@ -144,7 +144,7 @@ where
                         _,
                     >(values, validity, offset_iter, None),
                 };
-                ChunkedArray::from_chunks("", vec![arr]).into_series()
+                ChunkedArray::from_chunk_iter("", [arr]).into_series()
             } else {
                 _agg_helper_slice::<T, _>(groups_slice, |[first, len]| {
                     debug_assert!(len <= ca.len() as IdxSize);
@@ -216,7 +216,7 @@ where
                         _,
                     >(values, validity, offset_iter, None),
                 };
-                ChunkedArray::from_chunks("", vec![arr]).into_series()
+                ChunkedArray::from_chunk_iter("", [arr]).into_series()
             } else {
                 _agg_helper_slice::<T, _>(groups_slice, |[first, len]| {
                     debug_assert!(len <= ca.len() as IdxSize);

--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "extract_groups")]
 use arrow::array::StructArray;
-use arrow::array::{Array, MutableArray, MutableUtf8Array, Utf8Array};
+use arrow::array::{MutableArray, MutableUtf8Array, Utf8Array};
 use polars_core::export::regex::Regex;
 
 use super::*;

--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -101,9 +101,8 @@ pub(super) fn extract_group(
     group_index: usize,
 ) -> PolarsResult<Utf8Chunked> {
     let reg = Regex::new(pat)?;
-    ChunkedArray::try_from_chunk_iter(
-        ca.name(),
-        ca.downcast_iter()
-            .map(|array| extract_group_array(array, &reg, group_index)),
-    )
+    let chunks = ca
+        .downcast_iter()
+        .map(|array| extract_group_array(array, &reg, group_index));
+    ChunkedArray::try_from_chunk_iter(ca.name(), chunks)
 }

--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -101,12 +101,9 @@ pub(super) fn extract_group(
     group_index: usize,
 ) -> PolarsResult<Utf8Chunked> {
     let reg = Regex::new(pat)?;
-
-    let chunks = ca
-        .downcast_iter()
-        .map(|array| Ok(extract_group_array(array, &reg, group_index)?.to_boxed()))
-        .collect::<PolarsResult<Vec<Box<dyn Array>>>>()?;
-
-    // SAFETY: all chunks have type Utf8Array
-    unsafe { Ok(ChunkedArray::from_chunks(ca.name(), chunks)) }
+    ChunkedArray::try_from_chunk_iter(
+        ca.name(),
+        ca.downcast_iter()
+            .map(|array| extract_group_array(array, &reg, group_index)),
+    )
 }

--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "extract_groups")]
-use arrow::array::StructArray;
+use arrow::array::{Array, StructArray};
 use arrow::array::{MutableArray, MutableUtf8Array, Utf8Array};
 use polars_core::export::regex::Regex;
 

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -403,7 +403,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
             .downcast_iter()
             .map(|c| substring(c, start, &length))
             .collect::<arrow::error::Result<_>>()?;
-
+        // SAFETY: these are all the same type.
         unsafe { Ok(Utf8Chunked::from_chunks(ca.name(), chunks)) }
     }
 }

--- a/crates/polars-ops/src/series/ops/floor_divide.rs
+++ b/crates/polars-ops/src/series/ops/floor_divide.rs
@@ -1,6 +1,5 @@
 use arrow::array::{Array, PrimitiveArray};
 use num::NumCast;
-use polars_arrow::prelude::ArrayRef;
 use polars_arrow::utils::combine_validities_and;
 use polars_core::datatypes::PolarsNumericType;
 use polars_core::export::num;
@@ -85,11 +84,8 @@ fn floor_div_ca<T: PolarsNumericType>(a: &ChunkedArray<T>, b: &ChunkedArray<T>) 
     let chunks = a
         .downcast_iter()
         .zip(b.downcast_iter())
-        .map(|(a, b)| Box::new(floor_div_array(a, b)) as ArrayRef)
-        .collect();
-
-    // safety: same dtypes
-    unsafe { ChunkedArray::from_chunks(a.name(), chunks) }
+        .map(|(a, b)| floor_div_array(a, b));
+    ChunkedArray::from_chunk_iter(a.name(), chunks)
 }
 
 pub fn floor_div_series(a: &Series, b: &Series) -> PolarsResult<Series> {

--- a/crates/polars-ops/src/series/ops/fused.rs
+++ b/crates/polars-ops/src/series/ops/fused.rs
@@ -1,5 +1,4 @@
 use arrow::array::PrimitiveArray;
-use polars_arrow::prelude::ArrayRef;
 use polars_arrow::utils::combine_validities_and;
 use polars_core::prelude::*;
 use polars_core::utils::align_chunks_ternary;
@@ -37,16 +36,12 @@ fn fma_ca<T: PolarsNumericType>(
     c: &ChunkedArray<T>,
 ) -> ChunkedArray<T> {
     let (a, b, c) = align_chunks_ternary(a, b, c);
-
     let chunks = a
         .downcast_iter()
         .zip(b.downcast_iter())
         .zip(c.downcast_iter())
-        .map(|((a, b), c)| Box::new(fma_arr(a, b, c)) as ArrayRef)
-        .collect();
-
-    // safety: same dtypes
-    unsafe { ChunkedArray::from_chunks(a.name(), chunks) }
+        .map(|((a, b), c)| fma_arr(a, b, c));
+    ChunkedArray::from_chunk_iter(a.name(), chunks)
 }
 
 pub fn fma_series(a: &Series, b: &Series, c: &Series) -> Series {
@@ -95,16 +90,12 @@ fn fsm_ca<T: PolarsNumericType>(
     c: &ChunkedArray<T>,
 ) -> ChunkedArray<T> {
     let (a, b, c) = align_chunks_ternary(a, b, c);
-
     let chunks = a
         .downcast_iter()
         .zip(b.downcast_iter())
         .zip(c.downcast_iter())
-        .map(|((a, b), c)| Box::new(fsm_arr(a, b, c)) as ArrayRef)
-        .collect();
-
-    // safety: same dtypes
-    unsafe { ChunkedArray::from_chunks(a.name(), chunks) }
+        .map(|((a, b), c)| fsm_arr(a, b, c));
+    ChunkedArray::from_chunk_iter(a.name(), chunks)
 }
 
 pub fn fsm_series(a: &Series, b: &Series, c: &Series) -> Series {
@@ -152,16 +143,12 @@ fn fms_ca<T: PolarsNumericType>(
     c: &ChunkedArray<T>,
 ) -> ChunkedArray<T> {
     let (a, b, c) = align_chunks_ternary(a, b, c);
-
     let chunks = a
         .downcast_iter()
         .zip(b.downcast_iter())
         .zip(c.downcast_iter())
-        .map(|((a, b), c)| Box::new(fms_arr(a, b, c)) as ArrayRef)
-        .collect();
-
-    // safety: same dtypes
-    unsafe { ChunkedArray::from_chunks(a.name(), chunks) }
+        .map(|((a, b), c)| fms_arr(a, b, c));
+    ChunkedArray::from_chunk_iter(a.name(), chunks)
 }
 
 pub fn fms_series(a: &Series, b: &Series, c: &Series) -> Series {

--- a/crates/polars-ops/src/series/ops/is_first.rs
+++ b/crates/polars-ops/src/series/ops/is_first.rs
@@ -45,7 +45,7 @@ fn is_first_boolean(ca: &BooleanChunked) -> BooleanChunked {
     }
 
     let arr = BooleanArray::new(ArrowDataType::Boolean, out.into(), None);
-    BooleanChunked::from_chunk_iter(ca.name(), Some(arr))
+    BooleanChunked::from_chunk_iter(ca.name(), [arr])
 }
 
 #[cfg(feature = "dtype-struct")]
@@ -61,7 +61,7 @@ fn is_first_struct(s: &Series) -> PolarsResult<BooleanChunked> {
     }
 
     let arr = BooleanArray::new(ArrowDataType::Boolean, out.into(), None);
-    Ok(BooleanChunked::from_chunk_iter(s.name(), Some(arr)))
+    Ok(BooleanChunked::from_chunk_iter(s.name(), [arr]))
 }
 
 pub fn is_first(s: &Series) -> PolarsResult<BooleanChunked> {

--- a/crates/polars-ops/src/series/ops/is_first.rs
+++ b/crates/polars-ops/src/series/ops/is_first.rs
@@ -16,32 +16,28 @@ where
     let mut unique = PlHashSet::new();
     let chunks = ca
         .downcast_iter()
-        .map(|arr| {
-            let mask: BooleanArray = arr
+        .map(|arr| -> BooleanArray {
+            arr
                 .into_iter()
                 .map(|opt_v| unique.insert(opt_v))
-                .collect_trusted();
-            Box::new(mask) as ArrayRef
-        })
-        .collect();
+                .collect_trusted()
+        });
 
-    unsafe { BooleanChunked::from_chunks(ca.name(), chunks) }
+    BooleanChunked::from_chunk_iter(ca.name(), chunks)
 }
 
 fn is_first_bin(ca: &BinaryChunked) -> BooleanChunked {
     let mut unique = PlHashSet::new();
     let chunks = ca
         .downcast_iter()
-        .map(|arr| {
-            let mask: BooleanArray = arr
+        .map(|arr| -> BooleanArray {
+            arr
                 .into_iter()
                 .map(|opt_v| unique.insert(opt_v))
-                .collect_trusted();
-            Box::new(mask) as ArrayRef
-        })
-        .collect();
+                .collect_trusted()
+        });
 
-    unsafe { BooleanChunked::from_chunks(ca.name(), chunks) }
+    BooleanChunked::from_chunk_iter(ca.name(), chunks)
 }
 
 fn is_first_boolean(ca: &BooleanChunked) -> BooleanChunked {
@@ -54,9 +50,8 @@ fn is_first_boolean(ca: &BooleanChunked) -> BooleanChunked {
         out.set(index, true)
     }
 
-    let chunks =
-        vec![Box::new(BooleanArray::new(ArrowDataType::Boolean, out.into(), None)) as ArrayRef];
-    unsafe { BooleanChunked::from_chunks(ca.name(), chunks) }
+    let arr = BooleanArray::new(ArrowDataType::Boolean, out.into(), None);
+    BooleanChunked::from_chunk_iter(ca.name(), Some(arr))
 }
 
 #[cfg(feature = "dtype-struct")]
@@ -70,9 +65,9 @@ fn is_first_struct(s: &Series) -> PolarsResult<BooleanChunked> {
         // Group tuples are always in bounds
         unsafe { out.set_unchecked(idx as usize, true) }
     }
-    let chunks =
-        vec![Box::new(BooleanArray::new(ArrowDataType::Boolean, out.into(), None)) as ArrayRef];
-    Ok(unsafe { BooleanChunked::from_chunks(s.name(), chunks) })
+
+    let arr = BooleanArray::new(ArrowDataType::Boolean, out.into(), None);
+    Ok(BooleanChunked::from_chunk_iter(s.name(), Some(arr)))
 }
 
 pub fn is_first(s: &Series) -> PolarsResult<BooleanChunked> {

--- a/crates/polars-ops/src/series/ops/is_first.rs
+++ b/crates/polars-ops/src/series/ops/is_first.rs
@@ -14,28 +14,22 @@ where
     T::Native: Hash + Eq,
 {
     let mut unique = PlHashSet::new();
-    let chunks = ca
-        .downcast_iter()
-        .map(|arr| -> BooleanArray {
-            arr
-                .into_iter()
-                .map(|opt_v| unique.insert(opt_v))
-                .collect_trusted()
-        });
+    let chunks = ca.downcast_iter().map(|arr| -> BooleanArray {
+        arr.into_iter()
+            .map(|opt_v| unique.insert(opt_v))
+            .collect_trusted()
+    });
 
     BooleanChunked::from_chunk_iter(ca.name(), chunks)
 }
 
 fn is_first_bin(ca: &BinaryChunked) -> BooleanChunked {
     let mut unique = PlHashSet::new();
-    let chunks = ca
-        .downcast_iter()
-        .map(|arr| -> BooleanArray {
-            arr
-                .into_iter()
-                .map(|opt_v| unique.insert(opt_v))
-                .collect_trusted()
-        });
+    let chunks = ca.downcast_iter().map(|arr| -> BooleanArray {
+        arr.into_iter()
+            .map(|opt_v| unique.insert(opt_v))
+            .collect_trusted()
+    });
 
     BooleanChunked::from_chunk_iter(ca.name(), chunks)
 }

--- a/crates/polars-ops/src/series/ops/is_unique.rs
+++ b/crates/polars-ops/src/series/ops/is_unique.rs
@@ -35,7 +35,7 @@ where
         unsafe { values.set_unchecked(idx as usize, setter) }
     }
     let arr = BooleanArray::from_data_default(values.into(), None);
-    BooleanChunked::from_chunk_iter(ca.name(), Some(arr))
+    BooleanChunked::from_chunk_iter(ca.name(), [arr])
 }
 
 fn dispatcher(s: &Series, invert: bool) -> PolarsResult<BooleanChunked> {

--- a/crates/polars-ops/src/series/ops/is_unique.rs
+++ b/crates/polars-ops/src/series/ops/is_unique.rs
@@ -5,7 +5,7 @@ use arrow::bitmap::MutableBitmap;
 use polars_core::prelude::*;
 use polars_core::with_match_physical_integer_polars_type;
 
-// if invert then this is an `is_duplicated`.
+// If invert is true then this is an `is_duplicated`.
 fn is_unique_ca<'a, T>(ca: &'a ChunkedArray<T>, invert: bool) -> BooleanChunked
 where
     T: PolarsDataType,
@@ -15,8 +15,8 @@ where
     let len = ca.len();
     let mut idx_key = PlHashMap::new();
 
-    // instead of grouptuples, which allocates a full vec per group, we now just toggle a boolean
-    // that's false if a group has multiple entries.
+    // Instead of group_tuples, which allocates a full Vec per group, we now
+    // just toggle a boolean that's false if a group has multiple entries.
     ca.into_iter().enumerate().for_each(|(idx, key)| {
         idx_key
             .entry(key)
@@ -28,16 +28,14 @@ where
         .into_iter()
         .filter_map(|(_k, v)| if v.1 { Some(v.0) } else { None });
 
-    let mut values = MutableBitmap::with_capacity(len);
-
     let (default, setter) = if invert { (true, false) } else { (false, true) };
+    let mut values = MutableBitmap::with_capacity(len);
     values.extend_constant(len, default);
-
     for idx in unique_idx {
         unsafe { values.set_unchecked(idx as usize, setter) }
     }
     let arr = BooleanArray::from_data_default(values.into(), None);
-    unsafe { BooleanChunked::from_chunks(ca.name(), vec![Box::new(arr)]) }
+    BooleanChunked::from_chunk_iter(ca.name(), Some(arr))
 }
 
 fn dispatcher(s: &Series, invert: bool) -> PolarsResult<BooleanChunked> {

--- a/crates/polars-plan/src/dsl/function_expr/arg_where.rs
+++ b/crates/polars-plan/src/dsl/function_expr/arg_where.rs
@@ -32,11 +32,7 @@ pub(super) fn arg_where(s: &mut [Series]) -> PolarsResult<Option<Series>> {
 
             total_offset += arr.len();
         });
-        let arr = Box::new(IdxArr::from_vec(out)) as ArrayRef;
-        unsafe {
-            Ok(Some(
-                IdxCa::from_chunks(predicate.name(), vec![arr]).into_series(),
-            ))
-        }
+        let ca = IdxCa::from_chunk_iter(predicate.name(), Some(IdxArr::from_vec(out)));
+        Ok(Some(ca.into_series()))
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/arg_where.rs
+++ b/crates/polars-plan/src/dsl/function_expr/arg_where.rs
@@ -32,7 +32,7 @@ pub(super) fn arg_where(s: &mut [Series]) -> PolarsResult<Option<Series>> {
 
             total_offset += arr.len();
         });
-        let ca = IdxCa::from_chunk_iter(predicate.name(), Some(IdxArr::from_vec(out)));
+        let ca = IdxCa::from_chunk_iter(predicate.name(), [IdxArr::from_vec(out)]);
         Ok(Some(ca.into_series()))
     }
 }

--- a/crates/polars-time/src/chunkedarray/datetime.rs
+++ b/crates/polars-time/src/chunkedarray/datetime.rs
@@ -15,20 +15,18 @@ fn cast_and_apply<
     func: F,
 ) -> ChunkedArray<T> {
     let dtype = ca.dtype().to_arrow();
-    let chunks = ca
-        .downcast_iter()
-        .map(|arr| {
-            let arr = cast(
-                arr,
-                &dtype,
-                CastOptions {
-                    wrapped: true,
-                    partial: false,
-                },
-            )
-            .unwrap();
-            func(&*arr).unwrap()
-        });
+    let chunks = ca.downcast_iter().map(|arr| {
+        let arr = cast(
+            arr,
+            &dtype,
+            CastOptions {
+                wrapped: true,
+                partial: false,
+            },
+        )
+        .unwrap();
+        func(&*arr).unwrap()
+    });
     ChunkedArray::from_chunk_iter(ca.name(), chunks)
 }
 

--- a/crates/polars-time/src/chunkedarray/datetime.rs
+++ b/crates/polars-time/src/chunkedarray/datetime.rs
@@ -27,11 +27,9 @@ fn cast_and_apply<
                 },
             )
             .unwrap();
-            Box::from(func(&*arr).unwrap()) as ArrayRef
-        })
-        .collect();
-
-    unsafe { ChunkedArray::from_chunks(ca.name(), chunks) }
+            func(&*arr).unwrap()
+        });
+    ChunkedArray::from_chunk_iter(ca.name(), chunks)
 }
 
 pub trait DatetimeMethods: AsDatetime {

--- a/crates/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/crates/polars-time/src/chunkedarray/utf8/infer.rs
@@ -371,17 +371,15 @@ impl<T: PolarsNumericType> DatetimeInfer<T> {
 
 impl<T: PolarsNumericType> DatetimeInfer<T>
 where
-    ChunkedArray<T>: IntoSeries
+    ChunkedArray<T>: IntoSeries,
 {
     fn coerce_utf8(&mut self, ca: &Utf8Chunked) -> Series {
-        let chunks = ca
-            .downcast_iter()
-            .map(|array| {
-                let iter = array
-                    .into_iter()
-                    .map(|opt_val| opt_val.and_then(|val| self.parse(val)));
-                PrimitiveArray::from_trusted_len_iter(iter)
-            });
+        let chunks = ca.downcast_iter().map(|array| {
+            let iter = array
+                .into_iter()
+                .map(|opt_val| opt_val.and_then(|val| self.parse(val)));
+            PrimitiveArray::from_trusted_len_iter(iter)
+        });
         let mut out = ChunkedArray::from_chunk_iter(ca.name(), chunks)
             .into_series()
             .cast(&self.logical_type)

--- a/crates/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/crates/polars-time/src/chunkedarray/utf8/infer.rs
@@ -2,7 +2,6 @@ use chrono::{DateTime, NaiveDate, NaiveDateTime};
 use once_cell::sync::Lazy;
 use polars_arrow::export::arrow::array::PrimitiveArray;
 use polars_core::prelude::*;
-use polars_core::utils::arrow::types::NativeType;
 use regex::Regex;
 
 use super::patterns::{self, Pattern};
@@ -141,7 +140,7 @@ pub trait StrpTimeParser<T> {
 }
 
 #[cfg(feature = "dtype-datetime")]
-impl StrpTimeParser<i64> for DatetimeInfer<i64> {
+impl StrpTimeParser<i64> for DatetimeInfer<Int64Type> {
     fn parse_bytes(&mut self, val: &[u8], time_unit: Option<TimeUnit>) -> Option<i64> {
         if self.fmt_len == 0 {
             self.fmt_len = strptime::fmt_len(self.latest_fmt.as_bytes())?;
@@ -179,7 +178,7 @@ impl StrpTimeParser<i64> for DatetimeInfer<i64> {
 }
 
 #[cfg(feature = "dtype-date")]
-impl StrpTimeParser<i32> for DatetimeInfer<i32> {
+impl StrpTimeParser<i32> for DatetimeInfer<Int32Type> {
     fn parse_bytes(&mut self, val: &[u8], _time_unit: Option<TimeUnit>) -> Option<i32> {
         if self.fmt_len == 0 {
             self.fmt_len = strptime::fmt_len(self.latest_fmt.as_bytes())?;
@@ -211,11 +210,11 @@ impl StrpTimeParser<i32> for DatetimeInfer<i32> {
 }
 
 #[derive(Clone)]
-pub struct DatetimeInfer<T> {
+pub struct DatetimeInfer<T: PolarsNumericType> {
     pub pattern: Pattern,
     patterns: &'static [&'static str],
     latest_fmt: &'static str,
-    transform: fn(&str, &str) -> Option<T>,
+    transform: fn(&str, &str) -> Option<T::Native>,
     transform_bytes: StrpTimeState,
     fmt_len: u16,
     pub logical_type: DataType,
@@ -227,7 +226,7 @@ pub trait TryFromWithUnit<T>: Sized {
 }
 
 #[cfg(feature = "dtype-datetime")]
-impl TryFromWithUnit<Pattern> for DatetimeInfer<i64> {
+impl TryFromWithUnit<Pattern> for DatetimeInfer<Int64Type> {
     type Error = PolarsError;
 
     fn try_from_with_unit(value: Pattern, time_unit: Option<TimeUnit>) -> PolarsResult<Self> {
@@ -320,7 +319,7 @@ impl TryFromWithUnit<Pattern> for DatetimeInfer<i64> {
 }
 
 #[cfg(feature = "dtype-date")]
-impl TryFromWithUnit<Pattern> for DatetimeInfer<i32> {
+impl TryFromWithUnit<Pattern> for DatetimeInfer<Int32Type> {
     type Error = PolarsError;
 
     fn try_from_with_unit(value: Pattern, _time_unit: Option<TimeUnit>) -> PolarsResult<Self> {
@@ -348,8 +347,8 @@ impl TryFromWithUnit<Pattern> for DatetimeInfer<i32> {
     }
 }
 
-impl<T: NativeType> DatetimeInfer<T> {
-    pub fn parse(&mut self, val: &str) -> Option<T> {
+impl<T: PolarsNumericType> DatetimeInfer<T> {
+    pub fn parse(&mut self, val: &str) -> Option<T::Native> {
         match (self.transform)(val, self.latest_fmt) {
             Some(parsed) => Some(parsed),
             // try other patterns
@@ -368,7 +367,12 @@ impl<T: NativeType> DatetimeInfer<T> {
             }
         }
     }
+}
 
+impl<T: PolarsNumericType> DatetimeInfer<T>
+where
+    ChunkedArray<T>: IntoSeries
+{
     fn coerce_utf8(&mut self, ca: &Utf8Chunked) -> Series {
         let chunks = ca
             .downcast_iter()
@@ -376,20 +380,12 @@ impl<T: NativeType> DatetimeInfer<T> {
                 let iter = array
                     .into_iter()
                     .map(|opt_val| opt_val.and_then(|val| self.parse(val)));
-                Box::new(PrimitiveArray::from_trusted_len_iter(iter)) as ArrayRef
-            })
-            .collect();
-        let mut out = match self.logical_type {
-            DataType::Date => unsafe { Int32Chunked::from_chunks(ca.name(), chunks) }
-                .into_series()
-                .cast(&self.logical_type)
-                .unwrap(),
-            DataType::Datetime(_, _) => unsafe { Int64Chunked::from_chunks(ca.name(), chunks) }
-                .into_series()
-                .cast(&self.logical_type)
-                .unwrap(),
-            _ => unreachable!(),
-        };
+                PrimitiveArray::from_trusted_len_iter(iter)
+            });
+        let mut out = ChunkedArray::from_chunk_iter(ca.name(), chunks)
+            .into_series()
+            .cast(&self.logical_type)
+            .unwrap();
         out.rename(ca.name());
         out
     }
@@ -509,7 +505,7 @@ pub(crate) fn to_datetime(
                 .into_iter()
                 .find_map(|opt_val| opt_val.and_then(infer_pattern_datetime_single))
                 .ok_or_else(|| polars_err!(parse_fmt_idk = "date"))?;
-            let mut infer = DatetimeInfer::<i64>::try_from_with_unit(pattern, Some(tu))?;
+            let mut infer = DatetimeInfer::<Int64Type>::try_from_with_unit(pattern, Some(tu))?;
             if pattern == Pattern::DatetimeYMDZ
                 && tz.is_some()
                 && tz.map(|x| x.as_str()) != Some("UTC")
@@ -548,7 +544,7 @@ pub(crate) fn to_date(ca: &Utf8Chunked) -> PolarsResult<DateChunked> {
                 .into_iter()
                 .find_map(|opt_val| opt_val.and_then(infer_pattern_date_single))
                 .ok_or_else(|| polars_err!(parse_fmt_idk = "date"))?;
-            let mut infer = DatetimeInfer::<i32>::try_from_with_unit(pattern, None).unwrap();
+            let mut infer = DatetimeInfer::<Int32Type>::try_from_with_unit(pattern, None).unwrap();
             infer.coerce_utf8(ca).date().cloned()
         }
     }

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -281,7 +281,7 @@ impl PySeries {
                     }
                     previous = o;
                 }
-                
+
                 // SAFETY: we checked the type in the downcast.
                 let mut out = unsafe { ListChunked::from_chunks(name, vec![arr]) };
                 if fast_explode {

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -281,6 +281,8 @@ impl PySeries {
                     }
                     previous = o;
                 }
+                
+                // SAFETY: we checked the type in the downcast.
                 let mut out = unsafe { ListChunked::from_chunks(name, vec![arr]) };
                 if fast_explode {
                     out.set_fast_explode()


### PR DESCRIPTION
This reduces the amount of unsafe needed by avoiding `from_chunks`.