### PR TITLE
refactor(python): Add type alias `IntoExprColumn`

### DIFF
--- a/py-polars/polars/functions/range/date_range.py
+++ b/py-polars/polars/functions/range/date_range.py
@@ -21,13 +21,13 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from polars import Expr, Series
-    from polars.type_aliases import ClosedInterval, IntoExpr, TimeUnit
+    from polars.type_aliases import ClosedInterval, IntoExprColumn, TimeUnit
 
 
 @overload
 def date_range(
-    start: date | datetime | IntoExpr,
-    end: date | datetime | IntoExpr,
+    start: date | datetime | IntoExprColumn,
+    end: date | datetime | IntoExprColumn,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -41,8 +41,8 @@ def date_range(
 
 @overload
 def date_range(
-    start: date | datetime | IntoExpr,
-    end: date | datetime | IntoExpr,
+    start: date | datetime | IntoExprColumn,
+    end: date | datetime | IntoExprColumn,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -56,8 +56,8 @@ def date_range(
 
 @overload
 def date_range(
-    start: date | datetime | IntoExpr,
-    end: date | datetime | IntoExpr,
+    start: date | datetime | IntoExprColumn,
+    end: date | datetime | IntoExprColumn,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -72,8 +72,8 @@ def date_range(
 @deprecate_renamed_parameter("low", "start", version="0.18.0")
 @deprecate_renamed_parameter("high", "end", version="0.18.0")
 def date_range(
-    start: date | datetime | IntoExpr,
-    end: date | datetime | IntoExpr,
+    start: date | datetime | IntoExprColumn,
+    end: date | datetime | IntoExprColumn,
     interval: str | timedelta = "1d",
     *,
     closed: ClosedInterval = "both",
@@ -230,8 +230,8 @@ def date_range(
 
 @overload
 def date_ranges(
-    start: date | datetime | IntoExpr,
-    end: date | datetime | IntoExpr,
+    start: date | datetime | IntoExprColumn,
+    end: date | datetime | IntoExprColumn,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -244,8 +244,8 @@ def date_ranges(
 
 @overload
 def date_ranges(
-    start: date | datetime | IntoExpr,
-    end: date | datetime | IntoExpr,
+    start: date | datetime | IntoExprColumn,
+    end: date | datetime | IntoExprColumn,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -258,8 +258,8 @@ def date_ranges(
 
 @overload
 def date_ranges(
-    start: date | datetime | IntoExpr,
-    end: date | datetime | IntoExpr,
+    start: date | datetime | IntoExprColumn,
+    end: date | datetime | IntoExprColumn,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -271,8 +271,8 @@ def date_ranges(
 
 
 def date_ranges(
-    start: date | datetime | IntoExpr,
-    end: date | datetime | IntoExpr,
+    start: date | datetime | IntoExprColumn,
+    end: date | datetime | IntoExprColumn,
     interval: str | timedelta = "1d",
     *,
     closed: ClosedInterval = "both",
@@ -379,8 +379,8 @@ def date_ranges(
 
 
 def _warn_for_deprecated_date_range_use(
-    start: date | datetime | IntoExpr,
-    end: date | datetime | IntoExpr,
+    start: date | datetime | IntoExprColumn,
+    end: date | datetime | IntoExprColumn,
     interval: str,
     time_unit: TimeUnit | None,
     time_zone: str | None,

--- a/py-polars/polars/functions/range/datetime_range.py
+++ b/py-polars/polars/functions/range/datetime_range.py
@@ -12,17 +12,17 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     import polars.polars as plr
 
 if TYPE_CHECKING:
-    from datetime import datetime, timedelta
+    from datetime import date, datetime, timedelta
     from typing import Literal
 
     from polars import Expr, Series
-    from polars.type_aliases import ClosedInterval, IntoExpr, TimeUnit
+    from polars.type_aliases import ClosedInterval, IntoExprColumn, TimeUnit
 
 
 @overload
 def datetime_range(
-    start: datetime | IntoExpr,
-    end: datetime | IntoExpr,
+    start: datetime | date | IntoExprColumn,
+    end: datetime | date | IntoExprColumn,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -35,8 +35,8 @@ def datetime_range(
 
 @overload
 def datetime_range(
-    start: datetime | IntoExpr,
-    end: datetime | IntoExpr,
+    start: datetime | date | IntoExprColumn,
+    end: datetime | date | IntoExprColumn,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -49,8 +49,8 @@ def datetime_range(
 
 @overload
 def datetime_range(
-    start: datetime | IntoExpr,
-    end: datetime | IntoExpr,
+    start: datetime | date | IntoExprColumn,
+    end: datetime | date | IntoExprColumn,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -62,8 +62,8 @@ def datetime_range(
 
 
 def datetime_range(
-    start: datetime | IntoExpr,
-    end: datetime | IntoExpr,
+    start: datetime | date | IntoExprColumn,
+    end: datetime | date | IntoExprColumn,
     interval: str | timedelta = "1d",
     *,
     closed: ClosedInterval = "both",
@@ -199,8 +199,8 @@ def datetime_range(
 
 @overload
 def datetime_ranges(
-    start: datetime | IntoExpr,
-    end: datetime | IntoExpr,
+    start: datetime | date | IntoExprColumn,
+    end: datetime | date | IntoExprColumn,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -213,8 +213,8 @@ def datetime_ranges(
 
 @overload
 def datetime_ranges(
-    start: datetime | IntoExpr,
-    end: datetime | IntoExpr,
+    start: datetime | date | IntoExprColumn,
+    end: datetime | date | IntoExprColumn,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -227,8 +227,8 @@ def datetime_ranges(
 
 @overload
 def datetime_ranges(
-    start: datetime | IntoExpr,
-    end: datetime | IntoExpr,
+    start: datetime | date | IntoExprColumn,
+    end: datetime | date | IntoExprColumn,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -240,8 +240,8 @@ def datetime_ranges(
 
 
 def datetime_ranges(
-    start: datetime | IntoExpr,
-    end: datetime | IntoExpr,
+    start: datetime | date | IntoExprColumn,
+    end: datetime | date | IntoExprColumn,
     interval: str | timedelta = "1d",
     *,
     closed: ClosedInterval = "both",

--- a/py-polars/polars/functions/range/int_range.py
+++ b/py-polars/polars/functions/range/int_range.py
@@ -15,13 +15,13 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from polars import Expr, Series
-    from polars.type_aliases import IntoExpr, PolarsIntegerType
+    from polars.type_aliases import IntoExprColumn, PolarsIntegerType
 
 
 @overload
 def arange(
-    start: int | Expr | Series,
-    end: int | Expr | Series,
+    start: int | IntoExprColumn,
+    end: int | IntoExprColumn,
     step: int = ...,
     *,
     dtype: PolarsIntegerType = ...,
@@ -32,8 +32,8 @@ def arange(
 
 @overload
 def arange(
-    start: int | IntoExpr,
-    end: int | IntoExpr,
+    start: int | IntoExprColumn,
+    end: int | IntoExprColumn,
     step: int = ...,
     *,
     dtype: PolarsIntegerType = ...,
@@ -44,8 +44,8 @@ def arange(
 
 @overload
 def arange(
-    start: int | IntoExpr,
-    end: int | IntoExpr,
+    start: int | IntoExprColumn,
+    end: int | IntoExprColumn,
     step: int = ...,
     *,
     dtype: PolarsIntegerType = ...,
@@ -55,8 +55,8 @@ def arange(
 
 
 def arange(
-    start: int | IntoExpr,
-    end: int | IntoExpr,
+    start: int | IntoExprColumn,
+    end: int | IntoExprColumn,
     step: int = 1,
     *,
     dtype: PolarsIntegerType = Int64,
@@ -107,8 +107,8 @@ def arange(
 
 @overload
 def int_range(
-    start: int | IntoExpr,
-    end: int | IntoExpr,
+    start: int | IntoExprColumn,
+    end: int | IntoExprColumn,
     step: int = ...,
     *,
     dtype: PolarsIntegerType = ...,
@@ -119,8 +119,8 @@ def int_range(
 
 @overload
 def int_range(
-    start: int | IntoExpr,
-    end: int | IntoExpr,
+    start: int | IntoExprColumn,
+    end: int | IntoExprColumn,
     step: int = ...,
     *,
     dtype: PolarsIntegerType = ...,
@@ -131,8 +131,8 @@ def int_range(
 
 @overload
 def int_range(
-    start: int | IntoExpr,
-    end: int | IntoExpr,
+    start: int | IntoExprColumn,
+    end: int | IntoExprColumn,
     step: int = ...,
     *,
     dtype: PolarsIntegerType = ...,
@@ -142,8 +142,8 @@ def int_range(
 
 
 def int_range(
-    start: int | IntoExpr,
-    end: int | IntoExpr,
+    start: int | IntoExprColumn,
+    end: int | IntoExprColumn,
     step: int = 1,
     *,
     dtype: PolarsIntegerType = Int64,
@@ -199,8 +199,8 @@ def int_range(
 
 @overload
 def int_ranges(
-    start: IntoExpr,
-    end: IntoExpr,
+    start: int | IntoExprColumn,
+    end: int | IntoExprColumn,
     step: int = ...,
     *,
     dtype: PolarsIntegerType = ...,
@@ -211,8 +211,8 @@ def int_ranges(
 
 @overload
 def int_ranges(
-    start: IntoExpr,
-    end: IntoExpr,
+    start: int | IntoExprColumn,
+    end: int | IntoExprColumn,
     step: int = ...,
     *,
     dtype: PolarsIntegerType = ...,
@@ -223,8 +223,8 @@ def int_ranges(
 
 @overload
 def int_ranges(
-    start: IntoExpr,
-    end: IntoExpr,
+    start: int | IntoExprColumn,
+    end: int | IntoExprColumn,
     step: int = ...,
     *,
     dtype: PolarsIntegerType = ...,
@@ -234,8 +234,8 @@ def int_ranges(
 
 
 def int_ranges(
-    start: IntoExpr,
-    end: IntoExpr,
+    start: int | IntoExprColumn,
+    end: int | IntoExprColumn,
     step: int = 1,
     *,
     dtype: PolarsIntegerType = Int64,

--- a/py-polars/polars/functions/range/time_range.py
+++ b/py-polars/polars/functions/range/time_range.py
@@ -18,13 +18,13 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from polars import Expr, Series
-    from polars.type_aliases import ClosedInterval, IntoExpr
+    from polars.type_aliases import ClosedInterval, IntoExprColumn
 
 
 @overload
 def time_range(
-    start: time | IntoExpr | None = ...,
-    end: time | IntoExpr | None = ...,
+    start: time | IntoExprColumn | None = ...,
+    end: time | IntoExprColumn | None = ...,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -36,8 +36,8 @@ def time_range(
 
 @overload
 def time_range(
-    start: time | IntoExpr | None = ...,
-    end: time | IntoExpr | None = ...,
+    start: time | IntoExprColumn | None = ...,
+    end: time | IntoExprColumn | None = ...,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -49,8 +49,8 @@ def time_range(
 
 @overload
 def time_range(
-    start: time | IntoExpr | None = ...,
-    end: time | IntoExpr | None = ...,
+    start: time | IntoExprColumn | None = ...,
+    end: time | IntoExprColumn | None = ...,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -61,8 +61,8 @@ def time_range(
 
 
 def time_range(
-    start: time | IntoExpr | None = None,
-    end: time | IntoExpr | None = None,
+    start: time | IntoExprColumn | None = None,
+    end: time | IntoExprColumn | None = None,
     interval: str | timedelta = "1h",
     *,
     closed: ClosedInterval = "both",
@@ -180,8 +180,8 @@ def time_range(
 
 @overload
 def time_ranges(
-    start: time | IntoExpr | None = ...,
-    end: time | IntoExpr | None = ...,
+    start: time | IntoExprColumn | None = ...,
+    end: time | IntoExprColumn | None = ...,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -192,8 +192,8 @@ def time_ranges(
 
 @overload
 def time_ranges(
-    start: time | IntoExpr | None = ...,
-    end: time | IntoExpr | None = ...,
+    start: time | IntoExprColumn | None = ...,
+    end: time | IntoExprColumn | None = ...,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -204,8 +204,8 @@ def time_ranges(
 
 @overload
 def time_ranges(
-    start: time | IntoExpr | None = ...,
-    end: time | IntoExpr | None = ...,
+    start: time | IntoExprColumn | None = ...,
+    end: time | IntoExprColumn | None = ...,
     interval: str | timedelta = ...,
     *,
     closed: ClosedInterval = ...,
@@ -215,8 +215,8 @@ def time_ranges(
 
 
 def time_ranges(
-    start: time | IntoExpr | None = None,
-    end: time | IntoExpr | None = None,
+    start: time | IntoExprColumn | None = None,
+    end: time | IntoExprColumn | None = None,
     interval: str | timedelta = "1h",
     *,
     closed: ClosedInterval = "both",

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -60,12 +60,15 @@ SchemaDefinition: TypeAlias = Union[
 ]
 SchemaDict: TypeAlias = Mapping[str, PolarsDataType]
 
-# literal types that are allowed in expressions (auto-converted to pl.lit)
+# Python literal types (can convert into a `lit` expression)
 PythonLiteral: TypeAlias = Union[
     str, int, float, bool, date, time, datetime, timedelta, bytes, Decimal, List[Any]
 ]
+# Inputs that can convert into a `col` expression
+IntoExprColumn: TypeAlias = Union["Expr", "Series", str]
+# Inputs that can convert into an expression
+IntoExpr: TypeAlias = Union[PythonLiteral, IntoExprColumn, None]
 
-IntoExpr: TypeAlias = Union["Expr", PythonLiteral, "Series", None]
 ComparisonOperator: TypeAlias = Literal["eq", "neq", "gt", "lt", "gt_eq", "lt_eq"]
 
 # selector type, and related collection/sequence


### PR DESCRIPTION
This will help narrow down some type signatures, as `IntoExpr` was too broad in many cases.

This new type allows any input that converts into a `col` expression: `Expr`, `Series`, and `str`.