### PR TITLE
feat(rust): Custom `sink` implementations

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -41,6 +41,8 @@ impl Display for ErrString {
 
 #[derive(Debug, thiserror::Error)]
 pub enum PolarsError {
+    #[error("error sending data: {0}")]
+    SendError(ErrString),
     #[error(transparent)]
     ArrowError(Box<ArrowError>),
     #[error("not found: {0}")]
@@ -113,6 +115,7 @@ impl PolarsError {
             ShapeMismatch(msg) => ShapeMismatch(func(msg).into()),
             StringCacheMismatch(msg) => StringCacheMismatch(func(msg).into()),
             StructFieldNotFound(msg) => StructFieldNotFound(func(msg).into()),
+            SendError(msg) => SendError(func(msg).into()),
         }
     }
 }

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -156,8 +156,11 @@ pub fn create_physical_plan(
                 SinkType::File{file_type, ..} => panic!(
                     "sink_{file_type:?} not yet supported in standard engine. Use 'collect().write_parquet()'"
                 ),
+                SinkType::Sender { .. } => {
+                    panic!("Sender Sink not supported in standard engine.")
+                }
                 #[cfg(feature = "cloud")]
-                SinkType::Cloud{..} => panic!("Cloud Sink not supported in standard engine.")
+                SinkType::Cloud{..} => panic!("Cloud Sink not supported in standard engine."),
             }
         }
         Union { inputs, options } => {

--- a/crates/polars-lazy/src/prelude.rs
+++ b/crates/polars-lazy/src/prelude.rs
@@ -1,7 +1,8 @@
 pub(crate) use polars_ops::prelude::*;
 pub use polars_ops::prelude::{JoinArgs, JoinType, JoinValidation};
 pub use polars_plan::logical_plan::{
-    AnonymousScan, AnonymousScanOptions, FileType, Literal, LiteralValue, LogicalPlan, Null, NULL,
+    AnonymousScan, AnonymousScanOptions, FileType, Literal, LiteralValue, LogicalPlan, Null,
+    SinkSender, NULL,
 };
 #[cfg(feature = "csv")]
 pub use polars_plan::prelude::CsvWriterOptions;

--- a/crates/polars-lazy/src/prelude.rs
+++ b/crates/polars-lazy/src/prelude.rs
@@ -1,7 +1,7 @@
 pub(crate) use polars_ops::prelude::*;
 pub use polars_ops::prelude::{JoinArgs, JoinType, JoinValidation};
 pub use polars_plan::logical_plan::{
-    AnonymousScan, AnonymousScanOptions, Literal, LiteralValue, LogicalPlan, Null, NULL,
+    AnonymousScan, AnonymousScanOptions, FileType, Literal, LiteralValue, LogicalPlan, Null, NULL,
 };
 #[cfg(feature = "csv")]
 pub use polars_plan::prelude::CsvWriterOptions;

--- a/crates/polars-pipe/src/executors/sinks/file_sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/file_sink.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::path::Path;
 use std::thread::JoinHandle;
 
 use crossbeam_channel::{bounded, Receiver, Sender};

--- a/crates/polars-plan/src/dot.rs
+++ b/crates/polars-plan/src/dot.rs
@@ -400,6 +400,7 @@ impl LogicalPlan {
                         SinkType::File { .. } => "SINK (FILE)",
                         #[cfg(feature = "cloud")]
                         SinkType::Cloud { .. } => "SINK (CLOUD)",
+                        SinkType::Sender { .. } => "SINK (SENDER)",
                     },
                 };
                 self.write_dot(acc_str, prev_node, current_node, id_map)?;

--- a/crates/polars-plan/src/logical_plan/alp.rs
+++ b/crates/polars-plan/src/logical_plan/alp.rs
@@ -166,6 +166,7 @@ impl ALogicalPlan {
                 SinkType::File { .. } => "sink (file)",
                 #[cfg(feature = "cloud")]
                 SinkType::Cloud { .. } => "sink (cloud)",
+                SinkType::Sender { .. } => "sink (sender)",
             },
         }
     }

