### PR TITLE
chore(python): Use `os.PathLike` instead of `Path`.

### DIFF
--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -177,7 +177,7 @@ class Config(contextlib.ContextDecorator):
         self._original_state = ""
 
     @classmethod
-    def load(cls, cfg: Path | str) -> type[Config]:
+    def load(cls, cfg: os.PathLike | str) -> type[Config]:
         """
         Load and set previously saved (or shared) Config options from json/file.
 
@@ -189,7 +189,7 @@ class Config(contextlib.ContextDecorator):
         """
         options = json.loads(
             Path(normalise_filepath(cfg)).read_text()
-            if isinstance(cfg, Path) or Path(cfg).exists()
+            if isinstance(cfg, os.PathLike) or Path(cfg).exists()
             else cfg
         )
         os.environ.update(options.get("environment", {}))
@@ -222,7 +222,7 @@ class Config(contextlib.ContextDecorator):
         return cls
 
     @classmethod
-    def save(cls, file: Path | str | None = None) -> str:
+    def save(cls, file: os.PathLike | str | None = None) -> str:
         """
         Save the current set of Config options as a json string or file.
 
@@ -255,7 +255,7 @@ class Config(contextlib.ContextDecorator):
             {"environment": environment_vars, "direct": direct_vars},
             separators=(",", ":"),
         )
-        if isinstance(file, (str, Path)):
+        if isinstance(file, (str, os.PathLike)):
             file = Path(normalise_filepath(file)).resolve()
             file.write_text(options)
             return str(file)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from collections.abc import Sized
 from io import BytesIO, StringIO, TextIOWrapper
 from operator import itemgetter
-from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -649,7 +648,7 @@ class DataFrame:
     @classmethod
     def _read_csv(
         cls,
-        source: str | Path | BinaryIO | bytes,
+        source: str | os.PathLike | BinaryIO | bytes,
         *,
         has_header: bool = True,
         columns: Sequence[int] | Sequence[str] | None = None,
@@ -691,7 +690,7 @@ class DataFrame:
         self = cls.__new__(cls)
 
         path: str | None
-        if isinstance(source, (str, Path)):
+        if isinstance(source, (str, os.PathLike)):
             path = normalise_filepath(source)
         else:
             path = None
@@ -800,7 +799,7 @@ class DataFrame:
     @classmethod
     def _read_parquet(
         cls,
-        source: str | Path | BinaryIO | bytes,
+        source: str | os.PathLike | BinaryIO | bytes,
         *,
         columns: Sequence[int] | Sequence[str] | None = None,
         n_rows: int | None = None,
@@ -821,7 +820,7 @@ class DataFrame:
         polars.io.read_parquet
 
         """
-        if isinstance(source, (str, Path)):
+        if isinstance(source, (str, os.PathLike)):
             source = normalise_filepath(source)
         if isinstance(columns, str):
             columns = [columns]
