### PR TITLE
chore(rust) clean up superfluous cross-crate feature dependencies

### DIFF
--- a/crates/Makefile
+++ b/crates/Makefile
@@ -118,20 +118,10 @@ check-wasm:  ## Check wasm build without supported features
 		--exclude-features async              \
 		--exclude-features aws                \
 		--exclude-features azure              \
-		--exclude-features cross_join         \
-		--exclude-features csv                \
 		--exclude-features decompress         \
 		--exclude-features decompress-fast    \
 		--exclude-features default            \
 		--exclude-features docs-selection     \
-		--exclude-features dtype-array        \
-		--exclude-features dtype-categorical  \
-		--exclude-features dtype-decimal      \
-		--exclude-features dtype-full         \
-		--exclude-features dtype-i16          \
-		--exclude-features dtype-i8           \
-		--exclude-features dtype-u16          \
-		--exclude-features dtype-u8           \
 		--exclude-features extract_jsonpath   \
 		--exclude-features fmt                \
 		--exclude-features gcp                \
@@ -141,7 +131,6 @@ check-wasm:  ## Check wasm build without supported features
 		--exclude-features nightly            \
 		--exclude-features parquet            \
 		--exclude-features performant         \
-		--exclude-features sql                \
 		--exclude-features streaming          \
 		--exclude-features test
 

--- a/crates/polars-pipe/Cargo.toml
+++ b/crates/polars-pipe/Cargo.toml
@@ -11,7 +11,7 @@ description = "Lazy query engine for the Polars DataFrame library"
 [dependencies]
 polars-arrow = { version = "0.32.0", path = "../polars-arrow", default-features = false }
 polars-core = { version = "0.32.0", path = "../polars-core", features = ["lazy", "zip_with", "random"], default-features = false }
-polars-io = { version = "0.32.0", path = "../polars-io", default-features = false, features = ["ipc", "async"] }
+polars-io = { version = "0.32.0", path = "../polars-io", default-features = false }
 polars-ops = { version = "0.32.0", path = "../polars-ops", features = ["search_sorted"] }
 polars-plan = { version = "0.32.0", path = "../polars-plan", default-features = false, features = ["compile"] }
 polars-row = { version = "0.32.0", path = "../polars-row" }
@@ -29,7 +29,7 @@ smartstring = { workspace = true }
 version_check = { workspace = true }
 
 [features]
-compile = ["crossbeam-channel", "crossbeam-queue"]
+compile = ["crossbeam-channel", "crossbeam-queue", "polars-io/ipc"]
 csv = ["polars-plan/csv", "polars-io/csv"]
 parquet = ["polars-plan/parquet", "polars-io/parquet"]
 ipc = ["polars-plan/ipc", "polars-io/ipc"]


### PR DESCRIPTION
polars-pipe always depended on ipc and async of `polars-io`, but only the `polars-pipe/compile` feature needs ipc.

This also fixes wasm support for several features.