### PR TITLE
chore(rust) enable wasm test for decompress feature

### DIFF
--- a/crates/Makefile
+++ b/crates/Makefile
@@ -118,7 +118,6 @@ check-wasm:  ## Check wasm build without supported features
 		--exclude-features async              \
 		--exclude-features aws                \
 		--exclude-features azure              \
-		--exclude-features decompress         \
 		--exclude-features decompress-fast    \
 		--exclude-features default            \
 		--exclude-features docs-selection     \


### PR DESCRIPTION
This recent change: #10733 fixed the build for decompress on wasm, previously broken by https://github.com/pola-rs/polars/pull/10492#issuecomment-1681031677.