### PR TITLE
fix: var/std behavior around few elements

### DIFF
--- a/crates/polars-arrow/src/kernels/take_agg/var.rs
+++ b/crates/polars-arrow/src/kernels/take_agg/var.rs
@@ -31,11 +31,12 @@ where
         mean = new_mean;
         m2 = new_m2;
     }
-    match count {
-        0 => None,
-        1 => Some(0.0),
-        _ => Some(m2 / (count as f64 - ddof as f64)),
+
+    if count <= ddof as u64 {
+        return None;
     }
+
+    Some(m2 / (count as f64 - ddof as f64))
 }
 
 /// Take kernel for single chunk and an iterator as index.

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -291,13 +291,13 @@ where
         ca.into_series()
     }
     fn max_as_series(&self) -> Series {
-        let v = self.max();
+        let v = ChunkAgg::max(self);
         let mut ca: ChunkedArray<T> = [v].iter().copied().collect();
         ca.rename(self.name());
         ca.into_series()
     }
     fn min_as_series(&self) -> Series {
-        let v = self.min();
+        let v = ChunkAgg::min(self);
         let mut ca: ChunkedArray<T> = [v].iter().copied().collect();
         ca.rename(self.name());
         ca.into_series()

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -16,6 +16,7 @@ pub use var::*;
 use crate::chunked_array::ChunkedArray;
 use crate::datatypes::{BooleanChunked, PolarsNumericType};
 use crate::prelude::*;
+use crate::series::implementations::SeriesWrap;
 use crate::series::IsSorted;
 use crate::utils::CustomIterTools;
 
@@ -316,19 +317,14 @@ where
     }
 }
 
-macro_rules! impl_as_series {
-    ($self:expr, $agg:ident, $ty: ty) => {{
-        let v = $self.$agg();
-        let mut ca: $ty = [v].iter().copied().collect();
-        ca.rename($self.name());
-        ca.into_series()
-    }};
-    ($self:expr, $agg:ident, $arg:expr, $ty: ty) => {{
-        let v = $self.$agg($arg);
-        let mut ca: $ty = [v].iter().copied().collect();
-        ca.rename($self.name());
-        ca.into_series()
-    }};
+fn as_series<T>(name: &str, v: Option<T::Native>) -> Series
+where
+    T: PolarsNumericType,
+    SeriesWrap<ChunkedArray<T>>: SeriesTrait,
+{
+    let mut ca: ChunkedArray<T> = [v].into_iter().collect();
+    ca.rename(name);
+    ca.into_series()
 }
 
 impl<T> VarAggSeries for ChunkedArray<T>
@@ -339,41 +335,32 @@ where
         + compute::aggregate::SimdOrd<T::Native>,
 {
     fn var_as_series(&self, ddof: u8) -> Series {
-        impl_as_series!(self, var, ddof, Float64Chunked)
+        as_series::<Float64Type>(self.name(), self.var(ddof))
     }
 
     fn std_as_series(&self, ddof: u8) -> Series {
-        impl_as_series!(self, std, ddof, Float64Chunked)
+        as_series::<Float64Type>(self.name(), self.std(ddof))
     }
 }
 
 impl VarAggSeries for Float32Chunked {
     fn var_as_series(&self, ddof: u8) -> Series {
-        impl_as_series!(self, var, ddof, Float32Chunked)
+        as_series::<Float32Type>(self.name(), self.var(ddof).map(|x| x as f32))
     }
 
     fn std_as_series(&self, ddof: u8) -> Series {
-        impl_as_series!(self, std, ddof, Float32Chunked)
+        as_series::<Float32Type>(self.name(), self.std(ddof).map(|x| x as f32))
     }
 }
 
 impl VarAggSeries for Float64Chunked {
     fn var_as_series(&self, ddof: u8) -> Series {
-        impl_as_series!(self, var, ddof, Float64Chunked)
+        as_series::<Float64Type>(self.name(), self.var(ddof))
     }
 
     fn std_as_series(&self, ddof: u8) -> Series {
-        impl_as_series!(self, std, ddof, Float64Chunked)
+        as_series::<Float64Type>(self.name(), self.std(ddof))
     }
-}
-
-macro_rules! impl_quantile_as_series {
-    ($self:expr, $agg:ident, $ty: ty, $qtl:expr, $opt:expr) => {{
-        let v = $self.$agg($qtl, $opt)?;
-        let mut ca: $ty = [v].iter().copied().collect();
-        ca.rename($self.name());
-        Ok(ca.into_series())
-    }};
 }
 
 impl<T> QuantileAggSeries for ChunkedArray<T>
@@ -389,11 +376,14 @@ where
         quantile: f64,
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Series> {
-        impl_quantile_as_series!(self, quantile, Float64Chunked, quantile, interpol)
+        Ok(as_series::<Float64Type>(
+            self.name(),
+            self.quantile(quantile, interpol)?,
+        ))
     }
 
     fn median_as_series(&self) -> Series {
-        impl_as_series!(self, median, Float64Chunked)
+        as_series::<Float64Type>(self.name(), self.median())
     }
 }
 
