### PR TITLE
test(python): fix 'tz_aware.parquet' location in test (don't rely on implicit working directory)

### DIFF
--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import io
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -15,6 +14,8 @@ import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from polars.type_aliases import ParquetCompression
 
 
@@ -486,10 +487,8 @@ def test_parquet_string_cache() -> None:
     assert_series_equal(pl.read_parquet(f)["a"].cast(str), df["a"].cast(str))
 
 
-def test_tz_aware_parquet_9586() -> None:
-    result = pl.read_parquet(
-        Path("tests") / "unit" / "io" / "files" / "tz_aware.parquet"
-    )
+def test_tz_aware_parquet_9586(io_files_path: Path) -> None:
+    result = pl.read_parquet(io_files_path / "tz_aware.parquet")
     expected = pl.DataFrame(
         {"UTC_DATETIME_ID": [datetime(2023, 6, 26, 14, 15, 0, tzinfo=timezone.utc)]}
     ).select(pl.col("*").cast(pl.Datetime("ns", "UTC")))


### PR DESCRIPTION
Updates `test_tz_aware_parquet_9586` to use the `io_files_path` fixture instead of implicitly relying on the relative path from the working directory, which could result in a `FileNotFoundError`.