### PR TITLE
docs(python): add a note about `read_database` connection/cursor behaviour

### DIFF
--- a/py-polars/tests/unit/io/test_database_read.py
+++ b/py-polars/tests/unit/io/test_database_read.py
@@ -172,7 +172,7 @@ def test_read_database(
         # other user-supplied connections
         df = pl.read_database(
             connection=engine_or_connection_init(test_db),
-            query="SELECT * FROM test_data",
+            query="SELECT * FROM test_data WHERE name NOT LIKE '%polars%'",
         )
 
     assert df.schema == expected_dtypes


### PR DESCRIPTION
Some additional internal comments about what is being done, and improved internal member naming (`driver_name`, rather than `driver`), and an explicit entry in the `Notes` section to reassure the caller that:

1) If we have to create a temporary cursor we will automatically clean it up.
2) We will _never_ attempt to close/clean-up connections/cursors passed-in to the function.
