### PR TITLE
feat!: Change behavior of `all` - fix Kleene logic implementation for `all`/`any`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,12 +53,10 @@ xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 
 [workspace.dependencies.arrow]
 package = "arrow2"
-# git = "https://github.com/jorgecarleitao/arrow2"
-# git = "https://github.com/ritchie46/arrow2"
-# rev = "9beabec8cfb5502582d31ab898fdd36e7af0873c"
-# path = "../arrow2"
-# branch = "duration_json"
-version = "0.17.4"
+git = "https://github.com/jorgecarleitao/arrow2"
+rev = "7edf5f9e359e0ed02e9d0c6b9318b06964d805f0"
+# branch = ""
+# version = "0.17.4"
 default-features = false
 features = [
   "compute_aggregate",

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1652,9 +1652,30 @@ impl Expr {
         .with_fmt("ewm_var")
     }
 
-    /// Check if any boolean value is `true`
-    pub fn any(self, drop_nulls: bool) -> Self {
-        self.apply_private(BooleanFunction::Any { drop_nulls }.into())
+    /// Returns whether any of the values in the column are `true`.
+    ///
+    /// If `ignore_nulls` is `False`, [Kleene logic] is used to deal with nulls:
+    /// if the column contains any null values and no `true` values, the output
+    /// is null.
+    ///
+    /// [Kleene logic]: https://en.wikipedia.org/wiki/Three-valued_logic
+    pub fn any(self, ignore_nulls: bool) -> Self {
+        self.apply_private(BooleanFunction::Any { ignore_nulls }.into())
+            .with_function_options(|mut opt| {
+                opt.auto_explode = true;
+                opt
+            })
+    }
+
+    /// Returns whether all values in the column are `true`.
+    ///
+    /// If `ignore_nulls` is `False`, [Kleene logic] is used to deal with nulls:
+    /// if the column contains any null values and no `true` values, the output
+    /// is null.
+    ///
+    /// [Kleene logic]: https://en.wikipedia.org/wiki/Three-valued_logic
+    pub fn all(self, ignore_nulls: bool) -> Self {
+        self.apply_private(BooleanFunction::All { ignore_nulls }.into())
             .with_function_options(|mut opt| {
                 opt.auto_explode = true;
                 opt
@@ -1666,15 +1687,6 @@ impl Expr {
     /// This can be used to reduce memory pressure.
     pub fn shrink_dtype(self) -> Self {
         self.map_private(FunctionExpr::ShrinkType)
-    }
-
-    /// Check if all boolean values are `true`
-    pub fn all(self, drop_nulls: bool) -> Self {
-        self.apply_private(BooleanFunction::All { drop_nulls }.into())
-            .with_function_options(|mut opt| {
-                opt.auto_explode = true;
-                opt
-            })
     }
 
     #[cfg(feature = "dtype-struct")]

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -99,8 +99,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c468daea140b747d781a1da9f7db5f0a8e6636d4af20cc539e43d05b0604fa"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=7edf5f9e359e0ed02e9d0c6b9318b06964d805f0#7edf5f9e359e0ed02e9d0c6b9318b06964d805f0"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -123,7 +122,7 @@ dependencies = [
  "num-traits",
  "parquet2",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax",
  "rustc_version",
  "simdutf8",
  "streaming-iterator",
@@ -1863,7 +1862,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.7.4",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1874,14 +1873,8 @@ checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -60,7 +60,7 @@ class ExprListNameSpace:
         │ true  │
         │ false │
         │ false │
-        │ false │
+        │ true  │
         │ true  │
         │ null  │
         └───────┘

--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -15,20 +15,24 @@ if TYPE_CHECKING:
 
 
 @overload
-def all(exprs: Series) -> bool:  # type: ignore[misc]
+def all(exprs: Series, *, ignore_nulls: bool = ...) -> bool | None:  # type: ignore[misc]
     ...
 
 
 @overload
 def all(
-    exprs: IntoExpr | Iterable[IntoExpr] | None = ..., *more_exprs: IntoExpr
+    exprs: IntoExpr | Iterable[IntoExpr] | None = ...,
+    *more_exprs: IntoExpr,
+    ignore_nulls: bool = ...,
 ) -> Expr:
     ...
 
 
 @deprecate_renamed_parameter("columns", "exprs", version="0.18.7")
 def all(
-    exprs: IntoExpr | Iterable[IntoExpr] | None = None, *more_exprs: IntoExpr
+    exprs: IntoExpr | Iterable[IntoExpr] | None = None,
+    *more_exprs: IntoExpr,
+    ignore_nulls: bool = True,
 ) -> Expr | bool | None:
     """
     Either return an expression representing all columns, or evaluate a bitwise AND operation.
@@ -50,6 +54,14 @@ def all(
         parsed as column names, other non-expression inputs are parsed as literals.
     *more_exprs
         Additional columns to use in the aggregation, specified as positional arguments.
+    ignore_nulls
+        Ignore null values (default).
+
+        If set to ``False``, `Kleene logic`_ is used to deal with nulls:
+        if the column contains any null values and no ``True`` values,
+        the output is ``None``.
+
+        .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
     See Also
     --------
@@ -96,27 +108,33 @@ def all(
                 "passing a Series to `all` is deprecated. Use `Series.all()` instead.",
                 version="0.18.7",
             )
-            return exprs.all()
+            return exprs.all(ignore_nulls=ignore_nulls)
         elif isinstance(exprs, str):
-            return F.col(exprs).all()
+            return F.col(exprs).all(ignore_nulls=ignore_nulls)
 
     _warn_for_deprecated_horizontal_use("all")
     return F.all_horizontal(exprs, *more_exprs)
 
 
 @overload
-def any(exprs: Series) -> bool:  # type: ignore[misc]
+def any(exprs: Series, *, ignore_nulls: bool = ...) -> bool | None:  # type: ignore[misc]
     ...
 
 
 @overload
-def any(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
+def any(
+    exprs: IntoExpr | Iterable[IntoExpr],
+    *more_exprs: IntoExpr,
+    ignore_nulls: bool = ...,
+) -> Expr:
     ...
 
 
 @deprecate_renamed_parameter("columns", "exprs", version="0.18.7")
 def any(
-    exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr
+    exprs: IntoExpr | Iterable[IntoExpr],
+    *more_exprs: IntoExpr,
+    ignore_nulls: bool = True,
 ) -> Expr | bool | None:
     """
     Evaluate a bitwise OR operation.
@@ -141,6 +159,14 @@ def any(
         parsed as column names, other non-expression inputs are parsed as literals.
     *more_exprs
         Additional columns to use in the aggregation, specified as positional arguments.
+    ignore_nulls
+        Ignore null values (default).
+
+        If set to ``False``, `Kleene logic`_ is used to deal with nulls:
+        if the column contains any null values and no ``True`` values,
+        the output is ``None``.
+
+        .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
     Examples
     --------
@@ -167,9 +193,9 @@ def any(
                 "passing a Series to `any` is deprecated. Use `Series.any()` instead.",
                 version="0.18.7",
             )
-            return exprs.any()
+            return exprs.any(ignore_nulls=ignore_nulls)
         elif isinstance(exprs, str):
-            return F.col(exprs).any()
+            return F.col(exprs).any(ignore_nulls=ignore_nulls)
 
     _warn_for_deprecated_horizontal_use("any")
     return F.any_horizontal(exprs, *more_exprs)

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -57,7 +57,7 @@ class ListNameSpace:
         │ true  │
         │ false │
         │ false │
-        │ false │
+        │ true  │
         │ true  │
         │ null  │
         └───────┘

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1229,37 +1229,103 @@ class Series:
 
         """
 
-    def any(self, drop_nulls: bool = True) -> bool | None:
+    @overload
+    def any(self, *, ignore_nulls: Literal[True] = ...) -> bool:
+        ...
+
+    @overload
+    def any(self, *, ignore_nulls: bool) -> bool | None:
+        ...
+
+    @deprecate_renamed_parameter("drop_nulls", "ignore_nulls", version="0.19.0")
+    def any(self, *, ignore_nulls: bool = True) -> bool | None:
         """
-        Check if any boolean value in the column is `True`.
+        Return whether any of the values in the column are ``True``.
+
+        Only works on columns of data type :class:`Boolean`.
+
+        Parameters
+        ----------
+        ignore_nulls
+            Ignore null values (default).
+
+            If set to ``False``, `Kleene logic`_ is used to deal with nulls:
+            if the column contains any null values and no ``True`` values,
+            the output is ``None``.
+
+            .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
         Returns
         -------
-        Series
-            Series of data type :class:`Boolean`.
+        bool or None
+
+        Examples
+        --------
+        >>> pl.Series([True, False]).any()
+        True
+        >>> pl.Series([False, False]).any()
+        False
+        >>> pl.Series([None, False]).any()
+        False
+
+        Enable Kleene logic by setting ``ignore_nulls=False``.
+
+        >>> pl.Series([None, False]).any(ignore_nulls=False)  # Returns None
 
         """
         return (
             self.to_frame()
-            .select(F.col(self.name).any(drop_nulls=drop_nulls))
-            .to_series()
+            .select(F.col(self.name).any(ignore_nulls=ignore_nulls))
             .item()
         )
 
-    def all(self, drop_nulls: bool = True) -> bool | None:
+    @overload
+    def all(self, *, ignore_nulls: Literal[True] = ...) -> bool:
+        ...
+
+    @overload
+    def all(self, *, ignore_nulls: bool) -> bool | None:
+        ...
+
+    @deprecate_renamed_parameter("drop_nulls", "ignore_nulls", version="0.19.0")
+    def all(self, *, ignore_nulls: bool = True) -> bool | None:
         """
-        Check if all boolean values in the column are `True`.
+        Return whether all values in the column are ``True``.
+
+        Only works on columns of data type :class:`Boolean`.
+
+        Parameters
+        ----------
+        ignore_nulls
+            Ignore null values (default).
+
+            If set to ``False``, `Kleene logic`_ is used to deal with nulls:
+            if the column contains any null values and no ``True`` values,
+            the output is ``None``.
+
+            .. _Kleene logic: https://en.wikipedia.org/wiki/Three-valued_logic
 
         Returns
         -------
-        Series
-            Series of data type :class:`Boolean`.
+        bool or None
+
+        Examples
+        --------
+        >>> pl.Series([True, True]).all()
+        True
+        >>> pl.Series([False, True]).all()
+        False
+        >>> pl.Series([None, True]).all()
+        True
+
+        Enable Kleene logic by setting ``ignore_nulls=False``.
+
+        >>> pl.Series([None, True]).all(ignore_nulls=False)  # Returns None
 
         """
         return (
             self.to_frame()
-            .select(F.col(self.name).all(drop_nulls=drop_nulls))
-            .to_series()
+            .select(F.col(self.name).all(ignore_nulls=ignore_nulls))
             .item()
         )
 

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -1145,12 +1145,12 @@ impl PyExpr {
             .with_fmt("extend")
             .into()
     }
-    fn any(&self, drop_nulls: bool) -> Self {
-        self.inner.clone().any(drop_nulls).into()
-    }
 
-    fn all(&self, drop_nulls: bool) -> Self {
-        self.inner.clone().all(drop_nulls).into()
+    fn any(&self, ignore_nulls: bool) -> Self {
+        self.inner.clone().any(ignore_nulls).into()
+    }
+    fn all(&self, ignore_nulls: bool) -> Self {
+        self.inner.clone().all(ignore_nulls).into()
     }
 
     fn log(&self, base: f64) -> Self {

--- a/py-polars/tests/unit/datatypes/test_bool.py
+++ b/py-polars/tests/unit/datatypes/test_bool.py
@@ -61,9 +61,3 @@ def test_bool_literal_expressions() -> None:
     assert val(True | pl.col("x")) == {"literal": [True, True]}
     assert val(False ^ pl.col("x")) == {"literal": [False, True]}
     assert val(True ^ pl.col("x")) == {"literal": [True, False]}
-
-
-def test_all_empty() -> None:
-    s = pl.Series([], dtype=pl.Boolean)
-    assert s.all()
-    assert not s.any()

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -311,7 +311,7 @@ def test_list_all() -> None:
             ]
         }
     ).select(pl.col("a").list.all()).to_dict(False) == {
-        "a": [True, False, True, False, False, False, True]
+        "a": [True, False, True, False, False, True, True]
     }
 
 

--- a/py-polars/tests/unit/series/test_all_any.py
+++ b/py-polars/tests/unit/series/test_all_any.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ([], False),
+        ([None], False),
+        ([False], False),
+        ([False, None], False),
+        ([True], True),
+        ([True, None], True),
+    ],
+)
+def test_any(data: list[bool | None], expected: bool) -> None:
+    assert pl.Series(data, dtype=pl.Boolean).any() is expected
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ([], False),
+        ([None], None),
+        ([False], False),
+        ([False, None], None),
+        ([True], True),
+        ([True, None], True),
+    ],
+)
+def test_any_kleene(data: list[bool | None], expected: bool | None) -> None:
+    assert pl.Series(data, dtype=pl.Boolean).any(ignore_nulls=False) is expected
+
+
+def test_any_wrong_dtype() -> None:
+    with pytest.raises(pl.SchemaError, match="expected `Boolean`"):
+        pl.Series([0, 1, 0]).any()
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ([], True),
+        ([None], True),
+        ([False], False),
+        ([False, None], False),
+        ([True], True),
+        ([True, None], True),
+    ],
+)
+def test_all(data: list[bool | None], expected: bool) -> None:
+    assert pl.Series(data, dtype=pl.Boolean).all() is expected
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        ([], True),
+        ([None], None),
+        ([False], False),
+        ([False, None], False),
+        ([True], True),
+        ([True, None], None),
+    ],
+)
+def test_all_kleene(data: list[bool | None], expected: bool | None) -> None:
+    assert pl.Series(data, dtype=pl.Boolean).all(ignore_nulls=False) is expected
+
+
+def test_all_wrong_dtype() -> None:
+    with pytest.raises(pl.SchemaError, match="expected `Boolean`"):
+        pl.Series([0, 1, 0]).all()


### PR DESCRIPTION
Closes #10550 

#### Changes

* `all` will now ignore null values by default, rather than treat them as `False`.
  * This change is introduced by updating `arrow2` to a version that includes [this breaking change](https://github.com/jorgecarleitao/arrow2/pull/1545).

Before:
```python
>>> pl.Series([True, None]).all()
False
```

After:
```python
>>> pl.Series([True, None]).all()
True
```

#### Other changes
* Fix the implementation of Kleene logic. The output was incorrect in some cases, this has been corrected.
* Rename parameter `drop_nulls` to `ignore_nulls`, to better align with the rest of our API.
* Make the parameter `drop_nulls` keyword-only. _(all boolean flags must be keyword only)_ 
