### PR TITLE
depr(python): Deprecate behavior of list/tuple inputs for `lit`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -54,7 +54,7 @@ from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
 from polars.exceptions import NoRowsReturnedError, TooManyRowsReturnedError
-from polars.functions.lazy import col, lit
+from polars.functions import col, lit
 from polars.io._utils import _is_glob_pattern, _is_local_file
 from polars.io.excel._write_utils import (
     _unpack_multi_column_dict,

--- a/py-polars/polars/functions/__init__.py
+++ b/py-polars/polars/functions/__init__.py
@@ -48,7 +48,6 @@ from polars.functions.lazy import (
     head,
     implode,
     last,
-    lit,
     map,
     mean,
     median,
@@ -63,6 +62,7 @@ from polars.functions.lazy import (
     tail,
     var,
 )
+from polars.functions.lit import lit
 from polars.functions.range import (
     arange,
     date_range,

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextlib
-from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, overload
 
 import polars._reexport as pl
@@ -9,23 +8,14 @@ from polars.datatypes import (
     DTYPE_TEMPORAL_UNITS,
     Date,
     Datetime,
-    Duration,
     Int64,
-    Time,
     is_polars_dtype,
 )
-from polars.dependencies import _check_for_numpy
-from polars.dependencies import numpy as np
 from polars.utils._parse_expr_input import (
     parse_as_expression,
     parse_as_list_of_expressions,
 )
 from polars.utils._wrap import wrap_df, wrap_expr
-from polars.utils.convert import (
-    _datetime_to_pl_timestamp,
-    _time_to_pl_time,
-    _timedelta_to_pl_timedelta,
-)
 from polars.utils.deprecation import (
     deprecate_function,
     deprecate_renamed_parameter,
@@ -46,7 +36,6 @@ if TYPE_CHECKING:
         IntoExpr,
         PolarsDataType,
         RollingInterpolationMethod,
-        TimeUnit,
     )
 
 
@@ -862,128 +851,6 @@ def tail(column: str | Series, n: int = 10) -> Expr | Series:
         )
         return column.tail(n)
     return col(column).tail(n)
-
-
-def lit(
-    value: Any, dtype: PolarsDataType | None = None, *, allow_object: bool = False
-) -> Expr:
-    """
-    Return an expression representing a literal value.
-
-    Parameters
-    ----------
-    value
-        Value that should be used as a `literal`.
-    dtype
-        Optionally define a dtype.
-    allow_object
-        If type is unknown use an 'object' type.
-        By default, we will raise a `ValueException`
-        if the type is unknown.
-
-    Examples
-    --------
-    Literal scalar values:
-
-    >>> pl.lit(1)  # doctest: +IGNORE_RESULT
-    >>> pl.lit(5.5)  # doctest: +IGNORE_RESULT
-    >>> pl.lit(None)  # doctest: +IGNORE_RESULT
-    >>> pl.lit("foo_bar")  # doctest: +IGNORE_RESULT
-    >>> pl.lit(date(2021, 1, 20))  # doctest: +IGNORE_RESULT
-    >>> pl.lit(datetime(2023, 3, 31, 10, 30, 45))  # doctest: +IGNORE_RESULT
-
-    Literal list/Series data (1D):
-
-    >>> pl.lit([1, 2, 3])  # doctest: +IGNORE_RESULT
-    >>> pl.lit(pl.Series("x", [1, 2, 3]))  # doctest: +IGNORE_RESULT
-
-    Literal list/Series data (2D):
-
-    >>> pl.lit([[1, 2], [3, 4]])  # doctest: +IGNORE_RESULT
-    >>> pl.lit(pl.Series("y", [[1, 2], [3, 4]]))  # doctest: +IGNORE_RESULT
-
-    Expected datatypes
-
-    - ''pl.lit([])'' -> empty  Series Float32
-    - ''pl.lit([1, 2, 3])'' -> Series Int64
-    - ''pl.lit([[]])''-> empty  Series List<Null>
-    - ''pl.lit([[1, 2, 3]])'' -> Series List<i64>
-    - ''pl.lit(None)'' -> Series Null
-
-    """
-    time_unit: TimeUnit
-
-    if isinstance(value, datetime):
-        time_unit = "us" if dtype is None else getattr(dtype, "time_unit", "us")
-        time_zone = (
-            value.tzinfo
-            if getattr(dtype, "time_zone", None) is None
-            else getattr(dtype, "time_zone", None)
-        )
-        if (
-            value.tzinfo is not None
-            and getattr(dtype, "time_zone", None) is not None
-            and dtype.time_zone != str(value.tzinfo)  # type: ignore[union-attr]
-        ):
-            raise TypeError(
-                f"Time zone of dtype ({dtype.time_zone}) differs from time zone of value ({value.tzinfo})."  # type: ignore[union-attr]
-            )
-        e = lit(_datetime_to_pl_timestamp(value, time_unit)).cast(Datetime(time_unit))
-        if time_zone is not None:
-            return e.dt.replace_time_zone(str(time_zone))
-        else:
-            return e
-
-    elif isinstance(value, timedelta):
-        time_unit = "us" if dtype is None else getattr(dtype, "time_unit", "us")
-        return lit(_timedelta_to_pl_timedelta(value, time_unit)).cast(
-            Duration(time_unit)
-        )
-
-    elif isinstance(value, time):
-        return lit(_time_to_pl_time(value)).cast(Time)
-
-    elif isinstance(value, date):
-        return lit(datetime(value.year, value.month, value.day)).cast(Date)
-
-    elif isinstance(value, pl.Series):
-        name = value.name
-        value = value._s
-        e = wrap_expr(plr.lit(value, allow_object))
-        if name == "":
-            return e
-        return e.alias(name)
-
-    elif (_check_for_numpy(value) and isinstance(value, np.ndarray)) or isinstance(
-        value, (list, tuple)
-    ):
-        return lit(pl.Series("", value))
-
-    elif dtype:
-        return wrap_expr(plr.lit(value, allow_object)).cast(dtype)
-
-    try:
-        # numpy literals like np.float32(0) have item/dtype
-        item = value.item()
-
-        # numpy item() is py-native datetime/timedelta when units < 'ns'
-        if isinstance(item, (datetime, timedelta)):
-            return lit(item)
-
-        # handle 'ns' units
-        if isinstance(item, int) and hasattr(value, "dtype"):
-            dtype_name = value.dtype.name
-            if dtype_name.startswith(("datetime64[", "timedelta64[")):
-                time_unit = dtype_name[11:-1]
-                return lit(item).cast(
-                    Datetime(time_unit)
-                    if dtype_name.startswith("date")
-                    else Duration(time_unit)
-                )
-
-    except AttributeError:
-        item = value
-    return wrap_expr(plr.lit(item, allow_object))
 
 
 def corr(

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import contextlib
+from datetime import date, datetime, time, timedelta
+from typing import TYPE_CHECKING, Any
+
+import polars._reexport as pl
+from polars.datatypes import Date, Datetime, Duration, Time
+from polars.dependencies import _check_for_numpy
+from polars.dependencies import numpy as np
+from polars.utils._wrap import wrap_expr
+from polars.utils.convert import (
+    _datetime_to_pl_timestamp,
+    _time_to_pl_time,
+    _timedelta_to_pl_timedelta,
+)
+
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    import polars.polars as plr
+
+
+if TYPE_CHECKING:
+    from polars import Expr
+    from polars.type_aliases import PolarsDataType, TimeUnit
+
+
+def lit(
+    value: Any, dtype: PolarsDataType | None = None, *, allow_object: bool = False
+) -> Expr:
+    """
+    Return an expression representing a literal value.
+
+    Parameters
+    ----------
+    value
+        Value that should be used as a `literal`.
+    dtype
+        Optionally define a dtype.
+    allow_object
+        If type is unknown use an 'object' type.
+        By default, we will raise a `ValueException`
+        if the type is unknown.
+
+    Examples
+    --------
+    Literal scalar values:
+
+    >>> pl.lit(1)  # doctest: +IGNORE_RESULT
+    >>> pl.lit(5.5)  # doctest: +IGNORE_RESULT
+    >>> pl.lit(None)  # doctest: +IGNORE_RESULT
+    >>> pl.lit("foo_bar")  # doctest: +IGNORE_RESULT
+    >>> pl.lit(date(2021, 1, 20))  # doctest: +IGNORE_RESULT
+    >>> pl.lit(datetime(2023, 3, 31, 10, 30, 45))  # doctest: +IGNORE_RESULT
+
+    Literal list/Series data (1D):
+
+    >>> pl.lit([1, 2, 3])  # doctest: +IGNORE_RESULT
+    >>> pl.lit(pl.Series("x", [1, 2, 3]))  # doctest: +IGNORE_RESULT
+
+    Literal list/Series data (2D):
+
+    >>> pl.lit([[1, 2], [3, 4]])  # doctest: +IGNORE_RESULT
+    >>> pl.lit(pl.Series("y", [[1, 2], [3, 4]]))  # doctest: +IGNORE_RESULT
+
+    Expected datatypes
+
+    - ''pl.lit([])'' -> empty  Series Float32
+    - ''pl.lit([1, 2, 3])'' -> Series Int64
+    - ''pl.lit([[]])''-> empty  Series List<Null>
+    - ''pl.lit([[1, 2, 3]])'' -> Series List<i64>
+    - ''pl.lit(None)'' -> Series Null
+
+    """
+    time_unit: TimeUnit
+
+    if isinstance(value, datetime):
+        time_unit = "us" if dtype is None else getattr(dtype, "time_unit", "us")
+        time_zone = (
+            value.tzinfo
+            if getattr(dtype, "time_zone", None) is None
+            else getattr(dtype, "time_zone", None)
+        )
+        if (
+            value.tzinfo is not None
+            and getattr(dtype, "time_zone", None) is not None
+            and dtype.time_zone != str(value.tzinfo)  # type: ignore[union-attr]
+        ):
+            raise TypeError(
+                f"Time zone of dtype ({dtype.time_zone}) differs from time zone of value ({value.tzinfo})."  # type: ignore[union-attr]
+            )
+        e = lit(_datetime_to_pl_timestamp(value, time_unit)).cast(Datetime(time_unit))
+        if time_zone is not None:
+            return e.dt.replace_time_zone(str(time_zone))
+        else:
+            return e
+
+    elif isinstance(value, timedelta):
+        time_unit = "us" if dtype is None else getattr(dtype, "time_unit", "us")
+        return lit(_timedelta_to_pl_timedelta(value, time_unit)).cast(
+            Duration(time_unit)
+        )
+
+    elif isinstance(value, time):
+        return lit(_time_to_pl_time(value)).cast(Time)
+
+    elif isinstance(value, date):
+        return lit(datetime(value.year, value.month, value.day)).cast(Date)
+
+    elif isinstance(value, pl.Series):
+        name = value.name
+        value = value._s
+        e = wrap_expr(plr.lit(value, allow_object))
+        if name == "":
+            return e
+        return e.alias(name)
+
+    elif (_check_for_numpy(value) and isinstance(value, np.ndarray)) or isinstance(
+        value, (list, tuple)
+    ):
+        return lit(pl.Series("", value))
+
+    elif dtype:
+        return wrap_expr(plr.lit(value, allow_object)).cast(dtype)
+
+    try:
+        # numpy literals like np.float32(0) have item/dtype
+        item = value.item()
+
+        # numpy item() is py-native datetime/timedelta when units < 'ns'
+        if isinstance(item, (datetime, timedelta)):
+            return lit(item)
+
+        # handle 'ns' units
+        if isinstance(item, int) and hasattr(value, "dtype"):
+            dtype_name = value.dtype.name
+            if dtype_name.startswith(("datetime64[", "timedelta64[")):
+                time_unit = dtype_name[11:-1]
+                return lit(item).cast(
+                    Datetime(time_unit)
+                    if dtype_name.startswith("date")
+                    else Duration(time_unit)
+                )
+
+    except AttributeError:
+        item = value
+    return wrap_expr(plr.lit(item, allow_object))

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -42,6 +42,16 @@ def lit(
         By default, we will raise a `ValueException`
         if the type is unknown.
 
+    Notes
+    -----
+    Expected datatypes
+
+    - ``pl.lit([])`` -> empty  Series Float32
+    - ``pl.lit([1, 2, 3])`` -> Series Int64
+    - ``pl.lit([[]])``-> empty  Series List<Null>
+    - ``pl.lit([[1, 2, 3]])`` -> Series List<i64>
+    - ``pl.lit(None)`` -> Series Null
+
     Examples
     --------
     Literal scalar values:
@@ -55,21 +65,13 @@ def lit(
 
     Literal list/Series data (1D):
 
-    >>> pl.lit([1, 2, 3])  # doctest: +IGNORE_RESULT
+    >>> pl.lit([1, 2, 3])  # doctest: +SKIP
     >>> pl.lit(pl.Series("x", [1, 2, 3]))  # doctest: +IGNORE_RESULT
 
     Literal list/Series data (2D):
 
-    >>> pl.lit([[1, 2], [3, 4]])  # doctest: +IGNORE_RESULT
+    >>> pl.lit([[1, 2], [3, 4]])  # doctest: +SKIP
     >>> pl.lit(pl.Series("y", [[1, 2], [3, 4]]))  # doctest: +IGNORE_RESULT
-
-    Expected datatypes
-
-    - ''pl.lit([])'' -> empty  Series Float32
-    - ''pl.lit([1, 2, 3])'' -> Series Int64
-    - ''pl.lit([[]])''-> empty  Series List<Null>
-    - ''pl.lit([[1, 2, 3]])'' -> Series List<i64>
-    - ''pl.lit(None)'' -> Series Null
 
     """
     time_unit: TimeUnit

--- a/py-polars/tests/unit/functions/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/test_as_datatype.py
@@ -457,16 +457,21 @@ def test_struct_lit_cast() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     schema = {"a": pl.Int64, "b": pl.List(pl.Int64)}
 
-    for lit in [pl.lit(None), pl.lit([[]])]:
-        s = df.select(pl.struct([pl.col("a"), lit.alias("b")], schema=schema))["a"]  # type: ignore[arg-type]
-        assert s.dtype == pl.Struct(
-            [pl.Field("a", pl.Int64), pl.Field("b", pl.List(pl.Int64))]
+    for lit in [pl.lit(None), pl.lit(pl.Series([[]]))]:
+        out = df.select(pl.struct([pl.col("a"), lit.alias("b")], schema=schema))["a"]  # type: ignore[arg-type]
+
+        expected = pl.Series(
+            "a",
+            [
+                {"a": 1, "b": None},
+                {"a": 2, "b": None},
+                {"a": 3, "b": None},
+            ],
+            dtype=pl.Struct(
+                [pl.Field("a", pl.Int64), pl.Field("b", pl.List(pl.Int64))]
+            ),
         )
-        assert s.to_list() == [
-            {"a": 1, "b": None},
-            {"a": 2, "b": None},
-            {"a": 3, "b": None},
-        ]
+        assert_series_equal(out, expected)
 
 
 def test_suffix_in_struct_creation() -> None:

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import Any, Sequence
+
+import pytest
+
+import polars as pl
+
+
+@pytest.mark.parametrize(
+    "sequence",
+    [
+        [[1, 2], [3, 4, 5]],
+        (1, 2, 3),
+    ],
+)
+def test_lit_deprecated_sequence_input(sequence: Sequence[Any]) -> None:
+    with pytest.deprecated_call():
+        pl.lit(sequence)

--- a/py-polars/tests/unit/operations/test_random.py
+++ b/py-polars/tests/unit/operations/test_random.py
@@ -85,13 +85,12 @@ def test_rank_random_series() -> None:
 def test_shuffle_expr() -> None:
     # setting 'random.seed' should lead to reproducible results
     s = pl.Series("a", range(20))
-    s_list = s.to_list()
 
     random.seed(1)
     result1 = pl.select(pl.lit(s).shuffle()).to_series()
 
     random.seed(1)
-    result2 = pl.select(a=pl.lit(s_list).shuffle()).to_series()
+    result2 = pl.select(pl.lit(s).shuffle()).to_series()
     assert_series_equal(result1, result2)
 
 

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -790,8 +790,8 @@ def test_lit_dtypes() -> None:
             "f32": lit_series(0, pl.Float32),
             "u16": lit_series(0, pl.UInt16),
             "i16": lit_series(0, pl.Int16),
-            "i64": lit_series([8], None),
-            "list_i64": lit_series([[1, 2, 3]], None),
+            "i64": lit_series(pl.Series([8]), None),
+            "list_i64": lit_series(pl.Series([[1, 2, 3]]), None),
         }
     )
     assert df.dtypes == [


### PR DESCRIPTION
Prepares #9516

#### Changes

* Move `lit` to its own module - it's pretty long/complex and I want to break up the `lazy` module anyway.
* Add a `DeprecationWarning` when the input is `list` or `tuple`. 

#### Examples

Input:

```python
pl.select(pl.lit([1, 2]))
```
Old behavior:

```
shape: (2, 1)
┌─────┐
│     │
│ --- │
│ i64 │
╞═════╡
│ 1   │
│ 2   │
└─────┘
```

New behavior (to be added later in a breaking change):

```
shape: (1, 1)
┌───────────┐
│ literal   │
│ ---       │
│ list[i64] │
╞═══════════╡
│ [1, 2]    │
└───────────┘
```

Retain the old behavior by wrapping the list in a `Series`:

```python
pl.select(pl.lit(pl.Series([1, 2])))
```
```
shape: (2, 1)
┌─────┐
│     │
│ --- │
│ i64 │
╞═════╡
│ 1   │
│ 2   │
└─────┘
```