### PR TITLE
feat(rust, python): Add `literal` for str count_match

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -647,8 +647,8 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
         match func {
             #[cfg(feature = "regex")]
             Contains { literal, strict } => map_as_slice!(strings::contains, literal, strict),
-            CountMatches => {
-                map_as_slice!(strings::count_matches)
+            CountMatches(literal) => {
+                map_as_slice!(strings::count_matches, literal)
             },
             EndsWith { .. } => map_as_slice!(strings::ends_with),
             StartsWith { .. } => map_as_slice!(strings::starts_with),

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -26,7 +26,7 @@ pub enum StringFunction {
         literal: bool,
         strict: bool,
     },
-    CountMatches,
+    CountMatches(bool),
     EndsWith,
     Explode,
     Extract {
@@ -92,7 +92,7 @@ impl StringFunction {
             ConcatVertical(_) | ConcatHorizontal(_) => mapper.with_same_dtype(),
             #[cfg(feature = "regex")]
             Contains { .. } => mapper.with_dtype(DataType::Boolean),
-            CountMatches => mapper.with_dtype(DataType::UInt32),
+            CountMatches(_) => mapper.with_dtype(DataType::UInt32),
             EndsWith | StartsWith => mapper.with_dtype(DataType::Boolean),
             Explode => mapper.with_same_dtype(),
             Extract { .. } => mapper.with_same_dtype(),
@@ -132,7 +132,7 @@ impl Display for StringFunction {
         let s = match self {
             #[cfg(feature = "regex")]
             StringFunction::Contains { .. } => "contains",
-            StringFunction::CountMatches => "count_matches",
+            StringFunction::CountMatches(_) => "count_matches",
             StringFunction::EndsWith { .. } => "ends_with",
             StringFunction::Extract { .. } => "extract",
             #[cfg(feature = "concat_str")]
@@ -433,7 +433,7 @@ pub(super) fn extract_all(args: &[Series]) -> PolarsResult<Series> {
     }
 }
 
-pub(super) fn count_matches(args: &[Series]) -> PolarsResult<Series> {
+pub(super) fn count_matches(args: &[Series], literal: bool) -> PolarsResult<Series> {
     let s = &args[0];
     let pat = &args[1];
 
@@ -441,12 +441,13 @@ pub(super) fn count_matches(args: &[Series]) -> PolarsResult<Series> {
     let pat = pat.utf8()?;
     if pat.len() == 1 {
         if let Some(pat) = pat.get(0) {
-            ca.count_matches(pat).map(|ca| ca.into_series())
+            ca.count_matches(pat, literal).map(|ca| ca.into_series())
         } else {
             Ok(Series::full_null(ca.name(), ca.len(), &DataType::UInt32))
         }
     } else {
-        ca.count_matches_many(pat).map(|ca| ca.into_series())
+        ca.count_matches_many(pat, literal)
+            .map(|ca| ca.into_series())
     }
 }
 

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -128,9 +128,9 @@ impl StringNameSpace {
     }
 
     /// Count all successive non-overlapping regex matches.
-    pub fn count_matches(self, pat: Expr) -> Expr {
+    pub fn count_matches(self, pat: Expr, literal: bool) -> Expr {
         self.0
-            .map_many_private(StringFunction::CountMatches.into(), &[pat], false)
+            .map_many_private(StringFunction::CountMatches(literal).into(), &[pat], false)
     }
 
     /// Convert a Utf8 column into a Date/Datetime/Time column.

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1419,7 +1419,7 @@ class ExprStringNameSpace:
         """
         return wrap_expr(self._pyexpr.str_extract_groups(pattern))
 
-    def count_matches(self, pattern: str | Expr) -> Expr:
+    def count_matches(self, pattern: str | Expr, *, literal: bool = False) -> Expr:
         r"""
         Count all successive non-overlapping regex matches.
 
@@ -1428,6 +1428,8 @@ class ExprStringNameSpace:
         pattern
             A valid regular expression pattern, compatible with the `regex crate
             <https://docs.rs/regex/latest/regex/>`_.
+        literal
+            Treat ``pattern`` as a literal string, not as a regular expression.
 
         Returns
         -------
@@ -1453,9 +1455,27 @@ class ExprStringNameSpace:
         │ null         │
         └──────────────┘
 
+        >>> df = pl.DataFrame({"bar": ["12 dbc 3xy", "cat\\w", "1zy3\\d\\d", None]})
+        >>> df.select(
+        ...     pl.col("bar")
+        ...     .str.count_matches(r"\d", literal=True)
+        ...     .alias("count_digits"),
+        ... )
+        shape: (4, 1)
+        ┌──────────────┐
+        │ count_digits │
+        │ ---          │
+        │ u32          │
+        ╞══════════════╡
+        │ 0            │
+        │ 0            │
+        │ 2            │
+        │ null         │
+        └──────────────┘
+
         """
         pattern = parse_as_expression(pattern, str_as_lit=True)
-        return wrap_expr(self._pyexpr.str_count_matches(pattern))
+        return wrap_expr(self._pyexpr.str_count_matches(pattern, literal))
 
     def split(self, by: str, *, inclusive: bool = False) -> Expr:
         """

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -826,7 +826,7 @@ class StringNameSpace:
 
         """
 
-    def count_matches(self, pattern: str | Series) -> Series:
+    def count_matches(self, pattern: str | Series, *, literal: bool = False) -> Series:
         r"""
         Count all successive non-overlapping regex matches.
 
@@ -836,6 +836,8 @@ class StringNameSpace:
             A valid regular expression pattern, compatible with the `regex crate
             <https://docs.rs/regex/latest/regex/>`_. Can also be a :class:`Series` of
             regular expressions.
+        literal
+            Treat ``pattern`` as a literal string, not as a regular expression.
 
         Returns
         -------
@@ -854,6 +856,17 @@ class StringNameSpace:
             5
             6
             0
+            null
+        ]
+
+        >>> s = pl.Series("bar", ["12 dbc 3xy", "cat\\w", "1zy3\\d\\d", None])
+        >>> s.str.count_matches(r"\d", literal=True)
+        shape: (4,)
+        Series: 'bar' [u32]
+        [
+            0
+            0
+            2
             null
         ]
 

--- a/py-polars/src/expr/string.rs
+++ b/py-polars/src/expr/string.rs
@@ -267,8 +267,12 @@ impl PyExpr {
             .into())
     }
 
-    fn str_count_matches(&self, pat: Self) -> Self {
-        self.inner.clone().str().count_matches(pat.inner).into()
+    fn str_count_matches(&self, pat: Self, literal: bool) -> Self {
+        self.inner
+            .clone()
+            .str()
+            .count_matches(pat.inner, literal)
+            .into()
     }
 
     fn str_split(&self, by: &str) -> Self {

--- a/py-polars/tests/unit/namespaces/test_string.py
+++ b/py-polars/tests/unit/namespaces/test_string.py
@@ -45,6 +45,17 @@ def test_str_contains() -> None:
     assert_series_equal(s.str.contains("mes"), expected)
 
 
+def test_count_match_literal() -> None:
+    s = pl.Series(["12 dbc 3xy", "cat\\w", "1zy3\\d\\d", None])
+    out = s.str.count_matches(r"\d", literal=True)
+    expected = pl.Series([0, 0, 2, None], dtype=pl.UInt32)
+    assert_series_equal(out, expected)
+
+    out = s.str.count_matches(pl.Series([r"\w", r"\w", r"\d", r"\d"]), literal=True)
+    expected = pl.Series([0, 1, 2, None], dtype=pl.UInt32)
+    assert_series_equal(out, expected)
+
+
 def test_str_encode() -> None:
     s = pl.Series(["foo", "bar", None])
     hex_encoded = pl.Series(["666f6f", "626172", None])


### PR DESCRIPTION
This PR is committed to solve #10930. But not supports `extract_xxx` as I'm not very clear how to define a `match group` well in this `literal` mode, especially for `str.extract_groups()`.