### PR TITLE
feat(python)!: allow `from_arrow` to take a generator of RecordBatches, change error type to `TypeError`

### DIFF
--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -286,10 +286,10 @@ def test_from_arrow(monkeypatch: Any) -> None:
     assert df1.schema == {"x": pl.Utf8, "y": pl.Int32}
     assert df2.schema == {"x": pl.Utf8, "y": pl.Int32}
 
-    with pytest.raises(ValueError, match="got 'str'"):
+    with pytest.raises(TypeError, match="Cannot convert str"):
         pl.from_arrow(data="xyz")
 
-    with pytest.raises(ValueError, match="got generator of 'int'"):
+    with pytest.raises(TypeError, match="Cannot convert int"):
         pl.from_arrow(data=(x for x in (1, 2, 3)))
 
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -238,7 +238,7 @@ def test_from_arrow(monkeypatch: Any) -> None:
             Decimal("2.0"),
         ),
     ]
-    for arrow_data in (tbl, record_batches):
+    for arrow_data in (tbl, record_batches, (rb for rb in record_batches)):
         df = cast(pl.DataFrame, pl.from_arrow(arrow_data))
         assert df.schema == expected_schema
         assert df.rows() == expected_data
@@ -285,6 +285,12 @@ def test_from_arrow(monkeypatch: Any) -> None:
     assert df0.schema == {"id": pl.Utf8, "points": pl.Int64}
     assert df1.schema == {"x": pl.Utf8, "y": pl.Int32}
     assert df2.schema == {"x": pl.Utf8, "y": pl.Int32}
+
+    with pytest.raises(ValueError, match="got 'str'"):
+        pl.from_arrow(data="xyz")
+
+    with pytest.raises(ValueError, match="got generator of 'int'"):
+        pl.from_arrow(data=(x for x in (1, 2, 3)))
 
 
 def test_from_dict_with_column_order() -> None:

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -459,8 +459,8 @@ def test_from_arrow() -> None:
     assert df.shape == (3, 2)
     assert df.rows() == [(1, 4), (2, 5), (3, 6)]  # type: ignore[union-attr]
 
-    # if not a PyArrow type, raise a ValueError
-    with pytest.raises(ValueError):
+    # if not a PyArrow type, raise a TypeError
+    with pytest.raises(TypeError):
         _ = pl.from_arrow([1, 2])
 
     df = pl.from_arrow(


### PR DESCRIPTION
Slightly extends `pl.from_arrow` constructor to allow a generator of `RecordBatch` as input (which the underlying `pa.Table.from_batches` method accepts). 

---

As well as being convenient, _might_ offer some modest memory advantages if receiving multiple batches (started looking into allowing `read_database` to take connection objects, and snowflake has a [fetch_arrow_batches](https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-api#fetch_arrow_batches) method, for example) vs requiring up-front single-batch materialisation. Need to check the pyarrow source to see how it's handled there to confirm that though.