### PR TITLE
feat(python, rust!): Add `disable_string_cache`

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -532,7 +532,7 @@ mod test {
         assert_eq!(out.get_rev_map().len(), 2);
 
         // test the global branch
-        enable_string_cache(true);
+        enable_string_cache();
         // empty global cache
         let out = ca.cast(&DataType::Categorical(None))?;
         let out = out.categorical().unwrap().clone();
@@ -558,9 +558,11 @@ mod test {
     fn test_categorical_builder() {
         use crate::{enable_string_cache, reset_string_cache};
         let _lock = crate::SINGLE_LOCK.lock();
-        for b in &[false, true] {
+        for use_string_cache in &[false, true] {
             reset_string_cache();
-            enable_string_cache(*b);
+            if use_string_cache {
+                enable_string_cache();
+            }
 
             // Use 2 builders to check if the global string cache
             // does not interfere with the index mapping

--- a/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -512,12 +512,12 @@ impl CategoricalChunked {
 mod test {
     use crate::chunked_array::categorical::CategoricalChunkedBuilder;
     use crate::prelude::*;
-    use crate::{enable_string_cache, reset_string_cache, SINGLE_LOCK};
+    use crate::{disable_string_cache, enable_string_cache, SINGLE_LOCK};
 
     #[test]
     fn test_categorical_rev() -> PolarsResult<()> {
         let _lock = SINGLE_LOCK.lock();
-        reset_string_cache();
+        disable_string_cache();
         let slice = &[
             Some("foo"),
             None,
@@ -556,10 +556,10 @@ mod test {
 
     #[test]
     fn test_categorical_builder() {
-        use crate::{enable_string_cache, reset_string_cache};
+        use crate::{disable_string_cache, enable_string_cache};
         let _lock = crate::SINGLE_LOCK.lock();
-        for use_string_cache in &[false, true] {
-            reset_string_cache();
+        for use_string_cache in [false, true] {
+            disable_string_cache();
             if use_string_cache {
                 enable_string_cache();
             }

--- a/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
@@ -153,13 +153,13 @@ impl CategoricalChunked {
 mod test {
     use super::*;
     use crate::chunked_array::categorical::CategoricalChunkedBuilder;
-    use crate::{disable_string_cache, enable_string_cache, IUseStringCache};
+    use crate::{disable_string_cache, enable_string_cache, StringCacheHolder};
 
     #[test]
     fn test_merge_rev_map() {
         let _lock = SINGLE_LOCK.lock();
         disable_string_cache();
-        let _sc = IUseStringCache::hold();
+        let _sc = StringCacheHolder::hold();
 
         let mut builder1 = CategoricalChunkedBuilder::new("foo", 10);
         let mut builder2 = CategoricalChunkedBuilder::new("foo", 10);

--- a/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
@@ -153,12 +153,12 @@ impl CategoricalChunked {
 mod test {
     use super::*;
     use crate::chunked_array::categorical::CategoricalChunkedBuilder;
-    use crate::{enable_string_cache, reset_string_cache, IUseStringCache};
+    use crate::{disable_string_cache, enable_string_cache, IUseStringCache};
 
     #[test]
     fn test_merge_rev_map() {
         let _lock = SINGLE_LOCK.lock();
-        reset_string_cache();
+        disable_string_cache();
         let _sc = IUseStringCache::hold();
 
         let mut builder1 = CategoricalChunkedBuilder::new("foo", 10);

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -296,7 +296,7 @@ mod test {
     fn test_append_categorical() {
         let _lock = SINGLE_LOCK.lock();
         reset_string_cache();
-        enable_string_cache(true);
+        enable_string_cache();
 
         let mut s1 = Series::new("1", vec!["a", "b", "c"])
             .cast(&DataType::Categorical(None))
@@ -330,7 +330,6 @@ mod test {
     fn test_categorical_flow() -> PolarsResult<()> {
         let _lock = SINGLE_LOCK.lock();
         reset_string_cache();
-        enable_string_cache(false);
 
         // tests several things that may lose the dtype information
         let s = Series::new("a", vec!["a", "b", "c"]).cast(&DataType::Categorical(None))?;

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -2,7 +2,7 @@ mod builder;
 mod from;
 mod merge;
 mod ops;
-pub mod stringcache;
+pub mod string_cache;
 
 use bitflags::bitflags;
 pub use builder::*;
@@ -265,12 +265,12 @@ mod test {
     use std::convert::TryFrom;
 
     use super::*;
-    use crate::{enable_string_cache, reset_string_cache, SINGLE_LOCK};
+    use crate::{disable_string_cache, enable_string_cache, SINGLE_LOCK};
 
     #[test]
     fn test_categorical_round_trip() -> PolarsResult<()> {
         let _lock = SINGLE_LOCK.lock();
-        reset_string_cache();
+        disable_string_cache();
         let slice = &[
             Some("foo"),
             None,
@@ -295,7 +295,7 @@ mod test {
     #[test]
     fn test_append_categorical() {
         let _lock = SINGLE_LOCK.lock();
-        reset_string_cache();
+        disable_string_cache();
         enable_string_cache();
 
         let mut s1 = Series::new("1", vec!["a", "b", "c"])
@@ -329,7 +329,7 @@ mod test {
     #[test]
     fn test_categorical_flow() -> PolarsResult<()> {
         let _lock = SINGLE_LOCK.lock();
-        reset_string_cache();
+        disable_string_cache();
 
         // tests several things that may lose the dtype information
         let s = Series::new("a", vec!["a", "b", "c"]).cast(&DataType::Categorical(None))?;

--- a/crates/polars-core/src/chunked_array/logical/categorical/string_cache.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/string_cache.rs
@@ -94,19 +94,11 @@ pub fn enable_string_cache() {
 ///
 /// **Warning**: Disabling the string cache this way may cause errors if there
 /// are other threads that rely the global string cache being enabled.
-/// Consider using either [`with_string_cache`] or [`StringCacheHolder`] for a
-/// more reliable way of enabling and disabling the string cache.
+/// Consider using [`StringCacheHolder`] for a more reliable way of enabling
+/// and disabling the string cache.
 pub fn disable_string_cache() {
     USE_STRING_CACHE.store(0, Ordering::Release);
     STRING_CACHE.clear()
-}
-
-/// Execute a function with the global string cache enabled.
-pub fn with_string_cache<F: FnOnce() -> T, T>(func: F) -> T {
-    set_string_cache(true);
-    let out = func();
-    set_string_cache(false);
-    out
 }
 
 /// Check whether the global string cache is enabled.

--- a/crates/polars-core/src/chunked_array/logical/categorical/string_cache.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/string_cache.rs
@@ -43,14 +43,14 @@ impl Default for IUseStringCache {
 impl IUseStringCache {
     /// Hold the StringCache
     pub fn hold() -> IUseStringCache {
-        _set_string_cache(true);
+        set_string_cache(true);
         IUseStringCache { private_zst: () }
     }
 }
 
 impl Drop for IUseStringCache {
     fn drop(&mut self) {
-        _set_string_cache(false)
+        set_string_cache(false)
     }
 }
 
@@ -66,7 +66,7 @@ impl Drop for IUseStringCache {
 ///
 /// [`Categorical`]: crate::datatypes::DataType::Categorical
 pub fn enable_string_cache() {
-    _set_string_cache(true)
+    set_string_cache(true)
 }
 
 /// Disable and clear the global string cache.
@@ -77,9 +77,9 @@ pub fn disable_string_cache() {
 
 /// Execute a function with the global string cache enabled.
 pub fn with_string_cache<F: FnOnce() -> T, T>(func: F) -> T {
-    _set_string_cache(true);
+    set_string_cache(true);
     let out = func();
-    _set_string_cache(false);
+    set_string_cache(false);
     out
 }
 
@@ -88,12 +88,8 @@ pub fn using_string_cache() -> bool {
     USE_STRING_CACHE.load(Ordering::Acquire) > 0
 }
 
-/// Incrementing or decrement the number of string cache uses.
-///
-/// WARNING: Do not use this function directly. This is a private function
-/// intended for creating RAII objects. It is technically public because it is
-/// used directly by the Python implementation to create a context manager.
-pub fn _set_string_cache(active: bool) {
+/// Increment or decrement the number of string cache uses.
+fn set_string_cache(active: bool) {
     if active {
         USE_STRING_CACHE.fetch_add(1, Ordering::Release);
     } else {

--- a/crates/polars-core/src/chunked_array/logical/categorical/string_cache.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/string_cache.rs
@@ -91,6 +91,11 @@ pub fn enable_string_cache() {
 }
 
 /// Disable and clear the global string cache.
+///
+/// **Warning**: Disabling the string cache this way may cause errors if there
+/// are other threads that rely the global string cache being enabled.
+/// Consider using either [`with_string_cache`] or [`StringCacheHolder`] for a
+/// more reliable way of enabling and disabling the string cache.
 pub fn disable_string_cache() {
     USE_STRING_CACHE.store(0, Ordering::Release);
     STRING_CACHE.clear()

--- a/crates/polars-core/src/chunked_array/logical/categorical/string_cache.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/string_cache.rs
@@ -25,7 +25,7 @@ static STRING_CACHE_UUID_CTR: AtomicU32 = AtomicU32::new(0);
 /// ```
 /// use polars_core::StringCacheHolder;
 ///
-/// let handle = StringCacheHolder::hold();
+/// let _sc = StringCacheHolder::hold();
 /// ```
 ///
 /// The string cache is enabled until `handle` is dropped.

--- a/crates/polars-core/src/chunked_array/logical/categorical/string_cache.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/string_cache.rs
@@ -13,8 +13,8 @@ use crate::prelude::InitHashMaps;
 
 /// We use atomic reference counting to determine how many threads use the
 /// string cache. If the refcount is zero, we may clear the string cache.
-pub(crate) static STRING_CACHE_ENABLED: AtomicBool = AtomicBool::new(false);
-pub(crate) static STRING_CACHE_REFCOUNT: AtomicU32 = AtomicU32::new(0);
+static STRING_CACHE_REFCOUNT: AtomicU32 = AtomicU32::new(0);
+static STRING_CACHE_ENABLED: AtomicBool = AtomicBool::new(false);
 static STRING_CACHE_UUID_CTR: AtomicU32 = AtomicU32::new(0);
 
 /// Enable the global string cache as long as the object is alive ([RAII]).

--- a/crates/polars-core/src/chunked_array/logical/categorical/string_cache.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/string_cache.rs
@@ -14,7 +14,7 @@ use crate::prelude::InitHashMaps;
 /// We use atomic reference counting to determine how many threads use the
 /// string cache. If the refcount is zero, we may clear the string cache.
 static STRING_CACHE_REFCOUNT: AtomicU32 = AtomicU32::new(0);
-static STRING_CACHE_ENABLED: AtomicBool = AtomicBool::new(false);
+static STRING_CACHE_ENABLED_GLOBALLY: AtomicBool = AtomicBool::new(false);
 static STRING_CACHE_UUID_CTR: AtomicU32 = AtomicU32::new(0);
 
 /// Enable the global string cache as long as the object is alive ([RAII]).
@@ -86,7 +86,7 @@ fn decrement_string_cache_refcount() {
 ///
 /// [`Categorical`]: crate::datatypes::DataType::Categorical
 pub fn enable_string_cache() {
-    let was_enabled = STRING_CACHE_ENABLED.swap(true, Ordering::AcqRel);
+    let was_enabled = STRING_CACHE_ENABLED_GLOBALLY.swap(true, Ordering::AcqRel);
     if !was_enabled {
         increment_string_cache_refcount();
     }
@@ -97,7 +97,7 @@ pub fn enable_string_cache() {
 /// Note: Consider using [`StringCacheHolder`] for a more reliable way of
 /// enabling and disabling the string cache.
 pub fn disable_string_cache() {
-    let was_enabled = STRING_CACHE_ENABLED.swap(false, Ordering::AcqRel);
+    let was_enabled = STRING_CACHE_ENABLED_GLOBALLY.swap(false, Ordering::AcqRel);
     if was_enabled {
         decrement_string_cache_refcount();
     }

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -827,9 +827,9 @@ pub(crate) mod test {
     #[test]
     #[cfg(feature = "dtype-categorical")]
     fn test_iter_categorical() {
-        use crate::{reset_string_cache, SINGLE_LOCK};
+        use crate::{disable_string_cache, SINGLE_LOCK};
         let _lock = SINGLE_LOCK.lock();
-        reset_string_cache();
+        disable_string_cache();
         let ca = Utf8Chunked::new("", &[Some("foo"), None, Some("bar"), Some("ham")]);
         let ca = ca.cast(&DataType::Categorical(None)).unwrap();
         let ca = ca.categorical().unwrap();

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -120,7 +120,7 @@ impl CategoricalChunked {
 #[cfg(test)]
 mod test {
     use crate::prelude::*;
-    use crate::{enable_string_cache, reset_string_cache, SINGLE_LOCK};
+    use crate::{disable_string_cache, enable_string_cache, SINGLE_LOCK};
 
     fn assert_order(ca: &CategoricalChunked, cmp: &[&str]) {
         let s = ca.cast(&DataType::Utf8).unwrap();
@@ -134,7 +134,7 @@ mod test {
 
         let _lock = SINGLE_LOCK.lock();
         for use_string_cache in [true, false] {
-            reset_string_cache();
+            disable_string_cache();
             if use_string_cache {
                 enable_string_cache();
             }
@@ -165,7 +165,7 @@ mod test {
 
         let _lock = SINGLE_LOCK.lock();
         for use_string_cache in [true, false] {
-            reset_string_cache();
+            disable_string_cache();
             if use_string_cache {
                 enable_string_cache();
             }

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -133,9 +133,12 @@ mod test {
         let init = &["c", "b", "a", "d"];
 
         let _lock = SINGLE_LOCK.lock();
-        for toggle in [true, false] {
+        for use_string_cache in [true, false] {
             reset_string_cache();
-            enable_string_cache(toggle);
+            if use_string_cache {
+                enable_string_cache();
+            }
+
             let s = Series::new("", init).cast(&DataType::Categorical(None))?;
             let ca = s.categorical()?;
             let mut ca_lexical = ca.clone();
@@ -157,13 +160,16 @@ mod test {
     }
 
     #[test]
-
     fn test_cat_lexical_sort_multiple() -> PolarsResult<()> {
         let init = &["c", "b", "a", "a"];
 
         let _lock = SINGLE_LOCK.lock();
-        for enable in [true, false] {
-            enable_string_cache(enable);
+        for use_string_cache in [true, false] {
+            reset_string_cache();
+            if use_string_cache {
+                enable_string_cache();
+            }
+
             let s = Series::new("", init).cast(&DataType::Categorical(None))?;
             let ca = s.categorical()?;
             let mut ca_lexical: CategoricalChunked = ca.clone();

--- a/crates/polars-core/src/lib.rs
+++ b/crates/polars-core/src/lib.rs
@@ -38,7 +38,7 @@ use once_cell::sync::Lazy;
 use rayon::{ThreadPool, ThreadPoolBuilder};
 
 #[cfg(feature = "dtype-categorical")]
-pub use crate::chunked_array::logical::categorical::stringcache::*;
+pub use crate::chunked_array::logical::categorical::string_cache::*;
 
 pub static PROCESS_ID: Lazy<u128> = Lazy::new(|| {
     SystemTime::now()

--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -200,7 +200,7 @@ Help: if you're using Python, this may look something like:
 Alternatively, if the performance cost is acceptable, you could just set:
 
     import polars as pl
-    pl.enable_string_cache(True)
+    pl.enable_string_cache()
 
 on startup."#.trim_start())
     };

--- a/crates/polars-io/src/csv/read.rs
+++ b/crates/polars-io/src/csv/read.rs
@@ -584,7 +584,7 @@ where
 
             #[cfg(feature = "dtype-categorical")]
             if _has_cat {
-                _cat_lock = Some(polars_core::IUseStringCache::hold())
+                _cat_lock = Some(polars_core::StringCacheHolder::hold())
             }
 
             let mut csv_reader = self.core_reader(Some(Arc::new(schema)), to_cast)?;
@@ -602,7 +602,7 @@ where
                     })
                     .unwrap_or(false);
                 if has_cat {
-                    _cat_lock = Some(polars_core::IUseStringCache::hold())
+                    _cat_lock = Some(polars_core::StringCacheHolder::hold())
                 }
             }
             let mut csv_reader = self.core_reader(self.schema.clone(), vec![])?;

--- a/crates/polars-io/src/csv/read_impl/batched_mmap.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_mmap.rs
@@ -136,7 +136,7 @@ impl<'a> CoreReader<'a> {
         // RAII structure that will ensure we maintain a global stringcache
         #[cfg(feature = "dtype-categorical")]
         let _cat_lock = if _has_cat {
-            Some(polars_core::IUseStringCache::hold())
+            Some(polars_core::StringCacheHolder::hold())
         } else {
             None
         };
@@ -196,7 +196,7 @@ pub struct BatchedCsvReaderMmap<'a> {
     schema: SchemaRef,
     rows_read: IdxSize,
     #[cfg(feature = "dtype-categorical")]
-    _cat_lock: Option<polars_core::IUseStringCache>,
+    _cat_lock: Option<polars_core::StringCacheHolder>,
     #[cfg(not(feature = "dtype-categorical"))]
     _cat_lock: Option<u8>,
 }

--- a/crates/polars-io/src/csv/read_impl/batched_read.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_read.rs
@@ -219,7 +219,7 @@ impl<'a> CoreReader<'a> {
         // RAII structure that will ensure we maintain a global stringcache
         #[cfg(feature = "dtype-categorical")]
         let _cat_lock = if _has_cat {
-            Some(polars_core::IUseStringCache::hold())
+            Some(polars_core::StringCacheHolder::hold())
         } else {
             None
         };
@@ -279,7 +279,7 @@ pub struct BatchedCsvReaderRead<'a> {
     schema: SchemaRef,
     rows_read: IdxSize,
     #[cfg(feature = "dtype-categorical")]
-    _cat_lock: Option<polars_core::IUseStringCache>,
+    _cat_lock: Option<polars_core::StringCacheHolder>,
     #[cfg(not(feature = "dtype-categorical"))]
     _cat_lock: Option<u8>,
 }

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -251,7 +251,7 @@ pub fn read_parquet<R: MmapBytesReader>(
     // if there are multiple row groups and categorical data
     // we need a string cache
     // we keep it alive until the end of the function
-    let _string_cache = if n_row_groups > 1 {
+    let _sc = if n_row_groups > 1 {
         #[cfg(feature = "dtype-categorical")]
         {
             Some(polars_core::StringCacheHolder::hold())

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -254,7 +254,7 @@ pub fn read_parquet<R: MmapBytesReader>(
     let _string_cache = if n_row_groups > 1 {
         #[cfg(feature = "dtype-categorical")]
         {
-            Some(polars_core::IUseStringCache::hold())
+            Some(polars_core::StringCacheHolder::hold())
         }
         #[cfg(not(feature = "dtype-categorical"))]
         {

--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -495,7 +495,7 @@ impl PhysicalExpr for WindowExpr {
         // Worst case is that a categorical is created with indexes from the string
         // cache which is fine, as the physical representation is undefined.
         #[cfg(feature = "dtype-categorical")]
-        let _sc = polars_core::IUseStringCache::hold();
+        let _sc = polars_core::StringCacheHolder::hold();
         let mut ac = self.run_aggregation(df, state, &gb)?;
 
         use MapStrategy::*;

--- a/crates/polars-plan/src/logical_plan/functions/mod.rs
+++ b/crates/polars-plan/src/logical_plan/functions/mod.rs
@@ -332,7 +332,7 @@ impl FunctionNode {
                 // we use a global string cache here as streaming chunks all have different rev maps
                 #[cfg(feature = "dtype-categorical")]
                 {
-                    let _hold = StringCacheHolder::hold();
+                    let _sc = StringCacheHolder::hold();
                     Arc::get_mut(function).unwrap().call_udf(df)
                 }
 

--- a/crates/polars-plan/src/logical_plan/functions/mod.rs
+++ b/crates/polars-plan/src/logical_plan/functions/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use polars_core::prelude::*;
 #[cfg(feature = "dtype-categorical")]
-use polars_core::IUseStringCache;
+use polars_core::StringCacheHolder;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use smartstring::alias::String as SmartString;
@@ -332,7 +332,7 @@ impl FunctionNode {
                 // we use a global string cache here as streaming chunks all have different rev maps
                 #[cfg(feature = "dtype-categorical")]
                 {
-                    let _hold = IUseStringCache::hold();
+                    let _hold = StringCacheHolder::hold();
                     Arc::get_mut(function).unwrap().call_udf(df)
                 }
 

--- a/crates/polars/src/docs/performance.rs
+++ b/crates/polars/src/docs/performance.rs
@@ -67,7 +67,7 @@
 //!
 //! fn example(mut df_a: DataFrame, mut df_b: DataFrame) -> PolarsResult<DataFrame> {
 //!     // Set a global string cache
-//!     enable_string_cache(true);
+//!     enable_string_cache();
 //!
 //!     df_a.try_apply("a", |s| s.categorical().cloned())?;
 //!     df_b.try_apply("b", |s| s.categorical().cloned())?;

--- a/crates/polars/tests/it/core/joins.rs
+++ b/crates/polars/tests/it/core/joins.rs
@@ -1,6 +1,6 @@
 use polars_core::utils::{accumulate_dataframes_vertical, split_df};
 #[cfg(feature = "dtype-categorical")]
-use polars_core::{disable_string_cache, IUseStringCache};
+use polars_core::{disable_string_cache, StringCacheHolder};
 
 use super::*;
 
@@ -256,7 +256,7 @@ fn test_join_multiple_columns() {
 #[cfg_attr(miri, ignore)]
 #[cfg(feature = "dtype-categorical")]
 fn test_join_categorical() {
-    let _lock = IUseStringCache::hold();
+    let _lock = StringCacheHolder::hold();
     let _lock = polars_core::SINGLE_LOCK.lock();
 
     let (mut df_a, mut df_b) = get_dfs();
@@ -298,7 +298,7 @@ fn test_join_categorical() {
     disable_string_cache();
 
     // _sc is needed to ensure we hold the string cache.
-    let _sc = IUseStringCache::hold();
+    let _sc = StringCacheHolder::hold();
 
     df_b.try_apply("bar", |s| s.cast(&DataType::Categorical(None)))
         .unwrap();

--- a/crates/polars/tests/it/core/joins.rs
+++ b/crates/polars/tests/it/core/joins.rs
@@ -1,6 +1,6 @@
 use polars_core::utils::{accumulate_dataframes_vertical, split_df};
 #[cfg(feature = "dtype-categorical")]
-use polars_core::{disable_string_cache, StringCacheHolder};
+use polars_core::{disable_string_cache, StringCacheHolder, SINGLE_LOCK};
 
 use super::*;
 

--- a/crates/polars/tests/it/core/joins.rs
+++ b/crates/polars/tests/it/core/joins.rs
@@ -1,6 +1,6 @@
 use polars_core::utils::{accumulate_dataframes_vertical, split_df};
 #[cfg(feature = "dtype-categorical")]
-use polars_core::{reset_string_cache, IUseStringCache};
+use polars_core::{disable_string_cache, IUseStringCache};
 
 use super::*;
 
@@ -295,7 +295,7 @@ fn test_join_categorical() {
     df_a.try_apply("b", |s| s.cast(&DataType::Categorical(None)))
         .unwrap();
     // create a new cache
-    reset_string_cache();
+    disable_string_cache();
 
     // _sc is needed to ensure we hold the string cache.
     let _sc = IUseStringCache::hold();

--- a/crates/polars/tests/it/core/joins.rs
+++ b/crates/polars/tests/it/core/joins.rs
@@ -257,7 +257,7 @@ fn test_join_multiple_columns() {
 #[cfg(feature = "dtype-categorical")]
 fn test_join_categorical() {
     let _lock = StringCacheHolder::hold();
-    let _lock = polars_core::SINGLE_LOCK.lock();
+    let _lock = SINGLE_LOCK.lock();
 
     let (mut df_a, mut df_b) = get_dfs();
 

--- a/crates/polars/tests/it/core/joins.rs
+++ b/crates/polars/tests/it/core/joins.rs
@@ -256,8 +256,9 @@ fn test_join_multiple_columns() {
 #[cfg_attr(miri, ignore)]
 #[cfg(feature = "dtype-categorical")]
 fn test_join_categorical() {
-    let _lock = StringCacheHolder::hold();
-    let _lock = SINGLE_LOCK.lock();
+    let _guard = SINGLE_LOCK.lock();
+    disable_string_cache();
+    let _sc = StringCacheHolder::hold();
 
     let (mut df_a, mut df_b) = get_dfs();
 
@@ -294,10 +295,9 @@ fn test_join_categorical() {
     let (mut df_a, mut df_b) = get_dfs();
     df_a.try_apply("b", |s| s.cast(&DataType::Categorical(None)))
         .unwrap();
-    // create a new cache
-    disable_string_cache();
 
-    // _sc is needed to ensure we hold the string cache.
+    // Create a new string cache
+    drop(_sc);
     let _sc = StringCacheHolder::hold();
 
     df_b.try_apply("bar", |s| s.cast(&DataType::Categorical(None)))

--- a/crates/polars/tests/it/lazy/expressions/arity.rs
+++ b/crates/polars/tests/it/lazy/expressions/arity.rs
@@ -116,7 +116,7 @@ fn includes_null_predicate_3038() -> PolarsResult<()> {
 #[test]
 #[cfg(feature = "dtype-categorical")]
 fn test_when_then_otherwise_cats() -> PolarsResult<()> {
-    polars::enable_string_cache(true);
+    polars::enable_string_cache();
 
     let lf = df!["book" => [Some("bookA"),
         None,

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -1,6 +1,6 @@
 // used only if feature="is_in", feature="dtype-categorical"
 #[allow(unused_imports)]
-use polars_core::{with_string_cache, SINGLE_LOCK};
+use polars_core::{StringCacheHolder, SINGLE_LOCK};
 
 use super::*;
 
@@ -132,24 +132,22 @@ fn test_is_in_categorical_3420() -> PolarsResult<()> {
     ]?;
 
     let _guard = SINGLE_LOCK.lock();
+    disable_string_cache();
+    let _sc = StringCacheHolder::hold();
 
-    let _: PolarsResult<_> = with_string_cache(|| {
-        let s = Series::new("x", ["a", "b", "c"]).strict_cast(&DataType::Categorical(None))?;
-        let out = df
-            .lazy()
-            .with_column(col("a").strict_cast(DataType::Categorical(None)))
-            .filter(col("a").is_in(lit(s).alias("x")))
-            .collect()?;
+    let s = Series::new("x", ["a", "b", "c"]).strict_cast(&DataType::Categorical(None))?;
+    let out = df
+        .lazy()
+        .with_column(col("a").strict_cast(DataType::Categorical(None)))
+        .filter(col("a").is_in(lit(s).alias("x")))
+        .collect()?;
 
-        let mut expected = df![
-            "a" => ["a", "b", "c"],
-            "b" => [1, 2, 3]
-        ]?;
-        expected.try_apply("a", |s| s.cast(&DataType::Categorical(None)))?;
-        assert!(out.frame_equal(&expected));
-
-        Ok(())
-    });
+    let mut expected = df![
+        "a" => ["a", "b", "c"],
+        "b" => [1, 2, 3]
+    ]?;
+    expected.try_apply("a", |s| s.cast(&DataType::Categorical(None)))?;
+    assert!(out.frame_equal(&expected));
     Ok(())
 }
 

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -1,6 +1,6 @@
 // used only if feature="is_in", feature="dtype-categorical"
 #[allow(unused_imports)]
-use polars_core::{StringCacheHolder, SINGLE_LOCK};
+use polars_core::{disable_string_cache, StringCacheHolder, SINGLE_LOCK};
 
 use super::*;
 

--- a/py-polars/docs/source/reference/functions.rst
+++ b/py-polars/docs/source/reference/functions.rst
@@ -51,4 +51,5 @@ and a decorator, in order to explicitly scope cache lifetime.
 
     StringCache
     enable_string_cache
+    disable_string_cache
     using_string_cache

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -182,7 +182,12 @@ from polars.io import (
 from polars.lazyframe import LazyFrame
 from polars.series import Series
 from polars.sql import SQLContext
-from polars.string_cache import StringCache, enable_string_cache, using_string_cache
+from polars.string_cache import (
+    StringCache,
+    disable_string_cache,
+    enable_string_cache,
+    using_string_cache,
+)
 from polars.type_aliases import PolarsDataType
 from polars.utils import build_info, get_index_type, show_versions, threadpool_size
 
@@ -277,6 +282,7 @@ __all__ = [
     "scan_pyarrow_dataset",
     # polars.stringcache
     "StringCache",
+    "disable_string_cache",
     "enable_string_cache",
     "using_string_cache",
     # polars.config

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -7,6 +7,7 @@ from polars.utils.deprecation import issue_deprecation_warning
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
+    from polars.polars import PyStringCacheHolder
 
 if TYPE_CHECKING:
     from types import TracebackType
@@ -56,7 +57,7 @@ class StringCache(contextlib.ContextDecorator):
     """
 
     def __enter__(self) -> StringCache:
-        plr._set_string_cache(True)
+        self._string_cache = PyStringCacheHolder()
         return self
 
     def __exit__(
@@ -65,7 +66,7 @@ class StringCache(contextlib.ContextDecorator):
         exc_val: BaseException | None,
         exc_tb: TracebackType | None,
     ) -> None:
-        plr._set_string_cache(False)
+        del self._string_cache
 
 
 def enable_string_cache(enable: bool | None = None) -> None:
@@ -132,8 +133,9 @@ def enable_string_cache(enable: bool | None = None) -> None:
             " and `disable_string_cache()` to disable the string cache.",
             version="0.19.3",
         )
-        plr._set_string_cache(enable)
-        return
+        if enable is False:
+            plr.disable_string_cache()
+            return
 
     plr.enable_string_cache()
 

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -54,6 +54,16 @@ class StringCache(contextlib.ContextDecorator):
             "green"
     ]
 
+    The class can also be used as a function decorator, in which case the string cache
+    is enabled during function execution, and disabled afterwards.
+
+    >>> @pl.StringCache()
+    ... def construct_categoricals() -> pl.Series:
+    ...     s1 = pl.Series("color", ["red", "green", "red"], dtype=pl.Categorical)
+    ...     s2 = pl.Series("color", ["blue", "red", "green"], dtype=pl.Categorical)
+    ...     return pl.concat([s1, s2])
+    ...
+
     """
 
     def __enter__(self) -> StringCache:
@@ -89,8 +99,8 @@ def enable_string_cache(enable: bool | None = None) -> None:
 
     See Also
     --------
-    enable_string_cache : Function to disable the string cache.
     StringCache : Context manager for enabling and disabling the string cache.
+    disable_string_cache : Function to disable the string cache.
 
     Notes
     -----
@@ -144,15 +154,17 @@ def disable_string_cache() -> bool:
     """
     Disable and clear the global string cache.
 
+    Warnings
+    --------
+    Disabling the string cache this way may cause errors if there are other threads
+    that rely the global string cache being enabled.
+    Consider using the :class:`StringCache` context manager for a more reliable way of
+    enabling and disabling the string cache.
+
     See Also
     --------
     enable_string_cache : Function to enable the string cache.
     StringCache : Context manager for enabling and disabling the string cache.
-
-    Notes
-    -----
-    Consider using the :class:`StringCache` context manager for a more reliable way of
-    enabling and disabling the string cache.
 
     Examples
     --------

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -154,17 +154,15 @@ def disable_string_cache() -> bool:
     """
     Disable and clear the global string cache.
 
-    Warnings
-    --------
-    Disabling the string cache this way may cause errors if there are other threads
-    that rely the global string cache being enabled.
-    Consider using the :class:`StringCache` context manager for a more reliable way of
-    enabling and disabling the string cache.
-
     See Also
     --------
     enable_string_cache : Function to enable the string cache.
     StringCache : Context manager for enabling and disabling the string cache.
+
+    Notes
+    -----
+    Consider using the :class:`StringCache` context manager for a more reliable way of
+    enabling and disabling the string cache.
 
     Examples
     --------

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -26,44 +26,32 @@ class StringCache(contextlib.ContextDecorator):
     The amount of overhead depends on the number of categories in your data.
     It is advised to enable the global string cache only when strictly necessary.
 
-    If ``StringCache``s are nested, the global string cache will only be disabled and
-    cleared when the outermost context exits.
+    If ``StringCache`` calls are nested, the global string cache will only be disabled
+    and cleared when the outermost context exits.
 
     Examples
     --------
-    Construct two dataframes using the same string cache.
+    Construct two Series using the same global string cache.
 
     >>> with pl.StringCache():
-    ...     df1 = pl.DataFrame(
-    ...         data={
-    ...             "color": ["red", "green", "blue", "orange"],
-    ...             "value": [1, 2, 3, 4],
-    ...         },
-    ...         schema={"color": pl.Categorical, "value": pl.UInt8},
-    ...     )
-    ...     df2 = pl.DataFrame(
-    ...         data={
-    ...             "color": ["yellow", "green", "orange", "black", "red"],
-    ...             "char": ["a", "b", "c", "d", "e"],
-    ...         },
-    ...         schema={"color": pl.Categorical, "char": pl.Utf8},
-    ...     )
+    ...     s1 = pl.Series("color", ["red", "green", "red"], dtype=pl.Categorical)
+    ...     s2 = pl.Series("color", ["blue", "red", "green"], dtype=pl.Categorical)
     ...
 
-    As both dataframes use the same string cache for the categorical column,
-    the column can be used in a join operation.
+    As both Series are constructed under the same global string cache,
+    they can be concatenated.
 
-    >>> df1.join(df2, how="inner", on="color")
-    shape: (3, 3)
-    ┌────────┬───────┬──────┐
-    │ color  ┆ value ┆ char │
-    │ ---    ┆ ---   ┆ ---  │
-    │ cat    ┆ u8    ┆ str  │
-    ╞════════╪═══════╪══════╡
-    │ green  ┆ 2     ┆ b    │
-    │ orange ┆ 4     ┆ c    │
-    │ red    ┆ 1     ┆ e    │
-    └────────┴───────┴──────┘
+    >>> pl.concat([s1, s2])
+    shape: (6,)
+    Series: 'color' [cat]
+    [
+            "red"
+            "green"
+            "red"
+            "blue"
+            "red"
+            "green"
+    ]
 
     """
 
@@ -114,30 +102,27 @@ def enable_string_cache(enable: bool | None = None) -> None:
 
     Examples
     --------
+    Construct two Series using the same global string cache.
+
     >>> pl.enable_string_cache()
-    >>> df1 = pl.DataFrame(
-    ...     data={"color": ["red", "green", "blue", "orange"], "value": [1, 2, 3, 4]},
-    ...     schema={"color": pl.Categorical, "value": pl.UInt8},
-    ... )
-    >>> df2 = pl.DataFrame(
-    ...     data={
-    ...         "color": ["yellow", "green", "orange", "black", "red"],
-    ...         "char": ["a", "b", "c", "d", "e"],
-    ...     },
-    ...     schema={"color": pl.Categorical, "char": pl.Utf8},
-    ... )
+    >>> s1 = pl.Series("color", ["red", "green", "red"], dtype=pl.Categorical)
+    >>> s2 = pl.Series("color", ["blue", "red", "green"], dtype=pl.Categorical)
     >>> pl.disable_string_cache()
-    >>> df1.join(df2, how="inner", on="color")
-    shape: (3, 3)
-    ┌────────┬───────┬──────┐
-    │ color  ┆ value ┆ char │
-    │ ---    ┆ ---   ┆ ---  │
-    │ cat    ┆ u8    ┆ str  │
-    ╞════════╪═══════╪══════╡
-    │ green  ┆ 2     ┆ b    │
-    │ orange ┆ 4     ┆ c    │
-    │ red    ┆ 1     ┆ e    │
-    └────────┴───────┴──────┘
+
+    As both Series are constructed under the same global string cache,
+    they can be concatenated.
+
+    >>> pl.concat([s1, s2])
+    shape: (6,)
+    Series: 'color' [cat]
+    [
+            "red"
+            "green"
+            "red"
+            "blue"
+            "red"
+            "green"
+    ]
 
     """
     if enable is not None:
@@ -169,30 +154,27 @@ def disable_string_cache() -> bool:
 
     Examples
     --------
+    Construct two Series using the same global string cache.
+
     >>> pl.enable_string_cache()
-    >>> df1 = pl.DataFrame(
-    ...     data={"color": ["red", "green", "blue", "orange"], "value": [1, 2, 3, 4]},
-    ...     schema={"color": pl.Categorical, "value": pl.UInt8},
-    ... )
-    >>> df2 = pl.DataFrame(
-    ...     data={
-    ...         "color": ["yellow", "green", "orange", "black", "red"],
-    ...         "char": ["a", "b", "c", "d", "e"],
-    ...     },
-    ...     schema={"color": pl.Categorical, "char": pl.Utf8},
-    ... )
+    >>> s1 = pl.Series("color", ["red", "green", "red"], dtype=pl.Categorical)
+    >>> s2 = pl.Series("color", ["blue", "red", "green"], dtype=pl.Categorical)
     >>> pl.disable_string_cache()
-    >>> df1.join(df2, how="inner", on="color")
-    shape: (3, 3)
-    ┌────────┬───────┬──────┐
-    │ color  ┆ value ┆ char │
-    │ ---    ┆ ---   ┆ ---  │
-    │ cat    ┆ u8    ┆ str  │
-    ╞════════╪═══════╪══════╡
-    │ green  ┆ 2     ┆ b    │
-    │ orange ┆ 4     ┆ c    │
-    │ red    ┆ 1     ┆ e    │
-    └────────┴───────┴──────┘
+
+    As both Series are constructed under the same global string cache,
+    they can be concatenated.
+
+    >>> pl.concat([s1, s2])
+    shape: (6,)
+    Series: 'color' [cat]
+    [
+            "red"
+            "green"
+            "red"
+            "blue"
+            "red"
+            "green"
+    ]
 
     """
     return plr.disable_string_cache()

--- a/py-polars/polars/string_cache.py
+++ b/py-polars/polars/string_cache.py
@@ -164,6 +164,9 @@ def disable_string_cache() -> bool:
     Consider using the :class:`StringCache` context manager for a more reliable way of
     enabling and disabling the string cache.
 
+    When used in conjunction with the :class:`StringCache` context manager, the string
+    cache will not be disabled until the context manager exits.
+
     Examples
     --------
     Construct two Series using the same global string cache.

--- a/py-polars/src/functions/meta.rs
+++ b/py-polars/src/functions/meta.rs
@@ -24,16 +24,6 @@ pub fn threadpool_size() -> usize {
 }
 
 #[pyfunction]
-pub fn enable_string_cache(toggle: bool) {
-    polars_core::enable_string_cache(toggle)
-}
-
-#[pyfunction]
-pub fn using_string_cache() -> bool {
-    polars_core::using_string_cache()
-}
-
-#[pyfunction]
 pub fn set_float_fmt(fmt: &str) -> PyResult<()> {
     let fmt = match fmt {
         "full" => FloatFmt::Full,

--- a/py-polars/src/functions/mod.rs
+++ b/py-polars/src/functions/mod.rs
@@ -6,4 +6,5 @@ pub mod meta;
 pub mod misc;
 pub mod random;
 pub mod range;
+pub mod string_cache;
 pub mod whenthen;

--- a/py-polars/src/functions/string_cache.rs
+++ b/py-polars/src/functions/string_cache.rs
@@ -1,10 +1,6 @@
 use polars_core;
+use polars_core::IUseStringCache;
 use pyo3::prelude::*;
-
-#[pyfunction]
-pub fn _set_string_cache(active: bool) {
-    polars_core::_set_string_cache(active)
-}
 
 #[pyfunction]
 pub fn enable_string_cache() {
@@ -19,4 +15,19 @@ pub fn disable_string_cache() {
 #[pyfunction]
 pub fn using_string_cache() -> bool {
     polars_core::using_string_cache()
+}
+
+#[pyclass]
+pub struct PyStringCacheHolder {
+    _inner: IUseStringCache,
+}
+
+#[pymethods]
+impl PyStringCacheHolder {
+    #[new]
+    fn new() -> Self {
+        Self {
+            _inner: IUseStringCache::hold(),
+        }
+    }
 }

--- a/py-polars/src/functions/string_cache.rs
+++ b/py-polars/src/functions/string_cache.rs
@@ -1,0 +1,17 @@
+use polars_core;
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub fn set_string_cache(toggle: bool) {
+    polars_core::enable_string_cache(toggle)
+}
+
+#[pyfunction]
+pub fn disable_string_cache() {
+    polars_core::reset_string_cache()
+}
+
+#[pyfunction]
+pub fn using_string_cache() -> bool {
+    polars_core::using_string_cache()
+}

--- a/py-polars/src/functions/string_cache.rs
+++ b/py-polars/src/functions/string_cache.rs
@@ -1,5 +1,5 @@
 use polars_core;
-use polars_core::IUseStringCache;
+use polars_core::StringCacheHolder;
 use pyo3::prelude::*;
 
 #[pyfunction]
@@ -19,7 +19,7 @@ pub fn using_string_cache() -> bool {
 
 #[pyclass]
 pub struct PyStringCacheHolder {
-    _inner: IUseStringCache,
+    _inner: StringCacheHolder,
 }
 
 #[pymethods]
@@ -27,7 +27,7 @@ impl PyStringCacheHolder {
     #[new]
     fn new() -> Self {
         Self {
-            _inner: IUseStringCache::hold(),
+            _inner: StringCacheHolder::hold(),
         }
     }
 }

--- a/py-polars/src/functions/string_cache.rs
+++ b/py-polars/src/functions/string_cache.rs
@@ -2,13 +2,18 @@ use polars_core;
 use pyo3::prelude::*;
 
 #[pyfunction]
-pub fn set_string_cache(toggle: bool) {
-    polars_core::enable_string_cache(toggle)
+pub fn _set_string_cache(active: bool) {
+    polars_core::_set_string_cache(active)
+}
+
+#[pyfunction]
+pub fn enable_string_cache() {
+    polars_core::enable_string_cache()
 }
 
 #[pyfunction]
 pub fn disable_string_cache() {
-    polars_core::reset_string_cache()
+    polars_core::disable_string_cache()
 }
 
 #[pyfunction]

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -211,10 +211,16 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::meta::threadpool_size))
         .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::meta::enable_string_cache))
+    m.add_wrapped(wrap_pyfunction!(functions::string_cache::set_string_cache))
         .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::meta::using_string_cache))
-        .unwrap();
+    m.add_wrapped(wrap_pyfunction!(
+        functions::string_cache::disable_string_cache
+    ))
+    .unwrap();
+    m.add_wrapped(wrap_pyfunction!(
+        functions::string_cache::using_string_cache
+    ))
+    .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::meta::set_float_fmt))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::meta::get_float_fmt))

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -55,6 +55,7 @@ use crate::error::{
     StructFieldNotFoundError,
 };
 use crate::expr::PyExpr;
+use crate::functions::string_cache::PyStringCacheHolder;
 use crate::lazyframe::PyLazyFrame;
 use crate::lazygroupby::PyLazyGroupBy;
 use crate::series::PySeries;
@@ -75,6 +76,7 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PyLazyFrame>().unwrap();
     m.add_class::<PyLazyGroupBy>().unwrap();
     m.add_class::<PyExpr>().unwrap();
+    m.add_class::<PyStringCacheHolder>().unwrap();
     #[cfg(feature = "csv")]
     m.add_class::<batched_csv::PyBatchedCsv>().unwrap();
     #[cfg(feature = "sql")]
@@ -210,8 +212,6 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_wrapped(wrap_pyfunction!(functions::meta::get_index_type))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::meta::threadpool_size))
-        .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::string_cache::_set_string_cache))
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(
         functions::string_cache::enable_string_cache

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -211,8 +211,12 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::meta::threadpool_size))
         .unwrap();
-    m.add_wrapped(wrap_pyfunction!(functions::string_cache::set_string_cache))
+    m.add_wrapped(wrap_pyfunction!(functions::string_cache::_set_string_cache))
         .unwrap();
+    m.add_wrapped(wrap_pyfunction!(
+        functions::string_cache::enable_string_cache
+    ))
+    .unwrap();
     m.add_wrapped(wrap_pyfunction!(
         functions::string_cache::disable_string_cache
     ))

--- a/py-polars/tests/docs/run_doctest.py
+++ b/py-polars/tests/docs/run_doctest.py
@@ -47,7 +47,7 @@ if TYPE_CHECKING:
 def doctest_teardown(d: doctest.DocTest) -> None:
     # don't let config changes or string cache state leak between tests
     polars.Config.restore_defaults()
-    polars.enable_string_cache(False)
+    polars.disable_string_cache()
 
 
 def modules_in_path(p: Path) -> Iterator[ModuleType]:

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1290,7 +1290,6 @@ def test_duration_arithmetic() -> None:
     )
 
 
-
 def test_assign() -> None:
     # check if can assign in case of a single column
     df = pl.DataFrame({"a": [1, 2, 3]})

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -8,8 +8,6 @@ import pytest
 
 import polars as pl
 from polars.config import _POLARS_CFG_ENV_VARS, _get_float_fmt
-from polars.exceptions import StringCacheMismatchError
-from polars.testing import assert_frame_equal
 
 
 @pytest.fixture(autouse=True)
@@ -509,33 +507,6 @@ def test_shape_format_for_big_numbers() -> None:
         "│ 1       ┆ … │\n"
         "╰─────────┴───╯"
     )
-
-
-def test_string_cache() -> None:
-    df1 = pl.DataFrame({"a": ["foo", "bar", "ham"], "b": [1, 2, 3]})
-    df2 = pl.DataFrame({"a": ["foo", "spam", "eggs"], "c": [3, 2, 2]})
-
-    # ensure cache is off when casting to categorical; the join will fail
-    pl.enable_string_cache(False)
-    assert pl.using_string_cache() is False
-
-    df1a = df1.with_columns(pl.col("a").cast(pl.Categorical))
-    df2a = df2.with_columns(pl.col("a").cast(pl.Categorical))
-    with pytest.raises(StringCacheMismatchError):
-        _ = df1a.join(df2a, on="a", how="inner")
-
-    # now turn on the cache
-    pl.enable_string_cache(True)
-    assert pl.using_string_cache() is True
-
-    df1b = df1.with_columns(pl.col("a").cast(pl.Categorical))
-    df2b = df2.with_columns(pl.col("a").cast(pl.Categorical))
-    out = df1b.join(df2b, on="a", how="inner")
-
-    expected = pl.DataFrame(
-        {"a": ["foo"], "b": [1], "c": [3]}, schema_overrides={"a": pl.Categorical}
-    )
-    assert_frame_equal(out, expected)
 
 
 @pytest.mark.write_disk()

--- a/py-polars/tests/unit/test_string_cache.py
+++ b/py-polars/tests/unit/test_string_cache.py
@@ -85,6 +85,16 @@ def test_string_cache_context_manager_mixed_with_enable_disable() -> None:
     sc(False)
 
 
+def test_string_cache_enable_arg_deprecated() -> None:
+    sc(False)
+    with pytest.deprecated_call():
+        pl.enable_string_cache(True)
+    sc(True)
+    with pytest.deprecated_call():
+        pl.enable_string_cache(False)
+    sc(False)
+
+
 def test_string_cache_join() -> None:
     df1 = pl.DataFrame({"a": ["foo", "bar", "ham"], "b": [1, 2, 3]})
     df2 = pl.DataFrame({"a": ["foo", "spam", "eggs"], "c": [3, 2, 2]})
@@ -112,11 +122,40 @@ def test_string_cache_join() -> None:
     assert_frame_equal(out, expected)
 
 
-def test_string_cache_enable_arg_deprecated() -> None:
-    sc(False)
-    with pytest.deprecated_call():
-        pl.enable_string_cache(True)
-    sc(True)
-    with pytest.deprecated_call():
-        pl.enable_string_cache(False)
-    sc(False)
+def test_string_cache_eager_lazy() -> None:
+    # tests if the global string cache is really global and not interfered by the lazy
+    # execution. first the global settings was thread-local and this breaks with the
+    # parallel execution of lazy
+    with pl.StringCache():
+        df1 = pl.DataFrame(
+            {"region_ids": ["reg1", "reg2", "reg3", "reg4", "reg5"]}
+        ).select([pl.col("region_ids").cast(pl.Categorical)])
+
+        df2 = pl.DataFrame(
+            {"seq_name": ["reg4", "reg2", "reg1"], "score": [3.0, 1.0, 2.0]}
+        ).select([pl.col("seq_name").cast(pl.Categorical), pl.col("score")])
+
+        expected = pl.DataFrame(
+            {
+                "region_ids": ["reg1", "reg2", "reg3", "reg4", "reg5"],
+                "score": [2.0, 1.0, None, 3.0, None],
+            }
+        ).with_columns(pl.col("region_ids").cast(pl.Categorical))
+
+        result = df1.join(df2, left_on="region_ids", right_on="seq_name", how="left")
+        assert_frame_equal(result, expected)
+
+        # also check row-wise categorical insert.
+        # (column-wise is preferred, but this shouldn't fail)
+        for params in (
+            {"schema": [("region_ids", pl.Categorical)]},
+            {
+                "schema": ["region_ids"],
+                "schema_overrides": {"region_ids": pl.Categorical},
+            },
+        ):
+            df3 = pl.DataFrame(  # type: ignore[arg-type]
+                data=[["reg1"], ["reg2"], ["reg3"], ["reg4"], ["reg5"]],
+                **params,
+            )
+            assert_frame_equal(df1, df3)

--- a/py-polars/tests/unit/test_string_cache.py
+++ b/py-polars/tests/unit/test_string_cache.py
@@ -74,14 +74,14 @@ def test_string_cache_context_manager_mixed_with_enable_disable() -> None:
         with pl.StringCache():
             sc(True)
             pl.disable_string_cache()
-            sc(False)
-        sc(False)
+            sc(True)
+        sc(True)
     sc(False)
 
     with pl.StringCache():
         sc(True)
         pl.disable_string_cache()
-        sc(False)
+        sc(True)
     sc(False)
 
 

--- a/py-polars/tests/unit/test_string_cache.py
+++ b/py-polars/tests/unit/test_string_cache.py
@@ -16,7 +16,7 @@ def _disable_string_cache() -> Iterator[None]:
 
 
 def sc(set: bool) -> None:
-    """Short syntax for checking whether string cache is set."""
+    """Short syntax for asserting whether the global string cache is being used."""
     assert pl.using_string_cache() is set
 
 
@@ -83,6 +83,28 @@ def test_string_cache_context_manager_mixed_with_enable_disable() -> None:
         pl.disable_string_cache()
         sc(False)
     sc(False)
+
+
+def test_string_cache_decorator() -> None:
+    @pl.StringCache()
+    def my_function() -> None:
+        sc(True)
+
+    sc(False)
+    my_function()
+    sc(False)
+
+
+def test_string_cache_decorator_mixed_with_enable() -> None:
+    @pl.StringCache()
+    def my_function() -> None:
+        sc(True)
+        pl.enable_string_cache()
+        sc(True)
+
+    sc(False)
+    my_function()
+    sc(True)
 
 
 def test_string_cache_enable_arg_deprecated() -> None:


### PR DESCRIPTION
Closes #10425

#### Changes

* Deprecate the boolean argument for `enable_string_cache`. The function now always enables the string cache.
* Add a new function `disable_string_cache`. This disables the string cache.
* Fix the implementation of the StringCache context manager.
* On the Rust side, rename `IUseStringCache` to `StringCacheHolder`. `IUse...` seemed like a weird name to me - but maybe I am missing some convention here.
* Some internal refactoring.

API is now consistent across the Rust and Python side - with the exception that Python offers a context manager instead of a RAII object.