### PR TITLE
chore(python): Pin pydantic in dev requirements `<2.4.0`

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -12,7 +12,7 @@
 numpy
 pandas
 pyarrow
-pydantic >= 2.0.0
+pydantic >= 2.0.0, <2.4.0  # 2.4.0 breaks pyiceberg interop
 # Datetime / time zones
 backports.zoneinfo; python_version < '3.9'
 tzdata; platform_system == 'Windows'


### PR DESCRIPTION
The new release of pydantic (`2.4.0`) broke some of the pyiceberg tests.

Not really sure how to properly solve this, save for 