### PR TITLE
fix(rust,python): sanitize column naming in boolean ops

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -125,7 +125,8 @@ impl OptimizationRule for SimplifyBooleanRule {
                 AExpr::Literal(LiteralValue::Boolean(true))
             ) =>
             {
-                Some(expr_arena.get(*right).clone())
+                // We alias because of the left-hand naming rule.
+                Some(AExpr::Alias(*right, "literal".into()))
             },
             // x AND true => x
             AExpr::BinaryExpr {
@@ -186,7 +187,9 @@ impl OptimizationRule for SimplifyBooleanRule {
                 AExpr::Literal(LiteralValue::Boolean(false))
             ) =>
             {
-                Some(expr_arena.get(*right).clone())
+                let names = aexpr_to_leaf_names(*left, expr_arena);
+                let name = names.get(0).map(Arc::clone).unwrap_or_else(|| "".into());
+                Some(AExpr::Alias(*right, name))
             },
             // x or false => x
             AExpr::BinaryExpr {

--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -148,13 +148,11 @@ impl OptimizationRule for SimplifyBooleanRule {
                 left,
                 op: Operator::And,
                 right,
-            } if matches!(
-                expr_arena.get(*left),
-                AExpr::Literal(_)
-            ) && matches!(
-                expr_arena.get(*right),
-                AExpr::Literal(LiteralValue::Boolean(false))
-            ) =>
+            } if matches!(expr_arena.get(*left), AExpr::Literal(_))
+                && matches!(
+                    expr_arena.get(*right),
+                    AExpr::Literal(LiteralValue::Boolean(false))
+                ) =>
             {
                 Some(AExpr::Literal(LiteralValue::Boolean(false)))
             },
@@ -165,14 +163,11 @@ impl OptimizationRule for SimplifyBooleanRule {
             AExpr::BinaryExpr {
                 left,
                 op: Operator::And,
-                right
+                right,
             } if matches!(
                 expr_arena.get(*left),
                 AExpr::Literal(LiteralValue::Boolean(false))
-            ) && matches!(
-                expr_arena.get(*right),
-                AExpr::Literal(_)
-            ) =>
+            ) && matches!(expr_arena.get(*right), AExpr::Literal(_)) =>
             {
                 Some(AExpr::Literal(LiteralValue::Boolean(false)))
             },
@@ -187,9 +182,8 @@ impl OptimizationRule for SimplifyBooleanRule {
                 AExpr::Literal(LiteralValue::Boolean(false))
             ) =>
             {
-                let names = aexpr_to_leaf_names(*left, expr_arena);
-                let name = names.get(0).map(Arc::clone).unwrap_or_else(|| "".into());
-                Some(AExpr::Alias(*right, name))
+                // We alias because of the left-hand naming rule.
+                Some(AExpr::Alias(*right, "literal".into()))
             },
             // x or false => x
             AExpr::BinaryExpr {
@@ -212,13 +206,11 @@ impl OptimizationRule for SimplifyBooleanRule {
                 left,
                 op: Operator::Or,
                 right,
-            } if matches!(
-                expr_arena.get(*left),
-                AExpr::Literal(_)
-            ) && matches!(
-                expr_arena.get(*right),
-                AExpr::Literal(LiteralValue::Boolean(true))
-            ) =>
+            } if matches!(expr_arena.get(*left), AExpr::Literal(_))
+                && matches!(
+                    expr_arena.get(*right),
+                    AExpr::Literal(LiteralValue::Boolean(true))
+                ) =>
             {
                 Some(AExpr::Literal(LiteralValue::Boolean(true)))
             },
@@ -233,10 +225,7 @@ impl OptimizationRule for SimplifyBooleanRule {
             } if matches!(
                 expr_arena.get(*left),
                 AExpr::Literal(LiteralValue::Boolean(true))
-            ) && matches!(
-                expr_arena.get(*right),
-                AExpr::Literal(_)
-            ) =>
+            ) && matches!(expr_arena.get(*right), AExpr::Literal(_)) =>
             {
                 Some(AExpr::Literal(LiteralValue::Boolean(true)))
             },

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -149,7 +149,7 @@ class Expr:
     def __radd__(self, other: Any) -> Self:
         return self._from_pyexpr(self._to_pyexpr(other) + self._pyexpr)
 
