### PR TITLE
perf: actually use projection information in async parquet reader

### DIFF
--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -511,7 +511,6 @@ impl BatchedParquetReader {
     }
 
     pub async fn next_batches(&mut self, n: usize) -> PolarsResult<Option<Vec<DataFrame>>> {
-        dbg!(n);
         // fill up fifo stack
         if self.row_group_offset <= self.n_row_groups && self.chunks_fifo.len() < n {
             let row_group_start = self.row_group_offset;

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -511,6 +511,7 @@ impl BatchedParquetReader {
     }
 
     pub async fn next_batches(&mut self, n: usize) -> PolarsResult<Option<Vec<DataFrame>>> {
+        dbg!(n);
         // fill up fifo stack
         if self.row_group_offset <= self.n_row_groups && self.chunks_fifo.len() < n {
             let row_group_start = self.row_group_offset;

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -78,6 +78,7 @@ impl ParquetExec {
                     .await?
                     .with_n_rows(n_rows)
                     .with_row_count(mem::take(&mut self.file_options.row_count))
+                    .with_projection(projection)
                     .use_statistics(self.options.use_statistics)
                     .with_hive_partition_columns(hive_partitions);
 


### PR DESCRIPTION
Whoops, we accidentally didn't use the projection in aysnc parquet reading. fixes #10685