### PR TITLE
fix: Improve bound checks on temporal ranges

### DIFF
--- a/crates/polars-time/src/date_range.rs
+++ b/crates/polars-time/src/date_range.rs
@@ -16,27 +16,21 @@ pub fn in_nanoseconds_window(ndt: &NaiveDateTime) -> bool {
 pub fn date_range_impl(
     name: &str,
     start: i64,
-    stop: i64,
-    every: Duration,
+    end: i64,
+    interval: Duration,
     closed: ClosedWindow,
     tu: TimeUnit,
     _tz: Option<&TimeZone>,
 ) -> PolarsResult<DatetimeChunked> {
-    if start > stop {
-        polars_bail!(ComputeError: "'start' cannot be greater than 'stop'")
-    }
-    if every.negative {
-        polars_bail!(ComputeError: "'interval' cannot be negative")
-    }
     let mut out = match _tz {
         #[cfg(feature = "timezones")]
         Some(tz) => match tz.parse::<chrono_tz::Tz>() {
             Ok(tz) => {
                 let start = localize_timestamp(start, tu, tz);
-                let stop = localize_timestamp(stop, tu, tz);
+                let end = localize_timestamp(end, tu, tz);
                 Int64Chunked::new_vec(
                     name,
-                    temporal_range_vec(start?, stop?, every, closed, tu, Some(&tz))?,
+                    temporal_range_vec(start?, end?, interval, closed, tu, Some(&tz))?,
                 )
                 .into_datetime(tu, _tz.cloned())
             },
@@ -44,7 +38,7 @@ pub fn date_range_impl(
         },
         _ => Int64Chunked::new_vec(
             name,
-            temporal_range_vec(start, stop, every, closed, tu, None)?,
+            temporal_range_vec(start, end, interval, closed, tu, None)?,
         )
         .into_datetime(tu, None),
     };
@@ -53,41 +47,35 @@ pub fn date_range_impl(
     Ok(out)
 }
 
-/// Create a [`DatetimeChunked`] from a given `start` and `stop` date and a given `every` interval.
+/// Create a [`DatetimeChunked`] from a given `start` and `end` date and a given `interval`.
 pub fn date_range(
     name: &str,
     start: NaiveDateTime,
-    stop: NaiveDateTime,
-    every: Duration,
+    end: NaiveDateTime,
+    interval: Duration,
     closed: ClosedWindow,
     tu: TimeUnit,
     tz: Option<TimeZone>,
 ) -> PolarsResult<DatetimeChunked> {
-    let (start, stop) = match tu {
-        TimeUnit::Nanoseconds => (start.timestamp_nanos(), stop.timestamp_nanos()),
-        TimeUnit::Microseconds => (start.timestamp_micros(), stop.timestamp_micros()),
-        TimeUnit::Milliseconds => (start.timestamp_millis(), stop.timestamp_millis()),
+    let (start, end) = match tu {
+        TimeUnit::Nanoseconds => (start.timestamp_nanos(), end.timestamp_nanos()),
+        TimeUnit::Microseconds => (start.timestamp_micros(), end.timestamp_micros()),
+        TimeUnit::Milliseconds => (start.timestamp_millis(), end.timestamp_millis()),
     };
-    date_range_impl(name, start, stop, every, closed, tu, tz.as_ref())
+    date_range_impl(name, start, end, interval, closed, tu, tz.as_ref())
 }
 
 #[doc(hidden)]
 pub fn time_range_impl(
     name: &str,
     start: i64,
-    stop: i64,
-    every: Duration,
+    end: i64,
+    interval: Duration,
     closed: ClosedWindow,
 ) -> PolarsResult<TimeChunked> {
-    if start > stop {
-        polars_bail!(ComputeError: "'start' cannot be greater than 'stop'")
-    }
-    if every.negative {
-        polars_bail!(ComputeError: "'interval' cannot be negative")
-    }
     let mut out = Int64Chunked::new_vec(
         name,
-        temporal_range_vec(start, stop, every, closed, TimeUnit::Nanoseconds, None)?,
+        temporal_range_vec(start, end, interval, closed, TimeUnit::Nanoseconds, None)?,
     )
     .into_time();
 
@@ -95,15 +83,15 @@ pub fn time_range_impl(
     Ok(out)
 }
 
-/// Create a [`TimeChunked`] from a given `start` and `stop` date and a given `every` interval.
+/// Create a [`TimeChunked`] from a given `start` and `end` date and a given `interval`.
 pub fn time_range(
     name: &str,
     start: NaiveTime,
-    stop: NaiveTime,
-    every: Duration,
+    end: NaiveTime,
+    interval: Duration,
     closed: ClosedWindow,
 ) -> PolarsResult<TimeChunked> {
     let start = time_to_time64ns(&start);
-    let stop = time_to_time64ns(&stop);
-    time_range_impl(name, start, stop, every, closed)
+    let end = time_to_time64ns(&end);
+    time_range_impl(name, start, end, interval, closed)
 }

--- a/crates/polars-time/src/windows/calendar.rs
+++ b/crates/polars-time/src/windows/calendar.rs
@@ -38,26 +38,28 @@ pub const NS_WEEK: i64 = 7 * NS_DAY;
 /// vector of i64 representing temporal values
 pub fn temporal_range(
     start: i64,
-    stop: i64,
-    every: Duration,
+    end: i64,
+    interval: Duration,
     closed: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&Tz>,
 ) -> PolarsResult<Vec<i64>> {
+    check_range_bounds(start, end, interval)?;
+
     let size: usize;
     let offset_fn: fn(&Duration, i64, Option<&Tz>) -> PolarsResult<i64>;
 
     match tu {
         TimeUnit::Nanoseconds => {
-            size = ((stop - start) / every.duration_ns() + 1) as usize;
+            size = ((end - start) / interval.duration_ns() + 1) as usize;
             offset_fn = Duration::add_ns;
         },
         TimeUnit::Microseconds => {
-            size = ((stop - start) / every.duration_us() + 1) as usize;
+            size = ((end - start) / interval.duration_us() + 1) as usize;
             offset_fn = Duration::add_us;
         },
         TimeUnit::Milliseconds => {
-            size = ((stop - start) / every.duration_ms() + 1) as usize;
+            size = ((end - start) / interval.duration_ms() + 1) as usize;
             offset_fn = Duration::add_ms;
         },
     }
@@ -66,32 +68,42 @@ pub fn temporal_range(
     let mut t = start;
     match closed {
         ClosedWindow::Both => {
-            while t <= stop {
+            while t <= end {
                 ts.push(t);
-                t = offset_fn(&every, t, tz)?
+                t = offset_fn(&interval, t, tz)?
             }
         },
         ClosedWindow::Left => {
-            while t < stop {
+            while t < end {
                 ts.push(t);
-                t = offset_fn(&every, t, tz)?
+                t = offset_fn(&interval, t, tz)?
             }
         },
         ClosedWindow::Right => {
-            t = offset_fn(&every, t, tz)?;
-            while t <= stop {
+            t = offset_fn(&interval, t, tz)?;
+            while t <= end {
                 ts.push(t);
-                t = offset_fn(&every, t, tz)?
+                t = offset_fn(&interval, t, tz)?
             }
         },
         ClosedWindow::None => {
-            t = offset_fn(&every, t, tz)?;
-            while t < stop {
+            t = offset_fn(&interval, t, tz)?;
+            while t < end {
                 ts.push(t);
-                t = offset_fn(&every, t, tz)?
+                t = offset_fn(&interval, t, tz)?
             }
         },
     }
     debug_assert!(size >= ts.len());
     Ok(ts)
+}
+
+fn check_range_bounds(start: i64, end: i64, interval: Duration) -> PolarsResult<()> {
+    if start > end {
+        polars_bail!(ComputeError: "`end` must be equal to or greater than `start`")
+    }
+    if interval.negative || interval.is_zero() {
+        polars_bail!(ComputeError: "`interval` must be positive")
+    }
+    Ok(())
 }

--- a/py-polars/tests/unit/functions/range/test_time_range.py
+++ b/py-polars/tests/unit/functions/range/test_time_range.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
-from datetime import time
+from datetime import time, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
 
 import polars as pl
 from polars.testing import assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.type_aliases import ClosedInterval
 
 
 def test_time_range_schema() -> None:
@@ -48,11 +54,57 @@ def test_time_range_eager_explode() -> None:
     assert_series_equal(result, expected)
 
 
-def test_time_range_only_first_entry_used() -> None:
-    start = pl.Series([time(9, 0), time(10, 0)])
-    end = pl.Series([time(12, 0), time(11, 0)])
+def test_time_range_empty() -> None:
+    empty = pl.Series(dtype=pl.Time)
+    single = pl.Series([time(12, 0)])
 
-    result = pl.time_range(start, end, eager=True)
+    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+        pl.time_range(empty, single, eager=True)
+    with pytest.raises(pl.ComputeError, match="`end` must contain a single value"):
+        pl.time_range(single, empty, eager=True)
+    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+        pl.time_range(empty, empty, eager=True)
 
-    expected = pl.Series("time", [time(9, 0), time(10, 0), time(11, 0), time(12, 0)])
+
+def test_time_range_multiple_values() -> None:
+    single = pl.Series([time(12, 0)])
+    multiple = pl.Series([time(11, 0), time(12, 0)])
+
+    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+        pl.time_range(multiple, single, eager=True)
+    with pytest.raises(pl.ComputeError, match="`end` must contain a single value"):
+        pl.time_range(single, multiple, eager=True)
+    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+        pl.time_range(multiple, multiple, eager=True)
+
+
+def test_time_range_start_equals_end() -> None:
+    t = time(12, 0)
+
+    result = pl.time_range(t, t, closed="both", eager=True)
+
+    expected = pl.Series("time", [t])
     assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("closed", ["left", "right", "none"])
+def test_time_range_start_equals_end_open(closed: ClosedInterval) -> None:
+    t = time(12, 0)
+
+    result = pl.time_range(t, t, closed=closed, eager=True)
+
+    expected = pl.Series("time", dtype=pl.Time)
+    assert_series_equal(result, expected)
+
+
+def test_time_range_invalid_start_end() -> None:
+    with pytest.raises(
+        pl.ComputeError, match="`end` must be equal to or greater than `start`"
+    ):
+        pl.time_range(time(12), time(11), eager=True)
+
+
+@pytest.mark.parametrize("interval", [timedelta(0), timedelta(minutes=-10)])
+def test_time_range_invalid_step(interval: timedelta) -> None:
+    with pytest.raises(pl.ComputeError, match="`interval` must be positive"):
+        pl.time_range(time(11), time(12), interval=interval, eager=True)


### PR DESCRIPTION
#### Changes

Fixes:
* Intervals of zero duration are now correctly handled (instead of panicking)
* Empty columns are now correctly handled (instead of panicking)
* Columns with more than 1 value will now throw an error, instead of picking the first value. Users should explicitly state `.first()` if they want to pass the first value of a column to `time_range`/`date_range`

Misc:
* Make sure the naming of the `start`, `end`, and `interval` parameters is consistent internally.