### PR TITLE
fix(rust): restrict decimal casting to float64 for Python feature

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -83,6 +83,10 @@ impl PartialEq for DataType {
                 (Array(left_inner, left_width), Array(right_inner, right_width)) => {
                     left_width == right_width && left_inner == right_inner
                 },
+                #[cfg(feature = "dtype-decimal")]
+                (Decimal(lhs_precision, lhs_scale), Decimal(rhs_precision, rhs_scale)) => {
+                    lhs_precision == rhs_precision && lhs_scale == rhs_scale
+                },
                 _ => std::mem::discriminant(self) == std::mem::discriminant(other),
             }
         }

--- a/crates/polars-core/src/schema.rs
+++ b/crates/polars-core/src/schema.rs
@@ -48,11 +48,19 @@ where
             #[cfg(feature = "dtype-decimal")]
             let fld = match fld.dtype {
                 DataType::Decimal(_, _) => {
-                    if crate::config::decimal_is_active() {
-                        fld
-                    } else {
-                        let mut fld = fld.clone();
-                        fld.coerce(DataType::Float64);
+                    #[cfg(feature = "python")]
+                    {
+                        if crate::config::decimal_is_active() {
+                            fld
+                        } else {
+                            let mut fld = fld.clone();
+                            fld.coerce(DataType::Float64);
+                            fld
+                        }
+                    }
+
+                    #[cfg(not(feature = "python"))]
+                    {
                         fld
                     }
                 },

--- a/crates/polars-core/src/tests.rs
+++ b/crates/polars-core/src/tests.rs
@@ -55,17 +55,13 @@ fn test_dataframe_has_the_correct_schema() {
                 "decimal" => to_decimal(precision, scale, vec![1_i128])
             )
             .unwrap();
-            let get_dtype = |name: &str| data.schema().get_field(name).unwrap().data_type().clone();
-
-            // We use the following code to check the precision and scale of the decimal type.
-            // assert_eq!(dtype, Decimal(precision, scale) checks only enum variant type equality.
-            match get_dtype("decimal") {
-                DataType::Decimal(Some(precision), Some(scale)) => {
-                    assert_eq!(scale, scale);
-                    assert_eq!(precision, precision);
-                },
-                _ => assert!(false, "expected decimal"),
-            }
+            let dtype = data
+                .schema()
+                .get_field("decimal")
+                .unwrap()
+                .data_type()
+                .clone();
+            assert_eq!(dtype, DataType::Decimal(Some(precision), Some(scale)));
         }
     }
 }

--- a/crates/polars-core/src/tests.rs
+++ b/crates/polars-core/src/tests.rs
@@ -15,3 +15,57 @@ fn test_initial_empty_sort() -> PolarsResult<()> {
     series.f64()?.sort(false);
     Ok(())
 }
+
+#[cfg(feature = "dtype-decimal")]
+#[test]
+fn test_dataframe_has_the_correct_schema() {
+    let to_decimal = |precision, scale, data| {
+        Int128Chunked::from_vec("", data)
+            .into_decimal_unchecked(Some(precision), scale)
+            .into_series()
+    };
+
+    let data = df!(
+        "i32" => [1_i32],
+        "i64" => [1_i64],
+        "u32" => [1_u32],
+        "u64" => [1_u64],
+        "bool" => [true],
+        "f32" => [1_f32],
+        "f64" => [1_f64],
+        "utf8" => ["foo"],
+        "decimal" => to_decimal(38, 0, vec![1_i128])
+    )
+    .unwrap();
+    let get_dtype = |name: &str| data.schema().get_field(name).unwrap().data_type().clone();
+
+    assert_eq!(get_dtype("i32"), DataType::Int32);
+    assert_eq!(get_dtype("i64"), DataType::Int64);
+    assert_eq!(get_dtype("u32"), DataType::UInt32);
+    assert_eq!(get_dtype("u64"), DataType::UInt64);
+    assert_eq!(get_dtype("f32"), DataType::Float32);
+    assert_eq!(get_dtype("f64"), DataType::Float64);
+    assert_eq!(get_dtype("bool"), DataType::Boolean);
+    assert_eq!(get_dtype("utf8"), DataType::Utf8);
+    assert_eq!(get_dtype("decimal"), DataType::Decimal(Some(38), Some(0)));
+
+    for precision in 0..39 {
+        for scale in 0..=precision {
+            let data = df!(
+                "decimal" => to_decimal(precision, scale, vec![1_i128])
+            )
+            .unwrap();
+            let get_dtype = |name: &str| data.schema().get_field(name).unwrap().data_type().clone();
+
+            // We use the following code to check the precision and scale of the decimal type.
+            // assert_eq!(dtype, Decimal(precision, scale) checks only enum variant type equality.
+            match get_dtype("decimal") {
+                DataType::Decimal(Some(precision), Some(scale)) => {
+                    assert_eq!(scale, scale);
+                    assert_eq!(precision, precision);
+                },
+                _ => assert!(false, "expected decimal"),
+            }
+        }
+    }
+}

