### PR TITLE
fix: Correct hash and fmt for struct expr

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -240,6 +240,8 @@ impl Hash for FunctionExpr {
             FunctionExpr::Boolean(f) => f.hash(state),
             #[cfg(feature = "strings")]
             FunctionExpr::StringExpr(f) => f.hash(state),
+            #[cfg(feature = "dtype-struct")]
+            FunctionExpr::StructExpr(f) => f.hash(state),
             #[cfg(feature = "random")]
             FunctionExpr::Random { method, .. } => method.hash(state),
             #[cfg(feature = "range")]

--- a/crates/polars-plan/src/dsl/function_expr/struct_.rs
+++ b/crates/polars-plan/src/dsl/function_expr/struct_.rs
@@ -13,8 +13,8 @@ impl Display for StructFunction {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use self::*;
         match self {
-            StructFunction::FieldByIndex(_) => write!(f, "struct.field_by_name"),
-            StructFunction::FieldByName(_) => write!(f, "struct.field_by_index"),
+            StructFunction::FieldByIndex(index) => write!(f, "struct.field_by_index({index})"),
+            StructFunction::FieldByName(name) => write!(f, "struct.field_by_name({name})"),
         }
     }
 }


### PR DESCRIPTION
`AExpr` containing `StructFunction::FieldByName` with different `field` names were calculated to have the same `hash` value, resulting in incorrect reuse by `cse`.

This fixes #11116.

