### PR TITLE
fix(rust): string to decimal parsing 

### DIFF
--- a/crates/polars-arrow/src/compute/decimal.rs
+++ b/crates/polars-arrow/src/compute/decimal.rs
@@ -15,12 +15,9 @@ fn split_decimal_bytes(bytes: &[u8]) -> (Option<&[u8]>, Option<&[u8]>) {
     (lhs, rhs)
 }
 
-fn parse_integer_checked(bytes: &[u8]) -> Option<i128>{
-    let (n,len) = i128::from_radix_10_signed_checked(bytes);
-    match n {
-        Some(i) if len == bytes.len() => Some(i),
-        _ => None
-    }
+fn parse_integer_checked(bytes: &[u8]) -> Option<i128> {
+    let (n, len) = i128::from_radix_10_signed_checked(bytes);
+    n.filter(|_| len == bytes.len())
 }
 
 pub fn infer_scale(bytes: &[u8]) -> Option<u8> {

--- a/crates/polars-arrow/src/compute/decimal.rs
+++ b/crates/polars-arrow/src/compute/decimal.rs
@@ -9,7 +9,7 @@ fn leading_zeros(bytes: &[u8]) -> u8 {
 }
 
 fn split_decimal_bytes(bytes: &[u8]) -> (Option<&[u8]>, Option<&[u8]>) {
-    let mut a = bytes.splitn(2,|x| *x == b'.');
+    let mut a = bytes.splitn(2, |x| *x == b'.');
     let lhs = a.next();
     let rhs = a.next();
     (lhs, rhs)
@@ -150,10 +150,15 @@ mod test {
         assert_eq!(deserialize_decimal(val.as_bytes(), precision, scale), None);
 
         let val = "5.";
-        assert_eq!(deserialize_decimal(val.as_bytes(), precision, scale), Some(500000i128));
+        assert_eq!(
+            deserialize_decimal(val.as_bytes(), precision, scale),
+            Some(500000i128)
+        );
 
         let val = ".5";
-        assert_eq!(deserialize_decimal(val.as_bytes(), precision, scale), Some(50000i128));
-
+        assert_eq!(
+            deserialize_decimal(val.as_bytes(), precision, scale),
+            Some(50000i128)
+        );
     }
 }

--- a/crates/polars-arrow/src/compute/decimal.rs
+++ b/crates/polars-arrow/src/compute/decimal.rs
@@ -9,7 +9,7 @@ fn leading_zeros(bytes: &[u8]) -> u8 {
 }
 
 fn split_decimal_bytes(bytes: &[u8]) -> (Option<&[u8]>, Option<&[u8]>) {
-    let mut a = bytes.split(|x| *x == b'.');
+    let mut a = bytes.splitn(2,|x| *x == b'.');
     let lhs = a.next();
     let rhs = a.next();
     (lhs, rhs)
@@ -142,5 +142,18 @@ mod test {
 
         let val = "12.3ABC4";
         assert_eq!(deserialize_decimal(val.as_bytes(), precision, scale), None);
+
+        let val = "12.3.ABC4";
+        assert_eq!(deserialize_decimal(val.as_bytes(), precision, scale), None);
+
+        let val = "";
+        assert_eq!(deserialize_decimal(val.as_bytes(), precision, scale), None);
+
+        let val = "5.";
+        assert_eq!(deserialize_decimal(val.as_bytes(), precision, scale), Some(500000i128));
+
+        let val = ".5";
+        assert_eq!(deserialize_decimal(val.as_bytes(), precision, scale), Some(50000i128));
+
     }
 }


### PR DESCRIPTION
Avoid incorrect parsing of trailing characters 12ABC.123BC

See fix #10118 