### PR TITLE
docs: add note about use of `polars-lts-cpu` for macOS x86-64/rosetta

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,10 @@ Don't use this unless you hit the row boundary as the default polars is faster a
 
 ## Legacy
 
-Do you want polars to run on an old CPU (e.g. dating from before 2011)? Install `pip install polars-lts-cpu`. This polars project is
-compiled without [avx](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) target features.
+Do you want polars to run on an old CPU (e.g. dating from before 2011), or on an `x86-64` build
+of Python on Apple Silicon under Rosetta? Install `pip install polars-lts-cpu`. This version of
+polars is compiled without [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) target
+features.
 
 ## Sponsors
 


### PR DESCRIPTION
Ref: https://github.com/pola-rs/polars/issues/11650.
Seems worth noting this additional use-case for `polars-lts-cpu` in the README.