### PR TITLE
test(python): Skip failing test

### DIFF
--- a/py-polars/tests/unit/streaming/test_streaming_sort.py
+++ b/py-polars/tests/unit/streaming/test_streaming_sort.py
@@ -124,6 +124,10 @@ def test_out_of_core_sort_9503(monkeypatch: Any) -> None:
     }
 
 
+@pytest.mark.skip(
+    reason="This test is unreliable - it fails intermittently in our CI"
+    " with 'OSError: No such file or directory (os error 2)'."
+)
 @pytest.mark.write_disk()
 @pytest.mark.slow()
 def test_streaming_sort_multiple_columns(


### PR DESCRIPTION
I've seen this test fail multiple times in the same way. Example:
https://github.com/pola-rs/polars/actions/runs/5865815103/job/15903441979?pr=10495

Skipping it for now.