### PR TITLE
fix(rust,python): Fix edge-case where the Array dtype could (internally) be considered numeric

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -163,29 +163,19 @@ impl DataType {
 
     /// Check if this [`DataType`] is a numeric type.
     pub fn is_numeric(&self) -> bool {
-        // allow because it cannot be replaced when object feature is activated
-        #[allow(clippy::match_like_matches_macro)]
-        match self {
-            DataType::Utf8
-            | DataType::List(_)
-            | DataType::Date
-            | DataType::Datetime(_, _)
-            | DataType::Duration(_)
-            | DataType::Time
-            | DataType::Boolean
-            | DataType::Unknown
-            | DataType::Null => false,
-            DataType::Binary => false,
-            #[cfg(feature = "object")]
-            DataType::Object(_) => false,
-            #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_) => false,
-            #[cfg(feature = "dtype-struct")]
-            DataType::Struct(_) => false,
-            #[cfg(feature = "dtype-decimal")]
-            DataType::Decimal(_, _) => false,
-            _ => true,
-        }
+        matches!(
+            self,
+            DataType::UInt8
+                | DataType::UInt16
+                | DataType::UInt32
+                | DataType::UInt64
+                | DataType::Int8
+                | DataType::Int16
+                | DataType::Int32
+                | DataType::Int64
+                | DataType::Float32
+                | DataType::Float64
+        )
     }
 
     pub fn is_float(&self) -> bool {

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -1,6 +1,7 @@
 import pytest
 
 import polars as pl
+from polars.exceptions import InvalidOperationError
 from polars.testing import assert_series_equal
 
 
@@ -77,6 +78,18 @@ def test_array_in_group_by() -> None:
             "a": pl.List(pl.Array(inner=pl.Int64, width=2)),
         }
         assert out.to_dict(False) == {"g": [1, 2], "a": [[[1, 2], [2, 2]], [[1, 4]]]}
+
+
+def test_array_invalid_operation() -> None:
+    s = pl.Series(
+        [[1, 2], [8, 9]],
+        dtype=pl.Array(width=2, inner=pl.Int32),
+    )
+    with pytest.raises(
+        InvalidOperationError,
+        match=r"`sign` operation not supported for dtype `array\[",
+    ):
+        s.sign()
 
 
 def test_array_concat() -> None:

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from datetime import date, datetime, time
 from typing import Any, cast
 
@@ -131,14 +130,11 @@ def test_from_pandas() -> None:
         [None, None, None],
     ],
 )
-def test_from_pandas_nulls(nulls: Any) -> None:
+def test_from_pandas_nulls(nulls: list[None]) -> None:
     # empty and/or all null values, no pandas dtype
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", Warning)
-
-        ps = pd.Series(nulls)
-        srs = pl.from_pandas(ps)
-        assert nulls == srs.to_list()
+    ps = pd.Series(nulls)
+    s = pl.from_pandas(ps)
+    assert nulls == s.to_list()
 
 
 def test_from_pandas_nan_to_null() -> None:

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -121,13 +121,24 @@ def test_from_pandas() -> None:
     for col, dtype in overrides.items():
         assert out.schema[col] == dtype
 
+
+@pytest.mark.parametrize(
+    "nulls",
+    [
+        [],
+        [None],
+        [None, None],
+        [None, None, None],
+    ],
+)
+def test_from_pandas_nulls(nulls: Any) -> None:
     # empty and/or all null values, no pandas dtype
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", Warning)
 
-        for nulls in ([], [None], [None, None], [None, None, None]):
-            srs = pl.from_pandas(pd.Series(nulls))
-            assert nulls == srs.to_list()
+        ps = pd.Series(nulls)
+        srs = pl.from_pandas(ps)
+        assert nulls == srs.to_list()
 
 
 def test_from_pandas_nan_to_null() -> None:


### PR DESCRIPTION
Came across this one after seeing some inconsistent error messages debugging something else.
(Addresses an edge-case where Array dtype could inadvertantly be considered numeric).

* The `is_numeric` check was a bit peculiar (and likely prone to future breakage if/when adding new dtypes) as it decided that a dtype was numeric if It _wasn't_ various other dtypes, rather than because it _was_ numeric. Changed this so that we positively assert the dtype from the known numeric types instead, which seems a lot cleaner.

---

**Also:** fixes a minor test lint (`mypy` on py 3.11) caused by an update to `pandas-stubs`.

**Note:** for some reason we don't currently consider Decimal to be numeric here; that seems odd, so will probably revisit to better-understand why... this PR does not change this behaviour (indeed, quite a few things blow up if you do ;)