### PR TITLE
fix(rust, python): return correct results in group_by_rolling if there are duplicates

### DIFF
--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1261,7 +1261,7 @@ impl Expr {
                         tz: tz.as_ref(),
                         closed_window: options.closed_window,
                         fn_params: options.fn_params.clone(),
-                        by_unique_values: Some(by.n_unique()? == by.len())
+                        unique_time_values: Some(by.n_unique()? == by.len()),
                     };
 
                     rolling_fn(s, options).map(Some)

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1261,6 +1261,7 @@ impl Expr {
                         tz: tz.as_ref(),
                         closed_window: options.closed_window,
                         fn_params: options.fn_params.clone(),
+                        by_unique_values: Some(by.n_unique()? == by.len())
                     };
 
                     rolling_fn(s, options).map(Some)

--- a/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
@@ -72,7 +72,7 @@ pub struct RollingOptionsImpl<'a> {
     pub tz: Option<&'a TimeZone>,
     pub closed_window: Option<ClosedWindow>,
     pub fn_params: DynArgs,
-    pub by_unique_values: Option<bool>,
+    pub unique_time_values: Option<bool>,
 }
 
 #[cfg(feature = "rolling_window")]
@@ -94,7 +94,7 @@ impl From<RollingOptions> for RollingOptionsImpl<'static> {
             tz: None,
             closed_window: None,
             fn_params: options.fn_params,
-            by_unique_values: None,
+            unique_time_values: None,
         }
     }
 }
@@ -131,7 +131,7 @@ impl Default for RollingOptionsImpl<'static> {
             tz: None,
             closed_window: None,
             fn_params: None,
-            by_unique_values: None,
+            unique_time_values: None,
         }
     }
 }
@@ -247,7 +247,7 @@ fn rolling_agg<T>(
             ClosedWindow,
             TimeUnit,
             Option<&TimeZone>,
-            Option<bool>,
+            bool,
             DynArgs,
         ) -> PolarsResult<ArrayRef>,
     >,
@@ -305,7 +305,9 @@ where
             closed_window,
             tu,
             options.tz,
-            options.by_unique_values,
+            options
+                .unique_time_values
+                .expect("unique_time_values has already been calculated"),
             options.fn_params,
         )
     }?;

--- a/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
@@ -72,6 +72,7 @@ pub struct RollingOptionsImpl<'a> {
     pub tz: Option<&'a TimeZone>,
     pub closed_window: Option<ClosedWindow>,
     pub fn_params: DynArgs,
+    pub by_unique_values: Option<bool>,
 }
 
 #[cfg(feature = "rolling_window")]
@@ -93,6 +94,7 @@ impl From<RollingOptions> for RollingOptionsImpl<'static> {
             tz: None,
             closed_window: None,
             fn_params: options.fn_params,
+            by_unique_values: None,
         }
     }
 }
@@ -129,6 +131,7 @@ impl Default for RollingOptionsImpl<'static> {
             tz: None,
             closed_window: None,
             fn_params: None,
+            by_unique_values: None,
         }
     }
 }
@@ -244,6 +247,7 @@ fn rolling_agg<T>(
             ClosedWindow,
             TimeUnit,
             Option<&TimeZone>,
+            Option<bool>,
             DynArgs,
         ) -> PolarsResult<ArrayRef>,
     >,
@@ -301,6 +305,7 @@ where
             closed_window,
             tu,
             options.tz,
+            options.by_unique_values,
             options.fn_params,
         )
     }?;

--- a/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
@@ -54,6 +54,7 @@ pub(crate) fn rolling_min<T>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
+    by_unique_values: Option<bool>,
     _params: DynArgs,
 ) -> PolarsResult<ArrayRef>
 where
@@ -61,8 +62,8 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
-        _ => group_by_values_iter(period, time, closed_window, tu, None),
+        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok(), by_unique_values),
+        _ => group_by_values_iter(period, time, closed_window, tu, None, by_unique_values),
     };
     rolling_apply_agg_window::<no_nulls::MinWindow<_>, _, _>(values, offset_iter, None)
 }
@@ -75,6 +76,7 @@ pub(crate) fn rolling_max<T>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
+    by_unique_values: Option<bool>,
     _params: DynArgs,
 ) -> PolarsResult<ArrayRef>
 where
@@ -82,8 +84,8 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
-        _ => group_by_values_iter(period, time, closed_window, tu, None),
+        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok(), by_unique_values),
+        _ => group_by_values_iter(period, time, closed_window, tu, None, by_unique_values),
     };
     rolling_apply_agg_window::<no_nulls::MaxWindow<_>, _, _>(values, offset_iter, None)
 }
@@ -96,6 +98,7 @@ pub(crate) fn rolling_sum<T>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
+    by_unique_values: Option<bool>,
     _params: DynArgs,
 ) -> PolarsResult<ArrayRef>
 where
