### PR TITLE
refactor(rust): Add duration method for checking full days

### DIFF
--- a/crates/polars-time/src/windows/duration.rs
+++ b/crates/polars-time/src/windows/duration.rs
@@ -338,6 +338,14 @@ impl Duration {
         self.days
     }
 
+    /// Returns whether the duration consists of full days.
+    ///
+    /// Note that 24 hours is not considered a full day due to possible
+    /// daylight savings time transitions.
+    pub fn is_full_days(&self) -> bool {
+        self.nsecs == 0
+    }
+
     pub fn is_constant_duration(&self) -> bool {
         self.months == 0 && self.weeks == 0 && self.days == 0
     }

--- a/py-polars/tests/unit/functions/range/test_date_range.py
+++ b/py-polars/tests/unit/functions/range/test_date_range.py
@@ -879,3 +879,15 @@ def test_date_range_invalid_interval(interval: timedelta) -> None:
         pl.date_range(
             datetime(2000, 3, 20), datetime(2000, 3, 21), interval="-1h", eager=True
         )
+
+
+def test_date_range_24h_interval_results_in_datetime() -> None:
+    result = pl.LazyFrame().select(
+        pl.date_range(date(2022, 1, 1), date(2022, 1, 3), interval="24h")
+    )
+
+    assert result.schema == {"date": pl.Datetime}
+    expected = pl.Series(
+        "date", [datetime(2022, 1, 1), datetime(2022, 1, 2), datetime(2022, 1, 3)]
+    )
+    assert_series_equal(result.collect().to_series(), expected)


### PR DESCRIPTION
~We checked the interval for `nanoseconds == 0`, which is wrong: `24h` should give the same results as `1d`.~

Actually, the original check was correct. I am rebranding this as a refactor.