### PR TITLE
docs(python): Disable version warning banner for now

### DIFF
--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -138,7 +138,7 @@ html_theme_options = {
         "json_url": f"{web_root}/polars/docs/python/dev/_static/version_switcher.json",
         "version_match": switcher_version,
     },
-    "show_version_warning_banner": True,
+    "show_version_warning_banner": False,
     "navbar_end": ["version-switcher", "navbar-icon-links"],
     "check_switcher": False,
 }


### PR DESCRIPTION
There seems to be a bug in the Sphinx theme:

https://github.com/pydata/pydata-sphinx-theme/issues/1445

Let's disable the banner for now.