### PR TITLE
feat(python): Add custom error for `allow_copy=False`

### DIFF
--- a/py-polars/polars/interchange/buffer.py
+++ b/py-polars/polars/interchange/buffer.py
@@ -2,7 +2,12 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from polars.interchange.protocol import Buffer, DlpackDeviceType, DtypeKind
+from polars.interchange.protocol import (
+    Buffer,
+    CopyNotAllowedError,
+    DlpackDeviceType,
+    DtypeKind,
+)
 from polars.interchange.utils import polars_dtype_to_dtype
 
 if TYPE_CHECKING:
@@ -28,8 +33,8 @@ class PolarsBuffer(Buffer):
     def __init__(self, data: Series, *, allow_copy: bool = True):
         if data.n_chunks() > 1:
             if not allow_copy:
-                raise RuntimeError(
-                    "non-contiguous buffer must be made contiguous, which is not zero-copy"
+                raise CopyNotAllowedError(
+                    "non-contiguous buffer must be made contiguous"
                 )
             data = data.rechunk()
 

--- a/py-polars/polars/interchange/column.py
+++ b/py-polars/polars/interchange/column.py
@@ -4,7 +4,13 @@ from typing import TYPE_CHECKING
 
 from polars.datatypes import Categorical
 from polars.interchange.buffer import PolarsBuffer
-from polars.interchange.protocol import Column, ColumnNullType, DtypeKind, Endianness
+from polars.interchange.protocol import (
+    Column,
+    ColumnNullType,
+    CopyNotAllowedError,
+    DtypeKind,
+    Endianness,
+)
 from polars.interchange.utils import polars_dtype_to_dtype
 from polars.utils._wrap import wrap_s
 
@@ -33,9 +39,8 @@ class PolarsColumn(Column):
     def __init__(self, column: Series, *, allow_copy: bool = True):
         if column.dtype == Categorical and not column.cat.is_local():
             if not allow_copy:
-                raise RuntimeError(
-                    f"column {column.name!r} must be converted to a local categorical,"
-                    " which is not zero-copy"
+                raise CopyNotAllowedError(
+                    f"column {column.name!r} must be converted to a local categorical"
                 )
             column = column.cat.to_local()
 

--- a/py-polars/polars/interchange/dataframe.py
+++ b/py-polars/polars/interchange/dataframe.py
@@ -5,6 +5,7 @@ from itertools import accumulate
 from typing import TYPE_CHECKING
 
 from polars.interchange.column import PolarsColumn
+from polars.interchange.protocol import CopyNotAllowedError
 from polars.interchange.protocol import DataFrame as InterchangeDataFrame
 
 if TYPE_CHECKING:
@@ -225,8 +226,8 @@ class PolarsDataFrame(InterchangeDataFrame):
 
             if not all(x == 1 for x in chunk.n_chunks("all")):
                 if not self._allow_copy:
-                    raise RuntimeError(
-                        "unevenly chunked columns must be rechunked, which is not zero-copy"
+                    raise CopyNotAllowedError(
+                        "unevenly chunked columns must be rechunked"
                     )
                 chunk = chunk.rechunk()
 

--- a/py-polars/polars/interchange/protocol.py
+++ b/py-polars/polars/interchange/protocol.py
@@ -127,15 +127,6 @@ class CategoricalDescription(TypedDict):
     categories: PolarsColumn
 
 
-class Endianness:
-    """Enum indicating the byte-order of a data type."""
-
-    LITTLE = "<"
-    BIG = ">"
-    NATIVE = "="
-    NA = "|"
-
-
 class Buffer(Protocol):
     """Interchange buffer object."""
 
@@ -239,3 +230,16 @@ class DataFrame(Protocol):
 
     def get_chunks(self, n_chunks: int | None = None) -> Iterable[DataFrame]:
         """Return an iterator yielding the chunks of the dataframe."""
+
+
+class Endianness:
+    """Enum indicating the byte-order of a data type."""
+
+    LITTLE = "<"
+    BIG = ">"
+    NATIVE = "="
+    NA = "|"
+
+
+class CopyNotAllowedError(RuntimeError):
+    """Exception raised when a copy is required, but ``allow_copy`` is set to ``False``."""  # noqa: W505

--- a/py-polars/tests/unit/interchange/test_buffer.py
+++ b/py-polars/tests/unit/interchange/test_buffer.py
@@ -6,7 +6,7 @@ import pytest
 
 import polars as pl
 from polars.interchange.buffer import PolarsBuffer
-from polars.interchange.protocol import DlpackDeviceType
+from polars.interchange.protocol import CopyNotAllowedError, DlpackDeviceType
 
 
 @pytest.mark.parametrize(
@@ -26,7 +26,9 @@ def test_init_invalid_input() -> None:
     s = pl.Series([1, 2])
     data = pl.concat([s, s], rechunk=False)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(
+        CopyNotAllowedError, match="non-contiguous buffer must be made contiguous"
+    ):
         PolarsBuffer(data, allow_copy=False)
 
 

--- a/py-polars/tests/unit/interchange/test_column.py
+++ b/py-polars/tests/unit/interchange/test_column.py
@@ -4,7 +4,7 @@ import pytest
 
 import polars as pl
 from polars.interchange.column import PolarsColumn
-from polars.interchange.protocol import ColumnNullType, DtypeKind
+from polars.interchange.protocol import ColumnNullType, CopyNotAllowedError, DtypeKind
 from polars.testing import assert_series_equal
 
 
@@ -13,7 +13,7 @@ def test_init_global_categorical_zero_copy_fails() -> None:
         s = pl.Series("a", ["x"], dtype=pl.Categorical)
 
     with pytest.raises(
-        RuntimeError, match="column 'a' must be converted to a local categorical"
+        CopyNotAllowedError, match="column 'a' must be converted to a local categorical"
     ):
         PolarsColumn(s, allow_copy=False)
 
@@ -216,7 +216,9 @@ def test_get_buffers_chunked_zero_copy_fails() -> None:
     s = pl.concat([s1, s1], rechunk=False)
     col = PolarsColumn(s, allow_copy=False)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(
+        CopyNotAllowedError, match="non-contiguous buffer must be made contiguous"
+    ):
         col.get_buffers()
 
 

--- a/py-polars/tests/unit/interchange/test_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_dataframe.py
@@ -4,6 +4,7 @@ import pytest
 
 import polars as pl
 from polars.interchange.dataframe import PolarsDataFrame
+from polars.interchange.protocol import CopyNotAllowedError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -207,7 +208,9 @@ def test_get_chunks_zero_copy_fail() -> None:
 
     dfi = PolarsDataFrame(df, allow_copy=False)
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(
+        CopyNotAllowedError, match="unevenly chunked columns must be rechunked"
+    ):
         next(dfi.get_chunks())
 
 
@@ -282,7 +285,7 @@ def test_get_chunks_from_col_chunks_uneven_chunks_zero_copy_fails() -> None:
     assert_frame_equal(chunk1, expected1)
 
     # Second chunk requires a rechunk of the second column
-    with pytest.raises(RuntimeError, match="columns must be rechunked"):
+    with pytest.raises(CopyNotAllowedError, match="columns must be rechunked"):
         next(out)
 
 


### PR DESCRIPTION
Instead of stating with every RuntimeError that the operation is not zero copy, I created a `CopyNotAllowedError`. It subclasses `RuntimeError`, so this doesn't break anything.