@@ -871,7 +870,7 @@ class DataFrame:
     @classmethod
     def _read_avro(
         cls,
-        source: str | Path | BinaryIO | bytes,
+        source: str | os.PathLike | BinaryIO | bytes,
         *,
         columns: Sequence[int] | Sequence[str] | None = None,
         n_rows: int | None = None,
@@ -891,7 +890,7 @@ class DataFrame:
             Stop reading from Apache Avro file after reading ``n_rows``.
 
         """
-        if isinstance(source, (str, Path)):
+        if isinstance(source, (str, os.PathLike)):
             source = normalise_filepath(source)
         projection, columns = handle_projection_columns(columns)
         self = cls.__new__(cls)
@@ -901,7 +900,7 @@ class DataFrame:
     @classmethod
     def _read_ipc(
         cls,
-        source: str | Path | BinaryIO | bytes,
+        source: str | os.PathLike | BinaryIO | bytes,
         *,
         columns: Sequence[int] | Sequence[str] | None = None,
         n_rows: int | None = None,
@@ -937,7 +936,7 @@ class DataFrame:
             Memory map the file
 
         """
-        if isinstance(source, (str, Path)):
+        if isinstance(source, (str, os.PathLike)):
             source = normalise_filepath(source)
         if isinstance(columns, str):
             columns = [columns]
@@ -983,7 +982,7 @@ class DataFrame:
     @classmethod
     def _read_ipc_stream(
         cls,
-        source: str | Path | BinaryIO | bytes,
+        source: str | os.PathLike | BinaryIO | bytes,
         *,
         columns: Sequence[int] | Sequence[str] | None = None,
         n_rows: int | None = None,
@@ -1015,7 +1014,7 @@ class DataFrame:
             Make sure that all data is contiguous.
 
         """
-        if isinstance(source, (str, Path)):
+        if isinstance(source, (str, os.PathLike)):
             source = normalise_filepath(source)
         if isinstance(columns, str):
             columns = [columns]
@@ -1035,7 +1034,7 @@ class DataFrame:
     @classmethod
     def _read_json(
         cls,
-        source: str | Path | IOBase | bytes,
+        source: str | os.PathLike | IOBase | bytes,
         *,
         schema: SchemaDefinition | None = None,
         schema_overrides: SchemaDefinition | None = None,
@@ -1052,7 +1051,7 @@ class DataFrame:
         """
         if isinstance(source, StringIO):
             source = BytesIO(source.getvalue().encode())
-        elif isinstance(source, (str, Path)):
+        elif isinstance(source, (str, os.PathLike)):
             source = normalise_filepath(source)
 
         self = cls.__new__(cls)
@@ -1064,7 +1063,7 @@ class DataFrame:
     @classmethod
     def _read_ndjson(
         cls,
-        source: str | Path | IOBase | bytes,
+        source: str | os.PathLike | IOBase | bytes,
         *,
         schema: SchemaDefinition | None = None,
         schema_overrides: SchemaDefinition | None = None,
@@ -1082,7 +1081,7 @@ class DataFrame:
         """
         if isinstance(source, StringIO):
             source = BytesIO(source.getvalue().encode())
-        elif isinstance(source, (str, Path)):
+        elif isinstance(source, (str, os.PathLike)):
             source = normalise_filepath(source)
 
         self = cls.__new__(cls)
@@ -2325,7 +2324,7 @@ class DataFrame:
     @overload
     def write_json(
         self,
-        file: IOBase | str | Path,
+        file: IOBase | str | os.PathLike,
         *,
         pretty: bool = ...,
         row_oriented: bool = ...,
@@ -2334,7 +2333,7 @@ class DataFrame:
 
     def write_json(
         self,
-        file: IOBase | str | Path | None = None,
+        file: IOBase | str | os.PathLike | None = None,
         *,
         pretty: bool = False,
         row_oriented: bool = False,
@@ -2370,7 +2369,7 @@ class DataFrame:
         '[{"foo":1,"bar":6},{"foo":2,"bar":7},{"foo":3,"bar":8}]'
 
         """
-        if isinstance(file, (str, Path)):
+        if isinstance(file, (str, os.PathLike)):
             file = normalise_filepath(file)
         to_string_io = (file is not None) and isinstance(file, StringIO)
         if file is None or to_string_io:
@@ -2392,10 +2391,10 @@ class DataFrame:
         ...
 
     @overload
-    def write_ndjson(self, file: IOBase | str | Path) -> None:
+    def write_ndjson(self, file: IOBase | str | os.PathLike) -> None:
         ...
 
-    def write_ndjson(self, file: IOBase | str | Path | None = None) -> str | None:
+    def write_ndjson(self, file: IOBase | str | os.PathLike | None = None) -> str | None:
         r"""
         Serialize to newline delimited JSON representation.
 
@@ -2417,7 +2416,7 @@ class DataFrame:
         '{"foo":1,"bar":6}\n{"foo":2,"bar":7}\n{"foo":3,"bar":8}\n'
 
         """
-        if isinstance(file, (str, Path)):
+        if isinstance(file, (str, os.PathLike)):
             file = normalise_filepath(file)
         to_string_io = (file is not None) and isinstance(file, StringIO)
         if file is None or to_string_io:
@@ -2456,7 +2455,7 @@ class DataFrame:
     @overload
     def write_csv(
         self,
-        file: BytesIO | TextIOWrapper | str | Path,
+        file: BytesIO | TextIOWrapper | str | os.PathLike,
         *,
         has_header: bool = ...,
         separator: str = ...,
@@ -2474,7 +2473,7 @@ class DataFrame:
 
     def write_csv(
         self,
-        file: BytesIO | TextIOWrapper | str | Path | None = None,
+        file: BytesIO | TextIOWrapper | str | os.PathLike | None = None,
         *,
         has_header: bool = True,
         separator: str = ",",
@@ -2593,7 +2592,7 @@ class DataFrame:
 
     def write_avro(
         self,
-        file: BinaryIO | BytesIO | str | Path,
+        file: BinaryIO | BytesIO | str | os.PathLike,
         compression: AvroCompression = "uncompressed",
     ) -> None:
         """
@@ -2623,14 +2622,14 @@ class DataFrame:
         """
         if compression is None:
             compression = "uncompressed"
-        if isinstance(file, (str, Path)):
+        if isinstance(file, (str, os.PathLike)):
             file = normalise_filepath(file)
 
         self._df.write_avro(file, compression)
 
     def write_excel(
         self,
-        workbook: Workbook | BytesIO | Path | str | None = None,
+        workbook: Workbook | BytesIO | os.PathLike | str | None = None,
         worksheet: str | None = None,
         *,
         position: tuple[int, int] | str = "A1",
@@ -3140,14 +3139,14 @@ class DataFrame:
     @overload
     def write_ipc(
         self,
-        file: BinaryIO | BytesIO | str | Path,
+        file: BinaryIO | BytesIO | str | os.PathLike,
         compression: IpcCompression = "uncompressed",
     ) -> None:
         ...
 
     def write_ipc(
         self,
-        file: BinaryIO | BytesIO | str | Path | None,
+        file: BinaryIO | BytesIO | str | os.PathLike | None,
         compression: IpcCompression = "uncompressed",
     ) -> BytesIO | None:
         """
@@ -3181,7 +3180,7 @@ class DataFrame:
         return_bytes = file is None
         if return_bytes:
             file = BytesIO()
-        elif isinstance(file, (str, Path)):
+        elif isinstance(file, (str, os.PathLike)):
             file = normalise_filepath(file)
 
         if compression is None:
@@ -3201,14 +3200,14 @@ class DataFrame:
     @overload
     def write_ipc_stream(
         self,
-        file: BinaryIO | BytesIO | str | Path,
+        file: BinaryIO | BytesIO | str | os.PathLike,
         compression: IpcCompression = "uncompressed",
     ) -> None:
         ...
 
     def write_ipc_stream(
         self,
-        file: BinaryIO | BytesIO | str | Path | None,
+        file: BinaryIO | BytesIO | str | os.PathLike | None,
         compression: IpcCompression = "uncompressed",
     ) -> BytesIO | None:
         """
@@ -3242,7 +3241,7 @@ class DataFrame:
         return_bytes = file is None
         if return_bytes:
             file = BytesIO()
-        elif isinstance(file, (str, Path)):
+        elif isinstance(file, (str, os.PathLike)):
             file = normalise_filepath(file)
 
         if compression is None:
@@ -3253,7 +3252,7 @@ class DataFrame:
 
     def write_parquet(
         self,
-        file: str | Path | BytesIO,
+        file: str | os.PathLike | BytesIO,
         *,
         compression: ParquetCompression = "zstd",
         compression_level: int | None = None,
@@ -3327,7 +3326,7 @@ class DataFrame:
         """
         if compression is None:
             compression = "uncompressed"
-        if isinstance(file, (str, Path)):
+        if isinstance(file, (str, os.PathLike)):
             if pyarrow_options is not None and pyarrow_options.get("partition_cols"):
                 file = normalise_filepath(file, check_not_directory=False)
             else:
@@ -3469,7 +3468,7 @@ class DataFrame:
 
     def write_delta(
         self,
-        target: str | Path | deltalake.DeltaTable,
+        target: str | os.PathLike | deltalake.DeltaTable,
         *,
         mode: Literal["error", "append", "overwrite", "ignore"] = "error",
         overwrite_schema: bool = False,
@@ -3597,7 +3596,7 @@ class DataFrame:
         if delta_write_options is None:
             delta_write_options = {}
 
-        if isinstance(target, (str, Path)):
+        if isinstance(target, (str, os.PathLike)):
             target = _resolve_delta_lake_uri(str(target), strict=False)
 
         _check_for_unsupported_types(self.dtypes)

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+import os
 from io import BytesIO, StringIO
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal, overload
 
 from polars.utils._wrap import wrap_expr
@@ -197,12 +197,12 @@ class ExprMetaNameSpace:
         ...
 
     @overload
-    def write_json(self, file: IOBase | str | Path) -> None:
+    def write_json(self, file: IOBase | str | os.PathLike) -> None:
         ...
 
-    def write_json(self, file: IOBase | str | Path | None = None) -> str | None:
+    def write_json(self, file: IOBase | str | os.PathLike | None = None) -> str | None:
         """Write expression to json."""
-        if isinstance(file, (str, Path)):
+        if isinstance(file, (str, os.PathLike)):
             file = normalise_filepath(file)
         to_string_io = (file is not None) and isinstance(file, StringIO)
         if file is None or to_string_io:

--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import glob
+import os
 from contextlib import contextmanager
 from io import BytesIO, StringIO
 from pathlib import Path
@@ -26,27 +27,27 @@ def _is_local_file(file: str) -> bool:
 
 @overload
 def _prepare_file_arg(
-    file: str | list[str] | Path | BinaryIO | bytes, **kwargs: Any
+    file: str | list[str] | os.PathLike | BinaryIO | bytes, **kwargs: Any
 ) -> ContextManager[str | BinaryIO]:
     ...
 
 
 @overload
 def _prepare_file_arg(
-    file: str | TextIO | Path | BinaryIO | bytes, **kwargs: Any
+    file: str | TextIO | os.PathLike | BinaryIO | bytes, **kwargs: Any
 ) -> ContextManager[str | BinaryIO]:
     ...
 
 
 @overload
 def _prepare_file_arg(
-    file: str | list[str] | TextIO | Path | BinaryIO | bytes, **kwargs: Any
+    file: str | list[str] | TextIO | os.PathLike | BinaryIO | bytes, **kwargs: Any
 ) -> ContextManager[str | list[str] | BinaryIO | list[BinaryIO]]:
     ...
 
 
 def _prepare_file_arg(
-    file: str | list[str] | TextIO | Path | BinaryIO | bytes,
+    file: str | list[str] | TextIO | os.PathLike | BinaryIO | bytes,
     encoding: str | None = None,
     use_pyarrow: bool | None = None,
     raise_if_empty: bool = True,
@@ -129,7 +130,7 @@ def _prepare_file_arg(
             )
         )
 
-    if isinstance(file, Path):
+    if isinstance(file, os.PathLike):
         if not has_utf8_utf8_lossy_encoding:
             return _check_empty(
                 BytesIO(file.read_bytes().decode(encoding_str).encode("utf8")),

--- a/py-polars/polars/io/avro.py
+++ b/py-polars/polars/io/avro.py
@@ -5,14 +5,14 @@ from typing import TYPE_CHECKING, BinaryIO
 import polars._reexport as pl
 
 if TYPE_CHECKING:
+    import os
     from io import BytesIO
-    from pathlib import Path
 
     from polars import DataFrame
 
 
 def read_avro(
-    source: str | Path | BytesIO | BinaryIO,
+    source: str | os.PathLike | BytesIO | BinaryIO,
     *,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,

--- a/py-polars/polars/io/csv/batched_reader.py
+++ b/py-polars/polars/io/csv/batched_reader.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from pathlib import Path
+import os
 from typing import TYPE_CHECKING, Sequence
 
 from polars.datatypes import N_INFER_DEFAULT, py_type_to_dtype
@@ -18,6 +18,7 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import PyBatchedCsv
 
 if TYPE_CHECKING:
+
     from polars import DataFrame
     from polars.type_aliases import CsvEncoding, PolarsDataType, SchemaDict
 
@@ -27,7 +28,7 @@ class BatchedCsvReader:
 
     def __init__(
         self,
-        source: str | Path,
+        source: str | os.PathLike,
         has_header: bool = True,
         columns: Sequence[int] | Sequence[str] | None = None,
         separator: str = ",",
@@ -56,7 +57,7 @@ class BatchedCsvReader:
         truncate_ragged_lines: bool = False,
     ):
         path: str | None
-        if isinstance(source, (str, Path)):
+        if isinstance(source, (str, os.PathLike)):
             path = normalise_filepath(source)
 
         dtype_list: Sequence[tuple[str, PolarsDataType]] | None = None

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
+import os
 from typing import TYPE_CHECKING, Any, BinaryIO, Callable, Mapping, Sequence, TextIO
 
 import polars._reexport as pl
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 def read_csv(
-    source: str | TextIO | BytesIO | Path | BinaryIO | bytes,
+    source: str | TextIO | BytesIO | os.PathLike | BinaryIO | bytes,
     *,
     has_header: bool = True,
     columns: Sequence[int] | Sequence[str] | None = None,
@@ -397,7 +397,7 @@ def read_csv(
 
 
 def read_csv_batched(
-    source: str | Path,
+    source: str | os.PathLike,
     *,
     has_header: bool = True,
     columns: Sequence[int] | Sequence[str] | None = None,
@@ -689,7 +689,7 @@ def read_csv_batched(
 
 
 def scan_csv(
-    source: str | Path,
+    source: str | os.PathLike,
     *,
     has_header: bool = True,
     separator: str = ",",
@@ -892,7 +892,7 @@ def scan_csv(
     _check_arg_is_1byte("comment_char", comment_char, False)
     _check_arg_is_1byte("quote_char", quote_char, True)
 
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         source = normalise_filepath(source)
 
     return pl.LazyFrame._scan_csv(

--- a/py-polars/polars/io/excel/_write_utils.py
+++ b/py-polars/polars/io/excel/_write_utils.py
@@ -22,6 +22,7 @@ from polars.exceptions import DuplicateError
 from polars.selectors import _expand_selector_dicts, _expand_selectors
 
 if TYPE_CHECKING:
+    import os
     from typing import Literal
 
     from xlsxwriter import Workbook
@@ -504,7 +505,7 @@ def _xl_setup_table_options(
 
 
 def _xl_setup_workbook(
-    workbook: Workbook | BytesIO | Path | str | None, worksheet: str | None = None
+    workbook: Workbook | BytesIO | os.PathLike | str | None, worksheet: str | None = None
 ) -> tuple[Workbook, Worksheet, bool]:
     """Establish the target excel workbook and worksheet."""
     from xlsxwriter import Workbook

--- a/py-polars/polars/io/excel/functions.py
+++ b/py-polars/polars/io/excel/functions.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import os
 import re
 from io import StringIO
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, BinaryIO, NoReturn, Sequence, overload
 
 import polars._reexport as pl
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 @overload
 def read_excel(
-    source: str | BytesIO | Path | BinaryIO | bytes,
+    source: str | BytesIO | os.PathLike | BinaryIO | bytes,
     *,
     sheet_id: None = ...,
     sheet_name: str,
@@ -31,7 +31,7 @@ def read_excel(
 
 @overload
 def read_excel(
-    source: str | BytesIO | Path | BinaryIO | bytes,
+    source: str | BytesIO | os.PathLike | BinaryIO | bytes,
     *,
     sheet_id: None = ...,
     sheet_name: None = ...,
@@ -45,7 +45,7 @@ def read_excel(
 
 @overload
 def read_excel(
-    source: str | BytesIO | Path | BinaryIO | bytes,
+    source: str | BytesIO | os.PathLike | BinaryIO | bytes,
     *,
     sheet_id: int,
     sheet_name: str,
@@ -61,7 +61,7 @@ def read_excel(
 # Literal[0] overlaps with the return value for other integers
 @overload  # type: ignore[misc]
 def read_excel(
-    source: str | BytesIO | Path | BinaryIO | bytes,
+    source: str | BytesIO | os.PathLike | BinaryIO | bytes,
     *,
     sheet_id: Literal[0] | Sequence[int],
     sheet_name: None = ...,
@@ -75,7 +75,7 @@ def read_excel(
 
 @overload
 def read_excel(
-    source: str | BytesIO | Path | BinaryIO | bytes,
+    source: str | BytesIO | os.PathLike | BinaryIO | bytes,
     *,
     sheet_id: None,
     sheet_name: list[str] | tuple[str],
@@ -89,7 +89,7 @@ def read_excel(
 
 @overload
 def read_excel(
-    source: str | BytesIO | Path | BinaryIO | bytes,
+    source: str | BytesIO | os.PathLike | BinaryIO | bytes,
     *,
     sheet_id: int,
     sheet_name: None = ...,
@@ -102,7 +102,7 @@ def read_excel(
 
 
 def read_excel(
-    source: str | BytesIO | Path | BinaryIO | bytes,
+    source: str | BytesIO | os.PathLike | BinaryIO | bytes,
     *,
     sheet_id: int | Sequence[int] | None = None,
     sheet_name: str | list[str] | tuple[str] | None = None,
@@ -255,11 +255,11 @@ def read_excel(
 
 def _initialise_excel_parser(
     engine: str | None,
-    source: str | BytesIO | Path | BinaryIO | bytes,
+    source: str | BytesIO | os.PathLike | BinaryIO | bytes,
     xlsx2csv_options: dict[str, Any],
 ) -> tuple[Any, Any, list[dict[str, Any]]]:
     """Instantiate the indicated Excel parser and establish related properties."""
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         source = normalise_filepath(source)
 
     if engine == "openpyxl":

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from pathlib import Path
+import os
 from typing import TYPE_CHECKING, Any, BinaryIO
 
 import polars._reexport as pl
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 def read_ipc(
-    source: str | BinaryIO | BytesIO | Path | bytes,
+    source: str | BinaryIO | BytesIO | os.PathLike | bytes,
     *,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
@@ -112,7 +112,7 @@ def read_ipc(
 
 
 def read_ipc_stream(
-    source: str | BinaryIO | BytesIO | Path | bytes,
+    source: str | BinaryIO | BytesIO | os.PathLike | bytes,
     *,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
@@ -186,7 +186,7 @@ def read_ipc_stream(
         )
 
 
-def read_ipc_schema(source: str | BinaryIO | Path | bytes) -> dict[str, PolarsDataType]:
+def read_ipc_schema(source: str | BinaryIO | os.PathLike | bytes) -> dict[str, PolarsDataType]:
     """
     Get the schema of an IPC file without reading data.
 
@@ -203,14 +203,14 @@ def read_ipc_schema(source: str | BinaryIO | Path | bytes) -> dict[str, PolarsDa
         Dictionary mapping column names to datatypes
 
     """
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         source = normalise_filepath(source)
 
     return _read_ipc_schema(source)
 
 
 def scan_ipc(
-    source: str | Path,
+    source: str | os.PathLike,
     *,
     n_rows: int | None = None,
     cache: bool = True,

--- a/py-polars/polars/io/json.py
+++ b/py-polars/polars/io/json.py
@@ -5,15 +5,15 @@ from typing import TYPE_CHECKING
 import polars._reexport as pl
 
 if TYPE_CHECKING:
+    import os
     from io import IOBase
-    from pathlib import Path
 
     from polars import DataFrame
     from polars.type_aliases import SchemaDefinition
 
 
 def read_json(
-    source: str | Path | IOBase | bytes,
+    source: str | os.PathLike | IOBase | bytes,
     *,
     schema: SchemaDefinition | None = None,
     schema_overrides: SchemaDefinition | None = None,

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
+import os
 from typing import TYPE_CHECKING
 
 import polars._reexport as pl
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 def read_ndjson(
-    source: str | Path | IOBase | bytes,
+    source: str | os.PathLike | IOBase | bytes,
     *,
     schema: SchemaDefinition | None = None,
     schema_overrides: SchemaDefinition | None = None,
@@ -57,7 +57,7 @@ def read_ndjson(
 
 
 def scan_ndjson(
-    source: str | Path,
+    source: str | os.PathLike,
     *,
     infer_schema_length: int | None = N_INFER_DEFAULT,
     batch_size: int | None = 1024,
@@ -94,7 +94,7 @@ def scan_ndjson(
         Offset to start the row_count column (only use if the name is set)
 
     """
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         source = normalise_filepath(source)
 
     return pl.LazyFrame._scan_ndjson(

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from pathlib import Path
+import os
 from typing import TYPE_CHECKING, Any, BinaryIO
 
 import polars._reexport as pl
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 def read_parquet(
-    source: str | Path | BinaryIO | BytesIO | bytes,
+    source: str | os.PathLike | BinaryIO | BytesIO | bytes,
     *,
     columns: list[int] | list[str] | None = None,
     n_rows: int | None = None,
@@ -142,7 +142,7 @@ def read_parquet(
 
 
 def read_parquet_schema(
-    source: str | BinaryIO | Path | bytes,
+    source: str | BinaryIO | os.PathLike | bytes,
 ) -> dict[str, PolarsDataType]:
     """
     Get the schema of a Parquet file without reading data.
@@ -160,14 +160,14 @@ def read_parquet_schema(
         Dictionary mapping column names to datatypes
 
     """
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         source = normalise_filepath(source)
 
     return _read_parquet_schema(source)
 
 
 def scan_parquet(
-    source: str | Path,
+    source: str | os.PathLike,
     *,
     n_rows: int | None = None,
     cache: bool = True,
@@ -226,7 +226,7 @@ def scan_parquet(
     scan_pyarrow_dataset
 
     """
-    if isinstance(source, (str, Path)):
+    if isinstance(source, (str, os.PathLike)):
         source = normalise_filepath(source)
 
     return pl.LazyFrame._scan_parquet(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -433,7 +433,7 @@ class LazyFrame:
     @classmethod
     def _scan_ipc(
         cls,
-        source: str | Path,
+        source: str | os.PathLike,
         *,
         n_rows: int | None = None,
         cache: bool = True,
@@ -453,7 +453,7 @@ class LazyFrame:
         polars.io.scan_ipc
 
         """
-        if isinstance(source, (str, Path)):
+        if isinstance(source, (str, os.PathLike)):
             source = normalise_filepath(source)
 
         # try fsspec scanner
@@ -557,7 +557,7 @@ class LazyFrame:
     @classmethod
     @deprecate_renamed_function("deserialize", version="0.18.12")
     @deprecate_renamed_parameter("file", "source", version="0.18.12")
-    def read_json(cls, source: str | Path | IOBase) -> Self:
+    def read_json(cls, source: str | os.PathLike | IOBase) -> Self:
         """
         Read a logical plan from a JSON file to construct a LazyFrame.
 
@@ -579,7 +579,7 @@ class LazyFrame:
         return cls.deserialize(source)
 
     @classmethod
-    def deserialize(cls, source: str | Path | IOBase) -> Self:
+    def deserialize(cls, source: str | os.PathLike | IOBase) -> Self:
         """
         Read a logical plan from a JSON file to construct a LazyFrame.
 
@@ -612,7 +612,7 @@ class LazyFrame:
         """
         if isinstance(source, StringIO):
             source = BytesIO(source.getvalue().encode())
-        elif isinstance(source, (str, Path)):
+        elif isinstance(source, (str, os.PathLike)):
             source = normalise_filepath(source)
 
         return cls._from_pyldf(PyLazyFrame.deserialize(source))
@@ -802,10 +802,10 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...
 
     @overload
-    def serialize(self, file: IOBase | str | Path) -> None:
+    def serialize(self, file: IOBase | str | os.PathLike) -> None:
         ...
 
-    def serialize(self, file: IOBase | str | Path | None = None) -> str | None:
+    def serialize(self, file: IOBase | str | os.PathLike | None = None) -> str | None:
         """
         Serialize the logical plan of this LazyFrame to a file or string in JSON format.
 
@@ -842,7 +842,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┘
 
         """
-        if isinstance(file, (str, Path)):
+        if isinstance(file, (str, os.PathLike)):
             file = normalise_filepath(file)
         to_string_io = (file is not None) and isinstance(file, StringIO)
         if file is None or to_string_io:
@@ -864,11 +864,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...
 
     @overload
-    def write_json(self, file: IOBase | str | Path) -> None:
+    def write_json(self, file: IOBase | str | os.PathLike) -> None:
         ...
 
     @deprecate_renamed_function("serialize", version="0.18.12")
-    def write_json(self, file: IOBase | str | Path | None = None) -> str | None:
+    def write_json(self, file: IOBase | str | os.PathLike | None = None) -> str | None:
         """
         Serialize the logical plan of this LazyFrame to a file or string in JSON format.
 
@@ -1037,7 +1037,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         *,
         optimized: bool = True,
         show: bool = True,
-        output_path: str | Path | None = None,
+        output_path: str | os.PathLike | None = None,
         raw_output: bool = False,
         figsize: tuple[float, float] = (16.0, 12.0),
         type_coercion: bool = True,
@@ -1814,7 +1814,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def sink_parquet(
         self,
-        path: str | Path,
+        path: str | os.PathLike,
         *,
         compression: str = "zstd",
         compression_level: int | None = None,
@@ -1907,7 +1907,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def sink_ipc(
         self,
-        path: str | Path,
+        path: str | os.PathLike,
         *,
         compression: str | None = "zstd",
         maintain_order: bool = True,
@@ -1973,7 +1973,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def sink_csv(
         self,
-        path: str | Path,
+        path: str | os.PathLike,
         *,
         has_header: bool = True,
         separator: str = ",",

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -180,7 +180,7 @@ def can_create_dicts_with_pyarrow(dtypes: Sequence[PolarsDataType]) -> bool:
     )
 
 
-def normalise_filepath(path: str | Path, check_not_directory: bool = True) -> str:
+def normalise_filepath(path: str | os.PathLike, check_not_directory: bool = True) -> str:
     """Create a string path, expanding the home directory if present."""
     # don't use pathlib here as it modifies slashes (s3:// -> s3:/)
     path = os.path.expanduser(path)  # noqa: PTH111


### PR DESCRIPTION
When using type hints, I think it is better to check for capabilities instead of a specific class.

I'm also a little bit in a bind for this PR, so reject if you consider my arguments not strong enough:
- `os.PathLike` checks only if `__fspath__` is implemented. Nothing else. So no `open` or so
- `Path` is a local implementation, and for example [`S3Path`](https://github.com/liormizr/s3path/blob/master/s3path.py#L907) is based on this one as well. Maybe this would need a bit more review to see that if it's a string, we convert it into a `Path`, but if it's already one, we just keep it as such. Otherwise we'll loose information about what kind of path it is.

WDYT?