@@ -103,8 +106,8 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
-        _ => group_by_values_iter(period, time, closed_window, tu, None),
+        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok(), by_unique_values),
+        _ => group_by_values_iter(period, time, closed_window, tu, None, by_unique_values),
     };
     rolling_apply_agg_window::<no_nulls::SumWindow<_>, _, _>(values, offset_iter, None)
 }
@@ -117,6 +120,7 @@ pub(crate) fn rolling_mean<T>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
+    by_unique_values: Option<bool>,
     _params: DynArgs,
 ) -> PolarsResult<ArrayRef>
 where
@@ -124,8 +128,8 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
-        _ => group_by_values_iter(period, time, closed_window, tu, None),
+        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok(), by_unique_values),
+        _ => group_by_values_iter(period, time, closed_window, tu, None, by_unique_values),
     };
     rolling_apply_agg_window::<no_nulls::MeanWindow<_>, _, _>(values, offset_iter, None)
 }
@@ -138,6 +142,7 @@ pub(crate) fn rolling_var<T>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
+    by_unique_values: Option<bool>,
     params: DynArgs,
 ) -> PolarsResult<ArrayRef>
 where
@@ -145,8 +150,8 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
-        _ => group_by_values_iter(period, time, closed_window, tu, None),
+        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok(), by_unique_values),
+        _ => group_by_values_iter(period, time, closed_window, tu, None, by_unique_values),
     };
     rolling_apply_agg_window::<no_nulls::VarWindow<_>, _, _>(values, offset_iter, params)
 }
@@ -159,6 +164,7 @@ pub(crate) fn rolling_quantile<T>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
+    by_unique_values: Option<bool>,
     params: DynArgs,
 ) -> PolarsResult<ArrayRef>
 where
@@ -166,8 +172,8 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
-        _ => group_by_values_iter(period, time, closed_window, tu, None),
+        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok(), by_unique_values),
+        _ => group_by_values_iter(period, time, closed_window, tu, None, by_unique_values),
     };
     rolling_apply_agg_window::<no_nulls::QuantileWindow<_>, _, _>(values, offset_iter, params)
 }

--- a/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
@@ -54,7 +54,7 @@ pub(crate) fn rolling_min<T>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
-    by_unique_values: Option<bool>,
+    unique_time_values: bool,
     _params: DynArgs,
 ) -> PolarsResult<ArrayRef>
 where
@@ -62,8 +62,15 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok(), by_unique_values),
-        _ => group_by_values_iter(period, time, closed_window, tu, None, by_unique_values),
+        Some(tz) => group_by_values_iter(
+            period,
+            time,
+            closed_window,
+            tu,
+            tz.parse::<Tz>().ok(),
+            unique_time_values,
+        ),
+        _ => group_by_values_iter(period, time, closed_window, tu, None, unique_time_values),
     };
     rolling_apply_agg_window::<no_nulls::MinWindow<_>, _, _>(values, offset_iter, None)
 }
@@ -76,7 +83,7 @@ pub(crate) fn rolling_max<T>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
-    by_unique_values: Option<bool>,
+    unique_time_values: bool,
     _params: DynArgs,
 ) -> PolarsResult<ArrayRef>
 where
@@ -84,8 +91,15 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok(), by_unique_values),
-        _ => group_by_values_iter(period, time, closed_window, tu, None, by_unique_values),
+        Some(tz) => group_by_values_iter(
+            period,
+            time,
+            closed_window,
+            tu,
+            tz.parse::<Tz>().ok(),
+            unique_time_values,
+        ),
+        _ => group_by_values_iter(period, time, closed_window, tu, None, unique_time_values),
     };
     rolling_apply_agg_window::<no_nulls::MaxWindow<_>, _, _>(values, offset_iter, None)
 }
@@ -98,7 +112,7 @@ pub(crate) fn rolling_sum<T>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
-    by_unique_values: Option<bool>,
+    unique_time_values: bool,
     _params: DynArgs,
 ) -> PolarsResult<ArrayRef>
 where
@@ -106,8 +120,15 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok(), by_unique_values),
-        _ => group_by_values_iter(period, time, closed_window, tu, None, by_unique_values),
+        Some(tz) => group_by_values_iter(
+            period,
+            time,
+            closed_window,
+            tu,
+            tz.parse::<Tz>().ok(),
+            unique_time_values,
+        ),
+        _ => group_by_values_iter(period, time, closed_window, tu, None, unique_time_values),
     };
     rolling_apply_agg_window::<no_nulls::SumWindow<_>, _, _>(values, offset_iter, None)
 }
