### PR TITLE
fix(python): improve handling of database drivers that can return arrow data

### DIFF
--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -123,10 +123,7 @@ class ConnectionExecutor:
         result: Cursor, fetch_method: str, batch_size: int | None
     ) -> Iterable[pa.RecordBatch | pa.Table]:
         """Iterate over the result set, fetching arrow data in batches."""
-        size = (batch_size,) if batch_size else ()
-        while result:  # type: ignore[truthy-bool]
-            result = getattr(result, fetch_method)(*size)
-            yield result
+        yield from getattr(result, fetch_method)(batch_size)
 
     @staticmethod
     def _fetchall_rows(result: Cursor) -> Iterable[Sequence[Any]]:
@@ -156,27 +153,35 @@ class ConnectionExecutor:
         self, batch_size: int | None, schema_overrides: SchemaDict | None
     ) -> DataFrame | None:
         """Return resultset data in Arrow format for frame init."""
-        from polars import DataFrame
+        from polars import from_arrow
 
-        for driver, driver_properties in _ARROW_DRIVER_REGISTRY_.items():
-            if re.match(f"^{driver}$", self.driver_name):
-                size = batch_size if driver_properties["exact_batch_size"] else None
-                fetch_batches = driver_properties["fetch_batches"]
-                return DataFrame(
-                    data=(
-                        self._fetch_arrow(self.result, fetch_batches, size)
-                        if batch_size and fetch_batches is not None
-                        else getattr(self.result, driver_properties["fetch_all"])()
-                    ),
+        try:
+            for driver, driver_properties in _ARROW_DRIVER_REGISTRY_.items():
+                if re.match(f"^{driver}$", self.driver_name):
+                    size = batch_size if driver_properties["exact_batch_size"] else None
+                    fetch_batches = driver_properties["fetch_batches"]
+                    return from_arrow(  # type: ignore[return-value]
+                        data=(
+                            self._fetch_arrow(self.result, fetch_batches, size)
+                            if batch_size and fetch_batches is not None
+                            else getattr(self.result, driver_properties["fetch_all"])()
+                        ),
+                        schema_overrides=schema_overrides,
+                    )
+
+            if self.driver_name == "duckdb":
+                exec_kwargs = {"rows_per_batch": batch_size} if batch_size else {}
+                return from_arrow(  # type: ignore[return-value]
+                    self.result.arrow(**exec_kwargs),
                     schema_overrides=schema_overrides,
                 )
-
-        if self.driver_name == "duckdb":
-            exec_kwargs = {"rows_per_batch": batch_size} if batch_size else {}
-            return DataFrame(
-                self.result.arrow(**exec_kwargs),
-                schema_overrides=schema_overrides,
-            )
+        except Exception as err:
+            if (
+                self.driver_name != "turbodbc"
+                # eg: turbodbc compiled without arrow support...
+                or "does not support Apache Arrow" not in str(err)
+            ):
+                raise
 
         return None
 

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -43,6 +43,11 @@ _ARROW_DRIVER_REGISTRY_: dict[str, _DriverProperties_] = {
         "fetch_batches": "fetchmany_arrow",
         "exact_batch_size": True,
     },
+    "duckdb": {
+        "fetch_all": "fetch_arrow_table",
+        "fetch_batches": "fetch_record_batch",
+        "exact_batch_size": True,
+    },
     "snowflake": {
         "fetch_all": "fetch_arrow_all",
         "fetch_batches": "fetch_arrow_batches",
@@ -168,13 +173,6 @@ class ConnectionExecutor:
                         ),
                         schema_overrides=schema_overrides,
                     )