--- a/crates/polars-core/src/tests.rs
+++ b/crates/polars-core/src/tests.rs
@@ -47,21 +47,25 @@ fn test_dataframe_has_the_correct_schema() {
     assert_eq!(get_dtype("f64"), DataType::Float64);
     assert_eq!(get_dtype("bool"), DataType::Boolean);
     assert_eq!(get_dtype("utf8"), DataType::Utf8);
-    assert_eq!(get_dtype("decimal"), DataType::Decimal(Some(38), Some(0)));
 
-    for precision in 0..39 {
-        for scale in 0..=precision {
-            let data = df!(
-                "decimal" => to_decimal(precision, scale, vec![1_i128])
-            )
-            .unwrap();
-            let dtype = data
-                .schema()
-                .get_field("decimal")
-                .unwrap()
-                .data_type()
-                .clone();
-            assert_eq!(dtype, DataType::Decimal(Some(precision), Some(scale)));
+    #[cfg(not(feature = "python"))]
+    {
+        assert_eq!(get_dtype("decimal"), DataType::Decimal(Some(38), Some(0)));
+
+        for precision in 0..39 {
+            for scale in 0..=precision {
+                let data = df!(
+                    "decimal" => to_decimal(precision, scale, vec![1_i128])
+                )
+                .unwrap();
+                let dtype = data
+                    .schema()
+                    .get_field("decimal")
+                    .unwrap()
+                    .data_type()
+                    .clone();
+                assert_eq!(dtype, DataType::Decimal(Some(precision), Some(scale)));
+            }
         }
     }
 }


### PR DESCRIPTION
**Description:**

Decimal types are cast to float64 types, even when the Python feature is disabled. This issue results in misleading operations between decimals and i64 values when using Rust.

**Changes:**

* Restricted the casting to float64 for the Python feature, similar to the implementation found [here](https://github.com/pola-rs/polars/blob/b08bc7d533e1c860bff2a8cec5d891474e67611f/crates/polars-core/src/series/from.rs#L404-L442).
* Updated the DataType::Decimal equality comparison to also include precision and scale checks.

**Sample code showcasing the bug:**

```
use polars::prelude::*;

fn main() {
    let value = -4654825170126467706_i64;
    let x = Int128Chunked::from_vec("", vec![value as i128])
        .into_decimal_unchecked(Some(38), 0)
        .into_series();
    let y = Int64Chunked::from_vec("", vec![value]).into_series();

    let lazy_data = df!("x" => x.clone(), "y" => y.clone()).unwrap().lazy();
    let lazy_data = lazy_data.select(&[col("x") - col("y")]);
    let data = lazy_data.collect().unwrap();

    let result = data.select_at_idx(0).unwrap().get(0).unwrap();
    assert_eq!(result, AnyValue::Decimal(0, 0));
}
```

```
[dependencies]
debug-here = "0.2.2"
polars = { version = "0.33.1", features = ["lazy", "dtype-decimal"]}
```

**Output:**

```
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `Decimal(390, 0)`,
  right: `Decimal(0, 0)`', src/main.rs:15:5
```