### PR TITLE
feat(python,rust,cli): add `DATE` function for SQL

### DIFF
--- a/crates/polars-sql/Cargo.toml
+++ b/crates/polars-sql/Cargo.toml
@@ -12,7 +12,7 @@ description = "SQL transpiler for Polars. Converts SQL to Polars logical plans"
 arrow = { workspace = true }
 polars-core = { workspace = true }
 polars-error = { workspace = true }
-polars-lazy = { workspace = true, features = ["strings", "cross_join", "trigonometry", "abs", "round_series", "log", "regex", "is_in", "meta", "cum_agg"] }
+polars-lazy = { workspace = true, features = ["strings", "cross_join", "trigonometry", "abs", "round_series", "log", "regex", "is_in", "meta", "cum_agg", "dtype-date"] }
 polars-plan = { workspace = true }
 
 rand = { workspace = true }

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -217,8 +217,14 @@ pub(crate) enum PolarsSqlFunctions {
     /// ```
     Radians,
 
+    // ----
     // Date Functions
     // ----
+    /// SQL 'date' function
+    /// ```sql
+    /// SELECT DATE('2021-03-15') from df;
+    /// SELECT DATE('2021-03', '%Y-%m') from df;
+    /// ```
     Date,
 
     // ----

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -2,8 +2,8 @@ use polars_core::prelude::{polars_bail, polars_err, PolarsResult};
 use polars_lazy::dsl::Expr;
 use polars_plan::dsl::{coalesce, count, when};
 use polars_plan::logical_plan::LiteralValue;
-use polars_plan::prelude::lit;
 use polars_plan::prelude::LiteralValue::Null;
+use polars_plan::prelude::{lit, StrptimeOptions};
 use sqlparser::ast::{
     Expr as SqlExpr, Function as SQLFunction, FunctionArg, FunctionArgExpr, Value as SqlValue,
     WindowSpec, WindowType,
@@ -216,6 +216,10 @@ pub(crate) enum PolarsSqlFunctions {
     /// SELECT radians(column_1) from df;
     /// ```
     Radians,
+
+    // Date Functions
+    // ----
+    Date,
 
     // ----
     // String functions
@@ -471,6 +475,7 @@ impl PolarsSqlFunctions {
             "cot",
             "cotd",
             "count",
+            "date",
             "degrees",
             "ends_with",
             "exp",
@@ -558,6 +563,11 @@ impl PolarsSqlFunctions {
             // ----
             "nullif" => Self::NullIf,
             "coalesce" => Self::Coalesce,
+
+            // ----
+            // Date functions
+            // ----
+            "date" => Self::Date,
 
             // ----
             // String functions
@@ -717,6 +727,14 @@ impl SqlFunctionVisitor<'_> {
                         true))
                 }),
                 _ => polars_bail!(InvalidOperation:"Invalid number of arguments for RegexpLike: {}",function.args.len()),
+            },
+            Date => match function.args.len() {
+                1 => self.visit_unary(|e| e.str().to_date(StrptimeOptions::default())),
+                2 => self.visit_binary(|e, fmt| e.str().to_date(fmt)),
+                _ => polars_bail!(InvalidOperation:
+                    "Invalid number of arguments for Date: {}",
+                    function.args.len()
+                ),
             },
             RTrim => match function.args.len() {
                 1 => self.visit_unary(|e| e.str().strip_chars_end(lit(Null))),
@@ -1069,6 +1087,24 @@ impl FromSqlExpr for String {
         match expr {
             SqlExpr::Value(v) => match v {
                 SqlValue::SingleQuotedString(s) => Ok(s.clone()),
+                _ => polars_bail!(ComputeError: "can't parse literal {:?}", v),
+            },
+            _ => polars_bail!(ComputeError: "can't parse literal {:?}", expr),
+        }
+    }
+}
+
+impl FromSqlExpr for StrptimeOptions {
+    fn from_sql_expr(expr: &SqlExpr, _: &mut SQLContext) -> PolarsResult<Self>
+    where
+        Self: Sized,
+    {
+        match expr {
+            SqlExpr::Value(v) => match v {
+                SqlValue::SingleQuotedString(s) => Ok(StrptimeOptions {
+                    format: Some(s.clone()),
+                    ..StrptimeOptions::default()
+                }),
                 _ => polars_bail!(ComputeError: "can't parse literal {:?}", v),
             },
             _ => polars_bail!(ComputeError: "can't parse literal {:?}", expr),

--- a/py-polars/tests/unit/sql/test_sql.py
+++ b/py-polars/tests/unit/sql/test_sql.py
@@ -1232,3 +1232,23 @@ def test_sql_date() -> None:
     assert pl.select(
         pl.sql_expr("""CAST(DATE('2023-03', '%Y-%m') as STRING)""")
     ).frame_equal(expected)
+
+
+@pytest.mark.parametrize("match_float", [False, True])
+def test_sql_unary_ops_8890(match_float: bool) -> None:
+    with pl.SQLContext(
+        df=pl.DataFrame({"a": [-2, -1, 1, 2], "b": ["w", "x", "y", "z"]}),
+    ) as ctx:
+        in_values = "(-3.0, -1.0, +2.0, +4.0)" if match_float else "(-3, -1, +2, +4)"
+        res = ctx.execute(
+            f"""
+            SELECT *, -(3) as c, (+4) as d
+            FROM df WHERE a IN {in_values}
+            """
+        )
+        assert res.collect().to_dict(False) == {
+            "a": [-1, 2],
+            "b": ["x", "z"],
+            "c": [-3, -3],
+            "d": [4, 4],
+        }

--- a/py-polars/tests/unit/sql/test_sql.py
+++ b/py-polars/tests/unit/sql/test_sql.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 import math
 from pathlib import Path
 
@@ -1208,3 +1209,26 @@ def test_sql_unary_ops_8890(match_float: bool) -> None:
             "c": [-3, -3],
             "d": [4, 4],
         }
+
+def test_sql_date() -> None:
+    df = pl.DataFrame(
+        {
+            "date": [
+                datetime.date(2021, 3, 15),
+                datetime.date(2021, 3, 28),
+                datetime.date(2021, 4, 4),
+            ],
+            "version": ["0.0.1", "0.7.3", "0.7.4"],
+        }
+    )
+
+    with pl.SQLContext(df=df, eager_execution=True) as ctx:
+        expected = pl.DataFrame({"date": [True, False, False]})
+        assert ctx.execute("SELECT date < DATE('2021-03-20') from df").frame_equal(
+            expected
+        )
+
+    expected = pl.DataFrame({"literal": ["2023-03-01"]})
+    assert pl.select(
+        pl.sql_expr("""CAST(DATE('2023-03', '%Y-%m') as STRING)""")
+    ).frame_equal(expected)

--- a/py-polars/tests/unit/sql/test_sql.py
+++ b/py-polars/tests/unit/sql/test_sql.py
@@ -1210,6 +1210,7 @@ def test_sql_unary_ops_8890(match_float: bool) -> None:
             "d": [4, 4],
         }
 
+
 def test_sql_date() -> None:
     df = pl.DataFrame(
         {
@@ -1232,23 +1233,3 @@ def test_sql_date() -> None:
     assert pl.select(
         pl.sql_expr("""CAST(DATE('2023-03', '%Y-%m') as STRING)""")
     ).frame_equal(expected)
-
-
-@pytest.mark.parametrize("match_float", [False, True])
-def test_sql_unary_ops_8890(match_float: bool) -> None:
-    with pl.SQLContext(
-        df=pl.DataFrame({"a": [-2, -1, 1, 2], "b": ["w", "x", "y", "z"]}),
-    ) as ctx:
-        in_values = "(-3.0, -1.0, +2.0, +4.0)" if match_float else "(-3, -1, +2, +4)"
-        res = ctx.execute(
-            f"""
-            SELECT *, -(3) as c, (+4) as d
-            FROM df WHERE a IN {in_values}
-            """
-        )
-        assert res.collect().to_dict(False) == {
-            "a": [-1, 2],
-            "b": ["x", "z"],
-            "c": [-3, -3],
-            "d": [4, 4],
-        }


### PR DESCRIPTION
https://stackoverflow.com/questions/77227895/polars-sql-context-filter-by-date-or-datetime

This was a recent question on SO and the mentioned `DATE` function doesn't seem to exist yet.

I was interested in seeing how `polars-sql` worked and thought I'd have a look.
```python
import datetime
import polars as pl

df = pl.DataFrame({
    "date": [
        datetime.date(2021, 3, 15),
        datetime.date(2021, 3, 28),
        datetime.date(2021, 4, 4),
     ],
     "version": ["0.0.1", "0.7.3", "0.7.4"]
})

with pl.SQLContext(df=df, eager_execution=True) as ctx:
    print(ctx.execute("""SELECT *, date < DATE('2021-03-20') AS "alpha" from df"""))

# shape: (3, 3)
# ┌────────────┬─────────┬───────┐
# │ date       ┆ version ┆ alpha │
# │ ---        ┆ ---     ┆ ---   │
# │ date       ┆ str     ┆ bool  │
# ╞════════════╪═════════╪═══════╡
# │ 2021-03-15 ┆ 0.0.1   ┆ true  │
# │ 2021-03-28 ┆ 0.7.3   ┆ false │
# │ 2021-04-04 ┆ 0.7.4   ┆ false │
# └────────────┴─────────┴───────┘
```
Should `DATETIME` also be added as part of this? 