### PR TITLE
refactor(rust): make binary chunkedarray functions DRY

### DIFF
--- a/crates/polars-core/src/chunked_array/arithmetic/decimal.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/decimal.rs
@@ -2,7 +2,7 @@ use polars_arrow::compute::arithmetics::decimal;
 
 use super::*;
 use crate::prelude::DecimalChunked;
-use crate::utils::{align_chunks_binary};
+use crate::utils::align_chunks_binary;
 
 // TODO: remove
 impl ArrayArithmetics for i128 {

--- a/crates/polars-core/src/chunked_array/arithmetic/decimal.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/decimal.rs
@@ -2,6 +2,7 @@ use polars_arrow::compute::arithmetics::decimal;
 
 use super::*;
 use crate::prelude::DecimalChunked;
+use crate::utils::{align_chunks_binary};
 
 // TODO: remove
 impl ArrayArithmetics for i128 {

--- a/crates/polars-core/src/chunked_array/arithmetic/mod.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/mod.rs
@@ -15,7 +15,7 @@ use polars_arrow::utils::combine_validities_and;
 
 use crate::prelude::*;
 use crate::series::IsSorted;
-use crate::utils::{align_chunks_binary, align_chunks_binary_owned};
+use crate::utils::{align_chunks_binary_owned};
 
 pub trait ArrayArithmetics
 where
@@ -148,12 +148,7 @@ impl Add for &BinaryChunked {
             };
         }
 
-        let (lhs, rhs) = align_chunks_binary(self, rhs);
-        let chunks = lhs
-            .downcast_iter()
-            .zip(rhs.downcast_iter())
-            .map(|(a, b)| concat_binary(a, b));
-        ChunkedArray::from_chunk_iter(self.name(), chunks)
+        arity::binary_mut(self, rhs, concat_binary)
     }
 }
 
@@ -202,12 +197,7 @@ impl Add for &BooleanChunked {
         if self.len() == 1 {
             return rhs.add(self);
         }
-        let (lhs, rhs) = align_chunks_binary(self, rhs);
-        let chunks = lhs
-            .downcast_iter()
-            .zip(rhs.downcast_iter())
-            .map(|(a, b)| add_boolean(a, b));
-        ChunkedArray::from_chunk_iter(self.name(), chunks)
+        arity::binary_mut(self, rhs, add_boolean)
     }
 }
 

--- a/crates/polars-core/src/chunked_array/arithmetic/mod.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/mod.rs
@@ -15,7 +15,7 @@ use polars_arrow::utils::combine_validities_and;
 
 use crate::prelude::*;
 use crate::series::IsSorted;
-use crate::utils::{align_chunks_binary_owned};
+use crate::utils::align_chunks_binary_owned;
 
 pub trait ArrayArithmetics
 where

--- a/crates/polars-core/src/chunked_array/arithmetic/numeric.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/numeric.rs
@@ -12,15 +12,7 @@ where
     F: Fn(T::Native, T::Native) -> T::Native,
 {
     let mut ca = match (lhs.len(), rhs.len()) {
-        (a, b) if a == b => {
-            let (lhs, rhs) = align_chunks_binary(lhs, rhs);
-            let chunks = lhs
-                .downcast_iter()
-                .zip(rhs.downcast_iter())
-                .map(|(lhs, rhs)| Box::new(kernel(lhs, rhs)) as ArrayRef)
-                .collect();
-            unsafe { lhs.copy_with_chunks(chunks, false, false) }
-        },
+        (a, b) if a == b => arity::binary_mut(lhs, rhs, |lhs, rhs| kernel(lhs, rhs)),
         // broadcast right path
         (_, 1) => {
             let opt_rhs = rhs.get(0);

--- a/crates/polars-core/src/chunked_array/bitwise.rs
+++ b/crates/polars-core/src/chunked_array/bitwise.rs
@@ -6,7 +6,6 @@ use polars_arrow::utils::combine_validities_and;
 
 use super::arithmetic::arithmetic_helper;
 use super::*;
-use crate::utils::align_chunks_binary;
 
 impl<T> BitAnd for &ChunkedArray<T>
 where
@@ -73,12 +72,7 @@ impl BitOr for &BooleanChunked {
             _ => {},
         }
 
-        let (lhs, rhs) = align_chunks_binary(self, rhs);
-        let chunks = lhs
-            .downcast_iter()
-            .zip(rhs.downcast_iter())
-            .map(|(lhs, rhs)| compute::boolean_kleene::or(lhs, rhs));
-        BooleanChunked::from_chunk_iter(self.name(), chunks)
+        arity::binary_mut(self, rhs, compute::boolean_kleene::or)
     }
 }
 
@@ -123,16 +117,11 @@ impl BitXor for &BooleanChunked {
             _ => {},
         }
 
-        let (l, r) = align_chunks_binary(self, rhs);
-        let chunks = l
-            .downcast_iter()
-            .zip(r.downcast_iter())
-            .map(|(l_arr, r_arr)| {
-                let validity = combine_validities_and(l_arr.validity(), r_arr.validity());
-                let values = l_arr.values() ^ r_arr.values();
-                BooleanArray::from_data_default(values, validity)
-            });
-        ChunkedArray::from_chunk_iter(self.name(), chunks)
+        arity::binary_mut(self, rhs, |l_arr, r_arr| {
+            let validity = combine_validities_and(l_arr.validity(), r_arr.validity());
+            let values = l_arr.values() ^ r_arr.values();
+            BooleanArray::from_data_default(values, validity)
+        })
     }
 }
 
@@ -169,12 +158,7 @@ impl BitAnd for &BooleanChunked {
             _ => {},
         }
 
