### PR TITLE
feat: More dtypes supports cast to list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 [workspace.dependencies.arrow]
 package = "arrow2"
 git = "https://github.com/jorgecarleitao/arrow2"
-rev = "ba6a882bc1542b0b899774b696ebea77482b5c31"
+rev = "7c93e358fc400bf3c0c0219c22eefc6b38fc2d12"
 # branch = ""
 # version = "0.17.4"
 default-features = false

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
 [[package]]
 name = "arrow2"
 version = "0.17.4"
-source = "git+https://github.com/jorgecarleitao/arrow2?rev=ba6a882bc1542b0b899774b696ebea77482b5c31#ba6a882bc1542b0b899774b696ebea77482b5c31"
+source = "git+https://github.com/jorgecarleitao/arrow2?rev=7c93e358fc400bf3c0c0219c22eefc6b38fc2d12#7c93e358fc400bf3c0c0219c22eefc6b38fc2d12"
 dependencies = [
  "ahash",
  "arrow-format",
@@ -116,6 +116,7 @@ dependencies = [
  "futures",
  "getrandom",
  "hash_hasher",
+ "hashbrown 0.14.0",
  "lexical-core",
  "lz4",
  "multiversion",


### PR DESCRIPTION
This closes #10709.

Upstream pull request: https://github.com/jorgecarleitao/arrow2/pull/1567. Please review it first. :)

I will change the `arrow2` dependency to the correct upstream `rev` after that being merged.
