### PR TITLE
chore(python): Unpin `connectorx` and bump other Python dependencies

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Lint Markdown and TOML
         uses: dprint/check@v2.2
       - name: Spell Check with Typos
-        uses: crate-ci/typos@v1.16.1
+        uses: crate-ci/typos@v1.16.8

--- a/crates/polars-arrow/src/kernels/rolling/mod.rs
+++ b/crates/polars-arrow/src/kernels/rolling/mod.rs
@@ -30,7 +30,7 @@ pub fn compare_fn_nan_min<T>(a: &T, b: &T) -> Ordering
 where
     T: PartialOrd + IsFloat,
 {
-    // this branch should be opimized away for integers
+    // this branch should be optimized away for integers
     if T::is_float() {
         match (a.is_nan(), b.is_nan()) {
             // safety: we checked nans
@@ -52,7 +52,7 @@ pub fn compare_fn_nan_max<T>(a: &T, b: &T) -> Ordering
 where
     T: PartialOrd + IsFloat,
 {
-    // this branch should be opimized away for integers
+    // this branch should be optimized away for integers
     if T::is_float() {
         match (a.is_nan(), b.is_nan()) {
             // safety: we checked nans

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -4,9 +4,9 @@ numpy
 pandas
 pyarrow
 
-hypothesis==6.82.0
+hypothesis==6.82.6
 
-sphinx==7.1.1
+sphinx==7.2.4
 
 # Third-party Sphinx extensions
 autodocsumm==0.2.11

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -410,7 +410,7 @@ def _read_sql_connectorx(
     except ModuleNotFoundError:
         raise ModuleNotFoundError(
             "connectorx is not installed"
-            "\n\nPlease run `pip install connectorx>=0.3.1`."
+            "\n\nPlease run `pip install connectorx>=0.3.2`."
         ) from None
 
     tbl = cx.read_sql(

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -17,13 +17,13 @@ SQLAlchemy
 xlsx2csv
 XlsxWriter
 adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'
-connectorx==0.3.2a7  # Latest full release is broken - unpin when 0.3.2 released
+connectorx
 cloudpickle
 fsspec
 
 # Tooling
-hypothesis==6.82.0
-maturin==1.2.1
+hypothesis==6.82.6
+maturin==1.2.3
 patchelf; platform_system == 'Linux'  # Extra dependency for maturin, only for Linux
 pytest==7.4.0
 pytest-cov==4.1.0

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,5 +1,5 @@
 black==23.7.0
 blackdoc==0.3.8
-mypy==1.4.1
-ruff==0.0.285
-typos==1.16.1
+mypy==1.5.1
+ruff==0.0.286
+typos==1.16.8


### PR DESCRIPTION
I got a notification that `connectorx` has finally released a new version, so we can unpin the pre-release version. Also took the opportunity to bump our other Python deps.