### PR TITLE
chore(python): Clean up some `Sphinx` settings

### DIFF
--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -16,5 +16,4 @@ sphinx-copybutton==0.5.2
 sphinx-design[theme_pydata]==0.5.0
 sphinx-favicon==1.0.1
 
-commonmark==0.9.1
 livereload==2.6.3

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -11,9 +11,10 @@ sphinx==7.1.1
 # Third-party Sphinx extensions
 autodocsumm==0.2.11
 numpydoc==1.5.0
+pydata-sphinx-theme==0.13.3
 sphinx-autosummary-accessors==2023.4.0
 sphinx-copybutton==0.5.2
-sphinx-design[theme_pydata]==0.5.0
+sphinx-design==0.5.0
 sphinx-favicon==1.0.1
 
 livereload==2.6.3

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -11,12 +11,11 @@ sphinx==7.1.1
 # Third-party Sphinx extensions
 sphinx-autosummary-accessors==2023.4.0
 sphinx-copybutton==0.5.2
-sphinx-design==0.5.0
+sphinx-design[theme_pydata]==0.5.0
 sphinx-favicon==1.0.1
 
 autodocsumm==0.2.11
 commonmark==0.9.1
 livereload==2.6.3
 numpydoc==1.5.0
-pydata-sphinx-theme==0.13.3
 

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -20,6 +20,5 @@ sphinxcontrib-applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-napoleon==0.7
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -16,9 +16,9 @@ sphinx-autosummary-accessors==2023.4.0
 sphinx-copybutton==0.5.2
 sphinx-design==0.5.0
 sphinx-favicon==1.0.1
-sphinxcontrib-applehelp==1.0.4
-sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-applehelp==1.0.6
+sphinxcontrib-devhelp==1.0.4
+sphinxcontrib-htmlhelp==2.0.3
 sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.3
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-qthelp==1.0.5
+sphinxcontrib-serializinghtml==1.1.7

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -9,13 +9,12 @@ hypothesis==6.82.0
 sphinx==7.1.1
 
 # Third-party Sphinx extensions
+autodocsumm==0.2.11
+numpydoc==1.5.0
 sphinx-autosummary-accessors==2023.4.0
 sphinx-copybutton==0.5.2
 sphinx-design[theme_pydata]==0.5.0
 sphinx-favicon==1.0.1
 
-autodocsumm==0.2.11
 commonmark==0.9.1
 livereload==2.6.3
-numpydoc==1.5.0
-

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -16,9 +16,3 @@ sphinx-autosummary-accessors==2023.4.0
 sphinx-copybutton==0.5.2
 sphinx-design==0.5.0
 sphinx-favicon==1.0.1
-sphinxcontrib-applehelp==1.0.6
-sphinxcontrib-devhelp==1.0.4
-sphinxcontrib-htmlhelp==2.0.3
-sphinxcontrib-jsmath==1.0.1
-sphinxcontrib-qthelp==1.0.5
-sphinxcontrib-serializinghtml==1.1.7

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -6,13 +6,17 @@ pyarrow
 
 hypothesis==6.82.0
 
+sphinx==7.1.1
+
+# Third-party Sphinx extensions
+sphinx-autosummary-accessors==2023.4.0
+sphinx-copybutton==0.5.2
+sphinx-design==0.5.0
+sphinx-favicon==1.0.1
+
 autodocsumm==0.2.11
 commonmark==0.9.1
 livereload==2.6.3
 numpydoc==1.5.0
 pydata-sphinx-theme==0.13.3
-sphinx==7.1.1
-sphinx-autosummary-accessors==2023.4.0
-sphinx-copybutton==0.5.2
-sphinx-design==0.5.0
-sphinx-favicon==1.0.1
+

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -71,6 +71,34 @@ templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
 exclude_patterns = ["Thumbs.db", ".DS_Store"]
 
 
+# -- Extension settings  -----------------------------------------------------
+
+# sphinx.ext.intersphinx - link to other projects' documentation
+# https://www.sphinx-doc.org/en/master/usage/extensions/intersphinx.html
+intersphinx_mapping = {
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "pandas": ("https://pandas.pydata.org/docs/", None),
+    "pyarrow": ("https://arrow.apache.org/docs/", None),
+    "python": ("https://docs.python.org/3", None),
+}
+
+# sphinx.ext.napoleon - parse numpy docstrings
+# https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
+# Used in addition to numpydoc for stricter parsing requirements
+napoleon_numpy_docstring = True
+napoleon_google_docstring = False
+
+# numpydoc - parse numpy docstrings
+# https://numpydoc.readthedocs.io/en/latest/
+# Used in addition to Napoleon for nicer (more spacious) render of docstring sections
+numpydoc_show_class_members = False
+
+# Sphinx-copybutton - add copy button to code blocks
+# https://sphinx-copybutton.readthedocs.io/en/latest/index.html
+# strip the '>>>' and '...' prompt/continuation prefixes.
+copybutton_prompt_text = r">>> |\.\.\. "
+copybutton_prompt_is_regexp = True
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
@@ -85,13 +113,6 @@ html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]  # relative to html_static_path
 html_show_sourcelink = False
 
