### PR TITLE
docs(python): Keep versioned docs

### DIFF
--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -51,7 +51,26 @@ jobs:
           target-folder: docs/python/dev
           single-commit: true
 
-      - name: Deploy Python docs for latest release version
+      - name: Parse the tag to find the major/minor version of Polars
+        id: version
+        if: ${{ github.ref_type == 'tag' }}
+        shell: bash
+        run: |
+          tag="${{ github.ref_name }}"
+          regex="py-([0-9]+\.[0-9]+)\.[0-9]+.*"
+          [[ $tag =~ $regex ]]
+          version=${BASH_REMATCH[1]}
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy Python docs for latest release version - versioned
+        if: ${{ github.ref_type == 'tag' }}
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: py-polars/docs/build/html
+          target-folder: docs/python/${{ steps.version.outputs.version }}
+          single-commit: true
+
+      - name: Deploy Python docs for latest release version - stable
         if: ${{ github.ref_type == 'tag' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -67,7 +67,7 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html
-          target-folder: docs/python/${{ steps.version.outputs.version }}
+          target-folder: docs/python/version/${{ steps.version.outputs.version }}
           single-commit: true
 
       - name: Deploy Python docs for latest release version - stable

--- a/py-polars/docs/source/_static/version_switcher.json
+++ b/py-polars/docs/source/_static/version_switcher.json
@@ -12,6 +12,6 @@
     {
         "name": "0.18",
         "version": "0.18",
-        "url": "https://pola-rs.github.io/polars/docs/python/0.18/"
+        "url": "https://pola-rs.github.io/polars/docs/python/version/0.18/"
     }
 ]

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -30,6 +30,7 @@ extensions = [
     # Sphinx extensions
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
+    "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
     "sphinx.ext.linkcode",
     "sphinx.ext.mathjax",


### PR DESCRIPTION
Closes [#6373](https://github.com/pola-rs/polars/issues/6373)

Very simple solution: on new tags, we build the docs like normal, but we also push it to `docs/python/version/VERSION`. That way, we'll keep the most recent docs for each version.