-        let (lhs, rhs) = align_chunks_binary(self, rhs);
-        let chunks = lhs
-            .downcast_iter()
-            .zip(rhs.downcast_iter())
-            .map(|(lhs, rhs)| compute::boolean_kleene::and(lhs, rhs));
-        BooleanChunked::from_chunk_iter(self.name(), chunks)
+        arity::binary_mut(self, rhs, compute::boolean_kleene::and)
     }
 }
 

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -21,7 +21,7 @@ where
 {
     // Also includes validity in comparison.
     pub fn not_equal_and_validity(&self, rhs: &ChunkedArray<T>) -> BooleanChunked {
-        arity::binary_mut(self, rhs, |a, b| comparison::neq_and_validity(a, b))
+        arity::binary_mut_with_options(self, rhs, |a, b| comparison::neq_and_validity(a, b), "")
     }
 }
 
@@ -48,7 +48,7 @@ where
                     BooleanChunked::full_null("", rhs.len())
                 }
             },
-            _ => arity::binary_mut(self, rhs, |a, b| comparison::eq(a, b)),
+            _ => arity::binary_mut_with_options(self, rhs, |a, b| comparison::eq(a, b), ""),
         }
     }
 
@@ -69,7 +69,12 @@ where
                     rhs.is_null()
                 }
             },
-            _ => arity::binary_mut(self, rhs, |a, b| comparison::eq_and_validity(a, b)),
+            _ => arity::binary_mut_with_options(
+                self,
+                rhs,
+                |a, b| comparison::eq_and_validity(a, b),
+                "",
+            ),
         }
     }
 
@@ -90,7 +95,7 @@ where
                     BooleanChunked::full_null("", rhs.len())
                 }
             },
-            _ => arity::binary_mut(self, rhs, |a, b| comparison::neq(a, b)),
+            _ => arity::binary_mut_with_options(self, rhs, |a, b| comparison::neq(a, b), ""),
         }
     }
 
@@ -111,7 +116,12 @@ where
                     rhs.is_not_null()
                 }
             },
-            _ => arity::binary_mut(self, rhs, |a, b| comparison::neq_and_validity(a, b)),
+            _ => arity::binary_mut_with_options(
+                self,
+                rhs,
+                |a, b| comparison::neq_and_validity(a, b),
+                "",
+            ),
         }
     }
 
@@ -132,7 +142,7 @@ where
                     BooleanChunked::full_null("", rhs.len())
                 }
             },
-            _ => arity::binary_mut(self, rhs, |a, b| comparison::gt(a, b)),
+            _ => arity::binary_mut_with_options(self, rhs, |a, b| comparison::gt(a, b), ""),
         }
     }
 
@@ -153,7 +163,7 @@ where
                     BooleanChunked::full_null("", rhs.len())
                 }
             },
-            _ => arity::binary_mut(self, rhs, |a, b| comparison::gt_eq(a, b)),
+            _ => arity::binary_mut_with_options(self, rhs, |a, b| comparison::gt_eq(a, b), ""),
         }
     }
 
@@ -174,7 +184,7 @@ where
                     BooleanChunked::full_null("", rhs.len())
                 }
             },
-            _ => arity::binary_mut(self, rhs, |a, b| comparison::lt(a, b)),
+            _ => arity::binary_mut_with_options(self, rhs, |a, b| comparison::lt(a, b), ""),
         }
     }
 
@@ -195,7 +205,7 @@ where
                     BooleanChunked::full_null("", rhs.len())
                 }
             },
-            _ => arity::binary_mut(self, rhs, |a, b| comparison::lt_eq(a, b)),
+            _ => arity::binary_mut_with_options(self, rhs, |a, b| comparison::lt_eq(a, b), ""),
         }
     }
 }
@@ -218,7 +228,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 }
             },
             (1, _) => rhs.equal(self),
-            _ => arity::binary_mut(self, rhs, |lhs, rhs| comparison::eq(lhs, rhs)),
+            _ => arity::binary_mut_with_options(self, rhs, |lhs, rhs| comparison::eq(lhs, rhs), ""),
         }
     }
 
@@ -257,7 +267,12 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 }
             },
             (1, _) => rhs.equal_missing(self),
-            _ => arity::binary_mut(self, rhs, |lhs, rhs| comparison::eq_and_validity(lhs, rhs)),
+            _ => arity::binary_mut_with_options(
+                self,
+                rhs,
+                |lhs, rhs| comparison::eq_and_validity(lhs, rhs),
+                "",
+            ),
         }
     }
 
@@ -276,7 +291,9 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 }
             },
             (1, _) => rhs.not_equal(self),
-            _ => arity::binary_mut(self, rhs, |lhs, rhs| comparison::neq(lhs, rhs)),
+            _ => {
+                arity::binary_mut_with_options(self, rhs, |lhs, rhs| comparison::neq(lhs, rhs), "")
+            },
         }
     }
 
@@ -309,7 +326,12 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                 }
             },
             (1, _) => rhs.not_equal_missing(self),
-            _ => arity::binary_mut(self, rhs, |lhs, rhs| comparison::neq_and_validity(lhs, rhs)),
+            _ => arity::binary_mut_with_options(
+                self,
+                rhs,
+                |lhs, rhs| comparison::neq_and_validity(lhs, rhs),
+                "",
+            ),
         }
     }
 
@@ -336,7 +358,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                     BooleanChunked::full_null("", rhs.len())
                 }
             },
-            _ => arity::binary_mut(self, rhs, |lhs, rhs| comparison::gt(lhs, rhs)),
+            _ => arity::binary_mut_with_options(self, rhs, |lhs, rhs| comparison::gt(lhs, rhs), ""),
         }
     }
 
