### PR TITLE
feat(python): Remove deprecated `get_idx_type` - use `get_index_type` instead

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,21 +191,6 @@ dependencies = [
  "serde",
  "serde_json",
  "snap",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
 ]
 
 [[package]]
@@ -705,12 +681,6 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "git2"
@@ -1273,15 +1243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,13 +1468,11 @@ version = "0.32.0"
 dependencies = [
  "ahash",
  "arrow2",
- "async-trait",
  "bytes",
  "chrono",
  "chrono-tz",
  "fast-float",
  "flate2",
- "futures",
  "home",
  "lexical",
  "lexical-core",
@@ -1533,7 +1492,6 @@ dependencies = [
  "serde_json",
  "simd-json",
  "simdutf8",
- "tokio",
 ]
 
 [[package]]
@@ -1938,12 +1896,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,16 +2075,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
-name = "socket2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "sqlparser"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,20 +2224,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3ce25f50619af8b0aec2eb23deebe84249e19e2ddd393a6e16e3300a6dadfd"
-dependencies = [
- "backtrace",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "windows-sys",
-]
 
 [[package]]
 name = "toml"

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -174,13 +174,7 @@ from polars.series import Series
 from polars.sql import SQLContext
 from polars.string_cache import StringCache, enable_string_cache, using_string_cache
 from polars.type_aliases import PolarsDataType
-from polars.utils import (
-    build_info,
-    get_idx_type,
-    get_index_type,
-    show_versions,
-    threadpool_size,
-)
+from polars.utils import build_info, get_index_type, show_versions, threadpool_size
 
 # TODO: remove need for importing wrap utils at top level
 from polars.utils._wrap import wrap_df, wrap_s  # noqa: F401
@@ -361,7 +355,6 @@ __all__ = [
     "SQLContext",
     # polars.utils
     "build_info",
-    "get_idx_type",
     "get_index_type",
     "show_versions",
     "threadpool_size",

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -17,7 +17,7 @@ from polars.utils._parse_expr_input import (
 )
 from polars.utils._wrap import wrap_df, wrap_expr
 from polars.utils.deprecation import (
-    deprecate_function,
+    deprecate_renamed_function,
     deprecate_renamed_parameter,
     issue_deprecation_warning,
 )
@@ -478,9 +478,7 @@ def avg(column: Series) -> float:
     ...
 
 
-@deprecate_function(
-    "Please use `mean` instead, for which `avg` is an alias.", version="0.18.12"
-)
+@deprecate_renamed_function("mean", version="0.18.12")
 def avg(column: str | Series) -> Expr | float:
     """
     Alias for mean.

--- a/py-polars/polars/utils/__init__.py
+++ b/py-polars/polars/utils/__init__.py
@@ -17,7 +17,7 @@ from polars.utils.convert import (
     _to_python_time,
     _to_python_timedelta,
 )
-from polars.utils.meta import get_idx_type, get_index_type, threadpool_size
+from polars.utils.meta import get_index_type, threadpool_size
 from polars.utils.show_versions import show_versions
 from polars.utils.various import NoDefault, _polars_warn, no_default
 
@@ -26,7 +26,6 @@ __all__ = [
     "no_default",
     "build_info",
     "show_versions",
-    "get_idx_type",
     "get_index_type",
     "threadpool_size",
     # Required for Rust bindings

--- a/py-polars/polars/utils/meta.py
+++ b/py-polars/polars/utils/meta.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import contextlib
 from typing import TYPE_CHECKING
 
-from polars.utils.deprecation import deprecate_renamed_function
-
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import get_index_type as _get_index_type
     from polars.polars import threadpool_size as _threadpool_size
@@ -25,12 +23,6 @@ def get_index_type() -> DataTypeClass:
 
     """
     return _get_index_type()
-
-
-@deprecate_renamed_function(new_name="get_index_type", version="16.12")
-def get_idx_type() -> DataTypeClass:
-    """Get the datatype used for Polars indexing."""
-    return get_index_type()
 
 
 def threadpool_size() -> int:

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -13,7 +13,6 @@ from polars.utils.convert import (
     _timedelta_to_pl_duration,
     _timedelta_to_pl_timedelta,
 )
-from polars.utils.meta import get_idx_type
 from polars.utils.various import _in_notebook, parse_percentiles, parse_version
 
 if TYPE_CHECKING:
@@ -114,11 +113,6 @@ def test_estimated_size() -> None:
 def test_parse_version(v1: Any, v2: Any) -> None:
     assert parse_version(v1) > parse_version(v2)
     assert parse_version(v2) < parse_version(v1)
-
-
-def test_get_idx_type_deprecation() -> None:
-    with pytest.deprecated_call():
-        get_idx_type()
 
 
 def test_in_notebook() -> None:


### PR DESCRIPTION
This should have been included in https://github.com/pola-rs/polars/pull/10527, but I missed it as it was tagged with the wrong version. It was deprecated in version `0.16.12`.

#### Changes
* `get_idx_type` - removed - use `get_index_type`
