### PR TITLE
perf: process parquet statistics before downloading row-group

### DIFF
--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -38,7 +38,7 @@ rayon = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, optional = true }
 ryu = { workspace = true, optional = true }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, features = ["derive", "rc"], optional = true }
 serde_json = { version = "1", default-features = false, features = ["alloc", "raw_value"], optional = true }
 simd-json = { workspace = true, optional = true }
 simdutf8 = { workspace = true, optional = true }
@@ -65,6 +65,7 @@ json = [
   "dtype-struct",
   "csv",
 ]
+serde = ["dep:serde", "polars-core/serde-lazy"]
 # support for arrows ipc file parsing
 ipc = ["arrow/io_ipc", "arrow/io_ipc_compression"]
 # support for arrows streaming ipc file parsing

--- a/crates/polars-io/src/parquet/async_impl.rs
+++ b/crates/polars-io/src/parquet/async_impl.rs
@@ -189,7 +189,7 @@ impl FetchRowGroupsFromObjectStore {
         row_groups: Range<usize>,
     ) -> PolarsResult<ColumnStore> {
         // Fetch the required row groups.
-        let row_groups = &self
+        let row_groups = self
             .row_groups_metadata
             .get(row_groups.clone())
             .map_or_else(

--- a/crates/polars-io/src/parquet/mod.rs
+++ b/crates/polars-io/src/parquet/mod.rs
@@ -22,8 +22,11 @@ mod read;
 mod read_impl;
 mod write;
 
+use arrow::io::parquet::write::FileMetaData;
 pub use read::*;
 pub use write::{BrotliLevel, GzipLevel, ZstdLevel, *};
+
+pub type FileMetaDataRef = Arc<FileMetaData>;
 
 use super::*;
 

--- a/crates/polars-io/src/parquet/predicates.rs
+++ b/crates/polars-io/src/parquet/predicates.rs
@@ -18,20 +18,14 @@ impl ColumnStats {
 
 /// Collect the statistics in a column chunk.
 pub(crate) fn collect_statistics(
-    md: &[RowGroupMetaData],
+    md: &RowGroupMetaData,
     arrow_schema: &ArrowSchema,
-    rg: Option<usize>,
 ) -> ArrowResult<Option<BatchStats>> {
     let mut schema = Schema::with_capacity(arrow_schema.fields.len());
     let mut stats = vec![];
 
     for fld in &arrow_schema.fields {
-        // note that we only select a single row group.
-        let st = match rg {
-            None => deserialize(fld, md)?,
-            // we select a single row group and collect only those stats
-            Some(rg) => deserialize(fld, &md[rg..rg + 1])?,
-        };
+        let st = deserialize(fld, md)?;
         schema.with_column((&fld.name).into(), (&fld.data_type).into());
         stats.push(ColumnStats::from_arrow_stats(st, fld));
     }
@@ -45,13 +39,12 @@ pub(crate) fn collect_statistics(
 
 pub(super) fn read_this_row_group(
     predicate: Option<&Arc<dyn PhysicalIoExpr>>,
-    file_metadata: &arrow::io::parquet::read::FileMetaData,
+    md: &RowGroupMetaData,
     schema: &ArrowSchema,
-    rg: usize,
 ) -> PolarsResult<bool> {
     if let Some(pred) = &predicate {
         if let Some(pred) = pred.as_stats_evaluator() {
-            if let Some(stats) = collect_statistics(&file_metadata.row_groups, schema, Some(rg))? {
+            if let Some(stats) = collect_statistics(md, schema)? {
                 let should_read = pred.should_read(&stats);
                 // a parquet file may not have statistics of all columns
                 if matches!(should_read, Ok(false)) {

--- a/crates/polars-io/src/parquet/read.rs
+++ b/crates/polars-io/src/parquet/read.rs
@@ -49,6 +49,7 @@ pub struct ParquetReader<R: Read + Seek> {
     columns: Option<Vec<String>>,
     projection: Option<Vec<usize>>,
     parallel: ParallelStrategy,
+    schema: Option<SchemaRef>,
     row_count: Option<RowCount>,
     low_memory: bool,
     metadata: Option<Arc<FileMetaData>>,
@@ -65,8 +66,8 @@ impl<R: MmapBytesReader> ParquetReader<R> {
         projection: Option<&[usize]>,
     ) -> PolarsResult<DataFrame> {
         // this path takes predicates and parallelism into account
-        let metadata = read::read_metadata(&mut self.reader)?;
-        let schema = read::schema::infer_schema(&metadata)?;
+        let metadata = self.get_metadata()?.clone();
+        let schema = self.schema()?;
 
         let rechunk = self.rechunk;
         read_parquet(
@@ -129,9 +130,16 @@ impl<R: MmapBytesReader> ParquetReader<R> {
     }
 
     /// [`Schema`] of the file.
-    pub fn schema(&mut self) -> PolarsResult<Schema> {
-        let metadata = self.get_metadata()?;
-        Ok(Schema::from_iter(&read::infer_schema(metadata)?.fields))
+    pub fn schema(&mut self) -> PolarsResult<SchemaRef> {
+        match &self.schema {
+            Some(schema) => Ok(schema.clone()),
+            None => {
+                let metadata = self.get_metadata()?;
+                Ok(Arc::new(Schema::from_iter(
+                    &read::infer_schema(metadata)?.fields,
+                )))
+            },
+        }
     }
 
     /// Use statistics in the parquet to determine if pages
@@ -152,7 +160,7 @@ impl<R: MmapBytesReader> ParquetReader<R> {
         self
     }
 
-    pub fn get_metadata(&mut self) -> PolarsResult<&Arc<FileMetaData>> {
+    pub fn get_metadata(&mut self) -> PolarsResult<&FileMetaDataRef> {
         if self.metadata.is_none() {
             self.metadata = Some(Arc::new(read::read_metadata(&mut self.reader)?));
         }
@@ -163,11 +171,13 @@ impl<R: MmapBytesReader> ParquetReader<R> {
 impl<R: MmapBytesReader + 'static> ParquetReader<R> {
     pub fn batched(mut self, chunk_size: usize) -> PolarsResult<BatchedParquetReader> {
         let metadata = self.get_metadata()?.clone();
+        let schema = self.schema()?;
 
         let row_group_fetcher = FetchRowGroupsFromMmapReader::new(Box::new(self.reader))?.into();
         BatchedParquetReader::new(
             row_group_fetcher,
             metadata,
+            schema,
             self.n_rows.unwrap_or(usize::MAX),
             self.projection,
             self.row_count,
@@ -191,6 +201,7 @@ impl<R: MmapBytesReader> SerReader<R> for ParquetReader<R> {
             row_count: None,
             low_memory: false,
             metadata: None,
+            schema: None,
             use_statistics: true,
             hive_partition_columns: None,
         }
@@ -202,11 +213,11 @@ impl<R: MmapBytesReader> SerReader<R> for ParquetReader<R> {
     }
 
     fn finish(mut self) -> PolarsResult<DataFrame> {
-        let metadata = read::read_metadata(&mut self.reader)?;
-        let schema = read::schema::infer_schema(&metadata)?;
+        let schema = self.schema()?;
+        let metadata = self.get_metadata()?.clone();
 
         if let Some(cols) = &self.columns {
-            self.projection = Some(columns_to_projection(cols, &schema)?);
+            self.projection = Some(columns_to_projection_pl_schema(cols, schema.as_ref())?);
         }
 
         read_parquet(
@@ -238,6 +249,7 @@ pub struct ParquetAsyncReader {
     n_rows: Option<usize>,
     rechunk: bool,
     projection: Option<Vec<usize>>,
+    predicate: Option<Arc<dyn PhysicalIoExpr>>,
     row_count: Option<RowCount>,
     use_statistics: bool,
     hive_partition_columns: Option<Vec<Series>>,
@@ -258,14 +270,18 @@ impl ParquetAsyncReader {
             n_rows: None,
             projection: None,
             row_count: None,
+            predicate: None,
             use_statistics: true,
             hive_partition_columns: None,
             schema,
         })
     }
 
-    pub async fn schema(&mut self) -> PolarsResult<Schema> {
-        self.reader.schema().await
+    pub async fn schema(&mut self) -> PolarsResult<SchemaRef> {
+        match &self.schema {
+            Some(schema) => Ok(schema.clone()),
+            None => self.reader.schema().await.map(Arc::new),
+        }
     }
     pub async fn num_rows(&mut self) -> PolarsResult<usize> {
         self.reader.num_rows().await
@@ -291,6 +307,11 @@ impl ParquetAsyncReader {
         self
     }
 
+    pub fn with_predicate(mut self, predicate: Option<Arc<dyn PhysicalIoExpr>>) -> Self {
+        self.predicate = predicate;
+        self
+    }
+
     /// Use statistics in the parquet to determine if pages
     /// can be skipped from reading.
     pub fn use_statistics(mut self, toggle: bool) -> Self {
@@ -305,17 +326,20 @@ impl ParquetAsyncReader {
 
     pub async fn batched(mut self, chunk_size: usize) -> PolarsResult<BatchedParquetReader> {
         let metadata = self.reader.get_metadata().await?.clone();
+        let schema = self.schema().await?;
         // row group fetched deals with projection
         let row_group_fetcher = FetchRowGroupsFromObjectStore::new(
             self.reader,
             &metadata,
             self.schema.unwrap(),
             self.projection.as_deref(),
+            self.predicate.clone(),
         )?
         .into();
         BatchedParquetReader::new(
             row_group_fetcher,
             metadata,
+            schema,
             self.n_rows.unwrap_or(usize::MAX),
             self.projection,
             self.row_count,
@@ -329,12 +353,10 @@ impl ParquetAsyncReader {
         self.reader.get_metadata().await
     }
 
-    pub async fn finish(
-        self,
-        predicate: Option<Arc<dyn PhysicalIoExpr>>,
-    ) -> PolarsResult<DataFrame> {
+    pub async fn finish(self) -> PolarsResult<DataFrame> {
         let rechunk = self.rechunk;
 
+        let predicate = self.predicate.clone();
         // batched reader deals with slice pushdown
         let reader = self.batched(usize::MAX).await?;
         let mut iter = reader.iter(16);

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -178,7 +178,9 @@ fn rg_to_dfs_optionally_par_over_columns(
         let md = &file_metadata.row_groups[rg];
         let current_row_count = md.num_rows() as IdxSize;
 
-        if use_statistics && !read_this_row_group(predicate.as_ref(), file_metadata, schema, rg)? {
+        if use_statistics
+            && !read_this_row_group(predicate.as_ref(), &file_metadata.row_groups[rg], schema)?
+        {
             *previous_row_count += current_row_count;
             continue;
         }
@@ -273,7 +275,11 @@ fn rg_to_dfs_par_over_rg(
         .map(|(rg_idx, md, local_limit, row_count_start)| {
             if local_limit == 0
                 || use_statistics
-                    && !read_this_row_group(predicate.as_ref(), file_metadata, schema, rg_idx)?
+                    && !read_this_row_group(
+                        predicate.as_ref(),
+                        &file_metadata.row_groups[rg_idx],
+                        schema,
+                    )?
             {
                 return Ok(None);
             }

--- a/crates/polars-io/src/utils.rs
+++ b/crates/polars-io/src/utils.rs
@@ -75,6 +75,25 @@ pub(crate) fn apply_projection(schema: &ArrowSchema, projection: &[usize]) -> Ar
     ArrowSchema::from(fields)
 }
 
+#[cfg(feature = "parquet")]
+pub(crate) fn apply_projection_pl_schema(schema: &Schema, projection: &[usize]) -> Schema {
+    Schema::from_iter(projection.iter().map(|idx| {
+        let (name, dt) = schema.get_at_index(*idx).unwrap();
+        Field::new(name.as_str(), dt.clone())
+    }))
+}
+
+#[cfg(feature = "parquet")]
+pub(crate) fn columns_to_projection_pl_schema(
+    columns: &[String],
+    schema: &Schema,
+) -> PolarsResult<Vec<usize>> {
+    columns
+        .iter()
+        .map(|name| schema.try_get_full(name).map(|(idx, _, _)| idx))
+        .collect()
+}
+
 #[cfg(any(
     feature = "ipc",
     feature = "ipc_streaming",
@@ -85,11 +104,9 @@ pub(crate) fn columns_to_projection(
     columns: &[String],
     schema: &ArrowSchema,
 ) -> PolarsResult<Vec<usize>> {
-    use ahash::AHashMap;
-
     let mut prj = Vec::with_capacity(columns.len());
     if columns.len() > 100 {
-        let mut column_names = AHashMap::with_capacity(schema.fields.len());
+        let mut column_names = PlHashMap::with_capacity(schema.fields.len());
         schema.fields.iter().enumerate().for_each(|(i, c)| {
             column_names.insert(c.name.as_str(), i);
         });

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -80,9 +80,10 @@ impl ParquetExec {
                     .with_row_count(mem::take(&mut self.file_options.row_count))
                     .with_projection(projection)
                     .use_statistics(self.options.use_statistics)
+                    .with_predicate(predicate)
                     .with_hive_partition_columns(hive_partitions);
 
-                    reader.finish(predicate).await
+                    reader.finish().await
                 })
             }
             #[cfg(not(feature = "cloud"))]

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -85,11 +85,12 @@ macro_rules! try_delayed {
 }
 
 #[cfg(any(feature = "parquet", feature = "parquet_async",))]
-fn prepare_schema(mut schema: Schema, row_count: Option<&RowCount>) -> SchemaRef {
+fn prepare_schema(mut schema: SchemaRef, row_count: Option<&RowCount>) -> SchemaRef {
+    let schema_mut = Arc::make_mut(&mut schema);
     if let Some(rc) = row_count {
-        let _ = schema.insert_at_index(0, rc.name.as_str().into(), IDX_DTYPE);
+        let _ = schema_mut.insert_at_index(0, rc.name.as_str().into(), IDX_DTYPE);
     }
-    Arc::new(schema)
+    schema
 }
 
 impl LogicalPlanBuilder {
@@ -167,7 +168,7 @@ impl LogicalPlanBuilder {
                     let mut reader =
                         ParquetAsyncReader::from_uri(&uri, cloud_options.as_ref(), None, None)
                             .await?;
-                    let schema = Arc::new(reader.schema().await?);
+                    let schema = reader.schema().await?;
                     let num_rows = reader.num_rows().await?;
                     let metadata = reader.get_metadata().await?.clone();
 

--- a/crates/polars-plan/src/logical_plan/hive.rs
+++ b/crates/polars-plan/src/logical_plan/hive.rs
@@ -76,7 +76,7 @@ impl HivePartitions {
         } else {
             let schema: Schema = partitions.as_slice().into();
             let stats = BatchStats::new(
-                schema,
+                Arc::new(schema),
                 partitions
                     .into_iter()
                     .map(ColumnStats::from_column_literal)


### PR DESCRIPTION
A bit wasteful to download a row-group and not use it. :)