### PR TITLE
fix(rust, python): never panic in hash/equality doesn't hold in cse

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/cse_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cse_expr.rs
@@ -506,7 +506,12 @@ impl RewritingVisitor for CommonSubExprRewriter<'_> {
             return Ok(recurse);
         }
 
-        let (_, count) = self.sub_expr_map.get(id).unwrap();
+        // Because some expressions don't have hash / equality guarantee (e.g. floats)
+        // we can get none here. This must be changed later.
+        let Some((_, count)) = self.sub_expr_map.get(id) else {
+            self.visited_idx += 1;
+            return Ok(RewriteRecursion::NoMutateAndContinue);
+        };
         if *count > 1 {
             self.replaced_identifiers.insert(id.clone());
             // rewrite this sub-expression, don't visit its children

--- a/py-polars/tests/unit/test_cse.py
+++ b/py-polars/tests/unit/test_cse.py
@@ -358,3 +358,24 @@ def test_cse_quantile_10815() -> None:
         "a_1": [0.16650805109739197],
         "b_1": [0.2012768694081981],
     }
+
+
+def test_cse_nan_10824() -> None:
+    v = pl.col("a") / pl.col("b")
+    magic = pl.when(v > 0).then(pl.lit(float("nan"))).otherwise(v)
+    assert (
+        str(
+            (
+                pl.DataFrame(
+                    {
+                        "a": [1.0],
+                        "b": [1.0],
+                    }
+                )
+                .lazy()
+                .select(magic)
+                .collect(comm_subexpr_elim=True)
+            ).to_dict(False)
+        )
+        == "{'literal': [nan]}"
+    )


### PR DESCRIPTION
fixes #10824