### PR TITLE
feat(rust): Format null arrays in Series

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/any_value.rs
+++ b/crates/polars-core/src/chunked_array/ops/any_value.rs
@@ -4,6 +4,7 @@ use polars_utils::sync::SyncPtr;
 #[cfg(feature = "object")]
 use crate::chunked_array::object::extension::polars_extension::PolarsExtension;
 use crate::prelude::*;
+use crate::series::implementations::null::NullChunked;
 
 #[inline]
 #[allow(unused_variables)]
@@ -280,5 +281,16 @@ impl<T: PolarsObject> ChunkAnyValue for ObjectChunked<T> {
             None => Err(polars_err!(ComputeError: "index is out of bounds")),
             Some(v) => Ok(AnyValue::Object(v)),
         }
+    }
+}
+
+impl ChunkAnyValue for NullChunked {
+    #[inline]
+    unsafe fn get_any_value_unchecked(&self, _index: usize) -> AnyValue {
+        AnyValue::Null
+    }
+
+    fn get_any_value(&self, _index: usize) -> PolarsResult<AnyValue> {
+        Ok(AnyValue::Null)
     }
 }

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -149,6 +149,52 @@ fn format_object_array(
     }
 }
 
+macro_rules! format_nullarray {
+    ($f:ident, $length:expr, $dtype:expr, $name:expr, $array_type:expr) => {{
+        write!(
+            $f,
+            "shape: ({},)\n{}: '{}' [{}]\n[\n",
+            fmt_uint(&$length),
+            $array_type,
+            $name,
+            $dtype
+        )?;
+        let limit: usize = {
+            let limit = std::env::var(FMT_MAX_ROWS)
+                .as_deref()
+                .unwrap_or("")
+                .parse()
+                .map_or(LIMIT, |n: i64| if n < 0 { $length } else { n as usize });
+            std::cmp::min(limit, $length.clone())
+        };
+        let write_fn = |v, f: &mut Formatter| -> fmt::Result {
+            write!(f, "\t{}\n", v)?;
+
+            Ok(())
+        };
+        let v = "null";
+        if (limit == 0 && $length > 0) || ($length > limit + 1) {
+            if limit > 0 {
+                for i in 0..std::cmp::max((limit / 2), 1) {
+                    write_fn(v, $f)?;
+                }
+            }
+            write!($f, "\t…\n")?;
+            if limit > 1 {
+                for i in ($length - (limit + 1) / 2)..$length {
+                    write_fn(v, $f)?;
+                }
+            }
+        } else {
+            for i in 0..$length {
+                write_fn(v, $f)?;
+            }
+        }
+
+        write!($f, "]")
+    }};
+}
+
 impl<T> Debug for ChunkedArray<T>
 where
     T: PolarsNumericType,
