### PR TITLE
feat(python): add `binary`, `boolean`, `categorical`, `date`, `object`, and `time` selectors

### DIFF
--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -12,6 +12,8 @@ from polars.datatypes import (
     SIGNED_INTEGER_DTYPES,
     TEMPORAL_DTYPES,
     UNSIGNED_INTEGER_DTYPES,
+    Binary,
+    Boolean,
     Categorical,
     Date,
     Datetime,
@@ -374,6 +376,102 @@ def all() -> SelectorType:
     return _selector_proxy_(F.all(), name="all")
 
 
+def binary() -> SelectorType:
+    """
+    Select all binary columns.
+
+    See Also
+    --------
+    by_dtype : Select all columns matching the given dtype(s).
+    string : Select all string columns (optionally including categoricals).
+
+    Examples
+    --------
+    >>> import polars.selectors as cs
+    >>> df = pl.DataFrame({"a": [b"hello"], "b": ["world"], "c": [b"!"], "d": [":)"]})
+    >>> df
+    shape: (1, 4)
+    ┌───────────────┬───────┬───────────────┬─────┐
+    │ a             ┆ b     ┆ c             ┆ d   │
+    │ ---           ┆ ---   ┆ ---           ┆ --- │
+    │ binary        ┆ str   ┆ binary        ┆ str │
+    ╞═══════════════╪═══════╪═══════════════╪═════╡
+    │ [binary data] ┆ world ┆ [binary data] ┆ :)  │
+    └───────────────┴───────┴───────────────┴─────┘
+
+    Select binary columns and export as a dict:
+
+    >>> df.select(cs.binary()).to_dict(False)
+    {'a': [b'hello'], 'c': [b'!']}
+
+    Select all columns *except* for those that are binary:
+
+    >>> df.select(~cs.binary()).to_dict(False)
+    {'b': ['world'], 'd': [':)']}
+
+    """
+    return _selector_proxy_(F.col(Binary), name="binary")
+
+
+def boolean() -> SelectorType:
+    """
+    Select all boolean columns.
+
+    See Also
+    --------
+    by_dtype : Select all columns matching the given dtype(s).
+
+    Examples
+    --------
+    >>> import polars.selectors as cs
+    >>> df = pl.DataFrame({"n": range(1, 5)}).with_columns(n_even=pl.col("n") % 2 == 0)
+    >>> df
+    shape: (4, 2)
+    ┌─────┬────────┐
+    │ n   ┆ n_even │
+    │ --- ┆ ---    │
+    │ i64 ┆ bool   │
+    ╞═════╪════════╡
+    │ 1   ┆ false  │
+    │ 2   ┆ true   │
+    │ 3   ┆ false  │
+    │ 4   ┆ true   │
+    └─────┴────────┘
+
+    Select and invert boolean columns:
+
+    >>> df.with_columns(is_odd=cs.boolean().is_not())
+    shape: (4, 3)
+    ┌─────┬────────┬────────┐
+    │ n   ┆ n_even ┆ is_odd │
+    │ --- ┆ ---    ┆ ---    │
+    │ i64 ┆ bool   ┆ bool   │
+    ╞═════╪════════╪════════╡
+    │ 1   ┆ false  ┆ true   │
+    │ 2   ┆ true   ┆ false  │
+    │ 3   ┆ false  ┆ true   │
+    │ 4   ┆ true   ┆ false  │
+    └─────┴────────┴────────┘
+
+    Select all columns *except* for those that are boolean:
+
+    >>> df.select(~cs.boolean())
+    shape: (4, 1)
+    ┌─────┐
+    │ n   │
+    │ --- │
+    │ i64 │
+    ╞═════╡
+    │ 1   │
+    │ 2   │
+    │ 3   │
+    │ 4   │
+    └─────┘
+
+    """
+    return _selector_proxy_(F.col(Boolean), name="boolean")
+
+
 def by_dtype(
     *dtypes: PolarsDataType | Collection[PolarsDataType],
 ) -> SelectorType:
@@ -382,10 +480,7 @@ def by_dtype(
 
     See Also
     --------
-    integer : Select all integer columns.
-    float : Select all float columns.
-    numeric : Select all numeric columns.
-    temporal : Select all temporal columns.
+    by_name : Select all columns matching the given names.
 
     Examples
     --------
@@ -533,7 +628,7 @@ def categorical() -> SelectorType:
 
     See Also
     --------
-    by_dtype : Select all columns of a given dtype.
+    by_dtype : Select all columns matching the given dtype(s).
     string : Select all string columns (optionally including categoricals).
 
     Examples
@@ -877,6 +972,13 @@ def duration(
         One (or more) of the allowed timeunit precision strings, "ms", "us", and "ns".
         Omit to select columns with any valid timeunit.
 
+    See Also
+    --------
+    date : Select all date columns.
+    datetime : Select all datetime columns, optionally filtering by time unit/zone.
+    temporal : Select all temporal columns.
+    time : Select all time columns.
+
     Examples
     --------
     >>> from datetime import date, timedelta
@@ -1106,8 +1208,8 @@ def float() -> SelectorType:
     --------
     integer : Select all integer columns.
     numeric : Select all numeric columns.
-    temporal : Select all temporal columns.
-    string : Select all string columns.
+    signed_integer : Select all signed integer columns.
+    unsigned_integer : Select all unsigned integer columns.
 
     Examples
     --------
@@ -1161,8 +1263,8 @@ def integer() -> SelectorType:
     by_dtype : Select columns by dtype.
     float : Select all float columns.
     numeric : Select all numeric columns.
-    temporal : Select all temporal columns.
-    string : Select all string columns.
+    signed_integer : Select all signed integer columns.
+    unsigned_integer : Select all unsigned integer columns.
 
     Examples
     --------
@@ -1189,7 +1291,7 @@ def integer() -> SelectorType:
     │ 456 ┆ 1   │
     └─────┴─────┘
 
-    Select all columns *except* for those that are integer:
+    Select all columns *except* for those that are integer :
 
     >>> df.select(~cs.integer())
     shape: (2, 2)
@@ -1214,9 +1316,9 @@ def signed_integer() -> SelectorType:
     --------
     by_dtype : Select columns by dtype.
     float : Select all float columns.
-    integer: Select all integer columns.
+    integer : Select all integer columns.
     numeric : Select all numeric columns.
-    unsigned_integer: Select all unsigned integer columns.
+    unsigned_integer : Select all unsigned integer columns.
 
     Examples
     --------
@@ -1280,9 +1382,9 @@ def unsigned_integer() -> SelectorType:
     --------
     by_dtype : Select columns by dtype.
     float : Select all float columns.
-    integer: Select all integer columns.
+    integer : Select all integer columns.
     numeric : Select all numeric columns.
-    signed_integer: Select all signed integer columns.
+    signed_integer : Select all signed integer columns.
 
     Examples
     --------
@@ -1474,8 +1576,8 @@ def numeric() -> SelectorType:
     by_dtype : Select columns by dtype.
     float : Select all float columns.
     integer : Select all integer columns.
-    temporal : Select all temporal columns.
-    string : Select all string columns.
+    signed_integer : Select all signed integer columns.
+    unsigned_integer : Select all unsigned integer columns.
 
     Examples
     --------
@@ -1603,12 +1705,9 @@ def string(include_categorical: bool = False) -> SelectorType:
 
     See Also
     --------
-    by_dtype : Select all columns of a given dtype.
+    binary : Select all binary columns.
+    by_dtype : Select all columns matching the given dtype(s).
     categorical: Select all categorical columns.
-    float : Select all float columns.
-    integer : Select all integer columns.
-    numeric : Select all numeric columns.
-    temporal : Select all temporal columns.
 
     Examples
     --------
@@ -1669,11 +1768,11 @@ def temporal() -> SelectorType:
 
     See Also
     --------
-    by_dtype : Select all columns of a given dtype.
-    float : Select all float columns.
-    integer : Select all integer columns.
-    numeric : Select all numeric columns.
-    string : Select all string columns.
+    by_dtype : Select all columns matching the given dtype(s).
+    date : Select all date columns.
+    datetime : Select all datetime columns, optionally filtering by time unit/zone.
+    duration : Select all duration columns, optionally filtering by time unit.
+    time : Select all time columns.
 
     Examples
     --------

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -13,8 +13,10 @@ from polars.datatypes import (
     TEMPORAL_DTYPES,
     UNSIGNED_INTEGER_DTYPES,
     Categorical,
+    Date,
     Datetime,
     Duration,
+    Time,
     Utf8,
     is_polars_dtype,
 )
@@ -525,6 +527,57 @@ def by_name(*names: str | Collection[str]) -> SelectorType:
     )
 
 
+def categorical() -> SelectorType:
+    """
+    Select all categorical columns.
+
+    See Also
+    --------
+    by_dtype : Select all columns of a given dtype.
+    string : Select all string columns (optionally including categoricals).
+
+    Examples
+    --------
+    >>> import polars.selectors as cs
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "foo": ["xx", "yy"],
+    ...         "bar": [123, 456],
+    ...         "baz": [2.0, 5.5],
+    ...     },
+    ...     schema_overrides={"foo": pl.Categorical},
+    ... )
+
+    Select all categorical columns:
+
+    >>> df.select(cs.categorical())
+    shape: (2, 1)
+    ┌─────┐
+    │ foo │
+    │ --- │
+    │ cat │
+    ╞═════╡
+    │ xx  │
+    │ yy  │
+    └─────┘
+
+    Select all columns *except* for those that are categorical:
+
+    >>> df.select(~cs.categorical())
+    shape: (2, 2)
+    ┌─────┬─────┐
+    │ bar ┆ baz │
+    │ --- ┆ --- │
+    │ i64 ┆ f64 │
+    ╞═════╪═════╡
+    │ 123 ┆ 2.0 │
+    │ 456 ┆ 5.5 │
+    └─────┴─────┘
+
+    """
+    return _selector_proxy_(F.col(Categorical), name="categorical")
+
+
 def contains(substring: str | Collection[str]) -> SelectorType:
     """
     Select columns that contain the given literal substring(s).
@@ -602,6 +655,59 @@ def contains(substring: str | Collection[str]) -> SelectorType:
     )
 
 
+def date() -> SelectorType:
+    """
+    Select all date columns.
+
+    See Also
+    --------
+    datetime : Select all datetime columns, optionally filtering by time unit/zone.
+    duration : Select all duration columns, optionally filtering by time unit.
+    temporal : Select all temporal columns.
+    time : Select all time columns.
+
+    Examples
+    --------
+    >>> from datetime import date, datetime, time
+    >>> import polars.selectors as cs
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "dtm": [datetime(2001, 5, 7, 10, 25), datetime(2031, 12, 31, 0, 30)],
+    ...         "dt": [date(1999, 12, 31), date(2024, 8, 9)],
+    ...         "tm": [time(0, 0, 0), time(23, 59, 59)],
+    ...     },
+    ... )
+
+    Select all date columns:
+
+    >>> df.select(cs.date())
+    shape: (2, 1)
+    ┌────────────┐
+    │ dt         │
+    │ ---        │
+    │ date       │
+    ╞════════════╡
+    │ 1999-12-31 │
+    │ 2024-08-09 │
+    └────────────┘
+
+    Select all columns *except* for those that are dates:
+
+    >>> df.select(~cs.date())
+    shape: (2, 2)
+    ┌─────────────────────┬──────────┐
+    │ dtm                 ┆ tm       │
+    │ ---                 ┆ ---      │
+    │ datetime[μs]        ┆ time     │
+    ╞═════════════════════╪══════════╡
+    │ 2001-05-07 10:25:00 ┆ 00:00:00 │
+    │ 2031-12-31 00:30:00 ┆ 23:59:59 │
+    └─────────────────────┴──────────┘
+
+    """
+    return _selector_proxy_(F.col(Date), name="date")
+
+
 def datetime(
     time_unit: TimeUnit | Collection[TimeUnit] | None = None,
     time_zone: (str | timezone | Collection[str | timezone | None] | None) = (
@@ -622,6 +728,13 @@ def datetime(
           run ``import zoneinfo; zoneinfo.available_timezones()`` for a full list).
         * Set ``None`` to select Datetime columns that do not have a timezone.
         * Set "*" to select Datetime columns that have *any* timezone.
+
+    See Also
+    --------
+    date : Select all date columns.
+    duration : Select all duration columns, optionally filtering by time unit.
+    temporal : Select all temporal columns.
+    time : Select all time columns.
 
     Examples
     --------
@@ -1036,10 +1149,7 @@ def float() -> SelectorType:
     └─────┴─────┘
 
     """
