### PR TITLE
feat(python, rust): Adds `NULLIF` and `COALESCE` SQL functions

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1,6 +1,6 @@
 use polars_core::prelude::{polars_bail, polars_err, PolarsError, PolarsResult};
 use polars_lazy::dsl::Expr;
-use polars_plan::dsl::count;
+use polars_plan::dsl::{coalesce, count, when};
 use polars_plan::logical_plan::LiteralValue;
 use polars_plan::prelude::lit;
 use sqlparser::ast::{
@@ -232,6 +232,16 @@ pub(crate) enum PolarsSqlFunctions {
     /// SELECT UPPER(column_1) from df;
     /// ```
     Upper,
+    /// SQL 'nullif' function
+    /// ```sql
+    /// SELECT NULLIF(column_1, column_2) from df;
+    /// ```
+    NullIf,
+    /// SQL 'coalesce' function
+    /// ```sql
+    /// SELECT COALESCE(column_1, ...) from df;
+    /// ```
+    Coalesce,
 
     // ----
     // Aggregate functions
@@ -389,6 +399,7 @@ impl PolarsSqlFunctions {
             "cbrt",
             "ceil",
             "ceiling",
+            "coalesce",
             "cos",
             "cosd",
             "cot",
@@ -411,6 +422,7 @@ impl PolarsSqlFunctions {
             "ltrim",
             "max",
             "min",
+            "nullif",
             "octet_length",
             "pi",
             "pow",
@@ -475,6 +487,12 @@ impl TryFrom<&'_ SQLFunction> for PolarsSqlFunctions {
             "sqrt" => Self::Sqrt,
             "cbrt" => Self::Cbrt,
             "round" => Self::Round,
+
+            // ----
+            // Comparison functions
+            // ----
+            "nullif" => Self::NullIf,
+            "coalesce" => Self::Coalesce,
 
             // ----
             // String functions
@@ -580,6 +598,13 @@ impl SqlFunctionVisitor<'_> {
                     polars_bail!(InvalidOperation:"Invalid number of arguments for Round: {}",function.args.len());
                 },
             },
+
+            // ----
+            // Comparison functions
+            // ----
+            NullIf => self.visit_binary(|l, r: Expr| when(l.clone().eq(r)).then(lit(crate::functions::LiteralValue::Null)).otherwise(l)),
+            Coalesce => self.visit_variadic(coalesce),
+
             // ----
             // String functions
             // ----
@@ -778,6 +803,24 @@ impl SqlFunctionVisitor<'_> {
             },
             _ => self.not_supported_error(),
         }
+    }
+
+    fn visit_variadic(&self, f: impl Fn(&[Expr]) -> Expr) -> PolarsResult<Expr> {
+        self.try_visit_variadic(|e| Ok(f(e)))
+    }
+
+    fn try_visit_variadic(&self, f: impl Fn(&[Expr]) -> PolarsResult<Expr>) -> PolarsResult<Expr> {
+        let function = self.func;
+        let args = extract_args(function);
+        let mut expr_args = vec![];
+        for arg in args {
+            if let FunctionArgExpr::Expr(sql_expr) = arg {
+                expr_args.push(parse_sql_expr(sql_expr, self.ctx)?);
+            } else {
+                return self.not_supported_error();
+            };
+        }
+        f(&expr_args)
     }
 
     // fn visit_ternary<Arg: FromSqlExpr>(

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -602,7 +602,7 @@ impl SqlFunctionVisitor<'_> {
             // ----
             // Comparison functions
             // ----
-            NullIf => self.visit_binary(|l, r: Expr| when(l.clone().eq(r)).then(lit(crate::functions::LiteralValue::Null)).otherwise(l)),
+            NullIf => self.visit_binary(|l, r: Expr| when(l.clone().eq(r)).then(lit(LiteralValue::Null)).otherwise(l)),
             Coalesce => self.visit_variadic(coalesce),
 
             // ----


### PR DESCRIPTION
Adds a pair of functions from the Postgres SQL documentation:
https://www.postgresql.org/docs/current/functions-conditional.html#FUNCTIONS-COALESCE-NVL-IFNULL

I'm getting SQL issues from here: https://github.com/pola-rs/polars/issues/7227

Apparently these were community requested, I cannot find who requested them.  
