### PR TITLE
feat(python, rust): improve err msg strict cast

### DIFF
--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -17,7 +17,7 @@ def _is_glob_pattern(file: str) -> bool:
 
 def _is_local_file(file: str) -> bool:
     try:
-        next(glob.iglob(file, recursive=True))
+        next(glob.iglob(file, recursive=True))  # noqa: PTH207
         return True
     except StopIteration:
         return False

--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -17,7 +17,7 @@ def _is_glob_pattern(file: str) -> bool:
 
 def _is_local_file(file: str) -> bool:
     try:
-        next(glob.iglob(file, recursive=True))  # noqa: PTH207
+        next(glob.iglob(file, recursive=True))
         return True
     except StopIteration:
         return False

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -516,26 +516,10 @@ def test_skip_nulls_err() -> None:
         df.with_columns(pl.col("foo").apply(lambda x: x, skip_nulls=True))
 
 
-@pytest.mark.parametrize(
-    ("test_df", "type", "expected_message"),
-    [
-        pytest.param(
-            pl.DataFrame({"A": [1, 2, 3], "B": ["1", "2", "help"]}),
-            pl.UInt32,
-            re.escape(
-                "strict conversion from `str` to `u32` failed for column: B, "
-                'value(s) ["help"]; if you were trying to cast Utf8 to temporal '
-                "dtypes, consider using `strptime`"
-            ),
-            id="Unsigned integer",
-        )
-    ],
-)
-def test_cast_err_column_value_highlighting(
-    test_df: pl.DataFrame, type: pl.DataType, expected_message: str
-) -> None:
-    with pytest.raises(pl.ComputeError, match=expected_message):
-        test_df.with_columns(pl.all().cast(type))
+def test_cast_err_column_value_highlighting() -> None:
+    df = pl.DataFrame({"A": [1, 2, 3], "B": ["1", "2", "help"]})
+    with pytest.raises(pl.ComputeError, match="strict conversion from `str` to `u32` in column `B`"):
+        df.with_columns(pl.all().cast(pl.UInt32))
 
 
 def test_err_on_time_datetime_cast() -> None:

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import io
-import re
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING
 
@@ -518,7 +517,9 @@ def test_skip_nulls_err() -> None:
 
 def test_cast_err_column_value_highlighting() -> None:
     df = pl.DataFrame({"A": [1, 2, 3], "B": ["1", "2", "help"]})
-    with pytest.raises(pl.ComputeError, match="strict conversion from `str` to `u32` in column `B`"):
+    with pytest.raises(
+        pl.ComputeError, match="strict conversion from `str` to `u32` in column `B`"
+    ):
         df.with_columns(pl.all().cast(pl.UInt32))
 
 

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -622,7 +622,9 @@ def test_cast_frame() -> None:
     # test 'strict' mode
     lf = pl.LazyFrame({"a": [1000, 2000, 3000]})
 
-    with pytest.raises(ComputeError, match="conversion from `i64` to `u8` in column `a`"):
+    with pytest.raises(
+        ComputeError, match="conversion from `i64` to `u8` in column `a`"
+    ):
         lf.cast(pl.UInt8).collect()
 
     assert lf.cast(pl.UInt8, strict=False).collect().rows() == [

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -622,7 +622,7 @@ def test_cast_frame() -> None:
     # test 'strict' mode
     lf = pl.LazyFrame({"a": [1000, 2000, 3000]})
 
-    with pytest.raises(ComputeError, match="conversion from `i64` to `u8` failed"):
+    with pytest.raises(ComputeError, match="conversion from `i64` to `u8` in column `a`"):
         lf.cast(pl.UInt8).collect()
 
     assert lf.cast(pl.UInt8, strict=False).collect().rows() == [


### PR DESCRIPTION
improve error message when strict casting fails:

```python
pl.DataFrame(pl.int_range(0, 1000, eager=True)).with_columns(
    pl.col('int').cast(pl.Int8, strict=True),
)
```

OLD
```bash
ComputeError: strict conversion from `i64` to `i8` failed for column: int, value(s) [128, 129, … 999]; if you were trying to cast Utf8 to temporal dtypes, consider using `strptime`
```
NEW
```bash
ComputeError: strict conversion from `i64` to `i8` in column `int` failed for 872 value(s) (872 unique): [128, 129, … 999]

If you were trying to cast Utf8 to temporal dtypes, consider using `strptime`
```

Advantages:
- knowing how many total values failed to parse in a column is very useful
- knowing how many unique values failed to parse in a column is very useful
- consistency: date parsing uses the same message (e.g. `strict date parsing failed for 7 value(s) (5 unique): ["a", "b", … "e"]`)
- consistency: separate error from hint message
- no compute overhead (calling `.len()` on the failures is essentially free)

Disadvantages:
- none