### PR TITLE
fix(rust): Prevent panic on sample_n with replacement from empty df

### DIFF
--- a/crates/polars-core/src/chunked_array/random.rs
+++ b/crates/polars-core/src/chunked_array/random.rs
@@ -10,7 +10,7 @@ use crate::utils::{CustomIterTools, NoNull};
 
 fn create_rand_index_with_replacement(n: usize, len: usize, seed: Option<u64>) -> IdxCa {
     if len == 0 {
-        return NoNull::<IdxCa>::from_iter(std::iter::empty()).into_inner();
+        return IdxCa::new_vec("", vec![]);
     }
     let mut rng = SmallRng::seed_from_u64(seed.unwrap_or_else(get_global_random_u64));
     let dist = Uniform::new(0, len as IdxSize);
@@ -259,22 +259,6 @@ impl BooleanChunked {
 #[cfg(test)]
 mod test {
     use super::*;
-
-    #[test]
-    fn test_sample_empty_df() {
-        let df = df![
-            "foo" => Vec::<i32>::new()
-        ]
-        .unwrap();
-
-        // If with replacement, then expect empty df
-        assert_eq!(df.sample_n(3, true, false, None).unwrap().height(), 0);
-        assert_eq!(df.sample_frac(0.4, true, false, None).unwrap().height(), 0);
-
-        // If without replacement, then expect shape mismatch on sample_n not sample_frac
-        assert!(df.sample_n(3, false, false, None).is_err());
-        assert_eq!(df.sample_frac(0.4, false, false, None).unwrap().height(), 0);
-    }
 
     #[test]
     fn test_sample() {

--- a/crates/polars-core/src/chunked_array/random.rs
+++ b/crates/polars-core/src/chunked_array/random.rs
@@ -9,6 +9,9 @@ use crate::random::get_global_random_u64;
 use crate::utils::{CustomIterTools, NoNull};
 
 fn create_rand_index_with_replacement(n: usize, len: usize, seed: Option<u64>) -> IdxCa {
+    if len == 0 {
+        return NoNull::<IdxCa>::from_iter(std::iter::empty()).into_inner();
+    }
     let mut rng = SmallRng::seed_from_u64(seed.unwrap_or_else(get_global_random_u64));
     let dist = Uniform::new(0, len as IdxSize);
     (0..n as IdxSize)
@@ -256,6 +259,22 @@ impl BooleanChunked {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_sample_empty_df() {
+        let df = df![
+            "foo" => Vec::<i32>::new()
+        ]
+        .unwrap();
+
+        // If with replacement, then expect empty df
+        assert_eq!(df.sample_n(3, true, false, None).unwrap().height(), 0);
+        assert_eq!(df.sample_frac(0.4, true, false, None).unwrap().height(), 0);
+
+        // If without replacement, then expect shape mismatch on sample_n not sample_frac
+        assert!(df.sample_n(3, false, false, None).is_err());
+        assert_eq!(df.sample_frac(0.4, false, false, None).unwrap().height(), 0);
+    }
 
     #[test]
     fn test_sample() {

--- a/py-polars/tests/unit/operations/test_random.py
+++ b/py-polars/tests/unit/operations/test_random.py
@@ -54,6 +54,19 @@ def test_sample_df() -> None:
     assert df.sample(fraction=0.4, seed=0).shape == (1, 3)
 
 
+def test_sample_empty_df() -> None:
+    df = pl.DataFrame({"foo": []})
+
+    # // If with replacement, then expect empty df
+    assert df.sample(n=3, with_replacement=True).shape == (0, 1)
+    assert df.sample(fraction=0.4, with_replacement=True).shape == (0, 1)
+
+    # // If without replacement, then expect shape mismatch on sample_n not sample_frac
+    with pytest.raises(pl.ShapeError):
+        df.sample(n=3, with_replacement=False)
+    assert df.sample(fraction=0.4, with_replacement=False).shape == (0, 1)
+
+
 def test_sample_series() -> None:
     s = pl.Series("a", [1, 2, 3, 4, 5])
 


### PR DESCRIPTION
Sampling n from an empty dataframe panics if with_replacement=True. A test case is added documenting the behavior of sample_n and sample_frac for with_replacement and without.

I am not really sure why ensure_shape is used without symmetry, but it appears intentional.

```rust
let subdf = df.sample_n(50000, true, false, None)?;
```
 

```
shape: (0, 4)
┌──────────────┬─────┬─────┬─────┐
│ t            ┆ x   ┆ y   ┆ z   │
│ ---          ┆ --- ┆ --- ┆ --- │
│ datetime[μs] ┆ f64 ┆ f64 ┆ f64 │
╞══════════════╪═════╪═════╪═════╡
└──────────────┴─────┴─────┴─────┘

thread 'tokio-runtime-worker' panicked at 'Uniform::new called with `low >= high`', /Users/jwtrueb/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rand-0.8.5/src/distributions/uniform.rs:567:1
   0: rust_begin_unwind
             at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/std/src/panicking.rs:593:5
   1: core::panicking::panic_fmt
             at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/panicking.rs:67:14
   2: core::panicking::panic
             at /rustc/5680fa18feaa87f3ff04063800aec256c3d4b4be/library/core/src/panicking.rs:117:5
   3: <rand::distributions::uniform::UniformInt<u32> as rand::distributions::uniform::UniformSampler>::new
             at /Users/jwtrueb/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rand-0.8.5/src/distributions/uniform.rs:452:17
   4: rand::distributions::uniform::Uniform<X>::new
             at /Users/jwtrueb/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rand-0.8.5/src/distributions/uniform.rs:189:17
   5: polars_core::chunked_array::random::create_rand_index_with_replacement
             at /Users/jwtrueb/.cargo/registry/src/index.crates.io-6f17d22bba15001f/polars-core-0.32.1/src/chunked_array/random.rs:18:16
   6: polars_core::chunked_array::random::<impl polars_core::frame::DataFrame>::sample_n
             at /Users/jwtrueb/.cargo/registry/src/index.crates.io-6f17d22bba15001f/polars-core-0.32.1/src/chunked_array/random.rs:177:21
   7: qsib_data_viz::sample_data::{{closure}}::{{closure}}
             at ./src/main.rs:306:25
```