### PR TITLE
fix(python): preserve empty string '' column name in from_arrow

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1448,14 +1448,15 @@ def arrow_to_pydf(
         (schema or data.column_names), schema_overrides=schema_overrides
     )
 
-    try:
-        empty_str_idx = (
-            schema.names if schema is not None else data.column_names
-        ).index("")
-        column_names[empty_str_idx] = ""
+    empty_str_idx = None
 
-    except ValueError:
-        empty_str_idx = None
+    if schema is None:
+        try:
+            empty_str_idx = data.column_names.index("")
+            column_names[empty_str_idx] = ""
+
+        except ValueError:
+            pass
 
     try:
         if column_names != data.column_names:

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -708,10 +708,7 @@ def _unpack_schema(
         # coerce schema to list[str | tuple[str, PolarsDataType | PythonDataType | None]
         schema = list(schema.items())
     else:
-        column_names = [
-            (col or f"column_{i}") if isinstance(col, str) else col[0]
-            for i, col in enumerate(schema)
-        ]
+        column_names = [col if isinstance(col, str) else col[0] for col in schema]
 
     # determine column dtypes from schema and lookup_names
     lookup: dict[str, str] | None = (

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -476,6 +476,11 @@ def test_from_arrow() -> None:
     assert df.rows() == [(1, 4), (2, 5), (3, 6)]  # type: ignore[union-attr]
     assert df.schema == {"a": pl.UInt32, "b": pl.UInt64}  # type: ignore[union-attr]
 
+    # empty string column name
+    df = pl.select(pl.Series("", [1], pl.Int8))
+    assert pl.DataFrame(df.to_arrow()).schema == df.schema
+    assert pl.DataFrame(df.head(0).to_arrow()).schema == df.schema
+
 
 def test_from_pandas_dataframe() -> None:
     pd_df = pd.DataFrame([[1, 2, 3], [4, 5, 6]], columns=["a", "b", "c"])
@@ -1121,9 +1126,3 @@ def test_from_arrow_invalid_time_zone() -> None:
     )
     with pytest.raises(ComputeError, match=r"unable to parse time zone: '\+01:00'"):
         pl.from_arrow(arr)
-
-
-def test_empty_string_column_name_from_arrow() -> None:
-    df = pl.DataFrame(schema={"": pl.Int8, "a": pl.Int8})
-
-    assert pl.DataFrame(df.to_arrow()).schema == df.schema

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -1121,3 +1121,9 @@ def test_from_arrow_invalid_time_zone() -> None:
     )
     with pytest.raises(ComputeError, match=r"unable to parse time zone: '\+01:00'"):
         pl.from_arrow(arr)
+
+
+def test_empty_string_column_name_from_arrow() -> None:
+    df = pl.DataFrame(schema={"": pl.Int8, "a": pl.Int8})
+
+    assert pl.from_arrow(df.to_arrow()).schema == df.schema

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -1126,4 +1126,4 @@ def test_from_arrow_invalid_time_zone() -> None:
 def test_empty_string_column_name_from_arrow() -> None:
     df = pl.DataFrame(schema={"": pl.Int8, "a": pl.Int8})
 
-    assert pl.from_arrow(df.to_arrow()).schema == df.schema
+    assert pl.DataFrame(df.to_arrow()).schema == df.schema


### PR DESCRIPTION
Ran into this when using `read_csv(..., use_pyarrow=True)`:

```python
pl.read_csv(
    """\
,1
1,1\
""".encode(),
    use_pyarrow=True,
)
```

Before:
```
shape: (1, 2)
┌──────────┬─────┐
│ column_0 ┆ 1   │
│ ---      ┆ --- │
│ i64      ┆ i64 │
╞══════════╪═════╡
│ 1        ┆ 1   │
└──────────┴─────┘
```

After (now matches behavior of `read_csv(..., use_pyarrow=False)`):
```
shape: (1, 2)
┌─────┬─────┐
│     ┆ 1   │
│ --- ┆ --- │
│ i64 ┆ i64 │
╞═════╪═════╡
│ 1   ┆ 1   │
└─────┴─────┘
```