### PR TITLE
fix(rust): join_asof missing `tolerance` implementation, address edge-cases

### DIFF
--- a/crates/polars-core/src/frame/asof_join/asof.rs
+++ b/crates/polars-core/src/frame/asof_join/asof.rs
@@ -182,6 +182,62 @@ pub(super) fn join_asof_backward<T: PartialOrd + Copy + Debug>(
     out
 }
 
+pub(super) fn join_asof_nearest_with_tolerance<T: PartialOrd + Copy + Debug + Sub<Output = T>>(
+    left: &[T],
+    right: &[T],
+    tolerance: T,
+) -> Vec<Option<IdxSize>> {
+    let mut out = Vec::with_capacity(left.len());
+    let mut offset = 0 as IdxSize;
+    let max_value = tolerance;
+    let mut dist: T = max_value;
+
+    for &val_l in left {
+        loop {
+            match right.get(offset as usize) {
+                Some(&val_r) => {
+                    // This is (val_r - val_l).abs(), but works on strings/dates
+                    let dist_curr = if val_r > val_l {
+                        val_r - val_l
+                    } else {
+                        val_l - val_r
+                    };
+                    if dist_curr <= dist {
+                        // candidate for match
+                        dist = dist_curr;
+                        offset += 1;
+                    } else {
+                        // distance has increased, we're now farther away, so previous element was closest
+                        out.push(Some(offset - 1));
+
+                        // reset distance
+                        dist = max_value;
+
+                        // The next left-item may match on the same item, so we need to rewind the offset
+                        offset -= 1;
+                        break;
+                    }
+                },
+
+                None => {
+                    if offset > 1 {
+                        // we've reached the end with no matches, so the last item is the nearest for all remaining
+                        out.extend(
+                            std::iter::repeat(Some(offset - 1)).take(left.len() - out.len()),
+                        );
+                    } else {
+                        // this is only hit when the right frame is empty
+                        out.extend(std::iter::repeat(None).take(left.len() - out.len()));
+                    }
+                    return out;
+                },
+            }
+        }
+    }
+
+    out
+}
+
 pub(super) fn join_asof_nearest<T: PartialOrd + Copy + Debug + Sub<Output = T> + Bounded>(
     left: &[T],
     right: &[T],

--- a/crates/polars-core/src/frame/asof_join/asof.rs
+++ b/crates/polars-core/src/frame/asof_join/asof.rs
@@ -190,7 +190,7 @@ pub(super) fn join_asof_nearest_with_tolerance<
     tolerance: T,
 ) -> Vec<Option<IdxSize>> {
     let n_left = left.len();
-    
+
     if left.is_empty() {
         return Vec::new();
     }

--- a/crates/polars-core/src/frame/asof_join/mod.rs
+++ b/crates/polars-core/src/frame/asof_join/mod.rs
@@ -103,8 +103,16 @@ where
                     )
                 },
             },
-            AsofStrategy::Nearest => {
-                join_asof_nearest(ca.cont_slice().unwrap(), other.cont_slice().unwrap())
+            AsofStrategy::Nearest => match tolerance {
+                None => join_asof_nearest(ca.cont_slice().unwrap(), other.cont_slice().unwrap()),
+                Some(tolerance) => {
+                    let tolerance = tolerance.extract::<T::Native>().unwrap();
+                    join_asof_nearest_with_tolerance(
+                        self.cont_slice().unwrap(),
+                        other.cont_slice().unwrap(),
+                        tolerance,
+                    )
+                }
             },
         };
         Ok(out)

--- a/crates/polars-core/src/frame/asof_join/mod.rs
+++ b/crates/polars-core/src/frame/asof_join/mod.rs
@@ -112,7 +112,7 @@ where
                         other.cont_slice().unwrap(),
                         tolerance,
                     )
-                }
+                },
             },
         };
         Ok(out)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5571,8 +5571,8 @@ class DataFrame:
         tolerance
             Numeric tolerance. By setting this the join will only be done if the near
             keys are within this distance. If an asof join is done on columns of dtype
-            "Date", "Datetime", "Duration" or "Time", use the following string
-            language:
+            "Date", "Datetime", "Duration" or "Time", use either a datetime.timedelta
+            object or the following string language:
 
                 - 1ns   (1 nanosecond)
                 - 1us   (1 microsecond)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5543,7 +5543,8 @@ class DataFrame:
             'on' key is greater than or equal to the left's key.
 
           - A "nearest" search selects the last row in the right DataFrame whose value
-            is nearest to the left's key.
+            is nearest to the left's key. String keys are not currently supported for a
+            nearest search.
 
         The default is "backward".
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5522,7 +5522,7 @@ class DataFrame:
         by: str | Sequence[str] | None = None,
         strategy: AsofJoinStrategy = "backward",
         suffix: str = "_right",
