### PR TITLE
Gate a use statement by algorithm_group_by instead of rows

### DIFF
--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -47,7 +47,7 @@ pub(crate) mod private {
     use super::*;
     use crate::chunked_array::ops::compare_inner::{PartialEqInner, PartialOrdInner};
     use crate::chunked_array::Settings;
-    #[cfg(feature = "rows")]
+    #[cfg(feature = "algorithm_group_by")]
     use crate::frame::group_by::GroupsProxy;
 
     pub trait PrivateSeriesNumeric {

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.19.4"
+version = "0.19.5"
 dependencies = [
  "ahash",
  "built",


### PR DESCRIPTION
This resolves a build issue that existed prior to this commit:

```
$ cargo build --no-default-features --features dtype-i8,rows <snip>
error[E0432]: unresolved import `crate::frame::group_by`
  --> crates/polars-core/src/series/series_trait.rs:51:23
   |
51 |     use crate::frame::group_by::GroupsProxy;
   |                       ^^^^^^^^ could not find `group_by` in `frame`
```

Fixes: #11373