@@ -403,11 +393,14 @@ impl QuantileAggSeries for Float32Chunked {
         quantile: f64,
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Series> {
-        impl_quantile_as_series!(self, quantile, Float32Chunked, quantile, interpol)
+        Ok(as_series::<Float32Type>(
+            self.name(),
+            self.quantile(quantile, interpol)?,
+        ))
     }
 
     fn median_as_series(&self) -> Series {
-        impl_as_series!(self, median, Float32Chunked)
+        as_series::<Float32Type>(self.name(), self.median())
     }
 }
 
@@ -417,11 +410,14 @@ impl QuantileAggSeries for Float64Chunked {
         quantile: f64,
         interpol: QuantileInterpolOptions,
     ) -> PolarsResult<Series> {
-        impl_quantile_as_series!(self, quantile, Float64Chunked, quantile, interpol)
+        Ok(as_series::<Float64Type>(
+            self.name(),
+            self.quantile(quantile, interpol)?,
+        ))
     }
 
     fn median_as_series(&self) -> Series {
-        impl_as_series!(self, median, Float64Chunked)
+        as_series::<Float64Type>(self.name(), self.median())
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/aggregate/var.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/var.rs
@@ -7,88 +7,39 @@ pub trait VarAggSeries {
     fn std_as_series(&self, ddof: u8) -> Series;
 }
 
-impl<T> ChunkVar<f64> for ChunkedArray<T>
+impl<T> ChunkVar for ChunkedArray<T>
 where
-    T: PolarsIntegerType,
+    T: PolarsNumericType,
     <T::Native as Simd>::Simd: Add<Output = <T::Native as Simd>::Simd>
         + compute::aggregate::Sum<T::Native>
         + compute::aggregate::SimdOrd<T::Native>,
 {
     fn var(&self, ddof: u8) -> Option<f64> {
         let n_values = self.len() - self.null_count();
-
-        if ddof as usize > n_values {
+        if n_values <= ddof as usize {
             return None;
         }
-        let n_values = n_values as f64;
 
         let mean = self.mean()?;
         let squared: Float64Chunked = ChunkedArray::apply_values_generic(self, |value| {
             let tmp = value.to_f64().unwrap() - mean;
             tmp * tmp
         });
-        // Note, this is similar behavior to numpy if DDOF=1.
-        // in statistics DDOF often = 1.
-        // this last step is similar to mean, only now instead of 1/n it is 1/(n-1)
-        squared.sum().map(|sum| sum / (n_values - ddof as f64))
+
+        squared
+            .sum()
+            .map(|sum| sum / (n_values as f64 - ddof as f64))
     }
+
     fn std(&self, ddof: u8) -> Option<f64> {
         self.var(ddof).map(|var| var.sqrt())
     }
 }
 
-impl ChunkVar<f32> for Float32Chunked {
-    fn var(&self, ddof: u8) -> Option<f32> {
-        if self.len() == 1 {
-            return Some(0.0);
-        }
-        let n_values = self.len() - self.null_count();
-
-        if ddof as usize > n_values {
-            return None;
-        }
-        let n_values = n_values as f32;
-
-        let mean = self.mean()? as f32;
-        let squared = self.apply_values(|value| {
-            let tmp = value - mean;
-            tmp * tmp
-        });
-        squared.sum().map(|sum| sum / (n_values - ddof as f32))
-    }
-    fn std(&self, ddof: u8) -> Option<f32> {
-        self.var(ddof).map(|var| var.sqrt())
-    }
-}
-
-impl ChunkVar<f64> for Float64Chunked {
-    fn var(&self, ddof: u8) -> Option<f64> {
-        if self.len() == 1 {
-            return Some(0.0);
-        }
-        let n_values = self.len() - self.null_count();
-
-        if ddof as usize > n_values {
-            return None;
-        }
-        let n_values = n_values as f64;
-
-        let mean = self.mean()?;
-        let squared = self.apply_values(|value| {
-            let tmp = value - mean;
-            tmp * tmp
-        });
-        squared.sum().map(|sum| sum / (n_values - ddof as f64))
-    }
-    fn std(&self, ddof: u8) -> Option<f64> {
-        self.var(ddof).map(|var| var.sqrt())
-    }
-}
-
-impl ChunkVar<String> for Utf8Chunked {}
-impl ChunkVar<Series> for ListChunked {}
+impl ChunkVar for Utf8Chunked {}
+impl ChunkVar for ListChunked {}
 #[cfg(feature = "dtype-array")]
-impl ChunkVar<Series> for ArrayChunked {}
+impl ChunkVar for ArrayChunked {}
 #[cfg(feature = "object")]
-impl<T: PolarsObject> ChunkVar<Series> for ObjectChunked<T> {}
-impl ChunkVar<bool> for BooleanChunked {}
+impl<T: PolarsObject> ChunkVar for ObjectChunked<T> {}
+impl ChunkVar for BooleanChunked {}

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -380,14 +380,14 @@ pub trait ChunkQuantile<T> {
 }
 
 /// Variance and standard deviation aggregation.
-pub trait ChunkVar<T> {
+pub trait ChunkVar {
     /// Compute the variance of this ChunkedArray/Series.
-    fn var(&self, _ddof: u8) -> Option<T> {
+    fn var(&self, _ddof: u8) -> Option<f64> {
         None
     }
 
     /// Compute the standard deviation of this ChunkedArray/Series.
-    fn std(&self, _ddof: u8) -> Option<T> {
+    fn std(&self, _ddof: u8) -> Option<f64> {
         None
     }
 }

--- a/crates/polars-core/src/chunked_array/upstream_traits.rs
+++ b/crates/polars-core/src/chunked_array/upstream_traits.rs
@@ -35,7 +35,6 @@ impl<T: PolarsDataType> Default for ChunkedArray<T> {
 }
 
 /// FromIterator trait
-
 impl<T> FromIterator<Option<T::Native>> for ChunkedArray<T>
 where
     T: PolarsNumericType,

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -691,11 +691,8 @@ where
 impl<T> SeriesWrap<ChunkedArray<T>>
 where
     T: PolarsFloatType,
-    ChunkedArray<T>: IntoSeries
-        + ChunkVar
-        + VarAggSeries
-        + ChunkQuantile<T::Native>
-        + QuantileAggSeries,
+    ChunkedArray<T>:
+        IntoSeries + ChunkVar + VarAggSeries + ChunkQuantile<T::Native> + QuantileAggSeries,
     T::Native: Simd + NumericNative + Pow<T::Native, Output = T::Native>,
     <T::Native as Simd>::Simd: std::ops::Add<Output = <T::Native as Simd>::Simd>
         + arrow::compute::aggregate::Sum<T::Native>

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -527,7 +527,7 @@ where
                             1 => self.get(first as usize),
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
-                                arr_group.min()
+                                ChunkAgg::min(&arr_group)
                             },
                         }
                     })
@@ -610,7 +610,7 @@ where
                             1 => self.get(first as usize),
                             _ => {
                                 let arr_group = _slice_from_offsets(self, first, len);
-                                arr_group.max()
+                                ChunkAgg::max(&arr_group)
                             },
                         }
                     })
