### PR TITLE
Optionally cache results of `polars.datatypes.is_polars_dtype()`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -889,7 +889,7 @@ class Expr:
         ):
             if isinstance(item, str):
                 exclude_cols.append(item)
-            elif is_polars_dtype(item):
+            elif is_polars_dtype(item, use_cache=True):
                 exclude_dtypes.append(item)
             else:
                 raise TypeError(

--- a/py-polars/polars/functions/col.py
+++ b/py-polars/polars/functions/col.py
@@ -208,7 +208,7 @@ class ColumnFactory:
             item = names[0]
             if isinstance(item, str):
                 return wrap_expr(plr.cols(names))
-            elif is_polars_dtype(item):
+            elif is_polars_dtype(item, use_cache=True):
                 return wrap_expr(plr.dtype_cols(names))
             else:
                 raise TypeError(

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -544,7 +544,7 @@ def by_dtype(
             all_dtypes.append(tp)  # type: ignore[arg-type]
         elif isinstance(tp, Collection):
             for t in tp:
-                if not is_polars_dtype(t):
+                if not is_polars_dtype(t, use_cache=True):
                     raise TypeError(f"invalid dtype: {t!r}")
                 all_dtypes.append(t)
         else:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -249,7 +249,7 @@ class Series:
         # Raise early error on invalid dtype
         if (
             dtype is not None
-            and not is_polars_dtype(dtype)
+            and not is_polars_dtype(dtype, use_cache=True)
             and py_type_to_dtype(dtype, raise_unmatched=False) is None
         ):
             raise ValueError(

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -404,7 +404,7 @@ def sequence_to_pyseries(
     if (
         dtype is not None
         and dtype not in (List, Struct, Unknown)
-        and is_polars_dtype(dtype)
+        and is_polars_dtype(dtype, use_cache=True)
         and (python_dtype is None)
     ):
         constructor = polars_type_to_constructor(dtype)
@@ -707,7 +707,11 @@ def _unpack_schema(
                 col for col in column_dtypes if col not in column_names
             ]
     for col, dtype in column_dtypes.items():
-        if not is_polars_dtype(dtype, include_unknown=True) and dtype is not None:
+        if not is_polars_dtype(
+            dtype,  # type: ignore[call-overload]
+            include_unknown=True,
+            use_cache=True,
+        ):
             column_dtypes[col] = py_type_to_dtype(dtype)
 
     return (


### PR DESCRIPTION
Support optional caching of `polars.datatypes.is_polars_dtype()`. This avoids expensive and repetitive calls to `is instance()`. Caching is only possible for hashable `dtype` arguments.

More comprehensive alternative to #11059.