### PR TITLE
fix(python): ensure `series_equal` properly accounts for dtypes when strict=True

### DIFF
--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -281,9 +281,10 @@ impl PySeries {
     }
 
     fn series_equal(&self, other: &PySeries, null_equal: bool, strict: bool) -> bool {
-        if strict {
-            self.series.eq(&other.series)
-        } else if null_equal {
+        if strict && self.series.dtype().ne(other.series.dtype()) {
+            return false;
+        }
+        if null_equal {
             self.series.series_equal_missing(&other.series)
         } else {
             self.series.series_equal(&other.series)

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -281,7 +281,7 @@ impl PySeries {
     }
 
     fn series_equal(&self, other: &PySeries, null_equal: bool, strict: bool) -> bool {
-        if strict && self.series.dtype().ne(other.series.dtype()) {
+        if strict && (self.series.dtype() != other.series.dtype()) {
             return false;
         }
         if null_equal {

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -219,6 +219,30 @@ def test_concat() -> None:
     assert s.len() == 3
 
 
+def test_equal() -> None:
+    s1 = pl.Series("a", [1.0, 2.0, None], Float64)
+    s2 = pl.Series("a", [1, 2, None], Int64)
+
+    assert s1.series_equal(s2) is True
+    assert s1.series_equal(s2, strict=True) is False
+    assert s1.series_equal(s2, null_equal=False) is False
+
+    df = pl.DataFrame(
+        {"dtm": [datetime(2222, 2, 22, 22, 22, 22)]},
+        schema_overrides={"dtm": Datetime(time_zone="UTC")},
+    ).with_columns(
+        s3=pl.col("dtm").dt.convert_time_zone("Europe/London"),
+        s4=pl.col("dtm").dt.convert_time_zone("Asia/Tokyo"),
+    )
+    s3 = df["s3"].rename("b")
+    s4 = df["s4"].rename("b")
+
+    assert s3.series_equal(s4) is False
+    assert s3.series_equal(s4, strict=True) is False
+    assert s3.series_equal(s4, null_equal=False) is False
+    assert s3.dt.convert_time_zone("Asia/Tokyo").series_equal(s4) is True
+
+
 def test_to_frame() -> None:
     s1 = pl.Series([1, 2])
     s2 = pl.Series("s", [1, 2])


### PR DESCRIPTION
Closes #11001.

`series_equal` was ignoring dtype comparison when `strict=True` (the call to `eq` just ended-up resolving to `series_equal_missing` without ever actually comparing the dtypes).

```
strict
    Don't allow different numerical dtypes, e.g. comparing `pl.UInt32` with a
    `pl.Int64` will return `False`.
```

Fixed this so that we now match the behaviour given in the docs (above), and added some new test coverage.