### PR TITLE
build(python): Don't compile the `x86_64` Mac binaries with AVX/FMA instructions (unsupported under Rosetta)

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -132,7 +132,7 @@ jobs:
         run: echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt" >> $GITHUB_ENV
       - name: Set RUSTFLAGS for x86-64 MacOS
         if: matrix.architecture == 'x86-64' && matrix.package != 'polars-lts-cpu' && matrix.os == 'macos-latest'
-        run: echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+fma" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+fma" >> $GITHUB_ENV
       - name: Set RUSTFLAGS for x86-64 LTS CPU
         if: matrix.architecture == 'x86-64' && matrix.package == 'polars-lts-cpu'
         run: echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt --cfg use_mimalloc" >> $GITHUB_ENV

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -132,7 +132,7 @@ jobs:
         run: echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+avx,+avx2,+fma,+bmi1,+bmi2,+lzcnt" >> $GITHUB_ENV
       - name: Set RUSTFLAGS for x86-64 MacOS
         if: matrix.architecture == 'x86-64' && matrix.package != 'polars-lts-cpu' && matrix.os == 'macos-latest'
-        run: echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt,+fma" >> $GITHUB_ENV
+        run: echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt" >> $GITHUB_ENV
       - name: Set RUSTFLAGS for x86-64 LTS CPU
         if: matrix.architecture == 'x86-64' && matrix.package == 'polars-lts-cpu'
         run: echo "RUSTFLAGS=-C target-feature=+sse3,+ssse3,+sse4.1,+sse4.2,+popcnt --cfg use_mimalloc" >> $GITHUB_ENV


### PR DESCRIPTION
I suspect this closes #11650, as AVX instructions are not available[^1] under Rosetta.

(Note: this change has no impact on the native `aarch64` Apple Silicon builds).

FYI: for the curious, you can see exactly what _is_ supported by opening a Rosetta Terminal and running:
```bash
❯ sysctl -a | grep machdep.cpu.features

FPU VME DE PSE TSC MSR PAE MCE CX8 APIC SEP MTRR 
PGE MCA CMOV PAT PSE36 CLFSH DS ACPI MMX FXSR SSE 
SSE2 SS HTT TM PBE SSE3 PCLMULQDQ DTSE64 MON DSCPL 
VMX EST TM2 SSSE3 CX16 TPR PDCM SSE4.1 SSE4.2 AES SEGLIM64
```

[^1]: https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment#What-Cant-Be-Translated