### PR TITLE
feat(rust): apply left side predicate pushdown also to right side if all predicate columns are also join columns

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
@@ -157,13 +157,6 @@ pub(super) fn process_join(
             // business as usual
             _ => {}
         }
-
-        /*
-         * getLeftKeys
-         * if filter_left && allColumnsAreKeys
-         * replace predicate columns with right keys
-         * pushdown right
-         */
     }
 
     opt.pushdown_and_assign(input_left, pushdown_left, lp_arena, expr_arena)?;

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
@@ -66,6 +66,21 @@ fn join_produces_null(how: &JoinType) -> LeftRight<bool> {
     }
 }
 
+fn all_pred_cols_in_left_on(
+    predicate: Node,
+    expr_arena: &mut Arena<AExpr>,
+    left_on: &Vec<Node>,
+) -> bool {
+    let left_on_col_exprs: Vec<Expr> = left_on
+        .iter()
+        .map(|&node| node_to_expr(node, expr_arena))
+        .collect();
+    let mut col_exprs_in_predicate = aexpr_to_column_nodes_iter(predicate, expr_arena)
+        .map(|node| node_to_expr(node, expr_arena));
+
+    col_exprs_in_predicate.all(|expr| left_on_col_exprs.contains(&expr))
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) fn process_join(
     opt: &PredicatePushDown,
@@ -108,16 +123,20 @@ pub(super) fn process_join(
                 insert_and_combine_predicate(&mut pushdown_left, predicate, expr_arena);
                 filter_left = true;
             }
-            // Change 'else if' to 'if filter_left == false || all_columns_in_left_key'
-            // Replace column names with key column names on the right
 
-            // this is `else if` because if the predicate is in the left hand side
+            // if the predicate is in the left hand side
             // the right hand side should be renamed with the suffix.
             // in that case we should not push down as the user wants to filter on `x`
             // not on `x_rhs`.
             if filter_left == false
                 && check_input_node(predicate, &schema_right, expr_arena)
                 && !block_pushdown_right
+                // However, if we push down to the left and all predicate columns are also
+                // join columns, we also push down right
+                || filter_left == true 
+                    && all_pred_cols_in_left_on(predicate, expr_arena, &left_on)
+                    // TODO: Restricting to Inner and Left Join is probably too conservative
+                    && matches!(&options.args.how, JoinType::Inner | JoinType::Left)
             {
                 insert_and_combine_predicate(&mut pushdown_right, predicate, expr_arena);
                 filter_right = true;

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
@@ -133,7 +133,7 @@ pub(super) fn process_join(
                 && !block_pushdown_right
                 // However, if we push down to the left and all predicate columns are also
                 // join columns, we also push down right
-                || filter_left == true 
+                || filter_left == true
                     && all_pred_cols_in_left_on(predicate, expr_arena, &left_on)
                     // TODO: Restricting to Inner and Left Join is probably too conservative
                     && matches!(&options.args.how, JoinType::Inner | JoinType::Left)

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/join.rs
@@ -69,7 +69,7 @@ fn join_produces_null(how: &JoinType) -> LeftRight<bool> {
 fn all_pred_cols_in_left_on(
     predicate: Node,
     expr_arena: &mut Arena<AExpr>,
-    left_on: &Vec<Node>,
+    left_on: &[Node],
 ) -> bool {
     let left_on_col_exprs: Vec<Expr> = left_on
         .iter()
@@ -128,12 +128,12 @@ pub(super) fn process_join(
             // the right hand side should be renamed with the suffix.
             // in that case we should not push down as the user wants to filter on `x`
             // not on `x_rhs`.
-            if filter_left == false
+            if !filter_left
                 && check_input_node(predicate, &schema_right, expr_arena)
                 && !block_pushdown_right
                 // However, if we push down to the left and all predicate columns are also
                 // join columns, we also push down right
-                || filter_left == true
+                || filter_left
                     && all_pred_cols_in_left_on(predicate, expr_arena, &left_on)
                     // TODO: Restricting to Inner and Left Join is probably too conservative
                     && matches!(&options.args.how, JoinType::Inner | JoinType::Left)

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -271,7 +271,7 @@ fn test_predicate_pushdown_block_8847() -> PolarsResult<()> {
 }
 
 #[test]
-fn test_push_key_predicates_to_both_join_sides_7247() -> PolarsResult<()> {
+fn test_push_join_col_predicates_to_both_sides_7247() -> PolarsResult<()> {
     let df1 = df! {
         "a" => ["a1", "a2"],
         "b" => ["b1", "b2"],

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -269,3 +269,25 @@ fn test_predicate_pushdown_block_8847() -> PolarsResult<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_push_key_predicates_to_both_join_sides_7247() -> PolarsResult<()> {
+    let df1 = df! {
+        "a" => ["a1", "a2"],
+    }?;
+    let df2 = df! {
+        "a" => ["a1", "a1", "a2"],
+        "b" => ["a1", "b", "a2"]
+    }?;
+    let df = df1.lazy().left_join(df2.lazy(), col("a"), col("a"));
+    let out = df
+        .filter(col("a").eq(lit("a1")))
+        .filter(col("a").eq(col("b")))
+        .collect()?;
+    let expected = df![
+        "a" => ["a1"],
+        "b" => ["a1"],
+    ]?;
+    assert_eq!(out, expected);
+    Ok(())
+}

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -269,33 +269,3 @@ fn test_predicate_pushdown_block_8847() -> PolarsResult<()> {
 
     Ok(())
 }
-
-#[test]
-fn test_push_join_col_predicates_to_both_sides_7247() -> PolarsResult<()> {
-    let df1 = df! {
-        "a" => ["a1", "a2"],
-        "b" => ["b1", "b2"],
-    }?;
-    let df2 = df! {
-        "a" => ["a1", "a1", "a2"],
-        "b2" => ["b1", "b1", "b2"],
-        "c" => ["a1", "c", "a2"]
-    }?;
-    let df = df1.lazy().join(
-        df2.lazy(),
-        [col("a"), col("b")],
-        [col("a"), col("b2")],
-        JoinArgs::new(JoinType::Inner),
-    );
-    let out = df
-        .filter(col("a").eq(lit("a1")))
-        .filter(col("a").eq(col("c")))
-        .collect()?;
-    let expected = df![
-        "a" => ["a1"],
-        "b" => ["b1"],
-        "c" => ["a1"],
-    ]?;
-    assert_eq!(out, expected);
-    Ok(())
-}

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -274,19 +274,27 @@ fn test_predicate_pushdown_block_8847() -> PolarsResult<()> {
 fn test_push_key_predicates_to_both_join_sides_7247() -> PolarsResult<()> {
     let df1 = df! {
         "a" => ["a1", "a2"],
+        "b" => ["b1", "b2"],
     }?;
     let df2 = df! {
         "a" => ["a1", "a1", "a2"],
-        "b" => ["a1", "b", "a2"]
+        "b2" => ["b1", "b1", "b2"],
+        "c" => ["a1", "c", "a2"]
     }?;
-    let df = df1.lazy().left_join(df2.lazy(), col("a"), col("a"));
+    let df = df1.lazy().join(
+        df2.lazy(),
+        [col("a"), col("b")],
+        [col("a"), col("b2")],
+        JoinArgs::new(JoinType::Inner),
+    );
     let out = df
         .filter(col("a").eq(lit("a1")))
-        .filter(col("a").eq(col("b")))
+        .filter(col("a").eq(col("c")))
         .collect()?;
     let expected = df![
         "a" => ["a1"],
-        "b" => ["a1"],
+        "b" => ["b1"],
+        "c" => ["a1"],
     ]?;
     assert_eq!(out, expected);
     Ok(())


### PR DESCRIPTION
Closes #7247

I have limited it to left and inner joins for the sole reason that I don't really have experience with the other types. If this can be extended, it is an easy fix.