### PR TITLE
fix(python): partially address some PyCharm tooltip/signature issues with decorated methods

### DIFF
--- a/py-polars/polars/utils/deprecation.py
+++ b/py-polars/polars/utils/deprecation.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     import sys
     from typing import Mapping
 
+    from polars import Expr
     from polars.type_aliases import Ambiguous
 
     if sys.version_info >= (3, 10):
@@ -20,8 +21,7 @@ if TYPE_CHECKING:
 
     P = ParamSpec("P")
     T = TypeVar("T")
-if TYPE_CHECKING:
-    from polars import Expr
+
 
 USE_EARLIEST_TO_AMBIGUOUS: Mapping[bool, Ambiguous] = {
     True: "earliest",
@@ -60,6 +60,7 @@ def deprecate_function(
             )
             return function(*args, **kwargs)
 
+        wrapper.__signature__ = inspect.signature(function)  # type: ignore[attr-defined]
         return wrapper
 
     return decorate
@@ -94,6 +95,7 @@ def deprecate_renamed_parameter(
             )
             return function(*args, **kwargs)
 
+        wrapper.__signature__ = inspect.signature(function)  # type: ignore[attr-defined]
         return wrapper
 
     return decorate
@@ -232,6 +234,7 @@ def warn_closed_future_change() -> Callable[[Callable[P, T]], Callable[P, T]]:
                 )
             return function(*args, **kwargs)
 
+        wrapper.__signature__ = inspect.signature(function)  # type: ignore[attr-defined]
         return wrapper
 
     return decorate


### PR DESCRIPTION
This _doesn't_ fix editor autocomplete not showing the method signature, but _does_ fix it in the interactive console.

#### Before:

<img width="546" alt="Screenshot 2023-09-30 at 12 52 33" src="https://github.com/pola-rs/polars/assets/2613171/b2dd38d0-88c4-4548-b81d-7720942e827e">

#### After:

<img width="546" alt="Screenshot 2023-09-30 at 12 53 22" src="https://github.com/pola-rs/polars/assets/2613171/b287c9f2-1f3a-4af2-aa78-7c2a094f37ca">

