### PR TITLE
chore: request verbose logging output of minimal reproducable examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_python.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_python.yml
@@ -64,3 +64,20 @@ body:
         </details>
     validations:
       required: true
+
+  - type: textarea
+    id: version
+    attributes:
+      label: Log output
+      description: >
+        Set ``POLARS_VERBOSE=1`` environment before running the query. Paste the output of ``stderr`` here.
+      value: |
+        <details>
+
+        ```
+        Replace this line with the output of ``stderr``. Leave the backticks in place.
+        ```
+
+        </details>
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report_rust.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_rust.yml
@@ -62,3 +62,20 @@ body:
         </details>
     validations:
       required: true
+
+  - type: textarea
+    id: version
+    attributes:
+      label: Log output
+      description: >
+        Set ``POLARS_VERBOSE=1`` environment before running the query. Paste the output of ``stderr`` here.
+      value: |
+        <details>
+
+        ```
+        Replace this line with the output of ``stderr``. Leave the backticks in place.
+        ```
+
+        </details>
+    validations:
+      required: true


### PR DESCRIPTION
I often spend several triage iterations requesting for logs. If we ask those immediately, this croudsources the work we have to do and often can given an immediate idea of what is going on.