### PR TITLE
fix(python): don't conflate saved `Config` JSON string with file path

### DIFF
--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -33,7 +33,9 @@ Config load, save, and current state
    :toctree: api/
 
     Config.load
+    Config.load_from_file
     Config.save
+    Config.save_to_file
     Config.state
     Config.restore_defaults
 

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -193,7 +193,13 @@ class Config(contextlib.ContextDecorator):
         save: Save the current set of Config options as a JSON string or file.
 
         """
-        options = json.loads(cfg)
+        try:
+            options = json.loads(cfg)
+        except json.JSONDecodeError as err:
+            raise ValueError(
+                "invalid Config string (did you mean to use `load_from_file`?)"
+            ) from err
+
         os.environ.update(options.get("environment", {}))
         for cfg_methodname, value in options.get("direct", {}).items():
             if hasattr(cls, cfg_methodname):
@@ -216,7 +222,13 @@ class Config(contextlib.ContextDecorator):
         save: Save the current set of Config options as a JSON string or file.
 
         """
-        options = Path(normalize_filepath(file)).read_text()
+        try:
+            options = Path(normalize_filepath(file)).read_text()
+        except OSError as err:
+            raise ValueError(
+                f"invalid Config file (did you mean to use `load`?)\n{err}"
+            ) from err
+
         return cls.load(options)
 
     @classmethod

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -178,26 +178,46 @@ class Config(contextlib.ContextDecorator):
         self._original_state = ""
 
     @classmethod
-    def load(cls, cfg: Path | str) -> type[Config]:
+    def load(cls, cfg: str) -> type[Config]:
         """
-        Load and set previously saved (or shared) Config options from json/file.
+        Load (and set) previously saved Config options from a JSON string.
 
         Parameters
         ----------
         cfg : str
-            json string produced by ``Config.save()``, or a filepath to the same.
+            JSON string produced by ``Config.save()``.
+
+        See Also
+        --------
+        load_from_file : Load (and set) Config options from a JSON file.
+        save: Save the current set of Config options as a JSON string or file.
 
         """
-        options = json.loads(
-            Path(normalize_filepath(cfg)).read_text()
-            if isinstance(cfg, Path) or Path(cfg).exists()
-            else cfg
-        )
+        options = json.loads(cfg)
         os.environ.update(options.get("environment", {}))
         for cfg_methodname, value in options.get("direct", {}).items():
             if hasattr(cls, cfg_methodname):
                 getattr(cls, cfg_methodname)(value)
         return cls
+
+    @classmethod
+    def load_from_file(cls, file: Path | str) -> type[Config]:
+        """
+        Load (and set) previously saved Config options from file.
+
+        Parameters
+        ----------
+        file : Path | str
+            File path to a JSON string produced by ``Config.save()``.
+
+        See Also
+        --------
+        load : Load (and set) Config options from a JSON string.
+        save: Save the current set of Config options as a JSON string or file.
+
+        """
+        options = Path(normalize_filepath(file)).read_text()
+        return cls.load(options)
 
     @classmethod
     def restore_defaults(cls) -> type[Config]:
@@ -223,24 +243,24 @@ class Config(contextlib.ContextDecorator):
         return cls
 
     @classmethod
-    def save(cls, file: Path | str | None = None) -> str:
+    def save(cls) -> str:
         """
-        Save the current set of Config options as a json string or file.
+        Save the current set of Config options as a JSON string.
 
-        Parameters
-        ----------
-        file
-            optional path to a file into which the json string will be written.
+        See Also
+        --------
+        load : Load (and set) Config options from a JSON string.
+        load_from_file : Load (and set) Config options from a JSON file.
+        save_to_file : Save the current set of Config options as a JSON file.
 
         Examples
         --------
-        >>> cfg = pl.Config.save()
+        >>> json_str = pl.Config.save()
 
         Returns
         -------
         str
-            JSON string containing current Config options, or the path to the file where
-            the options are saved.
+            JSON string containing current Config options.
 
         """
         environment_vars = {
@@ -256,12 +276,32 @@ class Config(contextlib.ContextDecorator):
             {"environment": environment_vars, "direct": direct_vars},
             separators=(",", ":"),
         )
