### PR TITLE
fix(python): write_excel "hidden_columns" parameter fails when taking a selector

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -148,6 +148,7 @@ if TYPE_CHECKING:
         RowTotalsDefinition,
         SchemaDefinition,
         SchemaDict,
+        SelectorType,
         SizeUnit,
         StartBy,
         UniqueKeepStrategy,
@@ -2649,7 +2650,7 @@ class DataFrame:
         has_header: bool = True,
         autofilter: bool = True,
         autofit: bool = False,
-        hidden_columns: Sequence[str] | None = None,
+        hidden_columns: Sequence[str] | SelectorType | None = None,
         hide_gridlines: bool = False,
         sheet_zoom: int | None = None,
         freeze_panes: (
@@ -3069,9 +3070,10 @@ class DataFrame:
                     has_header=has_header,
                     format_cache=fmt_cache,
                 )
-
         # additional column-level properties
-        hidden_columns = _expand_selectors(df, hidden_columns or ())
+        if hidden_columns is None:
+            hidden_columns = ()
+        hidden_columns = _expand_selectors(df, hidden_columns)
         if isinstance(column_widths, int):
             column_widths = {column: column_widths for column in df.columns}
         else:

--- a/py-polars/tests/unit/io/test_excel.py
+++ b/py-polars/tests/unit/io/test_excel.py
@@ -14,6 +14,8 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from polars.type_aliases import SelectorType
+
 
 @pytest.fixture()
 def excel_file_path(io_files_path: Path) -> Path:
@@ -389,3 +391,12 @@ def test_excel_empty_sheet(empty_excel_file_path: Path) -> None:
 
     df = pl.read_excel(empty_excel_file_path, raise_if_empty=False)
     assert_frame_equal(df, pl.DataFrame())
+
+
+@pytest.mark.parametrize("hidden_columns", [["a"], ["a", "b"], cs.numeric(), cs.last()])
+def test_excel_hidden_columns(hidden_columns: list[str] | SelectorType) -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": ["x", "y"]})
+    xls = BytesIO()
+    df.write_excel(xls, hidden_columns=hidden_columns)
+    read_df = pl.read_excel(xls)
+    assert_frame_equal(df, read_df)


### PR DESCRIPTION
This fixes #10984.