### PR TITLE
docs(python): add `vertical_relaxed` example for `pl.concat`

### DIFF
--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -33,7 +33,7 @@ def concat(
     ----------
     items
         DataFrames, LazyFrames, or Series to concatenate.
-    how : {'vertical', 'diagonal', 'horizontal', 'align'}
+    how : {'vertical', 'vertical_relaxed', 'diagonal', 'horizontal', 'align'}
         Series only support the `vertical` strategy.
         LazyFrames do not support the `horizontal` strategy.
 
@@ -67,6 +67,19 @@ def concat(
     ╞═════╪═════╡
     │ 1   ┆ 3   │
     │ 2   ┆ 4   │
+    └─────┴─────┘
+
+    >>> df1 = pl.DataFrame({"a": [1], "b": [3]})
+    >>> df2 = pl.DataFrame({"a": [2.5], "b": [4]})
+    >>> pl.concat([df1, df2], how="vertical_relaxed")  # 'a' coerced into f64
+    shape: (2, 2)
+    ┌─────┬─────┐
+    │ a   ┆ b   │
+    │ --- ┆ --- │
+    │ f64 ┆ i64 │
+    ╞═════╪═════╡
+    │ 1.0 ┆ 3   │
+    │ 2.5 ┆ 4   │
     └─────┴─────┘
 
     >>> df_h1 = pl.DataFrame({"l1": [1, 2], "l2": [3, 4]})


### PR DESCRIPTION
From https://stackoverflow.com/questions/76898926/

I noticed `vertical_relaxed` is not present in the `how={...}` section of the docs which can make it easy to miss.

It also seems like having an example could be useful.

Perhaps it would also make sense for `.concat()` to mention `vertical_relaxed` in the error message?