### PR TITLE
feat(python): rework `ColumnFactory` to additionally support tab-complete for `col` in IPython

### DIFF
--- a/py-polars/polars/functions/col.py
+++ b/py-polars/polars/functions/col.py
@@ -1,19 +1,67 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Iterable, Protocol, cast
+from typing import TYPE_CHECKING, Any, Iterable, Protocol, cast
 
 from polars.datatypes import is_polars_dtype
 from polars.utils._wrap import wrap_expr
 
+plr: Any = None
 with contextlib.suppress(ImportError):  # Module not available when building docs
-    import polars.polars as plr
+    import polars.polars as plr  # type: ignore[no-redef]
 
 if TYPE_CHECKING:
     from polars.expr.expr import Expr
     from polars.type_aliases import PolarsDataType
 
 __all__ = ["col"]
+
+
+def _create_col(
+    name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
+    *more_names: str | PolarsDataType,
+) -> Expr:
+    """Create one or more column expressions representing column(s) in a DataFrame."""
+    if more_names:
+        if isinstance(name, str):
+            names_str = [name]
+            names_str.extend(more_names)  # type: ignore[arg-type]
+            return wrap_expr(plr.cols(names_str))
+        elif is_polars_dtype(name):
+            dtypes = [name]
+            dtypes.extend(more_names)
+            return wrap_expr(plr.dtype_cols(dtypes))
+        else:
+            raise TypeError(
+                "invalid input for `col`"
+                f"\n\nExpected `str` or `DataType`, got {type(name).__name__!r}."
+            )
+
+    if isinstance(name, str):
+        return wrap_expr(plr.col(name))
+    elif is_polars_dtype(name):
+        return wrap_expr(plr.dtype_cols([name]))
+    elif isinstance(name, Iterable):
+        names = list(name)
+        if not names:
+            return wrap_expr(plr.cols(names))
+
+        item = names[0]
+        if isinstance(item, str):
+            return wrap_expr(plr.cols(names))
+        elif is_polars_dtype(item):
+            return wrap_expr(plr.dtype_cols(names))
+        else:
+            raise TypeError(
+                "invalid input for `col`"
+                "\n\nExpected iterable of type `str` or `DataType`,"
+                f" got iterable of type {type(item).__name__!r}"
+            )
+    else:
+        raise TypeError(
+            "invalid input for `col`"
+            f"\n\nExpected `str` or `DataType`, got {type(name).__name__!r}"
+        )
 
 
 # appease lint by casting `col` with a protocol that conforms to the factory interface
@@ -32,7 +80,7 @@ class Column(Protocol):
 # handle attribute lookup on the metaclass (we use the factory uninstantiated)
 class ColumnFactoryMeta(type):
     def __getattr__(self, name: str) -> Expr:
-        return wrap_expr(plr.col(name))
+        return _create_col(name)
 
 
 # factory that creates columns using `col("name")` or `col.name` syntax
@@ -100,7 +148,7 @@ class ColumnFactory(metaclass=ColumnFactoryMeta):
         *more_names: str | PolarsDataType,
     ) -> Expr:
         """
-        Create a column expression representing column(s) in a dataframe.
+        Create one or more column expressions representing column(s) in a DataFrame.
 
         Parameters
         ----------
@@ -235,55 +283,23 @@ class ColumnFactory(metaclass=ColumnFactoryMeta):
         │ 2   ┆ 22        ┆ 1   │
         └─────┴───────────┴─────┘
 
-
         """
-        if more_names:
-            if isinstance(name, str):
-                names_str = [name]
-                names_str.extend(more_names)  # type: ignore[arg-type]
-                return wrap_expr(plr.cols(names_str))
-            elif is_polars_dtype(name):
-                dtypes = [name]
-                dtypes.extend(more_names)
-                return wrap_expr(plr.dtype_cols(dtypes))
-            else:
-                raise TypeError(
-                    "invalid input for `col`"
-                    f"\n\nExpected `str` or `DataType`, got {type(name).__name__!r}."
-                )
+        return _create_col(name, *more_names)
 
