### PR TITLE
fix: improve error handling for malformed csv parsing

### DIFF
--- a/crates/polars-io/src/csv/parser.rs
+++ b/crates/polars-io/src/csv/parser.rs
@@ -429,6 +429,16 @@ pub(super) fn parse_lines<'a>(
                 Some((mut field, needs_escaping)) => {
                     let field_len = field.len();
 
+                    if needs_escaping && !ignore_errors {
+                        let has_closing_quote =
+                            field_len > 1 && Some(field[field_len - 1]) == quote_char;
+                        polars_ensure!(
+                            has_closing_quote,
+                            ComputeError: "field '{}' is missing a closing quote",
+                            String::from_utf8_lossy(&field)
+                        );
+                    }
+
                     // +1 is the split character that is consumed by the iterator.
                     read_sol += field_len + 1;
 

--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -576,6 +576,17 @@ impl<'a> CoreReader<'a> {
             return Ok(df);
         }
 
+        if !self.ignore_errors {
+            if let Some(quote) = self.quote_char {
+                let quote_count = bytes.iter().filter(|&&byte| byte == quote).count();
+                let has_even_quotes = quote_count % 2 == 0;
+                polars_ensure!(
+                    has_even_quotes,
+                    ComputeError: "odd number of quote characters in CSV file"
+                );
+            }
+        }
+
         // all the buffers returned from the threads
         // Structure:
         //      the inner vec has got buffers from all the columns.

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1548,3 +1548,16 @@ def test_provide_schema() -> None:
         "B": [None, "ragged", None],
         "C": [None, None, None],
     }
+
+
+@pytest.mark.parametrize(
+    ("input_csv", "expected_error"),
+    [
+        (b"""a,b,c\n"A,C,E\nB,D,F""", r"odd number of quote characters in CSV file"),
+        (b"""a,b,c\nA,"C,"E\nB,D,F""", r"field '\"C,\"E' is missing a closing quote"),
+    ],
+    ids=["odd_quotes", "missing_closing_quote"],
+)
+def test_csv_quote_mismatch(input_csv: bytes, expected_error: str) -> None:
+    with pytest.raises(pl.ComputeError, match=expected_error):
+        pl.read_csv(input_csv)


### PR DESCRIPTION
Fixes #11019.

This pull request introduces two checks to enhance error handling when parsing CSV files, particularly in cases where quote characters are improperly placed:

1. **Global Scope Check (File-Level):** We now verify that the count of quote characters is even at the global, whole-file scope. An odd count of quote characters signifies a malformed CSV. Escaping a quote is achieved by doubling it (e.g., "ab""cd""de") and so the contract is upheld.
2. **Local Scope Check (Field-Level):** We examine the last character in each field, ensuring that it is a quote character. Additionally we confirm that the field length is at least 2 bytes. This prevents situations where a field consists solely of a quote character. This check is performed if the first byte of a field is a quote character.

Both tests are performed only if `quote_char == Some(x)`.

The checks improve an error handling when trying to parse csv like:
```
a,b,c
A,"B,C
```  
or:
```
a,b,c
A,"B,"C  
```