### PR TITLE
perf(rust, python): use binary abstraction for atan2

### DIFF
--- a/crates/polars-arrow/src/kernels/atan2.rs
+++ b/crates/polars-arrow/src/kernels/atan2.rs
@@ -1,0 +1,14 @@
+use arrow::array::PrimitiveArray;
+use arrow::compute::arity::binary;
+use arrow::types::NativeType;
+use num_traits::Float;
+
+pub fn atan2<T: NativeType>(
+    arr_1: &PrimitiveArray<T>,
+    arr_2: &PrimitiveArray<T>,
+) -> PrimitiveArray<T>
+where
+    T: Float,
+{
+    binary(arr_1, arr_2, arr_1.data_type().clone(), |a, b| a.atan2(b))
+}

--- a/crates/polars-arrow/src/kernels/mod.rs
+++ b/crates/polars-arrow/src/kernels/mod.rs
@@ -4,6 +4,7 @@ use arrow::array::BooleanArray;
 use arrow::bitmap::utils::BitChunks;
 #[cfg(feature = "simd")]
 pub mod agg_mean;
+pub mod atan2;
 #[cfg(feature = "dtype-array")]
 pub mod comparison;
 pub mod concatenate;


### PR DESCRIPTION
similar to #10562 , noticed another place where the less performant pattern is used