### PR TITLE
chore(python): fix potential memory leak from usage of `inspect.currentframe`

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -178,16 +178,26 @@ def _get_all_caller_variables() -> dict[str, Any]:
     # https://stackoverflow.com/questions/17407119/python-inspect-stack-is-slow
     frame = inspect.currentframe()
     n = 0
-    while frame:
-        fname = inspect.getfile(frame)
-        if fname.startswith(str(pkg_dir)):
-            frame = frame.f_back
-            n += 1
+    try:
+        while frame:
+            fname = inspect.getfile(frame)
+            if fname.startswith(str(pkg_dir)):
+                frame = frame.f_back
+                n += 1
+            else:
+                break
+        variables: dict[str, Any]
+        if frame is None:
+            variables = {}
         else:
-            break
-    if frame is None:
-        return {}
-    return {**frame.f_locals, **frame.f_globals}
+            variables = {**frame.f_locals, **frame.f_globals}
+    finally:
+        # https://docs.python.org/3/library/inspect.html
+        # > Though the cycle detector will catch these, destruction of the frames
+        # > (and local variables) can be made deterministic by removing the cycle
+        # > in a finally clause.
+        del frame
+    return variables
 
 
 class BytecodeParser:


### PR DESCRIPTION
originally reported here: https://github.com/pandas-dev/pandas/issues/54628