### PR TITLE
docs: Restrict the github workflow to deploy to the polars repo

### DIFF
--- a/.github/workflows/clear-caches.yml
+++ b/.github/workflows/clear-caches.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Clear all caches
+        if: ${{ github.repository == 'pola-rs/polars' }}
         run: gh cache delete --all
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/docs-global.yml
+++ b/.github/workflows/docs-global.yml
@@ -77,7 +77,7 @@ jobs:
         run: touch .nojekyll
 
       - name: Deploy docs
-        if: ${{ github.ref_type == 'tag' and github.repository == 'pola-rs/polars' }}
+        if: ${{ github.ref_type == 'tag' && github.repository == 'pola-rs/polars' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: site

--- a/.github/workflows/docs-global.yml
+++ b/.github/workflows/docs-global.yml
@@ -77,7 +77,7 @@ jobs:
         run: touch .nojekyll
 
       - name: Deploy docs
-        if: ${{ github.ref_type == 'tag' }}
+        if: ${{ github.ref_type == 'tag' and github.repository == 'pola-rs/polars' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: site

--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -44,7 +44,7 @@ jobs:
         run: make html
 
       - name: Deploy Python docs for latest development version
-        if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' and github.repository == 'pola-rs/polars' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html
@@ -63,7 +63,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Python docs for latest release version - versioned
-        if: ${{ github.ref_type == 'tag' }}
+        if: ${{ github.ref_type == 'tag' and github.repository == 'pola-rs/polars' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html
@@ -71,7 +71,7 @@ jobs:
           single-commit: true
 
       - name: Deploy Python docs for latest release version - stable
-        if: ${{ github.ref_type == 'tag' }}
+        if: ${{ github.ref_type == 'tag' and github.repository == 'pola-rs/polars' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html

--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -44,7 +44,7 @@ jobs:
         run: make html
 
       - name: Deploy Python docs for latest development version
-        if: ${{ github.ref_name == 'main' and github.repository == 'pola-rs/polars' }}
+        if: ${{ github.ref_name == 'main' && github.repository == 'pola-rs/polars' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html
@@ -63,7 +63,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Python docs for latest release version - versioned
-        if: ${{ github.ref_type == 'tag' and github.repository == 'pola-rs/polars' }}
+        if: ${{ github.ref_type == 'tag' && github.repository == 'pola-rs/polars' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html
@@ -71,7 +71,7 @@ jobs:
           single-commit: true
 
       - name: Deploy Python docs for latest release version - stable
-        if: ${{ github.ref_type == 'tag' and github.repository == 'pola-rs/polars' }}
+        if: ${{ github.ref_type == 'tag' && github.repository == 'pola-rs/polars' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html

--- a/.github/workflows/docs-rust.yml
+++ b/.github/workflows/docs-rust.yml
@@ -42,7 +42,7 @@ jobs:
           touch target/doc/.nojekyll
 
       - name: Deploy Rust docs
-        if: ${{ github.ref_name == 'main' and github.repository == 'pola-rs/polars' }}
+        if: ${{ github.ref_name == 'main' && github.repository == 'pola-rs/polars' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: target/doc

--- a/.github/workflows/docs-rust.yml
+++ b/.github/workflows/docs-rust.yml
@@ -42,7 +42,7 @@ jobs:
           touch target/doc/.nojekyll
 
       - name: Deploy Rust docs
-        if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' and github.repository == 'pola-rs/polars' }}
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: target/doc


### PR DESCRIPTION
The "problem" I was facing that in my forked repository, when I sync my repo (main branch), I got every time 2 errors.

This should be fixed with the proposed changes as it'll restrict the deployment of the docs to polars only.
