### PR TITLE
refactor(python): Remove `deprecate_renamed_methods` util

### DIFF
--- a/py-polars/docs/source/reference/dataframe/descriptive.rst
+++ b/py-polars/docs/source/reference/dataframe/descriptive.rst
@@ -6,6 +6,8 @@ Descriptive
 .. autosummary::
    :toctree: api/
 
+    DataFrame.approx_n_unique
+    DataFrame.approx_unique
     DataFrame.describe
     DataFrame.glimpse
     DataFrame.estimated_size

--- a/py-polars/docs/source/reference/expressions/list.rst
+++ b/py-polars/docs/source/reference/expressions/list.rst
@@ -17,11 +17,13 @@ The following methods are available under the `expr.list` attribute.
     Expr.list.contains
     Expr.list.count_match
     Expr.list.diff
+    Expr.list.difference
     Expr.list.eval
     Expr.list.explode
     Expr.list.first
     Expr.list.get
     Expr.list.head
+    Expr.list.intersection
     Expr.list.join
     Expr.list.last
     Expr.list.lengths
@@ -37,7 +39,9 @@ The following methods are available under the `expr.list` attribute.
     Expr.list.slice
     Expr.list.sort
     Expr.list.sum
+    Expr.list.symmetric_difference
     Expr.list.tail
     Expr.list.take
     Expr.list.to_struct
+    Expr.list.union
     Expr.list.unique

--- a/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
@@ -24,3 +24,4 @@ Read/write logical plan
     LazyFrame.from_json
     LazyFrame.read_json
     LazyFrame.serialize
+    LazyFrame.write_json

--- a/py-polars/docs/source/reference/lazyframe/modify_select.rst
+++ b/py-polars/docs/source/reference/lazyframe/modify_select.rst
@@ -6,6 +6,8 @@ Manipulation/selection
 .. autosummary::
    :toctree: api/
 
+    LazyFrame.approx_n_unique
+    LazyFrame.approx_unique
     LazyFrame.bottom_k
     LazyFrame.clear
     LazyFrame.clone

--- a/py-polars/docs/source/reference/series/list.rst
+++ b/py-polars/docs/source/reference/series/list.rst
@@ -17,12 +17,14 @@ The following methods are available under the `Series.list` attribute.
     Series.list.contains
     Series.list.count_match
     Series.list.diff
+    Series.list.difference
     Series.list.eval
     Series.list.explode
     Series.list.first
     Series.list.get
     Series.list.head
     Series.list.join
+    Series.list.intersection
     Series.list.last
     Series.list.lengths
     Series.list.max
@@ -37,7 +39,9 @@ The following methods are available under the `Series.list` attribute.
     Series.list.slice
     Series.list.sort
     Series.list.sum
+    Series.list.symmetric_difference
     Series.list.tail
     Series.list.take
     Series.list.to_struct
+    Series.list.union
     Series.list.unique

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -85,7 +85,6 @@ from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.deprecation import (
     deprecate_function,
     deprecate_renamed_function,
-    deprecate_renamed_methods,
     deprecate_renamed_parameter,
 )
 from polars.utils.various import (
@@ -179,10 +178,6 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 
-@deprecate_renamed_methods(
-    mapping={"approx_unique": "approx_n_unique"},
-    versions={"approx_unique": "0.18.12"},
-)
 class DataFrame:
     """
     Two-dimensional data structure representing data as a table with rows and columns.
@@ -8560,8 +8555,46 @@ class DataFrame:
             struct_fields = F.all() if (subset is None) else subset
             expr = F.struct(struct_fields)  # type: ignore[call-overload]
 
-        df = self.lazy().select(expr.n_unique()).collect()
+        df = self.lazy().select(expr.n_unique()).collect(no_optimization=True)
         return 0 if df.is_empty() else df.row(0)[0]
+
+    def approx_n_unique(self) -> DataFrame:
+        """
+        Approximate count of unique values.
+
+        This is done using the HyperLogLog++ algorithm for cardinality estimation.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [1, 2, 3, 4],
+        ...         "b": [1, 2, 1, 1],
+        ...     }
+        ... )
+        >>> df.approx_n_unique()
+        shape: (1, 2)
+        ┌─────┬─────┐
+        │ a   ┆ b   │
+        │ --- ┆ --- │
+        │ u32 ┆ u32 │
+        ╞═════╪═════╡
+        │ 4   ┆ 2   │
+        └─────┴─────┘
+
+        """
+        return self.lazy().approx_n_unique().collect(no_optimization=True)
+
+    @deprecate_renamed_function("approx_n_unique", version="0.18.12")
+    def approx_unique(self) -> DataFrame:
+        """
+        Approximate count of unique values.
+
+        .. deprecated:: 0.18.12
+            This method has been renamed to :func:`DataFrame.approx_n_unique`.
+
+        """
+        return self.approx_n_unique()
 
     def rechunk(self) -> Self:
         """

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -7,7 +7,7 @@ import polars._reexport as pl
 from polars import functions as F
 from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
