### PR TITLE
refactor(python): deprecate DataFrame.replace

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4408,7 +4408,7 @@ class DataFrame:
         --------
         >>> df = pl.DataFrame({"foo": [1, 2, 3], "bar": [4, 5, 6]})
         >>> s = pl.Series([10, 20, 30])
-        >>> df.replace("foo", s)  # works in-place!
+        >>> df.replace("foo", s)  # works in-place!  # doctest: +SKIP
         shape: (3, 2)
         ┌─────┬─────┐
         │ foo ┆ bar │

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -83,6 +83,7 @@ from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr, wrap_ldf, wrap_s
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.deprecation import (
+    deprecate_function,
     deprecate_renamed_methods,
     deprecate_renamed_parameter,
 )
@@ -1033,6 +1034,11 @@ class DataFrame:
         )
         return self
 
+    def _replace(self, column: str, new_column: Series) -> Self:
+        """Replace a column by a new Series (in place)."""
+        self._df.replace(column, new_column._s)
+        return self
+
     @property
     def shape(self) -> tuple[int, int]:
         """
@@ -1701,7 +1707,7 @@ class DataFrame:
                 self.replace_at_idx(col_selection, s)
             # df["foo"]
             elif isinstance(col_selection, str):
-                self.replace(col_selection, s)
+                self._replace(col_selection, s)
         else:
             raise TypeError(
                 f"cannot use `__setitem__` on DataFrame"
@@ -4380,6 +4386,13 @@ class DataFrame:
         """
         return self._df.frame_equal(other._df, null_equal)
 
+    @deprecate_function(
+        "DataFrame.replace is deprecated and will be removed in a future version. "
+        "Please use\n"
+        "    df = df.with_columns(new_column.alias(column_name))\n"
+        "instead.",
+        version="0.19.0",
+    )
     def replace(self, column: str, new_column: Series) -> Self:
         """
         Replace a column by a new Series.
@@ -4408,8 +4421,7 @@ class DataFrame:
         └─────┴─────┘
 
         """
-        self._df.replace(column, new_column._s)
-        return self
+        return self._replace(column, new_column)
 
     def slice(self, offset: int, length: int | None = None) -> Self:
         """

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -511,7 +511,8 @@ def test_sort_maintain_order() -> None:
 def test_replace() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3]})
     s = pl.Series("c", [True, False, True])
-    df.replace("a", s)
+    with pytest.deprecated_call():
+        df.replace("a", s)
     assert_frame_equal(df, pl.DataFrame({"a": [True, False, True], "b": [1, 2, 3]}))
 
 


### PR DESCRIPTION
```python

In [1]:     df = pl.DataFrame({"a": [2, 1, 3], "b": [1, 2, 3]})
   ...:     s = pl.Series("c", [True, False, True])
   ...:     df.replace("a", s)
<ipython-input-1-f6d07799c17b>:3: DeprecationWarning: `replace` is deprecated. DataFrame.replace is deprecated and will be removed in a future version. Please use
    df = df.with_columns(new_column.alias(column_name))
instead.
  df.replace("a", s)
Out[1]: 
shape: (3, 2)
┌───────┬─────┐
│ a     ┆ b   │
│ ---   ┆ --- │
│ bool  ┆ i64 │
╞═══════╪═════╡
│ true  ┆ 1   │
│ false ┆ 2   │
│ true  ┆ 3   │
└───────┴─────┘
```