### PR TITLE
depr(python): Deprecate some parameters of `cut`/`qcut`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3314,12 +3314,18 @@ class Expr:
             Include the the right endpoint of the bin each observation falls in.
             If set to ``True``, the resulting column will be a :class:`Struct`.
 
+        See Also
+        --------
+        qcut
+
         Examples
         --------
         Divide a column into three categories.
 
         >>> df = pl.DataFrame({"foo": [-2, -1, 0, 1, 2]})
-        >>> df.with_columns(pl.col("foo").cut([-1, 1], labels=["a", "b", "c"]).alias("cut"))
+        >>> df.with_columns(
+        ...     pl.col("foo").cut([-1, 1], labels=["a", "b", "c"]).alias("cut")
+        ... )
         shape: (5, 2)
         ┌─────┬─────┐
         │ foo ┆ cut │
@@ -3335,7 +3341,9 @@ class Expr:
 
         Add both the category and the breakpoint.
 
-        >>> df.with_columns(pl.col("foo").cut([-1, 1], include_breaks=True).alias("cut")).unnest("cut")
+        >>> df.with_columns(
+        ...     pl.col("foo").cut([-1, 1], include_breaks=True).alias("cut")
+        ... ).unnest("cut")
         shape: (5, 3)
         ┌─────┬──────┬────────────┐
         │ foo ┆ brk  ┆ foo_bin    │
@@ -3386,105 +3394,81 @@ class Expr:
             Include the the right endpoint of the bin each observation falls in.
             If True, the resulting column will be a Struct.
 
+        See Also
+        --------
+        cut
+
         Examples
         --------
-        >>> g = pl.repeat("a", 5, eager=True).append(pl.repeat("b", 5, eager=True))
-        >>> df = pl.DataFrame(dict(g=g, x=range(10)))
-        >>> df.with_columns(q=pl.col("x").qcut([0.5]))
-        shape: (10, 3)
-        ┌─────┬─────┬─────────────┐
-        │ g   ┆ x   ┆ q           │
-        │ --- ┆ --- ┆ ---         │
-        │ str ┆ i64 ┆ cat         │
-        ╞═════╪═════╪═════════════╡
-        │ a   ┆ 0   ┆ (-inf, 4.5] │
-        │ a   ┆ 1   ┆ (-inf, 4.5] │
-        │ a   ┆ 2   ┆ (-inf, 4.5] │
-        │ a   ┆ 3   ┆ (-inf, 4.5] │
-        │ …   ┆ …   ┆ …           │
-        │ b   ┆ 6   ┆ (4.5, inf]  │
-        │ b   ┆ 7   ┆ (4.5, inf]  │
-        │ b   ┆ 8   ┆ (4.5, inf]  │
-        │ b   ┆ 9   ┆ (4.5, inf]  │
-        └─────┴─────┴─────────────┘
-        >>> df.with_columns(q=pl.col("x").qcut(2))
-        shape: (10, 3)
-        ┌─────┬─────┬─────────────┐
-        │ g   ┆ x   ┆ q           │
-        │ --- ┆ --- ┆ ---         │
-        │ str ┆ i64 ┆ cat         │
-        ╞═════╪═════╪═════════════╡
-        │ a   ┆ 0   ┆ (-inf, 4.5] │
-        │ a   ┆ 1   ┆ (-inf, 4.5] │
-        │ a   ┆ 2   ┆ (-inf, 4.5] │
-        │ a   ┆ 3   ┆ (-inf, 4.5] │
-        │ …   ┆ …   ┆ …           │
-        │ b   ┆ 6   ┆ (4.5, inf]  │
-        │ b   ┆ 7   ┆ (4.5, inf]  │
-        │ b   ┆ 8   ┆ (4.5, inf]  │
-        │ b   ┆ 9   ┆ (4.5, inf]  │
-        └─────┴─────┴─────────────┘
-        >>> df.with_columns(q=pl.col("x").qcut([0.5], ["lo", "hi"]).over("g"))
-        shape: (10, 3)
-        ┌─────┬─────┬─────┐
-        │ g   ┆ x   ┆ q   │
-        │ --- ┆ --- ┆ --- │
-        │ str ┆ i64 ┆ cat │
-        ╞═════╪═════╪═════╡
-        │ a   ┆ 0   ┆ lo  │
-        │ a   ┆ 1   ┆ lo  │
-        │ a   ┆ 2   ┆ lo  │
-        │ a   ┆ 3   ┆ hi  │
-        │ …   ┆ …   ┆ …   │
-        │ b   ┆ 6   ┆ lo  │
-        │ b   ┆ 7   ┆ lo  │
-        │ b   ┆ 8   ┆ hi  │
-        │ b   ┆ 9   ┆ hi  │
-        └─────┴─────┴─────┘
-        >>> df.with_columns(q=pl.col("x").qcut([0.5], ["lo", "hi"], True).over("g"))
-        shape: (10, 3)
-        ┌─────┬─────┬─────┐
-        │ g   ┆ x   ┆ q   │
-        │ --- ┆ --- ┆ --- │
-        │ str ┆ i64 ┆ cat │
-        ╞═════╪═════╪═════╡
-        │ a   ┆ 0   ┆ lo  │
-        │ a   ┆ 1   ┆ lo  │
-        │ a   ┆ 2   ┆ hi  │
-        │ a   ┆ 3   ┆ hi  │
-        │ …   ┆ …   ┆ …   │
-        │ b   ┆ 6   ┆ lo  │
-        │ b   ┆ 7   ┆ hi  │
-        │ b   ┆ 8   ┆ hi  │
-        │ b   ┆ 9   ┆ hi  │
-        └─────┴─────┴─────┘
-        >>> df.with_columns(q=pl.col("x").qcut([0.25, 0.5], include_breaks=True))
-        shape: (10, 3)
-        ┌─────┬─────┬───────────────────────┐
-        │ g   ┆ x   ┆ q                     │
-        │ --- ┆ --- ┆ ---                   │
-        │ str ┆ i64 ┆ struct[2]             │
-        ╞═════╪═════╪═══════════════════════╡
-        │ a   ┆ 0   ┆ {2.25,"(-inf, 2.25]"} │
-        │ a   ┆ 1   ┆ {2.25,"(-inf, 2.25]"} │
-        │ a   ┆ 2   ┆ {2.25,"(-inf, 2.25]"} │
-        │ a   ┆ 3   ┆ {4.5,"(2.25, 4.5]"}   │
-        │ …   ┆ …   ┆ …                     │
-        │ b   ┆ 6   ┆ {inf,"(4.5, inf]"}    │
-        │ b   ┆ 7   ┆ {inf,"(4.5, inf]"}    │
-        │ b   ┆ 8   ┆ {inf,"(4.5, inf]"}    │
-        │ b   ┆ 9   ┆ {inf,"(4.5, inf]"}    │
-        └─────┴─────┴───────────────────────┘
+        Divide a column into three groups according to pre-defined quantile
+        probabilities.
+
+        >>> df = pl.DataFrame({"foo": [-2, -1, 0, 1, 2]})
+        >>> df.with_columns(
+        ...     pl.col("foo").qcut([0.25, 0.75], labels=["a", "b", "c"]).alias("qcut")
+        ... )
+        shape: (5, 2)
+        ┌─────┬──────┐
+        │ foo ┆ qcut │
+        │ --- ┆ ---  │
+        │ i64 ┆ cat  │
+        ╞═════╪══════╡
+        │ -2  ┆ a    │
+        │ -1  ┆ a    │
+        │ 0   ┆ b    │
+        │ 1   ┆ b    │
+        │ 2   ┆ c    │
+        └─────┴──────┘
+
+        Divide the column uniformly into two categories.
+
+        >>> df.with_columns(
+        ...     pl.col("foo")
+        ...     .qcut(2, labels=["low", "high"], left_closed=True)
+        ...     .alias("qcut")
+        ... )
+        shape: (5, 2)
+        ┌─────┬──────┐
+        │ foo ┆ qcut │
+        │ --- ┆ ---  │
+        │ i64 ┆ cat  │
+        ╞═════╪══════╡
+        │ -2  ┆ low  │
+        │ -1  ┆ low  │
+        │ 0   ┆ high │
+        │ 1   ┆ high │
+        │ 2   ┆ high │
+        └─────┴──────┘
+
+        Add both the category and the breakpoint.
+
+        >>> df.with_columns(
+        ...     pl.col("foo").qcut([0.25, 0.75], include_breaks=True).alias("qcut")
+        ... ).unnest("qcut")
+        shape: (5, 3)
+        ┌─────┬──────┬────────────┐
+        │ foo ┆ brk  ┆ foo_bin    │
+        │ --- ┆ ---  ┆ ---        │
+        │ i64 ┆ f64  ┆ cat        │
+        ╞═════╪══════╪════════════╡
+        │ -2  ┆ -1.0 ┆ (-inf, -1] │
+        │ -1  ┆ -1.0 ┆ (-inf, -1] │
+        │ 0   ┆ 1.0  ┆ (-1, 1]    │
+        │ 1   ┆ 1.0  ┆ (-1, 1]    │
+        │ 2   ┆ inf  ┆ (1, inf]   │
+        └─────┴──────┴────────────┘
 
         """
-        expr_f = (
-            self._pyexpr.qcut_uniform
-            if isinstance(quantiles, int)
-            else self._pyexpr.qcut
-        )
-        return self._from_pyexpr(
-            expr_f(quantiles, labels, left_closed, allow_duplicates, include_breaks)
-        )
+        if isinstance(quantiles, int):
+            pyexpr = self._pyexpr.qcut_uniform(
+                quantiles, labels, left_closed, allow_duplicates, include_breaks
+            )
+        else:
+            pyexpr = self._pyexpr.qcut(
+                quantiles, labels, left_closed, allow_duplicates, include_breaks
+            )
+
+        return self._from_pyexpr(pyexpr)
 
     def rle(self) -> Self:
         """

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3305,14 +3305,22 @@ class Expr:
         Parameters
         ----------
         breaks
