### PR TITLE
fix: Filter on empty objectChunked should not throw error

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -104,6 +104,7 @@ impl ChunkFilter<ListType> for ListChunked {
                 )),
             };
         }
+        check_filter_len!(self, filter);
         Ok(unsafe {
             arity::binary_unchecked_same_type(
                 self,
@@ -129,6 +130,7 @@ impl ChunkFilter<FixedSizeListType> for ArrayChunked {
                 )),
             };
         }
+        check_filter_len!(self, filter);
         Ok(unsafe {
             arity::binary_unchecked_same_type(
                 self,
@@ -157,7 +159,7 @@ where
                 _ => Ok(ObjectChunked::new_empty(self.name())),
             };
         }
-        polars_ensure!(!self.is_empty(), NoData: "cannot filter empty object array");
+        check_filter_len!(self, filter);
         let chunks = self.downcast_iter().collect::<Vec<_>>();
         let mut builder = ObjectChunkedBuilder::<T>::new(self.name(), self.len());
         for (idx, mask) in filter.into_iter().enumerate() {

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -1,4 +1,7 @@
+import pytest
+
 import polars as pl
+from polars import PolarsDataType
 from polars.testing import assert_frame_equal
 
 
@@ -48,6 +51,15 @@ def test_filter_is_in_4572() -> None:
         .agg(pl.col("k").filter(pl.col("k").is_in(["a"])).implode())
     )
     assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "dtype", [pl.Int32, pl.Boolean, pl.Utf8, pl.Binary, pl.List(pl.Int64), pl.Object]
+)
+def test_filter_on_empty(dtype: PolarsDataType) -> None:
+    df = pl.DataFrame({"a": []}, schema={"a": dtype})
+    out = df.filter(pl.col("a").is_null())
+    assert out.is_empty()
 
 
 def test_filter_aggregation_any() -> None:


### PR DESCRIPTION
This fixes #10999.