### PR TITLE
feat(python): better async_collect

### DIFF
--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -11,13 +11,13 @@ from typing import TYPE_CHECKING, Any, ClassVar, Hashable, cast
 _DATAFRAME_API_COMPAT_AVAILABLE = True
 _DELTALAKE_AVAILABLE = True
 _FSSPEC_AVAILABLE = True
+_GEVENT_AVAILABLE = True
 _HYPOTHESIS_AVAILABLE = True
 _NUMPY_AVAILABLE = True
 _PANDAS_AVAILABLE = True
 _PYARROW_AVAILABLE = True
 _PYDANTIC_AVAILABLE = True
 _ZONEINFO_AVAILABLE = True
-_GEVENT_AVAILABLE = True
 
 
 class _LazyModule(ModuleType):
@@ -231,12 +231,12 @@ __all__ = [
     "dataframe_api_compat",
     "deltalake",
     "fsspec",
+    "gevent",
     "numpy",
     "pandas",
     "pydantic",
     "pyarrow",
     "zoneinfo",
-    "gevent",
     # lazy utilities
     "_check_for_numpy",
     "_check_for_pandas",
@@ -246,10 +246,10 @@ __all__ = [
     # exported flags/guards
     "_DELTALAKE_AVAILABLE",
     "_FSSPEC_AVAILABLE",
+    "_GEVENT_AVAILABLE",
     "_HYPOTHESIS_AVAILABLE",
     "_NUMPY_AVAILABLE",
     "_PANDAS_AVAILABLE",
     "_PYARROW_AVAILABLE",
     "_ZONEINFO_AVAILABLE",
-    "_GEVENT_AVAILABLE",
 ]

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -17,6 +17,7 @@ _PANDAS_AVAILABLE = True
 _PYARROW_AVAILABLE = True
 _PYDANTIC_AVAILABLE = True
 _ZONEINFO_AVAILABLE = True
+_GEVENT_AVAILABLE = True
 
 
 class _LazyModule(ModuleType):
@@ -155,6 +156,7 @@ if TYPE_CHECKING:
     import dataframe_api_compat
     import deltalake
     import fsspec
+    import gevent
     import hypothesis
     import numpy
     import pandas
@@ -189,6 +191,7 @@ else:
         if sys.version_info >= (3, 9)
         else _lazy_import("backports.zoneinfo")
     )
+    gevent, _GEVENT_AVAILABLE = _lazy_import("gevent")
 
 
 @lru_cache(maxsize=None)
