### PR TITLE
fix(python): whitespace CSS in Notebook HTML updated to use `pre-wrap` instead of `pre`

### DIFF
--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -161,7 +161,7 @@ class NotebookFormatter(HTMLFormatter):
             .dataframe > thead > tr > th,
             .dataframe > tbody > tr > td {
               text-align: right;
-              white-space: pre;
+              white-space: pre-wrap;
             }
             </style>
         """


### PR DESCRIPTION
Follow-up to #10644, closes #10704.

This improves the previous CSS `whitespace` style definition update/fix such that long strings _can_ still wrap in Notebooks, while preserving accurate whitespace rendering (eg: not collapsing it).