### PR TITLE
feat: modernize CPU features

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -40,6 +40,32 @@ jobs:
           maturin-version: ${{ env.MATURIN_VERSION }}
           rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
 
+  manylinux-x64_64-lts-cpu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Fix README symlink
+        run: |
+          rm py-polars/README.md
+          cp README.md py-polars/README.md
+
+      - name: Prepare lts-cpu
+        run: sed -i 's/name = "polars"/name = "polars-lts-cpu"/' py-polars/pyproject.toml
+
+      - name: Publish wheel
+        uses: PyO3/maturin-action@v1
+        env:
+          RUSTFLAGS: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt --cfg use_mimalloc
+        with:
+          command: publish
+          args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+
   # Needed for Docker on Apple M1
   manylinux-aarch64:
     runs-on: ubuntu-latest
@@ -71,7 +97,91 @@ jobs:
           maturin-version: ${{ env.MATURIN_VERSION }}
           rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-  manylinux-bigidx:
+  win-macos-x64_64:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Fix README symlink
+        run: |
+          rm py-polars/README.md
+          cp README.md py-polars/README.md
+
+      - name: Publish wheel
+        uses: PyO3/maturin-action@v1
+        env:
+          RUSTFLAGS: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt
+
+        with:
+          command: publish
+          args: -m py-polars/Cargo.toml --skip-existing --no-sdist -o wheels -i python -u ritchie46
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+  win-macos-x64_64-lts-cpu:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Fix README symlink
+        run: |
+          rm py-polars/README.md
+          cp README.md py-polars/README.md
+
+      - name: Prepare lts-cpu
+        run: sed -i 's/name = "polars"/name = "polars-lts-cpu"/' py-polars/pyproject.toml
+
+      - name: Publish wheel
+        uses: PyO3/maturin-action@v1
+        env:
+          RUSTFLAGS: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt
+
+        with:
+          command: publish
+          args: -m py-polars/Cargo.toml --skip-existing --no-sdist -o wheels -i python -u ritchie46
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+  macos-aarch64:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Fix README symlink
+        run: |
+          rm py-polars/README.md
+          cp README.md py-polars/README.md
+
+      - name: Set up Rust targets
+        run: rustup target add aarch64-apple-darwin
+
+      - name: Publish wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          command: publish
+          args: -m py-polars/Cargo.toml --target aarch64-apple-darwin --no-sdist -o wheels -i python -u ritchie46
+          maturin-version: ${{ env.MATURIN_VERSION }}
+
+  manylinux-x64_64-bigidx:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -101,7 +211,7 @@ jobs:
           maturin-version: ${{ env.MATURIN_VERSION }}
           rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-  manylinux-x64_64-lts-cpu:
+  manylinux-x64_64-lts-cpu-bigidx:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -114,8 +224,11 @@ jobs:
           rm py-polars/README.md
           cp README.md py-polars/README.md
 
-      - name: Prepare lts-cpu
-        run: sed -i 's/name = "polars"/name = "polars-lts-cpu"/' py-polars/pyproject.toml
+      - name: Prepare lts-cpu-bigidx
+        run: |
+          sed -i 's/name = "polars"/name = "polars-lts-cpu-u64-idx"/' py-polars/pyproject.toml
+          # A brittle hack to insert the 'bigidx' feature
+          sed -i 's/"dynamic_group_by",/"dynamic_group_by",\n"bigidx",/' py-polars/Cargo.toml
 
       - name: Publish wheel
         uses: PyO3/maturin-action@v1
@@ -127,7 +240,79 @@ jobs:
           maturin-version: ${{ env.MATURIN_VERSION }}
           rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-  win-macos:
+  # Needed for Docker on Apple M1
+  manylinux-aarch64-bigidx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # Needed to avoid out-of-memory error
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+
+      - name: Fix README symlink
+        run: |
+          rm py-polars/README.md
+          cp README.md py-polars/README.md
+
+      - name: Prepare bigidx
+        run: |
+          sed -i 's/name = "polars"/name = "polars-u64-idx"/' py-polars/pyproject.toml
+          # A brittle hack to insert the 'bigidx' feature
+          sed -i 's/"dynamic_group_by",/"dynamic_group_by",\n"bigidx",/' py-polars/Cargo.toml
+
+      - name: Publish wheel
+        uses: PyO3/maturin-action@v1
+        env:
+          JEMALLOC_SYS_WITH_LG_PAGE: 16
+        with:
+          command: publish
+          args: -m py-polars/Cargo.toml --skip-existing --no-sdist -o wheels -i python -u ritchie46
+          target: aarch64-unknown-linux-gnu
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+  win-macos-x64_64-bigidx:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Fix README symlink
+        run: |
+          rm py-polars/README.md
+          cp README.md py-polars/README.md
+      
+      - name: Prepare bigidx
+        run: |
+          sed -i 's/name = "polars"/name = "polars-u64-idx"/' py-polars/pyproject.toml
+          # A brittle hack to insert the 'bigidx' feature
+          sed -i 's/"dynamic_group_by",/"dynamic_group_by",\n"bigidx",/' py-polars/Cargo.toml
+
+      - name: Publish wheel
+        uses: PyO3/maturin-action@v1
+        env:
+          RUSTFLAGS: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt
+
+        with:
+          command: publish
+          args: -m py-polars/Cargo.toml --skip-existing --no-sdist -o wheels -i python -u ritchie46
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
+
+  win-macos-x64_64-lts-cpu-bigidx:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -145,18 +330,24 @@ jobs:
           rm py-polars/README.md
           cp README.md py-polars/README.md
 
