### PR TITLE
ci(python): Add wheels to GitHub release

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -120,3 +120,20 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
+
+  update-github-release:
+    needs: build-wheels
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: dist
+          path: dist
+
+      - name: Upload binaries to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: dist/polars-*
+          file_glob: true
+          overwrite: true


### PR DESCRIPTION
This will add wheels and sdist as assets to the GitHub release (see image below from my fork).

I am not adding the `polars-lts-cpu` and `polars-u64-idx` wheels for now as I think they are less important.

![image](https://github.com/pola-rs/polars/assets/3502351/e9239c70-fd46-4e80-8f6d-5a63164bbd85)
