### PR TITLE
fix(python): require all `schema` arguments to be a unique set of equal width to the data, and hard error otherwise

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -829,7 +829,7 @@ def dict_to_pydf(
     nan_to_null: bool = False,
 ) -> PyDataFrame:
     """Construct a PyDataFrame from a dictionary of sequences."""
-    if isinstance(schema, dict) and data:
+    if not isinstance(schema, dict) and data:
         if not all((col in schema) for col in data):
             raise ValueError(
                 "the given column-schema names do not match the data dictionary"


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/11632.

`from_arrow` currently silently drops duplicated columns - this PR changes the behavior to instead hard error unless a schema is passed.

This also changes the behavior of dataframe construction, which now also hard errors when an explicitly passed schema contains duplicate names instead of transparently renaming them as `column_<index>`:

Before:
```python
>>> pl.DataFrame(schema=["", ""])
shape: (0, 2)
┌──────────┬──────────┐
│ column_0 ┆ column_1 │
│ ---      ┆ ---      │
│ f32      ┆ f32      │
╞══════════╪══════════╡
└──────────┴──────────┘
```
After:
```python
>>> pl.DataFrame(schema=["", ""])
Traceback (most recent call last):
...
exceptions.DuplicateError: Schema contained duplicate column names
```

However, note that DataFrame construction from a list of series (when not passed an explicit schema) retains its current behavior:
```python
>>> pl.DataFrame([pl.Series(), pl.Series("x"), pl.Series()])
shape: (0, 3)
┌──────────┬─────┬──────────┐
│ column_0 ┆ x   ┆ column_2 │
│ ---      ┆ --- ┆ ---      │
│ f32      ┆ f32 ┆ f32      │
╞══════════╪═════╪══════════╡
└──────────┴─────┴──────────┘
```