### PR TITLE
feat(python): Support numpy.random.Generator objects as random seeds

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import contextlib
 import os
-import random
 from collections import defaultdict
 from collections.abc import Sized
 from io import BytesIO, StringIO, TextIOWrapper

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -97,6 +97,7 @@ from polars.utils.various import (
     is_str_sequence,
     normalize_filepath,
     parse_percentiles,
+    parse_random_seed,
     parse_version,
     range_to_slice,
     scale_bytes,
@@ -8679,7 +8680,7 @@ class DataFrame:
         fraction: float | None = None,
         with_replacement: bool = False,
         shuffle: bool = False,
-        seed: int | None = None,
+        seed: int | np.random.Generator | None = None,
     ) -> Self:
         """
         Sample from this DataFrame.
@@ -8725,8 +8726,7 @@ class DataFrame:
         if n is not None and fraction is not None:
             raise ValueError("cannot specify both `n` and `fraction`")
 
-        if seed is None:
-            seed = random.randint(0, 10000)
+        seed = parse_random_seed(seed)
 
         if n is None and fraction is not None:
             return self._from_pydf(
@@ -9375,10 +9375,10 @@ class DataFrame:
 
     def hash_rows(
         self,
-        seed: int = 0,
-        seed_1: int | None = None,
-        seed_2: int | None = None,
-        seed_3: int | None = None,
+        seed: int | np.random.Generator = 0,
+        seed_1: int | np.random.Generator | None = None,
+        seed_2: int | np.random.Generator | None = None,
+        seed_3: int | np.random.Generator | None = None,
     ) -> Series:
         """
         Hash and combine the rows in this DataFrame.
@@ -9415,10 +9415,10 @@ class DataFrame:
         ]
 
         """
-        k0 = seed
-        k1 = seed_1 if seed_1 is not None else seed
-        k2 = seed_2 if seed_2 is not None else seed
-        k3 = seed_3 if seed_3 is not None else seed
+        k0 = parse_random_seed(seed)
+        k1 = parse_random_seed(seed_1 if seed_1 is not None else seed)
+        k2 = parse_random_seed(seed_2 if seed_2 is not None else seed)
+        k3 = parse_random_seed(seed_3 if seed_3 is not None else seed)
         return wrap_s(self._df.hash_rows(k0, k1, k2, k3))
 
     def interpolate(self) -> DataFrame:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5655,7 +5655,7 @@ class Series:
         fraction: float | None = None,
         with_replacement: bool = False,
         shuffle: bool = False,
-        seed: int | None = None,
+        seed: int | np.random.Generator | None = None,
     ) -> Series:
         """
         Sample from this Series.
@@ -5761,10 +5761,10 @@ class Series:
 
     def hash(
         self,
-        seed: int = 0,
-        seed_1: int | None = None,
-        seed_2: int | None = None,
-        seed_3: int | None = None,
+        seed: int | np.random.Generator = 0,
+        seed_1: int | np.random.Generator | None = None,
+        seed_2: int | np.random.Generator | None = None,
+        seed_3: int | np.random.Generator | None = None,
     ) -> Series:
         """
         Hash the Series.
@@ -5847,7 +5847,7 @@ class Series:
         method: RankMethod = "average",
         *,
         descending: bool = False,
-        seed: int | None = None,
+        seed: int | np.random.Generator | None = None,
     ) -> Series:
         """
         Assign ranks to data, dealing with ties appropriately.
@@ -6304,7 +6304,7 @@ class Series:
 
         """
 
-    def shuffle(self, seed: int | None = None) -> Series:
+    def shuffle(self, seed: int | np.random.Generator | None = None) -> Series:
         """
         Shuffle the contents of this Series.
 

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import inspect
 import os
+import random
 import re
 import sys
-import random
 import warnings
 from collections.abc import MappingView, Sized
 from enum import Enum
@@ -24,12 +24,12 @@ from polars.datatypes import (
     unpack_dtypes,
 )
 from polars.dependencies import _PYARROW_AVAILABLE
-from polars.dependencies import numpy as np
 
 if TYPE_CHECKING:
     from collections.abc import Reversible
 
     from polars import DataFrame, Series
+    from polars.dependencies import numpy as np
     from polars.type_aliases import PolarsDataType, PolarsIntegerType, SizeUnit
 
     if sys.version_info >= (3, 10):
