### PR TITLE
fix(python): only raise on actual parameter collision when "dtypes" specified in `read_excel` "read_csv_options" 

### DIFF
--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -82,6 +82,10 @@ class NoRowsReturnedError(RowsError):
     """Exception raised when no rows are returned, but at least one row is expected."""
 
 
+class ParameterCollisionError(RuntimeError):
+    """Exception raised when the same parameter occurs multiple times."""
+
+
 class PolarsInefficientMapWarning(Warning):
     """Warning raised when a potentially slow `apply` operation is performed."""
 


### PR DESCRIPTION
Closes #11161.

Fixes an oversight when specifying dtype overrides via "read_csv_options" passthrough for the default `xlsx2csv` engine.