### PR TITLE
feat(rust): binary search and rechunk in chunked gather

### DIFF
--- a/crates/nano-arrow/src/bitmap/bitmask.rs
+++ b/crates/nano-arrow/src/bitmap/bitmask.rs
@@ -1,0 +1,133 @@
+#[cfg(feature = "simd")]
+use std::simd::ToBitMask;
+
+use crate::bitmap::Bitmap;
+#[cfg(feature = "simd")]
+use num_traits::AsPrimitive;
+
+// Loads a u64 from the given byteslice, as if it were padded with zeros.
+fn load_padded_le_u64(bytes: &[u8]) -> u64 {
+    let len = bytes.len();
+    if len >= 8 {
+        return u64::from_le_bytes(bytes[0..8].try_into().unwrap());
+    }
+
+    if len >= 4 {
+        let lo = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let hi = u32::from_le_bytes(bytes[len - 4..len].try_into().unwrap());
+        return (lo as u64) | ((hi as u64) << (8 * (len - 4)));
+    }
+
+    if len == 0 {
+        return 0;
+    }
+
+    let lo = bytes[0] as u64;
+    let mid = (bytes[len / 2] as u64) << (8 * (len / 2));
+    let hi = (bytes[len - 1] as u64) << (8 * (len - 1));
+    lo | mid | hi
+}
+
+pub struct BitMask<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+    len: usize,
+}
+
+impl<'a> BitMask<'a> {
+    pub fn from_bitmap(bitmap: &'a Bitmap) -> Self {
+        let (bytes, offset, len) = bitmap.as_slice();
+        // Check length so we can use unsafe access in our get.
+        assert!(bytes.len() * 8 >= len + offset);
+        Self { bytes, offset, len }
+    }
+    
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline]
+    pub fn split_at(&self, idx: usize) -> (Self, Self) {
+        assert!(idx <= self.len);
+        unsafe { self.split_at_unchecked(idx) }
+    }
+
+    #[inline]
+    pub unsafe fn split_at_unchecked(&self, idx: usize) -> (Self, Self) {
+        debug_assert!(idx <= self.len);
+        let left = Self { len: idx, ..*self };
+        let right = Self {
+            len: self.len - idx,
+            offset: self.offset + idx,
+            ..*self
+        };
+        (left, right)
+    }
+
+    #[cfg(feature = "simd")]
+    #[inline]
+    pub fn get_simd<T>(&self, idx: usize) -> T
+    where
+        T: ToBitMask,
+        <T as ToBitMask>::BitMask: Copy + 'static,
+        u64: AsPrimitive<<T as ToBitMask>::BitMask>,
+    {
+        // We don't support 64-lane masks because then we couldn't load our
+        // bitwise mask as a u64 and then do the byteshift on it.
+
+        let lanes = std::mem::size_of::<T::BitMask>() * 8;
+        assert!(lanes < 64);
+
+        let start_byte_idx = (self.offset + idx) / 8;
+        let byte_shift = (self.offset + idx) % 8;
+        if idx + lanes <= self.len {
+            // SAFETY: fast path, we know this is completely in-bounds.
+            let mask = load_padded_le_u64(unsafe { self.bytes.get_unchecked(start_byte_idx..) });
+            T::from_bitmask((mask >> byte_shift).as_())
+        } else if idx < self.len {
+            // SAFETY: we know that at least the first byte is in-bounds.
+            // This is partially out of bounds, we have to do extra masking.
+            let mask = load_padded_le_u64(unsafe { self.bytes.get_unchecked(start_byte_idx..) });
+            let num_out_of_bounds = idx + lanes - self.len;
+            let shifted = (mask << num_out_of_bounds) >> (num_out_of_bounds + byte_shift);
+            T::from_bitmask(shifted.as_())
+        } else {
+            T::from_bitmask((0u64).as_())
+        }
+    }
+
+    #[inline]
+    pub fn get_u32(&self, idx: usize) -> u32 {
+        let start_byte_idx = (self.offset + idx) / 8;
+        let byte_shift = (self.offset + idx) % 8;
+        if idx + 32 <= self.len {
+            // SAFETY: fast path, we know this is completely in-bounds.
+            let mask = load_padded_le_u64(unsafe { self.bytes.get_unchecked(start_byte_idx..) });
+            (mask >> byte_shift) as u32
+        } else if idx < self.len {
+            // SAFETY: we know that at least the first byte is in-bounds.
+            // This is partially out of bounds, we have to do extra masking.
+            let mask = load_padded_le_u64(unsafe { self.bytes.get_unchecked(start_byte_idx..) });
+            let num_out_of_bounds = idx + 32 - self.len;
+            let shifted = (mask << num_out_of_bounds) >> (num_out_of_bounds + byte_shift);
+            shifted as u32
+        } else {
+            0
+        }
+    }
+
+    #[inline]
+    pub fn get(&self, idx: usize) -> bool {
+        let byte_idx = (self.offset + idx) / 8;
+        let byte_shift = (self.offset + idx) % 8;
+
+        if idx < self.len {
+            // SAFETY: we know this is in-bounds.
+            let byte = unsafe { *self.bytes.get_unchecked(byte_idx) };
+            (byte >> byte_shift) & 1 == 1
+        } else {
+            false
+        }
+    }
+}