-# adds useful copy functionality to all the examples; also
-# strips the '>>>' and '...' prompt/continuation prefixes.
-copybutton_prompt_text = r">>> |\.\.\. "
-copybutton_prompt_is_regexp = True
-
-autosummary_generate = True
-numpydoc_show_class_members = False
 
 # key site root paths
 static_assets_root = "https://raw.githubusercontent.com/pola-rs/polars-static/master"
@@ -145,13 +166,6 @@ favicons = [
         "href": f"{static_assets_root}/icons/touchicon-180x180.png",
     },
 ]
-
-intersphinx_mapping = {
-    "numpy": ("https://numpy.org/doc/stable/", None),
-    "pandas": ("https://pandas.pydata.org/docs/", None),
-    "pyarrow": ("https://arrow.apache.org/docs/", None),
-    "python": ("https://docs.python.org/3", None),
-}
 
 
 def linkcode_resolve(domain, info):

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -48,6 +48,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.linkcode",
     "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     # ----------------------
     # third-party extensions

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -47,7 +47,6 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.linkcode",
     "sphinx.ext.mathjax",
-    "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     # ----------------------
     # third-party extensions
@@ -82,15 +81,9 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
 }
 
-# sphinx.ext.napoleon - parse numpy docstrings
-# https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
-# Used in addition to numpydoc for stricter parsing requirements
-napoleon_numpy_docstring = True
-napoleon_google_docstring = False
-
 # numpydoc - parse numpy docstrings
 # https://numpydoc.readthedocs.io/en/latest/
-# Used in addition to Napoleon for nicer (more spacious) render of docstring sections
+# Used in favor of sphinx.ext.napoleon for nicer render of docstring sections
 numpydoc_show_class_members = False
 
 # Sphinx-copybutton - add copy button to code blocks

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -10,7 +10,6 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-import datetime
 import inspect
 import os
 import re
@@ -27,7 +26,7 @@ sys.path.insert(0, str(Path("../..").resolve()))
 
 project = "Polars"
 author = "Ritchie Vink"
-copyright = f"{datetime.date.today().year}, {author}"
+copyright = f"2020, {author}"
 
 
 # -- General configuration ---------------------------------------------------

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -1,14 +1,5 @@
 # Configuration file for the Sphinx documentation builder.
-#
-# This file only contains a selection of the most common options. For a full
-# list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
-# -- Path setup --------------------------------------------------------------
-
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
 
 import inspect
 import os
@@ -19,7 +10,12 @@ from pathlib import Path
 
 import sphinx_autosummary_accessors
 
-# add polars directory
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here.
+
+# Add py-polars directory
 sys.path.insert(0, str(Path("../..").resolve()))
 
 # -- Project information -----------------------------------------------------
@@ -28,24 +24,16 @@ project = "Polars"
 author = "Ritchie Vink"
 copyright = f"2020, {author}"
 
-
 # -- General configuration ---------------------------------------------------
 