-from polars.utils.deprecation import deprecate_renamed_methods
+from polars.utils.deprecation import deprecate_renamed_function
 
 if TYPE_CHECKING:
     from datetime import date, datetime, time
@@ -16,20 +16,6 @@ if TYPE_CHECKING:
     from polars.type_aliases import IntoExpr, NullBehavior, ToStructStrategy
 
 
-@deprecate_renamed_methods(
-    {
-        "difference": "set_difference",
-        "symmetric_difference": "set_symmetric_difference",
-        "intersection": "set_intersection",
-        "union": "set_union",
-    },
-    versions={
-        "difference": "0.18.10",
-        "symmetric_difference": "0.18.10",
-        "intersection": "0.18.10",
-        "union": "0.18.10",
-    },
-)
 class ExprListNameSpace:
     """Namespace for list related expressions."""
 
@@ -893,7 +879,7 @@ class ExprListNameSpace:
         """
         return wrap_expr(self._pyexpr.list_eval(expr._pyexpr, parallel))
 
-    def set_union(self, other: Expr | IntoExpr) -> Expr:
+    def set_union(self, other: IntoExpr) -> Expr:
         """
         Compute the SET UNION between the elements in this list and the elements of ``other``.
 
@@ -929,7 +915,7 @@ class ExprListNameSpace:
         other = parse_as_expression(other, str_as_lit=False)
         return wrap_expr(self._pyexpr.list_set_operation(other, "union"))
 
-    def set_difference(self, other: Expr | IntoExpr) -> Expr:
+    def set_difference(self, other: IntoExpr) -> Expr:
         """
         Compute the SET DIFFERENCE between the elements in this list and the elements of ``other``.
 
@@ -967,7 +953,7 @@ class ExprListNameSpace:
         other = parse_as_expression(other, str_as_lit=False)
         return wrap_expr(self._pyexpr.list_set_operation(other, "difference"))
 
-    def set_intersection(self, other: Expr | IntoExpr) -> Expr:
+    def set_intersection(self, other: IntoExpr) -> Expr:
         """
         Compute the SET INTERSECTION between the elements in this list and the elements of ``other``.
 
@@ -1003,7 +989,7 @@ class ExprListNameSpace:
         other = parse_as_expression(other, str_as_lit=False)
         return wrap_expr(self._pyexpr.list_set_operation(other, "intersection"))
 
-    def set_symmetric_difference(self, other: Expr | IntoExpr) -> Expr:
+    def set_symmetric_difference(self, other: IntoExpr) -> Expr:
         """
         Compute the SET SYMMETRIC DIFFERENCE between the elements in this list and the elements of ``other``.
 
@@ -1038,3 +1024,47 @@ class ExprListNameSpace:
         """  # noqa: W505.
         other = parse_as_expression(other, str_as_lit=False)
         return wrap_expr(self._pyexpr.list_set_operation(other, "symmetric_difference"))