+      - name: Prepare lts-cpu-bigidx
+        run: |
+          sed -i 's/name = "polars"/name = "polars-lts-cpu-u64-idx"/' py-polars/pyproject.toml
+          # A brittle hack to insert the 'bigidx' feature
+          sed -i 's/"dynamic_group_by",/"dynamic_group_by",\n"bigidx",/' py-polars/Cargo.toml
+
       - name: Publish wheel
         uses: PyO3/maturin-action@v1
         env:
-          RUSTFLAGS: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt
+          RUSTFLAGS: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt
 
         with:
           command: publish
-          args: -m py-polars/Cargo.toml --no-sdist --skip-existing -o wheels -i python -u ritchie46
+          args: -m py-polars/Cargo.toml --skip-existing --no-sdist -o wheels -i python -u ritchie46
           maturin-version: ${{ env.MATURIN_VERSION }}
           rust-toolchain: ${{ env.RUST_TOOLCHAIN }}
 
-  macos-aarch64:
+  macos-aarch64-bigidx:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -171,6 +362,12 @@ jobs:
 
       - name: Set up Rust targets
         run: rustup target add aarch64-apple-darwin
+      
+      - name: Prepare bigidx
+        run: |
+          sed -i 's/name = "polars"/name = "polars-u64-idx"/' py-polars/pyproject.toml
+          # A brittle hack to insert the 'bigidx' feature
+          sed -i 's/"dynamic_group_by",/"dynamic_group_by",\n"bigidx",/' py-polars/Cargo.toml
 
       - name: Publish wheel
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -23,6 +23,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      
+      # Needed to avoid potential out-of-memory errors.
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Fix README symlink
         run: |
@@ -47,6 +53,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      
+      # Needed to avoid potential out-of-memory errors.
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Fix README symlink
         run: |
@@ -75,7 +87,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      # Needed to avoid out-of-memory error
+      # Needed to avoid potential out-of-memory errors.
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
         with:
@@ -109,6 +121,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      
+      # Needed to avoid potential out-of-memory errors.
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Fix README symlink
         run: |
@@ -138,6 +156,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      
+      # Needed to avoid potential out-of-memory errors.
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Fix README symlink
         run: |
@@ -165,6 +189,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      
+      # Needed to avoid potential out-of-memory errors.
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Fix README symlink
         run: |
@@ -188,6 +218,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      
+      # Needed to avoid potential out-of-memory errors.
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Fix README symlink
         run: |
@@ -218,6 +254,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      
+      # Needed to avoid potential out-of-memory errors.
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Fix README symlink
         run: |
@@ -248,8 +290,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      # Needed to avoid out-of-memory error
+      
+      # Needed to avoid potential out-of-memory errors.
       - name: Set Swap Space
         uses: pierotofy/set-swap-space@master
         with:
@@ -289,6 +331,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      
+      # Needed to avoid potential out-of-memory errors.
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Fix README symlink
         run: |
@@ -324,6 +372,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      
+      # Needed to avoid potential out-of-memory errors.
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Fix README symlink
         run: |
@@ -354,6 +408,12 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+      
+      # Needed to avoid potential out-of-memory errors.
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
 
       - name: Fix README symlink
         run: |

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Publish wheel
         uses: PyO3/maturin-action@v1
         env:
-          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
+          RUSTFLAGS: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt
+
         with:
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
@@ -92,7 +93,8 @@ jobs:
       - name: Publish wheel
         uses: PyO3/maturin-action@v1
         env:
-          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
+          RUSTFLAGS: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt
+
         with:
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
@@ -118,7 +120,7 @@ jobs:
       - name: Publish wheel
         uses: PyO3/maturin-action@v1
         env:
-          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt --cfg use_mimalloc
+          RUSTFLAGS: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt --cfg use_mimalloc
         with:
           command: publish
           args: -m py-polars/Cargo.toml --skip-existing -o wheels -u ritchie46
@@ -146,7 +148,8 @@ jobs:
       - name: Publish wheel
         uses: PyO3/maturin-action@v1
         env:
-          RUSTFLAGS: -C target-feature=+fxsr,+sse,+sse2,+sse3,+sse4.1,+sse4.2
+          RUSTFLAGS: -C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt
+
         with:
           command: publish
           args: -m py-polars/Cargo.toml --no-sdist --skip-existing -o wheels -i python -u ritchie46

