### PR TITLE
chore(python): ensure that `make requirements` fully refreshes unpinned packages/deps

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -17,9 +17,9 @@ endif
 .PHONY: requirements
 requirements: .venv  ## Install/refresh all project requirements
 	$(VENV_BIN)/python -m pip install --upgrade pip
-	$(VENV_BIN)/pip install --upgrade --force-reinstall --no-deps -r requirements-dev.txt
-	$(VENV_BIN)/pip install --upgrade --force-reinstall --no-deps -r requirements-lint.txt
-	$(VENV_BIN)/pip install --upgrade --force-reinstall --no-deps -r docs/requirements-docs.txt
+	$(VENV_BIN)/pip install --upgrade --force-reinstall -r requirements-dev.txt
+	$(VENV_BIN)/pip install --upgrade --force-reinstall -r requirements-lint.txt
+	$(VENV_BIN)/pip install --upgrade --force-reinstall -r docs/requirements-docs.txt
 
 .PHONY: build
 build: .venv  ## Compile and install Polars for development

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -17,9 +17,9 @@ endif
 .PHONY: requirements
 requirements: .venv  ## Install/refresh all project requirements
 	$(VENV_BIN)/python -m pip install --upgrade pip
-	$(VENV_BIN)/pip install -r requirements-dev.txt
-	$(VENV_BIN)/pip install -r requirements-lint.txt
-	$(VENV_BIN)/pip install -r docs/requirements-docs.txt
+	$(VENV_BIN)/pip install --upgrade --force-reinstall --no-deps -r requirements-dev.txt
+	$(VENV_BIN)/pip install --upgrade --force-reinstall --no-deps -r requirements-lint.txt
+	$(VENV_BIN)/pip install --upgrade --force-reinstall --no-deps -r docs/requirements-docs.txt
 
 .PHONY: build
 build: .venv  ## Compile and install Polars for development

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -17,9 +17,9 @@ endif
 .PHONY: requirements
 requirements: .venv  ## Install/refresh all project requirements
 	$(VENV_BIN)/python -m pip install --upgrade pip
-	$(VENV_BIN)/pip install --upgrade --force-reinstall -r requirements-dev.txt
-	$(VENV_BIN)/pip install --upgrade --force-reinstall -r requirements-lint.txt
-	$(VENV_BIN)/pip install --upgrade --force-reinstall -r docs/requirements-docs.txt
+	$(VENV_BIN)/pip install --upgrade -r requirements-dev.txt
+	$(VENV_BIN)/pip install --upgrade -r requirements-lint.txt
+	$(VENV_BIN)/pip install --upgrade -r docs/requirements-docs.txt
 
 .PHONY: build
 build: .venv  ## Compile and install Polars for development


### PR DESCRIPTION
Until running the equivalent commands I was getting some mysterious new typing errors from `pre-commit` checks that a vanilla `make requirements` did not fix. Have confirmed locally that this properly refreshes unpinned packages/deps, ensuring that your local env will match what runs in CI (which does a fresh install).

If preferred, could make this a separate option, say `make requirements-clean`? (Though given that, post initial install, you're likely to _want_ it to be thorough I'm not sure there's any real value in two options - I'd say just make this one robust by default unless there's a compelling reason otherwise 🤔).