### PR TITLE
refactor: remove default auto-explode for map_many_private

### DIFF
--- a/crates/polars-plan/src/dsl/arithmetic.rs
+++ b/crates/polars-plan/src/dsl/arithmetic.rs
@@ -55,11 +55,8 @@ impl Expr {
             FunctionExpr::Pow(PowFunction::Generic),
             &[exponent.into()],
             false,
+            false,
         )
-        .with_function_options(|mut options| {
-            options.auto_explode = false;
-            options
-        })
     }
 
     /// Compute the square root of the given expression
@@ -117,11 +114,7 @@ impl Expr {
     /// Compute the inverse tangent of the given expression, with the angle expressed as the argument of a complex number
     #[cfg(feature = "trigonometry")]
     pub fn arctan2(self, x: Self) -> Self {
-        self.map_many_private(FunctionExpr::Atan2, &[x], false)
-            .with_function_options(|mut options| {
-                options.auto_explode = false;
-                options
-            })
+        self.map_many_private(FunctionExpr::Atan2, &[x], false, false)
     }
 
     /// Compute the hyperbolic cosine of the given expression

--- a/crates/polars-plan/src/dsl/binary.rs
+++ b/crates/polars-plan/src/dsl/binary.rs
@@ -10,6 +10,7 @@ impl BinaryNameSpace {
             FunctionExpr::BinaryExpr(BinaryFunction::Contains),
             &[pat],
             true,
+            true,
         )
     }
 
@@ -19,6 +20,7 @@ impl BinaryNameSpace {
             FunctionExpr::BinaryExpr(BinaryFunction::EndsWith),
             &[sub],
             true,
+            true,
         )
     }
 
@@ -27,6 +29,7 @@ impl BinaryNameSpace {
         self.0.map_many_private(
             FunctionExpr::BinaryExpr(BinaryFunction::StartsWith),
             &[sub],
+            true,
             true,
         )
     }

--- a/crates/polars-plan/src/dsl/dt.rs
+++ b/crates/polars-plan/src/dsl/dt.rs
@@ -219,6 +219,7 @@ impl DateLikeNameSpace {
         self.0.map_many_private(
             FunctionExpr::TemporalExpr(TemporalFunction::Truncate(offset)),
             &[every, ambiguous],
+            true,
             false,
         )
     }
@@ -266,7 +267,7 @@ impl DateLikeNameSpace {
     #[cfg(feature = "date_offset")]
     pub fn offset_by(self, by: Expr) -> Expr {
         self.0
-            .map_many_private(FunctionExpr::DateOffset, &[by], false)
+            .map_many_private(FunctionExpr::DateOffset, &[by], true, false)
     }
 
     #[cfg(feature = "timezones")]
@@ -274,6 +275,7 @@ impl DateLikeNameSpace {
         self.0.map_many_private(
             FunctionExpr::TemporalExpr(TemporalFunction::ReplaceTimeZone(time_zone)),
             &[ambiguous],
+            true,
             false,
         )
     }
@@ -282,6 +284,7 @@ impl DateLikeNameSpace {
         self.0.map_many_private(
             FunctionExpr::TemporalExpr(TemporalFunction::Combine(tu)),
             &[time],
+            true,
             false,
         )
     }

--- a/crates/polars-plan/src/dsl/dt.rs
+++ b/crates/polars-plan/src/dsl/dt.rs
@@ -267,7 +267,7 @@ impl DateLikeNameSpace {
     #[cfg(feature = "date_offset")]
     pub fn offset_by(self, by: Expr) -> Expr {
         self.0
-            .map_many_private(FunctionExpr::DateOffset, &[by], true, false)
+            .map_many_private(FunctionExpr::DateOffset, &[by], false, false)
     }
 
     #[cfg(feature = "timezones")]
@@ -275,7 +275,7 @@ impl DateLikeNameSpace {
         self.0.map_many_private(
             FunctionExpr::TemporalExpr(TemporalFunction::ReplaceTimeZone(time_zone)),
             &[ambiguous],
-            true,
+            false,
             false,
         )
     }
@@ -284,7 +284,7 @@ impl DateLikeNameSpace {
         self.0.map_many_private(
             FunctionExpr::TemporalExpr(TemporalFunction::Combine(tu)),
             &[time],
-            true,
+            false,
             false,
         )
     }

--- a/crates/polars-plan/src/dsl/dt.rs
+++ b/crates/polars-plan/src/dsl/dt.rs
@@ -259,6 +259,7 @@ impl DateLikeNameSpace {
             FunctionExpr::TemporalExpr(TemporalFunction::Round(every, offset)),
             &[ambiguous],
             false,
+            false,
         )
     }
 

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -108,7 +108,7 @@ impl ListNameSpace {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Take(null_on_oob)),
             &[index],
-            false,
+            true,
             false,
         )
     }