-            A list of unique cut points.
+            List of unique cut points.
         labels
-            Labels to assign to bins. If given, the length must be len(breaks) + 1.
+            Names of the categories. The number of labels must be equal to the number
+            of cut points plus one.
         left_closed
-            Set the intervals to be closed left instead of closed right.
+            Set the intervals to be left-closed instead of right-closed.
         include_breaks
-            Include the the right endpoint of the bin each observation falls in.
-            If set to ``True``, the resulting column will be a :class:`Struct`.
+            Include a column with the right endpoint of the bin each observation falls
+            in. This will change the data type of the output from a
+            :class:`Categorical` to a :class:`Struct`.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`Categorical` if ``include_breaks`` is set to
+            ``False`` (default), otherwise an expression of data type :class:`Struct.
 
         See Also
         --------
@@ -3380,19 +3388,26 @@ class Expr:
         ----------
         quantiles
             Either a list of quantile probabilities between 0 and 1 or a positive
-            integer determining the number of evenly spaced probabilities to use.
+            integer determining the number of bins with uniform probability.
         labels
-            Labels to assign to bins. If given, the length must be len(probs) + 1.
-            If computing over groups this must be set for now.
+            Names of the categories. The number of labels must be equal to the number
+            of categories.
         left_closed
-            Whether intervals should be [) instead of the default of (]
+            Set the intervals to be left-closed instead of right-closed.
         allow_duplicates
-            If True, the resulting quantile breaks don't have to be unique. This can
-            happen even with unique probs depending on the data. Duplicates will be
-            dropped, resulting in fewer bins.
+            If set to ``True``, duplicates in the resulting quantiles are dropped,
+            rather than raising a `DuplicateError`. This can happen even with unique
+            probabilities, depending on the data.
         include_breaks
-            Include the the right endpoint of the bin each observation falls in.
-            If True, the resulting column will be a Struct.
+            Include a column with the right endpoint of the bin each observation falls
+            in. This will change the data type of the output from a
+            :class:`Categorical` to a :class:`Struct`.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`Categorical` if ``include_breaks`` is set to
+            ``False`` (default), otherwise an expression of data type :class:`Struct.
 
         See Also
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3415,7 +3415,7 @@ class Expr:
 
         Examples
         --------
-        Divide a column into three groups according to pre-defined quantile
+        Divide a column into three categories according to pre-defined quantile
         probabilities.
 
         >>> df = pl.DataFrame({"foo": [-2, -1, 0, 1, 2]})
@@ -3435,7 +3435,7 @@ class Expr:
         │ 2   ┆ c    │
         └─────┴──────┘
 
