### PR TITLE
refactor(rust): remove unused apply functions and add fallible generic apply functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 [workspace.dependencies.arrow]
 package = "arrow2"
 git = "https://github.com/jorgecarleitao/arrow2"
-rev = "7edf5f9e359e0ed02e9d0c6b9318b06964d805f0"
+rev = "2b3e2a9e83725a557d78b90cd39298c5bef0ca4a"
 # branch = ""
 # version = "0.17.4"
 default-features = false

--- a/crates/polars-core/src/chunked_array/arithmetic/mod.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/mod.rs
@@ -189,7 +189,7 @@ impl Add for &BooleanChunked {
         if rhs.len() == 1 {
             let rhs = rhs.get(0);
             return match rhs {
-                Some(rhs) => self.apply_values(|v| v as IdxSize + rhs as IdxSize),
+                Some(rhs) => self.apply_values_generic(|v| v as IdxSize + rhs as IdxSize),
                 None => IdxCa::full_null(self.name(), self.len()),
             };
         }

--- a/crates/polars-core/src/chunked_array/arithmetic/mod.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/mod.rs
@@ -189,7 +189,7 @@ impl Add for &BooleanChunked {
         if rhs.len() == 1 {
             let rhs = rhs.get(0);
             return match rhs {
-                Some(rhs) => self.apply_cast_numeric(|v| v as IdxSize + rhs as IdxSize),
+                Some(rhs) => self.apply_values(|v| v as IdxSize + rhs as IdxSize),
                 None => IdxCa::full_null(self.name(), self.len()),
             };
         }

--- a/crates/polars-core/src/chunked_array/arithmetic/numeric.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/numeric.rs
@@ -18,14 +18,14 @@ where
             let opt_rhs = rhs.get(0);
             match opt_rhs {
                 None => ChunkedArray::full_null(lhs.name(), lhs.len()),
-                Some(rhs) => lhs.apply(|lhs| operation(lhs, rhs)),
+                Some(rhs) => lhs.apply_on_values(|lhs| operation(lhs, rhs)),
             }
         },
         (1, _) => {
             let opt_lhs = lhs.get(0);
             match opt_lhs {
                 None => ChunkedArray::full_null(lhs.name(), rhs.len()),
-                Some(lhs) => rhs.apply(|rhs| operation(lhs, rhs)),
+                Some(lhs) => rhs.apply_on_values(|rhs| operation(lhs, rhs)),
             }
         },
         _ => panic!("Cannot apply operation on arrays of different lengths"),
@@ -253,7 +253,7 @@ where
 
     fn add(self, rhs: N) -> Self::Output {
         let adder: T::Native = NumCast::from(rhs).unwrap();
-        let mut out = self.apply(|val| val + adder);
+        let mut out = self.apply_on_values(|val| val + adder);
         out.set_sorted_flag(self.is_sorted_flag());
         out
     }
@@ -268,7 +268,7 @@ where
 
     fn sub(self, rhs: N) -> Self::Output {
         let subber: T::Native = NumCast::from(rhs).unwrap();
-        let mut out = self.apply(|val| val - subber);
+        let mut out = self.apply_on_values(|val| val - subber);
         out.set_sorted_flag(self.is_sorted_flag());
         out
     }

--- a/crates/polars-core/src/chunked_array/arithmetic/numeric.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/numeric.rs
@@ -18,14 +18,14 @@ where
             let opt_rhs = rhs.get(0);
             match opt_rhs {
                 None => ChunkedArray::full_null(lhs.name(), lhs.len()),
-                Some(rhs) => lhs.apply_on_values(|lhs| operation(lhs, rhs)),
+                Some(rhs) => lhs.apply_values(|lhs| operation(lhs, rhs)),
             }
         },
         (1, _) => {
             let opt_lhs = lhs.get(0);
             match opt_lhs {
                 None => ChunkedArray::full_null(lhs.name(), rhs.len()),
-                Some(lhs) => rhs.apply_on_values(|rhs| operation(lhs, rhs)),
+                Some(lhs) => rhs.apply_values(|rhs| operation(lhs, rhs)),
             }
         },
         _ => panic!("Cannot apply operation on arrays of different lengths"),
@@ -253,7 +253,7 @@ where
 
     fn add(self, rhs: N) -> Self::Output {
         let adder: T::Native = NumCast::from(rhs).unwrap();
-        let mut out = self.apply_on_values(|val| val + adder);
+        let mut out = self.apply_values(|val| val + adder);
         out.set_sorted_flag(self.is_sorted_flag());
         out
     }
