### PR TITLE
fix(rust): Retain original dtype when deserializing an empty list

### DIFF
--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -4,6 +4,7 @@ use std::fmt::Formatter;
 use serde::de::{MapAccess, Visitor};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
+use crate::chunked_array::builder::AnonymousListBuilder;
 use crate::chunked_array::Settings;
 use crate::prelude::*;
 
@@ -202,16 +203,15 @@ impl<'de> Deserialize<'de> for Series {
                         let values: Vec<Option<Cow<str>>> = map.next_value()?;
                         Ok(Series::new(&name, values))
                     },
-                    DataType::List(_) => {
+                    DataType::List(inner) => {
                         let values: Vec<Option<Series>> = map.next_value()?;
-                        // retain dtype information in case of no actual values
-                        if values.is_empty() {
-                            Ok(Series::new_empty(&name, &dtype))
-                        } else if values.iter().all(|s| s.is_none()) {
-                            Ok(Series::full_null(&name, values.len(), &dtype))
-                        } else {
-                            Ok(Series::new(&name, values))
+                        let mut lb = AnonymousListBuilder::new(&name, values.len(), Some(*inner));
+                        for value in &values {
+                            lb.append_opt_series(value.as_ref()).map_err(|e| {
+                                de::Error::custom(format!("could not append series to list: {e}"))
+                            })?;
                         }
+                        Ok(lb.finish().into_series())
                     },
                     DataType::Binary => {
                         let values: Vec<Option<Cow<[u8]>>> = map.next_value()?;

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -204,8 +204,11 @@ impl<'de> Deserialize<'de> for Series {
                     },
                     DataType::List(_) => {
                         let values: Vec<Option<Series>> = map.next_value()?;
+                        // retain dtype information in case of no actual values
                         if values.is_empty() {
                             Ok(Series::new_empty(&name, &dtype))
+                        } else if values.iter().all(|s| s.is_none()) {
+                            Ok(Series::full_null(&name, values.len(), &dtype))
                         } else {
                             Ok(Series::new(&name, values))
                         }

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -190,3 +190,8 @@ def test_serde_categorical_series_10586() -> None:
     s = pl.Series(["a", "b", "b", "a", "c"], dtype=pl.Categorical)
     loaded_s = pickle.loads(pickle.dumps(s))
     assert_series_equal(loaded_s, s)
+
+
+def test_serde_keep_dtype_empty_list() -> None:
+    s = pl.Series([{"a": None}], dtype=pl.Struct([pl.Field("a", pl.List(pl.Utf8))]))
+    assert s.dtype == pickle.loads(pickle.dumps(s)).dtype


### PR DESCRIPTION
fix #10781 