### PR TITLE
feat(rust): add support for nextest

### DIFF
--- a/crates/Makefile
+++ b/crates/Makefile
@@ -55,6 +55,19 @@ test:  ## Run tests
 		-- \
 		--test-threads=2
 
+.PHONY: nextest
+nextest:  ## Run tests with nextest
+	cargo nextest run --all-features \
+		-p polars-lazy \
+		-p polars-io \
+		-p polars-core \
+		-p polars-arrow \
+		-p polars-time \
+		-p polars-utils \
+		-p polars-row \
+		-p polars-sql \
+		-p polars-plan \
+
 .PHONY: integration-tests
 integration-tests:  ## Run integration tests
 	cargo test --all-features --test it -p polars


### PR DESCRIPTION
This adds `make nextest` to the `crates` makefile, which runs the Rust tests using [`nextest`](https://nexte.st/) (`cargo install cargo-nextest`).

This reduced (not counting the compilation time) the time taken to run the Rust tests from like 2 minutes to 0.6 seconds on my machine.