### PR TITLE
build(rust): ensure `clippy` runs in pre-commit with `--all-features` (to match CI)

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -64,7 +64,7 @@ fmt: .venv  ## Run autoformatting and linting
 
 .PHONY: clippy
 clippy:  ## Run clippy
-	cargo clippy --locked -- -D warnings
+	cargo clippy --all-features --locked -- -D warnings
 
 .PHONY: pre-commit
 pre-commit: fmt clippy  ## Run all code quality checks


### PR DESCRIPTION
Just got caught out by this; CI flagged a clippy lint (in another PR) that `make pre-commit` didn't catch  ;)