-        Divide the column uniformly into two categories.
+        Divide a column into two categories using uniform quantile probabilities.
 
         >>> df.with_columns(
         ...     pl.col("foo")

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3309,49 +3309,45 @@ class Expr:
         labels
             Labels to assign to bins. If given, the length must be len(breaks) + 1.
         left_closed
-            Whether intervals should be [) instead of the default of (]
+            Set the intervals to be closed left instead of closed right.
         include_breaks
             Include the the right endpoint of the bin each observation falls in.
-            If True, the resulting column will be a Struct.
+            If set to ``True``, the resulting column will be a :class:`Struct`.
 
         Examples
         --------
-        >>> g = pl.repeat("a", 5, eager=True).append(pl.repeat("b", 5, eager=True))
-        >>> df = pl.DataFrame(dict(g=g, x=range(10)))
-        >>> df.with_columns(q=pl.col("x").cut([2, 5]))
-        shape: (10, 3)
-        ┌─────┬─────┬───────────┐
-        │ g   ┆ x   ┆ q         │
-        │ --- ┆ --- ┆ ---       │
-        │ str ┆ i64 ┆ cat       │
-        ╞═════╪═════╪═══════════╡
-        │ a   ┆ 0   ┆ (-inf, 2] │
-        │ a   ┆ 1   ┆ (-inf, 2] │
-        │ a   ┆ 2   ┆ (-inf, 2] │
-        │ a   ┆ 3   ┆ (2, 5]    │
-        │ …   ┆ …   ┆ …         │
-        │ b   ┆ 6   ┆ (5, inf]  │
-        │ b   ┆ 7   ┆ (5, inf]  │
-        │ b   ┆ 8   ┆ (5, inf]  │
-        │ b   ┆ 9   ┆ (5, inf]  │
-        └─────┴─────┴───────────┘
-        >>> df.with_columns(q=pl.col("x").cut([2, 5], left_closed=True))
-        shape: (10, 3)
-        ┌─────┬─────┬───────────┐
-        │ g   ┆ x   ┆ q         │
-        │ --- ┆ --- ┆ ---       │
-        │ str ┆ i64 ┆ cat       │
-        ╞═════╪═════╪═══════════╡
-        │ a   ┆ 0   ┆ [-inf, 2) │
-        │ a   ┆ 1   ┆ [-inf, 2) │
-        │ a   ┆ 2   ┆ [2, 5)    │
-        │ a   ┆ 3   ┆ [2, 5)    │
-        │ …   ┆ …   ┆ …         │
-        │ b   ┆ 6   ┆ [5, inf)  │
-        │ b   ┆ 7   ┆ [5, inf)  │
-        │ b   ┆ 8   ┆ [5, inf)  │
-        │ b   ┆ 9   ┆ [5, inf)  │
-        └─────┴─────┴───────────┘
+        Divide a column into three categories.
+
+        >>> df = pl.DataFrame({"foo": [-2, -1, 0, 1, 2]})
+        >>> df.with_columns(pl.col("foo").cut([-1, 1], labels=["a", "b", "c"]).alias("cut"))
+        shape: (5, 2)
+        ┌─────┬─────┐
+        │ foo ┆ cut │
+        │ --- ┆ --- │
+        │ i64 ┆ cat │
+        ╞═════╪═════╡
+        │ -2  ┆ a   │
+        │ -1  ┆ a   │
+        │ 0   ┆ b   │
+        │ 1   ┆ b   │
+        │ 2   ┆ c   │
+        └─────┴─────┘
+
+        Add both the category and the breakpoint.
+
+        >>> df.with_columns(pl.col("foo").cut([-1, 1], include_breaks=True).alias("cut")).unnest("cut")
+        shape: (5, 3)
+        ┌─────┬──────┬────────────┐
+        │ foo ┆ brk  ┆ foo_bin    │
+        │ --- ┆ ---  ┆ ---        │
+        │ i64 ┆ f64  ┆ cat        │
+        ╞═════╪══════╪════════════╡
+        │ -2  ┆ -1.0 ┆ (-inf, -1] │
+        │ -1  ┆ -1.0 ┆ (-inf, -1] │
+        │ 0   ┆ 1.0  ┆ (-1, 1]    │
+        │ 1   ┆ 1.0  ┆ (-1, 1]    │
+        │ 2   ┆ inf  ┆ (1, inf]   │
+        └─────┴──────┴────────────┘
 
         """
         return self._from_pyexpr(

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3320,7 +3320,7 @@ class Expr:
         -------
         Expr
             Expression of data type :class:`Categorical` if ``include_breaks`` is set to
-            ``False`` (default), otherwise an expression of data type :class:`Struct.
+            ``False`` (default), otherwise an expression of data type :class:`Struct`.
 
         See Also
         --------
@@ -3407,7 +3407,7 @@ class Expr:
         -------
         Expr
             Expression of data type :class:`Categorical` if ``include_breaks`` is set to
-            ``False`` (default), otherwise an expression of data type :class:`Struct.
+            ``False`` (default), otherwise an expression of data type :class:`Struct`.
 
         See Also
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -52,6 +52,7 @@ from polars.utils._parse_expr_input import (
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.deprecation import (
     deprecate_function,
+    deprecate_nonkeyword_arguments,
     deprecate_renamed_parameter,
     warn_closed_future_change,
 )
@@ -3290,10 +3291,11 @@ class Expr:
         quantile = parse_as_expression(quantile)
         return self._from_pyexpr(self._pyexpr.quantile(quantile, interpolation))
 
+    @deprecate_nonkeyword_arguments(["self", "breaks"], version="0.18.14")
     def cut(
         self,
-        breaks: list[float],
-        labels: list[str] | None = None,
+        breaks: Sequence[float],
+        labels: Sequence[str] | None = None,
         left_closed: bool = False,
         include_breaks: bool = False,
     ) -> Self:
@@ -3350,17 +3352,19 @@ class Expr:
         │ b   ┆ 8   ┆ [5, inf)  │
         │ b   ┆ 9   ┆ [5, inf)  │
         └─────┴─────┴───────────┘
+
         """
         return self._from_pyexpr(
             self._pyexpr.cut(breaks, labels, left_closed, include_breaks)
         )
 
+    @deprecate_nonkeyword_arguments(["self", "quantiles"], version="0.18.14")
     @deprecate_renamed_parameter("probs", "quantiles", version="0.18.8")
     @deprecate_renamed_parameter("q", "quantiles", version="0.18.12")
     def qcut(
         self,
-        quantiles: list[float] | int,
-        labels: list[str] | None = None,
+        quantiles: Sequence[float] | int,
+        labels: Sequence[str] | None = None,
         left_closed: bool = False,
         allow_duplicates: bool = False,
         include_breaks: bool = False,
@@ -3475,6 +3479,7 @@ class Expr:
         │ b   ┆ 8   ┆ {inf,"(4.5, inf]"}    │
         │ b   ┆ 9   ┆ {inf,"(4.5, inf]"}    │
         └─────┴─────┴───────────────────────┘
+
         """
         expr_f = (
             self._pyexpr.qcut_uniform

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1708,14 +1708,14 @@ class Series:
             ``True``.
 
             .. deprecated:: 0.19.0
-                This parameter will be removed. Use `Series.struct.rename_fields` to
+                This parameter will be removed. Use ``Series.struct.rename_fields`` to
                 rename the field instead.
         category_label
             Name of the category column. Only used if ``include_breaks`` is set to
             ``True``.
 
             .. deprecated:: 0.19.0
-                This parameter will be removed. Use `Series.struct.rename_fields` to
+                This parameter will be removed. Use ``Series.struct.rename_fields`` to
                 rename the field instead.
         left_closed
             Set the intervals to be left-closed instead of right-closed.
@@ -1729,14 +1729,14 @@ class Series:
 
             .. deprecated:: 0.19.0
                 This parameter will be removed. The same behavior can be achieved by
-                setting ``include_breaks=True`, unnesting the resulting struct Series,
+                setting ``include_breaks=True``, unnesting the resulting struct Series,
                 and adding the result to the original Series.
 
         Returns
         -------
         Series
             Series of data type :class:`Categorical` if ``include_breaks`` is set to
-            ``False`` (default), otherwise a Series of data type :class:`Struct.
+            ``False`` (default), otherwise a Series of data type :class:`Struct`.
 
         See Also
         --------
@@ -1916,14 +1916,14 @@ class Series:
             ``True``.
 
             .. deprecated:: 0.19.0
-                This parameter will be removed. Use `Series.struct.rename_fields` to
+                This parameter will be removed. Use ``Series.struct.rename_fields`` to
                 rename the field instead.
         category_label
             Name of the category column. Only used if ``include_breaks`` is set to
             ``True``.
 
             .. deprecated:: 0.19.0
-                This parameter will be removed. Use `Series.struct.rename_fields` to
+                This parameter will be removed. Use ``Series.struct.rename_fields`` to
                 rename the field instead.
         as_series
             If set to ``False``, return a DataFrame containing the original values,
@@ -1931,14 +1931,14 @@ class Series:
 
             .. deprecated:: 0.19.0
                 This parameter will be removed. The same behavior can be achieved by
-                setting ``include_breaks=True`, unnesting the resulting struct Series,
+                setting ``include_breaks=True``, unnesting the resulting struct Series,
                 and adding the result to the original Series.
 
         Returns
         -------
         Series
             Series of data type :class:`Categorical` if ``include_breaks`` is set to
-            ``False`` (default), otherwise a Series of data type :class:`Struct.
+            ``False`` (default), otherwise a Series of data type :class:`Struct`.
 
         Warnings
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1679,9 +1679,9 @@ class Series:
     ) -> Series | DataFrame:
         ...
 
-    @deprecate_nonkeyword_arguments(["self", "breaks"], version="0.18.14")
+    @deprecate_nonkeyword_arguments(["self", "breaks"], version="0.19.0")
     @deprecate_renamed_parameter("bins", "breaks", version="0.18.8")
-    @deprecate_renamed_parameter("series", "as_series", version="0.18.14")
+    @deprecate_renamed_parameter("series", "as_series", version="0.19.0")
     def cut(
         self,
         breaks: Sequence[float],
@@ -1707,14 +1707,14 @@ class Series:
             Name of the breakpoint column. Only used if ``include_breaks`` is set to
             ``True``.
 
-            .. deprecated:: 0.18.14
+            .. deprecated:: 0.19.0
                 This parameter will be removed. Use `Series.struct.rename_fields` to
                 rename the field instead.
         category_label
             Name of the category column. Only used if ``include_breaks`` is set to
             ``True``.
 
-            .. deprecated:: 0.18.14
+            .. deprecated:: 0.19.0
                 This parameter will be removed. Use `Series.struct.rename_fields` to
                 rename the field instead.
         left_closed
@@ -1726,7 +1726,7 @@ class Series:
         as_series
             If True, return a categorical Series in the data's original order.
 
-            .. deprecated:: 0.18.14
+            .. deprecated:: 0.19.0
                 This parameter will be removed. The same behavior can be achieved by
                 setting ``include_breaks=True`, unnesting the resulting struct Series,
                 and adding the result to the original Series.
@@ -1739,7 +1739,7 @@ class Series:
         --------
         Divide the series into three categories.
 
-        >>> s = pl.int_range(-2, 3, eager=True)
+        >>> s = pl.Series("int", [-2, -1, 0, 1, 2])
         >>> s.cut([-1, 1], labels=["a", "b", "c"])
         shape: (5,)
         Series: 'int' [cat]
@@ -1773,13 +1773,13 @@ class Series:
             issue_deprecation_warning(
                 "The `break_point_label` parameter for `Series.cut` will be removed."
                 " Use `Series.struct.rename_fields` to rename the field instead.",
-                version="0.18.14",
+                version="0.19.0",
             )
         if category_label != "category":
             issue_deprecation_warning(
                 "The `category_label` parameter for `Series.cut` will be removed."
                 " Use `Series.struct.rename_fields` to rename the field instead.",
-                version="0.18.14",
+                version="0.19.0",
             )
         if not as_series:
             issue_deprecation_warning(
@@ -1787,7 +1787,7 @@ class Series:
                 " The same behavior can be achieved by setting ``include_breaks=True`,"
                 " unnesting the resulting struct Series,"
                 " and adding the result to the original Series.",
-                version="0.18.14",
+                version="0.19.0",
             )
             temp_name = self.name + "_bin"
             return (

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1951,7 +1951,8 @@ class Series:
 
         Examples
         --------
-        Divide the column into three pre-defined quantiles.
+        Divide a column into three categories according to pre-defined quantile
+        probabilities.
 
         >>> s = pl.Series("foo", [-2, -1, 0, 1, 2])
         >>> s.qcut([0.25, 0.75], labels=["a", "b", "c"])
@@ -1965,7 +1966,7 @@ class Series:
                 "c"
         ]
 
-        Divide the column into two uniform quantiles.
+        Divide a column into two categories using uniform quantile probabilities.
 
         >>> s.qcut(2, labels=["low", "high"], left_closed=True)
         shape: (5,)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1704,10 +1704,19 @@ class Series:
             Labels to assign to the bins. If given, the number of labels must be
             equal to the number of breaks plus one.
         break_point_label
-            Name given to the breakpoint column/field. Only used if
-            ``include_breaks == True`` or ``as_series == False``.
+            Name of the breakpoint column. Only used if ``include_breaks`` is set to
+            ``True``.
+
+            .. deprecated:: 0.18.14
+                This parameter will be removed. Use `Series.struct.rename_fields` to
+                rename the field instead.
         category_label
-            Name given to the category column. Only used if series == False
+            Name of the category column. Only used if ``include_breaks`` is set to
+            ``True``.
+
+            .. deprecated:: 0.18.14
+                This parameter will be removed. Use `Series.struct.rename_fields` to
+                rename the field instead.
         left_closed
             Whether intervals should be ``[)`` instead of ``(]``.
         include_breaks
@@ -1742,7 +1751,7 @@ class Series:
                 "c"
         ]
 
-        Create a DataFrame with the break point and category for each value.
+        Create a DataFrame with the breakpoint and category for each value.
 
         >>> cut = s.cut([-1, 1], include_breaks=True).alias("cut")
         >>> s.to_frame().with_columns(cut).unnest("cut")
@@ -1760,35 +1769,47 @@ class Series:
         └─────┴─────────────┴────────────┘
 
         """
-        name = self._s.name()
-
+        if break_point_label != "break_point":
+            issue_deprecation_warning(
+                "The `break_point_label` parameter for `Series.cut` will be removed."
+                " Use `Series.struct.rename_fields` to rename the field instead.",
+                version="0.18.14",
+            )
+        if category_label != "category":
+            issue_deprecation_warning(
+                "The `category_label` parameter for `Series.cut` will be removed."
+                " Use `Series.struct.rename_fields` to rename the field instead.",
+                version="0.18.14",
+            )
         if not as_series:
             issue_deprecation_warning(
-                "the `as_series` parameter for `Series.cut` will be removed."
+                "The `as_series` parameter for `Series.cut` will be removed."
                 " The same behavior can be achieved by setting ``include_breaks=True`,"
                 " unnesting the resulting struct Series,"
-                " and adding the result to the original Series."
+                " and adding the result to the original Series.",
+                version="0.18.14",
             )
+            temp_name = self.name + "_bin"
             return (
                 self.to_frame()
                 .with_columns(
-                    F.col(name)
+                    F.col(self.name)
                     .cut(
                         breaks,
                         labels=labels,
                         left_closed=left_closed,
                         include_breaks=True,  # always include breaks
                     )
-                    .alias(name + "_bin")
+                    .alias(temp_name)
                 )
-                .unnest(name + "_bin")
-                .rename({"brk": break_point_label, name + "_bin": category_label})
+                .unnest(temp_name)
+                .rename({"brk": break_point_label, temp_name: category_label})
             )
 
         result = (
             self.to_frame()
             .select(
-                F.col(name).cut(
+                F.col(self.name).cut(
                     breaks,
                     labels=labels,
                     left_closed=left_closed,
@@ -1797,6 +1818,7 @@ class Series:
             )
             .to_series()
         )
+
         if include_breaks:
             result = result.struct.rename_fields([break_point_label, category_label])
 
@@ -1838,11 +1860,11 @@ class Series:
         quantiles: Sequence[float] | int,
         *,
         labels: Sequence[str] | None = ...,
-        break_point_label: str = ...,
-        category_label: str = ...,
         left_closed: bool = ...,
         allow_duplicates: bool = ...,
         include_breaks: bool = ...,
+        break_point_label: str = ...,
+        category_label: str = ...,
         as_series: bool,
     ) -> Series | DataFrame:
         ...
@@ -1854,11 +1876,11 @@ class Series:
         quantiles: Sequence[float] | int,
         *,
         labels: Sequence[str] | None = None,
-        break_point_label: str = "break_point",
-        category_label: str = "category",
         left_closed: bool = False,
         allow_duplicates: bool = False,
         include_breaks: bool = False,
+        break_point_label: str = "break_point",
+        category_label: str = "category",
         as_series: bool = True,
     ) -> Series | DataFrame:
         """
@@ -1872,11 +1894,6 @@ class Series:
         labels
             Labels to assign to the quantiles. If given, the length of labels must be
             ``len(breaks) + 1``.
-        break_point_label
-            Name given to the breakpoint column/field. Only used if ``series == False``
-            or ``include_breaks == True``.
-        category_label
-            Name given to the category column. Only used if ``series == False``.
         left_closed
             Whether intervals should be ``[)`` instead of ``(]``.
         allow_duplicates
@@ -1887,6 +1904,20 @@ class Series:
             Include the the right endpoint of the bin each observation falls in.
             If returning a DataFrame, it will be a column, and if returning a Series
             it will be a field in a Struct.
+        break_point_label
+            Name of the breakpoint column. Only used if ``include_breaks`` is set to
+            ``True``.
+
+            .. deprecated:: 0.18.14
+                This parameter will be removed. Use `Series.struct.rename_fields` to
+                rename the field instead.
+        category_label
+            Name of the category column. Only used if ``include_breaks`` is set to
+            ``True``.
+
+            .. deprecated:: 0.18.14
+                This parameter will be removed. Use `Series.struct.rename_fields` to
+                rename the field instead.
         as_series
             If ``True``, return a categorical Series in the data's original order.
 
@@ -1964,31 +1995,50 @@ class Series:
         ]
 
         """
-        n = self._s.name()
+        if break_point_label != "break_point":
+            issue_deprecation_warning(
+                "The `break_point_label` parameter for `Series.cut` will be removed."
+                " Use `Series.struct.rename_fields` to rename the field instead.",
+                version="0.18.14",
+            )
+        if category_label != "category":
+            issue_deprecation_warning(
+                "The `category_label` parameter for `Series.cut` will be removed."
+                " Use `Series.struct.rename_fields` to rename the field instead.",
+                version="0.18.14",
+            )
         if not as_series:
-            # "Old style" always includes breaks
+            issue_deprecation_warning(
+                "the `as_series` parameter for `Series.qcut` will be removed."
+                " The same behavior can be achieved by setting ``include_breaks=True`,"
+                " unnesting the resulting struct Series,"
+                " and adding the result to the original Series.",
+                version="0.18.14",
+            )
+            temp_name = self.name + "_bin"
             return (
                 self.to_frame()
                 .with_columns(
-                    F.col(n)
+                    F.col(self.name)
                     .qcut(
                         quantiles,
-                        labels,
+                        labels=labels,
                         left_closed=left_closed,
                         allow_duplicates=allow_duplicates,
-                        include_breaks=True,
+                        include_breaks=True,  # always include breaks
                     )
-                    .alias(n + "_bin")
+                    .alias(temp_name)
                 )
-                .unnest(n + "_bin")
-                .rename({"brk": break_point_label, n + "_bin": category_label})
+                .unnest(temp_name)
+                .rename({"brk": break_point_label, temp_name: category_label})
             )
-        res = (
+
+        result = (
             self.to_frame()
             .select(
-                F.col(n).qcut(
+                F.col(self.name).qcut(
                     quantiles,
-                    labels,
+                    labels=labels,
                     left_closed=left_closed,
                     allow_duplicates=allow_duplicates,
                     include_breaks=include_breaks,
@@ -1996,9 +2046,11 @@ class Series:
             )
             .to_series()
         )
+
         if include_breaks:
-            return res.struct.rename_fields([break_point_label, category_label])
-        return res
+            result = result.struct.rename_fields([break_point_label, category_label])
+
+        return result
 
     def rle(self) -> Series:
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1735,14 +1735,18 @@ class Series:
         -------
         Series or DataFrame
 
+        See Also
+        --------
+        qcut
+
         Examples
         --------
-        Divide the series into three categories.
+        Divide the column into three categories.
 
-        >>> s = pl.Series("int", [-2, -1, 0, 1, 2])
+        >>> s = pl.Series("foo", [-2, -1, 0, 1, 2])
         >>> s.cut([-1, 1], labels=["a", "b", "c"])
         shape: (5,)
-        Series: 'int' [cat]
+        Series: 'foo' [cat]
         [
                 "a"
                 "a"
@@ -1757,7 +1761,7 @@ class Series:
         >>> s.to_frame().with_columns(cut).unnest("cut")
         shape: (5, 3)
         ┌─────┬─────────────┬────────────┐
-        │ int ┆ break_point ┆ category   │
+        │ foo ┆ break_point ┆ category   │
         │ --- ┆ ---         ┆ ---        │
         │ i64 ┆ f64         ┆ cat        │
         ╞═════╪═════════════╪════════════╡
@@ -1830,11 +1834,11 @@ class Series:
         quantiles: Sequence[float] | int,
         *,
         labels: Sequence[str] | None = ...,
-        break_point_label: str = ...,
-        category_label: str = ...,
         left_closed: bool = ...,
         allow_duplicates: bool = ...,
         include_breaks: bool = ...,
+        break_point_label: str = ...,
+        category_label: str = ...,
         as_series: Literal[True] = ...,
     ) -> Series:
         ...
@@ -1845,11 +1849,11 @@ class Series:
         quantiles: Sequence[float] | int,
         *,
         labels: Sequence[str] | None = ...,
-        break_point_label: str = ...,
-        category_label: str = ...,
         left_closed: bool = ...,
         allow_duplicates: bool = ...,
         include_breaks: bool = ...,
+        break_point_label: str = ...,
+        category_label: str = ...,
         as_series: Literal[False],
     ) -> DataFrame:
         ...
@@ -1935,64 +1939,55 @@ class Series:
         This functionality is experimental and may change without it being considered a
         breaking change.
 
+        See Also
+        --------
+        cut
+
         Examples
         --------
-        >>> a = pl.Series("a", range(-2, 3))
-        >>> a.qcut(2, series=True)
-        shape: (8,)
-        Series: 'a' [cat]
+        Divide the column into three pre-defined quantiles.
+
+        >>> s = pl.Series("foo", [-2, -1, 0, 1, 2])
+        >>> s.qcut([0.25, 0.75], labels=["a", "b", "c"])
+        shape: (5,)
+        Series: 'foo' [cat]
         [
-                "(-inf, -1.5]"
-                "(-inf, -1.5]"
-                "(-inf, -1.5]"
-                "(-inf, -1.5]"
-                "(-1.5, inf]"
-                "(-1.5, inf]"
-                "(-1.5, inf]"
-                "(-1.5, inf]"
+                "a"
+                "a"
+                "b"
+                "b"
+                "c"
         ]
-        >>> a.qcut([0.0, 0.25, 0.75], series=False)
-        shape: (8, 3)
-        ┌─────┬─────────────┬───────────────┐
-        │ a   ┆ break_point ┆ category      │
-        │ --- ┆ ---         ┆ ---           │
-        │ i64 ┆ f64         ┆ cat           │
-        ╞═════╪═════════════╪═══════════════╡
-        │ -5  ┆ -5.0        ┆ (-inf, -5]    │
-        │ -4  ┆ -3.25       ┆ (-5, -3.25]   │
-        │ -3  ┆ 0.25        ┆ (-3.25, 0.25] │
-        │ -2  ┆ 0.25        ┆ (-3.25, 0.25] │
-        │ -1  ┆ 0.25        ┆ (-3.25, 0.25] │
-        │ 0   ┆ 0.25        ┆ (-3.25, 0.25] │
-        │ 1   ┆ inf         ┆ (0.25, inf]   │
-        │ 2   ┆ inf         ┆ (0.25, inf]   │
-        └─────┴─────────────┴───────────────┘
-        >>> a.qcut([0.0, 0.25, 0.75], series=True)
-        shape: (8,)
-        Series: 'a' [cat]
+
+        Divide the column into two uniform quantiles.
+
+        >>> s.qcut(2, labels=["low", "high"], left_closed=True)
+        shape: (5,)
+        Series: 'foo' [cat]
         [
-            "(-inf, -5]"
-            "(-5, -3.25]"
-            "(-3.25, 0.25]"
-            "(-3.25, 0.25]"
-            "(-3.25, 0.25]"
-            "(-3.25, 0.25]"
-            "(0.25, inf]"
-            "(0.25, inf]"
+                "low"
+                "low"
+                "high"
+                "high"
+                "high"
         ]
-        >>> a.qcut([0.0, 0.25, 0.75], series=True, left_closed=True)
-        shape: (8,)
-        Series: 'a' [cat]
-        [
-            "[-5, -3.25)"
-            "[-5, -3.25)"
-            "[-3.25, 0.25)"
-            "[-3.25, 0.25)"
-            "[-3.25, 0.25)"
-            "[-3.25, 0.25)"
-            "[0.25, inf)"
-            "[0.25, inf)"
-        ]
+
+        Create a DataFrame with the breakpoint and category for each value.
+
+        >>> cut = s.qcut([0.25, 0.75], include_breaks=True).alias("cut")
+        >>> s.to_frame().with_columns(cut).unnest("cut")
+        shape: (5, 3)
+        ┌─────┬─────────────┬────────────┐
+        │ foo ┆ break_point ┆ category   │
+        │ --- ┆ ---         ┆ ---        │
+        │ i64 ┆ f64         ┆ cat        │
+        ╞═════╪═════════════╪════════════╡
+        │ -2  ┆ -1.0        ┆ (-inf, -1] │
+        │ -1  ┆ -1.0        ┆ (-inf, -1] │
+        │ 0   ┆ 1.0         ┆ (-1, 1]    │
+        │ 1   ┆ 1.0         ┆ (-1, 1]    │
+        │ 2   ┆ inf         ┆ (1, inf]   │
+        └─────┴─────────────┴────────────┘
 
         """
         if break_point_label != "break_point":

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1699,10 +1699,10 @@ class Series:
         Parameters
         ----------
         breaks
-            A list of unique cut points.
+            List of unique cut points.
         labels
-            Labels to assign to the bins. If given, the number of labels must be
-            equal to the number of breaks plus one.
+            Names of the categories. The number of labels must be equal to the number
+            of cut points plus one.
         break_point_label
             Name of the breakpoint column. Only used if ``include_breaks`` is set to
             ``True``.
@@ -1718,13 +1718,14 @@ class Series:
                 This parameter will be removed. Use `Series.struct.rename_fields` to
                 rename the field instead.
         left_closed
-            Whether intervals should be ``[)`` instead of ``(]``.
+            Set the intervals to be left-closed instead of right-closed.
         include_breaks
-            Include the the right endpoint of the bin each observation falls in.
-            If returning a DataFrame, it will be a column, and if returning a Series
-            it will be a field in a Struct.
+            Include a column with the right endpoint of the bin each observation falls
+            in. This will change the data type of the output from a
+            :class:`Categorical` to a :class:`Struct`.
         as_series
-            If True, return a categorical Series in the data's original order.
+            If set to ``False``, return a DataFrame containing the original values,
+            the breakpoints, and the categories.
 
             .. deprecated:: 0.19.0
                 This parameter will be removed. The same behavior can be achieved by
@@ -1733,7 +1734,9 @@ class Series:
 
         Returns
         -------
-        Series or DataFrame
+        Series
+            Series of data type :class:`Categorical` if ``include_breaks`` is set to
+            ``False`` (default), otherwise a Series of data type :class:`Struct.
 
         See Also
         --------
@@ -1888,51 +1891,54 @@ class Series:
         as_series: bool = True,
     ) -> Series | DataFrame:
         """
-        Discretize continuous values into discrete categories based on their quantiles.
+        Bin continuous values into discrete categories based on their quantiles.
 
         Parameters
         ----------
         quantiles
             Either a list of quantile probabilities between 0 and 1 or a positive
-            integer determining the number of evenly spaced probabilities to use.
+            integer determining the number of bins with uniform probability.
         labels
-            Labels to assign to the quantiles. If given, the length of labels must be
-            ``len(breaks) + 1``.
+            Names of the categories. The number of labels must be equal to the number
+            of cut points plus one.
         left_closed
-            Whether intervals should be ``[)`` instead of ``(]``.
+            Set the intervals to be left-closed instead of right-closed.
         allow_duplicates
-            If ``True``, the resulting quantile breaks don't have to be unique. This can
-            happen even with unique probs depending on the data. Duplicates will be
-            dropped, resulting in fewer bins.
+            If set to ``True``, duplicates in the resulting quantiles are dropped,
+            rather than raising a `DuplicateError`. This can happen even with unique
+            probabilities, depending on the data.
         include_breaks
-            Include the the right endpoint of the bin each observation falls in.
-            If returning a DataFrame, it will be a column, and if returning a Series
-            it will be a field in a Struct.
+            Include a column with the right endpoint of the bin each observation falls
+            in. This will change the data type of the output from a
+            :class:`Categorical` to a :class:`Struct`.
         break_point_label
             Name of the breakpoint column. Only used if ``include_breaks`` is set to
             ``True``.
 
-            .. deprecated:: 0.18.14
+            .. deprecated:: 0.19.0
                 This parameter will be removed. Use `Series.struct.rename_fields` to
                 rename the field instead.
         category_label
             Name of the category column. Only used if ``include_breaks`` is set to
             ``True``.
 
-            .. deprecated:: 0.18.14
+            .. deprecated:: 0.19.0
                 This parameter will be removed. Use `Series.struct.rename_fields` to
                 rename the field instead.
         as_series
-            If ``True``, return a categorical Series in the data's original order.
+            If set to ``False``, return a DataFrame containing the original values,
+            the breakpoints, and the categories.
 
-            .. deprecated:: 0.18.14
+            .. deprecated:: 0.19.0
                 This parameter will be removed. The same behavior can be achieved by
                 setting ``include_breaks=True`, unnesting the resulting struct Series,
                 and adding the result to the original Series.
 
         Returns
         -------
-        Series or DataFrame
+        Series
+            Series of data type :class:`Categorical` if ``include_breaks`` is set to
+            ``False`` (default), otherwise a Series of data type :class:`Struct.
 
         Warnings
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -12,6 +12,7 @@ from typing import (
     Collection,
     Generator,
     Iterable,
+    Literal,
     NoReturn,
     Sequence,
     Union,
@@ -1635,6 +1636,48 @@ class Series:
         """
         return wrap_df(self._s.to_dummies(separator))
 
+    @overload
+    def cut(
+        self,
+        breaks: list[float],
+        labels: list[str] | None = ...,
+        break_point_label: str = ...,
+        category_label: str = ...,
+        *,
+        left_closed: bool = ...,
+        include_breaks: bool = ...,
+        series: Literal[True] = ...,
+    ) -> Series:
+        ...
+
+    @overload
+    def cut(
+        self,
+        breaks: list[float],
+        labels: list[str] | None = ...,
+        break_point_label: str = ...,
+        category_label: str = ...,
+        *,
+        left_closed: bool = ...,
+        include_breaks: bool = ...,
+        series: Literal[False],
+    ) -> DataFrame:
+        ...
+
+    @overload
+    def cut(
+        self,
+        breaks: list[float],
+        labels: list[str] | None = ...,
+        break_point_label: str = ...,
+        category_label: str = ...,
+        *,
+        left_closed: bool = ...,
+        include_breaks: bool = ...,
+        series: bool,
+    ) -> Series | DataFrame:
+        ...
+
     @deprecate_renamed_parameter("bins", "breaks", version="0.18.8")
     def cut(
         self,
@@ -1643,9 +1686,9 @@ class Series:
         break_point_label: str = "break_point",
         category_label: str = "category",
         *,
-        series: bool = True,
         left_closed: bool = False,
         include_breaks: bool = False,
+        series: bool = True,
     ) -> DataFrame | Series:
         """
         Bin continuous values into discrete categories.
@@ -1658,22 +1701,22 @@ class Series:
             Labels to assign to the bins. If given the length of labels must be
             len(breaks) + 1.
         break_point_label
-            Name given to the breakpoint column/field. Only used if series == False or
-            include_breaks == True
+            Name given to the breakpoint column/field. Only used if ``series == False``
+            or ``include_breaks == True``.
         category_label
             Name given to the category column. Only used if series == False
-        series
-            If True, return a categorical Series in the data's original order.
         left_closed
-            Whether intervals should be [) instead of (]
+            Whether intervals should be ``[)`` instead of ``(]``.
         include_breaks
             Include the the right endpoint of the bin each observation falls in.
             If returning a DataFrame, it will be a column, and if returning a Series
-            it will be a field in a Struct
+            it will be a field in a Struct.
+        series
+            If True, return a categorical Series in the data's original order.
 
         Returns
         -------
-        DataFrame or Series
+        Series or DataFrame
 
         Examples
         --------
@@ -1751,6 +1794,51 @@ class Series:
             return res.struct.rename_fields([break_point_label, category_label])
         return res
 
+    @overload
+    def qcut(
+        self,
+        quantiles: list[float] | int,
+        *,
+        labels: list[str] | None = ...,
+        break_point_label: str = ...,
+        category_label: str = ...,
+        left_closed: bool = ...,
+        allow_duplicates: bool = ...,
+        include_breaks: bool = ...,
+        series: Literal[True] = ...,
+    ) -> Series:
+        ...
+
+    @overload
+    def qcut(
+        self,
+        quantiles: list[float] | int,
+        *,
+        labels: list[str] | None = ...,
+        break_point_label: str = ...,
+        category_label: str = ...,
+        left_closed: bool = ...,
+        allow_duplicates: bool = ...,
+        include_breaks: bool = ...,
+        series: Literal[False],
+    ) -> DataFrame:
+        ...
+
+    @overload
+    def qcut(
+        self,
+        quantiles: list[float] | int,
+        *,
+        labels: list[str] | None = ...,
+        break_point_label: str = ...,
+        category_label: str = ...,
+        left_closed: bool = ...,
+        allow_duplicates: bool = ...,
+        include_breaks: bool = ...,
+        series: bool,
+    ) -> Series | DataFrame:
+        ...
+
     @deprecate_renamed_parameter("q", "quantiles", version="0.18.12")
     def qcut(
         self,
@@ -1759,10 +1847,10 @@ class Series:
         labels: list[str] | None = None,
         break_point_label: str = "break_point",
         category_label: str = "category",
-        series: bool = True,
         left_closed: bool = False,
         allow_duplicates: bool = False,
         include_breaks: bool = False,
+        series: bool = True,
     ) -> DataFrame | Series:
         """
         Discretize continuous values into discrete categories based on their quantiles.

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -1,11 +1,7 @@
 from datetime import timedelta
-from typing import cast
-
-import numpy as np
-from numpy import inf
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
 
 
 def test_corr() -> None:
@@ -25,138 +21,11 @@ def test_corr() -> None:
     assert_frame_equal(result, expected)
 
 
-def test_cut() -> None:
-    a = pl.Series("a", [v / 10 for v in range(-30, 30, 5)])
-    out = cast(pl.DataFrame, a.cut(breaks=[-1, 1], series=False))
-
-    assert out.shape == (12, 3)
-    assert out.filter(pl.col("break_point") < 1e9).to_dict(False) == {
-        "a": [-3.0, -2.5, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0],
-        "break_point": [-1.0, -1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0],
-        "category": [
-            "(-inf, -1]",
-            "(-inf, -1]",
-            "(-inf, -1]",
-            "(-inf, -1]",
-            "(-inf, -1]",
-            "(-1, 1]",
-            "(-1, 1]",
-            "(-1, 1]",
-            "(-1, 1]",
-        ],
-    }
-
-    # test cut on integers #4939
-    inf = float("inf")
-    df = pl.DataFrame({"a": list(range(5))})
-    ser = df.select("a").to_series()
-    assert cast(pl.DataFrame, ser.cut(breaks=[-1, 1], series=False)).rows() == [
-        (0.0, 1.0, "(-1, 1]"),
-        (1.0, 1.0, "(-1, 1]"),
-        (2.0, inf, "(1, inf]"),
-        (3.0, inf, "(1, inf]"),
-        (4.0, inf, "(1, inf]"),
-    ]
-
-    expected_df = pl.DataFrame(
-        {
-            "a": [5.0, 8.0, 9.0, 5.0, 0.0, 0.0, 1.0, 7.0, 6.0, 9.0],
-            "break_point": [inf, inf, inf, inf, 1.0, 1.0, 1.0, inf, inf, inf],
-            "category": [
-                "(1, inf]",
-                "(1, inf]",
-                "(1, inf]",
-                "(1, inf]",
-                "(-1, 1]",
-                "(-1, 1]",
-                "(-1, 1]",
-                "(1, inf]",
-                "(1, inf]",
-                "(1, inf]",
-            ],
-        }
-    )
-    np.random.seed(1)
-    a = pl.Series("a", np.random.randint(0, 10, 10))
-    out = cast(pl.DataFrame, a.cut(breaks=[-1, 1], series=False))
-    out_s = cast(pl.Series, a.cut(breaks=[-1, 1], series=True))
-    assert out["a"].cast(int).series_equal(a)
-    # Compare strings and categoricals without a hassle
-    assert_frame_equal(expected_df, out, check_dtype=False)
-    # It formats differently
-    assert_series_equal(
-        pl.Series(["(1, inf]"] * 4 + ["(-1, 1]"] * 3 + ["(1, inf]"] * 3),
-        out_s,
-        check_dtype=False,
-        check_names=False,
-    )
-
-
-def test_qcut() -> None:
-    input = pl.Series("a", range(-5, 3))
-    exp = pl.DataFrame(
-        {
-            "a": [-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0],
-            "break_point": [-5.0, -3.25, 0.25, 0.25, 0.25, 0.25, inf, inf],
-            "category": ["(-inf, -5]", "(-5, -3.25]"]
-            + ["(-3.25, 0.25]"] * 4
-            + ["(0.25, inf]"] * 2,
-        }
-    )
-    out = cast(pl.DataFrame, input.qcut([0.0, 0.25, 0.75], series=False))
-    out_s = cast(pl.Series, input.qcut([0.0, 0.25, 0.75], series=True))
-    assert_frame_equal(out, exp, check_dtype=False)
-    assert_series_equal(
-        exp["category"],
-        out_s,
-        check_dtype=False,
-        check_names=False,
-    )
-
-
 def test_hist() -> None:
     a = pl.Series("a", [1, 3, 8, 8, 2, 1, 3])
     assert (
         str(a.hist(bin_count=4).to_dict(False))
         == "{'break_point': [0.0, 2.25, 4.5, 6.75, inf], 'category': ['(-inf, 0.0]', '(0.0, 2.25]', '(2.25, 4.5]', '(4.5, 6.75]', '(6.75, inf]'], 'a_count': [0, 3, 2, 0, 2]}"
-    )
-
-
-def test_cut_null_values() -> None:
-    s = pl.Series([-1.0, None, 1.0, 2.0, None, 8.0, 4.0])
-    exp = pl.DataFrame(
-        {
-            "": [-1.0, None, 1.0, 2.0, None, 8.0, 4.0],
-            "break_point": [
-                0.5999999999999996,
-                None,
-                1.2000000000000002,
-                inf,
-                None,
-                inf,
-                inf,
-            ],
-            "category": [
-                "(-inf, 0.5999999999999996]",
-                None,
-                "(0.5999999999999996, 1.2000000000000002]",
-                "(1.2000000000000002, inf]",
-                None,
-                "(1.2000000000000002, inf]",
-                "(1.2000000000000002, inf]",
-            ],
-        }
-    )
-    assert_frame_equal(
-        cast(pl.DataFrame, s.qcut([0.2, 0.3], series=False)),
-        exp,
-        check_dtype=False,
-    )
-    assert_series_equal(
-        cast(pl.Series, s.qcut([0.2, 0.3], series=True)),
-        exp.get_column("category"),
-        check_dtype=False,
-        check_names=False,
     )
 
 
@@ -174,60 +43,3 @@ def test_correlation_cast_supertype() -> None:
     df = pl.DataFrame({"a": [1, 8, 3], "b": [4.0, 5.0, 2.0]})
     df = df.with_columns(pl.col("b"))
     assert df.select(pl.corr("a", "b")).to_dict(False) == {"a": [0.5447047794019223]}
-
-
-def test_cut_over() -> None:
-    with pl.StringCache():
-        x = pl.Series(range(20))
-    r = pl.Series(
-        [pl.repeat("a", 10, eager=True), pl.repeat("b", 10, eager=True)]
-    ).explode()
-    df = pl.DataFrame({"x": x, "g": r})
-
-    out = df.with_columns(pl.col("x").qcut([0.5]).over("g")).to_dict(False)
-    assert out == {
-        "x": [
-            "(-inf, 4.5]",
-            "(-inf, 4.5]",
-            "(-inf, 4.5]",
-            "(-inf, 4.5]",
-            "(-inf, 4.5]",
-            "(4.5, inf]",
-            "(4.5, inf]",
-            "(4.5, inf]",
-            "(4.5, inf]",
-            "(4.5, inf]",
-            "(-inf, 14.5]",
-            "(-inf, 14.5]",
-            "(-inf, 14.5]",
-            "(-inf, 14.5]",
-            "(-inf, 14.5]",
-            "(14.5, inf]",
-            "(14.5, inf]",
-            "(14.5, inf]",
-            "(14.5, inf]",
-            "(14.5, inf]",
-        ],
-        "g": [
-            "a",
-            "a",
-            "a",
-            "a",
-            "a",
-            "a",
-            "a",
-            "a",
-            "a",
-            "a",
-            "b",
-            "b",
-            "b",
-            "b",
-            "b",
-            "b",
-            "b",
-            "b",
-            "b",
-            "b",
-        ],
-    }

--- a/py-polars/tests/unit/series/test_cut.py
+++ b/py-polars/tests/unit/series/test_cut.py
@@ -1,0 +1,189 @@
+import numpy as np
+from numpy import inf
+
+import polars as pl
+from polars.testing import assert_frame_equal, assert_series_equal
+
+
+def test_cut() -> None:
+    a = pl.Series("a", [v / 10 for v in range(-30, 30, 5)])
+    out = a.cut(breaks=[-1, 1], series=False)
+
+    assert out.shape == (12, 3)
+    assert out.filter(pl.col("break_point") < 1e9).to_dict(False) == {
+        "a": [-3.0, -2.5, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0],
+        "break_point": [-1.0, -1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0],
+        "category": [
+            "(-inf, -1]",
+            "(-inf, -1]",
+            "(-inf, -1]",
+            "(-inf, -1]",
+            "(-inf, -1]",
+            "(-1, 1]",
+            "(-1, 1]",
+            "(-1, 1]",
+            "(-1, 1]",
+        ],
+    }
+
+    # test cut on integers #4939
+    inf = float("inf")
+    df = pl.DataFrame({"a": list(range(5))})
+    ser = df.select("a").to_series()
+    assert ser.cut(breaks=[-1, 1], series=False).rows() == [
+        (0.0, 1.0, "(-1, 1]"),
+        (1.0, 1.0, "(-1, 1]"),
+        (2.0, inf, "(1, inf]"),
+        (3.0, inf, "(1, inf]"),
+        (4.0, inf, "(1, inf]"),
+    ]
+
+    expected_df = pl.DataFrame(
+        {
+            "a": [5.0, 8.0, 9.0, 5.0, 0.0, 0.0, 1.0, 7.0, 6.0, 9.0],
+            "break_point": [inf, inf, inf, inf, 1.0, 1.0, 1.0, inf, inf, inf],
+            "category": [
+                "(1, inf]",
+                "(1, inf]",
+                "(1, inf]",
+                "(1, inf]",
+                "(-1, 1]",
+                "(-1, 1]",
+                "(-1, 1]",
+                "(1, inf]",
+                "(1, inf]",
+                "(1, inf]",
+            ],
+        }
+    )
+    np.random.seed(1)
+    a = pl.Series("a", np.random.randint(0, 10, 10))
+    out = a.cut(breaks=[-1, 1], series=False)
+    out_s = a.cut(breaks=[-1, 1], series=True)
+    assert out["a"].cast(int).series_equal(a)
+    # Compare strings and categoricals without a hassle
+    assert_frame_equal(expected_df, out, check_dtype=False)
+    # It formats differently
+    assert_series_equal(
+        pl.Series(["(1, inf]"] * 4 + ["(-1, 1]"] * 3 + ["(1, inf]"] * 3),
+        out_s,
+        check_dtype=False,
+        check_names=False,
+    )
+
+
+def test_qcut() -> None:
+    input = pl.Series("a", range(-5, 3))
+    exp = pl.DataFrame(
+        {
+            "a": [-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0],
+            "break_point": [-5.0, -3.25, 0.25, 0.25, 0.25, 0.25, inf, inf],
+            "category": ["(-inf, -5]", "(-5, -3.25]"]
+            + ["(-3.25, 0.25]"] * 4
+            + ["(0.25, inf]"] * 2,
+        }
+    )
+    out = input.qcut([0.0, 0.25, 0.75], series=False)
+    out_s = input.qcut([0.0, 0.25, 0.75], series=True)
+    assert_frame_equal(out, exp, check_dtype=False)
+    assert_series_equal(
+        exp["category"],
+        out_s,
+        check_dtype=False,
+        check_names=False,
+    )
+
+
+def test_qcut_null_values() -> None:
+    s = pl.Series([-1.0, None, 1.0, 2.0, None, 8.0, 4.0])
+    exp = pl.DataFrame(
+        {
+            "": [-1.0, None, 1.0, 2.0, None, 8.0, 4.0],
+            "break_point": [
+                0.5999999999999996,
+                None,
+                1.2000000000000002,
+                inf,
+                None,
+                inf,
+                inf,
+            ],
+            "category": [
+                "(-inf, 0.5999999999999996]",
+                None,
+                "(0.5999999999999996, 1.2000000000000002]",
+                "(1.2000000000000002, inf]",
+                None,
+                "(1.2000000000000002, inf]",
+                "(1.2000000000000002, inf]",
+            ],
+        }
+    )
+    assert_frame_equal(
+        s.qcut([0.2, 0.3], series=False),
+        exp,
+        check_dtype=False,
+    )
+    assert_series_equal(
+        s.qcut([0.2, 0.3], series=True),
+        exp.get_column("category"),
+        check_dtype=False,
+        check_names=False,
+    )
+
+
+def test_cut_over() -> None:
+    with pl.StringCache():
+        x = pl.Series(range(20))
+    r = pl.Series(
+        [pl.repeat("a", 10, eager=True), pl.repeat("b", 10, eager=True)]
+    ).explode()
+    df = pl.DataFrame({"x": x, "g": r})
+
+    out = df.with_columns(pl.col("x").qcut([0.5]).over("g")).to_dict(False)
+    assert out == {
+        "x": [
+            "(-inf, 4.5]",
+            "(-inf, 4.5]",
+            "(-inf, 4.5]",
+            "(-inf, 4.5]",
+            "(-inf, 4.5]",
+            "(4.5, inf]",
+            "(4.5, inf]",
+            "(4.5, inf]",
+            "(4.5, inf]",
+            "(4.5, inf]",
+            "(-inf, 14.5]",
+            "(-inf, 14.5]",
+            "(-inf, 14.5]",
+            "(-inf, 14.5]",
+            "(-inf, 14.5]",
+            "(14.5, inf]",
+            "(14.5, inf]",
+            "(14.5, inf]",
+            "(14.5, inf]",
+            "(14.5, inf]",
+        ],
+        "g": [
+            "a",
+            "a",
+            "a",
+            "a",
+            "a",
+            "a",
+            "a",
+            "a",
+            "a",
+            "a",
+            "b",
+            "b",
+            "b",
+            "b",
+            "b",
+            "b",
+            "b",
+            "b",
+            "b",
+            "b",
+        ],
+    }

--- a/py-polars/tests/unit/series/test_cut.py
+++ b/py-polars/tests/unit/series/test_cut.py
@@ -1,13 +1,58 @@
-import numpy as np
-from numpy import inf
+import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_series_equal
+
+inf = float("inf")
 
 
 def test_cut() -> None:
+    s = pl.Series("a", [-2, -1, 0, 1, 2])
+
+    out = s.cut([-1, 1])
+
+    expected = pl.Series(
+        "a",
+        [
+            "(-inf, -1]",
+            "(-inf, -1]",
+            "(-1, 1]",
+            "(-1, 1]",
+            "(1, inf]",
+        ],
+        dtype=pl.Categorical,
+    )
+    assert_series_equal(out, expected, categorical_as_str=True)
+
+
+def test_cut_include_breaks() -> None:
+    s = pl.Series("a", [-2, -1, 0, 1, 2])
+
+    out = s.cut([-1.5, 0.25, 1.0], labels=["a", "b", "c", "d"], include_breaks=True)
+
+    expected = pl.DataFrame(
+        {
+            "break_point": [-1.5, 0.25, 0.25, 1.0, inf],
+            "category": ["a", "b", "b", "c", "d"],
+        },
+        schema_overrides={"category": pl.Categorical},
+    ).to_struct("a")
+    assert_series_equal(out, expected, categorical_as_str=True)
+
+
+def test_cut_null_values() -> None:
+    s = pl.Series([-1.0, None, 1.0, 2.0, None, 8.0, 4.0])
+
+    result = s.cut([1.5, 5.0], labels=["a", "b", "c"])
+
+    expected = pl.Series(["a", None, "a", "b", None, "c", "b"], dtype=pl.Categorical)
+    assert_series_equal(result, expected, categorical_as_str=True)
+
+
+def test_cut_deprecated_as_series() -> None:
     a = pl.Series("a", [v / 10 for v in range(-30, 30, 5)])
-    out = a.cut(breaks=[-1, 1], series=False)
+    with pytest.deprecated_call():
+        out = a.cut(breaks=[-1, 1], as_series=False)
 
     assert out.shape == (12, 3)
     assert out.filter(pl.col("break_point") < 1e9).to_dict(False) == {
@@ -26,164 +71,10 @@ def test_cut() -> None:
         ],
     }
 
-    # test cut on integers #4939
-    inf = float("inf")
-    df = pl.DataFrame({"a": list(range(5))})
-    ser = df.select("a").to_series()
-    assert ser.cut(breaks=[-1, 1], series=False).rows() == [
-        (0.0, 1.0, "(-1, 1]"),
-        (1.0, 1.0, "(-1, 1]"),
-        (2.0, inf, "(1, inf]"),
-        (3.0, inf, "(1, inf]"),
-        (4.0, inf, "(1, inf]"),
-    ]
 
-    expected_df = pl.DataFrame(
-        {
-            "a": [5.0, 8.0, 9.0, 5.0, 0.0, 0.0, 1.0, 7.0, 6.0, 9.0],
-            "break_point": [inf, inf, inf, inf, 1.0, 1.0, 1.0, inf, inf, inf],
-            "category": [
-                "(1, inf]",
-                "(1, inf]",
-                "(1, inf]",
-                "(1, inf]",
-                "(-1, 1]",
-                "(-1, 1]",
-                "(-1, 1]",
-                "(1, inf]",
-                "(1, inf]",
-                "(1, inf]",
-            ],
-        }
-    )
-    np.random.seed(1)
-    a = pl.Series("a", np.random.randint(0, 10, 10))
-    out = a.cut(breaks=[-1, 1], series=False)
-    out_s = a.cut(breaks=[-1, 1], series=True)
-    assert out["a"].cast(int).series_equal(a)
-    # Compare strings and categoricals without a hassle
-    assert_frame_equal(expected_df, out, check_dtype=False)
-    # It formats differently
-    assert_series_equal(
-        pl.Series(["(1, inf]"] * 4 + ["(-1, 1]"] * 3 + ["(1, inf]"] * 3),
-        out_s,
-        check_dtype=False,
-        check_names=False,
-    )
-
-
-def test_qcut() -> None:
-    input = pl.Series("a", range(-5, 3))
-    exp = pl.DataFrame(
-        {
-            "a": [-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0],
-            "break_point": [-5.0, -3.25, 0.25, 0.25, 0.25, 0.25, inf, inf],
-            "category": ["(-inf, -5]", "(-5, -3.25]"]
-            + ["(-3.25, 0.25]"] * 4
-            + ["(0.25, inf]"] * 2,
-        }
-    )
-    out = input.qcut([0.0, 0.25, 0.75], series=False)
-    out_s = input.qcut([0.0, 0.25, 0.75], series=True)
-    assert_frame_equal(out, exp, check_dtype=False)
-    assert_series_equal(
-        exp["category"],
-        out_s,
-        check_dtype=False,
-        check_names=False,
-    )
-
-
-def test_qcut_null_values() -> None:
-    s = pl.Series([-1.0, None, 1.0, 2.0, None, 8.0, 4.0])
-    exp = pl.DataFrame(
-        {
-            "": [-1.0, None, 1.0, 2.0, None, 8.0, 4.0],
-            "break_point": [
-                0.5999999999999996,
-                None,
-                1.2000000000000002,
-                inf,
-                None,
-                inf,
-                inf,
-            ],
-            "category": [
-                "(-inf, 0.5999999999999996]",
-                None,
-                "(0.5999999999999996, 1.2000000000000002]",
-                "(1.2000000000000002, inf]",
-                None,
-                "(1.2000000000000002, inf]",
-                "(1.2000000000000002, inf]",
-            ],
-        }
-    )
-    assert_frame_equal(
-        s.qcut([0.2, 0.3], series=False),
-        exp,
-        check_dtype=False,
-    )
-    assert_series_equal(
-        s.qcut([0.2, 0.3], series=True),
-        exp.get_column("category"),
-        check_dtype=False,
-        check_names=False,
-    )
-
-
-def test_cut_over() -> None:
-    with pl.StringCache():
-        x = pl.Series(range(20))
-    r = pl.Series(
-        [pl.repeat("a", 10, eager=True), pl.repeat("b", 10, eager=True)]
-    ).explode()
-    df = pl.DataFrame({"x": x, "g": r})
-
-    out = df.with_columns(pl.col("x").qcut([0.5]).over("g")).to_dict(False)
-    assert out == {
-        "x": [
-            "(-inf, 4.5]",
-            "(-inf, 4.5]",
-            "(-inf, 4.5]",
-            "(-inf, 4.5]",
-            "(-inf, 4.5]",
-            "(4.5, inf]",
-            "(4.5, inf]",
-            "(4.5, inf]",
-            "(4.5, inf]",
-            "(4.5, inf]",
-            "(-inf, 14.5]",
-            "(-inf, 14.5]",
-            "(-inf, 14.5]",
-            "(-inf, 14.5]",
-            "(-inf, 14.5]",
-            "(14.5, inf]",
-            "(14.5, inf]",
-            "(14.5, inf]",
-            "(14.5, inf]",
-            "(14.5, inf]",
-        ],
-        "g": [
-            "a",
-            "a",
-            "a",
-            "a",
-            "a",
-            "a",
-            "a",
-            "a",
-            "a",
-            "a",
-            "b",
-            "b",
-            "b",
-            "b",
-            "b",
-            "b",
-            "b",
-            "b",
-            "b",
-            "b",
-        ],
-    }
+def test_cut_deprecated_label_name() -> None:
+    s = pl.Series([1.0, 2.0])
+    with pytest.deprecated_call():
+        s.cut([0.1], category_label="x")
+    with pytest.deprecated_call():
+        s.cut([0.1], break_point_label="x")

--- a/py-polars/tests/unit/series/test_qcut.py
+++ b/py-polars/tests/unit/series/test_qcut.py
@@ -58,6 +58,20 @@ def test_qcut_null_values() -> None:
     assert_series_equal(result, expected, categorical_as_str=True)
 
 
+def test_qcut_allow_duplicates() -> None:
+    s = pl.Series([1, 2, 2, 3])
+
+    with pytest.raises(pl.DuplicateError):
+        s.qcut([0.50, 0.51])
+
+    result = s.qcut([0.50, 0.51], allow_duplicates=True)
+
+    expected = pl.Series(
+        ["(-inf, 2]", "(-inf, 2]", "(-inf, 2]", "(2, inf]"], dtype=pl.Categorical
+    )
+    assert_series_equal(result, expected, categorical_as_str=True)
+
+
 def test_qcut_over() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/series/test_qcut.py
+++ b/py-polars/tests/unit/series/test_qcut.py
@@ -1,0 +1,86 @@
+import pytest
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+inf = float("inf")
+
+
+def test_qcut() -> None:
+    s = pl.Series("a", [-2, -1, 0, 1, 2])
+
+    out = s.qcut([0.25, 0.50])
+
+    expected = pl.Series(
+        "a",
+        [
+            "(-inf, -1]",
+            "(-inf, -1]",
+            "(-1, 0]",
+            "(0, inf]",
+            "(0, inf]",
+        ],
+        dtype=pl.Categorical,
+    )
+    assert_series_equal(out, expected, categorical_as_str=True)
+
+
+def test_qcut_n() -> None:
+    s = pl.Series("a", [-2, -1, 0, 1, 2])
+
+    out = s.qcut(2, labels=["x", "y"], left_closed=True)
+
+    expected = pl.Series("a", ["x", "x", "y", "y", "y"], dtype=pl.Categorical)
+    assert_series_equal(out, expected, categorical_as_str=True)
+
+
+def test_qcut_include_breaks() -> None:
+    s = pl.int_range(-2, 3, eager=True).alias("a")
+
+    out = s.qcut([0.0, 0.25, 0.75], labels=["a", "b", "c", "d"], include_breaks=True)
+
+    expected = pl.DataFrame(
+        {
+            "break_point": [-2.0, -1.0, 1.0, 1.0, inf],
+            "category": ["a", "b", "c", "c", "d"],
+        },
+        schema_overrides={"category": pl.Categorical},
+    ).to_struct("a")
+    assert_series_equal(out, expected, categorical_as_str=True)
+
+
+def test_qcut_null_values() -> None:
+    s = pl.Series([-1.0, None, 1.0, 2.0, None, 8.0, 4.0])
+
+    result = s.qcut([0.2, 0.3], labels=["a", "b", "c"])
+
+    expected = pl.Series(["a", None, "b", "c", None, "c", "c"], dtype=pl.Categorical)
+    assert_series_equal(result, expected, categorical_as_str=True)
+
+
+def test_qcut_over() -> None:
+    df = pl.DataFrame(
+        {
+            "group": ["a"] * 4 + ["b"] * 4,
+            "value": range(8),
+        }
+    )
+
+    out = df.select(
+        pl.col("value").qcut([0.5], labels=["low", "high"]).over("group")
+    ).to_series()
+
+    expected = pl.Series(
+        "value",
+        ["low", "low", "high", "high", "low", "low", "high", "high"],
+        dtype=pl.Categorical,
+    )
+    assert_series_equal(out, expected, categorical_as_str=True)
+
+
+def test_qcut_deprecated_label_name() -> None:
+    s = pl.Series([1.0, 2.0])
+    with pytest.deprecated_call():
+        s.qcut([0.1], category_label="x")
+    with pytest.deprecated_call():
+        s.qcut([0.1], break_point_label="x")

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -44,7 +44,7 @@ def test_error_on_reducing_map() -> None:
     ):
         df.select(
             pl.col("x")
-            .map(lambda x: x.cut(breaks=[1, 2, 3], series=False))
+            .map(lambda x: x.cut(breaks=[1, 2, 3], include_breaks=True).struct.unnest())
             .over("group")
         )
 


### PR DESCRIPTION
Partially addresses [#10468](https://github.com/pola-rs/polars/issues/10468)

#### Changes
* Rename `series` parameter to `as_series` and deprecate it. This is a remnant of the old `pl.cut` function. The method should just return a Series - possibly a struct Series if `include_breaks=True`.
* Add overload typing specification (will be removed when `as_series` is removed).
* Deprecate `category_label` and `break_point_label`. This is unnecessary parameter bloat. We should set sensible naming defaults and allow the user to overwrite it with `Series.struct.rename_fields` if they want.
* Clean up docstrings, doc exampes, tests.

To do, in a different PR:
* Split the parameter `quantiles` for `qcut` into two parameters - `probabilities` and `n_bins` (not 100% sure about the names).