### PR TITLE
fix: repair polars_err string interpolation

### DIFF
--- a/crates/polars-core/src/frame/hash_join/args.rs
+++ b/crates/polars-core/src/frame/hash_join/args.rs
@@ -125,7 +125,7 @@ impl JoinValidation {
         if !self.needs_checks() {
             return Ok(());
         }
-        polars_ensure!(n_keys == 1, ComputeError: "{validation} not yet supported for multiple keys");
+        polars_ensure!(n_keys == 1, ComputeError: "{self} validation on a {join_type} is not yet supported for multiple keys");
         polars_ensure!(matches!(join_type, JoinType::Inner | JoinType::Outer | JoinType::Left),
                       ComputeError: "{self} validation on a {join_type} join is not supported");
         Ok(())

--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -110,14 +110,14 @@ pub fn map_err<E: Error>(error: E) -> PolarsError {
 
 #[macro_export]
 macro_rules! polars_err {
+    ($variant:ident: $fmt:literal $(, $arg:expr)* $(,)?) => {
+        $crate::__private::must_use(
+            $crate::PolarsError::$variant(format!($fmt, $($arg),*).into())
+        )
+    };
     ($variant:ident: $err:expr $(,)?) => {
         $crate::__private::must_use(
             $crate::PolarsError::$variant($err.into())
-        )
-    };
-    ($variant:ident: $fmt:literal, $($arg:tt)+) => {
-        $crate::__private::must_use(
-            $crate::PolarsError::$variant(format!($fmt, $($arg)+).into())
         )
     };
     (expr = $expr:expr, $variant:ident: $err:expr $(,)?) => {

--- a/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -61,7 +61,7 @@ impl PhysicalExpr for AggregationExpr {
                             let out = rename_series(agg_s, &keep_name);
                             return Ok(AggregationContext::new(out, Cow::Borrowed(groups), true))
                         } else {
-                            polars_bail!(ComputeError: "cannot aggregate as {}, the column is already aggregated");
+                            polars_bail!(ComputeError: "cannot aggregate as {}, the column is already aggregated", self.agg_type);
                         }
                     },
                     _ => ()

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -275,7 +275,7 @@ impl SqlExprVisitor<'_> {
                 } else {
                     s.parse::<i64>().map(AnyValue::Int64).map_err(|_| ())
                 }
-                .map_err(|_| polars_err!(ComputeError: "cannot parse literal: {:?}"))?
+                .map_err(|_| polars_err!(ComputeError: "cannot parse literal: {s:?}"))?
             },
             SqlValue::SingleQuotedString(s)
             | SqlValue::NationalStringLiteral(s)


### PR DESCRIPTION
If only supplied a single argument, `polars_err!(Variant: "format string")` would interpret the first argument as an expression, not as a formatting literal. So things like `polars_err!(Variant: "{foo}")` were broken and would simply print `{foo}`.

This fix also uncovered a couple places where the formatting was just broken.