### PR TITLE
fix(rust,python,sql): rework SQL join constraint processing to properly account for all `USING` columns

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -7,10 +7,10 @@ use polars_lazy::prelude::*;
 use polars_plan::prelude::*;
 use polars_plan::utils::expressions_to_schema;
 use sqlparser::ast::{
-    Distinct, ExcludeSelectItem, Expr as SqlExpr, FunctionArg, GroupByExpr, JoinConstraint,
-    JoinOperator, ObjectName, ObjectType, Offset, OrderByExpr, Query, Select, SelectItem, SetExpr,
-    SetOperator, SetQuantifier, Statement, TableAlias, TableFactor, TableWithJoins,
-    Value as SQLValue, WildcardAdditionalOptions,
+    Distinct, ExcludeSelectItem, Expr as SqlExpr, FunctionArg, GroupByExpr, JoinOperator,
+    ObjectName, ObjectType, Offset, OrderByExpr, Query, Select, SelectItem, SetExpr, SetOperator,
+    SetQuantifier, Statement, TableAlias, TableFactor, TableWithJoins, Value as SQLValue,
+    WildcardAdditionalOptions,
 };
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::{Parser, ParserOptions};

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -7,16 +7,16 @@ use polars_lazy::prelude::*;
 use polars_plan::prelude::*;
 use polars_plan::utils::expressions_to_schema;
 use sqlparser::ast::{
-    Distinct, ExcludeSelectItem, Expr as SqlExpr, FunctionArg, GroupByExpr, JoinOperator,
-    ObjectName, ObjectType, Offset, OrderByExpr, Query, Select, SelectItem, SetExpr, SetOperator,
-    SetQuantifier, Statement, TableAlias, TableFactor, TableWithJoins, Value as SQLValue,
-    WildcardAdditionalOptions,
+    Distinct, ExcludeSelectItem, Expr as SqlExpr, FunctionArg, GroupByExpr, JoinConstraint,
+    JoinOperator, ObjectName, ObjectType, Offset, OrderByExpr, Query, Select, SelectItem, SetExpr,
+    SetOperator, SetQuantifier, Statement, TableAlias, TableFactor, TableWithJoins,
+    Value as SQLValue, WildcardAdditionalOptions,
 };
 use sqlparser::dialect::GenericDialect;
 use sqlparser::parser::{Parser, ParserOptions};
 
 use crate::function_registry::{DefaultFunctionRegistry, FunctionRegistry};
-use crate::sql_expr::{parse_sql_expr, process_join_constraint};
+use crate::sql_expr::{parse_sql_expr, process_join};
 use crate::table_functions::PolarsTableFunctions;
 
 /// The SQLContext is the main entry point for executing SQL queries.
