### PR TITLE
feat(rust): Support `duration + date`

### DIFF
--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::ops::{Deref, DerefMut, Mul};
+use std::ops::{Deref, DerefMut};
 
 use ahash::RandomState;
 


### PR DESCRIPTION
## Description

Closes: https://github.com/pola-rs/polars/issues/11034

This PR adds support for `duration + date`. Supporting that operation will bring the Rust API more in line with the Python API, which already supports it.

## Changes

* Support `duration + date`
* Tests