### PR TITLE
docs(python): Document that filter, drop_nulls, left join preserve order

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4738,7 +4738,6 @@ class DataFrame:
         """
         Drop all rows that contain null values.
 
-        Returns a new DataFrame.
         The original order of the remaining rows is preserved.
 
         Parameters

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5867,9 +5867,7 @@ class DataFrame:
             Join strategy.
 
             .. note::
-
-                - A left join preserves the row order of the left DataFrame.
-
+                A left join preserves the row order of the left DataFrame.
         left_on
             Name(s) of the left join column(s).
         right_on

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3896,6 +3896,8 @@ class DataFrame:
         """
         Filter the rows in the DataFrame based on a predicate expression.
 
+        The original order of the remaining rows is preserved.
+
         Parameters
         ----------
         predicate
@@ -4737,6 +4739,7 @@ class DataFrame:
         Drop all rows that contain null values.
 
         Returns a new DataFrame.
+        The original order of the remaining rows is preserved.
 
         Parameters
         ----------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5866,6 +5866,11 @@ class DataFrame:
             Name(s) of the join columns in both DataFrames.
         how : {'inner', 'left', 'outer', 'semi', 'anti', 'cross'}
             Join strategy.
+
+            .. note::
+
+                - A left join preserves the row order of the left DataFrame.
+
         left_on
             Name(s) of the left join column(s).
         right_on

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1387,28 +1387,29 @@ class Expr:
         """
         Drop all null values.
 
-        Warnings
+        The original order of the remaining elements is preserved.
+
+        See Also
         --------
-        Note that null values are not floating point NaN values!
+        drop_nans
+
+        Notes
+        -----
+        A null value is not the same as a NaN value.
         To drop NaN values, use :func:`drop_nans`.
 
         Examples
         --------
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "a": [8, 9, 10, 11],
-        ...         "b": [None, 4.0, 4.0, float("nan")],
-        ...     }
-        ... )
-        >>> df.select(pl.col("b").drop_nulls())
+        >>> df = pl.DataFrame({"a": [1.0, None, 3.0, float("nan")]})
+        >>> df.select(pl.col("a").drop_nulls())
         shape: (3, 1)
         ┌─────┐
-        │ b   │
+        │ a   │
         │ --- │
         │ f64 │
         ╞═════╡
-        │ 4.0 │
-        │ 4.0 │
+        │ 1.0 │
+        │ 3.0 │
         │ NaN │
         └─────┘
 
@@ -1417,31 +1418,32 @@ class Expr:
 
     def drop_nans(self) -> Self:
         """
-        Drop floating point NaN values.
+        Drop all floating point NaN values.
 
-        Warnings
+        The original order of the remaining elements is preserved.
+
+        See Also
         --------
-        Note that NaN values are not null values!
+        drop_nulls
+
+        Notes
+        -----
+        A NaN value is not the same as a null value.
         To drop null values, use :func:`drop_nulls`.
 
         Examples
         --------
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "a": [8, 9, 10, 11],
-        ...         "b": [None, 4.0, 4.0, float("nan")],
-        ...     }
-        ... )
-        >>> df.select(pl.col("b").drop_nans())
+        >>> df = pl.DataFrame({"a": [1.0, None, 3.0, float("nan")]})
+        >>> df.select(pl.col("a").drop_nans())
         shape: (3, 1)
         ┌──────┐
-        │ b    │
+        │ a    │
         │ ---  │
         │ f64  │
         ╞══════╡
+        │ 1.0  │
         │ null │
-        │ 4.0  │
-        │ 4.0  │
+        │ 3.0  │
         └──────┘
 
         """

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3607,6 +3607,8 @@ class Expr:
         """
         Filter a single column.
 
+        The original order of the remaining elements is preserved.
+
         Mostly useful in an aggregation context. If you want to filter on a DataFrame
         level, use `LazyFrame.filter`.
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3417,10 +3417,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Add a join operation to the Logical Plan.
 
