### PR TITLE
perf(rust, python): use binary abstraction in pow

### DIFF
--- a/crates/polars-arrow/src/kernels/mod.rs
+++ b/crates/polars-arrow/src/kernels/mod.rs
@@ -11,6 +11,7 @@ pub mod ewm;
 pub mod float;
 pub mod list;
 pub mod list_bytes_iter;
+pub mod pow;
 pub mod rolling;
 pub mod set;
 pub mod sort_partition;

--- a/crates/polars-arrow/src/kernels/pow.rs
+++ b/crates/polars-arrow/src/kernels/pow.rs
@@ -1,0 +1,14 @@
+use arrow::array::PrimitiveArray;
+use arrow::compute::arity::binary;
+use arrow::types::NativeType;
+use num_traits::pow::Pow;
+
+pub fn pow<T, F>(arr_1: &PrimitiveArray<T>, arr_2: &PrimitiveArray<F>) -> PrimitiveArray<T>
+where
+    T: Pow<F, Output = T> + NativeType,
+    F: NativeType,
+{
+    binary(arr_1, arr_2, arr_1.data_type().clone(), |a, b| {
+        Pow::pow(a, b)
+    })
+}

--- a/crates/polars-plan/src/dsl/function_expr/pow.rs
+++ b/crates/polars-plan/src/dsl/function_expr/pow.rs
@@ -1,7 +1,8 @@
 use num::pow::Pow;
-use polars_arrow::utils::CustomIterTools;
+use polars_arrow::kernels::pow::pow as pow_kernel;
 use polars_core::export::num;
 use polars_core::export::num::{Float, ToPrimitive};
+use polars_core::utils::align_chunks_binary;
 
 use super::*;
 
@@ -63,15 +64,13 @@ where
             exponent.apply(|exp| Pow::pow(base, exp)).into_series(),
         ))
     } else {
+        let (ca_1, ca_2) = align_chunks_binary(base, exponent);
+        let chunks = ca_1
+            .downcast_iter()
+            .zip(ca_2.downcast_iter())
+            .map(|(arr_1, arr_2)| pow_kernel(arr_1, arr_2));
         Ok(Some(
-            base.into_iter()
-                .zip(exponent)
-                .map(|(opt_base, opt_exponent)| match (opt_base, opt_exponent) {
-                    (Some(base), Some(exponent)) => Some(num::pow::Pow::pow(base, exponent)),
-                    _ => None,
-                })
-                .collect_trusted::<ChunkedArray<T>>()
-                .into_series(),
+            ChunkedArray::from_chunk_iter(ca_1.name(), chunks).into_series(),
         ))
     }
 }

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,21 +191,6 @@ dependencies = [
  "serde",
  "serde_json",
  "snap",
-]
-
-[[package]]
-name = "backtrace"
-version = "0.3.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
 ]
 
 [[package]]
@@ -705,12 +681,6 @@ dependencies = [
  "wasi",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.27.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
 name = "git2"
@@ -1273,15 +1243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,13 +1468,11 @@ version = "0.32.0"
 dependencies = [
  "ahash",
  "arrow2",
- "async-trait",
  "bytes",
  "chrono",
  "chrono-tz",
  "fast-float",
  "flate2",
- "futures",
  "home",
  "lexical",
  "lexical-core",
@@ -1533,7 +1492,6 @@ dependencies = [
  "serde_json",
  "simd-json",
  "simdutf8",
- "tokio",
 ]
 
 [[package]]
@@ -1938,12 +1896,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2123,16 +2075,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e9f0ab6ef7eb7353d9119c170a436d1bf248eea575ac42d19d12f4e34130831"
 
 [[package]]
-name = "socket2"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "sqlparser"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,20 +2224,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d3ce25f50619af8b0aec2eb23deebe84249e19e2ddd393a6e16e3300a6dadfd"
-dependencies = [
- "backtrace",
- "libc",
- "mio",
- "pin-project-lite",
- "socket2",
- "windows-sys",
-]
 
 [[package]]
 name = "toml"


### PR DESCRIPTION
splitting this out from #10446 as it's gonna take me a bit longer to figure that one out

but this is simple and already seems to improve performance

timing
```python
size = 100_000_000
df = pl.DataFrame({'a': np.random.randint(0, 4, size=size), 'b': np.random.randn(size)}, schema_overrides={'a': pl.UInt8})
print(ipython.run_line_magic("timeit", "df.select(pl.col('a').pow(pl.col('a')))"))
print(ipython.run_line_magic("timeit", "df.select(pl.col('b').pow(pl.col('b')))"))
```
on kaggle I see:

- before: `8.35 s ± 2.41 s`, `4.42 s ± 21.2 ms`
- after: `7.29 s ± 2.3 s`, `2.92 s ± 18.6 ms`

source: https://www.kaggle.com/code/marcogorelli/polars-timing/notebook?scriptVersionId=140186516