### PR TITLE
feat(python,rust): add quote_style="never" option for `write_csv`

### DIFF
--- a/crates/polars-io/src/csv/write.rs
+++ b/crates/polars-io/src/csv/write.rs
@@ -15,7 +15,7 @@ pub enum QuoteStyle {
     Necessary,
     /// This puts quotes around all fields that are non-numeric. Namely, when writing a field that does not parse as a valid float or integer, then quotes will be used even if they aren’t strictly necessary.
     NonNumeric,
-    /// Never quote any fields, even if it would usually be considered necessary.
+    /// Never quote any fields, even if it would produce invalid CSV data.
     Never,
 }
 

--- a/crates/polars-io/src/csv/write.rs
+++ b/crates/polars-io/src/csv/write.rs
@@ -15,6 +15,8 @@ pub enum QuoteStyle {
     Necessary,
     /// This puts quotes around all fields that are non-numeric. Namely, when writing a field that does not parse as a valid float or integer, then quotes will be used even if they aren’t strictly necessary.
     NonNumeric,
+    /// Never quote any fields, even if it would usually be considered necessary.
+    Never,
 }
 
 /// Write a DataFrame to csv.

--- a/crates/polars-io/src/csv/write_impl.rs
+++ b/crates/polars-io/src/csv/write_impl.rs
@@ -22,11 +22,12 @@ use serde::{Deserialize, Serialize};
 use super::write::QuoteStyle;
 
 fn fmt_and_escape_str(f: &mut Vec<u8>, v: &str, options: &SerializeOptions) -> std::io::Result<()> {
-    if v.is_empty() {
+    if options.quote_style == QuoteStyle::Never {
+        write!(f, "{v}")
+    } else if v.is_empty() {
         write!(f, "\"\"")
     } else {
         let needs_escaping = memchr(options.quote, v.as_bytes()).is_some();
-
         if needs_escaping {
             let replaced = unsafe {
                 // Replace from single quote " to double quote "".
@@ -40,6 +41,7 @@ fn fmt_and_escape_str(f: &mut Vec<u8>, v: &str, options: &SerializeOptions) -> s
         let surround_with_quotes = match options.quote_style {
             QuoteStyle::Always | QuoteStyle::NonNumeric => true,
             QuoteStyle::Necessary => memchr2(options.delimiter, b'\n', v.as_bytes()).is_some(),
+            QuoteStyle::Never => false,
         };
 
         let quote = options.quote as char;

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2528,7 +2528,7 @@ class DataFrame:
             ``Float64`` datatypes.
         null_value
             A string representing null values (defaulting to the empty string).
-        quote_style : {'necessary', 'always', 'non_numeric'}
+        quote_style : {'necessary', 'always', 'non_numeric', 'never'}
             Determines the quoting strategy used.
             - necessary (default): This puts quotes around fields only when necessary.
             They are necessary when fields contain a quote,
@@ -2537,6 +2537,8 @@ class DataFrame:
             (which is indistinguishable from a record with one empty field).
             This is the default.
             - always: This puts quotes around every field. Always.
+            - never: This never puts quotes around fields, even if they contain
+            characters that would typically require quotes (such as the separator).
             - non_numeric: This puts quotes around all fields that are non-numeric.
             Namely, when writing a field that does not parse as a valid float
             or integer, then quotes will be used even if they aren`t strictly

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2537,8 +2537,8 @@ class DataFrame:
             (which is indistinguishable from a record with one empty field).
             This is the default.
             - always: This puts quotes around every field. Always.
-            - never: This never puts quotes around fields, even if they contain
-            characters that would typically require quotes (such as the separator).
+            - never: This never puts quotes around fields, even if that results in
+            invalid CSV data (e.g.: by not quoting strings containing the separator).
             - non_numeric: This puts quotes around all fields that are non-numeric.
             Namely, when writing a field that does not parse as a valid float
             or integer, then quotes will be used even if they aren`t strictly

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2042,8 +2042,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             (which is indistinguishable from a record with one empty field).
             This is the default.
             - always: This puts quotes around every field. Always.
-            - never: This never puts quotes around fields, even if they contain
-            characters that would typically require quotes (such as the separator).
+            - never: This never puts quotes around fields, even if that results in
+            invalid CSV data (e.g.: by not quoting strings containing the separator).
             - non_numeric: This puts quotes around all fields that are non-numeric.
             Namely, when writing a field that does not parse as a valid float
             or integer, then quotes will be used even if they aren`t strictly

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2033,7 +2033,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             ``Float64`` datatypes.
         null_value
             A string representing null values (defaulting to the empty string).
-        quote_style : {'necessary', 'always', 'non_numeric'}
+        quote_style : {'necessary', 'always', 'non_numeric', 'never'}
             Determines the quoting strategy used.
             - necessary (default): This puts quotes around fields only when necessary.
             They are necessary when fields contain a quote,
@@ -2042,6 +2042,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             (which is indistinguishable from a record with one empty field).
             This is the default.
             - always: This puts quotes around every field. Always.
+            - never: This never puts quotes around fields, even if they contain
+            characters that would typically require quotes (such as the separator).
             - non_numeric: This puts quotes around all fields that are non-numeric.
             Namely, when writing a field that does not parse as a valid float
             or integer, then quotes will be used even if they aren`t strictly

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -76,7 +76,7 @@ ColumnNameOrSelector: TypeAlias = Union[str, SelectorType]
 # User-facing string literal types
 # The following all have an equivalent Rust enum with the same name
 AvroCompression: TypeAlias = Literal["uncompressed", "snappy", "deflate"]
-CsvQuoteStyle: TypeAlias = Literal["necessary", "always", "non_numeric"]
+CsvQuoteStyle: TypeAlias = Literal["necessary", "always", "non_numeric", "never"]
 CategoricalOrdering: TypeAlias = Literal["physical", "lexical"]
 CsvEncoding: TypeAlias = Literal["utf8", "utf8-lossy"]
 FillNullStrategy: TypeAlias = Literal[

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -1433,6 +1433,7 @@ impl FromPyObject<'_> for Wrap<QuoteStyle> {
             "always" => QuoteStyle::Always,
             "necessary" => QuoteStyle::Necessary,
             "non_numeric" => QuoteStyle::NonNumeric,
+            "never" => QuoteStyle::Never,
             v => {
                 return Err(PyValueError::new_err(format!(
                     "validate must be one of {{'always', 'necessary', 'non_numeric'}}, got {v}",

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1463,23 +1463,27 @@ def test_csv_quote_styles() -> None:
     df = pl.DataFrame(
         {
             "float": [1.0, 2.0, None],
-            "string": ["a", "abc", '"hello'],
+            "string": ["a", "a,bc", '"hello'],
             "int": [1, 2, 3],
             "bool": [True, False, None],
         }
     )
 
     assert (
-        df.write_csv(quote_style="necessary")
-        == 'float,string,int,bool\n1.0,a,1,true\n2.0,abc,2,false\n,"""hello",3,\n'
+        df.write_csv(quote_style="always")
+        == '"float","string","int","bool"\n"1.0","a","1","true"\n"2.0","a,bc","2","false"\n"","""hello","3",""\n'
     )
     assert (
-        df.write_csv(quote_style="always")
-        == '"float","string","int","bool"\n"1.0","a","1","true"\n"2.0","abc","2","false"\n"","""hello","3",""\n'
+        df.write_csv(quote_style="necessary")
+        == 'float,string,int,bool\n1.0,a,1,true\n2.0,"a,bc",2,false\n,"""hello",3,\n'
+    )
+    assert (
+        df.write_csv(quote_style="never")
+        == 'float,string,int,bool\n1.0,a,1,true\n2.0,a,bc,2,false\n,"hello,3,\n'
     )
     assert (
         df.write_csv(quote_style="non_numeric", quote="8")
-        == '8float8,8string8,8int8,8bool8\n1.0,8a8,1,8true8\n2.0,8abc8,2,8false8\n,8"hello8,3,\n'
+        == '8float8,8string8,8int8,8bool8\n1.0,8a8,1,8true8\n2.0,8a,bc8,2,8false8\n,8"hello8,3,\n'
     )
 
 


### PR DESCRIPTION
Closes #10992.

Adds a `QuoteStyle::Never` (Rust) or `quote_style="never"` (Python) option for `write_csv`.

 Can offer a little additional performance if we know that nothing needs to be quoted, or provide an option to write columns that aren't intended to be true CSV (as per the linked issue).