+
+    @deprecate_renamed_function("set_union", version="0.18.10")
+    def union(self, other: IntoExpr) -> Expr:
+        """
+        Compute the SET UNION between the elements in this list and the elements of ``other``.
+
+        .. deprecated:: 0.18.10
+            This method has been renamed to ``Expr.list.set_union``.
+
+        """  # noqa: W505
+        return self.set_union(other)
+
+    @deprecate_renamed_function("set_difference", version="0.18.10")
+    def difference(self, other: IntoExpr) -> Expr:
+        """
+        Compute the SET DIFFERENCE between the elements in this list and the elements of ``other``.
+
+        .. deprecated:: 0.18.10
+            This method has been renamed to ``Expr.list.set_difference``.
+
+        """  # noqa: W505
+        return self.set_difference(other)
+
+    @deprecate_renamed_function("set_intersection", version="0.18.10")
+    def intersection(self, other: IntoExpr) -> Expr:
+        """
+        Compute the SET INTERSECTION between the elements in this list and the elements of ``other``.
+
+        .. deprecated:: 0.18.10
+            This method has been renamed to ``Expr.list.set_intersection``.
+
+        """  # noqa: W505
+        return self.set_intersection(other)
+
+    @deprecate_renamed_function("set_symmetric_difference", version="0.18.10")
+    def symmetric_difference(self, other: IntoExpr) -> Expr:
+        """
+        Compute the SET SYMMETRIC DIFFERENCE between the elements in this list and the elements of ``other``.
+
+        .. deprecated:: 0.18.10
+            This method has been renamed to ``Expr.list.set_symmetric_difference``.
+
+        """  # noqa: W505
+        return self.set_symmetric_difference(other)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -60,7 +60,6 @@ from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.deprecation import (
     deprecate_function,
     deprecate_renamed_function,
-    deprecate_renamed_methods,
     deprecate_renamed_parameter,
 )
 from polars.utils.various import (
@@ -116,16 +115,6 @@ if TYPE_CHECKING:
     P = ParamSpec("P")
 
 
-@deprecate_renamed_methods(
-    mapping={
-        "approx_unique": "approx_n_unique",
-        "write_json": "serialize",
-    },
-    versions={
-        "approx_unique": "0.18.12",
-        "write_json": "0.18.12",
-    },
-)
 class LazyFrame:
     """
     Representation of a Lazy computation graph/query against a DataFrame.
@@ -868,6 +857,30 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         else:
             self._ldf.serialize(file)
         return None
+
+    @overload
+    def write_json(self, file: None = ...) -> str:
+        ...
+
+    @overload
+    def write_json(self, file: IOBase | str | Path) -> None:
+        ...
+
+    @deprecate_renamed_function("serialize", version="0.18.12")
+    def write_json(self, file: IOBase | str | Path | None = None) -> str | None:
+        """
+        Serialize the logical plan of this LazyFrame to a file or string in JSON format.
+
+        .. deprecated:: 0.18.12
+            This method has been renamed to :func:`LazyFrame.serialize`.
+
+        Parameters
+        ----------
+        file
+            File path to which the result should be written. If set to ``None``
+            (default), the output is returned as a string instead.
+        """
+        return self.serialize(file)
 
     def pipe(
         self,
@@ -4149,6 +4162,17 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         """
         return self.select(F.all().approx_n_unique())
+
+    @deprecate_renamed_function("approx_n_unique", version="0.18.12")
+    def approx_unique(self) -> Self:
+        """
+        Approximate count of unique values.
+
+        .. deprecated:: 0.18.12
+            This method has been renamed to :func:`LazyFrame.approx_n_unique`.
+
+        """
+        return self.approx_n_unique()
 
     def with_row_count(self, name: str = "row_nr", offset: int = 0) -> Self:
         """

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence
 from polars import functions as F
 from polars.series.utils import expr_dispatch
 from polars.utils._wrap import wrap_s
-from polars.utils.deprecation import deprecate_renamed_methods
+from polars.utils.deprecation import deprecate_renamed_function
 
 if TYPE_CHECKING:
     from datetime import date, datetime, time
@@ -16,20 +16,6 @@ if TYPE_CHECKING:
 
 
 @expr_dispatch
-@deprecate_renamed_methods(
-    {
-        "difference": "set_difference",
-        "symmetric_difference": "set_symmetric_difference",
-        "intersection": "set_intersection",
-        "union": "set_union",
-    },
-    versions={
-        "difference": "0.18.10",
-        "symmetric_difference": "0.18.10",
-        "intersection": "0.18.10",
-        "union": "0.18.10",
-    },
-)
 class ListNameSpace:
     """Namespace for list related methods."""
 
@@ -592,7 +578,7 @@ class ListNameSpace:
                 [5, 6, 7, 8]
         ]
 
-        """  # noqa: W505.
+        """  # noqa: W505
 
     def set_difference(self, other: Series) -> Series:
         """
@@ -621,7 +607,7 @@ class ListNameSpace:
                 [5, 7]
         ]
 
-        """  # noqa: W505.
+        """  # noqa: W505
 
     def set_intersection(self, other: Series) -> Series:
         """
@@ -646,7 +632,7 @@ class ListNameSpace:
                 [6]
         ]
 
-        """  # noqa: W505.
+        """  # noqa: W505
 
     def set_symmetric_difference(self, other: Series) -> Series:
         """
