### PR TITLE
refactor(rust): remove lz4_flex feature

### DIFF
--- a/crates/nano-arrow/Cargo.toml
+++ b/crates/nano-arrow/Cargo.toml
@@ -145,7 +145,6 @@ io_parquet_sample_test = ["io_parquet"]
 io_parquet_zstd = ["parquet2/zstd"]
 io_parquet_snappy = ["parquet2/snappy"]
 io_parquet_gzip = ["parquet2/gzip"]
-io_parquet_lz4_flex = ["parquet2/lz4_flex"]
 io_parquet_lz4 = ["parquet2/lz4"]
 io_parquet_brotli = ["parquet2/brotli"]
 


### PR DESCRIPTION
This fixes rust-analyzer in tests (or `cargo check` in general with `--all-features`), because `parquet2` has made the cardinal sin of having mutually exclusive features. This does mean that downstream Rust users of Polars can no longer choose which lz4 library it uses... which I don't think really matters all that much.