@@ -363,7 +385,12 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                     BooleanChunked::full_null("", rhs.len())
                 }
             },
-            _ => arity::binary_mut(self, rhs, |lhs, rhs| comparison::gt_eq(lhs, rhs)),
+            _ => arity::binary_mut_with_options(
+                self,
+                rhs,
+                |lhs, rhs| comparison::gt_eq(lhs, rhs),
+                "",
+            ),
         }
     }
 
@@ -390,7 +417,7 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                     BooleanChunked::full_null("", rhs.len())
                 }
             },
-            _ => arity::binary_mut(self, rhs, |lhs, rhs| comparison::lt(lhs, rhs)),
+            _ => arity::binary_mut_with_options(self, rhs, |lhs, rhs| comparison::lt(lhs, rhs), ""),
         }
     }
 
@@ -417,7 +444,12 @@ impl ChunkCompare<&BooleanChunked> for BooleanChunked {
                     BooleanChunked::full_null("", rhs.len())
                 }
             },
-            _ => arity::binary_mut(self, rhs, |lhs, rhs| comparison::lt_eq(lhs, rhs)),
+            _ => arity::binary_mut_with_options(
+                self,
+                rhs,
+                |lhs, rhs| comparison::lt_eq(lhs, rhs),
+                "",
+            ),
         }
     }
 }
@@ -475,7 +507,7 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 BooleanChunked::full_null("", rhs.len())
             }
         } else {
-            arity::binary_mut(self, rhs, comparison::binary::eq)
+            arity::binary_mut_with_options(self, rhs, comparison::binary::eq, "")
         }
     }
 
@@ -494,7 +526,7 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 rhs.is_null()
             }
         } else {
-            arity::binary_mut(self, rhs, comparison::binary::eq_and_validity)
+            arity::binary_mut_with_options(self, rhs, comparison::binary::eq_and_validity, "")
         }
     }
 
@@ -513,7 +545,7 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 BooleanChunked::full_null("", rhs.len())
             }
         } else {
-            arity::binary_mut(self, rhs, comparison::binary::neq)
+            arity::binary_mut_with_options(self, rhs, comparison::binary::neq, "")
         }
     }
 
@@ -532,7 +564,7 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 rhs.is_not_null()
             }
         } else {
-            arity::binary_mut(self, rhs, comparison::binary::neq_and_validity)
+            arity::binary_mut_with_options(self, rhs, comparison::binary::neq_and_validity, "")
         }
     }
 
@@ -551,7 +583,7 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 BooleanChunked::full_null("", self.len())
             }
         } else {
-            arity::binary_mut(self, rhs, comparison::binary::gt)
+            arity::binary_mut_with_options(self, rhs, comparison::binary::gt, "")
         }
     }
 
@@ -570,7 +602,7 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 BooleanChunked::full_null("", self.len())
             }
         } else {
-            arity::binary_mut(self, rhs, comparison::binary::gt_eq)
+            arity::binary_mut_with_options(self, rhs, comparison::binary::gt_eq, "")
         }
     }
 
@@ -589,7 +621,7 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 BooleanChunked::full_null("", self.len())
             }
         } else {
-            arity::binary_mut(self, rhs, comparison::binary::lt)
+            arity::binary_mut_with_options(self, rhs, comparison::binary::lt, "")
         }
     }
 
@@ -608,7 +640,7 @@ impl ChunkCompare<&BinaryChunked> for BinaryChunked {
                 BooleanChunked::full_null("", self.len())
             }
         } else {
-            arity::binary_mut(self, rhs, comparison::binary::lt_eq)
+            arity::binary_mut_with_options(self, rhs, comparison::binary::lt_eq, "")
         }
     }
 }
