### PR TITLE
refactor: eliminate repetition in utf8 datetime functions

### DIFF
--- a/crates/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/crates/polars-time/src/chunkedarray/utf8/mod.rs
@@ -7,41 +7,12 @@ use chrono::ParseError;
 pub use patterns::Pattern;
 #[cfg(feature = "dtype-time")]
 use polars_core::chunked_array::temporal::time_to_time64ns;
+use polars_utils::cache::CachedFunc;
 
 use super::*;
 #[cfg(feature = "dtype-date")]
 use crate::chunkedarray::date::naive_date_to_date;
 use crate::prelude::utf8::strptime::StrpTimeState;
-
-struct CachedFunc<T, R, F> {
-    func: F,
-    cache: PlHashMap<T, R>,
-}
-
-impl<T, R, F> CachedFunc<T, R, F>
-where
-    F: FnMut(T) -> R,
-    T: std::hash::Hash + Eq + Clone,
-    R: Copy,
-{
-    pub fn new(func: F) -> Self {
-        Self {
-            func,
-            cache: PlHashMap::new(),
-        }
-    }
-
-    pub fn eval(&mut self, x: T, use_cache: bool) -> R {
-        if use_cache {
-            *self
-                .cache
-                .entry(x)
-                .or_insert_with_key(|xr| (self.func)(xr.clone()))
-        } else {
-            (self.func)(x)
-        }
-    }
-}
 
 #[cfg(feature = "dtype-time")]
 fn time_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>

--- a/crates/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/crates/polars-time/src/chunkedarray/utf8/mod.rs
@@ -144,7 +144,7 @@ pub trait Utf8Methods: AsUtf8 {
             let naive_time = NaiveTime::parse_from_str(s, fmt).ok()?;
             Some(time_to_time64ns(&naive_time))
         });
-        let ca = utf8_ca.apply_generic(|opt_s| Some(convert.eval(opt_s?, use_cache)?));
+        let ca = utf8_ca.apply_generic(|opt_s| convert.eval(opt_s?, use_cache));
         Ok(ca.with_name(utf8_ca.name()).into())
     }
 

--- a/crates/polars-time/src/chunkedarray/utf8/mod.rs
+++ b/crates/polars-time/src/chunkedarray/utf8/mod.rs
@@ -13,6 +13,36 @@ use super::*;
 use crate::chunkedarray::date::naive_date_to_date;
 use crate::prelude::utf8::strptime::StrpTimeState;
 
+struct CachedFunc<T, R, F> {
+    func: F,
+    cache: PlHashMap<T, R>,
+}
+
+impl<T, R, F> CachedFunc<T, R, F>
+where
+    F: FnMut(T) -> R,
+    T: std::hash::Hash + Eq + Clone,
+    R: Copy,
+{
+    pub fn new(func: F) -> Self {
+        Self {
+            func,
+            cache: PlHashMap::new(),
+        }
+    }
+
+    pub fn eval(&mut self, x: T, use_cache: bool) -> R {
+        if use_cache {
+            *self
+                .cache
+                .entry(x)
+                .or_insert_with_key(|xr| (self.func)(xr.clone()))
+        } else {
+            (self.func)(x)
+        }
+    }
+}
+
 #[cfg(feature = "dtype-time")]
 fn time_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>
 // (string, fmt) -> PolarsResult
@@ -29,16 +59,11 @@ fn datetime_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>
 where
     F: Fn(&str, &str) -> chrono::ParseResult<K>,
 {
-    let result = patterns::DATETIME_Y_M_D
+    patterns::DATETIME_Y_M_D
         .iter()
+        .chain(patterns::DATETIME_D_M_Y)
         .find(|fmt| convert(val, fmt).is_ok())
-        .copied();
-    result.or_else(|| {
-        patterns::DATETIME_D_M_Y
-            .iter()
-            .find(|fmt| convert(val, fmt).is_ok())
-            .copied()
-    })
+        .copied()
 }
 
 fn date_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>
