### PR TITLE
docs(Rust): enhance internal crates readme with reference to main crate

### DIFF
--- a/crates/polars-algo/README.md
+++ b/crates/polars-algo/README.md
@@ -1,5 +1,5 @@
 # polars-algo
 
-`polars-algo` is a sub-crate of Polars that contains algorithms built upon Polars primitives.
+`polars-algo` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, designed to house algorithms built on Polars primitives.
 
-Not intended for external usage
+**Important Note**: This crate is **not intended for external usage**. If you're looking to use Polars, please refer to the main [Polars crate](https://crates.io/crates/polars) instead.

--- a/crates/polars-arrow/README.md
+++ b/crates/polars-arrow/README.md
@@ -1,5 +1,6 @@
 # polars-arrow
 
-`polars-arrow` is a sub-crate that provides Arrow interfaces for the Polars dataframe library.
+`polars-arrow` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, offering Arrow interfaces.
 
-Not intended for external usage
+**Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
+

--- a/crates/polars-arrow/README.md
+++ b/crates/polars-arrow/README.md
@@ -3,4 +3,3 @@
 `polars-arrow` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, offering Arrow interfaces.
 
 **Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
-

--- a/crates/polars-core/README.md
+++ b/crates/polars-core/README.md
@@ -1,5 +1,6 @@
 # polars-core
 
-`polars-core` is a sub-crate that provides core functionality for the Polars dataframe library.
+`polars-core` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, providing its core functionalities.
 
-Not intended for external usage
+**Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
+

--- a/crates/polars-core/README.md
+++ b/crates/polars-core/README.md
@@ -3,4 +3,3 @@
 `polars-core` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, providing its core functionalities.
 
 **Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
-

--- a/crates/polars-error/README.md
+++ b/crates/polars-error/README.md
@@ -1,5 +1,6 @@
 # polars-error
 
-`polars-error` is a sub-crate that provides error definitions for the Polars dataframe library.
+`polars-error` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, defining its error types.
 
-Not intended for external usage
+**Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
+

--- a/crates/polars-error/README.md
+++ b/crates/polars-error/README.md
@@ -3,4 +3,3 @@
 `polars-error` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, defining its error types.
 
 **Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
-

--- a/crates/polars-io/README.md
+++ b/crates/polars-io/README.md
@@ -3,4 +3,3 @@
 `polars-io` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, that provides IO functionality for the Polars dataframe library.
 
 **Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
-

--- a/crates/polars-io/README.md
+++ b/crates/polars-io/README.md
@@ -1,5 +1,6 @@
 # polars-io
 
-`polars-io` is a sub-crate that provides IO functionality for the Polars dataframe library.
+`polars-io` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, that provides IO functionality for the Polars dataframe library.
 
-Not intended for external usage
+**Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
+

--- a/crates/polars-json/README.md
+++ b/crates/polars-json/README.md
@@ -1,6 +1,6 @@
-# polars-utils
+# polars-json
 
-`polars-utils` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, supplying private utility functions.
+`polars-json` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, provides functionalities to handle JSON objects.
 
 **Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
 

--- a/crates/polars-json/README.md
+++ b/crates/polars-json/README.md
@@ -3,4 +3,3 @@
 `polars-json` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, provides functionalities to handle JSON objects.
 
 **Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
-

--- a/crates/polars-lazy/README.md
+++ b/crates/polars-lazy/README.md
@@ -1,7 +1,5 @@
 # polars-lazy
 
