### PR TITLE
chore(rust): bump chrono to 0.4.31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ ahash = "0.8"
 atoi = "2"
 bitflags = "2"
 bytemuck = { version = "1", features = ["derive", "extern_crate_alloc"] }
-chrono = { version = "0.4", default-features = false, features = ["std"] }
+chrono = { version = "0.4.31", default-features = false, features = ["std"] }
 chrono-tz = "0.8.1"
 ciborium = "0.2"
 either = "1.9"


### PR DESCRIPTION
chrono-0.4.31 deprecated `timestamp_nanos` in favor of a new function called `timestamp_nanos_opt` (see [chronotope/chrono#1275)](https://github.com/chronotope/chrono/pull/1275). Polars makes use of this new function, so chrono’s version should be bumped in the root manifest.