### PR TITLE
fix(rust,python,cli): don't conflate supported UNION ops in the SQL parser with (currently) unsupported UNION "BY NAME" variations

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -209,8 +209,12 @@ impl SQLContext {
         match quantifier {
             // UNION ALL
             SetQuantifier::All => concatenated,
-            // UNION DISTINCT | UNION
-            _ => concatenated.map(|lf| lf.unique(None, UniqueKeepStrategy::Any)),
+            // UNION [DISTINCT]
+            SetQuantifier::Distinct | SetQuantifier::None => {
+                concatenated.map(|lf| lf.unique(None, UniqueKeepStrategy::Any))
+            },
+            // TODO: support "UNION [ALL] BY NAME"
+            _ => polars_bail!(InvalidOperation: "UNION {} is not yet supported", quantifier),
         }
     }
 


### PR DESCRIPTION
Ref: https://github.com/pola-rs/polars/issues/9370.

Will come back to this and add proper `UNION BY NAME` and `UNION ALL BY NAME` support later, but we currently silently conflate both of these variations with `UNION [DISTINCT]`.

This PR catches such usage and raises a suitable error, eg:
```
InvalidOperationError: UNION [ALL] BY NAME not yet supported
```
(Will also notice any future flavours of `UNION` that we don't explicitly support, should any new ones be added to the parser later).