### PR TITLE
 test(python): improve parametric tests for group_by_rolling by skipping overflowing cases

### DIFF
--- a/py-polars/tests/parametric/test_groupby_rolling.py
+++ b/py-polars/tests/parametric/test_groupby_rolling.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import datetime as dt
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import hypothesis.strategies as st
-from hypothesis import assume, given, reject
+from hypothesis import assume, given
 
 import polars as pl
 from polars.testing import assert_frame_equal
@@ -17,10 +18,12 @@ if TYPE_CHECKING:
 
 
 @given(
-    period=st.timedeltas(min_value=timedelta(microseconds=0)).map(
-        _timedelta_to_pl_duration
-    ),
-    offset=st.timedeltas().map(_timedelta_to_pl_duration),
+    period=st.timedeltas(
+        min_value=timedelta(microseconds=0), max_value=timedelta(days=1000)
+    ).map(_timedelta_to_pl_duration),
+    offset=st.timedeltas(
+        min_value=timedelta(microseconds=0), max_value=timedelta(days=1000)
+    ).map(_timedelta_to_pl_duration),
     closed=strategy_closed,
     data=st.data(),
     time_unit=strategy_time_unit,
@@ -36,25 +39,27 @@ def test_group_by_rolling(
     dataframe = data.draw(
         dataframes(
             [
-                column("ts", dtype=pl.Datetime(time_unit)),
-                column("value", dtype=pl.Int64),
+                column(
+                    "ts",
+                    strategy=st.datetimes(
+                        min_value=dt.datetime(2000, 1, 1),
+                        max_value=dt.datetime(2001, 1, 1),
+                    ),
+                    dtype=pl.Datetime(time_unit),
+                ),
+                column(
+                    "value",
+                    strategy=st.integers(min_value=-100, max_value=100),
+                    dtype=pl.Int64,
+                ),
             ],
+            min_size=1,
         )
     )
     df = dataframe.sort("ts")
-    try:
-        result = df.group_by_rolling(
-            "ts", period=period, offset=offset, closed=closed
-        ).agg(pl.col("value"))
-    except pl.exceptions.PolarsPanicError as exc:
-        assert any(  # noqa: PT017
-            msg in str(exc)
-            for msg in (
-                "attempt to multiply with overflow",
-                "attempt to add with overflow",
-            )
-        )
-        reject()
+    result = df.group_by_rolling("ts", period=period, offset=offset, closed=closed).agg(
+        pl.col("value")
+    )
 
     expected_dict: dict[str, list[object]] = {"ts": [], "value": []}
     for ts, _ in df.iter_rows():
@@ -78,9 +83,9 @@ def test_group_by_rolling(
 
 
 @given(
-    window_size=st.timedeltas(min_value=timedelta(microseconds=0)).map(
-        _timedelta_to_pl_duration
-    ),
+    window_size=st.timedeltas(
+        min_value=timedelta(microseconds=0), max_value=timedelta(days=2)
+    ).map(_timedelta_to_pl_duration),
     closed=strategy_closed,
     data=st.data(),
     time_unit=strategy_time_unit,
@@ -107,28 +112,27 @@ def test_rolling_aggs(
     dataframe = data.draw(
         dataframes(
             [
-                column("ts", dtype=pl.Datetime(time_unit)),
-                column("value", dtype=pl.Int64),
+                column(
+                    "ts",
+                    strategy=st.datetimes(
+                        min_value=dt.datetime(2000, 1, 1),
+                        max_value=dt.datetime(2001, 1, 1),
+                    ),
+                    dtype=pl.Datetime(time_unit),
+                ),
+                column(
+                    "value",
+                    strategy=st.integers(min_value=-100, max_value=100),
+                    dtype=pl.Int64,
+                ),
             ],
         )
     )
     df = dataframe.sort("ts")
     func = f"rolling_{aggregation}"
-    try:
-        result = df.with_columns(
-            getattr(pl.col("value"), func)(
-                window_size=window_size, by="ts", closed=closed
-            )
-        )
-    except pl.exceptions.PolarsPanicError as exc:
-        assert any(  # noqa: PT017
-            msg in str(exc)
-            for msg in (
-                "attempt to multiply with overflow",
-                "attempt to add with overflow",
-            )
-        )
-        reject()
+    result = df.with_columns(
+        getattr(pl.col("value"), func)(window_size=window_size, by="ts", closed=closed)
+    )
 
     expected_dict: dict[str, list[object]] = {"ts": [], "value": []}
     for ts, _ in df.iter_rows():


### PR DESCRIPTION
~closes #11281 ~

~closes #11150~

~I think I'm going to have dreams about `group_by_rolling` tonight~

repurposed as a tests PR