-    return _selector_proxy_(
-        F.col(FLOAT_DTYPES),
-        name="float",
-    )
+    return _selector_proxy_(F.col(FLOAT_DTYPES), name="float")
 
 
 def integer() -> SelectorType:
@@ -1093,10 +1203,7 @@ def integer() -> SelectorType:
     └─────┴─────┘
 
     """
-    return _selector_proxy_(
-        F.col(INTEGER_DTYPES),
-        name="integer",
-    )
+    return _selector_proxy_(F.col(INTEGER_DTYPES), name="integer")
 
 
 def signed_integer() -> SelectorType:
@@ -1162,10 +1269,7 @@ def signed_integer() -> SelectorType:
     └──────┴──────┴──────┘
 
     """
-    return _selector_proxy_(
-        F.col(SIGNED_INTEGER_DTYPES),
-        name="signed_integer",
-    )
+    return _selector_proxy_(F.col(SIGNED_INTEGER_DTYPES), name="signed_integer")
 
 
 def unsigned_integer() -> SelectorType:
@@ -1233,10 +1337,7 @@ def unsigned_integer() -> SelectorType:
     └──────┴──────┴──────┘
 
     """
-    return _selector_proxy_(
-        F.col(UNSIGNED_INTEGER_DTYPES),
-        name="unsigned_integer",
-    )
+    return _selector_proxy_(F.col(UNSIGNED_INTEGER_DTYPES), name="unsigned_integer")
 
 
 def last() -> SelectorType:
@@ -1416,10 +1517,7 @@ def numeric() -> SelectorType:
     └─────┘
 
     """
