### PR TITLE
fix(rust): fix build for wasm

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -114,3 +114,28 @@ jobs:
 
       - name: Run cargo hack
         run: cargo hack check -p polars --each-feature --no-dev-deps
+
+  check-wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Rust
+        run: |
+          rustup target add wasm32-unknown-unknown
+          rustup show
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref_name == 'main' }}
+
+      - name: Install cargo hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      - name: Check wasm
+        working-directory: crates
+        run: make check-wasm
+

--- a/crates/Makefile
+++ b/crates/Makefile
@@ -110,3 +110,38 @@ publish:  ## Publish Polars crates
 help:  ## Display this help screen
 	@echo -e "\033[1mAvailable commands:\033[0m"
 	@grep -E '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' | sort
+
+.PHONY: check-wasm
+check-wasm:  ## Check wasm build without supported features
+	cargo hack check --target wasm32-unknown-unknown -p polars --no-dev-deps  \
+		--each-feature                        \
+		--exclude-features async              \
+		--exclude-features aws                \
+		--exclude-features azure              \
+		--exclude-features cross_join         \
+		--exclude-features csv                \
+		--exclude-features decompress         \
+		--exclude-features decompress-fast    \
+		--exclude-features default            \
+		--exclude-features docs-selection     \
+		--exclude-features dtype-array        \
+		--exclude-features dtype-categorical  \
+		--exclude-features dtype-decimal      \
+		--exclude-features dtype-full         \
+		--exclude-features dtype-i16          \
+		--exclude-features dtype-i8           \
+		--exclude-features dtype-u16          \
+		--exclude-features dtype-u8           \
+		--exclude-features extract_jsonpath   \
+		--exclude-features fmt                \
+		--exclude-features gcp                \
+		--exclude-features ipc                \
+		--exclude-features ipc_streaming      \
+		--exclude-features json               \
+		--exclude-features nightly            \
+		--exclude-features parquet            \
+		--exclude-features performant         \
+		--exclude-features sql                \
+		--exclude-features streaming          \
+		--exclude-features test
+

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -25,7 +25,6 @@ chrono-tz = { workspace = true, optional = true }
 fast-float = { version = "0.2", optional = true }
 flate2 = { version = "1", features = ["zlib-ng"], optional = true, default-features = false }
 futures = { workspace = true, optional = true }
-home = { version = "0.5.4" }
 lexical = { version = "6", optional = true, default-features = false, features = ["std", "parse-integers"] }
 lexical-core = { version = "0.8", optional = true }
 memchr = { workspace = true }
@@ -41,6 +40,9 @@ simd-json = { workspace = true, optional = true }
 simdutf8 = { version = "0.1", optional = true }
 tokio = { version = "1.26", features = ["net"], optional = true }
 url = { workspace = true, optional = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+home = "0.5.4"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/crates/polars-io/src/utils.rs
+++ b/crates/polars-io/src/utils.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
 
-use home::home_dir;
 use polars_core::frame::DataFrame;
 use polars_core::prelude::*;
 
@@ -16,7 +15,9 @@ use crate::ArrowSchema;
 pub fn resolve_homedir(path: &Path) -> PathBuf {
     // replace "~" with home directory
     if path.starts_with("~") {
-        if let Some(homedir) = home_dir() {
+        // home crate does not compile on wasm https://github.com/rust-lang/cargo/issues/12297
+        #[cfg(not(target_family = "wasm"))]
+        if let Some(homedir) = home::home_dir() {
             return homedir.join(path.strip_prefix("~").unwrap());
         }
     }

--- a/crates/polars-utils/src/wasm.rs
+++ b/crates/polars-utils/src/wasm.rs
@@ -5,6 +5,14 @@ impl Pool {
         rayon::current_num_threads()
     }
 
+    pub fn current_thread_index(&self) -> Option<usize> {
+        rayon::current_thread_index()
+    }
+
+    pub fn current_thread_has_pending_tasks(&self) -> Option<bool> {
+        None
+    }
+
     pub fn install<OP, R>(&self, op: OP) -> R
     where
         OP: FnOnce() -> R + Send,


### PR DESCRIPTION
Fixes issue #8783, where v0.29 broke the build for wasm.

This re-applies the fix from #9502, but with the `decompress` feature disabled as a merge race with #10492 caused it to break on wasm.