### PR TITLE
feat(python)!: Remove deprecated behavior from vertical aggregations

### DIFF
--- a/py-polars/polars/functions/aggregation/vertical.py
+++ b/py-polars/polars/functions/aggregation/vertical.py
@@ -1,59 +1,24 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Iterable, overload
+from typing import TYPE_CHECKING
 
-import polars._reexport as pl
 import polars.functions as F
-from polars.utils.deprecation import (
-    deprecate_renamed_parameter,
-    issue_deprecation_warning,
-)
 
 if TYPE_CHECKING:
-    from polars import Expr, Series
-    from polars.type_aliases import IntoExpr, PythonLiteral
+    from polars import Expr
 
 
-@overload
-def all(exprs: Series, *, ignore_nulls: bool = ...) -> bool | None:  # type: ignore[misc]
-    ...
-
-
-@overload
-def all(
-    exprs: IntoExpr | Iterable[IntoExpr] | None = ...,
-    *more_exprs: IntoExpr,
-    ignore_nulls: bool = ...,
-) -> Expr:
-    ...
-
-
-@deprecate_renamed_parameter("columns", "exprs", version="0.18.7")
-def all(
-    exprs: IntoExpr | Iterable[IntoExpr] | None = None,
-    *more_exprs: IntoExpr,
-    ignore_nulls: bool = True,
-) -> Expr | bool | None:
+def all(*names: str, ignore_nulls: bool = True) -> Expr:
     """
     Either return an expression representing all columns, or evaluate a bitwise AND operation.
 
-    If no arguments are passed, this is an alias for ``pl.col("*")``.
-    If a single string is passed, this is an alias for ``pl.col(name).any()``.
-
-    If a single Series is passed, this is an alias for ``Series.any()``.
-    **This functionality is deprecated**.
-
-    Otherwise, this function computes the bitwise AND horizontally across multiple
-    columns.
-    **This functionality is deprecated**, use ``pl.all_horizontal`` instead.
+    If no arguments are passed, this function is syntactic sugar for ``col("*")``.
+    Otherwise, this function is syntactic sugar for ``col(names).all()``.
 
     Parameters
     ----------
-    exprs
-        Column(s) to use in the aggregation. Accepts expression input. Strings are
-        parsed as column names, other non-expression inputs are parsed as literals.
-    *more_exprs
-        Additional columns to use in the aggregation, specified as positional arguments.
+    *names
+        Name(s) of the columns to use in the aggregation.
     ignore_nulls
         Ignore null values (default).
 
@@ -87,7 +52,7 @@ def all(
     │ 2   ┆ 0   │
     └─────┴─────┘
 
-    Evaluate bitwise AND for a column:
+    Evaluate bitwise AND for a column.
 
     >>> df.select(pl.all("a"))
     shape: (1, 1)
@@ -100,53 +65,17 @@ def all(
     └───────┘
 
     """  # noqa: W505
-    if not more_exprs:
-        if exprs is None:
-            return F.col("*")
-        elif isinstance(exprs, pl.Series):
-            issue_deprecation_warning(
-                "passing a Series to `all` is deprecated. Use `Series.all()` instead.",
-                version="0.18.7",
-            )
-            return exprs.all(ignore_nulls=ignore_nulls)
-        elif isinstance(exprs, str):
-            return F.col(exprs).all(ignore_nulls=ignore_nulls)
+    if not names:
+        return F.col("*")
 
