### PR TITLE
fix(rust, python): Fix serialization for categorical chunked.

### DIFF
--- a/crates/polars-core/src/serde/chunked_array.rs
+++ b/crates/polars-core/src/serde/chunked_array.rs
@@ -144,7 +144,7 @@ impl Serialize for CategoricalChunked {
         S: Serializer,
     {
         {
-            let mut state = serializer.serialize_map(Some(3))?;
+            let mut state = serializer.serialize_map(Some(4))?;
             state.serialize_entry("name", self.name())?;
             state.serialize_entry("datatype", self.dtype())?;
             state.serialize_entry("bit_settings", &self.get_flags())?;

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta
 import pytest
 
 import polars as pl
+from polars import StringCache
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -182,3 +183,10 @@ def test_pickle_lazyframe_nested_function_udf() -> None:
 
     q = pickle.loads(b)
     assert q.collect()["a"].to_list() == [2, 4, 6]
+
+
+@StringCache()
+def test_serde_categorical_series_10586() -> None:
+    s = pl.Series(["a", "b", "b", "a", "c"], dtype=pl.Categorical)
+    loaded_s = pickle.loads(pickle.dumps(s))
+    assert_series_equal(loaded_s, s)


### PR DESCRIPTION
This fixes #10586.