### PR TITLE
fix(rust, python): Set the correct fast_explode flag for ListUtf8ChunkedBuilder

### DIFF
--- a/crates/polars-core/src/chunked_array/builder/list/binary.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/binary.rs
@@ -48,6 +48,9 @@ impl ListUtf8ChunkedBuilder {
 
     #[inline]
     pub(crate) fn append(&mut self, ca: &Utf8Chunked) {
+        if ca.is_empty() {
+            self.fast_explode = false;
+        }
         let value_builder = self.builder.mut_values();
         value_builder.try_extend(ca).unwrap();
         self.builder.try_push_valid().unwrap();

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -315,3 +315,17 @@ def test_explode_array() -> None:
     for ex in ("a", ~cs.integer()):
         out = df.explode(ex).collect()  # type: ignore[arg-type]
         assert_frame_equal(out, expected)
+
+
+def test_utf8_list_agg_explode() -> None:
+    df = pl.DataFrame({"a": [[None], ["b"]]})
+
+    df = df.select(
+        pl.col("a").list.eval(pl.element().filter(pl.element().is_not_null()))
+    )
+    assert not df["a"].flags["FAST_EXPLODE"]
+
+    df2 = pl.DataFrame({"a": [[], ["b"]]})
+
+    assert_frame_equal(df, df2)
+    assert_frame_equal(df.explode("a"), df2.explode("a"))


### PR DESCRIPTION
This fixes #10676