### PR TITLE
feat(python): support schema overrides for frames created from databases

### DIFF
--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -253,6 +253,7 @@ class ConnectionExecutor:
 def read_database(  # noqa: D417
     query: str,
     connection: ConnectionOrCursor,
+    *,
     batch_size: int | None = None,
     schema_overrides: SchemaDict | None = None,
     **kwargs: Any,
@@ -286,6 +287,13 @@ def read_database(  # noqa: D417
       backend supports returning Arrow data directly then this facility will be used to
       efficiently instantiate the DataFrame; otherwise, the DataFrame is initialised
       from row-wise data.
+
+    * The ``read_connection_uri`` function is likely to be noticeably faster than
+      ``read_database`` if you are using a SQLAlchemy or DBAPI2 connection, as
+      ``connectorx`` will optimise translation of the result data into Arrow format
+      in Rust, whereas these libraries will return row-wise data to Python. Note that
+      you can easily determine the connection's URI from a SQLAlchemy engine object by
+      calling ``str(conn.engine.url)``.
 
     * If polars has to create a cursor from your connection in order to execute the
       query then that cursor will be automatically closed when the query completes;

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
     from polars import DataFrame
     from polars.dependencies import pyarrow as pa
-    from polars.type_aliases import ConnectionOrCursor, Cursor, DbReadEngine
+    from polars.type_aliases import ConnectionOrCursor, Cursor, DbReadEngine, SchemaDict
 
 
 class _DriverProperties_(TypedDict):
@@ -151,7 +151,9 @@ class ConnectionExecutor:
             else:
                 yield from rows
 
-    def _from_arrow(self, batch_size: int | None) -> DataFrame | None:
+    def _from_arrow(
+        self, batch_size: int | None, schema_overrides: SchemaDict | None
+    ) -> DataFrame | None:
         """Return resultset data in Arrow format for frame init."""
         from polars import DataFrame
 
@@ -160,18 +162,26 @@ class ConnectionExecutor:
                 size = batch_size if driver_properties["exact_batch_size"] else None
                 fetch_batches = driver_properties["fetch_batches"]
                 return DataFrame(
-                    self._fetch_arrow(self.result, fetch_batches, size)
-                    if batch_size and fetch_batches is not None
-                    else getattr(self.result, driver_properties["fetch_all"])()
+                    data=(
+                        self._fetch_arrow(self.result, fetch_batches, size)
+                        if batch_size and fetch_batches is not None
+                        else getattr(self.result, driver_properties["fetch_all"])()
+                    ),
+                    schema_overrides=schema_overrides,
                 )
 
         if self.driver_name == "duckdb":
             exec_kwargs = {"rows_per_batch": batch_size} if batch_size else {}
-            return DataFrame(self.result.arrow(**exec_kwargs))
+            return DataFrame(
+                self.result.arrow(**exec_kwargs),
+                schema_overrides=schema_overrides,
+            )
 
         return None
 
-    def _from_rows(self, batch_size: int | None) -> DataFrame | None:
+    def _from_rows(
+        self, batch_size: int | None, schema_overrides: SchemaDict | None
+    ) -> DataFrame | None:
         """Return resultset data row-wise for frame init."""
         from polars import DataFrame
 
@@ -189,6 +199,7 @@ class ConnectionExecutor:
                     else self._fetchmany_rows(self.result, batch_size)
                 ),
                 schema=column_names,
+                schema_overrides=schema_overrides,
                 orient="row",
             )
         return None
@@ -213,7 +224,9 @@ class ConnectionExecutor:
         self.result = result
         return self
 
-    def to_frame(self, batch_size: int | None = None) -> DataFrame:
+    def to_frame(
+        self, batch_size: int | None = None, schema_overrides: SchemaDict | None = None
+    ) -> DataFrame:
         """
         Convert the result set to a DataFrame.
 
@@ -227,7 +240,7 @@ class ConnectionExecutor:
             self._from_arrow,  # init from arrow-native data (most efficient option)
             self._from_rows,  # row-wise fallback covering sqlalchemy, dbapi2, pyodbc
         ):
-            frame = frame_init(batch_size)
+            frame = frame_init(batch_size=batch_size, schema_overrides=schema_overrides)
             if frame is not None:
                 return frame
 
@@ -241,6 +254,7 @@ def read_database(  # noqa: D417
     query: str,
     connection: ConnectionOrCursor,
     batch_size: int | None = None,
+    schema_overrides: SchemaDict | None = None,
     **kwargs: Any,
 ) -> DataFrame:
     """
