### PR TITLE
docs: Removed duplicated example

### DIFF
--- a/docs/user-guide/expressions/functions.md
+++ b/docs/user-guide/expressions/functions.md
@@ -17,12 +17,6 @@ By default if you perform an expression it will keep the same name as the origin
 
 {{code_block('user-guide/expressions/functions','samename',[])}}
 
-=== ":fontawesome-brands-python: Python"
-
-```python
---8<-- "python/user-guide/expressions/functions.py:samename"
-```
-
 ```python exec="on" result="text" session="user-guide/functions"
 --8<-- "python/user-guide/expressions/functions.py:samename"
 ```


### PR DESCRIPTION
Removed a duplicated example on polars-book

It was originally opened on the polars-book repository (https://github.com/pola-rs/polars-book/pull/405)
But it seems today the whole docs were moved to main