### PR TITLE
fix(rust): fix unicode truncation in json parsing

### DIFF
--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -2009,8 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "simd-json"
-version = "0.10.0"
-source = "git+https://github.com/ritchie46/simd-json?branch=initialize#946b316f686c6ad3050f694ea434248c38aa321d"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7f1293f0e4e11d52e588766fe9de8caa2857ff63809d40de83245452ca7c5c"
 dependencies = [
  "ahash",
  "halfbrown",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -212,8 +212,5 @@ lto = "fat"
 # Should not be used when packaging
 # target-cpu = "native"
 
-[patch.crates-io]
-simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "initialize" }
-
 # Prevent package from thinking it's in the workspace
 [workspace]

--- a/py-polars/tests/unit/io/test_lazy_json.py
+++ b/py-polars/tests/unit/io/test_lazy_json.py
@@ -95,3 +95,8 @@ def test_glob_n_rows(io_files_path: Path) -> None:
         "fats_g": [0.5, 6.0],
         "sugars_g": [2, 2],
     }
+
+
+# See #10661.
+def test_json_no_unicode_truncate() -> None:
+    assert pl.read_ndjson(rb'{"field": "\ufffd1234"}')[0, 0] == "\ufffd1234"


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/10661, https://github.com/pola-rs/polars/issues/9791, https://github.com/pola-rs/polars/issues/10034.

Ultimately I did not figure out what the issue was, and while trying to edit the code in a local copy of `simd-json` I noticed that the issue does not occur on the latest `main` (10.6). Then I realized we have an old patched version (10.0) of `simd-json` by ritchie, that fixes a bug that is also now fixed on `main`. So I bumped the dependency, removing the patch, and that also fixed the issue. So I suppose it was a bug in `simd-json` somewhere that has since been fixed.