### PR TITLE
feat(rust,python): Add useful cumulative operations for list series

### DIFF
--- a/crates/polars-ops/src/chunked_array/list/cum.rs
+++ b/crates/polars-ops/src/chunked_array/list/cum.rs
@@ -9,7 +9,7 @@ pub fn list_cum_concat(a: &ListChunked) -> PolarsResult<ListChunked> {
     for value in a {
         match (&mut acc, &value) {
             (Some(acc_inner), Some(v)) => {
-                acc_inner.append(&v)?;
+                acc_inner.append(v)?;
                 values.push(Some(acc_inner.clone()));
             },
             (None, Some(v)) => {
@@ -34,7 +34,7 @@ pub fn list_cum_set_union(a: &ListChunked) -> PolarsResult<ListChunked> {
         match (&mut acc, &value) {
             (Some(acc_inner), Some(v)) => {
                 let mut new_acc = acc_inner.clone();
-                new_acc.append(&v)?;
+                new_acc.append(v)?;
                 new_acc = new_acc.0.unique()?;
                 acc = Some(new_acc.clone());
                 values.push(Some(new_acc));

--- a/crates/polars-ops/src/chunked_array/list/cum.rs
+++ b/crates/polars-ops/src/chunked_array/list/cum.rs
@@ -6,20 +6,17 @@ pub fn list_cum_concat(a: &ListChunked) -> PolarsResult<ListChunked> {
 
     let mut values: Vec<Option<Series>> = Vec::new();
     let mut acc: Option<Series> = None;
-    for value in a.into_iter() {
+    for value in a {
         match (&mut acc, &value) {
             (Some(acc_inner), Some(v)) => {
-                println!("with_state {}", v);
-                acc_inner.append(&v);
+                acc_inner.append(&v)?;
                 values.push(Some(acc_inner.clone()));
             },
             (None, Some(v)) => {
-                println!("no_state {}", v);
                 acc = Some(v.clone());
                 values.push(Some(v.clone()));
             },
             (_, None) => {
-                println!("nothing at all");
                 values.push(None);
             },
         }
@@ -28,4 +25,34 @@ pub fn list_cum_concat(a: &ListChunked) -> PolarsResult<ListChunked> {
     let mut ca: ListChunked = values.into_iter().collect();
     ca.rename(a.name());
     Ok(ca)
+
+}
+
+pub fn list_cum_set_union(a: &ListChunked) -> PolarsResult<ListChunked> {
+
+    let mut values: Vec<Option<Series>> = Vec::new();
+    let mut acc: Option<Series> = None;
+    for value in a {
+        match (&mut acc, &value) {
+            (Some(acc_inner), Some(v)) => {
+                let mut new_acc = acc_inner.clone();
+                new_acc.append(&v)?;
+                new_acc = new_acc.0.unique()?;
+                acc = Some(new_acc.clone());
+                values.push(Some(new_acc));
+            },
+            (None, Some(v)) => {
+                acc = Some(v.0.unique()?);
+                values.push(acc.clone());
+            },
+            (_, None) => {
+                values.push(None);
+            },
+        }
+    }
+
+    let mut ca: ListChunked = values.into_iter().collect();
+    ca.rename(a.name());
+    Ok(ca)
+
 }

--- a/crates/polars-ops/src/chunked_array/list/cum.rs
+++ b/crates/polars-ops/src/chunked_array/list/cum.rs
@@ -1,0 +1,31 @@
+use std::option::Option;
+use std::vec::Vec;
+use polars_core::prelude::*;
+
+pub fn list_cum_concat(a: &ListChunked) -> PolarsResult<ListChunked> {
+
+    let mut values: Vec<Option<Series>> = Vec::new();
+    let mut acc: Option<Series> = None;
+    for value in a.into_iter() {
+        match (&mut acc, &value) {
+            (Some(acc_inner), Some(v)) => {
+                println!("with_state {}", v);
+                acc_inner.append(&v);
+                values.push(Some(acc_inner.clone()));
+            },
+            (None, Some(v)) => {
+                println!("no_state {}", v);
+                acc = Some(v.clone());
+                values.push(Some(v.clone()));
+            },
+            (_, None) => {
+                println!("nothing at all");
+                values.push(None);
+            },
+        }
+    }
+
+    let mut ca: ListChunked = values.into_iter().collect();
+    ca.rename(a.name());
+    Ok(ca)
+}

--- a/crates/polars-ops/src/chunked_array/list/cum.rs
+++ b/crates/polars-ops/src/chunked_array/list/cum.rs
@@ -1,9 +1,9 @@
 use std::option::Option;
 use std::vec::Vec;
+
 use polars_core::prelude::*;
 
 pub fn list_cum_concat(a: &ListChunked) -> PolarsResult<ListChunked> {
-
     let mut values: Vec<Option<Series>> = Vec::new();
     let mut acc: Option<Series> = None;
     for value in a {
@@ -25,11 +25,9 @@ pub fn list_cum_concat(a: &ListChunked) -> PolarsResult<ListChunked> {
     let mut ca: ListChunked = values.into_iter().collect();
     ca.rename(a.name());
     Ok(ca)
-
 }
 
 pub fn list_cum_set_union(a: &ListChunked) -> PolarsResult<ListChunked> {
-
     let mut values: Vec<Option<Series>> = Vec::new();
     let mut acc: Option<Series> = None;
     for value in a {
@@ -54,5 +52,4 @@ pub fn list_cum_set_union(a: &ListChunked) -> PolarsResult<ListChunked> {
     let mut ca: ListChunked = values.into_iter().collect();
     ca.rename(a.name());
     Ok(ca)
-
 }

--- a/crates/polars-ops/src/chunked_array/list/mod.rs
+++ b/crates/polars-ops/src/chunked_array/list/mod.rs
@@ -3,6 +3,7 @@ use polars_core::prelude::*;
 #[cfg(feature = "list_any_all")]
 mod any_all;
 mod count;
+mod cum;
 #[cfg(feature = "hash")]
 pub(crate) mod hash;
 mod min_max;
@@ -13,6 +14,7 @@ mod sum_mean;
 #[cfg(feature = "list_to_struct")]
 mod to_struct;
 
+pub use cum::*;
 #[cfg(feature = "list_count")]
 pub use count::*;
 #[cfg(not(feature = "list_count"))]

--- a/crates/polars-ops/src/chunked_array/list/mod.rs
+++ b/crates/polars-ops/src/chunked_array/list/mod.rs
@@ -14,11 +14,11 @@ mod sum_mean;
 #[cfg(feature = "list_to_struct")]
 mod to_struct;
 
-pub use cum::*;
 #[cfg(feature = "list_count")]
 pub use count::*;
 #[cfg(not(feature = "list_count"))]
 use count::*;
+pub use cum::*;
 pub use namespace::*;
 #[cfg(feature = "list_sets")]
 pub use sets::*;

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -555,7 +555,6 @@ pub trait ListNameSpaceImpl: AsList {
     fn lst_cum_set_union(&self) -> PolarsResult<ListChunked> {
         list_cum_set_union(&self.as_list())
     }
-
 }
 
 impl ListNameSpaceImpl for ListChunked {}

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -549,11 +549,11 @@ pub trait ListNameSpaceImpl: AsList {
     }
 
     fn lst_cum_concat(&self) -> PolarsResult<ListChunked> {
-        list_cum_concat(&self.as_list())
+        list_cum_concat(self.as_list())
     }
 
     fn lst_cum_set_union(&self) -> PolarsResult<ListChunked> {
-        list_cum_set_union(&self.as_list())
+        list_cum_set_union(self.as_list())
     }
 }
 

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -547,6 +547,11 @@ pub trait ListNameSpaceImpl: AsList {
         };
         Ok(out)
     }
+
+    fn lst_cum_concat(&self) -> PolarsResult<ListChunked> {
+        list_cum_concat(&self.as_list())
+    }
+
 }
 
 impl ListNameSpaceImpl for ListChunked {}

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -552,6 +552,10 @@ pub trait ListNameSpaceImpl: AsList {
         list_cum_concat(&self.as_list())
     }
 
+    fn lst_cum_set_union(&self) -> PolarsResult<ListChunked> {
+        list_cum_set_union(&self.as_list())
+    }
+
 }
 
 impl ListNameSpaceImpl for ListChunked {}

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -7,6 +7,7 @@ use super::*;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ListFunction {
     Concat,
+    CumConcat,
     #[cfg(feature = "is_in")]
     Contains,
     #[cfg(feature = "list_drop_nulls")]
@@ -41,6 +42,7 @@ impl Display for ListFunction {
 
         let name = match self {
             Concat => "concat",
+            CumConcat => "cum_concat",
             #[cfg(feature = "is_in")]
             Contains => "contains",
             #[cfg(feature = "list_drop_nulls")]
@@ -223,6 +225,10 @@ pub(super) fn concat(s: &mut [Series]) -> PolarsResult<Option<Series>> {
     }
 
     first_ca.lst_concat(other).map(|ca| Some(ca.into_series()))
+}
+
+pub(super) fn cum_concat(s: &Series) -> PolarsResult<Series> {
+    Ok(s.list()?.lst_cum_concat()?.into_series())
 }
 
 pub(super) fn get(s: &mut [Series]) -> PolarsResult<Option<Series>> {

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -8,6 +8,7 @@ use super::*;
 pub enum ListFunction {
     Concat,
     CumConcat,
+    CumSetUnion,
     #[cfg(feature = "is_in")]
     Contains,
     #[cfg(feature = "list_drop_nulls")]
@@ -43,6 +44,7 @@ impl Display for ListFunction {
         let name = match self {
             Concat => "concat",
             CumConcat => "cum_concat",
+            CumSetUnion => "cum_set_union",
             #[cfg(feature = "is_in")]
             Contains => "contains",
             #[cfg(feature = "list_drop_nulls")]
@@ -229,6 +231,10 @@ pub(super) fn concat(s: &mut [Series]) -> PolarsResult<Option<Series>> {
 
 pub(super) fn cum_concat(s: &Series) -> PolarsResult<Series> {
     Ok(s.list()?.lst_cum_concat()?.into_series())
+}
+
+pub(super) fn cum_set_union(s: &Series) -> PolarsResult<Series> {
+    Ok(s.list()?.lst_cum_set_union()?.into_series())
 }
 
 pub(super) fn get(s: &mut [Series]) -> PolarsResult<Option<Series>> {

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -554,6 +554,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                 match lf {
                     Concat => wrap!(list::concat),
                     CumConcat => map!(list::cum_concat),
+                    CumSetUnion => map!(list::cum_set_union),
                     #[cfg(feature = "is_in")]
                     Contains => wrap!(list::contains),
                     #[cfg(feature = "list_drop_nulls")]

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -553,6 +553,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
                 use ListFunction::*;
                 match lf {
                     Concat => wrap!(list::concat),
+                    CumConcat => map!(list::cum_concat),
                     #[cfg(feature = "is_in")]
                     Contains => wrap!(list::contains),
                     #[cfg(feature = "list_drop_nulls")]

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -98,6 +98,7 @@ impl FunctionExpr {
                 use ListFunction::*;
                 match l {
                     Concat => mapper.map_to_list_supertype(),
+                    CumConcat => mapper.with_same_dtype(),
                     #[cfg(feature = "is_in")]
                     Contains => mapper.with_dtype(DataType::Boolean),
                     #[cfg(feature = "list_drop_nulls")]

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -99,6 +99,7 @@ impl FunctionExpr {
                 match l {
                     Concat => mapper.map_to_list_supertype(),
                     CumConcat => mapper.with_same_dtype(),
+                    CumSetUnion => mapper.with_same_dtype(),
                     #[cfg(feature = "is_in")]
                     Contains => mapper.with_dtype(DataType::Boolean),
                     #[cfg(feature = "list_drop_nulls")]

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -329,4 +329,8 @@ impl ListNameSpace {
         let other = other.into();
         self.set_operation(other, SetOperation::SymmetricDifference)
     }
+
+    pub fn cum_concat(self) -> Expr {
+        self.0.map_private(FunctionExpr::ListExpr(ListFunction::CumConcat))
+    }
 }

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -331,10 +331,12 @@ impl ListNameSpace {
     }
 
     pub fn cum_concat(self) -> Expr {
-        self.0.map_private(FunctionExpr::ListExpr(ListFunction::CumConcat))
+        self.0
+            .map_private(FunctionExpr::ListExpr(ListFunction::CumConcat))
     }
 
     pub fn cum_set_union(self) -> Expr {
-        self.0.map_private(FunctionExpr::ListExpr(ListFunction::CumSetUnion))
+        self.0
+            .map_private(FunctionExpr::ListExpr(ListFunction::CumSetUnion))
     }
 }

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -333,4 +333,8 @@ impl ListNameSpace {
     pub fn cum_concat(self) -> Expr {
         self.0.map_private(FunctionExpr::ListExpr(ListFunction::CumConcat))
     }
+
+    pub fn cum_set_union(self) -> Expr {
+        self.0.map_private(FunctionExpr::ListExpr(ListFunction::CumSetUnion))
+    }
 }

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -349,6 +349,12 @@ class ExprListNameSpace:
         other_list.insert(0, wrap_expr(self._pyexpr))
         return F.concat_list(other_list)
 
+    def cum_concat(self) -> Expr:
+        """
+        asdgasdgasdg
+        """
+        return wrap_expr(self._pyexpr.list_cum_concat())
+
     def get(self, index: int | Expr | str) -> Expr:
         """
         Get the value by index in the sublists.

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -360,18 +360,18 @@ class ExprListNameSpace:
         ...         "a": [["a"], ["x", "y"], None, ["a", "b"]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").list.cum_concat())
-        shape: (2, 1)
-        ┌───────────────────────────┐
-        │ a                         │
-        │ ---                       │
-        │ list[str]                 │
-        ╞═══════════════════════════╡
-        │ ["a"]                     │
-        │ ["a", "x", "y"]           │
-        │ null                      │
-        │ ["a", "x", "y", "a", "b"] │
-        └───────────────────────────┘
+        >>> df.select(pl.col("a").list.cum_concat().list.join(""))
+        shape: (4, 1)
+        ┌─────────┐
+        │ a       │
+        │ ---     │
+        │ str     │
+        ╞═════════╡
+        │ "a"     │
+        │ "axy"   │
+        │ null    │
+        │ "axyab" │
+        └─────────┘
 
         """
         return wrap_expr(self._pyexpr.list_cum_concat())
@@ -387,18 +387,18 @@ class ExprListNameSpace:
         ...         "a": [["a"], ["x", "y"], None, ["a", "b"]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").list.cum_set_union())
-        shape: (2, 1)
-        ┌──────────────────────┐
-        │ a                    │
-        │ ---                  │
-        │ list[str]            │
-        ╞══════════════════════╡
-        │ ["a"]                │
-        │ ["a", "x", "y"]      │
-        │ null                 │
-        │ ["a", "b", "x", "y"] │
-        └──────────────────────┘
+        >>> df.select(pl.col("a").list.cum_set_union().list.join(""))
+        shape: (4, 1)
+        ┌────────┐
+        │ a      │
+        │ ---    │
+        │ str    │
+        ╞════════╡
+        │ "a"    │
+        │ "axy"  │
+        │ null   │
+        │ "abxy" │
+        └────────┘
 
         """
         return wrap_expr(self._pyexpr.list_cum_set_union())

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -395,7 +395,7 @@ class ExprListNameSpace:
         │ str  │
         ╞══════╡
         │ a    │
-        │ axy  │
+        │ ayx  │
         │ null │
         │ bayx │
         └──────┘

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -357,12 +357,7 @@ class ExprListNameSpace:
         --------
         >>> df = pl.DataFrame(
         ...     {
-        ...         "a": [
-                        ["a"], 
-                        ["x", "y"], 
-                        None, 
-                        ["a", "b"]
-                    ],
+        ...         "a": [["a"], ["x", "y"], None, ["a", "b"]],
         ...     }
         ... )
         >>> df.select(pl.col("a").list.cum_concat())
@@ -383,18 +378,13 @@ class ExprListNameSpace:
 
     def cum_set_union(self) -> Expr:
         """
-        Cumulatively apply a set union to the arrays in a Series dtype List in linear time.
+        Cumulatively apply a set union to the arrays in a Series dtype List.
 
         Examples
         --------
         >>> df = pl.DataFrame(
         ...     {
-        ...         "a": [
-                        ["a"], 
-                        ["x", "y"], 
-                        None, 
-                        ["a", "b"]
-                    ],
+        ...         "a": [["a"], ["x", "y"], None, ["a", "b"]],
         ...     }
         ... )
         >>> df.select(pl.col("a").list.cum_set_union())

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -387,7 +387,7 @@ class ExprListNameSpace:
         ...         "a": [["a"], ["x", "y"], None, ["a", "b"]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").list.cum_set_union().list.join(""))
+        >>> df.select(pl.col("a").list.cum_set_union().list.sort().list.join(""))
         shape: (4, 1)
         ┌──────┐
         │ a    │
@@ -395,9 +395,9 @@ class ExprListNameSpace:
         │ str  │
         ╞══════╡
         │ a    │
-        │ ayx  │
+        │ axy  │
         │ null │
-        │ bayx │
+        │ abxy │
         └──────┘
 
         """

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -350,15 +350,11 @@ class ExprListNameSpace:
         return F.concat_list(other_list)
 
     def cum_concat(self) -> Expr:
-        """
-        asdgasdgasdg
-        """
+        """Asdgasdgasdg."""
         return wrap_expr(self._pyexpr.list_cum_concat())
 
     def cum_set_union(self) -> Expr:
-        """
-        asdgasdgasdg
-        """
+        """Asdgasdgasdg."""
         return wrap_expr(self._pyexpr.list_cum_set_union())
 
     def get(self, index: int | Expr | str) -> Expr:

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -397,7 +397,7 @@ class ExprListNameSpace:
         │ a    │
         │ axy  │
         │ null │
-        │ abxy │
+        │ bayx │
         └──────┘
 
         """

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -355,6 +355,12 @@ class ExprListNameSpace:
         """
         return wrap_expr(self._pyexpr.list_cum_concat())
 
+    def cum_set_union(self) -> Expr:
+        """
+        asdgasdgasdg
+        """
+        return wrap_expr(self._pyexpr.list_cum_set_union())
+
     def get(self, index: int | Expr | str) -> Expr:
         """
         Get the value by index in the sublists.

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -362,16 +362,16 @@ class ExprListNameSpace:
         ... )
         >>> df.select(pl.col("a").list.cum_concat().list.join(""))
         shape: (4, 1)
-        ┌─────────┐
-        │ a       │
-        │ ---     │
-        │ str     │
-        ╞═════════╡
-        │ "a"     │
-        │ "axy"   │
-        │ null    │
-        │ "axyab" │
-        └─────────┘
+        ┌───────┐
+        │ a     │
+        │ ---   │
+        │ str   │
+        ╞═══════╡
+        │ a     │
+        │ axy   │
+        │ null  │
+        │ axyab │
+        └───────┘
 
         """
         return wrap_expr(self._pyexpr.list_cum_concat())
@@ -389,16 +389,16 @@ class ExprListNameSpace:
         ... )
         >>> df.select(pl.col("a").list.cum_set_union().list.join(""))
         shape: (4, 1)
-        ┌────────┐
-        │ a      │
-        │ ---    │
-        │ str    │
-        ╞════════╡
-        │ "a"    │
-        │ "axy"  │
-        │ null   │
-        │ "abxy" │
-        └────────┘
+        ┌──────┐
+        │ a    │
+        │ ---  │
+        │ str  │
+        ╞══════╡
+        │ a    │
+        │ axy  │
+        │ null │
+        │ abxy │
+        └──────┘
 
         """
         return wrap_expr(self._pyexpr.list_cum_set_union())

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -350,11 +350,67 @@ class ExprListNameSpace:
         return F.concat_list(other_list)
 
     def cum_concat(self) -> Expr:
-        """Asdgasdgasdg."""
+        """
+        Cumulatively concatenate the arrays in a Series dtype List in linear time.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [
+                        ["a"], 
+                        ["x", "y"], 
+                        None, 
+                        ["a", "b"]
+                    ],
+        ...     }
+        ... )
+        >>> df.select(pl.col("a").list.cum_concat())
+        shape: (2, 1)
+        ┌───────────────────────────┐
+        │ a                         │
+        │ ---                       │
+        │ list[str]                 │
+        ╞═══════════════════════════╡
+        │ ["a"]                     │
+        │ ["a", "x", "y"]           │
+        │ null                      │
+        │ ["a", "x", "y", "a", "b"] │
+        └───────────────────────────┘
+
+        """
         return wrap_expr(self._pyexpr.list_cum_concat())
 
     def cum_set_union(self) -> Expr:
-        """Asdgasdgasdg."""
+        """
+        Cumulatively apply a set union to the arrays in a Series dtype List in linear time.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [
+                        ["a"], 
+                        ["x", "y"], 
+                        None, 
+                        ["a", "b"]
+                    ],
+        ...     }
+        ... )
+        >>> df.select(pl.col("a").list.cum_set_union())
+        shape: (2, 1)
+        ┌──────────────────────┐
+        │ a                    │
+        │ ---                  │
+        │ list[str]            │
+        ╞══════════════════════╡
+        │ ["a"]                │
+        │ ["a", "x", "y"]      │
+        │ null                 │
+        │ ["a", "b", "x", "y"] │
+        └──────────────────────┘
+
+        """
         return wrap_expr(self._pyexpr.list_cum_set_union())
 
     def get(self, index: int | Expr | str) -> Expr:

--- a/py-polars/src/expr/list.rs
+++ b/py-polars/src/expr/list.rs
@@ -174,4 +174,8 @@ impl PyExpr {
     fn list_cum_concat(&self) -> Self {
         self.inner.clone().list().cum_concat().into()
     }
+
+    fn list_cum_set_union(&self) -> Self {
+        self.inner.clone().list().cum_set_union().into()
+    }
 }

--- a/py-polars/src/expr/list.rs
+++ b/py-polars/src/expr/list.rs
@@ -170,4 +170,8 @@ impl PyExpr {
         }
         .into()
     }
+
+    fn list_cum_concat(&self) -> Self {
+        self.inner.clone().list().cum_concat().into()
+    }
 }

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -513,15 +513,15 @@ def test_list_cum_concat() -> None:
 
 
 def test_list_cum_set_union() -> None:
-    a = pl.DataFrame({"a": [None, [0], [], None, [1, 5, 9], [0], [], None]})
+    a = pl.DataFrame({"a": [None, [0], [1, 5], None, [1, 5, 9], [0], [2, 0, 5], None]})
     assert a.select(pl.col("a").list.cum_set_union())["a"].to_list() == [
         None,
         [0],
-        [0],
+        [0, 1, 5],
         None,
         [0, 1, 5, 9],
         [0, 1, 5, 9],
-        [0, 1, 5, 9],
+        [0, 1, 2, 5, 9],
         None,
     ]
 

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -498,20 +498,32 @@ def test_list_tail_underflow_9087() -> None:
     ]
 
 
-def test_list_cum_concat() -> None:
+def test_list_cum_concat():
     a = pl.DataFrame({"a": [None, [0], [], None, [1, 5, 9], [0], [], None]})
-    print(a.select(pl.col("a").list.cum_concat())["a"])
-    print(a.select(pl.col("a").list.cum_concat())["a"].to_list())
-    # assert a.select(pl.col("a").list.cum_concat())["a"].to_list() == [
-    #     None,
-    #     [0],
-    #     [0],
-    #     None
-    #     [0, 1, 5, 9],
-    #     [0, 1, 5, 9, 0],
-    #     [0, 1, 5, 9, 0],
-    #     None
-    # ]
+    assert a.select(pl.col("a").list.cum_concat())["a"].to_list() == [
+        None,
+        [0],
+        [0],
+        None
+        [0, 1, 5, 9],
+        [0, 1, 5, 9, 0],
+        [0, 1, 5, 9, 0],
+        None
+    ]
+
+
+def test_list_cum_set_union():
+    a = pl.DataFrame({"a": [None, [0], [], None, [1, 5, 9], [0], [], None]})
+    assert a.select(pl.col("a").list.cum_set_union())["a"].to_list() == [
+        None,
+        [0],
+        [0],
+        None
+        [0, 1, 5, 9],
+        [0, 1, 5, 9],
+        [0, 1, 5, 9],
+        None
+    ]
 
 
 def test_list_count_match_boolean_nulls_9141() -> None:

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -498,6 +498,22 @@ def test_list_tail_underflow_9087() -> None:
     ]
 
 
+def test_list_cum_concat() -> None:
+    a = pl.DataFrame({"a": [None, [0], [], None, [1, 5, 9], [0], [], None]})
+    print(a.select(pl.col("a").list.cum_concat())["a"])
+    print(a.select(pl.col("a").list.cum_concat())["a"].to_list())
+    # assert a.select(pl.col("a").list.cum_concat())["a"].to_list() == [
+    #     None,
+    #     [0],
+    #     [0],
+    #     None
+    #     [0, 1, 5, 9],
+    #     [0, 1, 5, 9, 0],
+    #     [0, 1, 5, 9, 0],
+    #     None
+    # ]
+
+
 def test_list_count_match_boolean_nulls_9141() -> None:
     a = pl.DataFrame({"a": [[True, None, False]]})
     assert a.select(pl.col("a").list.count_matches(True))["a"].to_list() == [1]

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -498,31 +498,31 @@ def test_list_tail_underflow_9087() -> None:
     ]
 
 
-def test_list_cum_concat():
+def test_list_cum_concat() -> None:
     a = pl.DataFrame({"a": [None, [0], [], None, [1, 5, 9], [0], [], None]})
     assert a.select(pl.col("a").list.cum_concat())["a"].to_list() == [
         None,
         [0],
         [0],
-        None
+        None,
         [0, 1, 5, 9],
         [0, 1, 5, 9, 0],
         [0, 1, 5, 9, 0],
-        None
+        None,
     ]
 
 
-def test_list_cum_set_union():
+def test_list_cum_set_union() -> None:
     a = pl.DataFrame({"a": [None, [0], [], None, [1, 5, 9], [0], [], None]})
     assert a.select(pl.col("a").list.cum_set_union())["a"].to_list() == [
         None,
         [0],
         [0],
-        None
+        None,
         [0, 1, 5, 9],
         [0, 1, 5, 9],
         [0, 1, 5, 9],
-        None
+        None,
     ]
 
 


### PR DESCRIPTION
See https://github.com/pola-rs/polars/issues/11504

Our production pipelines process a lot of time series data - one useful pattern here is having a column representing "observed events" at a particular timepoint, which we currently capture using the following `cumulative_eval` call;

```python
lf.with_columns(
    pl.col("events_at_t").cumulative_eval(
        pl.element().drop_nulls().explode().unique().implode()
    ).alias("events_up_to_t")
)
```

This `.drop_nulls().explode().unique().implode()` pattern behaves much like a set union over all lists in the Series. Unfortunately, as said in the documentation for `cumulative_eval` - this is a quadratic operation, which scales quite badly for our needs. This PR provides a linear time implementation of the above expression as `list.cum_set_union`, and similarly provides an expression `list.cum_concat`.

Example usage from the unit tests;
```python
def test_list_cum_concat() -> None:
    a = pl.DataFrame({
        "a": [None, [0], [], None, [1, 5, 9], [0], [], None]
    })
    assert a.select(pl.col("a").list.cum_concat())["a"].to_list() == [
        None,
        [0],
        [0],
        None,
        [0, 1, 5, 9],
        [0, 1, 5, 9, 0],
        [0, 1, 5, 9, 0],
        None,
    ]


def test_list_cum_set_union() -> None:
    a = pl.DataFrame({
        "a": [None, [0], [1, 5], None, [1, 5, 9], [0], [2, 0, 5], None]
    })
    assert a.select(pl.col("a").list.cum_set_union())["a"].to_list() == [
        None,
        [0],
        [0, 1, 5],
        None,
        [0, 1, 5, 9],
        [0, 1, 5, 9],
        [0, 1, 2, 5, 9],
        None,
    ]
```