### PR TITLE
chore(python): Disable SIM108 lint

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -139,6 +139,7 @@ ignore = [
   "PT011", # pytest.raises({exception}) is too broad, set the match parameter or use a more specific exception
   # flake8-simplify
   "SIM102", # Use a single `if` statement instead of nested `if` statements
+  "SIM108", # Use ternary operator
   # ruff
   "RUF005", # unpack-instead-of-concatenating-to-collection-literal
   # pycodestyle


### PR DESCRIPTION
This lint often makes things less readable.

https://beta.ruff.rs/docs/rules/if-else-block-instead-of-if-exp/