### PR TITLE
feat(python): allow individual `Config` options to be easily reset to their default value

### DIFF
--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -37,6 +37,15 @@ Config load, save, and current state
     Config.state
     Config.restore_defaults
 
+While it is easy to restore *all* configuration options to their default
+value using ``restore_defaults``, it can also be useful to reset *individual*
+options. This can be done by setting the related value to ``None``, eg:
+
+.. code-block:: python
+
+    pl.Config.set_tbl_rows(None)
+
+
 Use as a context manager
 ------------------------
 

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import contextlib
 import os
+import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, get_args
 
 from polars.dependencies import json
 from polars.utils.various import normalise_filepath
@@ -19,11 +20,34 @@ with contextlib.suppress(ImportError):
     from polars.polars import get_float_fmt as _get_float_fmt  # type: ignore[no-redef]
     from polars.polars import set_float_fmt as _set_float_fmt
 
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    pass
+
 if TYPE_CHECKING:
     from types import TracebackType
-    from typing import Literal
+
+    from typing_extensions import TypeAlias
 
     from polars.type_aliases import FloatFmt
+
+TableFormatNames: TypeAlias = Literal[
+    "ASCII_FULL",
+    "ASCII_FULL_CONDENSED",
+    "ASCII_NO_BORDERS",
+    "ASCII_BORDERS_ONLY",
+    "ASCII_BORDERS_ONLY_CONDENSED",
+    "ASCII_HORIZONTAL_ONLY",
+    "ASCII_MARKDOWN",
+    "UTF8_FULL",
+    "UTF8_FULL_CONDENSED",
+    "UTF8_NO_BORDERS",
+    "UTF8_BORDERS_ONLY",
+    "UTF8_HORIZONTAL_ONLY",
+    "NOTHING",
+]
 
 
 # note: register all Config-specific environment variable names here; need to constrain
@@ -265,27 +289,26 @@ class Config(contextlib.ContextDecorator):
         return config_state
 
     @classmethod
-    def activate_decimals(cls, active: bool = True) -> type[Config]:
+    def activate_decimals(cls, active: bool | None = True) -> type[Config]:
         """
         Activate ``Decimal`` data types.
 
-        This is a temporary setting that will be removed later once the
-        ``Decimal`` type stabilize. This will happens without it being
-        considered a breaking change.
-
-        Currently, ``Decimal`` types are in an alpha state.
+        This is a temporary setting that will be removed once the ``Decimal`` type
+        stabilizes (``Decimal`` is currently considered to be in beta testing).
 
         """
         if not active:
             os.environ.pop("POLARS_ACTIVATE_DECIMAL", None)
         else:
-            os.environ["POLARS_ACTIVATE_DECIMAL"] = "1"
+            os.environ["POLARS_ACTIVATE_DECIMAL"] = str(int(active))
         return cls
 
     @classmethod
-    def set_ascii_tables(cls, active: bool = True) -> type[Config]:
+    def set_ascii_tables(cls, active: bool | None = True) -> type[Config]:
         """
-        Use ASCII characters to display table outlines (set False to revert to UTF8).
+        Use ASCII characters to display table outlines.
+
+        Set False to revert to the default UTF8_FULL_CONDENSED formatting style.
 
         Examples
         --------
@@ -304,18 +327,24 @@ class Config(contextlib.ContextDecorator):
         # └─────┴───────┘      +-----+-------+
 
         """
-        fmt = "ASCII_FULL_CONDENSED" if active else "UTF8_FULL_CONDENSED"
-        os.environ["POLARS_FMT_TABLE_FORMATTING"] = fmt
+        if active is None:
+            os.environ.pop("POLARS_FMT_TABLE_FORMATTING", None)
+        else:
+            fmt = "ASCII_FULL_CONDENSED" if active else "UTF8_FULL_CONDENSED"
+            os.environ["POLARS_FMT_TABLE_FORMATTING"] = fmt
         return cls
 
     @classmethod