--- a/py-polars/src/error.rs
+++ b/py-polars/src/error.rs
@@ -82,7 +82,6 @@ create_exception!(exceptions, SchemaFieldNotFoundError, PyException);
 create_exception!(exceptions, ShapeError, PyException);
 create_exception!(exceptions, StringCacheMismatchError, PyException);
 create_exception!(exceptions, StructFieldNotFoundError, PyException);
-create_exception!(exceptions, UnsupportedCPUError, PyException);
 
 #[macro_export]
 macro_rules! raise_err(

--- a/py-polars/src/error.rs
+++ b/py-polars/src/error.rs
@@ -82,6 +82,7 @@ create_exception!(exceptions, SchemaFieldNotFoundError, PyException);
 create_exception!(exceptions, ShapeError, PyException);
 create_exception!(exceptions, StringCacheMismatchError, PyException);
 create_exception!(exceptions, StructFieldNotFoundError, PyException);
+create_exception!(exceptions, UnsupportedCPUError, PyException);
 
 #[macro_export]
 macro_rules! raise_err(

--- a/py-polars/src/on_startup.rs
+++ b/py-polars/src/on_startup.rs
@@ -12,6 +12,8 @@ use pyo3::intern;
 use pyo3::prelude::*;
 
 use crate::dataframe::PyDataFrame;
+#[allow(unused_imports)]
+use crate::error::UnsupportedCPUError;
 use crate::map::lazy::{call_lambda_with_series, ToSeries};
 use crate::prelude::{python_udf, ObjectValue};
 use crate::py_modules::{POLARS, UTILS};
@@ -70,8 +72,17 @@ fn warning_function(msg: &str) {
     });
 }
 
+#[allow(unused_macros)]
+macro_rules! ensure_x86_feat {
+    ($feat:literal) => {
+        if !std::is_x86_feature_detected!($feat) {
+            return Err(UnsupportedCPUError::new_err(format!("Your CPU does not support the {} instruction set, which this build of Polars requires.", $feat.to_uppercase())));
+        }
+    }
+}
+
 #[pyfunction]
-pub fn __register_startup_deps() {
+pub fn __register_startup_deps() -> Result<(), PyErr> {
     if !registry::is_object_builder_registered() {
         // register object type builder
         let object_builder = Box::new(|name: &str, capacity: usize| {
@@ -97,5 +108,28 @@ pub fn __register_startup_deps() {
             // init AnyValue LUT
             crate::conversion::LUT.set(py, Default::default()).unwrap();
         });
+
+        // We have two levels of CPU features for x86_64, check them at runtime
+        // if this build requires them, so we give a nice error instead of a
+        // hard abort due to an invalid instruction.
+        #[cfg(target_feature = "sse3")]
+        {
+            ensure_x86_feat!("sse3");
+            ensure_x86_feat!("ssse3");
+            ensure_x86_feat!("sse4.1");
+            ensure_x86_feat!("sse4.2");
+            ensure_x86_feat!("popcnt");
+        }
+        #[cfg(target_feature = "avx")]
+        {
+            ensure_x86_feat!("avx");
+            ensure_x86_feat!("avx2");
+            ensure_x86_feat!("fma");
+            ensure_x86_feat!("bmi1");
+            ensure_x86_feat!("bmi2");
+            ensure_x86_feat!("lzcnt");
+        }
     }
+
+    Ok(())
 }

--- a/py-polars/src/on_startup.rs
+++ b/py-polars/src/on_startup.rs
@@ -13,7 +13,6 @@ use pyo3::prelude::*;
 
 use crate::dataframe::PyDataFrame;
 #[allow(unused_imports)]
-use crate::error::UnsupportedCPUError;
 use crate::map::lazy::{call_lambda_with_series, ToSeries};
 use crate::prelude::{python_udf, ObjectValue};
 use crate::py_modules::{POLARS, UTILS};
@@ -76,7 +75,7 @@ fn warning_function(msg: &str) {
 macro_rules! ensure_x86_feat {
     ($feat:literal) => {
         if !std::is_x86_feature_detected!($feat) {
-            return Err(UnsupportedCPUError::new_err(format!("Your CPU does not support the {} instruction set, which this build of Polars requires.", $feat.to_uppercase())));
+            return Err(PyImportError::new_err(format!("Your CPU does not support the {} instruction set, which this build of Polars requires.", $feat.to_uppercase())));
         }
     }
 }


### PR DESCRIPTION
This should give us enhanced performance. The vast majority of x86-64 CPUs out there support AVX2/BMI, especially among those doing data analysis. The last mainstream desktop/server CPUs without their support were released in 2016.

There are modern low-powered Pentium / Celeron chips found in NUCs, thin-client mini desktops used in offices and (potentially misconfigured) cheap cloud servers that don't have them, those will have to use the `lts-cpu` Polars packages.

To that end I made sure that all our builds have all possible variants with `-lts-cpu` and `-u64-idx`.