### PR TITLE
feat(rust): implementation of `array_to_string`

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -595,7 +595,7 @@ impl SqlFunctionVisitor<'_> {
 
                     Ok(s.list().join(sep))
                 }),
-                _ => unimplemented!("Currently `ConcatWs` only works as `concat_ws(sep, col)`")
+                _ => polars_bail!(InvalidOperation: "Currently `ConcatWs` only works as `concat_ws(sep, col)`")
             },
             Left => self.try_visit_binary(|e, length| {
                 Ok(e.str().str_slice(0, match length {

--- a/crates/polars-sql/tests/functions_string.rs
+++ b/crates/polars-sql/tests/functions_string.rs
@@ -82,7 +82,7 @@ fn test_string_functions() {
 }
 
 #[test]
-fn concat() {
+fn array_to_string() {
     let df = df! {
         "a" => &["first", "first", "third"],
         "b" => &[1, 1, 42],
@@ -105,7 +105,7 @@ fn concat() {
     let sql = r#"
         SELECT
             b,
-            concat_ws(', ', a) as as,
+            array_to_string(a, ', ') as as,
         FROM df_1
         ORDER BY
             b,

--- a/crates/polars-sql/tests/functions_string.rs
+++ b/crates/polars-sql/tests/functions_string.rs
@@ -80,3 +80,46 @@ fn test_string_functions() {
         .unwrap();
     assert!(df_sql.frame_equal_missing(&df_pl));
 }
+
+#[test]
+fn concat() {
+    let df = df! {
+        "a" => &["first", "first", "third"],
+        "b" => &[1, 1, 42],
+    }
+    .unwrap();
+    let mut context = SQLContext::new();
+    context.register("df", df.clone().lazy());
+    let sql = context
+        .execute(
+            r#"
+        SELECT
+            b,
+            a
+        FROM df
+        GROUP BY
+            b"#,
+        )
+        .unwrap();
+    context.register("df_1", sql.clone());
+    let sql = r#"
+        SELECT
+            b,
+            concat_ws(', ', a) as as,
+        FROM df_1
+        ORDER BY
+            b,
+            as"#;
+    let df_sql = context.execute(sql).unwrap().collect().unwrap();
+
+    let df_pl = df
+        .lazy()
+        .group_by([col("b")])
+        .agg([col("a")])
+        .select(&[col("b"), col("a").list().join(", ").alias("as")])
+        .sort_by_exprs(vec![col("b"), col("as")], vec![false, false], false, true)
+        .collect()
+        .unwrap();
+
+    assert!(df_sql.frame_equal_missing(&df_pl));
+}


### PR DESCRIPTION
Closes #10858.

Accepts `column` and `separator` to join its values

`SELECT a FROM df`:
|         a        |
|------------------|
|['Hello', 'World']|

`SELECT array_to_string(a, ', ') FROM df`:
|         a        |
|------------------|
|  'Hello, World'  |