### PR TITLE
feat(rust): be more permissive on predicate pushdown to left side of left join

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
@@ -42,7 +42,7 @@ fn should_block_join_specific(ae: &AExpr, how: &JoinType) -> LeftRight<bool> {
             } else {
                 join_produces_null(how)
             }
-        }
+        },
         _ => LeftRight(false, false),
     }
 }

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-// Enable information about individual sides of a join
+// information concerning individual sides of a join
 #[derive(PartialEq, Eq)]
 struct LeftRight<T>(T, T);
 
@@ -50,21 +50,18 @@ fn should_block_join_specific(ae: &AExpr, how: &JoinType) -> LeftRight<bool> {
 fn join_produces_null(how: &JoinType) -> LeftRight<bool> {
     #[cfg(feature = "asof_join")]
     {
-        if matches!(
-            how,
-            JoinType::Left | JoinType::Outer | JoinType::Cross | JoinType::AsOf(_)
-        ) {
-            LeftRight(true, true)
-        } else {
-            LeftRight(false, false)
+        match how {
+            JoinType::Left => LeftRight(false, true),
+            JoinType::Outer | JoinType::Cross | JoinType::AsOf(_) => LeftRight(true, true),
+            _ => LeftRight(false, false),
         }
     }
     #[cfg(not(feature = "asof_join"))]
     {
-        if matches!(how, JoinType::Left | JoinType::Outer | JoinType::Cross) {
-            LeftRight(true, true)
-        } else {
-            LeftRight(false, false)
+        match how {
+            JoinType::Left => LeftRight(false, true),
+            JoinType::Outer | JoinType::Cross => LeftRight(true, true),
+            _ => LeftRight(false, false),
         }
     }
 }

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -176,6 +176,22 @@ fn test_predicate_pushdown_blocked_by_outer_join() -> PolarsResult<()> {
 }
 
 #[test]
+fn test_binaryexpr_pushdown_left_join_9506() -> PolarsResult<()> {
+    let df1 = df! {
+        "a" => ["a1"],
+        "b" => ["b1"]
+    }?;
+    let df2 = df! {
+        "b" => ["b1"],
+        "c" => ["c1"]
+    }?;
+    let df = df1.lazy().left_join(df2.lazy(), col("b"), col("b"));
+    let out = df.filter(col("c").eq(lit("c2"))).collect()?;
+    assert!(out.height() == 0);
+    Ok(())
+}
+
+#[test]
 fn test_count_blocked_at_union_3963() -> PolarsResult<()> {
     let lf1 = df![
         "k" => ["x", "x", "y"],


### PR DESCRIPTION
Closes #9506

The main alteration is to introduce a tuple struct that allows to differentiate if a predicate pushdown should be blocked to the left or the right side of a join. I have only altered behaviour for "standard" left joins because I have no experience with asof-joins.