### PR TITLE
perf(rust, python): early return in replace_time_zone if target and source time zones match

### DIFF
--- a/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
+++ b/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
@@ -20,7 +20,10 @@ pub fn replace_time_zone(
     let from_time_zone = datetime.time_zone().as_deref().unwrap_or("UTC");
     let from_tz = parse_time_zone(from_time_zone)?;
     let to_tz = parse_time_zone(time_zone.unwrap_or("UTC"))?;
-    if (from_tz == to_tz) & ((from_tz == UTC) | (ambiguous.get(0) == Some("raise"))) {
+    if (from_tz == to_tz)
+        & ((from_tz == UTC)
+            | ((ambiguous.len() == 1) & (unsafe { ambiguous.get_unchecked(0) } == Some("raise"))))
+    {
         let mut out = datetime
             .0
             .clone()
@@ -39,7 +42,7 @@ pub fn replace_time_zone(
         TimeUnit::Nanoseconds => datetime_to_timestamp_ns,
     };
     let out = match ambiguous.len() {
-        1 => match ambiguous.get(0) {
+        1 => match unsafe { ambiguous.get_unchecked(0) } {
             Some(ambiguous) => datetime.0.try_apply(|timestamp| {
                 let ndt = timestamp_to_datetime(timestamp);
                 Ok(datetime_to_timestamp(convert_to_naive_local(

--- a/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
+++ b/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
@@ -20,7 +20,7 @@ pub fn replace_time_zone(
     let from_time_zone = datetime.time_zone().as_deref().unwrap_or("UTC");
     let from_tz = parse_time_zone(from_time_zone)?;
     let to_tz = parse_time_zone(time_zone.unwrap_or("UTC"))?;
-    if (from_tz == to_tz) & (from_tz == UTC) {
+    if (from_tz == to_tz) & ((from_tz == UTC) | (ambiguous.get(0) == Some("raise"))) {
         let mut out = datetime
             .0
             .clone()

--- a/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
+++ b/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
@@ -2,7 +2,7 @@ use arrow::temporal_conversions::{
     timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
 };
 use chrono::NaiveDateTime;
-use chrono_tz::Tz;
+use chrono_tz::{Tz, UTC};
 use polars_arrow::kernels::convert_to_naive_local;
 use polars_core::chunked_array::ops::arity::try_binary_elementwise_values;
 use polars_core::prelude::*;
@@ -20,6 +20,14 @@ pub fn replace_time_zone(
     let from_time_zone = datetime.time_zone().as_deref().unwrap_or("UTC");
     let from_tz = parse_time_zone(from_time_zone)?;
     let to_tz = parse_time_zone(time_zone.unwrap_or("UTC"))?;
+    if (from_tz == to_tz) & (from_tz == UTC) {
+        let mut out = datetime
+            .0
+            .clone()
+            .into_datetime(datetime.time_unit(), time_zone.map(|x| x.to_string()));
+        out.set_sorted_flag(datetime.is_sorted_flag());
+        return Ok(out);
+    }
     let timestamp_to_datetime: fn(i64) -> NaiveDateTime = match datetime.time_unit() {
         TimeUnit::Milliseconds => timestamp_ms_to_datetime,
         TimeUnit::Microseconds => timestamp_us_to_datetime,

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2151,9 +2151,9 @@ def test_replace_time_zone_ambiguous_raises() -> None:
     [
         ("Europe/London", False, "earliest"),
         ("Europe/London", False, "raise"),
-        ("UTC", False, "earliest"),
+        ("UTC", True, "earliest"),
         ("UTC", True, "raise"),
-        (None, False, "earliest"),
+        (None, True, "earliest"),
         (None, True, "raise"),
     ],
 )
@@ -2171,18 +2171,18 @@ def test_replace_time_zone_sortedness_series(
 
 
 @pytest.mark.parametrize(
-    ("from_tz", "ambiguous"),
+    ("from_tz", "expected_sortedness", "ambiguous"),
     [
-        ("Europe/London", "earliest"),
-        ("Europe/London", "raise"),
-        ("UTC", "earliest"),
-        ("UTC", "raise"),
-        (None, "earliest"),
-        (None, "raise"),
+        ("Europe/London", False, "earliest"),
+        ("Europe/London", False, "raise"),
+        ("UTC", True, "earliest"),
+        ("UTC", True, "raise"),
+        (None, True, "earliest"),
+        (None, True, "raise"),
     ],
 )
 def test_replace_time_zone_sortedness_expressions(
-    from_tz: str | None, ambiguous: str
+    from_tz: str | None, expected_sortedness: bool, ambiguous: str
 ) -> None:
     df = (
         pl.Series("ts", [1603584000000000, 1603587600000000])
@@ -2195,7 +2195,7 @@ def test_replace_time_zone_sortedness_expressions(
     result = df.select(
         pl.col("ts").dt.replace_time_zone("UTC", ambiguous=pl.col("ambiguous"))
     )
-    assert not result["ts"].flags["SORTED_ASC"]
+    assert result["ts"].flags["SORTED_ASC"] == expected_sortedness
 
 
 def test_use_earliest_deprecation() -> None:


### PR DESCRIPTION
closes #10516

This adds an early return for:
- None -> UTC
- UTC -> None
- UTC -> UTC
- None -> None

These are the only cases in which the early return can be safely done unfortunately - due to DST nonsense, replacing `'Europe/London'` with `'Europe/London'` might not return the same result