### PR TITLE
feat(python, rust): Add `strip_prefix` and `strip_suffix` to the string namespace

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -691,6 +691,8 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "nightly")]
             Titlecase => map!(strings::titlecase),
             Strip(matches) => map!(strings::strip, matches.as_deref()),
+            StripPrefix(prefix) => map!(strings::strip_prefix, &prefix),
+            StripSuffix(suffix) => map!(strings::strip_suffix, &suffix),
             LStrip(matches) => map!(strings::lstrip, matches.as_deref()),
             RStrip(matches) => map!(strings::rstrip, matches.as_deref()),
             #[cfg(feature = "string_from_radix")]

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -460,6 +460,22 @@ impl StringNameSpace {
             .map_private(FunctionExpr::StringExpr(StringFunction::Strip(matches)))
     }
 
+    /// Remove prefix.
+    pub fn strip_prefix(self, prefix: String) -> Expr {
+        self.0
+            .map_private(FunctionExpr::StringExpr(StringFunction::StripPrefix(
+                prefix,
+            )))
+    }
+
+    /// Remove suffix.
+    pub fn strip_suffix(self, suffix: String) -> Expr {
+        self.0
+            .map_private(FunctionExpr::StringExpr(StringFunction::StripSuffix(
+                suffix,
+            )))
+    }
+
     /// Remove leading characters, or whitespace if matches is None.
     pub fn lstrip(self, matches: Option<String>) -> Expr {
         self.0

--- a/py-polars/docs/source/reference/expressions/string.rst
+++ b/py-polars/docs/source/reference/expressions/string.rst
@@ -35,6 +35,8 @@ The following methods are available under the `expr.str` attribute.
     Expr.str.splitn
     Expr.str.starts_with
     Expr.str.strip
+    Expr.str.strip_prefix
+    Expr.str.strip_suffix
     Expr.str.strptime
     Expr.str.to_date
     Expr.str.to_datetime

--- a/py-polars/docs/source/reference/series/string.rst
+++ b/py-polars/docs/source/reference/series/string.rst
@@ -35,6 +35,8 @@ The following methods are available under the `Series.str` attribute.
     Series.str.splitn
     Series.str.starts_with
     Series.str.strip
+    Series.str.strip_prefix
+    Series.str.strip_suffix
     Series.str.strptime
     Series.str.to_date
     Series.str.to_datetime

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -583,36 +583,28 @@ class ExprStringNameSpace:
         """
         Remove prefix.
 
+        The prefix will be removed from the string exactly once, if found.
+
         Parameters
         ----------
         prefix
-            The prefix to be removed. The prefix will be removed exactly once from the
-            string if found.
+            The prefix to be removed.
 
         Examples
         --------
-        >>> df = pl.DataFrame({"baz": ["foo:bar", "foofoo:bar"]})
-        >>> df
-        shape: (2, 1)
-        ┌────────────┐
-        │ baz        │
-        │ ---        │
-        │ str        │
-        ╞════════════╡
-        │ foo:bar    │
-        │ foofoo:bar │
-        └────────────┘
-
-        >>> df.select(pl.col("baz").str.strip_prefix("foo"))
-        shape: (2, 1)
-        ┌─────────┐
-        │ baz     │
-        │ ---     │
-        │ str     │
-        ╞═════════╡
-        │ :bar    │
-        │ foo:bar │
-        └─────────┘
+        >>> df = pl.DataFrame({"a": ["foobar", "foofoobar", "foo", "bar"]})
+        >>> df.with_columns(pl.col("a").str.strip_prefix("foo").alias("stripped"))
+        shape: (4, 2)
+        ┌───────────┬──────────┐
+        │ a         ┆ stripped │
+        │ ---       ┆ ---      │
+        │ str       ┆ str      │
+        ╞═══════════╪══════════╡
+        │ foobar    ┆ bar      │
+        │ foofoobar ┆ foobar   │
+        │ foo       ┆          │
+        │ bar       ┆ bar      │
+        └───────────┴──────────┘
 
         """
         return wrap_expr(self._pyexpr.str_strip_prefix(prefix))
@@ -621,36 +613,28 @@ class ExprStringNameSpace:
         """
         Remove suffix.
 
+        The suffix will be removed from the string exactly once, if found.
+
         Parameters
         ----------
         suffix
-            The suffix to be removed. The suffix will be removed exactly once from the
-            string if found.
+            The suffix to be removed.
 
         Examples
         --------
-        >>> df = pl.DataFrame({"baz": ["foo:bar", "foo:barbar"]})
-        >>> df
-        shape: (2, 1)
-        ┌────────────┐
-        │ baz        │
-        │ ---        │
-        │ str        │
-        ╞════════════╡
-        │ foo:bar    │
-        │ foo:barbar │
-        └────────────┘
-
-        >>> df.select(pl.col("baz").str.strip_suffix("bar"))
-        shape: (2, 1)
-        ┌─────────┐
-        │ baz     │
-        │ ---     │
-        │ str     │
-        ╞═════════╡
-        │ foo:    │
-        │ foo:bar │
-        └─────────┘
+        >>> df = pl.DataFrame({"a": ["foobar", "foobarbar", "foo", "bar"]})
+        >>> df.with_columns(pl.col("a").str.strip_suffix("bar").alias("stripped"))
+        shape: (4, 2)
+        ┌───────────┬──────────┐
+        │ a         ┆ stripped │
+        │ ---       ┆ ---      │
+        │ str       ┆ str      │
+        ╞═══════════╪══════════╡
+        │ foobar    ┆ foo      │
+        │ foobarbar ┆ foobar   │
+        │ foo       ┆ foo      │
+        │ bar       ┆          │
+        └───────────┴──────────┘
 
         """
         return wrap_expr(self._pyexpr.str_strip_suffix(suffix))

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -594,14 +594,14 @@ class ExprStringNameSpace:
         >>> df = pl.DataFrame({"baz": ["foo:bar", "foofoo:bar"]})
         >>> df
         shape: (2, 1)
-        ┌─────────────┐
-        │ baz         │
-        │ ---         │
-        │ str         │
-        ╞═════════════╡
-        │ foo:bar     │
-        │ foofoo:bar  │
-        └─────────────┘
+        ┌────────────┐
+        │ baz        │
+        │ ---        │
+        │ str        │
+        ╞════════════╡
+        │ foo:bar    │
+        │ foofoo:bar │
+        └────────────┘
 
         >>> df.select(pl.col("baz").str.strip_prefix("foo"))
         shape: (2, 1)
@@ -632,14 +632,14 @@ class ExprStringNameSpace:
         >>> df = pl.DataFrame({"baz": ["foo:bar", "foo:barbar"]})
         >>> df
         shape: (2, 1)
-        ┌─────────────┐
-        │ baz         │
-        │ ---         │
-        │ str         │
-        ╞═════════════╡
-        │ foo:bar     │
-        │ foo:barbar  │
-        └─────────────┘
+        ┌────────────┐
+        │ baz        │
+        │ ---        │
+        │ str        │
+        ╞════════════╡
+        │ foo:bar    │
+        │ foo:barbar │
+        └────────────┘
 
         >>> df.select(pl.col("baz").str.strip_suffix("bar"))
         shape: (2, 1)

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -603,7 +603,7 @@ class ExprStringNameSpace:
         │ foofoo:bar  │
         └─────────────┘
 
-        >>> df.select(pl.col("baz").str.strip_prefix())
+        >>> df.select(pl.col("baz").str.strip_prefix("foo"))
         shape: (2, 1)
         ┌─────────┐
         │ baz     │
@@ -641,7 +641,7 @@ class ExprStringNameSpace:
         │ foo:barbar  │
         └─────────────┘
 
-        >>> df.select(pl.col("baz").str.strip_suffix())
+        >>> df.select(pl.col("baz").str.strip_suffix("bar"))
         shape: (2, 1)
         ┌─────────┐
         │ baz     │

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -580,7 +580,7 @@ class ExprStringNameSpace:
         return wrap_expr(self._pyexpr.str_strip(characters))
 
     def strip_prefix(self, prefix: str) -> Expr:
-        r"""
+        """
         Remove prefix.
 
         Parameters
@@ -618,7 +618,7 @@ class ExprStringNameSpace:
         return wrap_expr(self._pyexpr.str_strip_prefix(prefix))
 
     def strip_suffix(self, suffix: str) -> Expr:
-        r"""
+        """
         Remove suffix.
 
         Parameters

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -579,6 +579,82 @@ class ExprStringNameSpace:
         """
         return wrap_expr(self._pyexpr.str_strip(characters))
 
+    def strip_prefix(self, prefix: str) -> Expr:
+        r"""
+        Remove prefix.
+
+        Parameters
+        ----------
+        prefix
+            The prefix to be removed. The prefix will be removed exactly once from the
+            string if found.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"baz": ["foo:bar", "foofoo:bar"]})
+        >>> df
+        shape: (2, 1)
+        ┌─────────────┐
+        │ baz         │
+        │ ---         │
+        │ str         │
+        ╞═════════════╡
+        │ foo:bar     │
+        │ foofoo:bar  │
+        └─────────────┘
+
+        >>> df.select(pl.col("baz").str.strip_prefix())
+        shape: (2, 1)
+        ┌─────────┐
+        │ baz     │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ :bar    │
+        │ foo:bar │
+        └─────────┘
+
+        """
+        return wrap_expr(self._pyexpr.str_strip_prefix(prefix))
+
+    def strip_suffix(self, suffix: str) -> Expr:
+        r"""
+        Remove suffix.
+
+        Parameters
+        ----------
+        suffix
+            The suffix to be removed. The suffix will be removed exactly once from the
+            string if found.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"baz": ["foo:bar", "foo:barbar"]})
+        >>> df
+        shape: (2, 1)
+        ┌─────────────┐
+        │ baz         │
+        │ ---         │
+        │ str         │
+        ╞═════════════╡
+        │ foo:bar     │
+        │ foo:barbar  │
+        └─────────────┘
+
+        >>> df.select(pl.col("baz").str.strip_suffix())
+        shape: (2, 1)
+        ┌─────────┐
+        │ baz     │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ foo:    │
+        │ foo:bar │
+        └─────────┘
+
+        """
+        return wrap_expr(self._pyexpr.str_strip_suffix(suffix))
+
     def lstrip(self, characters: str | None = None) -> Expr:
         r"""
         Remove leading characters.

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1123,6 +1123,52 @@ class StringNameSpace:
 
         """
 
+    def strip_prefix(self, prefix: str) -> Series:
+        r"""
+        Remove prefix.
+
+        Parameters
+        ----------
+        prefix
+            The prefix to be removed. The prefix will be removed exactly once from the
+            string if found.
+
+        Examples
+        --------
+        >>> s = pl.Series(["foo:bar", "foofoo:bar"])
+        >>> s.str.strip_prefix("foo")
+        shape: (2,)
+        Series: '' [str]
+        [
+                ":bar"
+                "foo:bar"
+        ]
+
+        """
+
+    def strip_suffix(self, suffix: str) -> Series:
+        r"""
+        Remove postfix.
+
+        Parameters
+        ----------
+        suffix
+            The suffix to be removed. The suffix will be removed exactly once from the
+            string if found.
+
+        Examples
+        --------
+        >>> s = pl.Series(["foo:bar", "foo:barbar"])
+        >>> s.str.strip_suffix("foo")
+        shape: (2,)
+        Series: '' [str]
+        [
+                "foo:"
+                "foo:bar"
+        ]
+
+        """
+
     def lstrip(self, characters: str | None = None) -> Series:
         r"""
         Remove leading characters.

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1159,7 +1159,7 @@ class StringNameSpace:
         Examples
         --------
         >>> s = pl.Series(["foo:bar", "foo:barbar"])
