### PR TITLE
feat: support multiple sources in scan_file

### DIFF
--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -40,6 +40,10 @@ pub struct LazyCsvReader<'a> {
 
 #[cfg(feature = "csv")]
 impl<'a> LazyCsvReader<'a> {
+    pub fn new_paths(paths: Vec<PathBuf>) -> Self {
+        Self::new("").with_paths(paths)
+    }
+
     pub fn new(path: impl AsRef<Path>) -> Self {
         LazyCsvReader {
             path: path.as_ref().to_owned(),

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -13,6 +13,7 @@ use crate::prelude::*;
 #[cfg(feature = "csv")]
 pub struct LazyCsvReader<'a> {
     path: PathBuf,
+    paths: Vec<PathBuf>,
     separator: u8,
     has_header: bool,
     ignore_errors: bool,
@@ -42,6 +43,7 @@ impl<'a> LazyCsvReader<'a> {
     pub fn new(path: impl AsRef<Path>) -> Self {
         LazyCsvReader {
             path: path.as_ref().to_owned(),
+            paths: vec![],
             separator: b',',
             has_header: true,
             ignore_errors: false,
@@ -225,7 +227,7 @@ impl<'a> LazyCsvReader<'a> {
     where
         F: Fn(Schema) -> PolarsResult<Schema>,
     {
-        let mut file = if let Some(mut paths) = self.glob()? {
+        let mut file = if let Some(mut paths) = self.iter_paths()? {
             let path = match paths.next() {
                 Some(globresult) => globresult?,
                 None => polars_bail!(ComputeError: "globbing pattern did not match any files"),
@@ -302,8 +304,17 @@ impl LazyFileListReader for LazyCsvReader<'_> {
         &self.path
     }
 
+    fn paths(&self) -> &[PathBuf] {
+        &self.paths
+    }
+
     fn with_path(mut self, path: PathBuf) -> Self {
         self.path = path;
+        self
+    }
+
+    fn with_paths(mut self, paths: Vec<PathBuf>) -> Self {
+        self.paths = paths;
         self
     }
 

--- a/crates/polars-lazy/src/scan/file_list_reader.rs
+++ b/crates/polars-lazy/src/scan/file_list_reader.rs
@@ -40,7 +40,6 @@ pub trait LazyFileListReader: Clone {
                 .enumerate()
                 .map(|(i, r)| {
                     let path = r?;
-                    dbg!(&path);
                     let lf = self
                         .clone()
                         .with_path(path.clone())
@@ -77,7 +76,6 @@ pub trait LazyFileListReader: Clone {
 
             Ok(lf)
         } else {
-            dbg!("here");
             self.finish_no_glob()
         }
     }

--- a/crates/polars-lazy/src/scan/file_list_reader.rs
+++ b/crates/polars-lazy/src/scan/file_list_reader.rs
@@ -151,9 +151,9 @@ pub trait LazyFileListReader: Clone {
             }
         } else {
             polars_ensure!(self.path().to_string_lossy() == "", InvalidOperation: "expected only a single path argument");
-            Ok(Some(Box::new(
-                paths.to_vec().into_iter().map(|path| Ok(path)),
-            )))
+            // Lint is incorrect as we need static lifetime.
+            #[allow(clippy::unnecessary_to_owned)]
+            Ok(Some(Box::new(paths.to_vec().into_iter().map(Ok))))
         }
     }
 }

--- a/crates/polars-lazy/src/scan/ipc.rs
+++ b/crates/polars-lazy/src/scan/ipc.rs
@@ -112,4 +112,10 @@ impl LazyFrame {
     pub fn scan_ipc(path: impl AsRef<Path>, args: ScanArgsIpc) -> PolarsResult<Self> {
         LazyIpcReader::new(path.as_ref().to_owned(), args).finish()
     }
+
+    pub fn scan_ipc_files(paths: Vec<PathBuf>, args: ScanArgsIpc) -> PolarsResult<Self> {
+        LazyIpcReader::new(PathBuf::new(), args)
+            .with_paths(paths)
+            .finish()
+    }
 }

--- a/crates/polars-lazy/src/scan/ipc.rs
+++ b/crates/polars-lazy/src/scan/ipc.rs
@@ -30,11 +30,16 @@ impl Default for ScanArgsIpc {
 struct LazyIpcReader {
     args: ScanArgsIpc,
     path: PathBuf,
+    paths: Vec<PathBuf>,
 }
 
 impl LazyIpcReader {
     fn new(path: PathBuf, args: ScanArgsIpc) -> Self {
-        Self { args, path }
+        Self {
+            args,
+            path,
+            paths: vec![],
+        }
     }
 }
 
@@ -70,8 +75,17 @@ impl LazyFileListReader for LazyIpcReader {
         self.path.as_path()
     }
 
+    fn paths(&self) -> &[PathBuf] {
+        &self.paths
+    }
+
     fn with_path(mut self, path: PathBuf) -> Self {
         self.path = path;
+        self
+    }
+
+    fn with_paths(mut self, paths: Vec<PathBuf>) -> Self {
+        self.paths = paths;
         self
     }
 

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -20,6 +20,10 @@ pub struct LazyJsonLineReader {
 }
 
 impl LazyJsonLineReader {
+    pub fn new_paths(paths: Vec<PathBuf>) -> Self {
+        Self::new(PathBuf::new()).with_paths(paths)
+    }
+
     pub fn new(path: impl AsRef<Path>) -> Self {
         LazyJsonLineReader {
             path: path.as_ref().to_path_buf(),

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -9,6 +9,7 @@ use crate::prelude::{LazyFrame, ScanArgsAnonymous};
 #[derive(Clone)]
 pub struct LazyJsonLineReader {
     pub(crate) path: PathBuf,
+    paths: Vec<PathBuf>,
     pub(crate) batch_size: Option<usize>,
     pub(crate) low_memory: bool,
     pub(crate) rechunk: bool,
@@ -22,6 +23,7 @@ impl LazyJsonLineReader {
     pub fn new(path: impl AsRef<Path>) -> Self {
         LazyJsonLineReader {
             path: path.as_ref().to_path_buf(),
+            paths: vec![],
             batch_size: None,
             low_memory: false,
             rechunk: true,
@@ -91,8 +93,17 @@ impl LazyFileListReader for LazyJsonLineReader {
         &self.path
     }
 
+    fn paths(&self) -> &[PathBuf] {
+        &self.paths
+    }
+
     fn with_path(mut self, path: PathBuf) -> Self {
         self.path = path;
+        self
+    }
+
+    fn with_paths(mut self, paths: Vec<PathBuf>) -> Self {
+        self.paths = paths;
         self
     }
 

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -40,6 +40,7 @@ impl Default for ScanArgsParquet {
 struct LazyParquetReader {
     args: ScanArgsParquet,
     path: PathBuf,
+    paths: Vec<PathBuf>,
     known_schema: Option<SchemaRef>,
 }
 
@@ -48,6 +49,7 @@ impl LazyParquetReader {
         Self {
             args,
             path,
+            paths: vec![],
             known_schema: None,
         }
     }
@@ -88,8 +90,17 @@ impl LazyFileListReader for LazyParquetReader {
         self.path.as_path()
     }
 
+    fn paths(&self) -> &[PathBuf] {
+        &self.paths
+    }
+
     fn with_path(mut self, path: PathBuf) -> Self {
         self.path = path;
+        self
+    }
+
+    fn with_paths(mut self, paths: Vec<PathBuf>) -> Self {
+        self.paths = paths;
         self
     }
 
@@ -126,5 +137,12 @@ impl LazyFrame {
     /// Create a LazyFrame directly from a parquet scan.
     pub fn scan_parquet(path: impl AsRef<Path>, args: ScanArgsParquet) -> PolarsResult<Self> {
         LazyParquetReader::new(path.as_ref().to_owned(), args).finish()
+    }
+
+    /// Create a LazyFrame directly from a parquet scan.
+    pub fn scan_parquet_files(paths: Vec<PathBuf>, args: ScanArgsParquet) -> PolarsResult<Self> {
+        LazyParquetReader::new(PathBuf::new(), args)
+            .with_paths(paths)
+            .finish()
     }
 }

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -241,7 +241,6 @@ fn test_csv_globbing() -> PolarsResult<()> {
     let df = lf.clone().collect()?;
     assert_eq!(df.shape(), (100, 4));
     let df = LazyCsvReader::new(glob).finish()?.slice(20, 60).collect()?;
-    dbg!(&full_df, &df);
     assert!(full_df.slice(20, 60).frame_equal(&df));
 
     let mut expr_arena = Arena::with_capacity(16);

--- a/crates/polars-ops/src/frame/mod.rs
+++ b/crates/polars-ops/src/frame/mod.rs
@@ -46,7 +46,7 @@ pub trait DataFrameOps: IntoDf {
     ///   }.unwrap();
     ///
     ///   let dummies = df.to_dummies(None, false).unwrap();
-    ///   dbg!(dummies);
+    ///   println!("{}", dummies);
     /// # }
     /// ```
     /// Outputs:

--- a/crates/polars-ops/src/series/ops/approx_unique.rs
+++ b/crates/polars-ops/src/series/ops/approx_unique.rs
@@ -58,7 +58,7 @@ fn dispatcher(s: &Series) -> PolarsResult<Series> {
 ///  let s = Series::new("s", [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3]);
 ///
 ///   let approx_count = approx_n_unique(&s).unwrap();
-///   dbg!(approx_count);
+///   println!("{}", approx_count);
 /// # }
 /// ```
 /// Outputs:

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -475,7 +475,6 @@ fn test_skip_rows() -> PolarsResult<()> {
         .with_separator(b' ')
         .finish()?;
 
-    dbg!(&df);
     assert_eq!(df.height(), 3);
     Ok(())
 }

--- a/examples/read_parquet/src/main.rs
+++ b/examples/read_parquet/src/main.rs
@@ -10,6 +10,6 @@ fn main() -> PolarsResult<()> {
         ])
         .collect()?;
 
-    dbg!(df);
+    println!("{}", df);
     Ok(())
 }

--- a/examples/read_parquet_cloud/src/main.rs
+++ b/examples/read_parquet_cloud/src/main.rs
@@ -25,6 +25,6 @@ fn main() -> PolarsResult<()> {
         ])
         .collect()?;
 
-    dbg!(df);
+    println!("{}", df);
     Ok(())
 }

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -695,7 +695,7 @@ def read_csv_batched(
 
 
 def scan_csv(
-    source: str | Path,
+    source: str | Path | list[str] | list[Path],
     *,
     has_header: bool = True,
     separator: str = ",",
@@ -905,6 +905,8 @@ def scan_csv(
 
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source)
+    else:
+        source = [normalize_filepath(source) for source in source]
 
     return pl.LazyFrame._scan_csv(
         source,

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -209,7 +209,7 @@ def read_ipc_schema(source: str | BinaryIO | Path | bytes) -> dict[str, PolarsDa
 
 
 def scan_ipc(
-    source: str | Path,
+    source: str | Path | list[str] | list[Path],
     *,
     n_rows: int | None = None,
     cache: bool = True,

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import polars._reexport as pl
 from polars.datatypes import N_INFER_DEFAULT
-from polars.utils.various import normalize_filepath
 
 if TYPE_CHECKING:
     from io import IOBase
+    from pathlib import Path
 
     from polars import DataFrame, LazyFrame
     from polars.type_aliases import SchemaDefinition
@@ -57,7 +56,7 @@ def read_ndjson(
 
 
 def scan_ndjson(
-    source: str | Path,
+    source: str | list[str] | list[Path],
     *,
     infer_schema_length: int | None = N_INFER_DEFAULT,
     batch_size: int | None = 1024,
@@ -94,9 +93,6 @@ def scan_ndjson(
         Offset to start the row_count column (only use if the name is set)
 
     """
-    if isinstance(source, (str, Path)):
-        source = normalize_filepath(source)
-
     return pl.LazyFrame._scan_ndjson(
         source,
         infer_schema_length=infer_schema_length,

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -56,7 +56,7 @@ def read_ndjson(
 
 
 def scan_ndjson(
-    source: str | list[str] | list[Path],
+    source: str | Path | list[str] | list[Path],
     *,
     infer_schema_length: int | None = N_INFER_DEFAULT,
     batch_size: int | None = 1024,

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -167,7 +167,7 @@ def read_parquet_schema(
 
 
 def scan_parquet(
-    source: str | Path,
+    source: str | Path | list[str] | list[Path],
     *,
     n_rows: int | None = None,
     cache: bool = True,
@@ -196,7 +196,8 @@ def scan_parquet(
     Parameters
     ----------
     source
-        Path to a file.
+        Path(s) to a file
+        If a single path is given, it can be a globbing pattern.
     n_rows
         Stop reading from parquet file after reading ``n_rows``.
     cache
@@ -261,6 +262,8 @@ def scan_parquet(
     """
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source)
+    else:
+        source = [normalize_filepath(source) for source in source]
 
     return pl.LazyFrame._scan_parquet(
         source,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -493,7 +493,7 @@ class LazyFrame:
             source = None  # type: ignore[assignment]
 
         # try fsspec scanner
-        if can_use_fsspec and _is_local_file(source):  # type: ignore[arg-type]
+        if can_use_fsspec and not _is_local_file(source):  # type: ignore[arg-type]
             scan = _scan_ipc_fsspec(source, storage_options)  # type: ignore[arg-type]
             if n_rows:
                 scan = scan.head(n_rows)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -516,7 +516,7 @@ class LazyFrame:
     @classmethod
     def _scan_ndjson(
         cls,
-        source: str | list[str] | list[Path],
+        source: str | Path | list[str] | list[Path],
         *,
         infer_schema_length: int | None = None,
         batch_size: int | None = None,

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -516,7 +516,7 @@ class LazyFrame:
     @classmethod
     def _scan_ndjson(
         cls,
-        source: str,
+        source: str | list[str] | list[Path],
         *,
         infer_schema_length: int | None = None,
         batch_size: int | None = None,
@@ -536,9 +536,16 @@ class LazyFrame:
         polars.io.scan_ndjson
 
         """
+        if isinstance(source, (str, Path)):
+            source = normalize_filepath(source)
+            sources = []
+        else:
+            sources = [normalize_filepath(source) for source in source]
+            source = None  # type: ignore[assignment]
         self = cls.__new__(cls)
         self._ldf = PyLazyFrame.new_from_ndjson(
             source,
+            sources,
             infer_schema_length,
             batch_size,
             n_rows,

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -110,9 +110,10 @@ impl PyLazyFrame {
 
     #[staticmethod]
     #[cfg(feature = "json")]
-    #[pyo3(signature = (path, infer_schema_length, batch_size, n_rows, low_memory, rechunk, row_count))]
+    #[pyo3(signature = (path, paths, infer_schema_length, batch_size, n_rows, low_memory, rechunk, row_count))]
     fn new_from_ndjson(
-        path: String,
+        path: Option<PathBuf>,
+        paths: Vec<PathBuf>,
         infer_schema_length: Option<usize>,
         batch_size: Option<usize>,
         n_rows: Option<usize>,
@@ -122,7 +123,13 @@ impl PyLazyFrame {
     ) -> PyResult<Self> {
         let row_count = row_count.map(|(name, offset)| RowCount { name, offset });
 
-        let lf = LazyJsonLineReader::new(path)
+        let r = if let Some(path) = &path {
+            LazyJsonLineReader::new(path)
+        } else {
+            LazyJsonLineReader::new_paths(paths)
+        };
+
+        let lf = r
             .with_infer_schema_length(infer_schema_length)
             .with_batch_size(batch_size)
             .with_n_rows(n_rows)

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -242,3 +242,13 @@ def test_scan_csv_schema_overwrite_not_projected_8483(foods_file_path: Path) -> 
     )
     expected = pl.DataFrame({"count": 27}, schema={"count": pl.UInt32})
     assert_frame_equal(df, expected)
+
+
+def test_csv_list_arg(io_files_path: Path) -> None:
+    first = io_files_path / "foods1.csv"
+    second = io_files_path / "foods2.csv"
+
+    df = pl.scan_csv(source=[first, second]).collect()
+    assert df.shape == (54, 4)
+    assert df.row(-1) == ("seafood", 194, 12.0, 1)
+    assert df.row(0) == ("vegetables", 45, 0.5, 2)

--- a/py-polars/tests/unit/io/test_lazy_ipc.py
+++ b/py-polars/tests/unit/io/test_lazy_ipc.py
@@ -75,3 +75,13 @@ def test_glob_n_rows(io_files_path: Path) -> None:
         "fats_g": [0.5, 6.0],
         "sugars_g": [2, 2],
     }
+
+
+def test_ipc_list_arg(io_files_path: Path) -> None:
+    first = io_files_path / "foods1.ipc"
+    second = io_files_path / "foods2.ipc"
+
+    df = pl.scan_ipc(source=[first, second]).collect()
+    assert df.shape == (54, 4)
+    assert df.row(-1) == ("seafood", 194, 12.0, 1)
+    assert df.row(0) == ("vegetables", 45, 0.5, 2)

--- a/py-polars/tests/unit/io/test_lazy_json.py
+++ b/py-polars/tests/unit/io/test_lazy_json.py
@@ -100,3 +100,13 @@ def test_glob_n_rows(io_files_path: Path) -> None:
 # See #10661.
 def test_json_no_unicode_truncate() -> None:
     assert pl.read_ndjson(rb'{"field": "\ufffd1234"}')[0, 0] == "\ufffd1234"
+
+
+def test_ndjson_list_arg(io_files_path: Path) -> None:
+    first = io_files_path / "foods1.ndjson"
+    second = io_files_path / "foods2.ndjson"
+
+    df = pl.scan_ndjson(source=[first, second]).collect()
+    assert df.shape == (54, 4)
+    assert df.row(-1) == ("seafood", 194, 12.0, 1)
+    assert df.row(0) == ("vegetables", 45, 0.5, 2)

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -399,3 +399,13 @@ def test_parquet_statistics_filter_11069(tmp_path: Path) -> None:
     assert pl.scan_parquet(file_path).filter(pl.col("x").is_null()).collect().to_dict(
         False
     ) == {"x": [None]}
+
+
+def test_parquet_list_arg(io_files_path: Path) -> None:
+    first = io_files_path / "foods1.parquet"
+    second = io_files_path / "foods2.parquet"
+
+    df = pl.scan_parquet(source=[first, second]).collect()
+    assert df.shape == (54, 4)
+    assert df.row(-1) == ("seafood", 194, 12.0, 1)
+    assert df.row(0) == ("vegetables", 45, 0.5, 2)


### PR DESCRIPTION
This can improve performance of reading multiple files from the cloud that cannot be globbed. Creating a single `LazyFrame` will amortize the cost of retrieving a schema and dns lookups.

It is of course also more ergonomic. :)