-    def __and__(self, other: Expr | int) -> Self:
+    def __and__(self, other: Expr | int | bool) -> Self:
         return self._from_pyexpr(self._pyexpr._and(self._to_pyexpr(other)))
 
     def __rand__(self, other: Any) -> Self:
@@ -197,7 +197,7 @@ class Expr:
     def __neg__(self) -> Expr:
         return F.lit(0) - self
 
-    def __or__(self, other: Expr | int) -> Self:
+    def __or__(self, other: Expr | int | bool) -> Self:
         return self._from_pyexpr(self._pyexpr._or(self._to_pyexpr(other)))
 
     def __ror__(self, other: Any) -> Self:
@@ -224,10 +224,10 @@ class Expr:
     def __rtruediv__(self, other: Any) -> Self:
         return self._from_pyexpr(self._to_pyexpr(other) / self._pyexpr)
 
-    def __xor__(self, other: Expr) -> Self:
+    def __xor__(self, other: Expr | int | bool) -> Self:
         return self._from_pyexpr(self._pyexpr._xor(self._to_pyexpr(other)))
 
-    def __rxor__(self, other: Expr) -> Self:
+    def __rxor__(self, other: Any) -> Self:
         return self._from_pyexpr(self._to_pyexpr(other)._xor(self._pyexpr))
 
     # state

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -153,7 +153,7 @@ class Expr:
         return self._from_pyexpr(self._pyexpr._and(self._to_pyexpr(other)))
 
     def __rand__(self, other: Any) -> Self:
-        return self._from_pyexpr(self._pyexpr._and(self._to_pyexpr(other)))
+        return self._from_pyexpr(self._to_pyexpr(other)._and(self._pyexpr))
 
     def __eq__(self, other: Any) -> Self:  # type: ignore[override]
         return self._from_pyexpr(self._pyexpr.eq(self._to_expr(other)._pyexpr))
@@ -228,7 +228,7 @@ class Expr:
         return self._from_pyexpr(self._pyexpr._xor(self._to_pyexpr(other)))
 
     def __rxor__(self, other: Expr) -> Self:
-        return self._from_pyexpr(self._pyexpr._xor(self._to_pyexpr(other)))
+        return self._from_pyexpr(self._to_pyexpr(other)._xor(self._pyexpr))
 
     # state
     def __getstate__(self) -> Any:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -455,8 +455,10 @@ class Series:
             other = Series([other])
         return self._from_pyseries(self._s.bitand(other._s))
 
-    def __rand__(self, other: Series) -> Series:
-        return self.__and__(other)
+    def __rand__(self, other: Series) -> Self:
+        if not isinstance(other, Series):
+            other = Series([other])
+        return other & self
 
     def __or__(self, other: Series) -> Self:
         if not isinstance(other, Series):
@@ -464,7 +466,9 @@ class Series:
         return self._from_pyseries(self._s.bitor(other._s))
 
     def __ror__(self, other: Series) -> Self:
-        return self.__or__(other)
+        if not isinstance(other, Series):
+            other = Series([other])
+        return other | self
 
     def __xor__(self, other: Series) -> Self:
         if not isinstance(other, Series):
@@ -472,7 +476,9 @@ class Series:
         return self._from_pyseries(self._s.bitxor(other._s))
 
     def __rxor__(self, other: Series) -> Series:
-        return self.__xor__(other)
+        if not isinstance(other, Series):
+            other = Series([other])
+        return other ^ self
 
     def _comp(self, other: Any, op: ComparisonOperator) -> Self:
         # special edge-case; boolean broadcast series (eq/neq) is its own result

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -455,7 +455,7 @@ class Series:
             other = Series([other])
         return self._from_pyseries(self._s.bitand(other._s))
 
-    def __rand__(self, other: Series) -> Self:
+    def __rand__(self, other: Series) -> Series:
         if not isinstance(other, Series):
             other = Series([other])
         return other & self
@@ -465,7 +465,7 @@ class Series:
             other = Series([other])
         return self._from_pyseries(self._s.bitor(other._s))
 