-    _warn_for_deprecated_horizontal_use("all")
-    return F.all_horizontal(exprs, *more_exprs)
+    return F.col(*names).all(ignore_nulls=ignore_nulls)
 
 
-@overload
-def any(exprs: Series, *, ignore_nulls: bool = ...) -> bool | None:  # type: ignore[misc]
-    ...
-
-
-@overload
-def any(
-    exprs: IntoExpr | Iterable[IntoExpr],
-    *more_exprs: IntoExpr,
-    ignore_nulls: bool = ...,
-) -> Expr:
-    ...
-
-
-@deprecate_renamed_parameter("columns", "exprs", version="0.18.7")
-def any(
-    exprs: IntoExpr | Iterable[IntoExpr],
-    *more_exprs: IntoExpr,
-    ignore_nulls: bool = True,
-) -> Expr | bool | None:
+def any(*names: str, ignore_nulls: bool = True) -> Expr | bool | None:
     """
     Evaluate a bitwise OR operation.
 
-    If a single string is passed, this is an alias for ``pl.col(name).any()``.
-
-    If a single Series is passed, this is an alias for ``Series.any()``.
-    **This functionality is deprecated**.
-
-    Otherwise, this function computes the bitwise OR horizontally across multiple
-    columns.
-    **This functionality is deprecated**, use ``pl.any_horizontal`` instead.
+    Syntactic sugar for ``col(names).any()``.
 
     See Also
     --------
@@ -154,11 +83,8 @@ def any(
 
     Parameters
     ----------
-    exprs
-        Column(s) to use in the aggregation. Accepts expression input. Strings are
-        parsed as column names, other non-expression inputs are parsed as literals.
-    *more_exprs
-        Additional columns to use in the aggregation, specified as positional arguments.
+    *names
+        Name(s) of the columns to use in the aggregation.
     ignore_nulls
         Ignore null values (default).
 
@@ -187,50 +113,19 @@ def any(
     └──────┘
 
     """
-    if not more_exprs:
-        if isinstance(exprs, pl.Series):
-            issue_deprecation_warning(
-                "passing a Series to `any` is deprecated. Use `Series.any()` instead.",
-                version="0.18.7",
-            )
-            return exprs.any(ignore_nulls=ignore_nulls)
-        elif isinstance(exprs, str):
-            return F.col(exprs).any(ignore_nulls=ignore_nulls)
-
-    _warn_for_deprecated_horizontal_use("any")
-    return F.any_horizontal(exprs, *more_exprs)
+    return F.col(*names).any(ignore_nulls=ignore_nulls)
 
 
-@overload
-def max(exprs: Series) -> PythonLiteral | None:  # type: ignore[misc]
-    ...
-
-
-@overload
-def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
-    ...
-
-
-def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | Any:
+def max(*names: str) -> Expr:
     """
     Get the maximum value.
 
-    If a single string is passed, this is an alias for ``pl.col(name).max()``.
-
-    If a single Series is passed, this is an alias for ``Series.max()``.
-    **This functionality is deprecated**.
-
-    Otherwise, this function computes the maximum value horizontally across multiple
-    columns.
-    **This functionality is deprecated**, use ``pl.max_horizontal`` instead.
+    Syntactic sugar for ``col(names).max()``.
 
     Parameters
     ----------
-    exprs
-        Column(s) to use in the aggregation. Accepts expression input. Strings are
-        parsed as column names, other non-expression inputs are parsed as literals.
-    *more_exprs
-        Additional columns to use in the aggregation, specified as positional arguments.
+    *names
+        Name(s) of the columns to use in the aggregation.
 
     See Also
     --------
@@ -238,7 +133,7 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
 
     Examples
     --------
-    Get the maximum value of a column by passing a single column name.
+    Get the maximum value of a column.
 
     >>> df = pl.DataFrame(
     ...     {
@@ -257,8 +152,7 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
     │ 8   │
     └─────┘
 
-    Get column-wise maximums for multiple columns by passing a regular expression,
-    or call ``.max()`` on a multi-column expression instead.
+    Get the maximum value of multiple columns.
 
     >>> df.select(pl.max("^a|b$"))
     shape: (1, 2)
@@ -269,7 +163,7 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
     ╞═════╪═════╡
     │ 8   ┆ 5   │
     └─────┴─────┘
-    >>> df.select(pl.col("a", "b").max())
+    >>> df.select(pl.max("a", "b"))
     shape: (1, 2)
     ┌─────┬─────┐
     │ a   ┆ b   │
@@ -280,52 +174,19 @@ def max(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr | A
     └─────┴─────┘
 
     """
