### PR TITLE
refactor(rust): Simplify flag methods

### DIFF
--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -16,7 +16,7 @@ polars-utils = { version = "0.31.1", path = "../polars-utils" }
 
 ahash = { workspace = true }
 arrow = { workspace = true }
-bitflags = { workspace = true }
+bitflags = { workspace = true, features = ["serde"] }
 chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
 comfy-table = { version = "7.0.1", default_features = false, optional = true }

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -11,6 +11,7 @@ pub(crate) use ops::{CategoricalTakeRandomGlobal, CategoricalTakeRandomLocal};
 use polars_utils::sync::SyncPtr;
 
 use super::*;
+use crate::chunked_array::Settings;
 use crate::prelude::*;
 
 bitflags! {
@@ -83,19 +84,13 @@ impl CategoricalChunked {
         out
     }
 
-    pub(crate) fn get_flags(&self) -> u8 {
-        self.bit_settings.bits()
+    pub(crate) fn get_flags(&self) -> Settings {
+        self.logical().get_flags()
     }
 
     /// Set flags for the Chunked Array
-    pub(crate) fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
-        BitSettings::from_bits(flags)
-            .ok_or_else(
-                || polars_err!(ComputeError: "corrupt flags {} for {}", flags, self.dtype()),
-            )
-            .map(|settings| {
-                self.bit_settings = settings;
-            })
+    pub(crate) fn set_flags(&mut self, flags: Settings) {
+        self.logical_mut().set_flags(flags)
     }
 
     /// Build a categorical from an original RevMap. That means that the number of categories in the `RevMapping == self.unique().len()`.

--- a/crates/polars-core/src/datatypes/_serde.rs
+++ b/crates/polars-core/src/datatypes/_serde.rs
@@ -95,6 +95,7 @@ impl From<&DataType> for SerializableDataType {
             Categorical(_) => Self::Categorical,
             #[cfg(feature = "object")]
             Object(name) => Self::Object(name.to_string()),
+            dt => panic!("{dt:?} not supported"),
         }
     }
 }

--- a/crates/polars-core/src/datatypes/_serde.rs
+++ b/crates/polars-core/src/datatypes/_serde.rs
@@ -95,7 +95,6 @@ impl From<&DataType> for SerializableDataType {
             Categorical(_) => Self::Categorical,
             #[cfg(feature = "object")]
             Object(name) => Self::Object(name.to_string()),
-            dt => panic!("{dt:?} not supported"),
         }
     }
 }

--- a/crates/polars-core/src/serde/chunked_array.rs
+++ b/crates/polars-core/src/serde/chunked_array.rs
@@ -3,6 +3,7 @@ use std::cell::RefCell;
 use serde::ser::SerializeMap;
 use serde::{Serialize, Serializer};
 
+use crate::chunked_array::Settings;
 use crate::prelude::*;
 
 pub struct IterSer<I>
@@ -46,7 +47,7 @@ fn serialize_impl<T, S>(
     serializer: S,
     name: &str,
     dtype: &DataType,
-    bit_settings: u8,
+    bit_settings: Settings,
     ca: &ChunkedArray<T>,
 ) -> std::result::Result<<S as Serializer>::Ok, <S as Serializer>::Error>
 where

