### PR TITLE
fix(rust): fix serialization of empty lists

### DIFF
--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -204,7 +204,11 @@ impl<'de> Deserialize<'de> for Series {
                     },
                     DataType::List(_) => {
                         let values: Vec<Option<Series>> = map.next_value()?;
-                        Ok(Series::new(&name, values))
+                        if values.is_empty() {
+                            Ok(Series::new_empty(&name, &dtype))
+                        } else {
+                            Ok(Series::new(&name, values))
+                        }
                     },
                     DataType::Binary => {
                         let values: Vec<Option<Cow<[u8]>>> = map.next_value()?;

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -139,6 +139,11 @@ def test_json_sliced_list_serialization() -> None:
     sliced_df.write_ndjson(f)
     assert f.getvalue() == b'{"col1":2,"col2":[6,7,8]}\n'
 
+def test_json_deserialize_empty_list_10458() -> None:
+    schema = {'LIST_OF_STRINGS': pl.List(pl.Utf8)}
+    serialized_schema = pl.DataFrame(schema=schema).write_json()
+    df = pl.read_json(io.StringIO(serialized_schema))
+    assert df.schema == schema
 
 def test_json_deserialize_9687() -> None:
     response = {

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -139,11 +139,13 @@ def test_json_sliced_list_serialization() -> None:
     sliced_df.write_ndjson(f)
     assert f.getvalue() == b'{"col1":2,"col2":[6,7,8]}\n'
 
+
 def test_json_deserialize_empty_list_10458() -> None:
-    schema = {'LIST_OF_STRINGS': pl.List(pl.Utf8)}
+    schema = {"LIST_OF_STRINGS": pl.List(pl.Utf8)}
     serialized_schema = pl.DataFrame(schema=schema).write_json()
     df = pl.read_json(io.StringIO(serialized_schema))
     assert df.schema == schema
+
 
 def test_json_deserialize_9687() -> None:
     response = {


### PR DESCRIPTION
fix #10458

When values is empty, Series::new does not have information on the dtype/name and will return a Null Type