### PR TITLE
ci(python): Unpin maturin version, fix release workflow

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -26,7 +26,7 @@ jobs:
         architecture: [x86-64, aarch64]
         exclude:
           - os: windows-32gb-ram
-            cpu: aarch64
+            architecture: aarch64
 
     steps:
       - uses: actions/checkout@v4

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -4,6 +4,13 @@
 
 --prefer-binary
 
+# -----
+# BUILD
+# -----
+
+maturin
+patchelf; platform_system == 'Linux'  # Extra dependency for maturin, only for Linux
+
 # ------------
 # DEPENDENCIES
 # ------------
@@ -47,8 +54,6 @@ gevent
 # -------
 
 hypothesis==6.87.1
-maturin==1.2.3
-patchelf; platform_system == 'Linux'  # Extra dependency for maturin, only for Linux
 pytest==7.4.0
 pytest-cov==4.1.0
 pytest-xdist==3.3.1


### PR DESCRIPTION
I unpinned the maturin version in the dev dependencies, as we want to make sure our builds work on the latest version of maturin. If not, we'll find out quickly :smiling_imp: 

Also, I messed up something (small) in the release workflow.