-`polars-lazy` is a lazy query engine for the Polars DataFrame library. It allows you to perform operations on DataFrames in a lazy manner, only executing them when necessary. This can lead to significant performance improvements for large datasets.
+`polars-lazy` serves as the lazy query engine for the [Polars](https://crates.io/crates/polars) DataFrame library. It allows you to perform operations on DataFrames in a lazy manner, only executing them when necessary. This can lead to significant performance improvements for large datasets.
 
-## Features
-
-Please refer to the parent `polars` crate for a comprehensive list of features.
+**Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.

--- a/crates/polars-ops/README.md
+++ b/crates/polars-ops/README.md
@@ -1,5 +1,6 @@
 # polars-ops
 
-`polars-ops` is a sub-crate that provides more operations on Polars data structures.
+`polars-ops` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, providing extended operations on Polars data structures.
 
-Not intended for external usage
+**Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
+

--- a/crates/polars-ops/README.md
+++ b/crates/polars-ops/README.md
@@ -3,4 +3,3 @@
 `polars-ops` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, providing extended operations on Polars data structures.
 
 **Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
-

--- a/crates/polars-pipe/README.md
+++ b/crates/polars-pipe/README.md
@@ -1,5 +1,6 @@
-# Polars Pipe
+# polars-pipe
 
-`polars-pipe` is a sub-crate that provides OOC (out of core) algorithms to the polars physical plans.
+`polars-pipe` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, introducing OOC (out of core) algorithms to polars physical plans.
 
-Not intended for external usage.
+**Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
+

--- a/crates/polars-pipe/README.md
+++ b/crates/polars-pipe/README.md
@@ -3,4 +3,3 @@
 `polars-pipe` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, introducing OOC (out of core) algorithms to polars physical plans.
 
 **Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
-

--- a/crates/polars-plan/README.md
+++ b/crates/polars-plan/README.md
@@ -1,0 +1,6 @@
+# polars-plan-
+
+`polars-plan` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, that provides source code responsible for Polars logical planning.
+
+**Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
+

--- a/crates/polars-plan/README.md
+++ b/crates/polars-plan/README.md
@@ -3,4 +3,3 @@
 `polars-plan` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, that provides source code responsible for Polars logical planning.
 
 **Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
-

--- a/crates/polars-row/README.md
+++ b/crates/polars-row/README.md
@@ -3,4 +3,3 @@
 `polars-row` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, that provides row encodings for the Polars DataFrame Library.
 
 **Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
-

--- a/crates/polars-row/README.md
+++ b/crates/polars-row/README.md
@@ -1,11 +1,5 @@
 # polars-row
 
-`polars-row` is a sub-crate that provides row encodings for the Polars DataFrame library.
-
-Not intended for external usage
-
-# polars-row
-
 `polars-row` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, that provides row encodings for the Polars DataFrame Library.
 
 **Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.

--- a/crates/polars-row/README.md
+++ b/crates/polars-row/README.md
@@ -3,3 +3,10 @@
 `polars-row` is a sub-crate that provides row encodings for the Polars DataFrame library.
 
 Not intended for external usage
+
+# polars-row
+
+`polars-row` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, that provides row encodings for the Polars DataFrame Library.
+
+**Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
+

--- a/crates/polars-sql/README.md
+++ b/crates/polars-sql/README.md
@@ -1,6 +1,6 @@
-# Polars SQL
+# polars-sql
 
-`polars-sql` is a sub-crate that provides a SQL transpiler for Polars. It can convert SQL queries to Polars logical plans.
+`polars-sql` is a sub-crate of the [Polars](https://crates.io/crates/polars) library, offering a SQL transpiler. It allows for SQL query conversion to Polars logical plans.
 
 ## Usage
 
@@ -17,6 +17,4 @@ You can then import the crate in your Rust code using:
 use polars_sql::*;
 ```
 
-## Features
-
-Please refer to the parent `polars` crate for a comprehensive list of features.
+**Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.

--- a/crates/polars-time/README.md
+++ b/crates/polars-time/README.md
@@ -1,5 +1,5 @@
 # polars-time
 
-`polars-time` is a sub-crate that provides time-related code for the Polars dataframe library.
+`polars-time` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, focusing on time-related utilities.
 
-Not intended for external usage
+**Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.

--- a/crates/polars-utils/README.md
+++ b/crates/polars-utils/README.md
@@ -3,4 +3,3 @@
 `polars-utils` is an **internal sub-crate** of the [Polars](https://crates.io/crates/polars) library, supplying private utility functions.
 
 **Important Note**: This crate is **not intended for external usage**. Please refer to the main [Polars crate](https://crates.io/crates/polars) for intended usage.
-


### PR DESCRIPTION
As suggested in #10909, internal crates readme has been enhanced with reference to main polars crate.

polars-json and polars-plan had no readme before, so I'd ask for checking if suggested comment by me is relevant and descriptive enough