### PR TITLE
fix(python,rust): fix translation of Series-nested datetime/date values for `scan_pyarrow` predicates

### DIFF
--- a/py-polars/polars/io/iceberg.py
+++ b/py-polars/polars/io/iceberg.py
@@ -246,7 +246,7 @@ def _(a: Call) -> Any:
     if f == "field":
         return args
     elif f in _temporal_conversions:
-        # convert from polars-native i64 to ISO8601 strings
+        # convert from polars-native i64 to ISO8601 string
         return _temporal_conversions[f](*args).isoformat()
     else:
         ref = _convert_predicate(a.func.value)[0]  # type: ignore[attr-defined]

--- a/py-polars/polars/io/iceberg.py
+++ b/py-polars/polars/io/iceberg.py
@@ -18,16 +18,25 @@ from ast import (
     UnaryOp,
 )
 from functools import partial, singledispatch
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 import polars._reexport as pl
 from polars.dependencies import pyiceberg
 from polars.utils.convert import _to_python_date, _to_python_datetime
 
 if TYPE_CHECKING:
+    from datetime import date, datetime
+
     from pyiceberg.table import Table
 
     from polars import DataFrame, LazyFrame, Series
+
+__all__ = ["scan_iceberg"]
+
+_temporal_conversions: dict[str, Callable[..., datetime | date]] = {
+    "_to_python_date": _to_python_date,
+    "_to_python_datetime": _to_python_datetime,
+}
 
 
 def scan_iceberg(
@@ -236,10 +245,9 @@ def _(a: Call) -> Any:
     f = _convert_predicate(a.func)
     if f == "field":
         return args
-    elif f == "_to_python_datetime":
-        return _to_python_datetime(*args).isoformat()
-    elif f == "_to_python_date":
-        return _to_python_date(*args).isoformat()
+    elif f in _temporal_conversions:
+        # convert from polars-native i64 to ISO8601 strings
+        return _temporal_conversions[f](*args).isoformat()
     else:
         ref = _convert_predicate(a.func.value)[0]  # type: ignore[attr-defined]
         if f == "isin":
@@ -249,7 +257,7 @@ def _(a: Call) -> Any:
         elif f == "is_nan":
             return pyiceberg.expressions.IsNaN(ref)
 
-    raise ValueError(f"Unknown call: {f}")
+    raise ValueError(f"Unknown call: {f!r}")
 
 
 @_convert_predicate.register(Attribute)

--- a/py-polars/polars/io/pyarrow_dataset/anonymous_scan.py
+++ b/py-polars/polars/io/pyarrow_dataset/anonymous_scan.py
@@ -73,8 +73,11 @@ def _scan_pyarrow_dataset_impl(
     _filter = None
     if predicate:
         # imports are used by inline python evaluated by `eval`
+        from datetime import date, datetime  # noqa: F401
+
         from polars.datatypes import Date, Datetime, Duration  # noqa: F401
         from polars.utils.convert import (
+            _to_python_date,  # noqa: F401
             _to_python_datetime,  # noqa: F401
             _to_python_time,  # noqa: F401
             _to_python_timedelta,  # noqa: F401

--- a/py-polars/polars/io/pyarrow_dataset/anonymous_scan.py
+++ b/py-polars/polars/io/pyarrow_dataset/anonymous_scan.py
@@ -4,7 +4,7 @@ from functools import partial
 from typing import TYPE_CHECKING
 
 import polars._reexport as pl
-from polars.dependencies import pyarrow as pa  # noqa: TCH001
+from polars.dependencies import pyarrow as pa
 
 if TYPE_CHECKING:
     from polars import DataFrame, LazyFrame
@@ -71,17 +71,29 @@ def _scan_pyarrow_dataset_impl(
     from polars import from_arrow
 
     _filter = None
+
     if predicate:
-        # imports are used by inline python evaluated by `eval`
-        from polars.datatypes import Date, Datetime, Duration  # noqa: F401
+        from polars.datatypes import Date, Datetime, Duration
         from polars.utils.convert import (
-            _to_python_date,  # noqa: F401
-            _to_python_datetime,  # noqa: F401
-            _to_python_time,  # noqa: F401
-            _to_python_timedelta,  # noqa: F401
+            _to_python_date,
+            _to_python_datetime,
+            _to_python_time,
+            _to_python_timedelta,
         )
 
-        _filter = eval(predicate)
+        _filter = eval(
+            predicate,
+            {
+                "pa": pa,
+                "Date": Date,
+                "Datetime": Datetime,
+                "Duration": Duration,
+                "_to_python_date": _to_python_date,
+                "_to_python_datetime": _to_python_datetime,
+                "_to_python_time": _to_python_time,
+                "_to_python_timedelta": _to_python_timedelta,
+            },
+        )
 
     common_params = {"columns": with_columns, "filter": _filter}
     if batch_size is not None:

--- a/py-polars/polars/io/pyarrow_dataset/anonymous_scan.py
+++ b/py-polars/polars/io/pyarrow_dataset/anonymous_scan.py
@@ -73,8 +73,6 @@ def _scan_pyarrow_dataset_impl(
     _filter = None
     if predicate:
         # imports are used by inline python evaluated by `eval`
-        from datetime import date, datetime  # noqa: F401
-
         from polars.datatypes import Date, Datetime, Duration  # noqa: F401
         from polars.utils.convert import (
             _to_python_date,  # noqa: F401


### PR DESCRIPTION
While further probing the new Iceberg functionality[^1] I found (and have now fixed ;) a bug with our own pyarrow predicate generation for Series-nested AnyValue date/datetime literals (eg: as would be constructed by an `is_in` constraint).

(We were also calling out to deprecated/removed params for `_to_python_datetime`, using "tu" and "tz" instead of "time_unit" and "time_zone").

Fixed everything and added new unit tests to increase coverage, including examples of the date and datetime constraints that were previously failing:

## Example:
```python
from datetime import datetime
import polars as pl

df = pl.scan_iceberg( 
  "file:///.../tests/unit/io/files/iceberg-table/metadata/v2.metadata.json"
).filter(
  pl.col("ts").is_in([
    datetime(2023,3,1,18,15),
    datetime(2023,3,2,22,0),
  ])
).collect()
```
**Before**
_(dates/datetimes improperly converted within `is_in` constraint)_
```
ComputeError: SyntaxError: leading zeros in decimal integer 
literals are not permitted; use an 0o prefix for octal integers
```
**After**
```
┌─────┬─────┬─────────────────────┐
│ id  ┆ str ┆ ts                  │
│ --- ┆ --- ┆ ---                 │
│ i32 ┆ str ┆ datetime[μs]        │
╞═════╪═════╪═════════════════════╡
│ 1   ┆ 1   ┆ 2023-03-01 18:15:00 │
│ 3   ┆ 3   ┆ 2023-03-02 22:00:00 │
└─────┴─────┴─────────────────────┘
```

[^1]: FYI: @Fokko, the bug wasn't in the new code, it was ours, but to account for the fix I have slightly updated/extended the Iceberg AST parsing and unit tests that we landed earlier.