### PR TITLE
feat(python): raise a more helpful error when non-query statements passed to `read_database`

### DIFF
--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -54,26 +54,6 @@ except ImportError:
         """Exception raised when an unexpected state causes a panic in the underlying Rust library."""  # noqa: W505
 
 
-class InvalidAssert(Exception):
-    """Exception raised when an unsupported testing assert is made."""
-
-
-class RowsError(Exception):
-    """Exception raised when the number of returned rows does not match expectation."""
-
-
-class NoRowsReturnedError(RowsError):
-    """Exception raised when no rows are returned, but at least one row is expected."""
-
-
-class TooManyRowsReturnedError(RowsError):
-    """Exception raised when more rows than expected are returned."""
-
-
-class TimeZoneAwareConstructorWarning(Warning):
-    """Warning raised when constructing Series from non-UTC time-zone-aware inputs."""
-
-
 class ChronoFormatWarning(Warning):
     """
     Warning raised when a chrono format string contains dubious patterns.
@@ -86,12 +66,32 @@ class ChronoFormatWarning(Warning):
     """
 
 
-class PolarsInefficientMapWarning(Warning):
-    """
-    Warning raised when a potentially slow `apply` operation is performed.
+class InvalidAssert(Exception):
+    """Exception raised when an unsupported testing assert is made."""
 
-    Suggestion of what to replace slow pattern with will also be shown.
-    """
+
+class RowsError(Exception):
+    """Exception raised when the number of returned rows does not match expectation."""
+
+
+class NoRowsReturnedError(RowsError):
+    """Exception raised when no rows are returned, but at least one row is expected."""
+
+
+class PolarsInefficientMapWarning(Warning):
+    """Warning raised when a potentially slow `apply` operation is performed."""
+
+
+class TooManyRowsReturnedError(RowsError):
+    """Exception raised when more rows than expected are returned."""
+
+
+class TimeZoneAwareConstructorWarning(Warning):
+    """Warning raised when constructing Series from non-UTC time-zone-aware inputs."""
+
+
+class UnsuitableSQLError(ValueError):
+    """Exception raised when unsuitable SQL is given to a database method."""
 
 
 __all__ = [

--- a/py-polars/tests/unit/io/test_database_read.py
+++ b/py-polars/tests/unit/io/test_database_read.py
@@ -12,6 +12,7 @@ import pytest
 from sqlalchemy import create_engine
 
 import polars as pl
+from polars.exceptions import UnsuitableSQLError
 
 if TYPE_CHECKING:
     from polars.type_aliases import DbReadEngine
@@ -284,6 +285,24 @@ def test_read_database_mocked() -> None:
             TypeError,
             "Unrecognised connection .* unable to find 'execute' method",
             id="Invalid read DB kwargs",
+        ),
+        pytest.param(
+            "read_database",
+            None,
+            "/* tag: misc */ INSERT INTO xyz VALUES ('polars')",
+            sqlite3.connect(":memory:"),
+            UnsuitableSQLError,
+            "INSERT statements are not valid 'read' queries",
+            id="Invalid statement type",
+        ),
+        pytest.param(
+            "read_database",
+            None,
+            "DELETE FROM xyz WHERE id = 'polars'",
+            sqlite3.connect(":memory:"),
+            UnsuitableSQLError,
+            "DELETE statements are not valid 'read' queries",
+            id="Invalid statement type",
         ),
     ],
 )


### PR DESCRIPTION
Closes #10843.

The `read_database` method only handles (and _should_ only handle) statements that return query results; this update just helps make that clear by raising a more explicit exception when given unsuitable SQL.

This PR covers the vast majority of invalid query types; note that (due to differences in backend SQL) we do not positively identify "SELECT"-type queries (as these can also start "WITH", be stored procedures with vendor-specific syntax, etc) - rather, we identify known _invalid_ query types. This means that we shouldn't inadvertently reject a valid query from a lesser-known dialect.

## Example

```python
import polars as pl
from sqlalchemy import create_engine

conn = create_engine("sqlite:///")
pl.read_database("INSERT INTO xyz VALUES ('polars')", conn)
```
**Before**
_(as no results are returned the result cursor is never created)_
```
AttributeError: 'NoneType' object has no attribute 'description'
```
**After**
```
UnsuitableSQLError: INSERT statements are not valid 'read' queries
```