@@ -268,7 +268,7 @@ where
 
     fn sub(self, rhs: N) -> Self::Output {
         let subber: T::Native = NumCast::from(rhs).unwrap();
-        let mut out = self.apply_on_values(|val| val - subber);
+        let mut out = self.apply_values(|val| val - subber);
         out.set_sorted_flag(self.is_sorted_flag());
         out
     }

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -74,7 +74,7 @@ impl CategoricalChunked {
         // we can skip the apply and only update the rev_map
         let local_ca = self
             .logical()
-            .apply_on_opt(|opt_v| opt_v.map(|v| *physical_map.get(&v).unwrap()));
+            .apply(|opt_v| opt_v.map(|v| *physical_map.get(&v).unwrap()));
 
         let mut out =
             unsafe { Self::from_cats_and_rev_map_unchecked(local_ca, local_rev_map.into()) };

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -68,30 +68,8 @@ pub type ChunkIdIter<'a> = std::iter::Map<std::slice::Iter<'a, ArrayRef>, fn(&Ar
 ///
 /// ```rust
 /// # use polars_core::prelude::*;
-/// fn apply_cosine(ca: &Float32Chunked) -> Float32Chunked {
-///     ca.apply_values(|v| v.cos())
-/// }
-/// ```
-///
-/// If we would like to cast the result we could use a Rust Iterator instead of an `apply` method.
-/// Note that Iterators are slightly slower as the null values aren't ignored implicitly.
-///
-/// ```rust
-/// # use polars_core::prelude::*;
 /// fn apply_cosine_and_cast(ca: &Float32Chunked) -> Float64Chunked {
-///     ca.into_iter()
-///         .map(|opt_v| {
-///         opt_v.map(|v| v.cos() as f64)
-///     }).collect()
-/// }
-/// ```
-///
-/// Another option is to first cast and then use an apply.
-///
-/// ```rust
-/// # use polars_core::prelude::*;
-/// fn apply_cosine_and_cast(ca: &Float32Chunked) -> Float64Chunked {
-///     ca.apply_cast_numeric(|v| v.cos() as f64)
+///     ca.apply_values_generic(|v| v.cos() as f64)
 /// }
 /// ```
 ///

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -69,7 +69,7 @@ pub type ChunkIdIter<'a> = std::iter::Map<std::slice::Iter<'a, ArrayRef>, fn(&Ar
 /// ```rust
 /// # use polars_core::prelude::*;
 /// fn apply_cosine(ca: &Float32Chunked) -> Float32Chunked {
-///     ca.apply(|v| v.cos())
+///     ca.apply_on_values(|v| v.cos())
 /// }
 /// ```
 ///

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -69,7 +69,7 @@ pub type ChunkIdIter<'a> = std::iter::Map<std::slice::Iter<'a, ArrayRef>, fn(&Ar
 /// ```rust
 /// # use polars_core::prelude::*;
 /// fn apply_cosine(ca: &Float32Chunked) -> Float32Chunked {
-///     ca.apply_on_values(|v| v.cos())
+///     ca.apply_values(|v| v.cos())
 /// }
 /// ```
 ///

--- a/crates/polars-core/src/chunked_array/ops/abs.rs
+++ b/crates/polars-core/src/chunked_array/ops/abs.rs
@@ -9,6 +9,6 @@ where
     /// Convert all values to their absolute/positive value.
     #[must_use]
     pub fn abs(&self) -> Self {
-        self.apply_on_values(|v| v.abs())
+        self.apply_values(|v| v.abs())
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/abs.rs
+++ b/crates/polars-core/src/chunked_array/ops/abs.rs
@@ -9,6 +9,6 @@ where
     /// Convert all values to their absolute/positive value.
     #[must_use]
     pub fn abs(&self) -> Self {
-        self.apply(|v| v.abs())
+        self.apply_on_values(|v| v.abs())
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/aggregate/var.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/var.rs
@@ -50,7 +50,7 @@ impl ChunkVar<f32> for Float32Chunked {
         let n_values = n_values as f32;
 
         let mean = self.mean()? as f32;
-        let squared = self.apply(|value| {
+        let squared = self.apply_on_values(|value| {
             let tmp = value - mean;
             tmp * tmp
         });
@@ -74,7 +74,7 @@ impl ChunkVar<f64> for Float64Chunked {
         let n_values = n_values as f64;
 
         let mean = self.mean()?;
-        let squared = self.apply(|value| {
+        let squared = self.apply_on_values(|value| {
             let tmp = value - mean;
             tmp * tmp
         });

--- a/crates/polars-core/src/chunked_array/ops/aggregate/var.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/var.rs
@@ -23,7 +23,7 @@ where
         let n_values = n_values as f64;
 
         let mean = self.mean()?;
-        let squared: Float64Chunked = ChunkedArray::apply_values(self, |value| {
+        let squared: Float64Chunked = ChunkedArray::apply_values_generic(self, |value| {
             let tmp = value.to_f64().unwrap() - mean;
             tmp * tmp
         });
@@ -50,7 +50,7 @@ impl ChunkVar<f32> for Float32Chunked {
         let n_values = n_values as f32;
 
         let mean = self.mean()? as f32;
-        let squared = self.apply_on_values(|value| {
+        let squared = self.apply_values(|value| {
             let tmp = value - mean;
             tmp * tmp
         });
@@ -74,7 +74,7 @@ impl ChunkVar<f64> for Float64Chunked {
         let n_values = n_values as f64;
 
         let mean = self.mean()?;
-        let squared = self.apply_on_values(|value| {
+        let squared = self.apply_values(|value| {
             let tmp = value - mean;
             tmp * tmp
         });

--- a/crates/polars-core/src/chunked_array/ops/aggregate/var.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/var.rs
@@ -23,7 +23,7 @@ where
         let n_values = n_values as f64;
 
         let mean = self.mean()?;
-        let squared = self.apply_cast_numeric::<_, Float64Type>(|value| {
+        let squared: Float64Chunked = ChunkedArray::apply_values(self, |value| {
             let tmp = value.to_f64().unwrap() - mean;
             tmp * tmp
         });

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -11,7 +11,7 @@ use polars_arrow::bitmap::unary_mut;
 
 use crate::prelude::*;
 use crate::series::IsSorted;
-use crate::utils::{CustomIterTools, NoNull};
+use crate::utils::CustomIterTools;
 
 impl<T> ChunkedArray<T>
 where
@@ -80,24 +80,6 @@ macro_rules! apply {
             $self
                 .into_iter()
                 .map(|opt_v| opt_v.map($f))
-                .collect_trusted()
-        }
-    }};
-}
-
-macro_rules! apply_enumerate {
-    ($self:expr, $f:expr) => {{
-        if !$self.has_validity() {
-            $self
-                .into_no_null_iter()
-                .enumerate()
-                .map($f)
-                .collect_trusted()
-        } else {
-            $self
-                .into_iter()
-                .enumerate()
-                .map(|(idx, opt_v)| opt_v.map(|v| $f((idx, v))))
                 .collect_trusted()
         }
     }};
@@ -190,7 +172,7 @@ where
 {
     type FuncRet = T::Native;
 
-    fn apply<F>(&'a self, f: F) -> Self
+    fn apply_on_values<F>(&'a self, f: F) -> Self
     where
         F: Fn(T::Native) -> T::Native + Copy,
     {
@@ -219,7 +201,7 @@ where
         Ok(ca)
     }
 
-    fn apply_on_opt<F>(&'a self, f: F) -> Self
+    fn apply<F>(&'a self, f: F) -> Self
     where
         F: Fn(Option<T::Native>) -> Option<T::Native> + Copy,
     {
@@ -230,44 +212,6 @@ where
         Self::from_chunk_iter(self.name(), chunks)
     }
 
-    fn apply_with_idx<F>(&'a self, f: F) -> Self
-    where
-        F: Fn((usize, T::Native)) -> T::Native + Copy,
-    {
-        if !self.has_validity() {
-            let ca: NoNull<_> = self
-                .into_no_null_iter()
-                .enumerate()
-                .map(f)
-                .collect_trusted();
-            ca.into_inner()
-        } else {
-            // we know that we only iterate over length == self.len()
-            unsafe {
-                self.downcast_iter()
-                    .flatten()
-                    .trust_my_length(self.len())
-                    .enumerate()
-                    .map(|(idx, opt_v)| opt_v.map(|v| f((idx, *v))))
-                    .collect_trusted()
-            }
-        }
-    }
-
-    fn apply_with_idx_on_opt<F>(&'a self, f: F) -> Self
-    where
-        F: Fn((usize, Option<T::Native>)) -> Option<T::Native> + Copy,
-    {
-        // we know that we only iterate over length == self.len()
-        unsafe {
-            self.downcast_iter()
-                .flatten()
-                .trust_my_length(self.len())
-                .enumerate()
-                .map(|(idx, v)| f((idx, v.copied())))
-                .collect_trusted()
-        }
-    }
     fn apply_to_slice<F, V>(&'a self, f: F, slice: &mut [V])
     where
         F: Fn(Option<T::Native>, &V) -> V,
@@ -290,7 +234,7 @@ where
 impl<'a> ChunkApply<'a, bool> for BooleanChunked {
     type FuncRet = bool;
 
-    fn apply<F>(&self, f: F) -> Self
+    fn apply_on_values<F>(&self, f: F) -> Self
     where
         F: Fn(bool) -> bool + Copy,
     {
@@ -351,25 +295,11 @@ impl<'a> ChunkApply<'a, bool> for BooleanChunked {
         Ok(ret)
     }
 
-    fn apply_on_opt<F>(&'a self, f: F) -> Self
+    fn apply<F>(&'a self, f: F) -> Self
     where
         F: Fn(Option<bool>) -> Option<bool> + Copy,
     {
         self.into_iter().map(f).collect_trusted()
-    }
-
-    fn apply_with_idx<F>(&'a self, f: F) -> Self
-    where
-        F: Fn((usize, bool)) -> bool + Copy,
-    {
-        apply_enumerate!(self, f)
-    }
-
-    fn apply_with_idx_on_opt<F>(&'a self, f: F) -> Self
-    where
-        F: Fn((usize, Option<bool>)) -> Option<bool> + Copy,
-    {
-        self.into_iter().enumerate().map(f).collect_trusted()
     }
 
     fn apply_to_slice<F, T>(&'a self, f: F, slice: &mut [T])
@@ -426,7 +356,7 @@ impl BinaryChunked {
 impl<'a> ChunkApply<'a, &'a str> for Utf8Chunked {
     type FuncRet = Cow<'a, str>;
 
-    fn apply<F>(&'a self, f: F) -> Self
+    fn apply_on_values<F>(&'a self, f: F) -> Self
     where
         F: Fn(&'a str) -> Cow<'a, str> + Copy,
     {
@@ -447,27 +377,11 @@ impl<'a> ChunkApply<'a, &'a str> for Utf8Chunked {
         try_apply!(self, f)
     }
 
-    fn apply_on_opt<F>(&'a self, f: F) -> Self
+    fn apply<F>(&'a self, f: F) -> Self
     where
         F: Fn(Option<&'a str>) -> Option<Cow<'a, str>> + Copy,
     {
         let mut ca: Self = self.into_iter().map(f).collect_trusted();
-        ca.rename(self.name());
-        ca
-    }
-
-    fn apply_with_idx<F>(&'a self, f: F) -> Self
-    where
-        F: Fn((usize, &'a str)) -> Cow<'a, str> + Copy,
-    {
-        apply_enumerate!(self, f)
-    }
-
-    fn apply_with_idx_on_opt<F>(&'a self, f: F) -> Self
-    where
-        F: Fn((usize, Option<&'a str>)) -> Option<Cow<'a, str>> + Copy,
-    {
-        let mut ca: Self = self.into_iter().enumerate().map(f).collect_trusted();
         ca.rename(self.name());
         ca
     }
@@ -494,7 +408,7 @@ impl<'a> ChunkApply<'a, &'a str> for Utf8Chunked {
 impl<'a> ChunkApply<'a, &'a [u8]> for BinaryChunked {
     type FuncRet = Cow<'a, [u8]>;
 
-    fn apply<F>(&'a self, f: F) -> Self
+    fn apply_on_values<F>(&'a self, f: F) -> Self
     where
         F: Fn(&'a [u8]) -> Cow<'a, [u8]> + Copy,
     {
@@ -508,27 +422,11 @@ impl<'a> ChunkApply<'a, &'a [u8]> for BinaryChunked {
         try_apply!(self, f)
     }
 
-    fn apply_on_opt<F>(&'a self, f: F) -> Self
+    fn apply<F>(&'a self, f: F) -> Self
     where
         F: Fn(Option<&'a [u8]>) -> Option<Cow<'a, [u8]>> + Copy,
     {
         let mut ca: Self = self.into_iter().map(f).collect_trusted();
-        ca.rename(self.name());
-        ca
-    }
-
-    fn apply_with_idx<F>(&'a self, f: F) -> Self
-    where
-        F: Fn((usize, &'a [u8])) -> Cow<'a, [u8]> + Copy,
-    {
-        apply_enumerate!(self, f)
-    }
-
-    fn apply_with_idx_on_opt<F>(&'a self, f: F) -> Self
-    where
-        F: Fn((usize, Option<&'a [u8]>)) -> Option<Cow<'a, [u8]>> + Copy,
-    {
-        let mut ca: Self = self.into_iter().enumerate().map(f).collect_trusted();
         ca.rename(self.name());
         ca
     }
@@ -618,7 +516,7 @@ impl<'a> ChunkApply<'a, Series> for ListChunked {
     type FuncRet = Series;
 
     /// Apply a closure `F` elementwise.
-    fn apply<F>(&'a self, f: F) -> Self
+    fn apply_on_values<F>(&'a self, f: F) -> Self
     where
         F: Fn(Series) -> Series + Copy,
     {
@@ -666,7 +564,7 @@ impl<'a> ChunkApply<'a, Series> for ListChunked {
         Ok(ca)
     }
 
-    fn apply_on_opt<F>(&'a self, f: F) -> Self
+    fn apply<F>(&'a self, f: F) -> Self
     where
         F: Fn(Option<Series>) -> Option<Series> + Copy,
     {
@@ -674,54 +572,6 @@ impl<'a> ChunkApply<'a, Series> for ListChunked {
             return self.clone();
         }
         self.into_iter().map(f).collect_trusted()
-    }
-
-    /// Apply a closure elementwise. The closure gets the index of the element as first argument.
-    fn apply_with_idx<F>(&'a self, f: F) -> Self
-    where
-        F: Fn((usize, Series)) -> Series + Copy,
-    {
-        if self.is_empty() {
-            return self.clone();
-        }
-        let mut fast_explode = true;
-        let mut function = |(idx, s)| {
-            let out = f((idx, s));
-            if out.is_empty() {
-                fast_explode = false;
-            }
-            out
-        };
-        let mut ca: ListChunked = apply_enumerate!(self, function);
-        if fast_explode {
-            ca.set_fast_explode()
-        }
-        ca
-    }
-
-    /// Apply a closure elementwise. The closure gets the index of the element as first argument.
-    fn apply_with_idx_on_opt<F>(&'a self, f: F) -> Self
-    where
-        F: Fn((usize, Option<Series>)) -> Option<Series> + Copy,
-    {
-        if self.is_empty() {
-            return self.clone();
-        }
-        let mut fast_explode = true;
-        let function = |(idx, s)| {
-            let out = f((idx, s));
-            if let Some(out) = &out {
-                if out.is_empty() {
-                    fast_explode = false;
-                }
-            }
-            out
-        };
-        let mut ca: ListChunked = self.into_iter().enumerate().map(function).collect_trusted();
-        if fast_explode {
-            ca.set_fast_explode()
-        }
-        ca
     }
 
     fn apply_to_slice<F, T>(&'a self, f: F, slice: &mut [T])
@@ -752,7 +602,7 @@ where
 {
     type FuncRet = T;
 
-    fn apply<F>(&'a self, f: F) -> Self
+    fn apply_on_values<F>(&'a self, f: F) -> Self
     where
         F: Fn(&'a T) -> T + Copy,
     {
@@ -768,27 +618,13 @@ where
         todo!()
     }
 
-    fn apply_on_opt<F>(&'a self, f: F) -> Self
+    fn apply<F>(&'a self, f: F) -> Self
     where
         F: Fn(Option<&'a T>) -> Option<T> + Copy,
     {
         let mut ca: ObjectChunked<T> = self.into_iter().map(f).collect();
         ca.rename(self.name());
         ca
-    }
-
-    fn apply_with_idx<F>(&'a self, _f: F) -> Self
-    where
-        F: Fn((usize, &'a T)) -> T + Copy,
-    {
-        todo!()
-    }
-
-    fn apply_with_idx_on_opt<F>(&'a self, _f: F) -> Self
-    where
-        F: Fn((usize, Option<&'a T>)) -> Option<T> + Copy,
-    {
-        todo!()
     }
 
     fn apply_to_slice<F, V>(&'a self, f: F, slice: &mut [V])

--- a/crates/polars-core/src/chunked_array/ops/is_in.rs
+++ b/crates/polars-core/src/chunked_array/ops/is_in.rs
@@ -19,7 +19,7 @@ where
             }
         })
     });
-    Ok(ca.apply_values(|val| set.contains(&val)))
+    Ok(ca.apply_values_generic(|val| set.contains(&val)))
 }
 
 impl<T> IsIn for ChunkedArray<T>
@@ -256,7 +256,7 @@ impl IsIn for BooleanChunked {
                 } else {
                     !(other.sum().unwrap() as usize + nc) == other.len()
                 };
-                Ok(self.apply_on_values(|v| if v { has_true } else { has_false }))
+                Ok(self.apply_values(|v| if v { has_true } else { has_false }))
             }
             _ => polars_bail!(opq = is_in, self.dtype(), other.dtype()),
         }

--- a/crates/polars-core/src/chunked_array/ops/is_in.rs
+++ b/crates/polars-core/src/chunked_array/ops/is_in.rs
@@ -256,7 +256,7 @@ impl IsIn for BooleanChunked {
                 } else {
                     !(other.sum().unwrap() as usize + nc) == other.len()
                 };
-                Ok(self.apply(|v| if v { has_true } else { has_false }))
+                Ok(self.apply_on_values(|v| if v { has_true } else { has_false }))
             }
             _ => polars_bail!(opq = is_in, self.dtype(), other.dtype()),
         }

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -297,16 +297,6 @@ pub trait ChunkCast {
 }
 
 pub trait ChunkApplyCast<'a>: HasUnderlyingArray {
-    /// Apply a closure elementwise and cast to a Numeric [`ChunkedArray`]. This is fastest when the null check branching is more expensive
-    /// than the closure application.
-    ///
-    /// Null values remain null.
-    fn apply_cast_numeric<F, R>(&'a self, f: F) -> ChunkedArray<R>
-    where
-        F: Fn(<<Self as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>) -> R::Native
-            + Copy,
-        R: PolarsNumericType;
-
     /// Apply a closure on optional values and cast to Numeric ChunkedArray without null values.
     fn branch_apply_cast_numeric_no_null<F, R>(&'a self, f: F) -> ChunkedArray<R>
     where

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -296,17 +296,6 @@ pub trait ChunkCast {
     unsafe fn cast_unchecked(&self, data_type: &DataType) -> PolarsResult<Series>;
 }
 
-pub trait ChunkApplyCast<'a>: HasUnderlyingArray {
-    /// Apply a closure on optional values and cast to Numeric ChunkedArray without null values.
-    fn branch_apply_cast_numeric_no_null<F, R>(&'a self, f: F) -> ChunkedArray<R>
-    where
-        F: Fn(
-                Option<<<Self as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>>,
-            ) -> R::Native
-            + Copy,
-        R: PolarsNumericType;
-}
-
 /// Fastest way to do elementwise operations on a [`ChunkedArray<T>`] when the operation is cheaper than
 /// branching due to null checking.
 pub trait ChunkApply<'a, T> {
@@ -322,11 +311,11 @@ pub trait ChunkApply<'a, T> {
     /// ```
     /// use polars_core::prelude::*;
     /// fn double(ca: &UInt32Chunked) -> UInt32Chunked {
-    ///     ca.apply_on_values(|v| v * 2)
+    ///     ca.apply_values(|v| v * 2)
     /// }
     /// ```
     #[must_use]
-    fn apply_on_values<F>(&'a self, f: F) -> Self
+    fn apply_values<F>(&'a self, f: F) -> Self
     where
         F: Fn(T) -> Self::FuncRet + Copy;
 

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -332,11 +332,11 @@ pub trait ChunkApply<'a, T> {
     /// ```
     /// use polars_core::prelude::*;
     /// fn double(ca: &UInt32Chunked) -> UInt32Chunked {
-    ///     ca.apply(|v| v * 2)
+    ///     ca.apply_on_values(|v| v * 2)
     /// }
     /// ```
     #[must_use]
-    fn apply<F>(&'a self, f: F) -> Self
+    fn apply_on_values<F>(&'a self, f: F) -> Self
     where
         F: Fn(T) -> Self::FuncRet + Copy;
 
@@ -347,21 +347,9 @@ pub trait ChunkApply<'a, T> {
 
     /// Apply a closure elementwise including null values.
     #[must_use]
-    fn apply_on_opt<F>(&'a self, f: F) -> Self
+    fn apply<F>(&'a self, f: F) -> Self
     where
         F: Fn(Option<T>) -> Option<Self::FuncRet> + Copy;
-
-    /// Apply a closure elementwise. The closure gets the index of the element as first argument.
-    #[must_use]
-    fn apply_with_idx<F>(&'a self, f: F) -> Self
-    where
-        F: Fn((usize, T)) -> Self::FuncRet + Copy;
-
-    /// Apply a closure elementwise. The closure gets the index of the element as first argument.
-    #[must_use]
-    fn apply_with_idx_on_opt<F>(&'a self, f: F) -> Self
-    where
-        F: Fn((usize, Option<T>)) -> Option<Self::FuncRet> + Copy;
 
     /// Apply a closure elementwise and write results to a mutable slice.
     fn apply_to_slice<F, S>(&'a self, f: F, slice: &mut [S])

--- a/crates/polars-core/src/datatypes/from_values.rs
+++ b/crates/polars-core/src/datatypes/from_values.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use arrow::array::{BooleanArray, PrimitiveArray, Utf8Array};
-use polars_arrow::array::utf8::Utf8FromIter;
+use arrow::array::{BinaryArray, BooleanArray, PrimitiveArray, Utf8Array};
+use polars_arrow::array::utf8::{BinaryFromIter, Utf8FromIter};
 use polars_arrow::trusted_len::TrustedLen;
 
 use crate::prelude::StaticArray;
@@ -57,6 +57,8 @@ impl_primitive!(i8);
 impl_primitive!(i16);
 impl_primitive!(i32);
 impl_primitive!(i64);
+impl_primitive!(f32);
+impl_primitive!(f64);
 
 impl ArrayFromElementIter for &str {
     type ArrayType = Utf8Array<i64>;
@@ -85,5 +87,20 @@ impl ArrayFromElementIter for Cow<'_, str> {
         // SAFETY: guarded by `TrustedLen` trait
         let len = iter.size_hint().0;
         Utf8Array::from_values_iter(iter, len, len * 24)
+    }
+}
+
+impl ArrayFromElementIter for Cow<'_, [u8]> {
+    type ArrayType = BinaryArray<i64>;
+
+    fn array_from_iter<I: TrustedLen<Item = Option<Self>>>(iter: I) -> Self::ArrayType {
+        // SAFETY: guarded by `TrustedLen` trait
+        unsafe { BinaryArray::from_trusted_len_iter_unchecked(iter) }
+    }
+
+    fn array_from_values_iter<I: TrustedLen<Item = Self>>(iter: I) -> Self::ArrayType {
+        // SAFETY: guarded by `TrustedLen` trait
+        let len = iter.size_hint().0;
+        BinaryArray::from_values_iter(iter, len, len * 24)
     }
 }

--- a/crates/polars-core/src/datatypes/from_values.rs
+++ b/crates/polars-core/src/datatypes/from_values.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use arrow::array::{BooleanArray, PrimitiveArray, Utf8Array};
 use polars_arrow::array::utf8::Utf8FromIter;
 use polars_arrow::trusted_len::TrustedLen;
@@ -57,6 +59,21 @@ impl_primitive!(i32);
 impl_primitive!(i64);
 
 impl ArrayFromElementIter for &str {
+    type ArrayType = Utf8Array<i64>;
+
+    fn array_from_iter<I: TrustedLen<Item = Option<Self>>>(iter: I) -> Self::ArrayType {
+        // SAFETY: guarded by `TrustedLen` trait
+        unsafe { Utf8Array::from_trusted_len_iter_unchecked(iter) }
+    }
+
+    fn array_from_values_iter<I: TrustedLen<Item = Self>>(iter: I) -> Self::ArrayType {
+        // SAFETY: guarded by `TrustedLen` trait
+        let len = iter.size_hint().0;
+        Utf8Array::from_values_iter(iter, len, len * 24)
+    }
+}
+
+impl ArrayFromElementIter for Cow<'_, str> {
     type ArrayType = Utf8Array<i64>;
 
     fn array_from_iter<I: TrustedLen<Item = Option<Self>>>(iter: I) -> Self::ArrayType {

--- a/crates/polars-core/src/functions.rs
+++ b/crates/polars-core/src/functions.rs
@@ -49,8 +49,8 @@ where
     } else {
         let a_mean = a.mean()?;
         let b_mean = b.mean()?;
-        let a = a.apply_cast_numeric::<_, Float64Type>(|a| a.to_f64().unwrap() - a_mean);
-        let b = b.apply_cast_numeric(|b| b.to_f64().unwrap() - b_mean);
+        let a: Float64Chunked = a.apply_values(|a| a.to_f64().unwrap() - a_mean);
+        let b: Float64Chunked = b.apply_values(|b| b.to_f64().unwrap() - b_mean);
 
         let tmp = a * b;
         let n = tmp.len() - tmp.null_count();

--- a/crates/polars-core/src/functions.rs
+++ b/crates/polars-core/src/functions.rs
@@ -49,8 +49,8 @@ where
     } else {
         let a_mean = a.mean()?;
         let b_mean = b.mean()?;
-        let a: Float64Chunked = a.apply_values(|a| a.to_f64().unwrap() - a_mean);
-        let b: Float64Chunked = b.apply_values(|b| b.to_f64().unwrap() - b_mean);
+        let a: Float64Chunked = a.apply_values_generic(|a| a.to_f64().unwrap() - a_mean);
+        let b: Float64Chunked = b.apply_values_generic(|b| b.to_f64().unwrap() - b_mean);
 
         let tmp = a * b;
         let n = tmp.len() - tmp.null_count();

--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -234,50 +234,50 @@ pub mod checked {
                 UInt8 => s
                     .u8()
                     .unwrap()
-                    .apply_on_opt(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_u8().unwrap())))
+                    .apply(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_u8().unwrap())))
                     .into_series(),
                 #[cfg(feature = "dtype-i8")]
                 Int8 => s
                     .i8()
                     .unwrap()
-                    .apply_on_opt(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_i8().unwrap())))
+                    .apply(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_i8().unwrap())))
                     .into_series(),
                 #[cfg(feature = "dtype-i16")]
                 Int16 => s
                     .i16()
                     .unwrap()
-                    .apply_on_opt(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_i16().unwrap())))
+                    .apply(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_i16().unwrap())))
                     .into_series(),
                 #[cfg(feature = "dtype-u16")]
                 UInt16 => s
                     .u16()
                     .unwrap()
-                    .apply_on_opt(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_u16().unwrap())))
+                    .apply(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_u16().unwrap())))
                     .into_series(),
                 UInt32 => s
                     .u32()
                     .unwrap()
-                    .apply_on_opt(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_u32().unwrap())))
+                    .apply(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_u32().unwrap())))
                     .into_series(),
                 Int32 => s
                     .i32()
                     .unwrap()
-                    .apply_on_opt(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_i32().unwrap())))
+                    .apply(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_i32().unwrap())))
                     .into_series(),
                 UInt64 => s
                     .u64()
                     .unwrap()
-                    .apply_on_opt(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_u64().unwrap())))
+                    .apply(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_u64().unwrap())))
                     .into_series(),
                 Int64 => s
                     .i64()
                     .unwrap()
-                    .apply_on_opt(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_i64().unwrap())))
+                    .apply(|opt_v| opt_v.and_then(|v| v.checked_div(rhs.to_i64().unwrap())))
                     .into_series(),
                 Float32 => s
                     .f32()
                     .unwrap()
-                    .apply_on_opt(|opt_v| {
+                    .apply(|opt_v| {
                         opt_v.and_then(|v| {
                             let res = rhs.to_f32().unwrap();
                             if res.is_zero() {
@@ -291,7 +291,7 @@ pub mod checked {
                 Float64 => s
                     .f64()
                     .unwrap()
-                    .apply_on_opt(|opt_v| {
+                    .apply(|opt_v| {
                         opt_v.and_then(|v| {
                             let res = rhs.to_f64().unwrap();
                             if res.is_zero() {
@@ -698,21 +698,21 @@ where
     #[must_use]
     pub fn lhs_sub<N: Num + NumCast>(&self, lhs: N) -> Self {
         let lhs: T::Native = NumCast::from(lhs).expect("could not cast");
-        self.apply(|v| lhs - v)
+        self.apply_on_values(|v| lhs - v)
     }
 
     /// Apply lhs / self
     #[must_use]
     pub fn lhs_div<N: Num + NumCast>(&self, lhs: N) -> Self {
         let lhs: T::Native = NumCast::from(lhs).expect("could not cast");
-        self.apply(|v| lhs / v)
+        self.apply_on_values(|v| lhs / v)
     }
 
     /// Apply lhs % self
     #[must_use]
     pub fn lhs_rem<N: Num + NumCast>(&self, lhs: N) -> Self {
         let lhs: T::Native = NumCast::from(lhs).expect("could not cast");
-        self.apply(|v| lhs % v)
+        self.apply_on_values(|v| lhs % v)
     }
 }
 

--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -698,21 +698,21 @@ where
     #[must_use]
     pub fn lhs_sub<N: Num + NumCast>(&self, lhs: N) -> Self {
         let lhs: T::Native = NumCast::from(lhs).expect("could not cast");
-        self.apply_on_values(|v| lhs - v)
+        self.apply_values(|v| lhs - v)
     }
 
     /// Apply lhs / self
     #[must_use]
     pub fn lhs_div<N: Num + NumCast>(&self, lhs: N) -> Self {
         let lhs: T::Native = NumCast::from(lhs).expect("could not cast");
-        self.apply_on_values(|v| lhs / v)
+        self.apply_values(|v| lhs / v)
     }
 
     /// Apply lhs % self
     #[must_use]
     pub fn lhs_rem<N: Num + NumCast>(&self, lhs: N) -> Self {
         let lhs: T::Native = NumCast::from(lhs).expect("could not cast");
-        self.apply_on_values(|v| lhs % v)
+        self.apply_values(|v| lhs % v)
     }
 }
 

--- a/crates/polars-core/src/series/ops/round.rs
+++ b/crates/polars-core/src/series/ops/round.rs
@@ -8,26 +8,26 @@ impl Series {
     pub fn round(&self, decimals: u32) -> PolarsResult<Self> {
         if let Ok(ca) = self.f32() {
             if decimals == 0 {
-                let s = ca.apply(|val| val.round()).into_series();
+                let s = ca.apply_on_values(|val| val.round()).into_series();
                 return Ok(s);
             } else {
                 // Note we do the computation on f64 floats to not lose precision
                 // when the computation is done, we cast to f32
                 let multiplier = 10.0.pow(decimals as f64);
                 let s = ca
-                    .apply(|val| ((val as f64 * multiplier).round() / multiplier) as f32)
+                    .apply_on_values(|val| ((val as f64 * multiplier).round() / multiplier) as f32)
                     .into_series();
                 return Ok(s);
             }
         }
         if let Ok(ca) = self.f64() {
             if decimals == 0 {
-                let s = ca.apply(|val| val.round()).into_series();
+                let s = ca.apply_on_values(|val| val.round()).into_series();
                 return Ok(s);
             } else {
                 let multiplier = 10.0.pow(decimals as f64);
                 let s = ca
-                    .apply(|val| (val * multiplier).round() / multiplier)
+                    .apply_on_values(|val| (val * multiplier).round() / multiplier)
                     .into_series();
                 return Ok(s);
             }
@@ -38,11 +38,11 @@ impl Series {
     /// Floor underlying floating point array to the lowest integers smaller or equal to the float value.
     pub fn floor(&self) -> PolarsResult<Self> {
         if let Ok(ca) = self.f32() {
-            let s = ca.apply(|val| val.floor()).into_series();
+            let s = ca.apply_on_values(|val| val.floor()).into_series();
             return Ok(s);
         }
         if let Ok(ca) = self.f64() {
-            let s = ca.apply(|val| val.floor()).into_series();
+            let s = ca.apply_on_values(|val| val.floor()).into_series();
             return Ok(s);
         }
         polars_bail!(opq = floor, self.dtype());
@@ -51,11 +51,11 @@ impl Series {
     /// Ceil underlying floating point array to the highest integers smaller or equal to the float value.
     pub fn ceil(&self) -> PolarsResult<Self> {
         if let Ok(ca) = self.f32() {
-            let s = ca.apply(|val| val.ceil()).into_series();
+            let s = ca.apply_on_values(|val| val.ceil()).into_series();
             return Ok(s);
         }
         if let Ok(ca) = self.f64() {
-            let s = ca.apply(|val| val.ceil()).into_series();
+            let s = ca.apply_on_values(|val| val.ceil()).into_series();
             return Ok(s);
         }
         polars_bail!(opq = ceil, self.dtype());

--- a/crates/polars-core/src/series/ops/round.rs
+++ b/crates/polars-core/src/series/ops/round.rs
@@ -8,26 +8,26 @@ impl Series {
     pub fn round(&self, decimals: u32) -> PolarsResult<Self> {
         if let Ok(ca) = self.f32() {
             if decimals == 0 {
-                let s = ca.apply_on_values(|val| val.round()).into_series();
+                let s = ca.apply_values(|val| val.round()).into_series();
                 return Ok(s);
             } else {
                 // Note we do the computation on f64 floats to not lose precision
                 // when the computation is done, we cast to f32
                 let multiplier = 10.0.pow(decimals as f64);
                 let s = ca
-                    .apply_on_values(|val| ((val as f64 * multiplier).round() / multiplier) as f32)
+                    .apply_values(|val| ((val as f64 * multiplier).round() / multiplier) as f32)
                     .into_series();
                 return Ok(s);
             }
         }
         if let Ok(ca) = self.f64() {
             if decimals == 0 {
-                let s = ca.apply_on_values(|val| val.round()).into_series();
+                let s = ca.apply_values(|val| val.round()).into_series();
                 return Ok(s);
             } else {
                 let multiplier = 10.0.pow(decimals as f64);
                 let s = ca
-                    .apply_on_values(|val| (val * multiplier).round() / multiplier)
+                    .apply_values(|val| (val * multiplier).round() / multiplier)
                     .into_series();
                 return Ok(s);
             }
@@ -38,11 +38,11 @@ impl Series {
     /// Floor underlying floating point array to the lowest integers smaller or equal to the float value.
     pub fn floor(&self) -> PolarsResult<Self> {
         if let Ok(ca) = self.f32() {
-            let s = ca.apply_on_values(|val| val.floor()).into_series();
+            let s = ca.apply_values(|val| val.floor()).into_series();
             return Ok(s);
         }
         if let Ok(ca) = self.f64() {
-            let s = ca.apply_on_values(|val| val.floor()).into_series();
+            let s = ca.apply_values(|val| val.floor()).into_series();
             return Ok(s);
         }
         polars_bail!(opq = floor, self.dtype());
@@ -51,11 +51,11 @@ impl Series {
     /// Ceil underlying floating point array to the highest integers smaller or equal to the float value.
     pub fn ceil(&self) -> PolarsResult<Self> {
         if let Ok(ca) = self.f32() {
-            let s = ca.apply_on_values(|val| val.ceil()).into_series();
+            let s = ca.apply_values(|val| val.ceil()).into_series();
             return Ok(s);
         }
         if let Ok(ca) = self.f64() {
-            let s = ca.apply_on_values(|val| val.ceil()).into_series();
+            let s = ca.apply_values(|val| val.ceil()).into_series();
             return Ok(s);
         }
         polars_bail!(opq = ceil, self.dtype());

--- a/crates/polars-ops/src/chunked_array/binary/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/binary/namespace.rs
@@ -60,7 +60,7 @@ pub trait BinaryNameSpaceImpl: AsBinary {
                 Ok(bytes.into())
             })
         } else {
-            Ok(ca.apply_on_opt(|opt_s| opt_s.and_then(|s| hex::decode(s).ok().map(Cow::Owned))))
+            Ok(ca.apply(|opt_s| opt_s.and_then(|s| hex::decode(s).ok().map(Cow::Owned))))
         }
     }
 
@@ -68,7 +68,7 @@ pub trait BinaryNameSpaceImpl: AsBinary {
     fn hex_encode(&self) -> Series {
         let ca = self.as_binary();
         unsafe {
-            ca.apply(|s| hex::encode(s).into_bytes().into())
+            ca.apply_on_values(|s| hex::encode(s).into_bytes().into())
                 .cast_unchecked(&DataType::Utf8)
                 .unwrap()
         }
@@ -88,7 +88,7 @@ pub trait BinaryNameSpaceImpl: AsBinary {
                 Ok(bytes.into())
             })
         } else {
-            Ok(ca.apply_on_opt(|opt_s| {
+            Ok(ca.apply(|opt_s| {
                 opt_s.and_then(|s| general_purpose::STANDARD.decode(s).ok().map(Cow::Owned))
             }))
         }
@@ -98,7 +98,7 @@ pub trait BinaryNameSpaceImpl: AsBinary {
     fn base64_encode(&self) -> Series {
         let ca = self.as_binary();
         unsafe {
-            ca.apply(|s| general_purpose::STANDARD.encode(s).into_bytes().into())
+            ca.apply_on_values(|s| general_purpose::STANDARD.encode(s).into_bytes().into())
                 .cast_unchecked(&DataType::Utf8)
                 .unwrap()
         }

--- a/crates/polars-ops/src/chunked_array/binary/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/binary/namespace.rs
@@ -68,7 +68,7 @@ pub trait BinaryNameSpaceImpl: AsBinary {
     fn hex_encode(&self) -> Series {
         let ca = self.as_binary();
         unsafe {
-            ca.apply_on_values(|s| hex::encode(s).into_bytes().into())
+            ca.apply_values(|s| hex::encode(s).into_bytes().into())
                 .cast_unchecked(&DataType::Utf8)
                 .unwrap()
         }
@@ -98,7 +98,7 @@ pub trait BinaryNameSpaceImpl: AsBinary {
     fn base64_encode(&self) -> Series {
         let ca = self.as_binary();
         unsafe {
-            ca.apply_on_values(|s| general_purpose::STANDARD.encode(s).into_bytes().into())
+            ca.apply_values(|s| general_purpose::STANDARD.encode(s).into_bytes().into())
                 .cast_unchecked(&DataType::Utf8)
                 .unwrap()
         }

--- a/crates/polars-ops/src/chunked_array/strings/json_path.rs
+++ b/crates/polars-ops/src/chunked_array/strings/json_path.rs
@@ -45,7 +45,7 @@ pub trait Utf8JsonPathImpl: AsUtf8 {
             .map_err(|e| polars_err!(ComputeError: "error compiling JSONpath expression {}", e))?;
         Ok(self
             .as_utf8()
-            .apply_on_opt(|opt_s| opt_s.and_then(|s| extract_json(&pat, s))))
+            .apply(|opt_s| opt_s.and_then(|s| extract_json(&pat, s))))
     }
 
     /// Returns the inferred DataType for JSON values for each row
@@ -93,7 +93,7 @@ pub trait Utf8JsonPathImpl: AsUtf8 {
             .map_err(|e| polars_err!(ComputeError: "error compiling JSONpath expression: {}", e))?;
         Ok(self
             .as_utf8()
-            .apply_on_opt(|opt_s| opt_s.and_then(|s| select_json(&pat, s))))
+            .apply(|opt_s| opt_s.and_then(|s| select_json(&pat, s))))
     }
 
     fn json_path_extract(

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -29,7 +29,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     #[cfg(feature = "string_encoding")]
     fn hex_encode(&self) -> Utf8Chunked {
         let ca = self.as_utf8();
-        ca.apply_on_values(|s| hex::encode(s).into())
+        ca.apply_values(|s| hex::encode(s).into())
     }
 
     #[cfg(not(feature = "binary_encoding"))]
@@ -47,7 +47,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     #[cfg(feature = "string_encoding")]
     fn base64_encode(&self) -> Utf8Chunked {
         let ca = self.as_utf8();
-        ca.apply_on_values(|s| general_purpose::STANDARD.encode(s).into())
+        ca.apply_values(|s| general_purpose::STANDARD.encode(s).into())
     }
 
     #[cfg(feature = "string_from_radix")]
@@ -178,7 +178,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
         let reg = Regex::new(pat)?;
         let f = |s: &'a str| reg.replace(s, val);
         let ca = self.as_utf8();
-        Ok(ca.apply_on_values(f))
+        Ok(ca.apply_values(f))
     }
 
     /// Replace the leftmost literal (sub)string with another string
@@ -235,7 +235,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     fn replace_all(&self, pat: &str, val: &str) -> PolarsResult<Utf8Chunked> {
         let ca = self.as_utf8();
         let reg = Regex::new(pat)?;
-        Ok(ca.apply_on_values(|s| reg.replace_all(s, val)))
+        Ok(ca.apply_values(|s| reg.replace_all(s, val)))
     }
 
     /// Replace all matching literal (sub)strings with another string

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -29,7 +29,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     #[cfg(feature = "string_encoding")]
     fn hex_encode(&self) -> Utf8Chunked {
         let ca = self.as_utf8();
-        ca.apply(|s| hex::encode(s).into())
+        ca.apply_on_values(|s| hex::encode(s).into())
     }
 
     #[cfg(not(feature = "binary_encoding"))]
@@ -47,7 +47,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     #[cfg(feature = "string_encoding")]
     fn base64_encode(&self) -> Utf8Chunked {
         let ca = self.as_utf8();
-        ca.apply(|s| general_purpose::STANDARD.encode(s).into())
+        ca.apply_on_values(|s| general_purpose::STANDARD.encode(s).into())
     }
 
     #[cfg(feature = "string_from_radix")]
@@ -178,7 +178,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
         let reg = Regex::new(pat)?;
         let f = |s: &'a str| reg.replace(s, val);
         let ca = self.as_utf8();
-        Ok(ca.apply(f))
+        Ok(ca.apply_on_values(f))
     }
 
     /// Replace the leftmost literal (sub)string with another string
@@ -235,7 +235,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     fn replace_all(&self, pat: &str, val: &str) -> PolarsResult<Utf8Chunked> {
         let ca = self.as_utf8();
         let reg = Regex::new(pat)?;
-        Ok(ca.apply(|s| reg.replace_all(s, val)))
+        Ok(ca.apply_on_values(|s| reg.replace_all(s, val)))
     }
 
     /// Replace all matching literal (sub)strings with another string

--- a/crates/polars-ops/src/frame/pivot/mod.rs
+++ b/crates/polars-ops/src/frame/pivot/mod.rs
@@ -241,7 +241,7 @@ fn pivot_impl(
                 let headers = column_agg.unique_stable()?.cast(&DataType::Utf8)?;
                 let mut headers = headers.utf8().unwrap().clone();
                 if values.len() > 1 {
-                    headers = headers.apply(|v| Cow::from(format!("{value_col_name}{sep}{column_column_name}{sep}{v}")))
+                    headers = headers.apply_on_values(|v| Cow::from(format!("{value_col_name}{sep}{column_column_name}{sep}{v}")))
                 }
 
                 let n_cols = headers.len();

--- a/crates/polars-ops/src/frame/pivot/mod.rs
+++ b/crates/polars-ops/src/frame/pivot/mod.rs
@@ -241,7 +241,7 @@ fn pivot_impl(
                 let headers = column_agg.unique_stable()?.cast(&DataType::Utf8)?;
                 let mut headers = headers.utf8().unwrap().clone();
                 if values.len() > 1 {
-                    headers = headers.apply_on_values(|v| Cow::from(format!("{value_col_name}{sep}{column_column_name}{sep}{v}")))
+                    headers = headers.apply_values(|v| Cow::from(format!("{value_col_name}{sep}{column_column_name}{sep}{v}")))
                 }
 
                 let n_cols = headers.len();

--- a/crates/polars-ops/src/series/ops/floor_divide.rs
+++ b/crates/polars-ops/src/series/ops/floor_divide.rs
@@ -57,7 +57,7 @@ fn floor_div_ca<T: PolarsNumericType>(a: &ChunkedArray<T>, b: &ChunkedArray<T>) 
         let name = a.name();
         return if let Some(a) = a.get(0) {
             let mut out = if b.null_count() == 0 {
-                b.apply_on_values(|b| floor_div_element(a, b))
+                b.apply_values(|b| floor_div_element(a, b))
             } else {
                 b.apply(|b| b.map(|b| floor_div_element(a, b)))
             };
@@ -70,7 +70,7 @@ fn floor_div_ca<T: PolarsNumericType>(a: &ChunkedArray<T>, b: &ChunkedArray<T>) 
     if b.len() == 1 {
         return if let Some(b) = b.get(0) {
             if a.null_count() == 0 {
-                a.apply_on_values(|a| floor_div_element(a, b))
+                a.apply_values(|a| floor_div_element(a, b))
             } else {
                 a.apply(|a| a.map(|a| floor_div_element(a, b)))
             }

--- a/crates/polars-ops/src/series/ops/floor_divide.rs
+++ b/crates/polars-ops/src/series/ops/floor_divide.rs
@@ -57,9 +57,9 @@ fn floor_div_ca<T: PolarsNumericType>(a: &ChunkedArray<T>, b: &ChunkedArray<T>) 
         let name = a.name();
         return if let Some(a) = a.get(0) {
             let mut out = if b.null_count() == 0 {
-                b.apply(|b| floor_div_element(a, b))
+                b.apply_on_values(|b| floor_div_element(a, b))
             } else {
-                b.apply_on_opt(|b| b.map(|b| floor_div_element(a, b)))
+                b.apply(|b| b.map(|b| floor_div_element(a, b)))
             };
             out.rename(name);
             out
@@ -70,9 +70,9 @@ fn floor_div_ca<T: PolarsNumericType>(a: &ChunkedArray<T>, b: &ChunkedArray<T>) 
     if b.len() == 1 {
         return if let Some(b) = b.get(0) {
             if a.null_count() == 0 {
-                a.apply(|a| floor_div_element(a, b))
+                a.apply_on_values(|a| floor_div_element(a, b))
             } else {
-                a.apply_on_opt(|a| a.map(|a| floor_div_element(a, b)))
+                a.apply(|a| a.map(|a| floor_div_element(a, b)))
             }
         } else {
             ChunkedArray::full_null(a.name(), a.len())

--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -29,12 +29,12 @@ pub trait LogSeries: SeriesSealed {
             Float32 => s
                 .f32()
                 .unwrap()
-                .apply_on_values(|v| v.log(base as f32))
+                .apply_values(|v| v.log(base as f32))
                 .into_series(),
             Float64 => s
                 .f64()
                 .unwrap()
-                .apply_on_values(|v| v.log(base))
+                .apply_values(|v| v.log(base))
                 .into_series(),
             _ => s.cast(&DataType::Float64).unwrap().log(base),
         }
@@ -54,12 +54,12 @@ pub trait LogSeries: SeriesSealed {
             Float32 => s
                 .f32()
                 .unwrap()
-                .apply_on_values(|v| v.ln_1p())
+                .apply_values(|v| v.ln_1p())
                 .into_series(),
             Float64 => s
                 .f64()
                 .unwrap()
-                .apply_on_values(|v| v.ln_1p())
+                .apply_values(|v| v.ln_1p())
                 .into_series(),
             _ => s.cast(&DataType::Float64).unwrap().log1p(),
         }
@@ -76,8 +76,8 @@ pub trait LogSeries: SeriesSealed {
             Int64 => exp(s.i64().unwrap()).into_series(),
             UInt32 => exp(s.u32().unwrap()).into_series(),
             UInt64 => exp(s.u64().unwrap()).into_series(),
-            Float32 => s.f32().unwrap().apply_on_values(|v| v.exp()).into_series(),
-            Float64 => s.f64().unwrap().apply_on_values(|v| v.exp()).into_series(),
+            Float32 => s.f32().unwrap().apply_values(|v| v.exp()).into_series(),
+            Float64 => s.f64().unwrap().apply_values(|v| v.exp()).into_series(),
             _ => s.cast(&DataType::Float64).unwrap().exp(),
         }
     }

--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -26,8 +26,16 @@ pub trait LogSeries: SeriesSealed {
             Int64 => log(s.i64().unwrap(), base).into_series(),
             UInt32 => log(s.u32().unwrap(), base).into_series(),
             UInt64 => log(s.u64().unwrap(), base).into_series(),
-            Float32 => s.f32().unwrap().apply(|v| v.log(base as f32)).into_series(),
-            Float64 => s.f64().unwrap().apply(|v| v.log(base)).into_series(),
+            Float32 => s
+                .f32()
+                .unwrap()
+                .apply_on_values(|v| v.log(base as f32))
+                .into_series(),
+            Float64 => s
+                .f64()
+                .unwrap()
+                .apply_on_values(|v| v.log(base))
+                .into_series(),
             _ => s.cast(&DataType::Float64).unwrap().log(base),
         }
     }
@@ -43,8 +51,16 @@ pub trait LogSeries: SeriesSealed {
             Int64 => log1p(s.i64().unwrap()).into_series(),
             UInt32 => log1p(s.u32().unwrap()).into_series(),
             UInt64 => log1p(s.u64().unwrap()).into_series(),
-            Float32 => s.f32().unwrap().apply(|v| v.ln_1p()).into_series(),
-            Float64 => s.f64().unwrap().apply(|v| v.ln_1p()).into_series(),
+            Float32 => s
+                .f32()
+                .unwrap()
+                .apply_on_values(|v| v.ln_1p())
+                .into_series(),
+            Float64 => s
+                .f64()
+                .unwrap()
+                .apply_on_values(|v| v.ln_1p())
+                .into_series(),
             _ => s.cast(&DataType::Float64).unwrap().log1p(),
         }
     }
@@ -60,8 +76,8 @@ pub trait LogSeries: SeriesSealed {
             Int64 => exp(s.i64().unwrap()).into_series(),
             UInt32 => exp(s.u32().unwrap()).into_series(),
             UInt64 => exp(s.u64().unwrap()).into_series(),
-            Float32 => s.f32().unwrap().apply(|v| v.exp()).into_series(),
-            Float64 => s.f64().unwrap().apply(|v| v.exp()).into_series(),
+            Float32 => s.f32().unwrap().apply_on_values(|v| v.exp()).into_series(),
+            Float64 => s.f64().unwrap().apply_on_values(|v| v.exp()).into_series(),
             _ => s.cast(&DataType::Float64).unwrap().exp(),
         }
     }

--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -31,11 +31,7 @@ pub trait LogSeries: SeriesSealed {
                 .unwrap()
                 .apply_values(|v| v.log(base as f32))
                 .into_series(),
-            Float64 => s
-                .f64()
-                .unwrap()
-                .apply_values(|v| v.log(base))
-                .into_series(),
+            Float64 => s.f64().unwrap().apply_values(|v| v.log(base)).into_series(),
             _ => s.cast(&DataType::Float64).unwrap().log(base),
         }
     }
@@ -51,16 +47,8 @@ pub trait LogSeries: SeriesSealed {
             Int64 => log1p(s.i64().unwrap()).into_series(),
             UInt32 => log1p(s.u32().unwrap()).into_series(),
             UInt64 => log1p(s.u64().unwrap()).into_series(),
-            Float32 => s
-                .f32()
-                .unwrap()
-                .apply_values(|v| v.ln_1p())
-                .into_series(),
-            Float64 => s
-                .f64()
-                .unwrap()
-                .apply_values(|v| v.ln_1p())
-                .into_series(),
+            Float32 => s.f32().unwrap().apply_values(|v| v.ln_1p()).into_series(),
+            Float64 => s.f64().unwrap().apply_values(|v| v.ln_1p()).into_series(),
             _ => s.cast(&DataType::Float64).unwrap().log1p(),
         }
     }

--- a/crates/polars-plan/src/dsl/function_expr/pow.rs
+++ b/crates/polars-plan/src/dsl/function_expr/pow.rs
@@ -42,7 +42,7 @@ where
             a if a == 1.0 => base.clone().into_series(),
             // specialized sqrt will ensure (-inf)^0.5 = NaN
             // and will likely be faster as well.
-            a if a == 0.5 => base.apply(|v| v.sqrt()).into_series(),
+            a if a == 0.5 => base.apply_on_values(|v| v.sqrt()).into_series(),
             a if a.fract() == 0.0 && a < 10.0 && a > 1.0 => {
                 let mut out = base.clone();
 
@@ -51,7 +51,9 @@ where
                 }
                 out.into_series()
             },
-            _ => base.apply(|v| Pow::pow(v, exponent_value)).into_series(),
+            _ => base
+                .apply_on_values(|v| Pow::pow(v, exponent_value))
+                .into_series(),
         };
         Ok(Some(s))
     } else if (base.len() == 1) && (exponent.len() != 1) {
@@ -60,7 +62,9 @@ where
             .ok_or_else(|| polars_err!(ComputeError: "base is null"))?;
 
         Ok(Some(
-            exponent.apply(|exp| Pow::pow(base, exp)).into_series(),
+            exponent
+                .apply_on_values(|exp| Pow::pow(base, exp))
+                .into_series(),
         ))
     } else {
         Ok(Some(
@@ -129,7 +133,7 @@ where
     T::Native: num::pow::Pow<T::Native, Output = T::Native> + ToPrimitive + Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(base.apply(|v| v.sqrt()).into_series())
+    Ok(base.apply_on_values(|v| v.sqrt()).into_series())
 }
 
 pub(super) fn cbrt(base: &Series) -> PolarsResult<Series> {
@@ -156,5 +160,5 @@ where
     T::Native: num::pow::Pow<T::Native, Output = T::Native> + ToPrimitive + Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(base.apply(|v| v.cbrt()).into_series())
+    Ok(base.apply_on_values(|v| v.cbrt()).into_series())
 }

--- a/crates/polars-plan/src/dsl/function_expr/pow.rs
+++ b/crates/polars-plan/src/dsl/function_expr/pow.rs
@@ -42,7 +42,7 @@ where
             a if a == 1.0 => base.clone().into_series(),
             // specialized sqrt will ensure (-inf)^0.5 = NaN
             // and will likely be faster as well.
-            a if a == 0.5 => base.apply_on_values(|v| v.sqrt()).into_series(),
+            a if a == 0.5 => base.apply_values(|v| v.sqrt()).into_series(),
             a if a.fract() == 0.0 && a < 10.0 && a > 1.0 => {
                 let mut out = base.clone();
 
@@ -52,7 +52,7 @@ where
                 out.into_series()
             },
             _ => base
-                .apply_on_values(|v| Pow::pow(v, exponent_value))
+                .apply_values(|v| Pow::pow(v, exponent_value))
                 .into_series(),
         };
         Ok(Some(s))
@@ -63,7 +63,7 @@ where
 
         Ok(Some(
             exponent
-                .apply_on_values(|exp| Pow::pow(base, exp))
+                .apply_values(|exp| Pow::pow(base, exp))
                 .into_series(),
         ))
     } else {
@@ -133,7 +133,7 @@ where
     T::Native: num::pow::Pow<T::Native, Output = T::Native> + ToPrimitive + Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(base.apply_on_values(|v| v.sqrt()).into_series())
+    Ok(base.apply_values(|v| v.sqrt()).into_series())
 }
 
 pub(super) fn cbrt(base: &Series) -> PolarsResult<Series> {
@@ -160,5 +160,5 @@ where
     T::Native: num::pow::Pow<T::Native, Output = T::Native> + ToPrimitive + Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(base.apply_on_values(|v| v.cbrt()).into_series())
+    Ok(base.apply_values(|v| v.cbrt()).into_series())
 }

--- a/crates/polars-plan/src/dsl/function_expr/sign.rs
+++ b/crates/polars-plan/src/dsl/function_expr/sign.rs
@@ -27,9 +27,7 @@ where
     T::Native: num::Float,
     ChunkedArray<T>: IntoSeries,
 {
-    ca.apply_values(signum_improved)
-        .into_series()
-        .cast(&Int64)
+    ca.apply_values(signum_improved).into_series().cast(&Int64)
 }
 
 // Wrapper for the signum function that handles +/-0.0 inputs differently

--- a/crates/polars-plan/src/dsl/function_expr/sign.rs
+++ b/crates/polars-plan/src/dsl/function_expr/sign.rs
@@ -27,7 +27,7 @@ where
     T::Native: num::Float,
     ChunkedArray<T>: IntoSeries,
 {
-    ca.apply_on_values(signum_improved)
+    ca.apply_values(signum_improved)
         .into_series()
         .cast(&Int64)
 }

--- a/crates/polars-plan/src/dsl/function_expr/sign.rs
+++ b/crates/polars-plan/src/dsl/function_expr/sign.rs
@@ -27,7 +27,9 @@ where
     T::Native: num::Float,
     ChunkedArray<T>: IntoSeries,
 {
-    ca.apply(signum_improved).into_series().cast(&Int64)
+    ca.apply_on_values(signum_improved)
+        .into_series()
+        .cast(&Int64)
 }
 
 // Wrapper for the signum function that handles +/-0.0 inputs differently

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -339,9 +339,7 @@ pub(super) fn strip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> {
                 .into_series())
         }
     } else {
-        Ok(ca
-            .apply_values(|s| Cow::Borrowed(s.trim()))
-            .into_series())
+        Ok(ca.apply_values(|s| Cow::Borrowed(s.trim())).into_series())
     }
 }
 

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -331,16 +331,16 @@ pub(super) fn strip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> {
         if matches.chars().count() == 1 {
             // Fast path for when a single character is passed
             Ok(ca
-                .apply_on_values(|s| Cow::Borrowed(s.trim_matches(matches.chars().next().unwrap())))
+                .apply_values(|s| Cow::Borrowed(s.trim_matches(matches.chars().next().unwrap())))
                 .into_series())
         } else {
             Ok(ca
-                .apply_on_values(|s| Cow::Borrowed(s.trim_matches(|c| matches.contains(c))))
+                .apply_values(|s| Cow::Borrowed(s.trim_matches(|c| matches.contains(c))))
                 .into_series())
         }
     } else {
         Ok(ca
-            .apply_on_values(|s| Cow::Borrowed(s.trim()))
+            .apply_values(|s| Cow::Borrowed(s.trim()))
             .into_series())
     }
 }
@@ -352,18 +352,18 @@ pub(super) fn lstrip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> 
         if matches.chars().count() == 1 {
             // Fast path for when a single character is passed
             Ok(ca
-                .apply_on_values(|s| {
+                .apply_values(|s| {
                     Cow::Borrowed(s.trim_start_matches(matches.chars().next().unwrap()))
                 })
                 .into_series())
         } else {
             Ok(ca
-                .apply_on_values(|s| Cow::Borrowed(s.trim_start_matches(|c| matches.contains(c))))
+                .apply_values(|s| Cow::Borrowed(s.trim_start_matches(|c| matches.contains(c))))
                 .into_series())
         }
     } else {
         Ok(ca
-            .apply_on_values(|s| Cow::Borrowed(s.trim_start()))
+            .apply_values(|s| Cow::Borrowed(s.trim_start()))
             .into_series())
     }
 }
@@ -374,18 +374,18 @@ pub(super) fn rstrip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> 
         if matches.chars().count() == 1 {
             // Fast path for when a single character is passed
             Ok(ca
-                .apply_on_values(|s| {
+                .apply_values(|s| {
                     Cow::Borrowed(s.trim_end_matches(matches.chars().next().unwrap()))
                 })
                 .into_series())
         } else {
             Ok(ca
-                .apply_on_values(|s| Cow::Borrowed(s.trim_end_matches(|c| matches.contains(c))))
+                .apply_values(|s| Cow::Borrowed(s.trim_end_matches(|c| matches.contains(c))))
                 .into_series())
         }
     } else {
         Ok(ca
-            .apply_on_values(|s| Cow::Borrowed(s.trim_end()))
+            .apply_values(|s| Cow::Borrowed(s.trim_end()))
             .into_series())
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -331,15 +331,17 @@ pub(super) fn strip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> {
         if matches.chars().count() == 1 {
             // Fast path for when a single character is passed
             Ok(ca
-                .apply(|s| Cow::Borrowed(s.trim_matches(matches.chars().next().unwrap())))
+                .apply_on_values(|s| Cow::Borrowed(s.trim_matches(matches.chars().next().unwrap())))
                 .into_series())
         } else {
             Ok(ca
-                .apply(|s| Cow::Borrowed(s.trim_matches(|c| matches.contains(c))))
+                .apply_on_values(|s| Cow::Borrowed(s.trim_matches(|c| matches.contains(c))))
                 .into_series())
         }
     } else {
-        Ok(ca.apply(|s| Cow::Borrowed(s.trim())).into_series())
+        Ok(ca
+            .apply_on_values(|s| Cow::Borrowed(s.trim()))
+            .into_series())
     }
 }
 
@@ -350,15 +352,19 @@ pub(super) fn lstrip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> 
         if matches.chars().count() == 1 {
             // Fast path for when a single character is passed
             Ok(ca
-                .apply(|s| Cow::Borrowed(s.trim_start_matches(matches.chars().next().unwrap())))
+                .apply_on_values(|s| {
+                    Cow::Borrowed(s.trim_start_matches(matches.chars().next().unwrap()))
+                })
                 .into_series())
         } else {
             Ok(ca
-                .apply(|s| Cow::Borrowed(s.trim_start_matches(|c| matches.contains(c))))
+                .apply_on_values(|s| Cow::Borrowed(s.trim_start_matches(|c| matches.contains(c))))
                 .into_series())
         }
     } else {
-        Ok(ca.apply(|s| Cow::Borrowed(s.trim_start())).into_series())
+        Ok(ca
+            .apply_on_values(|s| Cow::Borrowed(s.trim_start()))
+            .into_series())
     }
 }
 
@@ -368,15 +374,19 @@ pub(super) fn rstrip(s: &Series, matches: Option<&str>) -> PolarsResult<Series> 
         if matches.chars().count() == 1 {
             // Fast path for when a single character is passed
             Ok(ca
-                .apply(|s| Cow::Borrowed(s.trim_end_matches(matches.chars().next().unwrap())))
+                .apply_on_values(|s| {
+                    Cow::Borrowed(s.trim_end_matches(matches.chars().next().unwrap()))
+                })
                 .into_series())
         } else {
             Ok(ca
-                .apply(|s| Cow::Borrowed(s.trim_end_matches(|c| matches.contains(c))))
+                .apply_on_values(|s| Cow::Borrowed(s.trim_end_matches(|c| matches.contains(c))))
                 .into_series())
         }
     } else {
-        Ok(ca.apply(|s| Cow::Borrowed(s.trim_end())).into_series())
+        Ok(ca
+            .apply_on_values(|s| Cow::Borrowed(s.trim_end()))
+            .into_series())
     }
 }
 

--- a/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
+++ b/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
@@ -120,13 +120,13 @@ where
             .get(0)
             .ok_or_else(|| polars_err!(ComputeError: "arctan2 x value is null"))?;
 
-        Ok(Some(y.apply_on_values(|v| v.atan2(x_value)).into_series()))
+        Ok(Some(y.apply_values(|v| v.atan2(x_value)).into_series()))
     } else if y.len() == 1 {
         let y_value = y
             .get(0)
             .ok_or_else(|| polars_err!(ComputeError: "arctan2 y value is null"))?;
 
-        Ok(Some(x.apply_on_values(|v| y_value.atan2(v)).into_series()))
+        Ok(Some(x.apply_values(|v| y_value.atan2(v)).into_series()))
     } else {
         Ok(Some(
             polars_core::prelude::arity::binary_mut(y, x, atan2_kernel).into_series(),
@@ -168,7 +168,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.cos()).into_series())
+    Ok(ca.apply_values(|v| v.cos()).into_series())
 }
 
 fn cot<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -177,7 +177,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.cos() / v.sin()).into_series())
+    Ok(ca.apply_values(|v| v.cos() / v.sin()).into_series())
 }
 
 fn sin<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -186,7 +186,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.sin()).into_series())
+    Ok(ca.apply_values(|v| v.sin()).into_series())
 }
 
 fn tan<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -195,7 +195,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.tan()).into_series())
+    Ok(ca.apply_values(|v| v.tan()).into_series())
 }
 
 fn arccos<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -204,7 +204,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.acos()).into_series())
+    Ok(ca.apply_values(|v| v.acos()).into_series())
 }
 
 fn arcsin<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -213,7 +213,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.asin()).into_series())
+    Ok(ca.apply_values(|v| v.asin()).into_series())
 }
 
 fn arctan<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -222,7 +222,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.atan()).into_series())
+    Ok(ca.apply_values(|v| v.atan()).into_series())
 }
 
 fn cosh<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -231,7 +231,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.cosh()).into_series())
+    Ok(ca.apply_values(|v| v.cosh()).into_series())
 }
 
 fn sinh<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -240,7 +240,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.sinh()).into_series())
+    Ok(ca.apply_values(|v| v.sinh()).into_series())
 }
 
 fn tanh<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -249,7 +249,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.tanh()).into_series())
+    Ok(ca.apply_values(|v| v.tanh()).into_series())
 }
 
 fn arccosh<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -258,7 +258,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.acosh()).into_series())
+    Ok(ca.apply_values(|v| v.acosh()).into_series())
 }
 
 fn arcsinh<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -267,7 +267,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.asinh()).into_series())
+    Ok(ca.apply_values(|v| v.asinh()).into_series())
 }
 
 fn arctanh<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -276,7 +276,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.atanh()).into_series())
+    Ok(ca.apply_values(|v| v.atanh()).into_series())
 }
 
 fn degrees<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -285,7 +285,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.to_degrees()).into_series())
+    Ok(ca.apply_values(|v| v.to_degrees()).into_series())
 }
 
 fn radians<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -294,5 +294,5 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_on_values(|v| v.to_radians()).into_series())
+    Ok(ca.apply_values(|v| v.to_radians()).into_series())
 }

--- a/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
+++ b/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
@@ -120,13 +120,13 @@ where
             .get(0)
             .ok_or_else(|| polars_err!(ComputeError: "arctan2 x value is null"))?;
 
-        Ok(Some(y.apply(|v| v.atan2(x_value)).into_series()))
+        Ok(Some(y.apply_on_values(|v| v.atan2(x_value)).into_series()))
     } else if y.len() == 1 {
         let y_value = y
             .get(0)
             .ok_or_else(|| polars_err!(ComputeError: "arctan2 y value is null"))?;
 
-        Ok(Some(x.apply(|v| y_value.atan2(v)).into_series()))
+        Ok(Some(x.apply_on_values(|v| y_value.atan2(v)).into_series()))
     } else {
         Ok(Some(
             polars_core::prelude::arity::binary_mut(y, x, atan2_kernel).into_series(),
@@ -168,7 +168,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.cos()).into_series())
+    Ok(ca.apply_on_values(|v| v.cos()).into_series())
 }
 
 fn cot<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -177,7 +177,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.cos() / v.sin()).into_series())
+    Ok(ca.apply_on_values(|v| v.cos() / v.sin()).into_series())
 }
 
 fn sin<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -186,7 +186,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.sin()).into_series())
+    Ok(ca.apply_on_values(|v| v.sin()).into_series())
 }
 
 fn tan<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -195,7 +195,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.tan()).into_series())
+    Ok(ca.apply_on_values(|v| v.tan()).into_series())
 }
 
 fn arccos<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -204,7 +204,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.acos()).into_series())
+    Ok(ca.apply_on_values(|v| v.acos()).into_series())
 }
 
 fn arcsin<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -213,7 +213,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.asin()).into_series())
+    Ok(ca.apply_on_values(|v| v.asin()).into_series())
 }
 
 fn arctan<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -222,7 +222,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.atan()).into_series())
+    Ok(ca.apply_on_values(|v| v.atan()).into_series())
 }
 
 fn cosh<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -231,7 +231,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.cosh()).into_series())
+    Ok(ca.apply_on_values(|v| v.cosh()).into_series())
 }
 
 fn sinh<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -240,7 +240,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.sinh()).into_series())
+    Ok(ca.apply_on_values(|v| v.sinh()).into_series())
 }
 
 fn tanh<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -249,7 +249,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.tanh()).into_series())
+    Ok(ca.apply_on_values(|v| v.tanh()).into_series())
 }
 
 fn arccosh<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -258,7 +258,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.acosh()).into_series())
+    Ok(ca.apply_on_values(|v| v.acosh()).into_series())
 }
 
 fn arcsinh<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -267,7 +267,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.asinh()).into_series())
+    Ok(ca.apply_on_values(|v| v.asinh()).into_series())
 }
 
 fn arctanh<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -276,7 +276,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.atanh()).into_series())
