### PR TITLE
fix(rust, python): fix bug where datetimes were not parsed in read_csv when pattern had no hour or minute

### DIFF
--- a/crates/polars-time/src/chunkedarray/utf8/infer.rs
+++ b/crates/polars-time/src/chunkedarray/utf8/infer.rs
@@ -232,25 +232,29 @@ impl TryFromWithUnit<Pattern> for DatetimeInfer<Int64Type> {
     fn try_from_with_unit(value: Pattern, time_unit: Option<TimeUnit>) -> PolarsResult<Self> {
         let time_unit = time_unit.expect("time_unit must be provided for datetime");
         match (value, time_unit) {
-            (Pattern::DatetimeDMY, TimeUnit::Milliseconds) => Ok(DatetimeInfer {
-                pattern: Pattern::DatetimeDMY,
-                patterns: patterns::DATETIME_D_M_Y,
-                latest_fmt: patterns::DATETIME_D_M_Y[0],
-                transform: transform_datetime_ms,
-                transform_bytes: StrpTimeState::default(),
-                fmt_len: 0,
-                logical_type: DataType::Datetime(TimeUnit::Milliseconds, None),
-            }),
-            (Pattern::DatetimeDMY, TimeUnit::Microseconds) => Ok(DatetimeInfer {
-                pattern: Pattern::DatetimeDMY,
-                patterns: patterns::DATETIME_D_M_Y,
-                latest_fmt: patterns::DATETIME_D_M_Y[0],
-                transform: transform_datetime_us,
-                transform_bytes: StrpTimeState::default(),
-                fmt_len: 0,
-                logical_type: DataType::Datetime(TimeUnit::Microseconds, None),
-            }),
-            (Pattern::DatetimeDMY, TimeUnit::Nanoseconds) => Ok(DatetimeInfer {
+            (Pattern::DatetimeDMY | Pattern::DateDMY, TimeUnit::Milliseconds) => {
+                Ok(DatetimeInfer {
+                    pattern: Pattern::DatetimeDMY,
+                    patterns: patterns::DATETIME_D_M_Y,
+                    latest_fmt: patterns::DATETIME_D_M_Y[0],
+                    transform: transform_datetime_ms,
+                    transform_bytes: StrpTimeState::default(),
+                    fmt_len: 0,
+                    logical_type: DataType::Datetime(TimeUnit::Milliseconds, None),
+                })
+            },
+            (Pattern::DatetimeDMY | Pattern::DateDMY, TimeUnit::Microseconds) => {
+                Ok(DatetimeInfer {
+                    pattern: Pattern::DatetimeDMY,
+                    patterns: patterns::DATETIME_D_M_Y,
+                    latest_fmt: patterns::DATETIME_D_M_Y[0],
+                    transform: transform_datetime_us,
+                    transform_bytes: StrpTimeState::default(),
+                    fmt_len: 0,
+                    logical_type: DataType::Datetime(TimeUnit::Microseconds, None),
+                })
+            },
+            (Pattern::DatetimeDMY | Pattern::DateDMY, TimeUnit::Nanoseconds) => Ok(DatetimeInfer {
                 pattern: Pattern::DatetimeDMY,
                 patterns: patterns::DATETIME_D_M_Y,
                 latest_fmt: patterns::DATETIME_D_M_Y[0],
@@ -259,25 +263,29 @@ impl TryFromWithUnit<Pattern> for DatetimeInfer<Int64Type> {
                 fmt_len: 0,
                 logical_type: DataType::Datetime(TimeUnit::Nanoseconds, None),
             }),
-            (Pattern::DatetimeYMD, TimeUnit::Milliseconds) => Ok(DatetimeInfer {
-                pattern: Pattern::DatetimeYMD,
-                patterns: patterns::DATETIME_Y_M_D,
-                latest_fmt: patterns::DATETIME_Y_M_D[0],
-                transform: transform_datetime_ms,
-                transform_bytes: StrpTimeState::default(),
-                fmt_len: 0,
-                logical_type: DataType::Datetime(TimeUnit::Milliseconds, None),
-            }),
-            (Pattern::DatetimeYMD, TimeUnit::Microseconds) => Ok(DatetimeInfer {
-                pattern: Pattern::DatetimeYMD,
-                patterns: patterns::DATETIME_Y_M_D,
-                latest_fmt: patterns::DATETIME_Y_M_D[0],
-                transform: transform_datetime_us,
-                transform_bytes: StrpTimeState::default(),
-                fmt_len: 0,
-                logical_type: DataType::Datetime(TimeUnit::Microseconds, None),
-            }),
-            (Pattern::DatetimeYMD, TimeUnit::Nanoseconds) => Ok(DatetimeInfer {
+            (Pattern::DatetimeYMD | Pattern::DateYMD, TimeUnit::Milliseconds) => {
+                Ok(DatetimeInfer {
+                    pattern: Pattern::DatetimeYMD,
+                    patterns: patterns::DATETIME_Y_M_D,
+                    latest_fmt: patterns::DATETIME_Y_M_D[0],
+                    transform: transform_datetime_ms,
+                    transform_bytes: StrpTimeState::default(),
+                    fmt_len: 0,
+                    logical_type: DataType::Datetime(TimeUnit::Milliseconds, None),
+                })
+            },
+            (Pattern::DatetimeYMD | Pattern::DateYMD, TimeUnit::Microseconds) => {
+                Ok(DatetimeInfer {
+                    pattern: Pattern::DatetimeYMD,
+                    patterns: patterns::DATETIME_Y_M_D,
+                    latest_fmt: patterns::DATETIME_Y_M_D[0],
+                    transform: transform_datetime_us,
+                    transform_bytes: StrpTimeState::default(),
+                    fmt_len: 0,
+                    logical_type: DataType::Datetime(TimeUnit::Microseconds, None),
+                })
+            },
+            (Pattern::DatetimeYMD | Pattern::DateYMD, TimeUnit::Nanoseconds) => Ok(DatetimeInfer {
                 pattern: Pattern::DatetimeYMD,
                 patterns: patterns::DATETIME_Y_M_D,
                 latest_fmt: patterns::DATETIME_Y_M_D[0],
@@ -313,7 +321,6 @@ impl TryFromWithUnit<Pattern> for DatetimeInfer<Int64Type> {
                 fmt_len: 0,
                 logical_type: DataType::Datetime(TimeUnit::Nanoseconds, None),
             }),
-            _ => polars_bail!(ComputeError: "could not convert pattern"),
         }
     }
 }


### PR DESCRIPTION
this addresses the second half of #10826 (thanks @JulianCologne for the easy-to-reproduce report, this kind of thing is essential for making software better)

doesn't close the issue yet as the first part is unaddressed, will think about that later

Solution:

the pattern was being inferred as `Pattern::DateDMY`, but that wasn't getting matched in
```python
(Pattern::DatetimeDMY, TimeUnit::Milliseconds)
```
, even though `Datetime` can handle such patterns.
So, I just did
```diff
- (Pattern::DatetimeDMY, TimeUnit::Milliseconds)
+ (Pattern::DatetimeDMY | Pattern::DateDMY, TimeUnit::Milliseconds)
```
and similarly for the other arms

---

Note: this one's easier to review hiding whitespace: https://github.com/pola-rs/polars/pull/10877/files?diff=unified&w=1