@@ -789,10 +821,11 @@ impl ChunkCompare<&StructChunked> for StructChunked {
 impl ChunkCompare<&ArrayChunked> for ArrayChunked {
     type Item = BooleanChunked;
     fn equal(&self, rhs: &ArrayChunked) -> BooleanChunked {
-        arity::binary_mut(
+        arity::binary_mut_with_options(
             self,
             rhs,
             polars_arrow::kernels::comparison::fixed_size_list_eq,
+            "",
         )
     }
 
@@ -802,10 +835,11 @@ impl ChunkCompare<&ArrayChunked> for ArrayChunked {
     }
 
     fn not_equal(&self, rhs: &ArrayChunked) -> BooleanChunked {
-        arity::binary_mut(
+        arity::binary_mut_with_options(
             self,
             rhs,
             polars_arrow::kernels::comparison::fixed_size_list_neq,
+            "",
         )
     }
 

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -13,7 +13,7 @@ use crate::prelude::*;
 use crate::series::IsSorted;
 use crate::utils::{CustomIterTools, NoNull};
 
-fn collect_array<T: NativeType, I: TrustedLen<Item = T>>(
+pub(super) fn collect_array<T: NativeType, I: TrustedLen<Item = T>>(
     iter: I,
     validity: Option<Bitmap>,
 ) -> PrimitiveArray<T> {

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -41,10 +41,11 @@ where
 }
 
 /// Applies a kernel that produces `Array` types.
-pub fn binary_mut<T, U, V, F, Arr>(
+pub fn binary_mut_with_options<T, U, V, F, Arr>(
     lhs: &ChunkedArray<T>,
     rhs: &ChunkedArray<U>,
     mut op: F,
+    name: &str,
 ) -> ChunkedArray<V>
 where
     T: PolarsDataType,
@@ -63,7 +64,28 @@ where
         .downcast_iter()
         .zip(rhs.downcast_iter())
         .map(|(lhs_arr, rhs_arr)| op(lhs_arr, rhs_arr));
-    ChunkedArray::from_chunk_iter(lhs.name(), iter)
+    ChunkedArray::from_chunk_iter(name, iter)
+}
+
+/// Applies a kernel that produces `Array` types.
+pub fn binary_mut<T, U, V, F, Arr>(
+    lhs: &ChunkedArray<T>,
+    rhs: &ChunkedArray<U>,
+    op: F,
+) -> ChunkedArray<V>
+where
+    T: PolarsDataType,
+    U: PolarsDataType,
+    V: PolarsDataType,
+    ChunkedArray<T>: HasUnderlyingArray,
+    ChunkedArray<U>: HasUnderlyingArray,
+    Arr: Array + StaticallyMatchesPolarsType<V>,
+    F: FnMut(
+        &<ChunkedArray<T> as HasUnderlyingArray>::ArrayT,
+        &<ChunkedArray<U> as HasUnderlyingArray>::ArrayT,
+    ) -> Arr,
+{
+    binary_mut_with_options(lhs, rhs, op, lhs.name())
 }
 
 /// Applies a kernel that produces `ArrayRef` of the same type.

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -1,0 +1,61 @@
+use arrow::array::Array;
+
+use crate::datatypes::{HasUnderlyingArray, StaticallyMatchesPolarsType};
+use crate::prelude::{ChunkedArray, PolarsDataType};
+use crate::utils::align_chunks_binary;
+
+/// Applies a kernel that produces `Array` types.
+pub fn binary_mut<T, U, V, F, Arr>(
+    lhs: &ChunkedArray<T>,
+    rhs: &ChunkedArray<U>,
+    mut op: F,
+) -> ChunkedArray<V>
+where
+    T: PolarsDataType,
+    U: PolarsDataType,
+    V: PolarsDataType,
+    ChunkedArray<T>: HasUnderlyingArray,
+    ChunkedArray<U>: HasUnderlyingArray,
+    Arr: Array + StaticallyMatchesPolarsType<V>,
+    F: FnMut(
+        &<ChunkedArray<T> as HasUnderlyingArray>::ArrayT,
+        &<ChunkedArray<U> as HasUnderlyingArray>::ArrayT,
+    ) -> Arr,
+{
+    let (lhs, rhs) = align_chunks_binary(lhs, rhs);
+    let iter = lhs
+        .downcast_iter()
+        .zip(rhs.downcast_iter())
+        .map(|(lhs_arr, rhs_arr)| op(lhs_arr, rhs_arr));
+    ChunkedArray::from_chunk_iter(lhs.name(), iter)
+}
+
+/// Applies a kernel that produces `ArrayRef` of the same type.
+///
+/// # Safety
+/// Caller must ensure that the returned `ArrayRef` belongs to `T: PolarsDataType`.
+pub unsafe fn binary_mut_unchecked_same_type<T, U, F>(
+    lhs: &ChunkedArray<T>,
+    rhs: &ChunkedArray<U>,
+    mut op: F,
+    keep_sorted: bool,
+    keep_fast_explode: bool,
+) -> ChunkedArray<T>
+where
+    T: PolarsDataType,
+    U: PolarsDataType,
+    ChunkedArray<T>: HasUnderlyingArray,
+    ChunkedArray<U>: HasUnderlyingArray,
+    F: FnMut(
+        &<ChunkedArray<T> as HasUnderlyingArray>::ArrayT,
+        &<ChunkedArray<U> as HasUnderlyingArray>::ArrayT,
+    ) -> Box<dyn Array>,
+{
+    let (lhs, rhs) = align_chunks_binary(lhs, rhs);
+    let chunks = lhs
+        .downcast_iter()
+        .zip(rhs.downcast_iter())
+        .map(|(lhs_arr, rhs_arr)| op(lhs_arr, rhs_arr))
+        .collect();
+    lhs.copy_with_chunks(chunks, keep_sorted, keep_fast_explode)
+}

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -1,8 +1,44 @@
 use arrow::array::Array;
+use polars_arrow::utils::combine_validities_and;
 
-use crate::datatypes::{HasUnderlyingArray, StaticallyMatchesPolarsType};
+use crate::chunked_array::ops::apply::collect_array;
+use crate::datatypes::{
+    HasUnderlyingArray, PolarsNumericType, StaticArray, StaticallyMatchesPolarsType,
+};
 use crate::prelude::{ChunkedArray, PolarsDataType};
 use crate::utils::align_chunks_binary;
+
+pub fn binary_elementwise_values<T, U, V, F>(
+    lhs: &ChunkedArray<T>,
+    rhs: &ChunkedArray<U>,
+    mut op: F,
+) -> ChunkedArray<V>
+where
+    T: PolarsDataType,
+    U: PolarsDataType,
+    V: PolarsNumericType,
+    ChunkedArray<T>: HasUnderlyingArray,
+    ChunkedArray<U>: HasUnderlyingArray,
+    F: for<'a> FnMut(
+        <<ChunkedArray<T> as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>,
+        <<ChunkedArray<U> as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>,
+    ) -> V::Native,
+{
+    let (lhs, rhs) = align_chunks_binary(lhs, rhs);
+    let iter = lhs
+        .downcast_iter()
+        .zip(rhs.downcast_iter())
+        .map(|(lhs_arr, rhs_arr)| {
+            let validity = combine_validities_and(lhs_arr.validity(), rhs_arr.validity());
+
+            let iter = lhs_arr
+                .values_iter()
+                .zip(rhs_arr.values_iter())
+                .map(|(lhs_val, rhs_val)| op(lhs_val, rhs_val));
+            collect_array(iter, validity)
+        });
+    ChunkedArray::from_chunk_iter(lhs.name(), iter)
+}
 
 /// Applies a kernel that produces `Array` types.
 pub fn binary_mut<T, U, V, F, Arr>(

--- a/crates/polars-core/src/chunked_array/ops/downcast.rs
+++ b/crates/polars-core/src/chunked_array/ops/downcast.rs
@@ -18,6 +18,7 @@ impl<'a, T> Chunks<'a, T> {
         }
     }
 
+    #[inline]
     pub fn get(&self, index: usize) -> Option<&'a T> {
         self.chunks.get(index).map(|arr| {
             let arr = &**arr;
@@ -25,6 +26,7 @@ impl<'a, T> Chunks<'a, T> {
         })
     }
 
+    #[inline]
     pub unsafe fn get_unchecked(&self, index: usize) -> &'a T {
         let arr = self.chunks.get_unchecked(index);
         let arr = &**arr;
@@ -35,6 +37,7 @@ impl<'a, T> Chunks<'a, T> {
         self.chunks.len()
     }
 
+    #[inline]
     pub fn last(&self) -> Option<&'a T> {
         self.chunks.last().map(|arr| {
             let arr = &**arr;
@@ -48,6 +51,7 @@ impl<T: PolarsDataType> ChunkedArray<T>
 where
     Self: HasUnderlyingArray,
 {
+    #[inline]
     pub fn downcast_iter(
         &self,
     ) -> impl Iterator<Item = &<Self as HasUnderlyingArray>::ArrayT> + DoubleEndedIterator {
@@ -62,6 +66,7 @@ where
     /// The caller must ensure:
     ///     * the length remains correct.
     ///     * the flags (sorted, etc) remain correct.
+    #[inline]
     pub unsafe fn downcast_iter_mut(
         &mut self,
     ) -> impl Iterator<Item = &mut <Self as HasUnderlyingArray>::ArrayT> + DoubleEndedIterator {
@@ -72,6 +77,7 @@ where
         })
     }
 
+    #[inline]
     pub fn downcast_chunks(&self) -> Chunks<'_, <Self as HasUnderlyingArray>::ArrayT> {
         Chunks::new(&self.chunks)
     }

--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -5,7 +5,6 @@ use arrow::compute::filter::filter as filter_fn;
 #[cfg(feature = "object")]
 use crate::chunked_array::object::builder::ObjectChunkedBuilder;
 use crate::prelude::*;
-use crate::utils::align_chunks_binary;
 
 macro_rules! check_filter_len {
     ($self:expr, $filter:expr) => {{
@@ -30,14 +29,15 @@ where
             };
         }
         check_filter_len!(self, filter);
-        let (left, filter) = align_chunks_binary(self, filter);
-
-        let chunks = left
-            .downcast_iter()
-            .zip(filter.downcast_iter())
-            .map(|(left, mask)| filter_fn(left, mask).unwrap())
-            .collect::<Vec<_>>();
-        unsafe { Ok(self.copy_with_chunks(chunks, true, true)) }
+        Ok(unsafe {
+            arity::binary_mut_unchecked_same_type(
+                self,
+                filter,
+                |left, mask| filter_fn(left, mask).unwrap(),
+                true,
+                true,
+            )
+        })
     }
 }
 
@@ -51,14 +51,15 @@ impl ChunkFilter<BooleanType> for BooleanChunked {
             };
         }
         check_filter_len!(self, filter);
-        let (left, filter) = align_chunks_binary(self, filter);
-
-        let chunks = left
-            .downcast_iter()
-            .zip(filter.downcast_iter())
-            .map(|(left, mask)| filter_fn(left, mask).unwrap())
-            .collect::<Vec<_>>();
-        unsafe { Ok(self.copy_with_chunks(chunks, true, true)) }
+        Ok(unsafe {
+            arity::binary_mut_unchecked_same_type(
+                self,
+                filter,
+                |left, mask| filter_fn(left, mask).unwrap(),
+                true,
+                true,
+            )
+        })
     }
 }
 
@@ -79,15 +80,15 @@ impl ChunkFilter<BinaryType> for BinaryChunked {
             };
         }
         check_filter_len!(self, filter);
