### PR TITLE
fix(python): fix comparing tz-aware series with stdlib datetime

### DIFF
--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import contextlib
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
 import polars._reexport as pl
@@ -91,7 +91,9 @@ def lit(
             raise TypeError(
                 f"time zone of dtype ({dtype.time_zone!r}) differs from time zone of value ({value.tzinfo!r})"  # type: ignore[union-attr]
             )
-        e = lit(_datetime_to_pl_timestamp(value, time_unit)).cast(Datetime(time_unit))
+        e = lit(
+            _datetime_to_pl_timestamp(value.replace(tzinfo=timezone.utc), time_unit)
+        ).cast(Datetime(time_unit))
         if time_zone is not None:
             return e.dt.replace_time_zone(
                 str(time_zone), ambiguous="earliest" if value.fold == 0 else "latest"

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -486,7 +486,7 @@ class Series:
             time_zone = self.dtype.time_zone  # type: ignore[union-attr]
             if str(other.tzinfo) != str(time_zone):
                 raise TypeError(
-                    f"Time zone of datetime '{other.tzinfo}' does not match Series timezone '{time_zone}'"
+                    f"Datetime time zone '{other.tzinfo}' does not match Series timezone '{time_zone}'"
                 )
             ts = _datetime_to_pl_timestamp(other, self.dtype.time_unit)  # type: ignore[union-attr]
             f = get_ffi_func(op + "_<>", Int64, self._s)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -483,6 +483,11 @@ class Series:
                 return ~self
 
         if isinstance(other, datetime) and self.dtype == Datetime:
+            time_zone = self.dtype.time_zone  # type: ignore[union-attr]
+            if str(other.tzinfo) != str(time_zone):
+                raise TypeError(
+                    f"Time zone of datetime '{other.tzinfo}' does not match Series timezone '{time_zone}'"
+                )
             ts = _datetime_to_pl_timestamp(other, self.dtype.time_unit)  # type: ignore[union-attr]
             f = get_ffi_func(op + "_<>", Int64, self._s)
             assert f is not None

--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -98,8 +98,10 @@ def _negate_duration(duration: str) -> str:
 
 
 def _datetime_to_pl_timestamp(dt: datetime, time_unit: TimeUnit | None) -> int:
-    """Convert a python datetime to a timestamp in nanoseconds."""
-    dt = dt.replace(tzinfo=timezone.utc) if dt.tzinfo != timezone.utc else dt
+    """Convert a python datetime to a timestamp in given time unit."""
+    if dt.tzinfo is None:
+        # Make sure to use UTC rather than system time zone.
+        dt = dt.replace(tzinfo=timezone.utc)
     if time_unit == "ns":
         micros = dt.microsecond
         return 1_000 * (_timestamp_in_seconds(dt) * 1_000_000 + micros)

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -515,6 +515,28 @@ def test_date_comp(one: PolarsTemporalType, two: PolarsTemporalType) -> None:
     assert (a <= one).to_list() == [True, False]
 
 
+def test_datetime_comp_tz_aware() -> None:
+    a = pl.Series(
+        "a", [datetime(2020, 1, 1), datetime(2020, 1, 2)]
+    ).dt.replace_time_zone("Asia/Kathmandu")
+    other = datetime(2020, 1, 1, tzinfo=ZoneInfo("Asia/Kathmandu"))
+    result = a > other
+    expected = pl.Series("a", [False, True])
+    assert_series_equal(result, expected)
+
+
+def test_datetime_comp_tz_aware_invalid() -> None:
+    a = pl.Series(
+        "a", [datetime(2020, 1, 1), datetime(2020, 1, 2)]
+    ).dt.replace_time_zone("Asia/Kathmandu")
+    other = datetime(2020, 1, 1)
+    with pytest.raises(
+        TypeError,
+        match="Time zone of datetime 'None' does not match Series timezone 'Asia/Kathmandu'",
+    ):
+        _ = a > other
+
+
 @pytest.mark.parametrize("tzinfo", [None, ZoneInfo("Asia/Kathmandu")])
 def test_truncate_negative_offset(tzinfo: ZoneInfo | None) -> None:
     time_zone = tzinfo.key if tzinfo is not None else None

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -532,7 +532,7 @@ def test_datetime_comp_tz_aware_invalid() -> None:
     other = datetime(2020, 1, 1)
     with pytest.raises(
         TypeError,
-        match="Time zone of datetime 'None' does not match Series timezone 'Asia/Kathmandu'",
+        match="Datetime time zone 'None' does not match Series timezone 'Asia/Kathmandu'",
     ):
         _ = a > other
 


### PR DESCRIPTION
closes #11470 

summary of change:
- `_datetime_to_pl_timestamp` would previously always set `UTC` as the time zone before calculating the timestamp. I think this was only the intention for `pl.lit(datetime(...), dtype=(..., time_zone))`, where the time zone is to be replaced at the end

So, I've changed `_datetime_to_pl_timestamp` to only set `UTC` if the time zone is None (to avoid the python stdlib weirdness of using the system's time zone), and otherwise it's up to the caller (in this case, `lit`) to replace the timezone before calling `_datetime_to_pl_timestamp`.
Like this, `__gt__` can just use the datetime as-is and doesn't need to do a "double-replace-time-zone"