-# Add any Sphinx extension module names here, as strings. They can be
-# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
-# ones.
 extensions = [
-    # ----------------------
-    # sphinx extensions
-    # ----------------------
+    # Sphinx extensions
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.linkcode",
     "sphinx.ext.mathjax",
-    # ----------------------
-    # third-party extensions
-    # ----------------------
+    # Third-party extensions
     "autodocsumm",
     "numpydoc",
     "sphinx_autosummary_accessors",
@@ -65,7 +53,6 @@ templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["Thumbs.db", ".DS_Store"]
-
 
 # -- Extension settings  -----------------------------------------------------
 
@@ -91,9 +78,7 @@ copybutton_prompt_is_regexp = True
 
 # -- Options for HTML output -------------------------------------------------
 
-# The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes.
-
+# The theme to use for HTML and HTML Help pages.
 html_theme = "pydata_sphinx_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -40,14 +40,9 @@ extensions = [
     # ----------------------
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
-    "sphinx.ext.coverage",
-    "sphinx.ext.doctest",
-    "sphinx.ext.extlinks",
-    "sphinx.ext.ifconfig",
     "sphinx.ext.intersphinx",
     "sphinx.ext.linkcode",
     "sphinx.ext.mathjax",
-    "sphinx.ext.todo",
     # ----------------------
     # third-party extensions
     # ----------------------
@@ -61,7 +56,9 @@ extensions = [
 
 maximum_signature_line_length = 88
 
-# Add any paths that contain templates here, relative to this directory.
+# Below setting is used by
+# sphinx-autosummary-accessors - build docs for namespace accessors like `Series.str`
+# https://sphinx-autosummary-accessors.readthedocs.io/en/stable/
 templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
 
 # List of patterns, relative to source directory, that match files and
@@ -85,6 +82,7 @@ intersphinx_mapping = {
 # https://numpydoc.readthedocs.io/en/latest/
 # Used in favor of sphinx.ext.napoleon for nicer render of docstring sections
 numpydoc_show_class_members = False
+
 
 # Sphinx-copybutton - add copy button to code blocks
 # https://sphinx-copybutton.readthedocs.io/en/latest/index.html
@@ -161,6 +159,8 @@ favicons = [
 ]
 
 
+# sphinx-ext-linkcode - Add external links to source code
+# https://www.sphinx-doc.org/en/master/usage/extensions/linkcode.html
 def linkcode_resolve(domain, info):
     """
     Determine the URL corresponding to Python object.

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -83,7 +83,6 @@ intersphinx_mapping = {
 # Used in favor of sphinx.ext.napoleon for nicer render of docstring sections
 numpydoc_show_class_members = False
 
-
 # Sphinx-copybutton - add copy button to code blocks
 # https://sphinx-copybutton.readthedocs.io/en/latest/index.html
 # strip the '>>>' and '...' prompt/continuation prefixes.
@@ -103,7 +102,6 @@ html_theme = "pydata_sphinx_theme"
 html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]  # relative to html_static_path
 html_show_sourcelink = False
-
 
 # key site root paths
 static_assets_root = "https://raw.githubusercontent.com/pola-rs/polars-static/master"
@@ -145,6 +143,8 @@ html_theme_options = {
     },
 }
 
+# sphinx-favicon - Add support for custom favicons
+# https://github.com/tcmetzger/sphinx-favicon
 favicons = [
     {
         "rel": "icon",

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -1925,13 +1925,13 @@ class ExprDateTimeNameSpace:
             - 1y    (1 calendar year)
             - 1i    (1 index count)
 
-        Suffix with `"_saturating"` to indicate that dates too large for
-        their month should saturate at the largest date (e.g. 2022-02-29 -> 2022-02-28)
-        instead of erroring.
+            Suffix with `"_saturating"` to indicate that dates too large for
+            their month should saturate at the largest date
+            (e.g. 2022-02-29 -> 2022-02-28) instead of erroring.
 
-        By "calendar day", we mean the corresponding time on the next day (which may
-        not be 24 hours, due to daylight savings). Similarly for "calendar week",
-        "calendar month", "calendar quarter", and "calendar year".
+            By "calendar day", we mean the corresponding time on the next day (which may
+            not be 24 hours, due to daylight savings). Similarly for "calendar week",
+            "calendar month", "calendar quarter", and "calendar year".
 
         Returns
         -------
@@ -1989,6 +1989,7 @@ class ExprDateTimeNameSpace:
         │ 2004-01-31 00:00:00 │
         │ 2005-01-31 00:00:00 │
         └─────────────────────┘
+
         """
         return wrap_expr(self._pyexpr.dt_offset_by(by))
 

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -2065,6 +2065,7 @@ def from_epoch(
     Utility function that parses an epoch timestamp (or Unix time) to Polars Date(time).
 
     Depending on the `time_unit` provided, this function will return a different dtype:
+
     - time_unit="d" returns pl.Date
     - time_unit="s" returns pl.Datetime["us"] (pl.Datetime's default)
     - time_unit="ms" returns pl.Datetime["ms"]

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -58,13 +58,6 @@ def read_csv(
     """
     Read a CSV file into a DataFrame.
 
-    Notes
-    -----
-    This operation defaults to a `rechunk` operation at the end, meaning that
-    all data will be stored continuously in memory.
-    Set `rechunk=False` if you are benchmarking the csv-reader. A `rechunk` is
-    an expensive operation.
-
     Parameters
     ----------
     source
@@ -174,6 +167,13 @@ def read_csv(
     Returns
     -------
     DataFrame
+
+    Notes
+    -----
+    This operation defaults to a `rechunk` operation at the end, meaning that
+    all data will be stored continuously in memory.
+    Set `rechunk=False` if you are benchmarking the csv-reader. A `rechunk` is
+    an expensive operation.
 
     See Also
     --------

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -227,6 +227,7 @@ def scan_delta(
     <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html#variants>`__.
 
     Following type of table paths are supported,
+
     * az://<container>/<path>
     * adl://<container>/<path>
     * abfs[s]://<container>/<path>


### PR DESCRIPTION
Changes:
* Drop the deprecated `sphinxcontrib-napoleon` package. It was superseded by the Sphinx built-in `napoleon` extension, but we actually do not need this at all as the `numpydoc` extension already helps us parse numpy-style docstrings. `numpydoc` results in a bit nicer formatting, so we'll use that instead.
* Drop all the other `sphinxcontrib` packages, as they are required dependencies of the `Sphinx` package. No need to specify these transitive dependencies in our requirements.
* Drop the `commonmark` dependency as we do not use Markdown and it is deprecated anyway (superseded by [`markdown-it-py`](https://github.com/executablebooks/markdown-it-py)).
* Set copyright year to 2020 as per the LICENSE file.
* Add some links/explanations to the current Sphinx extension settings.
* Fix a few docstring formatting issues.