-        let (left, filter) = align_chunks_binary(self, filter);
-
-        let chunks = left
-            .downcast_iter()
-            .zip(filter.downcast_iter())
-            .map(|(left, mask)| filter_fn(left, mask).unwrap())
-            .collect::<Vec<_>>();
-
-        unsafe { Ok(self.copy_with_chunks(chunks, true, true)) }
+        Ok(unsafe {
+            arity::binary_mut_unchecked_same_type(
+                self,
+                filter,
+                |left, mask| filter_fn(left, mask).unwrap(),
+                true,
+                true,
+            )
+        })
     }
 }
 
@@ -103,19 +104,15 @@ impl ChunkFilter<ListType> for ListChunked {
                 )),
             };
         }
-        let (left, filter) = align_chunks_binary(self, filter);
-
-        let chunks = left
-            .downcast_iter()
-            .zip(filter.downcast_iter())
-            .map(|(left, mask)| filter_fn(left, mask).unwrap())
-            .collect::<Vec<_>>();
-
-        // inner type may be categorical or logical type so we clone the state.
-        let mut ca = self.clone();
-        ca.chunks = chunks;
-        ca.compute_len();
-        Ok(ca)
+        Ok(unsafe {
+            arity::binary_mut_unchecked_same_type(
+                self,
+                filter,
+                |left, mask| filter_fn(left, mask).unwrap(),
+                true,
+                true,
+            )
+        })
     }
 }
 
