### PR TITLE
feat!: Consistent return type for `date_range`/`time_range`

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -803,7 +803,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
                 time_zone,
             } => {
                 map_as_slice!(
-                    temporal::temporal_range_dispatch,
+                    temporal::temporal_ranges_dispatch,
                     "date_range",
                     every,
                     closed,
@@ -823,7 +823,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             },
             TimeRanges { every, closed } => {
                 map_as_slice!(
-                    temporal::temporal_range_dispatch,
+                    temporal::temporal_ranges_dispatch,
                     "time_range",
                     every,
                     closed,

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -68,9 +68,8 @@ impl FunctionExpr {
                         time_zone,
                     } => {
                         // output dtype may change based on `every`, `time_unit`, and `time_zone`
-                        let inner_dtype =
-                            mapper.map_to_date_range_dtype(every, time_unit, time_zone)?;
-                        return Ok(Field::new("date", DataType::List(Box::new(inner_dtype))));
+                        let dtype = mapper.map_to_date_range_dtype(every, time_unit, time_zone)?;
+                        return Ok(Field::new("date", dtype));
                     },
                     DateRanges {
                         every,
@@ -88,7 +87,7 @@ impl FunctionExpr {
                     },
 
                     TimeRange { .. } => {
-                        return Ok(Field::new("time", DataType::List(Box::new(DataType::Time))));
+                        return Ok(Field::new("time", DataType::Time));
                     },
                     TimeRanges { .. } => {
                         return Ok(Field::new(

--- a/py-polars/polars/functions/range.py
+++ b/py-polars/polars/functions/range.py
@@ -555,14 +555,7 @@ def date_range(
         result = result.alias(name)
 
     if eager:
-        s = F.select(result).to_series()
-        if s.len() == 1:
-            s = s.explode().set_sorted()
-        else:
-            _warn_for_deprecation_date_range()
-        return s
-
-    _warn_for_deprecation_date_range()
+        return F.select(result).to_series()
 
     return result
 
@@ -820,14 +813,7 @@ def time_range(
         result = result.alias(name)
 
     if eager:
-        s = F.select(result).to_series()
-        if s.len() == 1:
-            s = s.explode().set_sorted()
-        else:
-            _warn_for_deprecation_time_range()
-        return s
-
-    _warn_for_deprecation_time_range()
+        return F.select(result).to_series()
 
     return result
 
@@ -955,21 +941,3 @@ def _parse_interval_argument(interval: str | timedelta) -> str:
     if " " in interval:
         interval = interval.replace(" ", "")
     return interval.lower()
-
-
-def _warn_for_deprecation_date_range() -> None:
-    issue_deprecation_warning(
-        "behavior of `date_range` will change in a future version."
-        " The result will be a single range of type Date or Datetime instead of List."
-        " Use the new `date_ranges` function to retain the old functionality and silence this warning.",
-        version="0.18.9",
-    )
-
-
-def _warn_for_deprecation_time_range() -> None:
-    issue_deprecation_warning(
-        "behavior of `time_range` will change in a future version."
-        " The result will be a single range of type Time instead of List."
-        " Use the new `date_ranges` function to retain the old functionality and silence this warning.",
-        version="0.18.9",
-    )

--- a/py-polars/tests/unit/functions/test_range.py
+++ b/py-polars/tests/unit/functions/test_range.py
@@ -547,10 +547,9 @@ def test_date_range_name() -> None:
     result_eager = pl.date_range(date(2020, 1, 1), date(2020, 1, 3), eager=True)
     assert result_eager.name == expected_name
 
-    with pytest.deprecated_call():
-        result_lazy = pl.select(
-            pl.date_range(date(2020, 1, 1), date(2020, 1, 3), eager=False)
-        ).to_series()
+    result_lazy = pl.select(
+        pl.date_range(date(2020, 1, 1), date(2020, 1, 3), eager=False)
+    ).to_series()
     assert result_lazy.name == expected_name
 
 
@@ -580,34 +579,28 @@ def test_date_range_eager_explode() -> None:
     assert_series_equal(result, expected)
 
 
-def test_date_range_deprecated_eager() -> None:
+def test_date_range_only_first_entry_used() -> None:
     start = pl.Series([date(2022, 1, 1), date(2022, 1, 2)])
     end = pl.Series([date(2022, 1, 4), date(2022, 1, 3)])
 
-    with pytest.deprecated_call():
-        result = pl.date_range(start, end, eager=True)
+    result = pl.date_range(start, end, eager=True)
 
     expected = pl.Series(
-        "date",
-        [
-            [date(2022, 1, 1), date(2022, 1, 2), date(2022, 1, 3), date(2022, 1, 4)],
-            [date(2022, 1, 2), date(2022, 1, 3)],
-        ],
+        "date", [date(2022, 1, 1), date(2022, 1, 2), date(2022, 1, 3), date(2022, 1, 4)]
     )
     assert_series_equal(result, expected)
 
 
 def test_time_range_lit_lazy() -> None:
-    with pytest.deprecated_call():
-        tm = pl.select(
-            pl.time_range(
-                start=time(1, 2, 3),
-                end=time(23, 59, 59),
-                interval="5h45m10s333ms",
-                closed="right",
-            ).alias("tm")
-        )
-    tm = tm.select(pl.col("tm").explode())
+    tm = pl.select(
+        pl.time_range(
+            start=time(1, 2, 3),
+            end=time(23, 59, 59),
+            interval="5h45m10s333ms",
+            closed="right",
+        ).alias("tm")
+    )
+
     assert tm["tm"].to_list() == [
         time(6, 47, 13, 333000),
         time(12, 32, 23, 666000),
@@ -615,9 +608,7 @@ def test_time_range_lit_lazy() -> None:
     ]
 
     # validate unset start/end
-    with pytest.deprecated_call():
-        tm = pl.select(pl.time_range(interval="5h45m10s333ms").alias("tm"))
-    tm = tm.select(pl.col("tm").explode())
+    tm = pl.select(pl.time_range(interval="5h45m10s333ms").alias("tm"))
     assert tm["tm"].to_list() == [
         time(0, 0),
         time(5, 45, 10, 333000),
@@ -626,13 +617,11 @@ def test_time_range_lit_lazy() -> None:
         time(23, 0, 41, 332000),
     ]
 
-    with pytest.deprecated_call():
-        tm = pl.select(
-            pl.time_range(
-                start=pl.lit(time(23, 59, 59, 999980)), interval="10000ns"
-            ).alias("tm")
+    tm = pl.select(
+        pl.time_range(start=pl.lit(time(23, 59, 59, 999980)), interval="10000ns").alias(
+            "tm"
         )
-    tm = tm.select(pl.col("tm").explode())
+    )
     assert tm["tm"].to_list() == [
         time(23, 59, 59, 999980),
         time(23, 59, 59, 999990),
@@ -720,10 +709,7 @@ def test_time_range_name() -> None:
     result_eager = pl.time_range(time(10), time(12), eager=True)
     assert result_eager.name == expected_name
 
-    with pytest.deprecated_call():
-        result_lazy = pl.select(
-            pl.time_range(time(10), time(12), eager=False)
-        ).to_series()
+    result_lazy = pl.select(pl.time_range(time(10), time(12), eager=False)).to_series()
     assert result_lazy.name == expected_name
 
 
@@ -774,7 +760,7 @@ def test_deprecated_name_arg() -> None:
         ("ns", "ns", "ns"),
     ],
 )
-def test_date_range_schema(
+def test_date_ranges_schema(
     values_time_zone: str | None,
     input_time_zone: str | None,
     output_time_zone: str | None,
@@ -1053,18 +1039,11 @@ def test_time_range_eager_explode() -> None:
     assert_series_equal(result, expected)
 
 
-def test_time_range_deprecated_eager() -> None:
+def test_time_range_only_first_entry_used() -> None:
     start = pl.Series([time(9, 0), time(10, 0)])
     end = pl.Series([time(12, 0), time(11, 0)])
 
-    with pytest.deprecated_call():
-        result = pl.time_range(start, end, eager=True)
+    result = pl.time_range(start, end, eager=True)
 
-    expected = pl.Series(
-        "time",
-        [
-            [time(9, 0), time(10, 0), time(11, 0), time(12, 0)],
-            [time(10, 0), time(11, 0)],
-        ],
-    )
+    expected = pl.Series("time", [time(9, 0), time(10, 0), time(11, 0), time(12, 0)])
     assert_series_equal(result, expected)


### PR DESCRIPTION
Closes [#9019](https://github.com/pola-rs/polars/issues/9019)

#### Changes
* Remove deprecated behavior in `date_range` and `time_range` 