### PR TITLE
fix(python): fix partial schema init with `read_dicts` and reduce latency of small-frame creation

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1090,14 +1090,14 @@ def _sequence_of_dict_to_pydf(
     )
     dicts_schema = (
         include_unknowns(schema_overrides, column_names or list(schema_overrides))
-        if schema_overrides and column_names
+        if column_names
         else None
     )
     pydf = PyDataFrame.read_dicts(data, infer_schema_length, dicts_schema)
 
-    if not schema_overrides and set(pydf.columns()) == set(column_names):
-        pass
-    elif column_names or schema_overrides:
+    # TODO: we can remove this `schema_overrides` block completely
+    #  once https://github.com/pola-rs/polars/issues/11044 is fixed
+    if schema_overrides:
         pydf = _post_apply_columns(
             pydf,
             columns=column_names,


### PR DESCRIPTION
Closes #10943.

@ritchie46 (and @hxzhao527, ref: #10954), as discussed:

This fixes an issue with partial schema creation and addresses the consistency of init from disjoint colnames; also reduces the latency of most "list of dicts" small-frame creation by letting the Rust-side constructor handle almost everything, avoiding Python-side set-construction and unnecessary calls into `_post_apply_columns`, which is the sort of thing that makes @jakob-keller happy ;) 

If we can fix https://github.com/pola-rs/polars/issues/11044 then we will be able to avoid _all_ calls into  `_post_apply_columns` for this constructor.