### PR TITLE
fix(rust, python): Correct field dtype of string concat

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -89,7 +89,7 @@ impl StringFunction {
         use StringFunction::*;
         match self {
             #[cfg(feature = "concat_str")]
-            ConcatVertical(_) | ConcatHorizontal(_) => mapper.with_same_dtype(),
+            ConcatVertical(_) | ConcatHorizontal(_) => mapper.with_dtype(DataType::Utf8),
             #[cfg(feature = "regex")]
             Contains { .. } => mapper.with_dtype(DataType::Boolean),
             CountMatches(_) => mapper.with_dtype(DataType::UInt32),

--- a/py-polars/tests/unit/functions/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/test_as_datatype.py
@@ -514,6 +514,16 @@ def test_concat_str_wildcard_expansion() -> None:
     ).to_series().to_list() == ["xs", "yo", "zs"]
 
 
+def test_concat_str_with_non_utf8_col() -> None:
+    out = (
+        pl.LazyFrame({"a": [0], "b": ["x"]})
+        .select(pl.concat_str(["a", "b"], separator="-").fill_null(pl.col("a")))
+        .collect()
+    )
+    expected = pl.Series("a", ["0-x"], dtype=pl.Utf8)
+    assert_series_equal(out.to_series(), expected)
+
+
 def test_format() -> None:
     df = pl.DataFrame({"a": ["a", "b", "c"], "b": [1, 2, 3]})
 


### PR DESCRIPTION
This try to fix #11050.