-    def set_auto_structify(cls, active: bool = False) -> type[Config]:
+    def set_auto_structify(cls, active: bool | None = False) -> type[Config]:
         """Allow multi-output expressions to be automatically turned into Structs."""
-        os.environ["POLARS_AUTO_STRUCTIFY"] = str(int(active))
+        if active is None:
+            os.environ.pop("POLARS_AUTO_STRUCTIFY", None)
+        else:
+            os.environ["POLARS_AUTO_STRUCTIFY"] = str(int(active))
         return cls
 
     @classmethod
-    def set_fmt_float(cls, fmt: FloatFmt = "mixed") -> type[Config]:
+    def set_fmt_float(cls, fmt: FloatFmt | None = "mixed") -> type[Config]:
         """
         Control how floating  point values are displayed.
 
@@ -325,11 +354,11 @@ class Config(contextlib.ContextDecorator):
             How to format floating point numbers
 
         """
-        _set_float_fmt(fmt)
+        _set_float_fmt(fmt="mixed" if fmt is None else fmt)
         return cls
 
     @classmethod
-    def set_fmt_str_lengths(cls, n: int) -> type[Config]:
+    def set_fmt_str_lengths(cls, n: int | None) -> type[Config]:
         """
         Set the number of characters used to display string values.
 
@@ -372,14 +401,17 @@ class Config(contextlib.ContextDecorator):
         └──────────────────────────────────────────────────┘
 
         """
-        if n <= 0:
-            raise ValueError("number of characters must be > 0")
+        if n is None:
+            os.environ.pop("POLARS_FMT_STR_LEN", None)
+        else:
+            if n <= 0:
+                raise ValueError("number of characters must be > 0")
 
-        os.environ["POLARS_FMT_STR_LEN"] = str(n)
+            os.environ["POLARS_FMT_STR_LEN"] = str(n)
         return cls
 
     @classmethod
-    def set_streaming_chunk_size(cls, size: int) -> type[Config]:
+    def set_streaming_chunk_size(cls, size: int | None) -> type[Config]:
         """
         Overwrite chunk size used in ``streaming`` engine.
 
@@ -395,15 +427,18 @@ class Config(contextlib.ContextDecorator):
             of this size.
 
         """
-        if size < 1:
-            raise ValueError("number of rows per chunk must be >= 1")
+        if size is None:
+            os.environ.pop("POLARS_STREAMING_CHUNK_SIZE", None)
+        else:
+            if size < 1:
+                raise ValueError("number of rows per chunk must be >= 1")
 
-        os.environ["POLARS_STREAMING_CHUNK_SIZE"] = str(size)
+            os.environ["POLARS_STREAMING_CHUNK_SIZE"] = str(size)
         return cls
 
     @classmethod
     def set_tbl_cell_alignment(
-        cls, format: Literal["LEFT", "CENTER", "RIGHT"]
+        cls, format: Literal["LEFT", "CENTER", "RIGHT"] | None
     ) -> type[Config]:
         """
         Set table cell alignment.
@@ -435,14 +470,19 @@ class Config(contextlib.ContextDecorator):
 
         Raises
         ------
-        KeyError: if alignment string not recognised.
+        ValueError: if alignment string not recognised.
 
         """
-        os.environ["POLARS_FMT_TABLE_CELL_ALIGNMENT"] = format
+        if format is None:
+            os.environ.pop("POLARS_FMT_TABLE_CELL_ALIGNMENT", None)
+        elif format not in {"LEFT", "CENTER", "RIGHT"}:
+            raise ValueError(f"invalid alignment: {format!r}")
+        else:
+            os.environ["POLARS_FMT_TABLE_CELL_ALIGNMENT"] = format
         return cls
 
     @classmethod