-
-            if self.driver_name == "duckdb":
-                exec_kwargs = {"rows_per_batch": batch_size} if batch_size else {}
-                return from_arrow(  # type: ignore[return-value]
-                    self.result.arrow(**exec_kwargs),
-                    schema_overrides=schema_overrides,
-                )
         except Exception as err:
             if (
                 self.driver_name != "turbodbc"

--- a/py-polars/tests/unit/interchange/test_from_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_from_dataframe.py
@@ -56,11 +56,11 @@ def test_from_dataframe_pyarrow_recordbatch_zero_copy() -> None:
     a = pa.array([1, 2])
     b = pa.array([3.0, 4.0])
     c = pa.array(["foo", "bar"])
+
     batch = pa.record_batch([a, b, c], names=["a", "b", "c"])
-
     result = pl.from_dataframe(batch, allow_copy=False)
-
     expected = pl.DataFrame({"a": [1, 2], "b": [3.0, 4.0], "c": ["foo", "bar"]})
+
     assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/io/test_database_read.py
+++ b/py-polars/tests/unit/io/test_database_read.py
@@ -77,6 +77,7 @@ def create_temp_sqlite_db(test_db: str) -> None:
         "expected_dtypes",
         "expected_dates",
         "schema_overrides",
+        "batch_size",
     ),
     [
         pytest.param(
@@ -90,6 +91,7 @@ def create_temp_sqlite_db(test_db: str) -> None:
             },
             [date(2020, 1, 1), date(2021, 12, 31)],
             {"id": pl.UInt8},
+            None,
             id="uri: connectorx",
         ),
         pytest.param(
@@ -103,6 +105,7 @@ def create_temp_sqlite_db(test_db: str) -> None:
             },
             ["2020-01-01", "2021-12-31"],
             {"id": pl.UInt8},
+            None,
             marks=pytest.mark.skipif(
                 sys.version_info < (3, 9) or sys.platform == "win32",
                 reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
@@ -120,6 +123,7 @@ def create_temp_sqlite_db(test_db: str) -> None:
             },
             [date(2020, 1, 1), date(2021, 12, 31)],
             {"id": pl.UInt8, "value": pl.Float32},
+            None,
             id="conn: sqlite3",
         ),
         pytest.param(
@@ -136,6 +140,7 @@ def create_temp_sqlite_db(test_db: str) -> None:
             },
             [date(2020, 1, 1), date(2021, 12, 31)],
             None,
+            None,
             id="conn: sqlalchemy",
         ),
         pytest.param(
@@ -149,11 +154,30 @@ def create_temp_sqlite_db(test_db: str) -> None:
             },
             ["2020-01-01", "2021-12-31"],
             None,
+            None,
             marks=pytest.mark.skipif(
                 sys.version_info < (3, 9) or sys.platform == "win32",
                 reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
             ),
-            id="conn: adbc",
+            id="conn: adbc (fetchall)",
+        ),
+        pytest.param(
+            "read_database",
+            adbc_sqlite_connect,
+            {
+                "id": pl.Int64,
+                "name": pl.Utf8,
+                "value": pl.Float64,
+                "date": pl.Utf8,
+            },
+            ["2020-01-01", "2021-12-31"],
+            None,
+            1,
+            marks=pytest.mark.skipif(
+                sys.version_info < (3, 9) or sys.platform == "win32",
+                reason="adbc_driver_sqlite not available below Python 3.9 / on Windows",
+            ),
+            id="conn: adbc (batched)",
         ),
     ],
 )
@@ -163,6 +187,7 @@ def test_read_database(
     expected_dtypes: dict[str, pl.DataType],
     expected_dates: list[date | str],
     schema_overrides: SchemaDict | None,
+    batch_size: int | None,
     tmp_path: Path,
 ) -> None:
     tmp_path.mkdir(exist_ok=True)
@@ -184,6 +209,7 @@ def test_read_database(
                 connection=conn,
                 query="SELECT * FROM test_data",
                 schema_overrides=schema_overrides,
+                batch_size=batch_size,
             )
     else:
         # other user-supplied connections
@@ -191,6 +217,7 @@ def test_read_database(
             connection=engine_or_connection_init(test_db),
             query="SELECT * FROM test_data WHERE name NOT LIKE '%polars%'",
             schema_overrides=schema_overrides,
+            batch_size=batch_size,
         )
 
     assert df.schema == expected_dtypes


### PR DESCRIPTION
Closes #11131.

Reworked the batched Arrow-return path and improved the related mocked tests. 

**Updates:** 
* Was finally able to install `turbodbc` _with_ the arrow extensions and validate the fix.
* Standardised `duckdb` interactions, adding an entry into the driver registry.
