### PR TITLE
fix(python)!: consistently use negative every as the default for offset in group_by_dynamic

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9884,10 +9884,9 @@ class DataFrame:
         every
             interval of the window
         period
-            length of the window, if None it is equal to 'every'
+            length of the window, if None it will equal 'every'
         offset
-            offset of the window if None and period is None it will be equal to negative
-            `every`
+            offset of the window, if None it will equal negative `every`
         truncate
             truncate the time value to the window lower bound
         include_boundaries

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5314,10 +5314,9 @@ class DataFrame:
         every
             interval of the window
         period
-            length of the window, if None it is equal to 'every'
+            length of the window, if None it will equal 'every'
         offset
-            offset of the window if None and period is None it will be equal to negative
-            `every`
+            offset of the window, if None it will equal negative `every`
         truncate
             truncate the time value to the window lower bound
         include_boundaries
@@ -5548,12 +5547,13 @@ class DataFrame:
         ...         closed="right",
         ...     ).agg(pl.col("A").alias("A_agg_list"))
         ... )
-        shape: (3, 4)
+        shape: (4, 4)
         ┌─────────────────┬─────────────────┬─────┬─────────────────┐
         │ _lower_boundary ┆ _upper_boundary ┆ idx ┆ A_agg_list      │
         │ ---             ┆ ---             ┆ --- ┆ ---             │
         │ i64             ┆ i64             ┆ i64 ┆ list[str]       │
         ╞═════════════════╪═════════════════╪═════╪═════════════════╡
+        │ -2              ┆ 1               ┆ -2  ┆ ["A", "A"]      │
         │ 0               ┆ 3               ┆ 0   ┆ ["A", "B", "B"] │
         │ 2               ┆ 5               ┆ 2   ┆ ["B", "B", "C"] │
         │ 4               ┆ 7               ┆ 4   ┆ ["C"]           │

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5715,10 +5715,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         every
             interval of the window
         period
-            length of the window, if None it is equal to 'every'
+            length of the window, if None it will equal 'every'
         offset
-            offset of the window if None and period is None it will be equal to negative
-            `every`
+            offset of the window, if None it will equal negative `every`
         truncate
             truncate the time value to the window lower bound
         include_boundaries

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -56,7 +56,7 @@ from polars.utils._parse_expr_input import (
     parse_as_list_of_expressions,
 )
 from polars.utils._wrap import wrap_df, wrap_expr
-from polars.utils.convert import _timedelta_to_pl_duration
+from polars.utils.convert import _negate_duration, _timedelta_to_pl_duration
 from polars.utils.deprecation import (
     deprecate_function,
     deprecate_renamed_function,
@@ -2908,7 +2908,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         index_column = parse_as_expression(index_column)
         if offset is None:
-            offset = f"-{_timedelta_to_pl_duration(period)}"
+            offset = _negate_duration(_timedelta_to_pl_duration(period))
 
         pyexprs_by = parse_as_list_of_expressions(by) if by is not None else []
         period = _timedelta_to_pl_duration(period)
@@ -2997,10 +2997,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         every
             interval of the window
         period
-            length of the window, if None it is equal to 'every'
+            length of the window, if None it will equal 'every'
         offset
-            offset of the window if None and period is None it will be equal to negative
-            `every`
+            offset of the window, if None it will equal negative `every`
         truncate
             truncate the time value to the window lower bound
         include_boundaries
@@ -3235,12 +3234,13 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     include_boundaries=True,
         ...     closed="right",
         ... ).agg(pl.col("A").alias("A_agg_list")).collect()
-        shape: (3, 4)
+        shape: (4, 4)
         ┌─────────────────┬─────────────────┬─────┬─────────────────┐
         │ _lower_boundary ┆ _upper_boundary ┆ idx ┆ A_agg_list      │
         │ ---             ┆ ---             ┆ --- ┆ ---             │
         │ i64             ┆ i64             ┆ i64 ┆ list[str]       │
         ╞═════════════════╪═════════════════╪═════╪═════════════════╡
+        │ -2              ┆ 1               ┆ -2  ┆ ["A", "A"]      │
         │ 0               ┆ 3               ┆ 0   ┆ ["A", "B", "B"] │
         │ 2               ┆ 5               ┆ 2   ┆ ["B", "B", "C"] │
         │ 4               ┆ 7               ┆ 4   ┆ ["C"]           │
