### PR TITLE
feat(rust, python): let "ambiguous" take "null" value

### DIFF
--- a/crates/polars-arrow/src/kernels/time.rs
+++ b/crates/polars-arrow/src/kernels/time.rs
@@ -7,13 +7,14 @@ pub fn convert_to_naive_local(
     to_tz: &Tz,
     ndt: NaiveDateTime,
     ambiguous: &str,
-) -> Result<NaiveDateTime> {
+) -> Result<Option<NaiveDateTime>> {
     let ndt = from_tz.from_utc_datetime(&ndt).naive_local();
     match to_tz.from_local_datetime(&ndt) {
-        LocalResult::Single(dt) => Ok(dt.naive_utc()),
+        LocalResult::Single(dt) => Ok(Some(dt.naive_utc())),
         LocalResult::Ambiguous(dt_earliest, dt_latest) => match ambiguous {
-            "earliest" => Ok(dt_earliest.naive_utc()),
-            "latest" => Ok(dt_latest.naive_utc()),
+            "null" => Ok(None),
+            "earliest" => Ok(Some(dt_earliest.naive_utc())),
+            "latest" => Ok(Some(dt_latest.naive_utc())),
             "raise" => Err(ArrowError::InvalidArgumentError(
                 format!("datetime '{}' is ambiguous in time zone '{}'. Please use `ambiguous` to tell how it should be localized.", ndt, to_tz)
             )),

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -61,6 +61,7 @@ class ExprDateTimeNameSpace:
             - ``'raise'`` (default): raise
             - ``'earliest'``: use the earliest datetime
             - ``'latest'``: use the latest datetime
+            - ``'null'``: set to null
 
         Notes
         -----
@@ -264,6 +265,7 @@ class ExprDateTimeNameSpace:
             - ``'raise'`` (default): raise
             - ``'earliest'``: use the earliest datetime
             - ``'latest'``: use the latest datetime
+            - ``'null'``: set to null
 
         Notes
         -----
@@ -1379,6 +1381,7 @@ class ExprDateTimeNameSpace:
             - ``'raise'`` (default): raise
             - ``'earliest'``: use the earliest datetime
             - ``'latest'``: use the latest datetime
+            - ``'null'``: set to null
 
         Examples
         --------

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -137,6 +137,7 @@ class ExprStringNameSpace:
             - ``'raise'`` (default): raise
             - ``'earliest'``: use the earliest datetime
             - ``'latest'``: use the latest datetime
+            - ``'null'``: set to null
 
         Examples
         --------
@@ -252,6 +253,7 @@ class ExprStringNameSpace:
             - ``'raise'`` (default): raise
             - ``'earliest'``: use the earliest datetime
             - ``'latest'``: use the latest datetime
+            - ``'null'``: set to null
 
         Notes
         -----

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -75,7 +75,7 @@ def datetime_(
         - ``'raise'`` (default): raise
         - ``'earliest'``: use the earliest datetime
         - ``'latest'``: use the latest datetime
-
+        - ``'null'``: set to null
 
     Returns
     -------

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1028,6 +1028,7 @@ class DateTimeNameSpace:
             - ``'raise'`` (default): raise
             - ``'earliest'``: use the earliest datetime
             - ``'latest'``: use the latest datetime
+            - ``'null'``: set to null
 
         Examples
         --------
@@ -1468,6 +1469,7 @@ class DateTimeNameSpace:
             - ``'raise'`` (default): raise
             - ``'earliest'``: use the earliest datetime
             - ``'latest'``: use the latest datetime
+            - ``'null'``: set to null
 
         Notes
         -----
@@ -1667,6 +1669,7 @@ class DateTimeNameSpace:
             - ``'raise'`` (default): raise
             - ``'earliest'``: use the earliest datetime
             - ``'latest'``: use the latest datetime
+            - ``'null'``: set to null
 
         Returns
         -------

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -137,6 +137,7 @@ class StringNameSpace:
             - ``'raise'`` (default): raise
             - ``'earliest'``: use the earliest datetime
             - ``'latest'``: use the latest datetime
+            - ``'null'``: set to null
 
         Examples
         --------
@@ -235,6 +236,7 @@ class StringNameSpace:
             - ``'raise'`` (default): raise
             - ``'earliest'``: use the earliest datetime
             - ``'latest'``: use the latest datetime
+            - ``'null'``: set to null
 
         Notes
         -----

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -144,7 +144,7 @@ ToStructStrategy: TypeAlias = Literal[
 ]  # ListToStructWidthStrategy
 
 # The following have no equivalent on the Rust side
-Ambiguous: TypeAlias = Literal["earliest", "latest", "raise"]
+Ambiguous: TypeAlias = Literal["earliest", "latest", "raise", "null"]
 ConcatMethod = Literal[
     "vertical", "vertical_relaxed", "diagonal", "horizontal", "align"
 ]


### PR DESCRIPTION
Suggested by @stinodego [here](https://github.com/pola-rs/polars/issues/10090#issuecomment-1676164681), but also:
- 'null' may need adding anyway for dealing with non-existent datetimes gracefully (https://github.com/pola-rs/polars/issues/11579#issuecomment-1752541589)
- this matches `ambiguous='NaT'` from pandas

Demo:
```python
In [7]: df = pl.DataFrame({
   ...:     'ts': pl.datetime_range(datetime(2020, 10, 25), datetime(2020, 10, 25, 6), '1h', eager=True),
   ...:     })

In [8]: df
Out[8]: 
shape: (7, 1)
┌─────────────────────┐
│ ts                  │
│ ---                 │
│ datetime[μs]        │
╞═════════════════════╡
│ 2020-10-25 00:00:00 │
│ 2020-10-25 01:00:00 │
│ 2020-10-25 02:00:00 │
│ 2020-10-25 03:00:00 │
│ 2020-10-25 04:00:00 │
│ 2020-10-25 05:00:00 │
│ 2020-10-25 06:00:00 │
└─────────────────────┘

In [9]: df.with_columns(
   ...:     ts_replaced = pl.col('ts').dt.replace_time_zone('Europe/London', ambiguous='null')
   ...: )
Out[9]: 
shape: (7, 2)
┌─────────────────────┬─────────────────────────────┐
│ ts                  ┆ ts_replaced                 │
│ ---                 ┆ ---                         │
│ datetime[μs]        ┆ datetime[μs, Europe/London] │
╞═════════════════════╪═════════════════════════════╡
│ 2020-10-25 00:00:00 ┆ 2020-10-25 00:00:00 BST     │
│ 2020-10-25 01:00:00 ┆ null                        │
│ 2020-10-25 02:00:00 ┆ 2020-10-25 02:00:00 GMT     │
│ 2020-10-25 03:00:00 ┆ 2020-10-25 03:00:00 GMT     │
│ 2020-10-25 04:00:00 ┆ 2020-10-25 04:00:00 GMT     │
│ 2020-10-25 05:00:00 ┆ 2020-10-25 05:00:00 GMT     │
│ 2020-10-25 06:00:00 ┆ 2020-10-25 06:00:00 GMT     │
└─────────────────────┴─────────────────────────────┘
```