-    if not more_exprs:
-        if isinstance(exprs, pl.Series):
-            issue_deprecation_warning(
-                "passing a Series to `max` is deprecated. Use `Series.max()` instead.",
-                version="0.18.7",
-            )
-            return exprs.max()
-        elif isinstance(exprs, str):
-            return F.col(exprs).max()
-
-    _warn_for_deprecated_horizontal_use("max")
-    return F.max_horizontal(exprs, *more_exprs)
+    return F.col(*names).max()
 
 
-@overload
-def min(exprs: Series) -> PythonLiteral | None:  # type: ignore[misc]
-    ...
-
-
-@overload
-def min(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
-    ...
-
-
-def min(
-    exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr
-) -> Expr | PythonLiteral | None:
+def min(*names: str) -> Expr:
     """
     Get the minimum value.
 
-    If a single string is passed, this is an alias for ``pl.col(name).min()``.
-
-    If a single Series is passed, this is an alias for ``Series.min()``.
-    **This functionality is deprecated**.
-
-    Otherwise, this function computes the minimum value horizontally across multiple
-    columns.
-    **This functionality is deprecated**, use ``pl.min_horizontal`` instead.
+    Syntactic sugar for ``col(names).min()``.
 
     Parameters
     ----------
-    exprs
-        Column(s) to use in the aggregation. Accepts expression input. Strings are
-        parsed as column names, other non-expression inputs are parsed as literals.
-    *more_exprs
-        Additional columns to use in the aggregation, specified as positional arguments.
+    *names
+        Name(s) of the columns to use in the aggregation.
 
     See Also
     --------
@@ -333,7 +194,7 @@ def min(
 
     Examples
     --------
-    Get the minimum value of a column by passing a single column name.
+    Get the minimum value of a column.
 
     >>> df = pl.DataFrame(
     ...     {
@@ -352,8 +213,7 @@ def min(
     │ 1   │
     └─────┘
 
-    Get column-wise minimums for multiple columns by passing a regular expression,
-    or call ``.min()`` on a multi-column expression instead.
+    Get the minimum value of multiple columns.
 
     >>> df.select(pl.min("^a|b$"))
     shape: (1, 2)
@@ -364,7 +224,7 @@ def min(
     ╞═════╪═════╡
     │ 1   ┆ 2   │
     └─────┴─────┘
-    >>> df.select(pl.col("a", "b").min())
+    >>> df.select(pl.min("a", "b"))
     shape: (1, 2)
     ┌─────┬─────┐
     │ a   ┆ b   │
@@ -375,52 +235,19 @@ def min(
     └─────┴─────┘
 
     """
-    if not more_exprs:
-        if isinstance(exprs, pl.Series):
-            issue_deprecation_warning(
-                "passing a Series to `min` is deprecated. Use `Series.min()` instead.",
-                version="0.18.7",
-            )
-            return exprs.min()
-        elif isinstance(exprs, str):
-            return F.col(exprs).min()
-
-    _warn_for_deprecated_horizontal_use("min")
-    return F.min_horizontal(exprs, *more_exprs)
+    return F.col(*names).min()
 
 
-@overload
-def sum(exprs: Series) -> int | float:  # type: ignore[misc]
-    ...
-
-
-@overload
-def sum(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
-    ...
-
-
-@deprecate_renamed_parameter("column", "exprs", version="0.18.7")
-def sum(
-    exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr
-) -> Expr | int | float:
+def sum(*names: str) -> Expr:
     """
     Sum all values.
 
-    If a single string is passed, this is an alias for ``pl.col(name).sum()``.
-
-    If a single Series is passed, this is an alias for ``Series.sum()``.
-    **This functionality is deprecated**.
-
-    Otherwise, this function computes the sum horizontally across multiple columns.
-    **This functionality is deprecated**, use ``pl.sum_horizontal`` instead.
+    Syntactic sugar for ``col(name).sum()``.
 
     Parameters
     ----------
-    exprs
-        Column(s) to use in the aggregation. Accepts expression input. Strings are
-        parsed as column names, other non-expression inputs are parsed as literals.
-    *more_exprs
-        Additional columns to use in the aggregation, specified as positional arguments.
+    *names
+        Name(s) of the columns to use in the aggregation.
 
     See Also
     --------
@@ -428,7 +255,7 @@ def sum(
 
     Examples
     --------
-    Sum a column by name:
+    Sum a column.
 
     >>> df = pl.DataFrame(
     ...     {
@@ -447,10 +274,9 @@ def sum(
     │ 3   │
     └─────┘
 
-    To aggregate the sums for more than one column/expression use ``pl.col(list).sum()``
-    or a regular expression selector like ``pl.sum(regex)``:
+    Sum multiple columns.
 
-    >>> df.select(pl.col("a", "c").sum())
+    >>> df.select(pl.sum("a", "c"))
     shape: (1, 2)
     ┌─────┬─────┐
     │ a   ┆ c   │
@@ -459,7 +285,6 @@ def sum(
     ╞═════╪═════╡
     │ 3   ┆ 11  │
     └─────┴─────┘
-
     >>> df.select(pl.sum("^.*[bc]$"))
     shape: (1, 2)
     ┌─────┬─────┐
@@ -471,53 +296,19 @@ def sum(
     └─────┴─────┘
 
     """
-    if not more_exprs:
-        if isinstance(exprs, pl.Series):
-            issue_deprecation_warning(
-                "passing a Series to `sum` is deprecated. Use `Series.sum()` instead.",
-                version="0.18.7",
-            )
-            return exprs.sum()
-        elif isinstance(exprs, str):
-            return F.col(exprs).sum()
-
-    _warn_for_deprecated_horizontal_use("sum")
-    return F.sum_horizontal(exprs, *more_exprs)
+    return F.col(*names).sum()
 
 
-@overload
-def cumsum(exprs: Series) -> Series:  # type: ignore[misc]
-    ...
-
-
-@overload
-def cumsum(exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr) -> Expr:
-    ...
-
-
-@deprecate_renamed_parameter("column", "exprs", version="0.18.7")
-def cumsum(
-    exprs: IntoExpr | Iterable[IntoExpr], *more_exprs: IntoExpr
-) -> Expr | Series:
+def cumsum(*names: str) -> Expr:
     """
     Cumulatively sum all values.
 
-    If a single string is passed, this is an alias for ``pl.col(name).cumsum()``.
-
-    If a single Series is passed, this is an alias for ``Series.cumsum()``.
-    **This functionality is deprecated**.
-
-    Otherwise, this function computes the cumulative sum horizontally across multiple
-    columns.
-    **This functionality is deprecated**, use ``pl.cumsum_horizontal`` instead.
+    Syntactic sugar for ``col(names).cumsum()``.
 
     Parameters
     ----------
-    exprs
-        Column(s) to use in the aggregation. Accepts expression input. Strings are
-        parsed as column names, other non-expression inputs are parsed as literals.
-    *more_exprs
-        Additional columns to use in the aggregation, specified as positional arguments.
+    *names
+        Name(s) of the columns to use in the aggregation.
 
     See Also
     --------
@@ -544,22 +335,4 @@ def cumsum(
     └─────┘
 
     """
-    if not more_exprs:
-        if isinstance(exprs, pl.Series):
-            issue_deprecation_warning(
-                "passing a Series to `cumsum` is deprecated. Use `Series.cumsum()` instead.",
-                version="0.18.7",
-            )
-            return exprs.cumsum()
-        elif isinstance(exprs, str):
-            return F.col(exprs).cumsum()
-
-    _warn_for_deprecated_horizontal_use("cumsum")
-    return F.cumsum_horizontal(exprs, *more_exprs)
-
-
-def _warn_for_deprecated_horizontal_use(name: str) -> None:
-    issue_deprecation_warning(
-        f"using `{name}` for horizontal computation is deprecated. Use `{name}_horizontal` instead.",
-        version="0.18.7",
-    )
+    return F.col(*names).cumsum()

--- a/py-polars/tests/unit/functions/aggregation/test_vertical.py
+++ b/py-polars/tests/unit/functions/aggregation/test_vertical.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 import polars as pl
-from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing import assert_frame_equal
 
 
 def assert_expr_equal(
@@ -55,35 +55,3 @@ def test_alias_for_col_agg(function: str, input: str) -> None:
     expected = getattr(pl.col(input), function)()  # e.g. pl.col(input).min()
     context = pl.DataFrame({"a": [1, 4], "b": [3, 2]})
     assert_expr_equal(result, expected, context)
-
-
-@pytest.mark.parametrize("function", ["all", "any"])
-def test_deprecated_alias_for_series_agg_bool(function: str) -> None:
-    s = pl.Series([True, True, False])
-    with pytest.deprecated_call():
-        result = getattr(pl, function)(s)  # e.g. pl.all(s)
-    expected = getattr(s, function)()  # e.g. s.all()
-    assert result == expected
-
-
-@pytest.mark.parametrize("function", ["min", "max", "sum"])
-def test_deprecated_alias_for_series_agg_numeric(function: str) -> None:
-    s = pl.Series([1, 2, 3])
-    with pytest.deprecated_call():
-        result = getattr(pl, function)(s)  # e.g. pl.max(s)
-    expected = getattr(s, function)()  # e.g. s.max()
-    assert result == expected
-
-
-def test_deprecated_alias_for_series_agg_cumsum() -> None:
-    s = pl.Series([1, 2, 3])
-    with pytest.deprecated_call():
-        result = pl.cumsum(s)
-    expected = s.cumsum()
-    assert_series_equal(result, expected)
-
-
-@pytest.mark.parametrize("function", ["all", "any", "min", "max", "sum", "cumsum"])
-def test_deprecated_horizontal(function: str) -> None:
-    with pytest.deprecated_call():
-        getattr(pl, function)(pl.col("a"))  # e.g. pl.all(pl.col("a"))

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -373,44 +373,43 @@ def test_lazy_functions() -> None:
     )
     expected = 1.0
     assert np.isclose(out.to_series(0), expected)
-    with pytest.deprecated_call():
-        assert np.isclose(pl.var(df["b"]), expected)  # type: ignore[arg-type]
+    assert np.isclose(df["b"].var(), expected)  # type: ignore[arg-type]
+
     expected = 1.0
     assert np.isclose(out.to_series(1), expected)
-    with pytest.deprecated_call():
-        assert np.isclose(pl.std(df["b"]), expected)  # type: ignore[arg-type]
+    assert np.isclose(df["b"].std(), expected)  # type: ignore[arg-type]
+
     expected = 3
     assert np.isclose(out.to_series(2), expected)
-    with pytest.deprecated_call():
-        assert np.isclose(pl.max(df["b"]), expected)  # type: ignore[arg-type]
+    assert np.isclose(df["b"].max(), expected)  # type: ignore[arg-type]
+
     expected = 1
     assert np.isclose(out.to_series(3), expected)
-    with pytest.deprecated_call():
-        assert np.isclose(pl.min(df["b"]), expected)  # type: ignore[arg-type]
+    assert np.isclose(df["b"].min(), expected)  # type: ignore[arg-type]
+
     expected = 6
     assert np.isclose(out.to_series(4), expected)
-    with pytest.deprecated_call():
-        assert np.isclose(pl.sum(df["b"]), expected)
+    assert np.isclose(df["b"].sum(), expected)
+
     expected = 2
     assert np.isclose(out.to_series(5), expected)
-    with pytest.deprecated_call():
-        assert np.isclose(pl.mean(df["b"]), expected)
+    assert np.isclose(df["b"].mean(), expected)  # type: ignore[arg-type]
+
     expected = 2
     assert np.isclose(out.to_series(6), expected)
-    with pytest.deprecated_call():
-        assert np.isclose(pl.median(df["b"]), expected)
+    assert np.isclose(df["b"].median(), expected)  # type: ignore[arg-type]
+
     expected = 3
     assert np.isclose(out.to_series(7), expected)
-    with pytest.deprecated_call():
-        assert np.isclose(pl.n_unique(df["b"]), expected)
+    assert np.isclose(df["b"].n_unique(), expected)
+
     expected = 1
     assert np.isclose(out.to_series(8), expected)
-    with pytest.deprecated_call():
-        assert np.isclose(pl.first(df["b"]), expected)
+    assert np.isclose(df["b"][0], expected)
+
     expected = 3
     assert np.isclose(out.to_series(9), expected)
-    with pytest.deprecated_call():
-        assert np.isclose(pl.last(df["b"]), expected)
+    assert np.isclose(df["b"][-1], expected)
 
     # regex selection
     out = df.select(


### PR DESCRIPTION
Not sure if this should be merged yet - it's quite widely used functionality, and it was only deprecated on `0.18.7`. Let's leave this for `1.0`?

#### Changes
* Remove overloaded functionality for `any`, `all`, `min`, `max`, `sum`, `cumsum`
  * No longer accepts `Series` input
  * No longer calculates a horizontal aggregation when given multiple inputs