### PR TITLE
fix(rust,python): describe() panicked at not implemented dtype Object

### DIFF
--- a/crates/polars-core/src/series/ops/null.rs
+++ b/crates/polars-core/src/series/ops/null.rs
@@ -51,6 +51,12 @@ impl Series {
                     .collect::<Vec<_>>();
                 StructChunked::new(name, &fields).unwrap().into_series()
             },
+            #[cfg(feature = "object")]
+            DataType::Object(_) => {
+                let series = vec![Series::full_null(name, size, &DataType::Utf8)];
+                let struct_chunked = StructChunked::new(name, &series).unwrap();
+                struct_chunked.into_series()
+            },
             DataType::Null => Series::new_null(name, size),
             _ => {
                 macro_rules! primitive {

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1541,13 +1541,13 @@ class Series:
                 "50%": str(self.dt.median()),
                 "max": str(self.dt.max()),
             }
-        elif self.is_object():
+        # don't create methods for these, others will be phased out
+        elif self.dtype is Object:
             stats = {
                 "count": self.len(),
                 "null_count": self.null_count(),
-                # self.unique() is not yet implemented for Object
-            }
-        elif self.is_struct():
+        }
+        elif isinstance(self.dtype, Struct):
             stats = {
                 "count": self.len(),
                 "null_count": self.null_count(),
@@ -3926,32 +3926,6 @@ class Series:
 
         """
         return self.dtype is Utf8
-
-    def is_object(self) -> bool:
-        """
-        Check if this Series datatype is an Object.
-
-        Examples
-        --------
-        >>> s = pl.Series([{"a": 1, "b": 2}], dtype=pl.Object)
-        >>> s.is_object()
-        True
-
-        """
-        return self.dtype is Object
-
-    def is_struct(self) -> bool:
-        """
-        Check if this Series datatype is a Struct.
-
-        Examples
-        --------
-        >>> s = pl.Series([{"a": 1, "b": 2}])
-        >>> s.is_struct()
-        True
-        
-        """
-        return isinstance(self.dtype, Struct)
 
     def view(self, *, ignore_nulls: bool = False) -> SeriesView:
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -43,6 +43,7 @@ from polars.datatypes import (
     Int64,
     List,
     Object,
+    Struct,
     Time,
     UInt32,
     UInt64,
@@ -1539,6 +1540,18 @@ class Series:
                 "min": str(self.dt.min()),
                 "50%": str(self.dt.median()),
                 "max": str(self.dt.max()),
+            }
+        elif self.is_object():
+            stats = {
+                "count": self.len(),
+                "null_count": self.null_count(),
+                # self.unique() is not yet implemented for Object
+            }
+        elif self.is_struct():
+            stats = {
+                "count": self.len(),
+                "null_count": self.null_count(),
+                "unique": len(self.unique()),
             }
         else:
             raise TypeError("this type is not supported")
@@ -3913,6 +3926,32 @@ class Series:
 
         """
         return self.dtype is Utf8
+
+    def is_object(self) -> bool:
+        """
+        Check if this Series datatype is an Object.
+
+        Examples
+        --------
+        >>> s = pl.Series([{"a": 1, "b": 2}], dtype=pl.Object)
+        >>> s.is_object()
+        True
+
+        """
+        return self.dtype is Object
+
+    def is_struct(self) -> bool:
+        """
+        Check if this Series datatype is a Struct.
+
+        Examples
+        --------
+        >>> s = pl.Series([{"a": 1, "b": 2}])
+        >>> s.is_struct()
+        True
+        
+        """
+        return isinstance(self.dtype, Struct)
 
     def view(self, *, ignore_nulls: bool = False) -> SeriesView:
         """

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1258,6 +1258,35 @@ def test_describe() -> None:
         ("max", 2.0, None, None),
     ]
 
+    # object
+    df = pl.DataFrame(
+        {
+            "numerical": [1, 2, 1],
+            "object": pl.Series(
+                [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], dtype=pl.Object
+            ),
+        }
+    )
+    described = df.describe(percentiles=(0.2, 0.4))
+
+    assert described.schema == {
+        "describe": pl.Utf8,
+        "numerical": pl.Float64,
+        "object": pl.Utf8,
+    }
+
+    assert described.rows() == [
+        ("count", 3.0, "3"),
+        ("null_count", 0.0, "0"),
+        ("mean", 1.3333333333333333, None),
+        ("std", 0.5773502691896257, None),
+        ("min", 1.0, None),
+        ("20%", 1.0, None),
+        ("40%", 1.0, None),
+        ("50%", 1.0, None),
+        ("max", 2.0, None),
+    ]
+
 
 def test_duration_arithmetic() -> None:
     df = pl.DataFrame(

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1105,6 +1105,9 @@ def test_describe() -> None:
     str_s = pl.Series(["abc", "pqr", "xyz"])
     bool_s = pl.Series([True, False, None, True, True])
     date_s = pl.Series([date(2021, 1, 1), date(2021, 1, 2), date(2021, 1, 3)])
+    object_s = pl.Series(
+        [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], dtype=pl.Object
+    )
     empty_s = pl.Series(np.empty(0))
 
     assert dict(num_s.describe().rows()) == {  # type: ignore[arg-type]
@@ -1145,6 +1148,10 @@ def test_describe() -> None:
         "50%": "2021-01-02",
         "max": "2021-01-03",
         "null_count": "0",
+    }
+    assert dict(object_s.describe().rows()) == {  # type: ignore[arg-type]
+        "count": 3,
+        "null_count": 0,
     }
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
fix #9830

The `is_struct` part might be a bit of a drive-by. You think having that functionality is relevant to have? If so can add tests for it.