### PR TITLE
refactor(python): deprecate DataFrame.insert_at_idx in favour of DataFrame.insert_at_index and LazyFrame.insert_at_index (which are not in place)

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1093,7 +1093,7 @@ impl DataFrame {
 
     /// Insert a new column at a given index without checking for duplicates.
     /// This can leave the DataFrame at an invalid state
-    fn insert_at_idx_no_name_check(
+    fn insert_at_index_no_name_check(
         &mut self,
         index: usize,
         series: Series,
@@ -1108,14 +1108,14 @@ impl DataFrame {
     }
 
     /// Insert a new column at a given index.
-    pub fn insert_at_idx<S: IntoSeries>(
+    pub fn insert_at_index<S: IntoSeries>(
         &mut self,
         index: usize,
         column: S,
     ) -> PolarsResult<&mut Self> {
         let series = column.into_series();
         self.check_already_present(series.name())?;
-        self.insert_at_idx_no_name_check(index, series)
+        self.insert_at_index_no_name_check(index, series)
     }
 
     fn add_column_by_search(&mut self, series: Series) -> PolarsResult<()> {
@@ -2613,7 +2613,7 @@ impl DataFrame {
 
         let mut summary = concat_df_unchecked(&tmp);
 
-        summary.insert_at_idx(0, Series::new("describe", headers))?;
+        summary.insert_at_index(0, Series::new("describe", headers))?;
 
         Ok(summary)
     }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1030,9 +1030,9 @@ impl PyDataFrame {
         Ok(())
     }
 
-    pub fn insert_at_idx(&mut self, index: usize, new_col: PySeries) -> PyResult<()> {
+    pub fn insert_at_index(&mut self, index: usize, new_col: PySeries) -> PyResult<()> {
         self.df
-            .insert_at_idx(index, new_col.series)
+            .insert_at_index(index, new_col.series)
             .map_err(PyPolarsErr::from)?;
         Ok(())
     }

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import sys
 import textwrap
-from polars.exceptions import DuplicateError
 import typing
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
@@ -18,6 +17,7 @@ from numpy.testing import assert_array_equal, assert_equal
 import polars as pl
 import polars.selectors as cs
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, FLOAT_DTYPES, INTEGER_DTYPES
+from polars.exceptions import DuplicateError
 from polars.testing import (
     assert_frame_equal,
     assert_frame_not_equal,

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -164,7 +164,7 @@ def test_align_frames() -> None:
         (pf1[["a", "b"]] * pf2[["a", "b"]])
         .fill_null(0)
         .select(pl.sum_horizontal("*").alias("dot"))
-        .insert_at_idx(0, pf1["date"])
+        .insert_at_index(0, pf1["date"])
     )
     # confirm we match the same operation in pandas
     assert_frame_equal(pl_dot, pl.from_pandas(pd_dot))

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -881,7 +881,7 @@ def test_init_only_columns() -> None:
                 pl.col("c").cast(pl.Int8),
             ]
         )
-        expected.insert_at_idx(3, pl.Series("d", [], pl.List(pl.UInt8)))
+        expected = expected.insert_at_index(3, pl.Series("d", [], pl.List(pl.UInt8)))
 
         assert df.shape == (0, 4)
         assert_frame_equal(df, expected)


### PR DESCRIPTION
closes #10528 

changes:
- Python: deprecated insert_at_idx in favour of insert_at_index (which isn't inplace), warning about the behaviour change
- Rust: renamed insert_at_idx to insert_at_index as breaking change, to keep it the same as on the Python side


I've not added `LazyFrame.insert_at_index` - it doesn't sound right to insert a `Series` into a `LazyFrame`, right? At least, there's no `replace` for `LazyFrame`