### PR TITLE
refactor: Adds `NotSupported` error variant

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -67,6 +67,8 @@ pub enum PolarsError {
     StringCacheMismatch(ErrString),
     #[error("field not found: {0}")]
     StructFieldNotFound(ErrString),
+    #[error("not implemented: {0}")]
+    NotSupported(ErrString),
 }
 
 impl From<ArrowError> for PolarsError {
@@ -100,6 +102,7 @@ impl PolarsError {
     pub fn wrap_msg(&self, func: &dyn Fn(&str) -> String) -> Self {
         use PolarsError::*;
         match self {
+            NotSupported(msg) => NotSupported(func(msg).into()),
             ArrowError(err) => ComputeError(func(&format!("ArrowError: {err}")).into()),
             ColumnNotFound(msg) => ColumnNotFound(func(msg).into()),
             ComputeError(msg) => ComputeError(func(msg).into()),

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -152,12 +152,12 @@ pub fn create_physical_plan(
         PythonScan { options, .. } => Ok(Box::new(executors::PythonScanExec { options })),
         Sink { payload, .. } => {
             match payload {
-                SinkType::Memory => panic!("Memory Sink not supported in the standard engine."),
-                SinkType::File{file_type, ..} => panic!(
-                    "sink_{file_type:?} not yet supported in standard engine. Use 'collect().write_parquet()'"
-                ),
+                SinkType::Memory => Err(PolarsError::NotSupported("Memory Sink not supported in the standard engine.".into())),
+                SinkType::File{file_type, ..} => Err(PolarsError::NotSupported(
+                    format!("sink_{file_type:?} not yet supported in standard engine. Use 'collect().write_parquet()'").into()
+                )),
                 #[cfg(feature = "cloud")]
-                SinkType::Cloud{..} => panic!("Cloud Sink not supported in standard engine.")
+                SinkType::Cloud{..} => Err(PolarsError::NotSupported("Cloud Sink not supported in standard engine.".into()))
             }
         }
         Union { inputs, options } => {

--- a/py-polars/src/error.rs
+++ b/py-polars/src/error.rs
@@ -31,6 +31,7 @@ impl std::convert::From<PyPolarsErr> for PyErr {
         use PyPolarsErr::*;
         match &err {
             Polars(err) => match err {
+                PolarsError::NotSupported(err) => NotSupported::new_err(err.to_string()),
                 PolarsError::ArrowError(err) => ArrowErrorException::new_err(format!("{err:?}")),
                 PolarsError::ColumnNotFound(name) => ColumnNotFoundError::new_err(name.to_string()),
                 PolarsError::ComputeError(err) => ComputeError::new_err(err.to_string()),
@@ -82,6 +83,7 @@ create_exception!(exceptions, SchemaFieldNotFoundError, PyException);
 create_exception!(exceptions, ShapeError, PyException);
 create_exception!(exceptions, StringCacheMismatchError, PyException);
 create_exception!(exceptions, StructFieldNotFoundError, PyException);
+create_exception!(exceptions, NotSupported, PyException);
 
 #[macro_export]
 macro_rules! raise_err(


### PR DESCRIPTION
I wanted a way to test is `sink_*` was possible for a specific LazyFrame. However, `sink_*` panics when non supported operations are applied, this would allow me to catch the error instead of just panicking.