### PR TITLE
refactor(rust): match_block_trailing_comma

### DIFF
--- a/crates/polars-arrow/src/array/list.rs
+++ b/crates/polars-arrow/src/array/list.rs
@@ -110,11 +110,11 @@ impl<'a> AnonymousBuilder<'a> {
                 None => {
                     let values = NullArray::new(DataType::Null, len).boxed();
                     (DataType::Null, values)
-                }
+                },
                 Some(inner_dtype) => {
                     let values = new_null_array(inner_dtype.clone(), len);
                     (inner_dtype.clone(), values)
-                }
+                },
             }
         } else {
             let inner_dtype = inner_dtype.unwrap_or_else(|| self.arrays[0].data_type());
@@ -187,7 +187,7 @@ pub fn convert_inner_type(array: &dyn Array, dtype: &DataType) -> Box<dyn Array>
                 array.validity().cloned(),
             )
             .boxed()
-        }
+        },
         DataType::Struct(fields) => {
             let array = array.as_any().downcast_ref::<StructArray>().unwrap();
             let inner = array.values();
@@ -197,7 +197,7 @@ pub fn convert_inner_type(array: &dyn Array, dtype: &DataType) -> Box<dyn Array>
                 .map(|(arr, field)| convert_inner_type(arr.as_ref(), field.data_type()))
                 .collect::<Vec<_>>();
             StructArray::new(dtype.clone(), new_values, array.validity().cloned()).boxed()
-        }
+        },
         _ => new_null_array(dtype.clone(), array.len()),
     }
 }

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -89,11 +89,11 @@ macro_rules! iter_to_values {
                     $validity.push(true);
                     $offsets.push($length_so_far);
                     Some(it)
-                }
+                },
                 None => {
                     $validity.push(false);
                     None
-                }
+                },
             })
             .flatten()
             .collect()
@@ -191,11 +191,11 @@ pub trait ListFromIter {
                     validity.push(true);
                     offsets.push(length_so_far);
                     Some(it)
-                }
+                },
                 None => {
                     validity.push(false);
                     None
-                }
+                },
             })
             .flatten()
             .trust_my_length(n_elements)
@@ -237,11 +237,11 @@ pub trait ListFromIter {
                     validity.push(true);
                     offsets.push(length_so_far);
                     Some(it)
-                }
+                },
                 None => {
                     validity.push(false);
                     None
-                }
+                },
             })
             .flatten()
             .trust_my_length(n_elements)

--- a/crates/polars-arrow/src/compute/cast.rs
+++ b/crates/polars-arrow/src/compute/cast.rs
@@ -8,7 +8,7 @@ pub fn cast(array: &dyn Array, to_type: &DataType) -> Result<Box<dyn Array>> {
         DataType::Decimal(precision, scale) if matches!(array.data_type(), DataType::LargeUtf8) => {
             let array = array.as_any().downcast_ref::<LargeStringArray>().unwrap();
             Ok(cast_utf8_to_decimal(array, Some(*precision), *scale))
-        }
+        },
         _ => arrow::compute::cast::cast(array, to_type, Default::default()),
     }
 }

--- a/crates/polars-arrow/src/compute/decimal.rs
+++ b/crates/polars-arrow/src/compute/decimal.rs
@@ -76,13 +76,13 @@ pub(super) fn deserialize_decimal(bytes: &[u8], precision: Option<u8>, scale: u8
                 return None;
             }
             atoi::<i128>(rhs)
-        }
+        },
         (Some(lhs), None) => {
             if lhs.len() > precision as usize || scale != 0 {
                 return None;
             }
             atoi::<i128>(lhs)
-        }
+        },
         (None, None) => None,
     }
 }

--- a/crates/polars-arrow/src/compute/take/boolean.rs
+++ b/crates/polars-arrow/src/compute/take/boolean.rs
@@ -50,11 +50,11 @@ unsafe fn take_values_indices_validity(
             debug_assert!(index < values.len());
             validity.push(values_validity.get_bit_unchecked(index));
             values_values.get_bit_unchecked(index)
-        }
+        },
         None => {
             validity.push(false);
             false
-        }
+        },
     });
     let values = Bitmap::from_trusted_len_iter(values);
     (values, validity.into())

--- a/crates/polars-arrow/src/compute/take/mod.rs
+++ b/crates/polars-arrow/src/compute/take/mod.rs
@@ -34,26 +34,26 @@ pub unsafe fn take_unchecked(arr: &dyn Array, idx: &IdxArr) -> ArrayRef {
         LargeUtf8 => {
             let arr = arr.as_any().downcast_ref().unwrap();
             take_utf8_unchecked(arr, idx)
-        }
+        },
         Boolean => {
             let arr = arr.as_any().downcast_ref().unwrap();
             Box::new(boolean::take_unchecked(arr, idx))
-        }
+        },
         #[cfg(feature = "dtype-array")]
         FixedSizeList => {
             let arr = arr.as_any().downcast_ref().unwrap();
             Box::new(fixed_size_list::take_unchecked(arr, idx))
-        }
+        },
         // TODO! implement proper unchecked version
         #[cfg(feature = "compute")]
         _ => {
             use arrow::compute::take::take;
             take(arr, idx).unwrap()
-        }
+        },
         #[cfg(not(feature = "compute"))]
         _ => {
             panic!("activate compute feature")
-        }
+        },
     }
 }
 

--- a/crates/polars-arrow/src/kernels/ewm/average.rs
+++ b/crates/polars-arrow/src/kernels/ewm/average.rs
@@ -44,7 +44,7 @@ where
                             old_wt = if adjust { old_wt + new_wt } else { T::one() };
                         }
                     }
-                }
+                },
             }
             match non_null_cnt < min_periods {
                 true => None,

--- a/crates/polars-arrow/src/kernels/ewm/variance.rs
+++ b/crates/polars-arrow/src/kernels/ewm/variance.rs
@@ -50,7 +50,7 @@ where
                         opt_mean_x = opt_x;
                         opt_mean_y = opt_y;
                     }
-                }
+                },
                 (_, Some(mean_x), Some(mean_y)) => {
                     if is_observation || !ignore_nulls {
                         sum_wt *= old_wt_factor;
@@ -92,13 +92,13 @@ where
                             }
                         }
                     }
-                }
+                },
                 _ => {
                     if is_observation {
                         opt_mean_x = opt_x;
                         opt_mean_y = opt_y;
                     }
-                }
+                },
             }
             match (non_na_cnt >= min_periods_fixed, bias) {
                 (false, _) => None,
@@ -114,7 +114,7 @@ where
                             None
                         }
                     }
-                }
+                },
                 (true, true) => Some(cov),
             }
         });

--- a/crates/polars-arrow/src/kernels/list_bytes_iter.rs
+++ b/crates/polars-arrow/src/kernels/list_bytes_iter.rs
@@ -27,7 +27,7 @@ unsafe fn bytes_iter<'a, T: NativeType>(
                 } else {
                     None
                 }
-            }
+            },
         }
     })
 }

--- a/crates/polars-arrow/src/kernels/mod.rs
+++ b/crates/polars-arrow/src/kernels/mod.rs
@@ -152,10 +152,10 @@ impl<'a> Iterator for MaskedSlicesIterator<'a> {
                         // iterating over chunks does not yield any new slice => continue to the next
                         self.current_bit = 0;
                         self.next()
-                    }
+                    },
                     other => other,
                 }
-            }
+            },
             State::Bits(mask) => {
                 match self.iterate_bits(mask, 64) {
                     None => {
@@ -163,10 +163,10 @@ impl<'a> Iterator for MaskedSlicesIterator<'a> {
                         // to chunks and continue to the next
                         self.state = State::Chunks;
                         self.next()
-                    }
+                    },
                     other => other,
                 }
-            }
+            },
             State::Remainder => match self.iterate_bits(self.remainder_mask, self.remainder_len) {
                 None => {
                     self.state = State::Finish;
@@ -175,7 +175,7 @@ impl<'a> Iterator for MaskedSlicesIterator<'a> {
                     } else {
                         None
                     }
-                }
+                },
                 other => other,
             },
             State::Finish => None,
@@ -236,23 +236,23 @@ impl<'a> Iterator for BinaryMaskedSliceIterator<'a> {
                                 self.filled = high;
                                 Some((low, high, true))
                             }
-                        }
+                        },
                         None => {
                             self.state = Finish;
                             Some((self.filled, self.slice_iter.total_len, false))
-                        }
+                        },
                     }
                 } else {
                     self.filled = self.high;
                     self.state = LastTrue;
                     Some((self.low, self.high, true))
                 }
-            }
+            },
             LastFalse => {
                 self.state = LastTrue;
                 self.filled = self.high;
                 Some((self.low, self.high, true))
-            }
+            },
             LastTrue => match self.slice_iter.next() {
                 Some((low, high)) => {
                     self.low = low;
@@ -261,7 +261,7 @@ impl<'a> Iterator for BinaryMaskedSliceIterator<'a> {
                     let last_filled = self.filled;
                     self.filled = low;
                     Some((last_filled, low, false))
-                }
+                },
                 None => {
                     self.state = Finish;
                     if self.filled != self.slice_iter.total_len {
@@ -269,7 +269,7 @@ impl<'a> Iterator for BinaryMaskedSliceIterator<'a> {
                     } else {
                         None
                     }
-                }
+                },
             },
             Finish => None,
         }

--- a/crates/polars-arrow/src/kernels/rolling/no_nulls/mean.rs
+++ b/crates/polars-arrow/src/kernels/rolling/no_nulls/mean.rs
@@ -65,6 +65,6 @@ where
                 no_nulls::compute_sum_weights,
                 &wts,
             )
-        }
+        },
     }
 }

--- a/crates/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
+++ b/crates/polars-arrow/src/kernels/rolling/no_nulls/min_max.rs
@@ -187,7 +187,7 @@ macro_rules! minmax_window {
                         } else {
                             self.update_m_and_m_idx(pm);
                         }
-                    }
+                    },
                     (Some(pm), None) => self.update_m_and_m_idx(pm),
                     (None, Some(em)) => self.update_m_and_m_idx(em),
                     // This would mean both the entering and previous windows are empty
@@ -275,7 +275,7 @@ macro_rules! rolling_minmax_func {
                         $wtd_f,
                         &weights,
                     )
-                }
+                },
             }
         }
     };

--- a/crates/polars-arrow/src/kernels/rolling/no_nulls/quantile.rs
+++ b/crates/polars-arrow/src/kernels/rolling/no_nulls/quantile.rs
@@ -48,7 +48,7 @@ impl<
             | QuantileInterpolOptions::Midpoint
             | QuantileInterpolOptions::Linear => {
                 ((length as f64 - 1.0) * self.prob).floor() as usize
-            }
+            },
             QuantileInterpolOptions::Higher => ((length as f64 - 1.0) * self.prob).ceil() as usize,
         };
 
@@ -69,7 +69,7 @@ impl<
 
                     (mid + mid_plus_1) / T::from::<f64>(2.0f64).unwrap()
                 }
-            }
+            },
             QuantileInterpolOptions::Linear => {
                 let float_idx = (length as f64 - 1.0) * self.prob;
                 let top_idx = f64::ceil(float_idx) as usize;
@@ -82,12 +82,12 @@ impl<
                     let proportion = T::from(float_idx - idx as f64).unwrap();
                     proportion * (vals[top_idx] - vals[idx]) + vals[idx]
                 }
-            }
+            },
             _ => {
                 // safety
                 // we are in bounds
                 unsafe { *vals.get_unchecked(idx) }
-            }
+            },
         }
     }
 }
@@ -144,7 +144,7 @@ where
                 weights,
                 wsum,
             ))
-        }
+        },
     }
 }
 
@@ -186,12 +186,12 @@ where
             } else {
                 vk
             }
-        }
+        },
         (_, Midpoint) => (vk + v_old) * NumCast::from(0.5).unwrap(),
         // This is seemingly the canonical way to do it.
         (_, Linear) => {
             v_old + <T as NumCast>::from((h - s_old) / (s - s_old)).unwrap() * (vk - v_old)
-        }
+        },
     }
 }
 

--- a/crates/polars-arrow/src/kernels/rolling/no_nulls/sum.rs
+++ b/crates/polars-arrow/src/kernels/rolling/no_nulls/sum.rs
@@ -103,7 +103,7 @@ where
                 no_nulls::compute_sum_weights,
                 &weights,
             )
-        }
+        },
         (false, Some(weights)) => {
             let weights = no_nulls::coerce_weights(weights);
             no_nulls::rolling_apply_weights(
@@ -114,7 +114,7 @@ where
                 no_nulls::compute_sum_weights,
                 &weights,
             )
-        }
+        },
     }
 }
 

--- a/crates/polars-arrow/src/kernels/rolling/no_nulls/variance.rs
+++ b/crates/polars-arrow/src/kernels/rolling/no_nulls/variance.rs
@@ -185,7 +185,7 @@ where
                 compute_var_weights,
                 &wts,
             )
-        }
+        },
     }
 }
 

--- a/crates/polars-arrow/src/kernels/rolling/nulls/min_max.rs
+++ b/crates/polars-arrow/src/kernels/rolling/nulls/min_max.rs
@@ -12,20 +12,20 @@ pub fn is_reverse_sorted_max_nulls<T: NativeType + PartialOrd + IsFloat>(
     for opt_v in ZipValidityIter::new(values.iter(), validity.iter()) {
         match (current_max, opt_v) {
             // do nothing
-            (None, None) => {}
+            (None, None) => {},
             (None, Some(v)) => current_max = Some(*v),
             (Some(current), Some(val)) => {
                 match compare_fn_nan_min(&current, val) {
                     Ordering::Greater => {
                         current_max = Some(*val);
-                    }
+                    },
                     // allowed
-                    Ordering::Equal => {}
+                    Ordering::Equal => {},
                     // not sorted
                     Ordering::Less => return false,
                 }
-            }
-            (Some(_current), None) => {}
+            },
+            (Some(_current), None) => {},
         }
     }
 
@@ -131,7 +131,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> MinMaxWindow<'a, T> {
                     None => extremum_in_between = Some(*value),
                     Some(current) => {
                         extremum_in_between = Some((self.take_extremum)(*value, current))
-                    }
+                    },
                 }
             }
         }
@@ -230,7 +230,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> MinMaxWindow<'a, T> {
 
         match (self.extremum, entering_extremum) {
             // all remains `None`
-            (None, None) => {}
+            (None, None) => {},
             (None, Some(new_min)) => self.extremum = Some(new_min),
             // entering min is `None` and the `min` is leaving, so the `in_between` min is the new
             // minimum.
@@ -239,12 +239,12 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> MinMaxWindow<'a, T> {
                 if recompute_extremum {
                     self.extremum = self.compute_extremum_in_between_leaving_and_entering(start);
                 }
-            }
+            },
             (Some(current_extremum), Some(entering_extremum)) => {
                 if recompute_extremum {
                     match (self.compare_fn_nan)(&current_extremum, &entering_extremum) {
                         // do nothing
-                        Ordering::Equal => {}
+                        Ordering::Equal => {},
                         // leaving < entering
                         ord if ord == self.agg_ordering => {
                             // leaving value could be the smallest, we might need to recompute
@@ -263,9 +263,9 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> MinMaxWindow<'a, T> {
                                     } else {
                                         self.extremum = Some(entering_extremum)
                                     }
-                                }
+                                },
                             }
-                        }
+                        },
                         // leaving > entering
                         _ => {
                             if (self.compare_fn_nan)(&entering_extremum, &current_extremum)
@@ -273,14 +273,14 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> MinMaxWindow<'a, T> {
                             {
                                 self.extremum = Some(entering_extremum)
                             }
-                        }
+                        },
                     }
                 } else if (self.compare_fn_nan)(&entering_extremum, &current_extremum)
                     == self.agg_ordering
                 {
                     self.extremum = Some(entering_extremum)
                 }
-            }
+            },
         }
         self.last_start = start;
         self.last_end = end;

--- a/crates/polars-arrow/src/kernels/rolling/nulls/mod.rs
+++ b/crates/polars-arrow/src/kernels/rolling/nulls/mod.rs
@@ -55,7 +55,7 @@ where
             let mut validity = MutableBitmap::with_capacity(len);
             validity.extend_constant(len, true);
             validity
-        }
+        },
     };
 
     let out = (0..len)
@@ -73,12 +73,12 @@ where
                         unsafe { validity.set_unchecked(idx, false) };
                         T::default()
                     }
-                }
+                },
                 None => {
                     // safety: we are in bounds
                     unsafe { validity.set_unchecked(idx, false) };
                     T::default()
-                }
+                },
             }
         })
         .collect_trusted::<Vec<_>>();

--- a/crates/polars-arrow/src/kernels/rolling/nulls/quantile.rs
+++ b/crates/polars-arrow/src/kernels/rolling/nulls/quantile.rs
@@ -54,7 +54,7 @@ impl<
             | QuantileInterpolOptions::Midpoint
             | QuantileInterpolOptions::Linear => {
                 ((length as f64 - 1.0) * self.prob).floor() as usize
-            }
+            },
             QuantileInterpolOptions::Higher => ((length as f64 - 1.0) * self.prob).ceil() as usize,
         };
 
@@ -68,7 +68,7 @@ impl<
                     (values[idx].unwrap() + values[top_idx].unwrap())
                         / T::from::<f64>(2.0f64).unwrap(),
                 )
-            }
+            },
             QuantileInterpolOptions::Linear => {
                 let float_idx = (length as f64 - 1.0) * self.prob;
                 let top_idx = f64::ceil(float_idx) as usize;
@@ -82,7 +82,7 @@ impl<
                             + values[idx].unwrap(),
                     )
                 }
-            }
+            },
             _ => Some(values[idx].unwrap()),
         }
     }

--- a/crates/polars-arrow/src/kernels/rolling/window.rs
+++ b/crates/polars-arrow/src/kernels/rolling/window.rs
@@ -82,7 +82,7 @@ where
                         (true, false) => Ordering::Greater,
                         (false, true) => Ordering::Less,
                     }
-                }
+                },
                 _ => a.partial_cmp(b).unwrap(),
             }
         });
@@ -107,7 +107,7 @@ where
                     (true, false) => Ordering::Greater,
                     (false, true) => Ordering::Less,
                 }
-            }
+            },
             _ => a.partial_cmp(&b).unwrap(),
         }
     } else {

--- a/crates/polars-arrow/src/kernels/sorted_join/inner.rs
+++ b/crates/polars-arrow/src/kernels/sorted_join/inner.rs
@@ -37,7 +37,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                             // reset right index because the next lhs value can be the same
                             right_idx = current_idx;
                             break;
-                        }
+                        },
                         Some(&val_r) => {
                             if val_l == val_r {
                                 out_lhs.push(left_idx + left_offset);
@@ -47,7 +47,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                                 right_idx = current_idx;
                                 break;
                             }
-                        }
+                        },
                     }
                 }
                 break;

--- a/crates/polars-arrow/src/kernels/sorted_join/left.rs
+++ b/crates/polars-arrow/src/kernels/sorted_join/left.rs
@@ -48,7 +48,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                                     // reset right index because the next lhs value can be the same
                                     right_idx = current_idx;
                                     break;
-                                }
+                                },
                                 Some(&val_r) => {
                                     if val_l == val_r {
                                         out_lhs.push(left_idx + left_offset);
@@ -58,7 +58,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                                         right_idx = current_idx;
                                         break;
                                     }
-                                }
+                                },
                             }
                         }
                         break;
@@ -72,13 +72,13 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                     }
                     // continue looping the right side
                     right_idx += 1;
-                }
+                },
                 // we depleted the right array
                 None => {
                     out_lhs.push(left_idx + left_offset);
                     out_rhs.push(None);
                     break;
-                }
+                },
             }
         }
         left_idx += 1;

--- a/crates/polars-arrow/src/kernels/take_agg/mod.rs
+++ b/crates/polars-arrow/src/kernels/take_agg/mod.rs
@@ -139,7 +139,7 @@ pub unsafe fn take_agg_utf8_iter_unchecked<
             (_, None) => {
                 null_count += 1;
                 acc
-            }
+            },
             (None, Some(str_val)) => Some(str_val),
         });
     if null_count == len {

--- a/crates/polars-core/src/chunked_array/arithmetic/decimal.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/decimal.rs
@@ -59,7 +59,7 @@ impl DecimalChunked {
                     .map(|(lhs, rhs)| kernel(lhs, rhs).map(|a| Box::new(a) as ArrayRef))
                     .collect::<PolarsResult<_>>()?;
                 unsafe { lhs.copy_with_chunks(chunks, false, false) }
-            }
+            },
             // broadcast right path
             (_, 1) => {
                 let opt_rhs = rhs.get(0);
@@ -71,9 +71,9 @@ impl DecimalChunked {
                             .map(|lhs| operation_lhs(lhs, rhs_val).map(|a| Box::new(a) as ArrayRef))
                             .collect::<PolarsResult<_>>()?;
                         unsafe { lhs.copy_with_chunks(chunks, false, false) }
-                    }
+                    },
                 }
-            }
+            },
             (1, _) => {
                 let opt_lhs = lhs.get(0);
                 match opt_lhs {
@@ -84,12 +84,12 @@ impl DecimalChunked {
                             .map(|rhs| operation_rhs(lhs_val, rhs).map(|a| Box::new(a) as ArrayRef))
                             .collect::<PolarsResult<_>>()?;
                         unsafe { lhs.copy_with_chunks(chunks, false, false) }
-                    }
+                    },
                 }
-            }
+            },
             _ => {
                 polars_bail!(ComputeError: "Cannot apply operation on arrays of different lengths")
-            }
+            },
         };
         ca.rename(lhs.name());
         Ok(ca.into_decimal_unchecked(self.precision(), self.scale()))

--- a/crates/polars-core/src/chunked_array/arithmetic/mod.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/mod.rs
@@ -128,7 +128,7 @@ impl Add for &BinaryChunked {
                         // ref is valid for the lifetime of this closure
                         unsafe { std::mem::transmute::<_, &'static [u8]>(out) }
                     })
-                }
+                },
                 None => BinaryChunked::full_null(self.name(), self.len()),
             };
         }

--- a/crates/polars-core/src/chunked_array/arithmetic/numeric.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/numeric.rs
@@ -20,7 +20,7 @@ where
                 .map(|(lhs, rhs)| Box::new(kernel(lhs, rhs)) as ArrayRef)
                 .collect();
             unsafe { lhs.copy_with_chunks(chunks, false, false) }
-        }
+        },
         // broadcast right path
         (_, 1) => {
             let opt_rhs = rhs.get(0);
@@ -28,14 +28,14 @@ where
                 None => ChunkedArray::full_null(lhs.name(), lhs.len()),
                 Some(rhs) => lhs.apply(|lhs| operation(lhs, rhs)),
             }
-        }
+        },
         (1, _) => {
             let opt_lhs = lhs.get(0);
             match opt_lhs {
                 None => ChunkedArray::full_null(lhs.name(), rhs.len()),
                 Some(lhs) => rhs.apply(|rhs| operation(lhs, rhs)),
             }
-        }
+        },
         _ => panic!("Cannot apply operation on arrays of different lengths"),
     };
     ca.rename(lhs.name());
@@ -65,7 +65,7 @@ where
             }
             lhs.set_sorted_flag(IsSorted::Not);
             lhs
-        }
+        },
         // broadcast right path
         (_, 1) => {
             let opt_rhs = rhs.get(0);
@@ -74,9 +74,9 @@ where
                 Some(rhs) => {
                     lhs.apply_mut(|lhs| operation(lhs, rhs));
                     lhs
-                }
+                },
             }
-        }
+        },
         (1, _) => {
             let opt_lhs = lhs.get(0);
             match opt_lhs {
@@ -85,9 +85,9 @@ where
                     rhs.apply_mut(|rhs| operation(lhs_val, rhs));
                     rhs.rename(lhs.name());
                     rhs
-                }
+                },
             }
-        }
+        },
         _ => panic!("Cannot apply operation on arrays of different lengths"),
     };
     ca

--- a/crates/polars-core/src/chunked_array/bitwise.rs
+++ b/crates/polars-core/src/chunked_array/bitwise.rs
@@ -51,7 +51,7 @@ impl BitOr for &BooleanChunked {
         match (self.len(), rhs.len()) {
             // make sure that we fall through if both are equal unit lengths
             // otherwise we stackoverflow
-            (1, 1) => {}
+            (1, 1) => {},
             (1, _) => {
                 return match self.get(0) {
                     Some(true) => BooleanChunked::full(self.name(), true, rhs.len()),
@@ -59,18 +59,18 @@ impl BitOr for &BooleanChunked {
                         let mut rhs = rhs.clone();
                         rhs.rename(self.name());
                         rhs
-                    }
+                    },
                     None => &self.new_from_index(0, rhs.len()) | rhs,
                 };
-            }
+            },
             (_, 1) => {
                 return match rhs.get(0) {
                     Some(true) => BooleanChunked::full(self.name(), true, self.len()),
                     Some(false) => self.clone(),
                     None => &rhs.new_from_index(0, self.len()) | self,
                 };
-            }
-            _ => {}
+            },
+            _ => {},
         }
 
         let (lhs, rhs) = align_chunks_binary(self, rhs);
@@ -97,30 +97,30 @@ impl BitXor for &BooleanChunked {
         match (self.len(), rhs.len()) {
             // make sure that we fall through if both are equal unit lengths
             // otherwise we stackoverflow
-            (1, 1) => {}
+            (1, 1) => {},
             (1, _) => {
                 return match self.get(0) {
                     Some(true) => {
                         let mut rhs = rhs.not();
                         rhs.rename(self.name());
                         rhs
-                    }
+                    },
                     Some(false) => {
                         let mut rhs = rhs.clone();
                         rhs.rename(self.name());
                         rhs
-                    }
+                    },
                     None => &self.new_from_index(0, rhs.len()) | rhs,
                 };
-            }
+            },
             (_, 1) => {
                 return match rhs.get(0) {
                     Some(true) => self.not(),
                     Some(false) => self.clone(),
                     None => &rhs.new_from_index(0, self.len()) | self,
                 };
-            }
-            _ => {}
+            },
+            _ => {},
         }
 
         let (l, r) = align_chunks_binary(self, rhs);
@@ -151,22 +151,22 @@ impl BitAnd for &BooleanChunked {
         match (self.len(), rhs.len()) {
             // make sure that we fall through if both are equal unit lengths
             // otherwise we stackoverflow
-            (1, 1) => {}
+            (1, 1) => {},
             (1, _) => {
                 return match self.get(0) {
                     Some(true) => rhs.clone(),
                     Some(false) => BooleanChunked::full(self.name(), false, rhs.len()),
                     None => &self.new_from_index(0, rhs.len()) & rhs,
                 };
-            }
+            },
             (_, 1) => {
                 return match rhs.get(0) {
                     Some(true) => self.clone(),
                     Some(false) => BooleanChunked::full(self.name(), false, self.len()),
                     None => self & &rhs.new_from_index(0, self.len()),
                 };
-            }
-            _ => {}
+            },
+            _ => {},
         }
 
         let (lhs, rhs) = align_chunks_binary(self, rhs);

--- a/crates/polars-core/src/chunked_array/builder/list/anonymous.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/anonymous.rs
@@ -28,7 +28,7 @@ impl<'a> AnonymousListBuilder<'a> {
             Some(s) => return self.append_series(s),
             None => {
                 self.append_null();
-            }
+            },
         }
         Ok(())
     }
@@ -38,7 +38,7 @@ impl<'a> AnonymousListBuilder<'a> {
             Some(s) => self.append_array(s),
             None => {
                 self.append_null();
-            }
+            },
         }
     }
 
@@ -68,7 +68,7 @@ impl<'a> AnonymousListBuilder<'a> {
                 let arr = &**s.array_ref(0);
                 self.builder.push(arr);
                 return Ok(());
-            }
+            },
             dt => self.inner_dtype.update(dt)?,
         }
         self.builder.push_multiple(s.chunks());
@@ -130,12 +130,12 @@ impl ListBuilderTrait for AnonymousOwnedListBuilder {
                     #[cfg(feature = "dtype-struct")]
                     DataType::Struct(_) => {
                         self.builder.push(&*(&**s.array_ref(0) as *const dyn Array));
-                    }
+                    },
                     dt => {
                         self.inner_dtype.update(dt)?;
                         self.builder
                             .push_multiple(&*(s.chunks().as_ref() as *const [ArrayRef]));
-                    }
+                    },
                 }
             }
             // this make sure that the underlying ArrayRef's are not dropped

--- a/crates/polars-core/src/chunked_array/builder/list/dtypes.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/dtypes.rs
@@ -18,7 +18,7 @@ impl DtypeMerger {
             #[cfg(feature = "dtype-categorical")]
             Some(DataType::Categorical(Some(rev_map))) if rev_map.is_global() => {
                 DtypeMerger::Categorical(RevMapMerger::new(rev_map))
-            }
+            },
             _ => DtypeMerger::Other(dtype),
         }
     }
@@ -32,11 +32,11 @@ impl DtypeMerger {
                     polars_bail!(ComputeError: "expected categorical rev-map")
                 };
                 return merger.merge_map(rev_map);
-            }
+            },
             DtypeMerger::Other(Some(set_dtype)) => {
                 polars_ensure!(set_dtype == dtype, ComputeError: "dtypes don't match, got {}, expected: {}", dtype, set_dtype)
-            }
-            _ => {}
+            },
+            _ => {},
         }
         Ok(())
     }

--- a/crates/polars-core/src/chunked_array/builder/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/mod.rs
@@ -101,8 +101,8 @@ pub fn get_list_builder(
                 value_capacity,
                 inner_type_logical.clone(),
             )))
-        }
-        _ => {}
+        },
+        _ => {},
     }
 
     let physical_type = inner_type_logical.to_physical();
@@ -162,6 +162,6 @@ pub fn get_list_builder(
                 get_binary_builder,
                 get_bool_builder
             ))
-        }
+        },
     }
 }

--- a/crates/polars-core/src/chunked_array/builder/list/primitive.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/primitive.rs
@@ -47,7 +47,7 @@ where
             Some(items) => self.append_slice(items),
             None => {
                 self.builder.push_null();
-            }
+            },
         }
     }
     /// Appends from an iterator over values

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -47,7 +47,7 @@ fn cast_impl_inner(
             Some(tz) => {
                 validate_time_zone(tz)?;
                 out.into_datetime(*tu, Some(tz.clone()))
-            }
+            },
             _ => out.into_datetime(*tu, None),
         },
         Duration(tu) => out.into_duration(*tu),
@@ -108,7 +108,7 @@ where
                 // we are guarded by the type system
                 let ca = unsafe { &*(self as *const ChunkedArray<T> as *const UInt32Chunked) };
                 CategoricalChunked::from_global_indices(ca.clone()).map(|ca| ca.into_series())
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(fields) => cast_single_to_struct(self.name(), &self.chunks, fields),
             _ => cast_impl_inner(self.name(), &self.chunks, data_type, checked).map(|mut s| {
@@ -162,7 +162,7 @@ where
                 } else {
                     polars_bail!(ComputeError: "cannot cast numeric types to 'Categorical'");
                 }
-            }
+            },
             _ => self.cast_impl(data_type, false),
         }
     }
@@ -178,7 +178,7 @@ impl ChunkCast for Utf8Chunked {
                 builder.drain_iter(iter);
                 let ca = builder.finish();
                 Ok(ca.into_series())
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(fields) => cast_single_to_struct(self.name(), &self.chunks, fields),
             #[cfg(feature = "dtype-decimal")]
@@ -197,11 +197,11 @@ impl ChunkCast for Utf8Chunked {
                             .into_decimal_unchecked(*precision, *scale)
                             .into_series())
                     }
-                }
+                },
                 (None, None) => self.to_decimal(100),
                 _ => {
                     polars_bail!(ComputeError: "expected 'precision' or 'scale' when casting to Decimal")
-                }
+                },
             },
             _ => cast_impl(self.name(), &self.chunks, data_type),
         }
@@ -289,7 +289,7 @@ impl ChunkCast for BooleanChunked {
                 let mut ca = boolean_to_utf8(self);
                 ca.rename(self.name());
                 Ok(ca.into_series())
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(fields) => cast_single_to_struct(self.name(), &self.chunks, fields),
             _ => cast_impl(self.name(), &self.chunks, data_type),
@@ -312,7 +312,7 @@ impl ChunkCast for ListChunked {
                     #[cfg(feature = "dtype-categorical")]
                     (dt, Categorical(None)) if !matches!(dt, Utf8 | Null) => {
                         polars_bail!(ComputeError: "cannot cast List inner type: '{:?}' to Categorical", dt)
-                    }
+                    },
                     _ => {
                         // ensure the inner logical type bubbles up
                         let (arr, child_type) = cast_list(self, child_type)?;
@@ -325,22 +325,22 @@ impl ChunkCast for ListChunked {
                                 &List(Box::new(child_type)),
                             ))
                         }
-                    }
+                    },
                 }
-            }
+            },
             #[cfg(feature = "dtype-array")]
             Array(_, _) => {
                 // TODO! bubble up logical types
                 let chunks = cast_chunks(self.chunks(), data_type, true)?;
                 unsafe { Ok(ArrayChunked::from_chunks(self.name(), chunks).into_series()) }
-            }
+            },
             _ => {
                 polars_bail!(
                     ComputeError: "cannot cast List type (inner: '{:?}', to: '{:?}')",
                     self.inner_dtype(),
                     data_type,
                 )
-            }
+            },
         }
     }
 
@@ -361,7 +361,7 @@ impl ChunkCast for ArrayChunked {
                     #[cfg(feature = "dtype-categorical")]
                     (dt, Categorical(None)) if !matches!(dt, Utf8) => {
                         polars_bail!(ComputeError: "cannot cast fixed-size-list inner type: '{:?}' to Categorical", dt)
-                    }
+                    },
                     _ => {
                         // ensure the inner logical type bubbles up
                         let (arr, child_type) = cast_fixed_size_list(self, child_type)?;
@@ -374,14 +374,14 @@ impl ChunkCast for ArrayChunked {
                                 &Array(Box::new(child_type), *width),
                             ))
                         }
-                    }
+                    },
                 }
-            }
+            },
             List(_) => {
                 // TODO! bubble up logical types
                 let chunks = cast_chunks(self.chunks(), data_type, true)?;
                 unsafe { Ok(ListChunked::from_chunks(self.name(), chunks).into_series()) }
-            }
+            },
             _ => polars_bail!(ComputeError: "cannot cast list type"),
         }
     }

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -60,19 +60,19 @@ where
                 } else {
                     BooleanChunked::full_null("", self.len())
                 }
-            }
+            },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.equal(value)
                 } else {
                     BooleanChunked::full_null("", rhs.len())
                 }
-            }
+            },
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 lhs.comparison(&rhs, |x, y| comparison::eq(x, y))
-            }
+            },
         }
     }
 
@@ -85,19 +85,19 @@ where
                 } else {
                     self.is_null()
                 }
-            }
+            },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.equal_missing(value)
                 } else {
                     rhs.is_null()
                 }
-            }
+            },
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 lhs.comparison(&rhs, |x, y| comparison::eq_and_validity(x, y))
-            }
+            },
         }
     }
 
@@ -110,19 +110,19 @@ where
                 } else {
                     BooleanChunked::full_null("", self.len())
                 }
-            }
+            },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.not_equal(value)
                 } else {
                     BooleanChunked::full_null("", rhs.len())
                 }
-            }
+            },
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 lhs.comparison(&rhs, |x, y| comparison::neq(x, y))
-            }
+            },
         }
     }
 
@@ -135,19 +135,19 @@ where
                 } else {
                     self.is_not_null()
                 }
-            }
+            },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.not_equal_missing(value)
                 } else {
                     rhs.is_not_null()
                 }
-            }
+            },
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 lhs.comparison(&rhs, |x, y| comparison::neq_and_validity(x, y))
-            }
+            },
         }
     }
 
@@ -160,19 +160,19 @@ where
                 } else {
                     BooleanChunked::full_null("", self.len())
                 }
-            }
+            },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.lt(value)
                 } else {
                     BooleanChunked::full_null("", rhs.len())
                 }
-            }
+            },
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 lhs.comparison(&rhs, |x, y| comparison::gt(x, y))
-            }
+            },
         }
     }
 
@@ -185,19 +185,19 @@ where
                 } else {
                     BooleanChunked::full_null("", self.len())
                 }
-            }
+            },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.lt_eq(value)
                 } else {
                     BooleanChunked::full_null("", rhs.len())
                 }
-            }
+            },
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 lhs.comparison(&rhs, |x, y| comparison::gt_eq(x, y))
-            }
+            },
         }
     }
 
@@ -210,19 +210,19 @@ where
                 } else {
                     BooleanChunked::full_null("", self.len())
                 }
-            }
+            },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.gt(value)
                 } else {
                     BooleanChunked::full_null("", rhs.len())
                 }
-            }
+            },
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 lhs.comparison(&rhs, |x, y| comparison::lt(x, y))
-            }
+            },
         }
     }
 
@@ -235,19 +235,19 @@ where
                 } else {
                     BooleanChunked::full_null("", self.len())
                 }
-            }
+            },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     rhs.gt_eq(value)
                 } else {
                     BooleanChunked::full_null("", rhs.len())
                 }
-            }
+            },
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 lhs.comparison(&rhs, |x, y| comparison::lt_eq(x, y))
-            }
+            },
         }
     }
 }
@@ -282,13 +282,13 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 } else {
                     BooleanChunked::full_null("", self.len())
                 }
-            }
+            },
             (1, _) => rhs.equal(self),
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 compare_bools(&lhs, &rhs, |lhs, rhs| comparison::eq(lhs, rhs))
-            }
+            },
         }
     }
 
@@ -325,13 +325,13 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 } else {
                     self.is_null()
                 }
-            }
+            },
             (1, _) => rhs.equal_missing(self),
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 compare_bools(&lhs, &rhs, |lhs, rhs| comparison::eq_and_validity(lhs, rhs))
-            }
+            },
         }
     }
 
@@ -348,13 +348,13 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 } else {
                     BooleanChunked::full_null("", self.len())
                 }
-            }
+            },
             (1, _) => rhs.not_equal(self),
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 compare_bools(&lhs, &rhs, |lhs, rhs| comparison::neq(lhs, rhs))
-            }
+            },
         }
     }
 
@@ -390,7 +390,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 } else {
                     self.is_not_null()
                 }
-            }
+            },
             (1, _) => rhs.not_equal_missing(self),
             _ => {
                 // same length
@@ -398,7 +398,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 compare_bools(&lhs, &rhs, |lhs, rhs| {
                     comparison::neq_and_validity(lhs, rhs)
                 })
-            }
+            },
         }
     }
 
@@ -414,7 +414,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 } else {
                     BooleanChunked::full_null("", self.len())
                 }
-            }
+            },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     match value {
@@ -424,12 +424,12 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 } else {
                     BooleanChunked::full_null("", rhs.len())
                 }
-            }
+            },
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 compare_bools(&lhs, &rhs, |lhs, rhs| comparison::gt(lhs, rhs))
-            }
+            },
         }
     }
 
@@ -445,7 +445,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 } else {
                     BooleanChunked::full_null("", self.len())
                 }
-            }
+            },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     match value {
@@ -455,12 +455,12 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 } else {
                     BooleanChunked::full_null("", rhs.len())
                 }
-            }
+            },
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 compare_bools(&lhs, &rhs, |lhs, rhs| comparison::gt_eq(lhs, rhs))
-            }
+            },
         }
     }
 
@@ -476,7 +476,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 } else {
                     BooleanChunked::full_null("", self.len())
                 }
-            }
+            },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     match value {
@@ -486,12 +486,12 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 } else {
                     BooleanChunked::full_null("", rhs.len())
                 }
-            }
+            },
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 compare_bools(&lhs, &rhs, |lhs, rhs| comparison::lt(lhs, rhs))
-            }
+            },
         }
     }
 
@@ -507,7 +507,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 } else {
                     BooleanChunked::full_null("", self.len())
                 }
-            }
+            },
             (1, _) => {
                 if let Some(value) = self.get(0) {
                     match value {
@@ -517,12 +517,12 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 } else {
                     BooleanChunked::full_null("", rhs.len())
                 }
-            }
+            },
             _ => {
                 // same length
                 let (lhs, rhs) = align_chunks_binary(self, rhs);
                 compare_bools(&lhs, &rhs, |lhs, rhs| comparison::lt_eq(lhs, rhs))
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/comparison/scalar.rs
+++ b/crates/polars-core/src/chunked_array/comparison/scalar.rs
@@ -58,10 +58,10 @@ where
                         mask.extend_constant(arr.len() - idx, !lower_part);
                         BooleanArray::from_data_default(mask.into(), None)
                     }
-                }
+                },
                 Ok(_) => {
                     unreachable!()
-                }
+                },
             };
             Box::new(mask) as ArrayRef
         })
@@ -103,7 +103,7 @@ where
                 let mut ca = binary_search(self, false, cmp_fn);
                 ca.set_sorted_flag(IsSorted::Ascending);
                 ca
-            }
+            },
             _ => self.primitive_compare_scalar(rhs, |l, rhs| comparison::gt_scalar(l, rhs)),
         }
     }
@@ -120,7 +120,7 @@ where
                 let mut ca = binary_search(self, false, cmp_fn);
                 ca.set_sorted_flag(IsSorted::Ascending);
                 ca
-            }
+            },
             _ => self.primitive_compare_scalar(rhs, |l, rhs| comparison::gt_eq_scalar(l, rhs)),
         }
     }
@@ -137,7 +137,7 @@ where
                 let mut ca = binary_search(self, true, cmp_fn);
                 ca.set_sorted_flag(IsSorted::Ascending);
                 ca
-            }
+            },
             _ => self.primitive_compare_scalar(rhs, |l, rhs| comparison::lt_scalar(l, rhs)),
         }
     }
@@ -154,7 +154,7 @@ where
                 let mut ca = binary_search(self, true, cmp_fn);
                 ca.set_sorted_flag(IsSorted::Ascending);
                 ca
-            }
+            },
             _ => self.primitive_compare_scalar(rhs, |l, rhs| comparison::lt_eq_scalar(l, rhs)),
         }
     }

--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -39,7 +39,7 @@ fn from_chunks_list_dtype(chunks: &mut Vec<ArrayRef>, dtype: DataType) -> DataTy
             chunks.clear();
             chunks.push(Box::new(new_array));
             DataType::List(Box::new(cat.dtype().clone()))
-        }
+        },
         #[cfg(all(feature = "dtype-array", feature = "dtype-categorical"))]
         DataType::Array(inner, width) if *inner == DataType::Categorical(None) => {
             let array = concatenate_owned_unchecked(chunks).unwrap();
@@ -65,7 +65,7 @@ fn from_chunks_list_dtype(chunks: &mut Vec<ArrayRef>, dtype: DataType) -> DataTy
             chunks.clear();
             chunks.push(Box::new(new_array));
             DataType::Array(Box::new(cat.dtype().clone()), width)
-        }
+        },
         _ => dtype,
     }
 }

--- a/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -33,7 +33,7 @@ impl RevMappingBuilder {
                     use std::hint::unreachable_unchecked;
                     unsafe { unreachable_unchecked() }
                 }
-            }
+            },
         };
     }
 
@@ -60,10 +60,10 @@ impl Debug for RevMapping {
         match self {
             RevMapping::Global(_, _, _) => {
                 write!(f, "global")
-            }
+            },
             RevMapping::Local(_) => {
                 write!(f, "local")
-            }
+            },
         }
     }
 }
@@ -111,7 +111,7 @@ impl RevMapping {
             Self::Global(map, a, _) => {
                 let idx = *map.get(&idx).unwrap();
                 a.value(idx as usize)
-            }
+            },
             Self::Local(a) => a.value(idx as usize),
         }
     }
@@ -121,7 +121,7 @@ impl RevMapping {
             Self::Global(map, a, _) => {
                 let idx = *map.get(&idx)?;
                 a.get(idx as usize)
-            }
+            },
             Self::Local(a) => a.get(idx as usize),
         }
     }
@@ -135,7 +135,7 @@ impl RevMapping {
             Self::Global(map, a, _) => {
                 let idx = *map.get(&idx).unwrap();
                 a.value_unchecked(idx as usize)
-            }
+            },
             Self::Local(a) => a.value_unchecked(idx as usize),
         }
     }
@@ -145,7 +145,7 @@ impl RevMapping {
             (RevMapping::Global(_, _, l), RevMapping::Global(_, _, r)) => *l == *r,
             (RevMapping::Local(l), RevMapping::Local(r)) => {
                 std::ptr::eq(l as *const Utf8Array<_>, r as *const Utf8Array<_>)
-            }
+            },
             _ => false,
         }
     }
@@ -167,12 +167,12 @@ impl RevMapping {
                     // value is always within bounds
                     .find(|(_k, &v)| (unsafe { a.value_unchecked(v as usize) } == value))
                     .map(|(k, _v)| *k)
-            }
+            },
             Self::Local(a) => {
                 // Safety: within bounds
                 unsafe { (0..a.len()).find(|idx| a.value_unchecked(*idx) == value) }
                     .map(|idx| idx as u32)
-            }
+            },
         }
     }
 }
@@ -247,7 +247,7 @@ impl<'a> CategoricalChunkedBuilder<'a> {
                 }
                 entry.insert_with_hasher(h, key, idx, |s| s.hash);
                 self.reverse_mapping.insert(s);
-            }
+            },
         };
         self.cat_builder.push(Some(idx));
     }

--- a/crates/polars-core/src/chunked_array/logical/categorical/from.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/from.rs
@@ -23,7 +23,7 @@ impl From<&CategoricalChunked> for DictionaryArray<u32> {
                     DictionaryArray::try_new_unchecked(dtype, keys.clone(), Box::new(arr.clone()))
                         .unwrap()
                 }
-            }
+            },
             RevMapping::Global(reverse_map, values, _uuid) => {
                 let iter = keys
                     .into_iter()
@@ -36,7 +36,7 @@ impl From<&CategoricalChunked> for DictionaryArray<u32> {
                     DictionaryArray::try_new_unchecked(dtype, keys, Box::new(values.clone()))
                         .unwrap()
                 }
-            }
+            },
         }
     }
 }
@@ -78,7 +78,7 @@ impl From<&CategoricalChunked> for DictionaryArray<i64> {
                     DictionaryArray::try_new_unchecked(dtype, keys, Box::new(values.clone()))
                         .unwrap()
                 }
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
@@ -105,7 +105,7 @@ impl RevMapMerger {
             Some(state) => {
                 let new_rev = RevMapping::Global(state.map, state.slots.into(), self.id);
                 Arc::new(new_rev)
-            }
+            },
         }
     }
 }
@@ -119,7 +119,7 @@ pub(crate) fn merge_rev_map(
             let mut merger = RevMapMerger::new(left.clone());
             merger.merge_map(right)?;
             Ok(merger.finish())
-        }
+        },
         (RevMapping::Local(arr_l), RevMapping::Local(arr_r)) => {
             // they are from the same source, just clone
             if std::ptr::eq(arr_l, arr_r) {
@@ -134,7 +134,7 @@ pub(crate) fn merge_rev_map(
                 .clone();
 
             Ok(Arc::new(RevMapping::Local(arr)))
-        }
+        },
         _ => polars_bail!(
             ComputeError:
             "unable to merge categorical under a global string cache with a non-cached one"

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -225,13 +225,13 @@ impl LogicalType for CategoricalChunked {
 
                 let ca = builder.finish();
                 Ok(ca.into_series())
-            }
+            },
             DataType::UInt32 => {
                 let ca = unsafe {
                     UInt32Chunked::from_chunks(self.logical.name(), self.logical.chunks.clone())
                 };
                 Ok(ca.into_series())
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_) => Ok(self.clone().into_series()),
             _ => self.logical.cast(dtype),
@@ -358,7 +358,7 @@ mod test {
                 let str_s = s.cast(&DataType::Utf8).unwrap();
                 assert_eq!(str_s.get(0)?, AnyValue::Utf8("a"));
                 assert_eq!(s.len(), 1);
-            }
+            },
             _ => panic!(),
         }
         let flat = aggregated.explode()?;

--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
@@ -8,10 +8,10 @@ impl CategoricalChunked {
             let ca = match &**cat_map {
                 RevMapping::Local(a) => {
                     UInt32Chunked::from_iter_values(self.logical().name(), 0..(a.len() as u32))
-                }
+                },
                 RevMapping::Global(map, _, _) => {
                     UInt32Chunked::from_iter_values(self.logical().name(), map.keys().copied())
-                }
+                },
             };
             // safety:
             // we only removed some indexes so we are still in bounds

--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/zip.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/zip.rs
@@ -12,7 +12,7 @@ impl CategoricalChunked {
                 // to make sure the indexes still make sense we need to offset the right hand side
                 self.logical()
                     .zip_with(mask, &(other.logical() + rev_map.len() as u32))?
-            }
+            },
             _ => self.logical().zip_with(mask, other.logical())?,
         };
         let new_state = self.merge_categorical_map(other)?;

--- a/crates/polars-core/src/chunked_array/logical/categorical/stringcache.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/stringcache.rs
@@ -140,7 +140,7 @@ impl SCacheInner {
         match entry {
             RawEntryMut::Occupied(entry) => {
                 global_idx = entry.key().idx;
-            }
+            },
             RawEntryMut::Vacant(entry) => {
                 let idx = self.payloads.len() as u32;
                 let key = Key::new(h, idx);
@@ -148,7 +148,7 @@ impl SCacheInner {
 
                 // only just now we allocate the string
                 self.payloads.push(s.into());
-            }
+            },
         }
         global_idx
     }

--- a/crates/polars-core/src/chunked_array/logical/date.rs
+++ b/crates/polars-core/src/chunked_array/logical/date.rs
@@ -42,7 +42,7 @@ impl LogicalType for DateChunked {
                 Ok((casted.deref() * conversion)
                     .into_datetime(*tu, tz.clone())
                     .into_series())
-            }
+            },
             (Date, Time) => Ok(Int64Chunked::full(self.name(), 0i64, self.len())
                 .into_time()
                 .into_series()),

--- a/crates/polars-core/src/chunked_array/logical/datetime.rs
+++ b/crates/polars-core/src/chunked_array/logical/datetime.rs
@@ -35,32 +35,32 @@ impl LogicalType for DatetimeChunked {
                 Ok((self.0.as_ref() * 1_000_000i64)
                     .into_datetime(TimeUnit::Nanoseconds, tz.clone())
                     .into_series())
-            }
+            },
             (Datetime(TimeUnit::Milliseconds, _), Datetime(TimeUnit::Microseconds, tz)) => {
                 Ok((self.0.as_ref() * 1_000i64)
                     .into_datetime(TimeUnit::Microseconds, tz.clone())
                     .into_series())
-            }
+            },
             (Datetime(TimeUnit::Nanoseconds, _), Datetime(TimeUnit::Milliseconds, tz)) => {
                 Ok((self.0.as_ref() / 1_000_000i64)
                     .into_datetime(TimeUnit::Milliseconds, tz.clone())
                     .into_series())
-            }
+            },
             (Datetime(TimeUnit::Nanoseconds, _), Datetime(TimeUnit::Microseconds, tz)) => {
                 Ok((self.0.as_ref() / 1_000i64)
                     .into_datetime(TimeUnit::Microseconds, tz.clone())
                     .into_series())
-            }
+            },
             (Datetime(TimeUnit::Microseconds, _), Datetime(TimeUnit::Milliseconds, tz)) => {
                 Ok((self.0.as_ref() / 1_000i64)
                     .into_datetime(TimeUnit::Milliseconds, tz.clone())
                     .into_series())
-            }
+            },
             (Datetime(TimeUnit::Microseconds, _), Datetime(TimeUnit::Nanoseconds, tz)) => {
                 Ok((self.0.as_ref() * 1_000i64)
                     .into_datetime(TimeUnit::Nanoseconds, tz.clone())
                     .into_series())
-            }
+            },
             #[cfg(feature = "dtype-date")]
             (Datetime(tu, _), Date) => match tu {
                 TimeUnit::Nanoseconds => Ok((self.0.as_ref() / NS_IN_DAY)

--- a/crates/polars-core/src/chunked_array/logical/duration.rs
+++ b/crates/polars-core/src/chunked_array/logical/duration.rs
@@ -34,32 +34,32 @@ impl LogicalType for DurationChunked {
                 Ok((self.0.as_ref() * 1_000_000i64)
                     .into_duration(TimeUnit::Nanoseconds)
                     .into_series())
-            }
+            },
             (Duration(TimeUnit::Milliseconds), Duration(TimeUnit::Microseconds)) => {
                 Ok((self.0.as_ref() * 1_000i64)
                     .into_duration(TimeUnit::Microseconds)
                     .into_series())
-            }
+            },
             (Duration(TimeUnit::Microseconds), Duration(TimeUnit::Milliseconds)) => {
                 Ok((self.0.as_ref() / 1_000i64)
                     .into_duration(TimeUnit::Milliseconds)
                     .into_series())
-            }
+            },
             (Duration(TimeUnit::Microseconds), Duration(TimeUnit::Nanoseconds)) => {
                 Ok((self.0.as_ref() * 1_000i64)
                     .into_duration(TimeUnit::Nanoseconds)
                     .into_series())
-            }
+            },
             (Duration(TimeUnit::Nanoseconds), Duration(TimeUnit::Milliseconds)) => {
                 Ok((self.0.as_ref() / 1_000_000i64)
                     .into_duration(TimeUnit::Milliseconds)
                     .into_series())
-            }
+            },
             (Duration(TimeUnit::Nanoseconds), Duration(TimeUnit::Microseconds)) => {
                 Ok((self.0.as_ref() / 1_000i64)
                     .into_duration(TimeUnit::Microseconds)
                     .into_series())
-            }
+            },
             _ => self.0.cast(dtype),
         }
     }

--- a/crates/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -53,7 +53,7 @@ fn fields_to_struct_array(fields: &[Series], physical: bool) -> (ArrayRef, Vec<S
                     } else {
                         s.to_arrow(0)
                     }
-                }
+                },
             }
         })
         .collect::<Vec<_>>();
@@ -154,7 +154,7 @@ impl StructChunked {
                 Some(a) => *a = arr,
                 None => {
                     self.chunks.push(arr);
-                }
+                },
             }
         }
         self.chunks.truncate(n_chunks);
@@ -219,7 +219,7 @@ impl StructChunked {
                             validity_agg.map_or_else(|| Some(v.clone()), |agg| Some(v.bitor(&agg)));
                         // n.b. This is "free" since any bitops trigger a count.
                         n_nulls = validity_agg.as_ref().map(|v| v.unset_bits());
-                    }
+                    },
                 }
             }
             // If it's none, every array was either Null-type or all null
@@ -318,7 +318,7 @@ impl StructChunked {
                             } else {
                                 s.cast(&new_field.dtype)
                             }
-                        }
+                        },
                         None => Ok(Series::full_null(
                             new_field.name(),
                             struct_len,
@@ -327,7 +327,7 @@ impl StructChunked {
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;
                 StructChunked::new(self.name(), &new_fields).map(|ca| ca.into_series())
-            }
+            },
             DataType::Utf8 => {
                 let mut ca = self.clone();
                 ca.rechunk();
@@ -381,7 +381,7 @@ impl StructChunked {
                     )) as ArrayRef;
                     Series::try_from((ca.name().as_str(), array))
                 }
-            }
+            },
             _ => {
                 let fields = self
                     .fields
@@ -395,7 +395,7 @@ impl StructChunked {
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;
                 Ok(Self::new_unchecked(self.field.name(), &fields).into_series())
-            }
+            },
         }
     }
 
@@ -456,7 +456,7 @@ impl Drop for StructChunked {
                         ArrowDataType::Extension(name, _, _) if name == EXTENSION_NAME => unsafe {
                             drop_object_array(arr.as_ref())
                         },
-                        _ => {}
+                        _ => {},
                     }
                 }
             }

--- a/crates/polars-core/src/chunked_array/logical/time.rs
+++ b/crates/polars-core/src/chunked_array/logical/time.rs
@@ -37,7 +37,7 @@ impl LogicalType for TimeChunked {
                 } else {
                     out
                 }
-            }
+            },
             _ => self.0.cast(dtype),
         }
     }

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -213,19 +213,19 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             IsSorted::Not => {
                 self.bit_settings
                     .remove(Settings::SORTED_ASC | Settings::SORTED_DSC);
-            }
+            },
             IsSorted::Ascending => {
                 // Unset descending sorted.
                 self.bit_settings.remove(Settings::SORTED_DSC);
                 // Set ascending sorted.
                 self.bit_settings.insert(Settings::SORTED_ASC)
-            }
+            },
             IsSorted::Descending => {
                 // Unset ascending sorted.
                 self.bit_settings.remove(Settings::SORTED_ASC);
                 // Set descending sorted.
                 self.bit_settings.insert(Settings::SORTED_DSC)
-            }
+            },
         }
     }
 
@@ -283,7 +283,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             match (self.dtype(), series.dtype()) {
                 (Int64, Datetime(_, _)) | (Int64, Duration(_)) | (Int32, Date) => {
                     &*(series_trait as *const dyn SeriesTrait as *const ChunkedArray<T>)
-                }
+                },
                 _ => panic!(
                     "cannot unpack series {:?} into matching type {:?}",
                     series,

--- a/crates/polars-core/src/chunked_array/ndarray.rs
+++ b/crates/polars-core/src/chunked_array/ndarray.rs
@@ -109,11 +109,11 @@ impl DataFrame {
                         DataType::Float32 => {
                             let ca = s.f32().unwrap();
                             ca.none_to_nan().into_series()
-                        }
+                        },
                         DataType::Float64 => {
                             let ca = s.f64().unwrap();
                             ca.none_to_nan().into_series()
-                        }
+                        },
                         _ => s,
                     };
                     Ok(s.rechunk())
@@ -182,7 +182,7 @@ impl DataFrame {
             IndexOrder::Fortran => {
                 let ndarr = Array2::from_shape_vec((shape.1, shape.0), membuf).unwrap();
                 Ok(ndarr.reversed_axes())
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -80,7 +80,7 @@ pub(crate) fn create_extension<I: Iterator<Item = Option<T>> + TrustedLen, T: Si
                     validity.push_unchecked(true)
                 }
                 mem::forget(t);
-            }
+            },
             None => {
                 null_count += 1;
                 unsafe {
@@ -88,7 +88,7 @@ pub(crate) fn create_extension<I: Iterator<Item = Option<T>> + TrustedLen, T: Si
                     // Safety: we allocated upfront
                     validity.push_unchecked(false)
                 }
-            }
+            },
         }
     }
 

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -109,14 +109,14 @@ where
                     // first_non_null returns in bound index
                     unsafe { self.get_unchecked(idx) }
                 })
-            }
+            },
             IsSorted::Descending => {
                 self.last_non_null().and_then(|idx| {
                     // Safety:
                     // last returns in bound index
                     unsafe { self.get_unchecked(idx) }
                 })
-            }
+            },
             IsSorted::Not => self
                 .downcast_iter()
                 .filter_map(compute::aggregate::min_primitive)
@@ -141,14 +141,14 @@ where
                     // first_non_null returns in bound index
                     unsafe { self.get_unchecked(idx) }
                 })
-            }
+            },
             IsSorted::Descending => {
                 self.first_non_null().and_then(|idx| {
                     // Safety:
                     // last returns in bound index
                     unsafe { self.get_unchecked(idx) }
                 })
-            }
+            },
             IsSorted::Not => self
                 .downcast_iter()
                 .filter_map(compute::aggregate::max_primitive)
@@ -170,7 +170,7 @@ where
             DataType::Float64 => {
                 let len = (self.len() - self.null_count()) as f64;
                 self.sum().map(|v| v.to_f64().unwrap() / len)
-            }
+            },
             _ => {
                 let null_count = self.null_count();
                 let len = self.len();
@@ -186,7 +186,7 @@ where
                             sum += polars_arrow::kernels::agg_mean::sum_as_f64(arr);
                         }
                         Some(sum / (len - null_count) as f64)
-                    }
+                    },
                     #[cfg(not(feature = "simd"))]
                     _ => {
                         let mut acc = 0.0;
@@ -214,9 +214,9 @@ where
                             }
                         }
                         Some(acc / len)
-                    }
+                    },
                 }
-            }
+            },
         }
     }
 }
@@ -231,7 +231,7 @@ impl BooleanChunked {
                 .map(|arr| match arr.validity() {
                     Some(validity) => {
                         (arr.len() - (validity & arr.values()).unset_bits()) as IdxSize
-                    }
+                    },
                     None => (arr.len() - arr.values().unset_bits()) as IdxSize,
                 })
                 .sum()

--- a/crates/polars-core/src/chunked_array/ops/aggregate/quantile.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/quantile.rs
@@ -25,15 +25,15 @@ fn quantile_idx(
     let mut base_idx = match interpol {
         QuantileInterpolOptions::Nearest => {
             (((length - null_count) as f64) * quantile + null_count as f64) as usize
-        }
+        },
         QuantileInterpolOptions::Lower
         | QuantileInterpolOptions::Midpoint
         | QuantileInterpolOptions::Linear => {
             (((length - null_count) as f64 - 1.0) * quantile + null_count as f64) as usize
-        }
+        },
         QuantileInterpolOptions::Higher => {
             (((length - null_count) as f64 - 1.0) * quantile + null_count as f64).ceil() as usize
-        }
+        },
     };
 
     base_idx = base_idx.clamp(0, length - 1);
@@ -114,7 +114,7 @@ fn quantile_slice<T: ToPrimitive + Ord>(
                     lower.to_f64().unwrap(),
                     upper.to_f64().unwrap(),
                 )))
-            }
+            },
             QuantileInterpolOptions::Linear => {
                 let upper = rhs.min_value().unwrap();
                 Ok(linear_interpol(
@@ -124,7 +124,7 @@ fn quantile_slice<T: ToPrimitive + Ord>(
                     float_idx,
                 )
                 .to_f64())
-            }
+            },
             _ => Ok(lower.to_f64()),
         }
     }
@@ -163,7 +163,7 @@ where
                 let upper = sorted.get(idx + 1).map(|v| v.to_f64().unwrap());
                 midpoint_interpol(lower.unwrap(), upper.unwrap()).to_f64()
             }
-        }
+        },
         QuantileInterpolOptions::Linear => {
             if top_idx == idx {
                 lower
@@ -172,7 +172,7 @@ where
 
                 linear_interpol(lower.unwrap(), upper.unwrap(), idx, float_idx).to_f64()
             }
-        }
+        },
         _ => lower,
     };
     Ok(opt)

--- a/crates/polars-core/src/chunked_array/ops/any_value.rs
+++ b/crates/polars-core/src/chunked_array/ops/any_value.rs
@@ -55,7 +55,7 @@ pub(crate) unsafe fn arr_to_any_value<'a>(
                     .unwrap();
                 AnyValue::List(s)
             }
-        }
+        },
         #[cfg(feature = "dtype-array")]
         DataType::Array(dt, width) => {
             let v: ArrayRef = downcast!(FixedSizeListArray);
@@ -68,55 +68,55 @@ pub(crate) unsafe fn arr_to_any_value<'a>(
                     .unwrap();
                 AnyValue::Array(s, *width)
             }
-        }
+        },
         #[cfg(feature = "dtype-categorical")]
         DataType::Categorical(rev_map) => {
             let arr = &*(arr as *const dyn Array as *const UInt32Array);
             let v = arr.value_unchecked(idx);
             AnyValue::Categorical(v, rev_map.as_ref().unwrap().as_ref(), SyncPtr::new_null())
-        }
+        },
         #[cfg(feature = "dtype-struct")]
         DataType::Struct(flds) => {
             let arr = &*(arr as *const dyn Array as *const StructArray);
             AnyValue::Struct(idx, arr, flds)
-        }
+        },
         #[cfg(feature = "dtype-datetime")]
         DataType::Datetime(tu, tz) => {
             let arr = &*(arr as *const dyn Array as *const Int64Array);
             let v = arr.value_unchecked(idx);
             AnyValue::Datetime(v, *tu, tz)
-        }
+        },
         #[cfg(feature = "dtype-date")]
         DataType::Date => {
             let arr = &*(arr as *const dyn Array as *const Int32Array);
             let v = arr.value_unchecked(idx);
             AnyValue::Date(v)
-        }
+        },
         #[cfg(feature = "dtype-duration")]
         DataType::Duration(tu) => {
             let arr = &*(arr as *const dyn Array as *const Int64Array);
             let v = arr.value_unchecked(idx);
             AnyValue::Duration(v, *tu)
-        }
+        },
         #[cfg(feature = "dtype-time")]
         DataType::Time => {
             let arr = &*(arr as *const dyn Array as *const Int64Array);
             let v = arr.value_unchecked(idx);
             AnyValue::Time(v)
-        }
+        },
         #[cfg(feature = "dtype-decimal")]
         DataType::Decimal(precision, scale) => {
             let arr = &*(arr as *const dyn Array as *const Int128Array);
             let v = arr.value_unchecked(idx);
             AnyValue::Decimal(v, scale.unwrap_or_else(|| unreachable!()))
-        }
+        },
         #[cfg(feature = "object")]
         DataType::Object(_) => {
             // We should almost never hit this. The only known exception is when we put objects in
             // structs. Any other hit should be considered a bug.
             let arr = &*(arr as *const dyn Array as *const FixedSizeBinaryArray);
             PolarsExtension::arr_to_av(arr, idx)
-        }
+        },
         DataType::Null => AnyValue::Null,
         dt => panic!("not implemented for {dt:?}"),
     }
@@ -163,7 +163,7 @@ impl<'a> AnyValue<'a> {
                         }
                     })
                 }
-            }
+            },
             _ => unreachable!(),
         }
     }

--- a/crates/polars-core/src/chunked_array/ops/append.rs
+++ b/crates/polars-core/src/chunked_array/ops/append.rs
@@ -43,13 +43,13 @@ pub(super) fn update_sorted_flag_before_append<'a, T>(
                 if end > start {
                     ca.set_sorted_flag(IsSorted::Not)
                 }
-            }
+            },
             (IsSorted::Descending, IsSorted::Descending) => {
                 let (start, end) = get_start_end();
                 if end < start {
                     ca.set_sorted_flag(IsSorted::Not)
                 }
-            }
+            },
             _ => ca.set_sorted_flag(IsSorted::Not),
         }
     } else if ca.is_empty() {

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -93,7 +93,7 @@ where
                     let vals = mutable.values_mut_slice();
                     vals.iter_mut().for_each(|v| *v = f(*v));
                     mutable.into()
-                }
+                },
             }
         }
     });

--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -95,7 +95,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             #[cfg(feature = "object")]
             DataType::Object(_) => {
                 panic!("implementation error")
-            }
+            },
             _ => {
                 fn inner_rechunk(chunks: &[ArrayRef]) -> Vec<ArrayRef> {
                     vec![concatenate_owned_unchecked(chunks).unwrap()]
@@ -107,7 +107,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
                     let chunks = inner_rechunk(&self.chunks);
                     unsafe { self.copy_with_chunks(chunks, true, true) }
                 }
-            }
+            },
         }
     }
 

--- a/crates/polars-core/src/chunked_array/ops/compare_inner.rs
+++ b/crates/polars-core/src/chunked_array/ops/compare_inner.rs
@@ -130,7 +130,7 @@ impl<'a> IntoPartialEqInner<'a> for &'a Utf8Chunked {
                 let arr = self.downcast_iter().next().unwrap();
                 let t = Utf8TakeRandomSingleChunk { arr };
                 Box::new(t)
-            }
+            },
             _ => {
                 let chunks = self.downcast_chunks();
                 let t = Utf8TakeRandom {
@@ -138,7 +138,7 @@ impl<'a> IntoPartialEqInner<'a> for &'a Utf8Chunked {
                     chunk_lens: self.chunks.iter().map(|a| a.len() as IdxSize).collect(),
                 };
                 Box::new(t)
-            }
+            },
         }
     }
 }
@@ -150,7 +150,7 @@ impl<'a> IntoPartialEqInner<'a> for &'a BinaryChunked {
                 let arr = self.downcast_iter().next().unwrap();
                 let t = BinaryTakeRandomSingleChunk { arr };
                 Box::new(t)
-            }
+            },
             _ => {
                 let chunks = self.downcast_chunks();
                 let t = BinaryTakeRandom {
@@ -158,7 +158,7 @@ impl<'a> IntoPartialEqInner<'a> for &'a BinaryChunked {
                     chunk_lens: self.chunks.iter().map(|a| a.len() as IdxSize).collect(),
                 };
                 Box::new(t)
-            }
+            },
         }
     }
 }
@@ -170,7 +170,7 @@ impl<'a> IntoPartialEqInner<'a> for &'a BooleanChunked {
                 let arr = self.downcast_iter().next().unwrap();
                 let t = BoolTakeRandomSingleChunk { arr };
                 Box::new(t)
-            }
+            },
             _ => {
                 let chunks = self.downcast_chunks();
                 let t = BoolTakeRandom {
@@ -178,7 +178,7 @@ impl<'a> IntoPartialEqInner<'a> for &'a BooleanChunked {
                     chunk_lens: self.chunks.iter().map(|a| a.len() as IdxSize).collect(),
                 };
                 Box::new(t)
-            }
+            },
         }
     }
 }
@@ -250,7 +250,7 @@ impl<'a> IntoPartialOrdInner<'a> for &'a Utf8Chunked {
                 let arr = self.downcast_iter().next().unwrap();
                 let t = Utf8TakeRandomSingleChunk { arr };
                 Box::new(t)
-            }
+            },
             _ => {
                 let chunks = self.downcast_chunks();
                 let t = Utf8TakeRandom {
@@ -258,7 +258,7 @@ impl<'a> IntoPartialOrdInner<'a> for &'a Utf8Chunked {
                     chunk_lens: self.chunks.iter().map(|a| a.len() as IdxSize).collect(),
                 };
                 Box::new(t)
-            }
+            },
         }
     }
 }
@@ -270,7 +270,7 @@ impl<'a> IntoPartialOrdInner<'a> for &'a BinaryChunked {
                 let arr = self.downcast_iter().next().unwrap();
                 let t = BinaryTakeRandomSingleChunk { arr };
                 Box::new(t)
-            }
+            },
             _ => {
                 let chunks = self.downcast_chunks();
                 let t = BinaryTakeRandom {
@@ -278,7 +278,7 @@ impl<'a> IntoPartialOrdInner<'a> for &'a BinaryChunked {
                     chunk_lens: self.chunks.iter().map(|a| a.len() as IdxSize).collect(),
                 };
                 Box::new(t)
-            }
+            },
         }
     }
 }
@@ -290,7 +290,7 @@ impl<'a> IntoPartialOrdInner<'a> for &'a BooleanChunked {
                 let arr = self.downcast_iter().next().unwrap();
                 let t = BoolTakeRandomSingleChunk { arr };
                 Box::new(t)
-            }
+            },
             _ => {
                 let chunks = self.downcast_chunks();
                 let t = BoolTakeRandom {
@@ -298,7 +298,7 @@ impl<'a> IntoPartialOrdInner<'a> for &'a BooleanChunked {
                     chunk_lens: self.chunks.iter().map(|a| a.len() as IdxSize).collect(),
                 };
                 Box::new(t)
-            }
+            },
         }
     }
 }
@@ -343,7 +343,7 @@ impl<'a, T: PolarsObject> IntoPartialEqInner<'a> for &'a ObjectChunked<T> {
                 let arr = self.downcast_iter().next().unwrap();
                 let t = ObjectTakeRandomSingleChunk { arr };
                 Box::new(t)
-            }
+            },
             _ => {
                 let chunks = self.downcast_chunks();
                 let t = ObjectTakeRandom {
@@ -351,7 +351,7 @@ impl<'a, T: PolarsObject> IntoPartialEqInner<'a> for &'a ObjectChunked<T> {
                     chunk_lens: self.chunks.iter().map(|a| a.len() as IdxSize).collect(),
                 };
                 Box::new(t)
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/concat_str.rs
+++ b/crates/polars-core/src/chunked_array/ops/concat_str.rs
@@ -10,7 +10,7 @@ fn fmt_and_write<T: Display>(value: Option<T>, buf: &mut String) {
         None => buf.push_str("null"),
         Some(v) => {
             write!(buf, "{v}").unwrap();
-        }
+        },
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/cum_agg.rs
+++ b/crates/polars-core/src/chunked_array/ops/cum_agg.rs
@@ -16,7 +16,7 @@ where
                 *state = v
             }
             Some(Some(*state))
-        }
+        },
         None => Some(None),
     }
 }
@@ -31,7 +31,7 @@ where
                 *state = v
             }
             Some(Some(*state))
-        }
+        },
         None => Some(None),
     }
 }
@@ -44,11 +44,11 @@ where
         (Some(state_inner), Some(v)) => {
             *state = Some(state_inner + v);
             Some(*state)
-        }
+        },
         (None, Some(v)) => {
             *state = Some(v);
             Some(*state)
-        }
+        },
         (_, None) => Some(None),
     }
 }
@@ -61,11 +61,11 @@ where
         (Some(state_inner), Some(v)) => {
             *state = Some(state_inner * v);
             Some(*state)
-        }
+        },
         (None, Some(v)) => {
             *state = Some(v);
             Some(*state)
-        }
+        },
         (_, None) => Some(None),
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/explode.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode.rs
@@ -248,7 +248,7 @@ impl ExplodeByOffsets for ListChunked {
                             // safety: the pointer is still valid as `owned` will not reallocate
                             builder.push(&*ptr as &dyn Array);
                         }
-                    }
+                    },
                 }
             }
         };

--- a/crates/polars-core/src/chunked_array/ops/extend.rs
+++ b/crates/polars-core/src/chunked_array/ops/extend.rs
@@ -70,7 +70,7 @@ where
             match arr.into_mut() {
                 Left(immutable) => {
                     extend_immutable(&immutable, &mut self.chunks, &other.chunks);
-                }
+                },
                 Right(mut mutable) => {
                     for arr in other.downcast_iter() {
                         match arr.null_count() {
@@ -80,7 +80,7 @@ where
                     }
                     let arr: PrimitiveArray<T::Native> = mutable.into();
                     self.chunks.push(Box::new(arr) as ArrayRef)
-                }
+                },
             }
         }
         self.compute_len();
@@ -112,14 +112,14 @@ impl Utf8Chunked {
         match arr.into_mut() {
             Left(immutable) => {
                 extend_immutable(&immutable, &mut self.chunks, &other.chunks);
-            }
+            },
             Right(mut mutable) => {
                 for arr in other.downcast_iter() {
                     mutable.extend_trusted_len(arr.into_iter())
                 }
                 let arr: Utf8Array<i64> = mutable.into();
                 self.chunks.push(Box::new(arr) as ArrayRef)
-            }
+            },
         }
         self.compute_len();
         self.set_sorted_flag(IsSorted::Not);
@@ -151,14 +151,14 @@ impl BinaryChunked {
         match arr.into_mut() {
             Left(immutable) => {
                 extend_immutable(&immutable, &mut self.chunks, &other.chunks);
-            }
+            },
             Right(mut mutable) => {
                 for arr in other.downcast_iter() {
                     mutable.extend_trusted_len(arr.into_iter())
                 }
                 let arr: BinaryArray<i64> = mutable.into();
                 self.chunks.push(Box::new(arr) as ArrayRef)
-            }
+            },
         }
         self.compute_len();
     }
@@ -190,14 +190,14 @@ impl BooleanChunked {
         match arr.into_mut() {
             Left(immutable) => {
                 extend_immutable(&immutable, &mut self.chunks, &other.chunks);
-            }
+            },
             Right(mut mutable) => {
                 for arr in other.downcast_iter() {
                     mutable.extend_trusted_len(arr.into_iter())
                 }
                 let arr: BooleanArray = mutable.into();
                 self.chunks.push(Box::new(arr) as ArrayRef)
-            }
+            },
         }
         self.compute_len();
         self.set_sorted_flag(IsSorted::Not);

--- a/crates/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/crates/polars-core/src/chunked_array/ops/fill_null.rs
@@ -61,21 +61,21 @@ impl Series {
                 let s = unsafe { s.cast_unchecked(&Binary)? };
                 let out = s.fill_null(strategy)?;
                 return unsafe { out.cast_unchecked(&Utf8) };
-            }
+            },
             Binary => {
                 let ca = s.binary().unwrap();
                 fill_null_binary(ca, strategy).map(|ca| ca.into_series())
-            }
+            },
             List(_) => {
                 let ca = s.list().unwrap();
                 fill_null_list(ca, strategy).map(|ca| ca.into_series())
-            }
+            },
             dt if dt.is_numeric() => {
                 with_match_physical_numeric_polars_type!(dt, |$T| {
                     let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
                         fill_null_numeric(ca, strategy).map(|ca| ca.into_series())
                 })
-            }
+            },
             _ => todo!(),
         }?;
         unsafe { out.cast_unchecked(logical_type) }
@@ -117,7 +117,7 @@ where
                 cnt = 0;
                 previous = Some(v.cheap_clone());
                 Some(v)
-            }
+            },
             None => {
                 if cnt < limit {
                     cnt += 1;
@@ -125,7 +125,7 @@ where
                 } else {
                     None
                 }
-            }
+            },
         })
         .collect_trusted()
 }
@@ -147,7 +147,7 @@ where
                 cnt = 0;
                 previous = Some(v.cheap_clone());
                 Some(v)
-            }
+            },
             None => {
                 if cnt < limit {
                     cnt += 1;
@@ -155,7 +155,7 @@ where
                 } else {
                     None
                 }
-            }
+            },
         })
         .collect_reversed()
 }
@@ -171,7 +171,7 @@ fn fill_backward_limit_binary(ca: &BinaryChunked, limit: IdxSize) -> BinaryChunk
                 cnt = 0;
                 previous = Some(v);
                 Some(v)
-            }
+            },
             None => {
                 if cnt < limit {
                     cnt += 1;
@@ -179,7 +179,7 @@ fn fill_backward_limit_binary(ca: &BinaryChunked, limit: IdxSize) -> BinaryChunk
                 } else {
                     None
                 }
-            }
+            },
         })
         .collect_trusted();
     out.into_iter().rev().collect_trusted()
@@ -198,7 +198,7 @@ where
             Some(value) => {
                 *previous = Some(value.cheap_clone());
                 Some(Some(value))
-            }
+            },
             None => Some(previous.as_ref().map(|v| v.cheap_clone())),
         })
         .collect_trusted()
@@ -218,7 +218,7 @@ where
             Some(value) => {
                 *previous = Some(value);
                 Some(Some(value))
-            }
+            },
             None => Some(*previous),
         })
         .collect_reversed()
@@ -233,7 +233,7 @@ macro_rules! impl_fill_backward {
                 Some(value) => {
                     *previous = Some(value.cheap_clone());
                     Some(Some(value))
-                }
+                },
                 None => Some(previous.as_ref().map(|s| s.cheap_clone())),
             })
             .collect_trusted();
@@ -253,7 +253,7 @@ macro_rules! impl_fill_backward_limit {
                     cnt = 0;
                     previous = Some(v.cheap_clone());
                     Some(v)
-                }
+                },
                 None => {
                     if cnt < $limit {
                         cnt += 1;
@@ -261,7 +261,7 @@ macro_rules! impl_fill_backward_limit {
                     } else {
                         None
                     }
-                }
+                },
             })
             .collect_trusted();
         out.into_iter().rev().collect_trusted()
@@ -316,7 +316,7 @@ fn fill_null_bool(ca: &BooleanChunked, strategy: FillNullStrategy) -> PolarsResu
             };
             out.rename(ca.name());
             Ok(out.into_series())
-        }
+        },
         FillNullStrategy::Backward(limit) => {
             let mut out: BooleanChunked = match limit {
                 None => fill_backward(ca),
@@ -324,7 +324,7 @@ fn fill_null_bool(ca: &BooleanChunked, strategy: FillNullStrategy) -> PolarsResu
             };
             out.rename(ca.name());
             Ok(out.into_series())
-        }
+        },
         FillNullStrategy::Min => ca
             .fill_null_with_values(ca.min().ok_or_else(err_fill_null)?)
             .map(|ca| ca.into_series()),
@@ -334,10 +334,10 @@ fn fill_null_bool(ca: &BooleanChunked, strategy: FillNullStrategy) -> PolarsResu
         FillNullStrategy::Mean => polars_bail!(opq = mean, "Boolean"),
         FillNullStrategy::One | FillNullStrategy::MaxBound => {
             ca.fill_null_with_values(true).map(|ca| ca.into_series())
-        }
+        },
         FillNullStrategy::Zero | FillNullStrategy::MinBound => {
             ca.fill_null_with_values(false).map(|ca| ca.into_series())
-        }
+        },
     }
 }
 
@@ -354,7 +354,7 @@ fn fill_null_binary(ca: &BinaryChunked, strategy: FillNullStrategy) -> PolarsRes
             };
             out.rename(ca.name());
             Ok(out)
-        }
+        },
         FillNullStrategy::Backward(limit) => {
             let mut out = match limit {
                 None => impl_fill_backward!(ca, BinaryChunked),
@@ -362,7 +362,7 @@ fn fill_null_binary(ca: &BinaryChunked, strategy: FillNullStrategy) -> PolarsRes
             };
             out.rename(ca.name());
             Ok(out)
-        }
+        },
         strat => polars_bail!(InvalidOperation: "fill-null strategy {:?} is not supported", strat),
     }
 }
@@ -380,7 +380,7 @@ fn fill_null_list(ca: &ListChunked, strategy: FillNullStrategy) -> PolarsResult<
             };
             out.rename(ca.name());
             Ok(out)
-        }
+        },
         FillNullStrategy::Backward(limit) => {
             let mut out: ListChunked = match limit {
                 None => impl_fill_backward!(ca, ListChunked),
@@ -388,7 +388,7 @@ fn fill_null_list(ca: &ListChunked, strategy: FillNullStrategy) -> PolarsResult<
             };
             out.rename(ca.name());
             Ok(out)
-        }
+        },
         strat => polars_bail!(InvalidOperation: "fill-null strategy {:?} is not supported", strat),
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -177,7 +177,7 @@ where
                         false => {
                             let v = arr.value(idx);
                             builder.append_value(v.clone())
-                        }
+                        },
                     }
                 }
             }

--- a/crates/polars-core/src/chunked_array/ops/is_in.rs
+++ b/crates/polars-core/src/chunked_array/ops/is_in.rs
@@ -133,7 +133,7 @@ impl IsIn for Utf8Chunked {
                                 .collect_trusted();
                             ca.rename(self.name());
                             Ok(ca)
-                        }
+                        },
                         Some(value) => {
                             match rev_map.find(value) {
                                 // all false
@@ -155,14 +155,14 @@ impl IsIn for Utf8Chunked {
                                         .collect_trusted();
                                     ca.rename(self.name());
                                     Ok(ca)
-                                }
+                                },
                             }
-                        }
+                        },
                     }
                 } else {
                     unreachable!()
                 }
-            }
+            },
             DataType::List(dt) if DataType::Utf8 == **dt => self.as_binary().is_in(
                 &other
                     .cast(&DataType::List(Box::new(DataType::Binary)))
@@ -320,14 +320,14 @@ impl IsIn for StructChunked {
                             (val, Some(series)) => {
                                 let ca = series.as_ref().struct_().unwrap();
                                 ca.into_iter().any(|a| a == val)
-                            }
+                            },
                             _ => false,
                         })
                         .collect()
                 };
                 ca.rename(self.name());
                 Ok(ca)
-            }
+            },
             _ => {
                 let other = other.cast(&other.dtype().to_physical()).unwrap();
                 let other = other.struct_()?;
@@ -386,7 +386,7 @@ impl IsIn for StructChunked {
                     .collect();
                 ca.rename(self.name());
                 Ok(ca)
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -658,7 +658,7 @@ impl ChunkExpandAtIndex<ListType> for ListChunked {
                 let mut ca = ListChunked::full(self.name(), &val, length);
                 ca.to_logical(self.inner_dtype());
                 ca
-            }
+            },
             None => ListChunked::full_null_with_dtype(self.name(), length, &self.inner_dtype()),
         }
     }
@@ -673,7 +673,7 @@ impl ChunkExpandAtIndex<FixedSizeListType> for ArrayChunked {
                 let mut ca = ArrayChunked::full(self.name(), &val, length);
                 ca.to_physical(self.inner_dtype());
                 ca
-            }
+            },
             None => ArrayChunked::full_null_with_dtype(self.name(), length, &self.inner_dtype(), 0),
         }
     }

--- a/crates/polars-core/src/chunked_array/ops/reverse.rs
+++ b/crates/polars-core/src/chunked_array/ops/reverse.rs
@@ -20,7 +20,7 @@ where
         match self.is_sorted_flag() {
             IsSorted::Ascending => out.set_sorted_flag(IsSorted::Descending),
             IsSorted::Descending => out.set_sorted_flag(IsSorted::Ascending),
-            _ => {}
+            _ => {},
         }
 
         out

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -230,7 +230,7 @@ mod inner_mod {
                     Some(v) => {
                         // SAFETY: we have pre-allocated.
                         unsafe { values.push_unchecked(v) }
-                    }
+                    },
                     None => {
                         // SAFETY: we allocated enough for both the `values` vec
                         // and the `validity_ptr`.
@@ -238,7 +238,7 @@ mod inner_mod {
                             values.push_unchecked(T::Native::default());
                             unset_bit_raw(validity_ptr, offset + window_size - 1);
                         }
-                    }
+                    },
                 }
             }
             let arr = PrimitiveArray::new(

--- a/crates/polars-core/src/chunked_array/ops/shift.rs
+++ b/crates/polars-core/src/chunked_array/ops/shift.rs
@@ -102,7 +102,7 @@ impl ChunkShiftFill<ListType, Option<&Series>> for ListChunked {
             Some(val) => Self::full(self.name(), val, fill_length),
             None => {
                 ListChunked::full_null_with_dtype(self.name(), fill_length, &self.inner_dtype())
-            }
+            },
         };
 
         if periods < 0 {
@@ -136,7 +136,7 @@ impl ChunkShiftFill<FixedSizeListType, Option<&Series>> for ArrayChunked {
             Some(val) => Self::full(self.name(), val, fill_length),
             None => {
                 ArrayChunked::full_null_with_dtype(self.name(), fill_length, &self.inner_dtype(), 0)
-            }
+            },
         };
 
         if periods < 0 {

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort.rs
@@ -50,7 +50,7 @@ where
                     // we allocated enough
                     unsafe { nulls_idx.push_unchecked(i) };
                     None
-                }
+                },
             }
         });
         vals.extend(iter);

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -52,7 +52,7 @@ pub(crate) fn arg_sort_multiple_impl<T: PartialOrd + Send + IsFloat + Copy>(
                             idx_b,
                         )
                     }
-                }
+                },
                 (true, Ordering::Less) => Ordering::Greater,
                 (true, Ordering::Greater) => Ordering::Less,
                 (_, ord) => ord,
@@ -77,7 +77,7 @@ pub fn _get_rows_encoded_compat_array(by: &Series) -> PolarsResult<ArrayRef> {
             } else {
                 ca.logical().chunks[0].clone()
             }
-        }
+        },
         _ => by.to_arrow(0),
     };
     Ok(out)
@@ -128,11 +128,11 @@ pub fn _get_rows_encoded(
                     cols.push(arr.clone() as ArrayRef);
                     fields.push(sort_field.clone())
                 }
-            }
+            },
             _ => {
                 cols.push(arr);
                 fields.push(sort_field)
-            }
+            },
         }
     }
     Ok(convert_columns(&cols, &fields))

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -484,7 +484,7 @@ impl ChunkSort<BinaryType> for BinaryChunked {
                     BinaryArray::from_data_unchecked_default(offsets.into(), values.into(), None)
                 };
                 (self.name(), ar).into()
-            }
+            },
             (_, true) => {
                 for val in v {
                     values.extend_from_slice(val);
@@ -506,7 +506,7 @@ impl ChunkSort<BinaryType> for BinaryChunked {
                     )
                 };
                 (self.name(), ar).into()
-            }
+            },
             (_, false) => {
                 let mut validity = MutableBitmap::with_capacity(len);
                 validity.extend_constant(null_count, false);
@@ -529,7 +529,7 @@ impl ChunkSort<BinaryType> for BinaryChunked {
                     )
                 };
                 (self.name(), ar).into()
-            }
+            },
         };
 
         let s = if options.descending {
@@ -682,7 +682,7 @@ pub(crate) fn convert_sort_column_multi_sort(s: &Series) -> PolarsResult<Series>
                 .map(convert_sort_column_multi_sort)
                 .collect::<PolarsResult<Vec<_>>>()?;
             return StructChunked::new(ca.name(), &new_fields).map(|ca| ca.into_series());
-        }
+        },
         _ => {
             let phys = s.to_physical_repr().into_owned();
             polars_ensure!(
@@ -690,7 +690,7 @@ pub(crate) fn convert_sort_column_multi_sort(s: &Series) -> PolarsResult<Series>
                 ComputeError: "cannot sort column of dtype `{}`", s.dtype()
             );
             phys
-        }
+        },
     };
     Ok(out)
 }

--- a/crates/polars-core/src/chunked_array/ops/take/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/take/mod.rs
@@ -88,7 +88,7 @@ where
                     (0, 1) => {
                         take_no_null_primitive_unchecked::<T::Native>(chunks.next().unwrap(), array)
                             as ArrayRef
-                    }
+                    },
                     (_, 1) => take_primitive_unchecked::<T::Native>(chunks.next().unwrap(), array)
                         as ArrayRef,
                     _ => {
@@ -105,10 +105,10 @@ where
                             ca.rename(self.name());
                             ca
                         }
-                    }
+                    },
                 };
                 self.finish_from_array(array)
-            }
+            },
             TakeIdx::Iter(iter) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), iter.size_hint().0);
@@ -121,15 +121,15 @@ where
                     (_, 1) => {
                         take_primitive_iter_unchecked::<T::Native, _>(chunks.next().unwrap(), iter)
                             as ArrayRef
-                    }
+                    },
                     _ => {
                         let mut ca = take_primitive_iter_n_chunks(self, iter);
                         ca.rename(self.name());
                         return ca;
-                    }
+                    },
                 };
                 self.finish_from_array(array)
-            }
+            },
             TakeIdx::IterNulls(iter) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), iter.size_hint().0);
@@ -147,10 +147,10 @@ where
                         let mut ca = take_primitive_opt_iter_n_chunks(self, iter);
                         ca.rename(self.name());
                         return ca;
-                    }
+                    },
                 };
                 self.finish_from_array(array)
-            }
+            },
         }
     }
 
@@ -196,10 +196,10 @@ impl ChunkTake for BooleanChunked {
                             ca.rename(self.name());
                             ca
                         }
-                    }
+                    },
                 };
                 self.finish_from_array(array)
-            }
+            },
             TakeIdx::Iter(iter) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), iter.size_hint().0);
@@ -207,16 +207,16 @@ impl ChunkTake for BooleanChunked {
                 let array = match (self.has_validity(), self.chunks.len()) {
                     (false, 1) => {
                         take_no_null_bool_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef
-                    }
+                    },
                     (_, 1) => take_bool_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef,
                     _ => {
                         let mut ca: BooleanChunked = take_iter_n_chunks_unchecked!(self, iter);
                         ca.rename(self.name());
                         return ca;
-                    }
+                    },
                 };
                 self.finish_from_array(array)
-            }
+            },
             TakeIdx::IterNulls(iter) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), iter.size_hint().0);
@@ -225,18 +225,18 @@ impl ChunkTake for BooleanChunked {
                     (false, 1) => {
                         take_no_null_bool_opt_iter_unchecked(chunks.next().unwrap(), iter)
                             as ArrayRef
-                    }
+                    },
                     (_, 1) => {
                         take_bool_opt_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef
-                    }
+                    },
                     _ => {
                         let mut ca: BooleanChunked = take_opt_iter_n_chunks_unchecked!(self, iter);
                         ca.rename(self.name());
                         return ca;
-                    }
+                    },
                 };
                 self.finish_from_array(array)
-            }
+            },
         }
     }
 
@@ -304,41 +304,41 @@ impl ChunkTake for BinaryChunked {
                             ca.rename(self.name());
                             ca
                         }
-                    }
+                    },
                 };
                 self.finish_from_array(array)
-            }
+            },
             TakeIdx::Iter(iter) => {
                 let array = match (self.has_validity(), self.chunks.len()) {
                     (false, 1) => {
                         take_no_null_binary_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef
-                    }
+                    },
                     (_, 1) => take_binary_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef,
                     _ => {
                         let mut ca: BinaryChunked = take_iter_n_chunks_unchecked!(self, iter);
                         ca.rename(self.name());
                         return ca;
-                    }
+                    },
                 };
                 self.finish_from_array(array)
-            }
+            },
             TakeIdx::IterNulls(iter) => {
                 let array = match (self.has_validity(), self.chunks.len()) {
                     (false, 1) => {
                         take_no_null_binary_opt_iter_unchecked(chunks.next().unwrap(), iter)
                             as ArrayRef
-                    }
+                    },
                     (_, 1) => {
                         take_binary_opt_iter_unchecked(chunks.next().unwrap(), iter) as ArrayRef
-                    }
+                    },
                     _ => {
                         let mut ca: BinaryChunked = take_opt_iter_n_chunks_unchecked!(self, iter);
                         ca.rename(self.name());
                         return ca;
-                    }
+                    },
                 };
                 self.finish_from_array(array)
-            }
+            },
         }
     }
 
@@ -393,10 +393,10 @@ impl ChunkTake for ListChunked {
                                 take_opt_iter_n_chunks_unchecked!(ca_self.as_ref(), iter);
                             ca.chunks.pop().unwrap()
                         }
-                    }
+                    },
                 };
                 self.finish_from_array(array)
-            }
+            },
             // todo! fast path for single chunk
             TakeIdx::Iter(iter) => {
                 if ca_self.chunks.len() == 1 {
@@ -406,7 +406,7 @@ impl ChunkTake for ListChunked {
                     let mut ca: ListChunked = take_iter_n_chunks_unchecked!(ca_self.as_ref(), iter);
                     self.finish_from_array(ca.chunks.pop().unwrap())
                 }
-            }
+            },
             TakeIdx::IterNulls(iter) => {
                 if ca_self.chunks.len() == 1 {
                     let idx: IdxCa = iter.map(|v| v.map(|v| v as IdxSize)).collect();
@@ -416,7 +416,7 @@ impl ChunkTake for ListChunked {
                         take_opt_iter_n_chunks_unchecked!(ca_self.as_ref(), iter);
                     self.finish_from_array(ca.chunks.pop().unwrap())
                 }
-            }
+            },
         }
     }
 
@@ -455,15 +455,15 @@ impl ChunkTake for ArrayChunked {
                 let arr = self.chunks[0].as_ref();
                 let arr = take_unchecked(arr, idx_array);
                 self.finish_from_array(arr)
-            }
+            },
             TakeIdx::Iter(iter) => {
                 let idx: NoNull<IdxCa> = iter.map(|v| v as IdxSize).collect();
                 ca_self.take_unchecked((&idx.into_inner()).into())
-            }
+            },
             TakeIdx::IterNulls(iter) => {
                 let idx: IdxCa = iter.map(|v| v.map(|v| v as IdxSize)).collect();
                 ca_self.take_unchecked((&idx).into())
-            }
+            },
         }
     }
 
@@ -507,7 +507,7 @@ impl<T: PolarsObject> ChunkTake for ObjectChunked<T> {
                             .collect();
                         ca.rename(self.name());
                         ca
-                    }
+                    },
                     _ => {
                         return if !array.has_validity() {
                             let iter = array.values().iter().map(|i| *i as usize);
@@ -532,9 +532,9 @@ impl<T: PolarsObject> ChunkTake for ObjectChunked<T> {
                             ca.rename(self.name());
                             ca
                         }
-                    }
+                    },
                 }
-            }
+            },
             TakeIdx::Iter(iter) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), iter.size_hint().0);
@@ -545,7 +545,7 @@ impl<T: PolarsObject> ChunkTake for ObjectChunked<T> {
                     iter.map(|idx| taker.get_unchecked(idx).cloned()).collect();
                 ca.rename(self.name());
                 ca
-            }
+            },
             TakeIdx::IterNulls(iter) => {
                 if self.is_empty() {
                     return Self::full_null(self.name(), iter.size_hint().0);
@@ -558,7 +558,7 @@ impl<T: PolarsObject> ChunkTake for ObjectChunked<T> {
 
                 ca.rename(self.name());
                 ca
-            }
+            },
         }
     }
 

--- a/crates/polars-core/src/chunked_array/ops/take/take_random.rs
+++ b/crates/polars-core/src/chunked_array/ops/take/take_random.rs
@@ -241,7 +241,7 @@ impl<'a> IntoTakeRandom<'a> for &'a Utf8Chunked {
                 let arr = self.downcast_iter().next().unwrap();
                 let t = Utf8TakeRandomSingleChunk { arr };
                 TakeRandBranch2::Single(t)
-            }
+            },
             _ => {
                 let chunks = self.downcast_chunks();
                 let t = Utf8TakeRandom {
@@ -249,7 +249,7 @@ impl<'a> IntoTakeRandom<'a> for &'a Utf8Chunked {
                     chunk_lens: self.chunks.iter().map(|a| a.len() as IdxSize).collect(),
                 };
                 TakeRandBranch2::Multi(t)
-            }
+            },
         }
     }
 }
@@ -313,7 +313,7 @@ impl<'a> IntoTakeRandom<'a> for &'a BinaryChunked {
                 let arr = self.downcast_iter().next().unwrap();
                 let t = BinaryTakeRandomSingleChunk { arr };
                 TakeRandBranch2::Single(t)
-            }
+            },
             _ => {
                 let chunks = self.downcast_chunks();
                 let t = BinaryTakeRandom {
@@ -321,7 +321,7 @@ impl<'a> IntoTakeRandom<'a> for &'a BinaryChunked {
                     chunk_lens: self.chunks.iter().map(|a| a.len() as IdxSize).collect(),
                 };
                 TakeRandBranch2::Multi(t)
-            }
+            },
         }
     }
 }
@@ -336,7 +336,7 @@ impl<'a> IntoTakeRandom<'a> for &'a BooleanChunked {
                 let arr = self.downcast_iter().next().unwrap();
                 let t = BoolTakeRandomSingleChunk { arr };
                 TakeRandBranch2::Single(t)
-            }
+            },
             _ => {
                 let chunks = self.downcast_chunks();
                 let t = BoolTakeRandom {
@@ -344,7 +344,7 @@ impl<'a> IntoTakeRandom<'a> for &'a BooleanChunked {
                     chunk_lens: self.chunks.iter().map(|a| a.len() as IdxSize).collect(),
                 };
                 TakeRandBranch2::Multi(t)
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/take/traits.rs
+++ b/crates/polars-core/src/chunked_array/ops/take/traits.rs
@@ -123,14 +123,14 @@ where
                         match opt_v {
                             Some(&v) if v >= len => {
                                 inbounds = false;
-                            }
-                            _ => {}
+                            },
+                            _ => {},
                         }
                     }
                 }
                 polars_ensure!(inbounds, ComputeError: "take indices are out of bounds");
                 Ok(())
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -91,7 +91,7 @@ fn mode_indices(groups: GroupsProxy) -> Vec<IdxSize> {
                 .take_while(|v| v.1.len() == max_occur)
                 .map(|v| v.0)
                 .collect()
-        }
+        },
         GroupsProxy::Slice { groups, .. } => {
             let last = groups.last().unwrap();
             let max_occur = last[1];
@@ -105,7 +105,7 @@ fn mode_indices(groups: GroupsProxy) -> Vec<IdxSize> {
                 })
                 .map(|v| v[0])
                 .collect()
-        }
+        },
     }
 }
 
@@ -180,11 +180,11 @@ where
                     let mask = self.not_equal_and_validity(&self.shift(1));
                     self.filter(&mask)
                 }
-            }
+            },
             IsSorted::Not => {
                 let sorted = self.sort(false);
                 sorted.unique()
-            }
+            },
         }
     }
 
@@ -221,11 +221,11 @@ where
                     let mask = self.not_equal_and_validity(&self.shift(1));
                     Ok(mask.sum().unwrap() as usize)
                 }
-            }
+            },
             IsSorted::Not => {
                 let sorted = self.sort(false);
                 sorted.n_unique()
-            }
+            },
         }
     }
 
@@ -269,7 +269,7 @@ impl ChunkUnique<BinaryType> for BinaryChunked {
                     self.name(),
                     set.iter().copied(),
                 ))
-            }
+            },
             _ => {
                 let mut set =
                     PlHashSet::with_capacity(std::cmp::min(HASHMAP_INIT_SIZE, self.len()));
@@ -280,7 +280,7 @@ impl ChunkUnique<BinaryType> for BinaryChunked {
                     self.name(),
                     set.iter().copied(),
                 ))
-            }
+            },
         }
     }
 

--- a/crates/polars-core/src/chunked_array/ops/unique/rank.rs
+++ b/crates/polars-core/src/chunked_array/ops/unique/rank.rs
@@ -48,14 +48,14 @@ pub(crate) fn rank(s: &Series, method: RankMethod, descending: bool, seed: Optio
                 Average => Series::new(s.name(), &[1.0f32]),
                 _ => Series::new(s.name(), &[1 as IdxSize]),
             };
-        }
+        },
         0 => {
             return match method {
                 Average => Float32Chunked::from_slice(s.name(), &[]).into_series(),
                 _ => IdxCa::from_slice(s.name(), &[]).into_series(),
             };
-        }
-        _ => {}
+        },
+        _ => {},
     }
 
     if s.null_count() > 0 {
@@ -128,7 +128,7 @@ pub(crate) fn rank(s: &Series, method: RankMethod, descending: bool, seed: Optio
         Ordinal => {
             let inv_ca = IdxCa::from_vec(s.name(), inv);
             inv_ca.into_series()
-        }
+        },
         #[cfg(feature = "random")]
         Random => {
             // Safety:
@@ -181,7 +181,7 @@ pub(crate) fn rank(s: &Series, method: RankMethod, descending: bool, seed: Optio
 
             let inv_ca = IdxCa::from_vec(s.name(), inv);
             inv_ca.into_series()
-        }
+        },
         _ => {
             let inv_ca = IdxCa::from_vec(s.name(), inv);
             // Safety:
@@ -285,12 +285,12 @@ pub(crate) fn rank(s: &Series, method: RankMethod, descending: bool, seed: Optio
                     // Safety:
                     // within bounds
                     unsafe { count.take_unchecked((&dense).into()).into_series() }
-                }
+                },
                 Min => {
                     // Safety:
                     // within bounds
                     unsafe { (count.take_unchecked((&dense).into()) + 1).into_series() }
-                }
+                },
                 Average => {
                     // Safety:
                     // in bounds
@@ -302,13 +302,13 @@ pub(crate) fn rank(s: &Series, method: RankMethod, descending: bool, seed: Optio
                         .unwrap()
                         + 1.0;
                     (&a + &b) * 0.5
-                }
+                },
                 #[cfg(feature = "random")]
                 Dense | Ordinal | Random => unimplemented!(),
                 #[cfg(not(feature = "random"))]
                 Dense | Ordinal => unimplemented!(),
             }
-        }
+        },
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/zip.rs
+++ b/crates/polars-core/src/chunked_array/ops/zip.rs
@@ -21,7 +21,7 @@ fn prepare_mask(mask: &BooleanArray) -> BooleanArray {
         Some(validity) if validity.unset_bits() != 0 => {
             let mask = mask.values() & validity;
             BooleanArray::from_data_default(mask, None)
-        }
+        },
         _ => mask.clone(),
     }
 }

--- a/crates/polars-core/src/chunked_array/random.rs
+++ b/crates/polars-core/src/chunked_array/random.rs
@@ -85,13 +85,13 @@ impl Series {
                 // Safety we know that we never go out of bounds
                 debug_assert_eq!(len, self.len());
                 unsafe { self.take_unchecked(&idx) }
-            }
+            },
             false => {
                 let idx = create_rand_index_no_replacement(n, len, seed, shuffle);
                 // Safety we know that we never go out of bounds
                 debug_assert_eq!(len, self.len());
                 unsafe { self.take_unchecked(&idx) }
-            }
+            },
         }
     }
 
@@ -139,13 +139,13 @@ where
                 // Safety we know that we never go out of bounds
                 debug_assert_eq!(len, self.len());
                 unsafe { Ok(self.take_unchecked((&idx).into())) }
-            }
+            },
             false => {
                 let idx = create_rand_index_no_replacement(n, len, seed, shuffle);
                 // Safety we know that we never go out of bounds
                 debug_assert_eq!(len, self.len());
                 unsafe { Ok(self.take_unchecked((&idx).into())) }
-            }
+            },
         }
     }
 

--- a/crates/polars-core/src/chunked_array/temporal/conversion.rs
+++ b/crates/polars-core/src/chunked_array/temporal/conversion.rs
@@ -12,7 +12,7 @@ impl From<&AnyValue<'_>> for NaiveDateTime {
             #[cfg(feature = "dtype-date")]
             AnyValue::Date(v) => {
                 NaiveDateTime::from_timestamp_opt(*v as i64 * SECONDS_IN_DAY, 0).unwrap()
-            }
+            },
             #[cfg(feature = "dtype-datetime")]
             AnyValue::Datetime(v, tu, _) => match tu {
                 TimeUnit::Nanoseconds => timestamp_ns_to_datetime(*v),

--- a/crates/polars-core/src/chunked_array/temporal/date.rs
+++ b/crates/polars-core/src/chunked_array/temporal/date.rs
@@ -49,7 +49,7 @@ impl DateChunked {
                         let datefmt = date32_to_date(*v).format(format);
                         write!(buf, "{datefmt}").unwrap();
                         mutarr.push(Some(&buf))
-                    }
+                    },
                 }
             }
 

--- a/crates/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/crates/polars-core/src/chunked_array/temporal/datetime.rs
@@ -33,7 +33,7 @@ fn apply_datefmt_f<'a>(
                 let datefmt = datefmt_f(converted);
                 write!(buf, "{datefmt}").unwrap();
                 mutarr.push(Some(&buf))
-            }
+            },
         }
     }
     let arr: Utf8Array<i64> = mutarr.into();
@@ -191,32 +191,32 @@ impl DatetimeChunked {
                 let ca = &self.0 / 1_000;
                 out.0 = ca;
                 out
-            }
+            },
             (Nanoseconds, Milliseconds) => {
                 let ca = &self.0 / 1_000_000;
                 out.0 = ca;
                 out
-            }
+            },
             (Microseconds, Nanoseconds) => {
                 let ca = &self.0 * 1_000;
                 out.0 = ca;
                 out
-            }
+            },
             (Microseconds, Milliseconds) => {
                 let ca = &self.0 / 1_000;
                 out.0 = ca;
                 out
-            }
+            },
             (Milliseconds, Nanoseconds) => {
                 let ca = &self.0 * 1_000_000;
                 out.0 = ca;
                 out
-            }
+            },
             (Milliseconds, Microseconds) => {
                 let ca = &self.0 * 1_000;
                 out.0 = ca;
                 out
-            }
+            },
             (Nanoseconds, Nanoseconds)
             | (Microseconds, Microseconds)
             | (Milliseconds, Milliseconds) => out,

--- a/crates/polars-core/src/chunked_array/temporal/duration.rs
+++ b/crates/polars-core/src/chunked_array/temporal/duration.rs
@@ -23,32 +23,32 @@ impl DurationChunked {
                 let ca = &self.0 / 1_000;
                 out.0 = ca;
                 out
-            }
+            },
             (Nanoseconds, Milliseconds) => {
                 let ca = &self.0 / 1_000_000;
                 out.0 = ca;
                 out
-            }
+            },
             (Microseconds, Nanoseconds) => {
                 let ca = &self.0 * 1_000;
                 out.0 = ca;
                 out
-            }
+            },
             (Microseconds, Milliseconds) => {
                 let ca = &self.0 / 1_000;
                 out.0 = ca;
                 out
-            }
+            },
             (Milliseconds, Nanoseconds) => {
                 let ca = &self.0 * 1_000_000;
                 out.0 = ca;
                 out
-            }
+            },
             (Milliseconds, Microseconds) => {
                 let ca = &self.0 * 1_000;
                 out.0 = ca;
                 out
-            }
+            },
             (Nanoseconds, Nanoseconds)
             | (Microseconds, Microseconds)
             | (Milliseconds, Milliseconds) => out,

--- a/crates/polars-core/src/chunked_array/temporal/mod.rs
+++ b/crates/polars-core/src/chunked_array/temporal/mod.rs
@@ -32,6 +32,6 @@ pub(crate) fn validate_time_zone(tz: &str) -> PolarsResult<()> {
         Ok(_) => Ok(()),
         Err(_) => {
             polars_bail!(ComputeError: "unable to parse time zone: '{}'. Please check the Time Zone Database for a list of available time zones", tz)
-        }
+        },
     }
 }

--- a/crates/polars-core/src/chunked_array/temporal/time.rs
+++ b/crates/polars-core/src/chunked_array/temporal/time.rs
@@ -37,7 +37,7 @@ impl TimeChunked {
                         let timefmt = time64ns_to_time(*v).format(format);
                         write!(buf, "{timefmt}").unwrap();
                         mutarr.push(Some(&buf))
-                    }
+                    },
                 }
             }
 

--- a/crates/polars-core/src/chunked_array/trusted_len.rs
+++ b/crates/polars-core/src/chunked_array/trusted_len.rs
@@ -60,11 +60,11 @@ where
                 match opt_item {
                     Some(item) => {
                         std::ptr::write(ptr, item);
-                    }
+                    },
                     None => {
                         std::ptr::write(ptr, T::Native::default());
                         unset_bit_raw(validity_ptr, offset)
-                    }
+                    },
                 }
             });
             vals.set_len(size)
@@ -99,11 +99,11 @@ impl FromIteratorReversed<Option<bool>> for BooleanChunked {
                             // validity bit is already true
                             set_bit_raw(vals_ptr, offset);
                         }
-                    }
+                    },
                     None => {
                         // unset validity bit
                         unset_bit_raw(validity_ptr, offset)
-                    }
+                    },
                 }
             });
         }

--- a/crates/polars-core/src/chunked_array/upstream_traits.rs
+++ b/crates/polars-core/src/chunked_array/upstream_traits.rs
@@ -60,7 +60,7 @@ where
                 #[cfg(not(feature = "performant"))]
                 iter.collect::<PrimitiveArray<T::Native>>()
                     .to(T::get_dtype().to_arrow())
-            }
+            },
             _ => iter
                 .collect::<PrimitiveArray<T::Native>>()
                 .to(T::get_dtype().to_arrow()),
@@ -204,10 +204,10 @@ impl FromIterator<Option<Series>> for ListChunked {
                 Some(Some(s)) => {
                     first_value = Some(s);
                     break;
-                }
+                },
                 Some(None) => {
                     init_null_count += 1;
-                }
+                },
                 None => return ListChunked::full_null("", init_null_count),
             }
         }
@@ -216,7 +216,7 @@ impl FromIterator<Option<Series>> for ListChunked {
             None => {
                 // already returned full_null above
                 unreachable!()
-            }
+            },
             Some(ref first_s) => {
                 // AnyValues with empty lists in python can create
                 // Series of an unknown dtype.
@@ -249,7 +249,7 @@ impl FromIterator<Option<Series>> for ListChunked {
                                 builder.append_opt_series(opt_s.as_ref()).unwrap();
                             }
                             builder.finish()
-                        }
+                        },
                         _ => {
                             // We don't know the needed capacity. We arbitrarily choose an average of 5 elements per series.
                             let mut builder = get_list_builder(
@@ -269,10 +269,10 @@ impl FromIterator<Option<Series>> for ListChunked {
                                 builder.append_opt_series(opt_s.as_ref()).unwrap();
                             }
                             builder.finish()
-                        }
+                        },
                     }
                 }
-            }
+            },
         }
     }
 }
@@ -335,11 +335,11 @@ impl<T: PolarsObject> FromIterator<Option<T>> for ObjectChunked<T> {
                 Some(value) => {
                     null_mask_builder.push(true);
                     value
-                }
+                },
                 None => {
                     null_mask_builder.push(false);
                     T::default()
-                }
+                },
             })
             .collect();
 
@@ -472,14 +472,14 @@ where
                         match opt_v {
                             Some(v) => {
                                 std::ptr::write(values_buf_ptr.add(i), v);
-                            }
+                            },
                             None => {
                                 let validity = match &mut local_validity {
                                     None => {
                                         let validity = MutableBitmap::with_capacity(local_len);
                                         local_validity = Some(validity);
                                         local_validity.as_mut().unwrap_unchecked()
-                                    }
+                                    },
                                     Some(validity) => validity,
                                 };
                                 validity.extend_constant(i - latest_validy_written, true);
@@ -487,7 +487,7 @@ where
                                 validity.push_unchecked(false);
                                 // initialize value
                                 std::ptr::write(values_buf_ptr.add(i), T::Native::default());
-                            }
+                            },
                         }
                     }
                 }
@@ -720,7 +720,7 @@ impl FromParallelIterator<Option<Series>> for ListChunked {
                     }
                 }
                 builder.finish()
-            }
+            },
             Some(dtype) => {
                 let mut builder =
                     get_list_builder(dtype, value_capacity, list_capacity, "collected").unwrap();
@@ -730,7 +730,7 @@ impl FromParallelIterator<Option<Series>> for ListChunked {
                     }
                 }
                 builder.finish()
-            }
+            },
             None => ListChunked::full_null_with_dtype("collected", list_capacity, &DataType::Null),
         }
     }

--- a/crates/polars-core/src/cloud.rs
+++ b/crates/polars-core/src/cloud.rs
@@ -208,7 +208,7 @@ impl CloudOptions {
                 {
                     polars_bail!(ComputeError: "'aws' feature is not enabled");
                 }
-            }
+            },
             CloudType::Azure => {
                 #[cfg(feature = "azure")]
                 {
@@ -219,7 +219,7 @@ impl CloudOptions {
                 {
                     polars_bail!(ComputeError: "'azure' feature is not enabled");
                 }
-            }
+            },
             CloudType::File => Ok(Self::default()),
             CloudType::Gcp => {
                 #[cfg(feature = "gcp")]
@@ -231,7 +231,7 @@ impl CloudOptions {
                 {
                     polars_bail!(ComputeError: "'gcp' feature is not enabled");
                 }
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -124,11 +124,11 @@ impl Serialize for AnyValue<'_> {
             AnyValue::Utf8(v) => serializer.serialize_newtype_variant(name, 13, "Utf8Owned", v),
             AnyValue::Utf8Owned(v) => {
                 serializer.serialize_newtype_variant(name, 13, "Utf8Owned", v.as_str())
-            }
+            },
             AnyValue::Binary(v) => serializer.serialize_newtype_variant(name, 14, "BinaryOwned", v),
             AnyValue::BinaryOwned(v) => {
                 serializer.serialize_newtype_variant(name, 14, "BinaryOwned", v)
-            }
+            },
             _ => todo!(),
         }
     }
@@ -244,7 +244,7 @@ impl<'a> Deserialize<'a> for AnyValue<'static> {
                             &String::from_utf8_lossy(v),
                             VARIANTS,
                         ))
-                    }
+                    },
                 };
                 Ok(field)
             }
@@ -277,59 +277,59 @@ impl<'a> Deserialize<'a> for AnyValue<'static> {
                     (AvField::Int8, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::Int8(value)
-                    }
+                    },
                     (AvField::Int16, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::Int16(value)
-                    }
+                    },
                     (AvField::Int32, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::Int32(value)
-                    }
+                    },
                     (AvField::Int64, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::Int64(value)
-                    }
+                    },
                     (AvField::UInt8, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::UInt8(value)
-                    }
+                    },
                     (AvField::UInt16, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::UInt16(value)
-                    }
+                    },
                     (AvField::UInt32, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::UInt32(value)
-                    }
+                    },
                     (AvField::UInt64, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::UInt64(value)
-                    }
+                    },
                     (AvField::Float32, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::Float32(value)
-                    }
+                    },
                     (AvField::Float64, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::Float64(value)
-                    }
+                    },
                     (AvField::Bool, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::Boolean(value)
-                    }
+                    },
                     (AvField::List, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::List(value)
-                    }
+                    },
                     (AvField::Utf8Owned, variant) => {
                         let value: String = variant.newtype_variant()?;
                         AnyValue::Utf8Owned(value.into())
-                    }
+                    },
                     (AvField::BinaryOwned, variant) => {
                         let value = variant.newtype_variant()?;
                         AnyValue::BinaryOwned(value)
-                    }
+                    },
                 };
                 Ok(out)
             }
@@ -406,7 +406,7 @@ impl<'a> AnyValue<'a> {
                 } else {
                     NumCast::from(0)
                 }
-            }
+            },
             _ => None,
         }
     }
@@ -484,7 +484,7 @@ impl<'a> AnyValue<'a> {
                     let ndt = convert(*v);
                     let date_value = naive_datetime_to_date(ndt);
                     AnyValue::Date(date_value)
-                }
+                },
                 _ => polars_bail!(
                     ComputeError: format!("cannot cast 'datetime' any-value to dtype {dtype}")
                 ),
@@ -510,7 +510,7 @@ impl<'a> AnyValue<'a> {
                     };
                     let value = func(ndt);
                     AnyValue::Datetime(value, *tu, &None)
-                }
+                },
                 _ => polars_bail!(
                     ComputeError: format!("cannot cast 'date' any-value to dtype {dtype}")
                 ),
@@ -551,14 +551,14 @@ impl AnyValue<'_> {
                 if !cheap {
                     Hash::hash(&Wrap(v.clone()), state)
                 }
-            }
+            },
             #[cfg(feature = "dtype-array")]
             Array(v, width) => {
                 if !cheap {
                     Hash::hash(&Wrap(v.clone()), state)
                 }
                 width.hash(state)
-            }
+            },
             #[cfg(feature = "dtype-date")]
             Date(v) => v.hash(state),
             #[cfg(feature = "dtype-datetime")]
@@ -566,20 +566,20 @@ impl AnyValue<'_> {
                 v.hash(state);
                 tu.hash(state);
                 tz.hash(state);
-            }
+            },
             #[cfg(feature = "dtype-duration")]
             Duration(v, tz) => {
                 v.hash(state);
                 tz.hash(state);
-            }
+            },
             #[cfg(feature = "dtype-time")]
             Time(v) => v.hash(state),
             #[cfg(feature = "dtype-categorical")]
             Categorical(v, _, _) => v.hash(state),
             #[cfg(feature = "object")]
-            Object(_) => {}
+            Object(_) => {},
             #[cfg(feature = "object")]
-            ObjectOwned(_) => {}
+            ObjectOwned(_) => {},
             #[cfg(feature = "dtype-struct")]
             Struct(_, _, _) | StructOwned(_) => {
                 if !cheap {
@@ -587,13 +587,13 @@ impl AnyValue<'_> {
                     self._materialize_struct_av(&mut buf);
                     buf.hash(state)
                 }
-            }
+            },
             #[cfg(feature = "dtype-decimal")]
             Decimal(v, k) => {
                 v.hash(state);
                 k.hash(state);
-            }
-            Null => {}
+            },
+            Null => {},
         }
     }
 }
@@ -714,19 +714,19 @@ impl<'a> AnyValue<'a> {
             Struct(idx, arr, fields) => {
                 let avs = struct_to_avs_static(idx, arr, fields);
                 StructOwned(Box::new((avs, fields.to_vec())))
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             StructOwned(payload) => {
                 let av = StructOwned(payload);
                 // safety: owned is already static
                 unsafe { std::mem::transmute::<AnyValue<'a>, AnyValue<'static>>(av) }
-            }
+            },
             #[cfg(feature = "object")]
             ObjectOwned(payload) => {
                 let av = ObjectOwned(payload);
                 // safety: owned is already static
                 unsafe { std::mem::transmute::<AnyValue<'a>, AnyValue<'static>>(av) }
-            }
+            },
             #[cfg(feature = "dtype-decimal")]
             Decimal(val, scale) => Decimal(val, scale),
             dt => polars_bail!(ComputeError: "cannot get static any-value from {}", dt),
@@ -747,7 +747,7 @@ impl<'a> AnyValue<'a> {
                     unsafe { arr.deref_unchecked().value(*idx as usize) }
                 };
                 Some(s)
-            }
+            },
             _ => None,
         }
     }
@@ -809,16 +809,16 @@ impl PartialEq for AnyValue<'_> {
             #[cfg(all(feature = "dtype-datetime", feature = "dtype-date"))]
             (Datetime(l, tul, tzl), Datetime(r, tur, tzr)) => {
                 *l == *r && *tul == *tur && tzl == tzr
-            }
+            },
             (List(l), List(r)) => l == r,
             #[cfg(feature = "dtype-categorical")]
             (Categorical(idx_l, rev_l, _), Categorical(idx_r, rev_r, _)) => match (rev_l, rev_r) {
                 (RevMapping::Global(_, _, id_l), RevMapping::Global(_, _, id_r)) => {
                     id_l == id_r && idx_l == idx_r
-                }
+                },
                 (RevMapping::Local(arr_l), RevMapping::Local(arr_r)) => {
                     std::ptr::eq(arr_l, arr_r) && idx_l == idx_r
-                }
+                },
                 _ => false,
             },
             #[cfg(feature = "dtype-duration")]
@@ -828,20 +828,20 @@ impl PartialEq for AnyValue<'_> {
                 let l = &*l.0;
                 let r = &*r.0;
                 l == r
-            }
+            },
             // TODO! add structowned with idx and arced structarray
             #[cfg(feature = "dtype-struct")]
             (StructOwned(l), Struct(idx, arr, fields)) => {
                 let fields_left = &*l.0;
                 let avs = struct_to_avs_static(*idx, arr, fields);
                 fields_left == avs
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             (Struct(idx, arr, fields), StructOwned(r)) => {
                 let fields_right = &*r.0;
                 let avs = struct_to_avs_static(*idx, arr, fields);
                 fields_right == avs
-            }
+            },
             _ => false,
         }
     }
@@ -1021,7 +1021,7 @@ impl GetAnyValue for ArrayRef {
                     None => AnyValue::Null,
                     Some(v) => AnyValue::Int8(v),
                 }
-            }
+            },
             ArrowDataType::Int16 => {
                 let arr = self
                     .as_any()
@@ -1031,7 +1031,7 @@ impl GetAnyValue for ArrayRef {
                     None => AnyValue::Null,
                     Some(v) => AnyValue::Int16(v),
                 }
-            }
+            },
             ArrowDataType::Int32 => {
                 let arr = self
                     .as_any()
@@ -1041,7 +1041,7 @@ impl GetAnyValue for ArrayRef {
                     None => AnyValue::Null,
                     Some(v) => AnyValue::Int32(v),
                 }
-            }
+            },
             ArrowDataType::Int64 => {
                 let arr = self
                     .as_any()
@@ -1051,7 +1051,7 @@ impl GetAnyValue for ArrayRef {
                     None => AnyValue::Null,
                     Some(v) => AnyValue::Int64(v),
                 }
-            }
+            },
             ArrowDataType::UInt8 => {
                 let arr = self
                     .as_any()
@@ -1061,7 +1061,7 @@ impl GetAnyValue for ArrayRef {
                     None => AnyValue::Null,
                     Some(v) => AnyValue::UInt8(v),
                 }
-            }
+            },
             ArrowDataType::UInt16 => {
                 let arr = self
                     .as_any()
@@ -1071,7 +1071,7 @@ impl GetAnyValue for ArrayRef {
                     None => AnyValue::Null,
                     Some(v) => AnyValue::UInt16(v),
                 }
-            }
+            },
             ArrowDataType::UInt32 => {
                 let arr = self
                     .as_any()
@@ -1081,7 +1081,7 @@ impl GetAnyValue for ArrayRef {
                     None => AnyValue::Null,
                     Some(v) => AnyValue::UInt32(v),
                 }
-            }
+            },
             ArrowDataType::UInt64 => {
                 let arr = self
                     .as_any()
@@ -1091,7 +1091,7 @@ impl GetAnyValue for ArrayRef {
                     None => AnyValue::Null,
                     Some(v) => AnyValue::UInt64(v),
                 }
-            }
+            },
             ArrowDataType::Float32 => {
                 let arr = self
                     .as_any()
@@ -1101,7 +1101,7 @@ impl GetAnyValue for ArrayRef {
                     None => AnyValue::Null,
                     Some(v) => AnyValue::Float32(v),
                 }
-            }
+            },
             ArrowDataType::Float64 => {
                 let arr = self
                     .as_any()
@@ -1111,7 +1111,7 @@ impl GetAnyValue for ArrayRef {
                     None => AnyValue::Null,
                     Some(v) => AnyValue::Float64(v),
                 }
-            }
+            },
             ArrowDataType::Boolean => {
                 let arr = self
                     .as_any()
@@ -1121,7 +1121,7 @@ impl GetAnyValue for ArrayRef {
                     None => AnyValue::Null,
                     Some(v) => AnyValue::Boolean(v),
                 }
-            }
+            },
             ArrowDataType::LargeUtf8 => {
                 let arr = self
                     .as_any()
@@ -1131,7 +1131,7 @@ impl GetAnyValue for ArrayRef {
                     None => AnyValue::Null,
                     Some(v) => AnyValue::Utf8(v),
                 }
-            }
+            },
             _ => unimplemented!(),
         }
     }
@@ -1143,34 +1143,34 @@ impl<K: NumericNative> From<K> for AnyValue<'_> {
             match K::PRIMITIVE {
                 PrimitiveType::Int8 => {
                     AnyValue::Int8(NumCast::from(value).unwrap_unchecked_release())
-                }
+                },
                 PrimitiveType::Int16 => {
                     AnyValue::Int16(NumCast::from(value).unwrap_unchecked_release())
-                }
+                },
                 PrimitiveType::Int32 => {
                     AnyValue::Int32(NumCast::from(value).unwrap_unchecked_release())
-                }
+                },
                 PrimitiveType::Int64 => {
                     AnyValue::Int64(NumCast::from(value).unwrap_unchecked_release())
-                }
+                },
                 PrimitiveType::UInt8 => {
                     AnyValue::UInt8(NumCast::from(value).unwrap_unchecked_release())
-                }
+                },
                 PrimitiveType::UInt16 => {
                     AnyValue::UInt16(NumCast::from(value).unwrap_unchecked_release())
-                }
+                },
                 PrimitiveType::UInt32 => {
                     AnyValue::UInt32(NumCast::from(value).unwrap_unchecked_release())
-                }
+                },
                 PrimitiveType::UInt64 => {
                     AnyValue::UInt64(NumCast::from(value).unwrap_unchecked_release())
-                }
+                },
                 PrimitiveType::Float32 => {
                     AnyValue::Float32(NumCast::from(value).unwrap_unchecked_release())
-                }
+                },
                 PrimitiveType::Float64 => {
                     AnyValue::Float64(NumCast::from(value).unwrap_unchecked_release())
-                }
+                },
                 // not supported by polars
                 _ => unreachable!(),
             }

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -82,7 +82,7 @@ impl PartialEq for DataType {
                 #[cfg(feature = "dtype-array")]
                 (Array(left_inner, left_width), Array(right_inner, right_width)) => {
                     left_width == right_width && left_inner == right_inner
-                }
+                },
                 _ => std::mem::discriminant(self) == std::mem::discriminant(other),
             }
         }
@@ -139,7 +139,7 @@ impl DataType {
                     .map(|s| Field::new(s.name(), s.data_type().to_physical()))
                     .collect();
                 Struct(new_fields)
-            }
+            },
             _ => self.clone(),
         }
     }
@@ -263,7 +263,7 @@ impl DataType {
             Struct(fields) => {
                 let fields = fields.iter().map(|fld| fld.to_arrow()).collect();
                 ArrowDataType::Struct(fields)
-            }
+            },
             Unknown => unreachable!(),
         }
     }
@@ -309,9 +309,9 @@ impl Display for DataType {
                     (None, Some(scale)) => f.write_str(&format!("decimal[{scale}]")),
                     (Some(precision), Some(scale)) => {
                         f.write_str(&format!("decimal[{precision},{scale}]"))
-                    }
+                    },
                 };
-            }
+            },
             DataType::Utf8 => "str",
             DataType::Binary => "binary",
             DataType::Date => "date",
@@ -321,7 +321,7 @@ impl Display for DataType {
                     Some(tz) => format!("datetime[{tu}, {tz}]"),
                 };
                 return f.write_str(&s);
-            }
+            },
             DataType::Duration(tu) => return write!(f, "duration[{tu}]"),
             DataType::Time => "time",
             #[cfg(feature = "dtype-array")]
@@ -347,17 +347,17 @@ pub fn merge_dtypes(left: &DataType, right: &DataType) -> PolarsResult<DataType>
         (Categorical(Some(rev_map_l)), Categorical(Some(rev_map_r))) => {
             let rev_map = merge_rev_map(rev_map_l, rev_map_r)?;
             Categorical(Some(rev_map))
-        }
+        },
         (List(inner_l), List(inner_r)) => {
             let merged = merge_dtypes(inner_l, inner_r)?;
             List(Box::new(merged))
-        }
+        },
         #[cfg(feature = "dtype-array")]
         (Array(inner_l, width_l), Array(inner_r, width_r)) => {
             polars_ensure!(width_l == width_r, ComputeError: "widths of FixedSizeWidth Series are not equal");
             let merged = merge_dtypes(inner_l, inner_r)?;
             Array(Box::new(merged), *width_l)
-        }
+        },
         (left, right) if left == right => left.clone(),
         _ => polars_bail!(ComputeError: "unable to merge datatypes"),
     })

--- a/crates/polars-core/src/datatypes/time_unit.rs
+++ b/crates/polars-core/src/datatypes/time_unit.rs
@@ -28,13 +28,13 @@ impl Display for TimeUnit {
         match self {
             TimeUnit::Nanoseconds => {
                 write!(f, "ns")
-            }
+            },
             TimeUnit::Microseconds => {
                 write!(f, "μs")
-            }
+            },
             TimeUnit::Milliseconds => {
                 write!(f, "ms")
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -144,7 +144,7 @@ fn format_object_array(
             }
 
             write!(f, "]")
-        }
+        },
         _ => unreachable!(),
     }
 }
@@ -237,74 +237,74 @@ impl Debug for Series {
         match self.dtype() {
             DataType::Boolean => {
                 format_array!(f, self.bool().unwrap(), "bool", self.name(), "Series")
-            }
+            },
             DataType::Utf8 => {
                 format_array!(f, self.utf8().unwrap(), "str", self.name(), "Series")
-            }
+            },
             DataType::UInt8 => {
                 format_array!(f, self.u8().unwrap(), "u8", self.name(), "Series")
-            }
+            },
             DataType::UInt16 => {
                 format_array!(f, self.u16().unwrap(), "u16", self.name(), "Series")
-            }
+            },
             DataType::UInt32 => {
                 format_array!(f, self.u32().unwrap(), "u32", self.name(), "Series")
-            }
+            },
             DataType::UInt64 => {
                 format_array!(f, self.u64().unwrap(), "u64", self.name(), "Series")
-            }
+            },
             DataType::Int8 => {
                 format_array!(f, self.i8().unwrap(), "i8", self.name(), "Series")
-            }
+            },
             DataType::Int16 => {
                 format_array!(f, self.i16().unwrap(), "i16", self.name(), "Series")
-            }
+            },
             DataType::Int32 => {
                 format_array!(f, self.i32().unwrap(), "i32", self.name(), "Series")
-            }
+            },
             DataType::Int64 => {
                 format_array!(f, self.i64().unwrap(), "i64", self.name(), "Series")
-            }
+            },
             DataType::Float32 => {
                 format_array!(f, self.f32().unwrap(), "f32", self.name(), "Series")
-            }
+            },
             DataType::Float64 => {
                 format_array!(f, self.f64().unwrap(), "f64", self.name(), "Series")
-            }
+            },
             #[cfg(feature = "dtype-date")]
             DataType::Date => format_array!(f, self.date().unwrap(), "date", self.name(), "Series"),
             #[cfg(feature = "dtype-datetime")]
             DataType::Datetime(_, _) => {
                 let dt = format!("{}", self.dtype());
                 format_array!(f, self.datetime().unwrap(), &dt, self.name(), "Series")
-            }
+            },
             #[cfg(feature = "dtype-time")]
             DataType::Time => format_array!(f, self.time().unwrap(), "time", self.name(), "Series"),
             #[cfg(feature = "dtype-duration")]
             DataType::Duration(_) => {
                 let dt = format!("{}", self.dtype());
                 format_array!(f, self.duration().unwrap(), &dt, self.name(), "Series")
-            }
+            },
             #[cfg(feature = "dtype-decimal")]
             DataType::Decimal(_, _) => {
                 let dt = format!("{}", self.dtype());
                 format_array!(f, self.decimal().unwrap(), &dt, self.name(), "Series")
-            }
+            },
             #[cfg(feature = "dtype-array")]
             DataType::Array(_, _) => {
                 let dt = format!("{}", self.dtype());
                 format_array!(f, self.array().unwrap(), &dt, self.name(), "Series")
-            }
+            },
             DataType::List(_) => {
                 let dt = format!("{}", self.dtype());
                 format_array!(f, self.list().unwrap(), &dt, self.name(), "Series")
-            }
+            },
             #[cfg(feature = "object")]
             DataType::Object(_) => format_object_array(f, self, self.name(), "Series"),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_) => {
                 format_array!(f, self.categorical().unwrap(), "cat", self.name(), "Series")
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             dt @ DataType::Struct(_) => format_array!(
                 f,
@@ -315,10 +315,10 @@ impl Debug for Series {
             ),
             DataType::Null => {
                 writeln!(f, "nullarray")
-            }
+            },
             DataType::Binary => {
                 format_array!(f, self.binary().unwrap(), "binary", self.name(), "Series")
-            }
+            },
             dt => panic!("{dt:?} not impl"),
         }
     }
@@ -851,9 +851,9 @@ impl Display for AnyValue<'_> {
                     None => write!(f, "{ndt}"),
                     Some(tz) => {
                         write!(f, "{}", PlTzAware::new(ndt, tz))
-                    }
+                    },
                 }
-            }
+            },
             #[cfg(feature = "dtype-duration")]
             AnyValue::Duration(v, tu) => match tu {
                 TimeUnit::Nanoseconds => fmt_duration_ns(f, *v),
@@ -864,12 +864,12 @@ impl Display for AnyValue<'_> {
             AnyValue::Time(_) => {
                 let nt: chrono::NaiveTime = self.into();
                 write!(f, "{nt}")
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             AnyValue::Categorical(_, _, _) => {
                 let s = self.get_str().unwrap();
                 write!(f, "\"{s}\"")
-            }
+            },
             #[cfg(feature = "dtype-array")]
             AnyValue::Array(s, _size) => write!(f, "{}", s.fmt_list()),
             AnyValue::List(s) => write!(f, "{}", s.fmt_list()),
@@ -882,7 +882,7 @@ impl Display for AnyValue<'_> {
                 let mut avs = vec![];
                 av._materialize_struct_av(&mut avs);
                 fmt_struct(f, &avs)
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             AnyValue::StructOwned(payload) => fmt_struct(f, &payload.0),
             #[cfg(feature = "dtype-decimal")]
@@ -915,7 +915,7 @@ impl Display for PlTzAware<'_> {
                 let dt_utc = chrono::Utc.from_local_datetime(&self.ndt).unwrap();
                 let dt_tz_aware = dt_utc.with_timezone(&tz);
                 write!(f, "{dt_tz_aware}")
-            }
+            },
             Err(_) => write!(f, "invalid timezone"),
         }
         #[cfg(not(feature = "timezones"))]

--- a/crates/polars-core/src/frame/asof_join/asof.rs
+++ b/crates/polars-core/src/frame/asof_join/asof.rs
@@ -31,11 +31,11 @@ pub(super) fn join_asof_forward_with_tolerance<T: PartialOrd + Copy + Debug + Su
                         break;
                     }
                     offset += 1;
-                }
+                },
                 None => {
                     out.extend(std::iter::repeat(None).take(left.len() - out.len()));
                     return out;
-                }
+                },
             }
         }
     }
@@ -103,7 +103,7 @@ where
                         previous_right = val_r;
                         offset += 1;
                     }
-                }
+                },
                 // we depleted the right array
                 // we cannot fill the remainder of the value, because we need to check tolerances
                 None => {
@@ -117,7 +117,7 @@ where
                     };
                     out.push(val);
                     break;
-                }
+                },
             }
         }
     }
@@ -162,7 +162,7 @@ pub(super) fn join_asof_backward<T: PartialOrd + Copy + Debug>(
                     else {
                         offset += 1;
                     }
-                }
+                },
                 // we depleted the right array
                 None => {
                     // if we have previous value, continue with that one
@@ -175,7 +175,7 @@ pub(super) fn join_asof_backward<T: PartialOrd + Copy + Debug>(
                     };
                     out.extend(std::iter::repeat(val).take(left.len() - out.len()));
                     return out;
-                }
+                },
             }
         }
     }
@@ -216,7 +216,7 @@ pub(super) fn join_asof_nearest<T: PartialOrd + Copy + Debug + Sub<Output = T> +
                         offset -= 1;
                         break;
                     }
-                }
+                },
 
                 None => {
                     if offset > 1 {
@@ -229,7 +229,7 @@ pub(super) fn join_asof_nearest<T: PartialOrd + Copy + Debug + Sub<Output = T> +
                         out.extend(std::iter::repeat(None).take(left.len() - out.len()));
                     }
                     return out;
-                }
+                },
             }
         }
     }
@@ -253,11 +253,11 @@ pub(super) fn join_asof_forward<T: PartialOrd + Copy + Debug>(
                         break;
                     }
                     offset += 1;
-                }
+                },
                 None => {
                     out.extend(std::iter::repeat(None).take(left.len() - out.len()));
                     return out;
-                }
+                },
             }
         }
     }

--- a/crates/polars-core/src/frame/asof_join/groups.rs
+++ b/crates/polars-core/src/frame/asof_join/groups.rs
@@ -215,7 +215,7 @@ fn process_group<K, T>(
         Some(_) => {
             results.push(join_idx);
             right_tbl_offsets.insert(k, (offset_slice, join_idx));
-        }
+        },
         None => {
             if forward {
                 previous_join_idx = None;
@@ -231,7 +231,7 @@ fn process_group<K, T>(
                 }
             }
             results.push(previous_join_idx)
-        }
+        },
     }
 }
 
@@ -261,7 +261,7 @@ where
                 tol,
                 false,
             )
-        }
+        },
         (None, AsofStrategy::Backward) => (
             join_asof_backward_with_indirection,
             T::Native::zero(),
@@ -270,13 +270,13 @@ where
         (Some(tolerance), AsofStrategy::Forward) => {
             let tol = tolerance.extract::<T::Native>().unwrap();
             (join_asof_forward_with_indirection_and_tolerance, tol, true)
-        }
+        },
         (None, AsofStrategy::Forward) => {
             (join_asof_forward_with_indirection, T::Native::zero(), true)
-        }
+        },
         (_, AsofStrategy::Nearest) => {
             (join_asof_nearest_with_indirection, T::Native::zero(), false)
-        }
+        },
     };
 
     let left_asof = left_asof.rechunk();
@@ -360,7 +360,7 @@ where
                                 &mut results,
                                 forward,
                             );
-                        }
+                        },
                         // only left values, right = null
                         None => results.push(None),
                     }
@@ -395,7 +395,7 @@ where
                 tol,
                 false,
             )
-        }
+        },
         (None, AsofStrategy::Backward) => (
             join_asof_backward_with_indirection,
             T::Native::zero(),
@@ -404,13 +404,13 @@ where
         (Some(tolerance), AsofStrategy::Forward) => {
             let tol = tolerance.extract::<T::Native>().unwrap();
             (join_asof_forward_with_indirection_and_tolerance, tol, true)
-        }
+        },
         (None, AsofStrategy::Forward) => {
             (join_asof_forward_with_indirection, T::Native::zero(), true)
-        }
+        },
         (_, AsofStrategy::Nearest) => {
             (join_asof_nearest_with_indirection, T::Native::zero(), false)
-        }
+        },
     };
 
     let left_asof = left_asof.rechunk();
@@ -484,7 +484,7 @@ where
                                 &mut results,
                                 forward,
                             );
-                        }
+                        },
                         // only left values, right = null
                         None => results.push(None),
                     }
@@ -521,7 +521,7 @@ where
                 tol,
                 false,
             )
-        }
+        },
         (None, AsofStrategy::Backward) => (
             join_asof_backward_with_indirection,
             T::Native::zero(),
@@ -530,13 +530,13 @@ where
         (Some(tolerance), AsofStrategy::Forward) => {
             let tol = tolerance.extract::<T::Native>().unwrap();
             (join_asof_forward_with_indirection_and_tolerance, tol, true)
-        }
+        },
         (None, AsofStrategy::Forward) => {
             (join_asof_forward_with_indirection, T::Native::zero(), true)
-        }
+        },
         (_, AsofStrategy::Nearest) => {
             (join_asof_nearest_with_indirection, T::Native::zero(), false)
-        }
+        },
     };
     let left_asof = left_asof.rechunk();
     let left_asof = left_asof.cont_slice().unwrap();
@@ -607,7 +607,7 @@ where
                                     &mut results,
                                     forward,
                                 );
-                            }
+                            },
                             // only left values, right = null
                             None => results.push(None),
                         }
@@ -669,7 +669,7 @@ fn dispatch_join<T: PolarsNumericType>(
                         &left_by, &right_by, left_asof, right_asof, tolerance, strategy,
                     )?
                 }
-            }
+            },
         }
     } else {
         for (lhs, rhs) in left_by.get_columns().iter().zip(right_by.get_columns()) {

--- a/crates/polars-core/src/frame/asof_join/mod.rs
+++ b/crates/polars-core/src/frame/asof_join/mod.rs
@@ -90,7 +90,7 @@ where
                         other.cont_slice().unwrap(),
                         tolerance,
                     )
-                }
+                },
             },
             AsofStrategy::Backward => match tolerance {
                 None => join_asof_backward(ca.cont_slice().unwrap(), other.cont_slice().unwrap()),
@@ -101,11 +101,11 @@ where
                         other.cont_slice().unwrap(),
                         tolerance,
                     )
-                }
+                },
             },
             AsofStrategy::Nearest => {
                 join_asof_nearest(ca.cont_slice().unwrap(), other.cont_slice().unwrap())
-            }
+            },
         };
         Ok(out)
     }
@@ -163,7 +163,7 @@ impl DataFrame {
                     .i32()
                     .unwrap()
                     .join_asof(&right_key, strategy, tolerance)
-            }
+            },
         }?;
 
         // take_idx are sorted so this is a bound check for all

--- a/crates/polars-core/src/frame/cross_join.rs
+++ b/crates/polars-core/src/frame/cross_join.rs
@@ -16,7 +16,7 @@ fn slice_take(
         Some((offset, len)) => {
             let (offset, len) = slice_offsets(offset, len, total_rows as usize);
             inner(offset as IdxSize, (len + offset) as IdxSize, n_rows_right)
-        }
+        },
     }
 }
 

--- a/crates/polars-core/src/frame/groupby/aggregations/agg_list.rs
+++ b/crates/polars-core/src/frame/groupby/aggregations/agg_list.rs
@@ -88,7 +88,7 @@ where
                     ca.set_fast_explode()
                 }
                 ca.into()
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 let mut can_fast_explode = true;
                 let arr = ca.downcast_iter().next().unwrap();
@@ -145,7 +145,7 @@ where
                     ca.set_fast_explode()
                 }
                 ca.into()
-            }
+            },
         }
     }
 }
@@ -161,7 +161,7 @@ impl AggList for BooleanChunked {
                     builder.append(&ca)
                 }
                 builder.finish().into_series()
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 let mut builder =
                     ListBooleanChunkedBuilder::new(self.name(), groups.len(), self.len());
@@ -170,7 +170,7 @@ impl AggList for BooleanChunked {
                     builder.append(&ca)
                 }
                 builder.finish().into_series()
-            }
+            },
         }
     }
 }
@@ -187,7 +187,7 @@ impl AggList for Utf8Chunked {
                     builder.append(&ca)
                 }
                 builder.finish().into_series()
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 let mut builder =
                     ListUtf8ChunkedBuilder::new(self.name(), groups.len(), self.len());
@@ -196,7 +196,7 @@ impl AggList for Utf8Chunked {
                     builder.append(&ca)
                 }
                 builder.finish().into_series()
-            }
+            },
         }
     }
 }
@@ -212,7 +212,7 @@ impl AggList for BinaryChunked {
                     builder.append(&ca)
                 }
                 builder.finish().into_series()
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 let mut builder =
                     ListBinaryChunkedBuilder::new(self.name(), groups.len(), self.len());
@@ -221,7 +221,7 @@ impl AggList for BinaryChunked {
                     builder.append(&ca)
                 }
                 builder.finish().into_series()
-            }
+            },
         }
     }
 }
@@ -305,7 +305,7 @@ impl AggList for ListChunked {
                 };
 
                 agg_list_by_slicing(self, self.dtype().clone(), groups.len(), func)
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 let func = |ca: &ListChunked,
                             mut can_fast_explode: bool,
@@ -333,7 +333,7 @@ impl AggList for ListChunked {
                 };
 
                 agg_list_by_slicing(self, self.dtype().clone(), groups.len(), func)
-            }
+            },
         }
     }
 }
@@ -371,7 +371,7 @@ impl AggList for ArrayChunked {
                 };
 
                 agg_list_by_slicing(self, self.dtype().clone(), groups.len(), func)
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 let func = |ca: &ArrayChunked,
                             mut can_fast_explode: bool,
@@ -397,7 +397,7 @@ impl AggList for ArrayChunked {
                 };
 
                 agg_list_by_slicing(self, self.dtype().clone(), groups.len(), func)
-            }
+            },
         }
     }
 }
@@ -422,12 +422,12 @@ impl<T: PolarsObject> AggList for ObjectChunked<T> {
                             let group_vals = self.take_unchecked(idx.into());
 
                             (group_vals, idx.len() as IdxSize)
-                        }
+                        },
                         GroupsIndicator::Slice([first, len]) => {
                             let group_vals = _slice_from_offsets(self, first, len);
 
                             (group_vals, len)
-                        }
+                        },
                     };
 
                     if len == 0 {
@@ -485,7 +485,7 @@ impl AggList for StructChunked {
                     builder.append_series(&taken).unwrap();
                 }
                 builder.finish().into_series()
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 let mut builder = AnonymousOwnedListBuilder::new(
                     self.name(),
@@ -497,7 +497,7 @@ impl AggList for StructChunked {
                     builder.append_series(&taken).unwrap();
                 }
                 builder.finish().into_series()
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/frame/groupby/aggregations/boolean.rs
+++ b/crates/polars-core/src/frame/groupby/aggregations/boolean.rs
@@ -22,11 +22,11 @@ impl BooleanChunked {
         match (self.is_sorted_flag(), self.null_count()) {
             (IsSorted::Ascending, 0) => {
                 return self.clone().into_series().agg_first(groups);
-            }
+            },
             (IsSorted::Descending, 0) => {
                 return self.clone().into_series().agg_last(groups);
-            }
-            _ => {}
+            },
+            _ => {},
         }
         let ca_self = self.rechunk();
         let arr = ca_self.downcast_iter().next().unwrap();
@@ -55,7 +55,7 @@ impl BooleanChunked {
                     _ => {
                         let arr_group = _slice_from_offsets(self, first, len);
                         arr_group.min()
-                    }
+                    },
                 }
             }),
         }
@@ -65,11 +65,11 @@ impl BooleanChunked {
         match (self.is_sorted_flag(), self.null_count()) {
             (IsSorted::Ascending, 0) => {
                 return self.clone().into_series().agg_last(groups);
-            }
+            },
             (IsSorted::Descending, 0) => {
                 return self.clone().into_series().agg_first(groups);
-            }
-            _ => {}
+            },
+            _ => {},
         }
 
         let ca_self = self.rechunk();
@@ -99,7 +99,7 @@ impl BooleanChunked {
                     _ => {
                         let arr_group = _slice_from_offsets(self, first, len);
                         arr_group.max()
-                    }
+                    },
                 }
             }),
         }

--- a/crates/polars-core/src/frame/groupby/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/groupby/aggregations/dispatch.rs
@@ -41,7 +41,7 @@ impl Series {
                         Some((take.len() - take.null_count()) as IdxSize)
                     }
                 })
-            }
+            },
         }
     }
 
@@ -59,7 +59,7 @@ impl Series {
                 // Safety:
                 // groups are always in bounds
                 self.take_opt_iter_unchecked(&mut iter)
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 let mut iter =
                     groups.iter().map(
@@ -74,7 +74,7 @@ impl Series {
                 // Safety:
                 // groups are always in bounds
                 self.take_opt_iter_unchecked(&mut iter)
-            }
+            },
         };
         if groups.is_sorted_flag() {
             out.set_sorted_flag(self.is_sorted_flag())
@@ -104,7 +104,7 @@ impl Series {
                         take.n_unique().ok().map(|v| v as IdxSize)
                     }
                 })
-            }
+            },
         }
     }
 
@@ -126,7 +126,7 @@ impl Series {
                 } else {
                     s
                 }
-            }
+            },
             _ => Series::full_null("", groups.len(), self.dtype()),
         }
     }
@@ -155,7 +155,7 @@ impl Series {
                 } else {
                     s
                 }
-            }
+            },
             _ => Series::full_null("", groups.len(), self.dtype()),
         }
     }
@@ -170,14 +170,14 @@ impl Series {
             Float64 => SeriesWrap(self.f64().unwrap().clone()).agg_mean(groups),
             dt if dt.is_numeric() => {
                 apply_method_physical_integer!(self, agg_mean, groups)
-            }
+            },
             dt @ Duration(_) => {
                 let s = self.to_physical_repr();
                 // agg_mean returns Float64
                 let out = s.agg_mean(groups);
                 // cast back to Int64 and then to logical duration type
                 out.cast(&Int64).unwrap().cast(dt).unwrap()
-            }
+            },
             _ => Series::full_null("", groups.len(), self.dtype()),
         }
     }
@@ -194,7 +194,7 @@ impl Series {
                     }
                 });
                 self.take_opt_iter_unchecked(&mut iter)
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 let mut iter = groups.iter().map(|&[first, len]| {
                     if len == 0 {
@@ -204,7 +204,7 @@ impl Series {
                     }
                 });
                 self.take_opt_iter_unchecked(&mut iter)
-            }
+            },
         };
         self.restore_logical(out)
     }

--- a/crates/polars-core/src/frame/groupby/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/groupby/aggregations/mod.rs
@@ -54,7 +54,7 @@ pub fn _use_rolling_kernels(groups: &GroupsSlice, chunks: &[ArrayRef]) -> bool {
             let second_offset = groups[1][0];
 
             second_offset < (first_offset + first_len) && chunks.len() == 1
-        }
+        },
     }
 }
 
@@ -106,7 +106,7 @@ where
                     // safety: we are in bounds
                     unsafe { validity.set_unchecked(idx, false) };
                     T::default()
-                }
+                },
             }
         })
         .collect_trusted::<Vec<_>>();
@@ -359,7 +359,7 @@ where
                 // checked with invalid quantile check
                 take._quantile(quantile, interpol).unwrap_unchecked()
             })
-        }
+        },
         GroupsProxy::Slice { groups, .. } => {
             if _use_rolling_kernels(groups, ca.chunks()) {
                 // this cast is a no-op for floats
@@ -387,7 +387,7 @@ where
                                 interpol,
                             })),
                         )
-                    }
+                    },
                 };
                 // The rolling kernels works on the dtype, this is not yet the
                 // float output type we need.
@@ -405,11 +405,11 @@ where
                                 ._quantile(quantile, interpol)
                                 .unwrap_unchecked()
                                 .map(|flt| NumCast::from(flt).unwrap_unchecked())
-                        }
+                        },
                     }
                 })
             }
-        }
+        },
     }
 }
 
@@ -432,10 +432,10 @@ where
                 let take = { ca.take_unchecked(idx.into()) };
                 take._median()
             })
-        }
+        },
         GroupsProxy::Slice { .. } => {
             agg_quantile_generic::<T, K>(ca, groups, 0.5, QuantileInterpolOptions::Linear)
-        }
+        },
     }
 }
 
@@ -461,11 +461,11 @@ where
         match (self.is_sorted_flag(), self.null_count()) {
             (IsSorted::Ascending, 0) => {
                 return self.clone().into_series().agg_first(groups);
-            }
+            },
             (IsSorted::Descending, 0) => {
                 return self.clone().into_series().agg_last(groups);
-            }
-            _ => {}
+            },
+            _ => {},
         }
         match groups {
             GroupsProxy::Idx(groups) => {
@@ -495,7 +495,7 @@ where
                         )
                     }
                 })
-            }
+            },
             GroupsProxy::Slice {
                 groups: groups_slice,
                 ..
@@ -528,11 +528,11 @@ where
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
                                 arr_group.min()
-                            }
+                            },
                         }
                     })
                 }
-            }
+            },
         }
     }
 
@@ -541,11 +541,11 @@ where
         match (self.is_sorted_flag(), self.null_count()) {
             (IsSorted::Ascending, 0) => {
                 return self.clone().into_series().agg_last(groups);
-            }
+            },
             (IsSorted::Descending, 0) => {
                 return self.clone().into_series().agg_first(groups);
-            }
-            _ => {}
+            },
+            _ => {},
         }
 
         match groups {
@@ -578,7 +578,7 @@ where
                         )
                     }
                 })
-            }
+            },
             GroupsProxy::Slice {
                 groups: groups_slice,
                 ..
@@ -611,11 +611,11 @@ where
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
                                 arr_group.max()
-                            }
+                            },
                         }
                     })
                 }
-            }
+            },
         }
     }
 
@@ -649,7 +649,7 @@ where
                         .unwrap_or(T::Native::zero())
                     }
                 })
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 if _use_rolling_kernels(groups, self.chunks()) {
                     let arr = self.downcast_iter().next().unwrap();
@@ -679,11 +679,11 @@ where
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
                                 arr_group.sum().unwrap_or(T::Native::zero())
-                            }
+                            },
                         }
                     })
                 }
-            }
+            },
         }
     }
 }
@@ -743,7 +743,7 @@ where
                     };
                     out.map(|flt| NumCast::from(flt).unwrap())
                 })
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 if _use_rolling_kernels(groups, self.chunks()) {
                     let arr = self.downcast_iter().next().unwrap();
@@ -773,11 +773,11 @@ where
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
                                 arr_group.mean().map(|flt| NumCast::from(flt).unwrap())
-                            }
+                            },
                         }
                     })
                 }
-            }
+            },
         }
     }
 
@@ -803,7 +803,7 @@ where
                     };
                     out.map(|flt| NumCast::from(flt).unwrap())
                 })
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 if _use_rolling_kernels(groups, self.chunks()) {
                     let arr = self.downcast_iter().next().unwrap();
@@ -822,7 +822,7 @@ where
                                 offset_iter,
                                 Some(Arc::new(RollingVarParams { ddof })),
                             )
-                        }
+                        },
                     };
                     ChunkedArray::<T>::from_chunk_iter("", [arr]).into_series()
                 } else {
@@ -834,11 +834,11 @@ where
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
                                 arr_group.var(ddof).map(|flt| NumCast::from(flt).unwrap())
-                            }
+                            },
                         }
                     })
                 }
-            }
+            },
         }
     }
     pub(crate) unsafe fn agg_std(&self, groups: &GroupsProxy, ddof: u8) -> Series
@@ -862,7 +862,7 @@ where
                     };
                     out.map(|flt| NumCast::from(flt.sqrt()).unwrap())
                 })
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 if _use_rolling_kernels(groups, self.chunks()) {
                     let arr = self.downcast_iter().next().unwrap();
@@ -881,7 +881,7 @@ where
                                 offset_iter,
                                 Some(Arc::new(RollingVarParams { ddof })),
                             )
-                        }
+                        },
                     };
 
                     let mut ca = ChunkedArray::<T>::from_chunk_iter("", [arr]);
@@ -896,11 +896,11 @@ where
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
                                 arr_group.std(ddof).map(|flt| NumCast::from(flt).unwrap())
-                            }
+                            },
                         }
                     })
                 }
-            }
+            },
         }
     }
 }
@@ -985,15 +985,15 @@ where
                                 .map(|(sum, null_count)| {
                                     sum / (idx.len() as f64 - null_count as f64)
                                 })
-                            }
+                            },
                             _ => {
                                 let take = { self.take_unchecked(idx.into()) };
                                 take.mean()
-                            }
+                            },
                         }
                     }
                 })
-            }
+            },
             GroupsProxy::Slice {
                 groups: groups_slice,
                 ..
@@ -1010,11 +1010,11 @@ where
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
                                 arr_group.mean()
-                            }
+                            },
                         }
                     })
                 }
-            }
+            },
         }
     }
 
@@ -1035,7 +1035,7 @@ where
                         take_var_nulls_primitive_iter_unchecked(arr, idx2usize(idx), ddof)
                     }
                 })
-            }
+            },
             GroupsProxy::Slice {
                 groups: groups_slice,
                 ..
@@ -1052,11 +1052,11 @@ where
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
                                 arr_group.var(ddof)
-                            }
+                            },
                         }
                     })
                 }
-            }
+            },
         }
     }
     pub(crate) unsafe fn agg_std(&self, groups: &GroupsProxy, ddof: u8) -> Series {
@@ -1077,7 +1077,7 @@ where
                     };
                     out.map(|v| v.sqrt())
                 })
-            }
+            },
             GroupsProxy::Slice {
                 groups: groups_slice,
                 ..
@@ -1094,11 +1094,11 @@ where
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
                                 arr_group.std(ddof)
-                            }
+                            },
                         }
                     })
                 }
-            }
+            },
         }
     }
 

--- a/crates/polars-core/src/frame/groupby/aggregations/utf8.rs
+++ b/crates/polars-core/src/frame/groupby/aggregations/utf8.rs
@@ -23,11 +23,11 @@ impl Utf8Chunked {
         match (&self.is_sorted_flag(), &self.null_count()) {
             (IsSorted::Ascending, 0) => {
                 return self.clone().into_series().agg_first(groups);
-            }
+            },
             (IsSorted::Descending, 0) => {
                 return self.clone().into_series().agg_last(groups);
-            }
-            _ => {}
+            },
+            _ => {},
         }
 
         match groups {
@@ -56,7 +56,7 @@ impl Utf8Chunked {
                         )
                     }
                 })
-            }
+            },
             GroupsProxy::Slice {
                 groups: groups_slice,
                 ..
@@ -73,7 +73,7 @@ impl Utf8Chunked {
                         // The borrowed has `arr_group`s lifetime, but it actually points to data
                         // hold by self. Here we tell the compiler that.
                         unsafe { std::mem::transmute::<Option<&str>, Option<&'a str>>(borrowed) }
-                    }
+                    },
                 }
             }),
         }
@@ -85,11 +85,11 @@ impl Utf8Chunked {
         match (self.is_sorted_flag(), self.null_count()) {
             (IsSorted::Ascending, 0) => {
                 return self.clone().into_series().agg_last(groups);
-            }
+            },
             (IsSorted::Descending, 0) => {
                 return self.clone().into_series().agg_first(groups);
-            }
-            _ => {}
+            },
+            _ => {},
         }
 
         match groups {
@@ -118,7 +118,7 @@ impl Utf8Chunked {
                         )
                     }
                 })
-            }
+            },
             GroupsProxy::Slice {
                 groups: groups_slice,
                 ..
@@ -135,7 +135,7 @@ impl Utf8Chunked {
                         // The borrowed has `arr_group`s lifetime, but it actually points to data
                         // hold by self. Here we tell the compiler that.
                         unsafe { std::mem::transmute::<Option<&str>, Option<&'a str>>(borrowed) }
-                    }
+                    },
                 }
             }),
         }

--- a/crates/polars-core/src/frame/groupby/hashing.rs
+++ b/crates/polars-core/src/frame/groupby/hashing.rs
@@ -159,11 +159,11 @@ where
         match entry {
             Entry::Vacant(entry) => {
                 entry.insert((idx, vec![idx]));
-            }
+            },
             Entry::Occupied(mut entry) => {
                 let v = entry.get_mut();
                 v.1.push(idx);
-            }
+            },
         }
     });
     if sorted {
@@ -226,11 +226,11 @@ where
                                     entry.insert_with_hasher(hash, *k, (idx, tuples), |k| {
                                         hasher.hash_one(k)
                                     });
-                                }
+                                },
                                 RawEntryMut::Occupied(mut entry) => {
                                     let v = entry.get_mut();
                                     v.1.push(idx);
-                                }
+                                },
                             }
                         }
                     });
@@ -290,11 +290,11 @@ where
                                     entry.insert_with_hasher(hash, k, (idx, tuples), |k| {
                                         hasher.hash_one(k)
                                     });
-                                }
+                                },
                                 RawEntryMut::Occupied(mut entry) => {
                                     let v = entry.get_mut();
                                     v.1.push(idx);
-                                }
+                                },
                             }
                         }
                     });
@@ -380,11 +380,11 @@ pub(crate) fn populate_multiple_key_hashmap<V, H, F, G>(
     match entry {
         RawEntryMut::Vacant(entry) => {
             entry.insert_hashed_nocheck(original_h, IdxHash::new(idx, original_h), vacant_fn());
-        }
+        },
         RawEntryMut::Occupied(mut entry) => {
             let (_k, v) = entry.get_key_value_mut();
             occupied_fn(v);
-        }
+        },
     }
 }
 
@@ -442,11 +442,11 @@ pub(crate) fn populate_multiple_key_hashmap2<'a, V, H, F, G>(
     match entry {
         RawEntryMut::Vacant(entry) => {
             entry.insert_hashed_nocheck(original_h, IdxHash::new(idx, original_h), vacant_fn());
-        }
+        },
         RawEntryMut::Occupied(mut entry) => {
             let (_k, v) = entry.get_key_value_mut();
             occupied_fn(v);
-        }
+        },
     }
 }
 

--- a/crates/polars-core/src/frame/groupby/into_groups.rs
+++ b/crates/polars-core/src/frame/groupby/into_groups.rs
@@ -156,22 +156,22 @@ where
                     &*(self as *const ChunkedArray<T> as *const ChunkedArray<UInt64Type>)
                 };
                 num_groups_proxy(ca, multithreaded, sorted)
-            }
+            },
             DataType::UInt32 => {
                 // convince the compiler that we are this type.
                 let ca: &UInt32Chunked = unsafe {
                     &*(self as *const ChunkedArray<T> as *const ChunkedArray<UInt32Type>)
                 };
                 num_groups_proxy(ca, multithreaded, sorted)
-            }
+            },
             DataType::Int64 | DataType::Float64 => {
                 let ca = self.bit_repr_large();
                 num_groups_proxy(&ca, multithreaded, sorted)
-            }
+            },
             DataType::Int32 | DataType::Float32 => {
                 let ca = self.bit_repr_small();
                 num_groups_proxy(&ca, multithreaded, sorted)
-            }
+            },
             #[cfg(feature = "performant")]
             DataType::Int8 => {
                 // convince the compiler that we are this type.
@@ -179,14 +179,14 @@ where
                     unsafe { &*(self as *const ChunkedArray<T> as *const ChunkedArray<Int8Type>) };
                 let ca = ca.reinterpret_unsigned();
                 num_groups_proxy(&ca, multithreaded, sorted)
-            }
+            },
             #[cfg(feature = "performant")]
             DataType::UInt8 => {
                 // convince the compiler that we are this type.
                 let ca: &UInt8Chunked =
                     unsafe { &*(self as *const ChunkedArray<T> as *const ChunkedArray<UInt8Type>) };
                 num_groups_proxy(ca, multithreaded, sorted)
-            }
+            },
             #[cfg(feature = "performant")]
             DataType::Int16 => {
                 // convince the compiler that we are this type.
@@ -194,7 +194,7 @@ where
                     unsafe { &*(self as *const ChunkedArray<T> as *const ChunkedArray<Int16Type>) };
                 let ca = ca.reinterpret_unsigned();
                 num_groups_proxy(&ca, multithreaded, sorted)
-            }
+            },
             #[cfg(feature = "performant")]
             DataType::UInt16 => {
                 // convince the compiler that we are this type.
@@ -202,12 +202,12 @@ where
                     &*(self as *const ChunkedArray<T> as *const ChunkedArray<UInt16Type>)
                 };
                 num_groups_proxy(ca, multithreaded, sorted)
-            }
+            },
             _ => {
                 let ca = unsafe { self.cast_unchecked(&DataType::UInt32).unwrap() };
                 let ca = ca.u32().unwrap();
                 num_groups_proxy(ca, multithreaded, sorted)
-            }
+            },
         };
         Ok(out)
     }

--- a/crates/polars-core/src/frame/groupby/mod.rs
+++ b/crates/polars-core/src/frame/groupby/mod.rs
@@ -43,7 +43,7 @@ fn prepare_dataframe_unsorted(by: &[Series]) -> DataFrame {
                     } else {
                         s.clone()
                     }
-                }
+                },
             })
             .collect(),
     )
@@ -273,7 +273,7 @@ impl<'df> GroupBy<'df> {
                                 out.set_sorted_flag(s.is_sorted_flag());
                             };
                             out
-                        }
+                        },
                         GroupsProxy::Slice { groups, rolling } => {
                             if *rolling && !groups.is_empty() {
                                 // groups can be sliced
@@ -292,7 +292,7 @@ impl<'df> GroupBy<'df> {
                             // sliced groups are always in order of discovery
                             out.set_sorted_flag(s.is_sorted_flag());
                             out
-                        }
+                        },
                     }
                 })
                 .collect()
@@ -314,7 +314,7 @@ impl<'df> GroupBy<'df> {
                     .filter(|a| !by.contains(a))
                     .map(|s| s.to_string())
                     .collect()
-            }
+            },
         };
 
         let keys = self.keys();

--- a/crates/polars-core/src/frame/groupby/perfect.rs
+++ b/crates/polars-core/src/frame/groupby/perfect.rs
@@ -210,14 +210,14 @@ impl CategoricalChunked {
                 } else {
                     self.logical().group_tuples(multithreaded, sorted).unwrap()
                 }
-            }
+            },
             RevMapping::Global(_mapping, _cached, _) => {
                 // TODO! see if we can optimize this
                 // the problem is that the global categories are not guaranteed packed together
                 // so we might need to deref them first to local ones, but that might be more
                 // expensive than just hashing (benchmark first)
                 self.logical().group_tuples(multithreaded, sorted).unwrap()
-            }
+            },
         };
         if sorted {
             out.sort()

--- a/crates/polars-core/src/frame/groupby/proxy.rs
+++ b/crates/polars-core/src/frame/groupby/proxy.rs
@@ -317,7 +317,7 @@ impl GroupsProxy {
                     .iter()
                     .map(|&[first, len]| (first, (first..first + len).collect_trusted::<Vec<_>>()))
                     .collect()
-            }
+            },
         }
     }
 
@@ -331,10 +331,10 @@ impl GroupsProxy {
                 if !groups.is_sorted_flag() {
                     groups.sort()
                 }
-            }
+            },
             GroupsProxy::Slice { .. } => {
                 // invariant of the type
-            }
+            },
         }
     }
 
@@ -363,7 +363,7 @@ impl GroupsProxy {
             GroupsProxy::Idx(mut groups) => std::mem::take(&mut groups.first),
             GroupsProxy::Slice { groups, .. } => {
                 groups.into_iter().map(|[first, _len]| first).collect()
-            }
+            },
         }
     }
 
@@ -401,7 +401,7 @@ impl GroupsProxy {
                 let first = groups.first[index];
                 let all = &groups.all[index];
                 GroupsIndicator::Idx((first, all))
-            }
+            },
             GroupsProxy::Slice { groups, .. } => GroupsIndicator::Slice(groups[index]),
         }
     }
@@ -437,11 +437,11 @@ impl GroupsProxy {
                     .map(|(_first, idx)| idx.len() as IdxSize)
                     .collect_trusted();
                 ca.into_inner()
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 let ca: NoNull<IdxCa> = groups.iter().map(|[_first, len]| *len).collect_trusted();
                 ca.into_inner()
-            }
+            },
         }
     }
     pub fn as_list_chunked(&self) -> ListChunked {
@@ -477,7 +477,7 @@ impl GroupsProxy {
                     groups,
                     rolling: false,
                 }
-            }
+            },
         }
     }
 
@@ -505,7 +505,7 @@ impl GroupsProxy {
                     all,
                     groups.is_sorted_flag(),
                 )))
-            }
+            },
             GroupsProxy::Slice { groups, rolling } => {
                 let groups = unsafe {
                     let groups = slice_slice(groups, offset, len);
@@ -517,7 +517,7 @@ impl GroupsProxy {
                     groups,
                     rolling: *rolling,
                 })
-            }
+            },
         };
 
         SlicedGroups {
@@ -588,10 +588,10 @@ impl<'a> Iterator for GroupsProxyIter<'a> {
                 GroupsProxy::Idx(groups) => {
                     let item = groups.get_unchecked(self.idx);
                     Some(GroupsIndicator::Idx(item))
-                }
+                },
                 GroupsProxy::Slice { groups, .. } => {
                     Some(GroupsIndicator::Slice(*groups.get_unchecked(self.idx)))
-                }
+                },
             }
         };
         self.idx += 1;
@@ -625,7 +625,7 @@ impl<'a> ParallelIterator for GroupsProxyParIter<'a> {
                     GroupsProxy::Idx(groups) => GroupsIndicator::Idx(groups.get_unchecked(i)),
                     GroupsProxy::Slice { groups, .. } => {
                         GroupsIndicator::Slice(*groups.get_unchecked(i))
-                    }
+                    },
                 }
             })
             .drive_unindexed(consumer)

--- a/crates/polars-core/src/frame/hash_join/mod.rs
+++ b/crates/polars-core/src/frame/hash_join/mod.rs
@@ -241,14 +241,14 @@ impl DataFrame {
                     left_idx = slice_slice(left_idx, offset, len);
                 }
                 unsafe { self._create_left_df_from_slice(left_idx, true, true) }
-            }
+            },
             ChunkJoinIds::Right(left_idx) => {
                 let mut left_idx = &*left_idx;
                 if let Some((offset, len)) = slice {
                     left_idx = slice_slice(left_idx, offset, len);
                 }
                 unsafe { self.create_left_df_chunked(left_idx, true) }
-            }
+            },
         };
 
         let materialize_right = || match right_idx {
@@ -262,14 +262,14 @@ impl DataFrame {
                         right_idx.iter().map(|opt_i| opt_i.map(|i| i as usize)),
                     )
                 }
-            }
+            },
             ChunkJoinOptIds::Right(right_idx) => {
                 let mut right_idx = &*right_idx;
                 if let Some((offset, len)) = slice {
                     right_idx = slice_slice(right_idx, offset, len);
                 }
                 unsafe { other.take_opt_chunked_unchecked(right_idx) }
-            }
+            },
         };
         let (df_left, df_right) = POOL.join(materialize_left, materialize_right);
 
@@ -390,7 +390,7 @@ impl DataFrame {
                     CategoricalChunked::from_cats_and_rev_map_unchecked(logical, new_rev_map)
                         .into_series()
                 }
-            }
+            },
             dt @ DataType::Datetime(_, _)
             | dt @ DataType::Time
             | dt @ DataType::Date

--- a/crates/polars-core/src/frame/hash_join/multiple_keys.rs
+++ b/crates/polars-core/src/frame/hash_join/multiple_keys.rs
@@ -316,12 +316,12 @@ pub fn _left_join_multiple_keys(
                                 result_idx_left
                                     .extend(std::iter::repeat(idx_a).take(indexes_b.len()));
                                 result_idx_right.extend(indexes_b.iter().copied().map(Some))
-                            }
+                            },
                             // only left values, right = null
                             None => {
                                 result_idx_left.push(idx_a);
                                 result_idx_right.push(None);
-                            }
+                            },
                         }
                         idx_a += 1;
                     }
@@ -521,7 +521,7 @@ fn probe_outer<F, G, H>(
                         let (tracker, indexes_b) = occupied.get_mut();
                         *tracker = true;
                         results.extend(indexes_b.iter().map(|&idx_b| swap_fn_match(idx_a, idx_b)))
-                    }
+                    },
                     // no match
                     RawEntryMut::Vacant(_) => results.push(swap_fn_no_match(idx_a)),
                 }

--- a/crates/polars-core/src/frame/hash_join/single_keys.rs
+++ b/crates/polars-core/src/frame/hash_join/single_keys.rs
@@ -36,11 +36,11 @@ where
                             match entry {
                                 Entry::Vacant(entry) => {
                                     entry.insert(vec![idx]);
-                                }
+                                },
                                 Entry::Occupied(mut entry) => {
                                     let v = entry.get_mut();
                                     v.push(idx);
-                                }
+                                },
                             }
                         }
                     });

--- a/crates/polars-core/src/frame/hash_join/single_keys_dispatch.rs
+++ b/crates/polars-core/src/frame/hash_join/single_keys_dispatch.rs
@@ -24,12 +24,12 @@ impl Series {
                 let lhs = lhs.as_binary();
                 let rhs = rhs.as_binary();
                 lhs.hash_join_left(&rhs, validate)
-            }
+            },
             Binary => {
                 let lhs = lhs.binary().unwrap();
                 let rhs = rhs.binary().unwrap();
                 lhs.hash_join_left(rhs, validate)
-            }
+            },
             _ => {
                 if self.bit_repr_is_large() {
                     let lhs = lhs.bit_repr_large();
@@ -40,7 +40,7 @@ impl Series {
                     let rhs = rhs.bit_repr_small();
                     num_group_join_left(&lhs, &rhs, validate)
                 }
-            }
+            },
         }
     }
 
@@ -57,12 +57,12 @@ impl Series {
                 let lhs = lhs.binary().unwrap();
                 let rhs = rhs.binary().unwrap();
                 lhs.hash_join_semi_anti(rhs, anti)
-            }
+            },
             Binary => {
                 let lhs = lhs.binary().unwrap();
                 let rhs = rhs.binary().unwrap();
                 lhs.hash_join_semi_anti(rhs, anti)
-            }
+            },
             _ => {
                 if self.bit_repr_is_large() {
                     let lhs = lhs.bit_repr_large();
@@ -73,7 +73,7 @@ impl Series {
                     let rhs = rhs.bit_repr_small();
                     num_group_join_anti_semi(&lhs, &rhs, anti)
                 }
-            }
+            },
         }
     }
 
@@ -95,12 +95,12 @@ impl Series {
                 let lhs = lhs.as_binary();
                 let rhs = rhs.as_binary();
                 lhs.hash_join_inner(&rhs, validate)
-            }
+            },
             Binary => {
                 let lhs = lhs.binary().unwrap();
                 let rhs = rhs.binary().unwrap();
                 lhs.hash_join_inner(rhs, validate)
-            }
+            },
             _ => {
                 if self.bit_repr_is_large() {
                     let lhs = self.bit_repr_large();
@@ -111,7 +111,7 @@ impl Series {
                     let rhs = other.bit_repr_small();
                     num_group_join_inner(&lhs, &rhs, validate)
                 }
-            }
+            },
         }
     }
 
@@ -132,12 +132,12 @@ impl Series {
                 let lhs = lhs.as_binary();
                 let rhs = rhs.as_binary();
                 lhs.hash_join_outer(&rhs, validate)
-            }
+            },
             Binary => {
                 let lhs = lhs.binary().unwrap();
                 let rhs = rhs.binary().unwrap();
                 lhs.hash_join_outer(rhs, validate)
-            }
+            },
             _ => {
                 if self.bit_repr_is_large() {
                     let lhs = self.bit_repr_large();
@@ -148,7 +148,7 @@ impl Series {
                     let rhs = other.bit_repr_small();
                     lhs.hash_join_outer(&rhs, validate)
                 }
-            }
+            },
         }
     }
 }
@@ -210,7 +210,7 @@ where
                 hash_join_tuples_inner(keys_a, keys_b, swapped, validate)?,
                 !swapped,
             ))
-        }
+        },
         (true, true, _, _) => {
             let keys_a = splitted_by_chunks(&splitted_a);
             let keys_b = splitted_by_chunks(&splitted_b);
@@ -218,7 +218,7 @@ where
                 hash_join_tuples_inner(keys_a, keys_b, swapped, validate)?,
                 !swapped,
             ))
-        }
+        },
         _ => {
             let keys_a = splitted_to_opt_vec(&splitted_a);
             let keys_b = splitted_to_opt_vec(&splitted_b);
@@ -226,7 +226,7 @@ where
                 hash_join_tuples_inner(keys_a, keys_b, swapped, validate)?,
                 !swapped,
             ))
-        }
+        },
     }
 }
 
@@ -289,7 +289,7 @@ where
             let keys_a = splitted_to_slice(&splitted_a);
             let keys_b = splitted_to_slice(&splitted_b);
             hash_join_tuples_left(keys_a, keys_b, None, None, validate)
-        }
+        },
         (0, 0, _, _) => {
             let keys_a = splitted_by_chunks(&splitted_a);
             let keys_b = splitted_by_chunks(&splitted_b);
@@ -303,7 +303,7 @@ where
                 mapping_right.as_deref(),
                 validate,
             )
-        }
+        },
         _ => {
             let keys_a = splitted_to_opt_vec(&splitted_a);
             let keys_b = splitted_to_opt_vec(&splitted_b);
@@ -316,7 +316,7 @@ where
                 mapping_right.as_deref(),
                 validate,
             )
-        }
+        },
     }
 }
 
@@ -347,7 +347,7 @@ where
                     .map(|ca| ca.into_no_null_iter())
                     .collect::<Vec<_>>();
                 hash_join_tuples_outer(iters_a, iters_b, swapped, validate)
-            }
+            },
             _ => {
                 let iters_a = splitted_a
                     .iter()
@@ -358,7 +358,7 @@ where
                     .map(|ca| ca.into_iter())
                     .collect::<Vec<_>>();
                 hash_join_tuples_outer(iters_a, iters_b, swapped, validate)
-            }
+            },
         }
     }
 }
@@ -476,7 +476,7 @@ impl BinaryChunked {
                     .map(|ca| ca.into_no_null_iter())
                     .collect::<Vec<_>>();
                 hash_join_tuples_outer(iters_a, iters_b, swapped, validate)
-            }
+            },
             _ => {
                 let iters_a = splitted_a
                     .iter()
@@ -487,7 +487,7 @@ impl BinaryChunked {
                     .map(|ca| ca.into_iter())
                     .collect::<Vec<_>>();
                 hash_join_tuples_outer(iters_a, iters_b, swapped, validate)
-            }
+            },
         }
     }
 }
@@ -520,7 +520,7 @@ where
             } else {
                 hash_join_tuples_left_semi(keys_a, keys_b)
             }
-        }
+        },
         (0, 0, _, _) => {
             let keys_a = splitted_by_chunks(&splitted_a);
             let keys_b = splitted_by_chunks(&splitted_b);
@@ -529,7 +529,7 @@ where
             } else {
                 hash_join_tuples_left_semi(keys_a, keys_b)
             }
-        }
+        },
         _ => {
             let keys_a = splitted_to_opt_vec(&splitted_a);
             let keys_b = splitted_to_opt_vec(&splitted_b);
@@ -538,6 +538,6 @@ where
             } else {
                 hash_join_tuples_left_semi(keys_a, keys_b)
             }
-        }
+        },
     }
 }

--- a/crates/polars-core/src/frame/hash_join/single_keys_left.rs
+++ b/crates/polars-core/src/frame/hash_join/single_keys_left.rs
@@ -36,7 +36,7 @@ pub(super) fn finish_left_join_mappings(
         None => ChunkJoinOptIds::Left(result_idx_right),
         Some(mapping) => {
             ChunkJoinOptIds::Right(unsafe { apply_opt_mapping(result_idx_right, mapping) })
-        }
+        },
     };
     (left, right)
 }
@@ -159,12 +159,12 @@ where
                         Some(indexes_b) => {
                             result_idx_left.extend(std::iter::repeat(idx_a).take(indexes_b.len()));
                             result_idx_right.extend(indexes_b.iter().copied().map(Some))
-                        }
+                        },
                         // only left values, right = null
                         None => {
                             result_idx_left.push(idx_a);
                             result_idx_right.push(None);
-                        }
+                        },
                     }
                 });
                 finish_left_join_mappings(

--- a/crates/polars-core/src/frame/hash_join/single_keys_outer.rs
+++ b/crates/polars-core/src/frame/hash_join/single_keys_outer.rs
@@ -41,7 +41,7 @@ fn probe_outer<T, F, G, H>(
                     let (tracker, indexes_b) = occupied.get_mut();
                     *tracker = true;
                     results.extend(indexes_b.iter().map(|&idx_b| swap_fn_match(idx_a, idx_b)))
-                }
+                },
                 // no match
                 RawEntryMut::Vacant(_) => results.push(swap_fn_no_match(idx_a)),
             }

--- a/crates/polars-core/src/frame/hash_join/sort_merge.rs
+++ b/crates/polars-core/src/frame/hash_join/sort_merge.rs
@@ -54,29 +54,29 @@ pub(super) fn par_sorted_merge_left(
         #[cfg(feature = "dtype-u16")]
         DataType::UInt16 => {
             par_sorted_merge_left_impl(s_left.u16().unwrap(), s_right.u16().unwrap())
-        }
+        },
         #[cfg(feature = "dtype-i16")]
         DataType::Int16 => {
             par_sorted_merge_left_impl(s_left.i16().unwrap(), s_right.i16().unwrap())
-        }
+        },
         DataType::UInt32 => {
             par_sorted_merge_left_impl(s_left.u32().unwrap(), s_right.u32().unwrap())
-        }
+        },
         DataType::Int32 => {
             par_sorted_merge_left_impl(s_left.i32().unwrap(), s_right.i32().unwrap())
-        }
+        },
         DataType::UInt64 => {
             par_sorted_merge_left_impl(s_left.u64().unwrap(), s_right.u64().unwrap())
-        }
+        },
         DataType::Int64 => {
             par_sorted_merge_left_impl(s_left.i64().unwrap(), s_right.i64().unwrap())
-        }
+        },
         DataType::Float32 => {
             par_sorted_merge_left_impl(s_left.f32().unwrap(), s_right.f32().unwrap())
-        }
+        },
         DataType::Float64 => {
             par_sorted_merge_left_impl(s_left.f64().unwrap(), s_right.f64().unwrap())
-        }
+        },
         _ => unreachable!(),
     }
 }
@@ -127,29 +127,29 @@ pub(super) fn par_sorted_merge_inner_no_nulls(
         #[cfg(feature = "dtype-u16")]
         DataType::UInt16 => {
             par_sorted_merge_inner_impl(s_left.u16().unwrap(), s_right.u16().unwrap())
-        }
+        },
         #[cfg(feature = "dtype-i16")]
         DataType::Int16 => {
             par_sorted_merge_inner_impl(s_left.i16().unwrap(), s_right.i16().unwrap())
-        }
+        },
         DataType::UInt32 => {
             par_sorted_merge_inner_impl(s_left.u32().unwrap(), s_right.u32().unwrap())
-        }
+        },
         DataType::Int32 => {
             par_sorted_merge_inner_impl(s_left.i32().unwrap(), s_right.i32().unwrap())
-        }
+        },
         DataType::UInt64 => {
             par_sorted_merge_inner_impl(s_left.u64().unwrap(), s_right.u64().unwrap())
-        }
+        },
         DataType::Int64 => {
             par_sorted_merge_inner_impl(s_left.i64().unwrap(), s_right.i64().unwrap())
-        }
+        },
         DataType::Float32 => {
             par_sorted_merge_inner_impl(s_left.f32().unwrap(), s_right.f32().unwrap())
-        }
+        },
         DataType::Float64 => {
             par_sorted_merge_inner_impl(s_left.f64().unwrap(), s_right.f64().unwrap())
-        }
+        },
         _ => unreachable!(),
     }
 }
@@ -212,7 +212,7 @@ pub fn _sort_or_hash_inner(
                 eprintln!("inner join: keys are sorted: use sorted merge join");
             }
             Ok((par_sorted_merge_inner_no_nulls(s_left, s_right), true))
-        }
+        },
         (IsSorted::Ascending, _, true)
             if is_numeric && size_factor_rhs < size_factor_acceptable =>
         {
@@ -239,7 +239,7 @@ pub fn _sort_or_hash_inner(
             });
 
             Ok(((left, right), true))
-        }
+        },
         (_, IsSorted::Ascending, true)
             if is_numeric && size_factor_lhs < size_factor_acceptable =>
         {
@@ -267,7 +267,7 @@ pub fn _sort_or_hash_inner(
 
             // set sorted to `false` as we descending sorted the left key.
             Ok(((left, right), false))
-        }
+        },
         _ => s_left.hash_join_inner(s_right, validate),
     }
 }
@@ -308,7 +308,7 @@ pub(super) fn sort_or_hash_left(
             }
             let (left_idx, right_idx) = par_sorted_merge_left(s_left, s_right);
             Ok(to_left_join_ids(left_idx, right_idx))
-        }
+        },
         (IsSorted::Ascending, _, true)
             if is_numeric && size_factor_rhs < size_factor_acceptable =>
         {
@@ -336,7 +336,7 @@ pub(super) fn sort_or_hash_left(
             });
 
             Ok(to_left_join_ids(left, right))
-        }
+        },
         // don't reverse sort a left join key yet. Have to figure out how to set sorted flag
         _ => s_left.hash_join_left(s_right, validate),
     }

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -253,7 +253,7 @@ impl DataFrame {
                                 &s.len(),
                             );
                         }
-                    }
+                    },
                     None => first_len = Some(s.len()),
                 }
 
@@ -288,7 +288,7 @@ impl DataFrame {
                                 &series.len(),
                             );
                         }
-                    }
+                    },
                     None => first_len = Some(series.len()),
                 }
 
@@ -473,7 +473,7 @@ impl DataFrame {
                     }
                 }
                 false
-            }
+            },
         }
     }
 
@@ -1026,7 +1026,7 @@ impl DataFrame {
             Some(cols) => {
                 selected_series = self.select_series(cols)?;
                 selected_series.iter()
-            }
+            },
             None => self.columns.iter(),
         };
 
@@ -1241,7 +1241,7 @@ impl DataFrame {
                 if s.len() <= idx {
                     return None;
                 }
-            }
+            },
             None => return None,
         }
         // safety: we just checked bounds
@@ -1928,7 +1928,7 @@ impl DataFrame {
                     return Ok(out.into_frame());
                 }
                 s.arg_sort(options)
-            }
+            },
             _ => {
                 if nulls_last || has_struct || std::env::var("POLARS_ROW_FMT_SORT").is_ok() {
                     argsort_multiple_row_fmt(&by_column, descending, nulls_last, parallel)?
@@ -1941,7 +1941,7 @@ impl DataFrame {
                     };
                     first.arg_sort_multiple(&options)?
                 }
-            }
+            },
         };
 
         if let Some((offset, len)) = slice {
@@ -2164,10 +2164,10 @@ impl DataFrame {
             1 => {
                 let new_col = new_col.new_from_index(0, df_height);
                 let _ = mem::replace(col, new_col);
-            }
+            },
             len if (len == df_height) => {
                 let _ = mem::replace(col, new_col);
-            }
+            },
             len => polars_bail!(
                 ShapeMismatch:
                 "resulting series has length {} while the dataframe has height {}",
@@ -2886,7 +2886,7 @@ impl DataFrame {
                         .unwrap()
                         .map(|cow| Some(cow.into_owned()))
                 })
-            }
+            },
         }
     }
 
@@ -2912,7 +2912,7 @@ impl DataFrame {
                         .unwrap()
                         .map(|cow| Some(cow.into_owned()))
                 })
-            }
+            },
         }
     }
 
@@ -2951,7 +2951,7 @@ impl DataFrame {
                         .unwrap()
                         .map(|cow| Some(cow.into_owned()))
                 })
-            }
+            },
         }
     }
 
@@ -3000,7 +3000,7 @@ impl DataFrame {
                     .cast(&DataType::Float64)?;
 
                 Ok(sum.map(|sum| &sum / &value_length))
-            }
+            },
         }
     }
 
@@ -3102,7 +3102,7 @@ impl DataFrame {
                 let (offset, len) = slice.unwrap_or((0, groups.len()));
                 let groups = groups.slice(offset, len);
                 df.apply_columns_par(&|s| unsafe { s.agg_first(&groups) })
-            }
+            },
             (UniqueKeepStrategy::Last, true) => {
                 // maintain order by last values, so the sorted groups are not correct as they
                 // are sorted by the first value
@@ -3119,26 +3119,26 @@ impl DataFrame {
                     Some((offset, len)) => {
                         let (offset, len) = slice_offsets(offset, len, groups.len());
                         groups.iter().skip(offset).take(len).map(func).collect()
-                    }
+                    },
                 };
 
                 let last_idx = last_idx.sort(false);
                 return Ok(unsafe { df.take_unchecked(&last_idx) });
-            }
+            },
             (UniqueKeepStrategy::First | UniqueKeepStrategy::Any, false) => {
                 let gb = df.groupby(names)?;
                 let groups = gb.get_groups();
                 let (offset, len) = slice.unwrap_or((0, groups.len()));
                 let groups = groups.slice(offset, len);
                 df.apply_columns_par(&|s| unsafe { s.agg_first(&groups) })
-            }
+            },
             (UniqueKeepStrategy::Last, false) => {
                 let gb = df.groupby(names)?;
                 let groups = gb.get_groups();
                 let (offset, len) = slice.unwrap_or((0, groups.len()));
                 let groups = groups.slice(offset, len);
                 df.apply_columns_par(&|s| unsafe { s.agg_last(&groups) })
-            }
+            },
             (UniqueKeepStrategy::None, _) => {
                 let df_part = df.select(names)?;
                 let mask = df_part.is_unique()?;
@@ -3147,7 +3147,7 @@ impl DataFrame {
                     Some((offset, len)) => mask.slice(offset, len),
                 };
                 return df.filter(&mask);
-            }
+            },
         };
         Ok(DataFrame::new_no_checks(columns))
     }
@@ -3310,11 +3310,11 @@ impl DataFrame {
                 match sorted {
                     IsSorted::Ascending => {
                         assert!(idx[0] <= idx[idx.len() - 1]);
-                    }
+                    },
                     IsSorted::Descending => {
                         assert!(idx[0] >= idx[idx.len() - 1]);
-                    }
-                    _ => {}
+                    },
+                    _ => {},
                 }
             }
         }
@@ -3358,7 +3358,7 @@ impl DataFrame {
                             }
                         })
                         .collect())
-                }
+                },
                 GroupsProxy::Slice { groups, .. } => Ok(groups
                     .into_par_iter()
                     .map(|[first, len]| df.slice(first as i64, len as usize))

--- a/crates/polars-core/src/frame/row/av_buffer.rs
+++ b/crates/polars-core/src/frame/row/av_buffer.rs
@@ -51,7 +51,7 @@ impl<'a> AnyValueBuffer<'a> {
             (Boolean(builder), val) => {
                 let v = val.extract::<u8>()?;
                 builder.append_value(v == 1)
-            }
+            },
             (Int32(builder), AnyValue::Null) => builder.append_null(),
             (Int32(builder), val) => builder.append_value(val.extract()?),
             (Int64(builder), AnyValue::Null) => builder.append_null(),
@@ -95,14 +95,14 @@ impl<'a> AnyValueBuffer<'a> {
                 // so we swap.
                 let v = convert_time_units(v, tu_r, *tu_l);
                 builder.append_value(v)
-            }
+            },
             #[cfg(feature = "dtype-duration")]
             (Duration(builder, _), AnyValue::Null) => builder.append_null(),
             #[cfg(feature = "dtype-duration")]
             (Duration(builder, tu_l), AnyValue::Duration(v, tu_r)) => {
                 let v = convert_time_units(v, tu_r, *tu_l);
                 builder.append_value(v)
-            }
+            },
             #[cfg(feature = "dtype-time")]
             (Time(builder), AnyValue::Time(v)) => builder.append_value(v),
             #[cfg(feature = "dtype-time")]
@@ -141,33 +141,33 @@ impl<'a> AnyValueBuffer<'a> {
                 let mut new = BooleanChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             Int32(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             Int64(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             UInt32(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             UInt64(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             #[cfg(feature = "dtype-date")]
             Date(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_date().into_series()
-            }
+            },
             #[cfg(feature = "dtype-datetime")]
             Datetime(b, tu, tz) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
@@ -178,29 +178,29 @@ impl<'a> AnyValueBuffer<'a> {
                     std::mem::take(tz)
                 };
                 new.finish().into_datetime(*tu, tz).into_series()
-            }
+            },
             #[cfg(feature = "dtype-duration")]
             Duration(b, tu) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_duration(*tu).into_series()
-            }
+            },
             #[cfg(feature = "dtype-time")]
             Time(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_time().into_series()
-            }
+            },
             Float32(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             Float64(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             Utf8(b) => {
                 let avg_values_len = b
                     .builder
@@ -212,37 +212,37 @@ impl<'a> AnyValueBuffer<'a> {
                     Utf8ChunkedBuilder::new(b.field.name(), capacity, avg_values_len * capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             #[cfg(feature = "dtype-i8")]
             Int8(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             #[cfg(feature = "dtype-i16")]
             Int16(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             #[cfg(feature = "dtype-u8")]
             UInt8(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             #[cfg(feature = "dtype-u16")]
             UInt16(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             All(dtype, vals) => {
                 let out = Series::from_any_values_and_dtype("", vals, dtype, false).unwrap();
                 let mut new = Vec::with_capacity(capacity);
                 std::mem::swap(&mut new, vals);
                 out
-            }
+            },
         }
     }
 
@@ -279,7 +279,7 @@ impl From<(&DataType, usize)> for AnyValueBuffer<'_> {
             #[cfg(feature = "dtype-datetime")]
             Datetime(tu, tz) => {
                 AnyValueBuffer::Datetime(PrimitiveChunkedBuilder::new("", len), *tu, tz.clone())
-            }
+            },
             #[cfg(feature = "dtype-duration")]
             Duration(tu) => AnyValueBuffer::Duration(PrimitiveChunkedBuilder::new("", len), *tu),
             #[cfg(feature = "dtype-time")]
@@ -348,7 +348,7 @@ impl<'a> AnyValueBufferTrusted<'a> {
                 for (b, _) in builders.iter_mut() {
                     b.add(AnyValue::Null);
                 }
-            }
+            },
             All(_, vals) => vals.push(AnyValue::Null),
         }
     }
@@ -362,74 +362,74 @@ impl<'a> AnyValueBufferTrusted<'a> {
                     unreachable_unchecked_release!()
                 };
                 builder.append_value(*v)
-            }
+            },
             #[cfg(feature = "dtype-i8")]
             Int8(builder) => {
                 let AnyValue::Int8(v) = val else {
                     unreachable_unchecked_release!()
                 };
                 builder.append_value(*v)
-            }
+            },
             #[cfg(feature = "dtype-i16")]
             Int16(builder) => {
                 let AnyValue::Int16(v) = val else {
                     unreachable_unchecked_release!()
                 };
                 builder.append_value(*v)
-            }
+            },
             Int32(builder) => {
                 let AnyValue::Int32(v) = val else {
                     unreachable_unchecked_release!()
                 };
                 builder.append_value(*v)
-            }
+            },
             Int64(builder) => {
                 let AnyValue::Int64(v) = val else {
                     unreachable_unchecked_release!()
                 };
                 builder.append_value(*v)
-            }
+            },
             #[cfg(feature = "dtype-u8")]
             UInt8(builder) => {
                 let AnyValue::UInt8(v) = val else {
                     unreachable_unchecked_release!()
                 };
                 builder.append_value(*v)
-            }
+            },
             #[cfg(feature = "dtype-u16")]
             UInt16(builder) => {
                 let AnyValue::UInt16(v) = val else {
                     unreachable_unchecked_release!()
                 };
                 builder.append_value(*v)
-            }
+            },
             UInt32(builder) => {
                 let AnyValue::UInt32(v) = val else {
                     unreachable_unchecked_release!()
                 };
                 builder.append_value(*v)
-            }
+            },
             UInt64(builder) => {
                 let AnyValue::UInt64(v) = val else {
                     unreachable_unchecked_release!()
                 };
                 builder.append_value(*v)
-            }
+            },
             Float32(builder) => {
                 let AnyValue::Float32(v) = val else {
                     unreachable_unchecked_release!()
                 };
                 builder.append_value(*v)
-            }
+            },
             Float64(builder) => {
                 let AnyValue::Float64(v) = val else {
                     unreachable_unchecked_release!()
                 };
                 builder.append_value(*v)
-            }
+            },
             _ => {
                 unreachable_unchecked_release!()
-            }
+            },
         }
     }
 
@@ -452,7 +452,7 @@ impl<'a> AnyValueBufferTrusted<'a> {
                             unreachable_unchecked_release!()
                         };
                         builder.append_value(v)
-                    }
+                    },
                     #[cfg(feature = "dtype-struct")]
                     Struct(builders) => {
                         let AnyValue::StructOwned(payload) = val else {
@@ -469,11 +469,11 @@ impl<'a> AnyValueBufferTrusted<'a> {
                                 builder.add(av.clone());
                             }
                         }
-                    }
+                    },
                     All(_, vals) => vals.push(val.clone().into_static().unwrap()),
                     _ => self.add_physical(val),
                 }
-            }
+            },
         }
     }
 
@@ -491,7 +491,7 @@ impl<'a> AnyValueBufferTrusted<'a> {
                             unreachable_unchecked_release!()
                         };
                         builder.append_value(v)
-                    }
+                    },
                     #[cfg(feature = "dtype-struct")]
                     Struct(builders) => {
                         let AnyValue::Struct(idx, arr, fields) = val else {
@@ -510,11 +510,11 @@ impl<'a> AnyValueBufferTrusted<'a> {
                                 builder.add(av);
                             }
                         }
-                    }
+                    },
                     All(_, vals) => vals.push(val.clone().into_static().unwrap()),
                     _ => self.add_physical(val),
                 }
-            }
+            },
         }
     }
 
@@ -525,37 +525,37 @@ impl<'a> AnyValueBufferTrusted<'a> {
                 let mut new = BooleanChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             Int32(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             Int64(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             UInt32(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             UInt64(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             Float32(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             Float64(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             Utf8(b) => {
                 let avg_values_len =
                     (b.builder.values().len() as f64) / ((b.builder.capacity() + 1) as f64) + 1.0;
@@ -564,31 +564,31 @@ impl<'a> AnyValueBufferTrusted<'a> {
                 let mut new = Utf8ChunkedBuilder::new(b.field.name(), capacity, new_values_len);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             #[cfg(feature = "dtype-i8")]
             Int8(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             #[cfg(feature = "dtype-i16")]
             Int16(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             #[cfg(feature = "dtype-u8")]
             UInt8(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             #[cfg(feature = "dtype-u16")]
             UInt16(b) => {
                 let mut new = PrimitiveChunkedBuilder::new(b.field.name(), capacity);
                 std::mem::swap(&mut new, b);
                 new.finish().into_series()
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             Struct(b) => {
                 let v = b
@@ -600,12 +600,12 @@ impl<'a> AnyValueBufferTrusted<'a> {
                     })
                     .collect::<Vec<_>>();
                 StructChunked::new("", &v).unwrap().into_series()
-            }
+            },
             All(dtype, vals) => {
                 let mut swap_vals = Vec::with_capacity(capacity);
                 std::mem::swap(vals, &mut swap_vals);
                 Series::from_any_values_and_dtype("", &swap_vals, dtype, false).unwrap()
-            }
+            },
         }
     }
 
@@ -646,7 +646,7 @@ impl From<(&DataType, usize)> for AnyValueBufferTrusted<'_> {
                     })
                     .collect::<Vec<_>>();
                 AnyValueBufferTrusted::Struct(buffers)
-            }
+            },
             // List can be recursive so use anyvalues for that
             dt => AnyValueBufferTrusted::All(dt.clone(), Vec::with_capacity(len)),
         }

--- a/crates/polars-core/src/frame/row/transpose.rs
+++ b/crates/polars-core/src/frame/row/transpose.rs
@@ -20,7 +20,7 @@ impl DataFrame {
                 let mut tmp = Vec::<Series>::with_capacity(new_width + 1);
                 tmp.push(Utf8Chunked::new(name, self.get_column_names()).into());
                 tmp
-            }
+            },
         };
 
         let cols = &self.columns;
@@ -43,7 +43,7 @@ impl DataFrame {
             DataType::Object(_) => {
                 // this requires to support `Object` in Series::iter which we don't yet
                 polars_bail!(InvalidOperation: "Object dtype not supported in 'transpose'")
-            }
+            },
             _ => {
                 let phys_dtype = dtype.to_physical();
                 let mut buffers = (0..new_width)
@@ -76,7 +76,7 @@ impl DataFrame {
                     s.rename(name);
                     s
                 }));
-            }
+            },
         };
         Ok(DataFrame::new_no_checks(cols_t))
     }
@@ -99,11 +99,11 @@ impl DataFrame {
                         .into_no_null_iter()
                         .map(|s| s.to_owned())
                         .collect()
-                }
+                },
                 Either::Right(names) => {
                     polars_ensure!(names.len() == self.height(), ShapeMismatch: "Length of new column names must be the same as the row count");
                     names
-                }
+                },
             },
         };
         if let Some(cn) = keep_names_as {
@@ -132,13 +132,13 @@ impl DataFrame {
                                     }
                                 }
                                 cache_id = Some(*id);
-                            }
+                            },
                         }
                     }
                 }
                 polars_ensure!(valid, ComputeError: "'transpose' of categorical can only be done if all are from the same global string cache")
-            }
-            _ => {}
+            },
+            _ => {},
         }
         df.transpose_from_dtype(&dtype, keep_names_as, &names_out)
     }

--- a/crates/polars-core/src/functions.rs
+++ b/crates/polars-core/src/functions.rs
@@ -168,7 +168,7 @@ pub fn concat_str(s: &[Series], delimiter: &str) -> PolarsResult<Utf8Chunked> {
                 None => {
                     // should not happen as the out loop counts to length
                     unreachable!()
-                }
+                },
             }
         });
 

--- a/crates/polars-core/src/hashing/vector_hasher.rs
+++ b/crates/polars-core/src/hashing/vector_hasher.rs
@@ -124,7 +124,7 @@ where
                         // inlined from ahash. This ensures we combine with the previous state
                         *h = folded_multiply(to_hash ^ *h, MULTIPLE);
                     });
-            }
+            },
         }
         offset += arr.len();
     });
@@ -213,7 +213,7 @@ impl VecHash for BinaryChunked {
                             };
                             *h = _boost_hash_combine(l, *h)
                         });
-                }
+                },
             }
             offset += arr.len();
         });
@@ -274,7 +274,7 @@ impl VecHash for BooleanChunked {
                             };
                             *h = _boost_hash_combine(l, *h)
                         });
-                }
+                },
             }
             offset += arr.len();
         });
@@ -410,11 +410,11 @@ where
                                 match entry {
                                     RawEntryMut::Vacant(entry) => {
                                         entry.insert_hashed_nocheck(*h, *k, (false, vec![idx]));
-                                    }
+                                    },
                                     RawEntryMut::Occupied(mut entry) => {
                                         let (_k, v) = entry.get_key_value_mut();
                                         v.1.push(idx);
-                                    }
+                                    },
                                 }
                             }
                         });

--- a/crates/polars-core/src/schema.rs
+++ b/crates/polars-core/src/schema.rs
@@ -55,7 +55,7 @@ where
                         fld.coerce(DataType::Float64);
                         fld
                     }
-                }
+                },
                 _ => fld,
             };
 

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -18,55 +18,55 @@ impl Serialize for Series {
             DataType::Binary => {
                 let ca = self.binary().unwrap();
                 ca.serialize(serializer)
-            }
+            },
             DataType::List(_) => {
                 let ca = self.list().unwrap();
                 ca.serialize(serializer)
-            }
+            },
             DataType::Boolean => {
                 let ca = self.bool().unwrap();
                 ca.serialize(serializer)
-            }
+            },
             DataType::Utf8 => {
                 let ca = self.utf8().unwrap();
                 ca.serialize(serializer)
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(_) => {
                 let ca = self.struct_().unwrap();
                 ca.serialize(serializer)
-            }
+            },
             #[cfg(feature = "dtype-date")]
             DataType::Date => {
                 let ca = self.date().unwrap();
                 ca.serialize(serializer)
-            }
+            },
             #[cfg(feature = "dtype-datetime")]
             DataType::Datetime(_, _) => {
                 let ca = self.datetime().unwrap();
                 ca.serialize(serializer)
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_) => {
                 let ca = self.categorical().unwrap();
                 ca.serialize(serializer)
-            }
+            },
             #[cfg(feature = "dtype-duration")]
             DataType::Duration(_) => {
                 let ca = self.duration().unwrap();
                 ca.serialize(serializer)
-            }
+            },
             #[cfg(feature = "dtype-time")]
             DataType::Time => {
                 let ca = self.time().unwrap();
                 ca.serialize(serializer)
-            }
+            },
             dt => {
                 with_match_physical_numeric_polars_type!(dt, |$T| {
                 let ca: &ChunkedArray<$T> = self.as_ref().as_ref().as_ref();
                 ca.serialize(serializer)
                 })
-            }
+            },
         }
     }
 }
@@ -103,18 +103,18 @@ impl<'de> Deserialize<'de> for Series {
                                 Ok(s) => Some(s),
                                 Err(_) => Some(Cow::Owned(map.next_value::<String>()?)),
                             };
-                        }
+                        },
                         "datatype" => {
                             dtype = Some(map.next_value()?);
-                        }
+                        },
                         "bit_settings" => {
                             bit_settings = Some(map.next_value()?);
-                        }
+                        },
                         "values" => {
                             // we delay calling next_value until we know the dtype
                             values_set = true;
                             break;
-                        }
+                        },
                         fld => return Err(de::Error::unknown_field(fld, FIELDS)),
                     }
                 }
@@ -129,86 +129,86 @@ impl<'de> Deserialize<'de> for Series {
                     DataType::Int8 => {
                         let values: Vec<Option<i8>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     #[cfg(feature = "dtype-u8")]
                     DataType::UInt8 => {
                         let values: Vec<Option<u8>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     #[cfg(feature = "dtype-i16")]
                     DataType::Int16 => {
                         let values: Vec<Option<i16>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     #[cfg(feature = "dtype-u16")]
                     DataType::UInt16 => {
                         let values: Vec<Option<u16>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     DataType::Int32 => {
                         let values: Vec<Option<i32>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     DataType::UInt32 => {
                         let values: Vec<Option<u32>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     DataType::Int64 => {
                         let values: Vec<Option<i64>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     DataType::UInt64 => {
                         let values: Vec<Option<u64>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     #[cfg(feature = "dtype-date")]
                     DataType::Date => {
                         let values: Vec<Option<i32>> = map.next_value()?;
                         Ok(Series::new(&name, values).cast(&DataType::Date).unwrap())
-                    }
+                    },
                     #[cfg(feature = "dtype-datetime")]
                     DataType::Datetime(tu, tz) => {
                         let values: Vec<Option<i64>> = map.next_value()?;
                         Ok(Series::new(&name, values)
                             .cast(&DataType::Datetime(tu, tz))
                             .unwrap())
-                    }
+                    },
                     #[cfg(feature = "dtype-duration")]
                     DataType::Duration(tu) => {
                         let values: Vec<Option<i64>> = map.next_value()?;
                         Ok(Series::new(&name, values)
                             .cast(&DataType::Duration(tu))
                             .unwrap())
-                    }
+                    },
                     #[cfg(feature = "dtype-time")]
                     DataType::Time => {
                         let values: Vec<Option<i64>> = map.next_value()?;
                         Ok(Series::new(&name, values).cast(&DataType::Time).unwrap())
-                    }
+                    },
                     DataType::Boolean => {
                         let values: Vec<Option<bool>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     DataType::Float32 => {
                         let values: Vec<Option<f32>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     DataType::Float64 => {
                         let values: Vec<Option<f64>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     DataType::Utf8 => {
                         let values: Vec<Option<Cow<str>>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     DataType::List(_) => {
                         let values: Vec<Option<Series>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     DataType::Binary => {
                         let values: Vec<Option<Cow<[u8]>>> = map.next_value()?;
                         Ok(Series::new(&name, values))
-                    }
+                    },
                     #[cfg(feature = "dtype-struct")]
                     DataType::Struct(_) => {
                         let values: Vec<Series> = map.next_value()?;
@@ -216,17 +216,17 @@ impl<'de> Deserialize<'de> for Series {
                         let mut s = ca.into_series();
                         s.rename(&name);
                         Ok(s)
-                    }
+                    },
                     #[cfg(feature = "dtype-categorical")]
                     DataType::Categorical(_) => {
                         let values: Vec<Option<Cow<str>>> = map.next_value()?;
                         Ok(Series::new(&name, values)
                             .cast(&DataType::Categorical(None))
                             .unwrap())
-                    }
+                    },
                     dt => {
                         panic!("{dt:?} dtype deserialization not yet implemented")
-                    }
+                    },
                 }?;
 
                 if let Some(f) = bit_settings {

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -24,7 +24,7 @@ fn any_values_to_utf8(avs: &[AnyValue], strict: bool) -> PolarsResult<Utf8Chunke
                     polars_bail!(ComputeError: "mixed dtypes found when building Utf8 Series")
                 }
                 builder.append_null()
-            }
+            },
             av => {
                 if strict {
                     polars_bail!(ComputeError: "mixed dtypes found when building Utf8 Series")
@@ -32,7 +32,7 @@ fn any_values_to_utf8(avs: &[AnyValue], strict: bool) -> PolarsResult<Utf8Chunke
                 owned.clear();
                 write!(owned, "{av}").unwrap();
                 builder.append_value(&owned);
-            }
+            },
         }
     }
     Ok(builder.finish())
@@ -140,7 +140,7 @@ fn any_values_to_list(
                 _ => {
                     valid = false;
                     None
-                }
+                },
             })
             .collect_trusted()
     }
@@ -157,12 +157,12 @@ fn any_values_to_list(
                             Err(_) => Some(Series::full_null(b.name(), b.len(), inner_type)),
                         }
                     }
-                }
+                },
                 AnyValue::Null => None,
                 _ => {
                     valid = false;
                     None
-                }
+                },
             })
             .collect_trusted()
     };
@@ -233,7 +233,7 @@ impl Series {
             #[cfg(feature = "dtype-decimal")]
             DataType::Decimal(precision, scale) => {
                 any_values_to_decimal(av, *precision, *scale)?.into_series()
-            }
+            },
             DataType::List(inner) => any_values_to_list(av, inner, strict)?.into_series(),
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(dtype_fields) => {
@@ -290,7 +290,7 @@ impl Series {
                                     // search for the name
                                     append_by_search()
                                 }
-                            }
+                            },
                             _ => field_avs.push(AnyValue::Null),
                         }
                     }
@@ -308,7 +308,7 @@ impl Series {
                     series_fields.push(s)
                 }
                 return StructChunked::new(name, &series_fields).map(|ca| ca.into_series());
-            }
+            },
             #[cfg(feature = "object")]
             DataType::Object(_) => {
                 use crate::chunked_array::object::registry;
@@ -323,7 +323,7 @@ impl Series {
                     }
                 }
                 return Ok(builder.to_series());
-            }
+            },
             DataType::Null => Series::full_null(name, av.len(), &DataType::Null),
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_) => {
@@ -331,7 +331,7 @@ impl Series {
                     match single_av {
                         AnyValue::Utf8(_) | AnyValue::Utf8Owned(_) | AnyValue::Null => {
                             any_values_to_utf8(av, strict)?
-                        }
+                        },
                         _ => polars_bail!(
                              ComputeError:
                              "categorical dtype with any-values of dtype {} not supported",
@@ -343,7 +343,7 @@ impl Series {
                 };
 
                 ca.cast(&DataType::Categorical(None)).unwrap()
-            }
+            },
             dt => panic!("{dt:?} not supported"),
         };
         s.rename(name);
@@ -371,7 +371,7 @@ impl Series {
                         unreachable!()
                     }
                 }
-            }
+            },
             Some(av) => {
                 #[cfg(feature = "dtype-decimal")]
                 {
@@ -383,7 +383,7 @@ impl Series {
                 }
                 let dtype: DataType = av.into();
                 Series::from_any_values_and_dtype(name, avs, &dtype, strict)
-            }
+            },
         }
     }
 }
@@ -430,7 +430,7 @@ impl<'a> From<&AnyValue<'a>> for DataType {
                     let rev_map = RevMapping::Local(array);
                     DataType::Categorical(Some(Arc::new(rev_map)))
                 }
-            }
+            },
             #[cfg(feature = "object")]
             Object(o) => DataType::Object(o.type_name()),
             #[cfg(feature = "object")]

--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -205,7 +205,7 @@ pub mod checked {
                                 } else {
                                     Some(l / r)
                                 }
-                            }
+                            },
                             _ => None,
                         })
                 })
@@ -237,7 +237,7 @@ pub mod checked {
                                 } else {
                                     Some(l / r)
                                 }
-                            }
+                            },
                             _ => None,
                         })
                 })
@@ -347,7 +347,7 @@ pub(crate) fn coerce_lhs_rhs<'a>(
         #[cfg(feature = "dtype-struct")]
         (DataType::Struct(_), DataType::Struct(_)) => {
             return Ok((Cow::Borrowed(lhs), Cow::Borrowed(rhs)))
-        }
+        },
         _ => try_get_supertype(lhs.dtype(), rhs.dtype())?,
     };
 
@@ -386,7 +386,7 @@ fn coerce_time_units<'a>(
                 Cow::Owned(rhs.cast(&DataType::Duration(units)).ok()?)
             };
             Some((left, right))
-        }
+        },
         // make sure to return Some here, so we don't cast to supertype.
         (DataType::Date, DataType::Duration(_)) => Some((Cow::Borrowed(lhs), Cow::Borrowed(rhs))),
         (DataType::Duration(lu), DataType::Duration(ru)) => {
@@ -402,13 +402,13 @@ fn coerce_time_units<'a>(
                 Cow::Owned(rhs.cast(&DataType::Duration(units)).ok()?)
             };
             Some((left, right))
-        }
+        },
         // swap the order
         (DataType::Duration(_), DataType::Datetime(_, _))
         | (DataType::Duration(_), DataType::Date) => {
             let (right, left) = coerce_time_units(rhs, lhs)?;
             Some((left, right))
-        }
+        },
         _ => None,
     }
 }
@@ -428,11 +428,11 @@ pub fn _struct_arithmetic<F: FnMut(&Series, &Series) -> Series>(
         (_, 1) => {
             let rhs = &rhs.fields()[0];
             s.apply_fields(|s| func(s, rhs)).into_series()
-        }
+        },
         (1, _) => {
             let s = &s.fields()[0];
             rhs.apply_fields(|rhs| func(s, rhs)).into_series()
-        }
+        },
         _ => {
             let mut rhs_iter = rhs.fields().iter();
 
@@ -441,7 +441,7 @@ pub fn _struct_arithmetic<F: FnMut(&Series, &Series) -> Series>(
                 None => s.clone(),
             })
             .into_series()
-        }
+        },
     }
 }
 
@@ -453,11 +453,11 @@ impl Sub for &Series {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
                 _struct_arithmetic(self, rhs, |a, b| a.sub(b))
-            }
+            },
             _ => {
                 let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
                 lhs.subtract(rhs.as_ref()).expect("data types don't match")
-            }
+            },
         }
     }
 }
@@ -468,11 +468,11 @@ impl Series {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
                 Ok(_struct_arithmetic(self, rhs, |a, b| a.add(b)))
-            }
+            },
             _ => {
                 let (lhs, rhs) = coerce_lhs_rhs(self, rhs)?;
                 lhs.add_to(rhs.as_ref())
-            }
+            },
         }
     }
 }
@@ -497,11 +497,11 @@ impl Mul for &Series {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
                 _struct_arithmetic(self, rhs, |a, b| a.mul(b))
-            }
+            },
             _ => {
                 let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
                 lhs.multiply(rhs.as_ref()).expect("data types don't match")
-            }
+            },
         }
     }
 }
@@ -519,11 +519,11 @@ impl Div for &Series {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
                 _struct_arithmetic(self, rhs, |a, b| a.div(b))
-            }
+            },
             _ => {
                 let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
                 lhs.divide(rhs.as_ref()).expect("data types don't match")
-            }
+            },
         }
     }
 }
@@ -541,11 +541,11 @@ impl Rem for &Series {
             #[cfg(feature = "dtype-struct")]
             (DataType::Struct(_), DataType::Struct(_)) => {
                 _struct_arithmetic(self, rhs, |a, b| a.rem(b))
-            }
+            },
             _ => {
                 let (lhs, rhs) = coerce_lhs_rhs(self, rhs).expect("cannot coerce datatypes");
                 lhs.remainder(rhs.as_ref()).expect("data types don't match")
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -57,7 +57,7 @@ where
         Some(cat_idx) => {
             let cat = cat.cast(&DataType::UInt32).unwrap();
             compare(&cat, cat_idx)
-        }
+        },
     }
 }
 
@@ -112,7 +112,7 @@ impl ChunkCompare<&Series> for Series {
                     |s, idx| s.equal(idx),
                     false,
                 );
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             (Utf8, Categorical(_), 1, _) => {
                 return compare_cat_to_str_series(
@@ -122,7 +122,7 @@ impl ChunkCompare<&Series> for Series {
                     |s, idx| s.equal(idx),
                     false,
                 );
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             (Categorical(Some(rev_map_l)), Categorical(Some(rev_map_r)), _, _) => {
                 if rev_map_l.same_src(rev_map_r) {
@@ -144,11 +144,11 @@ impl ChunkCompare<&Series> for Series {
                         consider setting a global string cache"
                     );
                 }
-            }
+            },
             (Null, Null, _, _) => BooleanChunked::full_null(self.name(), self.len()),
             _ => {
                 impl_compare!(self, rhs, equal)
-            }
+            },
         };
         out.rename(self.name());
         Ok(out)
@@ -168,7 +168,7 @@ impl ChunkCompare<&Series> for Series {
                     |s, idx| s.equal_missing(idx),
                     false,
                 );
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             (Utf8, Categorical(_), 1, _) => {
                 return compare_cat_to_str_series(
@@ -178,7 +178,7 @@ impl ChunkCompare<&Series> for Series {
                     |s, idx| s.equal_missing(idx),
                     false,
                 );
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             (Categorical(Some(rev_map_l)), Categorical(Some(rev_map_r)), _, _) => {
                 if rev_map_l.same_src(rev_map_r) {
@@ -200,11 +200,11 @@ impl ChunkCompare<&Series> for Series {
                         consider setting a global string cache"
                     );
                 }
-            }
+            },
             (Null, Null, _, _) => BooleanChunked::full(self.name(), true, self.len()),
             _ => {
                 impl_compare!(self, rhs, equal_missing)
-            }
+            },
         };
         out.rename(self.name());
         Ok(out)
@@ -224,7 +224,7 @@ impl ChunkCompare<&Series> for Series {
                     |s, idx| s.not_equal(idx),
                     true,
                 );
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             (Utf8, Categorical(_), 1, _) => {
                 return compare_cat_to_str_series(
@@ -234,7 +234,7 @@ impl ChunkCompare<&Series> for Series {
                     |s, idx| s.not_equal(idx),
                     true,
                 );
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             (Categorical(Some(rev_map_l)), Categorical(Some(rev_map_r)), _, _) => {
                 if rev_map_l.same_src(rev_map_r) {
@@ -256,11 +256,11 @@ impl ChunkCompare<&Series> for Series {
                         consider setting a global string cache"
                     );
                 }
-            }
+            },
             (Null, Null, _, _) => BooleanChunked::full_null(self.name(), self.len()),
             _ => {
                 impl_compare!(self, rhs, not_equal)
-            }
+            },
         };
         out.rename(self.name());
         Ok(out)
@@ -280,7 +280,7 @@ impl ChunkCompare<&Series> for Series {
                     |s, idx| s.not_equal_missing(idx),
                     true,
                 );
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             (Utf8, Categorical(_), 1, _) => {
                 return compare_cat_to_str_series(
@@ -290,7 +290,7 @@ impl ChunkCompare<&Series> for Series {
                     |s, idx| s.not_equal_missing(idx),
                     true,
                 );
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             (Categorical(Some(rev_map_l)), Categorical(Some(rev_map_r)), _, _) => {
                 if rev_map_l.same_src(rev_map_r) {
@@ -312,11 +312,11 @@ impl ChunkCompare<&Series> for Series {
                         consider setting a global string cache"
                     );
                 }
-            }
+            },
             (Null, Null, _, _) => BooleanChunked::full(self.name(), false, self.len()),
             _ => {
                 impl_compare!(self, rhs, not_equal_missing)
-            }
+            },
         };
         out.rename(self.name());
         Ok(out)
@@ -434,7 +434,7 @@ impl ChunkCompare<&str> for Series {
             #[cfg(feature = "dtype-categorical")]
             Categorical(_) => {
                 compare_cat_to_str_value(self, rhs, self.name(), |lhs, idx| lhs.equal(idx), false)
-            }
+            },
             _ => Ok(BooleanChunked::full(self.name(), false, self.len())),
         }
     }

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -78,7 +78,7 @@ impl Series {
             Array(_, _) => {
                 ArrayChunked::from_chunks_and_dtype_unchecked(name, chunks, dtype.clone())
                     .into_series()
-            }
+            },
             List(_) => ListChunked::from_chunks_and_dtype_unchecked(name, chunks, dtype.clone())
                 .into_series(),
             Utf8 => Utf8Chunked::from_chunks(name, chunks).into_series(),
@@ -92,7 +92,7 @@ impl Series {
                 );
                 ca.set_fast_unique(false);
                 ca.into_series()
-            }
+            },
             Boolean => BooleanChunked::from_chunks(name, chunks).into_series(),
             Float32 => Float32Chunked::from_chunks(name, chunks).into_series(),
             Float64 => Float64Chunked::from_chunks(name, chunks).into_series(),
@@ -115,7 +115,7 @@ impl Series {
                     pe.take_and_forget();
                     s
                 }
-            }
+            },
             Null => new_null(name, &chunks),
             Unknown => panic!("uh oh, somehow we don't know the dtype?"),
             #[allow(unreachable_patterns)]
@@ -136,14 +136,14 @@ impl Series {
             ArrowDataType::Utf8 => {
                 let chunks = cast_chunks(&chunks, &DataType::Utf8, false).unwrap();
                 Ok(Utf8Chunked::from_chunks(name, chunks).into_series())
-            }
+            },
             ArrowDataType::LargeBinary => {
                 Ok(BinaryChunked::from_chunks(name, chunks).into_series())
-            }
+            },
             ArrowDataType::Binary => {
                 let chunks = cast_chunks(&chunks, &DataType::Binary, false).unwrap();
                 Ok(BinaryChunked::from_chunks(name, chunks).into_series())
-            }
+            },
             ArrowDataType::List(_) | ArrowDataType::LargeList(_) => {
                 let (chunks, dtype) = to_physical_and_dtype(chunks);
                 unsafe {
@@ -152,7 +152,7 @@ impl Series {
                             .into_series(),
                     )
                 }
-            }
+            },
             #[cfg(feature = "dtype-array")]
             ArrowDataType::FixedSizeList(_, _) => {
                 let (chunks, dtype) = to_physical_and_dtype(chunks);
@@ -162,7 +162,7 @@ impl Series {
                             .into_series(),
                     )
                 }
-            }
+            },
             ArrowDataType::Boolean => Ok(BooleanChunked::from_chunks(name, chunks).into_series()),
             #[cfg(feature = "dtype-u8")]
             ArrowDataType::UInt8 => Ok(UInt8Chunked::from_chunks(name, chunks).into_series()),
@@ -179,7 +179,7 @@ impl Series {
             ArrowDataType::Float16 => {
                 let chunks = cast_chunks(&chunks, &DataType::Float32, false).unwrap();
                 Ok(Float32Chunked::from_chunks(name, chunks).into_series())
-            }
+            },
             ArrowDataType::Float32 => Ok(Float32Chunked::from_chunks(name, chunks).into_series()),
             ArrowDataType::Float64 => Ok(Float64Chunked::from_chunks(name, chunks).into_series()),
             #[cfg(feature = "dtype-date")]
@@ -188,13 +188,13 @@ impl Series {
                 Ok(Int32Chunked::from_chunks(name, chunks)
                     .into_date()
                     .into_series())
-            }
+            },
             #[cfg(feature = "dtype-datetime")]
             ArrowDataType::Date64 => {
                 let chunks = cast_chunks(&chunks, &DataType::Int64, false).unwrap();
                 let ca = Int64Chunked::from_chunks(name, chunks);
                 Ok(ca.into_datetime(TimeUnit::Milliseconds, None).into_series())
-            }
+            },
             #[cfg(feature = "dtype-datetime")]
             ArrowDataType::Timestamp(tu, tz) => {
                 let mut tz = tz.clone();
@@ -216,7 +216,7 @@ impl Series {
                     ArrowTimeUnit::Microsecond => s,
                     ArrowTimeUnit::Nanosecond => s,
                 })
-            }
+            },
             #[cfg(feature = "dtype-duration")]
             ArrowDataType::Duration(tu) => {
                 let chunks = cast_chunks(&chunks, &DataType::Int64, false).unwrap();
@@ -229,7 +229,7 @@ impl Series {
                     ArrowTimeUnit::Microsecond => s,
                     ArrowTimeUnit::Nanosecond => s,
                 })
-            }
+            },
             #[cfg(feature = "dtype-time")]
             ArrowDataType::Time64(tu) | ArrowDataType::Time32(tu) => {
                 let mut chunks = chunks;
@@ -246,12 +246,12 @@ impl Series {
                     ArrowTimeUnit::Microsecond => &s * 1_000,
                     ArrowTimeUnit::Nanosecond => s,
                 })
-            }
+            },
             ArrowDataType::Null => Ok(new_null(name, &chunks)),
             #[cfg(not(feature = "dtype-categorical"))]
             ArrowDataType::Dictionary(_, _, _) => {
                 panic!("activate dtype-categorical to convert dictionary arrays")
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             ArrowDataType::Dictionary(key_type, value_type, _) => {
                 use arrow::datatypes::IntegerType;
@@ -285,25 +285,25 @@ impl Series {
                 let (keys, values) = match key_type {
                     IntegerType::Int8 => {
                         unpack_keys_values!(i8)
-                    }
+                    },
                     IntegerType::UInt8 => {
                         unpack_keys_values!(u8)
-                    }
+                    },
                     IntegerType::Int16 => {
                         unpack_keys_values!(i16)
-                    }
+                    },
                     IntegerType::UInt16 => {
                         unpack_keys_values!(u16)
-                    }
+                    },
                     IntegerType::Int32 => {
                         unpack_keys_values!(i32)
-                    }
+                    },
                     IntegerType::UInt32 => {
                         unpack_keys_values!(u32)
-                    }
+                    },
                     IntegerType::Int64 => {
                         unpack_keys_values!(i64)
-                    }
+                    },
                     _ => polars_bail!(
                         ComputeError: "dictionaries with unsigned 64-bit keys are not supported"
                     ),
@@ -316,7 +316,7 @@ impl Series {
                 let mut ca = CategoricalChunked::from_keys_and_values(name, keys, values);
                 ca.set_fast_unique(false);
                 Ok(ca.into_series())
-            }
+            },
             #[cfg(feature = "object")]
             ArrowDataType::Extension(s, _, Some(_)) if s == EXTENSION_NAME => {
                 assert_eq!(chunks.len(), 1);
@@ -335,7 +335,7 @@ impl Series {
                     s
                 };
                 Ok(s)
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             ArrowDataType::Struct(logical_fields) => {
                 // We don't have to convert inner types, as that already
@@ -359,7 +359,7 @@ impl Series {
                                 None => arr.with_validity(Some(validity.clone())),
                                 Some(arr_validity) => {
                                     arr.with_validity(Some(arr_validity & validity))
-                                }
+                                },
                             },
                         })
                         .collect();
@@ -391,7 +391,7 @@ impl Series {
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;
                 Ok(StructChunked::new_unchecked(name, &fields).into_series())
-            }
+            },
             ArrowDataType::FixedSizeBinary(_) => {
                 if verbose() {
                     eprintln!(
@@ -400,7 +400,7 @@ impl Series {
                 }
                 let chunks = cast_chunks(&chunks, &DataType::Binary, true)?;
                 Ok(BinaryChunked::from_chunks(name, chunks).into_series())
-            }
+            },
             #[cfg(feature = "dtype-decimal")]
             ArrowDataType::Decimal(precision, scale)
             | ArrowDataType::Decimal256(precision, scale) => {
@@ -439,7 +439,7 @@ impl Series {
                         .into_decimal_unchecked(precision, scale)
                         .into_series())
                 }
-            }
+            },
             #[allow(unreachable_patterns)]
             ArrowDataType::Decimal256(_, _) | ArrowDataType::Decimal(_, _) => {
                 if verbose() {
@@ -452,7 +452,7 @@ impl Series {
                     cast_chunks(&chunks, &DataType::Float64, true)?,
                 )
                 .into_series())
-            }
+            },
             ArrowDataType::Map(_, _) => map_arrays_to_series(name, chunks),
             dt => polars_bail!(ComputeError: "cannot create series from {:?}", dt),
         }
@@ -504,13 +504,13 @@ fn to_physical_and_dtype(arrays: Vec<ArrayRef>) -> (Vec<ArrayRef>, DataType) {
                 .unwrap();
                 (s.chunks().clone(), s.dtype().clone())
             })
-        }
+        },
         ArrowDataType::List(field) => {
             let out = convert(&arrays, |arr| {
                 cast(arr, &ArrowDataType::LargeList(field.clone())).unwrap()
             });
             to_physical_and_dtype(out)
-        }
+        },
         #[cfg(feature = "dtype-array")]
         #[allow(unused_variables)]
         ArrowDataType::FixedSizeList(_, size) => {
@@ -542,13 +542,13 @@ fn to_physical_and_dtype(arrays: Vec<ArrayRef>) -> (Vec<ArrayRef>, DataType) {
                     .collect();
                 (arrays, DataType::Array(Box::new(dtype), *size))
             })
-        }
+        },
         ArrowDataType::FixedSizeBinary(_) | ArrowDataType::Binary => {
             let out = convert(&arrays, |arr| {
                 cast(arr, &ArrowDataType::LargeBinary).unwrap()
             });
             to_physical_and_dtype(out)
-        }
+        },
         ArrowDataType::LargeList(_) => {
             let values = arrays
                 .iter()
@@ -576,7 +576,7 @@ fn to_physical_and_dtype(arrays: Vec<ArrayRef>) -> (Vec<ArrayRef>, DataType) {
                 })
                 .collect();
             (arrays, DataType::List(Box::new(dtype)))
-        }
+        },
         ArrowDataType::Struct(_fields) => {
             feature_gated!("dtype-struct", {
                 debug_assert_eq!(arrays.len(), 1);
@@ -608,11 +608,11 @@ fn to_physical_and_dtype(arrays: Vec<ArrayRef>) -> (Vec<ArrayRef>, DataType) {
                     .collect();
                 (vec![arrow_array], DataType::Struct(polars_fields))
             })
-        }
+        },
         dt => {
             let dtype = dt.into();
             (arrays, dtype)
-        }
+        },
     }
 }
 

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -128,7 +128,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
                 let lhs = self.cast(&DataType::Int64).unwrap();
                 let rhs = rhs.cast(&DataType::Int64).unwrap();
                 Ok(lhs.subtract(&rhs)?.into_duration(*tu).into_series())
-            }
+            },
             (DataType::Datetime(tu, tz), DataType::Duration(tur)) => {
                 assert_eq!(tu, tur);
                 let lhs = self.cast(&DataType::Int64).unwrap();
@@ -137,7 +137,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
                     .subtract(&rhs)?
                     .into_datetime(*tu, tz.clone())
                     .into_series())
-            }
+            },
             (dtl, dtr) => polars_bail!(opq = sub, dtl, dtr),
         }
     }
@@ -151,7 +151,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
                     .add_to(&rhs)?
                     .into_datetime(*tu, tz.clone())
                     .into_series())
-            }
+            },
             (dtl, dtr) => polars_bail!(opq = add, dtl, dtr),
         }
     }
@@ -323,13 +323,13 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
         match (data_type, self.0.time_unit()) {
             (DataType::Utf8, TimeUnit::Milliseconds) => {
                 Ok(self.0.to_string("%F %T%.3f")?.into_series())
-            }
+            },
             (DataType::Utf8, TimeUnit::Microseconds) => {
                 Ok(self.0.to_string("%F %T%.6f")?.into_series())
-            }
+            },
             (DataType::Utf8, TimeUnit::Nanoseconds) => {
                 Ok(self.0.to_string("%F %T%.9f")?.into_series())
-            }
+            },
             _ => self.0.cast(data_type),
         }
     }

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -156,7 +156,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
                 let lhs = self.cast(&DataType::Int64).unwrap();
                 let rhs = rhs.cast(&DataType::Int64).unwrap();
                 Ok(lhs.subtract(&rhs)?.into_duration(*tu).into_series())
-            }
+            },
             (dtl, dtr) => polars_bail!(opq = sub, dtl, dtr),
         }
     }
@@ -167,7 +167,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
                 let lhs = self.cast(&DataType::Int64).unwrap();
                 let rhs = rhs.cast(&DataType::Int64).unwrap();
                 Ok(lhs.add_to(&rhs)?.into_duration(*tu).into_series())
-            }
+            },
             (DataType::Duration(tu), DataType::Datetime(tur, tz)) => {
                 polars_ensure!(tu == tur, InvalidOperation: "units are different");
                 let lhs = self.cast(&DataType::Int64).unwrap();
@@ -176,7 +176,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
                     .add_to(&rhs)?
                     .into_datetime(*tu, tz.clone())
                     .into_series())
-            }
+            },
             (dtl, dtr) => polars_bail!(opq = add, dtl, dtr),
         }
     }

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -305,7 +305,7 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
                 let main_thread = POOL.current_thread_index().is_none();
                 let groups = self.group_tuples(main_thread, false)?;
                 Ok(groups.len())
-            }
+            },
         }
     }
 

--- a/crates/polars-core/src/series/into.rs
+++ b/crates/polars-core/src/series/into.rs
@@ -55,7 +55,7 @@ impl Series {
                     arr.validity().cloned(),
                 );
                 Box::new(arr)
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(_) => {
                 let ca = self.categorical().unwrap();
@@ -73,17 +73,17 @@ impl Series {
 
                 let arr: DictionaryArray<u32> = (&new).into();
                 Box::new(arr) as ArrayRef
-            }
+            },
             #[cfg(feature = "dtype-date")]
             DataType::Date => cast(&*self.chunks()[chunk_idx], &DataType::Date.to_arrow()).unwrap(),
             #[cfg(feature = "dtype-datetime")]
             DataType::Datetime(_, _) => {
                 cast(&*self.chunks()[chunk_idx], &self.dtype().to_arrow()).unwrap()
-            }
+            },
             #[cfg(feature = "dtype-duration")]
             DataType::Duration(_) => {
                 cast(&*self.chunks()[chunk_idx], &self.dtype().to_arrow()).unwrap()
-            }
+            },
             #[cfg(feature = "dtype-time")]
             DataType::Time => cast(&*self.chunks()[chunk_idx], &DataType::Time.to_arrow()).unwrap(),
             #[cfg(feature = "object")]
@@ -101,7 +101,7 @@ impl Series {
                     let s = self.slice(offset, len);
                     object_series_to_arrow_array(&s)
                 }
-            }
+            },
             _ => self.array_ref(chunk_idx).clone(),
         }
     }

--- a/crates/polars-core/src/series/iterator.rs
+++ b/crates/polars-core/src/series/iterator.rs
@@ -130,7 +130,7 @@ impl Series {
                         }))
                             as Box<dyn ExactSizeIterator<Item = AnyValue<'_>> + '_>
                     }
-                }
+                },
                 DataType::Boolean => {
                     let arr = arr.as_any().downcast_ref::<BooleanArray>().unwrap();
                     if arr.null_count() == 0 {
@@ -144,7 +144,7 @@ impl Series {
                         }))
                             as Box<dyn ExactSizeIterator<Item = AnyValue<'_>> + '_>
                     }
-                }
+                },
                 _ => Box::new(self.iter()),
             }
         }

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -267,7 +267,7 @@ impl Series {
                 } else {
                     Err(err)
                 }
-            }
+            },
         }
     }
 
@@ -281,21 +281,21 @@ impl Series {
             DataType::Struct(_) => {
                 let ca = self.struct_().unwrap();
                 ca.cast_unchecked(dtype)
-            }
+            },
             DataType::List(_) => {
                 let ca = self.list().unwrap();
                 ca.cast_unchecked(dtype)
-            }
+            },
             dt if dt.is_numeric() => {
                 with_match_physical_numeric_polars_type!(dt, |$T| {
                     let ca: &ChunkedArray<$T> = self.as_ref().as_ref().as_ref();
                         ca.cast_unchecked(dtype)
                 })
-            }
+            },
             DataType::Binary => {
                 let ca = self.binary().unwrap();
                 ca.cast_unchecked(dtype)
-            }
+            },
             _ => self.cast(dtype),
         }
     }
@@ -444,7 +444,7 @@ impl Series {
                         .unwrap()
                         .into_series(),
                 )
-            }
+            },
             _ => Cow::Borrowed(self),
         }
     }
@@ -637,37 +637,37 @@ impl Series {
                 Int8 | UInt8 | Int16 | UInt16 => {
                     let s = self.cast(&Int64).unwrap();
                     s.cumsum(reverse)
-                }
+                },
                 Int32 => {
                     let ca = self.i32().unwrap();
                     ca.cumsum(reverse).into_series()
-                }
+                },
                 UInt32 => {
                     let ca = self.u32().unwrap();
                     ca.cumsum(reverse).into_series()
-                }
+                },
                 UInt64 => {
                     let ca = self.u64().unwrap();
                     ca.cumsum(reverse).into_series()
-                }
+                },
                 Int64 => {
                     let ca = self.i64().unwrap();
                     ca.cumsum(reverse).into_series()
-                }
+                },
                 Float32 => {
                     let ca = self.f32().unwrap();
                     ca.cumsum(reverse).into_series()
-                }
+                },
                 Float64 => {
                     let ca = self.f64().unwrap();
                     ca.cumsum(reverse).into_series()
-                }
+                },
                 #[cfg(feature = "dtype-duration")]
                 Duration(tu) => {
                     let ca = self.to_physical_repr();
                     let ca = ca.i64().unwrap();
                     ca.cumsum(reverse).cast(&Duration(*tu)).unwrap()
-                }
+                },
                 dt => panic!("cumsum not supported for dtype: {dt:?}"),
             }
         }
@@ -691,23 +691,23 @@ impl Series {
                 Int8 | UInt8 | Int16 | UInt16 | Int32 | UInt32 => {
                     let s = self.cast(&Int64).unwrap();
                     s.cumprod(reverse)
-                }
+                },
                 Int64 => {
                     let ca = self.i64().unwrap();
                     ca.cumprod(reverse).into_series()
-                }
+                },
                 UInt64 => {
                     let ca = self.u64().unwrap();
                     ca.cumprod(reverse).into_series()
-                }
+                },
                 Float32 => {
                     let ca = self.f32().unwrap();
                     ca.cumprod(reverse).into_series()
-                }
+                },
                 Float64 => {
                     let ca = self.f64().unwrap();
                     ca.cumprod(reverse).into_series()
-                }
+                },
                 dt => panic!("cumprod not supported for dtype: {dt:?}"),
             }
         }
@@ -730,23 +730,23 @@ impl Series {
                 Int8 | UInt8 | Int16 | UInt16 | Int32 | UInt32 => {
                     let s = self.cast(&Int64).unwrap();
                     s.product()
-                }
+                },
                 Int64 => {
                     let ca = self.i64().unwrap();
                     ca.prod_as_series()
-                }
+                },
                 UInt64 => {
                     let ca = self.u64().unwrap();
                     ca.prod_as_series()
-                }
+                },
                 Float32 => {
                     let ca = self.f32().unwrap();
                     ca.prod_as_series()
-                }
+                },
                 Float64 => {
                     let ca = self.f64().unwrap();
                     ca.prod_as_series()
-                }
+                },
                 dt => panic!("cumprod not supported for dtype: {dt:?}"),
             }
         }
@@ -768,12 +768,12 @@ impl Series {
 
         match self.dtype() {
             #[cfg(feature = "dtype-struct")]
-            DataType::Struct(_) => {}
+            DataType::Struct(_) => {},
             _ => {
                 if null_count == len {
                     return Ok(Series::full_null(self.name(), len, dtype));
                 }
-            }
+            },
         }
         let s = self.0.cast(dtype)?;
         if null_count != s.null_count() {
@@ -909,7 +909,7 @@ impl Series {
                 } else {
                     unsafe { Cow::Borrowed(arr.deref_unchecked().value(idx as usize)) }
                 }
-            }
+            },
             av => Cow::Owned(format!("{av}")),
         };
         Ok(out)
@@ -936,16 +936,16 @@ impl Series {
             DataType::Float32 => {
                 let val = &[self.mean().map(|m| m as f32)];
                 Series::new(self.name(), val)
-            }
+            },
             dt if dt.is_numeric() || matches!(dt, DataType::Boolean) => {
                 let val = &[self.mean()];
                 Series::new(self.name(), val)
-            }
+            },
             dt @ DataType::Duration(_) => {
                 Series::new(self.name(), &[self.mean().map(|v| v as i64)])
                     .cast(dt)
                     .unwrap()
-            }
+            },
             _ => return Series::full_null(self.name(), 1, self.dtype()),
         }
     }
@@ -996,9 +996,9 @@ impl Series {
                 RevMapping::Global(map, arr, _) => {
                     size +=
                         map.capacity() * std::mem::size_of::<u32>() * 2 + estimated_bytes_size(arr);
-                }
+                },
             },
-            _ => {}
+            _ => {},
         }
 
         size
@@ -1062,7 +1062,7 @@ where
                         self.dtype()
                     );
                 }
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/series/ops/diff.rs
+++ b/crates/polars-core/src/series/ops/diff.rs
@@ -18,7 +18,7 @@ impl Series {
                 let n = n as usize;
                 let len = s.len() - n;
                 Ok(&self.slice(n as i64, len) - &s.slice(0, len))
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/series/ops/ewm.rs
+++ b/crates/polars-core/src/series/ops/ewm.rs
@@ -24,7 +24,7 @@ impl Series {
                     options.ignore_nulls,
                 );
                 Series::try_from((self.name(), Box::new(result) as ArrayRef))
-            }
+            },
             DataType::Float64 => {
                 let xs = self.f64().unwrap();
                 let result = ewm_mean(
@@ -35,7 +35,7 @@ impl Series {
                     options.ignore_nulls,
                 );
                 Series::try_from((self.name(), Box::new(result) as ArrayRef))
-            }
+            },
             _ => self.cast(&DataType::Float64)?.ewm_mean(options),
         }
     }
@@ -54,7 +54,7 @@ impl Series {
                     options.ignore_nulls,
                 );
                 Series::try_from((self.name(), Box::new(result) as ArrayRef))
-            }
+            },
             DataType::Float64 => {
                 let xs = self.f64().unwrap();
                 let result = ewm_std(
@@ -66,7 +66,7 @@ impl Series {
                     options.ignore_nulls,
                 );
                 Series::try_from((self.name(), Box::new(result) as ArrayRef))
-            }
+            },
             _ => self.cast(&DataType::Float64)?.ewm_std(options),
         }
     }
@@ -85,7 +85,7 @@ impl Series {
                     options.ignore_nulls,
                 );
                 Series::try_from((self.name(), Box::new(result) as ArrayRef))
-            }
+            },
             DataType::Float64 => {
                 let xs = self.f64().unwrap();
                 let result = ewm_var(
@@ -97,7 +97,7 @@ impl Series {
                     options.ignore_nulls,
                 );
                 Series::try_from((self.name(), Box::new(result) as ArrayRef))
-            }
+            },
             _ => self.cast(&DataType::Float64)?.ewm_var(options),
         }
     }

--- a/crates/polars-core/src/series/ops/moment.rs
+++ b/crates/polars-core/src/series/ops/moment.rs
@@ -34,7 +34,7 @@ fn moment_precomputed_mean(s: &Series, moment: usize, mean: f64) -> PolarsResult
                 }
             }
             s.mean()
-        }
+        },
     };
     Ok(out)
 }

--- a/crates/polars-core/src/series/ops/null.rs
+++ b/crates/polars-core/src/series/ops/null.rs
@@ -6,11 +6,11 @@ impl Series {
         match dtype {
             DataType::List(inner_dtype) => {
                 ListChunked::full_null_with_dtype(name, size, inner_dtype).into_series()
-            }
+            },
             #[cfg(feature = "dtype-array")]
             DataType::Array(inner_dtype, width) => {
                 ArrayChunked::full_null_with_dtype(name, size, inner_dtype, *width).into_series()
-            }
+            },
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(rev_map) => {
                 let mut ca = CategoricalChunked::full_null(name, size);
@@ -19,7 +19,7 @@ impl Series {
                     unsafe { ca.set_rev_map(rev_map.clone(), false) }
                 }
                 ca.into_series()
-            }
+            },
             #[cfg(feature = "dtype-date")]
             DataType::Date => Int32Chunked::full_null(name, size)
                 .into_date()
@@ -50,7 +50,7 @@ impl Series {
                     .map(|fld| Series::full_null(fld.name(), size, fld.data_type()))
                     .collect::<Vec<_>>();
                 StructChunked::new(name, &fields).unwrap().into_series()
-            }
+            },
             DataType::Null => Series::new_null(name, size),
             _ => {
                 macro_rules! primitive {
@@ -74,7 +74,7 @@ impl Series {
                     }};
                 }
                 match_dtype_to_logical_apply_macro!(dtype, primitive, utf8, binary, bool)
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/series/ops/pct_change.rs
+++ b/crates/polars-core/src/series/ops/pct_change.rs
@@ -4,7 +4,7 @@ use crate::series::ops::NullBehavior;
 impl Series {
     pub fn pct_change(&self, n: i64) -> PolarsResult<Series> {
         match self.dtype() {
-            DataType::Float64 | DataType::Float32 => {}
+            DataType::Float64 | DataType::Float32 => {},
             _ => return self.cast(&DataType::Float64)?.pct_change(n),
         }
         let nn = self.fill_null(FillNullStrategy::Forward(None))?;

--- a/crates/polars-core/src/series/ops/to_list.rs
+++ b/crates/polars-core/src/series/ops/to_list.rs
@@ -11,7 +11,7 @@ fn reshape_fast_path(name: &str, s: &Series) -> Series {
         #[cfg(feature = "dtype-struct")]
         DataType::Struct(_) => {
             vec![Box::new(array_to_unit_list(s.array_ref(0).clone())) as ArrayRef]
-        }
+        },
         _ => s
             .chunks()
             .iter()
@@ -123,10 +123,10 @@ impl Series {
                     offset += cols;
                 }
                 Ok(builder.finish().into_series())
-            }
+            },
             _ => {
                 panic!("more than two dimensions not yet supported");
-            }
+            },
         }
     }
 }

--- a/crates/polars-core/src/series/ops/unique.rs
+++ b/crates/polars-core/src/series/ops/unique.rs
@@ -42,7 +42,7 @@ impl Series {
                 DataType::Utf8 => unique_counts(self.utf8().unwrap().into_iter()),
                 dt => {
                     panic!("'unique_counts' not implemented for {dt} data types")
-                }
+                },
             }
         }
     }

--- a/crates/polars-core/src/testing.rs
+++ b/crates/polars-core/src/testing.rs
@@ -23,8 +23,8 @@ impl Series {
                 if tz_lhs != tz_rhs {
                     return false;
                 }
-            }
-            _ => {}
+            },
+            _ => {},
         }
 
         // differences from Partial::eq in that numerical dtype may be different

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -642,7 +642,7 @@ where
                 Cow::Owned(left.match_chunks(right.chunk_id())),
                 Cow::Borrowed(right),
             )
-        }
+        },
     }
 }
 
@@ -714,7 +714,7 @@ where
                 Cow::Owned(b.match_chunks(c.chunk_id())),
                 Cow::Borrowed(c),
             )
-        }
+        },
         (_, 1, _) => {
             let a = a.rechunk();
             (
@@ -722,7 +722,7 @@ where
                 Cow::Owned(b.match_chunks(c.chunk_id())),
                 Cow::Borrowed(c),
             )
-        }
+        },
         (_, _, 1) => {
             let b = b.rechunk();
             (
@@ -730,7 +730,7 @@ where
                 Cow::Owned(b.match_chunks(a.chunk_id())),
                 Cow::Owned(c.match_chunks(a.chunk_id())),
             )
-        }
+        },
         _ => {
             // could optimize to choose to rechunk a primitive and not a string or list type
             let a = a.rechunk();
@@ -740,7 +740,7 @@ where
                 Cow::Owned(b.match_chunks(c.chunk_id())),
                 Cow::Borrowed(c),
             )
-        }
+        },
     }
 }
 

--- a/crates/polars-io/src/cloud/adaptors.rs
+++ b/crates/polars-io/src/cloud/adaptors.rs
@@ -102,7 +102,7 @@ impl AsyncRead for CloudReader {
             Poll::Ready(Ok(bytes)) => {
                 buf.copy_from_slice(&bytes);
                 Poll::Ready(Ok(bytes.len()))
-            }
+            },
             Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
             Poll::Pending => Poll::Pending,
         }
@@ -123,7 +123,7 @@ impl AsyncSeek for CloudReader {
                     "Cannot seek from end of stream when length is unknown.",
                 ))?;
                 self.pos = (length as i64 + pos) as u64
-            }
+            },
             io::SeekFrom::Current(pos) => self.pos = (self.pos as i64 + pos) as u64,
         };
         std::task::Poll::Ready(Ok(self.pos))

--- a/crates/polars-io/src/cloud/mod.rs
+++ b/crates/polars-io/src/cloud/mod.rs
@@ -35,31 +35,31 @@ pub fn build(url: &str, _options: Option<&CloudOptions>) -> BuildResult {
         CloudType::File => {
             let local = LocalFileSystem::new();
             Ok::<_, PolarsError>(Box::new(local) as Box<dyn ObjectStore>)
-        }
+        },
         CloudType::Aws => {
             #[cfg(feature = "aws")]
             match _options {
                 Some(options) => {
                     let store = options.build_aws(&cloud_location.bucket)?;
                     Ok::<_, PolarsError>(Box::new(store) as Box<dyn ObjectStore>)
-                }
+                },
                 _ => return err_missing_configuration("aws", &cloud_location.scheme),
             }
             #[cfg(not(feature = "aws"))]
             return err_missing_feature("aws", &cloud_location.scheme);
-        }
+        },
         CloudType::Gcp => {
             #[cfg(feature = "gcp")]
             match _options {
                 Some(options) => {
                     let store = options.build_gcp(&cloud_location.bucket)?;
                     Ok::<_, PolarsError>(Box::new(store) as Box<dyn ObjectStore>)
-                }
+                },
                 _ => return err_missing_configuration("gcp", &cloud_location.scheme),
             }
             #[cfg(not(feature = "gcp"))]
             return err_missing_feature("gcp", &cloud_location.scheme);
-        }
+        },
         CloudType::Azure => {
             {
                 #[cfg(feature = "azure")]
@@ -67,13 +67,13 @@ pub fn build(url: &str, _options: Option<&CloudOptions>) -> BuildResult {
                     Some(options) => {
                         let store = options.build_azure(&cloud_location.bucket)?;
                         Ok::<_, PolarsError>(Box::new(store) as Box<dyn ObjectStore>)
-                    }
+                    },
                     _ => return err_missing_configuration("azure", &cloud_location.scheme),
                 }
             }
             #[cfg(not(feature = "azure"))]
             return err_missing_feature("azure", &cloud_location.scheme);
-        }
+        },
     }?;
     Ok((cloud_location, store))
 }

--- a/crates/polars-io/src/csv/buffer.rs
+++ b/crates/polars-io/src/csv/buffer.rs
@@ -112,7 +112,7 @@ where
                         ComputeError: "remaining bytes non-empty",
                     );
                     self.append_null()
-                }
+                },
             };
         }
         Ok(())
@@ -216,7 +216,7 @@ impl ParsedBuffer for Utf8Field {
                 unsafe { self.data.set_len(data_len + n_written) }
                 self.offsets.push(self.data.len() as i64);
                 self.validity.push(true);
-            }
+            },
             false => {
                 if matches!(self.encoding, CsvEncoding::LossyUtf8) {
                     // Safety:
@@ -243,7 +243,7 @@ impl ParsedBuffer for Utf8Field {
                 } else {
                     polars_bail!(ComputeError: "invalid utf-8 sequence");
                 }
-            }
+            },
         }
 
         Ok(())
@@ -439,7 +439,7 @@ where
             None => {
                 buf.builder.append_null();
                 return Ok(());
-            }
+            },
         },
     };
     match DatetimeInfer::try_from_with_unit(pattern, time_unit) {
@@ -448,11 +448,11 @@ where
             buf.compiled = Some(infer);
             buf.builder.append_option(parsed);
             Ok(())
-        }
+        },
         Err(_) => {
             buf.builder.append_null();
             Ok(())
-        }
+        },
     }
 }
 
@@ -482,13 +482,13 @@ where
                     Some(parsed) => {
                         self.builder.append_value(parsed);
                         Ok(())
-                    }
+                    },
                     // fall back on chrono parser
                     // this is a lot slower, we need to do utf8 checking and use
                     // the slower parser
                     None => slow_datetime_parser(self, bytes, time_unit, ignore_errors),
                 }
-            }
+            },
         }
     }
 }
@@ -544,7 +544,7 @@ pub(crate) fn init_buffers<'a>(
                 #[cfg(feature = "dtype-categorical")]
                 &DataType::Categorical(_) => {
                     Buffer::Categorical(CategoricalField::new(name, capacity, quote_char))
-                }
+                },
                 dt => polars_bail!(
                     ComputeError: "unsupported data type when reading CSV: {} when reading CSV", dt,
                 ),
@@ -657,7 +657,7 @@ impl<'a> Buffer<'a> {
                 {
                     panic!("activate 'dtype-categorical' feature")
                 }
-            }
+            },
         };
         Ok(s)
     }
@@ -674,7 +674,7 @@ impl<'a> Buffer<'a> {
             Buffer::Utf8(v) => {
                 v.offsets.push(v.data.len() as i64);
                 v.validity.push(valid);
-            }
+            },
             #[cfg(feature = "dtype-datetime")]
             Buffer::Datetime { buf, .. } => buf.builder.append_null(),
             #[cfg(feature = "dtype-date")]
@@ -689,7 +689,7 @@ impl<'a> Buffer<'a> {
                 {
                     panic!("activate 'dtype-categorical' feature")
                 }
-            }
+            },
         };
     }
 
@@ -717,7 +717,7 @@ impl<'a> Buffer<'a> {
                 {
                     panic!("activate 'dtype-categorical' feature")
                 }
-            }
+            },
         }
     }
 
@@ -805,7 +805,7 @@ impl<'a> Buffer<'a> {
                     missing_is_null,
                     Some(*time_unit),
                 )
-            }
+            },
             #[cfg(feature = "dtype-date")]
             Date(buf) => <DatetimeField<Int32Type> as ParsedBuffer>::parse_bytes(
                 buf,
@@ -826,7 +826,7 @@ impl<'a> Buffer<'a> {
                 {
                     panic!("activate 'dtype-categorical' feature")
                 }
-            }
+            },
         }
     }
 }

--- a/crates/polars-io/src/csv/parser.rs
+++ b/crates/polars-io/src/csv/parser.rs
@@ -115,7 +115,7 @@ pub(crate) fn next_line_position(
                     }
                     total_pos += pos + 1;
                 }
-            }
+            },
             // don't count the fields
             (Some(_), None) => return Some(total_pos + pos),
             // // no new line found, check latest line (without eol) for number of fields
@@ -282,12 +282,12 @@ impl<'a> Iterator for SplitLines<'a> {
                     else if c == self.end_line_char && !in_field {
                         break;
                     }
-                }
+                },
                 None => {
                     // no new line found we are done
                     // the rest will be done by last line specific code.
                     return None;
-                }
+                },
             }
         }
 
@@ -418,7 +418,7 @@ pub(super) fn parse_lines<'a>(
                 None => {
                     bytes = &bytes[std::cmp::min(read_sol, bytes.len())..];
                     break;
-                }
+                },
                 Some((mut field, needs_escaping)) => {
                     let field_len = field.len();
 
@@ -495,11 +495,11 @@ pub(super) fn parse_lines<'a>(
                                     bytes = bytes_rem;
                                 }
                                 break;
-                            }
+                            },
                         }
                     }
                     idx += 1;
-                }
+                },
             }
         }
 

--- a/crates/polars-io/src/csv/read.rs
+++ b/crates/polars-io/src/csv/read.rs
@@ -56,7 +56,7 @@ impl NullValuesCompiled {
             Columns(v) => {
                 debug_assert!(index < v.len());
                 v.get_unchecked(index).as_bytes() == field
-            }
+            },
         }
     }
 }
@@ -73,7 +73,7 @@ impl NullValues {
                     null_values[i] = null_value;
                 }
                 NullValuesCompiled::Columns(null_values)
-            }
+            },
         })
     }
 }
@@ -389,31 +389,31 @@ impl<'a, R: MmapBytesReader + 'a> CsvReader<'a, R> {
                         to_cast.push(fld);
                         // let inference decide the column type
                         None
-                    }
+                    },
                     Int8 | Int16 | UInt8 | UInt16 => {
                         // We have not compiled these buffers, so we cast them later.
                         to_cast.push(fld.clone());
                         fld.coerce(DataType::Int32);
                         Some(fld)
-                    }
+                    },
                     #[cfg(feature = "dtype-categorical")]
                     Categorical(_) => {
                         _has_categorical = true;
                         Some(fld)
-                    }
+                    },
                     #[cfg(feature = "dtype-decimal")]
                     Decimal(precision, scale) => match (precision, scale) {
                         (_, Some(_)) => {
                             to_cast.push(fld.clone());
                             fld.coerce(Utf8);
                             Some(fld)
-                        }
+                        },
                         _ => {
                             _err = Some(PolarsError::ComputeError(
                                 "'scale' must be set when reading csv column as Decimal".into(),
                             ));
                             None
-                        }
+                        },
                     },
                     _ => Some(fld),
                 }
@@ -479,7 +479,7 @@ impl<'a> CsvReader<'a, Box<dyn MmapBytesReader>> {
                 )?;
                 let schema = Arc::new(inferred_schema);
                 Ok(to_batched_owned_mmap(self, schema))
-            }
+            },
         }
     }
     pub fn batched_read(
@@ -507,7 +507,7 @@ impl<'a> CsvReader<'a, Box<dyn MmapBytesReader>> {
                 )?;
                 let schema = Arc::new(inferred_schema);
                 Ok(to_batched_owned_read(self, schema))
-            }
+            },
         }
     }
 }
@@ -613,7 +613,7 @@ where
                         .collect::<Schema>();
 
                     Arc::new(schema)
-                }
+                },
                 _ => Arc::default(),
             };
             df = parse_dates(df, &fixed_schema)
@@ -640,7 +640,7 @@ fn parse_dates(mut df: DataFrame, fixed_schema: &Schema) -> DataFrame {
                         return ca.into_series();
                     }
                     s
-                }
+                },
                 _ => s,
             }
         })

--- a/crates/polars-io/src/csv/read_impl/batched_mmap.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_mmap.rs
@@ -34,7 +34,7 @@ pub(crate) fn get_file_chunks_iterator(
             Some(pos) => search_pos + pos,
             None => {
                 break;
-            }
+            },
         };
         offsets.push_back((*last_pos, end_pos));
         *last_pos = end_pos;
@@ -95,9 +95,9 @@ impl<'a> Iterator for ChunkOffsetIter<'a> {
                         let out = Some((self.last_offset, self.bytes.len()));
                         self.last_offset = self.bytes.len();
                         out
-                    }
+                    },
                 }
-            }
+            },
         }
     }
 }

--- a/crates/polars-io/src/csv/read_impl/batched_read.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_read.rs
@@ -36,7 +36,7 @@ pub(crate) fn get_offsets(
             Some(pos) => search_pos + pos,
             None => {
                 break;
-            }
+            },
         };
         offsets.push_back((start, end_pos));
         start = end_pos;

--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -238,7 +238,7 @@ impl<'a> CoreReader<'a> {
                     )?;
                     Arc::new(inferred_schema)
                 }
-            }
+            },
         };
         if let Some(dtypes) = dtype_overwrite {
             let s = Arc::make_mut(&mut schema);
@@ -326,7 +326,7 @@ impl<'a> CoreReader<'a> {
                 let pos = match bytes.first() {
                     Some(first) if Some(*first) == self.comment_char => {
                         next_line_position_naive(bytes, eol_char)
-                    }
+                    },
                     // we don't pass expected fields
                     // as we want to skip all rows
                     // no matter the no. of fields

--- a/crates/polars-io/src/csv/splitfields.rs
+++ b/crates/polars-io/src/csv/splitfields.rs
@@ -299,7 +299,7 @@ mod inner {
                             Some(idx) => {
                                 total_idx += idx;
                                 break;
-                            }
+                            },
                         }
                     }
                 }

--- a/crates/polars-io/src/csv/utils.rs
+++ b/crates/polars-io/src/csv/utils.rs
@@ -48,7 +48,7 @@ pub(crate) fn get_file_chunks(
             Some(pos) => search_pos + pos,
             None => {
                 break;
-            }
+            },
         };
         offsets.push((last_pos, end_pos));
         last_pos = end_pos;
@@ -113,11 +113,11 @@ fn infer_field_schema(string: &str, try_parse_dates: bool) -> DataType {
                     Some(pattern_with_offset) => match pattern_with_offset {
                         Pattern::DatetimeYMD | Pattern::DatetimeDMY => {
                             DataType::Datetime(TimeUnit::Microseconds, None)
-                        }
+                        },
                         Pattern::DateYMD | Pattern::DateDMY => DataType::Date,
                         Pattern::DatetimeYMDZ => {
                             DataType::Datetime(TimeUnit::Microseconds, Some("UTC".to_string()))
-                        }
+                        },
                     },
                     None => DataType::Utf8,
                 }
@@ -144,11 +144,11 @@ fn infer_field_schema(string: &str, try_parse_dates: bool) -> DataType {
                 Some(pattern_with_offset) => match pattern_with_offset {
                     Pattern::DatetimeYMD | Pattern::DatetimeDMY => {
                         DataType::Datetime(TimeUnit::Microseconds, None)
-                    }
+                    },
                     Pattern::DateYMD | Pattern::DateDMY => DataType::Date,
                     Pattern::DatetimeYMDZ => {
                         DataType::Datetime(TimeUnit::Microseconds, Some("UTC".to_string()))
-                    }
+                    },
                 },
                 None => DataType::Utf8,
             }
@@ -335,7 +335,7 @@ pub fn infer_file_schema_inner(
                 } else {
                     max_read_rows
                 }
-            }
+            },
             None => usize::MAX,
         })
         .skip(skip_rows_after_header)
@@ -376,17 +376,17 @@ pub fn infer_file_schema_inner(
                     match &null_values {
                         None => {
                             column_types[i].insert(infer_field_schema(&s, try_parse_dates));
-                        }
+                        },
                         Some(NullValues::AllColumns(names)) => {
                             if !names.iter().any(|nv| nv == s.as_ref()) {
                                 column_types[i].insert(infer_field_schema(&s, try_parse_dates));
                             }
-                        }
+                        },
                         Some(NullValues::AllColumnsSingle(name)) => {
                             if s.as_ref() != name {
                                 column_types[i].insert(infer_field_schema(&s, try_parse_dates));
                             }
-                        }
+                        },
                         Some(NullValues::Named(names)) => {
                             let current_name = &headers[i];
                             let null_name = &names.iter().find(|name| &name.0 == current_name);
@@ -398,7 +398,7 @@ pub fn infer_file_schema_inner(
                             } else {
                                 column_types[i].insert(infer_field_schema(&s, try_parse_dates));
                             }
-                        }
+                        },
                     }
                 }
             }
@@ -433,7 +433,7 @@ pub fn infer_file_schema_inner(
                 for dtype in possibilities.iter() {
                     fields.push(Field::new(field_name, dtype.clone()));
                 }
-            }
+            },
             2 => {
                 if possibilities.contains(&DataType::Int64)
                     && possibilities.contains(&DataType::Float64)
@@ -459,7 +459,7 @@ pub fn infer_file_schema_inner(
                     // default to Utf8 for conflicting datatypes (e.g bool and int)
                     fields.push(Field::new(field_name, DataType::Utf8));
                 }
-            }
+            },
             _ => fields.push(Field::new(field_name, DataType::Utf8)),
         }
     }
@@ -563,7 +563,7 @@ fn decompress_impl<R: Read>(
             let mut out = Vec::new();
             decoder.read_to_end(&mut out).ok()?;
             out
-        }
+        },
         Some(n_rows) => {
             // we take the first rows first '\n\
             let mut out = vec![];
@@ -603,7 +603,7 @@ fn decompress_impl<R: Read>(
                     Some(pos) => {
                         line_count += 1;
                         buf_pos += pos;
-                    }
+                    },
                     None => {
                         // take more bytes so that we might find a new line the next iteration
                         let read = decoder.take(chunk_size).read_to_end(&mut out).ok()?;
@@ -612,11 +612,11 @@ fn decompress_impl<R: Read>(
                             break;
                         }
                         continue;
-                    }
+                    },
                 };
             }
             out
-        }
+        },
     })
 }
 

--- a/crates/polars-io/src/csv/write_impl.rs
+++ b/crates/polars-io/src/csv/write_impl.rs
@@ -86,7 +86,7 @@ unsafe fn write_anyvalue(
         AnyValue::Categorical(idx, rev_map, _) => {
             let v = rev_map.get(idx);
             fmt_and_escape_str(f, v, options)
-        }
+        },
         #[cfg(feature = "dtype-date")]
         AnyValue::Date(v) => {
             let date = temporal_conversions::date32_to_date(v);
@@ -94,7 +94,7 @@ unsafe fn write_anyvalue(
                 None => write!(f, "{date}"),
                 Some(fmt) => write!(f, "{}", date.format(fmt)),
             }
-        }
+        },
         #[cfg(feature = "dtype-datetime")]
         AnyValue::Datetime(v, tu, _) => {
             let datetime_format = { *datetime_formats.get_unchecked(i) };
@@ -110,11 +110,11 @@ unsafe fn write_anyvalue(
                 #[cfg(not(feature = "timezones"))]
                 Some(_) => {
                     panic!("activate 'timezones' feature");
-                }
+                },
                 _ => ndt.format(datetime_format),
             };
             write!(f, "{formatted}")
-        }
+        },
         #[cfg(feature = "dtype-time")]
         AnyValue::Time(v) => {
             let date = temporal_conversions::time64ns_to_time(v);
@@ -122,7 +122,7 @@ unsafe fn write_anyvalue(
                 None => write!(f, "{date}"),
                 Some(fmt) => write!(f, "{}", date.format(fmt)),
             }
-        }
+        },
         ref dt => polars_bail!(ComputeError: "datatype {} cannot be written to csv", dt),
     }
     .map_err(|err| match value {
@@ -137,7 +137,7 @@ unsafe fn write_anyvalue(
             polars_err!(
                 ComputeError: "cannot format {} with format '{}'", type_name, datetime_format,
             )
-        }
+        },
         _ => polars_err!(ComputeError: "error writing value {}: {}", value, err),
     })
 }
@@ -206,7 +206,7 @@ pub(crate) fn write<W: Write>(
                 return Err(PolarsError::ComputeError(
                     "csv writer does not support object dtype".into(),
                 ))
-            }
+            },
             _ => false,
         };
         polars_ensure!(
@@ -245,7 +245,7 @@ pub(crate) fn write<W: Write>(
                     ),
                 };
                 (format, tz_parsed)
-            }
+            },
             DataType::Datetime(TimeUnit::Microseconds, tz) => {
                 let (format, tz_parsed) = match tz {
                     #[cfg(feature = "timezones")]
@@ -265,7 +265,7 @@ pub(crate) fn write<W: Write>(
                     ),
                 };
                 (format, tz_parsed)
-            }
+            },
             DataType::Datetime(TimeUnit::Nanoseconds, tz) => {
                 let (format, tz_parsed) = match tz {
                     #[cfg(feature = "timezones")]
@@ -285,7 +285,7 @@ pub(crate) fn write<W: Write>(
                     ),
                 };
                 (format, tz_parsed)
-            }
+            },
             _ => ("", None),
         })
         .unzip();
@@ -350,7 +350,7 @@ pub(crate) fn write<W: Write>(
                         None => {
                             finished = true;
                             break;
-                        }
+                        },
                     }
                     let current_ptr = col as *const SeriesIter;
                     if current_ptr != last_ptr {

--- a/crates/polars-io/src/ipc/ipc_stream.rs
+++ b/crates/polars-io/src/ipc/ipc_stream.rs
@@ -114,7 +114,7 @@ impl<R: Read> IpcStreamReader<R> {
                 let metadata = read::read_stream_metadata(&mut self.reader)?;
                 self.metadata = Option::from(metadata.clone());
                 Ok(metadata)
-            }
+            },
             Some(md) => Ok(md.clone()),
         }
     }

--- a/crates/polars-io/src/ipc/mmap.rs
+++ b/crates/polars-io/src/ipc/mmap.rs
@@ -58,7 +58,7 @@ impl ArrowReader for MMapChunkIter<'_> {
                     let cols = chunk.into_arrays();
                     let arrays = proj.iter().map(|i| cols[*i].clone()).collect();
                     Chunk::new(arrays)
-                }
+                },
             };
             Ok(Some(chunk))
         } else {
@@ -100,7 +100,7 @@ impl<R: MmapBytesReader> IpcReader<R> {
                     &schema,
                     self.row_count.clone(),
                 )
-            }
+            },
             None => polars_bail!(ComputeError: "cannot memory-map, you must provide a file"),
         }
     }

--- a/crates/polars-io/src/json/mod.rs
+++ b/crates/polars-io/src/json/mod.rs
@@ -144,11 +144,11 @@ where
                 let serializer = arrow_ndjson::write::Serializer::new(batches, vec![]);
                 let writer = arrow_ndjson::write::FileWriter::new(&mut self.buffer, serializer);
                 writer.collect::<ArrowResult<()>>()?;
-            }
+            },
             JsonFormat::Json => {
                 let serializer = json::write::Serializer::new(batches, vec![]);
                 json::write::write(&mut self.buffer, serializer)?;
-            }
+            },
         }
 
         Ok(())
@@ -267,7 +267,7 @@ where
                     || polars_err!(ComputeError: "can only deserialize json objects"),
                 )?;
                 DataFrame::try_from(arr.clone())
-            }
+            },
             JsonFormat::JsonLines => {
                 let mut json_reader = CoreJsonReader::new(
                     rb,
@@ -286,7 +286,7 @@ where
                     df.as_single_chunk_par();
                 }
                 Ok(df)
-            }
+            },
         }?;
 
         // TODO! Ensure we don't materialize the columns we don't need

--- a/crates/polars-io/src/mmap.rs
+++ b/crates/polars-io/src/mmap.rs
@@ -80,7 +80,7 @@ impl<'a, T: 'a + MmapBytesReader> From<&'a T> for ReaderBytes<'a> {
                 let f = m.to_file().unwrap();
                 let mmap = unsafe { memmap::Mmap::map(f).unwrap() };
                 ReaderBytes::Mapped(mmap, f)
-            }
+            },
         }
     }
 }

--- a/crates/polars-io/src/ndjson/buffer.rs
+++ b/crates/polars-io/src/ndjson/buffer.rs
@@ -43,7 +43,7 @@ impl Buffer<'_> {
                     _ => buf.append_null(),
                 }
                 Ok(())
-            }
+            },
             Int32(buf) => {
                 let n = deserialize_number::<i32>(value);
                 match n {
@@ -51,7 +51,7 @@ impl Buffer<'_> {
                     None => buf.append_null(),
                 }
                 Ok(())
-            }
+            },
             Int64(buf) => {
                 let n = deserialize_number::<i64>(value);
                 match n {
@@ -59,7 +59,7 @@ impl Buffer<'_> {
                     None => buf.append_null(),
                 }
                 Ok(())
-            }
+            },
             UInt64(buf) => {
                 let n = deserialize_number::<u64>(value);
                 match n {
@@ -67,7 +67,7 @@ impl Buffer<'_> {
                     None => buf.append_null(),
                 }
                 Ok(())
-            }
+            },
             UInt32(buf) => {
                 let n = deserialize_number::<u32>(value);
                 match n {
@@ -75,7 +75,7 @@ impl Buffer<'_> {
                     None => buf.append_null(),
                 }
                 Ok(())
-            }
+            },
             Float32(buf) => {
                 let n = deserialize_number::<f32>(value);
                 match n {
@@ -83,7 +83,7 @@ impl Buffer<'_> {
                     None => buf.append_null(),
                 }
                 Ok(())
-            }
+            },
             Float64(buf) => {
                 let n = deserialize_number::<f64>(value);
                 match n {
@@ -91,7 +91,7 @@ impl Buffer<'_> {
                     None => buf.append_null(),
                 }
                 Ok(())
-            }
+            },
 
             Utf8(buf) => {
                 match value {
@@ -99,24 +99,24 @@ impl Buffer<'_> {
                     _ => buf.append_null(),
                 }
                 Ok(())
-            }
+            },
             #[cfg(feature = "dtype-datetime")]
             Datetime(buf, _, _) => {
                 let v = deserialize_datetime::<Int64Type>(value);
                 buf.append_option(v);
                 Ok(())
-            }
+            },
             #[cfg(feature = "dtype-date")]
             Date(buf) => {
                 let v = deserialize_datetime::<Int32Type>(value);
                 buf.append_option(v);
                 Ok(())
-            }
+            },
             All(dtype, buf) => {
                 let av = deserialize_all(value, dtype, self.ignore_errors)?;
                 buf.push(av);
                 Ok(())
-            }
+            },
             _ => panic!("unexpected dtype when deserializing ndjson"),
         }
     }
@@ -199,7 +199,7 @@ fn deserialize_all<'a>(
                 .collect::<PolarsResult<_>>()?;
             let s = Series::from_any_values_and_dtype("", &vals, inner_dtype, false)?;
             AnyValue::List(s)
-        }
+        },
         #[cfg(feature = "dtype-struct")]
         Value::Object(doc) => {
             if let DataType::Struct(fields) = dtype {
@@ -224,7 +224,7 @@ fn deserialize_all<'a>(
                     ComputeError: "expected {} in json value, got object", dtype,
                 );
             }
-        }
+        },
         #[cfg(not(feature = "dtype-struct"))]
         val => AnyValue::Utf8Owned(format!("{:#?}", val).into()),
     };

--- a/crates/polars-io/src/ndjson/core.rs
+++ b/crates/polars-io/src/ndjson/core.rs
@@ -176,7 +176,7 @@ impl<'a> CoreJsonReader<'a> {
                 let schema = StructArray::get_fields(&data_type).iter().collect();
 
                 Arc::new(schema)
-            }
+            },
         };
         if let Some(overwriting_schema) = schema_overwrite {
             let schema = Arc::make_mut(&mut schema);
@@ -288,13 +288,13 @@ fn parse_impl(
                         }
                         PolarsResult::Ok(())
                     })?;
-                }
+                },
                 _ => {
                     buffers.iter_mut().for_each(|(_, inner)| inner.add_null());
-                }
+                },
             };
             true
-        }
+        },
     };
     polars_ensure!(all_good, ComputeError: "invalid JSON: unexpected end of file");
     Ok(n)
@@ -312,10 +312,10 @@ fn parse_lines(bytes: &[u8], buffers: &mut PlIndexMap<BufferKey, Buffer>) -> Pol
             Ok(value) => {
                 let bytes = value.get().as_bytes();
                 parse_impl(bytes, buffers, &mut buf)?;
-            }
+            },
             Err(e) => {
                 polars_bail!(ComputeError: "error parsing ndjson {}", e)
-            }
+            },
         }
     }
     Ok(())
@@ -400,7 +400,7 @@ pub(crate) fn get_file_chunks_json(bytes: &[u8], n_threads: usize) -> Vec<(usize
             Some(pos) => search_pos + pos,
             None => {
                 break;
-            }
+            },
         };
         offsets.push((last_pos, end_pos));
         last_pos = end_pos;

--- a/crates/polars-io/src/parquet/mmap.rs
+++ b/crates/polars-io/src/parquet/mmap.rs
@@ -53,7 +53,7 @@ fn _mmap_single_column<'a>(
                 )
             });
             entry.as_slice()
-        }
+        },
     };
     (meta, chunk)
 }

--- a/crates/polars-io/src/parquet/predicates.rs
+++ b/crates/polars-io/src/parquet/predicates.rs
@@ -29,7 +29,7 @@ impl ColumnStats {
                 Series::try_from(("", self.0.null_count.clone()))
                     .unwrap()
                     .sum()
-            }
+            },
         }
     }
 

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -35,12 +35,12 @@ fn column_idx_to_series(
     match field.data_type {
         ArrowDataType::Utf8 => {
             field.data_type = ArrowDataType::LargeUtf8;
-        }
+        },
         ArrowDataType::Binary => {
             field.data_type = ArrowDataType::LargeBinary;
-        }
+        },
         ArrowDataType::List(fld) => field.data_type = ArrowDataType::LargeList(fld),
-        _ => {}
+        _ => {},
     }
 
     let columns = mmap_columns(store, md.columns(), &field.name);
@@ -75,7 +75,7 @@ pub(super) fn array_iter_to_series(
                 }
             }
             out
-        }
+        },
     };
     if chunks.is_empty() {
         let arr = new_empty_array(field.data_type.clone());
@@ -442,7 +442,7 @@ impl BatchedParquetReader {
                     )?;
                     self.row_group_offset += n;
                     dfs
-                }
+                },
                 ParallelStrategy::RowGroups => {
                     let dfs = rg_to_dfs_par(
                         &store,
@@ -459,7 +459,7 @@ impl BatchedParquetReader {
                     )?;
                     self.row_group_offset += n;
                     dfs
-                }
+                },
                 _ => unimplemented!(),
             };
             // case where there is no data in the file
@@ -538,7 +538,7 @@ impl Iterator for BatchedParquetIter {
                     let batch = opt_batch?;
                     self.current_batch = batch.into_iter();
                     self.current_batch.next().map(Ok)
-                }
+                },
             },
         }
     }

--- a/crates/polars-io/src/parquet/write.rs
+++ b/crates/polars-io/src/parquet/write.rs
@@ -77,15 +77,15 @@ impl From<ParquetCompression> for CompressionOptions {
             Snappy => CompressionOptions::Snappy,
             Gzip(level) => {
                 CompressionOptions::Gzip(level.map(|v| GzipLevelParquet::try_new(v.0).unwrap()))
-            }
+            },
             Lzo => CompressionOptions::Lzo,
             Brotli(level) => {
                 CompressionOptions::Brotli(level.map(|v| BrotliLevelParquet::try_new(v.0).unwrap()))
-            }
+            },
             Lz4Raw => CompressionOptions::Lz4Raw,
             Zstd(level) => {
                 CompressionOptions::Zstd(level.map(|v| ZstdLevelParquet::try_new(v.0).unwrap()))
-            }
+            },
         }
     }
 }
@@ -218,7 +218,7 @@ fn prepare_rg_iter<'a>(
                 create_serializer(batch, parquet_schema.fields(), encodings, options, parallel);
 
             Some(row_group)
-        }
+        },
     })
 }
 

--- a/crates/polars-io/src/partition.rs
+++ b/crates/polars-io/src/partition.rs
@@ -110,7 +110,7 @@ where
                             self.write_partition_df(&mut part_df, i)
                         })
                         .collect::<PolarsResult<Vec<_>>>()
-                }
+                },
                 GroupsProxy::Slice { groups, .. } => groups
                     .par_iter()
                     .enumerate()

--- a/crates/polars-json/src/json/infer_schema.rs
+++ b/crates/polars-json/src/json/infer_schema.rs
@@ -151,12 +151,12 @@ pub(crate) fn coerce_data_type<A: Borrow<DataType>>(datatypes: &[A]) -> DataType
                 match acc.entry(field.name.as_str()) {
                     Entry::Occupied(mut v) => {
                         v.get_mut().insert(&field.data_type);
-                    }
+                    },
                     Entry::Vacant(v) => {
                         let mut a = PlHashSet::default();
                         a.insert(&field.data_type);
                         v.insert(a);
-                    }
+                    },
                 }
                 acc
             },
@@ -180,15 +180,15 @@ pub(crate) fn coerce_data_type<A: Borrow<DataType>>(datatypes: &[A]) -> DataType
         (LargeList(lhs), LargeList(rhs)) => {
             let inner = coerce_data_type(&[lhs.data_type(), rhs.data_type()]);
             LargeList(Box::new(Field::new(ITEM_NAME, inner, true)))
-        }
+        },
         (scalar, List(list)) => {
             let inner = coerce_data_type(&[scalar, list.data_type()]);
             LargeList(Box::new(Field::new(ITEM_NAME, inner, true)))
-        }
+        },
         (LargeList(list), scalar) => {
             let inner = coerce_data_type(&[scalar, list.data_type()]);
             LargeList(Box::new(Field::new(ITEM_NAME, inner, true)))
-        }
+        },
         (Float64, Int64) => Float64,
         (Int64, Float64) => Float64,
         (Int64, Boolean) => Int64,

--- a/crates/polars-lazy/src/dsl/eval.rs
+++ b/crates/polars-lazy/src/dsl/eval.rs
@@ -32,7 +32,7 @@ pub(crate) fn eval_field_to_dtype(f: &Field, expr: &Expr, list: bool) -> Field {
             } else {
                 Field::new(f.name(), dtype.clone())
             }
-        }
+        },
         Err(_) => Field::new(f.name(), DataType::Null),
     }
 }

--- a/crates/polars-lazy/src/dsl/functions.rs
+++ b/crates/polars-lazy/src/dsl/functions.rs
@@ -44,7 +44,7 @@ pub(crate) fn concat_impl<L: AsRef<[LazyFrame]>>(
                 existing_inputs.push(lp)
             }
             lf
-        }
+        },
         _ => {
             let mut lps = Vec::with_capacity(inputs.len());
             lps.push(lf.logical_plan);
@@ -64,7 +64,7 @@ pub(crate) fn concat_impl<L: AsRef<[LazyFrame]>>(
             lf.opt_state = opt_state;
 
             lf
-        }
+        },
     };
 
     if convert_supertypes {

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -70,7 +70,7 @@ fn run_per_sublist(
                         Err(e) => {
                             *m_err.lock().unwrap() = Some(e);
                             None
-                        }
+                        },
                     }
                 })
             })
@@ -91,7 +91,7 @@ fn run_per_sublist(
                         Err(e) => {
                             err = Some(e);
                             None
-                        }
+                        },
                     }
                 })
             })
@@ -134,7 +134,7 @@ fn run_on_groupby_engine(
         AggState::AggregatedFlat(_) | AggState::Literal(_) => {
             let out = ac.aggregated();
             out.as_list().into_series()
-        }
+        },
         _ => ac.aggregated(),
     };
     out.rename(name);
@@ -158,15 +158,15 @@ pub trait ListNameSpaceExtension: IntoListNameSpace + Sized {
                         polars_bail!(
                             ComputeError: "casting to categorical not allowed in `list.eval`"
                         )
-                    }
+                    },
                     Expr::Column(name) => {
                         polars_ensure!(
                             name.is_empty(),
                             ComputeError:
                             "named columns are not allowed in `list.eval`; consider using `element` or `col(\"\")`"
                         );
-                    }
-                    _ => {}
+                    },
+                    _ => {},
                 }
             }
             let lst = s.list()?.clone();

--- a/crates/polars-lazy/src/frame/err.rs
+++ b/crates/polars-lazy/src/frame/err.rs
@@ -11,7 +11,7 @@ macro_rules! fallible {
                     .0
                     .into();
                 return lf;
-            }
+            },
         }
     }};
 }

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1175,7 +1175,7 @@ impl LazyFrame {
                         .collect::<Vec<_>>(),
                 );
                 self.filter(predicate)
-            }
+            },
         }
     }
 
@@ -1290,7 +1290,7 @@ impl LazyFrame {
                         .unwrap(),
                 );
                 false
-            }
+            },
             _ => true,
         };
 

--- a/crates/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/groupby_partitioned.rs
@@ -196,7 +196,7 @@ fn can_run_partitioned(
                 // we never sample less than 100 data points.
                 let sample_size = std::cmp::max(100, sample_size);
                 (estimate_unique_count(keys, sample_size)?, "estimated")
-            }
+            },
         };
         if state.verbose() {
             eprintln!("{sampled_method} unique values: {unique_estimate}");

--- a/crates/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/groupby_rolling.rs
@@ -68,14 +68,14 @@ impl GroupByRollingExec {
                         for key in keys.iter_mut() {
                             *key = key.take_unchecked_from_slice(first).unwrap();
                         }
-                    }
+                    },
                     GroupsProxy::Slice { groups, .. } => {
                         for key in keys.iter_mut() {
                             let iter = &mut groups.iter().map(|[first, _len]| *first as usize)
                                 as &mut dyn TakeIterator<Item = usize>;
                             *key = key.take_iter_unchecked(iter);
                         }
-                    }
+                    },
                 }
             }
         };

--- a/crates/polars-lazy/src/physical_plan/executors/scan/mod.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/mod.rs
@@ -110,7 +110,7 @@ impl Executor for AnonymousScanExec {
                 (true, Some(predicate)) => {
                     self.options.predicate = predicate.as_expression().cloned();
                     self.function.scan(self.options.clone())
-                }
+                },
                 (false, Some(predicate)) => {
                     let mut df = self.function.scan(self.options.clone())?;
                     let s = predicate.evaluate(&df, state)?;
@@ -120,7 +120,7 @@ impl Executor for AnonymousScanExec {
                     df = df.filter(mask)?;
 
                     Ok(df)
-                }
+                },
                 _ => self.function.scan(self.options.clone()),
             },
             "anonymous_scan".into(),

--- a/crates/polars-lazy/src/physical_plan/exotic.rs
+++ b/crates/polars-lazy/src/physical_plan/exotic.rs
@@ -9,11 +9,11 @@ pub(crate) fn prepare_eval_expr(mut expr: Expr) -> Expr {
         Expr::Column(name) => {
             *name = Arc::from("");
             true
-        }
+        },
         Expr::Nth(_) => {
             *e = Expr::Column(Arc::from(""));
             true
-        }
+        },
         _ => true,
     });
     expr

--- a/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -77,31 +77,31 @@ impl PhysicalExpr for AggregationExpr {
                     let (s, groups) = ac.get_final_aggregation();
                     let agg_s = s.agg_min(&groups);
                     rename_series(agg_s, &keep_name)
-                }
+                },
                 GroupByMethod::Max => {
                     check_null_prop!();
                     let (s, groups) = ac.get_final_aggregation();
                     let agg_s = s.agg_max(&groups);
                     rename_series(agg_s, &keep_name)
-                }
+                },
                 GroupByMethod::Median => {
                     check_null_prop!();
                     let (s, groups) = ac.get_final_aggregation();
                     let agg_s = s.agg_median(&groups);
                     rename_series(agg_s, &keep_name)
-                }
+                },
                 GroupByMethod::Mean => {
                     check_null_prop!();
                     let (s, groups) = ac.get_final_aggregation();
                     let agg_s = s.agg_mean(&groups);
                     rename_series(agg_s, &keep_name)
-                }
+                },
                 GroupByMethod::Sum => {
                     check_null_prop!();
                     let (s, groups) = ac.get_final_aggregation();
                     let agg_s = s.agg_sum(&groups);
                     rename_series(agg_s, &keep_name)
-                }
+                },
                 GroupByMethod::Count => {
                     // a few fast paths that prevent materializing new groups
                     match ac.update_groups {
@@ -126,7 +126,7 @@ impl PhysicalExpr for AggregationExpr {
                                         })
                                         .collect_trusted();
                                     counts.into_inner()
-                                }
+                                },
                                 _ => {
                                     let counts: NoNull<IdxCa> = list
                                         .amortized_iter()
@@ -139,11 +139,11 @@ impl PhysicalExpr for AggregationExpr {
                                         })
                                         .collect_trusted();
                                     counts.into_inner()
-                                }
+                                },
                             };
                             s.rename(&keep_name);
                             s.into_series()
-                        }
+                        },
                         UpdateGroups::WithGroupsLen => {
                             // no need to update the groups
                             // we can just get the attribute, because we only need the length,
@@ -151,33 +151,33 @@ impl PhysicalExpr for AggregationExpr {
                             let mut ca = ac.groups.group_count();
                             ca.rename(&keep_name);
                             ca.into_series()
-                        }
+                        },
                         // materialize groups
                         _ => {
                             let mut ca = ac.groups().group_count();
                             ca.rename(&keep_name);
                             ca.into_series()
-                        }
+                        },
                     }
-                }
+                },
                 GroupByMethod::First => {
                     check_null_prop!();
                     let (s, groups) = ac.get_final_aggregation();
                     let agg_s = s.agg_first(&groups);
                     rename_series(agg_s, &keep_name)
-                }
+                },
                 GroupByMethod::Last => {
                     check_null_prop!();
                     let (s, groups) = ac.get_final_aggregation();
                     let agg_s = s.agg_last(&groups);
                     rename_series(agg_s, &keep_name)
-                }
+                },
                 GroupByMethod::NUnique => {
                     check_null_prop!();
                     let (s, groups) = ac.get_final_aggregation();
                     let agg_s = s.agg_n_unique(&groups);
                     rename_series(agg_s, &keep_name)
-                }
+                },
                 GroupByMethod::Implode => {
                     // if the aggregation is already
                     // in an aggregate flat state for instance by
@@ -192,31 +192,31 @@ impl PhysicalExpr for AggregationExpr {
                         _ => {
                             let agg = ac.aggregated();
                             agg.as_list().into_series()
-                        }
+                        },
                     };
                     rename_series(s, &keep_name)
-                }
+                },
                 GroupByMethod::Groups => {
                     let mut column: ListChunked = ac.groups().as_list_chunked();
                     column.rename(&keep_name);
                     column.into_series()
-                }
+                },
                 GroupByMethod::Std(ddof) => {
                     check_null_prop!();
                     let (s, groups) = ac.get_final_aggregation();
                     let agg_s = s.agg_std(&groups, ddof);
                     rename_series(agg_s, &keep_name)
-                }
+                },
                 GroupByMethod::Var(ddof) => {
                     check_null_prop!();
                     let (s, groups) = ac.get_final_aggregation();
                     let agg_s = s.agg_var(&groups, ddof);
                     rename_series(agg_s, &keep_name)
-                }
+                },
                 GroupByMethod::Quantile(_, _) => {
                     // implemented explicitly in AggQuantile struct
                     unimplemented!()
-                }
+                },
                 GroupByMethod::NanMin => {
                     #[cfg(feature = "propagate_nans")]
                     {
@@ -233,7 +233,7 @@ impl PhysicalExpr for AggregationExpr {
                     {
                         panic!("activate 'propagate_nans' feature")
                     }
-                }
+                },
                 GroupByMethod::NanMax => {
                     #[cfg(feature = "propagate_nans")]
                     {
@@ -250,7 +250,7 @@ impl PhysicalExpr for AggregationExpr {
                     {
                         panic!("activate 'propagate_nans' feature")
                     }
-                }
+                },
             }
         };
 
@@ -320,46 +320,46 @@ impl PartitionedAggregation for AggregationExpr {
                             .unwrap()
                             .into_series())
                     }
-                }
+                },
                 GroupByMethod::Implode => {
                     let new_name = series.name();
                     let mut agg = series.agg_list(groups);
                     agg.rename(new_name);
                     Ok(agg)
-                }
+                },
                 GroupByMethod::First => {
                     let mut agg = series.agg_first(groups);
                     agg.rename(series.name());
                     Ok(agg)
-                }
+                },
                 GroupByMethod::Last => {
                     let mut agg = series.agg_last(groups);
                     agg.rename(series.name());
                     Ok(agg)
-                }
+                },
                 GroupByMethod::Max => {
                     let mut agg = series.agg_max(groups);
                     agg.rename(series.name());
                     Ok(agg)
-                }
+                },
                 GroupByMethod::Min => {
                     let mut agg = series.agg_min(groups);
                     agg.rename(series.name());
                     Ok(agg)
-                }
+                },
                 GroupByMethod::Sum => {
                     let mut agg = series.agg_sum(groups);
                     agg.rename(series.name());
                     Ok(agg)
-                }
+                },
                 GroupByMethod::Count => {
                     let mut ca = groups.group_count();
                     ca.rename(series.name());
                     Ok(ca.into_series())
-                }
+                },
                 _ => {
                     unimplemented!()
-                }
+                },
             }
         }
     }
@@ -375,7 +375,7 @@ impl PartitionedAggregation for AggregationExpr {
                 let mut agg = unsafe { partitioned.agg_sum(groups) };
                 agg.rename(partitioned.name());
                 Ok(agg)
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             GroupByMethod::Mean => {
                 let new_name = partitioned.name();
@@ -388,14 +388,14 @@ impl PartitionedAggregation for AggregationExpr {
                             unsafe { POOL.join(|| count.agg_sum(groups), || sum.agg_sum(groups)) };
                         let agg_s = &agg_s / &agg_count;
                         Ok(rename_series(agg_s, new_name))
-                    }
+                    },
                     _ => Ok(Series::full_null(
                         new_name,
                         groups.len(),
                         partitioned.dtype(),
                     )),
                 }
-            }
+            },
             GroupByMethod::Implode => {
                 // the groups are scattered over multiple groups/sub dataframes.
                 // we now must collect them into a single group
@@ -431,14 +431,14 @@ impl PartitionedAggregation for AggregationExpr {
                             };
                             process_group(ca)?;
                         }
-                    }
+                    },
                     GroupsProxy::Slice { groups, .. } => {
                         for [first, len] in groups {
                             let len = *len as usize;
                             let ca = ca.slice(*first as i64, len);
                             process_group(ca)?;
                         }
-                    }
+                    },
                 }
 
                 let vals = values.iter().map(|arr| &**arr).collect::<Vec<_>>();
@@ -457,27 +457,27 @@ impl PartitionedAggregation for AggregationExpr {
                     ca.set_fast_explode()
                 }
                 Ok(ca.into_series().as_list().into_series())
-            }
+            },
             GroupByMethod::First => {
                 let mut agg = unsafe { partitioned.agg_first(groups) };
                 agg.rename(partitioned.name());
                 Ok(agg)
-            }
+            },
             GroupByMethod::Last => {
                 let mut agg = unsafe { partitioned.agg_last(groups) };
                 agg.rename(partitioned.name());
                 Ok(agg)
-            }
+            },
             GroupByMethod::Max => {
                 let mut agg = unsafe { partitioned.agg_max(groups) };
                 agg.rename(partitioned.name());
                 Ok(agg)
-            }
+            },
             GroupByMethod::Min => {
                 let mut agg = unsafe { partitioned.agg_min(groups) };
                 agg.rename(partitioned.name());
                 Ok(agg)
-            }
+            },
             _ => unimplemented!(),
         }
     }

--- a/crates/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -135,7 +135,7 @@ impl ApplyExpr {
                 }
                 let mut container = [s];
                 self.function.call_udf(&mut container)
-            }
+            },
         };
 
         let mut ca: ListChunked = if self.allow_threading {
@@ -168,13 +168,13 @@ impl ApplyExpr {
                 let ca = s.list().unwrap();
                 let out = ca.apply_to_inner(&|s| self.eval_and_flatten(&mut [s]))?;
                 (out.into_series(), true)
-            }
+            },
             AggState::AggregatedFlat(s) => (self.eval_and_flatten(&mut [s.clone()])?, true),
             AggState::NotAggregated(s) | AggState::Literal(s) => {
                 let (out, aggregated) = (self.eval_and_flatten(&mut [s.clone()])?, false);
                 check_map_output_len(s.len(), out.len(), &self.expr)?;
                 (out, aggregated)
-            }
+            },
         };
 
         ac.with_series_and_args(s, aggregated, Some(&self.expr), true)?;
@@ -295,7 +295,7 @@ impl PhysicalExpr for ApplyExpr {
                     let s = self.eval_and_flatten(&mut [ac.aggregated()])?;
                     ac.with_series(s, true, Some(&self.expr))?;
                     Ok(ac)
-                }
+                },
                 ApplyOptions::ApplyGroups => self.apply_single_group_aware(ac),
                 ApplyOptions::ApplyFlat => self.apply_single_elementwise(ac),
             }
@@ -311,7 +311,7 @@ impl PhysicalExpr for ApplyExpr {
                     ac.with_update_groups(UpdateGroups::WithGroupsLen);
                     ac.with_series(s, true, Some(&self.expr))?;
                     Ok(ac)
-                }
+                },
                 ApplyOptions::ApplyGroups => self.apply_multiple_group_aware(acs, df),
                 ApplyOptions::ApplyFlat => {
                     if acs
@@ -327,7 +327,7 @@ impl PhysicalExpr for ApplyExpr {
                             self.check_lengths,
                         )
                     }
-                }
+                },
             }
         }
     }
@@ -386,7 +386,7 @@ fn apply_multiple_elementwise<'a>(
             let mut ac = acs.swap_remove(0);
             ac.with_series(out.into_series(), true, None)?;
             Ok(ac)
-        }
+        },
         _ => {
             let mut s = acs
                 .iter_mut()
@@ -413,7 +413,7 @@ fn apply_multiple_elementwise<'a>(
             let mut ac = acs.swap_remove(0);
             ac.with_series_and_args(s, false, None, true)?;
             Ok(ac)
-        }
+        },
     }
 }
 
@@ -460,7 +460,7 @@ impl ApplyExpr {
                     },
                     None => Ok(true),
                 }
-            }
+            },
             #[cfg(feature = "is_in")]
             FunctionExpr::Boolean(BooleanFunction::IsIn) => {
                 let root = match expr_to_leaf_column_name(&input[0]) {
@@ -506,10 +506,10 @@ impl ApplyExpr {
                         }
 
                         Ok(true)
-                    }
+                    },
                     None => Ok(true),
                 }
-            }
+            },
             _ => Ok(true),
         }
     }

--- a/crates/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -53,7 +53,7 @@ pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> PolarsResu
         Operator::Eq => ChunkCompare::<&Series>::equal(left, right).map(|ca| ca.into_series()),
         Operator::NotEq => {
             ChunkCompare::<&Series>::not_equal(left, right).map(|ca| ca.into_series())
-        }
+        },
         Operator::Plus => Ok(left + right),
         Operator::Minus => Ok(left - right),
         Operator::Multiply => Ok(left * right),
@@ -73,7 +73,7 @@ pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> PolarsResu
             {
                 panic!("activate 'round_series' feature")
             }
-        }
+        },
         Operator::And => left.bitand(right),
         Operator::Or => left.bitor(right),
         Operator::Xor => left.bitxor(right),
@@ -121,7 +121,7 @@ impl BinaryExpr {
                         let l = l.as_ref();
                         let r = r.as_ref();
                         Some(apply_operator(l, r, self.op))
-                    }
+                    },
                     _ => None,
                 }
                 .transpose()
@@ -133,15 +133,15 @@ impl BinaryExpr {
         use AggState::*;
         match (ac_l.agg_state(), ac_r.agg_state()) {
             // no need to change update groups
-            (AggregatedList(_), _) => {}
+            (AggregatedList(_), _) => {},
             // we can take the groups of the rhs
             (_, AggregatedList(_)) if matches!(ac_r.update_groups, UpdateGroups::No) => {
                 ac_l.groups = ac_r.groups
-            }
+            },
             // we must update the groups
             _ => {
                 ac_l.with_update_groups(UpdateGroups::WithSeriesLen);
-            }
+            },
         }
 
         ac_l.with_series(ca.into_series(), true, Some(&self.expr))?;
@@ -229,7 +229,7 @@ impl PhysicalExpr for BinaryExpr {
             (AggState::AggregatedFlat(_), AggState::NotAggregated(_))
             | (AggState::NotAggregated(_), AggState::AggregatedFlat(_)) => {
                 self.apply_group_aware(ac_l, ac_r)
-            }
+            },
             (AggState::AggregatedList(lhs), AggState::AggregatedList(rhs)) => {
                 let lhs = lhs.list().unwrap();
                 let rhs = rhs.list().unwrap();
@@ -237,7 +237,7 @@ impl PhysicalExpr for BinaryExpr {
                     lhs.apply_to_inner(&|lhs| apply_operator(&lhs, &rhs.get_inner(), self.op))?;
                 ac_l.with_series(out.into_series(), true, Some(&self.expr))?;
                 Ok(ac_l)
-            }
+            },
             _ => self.apply_group_aware(ac_l, ac_r),
         }
     }
@@ -314,7 +314,7 @@ mod stats {
                     .ok()
                     .map(|s| s.any())
                     == Some(true)
-            }
+            },
             // col >= lit
             Operator::GtEq => {
                 // literal is bigger than max value
@@ -323,7 +323,7 @@ mod stats {
                     .ok()
                     .map(|ca| ca.any())
                     == Some(true)
-            }
+            },
             // col < lit
             Operator::Lt => {
                 // literal is smaller than min value
@@ -332,7 +332,7 @@ mod stats {
                     .ok()
                     .map(|ca| ca.any())
                     == Some(true)
-            }
+            },
             // col <= lit
             Operator::LtEq => {
                 // literal is smaller than min value
@@ -341,7 +341,7 @@ mod stats {
                     .ok()
                     .map(|ca| ca.any())
                     == Some(true)
-            }
+            },
             // default: read the file
             _ => true,
         }
@@ -357,7 +357,7 @@ mod stats {
                     .ok()
                     .map(|ca| ca.any())
                     == Some(true)
-            }
+            },
             Operator::GtEq => {
                 // literal is bigger than max value
                 // selection needs all rows
@@ -365,7 +365,7 @@ mod stats {
                     .ok()
                     .map(|ca| ca.any())
                     == Some(true)
-            }
+            },
             Operator::Lt => {
                 // literal is smaller than min value
                 // selection needs all rows
@@ -373,7 +373,7 @@ mod stats {
                     .ok()
                     .map(|ca| ca.any())
                     == Some(true)
-            }
+            },
             Operator::LtEq => {
                 // literal is smaller than min value
                 // selection needs all rows
@@ -381,7 +381,7 @@ mod stats {
                     .ok()
                     .map(|ca| ca.any())
                     == Some(true)
-            }
+            },
             // default: read the file
             _ => true,
         }
@@ -411,11 +411,11 @@ mod stats {
             {
                 match (fld_l.data_type(), fld_r.data_type()) {
                     #[cfg(feature = "dtype-categorical")]
-                    (DataType::Utf8, DataType::Categorical(_)) => {}
+                    (DataType::Utf8, DataType::Categorical(_)) => {},
                     #[cfg(feature = "dtype-categorical")]
-                    (DataType::Categorical(_), DataType::Utf8) => {}
+                    (DataType::Categorical(_), DataType::Utf8) => {},
                     (l, r) if l != r => panic!("implementation error: {l:?}, {r:?}"),
-                    _ => {}
+                    _ => {},
                 }
             }
 
@@ -432,9 +432,9 @@ mod stats {
                             debug_assert_eq!(min_max_s.null_count(), 0);
                             let lit_s = self.right.evaluate(&dummy, &state).unwrap();
                             Ok(apply_operator_stats_rhs_lit(&min_max_s, &lit_s, self.op))
-                        }
+                        },
                     }
-                }
+                },
                 (true, false) => {
                     let r = stats.get_stats(fld_r.name())?;
                     match r.to_min_max() {
@@ -444,9 +444,9 @@ mod stats {
                             debug_assert_eq!(min_max_s.null_count(), 0);
                             let lit_s = self.left.evaluate(&dummy, &state).unwrap();
                             Ok(apply_operator_stats_lhs_lit(&lit_s, &min_max_s, self.op))
-                        }
+                        },
                     }
-                }
+                },
                 // default: read the file
                 _ => Ok(true),
             };

--- a/crates/polars-lazy/src/physical_plan/expressions/cast.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/cast.rs
@@ -48,7 +48,7 @@ impl PhysicalExpr for CastExpr {
                 let ca = s.list().unwrap();
                 let casted = ca.apply_to_inner(&|s| self.finish(&s))?;
                 ac.with_series(casted.into_series(), true, None)?;
-            }
+            },
             AggState::AggregatedFlat(s) => {
                 let s = self.finish(s)?;
                 if ac.is_literal() {
@@ -56,7 +56,7 @@ impl PhysicalExpr for CastExpr {
                 } else {
                     ac.with_series(s, true, None)?;
                 }
-            }
+            },
             _ => {
                 // before we flatten, make sure that groups are updated
                 ac.groups();
@@ -69,7 +69,7 @@ impl PhysicalExpr for CastExpr {
                 } else {
                     ac.with_series(s, false, None)?;
                 }
-            }
+            },
         }
 
         Ok(ac)

--- a/crates/polars-lazy/src/physical_plan/expressions/column.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/column.rs
@@ -39,7 +39,7 @@ impl ColumnExpr {
                     }
                     Err(e)
                 }
-            }
+            },
         }
     }
 
@@ -139,15 +139,15 @@ impl PhysicalExpr for ColumnExpr {
                                 } else {
                                     self.process_by_linear_search(df, state, true)
                                 }
-                            }
+                            },
                         }
-                    }
+                    },
                     // in the future we will throw an error here
                     // now we do a linear search first as the lazy reported schema may still be incorrect
                     // in debug builds we panic so that it can be fixed when occurring
                     None => self.process_by_linear_search(df, state, true),
                 }
-            }
+            },
         };
         self.check_external_context(out, state)
     }

--- a/crates/polars-lazy/src/physical_plan/expressions/filter.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/filter.rs
@@ -111,7 +111,7 @@ impl PhysicalExpr for FilterExpr {
                                 .collect();
 
                             GroupsProxy::Idx(groups)
-                        }
+                        },
                         GroupsProxy::Slice { groups, .. } => {
                             let groups = groups
                                 .par_iter()
@@ -129,7 +129,7 @@ impl PhysicalExpr for FilterExpr {
                                 })
                                 .collect();
                             GroupsProxy::Idx(groups)
-                        }
+                        },
                     }
                 })
             };

--- a/crates/polars-lazy/src/physical_plan/expressions/group_iter.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/group_iter.rs
@@ -23,7 +23,7 @@ impl<'a> AggregationContext<'a> {
                         name,
                     ))
                 }
-            }
+            },
             AggState::AggregatedFlat(_) => {
                 self.groups();
                 let s = self.series();
@@ -37,13 +37,13 @@ impl<'a> AggregationContext<'a> {
                         name,
                     ))
                 }
-            }
+            },
             AggState::AggregatedList(_) => {
                 let s = self.series();
                 let list = s.list().unwrap();
                 let name = if keep_names { s.name() } else { "" };
                 Box::new(list.amortized_iter_with_name(name))
-            }
+            },
             AggState::NotAggregated(_) => {
                 // we don't take the owned series as we want a reference
                 let _ = self.aggregated();
@@ -51,7 +51,7 @@ impl<'a> AggregationContext<'a> {
                 let list = s.list().unwrap();
                 let name = if keep_names { s.name() } else { "" };
                 Box::new(list.amortized_iter_with_name(name))
-            }
+            },
         }
     }
 }

--- a/crates/polars-lazy/src/physical_plan/expressions/literal.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/literal.rs
@@ -54,13 +54,13 @@ impl PhysicalExpr for LiteralExpr {
                     let high = *high as i32;
                     let ca: NoNull<Int32Chunked> = (low..high).collect();
                     ca.into_inner().into_series()
-                }
+                },
                 DataType::Int64 => {
                     let low = *low;
                     let high = *high;
                     let ca: NoNull<Int64Chunked> = (low..high).collect();
                     ca.into_inner().into_series()
-                }
+                },
                 DataType::UInt32 => {
                     polars_ensure!(
                         *low >= 0 && *high <= u32::MAX as i64,
@@ -70,7 +70,7 @@ impl PhysicalExpr for LiteralExpr {
                     let high = *high as u32;
                     let ca: NoNull<UInt32Chunked> = (low..high).collect();
                     ca.into_inner().into_series()
-                }
+                },
                 dt => polars_bail!(
                     InvalidOperation: "datatype `{}` is not supported as range", dt
                 ),

--- a/crates/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -66,7 +66,7 @@ impl AggState {
                     // or single groups with more than one index
                     || !groups.is_empty()
                     && groups.get(0).len() > 1))
-            }
+            },
             _ => true,
         }
     }
@@ -116,7 +116,7 @@ pub struct AggregationContext<'a> {
 impl<'a> AggregationContext<'a> {
     pub(crate) fn groups(&mut self) -> &Cow<'a, GroupsProxy> {
         match self.update_groups {
-            UpdateGroups::No => {}
+            UpdateGroups::No => {},
             UpdateGroups::WithGroupsLen => {
                 // the groups are unordered
                 // and the series is aggregated with this groups
@@ -140,16 +140,16 @@ impl<'a> AggregationContext<'a> {
                             groups,
                             rolling: false,
                         })
-                    }
+                    },
                     // sliced groups are already in correct order
-                    GroupsProxy::Slice { .. } => {}
+                    GroupsProxy::Slice { .. } => {},
                 }
                 self.update_groups = UpdateGroups::No;
-            }
+            },
             UpdateGroups::WithSeriesLen => {
                 let s = self.series().clone();
                 self.det_groups_from_list(&s);
-            }
+            },
         }
         &self.groups
     }
@@ -194,11 +194,11 @@ impl<'a> AggregationContext<'a> {
             (true, &DataType::List(_)) => {
                 assert_eq!(series.len(), groups.len());
                 AggState::AggregatedList(series)
-            }
+            },
             (true, _) => {
                 assert_eq!(series.len(), groups.len());
                 AggState::AggregatedFlat(series)
-            }
+            },
             _ => AggState::NotAggregated(series),
         };
 
@@ -263,7 +263,7 @@ impl<'a> AggregationContext<'a> {
                     groups,
                     rolling: false,
                 });
-            }
+            },
             _ => {
                 let groups = self
                     .series()
@@ -286,7 +286,7 @@ impl<'a> AggregationContext<'a> {
                     groups,
                     rolling: false,
                 });
-            }
+            },
         }
         self.update_groups = UpdateGroups::No;
     }
@@ -308,10 +308,10 @@ impl<'a> AggregationContext<'a> {
                     self.update_groups = UpdateGroups::WithGroupsLen;
                     self.state = AggState::AggregatedList(agg);
                 }
-            }
-            AggState::AggregatedFlat(_) => {}
-            AggState::AggregatedList(_) => {}
-            AggState::Literal(_) => {}
+            },
+            AggState::AggregatedFlat(_) => {},
+            AggState::AggregatedList(_) => {},
+            AggState::Literal(_) => {},
         }
     }
 
@@ -352,7 +352,7 @@ impl<'a> AggregationContext<'a> {
                     );
                 }
                 AggState::AggregatedList(series)
-            }
+            },
             (true, _) => AggState::AggregatedFlat(series),
             _ => {
                 match self.state {
@@ -362,10 +362,10 @@ impl<'a> AggregationContext<'a> {
                     // applying a function on a literal, keeps the literal state
                     AggState::Literal(_) if series.len() == 1 && mapped => {
                         AggState::Literal(series)
-                    }
+                    },
                     _ => AggState::NotAggregated(series),
                 }
-            }
+            },
         };
         Ok(self)
     }
@@ -412,14 +412,14 @@ impl<'a> AggregationContext<'a> {
                 self.sorted = true;
                 self.update_groups = UpdateGroups::WithGroupsLen;
                 out
-            }
+            },
             AggState::AggregatedList(s) | AggState::AggregatedFlat(s) => s,
             AggState::Literal(s) => {
                 self.groups();
                 let rows = self.groups.len();
                 let s = s.new_from_index(0, rows);
                 s.reshape(&[rows as i64, -1]).unwrap()
-            }
+            },
         }
     }
 
@@ -433,7 +433,7 @@ impl<'a> AggregationContext<'a> {
                 self.groups();
                 let rows = self.groups.len();
                 s.new_from_index(0, rows)
-            }
+            },
             _ => self.aggregated(),
         }
     }
@@ -485,7 +485,7 @@ impl<'a> AggregationContext<'a> {
                 // [3, 4]
                 let groups = groups.unroll();
                 (flattened, Cow::Owned(groups))
-            }
+            },
         }
     }
 
@@ -507,7 +507,7 @@ impl<'a> AggregationContext<'a> {
                 }
 
                 Cow::Owned(s.explode().unwrap())
-            }
+            },
             AggState::AggregatedFlat(s) => Cow::Borrowed(s),
             AggState::Literal(s) => Cow::Borrowed(s),
         }

--- a/crates/polars-lazy/src/physical_plan/expressions/slice.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/slice.rs
@@ -126,7 +126,7 @@ impl PhysicalExpr for SliceExpr {
                             .map(|(first, idx)| slice_groups_idx(offset, length, first, idx))
                             .collect();
                         GroupsProxy::Idx(groups)
-                    }
+                    },
                     GroupsProxy::Slice { groups, .. } => {
                         let groups = groups
                             .iter()
@@ -136,9 +136,9 @@ impl PhysicalExpr for SliceExpr {
                             groups,
                             rolling: false,
                         }
-                    }
+                    },
                 }
-            }
+            },
             (Literal(offset), _) => {
                 let offset = extract_offset(offset, &self.expr)?;
                 let length = ac_length.aggregated();
@@ -157,7 +157,7 @@ impl PhysicalExpr for SliceExpr {
                             })
                             .collect();
                         GroupsProxy::Idx(groups)
-                    }
+                    },
                     GroupsProxy::Slice { groups, .. } => {
                         let groups = groups
                             .iter()
@@ -170,9 +170,9 @@ impl PhysicalExpr for SliceExpr {
                             groups,
                             rolling: false,
                         }
-                    }
+                    },
                 }
-            }
+            },
             (_, Literal(length)) => {
                 let length = extract_length(length, &self.expr)?;
                 let offset = ac_offset.aggregated();
@@ -191,7 +191,7 @@ impl PhysicalExpr for SliceExpr {
                             })
                             .collect();
                         GroupsProxy::Idx(groups)
-                    }
+                    },
                     GroupsProxy::Slice { groups, .. } => {
                         let groups = groups
                             .iter()
@@ -204,9 +204,9 @@ impl PhysicalExpr for SliceExpr {
                             groups,
                             rolling: false,
                         }
-                    }
+                    },
                 }
-            }
+            },
             _ => {
                 let length = ac_length.aggregated();
                 let offset = ac_offset.aggregated();
@@ -230,7 +230,7 @@ impl PhysicalExpr for SliceExpr {
                             })
                             .collect();
                         GroupsProxy::Idx(groups)
-                    }
+                    },
                     GroupsProxy::Slice { groups, .. } => {
                         let groups = groups
                             .iter()
@@ -244,9 +244,9 @@ impl PhysicalExpr for SliceExpr {
                             groups,
                             rolling: false,
                         }
-                    }
+                    },
                 }
-            }
+            },
         };
 
         ac.with_groups(groups);

--- a/crates/polars-lazy/src/physical_plan/expressions/sort.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/sort.rs
@@ -72,7 +72,7 @@ impl PhysicalExpr for SortExpr {
                 let ca = s.list().unwrap();
                 let out = ca.lst_sort(self.options);
                 ac.with_series(out.into_series(), true, Some(&self.expr))?;
-            }
+            },
             _ => {
                 let series = ac.flat_naive().into_owned();
 
@@ -97,7 +97,7 @@ impl PhysicalExpr for SortExpr {
                                     (new_idx.first().copied().unwrap_or(first), new_idx)
                                 })
                                 .collect()
-                        }
+                        },
                         GroupsProxy::Slice { groups, .. } => groups
                             .par_iter()
                             .map(|&[first, len]| {
@@ -111,7 +111,7 @@ impl PhysicalExpr for SortExpr {
                 });
                 let groups = GroupsProxy::Idx(groups);
                 ac.with_groups(groups);
-            }
+            },
         }
 
         Ok(ac)

--- a/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -139,7 +139,7 @@ impl PhysicalExpr for SortByExpr {
                                 });
                                 Some(unsafe { s.take_unchecked(&idx).unwrap() })
                             }
-                        }
+                        },
                         _ => None,
                     })
                     .collect()
@@ -185,7 +185,7 @@ impl PhysicalExpr for SortByExpr {
                                         ..Default::default()
                                     });
                                     map_sorted_indices_to_group_idx(&sorted_idx, idx)
-                                }
+                                },
                                 GroupsIndicator::Slice([first, len]) => {
                                     let group = sort_by_s.slice(first as i64, len as usize);
                                     let sorted_idx = group.arg_sort(SortOptions {
@@ -195,7 +195,7 @@ impl PhysicalExpr for SortByExpr {
                                         ..Default::default()
                                     });
                                     map_sorted_indices_to_group_slice(&sorted_idx, first)
-                                }
+                                },
                             };
                             let first = new_idx.first().unwrap_or_else(|| {
                                 invalid.store(true, Ordering::Relaxed);
@@ -264,7 +264,7 @@ impl PhysicalExpr for SortByExpr {
 
                                     let sorted_idx = groups[0].arg_sort_multiple(&options).unwrap();
                                     map_sorted_indices_to_group_idx(&sorted_idx, idx)
-                                }
+                                },
                                 GroupsIndicator::Slice([first, len]) => {
                                     let groups = sort_by_s
                                         .iter()
@@ -278,7 +278,7 @@ impl PhysicalExpr for SortByExpr {
                                     };
                                     let sorted_idx = groups[0].arg_sort_multiple(&options).unwrap();
                                     map_sorted_indices_to_group_slice(&sorted_idx, first)
-                                }
+                                },
                             };
                             let first = new_idx.first().unwrap_or_else(|| {
                                 invalid.store(true, Ordering::Relaxed);

--- a/crates/polars-lazy/src/physical_plan/expressions/take.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/take.rs
@@ -88,7 +88,7 @@ impl PhysicalExpr for TakeExpr {
                             .zip(groups.first().iter())
                             .map(|(idx, first)| idx.map(|idx| idx + first))
                             .collect_trusted()
-                    }
+                    },
                     GroupsProxy::Slice { groups, .. } => {
                         if groups.iter().zip(idx).any(|(g, idx)| match idx {
                             None => true,
@@ -101,18 +101,18 @@ impl PhysicalExpr for TakeExpr {
                             .zip(groups.iter())
                             .map(|(idx, g)| idx.map(|idx| idx + g[0]))
                             .collect_trusted()
-                    }
+                    },
                 };
                 let taken = ac.flat_naive().take(&idx)?;
                 ac.with_series(taken, true, Some(&self.expr))?;
                 return Ok(ac);
-            }
+            },
             AggState::AggregatedList(s) => s.list().unwrap().clone(),
             // Maybe a literal as well, this needs a different path
             AggState::NotAggregated(_) => {
                 let s = idx.aggregated();
                 s.list().unwrap().clone()
-            }
+            },
             AggState::Literal(s) => {
                 let idx = s.cast(&IDX_DTYPE)?;
                 let idx = idx.idx().unwrap();
@@ -137,20 +137,20 @@ impl PhysicalExpr for TakeExpr {
                                     }
 
                                     groups.first().iter().map(|f| *f + idx).collect_trusted()
-                                }
+                                },
                                 GroupsProxy::Slice { groups, .. } => {
                                     if groups.iter().any(|g| idx >= g[1]) {
                                         self.oob_err()?;
                                     }
 
                                     groups.iter().map(|g| g[0] + idx).collect_trusted()
-                                }
+                                },
                             };
                             let taken = ac.flat_naive().take(&idx.into_inner())?;
                             ac.with_series(taken, true, Some(&self.expr))?;
                             ac.with_update_groups(UpdateGroups::WithGroupsLen);
                             Ok(ac)
-                        }
+                        },
                     }
                 } else {
                     let out = ac
@@ -163,7 +163,7 @@ impl PhysicalExpr for TakeExpr {
                     ac.with_update_groups(UpdateGroups::WithGroupsLen);
                     Ok(ac)
                 };
-            }
+            },
         };
 
         let s = idx.cast(&DataType::List(Box::new(IDX_DTYPE)))?;

--- a/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -179,12 +179,12 @@ impl PhysicalExpr for TernaryExpr {
                 out.rename(truthy.name());
                 ac_truthy.with_series(out, true, Some(&self.expr))?;
                 Ok(ac_truthy)
-            }
+            },
 
             // we cannot flatten a list because that changes the order, so we apply over groups
             (AggregatedList(_), NotAggregated(_)) | (NotAggregated(_), AggregatedList(_)) => {
                 finish_as_iters(ac_truthy, ac_falsy, ac_mask)
-            }
+            },
             // then:
             //     col().shift()
             // otherwise:
@@ -278,7 +278,7 @@ impl PhysicalExpr for TernaryExpr {
                     ac_truthy.with_series(out.into_series(), true, Some(&self.expr))?;
                     Ok(ac_truthy)
                 }
-            }
+            },
             // Both are or a flat series or aggregated into a list
             // so we can flatten the Series an apply the operators
             _ => {
@@ -299,8 +299,8 @@ impl PhysicalExpr for TernaryExpr {
                                 if options.is_groups_sensitive() =>
                             {
                                 has_agg = true
-                            }
-                            _ => {}
+                            },
+                            _ => {},
                         }
                     }
                     if has_arity && has_agg {
@@ -326,7 +326,7 @@ impl PhysicalExpr for TernaryExpr {
                 ac_truthy.with_series(out, false, None)?;
 
                 Ok(ac_truthy)
-            }
+            },
         }
     }
     fn as_partitioned_aggregator(&self) -> Option<&dyn PartitionedAggregation> {

--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -70,12 +70,12 @@ impl WindowExpr {
                     for g in groups.all() {
                         idx_mapping.extend(g.iter().copied().zip(&mut iter));
                     }
-                }
+                },
                 GroupsProxy::Slice { groups, .. } => {
                     for &[first, len] in groups {
                         idx_mapping.extend((first..first + len).zip(&mut iter));
                     }
-                }
+                },
             }
         }
         // groups are changed, we use the new group indexes as arguments of the arg_sort
@@ -87,12 +87,12 @@ impl WindowExpr {
                     for g in groups.all() {
                         original_idx.extend_from_slice(g)
                     }
-                }
+                },
                 GroupsProxy::Slice { groups, .. } => {
                     for &[first, len] in groups {
                         original_idx.extend(first..first + len)
                     }
-                }
+                },
             };
 
             let mut original_idx_iter = original_idx.iter().copied();
@@ -102,12 +102,12 @@ impl WindowExpr {
                     for g in groups.all() {
                         idx_mapping.extend(g.iter().copied().zip(&mut original_idx_iter));
                     }
-                }
+                },
                 GroupsProxy::Slice { groups, .. } => {
                     for &[first, len] in groups {
                         idx_mapping.extend((first..first + len).zip(&mut original_idx_iter));
                     }
-                }
+                },
             }
             original_idx.clear();
             take_idx = original_idx;
@@ -226,8 +226,8 @@ impl WindowExpr {
                     match e {
                         Expr::Agg(AggExpr::Implode(_)) => {
                             finishes_list = true;
-                        }
-                        Expr::Alias(_, _) => {}
+                        },
+                        Expr::Alias(_, _) => {},
                         _ => break,
                     }
                 }
@@ -249,8 +249,8 @@ impl WindowExpr {
                     match e {
                         Expr::Column(_) => {
                             simple_col = true;
-                        }
-                        Expr::Alias(_, _) => {}
+                        },
+                        Expr::Alias(_, _) => {},
                         _ => break,
                     }
                 }
@@ -270,8 +270,8 @@ impl WindowExpr {
                     match e {
                         Expr::Agg(_) => {
                             agg_col = true;
-                        }
-                        Expr::Alias(_, _) => {}
+                        },
+                        Expr::Alias(_, _) => {},
                         _ => break,
                     }
                 }
@@ -294,11 +294,11 @@ impl WindowExpr {
                     match e {
                         Expr::Ternary { .. } | Expr::BinaryExpr { .. } => {
                             has_arity = true;
-                        }
-                        Expr::Alias(_, _) => {}
+                        },
+                        Expr::Alias(_, _) => {},
                         Expr::Agg(_) => {
                             agg_col = true;
-                        }
+                        },
                         Expr::Function { options, .. }
                         | Expr::AnonymousFunction { options, .. } => {
                             if options.auto_explode
@@ -306,8 +306,8 @@ impl WindowExpr {
                             {
                                 agg_col = true;
                             }
-                        }
-                        _ => {}
+                        },
+                        _ => {},
                     }
                 }
             }
@@ -348,7 +348,7 @@ impl WindowExpr {
                 } else {
                     Ok(MapStrategy::Map)
                 }
-            }
+            },
             // no aggregations, just return column
             // or an aggregation that has been flattened
             // we have to check which one
@@ -361,7 +361,7 @@ impl WindowExpr {
                 } else {
                     Ok(MapStrategy::Map)
                 }
-            }
+            },
             (WindowMapping::Join, AggState::NotAggregated(_)) => Ok(MapStrategy::Join),
             // literals, do nothing and let broadcast
             (_, AggState::Literal(_)) => Ok(MapStrategy::Nothing),
@@ -507,7 +507,7 @@ impl PhysicalExpr for WindowExpr {
                     out.rename(name.as_ref());
                 }
                 Ok(out)
-            }
+            },
             Explode => {
                 let mut out = ac.aggregated().explode()?;
                 cache_gb(gb, state, &cache_key);
@@ -515,7 +515,7 @@ impl PhysicalExpr for WindowExpr {
                     out.rename(name.as_ref());
                 }
                 Ok(out)
-            }
+            },
             Map => {
                 // TODO!
                 // investigate if sorted arrays can be return directly
@@ -536,7 +536,7 @@ impl PhysicalExpr for WindowExpr {
                     state,
                     &cache_key,
                 )
-            }
+            },
             Join => {
                 let out_column = ac.aggregated();
                 // we try to flatten/extend the array by repeating the aggregated value n times
@@ -552,7 +552,7 @@ impl PhysicalExpr for WindowExpr {
                     (UpdateGroups::No, Some(out)) => {
                         cache_gb(gb, state, &cache_key);
                         Ok(out)
-                    }
+                    },
                     (_, _) => {
                         let keys = gb.keys();
                         cache_gb(gb, state, &cache_key);
@@ -599,9 +599,9 @@ impl PhysicalExpr for WindowExpr {
                         }
 
                         Ok(out)
-                    }
+                    },
                 }
-            }
+            },
         }
     }
 
@@ -696,12 +696,12 @@ where
             for g in groups.all() {
                 idx_mapping.extend((&mut iter).take(g.len()).zip(g.iter().copied()));
             }
-        }
+        },
         GroupsProxy::Slice { groups, .. } => {
             for &[first, len] in groups {
                 idx_mapping.extend((&mut iter).take(len as usize).zip(first..first + len));
             }
-        }
+        },
     }
     let mut values = Vec::with_capacity(len);
     let ptr: *mut T::Native = values.as_mut_ptr();
@@ -726,7 +726,7 @@ where
                             }
                         })
                 })
-            }
+            },
             GroupsProxy::Slice { groups, .. } => {
                 // this should always succeed as we don't expect any chunks after an aggregation
                 let agg_vals = ca.cont_slice().ok()?;
@@ -744,7 +744,7 @@ where
                             }
                         })
                 });
-            }
+            },
         }
 
         // safety: we have written all slots
@@ -778,11 +778,11 @@ where
                                 Some(v) => {
                                     *values_ptr.add(idx) = v;
                                     *validity_ptr.add(idx) = true;
-                                }
+                                },
                                 None => {
                                     *values_ptr.add(idx) = T::Native::default();
                                     *validity_ptr.add(idx) = false;
-                                }
+                                },
                             };
                         }
                     }
@@ -807,17 +807,17 @@ where
                                     Some(v) => {
                                         *values_ptr.add(idx) = v;
                                         *validity_ptr.add(idx) = true;
-                                    }
+                                    },
                                     None => {
                                         *values_ptr.add(idx) = T::Native::default();
                                         *validity_ptr.add(idx) = false;
-                                    }
+                                    },
                                 };
                             }
                         }
                     }
                 })
-            }
+            },
         }
         // safety: we have written all slots
         unsafe { values.set_len(len) }

--- a/crates/polars-lazy/src/physical_plan/file_cache.rs
+++ b/crates/polars-lazy/src/physical_plan/file_cache.rs
@@ -22,7 +22,7 @@ impl FileCache {
                     mapping.insert(fp, Mutex::new((0, Default::default())));
                 }
                 Arc::new(mapping)
-            }
+            },
         };
 
         Self { inner }

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -54,11 +54,11 @@ fn partitionable_gb(
                     // count().alias() is allowed: count of 2
                     if depth <= 2 {
                         match expr_arena.get(*input) {
-                            AExpr::Count => {}
+                            AExpr::Count => {},
                             _ => {
                                 partitionable = false;
                                 break;
-                            }
+                            },
                         }
                     }
                 }
@@ -159,11 +159,11 @@ pub fn create_physical_plan(
                 .map(|node| create_physical_plan(node, lp_arena, expr_arena))
                 .collect::<PolarsResult<Vec<_>>>()?;
             Ok(Box::new(executors::UnionExec { inputs, options }))
-        }
+        },
         Slice { input, offset, len } => {
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
             Ok(Box::new(executors::SliceExec { input, offset, len }))
-        }
+        },
         Selection { input, predicate } => {
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
             let mut state = ExpressionConversionState::default();
@@ -174,7 +174,7 @@ pub fn create_physical_plan(
                 input,
                 state.has_windows,
             )))
-        }
+        },
         Scan {
             path,
             file_info,
@@ -227,7 +227,7 @@ pub fn create_physical_plan(
                     file_options,
                 ))),
             }
-        }
+        },
         Projection {
             expr,
             input,
@@ -262,7 +262,7 @@ pub fn create_physical_plan(
                 schema: _schema,
                 options,
             }))
-        }
+        },
         LocalProjection {
             expr,
             input,
@@ -290,7 +290,7 @@ pub fn create_physical_plan(
                 schema: _schema,
                 options: Default::default(),
             }))
-        }
+        },
         DataFrameScan {
             df,
             projection,
@@ -316,7 +316,7 @@ pub fn create_physical_plan(
                 selection,
                 predicate_has_windows: state.has_windows,
             }))
-        }
+        },
         AnonymousScan {
             function,
             predicate,
@@ -341,7 +341,7 @@ pub fn create_physical_plan(
                 predicate,
                 options,
             }))
-        }
+        },
         Sort {
             input,
             by_column,
@@ -361,15 +361,15 @@ pub fn create_physical_plan(
                 by_column,
                 args,
             }))
-        }
+        },
         Cache { input, id, count } => {
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
             Ok(Box::new(executors::CacheExec { id, input, count }))
-        }
+        },
         Distinct { input, options } => {
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
             Ok(Box::new(executors::UniqueExec { input, options }))
-        }
+        },
         Aggregate {
             input,
             keys,
@@ -468,7 +468,7 @@ pub fn create_physical_plan(
                     options.slice,
                 )))
             }
-        }
+        },
         Join {
             input_left,
             input_right,
@@ -517,7 +517,7 @@ pub fn create_physical_plan(
                 parallel,
                 options.args,
             )))
-        }
+        },
         HStack {
             input,
             exprs,
@@ -553,13 +553,13 @@ pub fn create_physical_plan(
                 input_schema,
                 options,
             }))
-        }
+        },
         MapFunction {
             input, function, ..
         } => {
             let input = create_physical_plan(input, lp_arena, expr_arena)?;
             Ok(Box::new(executors::UdfExec { input, function }))
-        }
+        },
         ExtContext {
             input, contexts, ..
         } => {
@@ -569,6 +569,6 @@ pub fn create_physical_plan(
                 .map(|node| create_physical_plan(node, lp_arena, expr_arena))
                 .collect::<PolarsResult<_>>()?;
             Ok(Box::new(executors::ExternalContext { input, contexts }))
-        }
+        },
     }
 }

--- a/crates/polars-lazy/src/physical_plan/state.rs
+++ b/crates/polars-lazy/src/physical_plan/state.rs
@@ -102,7 +102,7 @@ impl ExecutionState {
 
                 timer.store(start, end, name.as_ref().to_string());
                 out
-            }
+            },
         }
     }
 

--- a/crates/polars-lazy/src/physical_plan/streaming/checks.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/checks.rs
@@ -36,7 +36,7 @@ pub(super) fn is_streamable(node: Node, expr_arena: &Arena<AExpr>, context: Cont
         AExpr::Column(_) => {
             seen_column = true;
             true
-        }
+        },
         AExpr::Ternary { .. }
         | AExpr::BinaryExpr { .. }
         | AExpr::Alias(_, _)
@@ -45,7 +45,7 @@ pub(super) fn is_streamable(node: Node, expr_arena: &Arena<AExpr>, context: Cont
             LiteralValue::Series(_) | LiteralValue::Range { .. } => {
                 seen_lit_range = true;
                 true
-            }
+            },
             _ => true,
         },
         _ => false,

--- a/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
@@ -65,7 +65,7 @@ fn jit_insert_slice(
                 unreachable!()
             };
             (offset, len)
-        }
+        },
         Union {
             options:
                 UnionOptions {
@@ -146,24 +146,24 @@ pub(super) fn construct(
                         Rc::new(RefCell::new(1))
                     };
                     sink_nodes.push((operator_offset, node, shared_count))
-                }
+                },
                 PipelineNode::Operator(node) => {
                     operator_nodes.push(node);
                     let op = get_operator(node, lp_arena, expr_arena, &to_physical_piped_expr)?;
                     operators.push(op);
-                }
+                },
                 PipelineNode::Union(node) => {
                     operator_nodes.push(node);
                     jit_insert_slice(node, lp_arena, &mut sink_nodes, operator_offset);
                     let op = get_operator(node, lp_arena, expr_arena, &to_physical_piped_expr)?;
                     operators.push(op);
-                }
+                },
                 PipelineNode::RhsJoin(node) => {
                     operator_nodes.push(node);
                     jit_insert_slice(node, lp_arena, &mut sink_nodes, operator_offset);
                     let op = get_dummy_operator();
                     operators.push(op)
-                }
+                },
             }
         }
         let execution_id = branch.execution_id;
@@ -204,7 +204,7 @@ pub(super) fn construct(
                 // default case if the tree ended with a file_sink
                 final_sink
             }
-        }
+        },
         _ => unreachable!(),
     };
     // keep the original around for formatting purposes

--- a/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
@@ -143,22 +143,22 @@ pub(crate) fn insert_streaming_nodes(
                 state.streamable = true;
                 state.operators_sinks.push(PipelineNode::Operator(root));
                 stack.push((*input, state, current_idx))
-            }
+            },
             HStack { input, exprs, .. } if all_streamable(exprs, expr_arena, Context::Default) => {
                 state.streamable = true;
                 state.operators_sinks.push(PipelineNode::Operator(root));
                 stack.push((*input, state, current_idx))
-            }
+            },
             Slice { input, offset, .. } if *offset >= 0 => {
                 state.streamable = true;
                 state.operators_sinks.push(PipelineNode::Sink(root));
                 stack.push((*input, state, current_idx))
-            }
+            },
             FileSink { input, .. } => {
                 state.streamable = true;
                 state.operators_sinks.push(PipelineNode::Sink(root));
                 stack.push((*input, state, current_idx))
-            }
+            },
             Sort {
                 input,
                 by_column,
@@ -167,14 +167,14 @@ pub(crate) fn insert_streaming_nodes(
                 state.streamable = true;
                 state.operators_sinks.push(PipelineNode::Sink(root));
                 stack.push((*input, state, current_idx))
-            }
+            },
             Projection { input, expr, .. }
                 if all_streamable(expr, expr_arena, Context::Default) =>
             {
                 state.streamable = true;
                 state.operators_sinks.push(PipelineNode::Operator(root));
                 stack.push((*input, state, current_idx))
-            }
+            },
             // Rechunks are ignored
             MapFunction {
                 input,
@@ -182,7 +182,7 @@ pub(crate) fn insert_streaming_nodes(
             } => {
                 state.streamable = true;
                 stack.push((*input, state, current_idx))
-            }
+            },
             // Streamable functions will be converted
             lp @ MapFunction { input, function } => {
                 if function.is_streamable() {
@@ -200,7 +200,7 @@ pub(crate) fn insert_streaming_nodes(
                         &mut insert_file_sink_ptr,
                     )
                 }
-            }
+            },
             Scan {
                 file_options: options,
                 scan_type,
@@ -218,13 +218,13 @@ pub(crate) fn insert_streaming_nodes(
                     state.sources.push(root);
                     pipeline_trees[current_idx].push(state)
                 }
-            }
+            },
             DataFrameScan { .. } => {
                 if state.streamable {
                     state.sources.push(root);
                     pipeline_trees[current_idx].push(state)
                 }
-            }
+            },
             Join {
                 input_left,
                 input_right,
@@ -260,7 +260,7 @@ pub(crate) fn insert_streaming_nodes(
                 state_left.operators_sinks.push(PipelineNode::Sink(root));
                 stack.push((input_left, state_left, current_idx));
                 stack.push((input_right, state_right, current_idx));
-            }
+            },
             // add globbing patterns
             #[cfg(any(feature = "csv", feature = "parquet"))]
             Union { inputs, options }
@@ -276,7 +276,7 @@ pub(crate) fn insert_streaming_nodes(
             {
                 state.sources.push(root);
                 pipeline_trees[current_idx].push(state);
-            }
+            },
             Union {
                 options:
                     UnionOptions {
@@ -304,7 +304,7 @@ pub(crate) fn insert_streaming_nodes(
                     state.operators_sinks.push(PipelineNode::Union(root));
                     stack.push((*input, state, current_idx));
                 }
-            }
+            },
             Union {
                 inputs,
                 options: UnionOptions { slice: None, .. },
@@ -326,7 +326,7 @@ pub(crate) fn insert_streaming_nodes(
                         stack.push((*input, state, current_idx));
                     }
                 }
-            }
+            },
             Distinct { input, options }
                 if !options.maintain_order
                     && !matches!(options.keep_strategy, UniqueKeepStrategy::None) =>
@@ -334,7 +334,7 @@ pub(crate) fn insert_streaming_nodes(
                 state.streamable = true;
                 state.operators_sinks.push(PipelineNode::Sink(root));
                 stack.push((*input, state, current_idx))
-            }
+            },
             #[allow(unused_variables)]
             lp @ Aggregate {
                 input,
@@ -416,7 +416,7 @@ pub(crate) fn insert_streaming_nodes(
                 } else {
                     return Ok(false);
                 }
-            }
+            },
             lp => {
                 if allow_partial {
                     process_non_streamable_node(
@@ -431,7 +431,7 @@ pub(crate) fn insert_streaming_nodes(
                 } else {
                     return Ok(false);
                 }
-            }
+            },
         }
     }
     let mut inserted = false;

--- a/crates/polars-lazy/src/tests/cse.rs
+++ b/crates/polars-lazy/src/tests/cse.rs
@@ -54,7 +54,7 @@ fn test_cse_unions() -> PolarsResult<()> {
                 } else {
                     false
                 }
-            }
+            },
             _ => true,
         }
     }));
@@ -139,7 +139,7 @@ fn test_cse_union2_4925() -> PolarsResult<()> {
                 Cache { id, count, .. } => {
                     assert_eq!(*count, 1);
                     Some(*id)
-                }
+                },
                 _ => None,
             }
         })
@@ -197,7 +197,7 @@ fn test_cse_joins_4954() -> PolarsResult<()> {
                     ));
 
                     Some(*id)
-                }
+                },
                 _ => None,
             }
         })

--- a/crates/polars-lazy/src/tests/mod.rs
+++ b/crates/polars-lazy/src/tests/mod.rs
@@ -82,16 +82,16 @@ fn init_files() {
                             .with_statistics(true)
                             .finish(&mut df)
                             .unwrap();
-                    }
+                    },
                     ".ipc" => {
                         IpcWriter::new(f).finish(&mut df).unwrap();
-                    }
+                    },
                     ".ndjson" => {
                         #[cfg(feature = "json")]
                         {
                             JsonWriter::new(f).finish(&mut df).unwrap()
                         }
-                    }
+                    },
                     _ => panic!(),
                 }
             }

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -420,7 +420,7 @@ fn test_groupby_ternary_literal_predicate() -> PolarsResult<()> {
                         assert!(!matches!(expr_arena.get(*node), AExpr::Ternary { .. }));
                     }
                     false
-                }
+                },
                 _ => false,
             }
         });
@@ -494,11 +494,11 @@ fn test_with_column_prune() -> PolarsResult<()> {
                 assert_eq!(projection.len(), 1);
                 let name = &projection[0];
                 assert_eq!(name, "c1");
-            }
+            },
             HStack { exprs, .. } => {
                 assert_eq!(exprs.len(), 1);
-            }
-            _ => {}
+            },
+            _ => {},
         };
     });
 
@@ -566,7 +566,7 @@ fn test_flatten_unions() -> PolarsResult<()> {
         ALogicalPlan::Union { inputs, .. } => {
             // we make sure that the nested unions are flattened into a single union
             assert_eq!(inputs.len(), 5);
-        }
+        },
         _ => panic!(),
     }
     Ok(())

--- a/crates/polars-lazy/src/utils.rs
+++ b/crates/polars-lazy/src/utils.rs
@@ -14,13 +14,13 @@ pub(crate) fn agg_source_paths(
         match lp {
             Scan { path, .. } => {
                 paths.insert(path.clone());
-            }
+            },
             // always block parallel on anonymous sources
             // as we cannot know if they will lock or not.
             AnonymousScan { .. } => {
                 paths.insert("anonymous".into());
-            }
-            _ => {}
+            },
+            _ => {},
         }
     })
 }

--- a/crates/polars-ops/src/chunked_array/array/sum_mean.rs
+++ b/crates/polars-ops/src/chunked_array/array/sum_mean.rs
@@ -66,52 +66,52 @@ pub(super) fn sum_with_nulls(ca: &ArrayChunked, inner_dtype: &DataType) -> Polar
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         UInt32 => {
             let out: UInt32Chunked = ca
                 .amortized_iter()
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         UInt64 => {
             let out: UInt64Chunked = ca
                 .amortized_iter()
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         Int32 => {
             let out: Int32Chunked = ca
                 .amortized_iter()
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         Int64 => {
             let out: Int64Chunked = ca
                 .amortized_iter()
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         Float32 => {
             let out: Float32Chunked = ca
                 .amortized_iter()
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         Float64 => {
             let out: Float64Chunked = ca
                 .amortized_iter()
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         _ => {
             polars_bail!(ComputeError: "summing array with dtype: {} not yet supported", ca.dtype())
-        }
+        },
     };
     out.rename(ca.name());
     Ok(out)

--- a/crates/polars-ops/src/chunked_array/interpolate.rs
+++ b/crates/polars-ops/src/chunked_array/interpolate.rs
@@ -112,7 +112,7 @@ where
             Some(Some(v)) => {
                 av.push(v);
                 low_val = Some(v);
-            }
+            },
             Some(None) => {
                 match low_val {
                     None => continue, // Not a non-null value encountered yet so we skip.
@@ -121,23 +121,23 @@ where
                         loop {
                             steps += 1;
                             match iter.next() {
-                                None => break,   // End of iterator, break.
-                                Some(None) => {} // Another null.
+                                None => break,    // End of iterator, break.
+                                Some(None) => {}, // Another null.
                                 Some(Some(high)) => {
                                     let steps_n: T::Native = NumCast::from(steps).unwrap();
                                     interpolation_branch(low, high, steps, steps_n, &mut av);
                                     av.push(high);
                                     low_val = Some(high);
                                     break;
-                                }
+                                },
                             }
                         }
-                    }
+                    },
                 }
-            }
+            },
             None => {
                 break;
-            }
+            },
         }
     }
     if first != 0 || last != chunked_arr.len() {
@@ -180,7 +180,7 @@ fn interpolate_nearest(s: &Series) -> Series {
             }
             let out = downcast_as_macro_arg_physical!(s, dispatch);
             out.cast(logical).unwrap()
-        }
+        },
     }
 }
 
@@ -214,7 +214,7 @@ fn interpolate_linear(s: &Series) -> Series {
                 _ => s.as_ref().clone(),
             };
             out.cast(logical).unwrap()
-        }
+        },
     }
 }
 

--- a/crates/polars-ops/src/chunked_array/list/hash.rs
+++ b/crates/polars-ops/src/chunked_array/list/hash.rs
@@ -32,10 +32,10 @@ where
                 Some(v) => {
                     let r = random_state.hash_one(v);
                     hash_agg = _boost_hash_combine(hash_agg, r);
-                }
+                },
                 None => {
                     hash_agg = _boost_hash_combine(hash_agg, null_hash);
-                }
+                },
             }
         }
     });
@@ -67,7 +67,7 @@ pub(crate) fn hash(ca: &mut ListChunked, build_hasher: ahash::RandomState) -> UI
                         let ca = s.bit_repr_small();
                         hash_agg(&ca, &build_hasher)
                     }
-                }
+                },
             })
             .collect()
     });

--- a/crates/polars-ops/src/chunked_array/list/min_max.rs
+++ b/crates/polars-ops/src/chunked_array/list/min_max.rs
@@ -82,7 +82,7 @@ pub(super) fn list_min_function(ca: &ListChunked) -> Series {
                     .map(|s| s.and_then(|s| s.as_ref().bool().unwrap().min()))
                     .collect_trusted();
                 out.into_series()
-            }
+            },
             dt if dt.is_numeric() => {
                 with_match_physical_numeric_polars_type!(dt, |$T| {
                     let out: ChunkedArray<$T> = ca
@@ -97,7 +97,7 @@ pub(super) fn list_min_function(ca: &ListChunked) -> Series {
                             .collect_trusted();
                         out.into_series()
                 })
-            }
+            },
             _ => ca
                 .apply_amortized(|s| s.as_ref().min_as_series())
                 .explode()
@@ -188,7 +188,7 @@ pub(super) fn list_max_function(ca: &ListChunked) -> Series {
                     .map(|s| s.and_then(|s| s.as_ref().bool().unwrap().max()))
                     .collect_trusted();
                 out.into_series()
-            }
+            },
             dt if dt.is_numeric() => {
                 with_match_physical_numeric_polars_type!(dt, |$T| {
                     let out: ChunkedArray<$T> = ca
@@ -203,7 +203,7 @@ pub(super) fn list_max_function(ca: &ListChunked) -> Series {
                             .collect_trusted();
                         out.into_series()
                 })
-            }
+            },
             _ => ca
                 .apply_amortized(|s| s.as_ref().max_as_series())
                 .explode()

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -107,7 +107,7 @@ pub trait ListNameSpaceImpl: AsList {
                     builder.append_option(opt_val)
                 });
                 Ok(builder.finish())
-            }
+            },
             dt => polars_bail!(op = "`lst.join`", got = dt, expected = "Utf8"),
         }
     }
@@ -296,7 +296,7 @@ pub trait ListNameSpaceImpl: AsList {
                             match (opt_s, opt_idx) {
                                 (Some(s), Some(idx)) => {
                                     Some(take_series(s.as_ref(), idx, null_on_oob))
-                                }
+                                },
                                 _ => None,
                             }
                         }
@@ -306,7 +306,7 @@ pub trait ListNameSpaceImpl: AsList {
                 out.rename(list_ca.name());
 
                 Ok(out.into_series())
-            }
+            },
             UInt32 | UInt64 => index_typed_index(idx),
             dt if dt.is_signed() => {
                 if let Some(min) = idx.min::<i64>() {
@@ -327,7 +327,7 @@ pub trait ListNameSpaceImpl: AsList {
                 } else {
                     polars_bail!(ComputeError: "all indices are null");
                 }
-            }
+            },
             dt => polars_bail!(ComputeError: "cannot use dtype `{}` as an index", dt),
         }
     }
@@ -347,14 +347,14 @@ pub trait ListNameSpaceImpl: AsList {
                     if let DataType::Categorical(_) = &inner_super_type {
                         inner_super_type = merge_dtypes(&inner_super_type, inner_type)?;
                     }
-                }
+                },
                 dt => {
                     inner_super_type = try_get_supertype(&inner_super_type, dt)?;
                     #[cfg(feature = "dtype-categorical")]
                     if let DataType::Categorical(_) = &inner_super_type {
                         inner_super_type = merge_dtypes(&inner_super_type, dt)?;
                     }
-                }
+                },
             }
         }
 
@@ -404,7 +404,7 @@ pub trait ListNameSpaceImpl: AsList {
                         #[cfg(feature = "dtype-struct")]
                         DataType::Struct(_) => s = s.rechunk(),
                         // nothing
-                        _ => {}
+                        _ => {},
                     }
                     s
                 });
@@ -442,7 +442,7 @@ pub trait ListNameSpaceImpl: AsList {
                             it.next().unwrap();
                         }
                         continue;
-                    }
+                    },
                 };
 
                 let mut has_nulls = false;
@@ -452,10 +452,10 @@ pub trait ListNameSpaceImpl: AsList {
                             if !has_nulls {
                                 acc.append(s.as_ref())?;
                             }
-                        }
+                        },
                         None => {
                             has_nulls = true;
-                        }
+                        },
                     }
                 }
                 if has_nulls {
@@ -468,7 +468,7 @@ pub trait ListNameSpaceImpl: AsList {
                     #[cfg(feature = "dtype-struct")]
                     DataType::Struct(_) => acc = acc.rechunk(),
                     // nothing
-                    _ => {}
+                    _ => {},
                 }
                 builder.append_series(&acc).unwrap();
             }
@@ -532,7 +532,7 @@ fn cast_index(idx: Series, len: usize, null_on_oob: bool) -> PolarsResult<Series
             } else {
                 idx.cast(&IDX_DTYPE).unwrap()
             }
-        }
+        },
         #[cfg(feature = "big_idx")]
         UInt64 => {
             if null_on_oob {
@@ -541,7 +541,7 @@ fn cast_index(idx: Series, len: usize, null_on_oob: bool) -> PolarsResult<Series
             } else {
                 idx
             }
-        }
+        },
         #[cfg(not(feature = "big_idx"))]
         UInt64 => {
             if null_on_oob {
@@ -550,7 +550,7 @@ fn cast_index(idx: Series, len: usize, null_on_oob: bool) -> PolarsResult<Series
             } else {
                 idx.cast(&IDX_DTYPE).unwrap()
             }
-        }
+        },
         #[cfg(not(feature = "big_idx"))]
         UInt32 => {
             if null_on_oob {
@@ -559,27 +559,27 @@ fn cast_index(idx: Series, len: usize, null_on_oob: bool) -> PolarsResult<Series
             } else {
                 idx
             }
-        }
+        },
         dt if dt.is_unsigned() => idx.cast(&IDX_DTYPE).unwrap(),
         Int8 => {
             let a = idx.i8().unwrap();
             cast_signed_index_ca(a, len)
-        }
+        },
         Int16 => {
             let a = idx.i16().unwrap();
             cast_signed_index_ca(a, len)
-        }
+        },
         Int32 => {
             let a = idx.i32().unwrap();
             cast_signed_index_ca(a, len)
-        }
+        },
         Int64 => {
             let a = idx.i64().unwrap();
             cast_signed_index_ca(a, len)
-        }
+        },
         _ => {
             unreachable!()
-        }
+        },
     };
     polars_ensure!(
         out.null_count() == idx_null_count || null_on_oob,

--- a/crates/polars-ops/src/chunked_array/list/sets.rs
+++ b/crates/polars-ops/src/chunked_array/list/sets.rs
@@ -60,19 +60,19 @@ where
             set.extend(a);
             set2.extend(b);
             out.extend_buf(set.intersection(set2).copied())
-        }
+        },
         SetOperation::Union => {
             set.extend(a);
             set.extend(b);
             out.extend_buf(set.drain(..))
-        }
+        },
         SetOperation::Difference => {
             set.extend(a);
             for v in b {
                 set.remove(&v);
             }
             out.extend_buf(set.drain(..))
-        }
+        },
         SetOperation::SymmetricDifference => {
             set2.clear();
             // We could speed this up, but implementing ourselves, but we need to have a clonable
@@ -80,7 +80,7 @@ where
             set.extend(a);
             set2.extend(b);
             out.extend_buf(set.symmetric_difference(set2).copied())
-        }
+        },
     }
 }
 
@@ -254,7 +254,7 @@ fn array_set_operation(
             let a = utf8_to_binary(a);
             let b = utf8_to_binary(b);
             binary(&a, &b, offsets_a, offsets_b, set_op, validity, true)
-        }
+        },
         ArrowDataType::LargeBinary => {
             let a = values_a
                 .as_any()
@@ -265,10 +265,10 @@ fn array_set_operation(
                 .downcast_ref::<BinaryArray<i64>>()
                 .unwrap();
             binary(a, b, offsets_a, offsets_b, set_op, validity, false)
-        }
+        },
         ArrowDataType::Boolean => {
             todo!("boolean type not yet supported in list union operations")
-        }
+        },
         _ => {
             with_match_physical_integer_type!(dtype.into(), |$T| {
                 let a = values_a.as_any().downcast_ref::<PrimitiveArray<$T>>().unwrap();
@@ -276,7 +276,7 @@ fn array_set_operation(
 
                 primitive(&a, &b, offsets_a, offsets_b, set_op, validity)
             })
-        }
+        },
     }
 }
 

--- a/crates/polars-ops/src/chunked_array/list/sum_mean.rs
+++ b/crates/polars-ops/src/chunked_array/list/sum_mean.rs
@@ -80,49 +80,49 @@ pub(super) fn sum_with_nulls(ca: &ListChunked, inner_dtype: &DataType) -> Series
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         UInt32 => {
             let out: UInt32Chunked = ca
                 .amortized_iter()
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         UInt64 => {
             let out: UInt64Chunked = ca
                 .amortized_iter()
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         Int32 => {
             let out: Int32Chunked = ca
                 .amortized_iter()
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         Int64 => {
             let out: Int64Chunked = ca
                 .amortized_iter()
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         Float32 => {
             let out: Float32Chunked = ca
                 .amortized_iter()
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         Float64 => {
             let out: Float64Chunked = ca
                 .amortized_iter()
                 .map(|s| s.and_then(|s| s.as_ref().sum()))
                 .collect();
             out.into_series()
-        }
+        },
         // slowest sum_as_series path
         _ => ca
             .apply_amortized(|s| s.as_ref().sum_as_series())
@@ -205,7 +205,7 @@ pub(super) fn mean_with_nulls(ca: &ListChunked) -> Series {
 
             out.rename(ca.name());
             out.into_series()
-        }
+        },
         _ => {
             let mut out: Float64Chunked = ca
                 .amortized_iter()
@@ -214,6 +214,6 @@ pub(super) fn mean_with_nulls(ca: &ListChunked) -> Series {
 
             out.rename(ca.name());
             out.into_series()
-        }
+        },
     };
 }

--- a/crates/polars-ops/src/chunked_array/list/to_struct.rs
+++ b/crates/polars-ops/src/chunked_array/list/to_struct.rs
@@ -25,7 +25,7 @@ fn det_n_fields(ca: &ListChunked, n_fields: ListToStructWidthStrategy) -> usize 
                 }
             });
             max
-        }
+        },
         ListToStructWidthStrategy::FirstNonNull => {
             let mut len = 0;
             for arr in ca.downcast_iter() {
@@ -43,7 +43,7 @@ fn det_n_fields(ca: &ListChunked, n_fields: ListToStructWidthStrategy) -> usize 
                 }
             }
             len
-        }
+        },
     }
 }
 

--- a/crates/polars-ops/src/chunked_array/nan_propagating_aggregate.rs
+++ b/crates/polars-ops/src/chunked_array/nan_propagating_aggregate.rs
@@ -66,11 +66,11 @@ pub fn nan_min_s(s: &Series, name: &str) -> Series {
         DataType::Float32 => {
             let ca = s.f32().unwrap();
             Series::new(name, [ca_nan_agg(ca, nan_min)])
-        }
+        },
         DataType::Float64 => {
             let ca = s.f64().unwrap();
             Series::new(name, [ca_nan_agg(ca, nan_min)])
-        }
+        },
         _ => panic!("expected float"),
     }
 }
@@ -79,11 +79,11 @@ pub fn nan_max_s(s: &Series, name: &str) -> Series {
         DataType::Float32 => {
             let ca = s.f32().unwrap();
             Series::new(name, [ca_nan_agg(ca, nan_max)])
-        }
+        },
         DataType::Float64 => {
             let ca = s.f64().unwrap();
             Series::new(name, [ca_nan_agg(ca, nan_max)])
-        }
+        },
         _ => panic!("expected float"),
     }
 }
@@ -120,7 +120,7 @@ where
                     _ => {
                         let take = { ca.take_unchecked(idx.into()) };
                         ca_nan_agg(&take, nan_max)
-                    }
+                    },
                 }
             }
         }),
@@ -154,11 +154,11 @@ where
                         _ => {
                             let arr_group = _slice_from_offsets(ca, first, len);
                             ca_nan_agg(&arr_group, nan_max)
-                        }
+                        },
                     }
                 })
             }
-        }
+        },
     }
 }
 
@@ -192,7 +192,7 @@ where
                     _ => {
                         let take = { ca.take_unchecked(idx.into()) };
                         ca_nan_agg(&take, nan_min)
-                    }
+                    },
                 }
             }
         }),
@@ -226,11 +226,11 @@ where
                         _ => {
                             let arr_group = _slice_from_offsets(ca, first, len);
                             ca_nan_agg(&arr_group, nan_min)
-                        }
+                        },
                     }
                 })
             }
-        }
+        },
     }
 }
 
@@ -241,11 +241,11 @@ pub unsafe fn group_agg_nan_min_s(s: &Series, groups: &GroupsProxy) -> Series {
         DataType::Float32 => {
             let ca = s.f32().unwrap();
             group_nan_min(ca, groups)
-        }
+        },
         DataType::Float64 => {
             let ca = s.f64().unwrap();
             group_nan_min(ca, groups)
-        }
+        },
         _ => panic!("expected float"),
     }
 }
@@ -257,11 +257,11 @@ pub unsafe fn group_agg_nan_max_s(s: &Series, groups: &GroupsProxy) -> Series {
         DataType::Float32 => {
             let ca = s.f32().unwrap();
             group_nan_max(ca, groups)
-        }
+        },
         DataType::Float64 => {
             let ca = s.f64().unwrap();
             group_nan_max(ca, groups)
-        }
+        },
         _ => panic!("expected float"),
     }
 }

--- a/crates/polars-ops/src/chunked_array/set.rs
+++ b/crates/polars-ops/src/chunked_array/set.rs
@@ -73,7 +73,7 @@ unsafe fn set_at_idx_impl<V, T: NativeType>(
                     Some(value) => {
                         mut_validity.set_unchecked(*idx as usize, true);
                         *new_values_slice.get_unchecked_mut(*idx as usize) = value
-                    }
+                    },
                     None => mut_validity.set_unchecked(*idx as usize, false),
                 }
             }
@@ -86,7 +86,7 @@ unsafe fn set_at_idx_impl<V, T: NativeType>(
                 Some(value) => *new_values_slice.get_unchecked_mut(*idx as usize) = value,
                 None => {
                     null_idx.push(*idx);
-                }
+                },
             }
         }
         // only make a validity bitmap when null values are set
@@ -129,14 +129,14 @@ where
                 // Safety:
                 // we checked bounds
                 unsafe { set_at_idx_impl(current_values, values, arr, idx, len) };
-            }
+            },
             None => {
                 let mut new_values = arr.values().as_slice().to_vec();
                 // Safety:
                 // we checked bounds
                 unsafe { set_at_idx_impl(&mut new_values, values, arr, idx, len) };
                 arr.set_values(new_values.into());
-            }
+            },
         };
         Ok(ca.into_series())
     }

--- a/crates/polars-ops/src/chunked_array/strings/case.rs
+++ b/crates/polars-ops/src/chunked_array/strings/case.rs
@@ -97,12 +97,12 @@ fn to_lowercase_helper(s: &str, buf: &mut Vec<u8>) {
                 [a, b, '\0'] => {
                     s.push(a);
                     s.push(b);
-                }
+                },
                 [a, b, c] => {
                     s.push(a);
                     s.push(b);
                     s.push(c);
-                }
+                },
             }
         }
     }
@@ -177,12 +177,12 @@ fn push_char_to_upper(c: char, s: &mut String) {
         [a, b, '\0'] => {
             s.push(a);
             s.push(b);
-        }
+        },
         [a, b, c] => {
             s.push(a);
             s.push(b);
             s.push(c);
-        }
+        },
     }
 }
 

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -311,7 +311,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
                     } else {
                         builder.append_null()
                     }
-                }
+                },
             }
         }
         Ok(builder.finish())
@@ -339,7 +339,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
                     } else {
                         builder.append_null()
                     }
-                }
+                },
             }
         }
         Ok(builder.finish())

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -60,13 +60,13 @@ where
         Either::Left(mut v) => {
             let values = arg_partition(&mut v, k, descending);
             ChunkedArray::from_slice(ca.name(), values)
-        }
+        },
         Either::Right(mut v) => {
             let values = arg_partition(&mut v, k, descending);
             let mut out = ChunkedArray::from_iter(values.iter().copied());
             out.rename(ca.name());
             out
-        }
+        },
     }
 }
 

--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -47,7 +47,7 @@ fn merge_series(lhs: &Series, rhs: &Series, merge_indicator: &[bool]) -> Series 
             let rhs = rhs.bool().unwrap();
 
             merge_ca(lhs, rhs, merge_indicator).into_series()
-        }
+        },
         Utf8 => {
             // dispatch via binary
             let lhs = lhs.cast(&Binary).unwrap();
@@ -56,12 +56,12 @@ fn merge_series(lhs: &Series, rhs: &Series, merge_indicator: &[bool]) -> Series 
             let rhs = rhs.binary().unwrap();
             let out = merge_ca(lhs, rhs, merge_indicator);
             unsafe { out.cast_unchecked(&Utf8).unwrap() }
-        }
+        },
         Binary => {
             let lhs = lhs.binary().unwrap();
             let rhs = rhs.binary().unwrap();
             merge_ca(lhs, rhs, merge_indicator).into_series()
-        }
+        },
         #[cfg(feature = "dtype-struct")]
         Struct(_) => {
             let lhs = lhs.struct_().unwrap();
@@ -74,19 +74,19 @@ fn merge_series(lhs: &Series, rhs: &Series, merge_indicator: &[bool]) -> Series 
                 .map(|(lhs, rhs)| merge_series(lhs, rhs, merge_indicator))
                 .collect::<Vec<_>>();
             StructChunked::new("", &new_fields).unwrap().into_series()
-        }
+        },
         List(_) => {
             let lhs = lhs.list().unwrap();
             let rhs = rhs.list().unwrap();
             merge_ca(lhs, rhs, merge_indicator).into_series()
-        }
+        },
         dt => {
             with_match_physical_numeric_polars_type!(dt, |$T| {
                     let lhs: &ChunkedArray<$T> = lhs.as_ref().as_ref().as_ref();
                     let rhs: &ChunkedArray<$T> = rhs.as_ref().as_ref().as_ref();
                     merge_ca(lhs, rhs, merge_indicator).into_series()
             })
-        }
+        },
     }
 }
 
@@ -126,13 +126,13 @@ fn series_to_merge_indicator(lhs: &Series, rhs: &Series) -> Vec<bool> {
             let lhs = lhs_s.bool().unwrap();
             let rhs = rhs_s.bool().unwrap();
             get_merge_indicator(lhs.into_iter(), rhs.into_iter())
-        }
+        },
         DataType::Utf8 => {
             let lhs = lhs_s.utf8().unwrap();
             let rhs = rhs_s.utf8().unwrap();
 
             get_merge_indicator(lhs.into_iter(), rhs.into_iter())
-        }
+        },
         _ => {
             with_match_physical_numeric_polars_type!(lhs_s.dtype(), |$T| {
                     let lhs: &ChunkedArray<$T> = lhs_s.as_ref().as_ref().as_ref();
@@ -141,7 +141,7 @@ fn series_to_merge_indicator(lhs: &Series, rhs: &Series) -> Vec<bool> {
                     get_merge_indicator(lhs.into_iter(), rhs.into_iter())
 
             })
-        }
+        },
     }
 }
 

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -180,19 +180,19 @@ pub trait DataFrameJoinOps: IntoDf {
             return match args.how {
                 JoinType::Inner => {
                     left_df._inner_join_from_series(other, s_left, s_right, args, _verbose)
-                }
+                },
                 JoinType::Left => {
                     left_df._left_join_from_series(other, s_left, s_right, args, _verbose)
-                }
+                },
                 JoinType::Outer => left_df._outer_join_from_series(other, s_left, s_right, args),
                 #[cfg(feature = "semi_anti_join")]
                 JoinType::Anti => {
                     left_df._semi_anti_join_from_series(s_left, s_right, args.slice, true)
-                }
+                },
                 #[cfg(feature = "semi_anti_join")]
                 JoinType::Semi => {
                     left_df._semi_anti_join_from_series(s_left, s_right, args.slice, false)
-                }
+                },
                 #[cfg(feature = "asof_join")]
                 JoinType::AsOf(options) => {
                     let left_on = selected_left[0].name();
@@ -221,12 +221,12 @@ pub trait DataFrameJoinOps: IntoDf {
                         ),
                         _ => {
                             panic!("expected by arguments on both sides")
-                        }
+                        },
                     }
-                }
+                },
                 JoinType::Cross => {
                     unreachable!()
-                }
+                },
             };
         }
 
@@ -271,14 +271,14 @@ pub trait DataFrameJoinOps: IntoDf {
                     },
                 );
                 _finish_join(df_left, df_right, args.suffix.as_deref())
-            }
+            },
             JoinType::Left => {
                 let mut left = DataFrame::new_no_checks(selected_left_physical);
                 let mut right = DataFrame::new_no_checks(selected_right_physical);
                 let ids = _left_join_multiple_keys(&mut left, &mut right, None, None);
 
                 left_df._finish_left_join(ids, &remove_selected(other, &selected_right), args)
-            }
+            },
             JoinType::Outer => {
                 let left = DataFrame::new_no_checks(selected_left_physical);
                 let right = DataFrame::new_no_checks(selected_right_physical);
@@ -319,7 +319,7 @@ pub trait DataFrameJoinOps: IntoDf {
                 keys.extend_from_slice(df_left.get_columns());
                 let df_left = DataFrame::new_no_checks(keys);
                 _finish_join(df_left, df_right, args.suffix.as_deref())
-            }
+            },
             #[cfg(feature = "asof_join")]
             JoinType::AsOf(_) => polars_bail!(
                 ComputeError: "asof join not supported for join on multiple keys"
@@ -337,10 +337,10 @@ pub trait DataFrameJoinOps: IntoDf {
                 // Safety:
                 // indices are in bounds
                 Ok(unsafe { left_df._finish_anti_semi_join(&idx, args.slice) })
-            }
+            },
             JoinType::Cross => {
                 unreachable!()
-            }
+            },
         }
     }
 

--- a/crates/polars-ops/src/frame/pivot/mod.rs
+++ b/crates/polars-ops/src/frame/pivot/mod.rs
@@ -35,38 +35,38 @@ fn restore_logical_type(s: &Series, logical_type: &DataType) -> Series {
                 CategoricalChunked::from_cats_and_rev_map_unchecked(cats, rev_map.clone())
                     .into_series()
             }
-        }
+        },
         (DataType::Float32, DataType::UInt32) => {
             let ca = s.u32().unwrap();
             ca._reinterpret_float().into_series()
-        }
+        },
         (DataType::Float64, DataType::UInt64) => {
             let ca = s.u64().unwrap();
             ca._reinterpret_float().into_series()
-        }
+        },
         (DataType::Int32, DataType::UInt32) => {
             let ca = s.u32().unwrap();
             ca.reinterpret_signed()
-        }
+        },
         (DataType::Int64, DataType::UInt64) => {
             let ca = s.u64().unwrap();
             ca.reinterpret_signed()
-        }
+        },
         #[cfg(feature = "dtype-duration")]
         (DataType::Duration(_), DataType::UInt64) => {
             let ca = s.u64().unwrap();
             ca.reinterpret_signed().cast(logical_type).unwrap()
-        }
+        },
         #[cfg(feature = "dtype-datetime")]
         (DataType::Datetime(_, _), DataType::UInt64) => {
             let ca = s.u64().unwrap();
             ca.reinterpret_signed().cast(logical_type).unwrap()
-        }
+        },
         #[cfg(feature = "dtype-date")]
         (DataType::Date, DataType::UInt32) => {
             let ca = s.u32().unwrap();
             ca.reinterpret_signed().cast(logical_type).unwrap()
-        }
+        },
         _ => s.cast(logical_type).unwrap(),
     }
 }

--- a/crates/polars-ops/src/frame/pivot/positioning.rs
+++ b/crates/polars-ops/src/frame/pivot/positioning.rs
@@ -85,7 +85,7 @@ pub(super) fn position_aggregates(
                         let mut out = buf.into_series();
                         out.rename(name);
                         out
-                    }
+                    },
                     _ => Series::from_any_values_and_dtype(name, avs, &phys_type, false).unwrap(),
                 };
                 unsafe { out.cast_unchecked(logical_type).unwrap() }
@@ -205,11 +205,11 @@ pub(super) fn compute_col_idx(
         Int32 | UInt32 | Float32 => {
             let ca = column_agg_physical.bit_repr_small();
             compute_col_idx_numeric(&ca)
-        }
+        },
         Int64 | UInt64 | Float64 => {
             let ca = column_agg_physical.bit_repr_large();
             compute_col_idx_numeric(&ca)
-        }
+        },
         _ => {
             let mut col_to_idx = PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
             let mut idx = 0 as IdxSize;
@@ -224,7 +224,7 @@ pub(super) fn compute_col_idx(
                     idx
                 })
                 .collect()
-        }
+        },
     };
 
     Ok((col_locations, column_agg))
@@ -266,7 +266,7 @@ where
             s.rename(&index[0]);
             let s = restore_logical_type(&s, logical_type);
             Some(vec![s])
-        }
+        },
         _ => None,
     };
 
@@ -290,11 +290,11 @@ pub(super) fn compute_row_idx(
             Int32 | UInt32 | Float32 => {
                 let ca = index_agg_physical.bit_repr_small();
                 compute_row_idx_numeric(index, &ca, count, index_s.dtype())
-            }
+            },
             Int64 | UInt64 | Float64 => {
                 let ca = index_agg_physical.bit_repr_large();
                 compute_row_idx_numeric(index, &ca, count, index_s.dtype())
-            }
+            },
             _ => {
                 let mut row_to_idx =
                     PlIndexMap::with_capacity_and_hasher(HASHMAP_INIT_SIZE, Default::default());
@@ -319,12 +319,12 @@ pub(super) fn compute_row_idx(
                         );
                         let s = restore_logical_type(&s, index_s.dtype());
                         Some(vec![s])
-                    }
+                    },
                     _ => None,
                 };
 
                 (row_locations, idx as usize, row_index)
-            }
+            },
         }
     } else {
         let index_s = pivot_df.columns(index)?;
@@ -355,7 +355,7 @@ pub(super) fn compute_row_idx(
                         old_idx
                     });
                     row_locations.push(idx)
-                }
+                },
             }
         }
         let row_index = match count {

--- a/crates/polars-ops/src/series/ops/approx_unique.rs
+++ b/crates/polars-ops/src/series/ops/approx_unique.rs
@@ -29,7 +29,7 @@ fn dispatcher(s: &Series) -> PolarsResult<Series> {
             let s = s.cast(&Binary).unwrap();
             let ca = s.binary().unwrap();
             approx_n_unique_ca(ca)
-        }
+        },
         Float32 => approx_n_unique_ca(&s.bit_repr_small()),
         Float64 => approx_n_unique_ca(&s.bit_repr_large()),
         dt if dt.is_numeric() => {
@@ -37,7 +37,7 @@ fn dispatcher(s: &Series) -> PolarsResult<Series> {
                 let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
                 approx_n_unique_ca(ca)
             })
-        }
+        },
         dt => polars_bail!(opq = approx_n_unique, dt),
     }
 }

--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -23,11 +23,11 @@ impl ArgAgg for Series {
             Utf8 => {
                 let ca = s.utf8().unwrap();
                 arg_min_str(ca)
-            }
+            },
             Boolean => {
                 let ca = s.bool().unwrap();
                 arg_min_bool(ca)
-            }
+            },
             dt if dt.is_numeric() => {
                 with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
                     let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
@@ -39,7 +39,7 @@ impl ArgAgg for Series {
                         arg_min_numeric(ca)
                     }
                 })
-            }
+            },
             _ => None,
         }
     }
@@ -51,11 +51,11 @@ impl ArgAgg for Series {
             Utf8 => {
                 let ca = s.utf8().unwrap();
                 arg_max_str(ca)
-            }
+            },
             Boolean => {
                 let ca = s.bool().unwrap();
                 arg_max_bool(ca)
-            }
+            },
             dt if dt.is_numeric() => {
                 with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
                     let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
@@ -67,7 +67,7 @@ impl ArgAgg for Series {
                         arg_max_numeric(ca)
                     }
                 })
-            }
+            },
             _ => None,
         }
     }
@@ -260,7 +260,7 @@ where
                             } else {
                                 (acc.0, acc.1, new_offset)
                             }
-                        }
+                        },
                         (None, None, offset) => match chunk_min_idx {
                             Some(idx) => (Some(idx + offset), chunk_min_val, new_offset),
                             None => (None, None, new_offset),
@@ -269,7 +269,7 @@ where
                     }
                 })
                 .0
-        }
+        },
     }
 }
 
@@ -315,7 +315,7 @@ where
                             } else {
                                 (acc.0, acc.1, new_offset)
                             }
-                        }
+                        },
                         (None, None, offset) => match chunk_max_idx {
                             Some(idx) => (Some(idx + offset), chunk_max_val, new_offset),
                             None => (None, None, new_offset),
@@ -324,7 +324,7 @@ where
                     }
                 })
                 .0
-        }
+        },
     }
 }
 

--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -39,7 +39,7 @@ fn map_cats(
                 None => {
                     bld.append_null();
                     brk_vals.append_null();
-                }
+                },
                 Some(idx) => unsafe {
                     bld.append_value(cl.get_unchecked(idx));
                     brk_vals.append_value(*right_ends.get_unchecked(idx));
@@ -79,7 +79,7 @@ pub fn cut(
         Some(ll) => {
             polars_ensure!(ll.len() == sorted_breaks.len() + 1, ShapeMismatch: "Provide nbreaks + 1 labels");
             ll
-        }
+        },
         None => (once(&f64::NEG_INFINITY).chain(sorted_breaks.iter()))
             .zip(sorted_breaks.iter().chain(once(&f64::INFINITY)))
             .map(|v| {
@@ -131,7 +131,7 @@ pub fn qcut(
                         .unzip::<_, _, Vec<_>, Vec<_>>()
                         .1,
                 )
-            }
+            },
         };
         qbreaks.dedup();
         return cut(&s, qbreaks, lfilt, left_closed, include_breaks);

--- a/crates/polars-ops/src/series/ops/floor_divide.rs
+++ b/crates/polars-ops/src/series/ops/floor_divide.rs
@@ -95,8 +95,8 @@ pub fn floor_div_series(a: &Series, b: &Series) -> PolarsResult<Series> {
             return Ok(_struct_arithmetic(a, b, |a, b| {
                 floor_div_series(a, b).unwrap()
             }))
-        }
-        _ => {}
+        },
+        _ => {},
     }
 
     let logical_type = a.dtype();

--- a/crates/polars-ops/src/series/ops/is_first.rs
+++ b/crates/polars-ops/src/series/ops/is_first.rs
@@ -72,29 +72,29 @@ pub fn is_first(s: &Series) -> PolarsResult<BooleanChunked> {
         Boolean => {
             let ca = s.bool().unwrap();
             is_first_boolean(ca)
-        }
+        },
         Binary => {
             let ca = s.binary().unwrap();
             is_first_bin(ca)
-        }
+        },
         Utf8 => {
             let s = s.cast(&Binary).unwrap();
             return is_first(&s);
-        }
+        },
         Float32 => {
             let ca = s.bit_repr_small();
             is_first_numeric(&ca)
-        }
+        },
         Float64 => {
             let ca = s.bit_repr_large();
             is_first_numeric(&ca)
-        }
+        },
         dt if dt.is_numeric() => {
             with_match_physical_integer_polars_type!(s.dtype(), |$T| {
                 let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
                 is_first_numeric(ca)
             })
-        }
+        },
         #[cfg(feature = "dtype-struct")]
         Struct(_) => return is_first_struct(&s),
         dt => polars_bail!(opq = is_first, dt),

--- a/crates/polars-ops/src/series/ops/is_unique.rs
+++ b/crates/polars-ops/src/series/ops/is_unique.rs
@@ -45,24 +45,24 @@ fn dispatcher(s: &Series, invert: bool) -> PolarsResult<BooleanChunked> {
         Boolean => {
             let ca = s.bool().unwrap();
             is_unique_ca(ca, invert)
-        }
+        },
         Binary => {
             let ca = s.binary().unwrap();
             is_unique_ca(ca, invert)
-        }
+        },
         Utf8 => {
             let s = s.cast(&Binary).unwrap();
             let ca = s.binary().unwrap();
             is_unique_ca(ca, invert)
-        }
+        },
         Float32 => {
             let ca = s.bit_repr_small();
             is_unique_ca(&ca, invert)
-        }
+        },
         Float64 => {
             let ca = s.bit_repr_large();
             is_unique_ca(&ca, invert)
-        }
+        },
         #[cfg(feature = "dtype-struct")]
         Struct(_) => {
             let ca = s.struct_().unwrap().clone();
@@ -72,13 +72,13 @@ fn dispatcher(s: &Series, invert: bool) -> PolarsResult<BooleanChunked> {
             } else {
                 df.is_unique()
             };
-        }
+        },
         dt if dt.is_numeric() => {
             with_match_physical_integer_polars_type!(s.dtype(), |$T| {
                 let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
                 is_unique_ca(ca, invert)
             })
-        }
+        },
         dt => polars_bail!(opq = is_unique, dt),
     };
     Ok(out)

--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -88,7 +88,7 @@ pub trait LogSeries: SeriesSealed {
 
                 let log_pk = pk.log(base);
                 (&pk * &log_pk).sum::<f64>().map(|v| -v)
-            }
+            },
             _ => s
                 .cast(&DataType::Float64)
                 .ok()

--- a/crates/polars-ops/src/series/ops/rolling.rs
+++ b/crates/polars-ops/src/series/ops/rolling.rs
@@ -42,15 +42,15 @@ pub trait RollingSeries: SeriesSealed {
             DataType::Float64 => {
                 let ca = s.f64().unwrap();
                 rolling_skew(ca, window_size, bias).map(|ca| ca.into_series())
-            }
+            },
             DataType::Float32 => {
                 let ca = s.f32().unwrap();
                 rolling_skew(ca, window_size, bias).map(|ca| ca.into_series())
-            }
+            },
             dt if dt.is_numeric() => {
                 let s = s.cast(&DataType::Float64).unwrap();
                 s.rolling_skew(window_size, bias)
-            }
+            },
             dt => polars_bail!(opq = rolling_skew, dt),
         }
     }

--- a/crates/polars-ops/src/series/ops/search_sorted.rs
+++ b/crates/polars-ops/src/series/ops/search_sorted.rs
@@ -53,7 +53,7 @@ fn finish_side<G, I>(
     match side {
         SearchSortedSide::Any => {
             out.push(mid);
-        }
+        },
         SearchSortedSide::Left => {
             if mid as usize == len {
                 mid -= 1;
@@ -71,7 +71,7 @@ fn finish_side<G, I>(
                     break;
                 }
             }
-        }
+        },
         SearchSortedSide::Right => {
             if mid as usize == len {
                 out.push(mid);
@@ -90,7 +90,7 @@ fn finish_side<G, I>(
                     break;
                 }
             }
-        }
+        },
     }
 }
 
@@ -123,7 +123,7 @@ fn binary_search_array<G, I>(
                 } else {
                     compare_fn_nan_max(&value, &search_value)
                 }
-            }
+            },
         };
 
         // The reason why we use if/else control flow rather than match
@@ -205,7 +205,7 @@ fn search_sorted_bin_array(
                     None => out.push(0),
                     Some(search_value) => {
                         binary_search_array(side, &mut out, arr, ca.len(), search_value, descending)
-                    }
+                    },
                 }
             }
         }
@@ -232,14 +232,14 @@ pub fn search_sorted(
             let idx = search_sorted_bin_array(&ca, &search_values, side, descending);
 
             Ok(IdxCa::new_vec(s.name(), idx))
-        }
+        },
         DataType::Binary => {
             let ca = s.binary().unwrap();
             let search_values = search_values.binary().unwrap();
             let idx = search_sorted_bin_array(ca, search_values, side, descending);
 
             Ok(IdxCa::new_vec(s.name(), idx))
-        }
+        },
         dt if dt.is_numeric() => {
             let search_values = search_values.to_physical_repr();
 
@@ -250,7 +250,7 @@ pub fn search_sorted(
                 search_sorted_ca_array(ca, search_values, side, descending)
             });
             Ok(IdxCa::new_vec(s.name(), idx))
-        }
+        },
         _ => polars_bail!(opq = search_sorted, original_dtype),
     }
 }

--- a/crates/polars-ops/src/series/ops/to_dummies.rs
+++ b/crates/polars-ops/src/series/ops/to_dummies.rs
@@ -39,10 +39,10 @@ impl ToDummies for Series {
                 let ca = match group {
                     GroupsIndicator::Idx((_, group)) => {
                         dummies_helper_idx(group, self.len(), &name)
-                    }
+                    },
                     GroupsIndicator::Slice([offset, len]) => {
                         dummies_helper_slice(offset, len, self.len(), &name)
-                    }
+                    },
                 };
                 ca.into_series()
             })

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -32,12 +32,12 @@ pub trait SeriesMethods: SeriesSealed {
             DataType::List(_) => {
                 let mut ca = s.list().unwrap().clone();
                 crate::chunked_array::hash::hash(&mut ca, build_hasher)
-            }
+            },
             _ => {
                 let mut h = vec![];
                 s.0.vec_hash(build_hasher, &mut h).unwrap();
                 UInt64Chunked::from_vec(s.name(), h)
-            }
+            },
         }
     }
 

--- a/crates/polars-pipe/src/executors/sinks/groupby/aggregates/convert.rs
+++ b/crates/polars-pipe/src/executors/sinks/groupby/aggregates/convert.rs
@@ -56,10 +56,10 @@ pub fn can_convert_to_hash_agg(
                 | AExpr::Column(_)
                 | AExpr::BinaryExpr { .. }
                 | AExpr::Ternary { .. }
-                | AExpr::Alias(_, _) => {}
+                | AExpr::Alias(_, _) => {},
                 _ => {
                     can_run_partitioned = false;
-                }
+                },
             }
             ae
         })
@@ -98,7 +98,7 @@ pub fn can_convert_to_hash_agg(
                         false
                     }
                 })
-            }
+            },
             _ => false,
         }
     } else {
@@ -145,7 +145,7 @@ where
                     dt => panic!("{dt} unexpected"),
                 };
                 (logical_dtype, phys_expr, agg_fn)
-            }
+            },
             AAggExpr::Max { input, .. } => {
                 let phys_expr = to_physical(*input, expr_arena, Some(schema)).unwrap();
                 let logical_dtype = phys_expr.field(schema).unwrap().dtype;
@@ -164,7 +164,7 @@ where
                     dt => panic!("{dt} unexpected"),
                 };
                 (logical_dtype, phys_expr, agg_fn)
-            }
+            },
             AAggExpr::Sum(input) => {
                 let phys_expr = to_physical(*input, expr_arena, Some(schema)).unwrap();
                 let logical_dtype = phys_expr.field(schema).unwrap().dtype;
@@ -186,7 +186,7 @@ where
                         } else {
                             AggregateFunction::SumU64(SumAgg::<u64>::new())
                         }
-                    }
+                    },
                     // these are aggregated as i64 to prevent overflow
                     DataType::Int8 => AggregateFunction::SumI64(SumAgg::<i64>::new()),
                     DataType::Int16 => AggregateFunction::SumI64(SumAgg::<i64>::new()),
@@ -202,7 +202,7 @@ where
                     dt => AggregateFunction::Null(NullAgg::new(dt)),
                 };
                 (logical_dtype, phys_expr, agg_fn)
-            }
+            },
             AAggExpr::Mean(input) => {
                 let phys_expr = to_physical(*input, expr_arena, Some(schema)).unwrap();
 
@@ -222,7 +222,7 @@ where
                     dt => AggregateFunction::Null(NullAgg::new(dt)),
                 };
                 (logical_dtype, phys_expr, agg_fn)
-            }
+            },
             AAggExpr::First(input) => {
                 let phys_expr = to_physical(*input, expr_arena, Some(schema)).unwrap();
                 let logical_dtype = phys_expr.field(schema).unwrap().dtype;
@@ -231,7 +231,7 @@ where
                     phys_expr,
                     AggregateFunction::First(FirstAgg::new(logical_dtype.to_physical())),
                 )
-            }
+            },
             AAggExpr::Last(input) => {
                 let phys_expr = to_physical(*input, expr_arena, Some(schema)).unwrap();
                 let logical_dtype = phys_expr.field(schema).unwrap().dtype;
@@ -240,7 +240,7 @@ where
                     phys_expr,
                     AggregateFunction::Last(LastAgg::new(logical_dtype.to_physical())),
                 )
-            }
+            },
             AAggExpr::Count(input) => {
                 let phys_expr = to_physical(*input, expr_arena, Some(schema)).unwrap();
                 let logical_dtype = phys_expr.field(schema).unwrap().dtype;
@@ -249,7 +249,7 @@ where
                     phys_expr,
                     AggregateFunction::Count(CountAgg::new()),
                 )
-            }
+            },
             agg => panic!("{agg:?} not yet implemented."),
         },
         _ => todo!(),

--- a/crates/polars-pipe/src/executors/sinks/groupby/aggregates/mean.rs
+++ b/crates/polars-pipe/src/executors/sinks/groupby/aggregates/mean.rs
@@ -30,12 +30,12 @@ impl<K: NumericNative> MeanAgg<K> {
             (Some(val), Some(sum)) => {
                 self.sum = Some(sum + val);
                 self.count += 1;
-            }
+            },
             (Some(val), None) => {
                 self.sum = Some(val);
                 self.count += 1;
-            }
-            _ => {}
+            },
+            _ => {},
         }
     }
 }
@@ -86,12 +86,12 @@ where
             (Some(val), Some(sum)) => {
                 self.sum = Some(sum + val);
                 self.count += 1;
-            }
+            },
             (Some(val), None) => {
                 self.sum = Some(val);
                 self.count += 1;
-            }
-            _ => {}
+            },
+            _ => {},
         }
     }
 
@@ -118,12 +118,12 @@ where
             (Some(val), Some(sum)) => {
                 self.sum = Some(sum + val);
                 self.count += (arr.len() - arr.null_count()) as IdxSize;
-            }
+            },
             (Some(val), None) => {
                 self.sum = Some(val);
                 self.count += (arr.len() - arr.null_count()) as IdxSize;
-            }
-            _ => {}
+            },
+            _ => {},
         }
     }
 
@@ -137,12 +137,12 @@ where
             (Some(lhs), Some(rhs)) => {
                 self.sum = Some(lhs + rhs);
                 self.count += other.count;
-            }
+            },
             (None, Some(rhs)) => {
                 self.sum = Some(rhs);
                 self.count = other.count;
-            }
-            _ => {}
+            },
+            _ => {},
         };
     }
 

--- a/crates/polars-pipe/src/executors/sinks/groupby/aggregates/min_max.rs
+++ b/crates/polars-pipe/src/executors/sinks/groupby/aggregates/min_max.rs
@@ -61,9 +61,9 @@ impl<K: NumericNative, F: Fn(&K, &K) -> Ordering> MinMaxAgg<K, F> {
                 if (self.cmp_fn)(&current_agg, &val) == Ordering::Less {
                     self.agg = Some(val);
                 }
-            }
+            },
             (Some(val), None) => self.agg = Some(val),
-            (None, _) => {}
+            (None, _) => {},
         }
     }
 }

--- a/crates/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
+++ b/crates/polars-pipe/src/executors/sinks/groupby/aggregates/sum.rs
@@ -27,7 +27,7 @@ impl<K: NumericNative + Add<Output = K> + NumCast> SumAgg<K> {
         match (item.map(|v| K::from(v).unwrap()), self.sum) {
             (Some(val), Some(sum)) => self.sum = Some(sum + val),
             (Some(val), None) => self.sum = Some(val),
-            (None, _) => {}
+            (None, _) => {},
         }
     }
 }
@@ -99,11 +99,11 @@ where
         match (sum_primitive(arr), self.sum) {
             (Some(val), Some(sum)) => {
                 self.sum = Some(sum + val);
-            }
+            },
             (Some(val), None) => {
                 self.sum = Some(val);
-            }
-            _ => {}
+            },
+            _ => {},
         }
     }
 

--- a/crates/polars-pipe/src/executors/sinks/groupby/generic/hash_table.rs
+++ b/crates/polars-pipe/src/executors/sinks/groupby/generic/hash_table.rs
@@ -121,7 +121,7 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
 
                 self.keys.extend_from_slice(row);
                 Some(aggregation_idx)
-            }
+            },
         }
     }
 

--- a/crates/polars-pipe/src/executors/sinks/groupby/generic/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/groupby/generic/sink.rs
@@ -96,7 +96,7 @@ impl Sink for GenericGroupby2 {
             .ooc_state
             .check_memory_usage(&|| self.global_table.get_ooc_dump_schema())?
         {
-            SpillAction::None => {}
+            SpillAction::None => {},
             SpillAction::EarlyMerge => self.global_table.early_merge(),
             SpillAction::Dump => {
                 if let Some((partition_no, spill)) = self.global_table.get_ooc_dump() {
@@ -104,7 +104,7 @@ impl Sink for GenericGroupby2 {
                 } else {
                     // do nothing
                 }
-            }
+            },
         }
         Ok(SinkResult::CanHaveMoreInput)
     }

--- a/crates/polars-pipe/src/executors/sinks/groupby/generic/thread_local.rs
+++ b/crates/polars-pipe/src/executors/sinks/groupby/generic/thread_local.rs
@@ -164,8 +164,8 @@ impl SpillPartitions {
     fn combine(&mut self, other: &mut Self) {
         match (self.spilled, other.spilled) {
             (false, true) => std::mem::swap(self, other),
-            (true, false) => {}
-            (false, false) => {}
+            (true, false) => {},
+            (false, false) => {},
             (true, true) => {
                 self.finish();
                 other.finish();
@@ -175,7 +175,7 @@ impl SpillPartitions {
                 {
                     part_self.extend(part_other)
                 }
-            }
+            },
         }
     }
 

--- a/crates/polars-pipe/src/executors/sinks/groupby/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/groupby/mod.rs
@@ -44,7 +44,7 @@ pub(super) fn physical_agg_to_logical(cols: &mut [Series], output_schema: &Schem
                         unreachable!()
                     }
                 }
-            }
+            },
             _ => {
                 let dtype_left = s.dtype();
                 if dtype_left != dtype
@@ -53,7 +53,7 @@ pub(super) fn physical_agg_to_logical(cols: &mut [Series], output_schema: &Schem
                 {
                     *s = s.cast(dtype).unwrap()
                 }
-            }
+            },
         }
     }
 }

--- a/crates/polars-pipe/src/executors/sinks/groupby/ooc.rs
+++ b/crates/polars-pipe/src/executors/sinks/groupby/ooc.rs
@@ -114,12 +114,12 @@ impl Source for GroupBySource {
                             .collect::<Vec<_>>();
 
                         Ok(SourceResult::GotMoreData(chunks))
-                    }
+                    },
                     // recursively out of core path
                     FinalizedSink::Source(mut src) => src.get_batches(context),
                     _ => unreachable!(),
                 }
-            }
+            },
         }
     }
 

--- a/crates/polars-pipe/src/executors/sinks/groupby/primitive/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/groupby/primitive/mod.rs
@@ -428,7 +428,7 @@ where
                                 self.aggregators.push(agg_fn.split())
                             }
                             offset
-                        }
+                        },
                         RawEntryMut::Occupied(entry) => *entry.get(),
                     };
                     // combine the aggregation functions
@@ -519,7 +519,7 @@ where
                 current_aggregators.push(agg_fn.split())
             }
             offset
-        }
+        },
         RawEntryMut::Occupied(entry) => *entry.get(),
     }
 }

--- a/crates/polars-pipe/src/executors/sinks/groupby/string.rs
+++ b/crates/polars-pipe/src/executors/sinks/groupby/string.rs
@@ -288,7 +288,7 @@ impl Utf8GroupbySink {
                     unsafe {
                         self.ooc_state.set_row_as_ooc(iteration_idx);
                     }
-                }
+                },
                 RawEntryMut::Occupied(entry) => {
                     let agg_idx = *entry.get();
                     // # Safety
@@ -296,7 +296,7 @@ impl Utf8GroupbySink {
                     // this is sound because we writes are trailing from iteration
                     unsafe { write_agg_idx(agg_idx_ptr, processed, agg_idx) };
                     processed += 1;
-                }
+                },
             };
         }
 
@@ -368,7 +368,7 @@ impl Sink for Utf8GroupbySink {
                         aggregators.push(agg_fn.split())
                     }
                     value_offset
-                }
+                },
                 RawEntryMut::Occupied(entry) => *entry.get(),
             };
             // # Safety
@@ -456,7 +456,7 @@ impl Sink for Utf8GroupbySink {
                                 self.aggregators.push(agg_fn.split())
                             }
                             values_offset
-                        }
+                        },
                         RawEntryMut::Occupied(entry) => *entry.get(),
                     };
 

--- a/crates/polars-pipe/src/executors/sinks/groupby/utils.rs
+++ b/crates/polars-pipe/src/executors/sinks/groupby/utils.rs
@@ -73,6 +73,6 @@ pub(super) fn finalize_groupby(
             Ok(FinalizedSink::Source(Box::new(GroupBySource::new(
                 iot, df, sink, slice,
             )?)))
-        }
+        },
     }
 }

--- a/crates/polars-pipe/src/executors/sinks/joins/cross.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/cross.rs
@@ -110,7 +110,7 @@ impl Operator for CrossJoinProbe {
                     None => {
                         self.in_process_left = None;
                         Ok(OperatorResult::NeedsNewData)
-                    }
+                    },
                     Some(offset) => {
                         self.in_process_left_df = self.df.slice(offset as i64, size);
                         self.in_process_right = Some((0..chunk.data.height()).step_by(size));
@@ -123,9 +123,9 @@ impl Operator for CrossJoinProbe {
                             None,
                         )?;
                         Ok(OperatorResult::HaveMoreOutPut(chunk.with_data(df)))
-                    }
+                    },
                 }
-            }
+            },
             // deplete the right chunks over the current left chunk
             Some(offset) => {
                 // this will be the branch of the first call
@@ -143,14 +143,14 @@ impl Operator for CrossJoinProbe {
                         )?;
                         self.output_names = Some(df.get_column_names_owned());
                         df
-                    }
+                    },
                     Some(names) => self
                         .in_process_left_df
                         ._cross_join_with_names(&right_df, names)?,
                 };
 
                 Ok(OperatorResult::HaveMoreOutPut(chunk.with_data(df)))
-            }
+            },
         }
     }
     fn split(&self, _thread_no: usize) -> Box<dyn Operator> {

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_build.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_build.rs
@@ -197,10 +197,10 @@ impl Sink for GenericBuild {
                 RawEntryMut::Vacant(entry) => {
                     let key = Key::new(*h, current_chunk_offset, current_df_idx);
                     entry.insert(key, vec![payload]);
-                }
+                },
                 RawEntryMut::Occupied(mut entry) => {
                     entry.get_mut().push(payload);
-                }
+                },
             };
 
             current_df_idx += 1;
@@ -260,13 +260,13 @@ impl Sink for GenericBuild {
                                 payload.extend(iter);
                             }
                             entry.insert(key, payload);
-                        }
+                        },
                         RawEntryMut::Occupied(mut entry) => {
                             let iter = val
                                 .iter()
                                 .map(|[chunk_idx, val_idx]| [*chunk_idx + chunks_offset, *val_idx]);
                             entry.get_mut().extend(iter);
-                        }
+                        },
                     }
                 }
             })
@@ -325,7 +325,7 @@ impl Sink for GenericBuild {
                     self.join_type.clone(),
                 );
                 Ok(FinalizedSink::Operator(Box::new(probe_operator)))
-            }
+            },
             _ => unimplemented!(),
         }
     }

--- a/crates/polars-pipe/src/executors/sinks/joins/inner_left.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/inner_left.rs
@@ -162,7 +162,7 @@ impl GenericJoinProbe {
                 let out = _finish_join(left_df, right_df, Some(self.suffix.as_ref()))?;
                 self.output_names = Some(out.get_column_names_owned());
                 out
-            }
+            },
             Some(names) => unsafe {
                 // safety:
                 // if we have duplicate names, we overwrite
@@ -217,11 +217,11 @@ impl GenericJoinProbe {
                         .extend(indexes_right.iter().copied().map(Some));
                     self.join_tuples_b
                         .extend(std::iter::repeat(df_idx_left).take(indexes_right.len()));
-                }
+                },
                 None => {
                     self.join_tuples_b.push(df_idx_left);
                     self.join_tuples_a_left_join.push(None);
-                }
+                },
             }
         }
         let right_df = self.df_a.as_ref();

--- a/crates/polars-pipe/src/executors/sinks/reproject.rs
+++ b/crates/polars-pipe/src/executors/sinks/reproject.rs
@@ -42,13 +42,13 @@ impl Sink for ReProjectSink {
         Ok(match self.sink.finalize(context)? {
             FinalizedSink::Finished(df) => {
                 FinalizedSink::Finished(df.select(self.schema.iter_names())?)
-            }
+            },
             FinalizedSink::Operator(op) => {
                 FinalizedSink::Operator(Box::new(ReProjectOperator::new(self.schema.clone(), op)))
-            }
+            },
             FinalizedSink::Source(source) => {
                 FinalizedSink::Source(Box::new(ReProjectSource::new(self.schema.clone(), source)))
-            }
+            },
         })
     }
 

--- a/crates/polars-pipe/src/executors/sinks/sort/ooc.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/ooc.rs
@@ -191,13 +191,13 @@ fn partition_df(df: DataFrame, partitions: &IdxCa) -> PolarsResult<(DfIter, IdxC
                 unsafe { df._take_unchecked_slice_sorted(&group, false, IsSorted::Ascending) }
             });
             Box::new(iter) as DfIter
-        }
+        },
         GroupsProxy::Slice { groups, .. } => {
             let iter = groups
                 .into_iter()
                 .map(move |[first, len]| df.slice(first as i64, len as usize));
             Box::new(iter) as DfIter
-        }
+        },
     };
     Ok((out, partitions))
 }

--- a/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
@@ -282,7 +282,7 @@ impl Sink for SortSinkMultiple {
                     &self.output_schema,
                 );
                 Ok(FinalizedSink::Finished(df))
-            }
+            },
             FinalizedSink::Source(source) => Ok(FinalizedSink::Source(Box::new(DropEncoded {
                 source,
                 sort_idx: self.sort_idx.clone(),

--- a/crates/polars-pipe/src/executors/sinks/sort/source.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/source.rs
@@ -103,13 +103,13 @@ impl Source for SortSource {
                             self.finished = true;
                         }
                         out
-                    }
+                    },
                 }?;
 
                 // convert to chunks
                 let dfs = split_df(&mut df, self.n_threads)?;
                 Ok(SourceResult::GotMoreData(self.finish_batch(dfs)))
-            }
+            },
         }
     }
 

--- a/crates/polars-pipe/src/executors/sources/csv.rs
+++ b/crates/polars-pipe/src/executors/sources/csv.rs
@@ -125,12 +125,12 @@ impl Drop for CsvSource {
             match self.batched_reader {
                 Some(Either::Left(ptr)) => {
                     let _to_drop = Box::from_raw(ptr);
-                }
+                },
                 Some(Either::Right(ptr)) => {
                     let _to_drop = Box::from_raw(ptr);
-                }
+                },
                 // nothing initialized, nothing to drop
-                _ => {}
+                _ => {},
             }
             if let Some(ptr) = self.reader {
                 let _to_drop = Box::from_raw(ptr);
@@ -153,12 +153,12 @@ impl Source for CsvSource {
                 let reader = unsafe { &mut *batched_reader };
 
                 reader.next_batches(self.n_threads)?
-            }
+            },
             Either::Right(batched_reader) => {
                 let reader = unsafe { &mut *batched_reader };
 
                 reader.next_batches(self.n_threads)?
-            }
+            },
         };
         Ok(match batches {
             None => SourceResult::Finished,

--- a/crates/polars-pipe/src/executors/sources/reproject.rs
+++ b/crates/polars-pipe/src/executors/sources/reproject.rs
@@ -29,7 +29,7 @@ impl Source for ReProjectSource {
                     reproject_chunk(chunk, &mut self.positions, self.schema.as_ref())?;
                 }
                 SourceResult::GotMoreData(chunks)
-            }
+            },
         })
     }
 

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -65,7 +65,7 @@ where
                 }
             }
             Ok(Box::new(sources::DataFrameSource::from_df(df)) as Box<dyn Source>)
-        }
+        },
         Scan {
             path,
             file_info,
@@ -94,7 +94,7 @@ where
                         verbose,
                     )?;
                     Ok(Box::new(src) as Box<dyn Source>)
-                }
+                },
                 #[cfg(feature = "parquet")]
                 FileScan::Parquet {
                     options: parquet_options,
@@ -109,10 +109,10 @@ where
                         verbose,
                     )?;
                     Ok(Box::new(src) as Box<dyn Source>)
-                }
+                },
                 _ => todo!(),
             }
-        }
+        },
         _ => unreachable!(),
     }
 }
@@ -136,14 +136,14 @@ where
                 FileType::Parquet(options) => {
                     Box::new(ParquetSink::new(path, *options, input_schema.as_ref())?)
                         as Box<dyn Sink>
-                }
+                },
                 #[cfg(feature = "ipc")]
                 FileType::Ipc(options) => {
                     Box::new(IpcSink::new(path, *options, input_schema.as_ref())?) as Box<dyn Sink>
-                }
+                },
                 FileType::Memory => Box::new(OrderedSink::new()) as Box<dyn Sink>,
             }
-        }
+        },
         Join {
             input_left,
             input_right,
@@ -159,7 +159,7 @@ where
                 #[cfg(feature = "cross_join")]
                 JoinType::Cross => {
                     Box::new(CrossJoin::new(options.args.suffix().into())) as Box<dyn Sink>
-                }
+                },
                 join_type @ JoinType::Inner | join_type @ JoinType::Left => {
                     let input_schema_left = lp_arena.get(*input_left).schema(lp_arena);
                     let join_columns_left = Arc::new(exprs_to_physical(
@@ -191,14 +191,14 @@ where
                         join_columns_left,
                         join_columns_right,
                     )) as Box<dyn Sink>
-                }
+                },
                 _ => unimplemented!(),
             }
-        }
+        },
         Slice { offset, len, .. } => {
             let slice = SliceSink::new(*offset as u64, *len as usize);
             Box::new(slice) as Box<dyn Sink>
-        }
+        },
         Sort {
             input,
             by_column,
@@ -226,7 +226,7 @@ where
                 let sort_sink = SortSinkMultiple::new(args.clone(), input_schema, sort_idx);
                 Box::new(sort_sink) as Box<dyn Sink>
             }
-        }
+        },
         Distinct { input, options } => {
             // We create a Groupby.agg_first()/agg_last (depending on the keep strategy
             let input_schema = lp_arena.get(*input).schema(lp_arena).into_owned();
@@ -239,7 +239,7 @@ where
                         .collect::<Vec<_>>();
                     let aggs = vec![];
                     (keys, aggs, input_schema.clone())
-                }
+                },
                 Some(keys) => {
                     let mut groupby_out_schema = Schema::with_capacity(input_schema.len());
                     let key_names = PlHashSet::from_iter(keys.iter().map(|s| s.as_ref()));
@@ -265,19 +265,19 @@ where
                                 Some(match options.keep_strategy {
                                     UniqueKeepStrategy::First | UniqueKeepStrategy::Any => {
                                         expr_arena.add(AExpr::Agg(AAggExpr::First(col)))
-                                    }
+                                    },
                                     UniqueKeepStrategy::Last => {
                                         expr_arena.add(AExpr::Agg(AAggExpr::Last(col)))
-                                    }
+                                    },
                                     UniqueKeepStrategy::None => {
                                         unreachable!()
-                                    }
+                                    },
                                 })
                             }
                         })
                         .collect();
                     (keys, aggs, groupby_out_schema.into())
-                }
+                },
             };
 
             let key_columns = Arc::new(exprs_to_physical(
@@ -310,7 +310,7 @@ where
             ));
 
             Box::new(ReProjectSink::new(input_schema, groupby_sink))
-        }
+        },
         Aggregate {
             input,
             keys,
@@ -365,7 +365,7 @@ where
                                 options.slice,
                             )) as Box<dyn Sink>
                         })
-                    }
+                    },
                     (DataType::Utf8, 1) => Box::new(groupby::Utf8GroupbySink::new(
                         key_columns[0].clone(),
                         aggregation_columns,
@@ -384,10 +384,10 @@ where
                     )),
                 }
             }
-        }
+        },
         lp => {
             panic!("{lp:?} not implemented")
-        }
+        },
     };
     Ok(out)
 }
@@ -453,7 +453,7 @@ where
                 cse_exprs,
             };
             Box::new(op) as Box<dyn Operator>
-        }
+        },
         HStack { exprs, input, .. } => {
             let input_schema = lp_arena.get(*input).schema(lp_arena);
 
@@ -480,13 +480,13 @@ where
             )?;
 
             Box::new(op) as Box<dyn Operator>
-        }
+        },
         Selection { predicate, input } => {
             let input_schema = lp_arena.get(*input).schema(lp_arena);
             let predicate = to_physical(*predicate, expr_arena, Some(input_schema.as_ref()))?;
             let op = operators::FilterOperator { predicate };
             Box::new(op) as Box<dyn Operator>
-        }
+        },
         MapFunction {
             function: FunctionNode::FastProjection { columns },
             input,
@@ -495,19 +495,19 @@ where
             let op =
                 operators::FastProjectionOperator::new(columns.clone(), input_schema.into_owned());
             Box::new(op) as Box<dyn Operator>
-        }
+        },
         MapFunction { function, .. } => {
             let op = operators::FunctionOperator::new(function.clone());
             Box::new(op) as Box<dyn Operator>
-        }
+        },
         Union { .. } => {
             let op = operators::Pass::new("union");
             Box::new(op) as Box<dyn Operator>
-        }
+        },
 
         lp => {
             panic!("operator {lp:?} not (yet) supported")
-        }
+        },
     };
     Ok(op)
 }
@@ -568,10 +568,10 @@ where
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;
                 Box::new(sources::UnionSource::new(sources)) as Box<dyn Source>
-            }
+            },
             lp => {
                 panic!("source {lp:?} not (yet) supported")
-            }
+            },
         };
         source_objects.push(src)
     }
@@ -593,7 +593,7 @@ where
                         let sink = get_sink(node, lp_arena, expr_arena, &to_physical)?;
                         entry.insert(sink.split(0));
                         sink
-                    }
+                    },
                     Entry::Occupied(entry) => entry.get().split(0),
                 }
             };

--- a/crates/polars-pipe/src/pipeline/dispatcher.rs
+++ b/crates/polars-pipe/src/pipeline/dispatcher.rs
@@ -247,8 +247,8 @@ impl PipeLine {
                         Ok(SinkResult::Finished) | Err(_) => {
                             let mut lock = sink_results.lock().unwrap();
                             *lock = Some(out)
-                        }
-                        _ => {}
+                        },
+                        _ => {},
                     }
                 })
             }
@@ -293,7 +293,7 @@ impl PipeLine {
                     if let SinkResult::Finished = sink.sink(ec, chunk)? {
                         return Ok(SinkResult::Finished);
                     }
-                }
+                },
                 Some(op) => {
                     match op.execute(ec, &chunk)? {
                         OperatorResult::Finished(chunk) => in_process.push((op_i + 1, chunk)),
@@ -307,12 +307,12 @@ impl PipeLine {
                             // or sink into a slice so that we get sink::finished
                             // before we grow the stack with ever more coming chunks
                             in_process.push((op_i + 1, output_chunk));
-                        }
+                        },
                         OperatorResult::NeedsNewData => {
                             // done, take another chunk from the stack
-                        }
+                        },
                     }
-                }
+                },
             }
         }
         Ok(SinkResult::CanHaveMoreInput)
@@ -404,7 +404,7 @@ impl PipeLine {
                     // should not happen
                     FinalizedSink::Operator(_) => {
                         unreachable!()
-                    }
+                    },
                 }
             } else {
                 out = Some((shared_sink_count, reduced_sink))
@@ -446,7 +446,7 @@ impl PipeLine {
                     let mut pipeline = self.other_branches.borrow_mut().pop_front().unwrap();
                     sink_out = pipeline.run_pipeline(&ec, self.other_branches.clone())?;
                     sink_nodes = std::mem::take(&mut pipeline.sink_nodes);
-                }
+                },
                 Some(FinalizedSink::Finished(df)) => return Ok(std::mem::take(df)),
                 Some(FinalizedSink::Source(src)) => return consume_source(&mut **src, &ec),
 
@@ -474,7 +474,7 @@ impl PipeLine {
                     }
                     sink_out = pipeline.run_pipeline(&ec, self.other_branches.clone())?;
                     sink_nodes = std::mem::take(&mut pipeline.sink_nodes);
-                }
+                },
             }
         }
     }

--- a/crates/polars-plan/src/dot.rs
+++ b/crates/polars-plan/src/dot.rs
@@ -57,7 +57,7 @@ impl Expr {
                     branch += 1;
                 }
                 Ok(())
-            }
+            },
             _ => self.write_dot(acc_str, prev_node, &format!("{branch}{id}"), id),
         }
     }
@@ -157,7 +157,7 @@ impl LogicalPlan {
                     branch += 1;
                 }
                 Ok(())
-            }
+            },
             Cache {
                 input,
                 id: cache_id,
@@ -176,7 +176,7 @@ impl LogicalPlan {
                 // here we take the cache id, to ensure the same cached subplans get the same ids
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input.dot(acc_str, (*cache_id, cache_id + 1), current_node, id_map)
-            }
+            },
             Selection { predicate, input } => {
                 let pred = fmt_predicate(Some(predicate));
                 let fmt = format!("FILTER BY {pred}");
@@ -189,7 +189,7 @@ impl LogicalPlan {
 
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input.dot(acc_str, (branch, id + 1), current_node, id_map)
-            }
+            },
             #[cfg(feature = "python")]
             PythonScan { options } => self.write_scan(
                 acc_str,
@@ -218,7 +218,7 @@ impl LogicalPlan {
                 };
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input.dot(acc_str, (branch, id + 1), current_node, id_map)
-            }
+            },
             Sort {
                 input, by_column, ..
             } => {
@@ -230,7 +230,7 @@ impl LogicalPlan {
                 };
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input.dot(acc_str, (branch, id + 1), current_node, id_map)
-            }
+            },
             LocalProjection { expr, input, .. } => {
                 let schema = input.schema().map_err(|_| {
                     eprintln!("could not determine schema");
@@ -245,7 +245,7 @@ impl LogicalPlan {
                 };
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input.dot(acc_str, (branch, id + 1), current_node, id_map)
-            }
+            },
             Aggregate {
                 input, keys, aggs, ..
             } => {
@@ -264,7 +264,7 @@ impl LogicalPlan {
                 };
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input.dot(acc_str, (branch, id + 1), current_node, id_map)
-            }
+            },
             HStack { input, exprs, .. } => {
                 let mut fmt = String::with_capacity(128);
                 fmt.push_str("WITH COLUMNS [");
@@ -286,7 +286,7 @@ impl LogicalPlan {
                 };
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input.dot(acc_str, (branch, id + 1), current_node, id_map)
-            }
+            },
             Slice { input, offset, len } => {
                 let fmt = format!("SLICE offset: {offset}; len: {len}");
                 let current_node = DotNode {
@@ -296,7 +296,7 @@ impl LogicalPlan {
                 };
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input.dot(acc_str, (branch, id + 1), current_node, id_map)
-            }
+            },
             Distinct { input, options, .. } => {
                 let mut fmt = String::with_capacity(128);
                 fmt.push_str("DISTINCT");
@@ -314,7 +314,7 @@ impl LogicalPlan {
 
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input.dot(acc_str, (branch, id + 1), current_node, id_map)
-            }
+            },
             DataFrameScan {
                 schema,
                 projection,
@@ -339,7 +339,7 @@ impl LogicalPlan {
                 } else {
                     self.write_dot(acc_str, prev_node, current_node, id_map)
                 }
-            }
+            },
             Scan {
                 path,
                 file_info,
@@ -361,7 +361,7 @@ impl LogicalPlan {
                     id,
                     id_map,
                 )
-            }
+            },
             Join {
                 input_left,
                 input_right,
@@ -384,7 +384,7 @@ impl LogicalPlan {
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input_left.dot(acc_str, (branch + 100, id + 1), current_node, id_map)?;
                 input_right.dot(acc_str, (branch + 200, id + 1), current_node, id_map)
-            }
+            },
             MapFunction {
                 input, function, ..
             } => {
@@ -396,7 +396,7 @@ impl LogicalPlan {
                 };
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input.dot(acc_str, (branch, id + 1), current_node, id_map)
-            }
+            },
             ExtContext { input, .. } => {
                 let current_node = DotNode {
                     branch,
@@ -405,7 +405,7 @@ impl LogicalPlan {
                 };
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input.dot(acc_str, (branch, id + 1), current_node, id_map)
-            }
+            },
             FileSink { input, .. } => {
                 let current_node = DotNode {
                     branch,
@@ -414,7 +414,7 @@ impl LogicalPlan {
                 };
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;
                 input.dot(acc_str, (branch, id + 1), current_node, id_map)
-            }
+            },
             Error { err, .. } => {
                 let fmt = format!("{:?}", &**err);
                 let current_node = DotNode {
@@ -423,7 +423,7 @@ impl LogicalPlan {
                     fmt: &fmt,
                 };
                 self.write_dot(acc_str, prev_node, current_node, id_map)
-            }
+            },
         }
     }
 

--- a/crates/polars-plan/src/dsl/dt.rs
+++ b/crates/polars-plan/src/dsl/dt.rs
@@ -32,12 +32,12 @@ impl DateLikeNameSpace {
                 DataType::Datetime(_, _) => {
                     let ca = s.datetime().unwrap();
                     Ok(Some(ca.cast_time_unit(tu).into_series()))
-                }
+                },
                 #[cfg(feature = "dtype-duration")]
                 DataType::Duration(_) => {
                     let ca = s.duration().unwrap();
                     Ok(Some(ca.cast_time_unit(tu).into_series()))
-                }
+                },
                 dt => polars_bail!(ComputeError: "dtype `{}` has no time unit", dt),
             },
             GetOutput::map_dtype(move |dtype| match dtype {
@@ -56,13 +56,13 @@ impl DateLikeNameSpace {
                     let mut ca = s.datetime().unwrap().clone();
                     ca.set_time_unit(tu);
                     Ok(Some(ca.into_series()))
-                }
+                },
                 #[cfg(feature = "dtype-duration")]
                 DataType::Duration(_) => {
                     let mut ca = s.duration().unwrap().clone();
                     ca.set_time_unit(tu);
                     Ok(Some(ca.into_series()))
-                }
+                },
                 dt => polars_bail!(ComputeError: "dtype `{}` has no time unit", dt),
             },
             GetOutput::same_type(),
@@ -79,7 +79,7 @@ impl DateLikeNameSpace {
                     let mut ca = s.datetime().unwrap().clone();
                     ca.set_time_zone(time_zone.clone())?;
                     Ok(Some(ca.into_series()))
-                }
+                },
                 _ => polars_bail!(
                     ComputeError:
                     "cannot call `convert_time_zone` on tz-naive; set a time zone first \

--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -178,12 +178,12 @@ impl Hash for Expr {
             Expr::Filter { input, by } => {
                 input.hash(state);
                 by.hash(state);
-            }
+            },
             Expr::BinaryExpr { left, op, right } => {
                 left.hash(state);
                 right.hash(state);
                 std::mem::discriminant(op).hash(state)
-            }
+            },
             Expr::Cast {
                 expr,
                 data_type,
@@ -192,15 +192,15 @@ impl Hash for Expr {
                 expr.hash(state);
                 data_type.hash(state);
                 strict.hash(state)
-            }
+            },
             Expr::Sort { expr, options } => {
                 expr.hash(state);
                 options.hash(state);
-            }
+            },
             Expr::Alias(input, name) => {
                 input.hash(state);
                 name.hash(state)
-            }
+            },
             Expr::KeepName(input) => input.hash(state),
             Expr::Ternary {
                 predicate,
@@ -210,7 +210,7 @@ impl Hash for Expr {
                 predicate.hash(state);
                 truthy.hash(state);
                 falsy.hash(state);
-            }
+            },
             Expr::Function {
                 input,
                 function,
@@ -219,9 +219,9 @@ impl Hash for Expr {
                 input.hash(state);
                 std::mem::discriminant(function).hash(state);
                 options.hash(state);
-            }
+            },
             // already hashed by discriminant
-            Expr::Wildcard | Expr::Count => {}
+            Expr::Wildcard | Expr::Count => {},
             #[allow(unreachable_code)]
             _ => {
                 // the panic checks if we hit this
@@ -235,7 +235,7 @@ impl Hash for Expr {
                 // to check if we can cache a file
                 let s = format!("{self:?}");
                 s.hash(state)
-            }
+            },
         }
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/correlation.rs
+++ b/crates/polars-plan/src/dsl/function_expr/correlation.rs
@@ -31,7 +31,7 @@ pub(super) fn corr(s: &[Series], ddof: u8, method: CorrelationMethod) -> PolarsR
         #[cfg(all(feature = "rank", feature = "propagate_nans"))]
         CorrelationMethod::SpearmanRank(propagate_nans) => {
             spearman_rank_corr(s, ddof, propagate_nans)
-        }
+        },
         CorrelationMethod::Covariance => covariance(s),
     }
 }
@@ -46,39 +46,39 @@ fn covariance(s: &[Series]) -> PolarsResult<Series> {
             let ca_a = a.f32().unwrap();
             let ca_b = b.f32().unwrap();
             Series::new(name, &[polars_core::functions::cov_f(ca_a, ca_b)])
-        }
+        },
         DataType::Float64 => {
             let ca_a = a.f64().unwrap();
             let ca_b = b.f64().unwrap();
             Series::new(name, &[polars_core::functions::cov_f(ca_a, ca_b)])
-        }
+        },
         DataType::Int32 => {
             let ca_a = a.i32().unwrap();
             let ca_b = b.i32().unwrap();
             Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
-        }
+        },
         DataType::Int64 => {
             let ca_a = a.i64().unwrap();
             let ca_b = b.i64().unwrap();
             Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
-        }
+        },
         DataType::UInt32 => {
             let ca_a = a.u32().unwrap();
             let ca_b = b.u32().unwrap();
             Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
-        }
+        },
         DataType::UInt64 => {
             let ca_a = a.u64().unwrap();
             let ca_b = b.u64().unwrap();
             Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
-        }
+        },
         _ => {
             let a = a.cast(&DataType::Float64)?;
             let b = b.cast(&DataType::Float64)?;
             let ca_a = a.f64().unwrap();
             let ca_b = b.f64().unwrap();
             Series::new(name, &[polars_core::functions::cov_f(ca_a, ca_b)])
-        }
+        },
     };
     Ok(s)
 }
@@ -96,7 +96,7 @@ fn pearson_corr(s: &[Series], ddof: u8) -> PolarsResult<Series> {
                 name,
                 &[polars_core::functions::pearson_corr_f(ca_a, ca_b, ddof)],
             )
-        }
+        },
         DataType::Float64 => {
             let ca_a = a.f64().unwrap();
             let ca_b = b.f64().unwrap();
@@ -104,7 +104,7 @@ fn pearson_corr(s: &[Series], ddof: u8) -> PolarsResult<Series> {
                 name,
                 &[polars_core::functions::pearson_corr_f(ca_a, ca_b, ddof)],
             )
-        }
+        },
         DataType::Int32 => {
             let ca_a = a.i32().unwrap();
             let ca_b = b.i32().unwrap();
@@ -112,7 +112,7 @@ fn pearson_corr(s: &[Series], ddof: u8) -> PolarsResult<Series> {
                 name,
                 &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
             )
-        }
+        },
         DataType::Int64 => {
             let ca_a = a.i64().unwrap();
             let ca_b = b.i64().unwrap();
@@ -120,7 +120,7 @@ fn pearson_corr(s: &[Series], ddof: u8) -> PolarsResult<Series> {
                 name,
                 &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
             )
-        }
+        },
         DataType::UInt32 => {
             let ca_a = a.u32().unwrap();
             let ca_b = b.u32().unwrap();
@@ -128,7 +128,7 @@ fn pearson_corr(s: &[Series], ddof: u8) -> PolarsResult<Series> {
                 name,
                 &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
             )
-        }
+        },
         DataType::UInt64 => {
             let ca_a = a.u64().unwrap();
             let ca_b = b.u64().unwrap();
@@ -136,7 +136,7 @@ fn pearson_corr(s: &[Series], ddof: u8) -> PolarsResult<Series> {
                 name,
                 &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
             )
-        }
+        },
         _ => {
             let a = a.cast(&DataType::Float64)?;
             let b = b.cast(&DataType::Float64)?;
@@ -146,7 +146,7 @@ fn pearson_corr(s: &[Series], ddof: u8) -> PolarsResult<Series> {
                 name,
                 &[polars_core::functions::pearson_corr_f(ca_a, ca_b, ddof)],
             )
-        }
+        },
     };
     Ok(s)
 }

--- a/crates/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/crates/polars-plan/src/dsl/function_expr/datetime.rs
@@ -150,7 +150,7 @@ pub(super) fn time(s: &Series) -> PolarsResult<Series> {
         DataType::Datetime(_, Some(_)) => {
             polars_ops::prelude::replace_time_zone(s.datetime().unwrap(), None, None)?
                 .cast(&DataType::Time)
-        }
+        },
         DataType::Datetime(_, _) => s.datetime().unwrap().cast(&DataType::Time),
         DataType::Date => s.datetime().unwrap().cast(&DataType::Time),
         DataType::Time => Ok(s.clone()),
@@ -170,7 +170,7 @@ pub(super) fn date(s: &Series) -> PolarsResult<Series> {
                 out.set_sorted_flag(IsSorted::Not);
             }
             Ok(out)
-        }
+        },
         DataType::Datetime(_, _) => s.datetime().unwrap().cast(&DataType::Date),
         DataType::Date => Ok(s.clone()),
         dtype => polars_bail!(ComputeError: "expected Datetime or Date, got {}", dtype),
@@ -189,7 +189,7 @@ pub(super) fn datetime(s: &Series) -> PolarsResult<Series> {
                 out.set_sorted_flag(IsSorted::Not);
             }
             Ok(out)
-        }
+        },
         DataType::Datetime(tu, _) => s.datetime().unwrap().cast(&DataType::Datetime(*tu, None)),
         dtype => polars_bail!(ComputeError: "expected Datetime, got {}", dtype),
     }
@@ -276,7 +276,7 @@ pub(super) fn base_utc_offset(s: &Series) -> PolarsResult<Series> {
                 .parse::<Tz>()
                 .expect("Time zone has already been validated");
             Ok(base_utc_offset_fn(s.datetime().unwrap(), time_unit, &tz).into_series())
-        }
+        },
         dt => polars_bail!(
             opq = base_utc_offset,
             got = dt,
@@ -292,7 +292,7 @@ pub(super) fn dst_offset(s: &Series) -> PolarsResult<Series> {
                 .parse::<Tz>()
                 .expect("Time zone has already been validated");
             Ok(dst_offset_fn(s.datetime().unwrap(), time_unit, &tz).into_series())
-        }
+        },
         dt => polars_bail!(
             opq = dst_offset,
             got = dt,

--- a/crates/polars-plan/src/dsl/function_expr/fill_null.rs
+++ b/crates/polars-plan/src/dsl/function_expr/fill_null.rs
@@ -50,7 +50,7 @@ pub(super) fn fill_null(s: &[Series], super_type: &DataType) -> PolarsResult<Ser
                 }
             }
             default(series, fill_value)
-        }
+        },
         _ => default(series, fill_value),
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -86,7 +86,7 @@ pub(super) fn slice(args: &mut [Series]) -> PolarsResult<Option<Series>> {
                 .extract::<usize>()
                 .unwrap_or(usize::MAX);
             return Ok(Some(list_ca.lst_slice(offset, slice_len).into_series()));
-        }
+        },
         (1, length_slice_len) => {
             check_slice_arg_shape(length_slice_len, list_ca.len(), "length")?;
             let offset = offset_s.get(0).unwrap().try_extract::<i64>()?;
@@ -103,7 +103,7 @@ pub(super) fn slice(args: &mut [Series]) -> PolarsResult<Option<Series>> {
                     _ => None,
                 })
                 .collect_trusted()
-        }
+        },
         (offset_len, 1) => {
             check_slice_arg_shape(offset_len, list_ca.len(), "offset")?;
             let length_slice = length_s
@@ -121,7 +121,7 @@ pub(super) fn slice(args: &mut [Series]) -> PolarsResult<Option<Series>> {
                     _ => None,
                 })
                 .collect_trusted()
-        }
+        },
         _ => {
             check_slice_arg_shape(offset_s.len(), list_ca.len(), "offset")?;
             check_slice_arg_shape(length_s.len(), list_ca.len(), "length")?;
@@ -140,12 +140,12 @@ pub(super) fn slice(args: &mut [Series]) -> PolarsResult<Option<Series>> {
                     |((opt_s, opt_offset), opt_length)| match (opt_s, opt_offset, opt_length) {
                         (Some(s), Some(offset), Some(length)) => {
                             Some(s.as_ref().slice(offset, length as usize))
-                        }
+                        },
                         _ => None,
                     },
                 )
                 .collect_trusted()
-        }
+        },
     };
     out.rename(s.name());
     Ok(Some(out.into_series()))
@@ -160,7 +160,7 @@ pub(super) fn concat(s: &mut [Series]) -> PolarsResult<Option<Series>> {
         None => {
             first = first.reshape(&[-1, 1]).unwrap();
             first.list().unwrap()
-        }
+        },
     }
     .clone();
 
@@ -187,7 +187,7 @@ pub(super) fn get(s: &mut [Series]) -> PolarsResult<Option<Series>> {
             } else {
                 polars_bail!(ComputeError: "unexpected null index received in `arr.get`")
             }
-        }
+        },
         len if len == ca.len() => {
             let ca = ca.rechunk();
             let arr = ca.downcast_iter().next().unwrap();
@@ -211,7 +211,7 @@ pub(super) fn get(s: &mut [Series]) -> PolarsResult<Option<Series>> {
                 .collect::<IdxCa>();
             let s = Series::try_from((ca.name(), arr.values().clone())).unwrap();
             unsafe { s.take_unchecked(&take_by) }.map(Some)
-        }
+        },
         len => polars_bail!(
             ComputeError:
             "`arr.get` expression got an index array of length {} while the list has {} elements",

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -259,7 +259,7 @@ impl Hash for FunctionExpr {
             FunctionExpr::Interpolate(f) => f.hash(state),
             #[cfg(feature = "dtype-categorical")]
             FunctionExpr::Categorical(f) => f.hash(state),
-            _ => {}
+            _ => {},
         }
     }
 }
@@ -343,7 +343,7 @@ impl Display for FunctionExpr {
                 } else {
                     "unique"
                 }
-            }
+            },
             #[cfg(feature = "round_series")]
             Round { .. } => "round",
             #[cfg(feature = "round_series")]
@@ -460,7 +460,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                     Ok(Some(Series::new(s.name(), [s.null_count() as IdxSize])))
                 };
                 wrap!(f)
-            }
+            },
             Pow(func) => match func {
                 PowFunction::Generic => wrap!(pow::pow),
                 PowFunction::Sqrt => map!(pow::sqrt),
@@ -469,15 +469,15 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "row_hash")]
             Hash(k0, k1, k2, k3) => {
                 map!(row_hash::row_hash, k0, k1, k2, k3)
-            }
+            },
             #[cfg(feature = "arg_where")]
             ArgWhere => {
                 wrap!(arg_where::arg_where)
-            }
+            },
             #[cfg(feature = "search_sorted")]
             SearchSorted(side) => {
                 map_as_slice!(search_sorted::search_sorted_impl, side)
-            }
+            },
             #[cfg(feature = "strings")]
             StringExpr(s) => s.into(),
             BinaryExpr(s) => s.into(),
@@ -489,37 +489,37 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "date_offset")]
             DateOffset(offset) => {
                 map_owned!(temporal::date_offset, offset)
-            }
+            },
 
             #[cfg(feature = "trigonometry")]
             Trigonometry(trig_function) => {
                 map!(trigonometry::apply_trigonometric_function, trig_function)
-            }
+            },
             #[cfg(feature = "trigonometry")]
             Atan2 => {
                 wrap!(trigonometry::apply_arctan2)
-            }
+            },
 
             #[cfg(feature = "sign")]
             Sign => {
                 map!(sign::sign)
-            }
+            },
             FillNull { super_type } => {
                 map_as_slice!(fill_null::fill_null, &super_type)
-            }
+            },
 
             #[cfg(all(feature = "rolling_window", feature = "moment"))]
             RollingSkew { window_size, bias } => {
                 map!(rolling::rolling_skew, window_size, bias)
-            }
+            },
             ShiftAndFill { periods } => {
                 map_as_slice!(shift_and_fill::shift_and_fill, periods)
-            }
+            },
             DropNans => map_owned!(nan::drop_nans),
             #[cfg(feature = "round_series")]
             Clip { min, max } => {
                 map_owned!(clip::clip, min.clone(), max.clone())
-            }
+            },
             ListExpr(lf) => {
                 use ListFunction::*;
                 match lf {
@@ -540,7 +540,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                     #[cfg(feature = "list_any_all")]
                     All => map!(list::lst_all),
                 }
-            }
+            },
             #[cfg(feature = "dtype-array")]
             ArrayExpr(lf) => {
                 use ArrayFunction::*;
@@ -550,7 +550,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                     Sum => map!(array::sum),
                     Unique(stable) => map!(array::unique, stable),
                 }
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             StructExpr(sf) => {
                 use StructFunction::*;
@@ -558,11 +558,11 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                     FieldByIndex(index) => map!(struct_::get_by_index, index),
                     FieldByName(name) => map!(struct_::get_by_name, name.clone()),
                 }
-            }
+            },
             #[cfg(feature = "top_k")]
             TopK { k, descending } => {
                 map!(top_k, k, descending)
-            }
+            },
             Shift(periods) => map!(dispatch::shift, periods),
             Cumcount { reverse } => map!(cum::cumcount, reverse),
             Cumsum { reverse } => map!(cum::cumsum, reverse),
@@ -582,7 +582,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "interpolate")]
             Interpolate(method) => {
                 map!(dispatch::interpolate, method)
-            }
+            },
             #[cfg(feature = "log")]
             Entropy { base, normalize } => map!(log::entropy, base, normalize),
             #[cfg(feature = "log")]
@@ -664,37 +664,37 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             Contains { literal, strict } => map_as_slice!(strings::contains, literal, strict),
             CountMatch(pat) => {
                 map!(strings::count_match, &pat)
-            }
+            },
             EndsWith { .. } => map_as_slice!(strings::ends_with),
             StartsWith { .. } => map_as_slice!(strings::starts_with),
             Extract { pat, group_index } => {
                 map!(strings::extract, &pat, group_index)
-            }
+            },
             ExtractAll => {
                 map_as_slice!(strings::extract_all)
-            }
+            },
             #[cfg(feature = "extract_groups")]
             ExtractGroups { pat, dtype } => {
                 map!(strings::extract_groups, &pat, &dtype)
-            }
+            },
             NChars => map!(strings::n_chars),
             Length => map!(strings::lengths),
             #[cfg(feature = "string_justify")]
             Zfill(alignment) => {
                 map!(strings::zfill, alignment)
-            }
+            },
             #[cfg(feature = "string_justify")]
             LJust { width, fillchar } => {
                 map!(strings::ljust, width, fillchar)
-            }
+            },
             #[cfg(feature = "string_justify")]
             RJust { width, fillchar } => {
                 map!(strings::rjust, width, fillchar)
-            }
+            },
             #[cfg(feature = "temporal")]
             Strptime(dtype, options) => {
                 map!(strings::strptime, dtype.clone(), &options)
-            }
+            },
             #[cfg(feature = "concat_str")]
             ConcatVertical(delimiter) => map!(strings::concat, &delimiter),
             #[cfg(feature = "concat_str")]
@@ -729,13 +729,13 @@ impl From<BinaryFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
         match func {
             Contains { pat, literal } => {
                 map!(binary::contains, &pat, literal)
-            }
+            },
             EndsWith(sub) => {
                 map!(binary::ends_with, &sub)
-            }
+            },
             StartsWith(sub) => {
                 map!(binary::starts_with, &sub)
-            }
+            },
         }
     }
 }
@@ -766,7 +766,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             TimeStamp(tu) => map!(datetime::timestamp, tu),
             Truncate(truncate_options) => {
                 map!(datetime::truncate, &truncate_options)
-            }
+            },
             #[cfg(feature = "date_offset")]
             MonthStart => map!(datetime::month_start),
             #[cfg(feature = "date_offset")]
@@ -779,7 +779,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "timezones")]
             ReplaceTimeZone(tz, use_earliest) => {
                 map!(dispatch::replace_time_zone, tz.as_deref(), use_earliest)
-            }
+            },
             Combine(tu) => map_as_slice!(temporal::combine, tu),
             DateRange {
                 every,
@@ -795,7 +795,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
                     time_unit,
                     time_zone.clone()
                 )
-            }
+            },
             DateRanges {
                 every,
                 closed,
@@ -810,7 +810,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
                     time_unit,
                     time_zone.clone()
                 )
-            }
+            },
             TimeRange { every, closed } => {
                 map_as_slice!(
                     temporal::temporal_range_dispatch,
@@ -820,7 +820,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
                     None,
                     None
                 )
-            }
+            },
             TimeRanges { every, closed } => {
                 map_as_slice!(
                     temporal::temporal_range_dispatch,
@@ -830,7 +830,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
                     None,
                     None
                 )
-            }
+            },
             DatetimeFunction {
                 time_unit,
                 time_zone,
@@ -842,7 +842,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
                     time_zone.as_deref(),
                     use_earliest
                 )
-            }
+            },
         }
     }
 }
@@ -854,13 +854,13 @@ impl From<RangeFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
         match func {
             ARange { step } => {
                 map_as_slice!(range::arange, step)
-            }
+            },
             IntRange { step } => {
                 map_as_slice!(range::int_range, step)
-            }
+            },
             IntRanges { step } => {
                 map_as_slice!(range::int_ranges, step)
-            }
+            },
         }
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/nan.rs
+++ b/crates/polars-plan/src/dsl/function_expr/nan.rs
@@ -6,12 +6,12 @@ pub(super) fn drop_nans(s: Series) -> PolarsResult<Series> {
             let ca = s.f32()?;
             let mask = ca.is_not_nan();
             ca.filter(&mask).map(|ca| ca.into_series())
-        }
+        },
         DataType::Float64 => {
             let ca = s.f64()?;
             let mask = ca.is_not_nan();
             ca.filter(&mask).map(|ca| ca.into_series())
-        }
+        },
         _ => Ok(s),
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/pow.rs
+++ b/crates/polars-plan/src/dsl/function_expr/pow.rs
@@ -50,7 +50,7 @@ where
                     out = out * base.clone()
                 }
                 out.into_series()
-            }
+            },
             _ => base.apply(|v| Pow::pow(v, exponent_value)).into_series(),
         };
         Ok(Some(s))
@@ -82,15 +82,15 @@ fn pow_on_series(base: &Series, exponent: &Series) -> PolarsResult<Option<Series
         Float32 => {
             let ca = base.f32().unwrap();
             pow_on_floats(ca, exponent)
-        }
+        },
         Float64 => {
             let ca = base.f64().unwrap();
             pow_on_floats(ca, exponent)
-        }
+        },
         _ => {
             let base = base.cast(&DataType::Float64)?;
             pow_on_series(&base, exponent)
-        }
+        },
     }
 }
 
@@ -117,15 +117,15 @@ pub(super) fn sqrt(base: &Series) -> PolarsResult<Series> {
         Float32 => {
             let ca = base.f32().unwrap();
             sqrt_on_floats(ca)
-        }
+        },
         Float64 => {
             let ca = base.f64().unwrap();
             sqrt_on_floats(ca)
-        }
+        },
         _ => {
             let base = base.cast(&DataType::Float64)?;
             sqrt(&base)
-        }
+        },
     }
 }
 
@@ -144,15 +144,15 @@ pub(super) fn cbrt(base: &Series) -> PolarsResult<Series> {
         Float32 => {
             let ca = base.f32().unwrap();
             cbrt_on_floats(ca)
-        }
+        },
         Float64 => {
             let ca = base.f64().unwrap();
             cbrt_on_floats(ca)
-        }
+        },
         _ => {
             let base = base.cast(&DataType::Float64)?;
             cbrt(&base)
-        }
+        },
     }
 }
 

--- a/crates/polars-plan/src/dsl/function_expr/range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range.rs
@@ -38,7 +38,7 @@ where
                 name,
                 (end..=start).rev().step_by(step.unsigned_abs() as usize),
             )
-        }
+        },
     };
 
     let is_sorted = if end < start {
@@ -86,7 +86,7 @@ pub(super) fn int_range(s: &[Series], step: i64) -> PolarsResult<Series> {
                 .ok_or_else(|| polars_err!(NoData: "no data in `end` evaluation"))?;
 
             int_range_impl::<IdxType>(start, end, step)
-        }
+        },
         _ => {
             let start = start.cast(&DataType::Int64)?;
             let end = end.cast(&DataType::Int64)?;
@@ -99,7 +99,7 @@ pub(super) fn int_range(s: &[Series], step: i64) -> PolarsResult<Series> {
                 .get(0)
                 .ok_or_else(|| polars_err!(NoData: "no data in `end` evaluation"))?;
             int_range_impl::<Int64Type>(start, end, step)
-        }
+        },
     }
 }
 
@@ -140,15 +140,15 @@ pub(super) fn int_ranges(s: &[Series], step: i64) -> PolarsResult<Series> {
             match step {
                 1 => {
                     values_capacity += (end_v - start_v) as usize;
-                }
+                },
                 2.. => {
                     values_capacity += ((end_v - start_v) as usize / step as usize) + 1;
-                }
+                },
                 _ => {
                     polars_ensure!(start_v > end_v, InvalidOperation: "range must be decreasing if 'step' is negative");
                     values_capacity +=
                         ((end_v - start_v) as usize / step.unsigned_abs() as usize) + 1;
-                }
+                },
             }
         }
     }
@@ -165,10 +165,10 @@ pub(super) fn int_ranges(s: &[Series], step: i64) -> PolarsResult<Series> {
             (Some(&start_v), Some(&end_v)) => match step {
                 1 => {
                     builder.append_iter_values(start_v..end_v);
-                }
+                },
                 2.. => {
                     builder.append_iter_values((start_v..end_v).step_by(step as usize));
-                }
+                },
                 _ => builder.append_iter_values(
                     (end_v..=start_v)
                         .rev()

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -29,9 +29,9 @@ impl FunctionExpr {
                 match s {
                     Contains { .. } | EndsWith(_) | StartsWith(_) => {
                         mapper.with_dtype(DataType::Boolean)
-                    }
+                    },
                 }
-            }
+            },
             #[cfg(feature = "temporal")]
             TemporalExpr(fun) => {
                 use TemporalFunction::*;
@@ -60,7 +60,7 @@ impl FunctionExpr {
                     #[cfg(feature = "timezones")]
                     ReplaceTimeZone(tz, _use_earliest) => {
                         return mapper.map_datetime_dtype_timezone(tz.as_ref())
-                    }
+                    },
                     DateRange {
                         every,
                         closed: _,
@@ -71,7 +71,7 @@ impl FunctionExpr {
                         let inner_dtype =
                             mapper.map_to_date_range_dtype(every, time_unit, time_zone)?;
                         return Ok(Field::new("date", DataType::List(Box::new(inner_dtype))));
-                    }
+                    },
                     DateRanges {
                         every,
                         closed: _,
@@ -85,17 +85,17 @@ impl FunctionExpr {
                             "date_range",
                             DataType::List(Box::new(inner_dtype)),
                         ));
-                    }
+                    },
 
                     TimeRange { .. } => {
                         return Ok(Field::new("time", DataType::List(Box::new(DataType::Time))));
-                    }
+                    },
                     TimeRanges { .. } => {
                         return Ok(Field::new(
                             "time_range",
                             DataType::List(Box::new(DataType::Time)),
                         ));
-                    }
+                    },
                     DatetimeFunction {
                         time_unit,
                         time_zone,
@@ -105,17 +105,17 @@ impl FunctionExpr {
                             "datetime",
                             DataType::Datetime(*time_unit, time_zone.clone()),
                         ));
-                    }
+                    },
                     Combine(tu) => match mapper.with_same_dtype().unwrap().dtype {
                         DataType::Datetime(_, tz) => DataType::Datetime(*tu, tz),
                         DataType::Date => DataType::Datetime(*tu, None),
                         dtype => {
                             polars_bail!(ComputeError: "expected Date or Datetime, got {}", dtype)
-                        }
+                        },
                     },
                 };
                 mapper.with_dtype(dtype)
-            }
+            },
 
             #[cfg(feature = "range")]
             Range(fun) => {
@@ -125,10 +125,10 @@ impl FunctionExpr {
                     IntRange { .. } => Field::new("int", DataType::Int64),
                     IntRanges { .. } => {
                         Field::new("int_range", DataType::List(Box::new(DataType::Int64)))
-                    }
+                    },
                 };
                 Ok(field)
-            }
+            },
             #[cfg(feature = "date_offset")]
             DateOffset(_) => mapper.with_same_dtype(),
             #[cfg(feature = "trigonometry")]
@@ -164,7 +164,7 @@ impl FunctionExpr {
                     #[cfg(feature = "list_any_all")]
                     All => mapper.with_dtype(DataType::Boolean),
                 }
-            }
+            },
             #[cfg(feature = "dtype-array")]
             ArrayExpr(af) => {
                 use ArrayFunction::*;
@@ -179,7 +179,7 @@ impl FunctionExpr {
                         }
                     }),
                 }
-            }
+            },
             #[cfg(feature = "dtype-struct")]
             StructExpr(s) => {
                 use polars_core::utils::slice_offsets;
@@ -196,7 +196,7 @@ impl FunctionExpr {
                                 ComputeError: "expected struct dtype, got: `{}`", &fields[0].dtype
                             )
                         }
-                    }
+                    },
                     FieldByName(name) => {
                         if let DataType::Struct(flds) = &fields[0].dtype {
                             let fld = flds
@@ -209,9 +209,9 @@ impl FunctionExpr {
                         } else {
                             polars_bail!(StructFieldNotFound: "{}", name.as_ref());
                         }
-                    }
+                    },
                 }
-            }
+            },
             #[cfg(feature = "top_k")]
             TopK { .. } => mapper.with_same_dtype(),
             Shift(..) | Reverse => mapper.with_same_dtype(),
@@ -262,7 +262,7 @@ impl FunctionExpr {
                         dt.clone()
                     }
                 })
-            }
+            },
             #[cfg(feature = "log")]
             Entropy { .. } | Log { .. } | Log1p | Exp => mapper.map_to_float_dtype(),
             Unique(_) => mapper.with_same_dtype(),
@@ -396,26 +396,26 @@ impl<'a> FieldsMapper<'a> {
                 } else {
                     DataType::Datetime(*tu, Some(tz.to_string()))
                 }
-            }
+            },
             #[cfg(feature = "timezones")]
             (DataType::Datetime(_, Some(tz)), Some(time_unit), _, _) => {
                 DataType::Datetime(*time_unit, Some(tz.to_string()))
-            }
+            },
             #[cfg(feature = "timezones")]
             (DataType::Datetime(tu, Some(tz)), None, _, _) => {
                 DataType::Datetime(*tu, Some(tz.to_string()))
-            }
+            },
             #[cfg(feature = "timezones")]
             (DataType::Datetime(_, _), Some(time_unit), Some(tz), _) => {
                 DataType::Datetime(*time_unit, Some(tz.to_string()))
-            }
+            },
             #[cfg(feature = "timezones")]
             (DataType::Datetime(tu, _), None, Some(tz), _) => {
                 DataType::Datetime(*tu, Some(tz.to_string()))
-            }
+            },
             (DataType::Datetime(_, _), Some(time_unit), _, _) => {
                 DataType::Datetime(*time_unit, None)
-            }
+            },
             (DataType::Datetime(tu, _), None, _, _) => DataType::Datetime(*tu, None),
             (DataType::Date, time_unit, time_zone, every) => {
                 let nsecs = every.nanoseconds();
@@ -428,10 +428,10 @@ impl<'a> FieldsMapper<'a> {
                 } else {
                     DataType::Datetime(TimeUnit::Microseconds, time_zone.clone())
                 }
-            }
+            },
             (dtype, _, _, _) => {
                 polars_bail!(ComputeError: "expected Date or Datetime, got {}", dtype)
-            }
+            },
         };
         Ok(inner_dtype)
     }
@@ -447,13 +447,13 @@ impl<'a> FieldsMapper<'a> {
                         None => super_type_inner = Some(*inner.clone()),
                         Some(st_inner) => {
                             super_type_inner = Some(try_get_supertype(&st_inner, inner)?)
-                        }
+                        },
                     },
                     dt => match super_type_inner {
                         None => super_type_inner = Some((*dt).clone()),
                         Some(st_inner) => {
                             super_type_inner = Some(try_get_supertype(&st_inner, dt)?)
-                        }
+                        },
                     },
                 }
             }

--- a/crates/polars-plan/src/dsl/function_expr/shift_and_fill.rs
+++ b/crates/polars-plan/src/dsl/function_expr/shift_and_fill.rs
@@ -63,7 +63,7 @@ pub(super) fn shift_and_fill(args: &mut [Series], periods: i64) -> PolarsResult<
             ca.shift_and_fill(periods, fill_value)
                 .into_series()
                 .cast(logical)
-        }
+        },
         Utf8 => {
             let ca = s.utf8().unwrap();
             let fill_value = match fill_value {
@@ -74,7 +74,7 @@ pub(super) fn shift_and_fill(args: &mut [Series], periods: i64) -> PolarsResult<
             ca.shift_and_fill(periods, fill_value)
                 .into_series()
                 .cast(logical)
-        }
+        },
         List(_) => {
             let ca = s.list().unwrap();
             let fill_value = match fill_value {
@@ -85,7 +85,7 @@ pub(super) fn shift_and_fill(args: &mut [Series], periods: i64) -> PolarsResult<
             ca.shift_and_fill(periods, fill_value.as_ref())
                 .into_series()
                 .cast(logical)
-        }
+        },
         #[cfg(feature = "object")]
         Object(_) => shift_and_fill_with_mask(s, periods, fill_value_s),
         #[cfg(feature = "dtype-struct")]
@@ -101,9 +101,9 @@ pub(super) fn shift_and_fill(args: &mut [Series], periods: i64) -> PolarsResult<
 
             let out = downcast_as_macro_arg_physical!(physical, dispatch, periods, fill_value);
             out.cast(logical)
-        }
+        },
         _ => {
             unimplemented!()
-        }
+        },
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/sign.rs
+++ b/crates/polars-plan/src/dsl/function_expr/sign.rs
@@ -8,15 +8,15 @@ pub(super) fn sign(s: &Series) -> PolarsResult<Series> {
         Float32 => {
             let ca = s.f32().unwrap();
             sign_float(ca)
-        }
+        },
         Float64 => {
             let ca = s.f64().unwrap();
             sign_float(ca)
-        }
+        },
         dt if dt.is_numeric() => {
             let s = s.cast(&Float64)?;
             sign(&s)
-        }
+        },
         dt => polars_bail!(opq = sign, dt),
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -113,7 +113,7 @@ impl StringFunction {
             ToDecimal(_) => mapper.with_dtype(DataType::Decimal(None, None)),
             Uppercase | Lowercase | Strip(_) | LStrip(_) | RStrip(_) | Slice(_, _) => {
                 mapper.with_same_dtype()
-            }
+            },
             #[cfg(feature = "string_justify")]
             Zfill { .. } | LJust { .. } | RJust { .. } => mapper.with_same_dtype(),
         }
@@ -208,7 +208,7 @@ pub(super) fn contains(s: &[Series], literal: bool, strict: bool) -> PolarsResul
                 } else {
                     ca.contains(pat, strict)?
                 }
-            }
+            },
             None => BooleanChunked::full(ca.name(), false, ca.len()),
         },
         _ => {
@@ -227,7 +227,7 @@ pub(super) fn contains(s: &[Series], literal: bool, strict: bool) -> PolarsResul
                         (Some(src), Some(pat)) => {
                             let re = Regex::new(pat)?;
                             Ok(re.is_match(src))
-                        }
+                        },
                         _ => Ok(false),
                     })
                     .collect::<PolarsResult<_>>()?
@@ -240,7 +240,7 @@ pub(super) fn contains(s: &[Series], literal: bool, strict: bool) -> PolarsResul
                     })
                     .collect_trusted()
             }
-        }
+        },
     };
 
     out.rename(ca.name());
@@ -414,7 +414,7 @@ pub(super) fn strptime(
         DataType::Date => to_date(s, options),
         DataType::Datetime(time_unit, time_zone) => {
             to_datetime(s, &time_unit, time_zone.as_ref(), options)
-        }
+        },
         DataType::Time => to_time(s, options),
         dt => polars_bail!(ComputeError: "not implemented for dtype {}", dt),
     }
@@ -611,9 +611,9 @@ fn replace_n<'a>(
                         polars_bail!(ComputeError: "regex replacement with 'n > 1' not yet supported")
                     }
                     ca.replace(pat, val)
-                }
+                },
             }
-        }
+        },
         (1, len_val) => {
             if n > 1 {
                 polars_bail!(ComputeError: "multivalue replacement with 'n > 1' not yet supported")
@@ -642,7 +642,7 @@ fn replace_n<'a>(
                 }
             };
             Ok(iter_and_replace(ca, val, f))
-        }
+        },
         _ => polars_bail!(
             ComputeError: "dynamic pattern length in 'str.replace' expressions is not supported yet"
         ),
@@ -668,7 +668,7 @@ fn replace_all<'a>(
                 true => ca.replace_literal_all(pat, val),
                 false => ca.replace_all(pat, val),
             }
-        }
+        },
         (1, len_val) => {
             let mut pat = get_pat(pat)?.to_string();
             polars_ensure!(
@@ -687,7 +687,7 @@ fn replace_all<'a>(
 
             let f = |s: &'a str, val: &'a str| reg.replace_all(s, val);
             Ok(iter_and_replace(ca, val, f))
-        }
+        },
         _ => polars_bail!(
             ComputeError: "dynamic pattern length in 'str.replace' expressions is not supported yet"
         ),

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -98,14 +98,14 @@ pub(super) fn datetime(
             let mut ca = ca.into_datetime(*time_unit, None);
             ca = replace_time_zone(&ca, time_zone, use_earliest)?;
             ca
-        }
+        },
         _ => {
             polars_ensure!(
                 time_zone.is_none() && use_earliest.is_none(),
                 ComputeError: "cannot make use of the `time_zone` and `use_earliest` arguments without the 'timezones' feature enabled."
             );
             ca.into_datetime(*time_unit, None)
-        }
+        },
     };
 
     let mut s = ca.into_series();
@@ -123,7 +123,7 @@ pub(super) fn date_offset(s: Series, offset: Duration) -> PolarsResult<Series> {
                 .unwrap();
             preserve_sortedness = true;
             date_offset(s, offset).and_then(|s| s.cast(&DataType::Date))
-        }
+        },
         DataType::Datetime(tu, tz) => {
             let ca = s.datetime().unwrap();
 
@@ -140,11 +140,11 @@ pub(super) fn date_offset(s: Series, offset: Duration) -> PolarsResult<Series> {
                 Some(ref tz) => {
                     let offset_fn = offset_fn(tu);
                     ca.0.try_apply(|v| offset_fn(&offset, v, tz.parse::<Tz>().ok().as_ref()))
-                }
+                },
                 _ => {
                     let offset_fn = offset_fn(tu);
                     ca.0.try_apply(|v| offset_fn(&offset, v, None))
-                }
+                },
             }?;
             // Sortedness may not be preserved when crossing daylight savings time boundaries
             // for calendar-aware durations.
@@ -152,7 +152,7 @@ pub(super) fn date_offset(s: Series, offset: Duration) -> PolarsResult<Series> {
             preserve_sortedness =
                 tz.is_none() || tz.as_deref() == Some("UTC") || offset.is_constant_duration();
             out.cast(&DataType::Datetime(tu, tz))
-        }
+        },
         dt => polars_bail!(
             ComputeError: "cannot use 'date_offset' on Series of datatype {}", dt,
         ),
@@ -176,7 +176,7 @@ pub(super) fn combine(s: &[Series], tu: TimeUnit) -> PolarsResult<Series> {
         DataType::Datetime(_, tz) => tz.as_ref(),
         _dtype => {
             polars_bail!(ComputeError: format!("expected Date or Datetime, got {}", _dtype))
-        }
+        },
     };
 
     let date = date.cast(&DataType::Date)?;
@@ -228,7 +228,7 @@ pub(super) fn temporal_range_dispatch(
             } else {
                 DataType::Datetime(TimeUnit::Microseconds, None)
             }
-        }
+        },
         (DataType::Time, _) => DataType::Time,
         // overwrite nothing, keep as-is
         (DataType::Datetime(_, _), None) => start.dtype().clone(),
@@ -278,8 +278,8 @@ pub(super) fn temporal_range_dispatch(
         #[cfg(feature = "timezones")]
         (DataType::Datetime(tu, _), Some(tz)) => {
             dtype = DataType::Datetime(*tu, Some(tz.clone()));
-        }
-        _ => {}
+        },
+        _ => {},
     };
 
     let start = start.i64().unwrap();
@@ -309,12 +309,12 @@ pub(super) fn temporal_range_dispatch(
                         let rng = rng.to_physical_repr();
                         let rng = rng.i32().unwrap();
                         builder.append_slice(rng.cont_slice().unwrap())
-                    }
+                    },
                     _ => builder.append_null(),
                 }
             }
             builder.finish().into_series()
-        }
+        },
         DataType::Datetime(tu, ref tz) => {
             let mut builder = ListPrimitiveChunkedBuilder::<Int64Type>::new(
                 name,
@@ -327,12 +327,12 @@ pub(super) fn temporal_range_dispatch(
                     (Some(start), Some(stop)) => {
                         let rng = date_range_impl("", start, stop, every, closed, tu, tz.as_ref())?;
                         builder.append_slice(rng.cont_slice().unwrap())
-                    }
+                    },
                     _ => builder.append_null(),
                 }
             }
             builder.finish().into_series()
-        }
+        },
         DataType::Time => {
             let mut builder = ListPrimitiveChunkedBuilder::<Int64Type>::new(
                 name,
@@ -353,12 +353,12 @@ pub(super) fn temporal_range_dispatch(
                             None,
                         )?;
                         builder.append_slice(rng.cont_slice().unwrap())
-                    }
+                    },
                     _ => builder.append_null(),
                 }
             }
             builder.finish().into_series()
-        }
+        },
         _ => unimplemented!(),
     };
 

--- a/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
+++ b/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
@@ -56,15 +56,15 @@ pub(super) fn apply_trigonometric_function(
         Float32 => {
             let ca = s.f32().unwrap();
             apply_trigonometric_function_to_float(ca, trig_function)
-        }
+        },
         Float64 => {
             let ca = s.f64().unwrap();
             apply_trigonometric_function_to_float(ca, trig_function)
-        }
+        },
         dt if dt.is_numeric() => {
             let s = s.cast(&Float64)?;
             apply_trigonometric_function(&s, trig_function)
-        }
+        },
         dt => polars_bail!(op = "trigonometry", dt),
     }
 }
@@ -93,15 +93,15 @@ fn arctan2_on_series(y: &Series, x: &Series) -> PolarsResult<Option<Series>> {
         Float32 => {
             let y_ca: &ChunkedArray<Float32Type> = y.f32().unwrap();
             arctan2_on_floats(y_ca, x)
-        }
+        },
         Float64 => {
             let y_ca: &ChunkedArray<Float64Type> = y.f64().unwrap();
             arctan2_on_floats(y_ca, x)
-        }
+        },
         _ => {
             let y = y.cast(&DataType::Float64)?;
             arctan2_on_series(&y, x)
-        }
+        },
     }
 }
 

--- a/crates/polars-plan/src/dsl/functions/horizontal.rs
+++ b/crates/polars-plan/src/dsl/functions/horizontal.rs
@@ -77,7 +77,7 @@ where
                     }
                 }
                 Ok(Some(acc))
-            }
+            },
             None => Err(polars_err!(ComputeError: "`reduce` did not have any expressions to fold")),
         }
     }) as Arc<dyn SeriesUdf>);
@@ -122,7 +122,7 @@ where
                 }
 
                 StructChunked::new(acc.name(), &result).map(|ca| Some(ca.into_series()))
-            }
+            },
             None => Err(polars_err!(ComputeError: "`reduce` did not have any expressions to fold")),
         }
     }) as Arc<dyn SeriesUdf>);

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -285,7 +285,7 @@ impl ListNameSpace {
 
                             *lock = Some(dt.clone());
                             dt
-                        }
+                        },
                     }
                 }),
             )

--- a/crates/polars-plan/src/dsl/meta.rs
+++ b/crates/polars-plan/src/dsl/meta.rs
@@ -51,7 +51,7 @@ impl MetaNameSpace {
 
                 // continue iteration
                 true
-            }
+            },
             // continue iteration
             _ => true,
         });

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -84,7 +84,7 @@ impl Expr {
                     output_type,
                     options,
                 }
-            }
+            },
             Self::Function {
                 input,
                 function,
@@ -96,10 +96,10 @@ impl Expr {
                     function,
                     options,
                 }
-            }
+            },
             _ => {
                 panic!("implementation error")
-            }
+            },
         }
     }
 

--- a/crates/polars-plan/src/dsl/python_udf.rs
+++ b/crates/polars-plan/src/dsl/python_udf.rs
@@ -195,7 +195,7 @@ impl SeriesUdf for PythonUdfExpression {
                 let mut fld = fld.clone();
                 fld.coerce(DataType::Unknown);
                 fld
-            }
+            },
         }))
     }
 }
@@ -215,7 +215,7 @@ impl Expr {
                 let mut fld = fld.clone();
                 fld.coerce(DataType::Unknown);
                 fld
-            }
+            },
         });
 
         Expr::AnonymousFunction {

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -169,7 +169,7 @@ impl StringNameSpace {
                 } else {
                     TimeUnit::Microseconds
                 }
-            }
+            },
             (None, None) => TimeUnit::Microseconds,
         };
 
@@ -222,7 +222,7 @@ impl StringNameSpace {
                 Some(s) => {
                     let iter = s.split(&by);
                     builder.append_values_iter(iter);
-                }
+                },
             });
             Ok(Some(builder.finish().into_series()))
         };
@@ -247,7 +247,7 @@ impl StringNameSpace {
                 Some(s) => {
                     let iter = s.split_inclusive(&by);
                     builder.append_values_iter(iter);
-                }
+                },
             });
             Ok(Some(builder.finish().into_series()))
         };
@@ -276,7 +276,7 @@ impl StringNameSpace {
                     for arr in &mut arrs {
                         arr.push_null()
                     }
-                }
+                },
                 Some(s) => {
                     let mut arr_iter = arrs.iter_mut();
                     let split_iter = s.split(&by);
@@ -287,7 +287,7 @@ impl StringNameSpace {
                     for arr in arr_iter {
                         arr.push_null()
                     }
-                }
+                },
             });
             let fields = arrs
                 .into_iter()
@@ -330,7 +330,7 @@ impl StringNameSpace {
                     for arr in &mut arrs {
                         arr.push_null()
                     }
-                }
+                },
                 Some(s) => {
                     let mut arr_iter = arrs.iter_mut();
                     let split_iter = s.split_inclusive(&by);
@@ -341,7 +341,7 @@ impl StringNameSpace {
                     for arr in arr_iter {
                         arr.push_null()
                     }
-                }
+                },
             });
             let fields = arrs
                 .into_iter()
@@ -384,7 +384,7 @@ impl StringNameSpace {
                     for arr in &mut arrs {
                         arr.push_null()
                     }
-                }
+                },
                 Some(s) => {
                     let mut arr_iter = arrs.iter_mut();
                     let split_iter = s.splitn(n, &by);
@@ -395,7 +395,7 @@ impl StringNameSpace {
                     for arr in arr_iter {
                         arr.push_null()
                     }
-                }
+                },
             });
             let fields = arrs
                 .into_iter()

--- a/crates/polars-plan/src/dsl/struct_.rs
+++ b/crates/polars-plan/src/dsl/struct_.rs
@@ -56,7 +56,7 @@ impl StructNameSpace {
                             .map(|(fld, name)| Field::new(name, fld.data_type().clone()))
                             .collect();
                         DataType::Struct(fields)
-                    }
+                    },
                     // The types will be incorrect, but its better than nothing
                     // we can get an incorrect type with python lambdas, because we only know return type when running
                     // the query

--- a/crates/polars-plan/src/logical_plan/aexpr/hash.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/hash.rs
@@ -17,11 +17,11 @@ impl Hash for AExpr {
             } => {
                 options.hash(state);
                 function.hash(state)
-            }
+            },
             AExpr::AnonymousFunction { options, .. } => {
                 options.hash(state);
-            }
-            _ => {}
+            },
+            _ => {},
         }
     }
 }

--- a/crates/polars-plan/src/logical_plan/aexpr/mod.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/mod.rs
@@ -84,14 +84,14 @@ impl From<AAggExpr> for GroupByMethod {
                 } else {
                     GroupByMethod::Min
                 }
-            }
+            },
             Max { propagate_nans, .. } => {
                 if propagate_nans {
                     GroupByMethod::NanMax
                 } else {
                     GroupByMethod::Max
                 }
-            }
+            },
             Median(_) => GroupByMethod::Median,
             NUnique(_) => GroupByMethod::NUnique,
             First(_) => GroupByMethod::First,
@@ -245,36 +245,36 @@ impl AExpr {
         use AExpr::*;
 
         match self {
-            Nth(_) | Column(_) | Literal(_) | Wildcard | Count => {}
+            Nth(_) | Column(_) | Literal(_) | Wildcard | Count => {},
             Alias(e, _) => container.push(*e),
             BinaryExpr { left, op: _, right } => {
                 // reverse order so that left is popped first
                 container.push(*right);
                 container.push(*left);
-            }
+            },
             Cast { expr, .. } => container.push(*expr),
             Sort { expr, .. } => container.push(*expr),
             Take { expr, idx } => {
                 container.push(*idx);
                 // latest, so that it is popped first
                 container.push(*expr);
-            }
+            },
             SortBy { expr, by, .. } => {
                 for node in by {
                     container.push(*node)
                 }
                 // latest, so that it is popped first
                 container.push(*expr);
-            }
+            },
             Filter { input, by } => {
                 container.push(*by);
                 // latest, so that it is popped first
                 container.push(*input);
-            }
+            },
             Agg(agg_e) => {
                 let node = agg_e.get_input().first();
                 container.push(node);
-            }
+            },
             Ternary {
                 truthy,
                 falsy,
@@ -284,7 +284,7 @@ impl AExpr {
                 container.push(*falsy);
                 // latest, so that it is popped first
                 container.push(*truthy);
-            }
+            },
             AnonymousFunction { input, .. } | Function { input, .. } =>
             // we iterate in reverse order, so that the lhs is popped first and will be found
             // as the root columns/ input columns by `_suffix` and `_keep_name` etc.
@@ -294,7 +294,7 @@ impl AExpr {
                     .rev()
                     .copied()
                     .for_each(|node| container.push(node))
-            }
+            },
             Explode(e) => container.push(*e),
             Window {
                 function,
@@ -310,7 +310,7 @@ impl AExpr {
                 }
                 // latest so that it is popped first
                 container.push(*function);
-            }
+            },
             Slice {
                 input,
                 offset,
@@ -320,7 +320,7 @@ impl AExpr {
                 container.push(*offset);
                 // latest so that it is popped first
                 container.push(*input);
-            }
+            },
         }
     }
 
@@ -335,28 +335,28 @@ impl AExpr {
                 *right = inputs[0];
                 *left = inputs[1];
                 return self;
-            }
+            },
             Take { expr, idx } => {
                 *idx = inputs[0];
                 *expr = inputs[1];
                 return self;
-            }
+            },
             Sort { expr, .. } => expr,
             SortBy { expr, by, .. } => {
                 *expr = *inputs.last().unwrap();
                 by.clear();
                 by.extend_from_slice(&inputs[..inputs.len() - 1]);
                 return self;
-            }
+            },
             Filter { input, by, .. } => {
                 *by = inputs[0];
                 *input = inputs[1];
                 return self;
-            }
+            },
             Agg(a) => {
                 a.set_input(inputs[0]);
                 return self;
-            }
+            },
             Ternary {
                 truthy,
                 falsy,
@@ -366,12 +366,12 @@ impl AExpr {
                 *falsy = inputs[1];
                 *truthy = inputs[2];
                 return self;
-            }
+            },
             AnonymousFunction { input, .. } | Function { input, .. } => {
                 input.clear();
                 input.extend(inputs.iter().rev().copied());
                 return self;
-            }
+            },
             Window {
                 function,
                 partition_by,
@@ -384,7 +384,7 @@ impl AExpr {
 
                 assert!(order_by.is_none());
                 return self;
-            }
+            },
         };
         *input = inputs[0];
         self

--- a/crates/polars-plan/src/logical_plan/aexpr/schema.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/schema.rs
@@ -21,7 +21,7 @@ impl AExpr {
             Window { function, .. } => {
                 let e = arena.get(*function);
                 e.to_field(schema, ctxt, arena)
-            }
+            },
             Explode(expr) => {
                 let field = arena.get(*expr).to_field(schema, ctxt, arena)?;
 
@@ -30,7 +30,7 @@ impl AExpr {
                 } else {
                     Ok(field)
                 }
-            }
+            },
             Alias(expr, name) => Ok(Field::new(
                 name,
                 arena.get(*expr).get_type(schema, ctxt, arena)?,
@@ -48,7 +48,7 @@ impl AExpr {
                         field
                     }),
                 }
-            }
+            },
             Literal(sv) => Ok(match sv {
                 LiteralValue::Series(s) => s.field().into_owned(),
                 _ => Field::new("literal", sv.get_datatype()),
@@ -73,13 +73,13 @@ impl AExpr {
                             out_field.name().as_str()
                         };
                         Field::new(out_name, Boolean)
-                    }
+                    },
                     Operator::TrueDivide => return get_truediv_field(*left, arena, ctxt, schema),
                     _ => return get_arithmetic_field(*left, *right, arena, *op, ctxt, schema),
                 };
 
                 Ok(field)
-            }
+            },
             Sort { expr, .. } => arena.get(*expr).to_field(schema, ctxt, arena),
             Take { expr, .. } => arena.get(*expr).to_field(schema, ctxt, arena),
             SortBy { expr, .. } => arena.get(*expr).to_field(schema, ctxt, arena),
@@ -93,7 +93,7 @@ impl AExpr {
                     | Last(expr) => {
                         // default context because `col()` would return a list in aggregation context
                         arena.get(*expr).to_field(schema, Context::Default, arena)
-                    }
+                    },
                     Sum(expr) => {
                         let mut field =
                             arena.get(*expr).to_field(schema, Context::Default, arena)?;
@@ -106,69 +106,69 @@ impl AExpr {
                             field.coerce(dt);
                         }
                         Ok(field)
-                    }
+                    },
                     Median(expr) => {
                         let mut field =
                             arena.get(*expr).to_field(schema, Context::Default, arena)?;
                         float_type(&mut field);
                         Ok(field)
-                    }
+                    },
                     Mean(expr) => {
                         let mut field =
                             arena.get(*expr).to_field(schema, Context::Default, arena)?;
                         float_type(&mut field);
                         Ok(field)
-                    }
+                    },
                     Implode(expr) => {
                         // default context because `col()` would return a list in aggregation context
                         let mut field =
                             arena.get(*expr).to_field(schema, Context::Default, arena)?;
                         field.coerce(DataType::List(field.data_type().clone().into()));
                         Ok(field)
-                    }
+                    },
                     Std(expr, _) => {
                         let mut field =
                             arena.get(*expr).to_field(schema, Context::Default, arena)?;
                         float_type(&mut field);
                         Ok(field)
-                    }
+                    },
                     Var(expr, _) => {
                         let mut field =
                             arena.get(*expr).to_field(schema, Context::Default, arena)?;
                         float_type(&mut field);
                         Ok(field)
-                    }
+                    },
                     NUnique(expr) => {
                         let mut field =
                             arena.get(*expr).to_field(schema, Context::Default, arena)?;
                         field.coerce(IDX_DTYPE);
                         Ok(field)
-                    }
+                    },
                     Count(expr) => {
                         let mut field =
                             arena.get(*expr).to_field(schema, Context::Default, arena)?;
                         field.coerce(IDX_DTYPE);
                         Ok(field)
-                    }
+                    },
                     AggGroups(expr) => {
                         let mut field = arena.get(*expr).to_field(schema, ctxt, arena)?;
                         field.coerce(List(IDX_DTYPE.into()));
                         Ok(field)
-                    }
+                    },
                     Quantile { expr, .. } => {
                         let mut field =
                             arena.get(*expr).to_field(schema, Context::Default, arena)?;
                         float_type(&mut field);
                         Ok(field)
-                    }
+                    },
                 }
-            }
+            },
             Cast {
                 expr, data_type, ..
             } => {
                 let field = arena.get(*expr).to_field(schema, ctxt, arena)?;
                 Ok(Field::new(field.name(), data_type.clone()))
-            }
+            },
             Ternary { truthy, falsy, .. } => {
                 let mut truthy = arena.get(*truthy).to_field(schema, ctxt, arena)?;
                 let falsy = arena.get(*falsy).to_field(schema, ctxt, arena)?;
@@ -180,7 +180,7 @@ impl AExpr {
                     truthy.coerce(st);
                     Ok(truthy)
                 }
-            }
+            },
             AnonymousFunction {
                 output_type,
                 input,
@@ -195,7 +195,7 @@ impl AExpr {
                     .map(|node| arena.get(*node).to_field(schema, Context::Default, arena))
                     .collect::<PolarsResult<Vec<_>>>()?;
                 Ok(output_type.get_field(schema, ctxt, &fields))
-            }
+            },
             Function {
                 function, input, ..
             } => {
@@ -205,7 +205,7 @@ impl AExpr {
                     .map(|node| arena.get(*node).to_field(schema, Context::Default, arena))
                     .collect::<PolarsResult<Vec<_>>>()?;
                 function.get_field(schema, ctxt, &fields)
-            }
+            },
             Slice { input, .. } => arena.get(*input).to_field(schema, ctxt, arena),
             Wildcard => panic!("should be no wildcard at this point"),
             Nth(_) => panic!("should be no nth at this point"),
@@ -244,31 +244,31 @@ fn get_arithmetic_field(
                 (Date, Date) => Duration(TimeUnit::Milliseconds),
                 (left, right) => try_get_supertype(left, &right)?,
             }
-        }
+        },
         Operator::Plus
             if left_field.dtype == Boolean
                 && right_ae.get_type(schema, Context::Default, arena)? == Boolean =>
         {
             IDX_DTYPE
-        }
+        },
         _ => {
             match (left_ae, right_ae) {
-                (AExpr::Literal(_), AExpr::Literal(_)) => {}
+                (AExpr::Literal(_), AExpr::Literal(_)) => {},
                 (AExpr::Literal(_), _) => {
                     // literal will be coerced to match right type
                     let right_type = right_ae.get_type(schema, ctxt, arena)?;
                     left_field.coerce(right_type);
                     return Ok(left_field);
-                }
+                },
                 (_, AExpr::Literal(_)) => {
                     // literal will be coerced to match right type
                     return Ok(left_field);
-                }
-                _ => {}
+                },
+                _ => {},
             }
             let right_type = right_ae.get_type(schema, ctxt, arena)?;
             try_get_supertype(&left_field.dtype, &right_type)?
-        }
+        },
     };
 
     left_field.coerce(super_type);

--- a/crates/polars-plan/src/logical_plan/alp.rs
+++ b/crates/polars-plan/src/logical_plan/alp.rs
@@ -203,7 +203,7 @@ impl ALogicalPlan {
             HStack { schema, .. } => schema,
             Distinct { input, .. } | FileSink { input, .. } => {
                 return arena.get(*input).schema(arena)
-            }
+            },
             Slice { input, .. } => return arena.get(*input).schema(arena),
             MapFunction { input, function } => {
                 let input_schema = arena.get(*input).schema(arena);
@@ -211,10 +211,10 @@ impl ALogicalPlan {
                 return match input_schema {
                     Cow::Owned(schema) => {
                         Cow::Owned(function.schema(&schema).unwrap().into_owned())
-                    }
+                    },
                     Cow::Borrowed(schema) => function.schema(schema).unwrap(),
                 };
-            }
+            },
             ExtContext { schema, .. } => schema,
         };
         Cow::Borrowed(schema)
@@ -335,7 +335,7 @@ impl ALogicalPlan {
                     predicate: new_predicate,
                     scan_type: scan_type.clone(),
                 }
-            }
+            },
             DataFrameScan {
                 df,
                 schema,
@@ -355,7 +355,7 @@ impl ALogicalPlan {
                     projection: projection.clone(),
                     selection: new_selection,
                 }
-            }
+            },
             AnonymousScan {
                 function,
                 file_info,
@@ -375,7 +375,7 @@ impl ALogicalPlan {
                     predicate: new_predicate,
                     options: options.clone(),
                 }
-            }
+            },
             MapFunction { function, .. } => MapFunction {
                 input: inputs[0],
                 function: function.clone(),
@@ -396,7 +396,7 @@ impl ALogicalPlan {
     pub fn copy_exprs(&self, container: &mut Vec<Node>) {
         use ALogicalPlan::*;
         match self {
-            Slice { .. } | Cache { .. } | Distinct { .. } | Union { .. } | MapFunction { .. } => {}
+            Slice { .. } | Cache { .. } | Distinct { .. } | Union { .. } | MapFunction { .. } => {},
             Sort { by_column, .. } => container.extend_from_slice(by_column),
             Selection { predicate, .. } => container.push(*predicate),
             Projection { expr, .. } => container.extend_from_slice(expr),
@@ -404,32 +404,32 @@ impl ALogicalPlan {
             Aggregate { keys, aggs, .. } => {
                 let iter = keys.iter().copied().chain(aggs.iter().copied());
                 container.extend(iter)
-            }
+            },
             Join {
                 left_on, right_on, ..
             } => {
                 let iter = left_on.iter().copied().chain(right_on.iter().copied());
                 container.extend(iter)
-            }
+            },
             HStack { exprs, .. } => container.extend_from_slice(exprs),
             Scan { predicate, .. } => {
                 if let Some(node) = predicate {
                     container.push(*node)
                 }
-            }
+            },
             DataFrameScan { selection, .. } => {
                 if let Some(expr) = selection {
                     container.push(*expr)
                 }
-            }
+            },
             #[cfg(feature = "python")]
-            PythonScan { .. } => {}
+            PythonScan { .. } => {},
             AnonymousScan { predicate, .. } => {
                 if let Some(node) = predicate {
                     container.push(*node)
                 }
-            }
-            ExtContext { .. } | FileSink { .. } => {}
+            },
+            ExtContext { .. } | FileSink { .. } => {},
         }
     }
 
@@ -454,7 +454,7 @@ impl ALogicalPlan {
                     container.push_node(*node);
                 }
                 return;
-            }
+            },
             Slice { input, .. } => *input,
             Selection { input, .. } => *input,
             Projection { input, .. } => *input,
@@ -470,7 +470,7 @@ impl ALogicalPlan {
                 container.push_node(*input_left);
                 container.push_node(*input_right);
                 return;
-            }
+            },
             HStack { input, .. } => *input,
             Distinct { input, .. } => *input,
             MapFunction { input, .. } => *input,
@@ -482,7 +482,7 @@ impl ALogicalPlan {
                     container.push_node(*n)
                 }
                 *input
-            }
+            },
             Scan { .. } => return,
             DataFrameScan { .. } => return,
             AnonymousScan { .. } => return,

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -293,14 +293,14 @@ impl LogicalPlanBuilder {
             match schema {
                 None => {
                     let _ = inferred_schema.insert_at_index(0, rc.name.as_str().into(), IDX_DTYPE);
-                }
+                },
                 Some(inner) => {
                     schema = Some(Arc::new(
                         inner
                             .new_inserting_at_index(0, rc.name.as_str().into(), IDX_DTYPE)
                             .unwrap(),
                     ));
-                }
+                },
             }
         }
 
@@ -407,7 +407,7 @@ impl LogicalPlanBuilder {
             .filter_map(|(name, dtype)| match dtype {
                 DataType::Float32 | DataType::Float64 => {
                     Some(col(name).fill_nan(fill_value.clone()).alias(name))
-                }
+                },
                 _ => None,
             })
             .collect();
@@ -489,7 +489,7 @@ impl LogicalPlanBuilder {
             Expr::Column(name) => is_regex_projection(name),
             Expr::Wildcard | Expr::RenameAlias { .. } | Expr::Columns(_) | Expr::DtypeColumn(_) => {
                 true
-            }
+            },
             _ => false,
         }) {
             let schema = try_delayed!(self.0.schema(), &self.0, into);
@@ -502,13 +502,13 @@ impl LogicalPlanBuilder {
                 1 => {
                     // all good
                     rewritten.pop().unwrap()
-                }
+                },
                 0 => {
                     let msg = "The predicate expanded to zero expressions. \
                         This may for example be caused by a regex not matching column names or \
                         a column dtype match not hitting any dtypes in the DataFrame";
                     return raise_err!(polars_err!(ComputeError: msg), &self.0, into);
-                }
+                },
                 _ => {
                     let mut expanded = String::new();
                     for e in rewritten.iter().take(5) {
@@ -528,7 +528,7 @@ impl LogicalPlanBuilder {
                             This is ambiguous. Try to combine the predicates with the 'all_horizontal' or `any_horizontal' expression.")
                     };
                     return raise_err!(polars_err!(ComputeError: msg), &self.0, into);
-                }
+                },
             }
         } else {
             predicate

--- a/crates/polars-plan/src/logical_plan/conversion.rs
+++ b/crates/polars-plan/src/logical_plan/conversion.rs
@@ -21,7 +21,7 @@ pub fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
                 op,
                 right: r,
             }
-        }
+        },
         Expr::Cast {
             expr,
             data_type,
@@ -90,7 +90,7 @@ pub fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
                 AggExpr::AggGroups(expr) => AAggExpr::AggGroups(to_aexpr(*expr, arena)),
             };
             AExpr::Agg(a_agg)
-        }
+        },
         Expr::Ternary {
             predicate,
             truthy,
@@ -104,7 +104,7 @@ pub fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
                 truthy: t,
                 falsy: f,
             }
-        }
+        },
         Expr::AnonymousFunction {
             input,
             function,
@@ -204,7 +204,7 @@ pub fn to_alp(
                 .map(|lp| to_alp(lp, expr_arena, lp_arena))
                 .collect::<PolarsResult<_>>()?;
             ALogicalPlan::Union { inputs, options }
-        }
+        },
         LogicalPlan::Selection { input, predicate } => {
             let i = to_alp(*input, expr_arena, lp_arena)?;
             let p = to_aexpr(predicate, expr_arena);
@@ -212,11 +212,11 @@ pub fn to_alp(
                 input: i,
                 predicate: p,
             }
-        }
+        },
         LogicalPlan::Slice { input, offset, len } => {
             let input = to_alp(*input, expr_arena, lp_arena)?;
             ALogicalPlan::Slice { input, offset, len }
-        }
+        },
         LogicalPlan::DataFrameScan {
             df,
             schema,
@@ -244,7 +244,7 @@ pub fn to_alp(
                 schema,
                 options,
             }
-        }
+        },
         LogicalPlan::LocalProjection {
             expr,
             input,
@@ -257,7 +257,7 @@ pub fn to_alp(
                 input: i,
                 schema,
             }
-        }
+        },
         LogicalPlan::Sort {
             input,
             by_column,
@@ -273,11 +273,11 @@ pub fn to_alp(
                 by_column,
                 args,
             }
-        }
+        },
         LogicalPlan::Cache { input, id, count } => {
             let input = to_alp(*input, expr_arena, lp_arena)?;
             ALogicalPlan::Cache { input, id, count }
-        }
+        },
         LogicalPlan::Aggregate {
             input,
             keys,
@@ -303,7 +303,7 @@ pub fn to_alp(
                 maintain_order,
                 options,
             }
-        }
+        },
         LogicalPlan::Join {
             input_left,
             input_right,
@@ -332,7 +332,7 @@ pub fn to_alp(
                 right_on: r_on,
                 options,
             }
-        }
+        },
         LogicalPlan::HStack {
             input,
             exprs,
@@ -347,20 +347,20 @@ pub fn to_alp(
                 schema,
                 options,
             }
-        }
+        },
         LogicalPlan::Distinct { input, options } => {
             let input = to_alp(*input, expr_arena, lp_arena)?;
             ALogicalPlan::Distinct { input, options }
-        }
+        },
         LogicalPlan::MapFunction { input, function } => {
             let input = to_alp(*input, expr_arena, lp_arena)?;
             ALogicalPlan::MapFunction { input, function }
-        }
+        },
         LogicalPlan::Error { err, .. } => {
             // We just take the error. The LogicalPlan should not be used anymore once this
             // is taken.
             return Err(err.take());
-        }
+        },
         LogicalPlan::ExtContext {
             input,
             contexts,
@@ -376,11 +376,11 @@ pub fn to_alp(
                 contexts,
                 schema,
             }
-        }
+        },
         LogicalPlan::FileSink { input, payload } => {
             let input = to_alp(*input, expr_arena, lp_arena)?;
             ALogicalPlan::FileSink { input, payload }
-        }
+        },
     };
     Ok(lp_arena.add(v))
 }
@@ -394,7 +394,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
         AExpr::Alias(expr, name) => {
             let exp = node_to_expr(expr, expr_arena);
             Expr::Alias(Box::new(exp), name)
-        }
+        },
         AExpr::Column(a) => Expr::Column(a),
         AExpr::Literal(s) => Expr::Literal(s),
         AExpr::BinaryExpr { left, op, right } => {
@@ -405,7 +405,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                 op,
                 right: Box::new(r),
             }
-        }
+        },
         AExpr::Cast {
             expr,
             data_type,
@@ -417,14 +417,14 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                 data_type,
                 strict,
             }
-        }
+        },
         AExpr::Sort { expr, options } => {
             let exp = node_to_expr(expr, expr_arena);
             Expr::Sort {
                 expr: Box::new(exp),
                 options,
             }
-        }
+        },
         AExpr::Take { expr, idx } => {
             let expr = node_to_expr(expr, expr_arena);
             let idx = node_to_expr(idx, expr_arena);
@@ -432,7 +432,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                 expr: Box::new(expr),
                 idx: Box::new(idx),
             }
-        }
+        },
         AExpr::SortBy {
             expr,
             by,
@@ -448,7 +448,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                 by,
                 descending,
             }
-        }
+        },
         AExpr::Filter { input, by } => {
             let input = node_to_expr(input, expr_arena);
             let by = node_to_expr(by, expr_arena);
@@ -456,7 +456,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                 input: Box::new(input),
                 by: Box::new(by),
             }
-        }
+        },
         AExpr::Agg(agg) => match agg {
             AAggExpr::Min {
                 input,
@@ -468,7 +468,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                     propagate_nans,
                 }
                 .into()
-            }
+            },
             AAggExpr::Max {
                 input,
                 propagate_nans,
@@ -479,32 +479,32 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                     propagate_nans,
                 }
                 .into()
-            }
+            },
 
             AAggExpr::Median(expr) => {
                 let exp = node_to_expr(expr, expr_arena);
                 AggExpr::Median(Box::new(exp)).into()
-            }
+            },
             AAggExpr::NUnique(expr) => {
                 let exp = node_to_expr(expr, expr_arena);
                 AggExpr::NUnique(Box::new(exp)).into()
-            }
+            },
             AAggExpr::First(expr) => {
                 let exp = node_to_expr(expr, expr_arena);
                 AggExpr::First(Box::new(exp)).into()
-            }
+            },
             AAggExpr::Last(expr) => {
                 let exp = node_to_expr(expr, expr_arena);
                 AggExpr::Last(Box::new(exp)).into()
-            }
+            },
             AAggExpr::Mean(expr) => {
                 let exp = node_to_expr(expr, expr_arena);
                 AggExpr::Mean(Box::new(exp)).into()
-            }
+            },
             AAggExpr::Implode(expr) => {
                 let exp = node_to_expr(expr, expr_arena);
                 AggExpr::Implode(Box::new(exp)).into()
-            }
+            },
             AAggExpr::Quantile {
                 expr,
                 quantile,
@@ -518,27 +518,27 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                     interpol,
                 }
                 .into()
-            }
+            },
             AAggExpr::Sum(expr) => {
                 let exp = node_to_expr(expr, expr_arena);
                 AggExpr::Sum(Box::new(exp)).into()
-            }
+            },
             AAggExpr::Std(expr, ddof) => {
                 let exp = node_to_expr(expr, expr_arena);
                 AggExpr::Std(Box::new(exp), ddof).into()
-            }
+            },
             AAggExpr::Var(expr, ddof) => {
                 let exp = node_to_expr(expr, expr_arena);
                 AggExpr::Var(Box::new(exp), ddof).into()
-            }
+            },
             AAggExpr::AggGroups(expr) => {
                 let exp = node_to_expr(expr, expr_arena);
                 AggExpr::AggGroups(Box::new(exp)).into()
-            }
+            },
             AAggExpr::Count(expr) => {
                 let exp = node_to_expr(expr, expr_arena);
                 AggExpr::Count(Box::new(exp)).into()
-            }
+            },
         },
         AExpr::Ternary {
             predicate,
@@ -554,7 +554,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                 truthy: Box::new(t),
                 falsy: Box::new(f),
             }
-        }
+        },
         AExpr::AnonymousFunction {
             input,
             function,
@@ -590,7 +590,7 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                 order_by,
                 options,
             }
-        }
+        },
         AExpr::Slice {
             input,
             offset,
@@ -659,7 +659,7 @@ impl ALogicalPlan {
                     .map(|node| convert_to_lp(node, lp_arena))
                     .collect();
                 LogicalPlan::Union { inputs, options }
-            }
+            },
             ALogicalPlan::Slice { input, offset, len } => {
                 let lp = convert_to_lp(input, lp_arena);
                 LogicalPlan::Slice {
@@ -667,7 +667,7 @@ impl ALogicalPlan {
                     offset,
                     len,
                 }
-            }
+            },
             ALogicalPlan::Selection { input, predicate } => {
                 let lp = convert_to_lp(input, lp_arena);
                 let p = node_to_expr(predicate, expr_arena);
@@ -675,7 +675,7 @@ impl ALogicalPlan {
                     input: Box::new(lp),
                     predicate: p,
                 }
-            }
+            },
             ALogicalPlan::DataFrameScan {
                 df,
                 schema,
@@ -703,7 +703,7 @@ impl ALogicalPlan {
                     schema,
                     options,
                 }
-            }
+            },
             ALogicalPlan::LocalProjection {
                 expr,
                 input,
@@ -716,7 +716,7 @@ impl ALogicalPlan {
                     input: Box::new(i),
                     schema,
                 }
-            }
+            },
             ALogicalPlan::Sort {
                 input,
                 by_column,
@@ -728,11 +728,11 @@ impl ALogicalPlan {
                     by_column: nodes_to_exprs(&by_column, expr_arena),
                     args,
                 }
-            }
+            },
             ALogicalPlan::Cache { input, id, count } => {
                 let input = Box::new(convert_to_lp(input, lp_arena));
                 LogicalPlan::Cache { input, id, count }
-            }
+            },
             ALogicalPlan::Aggregate {
                 input,
                 keys,
@@ -753,7 +753,7 @@ impl ALogicalPlan {
                     maintain_order,
                     options: dynamic_options,
                 }
-            }
+            },
             ALogicalPlan::Join {
                 input_left,
                 input_right,
@@ -773,7 +773,7 @@ impl ALogicalPlan {
                     right_on: nodes_to_exprs(&right_on, expr_arena),
                     options,
                 }
-            }
+            },
             ALogicalPlan::HStack {
                 input,
                 exprs,
@@ -788,18 +788,18 @@ impl ALogicalPlan {
                     schema,
                     options,
                 }
-            }
+            },
             ALogicalPlan::Distinct { input, options } => {
                 let i = convert_to_lp(input, lp_arena);
                 LogicalPlan::Distinct {
                     input: Box::new(i),
                     options,
                 }
-            }
+            },
             ALogicalPlan::MapFunction { input, function } => {
                 let input = Box::new(convert_to_lp(input, lp_arena));
                 LogicalPlan::MapFunction { input, function }
-            }
+            },
             ALogicalPlan::ExtContext {
                 input,
                 contexts,
@@ -815,11 +815,11 @@ impl ALogicalPlan {
                     contexts,
                     schema,
                 }
-            }
+            },
             ALogicalPlan::FileSink { input, payload } => {
                 let input = Box::new(convert_to_lp(input, lp_arena));
                 LogicalPlan::FileSink { input, payload }
-            }
+            },
         }
     }
 }

--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -65,7 +65,7 @@ impl LogicalPlan {
                     &options.predicate,
                     options.n_rows,
                 )
-            }
+            },
             AnonymousScan {
                 file_info,
                 predicate,
@@ -87,7 +87,7 @@ impl LogicalPlan {
                     predicate,
                     options.n_rows,
                 )
-            }
+            },
             Union { inputs, options } => {
                 let mut name = String::new();
                 let name = if let Some(slice) = options.slice {
@@ -107,11 +107,11 @@ impl LogicalPlan {
                     plan._format(f, sub_sub_indent)?;
                 }
                 write!(f, "\n{:indent$}END {}", "", name)
-            }
+            },
             Cache { input, id, count } => {
                 write!(f, "{:indent$}CACHE[id: {:x}, count: {}]", "", *id, *count)?;
                 input._format(f, sub_indent)
-            }
+            },
             Scan {
                 path,
                 file_info,
@@ -135,12 +135,12 @@ impl LogicalPlan {
                     predicate,
                     file_options.n_rows,
                 )
-            }
+            },
             Selection { predicate, input } => {
                 // this one is writeln because we don't increase indent (which inserts a line)
                 writeln!(f, "{:indent$}FILTER {predicate:?} FROM", "")?;
                 input._format(f, indent)
-            }
+            },
             DataFrameScan {
                 schema,
                 projection,
@@ -165,28 +165,28 @@ impl LogicalPlan {
                     total_columns,
                     selection,
                 )
-            }
+            },
             Projection { expr, input, .. } => {
                 write!(f, "{:indent$} SELECT {expr:?} FROM", "")?;
                 input._format(f, sub_indent)
-            }
+            },
             LocalProjection { expr, input, .. } => {
                 write!(f, "{:indent$} LOCAL SELECT {expr:?} FROM", "")?;
                 input._format(f, sub_indent)
-            }
+            },
             Sort {
                 input, by_column, ..
             } => {
                 write!(f, "{:indent$}SORT BY {by_column:?}", "")?;
                 input._format(f, sub_indent)
-            }
+            },
             Aggregate {
                 input, keys, aggs, ..
             } => {
                 write!(f, "{:indent$}AGGREGATE", "")?;
                 write!(f, "\n{:indent$}\t{aggs:?} BY {keys:?} FROM", "")?;
                 input._format(f, sub_indent)
-            }
+            },
             Join {
                 input_left,
                 input_right,
@@ -202,36 +202,36 @@ impl LogicalPlan {
                 write!(f, "\n{:indent$}RIGHT PLAN ON: {right_on:?}", "")?;
                 input_right._format(f, sub_indent)?;
                 write!(f, "\n{:indent$}END {} JOIN", "", how)
-            }
+            },
             HStack { input, exprs, .. } => {
                 write!(f, "{:indent$} WITH_COLUMNS:", "",)?;
                 write!(f, "\n{:indent$} {exprs:?}", "")?;
                 input._format(f, sub_indent)
-            }
+            },
             Distinct { input, options } => {
                 write!(f, "{:indent$}UNIQUE BY {:?}", "", options.subset)?;
                 input._format(f, sub_indent)
-            }
+            },
             Slice { input, offset, len } => {
                 write!(f, "{:indent$}SLICE[offset: {offset}, len: {len}]", "")?;
                 input._format(f, sub_indent)
-            }
+            },
             MapFunction {
                 input, function, ..
             } => {
                 let function_fmt = format!("{function}");
                 write!(f, "{:indent$}{function_fmt}", "")?;
                 input._format(f, sub_indent)
-            }
+            },
             Error { input, err } => write!(f, "{err:?}\n{input:?}"),
             ExtContext { input, .. } => {
                 write!(f, "{:indent$}EXTERNAL_CONTEXT", "")?;
                 input._format(f, sub_indent)
-            }
+            },
             FileSink { input, .. } => {
                 write!(f, "{:indent$}FILE_SINK", "")?;
                 input._format(f, sub_indent)
-            }
+            },
         }
     }
 }
@@ -267,12 +267,12 @@ impl Debug for Expr {
                     LiteralValue::Utf8(v) => {
                         // dot breaks with debug fmt due to \"
                         write!(f, "Utf8({v})")
-                    }
+                    },
                     _ => {
                         write!(f, "{v:?}")
-                    }
+                    },
                 }
-            }
+            },
             BinaryExpr { left, op, right } => write!(f, "[({left:?}) {op:?} ({right:?})]"),
             Sort { expr, options } => match options.descending {
                 true => write!(f, "{expr:?}.sort(desc)"),
@@ -284,13 +284,13 @@ impl Debug for Expr {
                 descending,
             } => {
                 write!(f, "{expr:?}.sort_by(by={by:?}, descending={descending:?})",)
-            }
+            },
             Filter { input, by } => {
                 write!(f, "{input:?}.filter({by:?})")
-            }
+            },
             Take { expr, idx } => {
                 write!(f, "{expr:?}.take({idx:?})")
-            }
+            },
             Agg(agg) => {
                 use AggExpr::*;
                 match agg {
@@ -303,7 +303,7 @@ impl Debug for Expr {
                         } else {
                             write!(f, "{input:?}.min()")
                         }
-                    }
+                    },
                     Max {
                         input,
                         propagate_nans,
@@ -313,7 +313,7 @@ impl Debug for Expr {
                         } else {
                             write!(f, "{input:?}.max()")
                         }
-                    }
+                    },
                     Median(expr) => write!(f, "{expr:?}.median()"),
                     Mean(expr) => write!(f, "{expr:?}.mean()"),
                     First(expr) => write!(f, "{expr:?}.first()"),
@@ -327,7 +327,7 @@ impl Debug for Expr {
                     Std(expr, _) => write!(f, "{expr:?}.var()"),
                     Quantile { expr, .. } => write!(f, "{expr:?}.quantile()"),
                 }
-            }
+            },
             Cast {
                 expr,
                 data_type,
@@ -338,7 +338,7 @@ impl Debug for Expr {
                 } else {
                     write!(f, "{expr:?}.cast({data_type:?})")
                 }
-            }
+            },
             Ternary {
                 predicate,
                 truthy,
@@ -355,14 +355,14 @@ impl Debug for Expr {
                 } else {
                     write!(f, "{:?}.{function}()", input[0])
                 }
-            }
+            },
             AnonymousFunction { input, options, .. } => {
                 if input.len() >= 2 {
                     write!(f, "{:?}.{}({:?})", input[0], options.fmt_str, &input[1..])
                 } else {
                     write!(f, "{:?}.{}()", input[0], options.fmt_str)
                 }
-            }
+            },
             Slice {
                 input,
                 offset,
@@ -399,11 +399,11 @@ impl Debug for LiteralValue {
                 } else {
                     write!(f, "Series[{name}]")
                 }
-            }
+            },
             _ => {
                 let av = self.to_anyvalue().unwrap();
                 write!(f, "{av}")
-            }
+            },
         }
     }
 }

--- a/crates/polars-plan/src/logical_plan/functions/mod.rs
+++ b/crates/polars-plan/src/logical_plan/functions/mod.rs
@@ -170,7 +170,7 @@ impl FunctionNode {
                 Some(schema_fn) => {
                     let output_schema = schema_fn.get_schema(input_schema)?;
                     Ok(Cow::Owned(output_schema))
-                }
+                },
             },
             #[cfg(feature = "python")]
             OpaquePython { schema, .. } => Ok(schema
@@ -187,7 +187,7 @@ impl FunctionNode {
                     })
                     .collect::<PolarsResult<Schema>>()?;
                 Ok(Cow::Owned(Arc::new(schema)))
-            }
+            },
             DropNulls { .. } => Ok(Cow::Borrowed(input_schema)),
             Rechunk => Ok(Cow::Borrowed(input_schema)),
             Unnest { columns: _columns } => {
@@ -204,15 +204,15 @@ impl FunctionNode {
                                             fld.data_type().clone(),
                                         );
                                     }
-                                }
+                                },
                                 DataType::Unknown => {
                                     // pass through unknown
-                                }
+                                },
                                 _ => {
                                     polars_bail!(
                                         SchemaMismatch: "expected struct dtype, got: `{}`", dtype
                                     );
-                                }
+                                },
                             }
                         } else {
                             new_schema.with_column(name.clone(), dtype.clone());
@@ -225,14 +225,14 @@ impl FunctionNode {
                 {
                     panic!("activate feature 'dtype-struct'")
                 }
-            }
+            },
             #[cfg(feature = "merge_sorted")]
             MergeSorted { .. } => Ok(Cow::Borrowed(input_schema)),
             Rename { existing, new, .. } => rename::rename_schema(input_schema, existing, new),
             Drop { names } => drop::drop_schema(input_schema, names),
             Explode { schema, .. } | RowCount { schema, .. } | Melt { schema, .. } => {
                 Ok(Cow::Owned(schema.clone()))
-            }
+            },
         }
     }
 
@@ -305,7 +305,7 @@ impl FunctionNode {
             Rechunk => {
                 df.as_single_chunk_par();
                 Ok(df)
-            }
+            },
             #[cfg(feature = "merge_sorted")]
             MergeSorted { column } => merge_sorted(&df, column.as_ref()),
             Unnest { columns: _columns } => {
@@ -317,7 +317,7 @@ impl FunctionNode {
                 {
                     panic!("activate feature 'dtype-struct'")
                 }
-            }
+            },
             Pipeline { function, .. } => {
                 // we use a global string cache here as streaming chunks all have different rev maps
                 #[cfg(feature = "dtype-categorical")]
@@ -330,14 +330,14 @@ impl FunctionNode {
                 {
                     Arc::get_mut(function).unwrap().call_udf(df)
                 }
-            }
+            },
             Rename { existing, new, .. } => rename::rename_impl(df, existing, new),
             Drop { names } => drop::drop_impl(df, names),
             Explode { columns, .. } => df.explode(columns.as_ref()),
             Melt { args, .. } => {
                 let args = (**args).clone();
                 df.melt2(args)
-            }
+            },
             RowCount { name, offset, .. } => df.with_row_count(name.as_ref(), *offset),
         }
     }
@@ -360,18 +360,18 @@ impl Display for FunctionNode {
                 write!(f, "FAST_PROJECT: ")?;
                 let columns = columns.as_ref();
                 fmt_column_delimited(f, columns, "[", "]")
-            }
+            },
             DropNulls { subset } => {
                 write!(f, "DROP_NULLS by: ")?;
                 let subset = subset.as_ref();
                 fmt_column_delimited(f, subset, "[", "]")
-            }
+            },
             Rechunk => write!(f, "RECHUNK"),
             Unnest { columns } => {
                 write!(f, "UNNEST by:")?;
                 let columns = columns.as_ref();
                 fmt_column_delimited(f, columns, "[", "]")
-            }
+            },
             #[cfg(feature = "merge_sorted")]
             MergeSorted { .. } => write!(f, "MERGE SORTED"),
             Pipeline { original, .. } => {
@@ -383,7 +383,7 @@ impl Display for FunctionNode {
                 } else {
                     writeln!(f, "PIPELINE")
                 }
-            }
+            },
             Rename { .. } => write!(f, "RENAME"),
             Drop { .. } => write!(f, "DROP"),
             Explode { .. } => write!(f, "EXPLODE"),

--- a/crates/polars-plan/src/logical_plan/iterator.rs
+++ b/crates/polars-plan/src/logical_plan/iterator.rs
@@ -6,31 +6,31 @@ macro_rules! push_expr {
     ($current_expr:expr, $push:ident, $iter:ident) => {{
         use Expr::*;
         match $current_expr {
-            Nth(_) | Column(_) | Literal(_) | Wildcard | Columns(_) | DtypeColumn(_) | Count => {}
+            Nth(_) | Column(_) | Literal(_) | Wildcard | Columns(_) | DtypeColumn(_) | Count => {},
             Alias(e, _) => $push(e),
             BinaryExpr { left, op: _, right } => {
                 // reverse order so that left is popped first
                 $push(right);
                 $push(left);
-            }
+            },
             Cast { expr, .. } => $push(expr),
             Sort { expr, .. } => $push(expr),
             Take { expr, idx } => {
                 $push(idx);
                 $push(expr);
-            }
+            },
             Filter { input, by } => {
                 $push(by);
                 // latest, so that it is popped first
                 $push(input);
-            }
+            },
             SortBy { expr, by, .. } => {
                 for e in by {
                     $push(e)
                 }
                 // latest, so that it is popped first
                 $push(expr);
-            }
+            },
             Agg(agg_e) => {
                 use AggExpr::*;
                 match agg_e {
@@ -49,7 +49,7 @@ macro_rules! push_expr {
                     Std(e, _) => $push(e),
                     Var(e, _) => $push(e),
                 }
-            }
+            },
             Ternary {
                 truthy,
                 falsy,
@@ -59,7 +59,7 @@ macro_rules! push_expr {
                 $push(falsy);
                 // latest, so that it is popped first
                 $push(truthy);
-            }
+            },
             // we iterate in reverse order, so that the lhs is popped first and will be found
             // as the root columns/ input columns by `_suffix` and `_keep_name` etc.
             AnonymousFunction { input, .. } => input.$iter().rev().for_each(|e| $push(e)),
@@ -79,7 +79,7 @@ macro_rules! push_expr {
                 }
                 // latest so that it is popped first
                 $push(function);
-            }
+            },
             Slice {
                 input,
                 offset,
@@ -89,12 +89,12 @@ macro_rules! push_expr {
                 $push(offset);
                 // latest, so that it is popped first
                 $push(input);
-            }
+            },
             Exclude(e, _) => $push(e),
             KeepName(e) => $push(e),
             RenameAlias { expr, .. } => $push(expr),
             // pass
-            Selector(_) => {}
+            Selector(_) => {},
         }
     }};
 }

--- a/crates/polars-plan/src/logical_plan/lit.rs
+++ b/crates/polars-plan/src/logical_plan/lit.rs
@@ -203,7 +203,7 @@ impl TryFrom<AnyValue<'_>> for LiteralValue {
                         ))
                     }
                 }
-            }
+            },
             v => polars_bail!(
                 ComputeError: "cannot convert any-value {:?} to literal", v
             ),

--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -79,7 +79,7 @@ impl std::fmt::Display for ErrorState {
             ErrorState::NotYetEncountered { err } => write!(f, "NotYetEncountered({err})")?,
             ErrorState::AlreadyEncountered { prev_err_msg } => {
                 write!(f, "AlreadyEncountered({prev_err_msg})")?
-            }
+            },
         };
 
         Ok(())
@@ -121,12 +121,12 @@ impl ErrorStateSync {
                     ErrorState::NotYetEncountered { err } => err,
                     ErrorState::AlreadyEncountered { .. } => unreachable!(),
                 }
-            }
+            },
             ErrorState::AlreadyEncountered { prev_err_msg } => {
                 polars_err!(
                     ComputeError: "LogicalPlan already failed with error: '{}'", prev_err_msg,
                 )
-            }
+            },
         }
     }
 }

--- a/crates/polars-plan/src/logical_plan/optimizer/cache_states.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cache_states.rs
@@ -19,7 +19,7 @@ fn get_upper_projections(
                 out.extend(aexpr_to_leaf_names_iter(*node, expr_arena));
             }
             Some(out)
-        }
+        },
         // other
         _ => None,
     }
@@ -77,14 +77,14 @@ pub(super) fn set_cache_states(
                         let options = Arc::make_mut(options);
                         options.allow_parallel = false;
                     }
-                }
+                },
                 // don't allow parallelism as caches need each others work
                 // also self-referencing plans can deadlock on the files they lock
                 Union { options, .. } if has_caches && options.parallel => {
                     if let Union { options, .. } = lp_arena.get_mut(current_node) {
                         options.parallel = false;
                     }
-                }
+                },
                 Cache { input, id, .. } => {
                     caches_seen += 1;
 
@@ -124,8 +124,8 @@ pub(super) fn set_cache_states(
                         }
                     }
                     cache_id = Some(*id);
-                }
-                _ => {}
+                },
+                _ => {},
             }
 
             parent = Some(current_node);

--- a/crates/polars-plan/src/logical_plan/optimizer/cse.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cse.rs
@@ -48,7 +48,7 @@ pub(super) fn collect_trails(
             *id += 1;
             trails.insert(*id, new_trail);
             collect_trails(*input_right, lp_arena, trails, id, true)?;
-        }
+        },
         Union { inputs, .. } => {
             if inputs.len() > 200 {
                 // don't even bother with cse on this many inputs
@@ -68,10 +68,10 @@ pub(super) fn collect_trails(
                     trails.insert(*id, new_trail.clone());
                 }
             }
-        }
+        },
         ExtContext { .. } => {
             // block for now.
-        }
+        },
         lp => {
             // other nodes have only a single input
             let nodes = &mut [None];
@@ -79,7 +79,7 @@ pub(super) fn collect_trails(
             if let Some(input) = nodes[0] {
                 collect_trails(input, lp_arena, trails, id, collect)?
             }
-        }
+        },
     }
     Some(())
 }
@@ -133,10 +133,10 @@ fn lp_node_equal(a: &ALogicalPlan, b: &ALogicalPlan, expr_arena: &Arena<AExpr>) 
             path_left == path_right
                 && scan_type_left == scan_type_right
                 && predicate_equal(*predicate_left, *predicate_right, expr_arena)
-        }
+        },
         (Selection { predicate: l, .. }, Selection { predicate: r, .. }) => {
             AExpr::is_equal(*l, *r, expr_arena)
-        }
+        },
         (Projection { expr: l, .. }, Projection { expr: r, .. })
         | (HStack { exprs: l, .. }, HStack { exprs: r, .. }) => expr_nodes_equal(l, r, expr_arena),
         (
@@ -187,7 +187,7 @@ fn lp_node_equal(a: &ALogicalPlan, b: &ALogicalPlan, expr_arena: &Arena<AExpr>) 
                 && options_l == options_r
                 && expr_nodes_equal(keys_l, keys_r, expr_arena)
                 && expr_nodes_equal(agg_l, agg_r, expr_arena)
-        }
+        },
         #[cfg(feature = "python")]
         (PythonScan { options: l, .. }, PythonScan { options: r, .. }) => l == r,
         _ => {
@@ -197,7 +197,7 @@ fn lp_node_equal(a: &ALogicalPlan, b: &ALogicalPlan, expr_arena: &Arena<AExpr>) 
             // is below the joining/union root
             // that gets complicated quick
             false
-        }
+        },
     }
 }
 
@@ -323,7 +323,7 @@ pub(crate) fn elim_cmn_subplans(
                 cache_mapping.insert(node1, cache_id);
                 cache_mapping.insert(node2, cache_id);
                 cache_id
-            }
+            },
         };
         *cache_counts.entry(cache_id).or_insert(0usize) += 1;
     }
@@ -344,7 +344,7 @@ pub(crate) fn elim_cmn_subplans(
             (_, Some(h)) => *h,
             _ => {
                 unreachable!()
-            }
+            },
         };
         let cache_count = *cache_counts.get(&cache_id).unwrap();
 
@@ -393,7 +393,7 @@ pub(crate) fn decrement_file_counters_by_cache_hits(
             } else {
                 options.file_counter -= acc_count as FileCount
             }
-        }
+        },
         Cache { count, input, .. } => {
             // we use usize::MAX for an infinite cache.
             let new_count = if *count != usize::MAX {
@@ -402,7 +402,7 @@ pub(crate) fn decrement_file_counters_by_cache_hits(
                 acc_count
             };
             decrement_file_counters_by_cache_hits(*input, lp_arena, _expr_arena, new_count, scratch)
-        }
+        },
         lp => {
             lp.copy_inputs(scratch);
             while let Some(input) = scratch.pop() {
@@ -414,6 +414,6 @@ pub(crate) fn decrement_file_counters_by_cache_hits(
                     scratch,
                 )
             }
-        }
+        },
     }
 }

--- a/crates/polars-plan/src/logical_plan/optimizer/cse_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cse_expr.rs
@@ -248,7 +248,7 @@ impl ExprIdentifierVisitor<'_> {
                 VisitRecord::SubExprId(s, valid) => {
                     id.combine(&s);
                     is_valid_accumulated &= valid
-                }
+                },
             }
         }
         unreachable!()
@@ -264,7 +264,7 @@ impl ExprIdentifierVisitor<'_> {
             // skip window functions for now until we properly implemented the physical side
             AExpr::Column(_) | AExpr::Count | AExpr::Literal(_) | AExpr::Alias(_, _) => {
                 Some((VisitRecursion::Continue, true))
-            }
+            },
             #[cfg(feature = "random")]
             AExpr::Function {
                 function: FunctionExpr::Random { .. },
@@ -278,20 +278,20 @@ impl ExprIdentifierVisitor<'_> {
                     match ae {
                         AExpr::Agg(_) | AExpr::AnonymousFunction { .. } => {
                             Some((VisitRecursion::Continue, false))
-                        }
+                        },
                         AExpr::Function { options, .. } => {
                             if options.is_groups_sensitive() {
                                 Some((VisitRecursion::Continue, false))
                             } else {
                                 None
                             }
-                        }
+                        },
                         _ => None,
                     }
                 } else {
                     None
                 }
-            }
+            },
         }
     }
 }
@@ -635,7 +635,7 @@ impl<'a> RewritingVisitor for CommonSubExprOptimizer<'a> {
         Ok(match node.to_alp() {
             Projection { .. } | HStack { .. } | Aggregate { .. } => {
                 RewriteRecursion::MutateAndContinue
-            }
+            },
             _ => RewriteRecursion::NoMutateAndContinue,
         })
     }
@@ -677,7 +677,7 @@ impl<'a> RewritingVisitor for CommonSubExprOptimizer<'a> {
                         };
                         lp_arena.replace(arena_idx, lp);
                     }
-                }
+                },
                 ALogicalPlan::HStack {
                     input,
                     exprs,
@@ -700,7 +700,7 @@ impl<'a> RewritingVisitor for CommonSubExprOptimizer<'a> {
                         };
                         lp_arena.replace(arena_idx, lp);
                     }
-                }
+                },
                 ALogicalPlan::Aggregate {
                     input,
                     keys,
@@ -741,8 +741,8 @@ impl<'a> RewritingVisitor for CommonSubExprOptimizer<'a> {
                         };
                         lp_arena.replace(arena_idx, lp);
                     }
-                }
-                _ => {}
+                },
+                _ => {},
             }
             PolarsResult::Ok(())
         })?;

--- a/crates/polars-plan/src/logical_plan/optimizer/delay_rechunk.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/delay_rechunk.rs
@@ -37,14 +37,14 @@ impl OptimizationRule for DelayRechunk {
                         Scan { .. } => {
                             input_node = Some(node);
                             break;
-                        }
+                        },
                         Union { .. } => {
                             input_node = Some(node);
                             break;
-                        }
+                        },
                         // don't delay rechunk if there is a join first
                         Join { .. } => break,
-                        _ => {}
+                        _ => {},
                     }
                 }
 
@@ -55,16 +55,16 @@ impl OptimizationRule for DelayRechunk {
                             ..
                         } => {
                             options.rechunk = false;
-                        }
+                        },
                         Union { options, .. } => {
                             options.rechunk = false;
-                        }
+                        },
                         _ => unreachable!(),
                     }
                 };
 
                 None
-            }
+            },
             _ => None,
         }
     }

--- a/crates/polars-plan/src/logical_plan/optimizer/drop_nulls.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/drop_nulls.rs
@@ -81,7 +81,7 @@ impl OptimizationRule for ReplaceDropNulls {
                 } else {
                     None
                 }
-            }
+            },
             _ => None,
         }
     }

--- a/crates/polars-plan/src/logical_plan/optimizer/fast_projection.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/fast_projection.rs
@@ -73,7 +73,7 @@ impl OptimizationRule for FastProjectionAndCollapse {
                 } else {
                     None
                 }
-            }
+            },
             LocalProjection { input, expr, .. } => impl_fast_projection(*input, expr, expr_arena),
             MapFunction {
                 input,
@@ -103,10 +103,10 @@ impl OptimizationRule for FastProjectionAndCollapse {
                         } else {
                             None
                         }
-                    }
+                    },
                     _ => None,
                 }
-            }
+            },
             // if there are 2 subsequent caches, flatten them and only take the inner
             Cache {
                 input,
@@ -128,7 +128,7 @@ impl OptimizationRule for FastProjectionAndCollapse {
                 } else {
                     None
                 }
-            }
+            },
             _ => None,
         }
     }

--- a/crates/polars-plan/src/logical_plan/optimizer/file_caching.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/file_caching.rs
@@ -45,7 +45,7 @@ fn process_with_columns(
         // no projection, so we must take all columns
         None => {
             cols.1.extend(schema.iter_names().map(|t| t.to_string()));
-        }
+        },
     }
 }
 
@@ -73,12 +73,12 @@ pub fn collect_fingerprints(
                 slice,
             };
             fps.push(fp);
-        }
+        },
         lp => {
             for input in lp.get_inputs() {
                 collect_fingerprints(input, fps, lp_arena, expr_arena)
             }
-        }
+        },
     }
 }
 
@@ -113,12 +113,12 @@ pub fn find_column_union_and_fingerprints(
                 columns,
                 &file_info.schema,
             );
-        }
+        },
         lp => {
             for input in lp.get_inputs() {
                 find_column_union_and_fingerprints(input, columns, lp_arena, expr_arena)
             }
-        }
+        },
     }
 }
 
@@ -246,7 +246,7 @@ impl FileCacher {
                         behind_cache,
                     );
                     lp_arena.replace(root, lp);
-                }
+                },
                 lp => {
                     let behind_cache = behind_cache || matches!(&lp, ALogicalPlan::Cache { .. });
 
@@ -255,7 +255,7 @@ impl FileCacher {
                         stack.push((input, behind_cache))
                     }
                     lp_arena.replace(root, lp);
-                }
+                },
             }
         }
         scratch.clear();

--- a/crates/polars-plan/src/logical_plan/optimizer/flatten_union.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/flatten_union.rs
@@ -45,7 +45,7 @@ impl OptimizationRule for FlattenUnionRule {
                     inputs: new_inputs,
                     options,
                 })
-            }
+            },
             _ => None,
         }
     }

--- a/crates/polars-plan/src/logical_plan/optimizer/fused.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/fused.rs
@@ -92,7 +92,7 @@ impl OptimizationRule for FusedArithmetic {
                             // we reordered the arguments, so we don't obey the left expression output name
                             // rule anymore, that's why we alias
                             Ok(Some(Alias(node, Arc::from(output_field.name.as_str()))))
-                        }
+                        },
                         _ => unreachable!(),
                     },
                     _ => match expr_arena.get(*right) {
@@ -108,12 +108,12 @@ impl OptimizationRule for FusedArithmetic {
                             (Some(true), _) => {
                                 let input = vec![*left, *a, *b];
                                 Ok(Some(get_expr(input, FusedOperator::MultiplyAdd)))
-                            }
+                            },
                         },
                         _ => Ok(None),
                     },
                 }
-            }
+            },
 
             BinaryExpr {
                 left,
@@ -134,7 +134,7 @@ impl OptimizationRule for FusedArithmetic {
                         (Some(true), _) => {
                             let input = vec![*left, *a, *b];
                             Ok(Some(get_expr(input, FusedOperator::SubMultiply)))
-                        }
+                        },
                     },
                     _ => {
                         // FUSED MULTIPLY SUB
@@ -152,14 +152,14 @@ impl OptimizationRule for FusedArithmetic {
                                     (Some(true), _) => {
                                         let input = vec![*a, *b, *right];
                                         Ok(Some(get_expr(input, FusedOperator::MultiplySub)))
-                                    }
+                                    },
                                 }
-                            }
+                            },
                             _ => Ok(None),
                         }
-                    }
+                    },
                 }
-            }
+            },
             _ => Ok(None),
         }
     }

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
@@ -98,7 +98,7 @@ pub(super) fn predicate_is_sort_boundary(node: Node, expr_arena: &Arena<AExpr>) 
             // like sum, min, etc).
             // function that match this are `cumsum`, `shift`, `sort`, etc.
             options.is_groups_sensitive() && !options.auto_explode
-        }
+        },
         _ => false,
     };
     has_aexpr(node, expr_arena, matches)
@@ -293,7 +293,7 @@ where
                 &mut local_predicates,
             ) {
                 LoopBehavior::Continue => continue,
-                LoopBehavior::Nothing => {}
+                LoopBehavior::Nothing => {},
             }
         }
         let input_schema = lp_arena.get(input).schema(lp_arena);
@@ -436,7 +436,7 @@ pub(super) fn partition_by_full_context(
             AExpr::BinaryExpr { left, right, .. } => {
                 expr_arena.get(*left).groups_sensitive()
                     || expr_arena.get(*right).groups_sensitive()
-            }
+            },
             ae => ae.groups_sensitive(),
         })
     })

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/functions/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/functions/mod.rs
@@ -44,7 +44,7 @@ pub(super) fn process_functions(
                 function: function.clone(),
             };
             Ok(lp)
-        }
+        },
         Explode { columns, .. } => {
             columns.iter().for_each(|name| {
                 add_str_to_accumulated(name, &mut acc_projections, &mut projected_names, expr_arena)
@@ -60,7 +60,7 @@ pub(super) fn process_functions(
             Ok(ALogicalPlanBuilder::new(input, expr_arena, lp_arena)
                 .explode(columns.clone())
                 .build())
-        }
+        },
         Melt { args, .. } => {
             let lp = ALogicalPlan::MapFunction {
                 input,
@@ -77,7 +77,7 @@ pub(super) fn process_functions(
                 lp_arena,
                 expr_arena,
             )
-        }
+        },
         _ => {
             let lp = ALogicalPlan::MapFunction {
                 input,
@@ -131,6 +131,6 @@ pub(super) fn process_functions(
                     expr_arena,
                 )
             }
-        }
+        },
     }
 }

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
@@ -357,7 +357,7 @@ impl ProjectionPushDown {
                 Ok(ALogicalPlanBuilder::new(input, expr_arena, lp_arena)
                     .project_local(proj)
                     .build())
-            }
+            },
             AnonymousScan {
                 function,
                 file_info,
@@ -400,7 +400,7 @@ impl ProjectionPushDown {
                     };
                     Ok(lp)
                 }
-            }
+            },
             DataFrameScan {
                 df,
                 schema,
@@ -426,7 +426,7 @@ impl ProjectionPushDown {
                     selection,
                 };
                 Ok(lp)
-            }
+            },
             #[cfg(feature = "python")]
             PythonScan {
                 mut options,
@@ -445,7 +445,7 @@ impl ProjectionPushDown {
                     )?))
                 };
                 Ok(PythonScan { options, predicate })
-            }
+            },
             Scan {
                 path,
                 file_info,
@@ -480,7 +480,7 @@ impl ProjectionPushDown {
                     file_options,
                 };
                 Ok(lp)
-            }
+            },
             Sort {
                 input,
                 by_column,
@@ -515,7 +515,7 @@ impl ProjectionPushDown {
                     by_column,
                     args,
                 })
-            }
+            },
             Distinct { input, options } => {
                 // make sure that the set of unique columns is projected
                 if !acc_projections.is_empty() {
@@ -551,7 +551,7 @@ impl ProjectionPushDown {
                     expr_arena,
                 )?;
                 Ok(Distinct { input, options })
-            }
+            },
             Selection { predicate, input } => {
                 if !acc_projections.is_empty() {
                     // make sure that the filter column is projected
@@ -571,7 +571,7 @@ impl ProjectionPushDown {
                     expr_arena,
                 )?;
                 Ok(Selection { predicate, input })
-            }
+            },
             Aggregate {
                 input,
                 keys,
@@ -682,7 +682,7 @@ impl ProjectionPushDown {
                     contexts,
                     schema: Arc::new(new_schema),
                 })
-            }
+            },
             MapFunction {
                 input,
                 ref function,
@@ -707,7 +707,7 @@ impl ProjectionPushDown {
                     lp_arena,
                     expr_arena,
                 )
-            }
+            },
             // These nodes only have inputs and exprs, so we can use same logic.
             lp @ Slice { .. } | lp @ FileSink { .. } => process_generic(
                 self,
@@ -733,7 +733,7 @@ impl ProjectionPushDown {
                             .build(),
                     )
                 }
-            }
+            },
         }
     }
 

--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -126,7 +126,7 @@ impl OptimizationRule for SimplifyBooleanRule {
             ) =>
             {
                 Some(expr_arena.get(*right).clone())
-            }
+            },
             // x AND true => x
             AExpr::BinaryExpr {
                 left,
@@ -138,7 +138,7 @@ impl OptimizationRule for SimplifyBooleanRule {
             ) =>
             {
                 Some(expr_arena.get(*left).clone())
-            }
+            },
             // x AND false -> false
             AExpr::BinaryExpr {
                 op: Operator::And,
@@ -150,7 +150,7 @@ impl OptimizationRule for SimplifyBooleanRule {
             ) =>
             {
                 Some(AExpr::Literal(LiteralValue::Boolean(false)))
-            }
+            },
             // false AND x -> false
             AExpr::BinaryExpr {
                 left,
@@ -162,7 +162,7 @@ impl OptimizationRule for SimplifyBooleanRule {
             ) =>
             {
                 Some(AExpr::Literal(LiteralValue::Boolean(false)))
-            }
+            },
             // false or x => x
             AExpr::BinaryExpr {
                 left,
@@ -174,7 +174,7 @@ impl OptimizationRule for SimplifyBooleanRule {
             ) =>
             {
                 Some(expr_arena.get(*right).clone())
-            }
+            },
             // x or false => x
             AExpr::BinaryExpr {
                 left,
@@ -187,7 +187,7 @@ impl OptimizationRule for SimplifyBooleanRule {
             ) =>
             {
                 Some(expr_arena.get(*left).clone())
-            }
+            },
 
             // false OR x => x
             AExpr::BinaryExpr {
@@ -200,7 +200,7 @@ impl OptimizationRule for SimplifyBooleanRule {
             ) =>
             {
                 Some(expr_arena.get(*right).clone())
-            }
+            },
 
             // true OR x => true
             AExpr::BinaryExpr {
@@ -213,7 +213,7 @@ impl OptimizationRule for SimplifyBooleanRule {
             ) =>
             {
                 Some(AExpr::Literal(LiteralValue::Boolean(true)))
-            }
+            },
 
             // x OR true => true
             AExpr::BinaryExpr {
@@ -226,7 +226,7 @@ impl OptimizationRule for SimplifyBooleanRule {
             ) =>
             {
                 Some(AExpr::Literal(LiteralValue::Boolean(true)))
-            }
+            },
             AExpr::Ternary {
                 truthy, predicate, ..
             } if matches!(
@@ -235,7 +235,7 @@ impl OptimizationRule for SimplifyBooleanRule {
             ) =>
             {
                 Some(expr_arena.get(*truthy).clone())
-            }
+            },
             AExpr::Ternary {
                 truthy,
                 falsy,
@@ -251,7 +251,7 @@ impl OptimizationRule for SimplifyBooleanRule {
                 } else {
                     Some(AExpr::Alias(*falsy, names[0].clone()))
                 }
-            }
+            },
             AExpr::Function {
                 input,
                 function: FunctionExpr::Boolean(BooleanFunction::IsNot),
@@ -269,10 +269,10 @@ impl OptimizationRule for SimplifyBooleanRule {
                     // not(lit x) => !x
                     AExpr::Literal(LiteralValue::Boolean(b)) => {
                         Some(AExpr::Literal(LiteralValue::Boolean(!b)))
-                    }
+                    },
                     _ => None,
                 }
-            }
+            },
             _ => None,
         };
         Ok(out)
@@ -287,7 +287,7 @@ where
         return match (lit_left, lit_right) {
             (LiteralValue::Boolean(x), LiteralValue::Boolean(y)) => {
                 Some(AExpr::Literal(LiteralValue::Boolean(operation(*x, *y))))
-            }
+            },
             _ => None,
         };
     }
@@ -350,7 +350,7 @@ fn string_addition_to_linear_concat(
                     } else {
                         None
                     }
-                }
+                },
                 // concat + str
                 (
                     AExpr::Function {
@@ -372,7 +372,7 @@ fn string_addition_to_linear_concat(
                     } else {
                         None
                     }
-                }
+                },
                 // str + concat
                 (
                     _,
@@ -395,7 +395,7 @@ fn string_addition_to_linear_concat(
                     } else {
                         None
                     }
-                }
+                },
                 _ => Some(AExpr::Function {
                     input: vec![left_ae, right_ae],
                     function: StringFunction::ConcatHorizontal("".to_string()).into(),
@@ -479,9 +479,9 @@ impl OptimizationRule for SimplifyExprRule {
                                 {
                                     None
                                 }
-                            }
+                            },
                         }
-                    }
+                    },
                     Minus => eval_binary_same_type!(left_aexpr, -, right_aexpr),
                     Multiply => eval_binary_same_type!(left_aexpr, *, right_aexpr),
                     Divide => eval_binary_same_type!(left_aexpr, /, right_aexpr),
@@ -492,10 +492,10 @@ impl OptimizationRule for SimplifyExprRule {
                             match (lit_left, lit_right) {
                                 (LiteralValue::Float32(x), LiteralValue::Float32(y)) => {
                                     Some(AExpr::Literal(LiteralValue::Float32(x / y)))
-                                }
+                                },
                                 (LiteralValue::Float64(x), LiteralValue::Float64(y)) => {
                                     Some(AExpr::Literal(LiteralValue::Float64(x / y)))
-                                }
+                                },
                                 #[cfg(feature = "dtype-i8")]
                                 (LiteralValue::Int8(x), LiteralValue::Int8(y)) => Some(
                                     AExpr::Literal(LiteralValue::Float64(*x as f64 / *y as f64)),
@@ -529,7 +529,7 @@ impl OptimizationRule for SimplifyExprRule {
                         } else {
                             None
                         }
-                    }
+                    },
                     Modulus => eval_binary_same_type!(left_aexpr, %, right_aexpr),
                     Lt => eval_binary_bool_type!(left_aexpr, <, right_aexpr),
                     Gt => eval_binary_bool_type!(left_aexpr, >, right_aexpr),
@@ -591,7 +591,7 @@ impl OptimizationRule for SimplifyExprRule {
                     }),
                     _ => None,
                 }
-            }
+            },
             // sort().reverse() -> sort(reverse)
             // sort_by().reverse() -> sort_by(reverse)
             AExpr::Function {
@@ -608,7 +608,7 @@ impl OptimizationRule for SimplifyExprRule {
                             expr: *expr,
                             options,
                         })
-                    }
+                    },
                     AExpr::SortBy {
                         expr,
                         by,
@@ -621,7 +621,7 @@ impl OptimizationRule for SimplifyExprRule {
                     // TODO: add support for cumsum and other operation that allow reversing.
                     _ => None,
                 }
-            }
+            },
             AExpr::Cast {
                 expr,
                 data_type,
@@ -629,7 +629,7 @@ impl OptimizationRule for SimplifyExprRule {
             } => {
                 let input = expr_arena.get(*expr);
                 inline_cast(input, data_type, *strict)?
-            }
+            },
             // flatten nested concat_str calls
             #[cfg(all(feature = "strings", feature = "concat_str"))]
             AExpr::Function {
@@ -658,7 +658,7 @@ impl OptimizationRule for SimplifyExprRule {
                 } else {
                     None
                 }
-            }
+            },
 
             _ => None,
         };
@@ -676,7 +676,7 @@ fn inline_cast(input: &AExpr, dtype: &DataType, strict: bool) -> PolarsResult<Op
                     s.cast(dtype)
                 }?;
                 LiteralValue::Series(SpecialEq::new(s))
-            }
+            },
             _ => {
                 let Some(av) = lv.to_anyvalue() else {
                     return Ok(None);
@@ -692,7 +692,7 @@ fn inline_cast(input: &AExpr, dtype: &DataType, strict: bool) -> PolarsResult<Op
                     #[cfg(feature = "dtype-categorical")]
                     (AnyValue::Categorical(_, _, _), _) | (_, DataType::Categorical(_)) => {
                         return Ok(None)
-                    }
+                    },
                     #[cfg(feature = "dtype-struct")]
                     (_, DataType::Struct(_)) => return Ok(None),
                     (av, _) => {
@@ -708,9 +708,9 @@ fn inline_cast(input: &AExpr, dtype: &DataType, strict: bool) -> PolarsResult<Op
                             }
                         };
                         out.try_into()?
-                    }
+                    },
                 }
-            }
+            },
         },
         _ => return Ok(None),
     };

--- a/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_expr.rs
@@ -34,7 +34,7 @@ impl OptimizationRule for SlicePushDown {
                     let input = self.scratch[0];
                     let new_input = pushdown(input, offset, length, expr_arena);
                     Some(ae.replace_inputs(&[new_input]))
-                }
+                },
                 Literal(lv) => {
                     match lv {
                         LiteralValue::Series(_) => None,
@@ -42,7 +42,7 @@ impl OptimizationRule for SlicePushDown {
                         // no need to slice a literal value of unit length
                         lv => Some(Literal(lv.clone())),
                     }
-                }
+                },
                 BinaryExpr { left, right, op } => {
                     let left = *left;
                     let right = *right;
@@ -51,7 +51,7 @@ impl OptimizationRule for SlicePushDown {
                     let left = pushdown(left, offset, length, expr_arena);
                     let right = pushdown(right, offset, length, expr_arena);
                     Some(BinaryExpr { left, op, right })
-                }
+                },
                 Ternary {
                     truthy,
                     falsy,
@@ -69,7 +69,7 @@ impl OptimizationRule for SlicePushDown {
                         falsy,
                         predicate,
                     })
-                }
+                },
                 m @ AnonymousFunction { options, .. }
                     if matches!(options.collect_groups, ApplyOptions::ApplyFlat) =>
                 {
@@ -94,7 +94,7 @@ impl OptimizationRule for SlicePushDown {
                     } else {
                         unreachable!()
                     }
-                }
+                },
                 _ => None,
             };
             Ok(out)

--- a/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -39,7 +39,7 @@ impl SlicePushDown {
                     len: state.len,
                 };
                 Ok(lp)
-            }
+            },
             None => Ok(lp),
         }
     }

--- a/crates/polars-plan/src/logical_plan/optimizer/type_coercion/binary.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/type_coercion/binary.rs
@@ -108,7 +108,7 @@ fn process_list_arithmetic(
             } else {
                 Ok(None)
             }
-        }
+        },
         (_, DataType::List(inner)) => {
             if type_left != **inner {
                 let new_node_left = expr_arena.add(AExpr::Cast {
@@ -125,7 +125,7 @@ fn process_list_arithmetic(
             } else {
                 Ok(None)
             }
-        }
+        },
         _ => unreachable!(),
     }
 }
@@ -157,7 +157,7 @@ fn process_struct_numeric_arithmetic(
             } else {
                 Ok(None)
             }
-        }
+        },
         (_, DataType::Struct(fields)) => {
             if let Some(first) = fields.first() {
                 let new_node_left = expr_arena.add(AExpr::Cast {
@@ -174,7 +174,7 @@ fn process_struct_numeric_arithmetic(
             } else {
                 Ok(None)
             }
-        }
+        },
         _ => unreachable!(),
     }
 }
@@ -221,25 +221,25 @@ pub(super) fn process_binary(
             if op.is_comparison() && dt.is_numeric() =>
         {
             return Ok(None)
-        }
+        },
         #[cfg(feature = "dtype-categorical")]
         (Utf8 | Categorical(_), dt, op) | (dt, Utf8 | Categorical(_), op)
             if op.is_comparison() && dt.is_numeric() =>
         {
             return Ok(None)
-        }
+        },
         #[cfg(feature = "dtype-date")]
         (Date, Utf8, op) | (Utf8, Date, op) if op.is_comparison() => err_date_str_compare()?,
         #[cfg(feature = "dtype-datetime")]
         (Datetime(_, _), Utf8, op) | (Utf8, Datetime(_, _), op) if op.is_comparison() => {
             err_date_str_compare()?
-        }
+        },
         #[cfg(feature = "dtype-time")]
         (Time, Utf8, op) if op.is_comparison() => err_date_str_compare()?,
         // structs can be arbitrarily nested, leave the complexity to the caller for now.
         #[cfg(feature = "dtype-struct")]
         (Struct(_), Struct(_), _op) => return Ok(None),
-        _ => {}
+        _ => {},
     }
     let compare_cat_to_string = compares_cat_to_string(&type_left, &type_right, op);
     let datetime_arithmetic = is_datetime_arithmetic(&type_left, &type_right, op);

--- a/crates/polars-plan/src/logical_plan/optimizer/type_coercion/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/type_coercion/mod.rs
@@ -30,124 +30,124 @@ fn shrink_literal(dtype_other: &DataType, literal: &LiteralValue) -> Option<Data
             if *v > 0 {
                 return Some(DataType::UInt64);
             }
-        }
+        },
         (DataType::UInt64, LiteralValue::Int32(v)) => {
             if *v > 0 {
                 return Some(DataType::UInt64);
             }
-        }
+        },
         #[cfg(feature = "dtype-i16")]
         (DataType::UInt64, LiteralValue::Int16(v)) => {
             if *v > 0 {
                 return Some(DataType::UInt64);
             }
-        }
+        },
         #[cfg(feature = "dtype-i8")]
         (DataType::UInt64, LiteralValue::Int8(v)) => {
             if *v > 0 {
                 return Some(DataType::UInt64);
             }
-        }
+        },
         (DataType::UInt32, LiteralValue::Int64(v)) => {
             if *v > 0 && *v < u32::MAX as i64 {
                 return Some(DataType::UInt32);
             }
-        }
+        },
         (DataType::UInt32, LiteralValue::Int32(v)) => {
             if *v > 0 {
                 return Some(DataType::UInt32);
             }
-        }
+        },
         #[cfg(feature = "dtype-i16")]
         (DataType::UInt32, LiteralValue::Int16(v)) => {
             if *v > 0 {
                 return Some(DataType::UInt32);
             }
-        }
+        },
         #[cfg(feature = "dtype-i8")]
         (DataType::UInt32, LiteralValue::Int8(v)) => {
             if *v > 0 {
                 return Some(DataType::UInt32);
             }
-        }
+        },
         (DataType::UInt16, LiteralValue::Int64(v)) => {
             if *v > 0 && *v < u16::MAX as i64 {
                 return Some(DataType::UInt16);
             }
-        }
+        },
         (DataType::UInt16, LiteralValue::Int32(v)) => {
             if *v > 0 && *v < u16::MAX as i32 {
                 return Some(DataType::UInt16);
             }
-        }
+        },
         #[cfg(feature = "dtype-i16")]
         (DataType::UInt16, LiteralValue::Int16(v)) => {
             if *v > 0 {
                 return Some(DataType::UInt16);
             }
-        }
+        },
         #[cfg(feature = "dtype-i8")]
         (DataType::UInt16, LiteralValue::Int8(v)) => {
             if *v > 0 {
                 return Some(DataType::UInt16);
             }
-        }
+        },
         (DataType::UInt8, LiteralValue::Int64(v)) => {
             if *v > 0 && *v < u8::MAX as i64 {
                 return Some(DataType::UInt8);
             }
-        }
+        },
         (DataType::UInt8, LiteralValue::Int32(v)) => {
             if *v > 0 && *v < u8::MAX as i32 {
                 return Some(DataType::UInt8);
             }
-        }
+        },
         #[cfg(feature = "dtype-i16")]
         (DataType::UInt8, LiteralValue::Int16(v)) => {
             if *v > 0 && *v < u8::MAX as i16 {
                 return Some(DataType::UInt8);
             }
-        }
+        },
         #[cfg(feature = "dtype-i8")]
         (DataType::UInt8, LiteralValue::Int8(v)) => {
             if *v > 0 && *v < u8::MAX as i8 {
                 return Some(DataType::UInt8);
             }
-        }
+        },
         (DataType::Int32, LiteralValue::Int64(v)) => {
             if *v <= i32::MAX as i64 {
                 return Some(DataType::Int32);
             }
-        }
+        },
         (DataType::Int16, LiteralValue::Int64(v)) => {
             if *v <= i16::MAX as i64 {
                 return Some(DataType::Int16);
             }
-        }
+        },
         (DataType::Int16, LiteralValue::Int32(v)) => {
             if *v <= i16::MAX as i32 {
                 return Some(DataType::Int16);
             }
-        }
+        },
         (DataType::Int8, LiteralValue::Int64(v)) => {
             if *v <= i8::MAX as i64 {
                 return Some(DataType::Int8);
             }
-        }
+        },
         (DataType::Int8, LiteralValue::Int32(v)) => {
             if *v <= i8::MAX as i32 {
                 return Some(DataType::Int8);
             }
-        }
+        },
         #[cfg(feature = "dtype-i16")]
         (DataType::Int8, LiteralValue::Int16(v)) => {
             if *v <= i8::MAX as i16 {
                 return Some(DataType::Int8);
             }
-        }
+        },
         _ => {
             // the rest is done by supertypes.
-        }
+        },
     }
     None
 }
@@ -176,7 +176,7 @@ fn modify_supertype(
                 Literal(LiteralValue::Float64(_) | LiteralValue::Int32(_) | LiteralValue::Int64(_)),
             ) if matches!(type_left, DataType::Float32) => st = DataType::Float32,
             // always make sure that we cast to floats if one of the operands is float
-            (Literal(lv), _) | (_, Literal(lv)) if lv.is_float() => {}
+            (Literal(lv), _) | (_, Literal(lv)) if lv.is_float() => {},
 
             // TODO: see if we can activate this for columns as well.
             // shrink the literal value if it fits in the column dtype
@@ -184,15 +184,15 @@ fn modify_supertype(
                 if let Some(dtype) = shrink_literal(type_left, lv) {
                     st = dtype;
                 }
-            }
+            },
             // shrink the literal value if it fits in the column dtype
             (Literal(lv), Literal(LiteralValue::Series(_))) => {
                 if let Some(dtype) = shrink_literal(type_right, lv) {
                     st = dtype;
                 }
-            }
+            },
             // do nothing and use supertype
-            (Literal(_), Literal(_)) => {}
+            (Literal(_), Literal(_)) => {},
 
             // cast literal to right type if they fit in the range
             (Literal(value), _) => {
@@ -201,7 +201,7 @@ fn modify_supertype(
                         st = type_right.clone();
                     }
                 }
-            }
+            },
             // cast literal to left type
             (_, Literal(value)) => {
                 if let Some(lit_val) = value.to_anyvalue() {
@@ -209,9 +209,9 @@ fn modify_supertype(
                         st = type_left.clone();
                     }
                 }
-            }
+            },
             // do nothing
-            _ => {}
+            _ => {},
         }
     } else {
         use DataType::*;
@@ -221,7 +221,7 @@ fn modify_supertype(
             (Categorical(_), Utf8, _, AExpr::Literal(_))
             | (Utf8, Categorical(_), AExpr::Literal(_), _) => {
                 st = Categorical(None);
-            }
+            },
             // when then expression literals can have a different list type.
             // so we cast the literal to the other hand side.
             (List(inner), List(other), _, AExpr::Literal(_))
@@ -229,9 +229,9 @@ fn modify_supertype(
                 if inner != other =>
             {
                 st = DataType::List(inner.clone())
-            }
+            },
             // do nothing
-            _ => {}
+            _ => {},
         }
     }
     st
@@ -325,7 +325,7 @@ impl OptimizationRule for TypeCoercionRule {
                     falsy: new_node_falsy,
                     predicate,
                 })
-            }
+            },
             AExpr::BinaryExpr {
                 left: node_left,
                 op,
@@ -359,10 +359,10 @@ impl OptimizationRule for TypeCoercionRule {
                             // does not matter
                             strict: false,
                         }
-                    }
+                    },
                     (dt, DataType::Utf8) => {
                         polars_bail!(ComputeError: "cannot compare {:?} to {:?} type in 'is_in' operation", dt, type_other)
-                    }
+                    },
                     (DataType::List(_), _) | (_, DataType::List(_)) => return Ok(None),
                     #[cfg(feature = "dtype-struct")]
                     (DataType::Struct(_), _) | (_, DataType::Struct(_)) => return Ok(None),
@@ -376,7 +376,7 @@ impl OptimizationRule for TypeCoercionRule {
                             // does not matter
                             strict: false,
                         }
-                    }
+                    },
                     // do nothing
                     _ => return Ok(None),
                 };
@@ -390,7 +390,7 @@ impl OptimizationRule for TypeCoercionRule {
                     input,
                     options,
                 })
-            }
+            },
             // fill null has a supertype set during projection
             // to make the schema known before the optimization phase
             AExpr::Function {
@@ -417,7 +417,7 @@ impl OptimizationRule for TypeCoercionRule {
                 } else {
                     None
                 }
-            }
+            },
             // generic type coercion of any function.
             AExpr::Function {
                 // only for `DataType::Unknown` as it still has to be set.
@@ -497,7 +497,7 @@ impl OptimizationRule for TypeCoercionRule {
                     input: new_nodes,
                     options,
                 })
-            }
+            },
             _ => None,
         };
         Ok(out)

--- a/crates/polars-plan/src/logical_plan/pyarrow.rs
+++ b/crates/polars-plan/src/logical_plan/pyarrow.rs
@@ -26,7 +26,7 @@ pub(super) fn predicate_to_pa(
             } else {
                 None
             }
-        }
+        },
         AExpr::Column(name) => Some(format!("pa.compute.field('{}')", name.as_ref())),
         AExpr::Alias(input, _) => predicate_to_pa(*input, expr_arena, args),
         AExpr::Literal(LiteralValue::Series(s)) => {
@@ -50,7 +50,7 @@ pub(super) fn predicate_to_pa(
 
                 Some(list_repr)
             }
-        }
+        },
         AExpr::Literal(lv) => {
             let av = lv.to_anyvalue()?;
             let dtype = av.dtype();
@@ -63,13 +63,13 @@ pub(super) fn predicate_to_pa(
                     } else {
                         Some("pa.compute.scalar(False)".to_string())
                     }
-                }
+                },
                 #[cfg(feature = "dtype-date")]
                 AnyValue::Date(v) => {
                     // the function `_to_python_date` and the `Date`
                     // dtype have to be in scope on the python side
                     Some(format!("_to_python_date(value={v})"))
-                }
+                },
                 #[cfg(feature = "dtype-datetime")]
                 AnyValue::Datetime(v, tu, tz) => {
                     // the function `_to_python_datetime` and the `Datetime`
@@ -87,7 +87,7 @@ pub(super) fn predicate_to_pa(
                             tz
                         )),
                     }
-                }
+                },
                 // Activate once pyarrow supports them
                 // #[cfg(feature = "dtype-time")]
                 // AnyValue::Time(v) => {
@@ -115,9 +115,9 @@ pub(super) fn predicate_to_pa(
                     } else {
                         None
                     }
-                }
+                },
             }
-        }
+        },
         AExpr::Function {
             function: FunctionExpr::Boolean(BooleanFunction::IsNot),
             input,
@@ -126,7 +126,7 @@ pub(super) fn predicate_to_pa(
             let input = input.first().unwrap();
             let input = predicate_to_pa(*input, expr_arena, args)?;
             Some(format!("~({input})"))
-        }
+        },
         AExpr::Function {
             function: FunctionExpr::Boolean(BooleanFunction::IsNull),
             input,
@@ -135,7 +135,7 @@ pub(super) fn predicate_to_pa(
             let input = input.first().unwrap();
             let input = predicate_to_pa(*input, expr_arena, args)?;
             Some(format!("({input}).is_null()"))
-        }
+        },
         AExpr::Function {
             function: FunctionExpr::Boolean(BooleanFunction::IsNotNull),
             input,
@@ -144,7 +144,7 @@ pub(super) fn predicate_to_pa(
             let input = input.first().unwrap();
             let input = predicate_to_pa(*input, expr_arena, args)?;
             Some(format!("~({input}).is_null()"))
-        }
+        },
         #[cfg(feature = "is_in")]
         AExpr::Function {
             function: FunctionExpr::Boolean(BooleanFunction::IsIn),
@@ -157,7 +157,7 @@ pub(super) fn predicate_to_pa(
             let values = predicate_to_pa(*input.get(1)?, expr_arena, args)?;
 
             Some(format!("({col}).isin({values})"))
-        }
+        },
         _ => None,
     }
 }

--- a/crates/polars-plan/src/logical_plan/schema.rs
+++ b/crates/polars-plan/src/logical_plan/schema.rs
@@ -35,7 +35,7 @@ impl LogicalPlan {
                     Cow::Owned(schema) => Ok(Cow::Owned(function.schema(&schema)?.into_owned())),
                     Cow::Borrowed(schema) => function.schema(schema),
                 }
-            }
+            },
             Error { err, .. } => Err(err.take()),
             ExtContext { schema, .. } => Ok(Cow::Borrowed(schema)),
         }
@@ -91,13 +91,13 @@ pub fn set_estimated_row_counts(
                 .count()
                 + 1;
             set_estimated_row_counts(*input, lp_arena, expr_arena, _filter_count)
-        }
+        },
         Slice { input, len, .. } => {
             let len = *len as usize;
             let mut out = set_estimated_row_counts(*input, lp_arena, expr_arena, _filter_count);
             apply_slice(&mut out, Some((0, len)));
             out
-        }
+        },
         Union { .. } => {
             if let Union {
                 inputs,
@@ -120,7 +120,7 @@ pub fn set_estimated_row_counts(
             } else {
                 unreachable!()
             }
-        }
+        },
         Join { .. } => {
             if let Join {
                 input_left,
@@ -145,17 +145,17 @@ pub fn set_estimated_row_counts(
                     JoinType::Left => {
                         let (known_size, estimated_size) = options.rows_left;
                         (known_size, estimated_size, filter_count_left)
-                    }
+                    },
                     JoinType::Cross | JoinType::Outer => {
                         let (known_size_left, estimated_size_left) = options.rows_left;
                         let (known_size_right, estimated_size_right) = options.rows_right;
                         match (known_size_left, known_size_right) {
                             (Some(l), Some(r)) => {
                                 (Some(l * r), estimated_size_left, estimated_size_right)
-                            }
+                            },
                             _ => (None, estimated_size_left * estimated_size_right, 0),
                         }
-                    }
+                    },
                     _ => {
                         let (known_size_left, estimated_size_left) = options.rows_left;
                         let (known_size_right, estimated_size_right) = options.rows_right;
@@ -164,7 +164,7 @@ pub fn set_estimated_row_counts(
                         } else {
                             (known_size_right, estimated_size_right, 0)
                         }
-                    }
+                    },
                 };
                 apply_slice(&mut out, options.args.slice);
                 lp_arena.replace(
@@ -182,28 +182,28 @@ pub fn set_estimated_row_counts(
             } else {
                 unreachable!()
             }
-        }
+        },
         DataFrameScan { df, .. } => {
             let len = df.height();
             (Some(len), len, _filter_count)
-        }
+        },
         Scan { file_info, .. } => {
             let (known_size, estimated_size) = file_info.row_estimation;
             (known_size, estimated_size, _filter_count)
-        }
+        },
         #[cfg(feature = "python")]
         PythonScan { .. } => {
             // TODO! get row estimation.
             (None, usize::MAX, _filter_count)
-        }
+        },
         AnonymousScan { options, .. } => {
             let size = options.n_rows;
             (size, size.unwrap_or(usize::MAX), _filter_count)
-        }
+        },
         lp => {
             let input = lp.get_input().unwrap();
             set_estimated_row_counts(input, lp_arena, expr_arena, _filter_count)
-        }
+        },
     }
 }
 
@@ -296,6 +296,6 @@ pub(crate) fn det_join_schema(
             }
 
             Ok(Arc::new(new_schema))
-        }
+        },
     }
 }

--- a/crates/polars-plan/src/logical_plan/tree_format.rs
+++ b/crates/polars-plan/src/logical_plan/tree_format.rs
@@ -24,14 +24,14 @@ impl UpperExp for AExpr {
                 } else {
                     write!(f, "cast({})", data_type)
                 }
-            }
+            },
             AExpr::Sort { options, .. } => {
                 return write!(
                     f,
                     "sort: {}{}{}",
                     options.descending as u8, options.nulls_last as u8, options.multithreaded as u8
                 )
-            }
+            },
             AExpr::Take { .. } => "take",
             AExpr::SortBy { descending, .. } => {
                 write!(f, "sort_by:")?;
@@ -39,16 +39,16 @@ impl UpperExp for AExpr {
                     write!(f, "{}", *i as u8)?;
                 }
                 return Ok(());
-            }
+            },
             AExpr::Filter { .. } => "filter",
             AExpr::Agg(a) => {
                 let s: &str = a.into();
                 return write!(f, "{}", s.to_lowercase());
-            }
+            },
             AExpr::Ternary { .. } => "ternary",
             AExpr::AnonymousFunction { options, .. } => {
                 return write!(f, "anonymous_function: {}", options.fmt_str)
-            }
+            },
             AExpr::Function { function, .. } => return write!(f, "function: {function}"),
             AExpr::Window { .. } => "window",
             AExpr::Wildcard => "*",

--- a/crates/polars-plan/src/logical_plan/visitor/expr.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/expr.rs
@@ -14,7 +14,7 @@ impl TreeWalker for Expr {
 
         for child in scratch {
             match op(child)? {
-                VisitRecursion::Continue => {}
+                VisitRecursion::Continue => {},
                 // early stop
                 VisitRecursion::Skip => return Ok(VisitRecursion::Continue),
                 VisitRecursion::Stop => return Ok(VisitRecursion::Stop),
@@ -174,7 +174,7 @@ impl AexprNode {
                     let l = l.as_ref() as *const _ as *const () as usize;
                     let r = r.as_ref() as *const _ as *const () as usize;
                     l == r
-                }
+                },
                 (BinaryExpr { op: l, .. }, BinaryExpr { op: r, .. }) => l == r,
                 _ => false,
             };
@@ -197,7 +197,7 @@ impl AexprNode {
                         if !l.is_equal(&r, scratch1, scratch2) {
                             return false;
                         }
-                    }
+                    },
                     (None, None) => return true,
                     _ => return false,
                 }
@@ -233,7 +233,7 @@ impl TreeWalker for AexprNode {
                 arena: self.arena,
             };
             match op(&aenode)? {
-                VisitRecursion::Continue => {}
+                VisitRecursion::Continue => {},
                 // early stop
                 VisitRecursion::Skip => return Ok(VisitRecursion::Continue),
                 VisitRecursion::Stop => return Ok(VisitRecursion::Stop),

--- a/crates/polars-plan/src/logical_plan/visitor/lp.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/lp.rs
@@ -107,7 +107,7 @@ impl TreeWalker for ALogicalPlanNode {
                 arena: self.arena,
             };
             match op(&lp_node)? {
-                VisitRecursion::Continue => {}
+                VisitRecursion::Continue => {},
                 // early stop
                 VisitRecursion::Skip => return Ok(VisitRecursion::Continue),
                 VisitRecursion::Stop => return Ok(VisitRecursion::Stop),

--- a/crates/polars-plan/src/logical_plan/visitor/visitors.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/visitors.rs
@@ -13,7 +13,7 @@ pub trait TreeWalker: Sized {
     /// Walks all nodes in depth-first-order.
     fn visit(&self, visitor: &mut dyn Visitor<Node = Self>) -> PolarsResult<VisitRecursion> {
         match visitor.pre_visit(self)? {
-            VisitRecursion::Continue => {}
+            VisitRecursion::Continue => {},
             // If the recursion should skip, do not apply to its children. And let the recursion continue
             VisitRecursion::Skip => return Ok(VisitRecursion::Continue),
             // If the recursion should stop, do not apply to its children
@@ -21,7 +21,7 @@ pub trait TreeWalker: Sized {
         };
 
         match self.apply_children(&mut |node| node.visit(visitor))? {
-            VisitRecursion::Continue => {}
+            VisitRecursion::Continue => {},
             // If the recursion should skip, do not apply to its children. And let the recursion continue
             VisitRecursion::Skip => return Ok(VisitRecursion::Continue),
             // If the recursion should stop, do not apply to its children

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -102,7 +102,7 @@ pub(crate) fn aexpr_is_elementwise(current_node: Node, arena: &Arena<AExpr>) -> 
         match e {
             AnonymousFunction { options, .. } | Function { options, .. } => {
                 !matches!(options.collect_groups, ApplyOptions::ApplyGroups)
-            }
+            },
             Column(_)
             | Alias(_, _)
             | Literal(_)
@@ -146,7 +146,7 @@ pub(crate) fn has_leaf_literal(e: &Expr) -> bool {
         _ => {
             let roots = expr_to_root_column_exprs(e);
             roots.iter().any(|e| matches!(e, Expr::Literal(_)))
-        }
+        },
     }
 }
 
@@ -173,7 +173,7 @@ pub fn expr_output_name(expr: &Expr) -> PolarsResult<Arc<str>> {
                 "this expression may produce multiple output names"
             ),
             Expr::Count => return Ok(Arc::from(COUNT)),
-            _ => {}
+            _ => {},
         }
     }
     polars_bail!(
@@ -192,7 +192,7 @@ pub(crate) fn get_single_leaf(expr: &Expr) -> PolarsResult<Arc<str>> {
             Expr::SortBy { expr, .. } => return get_single_leaf(expr),
             Expr::Window { function, .. } => return get_single_leaf(function),
             Expr::Column(name) => return Ok(name.clone()),
-            _ => {}
+            _ => {},
         }
     }
     polars_bail!(
@@ -290,7 +290,7 @@ pub(crate) fn rename_matching_aexpr_leaf_names(
             Expr::Column(name) if &**name == current => {
                 *name = Arc::from(new_name);
                 true
-            }
+            },
             _ => true,
         });
         to_aexpr(new_expr, arena)
@@ -313,8 +313,8 @@ pub(crate) fn aexpr_assign_renamed_leaf(
         match arena.get(node) {
             AExpr::Column(name) if &**name == current => {
                 return arena.add(AExpr::Column(Arc::from(new_name)))
-            }
-            _ => {}
+            },
+            _ => {},
         }
     }
     panic!("should be a root column that is renamed");
@@ -326,8 +326,8 @@ pub(crate) fn expr_to_root_column_exprs(expr: &Expr) -> Vec<Expr> {
     expr.into_iter().for_each(|e| match e {
         Expr::Column(_) | Expr::Wildcard => {
             out.push(e.clone());
-        }
-        _ => {}
+        },
+        _ => {},
     });
     out
 }
@@ -353,7 +353,7 @@ pub fn aexpr_to_leaf_names_iter(
         AExpr::Column(name) => name.clone(),
         e => {
             panic!("{e:?} not expected")
-        }
+        },
     })
 }
 

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -55,18 +55,18 @@ unsafe fn decode(rows: &mut [&[u8]], field: &SortField, data_type: &DataType) ->
                 arr.validity().cloned(),
             )
             .to_boxed()
-        }
+        },
         DataType::Struct(fields) => {
             let values = fields
                 .iter()
                 .map(|struct_fld| decode(rows, field, struct_fld.data_type()))
                 .collect();
             StructArray::new(data_type.clone(), values, None).to_boxed()
-        }
+        },
         dt => {
             with_match_arrow_primitive_type!(dt, |$T| {
                 decode_primitive::<$T>(rows, field).to_boxed()
             })
-        }
+        },
     }
 }

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -52,17 +52,17 @@ pub fn convert_columns_amortized<'a, I: IntoIterator<Item = &'a SortField>>(
                         flattened_columns.push(arr.clone() as ArrayRef);
                         flattened_fields.push(field.clone())
                     }
-                }
+                },
                 DataType::LargeUtf8 => {
                     flattened_columns.push(
                         cast(arr.as_ref(), &DataType::LargeBinary, Default::default()).unwrap(),
                     );
                     flattened_fields.push(field.clone());
-                }
+                },
                 _ => {
                     flattened_columns.push(arr.clone());
                     flattened_fields.push(field.clone());
-                }
+                },
             }
         }
         let values_size =
@@ -109,14 +109,14 @@ unsafe fn encode_array(array: &dyn Array, field: &SortField, out: &mut RowsEncod
         DataType::Boolean => {
             let array = array.as_any().downcast_ref::<BooleanArray>().unwrap();
             crate::fixed::encode_iter(array.into_iter(), out, field);
-        }
+        },
         DataType::LargeBinary => {
             let array = array.as_any().downcast_ref::<BinaryArray<i64>>().unwrap();
             crate::variable::encode_iter(array.into_iter(), out, field)
-        }
+        },
         DataType::LargeUtf8 => {
             panic!("should be cast to binary")
-        }
+        },
         DataType::Dictionary(_, _, _) => {
             let array = array
                 .as_any()
@@ -127,13 +127,13 @@ unsafe fn encode_array(array: &dyn Array, field: &SortField, out: &mut RowsEncod
                 .unwrap()
                 .map(|opt_s| opt_s.map(|s| s.as_bytes()));
             crate::variable::encode_iter(iter, out, field)
-        }
+        },
         dt => {
             with_match_arrow_primitive_type!(dt, |$T| {
                 let array = array.as_any().downcast_ref::<PrimitiveArray<$T>>().unwrap();
                 encode_primitive(array, field, out);
             })
-        }
+        },
     };
 }
 
@@ -213,7 +213,7 @@ pub fn allocate_rows_buf(
                         }
                     }
                     processed_count += 1;
-                }
+                },
                 ArrowDataType::Dictionary(_, _, _) => {
                     let array = array
                         .as_any()
@@ -237,10 +237,10 @@ pub fn allocate_rows_buf(
                         }
                     }
                     processed_count += 1;
-                }
+                },
                 _ => {
                     // the rest is fixed
-                }
+                },
             }
         }
         // now we use the lengths and the same buffer to determine the offsets

--- a/crates/polars-row/src/variable.rs
+++ b/crates/polars-row/src/variable.rs
@@ -78,7 +78,7 @@ unsafe fn encode_one(
             };
             *out.get_unchecked_release_mut(0) = MaybeUninit::new(byte);
             1
-        }
+        },
         Some(val) => {
             let block_count = ceil(val.len(), BLOCK_SIZE);
             let end_offset = 1 + block_count * (BLOCK_SIZE + 1);
@@ -138,13 +138,13 @@ unsafe fn encode_one(
                 }
             }
             end_offset
-        }
+        },
         None => {
             *out.get_unchecked_release_mut(0) = MaybeUninit::new(get_null_sentinel(field));
             // // write remainder as zeros
             // out.get_unchecked_release_mut(1..).fill(MaybeUninit::new(0));
             1
-        }
+        },
     }
 }
 pub(crate) unsafe fn encode_iter<'a, I: Iterator<Item = Option<&'a [u8]>>>(

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -159,7 +159,7 @@ impl SQLContext {
             } => self.process_union(left, right, set_quantifier, query),
             SetExpr::SetOperation { op, .. } => {
                 polars_bail!(InvalidOperation: "{} operation not yet supported", op)
-            }
+            },
             op => polars_bail!(InvalidOperation: "{} operation not yet supported", op),
         }
     }
@@ -198,7 +198,7 @@ impl SQLContext {
 
                 let df = DataFrame::new(vec![plan])?;
                 Ok(df.lazy())
-            }
+            },
             _ => unreachable!(),
         }
     }
@@ -217,7 +217,7 @@ impl SQLContext {
                     self.table_map.remove(&name.to_string());
                 }
                 Ok(DataFrame::empty().lazy())
-            }
+            },
             _ => unreachable!(),
         }
     }
@@ -247,24 +247,24 @@ impl SQLContext {
                         let (left_on, right_on) =
                             process_join_constraint(constraint, &tbl_name, &join_tbl_name)?;
                         lf = lf.inner_join(join_tbl, left_on, right_on)
-                    }
+                    },
                     JoinOperator::LeftOuter(constraint) => {
                         let (left_on, right_on) =
                             process_join_constraint(constraint, &tbl_name, &join_tbl_name)?;
                         lf = lf.left_join(join_tbl, left_on, right_on)
-                    }
+                    },
                     JoinOperator::FullOuter(constraint) => {
                         let (left_on, right_on) =
                             process_join_constraint(constraint, &tbl_name, &join_tbl_name)?;
                         lf = lf.outer_join(join_tbl, left_on, right_on)
-                    }
+                    },
                     JoinOperator::CrossJoin => lf = lf.cross_join(join_tbl),
                     join_type => {
                         polars_bail!(
                             InvalidOperation:
                             "join type '{:?}' not yet supported by polars-sql", join_type
                         );
-                    }
+                    },
                 }
             }
         };
@@ -288,7 +288,7 @@ impl SQLContext {
             Some(expr) => {
                 let filter_expression = parse_sql_expr(expr, self)?;
                 lf.filter(filter_expression)
-            }
+            },
             None => lf,
         };
 
@@ -302,15 +302,15 @@ impl SQLContext {
                     SelectItem::ExprWithAlias { expr, alias } => {
                         let expr = parse_sql_expr(expr, self)?;
                         expr.alias(&alias.value)
-                    }
+                    },
                     SelectItem::QualifiedWildcard(oname, wildcard_options) => {
                         self.process_qualified_wildcard(oname, wildcard_options)?
-                    }
+                    },
                     SelectItem::Wildcard(wildcard_options) => {
                         contains_wildcard = true;
                         let e = col("*");
                         self.process_wildcard_additional_options(e, wildcard_options)?
-                    }
+                    },
                 })
             })
             .collect::<PolarsResult<_>>()?;
@@ -331,7 +331,7 @@ impl SQLContext {
                         Ok(idx) => Ok(idx),
                     }?;
                     Ok(projections[idx].clone())
-                }
+                },
                 SqlExpr::Value(_) => Err(polars_err!(
                     ComputeError:
                     "groupby error: a positive number or an expression expected",
@@ -377,7 +377,7 @@ impl SQLContext {
                     lf = self.process_order_by(lf, &query.order_by)?;
                 }
                 return Ok(lf.unique_stable(Some(cols), UniqueKeepStrategy::First));
-            }
+            },
             None => lf,
         };
 
@@ -436,7 +436,7 @@ impl SQLContext {
                 } else {
                     polars_bail!(ComputeError: "relation '{}' was not found", tbl_name);
                 }
-            }
+            },
             // Support bare table, optional with alias for now
             _ => polars_bail!(ComputeError: "not implemented"),
         }
@@ -599,7 +599,7 @@ impl SQLContext {
                 })?;
                 let schema = lf.schema()?;
                 cols(schema.iter_names())
-            }
+            },
             e => polars_bail!(
                 ComputeError: "Invalid wildcard expression: {:?}",
                 e
@@ -620,7 +620,7 @@ impl SQLContext {
             Some(ExcludeSelectItem::Single(ident)) => expr.exclude(vec![&ident.value]),
             Some(ExcludeSelectItem::Multiple(idents)) => {
                 expr.exclude(idents.iter().map(|i| &i.value))
-            }
+            },
             _ => expr,
         })
     }

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -698,7 +698,7 @@ impl SqlFunctionVisitor<'_> {
         match self.func.over.as_ref() {
             Some(WindowType::WindowSpec(spec)) => {
                 self.apply_cumulative_window(f, cumulative_f, spec)
-            }
+            },
             Some(WindowType::NamedWindow(named_window)) => polars_bail!(
                 InvalidOperation: "Named windows are not supported yet. Got {:?}",
                 named_window
@@ -746,7 +746,7 @@ impl SqlFunctionVisitor<'_> {
                 let expr = parse_sql_expr(sql_expr, self.ctx)?;
                 // apply the function on the inner expr -- e.g. SUM(a) -> SUM
                 Ok(f(expr))
-            }
+            },
             _ => self.not_supported_error(),
         }
     }
@@ -766,7 +766,7 @@ impl SqlFunctionVisitor<'_> {
                 let expr1 = parse_sql_expr(sql_expr1, self.ctx)?;
                 let expr2 = Arg::from_sql_expr(sql_expr2, self.ctx)?;
                 f(expr1, expr2)
-            }
+            },
             _ => self.not_supported_error(),
         }
     }
@@ -791,7 +791,7 @@ impl SqlFunctionVisitor<'_> {
                 let expr2 = Arg::from_sql_expr(sql_expr2, self.ctx)?;
                 let expr3 = Arg::from_sql_expr(sql_expr3, self.ctx)?;
                 f(expr1, expr2, expr3)
-            }
+            },
             _ => self.not_supported_error(),
         }
     }
@@ -814,7 +814,7 @@ impl SqlFunctionVisitor<'_> {
                 let expr =
                     self.apply_window_spec(parse_sql_expr(sql_expr, self.ctx)?, &self.func.over)?;
                 Ok(expr.count())
-            }
+            },
             // count(*)
             (false, [FunctionArgExpr::Wildcard]) => Ok(count()),
             // count(distinct column_name)
@@ -822,7 +822,7 @@ impl SqlFunctionVisitor<'_> {
                 let expr =
                     self.apply_window_spec(parse_sql_expr(sql_expr, self.ctx)?, &self.func.over)?;
                 Ok(expr.n_unique())
-            }
+            },
             _ => self.not_supported_error(),
         }
     }
@@ -856,7 +856,7 @@ impl SqlFunctionVisitor<'_> {
                         .collect::<PolarsResult<Vec<_>>>()?;
                     expr.over(partition_by)
                 }
-            }
+            },
             Some(WindowType::NamedWindow(named_window)) => polars_bail!(
                 InvalidOperation: "Named windows are not supported yet. Got: {:?}",
                 named_window

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -18,11 +18,11 @@ pub(crate) fn map_sql_polars_datatype(data_type: &SQLDataType) -> PolarsResult<D
     Ok(match data_type {
         SQLDataType::Array(Some(inner_type)) => {
             DataType::List(Box::new(map_sql_polars_datatype(inner_type)?))
-        }
+        },
         SQLDataType::BigInt(_) => DataType::Int64,
         SQLDataType::Binary(_) | SQLDataType::Blob(_) | SQLDataType::Varbinary(_) => {
             DataType::Binary
-        }
+        },
         SQLDataType::Boolean => DataType::Boolean,
         SQLDataType::Char(_)
         | SQLDataType::CharVarying(_)
@@ -83,10 +83,10 @@ impl SqlExprVisitor<'_> {
             } => self.visit_is_in(expr, list, *negated),
             SqlExpr::IsDistinctFrom(e1, e2) => {
                 Ok(self.visit_expr(e1)?.neq_missing(self.visit_expr(e2)?))
-            }
+            },
             SqlExpr::IsNotDistinctFrom(e1, e2) => {
                 Ok(self.visit_expr(e1)?.eq_missing(self.visit_expr(e2)?))
-            }
+            },
             SqlExpr::IsFalse(expr) => Ok(self.visit_expr(expr)?.eq(lit(false))),
             SqlExpr::IsNotFalse(expr) => Ok(self.visit_expr(expr)?.eq(lit(false)).not()),
             SqlExpr::IsNotNull(expr) => Ok(self.visit_expr(expr)?.is_not_null()),
@@ -104,7 +104,7 @@ impl SqlExprVisitor<'_> {
             e @ SqlExpr::Case { .. } => self.visit_when_then(e),
             other => {
                 polars_bail!(InvalidOperation: "SQL expression {:?} is not yet supported", other)
-            }
+            },
         }
     }
 
@@ -131,7 +131,7 @@ impl SqlExprVisitor<'_> {
                         tbl_name
                     )
                 }
-            }
+            },
             _ => polars_bail!(
                 ComputeError: "Invalid identifier {:?}",
                 idents
@@ -185,7 +185,7 @@ impl SqlExprVisitor<'_> {
             SQLBinaryOperator::Spaceship => left.eq_missing(right),
             SQLBinaryOperator::StringConcat => {
                 left.cast(DataType::Utf8) + right.cast(DataType::Utf8)
-            }
+            },
             SQLBinaryOperator::Xor => left.xor(right),
             // ----
             // Regular expression operators
@@ -201,13 +201,13 @@ impl SqlExprVisitor<'_> {
             SQLBinaryOperator::PGRegexIMatch => match right {
                 Expr::Literal(LiteralValue::Utf8(pat)) => {
                     left.str().contains(lit(format!("(?i){}", pat)), true)
-                }
+                },
                 _ => polars_bail!(ComputeError: "Invalid pattern for '~*' operator: {:?}", right),
             },
             SQLBinaryOperator::PGRegexNotIMatch => match right {
                 Expr::Literal(LiteralValue::Utf8(pat)) => {
                     left.str().contains(lit(format!("(?i){}", pat)), true).not()
-                }
+                },
                 _ => polars_bail!(ComputeError: "Invalid pattern for '!~*' operator: {:?}", right),
             },
             other => polars_bail!(ComputeError: "SQL operator {:?} is not yet supported", other),
@@ -257,7 +257,7 @@ impl SqlExprVisitor<'_> {
                     s.parse::<i64>().map(lit).map_err(|_| ())
                 }
                 .map_err(|_| polars_err!(ComputeError: "cannot parse literal: {:?}", s))?
-            }
+            },
             SqlValue::SingleQuotedString(s) => lit(s.clone()),
             other => polars_bail!(ComputeError: "SQL value {:?} is not yet supported", other),
         })
@@ -276,7 +276,7 @@ impl SqlExprVisitor<'_> {
                     s.parse::<i64>().map(AnyValue::Int64).map_err(|_| ())
                 }
                 .map_err(|_| polars_err!(ComputeError: "cannot parse literal: {:?}"))?
-            }
+            },
             SqlValue::SingleQuotedString(s)
             | SqlValue::NationalStringLiteral(s)
             | SqlValue::HexStringLiteral(s)
@@ -514,11 +514,11 @@ pub(super) fn process_join_constraint(
                         }
                     }
                 }
-            }
+            },
             (SqlExpr::Identifier(left), SqlExpr::Identifier(right)) => {
                 return Ok((col(&left.value), col(&right.value)))
-            }
-            _ => {}
+            },
+            _ => {},
         }
     }
     if let JoinConstraint::Using(idents) = constraint {
@@ -563,7 +563,7 @@ pub fn sql_expr<S: AsRef<str>>(s: S) -> PolarsResult<Expr> {
         SelectItem::ExprWithAlias { expr, alias } => {
             let expr = parse_sql_expr(expr, &ctx)?;
             expr.alias(&alias.value)
-        }
+        },
         SelectItem::UnnamedExpr(expr) => parse_sql_expr(expr, &ctx)?,
         _ => polars_bail!(InvalidOperation: "Unable to parse '{}' as Expr", s.as_ref()),
     })

--- a/crates/polars-time/src/chunkedarray/rolling_window/floats.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/floats.rs
@@ -138,11 +138,11 @@ where
                 DataType::Float32 => {
                     let ca: &mut ChunkedArray<Float32Type> = s._get_inner_mut().as_mut();
                     ca.apply_mut(|v| v.powf(0.5))
-                }
+                },
                 DataType::Float64 => {
                     let ca: &mut ChunkedArray<Float64Type> = s._get_inner_mut().as_mut();
                     ca.apply_mut(|v| v.powf(0.5))
-                }
+                },
                 _ => unreachable!(),
             }
             s

--- a/crates/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/crates/polars-time/src/chunkedarray/utf8/infer.rs
@@ -364,7 +364,7 @@ impl<T: PolarsNumericType> DatetimeInfer<T> {
                     }
                 }
                 None
-            }
+            },
         }
     }
 }
@@ -529,7 +529,7 @@ pub(crate) fn to_datetime(
                     }
                 })?,
             }
-        }
+        },
     }
 }
 #[cfg(feature = "dtype-date")]
@@ -544,6 +544,6 @@ pub(crate) fn to_date(ca: &Utf8Chunked) -> PolarsResult<DateChunked> {
                 .ok_or_else(|| polars_err!(parse_fmt_idk = "date"))?;
             let mut infer = DatetimeInfer::<Int32Type>::try_from_with_unit(pattern, None).unwrap();
             infer.coerce_utf8(ca).date().cloned()
-        }
+        },
     }
 }

--- a/crates/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/crates/polars-time/src/chunkedarray/utf8/mod.rs
@@ -209,16 +209,16 @@ pub trait Utf8Methods: AsUtf8 {
                                 match e.0 {
                                     ParseErrorKind::TooLong => {
                                         s = &s[..s.len() - 1];
-                                    }
+                                    },
                                     _ => {
                                         s = &s[i..];
-                                    }
+                                    },
                                 }
-                            }
+                            },
                         }
                     }
                     None
-                }
+                },
             })
             .collect_trusted();
         ca.rename(utf8_ca.name());
@@ -270,16 +270,16 @@ pub trait Utf8Methods: AsUtf8 {
                                 match e.0 {
                                     ParseErrorKind::TooLong => {
                                         s = &s[..s.len() - 1];
-                                    }
+                                    },
                                     _ => {
                                         s = &s[i..];
-                                    }
+                                    },
                                 }
-                            }
+                            },
                         }
                     }
                     None
-                }
+                },
             })
             .collect_trusted();
         ca.rename(utf8_ca.name());
@@ -287,7 +287,7 @@ pub trait Utf8Methods: AsUtf8 {
             #[cfg(feature = "timezones")]
             (false, Some(tz)) => {
                 polars_ops::prelude::replace_time_zone(&ca.into_datetime(tu, None), Some(tz), None)
-            }
+            },
             #[cfg(feature = "timezones")]
             (true, _) => Ok(ca.into_datetime(tu, Some("UTC".to_string()))),
             _ => Ok(ca.into_datetime(tu, None)),
@@ -417,7 +417,7 @@ pub trait Utf8Methods: AsUtf8 {
                                             let value = convert(s);
                                             entry.insert(value);
                                             value
-                                        }
+                                        },
                                         Entry::Occupied(val) => *val.get(),
                                     }
                                 } else {

--- a/crates/polars-time/src/chunkedarray/utf8/strptime.rs
+++ b/crates/polars-time/src/chunkedarray/utf8/strptime.rs
@@ -129,28 +129,28 @@ impl StrpTimeState {
                         if negative {
                             year *= -1
                         }
-                    }
+                    },
                     b'm' => {
                         (month, offset) = update_and_parse(2, offset, val)?;
                         if month > 12 {
                             return None;
                         }
-                    }
+                    },
                     b'b' => {
                         (month, offset) = parse_month_abbrev(val, offset)?;
-                    }
+                    },
                     b'd' => {
                         (day, offset) = update_and_parse(2, offset, val)?;
-                    }
+                    },
                     b'H' => {
                         (hour, offset) = update_and_parse(2, offset, val)?;
-                    }
+                    },
                     b'M' => {
                         (min, offset) = update_and_parse(2, offset, val)?;
-                    }
+                    },
                     b'S' => {
                         (sec, offset) = update_and_parse(2, offset, val)?;
-                    }
+                    },
                     b'y' => {
                         let new_offset = offset + 2;
                         let bytes = val.get_unchecked_release(offset..new_offset);
@@ -166,21 +166,21 @@ impl StrpTimeState {
                             year = 1900 + decade;
                         }
                         offset = new_offset;
-                    }
+                    },
                     b'9' => {
                         (nano, offset) = update_and_parse(9, offset, val)?;
                         break;
-                    }
+                    },
                     b'6' => {
                         (nano, offset) = update_and_parse(6, offset, val)?;
                         nano *= 1000;
                         break;
-                    }
+                    },
                     b'3' => {
                         (nano, offset) = update_and_parse(3, offset, val)?;
                         nano *= 1_000_000;
                         break;
-                    }
+                    },
                     _ => return None,
                 }
             }
@@ -222,22 +222,22 @@ pub(super) fn fmt_len(fmt: &[u8]) -> Option<u16> {
                     cnt += 9;
                     debug_assert_eq!(iter.next(), Some(&b'f'));
                     return Some(cnt);
-                }
+                },
                 b'6' => {
                     cnt += 6;
                     debug_assert_eq!(iter.next(), Some(&b'f'));
                     return Some(cnt);
-                }
+                },
                 b'3' => {
                     cnt += 3;
                     debug_assert_eq!(iter.next(), Some(&b'f'));
                     return Some(cnt);
-                }
+                },
                 _ => return None,
             },
             _ => {
                 cnt += 1;
-            }
+            },
         }
     }
     Some(cnt)

--- a/crates/polars-time/src/date_range.rs
+++ b/crates/polars-time/src/date_range.rs
@@ -39,7 +39,7 @@ pub fn date_range_impl(
                     temporal_range_vec(start?, stop?, every, closed, tu, Some(&tz))?,
                 )
                 .into_datetime(tu, _tz.cloned())
-            }
+            },
             Err(_) => polars_bail!(ComputeError: "unable to parse time zone: '{}'", tz),
         },
         _ => Int64Chunked::new_vec(

--- a/crates/polars-time/src/groupby/dynamic.rs
+++ b/crates/polars-time/src/groupby/dynamic.rs
@@ -165,7 +165,7 @@ impl Wrap<&DataFrame> {
                 )?;
                 let out = out.cast(&Int64).unwrap().cast(&Int32).unwrap();
                 return Ok((out, by, gt));
-            }
+            },
             Int64 => {
                 let time_type = Datetime(TimeUnit::Nanoseconds, None);
                 let dt = time.cast(&time_type).unwrap();
@@ -179,7 +179,7 @@ impl Wrap<&DataFrame> {
                 )?;
                 let out = out.cast(&Int64).unwrap();
                 return Ok((out, by, gt));
-            }
+            },
             dt => polars_bail!(
                 ComputeError:
                 "expected any of the following dtypes: {{ Date, Datetime, Int32, Int64 }}, got {}",
@@ -190,7 +190,7 @@ impl Wrap<&DataFrame> {
             #[cfg(feature = "timezones")]
             Some(tz) => {
                 self.impl_groupby_rolling(dt, by, options, tu, tz.parse::<Tz>().ok(), time_type)
-            }
+            },
             _ => self.impl_groupby_rolling(dt, by, options, tu, None, time_type),
         }
     }
@@ -239,7 +239,7 @@ impl Wrap<&DataFrame> {
                     }
                 }
                 return Ok((out, keys, gt));
-            }
+            },
             Int64 => {
                 let time_type = Datetime(TimeUnit::Nanoseconds, None);
                 let dt = time.cast(&time_type).unwrap();
@@ -252,7 +252,7 @@ impl Wrap<&DataFrame> {
                     }
                 }
                 return Ok((out, keys, gt));
-            }
+            },
             dt => polars_bail!(
                 ComputeError:
                 "expected any of the following dtypes: {{ Date, Datetime, Int32, Int64 }}, got {}",
@@ -302,11 +302,11 @@ impl Wrap<&DataFrame> {
                 (None, None) => {
                     lower_bound = Some(lower);
                     upper_bound = Some(upper);
-                }
+                },
                 (Some(lower_bound), Some(upper_bound)) => {
                     lower_bound.extend_from_slice(&lower);
                     upper_bound.extend_from_slice(&upper);
-                }
+                },
                 _ => unreachable!(),
             };
 
@@ -375,7 +375,7 @@ impl Wrap<&DataFrame> {
 
                         // then parallelize the flatten in the `from` impl
                         Ok(GroupsProxy::Idx(GroupsIdx::from(groups)))
-                    }
+                    },
                     GroupsProxy::Slice { groups, .. } => {
                         let mut ir = groups
                             .par_iter()
@@ -412,7 +412,7 @@ impl Wrap<&DataFrame> {
                             groups,
                             rolling: false,
                         })
-                    }
+                    },
                 })
             } else {
                 POOL.install(|| match groups {
@@ -442,7 +442,7 @@ impl Wrap<&DataFrame> {
                             })
                             .collect::<PolarsResult<Vec<_>>>()?;
                         Ok(GroupsProxy::Idx(GroupsIdx::from(groupsidx)))
-                    }
+                    },
                     GroupsProxy::Slice { groups, .. } => {
                         let groups = groups
                             .par_iter()
@@ -470,7 +470,7 @@ impl Wrap<&DataFrame> {
                             groups,
                             rolling: false,
                         })
-                    }
+                    },
                 })
             }
         }?;
@@ -586,7 +586,7 @@ impl Wrap<&DataFrame> {
                         .collect::<PolarsResult<Vec<_>>>()?;
 
                     Ok(GroupsProxy::Idx(GroupsIdx::from(idx)))
-                }
+                },
                 GroupsProxy::Slice { groups, .. } => {
                     let slice_groups = groups
                         .par_iter()
@@ -611,7 +611,7 @@ impl Wrap<&DataFrame> {
                         groups: slice_groups,
                         rolling: false,
                     })
-                }
+                },
             })
         }?;
 

--- a/crates/polars-time/src/month_end.rs
+++ b/crates/polars-time/src/month_end.rs
@@ -38,17 +38,17 @@ impl PolarsMonthEnd for DatetimeChunked {
                 timestamp_to_datetime = timestamp_ns_to_datetime;
                 datetime_to_timestamp = datetime_to_timestamp_ns;
                 offset_fn = Duration::add_ns;
-            }
+            },
             TimeUnit::Microseconds => {
                 timestamp_to_datetime = timestamp_us_to_datetime;
                 datetime_to_timestamp = datetime_to_timestamp_us;
                 offset_fn = Duration::add_us;
-            }
+            },
             TimeUnit::Milliseconds => {
                 timestamp_to_datetime = timestamp_ms_to_datetime;
                 datetime_to_timestamp = datetime_to_timestamp_ms;
                 offset_fn = Duration::add_ms;
-            }
+            },
         };
         Ok(self
             .0

--- a/crates/polars-time/src/month_start.rs
+++ b/crates/polars-time/src/month_start.rs
@@ -63,15 +63,15 @@ impl PolarsMonthStart for DatetimeChunked {
             TimeUnit::Nanoseconds => {
                 timestamp_to_datetime = timestamp_ns_to_datetime;
                 datetime_to_timestamp = datetime_to_timestamp_ns;
-            }
+            },
             TimeUnit::Microseconds => {
                 timestamp_to_datetime = timestamp_us_to_datetime;
                 datetime_to_timestamp = datetime_to_timestamp_us;
-            }
+            },
             TimeUnit::Milliseconds => {
                 timestamp_to_datetime = timestamp_ms_to_datetime;
                 datetime_to_timestamp = datetime_to_timestamp_ms;
-            }
+            },
         };
         Ok(self
             .0

--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -199,12 +199,12 @@ fn upsample_single_impl(
                         &[index_col_name],
                         JoinArgs::new(JoinType::Left),
                     )
-                }
+                },
                 _ => polars_bail!(
                     ComputeError: "cannot determine upsample boundaries: all elements are null"
                 ),
             }
-        }
+        },
         dt => polars_bail!(
             ComputeError: "upsample not allowed for index column of dtype {}", dt,
         ),

--- a/crates/polars-time/src/utils.rs
+++ b/crates/polars-time/src/utils.rs
@@ -34,7 +34,7 @@ pub(crate) fn localize_datetime(
             polars_bail!(
                 ComputeError: format!("datetime '{}' is non-existent in time zone '{}'. Non-existent datetimes are not yet supported", ndt, tz)
             )
-        }
+        },
     }
 }
 
@@ -52,19 +52,19 @@ pub(crate) fn localize_timestamp(timestamp: i64, tu: TimeUnit, tz: Tz) -> Polars
                 localize_datetime(timestamp_ns_to_datetime(timestamp), &tz, None)?
                     .timestamp_nanos(),
             )
-        }
+        },
         TimeUnit::Microseconds => {
             Ok(
                 localize_datetime(timestamp_us_to_datetime(timestamp), &tz, None)?
                     .timestamp_micros(),
             )
-        }
+        },
         TimeUnit::Milliseconds => {
             Ok(
                 localize_datetime(timestamp_ms_to_datetime(timestamp), &tz, None)?
                     .timestamp_millis(),
             )
-        }
+        },
     }
 }
 
@@ -73,12 +73,12 @@ pub(crate) fn unlocalize_timestamp(timestamp: i64, tu: TimeUnit, tz: Tz) -> i64 
     match tu {
         TimeUnit::Nanoseconds => {
             unlocalize_datetime(timestamp_ns_to_datetime(timestamp), &tz).timestamp_nanos()
-        }
+        },
         TimeUnit::Microseconds => {
             unlocalize_datetime(timestamp_us_to_datetime(timestamp), &tz).timestamp_micros()
-        }
+        },
         TimeUnit::Milliseconds => {
             unlocalize_datetime(timestamp_ms_to_datetime(timestamp), &tz).timestamp_millis()
-        }
+        },
     }
 }

--- a/crates/polars-time/src/windows/calendar.rs
+++ b/crates/polars-time/src/windows/calendar.rs
@@ -51,15 +51,15 @@ pub fn temporal_range(
         TimeUnit::Nanoseconds => {
             size = ((stop - start) / every.duration_ns() + 1) as usize;
             offset_fn = Duration::add_ns;
-        }
+        },
         TimeUnit::Microseconds => {
             size = ((stop - start) / every.duration_us() + 1) as usize;
             offset_fn = Duration::add_us;
-        }
+        },
         TimeUnit::Milliseconds => {
             size = ((stop - start) / every.duration_ms() + 1) as usize;
             offset_fn = Duration::add_ms;
-        }
+        },
     }
     let mut ts = Vec::with_capacity(size);
 
@@ -70,27 +70,27 @@ pub fn temporal_range(
                 ts.push(t);
                 t = offset_fn(&every, t, tz)?
             }
-        }
+        },
         ClosedWindow::Left => {
             while t < stop {
                 ts.push(t);
                 t = offset_fn(&every, t, tz)?
             }
-        }
+        },
         ClosedWindow::Right => {
             t = offset_fn(&every, t, tz)?;
             while t <= stop {
                 ts.push(t);
                 t = offset_fn(&every, t, tz)?
             }
-        }
+        },
         ClosedWindow::None => {
             t = offset_fn(&every, t, tz)?;
             while t < stop {
                 ts.push(t);
                 t = offset_fn(&every, t, tz)?
             }
-        }
+        },
     }
     debug_assert!(size >= ts.len());
     Ok(ts)

--- a/crates/polars-time/src/windows/duration.rs
+++ b/crates/polars-time/src/windows/duration.rs
@@ -155,10 +155,10 @@ impl Duration {
                         Some((i, ch_)) => {
                             ch = ch_;
                             start = i
-                        }
+                        },
                         None => {
                             break;
-                        }
+                        },
                     }
                 }
                 if unit.is_empty() {
@@ -218,7 +218,7 @@ impl Duration {
 
             match (self.negative, interval.negative) {
                 (true, true) | (true, false) => months = -months + interval.months(),
-                _ => {}
+                _ => {},
             }
             Duration::from_months(months)
         } else if self.weeks_only() && interval.weeks_only() {
@@ -226,7 +226,7 @@ impl Duration {
 
             match (self.negative, interval.negative) {
                 (true, true) | (true, false) => weeks = -weeks + interval.weeks(),
-                _ => {}
+                _ => {},
             }
             Duration::from_weeks(weeks)
         } else if self.days_only() && interval.days_only() {
@@ -234,7 +234,7 @@ impl Duration {
 
             match (self.negative, interval.negative) {
                 (true, true) | (true, false) => days = -days + interval.days(),
-                _ => {}
+                _ => {},
             }
             Duration::from_days(days)
         } else {
@@ -453,7 +453,7 @@ impl Duration {
                     #[cfg(feature = "timezones")]
                     Some(tz) => {
                         datetime_to_timestamp(unlocalize_datetime(timestamp_to_datetime(t), tz))
-                    }
+                    },
                     _ => t,
                 };
                 let duration = nsecs_to_unit(self.nsecs);
@@ -470,7 +470,7 @@ impl Duration {
                     )?)),
                     _ => Ok(t - remainder),
                 }
-            }
+            },
             // truncate by weeks
             (0, _, 0, 0) => {
                 let dt = match tz {
@@ -492,14 +492,14 @@ impl Duration {
                         first_day_of_week.and_time(NaiveTime::default()),
                     )),
                 }
-            }
+            },
             // truncate by days
             (0, 0, _, 0) => {
                 let t = match tz {
                     #[cfg(feature = "timezones")]
                     Some(tz) => {
                         datetime_to_timestamp(unlocalize_datetime(timestamp_to_datetime(t), tz))
-                    }
+                    },
                     _ => t,
                 };
                 let duration = self.days * nsecs_to_unit(NS_DAY);
@@ -516,7 +516,7 @@ impl Duration {
                     )?)),
                     _ => Ok(t - remainder),
                 }
-            }
+            },
             // truncate by months
             (_, 0, 0, 0) => {
                 let ts = match tz {
@@ -547,10 +547,10 @@ impl Duration {
                     )?)),
                     _ => Ok(datetime_to_timestamp(dt)),
                 }
-            }
+            },
             _ => {
                 polars_bail!(ComputeError: "duration may not mix month, weeks and nanosecond units")
-            }
+            },
         }
     }
 
@@ -651,7 +651,7 @@ impl Duration {
                         tz,
                         None,
                     )?);
-                }
+                },
                 _ => new_t += if d.negative { -t_weeks } else { t_weeks },
             };
         }
@@ -669,7 +669,7 @@ impl Duration {
                         tz,
                         None,
                     )?);
-                }
+                },
                 _ => new_t += if d.negative { -t_days } else { t_days },
             };
         }

--- a/crates/polars-time/src/windows/groupby.rs
+++ b/crates/polars-time/src/windows/groupby.rs
@@ -202,7 +202,7 @@ pub fn groupby_windows(
                 &mut upper_bound,
                 &mut groups,
             );
-        }
+        },
         _ => {
             update_groups_and_bounds(
                 window
@@ -217,7 +217,7 @@ pub fn groupby_windows(
                 &mut upper_bound,
                 &mut groups,
             );
-        }
+        },
     };
 
     (groups, lower_bound, upper_bound)

--- a/crates/polars-time/src/windows/window.rs
+++ b/crates/polars-time/src/windows/window.rs
@@ -171,7 +171,7 @@ impl<'a> BoundsIter<'a> {
                 };
                 boundary.stop = offset_fn(&window.period, boundary.start, tz)?;
                 boundary
-            }
+            },
             StartBy::WindowBound => match tu {
                 TimeUnit::Nanoseconds => window.get_earliest_bounds_ns(boundary.start, tz)?,
                 TimeUnit::Microseconds => window.get_earliest_bounds_us(boundary.start, tz)?,
@@ -222,7 +222,7 @@ impl<'a> BoundsIter<'a> {
                             // and compute the end of the window defined by the 'period'
                             let stop = offset(&window.period, start, Some(tz))?;
                             (start, stop)
-                        }
+                        },
                         _ => {
                             let tz = chrono::Utc;
                             let dt = dt.and_local_timezone(tz).unwrap();
@@ -241,11 +241,11 @@ impl<'a> BoundsIter<'a> {
                             // and compute the end of the window defined by the 'period'
                             let stop = offset(&window.period, start, None).unwrap();
                             (start, stop)
-                        }
+                        },
                     };
                     boundary
                 }
-            }
+            },
         };
         Ok(Self {
             window,
@@ -269,15 +269,15 @@ impl<'a> Iterator for BoundsIter<'a> {
                 TimeUnit::Nanoseconds => {
                     self.bi.start = self.window.every.add_ns(self.bi.start, self.tz).unwrap();
                     self.bi.stop = self.window.every.add_ns(self.bi.stop, self.tz).unwrap();
-                }
+                },
                 TimeUnit::Microseconds => {
                     self.bi.start = self.window.every.add_us(self.bi.start, self.tz).unwrap();
                     self.bi.stop = self.window.every.add_us(self.bi.stop, self.tz).unwrap();
-                }
+                },
                 TimeUnit::Milliseconds => {
                     self.bi.start = self.window.every.add_ms(self.bi.start, self.tz).unwrap();
                     self.bi.stop = self.window.every.add_ms(self.bi.stop, self.tz).unwrap();
-                }
+                },
             }
             Some(out)
         } else {

--- a/crates/polars-utils/src/error.rs
+++ b/crates/polars-utils/src/error.rs
@@ -14,7 +14,7 @@ impl Display for PolarsUtilsError {
             PolarsUtilsError::ComputeError(s) => {
                 let s = s.as_ref();
                 write!(f, "{s}")
-            }
+            },
         }
     }
 }

--- a/crates/polars/tests/it/core/date_like.rs
+++ b/crates/polars/tests/it/core/date_like.rs
@@ -11,7 +11,7 @@ fn test_agg_list_type() -> PolarsResult<()> {
     let result = match l.dtype() {
         DataType::List(inner) => {
             matches!(&**inner, DataType::Datetime(TimeUnit::Nanoseconds, None))
-        }
+        },
         _ => false,
     };
     assert!(result);

--- a/examples/python_rust_compiled_function/src/lib.rs
+++ b/examples/python_rust_compiled_function/src/lib.rs
@@ -39,7 +39,7 @@ fn hamming_distance_strs(a: Option<&str>, b: Option<&str>) -> Option<u32> {
                         .sum::<u32>(),
                 )
             }
-        }
+        },
     }
 }
 

--- a/py-polars/src/apply/dataframe.rs
+++ b/py-polars/src/apply/dataframe.rs
@@ -238,7 +238,7 @@ pub fn apply_lambda_with_list_out_type<'a>(
                         } else {
                             panic!("should return a Series, got a {val:?}")
                         }
-                    }
+                    },
                 },
                 Err(e) => panic!("python function failed {e}"),
             }

--- a/py-polars/src/apply/lazy.rs
+++ b/py-polars/src/apply/lazy.rs
@@ -38,9 +38,9 @@ impl ToSeries for PyObject {
                             "expected a something that could convert to a `Series` but got: {}",
                             self.as_ref(py).get_type()
                         )
-                    }
+                    },
                 }
-            }
+            },
         };
         let pyseries = py_pyseries.extract::<PySeries>(py).unwrap();
         // Finally get the actual Series

--- a/py-polars/src/apply/mod.rs
+++ b/py-polars/src/apply/mod.rs
@@ -42,7 +42,7 @@ fn iterator_to_struct<'a>(
             return Err(crate::error::ComputeError::new_err(format!(
                 "expected struct got {first_value:?}",
             )))
-        }
+        },
     };
 
     // every item in the struct is kept as its own buffer of anyvalues
@@ -76,7 +76,7 @@ fn iterator_to_struct<'a>(
                 for field_items in struct_fields.values_mut() {
                     field_items.push(AnyValue::Null);
                 }
-            }
+            },
             Some(dict) => {
                 let dict = dict.downcast::<PyDict>()?;
 
@@ -111,7 +111,7 @@ fn iterator_to_struct<'a>(
                         }
                     }
                 }
-            }
+            },
         }
     }
 
@@ -279,7 +279,7 @@ fn iterator_to_list(
                 } else {
                     builder.append_series(&s).map_err(PyPolarsErr::from)?
                 }
-            }
+            },
         }
     }
     Ok(builder.finish())

--- a/py-polars/src/apply/series.rs
+++ b/py-polars/src/apply/series.rs
@@ -82,7 +82,7 @@ fn infer_and_finish<'a, A: ApplyLambda<'a>>(
                 applyer
                     .apply_extract_any_values(py, lambda, null_count, av.0)
                     .map(|s| s.into())
-            }
+            },
         }
     } else if out.is_instance_of::<PyDict>() {
         let first = out.extract::<Wrap<AnyValue<'_>>>()?;
@@ -1133,10 +1133,10 @@ fn append_series(
             builder
                 .append_series(&pyseries.series)
                 .map_err(PyPolarsErr::from)?;
-        }
+        },
         Err(_) => {
             builder.append_opt_series(None).map_err(PyPolarsErr::from)?;
-        }
+        },
     };
     Ok(())
 }
@@ -1161,7 +1161,7 @@ fn call_series_lambda(pypolars: &PyModule, lambda: &PyAny, series: Series) -> Op
                 .expect("could not get series attribute '_s'");
             let pyseries = py_pyseries.extract::<PySeries>().unwrap();
             Some(pyseries.series)
-        }
+        },
         Err(_) => None,
     }
 }
@@ -1259,7 +1259,7 @@ impl<'a> ApplyLambda<'a> for ListChunked {
                 };
                 let ca = builder.finish();
                 Ok(PySeries::new(ca.into_series()))
-            }
+            },
             _ => unimplemented!(),
         }
     }
@@ -1738,7 +1738,7 @@ impl<'a> ApplyLambda<'a> for ArrayChunked {
                 };
                 let ca = builder.finish();
                 Ok(PySeries::new(ca.into_series()))
-            }
+            },
             _ => unimplemented!(),
         }
     }

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -224,11 +224,11 @@ impl IntoPy<PyObject> for Wrap<AnyValue<'_>> {
                     unsafe { arr.deref_unchecked().value(idx as usize) }
                 };
                 s.into_py(py)
-            }
+            },
             AnyValue::Date(v) => {
                 let convert = utils.getattr(intern!(py, "_to_python_date")).unwrap();
                 convert.call1((v,)).unwrap().into_py(py)
-            }
+            },
             AnyValue::Datetime(v, time_unit, time_zone) => {
                 let convert = utils.getattr(intern!(py, "_to_python_datetime")).unwrap();
                 let time_unit = time_unit.to_ascii();
@@ -236,16 +236,16 @@ impl IntoPy<PyObject> for Wrap<AnyValue<'_>> {
                     .call1((v, time_unit, time_zone.as_ref().map(|s| s.as_str())))
                     .unwrap()
                     .into_py(py)
-            }
+            },
             AnyValue::Duration(v, time_unit) => {
                 let convert = utils.getattr(intern!(py, "_to_python_timedelta")).unwrap();
                 let time_unit = time_unit.to_ascii();
                 convert.call1((v, time_unit)).unwrap().into_py(py)
-            }
+            },
             AnyValue::Time(v) => {
                 let convert = utils.getattr(intern!(py, "_to_python_time")).unwrap();
                 convert.call1((v,)).unwrap().into_py(py)
-            }
+            },
             AnyValue::Array(v, _) | AnyValue::List(v) => PySeries::new(v).to_list(),
             ref av @ AnyValue::Struct(_, _, flds) => struct_dict(py, av._iter_struct_av(), flds),
             AnyValue::StructOwned(payload) => struct_dict(py, payload.0.into_iter(), &payload.1),
@@ -253,12 +253,12 @@ impl IntoPy<PyObject> for Wrap<AnyValue<'_>> {
             AnyValue::Object(v) => {
                 let object = v.as_any().downcast_ref::<ObjectValue>().unwrap();
                 object.inner.clone()
-            }
+            },
             #[cfg(feature = "object")]
             AnyValue::ObjectOwned(v) => {
                 let object = v.0.as_any().downcast_ref::<ObjectValue>().unwrap();
                 object.inner.clone()
-            }
+            },
             AnyValue::Binary(v) => v.into_py(py),
             AnyValue::BinaryOwned(v) => v.into_py(py),
             AnyValue::Decimal(v, scale) => {
@@ -277,7 +277,7 @@ impl IntoPy<PyObject> for Wrap<AnyValue<'_>> {
                     .call1((v.is_negative() as u8, digits, n_digits, -(scale as i32)))
                     .unwrap()
                     .into_py(py)
-            }
+            },
         }
     }
 }
@@ -310,12 +310,12 @@ impl ToPyObject for Wrap<DataType> {
                 let inner = Wrap(*inner.clone()).to_object(py);
                 let list_class = pl.getattr(intern!(py, "Array")).unwrap();
                 list_class.call1((*size, inner)).unwrap().into()
-            }
+            },
             DataType::List(inner) => {
                 let inner = Wrap(*inner.clone()).to_object(py);
                 let list_class = pl.getattr(intern!(py, "List")).unwrap();
                 list_class.call1((inner,)).unwrap().into()
-            }
+            },
             DataType::Date => pl.getattr(intern!(py, "Date")).unwrap().into(),
             DataType::Datetime(tu, tz) => {
                 let datetime_class = pl.getattr(intern!(py, "Datetime")).unwrap();
@@ -323,11 +323,11 @@ impl ToPyObject for Wrap<DataType> {
                     .call1((tu.to_ascii(), tz.clone()))
                     .unwrap()
                     .into()
-            }
+            },
             DataType::Duration(tu) => {
                 let duration_class = pl.getattr(intern!(py, "Duration")).unwrap();
                 duration_class.call1((tu.to_ascii(),)).unwrap().into()
-            }
+            },
             #[cfg(feature = "object")]
             DataType::Object(_) => pl.getattr(intern!(py, "Object")).unwrap().into(),
             DataType::Categorical(_) => pl.getattr(intern!(py, "Categorical")).unwrap().into(),
@@ -342,7 +342,7 @@ impl ToPyObject for Wrap<DataType> {
                 let fields = PyList::new(py, iter);
                 let struct_class = pl.getattr(intern!(py, "Struct")).unwrap();
                 struct_class.call1((fields,)).unwrap().into()
-            }
+            },
             DataType::Null => pl.getattr(intern!(py, "Null")).unwrap().into(),
             DataType::Unknown => pl.getattr(intern!(py, "Unknown")).unwrap().into(),
         }
@@ -400,38 +400,38 @@ impl FromPyObject<'_> for Wrap<DataType> {
                         return Err(PyValueError::new_err(format!(
                             "{dt} is not a recognised polars DataType.",
                         )))
-                    }
+                    },
                 }
-            }
+            },
             "Duration" => {
                 let time_unit = ob.getattr(intern!(py, "time_unit")).unwrap();
                 let time_unit = time_unit.extract::<Wrap<TimeUnit>>()?.0;
                 DataType::Duration(time_unit)
-            }
+            },
             "Datetime" => {
                 let time_unit = ob.getattr(intern!(py, "time_unit")).unwrap();
                 let time_unit = time_unit.extract::<Wrap<TimeUnit>>()?.0;
                 let time_zone = ob.getattr(intern!(py, "time_zone")).unwrap();
                 let time_zone = time_zone.extract()?;
                 DataType::Datetime(time_unit, time_zone)
-            }
+            },
             "Decimal" => {
                 let precision = ob.getattr(intern!(py, "precision"))?.extract()?;
                 let scale = ob.getattr(intern!(py, "scale"))?.extract()?;
                 DataType::Decimal(precision, Some(scale))
-            }
+            },
             "List" => {
                 let inner = ob.getattr(intern!(py, "inner")).unwrap();
                 let inner = inner.extract::<Wrap<DataType>>()?;
                 DataType::List(Box::new(inner.0))
-            }
+            },
             "Array" => {
                 let inner = ob.getattr(intern!(py, "inner")).unwrap();
                 let width = ob.getattr(intern!(py, "width")).unwrap();
                 let inner = inner.extract::<Wrap<DataType>>()?;
                 let width = width.extract::<usize>()?;
                 DataType::Array(Box::new(inner.0), width)
-            }
+            },
             "Struct" => {
                 let fields = ob.getattr(intern!(py, "fields"))?;
                 let fields = fields
@@ -440,13 +440,13 @@ impl FromPyObject<'_> for Wrap<DataType> {
                     .map(|f| f.0)
                     .collect::<Vec<Field>>();
                 DataType::Struct(fields)
-            }
+            },
             dt => {
                 return Err(PyTypeError::new_err(format!(
                     "A {dt} object is not a recognised polars DataType. \
                     Hint: use the class without instantiating it.",
                 )))
-            }
+            },
         };
         Ok(Wrap(dtype))
     }
@@ -877,16 +877,16 @@ impl<'s> FromPyObject<'s> for Wrap<AnyValue<'s>> {
                                                 // `datetime.datetime` is a subclass of `datetime.date`,
                                                 // so need to check `datetime.datetime` first
                                                 return convert_datetime;
-                                            }
+                                            },
                                             "<class 'datetime.date'>" => {
                                                 return convert_date;
-                                            }
+                                            },
                                             _ => (),
                                         }
                                     }
 
                                     get_object
-                                }
+                                },
                             }
                         }
                     },
@@ -1070,7 +1070,7 @@ impl FromPyObject<'_> for Wrap<AsofStrategy> {
                 return Err(PyValueError::new_err(format!(
                     "strategy must be one of {{'backward', 'forward', 'nearest'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1085,7 +1085,7 @@ impl FromPyObject<'_> for Wrap<InterpolationMethod> {
                 return Err(PyValueError::new_err(format!(
                     "method must be one of {{'linear', 'nearest'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1102,7 +1102,7 @@ impl FromPyObject<'_> for Wrap<Option<AvroCompression>> {
                 return Err(PyValueError::new_err(format!(
                     "compression must be one of {{'uncompressed', 'snappy', 'deflate'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1117,7 +1117,7 @@ impl FromPyObject<'_> for Wrap<CategoricalOrdering> {
                 return Err(PyValueError::new_err(format!(
                     "ordering must be one of {{'physical', 'lexical'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1156,7 +1156,7 @@ impl FromPyObject<'_> for Wrap<ClosedWindow> {
                 return Err(PyValueError::new_err(format!(
                     "closed must be one of {{'left', 'right', 'both', 'none'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1171,7 +1171,7 @@ impl FromPyObject<'_> for Wrap<CsvEncoding> {
                 return Err(PyValueError::new_err(format!(
                     "encoding must be one of {{'utf8', 'utf8-lossy'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1188,7 +1188,7 @@ impl FromPyObject<'_> for Wrap<Option<IpcCompression>> {
                 return Err(PyValueError::new_err(format!(
                     "compression must be one of {{'uncompressed', 'lz4', 'zstd'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1208,7 +1208,7 @@ impl FromPyObject<'_> for Wrap<JoinType> {
                 return Err(PyValueError::new_err(format!(
                 "how must be one of {{'inner', 'left', 'outer', 'semi', 'anti', 'cross'}}, got {v}",
             )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1223,7 +1223,7 @@ impl FromPyObject<'_> for Wrap<ListToStructWidthStrategy> {
                 return Err(PyValueError::new_err(format!(
                     "n_field_strategy must be one of {{'first_non_null', 'max_width'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1238,7 +1238,7 @@ impl FromPyObject<'_> for Wrap<NullBehavior> {
                 return Err(PyValueError::new_err(format!(
                     "null behavior must be one of {{'drop', 'ignore'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1253,7 +1253,7 @@ impl FromPyObject<'_> for Wrap<NullStrategy> {
                 return Err(PyValueError::new_err(format!(
                     "null strategy must be one of {{'ignore', 'propagate'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1271,7 +1271,7 @@ impl FromPyObject<'_> for Wrap<ParallelStrategy> {
                 return Err(PyValueError::new_err(format!(
                     "parallel must be one of {{'auto', 'columns', 'row_groups', 'none'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1286,7 +1286,7 @@ impl FromPyObject<'_> for Wrap<IndexOrder> {
                 return Err(PyValueError::new_err(format!(
                     "order must be one of {{'fortran', 'c'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1339,7 +1339,7 @@ impl FromPyObject<'_> for Wrap<TimeUnit> {
                 return Err(PyValueError::new_err(format!(
                     "time unit must be one of {{'ns', 'us', 'ms'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1356,7 +1356,7 @@ impl FromPyObject<'_> for Wrap<UniqueKeepStrategy> {
                 return Err(PyValueError::new_err(format!(
                     "keep must be one of {{'first', 'last', 'any', 'none'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1372,7 +1372,7 @@ impl FromPyObject<'_> for Wrap<IpcCompression> {
                 return Err(PyValueError::new_err(format!(
                     "compression must be one of {{'zstd', 'lz4'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1388,7 +1388,7 @@ impl FromPyObject<'_> for Wrap<SearchSortedSide> {
                 return Err(PyValueError::new_err(format!(
                     "side must be one of {{'any', 'left', 'right'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1404,7 +1404,7 @@ impl FromPyObject<'_> for Wrap<WindowMapping> {
                 return Err(PyValueError::new_err(format!(
                     "side must be one of {{'group_to_rows', 'join', 'explode'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }
@@ -1421,7 +1421,7 @@ impl FromPyObject<'_> for Wrap<JoinValidation> {
                 return Err(PyValueError::new_err(format!(
                     "validate must be one of {{'m:m', 'm:1', '1:m', '1:1'}}, got {v}",
                 )))
-            }
+            },
         };
         Ok(Wrap(parsed))
     }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -61,11 +61,11 @@ impl PyDataFrame {
             DataType::Null => {
                 fld.coerce(DataType::Boolean);
                 fld
-            }
+            },
             DataType::Decimal(_, _) => {
                 fld.coerce(DataType::Decimal(None, None));
                 fld
-            }
+            },
             _ => fld,
         });
         let mut schema = Schema::from_iter(fields);
@@ -263,7 +263,7 @@ impl PyDataFrame {
                     .use_statistics(use_statistics)
                     .set_rechunk(rechunk)
                     .finish()
-            }
+            },
             Rust(f) => ParquetReader::new(f.into_inner())
                 .with_projection(projection)
                 .with_columns(columns)
@@ -393,7 +393,7 @@ impl PyDataFrame {
                         .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
                     Ok(out.into())
                 }
-            }
+            },
         }
     }
 
@@ -638,7 +638,7 @@ impl PyDataFrame {
                     DataType::Object(_) => {
                         let obj: Option<&ObjectValue> = s.get_object(idx).map(|any| any.into());
                         obj.to_object(py)
-                    }
+                    },
                     _ => Wrap(s.get(idx).unwrap()).into_py(py),
                 }),
             )
@@ -662,7 +662,7 @@ impl PyDataFrame {
                                 let obj: Option<&ObjectValue> =
                                     s.get_object(idx).map(|any| any.into());
                                 obj.to_object(py)
-                            }
+                            },
                             // safety: we are in bounds.
                             _ => unsafe { Wrap(s.get_unchecked(idx)).into_py(py) },
                         }),
@@ -681,7 +681,7 @@ impl PyDataFrame {
                 None => st = Some(dt_i.clone()),
                 Some(ref mut st) => {
                     *st = try_get_supertype(st, dt_i).ok()?;
-                }
+                },
             }
         }
         let st = st?;
@@ -1306,43 +1306,43 @@ impl PyDataFrame {
                 Some(DataType::Int32) => {
                     apply_lambda_with_primitive_out_type::<Int32Type>(df, py, lambda, 0, None)
                         .into_series()
-                }
+                },
                 Some(DataType::Int64) => {
                     apply_lambda_with_primitive_out_type::<Int64Type>(df, py, lambda, 0, None)
                         .into_series()
-                }
+                },
                 Some(DataType::UInt32) => {
                     apply_lambda_with_primitive_out_type::<UInt32Type>(df, py, lambda, 0, None)
                         .into_series()
-                }
+                },
                 Some(DataType::UInt64) => {
                     apply_lambda_with_primitive_out_type::<UInt64Type>(df, py, lambda, 0, None)
                         .into_series()
-                }
+                },
                 Some(DataType::Float32) => {
                     apply_lambda_with_primitive_out_type::<Float32Type>(df, py, lambda, 0, None)
                         .into_series()
-                }
+                },
                 Some(DataType::Float64) => {
                     apply_lambda_with_primitive_out_type::<Float64Type>(df, py, lambda, 0, None)
                         .into_series()
-                }
+                },
                 Some(DataType::Boolean) => {
                     apply_lambda_with_bool_out_type(df, py, lambda, 0, None).into_series()
-                }
+                },
                 Some(DataType::Date) => {
                     apply_lambda_with_primitive_out_type::<Int32Type>(df, py, lambda, 0, None)
                         .into_date()
                         .into_series()
-                }
+                },
                 Some(DataType::Datetime(tu, tz)) => {
                     apply_lambda_with_primitive_out_type::<Int64Type>(df, py, lambda, 0, None)
                         .into_datetime(tu, tz)
                         .into_series()
-                }
+                },
                 Some(DataType::Utf8) => {
                     apply_lambda_with_utf8_out_type(df, py, lambda, 0, None).into_series()
-                }
+                },
                 _ => return apply_lambda_unknown(df, py, lambda, inference_size),
             };
 

--- a/py-polars/src/datatypes.rs
+++ b/py-polars/src/datatypes.rs
@@ -64,7 +64,7 @@ impl From<&DataType> for PyDataType {
             DataType::Struct(_) => Struct,
             DataType::Null | DataType::Unknown => {
                 panic!("null or unknown not expected here")
-            }
+            },
         }
     }
 }

--- a/py-polars/src/error.rs
+++ b/py-polars/src/error.rs
@@ -37,20 +37,20 @@ impl std::convert::From<PyPolarsErr> for PyErr {
                 PolarsError::Duplicate(err) => DuplicateError::new_err(err.to_string()),
                 PolarsError::InvalidOperation(err) => {
                     InvalidOperationError::new_err(err.to_string())
-                }
+                },
                 PolarsError::Io(err) => PyIOError::new_err(err.to_string()),
                 PolarsError::NoData(err) => NoDataError::new_err(err.to_string()),
                 PolarsError::SchemaFieldNotFound(name) => {
                     SchemaFieldNotFoundError::new_err(name.to_string())
-                }
+                },
                 PolarsError::SchemaMismatch(err) => SchemaError::new_err(err.to_string()),
                 PolarsError::ShapeMismatch(err) => ShapeError::new_err(err.to_string()),
                 PolarsError::StringCacheMismatch(err) => {
                     StringCacheMismatchError::new_err(err.to_string())
-                }
+                },
                 PolarsError::StructFieldNotFound(name) => {
                     StructFieldNotFoundError::new_err(name.to_string())
-                }
+                },
             },
             Arrow(err) => ArrowErrorException::new_err(format!("{err:?}")),
             _ => default(),

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -93,7 +93,7 @@ impl PyExpr {
                 self.inner = ciborium::de::from_reader(s.as_bytes())
                     .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
                 Ok(())
-            }
+            },
             Err(e) => Err(e),
         }
     }
@@ -643,7 +643,7 @@ impl PyExpr {
                     Ok(pyseries) => {
                         let pyseries = pyseries.extract::<PySeries>(py).unwrap();
                         pyseries.series
-                    }
+                    },
                     Err(_) => {
                         let obj = out;
                         let is_float = obj.as_ref(py).is_instance_of::<PyFloat>();
@@ -660,7 +660,7 @@ impl PyExpr {
                                     obj.extract::<u8>(py)
                                         .map(|v| UInt8Chunked::from_slice("", &[v]).into_series())
                                 }
-                            }
+                            },
                             UInt16 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
@@ -669,7 +669,7 @@ impl PyExpr {
                                     obj.extract::<u16>(py)
                                         .map(|v| UInt16Chunked::from_slice("", &[v]).into_series())
                                 }
-                            }
+                            },
                             UInt32 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
@@ -678,7 +678,7 @@ impl PyExpr {
                                     obj.extract::<u32>(py)
                                         .map(|v| UInt32Chunked::from_slice("", &[v]).into_series())
                                 }
-                            }
+                            },
                             UInt64 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
@@ -687,7 +687,7 @@ impl PyExpr {
                                     obj.extract::<u64>(py)
                                         .map(|v| UInt64Chunked::from_slice("", &[v]).into_series())
                                 }
-                            }
+                            },
                             Int8 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
@@ -696,7 +696,7 @@ impl PyExpr {
                                     obj.extract::<i8>(py)
                                         .map(|v| Int8Chunked::from_slice("", &[v]).into_series())
                                 }
-                            }
+                            },
                             Int16 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
@@ -705,7 +705,7 @@ impl PyExpr {
                                     obj.extract::<i16>(py)
                                         .map(|v| Int16Chunked::from_slice("", &[v]).into_series())
                                 }
-                            }
+                            },
                             Int32 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
@@ -714,7 +714,7 @@ impl PyExpr {
                                     obj.extract::<i32>(py)
                                         .map(|v| Int32Chunked::from_slice("", &[v]).into_series())
                                 }
-                            }
+                            },
                             Int64 => {
                                 if is_float {
                                     let v = obj.extract::<f64>(py).unwrap();
@@ -723,7 +723,7 @@ impl PyExpr {
                                     obj.extract::<i64>(py)
                                         .map(|v| Int64Chunked::from_slice("", &[v]).into_series())
                                 }
-                            }
+                            },
                             Float32 => obj
                                 .extract::<f32>(py)
                                 .map(|v| Float32Chunked::from_slice("", &[v]).into_series()),
@@ -737,9 +737,9 @@ impl PyExpr {
                             Ok(s) => s,
                             Err(e) => {
                                 panic!("{e:?}")
-                            }
+                            },
                         }
-                    }
+                    },
                 }
             })
         };

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -217,7 +217,7 @@ pub fn get_either_file(py_f: PyObject, truncate: bool) -> PyResult<EitherRustPyt
                     Err(_e) => {
                         no_such_file_err(s)?;
                         unreachable!();
-                    }
+                    },
                 }
             };
             Ok(EitherRustPythonFile::Rust(f))
@@ -251,7 +251,7 @@ pub fn get_mmap_bytes_reader<'a>(py_f: &'a PyAny) -> PyResult<Box<dyn MmapBytesR
             Err(_e) => {
                 no_such_file_err(s)?;
                 unreachable!();
-            }
+            },
         };
         Ok(Box::new(f))
     }

--- a/py-polars/src/functions/io.rs
+++ b/py-polars/src/functions/io.rs
@@ -13,7 +13,7 @@ pub fn read_ipc_schema(py: Python, py_f: PyObject) -> PyResult<PyObject> {
     let metadata = match get_either_file(py_f, false)? {
         EitherRustPythonFile::Rust(mut r) => {
             read_file_metadata(&mut r).map_err(PyPolarsErr::from)?
-        }
+        },
         EitherRustPythonFile::Py(mut r) => read_file_metadata(&mut r).map_err(PyPolarsErr::from)?,
     };
 

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -316,11 +316,11 @@ pub fn lit(value: &PyAny, allow_object: bool) -> PyResult<PyExpr> {
                 } else {
                     Ok(dsl::lit(val).into())
                 }
-            }
+            },
             _ => {
                 let val = int.extract::<u64>().unwrap();
                 Ok(dsl::lit(val).into())
-            }
+            },
         }
     } else if let Ok(float) = value.downcast::<PyFloat>() {
         let val = float.extract::<f64>().unwrap();

--- a/py-polars/src/functions/meta.rs
+++ b/py-polars/src/functions/meta.rs
@@ -42,7 +42,7 @@ pub fn set_float_fmt(fmt: &str) -> PyResult<()> {
             return Err(PyValueError::new_err(format!(
                 "fmt must be one of {{'full', 'mixed'}}, got {e}",
             )))
-        }
+        },
     };
     polars_core::fmt::set_float_fmt(fmt);
     Ok(())

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -78,7 +78,7 @@ impl PyLazyFrame {
                     .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
                 self.ldf = LazyFrame::from(lp);
                 Ok(())
-            }
+            },
             Err(e) => Err(e),
         }
     }

--- a/py-polars/src/series/aggregation.rs
+++ b/py-polars/src/series/aggregation.rs
@@ -29,7 +29,7 @@ impl PySeries {
             DataType::Boolean => {
                 let s = self.series.cast(&DataType::UInt8).unwrap();
                 s.mean()
-            }
+            },
             _ => self.series.mean(),
         }
     }
@@ -39,7 +39,7 @@ impl PySeries {
             DataType::Boolean => {
                 let s = self.series.cast(&DataType::UInt8).unwrap();
                 s.median()
-            }
+            },
             _ => self.series.median(),
         }
     }

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -96,7 +96,7 @@ impl PySeries {
                             return Err(e);
                         }
                         builder.append_null()
-                    }
+                    },
                 }
             }
         }
@@ -129,7 +129,7 @@ where
                         return Err(e);
                     }
                     builder.append_null()
-                }
+                },
             }
         }
     }
@@ -247,7 +247,7 @@ impl PySeries {
                         ))
                         .map_err(PyPolarsErr::from)?;
                     Ok(series.into())
-                }
+                },
                 _ => Err(PyValueError::new_err("could not create Array from input")),
             }
         }
@@ -288,12 +288,12 @@ impl PySeries {
                     out.set_fast_explode()
                 }
                 Ok(out.into_series().into())
-            }
+            },
             _ => {
                 let series: Series =
                     std::convert::TryFrom::try_from((name, arr)).map_err(PyPolarsErr::from)?;
                 Ok(series.into())
-            }
+            },
         }
     }
 }

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -43,22 +43,22 @@ impl PySeries {
                     );
                     Ok(np_arr.into_py(py))
                 }
-            }
+            },
             DataType::Utf8 => {
                 let ca = s.utf8().unwrap();
                 let np_arr = PyArray1::from_iter(py, ca.into_iter().map(|s| s.into_py(py)));
                 Ok(np_arr.into_py(py))
-            }
+            },
             DataType::Binary => {
                 let ca = s.binary().unwrap();
                 let np_arr = PyArray1::from_iter(py, ca.into_iter().map(|s| s.into_py(py)));
                 Ok(np_arr.into_py(py))
-            }
+            },
             DataType::Boolean => {
                 let ca = s.bool().unwrap();
                 let np_arr = PyArray1::from_iter(py, ca.into_iter().map(|s| s.into_py(py)));
                 Ok(np_arr.into_py(py))
-            }
+            },
             #[cfg(feature = "object")]
             DataType::Object(_) => {
                 let ca = s
@@ -68,13 +68,13 @@ impl PySeries {
                 let np_arr =
                     PyArray1::from_iter(py, ca.into_iter().map(|opt_v| opt_v.to_object(py)));
                 Ok(np_arr.into_py(py))
-            }
+            },
             dt => {
                 raise_err!(
                     format!("'to_numpy' not supported for dtype: {dt:?}"),
                     ComputeError
                 );
-            }
+            },
         }
     }
 
@@ -97,7 +97,7 @@ impl PySeries {
                     DataType::Float64 => PyList::new(py, series.f64().unwrap()),
                     DataType::Categorical(_) => {
                         PyList::new(py, series.categorical().unwrap().iter_str())
-                    }
+                    },
                     #[cfg(feature = "object")]
                     DataType::Object(_) => {
                         let v = PyList::empty(py);
@@ -109,7 +109,7 @@ impl PySeries {
                             v.append(val).unwrap();
                         }
                         v
-                    }
+                    },
                     DataType::List(_) => {
                         let v = PyList::empty(py);
                         let ca = series.list().unwrap();
@@ -117,15 +117,15 @@ impl PySeries {
                             match opt_s {
                                 None => {
                                     v.append(py.None()).unwrap();
-                                }
+                                },
                                 Some(s) => {
                                     let pylst = to_list_recursive(py, s.as_ref());
                                     v.append(pylst).unwrap();
-                                }
+                                },
                             }
                         }
                         v
-                    }
+                    },
                     DataType::Array(_, _) => {
                         let v = PyList::empty(py);
                         let ca = series.array().unwrap();
@@ -133,47 +133,47 @@ impl PySeries {
                             match opt_s {
                                 None => {
                                     v.append(py.None()).unwrap();
-                                }
+                                },
                                 Some(s) => {
                                     let pylst = to_list_recursive(py, s.as_ref());
                                     v.append(pylst).unwrap();
-                                }
+                                },
                             }
                         }
                         v
-                    }
+                    },
                     DataType::Date => {
                         let ca = series.date().unwrap();
                         return Wrap(ca).to_object(py);
-                    }
+                    },
                     DataType::Time => {
                         let ca = series.time().unwrap();
                         return Wrap(ca).to_object(py);
-                    }
+                    },
                     DataType::Datetime(_, _) => {
                         let ca = series.datetime().unwrap();
                         return Wrap(ca).to_object(py);
-                    }
+                    },
                     DataType::Decimal(_, _) => {
                         let ca = series.decimal().unwrap();
                         return Wrap(ca).to_object(py);
-                    }
+                    },
                     DataType::Utf8 => {
                         let ca = series.utf8().unwrap();
                         return Wrap(ca).to_object(py);
-                    }
+                    },
                     DataType::Struct(_) => {
                         let ca = series.struct_().unwrap();
                         return Wrap(ca).to_object(py);
-                    }
+                    },
                     DataType::Duration(_) => {
                         let ca = series.duration().unwrap();
                         return Wrap(ca).to_object(py);
-                    }
+                    },
                     DataType::Binary => {
                         let ca = series.binary().unwrap();
                         return Wrap(ca).to_object(py);
-                    }
+                    },
                     DataType::Null => {
                         let null: Option<u8> = None;
                         let n = series.len();
@@ -196,10 +196,10 @@ impl PySeries {
                         impl ExactSizeIterator for NullIter {}
 
                         PyList::new(py, NullIter { iter, n })
-                    }
+                    },
                     DataType::Unknown => {
                         panic!("to_list not implemented for unknown")
-                    }
+                    },
                 };
                 pylist.to_object(py)
             }

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -384,7 +384,7 @@ impl PySeries {
                         call_lambda_and_extract::<_, Wrap<AnyValue>>(py, lambda, input)
                             .unwrap()
                             .0
-                    }
+                    },
                 });
                 avs.extend(iter);
                 return Ok(Series::new(self.name(), &avs).into());
@@ -401,7 +401,7 @@ impl PySeries {
                         None
                     )?;
                     ca.into_series()
-                }
+                },
                 Some(DataType::Int16) => {
                     let ca: Int16Chunked = dispatch_apply!(
                         series,
@@ -412,7 +412,7 @@ impl PySeries {
                         None
                     )?;
                     ca.into_series()
-                }
+                },
                 Some(DataType::Int32) => {
                     let ca: Int32Chunked = dispatch_apply!(
                         series,
@@ -423,7 +423,7 @@ impl PySeries {
                         None
                     )?;
                     ca.into_series()
-                }
+                },
                 Some(DataType::Int64) => {
                     let ca: Int64Chunked = dispatch_apply!(
                         series,
@@ -434,7 +434,7 @@ impl PySeries {
                         None
                     )?;
                     ca.into_series()
-                }
+                },
                 Some(DataType::UInt8) => {
                     let ca: UInt8Chunked = dispatch_apply!(
                         series,
@@ -445,7 +445,7 @@ impl PySeries {
                         None
                     )?;
                     ca.into_series()
-                }
+                },
                 Some(DataType::UInt16) => {
                     let ca: UInt16Chunked = dispatch_apply!(
                         series,
@@ -456,7 +456,7 @@ impl PySeries {
                         None
                     )?;
                     ca.into_series()
-                }
+                },
                 Some(DataType::UInt32) => {
                     let ca: UInt32Chunked = dispatch_apply!(
                         series,
@@ -467,7 +467,7 @@ impl PySeries {
                         None
                     )?;
                     ca.into_series()
-                }
+                },
                 Some(DataType::UInt64) => {
                     let ca: UInt64Chunked = dispatch_apply!(
                         series,
@@ -478,7 +478,7 @@ impl PySeries {
                         None
                     )?;
                     ca.into_series()
-                }
+                },
                 Some(DataType::Float32) => {
                     let ca: Float32Chunked = dispatch_apply!(
                         series,
@@ -489,7 +489,7 @@ impl PySeries {
                         None
                     )?;
                     ca.into_series()
-                }
+                },
                 Some(DataType::Float64) => {
                     let ca: Float64Chunked = dispatch_apply!(
                         series,
@@ -500,7 +500,7 @@ impl PySeries {
                         None
                     )?;
                     ca.into_series()
-                }
+                },
                 Some(DataType::Boolean) => {
                     let ca: BooleanChunked = dispatch_apply!(
                         series,
@@ -511,7 +511,7 @@ impl PySeries {
                         None
                     )?;
                     ca.into_series()
-                }
+                },
                 Some(DataType::Utf8) => {
                     let ca = dispatch_apply!(
                         series,
@@ -523,7 +523,7 @@ impl PySeries {
                     )?;
 
                     ca.into_series()
-                }
+                },
                 #[cfg(feature = "object")]
                 Some(DataType::Object(_)) => {
                     let ca = dispatch_apply!(
@@ -535,7 +535,7 @@ impl PySeries {
                         None
                     )?;
                     ca.into_series()
-                }
+                },
                 None => return dispatch_apply!(series, apply_lambda_unknown, py, lambda),
 
                 _ => return dispatch_apply!(series, apply_lambda_unknown, py, lambda),
@@ -614,7 +614,7 @@ impl PySeries {
                 self.series = ciborium::de::from_reader(s.as_bytes())
                     .map_err(|e| PyPolarsErr::Other(format!("{}", e)))?;
                 Ok(())
-            }
+            },
             Err(e) => Err(e),
         }
     }

--- a/py-polars/src/series/numpy_ufunc.rs
+++ b/py-polars/src/series/numpy_ufunc.rs
@@ -92,11 +92,11 @@ macro_rules! impl_ufuncs {
                                 validity,
                             );
                             PySeries::new(ca.into_series())
-                        }
+                        },
                         Err(e) => {
                             // return error information
                             return Err(e);
-                        }
+                        },
                     };
 
                     Ok(s)

--- a/py-polars/src/series/set_at_idx.rs
+++ b/py-polars/src/series/set_at_idx.rs
@@ -15,7 +15,7 @@ impl PySeries {
             Ok(out) => {
                 self.series = out;
                 Ok(())
-            }
+            },
             Err(e) => Err(PyErr::from(PyPolarsErr::from(e))),
         }
     }
@@ -48,62 +48,62 @@ fn set_at_idx(mut s: Series, idx: &Series, values: &Series) -> PolarsResult<Seri
             let ca: &mut ChunkedArray<Int8Type> = mutable_s.as_mut();
             let values = values.i8()?;
             std::mem::take(ca).set_at_idx2(idx, values)
-        }
+        },
         DataType::Int16 => {
             let ca: &mut ChunkedArray<Int16Type> = mutable_s.as_mut();
             let values = values.i16()?;
             std::mem::take(ca).set_at_idx2(idx, values)
-        }
+        },
         DataType::Int32 => {
             let ca: &mut ChunkedArray<Int32Type> = mutable_s.as_mut();
             let values = values.i32()?;
             std::mem::take(ca).set_at_idx2(idx, values)
-        }
+        },
         DataType::Int64 => {
             let ca: &mut ChunkedArray<Int64Type> = mutable_s.as_mut();
             let values = values.i64()?;
             std::mem::take(ca).set_at_idx2(idx, values)
-        }
+        },
         DataType::UInt8 => {
             let ca: &mut ChunkedArray<UInt8Type> = mutable_s.as_mut();
             let values = values.u8()?;
             std::mem::take(ca).set_at_idx2(idx, values)
-        }
+        },
         DataType::UInt16 => {
             let ca: &mut ChunkedArray<UInt16Type> = mutable_s.as_mut();
             let values = values.u16()?;
             std::mem::take(ca).set_at_idx2(idx, values)
-        }
+        },
         DataType::UInt32 => {
             let ca: &mut ChunkedArray<UInt32Type> = mutable_s.as_mut();
             let values = values.u32()?;
             std::mem::take(ca).set_at_idx2(idx, values)
-        }
+        },
         DataType::UInt64 => {
             let ca: &mut ChunkedArray<UInt64Type> = mutable_s.as_mut();
             let values = values.u64()?;
             std::mem::take(ca).set_at_idx2(idx, values)
-        }
+        },
         DataType::Float32 => {
             let ca: &mut ChunkedArray<Float32Type> = mutable_s.as_mut();
             let values = values.f32()?;
             std::mem::take(ca).set_at_idx2(idx, values)
-        }
+        },
         DataType::Float64 => {
             let ca: &mut ChunkedArray<Float64Type> = mutable_s.as_mut();
             let values = values.f64()?;
             std::mem::take(ca).set_at_idx2(idx, values)
-        }
+        },
         DataType::Boolean => {
             let ca = s.bool()?;
             let values = values.bool()?;
             ca.set_at_idx2(idx, values)
-        }
+        },
         DataType::Utf8 => {
             let ca = s.utf8()?;
             let values = values.utf8()?;
             ca.set_at_idx2(idx, values)
-        }
+        },
         _ => panic!("not yet implemented for dtype: {logical_dtype}"),
     };
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,3 @@
 group_imports = "StdExternalCrate"
 imports_granularity = "Module"
+match_block_trailing_comma = true


### PR DESCRIPTION
This gigantic pull request is caused by a single-line change in `rustfmt.toml`:

```toml
match_block_trailing_comma = true
```

It makes (in my opinion) match blocks more consistent by always requiring a comma after each block. So instead of this:

```rust
match boo {
    Foo => "foo", // Comma required
    Foo => { println!("foo detected"); "foo" } // Comma not required, cargo fmt removes it
    Baz => "baz", // Comma not required (final item), cargo fmt adds it
}
```

it makes it consistent so that after *every* match, regardless of whether it is a block or not, a comma is always added. I prefer this style but I can understand it if we don't want this giant pull request that will cause merge conflicts for older pull requests.