@@ -46,24 +71,19 @@ fn date_pattern<F, K>(val: &str, convert: F) -> Option<&'static str>
 where
     F: Fn(&str, &str) -> chrono::ParseResult<K>,
 {
-    let result = patterns::DATE_Y_M_D
+    patterns::DATE_Y_M_D
         .iter()
+        .chain(patterns::DATE_D_M_Y)
         .find(|fmt| convert(val, fmt).is_ok())
-        .copied();
-    result.or_else(|| {
-        patterns::DATE_D_M_Y
-            .iter()
-            .find(|fmt| convert(val, fmt).is_ok())
-            .copied()
-    })
+        .copied()
 }
 
 struct ParseErrorByteCopy(ParseErrorKind);
 
 impl From<ParseError> for ParseErrorByteCopy {
     fn from(e: ParseError) -> Self {
-        // we need to do this until chrono ParseErrorKind is public
-        // blocked by https://github.com/chronotope/chrono/pull/588
+        // We need to do this until chrono ParseErrorKind is public
+        // blocked by https://github.com/chronotope/chrono/pull/588.
         unsafe { std::mem::transmute(e) }
     }
 }
@@ -92,93 +112,40 @@ fn get_first_val(ca: &Utf8Chunked) -> PolarsResult<&str> {
 #[cfg(feature = "dtype-datetime")]
 fn sniff_fmt_datetime(ca_utf8: &Utf8Chunked) -> PolarsResult<&'static str> {
     let val = get_first_val(ca_utf8)?;
-    match datetime_pattern(val, NaiveDateTime::parse_from_str) {
-        Some(pattern) => Ok(pattern),
-        None => match datetime_pattern(val, NaiveDate::parse_from_str) {
-            Some(pattern) => Ok(pattern),
-            None => polars_bail!(parse_fmt_idk = "datetime"),
-        },
-    }
+    datetime_pattern(val, NaiveDateTime::parse_from_str)
+        .or_else(|| datetime_pattern(val, NaiveDate::parse_from_str))
+        .ok_or_else(|| polars_err!(parse_fmt_idk = "datetime"))
 }
 
 #[cfg(feature = "dtype-date")]
 fn sniff_fmt_date(ca_utf8: &Utf8Chunked) -> PolarsResult<&'static str> {
     let val = get_first_val(ca_utf8)?;
-    if let Some(pattern) = date_pattern(val, NaiveDate::parse_from_str) {
-        return Ok(pattern);
-    }
-    polars_bail!(parse_fmt_idk = "date");
+    date_pattern(val, NaiveDate::parse_from_str).ok_or_else(|| polars_err!(parse_fmt_idk = "date"))
 }
 
 #[cfg(feature = "dtype-time")]
 fn sniff_fmt_time(ca_utf8: &Utf8Chunked) -> PolarsResult<&'static str> {
     let val = get_first_val(ca_utf8)?;
