### PR TITLE
feat(python): column selector support for `DataFrame.melt` and `LazyFrame.unnest`

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5375,7 +5375,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         return self.select(F.col("*").interpolate())
 
-    def unnest(self, columns: str | Sequence[str], *more_columns: str) -> Self:
+    def unnest(
+        self,
+        columns: ColumnNameOrSelector | Collection[ColumnNameOrSelector],
+        *more_columns: ColumnNameOrSelector,
+    ) -> Self:
         """
         Decompose struct columns into separate columns for each of their fields.
 
@@ -5423,11 +5427,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └────────┴─────┴─────┴──────┴───────────┴───────┘
 
         """
-        if isinstance(columns, str):
-            columns = [columns]
-        if more_columns:
-            columns = list(columns)
-            columns.extend(more_columns)
+        columns = _expand_selectors(self, columns, *more_columns)
         return self._from_pyldf(self._ldf.unnest(columns))
 
     def merge_sorted(self, other: LazyFrame, key: str) -> Self:

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -122,8 +122,11 @@ def test_struct_unnesting() -> None:
         }
     )
     for cols in ("foo", cs.ends_with("oo")):
-        out = df.unnest(cols)  # type: ignore[arg-type]
-        assert_frame_equal(out, expected)
+        out_eager = df.unnest(cols)  # type: ignore[arg-type]
+        assert_frame_equal(out_eager, expected)
+
+        out_lazy = df.lazy().unnest(cols)  # type: ignore[arg-type]
+        assert_frame_equal(out_lazy, expected.lazy())
 
     out = (
         df_base.lazy()

--- a/py-polars/tests/unit/operations/test_melt.py
+++ b/py-polars/tests/unit/operations/test_melt.py
@@ -6,8 +6,11 @@ from polars.testing import assert_frame_equal
 def test_melt() -> None:
     df = pl.DataFrame({"A": ["a", "b", "c"], "B": [1, 3, 5], "C": [2, 4, 6]})
     for _idv, _vv in (("A", ("B", "C")), (cs.string(), cs.integer())):
-        melted = df.melt(id_vars="A", value_vars=["B", "C"])
-        assert all(melted["value"] == [1, 3, 5, 2, 4, 6])
+        melted_eager = df.melt(id_vars="A", value_vars=["B", "C"])
+        assert all(melted_eager["value"] == [1, 3, 5, 2, 4, 6])
+
+        melted_lazy = df.lazy().melt(id_vars="A", value_vars=["B", "C"])
+        assert all(melted_lazy.collect()["value"] == [1, 3, 5, 2, 4, 6])
 
     melted = df.melt(id_vars="A", value_vars="B")
     assert all(melted["value"] == [1, 3, 5])


### PR DESCRIPTION
Closes #11635.

Fixes a minor oversight; the upgrade of these two methods (to better interop with polars column `selectors`) was accidentally omitted from the previous/larger #10255 update.