-        if isinstance(name, str):
-            return wrap_expr(plr.col(name))
-        elif is_polars_dtype(name):
-            return wrap_expr(plr.dtype_cols([name]))
-        elif isinstance(name, Iterable):
-            names = list(name)
-            if not names:
-                return wrap_expr(plr.cols(names))
-
-            item = names[0]
-            if isinstance(item, str):
-                return wrap_expr(plr.cols(names))
-            elif is_polars_dtype(item):
-                return wrap_expr(plr.dtype_cols(names))
-            else:
-                raise TypeError(
-                    "invalid input for `col`"
-                    "\n\nExpected iterable of type `str` or `DataType`,"
-                    f" got iterable of type {type(item).__name__!r}"
-                )
-        else:
-            raise TypeError(
-                "invalid input for `col`"
-                f"\n\nExpected `str` or `DataType`, got {type(name).__name__!r}"
-            )
+    # appease sphinx; we actually use '__new__'
+    def __call__(
+        self,
+        name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
+        *more_names: str | PolarsDataType,
+    ) -> Expr:
+        return _create_col(name, *more_names)
 
     def __getattr__(self, name: str) -> Expr:
         """
         Create a column expression using attribute syntax.
 
-        Note that this syntax does not support passing data types or multiple column
-        names.
+        Note that this syntax does not support passing data
+        types or multiple column names.
 
         Parameters
         ----------

--- a/py-polars/polars/functions/col.py
+++ b/py-polars/polars/functions/col.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Iterable, Protocol, cast
 
 from polars.datatypes import is_polars_dtype
 from polars.utils._wrap import wrap_expr
@@ -10,16 +10,38 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     import polars.polars as plr
 
 if TYPE_CHECKING:
-    from polars import Expr
+    from polars.expr.expr import Expr
     from polars.type_aliases import PolarsDataType
 
 __all__ = ["col"]
 
 
-class ColumnFactory:
-    """
-    Helper class for creating column expressions.
+# appease lint by casting `col` with a protocol that conforms to the factory interface
+class Column(Protocol):
+    def __call__(
+        self,
+        name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
+        *more_names: str | PolarsDataType,
+    ) -> Expr:
+        ...
 
+    def __getattr__(self, name: str) -> Expr:
+        ...
+
+
+# handle attribute lookup on the metaclass (we use the factory uninstantiated)
+class ColumnFactoryMeta(type):
+    def __getattr__(self, name: str) -> Expr:
+        return wrap_expr(plr.col(name))
+
+
+# factory that creates columns using `col("name")` or `col.name` syntax
+class ColumnFactory(metaclass=ColumnFactoryMeta):
+    """
+    Create Polars column expressions.
+
+    Notes
+    -----
     An instance of this class is exported under the name ``col``. It can be used as
     though it were a function by calling, for example, ``pl.col("foo")``.
     See the :func:`__call__` method for further documentation.
@@ -29,17 +51,51 @@ class ColumnFactory:
     ``col("foo")``.
     See the :func:`__getattr__` method for further documentation.
 
-    Notes
-    -----
     The function call syntax is considered the idiomatic way of constructing a column
     expression. The alternative attribute syntax can be useful for quick prototyping as
     it can save some keystrokes, but has drawbacks in both expressiveness and
     readability.
 
+    Examples
+    --------
+    >>> from polars import col
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "foo": [1, 2],
+    ...         "bar": [3, 4],
+    ...     }
+    ... )
+
+    Create a new column expression using the standard syntax:
+
+    >>> df.with_columns(baz=(col("foo") * col("bar")) / 2)
+    shape: (2, 3)
+    ┌─────┬─────┬─────┐
+    │ foo ┆ bar ┆ baz │
+    │ --- ┆ --- ┆ --- │
+    │ i64 ┆ i64 ┆ f64 │
+    ╞═════╪═════╪═════╡
+    │ 1   ┆ 3   ┆ 1.5 │
+    │ 2   ┆ 4   ┆ 4.0 │
+    └─────┴─────┴─────┘
+
+    Use attribute lookup to create a new column expression:
+
+    >>> df.with_columns(baz=(col.foo + col.bar))
+    shape: (2, 3)
+    ┌─────┬─────┬─────┐
+    │ foo ┆ bar ┆ baz │
+    │ --- ┆ --- ┆ --- │
+    │ i64 ┆ i64 ┆ i64 │
+    ╞═════╪═════╪═════╡
+    │ 1   ┆ 3   ┆ 4   │
+    │ 2   ┆ 4   ┆ 6   │
+    └─────┴─────┴─────┘
+
     """
 
-    def __call__(
-        self,
+    def __new__(  # type: ignore[misc]
+        cls,
         name: str | PolarsDataType | Iterable[str] | Iterable[PolarsDataType],
         *more_names: str | PolarsDataType,
     ) -> Expr:
@@ -255,8 +311,7 @@ class ColumnFactory:
         └─────┘
 
         """
-        return wrap_expr(plr.col(name))
+        return getattr(type(self), name)
 
 
-# Set up a single instance of the class and use it as a column factory
-col = ColumnFactory()
+col = cast(Column, ColumnFactory)


### PR DESCRIPTION
Closes #11433.

Reworks the `ColumnFactory` to improve tab-complete in IPython (without regression in other IDEs).

![ipython_col_complete](https://github.com/pola-rs/polars/assets/2613171/50aa76c4-3271-4fc3-9742-5711373bbb7e)
