### PR TITLE
docs(python): put `fetch` explanation in a "notes" block to better highlight it in the docs

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2151,14 +2151,6 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Collect a small number of rows for debugging purposes.
 
-        Fetch is like a :func:`collect` operation, but it overwrites the number of rows
-        read by every scan operation. This is a utility that helps debug a query on a
-        smaller number of rows.
-
-        Note that the fetch does not guarantee the final number of rows in the
-        DataFrame. Filter, join operations and a lower number of rows available in the
-        scanned file influence the final number of rows.
-
         Parameters
         ----------
         n_rows
@@ -2181,6 +2173,17 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Common subexpressions will be cached and reused.
         streaming
             Run parts of the query in a streaming fashion (this is in an alpha state)
+
+        Notes
+        -----
+        This is similar to a :func:`collect` operation, but it overwrites the number of
+        rows read by *every* scan operation. This is strictly a utility function that
+        can help to debug a query using a smaller number of rows, and should *not* be
+        used in production code.
+
+        Be aware that ``fetch`` does not guarantee the final number of rows in the
+        DataFrame. Filter, join operations and fewer rows being available in
+        the scanned file will all influence the final number of rows.
 
         Returns
         -------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2177,13 +2177,16 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         Notes
         -----
         This is similar to a :func:`collect` operation, but it overwrites the number of
-        rows read by *every* scan operation. This is strictly a utility function that
-        can help to debug a query using a smaller number of rows, and should *not* be
-        used in production code.
+        rows read by *every* scan operation. Be aware that ``fetch`` does not guarantee
+        the final number of rows in the DataFrame. Filters, join operations and fewer
+        rows being available in the scanned data will all influence the final number
+        of rows (joins are especially susceptible to this, and may return no data
+        at all if ``n_rows`` is too small as the joi keys may not be present).
 
-        Be aware that ``fetch`` does not guarantee the final number of rows in the
-        DataFrame. Filter, join operations and fewer rows being available in
-        the scanned file will all influence the final number of rows.
+        Warnings
+        --------
+        This is strictly a utility function that can help to debug queries using a
+        smaller number of rows, and should *not* be used in production code.
 
         Returns
         -------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2181,7 +2181,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         the final number of rows in the DataFrame. Filters, join operations and fewer
         rows being available in the scanned data will all influence the final number
         of rows (joins are especially susceptible to this, and may return no data
-        at all if ``n_rows`` is too small as the joi keys may not be present).
+        at all if ``n_rows`` is too small as the join keys may not be present).
 
         Warnings
         --------


### PR DESCRIPTION
Minor improvements to `fetch` docstring.

(Might even be worth further emphasising the _"this is a debug function"_ part in a `warning` block?)