### PR TITLE
docs: Update URLs for dev documentation

### DIFF
--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -48,7 +48,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html
-          target-folder: py-polars/dev
+          target-folder: docs/python/dev
           single-commit: true
 
       - name: Deploy Python docs for latest release version
@@ -56,6 +56,6 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html
-          # Keeping the html subfolder here for backwards compatibility
+          # Keeping this folder for backwards compatibility
           target-folder: py-polars/html
           single-commit: true

--- a/.github/workflows/docs-rust.yml
+++ b/.github/workflows/docs-rust.yml
@@ -46,7 +46,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: target/doc
-          clean-exclude: py-polars/**
+          target-folder: docs/rust/dev
           single-commit: true
 
       # Make sure documentation artifacts are not cached

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ For contributing to the user guide, please refer to the [contributing guide](htt
 
 ### API reference
 
-Polars has separate API references for [Rust](https://pola-rs.github.io/polars/polars/index.html), [Python](https://pola-rs.github.io/polars/py-polars/html/reference/index.html), and [Node.js](https://pola-rs.github.io/nodejs-polars/index.html).
+Polars has separate API references for [Rust](https://pola-rs.github.io/polars/polars/index.html) and [Python](https://pola-rs.github.io/polars/py-polars/html/reference/index.html).
 These are generated directly from the codebase, so in order to contribute, you will have to follow the steps outlined in [this section](#contributing-to-the-codebase) above.
 
 #### Rust

--- a/py-polars/docs/source/_static/version_switcher.json
+++ b/py-polars/docs/source/_static/version_switcher.json
@@ -2,11 +2,16 @@
     {
         "name": "dev",
         "version": "dev",
-        "url": "https://pola-rs.github.io/polars/py-polars/dev/"
+        "url": "https://pola-rs.github.io/polars/docs/python/dev/"
     },
     {
-        "name": "0.18 (stable)",
-        "version": "0.18",
+        "name": "0.19 (stable)",
+        "version": "0.19",
         "url": "https://pola-rs.github.io/polars/py-polars/html/"
+    },
+    {
+        "name": "0.18",
+        "version": "0.18",
+        "url": "https://pola-rs.github.io/polars/docs/python/0.18/"
     }
 ]

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -131,7 +131,7 @@ html_theme_options = {
         "image_dark": f"{static_assets_root}/logos/polars-logo-dimmed-medium.png",
     },
     "switcher": {
-        "json_url": f"{web_root}/polars/py-polars/dev/_static/version_switcher.json",
+        "json_url": f"{web_root}/polars/docs/python/dev/_static/version_switcher.json",
         "version_match": switcher_version,
     },
     "navbar_end": ["version-switcher", "navbar-icon-links"],


### PR DESCRIPTION
In preparation for [#6373](https://github.com/pola-rs/polars/issues/6373)

After merging this...
* Rust dev docs will be under: https://pola-rs.github.io/polars/docs/rust/dev
* Python dev docs will be under: https://pola-rs.github.io/polars/docs/python/dev

Stable Python docs will remain the same for now: https://pola-rs.github.io/polars/py-polars/html
Stable Rust docs remain at https://docs.rs/polars/latest/polars/