### PR TITLE
perf(rust, python): parse time zones outside of downcast_iter() in replace_time_zone

### DIFF
--- a/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
+++ b/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
@@ -9,8 +9,21 @@ pub fn replace_time_zone(
     let out: PolarsResult<_> = {
         let from = ca.time_zone().as_deref().unwrap_or("UTC");
         let to = time_zone.unwrap_or("UTC");
+        let (from_tz, to_tz) = match from.parse::<chrono_tz::Tz>() {
+            Ok(from_tz) => match to.parse::<chrono_tz::Tz>() {
+                Ok(to_tz) => (from_tz, to_tz),
+                Err(_) => polars_bail!(ComputeError: "unable to parse time zone: '{}'", to),
+            },
+            Err(_) => polars_bail!(ComputeError: "unable to parse time zone: '{}'", from),
+        };
         let chunks = ca.downcast_iter().map(|arr| {
-            replace_time_zone_kernel(arr, ca.time_unit().to_arrow(), from, to, use_earliest)
+            replace_time_zone_kernel(
+                arr,
+                ca.time_unit().to_arrow(),
+                &from_tz,
+                &to_tz,
+                use_earliest,
+            )
         });
         let out = ChunkedArray::try_from_chunk_iter(ca.name(), chunks)?;
         Ok(out.into_datetime(ca.time_unit(), time_zone.map(|x| x.to_string())))


### PR DESCRIPTION


Noticed while looking into #10090

I probably introduced this inefficiency the first time round, sorry about that