### PR TITLE
refactor: introduce with_name for Series/ChunkedArray

### DIFF
--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -360,6 +360,12 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     pub fn rename(&mut self, name: &str) {
         self.field = Arc::new(Field::new(name, self.field.data_type().clone()))
     }
+    
+    /// Return this ChunkedArray with a new name.
+    pub fn with_name(mut self, name: &str) -> Self {
+        self.rename(name);
+        self
+    }
 }
 
 impl<T> ChunkedArray<T>

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -360,7 +360,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     pub fn rename(&mut self, name: &str) {
         self.field = Arc::new(Field::new(name, self.field.data_type().clone()))
     }
-    
+
     /// Return this ChunkedArray with a new name.
     pub fn with_name(mut self, name: &str) -> Self {
         self.rename(name);

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -73,22 +73,28 @@ where
         ChunkedArray::try_from_chunk_iter(self.name(), iter)
     }
 
-    pub fn apply_generic<'a, U, K, F>(&'a self, op: F) -> ChunkedArray<U>
+    pub fn apply_generic<'a, U, K, F>(&'a self, mut op: F) -> ChunkedArray<U>
     where
         U: PolarsDataType,
         F: FnMut(
                 Option<<<Self as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>>,
-            ) -> Option<K>
-            + Copy,
+            ) -> Option<K>,
         K: ArrayFromElementIter,
         K::ArrayType: StaticallyMatchesPolarsType<U>,
     {
-        let iter = self.downcast_iter().map(|arr| {
-            let element_iter = arr.iter().map(op);
-            K::array_from_iter(element_iter)
-        });
-
-        ChunkedArray::from_chunk_iter(self.name(), iter)
+        if self.null_count() == 0 {
+            let iter = self.downcast_iter().map(|arr| {
+                let element_iter = arr.values_iter().map(|x| op(Some(x)));
+                K::array_from_iter(element_iter)
+            });
+            ChunkedArray::from_chunk_iter(self.name(), iter)
+        } else {
+            let iter = self.downcast_iter().map(|arr| {
+                let element_iter = arr.iter().map(|x| op(x));
+                K::array_from_iter(element_iter)
+            });
+            ChunkedArray::from_chunk_iter(self.name(), iter)
+        }
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -90,7 +90,7 @@ where
             ChunkedArray::from_chunk_iter(self.name(), iter)
         } else {
             let iter = self.downcast_iter().map(|arr| {
-                let element_iter = arr.iter().map(|x| op(x));
+                let element_iter = arr.iter().map(&mut op);
                 K::array_from_iter(element_iter)
             });
             ChunkedArray::from_chunk_iter(self.name(), iter)

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -77,8 +77,8 @@ where
     where
         U: PolarsDataType,
         F: FnMut(
-                Option<<<Self as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>>,
-            ) -> Option<K>,
+            Option<<<Self as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>>,
+        ) -> Option<K>,
         K: ArrayFromElementIter,
         K::ArrayType: StaticallyMatchesPolarsType<U>,
     {

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -228,6 +228,12 @@ impl Series {
         self
     }
 
+    /// Return this Series with a new name.
+    pub fn with_name(mut self, name: &str) -> Series {
+        self.rename(name);
+        self
+    }
+
     /// Shrink the capacity of this array to fit its length.
     pub fn shrink_to_fit(&mut self) {
         self._get_inner_mut().shrink_to_fit()

--- a/crates/polars-time/src/chunkedarray/time.rs
+++ b/crates/polars-time/src/chunkedarray/time.rs
@@ -50,7 +50,7 @@ impl TimeMethods for TimeChunked {
     }
 
     fn parse_from_str_slice(name: &str, v: &[&str], fmt: &str) -> TimeChunked {
-        let mut ca: Int64Chunked = v
+        v
             .iter()
             .map(|s| {
                 NaiveTime::parse_from_str(s, fmt)
@@ -58,8 +58,8 @@ impl TimeMethods for TimeChunked {
                     .as_ref()
                     .map(time_to_time64ns)
             })
-            .collect_trusted();
-        ca.rename(name);
-        ca.into()
+            .collect_trusted::<Int64Chunked>()
+            .with_name(name)
+            .into()
     }
 }

--- a/crates/polars-time/src/chunkedarray/time.rs
+++ b/crates/polars-time/src/chunkedarray/time.rs
@@ -50,8 +50,7 @@ impl TimeMethods for TimeChunked {
     }
 
     fn parse_from_str_slice(name: &str, v: &[&str], fmt: &str) -> TimeChunked {
-        v
-            .iter()
+        v.iter()
             .map(|s| {
                 NaiveTime::parse_from_str(s, fmt)
                     .ok()

--- a/crates/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/crates/polars-time/src/chunkedarray/utf8/infer.rs
@@ -380,12 +380,11 @@ where
                 .map(|opt_val| opt_val.and_then(|val| self.parse(val)));
             PrimitiveArray::from_trusted_len_iter(iter)
         });
-        let mut out = ChunkedArray::from_chunk_iter(ca.name(), chunks)
+        ChunkedArray::from_chunk_iter(ca.name(), chunks)
             .into_series()
             .cast(&self.logical_type)
-            .unwrap();
-        out.rename(ca.name());
-        out
+            .unwrap()
+            .with_name(ca.name())
     }
 }
 


### PR DESCRIPTION
This will let us avoid writing `let mut ca = ...; ca.rename(...); ca` all the time.