### PR TITLE
fix(rust, python): arg_min & arg_max return null for empty series

### DIFF
--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -91,7 +91,9 @@ pub(crate) fn arg_max_bool(ca: &BooleanChunked) -> Option<usize> {
 }
 
 fn arg_min_bool(ca: &BooleanChunked) -> Option<usize> {
-    if ca.is_empty() || ca.null_count() == ca.len() || ca.all() {
+    if ca.is_empty() {
+        None
+    } else if ca.null_count() == ca.len() || ca.all() {
         Some(0)
     } else if ca.null_count() == 0 && ca.chunks().len() == 1 {
         let arr = ca.downcast_iter().next().unwrap();
@@ -195,6 +197,9 @@ fn first_unset_bit(mask: &Bitmap) -> usize {
 }
 
 fn arg_min_str(ca: &Utf8Chunked) -> Option<usize> {
+    if ca.is_empty() {
+        return None;
+    }
     match ca.is_sorted_flag() {
         IsSorted::Ascending => Some(0),
         IsSorted::Descending => Some(ca.len() - 1),
@@ -207,6 +212,9 @@ fn arg_min_str(ca: &Utf8Chunked) -> Option<usize> {
 }
 
 fn arg_max_str(ca: &Utf8Chunked) -> Option<usize> {
+    if ca.is_empty() {
+        return None;
+    }
     match ca.is_sorted_flag() {
         IsSorted::Ascending => Some(ca.len() - 1),
         IsSorted::Descending => Some(0),

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -544,3 +544,16 @@ def test_list_take_oob_10079() -> None:
     )
     with pytest.raises(pl.ComputeError, match="take indices are out of bounds"):
         df.select(pl.col("a").take(999))
+
+
+def test_utf8_empty_series_arg_min_max_10703() -> None:
+    res = pl.select(pl.lit(pl.Series("list", [["a"], []]))).with_columns(
+        pl.all(),
+        pl.all().list.arg_min().alias("arg_min"),
+        pl.all().list.arg_max().alias("arg_max"),
+    )
+    assert res.to_dict(False) == {
+        "list": [["a"], []],
+        "arg_min": [0, None],
+        "arg_max": [0, None],
+    }


### PR DESCRIPTION
This fixes #10703.