### PR TITLE
refactor(rust): Further refactor temporal range functions

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -772,7 +772,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
                 time_zone,
             } => {
                 map_as_slice!(
-                    temporal::temporal_range_dispatch,
+                    temporal::temporal_range,
                     every,
                     closed,
                     time_unit,
@@ -786,7 +786,7 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
                 time_zone,
             } => {
                 map_as_slice!(
-                    temporal::temporal_ranges_dispatch,
+                    temporal::temporal_ranges,
                     every,
                     closed,
                     time_unit,

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -773,7 +773,6 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             } => {
                 map_as_slice!(
                     temporal::temporal_range_dispatch,
-                    "date",
                     every,
                     closed,
                     time_unit,
@@ -788,7 +787,6 @@ impl From<TemporalFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             } => {
                 map_as_slice!(
                     temporal::temporal_ranges_dispatch,
-                    "date_range",
                     every,
                     closed,
                     time_unit,

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -278,6 +278,7 @@ fn date_ranges(s: &[Series], interval: Duration, closed: ClosedWindow) -> Polars
     for (start, end) in start.as_ref().into_iter().zip(&end) {
         match (start, end) {
             (Some(start), Some(end)) => {
+                // TODO: Implement an i32 version of `date_range_impl`
                 let rng = date_range_impl(
                     "",
                     start,

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -206,7 +206,6 @@ pub(super) fn combine(s: &[Series], tu: TimeUnit) -> PolarsResult<Series> {
 
 pub(super) fn temporal_range_dispatch(
     s: &[Series],
-    name: &str,
     every: Duration,
     closed: ClosedWindow,
     time_unit: Option<TimeUnit>,
@@ -291,7 +290,7 @@ pub(super) fn temporal_range_dispatch(
 
     let out = match dtype {
         DataType::Date => date_range_impl(
-            name,
+            "date",
             start,
             end,
             every,
@@ -300,7 +299,7 @@ pub(super) fn temporal_range_dispatch(
             None,
         )?,
         DataType::Datetime(tu, ref tz) => {
-            date_range_impl(name, start, end, every, closed, tu, tz.as_ref())?
+            date_range_impl("date", start, end, every, closed, tu, tz.as_ref())?
         },
         _ => unimplemented!(),
     };
@@ -309,7 +308,6 @@ pub(super) fn temporal_range_dispatch(
 
 pub(super) fn temporal_ranges_dispatch(
     s: &[Series],
-    name: &str,
     every: Duration,
     closed: ClosedWindow,
     time_unit: Option<TimeUnit>,
@@ -397,7 +395,7 @@ pub(super) fn temporal_ranges_dispatch(
     let list = match dtype {
         DataType::Date => {
             let mut builder = ListPrimitiveChunkedBuilder::<Int32Type>::new(
-                name,
+                "date_range",
                 start.len(),
                 start.len() * CAPACITY_FACTOR,
                 DataType::Int32,
@@ -426,7 +424,7 @@ pub(super) fn temporal_ranges_dispatch(
         },
         DataType::Datetime(tu, ref tz) => {
             let mut builder = ListPrimitiveChunkedBuilder::<Int64Type>::new(
-                name,
+                "date_range",
                 start.len(),
                 start.len() * CAPACITY_FACTOR,
                 DataType::Int64,

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -257,11 +257,7 @@ fn date_range(s: &[Series], interval: Duration, closed: ClosedWindow) -> PolarsR
     Ok(result.into_series())
 }
 
-pub(super) fn date_ranges(
-    s: &[Series],
-    interval: Duration,
-    closed: ClosedWindow,
-) -> PolarsResult<Series> {
+fn date_ranges(s: &[Series], interval: Duration, closed: ClosedWindow) -> PolarsResult<Series> {
     let start = &s[0];
     let end = &s[1];
 
@@ -383,7 +379,7 @@ fn datetime_range(
     Ok(result.cast(&dtype).unwrap().into_series())
 }
 
-pub(super) fn datetime_ranges(
+fn datetime_ranges(
     s: &[Series],
     interval: Duration,
     closed: ClosedWindow,

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -243,7 +243,7 @@ fn date_range(s: &[Series], interval: Duration, closed: ClosedWindow) -> PolarsR
     let start = temporal_series_to_i64_scalar(start) * DAYS_TO_MILLISECONDS;
     let end = temporal_series_to_i64_scalar(end) * DAYS_TO_MILLISECONDS;
 
-    let result = date_range_impl(
+    let result = datetime_range_impl(
         "date",
         start,
         end,
@@ -279,7 +279,7 @@ fn date_ranges(s: &[Series], interval: Duration, closed: ClosedWindow) -> Polars
         match (start, end) {
             (Some(start), Some(end)) => {
                 // TODO: Implement an i32 version of `date_range_impl`
-                let rng = date_range_impl(
+                let rng = datetime_range_impl(
                     "",
                     start,
                     end,
@@ -373,7 +373,7 @@ fn datetime_range(
 
     let result = match dtype {
         DataType::Datetime(tu, ref tz) => {
-            date_range_impl("date", start, end, interval, closed, tu, tz.as_ref())?
+            datetime_range_impl("date", start, end, interval, closed, tu, tz.as_ref())?
         },
         _ => unimplemented!(),
     };
@@ -470,7 +470,7 @@ fn datetime_ranges(
                 match (start, end) {
                     (Some(start), Some(end)) => {
                         let rng =
-                            date_range_impl("", start, end, interval, closed, tu, tz.as_ref())?;
+                            datetime_range_impl("", start, end, interval, closed, tu, tz.as_ref())?;
                         builder.append_slice(rng.cont_slice().unwrap())
                     },
                     _ => builder.append_null(),

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -211,7 +211,7 @@ pub(super) fn temporal_range(
     time_unit: Option<TimeUnit>,
     time_zone: Option<TimeZone>,
 ) -> PolarsResult<Series> {
-    if *s[0].dtype() == DataType::Date && interval.nanoseconds() == 0 {
+    if s[0].dtype() == &DataType::Date && interval.nanoseconds() == 0 {
         date_range(s, interval, closed)
     } else {
         datetime_range(s, interval, closed, time_unit, time_zone)
@@ -335,7 +335,7 @@ pub(super) fn temporal_ranges(
     time_unit: Option<TimeUnit>,
     time_zone: Option<TimeZone>,
 ) -> PolarsResult<Series> {
-    if *s[0].dtype() == DataType::Date && interval.nanoseconds() == 0 {
+    if s[0].dtype() == &DataType::Date && interval.nanoseconds() == 0 {
         date_ranges(s, interval, closed)
     } else {
         datetime_ranges(s, interval, closed, time_unit, time_zone)

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -6,7 +6,7 @@ use polars_time::prelude::*;
 
 use super::*;
 
-const DAYS_TO_MICROSECONDS: i64 = SECONDS_IN_DAY * 1000;
+const DAYS_TO_MILLISECONDS: i64 = SECONDS_IN_DAY * 1000;
 const CAPACITY_FACTOR: usize = 5;
 
 pub(super) fn datetime(
@@ -218,12 +218,7 @@ pub(super) fn temporal_range_dispatch(
     polars_ensure!(start.len() == 1, ComputeError: "`start` must contain a single value");
     polars_ensure!(end.len() == 1, ComputeError: "`end` must contain a single value");
 
-    polars_ensure!(
-        start.len() == end.len(),
-        ComputeError: "`start` and `end` must have the same length",
-    );
-
-    // Note: `start` and `stop` have already been cast to their supertype,
+    // Note: `start` and `end` have already been cast to their supertype,
     // so only `start`'s dtype needs to be matched against.
     #[allow(unused_mut)] // `dtype` is mutated within a "feature = timezones" block.
     let mut dtype = match (start.dtype(), time_unit) {
@@ -278,8 +273,8 @@ pub(super) fn temporal_range_dispatch(
     };
 
     if dtype == DataType::Date {
-        start = &start * DAYS_TO_MICROSECONDS;
-        end = &end * DAYS_TO_MICROSECONDS;
+        start = &start * DAYS_TO_MILLISECONDS;
+        end = &end * DAYS_TO_MILLISECONDS;
     }
 
     // overwrite time zone, if specified
@@ -383,8 +378,8 @@ pub(super) fn temporal_ranges_dispatch(
     };
 
     if dtype == DataType::Date {
-        start = &start * DAYS_TO_MICROSECONDS;
-        end = &end * DAYS_TO_MICROSECONDS;
+        start = &start * DAYS_TO_MILLISECONDS;
+        end = &end * DAYS_TO_MILLISECONDS;
     }
 
     // overwrite time zone, if specified

--- a/crates/polars-time/src/date_range.rs
+++ b/crates/polars-time/src/date_range.rs
@@ -12,41 +12,6 @@ pub fn in_nanoseconds_window(ndt: &NaiveDateTime) -> bool {
     !(ndt.year() > 2554 || ndt.year() < 1386)
 }
 
-#[doc(hidden)]
-pub fn datetime_range_impl(
-    name: &str,
-    start: i64,
-    end: i64,
-    interval: Duration,
-    closed: ClosedWindow,
-    tu: TimeUnit,
-    _tz: Option<&TimeZone>,
-) -> PolarsResult<DatetimeChunked> {
-    let mut out = match _tz {
-        #[cfg(feature = "timezones")]
-        Some(tz) => match tz.parse::<chrono_tz::Tz>() {
-            Ok(tz) => {
-                let start = localize_timestamp(start, tu, tz);
-                let end = localize_timestamp(end, tu, tz);
-                Int64Chunked::new_vec(
-                    name,
-                    temporal_range_vec(start?, end?, interval, closed, tu, Some(&tz))?,
-                )
-                .into_datetime(tu, _tz.cloned())
-            },
-            Err(_) => polars_bail!(ComputeError: "unable to parse time zone: '{}'", tz),
-        },
-        _ => Int64Chunked::new_vec(
-            name,
-            temporal_range_vec(start, end, interval, closed, tu, None)?,
-        )
-        .into_datetime(tu, None),
-    };
-
-    out.set_sorted_flag(IsSorted::Ascending);
-    Ok(out)
-}
-
 /// Create a [`DatetimeChunked`] from a given `start` and `end` date and a given `interval`.
 pub fn date_range(
     name: &str,
@@ -66,18 +31,35 @@ pub fn date_range(
 }
 
 #[doc(hidden)]
-pub fn time_range_impl(
+pub fn datetime_range_impl(
     name: &str,
     start: i64,
     end: i64,
     interval: Duration,
     closed: ClosedWindow,
-) -> PolarsResult<TimeChunked> {
-    let mut out = Int64Chunked::new_vec(
-        name,
-        temporal_range_vec(start, end, interval, closed, TimeUnit::Nanoseconds, None)?,
-    )
-    .into_time();
+    tu: TimeUnit,
+    _tz: Option<&TimeZone>,
+) -> PolarsResult<DatetimeChunked> {
+    let mut out = match _tz {
+        #[cfg(feature = "timezones")]
+        Some(tz) => match tz.parse::<chrono_tz::Tz>() {
+            Ok(tz) => {
+                let start = localize_timestamp(start, tu, tz);
+                let end = localize_timestamp(end, tu, tz);
+                Int64Chunked::new_vec(
+                    name,
+                    datetime_range_i64(start?, end?, interval, closed, tu, Some(&tz))?,
+                )
+                .into_datetime(tu, _tz.cloned())
+            },
+            Err(_) => polars_bail!(ComputeError: "unable to parse time zone: '{}'", tz),
+        },
+        _ => Int64Chunked::new_vec(
+            name,
+            datetime_range_i64(start, end, interval, closed, tu, None)?,
+        )
+        .into_datetime(tu, None),
+    };
 
     out.set_sorted_flag(IsSorted::Ascending);
     Ok(out)
@@ -94,4 +76,22 @@ pub fn time_range(
     let start = time_to_time64ns(&start);
     let end = time_to_time64ns(&end);
     time_range_impl(name, start, end, interval, closed)
+}
+
+#[doc(hidden)]
+pub fn time_range_impl(
+    name: &str,
+    start: i64,
+    end: i64,
+    interval: Duration,
+    closed: ClosedWindow,
+) -> PolarsResult<TimeChunked> {
+    let mut out = Int64Chunked::new_vec(
+        name,
+        datetime_range_i64(start, end, interval, closed, TimeUnit::Nanoseconds, None)?,
+    )
+    .into_time();
+
+    out.set_sorted_flag(IsSorted::Ascending);
+    Ok(out)
 }

--- a/crates/polars-time/src/date_range.rs
+++ b/crates/polars-time/src/date_range.rs
@@ -13,7 +13,7 @@ pub fn in_nanoseconds_window(ndt: &NaiveDateTime) -> bool {
 }
 
 #[doc(hidden)]
-pub fn date_range_impl(
+pub fn datetime_range_impl(
     name: &str,
     start: i64,
     end: i64,
@@ -62,7 +62,7 @@ pub fn date_range(
         TimeUnit::Microseconds => (start.timestamp_micros(), end.timestamp_micros()),
         TimeUnit::Milliseconds => (start.timestamp_millis(), end.timestamp_millis()),
     };
-    date_range_impl(name, start, end, interval, closed, tu, tz.as_ref())
+    datetime_range_impl(name, start, end, interval, closed, tu, tz.as_ref())
 }
 
 #[doc(hidden)]

--- a/crates/polars-time/src/group_by/dynamic.rs
+++ b/crates/polars-time/src/group_by/dynamic.rs
@@ -807,7 +807,7 @@ mod test {
             .and_hms_opt(3, 0, 0)
             .unwrap()
             .timestamp_millis();
-        let range = date_range_impl(
+        let range = datetime_range_impl(
             "date",
             start,
             stop,
@@ -860,7 +860,7 @@ mod test {
             .and_hms_opt(3, 0, 0)
             .unwrap()
             .timestamp_millis();
-        let range = date_range_impl(
+        let range = datetime_range_impl(
             "_upper_boundary",
             start,
             stop,
@@ -883,7 +883,7 @@ mod test {
             .and_hms_opt(2, 0, 0)
             .unwrap()
             .timestamp_millis();
-        let range = date_range_impl(
+        let range = datetime_range_impl(
             "_lower_boundary",
             start,
             stop,
@@ -922,7 +922,7 @@ mod test {
             .and_hms_opt(12, 0, 0)
             .unwrap()
             .timestamp_millis();
-        let range = date_range_impl(
+        let range = datetime_range_impl(
             "date",
             start,
             stop,

--- a/crates/polars-time/src/lib.rs
+++ b/crates/polars-time/src/lib.rs
@@ -26,7 +26,7 @@ pub use month_start::*;
 pub use round::*;
 pub use truncate::*;
 pub use upsample::*;
-pub use windows::calendar::temporal_range as temporal_range_vec;
+pub use windows::calendar::datetime_range_i64;
 pub use windows::duration::Duration;
 pub use windows::group_by::ClosedWindow;
 pub use windows::window::Window;

--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -188,7 +188,7 @@ fn upsample_single_impl(
                         TimeUnit::Microseconds => offset.add_us(first, None)?,
                         TimeUnit::Milliseconds => offset.add_ms(first, None)?,
                     };
-                    let range = date_range_impl(
+                    let range = datetime_range_impl(
                         index_col_name,
                         first,
                         last,

--- a/crates/polars-time/src/windows/calendar.rs
+++ b/crates/polars-time/src/windows/calendar.rs
@@ -99,11 +99,7 @@ pub fn temporal_range(
 }
 
 fn check_range_bounds(start: i64, end: i64, interval: Duration) -> PolarsResult<()> {
-    if start > end {
-        polars_bail!(ComputeError: "`end` must be equal to or greater than `start`")
-    }
-    if interval.negative || interval.is_zero() {
-        polars_bail!(ComputeError: "`interval` must be positive")
-    }
+    polars_ensure!(end >= start, ComputeError: "`end` must be equal to or greater than `start`");
+    polars_ensure!(!interval.negative && !interval.is_zero(), ComputeError: "`interval` must be positive");
     Ok(())
 }

--- a/crates/polars-time/src/windows/calendar.rs
+++ b/crates/polars-time/src/windows/calendar.rs
@@ -36,7 +36,7 @@ pub const NS_DAY: i64 = 24 * NS_HOUR;
 pub const NS_WEEK: i64 = 7 * NS_DAY;
 
 /// vector of i64 representing temporal values
-pub fn temporal_range(
+pub fn datetime_range_i64(
     start: i64,
     end: i64,
     interval: Duration,

--- a/crates/polars-time/src/windows/test.rs
+++ b/crates/polars-time/src/windows/test.rs
@@ -15,7 +15,7 @@ fn test_date_range() {
         .unwrap()
         .and_hms_opt(0, 0, 0)
         .unwrap();
-    let dates = temporal_range_vec(
+    let dates = datetime_range_i64(
         start.timestamp_nanos(),
         end.timestamp_nanos(),
         Duration::parse("1mo"),
@@ -46,7 +46,7 @@ fn test_feb_date_range() {
         .unwrap()
         .and_hms_opt(0, 0, 0)
         .unwrap();
-    let dates = temporal_range_vec(
+    let dates = datetime_range_i64(
         start.timestamp_nanos(),
         end.timestamp_nanos(),
         Duration::parse("1mo"),
@@ -167,7 +167,7 @@ fn test_boundaries() {
         .and_hms_opt(3, 0, 0)
         .unwrap();
 
-    let ts = temporal_range_vec(
+    let ts = datetime_range_i64(
         start.timestamp_nanos(),
         stop.timestamp_nanos(),
         Duration::parse("30m"),
@@ -343,7 +343,7 @@ fn test_boundaries_2() {
         .and_hms_opt(4, 0, 0)
         .unwrap();
 
-    let ts = temporal_range_vec(
+    let ts = datetime_range_i64(
         start.timestamp_nanos(),
         stop.timestamp_nanos(),
         Duration::parse("30m"),
@@ -451,7 +451,7 @@ fn test_boundaries_ms() {
         .and_hms_opt(3, 0, 0)
         .unwrap();
 
-    let ts = temporal_range_vec(
+    let ts = datetime_range_i64(
         start.timestamp_millis(),
         stop.timestamp_millis(),
         Duration::parse("30m"),
@@ -627,7 +627,7 @@ fn test_rolling_lookback() {
         .unwrap()
         .and_hms_opt(4, 0, 0)
         .unwrap();
-    let dates = temporal_range_vec(
+    let dates = datetime_range_i64(
         start.timestamp_millis(),
         end.timestamp_millis(),
         Duration::parse("30m"),

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "ahash",
  "built",


### PR DESCRIPTION
Preparation for #10006 

`time_range` and `date_range` are now quite clean.

`date_range` must be re-implemented to work with `i32` instead of `i64`.
`datetime_range` requires a lot more work to clean up...

At least they are now separated, so the new `datetime_range` expression can be added (in a separate PR).