### PR TITLE
ci(python): Trigger Python release from Actions workflow dispatch

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      # Latest commit to include with the release. If omitted, use the latest commit on the main branch.
+      sha:
+        description: Commit SHA
+        type: string
 
 permissions:
   contents: write
@@ -18,6 +23,7 @@ jobs:
         uses: release-drafter/release-drafter@v5
         with:
           config-name: release-drafter-rust.yml
+          commitish: ${{ inputs.sha }}
           disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -26,6 +32,7 @@ jobs:
         uses: release-drafter/release-drafter@v5
         with:
           config-name: release-drafter-python.yml
+          commitish: ${{ inputs.sha }}
           disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,9 +1,21 @@
 name: Release Python
 
 on:
-  push:
-    tags:
-      - py-*
+  workflow_dispatch:
+    inputs:
+      # Latest commit to include with the release. If omitted, use the latest commit on the main branch.
+      sha:
+        description: Commit SHA
+        type: string
+      # Create the sdist and build the wheels, but do not publish to PyPI / GitHub.
+      dry-run:
+        description: Dry run
+        type: boolean
+        default: false
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   PYTHON_VERSION: '3.8'
@@ -25,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
 
       # Avoid potential out-of-memory errors
       - name: Set swap space for Linux
@@ -60,7 +74,7 @@ jobs:
 
       - name: Test sdist
         run: |
-          TOOLCHAIN=$(cat rust-toolchain.toml | grep -oP 'channel = "\K[^"]+')
+          TOOLCHAIN=$(grep -oP 'channel = "\K[^"]+' rust-toolchain.toml)
           rustup default $TOOLCHAIN
           pip install --force-reinstall --verbose dist/*.tar.gz
           python -c 'import polars'
@@ -85,6 +99,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
 
       # Avoid potential out-of-memory errors
       - name: Set swap space for Linux
@@ -154,6 +170,7 @@ jobs:
           path: dist/*.whl
 
   publish-to-pypi:
+    if: inputs.dry-run == false
     needs: [create-sdist, build-wheels]
     environment:
       name: release-python
@@ -180,20 +197,52 @@ jobs:
         with:
           verbose: true
 
-  update-github-release:
-    needs: create-sdist
+  publish-to-github:
+    needs: publish-to-pypi
     runs-on: ubuntu-latest
-
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+
       - name: Download sdist
         uses: actions/download-artifact@v3
         with:
           name: sdist
           path: dist
 
+      - name: Get version from Cargo.toml
+        id: version
+        working-directory: py-polars
+        run: |
+          VERSION=$(grep -m 1 -oP 'version = "\K[^"]+' Cargo.toml)
+          if [[ "$VERSION" == *"-"* ]]; then
+            IS_PRERELEASE=true
+          else
+            IS_PRERELEASE=false
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "is_prerelease=$IS_PRERELEASE" >> $GITHUB_OUTPUT
+
+      - name: Create and publish GitHub release
+        id: release
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter-python.yml
+          name: Python Polars ${{ steps.version.outputs.version }}
+          tag: py-${{ steps.version.outputs.version }}
+          version: ${{ steps.version.outputs.version }}
+          prerelease: ${{ steps.version.outputs.is_prerelease }}
+          commitish: ${{ inputs.sha }}
+          publish: true
+          disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload sdist as asset to GitHub release
         uses: svenstaro/upload-release-action@v2
         with:
           file: dist/polars-*.tar.gz
           file_glob: true
+          tag: ${{ steps.release.outputs.tag_name }}
           overwrite: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,21 +219,14 @@ Start by bumping the version number in the source code:
 
 Directly after merging your pull request, release the new version:
 
-8. Go back to the [releases page](https://github.com/pola-rs/polars/releases) and click _Edit_ on the appropriate draft release.
-9. On the draft release page, click _Publish release_. This will create a new release and a new tag, which will trigger the GitHub Actions release workflow ([Python](https://github.com/pola-rs/polars/actions/workflows/release-python.yml) / [Rust](https://github.com/pola-rs/polars/actions/workflows/release-rust.yml)).
-10. Wait for all release jobs to finish, then check [crates.io](https://crates.io/crates/polars)/[PyPI](https://pypi.org/project/polars/) to verify that the new Polars release is now available.
+8. Go to the release workflow ([Python](https://github.com/pola-rs/polars/actions/workflows/release-python.yml)/[Rust](https://github.com/pola-rs/polars/actions/workflows/release-rust.yml)), click _Run workflow_ in the top right, and click the green button. This will trigger the workflow, which will build all release artifacts and publish them.
+9. Wait for the workflow to finish, then check [crates.io](https://crates.io/crates/polars)/[PyPI](https://pypi.org/project/polars/)/[GitHub](https://github.com/pola-rs/polars/releases) to verify that the new Polars release is now available.
 
 ### Troubleshooting
 
 It may happen that one or multiple release jobs fail. If so, you should first try to simply re-run the failed jobs from the GitHub Actions UI.
 
-If that doesn't help, you will have to figure out what's wrong and commit a fix. Once your fix has made it to the `main` branch, re-trigger the release workflow by updating the git tag associated with the release. Note the commit hash of your fix, and run the following command:
-
-```shell
-git tag -f <version-number> <commit-hash> && git push -f origin <version-number>
-```
-
-This will update the tag to point to the commit of your fix. The release workflows will re-trigger and hopefully succeed this time!
+If that doesn't help, you will have to figure out what's wrong and commit a fix. Once your fix has made it to the `main` branch, simply re-trigger the release workflow.
 
 ## License
 


### PR DESCRIPTION
#### Changes

* Releases are now triggered by manually triggering the GitHub Actions [workflow](https://github.com/pola-rs/polars/actions/workflows/release-python.yml).
* The benefit of this new approach is that all artifacts are built first, and only if everything succeeds, we publish to PyPI and publish a GitHub release.
* Includes the option to do a dry-run (only build artifacts, do not publish) and specifying a commit hash (if some PRs were merged that should not be included).
* Includes support for pre-releases (when `py-polars/Cargo.toml` version includes pre-release information, e.g. `1.0.0-rc.1`)
* Updated `CONTRIBUTING.md` to describe the new way of working.

This change should make the release process a lot more reliable!