### PR TITLE
chore(python): Create `.venv` in repo root

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,10 +36,9 @@ jobs:
           python-version: '3.11'
 
       - name: Create virtual environment
-        working-directory: py-polars
         run: |
           python -m venv .venv
-          echo "$GITHUB_WORKSPACE/py-polars/.venv/bin" >> $GITHUB_PATH
+          echo "$GITHUB_WORKSPACE/.venv/bin" >> $GITHUB_PATH
 
       - name: Install Python dependencies
         working-directory: py-polars

--- a/.github/workflows/test-bytecode-parser.yml
+++ b/.github/workflows/test-bytecode-parser.yml
@@ -5,20 +5,10 @@ on:
     paths:
       - py-polars/**
       - .github/workflows/test-bytecode-parser.yml
-  push:
-    branches:
-      - main
-    paths:
-      - py-polars/**
-      - .github/workflows/test-bytecode-parser.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-defaults:
-  run:
-    working-directory: py-polars
 
 jobs:
   ubuntu:
@@ -36,14 +26,9 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Create virtual environment
-        run: |
-          python -m venv .venv
-          echo "$GITHUB_WORKSPACE/py-polars/.venv/bin" >> $GITHUB_PATH
-
       - name: Install dependencies
         run: pip install ipython numpy pytest
 
       - name: Run tests
-        if: github.ref_name != 'main'
+        working-directory: py-polars
         run: PYTHONPATH=polars/utils pytest tests/test_udfs.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ make test
 
 This will do a number of things:
 
-- Use Python to create a virtual environment in the `py-polars/.venv` folder.
+- Use Python to create a virtual environment in the `.venv` folder.
 - Use [pip](https://pip.pypa.io/) to install all Python dependencies for development, linting, and building documentation.
 - Use Rust to compile and install Polars in your virtual environment.
 - Use [pytest](https://docs.pytest.org/) to run the Python unittests in your virtual environment

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.DEFAULT_GOAL := help
+
+PYTHONPATH=
+SHELL=/bin/bash
+VENV=.venv
+
+ifeq ($(OS),Windows_NT)
+	VENV_BIN=$(VENV)/Scripts
+else
+	VENV_BIN=$(VENV)/bin
+endif
+
+.venv:  ## Set up Python virtual environment and install requirements
+	python3 -m venv $(VENV)
+	$(MAKE) requirements
+
+.PHONY: requirements
+requirements: .venv  ## Install/refresh Python project requirements
+	$(VENV_BIN)/python -m pip install --upgrade pip
+	$(VENV_BIN)/pip install --upgrade -r py-polars/requirements-dev.txt
+	$(VENV_BIN)/pip install --upgrade -r py-polars/requirements-lint.txt
+	$(VENV_BIN)/pip install --upgrade -r py-polars/docs/requirements-docs.txt
+
+.PHONY: clean
+clean:  ## Clean up caches and build artifacts
+	@rm -rf .venv/
+	@rm -rf target/
+	@rm -f Cargo.lock
+	@cargo clean
+	@$(MAKE) -s -C py-polars/ $@
+
+.PHONY: help
+help:  ## Display this help screen
+	@echo -e "\033[1mAvailable commands:\033[0m"
+	@grep -E '^[a-z.A-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' | sort

--- a/dprint.json
+++ b/dprint.json
@@ -1,14 +1,17 @@
 {
-  "includes": [
-    "**/*.{md,toml}"
-  ],
-  "excludes": [
-    "**/target",
-    "py-polars/.pytest_cache",
-    "py-polars/.venv"
-  ],
-  "plugins": [
-    "https://plugins.dprint.dev/markdown-0.15.2.wasm",
-    "https://plugins.dprint.dev/toml-0.5.4.wasm"
-  ]
+    "includes": [
+        "**/*.{md,toml}"
+    ],
+    "excludes": [
+        ".venv/",
+        "**/target/",
+        "py-polars/.hypothesis/",
+        "py-polars/.mypy_cache/",
+        "py-polars/.pytest_cache/",
+        "py-polars/.ruff_cache/"
+    ],
+    "plugins": [
+        "https://plugins.dprint.dev/markdown-0.16.0.wasm",
+        "https://plugins.dprint.dev/toml-0.5.4.wasm"
+    ]
 }

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -2,7 +2,7 @@
 
 PYTHONPATH=
 SHELL=/bin/bash
-VENV = .venv
+VENV=../.venv
 
 ifeq ($(OS),Windows_NT)
 	VENV_BIN=$(VENV)/Scripts
@@ -10,16 +10,13 @@ else
 	VENV_BIN=$(VENV)/bin
 endif
 
+.PHONY: .venv
 .venv:  ## Set up virtual environment and install requirements
-	python3 -m venv $(VENV)
-	$(MAKE) requirements
+	@$(MAKE) -s -C .. $@
 
 .PHONY: requirements
 requirements: .venv  ## Install/refresh all project requirements
-	$(VENV_BIN)/python -m pip install --upgrade pip
-	$(VENV_BIN)/pip install --upgrade -r requirements-dev.txt
-	$(VENV_BIN)/pip install --upgrade -r requirements-lint.txt
-	$(VENV_BIN)/pip install --upgrade -r docs/requirements-docs.txt
+	@$(MAKE) -s -C .. $@
 
 .PHONY: build
 build: .venv  ## Compile and install Polars for development
@@ -91,7 +88,6 @@ coverage: .venv build  ## Run tests and report coverage
 
 .PHONY: clean
 clean:  ## Clean up caches and build artifacts
-	@rm -rf .venv/
 	@rm -rf target/
 	@rm -rf docs/build/
 	@rm -rf docs/source/reference/api/


### PR DESCRIPTION
Preparation for #10560

Building the user guide requires `mkdocs`, which is a Python dependency. After moving the docs into this repo, we'll also have Python files (code snippets) in the `docs` folder. Because of this, we'll want to run some Python commands from the root of the repo, so it makes sense to move the Python virtual environment to the repo root.

This shouldn't impact anyone's workflow. All existing make commands should still work identically.

#### Changes

* Add top-level Makefile including the following commands (can add more commands later):
  * `.venv`
  * `requirements`
  * `clean`
  * `help`
* Adjust the Python Makefile to dispatch to the top-level Makefile for `.venv` / `requirements` commands and use the right venv path.
* Update other `.venv` references
* Update bytecode parser workflow to not run on the main branch - there is no need since nothing is being cached.
* Update `dprint` plugin versions