-        if isinstance(file, (str, Path)):
-            file = Path(normalize_filepath(file)).resolve()
-            file.write_text(options)
-            return str(file)
-
         return options
+
+    @classmethod
+    def save_to_file(cls, file: Path | str) -> None:
+        """
+        Save the current set of Config options as a JSON file.
+
+        Parameters
+        ----------
+        file
+            Optional path to a file into which the JSON string will be written.
+            Leave as ``None`` to return the JSON string directly.
+
+        See Also
+        --------
+        load : Load (and set) Config options from a JSON string.
+        load_from_file : Load (and set) Config options from a JSON file.
+        save : Save the current set of Config options as a JSON string.
+
+        Examples
+        --------
+        >>> json_file = pl.Config().save("~/polars/config.json")  # doctest: +SKIP
+
+        """
+        file = Path(normalize_filepath(file)).resolve()
+        file.write_text(cls.save())
 
     @classmethod
     @deprecate_nonkeyword_arguments(version="0.19.3")
@@ -274,12 +314,12 @@ class Config(contextlib.ContextDecorator):
         Parameters
         ----------
         if_set : bool
-            by default this will show the state of all ``Config`` environment variables.
+            By default this will show the state of all ``Config`` environment variables.
             change this to ``True`` to restrict the returned dictionary to include only
             those that have been set to a specific value.
 
         env_only : bool