--- a/crates/nano-arrow/src/bitmap/bitmask.rs
+++ b/crates/nano-arrow/src/bitmap/bitmask.rs
@@ -1,9 +1,10 @@
 #[cfg(feature = "simd")]
 use std::simd::ToBitMask;
 
-use crate::bitmap::Bitmap;
 #[cfg(feature = "simd")]
 use num_traits::AsPrimitive;
+
+use crate::bitmap::Bitmap;
 
 // Loads a u64 from the given byteslice, as if it were padded with zeros.
 fn load_padded_le_u64(bytes: &[u8]) -> u64 {
@@ -41,7 +42,7 @@ impl<'a> BitMask<'a> {
         assert!(bytes.len() * 8 >= len + offset);
         Self { bytes, offset, len }
     }
-    
+
     #[inline(always)]
     pub fn len(&self) -> usize {
         self.len
@@ -53,6 +54,8 @@ impl<'a> BitMask<'a> {
         unsafe { self.split_at_unchecked(idx) }
     }
 
+    /// # Safety
+    /// The index must be in-bounds.
     #[inline]
     pub unsafe fn split_at_unchecked(&self, idx: usize) -> (Self, Self) {
         debug_assert!(idx <= self.len);

--- a/crates/nano-arrow/src/bitmap/mod.rs
+++ b/crates/nano-arrow/src/bitmap/mod.rs
@@ -15,3 +15,5 @@ mod assign_ops;
 pub use assign_ops::*;
 
 pub mod utils;
+
+pub mod bitmask;

--- a/crates/polars-core/src/chunked_array/ops/aggregate/float_sum.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/float_sum.rs
@@ -2,7 +2,8 @@ use std::ops::{Add, IndexMut};
 #[cfg(feature = "simd")]
 use std::simd::{Mask, Simd, SimdElement};
 
-use arrow::bitmap::{Bitmap, bitmask::BitMask};
+use arrow::bitmap::bitmask::BitMask;
+use arrow::bitmap::Bitmap;
 
 const STRIPE: usize = 16;
 const PAIRWISE_RECURSION_LIMIT: usize = 128;

--- a/crates/polars-core/src/chunked_array/ops/aggregate/float_sum.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/float_sum.rs
@@ -1,112 +1,11 @@
 use std::ops::{Add, IndexMut};
 #[cfg(feature = "simd")]
-use std::simd::{Mask, Simd, SimdElement, ToBitMask};
+use std::simd::{Mask, Simd, SimdElement};
 
-use arrow::bitmap::Bitmap;
-#[cfg(feature = "simd")]
-use num_traits::AsPrimitive;
+use arrow::bitmap::{Bitmap, bitmask::BitMask};
 
 const STRIPE: usize = 16;
 const PAIRWISE_RECURSION_LIMIT: usize = 128;
-
-// Load 8 bytes as little-endian into a u64, padding with zeros if it's too short.
-#[cfg(feature = "simd")]
-pub fn load_padded_le_u64(bytes: &[u8]) -> u64 {
-    let len = bytes.len();
-    if len >= 8 {
-        return u64::from_le_bytes(bytes[0..8].try_into().unwrap());
-    }
-
-    if len >= 4 {
-        let lo = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
-        let hi = u32::from_le_bytes(bytes[len - 4..len].try_into().unwrap());
-        return (lo as u64) | ((hi as u64) << (8 * (len - 4)));
-    }
-
-    if len == 0 {
-        return 0;
-    }
-
-    let lo = bytes[0] as u64;
-    let mid = (bytes[len / 2] as u64) << (8 * (len / 2));
-    let hi = (bytes[len - 1] as u64) << (8 * (len - 1));
-    lo | mid | hi
-}
-
-struct BitMask<'a> {
-    bytes: &'a [u8],
-    offset: usize,
-    len: usize,
-}
-
-impl<'a> BitMask<'a> {
-    pub fn new(bitmap: &'a Bitmap) -> Self {
-        let (bytes, offset, len) = bitmap.as_slice();
-        // Check length so we can use unsafe access in our get.
-        assert!(bytes.len() * 8 >= len + offset);
-        Self { bytes, offset, len }
-    }
-
-    fn split_at(&self, idx: usize) -> (Self, Self) {
-        assert!(idx <= self.len);
-        unsafe { self.split_at_unchecked(idx) }
-    }
-
-    unsafe fn split_at_unchecked(&self, idx: usize) -> (Self, Self) {
-        debug_assert!(idx <= self.len);
-        let left = Self { len: idx, ..*self };
-        let right = Self {
-            len: self.len - idx,
-            offset: self.offset + idx,
-            ..*self
-        };
-        (left, right)
-    }
-
-    #[cfg(feature = "simd")]
-    pub fn get_simd<T>(&self, idx: usize) -> T
-    where
-        T: ToBitMask,
-        <T as ToBitMask>::BitMask: Copy + 'static,
-        u64: AsPrimitive<<T as ToBitMask>::BitMask>,
-    {
-        // We don't support 64-lane masks because then we couldn't load our
-        // bitwise mask as a u64 and then do the byteshift on it.
-
-        let lanes = std::mem::size_of::<T::BitMask>() * 8;
-        assert!(lanes < 64);
-
-        let start_byte_idx = (self.offset + idx) / 8;
-        let byte_shift = (self.offset + idx) % 8;
-        if idx + lanes <= self.len {
-            // SAFETY: fast path, we know this is completely in-bounds.
-            let mask = load_padded_le_u64(unsafe { self.bytes.get_unchecked(start_byte_idx..) });
-            T::from_bitmask((mask >> byte_shift).as_())
-        } else if idx < self.len {
-            // SAFETY: we know that at least the first byte is in-bounds.
-            // This is partially out of bounds, we have to do extra masking.
-            let mask = load_padded_le_u64(unsafe { self.bytes.get_unchecked(start_byte_idx..) });
-            let num_out_of_bounds = idx + lanes - self.len;
-            let shifted = (mask << num_out_of_bounds) >> (num_out_of_bounds + byte_shift);
-            T::from_bitmask(shifted.as_())
-        } else {
-            T::from_bitmask((0u64).as_())
-        }
-    }
-
-    pub fn get(&self, idx: usize) -> bool {
-        let byte_idx = (self.offset + idx) / 8;
-        let byte_shift = (self.offset + idx) % 8;
-
-        if idx < self.len {
-            // SAFETY: we know this is in-bounds.
-            let byte = unsafe { *self.bytes.get_unchecked(byte_idx) };
-            (byte >> byte_shift) & 1 == 1
-        } else {
-            false
-        }
-    }
-}
 
 fn vector_horizontal_sum<V, T>(mut v: V) -> T
 where
@@ -222,7 +121,7 @@ macro_rules! def_sum {
             /// Also, f.len() == mask.len().
             unsafe fn pairwise_sum_with_mask(f: &[$T], mask: BitMask<'_>) -> f64 {
                 debug_assert!(f.len() > 0 && f.len() % PAIRWISE_RECURSION_LIMIT == 0);
-                debug_assert!(f.len() == mask.len);
+                debug_assert!(f.len() == mask.len());
 
                 if let Ok(block) = f.try_into() {
                     return sum_block_vectorized_with_mask(block, mask) as f64;
@@ -253,8 +152,8 @@ macro_rules! def_sum {
             }
 
             pub fn sum_with_validity(f: &[$T], validity: &Bitmap) -> f64 {
-                let mask = BitMask::new(validity);
-                assert!(f.len() == mask.len);
+                let mask = BitMask::from_bitmap(validity);
+                assert!(f.len() == mask.len());
 
                 let remainder = f.len() % PAIRWISE_RECURSION_LIMIT;
                 let (rest, main) = f.split_at(remainder);

--- a/crates/polars-core/src/chunked_array/ops/gather.rs
+++ b/crates/polars-core/src/chunked_array/ops/gather.rs
@@ -25,7 +25,6 @@ pub fn check_bounds_nulls(idx: &PrimitiveArray<IdxSize>, len: IdxSize) -> Polars
     Ok(())
 }
 
-
 impl<T: PolarsDataType, I: AsRef<[IdxSize]> + ?Sized> ChunkTake<I> for ChunkedArray<T>
 where
     ChunkedArray<T>: ChunkTakeUnchecked<I>,
@@ -39,7 +38,6 @@ where
         Ok(unsafe { self.take_unchecked(indices) })
     }
 }
-
 
 impl<T: PolarsDataType> ChunkTake<IdxCa> for ChunkedArray<T>
 where

--- a/crates/polars-core/src/datatypes/static_array.rs
+++ b/crates/polars-core/src/datatypes/static_array.rs
@@ -55,10 +55,17 @@ pub trait StaticArray:
     /// # Safety
     /// It is the callers responsibility that the `idx < self.len()`.
     unsafe fn value_unchecked(&self, idx: usize) -> Self::ValueT<'_>;
-    
+
+    /// # Safety
+    /// The indices must be in-bounds.
     #[inline]
-    unsafe fn gather_unchecked_trusted<I: Iterator<Item=usize> + TrustedLen>(&self, it: I, dtype: DataType) -> Self {
-        it.map(|i| self.value_unchecked(i)).collect_arr_with_dtype(dtype)
+    unsafe fn gather_unchecked_trusted<I: Iterator<Item = usize> + TrustedLen>(
+        &self,
+        it: I,
+        dtype: DataType,
+    ) -> Self {
+        it.map(|i| self.value_unchecked(i))
+            .collect_arr_with_dtype(dtype)
     }
 
     fn iter(&self) -> ZipValidity<Self::ValueT<'_>, Self::ValueIterT<'_>, BitmapIter>;
@@ -84,7 +91,11 @@ impl<T: NumericNative> StaticArray for PrimitiveArray<T> {
     }
 
     #[inline]
-    unsafe fn gather_unchecked_trusted<I: Iterator<Item=usize> + TrustedLen>(&self, it: I, _dtype: DataType) -> Self {
+    unsafe fn gather_unchecked_trusted<I: Iterator<Item = usize> + TrustedLen>(
+        &self,
+        it: I,
+        _dtype: DataType,
+    ) -> Self {
         let arr: &[T] = self.values();
         let v = Vec::from_trusted_len_iter(it.map(|i| *arr.get_unchecked(i)));
         PrimitiveArray::from_vec(v)

--- a/crates/polars-core/src/datatypes/static_array.rs
+++ b/crates/polars-core/src/datatypes/static_array.rs
@@ -54,7 +54,7 @@ pub trait StaticArray:
     /// # Safety
     /// It is the callers responsibility that the `idx < self.len()`.
     unsafe fn value_unchecked(&self, idx: usize) -> Self::ValueT<'_>;
-    
+
     #[inline(always)]
     fn as_slice(&self) -> Option<&[Self::ValueT<'_>]> {
         None

--- a/crates/polars-core/src/datatypes/static_array.rs
+++ b/crates/polars-core/src/datatypes/static_array.rs
@@ -65,7 +65,7 @@ pub trait StaticArray:
         dtype: DataType,
     ) -> Self {
         it.map(|i| self.value_unchecked(i))
-            .collect_arr_with_dtype(dtype)
+            .collect_arr_trusted_with_dtype(dtype)
     }
 
     fn iter(&self) -> ZipValidity<Self::ValueT<'_>, Self::ValueIterT<'_>, BitmapIter>;

--- a/crates/polars-core/src/datatypes/static_array_collect.rs
+++ b/crates/polars-core/src/datatypes/static_array_collect.rs
@@ -298,10 +298,12 @@ macro_rules! impl_trusted_collect_vec_validity {
 }
 
 impl<T: NumericNative> ArrayFromIter<T> for PrimitiveArray<T> {
+    #[inline]
     fn arr_from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         PrimitiveArray::from_vec(iter.into_iter().collect())
     }
 
+    #[inline]
     fn arr_from_iter_trusted<I>(iter: I) -> Self
     where
         I: IntoIterator<Item = T>,
@@ -310,11 +312,13 @@ impl<T: NumericNative> ArrayFromIter<T> for PrimitiveArray<T> {
         PrimitiveArray::from_vec(Vec::from_trusted_len_iter(iter))
     }
 
+    #[inline]
     fn try_arr_from_iter<E, I: IntoIterator<Item = Result<T, E>>>(iter: I) -> Result<Self, E> {
         let v: Result<Vec<T>, E> = iter.into_iter().collect();
         Ok(PrimitiveArray::from_vec(v?))
     }
 
+    #[inline]
     fn try_arr_from_iter_trusted<E, I>(iter: I) -> Result<Self, E>
     where
         I: IntoIterator<Item = Result<T, E>>,

--- a/crates/polars-core/src/datatypes/static_array_collect.rs
+++ b/crates/polars-core/src/datatypes/static_array_collect.rs
@@ -83,7 +83,7 @@ impl<T, A: ParameterFreeDtypeStaticArray + ArrayFromIter<T>> ArrayFromIterDtype<
         I::IntoIter: TrustedLen,
     {
         debug_assert!(std::mem::discriminant(&dtype) == std::mem::discriminant(&A::get_dtype()));
-        Self::arr_from_iter_with_dtype(dtype, iter)
+        Self::arr_from_iter_trusted(iter)
     }
 
     #[inline(always)]
@@ -102,7 +102,7 @@ impl<T, A: ParameterFreeDtypeStaticArray + ArrayFromIter<T>> ArrayFromIterDtype<
         I::IntoIter: TrustedLen,
     {
         debug_assert!(std::mem::discriminant(&dtype) == std::mem::discriminant(&A::get_dtype()));
-        Self::try_arr_from_iter_with_dtype(dtype, iter)
+        Self::try_arr_from_iter_trusted(iter)
     }
 }
 

--- a/crates/polars-ops/src/chunked_array/set.rs
+++ b/crates/polars-ops/src/chunked_array/set.rs
@@ -4,6 +4,7 @@ use polars_core::prelude::*;
 use polars_core::series::IsSorted;
 use polars_core::utils::arrow::bitmap::MutableBitmap;
 use polars_core::utils::arrow::types::NativeType;
+use polars_utils::index::check_bounds;
 
 pub trait ChunkedSet<T: Copy> {
     fn set_at_idx2<V>(self, idx: &[IdxSize], values: V) -> PolarsResult<Series>
@@ -24,19 +25,6 @@ fn check_sorted(idx: &[IdxSize]) -> PolarsResult<()> {
         previous = i;
     }
     polars_ensure!(sorted, ComputeError: "set indices must be sorted");
-    Ok(())
-}
-
-fn check_bounds(idx: &[IdxSize], len: IdxSize) -> PolarsResult<()> {
-    let mut inbounds = true;
-
-    for &i in idx {
-        if i >= len {
-            // we will not break here as that prevents SIMD
-            inbounds = false;
-        }
-    }
-    polars_ensure!(inbounds, ComputeError: "set indices are out of bounds");
     Ok(())
 }
 

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -1,0 +1,16 @@
+use polars_error::{polars_bail, polars_ensure, PolarsResult};
+
+use crate::IdxSize;
+
+pub fn check_bounds(idx: &[IdxSize], len: IdxSize) -> PolarsResult<()> {
+    let mut inbounds = true;
+
+    for &i in idx {
+        if i >= len {
+            // we will not break here as that prevents SIMD
+            inbounds = false;
+        }
+    }
+    polars_ensure!(inbounds, ComputeError: "indices are out of bounds");
+    Ok(())
+}

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -29,5 +29,7 @@ pub mod vec;
 #[cfg(target_family = "wasm")]
 pub mod wasm;
 
+pub mod index;
 pub mod io;
+
 pub use io::open_file;


### PR DESCRIPTION
If the number of target arrays is > 8 we rechunk, otherwise we do a bitwise binary search to find the chunk index.