### PR TITLE
fix(rust,python): fix empty Series construction edge-case with Struct dtype

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -112,7 +112,7 @@ impl StructChunked {
             }
             Ok(Self::new_unchecked(name, &new_fields))
         } else if fields.is_empty() {
-            let fields = &[Series::full_null("", 1, &DataType::Null)];
+            let fields = &[Series::full_null("", 0, &DataType::Null)];
             Ok(Self::new_unchecked(name, fields))
         } else {
             Ok(Self::new_unchecked(name, fields))

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -631,6 +631,20 @@ def test_empty_struct() -> None:
     assert df.to_dict(False) == {"a": [{"": None}]}
 
 
+def test_empty_series_nested_dtype() -> None:
+    # various flavours of empty nested dtype
+    for dtype in (
+        pl.List,
+        pl.List(pl.Null),
+        pl.Array(32),
+        pl.Struct,
+        pl.Struct([pl.Field("", pl.Null)]),
+    ):
+        s = pl.Series(values=[], dtype=dtype)  # type: ignore[arg-type]
+        assert s.dtype.base_type() == dtype.base_type()  # type: ignore[attr-defined]
+        assert s.to_list() == []
+
+
 def test_empty_with_schema_struct() -> None:
     # Empty structs, with schema
     struct_schema = {"a": pl.Date, "b": pl.Boolean, "c": pl.Float64}

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -2,13 +2,18 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, time
+from typing import TYPE_CHECKING
 
 import pandas as pd
 import pyarrow as pa
+import pytest
 
 import polars as pl
 import polars.selectors as cs
 from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from polars.datatypes import PolarsDataType
 
 
 def test_struct_to_list() -> None:
@@ -631,18 +636,24 @@ def test_empty_struct() -> None:
     assert df.to_dict(False) == {"a": [{"": None}]}
 
 
-def test_empty_series_nested_dtype() -> None:
-    # various flavours of empty nested dtype
-    for dtype in (
+@pytest.mark.parametrize(
+    "dtype",
+    [
         pl.List,
         pl.List(pl.Null),
+        pl.List(pl.Utf8),
         pl.Array(32),
+        pl.Array(16, inner=pl.UInt8),
         pl.Struct,
         pl.Struct([pl.Field("", pl.Null)]),
-    ):
-        s = pl.Series(values=[], dtype=dtype)  # type: ignore[arg-type]
-        assert s.dtype.base_type() == dtype.base_type()  # type: ignore[attr-defined]
-        assert s.to_list() == []
+        pl.Struct([pl.Field("x", pl.UInt32), pl.Field("y", pl.Float64)]),
+    ],
+)
+def test_empty_series_nested_dtype(dtype: PolarsDataType) -> None:
+    # various flavours of empty nested dtype
+    s = pl.Series("nested", dtype=dtype)
+    assert s.dtype.base_type() == dtype.base_type()
+    assert s.to_list() == []
 
 
 def test_empty_with_schema_struct() -> None:

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -97,10 +97,13 @@ def test_read_ndjson_empty_array() -> None:
 
 
 def test_ndjson_nested_null() -> None:
-    payload = """{"foo":{"bar":[{}]}}"""
-    assert pl.read_ndjson(io.StringIO(payload)).to_dict(False) == {
-        "foo": [{"bar": [{"": None}]}]
-    }
+    json_payload = """{"foo":{"bar":[{}]}}"""
+    df = pl.read_ndjson(io.StringIO(json_payload))
+
+    # 'bar' represents an empty list of structs; check the schema is correct (eg: picks
+    # up that it IS a list of structs), but confirm that list is empty (ref: #11301)
+    assert df.schema == {"foo": pl.Struct([pl.Field("bar", pl.List(pl.Struct([])))])}
+    assert df.to_dict(False) == {"foo": [{"bar": []}]}
 
 
 def test_ndjson_nested_utf8_int() -> None:


### PR DESCRIPTION
Closes #11259.

There was a potential off-by-one error here when initialising an empty Series; we'd end up with a one-element Series instead.

**Before:** 
_(no data, but we create an unexpected series value)_
```python
pl.Series(dtype=pl.Struct)
# shape: (1,)
# Series: '' [struct[1]]
# [
#     {null}
# ]
```
**After:**
 _(empty, as expected)_
```python
pl.Series(dtype=pl.Struct)
# shape: (0,)
# Series: '' [struct[1]]
# [
# ]
```
