### PR TITLE
fix(python): Add some missing expr type hint for series

### DIFF
--- a/py-polars/polars/expr/binary.py
+++ b/py-polars/polars/expr/binary.py
@@ -7,7 +7,7 @@ from polars.utils._wrap import wrap_expr
 
 if TYPE_CHECKING:
     from polars import Expr
-    from polars.type_aliases import TransferEncoding
+    from polars.type_aliases import IntoExpr, TransferEncoding
 
 
 class ExprBinaryNameSpace:
@@ -18,7 +18,7 @@ class ExprBinaryNameSpace:
     def __init__(self, expr: Expr):
         self._pyexpr = expr._pyexpr
 
-    def contains(self, literal: bytes | Expr) -> Expr:
+    def contains(self, literal: IntoExpr) -> Expr:
         r"""
         Check if binaries in Series contain a binary substring.
 
@@ -65,7 +65,7 @@ class ExprBinaryNameSpace:
         literal = parse_as_expression(literal, str_as_lit=True)
         return wrap_expr(self._pyexpr.bin_contains(literal))
 
-    def ends_with(self, suffix: bytes | Expr) -> Expr:
+    def ends_with(self, suffix: IntoExpr) -> Expr:
         r"""
         Check if string values end with a binary substring.
 
@@ -112,7 +112,7 @@ class ExprBinaryNameSpace:
         suffix = parse_as_expression(suffix, str_as_lit=True)
         return wrap_expr(self._pyexpr.bin_ends_with(suffix))
 
-    def starts_with(self, prefix: bytes | Expr) -> Expr:
+    def starts_with(self, prefix: IntoExpr) -> Expr:
         r"""
         Check if values start with a binary substring.
 

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from polars import Expr
     from polars.type_aliases import (
         Ambiguous,
+        IntoExpr,
         PolarsDataType,
         PolarsTemporalType,
         TimeUnit,
@@ -1511,7 +1512,7 @@ class ExprStringNameSpace:
         pattern = parse_as_expression(pattern, str_as_lit=True)
         return wrap_expr(self._pyexpr.str_count_matches(pattern, literal))
 
-    def split(self, by: str | Expr, *, inclusive: bool = False) -> Expr:
+    def split(self, by: IntoExpr, *, inclusive: bool = False) -> Expr:
         """
         Split the string by a substring.
 

--- a/py-polars/polars/series/binary.py
+++ b/py-polars/polars/series/binary.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
-    from polars import Expr, Series
+    from polars import Series
     from polars.polars import PySeries
-    from polars.type_aliases import TransferEncoding
+    from polars.type_aliases import IntoExpr, TransferEncoding
 
 
 @expr_dispatch
@@ -19,7 +19,7 @@ class BinaryNameSpace:
     def __init__(self, series: Series):
         self._s: PySeries = series._s
 
-    def contains(self, literal: bytes | Expr) -> Series:
+    def contains(self, literal: IntoExpr) -> Series:
         """
         Check if binaries in Series contain a binary substring.
 
@@ -35,7 +35,7 @@ class BinaryNameSpace:
 
         """
 
-    def ends_with(self, suffix: bytes | Expr) -> Series:
+    def ends_with(self, suffix: IntoExpr) -> Series:
         """
         Check if string values end with a binary substring.
 
@@ -46,7 +46,7 @@ class BinaryNameSpace:
 
         """
 
-    def starts_with(self, prefix: bytes | Expr) -> Series:
+    def starts_with(self, prefix: IntoExpr) -> Series:
         """
         Check if values start with a binary substring.
 

--- a/py-polars/polars/series/binary.py
+++ b/py-polars/polars/series/binary.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from polars.series.utils import expr_dispatch
 
 if TYPE_CHECKING:
-    from polars import Series
+    from polars import Expr, Series
     from polars.polars import PySeries
     from polars.type_aliases import TransferEncoding
 
@@ -19,7 +19,7 @@ class BinaryNameSpace:
     def __init__(self, series: Series):
         self._s: PySeries = series._s
 
-    def contains(self, literal: bytes) -> Series:
+    def contains(self, literal: bytes | Expr) -> Series:
         """
         Check if binaries in Series contain a binary substring.
 
@@ -35,7 +35,7 @@ class BinaryNameSpace:
 
         """
 
-    def ends_with(self, suffix: bytes) -> Series:
+    def ends_with(self, suffix: bytes | Expr) -> Series:
         """
         Check if string values end with a binary substring.
 
@@ -46,7 +46,7 @@ class BinaryNameSpace:
 
         """
 
-    def starts_with(self, prefix: bytes) -> Series:
+    def starts_with(self, prefix: bytes | Expr) -> Series:
         """
         Check if values start with a binary substring.
 

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
     from polars.polars import PySeries
     from polars.type_aliases import (
         Ambiguous,
+        IntoExpr,
         PolarsDataType,
         PolarsTemporalType,
         TimeUnit,
@@ -872,7 +873,7 @@ class StringNameSpace:
 
         """
 
-    def split(self, by: str | Expr, *, inclusive: bool = False) -> Series:
+    def split(self, by: IntoExpr, *, inclusive: bool = False) -> Series:
         """
         Split the string by a substring.
 

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -872,7 +872,7 @@ class StringNameSpace:
 
         """
 
-    def split(self, by: str, *, inclusive: bool = False) -> Series:
+    def split(self, by: str | Expr, *, inclusive: bool = False) -> Series:
         """
         Split the string by a substring.
 


### PR DESCRIPTION
We have already supports expr for these methods, but just forgot to modify the type hint in series module.