### PR TITLE
fix(python): fix missing timestamp cast in delta schema

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3515,7 +3515,8 @@ class DataFrame:
         to which they can be cast. This affects the following data types:
 
         - Unsigned integers
-        - :class:`Datetime` types with millisecond or nanosecond precision
+        - :class:`Datetime` types with millisecond or nanosecond precision,
+            regardless of timezone
         - :class:`Utf8`, :class:`Binary`, and :class:`List` ('large' types)
 
         Polars columns are always nullable. To write data to a delta table with

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3515,8 +3515,8 @@ class DataFrame:
         to which they can be cast. This affects the following data types:
 
         - Unsigned integers
-        - :class:`Datetime` types with millisecond or nanosecond precision,
-            regardless of timezone
+        - :class:`Datetime` types with millisecond or nanosecond precision or with
+            time zone information
         - :class:`Utf8`, :class:`Binary`, and :class:`List` ('large' types)
 
         Polars columns are always nullable. To write data to a delta table with

--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -17,7 +17,7 @@ def _is_glob_pattern(file: str) -> bool:
 
 def _is_local_file(file: str) -> bool:
     try:
-        next(glob.iglob(file, recursive=True))
+        next(glob.iglob(file, recursive=True))  # noqa: PTH207
         return True
     except StopIteration:
         return False

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -349,6 +349,8 @@ def _convert_pa_schema_to_delta(schema: pa.schema) -> pa.schema:
         elif isinstance(dtype, pa.StructType):
             return struct_to_delta_dtype(dtype)
         elif isinstance(dtype, pa.TimestampType):
+            # TODO: Support time zones when implemented by delta-rs. See:
+            # https://github.com/delta-io/delta-rs/issues/1598
             return pa.timestamp("us")
         try:
             return dtype_map[dtype]

--- a/py-polars/polars/io/delta.py
+++ b/py-polars/polars/io/delta.py
@@ -338,8 +338,6 @@ def _convert_pa_schema_to_delta(schema: pa.schema) -> pa.schema:
         pa.uint16(): pa.int16(),
         pa.uint32(): pa.int32(),
         pa.uint64(): pa.int64(),
-        pa.timestamp("ns"): pa.timestamp("us"),
-        pa.timestamp("ms"): pa.timestamp("us"),
         pa.large_string(): pa.string(),
         pa.large_binary(): pa.binary(),
     }
@@ -350,7 +348,8 @@ def _convert_pa_schema_to_delta(schema: pa.schema) -> pa.schema:
             return list_to_delta_dtype(dtype)
         elif isinstance(dtype, pa.StructType):
             return struct_to_delta_dtype(dtype)
-
+        elif isinstance(dtype, pa.TimestampType):
+            return pa.timestamp("us")
         try:
             return dtype_map[dtype]
         except KeyError:

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -197,7 +197,7 @@ def test_write_delta(df: pl.DataFrame, tmp_path: Path) -> None:
         pl.Series(
             "date_ns",
             [datetime(2010, 1, 1, 0, 0)],
-            dtype=pl.Datetime(time_unit="ns"),
+            dtype=pl.Datetime(time_unit="ns", time_zone="ETC"),
         ),
         pl.Series(
             "date_us",
@@ -262,7 +262,7 @@ def test_write_delta(df: pl.DataFrame, tmp_path: Path) -> None:
                 [
                     pl.Field(
                         "date_range",
-                        pl.List(pl.Datetime(time_unit="ms", time_zone=None)),
+                        pl.List(pl.Datetime(time_unit="ms", time_zone="UTC")),
                     ),
                     pl.Field(
                         "date_us", pl.List(pl.Datetime(time_unit="ms", time_zone=None))

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -344,6 +344,7 @@ def test_write_delta_with_schema_10540(tmp_path: Path) -> None:
     pa_schema = pa.schema([("a", pa.int64())])
     df.write_delta(tmp_path, delta_write_options={"schema": pa_schema})
 
+
 @pytest.mark.parametrize(
     "series",
     [
@@ -352,31 +353,31 @@ def test_write_delta_with_schema_10540(tmp_path: Path) -> None:
             [datetime(2010, 1, 1, 0, 0)],
             dtype=pl.Datetime(time_unit="us", time_zone="UTC"),
         ),
-            pl.Series(
+        pl.Series(
             "date",
             [datetime(2010, 1, 1, 0, 0)],
             dtype=pl.Datetime(time_unit="ns", time_zone="EST"),
         ),
-            pl.Series(
+        pl.Series(
             "date",
             [datetime(2010, 1, 1, 0, 0)],
             dtype=pl.Datetime(time_unit="ms", time_zone="EST"),
         ),
-    ]
+    ],
 )
 def test_write_delta_with_tz_in_df(series: pl.Series, tmp_path: Path) -> None:
     df = series.to_frame()
-    
+
     pa_schema = pa.schema([("date", pa.timestamp("us"))])
-    
+
     df.write_delta(tmp_path, mode="append")
     # write second time because delta-rs also casts timestamp with tz to timestamp no tz
     df.write_delta(tmp_path, mode="append")
-    
+
     tbl = DeltaTable(tmp_path)
     assert pa_schema == tbl.schema().to_pyarrow()
 
     tbl.load_version(0)
-    
+
     df_delta = pl.read_delta(tmp_path.as_posix(), version=0)
-    assert_frame_equal(df_delta, df.select(pl.col('date').cast(pl.Datetime('us'))))
+    assert_frame_equal(df_delta, df.select(pl.col("date").cast(pl.Datetime("us"))))

--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -343,3 +343,40 @@ def test_write_delta_with_schema_10540(tmp_path: Path) -> None:
 
     pa_schema = pa.schema([("a", pa.int64())])
     df.write_delta(tmp_path, delta_write_options={"schema": pa_schema})
+
+@pytest.mark.parametrize(
+    "series",
+    [
+        pl.Series(
+            "date",
+            [datetime(2010, 1, 1, 0, 0)],
+            dtype=pl.Datetime(time_unit="us", time_zone="UTC"),
+        ),
+            pl.Series(
+            "date",
+            [datetime(2010, 1, 1, 0, 0)],
+            dtype=pl.Datetime(time_unit="ns", time_zone="EST"),
+        ),
+            pl.Series(
+            "date",
+            [datetime(2010, 1, 1, 0, 0)],
+            dtype=pl.Datetime(time_unit="ms", time_zone="EST"),
+        ),
+    ]
+)
+def test_write_delta_with_tz_in_df(series: pl.Series, tmp_path: Path) -> None:
+    df = series.to_frame()
+    
+    pa_schema = pa.schema([("date", pa.timestamp("us"))])
+    
+    df.write_delta(tmp_path, mode="append")
+    # write second time because delta-rs also casts timestamp with tz to timestamp no tz
+    df.write_delta(tmp_path, mode="append")
+    
+    tbl = DeltaTable(tmp_path)
+    assert pa_schema == tbl.schema().to_pyarrow()
+
+    tbl.load_version(0)
+    
+    df_delta = pl.read_delta(tmp_path.as_posix(), version=0)
+    assert_frame_equal(df_delta, df.select(pl.col('date').cast(pl.Datetime('us'))))


### PR DESCRIPTION
In the recent change, there was fixed mapping between timestamps in ms/ns to us precision. However, delta-rs writes everything in non-timezone timestamps. So we can safely cast any timestamp, regardless of the timezone or precision, simply to us precision with no TZ. 

This change will prevent this from happening when you're writing a delta table:

`Exception: Schema error: Invalid data type for Delta Lake: Timestamp(Millisecond, Some("UTC"))
`

Changed the test cases to include time zones in some of them.