@@ -3249,7 +3249,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """  # noqa: W505
         index_column = parse_as_expression(index_column)
         if offset is None:
-            offset = f"-{_timedelta_to_pl_duration(every)}" if period is None else "0ns"
+            offset = _negate_duration(_timedelta_to_pl_duration(every))
 
         if period is None:
             period = every

--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -91,6 +91,12 @@ def _timedelta_to_pl_duration(td: timedelta | str | None) -> str | None:
         return f"{d}{s}{us}"
 
 
+def _negate_duration(duration: str) -> str:
+    if duration.startswith("-"):
+        return duration[1:]
+    return f"-{duration}"
+
+
 def _datetime_to_pl_timestamp(dt: datetime, time_unit: TimeUnit | None) -> int:
     """Convert a python datetime to a timestamp in nanoseconds."""
     dt = dt.replace(tzinfo=timezone.utc) if dt.tzinfo != timezone.utc else dt

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -590,8 +590,13 @@ def test_truncate_negative_offset(tzinfo: ZoneInfo | None) -> None:
             "idx", every="2i", period="3i", include_boundaries=True
         ).agg(pl.col("A"))
 
-        assert out.shape == (3, 4)
-        assert out["A"].to_list() == [["A", "A", "B"], ["B", "B", "B"], ["B", "C"]]
+        assert out.shape == (4, 4)
+        assert out["A"].to_list() == [
+            ["A"],
+            ["A", "A", "B"],
+            ["B", "B", "B"],
+            ["B", "C"],
+        ]
 
 
 def test_to_arrow() -> None:
@@ -658,13 +663,14 @@ def test_groupy_by_dynamic_median_10695() -> None:
         pl.col("foo").median()
     ).to_dict(False) == {
         "timestamp": [
+            datetime(2023, 8, 22, 15, 43),
             datetime(2023, 8, 22, 15, 44),
             datetime(2023, 8, 22, 15, 45),
             datetime(2023, 8, 22, 15, 46),
             datetime(2023, 8, 22, 15, 47),
             datetime(2023, 8, 22, 15, 48),
         ],
-        "foo": [1.0, 1.0, 1.0, 1.0, 1.0],
+        "foo": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
     }
 
 

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -761,11 +761,11 @@ def test_rolling_kernels_group_by_dynamic_7548() -> None:
     ).to_dict(
         False
     ) == {
-        "time": [0, 1, 2, 3],
-        "value": [[0, 1, 2], [1, 2, 3], [2, 3], [3]],
-        "min_value": [0, 1, 2, 3],
-        "max_value": [2, 3, 3, 3],
-        "sum_value": [3, 6, 5, 3],
+        "time": [-1, 0, 1, 2, 3],
+        "value": [[0, 1], [0, 1, 2], [1, 2, 3], [2, 3], [3]],
+        "min_value": [0, 0, 1, 2, 3],
+        "max_value": [1, 2, 3, 3, 3],
+        "sum_value": [1, 3, 6, 5, 3],
     }
 
 

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -348,10 +348,10 @@ def test_group_by_dynamic_flat_agg_4814() -> None:
             (pl.col("b") / pl.col("a")).last().alias("last_ratio_2"),
         ]
     ).to_dict(False) == {
-        "a": [1, 2],
-        "sum_ratio_1": [4.2, 5.0],
-        "last_ratio_1": [6.0, 6.0],
-        "last_ratio_2": [6.0, 6.0],
+        "a": [0, 1, 2],
+        "sum_ratio_1": [1.0, 4.2, 5.0],
+        "last_ratio_1": [1.0, 6.0, 6.0],
+        "last_ratio_2": [1.0, 6.0, 6.0],
     }
 
 
@@ -388,7 +388,7 @@ def test_group_by_dynamic_overlapping_groups_flat_apply_multiple_5038(
         .to_dict(False)
     )
 
-    assert res["corr"] == pytest.approx([6.988674024215477])
+    assert res["corr"] == pytest.approx([9.148920923684765])
     assert res["a"] == [None]
 
 
@@ -576,10 +576,11 @@ def test_group_by_dynamic_elementwise_following_mean_agg_6904(
         pl.DataFrame(
             {
                 "a": [
+                    datetime(2020, 12, 31, 23, 59, 50),
                     datetime(2021, 1, 1, 0, 0),
                     datetime(2021, 1, 1, 0, 0, 10),
                 ],
-                "c": [0.9092974268256817, -0.7568024953079282],
+                "c": [0.9092974268256817, 0.9092974268256817, -0.7568024953079282],
             }
         ).with_columns(pl.col("a").dt.replace_time_zone(time_zone)),
     )


### PR DESCRIPTION
closes #11163 

technically breaking, but to be honest I consider the current behaviour buggy as it's not reporting valid windows - my suggestion would be treat it as a bug fix

but, could deprecate the behaviour and make the change in 1.0 if people prefer

---

my understanding of `group_by_dynamic` is the windows are:
- [start, start + period)
- [start + every, start + every + period)
- [start + 2 every, start + 2 every + period)
- ...

and that `start` is `earliest_timestamp.truncate(every) + offset`

So, I don't really see why `offset` depends on `period` at all, but I might be missing something