### PR TITLE
feat(python)!: ensure consistent return types from `item`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1756,7 +1756,6 @@ class DataFrame:
         self,
         row: int | None = None,
         column: int | str | None = None,
-        lists_as_series: bool = True,
     ) -> Any:
         """
         Return the element at the given row/column, or the dataframe as a scalar.
@@ -1772,8 +1771,6 @@ class DataFrame:
             Optional row index.
         column
             Optional column index or name.
-        lists_as_series
-            When retrieving nested List items, return them as Series.
 
         Examples
         --------
@@ -1796,7 +1793,7 @@ class DataFrame:
                     f"Can only call '.item()' if the dataframe is of shape (1,1), or if "
                     f"explicit row/col values are provided; frame has shape {self.shape}"
                 )
-            return self._df.select_at_idx(0).get_idx(0, lists_as_series)
+            return self._df.select_at_idx(0).get_idx(0, False)
 
         elif row is None or column is None:
             raise ValueError("cannot call `.item()` with only one of `row` or `column`")
@@ -1808,7 +1805,7 @@ class DataFrame:
         )
         if s is None:
             raise ValueError(f"column index {column!r} is out of bounds")
-        return s.get_idx(row, lists_as_series)
+        return s.get_idx(row, False)
 
     def to_arrow(self) -> pa.Table:
         """

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1752,9 +1752,14 @@ class DataFrame:
             ).render()
         )
 
-    def item(self, row: int | None = None, column: int | str | None = None) -> Any:
+    def item(
+        self,
+        row: int | None = None,
+        column: int | str | None = None,
+        lists_as_series: bool = True,
+    ) -> Any:
         """
-        Return the dataframe as a scalar, or return the element at the given row/column.
+        Return the element at the given row/column, or the dataframe as a scalar.
 
         Notes
         -----
@@ -1767,6 +1772,8 @@ class DataFrame:
             Optional row index.
         column
             Optional column index or name.
+        lists_as_series
+            When retrieving nested List items, return them as Series.
 
         Examples
         --------
@@ -1789,7 +1796,7 @@ class DataFrame:
                     f"Can only call '.item()' if the dataframe is of shape (1,1), or if "
                     f"explicit row/col values are provided; frame has shape {self.shape}"
                 )
-            return self._df.select_at_idx(0).get_idx(0)
+            return self._df.select_at_idx(0).get_idx(0, lists_as_series)
 
         elif row is None or column is None:
             raise ValueError("cannot call `.item()` with only one of `row` or `column`")
@@ -1801,7 +1808,7 @@ class DataFrame:
         )
         if s is None:
             raise ValueError(f"column index {column!r} is out of bounds")
-        return s.get_idx(row)
+        return s.get_idx(row, lists_as_series)
 
     def to_arrow(self) -> pa.Table:
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -890,7 +890,7 @@ class Series:
             #  make this path a lot slower (~10x) than it needs to be.
             get_idx = self._s.get_idx
             for idx in range(0, self.len()):
-                yield get_idx(idx)
+                yield get_idx(idx, True)
         else:
             buffer_size = 25_000
             for offset in range(0, self.len(), buffer_size):
@@ -976,7 +976,7 @@ class Series:
         elif isinstance(item, int):
             if item < 0:
                 item = self.len() + item
-            return self._s.get_idx(item)
+            return self._s.get_idx(item, True)
 
         # Slice.
         elif isinstance(item, slice):

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -154,9 +154,9 @@ impl PySeries {
         }
     }
 
-    fn get_idx(&self, py: Python, idx: usize) -> PyResult<PyObject> {
+    fn get_idx(&self, py: Python, idx: usize, wrap_lists: bool) -> PyResult<PyObject> {
         let av = self.series.get(idx).map_err(PyPolarsErr::from)?;
-        if let AnyValue::List(s) = av {
+        if let (true, AnyValue::List(s)) = (wrap_lists, av) {
             let pyseries = PySeries::new(s);
             let out = POLARS
                 .getattr(py, "wrap_s")

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3272,6 +3272,16 @@ def test_item() -> None:
     with pytest.raises(ValueError, match="column index 10 is out of bounds"):
         df.item(0, 10)
 
+    # nested lists/series
+    df = pl.DataFrame(
+        {
+            "a": ["1", "2", "3"],
+            "b": [["a", "b"], ["c", "d"], ["e", "f"]],
+        }
+    )
+    assert_series_equal(df.item(1, "b"), pl.Series(["c", "d"]))
+    assert df.item(1, "b", lists_as_series=False), ["c", "d"]
+
 
 @pytest.mark.parametrize(
     ("subset", "keep", "expected_mask"),

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3272,15 +3272,23 @@ def test_item() -> None:
     with pytest.raises(ValueError, match="column index 10 is out of bounds"):
         df.item(0, 10)
 
-    # nested lists/series
+    # retrieving nested dtypes
     df = pl.DataFrame(
         {
-            "a": ["1", "2", "3"],
+            "a": [[123, 456], [789, 101], [112, 131]],
             "b": [["a", "b"], ["c", "d"], ["e", "f"]],
-        }
+            "c": [{"x": 444}, {"x": 555}, {"x": 666}],
+        },
+        schema_overrides={"a": pl.Array(2, pl.Int32)},
     )
-    assert_series_equal(df.item(1, "b"), pl.Series(["c", "d"]))
-    assert df.item(1, "b", lists_as_series=False), ["c", "d"]
+    assert df.schema == {
+        "a": pl.Array(2, pl.Int32),
+        "b": pl.List(pl.Utf8),
+        "c": pl.Struct([pl.Field("x", pl.Int64)]),
+    }
+    assert df.item(0, "a") == [123, 456]
+    assert df.item(1, "b") == ["c", "d"]
+    assert df.item(2, "c") == {"x": 666}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Ensures that we return consistent types from `item`, taking the fast-path by default.

* All dtypes (scalars, array, struct etc) _except_ `List` return python-native values from `item()` - now `List` does too (instead of being the only one that returns a Series).
* This update provides a **~50%** speedup over having to make a subsequent `to_list()` call after the initial call to `item()` (as is currently necessary).

## Example
```python
import polars as pl

df = pl.DataFrame({
    "a": ["1", "2", "3"],
    "b": [["a", "b"], ["c", "d"], ["e", "f"]],
})
# shape: (3, 2)
# ┌─────┬────────────┐
# │ a   ┆ b          │
# │ --- ┆ ---        │
# │ str ┆ list[str]  │
# ╞═════╪════════════╡
# │ 1   ┆ ["a", "b"] │
# │ 2   ┆ ["c", "d"] │
# │ 3   ┆ ["e", "f"] │
# └─────┴────────────┘
```
Current behaviour:
```python
df.item(1, "b")
# shape: (2,)
# Series: '' [str]
# [
#   "c"
#   "d"
# ]
```
Updated behaviour (breaking):
```python
df.item(1, "b")
# ['c', 'd']
```

## Timings
Previously, to get python-native values back:
```python
%timeit  df.item(1, "b").to_list()
# 745 ns ± 2.69 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

%timeit  df.item(1, "b")
# 478 ns ± 2.35 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```