### PR TITLE
fix: lock chrono to <0.4.31 due to deprecations of "timestamp_nanos"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ahash = "0.8"
 atoi = "2"
 bitflags = "2"
 bytemuck = { version = "1", features = ["derive", "extern_crate_alloc"] }
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "<0.4.31", default-features = false, features = ["std"] }
 chrono-tz = "0.8.1"
 ciborium = "0.2"
 either = "1.8"


### PR DESCRIPTION
CI is breaking across the board because of a deprecation in chrono`0.4.31`

This locks the version to <0.4.31. 

see https://github.com/pola-rs/polars/issues/11145 for more info