### PR TITLE
fix(python): address unexpected expression name from use of unary `-` or `+` operators

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -195,7 +195,10 @@ class Expr:
         return self._from_pyexpr(self._pyexpr.neq(self._to_expr(other)._pyexpr))
 
     def __neg__(self) -> Expr:
-        return F.lit(0) - self
+        neg_expr = F.lit(0) - self
+        if (name := self.meta.output_name(raise_if_undetermined=False)) is not None:
+            neg_expr = neg_expr.alias(name)
+        return neg_expr
 
     def __or__(self, other: Expr | int | bool) -> Self:
         return self._from_pyexpr(self._pyexpr._or(self._to_pyexpr(other)))
@@ -204,7 +207,10 @@ class Expr:
         return self._from_pyexpr(self._to_pyexpr(other)._or(self._pyexpr))
 
     def __pos__(self) -> Expr:
-        return F.lit(0) + self
+        pos_expr = F.lit(0) + self
+        if (name := self.meta.output_name(raise_if_undetermined=False)) is not None:
+            pos_expr = pos_expr.alias(name)
+        return pos_expr
 
     def __pow__(self, power: int | float | Series | Expr) -> Self:
         return self.pow(power)

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -4,6 +4,7 @@ from io import BytesIO, StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, overload
 
+from polars.exceptions import ComputeError
 from polars.utils._wrap import wrap_expr
 from polars.utils.deprecation import deprecate_nonkeyword_arguments
 from polars.utils.various import normalize_filepath
@@ -88,12 +89,21 @@ class ExprMetaNameSpace:
         """
         return self._pyexpr.meta_is_regex_projection()
 
-    def output_name(self) -> str:
+    @overload
+    def output_name(self, *, raise_if_undetermined: Literal[True] = True) -> str:
+        ...
+
+    @overload
+    def output_name(self, *, raise_if_undetermined: Literal[False]) -> str | None:
+        ...
+
+    def output_name(self, *, raise_if_undetermined: bool = True) -> str | None:
         """
         Get the column name that this expression would produce.
 
-        It may not always be possible to determine the output name, as that can depend
-        on the schema of the context; in that case this will raise ``ComputeError``.
+        It may not always be possible to determine the output name as that can depend
+        on the schema of the context; in that case this will raise ``ComputeError`` if
+        ``raise_if_undetermined`` is True (the default), or ``None`` otherwise.
 
         Examples
         --------
@@ -109,12 +119,16 @@ class ExprMetaNameSpace:
         >>> e_sum_slice = pl.sum("foo").slice(pl.count() - 10, pl.col("bar"))
         >>> e_sum_slice.meta.output_name()
         'foo'
-        >>> e_count = pl.count()
-        >>> e_count.meta.output_name()
+        >>> pl.count().meta.output_name()
         'count'
 
         """
-        return self._pyexpr.meta_output_name()
+        try:
+            return self._pyexpr.meta_output_name()
+        except ComputeError:
+            if not raise_if_undetermined:
+                return None
+            raise
 
     def pop(self) -> list[Expr]:
         """

--- a/py-polars/tests/unit/namespaces/test_meta.py
+++ b/py-polars/tests/unit/namespaces/test_meta.py
@@ -43,6 +43,8 @@ def test_root_and_output_names() -> None:
     ):
         pl.all().suffix("_").meta.output_name()
 
+    assert pl.all().suffix("_").meta.output_name(raise_if_undetermined=False) is None
+
 
 def test_undo_aliases() -> None:
     e = pl.col("foo").alias("bar")

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -265,6 +265,22 @@ def test_null_count_expr() -> None:
     assert df.select([pl.all().null_count()]).to_dict(False) == {"key": [0], "val": [1]}
 
 
+def test_pos_neg() -> None:
+    df = pl.DataFrame(
+        {
+            "x": [3, 2, 1],
+            "y": [6, 7, 8],
+        }
+    ).with_columns(-pl.col("x"), +pl.col("y"), -pl.lit(1))
+
+    # #11149: ensure that we preserve the output name (where available)
+    assert df.to_dict(False) == {
+        "x": [-3, -2, -1],
+        "y": [6, 7, 8],
+        "literal": [-1, -1, -1],
+    }
+
+
 def test_power_by_expression() -> None:
     out = pl.DataFrame(
         {"a": [1, None, None, 4, 5, 6], "b": [1, 2, None, 4, None, 6]}

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -270,7 +270,8 @@ def test_schema_owned_arithmetic_5669() -> None:
         .with_columns(-pl.col("A").alias("B"))
         .collect()
     )
-    assert df.columns == ["A", "literal"], df.columns
+    assert df.columns == ["A", "B"]
+    assert df.rows() == [(3, -3)]
 
 
 def test_fill_null_f32_with_lit() -> None:


### PR DESCRIPTION
Closes #11149.

Because we implement `-expr` as `lit(0) - expr` (and `+expr` as `lit(0) + expr`) the output name of the resulting expressions is `literal`. While this makes sense (leftmost expr naming convention), it is not something that the caller expects as this is an internal detail that they know nothing about (and shouldn't have to read the source to discover ;)

In accordance with "the principle of least surprise", this PR maintains the _expected_ name, as determined from the rhs `expr` (via `meta.output_name`), and not the anonymous/internal lhs `lit`. As well as resulting in the expected name for a single op, this also ensures that you can easily negate multiple columns without having to explicitly alias them all (to avoid a duplicate colnames error).

## Notes

I can see that #5669 wanted to codify the naming behaviour as "literal", but I think that's not the way to go as this is an _internal_ implementation detail that the user doesn't see (and therefore can't predict/understand) _and_ that could change (if we wanted to use a dedicated `.neg()` expression method on the Rust side, change it to `expr * -1`, etc; the name should stay stable irrespective of the underlying implementation). 

## Example
Negating a single column:
```python
df = pl.DataFrame({"x": [3, 2, 1]})
df.with_columns(-pl.col("x"))
```
**Before**
```
┌─────┬─────────┐
│ x   ┆ literal │
│ --- ┆ ---     │
│ i64 ┆ i64     │
╞═════╪═════════╡
│ 3   ┆ -3      │
│ 2   ┆ -2      │
│ 1   ┆ -1      │
└─────┴─────────┘
```
**After**
```
┌─────┐
│ x   │
│ --- │
│ i64 │
╞═════╡
│ -3  │
│ -2  │
│ -1  │
└─────┘
```
Negating multiple columns:
```python
pl.DataFrame(
    {
        "x": [3, 2, 1],
        "y": [6, 7, 8],
    }
).with_columns(-pl.col("x"), -pl.col("y"))
```
**Before**
```python
ComputeError: The name: 'literal' passed to `LazyFrame.with_columns` is duplicate
```
**After**
```
┌─────┬─────┐
│ x   ┆ y   │
│ --- ┆ --- │
│ i64 ┆ i64 │
╞═════╪═════╡
│ -3  ┆ -6  │
│ -2  ┆ -7  │
│ -1  ┆ -8  │
└─────┴─────┘
```