@@ -132,19 +129,15 @@ impl ChunkFilter<FixedSizeListType> for ArrayChunked {
                 )),
             };
         }
-        let (left, filter) = align_chunks_binary(self, filter);
-
-        let chunks = left
-            .downcast_iter()
-            .zip(filter.downcast_iter())
-            .map(|(left, mask)| filter_fn(left, mask).unwrap())
-            .collect::<Vec<_>>();
-
-        // inner type may be categorical or logical type so we clone the state.
-        let mut ca = self.clone();
-        ca.chunks = chunks;
-        ca.compute_len();
-        Ok(ca)
+        Ok(unsafe {
+            arity::binary_mut_unchecked_same_type(
+                self,
+                filter,
+                |left, mask| filter_fn(left, mask).unwrap(),
+                true,
+                true,
+            )
+        })
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/min_max_binary.rs
+++ b/crates/polars-core/src/chunked_array/ops/min_max_binary.rs
@@ -6,40 +6,19 @@ use crate::prelude::*;
 use crate::series::arithmetic::coerce_lhs_rhs;
 use crate::utils::align_chunks_binary;
 
-fn cmp_binary<T, F>(left: &ChunkedArray<T>, right: &ChunkedArray<T>, op: F) -> ChunkedArray<T>
-where
-    T: PolarsNumericType,
-    F: Fn(T::Native, T::Native) -> T::Native,
-{
-    let (left, right) = align_chunks_binary(left, right);
-    let chunks = left
-        .downcast_iter()
-        .zip(right.downcast_iter())
-        .map(|(left, right)| {
-            let values = left
-                .values()
-                .iter()
-                .zip(right.values().iter())
-                .map(|(l, r)| op(*l, *r))
-                .collect::<Vec<_>>();
-            PrimitiveArray::from_data_default(values.into(), None)
-        });
-    ChunkedArray::from_chunk_iter(left.name(), chunks)
-}
-
 fn min_binary<T>(left: &ChunkedArray<T>, right: &ChunkedArray<T>) -> ChunkedArray<T>
 where
     T: PolarsNumericType,
     T::Native: PartialOrd,
 {
-    let op = |l, r| {
+    let op = |l: &T::Native, r: &T::Native| {
         if l < r {
-            l
+            *l
         } else {
-            r
+            *r
         }
     };
-    cmp_binary(left, right, op)
+    arity::binary_elementwise_values(left, right, op)
 }
 
 fn max_binary<T>(left: &ChunkedArray<T>, right: &ChunkedArray<T>) -> ChunkedArray<T>
@@ -47,14 +26,14 @@ where
     T: PolarsNumericType,
     T::Native: PartialOrd,
 {
-    let op = |l, r| {
+    let op = |l: &T::Native, r: &T::Native| {
         if l > r {
-            l
+            *l
         } else {
-            r
+            *r
         }
     };
-    cmp_binary(left, right, op)
+    arity::binary_elementwise_values(left, right, op)
 }
 
 pub(crate) fn min_max_binary_series(

--- a/crates/polars-core/src/chunked_array/ops/min_max_binary.rs
+++ b/crates/polars-core/src/chunked_array/ops/min_max_binary.rs
@@ -1,10 +1,6 @@
-use arrow::array::PrimitiveArray;
-use polars_arrow::prelude::FromData;
-
 use crate::datatypes::PolarsNumericType;
 use crate::prelude::*;
 use crate::series::arithmetic::coerce_lhs_rhs;
-use crate::utils::align_chunks_binary;
 
 fn min_binary<T>(left: &ChunkedArray<T>, right: &ChunkedArray<T>) -> ChunkedArray<T>
 where

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod aggregate;
 pub(crate) mod any_value;
 pub(crate) mod append;
 mod apply;
+pub mod arity;
 mod bit_repr;
 pub(crate) mod chunkops;
 pub(crate) mod compare_inner;

--- a/crates/polars-core/src/chunked_array/ops/repeat_by.rs
+++ b/crates/polars-core/src/chunked_array/ops/repeat_by.rs
@@ -30,16 +30,17 @@ where
                     .collect::<Vec<IdxSize>>(),
             ));
         }
-        let iter = self
-            .into_iter()
-            .zip(by)
-            .map(|(opt_v, opt_by)| opt_by.map(|by| std::iter::repeat(opt_v).take(by as usize)));
 
-        // SAFETY: length of iter is trusted.
-        let arr = unsafe {
-            LargeListArray::from_iter_primitive_trusted_len(iter, T::get_dtype().to_arrow())
-        };
-        Ok(ChunkedArray::with_chunk(self.name(), arr))
+        Ok(arity::binary_mut(self, by, |arr, by| {
+            let iter = arr.into_iter().zip(by).map(|(opt_v, opt_by)| {
+                opt_by.map(|by| std::iter::repeat(opt_v.copied()).take(*by as usize))
+            });
+
+            // SAFETY: length of iter is trusted.
+            unsafe {
+                LargeListArray::from_iter_primitive_trusted_len(iter, T::get_dtype().to_arrow())
+            }
+        }))
     }
 }
 impl RepeatBy for BooleanChunked {
@@ -55,14 +56,14 @@ impl RepeatBy for BooleanChunked {
             ));
         }
 
