### PR TITLE
feat(python): add support for "outer" mode to frame `update` method

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9721,7 +9721,7 @@ class DataFrame:
         on: str | Sequence[str] | None = None,
         left_on: str | Sequence[str] | None = None,
         right_on: str | Sequence[str] | None = None,
-        how: Literal["left", "inner"] = "left",
+        how: Literal["left", "inner", "outer"] = "left",
     ) -> DataFrame:
         """
         Update the values in this `DataFrame` with the non-null values in `other`.
@@ -9746,10 +9746,12 @@ class DataFrame:
            Join column(s) of the left DataFrame.
         right_on
            Join column(s) of the right DataFrame.
-        how : {'left', 'inner'}
-            'left' will keep all rows from the left table. Rows may be duplicated if
-            multiple rows in right frame match left row's `on` key.
-            'inner' will remove rows that are not found in other
+        how : {'left', 'inner', 'outer'}
+            * 'left' will keep all rows from the left table; rows may be duplicated
+              if multiple rows in the right frame match the left row's key.
+            * 'inner' keeps only those rows where the key exists in both frames.
+            * 'outer' will update existing rows where the key matches while also
+              adding any new rows contained in the given frame.
 
         Examples
         --------
@@ -9773,21 +9775,13 @@ class DataFrame:
         └─────┴─────┘
         >>> new_df = pl.DataFrame(
         ...     {
-        ...         "B": [4, None, 6],
-        ...         "C": [7, 8, 9],
+        ...         "B": [-66, None, -99],
+        ...         "C": [5, 3, 1],
         ...     }
         ... )
-        >>> new_df
-        shape: (3, 2)
-        ┌──────┬─────┐
-        │ B    ┆ C   │
-        │ ---  ┆ --- │
-        │ i64  ┆ i64 │
-        ╞══════╪═════╡
-        │ 4    ┆ 7   │
-        │ null ┆ 8   │
-        │ 6    ┆ 9   │
-        └──────┴─────┘
+
+        Update `df` values with the non-null values in `new_df`, by row index:
+
         >>> df.update(new_df)
         shape: (4, 2)
         ┌─────┬─────┐
@@ -9795,10 +9789,42 @@ class DataFrame:
         │ --- ┆ --- │
         │ i64 ┆ i64 │
         ╞═════╪═════╡
-        │ 1   ┆ 4   │
+        │ 1   ┆ -66 │
         │ 2   ┆ 500 │
-        │ 3   ┆ 6   │
+        │ 3   ┆ -99 │
         │ 4   ┆ 700 │
+        └─────┴─────┘
+
+        Update `df` values with the non-null values in `new_df`, by row index,
+        but only keeping those rows that are common to both frames:
+
+        >>> df.update(new_df, how="inner")
+        shape: (3, 2)
+        ┌─────┬─────┐
+        │ A   ┆ B   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ -66 │
+        │ 2   ┆ 500 │
+        │ 3   ┆ -99 │
+        └─────┴─────┘
+
+        Update `df` values with the non-null values in `new_df`, using an outer join
+        strategy that defines explicit join columns in each frame:
+
+        >>> df.update(new_df, left_on=["A"], right_on=["C"], how="outer")
+        shape: (5, 2)
+        ┌─────┬─────┐
+        │ A   ┆ B   │
+        │ --- ┆ --- │
+        │ i64 ┆ i64 │
+        ╞═════╪═════╡
+        │ 1   ┆ -99 │
+        │ 2   ┆ 500 │
+        │ 3   ┆ 600 │
+        │ 4   ┆ 700 │
+        │ 5   ┆ -66 │
         └─────┴─────┘
 
         """

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5662,8 +5662,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┘
 
         """
-        row_count_used = False
+        if how not in ("left", "inner", "outer"):
+            raise ValueError(
+                f"`how` must be one of {{'left', 'inner', 'outer'}}; found {how!r}"
+            )
 
+        row_count_used = False
         if on is None:
             if left_on is None and right_on is None:
                 # no keys provided--use row count

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -544,11 +544,27 @@ def test_update() -> None:
 
     assert df1.update(df2, on="a").to_dict(False) == {"a": [1, 2, 3], "b": [4, 8, 9]}
 
-    a = pl.DataFrame({"a": [1, 2, 3]})
-    b = pl.DataFrame({"b": [4, 5]})
+    a = pl.LazyFrame({"a": [1, 2, 3]})
+    b = pl.LazyFrame({"b": [4, 5], "c": [3, 1]})
     c = a.update(b)
 
-    assert c.rows() == a.rows()
+    assert_frame_equal(a, c)
+
+    # check behaviour of 'how' param
+    assert [1, 2, 3] == list(
+        a.update(b, left_on="a", right_on="c").collect().to_series()
+    )
+    assert [1, 3] == list(
+        a.update(b, how="inner", left_on="a", right_on="c").collect().to_series()
+    )
+    assert [1, 2, 3, 4, 5] == sorted(
+        a.update(b.rename({"b": "a"}), how="outer", on="a").collect().to_series()
+    )
+
+    # edge-case #11684
+    x = pl.DataFrame({"a": [0, 1]})
+    y = pl.DataFrame({"a": [2, 3]})
+    assert [0, 1, 2, 3] == sorted(x.update(y, on="a", how="outer")["a"].to_list())
 
 
 def test_join_frame_consistency() -> None:

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -566,6 +566,14 @@ def test_update() -> None:
     y = pl.DataFrame({"a": [2, 3]})
     assert [0, 1, 2, 3] == sorted(x.update(y, on="a", how="outer")["a"].to_list())
 
+    # disallowed join strategies
+    for join_strategy in ("cross", "anti", "semi"):
+        with pytest.raises(
+            ValueError,
+            match=f"`how` must be one of {{'left', 'inner', 'outer'}}; found '{join_strategy}'",
+        ):
+            a.update(b, how=join_strategy)  # type: ignore[arg-type]
+
 
 def test_join_frame_consistency() -> None:
     df = pl.DataFrame({"A": [1, 2, 3]})


### PR DESCRIPTION
Closes #11684.

We didn't explicitly support `how="outer"` here, but did let it through silently. It would mostly work, except in the edge-case described in the linked issue; this PR now explicitly allows for an "outer" mode, explicitly _disallows_ any join strategy that we don't support in `update`, and better validates all of the expected behaviour.

Also adds more examples and tests, as the various "how" options (outside of the default "left") were either barely tested or not tested at all (and had no supporting examples).