### PR TITLE
perf(python): optimize `_unpack_schema()`

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -678,42 +678,59 @@ def _unpack_schema(
     Works for any (name, dtype) pairs or schema dict input,
     overriding any inferred dtypes with explicit dtypes if supplied.
     """
-    if isinstance(schema, dict):
-        schema = list(schema.items())
-    column_names = [
-        (col or f"column_{i}") if isinstance(col, str) else col[0]
-        for i, col in enumerate(schema or [])
-    ]
-    if not column_names and n_expected:
-        column_names = [f"column_{i}" for i in range(n_expected)]
-    lookup = (
-        {
-            col: name
-            for col, name in zip_longest(column_names, lookup_names or [])
-            if name
+    # coerce schema_overrides to dict[str, PolarsDataType]
+    if schema_overrides:
+        schema_overrides = {
+            name: dtype
+            if is_polars_dtype(dtype, include_unknown=True)
+            else py_type_to_dtype(dtype)
+            for name, dtype in schema_overrides.items()
         }
+    else:
+        schema_overrides = {}
+
+    # fastpath for empty schema
+    if not schema:
+        return (
+            [f"column_{i}" for i in range(n_expected)] if n_expected else [],
+            schema_overrides,
+        )
+
+    # determine column names from schema
+    if isinstance(schema, dict):
+        column_names: list[str] = list(schema)
+        # coerce schema to list[str | tuple[str, PolarsDataType | PythonDataType | None]
+        schema = list(schema.items())
+    else:
+        column_names = [
+            (col or f"column_{i}") if isinstance(col, str) else col[0]
+            for i, col in enumerate(schema)
+        ]
+
+    # determine column dtypes from schema and lookup_names
+    lookup: dict[str, str] | None = (
+        {col: name for col, name in zip_longest(column_names, lookup_names) if name}
         if lookup_names
         else None
     )
-    column_dtypes = {
-        lookup.get(col[0], col[0]) if lookup else col[0]: col[1]
-        for col in (schema or [])
-        if not isinstance(col, str) and col[1] is not None
+    column_dtypes: dict[str, PolarsDataType] = {
+        lookup.get((name := col[0]), name)
+        if lookup
+        else col[0]: dtype  # type: ignore[misc]
+        if is_polars_dtype(dtype, include_unknown=True)
+        else py_type_to_dtype(dtype)
+        for col in schema
+        if isinstance(col, tuple) and (dtype := col[1]) is not None
     }
+
+    # apply schema overrides
     if schema_overrides:
         column_dtypes.update(schema_overrides)
-        if schema and include_overrides_in_columns:
-            column_names = column_names + [
-                col for col in column_dtypes if col not in column_names
-            ]
-    for col, dtype in column_dtypes.items():
-        if not is_polars_dtype(dtype, include_unknown=True) and dtype is not None:
-            column_dtypes[col] = py_type_to_dtype(dtype)
 
-    return (
-        column_names,  # type: ignore[return-value]
-        column_dtypes,
-    )
+        if include_overrides_in_columns:
+            column_names.extend(col for col in column_dtypes if col not in column_names)
+
+    return column_names, column_dtypes
 
 
 def _expand_dict_data(


### PR DESCRIPTION
Provides significant performance improvements to `pl.utils._construction._unpack_schema()`:

1. `python -m timeit -s "import polars as pl" "pl.utils._construction._unpack_schema(None)"`
487 nsec vs. 116 nsec per loop -> _4.20x_

1. `python -m timeit -s "import polars as pl; schema = tuple(f'col_{i}' for i in range(10))" "pl.utils._construction._unpack_schema(schema)"`
1.04 usec vs. 838 nsec per loop -> _1.24x_

1. `python -m timeit -s "import polars as pl; schema = {f'col_{i}': pl.Float64 for i in range(10)}" "pl.utils._construction._unpack_schema(schema)"`
2.82 usec vs. 1.85 usec per loop -> _1.52x_

1. `python -m timeit -s "import polars as pl; n_expected = 10; schema_overrides = {f'col_{i}': pl.Float64 for i in range(n_expected)}" "pl.utils._construction._unpack_schema(None, schema_overrides=schema_overrides, n_expected=n_expected)"`
3.44 usec vs. 2.13 usec per loop -> _1.15x_

1. ...