### PR TITLE
fix(rust, python): fix rolling_* functions when "by" has nanosecond resolution

### DIFF
--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1234,10 +1234,9 @@ impl Expr {
                         ComputeError: "`weights` is not supported in 'rolling by' expression"
                     );
                     let (by, tz) = match by.dtype() {
-                        DataType::Datetime(_, tz) => (
-                            by.cast(&DataType::Datetime(TimeUnit::Microseconds, None))?,
-                            tz,
-                        ),
+                        DataType::Datetime(tu, tz) => {
+                            (by.cast(&DataType::Datetime(*tu, None))?, tz)
+                        },
                         _ => (by.clone(), &None),
                     };
                     let by = by.datetime().unwrap();


### PR DESCRIPTION
closes #11003