--- a/crates/polars-core/src/serde/mod.rs
+++ b/crates/polars-core/src/serde/mod.rs
@@ -4,6 +4,7 @@ pub mod series;
 
 #[cfg(test)]
 mod test {
+    use crate::chunked_array::Settings;
     use crate::prelude::*;
     use crate::series::IsSorted;
 
@@ -55,7 +56,7 @@ mod test {
             let json = serde_json::to_string(&column).unwrap();
             let out = serde_json::from_reader::<_, Series>(json.as_bytes()).unwrap();
             let f = out.get_flags();
-            assert_ne!(f, 0u8);
+            assert_ne!(f, Settings::empty());
             assert_eq!(column.get_flags(), out.get_flags());
         }
     }

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -4,6 +4,7 @@ use std::fmt::Formatter;
 use serde::de::{MapAccess, Visitor};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::chunked_array::Settings;
 use crate::prelude::*;
 
 impl Serialize for Series {
@@ -94,7 +95,7 @@ impl<'de> Deserialize<'de> for Series {
             {
                 let mut name: Option<Cow<'de, str>> = None;
                 let mut dtype = None;
-                let mut bit_settings: Option<u8> = None;
+                let mut bit_settings: Option<Settings> = None;
                 let mut values_set = false;
                 while let Some(key) = map.next_key::<Cow<str>>().unwrap() {
                     match key.as_ref() {
@@ -231,7 +232,6 @@ impl<'de> Deserialize<'de> for Series {
 
                 if let Some(f) = bit_settings {
                     s.set_flags(f)
-                        .map_err(|_| de::Error::custom("bit flags are corrupt"))?
                 }
                 Ok(s)
             }

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -8,6 +8,8 @@ use crate::chunked_array::{AsSinglePtr, Settings};
 use crate::frame::groupby::*;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
+#[cfg(feature = "chunked_ids")]
+use crate::series::IsSorted;
 
 impl private::PrivateSeries for SeriesWrap<ArrayChunked> {
     fn compute_len(&mut self) {

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -4,11 +4,10 @@ use std::borrow::Cow;
 use super::{private, IntoSeries, SeriesTrait};
 use crate::chunked_array::comparison::*;
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
-use crate::chunked_array::AsSinglePtr;
+use crate::chunked_array::{AsSinglePtr, Settings};
 use crate::frame::groupby::*;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
-use crate::series::IsSorted;
 
 impl private::PrivateSeries for SeriesWrap<ArrayChunked> {
     fn compute_len(&mut self) {
@@ -21,20 +20,16 @@ impl private::PrivateSeries for SeriesWrap<ArrayChunked> {
         self.0.ref_field().data_type()
     }
 
-    fn _get_flags(&self) -> u8 {
+    fn _get_flags(&self) -> Settings {
         self.0.get_flags()
     }
 
-    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: Settings) {
         self.0.set_flags(flags)
     }
 
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
-    }
-
-    fn _set_sorted_flag(&mut self, is_sorted: IsSorted) {
-        self.0.set_sorted_flag(is_sorted)
     }
 
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -100,13 +100,7 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
 
 impl SeriesTrait for SeriesWrap<BinaryChunked> {
     fn is_sorted_flag(&self) -> IsSorted {
-        if self.0.is_sorted_ascending_flag() {
-            IsSorted::Ascending
-        } else if self.0.is_sorted_descending_flag() {
-            IsSorted::Descending
-        } else {
-            IsSorted::Not
-        }
+        self.0.is_sorted_flag()
     }
 
     fn rename(&mut self, name: &str) {

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -24,18 +24,14 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _get_flags(&self) -> u8 {
+    fn _get_flags(&self) -> Settings {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: Settings) {
         self.0.set_flags(flags)
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
-    }
-
-    fn _set_sorted_flag(&mut self, is_sorted: IsSorted) {
-        self.0.set_sorted_flag(is_sorted)
     }
 
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
@@ -99,10 +95,6 @@ impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
 }
 
 impl SeriesTrait for SeriesWrap<BinaryChunked> {
-    fn is_sorted_flag(&self) -> IsSorted {
-        self.0.is_sorted_flag()
-    }
-
     fn rename(&mut self, name: &str) {
         self.0.rename(name);
     }

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -113,13 +113,7 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
 
 impl SeriesTrait for SeriesWrap<BooleanChunked> {
     fn is_sorted_flag(&self) -> IsSorted {
-        if self.0.is_sorted_ascending_flag() {
-            IsSorted::Ascending
-        } else if self.0.is_sorted_descending_flag() {
-            IsSorted::Descending
-        } else {
-            IsSorted::Not
-        }
+        self.0.is_sorted_flag()
     }
 
     fn bitxor(&self, other: &Series) -> PolarsResult<Series> {

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -25,18 +25,14 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _get_flags(&self) -> u8 {
+    fn _get_flags(&self) -> Settings {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: Settings) {
         self.0.set_flags(flags)
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
-    }
-
-    fn _set_sorted_flag(&mut self, is_sorted: IsSorted) {
-        self.0.set_sorted_flag(is_sorted)
     }
 
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
@@ -112,10 +108,6 @@ impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
 }
 
 impl SeriesTrait for SeriesWrap<BooleanChunked> {
-    fn is_sorted_flag(&self) -> IsSorted {
-        self.0.is_sorted_flag()
-    }
-
     fn bitxor(&self, other: &Series) -> PolarsResult<Series> {
         let other = self.0.unpack_series_matching_type(other)?;
         Ok((&self.0).bitxor(other).into_series())

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -161,13 +161,7 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
 
 impl SeriesTrait for SeriesWrap<CategoricalChunked> {
     fn is_sorted_flag(&self) -> IsSorted {
-        if self.0.logical().is_sorted_ascending_flag() {
-            IsSorted::Ascending
-        } else if self.0.logical().is_sorted_descending_flag() {
-            IsSorted::Descending
-        } else {
-            IsSorted::Not
-        }
+        self.0.logical().is_sorted_flag()
     }
 
     fn rename(&mut self, name: &str) {

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -64,10 +64,10 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-    fn _get_flags(&self) -> u8 {
+    fn _get_flags(&self) -> Settings {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: Settings) {
         self.0.set_flags(flags)
     }
 
@@ -77,10 +77,6 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
             cats.explode_by_offsets(offsets).u32().unwrap().clone()
         })
         .into_series()
-    }
-
-    fn _set_sorted_flag(&mut self, is_sorted: IsSorted) {
-        self.0.logical_mut().set_sorted_flag(is_sorted)
     }
 
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
@@ -160,10 +156,6 @@ impl private::PrivateSeries for SeriesWrap<CategoricalChunked> {
 }
 
 impl SeriesTrait for SeriesWrap<CategoricalChunked> {
-    fn is_sorted_flag(&self) -> IsSorted {
-        self.0.logical().is_sorted_flag()
-    }
-
     fn rename(&mut self, name: &str) {
         self.0.logical_mut().rename(name);
     }

--- a/crates/polars-core/src/series/implementations/dates_time.rs
+++ b/crates/polars-core/src/series/implementations/dates_time.rs
@@ -8,7 +8,7 @@
 //! (depending on the result) cast back to the original type
 //!
 use std::borrow::Cow;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 
 use ahash::RandomState;
 use polars_arrow::prelude::QuantileInterpolOptions;
@@ -39,10 +39,10 @@ macro_rules! impl_dyn_series {
             fn _dtype(&self) -> &DataType {
                 self.0.dtype()
             }
-            fn _get_flags(&self) -> u8{
+            fn _get_flags(&self) -> Settings{
                 self.0.get_flags()
             }
-            fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+            fn _set_flags(&mut self, flags: Settings){
                 self.0.set_flags(flags)
             }
 
@@ -63,9 +63,6 @@ macro_rules! impl_dyn_series {
                 self.0.cummin(reverse).$into_logical().into_series()
             }
 
-            fn _set_sorted_flag(&mut self, is_sorted: IsSorted) {
-                self.0.deref_mut().set_sorted_flag(is_sorted)
-            }
 
             #[cfg(feature = "zip_with")]
             fn zip_with_same_type(
@@ -166,9 +163,6 @@ macro_rules! impl_dyn_series {
         }
 
         impl SeriesTrait for SeriesWrap<$ca> {
-            fn is_sorted_flag(&self) -> IsSorted {
-                self.0.is_sorted_flag()
-            }
 
             fn rename(&mut self, name: &str) {
                 self.0.rename(name);

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -175,13 +175,7 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
 
 impl SeriesTrait for SeriesWrap<DatetimeChunked> {
     fn is_sorted_flag(&self) -> IsSorted {
-        if self.0.is_sorted_ascending_flag() {
-            IsSorted::Ascending
-        } else if self.0.is_sorted_descending_flag() {
-            IsSorted::Descending
-        } else {
-            IsSorted::Not
-        }
+        self.0.is_sorted_flag()
     }
 
     fn rename(&mut self, name: &str) {

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 
 use ahash::RandomState;
 
@@ -35,10 +35,10 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-    fn _get_flags(&self) -> u8 {
+    fn _get_flags(&self) -> Settings {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: Settings) {
         self.0.set_flags(flags)
     }
 
@@ -63,10 +63,6 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
             .cummin(reverse)
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
             .into_series()
-    }
-
-    fn _set_sorted_flag(&mut self, is_sorted: IsSorted) {
-        self.0.deref_mut().set_sorted_flag(is_sorted)
     }
 
     #[cfg(feature = "zip_with")]
@@ -174,10 +170,6 @@ impl private::PrivateSeries for SeriesWrap<DatetimeChunked> {
 }
 
 impl SeriesTrait for SeriesWrap<DatetimeChunked> {
-    fn is_sorted_flag(&self) -> IsSorted {
-        self.0.is_sorted_flag()
-    }
-
     fn rename(&mut self, name: &str) {
         self.0.rename(name);
     }

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -51,10 +51,10 @@ impl private::PrivateSeries for SeriesWrap<DecimalChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.dtype()
     }
-    fn _get_flags(&self) -> u8 {
+    fn _get_flags(&self) -> Settings {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: Settings) {
         self.0.set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -60,10 +60,10 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             .into_series()
     }
 
-    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: Settings) {
         self.0.deref_mut().set_flags(flags)
     }
-    fn _get_flags(&self) -> u8 {
+    fn _get_flags(&self) -> Settings {
         self.0.deref().get_flags()
     }
 
@@ -207,10 +207,6 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
 }
 
 impl SeriesTrait for SeriesWrap<DurationChunked> {
-    fn is_sorted_flag(&self) -> IsSorted {
-        self.0.is_sorted_flag()
-    }
-
     fn rename(&mut self, name: &str) {
         self.0.rename(name);
     }

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -208,13 +208,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
 
 impl SeriesTrait for SeriesWrap<DurationChunked> {
     fn is_sorted_flag(&self) -> IsSorted {
-        if self.0.is_sorted_ascending_flag() {
-            IsSorted::Ascending
-        } else if self.0.is_sorted_descending_flag() {
-            IsSorted::Descending
-        } else {
-            IsSorted::Not
-        }
+        self.0.is_sorted_flag()
     }
 
     fn rename(&mut self, name: &str) {

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -30,10 +30,10 @@ macro_rules! impl_dyn_series {
                 self.0.ref_field().data_type()
             }
 
-            fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+            fn _set_flags(&mut self, flags: Settings) {
                 self.0.set_flags(flags)
             }
-            fn _get_flags(&self) -> u8 {
+            fn _get_flags(&self) -> Settings {
                 self.0.get_flags()
             }
             fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
@@ -48,10 +48,6 @@ macro_rules! impl_dyn_series {
             #[cfg(feature = "cum_agg")]
             fn _cummin(&self, reverse: bool) -> Series {
                 self.0.cummin(reverse).into_series()
-            }
-
-            fn _set_sorted_flag(&mut self, is_sorted: IsSorted) {
-                self.0.set_sorted_flag(is_sorted)
             }
 
             unsafe fn equal_element(
@@ -149,10 +145,6 @@ macro_rules! impl_dyn_series {
         }
 
         impl SeriesTrait for SeriesWrap<$ca> {
-            fn is_sorted_flag(&self) -> IsSorted {
-                self.0.is_sorted_flag()
-            }
-
             #[cfg(feature = "rolling_window")]
             fn rolling_apply(
                 &self,

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -150,13 +150,7 @@ macro_rules! impl_dyn_series {
 
         impl SeriesTrait for SeriesWrap<$ca> {
             fn is_sorted_flag(&self) -> IsSorted {
-                if self.0.is_sorted_ascending_flag() {
-                    IsSorted::Ascending
-                } else if self.0.is_sorted_descending_flag() {
-                    IsSorted::Descending
-                } else {
-                    IsSorted::Not
-                }
+                self.0.is_sorted_flag()
             }
 
             #[cfg(feature = "rolling_window")]

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -4,11 +4,10 @@ use std::borrow::Cow;
 use super::{private, IntoSeries, SeriesTrait};
 use crate::chunked_array::comparison::*;
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
-use crate::chunked_array::AsSinglePtr;
+use crate::chunked_array::{AsSinglePtr, Settings};
 use crate::frame::groupby::*;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
-use crate::series::IsSorted;
 
 impl private::PrivateSeries for SeriesWrap<ListChunked> {
     fn compute_len(&mut self) {
@@ -20,19 +19,15 @@ impl private::PrivateSeries for SeriesWrap<ListChunked> {
     fn _dtype(&self) -> &DataType {
         self.0.ref_field().data_type()
     }
-    fn _get_flags(&self) -> u8 {
+    fn _get_flags(&self) -> Settings {
         self.0.get_flags()
     }
-    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: Settings) {
         self.0.set_flags(flags)
     }
 
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
-    }
-
-    fn _set_sorted_flag(&mut self, is_sorted: IsSorted) {
-        self.0.set_sorted_flag(is_sorted)
     }
 
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -8,6 +8,7 @@ use crate::chunked_array::{AsSinglePtr, Settings};
 use crate::frame::groupby::*;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
+use crate::series::IsSorted;
 
 impl private::PrivateSeries for SeriesWrap<ListChunked> {
     fn compute_len(&mut self) {

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -8,6 +8,7 @@ use crate::chunked_array::{AsSinglePtr, Settings};
 use crate::frame::groupby::*;
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
+#[cfg(feature = "chunked_ids")]
 use crate::series::IsSorted;
 
 impl private::PrivateSeries for SeriesWrap<ListChunked> {

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -91,11 +91,11 @@ macro_rules! impl_dyn_series {
                 self.0.ref_field().data_type()
             }
 
-            fn _get_flags(&self) -> u8 {
+            fn _get_flags(&self) -> Settings {
                 self.0.get_flags()
             }
 
-            fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+            fn _set_flags(&mut self, flags: Settings) {
                 self.0.set_flags(flags)
             }
 
@@ -111,10 +111,6 @@ macro_rules! impl_dyn_series {
             #[cfg(feature = "cum_agg")]
             fn _cummin(&self, reverse: bool) -> Series {
                 self.0.cummin(reverse).into_series()
-            }
-
-            fn _set_sorted_flag(&mut self, is_sorted: IsSorted) {
-                self.0.set_sorted_flag(is_sorted)
             }
 
             unsafe fn equal_element(
@@ -216,10 +212,6 @@ macro_rules! impl_dyn_series {
         }
 
         impl SeriesTrait for SeriesWrap<$ca> {
-            fn is_sorted_flag(&self) -> IsSorted {
-                self.0.is_sorted_flag()
-            }
-
             #[cfg(feature = "rolling_window")]
             fn rolling_apply(
                 &self,

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -217,13 +217,7 @@ macro_rules! impl_dyn_series {
 
         impl SeriesTrait for SeriesWrap<$ca> {
             fn is_sorted_flag(&self) -> IsSorted {
-                if self.0.is_sorted_ascending_flag() {
-                    IsSorted::Ascending
-                } else if self.0.is_sorted_descending_flag() {
-                    IsSorted::Descending
-                } else {
-                    IsSorted::Not
-                }
+                self.0.is_sorted_flag()
             }
 
             #[cfg(feature = "rolling_window")]

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -50,9 +50,7 @@ impl PrivateSeries for NullChunked {
     }
 
     #[allow(unused)]
-    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
-        Ok(())
-    }
+    fn _set_flags(&mut self, flags: Settings) {}
 
     fn _dtype(&self) -> &DataType {
         &DataType::Null
@@ -66,8 +64,8 @@ impl PrivateSeries for NullChunked {
         ExplodeByOffsets::explode_by_offsets(self, offsets)
     }
 
-    fn _get_flags(&self) -> u8 {
-        0u8
+    fn _get_flags(&self) -> Settings {
+        Settings::empty()
     }
 }
 

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -39,10 +39,10 @@ where
         self.0.dtype()
     }
 
-    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: Settings) {
         self.0.set_flags(flags)
     }
-    fn _get_flags(&self) -> u8 {
+    fn _get_flags(&self) -> Settings {
         self.0.get_flags()
     }
     unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -5,6 +5,7 @@ use ahash::RandomState;
 
 use crate::chunked_array::object::PolarsObjectSafe;
 use crate::chunked_array::ops::compare_inner::{IntoPartialEqInner, PartialEqInner};
+use crate::chunked_array::Settings;
 use crate::frame::groupby::{GroupsProxy, IntoGroupsProxy};
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -26,11 +26,9 @@ impl private::PrivateSeries for SeriesWrap<StructChunked> {
         self.0.ref_field().data_type()
     }
     #[allow(unused)]
-    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
-        Ok(())
-    }
-    fn _get_flags(&self) -> u8 {
-        0u8
+    fn _set_flags(&mut self, flags: Settings) {}
+    fn _get_flags(&self) -> Settings {
+        Settings::empty()
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0

--- a/crates/polars-core/src/series/implementations/utf8.rs
+++ b/crates/polars-core/src/series/implementations/utf8.rs
@@ -25,18 +25,14 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
         self.0.ref_field().data_type()
     }
 
-    fn _set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    fn _set_flags(&mut self, flags: Settings) {
         self.0.set_flags(flags)
     }
-    fn _get_flags(&self) -> u8 {
+    fn _get_flags(&self) -> Settings {
         self.0.get_flags()
     }
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
         self.0.explode_by_offsets(offsets)
-    }
-
-    fn _set_sorted_flag(&mut self, is_sorted: IsSorted) {
-        self.0.set_sorted_flag(is_sorted)
     }
 
     unsafe fn equal_element(&self, idx_self: usize, idx_other: usize, other: &Series) -> bool {
@@ -108,10 +104,6 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
 }
 
 impl SeriesTrait for SeriesWrap<Utf8Chunked> {
-    fn is_sorted_flag(&self) -> IsSorted {
-        self.0.is_sorted_flag()
-    }
-
     fn rename(&mut self, name: &str) {
         self.0.rename(name);
     }

--- a/crates/polars-core/src/series/implementations/utf8.rs
+++ b/crates/polars-core/src/series/implementations/utf8.rs
@@ -109,13 +109,7 @@ impl private::PrivateSeries for SeriesWrap<Utf8Chunked> {
 
 impl SeriesTrait for SeriesWrap<Utf8Chunked> {
     fn is_sorted_flag(&self) -> IsSorted {
-        if self.0.is_sorted_ascending_flag() {
-            IsSorted::Ascending
-        } else if self.0.is_sorted_descending_flag() {
-            IsSorted::Descending
-        } else {
-            IsSorted::Not
-        }
+        self.0.is_sorted_flag()
     }
 
     fn rename(&mut self, name: &str) {

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -206,17 +206,7 @@ impl Series {
 
     pub fn set_sorted_flag(&mut self, sorted: IsSorted) {
         let mut flags = self.get_flags();
-        match sorted {
-            IsSorted::Not => flags.remove(Settings::SORTED_DSC | Settings::SORTED_ASC),
-            IsSorted::Ascending => {
-                flags.remove(Settings::SORTED_DSC);
-                flags.insert(Settings::SORTED_ASC);
-            },
-            IsSorted::Descending => {
-                flags.remove(Settings::SORTED_ASC);
-                flags.insert(Settings::SORTED_DSC);
-            },
-        }
+        flags.set_sorted_flag(sorted);
         self.set_flags(flags);
     }
 

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -27,6 +27,7 @@ use num_traits::NumCast;
 use rayon::prelude::*;
 pub use series_trait::{IsSorted, *};
 
+use crate::chunked_array::Settings;
 #[cfg(feature = "rank")]
 use crate::prelude::unique::rank::rank;
 #[cfg(feature = "zip_with")]
@@ -192,20 +193,42 @@ impl Series {
         &mut *chunks
     }
 
+    pub fn is_sorted_flag(&self) -> IsSorted {
+        let flags = self.get_flags();
+        if flags.contains(Settings::SORTED_DSC) {
+            IsSorted::Descending
+        } else if flags.contains(Settings::SORTED_ASC) {
+            IsSorted::Ascending
+        } else {
+            IsSorted::Not
+        }
+    }
+
     pub fn set_sorted_flag(&mut self, sorted: IsSorted) {
-        let inner = self._get_inner_mut();
-        inner._set_sorted_flag(sorted)
+        let mut flags = self.get_flags();
+        match sorted {
+            IsSorted::Not => flags.remove(Settings::SORTED_DSC | Settings::SORTED_ASC),
+            IsSorted::Ascending => {
+                flags.remove(Settings::SORTED_DSC);
+                flags.insert(Settings::SORTED_ASC);
+            },
+            IsSorted::Descending => {
+                flags.remove(Settings::SORTED_ASC);
+                flags.insert(Settings::SORTED_DSC);
+            },
+        }
+        self.set_flags(flags);
     }
 
     pub(crate) fn clear_settings(&mut self) {
-        let _ = self.set_flags(0u8);
+        self.set_flags(Settings::empty());
     }
     #[allow(dead_code)]
-    pub(crate) fn get_flags(&self) -> u8 {
+    pub fn get_flags(&self) -> Settings {
         self.0._get_flags()
     }
 
-    pub(crate) fn set_flags(&mut self, flags: u8) -> PolarsResult<()> {
+    pub(crate) fn set_flags(&mut self, flags: Settings) {
         self._get_inner_mut()._set_flags(flags)
     }
 

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -46,6 +46,7 @@ pub(crate) mod private {
 
     use super::*;
     use crate::chunked_array::ops::compare_inner::{PartialEqInner, PartialOrdInner};
+    use crate::chunked_array::Settings;
     #[cfg(feature = "rows")]
     use crate::frame::groupby::GroupsProxy;
 
@@ -79,9 +80,9 @@ pub(crate) mod private {
 
         fn compute_len(&mut self);
 
-        fn _get_flags(&self) -> u8;
+        fn _get_flags(&self) -> Settings;
 
-        fn _set_flags(&mut self, flags: u8) -> PolarsResult<()>;
+        fn _set_flags(&mut self, flags: Settings);
 
         fn explode_by_offsets(&self, _offsets: &[i64]) -> Series {
             invalid_operation_panic!(explode_by_offsets, self)
@@ -97,10 +98,6 @@ pub(crate) mod private {
         #[cfg(feature = "cum_agg")]
         fn _cummin(&self, _reverse: bool) -> Series {
             panic!("operation cummin not supported for this dtype")
-        }
-
-        fn _set_sorted_flag(&mut self, _is_sorted: IsSorted) {
-            // ignore
         }
 
         unsafe fn equal_element(
@@ -194,11 +191,6 @@ pub(crate) mod private {
 pub trait SeriesTrait:
     Send + Sync + private::PrivateSeries + private::PrivateSeriesNumeric
 {
-    /// Check if [`Series`] is sorted.
-    fn is_sorted_flag(&self) -> IsSorted {
-        IsSorted::Not
-    }
-
     /// Rename the Series.
     fn rename(&mut self, name: &str);
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -233,6 +233,9 @@ name = "bitflags"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "brotli"

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2293,7 +2293,7 @@ class DataFrame:
         ...     }
         ... )
         >>> df.write_json()
-        '{"columns":[{"name":"foo","datatype":"Int64","bit_settings":0,"values":[1,2,3]},{"name":"bar","datatype":"Int64","bit_settings":0,"values":[6,7,8]}]}'
+        '{"columns":[{"name":"foo","datatype":"Int64","bit_settings":"","values":[1,2,3]},{"name":"bar","datatype":"Int64","bit_settings":"","values":[6,7,8]}]}'
         >>> df.write_json(row_oriented=True)
         '[{"foo":1,"bar":6},{"foo":2,"bar":7},{"foo":3,"bar":8}]'
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -846,7 +846,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         >>> lf = pl.LazyFrame({"a": [1, 2, 3]}).sum()
         >>> json = lf.serialize()
         >>> json
-        '{"LocalProjection":{"expr":[{"Agg":{"Sum":{"Column":"a"}}}],"input":{"DataFrameScan":{"df":{"columns":[{"name":"a","datatype":"Int64","bit_settings":0,"values":[1,2,3]}]},"schema":{"inner":{"a":"Int64"}},"output_schema":null,"projection":null,"selection":null}},"schema":{"inner":{"a":"Int64"}}}}'
+        '{"LocalProjection":{"expr":[{"Agg":{"Sum":{"Column":"a"}}}],"input":{"DataFrameScan":{"df":{"columns":[{"name":"a","datatype":"Int64","bit_settings":"","values":[1,2,3]}]},"schema":{"inner":{"a":"Int64"}},"output_schema":null,"projection":null,"selection":null}},"schema":{"inner":{"a":"Int64"}}}}'
 
         The logical plan can later be deserialized back into a LazyFrame.
 

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -35,7 +35,7 @@ def test_to_from_file(df: pl.DataFrame, tmp_path: Path) -> None:
 def test_write_json_to_string() -> None:
     # Tests if it runs if no arg given
     df = pl.DataFrame({"a": [1, 2, 3]})
-    expected_str = '{"columns":[{"name":"a","datatype":"Int64","bit_settings":0,"values":[1,2,3]}]}'
+    expected_str = '{"columns":[{"name":"a","datatype":"Int64","bit_settings":"","values":[1,2,3]}]}'
     assert df.write_json() == expected_str
 
 


### PR DESCRIPTION
- remove is_sorted_flag / _set_sorted_flag from series traits
- Use Settings struct instead of u8
