### PR TITLE
feat(rust, python): Add failed column to cast exception

### DIFF
--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -794,9 +794,9 @@ impl Series {
             let failures = self.filter_threaded(&failure_mask, false)?.unique()?;
             polars_bail!(
                 ComputeError:
-                "strict conversion from `{}` to `{}` failed for value(s) {}; \
+                "strict conversion from `{}` to `{}` failed for column: {}, value(s) {}; \
                 if you were trying to cast Utf8 to temporal dtypes, consider using `strptime`",
-                self.dtype(), dtype, failures.fmt_list(),
+                self.dtype(), dtype, s.name(), failures.fmt_list(),
 
             );
         } else {

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import re
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, Iterator, cast
 
@@ -534,6 +535,30 @@ def test_cast() -> None:
     # display failed values, GH#4706
     with pytest.raises(pl.ComputeError, match="foobar"):
         pl.Series(["1", "2", "3", "4", "foobar"]).cast(int)
+
+
+@pytest.mark.parametrize(
+    ("test_df", "type", "expected_message"),
+    [
+        pytest.param(
+            pl.DataFrame({"A": [1, 2, 3], "B": ["1", "2", "help"]}),
+            pl.UInt32,
+            re.escape(
+                (
+                    "strict conversion from `str` to `u32` failed for column: B, "
+                    'value(s) ["help"]; if you were trying to cast Utf8 to temporal '
+                    "dtypes, consider using `strptime`"
+                )
+            ),
+            id="Unsigned integer",
+        )
+    ],
+)
+def test_cast_exception(
+    test_df: pl.DataFrame, type: pl.DataType, expected_message: str
+) -> None:
+    with pytest.raises(pl.ComputeError, match=expected_message):
+        test_df.with_columns(pl.all().cast(type))
 
 
 def test_to_pandas() -> None:

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -544,11 +544,9 @@ def test_cast() -> None:
             pl.DataFrame({"A": [1, 2, 3], "B": ["1", "2", "help"]}),
             pl.UInt32,
             re.escape(
-                (
-                    "strict conversion from `str` to `u32` failed for column: B, "
-                    'value(s) ["help"]; if you were trying to cast Utf8 to temporal '
-                    "dtypes, consider using `strptime`"
-                )
+                "strict conversion from `str` to `u32` failed for column: B, "
+                'value(s) ["help"]; if you were trying to cast Utf8 to temporal '
+                "dtypes, consider using `strptime`"
             ),
             id="Unsigned integer",
         )

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import math
-import re
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, Iterator, cast
 
@@ -535,28 +534,6 @@ def test_cast() -> None:
     # display failed values, GH#4706
     with pytest.raises(pl.ComputeError, match="foobar"):
         pl.Series(["1", "2", "3", "4", "foobar"]).cast(int)
-
-
-@pytest.mark.parametrize(
-    ("test_df", "type", "expected_message"),
-    [
-        pytest.param(
-            pl.DataFrame({"A": [1, 2, 3], "B": ["1", "2", "help"]}),
-            pl.UInt32,
-            re.escape(
-                "strict conversion from `str` to `u32` failed for column: B, "
-                'value(s) ["help"]; if you were trying to cast Utf8 to temporal '
-                "dtypes, consider using `strptime`"
-            ),
-            id="Unsigned integer",
-        )
-    ],
-)
-def test_cast_exception(
-    test_df: pl.DataFrame, type: pl.DataType, expected_message: str
-) -> None:
-    with pytest.raises(pl.ComputeError, match=expected_message):
-        test_df.with_columns(pl.all().cast(type))
 
 
 def test_to_pandas() -> None:

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import re
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING
 
@@ -524,6 +525,28 @@ def test_skip_nulls_err() -> None:
         pl.ComputeError, match=r"The output type of 'apply' function cannot determined"
     ):
         df.with_columns(pl.col("foo").apply(lambda x: x, skip_nulls=True))
+
+
+@pytest.mark.parametrize(
+    ("test_df", "type", "expected_message"),
+    [
+        pytest.param(
+            pl.DataFrame({"A": [1, 2, 3], "B": ["1", "2", "help"]}),
+            pl.UInt32,
+            re.escape(
+                "strict conversion from `str` to `u32` failed for column: B, "
+                'value(s) ["help"]; if you were trying to cast Utf8 to temporal '
+                "dtypes, consider using `strptime`"
+            ),
+            id="Unsigned integer",
+        )
+    ],
+)
+def test_cast_err_column_value_highlighting(
+    test_df: pl.DataFrame, type: pl.DataType, expected_message: str
+) -> None:
+    with pytest.raises(pl.ComputeError, match=expected_message):
+        test_df.with_columns(pl.all().cast(type))
 
 
 def test_err_on_time_datetime_cast() -> None:


### PR DESCRIPTION
- Add the failed column name to cast exception message.
- Add unit test for cast exception.

```python
NUM_COLS = 10
NUM_ROWS = 1000

RAND_COL = np.random.randint(0, NUM_COLS)
RAND_ROW = np.random.randint(0, NUM_ROWS)

DATA = np.random.randint(0, 100, size=(NUM_ROWS, NUM_COLS))
DATA[RAND_ROW, RAND_COL] = -1

pl.DataFrame(DATA).with_columns(
    pl.all().cast(pl.UInt32),
)
```
Now outputs:
```
exceptions.ComputeError: strict conversion from `i64` to `u32` failed for column: column_8, value(s) [-1]; if you were trying to cast Utf8 to temporal dtypes, consider using `strptime`
```

Closes #10480