### PR TITLE
feat(python): Polars plugins

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -374,10 +374,9 @@ impl Utf8Chunked {
     /// Utility that reuses an string buffer to amortize allocations.
     /// Prefer this over an `apply` that returns an owned `String`.
     pub fn apply_to_buffer<'a, F>(&'a self, mut f: F) -> Self
-        where
-            F: FnMut(&'a str, &mut String)
+    where
+        F: FnMut(&'a str, &mut String),
     {
-
         let mut buf = String::new();
         let outer = |s: &'a str| {
             buf.clear();

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -370,6 +370,22 @@ impl Utf8Chunked {
         });
         Utf8Chunked::from_chunk_iter(self.name(), chunks)
     }
+
+    /// Utility that reuses an string buffer to amortize allocations.
+    /// Prefer this over an `apply` that returns an owned `String`.
+    pub fn apply_to_buffer<'a, F>(&'a self, mut f: F) -> Self
+        where
+            F: FnMut(&'a str, &mut String)
+    {
+
+        let mut buf = String::new();
+        let outer = |s: &'a str| {
+            buf.clear();
+            f(s, &mut buf);
+            unsafe { std::mem::transmute::<&str, &'a str>(buf.as_str()) }
+        };
+        self.apply_mut(outer)
+    }
 }
 
 impl BinaryChunked {

--- a/crates/polars-ffi/Cargo.toml
+++ b/crates/polars-ffi/Cargo.toml
@@ -11,4 +11,4 @@ repository.workspace = true
 
 [dependencies]
 arrow = { workspace = true }
-polars-core = { version = "0.32.0", path = "../polars-core", features = ["lazy", "zip_with", "random"], default-features = false }
+polars-core = { version = "0.32.0", path = "../polars-core", default-features = false }

--- a/crates/polars-ffi/Cargo.toml
+++ b/crates/polars-ffi/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "polars-ffi"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+arrow = { workspace = true }
+polars-core = { version = "0.32.0", path = "../polars-core", features = ["lazy", "zip_with", "random"], default-features = false }

--- a/crates/polars-ffi/src/lib.rs
+++ b/crates/polars-ffi/src/lib.rs
@@ -1,43 +1,85 @@
+use std::mem::ManuallyDrop;
+
 use arrow::ffi;
 use arrow::ffi::{ArrowArray, ArrowSchema};
 use polars_core::error::PolarsResult;
 use polars_core::prelude::{ArrayRef, ArrowField, Series};
 
+// A utility that helps releasing/owning memory.
+#[allow(dead_code)]
+struct PrivateData {
+    schema: Box<ArrowSchema>,
+    arrays: Box<[*mut ArrowArray]>,
+}
+
 /// An FFI exported `Series`.
 #[repr(C)]
 pub struct SeriesExport {
-    field: ArrowSchema,
-    arrays: *mut ArrowArray,
+    field: *mut ArrowSchema,
+    // A double ptr, so we can easily release the buffer
+    // without dropping the arrays.
+    arrays: *mut *mut ArrowArray,
     len: usize,
+    release: Option<unsafe extern "C" fn(arg1: *mut SeriesExport)>,
+    private_data: *mut std::os::raw::c_void,
+}
+
+impl Drop for SeriesExport {
+    fn drop(&mut self) {
+        if let Some(release) = self.release {
+            unsafe { release(self) }
+        }
+    }
+}
+
+// callback used to drop [SeriesExport] when it is exported.
+unsafe extern "C" fn c_release_series_export(e: *mut SeriesExport) {
+    if e.is_null() {
+        return;
+    }
+    let e = &mut *e;
+    let private = Box::from_raw(e.private_data as *mut PrivateData);
+    for ptr in private.arrays.iter() {
+        // drop the box, not the array
+        let _ = Box::from_raw(*ptr as *mut ManuallyDrop<ArrowArray>);
+    }
+
+    e.release = None;
 }
 
 pub fn export_series(s: &Series) -> SeriesExport {
     let field = ArrowField::new(s.name(), s.dtype().to_arrow(), true);
-    let schema = ffi::export_field_to_c(&field);
+    let schema = Box::new(ffi::export_field_to_c(&field));
     let mut arrays = s
         .chunks()
         .iter()
-        .map(|arr| ffi::export_array_to_c(arr.clone()))
+        .map(|arr| Box::into_raw(Box::new(ffi::export_array_to_c(arr.clone()))))
         .collect::<Box<_>>();
     let len = arrays.len();
     let ptr = arrays.as_mut_ptr();
-    Box::leak(arrays);
     SeriesExport {
-        field: schema,
+        field: schema.as_ref() as *const ArrowSchema as *mut ArrowSchema,
         arrays: ptr,
         len,
+        release: Some(c_release_series_export),
+        private_data: Box::into_raw(Box::new(PrivateData { arrays, schema }))
+            as *mut std::os::raw::c_void,
     }
 }
 
 /// # Safety
 /// `SeriesExport` must be valid
 pub unsafe fn import_series(e: SeriesExport) -> PolarsResult<Series> {
-    let field = ffi::import_field_from_c(&e.field)?;
+    let field = ffi::import_field_from_c(&(*e.field))?;
 
-    let chunks = (0..e.len).map(|i| {
-        let arr = std::ptr::read(e.arrays.add(i));
-        import_array(arr, &e.field)
-    }).collect::<PolarsResult<Vec<_>>>()?;
+    let pointers = std::slice::from_raw_parts_mut(e.arrays, e.len);
+    let chunks = pointers
+        .iter()
+        .map(|ptr| {
+            let arr = std::ptr::read(*ptr);
+            import_array(arr, &(*e.field))
+        })
+        .collect::<PolarsResult<Vec<_>>>()?;
 
     Ok(Series::from_chunks_and_dtype_unchecked(
         &field.name,
@@ -79,22 +121,8 @@ mod test {
         let s = Series::new("a", [1, 2]);
         let e = export_series(&s);
 
-        let s = vec![s];
-        let input = s.iter().map(export_series).collect::<Vec<_>>().into_boxed_slice();
-        let slice_ptr = input.as_ptr();
-        std::mem::forget(input);
-
-
-        let len = 1;
         unsafe {
-            let inputs = Vec::from_raw_parts(slice_ptr as *mut SeriesExport, len, len);
-            drop(inputs);
-        }
-        drop(s);
-
-
-        // unsafe {
-        //     assert_eq!(import_series(e).unwrap(), s);
-        // };
+            assert_eq!(import_series(e).unwrap(), s);
+        };
     }
 }

--- a/crates/polars-ffi/src/lib.rs
+++ b/crates/polars-ffi/src/lib.rs
@@ -1,0 +1,46 @@
+use arrow::ffi;
+use arrow::ffi::ArrowArray;
+use polars_core::error::{ArrowError, PolarsResult};
+use polars_core::prelude::{ArrayRef, ArrowField, Series};
+
+fn export_array(array: ArrayRef, name: &str) -> (ffi::ArrowArray, ffi::ArrowSchema) {
+    // importing an array requires an associated field so that the consumer knows its datatype.
+    // Thus, we need to export both
+    let field = ArrowField::new(name, array.data_type().clone(), true);
+    (
+        ffi::export_array_to_c(array),
+        ffi::export_field_to_c(&http://www.lurklurk.org/linkers/linkers.htmlfield),
+    )
+}
+
+/// # Safety
+/// `ArrowArray` and `ArrowSchema` must be valid
+unsafe fn import_array(
+    array: ffi::ArrowArray,
+    schema: &ffi::ArrowSchema,
+) -> PolarsResult<ArrayRef> {
+    let field = ffi::import_field_from_c(schema)?;
+    let out = ffi::import_array_from_c(array, field.data_type)?;
+    Ok(out)
+}
+
+#[repr(C)]
+struct SeriesExport {
+    field: ArrowField,
+    arrays: *mut *mut ArrowArray,
+    n_chunks: usize,
+}
+
+fn export_series(s: &Series) -> SeriesExport {
+    let field = ArrowField::new(name, s.dtype().to_arrow(), true);
+    let arrays = s
+        .chunks()
+        .iter()
+        .map(|arr| Box::into_raw(Box::new(ffi::export_array_to_c(arr.clone()))))
+        .collect::<Box<_>>();
+    SeriesExport {
+        field,
+        arrays: arrays.as_mut_ptr(),
+        n_chunks: s.n_chunks(),
+    }
+}

--- a/crates/polars-ffi/src/lib.rs
+++ b/crates/polars-ffi/src/lib.rs
@@ -1,16 +1,49 @@
 use arrow::ffi;
-use arrow::ffi::ArrowArray;
-use polars_core::error::{ArrowError, PolarsResult};
+use arrow::ffi::{ArrowArray, ArrowSchema};
+use polars_core::error::PolarsResult;
 use polars_core::prelude::{ArrayRef, ArrowField, Series};
 
-fn export_array(array: ArrayRef, name: &str) -> (ffi::ArrowArray, ffi::ArrowSchema) {
-    // importing an array requires an associated field so that the consumer knows its datatype.
-    // Thus, we need to export both
-    let field = ArrowField::new(name, array.data_type().clone(), true);
-    (
-        ffi::export_array_to_c(array),
-        ffi::export_field_to_c(&http://www.lurklurk.org/linkers/linkers.htmlfield),
-    )
+/// An FFI exported `Series`.
+#[repr(C)]
+pub struct SeriesExport {
+    field: ArrowSchema,
+    arrays: *mut ArrowArray,
+    len: usize,
+}
+
+pub fn export_series(s: &Series) -> SeriesExport {
+    let field = ArrowField::new(s.name(), s.dtype().to_arrow(), true);
+    let schema = ffi::export_field_to_c(&field);
+    let mut arrays = s
+        .chunks()
+        .iter()
+        .map(|arr| ffi::export_array_to_c(arr.clone()))
+        .collect::<Box<_>>();
+    let len = arrays.len();
+    let ptr = arrays.as_mut_ptr();
+    Box::leak(arrays);
+    SeriesExport {
+        field: schema,
+        arrays: ptr,
+        len,
+    }
+}
+
+/// # Safety
+/// `SeriesExport`
+pub unsafe fn import_series(e: SeriesExport) -> PolarsResult<Series> {
+    let field = ffi::import_field_from_c(&e.field)?;
+
+    let arrays = Vec::from_raw_parts(e.arrays, e.len, e.len);
+    let chunks = arrays
+        .into_iter()
+        .map(|arr| import_array(arr, &e.field))
+        .collect::<PolarsResult<Vec<_>>>()?;
+    Ok(Series::from_chunks_and_dtype_unchecked(
+        &field.name,
+        chunks,
+        &(&field.data_type).into(),
+    ))
 }
 
 /// # Safety
@@ -24,23 +57,19 @@ unsafe fn import_array(
     Ok(out)
 }
 
-#[repr(C)]
-struct SeriesExport {
-    field: ArrowField,
-    arrays: *mut *mut ArrowArray,
-    n_chunks: usize,
-}
+#[cfg(test)]
+mod test {
+    use polars_core::prelude::*;
 
-fn export_series(s: &Series) -> SeriesExport {
-    let field = ArrowField::new(name, s.dtype().to_arrow(), true);
-    let arrays = s
-        .chunks()
-        .iter()
-        .map(|arr| Box::into_raw(Box::new(ffi::export_array_to_c(arr.clone()))))
-        .collect::<Box<_>>();
-    SeriesExport {
-        field,
-        arrays: arrays.as_mut_ptr(),
-        n_chunks: s.n_chunks(),
+    use super::*;
+
+    #[test]
+    fn test_ffi() {
+        let s = Series::new("a", [1, 2]);
+        let e = export_series(&s);
+
+        unsafe {
+            assert_eq!(import_series(e).unwrap(), s);
+        };
     }
 }

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -12,8 +12,10 @@ description = "Lazy query engine for the Polars DataFrame library"
 doctest = false
 
 [dependencies]
+libloading = { version = "0.8.0", optional = true }
 polars-arrow = { version = "0.32.0", path = "../polars-arrow" }
 polars-core = { version = "0.32.0", path = "../polars-core", features = ["lazy", "zip_with", "random"], default-features = false }
+polars-ffi = { version = "0.32.0", path = "../polars-ffi", optional = true }
 polars-io = { version = "0.32.0", path = "../polars-io", features = ["lazy", "csv"], default-features = false }
 polars-ops = { version = "0.32.0", path = "../polars-ops", default-features = false }
 polars-time = { version = "0.32.0", path = "../polars-time", optional = true }
@@ -140,6 +142,7 @@ list_any_all = ["polars-ops/list_any_all"]
 cutqcut = ["polars-ops/cutqcut"]
 rle = ["polars-ops/rle"]
 extract_groups = ["regex", "dtype-struct", "polars-ops/extract_groups"]
+ffi_plugin = ["libloading", "polars-ffi"]
 
 bigidx = ["polars-arrow/bigidx", "polars-core/bigidx", "polars-utils/bigidx"]
 

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -37,7 +37,7 @@ mod rolling;
 mod round;
 #[cfg(feature = "row_hash")]
 mod row_hash;
-mod schema;
+pub(super) mod schema;
 #[cfg(feature = "search_sorted")]
 mod search_sorted;
 mod shift_and_fill;
@@ -236,7 +236,6 @@ pub enum FunctionExpr {
     FfiPlugin {
         lib: Arc<str>,
         symbol: Arc<str>,
-        output_type: DataType,
     },
 }
 
@@ -268,11 +267,9 @@ impl Hash for FunctionExpr {
             FunctionExpr::FfiPlugin {
                 lib,
                 symbol,
-                output_type,
             } => {
                 lib.hash(state);
                 symbol.hash(state);
-                output_type.hash(state);
             },
             _ => {},
         }
@@ -660,7 +657,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             SetSortedFlag(sorted) => map!(dispatch::set_sorted_flag, sorted),
             #[cfg(feature = "ffi_plugin")]
             FfiPlugin { lib, symbol, .. } => {
-                map_as_slice!(plugin::call_plugin, lib.as_ref(), symbol.as_ref())
+                unsafe { map_as_slice!(plugin::call_plugin, lib.as_ref(), symbol.as_ref()) }
             },
         }
     }

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -264,10 +264,7 @@ impl Hash for FunctionExpr {
             #[cfg(feature = "dtype-categorical")]
             FunctionExpr::Categorical(f) => f.hash(state),
             #[cfg(feature = "ffi_plugin")]
-            FunctionExpr::FfiPlugin {
-                lib,
-                symbol,
-            } => {
+            FunctionExpr::FfiPlugin { lib, symbol } => {
                 lib.hash(state);
                 symbol.hash(state);
             },
@@ -656,8 +653,8 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             Random { method, seed } => map!(random::random, method, seed),
             SetSortedFlag(sorted) => map!(dispatch::set_sorted_flag, sorted),
             #[cfg(feature = "ffi_plugin")]
-            FfiPlugin { lib, symbol, .. } => {
-                unsafe { map_as_slice!(plugin::call_plugin, lib.as_ref(), symbol.as_ref()) }
+            FfiPlugin { lib, symbol, .. } => unsafe {
+                map_as_slice!(plugin::call_plugin, lib.as_ref(), symbol.as_ref())
             },
         }
     }

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -230,6 +230,7 @@ pub enum FunctionExpr {
         seed: Option<u64>,
     },
     SetSortedFlag(IsSorted),
+    Ffi
 }
 
 impl Hash for FunctionExpr {

--- a/crates/polars-plan/src/dsl/function_expr/plugin.rs
+++ b/crates/polars-plan/src/dsl/function_expr/plugin.rs
@@ -1,0 +1,22 @@
+use polars_ffi::*;
+
+use super::*;
+
+pub(super) fn call_plugin(s: &[Series], lib: &str, symbol: &str) -> PolarsResult<Series> {
+    unsafe {
+        let lib = libloading::Library::new(lib).map_err(|e| {
+            PolarsError::ComputeError(format!("error loading dynamic library: {e}").into())
+        })?;
+        let symbol: libloading::Symbol<
+            unsafe extern "C" fn(*const SeriesExport, usize) -> SeriesExport,
+        > = lib.get(symbol.as_bytes()).unwrap();
+
+        let n_args = s.len();
+
+        let input = s.iter().map(export_series).collect::<Vec<_>>();
+        let slice_ptr = input.as_ptr();
+
+        let out = symbol(slice_ptr, n_args);
+        import_series(out)
+    }
+}

--- a/crates/polars-plan/src/dsl/function_expr/plugin.rs
+++ b/crates/polars-plan/src/dsl/function_expr/plugin.rs
@@ -1,15 +1,40 @@
+use std::sync::RwLock;
 use polars_ffi::*;
 
 use super::*;
 use arrow::ffi::{
     ArrowSchema, import_field_from_c
 };
+use libloading::Library;
+use once_cell::sync::Lazy;
+
+static LOADED: Lazy<RwLock<PlHashMap<String, Library>>> = Lazy::new(|| {
+    Default::default()
+});
+
+fn get_lib(lib: &str) -> PolarsResult<&'static Library> {
+    let lib_map = LOADED.read().unwrap();
+    if let Some(library) = lib_map.get(lib) {
+        // lifetime is static as we never remove libraries.
+        return Ok(unsafe { std::mem::transmute::<&Library, &'static Library>(library) })
+    } else {
+            drop(lib_map);
+            let libary = unsafe { Library::new(lib).map_err(|e| {
+                PolarsError::ComputeError(format!("error loading dynamic library: {e}").into())
+            })?} ;
+
+            let mut lib_map = LOADED.write().unwrap();
+            lib_map.insert(lib.to_string(), libary);
+            drop(lib_map);
+
+        return get_lib(lib)
+    }
+}
 
 pub(super) unsafe fn call_plugin(s: &[Series], lib: &str, symbol: &str) -> PolarsResult<Series> {
-    let out = {
-        let lib = libloading::Library::new(lib).map_err(|e| {
-            PolarsError::ComputeError(format!("error loading dynamic library: {e}").into())
-        })?;
+    let lib = get_lib(lib)?;
+
+
         let symbol: libloading::Symbol<
             unsafe extern "C" fn(*const SeriesExport, usize) -> SeriesExport,
         > = lib.get(symbol.as_bytes()).unwrap();
@@ -20,20 +45,12 @@ pub(super) unsafe fn call_plugin(s: &[Series], lib: &str, symbol: &str) -> Polar
         let slice_ptr = input.as_ptr();
         std::mem::forget(input);
 
-        // let out = symbol(slice_ptr, n_args);
-        // let out = import_series(out);
-        // out
-        slice_ptr
-    };
-        // dbg!(out);
-        drop(out);
-        Ok(Series::full_null("", s[0].len(), &DataType::Null))
+        let out = symbol(slice_ptr, n_args);
+        import_series(out)
 }
 
 pub(super) unsafe fn plugin_field(fields: &[Field], lib: &str, symbol: &str) -> PolarsResult<Field> {
-    let lib = libloading::Library::new(lib).map_err(|e| {
-        PolarsError::ComputeError(format!("error loading dynamic library: {e}").into())
-    })?;
+    let lib = get_lib(lib)?;
 
     let symbol: libloading::Symbol<
         unsafe extern "C" fn(*const ArrowSchema, usize) -> ArrowSchema,
@@ -42,7 +59,6 @@ pub(super) unsafe fn plugin_field(fields: &[Field], lib: &str, symbol: &str) -> 
     let fields = fields.iter().map(|field| arrow::ffi::export_field_to_c(&field.to_arrow())).collect::<Vec<_>>().into_boxed_slice();
     let n_args = fields.len();
     let slice_ptr = fields.as_ptr();
-    std::mem::forget(fields);
     let out = symbol(slice_ptr, n_args);
 
     let arrow_field = import_field_from_c(&out)?;

--- a/crates/polars-plan/src/dsl/function_expr/plugin.rs
+++ b/crates/polars-plan/src/dsl/function_expr/plugin.rs
@@ -1,9 +1,12 @@
 use polars_ffi::*;
 
 use super::*;
+use arrow::ffi::{
+    ArrowSchema, import_field_from_c
+};
 
-pub(super) fn call_plugin(s: &[Series], lib: &str, symbol: &str) -> PolarsResult<Series> {
-    unsafe {
+pub(super) unsafe fn call_plugin(s: &[Series], lib: &str, symbol: &str) -> PolarsResult<Series> {
+    let out = {
         let lib = libloading::Library::new(lib).map_err(|e| {
             PolarsError::ComputeError(format!("error loading dynamic library: {e}").into())
         })?;
@@ -13,10 +16,35 @@ pub(super) fn call_plugin(s: &[Series], lib: &str, symbol: &str) -> PolarsResult
 
         let n_args = s.len();
 
-        let input = s.iter().map(export_series).collect::<Vec<_>>();
+        let input = s.iter().map(export_series).collect::<Vec<_>>().into_boxed_slice();
         let slice_ptr = input.as_ptr();
+        std::mem::forget(input);
 
-        let out = symbol(slice_ptr, n_args);
-        import_series(out)
-    }
+        // let out = symbol(slice_ptr, n_args);
+        // let out = import_series(out);
+        // out
+        slice_ptr
+    };
+        // dbg!(out);
+        drop(out);
+        Ok(Series::full_null("", s[0].len(), &DataType::Null))
+}
+
+pub(super) unsafe fn plugin_field(fields: &[Field], lib: &str, symbol: &str) -> PolarsResult<Field> {
+    let lib = libloading::Library::new(lib).map_err(|e| {
+        PolarsError::ComputeError(format!("error loading dynamic library: {e}").into())
+    })?;
+
+    let symbol: libloading::Symbol<
+        unsafe extern "C" fn(*const ArrowSchema, usize) -> ArrowSchema,
+    > = lib.get(symbol.as_bytes()).unwrap();
+
+    let fields = fields.iter().map(|field| arrow::ffi::export_field_to_c(&field.to_arrow())).collect::<Vec<_>>().into_boxed_slice();
+    let n_args = fields.len();
+    let slice_ptr = fields.as_ptr();
+    std::mem::forget(fields);
+    let out = symbol(slice_ptr, n_args);
+
+    let arrow_field = import_field_from_c(&out)?;
+    Ok(Field::from(&arrow_field))
 }

--- a/crates/polars-plan/src/dsl/function_expr/plugin.rs
+++ b/crates/polars-plan/src/dsl/function_expr/plugin.rs
@@ -1,62 +1,71 @@
 use std::sync::RwLock;
+
+use arrow::ffi::{import_field_from_c, ArrowSchema};
+use libloading::Library;
+use once_cell::sync::Lazy;
 use polars_ffi::*;
 
 use super::*;
-use arrow::ffi::{
-    ArrowSchema, import_field_from_c
-};
-use libloading::Library;
-use once_cell::sync::Lazy;
 
-static LOADED: Lazy<RwLock<PlHashMap<String, Library>>> = Lazy::new(|| {
-    Default::default()
-});
+static LOADED: Lazy<RwLock<PlHashMap<String, Library>>> = Lazy::new(Default::default);
 
 fn get_lib(lib: &str) -> PolarsResult<&'static Library> {
     let lib_map = LOADED.read().unwrap();
     if let Some(library) = lib_map.get(lib) {
         // lifetime is static as we never remove libraries.
-        return Ok(unsafe { std::mem::transmute::<&Library, &'static Library>(library) })
+        Ok(unsafe { std::mem::transmute::<&Library, &'static Library>(library) })
     } else {
-            drop(lib_map);
-            let libary = unsafe { Library::new(lib).map_err(|e| {
+        drop(lib_map);
+        let library = unsafe {
+            Library::new(lib).map_err(|e| {
                 PolarsError::ComputeError(format!("error loading dynamic library: {e}").into())
-            })?} ;
+            })?
+        };
 
-            let mut lib_map = LOADED.write().unwrap();
-            lib_map.insert(lib.to_string(), libary);
-            drop(lib_map);
+        let mut lib_map = LOADED.write().unwrap();
+        lib_map.insert(lib.to_string(), library);
+        drop(lib_map);
 
-        return get_lib(lib)
+        get_lib(lib)
     }
 }
 
 pub(super) unsafe fn call_plugin(s: &[Series], lib: &str, symbol: &str) -> PolarsResult<Series> {
     let lib = get_lib(lib)?;
 
-
-        let symbol: libloading::Symbol<
-            unsafe extern "C" fn(*const SeriesExport, usize) -> SeriesExport,
-        > = lib.get(symbol.as_bytes()).unwrap();
-
-        let n_args = s.len();
-
-        let input = s.iter().map(export_series).collect::<Vec<_>>().into_boxed_slice();
-        let slice_ptr = input.as_ptr();
-        std::mem::forget(input);
-
-        let out = symbol(slice_ptr, n_args);
-        import_series(out)
-}
-
-pub(super) unsafe fn plugin_field(fields: &[Field], lib: &str, symbol: &str) -> PolarsResult<Field> {
-    let lib = get_lib(lib)?;
-
     let symbol: libloading::Symbol<
-        unsafe extern "C" fn(*const ArrowSchema, usize) -> ArrowSchema,
+        unsafe extern "C" fn(*const SeriesExport, usize) -> SeriesExport,
     > = lib.get(symbol.as_bytes()).unwrap();
 
-    let fields = fields.iter().map(|field| arrow::ffi::export_field_to_c(&field.to_arrow())).collect::<Vec<_>>().into_boxed_slice();
+    let n_args = s.len();
+
+    let input = s.iter().map(export_series).collect::<Vec<_>>();
+    let slice_ptr = input.as_ptr();
+    let out = symbol(slice_ptr, n_args);
+
+    for e in input {
+        std::mem::forget(e);
+    }
+
+    import_series(out)
+}
+
+pub(super) unsafe fn plugin_field(
+    fields: &[Field],
+    lib: &str,
+    symbol: &str,
+) -> PolarsResult<Field> {
+    let lib = get_lib(lib)?;
+
+    let symbol: libloading::Symbol<unsafe extern "C" fn(*const ArrowSchema, usize) -> ArrowSchema> =
+        lib.get(symbol.as_bytes()).unwrap();
+
+    // we deallocate the fields buffer
+    let fields = fields
+        .iter()
+        .map(|field| arrow::ffi::export_field_to_c(&field.to_arrow()))
+        .collect::<Vec<_>>()
+        .into_boxed_slice();
     let n_args = fields.len();
     let slice_ptr = fields.as_ptr();
     let out = symbol(slice_ptr, n_args);

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -241,7 +241,9 @@ impl FunctionExpr {
             Random { .. } => mapper.with_same_dtype(),
             SetSortedFlag(_) => mapper.with_same_dtype(),
             #[cfg(feature = "ffi_plugin")]
-            FfiPlugin { lib, symbol } => unsafe { plugin::plugin_field(fields, lib, &format!("__polars_field_{}", symbol.as_ref())) },
+            FfiPlugin { lib, symbol } => unsafe {
+                plugin::plugin_field(fields, lib, &format!("__polars_field_{}", symbol.as_ref()))
+            },
         }
     }
 }
@@ -252,9 +254,7 @@ pub struct FieldsMapper<'a> {
 
 impl<'a> FieldsMapper<'a> {
     pub fn new(fields: &'a [Field]) -> Self {
-        Self {
-            fields
-        }
+        Self { fields }
     }
 
     /// Field with the same dtype.

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -240,6 +240,10 @@ impl FunctionExpr {
             #[cfg(feature = "random")]
             Random { .. } => mapper.with_same_dtype(),
             SetSortedFlag(_) => mapper.with_same_dtype(),
+            #[cfg(feature = "ffi_plugin")]
+            // TODO! must be a function that calls the inner type.
+            // use python for this?
+            FfiPlugin { output_type, .. } => mapper.with_dtype(output_type.clone()),
         }
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -241,36 +241,40 @@ impl FunctionExpr {
             Random { .. } => mapper.with_same_dtype(),
             SetSortedFlag(_) => mapper.with_same_dtype(),
             #[cfg(feature = "ffi_plugin")]
-            // TODO! must be a function that calls the inner type.
-            // use python for this?
-            FfiPlugin { output_type, .. } => mapper.with_dtype(output_type.clone()),
+            FfiPlugin { lib, symbol } => unsafe { plugin::plugin_field(fields, lib, &format!("__polars_field_{}", symbol.as_ref())) },
         }
     }
 }
 
-pub(super) struct FieldsMapper<'a> {
+pub struct FieldsMapper<'a> {
     fields: &'a [Field],
 }
 
 impl<'a> FieldsMapper<'a> {
+    pub fn new(fields: &'a [Field]) -> Self {
+        Self {
+            fields
+        }
+    }
+
     /// Field with the same dtype.
-    pub(super) fn with_same_dtype(&self) -> PolarsResult<Field> {
+    pub fn with_same_dtype(&self) -> PolarsResult<Field> {
         self.map_dtype(|dtype| dtype.clone())
     }
 
     /// Set a dtype.
-    pub(super) fn with_dtype(&self, dtype: DataType) -> PolarsResult<Field> {
+    pub fn with_dtype(&self, dtype: DataType) -> PolarsResult<Field> {
         Ok(Field::new(self.fields[0].name(), dtype))
     }
 
     /// Map a single dtype.
-    pub(super) fn map_dtype(&self, func: impl Fn(&DataType) -> DataType) -> PolarsResult<Field> {
+    pub fn map_dtype(&self, func: impl Fn(&DataType) -> DataType) -> PolarsResult<Field> {
         let dtype = func(self.fields[0].data_type());
         Ok(Field::new(self.fields[0].name(), dtype))
     }
 
     /// Map to a float supertype.
-    pub(super) fn map_to_float_dtype(&self) -> PolarsResult<Field> {
+    pub fn map_to_float_dtype(&self) -> PolarsResult<Field> {
         self.map_dtype(|dtype| match dtype {
             DataType::Float32 => DataType::Float32,
             _ => DataType::Float64,
@@ -278,13 +282,13 @@ impl<'a> FieldsMapper<'a> {
     }
 
     /// Map to a physical type.
-    pub(super) fn to_physical_type(&self) -> PolarsResult<Field> {
+    pub fn to_physical_type(&self) -> PolarsResult<Field> {
         self.map_dtype(|dtype| dtype.to_physical())
     }
 
     /// Map a single dtype with a potentially failing mapper function.
     #[cfg(any(feature = "timezones", feature = "dtype-array"))]
-    pub(super) fn try_map_dtype(
+    pub fn try_map_dtype(
         &self,
         func: impl Fn(&DataType) -> PolarsResult<DataType>,
     ) -> PolarsResult<Field> {
@@ -293,7 +297,7 @@ impl<'a> FieldsMapper<'a> {
     }
 
     /// Map all dtypes with a potentially failing mapper function.
-    pub(super) fn try_map_dtypes(
+    pub fn try_map_dtypes(
         &self,
         func: impl Fn(&[&DataType]) -> PolarsResult<DataType>,
     ) -> PolarsResult<Field> {
@@ -309,7 +313,7 @@ impl<'a> FieldsMapper<'a> {
     }
 
     /// Map the dtype to the "supertype" of all fields.
-    pub(super) fn map_to_supertype(&self) -> PolarsResult<Field> {
+    pub fn map_to_supertype(&self) -> PolarsResult<Field> {
         let mut first = self.fields[0].clone();
         let mut st = first.data_type().clone();
         for field in &self.fields[1..] {
@@ -320,7 +324,7 @@ impl<'a> FieldsMapper<'a> {
     }
 
     /// Map the dtype to the dtype of the list elements.
-    pub(super) fn map_to_list_inner_dtype(&self) -> PolarsResult<Field> {
+    pub fn map_to_list_inner_dtype(&self) -> PolarsResult<Field> {
         let mut first = self.fields[0].clone();
         let dt = first
             .data_type()
@@ -332,7 +336,7 @@ impl<'a> FieldsMapper<'a> {
     }
 
     /// Map the dtypes to the "supertype" of a list of lists.
-    pub(super) fn map_to_list_supertype(&self) -> PolarsResult<Field> {
+    pub fn map_to_list_supertype(&self) -> PolarsResult<Field> {
         self.try_map_dtypes(|dts| {
             let mut super_type_inner = None;
 
@@ -358,7 +362,7 @@ impl<'a> FieldsMapper<'a> {
 
     /// Set the timezone of a datetime dtype.
     #[cfg(feature = "timezones")]
-    pub(super) fn map_datetime_dtype_timezone(&self, tz: Option<&TimeZone>) -> PolarsResult<Field> {
+    pub fn map_datetime_dtype_timezone(&self, tz: Option<&TimeZone>) -> PolarsResult<Field> {
         self.try_map_dtype(|dt| {
             if let DataType::Datetime(tu, _) = dt {
                 Ok(DataType::Datetime(*tu, tz.cloned()))
@@ -368,7 +372,7 @@ impl<'a> FieldsMapper<'a> {
         })
     }
 
-    fn nested_sum_type(&self) -> PolarsResult<Field> {
+    pub fn nested_sum_type(&self) -> PolarsResult<Field> {
         let mut first = self.fields[0].clone();
         use DataType::*;
         let dt = first.data_type().inner_dtype().cloned().unwrap_or(Unknown);
@@ -382,7 +386,7 @@ impl<'a> FieldsMapper<'a> {
     }
 
     #[cfg(feature = "extract_jsonpath")]
-    pub(super) fn with_opt_dtype(&self, dtype: Option<DataType>) -> PolarsResult<Field> {
+    pub fn with_opt_dtype(&self, dtype: Option<DataType>) -> PolarsResult<Field> {
         let dtype = dtype.unwrap_or(DataType::Unknown);
         self.with_dtype(dtype)
     }

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -65,6 +65,7 @@ use crate::prelude::*;
 use crate::utils::has_expr;
 #[cfg(feature = "is_in")]
 use crate::utils::has_leaf_literal;
+pub use function_expr::schema::FieldsMapper;
 
 impl Expr {
     /// Modify the Options passed to the `Function` node.

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -41,6 +41,7 @@ pub use arity::*;
 #[cfg(feature = "dtype-array")]
 pub use array::*;
 pub use expr::*;
+pub use function_expr::schema::FieldsMapper;
 pub use function_expr::*;
 pub use functions::*;
 pub use list::*;
@@ -65,7 +66,6 @@ use crate::prelude::*;
 use crate::utils::has_expr;
 #[cfg(feature = "is_in")]
 use crate::utils::has_leaf_literal;
-pub use function_expr::schema::FieldsMapper;
 
 impl Expr {
     /// Modify the Options passed to the `Function` node.

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -998,6 +998,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d580318f95776505201b28cf98eb1fa5e4be3b689633ba6a3e6cd880ff22d8cb"
+dependencies = [
+ "cfg-if",
+ "windows-sys",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1463,6 +1473,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "polars-ffi"
+version = "0.32.0"
+dependencies = [
+ "arrow2",
+ "polars-core",
+]
+
+[[package]]
 name = "polars-io"
 version = "0.32.0"
 dependencies = [
@@ -1588,9 +1606,11 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "ciborium",
+ "libloading",
  "once_cell",
  "polars-arrow",
  "polars-core",
+ "polars-ffi",
  "polars-io",
  "polars-ops",
  "polars-time",
@@ -1697,6 +1717,7 @@ dependencies = [
  "polars-error",
  "polars-lazy",
  "polars-ops",
+ "polars-plan",
  "pyo3",
  "pyo3-built",
  "serde_json",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -12,6 +12,7 @@ polars-algo = { path = "../crates/polars-algo", default-features = false }
 polars-core = { path = "../crates/polars-core", default-features = false, features = ["python"] }
 polars-error = { path = "../crates/polars-error" }
 polars-lazy = { path = "../crates/polars-lazy", default-features = false, features = ["python"] }
+polars-plan = { path = "../crates/polars-plan", default-features = false }
 polars-ops = { path = "../crates/polars-ops", default-features = false }
 
 ahash = "0.8"
@@ -139,6 +140,7 @@ list_any_all = ["polars/list_any_all"]
 cutqcut = ["polars/cutqcut"]
 rle = ["polars/rle"]
 extract_groups = ["polars/extract_groups"]
+ffi_plugin = ["polars-plan/ffi_plugin"]
 
 all = [
   "dtype-i8",
@@ -185,6 +187,7 @@ all = [
   "rle",
   "extract_groups",
   "polars-ops/convert_index",
+  "ffi_plugin"
 ]
 
 # we cannot conditionally activate simd

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -12,8 +12,8 @@ polars-algo = { path = "../crates/polars-algo", default-features = false }
 polars-core = { path = "../crates/polars-core", default-features = false, features = ["python"] }
 polars-error = { path = "../crates/polars-error" }
 polars-lazy = { path = "../crates/polars-lazy", default-features = false, features = ["python"] }
-polars-plan = { path = "../crates/polars-plan", default-features = false }
 polars-ops = { path = "../crates/polars-ops", default-features = false }
+polars-plan = { path = "../crates/polars-plan", default-features = false }
 
 ahash = "0.8"
 ciborium = "0.2"
@@ -187,7 +187,7 @@ all = [
   "rle",
   "extract_groups",
   "polars-ops/convert_index",
-  "ffi_plugin"
+  "ffi_plugin",
 ]
 
 # we cannot conditionally activate simd

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -9265,6 +9265,62 @@ class Expr:
             function, window_size, weights, min_periods, center=center
         )
 
+    def _register_plugin(
+        self,
+        lib: str,
+        symbol: str,
+        args: list[IntoExpr] | None = None,
+        *,
+        is_elementwise: bool = False,
+        input_wildcard_expansion: bool = False,
+        auto_explode: bool = False,
+        cast_to_supertypes: bool = False,
+    ) -> Self:
+        """
+        Register a shared library as a plugin
+
+        .. warning::
+            This is highly unsafe as this will call the C function
+            loaded by ``lib::symbol``
+
+        .. note::
+            This functionality is unstable and may change without it
+            being considered breaking.
+
+        Parameters
+        ----------
+        lib
+            Library to load.
+        symbol
+            Function to load.
+        is_elementwise
+            If the function only operates on scalars
+            this will trigger fast paths.
+        input_wildcard_expansion
+            Expand expressions as input of this function.
+        auto_explode
+            Explode the results in a group_by.
+            This is recommended for aggregation functions.
+        cast_to_supertypes
+            Cast the input datatypes to their supertype.
+
+        """
+        if args is None:
+            args = []
+        else:
+            args = [parse_as_expression(a) for a in args]
+        return self._from_pyexpr(
+            self._pyexpr.register_plugin(
+                lib,
+                symbol,
+                args,
+                is_elementwise,
+                input_wildcard_expansion,
+                auto_explode,
+                cast_to_supertypes,
+            )
+        )
+
     @property
     def bin(self) -> ExprBinaryNameSpace:
         """
@@ -9396,24 +9452,6 @@ class Expr:
 
         """
         return ExprStructNameSpace(self)
-
-    def _register_plugin(self,
-                         lib: str,
-    symbol: str,
-    is_elementwise: bool = False,
-    input_wildcard_expansion: bool = False,
-    auto_explode: bool = False,
-    cast_to_supertypes: bool = False,
-                         ) -> Self:
-
-        return self._from_pyexpr(self._pyexpr.register_plugin(
-            lib,
-            symbol,
-            is_elementwise,
-            input_wildcard_expansion,
-            auto_explode,
-            cast_to_supertypes
-        ))
 
 
 def _prepare_alpha(

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -9397,6 +9397,24 @@ class Expr:
         """
         return ExprStructNameSpace(self)
 
+    def _register_plugin(self,
+                         lib: str,
+    symbol: str,
+    is_elementwise: bool = False,
+    input_wildcard_expansion: bool = False,
+    auto_explode: bool = False,
+    cast_to_supertypes: bool = False,
+                         ) -> Self:
+
+        return self._from_pyexpr(self._pyexpr.register_plugin(
+            lib,
+            symbol,
+            is_elementwise,
+            input_wildcard_expansion,
+            auto_explode,
+            cast_to_supertypes
+        ))
+
 
 def _prepare_alpha(
     com: float | int | None = None,

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -9277,7 +9277,7 @@ class Expr:
         cast_to_supertypes: bool = False,
     ) -> Self:
         """
-        Register a shared library as a plugin
+        Register a shared library as a plugin.
 
         .. warning::
             This is highly unsafe as this will call the C function
@@ -9293,6 +9293,8 @@ class Expr:
             Library to load.
         symbol
             Function to load.
+        args
+            Arguments (other than self) passed to this function.
         is_elementwise
             If the function only operates on scalars
             this will trigger fast paths.

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -868,7 +868,17 @@ def warn_on_inefficient_map(
             )
 
 
-__all__ = [
-    "BytecodeParser",
-    "warn_on_inefficient_map",
-]
+def is_shared_lib(file: str) -> bool:
+    return file.endswith((".so", ".dll"))
+
+
+def _get_shared_lib_location(main_file: Any) -> str:
+    import os
+
+    directory = os.path.dirname(main_file)  # noqa: PTH120
+    return os.path.join(  # noqa: PTH118
+        directory, next(filter(is_shared_lib, os.listdir(directory)))
+    )
+
+
+__all__ = ["BytecodeParser", "warn_on_inefficient_map", "_get_shared_lib_location"]

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -856,6 +856,7 @@ impl PyExpr {
     }
 
     #[cfg(feature = "ffi_plugin")]
+    #[allow(clippy::too_many_arguments)]
     fn register_plugin(
         &self,
         lib: &str,


### PR DESCRIPTION
This allows support for polars plugins. These are expression exposed in a different shared library and dynamically linked into the polars main library.

This mean we or third parties can create their own expressions and they will run on our engine without python interference. So no blockage by the GIL.

We can therefore keep polars more lean and maybe add support for a `polars-distance`, `polars-geo`, `polars-ml`, etc. Those can then have specialized expressions and don't have to worry as much for code bloat as they can be optionally installed.

The idea is that you define an expression in another Rust crate with a proc_macro `polars_expr`.

That macro can have the following attributes:

- `output_type` -> to define the output type of that expression
- `type_func` -> to define a function that computes the output type based on input types.

Here is an example of a `String` conversion expression that converts any string to [pig latin](https://en.wikipedia.org/wiki/Pig_Latin):

```rust
fn pig_latin_str(value: &str, output: &mut String) {
    if let Some(first_char) = value.chars().next() {
        write!(output, "{}{}ay", &value[1..], first_char).unwrap()
    }
}

#[polars_expr(output_type=Utf8)]
fn pig_latinnify(inputs: &[Series]) -> PolarsResult<Series> {
    let ca = inputs[0].utf8()?;
    let out: Utf8Chunked = ca.apply_to_buffer(pig_latin_str);
    Ok(out.into_series())
}
```

On the python side this expression can then be registered under a namespace:

```python
import polars as pl
from polars.utils.udfs import _get_shared_lib_location

lib = _get_shared_lib_location(__file__)


@pl.api.register_expr_namespace("language")
class Language:
    def __init__(self, expr: pl.Expr):
        self._expr = expr

    def pig_latinnify(self) -> pl.Expr:
        return self._expr._register_plugin(
            lib=lib,
            symbol="pig_latinnify",
            is_elementwise=True,
        )
```

Compile/ship and then it is ready to use:

```python
import polars as pl
from expression_lib import Language

df = pl.DataFrame({
    "names": ["Richard", "Alice", "Bob"],
})


out = df.with_columns(
   pig_latin = pl.col("names").language.pig_latinnify()
)
print(out)
```

```
shape: (3, 2)
┌─────────┬───────────┐
│ names   ┆ pig_latin │
│ ---     ┆ ---       │
│ str     ┆ str       │
╞═════════╪═══════════╡
│ Richard ┆ ichardRay │
│ Alice   ┆ liceAay   │
│ Bob     ┆ obBay     │
└─────────┴───────────┘
```

See the full example here: https://github.com/pola-rs/pyo3-polars/tree/plugin/example/derive_expression