--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -230,6 +230,7 @@ impl LogicalPlan {
                     SinkType::File { .. } => "SINK (file)",
                     #[cfg(feature = "cloud")]
                     SinkType::Cloud { .. } => "SINK (cloud)",
+                    SinkType::Sender { .. } => "SINK (sender)",
                 };
                 write!(f, "{:indent$}{}", "", name)?;
                 input._format(f, sub_indent)

--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -49,7 +49,7 @@ pub use functions::*;
 pub use iterator::*;
 pub use lit::*;
 pub use optimizer::*;
-pub use options::FileType;
+pub use options::{FileType, SinkSender};
 pub use schema::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -49,6 +49,7 @@ pub use functions::*;
 pub use iterator::*;
 pub use lit::*;
 pub use optimizer::*;
+pub use options::FileType;
 pub use schema::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/py-polars/src/error.rs
+++ b/py-polars/src/error.rs
@@ -31,6 +31,7 @@ impl std::convert::From<PyPolarsErr> for PyErr {
         use PyPolarsErr::*;
         match &err {
             Polars(err) => match err {
+                PolarsError::SendError(err) => SendError::new_err(err.to_string()),
                 PolarsError::ArrowError(err) => ArrowErrorException::new_err(format!("{err:?}")),
                 PolarsError::ColumnNotFound(name) => ColumnNotFoundError::new_err(name.to_string()),
                 PolarsError::ComputeError(err) => ComputeError::new_err(err.to_string()),
@@ -70,6 +71,7 @@ impl Debug for PyPolarsErr {
     }
 }
 
+create_exception!(exceptions, SendError, PyException);
 create_exception!(exceptions, ArrowErrorException, PyException);
 create_exception!(exceptions, ColumnNotFoundError, PyException);
 create_exception!(exceptions, ComputeError, PyException);


### PR DESCRIPTION
# Purpose

I want to build an asynchornous HTTP server that uses polars under the hood to manipulate some data frames. From my understanding the `sink_*` methods only allow writing to files but I want to be able to stream to an HTTP Response Body for example. 

Since libraries like `hyper` use a `Sender` (as in mpsc) to build a Body I though creating a way to write to any sender would be awesome.

# My implemetation

I exposed the `FileType` enum in order to now have to create different `sink_*` implementations, however this could be changed.

I also created a `SinkSender` trait that implements all the methods necesarry to create custom sink implementations.

Additionally, I created a `SendError` variant in `PolarsError`.

## Example

In this example I placed a single `iris.csv` file, just for testing purposes.

```rust
use bytes::Bytes;
use polars::prelude::*;
use std::{
    sync::mpsc::{sync_channel, Receiver, SyncSender},
    thread,
};

#[derive(Debug)]
struct MySender(SyncSender<Bytes>);

impl SinkSender for MySender {
    fn sink_send(&self, buf: &[u8]) -> PolarsResult<usize> {
        self.0.send(Bytes::copy_from_slice(buf)).map_or_else(
            |e| Err(PolarsError::SendError(e.to_string().into())),
            |_| Ok(buf.len()),
        )
    }
    fn sink_flush(&self) -> PolarsResult<()> {
        Ok(())
    }
}

fn spawn_reader_thread(rx: Receiver<Bytes>) -> thread::JoinHandle<()> {
    thread::spawn(move || {
        while let Ok(buf) = rx.recv() {
            println!("{:?}", buf);
        }
    })
}

fn main() {
    let (tx, rx) = sync_channel::<Bytes>(0);
    let iris = LazyCsvReader::new("iris.csv")
        .has_header(true)
        .finish()
        .unwrap();

    let reader_job = spawn_reader_thread(rx);

    iris.sink_sender(MySender(tx), FileType::Ipc(IpcWriterOptions::default()))
        .unwrap();

    reader_job.join().unwrap();
}
```