@@ -657,4 +643,48 @@ class ListNameSpace:
         other
             Right hand side of the set operation.
 
-        """  # noqa: W505.
+        """  # noqa: W505
+
+    @deprecate_renamed_function("set_union", version="0.18.10")
+    def union(self, other: Series) -> Series:
+        """
+        Compute the SET UNION between the elements in this list and the elements of ``other``.
+
+        .. deprecated:: 0.18.10
+            This method has been renamed to ``Series.list.set_union``.
+
+        """  # noqa: W505
+        return self.set_union(other)
+
+    @deprecate_renamed_function("set_difference", version="0.18.10")
+    def difference(self, other: Series) -> Series:
+        """
+        Compute the SET DIFFERENCE between the elements in this list and the elements of ``other``.
+
+        .. deprecated:: 0.18.10
+            This method has been renamed to ``Series.list.set_difference``.
+
+        """  # noqa: W505
+        return self.set_difference(other)
+
+    @deprecate_renamed_function("set_intersection", version="0.18.10")
+    def intersection(self, other: Series) -> Series:
+        """
+        Compute the SET INTERSECTION between the elements in this list and the elements of ``other``.
+
+        .. deprecated:: 0.18.10
+            This method has been renamed to ``Series.list.set_intersection``.
+
+        """  # noqa: W505
+        return self.set_intersection(other)
+
+    @deprecate_renamed_function("set_symmetric_difference", version="0.18.10")
+    def symmetric_difference(self, other: Series) -> Series:
+        """
+        Compute the SET SYMMETRIC DIFFERENCE between the elements in this list and the elements of ``other``.
+
+        .. deprecated:: 0.18.10
+            This method has been renamed to ``Series.list.set_symmetric_difference``.
+
+        """  # noqa: W505
+        return self.set_symmetric_difference(other)

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -30,7 +30,7 @@ def test_lazyframe_deprecated_serde() -> None:
     lf = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]}).lazy().select(pl.col("a"))
 
     with pytest.deprecated_call():
-        json = lf.write_json()  # type: ignore[attr-defined]
+        json = lf.write_json()
     with pytest.deprecated_call():
         result_from = pl.LazyFrame.from_json(json)
     with pytest.deprecated_call():

--- a/py-polars/tests/unit/utils/test_deprecation.py
+++ b/py-polars/tests/unit/utils/test_deprecation.py
@@ -9,7 +9,6 @@ from polars.utils.deprecation import (
     deprecate_function,
     deprecate_nonkeyword_arguments,
     deprecate_renamed_function,
-    deprecate_renamed_methods,
     deprecate_renamed_parameter,
     issue_deprecation_warning,
     warn_closed_future_change,
@@ -50,30 +49,6 @@ def test_deprecate_renamed_parameter(recwarn: Any) -> None:
     assert len(recwarn) == 2
     assert "oof" in str(recwarn[0].message)
     assert "rab" in str(recwarn[1].message)
-
-
-def test_deprecate_renamed_methods() -> None:
-    # one-to-one redirection
-    @deprecate_renamed_methods({"foo": "bar"}, versions={"foo": "1.0.0"})
-    class DemoClass1:
-        def bar(self, upper: bool = False) -> str:
-            return "BAZ" if upper else "baz"
-
-    with pytest.deprecated_call():
-        result = DemoClass1().foo()  # type: ignore[attr-defined]
-    assert result == "baz"
-
-    # redirection with **kwargs
-    @deprecate_renamed_methods(
-        {"foo": ("bar", {"upper": True})}, versions={"foo": "1.0.0"}
-    )
-    class DemoClass2:
-        def bar(self, upper: bool = False) -> str:
-            return "BAZ" if upper else "baz"
-
-    with pytest.deprecated_call():
-        result = DemoClass2().foo()  # type: ignore[attr-defined]
-    assert result == "BAZ"
 
 
 class Foo:  # noqa: D101


### PR DESCRIPTION
Closes #8004 

The `deprecate_renamed_methods` decorator has a big downside: the deprecated methods are no longer available in the docs. 
While this is nice from a "move fast and break things" standpoint, it's important that the docs contain the deprecated functionality to help people upgrade their code to newer versions.

#### Changes
* Remove `deprecate_renamed_methods` utility
* Re-add the removed methods and deprecate them with `deprecate_renamed_function`
* Add missing `DataFrame.approx_n_unique` method