-    def set_tbl_cols(cls, n: int) -> type[Config]:
+    def set_tbl_cols(cls, n: int | None) -> type[Config]:
         """
         Set the number of columns that are visible when displaying tables.
 
@@ -483,11 +523,16 @@ class Config(contextlib.ContextDecorator):
         └─────┴─────┴─────┴─────┴─────┴───┴─────┴─────┴─────┴─────┴─────┘
 
         """
-        os.environ["POLARS_FMT_MAX_COLS"] = str(n)
+        if n is None:
+            os.environ.pop("POLARS_FMT_MAX_COLS", None)
+        else:
+            os.environ["POLARS_FMT_MAX_COLS"] = str(n)
         return cls
 
     @classmethod
-    def set_tbl_column_data_type_inline(cls, active: bool = True) -> type[Config]:
+    def set_tbl_column_data_type_inline(
+        cls, active: bool | None = True
+    ) -> type[Config]:
         """
         Moves the data type inline with the column name (to the right, in parentheses).
 
@@ -508,11 +553,14 @@ class Config(contextlib.ContextDecorator):
         # └─────┴───────┘
 
         """
-        os.environ["POLARS_FMT_TABLE_INLINE_COLUMN_DATA_TYPE"] = str(int(active))
+        if active is None:
+            os.environ.pop("POLARS_FMT_TABLE_INLINE_COLUMN_DATA_TYPE", None)
+        else:
+            os.environ["POLARS_FMT_TABLE_INLINE_COLUMN_DATA_TYPE"] = str(int(active))
         return cls
 
     @classmethod
-    def set_tbl_dataframe_shape_below(cls, active: bool = True) -> type[Config]:
+    def set_tbl_dataframe_shape_below(cls, active: bool | None = True) -> type[Config]:
         """
         Print the DataFrame shape information below the data when displaying tables.
 
@@ -533,31 +581,17 @@ class Config(contextlib.ContextDecorator):
         # └─────┴───────┘      shape: (3, 2)
 
         """
-        os.environ["POLARS_FMT_TABLE_DATAFRAME_SHAPE_BELOW"] = str(int(active))
+        if active is None:
+            os.environ.pop("POLARS_FMT_TABLE_DATAFRAME_SHAPE_BELOW", None)
+        else:
+            os.environ["POLARS_FMT_TABLE_DATAFRAME_SHAPE_BELOW"] = str(int(active))
         return cls
 
     @classmethod
     def set_tbl_formatting(
         cls,
-        format: (
-            Literal[
-                "ASCII_FULL",
-                "ASCII_FULL_CONDENSED",
-                "ASCII_NO_BORDERS",
-                "ASCII_BORDERS_ONLY",
-                "ASCII_BORDERS_ONLY_CONDENSED",
-                "ASCII_HORIZONTAL_ONLY",
-                "ASCII_MARKDOWN",
-                "UTF8_FULL",
-                "UTF8_FULL_CONDENSED",
-                "UTF8_NO_BORDERS",
-                "UTF8_BORDERS_ONLY",
-                "UTF8_HORIZONTAL_ONLY",
-                "NOTHING",
-            ]
-            | None
-        ) = None,
-        rounded_corners: bool = False,
+        format: TableFormatNames | None = None,
+        rounded_corners: bool | None = False,
     ) -> type[Config]:
         """
         Set table formatting style.
@@ -606,18 +640,30 @@ class Config(contextlib.ContextDecorator):
 
         Raises
         ------
-        KeyError: if format string not recognised.
+        ValueError: if format string not recognised.
 
         """
-        # can see what the different styles look like in the comfy-table tests:
+        # note: can see what the different styles look like in the comfy-table tests
         # https://github.com/Nukesor/comfy-table/blob/main/tests/all/presets_test.rs
-        if format:
+        if format is None:
+            os.environ.pop("POLARS_FMT_TABLE_FORMATTING", None)
+        else:
+            valid_format_names = get_args(TableFormatNames)
+            if format not in valid_format_names:
+                raise ValueError(
+                    f"invalid table format name: {format!r}\nExpected one of: {', '.join(valid_format_names)}"
+                )
             os.environ["POLARS_FMT_TABLE_FORMATTING"] = format
