### PR TITLE
fix(python): address VSCode issue with autocomplete on `selector` expressions in editor/console

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9136,7 +9136,7 @@ class DataFrame:
         from polars.selectors import expand_selector, is_selector
 
         if is_selector(key):
-            key_tuple = expand_selector(target=self, selector=key)  # type: ignore[type-var]
+            key_tuple = expand_selector(target=self, selector=key)
         elif not isinstance(key, str):
             key_tuple = tuple(key)  # type: ignore[arg-type]
         else:
@@ -9174,7 +9174,7 @@ class DataFrame:
                     k = get_key(d)
                     if not include_key:
                         for ix in key_tuple:
-                            del d[ix]
+                            del d[ix]  # type: ignore[arg-type]
                     if unique:
                         rows[k] = d
                     else:

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from datetime import timezone
-from typing import TYPE_CHECKING, Any, Collection, Mapping, TypeVar
+from typing import TYPE_CHECKING, Any, Collection, Literal, Mapping, overload
 
 from polars import functions as F
 from polars.datatypes import (
@@ -31,12 +31,22 @@ if TYPE_CHECKING:
 
     from polars import DataFrame, LazyFrame
     from polars.datatypes import PolarsDataType
-    from polars.type_aliases import TimeUnit
+    from polars.type_aliases import SelectorType, TimeUnit
 
     if sys.version_info >= (3, 11):
         from typing import Self
     else:
         from typing_extensions import Self
+
+
+@overload
+def is_selector(obj: _selector_proxy_) -> Literal[True]:  # type: ignore[misc]
+    ...
+
+
+@overload
+def is_selector(obj: Any) -> Literal[False]:
+    ...
 
 
 def is_selector(obj: Any) -> bool:
@@ -322,9 +332,6 @@ def _re_string(string: str | Collection[str]) -> str:
                 strings.append(st)
         rx = "|".join(re.escape(x) for x in strings)
     return f"({rx})"
-
-
-SelectorType = TypeVar("SelectorType", Expr, _selector_proxy_)
 
 
 def all() -> SelectorType:
@@ -1964,5 +1971,4 @@ __all__ = [
     "string",
     "is_selector",
     "expand_selector",
-    "SelectorType",
 ]


### PR DESCRIPTION
Closes #11226.

It seems that PyCharm correctly resolved the `_selector_proxy_` type as `Expr` (so I didn't notice any issues with it), but VSCode didn't (or otherwise got confused), apparently leading to no VSCode autocomplete on selector expressions. 

This PR removes a redundant `SelectorType` declaration (plausibly responsible in some way) and very slightly tweaks the `selectors` module typing. Installed a copy of VSCode to help validate/debug the issue and can confirm that this change seems to fix things (while PyCharm remains happy).

---

VSCode users rejoice  ;)

<img width="402" alt="Screenshot 2023-09-21 at 23 34 33" src="https://github.com/pola-rs/polars/assets/2613171/39316e70-a4ad-4c70-8f41-14685ebfe814">