@@ -181,7 +181,7 @@ impl ListNameSpace {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Slice),
             &[offset, length],
-            false,
+            true,
             false,
         )
     }

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -108,7 +108,7 @@ impl ListNameSpace {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Take(null_on_oob)),
             &[index],
-            true,
+            false,
             false,
         )
     }
@@ -130,7 +130,7 @@ impl ListNameSpace {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Join),
             &[separator],
-            true,
+            false,
             false,
         )
     }
@@ -181,7 +181,7 @@ impl ListNameSpace {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Slice),
             &[offset, length],
-            true,
+            false,
             false,
         )
     }

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -90,8 +90,12 @@ impl ListNameSpace {
 
     /// Get items in every sublist by index.
     pub fn get(self, index: Expr) -> Expr {
-        self.0
-            .map_many_private(FunctionExpr::ListExpr(ListFunction::Get), &[index], false)
+        self.0.map_many_private(
+            FunctionExpr::ListExpr(ListFunction::Get),
+            &[index],
+            true,
+            false,
+        )
     }
 
     /// Get items in every sublist by multiple indexes.
@@ -104,6 +108,7 @@ impl ListNameSpace {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Take(null_on_oob)),
             &[index],
+            true,
             false,
         )
     }
@@ -125,6 +130,7 @@ impl ListNameSpace {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Join),
             &[separator],
+            true,
             false,
         )
     }
@@ -175,6 +181,7 @@ impl ListNameSpace {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Slice),
             &[offset, length],
+            true,
             false,
         )
     }
@@ -254,6 +261,7 @@ impl ListNameSpace {
             .map_many_private(
                 FunctionExpr::ListExpr(ListFunction::Contains),
                 &[other],
+                true,
                 false,
             )
             .with_function_options(|mut options| {
@@ -270,6 +278,7 @@ impl ListNameSpace {
             .map_many_private(
                 FunctionExpr::ListExpr(ListFunction::CountMatches),
                 &[other],
+                true,
                 false,
             )
             .with_function_options(|mut options| {
@@ -284,11 +293,11 @@ impl ListNameSpace {
             .map_many_private(
                 FunctionExpr::ListExpr(ListFunction::SetOperation(set_operation)),
                 &[other],
+                false,
                 true,
             )
             .with_function_options(|mut options| {
                 options.input_wildcard_expansion = true;
-                options.auto_explode = false;
                 options
             })
     }

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -690,6 +690,7 @@ impl Expr {
         self,
         function_expr: FunctionExpr,
         arguments: &[Expr],
+        auto_explode: bool,
         cast_to_supertypes: bool,
     ) -> Self {
         let mut input = Vec::with_capacity(arguments.len() + 1);
@@ -701,7 +702,7 @@ impl Expr {
             function: function_expr,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                auto_explode: true,
+                auto_explode,
                 cast_to_supertypes,
                 ..Default::default()
             },
@@ -1053,7 +1054,7 @@ impl Expr {
         let arguments = &[other];
         // we don't have to apply on groups, so this is faster
         if has_literal {
-            self.map_many_private(BooleanFunction::IsIn.into(), arguments, true)
+            self.map_many_private(BooleanFunction::IsIn.into(), arguments, true, true)
         } else {
             self.apply_many_private(BooleanFunction::IsIn.into(), arguments, true, true)
         }

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -123,7 +123,7 @@ impl StringNameSpace {
     /// Extract each successive non-overlapping match in an individual string as an array
     pub fn extract_all(self, pat: Expr) -> Expr {
         self.0
-            .map_many_private(StringFunction::ExtractAll.into(), &[pat], true, false)
+            .map_many_private(StringFunction::ExtractAll.into(), &[pat], false, false)
     }
 
     /// Count all successive non-overlapping regex matches.
@@ -214,13 +214,13 @@ impl StringNameSpace {
     /// Split the string by a substring. The resulting dtype is `List<Utf8>`.
     pub fn split(self, by: Expr) -> Expr {
         self.0
-            .map_many_private(StringFunction::Split(false).into(), &[by], true, false)
+            .map_many_private(StringFunction::Split(false).into(), &[by], false, false)
     }
 
     /// Split the string by a substring and keep the substring. The resulting dtype is `List<Utf8>`.
     pub fn split_inclusive(self, by: Expr) -> Expr {
         self.0
-            .map_many_private(StringFunction::Split(true).into(), &[by], true, false)
+            .map_many_private(StringFunction::Split(true).into(), &[by], false, false)
     }
 
     #[cfg(feature = "dtype-struct")]
@@ -262,7 +262,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::Replace { n: 1, literal }),
             &[pat, value],
-            true,
+            false,
             true,
         )
     }
@@ -273,7 +273,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::Replace { n, literal }),
             &[pat, value],
-            true,
+            false,
             true,
         )
     }
@@ -284,7 +284,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::Replace { n: -1, literal }),
             &[pat, value],
-            true,
+            false,
             true,
         )
     }
@@ -318,7 +318,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::StripPrefix),
             &[prefix],
