### PR TITLE
perf(python): optimize `_unpack_schema()`

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -669,11 +669,17 @@ def _unpack_schema(
     ]
     if not column_names and n_expected:
         column_names = [f"column_{i}" for i in range(n_expected)]
-    lookup = {
-        col: name for col, name in zip_longest(column_names, lookup_names or []) if name
-    }
+    lookup = (
+        {
+            col: name
+            for col, name in zip_longest(column_names, lookup_names or [])
+            if name
+        }
+        if lookup_names
+        else None
+    )
     column_dtypes = {
-        lookup.get(col[0], col[0]): col[1]
+        lookup.get(col[0], col[0]) if lookup else col[0]: col[1]
         for col in (schema or [])
         if not isinstance(col, str) and col[1] is not None
     }


### PR DESCRIPTION
`_unpack_schema()` is called without the `lookup_names` argument in all but one cases. This PR provides a fast path that results in ~10% to 15% speedup.