@@ -120,7 +141,7 @@ pub(crate) fn rolling_mean<T>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
-    by_unique_values: Option<bool>,
+    unique_time_values: bool,
     _params: DynArgs,
 ) -> PolarsResult<ArrayRef>
 where
@@ -128,8 +149,15 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok(), by_unique_values),
-        _ => group_by_values_iter(period, time, closed_window, tu, None, by_unique_values),
+        Some(tz) => group_by_values_iter(
+            period,
+            time,
+            closed_window,
+            tu,
+            tz.parse::<Tz>().ok(),
+            unique_time_values,
+        ),
+        _ => group_by_values_iter(period, time, closed_window, tu, None, unique_time_values),
     };
     rolling_apply_agg_window::<no_nulls::MeanWindow<_>, _, _>(values, offset_iter, None)
 }
@@ -142,7 +170,7 @@ pub(crate) fn rolling_var<T>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
-    by_unique_values: Option<bool>,
+    unique_time_values: bool,
     params: DynArgs,
 ) -> PolarsResult<ArrayRef>
 where
@@ -150,8 +178,15 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok(), by_unique_values),
-        _ => group_by_values_iter(period, time, closed_window, tu, None, by_unique_values),
+        Some(tz) => group_by_values_iter(
+            period,
+            time,
+            closed_window,
+            tu,
+            tz.parse::<Tz>().ok(),
+            unique_time_values,
+        ),
+        _ => group_by_values_iter(period, time, closed_window, tu, None, unique_time_values),
     };
     rolling_apply_agg_window::<no_nulls::VarWindow<_>, _, _>(values, offset_iter, params)
 }
@@ -164,7 +199,7 @@ pub(crate) fn rolling_quantile<T>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<&TimeZone>,
-    by_unique_values: Option<bool>,
+    unique_time_values: bool,
     params: DynArgs,
 ) -> PolarsResult<ArrayRef>
 where
@@ -172,8 +207,15 @@ where
 {
     let offset_iter = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok(), by_unique_values),
-        _ => group_by_values_iter(period, time, closed_window, tu, None, by_unique_values),
+        Some(tz) => group_by_values_iter(
+            period,
+            time,
+            closed_window,
+            tu,
+            tz.parse::<Tz>().ok(),
+            unique_time_values,
+        ),
+        _ => group_by_values_iter(period, time, closed_window, tu, None, unique_time_values),
     };
     rolling_apply_agg_window::<no_nulls::QuantileWindow<_>, _, _>(values, offset_iter, params)
 }

--- a/crates/polars-time/src/group_by/dynamic.rs
+++ b/crates/polars-time/src/group_by/dynamic.rs
@@ -538,6 +538,7 @@ impl Wrap<&DataFrame> {
                     options.closed_window,
                     tu,
                     tz,
+                    dt.n_unique()? == dt.len(),
                 )?,
                 rolling: true,
             })
@@ -576,6 +577,7 @@ impl Wrap<&DataFrame> {
                                 options.closed_window,
                                 tu,
                                 tz,
+                                dt.n_unique()? == dt.len(),
                             )?;
                             Ok(update_subgroups_idx(&sub_groups, base_g))
                         })
@@ -597,6 +599,7 @@ impl Wrap<&DataFrame> {
                                 options.closed_window,
                                 tu,
                                 tz,
+                                dt.n_unique()? == dt.len(),
                             )?;
                             Ok(update_subgroups_slice(&sub_groups, *base_g))
                         })

--- a/crates/polars-time/src/windows/group_by.rs
+++ b/crates/polars-time/src/windows/group_by.rs
@@ -460,12 +460,19 @@ pub(crate) fn group_by_values_iter<'a>(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<Tz>,
+    by_unique_values: Option<bool>,
 ) -> Box<dyn TrustedLen<Item = PolarsResult<(IdxSize, IdxSize)>> + 'a> {
     let mut offset = period;
     offset.negative = true;
-    // t is at the right endpoint of the window
-    let iter = group_by_values_iter_lookbehind(period, offset, time, closed_window, tu, tz, 0);
-    Box::new(iter)
+    if by_unique_values == Some(true) {
+        // t is at the right endpoint of the window
+        let iter = group_by_values_iter_lookbehind(period, offset, time, closed_window, tu, tz, 0);
+        Box::new(iter)
+    } else {
+        let iter = group_by_values_iter_partial_lookbehind(period, offset, time, closed_window, tu, tz);
+        Box::new(iter)
+
+    }
 }
 
 /// Different from `group_by_windows`, where define window buckets and search which values fit that

--- a/crates/polars-time/src/windows/test.rs
+++ b/crates/polars-time/src/windows/test.rs
@@ -690,6 +690,7 @@ fn test_rolling_lookback() {
         ClosedWindow::Right,
         TimeUnit::Milliseconds,
         None,
+        true,
     )
     .unwrap();
     assert_eq!(dates.len(), groups.len());
