### PR TITLE
fix: compute length of null array in explode

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/explode.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode.rs
@@ -176,7 +176,16 @@ impl ExplodeByOffsets for Float64Chunked {
 
 impl ExplodeByOffsets for NullChunked {
     fn explode_by_offsets(&self, offsets: &[i64]) -> Series {
-        NullChunked::new(self.name.clone(), offsets.len() - 1).into_series()
+        let mut last_offset = offsets[0];
+
+        let mut len = 0;
+        for &offset in &offsets[1..] {
+            // If offset == last_offset we have an empty list and a new row is inserted,
+            // therefore we always increase at least 1.
+            len += std::cmp::max(offset - last_offset, 1) as usize;
+            last_offset = offset;
+        }
+        NullChunked::new(self.name.clone(), len).into_series()
     }
 }
 

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -314,7 +314,7 @@ impl Debug for Series {
                 "Series"
             ),
             DataType::Null => {
-                writeln!(f, "nullarray")
+                writeln!(f, "nullarray; shape: {}", self.len())
             },
             DataType::Binary => {
                 format_array!(f, self.binary().unwrap(), "binary", self.name(), "Series")

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -329,3 +329,23 @@ def test_utf8_list_agg_explode() -> None:
 
     assert_frame_equal(df, df2)
     assert_frame_equal(df.explode("a"), df2.explode("a"))
+
+
+def test_explode_null_struct() -> None:
+    df = [
+        {"col1": None},
+        {
+            "col1": [
+                {"field1": None, "field2": None, "field3": None},
+                {"field1": None, "field2": "some", "field3": "value"},
+            ]
+        },
+    ]
+
+    assert pl.DataFrame(df).explode("col1").to_dict(False) == {
+        "col1": [
+            {"field1": None, "field2": None, "field3": None},
+            {"field1": None, "field2": None, "field3": None},
+            {"field1": None, "field2": "some", "field3": "value"},
+        ]
+    }


### PR DESCRIPTION
fixes #10938