### PR TITLE
fix(rust,python): use actual number of read rows for hive materialization

### DIFF
--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -220,12 +220,10 @@ fn rg_to_dfs_optionally_par_over_columns(
         *remaining_rows = remaining_rows.saturating_sub(file_metadata.row_groups[rg].num_rows());
 
         let mut df = DataFrame::new_no_checks(columns);
-        let num_read_rows = df.height();
-
         if let Some(rc) = &row_count {
             df.with_row_count_mut(&rc.name, Some(*previous_row_count + rc.offset));
         }
-        materialize_hive_partitions(&mut df, hive_partition_columns, num_read_rows);
+        materialize_hive_partitions(&mut df, hive_partition_columns, df.height());
         apply_predicate(&mut df, predicate.as_deref(), true)?;
 
         *previous_row_count += current_row_count;
@@ -296,12 +294,10 @@ fn rg_to_dfs_par_over_rg(
                 .collect::<PolarsResult<Vec<_>>>()?;
 
             let mut df = DataFrame::new_no_checks(columns);
-            let num_read_rows = df.height();
-
             if let Some(rc) = &row_count {
                 df.with_row_count_mut(&rc.name, Some(row_count_start as IdxSize + rc.offset));
             }
-            materialize_hive_partitions(&mut df, hive_partition_columns, num_read_rows);
+            materialize_hive_partitions(&mut df, hive_partition_columns, df.height());
 
             apply_predicate(&mut df, predicate.as_deref(), false)?;
 

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -220,10 +220,12 @@ fn rg_to_dfs_optionally_par_over_columns(
         *remaining_rows = remaining_rows.saturating_sub(file_metadata.row_groups[rg].num_rows());
 
         let mut df = DataFrame::new_no_checks(columns);
+        let num_read_rows = df.height();
+
         if let Some(rc) = &row_count {
             df.with_row_count_mut(&rc.name, Some(*previous_row_count + rc.offset));
         }
-        materialize_hive_partitions(&mut df, hive_partition_columns, df.height());
+        materialize_hive_partitions(&mut df, hive_partition_columns, num_read_rows);
         apply_predicate(&mut df, predicate.as_deref(), true)?;
 
         *previous_row_count += current_row_count;
@@ -294,10 +296,12 @@ fn rg_to_dfs_par_over_rg(
                 .collect::<PolarsResult<Vec<_>>>()?;
 
             let mut df = DataFrame::new_no_checks(columns);
+            let num_read_rows = df.height();
+
             if let Some(rc) = &row_count {
                 df.with_row_count_mut(&rc.name, Some(row_count_start as IdxSize + rc.offset));
             }
-            materialize_hive_partitions(&mut df, hive_partition_columns, df.height());
+            materialize_hive_partitions(&mut df, hive_partition_columns, num_read_rows);
 
             apply_predicate(&mut df, predicate.as_deref(), false)?;
 

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -95,14 +95,9 @@ pub(super) fn array_iter_to_series(
 }
 
 /// Materializes hive partitions.
-/// We have a special num_rows arg, as df can be empty.
-fn materialize_hive_partitions(
-    df: &mut DataFrame,
-    hive_partition_columns: Option<&[Series]>,
-    num_rows: Option<usize>,
-) {
+fn materialize_hive_partitions(df: &mut DataFrame, hive_partition_columns: Option<&[Series]>) {
     if let Some(hive_columns) = hive_partition_columns {
-        let num_rows = num_rows.unwrap_or(df.height());
+        let num_rows = df.height();
 
         for s in hive_columns {
             unsafe { df.with_column_unchecked(s.new_from_index(0, num_rows)) };
@@ -225,7 +220,7 @@ fn rg_to_dfs_optionally_par_over_columns(
         if let Some(rc) = &row_count {
             df.with_row_count_mut(&rc.name, Some(*previous_row_count + rc.offset));
         }
-        materialize_hive_partitions(&mut df, hive_partition_columns, None);
+        materialize_hive_partitions(&mut df, hive_partition_columns);
 
         apply_predicate(&mut df, predicate.as_deref(), true)?;
 
@@ -301,7 +296,7 @@ fn rg_to_dfs_par_over_rg(
             if let Some(rc) = &row_count {
                 df.with_row_count_mut(&rc.name, Some(row_count_start as IdxSize + rc.offset));
             }
-            materialize_hive_partitions(&mut df, hive_partition_columns, None);
+            materialize_hive_partitions(&mut df, hive_partition_columns);
 
             apply_predicate(&mut df, predicate.as_deref(), false)?;
 

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -220,11 +220,12 @@ fn rg_to_dfs_optionally_par_over_columns(
         *remaining_rows = remaining_rows.saturating_sub(file_metadata.row_groups[rg].num_rows());
 
         let mut df = DataFrame::new_no_checks(columns);
+        let num_read_rows = df.height();
+
         if let Some(rc) = &row_count {
             df.with_row_count_mut(&rc.name, Some(*previous_row_count + rc.offset));
         }
-        materialize_hive_partitions(&mut df, hive_partition_columns, md.num_rows());
-
+        materialize_hive_partitions(&mut df, hive_partition_columns, num_read_rows);
         apply_predicate(&mut df, predicate.as_deref(), true)?;
 
         *previous_row_count += current_row_count;
@@ -295,11 +296,12 @@ fn rg_to_dfs_par_over_rg(
                 .collect::<PolarsResult<Vec<_>>>()?;
 
             let mut df = DataFrame::new_no_checks(columns);
+            let num_read_rows = df.height();
 
             if let Some(rc) = &row_count {
                 df.with_row_count_mut(&rc.name, Some(row_count_start as IdxSize + rc.offset));
             }
-            materialize_hive_partitions(&mut df, hive_partition_columns, md.num_rows());
+            materialize_hive_partitions(&mut df, hive_partition_columns, num_read_rows);
 
             apply_predicate(&mut df, predicate.as_deref(), false)?;
 

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -54,6 +54,9 @@ def test_hive_partitioned_predicate_pushdown(
     # tests: 11536
     assert q.filter(pl.col("sugars_g") == 25).collect().shape == (1, 4)
 
+    # tests: 11682
+    assert q.head(1).collect().select(pl.all_horizontal(pl.all().count() == 1)).item()
+
 
 @pytest.mark.write_disk()
 def test_hive_partitioned_projection_pushdown(

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -74,6 +74,7 @@ def test_hive_partitioned_slice_pushdown(io_files_path: Path, tmp_path: Path) ->
 
     # tests: 11682
     assert q.head(1).collect().select(pl.all_horizontal(pl.all().count() == 1)).item()
+    assert q.head(0).collect().columns == ["calories", "sugars_g", "category", "fats_g"]
 
 
 @pytest.mark.write_disk()


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/11682

`md.num_rows()` cannot be used as `column_idx_to_series` may not read the entire row group when there is a SELECT->LIMIT