### PR TITLE
docs(python): fix rendering of bullet points in dt.round

### DIFF
--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -67,17 +67,17 @@ class ExprDateTimeNameSpace:
         The ``every`` and ``offset`` argument are created with the
         the following string language:
 
-        - 1ns # 1 nanosecond
-        - 1us # 1 microsecond
-        - 1ms # 1 millisecond
-        - 1s  # 1 second
-        - 1m  # 1 minute
-        - 1h  # 1 hour
-        - 1d  # 1 calendar day
-        - 1w  # 1 calendar week
-        - 1mo # 1 calendar month
-        - 1q  # 1 calendar quarter
-        - 1y  # 1 calendar year
+        - 1ns   (1 nanosecond)
+        - 1us   (1 microsecond)
+        - 1ms   (1 millisecond)
+        - 1s    (1 second)
+        - 1m    (1 minute)
+        - 1h    (1 hour)
+        - 1d    (1 calendar day)
+        - 1w    (1 calendar week)
+        - 1mo   (1 calendar month)
+        - 1q    (1 calendar quarter)
+        - 1y    (1 calendar year)
 
         These strings can be combined:
 
@@ -254,17 +254,17 @@ class ExprDateTimeNameSpace:
         The `every` and `offset` argument are created with the
         the following small string formatting language:
 
-        1ns  # 1 nanosecond
-        1us  # 1 microsecond
-        1ms  # 1 millisecond
-        1s   # 1 second
-        1m   # 1 minute
-        1h   # 1 hour
-        1d   # 1 calendar day
-        1w   # 1 calendar week
-        1mo  # 1 calendar month
-        1q   # 1 calendar quarter
-        1y   # 1 calendar year
+        - 1ns   (1 nanosecond)
+        - 1us   (1 microsecond)
+        - 1ms   (1 millisecond)
+        - 1s    (1 second)
+        - 1m    (1 minute)
+        - 1h    (1 hour)
+        - 1d    (1 calendar day)
+        - 1w    (1 calendar week)
+        - 1mo   (1 calendar month)
+        - 1q    (1 calendar quarter)
+        - 1y    (1 calendar year)
 
         eg: 3d12h4m25s  # 3 days, 12 hours, 4 minutes, and 25 seconds
 

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1633,17 +1633,17 @@ class DateTimeNameSpace:
         The ``every`` and ``offset`` argument are created with the
         the following string language:
 
-        - 1ns # 1 nanosecond
-        - 1us # 1 microsecond
-        - 1ms # 1 millisecond
-        - 1s  # 1 second
-        - 1m  # 1 minute
-        - 1h  # 1 hour
-        - 1d  # 1 calendar day
-        - 1w  # 1 calendar week
-        - 1mo # 1 calendar month
-        - 1q  # 1 calendar quarter
-        - 1y  # 1 calendar year
+        - 1ns   (1 nanosecond)
+        - 1us   (1 microsecond)
+        - 1ms   (1 millisecond)
+        - 1s    (1 second)
+        - 1m    (1 minute)
+        - 1h    (1 hour)
+        - 1d    (1 calendar day)
+        - 1w    (1 calendar week)
+        - 1mo   (1 calendar month)
+        - 1q    (1 calendar quarter)
+        - 1y    (1 calendar year)
 
         These strings can be combined:
 
@@ -1788,17 +1788,17 @@ class DateTimeNameSpace:
         The `every` and `offset` argument are created with the
         the following string language:
 
-        - 1ns # 1 nanosecond
-        - 1us # 1 microsecond
-        - 1ms # 1 millisecond
-        - 1s  # 1 second
-        - 1m  # 1 minute
-        - 1h  # 1 hour
-        - 1d  # 1 calendar day
-        - 1w  # 1 calendar week
-        - 1mo # 1 calendar month
-        - 1q  # 1 calendar quarter
-        - 1y  # 1 calendar year
+        - 1ns   (1 nanosecond)
+        - 1us   (1 microsecond)
+        - 1ms   (1 millisecond)
+        - 1s    (1 second)
+        - 1m    (1 minute)
+        - 1h    (1 hour)
+        - 1d    (1 calendar day)
+        - 1w    (1 calendar week)
+        - 1mo   (1 calendar month)
+        - 1q    (1 calendar quarter)
+        - 1y    (1 calendar year)
 
         These strings can be combined:
 


### PR DESCRIPTION
These bullet points don't render at the moment: https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.Expr.dt.round.html#polars.Expr.dt.round

So, updating them (and updating the formatting of the string language to be consistent with how it is in other docstrings)