### PR TITLE
perf: slightly faster float equality

### DIFF
--- a/crates/nano-arrow/src/util/total_ord.rs
+++ b/crates/nano-arrow/src/util/total_ord.rs
@@ -228,8 +228,8 @@ macro_rules! impl_eq_ord_float {
         impl TotalEq for $f {
             #[inline(always)]
             fn tot_eq(&self, other: &Self) -> bool {
-                if self.is_nan() && other.is_nan() {
-                    true
+                if self.is_nan() {
+                    other.is_nan()
                 } else {
                     self == other
                 }


### PR DESCRIPTION
Incredibly minor but came across it while upstreaming to https://github.com/reem/rust-ordered-float, so might as well backport.