### PR TITLE
test(python): Move sink tests to streaming module

### DIFF
--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -384,40 +384,6 @@ def test_parquet_nested_dictionaries_6217() -> None:
 
 
 @pytest.mark.write_disk()
-def test_sink_parquet(io_files_path: Path, tmp_path: Path) -> None:
-    tmp_path.mkdir(exist_ok=True)
-
-    file = io_files_path / "small.parquet"
-
-    file_path = tmp_path / "sink.parquet"
-
-    df_scanned = pl.scan_parquet(file)
-    df_scanned.sink_parquet(file_path)
-
-    with pl.StringCache():
-        result = pl.read_parquet(file_path)
-        df_read = pl.read_parquet(file)
-        assert_frame_equal(result, df_read)
-
-
-@pytest.mark.write_disk()
-def test_sink_ipc(io_files_path: Path, tmp_path: Path) -> None:
-    tmp_path.mkdir(exist_ok=True)
-
-    file = io_files_path / "small.parquet"
-
-    file_path = tmp_path / "sink.ipc"
-
-    df_scanned = pl.scan_parquet(file)
-    df_scanned.sink_ipc(file_path)
-
-    with pl.StringCache():
-        result = pl.read_ipc(file_path)
-        df_read = pl.read_parquet(file)
-        assert_frame_equal(result, df_read)
-
-
-@pytest.mark.write_disk()
 def test_fetch_union(tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)
 

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -241,31 +241,6 @@ def test_streaming_9776() -> None:
 
 
 @pytest.mark.write_disk()
-def test_streaming_10115(tmp_path: Path) -> None:
-    in_path = tmp_path / "in.parquet"
-    out_path = tmp_path / "out.parquet"
-
-    # this fails if the schema will be incorrectly due to the projection
-    # pushdown
-    (pl.DataFrame([{"x": 1, "y": "foo"}]).write_parquet(in_path))
-
-    joiner = pl.LazyFrame([{"y": "foo", "z": "_"}])
-
-    (
-        pl.scan_parquet(in_path)
-        .join(joiner, how="left", on="y")
-        .select("x", "y", "z")
-        .sink_parquet(out_path)  #
-    )
-
-    assert pl.read_parquet(out_path).to_dict(False) == {
-        "x": [1],
-        "y": ["foo"],
-        "z": ["_"],
-    }
-
-
-@pytest.mark.write_disk()
 def test_stream_empty_file(tmp_path: Path) -> None:
     p = tmp_path / "in.parquet"
     schema = {


### PR DESCRIPTION
This will make sure the `sink` tests are ran on the same runner as other streaming tests. This is important due to possible test failures caused by garbage collection of disk spill.

Fortunately, we haven't had many spurious test failures recently, but I did spot one... I figured this might be the cause.