### PR TITLE
fix(rust,python): ensure trailing quote is written for temporal data when CSV `quote_style` is non-numeric

### DIFF
--- a/crates/polars-io/src/csv/write_impl.rs
+++ b/crates/polars-io/src/csv/write_impl.rs
@@ -186,21 +186,19 @@ unsafe fn write_anyvalue(
                                 },
                                 _ => ndt.format(datetime_format),
                             };
-                            write!(f, "{formatted}").map_err(|_|{
+                            let str_result = write!(f, "{formatted}");
+                            if str_result.is_err() {
                                 let datetime_format = unsafe { *datetime_formats.get_unchecked(i) };
                                 let type_name = if tz.is_some() {
                                     "DateTime"
                                 } else {
                                     "NaiveDateTime"
                                 };
-                                polars_err!(
+                                polars_bail!(
                                     ComputeError: "cannot format {} with format '{}'", type_name, datetime_format,
                                 )
-                            })?;
-                            if end_with_quote {
-                                write!(f, "{quote}")?
-                            }
-                            return Ok(())
+                            };
+                            str_result
                         },
                         #[cfg(feature = "dtype-time")]
                         AnyValue::Time(v) => {

--- a/crates/polars-io/src/csv/write_impl.rs
+++ b/crates/polars-io/src/csv/write_impl.rs
@@ -186,8 +186,7 @@ unsafe fn write_anyvalue(
                                 },
                                 _ => ndt.format(datetime_format),
                             };
