### PR TITLE
docs(python): cross-reference `null_count` from `has_validity` (clarifies the correct way to check for nulls)

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3293,10 +3293,12 @@ class Series:
 
         Notes
         -----
-        While the _absence_ of a validity bitmask guarantees that a Series does not
-        have ``null`` values, the converse is not true, eg: the _presence_ of a
-        bitmask does not mean that there _are_ null values, as every value of the
+        While the *absence* of a validity bitmask guarantees that a Series does not
+        have ``null`` values, the converse is not true, eg: the *presence* of a
+        bitmask does not mean that there are null values, as every value of the
         bitmask could be ``false``.
+
+        To confirm that a column has ``null`` values use :func:`null_count`.
 
         """
         return self._s.has_validity()


### PR DESCRIPTION
Quick/minor follow-up, ref: https://github.com/pola-rs/polars/pull/11319#discussion_r1336849942.

Adds explicit advice (and a cross-link) to the `null_count` method to show the right way to confirm that `null` values are present (also fixes the italics; should have used `*`, not `_` ;)