-        os.environ["POLARS_FMT_TABLE_ROUNDED_CORNERS"] = str(int(rounded_corners))
+
+        if rounded_corners is None:
+            os.environ.pop("POLARS_FMT_TABLE_ROUNDED_CORNERS", None)
+        else:
+            os.environ["POLARS_FMT_TABLE_ROUNDED_CORNERS"] = str(int(rounded_corners))
+
         return cls
 
     @classmethod
-    def set_tbl_hide_column_data_types(cls, active: bool = True) -> type[Config]:
+    def set_tbl_hide_column_data_types(cls, active: bool | None = True) -> type[Config]:
         """
         Hide table column data types (i64, f64, str etc.).
 
@@ -638,11 +684,14 @@ class Config(contextlib.ContextDecorator):
         # └─────┴───────┘
 
         """
-        os.environ["POLARS_FMT_TABLE_HIDE_COLUMN_DATA_TYPES"] = str(int(active))
+        if active is None:
+            os.environ.pop("POLARS_FMT_TABLE_HIDE_COLUMN_DATA_TYPES", None)
+        else:
+            os.environ["POLARS_FMT_TABLE_HIDE_COLUMN_DATA_TYPES"] = str(int(active))
         return cls
 
     @classmethod
-    def set_tbl_hide_column_names(cls, active: bool = True) -> type[Config]:
+    def set_tbl_hide_column_names(cls, active: bool | None = True) -> type[Config]:
         """
         Hide table column names.
 
@@ -663,11 +712,14 @@ class Config(contextlib.ContextDecorator):
         # └─────┴───────┘
 
         """
-        os.environ["POLARS_FMT_TABLE_HIDE_COLUMN_NAMES"] = str(int(active))
+        if active is None:
+            os.environ.pop("POLARS_FMT_TABLE_HIDE_COLUMN_NAMES", None)
+        else:
+            os.environ["POLARS_FMT_TABLE_HIDE_COLUMN_NAMES"] = str(int(active))
         return cls
 
     @classmethod
-    def set_tbl_hide_dtype_separator(cls, active: bool = True) -> type[Config]:
+    def set_tbl_hide_dtype_separator(cls, active: bool | None = True) -> type[Config]:
         """
         Hide the '---' separator between the column names and column types.
 
@@ -692,11 +744,14 @@ class Config(contextlib.ContextDecorator):
         # └─────┴───────┘
 
         """
-        os.environ["POLARS_FMT_TABLE_HIDE_COLUMN_SEPARATOR"] = str(int(active))
+        if active is None:
+            os.environ.pop("POLARS_FMT_TABLE_HIDE_COLUMN_SEPARATOR", None)
+        else:
+            os.environ["POLARS_FMT_TABLE_HIDE_COLUMN_SEPARATOR"] = str(int(active))
         return cls
 
     @classmethod
-    def set_tbl_hide_dataframe_shape(cls, active: bool = True) -> type[Config]:
+    def set_tbl_hide_dataframe_shape(cls, active: bool | None = True) -> type[Config]:
         """
         Hide the DataFrame shape information when displaying tables.
 
@@ -717,13 +772,16 @@ class Config(contextlib.ContextDecorator):
         # └─────┴───────┘
 
         """
-        os.environ["POLARS_FMT_TABLE_HIDE_DATAFRAME_SHAPE_INFORMATION"] = str(
-            int(active)
-        )
+        if active is None:
+            os.environ.pop("POLARS_FMT_TABLE_HIDE_DATAFRAME_SHAPE_INFORMATION", None)
+        else:
+            os.environ["POLARS_FMT_TABLE_HIDE_DATAFRAME_SHAPE_INFORMATION"] = str(
+                int(active)
+            )
         return cls
 
     @classmethod