-    if let Some(pattern) = time_pattern(val, NaiveTime::parse_from_str) {
-        return Ok(pattern);
-    }
-    polars_bail!(parse_fmt_idk = "time");
+    time_pattern(val, NaiveTime::parse_from_str).ok_or_else(|| polars_err!(parse_fmt_idk = "time"))
 }
 
 pub trait Utf8Methods: AsUtf8 {
     #[cfg(feature = "dtype-time")]
     /// Parsing string values and return a [`TimeChunked`]
-    fn as_time(&self, fmt: Option<&str>, cache: bool) -> PolarsResult<TimeChunked> {
+    fn as_time(&self, fmt: Option<&str>, use_cache: bool) -> PolarsResult<TimeChunked> {
         let utf8_ca = self.as_utf8();
         let fmt = match fmt {
             Some(fmt) => fmt,
             None => sniff_fmt_time(utf8_ca)?,
         };
-        let cache = cache && utf8_ca.len() > 50;
+        let use_cache = use_cache && utf8_ca.len() > 50;
 
-        let mut cache_map = PlHashMap::new();
-
-        let mut ca: Int64Chunked = match utf8_ca.has_validity() {
-            false => utf8_ca
-                .into_no_null_iter()
-                .map(|s| {
-                    if cache {
-                        *cache_map.entry(s).or_insert_with(|| {
-                            NaiveTime::parse_from_str(s, fmt)
-                                .ok()
-                                .as_ref()
-                                .map(time_to_time64ns)
-                        })
-                    } else {
-                        NaiveTime::parse_from_str(s, fmt)
-                            .ok()
-                            .as_ref()
-                            .map(time_to_time64ns)
-                    }
-                })
-                .collect_trusted(),
-            _ => utf8_ca
-                .into_iter()
-                .map(|opt_s| {
-                    let opt_nd = opt_s.map(|s| {
-                        if cache {
-                            *cache_map.entry(s).or_insert_with(|| {
-                                NaiveTime::parse_from_str(s, fmt)
-                                    .ok()
-                                    .as_ref()
-                                    .map(time_to_time64ns)
-                            })
-                        } else {
-                            NaiveTime::parse_from_str(s, fmt)
-                                .ok()
-                                .as_ref()
-                                .map(time_to_time64ns)
-                        }
-                    });
-                    match opt_nd {
-                        None => None,
-                        Some(None) => None,
-                        Some(Some(nd)) => Some(nd),
-                    }
-                })
-                .collect_trusted(),
-        };
-        ca.rename(utf8_ca.name());
-        Ok(ca.into())
+        let mut convert = CachedFunc::new(|s| {
+            let naive_time = NaiveTime::parse_from_str(s, fmt).ok()?;
+            Some(time_to_time64ns(&naive_time))
+        });
+        let ca = utf8_ca.apply_generic(|opt_s| Some(convert.eval(opt_s?, use_cache)?));
+        Ok(ca.with_name(utf8_ca.name()).into())
     }
 
     #[cfg(feature = "dtype-date")]
@@ -191,38 +158,29 @@ pub trait Utf8Methods: AsUtf8 {
             Some(fmt) => fmt,
             None => sniff_fmt_date(utf8_ca)?,
         };
-        let mut ca: Int32Chunked = utf8_ca
-            .into_iter()
-            .map(|opt_s| match opt_s {
-                None => None,
-                Some(mut s) => {
-                    let fmt_len = fmt.len();
+        let ca = utf8_ca.apply_generic(|opt_s| {
+            let mut s = opt_s?;
+            let fmt_len = fmt.len();
 
-                    for i in 1..(s.len().saturating_sub(fmt_len)) {
-                        if s.is_empty() {
-                            return None;
-                        }
-                        match NaiveDate::parse_from_str(s, fmt).map(naive_date_to_date) {
-                            Ok(nd) => return Some(nd),
-                            Err(e) => {
-                                let e: ParseErrorByteCopy = e.into();
-                                match e.0 {
-                                    ParseErrorKind::TooLong => {
-                                        s = &s[..s.len() - 1];
-                                    },
-                                    _ => {
-                                        s = &s[i..];
-                                    },
-                                }
-                            },
-                        }
-                    }
-                    None
-                },
-            })
-            .collect_trusted();
-        ca.rename(utf8_ca.name());
-        Ok(ca.into())
+            for i in 1..(s.len().saturating_sub(fmt_len)) {
+                if s.is_empty() {
+                    return None;
+                }
+                match NaiveDate::parse_from_str(s, fmt).map(naive_date_to_date) {
+                    Ok(nd) => return Some(nd),
+                    Err(e) => match ParseErrorByteCopy::from(e).0 {
+                        ParseErrorKind::TooLong => {
+                            s = &s[..s.len() - 1];
+                        },
+                        _ => {
+                            s = &s[i..];
+                        },
+                    },
+                }
+            }
+            None
+        });
+        Ok(ca.with_name(utf8_ca.name()).into())
     }
 
     #[cfg(feature = "dtype-datetime")]
@@ -249,41 +207,38 @@ pub trait Utf8Methods: AsUtf8 {
             TimeUnit::Milliseconds => datetime_to_timestamp_ms,
         };
 
-        let mut ca: Int64Chunked = utf8_ca
-            .into_iter()
-            .map(|opt_s| match opt_s {
-                None => None,
-                Some(mut s) => {
-                    let fmt_len = fmt.len();
+        let ca = utf8_ca
+            .apply_generic(|opt_s| {
+                let mut s = opt_s?;
+                let fmt_len = fmt.len();
 
-                    for i in 1..(s.len().saturating_sub(fmt_len)) {
-                        if s.is_empty() {
-                            return None;
-                        }
-                        let timestamp = match tz_aware {
-                            true => DateTime::parse_from_str(s, fmt).map(|dt| func(dt.naive_utc())),
-                            false => NaiveDateTime::parse_from_str(s, fmt).map(func),
-                        };
-                        match timestamp {
-                            Ok(ts) => return Some(ts),
-                            Err(e) => {
-                                let e: ParseErrorByteCopy = e.into();
-                                match e.0 {
-                                    ParseErrorKind::TooLong => {
-                                        s = &s[..s.len() - 1];
-                                    },
-                                    _ => {
-                                        s = &s[i..];
-                                    },
-                                }
-                            },
-                        }
+                for i in 1..(s.len().saturating_sub(fmt_len)) {
+                    if s.is_empty() {
+                        return None;
                     }
-                    None
-                },
+                    let timestamp = if tz_aware {
+                        DateTime::parse_from_str(s, fmt).map(|dt| func(dt.naive_utc()))
+                    } else {
+                        NaiveDateTime::parse_from_str(s, fmt).map(func)
+                    };
+                    match timestamp {
+                        Ok(ts) => return Some(ts),
+                        Err(e) => {
+                            let e: ParseErrorByteCopy = e.into();
+                            match e.0 {
+                                ParseErrorKind::TooLong => {
+                                    s = &s[..s.len() - 1];
+                                },
+                                _ => {
+                                    s = &s[i..];
+                                },
+                            }
+                        },
+                    }
+                }
+                None
             })
-            .collect_trusted();
-        ca.rename(utf8_ca.name());
+            .with_name(utf8_ca.name());
         match (tz_aware, tz) {
             #[cfg(feature = "timezones")]
             (false, Some(tz)) => polars_ops::prelude::replace_time_zone(
@@ -299,87 +254,46 @@ pub trait Utf8Methods: AsUtf8 {
 
     #[cfg(feature = "dtype-date")]
     /// Parsing string values and return a [`DateChunked`]
-    fn as_date(&self, fmt: Option<&str>, cache: bool) -> PolarsResult<DateChunked> {
+    fn as_date(&self, fmt: Option<&str>, use_cache: bool) -> PolarsResult<DateChunked> {
         let utf8_ca = self.as_utf8();
         let fmt = match fmt {
             Some(fmt) => fmt,
             None => return infer::to_date(utf8_ca),
         };
-        let cache = cache && utf8_ca.len() > 50;
+        let use_cache = use_cache && utf8_ca.len() > 50;
         let fmt = strptime::compile_fmt(fmt)?;
-        let mut cache_map = PlHashMap::new();
 
-        // we can use the fast parser
-        let mut ca: Int32Chunked = if let Some(fmt_len) = strptime::fmt_len(fmt.as_bytes()) {
+        // We can use the fast parser.
+        let ca = if let Some(fmt_len) = strptime::fmt_len(fmt.as_bytes()) {
             let mut strptime_cache = StrpTimeState::default();
-            let mut convert = |s: &str| {
-                // Safety:
-                // fmt_len is correct, it was computed with this `fmt` str.
+            let mut convert = CachedFunc::new(|s: &str| {
+                // SAFETY: fmt_len is correct, it was computed with this `fmt` str.
                 match unsafe { strptime_cache.parse(s.as_bytes(), fmt.as_bytes(), fmt_len) } {
-                    // fallback to chrono
+                    // Fallback to chrono.
                     None => NaiveDate::parse_from_str(s, &fmt).ok(),
                     Some(ndt) => Some(ndt.date()),
                 }
                 .map(naive_date_to_date)
-            };
-
-            if utf8_ca.null_count() == 0 {
-                utf8_ca
-                    .into_no_null_iter()
-                    .map(|val| {
-                        if cache {
-                            *cache_map.entry(val).or_insert_with(|| convert(val))
-                        } else {
-                            convert(val)
-                        }
-                    })
-                    .collect_trusted()
-            } else {
-                utf8_ca
-                    .into_iter()
-                    .map(|opt_s| {
-                        opt_s.and_then(|val| {
-                            if cache {
-                                *cache_map.entry(val).or_insert_with(|| convert(val))
-                            } else {
-                                convert(val)
-                            }
-                        })
-                    })
-                    .collect_trusted()
-            }
+            });
+            utf8_ca.apply_generic(|val| convert.eval(val?, use_cache))
         } else {
-            utf8_ca
-                .into_iter()
-                .map(|opt_s| {
-                    opt_s.and_then(|s| {
-                        if cache {
-                            *cache_map.entry(s).or_insert_with(|| {
-                                NaiveDate::parse_from_str(s, &fmt)
-                                    .ok()
-                                    .map(naive_date_to_date)
-                            })
-                        } else {
-                            NaiveDate::parse_from_str(s, &fmt)
-                                .ok()
-                                .map(naive_date_to_date)
-                        }
-                    })
-                })
-                .collect_trusted()
+            let mut convert = CachedFunc::new(|s| {
+                let naive_date = NaiveDate::parse_from_str(s, &fmt).ok()?;
+                Some(naive_date_to_date(naive_date))
+            });
+            utf8_ca.apply_generic(|val| convert.eval(val?, use_cache))
         };
 
-        ca.rename(utf8_ca.name());
-        Ok(ca.into())
+        Ok(ca.with_name(utf8_ca.name()).into())
     }
 
     #[cfg(feature = "dtype-datetime")]
-    /// Parsing string values and return a [`DatetimeChunked`]
+    /// Parsing string values and return a [`DatetimeChunked`].
     fn as_datetime(
         &self,
         fmt: Option<&str>,
         tu: TimeUnit,
-        cache: bool,
+        use_cache: bool,
         tz_aware: bool,
         tz: Option<&TimeZone>,
         ambiguous: &Utf8Chunked,
@@ -390,7 +304,7 @@ pub trait Utf8Methods: AsUtf8 {
             None => return infer::to_datetime(utf8_ca, tu, tz, ambiguous),
         };
         let fmt = strptime::compile_fmt(fmt)?;
-        let cache = cache && utf8_ca.len() > 50;
+        let use_cache = use_cache && utf8_ca.len() > 50;
 
         let func = match tu {
             TimeUnit::Nanoseconds => datetime_to_timestamp_ns,
@@ -401,115 +315,45 @@ pub trait Utf8Methods: AsUtf8 {
         if tz_aware {
             #[cfg(feature = "timezones")]
             {
-                use polars_arrow::export::hashbrown::hash_map::Entry;
-                let mut cache_map = PlHashMap::new();
-
-                let convert = |s: &str| {
-                    DateTime::parse_from_str(s, &fmt)
-                        .ok()
-                        .map(|dt| func(dt.naive_utc()))
-                };
-
-                let mut ca: Int64Chunked = utf8_ca
-                    .into_iter()
-                    .map(|opt_s| {
-                        opt_s
-                            .map(|s| {
-                                let out = if cache {
-                                    match cache_map.entry(s) {
-                                        Entry::Vacant(entry) => {
-                                            let value = convert(s);
-                                            entry.insert(value);
-                                            value
-                                        },
-                                        Entry::Occupied(val) => *val.get(),
-                                    }
-                                } else {
-                                    convert(s)
-                                };
-                                Ok(out)
-                            })
-                            .transpose()
-                            .map(|options| options.flatten())
-                    })
-                    .collect::<PolarsResult<_>>()?;
-
-                ca.rename(utf8_ca.name());
-                Ok(ca.into_datetime(tu, Some("UTC".to_string())))
+                let mut convert = CachedFunc::new(|s: &str| {
+                    let dt = DateTime::parse_from_str(s, &fmt).ok()?;
+                    Some(func(dt.naive_utc()))
+                });
+                Ok(utf8_ca
+                    .apply_generic(|opt_s| convert.eval(opt_s?, use_cache))
+                    .with_name(utf8_ca.name())
+                    .into_datetime(tu, Some("UTC".to_string())))
             }
             #[cfg(not(feature = "timezones"))]
             {
                 panic!("activate 'timezones' feature")
             }
         } else {
-            let mut cache_map = PlHashMap::new();
             let transform = match tu {
                 TimeUnit::Nanoseconds => infer::transform_datetime_ns,
                 TimeUnit::Microseconds => infer::transform_datetime_us,
                 TimeUnit::Milliseconds => infer::transform_datetime_ms,
             };
-            // we can use the fast parser
-            let mut ca: Int64Chunked = if let Some(fmt_len) =
-                self::strptime::fmt_len(fmt.as_bytes())
-            {
+            // We can use the fast parser.
+            let ca = if let Some(fmt_len) = self::strptime::fmt_len(fmt.as_bytes()) {
                 let mut strptime_cache = StrpTimeState::default();
-                let mut convert = |s: &str| {
-                    // Safety:
-                    // fmt_len is correct, it was computed with this `fmt` str.
+                let mut convert = CachedFunc::new(|s: &str| {
+                    // SAFETY: fmt_len is correct, it was computed with this `fmt` str.
                     match unsafe { strptime_cache.parse(s.as_bytes(), fmt.as_bytes(), fmt_len) } {
                         None => transform(s, &fmt),
                         Some(ndt) => Some(func(ndt)),
                     }
-                };
-                if utf8_ca.null_count() == 0 {
-                    utf8_ca
-                        .into_no_null_iter()
-                        .map(|val| {
-                            if cache {
-                                *cache_map.entry(val).or_insert_with(|| convert(val))
-                            } else {
-                                convert(val)
-                            }
-                        })
-                        .collect_trusted()
-                } else {
-                    utf8_ca
-                        .into_iter()
-                        .map(|opt_s| {
-                            opt_s.and_then(|val| {
-                                if cache {
-                                    *cache_map.entry(val).or_insert_with(|| convert(val))
-                                } else {
-                                    convert(val)
-                                }
-                            })
-                        })
-                        .collect_trusted()
-                }
+                });
+                utf8_ca.apply_generic(|opt_s| convert.eval(opt_s?, use_cache))
             } else {
-                let mut cache_map = PlHashMap::new();
-                utf8_ca
-                    .into_iter()
-                    .map(|opt_s| {
-                        opt_s.and_then(|s| {
-                            if cache {
-                                *cache_map.entry(s).or_insert_with(|| transform(s, &fmt))
-                            } else {
-                                transform(s, &fmt)
-                            }
-                        })
-                    })
-                    .collect_trusted()
+                let mut convert = CachedFunc::new(|s| transform(s, &fmt));
+                utf8_ca.apply_generic(|opt_s| convert.eval(opt_s?, use_cache))
             };
-            ca.rename(utf8_ca.name());
+            let dt = ca.with_name(utf8_ca.name()).into_datetime(tu, None);
             match tz {
                 #[cfg(feature = "timezones")]
-                Some(tz) => polars_ops::prelude::replace_time_zone(
-                    &ca.into_datetime(tu, None),
-                    Some(tz),
-                    ambiguous,
-                ),
-                _ => Ok(ca.into_datetime(tu, None)),
+                Some(tz) => polars_ops::prelude::replace_time_zone(&dt, Some(tz), ambiguous),
+                _ => Ok(dt),
             }
         }
     }

--- a/crates/polars-utils/src/cache.rs
+++ b/crates/polars-utils/src/cache.rs
@@ -1,0 +1,31 @@
+use crate::aliases::PlHashMap;
+
+pub struct CachedFunc<T, R, F> {
+    func: F,
+    cache: PlHashMap<T, R>,
+}
+
+impl<T, R, F> CachedFunc<T, R, F>
+where
+    F: FnMut(T) -> R,
+    T: std::hash::Hash + Eq + Clone,
+    R: Copy,
+{
+    pub fn new(func: F) -> Self {
+        Self {
+            func,
+            cache: PlHashMap::with_capacity_and_hasher(0, Default::default()),
+        }
+    }
+
+    pub fn eval(&mut self, x: T, use_cache: bool) -> R {
+        if use_cache {
+            *self
+                .cache
+                .entry(x)
+                .or_insert_with_key(|xr| (self.func)(xr.clone()))
+        } else {
+            (self.func)(x)
+        }
+    }
+}

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 pub mod arena;
 pub mod atomic;
+pub mod cache;
 pub mod cell;
 pub mod contention_pool;
 mod error;


### PR DESCRIPTION
This should not have changed any semantics.

If we find it to be useful somewhere else we can move `CachedFunc` to `utils` or something.