+    Ok(ca.apply_on_values(|v| v.atanh()).into_series())
 }
 
 fn degrees<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -285,7 +285,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.to_degrees()).into_series())
+    Ok(ca.apply_on_values(|v| v.to_degrees()).into_series())
 }
 
 fn radians<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>
@@ -294,5 +294,5 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply(|v| v.to_radians()).into_series())
+    Ok(ca.apply_on_values(|v| v.to_radians()).into_series())
 }

--- a/crates/polars-time/src/base_utc_offset.rs
+++ b/crates/polars-time/src/base_utc_offset.rs
@@ -21,7 +21,7 @@ pub fn base_utc_offset(
         TimeUnit::Microseconds => timestamp_us_to_datetime,
         TimeUnit::Milliseconds => timestamp_ms_to_datetime,
     };
-    ca.0.apply_on_values(|t| {
+    ca.0.apply_values(|t| {
         let ndt = timestamp_to_datetime(t);
         let dt = time_zone.from_utc_datetime(&ndt);
         dt.offset().base_utc_offset().num_milliseconds()

--- a/crates/polars-time/src/base_utc_offset.rs
+++ b/crates/polars-time/src/base_utc_offset.rs
@@ -21,7 +21,7 @@ pub fn base_utc_offset(
         TimeUnit::Microseconds => timestamp_us_to_datetime,
         TimeUnit::Milliseconds => timestamp_ms_to_datetime,
     };
-    ca.0.apply(|t| {
+    ca.0.apply_on_values(|t| {
         let ndt = timestamp_to_datetime(t);
         let dt = time_zone.from_utc_datetime(&ndt);
         dt.offset().base_utc_offset().num_milliseconds()

--- a/crates/polars-time/src/dst_offset.rs
+++ b/crates/polars-time/src/dst_offset.rs
@@ -18,7 +18,7 @@ pub fn dst_offset(ca: &DatetimeChunked, time_unit: &TimeUnit, time_zone: &Tz) ->
         TimeUnit::Microseconds => timestamp_us_to_datetime,
         TimeUnit::Milliseconds => timestamp_ms_to_datetime,
     };
-    ca.0.apply(|t| {
+    ca.0.apply_on_values(|t| {
         let ndt = timestamp_to_datetime(t);
         let dt = time_zone.from_utc_datetime(&ndt);
         dt.offset().dst_offset().num_milliseconds()

--- a/crates/polars-time/src/dst_offset.rs
+++ b/crates/polars-time/src/dst_offset.rs
@@ -18,7 +18,7 @@ pub fn dst_offset(ca: &DatetimeChunked, time_unit: &TimeUnit, time_zone: &Tz) ->
         TimeUnit::Microseconds => timestamp_us_to_datetime,
         TimeUnit::Milliseconds => timestamp_ms_to_datetime,
     };
-    ca.0.apply_on_values(|t| {
+    ca.0.apply_values(|t| {
         let ndt = timestamp_to_datetime(t);
         let dt = time_zone.from_utc_datetime(&ndt);
         dt.offset().dst_offset().num_milliseconds()

--- a/crates/polars/src/docs/eager.rs
+++ b/crates/polars/src/docs/eager.rs
@@ -148,7 +148,7 @@
 //! let ca = UInt32Chunked::new("foo", &[1, 2, 3]);
 //!
 //! // 1 / ca
-//! let divide_one_by_ca = ca.apply(|rhs| 1 / rhs);
+//! let divide_one_by_ca = ca.apply_on_values(|rhs| 1 / rhs);
 //! ```
 //!
 //! ## Comparisons
@@ -245,7 +245,7 @@
 //!
 //! // apply a closure over all values
 //! let s = Series::new("foo", &[Some(1), Some(2), None]);
-//! s.i32()?.apply(|value| value * 20);
+//! s.i32()?.apply_on_values(|value| value * 20);
 //!
 //! // count string lengths
 //! let s = Series::new("foo", &["foo", "bar", "foobar"]);

--- a/crates/polars/src/docs/eager.rs
+++ b/crates/polars/src/docs/eager.rs
@@ -148,7 +148,7 @@
 //! let ca = UInt32Chunked::new("foo", &[1, 2, 3]);
 //!
 //! // 1 / ca
-//! let divide_one_by_ca = ca.apply_on_values(|rhs| 1 / rhs);
+//! let divide_one_by_ca = ca.apply_values(|rhs| 1 / rhs);
 //! ```
 //!
 //! ## Comparisons
@@ -245,7 +245,7 @@
 //!
 //! // apply a closure over all values
 //! let s = Series::new("foo", &[Some(1), Some(2), None]);
-//! s.i32()?.apply_on_values(|value| value * 20);
+//! s.i32()?.apply_values(|value| value * 20);
 //!
 //! // count string lengths
 //! let s = Series::new("foo", &["foo", "bar", "foobar"]);

--- a/crates/polars/src/docs/eager.rs
+++ b/crates/polars/src/docs/eager.rs
@@ -249,7 +249,7 @@
 //!
 //! // count string lengths
 //! let s = Series::new("foo", &["foo", "bar", "foobar"]);
-//! s.utf8()?.apply_cast_numeric::<_, UInt64Type>(|str_val| str_val.len() as u64);
+//! s.utf8()?.apply_values_generic(|str_val| str_val.len() as u64);
 //!
 //! # Ok(())
 //! # }

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.4"
-source = "git+https://github.com/jorgecarleitao/arrow2?rev=7edf5f9e359e0ed02e9d0c6b9318b06964d805f0#7edf5f9e359e0ed02e9d0c6b9318b06964d805f0"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=2b3e2a9e83725a557d78b90cd39298c5bef0ca4a#2b3e2a9e83725a557d78b90cd39298c5bef0ca4a"
 dependencies = [
  "ahash",
  "arrow-format",


### PR DESCRIPTION
Also speeds up `apply` for string and binary dtypes.