### PR TITLE
refactor(python): simplify `SchemaDefinition` type alias

### DIFF
--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -55,7 +55,6 @@ PythonDataType: TypeAlias = Union[
 ]
 
 SchemaDefinition: TypeAlias = Union[
-    Sequence[str],
     Mapping[str, Union[PolarsDataType, PythonDataType]],
     Sequence[Union[str, Tuple[str, Union[PolarsDataType, PythonDataType, None]]]],
 ]


### PR DESCRIPTION
Trivial simplification of type alias `SchemaDefinition`:

```python
Union[
    Sequence[str],  # redundant: covered by more generic Sequence below
    Mapping[str, Union[PolarsDataType, PythonDataType]],
    Sequence[Union[str, Tuple[str, Union[PolarsDataType, PythonDataType, None]]]],
]
```