### PR TITLE
feat(python): Add syntactic sugar to `DataFrame.filter`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3899,8 +3899,7 @@ class DataFrame:
 
     def filter(
         self,
-        *predicates: (Expr | str | Series | list[bool] | np.ndarray[Any, Any] | bool)
-        | None,
+        *predicates: IntoExpr | list[bool] | np.ndarray[Any, Any],
         **constraints: dict[str, Any],
     ) -> DataFrame:
         """
@@ -3928,7 +3927,7 @@ class DataFrame:
         Filter on one condition:
 
         >>> df.filter(pl.col("foo") < 3)
-        shape: (1, 3)
+        shape: (2, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
         │ --- ┆ --- ┆ --- │
@@ -3988,7 +3987,9 @@ class DataFrame:
 
         """
         return (
-            self.lazy().filter(*predicates, **constraints).collect(_eager=True)  # type: ignore[arg-type]
+            self.lazy()
+            .filter(*predicates, **constraints)  # type: ignore[arg-type]
+            .collect(_eager=True)
         )
 
     @overload

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3928,7 +3928,7 @@ class DataFrame:
         Filter on one condition:
 
         >>> df.filter(pl.col("foo") < 3)
-        shape: (2, 3)
+        shape: (1, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
         │ --- ┆ --- ┆ --- │
@@ -3999,17 +3999,13 @@ class DataFrame:
             ]
 
             # if multiple predicates are supplied, perform logical AND
-            predicate_iter = iter(predicates)
-            predicates = next(predicate_iter)  # type: ignore[arg-type]
-            for pred in predicate_iter:
-                predicates = predicates & pred  # type: ignore[assignment, operator]
+            if len(predicates) > 1:
+                predicates = F.all_horizontal(predicates)  # type: ignore[assignment, arg-type]
+            else:
+                predicates = predicates[0]  # type: ignore[assignment]
         if has_constraints:
-            # basic column filters provided. Logically AND them together
-            constraint_iter = iter(constraints.items())
-            key, value = next(constraint_iter)
-            constraints = col(key) == value  # type: ignore[assignment]
-            for key, value in constraint_iter:
-                constraints = constraints & (col(key) == value)  # type: ignore[assignment]
+            # basic column filters provided
+            constraints = F.all_horizontal(col(k) == v for k, v in constraints.items())  # type: ignore[assignment]
 
         if has_predicates and has_constraints:
             predicates = predicates & constraints  # type: ignore[operator]

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -77,6 +77,7 @@ def parse_as_expression(
     *,
     str_as_lit: bool = False,
     structify: bool = False,
+    wrap: bool = False,
 ) -> PyExpr | Expr:
     """
     Parse a single input into an expression.
@@ -119,7 +120,7 @@ def parse_as_expression(
     if structify:
         expr = _structify_expression(expr)
 
-    return expr._pyexpr
+    return expr if wrap else expr._pyexpr
 
 
 def _structify_expression(expr: Expr) -> Expr:

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2815,6 +2815,27 @@ def test_filter_sequence() -> None:
     assert df.filter(np.array([True, False, True]))["a"].to_list() == [1, 3]
 
 
+def test_filter_multiple_predicates() -> None:
+    df = pl.DataFrame(
+        {"a": [1, 1, 1, 2, 2], "b": [1, 1, 2, 2, 2], "c": [1, 1, 2, 3, 4]}
+    )
+
+    # using multiple predicates
+    out = df.filter(pl.col("a") == 1, pl.col("b") <= 2)
+    expected = pl.DataFrame({"a": [1, 1, 1], "b": [1, 1, 2], "c": [1, 1, 2]})
+    assert_frame_equal(out, expected)
+
+    # using multiple kwargs
+    out = df.filter(a=1, b=2)  # type: ignore[arg-type]
+    expected = pl.DataFrame({"a": [1], "b": [2], "c": [2]})
+    assert_frame_equal(out, expected)
+
+    # using both
+    out = df.filter(pl.col("a") == 1, pl.col("b") <= 2, a=1, b=2)  # type: ignore[arg-type]
+    expected = pl.DataFrame({"a": [1], "b": [2], "c": [2]})
+    assert_frame_equal(out, expected)
+
+
 def test_indexing_set() -> None:
     df = pl.DataFrame({"bool": [True, True], "str": ["N/A", "N/A"], "nr": [1, 2]})
 

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -161,6 +161,27 @@ def test_filter_str() -> None:
     assert_frame_equal(result, expected)
 
 
+def test_filter_multiple_predicates() -> None:
+    ldf = pl.LazyFrame(
+        {"a": [1, 1, 1, 2, 2], "b": [1, 1, 2, 2, 2], "c": [1, 1, 2, 3, 4]}
+    )
+
+    # using multiple predicates
+    out = ldf.filter(pl.col("a") == 1, pl.col("b") <= 2).collect()
+    expected = pl.DataFrame({"a": [1, 1, 1], "b": [1, 1, 2], "c": [1, 1, 2]})
+    assert_frame_equal(out, expected)
+
+    # using multiple kwargs
+    out = ldf.filter(a=1, b=2).collect()  # type: ignore[arg-type]
+    expected = pl.DataFrame({"a": [1], "b": [2], "c": [2]})
+    assert_frame_equal(out, expected)
+
+    # using both
+    out = ldf.filter(pl.col("a") == 1, pl.col("b") <= 2, a=1, b=2).collect()  # type: ignore[arg-type]
+    expected = pl.DataFrame({"a": [1], "b": [2], "c": [2]})
+    assert_frame_equal(out, expected)
+
+
 def test_apply_custom_function() -> None:
     ldf = pl.LazyFrame(
         {


### PR DESCRIPTION
Resolves #11642

This was mainly to get the ball rolling, I'm really looking forward to this feature. I'm happy to give this up to someone else that wants to do a more comprehensive implementation, but I think I covered what was discussed, and I did it using @alexander-beedie's suggested arguments. Suggestions are always welcome of course.

## Examples
From https://github.com/pola-rs/polars/issues/11642#issuecomment-1757183618:
```python
# just `*predicates`
df.filter( 
    pl.col("a") >= 0, 
    pl.col("b").is_not_null(),
    pl.col("").str.starts_with("!"),
 )

# supply list of predicates assembled elsewhere;
# becomes trivial to splat into filter
df.filter( *conditions )

# just `**constraints`
df.filter( 
    x = 0,
    y = "xxx",
    z = date.today(),
)

# mix of `*predicates` (via splat, for example), and `**constraints`
df.filter( *conditions, value=0, start_date=date.today() )
```