### PR TITLE
fix(python): behaviour of `reversed(df)`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1509,7 +1509,10 @@ class DataFrame:
         return key in self.columns
 
     def __iter__(self) -> Iterator[Any]:
-        return self.get_columns().__iter__()
+        return iter(self.get_columns())
+
+    def __reversed__(self) -> Iterator[Any]:
+        return reversed(self.get_columns())
 
     def _pos_idx(self, idx: int, dim: int) -> int:
         if idx >= 0:

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -630,6 +630,10 @@ class Struct(NestedType):
         for fld in self.fields or []:
             yield fld.name, fld.dtype
 
+    def __reversed__(self) -> Iterator[tuple[str, PolarsDataType]]:
+        for fld in reversed(self.fields or []):
+            yield fld.name, fld.dtype
+
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
         return f"{class_name}({self.fields})"

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3129,6 +3129,26 @@ def test_set() -> None:
         df[True] = 1  # type: ignore[index]
 
 
+def test_series_iter_over_frame() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [2, 3, 4], "c": [3, 4, 5]})
+
+    expected = {
+        0: pl.Series("a", [1, 2, 3]),
+        1: pl.Series("b", [2, 3, 4]),
+        2: pl.Series("c", [3, 4, 5]),
+    }
+    for idx, s in enumerate(df):
+        assert_series_equal(s, expected[idx])
+
+    expected = {
+        0: pl.Series("c", [3, 4, 5]),
+        1: pl.Series("b", [2, 3, 4]),
+        2: pl.Series("a", [1, 2, 3]),
+    }
+    for idx, s in enumerate(reversed(df)):
+        assert_series_equal(s, expected[idx])
+
+
 def test_union_with_aliases_4770() -> None:
     lf = pl.DataFrame(
         {

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1907,6 +1907,10 @@ def test_iter_nested_list() -> None:
     assert_series_equal(elems[0], pl.Series([1, 2]))
     assert_series_equal(elems[1], pl.Series([3, 4]))
 
+    rev_elems = list(reversed(pl.Series("s", [[1, 2], [3, 4]])))
+    assert_series_equal(rev_elems[0], pl.Series([3, 4]))
+    assert_series_equal(rev_elems[1], pl.Series([1, 2]))
+
 
 def test_iter_nested_struct() -> None:
     # note: this feels inconsistent with the above test for nested list, but
@@ -1914,6 +1918,10 @@ def test_iter_nested_struct() -> None:
     elems = list(pl.Series("s", [{"a": 1, "b": 2}, {"a": 3, "b": 4}]))
     assert elems[0] == {"a": 1, "b": 2}
     assert elems[1] == {"a": 3, "b": 4}
+
+    rev_elems = list(reversed(pl.Series("s", [{"a": 1, "b": 2}, {"a": 3, "b": 4}])))
+    assert rev_elems[0] == {"a": 3, "b": 4}
+    assert rev_elems[1] == {"a": 1, "b": 2}
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -11,6 +11,10 @@ from polars.datatypes import (
     DTYPE_TEMPORAL_UNITS,
     DataTypeClass,
     DataTypeGroup,
+    Field,
+    Int64,
+    List,
+    Struct,
     py_type_to_dtype,
 )
 
@@ -162,3 +166,19 @@ def test_conversion_dtype() -> None:
             ],
         ],
     }
+
+
+def test_struct_field_iter() -> None:
+    s = Struct(
+        [Field("a", List(List(Int64))), Field("b", List(Int64)), Field("c", Int64)]
+    )
+    assert list(s) == [
+        ("a", List(List(Int64))),
+        ("b", List(Int64)),
+        ("c", Int64),
+    ]
+    assert list(reversed(s)) == [
+        ("c", Int64),
+        ("b", List(Int64)),
+        ("a", List(List(Int64))),
+    ]


### PR DESCRIPTION
DataFrames are iterable, with an explicit python-side `__iter__` implementation, returning their component Series in order like so:
```python
df = pl.DataFrame( {"a": [1,2], "b":[2,3], "c":[3,4]} )
list( df )

# [shape: (2,)
# Series: 'a' [i64]
# [
#   1
#   2
# ], shape: (2,)
# Series: 'b' [i64]
# [
#   2
#   3
# ], shape: (2,)
# Series: 'c' [i64]
# [
#   3
#   4
# ]]
```

You'll never guess what `list(reversed(df))` currently does though :))

Instead of returning the Series above in reverse order... it returns one DataFrame per row, in reverse row order. 

```python
list(reversed(df))

# [shape: (1, 3)
#  ┌─────┬─────┬─────┐
#  │ a   ┆ b   ┆ c   │
#  │ --- ┆ --- ┆ --- │
#  │ i64 ┆ i64 ┆ i64 │
#  ╞═════╪═════╪═════╡
#  │ 2   ┆ 3   ┆ 4   │
#  └─────┴─────┴─────┘,
#  shape: (1, 3)
#  ┌─────┬─────┬─────┐
#  │ a   ┆ b   ┆ c   │
#  │ --- ┆ --- ┆ --- │
#  │ i64 ┆ i64 ┆ i64 │
#  ╞═════╪═════╪═════╡
#  │ 1   ┆ 2   ┆ 3   │
#  └─────┴─────┴─────┘]
```

(If anyone can tell me why without looking pretty hard at the code I'll buy you a coffee, heh).

This PR fixes it with a simple/explicit `__reversed__` implementation so that we get the Series in reverse order instead, as expected, consistent with its non-reversed behaviour.

---

**Also:**
 
* Allows Struct dtype fields to be iterated in reverse too.
* Adds several unit tests covering other reversible types.