-            include only Config environment variables in the output; some options (such
+            Include only Config environment variables in the output; some options (such
             as "set_fmt_float") are set directly, not via an environment variable.
 
         Examples
@@ -362,7 +402,7 @@ class Config(contextlib.ContextDecorator):
         Parameters
         ----------
         fmt : {"mixed", "full"}
-            How to format floating point numbers
+            How to format floating point numbers.
 
         """
         _set_float_fmt(fmt="mixed" if fmt is None else fmt)
@@ -376,7 +416,7 @@ class Config(contextlib.ContextDecorator):
         Parameters
         ----------
         n : int
-            number of characters to display
+            Number of characters to display.
 
         Examples
         --------
@@ -500,7 +540,7 @@ class Config(contextlib.ContextDecorator):
         Parameters
         ----------
         n : int
-            number of columns to display; if ``n < 0`` (eg: -1), display all columns.
+            Number of columns to display; if ``n < 0`` (eg: -1), display all columns.
 
         Examples
         --------
@@ -625,7 +665,7 @@ class Config(contextlib.ContextDecorator):
             * "NOTHING": No borders or other lines.
 
         rounded_corners : bool
-            apply rounded corners to UTF8-styled tables (no-op for ASCII formats).
+            Apply rounded corners to UTF8-styled tables (no-op for ASCII formats).
 
         Notes
         -----
@@ -799,7 +839,7 @@ class Config(contextlib.ContextDecorator):
         Parameters
         ----------
         n : int
-            number of rows to display; if ``n < 0`` (eg: -1), display all
+            Number of rows to display; if ``n < 0`` (eg: -1), display all
             rows (DataFrame) and all elements (Series).
 
         Examples
@@ -831,12 +871,12 @@ class Config(contextlib.ContextDecorator):
     @classmethod
     def set_tbl_width_chars(cls, width: int | None) -> type[Config]:
         """
-        Set the number of characters used to draw the table.
+        Set the maximum width of a table in characters.
 
         Parameters
         ----------
         width : int
-            number of chars
+            Maximum table width in characters.
 
         """
         if width is None:
@@ -847,7 +887,16 @@ class Config(contextlib.ContextDecorator):
 
     @classmethod
     def set_verbose(cls, active: bool | None = True) -> type[Config]:
-        """Enable additional verbose/debug logging."""
+        """
+        Enable additional verbose/debug logging.
+
+        Examples
+        --------
+        >>> pl.Config.set_verbose(True)  # doctest: +SKIP
+        >>> with pl.Config(verbose=True):  # doctest: +SKIP
+        ...     do_polars_operations()
+        ...
+        """
         if active is None:
             os.environ.pop("POLARS_VERBOSE", None)
         else:

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Iterator
+from pathlib import Path
+from typing import Any, Iterator
 
 import pytest
 
@@ -9,9 +10,6 @@ import polars as pl
 from polars.config import _POLARS_CFG_ENV_VARS, _get_float_fmt
 from polars.exceptions import StringCacheMismatchError
 from polars.testing import assert_frame_equal
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 @pytest.fixture(autouse=True)
@@ -570,6 +568,16 @@ def test_config_load_save(tmp_path: Path) -> None:
         if file is None:
             pl.Config.load(cfg)
         else:
+            with pytest.raises(ValueError, match="invalid Config file"):
+                pl.Config.load_from_file(cfg)
+
+            if isinstance(file, Path):
+                with pytest.raises(TypeError, match="the JSON object must be str"):
+                    pl.Config.load(file)  # type: ignore[arg-type]
+            else:
+                with pytest.raises(ValueError, match="invalid Config string"):
+                    pl.Config.load(file)
+
             pl.Config.load_from_file(file)
 
         # ...and confirm the saved options were set.

--- a/py-polars/tests/unit/test_cfg.py
+++ b/py-polars/tests/unit/test_cfg.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
-from typing import Any, Iterator
+from typing import TYPE_CHECKING, Any, Iterator
 
 import pytest
 
@@ -10,6 +9,9 @@ import polars as pl
 from polars.config import _POLARS_CFG_ENV_VARS, _get_float_fmt
 from polars.exceptions import StringCacheMismatchError
 from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @pytest.fixture(autouse=True)
@@ -540,15 +542,23 @@ def test_string_cache() -> None:
 
 @pytest.mark.write_disk()
 def test_config_load_save(tmp_path: Path) -> None:
-    for file in (None, tmp_path / "polars.config", str(tmp_path / "polars.config")):
+    for file in (
+        None,
+        tmp_path / "polars.config",
+        str(tmp_path / "polars.config"),
+    ):
         # set some config options...
         pl.Config.set_tbl_cols(12)
         pl.Config.set_verbose(True)
         pl.Config.set_fmt_float("full")
         assert os.environ.get("POLARS_VERBOSE") == "1"
 
-        cfg = pl.Config.save(file)
-        assert isinstance(cfg, str)
+        if file is None:
+            cfg = pl.Config.save()
+            assert isinstance(cfg, str)
+        else:
+            assert pl.Config.save_to_file(file) is None
+
         assert "POLARS_VERBOSE" in pl.Config.state(if_set=True)
 
         # ...modify the same options...
@@ -556,10 +566,11 @@ def test_config_load_save(tmp_path: Path) -> None:
         pl.Config.set_verbose(False)
         assert os.environ.get("POLARS_VERBOSE") == "0"
 
-        # ...load back from config...
-        if file is not None:
-            assert Path(cfg).is_file()
-        pl.Config.load(cfg)
+        # ...load back from config file/string...
+        if file is None:
+            pl.Config.load(cfg)
+        else:
+            pl.Config.load_from_file(file)
 
         # ...and confirm the saved options were set.
         assert os.environ.get("POLARS_FMT_MAX_COLS") == "12"
@@ -575,6 +586,19 @@ def test_config_load_save(tmp_path: Path) -> None:
         assert os.environ.get("POLARS_FMT_MAX_COLS") is None
         assert os.environ.get("POLARS_VERBOSE") is None
         assert _get_float_fmt() == "mixed"
+
+    # ref: #11094
+    with pl.Config(
+        streaming_chunk_size=100,
+        tbl_cols=2000,
+        tbl_formatting="UTF8_NO_BORDERS",
+        tbl_hide_column_data_types=True,
+        tbl_hide_dtype_separator=True,
+        tbl_rows=2000,
+        tbl_width_chars=2000,
+        verbose=True,
+    ):
+        assert isinstance(repr(pl.DataFrame({"xyz": [0]})), str)
 
 
 def test_config_scope() -> None:


### PR DESCRIPTION
Closes #11094 (and addresses https://github.com/pola-rs/polars/pull/9391#discussion_r1233426042).

As well as removing ambiguity, also now raises specific errors if a `Path` object is passed to `Config.load` or a JSON string is passed to `Config.load_from_file`.

**Also:**
Some (minor) docstring improvements, and additional test coverage.