@@ -266,50 +266,36 @@ impl SQLContext {
 
     /// execute the 'FROM' part of the query
     fn execute_from_statement(&mut self, tbl_expr: &TableWithJoins) -> PolarsResult<LazyFrame> {
-        let (tbl_name, mut lf) = self.get_table(&tbl_expr.relation)?;
+        let (l_name, mut lf) = self.get_table(&tbl_expr.relation)?;
         if !tbl_expr.joins.is_empty() {
             for tbl in &tbl_expr.joins {
-                let (join_tbl_name, join_tbl) = self.get_table(&tbl.relation)?;
+                let (r_name, rf) = self.get_table(&tbl.relation)?;
                 lf = match &tbl.join_operator {
-                    JoinOperator::CrossJoin => lf.cross_join(join_tbl),
+                    JoinOperator::CrossJoin => lf.cross_join(rf),
                     JoinOperator::FullOuter(constraint) => {
-                        let (left_on, right_on) =
-                            process_join_constraint(constraint, &tbl_name, &join_tbl_name)?;
-                        lf.outer_join(join_tbl, left_on, right_on)
+                        process_join(lf, rf, constraint, &l_name, &r_name, JoinType::Outer)?
                     },
                     JoinOperator::Inner(constraint) => {
-                        let (left_on, right_on) =
-                            process_join_constraint(constraint, &tbl_name, &join_tbl_name)?;
-                        lf.inner_join(join_tbl, left_on, right_on)
+                        process_join(lf, rf, constraint, &l_name, &r_name, JoinType::Inner)?
+                    },
+                    JoinOperator::LeftOuter(constraint) => {
+                        process_join(lf, rf, constraint, &l_name, &r_name, JoinType::Left)?
                     },
                     #[cfg(feature = "semi_anti_join")]
                     JoinOperator::LeftAnti(constraint) => {
-                        let (left_on, right_on) =
-                            process_join_constraint(constraint, &tbl_name, &join_tbl_name)?;
-                        lf.anti_join(join_tbl, left_on, right_on)
-                    },
-                    JoinOperator::LeftOuter(constraint) => {
-                        let (left_on, right_on) =
-                            process_join_constraint(constraint, &tbl_name, &join_tbl_name)?;
-                        lf.left_join(join_tbl, left_on, right_on)
+                        process_join(lf, rf, constraint, &l_name, &r_name, JoinType::Anti)?
                     },
                     #[cfg(feature = "semi_anti_join")]
                     JoinOperator::LeftSemi(constraint) => {
-                        let (left_on, right_on) =
-                            process_join_constraint(constraint, &tbl_name, &join_tbl_name)?;
-                        lf.semi_join(join_tbl, left_on, right_on)
+                        process_join(lf, rf, constraint, &l_name, &r_name, JoinType::Semi)?
                     },
                     #[cfg(feature = "semi_anti_join")]
                     JoinOperator::RightAnti(constraint) => {
-                        let (left_on, right_on) =
-                            process_join_constraint(constraint, &tbl_name, &join_tbl_name)?;
-                        join_tbl.anti_join(lf, right_on, left_on)
+                        process_join(rf, lf, constraint, &l_name, &r_name, JoinType::Anti)?
                     },
                     #[cfg(feature = "semi_anti_join")]
                     JoinOperator::RightSemi(constraint) => {
-                        let (left_on, right_on) =
-                            process_join_constraint(constraint, &tbl_name, &join_tbl_name)?;
-                        join_tbl.semi_join(lf, right_on, left_on)
+                        process_join(rf, lf, constraint, &l_name, &r_name, JoinType::Semi)?
                     },
                     join_type => {
                         polars_bail!(
@@ -320,7 +306,6 @@ impl SQLContext {
                 }
             }
         };
-
         Ok(lf)
     }
 

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -623,11 +623,31 @@ pub(crate) fn parse_sql_expr(expr: &SqlExpr, ctx: &mut SQLContext) -> PolarsResu
     visitor.visit_expr(expr)
 }
 
+pub(super) fn process_join(
+    left_tbl: LazyFrame,
+    right_tbl: LazyFrame,
+    constraint: &JoinConstraint,
+    tbl_name: &String,
+    join_tbl_name: &String,
+    join_type: JoinType,
+) -> PolarsResult<LazyFrame> {
+    let (left_on, right_on) = process_join_constraint(constraint, &tbl_name, &join_tbl_name)?;
+
+    Ok(left_tbl
+        .join_builder()
+        .with(right_tbl)
+        .left_on(left_on)
+        .right_on(right_on)
+        .how(join_type)
+        .finish()
+        .into())
+}
+
 pub(super) fn process_join_constraint(
     constraint: &JoinConstraint,
     left_name: &str,
     right_name: &str,
-) -> PolarsResult<(Expr, Expr)> {
+) -> PolarsResult<(Vec<Expr>, Vec<Expr>)> {
     if let JoinConstraint::On(SqlExpr::BinaryOp { left, op, right }) = constraint {
         match (left.as_ref(), right.as_ref()) {
             (SqlExpr::CompoundIdentifier(left), SqlExpr::CompoundIdentifier(right)) => {
@@ -639,23 +659,24 @@ pub(super) fn process_join_constraint(
 
                     if let BinaryOperator::Eq = op {
                         if left_name == tbl_a && right_name == tbl_b {
-                            return Ok((col(col_a), col(col_b)));
+                            return Ok((vec![col(col_a)], vec![col(col_b)]));
                         } else if left_name == tbl_b && right_name == tbl_a {
-                            return Ok((col(col_b), col(col_a)));
+                            return Ok((vec![col(col_b)], vec![col(col_a)]));
                         }
                     }
                 }
             },
             (SqlExpr::Identifier(left), SqlExpr::Identifier(right)) => {
-                return Ok((col(&left.value), col(&right.value)))
+                return Ok((vec![col(&left.value)], vec![col(&right.value)]))
             },
             _ => {},
         }
     }
     if let JoinConstraint::Using(idents) = constraint {
         if !idents.is_empty() {
-            let cols = &idents[0].value;
-            return Ok((col(cols), col(cols)));
+            let mut using = Vec::with_capacity(idents.len());
+            using.extend(idents.into_iter().map(|id| col(&id.value)));
+            return Ok((using.clone(), using.clone()));
         }
     }
     polars_bail!(InvalidOperation: "SQL join constraint {:?} is not yet supported", constraint);

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -627,11 +627,11 @@ pub(super) fn process_join(
     left_tbl: LazyFrame,
     right_tbl: LazyFrame,
     constraint: &JoinConstraint,
-    tbl_name: &String,
-    join_tbl_name: &String,
+    tbl_name: &str,
+    join_tbl_name: &str,
     join_type: JoinType,
 ) -> PolarsResult<LazyFrame> {
-    let (left_on, right_on) = process_join_constraint(constraint, &tbl_name, &join_tbl_name)?;
+    let (left_on, right_on) = process_join_constraint(constraint, tbl_name, join_tbl_name)?;
 
     Ok(left_tbl
         .join_builder()
@@ -639,8 +639,7 @@ pub(super) fn process_join(
         .left_on(left_on)
         .right_on(right_on)
         .how(join_type)
-        .finish()
-        .into())
+        .finish())
 }
 
 pub(super) fn process_join_constraint(
@@ -675,7 +674,7 @@ pub(super) fn process_join_constraint(
     if let JoinConstraint::Using(idents) = constraint {
         if !idents.is_empty() {
             let mut using = Vec::with_capacity(idents.len());
-            using.extend(idents.into_iter().map(|id| col(&id.value)));
+            using.extend(idents.iter().map(|id| col(&id.value)));
             return Ok((using.clone(), using.clone()));
         }
     }


### PR DESCRIPTION
Partially addresses #11290.

Ref: https://github.com/pola-rs/polars/issues/11290#issuecomment-1733881081
Ref: https://github.com/pola-rs/polars/pull/11501#issuecomment-1747017914

Turns out we have been silently eating all columns after the first one in `USING` clauses. I've reworked the processing here so that we now properly capture and apply _all_ of the declared constraint columns, and added/fixed some test coverage.