### PR TITLE
fix(python): handle ambiguous datetimes in pl.lit

### DIFF
--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -93,7 +93,9 @@ def lit(
             )
         e = lit(_datetime_to_pl_timestamp(value, time_unit)).cast(Datetime(time_unit))
         if time_zone is not None:
-            return e.dt.replace_time_zone(str(time_zone))
+            return e.dt.replace_time_zone(
+                str(time_zone), ambiguous="earliest" if value.fold == 0 else "latest"
+            )
         else:
             return e
 

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any, Sequence
 
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 @pytest.mark.parametrize(
@@ -17,3 +19,21 @@ import polars as pl
 def test_lit_deprecated_sequence_input(sequence: Sequence[Any]) -> None:
     with pytest.deprecated_call():
         pl.lit(sequence)
+
+
+def test_lit_ambiguous_datetimes_11379() -> None:
+    df = pl.DataFrame(
+        {
+            "ts": pl.datetime_range(
+                datetime(2020, 10, 25),
+                datetime(2020, 10, 25, 2),
+                "1h",
+                time_zone="Europe/London",
+                eager=True,
+            )
+        }
+    )
+    for i in range(len(df)):
+        result = df.filter(pl.col("ts") >= df["ts"][i])
+        expected = df[i:]
+        assert_frame_equal(result, expected)


### PR DESCRIPTION
closes #11379 