### PR TITLE
fix(python): address inconsistency in init from square numpy arrays with/without an explicit schema

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1236,8 +1236,10 @@ def numpy_to_pydf(
                 orient = "row"
 
             elif orient is None and schema is not None:
-                # infer orientation from 'schema' param
-                if len(schema) == shape[0]:
+                # infer orientation from 'schema' param; if square array
+                # we maintain the default convention where first axis = rows
+                n_schema_cols = len(schema)
+                if n_schema_cols == shape[0] and n_schema_cols != shape[1]:
                     orient = "col"
                     n_columns = shape[0]
                 else:

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -526,6 +526,15 @@ def test_init_ndarray(monkeypatch: Any) -> None:
             orient="row",
         )
 
+    # 2D square array; ensure that we maintain convention
+    # (first axis = rows) with/without an explicit schema
+    arr = np.arange(4).reshape(2, 2)
+    assert (
+        [(0, 1), (2, 3)]
+        == pl.DataFrame(arr).rows()
+        == pl.DataFrame(arr, schema=["a", "b"]).rows()
+    )
+
     # 3D array
     with pytest.raises(ValueError):
         _ = pl.DataFrame(np.random.randn(2, 2, 2))


### PR DESCRIPTION
Closes #10424.

The presence of a schema should not cause transposition on init from square numpy arrays.