-        let iter = self
-            .into_iter()
-            .zip(by)
-            .map(|(opt_v, opt_by)| opt_by.map(|by| std::iter::repeat(opt_v).take(by as usize)));
+        Ok(arity::binary_mut(self, by, |arr, by| {
+            let iter = arr.into_iter().zip(by).map(|(opt_v, opt_by)| {
+                opt_by.map(|by| std::iter::repeat(opt_v).take(*by as usize))
+            });
 
-        // SAFETY: length of iter is trusted.
-        let arr = unsafe { LargeListArray::from_iter_bool_trusted_len(iter) };
-        Ok(ChunkedArray::with_chunk(self.name(), arr))
+            // SAFETY: length of iter is trusted.
+            unsafe { LargeListArray::from_iter_bool_trusted_len(iter) }
+        }))
     }
 }
 impl RepeatBy for Utf8Chunked {
@@ -79,14 +80,14 @@ impl RepeatBy for Utf8Chunked {
             ));
         }
 
-        let iter = self
-            .into_iter()
-            .zip(by)
-            .map(|(opt_v, opt_by)| opt_by.map(|by| std::iter::repeat(opt_v).take(by as usize)));
+        Ok(arity::binary_mut(self, by, |arr, by| {
+            let iter = arr.into_iter().zip(by).map(|(opt_v, opt_by)| {
+                opt_by.map(|by| std::iter::repeat(opt_v).take(*by as usize))
+            });
 
-        // SAFETY: length of iter is trusted.
-        let arr = unsafe { LargeListArray::from_iter_utf8_trusted_len(iter, self.len()) };
-        Ok(ChunkedArray::with_chunk(self.name(), arr))
+            // SAFETY: length of iter is trusted.
+            unsafe { LargeListArray::from_iter_utf8_trusted_len(iter, self.len()) }
+        }))
     }
 }
 
@@ -102,13 +103,14 @@ impl RepeatBy for BinaryChunked {
                     .collect::<Vec<IdxSize>>(),
             ));
         }
-        let iter = self
-            .into_iter()
-            .zip(by)
-            .map(|(opt_v, opt_by)| opt_by.map(|by| std::iter::repeat(opt_v).take(by as usize)));
 
-        // SAFETY: length of iter is trusted.
-        let arr = unsafe { LargeListArray::from_iter_binary_trusted_len(iter, self.len()) };
-        Ok(ChunkedArray::with_chunk(self.name(), arr))
+        Ok(arity::binary_mut(self, by, |arr, by| {
+            let iter = arr.into_iter().zip(by).map(|(opt_v, opt_by)| {
+                opt_by.map(|by| std::iter::repeat(opt_v).take(*by as usize))
+            });
+
+            // SAFETY: length of iter is trusted.
+            unsafe { LargeListArray::from_iter_binary_trusted_len(iter, self.len()) }
+        }))
     }
 }