@@ -257,6 +271,12 @@ def read_database(  # noqa: D417
         The number of rows to fetch each time as data is collected; if this option is
         supported by the backend it will be passed to the underlying query execution
         method (if the backend does not have such support it is ignored without error).
+    schema_overrides
+        A dictionary mapping column names to dtypes, used to override the schema
+        inferred from the query cursor or given by the incoming Arrow data (depending
+        on driver/backend). This can be useful if the given types can be more precisely
+        defined (for example, if you know that a given column can be declared as `u32`
+        instead of `i64`).
 
     Notes
     -----
@@ -281,7 +301,8 @@ def read_database(  # noqa: D417
 
     >>> df = pl.read_database(
     ...     query="SELECT * FROM test_data",
-    ...     connection=conn,
+    ...     connection=user_conn,
+    ...     schema_overrides={"normalised_score": pl.UInt8},
     ... )  # doctest: +SKIP
 
     """
@@ -290,14 +311,19 @@ def read_database(  # noqa: D417
             message="Use of a string URI with 'read_database' is deprecated; use 'read_database_uri' instead",
             version="0.19.0",
         )
-        return read_database_uri(query, uri=connection, **kwargs)
+        return read_database_uri(
+            query, uri=connection, schema_overrides=schema_overrides, **kwargs
+        )
     elif kwargs:
         raise ValueError(
             f"`read_database` **kwargs only exist for deprecating string URIs: found {kwargs!r}"
         )
 
     with ConnectionExecutor(connection) as cx:
-        return cx.execute(query).to_frame(batch_size)
+        return cx.execute(query).to_frame(
+            batch_size=batch_size,
+            schema_overrides=schema_overrides,
+        )
 
 
 def read_database_uri(
@@ -309,6 +335,7 @@ def read_database_uri(
     partition_num: int | None = None,
     protocol: str | None = None,
     engine: DbReadEngine | None = None,
+    schema_overrides: SchemaDict | None = None,
 ) -> DataFrame:
     """
     Read the results of a SQL query into a DataFrame, given a URI.
@@ -348,10 +375,13 @@ def read_database_uri(
           an up-to-date list of drivers please see the ADBC docs:
 
           * https://arrow.apache.org/adbc/
+    schema_overrides
+        A dictionary mapping column names to dtypes, used to override the schema
+        given in the data returned by the query.
 
     Notes
     -----
-    For ``connectorx``, ensure that you have ``connectorx>=0.3.1``. The documentation
+    For ``connectorx``, ensure that you have ``connectorx>=0.3.2``. The documentation
     is available `here <https://sfu-db.github.io/connector-x/intro.html>`_.
 
     For ``adbc`` you will need to have installed ``pyarrow`` and the ADBC driver associated
@@ -416,11 +446,12 @@ def read_database_uri(
             partition_range=partition_range,
             partition_num=partition_num,
             protocol=protocol,
+            schema_overrides=schema_overrides,
         )
     elif engine == "adbc":
         if not isinstance(query, str):
             raise ValueError("only a single SQL query string is accepted for adbc")
-        return _read_sql_adbc(query, uri)
+        return _read_sql_adbc(query, uri, schema_overrides)
     else:
         raise ValueError(
             f"engine must be one of {{'connectorx', 'adbc'}}, got {engine!r}"
@@ -434,6 +465,7 @@ def _read_sql_connectorx(
     partition_range: tuple[int, int] | None = None,
     partition_num: int | None = None,
     protocol: str | None = None,
+    schema_overrides: SchemaDict | None = None,
 ) -> DataFrame:
     try:
         import connectorx as cx
@@ -452,14 +484,16 @@ def _read_sql_connectorx(
         partition_num=partition_num,
         protocol=protocol,
     )
-    return from_arrow(tbl)  # type: ignore[return-value]
+    return from_arrow(tbl, schema_overrides=schema_overrides)  # type: ignore[return-value]
 
 
-def _read_sql_adbc(query: str, connection_uri: str) -> DataFrame:
+def _read_sql_adbc(
+    query: str, connection_uri: str, schema_overrides: SchemaDict | None
+) -> DataFrame:
     with _open_adbc_connection(connection_uri) as conn, conn.cursor() as cursor:
         cursor.execute(query)
         tbl = cursor.fetch_arrow_table()
-    return from_arrow(tbl)  # type: ignore[return-value]
+    return from_arrow(tbl, schema_overrides=schema_overrides)  # type: ignore[return-value]
 
 
 def _open_adbc_connection(connection_uri: str) -> Any:

--- a/py-polars/tests/unit/io/test_database_read.py
+++ b/py-polars/tests/unit/io/test_database_read.py
@@ -175,16 +175,22 @@ def test_read_database(
             uri=f"sqlite:///{test_db}",
             query="SELECT * FROM test_data",
             engine=str(engine_or_connection_init),  # type: ignore[arg-type]
+            schema_overrides=schema_overrides,
         )
     elif "adbc" in os.environ["PYTEST_CURRENT_TEST"]:
         # externally instantiated adbc connections
         with engine_or_connection_init(test_db) as conn, conn.cursor():
-            df = pl.read_database(connection=conn, query="SELECT * FROM test_data")
+            df = pl.read_database(
+                connection=conn,
+                query="SELECT * FROM test_data",
+                schema_overrides=schema_overrides,
+            )
     else:
         # other user-supplied connections
         df = pl.read_database(
             connection=engine_or_connection_init(test_db),
             query="SELECT * FROM test_data WHERE name NOT LIKE '%polars%'",
+            schema_overrides=schema_overrides,
         )
 
     assert df.schema == expected_dtypes

--- a/py-polars/tests/unit/io/test_database_read.py
+++ b/py-polars/tests/unit/io/test_database_read.py
@@ -15,7 +15,7 @@ import polars as pl
 from polars.exceptions import UnsuitableSQLError
 
 if TYPE_CHECKING:
-    from polars.type_aliases import DbReadEngine
+    from polars.type_aliases import DbReadEngine, SchemaDict
 
 
 def adbc_sqlite_connect(*args: Any, **kwargs: Any) -> Any:
@@ -71,30 +71,38 @@ def create_temp_sqlite_db(test_db: str) -> None:
 
 @pytest.mark.write_disk()
 @pytest.mark.parametrize(
-    ("read_method", "engine_or_connection_init", "expected_dtypes", "expected_dates"),
+    (
+        "read_method",
+        "engine_or_connection_init",
+        "expected_dtypes",
+        "expected_dates",
+        "schema_overrides",
+    ),
     [
         pytest.param(
             "read_database_uri",
             "connectorx",
             {
-                "id": pl.Int64,
+                "id": pl.UInt8,
                 "name": pl.Utf8,
                 "value": pl.Float64,
                 "date": pl.Date,
             },
             [date(2020, 1, 1), date(2021, 12, 31)],
+            {"id": pl.UInt8},
             id="uri: connectorx",
         ),
         pytest.param(
             "read_database_uri",
             "adbc",
             {
-                "id": pl.Int64,
+                "id": pl.UInt8,
                 "name": pl.Utf8,
                 "value": pl.Float64,
                 "date": pl.Utf8,
             },
             ["2020-01-01", "2021-12-31"],
+            {"id": pl.UInt8},
             marks=pytest.mark.skipif(
                 sys.version_info < (3, 9) or sys.platform == "win32",
                 reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
@@ -105,12 +113,13 @@ def create_temp_sqlite_db(test_db: str) -> None:
             "read_database",
             lambda path: sqlite3.connect(path, detect_types=True),
             {
-                "id": pl.Int64,
+                "id": pl.UInt8,
                 "name": pl.Utf8,
-                "value": pl.Float64,
+                "value": pl.Float32,
                 "date": pl.Date,
             },
             [date(2020, 1, 1), date(2021, 12, 31)],
+            {"id": pl.UInt8, "value": pl.Float32},
             id="conn: sqlite3",
         ),
         pytest.param(
@@ -126,6 +135,7 @@ def create_temp_sqlite_db(test_db: str) -> None:
                 "date": pl.Date,
             },
             [date(2020, 1, 1), date(2021, 12, 31)],
+            None,
             id="conn: sqlalchemy",
         ),
         pytest.param(
@@ -138,6 +148,7 @@ def create_temp_sqlite_db(test_db: str) -> None:
                 "date": pl.Utf8,
             },
             ["2020-01-01", "2021-12-31"],
+            None,
             marks=pytest.mark.skipif(
                 sys.version_info < (3, 9) or sys.platform == "win32",
                 reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
@@ -151,6 +162,7 @@ def test_read_database(
     engine_or_connection_init: Any,
     expected_dtypes: dict[str, pl.DataType],
     expected_dates: list[date | str],
+    schema_overrides: SchemaDict | None,
     tmp_path: Path,
 ) -> None:
     tmp_path.mkdir(exist_ok=True)


### PR DESCRIPTION
Covers both `read_database` and `read_database_uri`. 

Database return types can often be overly broad; this allows individual column dtypes to be specified more exactly where those dtypes are better-known by the caller.

Also: added a performance note to the docs (prefer loading from URI if you have a sqlalchemy/dbapi2 connection and the backend is supported by `connectorx`).

## Example
Setup:
```python
import sqlite3
conn = sqlite3.connect("test.db")
conn.executescript(
    """
    CREATE TABLE test_data (id INTEGER PRIMARY KEY, name TEXT NOT NULL, value FLOAT);
    INSERT INTO test_data(name,value) VALUES ('misc',100.0), ('other',-99.5);
    """
)
```
Sample queries:
```python
pl.read_database(
    connection=conn,
    query="SELECT * FROM test_data",
)
# shape: (2, 3)
# ┌─────┬───────┬───────┐
# │ id  ┆ name  ┆ value │
# │ --- ┆ ---   ┆ ---   │
# │ i64 ┆ str   ┆ f64   │  << default dtypes
# ╞═════╪═══════╪═══════╡
# │ 1   ┆ misc  ┆ 100.0 │
# │ 2   ┆ other ┆ -99.5 │
# └─────┴───────┴───────┘

pl.read_database(
    connection=conn,
    query="SELECT * FROM test_data",
    schema_overrides={"id": pl.UInt8, "value":pl.Float32},
)
# shape: (2, 3)
# ┌─────┬───────┬───────┐
# │ id  ┆ name  ┆ value │
# │ --- ┆ ---   ┆ ---   │
# │ u8  ┆ str   ┆ f32   │  << more specific dtypes
# ╞═════╪═══════╪═══════╡
# │ 1   ┆ misc  ┆ 100.0 │
# │ 2   ┆ other ┆ -99.5 │
# └─────┴───────┴───────┘
```