### PR TITLE
perf(python): optimise retrieval speed of values from `df.item` (~4-5x speedup)

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1792,7 +1792,11 @@ class DataFrame:
         elif row is None or column is None:
             raise ValueError("Cannot call '.item()' with only one of 'row' or 'column'")
 
-        return self[row, column]
+        return (
+            self._df.select_at_idx(column)
+            if isinstance(column, int)
+            else self._df.column(column)
+        ).get_idx(row)
 
     def to_arrow(self) -> pa.Table:
         """

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1787,7 +1787,7 @@ class DataFrame:
                     f"Can only call '.item()' if the dataframe is of shape (1,1), or if "
                     f"explicit row/col values are provided; frame has shape {self.shape}"
                 )
-            return self[0, 0]
+            return self._df.select_at_idx(0).get_idx(0)
 
         elif row is None or column is None:
             raise ValueError("Cannot call '.item()' with only one of 'row' or 'column'")


### PR DESCRIPTION
We can get a ~4-5x speedup on `df.item()` by avoiding the unnecessary indirection that comes by passing-through to `__getitem__`. Instead, we can get away with a single `isinstance` check before calling the underlying `PySeries` directly.

(Another way to frame it would be that the _intrinsic_ speed of value retrieval hasn't changed at all, but the latency associated with setting up the call and returning the resulting value has been significantly reduced ;)

## Timings
Before/after:
```
1.52 µs ± 12.8 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops)
 338 ns ± 1.21 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops)
```