-    return _selector_proxy_(
-        F.col(NUMERIC_DTYPES),
-        name="numeric",
-    )
+    return _selector_proxy_(F.col(NUMERIC_DTYPES), name="numeric")
 
 
 def starts_with(*prefix: str) -> SelectorType:
@@ -1501,11 +1599,12 @@ def starts_with(*prefix: str) -> SelectorType:
 
 def string(include_categorical: bool = False) -> SelectorType:
     """
-    Select all Utf8 (and, optionally, Categorical) string columns.
+    Select all Utf8 (and, optionally, Categorical) string columns .
 
     See Also
     --------
     by_dtype : Select all columns of a given dtype.
+    categorical: Select all categorical columns.
     float : Select all float columns.
     integer : Select all integer columns.
     numeric : Select all numeric columns.
@@ -1601,9 +1700,9 @@ def temporal() -> SelectorType:
     │ 2021-01-02 ┆ 20:30:45 │
     └────────────┴──────────┘
 
-    Match all temporal columns *except* for `Time` columns:
+    Match all temporal columns *except* for time columns:
 
-    >>> df.select(cs.temporal() - cs.by_dtype(pl.Time))
+    >>> df.select(cs.temporal() - cs.time())
     shape: (2, 1)
     ┌────────────┐
     │ dt         │
@@ -1628,17 +1727,69 @@ def temporal() -> SelectorType:
     └────────┘
 
     """
