### PR TITLE
test(python): Gather all streaming tests

### DIFF
--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -183,11 +183,6 @@ def test_lazy_n_rows(foods_file_path: Path) -> None:
     }
 
 
-def test_scan_slice_streaming(foods_file_path: Path) -> None:
-    df = pl.scan_csv(foods_file_path).head(5).collect(streaming=True)
-    assert df.shape == (5, 4)
-
-
 @pytest.mark.write_disk()
 def test_glob_skip_rows(tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -211,17 +211,6 @@ def test_glob_parquet(df: pl.DataFrame, tmp_path: Path) -> None:
     assert pl.scan_parquet(path_glob).collect().shape == (3, 16)
 
 
-@pytest.mark.write_disk()
-def test_streaming_parquet_glob_5900(df: pl.DataFrame, tmp_path: Path) -> None:
-    tmp_path.mkdir(exist_ok=True)
-    file_path = tmp_path / "small.parquet"
-    df.write_parquet(file_path)
-
-    path_glob = tmp_path / "small*.parquet"
-    result = pl.scan_parquet(path_glob).select(pl.all().first()).collect(streaming=True)
-    assert result.shape == (1, 16)
-
-
 def test_chunked_round_trip() -> None:
     df1 = pl.DataFrame(
         {

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -280,16 +280,3 @@ def test_sum_empty_and_null_set() -> None:
     df = pl.DataFrame({"a": [None, None, None], "b": [1, 1, 1]})
     assert df.select(pl.sum("a")).item() == 0.0
     assert df.groupby("b").agg(pl.sum("a"))["a"].item() == 0.0
-
-
-def test_null_sum_streaming_10455() -> None:
-    df = pl.DataFrame(
-        {
-            "x": [1] * 10,
-            "y": [None] * 10,
-        }
-    )
-    assert df.lazy().groupby("x").sum().collect(streaming=True).to_dict(False) == {
-        "x": [1],
-        "y": [0.0],
-    }

--- a/py-polars/tests/unit/operations/test_groupby.py
+++ b/py-polars/tests/unit/operations/test_groupby.py
@@ -430,23 +430,6 @@ def test_groupby_all_masked_out() -> None:
     assert_frame_equal(parts[0], df)
 
 
-def test_groupby_min_max_string_type() -> None:
-    table = pl.from_dict({"a": [1, 1, 2, 2, 2], "b": ["a", "b", "c", "d", None]})
-
-    expected = {"a": [1, 2], "min": ["a", "c"], "max": ["b", "d"]}
-
-    for streaming in [True, False]:
-        assert (
-            table.lazy()
-            .groupby("a")
-            .agg([pl.min("b").alias("min"), pl.max("b").alias("max")])
-            .collect(streaming=streaming)
-            .sort("a")
-            .to_dict(False)
-            == expected
-        )
-
-
 def test_groupby_null_propagation_6185() -> None:
     df_1 = pl.DataFrame({"A": [0, 0], "B": [1, 2]})
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -359,16 +359,6 @@ def test_sorted_flag_after_joins() -> None:
     joined = dfb.join(dfa, on="b", how="anti")
     assert not joined["a"].flags["SORTED_ASC"]
 
-    # streaming left join
-    df1 = pl.DataFrame({"x": [1, 2, 3, 4], "y": [2, 4, 6, 6]}).set_sorted("x")
-    df2 = pl.DataFrame({"x": [4, 2, 3, 1], "z": [1, 4, 9, 1]})
-    assert (
-        df1.lazy()
-        .join(df2.lazy(), on="x", how="left")
-        .collect(streaming=True)["x"]
-        .flags["SORTED_ASC"]
-    )
-
 
 def test_jit_sort_joins() -> None:
     n = 200
@@ -410,54 +400,6 @@ def test_jit_sort_joins() -> None:
         a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
         assert_frame_equal(a, pl_result)
         assert pl_result["a"].flags["SORTED_ASC"]
-
-
-def test_streaming_joins() -> None:
-    n = 100
-    dfa = pd.DataFrame(
-        {
-            "a": np.random.randint(0, 40, n),
-            "b": np.arange(0, n),
-        }
-    )
-
-    n = 100
-    dfb = pd.DataFrame(
-        {
-            "a": np.random.randint(0, 40, n),
-            "b": np.arange(0, n),
-        }
-    )
-    dfa_pl = pl.from_pandas(dfa).sort("a")
-    dfb_pl = pl.from_pandas(dfb)
-
-    join_strategies: list[Literal["inner", "left"]] = ["inner", "left"]
-    for how in join_strategies:
-        pd_result = dfa.merge(dfb, on="a", how=how)
-        pd_result.columns = pd.Index(["a", "b", "b_right"])
-
-        pl_result = (
-            dfa_pl.lazy()
-            .join(dfb_pl.lazy(), on="a", how=how)
-            .sort(["a", "b"])
-            .collect(streaming=True)
-        )
-
-        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
-        pl.testing.assert_frame_equal(a, pl_result, check_dtype=False)
-
-        pd_result = dfa.merge(dfb, on=["a", "b"], how=how)
-
-        pl_result = (
-            dfa_pl.lazy()
-            .join(dfb_pl.lazy(), on=["a", "b"], how=how)
-            .sort(["a", "b"])
-            .collect(streaming=True)
-        )
-
-        # we cast to integer because pandas joins creates floats
-        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
-        pl.testing.assert_frame_equal(a, pl_result, check_dtype=False)
 
 
 def test_join_panic_on_binary_expr_5915() -> None:

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -222,7 +222,6 @@ def test_sorted_flag() -> None:
     ).sort("timestamp")
 
     assert q.collect()["timestamp"].flags["SORTED_ASC"]
-    assert q.collect(streaming=True)["timestamp"].flags["SORTED_ASC"]
 
     # top-k/bottom-k
     df = pl.DataFrame({"foo": [56, 2, 3]})

--- a/py-polars/tests/unit/streaming/test_streaming_cse.py
+++ b/py-polars/tests/unit/streaming/test_streaming_cse.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+pytestmark = pytest.mark.xdist_group("streaming")
+
+
+def test_cse_expr_selection_streaming(monkeypatch: Any, capfd: Any) -> None:
+    monkeypatch.setenv("POLARS_VERBOSE", "1")
+    q = pl.LazyFrame(
+        {
+            "a": [1, 2, 3, 4],
+            "b": [1, 2, 3, 4],
+            "c": [1, 2, 3, 4],
+        }
+    )
+
+    derived = pl.col("a") * pl.col("b")
+    derived2 = derived * derived
+
+    exprs = [
+        derived.alias("d1"),
+        derived2.alias("d2"),
+        (derived2 * 10).alias("d3"),
+    ]
+
+    assert q.select(exprs).collect(comm_subexpr_elim=True, streaming=True).to_dict(
+        False
+    ) == {"d1": [1, 4, 9, 16], "d2": [1, 16, 81, 256], "d3": [10, 160, 810, 2560]}
+    assert q.with_columns(exprs).collect(
+        comm_subexpr_elim=True, streaming=True
+    ).to_dict(False) == {
+        "a": [1, 2, 3, 4],
+        "b": [1, 2, 3, 4],
+        "c": [1, 2, 3, 4],
+        "d1": [1, 4, 9, 16],
+        "d2": [1, 16, 81, 256],
+        "d3": [10, 160, 810, 2560],
+    }
+    err = capfd.readouterr().err
+    assert "df -> projection[cse] -> ordered_sink" in err
+    assert "df -> hstack[cse] -> ordered_sink" in err
+
+
+@pytest.mark.skip(reason="activate once fixed")
+def test_cse_expr_groupby() -> None:
+    q = pl.LazyFrame(
+        {
+            "a": [1, 2, 3, 4],
+            "b": [1, 2, 3, 4],
+            "c": [1, 2, 3, 4],
+        }
+    )
+
+    derived = pl.col("a") * pl.col("b")
+
+    q = (
+        q.groupby("a")
+        .agg(derived.sum().alias("sum"), derived.min().alias("min"))
+        .sort("min")
+    )
+
+    assert "__POLARS_CSER" in q.explain(comm_subexpr_elim=True, optimized=True)
+
+    s = q.explain(
+        comm_subexpr_elim=True, optimized=True, streaming=True, comm_subplan_elim=False
+    )
+    # check if it uses CSE_expr
+    # and is a complete pipeline
+    assert "__POLARS_CSER" in s
+    assert s.startswith("--- PIPELINE")
+
+    expected = pl.DataFrame(
+        {"a": [1, 2, 3, 4], "sum": [1, 4, 9, 16], "min": [1, 4, 9, 16]}
+    )
+    for streaming in [True, False]:
+        out = q.collect(comm_subexpr_elim=True, streaming=streaming)
+        assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+import polars as pl
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.xdist_group("streaming")
+
+
+@pytest.mark.write_disk()
+def test_streaming_parquet_glob_5900(df: pl.DataFrame, tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    file_path = tmp_path / "small.parquet"
+    df.write_parquet(file_path)
+
+    path_glob = tmp_path / "small*.parquet"
+    result = pl.scan_parquet(path_glob).select(pl.all().first()).collect(streaming=True)
+    assert result.shape == (1, 16)
+
+
+def test_scan_slice_streaming(io_files_path: Path) -> None:
+    foods_file_path = io_files_path / "foods1.csv"
+    df = pl.scan_csv(foods_file_path).head(5).collect(streaming=True)
+    assert df.shape == (5, 4)

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+pytestmark = pytest.mark.xdist_group("streaming")
+
+
+def test_streaming_joins() -> None:
+    n = 100
+    dfa = pd.DataFrame(
+        {
+            "a": np.random.randint(0, 40, n),
+            "b": np.arange(0, n),
+        }
+    )
+
+    n = 100
+    dfb = pd.DataFrame(
+        {
+            "a": np.random.randint(0, 40, n),
+            "b": np.arange(0, n),
+        }
+    )
+    dfa_pl = pl.from_pandas(dfa).sort("a")
+    dfb_pl = pl.from_pandas(dfb)
+
+    join_strategies: list[Literal["inner", "left"]] = ["inner", "left"]
+    for how in join_strategies:
+        pd_result = dfa.merge(dfb, on="a", how=how)
+        pd_result.columns = pd.Index(["a", "b", "b_right"])
+
+        pl_result = (
+            dfa_pl.lazy()
+            .join(dfb_pl.lazy(), on="a", how=how)
+            .sort(["a", "b"])
+            .collect(streaming=True)
+        )
+
+        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
+        assert_frame_equal(a, pl_result, check_dtype=False)
+
+        pd_result = dfa.merge(dfb, on=["a", "b"], how=how)
+
+        pl_result = (
+            dfa_pl.lazy()
+            .join(dfb_pl.lazy(), on=["a", "b"], how=how)
+            .sort(["a", "b"])
+            .collect(streaming=True)
+        )
+
+        # we cast to integer because pandas joins creates floats
+        a = pl.from_pandas(pd_result).with_columns(pl.all().cast(int)).sort(["a", "b"])
+        assert_frame_equal(a, pl_result, check_dtype=False)
+
+
+def test_sorted_flag_after_streaming_join() -> None:
+    # streaming left join
+    df1 = pl.DataFrame({"x": [1, 2, 3, 4], "y": [2, 4, 6, 6]}).set_sorted("x")
+    df2 = pl.DataFrame({"x": [4, 2, 3, 1], "z": [1, 4, 9, 1]})
+    assert (
+        df1.lazy()
+        .join(df2.lazy(), on="x", how="left")
+        .collect(streaming=True)["x"]
+        .flags["SORTED_ASC"]
+    )

--- a/py-polars/tests/unit/streaming/test_streaming_sort.py
+++ b/py-polars/tests/unit/streaming/test_streaming_sort.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from typing import Any
 
@@ -138,3 +140,16 @@ def test_streaming_sort_multiple_columns(
     assert "RUN STREAMING PIPELINE" in err
     assert "df -> sort_multiple" in err
     assert out.columns == ["vals", "strs"]
+
+
+def test_streaming_sort_sorted_flag() -> None:
+    # empty
+    q = pl.LazyFrame(
+        schema={
+            "store_id": pl.UInt16,
+            "item_id": pl.UInt32,
+            "timestamp": pl.Datetime,
+        }
+    ).sort("timestamp")
+
+    assert q.collect(streaming=True)["timestamp"].flags["SORTED_ASC"]

--- a/py-polars/tests/unit/streaming/test_streaming_unique.py
+++ b/py-polars/tests/unit/streaming/test_streaming_unique.py
@@ -1,10 +1,14 @@
-from pathlib import Path
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 pytestmark = pytest.mark.xdist_group("streaming")
 

--- a/py-polars/tests/unit/test_cse.py
+++ b/py-polars/tests/unit/test_cse.py
@@ -6,7 +6,6 @@ from typing import Any
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal
 
 
 def test_cse_rename_cross_join_5405() -> None:
@@ -175,79 +174,6 @@ def test_cse_expr_selection_context(monkeypatch: Any, capfd: Any) -> None:
     out = capfd.readouterr().out
     assert "run ProjectionExec with 2 CSE" in out
     assert "run StackExec with 2 CSE" in out
-
-
-def test_cse_expr_selection_streaming(monkeypatch: Any, capfd: Any) -> None:
-    monkeypatch.setenv("POLARS_VERBOSE", "1")
-    q = pl.LazyFrame(
-        {
-            "a": [1, 2, 3, 4],
-            "b": [1, 2, 3, 4],
-            "c": [1, 2, 3, 4],
-        }
-    )
-
-    derived = pl.col("a") * pl.col("b")
-    derived2 = derived * derived
-
-    exprs = [
-        derived.alias("d1"),
-        derived2.alias("d2"),
-        (derived2 * 10).alias("d3"),
-    ]
-
-    assert q.select(exprs).collect(comm_subexpr_elim=True, streaming=True).to_dict(
-        False
-    ) == {"d1": [1, 4, 9, 16], "d2": [1, 16, 81, 256], "d3": [10, 160, 810, 2560]}
-    assert q.with_columns(exprs).collect(
-        comm_subexpr_elim=True, streaming=True
-    ).to_dict(False) == {
-        "a": [1, 2, 3, 4],
-        "b": [1, 2, 3, 4],
-        "c": [1, 2, 3, 4],
-        "d1": [1, 4, 9, 16],
-        "d2": [1, 16, 81, 256],
-        "d3": [10, 160, 810, 2560],
-    }
-    err = capfd.readouterr().err
-    assert "df -> projection[cse] -> ordered_sink" in err
-    assert "df -> hstack[cse] -> ordered_sink" in err
-
-
-@pytest.mark.skip(reason="activate once fixed")
-def test_cse_expr_groupby() -> None:
-    q = pl.LazyFrame(
-        {
-            "a": [1, 2, 3, 4],
-            "b": [1, 2, 3, 4],
-            "c": [1, 2, 3, 4],
-        }
-    )
-
-    derived = pl.col("a") * pl.col("b")
-
-    q = (
-        q.groupby("a")
-        .agg(derived.sum().alias("sum"), derived.min().alias("min"))
-        .sort("min")
-    )
-
-    assert "__POLARS_CSER" in q.explain(comm_subexpr_elim=True, optimized=True)
-
-    s = q.explain(
-        comm_subexpr_elim=True, optimized=True, streaming=True, comm_subplan_elim=False
-    )
-    # check if it uses CSE_expr
-    # and is a complete pipeline
-    assert "__POLARS_CSER" in s
-    assert s.startswith("--- PIPELINE")
-
-    expected = pl.DataFrame(
-        {"a": [1, 2, 3, 4], "sum": [1, 4, 9, 16], "min": [1, 4, 9, 16]}
-    )
-    for streaming in [True, False]:
-        out = q.collect(comm_subexpr_elim=True, streaming=streaming)
-        assert_frame_equal(out, expected)
 
 
 def test_windows_cse_excluded() -> None:

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -73,24 +73,6 @@ def test_predicate_null_block_asof_join() -> None:
     }
 
 
-def test_streaming_empty_df() -> None:
-    df = pl.DataFrame(
-        [
-            pl.Series("a", ["a", "b", "c", "b", "a", "a"], dtype=pl.Categorical()),
-            pl.Series("b", ["b", "c", "c", "b", "a", "c"], dtype=pl.Categorical()),
-        ]
-    )
-
-    result = (
-        df.lazy()
-        .join(df.lazy(), on="a", how="inner")
-        .filter(False)
-        .collect(streaming=True)
-    )
-
-    assert result.to_dict(False) == {"a": [], "b": [], "b_right": []}
-
-
 def test_predicate_strptime_6558() -> None:
     assert (
         pl.DataFrame({"date": ["2022-01-03", "2020-01-04", "2021-02-03", "2019-01-04"]})

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -114,16 +114,6 @@ def test_unnest_columns_available() -> None:
     }
 
 
-def test_streaming_duplicate_cols_5537() -> None:
-    assert pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]}).lazy().with_columns(
-        [(pl.col("a") * 2).alias("foo"), (pl.col("a") * 3)]
-    ).collect(streaming=True).to_dict(False) == {
-        "a": [3, 6, 9],
-        "b": [1, 2, 3],
-        "foo": [2, 4, 6],
-    }
-
-
 def test_double_projection_union() -> None:
     lf1 = pl.DataFrame(
         {

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -262,24 +262,6 @@ def test_diff_duration_dtype() -> None:
     ]
 
 
-def test_boolean_agg_schema() -> None:
-    df = pl.DataFrame(
-        {
-            "x": [1, 1, 1],
-            "y": [False, True, False],
-        }
-    ).lazy()
-
-    agg_df = df.groupby("x").agg(pl.col("y").max().alias("max_y"))
-
-    for streaming in [True, False]:
-        assert (
-            agg_df.collect(streaming=streaming).schema
-            == agg_df.schema
-            == {"x": pl.Int64, "max_y": pl.Boolean}
-        )
-
-
 def test_schema_owned_arithmetic_5669() -> None:
     df = (
         pl.DataFrame({"A": [1, 2, 3]})


### PR DESCRIPTION
Since we're still getting failures on the streaming tests, another attempt at gathering all streaming tests under one runner.

If this doesn't fix it, there must be a bug in the garbage collection.