-            true,
+            false,
             false,
         )
     }
@@ -328,7 +328,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::StripSuffix),
             &[suffix],
-            true,
+            false,
             false,
         )
     }

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -234,6 +234,7 @@ impl StringNameSpace {
             .into(),
             &[by],
             false,
+            false,
         )
     }
 
@@ -245,6 +246,7 @@ impl StringNameSpace {
             StringFunction::SplitExact { n, inclusive: true }.into(),
             &[by],
             false,
+            false,
         )
     }
 
@@ -253,7 +255,7 @@ impl StringNameSpace {
     /// keeps the remainder of the string intact. The resulting dtype is [`DataType::Struct`].
     pub fn splitn(self, by: Expr, n: usize) -> Expr {
         self.0
-            .map_many_private(StringFunction::SplitN(n).into(), &[by], false)
+            .map_many_private(StringFunction::SplitN(n).into(), &[by], false, false)
     }
 
     #[cfg(feature = "regex")]

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -14,6 +14,7 @@ impl StringNameSpace {
             }),
             &[pat],
             true,
+            true,
         )
     }
 
@@ -28,6 +29,7 @@ impl StringNameSpace {
             }),
             &[pat],
             true,
+            true,
         )
     }
 
@@ -37,6 +39,7 @@ impl StringNameSpace {
             FunctionExpr::StringExpr(StringFunction::EndsWith),
             &[sub],
             true,
+            true,
         )
     }
 
@@ -45,6 +48,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::StartsWith),
             &[sub],
+            true,
             true,
         )
     }
@@ -119,13 +123,17 @@ impl StringNameSpace {
     /// Extract each successive non-overlapping match in an individual string as an array
     pub fn extract_all(self, pat: Expr) -> Expr {
         self.0
-            .map_many_private(StringFunction::ExtractAll.into(), &[pat], false)
+            .map_many_private(StringFunction::ExtractAll.into(), &[pat], true, false)
     }
 
     /// Count all successive non-overlapping regex matches.
     pub fn count_matches(self, pat: Expr, literal: bool) -> Expr {
-        self.0
-            .map_many_private(StringFunction::CountMatches(literal).into(), &[pat], false)
+        self.0.map_many_private(
+            StringFunction::CountMatches(literal).into(),
+            &[pat],
+            true,
+            false,
+        )
     }
 
     /// Convert a Utf8 column into a Date/Datetime/Time column.
@@ -134,6 +142,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             StringFunction::Strptime(dtype, options).into(),
             &[ambiguous],
+            true,
             false,
         )
     }
@@ -205,13 +214,13 @@ impl StringNameSpace {
     /// Split the string by a substring. The resulting dtype is `List<Utf8>`.
     pub fn split(self, by: Expr) -> Expr {
         self.0
-            .map_many_private(StringFunction::Split(false).into(), &[by], false)
+            .map_many_private(StringFunction::Split(false).into(), &[by], true, false)
     }
 
     /// Split the string by a substring and keep the substring. The resulting dtype is `List<Utf8>`.
     pub fn split_inclusive(self, by: Expr) -> Expr {
         self.0
-            .map_many_private(StringFunction::Split(true).into(), &[by], false)
+            .map_many_private(StringFunction::Split(true).into(), &[by], true, false)
     }
 
     #[cfg(feature = "dtype-struct")]
@@ -254,6 +263,7 @@ impl StringNameSpace {
             FunctionExpr::StringExpr(StringFunction::Replace { n: 1, literal }),
             &[pat, value],
             true,
+            true,
         )
     }
 
@@ -264,6 +274,7 @@ impl StringNameSpace {
             FunctionExpr::StringExpr(StringFunction::Replace { n, literal }),
             &[pat, value],
             true,
+            true,
         )
     }
 
@@ -273,6 +284,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::Replace { n: -1, literal }),
             &[pat, value],
+            true,
             true,
         )
     }
@@ -306,6 +318,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::StripPrefix),
             &[prefix],
+            true,
             false,
         )
     }
@@ -315,6 +328,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::StripSuffix),
             &[suffix],
+            true,
             false,
         )
     }


### PR DESCRIPTION
per comment(https://github.com/pola-rs/polars/pull/11230#discussion_r1333920358).

Note: I just keep the original value for `auto-explode`, doesn't change any setting. But this may be a good opportunity to check if our previous setting for `auto-explode` was correct. 😆 