### PR TITLE
fix(python,rust): make error message consistent with other calls to python functions from rust

### DIFF
--- a/py-polars/src/map/lazy.rs
+++ b/py-polars/src/map/lazy.rs
@@ -157,7 +157,7 @@ pub(crate) fn call_lambda_with_series_slice(
     // call the lambda and get a python side Series wrapper
     match lambda.call1(py, (wrapped_s,)) {
         Ok(pyobj) => pyobj,
-        Err(e) => panic!("python apply failed: {}", e.value(py)),
+        Err(e) => panic!("python function failed: {}", e.value(py)),
     }
 }
 


### PR DESCRIPTION
This stood out slightly after the switchover from `apply` to `map_*` naming; the other three places I found where we raise errors on pyfunc failure use _"python function failed: ..."_ instead of _"python apply failed: ..."_, so this is just a trivial update for consistency.

![Screenshot 2023-09-18 at 13 12 15](https://github.com/pola-rs/polars/assets/2613171/282fbf13-b0d9-44f1-9ef1-affb51e03dc6)
