### PR TITLE
fix(rust, python): Reused input series in rolling_apply should not be orderly

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -119,10 +119,10 @@ mod inner_mod {
                         unsafe {
                             *ptr = arr_window;
                         }
-                        // ensure the length is correct
-                        series_container._get_inner_mut().compute_len();
                         // reset flags as we reuse this container
                         series_container.clear_settings();
+                        // ensure the length is correct
+                        series_container._get_inner_mut().compute_len();
                         let s = if size == options.window_size {
                             f(&series_container.multiply(&weights_series).unwrap())
                         } else {
@@ -167,10 +167,10 @@ mod inner_mod {
                         unsafe {
                             *ptr = arr_window;
                         }
-                        // ensure the length is correct
-                        series_container._get_inner_mut().compute_len();
                         // reset flags as we reuse this container
                         series_container.clear_settings();
+                        // ensure the length is correct
+                        series_container._get_inner_mut().compute_len();
                         let s = f(&series_container);
                         let out = self.unpack_series_matching_type(&s)?;
                         builder.append_option(out.get(0));

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -121,7 +121,8 @@ mod inner_mod {
                         }
                         // ensure the length is correct
                         series_container._get_inner_mut().compute_len();
-
+                        // reset flags as we reuse this container
+                        series_container.clear_settings();
                         let s = if size == options.window_size {
                             f(&series_container.multiply(&weights_series).unwrap())
                         } else {
@@ -168,7 +169,8 @@ mod inner_mod {
                         }
                         // ensure the length is correct
                         series_container._get_inner_mut().compute_len();
-
+                        // reset flags as we reuse this container
+                        series_container.clear_settings();
                         let s = f(&series_container);
                         let out = self.unpack_series_matching_type(&s)?;
                         builder.append_option(out.get(0));

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -790,6 +790,20 @@ def test_rolling_window_size_9160() -> None:
     ).to_list() == [1]
 
 
+def test_rolling_apply_clear_reuse_series_state_10681() -> None:
+    df = pl.DataFrame({"a": [1, 1, 1, 1, 2, 2, 2, 2], "b": [0, 1, 11.0, 7, 4, 2, 3, 8]})
+    assert df.with_columns(
+        pl.col("b")
+        .rolling_apply(lambda s: s.min(), window_size=3, min_periods=2)
+        .over("a")
+        .alias("min")
+    ).to_dict(False) == {
+        "a": [1, 1, 1, 1, 2, 2, 2, 2],
+        "b": [0.0, 1.0, 11.0, 7.0, 4.0, 2.0, 3.0, 8.0],
+        "min": [None, 0.0, 0.0, 1.0, None, 2.0, 2.0, 2.0],
+    }
+
+
 def test_rolling_empty_window_9406() -> None:
     datecol = pl.Series(
         "d",


### PR DESCRIPTION
This fixes #10681.