-            .. note::
-
-                - A left join preserves the row order of the left DataFrame.
-
         Parameters
         ----------
         other
@@ -3430,6 +3426,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             None.
         how : {'inner', 'left', 'outer', 'semi', 'anti', 'cross'}
             Join strategy.
+
+            .. note::
+                A left join preserves the row order of the left DataFrame.
         left_on
             Join column of the left DataFrame.
         right_on

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2406,6 +2406,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Filter the rows in the LazyFrame based on a predicate expression.
 
+        The original order of the remaining rows is preserved.
+
         Parameters
         ----------
         predicate
@@ -4971,6 +4973,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Drop all rows that contain null values.
 
         Returns a new LazyFrame.
+        The original order of the remaining rows is preserved.
 
         Parameters
         ----------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4976,7 +4976,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Drop all rows that contain null values.
 
-        Returns a new LazyFrame.
         The original order of the remaining rows is preserved.
 
         Parameters

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3417,6 +3417,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Add a join operation to the Logical Plan.
 
+            .. note::
+
+                - A left join preserves the row order of the left DataFrame.
+
         Parameters
         ----------
         other

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1397,6 +1397,7 @@ class Series:
         Drop all null values.
 
         Creates a new Series that copies data from this Series without null values.
+        The original order of the remaining elements is preserved.
         """
 
     def drop_nans(self) -> Series:
@@ -2815,6 +2816,8 @@ class Series:
     def filter(self, predicate: Series | list[bool]) -> Self:
         """
         Filter elements by a boolean mask.
+
+        The original order of the remaining elements is preserved.
 
         Parameters
         ----------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1410,7 +1410,7 @@ class Series:
         Examples
         --------
         >>> s = pl.Series([1.0, None, 3.0, float("nan")])
-        >>> s.drop_nans()
+        >>> s.drop_nulls()
         shape: (3,)
         Series: '' [f64]
         [

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1396,12 +1396,59 @@ class Series:
         """
         Drop all null values.
 
-        Creates a new Series that copies data from this Series without null values.
         The original order of the remaining elements is preserved.
+
+        See Also
+        --------
+        drop_nans
+
+        Notes
+        -----
+        A null value is not the same as a NaN value.
+        To drop NaN values, use :func:`drop_nans`.
+
+        Examples
+        --------
+        >>> s = pl.Series([1.0, None, 3.0, float("nan")])
+        >>> s.drop_nans()
+        shape: (3,)
+        Series: '' [f64]
+        [
+                1.0
+                3.0
+                NaN
+        ]
+
         """
 
     def drop_nans(self) -> Series:
-        """Drop NaN values."""
+        """
+        Drop all floating point NaN values.
+
+        The original order of the remaining elements is preserved.
+
+        See Also
+        --------
+        drop_nulls
+
+        Notes
+        -----
+        A NaN value is not the same as a null value.
+        To drop null values, use :func:`drop_nulls`.
+
+        Examples
+        --------
+        >>> s = pl.Series([1.0, None, 3.0, float("nan")])
+        >>> s.drop_nans()
+        shape: (3,)
+        Series: '' [f64]
+        [
+                1.0
+                null
+                3.0
+        ]
+
+        """
 
     def to_frame(self, name: str | None = None) -> DataFrame:
         """


### PR DESCRIPTION
Closes #10950 

- I only added python docs.
- I don't always know how many blank lines are needed with all this fancy docstring stuff.
- I'm not 100% firm on the wording:
    - "original order is preserved" or "relative order is preserved" or simply "order is preserved"
- I didn't add any notes to `Expr.filter()` or `Expr.drop_nulls()`
- The current docstrings for `drop_nulls` mention `Returns a new DataFrame`, whereas the docstrings for `filter` do not.
Since basically everything in polars returns a new copy, I'm not sure whether `Returns a new DataFrame` needs to be said.