### PR TITLE
docs(python): add note about adbc flight sql driver

### DIFF
--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -288,12 +288,17 @@ def read_database(  # noqa: D417
       efficiently instantiate the DataFrame; otherwise, the DataFrame is initialised
       from row-wise data.
 
+    * Support for Arrow Flight SQL data is available via the ``adbc-driver-flightsql``
+      package; see https://arrow.apache.org/adbc/current/driver/flight_sql.html for
+      more details about using this driver (notable databases implementing Flight SQL
+      include Dremio and InfluxDB).
+
     * The ``read_connection_uri`` function is likely to be noticeably faster than
       ``read_database`` if you are using a SQLAlchemy or DBAPI2 connection, as
-      ``connectorx`` will optimise translation of the result data into Arrow format
-      in Rust, whereas these libraries will return row-wise data to Python. Note that
-      you can easily determine the connection's URI from a SQLAlchemy engine object by
-      calling ``str(conn.engine.url)``.
+      ``connectorx`` will optimise translation of the result set into Arrow format
+      in Rust, whereas these libraries will return row-wise data to Python *before*
+      we can load into Arrow. Note that you can easily determine the connection's
+      URI from a SQLAlchemy engine object by calling ``str(conn.engine.url)``.
 
     * If polars has to create a cursor from your connection in order to execute the
       query then that cursor will be automatically closed when the query completes;


### PR DESCRIPTION
Added a note about use of `adbc-driver-flightsql` if you are looking for Arrow Flight SQL support via `pl.read_database`.