### PR TITLE
docs(python): Enable version warning banner

### DIFF
--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -11,7 +11,7 @@ sphinx==7.2.4
 # Third-party Sphinx extensions
 autodocsumm==0.2.11
 numpydoc==1.5.0
-pydata-sphinx-theme==0.13.3
+pydata-sphinx-theme==0.14.1
 sphinx-autosummary-accessors==2023.4.0
 sphinx-copybutton==0.5.2
 sphinx-design==0.5.0

--- a/py-polars/docs/source/_static/version_switcher.json
+++ b/py-polars/docs/source/_static/version_switcher.json
@@ -7,7 +7,8 @@
     {
         "name": "0.19 (stable)",
         "version": "0.19",
-        "url": "https://pola-rs.github.io/polars/py-polars/html/"
+        "url": "https://pola-rs.github.io/polars/py-polars/html/",
+        "preferred": true
     },
     {
         "name": "0.18",

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -138,6 +138,7 @@ html_theme_options = {
         "json_url": f"{web_root}/polars/docs/python/dev/_static/version_switcher.json",
         "version_match": switcher_version,
     },
+    "show_version_warning_banner": True,
     "navbar_end": ["version-switcher", "navbar-icon-links"],
     "check_switcher": False,
 }


### PR DESCRIPTION
This will show a warning when you're browsing a non-stable version of the docs.

Reference:
https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/announcements.html#version-warning-banners