### PR TITLE
fix(python): Fix `write_delta` with schema in `delta_write_options`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3465,7 +3465,6 @@ class DataFrame:
         data = self.to_arrow()
 
         schema = delta_write_options.pop("schema", None)
-        
         if schema is None:
             schema = _convert_pa_schema_to_delta(data.schema)
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3464,8 +3464,8 @@ class DataFrame:
 
         data = self.to_arrow()
 
-        schema = delta_write_options.get("schema")
-        delta_write_options.pop("schema", None)
+        schema = delta_write_options.pop("schema", None)
+        
         if schema is None:
             schema = _convert_pa_schema_to_delta(data.schema)
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3465,6 +3465,7 @@ class DataFrame:
         data = self.to_arrow()
 
         schema = delta_write_options.get("schema")
+        delta_write_options.pop("schema", None)
         if schema is None:
             schema = _convert_pa_schema_to_delta(data.schema)
 

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 
+import pyarrow as pa
 import pyarrow.fs
 import pytest
 from deltalake import DeltaTable
@@ -335,3 +336,10 @@ def test_write_delta_w_compatible_schema(series: pl.Series, tmp_path: Path) -> N
 
     tbl = DeltaTable(tmp_path)
     assert tbl.version() == 1
+
+
+def test_write_delta_with_schema_10540(tmp_path: Path) -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+
+    pa_schema = pa.schema([("a", pa.int64())])
+    df.write_delta(tmp_path, delta_write_options={"schema": pa_schema})


### PR DESCRIPTION
Closes #10540

This fixes a bug where the schema is passed twice to the `write_deltalake` method.