@@ -692,7 +692,7 @@ impl<T> SeriesWrap<ChunkedArray<T>>
 where
     T: PolarsFloatType,
     ChunkedArray<T>: IntoSeries
-        + ChunkVar<T::Native>
+        + ChunkVar
         + VarAggSeries
         + ChunkQuantile<T::Native>
         + QuantileAggSeries,

--- a/crates/polars-plan/src/dsl/function_expr/correlation.rs
+++ b/crates/polars-plan/src/dsl/function_expr/correlation.rs
@@ -41,46 +41,21 @@ fn covariance(s: &[Series]) -> PolarsResult<Series> {
     let b = &s[1];
     let name = "cov";
 
-    let s = match a.dtype() {
-        DataType::Float32 => {
-            let ca_a = a.f32().unwrap();
-            let ca_b = b.f32().unwrap();
-            Series::new(name, &[polars_core::functions::cov_f(ca_a, ca_b)])
-        },
-        DataType::Float64 => {
-            let ca_a = a.f64().unwrap();
-            let ca_b = b.f64().unwrap();
-            Series::new(name, &[polars_core::functions::cov_f(ca_a, ca_b)])
-        },
-        DataType::Int32 => {
-            let ca_a = a.i32().unwrap();
-            let ca_b = b.i32().unwrap();
-            Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
-        },
-        DataType::Int64 => {
-            let ca_a = a.i64().unwrap();
-            let ca_b = b.i64().unwrap();
-            Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
-        },
-        DataType::UInt32 => {
-            let ca_a = a.u32().unwrap();
-            let ca_b = b.u32().unwrap();
-            Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
-        },
-        DataType::UInt64 => {
-            let ca_a = a.u64().unwrap();
-            let ca_b = b.u64().unwrap();
-            Series::new(name, &[polars_core::functions::cov_i(ca_a, ca_b)])
-        },
+    use polars_core::functions::cov;
+    let ret = match a.dtype() {
+        DataType::Float32 => cov(a.f32().unwrap(), b.f32().unwrap()),
+        DataType::Float64 => cov(a.f64().unwrap(), b.f64().unwrap()),
+        DataType::Int32 => cov(a.i32().unwrap(), b.i32().unwrap()),
+        DataType::Int64 => cov(a.i64().unwrap(), b.i64().unwrap()),
+        DataType::UInt32 => cov(a.u32().unwrap(), b.u32().unwrap()),
+        DataType::UInt64 => cov(a.u64().unwrap(), b.u64().unwrap()),
         _ => {
             let a = a.cast(&DataType::Float64)?;
             let b = b.cast(&DataType::Float64)?;
-            let ca_a = a.f64().unwrap();
-            let ca_b = b.f64().unwrap();
-            Series::new(name, &[polars_core::functions::cov_f(ca_a, ca_b)])
+            cov(a.f64().unwrap(), b.f64().unwrap())
         },
     };
-    Ok(s)
+    Ok(Series::new(name, &[ret]))
 }
 
 fn pearson_corr(s: &[Series], ddof: u8) -> PolarsResult<Series> {
@@ -88,67 +63,20 @@ fn pearson_corr(s: &[Series], ddof: u8) -> PolarsResult<Series> {
     let b = &s[1];
     let name = "pearson_corr";
 
-    let s = match a.dtype() {
-        DataType::Float32 => {
-            let ca_a = a.f32().unwrap();
-            let ca_b = b.f32().unwrap();
-            Series::new(
-                name,
-                &[polars_core::functions::pearson_corr_f(ca_a, ca_b, ddof)],
-            )
-        },
-        DataType::Float64 => {
-            let ca_a = a.f64().unwrap();
-            let ca_b = b.f64().unwrap();
-            Series::new(
-                name,
-                &[polars_core::functions::pearson_corr_f(ca_a, ca_b, ddof)],
-            )
-        },
-        DataType::Int32 => {
-            let ca_a = a.i32().unwrap();
-            let ca_b = b.i32().unwrap();
-            Series::new(
-                name,
-                &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
-            )
-        },
-        DataType::Int64 => {
-            let ca_a = a.i64().unwrap();
-            let ca_b = b.i64().unwrap();
-            Series::new(
-                name,
-                &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
-            )
-        },
-        DataType::UInt32 => {
-            let ca_a = a.u32().unwrap();
-            let ca_b = b.u32().unwrap();
-            Series::new(
-                name,
-                &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
-            )
-        },
-        DataType::UInt64 => {
-            let ca_a = a.u64().unwrap();
-            let ca_b = b.u64().unwrap();
-            Series::new(
-                name,
-                &[polars_core::functions::pearson_corr_i(ca_a, ca_b, ddof)],
-            )
-        },
+    use polars_core::functions::pearson_corr;
+    let ret = match a.dtype() {
+        DataType::Float32 => pearson_corr(a.f32().unwrap(), b.f32().unwrap(), ddof),
+        DataType::Float64 => pearson_corr(a.f64().unwrap(), b.f64().unwrap(), ddof),
+        DataType::Int32 => pearson_corr(a.i32().unwrap(), b.i32().unwrap(), ddof),
+        DataType::Int64 => pearson_corr(a.i64().unwrap(), b.i64().unwrap(), ddof),
+        DataType::UInt32 => pearson_corr(a.u32().unwrap(), b.u32().unwrap(), ddof),
         _ => {
             let a = a.cast(&DataType::Float64)?;
             let b = b.cast(&DataType::Float64)?;
-            let ca_a = a.f64().unwrap();
-            let ca_b = b.f64().unwrap();
-            Series::new(
-                name,
-                &[polars_core::functions::pearson_corr_f(ca_a, ca_b, ddof)],
-            )
+            pearson_corr(a.f64().unwrap(), b.f64().unwrap(), ddof)
         },
     };
-    Ok(s)
+    Ok(Series::new(name, &[ret]))
 }
 
 #[cfg(all(feature = "rank", feature = "propagate_nans"))]

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -1,4 +1,3 @@
-import math
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -100,7 +99,7 @@ def test_median() -> None:
 
 def test_single_element_std() -> None:
     s = pl.Series([1])
-    assert math.isnan(s.std(ddof=1))  # type: ignore[arg-type]
+    assert s.std(ddof=1) is None
     assert s.std(ddof=0) == 0.0
 
 


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/10820.

We now correctly and consistently return null when the number of elements is fewer than or equal to `ddof` as then the standard deviation/variance is undefined.