-    def __ror__(self, other: Series) -> Self:
+    def __ror__(self, other: Series) -> Series:
         if not isinstance(other, Series):
             other = Series([other])
         return other | self

--- a/py-polars/tests/unit/datatypes/test_bool.py
+++ b/py-polars/tests/unit/datatypes/test_bool.py
@@ -46,10 +46,10 @@ def test_bool_opts() -> None:
     assert df.select(pl.col('x') & False).to_dict(as_series=False) == {'x': [False, False]}
     assert df.select(pl.col('x') | True).to_dict(as_series=False) == {'x': [True, True]}
     assert df.select(pl.col('x') | False).to_dict(as_series=False) == {'x': [False, True]}
-    assert df.select(True  & pl.col('x')).to_dict(as_series=False) == {'x': [False, True]}
-    assert df.select(False & pl.col('x')).to_dict(as_series=False) == {'x': [False, False]}
-    assert df.select(True  | pl.col('x')).to_dict(as_series=False) == {'x': [True, True]}
-    assert df.select(False | pl.col('x')).to_dict(as_series=False) == {'x': [False, True]}
+    assert df.select(True  & pl.col('x')).to_dict(as_series=False) == {'literal': [False, True]}
+    assert df.select(False & pl.col('x')).to_dict(as_series=False) == {'literal': [False, False]}
+    assert df.select(True  | pl.col('x')).to_dict(as_series=False) == {'literal': [True, True]}
+    assert df.select(False | pl.col('x')).to_dict(as_series=False) == {'literal': [False, True]}
 
 def test_all_empty() -> None:
     s = pl.Series([], dtype=pl.Boolean)

--- a/py-polars/tests/unit/datatypes/test_bool.py
+++ b/py-polars/tests/unit/datatypes/test_bool.py
@@ -39,7 +39,17 @@ def test_bool_min_max() -> None:
     assert pl.Series([False, True]).max()
     assert pl.Series([True, True]).max()
     assert not pl.Series([False, False]).max()
-
+    
+def test_bool_opts() -> None:
+    df = pl.DataFrame({'x': [False, True]})
+    assert df.select(pl.col('x') & True).to_dict(as_series=False) == {'x': [False, True]}
+    assert df.select(pl.col('x') & False).to_dict(as_series=False) == {'x': [False, False]}
+    assert df.select(pl.col('x') | True).to_dict(as_series=False) == {'x': [True, True]}
+    assert df.select(pl.col('x') | False).to_dict(as_series=False) == {'x': [False, True]}
+    assert df.select(True  & pl.col('x')).to_dict(as_series=False) == {'x': [False, True]}
+    assert df.select(False & pl.col('x')).to_dict(as_series=False) == {'x': [False, False]}
+    assert df.select(True  | pl.col('x')).to_dict(as_series=False) == {'x': [True, True]}
+    assert df.select(False | pl.col('x')).to_dict(as_series=False) == {'x': [False, True]}
 
 def test_all_empty() -> None:
     s = pl.Series([], dtype=pl.Boolean)

--- a/py-polars/tests/unit/datatypes/test_bool.py
+++ b/py-polars/tests/unit/datatypes/test_bool.py
@@ -40,16 +40,20 @@ def test_bool_min_max() -> None:
     assert pl.Series([True, True]).max()
     assert not pl.Series([False, False]).max()
     
-def test_bool_opts() -> None:
+def test_bool_lits() -> None:
     df = pl.DataFrame({'x': [False, True]})
-    assert df.select(pl.col('x') & True).to_dict(as_series=False) == {'x': [False, True]}
     assert df.select(pl.col('x') & False).to_dict(as_series=False) == {'x': [False, False]}
-    assert df.select(pl.col('x') | True).to_dict(as_series=False) == {'x': [True, True]}
+    assert df.select(pl.col('x') & True).to_dict(as_series=False) == {'x': [False, True]}
     assert df.select(pl.col('x') | False).to_dict(as_series=False) == {'x': [False, True]}
