### PR TITLE
chore(rust): Fix some cargo manifest warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,9 @@ bytemuck = { version = "1", features = ["derive", "extern_crate_alloc"] }
 chrono = { version = "0.4.31", default-features = false, features = ["std"] }
 chrono-tz = "0.8.1"
 ciborium = "0.2"
+crossbeam-channel = "0.5.1"
 either = "1.9"
+ethnum = "1.3.2"
 futures = "0.3.25"
 hashbrown = { version = "0.14", features = ["rayon", "ahash"] }
 indexmap = { version = "2", features = ["std"] }
@@ -48,6 +50,8 @@ smartstring = "1"
 sqlparser = "0.36"
 strum_macros = "0.25"
 thiserror = "1"
+tokio = "1.26"
+tokio-util = "0.7.8"
 url = "2.4"
 version_check = "0.9.4"
 simdutf8 = "0.1.4"

--- a/crates/nano-arrow/Cargo.toml
+++ b/crates/nano-arrow/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "nano-arrow"
 version = "0.1.0"
-authors = ["Jorge C. Leitao <jorgecarleitao@gmail.com>", "Apache Arrow <dev@arrow.apache.org>", "Ritchie Vink <ritchie46@gmail.com>"]
+authors = [
+  "Jorge C. Leitao <jorgecarleitao@gmail.com>",
+  "Apache Arrow <dev@arrow.apache.org>",
+  "Ritchie Vink <ritchie46@gmail.com>",
+]
 edition = { workspace = true }
 homepage = { workspace = true }
 license = "Apache 2.0 AND MIT"
@@ -15,15 +19,15 @@ bytemuck = { workspace = true }
 chrono = { workspace = true }
 # for timezone support
 chrono-tz = { workspace = true, optional = true }
-dyn-clone = "1"
+dyn-clone = { version = "1" }
 either = { workspace = true }
-foreign_vec = "0.1.0"
+foreign_vec = { version = "0.1" }
 hashbrown = { workspace = true }
 num-traits = { workspace = true }
 simdutf8 = { workspace = true }
 
 # for decimal i256
-ethnum = "1"
+ethnum = { workspace = true }
 
 # To efficiently cast numbers to strings
 lexical-core = { workspace = true, optional = true }
@@ -46,7 +50,7 @@ zstd = { version = "0.12", optional = true }
 base64 = { workspace = true, optional = true }
 
 # to write to parquet as a stream
-futures = { version = "0.3", optional = true }
+futures = { workspace = true, optional = true }
 
 # to read IPC as a stream
 async-stream = { version = "0.3.2", optional = true }
@@ -69,9 +73,6 @@ arrow-buffer = { version = ">=40", optional = true }
 arrow-data = { version = ">=40", optional = true }
 arrow-schema = { version = ">=40", optional = true }
 