--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -118,7 +118,6 @@ pub mod checked {
     use num_traits::{CheckedDiv, One, ToPrimitive, Zero};
 
     use super::*;
-    use crate::utils::align_chunks_binary;
 
     pub trait NumOpsDispatchCheckedInner: PolarsDataType + Sized {
         /// Checked integer division. Computes self / rhs, returning None if rhs == 0 or the division results in overflow.
@@ -161,24 +160,14 @@ pub mod checked {
             // Note that the physical type correctness is checked!
             // The ChunkedArray with the wrong dtype is dropped after this operation
             let rhs = unsafe { lhs.unpack_series_matching_physical_type(rhs) };
-            let (l, r) = align_chunks_binary(lhs, rhs);
 
-            Ok((l)
-                .downcast_iter()
-                .zip(r.downcast_iter())
-                .flat_map(|(l_arr, r_arr)| {
-                    l_arr
-                        .into_iter()
-                        .zip(r_arr)
-                        // we don't use a kernel, because the checked div also supplies nulls.
-                        // so the usual bit combining is not enough.
-                        .map(|(opt_l, opt_r)| match (opt_l, opt_r) {
-                            (Some(l), Some(r)) => l.checked_div(r),
-                            _ => None,
-                        })
+            Ok(
+                arity::binary_elementwise(lhs, rhs, |opt_l, opt_r| match (opt_l, opt_r) {
+                    (Some(l), Some(r)) => l.checked_div(r),
+                    _ => None,
                 })
-                .collect::<ChunkedArray<T>>()
-                .into_series())
+                .into_series(),
+            )
         }
     }
 
@@ -187,30 +176,22 @@ pub mod checked {
             // Safety:
             // see check_div for chunkedarray<T>
             let rhs = unsafe { lhs.unpack_series_matching_physical_type(rhs) };
-            let (l, r) = align_chunks_binary(lhs, rhs);
 
-            Ok((l)
-                .downcast_iter()
-                .zip(r.downcast_iter())
-                .flat_map(|(l_arr, r_arr)| {
-                    l_arr
-                        .into_iter()
-                        .zip(r_arr)
-                        // we don't use a kernel, because the checked div also supplies nulls.
-                        // so the usual bit combining is not enough.
-                        .map(|(opt_l, opt_r)| match (opt_l, opt_r) {
-                            (Some(l), Some(r)) => {
-                                if r.is_zero() {
-                                    None
-                                } else {
-                                    Some(l / r)
-                                }
-                            },
-                            _ => None,
-                        })
+            Ok(
+                arity::binary_elementwise::<_, _, Float32Type, _>(lhs, rhs, |opt_l, opt_r| match (
+                    opt_l, opt_r,
+                ) {
+                    (Some(l), Some(r)) => {
+                        if r.is_zero() {
+                            None
+                        } else {
+                            Some(l / r)
+                        }
+                    },
+                    _ => None,
                 })
-                .collect::<Float32Chunked>()
-                .into_series())
+                .into_series(),
+            )
         }
     }
 
@@ -219,30 +200,22 @@ pub mod checked {
             // Safety:
             // see check_div
             let rhs = unsafe { lhs.unpack_series_matching_physical_type(rhs) };
-            let (l, r) = align_chunks_binary(lhs, rhs);
 
-            Ok((l)
-                .downcast_iter()
-                .zip(r.downcast_iter())
-                .flat_map(|(l_arr, r_arr)| {
-                    l_arr
-                        .into_iter()
-                        .zip(r_arr)
-                        // we don't use a kernel, because the checked div also supplies nulls.
-                        // so the usual bit combining is not enough.
-                        .map(|(opt_l, opt_r)| match (opt_l, opt_r) {
-                            (Some(l), Some(r)) => {
-                                if r.is_zero() {
-                                    None
-                                } else {
-                                    Some(l / r)
-                                }
-                            },
-                            _ => None,
-                        })
+            Ok(
+                arity::binary_elementwise::<_, _, Float64Type, _>(lhs, rhs, |opt_l, opt_r| match (
+                    opt_l, opt_r,
+                ) {
+                    (Some(l), Some(r)) => {
+                        if r.is_zero() {
+                            None
+                        } else {
+                            Some(l / r)
+                        }
+                    },
+                    _ => None,
                 })
-                .collect::<Float64Chunked>()
-                .into_series())
+                .into_series(),
+            )
         }
     }
 

--- a/crates/polars-ops/src/chunked_array/list/sets.rs
+++ b/crates/polars-ops/src/chunked_array/list/sets.rs
@@ -10,7 +10,6 @@ use arrow::offset::OffsetsBuffer;
 use arrow::types::NativeType;
 use polars_arrow::utils::combine_validities_and;
 use polars_core::prelude::*;
-use polars_core::utils::align_chunks_binary;
 use polars_core::with_match_physical_integer_type;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -281,16 +280,5 @@ fn array_set_operation(
 }
 
 pub fn list_set_operation(a: &ListChunked, b: &ListChunked, set_op: SetOperation) -> ListChunked {
-    let (a, b) = align_chunks_binary(a, b);
-
-    // no downcasting needed as lists
-    // already have logical types
-    let chunks = a
-        .downcast_iter()
-        .zip(b.downcast_iter())
-        .map(|(a, b)| array_set_operation(a, b, set_op).boxed())
-        .collect::<Vec<_>>();
-
-    // safety: dtypes are correct
-    unsafe { a.with_chunks(chunks) }
+    arity::binary_mut(a, b, |a, b| array_set_operation(a, b, set_op))
 }

--- a/crates/polars-ops/src/chunked_array/list/sets.rs
+++ b/crates/polars-ops/src/chunked_array/list/sets.rs
@@ -280,5 +280,14 @@ fn array_set_operation(
 }
 
 pub fn list_set_operation(a: &ListChunked, b: &ListChunked, set_op: SetOperation) -> ListChunked {
-    arity::binary_mut(a, b, |a, b| array_set_operation(a, b, set_op))
+    // we use the unsafe variant because we want to keep the nested logical types type.
+    unsafe {
+        arity::binary_mut_unchecked_same_type(
+            a,
+            b,
+            |a, b| array_set_operation(a, b, set_op).boxed(),
+            false,
+            false,
+        )
+    }
 }

--- a/crates/polars-ops/src/series/ops/floor_divide.rs
+++ b/crates/polars-ops/src/series/ops/floor_divide.rs
@@ -6,7 +6,6 @@ use polars_core::export::num;
 use polars_core::prelude::*;
 #[cfg(feature = "dtype-struct")]
 use polars_core::series::arithmetic::_struct_arithmetic;
-use polars_core::utils::align_chunks_binary;
 use polars_core::with_match_physical_numeric_polars_type;
 
 #[inline]
@@ -79,13 +78,7 @@ fn floor_div_ca<T: PolarsNumericType>(a: &ChunkedArray<T>, b: &ChunkedArray<T>) 
             ChunkedArray::full_null(a.name(), a.len())
         };
     }
-    let (a, b) = align_chunks_binary(a, b);
-
-    let chunks = a
-        .downcast_iter()
-        .zip(b.downcast_iter())
-        .map(|(a, b)| floor_div_array(a, b));
-    ChunkedArray::from_chunk_iter(a.name(), chunks)
+    arity::binary_mut(a, b, floor_div_array)
 }
 
 pub fn floor_div_series(a: &Series, b: &Series) -> PolarsResult<Series> {

--- a/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
+++ b/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
@@ -1,7 +1,6 @@
 use num::Float;
 use polars_arrow::kernels::atan2::atan2 as atan2_kernel;
 use polars_core::export::num;
-use polars_core::utils::align_chunks_binary;
 
 use super::*;
 
@@ -129,13 +128,8 @@ where
 
         Ok(Some(x.apply(|v| y_value.atan2(v)).into_series()))
     } else {
-        let (ca_1, ca_2) = align_chunks_binary(y, x);
-        let chunks = ca_1
-            .downcast_iter()
-            .zip(ca_2.downcast_iter())
-            .map(|(arr_1, arr_2)| atan2_kernel(arr_1, arr_2));
         Ok(Some(
-            ChunkedArray::from_chunk_iter(ca_1.name(), chunks).into_series(),
+            polars_core::prelude::arity::binary_mut(y, x, atan2_kernel).into_series(),
         ))
     }
 }


### PR DESCRIPTION
take @orlp 's new StaticArray trait indirections and clean up a lot of binary chunkedarray logic that can be made dry.

@MarcoGorelli this makes binary functions much easier to deal with for both kernels as well as elementwise functions. 