@@ -233,6 +236,7 @@ __all__ = [
     "pydantic",
     "pyarrow",
     "zoneinfo",
+    "gevent",
     # lazy utilities
     "_check_for_numpy",
     "_check_for_pandas",
@@ -247,4 +251,5 @@ __all__ = [
     "_PANDAS_AVAILABLE",
     "_PYARROW_AVAILABLE",
     "_ZONEINFO_AVAILABLE",
+    "_GEVENT_AVAILABLE",
 ]

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1711,6 +1711,31 @@ def collect_all_async(
     May be useful if you use gevent or asyncio and want to release control to other
     greenlets/tasks while LazyFrames are being collected.
 
+    Parameters
+    ----------
+    lazy_frames
+        A list of LazyFrames to collect.
+    gevent
+        Return wrapper to `gevent.event.AsyncResult` instead of Awaitable
+    type_coercion
+        Do type coercion optimization.
+    predicate_pushdown
+        Do predicate pushdown optimization.
+    projection_pushdown
+        Do projection pushdown optimization.
+    simplify_expression
+        Run simplify expressions optimization.
+    no_optimization
+        Turn off (certain) optimizations.
+    slice_pushdown
+        Slice pushdown optimization.
+    comm_subplan_elim
+        Will try to cache branching subplans that occur on self-joins or unions.
+    comm_subexpr_elim
+        Common subexpressions will be cached and reused.
+    streaming
+        Run parts of the query in a streaming fashion (this is in an alpha state)
+
     Notes
     -----
     In case of error `set_exception` is used on

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -23,8 +23,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable
-    from typing import Collection, Literal
+    from typing import Awaitable, Collection, Literal
 
     from polars import DataFrame, Expr, LazyFrame, Series
     from polars.type_aliases import (

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, overload
 import polars._reexport as pl
 import polars.functions as F
 from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Datetime, Int64
-from polars.utils._async import _AsyncDataFrameResult
+from polars.utils._async import _AioDataFrameResult, _GeventDataFrameResult
 from polars.utils._parse_expr_input import (
     parse_as_expression,
     parse_as_list_of_expressions,
@@ -23,7 +23,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 
 if TYPE_CHECKING:
-    from queue import Queue
+    from collections.abc import Awaitable
     from typing import Collection, Literal
 
     from polars import DataFrame, Expr, LazyFrame, Series
@@ -1652,10 +1652,29 @@ def collect_all(
     return result
 
 
+@overload
 def collect_all_async(
     lazy_frames: Sequence[LazyFrame],
-    queue: Queue[list[DataFrame] | Exception],
     *,
+    gevent: Literal[True],
+    type_coercion: bool = True,
+    predicate_pushdown: bool = True,
+    projection_pushdown: bool = True,
+    simplify_expression: bool = True,
+    no_optimization: bool = True,
+    slice_pushdown: bool = True,
+    comm_subplan_elim: bool = True,
+    comm_subexpr_elim: bool = True,
+    streaming: bool = True,
+) -> _GeventDataFrameResult[list[DataFrame]]:
+    ...
+
+
+@overload
+def collect_all_async(
+    lazy_frames: Sequence[LazyFrame],
+    *,
+    gevent: Literal[False] = False,
     type_coercion: bool = True,
     predicate_pushdown: bool = True,
     projection_pushdown: bool = True,
@@ -1665,33 +1684,38 @@ def collect_all_async(
     comm_subplan_elim: bool = True,
     comm_subexpr_elim: bool = True,
     streaming: bool = False,
-) -> _AsyncDataFrameResult[list[DataFrame]]:
+) -> Awaitable[list[DataFrame]]:
+    ...
+
+
+def collect_all_async(
+    lazy_frames: Sequence[LazyFrame],
+    *,
+    gevent: bool = False,
+    type_coercion: bool = True,
+    predicate_pushdown: bool = True,
+    projection_pushdown: bool = True,
+    simplify_expression: bool = True,
+    no_optimization: bool = False,
+    slice_pushdown: bool = True,
+    comm_subplan_elim: bool = True,
+    comm_subexpr_elim: bool = True,
+    streaming: bool = False,
+) -> Awaitable[list[DataFrame]] | _GeventDataFrameResult[list[DataFrame]]:
     """
     Collect multiple LazyFrames at the same time asynchronously in thread pool.
 
     Collects into a list of DataFrame, like :func:`polars.collect_all`
-    but instead of returning them directly its collected inside thread pool
-    and gets put into `queue` with `put_nowait` method,
-    while this method returns almost instantly.
+    but instead of returning them directly they are scheduled to be collected
+    inside thread pool, while this method returns almost instantly.
 
     May be useful if you use gevent or asyncio and want to release control to other
     greenlets/tasks while LazyFrames are being collected.
-    You must use correct queue in that case.
-    Given `queue` must be thread safe!
-
-    For gevent use
-    [`gevent.queue.Queue`](https://www.gevent.org/api/gevent.queue.html#gevent.queue.Queue).
-
-    For asyncio
-    [`asyncio.queues.Queue`](https://docs.python.org/3/library/asyncio-queue.html#queue)
-    can not be used, since it's not thread safe!
-    For that purpose use [janus](https://github.com/aio-libs/janus) library.
 
     Notes
     -----
-    Results are put in queue exactly once using `put_nowait`.
-    If error occurred then Exception will be put in the queue instead of result
-    which is then raised by returned wrapper `get` method.
+    In case of error `set_exception` is used on
+    `asyncio.Future`/`gevent.event.AsyncResult` and will be reraised by them.
 
     Warnings
     --------
@@ -1705,8 +1729,10 @@ def collect_all_async(
 
     Returns
     -------
-    Wrapper that has `get` method and `queue` attribute with given queue.
-    `get` accepts kwargs that are passed down to `queue.get`.
+    If `gevent=False` (default) then returns awaitable.
+
+    If `gevent=True` then returns wrapper that has
+    `.get(block=True, timeout=None)` method.
     """
     if no_optimization:
         predicate_pushdown = False
@@ -1731,9 +1757,9 @@ def collect_all_async(
         )
         prepared.append(ldf)
 
-    result = _AsyncDataFrameResult(queue)
-    plr.collect_all_with_callback(prepared, result._callback_all)
-    return result
+    result = _GeventDataFrameResult() if gevent else _AioDataFrameResult()
+    plr.collect_all_with_callback(prepared, result._callback_all)  # type: ignore[attr-defined]
+    return result  # type: ignore[return-value]
 
 
 def select(*exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr) -> DataFrame:

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1704,8 +1704,8 @@ def collect_all_async(
     """
     Collect multiple LazyFrames at the same time asynchronously in thread pool.
 
-    Collects into a list of DataFrame, like :func:`polars.collect_all`
-    but instead of returning them directly they are scheduled to be collected
+    Collects into a list of DataFrame (like :func:`polars.collect_all`),
+    but instead of returning them directly, they are scheduled to be collected
     inside thread pool, while this method returns almost instantly.
 
     May be useful if you use gevent or asyncio and want to release control to other

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -74,9 +74,8 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
 
 if TYPE_CHECKING:
     import sys
-    from collections.abc import Awaitable
     from io import IOBase
-    from typing import Literal
+    from typing import Awaitable, Literal
 
     import pyarrow as pa
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1760,6 +1760,29 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         May be useful if you use gevent or asyncio and want to release control to other
         greenlets/tasks while LazyFrames are being collected.
 
+        Parameters
+        ----------
+        gevent
+            Return wrapper to `gevent.event.AsyncResult` instead of Awaitable
+        type_coercion
+            Do type coercion optimization.
+        predicate_pushdown
+            Do predicate pushdown optimization.
+        projection_pushdown
+            Do projection pushdown optimization.
+        simplify_expression
+            Run simplify expressions optimization.
+        no_optimization
+            Turn off (certain) optimizations.
+        slice_pushdown
+            Slice pushdown optimization.
+        comm_subplan_elim
+            Will try to cache branching subplans that occur on self-joins or unions.
+        comm_subexpr_elim
+            Common subexpressions will be cached and reused.
+        streaming
+            Run parts of the query in a streaming fashion (this is in an alpha state)
+
         Notes
         -----
         In case of error `set_exception` is used on

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1753,8 +1753,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Collect DataFrame asynchronously in thread pool.
 
-        Collects into a DataFrame, like :func:`collect` but instead of returning
-        dataframe directly they are scheduled to be collected inside thread pool,
+        Collects into a DataFrame (like :func:`collect`), but instead of returning
+        dataframe directly, they are scheduled to be collected inside thread pool,
         while this method returns almost instantly.
 
         May be useful if you use gevent or asyncio and want to release control to other

--- a/py-polars/polars/utils/_async.py
+++ b/py-polars/polars/utils/_async.py
@@ -33,7 +33,9 @@ class _GeventDataFrameResult(Generic[T]):
         self._watcher = get_hub().loop.async_()
         self._watcher.start(self._watcher_callback)
 
-    def get(self, block: bool = True, timeout: float | int | None = None) -> T:
+    def get(
+        self, block: bool = True, timeout: float | int | None = None  # noqa: FBT001
+    ) -> T:
         return self.result.get(block=block, timeout=timeout)
 
     @property

--- a/py-polars/polars/utils/_async.py
+++ b/py-polars/polars/utils/_async.py
@@ -64,7 +64,7 @@ class _GeventDataFrameResult(Generic[T]):
         self._watcher.send()
 
 
-class _AioDataFrameResult(Generic[T], Awaitable[T]):
+class _AioDataFrameResult(Awaitable[T], Generic[T]):
     __slots__ = ("loop", "result")
 
     def __init__(self) -> None:

--- a/py-polars/polars/utils/_async.py
+++ b/py-polars/polars/utils/_async.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Awaitable
-from typing import TYPE_CHECKING, Any, Generator, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Awaitable, Generator, Generic, TypeVar
 
 from polars.utils._wrap import wrap_df
 

--- a/py-polars/polars/utils/_async.py
+++ b/py-polars/polars/utils/_async.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from collections.abc import Awaitable
+from typing import TYPE_CHECKING, Any, Generator, Generic, TypeVar
 
 from polars.utils._wrap import wrap_df
 
 if TYPE_CHECKING:
-    from queue import Queue
+    from asyncio.futures import Future
 
     from polars.polars import PyDataFrame
 
@@ -13,33 +14,73 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 
 
-class _AsyncDataFrameResult(Generic[T]):
-    queue: Queue[Exception | T]
-    _result: Exception | T | None
+class _GeventDataFrameResult(Generic[T]):
+    __slots__ = ("_watcher", "_value", "_result")
 
-    __slots__ = ("queue", "_result")
+    def __init__(self) -> None:
+        from gevent.event import AsyncResult  # type: ignore[import]
+        from gevent.hub import get_hub  # type: ignore[import]
 
-    def __init__(self, queue: Queue[Exception | T]) -> None:
-        self.queue = queue
-        self._result = None
+        self._value: None | Exception | PyDataFrame | list[PyDataFrame] = None
+        self._result = AsyncResult()
 
-    def get(self, **kwargs: Any) -> T:
-        if self._result is not None:
-            if isinstance(self._result, Exception):
-                raise self._result
-            return self._result
+        self._watcher = get_hub().loop.async_()
+        self._watcher.start(self._watcher_callback)
 
-        self._result = self.queue.get(**kwargs)
-        if isinstance(self._result, Exception):
-            raise self._result
+    def get(self, block: bool = True, timeout: float | int | None = None) -> T:
+        return self.result.get(block=block, timeout=timeout)
+
+    @property
+    def result(self) -> Any:
+        # required if we did not made any switches and just want results later
+        # with block=False and possibly without timeout
+        if self._value is not None and not self._result.ready():
+            self._watcher_callback()
         return self._result
+
+    def _watcher_callback(self) -> None:
+        if isinstance(self._value, Exception):
+            self._result.set_exception(self._value)
+        else:
+            self._result.set(self._value)
+        self._watcher.close()
 
     def _callback(self, obj: PyDataFrame | Exception) -> None:
         if not isinstance(obj, Exception):
             obj = wrap_df(obj)
-        self.queue.put_nowait(obj)
+        self._value = obj
+        self._watcher.send()
 
     def _callback_all(self, obj: list[PyDataFrame] | Exception) -> None:
         if not isinstance(obj, Exception):
             obj = [wrap_df(pydf) for pydf in obj]
-        self.queue.put_nowait(obj)  # type: ignore[arg-type]
+        self._value = obj
+        self._watcher.send()
+
+
+class _AioDataFrameResult(Generic[T], Awaitable[T]):
+    __slots__ = ("loop", "result")
+
+    def __init__(self) -> None:
+        from asyncio import get_event_loop
+
+        self.loop = get_event_loop()
+        self.result: Future[T] = self.loop.create_future()
+
+    def __await__(self) -> Generator[Any, None, T]:
+        return self.result.__await__()
+
+    def _callback(self, obj: PyDataFrame | Exception) -> None:
+        if isinstance(obj, Exception):
+            self.loop.call_soon_threadsafe(self.result.set_exception, obj)
+        else:
+            self.loop.call_soon_threadsafe(self.result.set_result, wrap_df(obj))
+
+    def _callback_all(self, obj: list[PyDataFrame] | Exception) -> None:
+        if isinstance(obj, Exception):
+            self.loop.call_soon_threadsafe(self.result.set_exception, obj)
+        else:
+            self.loop.call_soon_threadsafe(
+                self.result.set_result,
+                [wrap_df(pydf) for pydf in obj],
+            )

--- a/py-polars/polars/utils/_async.py
+++ b/py-polars/polars/utils/_async.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Awaitable, Generator, Generic, TypeVar
 
+from polars.dependencies import _GEVENT_AVAILABLE
 from polars.utils._wrap import wrap_df
 
 if TYPE_CHECKING:
@@ -17,6 +18,12 @@ class _GeventDataFrameResult(Generic[T]):
     __slots__ = ("_watcher", "_value", "_result")
 
     def __init__(self) -> None:
+        if not _GEVENT_AVAILABLE:
+            raise ImportError(
+                "gevent is required for using LazyFrame.collect_async(gevent=True) or"
+                "polars.collect_all_async(gevent=True)"
+            )
+
         from gevent.event import AsyncResult  # type: ignore[import]
         from gevent.hub import get_hub  # type: ignore[import]
 

--- a/py-polars/polars/utils/show_versions.py
+++ b/py-polars/polars/utils/show_versions.py
@@ -63,6 +63,7 @@ def _get_dependency_info() -> dict[str, str]:
         "connectorx",
         "deltalake",
         "fsspec",
+        "gevent",
         "matplotlib",
         "numpy",
         "pandas",
@@ -71,7 +72,6 @@ def _get_dependency_info() -> dict[str, str]:
         "sqlalchemy",
         "xlsx2csv",
         "xlsxwriter",
-        "gevent",
     ]
     return {f"{name}:": _get_dependency_version(name) for name in opt_deps}
 

--- a/py-polars/polars/utils/show_versions.py
+++ b/py-polars/polars/utils/show_versions.py
@@ -71,6 +71,7 @@ def _get_dependency_info() -> dict[str, str]:
         "sqlalchemy",
         "xlsx2csv",
         "xlsxwriter",
+        "gevent",
     ]
     return {f"{name}:": _get_dependency_version(name) for name in opt_deps}
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -52,6 +52,7 @@ pydantic = ["pydantic"]
 sqlalchemy = ["sqlalchemy", "pandas"]
 xlsxwriter = ["xlsxwriter"]
 adbc = ["adbc_driver_sqlite"]
+cloudpickle = ["cloudpickle"]
 gevent = ["gevent"]
 all = [
   "polars[pyarrow,pandas,numpy,fsspec,connectorx,xlsx2csv,deltalake,timezone,matplotlib,pydantic,sqlalchemy,xlsxwriter,adbc,cloudpickle,gevent]",

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -52,9 +52,9 @@ pydantic = ["pydantic"]
 sqlalchemy = ["sqlalchemy", "pandas"]
 xlsxwriter = ["xlsxwriter"]
 adbc = ["adbc_driver_sqlite"]
-cloudpickle = ["cloudpickle"]
+gevent = ["gevent"]
 all = [
-  "polars[pyarrow,pandas,numpy,fsspec,connectorx,xlsx2csv,deltalake,timezone,matplotlib,pydantic,sqlalchemy,xlsxwriter,adbc,cloudpickle]",
+  "polars[pyarrow,pandas,numpy,fsspec,connectorx,xlsx2csv,deltalake,timezone,matplotlib,pydantic,sqlalchemy,xlsxwriter,adbc,cloudpickle,gevent]",
 ]
 
 [tool.mypy]

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -80,6 +80,7 @@ module = [
   "deltalake.*",
   "ezodf.*",
   "fsspec.*",
+  "gevent",
   "matplotlib.*",
   "moto.server",
   "openpyxl",
@@ -90,7 +91,6 @@ module = [
   "xlsx2csv",
   "xlsxwriter.*",
   "zoneinfo",
-  "gevent",
 ]
 ignore_missing_imports = true
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -89,6 +89,7 @@ module = [
   "xlsx2csv",
   "xlsxwriter.*",
   "zoneinfo",
+  "gevent",
 ]
 ignore_missing_imports = true
 

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -38,6 +38,7 @@ deltalake == 0.10.1
 dataframe-api-compat >= 0.1.6
 # Other
 matplotlib
+gevent
 
 # -------
 # TOOLING

--- a/py-polars/tests/unit/test_async.py
+++ b/py-polars/tests/unit/test_async.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from functools import partial
+from typing import Any, Callable
+
+import gevent  # type: ignore[import]
+import pytest
+
+import polars as pl
+
+
+async def _aio_collect_async(raises: bool = False) -> pl.DataFrame:
+    lf = (
+        pl.LazyFrame(
+            {
+                "a": ["a", "b", "a", "b", "b", "c"],
+                "b": [1, 2, 3, 4, 5, 6],
+                "c": [6, 5, 4, 3, 2, 1],
+            }
+        )
+        .group_by("a", maintain_order=True)
+        .agg(pl.all().sum())
+    )
+    if raises:
+        lf = lf.select(pl.col("foo_bar"))
+    return await lf.collect_async()
+
+
+async def _aio_collect_all_async(raises: bool = False) -> list[pl.DataFrame]:
+    lf = (
+        pl.LazyFrame(
+            {
+                "a": ["a", "b", "a", "b", "b", "c"],
+                "b": [1, 2, 3, 4, 5, 6],
+                "c": [6, 5, 4, 3, 2, 1],
+            }
+        )
+        .group_by("a", maintain_order=True)
+        .agg(pl.all().sum())
+    )
+    if raises:
+        lf = lf.select(pl.col("foo_bar"))
+
+    lf2 = pl.LazyFrame({"a": [1, 2], "b": [1, 2]}).group_by("a").sum()
+
+    return await pl.collect_all_async([lf, lf2])
+
+
+_aio_collect = pytest.mark.parametrize(
+    ("collect", "raises"),
+    [
+        (_aio_collect_async, None),
+        (_aio_collect_all_async, None),
+        (partial(_aio_collect_async, True), pl.ColumnNotFoundError),
+        (partial(_aio_collect_all_async, True), pl.ColumnNotFoundError),
+    ],
+)
+
+
+def _aio_run(coroutine: Any, raises: Exception | None = None) -> None:
+    if raises is not None:
+        with pytest.raises(raises):  # type: ignore[call-overload]
+            asyncio.run(coroutine)
+    else:
+        assert len(asyncio.run(coroutine)) > 0
+
+
+@_aio_collect
+def test_collect_async_switch(
+    collect: Callable[[], Any],
+    raises: Exception | None,
+) -> None:
+    async def main() -> Any:
+        df = collect()
+        await asyncio.sleep(0.3)
+        return await df
+
+    _aio_run(main(), raises)
+
+
+@_aio_collect
+def test_collect_async_task(
+    collect: Callable[[], Any], raises: Exception | None
+) -> None:
+    async def main() -> Any:
+        df = asyncio.create_task(collect())
+        await asyncio.sleep(0.3)
+        return await df
+
+    _aio_run(main(), raises)
+
+
+def _gevent_collect_async(raises: bool = False) -> Any:
+    lf = (
+        pl.LazyFrame(
+            {
+                "a": ["a", "b", "a", "b", "b", "c"],
+                "b": [1, 2, 3, 4, 5, 6],
+                "c": [6, 5, 4, 3, 2, 1],
+            }
+        )
+        .group_by("a", maintain_order=True)
+        .agg(pl.all().sum())
+    )
+    if raises:
+        lf = lf.select(pl.col("foo_bar"))
+    return lf.collect_async(gevent=True)
+
+
+def _gevent_collect_all_async(raises: bool = False) -> Any:
+    lf = (
+        pl.LazyFrame(
+            {
+                "a": ["a", "b", "a", "b", "b", "c"],
+                "b": [1, 2, 3, 4, 5, 6],
+                "c": [6, 5, 4, 3, 2, 1],
+            }
+        )
+        .group_by("a", maintain_order=True)
+        .agg(pl.all().sum())
+    )
+    if raises:
+        lf = lf.select(pl.col("foo_bar"))
+    return pl.collect_all_async([lf], gevent=True)
+
+
+_gevent_collect = pytest.mark.parametrize(
+    ("get_result", "raises"),
+    [
+        (_gevent_collect_async, None),
+        (_gevent_collect_all_async, None),
+        (partial(_gevent_collect_async, True), pl.ColumnNotFoundError),
+        (partial(_gevent_collect_all_async, True), pl.ColumnNotFoundError),
+    ],
+)
+
+
+def _gevent_run(callback: Callable[[], Any], raises: Exception | None = None) -> None:
+    if raises is not None:
+        with pytest.raises(raises):  # type: ignore[call-overload]
+            callback()
+    else:
+        assert len(callback()) > 0
+
+
+@_gevent_collect
+def test_gevent_collect_async_without_hub(
+    get_result: Callable[[], Any], raises: Exception | None
+) -> None:
+    def main() -> Any:
+        return get_result().get()
+
+    _gevent_run(main, raises)
+
+
+@_gevent_collect
+def test_gevent_collect_async_with_hub(
+    get_result: Callable[[], Any], raises: Exception | None
+) -> None:
+    _hub = gevent.get_hub()
+
+    def main() -> Any:
+        return get_result().get()
+
+    _gevent_run(main, raises)
+
+
+@_gevent_collect
+def test_gevent_collect_async_switch(
+    get_result: Callable[[], Any], raises: Exception | None
+) -> None:
+    def main() -> Any:
+        result = get_result()
+        gevent.sleep(0.1)
+        return result.get(block=False, timeout=3)
+
+    _gevent_run(main, raises)
+
+
+@_gevent_collect
+def test_gevent_collect_async_no_switch(
+    get_result: Callable[[], Any], raises: Exception | None
+) -> None:
+    def main() -> Any:
+        result = get_result()
+        time.sleep(1)
+        return result.get(block=False, timeout=None)
+
+    _gevent_run(main, raises)
+
+
+@_gevent_collect
+def test_gevent_collect_async_spawn(
+    get_result: Callable[[], Any], raises: Exception | None
+) -> None:
+    def main() -> Any:
+        result_greenlet = gevent.spawn(get_result)
+        gevent.spawn(gevent.sleep, 0.1)
+        return result_greenlet.get().get()
+
+    _gevent_run(main, raises)

--- a/py-polars/tests/unit/test_async.py
+++ b/py-polars/tests/unit/test_async.py
@@ -5,10 +5,10 @@ import time
 from functools import partial
 from typing import Any, Callable
 
-import gevent  # type: ignore[import]
 import pytest
 
 import polars as pl
+from polars.dependencies import gevent
 
 
 async def _aio_collect_async(raises: bool = False) -> pl.DataFrame:


### PR DESCRIPTION
In #10616 @jakob-keller proposed to simplify this to `await ldf.collect_async()` for asyncio. Not it's possible.

Api now is way nicer and defaults to asyncio, since its most common usage. Don't need to pass Queue instances.
Also since they had to be thread safe - default queues from asyncio and gevent were not compatible and external dependency janus was required to safely use them.

asyncio implementation turned out fairly simple 
But with gevent  I was not able to to do this with [ILoop.run_callback_threadsafe](https://www.gevent.org/api/gevent.hub.html#gevent._interfaces.ILoop.run_callback_threadsafe) for some reason due to `LoopExit: This operation would block forever`, while they say it's a [asyncio.loop.call_soon_threadsafe](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_soon_threadsafe) alternative. 
Maybe there are some checks that are not compatible with how objects are called from out of thread rust side...

Managed to use lower level api, but with nuance that results into AsyncResult are only being set when context switch occurs. (get(block=True), get(block=False, timeout=...) works, but get(block=False, timeout=None) does not),
worked around making result a property to check for this case.