### PR TITLE
refactor: genericize PolarsDataType

### DIFF
--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -72,8 +72,8 @@ fn from_chunks_list_dtype(chunks: &mut Vec<ArrayRef>, dtype: DataType) -> DataTy
 
 impl<T, A> From<A> for ChunkedArray<T>
 where
-    T: PolarsDataType,
-    A: StaticallyMatchesPolarsType<T> + Array,
+    T: PolarsDataType + HasArrayT<ArrayT=A>,
+    A: Array,
 {
     fn from(arr: A) -> Self {
         Self::with_chunk("", arr)
@@ -86,7 +86,8 @@ where
 {
     pub fn with_chunk<A>(name: &str, arr: A) -> Self
     where
-        A: StaticallyMatchesPolarsType<T> + Array,
+        A: Array,
+        T: HasArrayT<ArrayT=A>
     {
         unsafe { Self::from_chunks(name, vec![Box::new(arr)]) }
     }
@@ -94,7 +95,8 @@ where
     pub fn from_chunk_iter<I>(name: &str, iter: I) -> Self
     where
         I: IntoIterator,
-        <I as IntoIterator>::Item: StaticallyMatchesPolarsType<T> + Array,
+        T: HasArrayT<ArrayT=<I as IntoIterator>::Item>,
+        <I as IntoIterator>::Item: Array,
     {
         let chunks = iter
             .into_iter()
@@ -106,7 +108,8 @@ where
     pub fn try_from_chunk_iter<I, A, E>(name: &str, iter: I) -> Result<Self, E>
     where
         I: IntoIterator<Item = Result<A, E>>,
-        A: StaticallyMatchesPolarsType<T> + Array,
+        T: HasArrayT<ArrayT=A>,
+        A: Array,
     {
         let chunks: Result<_, _> = iter
             .into_iter()

--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -72,7 +72,7 @@ fn from_chunks_list_dtype(chunks: &mut Vec<ArrayRef>, dtype: DataType) -> DataTy
 
 impl<T, A> From<A> for ChunkedArray<T>
 where
-    T: PolarsDataType + HasArrayT<ArrayT=A>,
+    T: PolarsDataType + HasArrayType<Array=A>,
     A: Array,
 {
     fn from(arr: A) -> Self {
@@ -87,7 +87,7 @@ where
     pub fn with_chunk<A>(name: &str, arr: A) -> Self
     where
         A: Array,
-        T: HasArrayT<ArrayT=A>
+        T: HasArrayType<Array=A>
     {
         unsafe { Self::from_chunks(name, vec![Box::new(arr)]) }
     }
@@ -95,7 +95,7 @@ where
     pub fn from_chunk_iter<I>(name: &str, iter: I) -> Self
     where
         I: IntoIterator,
-        T: HasArrayT<ArrayT=<I as IntoIterator>::Item>,
+        T: HasArrayType<Array=<I as IntoIterator>::Item>,
         <I as IntoIterator>::Item: Array,
     {
         let chunks = iter
@@ -108,7 +108,7 @@ where
     pub fn try_from_chunk_iter<I, A, E>(name: &str, iter: I) -> Result<Self, E>
     where
         I: IntoIterator<Item = Result<A, E>>,
-        T: HasArrayT<ArrayT=A>,
+        T: HasArrayType<Array=A>,
         A: Array,
     {
         let chunks: Result<_, _> = iter

--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -72,7 +72,7 @@ fn from_chunks_list_dtype(chunks: &mut Vec<ArrayRef>, dtype: DataType) -> DataTy
 
 impl<T, A> From<A> for ChunkedArray<T>
 where
-    T: PolarsDataType + HasArrayType<Array = A>,
+    T: PolarsDataType<Array = A>,
     A: Array,
 {
     fn from(arr: A) -> Self {
@@ -87,7 +87,7 @@ where
     pub fn with_chunk<A>(name: &str, arr: A) -> Self
     where
         A: Array,
-        T: HasArrayType<Array = A>,
+        T: PolarsDataType<Array = A>,
     {
         unsafe { Self::from_chunks(name, vec![Box::new(arr)]) }
     }
@@ -95,7 +95,7 @@ where
     pub fn from_chunk_iter<I>(name: &str, iter: I) -> Self
     where
         I: IntoIterator,
-        T: HasArrayType<Array = <I as IntoIterator>::Item>,
+        T: PolarsDataType<Array = <I as IntoIterator>::Item>,
         <I as IntoIterator>::Item: Array,
     {
         let chunks = iter
@@ -108,7 +108,7 @@ where
     pub fn try_from_chunk_iter<I, A, E>(name: &str, iter: I) -> Result<Self, E>
     where
         I: IntoIterator<Item = Result<A, E>>,
-        T: HasArrayType<Array = A>,
+        T: PolarsDataType<Array = A>,
         A: Array,
     {
         let chunks: Result<_, _> = iter

--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -72,7 +72,7 @@ fn from_chunks_list_dtype(chunks: &mut Vec<ArrayRef>, dtype: DataType) -> DataTy
 
 impl<T, A> From<A> for ChunkedArray<T>
 where
-    T: PolarsDataType + HasArrayType<Array=A>,
+    T: PolarsDataType + HasArrayType<Array = A>,
     A: Array,
 {
     fn from(arr: A) -> Self {
@@ -87,7 +87,7 @@ where
     pub fn with_chunk<A>(name: &str, arr: A) -> Self
     where
         A: Array,
-        T: HasArrayType<Array=A>
+        T: HasArrayType<Array = A>,
     {
         unsafe { Self::from_chunks(name, vec![Box::new(arr)]) }
     }
@@ -95,7 +95,7 @@ where
     pub fn from_chunk_iter<I>(name: &str, iter: I) -> Self
     where
         I: IntoIterator,
-        T: HasArrayType<Array=<I as IntoIterator>::Item>,
+        T: HasArrayType<Array = <I as IntoIterator>::Item>,
         <I as IntoIterator>::Item: Array,
     {
         let chunks = iter
@@ -108,7 +108,7 @@ where
     pub fn try_from_chunk_iter<I, A, E>(name: &str, iter: I) -> Result<Self, E>
     where
         I: IntoIterator<Item = Result<A, E>>,
-        T: HasArrayType<Array=A>,
+        T: HasArrayType<Array = A>,
         A: Array,
     {
         let chunks: Result<_, _> = iter

--- a/crates/polars-core/src/chunked_array/list/iterator.rs
+++ b/crates/polars-core/src/chunked_array/list/iterator.rs
@@ -173,7 +173,7 @@ impl ListChunked {
     where
         V: PolarsDataType,
         F: FnMut(Option<UnstableSeries<'a>>) -> Option<K> + Copy,
-        K: ArrayFromElementIter<ArrayType=ArrayT<V>>,
+        K: ArrayFromElementIter<ArrayType = ArrayT<V>>,
     {
         // TODO! make an amortized iter that does not flatten
 

--- a/crates/polars-core/src/chunked_array/list/iterator.rs
+++ b/crates/polars-core/src/chunked_array/list/iterator.rs
@@ -173,8 +173,7 @@ impl ListChunked {
     where
         V: PolarsDataType,
         F: FnMut(Option<UnstableSeries<'a>>) -> Option<K> + Copy,
-        K: ArrayFromElementIter,
-        K::ArrayType: StaticallyMatchesPolarsType<V>,
+        K: ArrayFromElementIter<ArrayType=<V as HasArrayT>::ArrayT>,
     {
         // TODO! make an amortized iter that does not flatten
 

--- a/crates/polars-core/src/chunked_array/list/iterator.rs
+++ b/crates/polars-core/src/chunked_array/list/iterator.rs
@@ -173,7 +173,7 @@ impl ListChunked {
     where
         V: PolarsDataType,
         F: FnMut(Option<UnstableSeries<'a>>) -> Option<K> + Copy,
-        K: ArrayFromElementIter<ArrayType=<V as HasArrayT>::ArrayT>,
+        K: ArrayFromElementIter<ArrayType=ArrayT<V>>,
     {
         // TODO! make an amortized iter that does not flatten
 

--- a/crates/polars-core/src/chunked_array/list/iterator.rs
+++ b/crates/polars-core/src/chunked_array/list/iterator.rs
@@ -173,7 +173,7 @@ impl ListChunked {
     where
         V: PolarsDataType,
         F: FnMut(Option<UnstableSeries<'a>>) -> Option<K> + Copy,
-        K: ArrayFromElementIter<ArrayType = ArrayT<V>>,
+        K: ArrayFromElementIter<ArrayType = V::Array>,
     {
         // TODO! make an amortized iter that does not flatten
 

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -22,7 +22,7 @@ where
     where
         U: PolarsDataType,
         F: FnMut(PhysicalT<'a, T>) -> K + Copy,
-        K: ArrayFromElementIter<ArrayType=ArrayT<U>>,
+        K: ArrayFromElementIter<ArrayType = ArrayT<U>>,
     {
         let iter = self.downcast_iter().map(|arr| {
             let element_iter = arr.values_iter().map(op);
@@ -36,9 +36,8 @@ where
     pub fn try_apply_values_generic<'a, U, K, F, E>(&'a self, op: F) -> Result<ChunkedArray<U>, E>
     where
         U: PolarsDataType,
-        F: FnMut(PhysicalT<'a, T>) -> Result<K, E>
-            + Copy,
-        K: ArrayFromElementIter<ArrayType=ArrayT<U>>,
+        F: FnMut(PhysicalT<'a, T>) -> Result<K, E> + Copy,
+        K: ArrayFromElementIter<ArrayType = ArrayT<U>>,
         E: Error,
     {
         let iter = self.downcast_iter().map(|arr| {
@@ -53,11 +52,8 @@ where
     pub fn try_apply_generic<'a, U, K, F, E>(&'a self, op: F) -> Result<ChunkedArray<U>, E>
     where
         U: PolarsDataType,
-        F: FnMut(
-                Option<PhysicalT<'a, T>>,
-            ) -> Result<Option<K>, E>
-            + Copy,
-        K: ArrayFromElementIter<ArrayType=ArrayT<U>>,
+        F: FnMut(Option<PhysicalT<'a, T>>) -> Result<Option<K>, E> + Copy,
+        K: ArrayFromElementIter<ArrayType = ArrayT<U>>,
         E: Error,
     {
         let iter = self.downcast_iter().map(|arr| {
@@ -72,10 +68,8 @@ where
     pub fn apply_generic<'a, U, K, F>(&'a self, mut op: F) -> ChunkedArray<U>
     where
         U: PolarsDataType,
-        F: FnMut(
-            Option<PhysicalT<'a, T>>,
-        ) -> Option<K>,
-        K: ArrayFromElementIter<ArrayType=ArrayT<U>>,
+        F: FnMut(Option<PhysicalT<'a, T>>) -> Option<K>,
+        K: ArrayFromElementIter<ArrayType = ArrayT<U>>,
     {
         if self.null_count() == 0 {
             let iter = self.downcast_iter().map(|arr| {

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -22,7 +22,7 @@ where
     where
         U: PolarsDataType,
         F: FnMut(PhysicalT<'a, T>) -> K + Copy,
-        K: ArrayFromElementIter<ArrayType=<U as HasArrayT>::ArrayT>,
+        K: ArrayFromElementIter<ArrayType=ArrayT<U>>,
     {
         let iter = self.downcast_iter().map(|arr| {
             let element_iter = arr.values_iter().map(op);
@@ -38,7 +38,7 @@ where
         U: PolarsDataType,
         F: FnMut(PhysicalT<'a, T>) -> Result<K, E>
             + Copy,
-        K: ArrayFromElementIter<ArrayType=<U as HasArrayT>::ArrayT>,
+        K: ArrayFromElementIter<ArrayType=ArrayT<U>>,
         E: Error,
     {
         let iter = self.downcast_iter().map(|arr| {
@@ -57,7 +57,7 @@ where
                 Option<PhysicalT<'a, T>>,
             ) -> Result<Option<K>, E>
             + Copy,
-        K: ArrayFromElementIter<ArrayType=<U as HasArrayT>::ArrayT>,
+        K: ArrayFromElementIter<ArrayType=ArrayT<U>>,
         E: Error,
     {
         let iter = self.downcast_iter().map(|arr| {
@@ -75,7 +75,7 @@ where
         F: FnMut(
             Option<PhysicalT<'a, T>>,
         ) -> Option<K>,
-        K: ArrayFromElementIter<ArrayType=<U as HasArrayT>::ArrayT>,
+        K: ArrayFromElementIter<ArrayType=ArrayT<U>>,
     {
         if self.null_count() == 0 {
             let iter = self.downcast_iter().map(|arr| {

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -21,7 +21,7 @@ where
     pub fn apply_values_generic<'a, U, K, F>(&'a self, op: F) -> ChunkedArray<U>
     where
         U: PolarsDataType,
-        F: FnMut(<<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>) -> K + Copy,
+        F: FnMut(PhysicalT<'a, T>) -> K + Copy,
         K: ArrayFromElementIter,
         K::ArrayType: StaticallyMatchesPolarsType<U>,
     {
@@ -37,7 +37,7 @@ where
     pub fn try_apply_values_generic<'a, U, K, F, E>(&'a self, op: F) -> Result<ChunkedArray<U>, E>
     where
         U: PolarsDataType,
-        F: FnMut(<<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>) -> Result<K, E>
+        F: FnMut(PhysicalT<'a, T>) -> Result<K, E>
             + Copy,
         K: ArrayFromElementIter,
         K::ArrayType: StaticallyMatchesPolarsType<U>,
@@ -56,7 +56,7 @@ where
     where
         U: PolarsDataType,
         F: FnMut(
-                Option<<<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>>,
+                Option<PhysicalT<'a, T>>,
             ) -> Result<Option<K>, E>
             + Copy,
         K: ArrayFromElementIter,
@@ -76,7 +76,7 @@ where
     where
         U: PolarsDataType,
         F: FnMut(
-            Option<<<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>>,
+            Option<PhysicalT<'a, T>>,
         ) -> Option<K>,
         K: ArrayFromElementIter,
         K::ArrayType: StaticallyMatchesPolarsType<U>,

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -21,8 +21,8 @@ where
     pub fn apply_values_generic<'a, U, K, F>(&'a self, op: F) -> ChunkedArray<U>
     where
         U: PolarsDataType,
-        F: FnMut(PhysicalT<'a, T>) -> K + Copy,
-        K: ArrayFromElementIter<ArrayType = ArrayT<U>>,
+        F: FnMut(T::Physical<'a>) -> K + Copy,
+        K: ArrayFromElementIter<ArrayType = U::Array>,
     {
         let iter = self.downcast_iter().map(|arr| {
             let element_iter = arr.values_iter().map(op);
@@ -36,8 +36,8 @@ where
     pub fn try_apply_values_generic<'a, U, K, F, E>(&'a self, op: F) -> Result<ChunkedArray<U>, E>
     where
         U: PolarsDataType,
-        F: FnMut(PhysicalT<'a, T>) -> Result<K, E> + Copy,
-        K: ArrayFromElementIter<ArrayType = ArrayT<U>>,
+        F: FnMut(T::Physical<'a>) -> Result<K, E> + Copy,
+        K: ArrayFromElementIter<ArrayType = U::Array>,
         E: Error,
     {
         let iter = self.downcast_iter().map(|arr| {
@@ -52,8 +52,8 @@ where
     pub fn try_apply_generic<'a, U, K, F, E>(&'a self, op: F) -> Result<ChunkedArray<U>, E>
     where
         U: PolarsDataType,
-        F: FnMut(Option<PhysicalT<'a, T>>) -> Result<Option<K>, E> + Copy,
-        K: ArrayFromElementIter<ArrayType = ArrayT<U>>,
+        F: FnMut(Option<T::Physical<'a>>) -> Result<Option<K>, E> + Copy,
+        K: ArrayFromElementIter<ArrayType = U::Array>,
         E: Error,
     {
         let iter = self.downcast_iter().map(|arr| {
@@ -68,8 +68,8 @@ where
     pub fn apply_generic<'a, U, K, F>(&'a self, mut op: F) -> ChunkedArray<U>
     where
         U: PolarsDataType,
-        F: FnMut(Option<PhysicalT<'a, T>>) -> Option<K>,
-        K: ArrayFromElementIter<ArrayType = ArrayT<U>>,
+        F: FnMut(Option<T::Physical<'a>>) -> Option<K>,
+        K: ArrayFromElementIter<ArrayType = U::Array>,
     {
         if self.null_count() == 0 {
             let iter = self.downcast_iter().map(|arr| {

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -17,12 +17,11 @@ use crate::utils::CustomIterTools;
 impl<T> ChunkedArray<T>
 where
     T: PolarsDataType,
-    Self: HasUnderlyingArray,
 {
     pub fn apply_values_generic<'a, U, K, F>(&'a self, op: F) -> ChunkedArray<U>
     where
         U: PolarsDataType,
-        F: FnMut(<<Self as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>) -> K + Copy,
+        F: FnMut(<<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>) -> K + Copy,
         K: ArrayFromElementIter,
         K::ArrayType: StaticallyMatchesPolarsType<U>,
     {
@@ -38,7 +37,7 @@ where
     pub fn try_apply_values_generic<'a, U, K, F, E>(&'a self, op: F) -> Result<ChunkedArray<U>, E>
     where
         U: PolarsDataType,
-        F: FnMut(<<Self as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>) -> Result<K, E>
+        F: FnMut(<<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>) -> Result<K, E>
             + Copy,
         K: ArrayFromElementIter,
         K::ArrayType: StaticallyMatchesPolarsType<U>,
@@ -57,7 +56,7 @@ where
     where
         U: PolarsDataType,
         F: FnMut(
-                Option<<<Self as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>>,
+                Option<<<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>>,
             ) -> Result<Option<K>, E>
             + Copy,
         K: ArrayFromElementIter,
@@ -77,7 +76,7 @@ where
     where
         U: PolarsDataType,
         F: FnMut(
-            Option<<<Self as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>>,
+            Option<<<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>>,
         ) -> Option<K>,
         K: ArrayFromElementIter,
         K::ArrayType: StaticallyMatchesPolarsType<U>,

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -22,8 +22,7 @@ where
     where
         U: PolarsDataType,
         F: FnMut(PhysicalT<'a, T>) -> K + Copy,
-        K: ArrayFromElementIter,
-        K::ArrayType: StaticallyMatchesPolarsType<U>,
+        K: ArrayFromElementIter<ArrayType=<U as HasArrayT>::ArrayT>,
     {
         let iter = self.downcast_iter().map(|arr| {
             let element_iter = arr.values_iter().map(op);
@@ -39,8 +38,7 @@ where
         U: PolarsDataType,
         F: FnMut(PhysicalT<'a, T>) -> Result<K, E>
             + Copy,
-        K: ArrayFromElementIter,
-        K::ArrayType: StaticallyMatchesPolarsType<U>,
+        K: ArrayFromElementIter<ArrayType=<U as HasArrayT>::ArrayT>,
         E: Error,
     {
         let iter = self.downcast_iter().map(|arr| {
@@ -59,8 +57,7 @@ where
                 Option<PhysicalT<'a, T>>,
             ) -> Result<Option<K>, E>
             + Copy,
-        K: ArrayFromElementIter,
-        K::ArrayType: StaticallyMatchesPolarsType<U>,
+        K: ArrayFromElementIter<ArrayType=<U as HasArrayT>::ArrayT>,
         E: Error,
     {
         let iter = self.downcast_iter().map(|arr| {
@@ -78,8 +75,7 @@ where
         F: FnMut(
             Option<PhysicalT<'a, T>>,
         ) -> Option<K>,
-        K: ArrayFromElementIter,
-        K::ArrayType: StaticallyMatchesPolarsType<U>,
+        K: ArrayFromElementIter<ArrayType=<U as HasArrayT>::ArrayT>,
     {
         if self.null_count() == 0 {
             let iter = self.downcast_iter().map(|arr| {

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -4,8 +4,8 @@ use arrow::array::Array;
 use polars_arrow::utils::combine_validities_and;
 
 use crate::datatypes::{
-    ArrayFromElementIter, HasUnderlyingArray, PolarsNumericType, StaticArray,
-    StaticallyMatchesPolarsType,
+    ArrayFromElementIter, PolarsNumericType, StaticArray,
+    StaticallyMatchesPolarsType, HasArrayT,
 };
 use crate::prelude::{ChunkedArray, PolarsDataType};
 use crate::utils::align_chunks_binary;
@@ -20,11 +20,9 @@ where
     T: PolarsDataType,
     U: PolarsDataType,
     V: PolarsDataType,
-    ChunkedArray<T>: HasUnderlyingArray,
-    ChunkedArray<U>: HasUnderlyingArray,
     F: for<'a> FnMut(
-        Option<<<ChunkedArray<T> as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>>,
-        Option<<<ChunkedArray<U> as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>>,
+        Option<<<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>>,
+        Option<<<U as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>>,
     ) -> Option<K>,
     K: ArrayFromElementIter,
     K::ArrayType: StaticallyMatchesPolarsType<V>,
@@ -53,11 +51,9 @@ where
     T: PolarsDataType,
     U: PolarsDataType,
     V: PolarsDataType,
-    ChunkedArray<T>: HasUnderlyingArray,
-    ChunkedArray<U>: HasUnderlyingArray,
     F: for<'a> FnMut(
-        Option<<<ChunkedArray<T> as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>>,
-        Option<<<ChunkedArray<U> as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>>,
+        Option<<<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>>,
+        Option<<<U as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>>,
     ) -> Result<Option<K>, E>,
     K: ArrayFromElementIter,
     K::ArrayType: StaticallyMatchesPolarsType<V>,
@@ -87,11 +83,9 @@ where
     T: PolarsDataType,
     U: PolarsDataType,
     V: PolarsNumericType,
-    ChunkedArray<T>: HasUnderlyingArray,
-    ChunkedArray<U>: HasUnderlyingArray,
     F: for<'a> FnMut(
-        <<ChunkedArray<T> as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>,
-        <<ChunkedArray<U> as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>,
+        <<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>,
+        <<U as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>,
     ) -> K,
     K: ArrayFromElementIter,
     K::ArrayType: StaticallyMatchesPolarsType<V>,
@@ -124,11 +118,9 @@ where
     T: PolarsDataType,
     U: PolarsDataType,
     V: PolarsNumericType,
-    ChunkedArray<T>: HasUnderlyingArray,
-    ChunkedArray<U>: HasUnderlyingArray,
     F: for<'a> FnMut(
-        <<ChunkedArray<T> as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>,
-        <<ChunkedArray<U> as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>,
+        <<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>,
+        <<U as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>,
     ) -> Result<K, E>,
     K: ArrayFromElementIter,
     K::ArrayType: StaticallyMatchesPolarsType<V>,
@@ -164,12 +156,10 @@ where
     T: PolarsDataType,
     U: PolarsDataType,
     V: PolarsDataType,
-    ChunkedArray<T>: HasUnderlyingArray,
-    ChunkedArray<U>: HasUnderlyingArray,
     Arr: Array + StaticallyMatchesPolarsType<V>,
     F: FnMut(
-        &<ChunkedArray<T> as HasUnderlyingArray>::ArrayT,
-        &<ChunkedArray<U> as HasUnderlyingArray>::ArrayT,
+        &<T as HasArrayT>::ArrayT,
+        &<U as HasArrayT>::ArrayT,
     ) -> Arr,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
@@ -190,12 +180,10 @@ where
     T: PolarsDataType,
     U: PolarsDataType,
     V: PolarsDataType,
-    ChunkedArray<T>: HasUnderlyingArray,
-    ChunkedArray<U>: HasUnderlyingArray,
     Arr: Array + StaticallyMatchesPolarsType<V>,
     F: FnMut(
-        &<ChunkedArray<T> as HasUnderlyingArray>::ArrayT,
-        &<ChunkedArray<U> as HasUnderlyingArray>::ArrayT,
+        &<T as HasArrayT>::ArrayT,
+        &<U as HasArrayT>::ArrayT,
     ) -> Arr,
 {
     binary_mut_with_options(lhs, rhs, op, lhs.name())
@@ -211,12 +199,10 @@ where
     T: PolarsDataType,
     U: PolarsDataType,
     V: PolarsDataType,
-    ChunkedArray<T>: HasUnderlyingArray,
-    ChunkedArray<U>: HasUnderlyingArray,
     Arr: Array + StaticallyMatchesPolarsType<V>,
     F: FnMut(
-        &<ChunkedArray<T> as HasUnderlyingArray>::ArrayT,
-        &<ChunkedArray<U> as HasUnderlyingArray>::ArrayT,
+        &<T as HasArrayT>::ArrayT,
+        &<U as HasArrayT>::ArrayT,
     ) -> Result<Arr, E>,
     E: Error,
 {
@@ -243,11 +229,9 @@ pub unsafe fn binary_unchecked_same_type<T, U, F>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    ChunkedArray<T>: HasUnderlyingArray,
-    ChunkedArray<U>: HasUnderlyingArray,
     F: FnMut(
-        &<ChunkedArray<T> as HasUnderlyingArray>::ArrayT,
-        &<ChunkedArray<U> as HasUnderlyingArray>::ArrayT,
+        &<T as HasArrayT>::ArrayT,
+        &<U as HasArrayT>::ArrayT,
     ) -> Box<dyn Array>,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
@@ -274,11 +258,9 @@ pub unsafe fn try_binary_unchecked_same_type<T, U, F, E>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    ChunkedArray<T>: HasUnderlyingArray,
-    ChunkedArray<U>: HasUnderlyingArray,
     F: FnMut(
-        &<ChunkedArray<T> as HasUnderlyingArray>::ArrayT,
-        &<ChunkedArray<U> as HasUnderlyingArray>::ArrayT,
+        &<T as HasArrayT>::ArrayT,
+        &<U as HasArrayT>::ArrayT,
     ) -> Result<Box<dyn Array>, E>,
     E: Error,
 {

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -4,7 +4,7 @@ use arrow::array::Array;
 use polars_arrow::utils::combine_validities_and;
 
 use crate::datatypes::{
-    ArrayFromElementIter, HasArrayType, PhysicalT, PolarsNumericType, StaticArray, ArrayT,
+    ArrayFromElementIter, ArrayT, HasArrayType, PhysicalT, PolarsNumericType, StaticArray,
 };
 use crate::prelude::{ChunkedArray, PolarsDataType};
 use crate::utils::align_chunks_binary;

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -4,7 +4,7 @@ use arrow::array::Array;
 use polars_arrow::utils::combine_validities_and;
 
 use crate::datatypes::{
-    ArrayFromElementIter, HasArrayT, PhysicalT, PolarsNumericType, StaticArray, ArrayT,
+    ArrayFromElementIter, HasArrayType, PhysicalT, PolarsNumericType, StaticArray, ArrayT,
 };
 use crate::prelude::{ChunkedArray, PolarsDataType};
 use crate::utils::align_chunks_binary;
@@ -138,7 +138,7 @@ pub fn binary_mut_with_options<T, U, V, F, Arr>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    V: PolarsDataType + HasArrayT<ArrayT = Arr>,
+    V: PolarsDataType + HasArrayType<Array = Arr>,
     Arr: Array,
     F: FnMut(&ArrayT<T>, &ArrayT<U>) -> Arr,
 {
@@ -159,7 +159,7 @@ pub fn binary<T, U, V, F, Arr>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    V: PolarsDataType + HasArrayT<ArrayT = Arr>,
+    V: PolarsDataType + HasArrayType<Array = Arr>,
     Arr: Array,
     F: FnMut(&ArrayT<T>, &ArrayT<U>) -> Arr,
 {
@@ -175,7 +175,7 @@ pub fn try_binary<T, U, V, F, Arr, E>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    V: PolarsDataType + HasArrayT<ArrayT = Arr>,
+    V: PolarsDataType + HasArrayType<Array = Arr>,
     Arr: Array,
     F: FnMut(&ArrayT<T>, &ArrayT<U>) -> Result<Arr, E>,
     E: Error,

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -4,8 +4,7 @@ use arrow::array::Array;
 use polars_arrow::utils::combine_validities_and;
 
 use crate::datatypes::{
-    ArrayFromElementIter, PolarsNumericType, StaticArray,
-    StaticallyMatchesPolarsType, HasArrayT,
+    ArrayFromElementIter, PolarsNumericType, StaticArray, HasArrayT,
 };
 use crate::prelude::{ChunkedArray, PolarsDataType};
 use crate::utils::align_chunks_binary;
@@ -24,8 +23,7 @@ where
         Option<<<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>>,
         Option<<<U as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>>,
     ) -> Option<K>,
-    K: ArrayFromElementIter,
-    K::ArrayType: StaticallyMatchesPolarsType<V>,
+    K: ArrayFromElementIter<ArrayType=<V as HasArrayT>::ArrayT>,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
     let iter = lhs
@@ -55,8 +53,7 @@ where
         Option<<<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>>,
         Option<<<U as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>>,
     ) -> Result<Option<K>, E>,
-    K: ArrayFromElementIter,
-    K::ArrayType: StaticallyMatchesPolarsType<V>,
+    K: ArrayFromElementIter<ArrayType=<V as HasArrayT>::ArrayT>,
     E: Error,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
@@ -87,8 +84,7 @@ where
         <<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>,
         <<U as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>,
     ) -> K,
-    K: ArrayFromElementIter,
-    K::ArrayType: StaticallyMatchesPolarsType<V>,
+    K: ArrayFromElementIter<ArrayType=<V as HasArrayT>::ArrayT>,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
     let iter = lhs
@@ -122,8 +118,7 @@ where
         <<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>,
         <<U as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>,
     ) -> Result<K, E>,
-    K: ArrayFromElementIter,
-    K::ArrayType: StaticallyMatchesPolarsType<V>,
+    K: ArrayFromElementIter<ArrayType=<V as HasArrayT>::ArrayT>,
     E: Error,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
@@ -155,8 +150,8 @@ pub fn binary_mut_with_options<T, U, V, F, Arr>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    V: PolarsDataType,
-    Arr: Array + StaticallyMatchesPolarsType<V>,
+    V: PolarsDataType + HasArrayT<ArrayT=Arr>,
+    Arr: Array,
     F: FnMut(
         &<T as HasArrayT>::ArrayT,
         &<U as HasArrayT>::ArrayT,
@@ -179,8 +174,8 @@ pub fn binary<T, U, V, F, Arr>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    V: PolarsDataType,
-    Arr: Array + StaticallyMatchesPolarsType<V>,
+    V: PolarsDataType + HasArrayT<ArrayT=Arr>,
+    Arr: Array,
     F: FnMut(
         &<T as HasArrayT>::ArrayT,
         &<U as HasArrayT>::ArrayT,
@@ -198,8 +193,8 @@ pub fn try_binary<T, U, V, F, Arr, E>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    V: PolarsDataType,
-    Arr: Array + StaticallyMatchesPolarsType<V>,
+    V: PolarsDataType + HasArrayT<ArrayT=Arr>,
+    Arr: Array,
     F: FnMut(
         &<T as HasArrayT>::ArrayT,
         &<U as HasArrayT>::ArrayT,

--- a/crates/polars-core/src/chunked_array/ops/arity.rs
+++ b/crates/polars-core/src/chunked_array/ops/arity.rs
@@ -3,9 +3,7 @@ use std::error::Error;
 use arrow::array::Array;
 use polars_arrow::utils::combine_validities_and;
 
-use crate::datatypes::{
-    ArrayFromElementIter, ArrayT, HasArrayType, PhysicalT, PolarsNumericType, StaticArray,
-};
+use crate::datatypes::{ArrayFromElementIter, PolarsNumericType, StaticArray};
 use crate::prelude::{ChunkedArray, PolarsDataType};
 use crate::utils::align_chunks_binary;
 
@@ -19,8 +17,8 @@ where
     T: PolarsDataType,
     U: PolarsDataType,
     V: PolarsDataType,
-    F: for<'a> FnMut(Option<PhysicalT<'a, T>>, Option<PhysicalT<'a, U>>) -> Option<K>,
-    K: ArrayFromElementIter<ArrayType = ArrayT<V>>,
+    F: for<'a> FnMut(Option<T::Physical<'a>>, Option<U::Physical<'a>>) -> Option<K>,
+    K: ArrayFromElementIter<ArrayType = V::Array>,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
     let iter = lhs
@@ -46,8 +44,8 @@ where
     T: PolarsDataType,
     U: PolarsDataType,
     V: PolarsDataType,
-    F: for<'a> FnMut(Option<PhysicalT<'a, T>>, Option<PhysicalT<'a, U>>) -> Result<Option<K>, E>,
-    K: ArrayFromElementIter<ArrayType = ArrayT<V>>,
+    F: for<'a> FnMut(Option<T::Physical<'a>>, Option<U::Physical<'a>>) -> Result<Option<K>, E>,
+    K: ArrayFromElementIter<ArrayType = V::Array>,
     E: Error,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
@@ -74,8 +72,8 @@ where
     T: PolarsDataType,
     U: PolarsDataType,
     V: PolarsNumericType,
-    F: for<'a> FnMut(PhysicalT<'a, T>, PhysicalT<'a, U>) -> K,
-    K: ArrayFromElementIter<ArrayType = ArrayT<V>>,
+    F: for<'a> FnMut(T::Physical<'a>, U::Physical<'a>) -> K,
+    K: ArrayFromElementIter<ArrayType = V::Array>,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
     let iter = lhs
@@ -105,8 +103,8 @@ where
     T: PolarsDataType,
     U: PolarsDataType,
     V: PolarsNumericType,
-    F: for<'a> FnMut(PhysicalT<'a, T>, PhysicalT<'a, U>) -> Result<K, E>,
-    K: ArrayFromElementIter<ArrayType = ArrayT<V>>,
+    F: for<'a> FnMut(T::Physical<'a>, U::Physical<'a>) -> Result<K, E>,
+    K: ArrayFromElementIter<ArrayType = V::Array>,
     E: Error,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
@@ -138,9 +136,9 @@ pub fn binary_mut_with_options<T, U, V, F, Arr>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    V: PolarsDataType + HasArrayType<Array = Arr>,
+    V: PolarsDataType<Array = Arr>,
     Arr: Array,
-    F: FnMut(&ArrayT<T>, &ArrayT<U>) -> Arr,
+    F: FnMut(&T::Array, &U::Array) -> Arr,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
     let iter = lhs
@@ -159,9 +157,9 @@ pub fn binary<T, U, V, F, Arr>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    V: PolarsDataType + HasArrayType<Array = Arr>,
+    V: PolarsDataType<Array = Arr>,
     Arr: Array,
-    F: FnMut(&ArrayT<T>, &ArrayT<U>) -> Arr,
+    F: FnMut(&T::Array, &U::Array) -> Arr,
 {
     binary_mut_with_options(lhs, rhs, op, lhs.name())
 }
@@ -175,9 +173,9 @@ pub fn try_binary<T, U, V, F, Arr, E>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    V: PolarsDataType + HasArrayType<Array = Arr>,
+    V: PolarsDataType<Array = Arr>,
     Arr: Array,
-    F: FnMut(&ArrayT<T>, &ArrayT<U>) -> Result<Arr, E>,
+    F: FnMut(&T::Array, &U::Array) -> Result<Arr, E>,
     E: Error,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
@@ -203,7 +201,7 @@ pub unsafe fn binary_unchecked_same_type<T, U, F>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    F: FnMut(&ArrayT<T>, &ArrayT<U>) -> Box<dyn Array>,
+    F: FnMut(&T::Array, &U::Array) -> Box<dyn Array>,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);
     let chunks = lhs
@@ -229,7 +227,7 @@ pub unsafe fn try_binary_unchecked_same_type<T, U, F, E>(
 where
     T: PolarsDataType,
     U: PolarsDataType,
-    F: FnMut(&ArrayT<T>, &ArrayT<U>) -> Result<Box<dyn Array>, E>,
+    F: FnMut(&T::Array, &U::Array) -> Result<Box<dyn Array>, E>,
     E: Error,
 {
     let (lhs, rhs) = align_chunks_binary(lhs, rhs);

--- a/crates/polars-core/src/chunked_array/ops/downcast.rs
+++ b/crates/polars-core/src/chunked_array/ops/downcast.rs
@@ -47,18 +47,15 @@ impl<'a, T> Chunks<'a, T> {
 }
 
 #[doc(hidden)]
-impl<T: PolarsDataType> ChunkedArray<T>
-where
-    Self: HasUnderlyingArray,
-{
+impl<T: PolarsDataType> ChunkedArray<T> {
     #[inline]
     pub fn downcast_iter(
         &self,
-    ) -> impl Iterator<Item = &<Self as HasUnderlyingArray>::ArrayT> + DoubleEndedIterator {
+    ) -> impl Iterator<Item = &<T as HasArrayT>::ArrayT> + DoubleEndedIterator {
         self.chunks.iter().map(|arr| {
-            // SAFETY: HasUnderlyingArray guarantees this is correct.
+            // SAFETY: HasArrayT guarantees this is correct.
             let arr = &**arr;
-            unsafe { &*(arr as *const dyn Array as *const <Self as HasUnderlyingArray>::ArrayT) }
+            unsafe { &*(arr as *const dyn Array as *const <T as HasArrayT>::ArrayT) }
         })
     }
 
@@ -69,16 +66,16 @@ where
     #[inline]
     pub unsafe fn downcast_iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = &mut <Self as HasUnderlyingArray>::ArrayT> + DoubleEndedIterator {
+    ) -> impl Iterator<Item = &mut <T as HasArrayT>::ArrayT> + DoubleEndedIterator {
         self.chunks.iter_mut().map(|arr| {
-            // SAFETY: HasUnderlyingArray guarantees this is correct.
+            // SAFETY: HasArrayT guarantees this is correct.
             let arr = &mut **arr;
-            &mut *(arr as *mut dyn Array as *mut <Self as HasUnderlyingArray>::ArrayT)
+            &mut *(arr as *mut dyn Array as *mut <T as HasArrayT>::ArrayT)
         })
     }
 
     #[inline]
-    pub fn downcast_chunks(&self) -> Chunks<'_, <Self as HasUnderlyingArray>::ArrayT> {
+    pub fn downcast_chunks(&self) -> Chunks<'_, <T as HasArrayT>::ArrayT> {
         Chunks::new(&self.chunks)
     }
 

--- a/crates/polars-core/src/chunked_array/ops/downcast.rs
+++ b/crates/polars-core/src/chunked_array/ops/downcast.rs
@@ -49,11 +49,11 @@ impl<'a, T> Chunks<'a, T> {
 #[doc(hidden)]
 impl<T: PolarsDataType> ChunkedArray<T> {
     #[inline]
-    pub fn downcast_iter(&self) -> impl Iterator<Item = &ArrayT<T>> + DoubleEndedIterator {
+    pub fn downcast_iter(&self) -> impl Iterator<Item = &T::Array> + DoubleEndedIterator {
         self.chunks.iter().map(|arr| {
-            // SAFETY: ArrayT guarantees this is correct.
+            // SAFETY: T::Array guarantees this is correct.
             let arr = &**arr;
-            unsafe { &*(arr as *const dyn Array as *const ArrayT<T>) }
+            unsafe { &*(arr as *const dyn Array as *const T::Array) }
         })
     }
 
@@ -64,16 +64,16 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     #[inline]
     pub unsafe fn downcast_iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = &mut ArrayT<T>> + DoubleEndedIterator {
+    ) -> impl Iterator<Item = &mut T::Array> + DoubleEndedIterator {
         self.chunks.iter_mut().map(|arr| {
-            // SAFETY: ArrayT guarantees this is correct.
+            // SAFETY: T::Array guarantees this is correct.
             let arr = &mut **arr;
-            &mut *(arr as *mut dyn Array as *mut ArrayT<T>)
+            &mut *(arr as *mut dyn Array as *mut T::Array)
         })
     }
 
     #[inline]
-    pub fn downcast_chunks(&self) -> Chunks<'_, ArrayT<T>> {
+    pub fn downcast_chunks(&self) -> Chunks<'_, T::Array> {
         Chunks::new(&self.chunks)
     }
 

--- a/crates/polars-core/src/chunked_array/ops/downcast.rs
+++ b/crates/polars-core/src/chunked_array/ops/downcast.rs
@@ -49,9 +49,7 @@ impl<'a, T> Chunks<'a, T> {
 #[doc(hidden)]
 impl<T: PolarsDataType> ChunkedArray<T> {
     #[inline]
-    pub fn downcast_iter(
-        &self,
-    ) -> impl Iterator<Item = &ArrayT<T>> + DoubleEndedIterator {
+    pub fn downcast_iter(&self) -> impl Iterator<Item = &ArrayT<T>> + DoubleEndedIterator {
         self.chunks.iter().map(|arr| {
             // SAFETY: ArrayT guarantees this is correct.
             let arr = &**arr;

--- a/crates/polars-core/src/chunked_array/ops/downcast.rs
+++ b/crates/polars-core/src/chunked_array/ops/downcast.rs
@@ -51,11 +51,11 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     #[inline]
     pub fn downcast_iter(
         &self,
-    ) -> impl Iterator<Item = &<T as HasArrayT>::ArrayT> + DoubleEndedIterator {
+    ) -> impl Iterator<Item = &ArrayT<T>> + DoubleEndedIterator {
         self.chunks.iter().map(|arr| {
-            // SAFETY: HasArrayT guarantees this is correct.
+            // SAFETY: ArrayT guarantees this is correct.
             let arr = &**arr;
-            unsafe { &*(arr as *const dyn Array as *const <T as HasArrayT>::ArrayT) }
+            unsafe { &*(arr as *const dyn Array as *const ArrayT<T>) }
         })
     }
 
@@ -66,16 +66,16 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     #[inline]
     pub unsafe fn downcast_iter_mut(
         &mut self,
-    ) -> impl Iterator<Item = &mut <T as HasArrayT>::ArrayT> + DoubleEndedIterator {
+    ) -> impl Iterator<Item = &mut ArrayT<T>> + DoubleEndedIterator {
         self.chunks.iter_mut().map(|arr| {
-            // SAFETY: HasArrayT guarantees this is correct.
+            // SAFETY: ArrayT guarantees this is correct.
             let arr = &mut **arr;
-            &mut *(arr as *mut dyn Array as *mut <T as HasArrayT>::ArrayT)
+            &mut *(arr as *mut dyn Array as *mut ArrayT<T>)
         })
     }
 
     #[inline]
-    pub fn downcast_chunks(&self) -> Chunks<'_, <T as HasArrayT>::ArrayT> {
+    pub fn downcast_chunks(&self) -> Chunks<'_, ArrayT<T>> {
         Chunks::new(&self.chunks)
     }
 

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -589,10 +589,9 @@ macro_rules! impl_chunk_expand {
     }};
 }
 
-impl<T: PolarsDataType> ChunkExpandAtIndex<T> for ChunkedArray<T>
+impl<T: PolarsNumericType> ChunkExpandAtIndex<T> for ChunkedArray<T>
 where
     ChunkedArray<T>: ChunkFull<T::Native> + TakeRandom<Item = T::Native>,
-    T: PolarsNumericType,
 {
     fn new_from_index(&self, index: usize, length: usize) -> ChunkedArray<T> {
         let mut out = impl_chunk_expand!(self, length, index);

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -47,40 +47,30 @@ pub use time_unit::*;
 use crate::chunked_array::arithmetic::ArrayArithmetics;
 pub use crate::chunked_array::logical::*;
 #[cfg(feature = "object")]
+use crate::chunked_array::object::ObjectArray;
+#[cfg(feature = "object")]
 use crate::chunked_array::object::PolarsObjectSafe;
 use crate::prelude::*;
 use crate::utils::Wrap;
 
-pub trait PolarsDataType: Send + Sync + Sized + HasArrayType + HasLogicalType {}
+/// # Safety
+///
+/// The StaticArray and dtype return must be correct.
+pub unsafe trait PolarsDataType: Send + Sync + Sized {
+    type Physical<'a>;
+    type Array: for<'a> StaticArray<ValueT<'a> = Self::Physical<'a>>;
 
-// Important: PolarsNumericType implements PolarsDataType and HasArrayT
-// using a blanket implementation. If we added the bounds to the trait itself
-// Rust ignores the blanket implementation for type checking and will complain
-// about a generic ArrayT given by HasArrayT instead of PrimitiveArray<Native>.
-pub trait PolarsNumericType: Send + Sync + Sized + HasLogicalType + 'static {
-    type Native: NumericNative;
-}
-impl<T: PolarsNumericType> PolarsDataType for T {}
-unsafe impl<T: PolarsNumericType> HasArrayType for T {
-    type Array = PrimitiveArray<T::Native>;
-}
-
-pub trait HasLogicalType {
     fn get_dtype() -> DataType
     where
         Self: Sized;
 }
 
-/// Gives the underlying array type for a particular data type.
-#[doc(hidden)]
-pub unsafe trait HasArrayType {
-    type Array: StaticArray;
+pub trait PolarsNumericType: 'static
+where
+    Self: for<'a> PolarsDataType<Physical<'a> = Self::Native, Array = PrimitiveArray<Self::Native>>,
+{
+    type Native: NumericNative;
 }
-
-/// Gets the physical type associated with a PolarsDataType. Same as T::Native for
-/// PolarsNumericTypes.
-pub type ArrayT<T> = <T as HasArrayType>::Array;
-pub type PhysicalT<'a, T> = <<T as HasArrayType>::Array as StaticArray>::ValueT<'a>;
 
 pub trait PolarsIntegerType: PolarsNumericType {}
 pub trait PolarsFloatType: PolarsNumericType {}
@@ -90,7 +80,10 @@ macro_rules! impl_polars_num_datatype {
         #[derive(Clone, Copy)]
         pub struct $ca {}
 
-        impl HasLogicalType for $ca {
+        unsafe impl PolarsDataType for $ca {
+            type Physical<'a> = $physical;
+            type Array = PrimitiveArray<$physical>;
+
             #[inline]
             fn get_dtype() -> DataType {
                 DataType::$variant
@@ -106,21 +99,18 @@ macro_rules! impl_polars_num_datatype {
 }
 
 macro_rules! impl_polars_datatype {
-    ($ca:ident, $variant:ident, $arr:ty) => {
+    ($ca:ident, $variant:ident, $arr:ty, $lt:lifetime, $phys:ty) => {
         #[derive(Clone, Copy)]
         pub struct $ca {}
 
-        impl HasLogicalType for $ca {
+        unsafe impl PolarsDataType for $ca {
+            type Physical<$lt> = $phys;
+            type Array = $arr;
+
             #[inline]
             fn get_dtype() -> DataType {
                 DataType::$variant
             }
-        }
-
-        impl PolarsDataType for $ca {}
-
-        unsafe impl HasArrayType for $ca {
-            type Array = $arr;
         }
     };
 }
@@ -135,48 +125,54 @@ impl_polars_num_datatype!(PolarsIntegerType, Int32Type, Int32, i32);
 impl_polars_num_datatype!(PolarsIntegerType, Int64Type, Int64, i64);
 impl_polars_num_datatype!(PolarsFloatType, Float32Type, Float32, f32);
 impl_polars_num_datatype!(PolarsFloatType, Float64Type, Float64, f64);
-impl_polars_datatype!(DateType, Date, PrimitiveArray<i32>);
+impl_polars_datatype!(DateType, Date, PrimitiveArray<i32>, 'a, i32);
 #[cfg(feature = "dtype-decimal")]
-impl_polars_datatype!(DecimalType, Unknown, PrimitiveArray<i128>);
-impl_polars_datatype!(DatetimeType, Unknown, PrimitiveArray<i64>);
-impl_polars_datatype!(DurationType, Unknown, PrimitiveArray<i64>);
-impl_polars_datatype!(CategoricalType, Unknown, PrimitiveArray<u32>);
-impl_polars_datatype!(TimeType, Time, PrimitiveArray<i64>);
-impl_polars_datatype!(Utf8Type, Utf8, Utf8Array<i64>);
-impl_polars_datatype!(BinaryType, Binary, BinaryArray<i64>);
-impl_polars_datatype!(BooleanType, Boolean, BooleanArray);
+impl_polars_datatype!(DecimalType, Unknown, PrimitiveArray<i128>, 'a, i128);
+impl_polars_datatype!(DatetimeType, Unknown, PrimitiveArray<i64>, 'a, i64);
+impl_polars_datatype!(DurationType, Unknown, PrimitiveArray<i64>, 'a, i64);
+impl_polars_datatype!(CategoricalType, Unknown, PrimitiveArray<u32>, 'a, u32);
+impl_polars_datatype!(TimeType, Time, PrimitiveArray<i64>, 'a, i64);
+impl_polars_datatype!(Utf8Type, Utf8, Utf8Array<i64>, 'a, &'a str);
+impl_polars_datatype!(BinaryType, Binary, BinaryArray<i64>, 'a, &'a [u8]);
+impl_polars_datatype!(BooleanType, Boolean, BooleanArray, 'a, bool);
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ListType {}
-impl PolarsDataType for ListType {}
-impl HasLogicalType for ListType {
+unsafe impl PolarsDataType for ListType {
+    type Physical<'a> = Box<dyn Array>;
+    type Array = ListArray<i64>;
+
     fn get_dtype() -> DataType {
-        // Mull as we cannot know anything without self.
+        // Null as we cannot know anything without self.
         DataType::List(Box::new(DataType::Null))
     }
-}
-unsafe impl HasArrayType for ListType {
-    type Array = ListArray<i64>;
 }
 
 #[cfg(feature = "dtype-array")]
 pub struct FixedSizeListType {}
 #[cfg(feature = "dtype-array")]
-impl HasLogicalType for FixedSizeListType {
+unsafe impl PolarsDataType for FixedSizeListType {
+    type Physical<'a> = Box<dyn Array>;
+    type Array = FixedSizeListArray;
+
     fn get_dtype() -> DataType {
         // Null as we cannot know anything without self.
         DataType::Array(Box::new(DataType::Null), 0)
     }
 }
 #[cfg(feature = "dtype-array")]
-impl PolarsDataType for FixedSizeListType {}
-#[cfg(feature = "dtype-array")]
-unsafe impl HasArrayType for FixedSizeListType {
-    type Array = FixedSizeListArray;
-}
-
 #[cfg(feature = "dtype-decimal")]
 pub struct Int128Type {}
+#[cfg(feature = "dtype-decimal")]
+unsafe impl PolarsDataType for Int128Type {
+    type Physical<'a> = i128;
+    type Array = PrimitiveArray<i128>;
+
+    fn get_dtype() -> DataType {
+        // Scale is not None to allow for get_any_value() to work.
+        DataType::Decimal(None, Some(0))
+    }
+}
 #[cfg(feature = "dtype-decimal")]
 impl PolarsNumericType for Int128Type {
     type Native = i128;
@@ -184,25 +180,16 @@ impl PolarsNumericType for Int128Type {
 #[cfg(feature = "dtype-decimal")]
 impl PolarsIntegerType for Int128Type {}
 #[cfg(feature = "dtype-decimal")]
-impl HasLogicalType for Int128Type {
-    fn get_dtype() -> DataType {
-        DataType::Decimal(None, Some(0)) // scale is not None to allow for get_any_value() to work
-    }
-}
-
 #[cfg(feature = "object")]
 pub struct ObjectType<T>(T);
 #[cfg(feature = "object")]
-impl<T: PolarsObject> PolarsDataType for ObjectType<T> {}
-#[cfg(feature = "object")]
-impl<T: PolarsObject> HasLogicalType for ObjectType<T> {
+unsafe impl<T: PolarsObject> PolarsDataType for ObjectType<T> {
+    type Physical<'a> = &'a ();
+    type Array = ObjectArray<T>;
+
     fn get_dtype() -> DataType {
         DataType::Object(T::type_name())
     }
-}
-#[cfg(feature = "object")]
-unsafe impl<T: PolarsObject> HasArrayType for ObjectType<T> {
-    type Array = crate::chunked_array::object::ObjectArray<T>;
 }
 
 #[cfg(feature = "dtype-array")]

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -207,16 +207,6 @@ unsafe impl<T: PolarsObject> HasArrayT for ObjectType<T> {
     type ArrayT = crate::chunked_array::object::ObjectArray<T>;
 }
 
-
-/// Any type that is not nested.
-pub trait PolarsSingleType: PolarsDataType {}
-
-impl<T> PolarsSingleType for T where T: NativeType + PolarsDataType {}
-
-impl PolarsSingleType for Utf8Type {}
-
-impl PolarsSingleType for BinaryType {}
-
 #[cfg(feature = "dtype-array")]
 pub type ArrayChunked = ChunkedArray<FixedSizeListType>;
 pub type ListChunked = ChunkedArray<ListType>;

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -370,63 +370,6 @@ impl PolarsIntegerType for Int64Type {}
 // Provide options to cloud providers (credentials, region).
 pub type CloudOptions = PlHashMap<String, String>;
 
-/// Used to safely match the underlying type of Polars data structures.
-///
-/// # Safety
-///
-/// The underlying physical type of the data structure on which this
-/// is implemented must always match the given PolarsDataType.
-pub unsafe trait StaticallyMatchesPolarsType<T: PolarsDataType> {}
-
-unsafe impl<T: PolarsNumericType> StaticallyMatchesPolarsType<T> for PrimitiveArray<T::Native> {}
-unsafe impl StaticallyMatchesPolarsType<CategoricalType> for PrimitiveArray<u32> {}
-unsafe impl StaticallyMatchesPolarsType<Utf8Type> for Utf8Array<i64> {}
-unsafe impl StaticallyMatchesPolarsType<BinaryType> for BinaryArray<i64> {}
-unsafe impl StaticallyMatchesPolarsType<BooleanType> for BooleanArray {}
-unsafe impl StaticallyMatchesPolarsType<ListType> for ListArray<i64> {}
-#[cfg(feature = "dtype-array")]
-unsafe impl StaticallyMatchesPolarsType<FixedSizeListType> for FixedSizeListArray {}
-
-#[doc(hidden)]
-pub unsafe trait HasUnderlyingArray {
-    type ArrayT: StaticArray;
-}
-
-unsafe impl<T: PolarsNumericType> HasUnderlyingArray for ChunkedArray<T> {
-    type ArrayT = PrimitiveArray<T::Native>;
-}
-
-unsafe impl HasUnderlyingArray for BooleanChunked {
-    type ArrayT = BooleanArray;
-}
-
-unsafe impl HasUnderlyingArray for Utf8Chunked {
-    type ArrayT = Utf8Array<i64>;
-}
-
-unsafe impl HasUnderlyingArray for BinaryChunked {
-    type ArrayT = BinaryArray<i64>;
-}
-
-unsafe impl HasUnderlyingArray for ListChunked {
-    type ArrayT = ListArray<i64>;
-}
-
-#[cfg(feature = "dtype-array")]
-unsafe impl HasUnderlyingArray for ArrayChunked {
-    type ArrayT = FixedSizeListArray;
-}
-
-#[cfg(feature = "object")]
-unsafe impl<T: PolarsObject> HasUnderlyingArray for ObjectChunked<T> {
-    type ArrayT = crate::chunked_array::object::ObjectArray<T>;
-}
-
-
-
-
-
-
 #[doc(hidden)]
 pub unsafe trait HasArrayT {
     type ArrayT: StaticArray;

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -51,7 +51,6 @@ use crate::chunked_array::object::PolarsObjectSafe;
 use crate::prelude::*;
 use crate::utils::Wrap;
 
-
 pub trait PolarsDataType: Send + Sync + Sized + HasArrayType + HasLogicalType {}
 
 // Important: PolarsNumericType implements PolarsDataType and HasArrayT
@@ -146,7 +145,6 @@ impl_polars_datatype!(TimeType, Time, PrimitiveArray<i64>);
 impl_polars_datatype!(Utf8Type, Utf8, Utf8Array<i64>);
 impl_polars_datatype!(BinaryType, Binary, BinaryArray<i64>);
 impl_polars_datatype!(BooleanType, Boolean, BooleanArray);
-
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ListType {}

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -80,8 +80,8 @@ pub unsafe trait HasArrayT {
 
 /// Gets the physical type associated with a PolarsDataType. Same as T::Native for
 /// PolarsNumericTypes.
+pub type ArrayT<T> = <T as HasArrayT>::ArrayT;
 pub type PhysicalT<'a, T> = <<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>;
-
 
 pub trait PolarsIntegerType: PolarsNumericType {}
 pub trait PolarsFloatType: PolarsNumericType {}

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -260,42 +260,42 @@ pub trait NumericNative:
     + IsFloat
     + ArrayArithmetics
 {
-    type POLARSTYPE: PolarsNumericType;
+    type PolarsType: PolarsNumericType;
 }
 
 impl NumericNative for i8 {
-    type POLARSTYPE = Int8Type;
+    type PolarsType = Int8Type;
 }
 impl NumericNative for i16 {
-    type POLARSTYPE = Int16Type;
+    type PolarsType = Int16Type;
 }
 impl NumericNative for i32 {
-    type POLARSTYPE = Int32Type;
+    type PolarsType = Int32Type;
 }
 impl NumericNative for i64 {
-    type POLARSTYPE = Int64Type;
+    type PolarsType = Int64Type;
 }
 impl NumericNative for u8 {
-    type POLARSTYPE = UInt8Type;
+    type PolarsType = UInt8Type;
 }
 impl NumericNative for u16 {
-    type POLARSTYPE = UInt16Type;
+    type PolarsType = UInt16Type;
 }
 impl NumericNative for u32 {
-    type POLARSTYPE = UInt32Type;
+    type PolarsType = UInt32Type;
 }
 impl NumericNative for u64 {
-    type POLARSTYPE = UInt64Type;
+    type PolarsType = UInt64Type;
 }
 #[cfg(feature = "dtype-decimal")]
 impl NumericNative for i128 {
-    type POLARSTYPE = Int128Type;
+    type PolarsType = Int128Type;
 }
 impl NumericNative for f32 {
-    type POLARSTYPE = Float32Type;
+    type PolarsType = Float32Type;
 }
 impl NumericNative for f64 {
-    type POLARSTYPE = Float64Type;
+    type PolarsType = Float64Type;
 }
 
 // Provide options to cloud providers (credentials, region).

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -65,50 +65,107 @@ pub trait PolarsDataType: Send + Sync {
     fn get_dtype() -> DataType
     where
         Self: Sized;
+    
+    type Native<'a>;
+    type ArrayT: for<'a> StaticArray<ValueT<'a>=Self::Native<'a>>;
+}
+
+pub trait PolarsNumericType: Send + Sync + 'static {
+    fn get_dtype() -> DataType
+    where
+        Self: Sized;
+    
+    type Native: NumericNative;
+    type ArrayT: for<'a> StaticArray<ValueT<'a>=Self::Native>;
+}
+
+pub trait PolarsIntegerType: Send + Sync + 'static {
+    fn get_dtype() -> DataType
+    where
+        Self: Sized;
+    
+    type Native: NumericNative;
+    type ArrayT: for<'a> StaticArray<ValueT<'a>=Self::Native>;
+}
+
+impl<T: PolarsIntegerType> PolarsNumericType for T {
+    fn get_dtype() -> DataType { <Self as PolarsIntegerType>::get_dtype() }
+    type Native = <Self as PolarsIntegerType>::Native;
+    type ArrayT = <Self as PolarsIntegerType>::ArrayT;
+}
+
+impl<T: PolarsNumericType> PolarsDataType for T {
+    fn get_dtype() -> DataType { <Self as PolarsNumericType>::get_dtype() }
+    type Native<'a> = <Self as PolarsNumericType>::Native;
+    type ArrayT = <Self as PolarsNumericType>::ArrayT;
 }
 
 macro_rules! impl_polars_datatype {
-    ($ca:ident, $variant:ident, $physical:ty) => {
+    ($trait: ident, $ca:ident, $variant:ident, $physical:ty, $arr:ty) => {
         #[derive(Clone, Copy)]
         pub struct $ca {}
 
-        impl PolarsDataType for $ca {
+        impl $trait for $ca {
             #[inline]
             fn get_dtype() -> DataType {
                 DataType::$variant
             }
+            
+            type Native = $physical;
+            type ArrayT = $arr;
+        }
+    };
+
+    ($trait: ident, $lt: lifetime, $ca:ident, $variant:ident, $physical:ty, $arr:ty) => {
+        #[derive(Clone, Copy)]
+        pub struct $ca {}
+
+        impl $trait for $ca {
+            #[inline]
+            fn get_dtype() -> DataType {
+                DataType::$variant
+            }
+            
+            type Native<$lt> = $physical;
+            type ArrayT = $arr;
         }
     };
 }
 
-impl_polars_datatype!(UInt8Type, UInt8, u8);
-impl_polars_datatype!(UInt16Type, UInt16, u16);
-impl_polars_datatype!(UInt32Type, UInt32, u32);
-impl_polars_datatype!(UInt64Type, UInt64, u64);
-impl_polars_datatype!(Int8Type, Int8, i8);
-impl_polars_datatype!(Int16Type, Int16, i16);
-impl_polars_datatype!(Int32Type, Int32, i32);
-impl_polars_datatype!(Int64Type, Int64, i64);
-impl_polars_datatype!(Float32Type, Float32, f32);
-impl_polars_datatype!(Float64Type, Float64, f64);
-impl_polars_datatype!(DateType, Date, i32);
+impl_polars_datatype!(PolarsIntegerType, UInt8Type, UInt8, u8, PrimitiveArray<u8>);
+impl_polars_datatype!(PolarsIntegerType, UInt16Type, UInt16, u16, PrimitiveArray<u16>);
+impl_polars_datatype!(PolarsIntegerType, UInt32Type, UInt32, u32, PrimitiveArray<u32>);
+impl_polars_datatype!(PolarsIntegerType, UInt64Type, UInt64, u64, PrimitiveArray<u64>);
+impl_polars_datatype!(PolarsIntegerType, Int8Type, Int8, i8, PrimitiveArray<i8>);
+impl_polars_datatype!(PolarsIntegerType, Int16Type, Int16, i16, PrimitiveArray<i16>);
+impl_polars_datatype!(PolarsIntegerType, Int32Type, Int32, i32, PrimitiveArray<i32>);
+impl_polars_datatype!(PolarsIntegerType, Int64Type, Int64, i64, PrimitiveArray<i64>);
+impl_polars_datatype!(PolarsNumericType, Float32Type, Float32, f32, PrimitiveArray<f32>);
+impl_polars_datatype!(PolarsNumericType, Float64Type, Float64, f64, PrimitiveArray<f64>);
+impl_polars_datatype!(PolarsDataType, 'a, DateType, Date, i32, PrimitiveArray<i32>);
 #[cfg(feature = "dtype-decimal")]
-impl_polars_datatype!(DecimalType, Unknown, i128);
-impl_polars_datatype!(DatetimeType, Unknown, i64);
-impl_polars_datatype!(DurationType, Unknown, i64);
-impl_polars_datatype!(CategoricalType, Unknown, u32);
-impl_polars_datatype!(TimeType, Time, i64);
+impl_polars_datatype!(PolarsDataType, 'a, DecimalType, Unknown, i128, PrimitiveArray<i128>);
+impl_polars_datatype!(PolarsDataType, 'a, DatetimeType, Unknown, i64, PrimitiveArray<i64>);
+impl_polars_datatype!(PolarsDataType, 'a, DurationType, Unknown, i64, PrimitiveArray<i64>);
+impl_polars_datatype!(PolarsDataType, 'a, CategoricalType, Unknown, u32, PrimitiveArray<u32>);
+impl_polars_datatype!(PolarsDataType, 'a, TimeType, Time, i64, PrimitiveArray<i64>);
 
 impl PolarsDataType for Utf8Type {
     fn get_dtype() -> DataType {
         DataType::Utf8
     }
+    
+    type Native<'a> = &'a str;
+    type ArrayT = Utf8Array<i64>;
 }
 
 impl PolarsDataType for BinaryType {
     fn get_dtype() -> DataType {
         DataType::Binary
     }
+
+    type Native<'a> = &'a [u8];
+    type ArrayT = BinaryArray<i64>;
 }
 
 pub struct BooleanType {}
@@ -117,6 +174,9 @@ impl PolarsDataType for BooleanType {
     fn get_dtype() -> DataType {
         DataType::Boolean
     }
+    
+    type Native<'a> = bool;
+    type ArrayT = BooleanArray;
 }
 
 impl PolarsDataType for ListType {
@@ -124,6 +184,9 @@ impl PolarsDataType for ListType {
         // null as we cannot know anything without self.
         DataType::List(Box::new(DataType::Null))
     }
+    
+    type Native<'a> = Box<dyn Array>;
+    type ArrayT = ListArray<i64>;
 }
 
 #[cfg(feature = "dtype-array")]
@@ -132,16 +195,22 @@ impl PolarsDataType for FixedSizeListType {
         // null as we cannot know anything without self.
         DataType::Array(Box::new(DataType::Null), 0)
     }
+
+    type Native<'a> = Box<dyn Array>;
+    type ArrayT = FixedSizeListArray;
 }
 
 #[cfg(feature = "dtype-decimal")]
 pub struct Int128Type {}
 
 #[cfg(feature = "dtype-decimal")]
-impl PolarsDataType for Int128Type {
+impl PolarsIntegerType for Int128Type {
     fn get_dtype() -> DataType {
         DataType::Decimal(None, Some(0)) // scale is not None to allow for get_any_value() to work
     }
+
+    type Native = i128;
+    type ArrayT = PrimitiveArray<i128>;
 }
 
 #[cfg(feature = "object")]
@@ -154,6 +223,9 @@ impl<T: PolarsObject> PolarsDataType for ObjectType<T> {
     fn get_dtype() -> DataType {
         DataType::Object(T::type_name())
     }
+
+    type Native<'a> = &'a ();
+    type ArrayT = crate::chunked_array::object::ObjectArray<T>;
 }
 
 /// Any type that is not nested
@@ -244,6 +316,7 @@ impl NumericNative for f64 {
     type POLARSTYPE = Float64Type;
 }
 
+/*
 pub trait PolarsNumericType: Send + Sync + PolarsDataType + 'static {
     type Native: NumericNative;
 }
@@ -291,6 +364,8 @@ impl PolarsIntegerType for Int8Type {}
 impl PolarsIntegerType for Int16Type {}
 impl PolarsIntegerType for Int32Type {}
 impl PolarsIntegerType for Int64Type {}
+
+*/
 
 pub trait PolarsFloatType: PolarsNumericType {}
 impl PolarsFloatType for Float32Type {}

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -160,7 +160,6 @@ unsafe impl PolarsDataType for FixedSizeListType {
         DataType::Array(Box::new(DataType::Null), 0)
     }
 }
-#[cfg(feature = "dtype-array")]
 #[cfg(feature = "dtype-decimal")]
 pub struct Int128Type {}
 #[cfg(feature = "dtype-decimal")]
@@ -179,7 +178,6 @@ impl PolarsNumericType for Int128Type {
 }
 #[cfg(feature = "dtype-decimal")]
 impl PolarsIntegerType for Int128Type {}
-#[cfg(feature = "dtype-decimal")]
 #[cfg(feature = "object")]
 pub struct ObjectType<T>(T);
 #[cfg(feature = "object")]

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -7,7 +7,7 @@ use polars_core::with_match_physical_integer_polars_type;
 fn is_in_helper<'a, T>(ca: &'a ChunkedArray<T>, other: &Series) -> PolarsResult<BooleanChunked>
 where
     T: PolarsDataType,
-    PhysicalT<'a, T>: Hash + Eq + Copy,
+    T::Physical<'a>: Hash + Eq + Copy,
 {
     let mut set = PlHashSet::with_capacity(other.len());
 

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -7,7 +7,7 @@ use polars_core::with_match_physical_integer_polars_type;
 fn is_in_helper<'a, T>(ca: &'a ChunkedArray<T>, other: &Series) -> PolarsResult<BooleanChunked>
 where
     T: PolarsDataType,
-    <<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>: Hash + Eq + Copy,
+    PhysicalT<'a, T>: Hash + Eq + Copy,
 {
     let mut set = PlHashSet::with_capacity(other.len());
 

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -7,8 +7,7 @@ use polars_core::with_match_physical_integer_polars_type;
 fn is_in_helper<'a, T>(ca: &'a ChunkedArray<T>, other: &Series) -> PolarsResult<BooleanChunked>
 where
     T: PolarsDataType,
-    ChunkedArray<T>: HasUnderlyingArray,
-    <<ChunkedArray<T> as HasUnderlyingArray>::ArrayT as StaticArray>::ValueT<'a>: Hash + Eq + Copy,
+    <<T as HasArrayT>::ArrayT as StaticArray>::ValueT<'a>: Hash + Eq + Copy,
 {
     let mut set = PlHashSet::with_capacity(other.len());
 

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/mean.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/mean.rs
@@ -107,7 +107,7 @@ where
             let arr = values.chunks().get_unchecked(0);
             arr.sliced_unchecked(offset as usize, length as usize)
         };
-        let dtype = <K::PolarsType as HasLogicalType>::get_dtype().to_arrow();
+        let dtype = K::PolarsType::get_dtype().to_arrow();
         let arr = polars_arrow::compute::cast::cast(arr.as_ref(), &dtype).unwrap();
         let arr = unsafe {
             arr.as_any()

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/mean.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/mean.rs
@@ -107,7 +107,7 @@ where
             let arr = values.chunks().get_unchecked(0);
             arr.sliced_unchecked(offset as usize, length as usize)
         };
-        let dtype = <K::POLARSTYPE as PolarsDataType>::get_dtype().to_arrow();
+        let dtype = <K::POLARSTYPE as HasLogicalType>::get_dtype().to_arrow();
         let arr = polars_arrow::compute::cast::cast(arr.as_ref(), &dtype).unwrap();
         let arr = unsafe {
             arr.as_any()

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/mean.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/mean.rs
@@ -42,7 +42,7 @@ impl<K: NumericNative> MeanAgg<K> {
 
 impl<K> AggregateFn for MeanAgg<K>
 where
-    K::POLARSTYPE: PolarsNumericType,
+    K::PolarsType: PolarsNumericType,
     K: NumericNative + Add<Output = K>,
     <K as Simd>::Simd: Add<Output = <K as Simd>::Simd> + Sum<K>,
 {
@@ -107,7 +107,7 @@ where
             let arr = values.chunks().get_unchecked(0);
             arr.sliced_unchecked(offset as usize, length as usize)
         };
-        let dtype = <K::POLARSTYPE as HasLogicalType>::get_dtype().to_arrow();
+        let dtype = <K::PolarsType as HasLogicalType>::get_dtype().to_arrow();
         let arr = polars_arrow::compute::cast::cast(arr.as_ref(), &dtype).unwrap();
         let arr = unsafe {
             arr.as_any()

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/mean.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/mean.rs
@@ -107,7 +107,7 @@ where
             let arr = values.chunks().get_unchecked(0);
             arr.sliced_unchecked(offset as usize, length as usize)
         };
-        let dtype = K::POLARSTYPE::get_dtype().to_arrow();
+        let dtype = <K::POLARSTYPE as PolarsDataType>::get_dtype().to_arrow();
         let arr = polars_arrow::compute::cast::cast(arr.as_ref(), &dtype).unwrap();
         let arr = unsafe {
             arr.as_any()

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/min_max.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/min_max.rs
@@ -89,7 +89,7 @@ where
         length: IdxSize,
         values: &Series,
     ) {
-        let ca: &ChunkedArray<K::POLARSTYPE> = values.as_ref().as_ref();
+        let ca: &ChunkedArray<K::PolarsType> = values.as_ref().as_ref();
         let arr = ca.downcast_iter().next().unwrap();
         let arr = unsafe { arr.slice_typed_unchecked(offset as usize, length as usize) };
         // convince the compiler that K::POLARSTYPE::Native == K

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/sum.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/sum.rs
@@ -89,7 +89,7 @@ where
             let arr = values.chunks().get_unchecked(0);
             arr.sliced_unchecked(offset as usize, length as usize)
         };
-        let dtype = <K::POLARSTYPE as PolarsNumericType>::get_dtype().to_arrow();
+        let dtype = <K::POLARSTYPE as HasLogicalType>::get_dtype().to_arrow();
         let arr = polars_arrow::compute::cast::cast(arr.as_ref(), &dtype).unwrap();
         let arr = unsafe {
             arr.as_any()

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/sum.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/sum.rs
@@ -34,7 +34,7 @@ impl<K: NumericNative + Add<Output = K> + NumCast> SumAgg<K> {
 
 impl<K> AggregateFn for SumAgg<K>
 where
-    K::POLARSTYPE: PolarsNumericType,
+    K::PolarsType: PolarsNumericType,
     K: NumericNative + Add<Output = K>,
     <K as Simd>::Simd: Add<Output = <K as Simd>::Simd> + Sum<K>,
 {
@@ -89,7 +89,7 @@ where
             let arr = values.chunks().get_unchecked(0);
             arr.sliced_unchecked(offset as usize, length as usize)
         };
-        let dtype = <K::POLARSTYPE as HasLogicalType>::get_dtype().to_arrow();
+        let dtype = <K::PolarsType as HasLogicalType>::get_dtype().to_arrow();
         let arr = polars_arrow::compute::cast::cast(arr.as_ref(), &dtype).unwrap();
         let arr = unsafe {
             arr.as_any()

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/sum.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/sum.rs
@@ -89,7 +89,7 @@ where
             let arr = values.chunks().get_unchecked(0);
             arr.sliced_unchecked(offset as usize, length as usize)
         };
-        let dtype = <K::PolarsType as HasLogicalType>::get_dtype().to_arrow();
+        let dtype = K::PolarsType::get_dtype().to_arrow();
         let arr = polars_arrow::compute::cast::cast(arr.as_ref(), &dtype).unwrap();
         let arr = unsafe {
             arr.as_any()

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/sum.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/sum.rs
@@ -89,7 +89,7 @@ where
             let arr = values.chunks().get_unchecked(0);
             arr.sliced_unchecked(offset as usize, length as usize)
         };
-        let dtype = K::POLARSTYPE::get_dtype().to_arrow();
+        let dtype = <K::POLARSTYPE as PolarsNumericType>::get_dtype().to_arrow();
         let arr = polars_arrow::compute::cast::cast(arr.as_ref(), &dtype).unwrap();
         let arr = unsafe {
             arr.as_any()


### PR DESCRIPTION
This should reduce friction with writing generic code by making the static compile-time type relationships available on `PolarsDataType`s themselves. I also managed to eliminate the`StaticallyMatchesPolars` and `HasUnderlyingArray` traits.