### PR TITLE
docs(python): Add version switcher to API reference

### DIFF
--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -40,6 +40,7 @@ jobs:
         working-directory: py-polars/docs
         env:
           SPHINXOPTS: -W --jobs=auto
+          POLARS_VERSION: ${{ github.ref_name }}
         run: make html
 
       - name: Deploy Python docs for latest development version

--- a/py-polars/docs/source/_static/css/custom.css
+++ b/py-polars/docs/source/_static/css/custom.css
@@ -1,5 +1,5 @@
 /* To have blue background of width of the block (instead of width of content) */
-dl.class > dt:first-of-type {
+dl.class>dt:first-of-type {
     display: block !important;
 }
 
@@ -28,7 +28,7 @@ div.bd-sidebar-primary {
     background-image: linear-gradient(90deg, var(--pst-gradient-sidebar-left) 0%, var(--pst-gradient-sidebar-right) 100%);
 }
 
-footer.bd-footer{
+footer.bd-footer {
     background-color: var(--pst-color-on-background);
 }
 
@@ -39,6 +39,17 @@ footer.bd-footer{
 div.bd-sidebar-secondary {
     display: none;
 }
+
 label.sidebar-toggle.secondary-toggle {
     display: none !important;
+}
+
+/* Style all version dropdown links with `stable` in the version name */
+.version-switcher__container a[data-version-name*="stable"] {
+    background-color: green;
+}
+
+/* Style all version dropdown links with `dev` in the version name */
+.version-switcher__container a[data-version-name*="dev"] {
+    background-color: orange;
 }

--- a/py-polars/docs/source/_static/css/custom.css
+++ b/py-polars/docs/source/_static/css/custom.css
@@ -43,13 +43,3 @@ div.bd-sidebar-secondary {
 label.sidebar-toggle.secondary-toggle {
     display: none !important;
 }
-
-/* Style all version dropdown links with `stable` in the version name */
-.version-switcher__container a[data-version-name*="stable"] {
-    background-color: green;
-}
-
-/* Style all version dropdown links with `dev` in the version name */
-.version-switcher__container a[data-version-name*="dev"] {
-    background-color: orange;
-}

--- a/py-polars/docs/source/_static/version_switcher.json
+++ b/py-polars/docs/source/_static/version_switcher.json
@@ -1,0 +1,12 @@
+[
+    {
+        "name": "dev",
+        "version": "dev",
+        "url": "https://pola-rs.github.io/polars/py-polars/dev/reference/"
+    },
+    {
+        "name": "0.18 (stable)",
+        "version": "0.18",
+        "url": "https://pola-rs.github.io/polars/py-polars/html/reference/"
+    }
+]

--- a/py-polars/docs/source/_static/version_switcher.json
+++ b/py-polars/docs/source/_static/version_switcher.json
@@ -2,11 +2,11 @@
     {
         "name": "dev",
         "version": "dev",
-        "url": "https://pola-rs.github.io/polars/py-polars/dev/reference/"
+        "url": "https://pola-rs.github.io/polars/py-polars/dev/"
     },
     {
         "name": "0.18 (stable)",
         "version": "0.18",
-        "url": "https://pola-rs.github.io/polars/py-polars/html/reference/"
+        "url": "https://pola-rs.github.io/polars/py-polars/html/"
     }
 ]

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -93,6 +93,11 @@ static_assets_root = "https://raw.githubusercontent.com/pola-rs/polars-static/ma
 github_root = "https://github.com/pola-rs/polars"
 web_root = "https://pola-rs.github.io"
 
+# Specify version for version switcher dropdown menu
+switcher_version_env = os.environ.get("POLARS_VERSION", "main")
+version_match = re.fullmatch(r"py-(\d+\.\d+)\.\d+.*", switcher_version_env)
+switcher_version = version_match.group(1) if version_match is not None else "dev"
+
 html_theme_options = {
     "external_links": [
         {
@@ -124,8 +129,13 @@ html_theme_options = {
     "logo": {
         "image_light": f"{static_assets_root}/logos/polars-logo-dark-medium.png",
         "image_dark": f"{static_assets_root}/logos/polars-logo-dimmed-medium.png",
-        "link": f"{web_root}/polars/py-polars/html/reference/index.html",
     },
+    "switcher": {
+        "json_url": "https://pola-rs.github.io/polars/py-polars/dev/_static/version_switcher.json",
+        "version_match": switcher_version,
+    },
+    "navbar_end": ["version-switcher", "navbar-icon-links"],
+    "check_switcher": False,
 }
 
 # sphinx-favicon - Add support for custom favicons

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -131,7 +131,7 @@ html_theme_options = {
         "image_dark": f"{static_assets_root}/logos/polars-logo-dimmed-medium.png",
     },
     "switcher": {
-        "json_url": "https://pola-rs.github.io/polars/py-polars/dev/_static/version_switcher.json",
+        "json_url": f"{web_root}/polars/py-polars/dev/_static/version_switcher.json",
         "version_match": switcher_version,
     },
     "navbar_end": ["version-switcher", "navbar-icon-links"],


### PR DESCRIPTION
#### Changes
* Adds a version switcher dropdown menu in our Python API docs.

![image](https://github.com/pola-rs/polars/assets/3502351/97e6352c-12a7-4f1b-a273-1a88cfe1892e)
