### PR TITLE
docs(python): Adds missing method refs in LazyDataFrame API docs

### DIFF
--- a/py-polars/docs/source/reference/dataframe/modify_select.rst
+++ b/py-polars/docs/source/reference/dataframe/modify_select.rst
@@ -7,6 +7,7 @@ Manipulation/selection
    :toctree: api/
 
     DataFrame.bottom_k
+    DataFrame.cast
     DataFrame.clear
     DataFrame.clone
     DataFrame.drop

--- a/py-polars/docs/source/reference/functions.rst
+++ b/py-polars/docs/source/reference/functions.rst
@@ -31,6 +31,7 @@ Parallelization
    :toctree: api/
 
    collect_all
+   collect_all_async
 
 Random
 ~~~~~~

--- a/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
+++ b/py-polars/docs/source/reference/lazyframe/miscellaneous.rst
@@ -8,6 +8,7 @@ Miscellaneous
 
     LazyFrame.cache
     LazyFrame.collect
+    LazyFrame.collect_async
     LazyFrame.fetch
     LazyFrame.lazy
     LazyFrame.map

--- a/py-polars/docs/source/reference/lazyframe/modify_select.rst
+++ b/py-polars/docs/source/reference/lazyframe/modify_select.rst
@@ -9,6 +9,7 @@ Manipulation/selection
     LazyFrame.approx_n_unique
     LazyFrame.approx_unique
     LazyFrame.bottom_k
+    LazyFrame.cast
     LazyFrame.clear
     LazyFrame.clone
     LazyFrame.drop


### PR DESCRIPTION
This PR adds missing methods to the API docs, so they are shown in `LazyDataFrame`'s [API docs](https://pola-rs.github.io/polars/py-polars/html/reference/lazyframe/index.html).