@@ -711,6 +712,7 @@ fn test_rolling_lookback() {
         ClosedWindow::Right,
         TimeUnit::Milliseconds,
         None,
+        true,
     )
     .unwrap();
     assert_eq!(dates.len(), groups.len());
@@ -732,6 +734,7 @@ fn test_rolling_lookback() {
         ClosedWindow::Right,
         TimeUnit::Milliseconds,
         None,
+        true,
     )
     .unwrap();
     assert_eq!(dates.len(), groups.len());

--- a/py-polars/tests/parametric/test_groupby_rolling.py
+++ b/py-polars/tests/parametric/test_groupby_rolling.py
@@ -41,7 +41,7 @@ def test_group_by_rolling(
             ],
         )
     )
-    df = dataframe.sort("ts").unique("ts")
+    df = dataframe.sort("ts")
     try:
         result = df.group_by_rolling(
             "ts", period=period, offset=offset, closed=closed
@@ -73,5 +73,82 @@ def test_group_by_rolling(
     expected = pl.DataFrame(expected_dict).select(
         pl.col("ts").cast(pl.Datetime(time_unit)),
         pl.col("value").cast(pl.List(pl.Int64)),
+    )
+    assert_frame_equal(result, expected)
+
+
+@given(
+    window_size=st.timedeltas(min_value=timedelta(microseconds=0)).map(
+        _timedelta_to_pl_duration
+    ),
+    closed=strategy_closed,
+    data=st.data(),
+    time_unit=strategy_time_unit,
+    aggregation=st.sampled_from(
+        [
+            "min",
+            "max",
+            "mean",
+            "sum",
+            #  "std", blocked by https://github.com/pola-rs/polars/issues/11140
+            #  "var", blocked by https://github.com/pola-rs/polars/issues/11140
+            "median",
+        ]
+    ),
+)
+def test_rolling_aggs(
+    window_size: str,
+    closed: ClosedInterval,
+    data: st.DataObject,
+    time_unit: TimeUnit,
+    aggregation: str,
+) -> None:
+    assume(window_size != "")
+    dataframe = data.draw(
+        dataframes(
+            [
+                column("ts", dtype=pl.Datetime(time_unit)),
+                column("value", dtype=pl.Int64),
+            ],
+        )
+    )
+    df = dataframe.sort("ts")
+    func = f"rolling_{aggregation}"
+    try:
+        result = df.with_columns(
+            getattr(pl.col("value"), func)(
+                window_size=window_size, by="ts", closed=closed
+            )
+        )
+    except pl.exceptions.PolarsPanicError as exc:
+        assert any(  # noqa: PT017
+            msg in str(exc)
+            for msg in (
+                "attempt to multiply with overflow",
+                "attempt to add with overflow",
+            )
+        )
+        reject()
+
+    expected_dict: dict[str, list[object]] = {"ts": [], "value": []}
+    for ts, _ in df.iter_rows():
+        window = df.filter(
+            pl.col("ts").is_between(
+                pl.lit(ts, dtype=pl.Datetime(time_unit)).dt.offset_by(
+                    f"-{window_size}"
+                ),
+                pl.lit(ts, dtype=pl.Datetime(time_unit)),
+                closed=closed,
+            )
+        )
+        expected_dict["ts"].append(ts)
+        if window.is_empty():
+            expected_dict["value"].append(None)
+        else:
+            value = getattr(window["value"], aggregation)()
+            expected_dict["value"].append(value)
+    expected = pl.DataFrame(expected_dict).select(
+        pl.col("ts").cast(pl.Datetime(time_unit)),
+        pl.col("value").cast(result["value"].dtype),
     )
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -78,6 +78,15 @@ def test_rolling_kernels_and_group_by_rolling(
     assert_frame_equal(out1, out2)
 
 
+def test_group_by_rolling_with_dupes_11150() -> None:
+    df = pl.DataFrame({"ts": [datetime(2000, 1, 1)] * 2, "value": [0, 1]})
+    result = df.sort("ts").with_columns(
+        pl.col("value").rolling_max("1d", by="ts", closed="right")
+    )
+    expected = pl.DataFrame({"ts": [datetime(2000, 1, 1)] * 2, "value": [1, 1]})
+    assert_frame_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     ("offset", "closed", "expected_values"),
     [


### PR DESCRIPTION
closes #11150

Timing: https://www.kaggle.com/code/marcogorelli/polars-timing/notebook?scriptVersionId=143796114

From the above, on ~100 million rows:
- no duplicates
  - before: 7.34 s ± 52 ms
  - after: 7.6 s ± 107 ms (no big difference)
- duplicates 
  - before: 7.89 s ± 46 ms
  - after: 20 s ± 73.9 ms (slower, but at least now it's correct)