### PR TITLE
build(python): Enable additional flags for x86-64 wheels

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -112,7 +112,10 @@ jobs:
         run: tomlq -i -t '.dependencies.polars.features += ["bigidx"]' py-polars/Cargo.toml
 
       - name: Set RUSTFLAGS for x86-64
-        if: matrix.architecture == 'x86-64' && matrix.package != 'polars-lts-cpu'
+        if: matrix.architecture == 'x86-64' && matrix.package != 'polars-lts-cpu' && matrix.os != 'macos-latest'
+        run: echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt" >> $GITHUB_ENV
+      - name: Set RUSTFLAGS for x86-64 MacOS
+        if: matrix.architecture == 'x86-64' && matrix.package != 'polars-lts-cpu' && matrix.os == 'macos-latest'
         run: echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma" >> $GITHUB_ENV
       - name: Set RUSTFLAGS for x86-64 LTS CPU
         if: matrix.architecture == 'x86-64' && matrix.package == 'polars-lts-cpu'


### PR DESCRIPTION
We have enabled extra CPU optimizations for our Linux and Windows x86-64 wheels:

```diff
- RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma
+ RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt
```

This will lead to better performance on modern CPUs.

However, for users on old CPUs, this may lead to an error when importing Polars _(illegal instruction)_.
**If this is the case for you, please let us know on Discord or make an issue on GitHub.**

If you can no longer import Polars, you can use the `polars-lts-cpu` package instead.

_Highlighted not for the magnitude of this achievement - but for visiblity in the changelog as this might trip up some of our users._