-        tolerance: str | int | float | None = None,
+        tolerance: str | int | float | timedelta | None = None,
         allow_parallel: bool = True,
         force_parallel: bool = False,
     ) -> DataFrame:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2877,7 +2877,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         by: str | Sequence[str] | None = None,
         strategy: AsofJoinStrategy = "backward",
         suffix: str = "_right",
-        tolerance: str | int | float | None = None,
+        tolerance: str | int | float | timedelta | None = None,
         allow_parallel: bool = True,
         force_parallel: bool = False,
     ) -> Self:
@@ -2926,8 +2926,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         tolerance
             Numeric tolerance. By setting this the join will only be done if the near
             keys are within this distance. If an asof join is done on columns of dtype
-            "Date", "Datetime", "Duration" or "Time" you use the following string
-            language:
+            "Date", "Datetime", "Duration" or "Time", use either a datetime.timedelta
+            object or the following string language:
 
                 - 1ns   (1 nanosecond)
                 - 1us   (1 microsecond)
@@ -3027,6 +3027,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         tolerance_num: float | int | None = None
         if isinstance(tolerance, str):
             tolerance_str = tolerance
+        elif isinstance(tolerance, timedelta):
+            tolerance_str = _timedelta_to_pl_duration(tolerance)
         else:
             tolerance_num = tolerance
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2897,8 +2897,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
           - A "forward" search selects the first row in the right DataFrame whose
             'on' key is greater than or equal to the left's key.
 
-        - A "nearest" search selects the last row in the right DataFrame whose value
-          is nearest to the left's key.
+            A "nearest" search selects the last row in the right DataFrame whose value
+            is nearest to the left's key. String keys are not currently supported for a
+            nearest search.
 
         The default is "backward".
 

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -550,6 +550,34 @@ def test_asof_join_nearest_by_date() -> None:
     assert_frame_equal(out, expected)
 
 
+def test_asof_nearest_with_tolerance() -> None:
+    df1 = pl.DataFrame(
+        {
+            "ts": [
+                datetime(2023, 3, 3, 9, 16, 24, 960_000),
+                datetime(2023, 3, 3, 10, 40, 56, 230_000),
+                datetime(2023, 3, 3, 11, 17, 33, 720_000),
+            ],
+            "A": [10, 10, 11],
+        }
+    ).sort(by="ts")
+    df2 = pl.DataFrame(
+        {
+            "ts": [
+                datetime(2023, 3, 3, 9, 20, 25, 110_000),
+                datetime(2023, 3, 3, 10, 40, 56, 75_000),
+                datetime(2023, 3, 3, 11, 14, 32, 10_000),
+            ],
+            "B": ["Y", "Y", "N"],
+        }
+    ).sort(by="ts")
+    df2 = df2.with_columns(pl.col("ts").alias("ts_copy")).sort(by="ts")
+
+    out = df1.join_asof(df2, on="ts", tolerance="1s", strategy="nearest")
+
+    m = 1
+
+
 def test_asof_join_string_err() -> None:
     left = pl.DataFrame({"date_str": ["2023/02/15"]}).sort("date_str")
     right = pl.DataFrame(

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any
 
 import numpy as np
@@ -589,6 +589,12 @@ def test_asof_join_nearest_with_tolerance() -> None:
     ).set_sorted("asof_key")
     out = df1.join_asof(df2, on="asof_key", strategy="nearest", tolerance="1d4h")
     expected = df1.with_columns(pl.Series([None, 4, 4, 4, 5]).alias("b"))
+    assert_frame_equal(out, expected)
+
+    # Case 8: test using timedelta tolerance
+    out = df1.join_asof(
+        df2, on="asof_key", strategy="nearest", tolerance=timedelta(days=1, hours=4)
+    )
     assert_frame_equal(out, expected)
 
 

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -426,6 +426,7 @@ def test_asof_join_sorted_by_group(capsys: Any) -> None:
 
 
 def test_asof_join_nearest() -> None:
