### PR TITLE
test(python): Mark import timing check as slow

### DIFF
--- a/py-polars/tests/unit/test_polars_import.py
+++ b/py-polars/tests/unit/test_polars_import.py
@@ -41,6 +41,7 @@ def _import_timings_as_frame(best_of: int) -> pl.DataFrame:
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Unreliable on Windows")
+@pytest.mark.slow()
 def test_polars_import() -> None:
     # note: take the fastest of several runs to reduce noise.
     df_import = _import_timings_as_frame(best_of=3)


### PR DESCRIPTION
This avoids running the test locally, but still runs it in the CI.

The timing threshold is tuned for the CI machines. If your local machine is slow it will give many false positives - if it's fast you'll never trigger it even if you mess up the imports. So there's not much use running this locally.

Now that I think about it, the part that checks whether the dependencies are imported at all would make sense locally. Still, it's a relatively slow test so the `slow` marker is appropriate. It will be included with `make test-all`.