### PR TITLE
test(python): Update for new pyarrow `13.0.0` behavior

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9276,14 +9276,12 @@ class DataFrame:
 
         >>> for frame in df.iter_slices(n_rows=15_000):
         ...     record_batch = frame.to_arrow().to_batches()[0]
-        ...     print(record_batch, "\n<< ", len(record_batch))
+        ...     print(f"{record_batch.schema}\n<< {len(record_batch)}")
         ...
-        pyarrow.RecordBatch
         a: int32
         b: date32[day]
         c: large_string
         << 15000
-        pyarrow.RecordBatch
         a: int32
         b: date32[day]
         c: large_string

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -569,13 +569,13 @@ def test_to_pandas() -> None:
     )
     pd_out = df.to_pandas()
     pd_out_dtypes_expected = [
-        np.uint8,
-        np.float64,
-        np.float64,
-        np.dtype("datetime64[ns]"),
-        np.object_,
-        np.object_,
-        np.dtype("datetime64[ns]"),
+        np.dtype(np.uint8),
+        np.dtype(np.float64),
+        np.dtype(np.float64),
+        np.dtype("datetime64[ms]"),
+        np.dtype(np.object_),
+        np.dtype(np.object_),
+        np.dtype("datetime64[us]"),
         pd.CategoricalDtype(categories=["a", "b", "c"], ordered=False),
         pd.CategoricalDtype(categories=["e", "f"], ordered=False),
     ]


### PR DESCRIPTION
New version of `pyarrow` just dropped. Apparently it changes interoperability with pandas slightly for date/datetime types. Had to adjust one of our tests.

EDIT: Also had to update one of our doctests because the `repr` of `RecordBatch` has changed.