### PR TITLE
ci: Use `GITHUB_TOKEN` to get contributor information for docs

### DIFF
--- a/.github/workflows/docs-global.yml
+++ b/.github/workflows/docs-global.yml
@@ -67,6 +67,8 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v1
 
       - name: Build documentation
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mkdocs build
 
       - name: Add .nojekyll

--- a/docs/_build/scripts/people.py
+++ b/docs/_build/scripts/people.py
@@ -1,9 +1,10 @@
 import itertools
-from github import Github
+from github import Github, Auth
 import os
 
 token = os.getenv("GITHUB_TOKEN")
-g = Github(token)
+auth = Auth.Token(token) if token else None
+g = Github(auth=auth)
 
 ICON_TEMPLATE = "[![{login}]({avatar_url}){{.contributor_icon}}]({html_url})"
 

--- a/docs/_build/scripts/people.py
+++ b/docs/_build/scripts/people.py
@@ -1,7 +1,9 @@
 import itertools
 from github import Github
+import os
 
-g = Github(None)
+token = os.getenv("GITHUB_TOKEN")
+g = Github(token)
 
 ICON_TEMPLATE = "[![{login}]({avatar_url}){{.contributor_icon}}]({html_url})"
 


### PR DESCRIPTION
Closes [#11101](https://github.com/pola-rs/polars/issues/11101)

This will use the GITHUB_TOKEN in the CI to get the contributor information. Locally, it will get the information without authentication (which may fail, albeit rarely).