### PR TITLE
tests(python): account for version-based issue with pyarrow datetime units in tests

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -196,6 +196,7 @@ filterwarnings = [
   "error",
   # ...except where it prevents test debugging in an IPython console
   "ignore:.*unrecognized arguments.*PyDevIPCompleter:DeprecationWarning",
+  "ignore:.*is_sparse is deprecated.*:FutureWarning",
 ]
 xfail_strict = true
 

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -6,7 +6,9 @@
 
 # Dependencies
 dataframe-api-compat >= 0.1.6
-deltalake >= 0.10.0
+# pin deltalake until issues with pyarrow 13 resolved
+# https://github.com/delta-io/delta-rs/pull/1602
+deltalake == 0.10.1
 numpy
 pandas
 pyarrow

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -566,15 +566,18 @@ def test_to_pandas() -> None:
             pl.col("f").cast(pl.Categorical).alias("i"),
         ]
     )
+
     pd_out = df.to_pandas()
+    ns_datetimes = pa.__version__ < "13"
+
     pd_out_dtypes_expected = [
         np.dtype(np.uint8),
         np.dtype(np.float64),
         np.dtype(np.float64),
-        np.dtype("datetime64[ms]"),
+        np.dtype(f"datetime64[{'ns' if ns_datetimes else 'ms'}]"),
         np.dtype(np.object_),
         np.dtype(np.object_),
-        np.dtype("datetime64[us]"),
+        np.dtype(f"datetime64[{'ns' if ns_datetimes else 'us'}]"),
         pd.CategoricalDtype(categories=["a", "b", "c"], ordered=False),
         pd.CategoricalDtype(categories=["e", "f"], ordered=False),
     ]


### PR DESCRIPTION
Latest `deltalake` pinned `pyarrow` at `< 13`, causing some unit test failures on package update (as we had previously updated the test to handle the changes in 13 and got unexpectedly reverted back to 12 by their pin).