### PR TITLE
feat(python, rust): preserve whitespace in notebook output

### DIFF
--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -161,6 +161,7 @@ class NotebookFormatter(HTMLFormatter):
             .dataframe > thead > tr > th,
             .dataframe > tbody > tr > td {
               text-align: right;
+              white-space: pre;
             }
             </style>
         """


### PR DESCRIPTION
fixes #10643 
