### PR TITLE
feat(python): Add syntactic sugar for `col("foo")` -> `col.foo`

### DIFF
--- a/py-polars/docs/source/reference/expressions/col.rst
+++ b/py-polars/docs/source/reference/expressions/col.rst
@@ -11,7 +11,7 @@ See the class documentation below for examples and further documentation.
 -----
 
 .. currentmodule:: polars.functions.col
-.. autoclass:: Column
+.. autoclass:: ColumnFactory
    :members: __call__, __getattr__
    :noindex:
    :autosummary:

--- a/py-polars/docs/source/reference/expressions/col.rst
+++ b/py-polars/docs/source/reference/expressions/col.rst
@@ -1,0 +1,18 @@
+==========
+polars.col
+==========
+
+Create an expression representing column(s) in a dataframe.
+
+``col`` is technically not a function, but it can be used like one.
+
+See the class documentation below for examples and further documentation.
+
+-----
+
+.. currentmodule:: polars.functions.col
+.. autoclass:: Column
+   :members: __call__, __getattr__
+   :noindex:
+   :autosummary:
+   :autosummary-nosignatures:

--- a/py-polars/docs/source/reference/expressions/columns.rst
+++ b/py-polars/docs/source/reference/expressions/columns.rst
@@ -6,10 +6,15 @@ Columns / names
 .. autosummary::
    :toctree: api/
 
-    col
     Expr.alias
     Expr.exclude
     Expr.keep_name
     Expr.map_alias
     Expr.prefix
     Expr.suffix
+
+.. toctree::
+   :maxdepth: 2
+   :hidden:
+
+   col

