### PR TITLE
docs(python): Fix link to source code

### DIFF
--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -95,8 +95,8 @@ github_root = "https://github.com/pola-rs/polars"
 web_root = "https://pola-rs.github.io"
 
 # Specify version for version switcher dropdown menu
-switcher_version_env = os.environ.get("POLARS_VERSION", "main")
-version_match = re.fullmatch(r"py-(\d+\.\d+)\.\d+.*", switcher_version_env)
+git_ref = os.environ.get("POLARS_VERSION", "main")
+version_match = re.fullmatch(r"py-(\d+\.\d+)\.\d+.*", git_ref)
 switcher_version = version_match.group(1) if version_match is not None else "dev"
 
 html_theme_options = {
@@ -210,7 +210,7 @@ def linkcode_resolve(domain, info):
     polars_root = (conf_dir_path.parent.parent / "polars").absolute()
 
     fn = os.path.relpath(fn, start=polars_root)
-    return f"{github_root}/blob/main/py-polars/polars/{fn}{linespec}"
+    return f"{github_root}/blob/{git_ref}/py-polars/polars/{fn}{linespec}"
 
 
 def _minify_classpaths(s: str) -> str:


### PR DESCRIPTION
Makes the source link (right in the picture) behave correctly when not on the dev version of the docs.

![image](https://github.com/pola-rs/polars/assets/3502351/41a145c0-c8e7-4727-bf9f-1b2a5063401c)
