### PR TITLE
fix(python): raise appropriate error from newly-optimised `item` on invalid (out of bounds) column index

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1569,9 +1569,7 @@ class DataFrame:
                 if (col_selection >= 0 and col_selection >= self.width) or (
                     col_selection < 0 and col_selection < -self.width
                 ):
-                    raise ValueError(
-                        f'Column index "{col_selection}" is out of bounds.'
-                    )
+                    raise ValueError(f'Column index "{col_selection}" is out of bounds')
                 series = self.to_series(col_selection)
                 return series[row_selection]
 
@@ -1786,13 +1784,16 @@ class DataFrame:
             return self._df.select_at_idx(0).get_idx(0)
 
         elif row is None or column is None:
-            raise ValueError("Cannot call '.item()' with only one of 'row' or 'column'")
+            raise ValueError("cannot call `.item()` with only one of `row` or `column`")
 
-        return (
+        s = (
             self._df.select_at_idx(column)
             if isinstance(column, int)
             else self._df.column(column)
-        ).get_idx(row)
+        )
+        if s is None:
+            raise ValueError(f'Column index "{column}" is out of bounds.')
+        return s.get_idx(row)
 
     def to_arrow(self) -> pa.Table:
         """

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1569,7 +1569,7 @@ class DataFrame:
                 if (col_selection >= 0 and col_selection >= self.width) or (
                     col_selection < 0 and col_selection < -self.width
                 ):
-                    raise ValueError(f'Column index "{col_selection}" is out of bounds')
+                    raise ValueError(f"column index {col_selection!r} is out of bounds")
                 series = self.to_series(col_selection)
                 return series[row_selection]
 
@@ -1792,7 +1792,7 @@ class DataFrame:
             else self._df.column(column)
         )
         if s is None:
-            raise ValueError(f'Column index "{column}" is out of bounds.')
+            raise ValueError(f"column index {column!r} is out of bounds")
         return s.get_idx(row)
 
     def to_arrow(self) -> pa.Table:

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -748,7 +748,7 @@ def last(column: str | Series | None = None) -> Expr:
         if column.len() > 0:
             return column[-1]
         else:
-            raise IndexError("The series is empty, so no last value can be returned,")
+            raise IndexError("The series is empty, so no last value can be returned.")
     return col(column).last()
 
 

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -748,7 +748,7 @@ def last(column: str | Series | None = None) -> Expr:
         if column.len() > 0:
             return column[-1]
         else:
-            raise IndexError("The series is empty, so no last value can be returned.")
+            raise IndexError("the series is empty, so no last value can be returned")
     return col(column).last()
 
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3269,7 +3269,7 @@ def test_item() -> None:
     df = pl.DataFrame({})
     with pytest.raises(ValueError, match=r".* frame has shape \(0, 0\)"):
         df.item()
-    with pytest.raises(ValueError, match='Column index "10" is out of bounds'):
+    with pytest.raises(ValueError, match="column index 10 is out of bounds"):
         df.item(0, 10)
 
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3253,22 +3253,24 @@ def test_item() -> None:
     assert df.item() == 1
 
     df = pl.DataFrame({"a": [1, 2]})
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r".* frame has shape \(2, 1\)"):
         df.item()
 
     assert df.item(0, 0) == 1
     assert df.item(1, "a") == 2
 
     df = pl.DataFrame({"a": [1], "b": [2]})
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r".* frame has shape \(1, 2\)"):
         df.item()
 
     assert df.item(0, "a") == 1
     assert df.item(0, "b") == 2
 
     df = pl.DataFrame({})
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match=r".* frame has shape \(0, 0\)"):
         df.item()
+    with pytest.raises(ValueError, match='Column index "10" is out of bounds'):
+        df.item(0, 10)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We were missing test coverage for out-of-bounds column indexes passed to `df.item(…)`. This PR adds that test coverage and now raises the expected `ValueError` from the newly-optimised [^1] `item` method if necessary. 

[^1]: #10411