### PR TITLE
fix(rust, python): Reading an only-header csv file in streaming mode should not panic

### DIFF
--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -146,7 +146,9 @@ where
                     Box::new(CsvSink::new(path, options.clone(), input_schema.as_ref())?)
                         as Box<dyn Sink>
                 },
-                FileType::Memory => Box::new(OrderedSink::new()) as Box<dyn Sink>,
+                FileType::Memory => {
+                    Box::new(OrderedSink::new(input_schema.into_owned())) as Box<dyn Sink>
+                },
             }
         },
         Join {

--- a/py-polars/tests/unit/io/files/only_header.csv
+++ b/py-polars/tests/unit/io/files/only_header.csv
@@ -1,0 +1,1 @@
+Name,Address

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -109,3 +109,9 @@ def test_sink_csv_exception_for_quote(value: str) -> None:
     df = pl.LazyFrame({"dummy": ["abc"]})
     with pytest.raises(ValueError, match="only single byte quote char is allowed"):
         df.sink_csv("path", quote=value)
+
+
+def test_scan_csv_only_header_10792(io_files_path: Path) -> None:
+    foods_file_path = io_files_path / "only_header.csv"
+    df = pl.scan_csv(foods_file_path).collect(streaming=True)
+    assert df.to_dict(False) == {"Name": [], "Address": []}


### PR DESCRIPTION
This fixes #10792.