-    return _selector_proxy_(
-        F.col(TEMPORAL_DTYPES),
-        name="temporal",
-    )
+    return _selector_proxy_(F.col(TEMPORAL_DTYPES), name="temporal")
+
+
+def time() -> SelectorType:
+    """
+    Select all time columns.
+
+    See Also
+    --------
+    date : Select all date columns.
+    datetime : Select all datetime columns, optionally filtering by time unit/zone.
+    duration : Select all duration columns, optionally filtering by time unit.
+    temporal : Select all temporal columns.
+
+    Examples
+    --------
+    >>> from datetime import date, datetime, time
+    >>> import polars.selectors as cs
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "dtm": [datetime(2001, 5, 7, 10, 25), datetime(2031, 12, 31, 0, 30)],
+    ...         "dt": [date(1999, 12, 31), date(2024, 8, 9)],
+    ...         "tm": [time(0, 0, 0), time(23, 59, 59)],
+    ...     },
+    ... )
+
+    Select all time columns:
+
+    >>> df.select(cs.time())
+    shape: (2, 1)
+    ┌──────────┐
+    │ tm       │
+    │ ---      │
+    │ time     │
+    ╞══════════╡
+    │ 00:00:00 │
+    │ 23:59:59 │
+    └──────────┘
+
+    Select all columns *except* for those that are times:
+
+    >>> df.select(~cs.time())
+    shape: (2, 2)
+    ┌─────────────────────┬────────────┐
+    │ dtm                 ┆ dt         │
+    │ ---                 ┆ ---        │
+    │ datetime[μs]        ┆ date       │
+    ╞═════════════════════╪════════════╡
+    │ 2001-05-07 10:25:00 ┆ 1999-12-31 │
+    │ 2031-12-31 00:30:00 ┆ 2024-08-09 │
+    └─────────────────────┴────────────┘
+
+    """
+    return _selector_proxy_(F.col(Time), name="time")
 
 
 __all__ = [
     "all",
     "by_dtype",
     "by_name",
+    "categorical",
     "contains",
+    "date",
     "datetime",
     "duration",
     "ends_with",
@@ -1650,6 +1801,7 @@ __all__ = [
     "numeric",
     "starts_with",
     "temporal",
+    "time",
     "string",
     "is_selector",
     "expand_selector",

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -1658,7 +1658,7 @@ def object() -> SelectorType:
 
     Select object columns and export as a dict:
 
-    >>> df.select(cs.object()).to_dict(False)
+    >>> df.select(cs.object()).to_dict(False)  # doctest: +IGNORE_RESULT
     {
         "uuid_obj": [
             UUID("6be063cf-c9c6-43be-878e-e446cfd42981"),
@@ -1668,7 +1668,7 @@ def object() -> SelectorType:
 
     Select all columns *except* for those that are object and export as dict:
 
-    >>> df.select(~cs.object())
+    >>> df.select(~cs.object())  # doctest: +IGNORE_RESULT
     {
         "idx": [0, 1],
         "uuid_str": [

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -18,6 +18,7 @@ from polars.datatypes import (
     Date,
     Datetime,
     Duration,
+    Object,
     Time,
     Utf8,
     is_polars_dtype,
@@ -1620,6 +1621,64 @@ def numeric() -> SelectorType:
 
     """
     return _selector_proxy_(F.col(NUMERIC_DTYPES), name="numeric")
+
+
+def object() -> SelectorType:
+    """
+    Select all object columns.
+
+    See Also
+    --------
+    by_dtype : Select columns by dtype.
+
+    Examples
+    --------
+    >>> import polars.selectors as cs
+    >>> from uuid import uuid4
+    >>> with pl.Config(fmt_str_lengths=36):
+    ...     df = pl.DataFrame(
+    ...         {
+    ...             "idx": [0, 1],
+    ...             "uuid_obj": [uuid4(), uuid4()],
+    ...             "uuid_str": [str(uuid4()), str(uuid4())],
+    ...         },
+    ...         schema_overrides={"idx": pl.Int32},
+    ...     )
+    ...     print(df)  # doctest: +IGNORE_RESULT
+    ...
+    shape: (2, 3)
+    ┌─────┬──────────────────────────────────────┬──────────────────────────────────────┐
+    │ idx ┆ uuid_obj                             ┆ uuid_str                             │
+    │ --- ┆ ---                                  ┆ ---                                  │
+    │ i32 ┆ object                               ┆ str                                  │
+    ╞═════╪══════════════════════════════════════╪══════════════════════════════════════╡
+    │ 0   ┆ 6be063cf-c9c6-43be-878e-e446cfd42981 ┆ acab9fea-c05d-4b91-b639-418004a63f33 │
+    │ 1   ┆ 7849d8f9-2cac-48e7-96d3-63cf81c14869 ┆ 28c65415-8b7d-4857-a4ce-300dca14b12b │
+    └─────┴──────────────────────────────────────┴──────────────────────────────────────┘
+
+    Select object columns and export as a dict:
+
+    >>> df.select(cs.object()).to_dict(False)
+    {
+        "uuid_obj": [
+            UUID("6be063cf-c9c6-43be-878e-e446cfd42981"),
+            UUID("7849d8f9-2cac-48e7-96d3-63cf81c14869"),
+        ]
+    }
+
+    Select all columns *except* for those that are object and export as dict:
+
+    >>> df.select(~cs.object())
+    {
+        "idx": [0, 1],
+        "uuid_str": [
+            "acab9fea-c05d-4b91-b639-418004a63f33",
+            "28c65415-8b7d-4857-a4ce-300dca14b12b",
+        ],
+    }
+
+    """  # noqa: W505
+    return _selector_proxy_(F.col(Object), name="object")
 
 
 def starts_with(*prefix: str) -> SelectorType:

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -261,6 +261,24 @@ def test_selector_matches(df: pl.DataFrame) -> None:
     ]
 
 
+def test_selector_miscellaneous(df: pl.DataFrame) -> None:
+    assert df.select(cs.string()).columns == ["qqR"]
+    assert df.select(cs.categorical()).columns == []
+
+    test_schema = {
+        "abc": pl.Utf8,
+        "mno": pl.Binary,
+        "tuv": pl.Object,
+        "xyz": pl.Categorical,
+    }
+    assert expand_selector(test_schema, cs.binary()) == ("mno",)
+    assert expand_selector(test_schema, ~cs.binary()) == ("abc", "tuv", "xyz")
+    assert expand_selector(test_schema, cs.object()) == ("tuv",)
+    assert expand_selector(test_schema, ~cs.object()) == ("abc", "mno", "xyz")
+    assert expand_selector(test_schema, cs.categorical()) == ("xyz",)
+    assert expand_selector(test_schema, ~cs.categorical()) == ("abc", "mno", "tuv")
+
+
 def test_selector_numeric(df: pl.DataFrame) -> None:
     assert df.select(cs.numeric()).schema == {
         "abc": pl.UInt16,
@@ -297,20 +315,6 @@ def test_selector_startswith(df: pl.DataFrame) -> None:
         "opp",
         "qqR",
     ]
-
-
-def test_selector_strings_categorical(df: pl.DataFrame) -> None:
-    assert df.select(cs.string()).columns == ["qqR"]
-    assert df.select(cs.categorical()).columns == []
-    assert expand_selector(
-        {"abc": pl.Utf8, "mno": pl.Binary, "xyz": pl.Categorical}, cs.categorical()
-    ) == ("xyz",)
-    assert expand_selector(
-        {"abc": pl.Utf8, "mno": pl.Binary, "xyz": pl.Categorical}, cs.binary()
-    ) == ("mno",)
-    assert expand_selector(
-        {"abc": pl.Utf8, "mno": pl.Binary, "xyz": pl.Categorical}, ~cs.categorical()
-    ) == ("abc", "mno")
 
 
 def test_selector_temporal(df: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -43,7 +43,7 @@ def test_selector_all(df: pl.DataFrame) -> None:
 
 
 def test_selector_by_dtype(df: pl.DataFrame) -> None:
-    assert df.select(cs.by_dtype(pl.UInt16, pl.Boolean)).schema == {
+    assert df.select(cs.by_dtype(pl.UInt16) | cs.boolean()).schema == {
         "abc": pl.UInt16,
         "eee": pl.Boolean,
         "fgg": pl.Boolean,
@@ -303,11 +303,14 @@ def test_selector_strings_categorical(df: pl.DataFrame) -> None:
     assert df.select(cs.string()).columns == ["qqR"]
     assert df.select(cs.categorical()).columns == []
     assert expand_selector(
-        {"abc": pl.Utf8, "xyz": pl.Categorical}, cs.categorical()
+        {"abc": pl.Utf8, "mno": pl.Binary, "xyz": pl.Categorical}, cs.categorical()
     ) == ("xyz",)
     assert expand_selector(
-        {"abc": pl.Utf8, "xyz": pl.Categorical}, ~cs.categorical()
-    ) == ("abc",)
+        {"abc": pl.Utf8, "mno": pl.Binary, "xyz": pl.Categorical}, cs.binary()
+    ) == ("mno",)
+    assert expand_selector(
+        {"abc": pl.Utf8, "mno": pl.Binary, "xyz": pl.Categorical}, ~cs.categorical()
+    ) == ("abc", "mno")
 
 
 def test_selector_temporal(df: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -299,6 +299,17 @@ def test_selector_startswith(df: pl.DataFrame) -> None:
     ]
 
 
+def test_selector_strings_categorical(df: pl.DataFrame) -> None:
+    assert df.select(cs.string()).columns == ["qqR"]
+    assert df.select(cs.categorical()).columns == []
+    assert expand_selector(
+        {"abc": pl.Utf8, "xyz": pl.Categorical}, cs.categorical()
+    ) == ("xyz",)
+    assert expand_selector(
+        {"abc": pl.Utf8, "xyz": pl.Categorical}, ~cs.categorical()
+    ) == ("abc",)
+
+
 def test_selector_temporal(df: pl.DataFrame) -> None:
     assert df.select(cs.temporal()).schema == {
         "ghi": pl.Time,
@@ -310,6 +321,8 @@ def test_selector_temporal(df: pl.DataFrame) -> None:
     assert set(df.select(~cs.temporal()).columns) == (
         all_columns - {"ghi", "JJK", "Lmn", "opp"}
     )
+    assert df.select(cs.time()).schema == {"ghi": pl.Time}
+    assert df.select(cs.date() | cs.time()).schema == {"ghi": pl.Time, "JJK": pl.Date}
 
 
 def test_selector_expansion() -> None:


### PR DESCRIPTION
Extends the available suite of dtype-based selectors with...

* `cs.categorical()`
* `cs.date()`
* `cs.time()` 

**Update 1**: 
* `cs.binary()`
* `cs.boolean()`

**Update 2**: 
* `cs.object()`