@@ -495,7 +495,8 @@ def parse_percentiles(percentiles: Sequence[float] | float | None) -> Sequence[f
 
 
 def parse_random_seed(seed: int | np.random.Generator | None) -> int:
-    """Parse the random seed, in case a numpy.random.Generator is used.
+    """
+    Parse the random seed, in case a numpy.random.Generator is used.
 
     If ``seed`` is None, a random seed is generated using the ``random`` module.
     If ``seed`` is a numpy.random.Generator, a random seed is generated from the

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -511,10 +511,9 @@ def parse_random_seed(seed: int | np.random.Generator | None) -> int:
     -------
     The random seed.
     """
-    try:
-        return seed.integers(0, 10000)
-    except AttributeError:
-        pass
+    # Originally this was a try/except clause, but mypy didn't like that.
+    if hasattr(seed, "integers"):
+        return seed.integers(0, 10000)  # type: ignore[union-attr]
 
     if seed is None:
         return random.randint(0, 10000)

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -4,6 +4,7 @@ import inspect
 import os
 import re
 import sys
+import random
 import warnings
 from collections.abc import MappingView, Sized
 from enum import Enum
@@ -23,6 +24,7 @@ from polars.datatypes import (
     unpack_dtypes,
 )
 from polars.dependencies import _PYARROW_AVAILABLE
+from polars.dependencies import numpy as np
 
 if TYPE_CHECKING:
     from collections.abc import Reversible
@@ -490,3 +492,30 @@ def parse_percentiles(percentiles: Sequence[float] | float | None) -> Sequence[f
         at_or_above_50_percentiles = [0.5, *at_or_above_50_percentiles]
 
     return [*sub_50_percentiles, *at_or_above_50_percentiles]
+
+
+def parse_random_seed(seed: int | np.random.Generator | None) -> int:
+    """Parse the random seed, in case a numpy.random.Generator is used.
+
+    If ``seed`` is None, a random seed is generated using the ``random`` module.
+    If ``seed`` is a numpy.random.Generator, a random seed is generated from the
+    Generator object.
+
+    Parameters
+    ----------
+    seed
+        The provided random seed, Generator, or ``None``.
+
+    Returns
+    -------
+    The random seed.
+    """
+    try:
+        return seed.integers(0, 10000)
+    except AttributeError:
+        pass
+
+    if seed is None:
+        return random.randint(0, 10000)
+
+    return seed

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1867,19 +1867,26 @@ def test_reproducible_hash_with_seeds() -> None:
 
 @pytest.mark.parametrize("seeds", [(11, 22, 33, 44), (11, None, None, None)])
 @pytest.mark.parametrize("use_numpy", [False, True])
-def test_hash_with_different_seed_types(seeds: tuple[int | None], use_numpy: bool) -> None:
-    """Test that hashes are at least consistent within a session.
+def test_hash_with_different_seed_types(
+    seeds: tuple[int | None], use_numpy: bool
+) -> None:
+    """
+    Test that hashes are at least consistent within a session.
 
     Verifies that int, numpy.random.Generator, None seeds yield reproducible hashes.
     """
     df = pl.DataFrame({"s": [1234, None, 5678]})
 
     def get_hash(df, seeds: tuple[int], use_numpy: bool) -> tuple[pl.Series]:
-        """A small helper function"""
+        """A small helper function."""
         if use_numpy:
             seeds = [np.random.default_rng(s) for s in seeds if s is not None]
 
-        return df.hash_rows(*seeds), df["s"].hash(*seeds), df.select([pl.col("s").hash(*seeds)])["s"]
+        return (
+            df.hash_rows(*seeds),
+            df["s"].hash(*seeds),
+            df.select([pl.col("s").hash(*seeds)])["s"],
+        )
 
     first_run = get_hash(df, seeds, use_numpy)
     second_run = get_hash(df, seeds, use_numpy)
@@ -1894,12 +1901,12 @@ def test_sample_with_different_seed_types(seed: int | None, use_numpy: bool) -> 
     df = pl.DataFrame({"s": [1234, None, 5678, 8765, 4321, 123, 456, 789]})
 
     def get_sample(df, seed: tuple[int], use_numpy: bool) -> tuple[pl.Series]:
-        """A small helper function"""
+        """A small helper function."""
         seed = np.random.default_rng(seed) if use_numpy else seed
         return (
             df.sample(fraction=1, shuffle=True, seed=seed)["s"],
             df["s"].sample(fraction=1, shuffle=True, seed=seed),
-            df.select([pl.col("s").sample(fraction=1, shuffle=True, seed=seed)])["s"]
+            df.select([pl.col("s").sample(fraction=1, shuffle=True, seed=seed)])["s"],
         )
 
     first_run = get_sample(df, seed, use_numpy)

--- a/py-polars/tests/unit/operations/test_random.py
+++ b/py-polars/tests/unit/operations/test_random.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
-import numpy as np
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
@@ -48,8 +48,12 @@ def test_sample_expr() -> None:
     assert_series_equal(result1, result2)
 
     # Similarly using a numpy.random.Generator:
-    result1 = pl.select(pl.lit(a).sample(n=10, seed=np.random.default_rng(1))).to_series()
-    result2 = pl.select(pl.lit(a).sample(n=10, seed=np.random.default_rng(1))).to_series()
+    result1 = pl.select(
+        pl.lit(a).sample(n=10, seed=np.random.default_rng(1))
+    ).to_series()
+    result2 = pl.select(
+        pl.lit(a).sample(n=10, seed=np.random.default_rng(1))
+    ).to_series()
     assert_series_equal(result1, result2)
 
 

--- a/py-polars/tests/unit/utils/test_various.py
+++ b/py-polars/tests/unit/utils/test_various.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import random
+
+import numpy as np
+import pytest
+from polars.utils.various import parse_random_seed
+
+
+@pytest.mark.parametrize(
+    ("seed", "expected"),
+    [
+        (42, 42),
+        (np.random.default_rng(42), 892),
+        (None, 2201),
+    ],
+)
+def test_parse_random_seed(
+    seed: int | np.random.Generator | None, expected: int
+) -> None:
+    """Check that the random seed is parsed correctly."""
+    random.seed(1)
+    assert parse_random_seed(seed) == expected

--- a/py-polars/tests/unit/utils/test_various.py
+++ b/py-polars/tests/unit/utils/test_various.py
@@ -4,6 +4,7 @@ import random
 
 import numpy as np
 import pytest
+
 from polars.utils.various import parse_random_seed
 
 


### PR DESCRIPTION
This PR implements the proposed enhancement from #11075, adding support for using `numpy.random.Generator` objects as random seeds for stochastic methods within Polars. I also tried to add unit tests in the relevant locations.