@@ -313,7 +359,7 @@ impl Debug for Series {
                 "Series"
             ),
             DataType::Null => {
-                writeln!(f, "nullarray; shape: {}", self.len())
+                format_nullarray!(f, self.len(), "nullarray", "null", "Series")
             },
             DataType::Binary => {
                 format_array!(f, self.binary().unwrap(), "binary", self.name(), "Series")

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -359,7 +359,7 @@ impl Debug for Series {
                 "Series"
             ),
             DataType::Null => {
-                format_nullarray!(f, self.len(), "nullarray", "null", "Series")
+                format_nullarray!(f, self.len(), "nullarray", self.name(), "Series")
             },
             DataType::Binary => {
                 format_array!(f, self.binary().unwrap(), "binary", self.name(), "Series")

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -175,18 +175,18 @@ macro_rules! format_nullarray {
         let v = "null";
         if (limit == 0 && $length > 0) || ($length > limit + 1) {
             if limit > 0 {
-                for i in 0..std::cmp::max((limit / 2), 1) {
+                for _i in 0..std::cmp::max((limit / 2), 1) {
                     write_fn(v, $f)?;
                 }
             }
             write!($f, "\t…\n")?;
             if limit > 1 {
-                for i in ($length - (limit + 1) / 2)..$length {
+                for _i in ($length - (limit + 1) / 2)..$length {
                     write_fn(v, $f)?;
                 }
             }
         } else {
-            for i in 0..$length {
+            for _i in 0..$length {
                 write_fn(v, $f)?;
             }
         }

--- a/crates/polars-core/src/series/ops/downcast.rs
+++ b/crates/polars-core/src/series/ops/downcast.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::series::implementations::null::NullChunked;
 
 macro_rules! unpack_chunked {
     ($series:expr, $expected:pat => $ca:ty, $name:expr) => {
@@ -151,5 +152,10 @@ impl Series {
             }
         }
         unpack_chunked!(self, DataType::Struct(_) => StructChunked, "Struct")
+    }
+
+    /// Unpack to [`ChunkedArray`] of dtype `[DataType::Null]`
+    pub fn null(&self) -> PolarsResult<&NullChunked> {
+        unpack_chunked!(self, DataType::Null => NullChunked, "Null")
     }
 }

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -607,6 +607,17 @@ def test_init_ndarray(monkeypatch: Any) -> None:
     assert df2.rows() == [(1.0, 4.0), (2.5, None), (None, 6.5)]
 
 
+def test_nullarray_print_format() -> None:
+    tbl_null = pa.table({"a": [None, None]})
+    df_null = pl.from_arrow(tbl_null)
+    assert df_null.schema == {"a": pl.Null}
+    assert df_null.rows() == [(None,), (None,)]
+
+    expected_string = "shape: (2,)\nSeries: 'null' [nullarray]\n[\n\tnull\n\tnull\n]"
+    assert str(df_null["a"]) == expected_string
+    
+
+
 def test_init_arrow() -> None:
     # Handle unnamed column
     df = pl.DataFrame(pa.table({"a": [1, 2], None: [3, 4]}))

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -608,14 +608,13 @@ def test_init_ndarray(monkeypatch: Any) -> None:
 
 
 def test_nullarray_print_format() -> None:
-    tbl_null = pa.table({"a": [None, None]})
-    df_null = pl.from_arrow(tbl_null)
+    pa_tbl_null = pa.table({"a": [None, None]})
+    df_null = pl.from_arrow(pa_tbl_null)
     assert df_null.schema == {"a": pl.Null}
     assert df_null.rows() == [(None,), (None,)]
 
     expected_string = "shape: (2,)\nSeries: 'null' [nullarray]\n[\n\tnull\n\tnull\n]"
     assert str(df_null["a"]) == expected_string
-    
 
 
 def test_init_arrow() -> None:

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -613,7 +613,7 @@ def test_nullarray_print_format() -> None:
     assert df_null.schema == {"a": pl.Null}
     assert df_null.rows() == [(None,), (None,)]
 
-    expected_string = "shape: (2,)\nSeries: 'null' [nullarray]\n[\n\tnull\n\tnull\n]"
+    expected_string = "shape: (2,)\nSeries: 'a' [nullarray]\n[\n\tnull\n\tnull\n]"
     assert str(df_null["a"]) == expected_string
 
 

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -611,7 +611,7 @@ def test_null_array_print_format() -> None:
     pa_tbl_null = pa.table({"a": [None, None]})
     df_null = pl.from_arrow(pa_tbl_null)
     assert df_null.shape == (2, 1)
-    assert df_null.dtypes == pl.Null  # type: ignore[union-attr]
+    assert df_null.dtypes == [pl.Null]  # type: ignore[union-attr]
     assert df_null.rows() == [(None,), (None,)]  # type: ignore[union-attr]
 
     assert (

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -607,14 +607,24 @@ def test_init_ndarray(monkeypatch: Any) -> None:
     assert df2.rows() == [(1.0, 4.0), (2.5, None), (None, 6.5)]
 
 
-def test_nullarray_print_format() -> None:
+def test_null_array_print_format() -> None:
     pa_tbl_null = pa.table({"a": [None, None]})
     df_null = pl.from_arrow(pa_tbl_null)
-    assert df_null.schema == {"a": pl.Null}
-    assert df_null.rows() == [(None,), (None,)]
+    assert df_null.shape == (2, 1)
+    assert df_null.dtypes == pl.Null  # type: ignore[union-attr]
+    assert df_null.rows() == [(None,), (None,)]  # type: ignore[union-attr]
 
-    expected_string = "shape: (2,)\nSeries: 'a' [nullarray]\n[\n\tnull\n\tnull\n]"
-    assert str(df_null["a"]) == expected_string
+    assert (
+        str(df_null) == "shape: (2, 1)\n"
+        "┌──────┐\n"
+        "│ a    │\n"
+        "│ ---  │\n"
+        "│ null │\n"
+        "╞══════╡\n"
+        "│ null │\n"
+        "│ null │\n"
+        "└──────┘"
+    )
 
 
 def test_init_arrow() -> None:


### PR DESCRIPTION
Resolves #7153

null array now is shown as:

``` 
shape: (2,)
Series: 'a' [nullarray]
[
        null
        null
] 
``` 

instead of 

```
nullarray
```

Could refactor the code a bit cause it overlaps with `format_array` a lot, so there is quite some repitition, but made this PR to see if this is in the right direction at all.