### PR TITLE
fix(rust): Fix incorrect handling of VisitRecursion::Skip.

### DIFF
--- a/crates/polars-plan/src/logical_plan/visitor/expr.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/expr.rs
@@ -14,9 +14,9 @@ impl TreeWalker for Expr {
 
         for child in scratch {
             match op(child)? {
-                VisitRecursion::Continue => {},
+                // let the recursion continue
+                VisitRecursion::Continue | VisitRecursion::Skip => {},
                 // early stop
-                VisitRecursion::Skip => return Ok(VisitRecursion::Continue),
                 VisitRecursion::Stop => return Ok(VisitRecursion::Stop),
             }
         }
@@ -233,9 +233,9 @@ impl TreeWalker for AexprNode {
                 arena: self.arena,
             };
             match op(&aenode)? {
-                VisitRecursion::Continue => {},
+                // let the recursion continue
+                VisitRecursion::Continue | VisitRecursion::Skip => {},
                 // early stop
-                VisitRecursion::Skip => return Ok(VisitRecursion::Continue),
                 VisitRecursion::Stop => return Ok(VisitRecursion::Stop),
             }
         }

--- a/crates/polars-plan/src/logical_plan/visitor/lp.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/lp.rs
@@ -107,9 +107,9 @@ impl TreeWalker for ALogicalPlanNode {
                 arena: self.arena,
             };
             match op(&lp_node)? {
-                VisitRecursion::Continue => {},
+                // let the recursion continue
+                VisitRecursion::Continue | VisitRecursion::Skip => {},
                 // early stop
-                VisitRecursion::Skip => return Ok(VisitRecursion::Continue),
                 VisitRecursion::Stop => return Ok(VisitRecursion::Stop),
             }
         }

--- a/crates/polars-plan/src/logical_plan/visitor/visitors.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/visitors.rs
@@ -21,10 +21,9 @@ pub trait TreeWalker: Sized {
         };
 
         match self.apply_children(&mut |node| node.visit(visitor))? {
-            VisitRecursion::Continue => {},
-            // If the recursion should skip, do not apply to its children. And let the recursion continue
-            VisitRecursion::Skip => return Ok(VisitRecursion::Continue),
-            // If the recursion should stop, do not apply to its children
+            // let the recursion continue
+            VisitRecursion::Continue | VisitRecursion::Skip => {},
+            // If the recursion should stop, no further post visit will be performed
             VisitRecursion::Stop => return Ok(VisitRecursion::Stop),
         }
 

--- a/py-polars/tests/unit/test_cse.py
+++ b/py-polars/tests/unit/test_cse.py
@@ -358,3 +358,11 @@ def test_cse_10441() -> None:
     assert pl.LazyFrame({"a": [1, 2, 3], "b": [3, 2, 1]}).select(
         pl.col("a").sum() + pl.col("a").sum() + pl.col("b").sum()
     ).collect(comm_subexpr_elim=True).to_dict(False) == {"a": [18]}
+
+
+def test_cse_10452() -> None:
+    q = pl.LazyFrame({"a": [1, 2, 3], "b": [3, 2, 1]}).select(
+        pl.col("b").sum() + pl.col("a").sum().over([pl.col("b")]) + pl.col("b").sum()
+    )
+    assert "__POLARS_CSE" in q.explain(comm_subexpr_elim=True)
+    assert q.collect(comm_subexpr_elim=True).to_dict(False) == {"b": [13, 14, 15]}


### PR DESCRIPTION
I'm not sure if this is a suitable fix, but many comments in the code indicate that the purpose of `VisitRecursion::Skip` is to no longer continue visiting subexpressions(no hint of also skipping the visit of sibling exprs).  If that's indeed the case, perhaps we should at least fix these comments.

This fixes #10451. 