### PR TITLE
fix(python,rust): fix for `write_csv` when using non-default "quote" char

### DIFF
--- a/crates/polars-io/src/csv/write_impl.rs
+++ b/crates/polars-io/src/csv/write_impl.rs
@@ -22,35 +22,33 @@ use super::write::QuoteStyle;
 
 fn fmt_and_escape_str(f: &mut Vec<u8>, v: &str, options: &SerializeOptions) -> std::io::Result<()> {
     if options.quote_style == QuoteStyle::Never {
-        write!(f, "{v}")
-    } else {
-        let quote = options.quote as char;
-        if v.is_empty() {
-            write!(f, "{quote}{quote}")
-        } else {
-            let needs_escaping = memchr(options.quote, v.as_bytes()).is_some();
-            if needs_escaping {
-                let replaced = unsafe {
-                    // Replace from single quote " to double quote "".
-                    v.replace(
-                        std::str::from_utf8_unchecked(&[options.quote]),
-                        std::str::from_utf8_unchecked(&[options.quote, options.quote]),
-                    )
-                };
-                return write!(f, "{quote}{replaced}{quote}");
-            }
-            let surround_with_quotes = match options.quote_style {
-                QuoteStyle::Always | QuoteStyle::NonNumeric => true,
-                QuoteStyle::Necessary => memchr2(options.delimiter, b'\n', v.as_bytes()).is_some(),
-                QuoteStyle::Never => false,
-            };
+        return write!(f, "{v}");
+    }
+    let quote = options.quote as char;
+    if v.is_empty() {
+        return write!(f, "{quote}{quote}");
+    }
+    let needs_escaping = memchr(options.quote, v.as_bytes()).is_some();
+    if needs_escaping {
+        let replaced = unsafe {
+            // Replace from single quote " to double quote "".
+            v.replace(
+                std::str::from_utf8_unchecked(&[options.quote]),
+                std::str::from_utf8_unchecked(&[options.quote, options.quote]),
+            )
+        };
+        return write!(f, "{quote}{replaced}{quote}");
+    }
+    let surround_with_quotes = match options.quote_style {
+        QuoteStyle::Always | QuoteStyle::NonNumeric => true,
+        QuoteStyle::Necessary => memchr2(options.delimiter, b'\n', v.as_bytes()).is_some(),
+        QuoteStyle::Never => false,
+    };
 
-            if surround_with_quotes {
-                write!(f, "{quote}{v}{quote}")
-            } else {
-                write!(f, "{v}")
-            }
-        }
+    if surround_with_quotes {
+        write!(f, "{quote}{v}{quote}")
+    } else {
+        write!(f, "{v}")
     }
 }
 

--- a/crates/polars-io/src/csv/write_impl.rs
+++ b/crates/polars-io/src/csv/write_impl.rs
@@ -23,31 +23,33 @@ use super::write::QuoteStyle;
 fn fmt_and_escape_str(f: &mut Vec<u8>, v: &str, options: &SerializeOptions) -> std::io::Result<()> {
     if options.quote_style == QuoteStyle::Never {
         write!(f, "{v}")
-    } else if v.is_empty() {
-        write!(f, "\"\"")
     } else {
-        let needs_escaping = memchr(options.quote, v.as_bytes()).is_some();
-        if needs_escaping {
-            let replaced = unsafe {
-                // Replace from single quote " to double quote "".
-                v.replace(
-                    std::str::from_utf8_unchecked(&[options.quote]),
-                    std::str::from_utf8_unchecked(&[options.quote, options.quote]),
-                )
-            };
-            return write!(f, "\"{replaced}\"");
-        }
-        let surround_with_quotes = match options.quote_style {
-            QuoteStyle::Always | QuoteStyle::NonNumeric => true,
-            QuoteStyle::Necessary => memchr2(options.delimiter, b'\n', v.as_bytes()).is_some(),
-            QuoteStyle::Never => false,
-        };
-
         let quote = options.quote as char;
-        if surround_with_quotes {
-            write!(f, "{quote}{v}{quote}")
+        if v.is_empty() {
+            write!(f, "{quote}{quote}")
         } else {
-            write!(f, "{v}")
+            let needs_escaping = memchr(options.quote, v.as_bytes()).is_some();
+            if needs_escaping {
+                let replaced = unsafe {
+                    // Replace from single quote " to double quote "".
+                    v.replace(
+                        std::str::from_utf8_unchecked(&[options.quote]),
+                        std::str::from_utf8_unchecked(&[options.quote, options.quote]),
+                    )
+                };
+                return write!(f, "{quote}{replaced}{quote}");
+            }
+            let surround_with_quotes = match options.quote_style {
+                QuoteStyle::Always | QuoteStyle::NonNumeric => true,
+                QuoteStyle::Necessary => memchr2(options.delimiter, b'\n', v.as_bytes()).is_some(),
+                QuoteStyle::Never => false,
+            };
+
+            if surround_with_quotes {
+                write!(f, "{quote}{v}{quote}")
+            } else {
+                write!(f, "{v}")
+            }
         }
     }
 }

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -561,7 +561,6 @@ def test_csv_quote_char() -> None:
             ),
         ]
     )
-
     rolling_stones = textwrap.dedent(
         """\
         linenum,last_name,first_name
@@ -576,7 +575,6 @@ def test_csv_quote_char() -> None:
         9,J"o"ne"s,Brian
         """
     )
-
     for use_pyarrow in (False, True):
         out = pl.read_csv(
             rolling_stones.encode(), quote_char=None, use_pyarrow=use_pyarrow
@@ -586,7 +584,10 @@ def test_csv_quote_char() -> None:
 
     # non-standard quote char
     df = pl.DataFrame({"x": ["", "0*0", "xyz"]})
-    assert df.write_csv(quote="*") == "x\n**\n*0**0*\nxyz\n"
+    csv_data = df.write_csv(quote="*")
+
+    assert csv_data == "x\n**\n*0**0*\nxyz\n"
+    assert_frame_equal(df, pl.read_csv(io.StringIO(csv_data), quote_char="*"))
 
 
 def test_csv_empty_quotes_char_1622() -> None:

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -584,6 +584,10 @@ def test_csv_quote_char() -> None:
         assert out.shape == (9, 3)
         assert_frame_equal(out, expected)
 
+    # non-standard quote char
+    df = pl.DataFrame({"x": ["", "0*0", "xyz"]})
+    assert df.write_csv(quote="*") == "x\n**\n*0**0*\nxyz\n"
+
 
 def test_csv_empty_quotes_char_1622() -> None:
     pl.read_csv(b"a,b,c,d\nA1,B1,C1,1\nA2,B2,C2,2\n", quote_char="")


### PR DESCRIPTION
We weren't respecting custom "quote" char in two places:
* empty string representation.
* quoting values that contain the quote char.

# Example

```python
import polars as pl
df = pl.DataFrame( {"string":["","0*0","xyz"]} )
# shape: (3, 1)
# ┌────────┐
# │ string │
# │ ---    │
# │ str    │
# ╞════════╡
# │        │
# │ 0*0    │
# │ xyz    │
# └────────┘
```

### Before

Empty string quoted as `""` instead of `**`.
Value containing quote char `*` quoted using `"`.
```python
df.write_csv( quote="*" )
# 'string\n""\n"0**0"\nxyz\n'
```

### After

Both cases properly use the declared quote char `*`.
```python
df.write_csv( quote="*" )
# 'string\n**\n*0**0*\nxyz\n'
```
