### PR TITLE
fix(python): selectors by_name and by_dtype should allow empty list as input

### DIFF
--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -551,7 +551,7 @@ def by_dtype(
             raise TypeError(f"invalid dtype: {tp!r}")
 
     return _selector_proxy_(
-        F.col(*all_dtypes), name="by_dtype", parameters={"dtypes": all_dtypes}
+        F.col(all_dtypes), name="by_dtype", parameters={"dtypes": all_dtypes}
     )
 
 
@@ -620,7 +620,7 @@ def by_name(*names: str | Collection[str]) -> SelectorType:
             TypeError(f"Invalid name: {nm!r}")
 
     return _selector_proxy_(
-        F.col(*all_names), name="by_name", parameters={"*names": all_names}
+        F.col(all_names), name="by_name", parameters={"*names": all_names}
     )
 
 

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -55,6 +55,8 @@ def test_selector_by_dtype(df: pl.DataFrame) -> None:
         "fgg": pl.Boolean,
         "qqR": pl.Utf8,
     }
+    assert df.select(cs.by_dtype()).schema == {}
+    assert df.select(cs.by_dtype([])).schema == {}
 
 
 def test_selector_by_name(df: pl.DataFrame) -> None:
@@ -69,6 +71,8 @@ def test_selector_by_name(df: pl.DataFrame) -> None:
         "JJK",
         "qqR",
     ]
+    assert df.select(cs.by_name()).columns == []
+    assert df.select(cs.by_name([])).columns == []
 
 
 def test_selector_contains(df: pl.DataFrame) -> None:


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/10855

Currently the selectors are being created with an unpacked list `F.col(*all_names)`, but since `F.col` can manage iterables, by not unpacking we allow selecting nothing by inputing an empty list.

```python
import polars as pl
import polars.selectors as cs

cols_to_process = [] # This could come from an input file

# This works now
df = pl.DataFrame({"a": [1,2,3]}) 
df_processed = df.with_columns(cs.by_name(cols_to_process) * 2)
```

Fixing this in my opinion gives more consistency on how some functions work: `with_columns` also works with empty lists for example. 