### PR TITLE
fix: Allow exactly one value in start/end for `int_range`

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/range/date_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/date_range.rs
@@ -3,7 +3,7 @@ use polars_core::series::Series;
 use polars_core::utils::arrow::temporal_conversions::MILLISECONDS_IN_DAY;
 use polars_time::{datetime_range_impl, ClosedWindow, Duration};
 
-use super::utils::{ensure_range_bounds_contain_single_value, temporal_series_to_i64_scalar};
+use super::utils::{ensure_range_bounds_contain_exactly_one_value, temporal_series_to_i64_scalar};
 use crate::dsl::function_expr::FieldsMapper;
 
 const CAPACITY_FACTOR: usize = 5;
@@ -40,7 +40,7 @@ fn date_range(s: &[Series], interval: Duration, closed: ClosedWindow) -> PolarsR
     let start = &s[0];
     let end = &s[1];
 
-    ensure_range_bounds_contain_single_value(start, end)?;
+    ensure_range_bounds_contain_exactly_one_value(start, end)?;
 
     let dtype = DataType::Date;
     let start = temporal_series_to_i64_scalar(start) * MILLISECONDS_IN_DAY;
@@ -120,7 +120,7 @@ fn datetime_range(
     let start = &s[0];
     let end = &s[1];
 
-    ensure_range_bounds_contain_single_value(start, end)?;
+    ensure_range_bounds_contain_exactly_one_value(start, end)?;
 
     // Note: `start` and `end` have already been cast to their supertype,
     // so only `start`'s dtype needs to be matched against.

--- a/crates/polars-plan/src/dsl/function_expr/range/date_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/date_range.rs
@@ -3,7 +3,7 @@ use polars_core::series::Series;
 use polars_core::utils::arrow::temporal_conversions::MILLISECONDS_IN_DAY;
 use polars_time::{datetime_range_impl, ClosedWindow, Duration};
 
-use super::utils::temporal_series_to_i64_scalar;
+use super::utils::{ensure_range_bounds_contain_single_value, temporal_series_to_i64_scalar};
 use crate::dsl::function_expr::FieldsMapper;
 
 const CAPACITY_FACTOR: usize = 5;
@@ -40,8 +40,7 @@ fn date_range(s: &[Series], interval: Duration, closed: ClosedWindow) -> PolarsR
     let start = &s[0];
     let end = &s[1];
 
-    polars_ensure!(start.len() == 1, ComputeError: "`start` must contain a single value");
-    polars_ensure!(end.len() == 1, ComputeError: "`end` must contain a single value");
+    ensure_range_bounds_contain_single_value(start, end)?;
 
     let dtype = DataType::Date;
     let start = temporal_series_to_i64_scalar(start) * MILLISECONDS_IN_DAY;
@@ -121,8 +120,7 @@ fn datetime_range(
     let start = &s[0];
     let end = &s[1];
 
-    polars_ensure!(start.len() == 1, ComputeError: "`start` must contain a single value");
-    polars_ensure!(end.len() == 1, ComputeError: "`end` must contain a single value");
+    ensure_range_bounds_contain_single_value(start, end)?;
 
     // Note: `start` and `end` have already been cast to their supertype,
     // so only `start`'s dtype needs to be matched against.

--- a/crates/polars-plan/src/dsl/function_expr/range/int_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/int_range.rs
@@ -1,13 +1,13 @@
 use polars_core::prelude::*;
 use polars_core::series::{IsSorted, Series};
 
-use super::utils::ensure_range_bounds_contain_single_value;
+use super::utils::ensure_range_bounds_contain_exactly_one_value;
 
 pub(super) fn int_range(s: &[Series], step: i64) -> PolarsResult<Series> {
     let start = &s[0];
     let end = &s[1];
 
-    ensure_range_bounds_contain_single_value(start, end)?;
+    ensure_range_bounds_contain_exactly_one_value(start, end)?;
 
     match start.dtype() {
         dt if dt == &IDX_DTYPE => {

--- a/crates/polars-plan/src/dsl/function_expr/range/int_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/int_range.rs
@@ -1,35 +1,27 @@
 use polars_core::prelude::*;
 use polars_core::series::{IsSorted, Series};
 
+use super::utils::ensure_range_bounds_contain_single_value;
+
 pub(super) fn int_range(s: &[Series], step: i64) -> PolarsResult<Series> {
     let start = &s[0];
     let end = &s[1];
 
+    ensure_range_bounds_contain_single_value(start, end)?;
+
     match start.dtype() {
         dt if dt == &IDX_DTYPE => {
-            let start = start
-                .idx()?
-                .get(0)
-                .ok_or_else(|| polars_err!(NoData: "no data in `start` evaluation"))?;
+            let start = start.idx()?.get(0).unwrap();
             let end = end.cast(&IDX_DTYPE)?;
-            let end = end
-                .idx()?
-                .get(0)
-                .ok_or_else(|| polars_err!(NoData: "no data in `end` evaluation"))?;
+            let end = end.idx()?.get(0).unwrap();
 
             int_range_impl::<IdxType>(start, end, step)
         },
         _ => {
             let start = start.cast(&DataType::Int64)?;
             let end = end.cast(&DataType::Int64)?;
-            let start = start
-                .i64()?
-                .get(0)
-                .ok_or_else(|| polars_err!(NoData: "no data in `start` evaluation"))?;
-            let end = end
-                .i64()?
-                .get(0)
-                .ok_or_else(|| polars_err!(NoData: "no data in `end` evaluation"))?;
+            let start = start.i64()?.get(0).unwrap();
+            let end = end.i64()?.get(0).unwrap();
             int_range_impl::<Int64Type>(start, end, step)
         },
     }

--- a/crates/polars-plan/src/dsl/function_expr/range/time_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/time_range.rs
@@ -2,7 +2,7 @@ use polars_core::prelude::*;
 use polars_core::series::Series;
 use polars_time::{time_range_impl, ClosedWindow, Duration};
 
-use super::utils::temporal_series_to_i64_scalar;
+use super::utils::{ensure_range_bounds_contain_single_value, temporal_series_to_i64_scalar};
 
 const CAPACITY_FACTOR: usize = 5;
 
@@ -14,8 +14,7 @@ pub(super) fn time_range(
     let start = &s[0];
     let end = &s[1];
 
-    polars_ensure!(start.len() == 1, ComputeError: "`start` must contain a single value");
-    polars_ensure!(end.len() == 1, ComputeError: "`end` must contain a single value");
+    ensure_range_bounds_contain_single_value(start, end)?;
 
     let dtype = DataType::Time;
     let start = temporal_series_to_i64_scalar(&start.cast(&dtype)?);

--- a/crates/polars-plan/src/dsl/function_expr/range/time_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/time_range.rs
@@ -2,7 +2,7 @@ use polars_core::prelude::*;
 use polars_core::series::Series;
 use polars_time::{time_range_impl, ClosedWindow, Duration};
 
-use super::utils::{ensure_range_bounds_contain_single_value, temporal_series_to_i64_scalar};
+use super::utils::{ensure_range_bounds_contain_exactly_one_value, temporal_series_to_i64_scalar};
 
 const CAPACITY_FACTOR: usize = 5;
 
@@ -14,7 +14,7 @@ pub(super) fn time_range(
     let start = &s[0];
     let end = &s[1];
 
-    ensure_range_bounds_contain_single_value(start, end)?;
+    ensure_range_bounds_contain_exactly_one_value(start, end)?;
 
     let dtype = DataType::Time;
     let start = temporal_series_to_i64_scalar(&start.cast(&dtype)?);

--- a/crates/polars-plan/src/dsl/function_expr/range/utils.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/utils.rs
@@ -1,3 +1,4 @@
+use polars_core::prelude::{polars_bail, polars_ensure, PolarsResult};
 use polars_core::series::Series;
 
 pub(super) fn temporal_series_to_i64_scalar(s: &Series) -> i64 {
@@ -6,4 +7,13 @@ pub(super) fn temporal_series_to_i64_scalar(s: &Series) -> i64 {
         .unwrap()
         .extract::<i64>()
         .unwrap()
+}
+
+pub(super) fn ensure_range_bounds_contain_single_value(
+    start: &Series,
+    end: &Series,
+) -> PolarsResult<()> {
+    polars_ensure!(start.len() == 1, ComputeError: "`start` must contain a single value");
+    polars_ensure!(end.len() == 1, ComputeError: "`end` must contain a single value");
+    Ok(())
 }

--- a/crates/polars-plan/src/dsl/function_expr/range/utils.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/utils.rs
@@ -9,7 +9,7 @@ pub(super) fn temporal_series_to_i64_scalar(s: &Series) -> i64 {
         .unwrap()
 }
 
-pub(super) fn ensure_range_bounds_contain_single_value(
+pub(super) fn ensure_range_bounds_contain_exactly_one_value(
     start: &Series,
     end: &Series,
 ) -> PolarsResult<()> {

--- a/crates/polars-plan/src/dsl/function_expr/range/utils.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/utils.rs
@@ -13,7 +13,13 @@ pub(super) fn ensure_range_bounds_contain_single_value(
     start: &Series,
     end: &Series,
 ) -> PolarsResult<()> {
-    polars_ensure!(start.len() == 1, ComputeError: "`start` must contain a single value");
-    polars_ensure!(end.len() == 1, ComputeError: "`end` must contain a single value");
+    polars_ensure!(
+        start.len() == 1,
+        ComputeError: "`start` must contain exactly one value, got {} values", start.len()
+    );
+    polars_ensure!(
+        end.len() == 1,
+        ComputeError: "`end` must contain exactly one value, got {} values", end.len()
+    );
     Ok(())
 }

--- a/py-polars/tests/unit/functions/range/test_date_range.py
+++ b/py-polars/tests/unit/functions/range/test_date_range.py
@@ -840,27 +840,39 @@ def test_date_range_no_alias_schema_9037() -> None:
     assert result.collect().schema == expected_schema
 
 
-def test_time_range_empty() -> None:
+def test_time_range_input_shape_empty() -> None:
     empty = pl.Series(dtype=pl.Datetime)
     single = pl.Series([datetime(2022, 1, 2)])
 
-    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`start` must contain exactly one value, got 0 values"
+    ):
         pl.date_range(empty, single, eager=True)
-    with pytest.raises(pl.ComputeError, match="`end` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`end` must contain exactly one value, got 0 values"
+    ):
         pl.date_range(single, empty, eager=True)
-    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`start` must contain exactly one value, got 0 values"
+    ):
         pl.date_range(empty, empty, eager=True)
 
 
-def test_time_range_multiple_values() -> None:
+def test_time_range_input_shape_multiple_values() -> None:
     single = pl.Series([datetime(2022, 1, 2)])
     multiple = pl.Series([datetime(2022, 1, 3), datetime(2022, 1, 4)])
 
-    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`start` must contain exactly one value, got 2 values"
+    ):
         pl.date_range(multiple, single, eager=True)
-    with pytest.raises(pl.ComputeError, match="`end` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`end` must contain exactly one value, got 2 values"
+    ):
         pl.date_range(single, multiple, eager=True)
-    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`start` must contain exactly one value, got 2 values"
+    ):
         pl.date_range(multiple, multiple, eager=True)
 
 

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -94,25 +94,37 @@ def test_int_ranges_schema_dtype_arg() -> None:
     assert result.collect().schema == expected_schema
 
 
-def test_int_range_empty() -> None:
+def test_int_range_input_shape_empty() -> None:
     empty = pl.Series(dtype=pl.Time)
     single = pl.Series([5])
 
-    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`start` must contain exactly one value, got 0 values"
+    ):
         pl.int_range(empty, single, eager=True)
-    with pytest.raises(pl.ComputeError, match="`end` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`end` must contain exactly one value, got 0 values"
+    ):
         pl.int_range(single, empty, eager=True)
-    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`start` must contain exactly one value, got 0 values"
+    ):
         pl.int_range(empty, empty, eager=True)
 
 
-def test_int_range_multiple_values() -> None:
+def test_int_range_input_shape_multiple_values() -> None:
     single = pl.Series([5])
     multiple = pl.Series([10, 15])
 
-    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`start` must contain exactly one value, got 2 values"
+    ):
         pl.int_range(multiple, single, eager=True)
-    with pytest.raises(pl.ComputeError, match="`end` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`end` must contain exactly one value, got 2 values"
+    ):
         pl.int_range(single, multiple, eager=True)
-    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`start` must contain exactly one value, got 2 values"
+    ):
         pl.int_range(multiple, multiple, eager=True)

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -92,3 +92,27 @@ def test_int_ranges_schema_dtype_arg() -> None:
     expected_schema = {"int_range": pl.List(pl.UInt16)}
     assert result.schema == expected_schema
     assert result.collect().schema == expected_schema
+
+
+def test_int_range_empty() -> None:
+    empty = pl.Series(dtype=pl.Time)
+    single = pl.Series([5])
+
+    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+        pl.int_range(empty, single, eager=True)
+    with pytest.raises(pl.ComputeError, match="`end` must contain a single value"):
+        pl.int_range(single, empty, eager=True)
+    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+        pl.int_range(empty, empty, eager=True)
+
+
+def test_int_range_multiple_values() -> None:
+    single = pl.Series([5])
+    multiple = pl.Series([10, 15])
+
+    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+        pl.int_range(multiple, single, eager=True)
+    with pytest.raises(pl.ComputeError, match="`end` must contain a single value"):
+        pl.int_range(single, multiple, eager=True)
+    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+        pl.int_range(multiple, multiple, eager=True)

--- a/py-polars/tests/unit/functions/range/test_time_range.py
+++ b/py-polars/tests/unit/functions/range/test_time_range.py
@@ -54,27 +54,39 @@ def test_time_range_eager_explode() -> None:
     assert_series_equal(result, expected)
 
 
-def test_time_range_empty() -> None:
+def test_time_range_input_shape_empty() -> None:
     empty = pl.Series(dtype=pl.Time)
     single = pl.Series([time(12, 0)])
 
-    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`start` must contain exactly one value, got 0 values"
+    ):
         pl.time_range(empty, single, eager=True)
-    with pytest.raises(pl.ComputeError, match="`end` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`end` must contain exactly one value, got 0 values"
+    ):
         pl.time_range(single, empty, eager=True)
-    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`start` must contain exactly one value, got 0 values"
+    ):
         pl.time_range(empty, empty, eager=True)
 
 
-def test_time_range_multiple_values() -> None:
+def test_time_range_input_shape_multiple_values() -> None:
     single = pl.Series([time(12, 0)])
     multiple = pl.Series([time(11, 0), time(12, 0)])
 
-    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`start` must contain exactly one value, got 2 values"
+    ):
         pl.time_range(multiple, single, eager=True)
-    with pytest.raises(pl.ComputeError, match="`end` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`end` must contain exactly one value, got 2 values"
+    ):
         pl.time_range(single, multiple, eager=True)
-    with pytest.raises(pl.ComputeError, match="`start` must contain a single value"):
+    with pytest.raises(
+        pl.ComputeError, match="`start` must contain exactly one value, got 2 values"
+    ):
         pl.time_range(multiple, multiple, eager=True)
 
 


### PR DESCRIPTION
Closes #10902 

I'd rather have a more specific error type, but I'll pick that up separately.