-[target.wasm32-unknown-unknown.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
-
 # parquet support
 [dependencies.parquet2]
 version = "0.17"
@@ -82,24 +83,26 @@ features = ["async"]
 [dev-dependencies]
 avro-rs = { version = "0.13", features = ["snappy"] }
 criterion = "0.4"
-crossbeam-channel = "0.5.1"
+crossbeam-channel = { workspace = true }
 doc-comment = "0.3"
 flate2 = "1"
 # used to run formal property testing
 proptest = { version = "1", default_features = false, features = ["std"] }
 # use for flaky testing
-rand = "0.8"
+rand = { workspace = true }
 # use for generating and testing random data samples
 sample-arrow2 = "0.1"
 sample-std = "0.1"
 sample-test = "0.1"
 # used to test async readers
-tokio = { version = "1", features = ["macros", "rt", "fs", "io-util"] }
-tokio-util = { version = "0.7", features = ["compat"] }
+tokio = { workspace = true, features = ["macros", "rt", "fs", "io-util"] }
+tokio-util = { workspace = true, features = ["compat"] }
 
-[package.metadata.docs.rs]
-features = ["full"]
-rustdoc-args = ["--cfg", "docsrs"]
+[build-dependencies]
+rustc_version = "0.4.0"
+
+[target.wasm32-unknown-unknown.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 
 [features]
 default = []
@@ -189,8 +192,9 @@ compute = [
 ]
 simd = []
 
-[build-dependencies]
-rustc_version = "0.4.0"
+[package.metadata.docs.rs]
+features = ["full"]
+rustdoc-args = ["--cfg", "docsrs"]
 
 [package.metadata.cargo-all-features]
 allowlist = ["compute", "compute_sort", "compute_hash", "compute_nullif"]

--- a/crates/nano-arrow/Cargo.toml
+++ b/crates/nano-arrow/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "nano-arrow"
 version = "0.1.0"
-authors = ["Jorge C. Leitao <jorgecarleitao@gmail.com>", "Apache Arrow <dev@arrow.apache.org>", "Ritchie Vink"]
-edition.workspace = true
-homepage.workspace = true
-licence = "Apache 2.0 and MIT"
-repository.workspace = true
+authors = ["Jorge C. Leitao <jorgecarleitao@gmail.com>", "Apache Arrow <dev@arrow.apache.org>", "Ritchie Vink <ritchie46@gmail.com>"]
+edition = { workspace = true }
+homepage = { workspace = true }
+license = "Apache 2.0 AND MIT"
+repository = { workspace = true }
 description = "Minimal implementation of the Arrow specification forked from arrow2."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/nano-arrow/Cargo.toml
+++ b/crates/nano-arrow/Cargo.toml
@@ -11,16 +11,16 @@ description = "Minimal implementation of the Arrow specification forked from arr
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytemuck.workspace = true
-chrono.workspace = true
+bytemuck = { workspace = true }
+chrono = { workspace = true }
 # for timezone support
 chrono-tz = { workspace = true, optional = true }
 dyn-clone = "1"
-either.workspace = true
+either = { workspace = true }
 foreign_vec = "0.1.0"
-hashbrown.workspace = true
-num-traits.workspace = true
-simdutf8.workspace = true
+hashbrown = { workspace = true }
+num-traits = { workspace = true }
+simdutf8 = { workspace = true }
 
 # for decimal i256
 ethnum = "1"
@@ -61,7 +61,7 @@ strength_reduce = { version = "0.2", optional = true }
 multiversion = { workspace = true, optional = true }
 
 # Faster hashing
-ahash.workspace = true
+ahash = { workspace = true }
 
 # Support conversion to/from arrow-rs
 arrow-array = { version = ">=40", optional = true }

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -15,7 +15,7 @@ arrow = { workspace = true }
 atoi = { workspace = true, optional = true }
 chrono = { workspace = true, optional = true }
 chrono-tz = { workspace = true, optional = true }
-ethnum = { version = "1.3.2", optional = true }
+ethnum = { workspace = true, optional = true }
 hashbrown = { workspace = true }
 multiversion = { workspace = true }
 num-traits = { workspace = true }

--- a/crates/polars-ffi/Cargo.toml
+++ b/crates/polars-ffi/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "polars-ffi"
-version.workspace = true
-authors.workspace = true
-edition.workspace = true
-homepage.workspace = true
-license.workspace = true
-repository.workspace = true
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 description = "FFI utils for the Polars project."
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -40,8 +40,8 @@ serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value"], optional = true }
 simd-json = { workspace = true, optional = true }
 simdutf8 = { workspace = true, optional = true }
-tokio = { version = "1.26", features = ["net"], optional = true }
-tokio-util = { version = "0.7.8", features = ["io", "io-util"], optional = true }
+tokio = { workspace = true, features = ["net"], optional = true }
+tokio-util = { workspace = true, features = ["io", "io-util"], optional = true }
 url = { workspace = true, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/crates/polars-json/Cargo.toml
+++ b/crates/polars-json/Cargo.toml
@@ -15,7 +15,7 @@ polars-utils = { workspace = true }
 
 ahash = { workspace = true }
 arrow = { workspace = true }
-chrono = { workpace = true }
+chrono = { workspace = true }
 fallible-streaming-iterator = { version = "0.1" }
 hashbrown = { workspace = true }
 indexmap = { workspace = true }

--- a/crates/polars-pipe/Cargo.toml
+++ b/crates/polars-pipe/Cargo.toml
@@ -17,7 +17,7 @@ polars-plan = { workspace = true }
 polars-row = { workspace = true }
 polars-utils = { workspace = true, features = ["sysinfo"] }
 
-crossbeam-channel = { version = "0.5" }
+crossbeam-channel = { workspace = true }
 crossbeam-queue = { version = "0.3" }
 enum_dispatch = { version = "0.3" }
 hashbrown = { workspace = true }

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -27,9 +27,8 @@ rand = { workspace = true }
 version_check = { workspace = true }
 
 # enable js feature for getrandom to work in wasm
-[target.'cfg(target_family = "wasm")'.dependencies.getrandom]
-version = "0.2"
-features = ["js"]
+[target.'cfg(target_family = "wasm")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 
 [features]
 sql = ["polars-sql"]

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -303,10 +303,8 @@ checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-targets",
 ]
 


### PR DESCRIPTION
We had some warnings stemming from typos:
* `licence` -> `license`
* `workpace` -> `workspace`

Also cleaned up the `nano-arrow` manifest, moving some dependency versions to the workspace level.