### PR TITLE
fix(rust, python): respect 'ignore_errors=False' in csv parser

### DIFF
--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -32,7 +32,7 @@ use crate::chunked_array::Settings;
 use crate::prelude::unique::rank::rank;
 #[cfg(feature = "zip_with")]
 use crate::series::arithmetic::coerce_lhs_rhs;
-use crate::utils::{_split_offsets, split_ca, split_series, Wrap};
+use crate::utils::{_split_offsets, get_casting_failures, split_ca, split_series, Wrap};
 use crate::POOL;
 
 /// # Series
@@ -790,14 +790,12 @@ impl Series {
         }
         let s = self.0.cast(dtype)?;
         if null_count != s.null_count() {
-            let failure_mask = !self.is_null() & s.is_null();
-            let failures = self.filter_threaded(&failure_mask, false)?.unique()?;
+            let failures = get_casting_failures(self, &s)?;
             polars_bail!(
                 ComputeError:
                 "strict conversion from `{}` to `{}` failed for column: {}, value(s) {}; \
                 if you were trying to cast Utf8 to temporal dtypes, consider using `strptime`",
                 self.dtype(), dtype, s.name(), failures.fmt_list(),
-
             );
         } else {
             Ok(s)

--- a/crates/polars-core/src/utils/series.rs
+++ b/crates/polars-core/src/utils/series.rs
@@ -39,3 +39,8 @@ pub fn ensure_sorted_arg(s: &Series, operation: &str) -> PolarsResult<()> {
     ", operation);
     Ok(())
 }
+
+pub fn get_casting_failures(input: &Series, output: &Series) -> PolarsResult<Series> {
+    let failure_mask = !input.is_null() & output.is_null();
+    input.filter_threaded(&failure_mask, false)?.unique()
+}

--- a/crates/polars-io/src/csv/read_impl/batched_mmap.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_mmap.rs
@@ -249,7 +249,7 @@ impl<'a> BatchedCsvReaderMmap<'a> {
                         self.starting_point_offset,
                     )?;
 
-                    cast_columns(&mut df, &self.to_cast, false)?;
+                    cast_columns(&mut df, &self.to_cast, false, self.ignore_errors)?;
 
                     update_string_stats(&self.str_capacities, &self.str_columns, &df)?;
                     if let Some(rc) = &self.row_count {

--- a/crates/polars-io/src/csv/read_impl/batched_read.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_read.rs
@@ -346,7 +346,7 @@ impl<'a> BatchedCsvReaderRead<'a> {
                         self.starting_point_offset,
                     )?;
 
-                    cast_columns(&mut df, &self.to_cast, false)?;
+                    cast_columns(&mut df, &self.to_cast, false, self.ignore_errors)?;
 
                     update_string_stats(&self.str_capacities, &self.str_columns, &df)?;
                     if let Some(rc) = &self.row_count {

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -442,6 +442,7 @@ AUDCAD,1616455921,0.96212,0.95666,1
             "b",
             DataType::Datetime(TimeUnit::Nanoseconds, None),
         )]))))
+        .with_ignore_errors(true)
         .finish()?;
 
     assert_eq!(

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1440,3 +1440,25 @@ def test_csv_quote_styles() -> None:
         df.write_csv(quote_style="non_numeric", quote="8")
         == '8float8,8string8,8int8,8bool8\n1.0,8a8,1,8true8\n2.0,8abc8,2,8false8\n,8"hello8,3,\n'
     )
+
+
+def test_ignore_errors_casting_dtypes() -> None:
+    csv = '''inventory
+    10
+
+    400
+    90
+    '''
+
+    assert pl.read_csv(
+        source=io.StringIO(csv),
+        dtypes={'inventory': pl.Int8},
+        ignore_errors=True,
+    ).to_dict(False) == {'inventory': [10, None, None, 90]}
+
+    with pytest.raises(pl.ComputeError):
+        pl.read_csv(
+            source=io.StringIO(csv),
+            dtypes={'inventory': pl.Int8},
+            ignore_errors=False,
+        )

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1443,22 +1443,32 @@ def test_csv_quote_styles() -> None:
 
 
 def test_ignore_errors_casting_dtypes() -> None:
-    csv = '''inventory
+    csv = """inventory
     10
 
     400
     90
-    '''
+    """
 
     assert pl.read_csv(
         source=io.StringIO(csv),
-        dtypes={'inventory': pl.Int8},
+        dtypes={"inventory": pl.Int8},
         ignore_errors=True,
-    ).to_dict(False) == {'inventory': [10, None, None, 90]}
+    ).to_dict(False) == {"inventory": [10, None, None, 90]}
 
     with pytest.raises(pl.ComputeError):
         pl.read_csv(
             source=io.StringIO(csv),
-            dtypes={'inventory': pl.Int8},
+            dtypes={"inventory": pl.Int8},
+            ignore_errors=False,
+        )
+
+
+def test_ignore_errors_date_parser() -> None:
+    data_invalid_date = "int,float,date\n3,3.4,X"
+    with pytest.raises(pl.ComputeError):
+        pl.read_csv(
+            source=io.StringIO(data_invalid_date),
+            dtypes={"date": pl.Date},
             ignore_errors=False,
         )


### PR DESCRIPTION
fixes #10344