### PR TITLE
feat(rust, python): propagate null is in `is_in` and more generic array construction

### DIFF
--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -59,7 +59,7 @@ lazy = []
 
 # ~40% faster collect, needed until trustedlength iter stabilizes
 # more fast paths, slower compilation
-performant = ["polars-arrow/performant"]
+performant = ["polars-arrow/performant", "reinterpret"]
 
 # extra utilities for Utf8Chunked
 strings = ["regex", "polars-arrow/strings", "arrow/compute_substring", "polars-error/regex"]
@@ -77,7 +77,7 @@ sort_multiple = []
 rows = []
 
 # operations
-is_in = []
+is_in = ["reinterpret"]
 zip_with = []
 round_series = []
 checked_arithmetic = []

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -13,6 +13,44 @@ use crate::prelude::*;
 use crate::series::IsSorted;
 use crate::utils::{CustomIterTools, NoNull};
 
+impl<T> ChunkedArray<T>
+where
+    T: PolarsDataType,
+    Self: HasUnderlyingArray,
+{
+    pub fn apply_values<'a, U, K, F>(&'a self, mut op: F) -> ChunkedArray<U>
+    where
+        U: PolarsDataType,
+        F: FnMut(<<Self as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>) -> K,
+        K: ArrayFromElementIter,
+        K::ArrayType: StaticallyMatchesPolarsType<U>,
+    {
+        let iter = self.downcast_iter().map(|arr| {
+            let element_iter = arr.values_iter().map( op);
+            let array = K::array_from_values_iter(element_iter);
+            array.with_validity_typed(arr.validity().cloned())
+        });
+
+        ChunkedArray::from_chunk_iter(self.name(), iter)
+    }
+    pub fn apply2<'a, U, K, F>(&'a self, mut op: F) -> ChunkedArray<U>
+    where
+        U: PolarsDataType,
+        F: FnMut(
+            Option<<<Self as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>>,
+        ) -> Option<K>,
+        K: ArrayFromElementIter,
+        K::ArrayType: StaticallyMatchesPolarsType<U>,
+    {
+        let iter = self.downcast_iter().map(|arr| {
+            let element_iter = arr.iter().map( op);
+            K::array_from_iter(element_iter)
+        });
+
+        ChunkedArray::from_chunk_iter(self.name(), iter)
+    }
+}
+
 pub(super) fn collect_array<T: NativeType, I: TrustedLen<Item = T>>(
     iter: I,
     validity: Option<Bitmap>,

--- a/crates/polars-core/src/chunked_array/ops/bit_repr.rs
+++ b/crates/polars-core/src/chunked_array/ops/bit_repr.rs
@@ -22,17 +22,47 @@ fn reinterpret_chunked_array<T: PolarsNumericType, U: PolarsNumericType>(
     ChunkedArray::from_chunk_iter(ca.name(), chunks)
 }
 
-#[cfg(feature = "performant")]
-impl Int16Chunked {
-    pub(crate) fn reinterpret_unsigned(&self) -> UInt16Chunked {
-        reinterpret_chunked_array(self)
+#[cfg(all(feature = "reinterpret", feature = "dtype-i16"))]
+impl Reinterpret for Int16Chunked {
+    fn reinterpret_signed(&self) -> Series {
+        self.clone().into_series()
+    }
+
+    fn reinterpret_unsigned(&self) -> Series {
+        reinterpret_chunked_array::<_, UInt16Type>(self).into_series()
     }
 }
 
-#[cfg(feature = "performant")]
-impl Int8Chunked {
-    pub(crate) fn reinterpret_unsigned(&self) -> UInt8Chunked {
-        reinterpret_chunked_array(self)
+#[cfg(all(feature = "reinterpret", feature = "dtype-u16"))]
+impl Reinterpret for UInt16Chunked {
+    fn reinterpret_signed(&self) -> Series {
+        reinterpret_chunked_array::<_, Int16Type>(self).into_series()
+    }
+
+    fn reinterpret_unsigned(&self) -> Series {
+        self.clone().into_series()
+    }
+}
+
+#[cfg(all(feature = "reinterpret", feature = "dtype-i8"))]
+impl Reinterpret for Int8Chunked {
+    fn reinterpret_signed(&self) -> Series {
+        self.clone().into_series()
+    }
+
+    fn reinterpret_unsigned(&self) -> Series {
+        reinterpret_chunked_array::<_, UInt8Type>(self).into_series()
+    }
+}
+
+#[cfg(all(feature = "reinterpret", feature = "dtype-u8"))]
+impl Reinterpret for UInt8Chunked {
+    fn reinterpret_signed(&self) -> Series {
+        reinterpret_chunked_array::<_, Int8Type>(self).into_series()
+    }
+
+    fn reinterpret_unsigned(&self) -> Series {
+        self.clone().into_series()
     }
 }
 
@@ -120,7 +150,29 @@ impl Reinterpret for Int32Chunked {
     }
 
     fn reinterpret_unsigned(&self) -> Series {
-        self.bit_repr_large().into_series()
+        self.bit_repr_small().into_series()
+    }
+}
+
+#[cfg(feature = "reinterpret")]
+impl Reinterpret for Float32Chunked {
+    fn reinterpret_signed(&self) -> Series {
+        reinterpret_chunked_array::<_, Int32Type>(self).into_series()
+    }
+
+    fn reinterpret_unsigned(&self) -> Series {
+        reinterpret_chunked_array::<_, UInt32Type>(self).into_series()
+    }
+}
+
+#[cfg(feature = "reinterpret")]
+impl Reinterpret for Float64Chunked {
+    fn reinterpret_signed(&self) -> Series {
+        reinterpret_chunked_array::<_, Int64Type>(self).into_series()
+    }
+
+    fn reinterpret_unsigned(&self) -> Series {
+        reinterpret_chunked_array::<_, UInt64Type>(self).into_series()
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/bit_repr.rs
+++ b/crates/polars-core/src/chunked_array/ops/bit_repr.rs
@@ -22,7 +22,7 @@ fn reinterpret_chunked_array<T: PolarsNumericType, U: PolarsNumericType>(
     ChunkedArray::from_chunk_iter(ca.name(), chunks)
 }
 
-#[cfg(all(feature = "reinterpret", feature = "dtype-i16"))]
+#[cfg(all(feature = "reinterpret", feature = "dtype-i16", feature = "dtype-u16"))]
 impl Reinterpret for Int16Chunked {
     fn reinterpret_signed(&self) -> Series {
         self.clone().into_series()
@@ -33,7 +33,7 @@ impl Reinterpret for Int16Chunked {
     }
 }
 
-#[cfg(all(feature = "reinterpret", feature = "dtype-u16"))]
+#[cfg(all(feature = "reinterpret", feature = "dtype-u16", feature = "dtype-i16"))]
 impl Reinterpret for UInt16Chunked {
     fn reinterpret_signed(&self) -> Series {
         reinterpret_chunked_array::<_, Int16Type>(self).into_series()
@@ -44,7 +44,7 @@ impl Reinterpret for UInt16Chunked {
     }
 }
 
-#[cfg(all(feature = "reinterpret", feature = "dtype-i8"))]
+#[cfg(all(feature = "reinterpret", feature = "dtype-i8", feature = "dtype-u8"))]
 impl Reinterpret for Int8Chunked {
     fn reinterpret_signed(&self) -> Series {
         self.clone().into_series()
@@ -55,7 +55,7 @@ impl Reinterpret for Int8Chunked {
     }
 }
 
-#[cfg(all(feature = "reinterpret", feature = "dtype-u8"))]
+#[cfg(all(feature = "reinterpret", feature = "dtype-u8", feature = "dtype-i8"))]
 impl Reinterpret for UInt8Chunked {
     fn reinterpret_signed(&self) -> Series {
         reinterpret_chunked_array::<_, Int8Type>(self).into_series()

--- a/crates/polars-core/src/chunked_array/ops/is_in.rs
+++ b/crates/polars-core/src/chunked_array/ops/is_in.rs
@@ -3,40 +3,7 @@ use std::hash::Hash;
 use crate::prelude::*;
 use crate::utils::{try_get_supertype, CustomIterTools};
 
-unsafe fn is_in_helper<T, P>(ca: &ChunkedArray<T>, other: &Series) -> PolarsResult<BooleanChunked>
-where
-    T: PolarsNumericType,
-    P: Eq + Hash + Copy,
-{
-    let mut set = PlHashSet::with_capacity(other.len());
-
-    let other = ca.unpack_series_matching_type(other)?;
-    other.downcast_iter().for_each(|iter| {
-        iter.into_iter().for_each(|opt_val| {
-            // Safety
-            // bit sizes are/ should be equal
-            let ptr = &opt_val.copied() as *const Option<T::Native> as *const Option<P>;
-            let opt_val = *ptr;
-            set.insert(opt_val);
-        })
-    });
-
-    let name = ca.name();
-    let mut ca: BooleanChunked = ca
-        .into_iter()
-        .map(|opt_val| {
-            // Safety
-            // bit sizes are/ should be equal
-            let ptr = &opt_val as *const Option<T::Native> as *const Option<P>;
-            let opt_val = *ptr;
-            set.contains(&opt_val)
-        })
-        .collect_trusted();
-    ca.rename(name);
-    Ok(ca)
-}
-
-fn is_in_helper2<'a, T>(ca: &'a ChunkedArray<T>, other: &Series) -> PolarsResult<BooleanChunked>
+fn is_in_helper<'a, T>(ca: &'a ChunkedArray<T>, other: &Series) -> PolarsResult<BooleanChunked>
 where
     T: PolarsDataType,
     ChunkedArray<T>: HasUnderlyingArray,
@@ -53,27 +20,12 @@ where
         })
     });
     Ok(ca.apply_values(|val| set.contains(&val)))
-
-    // let name = ca.name();
-    //
-    // let mut ca: BooleanChunked = ca
-    //     .into_iter()
-    //     .map(|opt_val| {
-    //
-    //         // Safety
-    //         // bit sizes are/ should be equal
-    //         let ptr = &opt_val as *const Option<T::Native> as *const Option<P>;
-    //         let opt_val = *ptr;
-    //         set.contains(&opt_val)
-    //     })
-    //     .collect_trusted();
-    // ca.rename(name);
-    // Ok(ca)
 }
 
 impl<T> IsIn for ChunkedArray<T>
 where
-    T: PolarsNumericType,
+    T: PolarsIntegerType,
+    T::Native: Hash + Eq,
 {
     fn is_in(&self, other: &Series) -> PolarsResult<BooleanChunked> {
         // We check implicitly cast to supertype here
@@ -123,24 +75,7 @@ where
                     let right = other.cast(&st)?;
                     return left.is_in(&right);
                 }
-                // now that the types are equal, we coerce every 32 bit array to u32
-                // and every 64 bit array to u64 (including floats)
-                // this allows hashing them and greatly reduces the number of code paths.
-                match self.dtype() {
-                    DataType::UInt64 | DataType::Int64 | DataType::Float64 => unsafe {
-                        is_in_helper::<T, u64>(self, other)
-                    },
-                    DataType::UInt32 | DataType::Int32 | DataType::Float32 => unsafe {
-                        is_in_helper::<T, u32>(self, other)
-                    },
-                    DataType::UInt8 | DataType::Int8 => unsafe {
-                        is_in_helper::<T, u8>(self, other)
-                    },
-                    DataType::UInt16 | DataType::Int16 => unsafe {
-                        is_in_helper::<T, u16>(self, other)
-                    },
-                    dt => polars_bail!(opq = is_in, dt),
-                }
+                is_in_helper(self, other)
             }
         }
         .map(|mut ca| {
@@ -149,6 +84,26 @@ where
         })
     }
 }
+
+impl IsIn for Float32Chunked {
+    fn is_in(&self, other: &Series) -> PolarsResult<BooleanChunked> {
+        let other = other.cast(&DataType::Float32)?;
+        let other = other.f32().unwrap();
+        let other = other.reinterpret_unsigned();
+        let ca = self.reinterpret_unsigned();
+        ca.is_in(&other)
+    }
+}
+impl IsIn for Float64Chunked {
+    fn is_in(&self, other: &Series) -> PolarsResult<BooleanChunked> {
+        let other = other.cast(&DataType::Float64)?;
+        let other = other.f64().unwrap();
+        let other = other.reinterpret_unsigned();
+        let ca = self.reinterpret_unsigned();
+        ca.is_in(&other)
+    }
+}
+
 impl IsIn for Utf8Chunked {
     fn is_in(&self, other: &Series) -> PolarsResult<BooleanChunked> {
         match other.dtype() {
@@ -244,20 +199,7 @@ impl IsIn for BinaryChunked {
                 Ok(ca)
             }
             DataType::Binary => {
-                let mut set = PlHashSet::with_capacity(other.len());
-
-                let other = other.binary()?;
-                other.downcast_iter().for_each(|iter| {
-                    iter.into_iter().for_each(|opt_val| {
-                        set.insert(opt_val);
-                    })
-                });
-                let mut ca: BooleanChunked = self
-                    .into_iter()
-                    .map(|opt_val| set.contains(&opt_val))
-                    .collect_trusted();
-                ca.rename(self.name());
-                Ok(ca)
+                is_in_helper(self, other)
             }
             _ => polars_bail!(opq = is_in, self.dtype(), other.dtype()),
         }

--- a/crates/polars-core/src/chunked_array/ops/min_max_binary.rs
+++ b/crates/polars-core/src/chunked_array/ops/min_max_binary.rs
@@ -7,11 +7,11 @@ where
     T: PolarsNumericType,
     T::Native: PartialOrd,
 {
-    let op = |l: &T::Native, r: &T::Native| {
+    let op = |l: T::Native, r: T::Native| {
         if l < r {
-            *l
+            l
         } else {
-            *r
+            r
         }
     };
     arity::binary_elementwise_values(left, right, op)
@@ -22,11 +22,11 @@ where
     T: PolarsNumericType,
     T::Native: PartialOrd,
 {
-    let op = |l: &T::Native, r: &T::Native| {
+    let op = |l: T::Native, r: T::Native| {
         if l > r {
-            *l
+            l
         } else {
-            *r
+            r
         }
     };
     arity::binary_elementwise_values(left, right, op)

--- a/crates/polars-core/src/datatypes/from_values.rs
+++ b/crates/polars-core/src/datatypes/from_values.rs
@@ -1,0 +1,72 @@
+use arrow::array::{BooleanArray, PrimitiveArray, Utf8Array};
+use polars_arrow::array::utf8::Utf8FromIter;
+use polars_arrow::trusted_len::TrustedLen;
+
+use crate::prelude::StaticArray;
+
+pub trait FromValuesIter
+where
+    Self: Sized,
+{
+    type ArrayType: StaticArray;
+
+    fn array_from_iter<I: TrustedLen<Item = Option<Self>>>(iter: I) -> Self::ArrayType;
+
+    fn array_from_values_iter<I: TrustedLen<Item = Self>>(iter: I) -> Self::ArrayType;
+}
+
+impl FromValuesIter for bool {
+    type ArrayType = BooleanArray;
+
+    fn array_from_iter<I: TrustedLen<Item = Option<Self>>>(iter: I) -> Self::ArrayType {
+        // SAFETY: guarded by `TrustedLen` trait
+        unsafe { BooleanArray::from_trusted_len_iter_unchecked(iter) }
+    }
+
+    fn array_from_values_iter<I: TrustedLen<Item = Self>>(iter: I) -> Self::ArrayType {
+        // SAFETY: guarded by `TrustedLen` trait
+        unsafe { BooleanArray::from_trusted_len_values_iter_unchecked(iter) }
+    }
+}
+
+macro_rules! impl_primitive {
+    ($tp:ty) => {
+        impl FromValuesIter for $tp {
+            type ArrayType = PrimitiveArray<Self>;
+
+            fn array_from_iter<I: TrustedLen<Item = Option<Self>>>(iter: I) -> Self::ArrayType {
+                // SAFETY: guarded by `TrustedLen` trait
+                unsafe { PrimitiveArray::from_trusted_len_iter_unchecked(iter) }
+            }
+
+            fn array_from_values_iter<I: TrustedLen<Item = Self>>(iter: I) -> Self::ArrayType {
+                // SAFETY: guarded by `TrustedLen` trait
+                unsafe { PrimitiveArray::from_trusted_len_values_iter_unchecked(iter) }
+            }
+        }
+    };
+}
+
+impl_primitive!(u8);
+impl_primitive!(u16);
+impl_primitive!(u32);
+impl_primitive!(u64);
+impl_primitive!(i8);
+impl_primitive!(i16);
+impl_primitive!(i32);
+impl_primitive!(i64);
+
+impl FromValuesIter for &str {
+    type ArrayType = Utf8Array<i64>;
+
+    fn array_from_iter<I: TrustedLen<Item = Option<Self>>>(iter: I) -> Self::ArrayType {
+        // SAFETY: guarded by `TrustedLen` trait
+        unsafe { Utf8Array::from_trusted_len_iter_unchecked(iter) }
+    }
+
+    fn array_from_values_iter<I: TrustedLen<Item = Self>>(iter: I) -> Self::ArrayType {
+        // SAFETY: guarded by `TrustedLen` trait
+        let len = iter.size_hint().0;
+        Utf8Array::from_values_iter(iter, len, len * 24)
+    }
+}

--- a/crates/polars-core/src/datatypes/from_values.rs
+++ b/crates/polars-core/src/datatypes/from_values.rs
@@ -4,7 +4,7 @@ use polars_arrow::trusted_len::TrustedLen;
 
 use crate::prelude::StaticArray;
 
-pub trait FromValuesIter
+pub trait ArrayFromElementIter
 where
     Self: Sized,
 {
@@ -15,7 +15,7 @@ where
     fn array_from_values_iter<I: TrustedLen<Item = Self>>(iter: I) -> Self::ArrayType;
 }
 
-impl FromValuesIter for bool {
+impl ArrayFromElementIter for bool {
     type ArrayType = BooleanArray;
 
     fn array_from_iter<I: TrustedLen<Item = Option<Self>>>(iter: I) -> Self::ArrayType {
@@ -31,7 +31,7 @@ impl FromValuesIter for bool {
 
 macro_rules! impl_primitive {
     ($tp:ty) => {
-        impl FromValuesIter for $tp {
+        impl ArrayFromElementIter for $tp {
             type ArrayType = PrimitiveArray<Self>;
 
             fn array_from_iter<I: TrustedLen<Item = Option<Self>>>(iter: I) -> Self::ArrayType {
@@ -56,7 +56,7 @@ impl_primitive!(i16);
 impl_primitive!(i32);
 impl_primitive!(i64);
 
-impl FromValuesIter for &str {
+impl ArrayFromElementIter for &str {
     type ArrayType = Utf8Array<i64>;
 
     fn array_from_iter<I: TrustedLen<Item = Option<Self>>>(iter: I) -> Self::ArrayType {

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -12,6 +12,7 @@ mod aliases;
 mod any_value;
 mod dtype;
 mod field;
+mod from_values;
 mod static_array;
 mod time_unit;
 

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -32,6 +32,7 @@ use arrow::types::simd::Simd;
 use arrow::types::NativeType;
 pub use dtype::*;
 pub use field::*;
+pub use from_values::ArrayFromElementIter;
 use num_traits::{Bounded, FromPrimitive, Num, NumCast, Zero};
 use polars_arrow::data_types::IsFloat;
 #[cfg(feature = "serde")]

--- a/crates/polars-core/src/datatypes/static_array.rs
+++ b/crates/polars-core/src/datatypes/static_array.rs
@@ -1,4 +1,5 @@
 use arrow::bitmap::utils::{BitmapIter, ZipValidity};
+use arrow::bitmap::Bitmap;
 
 #[cfg(feature = "object")]
 use crate::chunked_array::object::ObjectArray;
@@ -16,6 +17,7 @@ pub trait StaticArray: Array {
 
     fn iter(&self) -> ZipValidity<Self::ValueT<'_>, Self::ValueIterT<'_>, BitmapIter>;
     fn values_iter(&self) -> Self::ValueIterT<'_>;
+    fn with_validity_typed(self, validity: Option<Bitmap>) -> Self;
 }
 
 impl<T: NumericNative> StaticArray for PrimitiveArray<T> {
@@ -28,6 +30,9 @@ impl<T: NumericNative> StaticArray for PrimitiveArray<T> {
 
     fn iter(&self) -> ZipValidity<Self::ValueT<'_>, Self::ValueIterT<'_>, BitmapIter> {
         ZipValidity::new_with_validity(self.values().iter().copied(), self.validity())
+    }
+    fn with_validity_typed(self, validity: Option<Bitmap>) -> Self {
+        self.with_validity(validity)
     }
 }
 
@@ -42,6 +47,9 @@ impl StaticArray for BooleanArray {
     fn iter(&self) -> ZipValidity<Self::ValueT<'_>, Self::ValueIterT<'_>, BitmapIter> {
         self.iter()
     }
+    fn with_validity_typed(self, validity: Option<Bitmap>) -> Self {
+        self.with_validity(validity)
+    }
 }
 
 impl StaticArray for Utf8Array<i64> {
@@ -54,6 +62,9 @@ impl StaticArray for Utf8Array<i64> {
 
     fn iter(&self) -> ZipValidity<Self::ValueT<'_>, Self::ValueIterT<'_>, BitmapIter> {
         self.iter()
+    }
+    fn with_validity_typed(self, validity: Option<Bitmap>) -> Self {
+        self.with_validity(validity)
     }
 }
 
@@ -68,6 +79,9 @@ impl StaticArray for BinaryArray<i64> {
     fn iter(&self) -> ZipValidity<Self::ValueT<'_>, Self::ValueIterT<'_>, BitmapIter> {
         self.iter()
     }
+    fn with_validity_typed(self, validity: Option<Bitmap>) -> Self {
+        self.with_validity(validity)
+    }
 }
 
 impl StaticArray for ListArray<i64> {
@@ -80,6 +94,9 @@ impl StaticArray for ListArray<i64> {
 
     fn iter(&self) -> ZipValidity<Self::ValueT<'_>, Self::ValueIterT<'_>, BitmapIter> {
         self.iter()
+    }
+    fn with_validity_typed(self, validity: Option<Bitmap>) -> Self {
+        self.with_validity(validity)
     }
 }
 
@@ -95,6 +112,9 @@ impl StaticArray for FixedSizeListArray {
     fn iter(&self) -> ZipValidity<Self::ValueT<'_>, Self::ValueIterT<'_>, BitmapIter> {
         self.iter()
     }
+    fn with_validity_typed(self, validity: Option<Bitmap>) -> Self {
+        self.with_validity(validity)
+    }
 }
 
 #[cfg(feature = "object")]
@@ -107,6 +127,9 @@ impl<T: PolarsObject> StaticArray for ObjectArray<T> {
     }
 
     fn iter(&self) -> ZipValidity<Self::ValueT<'_>, Self::ValueIterT<'_>, BitmapIter> {
+        todo!()
+    }
+    fn with_validity_typed(self, _validity: Option<Bitmap>) -> Self {
         todo!()
     }
 }

--- a/crates/polars-core/src/datatypes/static_array.rs
+++ b/crates/polars-core/src/datatypes/static_array.rs
@@ -19,15 +19,15 @@ pub trait StaticArray: Array {
 }
 
 impl<T: NumericNative> StaticArray for PrimitiveArray<T> {
-    type ValueT<'a> = &'a T;
-    type ValueIterT<'a> = std::slice::Iter<'a, T>;
+    type ValueT<'a> = T;
+    type ValueIterT<'a> = std::iter::Copied<std::slice::Iter<'a, T>>;
 
     fn values_iter(&self) -> Self::ValueIterT<'_> {
-        self.values_iter()
+        self.values_iter().copied()
     }
 
     fn iter(&self) -> ZipValidity<Self::ValueT<'_>, Self::ValueIterT<'_>, BitmapIter> {
-        self.iter()
+        ZipValidity::new_with_validity(self.values().iter().copied(), self.validity())
     }
 }
 

--- a/crates/polars-core/src/frame/groupby/into_groups.rs
+++ b/crates/polars-core/src/frame/groupby/into_groups.rs
@@ -172,7 +172,7 @@ where
                 let ca = self.bit_repr_small();
                 num_groups_proxy(&ca, multithreaded, sorted)
             },
-            #[cfg(feature = "performant")]
+            #[cfg(all(feature = "performant", feature = "dtype-i8", feature = "dtype-u8"))]
             DataType::Int8 => {
                 // convince the compiler that we are this type.
                 let ca: &Int8Chunked =
@@ -180,14 +180,14 @@ where
                 let s = ca.reinterpret_unsigned();
                 return s.group_tuples(multithreaded, sorted);
             },
-            #[cfg(feature = "performant")]
+            #[cfg(all(feature = "performant", feature = "dtype-i8", feature = "dtype-u8"))]
             DataType::UInt8 => {
                 // convince the compiler that we are this type.
                 let ca: &UInt8Chunked =
                     unsafe { &*(self as *const ChunkedArray<T> as *const ChunkedArray<UInt8Type>) };
                 num_groups_proxy(ca, multithreaded, sorted)
             },
-            #[cfg(feature = "performant")]
+            #[cfg(all(feature = "performant", feature = "dtype-i16", feature = "dtype-u16"))]
             DataType::Int16 => {
                 // convince the compiler that we are this type.
                 let ca: &Int16Chunked =
@@ -195,7 +195,7 @@ where
                 let s = ca.reinterpret_unsigned();
                 return s.group_tuples(multithreaded, sorted);
             },
-            #[cfg(feature = "performant")]
+            #[cfg(all(feature = "performant", feature = "dtype-i16", feature = "dtype-u16"))]
             DataType::UInt16 => {
                 // convince the compiler that we are this type.
                 let ca: &UInt16Chunked = unsafe {

--- a/crates/polars-core/src/frame/groupby/into_groups.rs
+++ b/crates/polars-core/src/frame/groupby/into_groups.rs
@@ -177,8 +177,8 @@ where
                 // convince the compiler that we are this type.
                 let ca: &Int8Chunked =
                     unsafe { &*(self as *const ChunkedArray<T> as *const ChunkedArray<Int8Type>) };
-                let ca = ca.reinterpret_unsigned();
-                num_groups_proxy(&ca, multithreaded, sorted)
+                let s = ca.reinterpret_unsigned();
+                return s.group_tuples(multithreaded, sorted);
             },
             #[cfg(feature = "performant")]
             DataType::UInt8 => {
@@ -192,8 +192,8 @@ where
                 // convince the compiler that we are this type.
                 let ca: &Int16Chunked =
                     unsafe { &*(self as *const ChunkedArray<T> as *const ChunkedArray<Int16Type>) };
-                let ca = ca.reinterpret_unsigned();
-                num_groups_proxy(&ca, multithreaded, sorted)
+                let s = ca.reinterpret_unsigned();
+                return s.group_tuples(multithreaded, sorted);
             },
             #[cfg(feature = "performant")]
             DataType::UInt16 => {

--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -163,7 +163,7 @@ pub mod checked {
 
             Ok(
                 arity::binary_elementwise(lhs, rhs, |opt_l, opt_r| match (opt_l, opt_r) {
-                    (Some(l), Some(r)) => l.checked_div(r),
+                    (Some(l), Some(r)) => l.checked_div(&r),
                     _ => None,
                 })
                 .into_series(),

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -44,14 +44,9 @@ def test_is_in_empty_list_4639() -> None:
     df = pl.DataFrame({"a": [1, None]})
     empty_list: list[int] = []
 
-    print(df.with_columns(pl.col("a").is_in(empty_list)))
     assert df.with_columns([pl.col("a").is_in(empty_list).alias("a_in_list")]).to_dict(
         False
-    ) == {"a": [1, None], "a_in_list": [False, False]}
-    # df = pl.DataFrame()
-    # assert df.with_columns(
-    #     [pl.lit(None).cast(pl.Int64).is_in(empty_list).alias("in_empty_list")]
-    # ).to_dict(False) == {"in_empty_list": [False]}
+    ) == {"a": [1, None], "a_in_list": [False, None]}
 
 
 def test_is_in_struct() -> None:

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -66,6 +66,23 @@ def test_is_in_struct() -> None:
     }
 
 
+def test_is_in_null_prop() -> None:
+    assert pl.Series([None], dtype=pl.Float32).is_in(pl.Series([42])).item() is None
+    assert (
+        pl.Series([{"a": None}], dtype=pl.Struct({"a": pl.Float32}))
+        .is_in(pl.Series([{"a": 42}]))
+        .item()
+        is None
+    )
+    assert pl.Series([None], dtype=pl.Boolean).is_in(pl.Series([42])).item() is None
+    assert (
+        pl.Series([{"a": None}], dtype=pl.Struct({"a": pl.Boolean}))
+        .is_in(pl.Series([{"a": 42}]))
+        .item()
+        is None
+    )
+
+
 def test_is_in_df() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
     assert df.select(pl.col("a").is_in([1, 2]))["a"].to_list() == [


### PR DESCRIPTION
Can reduce the number of kernels with the new traits that can construct from `StaticArray`'s.

closes #10613
closes #9105