### PR TITLE
refactor(rust): Bring cloud monikers in line with the ones in `is_cloud_url`

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -90,8 +90,8 @@ impl FromStr for CloudType {
     fn from_str(url: &str) -> Result<Self, Self::Err> {
         let parsed = Url::parse(url).map_err(to_compute_err)?;
         Ok(match parsed.scheme() {
-            "s3" => Self::Aws,
-            "az" | "adl" | "abfs" => Self::Azure,
+            "s3" | "s3a" => Self::Aws,
+            "az" | "azure" | "adl" | "abfs" | "abfss" => Self::Azure,
             "gs" | "gcp" | "gcs" => Self::Gcp,
             "file" => Self::File,
             _ => polars_bail!(ComputeError: "unknown url scheme"),


### PR DESCRIPTION
Smarter people than me might want to use [`object_store::parse_url`](https://docs.rs/object_store/latest/object_store/fn.parse_url.html) to process `parsed` into an `ObjectStore`. Then decide which cloud provider it is, based on the type of the object store.

Then we could even support http(s) urls as targets. Plus, all the logic would be in something we don't need to maintain :)