### PR TITLE
ci(python): Remove toolchain specification workaround

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -153,9 +153,6 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           command: build
-          # Temporarily pin Rust toolchain version here due to bug:
-          # https://github.com/PyO3/maturin-action/issues/215
-          rust-toolchain: nightly-2023-10-02
           target: ${{ steps.target.outputs.target }}
           args: >
             --release


### PR DESCRIPTION
This [issue](https://github.com/PyO3/maturin-action/issues/215) was fixed, so this workaround is no longer necessary.