### PR TITLE
feat(python): support `read_database` options passthrough to the underlying connection's `execute` method (enables parameterised SQL queries, etc)

### DIFF
--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -351,7 +351,7 @@ def read_database(  # noqa D417
         instead of `i64`).
     execute_options
         These options will be passed through into the underlying query execution method
-        as **kwargs. In the case of connections made using an ODBC string (which use
+        as kwargs. In the case of connections made using an ODBC string (which use
         `arrow-odbc`) these options are passed to the ``read_arrow_batches_from_odbc``
         method.
 

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, Iterable, Sequence, TypedDict
 from polars.convert import from_arrow
 from polars.exceptions import UnsuitableSQLError
 from polars.utils.deprecation import (
-    deprecate_nonkeyword_arguments,
     deprecate_renamed_parameter,
     issue_deprecation_warning,
 )
@@ -94,13 +93,15 @@ class ODBCCursorProxy:
 
     def __init__(self, connection_string: str) -> None:
         self.connection_string = connection_string
+        self.execute_options: dict[str, Any] = {}
         self.query: str | None = None
 
     def close(self) -> None:
         """Close the cursor (n/a: nothing to close)."""
 
-    def execute(self, query: str) -> None:
+    def execute(self, query: str, **execute_options: Any) -> None:
         """Execute a query (n/a: just store query for the fetch* methods)."""
+        self.execute_options = execute_options
         self.query = query
 
     def fetchmany(
@@ -113,8 +114,10 @@ class ODBCCursorProxy:
             query=self.query,
             batch_size=batch_size,
             connection_string=self.connection_string,
+            **self.execute_options,
         )
 
+    # internally arrow-odbc always reads batches
     fetchall = fetchmany
 
 
@@ -257,9 +260,12 @@ class ConnectionExecutor:
             )
         return None
 
-    @deprecate_nonkeyword_arguments(allowed_args=["self", "query"], version="0.19.3")
     def execute(
-        self, query: str | Selectable, select_queries_only: bool = True  # noqa: FBT001
+        self,
+        query: str | Selectable,
+        *,
+        options: dict[str, Any] | None = None,
+        select_queries_only: bool = True,
     ) -> Self:
         """Execute a query and reference the result set."""
         if select_queries_only and isinstance(query, str):
@@ -274,7 +280,7 @@ class ConnectionExecutor:
 
             query = text(query)  # type: ignore[assignment]
 
-        if (result := self.cursor.execute(query)) is None:
+        if (result := self.cursor.execute(query, **(options or {}))) is None:
             result = self.cursor  # some cursors execute in-place
 
         self.result = result
@@ -306,12 +312,13 @@ class ConnectionExecutor:
 
 
 @deprecate_renamed_parameter("connection_uri", "connection", version="0.18.9")