-        >>> s.str.strip_suffix("foo")
+        >>> s.str.strip_suffix("bar")
         shape: (2,)
         Series: '' [str]
         [

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1124,47 +1124,53 @@ class StringNameSpace:
         """
 
     def strip_prefix(self, prefix: str) -> Series:
-        r"""
+        """
         Remove prefix.
+
+        The prefix will be removed from the string exactly once, if found.
 
         Parameters
         ----------
         prefix
-            The prefix to be removed. The prefix will be removed exactly once from the
-            string if found.
+            The prefix to be removed.
 
         Examples
         --------
-        >>> s = pl.Series(["foo:bar", "foofoo:bar"])
+        >>> s = pl.Series(["foobar", "foofoobar", "foo", "bar"])
         >>> s.str.strip_prefix("foo")
-        shape: (2,)
+        shape: (4,)
         Series: '' [str]
         [
-                ":bar"
-                "foo:bar"
+                "bar"
+                "foobar"
+                ""
+                "bar"
         ]
 
         """
 
     def strip_suffix(self, suffix: str) -> Series:
-        r"""
-        Remove postfix.
+        """
+        Remove suffix.
+
+        The suffix will be removed from the string exactly once, if found.
 
         Parameters
         ----------
         suffix
-            The suffix to be removed. The suffix will be removed exactly once from the
-            string if found.
+            The suffix to be removed.
 
         Examples
         --------
-        >>> s = pl.Series(["foo:bar", "foo:barbar"])
+        >>> s = pl.Series(["foobar", "foobarbar", "foo", "bar"])
         >>> s.str.strip_suffix("bar")
-        shape: (2,)
+        shape: (4,)
         Series: '' [str]
         [
-                "foo:"
-                "foo:bar"
+                "foo"
+                "foobar"
+                "foo"
+                ""
         ]
 
         """

--- a/py-polars/src/expr/string.rs
+++ b/py-polars/src/expr/string.rs
@@ -67,6 +67,14 @@ impl PyExpr {
         self.inner.clone().str().strip(matches).into()
     }
 
+    fn str_strip_prefix(&self, prefix: String) -> Self {
+        self.inner.clone().str().strip_prefix(prefix).into()
+    }
+
+    fn str_strip_suffix(&self, suffix: String) -> Self {
+        self.inner.clone().str().strip_suffix(suffix).into()
+    }
+
     fn str_rstrip(&self, matches: Option<String>) -> Self {
         self.inner.clone().str().rstrip(matches).into()
     }

--- a/py-polars/tests/unit/namespaces/test_string.py
+++ b/py-polars/tests/unit/namespaces/test_string.py
@@ -197,14 +197,14 @@ def test_str_strip() -> None:
 
 
 def test_str_strip_prefix() -> None:
-    s = pl.Series(["foo:bar", "foofoo:bar"])
-    expected = pl.Series([":bar", "foo:bar"])
+    s = pl.Series(["foo:bar", "foofoo:bar", "bar:bar", "foo", ""])
+    expected = pl.Series([":bar", "foo:bar", "bar:bar", "", ""])
     assert_series_equal(s.str.strip_prefix("foo"), expected)
 
 
 def test_str_strip_suffix() -> None:
-    s = pl.Series(["foo:bar", "foo:barbar"])
-    expected = pl.Series(["foo:", "foo:bar"])
+    s = pl.Series(["foo:bar", "foo:barbar", "foo:foo", "bar", ""])
+    expected = pl.Series(["foo:", "foo:bar", "foo:foo", "", ""])
     assert_series_equal(s.str.strip_suffix("bar"), expected)
 
 

--- a/py-polars/tests/unit/namespaces/test_string.py
+++ b/py-polars/tests/unit/namespaces/test_string.py
@@ -196,6 +196,18 @@ def test_str_strip() -> None:
     assert_series_equal(s.str.strip(" hwo"), expected)
 
 
+def test_str_strip_prefix() -> None:
+    s = pl.Series(["foo:bar", "foofoo:bar"])
+    expected = pl.Series([":bar", "foo:bar"])
+    assert_series_equal(s.str.strip_prefix("foo"), expected)
+
+
+def test_str_strip_suffix() -> None:
+    s = pl.Series(["foo:bar", "foo:barbar"])
+    expected = pl.Series(["foo:", "foo:bar"])
+    assert_series_equal(s.str.strip_suffix("bar"), expected)
+
+
 def test_str_lstrip() -> None:
     s = pl.Series([" hello ", "\t world"])
     expected = pl.Series(["hello ", "world"])


### PR DESCRIPTION
Partially addresses #10603

This PR adds the two functions `strip_prefix` and `strip_suffix` to both Rust and Python.