### PR TITLE
feat(python): Add `from_dataframe` fast path and improve typing

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1274,7 +1274,7 @@ class DataFrame:
         self, nan_as_null: bool = False, allow_copy: bool = True
     ) -> PolarsDataFrame:
         """
-        Convert to a DataFrame object implementing the DataFrame interchange protocol.
+        Convert to a dataframe object implementing the dataframe interchange protocol.
 
         Parameters
         ----------

--- a/py-polars/polars/interchange/from_dataframe.py
+++ b/py-polars/polars/interchange/from_dataframe.py
@@ -6,13 +6,15 @@ import polars._reexport as pl
 from polars.convert import from_arrow
 from polars.dependencies import _PYARROW_AVAILABLE
 from polars.dependencies import pyarrow as pa
+from polars.interchange.dataframe import PolarsDataFrame
 from polars.utils.various import parse_version
 
 if TYPE_CHECKING:
     from polars import DataFrame
+    from polars.interchange.protocol import SupportsInterchange
 
 
-def from_dataframe(df: Any, *, allow_copy: bool = True) -> DataFrame:
+def from_dataframe(df: SupportsInterchange, *, allow_copy: bool = True) -> DataFrame:
     """
     Build a Polars DataFrame from any dataframe supporting the interchange protocol.
 
@@ -61,6 +63,9 @@ def from_dataframe(df: Any, *, allow_copy: bool = True) -> DataFrame:
     """
     if isinstance(df, pl.DataFrame):
         return df
+    elif isinstance(df, PolarsDataFrame):
+        return df._df
+
     if not hasattr(df, "__dataframe__"):
         raise TypeError(
             f"`df` of type {type(df).__name__!r} does not support the dataframe interchange protocol"

--- a/py-polars/polars/interchange/protocol.py
+++ b/py-polars/polars/interchange/protocol.py
@@ -195,7 +195,7 @@ class DataFrame(Protocol):
     def __dataframe__(
         self, nan_as_null: bool = False, allow_copy: bool = True
     ) -> DataFrame:
-        """Construct a new dataframe object, potentially changing the parameters."""
+        """Convert to a dataframe object implementing the dataframe interchange protocol."""  # noqa: W505
 
     @property
     def metadata(self) -> dict[str, Any]:
@@ -230,6 +230,15 @@ class DataFrame(Protocol):
 
     def get_chunks(self, n_chunks: int | None = None) -> Iterable[DataFrame]:
         """Return an iterator yielding the chunks of the dataframe."""
+
+
+class SupportsInterchange(Protocol):
+    """Dataframe that supports conversion into an interchange dataframe object."""
+
+    def __dataframe__(
+        self, nan_as_null: bool = False, allow_copy: bool = True
+    ) -> SupportsInterchange:
+        """Convert to a dataframe object implementing the dataframe interchange protocol."""  # noqa: W505
 
 
 class Endianness:

--- a/py-polars/tests/unit/interchange/test_from_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_from_dataframe.py
@@ -12,8 +12,17 @@ from polars.testing import assert_frame_equal
 
 def test_from_dataframe_polars() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0], "c": ["foo", "bar"]})
+    result = pl.from_dataframe(df, allow_copy=False)
+    assert_frame_equal(result, df)
+
+
+def test_from_dataframe_polars_interchange_fast_path() -> None:
+    df = pl.DataFrame(
+        {"a": [1, 2], "b": [3.0, 4.0], "c": ["foo", "bar"]},
+        schema_overrides={"c": pl.Categorical},
+    )
     dfi = df.__dataframe__()
-    result = pl.from_dataframe(dfi)
+    result = pl.from_dataframe(dfi, allow_copy=False)
     assert_frame_equal(result, df)
 
 
@@ -74,7 +83,7 @@ def test_from_dataframe_allow_copy() -> None:
 def test_from_dataframe_invalid_type() -> None:
     df = [[1, 2], [3, 4]]
     with pytest.raises(TypeError):
-        pl.from_dataframe(df)
+        pl.from_dataframe(df)  # type: ignore[arg-type]
 
 
 def test_from_dataframe_pyarrow_required(monkeypatch: Any) -> None:
@@ -82,7 +91,7 @@ def test_from_dataframe_pyarrow_required(monkeypatch: Any) -> None:
 
     df = pl.DataFrame({"a": [1, 2]})
     with pytest.raises(ImportError, match="pyarrow"):
-        pl.from_dataframe(df.__dataframe__())
+        pl.from_dataframe(df.to_pandas())
 
     # 'Converting' from a Polars dataframe does not hit this requirement
     result = pl.from_dataframe(df)
@@ -90,7 +99,7 @@ def test_from_dataframe_pyarrow_required(monkeypatch: Any) -> None:
 
 
 def test_from_dataframe_pyarrow_min_version(monkeypatch: Any) -> None:
-    dfi = pl.DataFrame({"a": [1, 2]}).__dataframe__()
+    dfi = pl.DataFrame({"a": [1, 2]}).to_arrow().__dataframe__()
 
     monkeypatch.setattr(
         pl.convert.pa,  # type: ignore[attr-defined]
@@ -106,9 +115,9 @@ def test_from_dataframe_pyarrow_min_version(monkeypatch: Any) -> None:
 def test_from_dataframe_data_type_not_implemented_by_arrow(
     dtype: pl.PolarsDataType,
 ) -> None:
-    df = pl.Series(dtype=dtype).to_frame()
+    df = pl.Series([0], dtype=dtype).to_frame().to_arrow()
     dfi = df.__dataframe__()
-    with pytest.raises(NotImplementedError, match="not supported"):
+    with pytest.raises(ValueError, match="not supported"):
         pl.from_dataframe(dfi)
 
 

--- a/py-polars/tests/unit/interchange/test_roundtrip.py
+++ b/py-polars/tests/unit/interchange/test_roundtrip.py
@@ -29,27 +29,6 @@ protocol_dtypes = [
 
 
 @given(dataframes(allowed_dtypes=protocol_dtypes, excluded_dtypes=[pl.Boolean]))
-def test_roundtrip_polars_parametric(df: pl.DataFrame) -> None:
-    dfi = df.__dataframe__()
-    with pl.StringCache():
-        result = pl.from_dataframe(dfi)
-    assert_frame_equal(result, df, categorical_as_str=True)
-
-
-@given(
-    dataframes(
-        allowed_dtypes=protocol_dtypes,
-        excluded_dtypes=[pl.Boolean, pl.Categorical],
-        chunked=False,
-    )
-)
-def test_roundtrip_polars_zero_copy_parametric(df: pl.DataFrame) -> None:
-    dfi = df.__dataframe__(allow_copy=False)
-    result = pl.from_dataframe(dfi, allow_copy=False)
-    assert_frame_equal(result, df, categorical_as_str=True)
-
-
-@given(dataframes(allowed_dtypes=protocol_dtypes, excluded_dtypes=[pl.Boolean]))
 def test_roundtrip_pyarrow_parametric(df: pl.DataFrame) -> None:
     dfi = df.__dataframe__()
     note(f"n_chunks: {dfi.num_chunks()}")


### PR DESCRIPTION
#### Changes

* Add fast path for when the interchange object is created by Polars. We can then simply take the underlying Polars DataFrame.
* Use a `Protocol` type for the input of `from_dataframe`.