-    assert df.select(True  & pl.col('x')).to_dict(as_series=False) == {'literal': [False, True]}
+    assert df.select(pl.col('x') | True).to_dict(as_series=False) == {'x': [True, True]}
+    assert df.select(pl.col('x') ^ False).to_dict(as_series=False) == {'x': [False, True]}
+    assert df.select(pl.col('x') ^ True).to_dict(as_series=False) == {'x': [True, False]}
     assert df.select(False & pl.col('x')).to_dict(as_series=False) == {'literal': [False, False]}
-    assert df.select(True  | pl.col('x')).to_dict(as_series=False) == {'literal': [True, True]}
+    assert df.select(True  & pl.col('x')).to_dict(as_series=False) == {'literal': [False, True]}
     assert df.select(False | pl.col('x')).to_dict(as_series=False) == {'literal': [False, True]}
+    assert df.select(True  | pl.col('x')).to_dict(as_series=False) == {'literal': [True, True]}
+    assert df.select(False ^ pl.col('x')).to_dict(as_series=False) == {'literal': [False, True]}
+    assert df.select(True  ^ pl.col('x')).to_dict(as_series=False) == {'literal': [True, False]}
 
 def test_all_empty() -> None:
     s = pl.Series([], dtype=pl.Boolean)

--- a/py-polars/tests/unit/datatypes/test_bool.py
+++ b/py-polars/tests/unit/datatypes/test_bool.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 
@@ -39,21 +41,27 @@ def test_bool_min_max() -> None:
     assert pl.Series([False, True]).max()
     assert pl.Series([True, True]).max()
     assert not pl.Series([False, False]).max()
-    
-def test_bool_lits() -> None:
-    df = pl.DataFrame({'x': [False, True]})
-    assert df.select(pl.col('x') & False).to_dict(as_series=False) == {'x': [False, False]}
-    assert df.select(pl.col('x') & True).to_dict(as_series=False) == {'x': [False, True]}
-    assert df.select(pl.col('x') | False).to_dict(as_series=False) == {'x': [False, True]}
-    assert df.select(pl.col('x') | True).to_dict(as_series=False) == {'x': [True, True]}
-    assert df.select(pl.col('x') ^ False).to_dict(as_series=False) == {'x': [False, True]}
-    assert df.select(pl.col('x') ^ True).to_dict(as_series=False) == {'x': [True, False]}
-    assert df.select(False & pl.col('x')).to_dict(as_series=False) == {'literal': [False, False]}
-    assert df.select(True  & pl.col('x')).to_dict(as_series=False) == {'literal': [False, True]}
-    assert df.select(False | pl.col('x')).to_dict(as_series=False) == {'literal': [False, True]}
-    assert df.select(True  | pl.col('x')).to_dict(as_series=False) == {'literal': [True, True]}
-    assert df.select(False ^ pl.col('x')).to_dict(as_series=False) == {'literal': [False, True]}
-    assert df.select(True  ^ pl.col('x')).to_dict(as_series=False) == {'literal': [True, False]}
+
+
+def test_bool_literal_expressions() -> None:
+    df = pl.DataFrame({"x": [False, True]})
+
+    def val(expr: pl.Expr) -> dict[str, list[bool]]:
+        return df.select(expr).to_dict(as_series=False)
+
+    assert val(pl.col("x") & False) == {"x": [False, False]}
+    assert val(pl.col("x") & True) == {"x": [False, True]}
+    assert val(pl.col("x") | False) == {"x": [False, True]}
+    assert val(pl.col("x") | True) == {"x": [True, True]}
+    assert val(pl.col("x") ^ False) == {"x": [False, True]}
+    assert val(pl.col("x") ^ True) == {"x": [True, False]}
+    assert val(False & pl.col("x")) == {"literal": [False, False]}
+    assert val(True & pl.col("x")) == {"literal": [False, True]}
+    assert val(False | pl.col("x")) == {"literal": [False, True]}
+    assert val(True | pl.col("x")) == {"literal": [True, True]}
+    assert val(False ^ pl.col("x")) == {"literal": [False, True]}
+    assert val(True ^ pl.col("x")) == {"literal": [True, False]}
+
 
 def test_all_empty() -> None:
     s = pl.Series([], dtype=pl.Boolean)


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/10370 and https://github.com/pola-rs/polars/issues/10530.