### PR TITLE
docs(python): map-related docstring updates

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6014,7 +6014,7 @@ class DataFrame:
             Output type of the operation. If none given, Polars tries to infer the type.
         inference_size
             Only used in the case when the custom function returns rows.
-            This uses the first `n` rows to determine the output schema
+            This uses the first `n` rows to determine the output schema.
 
         Notes
         -----
@@ -6025,7 +6025,7 @@ class DataFrame:
 
         * If your function is expensive and you don't want it to be called more than
           once for a given input, consider applying an ``@lru_cache`` decorator to it.
-          With suitable data you may achieve order-of-magnitude speedups (or more).
+          If your data is suitable you may achieve *significant* speedups.
 
         Examples
         --------

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -266,7 +266,7 @@ class GroupBy:
         Parameters
         ----------
         function
-            Custom function.
+            Custom function that receives a DataFrame and returns a DataFrame.
 
         Returns
         -------
@@ -877,12 +877,12 @@ class RollingGroupBy:
         """
         Apply a custom/user-defined function (UDF) over the groups as a new DataFrame.
 
-        Using this is considered an anti-pattern. This will be very slow because:
+        Using this is considered an anti-pattern as it will be very slow because:
 
         - it forces the engine to materialize the whole `DataFrames` for the groups.
-        - it is not parallelized
+        - it is not parallelized.
         - it blocks optimizations as the passed python function is opaque to the
-          optimizer
+          optimizer.
 
         The idiomatic way to apply custom functions over multiple columns is using:
 
@@ -891,7 +891,8 @@ class RollingGroupBy:
         Parameters
         ----------
         function
-            Function to apply over each group of the `LazyFrame`.
+            Function to apply over each group of the `LazyFrame`; it receives
+            a DataFrame and should return a DataFrame.
         schema
             Schema of the output function. This has to be known statically. If the
             given schema is incorrect, this is a bug in the caller's query and may
@@ -1067,12 +1068,12 @@ class DynamicGroupBy:
         """
         Apply a custom/user-defined function (UDF) over the groups as a new DataFrame.
 
-        Using this is considered an anti-pattern. This will be very slow because:
+        Using this is considered an anti-pattern as it will be very slow because:
 
         - it forces the engine to materialize the whole `DataFrames` for the groups.
-        - it is not parallelized
+        - it is not parallelized.
         - it blocks optimizations as the passed python function is opaque to the
-          optimizer
+          optimizer.
 
         The idiomatic way to apply custom functions over multiple columns is using:
 
@@ -1081,7 +1082,8 @@ class DynamicGroupBy:
         Parameters
         ----------
         function
-            Function to apply over each group of the `LazyFrame`.
+            Function to apply over each group of the `LazyFrame`; it receives
+            a DataFrame and should return a DataFrame.
         schema
             Schema of the output function. This has to be known statically. If the
             given schema is incorrect, this is a bug in the caller's query and may

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -974,11 +974,11 @@ def map_batches(
     Parameters
     ----------
     exprs
-        Input Series to f
+        Expression(s) representing the input Series to the function.
     function
-        Function to apply over the input
+        Function to apply over the input.
     return_dtype
-        dtype of the output Series
+        dtype of the output Series.
 
     Returns
     -------
@@ -1069,22 +1069,14 @@ def map_groups(
         This method is much slower than the native expressions API.
         Only use it if you cannot implement your logic otherwise.
 
-    Depending on the context it has the following behavior:
-
-    * Select
-        Don't use apply, use `map`
-    * GroupBy
-        expected type `f`: Callable[[Series], Series]
-        Applies a python function over each group.
-
     Parameters
     ----------
     exprs
-        Input Series to f
+        Expression(s) representing the input Series to the function.
     function
-        Function to apply over the input
+        Function to apply over the input; should be of type Callable[[Series], Series].
     return_dtype
-        dtype of the output Series
+        dtype of the output Series.
     returns_scalar
         If the function returns a single scalar as output.
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5170,13 +5170,16 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Examples
         --------
-        >>> lf = pl.LazyFrame(
-        ...     {
-        ...         "a": range(-100_000, 0),
-        ...         "b": range(0, 100_000),
-        ...     }
+        >>> lf = (  # doctest: +SKIP
+        ...     pl.LazyFrame(
+        ...         {
+        ...             "a": pl.int_range(-100_000, 0, eager=True),
+        ...             "b": pl.int_range(0, 100_000, eager=True),
+        ...         }
+        ...     )
+        ...     .map_batches(lambda x: 2 * x, streamable=True)
+        ...     .collect(streaming=True)
         ... )
-        >>> lf.map_batches(lambda x: 2 * x, streamable=True).collect(streaming=True)
         shape: (100_000, 2)
         ┌─────────┬────────┐
         │ a       ┆ b      │

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5172,20 +5172,27 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         --------
         >>> lf = pl.LazyFrame(
         ...     {
-        ...         "a": [1, 2],
-        ...         "b": [3, 4],
+        ...         "a": range(-100_000, 0),
+        ...         "b": range(0, 100_000),
         ...     }
         ... )
-        >>> lf.map_batches(lambda x: 2 * x).collect()
-        shape: (2, 2)
-        ┌─────┬─────┐
-        │ a   ┆ b   │
-        │ --- ┆ --- │
-        │ i64 ┆ i64 │
-        ╞═════╪═════╡
-        │ 2   ┆ 6   │
-        │ 4   ┆ 8   │
-        └─────┴─────┘
+        >>> lf.map_batches(lambda x: 2 * x, streamable=True).collect(streaming=True)
+        shape: (100_000, 2)
+        ┌─────────┬────────┐
+        │ a       ┆ b      │
+        │ ---     ┆ ---    │
+        │ i64     ┆ i64    │
+        ╞═════════╪════════╡
+        │ -200000 ┆ 0      │
+        │ -199998 ┆ 2      │
+        │ -199996 ┆ 4      │
+        │ -199994 ┆ 6      │
+        │ …       ┆ …      │
+        │ -8      ┆ 199992 │
+        │ -6      ┆ 199994 │
+        │ -4      ┆ 199996 │
+        │ -2      ┆ 199998 │
+        └─────────┴────────┘
 
         """
         if no_optimizations:

--- a/py-polars/polars/lazyframe/group_by.py
+++ b/py-polars/polars/lazyframe/group_by.py
@@ -157,7 +157,7 @@ class LazyGroupBy:
             This method is much slower than the native expressions API.
             Only use it if you cannot implement your logic otherwise.
 
-        Using this is considered an anti-pattern. This will be very slow because:
+        Using this is considered an anti-pattern as it will be very slow because:
 
         - it forces the engine to materialize the whole `DataFrames` for the groups.
         - it is not parallelized

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4875,7 +4875,7 @@ class Series:
         -----
         If your function is expensive and you don't want it to be called more than
         once for a given input, consider applying an ``@lru_cache`` decorator to it.
-        With suitable data you may achieve order-of-magnitude speedups (or more).
+        If your data is suitable you may achieve *significant* speedups.
 
         Examples
         --------

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -845,7 +845,7 @@ def warn_on_inefficient_map(
         or ``"series"``.
     """
     if map_target == "frame":
-        raise NotImplementedError("TODO: 'frame' and 'series' map-function parsing")
+        raise NotImplementedError("TODO: 'frame' map-function parsing")
 
     # note: we only consider simple functions with a single col/param
     if not (col := columns and columns[0]):


### PR DESCRIPTION
Various updates for assorted `map_*` docstrings. Includes additional information, minor clarifications, and a new example showing window function context via `over` grouping.