-def read_database(  # noqa: D417
+def read_database(  # noqa D417
     query: str | Selectable,
     connection: ConnectionOrCursor | str,
     *,
     batch_size: int | None = None,
     schema_overrides: SchemaDict | None = None,
+    execute_options: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> DataFrame:
     """
@@ -324,8 +331,9 @@ def read_database(  # noqa: D417
         be a suitable "Selectable", otherwise it is expected to be a string).
     connection
         An instantiated connection (or cursor/client object) that the query can be
-        executed against. Can also pass a valid ODBC connection string here, if you
-        have installed the ``arrow-odbc`` driver/package.
+        executed against. Can also pass a valid ODBC connection string, starting with
+        "Driver=", in which case the ``arrow-odbc`` package will be used to establish
+        the connection and return Arrow-native data to Polars.
     batch_size
         Enable batched data fetching (internally) instead of collecting all rows at
         once; this can be helpful for minimising the peak memory used for very large
@@ -341,6 +349,11 @@ def read_database(  # noqa: D417
         on driver/backend). This can be useful if the given types can be more precisely
         defined (for example, if you know that a given column can be declared as `u32`
         instead of `i64`).
+    execute_options
+        These options will be passed through into the underlying query execution method
+        as **kwargs. In the case of connections made using an ODBC string (which use
+        `arrow-odbc`) these options are passed to the ``read_arrow_batches_from_odbc``
+        method.
 
     Notes
     -----
@@ -356,7 +369,7 @@ def read_database(  # noqa: D417
       more details about using this driver (notable databases implementing Flight SQL
       include Dremio and InfluxDB).
 
-    * The ``read_connection_uri`` function is likely to be noticeably faster than
+    * The ``read_database_uri`` function is likely to be noticeably faster than
       ``read_database`` if you are using a SQLAlchemy or DBAPI2 connection, as
       ``connectorx`` will optimise translation of the result set into Arrow format
       in Rust, whereas these libraries will return row-wise data to Python *before*
@@ -381,15 +394,26 @@ def read_database(  # noqa: D417
     ...     schema_overrides={"normalised_score": pl.UInt8},
     ... )  # doctest: +SKIP
 
-    Instantiate a DataFrame using an ODBC connection string (requires ``arrow-odbc``):
+    Use a parameterised SQLAlchemy query, passing values via ``execute_options``:
+
+    >>> df = pl.read_database(
+    ...     query="SELECT * FROM test_data WHERE metric > :value",
+    ...     connection=alchemy_conn,
+    ...     execute_options={"parameters": {"value": 0}},
+    ... )  # doctest: +SKIP
+
+    Instantiate a DataFrame using an ODBC connection string (requires ``arrow-odbc``)
+    and set upper limits on the buffer size of variadic text/binary columns:
 
     >>> df = pl.read_database(
     ...     query="SELECT * FROM test_data",
     ...     connection="Driver={PostgreSQL};Server=localhost;Port=5432;Database=test;Uid=usr;Pwd=",
+    ...     execute_options={"max_text_size": 512, "max_binary_size": 1024},
     ... )  # doctest: +SKIP
 
     """  # noqa: W505
     if isinstance(connection, str):
+        # check for odbc connection string
         if re.sub(r"\s", "", connection[:20]).lower().startswith("driver="):
             try:
                 import arrow_odbc  # noqa: F401
@@ -401,6 +425,7 @@ def read_database(  # noqa: D417
 
             connection = ODBCCursorProxy(connection)
         else:
+            # otherwise looks like a call to read_database_uri
             issue_deprecation_warning(
                 message="Use of a string URI with 'read_database' is deprecated; use 'read_database_uri' instead",
                 version="0.19.0",
@@ -410,16 +435,25 @@ def read_database(  # noqa: D417
                     f"`read_database_uri` expects one or more string queries; found {type(query)}"
                 )
             return read_database_uri(
-                query, uri=connection, schema_overrides=schema_overrides, **kwargs
+                query,
+                uri=connection,
+                schema_overrides=schema_overrides,
+                **kwargs,
             )
 
+    # note: can remove this check (and **kwargs) once we drop the
+    # pass-through deprecation support for read_database_uri
     if kwargs:
         raise ValueError(
             f"`read_database` **kwargs only exist for passthrough to `read_database_uri`: found {kwargs!r}"
         )
 
+    # return frame from arbitrary connections using the executor abstraction
     with ConnectionExecutor(connection) as cx:
-        return cx.execute(query).to_frame(
+        return cx.execute(
+            query=query,
+            options=execute_options,
+        ).to_frame(
             batch_size=batch_size,
             schema_overrides=schema_overrides,
         )

--- a/py-polars/tests/unit/io/test_database_read.py
+++ b/py-polars/tests/unit/io/test_database_read.py
@@ -6,10 +6,11 @@ import sys
 from contextlib import suppress
 from datetime import date
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import pytest
-from sqlalchemy import MetaData, Table, create_engine, select
+from sqlalchemy import Integer, MetaData, Table, create_engine, func, select
+from sqlalchemy.sql.expression import cast as alchemy_cast
 
 import polars as pl
 from polars.exceptions import UnsuitableSQLError
@@ -229,25 +230,41 @@ def test_read_database(
 def test_read_database_alchemy_selectable(tmp_path: Path) -> None:
     # setup underlying test data
     tmp_path.mkdir(exist_ok=True)
-    test_db = str(tmp_path / "test.db")
-    create_temp_sqlite_db(test_db)
-
-    # establish alchemy query
+    create_temp_sqlite_db(test_db := str(tmp_path / "test.db"))
     conn = create_engine(f"sqlite:///{test_db}")
     t = Table("test_data", MetaData(), autoload_with=conn)
-    alchemy_query = select(t.c.date, t.c.name, t.c.value).where(t.c.value < 0)
 
-    # validate read_database with alchemy "selectable"
-    df = pl.read_database(alchemy_query, connection=conn.connect())
+    # establish sqlalchemy "selectable" and validate usage
+    selectable_query = select(
+        alchemy_cast(func.strftime("%Y", t.c.date), Integer).label("year"),
+        t.c.name,
+        t.c.value,
+    ).where(t.c.value < 0)
+
     assert_frame_equal(
-        df,
-        pl.DataFrame(
-            {
-                "date": [date(2021, 12, 31)],
-                "name": ["other"],
-                "value": [-99.5],
-            },
+        pl.read_database(selectable_query, connection=conn.connect()),
+        pl.DataFrame({"year": [2021], "name": ["other"], "value": [-99.5]}),
+    )
+
+
+def test_read_database_parameterisd(tmp_path: Path) -> None:
+    # setup underlying test data
+    tmp_path.mkdir(exist_ok=True)
+    create_temp_sqlite_db(test_db := str(tmp_path / "test.db"))
+    conn = create_engine(f"sqlite:///{test_db}")
+
+    # establish a parameterised query and validate usage
+    parameterised_query = """
+        SELECT CAST(STRFTIME('%Y',"date") AS INT) as "year", name, value
+        FROM test_data WHERE value < :n
+    """
+    assert_frame_equal(
+        pl.read_database(
+            parameterised_query,
+            connection=conn.connect(),
+            execute_options={"parameters": {"n": 0}},
         ),
+        pl.DataFrame({"year": [2021], "name": ["other"], "value": [-99.5]}),
     )
 
 
@@ -309,98 +326,162 @@ def test_read_database_mocked() -> None:
         assert df.rows() == [(1, "aa"), (2, "bb"), (3, "cc")]
 
 
+class ExceptionTestParams(NamedTuple):
+    """Clarify exception testing params."""
+
+    read_method: str
+    query: str | list[str]
+    protocol: Any
+    errclass: type[Exception]
+    errmsg: str
+    engine: str | None = None
+    execute_options: dict[str, Any] | None = None
+    kwargs: dict[str, Any] | None = None
+
+
 @pytest.mark.parametrize(
-    ("read_method", "engine", "query", "database", "errclass", "err"),
+    (
+        "read_method",
+        "query",
+        "protocol",
+        "errclass",
+        "errmsg",
+        "engine",
+        "execute_options",
+        "kwargs",
+    ),
     [
         pytest.param(
-            "read_database_uri",
-            "not_an_engine",
-            "SELECT * FROM test_data",
-            "sqlite",
-            ValueError,
-            "engine must be one of {'connectorx', 'adbc'}, got 'not_an_engine'",
+            *ExceptionTestParams(
+                read_method="read_database_uri",
+                query="SELECT * FROM test_data",
+                protocol="sqlite",
+                errclass=ValueError,
+                errmsg="engine must be one of {'connectorx', 'adbc'}, got 'not_an_engine'",
+                engine="not_an_engine",
+            ),
             id="Not an available sql engine",
         ),
         pytest.param(
-            "read_database_uri",
-            "adbc",
-            ["SELECT * FROM test_data", "SELECT * FROM test_data"],
-            "sqlite",
-            ValueError,
-            "only a single SQL query string is accepted for adbc",
+            *ExceptionTestParams(
+                read_method="read_database_uri",
+                query=["SELECT * FROM test_data", "SELECT * FROM test_data"],
+                protocol="sqlite",
+                errclass=ValueError,
+                errmsg="only a single SQL query string is accepted for adbc",
+                engine="adbc",
+            ),
             id="Unavailable list of queries for adbc",
         ),
         pytest.param(
-            "read_database_uri",
-            "adbc",
-            "SELECT * FROM test_data",
-            "mysql",
-            ImportError,
-            "ADBC mysql driver not detected",
+            *ExceptionTestParams(
+                read_method="read_database_uri",
+                query="SELECT * FROM test_data",
+                protocol="mysql",
+                errclass=ImportError,
+                errmsg="ADBC mysql driver not detected",
+                engine="adbc",
+            ),
             id="Unavailable adbc driver",
         ),
         pytest.param(
-            "read_database_uri",
-            "adbc",
-            "SELECT * FROM test_data",
-            sqlite3.connect(":memory:"),
-            TypeError,
-            "expected connection to be a URI string",
+            *ExceptionTestParams(
+                read_method="read_database_uri",
+                query="SELECT * FROM test_data",
+                protocol=sqlite3.connect(":memory:"),
+                errclass=TypeError,
+                errmsg="expected connection to be a URI string",
+                engine="adbc",
+            ),
             id="Invalid connection URI",
         ),
         pytest.param(
-            "read_database",
-            None,
-            "SELECT * FROM imaginary_table",
-            sqlite3.connect(":memory:"),
-            sqlite3.OperationalError,
-            "no such table: imaginary_table",
+            *ExceptionTestParams(
+                read_method="read_database",
+                query="SELECT * FROM imaginary_table",
+                protocol=sqlite3.connect(":memory:"),
+                errclass=sqlite3.OperationalError,
+                errmsg="no such table: imaginary_table",
+            ),
+            id="Invalid query (unrecognised table name)",
+        ),
+        pytest.param(
+            *ExceptionTestParams(
+                read_method="read_database",
+                query="SELECT * FROM imaginary_table",
+                protocol=sys.getsizeof,  # not a connection
+                errclass=TypeError,
+                errmsg="Unrecognised connection .* unable to find 'execute' method",
+            ),
             id="Invalid read DB kwargs",
         ),
         pytest.param(
-            "read_database",
-            None,
-            "SELECT * FROM imaginary_table",
-            sys.getsizeof,  # not a connection
-            TypeError,
-            "Unrecognised connection .* unable to find 'execute' method",
-            id="Invalid read DB kwargs",
-        ),
-        pytest.param(
-            "read_database",
-            None,
-            "/* tag: misc */ INSERT INTO xyz VALUES ('polars')",
-            sqlite3.connect(":memory:"),
-            UnsuitableSQLError,
-            "INSERT statements are not valid 'read' queries",
+            *ExceptionTestParams(
+                read_method="read_database",
+                query="/* tag: misc */ INSERT INTO xyz VALUES ('polars')",
+                protocol=sqlite3.connect(":memory:"),
+                errclass=UnsuitableSQLError,
+                errmsg="INSERT statements are not valid 'read' queries",
+            ),
             id="Invalid statement type",
         ),
         pytest.param(
-            "read_database",
-            None,
-            "DELETE FROM xyz WHERE id = 'polars'",
-            sqlite3.connect(":memory:"),
-            UnsuitableSQLError,
-            "DELETE statements are not valid 'read' queries",
+            *ExceptionTestParams(
+                read_method="read_database",
+                query="DELETE FROM xyz WHERE id = 'polars'",
+                protocol=sqlite3.connect(":memory:"),
+                errclass=UnsuitableSQLError,
+                errmsg="DELETE statements are not valid 'read' queries",
+            ),
             id="Invalid statement type",
+        ),
+        pytest.param(
+            *ExceptionTestParams(
+                read_method="read_database",
+                engine="adbc",
+                query="SELECT * FROM test_data",
+                protocol=sqlite3.connect(":memory:"),
+                errclass=TypeError,
+                errmsg="takes no keyword arguments",
+                execute_options={"parameters": {"n": 0}},
+            ),
+            id="Invalid execute_options",
+        ),
+        pytest.param(
+            *ExceptionTestParams(
+                read_method="read_database",
+                engine="adbc",
+                query="SELECT * FROM test_data",
+                protocol=sqlite3.connect(":memory:"),
+                errclass=ValueError,
+                errmsg=r"`read_database` \*\*kwargs only exist for passthrough to `read_database_uri`",
+                kwargs={"partition_on": "id"},
+            ),
+            id="Invalid kwargs",
         ),
     ],
 )
 def test_read_database_exceptions(
     read_method: str,
-    engine: DbReadEngine | None,
     query: str,
-    database: Any,
-    errclass: type,
-    err: str,
+    protocol: Any,
+    errclass: type[Exception],
+    errmsg: str,
+    engine: DbReadEngine | None,
+    execute_options: dict[str, Any] | None,
+    kwargs: dict[str, Any] | None,
     tmp_path: Path,
 ) -> None:
     if read_method == "read_database_uri":
-        conn = f"{database}://test" if isinstance(database, str) else database
+        conn = f"{protocol}://test" if isinstance(protocol, str) else protocol
         params = {"uri": conn, "query": query, "engine": engine}
     else:
-        params = {"connection": database, "query": query}
+        params = {"connection": protocol, "query": query}
+        if execute_options:
+            params["execute_options"] = execute_options
+        if kwargs is not None:
+            params.update(kwargs)
 
     read_database = getattr(pl, read_method)
-    with pytest.raises(errclass, match=err):
+    with pytest.raises(errclass, match=errmsg):
         read_database(**params)


### PR DESCRIPTION
Closes #7376 and closes #10835.

Continuing to build-out database connectivity; this PR adds support for passthrough of arbitrary parameters to the underlying connection's `execute`.

This enables clean support for _parameterised_ SQL queries (amongst other things, such as control over `arrow-odbc` varchar/binary max buffer length[^1], and more).

Added test coverage for both the feature itself and new potential error conditions.

## Examples

Parameterised `sqlalchemy` query:
```python
df = pl.read_database(
    connection = alchemy_connection,
    query = "SELECT * FROM tbl WHERE metric > :value",
    execute_options = {"parameters": {"value": 0}},
)
```
Custom `arrow-odbc` upper limits on text/binary buffers bound to variadic columns:
```python
df = pl.read_database(
    connection = odbc_connection_string,
    query = "SELECT * FROM tbl",
    execute_options = {"max_text_size": 512, "max_binary_size": 1024},
)
```

[^1]: https://github.com/pola-rs/polars/pull/11448#issuecomment-1750098985