-    def set_tbl_rows(cls, n: int) -> type[Config]:
+    def set_tbl_rows(cls, n: int | None) -> type[Config]:
         """
         Set the max number of rows used to draw the table (both Dataframe and Series).
 
@@ -753,11 +811,14 @@ class Config(contextlib.ContextDecorator):
         └─────┴───────┘
 
         """
-        os.environ["POLARS_FMT_MAX_ROWS"] = str(n)
+        if n is None:
+            os.environ.pop("POLARS_FMT_MAX_ROWS", None)
+        else:
+            os.environ["POLARS_FMT_MAX_ROWS"] = str(n)
         return cls
 
     @classmethod
-    def set_tbl_width_chars(cls, width: int) -> type[Config]:
+    def set_tbl_width_chars(cls, width: int | None) -> type[Config]:
         """
         Set the number of characters used to draw the table.
 
@@ -767,11 +828,17 @@ class Config(contextlib.ContextDecorator):
             number of chars
 
         """
-        os.environ["POLARS_TABLE_WIDTH"] = str(width)
+        if width is None:
+            os.environ.pop("POLARS_TABLE_WIDTH", None)
+        else:
+            os.environ["POLARS_TABLE_WIDTH"] = str(width)
         return cls
 
     @classmethod
-    def set_verbose(cls, active: bool = True) -> type[Config]:
+    def set_verbose(cls, active: bool | None = True) -> type[Config]:
         """Enable additional verbose/debug logging."""
-        os.environ["POLARS_VERBOSE"] = str(int(active))
+        if active is None:
+            os.environ.pop("POLARS_VERBOSE", None)
+        else:
+            os.environ["POLARS_VERBOSE"] = str(int(active))
         return cls

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -117,26 +117,35 @@ class Config(contextlib.ContextDecorator):
         """
         Initialise a Config object instance for context manager usage.
 
-        Any `options` kwargs should correspond to the available named "set_"
-        methods, but can optionally to omit the "set_" prefix for brevity.
+        Any ``options`` kwargs should correspond to the available named "set_*"
+        methods, but are allowed to omit the "set_" prefix for brevity.
 
         Parameters
         ----------
         restore_defaults
             set all options to their default values (this is applied before
             setting any other options).
-        options
+        **options
             keyword args that will set the option; equivalent to calling the
             named "set_<option>" method with the given value.
 
         Examples
         --------
+        >>> df = pl.DataFrame({"abc": [1.0, 2.5, 5.0], "xyz": [True, False, True]})
         >>> with pl.Config(
         ...     # these options will be set for scope duration
         ...     tbl_formatting="ASCII_MARKDOWN",
-        ...     tbl_width_chars=180,
+        ...     tbl_hide_dataframe_shape=True,
+        ...     tbl_rows=10,
         ... ):
-        ...     pass
+        ...     print(df)
+        | abc | xyz   |
+        | --- | ---   |
+        | f64 | bool  |
+        |-----|-------|
+        | 1.0 | true  |
+        | 2.5 | false |
+        | 5.0 | true  |
 
         """
         # save original state _before_ any changes are made


### PR DESCRIPTION
Provides a consistent way to reset _individual_ `Config` options back to their default (without having to know what that default is) by simply setting them to `None`. The related environment var is popped, leaving it in the original/unset state.

**Example**:
```python
pl.Config.set_table_cols( None )
```

Added a note explaining this option to the docs, and added a thorough unit test that validates the behaviour.

Note: it's already easy to reset _all_ values by calling `pl.Config.restore_defaults()`.

---

**Also**: Both `set_tbl_cell_alignment` and `set_tbl_formatting` claimed to raise a `KeyError` if given invalid options. However, they did not actually do this (and a `KeyError` would have been the wrong type of error to raise even if they did ;)

This is now fixed, raising a `ValueError` in each case if the supplied option is invalid.