### PR TITLE
docs: remove low contrast coloring from visited links

### DIFF
--- a/py-polars/docs/source/_static/css/custom.css
+++ b/py-polars/docs/source/_static/css/custom.css
@@ -43,3 +43,7 @@ div.bd-sidebar-secondary {
 label.sidebar-toggle.secondary-toggle {
     display: none !important;
 }
+
+a:visited {
+    color: var(--pst-color-link);
+}


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/11029. The issue is caused by an upstream change to the sphinx theme (https://github.com/sphinx-doc/sphinx/commit/23c7fdde756b6394c1f60ab0b78c4699ccd3a8f4) which added styling to visited links. This PR explicitly sets the styling of visited links to override it.
