### PR TITLE
 fix(rust,python): incorrect `is_first_distinct` for boolean arrays of length >= 64

### DIFF
--- a/crates/polars-arrow/src/bit_util.rs
+++ b/crates/polars-arrow/src/bit_util.rs
@@ -165,16 +165,16 @@ pub fn find_first_true_false_null(
     for (truth_mask, null_mask) in (&mut bit_chunks).zip(&mut validity_chunks) {
         let mask = null_mask & truth_mask & true_not_found_mask;
         if mask > 0 {
-            true_index = Some(offset + mask.leading_zeros() as usize);
+            true_index = Some(offset + mask.trailing_zeros() as usize);
             true_not_found_mask = 0;
         }
         let mask = null_mask & !truth_mask & false_not_found_mask;
         if mask > 0 {
-            false_index = Some(offset + mask.leading_zeros() as usize);
+            false_index = Some(offset + mask.trailing_zeros() as usize);
             false_not_found_mask = 0;
         }
         if !null_mask & null_not_found_mask > 0 {
-            null_index = Some(offset + null_mask.leading_ones() as usize);
+            null_index = Some(offset + null_mask.trailing_ones() as usize);
             null_not_found_mask = 0;
         }
         if null_not_found_mask | true_not_found_mask | false_not_found_mask == 0 {
@@ -211,12 +211,12 @@ pub fn find_first_true_false_no_null(
     for truth_mask in &mut bit_chunks {
         let mask = truth_mask & true_not_found_mask;
         if mask > 0 {
-            true_index = Some(offset + mask.leading_zeros() as usize);
+            true_index = Some(offset + mask.trailing_zeros() as usize);
             true_not_found_mask = 0;
         }
         let mask = !truth_mask & false_not_found_mask;
         if mask > 0 {
-            false_index = Some(offset + mask.leading_zeros() as usize);
+            false_index = Some(offset + mask.trailing_zeros() as usize);
             false_not_found_mask = 0;
         }
         if true_not_found_mask | false_not_found_mask == 0 {

--- a/py-polars/tests/unit/operations/test_is_first_last_distinct.py
+++ b/py-polars/tests/unit/operations/test_is_first_last_distinct.py
@@ -13,8 +13,8 @@ def test_is_first_distinct() -> None:
 
 def test_is_first_distinct_bool_bit_chunk_index_calc() -> None:
     # The fast path activates on sizes >=64 and processes in chunks of 64-bits.
-    # It calculates the indexes using the bit counts, this test ensures it
-    # counts from the correct side.
+    # It calculates the indexes using the bit counts, which needs to be from the
+    # correct side.
     assert pl.arange(0, 64, eager=True).filter(
         pl.Series("x", [True] + 63 * [False]).is_first_distinct()
     ).to_list() == [0, 1]

--- a/py-polars/tests/unit/operations/test_is_first_last_distinct.py
+++ b/py-polars/tests/unit/operations/test_is_first_last_distinct.py
@@ -11,6 +11,27 @@ def test_is_first_distinct() -> None:
     assert_series_equal(result, expected)
 
 
+def test_is_first_distinct_bool_bit_chunk_index_calc() -> None:
+    # The fast path activates on sizes >=64 and processes in chunks of 64-bits.
+    # It calculates the indexes using the bit counts, this test ensures it
+    # counts from the correct side.
+    assert pl.arange(0, 64, eager=True).filter(
+        pl.Series("x", [True] + 63 * [False]).is_first_distinct()
+    ).to_list() == [0, 1]
+
+    assert pl.arange(0, 64, eager=True).filter(
+        pl.Series("x", [False] + 63 * [True]).is_first_distinct()
+    ).to_list() == [0, 1]
+
+    assert pl.arange(0, 64, eager=True).filter(
+        pl.Series("x", 2 * [True] + 2 * [False] + 60 * [None]).is_first_distinct()
+    ).to_list() == [0, 2, 4]
+
+    assert pl.arange(0, 64, eager=True).filter(
+        pl.Series("x", 2 * [False] + 2 * [None] + 60 * [True]).is_first_distinct()
+    ).to_list() == [0, 2, 4]
+
+
 def test_is_first_distinct_struct() -> None:
     lf = pl.LazyFrame({"a": [1, 2, 3, 2, None, 2, 1], "b": [0, 2, 3, 2, None, 2, 0]})
     result = lf.select(pl.struct("a", "b").is_first_distinct())

--- a/py-polars/tests/unit/operations/test_is_first_last_distinct.py
+++ b/py-polars/tests/unit/operations/test_is_first_last_distinct.py
@@ -16,19 +16,19 @@ def test_is_first_distinct_bool_bit_chunk_index_calc() -> None:
     # It calculates the indexes using the bit counts, which needs to be from the
     # correct side.
     assert pl.arange(0, 64, eager=True).filter(
-        pl.Series("x", [True] + 63 * [False]).is_first_distinct()
+        pl.Series([True] + 63 * [False]).is_first_distinct()
     ).to_list() == [0, 1]
 
     assert pl.arange(0, 64, eager=True).filter(
-        pl.Series("x", [False] + 63 * [True]).is_first_distinct()
+        pl.Series([False] + 63 * [True]).is_first_distinct()
     ).to_list() == [0, 1]
 
     assert pl.arange(0, 64, eager=True).filter(
-        pl.Series("x", 2 * [True] + 2 * [False] + 60 * [None]).is_first_distinct()
+        pl.Series(2 * [True] + 2 * [False] + 60 * [None]).is_first_distinct()
     ).to_list() == [0, 2, 4]
 
     assert pl.arange(0, 64, eager=True).filter(
-        pl.Series("x", 2 * [False] + 2 * [None] + 60 * [True]).is_first_distinct()
+        pl.Series(2 * [False] + 2 * [None] + 60 * [True]).is_first_distinct()
     ).to_list() == [0, 2, 4]
 
 


### PR DESCRIPTION
fixes https://github.com/pola-rs/polars/issues/11530

`is_first_distinct` goes through a fast path for boolean arrays whose lengths are >=64, and it currently calculates index offsets from the wrong side (leading bits instead of trailing bits).
