### PR TITLE
feat(python): support selector usage in `write_excel` arguments

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -66,7 +66,7 @@ from polars.io.excel._write_utils import (
     _xl_unique_table_name,
     _XLFormatCache,
 )
-from polars.selectors import _expand_selectors
+from polars.selectors import _expand_selector_dicts, _expand_selectors
 from polars.slice import PolarsSlice
 from polars.utils._construction import (
     _post_apply_columns,
@@ -119,8 +119,10 @@ if TYPE_CHECKING:
         AsofJoinStrategy,
         AvroCompression,
         ClosedInterval,
+        ColumnFormatDict,
         ColumnNameOrSelector,
         ColumnTotalsDefinition,
+        ColumnWidthsDefinition,
         ComparisonOperator,
         ConditionalFormatDict,
         CsvEncoding,
@@ -2567,12 +2569,12 @@ class DataFrame:
         position: tuple[int, int] | str = "A1",
         table_style: str | dict[str, Any] | None = None,
         table_name: str | None = None,
-        column_formats: dict[str | tuple[str, ...], str | dict[str, str]] | None = None,
+        column_formats: ColumnFormatDict | None = None,
         dtype_formats: dict[OneOrMoreDataTypes, str] | None = None,
         conditional_formats: ConditionalFormatDict | None = None,
         header_format: dict[str, Any] | None = None,
         column_totals: ColumnTotalsDefinition | None = None,
-        column_widths: dict[str | tuple[str, ...], int] | int | None = None,
+        column_widths: ColumnWidthsDefinition | None = None,
         row_totals: RowTotalsDefinition | None = None,
         row_heights: dict[int | tuple[int, ...], int] | int | None = None,
         sparklines: dict[str, Sequence[str] | dict[str, Any]] | None = None,
@@ -2615,9 +2617,9 @@ class DataFrame:
             Name of the output table object in the worksheet; can then be referred to
             in the sheet by formulae/charts, or by subsequent ``xlsxwriter`` operations.
         column_formats : dict
-            A ``{colname:str,}`` dictionary for applying an Excel format string to the
-            given columns. Formats defined here (such as "dd/mm/yyyy", "0.00%", etc)
-            will override any defined in ``dtype_formats`` (below).
+            A ``{colname(s):str,}`` or ``{selector:str,}`` dictionary for applying an
+            Excel format string to the given columns. Formats defined here (such as
+            "dd/mm/yyyy", "0.00%", etc) will override any defined in ``dtype_formats``.
         dtype_formats : dict
             A ``{dtype:str,}`` dictionary that sets the default Excel format for the
             given dtype. (This can be overridden on a per-column basis by the
@@ -2625,8 +2627,8 @@ class DataFrame:
             ``pl.FLOAT_DTYPES`` as the dtype/format key, to simplify setting uniform
             integer and float formats.
         conditional_formats : dict
-            A ``{colname(s):str,}``, ``{colname(s):dict,}``, or ``{colname(s):list,}``
-            dictionary defining conditional format options for the specified columns.
+            A dictionary of colname (or selector) keys to a format str, dict, or list
+            that defines conditional formatting options for the specified columns.
 
             * If supplying a string typename, should be one of the valid ``xlsxwriter``
               types such as "3_color_scale", "data_bar", etc.
@@ -2652,9 +2654,9 @@ class DataFrame:
             Valid total function names are "average", "count_nums", "count", "max",
             "min", "std_dev", "sum", and "var".
         column_widths : {dict, int}
-            A ``{colname:int,}`` dict or single integer that sets (or overrides if
-            autofitting) table column widths in integer pixel units. If given as an
-            integer the same value is used for all table columns.
+            A ``{colname:int,}`` or ``{selector:int,}`` dict or a single integer that
+            sets (or overrides if autofitting) table column widths, in integer pixel
+            units. If given as an integer the same value is used for all table columns.
         row_totals : {dict, bool}
             Add a row-total column to the right-hand side of the exported table.
 
@@ -2695,7 +2697,7 @@ class DataFrame:
               "formula" (mandatory), one of "insert_before" or "insert_after", and
               optionally "return_dtype". The latter is used to appropriately format the
               output of the formula and allow it to participate in row/column totals.
-        float_precision : {dict, int}
+        float_precision : int
             Default number of decimals displayed for floating point columns (note that
             this is purely a formatting directive; the actual values are not rounded).
         has_header : bool
@@ -2705,7 +2707,7 @@ class DataFrame:
         autofit : bool
             Calculate individual column widths from the data.
         hidden_columns : list
-             A list of table columns to hide in the worksheet.
+             A list or selector representing table columns to hide in the worksheet.
         hide_gridlines : bool
             Do not display any gridlines on the output worksheet.
         sheet_zoom : int
@@ -2724,7 +2726,6 @@ class DataFrame:
               the `top_row` and `top_col`. Thus, to freeze only the top row and have the
               scrolling region begin at row 10, column D (5th col), supply (1, 0, 9, 4).
               Using cell notation for (row, col), supplying ("A2", 9, 4) is equivalent.
-
 
         Notes
         -----
@@ -3003,9 +3004,13 @@ class DataFrame:
                 )
 
         # additional column-level properties
-        hidden_columns = hidden_columns or ()
+        hidden_columns = _expand_selectors(df, hidden_columns or ())
         if isinstance(column_widths, int):
             column_widths = {column: column_widths for column in df.columns}
+        else:
+            column_widths = _expand_selector_dicts(  # type: ignore[assignment]
+                df, column_widths, expand_keys=True, expand_values=False
+            )
         column_widths = _unpack_multi_column_dict(column_widths or {})  # type: ignore[assignment]
 
         for column in df.columns:

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -173,6 +173,30 @@ def _expand_selectors(
     return expanded
 
 
+def _expand_selector_dicts(
+    df: DataFrame,
+    d: Mapping[Any, Any] | None,
+    expand_keys: bool,
+    expand_values: bool,
+    tuple_keys: bool = False,
+) -> dict[str, Any]:
+    """Expand dict key/value selectors into their underlying column names."""
+    expanded = {}
+    for key, value in (d or {}).items():
+        if expand_values and is_selector(value):
+            expanded[key] = expand_selector(df, selector=value)
+            value = expanded[key]
+        if expand_keys and is_selector(key):
+            cols = expand_selector(df, selector=key)
+            if tuple_keys:
+                expanded[cols] = value
+            else:
+                expanded.update({c: value for c in cols})
+        else:
+            expanded[key] = value
+    return expanded
+
+
 class _selector_proxy_(Expr):
     """Base column selector expression/proxy."""
 

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -161,9 +161,14 @@ FrameInitTypes: TypeAlias = Union[
 ]
 
 # Excel IO
+ColumnFormatDict: TypeAlias = Mapping[
+    # dict of colname(s) or selector(s) to format string or dict
+    ColumnNameOrSelector | tuple[ColumnNameOrSelector, ...],
+    str | dict[str, str],
+]
 ConditionalFormatDict: TypeAlias = Mapping[
     # dict of colname(s) to str, dict, or sequence of str/dict
-    Union[str, Collection[str]],
+    Union[ColumnNameOrSelector, Collection[str]],
     Union[str, Union[Mapping[str, Any], Sequence[Union[str, Mapping[str, Any]]]]],
 ]
 ColumnTotalsDefinition: TypeAlias = Union[
@@ -171,6 +176,9 @@ ColumnTotalsDefinition: TypeAlias = Union[
     Mapping[Union[str, Collection[str]], str],
     Sequence[str],
     bool,
+]
+ColumnWidthsDefinition: TypeAlias = Union[
+    dict[ColumnNameOrSelector, Union[tuple[str, ...], int]], int
 ]
 RowTotalsDefinition: TypeAlias = Union[
     # dict of colname to str(s), a collection of str, or a boolean

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -163,8 +163,8 @@ FrameInitTypes: TypeAlias = Union[
 # Excel IO
 ColumnFormatDict: TypeAlias = Mapping[
     # dict of colname(s) or selector(s) to format string or dict
-    ColumnNameOrSelector | tuple[ColumnNameOrSelector, ...],
-    str | dict[str, str],
+    Union[ColumnNameOrSelector, Tuple[ColumnNameOrSelector, ...]],
+    Union[str, Mapping[str, str]],
 ]
 ConditionalFormatDict: TypeAlias = Mapping[
     # dict of colname(s) to str, dict, or sequence of str/dict
@@ -178,7 +178,7 @@ ColumnTotalsDefinition: TypeAlias = Union[
     bool,
 ]
 ColumnWidthsDefinition: TypeAlias = Union[
-    dict[ColumnNameOrSelector, Union[tuple[str, ...], int]], int
+    Mapping[ColumnNameOrSelector, Union[Tuple[str, ...], int]], int
 ]
 RowTotalsDefinition: TypeAlias = Union[
     # dict of colname to str(s), a collection of str, or a boolean

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 import polars as pl
+import polars.selectors as cs
 from polars.exceptions import NoDataError
 from polars.testing import assert_frame_equal
 
@@ -219,7 +220,7 @@ def test_excel_sparklines() -> None:
             worksheet="frame_data",
             table_style="Table Style Light 2",
             dtype_formats={pl.INTEGER_DTYPES: "#,##0_);(#,##0)"},
-            column_formats={("h1", "h2"): "#,##0_);(#,##0)"},
+            column_formats={cs.starts_with("h"): "#,##0_);(#,##0)"},
             sparklines={
                 "trend": ["q1", "q2", "q3", "q4"],
                 "+/-": {
@@ -229,13 +230,13 @@ def test_excel_sparklines() -> None:
                 },
             },
             conditional_formats={
-                ("q1", "q2", "q3", "q4", "h1", "h2"): {
+                cs.starts_with("q", "h"): {
                     "type": "2_color_scale",
                     "min_color": "#95b3d7",
                     "max_color": "#ffffff",
                 }
             },
-            column_widths={("q1", "q2", "q3", "q4", "h1", "h2"): 40},
+            column_widths={cs.starts_with("q", "h"): 40},
             row_totals={
                 "h1": ("q1", "q2"),
                 "h2": ("q3", "q4"),


### PR DESCRIPTION
Continues the recent expansion of selector capabilities in other frame methods, integrating additional support for `write_excel`, specifically with respect to...

* `column_formats`
* `conditional_formats`
* `column_widths`
* `column_totals`
* `row_totals`

## Example

Demonstrates use of selectors (in place of column names) in the updated params:
```python
import polars as pl

df = pl.DataFrame({
    "id": ["aaa", "bbb", "ccc", "ddd", "eee"],
    "q1": [100, 55, -20, 0, 35],
    "q2": [30, -10, 15, 60, 20],
    "q3": [-50, 0, 40, 80, 80],
    "q4": [75, 55, 25, -10, -55],
})

df.write_excel(  
    table_style = "Table Style Medium 23",
    column_formats = {
        cs.starts_with("q"): {"italic": True},
    },
    conditional_formats = {
        cs.starts_with("q"): {
            "type": "2_color_scale",
            "min_color": "#95b3d7",
            "max_color": "#ffffff",
        },
    },
    column_widths = {cs.numeric(): 100},
    column_totals = {cs.numeric(): "sum"},   
)
```
![polars_xl_export](https://github.com/pola-rs/polars/assets/2613171/f9d85675-d644-4e4a-8813-c5012521782d)