+    # Generic join_asof
     df1 = pl.DataFrame(
         {
             "asof_key": [-1, 1, 2, 4, 6],
@@ -435,20 +436,160 @@ def test_asof_join_nearest() -> None:
 
     df2 = pl.DataFrame(
         {
-            "asof_key": [1, 2, 4, 5],
+            "asof_key": [-1, 2, 4, 5],
             "b": [1, 2, 3, 4],
         }
     ).sort(by="asof_key")
 
     expected = pl.DataFrame(
-        {"asof_key": [-1, 1, 2, 4, 6], "a": [1, 2, 3, 4, 5], "b": [1, 1, 2, 3, 4]}
+        {"asof_key": [-1, 1, 2, 4, 6], "a": [1, 2, 3, 4, 5], "b": [1, 2, 2, 3, 4]}
     )
 
     out = df1.join_asof(df2, on="asof_key", strategy="nearest")
     assert_frame_equal(out, expected)
 
+    # Edge case: last item of right matches multiples on left
+    df1 = pl.DataFrame(
+        {
+            "asof_key": [9, 9, 10, 10, 10],
+            "a": [1, 2, 3, 4, 5],
+        }
+    ).set_sorted("asof_key")
+
+    df2 = pl.DataFrame(
+        {
+            "asof_key": [1, 2, 3, 10],
+            "b": [1, 2, 3, 4],
+        }
+    ).set_sorted("asof_key")
+
+    expected = pl.DataFrame(
+        {
+            "asof_key": [9, 9, 10, 10, 10],
+            "a": [1, 2, 3, 4, 5],
+            "b": [4, 4, 4, 4, 4],
+        }
+    )
+
+    out = df1.join_asof(df2, on="asof_key", strategy="nearest")
+    assert_frame_equal(out, expected)
+
+    # test with tolerance: edge cases
+    a = b = [1, 2, 3, 4, 5]
+    # Case 1: complete miss
+    df1 = pl.DataFrame({"asof_key": [1, 2, 3, 4, 5], "a": a}).set_sorted("asof_key")
+    df2 = pl.DataFrame(
+        {
+            "asof_key": [7, 8, 9, 10, 11],
+            "b": b,
+        }
+    ).set_sorted("asof_key")
+    expected = df1.with_columns(pl.Series([None, None, None, None, None]).alias("b"))
+    out = df1.join_asof(df2, on="asof_key", strategy="nearest", tolerance=1)
+    assert_frame_equal(out, expected)
+
+    # Case 2: complete miss in other direction
+    df1 = pl.DataFrame({"asof_key": [7, 8, 9, 10, 11], "a": a}).set_sorted("asof_key")
+    df2 = pl.DataFrame(
+        {
+            "asof_key": [1, 2, 3, 4, 5],
+            "b": b,
+        }
+    ).set_sorted("asof_key")
+    expected = df1.with_columns(pl.Series([None, None, None, None, None]).alias("b"))
+    out = df1.join_asof(df2, on="asof_key", strategy="nearest", tolerance=1)
+    assert_frame_equal(out, expected)
+
+    # Case 3: match first item
+    df1 = pl.DataFrame({"asof_key": [1, 2, 3, 4, 5], "a": a}).set_sorted("asof_key")
+    df2 = pl.DataFrame(
+        {
+            "asof_key": [6, 7, 8, 9, 10],
+            "b": b,
+        }
+    ).set_sorted("asof_key")
+    out = df1.join_asof(df2, on="asof_key", strategy="nearest", tolerance=1)
+    expected = df1.with_columns(pl.Series([None, None, None, None, None]).alias("b"))
+    assert_frame_equal(out, expected)
+
+    # Case 4: match last item
+    df1 = pl.DataFrame({"asof_key": [1, 2, 3, 4, 5], "a": a}).set_sorted("asof_key")
+    df2 = pl.DataFrame(
+        {
+            "asof_key": [-4, -3, -2, -1, 0],
+            "b": b,
+        }
+    ).set_sorted("asof_key")
+    out = df1.join_asof(df2, on="asof_key", strategy="nearest", tolerance=1)
+    expected = df1.with_columns(pl.Series([None, None, None, None, None]).alias("b"))
+    assert_frame_equal(out, expected)
+
+    # Case 5: match multiples, pick closer
+    df1 = pl.DataFrame(
+        {"asof_key": pl.Series([1, 2, 3, 4, 5], dtype=pl.Float64), "a": a}
+    ).set_sorted("asof_key")
+    df2 = pl.DataFrame(
+        {
+            "asof_key": [0, 2, 2.4, 3.4, 10],
+            "b": b,
+        }
+    ).set_sorted("asof_key")
+    out = df1.join_asof(df2, on="asof_key", strategy="nearest", tolerance=1)
+    expected = df1.with_columns(pl.Series([2, 2, 4, 4, None]).alias("b"))
+    assert_frame_equal(out, expected)
+
+    # Case 6: use 0 tolerance
+    df1 = pl.DataFrame(
+        {"asof_key": pl.Series([1, 2, 3, 4, 5], dtype=pl.Float64), "a": a}
+    ).set_sorted("asof_key")
+    df2 = pl.DataFrame(
+        {
+            "asof_key": [0, 2, 2.4, 3.4, 10],
+            "b": b,
+        }
+    ).set_sorted("asof_key")
+    out = df1.join_asof(df2, on="asof_key", strategy="nearest", tolerance=0)
+    expected = df1.with_columns(pl.Series([None, 2, None, None, None]).alias("b"))
+    assert_frame_equal(out, expected)
+
+    # Case 7: test with datetime
+    df1 = pl.DataFrame(
+        {
+            "asof_key": pl.Series(
+                [
+                    datetime(2023, 1, 1),
+                    datetime(2023, 1, 2),
+                    datetime(2023, 1, 3),
+                    datetime(2023, 1, 4),
+                    datetime(2023, 1, 6),
+                ]
+            ),
+            "a": a,
+        }
+    ).set_sorted("asof_key")
+    df2 = pl.DataFrame(
+        {
+            "asof_key": pl.Series(
+                [
+                    datetime(2022, 1, 1),
+                    datetime(2022, 1, 2),
+                    datetime(2022, 1, 3),
+                    datetime(
+                        2023, 1, 2, 21, 30, 0
+                    ),  # should match with 2023-01-02, 2023-01-03, and 2021-01-04
+                    datetime(2023, 1, 7),
+                ]
+            ),
+            "b": b,
+        }
+    ).set_sorted("asof_key")
+    out = df1.join_asof(df2, on="asof_key", strategy="nearest", tolerance="1d4h")
+    expected = df1.with_columns(pl.Series([None, 4, 4, 4, 5]).alias("b"))
+    assert_frame_equal(out, expected)
+
 
 def test_asof_join_nearest_by() -> None:
+    # Generic join_asof
     df1 = pl.DataFrame(
         {
             "asof_key": [-1, 1, 2, 6, 1],
@@ -459,7 +600,7 @@ def test_asof_join_nearest_by() -> None:
 
     df2 = pl.DataFrame(
         {
-            "asof_key": [1, 2, 5, 1],
+            "asof_key": [-1, 2, 5, 1],
             "group": [1, 1, 2, 2],
             "b": [1, 2, 3, 4],
         }
@@ -469,10 +610,36 @@ def test_asof_join_nearest_by() -> None:
         {
             "asof_key": [-1, 1, 2, 6, 1],
             "group": [1, 1, 1, 2, 2],
-            "a": [1, 2, 3, 2, 5],
-            "b": [1, 1, 2, 3, 4],
+            "a": [1, 2, 3, 5, 2],
+            "b": [1, 2, 2, 4, 3],
         }
     ).sort(by=["group", "asof_key"])
+
+    # Edge case: last item of right matches multiples on left
+    df1 = pl.DataFrame(
+        {
+            "asof_key": [9, 9, 10, 10, 10],
+            "group": [1, 1, 1, 2, 2],
+            "a": [1, 2, 3, 2, 5],
+        }
+    ).sort(by=["group", "asof_key"])
+
+    df2 = pl.DataFrame(
+        {
+            "asof_key": [-1, 1, 1, 10],
+            "group": [1, 1, 2, 2],
+            "b": [1, 2, 3, 4],
+        }
+    ).sort(by=["group", "asof_key"])
+
+    expected = pl.DataFrame(
+        {
+            "asof_key": [9, 9, 10, 10, 10],
+            "group": [1, 1, 1, 2, 2],
+            "a": [1, 2, 3, 2, 5],
+            "b": [2, 2, 2, 4, 4],
+        }
+    )
 
     out = df1.join_asof(df2, on="asof_key", by="group", strategy="nearest")
     assert_frame_equal(out, expected)
@@ -548,34 +715,6 @@ def test_asof_join_nearest_by_date() -> None:
 
     out = df1.join_asof(df2, on="asof_key", by="group", strategy="nearest")
     assert_frame_equal(out, expected)
-
-
-def test_asof_nearest_with_tolerance() -> None:
-    df1 = pl.DataFrame(
-        {
-            "ts": [
-                datetime(2023, 3, 3, 9, 16, 24, 960_000),
-                datetime(2023, 3, 3, 10, 40, 56, 230_000),
-                datetime(2023, 3, 3, 11, 17, 33, 720_000),
-            ],
-            "A": [10, 10, 11],
-        }
-    ).sort(by="ts")
-    df2 = pl.DataFrame(
-        {
-            "ts": [
-                datetime(2023, 3, 3, 9, 20, 25, 110_000),
-                datetime(2023, 3, 3, 10, 40, 56, 75_000),
-                datetime(2023, 3, 3, 11, 14, 32, 10_000),
-            ],
-            "B": ["Y", "Y", "N"],
-        }
-    ).sort(by="ts")
-    df2 = df2.with_columns(pl.col("ts").alias("ts_copy")).sort(by="ts")
-
-    out = df1.join_asof(df2, on="ts", tolerance="1s", strategy="nearest")
-
-    m = 1
 
 
 def test_asof_join_string_err() -> None:


### PR DESCRIPTION
Resolves #10462, Resolves #10534, and Resolves #10532. Main changes:

1. Implemented tolerance for `strategy="nearest"`
2. Increase test coverage for join_asof with nearest.
3. Allow `timedelta` objects for the tolerance input.