-                            return write!(f, "{formatted}").map_err(|_|{
-
+                            write!(f, "{formatted}").map_err(|_|{
                                 let datetime_format = unsafe { *datetime_formats.get_unchecked(i) };
                                 let type_name = if tz.is_some() {
                                     "DateTime"
@@ -195,9 +194,13 @@ unsafe fn write_anyvalue(
                                     "NaiveDateTime"
                                 };
                                 polars_err!(
-                ComputeError: "cannot format {} with format '{}'", type_name, datetime_format,
-            )
-                            });
+                                    ComputeError: "cannot format {} with format '{}'", type_name, datetime_format,
+                                )
+                            })?;
+                            if end_with_quote {
+                                write!(f, "{quote}")?
+                            }
+                            return Ok(())
                         },
                         #[cfg(feature = "dtype-time")]
                         AnyValue::Time(v) => {

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1460,8 +1460,10 @@ def test_csv_9929() -> None:
 
 
 def test_csv_quote_styles() -> None:
-    dt = date(1999, 12, 31)
     dtm = datetime(2077, 7, 5, 3, 1, 0)
+    dt = dtm.date()
+    tm = dtm.time()
+
     df = pl.DataFrame(
         {
             "float": [1.0, 2.0, None],
@@ -1470,31 +1472,36 @@ def test_csv_quote_styles() -> None:
             "bool": [True, False, None],
             "date": [dt, None, dt],
             "datetime": [None, dtm, dtm],
+            "time": [tm, tm, None],
         }
     )
-    assert df.write_csv(quote_style="always") == (
-        '"float","string","int","bool","date","datetime"\n'
-        '"1.0","a","1","true","1999-12-31",""\n'
-        '"2.0","a,bc","2","false","","2077-07-05T03:01:00.000000"\n'
-        '"","""hello","3","","1999-12-31","2077-07-05T03:01:00.000000"\n'
+    temporal_formats = {
+        "datetime_format": "%Y-%m-%dT%H:%M:%S",
+        "time_format": "%H:%M:%S",
+    }
+    assert df.write_csv(quote_style="always", **temporal_formats) == (
+        '"float","string","int","bool","date","datetime","time"\n'
+        '"1.0","a","1","true","2077-07-05","","03:01:00"\n'
+        '"2.0","a,bc","2","false","","2077-07-05T03:01:00","03:01:00"\n'
+        '"","""hello","3","","2077-07-05","2077-07-05T03:01:00",""\n'
     )
-    assert df.write_csv(quote_style="necessary") == (
-        "float,string,int,bool,date,datetime\n"
-        "1.0,a,1,true,1999-12-31,\n"
-        '2.0,"a,bc",2,false,,2077-07-05T03:01:00.000000\n'
-        ',"""hello",3,,1999-12-31,2077-07-05T03:01:00.000000\n'
+    assert df.write_csv(quote_style="necessary", **temporal_formats) == (
+        "float,string,int,bool,date,datetime,time\n"
+        "1.0,a,1,true,2077-07-05,,03:01:00\n"
+        '2.0,"a,bc",2,false,,2077-07-05T03:01:00,03:01:00\n'
+        ',"""hello",3,,2077-07-05,2077-07-05T03:01:00,\n'
     )
-    assert df.write_csv(quote_style="never") == (
-        "float,string,int,bool,date,datetime\n"
-        "1.0,a,1,true,1999-12-31,\n"
-        "2.0,a,bc,2,false,,2077-07-05T03:01:00.000000\n"
-        ',"hello,3,,1999-12-31,2077-07-05T03:01:00.000000\n'
+    assert df.write_csv(quote_style="never", **temporal_formats) == (
+        "float,string,int,bool,date,datetime,time\n"
+        "1.0,a,1,true,2077-07-05,,03:01:00\n"
+        "2.0,a,bc,2,false,,2077-07-05T03:01:00,03:01:00\n"
+        ',"hello,3,,2077-07-05,2077-07-05T03:01:00,\n'
     )
-    assert df.write_csv(quote_style="non_numeric", quote="8") == (
-        "8float8,8string8,8int8,8bool8,8date8,8datetime8\n"
-        "1.0,8a8,1,8true8,81999-12-318,\n"
-        "2.0,8a,bc8,2,8false8,,82077-07-05T03:01:00.0000008\n"
-        ',8"hello8,3,,81999-12-318,82077-07-05T03:01:00.0000008\n'
+    assert df.write_csv(quote_style="non_numeric", quote="8", **temporal_formats) == (
+        "8float8,8string8,8int8,8bool8,8date8,8datetime8,8time8\n"
+        "1.0,8a8,1,8true8,82077-07-058,,803:01:008\n"
+        "2.0,8a,bc8,2,8false8,,82077-07-05T03:01:008,803:01:008\n"
+        ',8"hello8,3,,82077-07-058,82077-07-05T03:01:008,\n'
     )
 
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1460,30 +1460,41 @@ def test_csv_9929() -> None:
 
 
 def test_csv_quote_styles() -> None:
+    dt = date(1999, 12, 31)
+    dtm = datetime(2077, 7, 5, 3, 1, 0)
     df = pl.DataFrame(
         {
             "float": [1.0, 2.0, None],
             "string": ["a", "a,bc", '"hello'],
             "int": [1, 2, 3],
             "bool": [True, False, None],
+            "date": [dt, None, dt],
+            "datetime": [None, dtm, dtm],
         }
     )
-
-    assert (
-        df.write_csv(quote_style="always")
-        == '"float","string","int","bool"\n"1.0","a","1","true"\n"2.0","a,bc","2","false"\n"","""hello","3",""\n'
+    assert df.write_csv(quote_style="always") == (
+        '"float","string","int","bool","date","datetime"\n'
+        '"1.0","a","1","true","1999-12-31",""\n'
+        '"2.0","a,bc","2","false","","2077-07-05T03:01:00.000000"\n'
+        '"","""hello","3","","1999-12-31","2077-07-05T03:01:00.000000"\n'
     )
-    assert (
-        df.write_csv(quote_style="necessary")
-        == 'float,string,int,bool\n1.0,a,1,true\n2.0,"a,bc",2,false\n,"""hello",3,\n'
+    assert df.write_csv(quote_style="necessary") == (
+        "float,string,int,bool,date,datetime\n"
+        "1.0,a,1,true,1999-12-31,\n"
+        '2.0,"a,bc",2,false,,2077-07-05T03:01:00.000000\n'
+        ',"""hello",3,,1999-12-31,2077-07-05T03:01:00.000000\n'
     )
-    assert (
-        df.write_csv(quote_style="never")
-        == 'float,string,int,bool\n1.0,a,1,true\n2.0,a,bc,2,false\n,"hello,3,\n'
+    assert df.write_csv(quote_style="never") == (
+        "float,string,int,bool,date,datetime\n"
+        "1.0,a,1,true,1999-12-31,\n"
+        "2.0,a,bc,2,false,,2077-07-05T03:01:00.000000\n"
+        ',"hello,3,,1999-12-31,2077-07-05T03:01:00.000000\n'
     )
-    assert (
-        df.write_csv(quote_style="non_numeric", quote="8")
-        == '8float8,8string8,8int8,8bool8\n1.0,8a8,1,8true8\n2.0,8a,bc8,2,8false8\n,8"hello8,3,\n'
+    assert df.write_csv(quote_style="non_numeric", quote="8") == (
+        "8float8,8string8,8int8,8bool8,8date8,8datetime8\n"
+        "1.0,8a8,1,8true8,81999-12-318,\n"
+        "2.0,8a,bc8,2,8false8,,82077-07-05T03:01:00.0000008\n"
+        ',8"hello8,3,,81999-12-318,82077-07-05T03:01:00.0000008\n'
     )
 
 

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -6,7 +6,7 @@ import sys
 import textwrap
 import zlib
 from datetime import date, datetime, time, timedelta, timezone
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, TypedDict, cast
 
 import numpy as np
 import pyarrow as pa
@@ -1460,6 +1460,15 @@ def test_csv_9929() -> None:
 
 
 def test_csv_quote_styles() -> None:
+    class TemporalFormats(TypedDict):
+        datetime_format: str
+        time_format: str
+
+    temporal_formats: TemporalFormats = {
+        "datetime_format": "%Y-%m-%dT%H:%M:%S",
+        "time_format": "%H:%M:%S",
+    }
+
     dtm = datetime(2077, 7, 5, 3, 1, 0)
     dt = dtm.date()
     tm = dtm.time()
@@ -1475,10 +1484,7 @@ def test_csv_quote_styles() -> None:
             "time": [tm, tm, None],
         }
     )
-    temporal_formats = {
-        "datetime_format": "%Y-%m-%dT%H:%M:%S",
-        "time_format": "%H:%M:%S",
-    }
+
     assert df.write_csv(quote_style="always", **temporal_formats) == (
         '"float","string","int","bool","date","datetime","time"\n'
         '"1.0","a","1","true","2077-07-05","","03:01:00"\n'


### PR DESCRIPTION
Closes #11324.

We missed writing the trailing quote for datetime values in CSV output when `quote_style` was "non_numeric". Fixed, and extended the related test-coverage to include date/datetime values.

## Example
```python
import polars as pl
from datetime import datetime
df = pl.DataFrame({"dtm": [datetime.now(), datetime.now()]})
```

#### Before
_(datetime values are missing trailing quotes)_
```python
print( df.write_csv( has_header=True, quote_style = 'non_numeric') )
# "dtm"
# "2023-09-26T11:59:34.345885
# "2023-09-26T11:59:34.345931
```
#### After
```python
print( df.write_csv( has_header=True, quote_style = 'non_numeric') )
# "dtm"
# "2023-09-26T11:59:34.345885"
# "2023-09-26T11:59:34.345931"
```