--- a/py-polars/polars/functions/__init__.py
+++ b/py-polars/polars/functions/__init__.py
@@ -22,6 +22,7 @@ from polars.functions.as_datatype import (
 from polars.functions.as_datatype import date_ as date
 from polars.functions.as_datatype import datetime_ as datetime
 from polars.functions.as_datatype import time_ as time
+from polars.functions.col import col
 from polars.functions.eager import align_frames, concat
 from polars.functions.lazy import (
     apply,
@@ -32,7 +33,6 @@ from polars.functions.lazy import (
     arg_where,
     avg,
     coalesce,
-    col,
     collect_all,
     collect_all_async,
     corr,

--- a/py-polars/polars/functions/col.py
+++ b/py-polars/polars/functions/col.py
@@ -9,182 +9,254 @@ from polars.utils._wrap import wrap_expr
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
 
-
 if TYPE_CHECKING:
     from polars import Expr
     from polars.type_aliases import PolarsDataType
 
+__all__ = ["col"]
 
-def col(
-    name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
-    *more_names: str | PolarsDataType,
-) -> Expr:
+
+class Column:
     """
-    Return an expression representing column(s) in a dataframe.
+    Helper class for creating column expressions.
 
-    Parameters
-    ----------
-    name
-        The name or datatype of the column(s) to represent. Accepts regular expression
-        input. Regular expressions should start with ``^`` and end with ``$``.
-    *more_names
-        Additional names or datatypes of columns to represent, specified as positional
-        arguments.
+    An instance of this class is exported under the name ``col``. It can be used as
+    though it were a function by calling, for example, ``pl.col("foo")``.
+    See the :func:`__call__` method for further documentation.
 
-    Examples
-    --------
-    Pass a single column name to represent that column.
+    This helper class enables an alternative syntax for creating a column expression
+    through attribute lookup. For example ``col.foo`` creates an expression equal to
+    ``col("foo")``.
+    See the :func:`__getattr__` method for further documentation.
 
-    >>> df = pl.DataFrame(
-    ...     {
-    ...         "ham": [1, 2, 3],
-    ...         "hamburger": [11, 22, 33],
-    ...         "foo": [3, 2, 1],
-    ...         "bar": ["a", "b", "c"],
-    ...     }
-    ... )
-    >>> df.select(pl.col("foo"))
-    shape: (3, 1)
-    ┌─────┐
-    │ foo │
-    │ --- │
-    │ i64 │
-    ╞═════╡
-    │ 3   │
-    │ 2   │
-    │ 1   │
-    └─────┘
-
-    Use the wildcard ``*`` to represent all columns.
-
-    >>> df.select(pl.col("*"))
-    shape: (3, 4)
-    ┌─────┬───────────┬─────┬─────┐
-    │ ham ┆ hamburger ┆ foo ┆ bar │
-    │ --- ┆ ---       ┆ --- ┆ --- │
-    │ i64 ┆ i64       ┆ i64 ┆ str │
-    ╞═════╪═══════════╪═════╪═════╡
-    │ 1   ┆ 11        ┆ 3   ┆ a   │
-    │ 2   ┆ 22        ┆ 2   ┆ b   │
-    │ 3   ┆ 33        ┆ 1   ┆ c   │
-    └─────┴───────────┴─────┴─────┘
-    >>> df.select(pl.col("*").exclude("ham"))
-    shape: (3, 3)
-    ┌───────────┬─────┬─────┐
-    │ hamburger ┆ foo ┆ bar │
-    │ ---       ┆ --- ┆ --- │
-    │ i64       ┆ i64 ┆ str │
-    ╞═══════════╪═════╪═════╡
-    │ 11        ┆ 3   ┆ a   │
-    │ 22        ┆ 2   ┆ b   │
-    │ 33        ┆ 1   ┆ c   │
-    └───────────┴─────┴─────┘
-
-    Regular expression input is supported.
-
-    >>> df.select(pl.col("^ham.*$"))
-    shape: (3, 2)
-    ┌─────┬───────────┐
-    │ ham ┆ hamburger │
-    │ --- ┆ ---       │
-    │ i64 ┆ i64       │
-    ╞═════╪═══════════╡
-    │ 1   ┆ 11        │
-    │ 2   ┆ 22        │
-    │ 3   ┆ 33        │
-    └─────┴───────────┘
-
-    Multiple columns can be represented by passing a list of names.
-
-    >>> df.select(pl.col(["hamburger", "foo"]))
-    shape: (3, 2)
-    ┌───────────┬─────┐
-    │ hamburger ┆ foo │
-    │ ---       ┆ --- │
-    │ i64       ┆ i64 │
-    ╞═══════════╪═════╡
-    │ 11        ┆ 3   │
-    │ 22        ┆ 2   │
-    │ 33        ┆ 1   │
-    └───────────┴─────┘
-
-    Or use positional arguments to represent multiple columns in the same way.
-
-    >>> df.select(pl.col("hamburger", "foo"))
-    shape: (3, 2)
-    ┌───────────┬─────┐
-    │ hamburger ┆ foo │
-    │ ---       ┆ --- │
-    │ i64       ┆ i64 │
-    ╞═══════════╪═════╡
-    │ 11        ┆ 3   │
-    │ 22        ┆ 2   │
-    │ 33        ┆ 1   │
-    └───────────┴─────┘
-
-    Easily select all columns that match a certain data type by passing that datatype.
-
-    >>> df.select(pl.col(pl.Utf8))
-    shape: (3, 1)
-    ┌─────┐
-    │ bar │
-    │ --- │
-    │ str │
-    ╞═════╡
-    │ a   │
-    │ b   │
-    │ c   │
-    └─────┘
-    >>> df.select(pl.col(pl.Int64, pl.Float64))
-    shape: (3, 3)
-    ┌─────┬───────────┬─────┐
-    │ ham ┆ hamburger ┆ foo │
-    │ --- ┆ ---       ┆ --- │
-    │ i64 ┆ i64       ┆ i64 │
-    ╞═════╪═══════════╪═════╡
-    │ 1   ┆ 11        ┆ 3   │
-    │ 2   ┆ 22        ┆ 2   │
-    │ 3   ┆ 33        ┆ 1   │
-    └─────┴───────────┴─────┘
+    Notes
+    -----
+    The function call syntax is considered the idiomatic way of constructing a column
+    expression. The alternative attribute syntax can be useful for quick prototyping as
+    it can save some keystrokes, but has drawbacks in both expressiveness and
+    readability.
 
     """
-    if more_names:
+
+    def __call__(
+        self,
+        name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
+        *more_names: str | PolarsDataType,
+    ) -> Expr:
+        """
+        Create a column expression representing column(s) in a dataframe.
+
+        Parameters
+        ----------
+        name
+            The name or datatype of the column(s) to represent.
+            Accepts regular expression input.
+            Regular expressions should start with ``^`` and end with ``$``.
+        *more_names
+            Additional names or datatypes of columns to represent,
+            specified as positional arguments.
+
+        Examples
+        --------
+        Pass a single column name to represent that column.
+
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "ham": [1, 2],
+        ...         "hamburger": [11, 22],
+        ...         "foo": [2, 1],
+        ...         "bar": ["a", "b"],
+        ...     }
+        ... )
+        >>> df.select(pl.col("foo"))
+        shape: (2, 1)
+        ┌─────┐
+        │ foo │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 2   │
+        │ 1   │
+        └─────┘
+
+        Use dot syntax to save keystrokes for quick prototyping.
+
+        >>> from polars import col as c
+        >>> df.select(c.foo + c.ham)
+        shape: (2, 1)
+        ┌─────┐
+        │ foo │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 3   │
+        │ 3   │
+        └─────┘
+
+        Use the wildcard ``*`` to represent all columns.
+
+        >>> df.select(pl.col("*"))
+        shape: (2, 4)
+        ┌─────┬───────────┬─────┬─────┐
+        │ ham ┆ hamburger ┆ foo ┆ bar │
+        │ --- ┆ ---       ┆ --- ┆ --- │
+        │ i64 ┆ i64       ┆ i64 ┆ str │
+        ╞═════╪═══════════╪═════╪═════╡
+        │ 1   ┆ 11        ┆ 2   ┆ a   │
+        │ 2   ┆ 22        ┆ 1   ┆ b   │
+        └─────┴───────────┴─────┴─────┘
+        >>> df.select(pl.col("*").exclude("ham"))
+        shape: (2, 3)
+        ┌───────────┬─────┬─────┐
+        │ hamburger ┆ foo ┆ bar │
+        │ ---       ┆ --- ┆ --- │
+        │ i64       ┆ i64 ┆ str │
+        ╞═══════════╪═════╪═════╡
+        │ 11        ┆ 2   ┆ a   │
+        │ 22        ┆ 1   ┆ b   │
+        └───────────┴─────┴─────┘
+
+        Regular expression input is supported.
+
+        >>> df.select(pl.col("^ham.*$"))
+        shape: (2, 2)
+        ┌─────┬───────────┐
+        │ ham ┆ hamburger │
+        │ --- ┆ ---       │
+        │ i64 ┆ i64       │
+        ╞═════╪═══════════╡
+        │ 1   ┆ 11        │
+        │ 2   ┆ 22        │
+        └─────┴───────────┘
+
+        Multiple columns can be represented by passing a list of names.
+
+        >>> df.select(pl.col(["hamburger", "foo"]))
+        shape: (2, 2)
+        ┌───────────┬─────┐
+        │ hamburger ┆ foo │
+        │ ---       ┆ --- │
+        │ i64       ┆ i64 │
+        ╞═══════════╪═════╡
+        │ 11        ┆ 2   │
+        │ 22        ┆ 1   │
+        └───────────┴─────┘
+
+        Or use positional arguments to represent multiple columns in the same way.
+
+        >>> df.select(pl.col("hamburger", "foo"))
+        shape: (2, 2)
+        ┌───────────┬─────┐
+        │ hamburger ┆ foo │
+        │ ---       ┆ --- │
+        │ i64       ┆ i64 │
+        ╞═══════════╪═════╡
+        │ 11        ┆ 2   │
+        │ 22        ┆ 1   │
+        └───────────┴─────┘
+
+        Easily select all columns that match a certain data type by passing that
+        datatype.
+
+        >>> df.select(pl.col(pl.Utf8))
+        shape: (2, 1)
+        ┌─────┐
+        │ bar │
+        │ --- │
+        │ str │
+        ╞═════╡
+        │ a   │
+        │ b   │
+        └─────┘
+        >>> df.select(pl.col(pl.Int64, pl.Float64))
+        shape: (2, 3)
+        ┌─────┬───────────┬─────┐
+        │ ham ┆ hamburger ┆ foo │
+        │ --- ┆ ---       ┆ --- │
+        │ i64 ┆ i64       ┆ i64 │
+        ╞═════╪═══════════╪═════╡
+        │ 1   ┆ 11        ┆ 2   │
+        │ 2   ┆ 22        ┆ 1   │
+        └─────┴───────────┴─────┘
+
+
+        """
+        if more_names:
+            if isinstance(name, str):
+                names_str = [name]
+                names_str.extend(more_names)  # type: ignore[arg-type]
+                return wrap_expr(plr.cols(names_str))
+            elif is_polars_dtype(name):
+                dtypes = [name]
+                dtypes.extend(more_names)
+                return wrap_expr(plr.dtype_cols(dtypes))
+            else:
+                raise TypeError(
+                    "invalid input for `col`"
+                    f"\n\nExpected `str` or `DataType`, got {type(name).__name__!r}."
+                )
+
         if isinstance(name, str):
-            names_str = [name]
-            names_str.extend(more_names)  # type: ignore[arg-type]
-            return wrap_expr(plr.cols(names_str))
+            return wrap_expr(plr.col(name))
         elif is_polars_dtype(name):
-            dtypes = [name]
-            dtypes.extend(more_names)
-            return wrap_expr(plr.dtype_cols(dtypes))
+            return wrap_expr(plr.dtype_cols([name]))
+        elif isinstance(name, Iterable):
+            names = list(name)
+            if not names:
+                return wrap_expr(plr.cols(names))
+
+            item = names[0]
+            if isinstance(item, str):
+                return wrap_expr(plr.cols(names))
+            elif is_polars_dtype(item):
+                return wrap_expr(plr.dtype_cols(names))
+            else:
+                raise TypeError(
+                    "invalid input for `col`"
+                    "\n\nExpected iterable of type `str` or `DataType`,"
+                    f" got iterable of type {type(item).__name__!r}"
+                )
         else:
             raise TypeError(
                 "invalid input for `col`"
-                f"\n\nExpected `str` or `DataType`, got {type(name).__name__!r}."
+                f"\n\nExpected `str` or `DataType`, got {type(name).__name__!r}"
             )
 
-    if isinstance(name, str):
+    def __getattr__(self, name: str) -> Expr:
+        """
+        Create a column expression using attribute syntax.
+
+        Note that this syntax does not support passing data types or multiple column
+        names.
+
+        Parameters
+        ----------
+        name
+            The name of the column to represent.
+
+        Examples
+        --------
+        >>> from polars import col as c
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "foo": [1, 2],
+        ...         "bar": [3, 4],
+        ...     }
+        ... )
+        >>> df.select(c.foo + c.bar)
+        shape: (2, 1)
+        ┌─────┐
+        │ foo │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 4   │
+        │ 6   │
+        └─────┘
+
+        """
         return wrap_expr(plr.col(name))
-    elif is_polars_dtype(name):
-        return wrap_expr(plr.dtype_cols([name]))
-    elif isinstance(name, Iterable):
-        names = list(name)
-        if not names:
-            return wrap_expr(plr.cols(names))
 
-        item = names[0]
-        if isinstance(item, str):
-            return wrap_expr(plr.cols(names))
-        elif is_polars_dtype(item):
-            return wrap_expr(plr.dtype_cols(names))
-        else:
-            raise TypeError(
-                "invalid input for `col`"
-                "\n\nExpected iterable of type `str` or `DataType`,"
-                f" got iterable of type {type(item).__name__!r}"
-            )
-    else:
-        raise TypeError(
-            "invalid input for `col`"
-            f"\n\nExpected `str` or `DataType`, got {type(name).__name__!r}"
-        )
+
+# Set up a single instance of the class and use it as a column factory
+col = Column()

--- a/py-polars/polars/functions/col.py
+++ b/py-polars/polars/functions/col.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Iterable
+
+from polars.datatypes import is_polars_dtype
+from polars.utils._wrap import wrap_expr
+
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    import polars.polars as plr
+
+
+if TYPE_CHECKING:
+    from polars import Expr
+    from polars.type_aliases import PolarsDataType
+
+
+def col(
+    name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
+    *more_names: str | PolarsDataType,
+) -> Expr:
+    """
+    Return an expression representing column(s) in a dataframe.
+
+    Parameters
+    ----------
+    name
+        The name or datatype of the column(s) to represent. Accepts regular expression
+        input. Regular expressions should start with ``^`` and end with ``$``.
+    *more_names
+        Additional names or datatypes of columns to represent, specified as positional
+        arguments.
+
+    Examples
+    --------
+    Pass a single column name to represent that column.
+
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "ham": [1, 2, 3],
+    ...         "hamburger": [11, 22, 33],
+    ...         "foo": [3, 2, 1],
+    ...         "bar": ["a", "b", "c"],
+    ...     }
+    ... )
+    >>> df.select(pl.col("foo"))
+    shape: (3, 1)
+    ┌─────┐
+    │ foo │
+    │ --- │
+    │ i64 │
+    ╞═════╡
+    │ 3   │
+    │ 2   │
+    │ 1   │
+    └─────┘
+
+    Use the wildcard ``*`` to represent all columns.
+
+    >>> df.select(pl.col("*"))
+    shape: (3, 4)
+    ┌─────┬───────────┬─────┬─────┐
+    │ ham ┆ hamburger ┆ foo ┆ bar │
+    │ --- ┆ ---       ┆ --- ┆ --- │
+    │ i64 ┆ i64       ┆ i64 ┆ str │
+    ╞═════╪═══════════╪═════╪═════╡
+    │ 1   ┆ 11        ┆ 3   ┆ a   │
+    │ 2   ┆ 22        ┆ 2   ┆ b   │
+    │ 3   ┆ 33        ┆ 1   ┆ c   │
+    └─────┴───────────┴─────┴─────┘
+    >>> df.select(pl.col("*").exclude("ham"))
+    shape: (3, 3)
+    ┌───────────┬─────┬─────┐
+    │ hamburger ┆ foo ┆ bar │
+    │ ---       ┆ --- ┆ --- │
+    │ i64       ┆ i64 ┆ str │
+    ╞═══════════╪═════╪═════╡
+    │ 11        ┆ 3   ┆ a   │
+    │ 22        ┆ 2   ┆ b   │
+    │ 33        ┆ 1   ┆ c   │
+    └───────────┴─────┴─────┘
+
+    Regular expression input is supported.
+
+    >>> df.select(pl.col("^ham.*$"))
+    shape: (3, 2)
+    ┌─────┬───────────┐
+    │ ham ┆ hamburger │
+    │ --- ┆ ---       │
+    │ i64 ┆ i64       │
+    ╞═════╪═══════════╡
+    │ 1   ┆ 11        │
+    │ 2   ┆ 22        │
+    │ 3   ┆ 33        │
+    └─────┴───────────┘
+
+    Multiple columns can be represented by passing a list of names.
+
+    >>> df.select(pl.col(["hamburger", "foo"]))
+    shape: (3, 2)
+    ┌───────────┬─────┐
+    │ hamburger ┆ foo │
+    │ ---       ┆ --- │
+    │ i64       ┆ i64 │
+    ╞═══════════╪═════╡
+    │ 11        ┆ 3   │
+    │ 22        ┆ 2   │
+    │ 33        ┆ 1   │
+    └───────────┴─────┘
+
+    Or use positional arguments to represent multiple columns in the same way.
+
+    >>> df.select(pl.col("hamburger", "foo"))
+    shape: (3, 2)
+    ┌───────────┬─────┐
+    │ hamburger ┆ foo │
+    │ ---       ┆ --- │
+    │ i64       ┆ i64 │
+    ╞═══════════╪═════╡
+    │ 11        ┆ 3   │
+    │ 22        ┆ 2   │
+    │ 33        ┆ 1   │
+    └───────────┴─────┘
+
+    Easily select all columns that match a certain data type by passing that datatype.
+
+    >>> df.select(pl.col(pl.Utf8))
+    shape: (3, 1)
+    ┌─────┐
+    │ bar │
+    │ --- │
+    │ str │
+    ╞═════╡
+    │ a   │
+    │ b   │
+    │ c   │
+    └─────┘
+    >>> df.select(pl.col(pl.Int64, pl.Float64))
+    shape: (3, 3)
+    ┌─────┬───────────┬─────┐
+    │ ham ┆ hamburger ┆ foo │
+    │ --- ┆ ---       ┆ --- │
+    │ i64 ┆ i64       ┆ i64 │
+    ╞═════╪═══════════╪═════╡
+    │ 1   ┆ 11        ┆ 3   │
+    │ 2   ┆ 22        ┆ 2   │
+    │ 3   ┆ 33        ┆ 1   │
+    └─────┴───────────┴─────┘
+
+    """
+    if more_names:
+        if isinstance(name, str):
+            names_str = [name]
+            names_str.extend(more_names)  # type: ignore[arg-type]
+            return wrap_expr(plr.cols(names_str))
+        elif is_polars_dtype(name):
+            dtypes = [name]
+            dtypes.extend(more_names)
+            return wrap_expr(plr.dtype_cols(dtypes))
+        else:
+            raise TypeError(
+                "invalid input for `col`"
+                f"\n\nExpected `str` or `DataType`, got {type(name).__name__!r}."
+            )
+
+    if isinstance(name, str):
+        return wrap_expr(plr.col(name))
+    elif is_polars_dtype(name):
+        return wrap_expr(plr.dtype_cols([name]))
+    elif isinstance(name, Iterable):
+        names = list(name)
+        if not names:
+            return wrap_expr(plr.cols(names))
+
+        item = names[0]
+        if isinstance(item, str):
+            return wrap_expr(plr.cols(names))
+        elif is_polars_dtype(item):
+            return wrap_expr(plr.dtype_cols(names))
+        else:
+            raise TypeError(
+                "invalid input for `col`"
+                "\n\nExpected iterable of type `str` or `DataType`,"
+                f" got iterable of type {type(item).__name__!r}"
+            )
+    else:
+        raise TypeError(
+            "invalid input for `col`"
+            f"\n\nExpected `str` or `DataType`, got {type(name).__name__!r}"
+        )

--- a/py-polars/polars/functions/col.py
+++ b/py-polars/polars/functions/col.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 __all__ = ["col"]
 
 
-class Column:
+class ColumnFactory:
     """
     Helper class for creating column expressions.
 
@@ -259,4 +259,4 @@ class Column:
 
 
 # Set up a single instance of the class and use it as a column factory
-col = Column()
+col = ColumnFactory()

--- a/py-polars/tests/unit/functions/test_col.py
+++ b/py-polars/tests/unit/functions/test_col.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import polars as pl
+from polars import col
+from polars.testing import assert_frame_equal
+
+
+def test_col_select() -> None:
+    df = pl.DataFrame(
+        {
+            "ham": [1, 2, 3],
+            "hamburger": [11, 22, 33],
+            "foo": [3, 2, 1],
+            "bar": ["a", "b", "c"],
+        }
+    )
+
+    # Single column
+    assert df.select(pl.col("foo")).columns == ["foo"]
+    # Regex
+    assert df.select(pl.col("*")).columns == ["ham", "hamburger", "foo", "bar"]
+    assert df.select(pl.col("^ham.*$")).columns == ["ham", "hamburger"]
+    assert df.select(pl.col("*").exclude("ham")).columns == ["hamburger", "foo", "bar"]
+    # Multiple inputs
+    assert df.select(pl.col(["hamburger", "foo"])).columns == ["hamburger", "foo"]
+    assert df.select(pl.col("hamburger", "foo")).columns == ["hamburger", "foo"]
+    assert df.select(pl.col(pl.Series(["ham", "foo"]))).columns == ["ham", "foo"]
+    # Dtypes
+    assert df.select(pl.col(pl.Utf8)).columns == ["bar"]
+    assert df.select(pl.col(pl.Int64, pl.Float64)).columns == [
+        "ham",
+        "hamburger",
+        "foo",
+    ]
+
+
+def test_col_series_selection() -> None:
+    ldf = pl.LazyFrame({"a": [1], "b": [1], "c": [1]})
+    srs = pl.Series(["b", "c"])
+
+    assert ldf.select(pl.col(srs)).columns == ["b", "c"]
+
+
+def test_col_dot_style() -> None:
+    df = pl.DataFrame({"lower": 1, "UPPER": 2, "_underscored": 3})
+
+    result = df.select(
+        col.lower,
+        col.UPPER,
+        col._underscored,
+    )
+
+    expected = df.select("lower", "UPPER", "_underscored")
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -34,35 +34,6 @@ def test_arg_true() -> None:
     assert_frame_equal(res, expected)
 
 
-def test_col_select() -> None:
-    df = pl.DataFrame(
-        {
-            "ham": [1, 2, 3],
-            "hamburger": [11, 22, 33],
-            "foo": [3, 2, 1],
-            "bar": ["a", "b", "c"],
-        }
-    )
-
-    # Single column
-    assert df.select(pl.col("foo")).columns == ["foo"]
-    # Regex
-    assert df.select(pl.col("*")).columns == ["ham", "hamburger", "foo", "bar"]
-    assert df.select(pl.col("^ham.*$")).columns == ["ham", "hamburger"]
-    assert df.select(pl.col("*").exclude("ham")).columns == ["hamburger", "foo", "bar"]
-    # Multiple inputs
-    assert df.select(pl.col(["hamburger", "foo"])).columns == ["hamburger", "foo"]
-    assert df.select(pl.col("hamburger", "foo")).columns == ["hamburger", "foo"]
-    assert df.select(pl.col(pl.Series(["ham", "foo"]))).columns == ["ham", "foo"]
-    # Dtypes
-    assert df.select(pl.col(pl.Utf8)).columns == ["bar"]
-    assert df.select(pl.col(pl.Int64, pl.Float64)).columns == [
-        "ham",
-        "hamburger",
-        "foo",
-    ]
-
-
 def test_suffix(fruits_cars: pl.DataFrame) -> None:
     df = fruits_cars
     out = df.select([pl.all().suffix("_reverse")])

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -640,13 +640,6 @@ def test_cast_frame() -> None:
     ]
 
 
-def test_col_series_selection() -> None:
-    ldf = pl.LazyFrame({"a": [1], "b": [1], "c": [1]})
-    srs = pl.Series(["b", "c"])
-
-    assert ldf.select(pl.col(srs)).columns == ["b", "c"]
-
-
 def test_interpolate() -> None:
     df = pl.DataFrame({"a": [1, None, 3]})
     assert df.select(pl.col("a").interpolate())["a"].to_list() == [1, 2, 3]


### PR DESCRIPTION
Closes #10866, closes #7398

#### Changes
* Implement `col` as a factory object rather than a function. It supports `col.foo` as an alias for `col("foo")`.