### PR TITLE
fix: async parquet. 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ polars-error = { version = "0.33.2", path = "crates/polars-error", default-featu
 polars-json = { version = "0.33.2", path = "crates/polars-json", default-features = false }
 polars = { version = "0.33.2", path = "crates/polars", default-features = false }
 rand_distr = "0.4"
-reqwest = {version = "0.11", default-features=false}
+reqwest = { version = "0.11", default-features = false }
 
 [workspace.dependencies.arrow]
 package = "nano-arrow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ polars-error = { version = "0.33.2", path = "crates/polars-error", default-featu
 polars-json = { version = "0.33.2", path = "crates/polars-json", default-features = false }
 polars = { version = "0.33.2", path = "crates/polars", default-features = false }
 rand_distr = "0.4"
+reqwest = {version = "0.11", features = ["blocking"], default-features=false}
 
 [workspace.dependencies.arrow]
 package = "nano-arrow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,7 @@ polars-error = { version = "0.33.2", path = "crates/polars-error", default-featu
 polars-json = { version = "0.33.2", path = "crates/polars-json", default-features = false }
 polars = { version = "0.33.2", path = "crates/polars", default-features = false }
 rand_distr = "0.4"
-reqwest = {version = "0.11", features = ["blocking"], default-features=false}
+reqwest = {version = "0.11", default-features=false}
 
 [workspace.dependencies.arrow]
 package = "nano-arrow"

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -44,7 +44,7 @@ simd-json = { workspace = true, optional = true }
 simdutf8 = { workspace = true, optional = true }
 smartstring = { workspace = true }
 tokio = { workspace = true, features = ["net"], optional = true }
-tokio-util = { workspace = true, features = ["io", "io-util"], optional = true, default-features = false }
+tokio-util = { workspace = true, features = ["io", "io-util"], optional = true }
 url = { workspace = true, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -36,13 +36,15 @@ once_cell = { workspace = true }
 percent-encoding = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
+reqwest = { workspace = true, optional = true }
 ryu = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value"], optional = true }
 simd-json = { workspace = true, optional = true }
 simdutf8 = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["net"], optional = true }
-tokio-util = { workspace = true, features = ["io", "io-util"], optional = true }
+smartstring = { workspace = true }
+tokio = { workspace = true, features = ["net"], optional = true, default-features = false }
+tokio-util = { workspace = true, features = ["io", "io-util"], optional = true, default-features = false }
 url = { workspace = true, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
@@ -93,7 +95,7 @@ lazy = []
 parquet = ["polars-core/parquet", "arrow/io_parquet", "arrow/io_parquet_compression"]
 async = ["async-trait", "futures", "tokio", "tokio-util", "arrow/io_ipc_write_async", "polars-error/regex"]
 cloud = ["object_store", "async", "polars-error/object_store", "url"]
-aws = ["object_store/aws", "cloud"]
+aws = ["object_store/aws", "cloud", "reqwest"]
 azure = ["object_store/azure", "cloud"]
 gcp = ["object_store/gcp", "cloud"]
 partition = ["polars-core/partition_by"]

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -43,7 +43,7 @@ serde_json = { version = "1", default-features = false, features = ["alloc", "ra
 simd-json = { workspace = true, optional = true }
 simdutf8 = { workspace = true, optional = true }
 smartstring = { workspace = true }
-tokio = { workspace = true, features = ["net"], optional = true, default-features = false }
+tokio = { workspace = true, features = ["net"], optional = true }
 tokio-util = { workspace = true, features = ["io", "io-util"], optional = true, default-features = false }
 url = { workspace = true, optional = true }
 

--- a/crates/polars-io/src/cloud/adaptors.rs
+++ b/crates/polars-io/src/cloud/adaptors.rs
@@ -240,8 +240,7 @@ mod tests {
         .unwrap()
     }
 
-    #[tokio::test]
-    async fn csv_to_local_objectstore_cloudwriter() {
+    fn csv_to_local_objectstore_cloudwriter() {
         use crate::csv::CsvWriter;
         use crate::prelude::SerWriter;
 
@@ -254,8 +253,8 @@ mod tests {
 
         let path: object_store::path::Path = "cloud_writer_example.csv".into();
 
-        let mut cloud_writer = CloudWriter::new_with_object_store(object_store, path)
-            .await
+        let mut cloud_writer = get_runtime()
+            .block_on(CloudWriter::new_with_object_store(object_store, path))
             .unwrap();
         CsvWriter::new(&mut cloud_writer)
             .finish(&mut df)
@@ -264,15 +263,14 @@ mod tests {
 
     // Skip this tests on Windows since it does not have a convenient /tmp/ location.
     #[cfg_attr(target_os = "windows", ignore)]
-    #[tokio::test]
     async fn cloudwriter_from_cloudlocation_test() {
         use crate::csv::CsvWriter;
         use crate::prelude::SerWriter;
 
         let mut df = example_dataframe();
 
-        let mut cloud_writer = CloudWriter::new("file:///tmp/cloud_writer_example2.csv", None)
-            .await
+        let mut cloud_writer = get_runtime()
+            .block_on(CloudWriter::new_with_object_store(object_store, path))
             .unwrap();
 
         CsvWriter::new(&mut cloud_writer)

--- a/crates/polars-io/src/cloud/adaptors.rs
+++ b/crates/polars-io/src/cloud/adaptors.rs
@@ -270,7 +270,10 @@ mod tests {
         let mut df = example_dataframe();
 
         let mut cloud_writer = get_runtime()
-            .block_on(CloudWriter::new_with_object_store(object_store, path))
+            .block_on(CloudWriter::new(
+                "file:///tmp/cloud_writer_example2.csv",
+                None,
+            ))
             .unwrap();
 
         CsvWriter::new(&mut cloud_writer)

--- a/crates/polars-io/src/cloud/adaptors.rs
+++ b/crates/polars-io/src/cloud/adaptors.rs
@@ -182,8 +182,9 @@ impl CloudWriter {
     ///
     /// Wrapper around `CloudWriter::new_with_object_store` that is useful if you only have a single write task.
     /// TODO: Naming?
-    pub fn new(uri: &str, cloud_options: Option<&CloudOptions>) -> PolarsResult<Self> {
-        let (cloud_location, object_store) = crate::cloud::build_object_store(uri, cloud_options)?;
+    pub async fn new(uri: &str, cloud_options: Option<&CloudOptions>) -> PolarsResult<Self> {
+        let (cloud_location, object_store) =
+            crate::cloud::build_object_store(uri, cloud_options).await?;
         Self::new_with_object_store(object_store, cloud_location.prefix.into())
     }
 
@@ -267,15 +268,16 @@ mod tests {
 
     // Skip this tests on Windows since it does not have a convenient /tmp/ location.
     #[cfg_attr(target_os = "windows", ignore)]
-    #[test]
-    fn cloudwriter_from_cloudlocation_test() {
+    #[tokio::test]
+    async fn cloudwriter_from_cloudlocation_test() {
         use crate::csv::CsvWriter;
         use crate::prelude::SerWriter;
 
         let mut df = example_dataframe();
 
-        let mut cloud_writer =
-            CloudWriter::new("file:///tmp/cloud_writer_example2.csv", None).unwrap();
+        let mut cloud_writer = CloudWriter::new("file:///tmp/cloud_writer_example2.csv", None)
+            .await
+            .unwrap();
 
         CsvWriter::new(&mut cloud_writer)
             .finish(&mut df)

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -166,7 +166,7 @@ pub async fn glob(url: &str, cloud_options: Option<&CloudOptions>) -> PolarsResu
             expansion,
         },
         store,
-    ) = super::build_object_store(url, cloud_options)?;
+    ) = super::build_object_store(url, cloud_options).await?;
     let matcher = Matcher::new(prefix.clone(), expansion.as_deref())?;
 
     let list_stream = store

--- a/crates/polars-io/src/cloud/mod.rs
+++ b/crates/polars-io/src/cloud/mod.rs
@@ -19,6 +19,7 @@ mod adaptors;
 #[cfg(feature = "cloud")]
 mod glob;
 pub mod options;
+
 #[cfg(feature = "cloud")]
 pub use adaptors::*;
 #[cfg(feature = "cloud")]

--- a/crates/polars-io/src/cloud/mod.rs
+++ b/crates/polars-io/src/cloud/mod.rs
@@ -46,7 +46,7 @@ fn err_missing_configuration(feature: &str, scheme: &str) -> BuildResult {
 
 /// Build an [`ObjectStore`] based on the URL and passed in url. Return the cloud location and an implementation of the object store.
 #[cfg(feature = "cloud")]
-pub fn build_object_store(url: &str, _options: Option<&CloudOptions>) -> BuildResult {
+pub async fn build_object_store(url: &str, _options: Option<&CloudOptions>) -> BuildResult {
     let cloud_location = CloudLocation::new(url)?;
     let store = match CloudType::from_str(url)? {
         CloudType::File => {
@@ -59,7 +59,7 @@ pub fn build_object_store(url: &str, _options: Option<&CloudOptions>) -> BuildRe
                 let options = _options
                     .map(Cow::Borrowed)
                     .unwrap_or_else(|| Cow::Owned(Default::default()));
-                let store = options.build_aws(url)?;
+                let store = options.build_aws(url).await?;
                 Ok::<_, PolarsError>(Arc::new(store) as Arc<dyn ObjectStore>)
             }
             #[cfg(not(feature = "aws"))]

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -1,4 +1,5 @@
 use std::str::FromStr;
+use std::sync::Mutex;
 
 #[cfg(feature = "aws")]
 use object_store::aws::AmazonS3Builder;
@@ -16,12 +17,20 @@ pub use object_store::gcp::GoogleConfigKey;
 use object_store::ObjectStore;
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
 use object_store::{BackoffConfig, RetryConfig};
+use once_cell::sync::Lazy;
 use polars_core::error::{PolarsError, PolarsResult};
 use polars_error::*;
+use polars_utils::cache::FastFixedCache;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use smartstring::alias::String as SmartString;
 #[cfg(feature = "async")]
 use url::Url;
+use polars_core::config::verbose;
+
+#[cfg(feature = "aws")]
+static BUCKET_REGION: Lazy<Mutex<FastFixedCache<SmartString, SmartString>>> =
+    Lazy::new(|| Mutex::new(FastFixedCache::default()));
 
 /// The type of the config keys must satisfy the following requirements:
 /// 1. must be easily collected into a HashMap, the type required by the object_crate API.
@@ -119,7 +128,7 @@ impl CloudOptions {
 
     /// Build the [`ObjectStore`] implementation for AWS.
     #[cfg(feature = "aws")]
-    pub fn build_aws(&self, url: &str) -> PolarsResult<impl ObjectStore> {
+    pub async fn build_aws(&self, url: &str) -> PolarsResult<impl ObjectStore> {
         let options = self.aws.as_ref();
         let mut builder = AmazonS3Builder::from_env().with_url(url);
         if let Some(options) = options {
@@ -127,6 +136,39 @@ impl CloudOptions {
                 builder = builder.with_config(*key, value);
             }
         }
+
+        if builder
+            .get_config_value(&AmazonS3ConfigKey::DefaultRegion)
+            .is_none()
+            && builder
+                .get_config_value(&AmazonS3ConfigKey::Region)
+                .is_none()
+        {
+            let mut bucket_region = BUCKET_REGION.lock().unwrap();
+            let bucket = crate::cloud::CloudLocation::new(url)?.bucket;
+
+            match bucket_region.get(bucket.as_str()) {
+                Some(region) => {
+                    builder = builder.with_config(AmazonS3ConfigKey::Region, region.as_str())
+                },
+                None => {
+                    polars_warn!("'(default_)region' not set; polars will try to get it from bucket\n\nSet the region manually to silence this warning.");
+                    let result = reqwest::Client::builder()
+                        .build()
+                        .unwrap()
+                        .head(format!("https://{bucket}.s3.amazonaws.com"))
+                        .send()
+                        .await
+                        .map_err(to_compute_err)?;
+                    if let Some(region) = result.headers().get("x-amz-bucket-region") {
+                        let region =
+                            std::str::from_utf8(region.as_bytes()).map_err(to_compute_err)?;
+                        bucket_region.insert(bucket.into(), region.into());
+                        builder = builder.with_config(AmazonS3ConfigKey::Region, region)
+                    }
+                },
+            };
+        };
 
         builder
             .with_retry(get_retry_config(self.max_retries))

--- a/crates/polars-io/src/lib.rs
+++ b/crates/polars-io/src/lib.rs
@@ -32,6 +32,8 @@ use regex::Regex;
 
 #[cfg(feature = "partition")]
 pub mod partition;
+#[cfg(feature = "async")]
+pub mod pl_async;
 
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};

--- a/crates/polars-io/src/parquet/async_impl.rs
+++ b/crates/polars-io/src/parquet/async_impl.rs
@@ -19,7 +19,6 @@ use polars_core::schema::Schema;
 use super::cloud::{build_object_store, CloudLocation, CloudReader};
 use super::mmap;
 use super::mmap::ColumnStore;
-use super::read_impl::FetchRowGroups;
 use crate::cloud::CloudOptions;
 
 pub struct ParquetObjectStore {
@@ -100,7 +99,6 @@ type RowGroupChunks<'a> = Vec<Vec<(&'a ColumnChunkMetaData, Vec<u8>)>>;
 
 /// Download rowgroups for the column whose indexes are given in `projection`.
 /// We concurrently download the columns for each field.
-#[tokio::main(flavor = "current_thread")]
 async fn download_projection<'a: 'b, 'b>(
     projection: &[usize],
     row_groups: &'a [RowGroupMetaData],
@@ -140,7 +138,7 @@ async fn download_projection<'a: 'b, 'b>(
         .await
 }
 
-pub(crate) struct FetchRowGroupsFromObjectStore {
+pub struct FetchRowGroupsFromObjectStore {
     reader: ParquetObjectStore,
     row_groups_metadata: Vec<RowGroupMetaData>,
     projection: Vec<usize>,
@@ -169,10 +167,11 @@ impl FetchRowGroupsFromObjectStore {
             schema,
         })
     }
-}
 
-impl FetchRowGroups for FetchRowGroupsFromObjectStore {
-    fn fetch_row_groups(&mut self, row_groups: Range<usize>) -> PolarsResult<ColumnStore> {
+    pub(crate) async fn fetch_row_groups(
+        &mut self,
+        row_groups: Range<usize>,
+    ) -> PolarsResult<ColumnStore> {
         // Fetch the required row groups.
         let row_groups = &self
             .row_groups_metadata
@@ -186,7 +185,8 @@ impl FetchRowGroups for FetchRowGroupsFromObjectStore {
 
         // Package in the format required by ColumnStore.
         let downloaded =
-            download_projection(&self.projection, row_groups, &self.schema, &self.reader)?;
+            download_projection(&self.projection, row_groups, &self.schema, &self.reader).await?;
+
         if self.logging {
             eprintln!(
                 "BatchedParquetReader: fetched {} row_groups for {} fields, yielding {} column chunks.",

--- a/crates/polars-io/src/parquet/async_impl.rs
+++ b/crates/polars-io/src/parquet/async_impl.rs
@@ -30,8 +30,8 @@ pub struct ParquetObjectStore {
 }
 
 impl ParquetObjectStore {
-    pub fn from_uri(uri: &str, options: Option<&CloudOptions>) -> PolarsResult<Self> {
-        let (CloudLocation { prefix, .. }, store) = build_object_store(uri, options)?;
+    pub async fn from_uri(uri: &str, options: Option<&CloudOptions>) -> PolarsResult<Self> {
+        let (CloudLocation { prefix, .. }, store) = build_object_store(uri, options).await?;
 
         Ok(ParquetObjectStore {
             store,

--- a/crates/polars-io/src/parquet/read.rs
+++ b/crates/polars-io/src/parquet/read.rs
@@ -245,12 +245,12 @@ pub struct ParquetAsyncReader {
 
 #[cfg(feature = "cloud")]
 impl ParquetAsyncReader {
-    pub fn from_uri(
+    pub async fn from_uri(
         uri: &str,
         cloud_options: Option<&CloudOptions>,
     ) -> PolarsResult<ParquetAsyncReader> {
         Ok(ParquetAsyncReader {
-            reader: ParquetObjectStore::from_uri(uri, cloud_options)?,
+            reader: ParquetObjectStore::from_uri(uri, cloud_options).await?,
             rechunk: false,
             n_rows: None,
             projection: None,
@@ -266,7 +266,7 @@ impl ParquetAsyncReader {
         uri: &str,
         options: Option<&CloudOptions>,
     ) -> PolarsResult<(Schema, usize)> {
-        let mut reader = ParquetAsyncReader::from_uri(uri, options)?;
+        let mut reader = ParquetAsyncReader::from_uri(uri, options).await?;
         let schema = reader.schema().await?;
         let num_rows = reader.num_rows().await?;
         Ok((schema, num_rows))

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -14,9 +14,11 @@ use rayon::prelude::*;
 
 use super::mmap::ColumnStore;
 use crate::mmap::{MmapBytesReader, ReaderBytes};
+use crate::parquet::async_impl::FetchRowGroupsFromObjectStore;
 use crate::parquet::mmap::mmap_columns;
 use crate::parquet::predicates::read_this_row_group;
 use crate::parquet::{mmap, ParallelStrategy};
+use crate::pl_async::get_runtime;
 use crate::predicates::{apply_predicate, arrow_schema_to_empty_df, PhysicalIoExpr};
 use crate::utils::{apply_projection, get_reader_bytes};
 use crate::RowCount;
@@ -342,14 +344,7 @@ pub fn read_parquet<R: MmapBytesReader>(
     }
 }
 
-/// Provide RowGroup content to the BatchedReader.
-/// This allows us to share the code to do in-memory processing for different use cases.
-pub trait FetchRowGroups: Sync + Send {
-    /// Fetch the row groups in the given range and package them in a ColumnStore.
-    fn fetch_row_groups(&mut self, row_groups: Range<usize>) -> PolarsResult<ColumnStore>;
-}
-
-pub(crate) struct FetchRowGroupsFromMmapReader(ReaderBytes<'static>);
+pub struct FetchRowGroupsFromMmapReader(ReaderBytes<'static>);
 
 impl FetchRowGroupsFromMmapReader {
     pub fn new(mut reader: Box<dyn MmapBytesReader>) -> PolarsResult<Self> {
@@ -364,19 +359,43 @@ impl FetchRowGroupsFromMmapReader {
         let reader_bytes = get_reader_bytes(reader_ptr)?;
         Ok(FetchRowGroupsFromMmapReader(reader_bytes))
     }
+    async fn fetch_row_groups(&mut self, _row_groups: Range<usize>) -> PolarsResult<ColumnStore> {
+        Ok(mmap::ColumnStore::Local(self.0.deref()))
+    }
 }
 
-/// There is nothing to do when fetching a mmap-ed file.
-impl FetchRowGroups for FetchRowGroupsFromMmapReader {
-    fn fetch_row_groups(&mut self, _row_groups: Range<usize>) -> PolarsResult<ColumnStore> {
-        Ok(mmap::ColumnStore::Local(self.0.deref()))
+// We couldn't use a trait as async trait gave very hard HRT lifetime errors.
+// Maybe a puzzle for another day.
+pub enum RowGroupFetcher {
+    ObjectStore(FetchRowGroupsFromObjectStore),
+    Local(FetchRowGroupsFromMmapReader),
+}
+
+impl From<FetchRowGroupsFromObjectStore> for RowGroupFetcher {
+    fn from(value: FetchRowGroupsFromObjectStore) -> Self {
+        RowGroupFetcher::ObjectStore(value)
+    }
+}
+
+impl From<FetchRowGroupsFromMmapReader> for RowGroupFetcher {
+    fn from(value: FetchRowGroupsFromMmapReader) -> Self {
+        RowGroupFetcher::Local(value)
+    }
+}
+
+impl RowGroupFetcher {
+    async fn fetch_row_groups(&mut self, _row_groups: Range<usize>) -> PolarsResult<ColumnStore> {
+        match self {
+            RowGroupFetcher::Local(f) => f.fetch_row_groups(_row_groups).await,
+            RowGroupFetcher::ObjectStore(f) => f.fetch_row_groups(_row_groups).await,
+        }
     }
 }
 
 pub struct BatchedParquetReader {
     // use to keep ownership
     #[allow(dead_code)]
-    row_group_fetcher: Box<dyn FetchRowGroups>,
+    row_group_fetcher: RowGroupFetcher,
     limit: usize,
     projection: Vec<usize>,
     schema: ArrowSchema,
@@ -395,7 +414,7 @@ pub struct BatchedParquetReader {
 impl BatchedParquetReader {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        row_group_fetcher: Box<dyn FetchRowGroups>,
+        row_group_fetcher: RowGroupFetcher,
         metadata: FileMetaData,
         limit: usize,
         projection: Option<Vec<usize>>,
@@ -434,14 +453,15 @@ impl BatchedParquetReader {
         })
     }
 
-    pub fn next_batches(&mut self, n: usize) -> PolarsResult<Option<Vec<DataFrame>>> {
+    pub async fn next_batches(&mut self, n: usize) -> PolarsResult<Option<Vec<DataFrame>>> {
         // fill up fifo stack
         if self.row_group_offset <= self.n_row_groups && self.chunks_fifo.len() < n {
             let row_group_start = self.row_group_offset;
             let row_group_end = std::cmp::min(self.row_group_offset + n, self.n_row_groups);
             let store = self
                 .row_group_fetcher
-                .fetch_row_groups(row_group_start..row_group_end)?;
+                .fetch_row_groups(row_group_start..row_group_end)
+                .await?;
             let dfs = match self.parallel {
                 ParallelStrategy::Columns => {
                     let dfs = rg_to_dfs(
@@ -536,6 +556,17 @@ impl BatchedParquetReader {
             batches_per_iter,
             inner: self,
             current_batch: vec![].into_iter(),
+            rt: Some(get_runtime()),
+        }
+    }
+
+    /// Turn the batched reader into an iterator.
+    pub fn iter_async(self, batches_per_iter: usize) -> BatchedParquetIter {
+        BatchedParquetIter {
+            batches_per_iter,
+            inner: self,
+            current_batch: vec![].into_iter(),
+            rt: None,
         }
     }
 }
@@ -544,6 +575,24 @@ pub struct BatchedParquetIter {
     batches_per_iter: usize,
     inner: BatchedParquetReader,
     current_batch: std::vec::IntoIter<DataFrame>,
+    rt: Option<tokio::runtime::Runtime>,
+}
+
+impl BatchedParquetIter {
+    // todo! implement stream
+    pub(crate) async fn next_(&mut self) -> Option<PolarsResult<DataFrame>> {
+        match self.current_batch.next() {
+            Some(df) => Some(Ok(df)),
+            None => match self.inner.next_batches(self.batches_per_iter).await {
+                Err(e) => Some(Err(e)),
+                Ok(opt_batch) => {
+                    let batch = opt_batch?;
+                    self.current_batch = batch.into_iter();
+                    self.current_batch.next().map(Ok)
+                },
+            },
+        }
+    }
 }
 
 impl Iterator for BatchedParquetIter {
@@ -552,7 +601,12 @@ impl Iterator for BatchedParquetIter {
     fn next(&mut self) -> Option<Self::Item> {
         match self.current_batch.next() {
             Some(df) => Some(Ok(df)),
-            None => match self.inner.next_batches(self.batches_per_iter) {
+            None => match self
+                .rt
+                .as_ref()
+                .unwrap()
+                .block_on(self.inner.next_batches(self.batches_per_iter))
+            {
                 Err(e) => Some(Err(e)),
                 Ok(opt_batch) => {
                     let batch = opt_batch?;

--- a/crates/polars-io/src/pl_async.rs
+++ b/crates/polars-io/src/pl_async.rs
@@ -1,0 +1,9 @@
+use tokio::runtime::{Builder, Runtime};
+
+pub fn get_runtime() -> Runtime {
+    Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap()
+}

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -26,6 +26,7 @@ once_cell = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 rayon = { workspace = true }
 smartstring = { workspace = true }
+tokio = { workspace = true, optional = true, default-features = false }
 
 [dev-dependencies]
 serde_json = { workspace = true }
@@ -42,7 +43,7 @@ async = [
   "polars-io/cloud",
   "polars-pipe?/async",
 ]
-cloud = ["async", "polars-pipe?/cloud", "polars-plan/cloud"]
+cloud = ["async", "polars-pipe?/cloud", "polars-plan/cloud", "tokio"]
 cloud_write = ["cloud"]
 ipc = ["polars-io/ipc", "polars-plan/ipc", "polars-pipe?/ipc"]
 json = ["polars-io/json", "polars-plan/json", "polars-json"]

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -26,7 +26,7 @@ once_cell = { workspace = true }
 pyo3 = { workspace = true, optional = true }
 rayon = { workspace = true }
 smartstring = { workspace = true }
-tokio = { workspace = true, optional = true, default-features = false }
+tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -62,27 +62,24 @@ impl ParquetExec {
         } else if is_cloud_url(self.path.as_path()) {
             #[cfg(feature = "cloud")]
             {
-                tokio::runtime::Builder::new_current_thread()
-                    .build()
-                    .unwrap()
-                    .block_on(async {
-                        let reader = ParquetAsyncReader::from_uri(
-                            &self.path.to_string_lossy(),
-                            self.cloud_options.as_ref(),
-                        )
-                        .await?
-                        .with_n_rows(n_rows)
-                        .with_row_count(mem::take(&mut self.file_options.row_count))
-                        .use_statistics(self.options.use_statistics)
-                        .with_hive_partition_columns(
-                            self.file_info
-                                .hive_parts
-                                .as_ref()
-                                .map(|hive| hive.materialize_partition_columns()),
-                        );
+                polars_io::pl_async::get_runtime().block_on(async {
+                    let reader = ParquetAsyncReader::from_uri(
+                        &self.path.to_string_lossy(),
+                        self.cloud_options.as_ref(),
+                    )
+                    .await?
+                    .with_n_rows(n_rows)
+                    .with_row_count(mem::take(&mut self.file_options.row_count))
+                    .use_statistics(self.options.use_statistics)
+                    .with_hive_partition_columns(
+                        self.file_info
+                            .hive_parts
+                            .as_ref()
+                            .map(|hive| hive.materialize_partition_columns()),
+                    );
 
-                        reader.finish(predicate)
-                    })
+                    reader.finish(predicate).await
+                })
             }
             #[cfg(not(feature = "cloud"))]
             {

--- a/crates/polars-pipe/Cargo.toml
+++ b/crates/polars-pipe/Cargo.toml
@@ -16,6 +16,7 @@ polars-ops = { workspace = true, features = ["search_sorted"] }
 polars-plan = { workspace = true }
 polars-row = { workspace = true }
 polars-utils = { workspace = true, features = ["sysinfo"] }
+tokio = { workspace = true, optional = true, default-features = false }
 
 crossbeam-channel = { workspace = true }
 crossbeam-queue = { version = "0.3" }
@@ -30,7 +31,7 @@ version_check = { workspace = true }
 
 [features]
 csv = ["polars-plan/csv", "polars-io/csv"]
-cloud = ["async", "polars-io/cloud", "polars-plan/cloud"]
+cloud = ["async", "polars-io/cloud", "polars-plan/cloud", "tokio"]
 parquet = ["polars-plan/parquet", "polars-io/parquet"]
 ipc = ["polars-plan/ipc", "polars-io/ipc"]
 async = ["polars-plan/async", "polars-io/async"]

--- a/crates/polars-pipe/Cargo.toml
+++ b/crates/polars-pipe/Cargo.toml
@@ -16,7 +16,7 @@ polars-ops = { workspace = true, features = ["search_sorted"] }
 polars-plan = { workspace = true }
 polars-row = { workspace = true }
 polars-utils = { workspace = true, features = ["sysinfo"] }
-tokio = { workspace = true, optional = true, default-features = false }
+tokio = { workspace = true, optional = true }
 
 crossbeam-channel = { workspace = true }
 crossbeam-queue = { version = "0.3" }

--- a/crates/polars-pipe/src/executors/sinks/file_sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/file_sink.rs
@@ -103,13 +103,14 @@ pub struct ParquetCloudSink {}
 #[cfg(all(feature = "parquet", feature = "cloud"))]
 impl ParquetCloudSink {
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(
+    #[tokio::main(flavor = "current_thread")]
+    pub async fn new(
         uri: &str,
         cloud_options: Option<&polars_io::cloud::CloudOptions>,
         parquet_options: ParquetWriteOptions,
         schema: &Schema,
     ) -> PolarsResult<FilesSink> {
-        let cloud_writer = polars_io::cloud::CloudWriter::new(uri, cloud_options)?;
+        let cloud_writer = polars_io::cloud::CloudWriter::new(uri, cloud_options).await?;
         let writer = ParquetWriter::new(cloud_writer)
             .with_compression(parquet_options.compression)
             .with_data_pagesize_limit(parquet_options.data_pagesize_limit)

--- a/crates/polars-pipe/src/executors/sources/parquet.rs
+++ b/crates/polars-pipe/src/executors/sources/parquet.rs
@@ -5,6 +5,7 @@ use polars_core::schema::*;
 use polars_core::POOL;
 use polars_io::cloud::CloudOptions;
 use polars_io::parquet::{BatchedParquetReader, ParquetReader};
+use polars_io::pl_async::get_runtime;
 #[cfg(feature = "async")]
 use polars_io::prelude::ParquetAsyncReader;
 use polars_io::{is_cloud_url, SerReader};
@@ -26,6 +27,7 @@ pub struct ParquetSource {
     cloud_options: Option<CloudOptions>,
     file_info: FileInfo,
     verbose: bool,
+    rt: tokio::runtime::Runtime,
 }
 
 impl ParquetSource {
@@ -61,24 +63,22 @@ impl ParquetSource {
             #[cfg(feature = "async")]
             {
                 let uri = path.to_string_lossy();
-                tokio::runtime::Builder::new_current_thread()
-                    .build()
-                    .unwrap()
-                    .block_on(async {
-                        ParquetAsyncReader::from_uri(&uri, self.cloud_options.as_ref())
-                            .await?
-                            .with_n_rows(file_options.n_rows)
-                            .with_row_count(file_options.row_count)
-                            .with_projection(projection)
-                            .use_statistics(options.use_statistics)
-                            .with_hive_partition_columns(
-                                self.file_info
-                                    .hive_parts
-                                    .as_ref()
-                                    .map(|hive| hive.materialize_partition_columns()),
-                            )
-                            .batched(chunk_size)
-                    })?
+                polars_io::pl_async::get_runtime().block_on(async {
+                    ParquetAsyncReader::from_uri(&uri, self.cloud_options.as_ref())
+                        .await?
+                        .with_n_rows(file_options.n_rows)
+                        .with_row_count(file_options.row_count)
+                        .with_projection(projection)
+                        .use_statistics(options.use_statistics)
+                        .with_hive_partition_columns(
+                            self.file_info
+                                .hive_parts
+                                .as_ref()
+                                .map(|hive| hive.materialize_partition_columns()),
+                        )
+                        .batched(chunk_size)
+                        .await
+                })?
             }
         } else {
             let file = std::fs::File::open(path).unwrap();
@@ -121,6 +121,7 @@ impl ParquetSource {
             cloud_options,
             file_info,
             verbose,
+            rt: get_runtime(),
         })
     }
 }
@@ -130,11 +131,12 @@ impl Source for ParquetSource {
         if self.batched_reader.is_none() {
             self.init_reader()?;
         }
-        let batches = self
-            .batched_reader
-            .as_mut()
-            .unwrap()
-            .next_batches(self.n_threads)?;
+        let batches = self.rt.block_on(
+            self.batched_reader
+                .as_mut()
+                .unwrap()
+                .next_batches(self.n_threads),
+        )?;
         Ok(match batches {
             None => SourceResult::Finished,
             Some(batches) => SourceResult::GotMoreData(

--- a/crates/polars-utils/src/cache.rs
+++ b/crates/polars-utils/src/cache.rs
@@ -53,6 +53,12 @@ pub struct FastFixedCache<K, V> {
     hash_builder: RandomState,
 }
 
+impl<K: Hash + Eq, V> Default for FastFixedCache<K, V> {
+    fn default() -> Self {
+        Self::new(MIN_FAST_FIXED_CACHE_SIZE)
+    }
+}
+
 impl<K: Hash + Eq, V> FastFixedCache<K, V> {
     pub fn new(n: usize) -> Self {
         let n = (n.max(MIN_FAST_FIXED_CACHE_SIZE)).next_power_of_two();

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -785,6 +785,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1403,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "numpy"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,11 +1727,13 @@ dependencies = [
  "polars-utils",
  "rayon",
  "regex",
+ "reqwest",
  "ryu",
  "serde",
  "serde_json",
  "simd-json",
  "simdutf8",
+ "smartstring",
  "tokio",
  "tokio-util",
  "url",
@@ -1761,6 +1779,7 @@ dependencies = [
  "pyo3",
  "rayon",
  "smartstring",
+ "tokio",
  "version_check",
 ]
 
@@ -1815,6 +1834,7 @@ dependencies = [
  "polars-utils",
  "rayon",
  "smartstring",
+ "tokio",
  "version_check",
 ]
 
@@ -2657,6 +2677,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "num_cpus",
  "pin-project-lite",
  "socket2 0.5.4",
  "tokio-macros",

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -785,12 +785,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,16 +1394,6 @@ checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
 ]
 
 [[package]]
@@ -2677,7 +2661,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "socket2 0.5.4",
  "tokio-macros",


### PR DESCRIPTION
This got complicated quickly. This sets the basis for better async support in polars. Had to do some refactors as async traits lead to very complicated HRT errors.

fixes #11389

Also add auto-inference of aws regions as drive by.