### PR TITLE
feat: optimize asof_join and allow null/string keys

### DIFF
--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -35,6 +35,8 @@ use bytemuck::Zeroable;
 pub use dtype::*;
 pub use field::*;
 use num_traits::{Bounded, FromPrimitive, Num, NumCast, One, Zero};
+use polars_arrow::data_types::IsFloat;
+use polars_utils::abs_diff::AbsDiff;
 #[cfg(feature = "serde")]
 use serde::de::{EnumAccess, Error, Unexpected, VariantAccess, Visitor};
 #[cfg(any(feature = "serde", feature = "serde-lazy"))]
@@ -255,6 +257,7 @@ pub trait NumericNative:
     + Rem<Output = Self>
     + AddAssign
     + SubAssign
+    + AbsDiff
     + Bounded
     + FromPrimitive
     + IsFloat

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -63,7 +63,7 @@ pub struct Flat;
 ///
 /// The StaticArray and dtype return must be correct.
 pub unsafe trait PolarsDataType: Send + Sync + Sized {
-    type Physical<'a>;
+    type Physical<'a>: std::fmt::Debug;
     type ZeroablePhysical<'a>: Zeroable + From<Self::Physical<'a>>;
     type Array: for<'a> StaticArray<
         ValueT<'a> = Self::Physical<'a>,

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -35,7 +35,6 @@ use bytemuck::Zeroable;
 pub use dtype::*;
 pub use field::*;
 use num_traits::{Bounded, FromPrimitive, Num, NumCast, One, Zero};
-use polars_arrow::data_types::IsFloat;
 use polars_utils::abs_diff::AbsDiff;
 #[cfg(feature = "serde")]
 use serde::de::{EnumAccess, Error, Unexpected, VariantAccess, Visitor};

--- a/crates/polars-ops/src/frame/join/asof/default.rs
+++ b/crates/polars-ops/src/frame/join/asof/default.rs
@@ -1,356 +1,123 @@
-use std::fmt::Debug;
-use std::ops::{Add, Sub};
+use arrow::bitmap::Bitmap;
+use num_traits::{Zero, Bounded};
+use polars_arrow::index::IdxSize;
+use polars_core::prelude::*;
+use polars_utils::abs_diff::AbsDiff;
 
-use arrow::legacy::index::IdxSize;
-use num_traits::Bounded;
+use super::{AsofStrategy, join_asof_backward_step, join_asof_forward_step, join_asof_nearest_step};
 
-pub(super) fn join_asof_forward_with_tolerance<T: PartialOrd + Copy + Debug + Sub<Output = T>>(
+fn join_asof_forward<T: NumericNative>(
     left: &[T],
     right: &[T],
-    tolerance: T,
-) -> Vec<Option<IdxSize>> {
-    if right.is_empty() {
-        return vec![None; left.len()];
-    }
-    if left.is_empty() {
-        return vec![];
+    tolerance: T::Abs,
+) -> IdxCa {
+    if left.is_empty() || right.is_empty() {
+        return IdxCa::full_null("", left.len());
     }
 
-    let mut out = Vec::with_capacity(left.len());
-    let mut offset = 0 as IdxSize;
+    let mut out = vec![0; left.len()];
+    let mut mask = vec![0; (left.len() + 7) / 8];
+    let mut offset = 0;
 
-    for &val_l in left {
-        loop {
-            match right.get(offset as usize) {
-                Some(&val_r) => {
-                    if val_r >= val_l {
-                        let dist = val_r - val_l;
-                        let value = if dist > tolerance { None } else { Some(offset) };
-
-                        out.push(value);
-                        break;
-                    }
-                    offset += 1;
-                },
-                None => {
-                    out.extend(std::iter::repeat(None).take(left.len() - out.len()));
-                    return out;
-                },
-            }
+    for (i, &val_l) in left.iter().enumerate() {
+        if join_asof_forward_step(&mut offset, val_l, |j| right[j], right.len(), tolerance) {
+            out[i] = offset as IdxSize;
+            mask[i / 8] |= 1 << (i % 8);
         }
     }
-    out
+
+    let bitmap = Bitmap::try_new(mask, out.len()).unwrap();
+    IdxCa::new_from_owned_with_null_bitmap("", out, Some(bitmap))
 }
 
-pub(super) fn join_asof_backward_with_tolerance<T>(
+fn join_asof_backward<T: NumericNative>(
     left: &[T],
     right: &[T],
-    tolerance: T,
-) -> Vec<Option<IdxSize>>
+    tolerance: T::Abs,
+) -> IdxCa {
+    if left.is_empty() || right.is_empty() {
+        return IdxCa::full_null("", left.len());
+    }
+
+    let mut out = vec![0; left.len()];
+    let mut mask = vec![0; (left.len() + 7) / 8];
+    let mut offset = right.len();
+
+    for (i, &val_l) in left.iter().enumerate().rev() {
+        if join_asof_backward_step(&mut offset, val_l, |j| right[j], tolerance) {
+            out[i] = offset as IdxSize - 1;
+            mask[i / 8] |= 1 << (i % 8);
+        }
+    }
+
+    let bitmap = Bitmap::try_new(mask, out.len()).unwrap();
+    IdxCa::new_from_owned_with_null_bitmap("", out, Some(bitmap))
+}
+
+fn join_asof_nearest<T: NumericNative>(
+    left: &[T],
+    right: &[T],
+    tolerance: T::Abs,
+) -> IdxCa {
+    if left.is_empty() || right.is_empty() {
+        return IdxCa::full_null("", left.len());
+    }
+
+    let mut out = vec![0; left.len()];
+    let mut mask = vec![0; (left.len() + 7) / 8];
+    let mut offset = right.len();
+
+    for (i, &val_l) in left.iter().enumerate().rev() {
+        if join_asof_nearest_step(&mut offset, val_l, |j| right[j], tolerance) {
+            out[i] = offset as IdxSize - 1;
+            mask[i / 8] |= 1 << (i % 8);
+        }
+    }
+
+    let bitmap = Bitmap::try_new(mask, out.len()).unwrap();
+    IdxCa::new_from_owned_with_null_bitmap("", out, Some(bitmap))
+}
+
+pub(crate) fn join_asof<T>(
+    input_ca: &ChunkedArray<T>,
+    other: &Series,
+    strategy: AsofStrategy,
+    tolerance: Option<AnyValue<'static>>,
+) -> PolarsResult<IdxCa>
 where
-    T: PartialOrd + Copy + Debug + Sub<Output = T>,
+    T: PolarsNumericType,
+    T::Native: Bounded + PartialOrd,
+    <T::Native as AbsDiff>::Abs: Bounded,
 {
-    if right.is_empty() {
-        return vec![None; left.len()];
-    }
-    if left.is_empty() {
-        return vec![];
-    }
-    let mut out = Vec::with_capacity(left.len());
+    let abs_tolerance = if let Some(t) = tolerance {
+        t.extract::<T::Native>().unwrap().abs_diff(T::Native::zero())
+    } else {
+        T::Native::max_abs_diff()       
+    };
+    let other = input_ca.unpack_series_matching_type(other)?;
 
-    let mut offset = 0 as IdxSize;
-    // left array could start lower than right;
-    // left: [-1, 0, 1, 2],
-    // right: [1, 2, 3]
-    // first values should be None, until left has caught up
-    let mut left_caught_up = false;
+    // Cont_slice requires a single chunk.
+    let ca = input_ca.rechunk();
+    let other = other.rechunk();
 
-    // init with left so that the distance starts at 0
-    let mut previous_right = left[0];
-    let mut dist;
-
-    for &val_l in left {
-        loop {
-            dist = val_l - previous_right;
-
-            match right.get(offset as usize) {
-                Some(&val_r) => {
-                    // we fill nulls until left value is larger than right
-                    if !left_caught_up {
-                        if val_l < val_r {
-                            out.push(None);
-                            break;
-                        } else {
-                            left_caught_up = true;
-                        }
-                    }
-
-                    // right is larger than left.
-                    // we take the last value before that
-                    if val_r > val_l {
-                        let value = if dist > tolerance {
-                            None
-                        } else {
-                            Some(offset - 1)
-                        };
-
-                        out.push(value);
-                        break;
-                    }
-                    // right still smaller or equal to left
-                    // continue looping the right side
-                    else {
-                        previous_right = val_r;
-                        offset += 1;
-                    }
-                },
-                // we depleted the right array
-                // we cannot fill the remainder of the value, because we need to check tolerances
-                None => {
-                    // if we have previous value, continue with that one
-                    let val = if left_caught_up && dist <= tolerance {
-                        Some(offset - 1)
-                    }
-                    // else null
-                    else {
-                        None
-                    };
-                    out.push(val);
-                    break;
-                },
-            }
-        }
-    }
-    out
-}
-
-pub(super) fn join_asof_backward<T: PartialOrd + Copy + Debug>(
-    left: &[T],
-    right: &[T],
-) -> Vec<Option<IdxSize>> {
-    let mut out = Vec::with_capacity(left.len());
-
-    let mut offset = 0 as IdxSize;
-    // left array could start lower than right;
-    // left: [-1, 0, 1, 2],
-    // right: [1, 2, 3]
-    // first values should be None, until left has caught up
-    let mut left_caught_up = false;
-
-    for &val_l in left {
-        loop {
-            match right.get(offset as usize) {
-                Some(&val_r) => {
-                    // we fill nulls until left value is larger than right
-                    if !left_caught_up {
-                        if val_l < val_r {
-                            out.push(None);
-                            break;
-                        } else {
-                            left_caught_up = true;
-                        }
-                    }
-
-                    // right is larger than left.
-                    // we take the last value before that
-                    if val_r > val_l {
-                        out.push(Some(offset - 1));
-                        break;
-                    }
-                    // right still smaller or equal to left
-                    // continue looping the right side
-                    else {
-                        offset += 1;
-                    }
-                },
-                // we depleted the right array
-                None => {
-                    // if we have previous value, continue with that one
-                    let val = if left_caught_up {
-                        Some(offset - 1)
-                    }
-                    // else all null
-                    else {
-                        None
-                    };
-                    out.extend(std::iter::repeat(val).take(left.len() - out.len()));
-                    return out;
-                },
-            }
-        }
-    }
-    out
-}
-
-pub(super) fn join_asof_nearest_with_tolerance<
-    T: PartialOrd + Copy + Debug + Sub<Output = T> + Add<Output = T> + Bounded,
->(
-    left: &[T],
-    right: &[T],
-    tolerance: T,
-) -> Vec<Option<IdxSize>> {
-    let n_left = left.len();
-
-    if left.is_empty() {
-        return Vec::new();
-    }
-    let mut out = Vec::with_capacity(n_left);
-    if right.is_empty() {
-        out.extend(std::iter::repeat(None).take(n_left));
-        return out;
-    }
-
-    // If we know the first/last values, we can leave early in many cases.
-    let n_right = right.len();
-    let first_left = left[0];
-    let last_left = left[n_left - 1];
-    let r_lower_bound = right[0] - tolerance;
-    let r_upper_bound = right[n_right - 1] + tolerance;
-
-    // If the left and right hand side are disjoint partitions, we can early exit.
-    if (r_lower_bound > last_left) || (r_upper_bound < first_left) {
-        out.extend(std::iter::repeat(None).take(n_left));
-        return out;
-    }
-
-    for &val_l in left {
-        // Detect early exit cases
-        if val_l < r_lower_bound {
-            // The left value is too low.
-            out.push(None);
-            continue;
-        } else if val_l > r_upper_bound {
-            // The left value is too high. Subsequent left values are guaranteed to
-            // be too high as well, so we can early return.
-            out.extend(std::iter::repeat(None).take(n_left - out.len()));
-            return out;
-        }
-
-        // The left value is contained within the RHS window, so we might have a match.
-        let mut offset: IdxSize = 0;
-        let mut dist = tolerance;
-        let mut found_window = false;
-        let val_l_upper_bound = val_l + tolerance;
-        for &val_r in right {
-            // We haven't reached the window yet; go to next RHS value.
-            if val_l > val_r + tolerance {
-                offset += 1;
-                continue;
-            }
-
-            // We passed the window without a match, so leave immediately.
-            if !found_window && (val_r > val_l_upper_bound) {
-                out.push(None);
-                break;
-            }
-
-            // We made it to the window: matches are now possible, start measuring distance.
-            let current_dist = if val_l > val_r {
-                val_l - val_r
-            } else {
-                val_r - val_l
-            };
-            if current_dist <= dist {
-                dist = current_dist;
-                if offset == (n_right - 1) as IdxSize {
-                    // We're the last item, it's a match.
-                    out.push(Some(offset));
-                    break;
-                }
-            } else {
-                // We'ved moved farther away, so the last element was the match if it's within tolerance
-                if found_window {
-                    out.push(Some(offset - 1));
-                } else {
-                    out.push(None);
-                }
-                break;
-            }
-            found_window = true;
-            offset += 1;
-        }
-    }
-
-    out
-}
-
-pub(super) fn join_asof_nearest<T: PartialOrd + Copy + Debug + Sub<Output = T> + Bounded>(
-    left: &[T],
-    right: &[T],
-) -> Vec<Option<IdxSize>> {
-    let mut out = Vec::with_capacity(left.len());
-    let mut offset = 0 as IdxSize;
-    let max_value = <T as num_traits::Bounded>::max_value();
-
-    for &val_l in left {
-        let mut dist: T = max_value;
-        loop {
-            match right.get(offset as usize) {
-                Some(&val_r) => {
-                    // This is (val_r - val_l).abs(), but works on strings/dates
-                    let dist_curr = if val_r > val_l {
-                        val_r - val_l
-                    } else {
-                        val_l - val_r
-                    };
-                    if dist_curr <= dist {
-                        // candidate for match
-                        dist = dist_curr;
-                        offset += 1;
-                    } else {
-                        // distance has increased, we're now farther away, so previous element was closest
-                        out.push(Some(offset - 1));
-
-                        // The next left-item may match on the same item, so we need to rewind the offset
-                        offset -= 1;
-                        break;
-                    }
-                },
-
-                None => {
-                    if offset > 1 {
-                        // we've reached the end with no matches, so the last item is the nearest for all remaining
-                        out.extend(
-                            std::iter::repeat(Some(offset - 1)).take(left.len() - out.len()),
-                        );
-                    } else {
-                        // this is only hit when the right frame is empty
-                        out.extend(std::iter::repeat(None).take(left.len() - out.len()));
-                    }
-                    return out;
-                },
-            }
-        }
-    }
-
-    out
-}
-
-pub(super) fn join_asof_forward<T: PartialOrd + Copy + Debug>(
-    left: &[T],
-    right: &[T],
-) -> Vec<Option<IdxSize>> {
-    let mut out = Vec::with_capacity(left.len());
-    let mut offset = 0 as IdxSize;
-
-    for &val_l in left {
-        loop {
-            match right.get(offset as usize) {
-                Some(&val_r) => {
-                    if val_r >= val_l {
-                        out.push(Some(offset));
-                        break;
-                    }
-                    offset += 1;
-                },
-                None => {
-                    out.extend(std::iter::repeat(None).take(left.len() - out.len()));
-                    return out;
-                },
-            }
-        }
-    }
-    out
+    let out = match strategy {
+        AsofStrategy::Forward => join_asof_forward(
+            ca.cont_slice().unwrap(),
+            other.cont_slice().unwrap(),
+            abs_tolerance,
+        ),
+        AsofStrategy::Backward => join_asof_backward(
+            ca.cont_slice().unwrap(),
+            other.cont_slice().unwrap(),
+            abs_tolerance
+        ),
+        AsofStrategy::Nearest => join_asof_nearest(
+            ca.cont_slice().unwrap(),
+            other.cont_slice().unwrap(),
+            abs_tolerance
+        ),
+    };
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -362,35 +129,44 @@ mod test {
         let a = [-1, 2, 3, 3, 3, 4];
         let b = [1, 2, 3, 3];
 
-        let tuples = join_asof_backward(&a, &b);
+        let tuples = join_asof_backward(&a, &b, u32::MAX);
         assert_eq!(tuples.len(), a.len());
-        assert_eq!(tuples, &[None, Some(1), Some(3), Some(3), Some(3), Some(3)]);
+        assert_eq!(
+            tuples.to_vec(),
+            &[None, Some(1), Some(3), Some(3), Some(3), Some(3)]
+        );
 
         let b = [1, 2, 4, 5];
-        let tuples = join_asof_backward(&a, &b);
-        assert_eq!(tuples, &[None, Some(1), Some(1), Some(1), Some(1), Some(2)]);
+        let tuples = join_asof_backward(&a, &b, u32::MAX);
+        assert_eq!(
+            tuples.to_vec(),
+            &[None, Some(1), Some(1), Some(1), Some(1), Some(2)]
+        );
 
         let a = [2, 4, 4, 4];
         let b = [1, 2, 3, 3];
-        let tuples = join_asof_backward(&a, &b);
-        assert_eq!(tuples, &[Some(1), Some(3), Some(3), Some(3)]);
+        let tuples = join_asof_backward(&a, &b, u32::MAX);
+        assert_eq!(tuples.to_vec(), &[Some(1), Some(3), Some(3), Some(3)]);
     }
 
     #[test]
     fn test_asof_backward_tolerance() {
         let a = [-1, 20, 25, 30, 30, 40];
         let b = [10, 20, 30, 30];
-        let tuples = join_asof_backward_with_tolerance(&a, &b, 4);
-        assert_eq!(tuples, &[None, Some(1), None, Some(3), Some(3), None]);
+        let tuples = join_asof_backward(&a, &b, 4u32);
+        assert_eq!(
+            tuples.to_vec(),
+            &[None, Some(1), None, Some(3), Some(3), None]
+        );
     }
 
     #[test]
     fn test_asof_forward_tolerance() {
         let a = [-1, 20, 25, 30, 30, 40, 52];
         let b = [10, 20, 33, 55];
-        let tuples = join_asof_forward_with_tolerance(&a, &b, 4);
+        let tuples = join_asof_forward(&a, &b, 4u32);
         assert_eq!(
-            tuples,
+            tuples.to_vec(),
             &[None, Some(1), None, Some(2), Some(2), None, Some(3)]
         );
     }
@@ -400,8 +176,8 @@ mod test {
         let a = [-1, 1, 2, 4, 6];
         let b = [1, 2, 4, 5];
 
-        let tuples = join_asof_forward(&a, &b);
+        let tuples = join_asof_forward(&a, &b, u32::MAX);
         assert_eq!(tuples.len(), a.len());
-        assert_eq!(tuples, &[Some(0), Some(0), Some(1), Some(2), None]);
+        assert_eq!(tuples.to_vec(), &[Some(0), Some(0), Some(1), Some(2), None]);
     }
 }

--- a/crates/polars-ops/src/frame/join/asof/default.rs
+++ b/crates/polars-ops/src/frame/join/asof/default.rs
@@ -5,8 +5,7 @@ use polars_core::prelude::*;
 use polars_utils::abs_diff::AbsDiff;
 
 use super::{
-    AsofJoinBackwardState,
-    AsofJoinForwardState, AsofJoinNearestState, AsofJoinState, AsofStrategy,
+    AsofJoinBackwardState, AsofJoinForwardState, AsofJoinNearestState, AsofJoinState, AsofStrategy,
 };
 
 fn join_asof_impl<'a, T, S, F>(left: &'a T::Array, right: &'a T::Array, mut filter: F) -> IdxCa

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -794,6 +794,7 @@ pub trait AsofJoinBy: IntoDf {
         check_asof_columns(
             &left_asof,
             &right_asof,
+            tolerance.is_some(),
             left_by.is_empty() && right_by.is_empty(),
         )?;
 

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -246,7 +246,7 @@ where
                     for h_left in by_left_view.iter().copied() {
                         let idx_left = offset + ctr;
                         ctr += 1;
-                        let opt_left_val = left_val_arr.get(idx_left as usize);
+                        let opt_left_val = left_val_arr.get(idx_left);
 
                         let Some(left_val) = opt_left_val else {
                             results.push(None);
@@ -264,7 +264,7 @@ where
                                 mk::compare_df_rows2(
                                     by_left,
                                     by_right,
-                                    idx_left as usize,
+                                    idx_left,
                                     idx_right as usize,
                                 )
                             }
@@ -314,12 +314,12 @@ where
             DataType::Utf8 => {
                 let left_by = &left_by_s.utf8().unwrap().as_binary();
                 let right_by = right_by_s.utf8().unwrap().as_binary();
-                asof_join_by_binary::<T, A, F>(&left_by, &right_by, left_asof, right_asof, filter)
+                asof_join_by_binary::<T, A, F>(left_by, &right_by, left_asof, right_asof, filter)
             },
             DataType::Binary => {
                 let left_by = &left_by_s.binary().unwrap();
                 let right_by = right_by_s.binary().unwrap();
-                asof_join_by_binary::<T, A, F>(&left_by, &right_by, left_asof, right_asof, filter)
+                asof_join_by_binary::<T, A, F>(left_by, right_by, left_asof, right_asof, filter)
             },
             _ => {
                 if left_by_s.bit_repr_is_large() {
@@ -429,35 +429,35 @@ fn dispatch_join_type(
     match left_asof.dtype() {
         DataType::Int64 => {
             let ca = left_asof.i64().unwrap();
-            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+            dispatch_join_strategy_numeric(ca, right_asof, left_by, right_by, strategy, tolerance)
         },
         DataType::Int32 => {
             let ca = left_asof.i32().unwrap();
-            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+            dispatch_join_strategy_numeric(ca, right_asof, left_by, right_by, strategy, tolerance)
         },
         DataType::UInt64 => {
             let ca = left_asof.u64().unwrap();
-            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+            dispatch_join_strategy_numeric(ca, right_asof, left_by, right_by, strategy, tolerance)
         },
         DataType::UInt32 => {
             let ca = left_asof.u32().unwrap();
-            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+            dispatch_join_strategy_numeric(ca, right_asof, left_by, right_by, strategy, tolerance)
         },
         DataType::Float32 => {
             let ca = left_asof.f32().unwrap();
-            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+            dispatch_join_strategy_numeric(ca, right_asof, left_by, right_by, strategy, tolerance)
         },
         DataType::Float64 => {
             let ca = left_asof.f64().unwrap();
-            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+            dispatch_join_strategy_numeric(ca, right_asof, left_by, right_by, strategy, tolerance)
         },
         DataType::Boolean => {
             let ca = left_asof.bool().unwrap();
-            dispatch_join_strategy::<BooleanType>(ca, &right_asof, left_by, right_by, strategy)
+            dispatch_join_strategy::<BooleanType>(ca, right_asof, left_by, right_by, strategy)
         },
         DataType::Binary => {
             let ca = left_asof.binary().unwrap();
-            dispatch_join_strategy::<BinaryType>(ca, &right_asof, left_by, right_by, strategy)
+            dispatch_join_strategy::<BinaryType>(ca, right_asof, left_by, right_by, strategy)
         },
         DataType::Utf8 => {
             let ca = left_asof.utf8().unwrap();
@@ -534,8 +534,8 @@ pub trait AsofJoinBy: IntoDf {
         }
 
         let right_join_tuples = dispatch_join_type(
-            &*left_asof,
-            &*right_asof,
+            &left_asof,
+            &right_asof,
             &mut left_by,
             &mut right_by,
             strategy,

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -1,377 +1,53 @@
-use std::fmt::Debug;
 use std::hash::Hash;
-use std::ops::{Add, Sub};
 
 use ahash::RandomState;
-use arrow::types::NativeType;
-use num_traits::{Bounded, Zero};
+use num_traits::Zero;
 use polars_core::hashing::partition::AsU64;
 use polars_core::hashing::{_df_rows_to_hashes_threaded_vertical, _HASHMAP_INIT_SIZE};
 use polars_core::utils::{split_ca, split_df};
 use polars_core::POOL;
+use polars_utils::abs_diff::AbsDiff;
 use rayon::prelude::*;
 use smartstring::alias::String as SmartString;
 
 use super::*;
 use crate::frame::IntoDf;
 
-pub(super) unsafe fn join_asof_backward_with_indirection_and_tolerance<
-    T: PartialOrd + Copy + Sub<Output = T> + Debug,
->(
-    val_l: T,
-    right: &[T],
-    offsets: &[IdxSize],
-    tolerance: T,
-) -> (Option<IdxSize>, usize) {
-    if offsets.is_empty() {
-        return (None, 0);
-    }
-    let mut previous_idx = *offsets.get_unchecked(0);
-    let first = *right.get_unchecked(previous_idx as usize);
-    if val_l < first {
-        (None, 0)
-    } else {
-        for (idx, &offset) in offsets.iter().enumerate() {
-            let val_r = *right.get_unchecked(offset as usize);
 
-            // the point that is larger is not allowed
-            if val_r > val_l {
-                // compute the distance of previous point, that one was still backwards
-                let previous_value = *right.get_unchecked(previous_idx as usize);
-                let dist = val_l - previous_value;
-                return if dist > tolerance {
-                    (None, idx)
-                } else {
-                    (Some(previous_idx), idx)
-                };
-            }
-            previous_idx = offset
-        }
-        // check remaining values that still suffice the distance constraint
-        let previous_value = *right.get_unchecked(previous_idx as usize);
-        let dist = val_l - previous_value;
-        if dist > tolerance {
-            (None, offsets.len())
-        } else {
-            (Some(previous_idx), offsets.len())
-        }
-    }
-}
-
-pub(super) unsafe fn join_asof_forward_with_indirection_and_tolerance<
-    T: PartialOrd + Copy + Sub<Output = T> + Debug,
->(
-    val_l: T,
-    right: &[T],
-    offsets: &[IdxSize],
-    tolerance: T,
-) -> (Option<IdxSize>, usize) {
-    if offsets.is_empty() {
-        return (None, 0);
-    }
-    let last_offset = *offsets.get_unchecked(offsets.len() - 1);
-    let last_value = *right.get_unchecked(last_offset as usize);
-    if val_l <= last_value {
-        for (idx, &offset) in offsets.iter().enumerate() {
-            let val_r = *right.get_unchecked(offset as usize);
-            if val_r >= val_l {
-                let dist = val_r - val_l;
-                return if dist > tolerance {
-                    (None, idx)
-                } else {
-                    (Some(offset), idx)
-                };
-            }
-        }
-    }
-    (None, offsets.len())
-}
-
-pub(super) unsafe fn join_asof_nearest_with_indirection_and_tolerance<
-    T: PartialOrd + Copy + Debug + Sub<Output = T> + Add<Output = T>,
->(
-    val_l: T,
-    right: &[T],
-    offsets: &[IdxSize],
-    tolerance: T,
-) -> (Option<IdxSize>, usize) {
-    if offsets.is_empty() {
-        return (None, 0);
-    }
-
-    // If we know the first/last values, we can leave early in many cases.
-    let n_right = offsets.len();
-    let r_upper_bound = right[offsets[n_right - 1] as usize] + tolerance;
-
-    // The left value is too high. Subsequent values are guaranteed to be too
-    // high as well, so we can early return.
-    if val_l > r_upper_bound {
-        return (None, n_right - 1);
-    }
-
-    let mut dist: T = tolerance;
-    let mut prev_offset: IdxSize = 0;
-    let mut found_window = false;
-    for (idx, &offset) in offsets.iter().enumerate() {
-        let val_r = *right.get_unchecked(offset as usize);
-
-        // We haven't reached the window yet; go to next RHS value.
-        if val_l > val_r + tolerance {
-            prev_offset = offset;
-            continue;
-        }
-
-        // We passed the window without a match, so leave immediately.
-        if !found_window && (val_r > val_l + tolerance) {
-            return (None, n_right - 1);
-        }
-
-        // We made it to the window: matches are now possible, start measuring distance.
-        let current_dist = if val_l > val_r {
-            val_l - val_r
-        } else {
-            val_r - val_l
-        };
-        if current_dist <= dist {
-            dist = current_dist;
-            if idx == (n_right - 1) {
-                // We're the last item, it's a match.
-                return (Some(offset), idx);
-            }
-            prev_offset = offset;
-        } else {
-            // We'ved moved farther away, so the last element was the match if it's within tolerance
-            if found_window {
-                return (Some(prev_offset), idx - 1);
-            } else {
-                return (None, n_right - 1);
-            }
-        }
-        found_window = true;
-    }
-
-    // This should be unreachable.
-    (None, 0)
-}
-
-pub(super) unsafe fn join_asof_backward_with_indirection<T: PartialOrd + Copy + Debug>(
-    val_l: T,
-    right: &[T],
-    offsets: &[IdxSize],
-    // only there to have the same function signature
-    _: T,
-) -> (Option<IdxSize>, usize) {
-    if offsets.is_empty() {
-        return (None, 0);
-    }
-    let mut previous = *offsets.get_unchecked(0);
-    let first = *right.get_unchecked(previous as usize);
-    if val_l < first {
-        (None, 0)
-    } else {
-        for (idx, &offset) in offsets.iter().enumerate() {
-            let val_r = *right.get_unchecked(offset as usize);
-            if val_r > val_l {
-                return (Some(previous), idx);
-            }
-            previous = offset
-        }
-        (Some(previous), offsets.len())
-    }
-}
-
-pub(super) unsafe fn join_asof_forward_with_indirection<T: PartialOrd + Copy + Debug>(
-    val_l: T,
-    right: &[T],
-    offsets: &[IdxSize],
-    // only there to have the same function signature
-    _: T,
-) -> (Option<IdxSize>, usize) {
-    if offsets.is_empty() {
-        return (None, 0);
-    }
-    let last_offset = *offsets.get_unchecked(offsets.len() - 1);
-    let last_value = *right.get_unchecked(last_offset as usize);
-    if val_l <= last_value {
-        for (idx, &offset) in offsets.iter().enumerate() {
-            let val_r = *right.get_unchecked(offset as usize);
-            if val_r >= val_l {
-                return (Some(offset), idx);
-            }
-        }
-    }
-    (None, offsets.len())
-}
-
-pub(super) unsafe fn join_asof_nearest_with_indirection<
-    T: PartialOrd + Copy + Debug + Sub<Output = T> + Bounded,
->(
-    val_l: T,
-    right: &[T],
-    offsets: &[IdxSize],
-    // only there to have the same function signature
-    _: T,
-) -> (Option<IdxSize>, usize) {
-    if offsets.is_empty() {
-        return (None, 0);
-    }
-    let max_possible_dist = <T as Bounded>::max_value();
-    let mut dist: T = max_possible_dist;
-    let mut prev_offset: IdxSize = 0;
-    for (idx, &offset) in offsets.iter().enumerate() {
-        let val_r = *right.get_unchecked(offset as usize);
-        // This is (val_r - val_l).abs(), but works on strings/dates
-        let dist_curr = if val_r > val_l {
-            val_r - val_l
-        } else {
-            val_l - val_r
-        };
-        if dist_curr <= dist {
-            // candidate for match
-            dist = dist_curr;
-        } else {
-            return (Some(prev_offset), idx - 1);
-        }
-        prev_offset = offset;
-    }
-
-    // if we've reached the end with nearest and haven't returned, it means that the last item was the closest
-    // note for a nearest-match, we can re-match on the same val_r next time,
-    // so we need to rewind the idx by 1
-    (Some(offsets[offsets.len() - 1]), offsets.len() - 1)
-}
-
-// process the group taken by the `by` operation and keep track of the offset.
-// we don't process a group at once but per `index_left` we find the `right_index` and keep track
-// of the offsets we have already processed in a separate hashmap. Then on a next iteration we can
-// continue from that offsets location.
-#[allow(clippy::too_many_arguments)]
-#[allow(clippy::type_complexity)]
-fn process_group<K, T>(
-    k: K,
-    idx_left: IdxSize,
-    tolerance: T,
-    indexes_right: &[IdxSize],
-    right_tbl_offsets: &mut PlHashMap<K, (usize, Option<IdxSize>)>,
-    join_asof_fn: unsafe fn(T, &[T], &[IdxSize], T) -> (Option<IdxSize>, usize),
-    left_asof: &[T],
-    right_asof: &[T],
-    results: &mut Vec<Option<IdxSize>>,
-    forward: bool,
-) where
-    K: Hash + PartialEq + Eq,
-    T: NativeType + Sub<Output = T> + PartialOrd + Zero,
-{
-    let (offset_slice, mut previous_join_idx) =
-        *right_tbl_offsets.get(&k).unwrap_or(&(0usize, None));
-    debug_assert!((idx_left as usize) < left_asof.len());
-    let val_l = unsafe { *left_asof.get_unchecked(idx_left as usize) };
-    // Safety;
-    // elide bound checks
-    let (join_idx, offset_slice_add) =
-        unsafe { join_asof_fn(val_l, right_asof, &indexes_right[offset_slice..], tolerance) };
-    let offset_slice = offset_slice + offset_slice_add;
-
-    match join_idx {
-        Some(_) => {
-            results.push(join_idx);
-            right_tbl_offsets.insert(k, (offset_slice, join_idx));
-        },
-        None => {
-            if forward {
-                previous_join_idx = None;
-            }
-            if tolerance > Zero::zero() {
-                if let Some(idx) = previous_join_idx {
-                    debug_assert!((idx as usize) < right_asof.len());
-                    let val_r = unsafe { *right_asof.get_unchecked(idx as usize) };
-                    let dist = val_l - val_r;
-                    if dist > tolerance {
-                        previous_join_idx = None;
-                    }
-                }
-            }
-            results.push(previous_join_idx)
-        },
-    }
-}
-
-fn asof_join_by_numeric<T, S>(
+fn asof_join_by_numeric<T, S, A, F>(
     by_left: &ChunkedArray<S>,
     by_right: &ChunkedArray<S>,
     left_asof: &ChunkedArray<T>,
     right_asof: &ChunkedArray<T>,
-    tolerance: Option<AnyValue<'static>>,
-    strategy: AsofStrategy,
+    filter: F,
 ) -> PolarsResult<Vec<Option<IdxSize>>>
 where
-    T: PolarsNumericType,
+    T: PolarsDataType,
     S: PolarsNumericType,
     S::Native: Hash + Eq + AsU64,
+    A: for<'a> AsofJoinState<T::Physical<'a>>,
+    F: Sync + for<'a> Fn(T::Physical<'a>, T::Physical<'a>) -> bool,
 {
-    #[allow(clippy::type_complexity)]
-    let (join_asof_fn, tolerance, forward): (
-        unsafe fn(T::Native, &[T::Native], &[IdxSize], T::Native) -> (Option<IdxSize>, usize),
-        _,
-        _,
-    ) = match (tolerance, strategy) {
-        (Some(tolerance), AsofStrategy::Backward) => {
-            let tol = tolerance.extract::<T::Native>().unwrap();
-            (
-                join_asof_backward_with_indirection_and_tolerance,
-                tol,
-                false,
-            )
-        },
-        (None, AsofStrategy::Backward) => (
-            join_asof_backward_with_indirection,
-            T::Native::zero(),
-            false,
-        ),
-        (Some(tolerance), AsofStrategy::Forward) => {
-            let tol = tolerance.extract::<T::Native>().unwrap();
-            (join_asof_forward_with_indirection_and_tolerance, tol, true)
-        },
-        (None, AsofStrategy::Forward) => {
-            (join_asof_forward_with_indirection, T::Native::zero(), true)
-        },
-        (Some(tolerance), AsofStrategy::Nearest) => {
-            let tol = tolerance.extract::<T::Native>().unwrap();
-            (join_asof_nearest_with_indirection_and_tolerance, tol, false)
-        },
-        (None, AsofStrategy::Nearest) => {
-            (join_asof_nearest_with_indirection, T::Native::zero(), false)
-        },
-    };
-
     let left_asof = left_asof.rechunk();
-    let err = |_: PolarsError| {
-        polars_err!(
-            ComputeError: "keys are not allowed to have null values in asof join"
-        )
-    };
-    let left_asof = left_asof.cont_slice().map_err(err)?;
-
     let right_asof = right_asof.rechunk();
-    let right_asof = right_asof.cont_slice().map_err(err)?;
+    let left_val_arr = left_asof.downcast_iter().next().unwrap();
+    let right_val_arr = right_asof.downcast_iter().next().unwrap();
 
     let n_threads = POOL.current_num_threads();
     let splitted_left = split_ca(by_left, n_threads).unwrap();
     let splitted_right = split_ca(by_right, n_threads).unwrap();
 
-    let vals_left = splitted_left
+    // TODO: handle nulls more efficiently. Right now we just join on the value
+    // ignoring the validity mask, and ignore the nulls later.
+    let right_slices = splitted_right
         .iter()
-        .map(|ca| ca.cont_slice().unwrap())
-        .collect::<Vec<_>>();
-    let vals_right = splitted_right
-        .iter()
-        .map(|ca| ca.cont_slice().unwrap())
-        .collect::<Vec<_>>();
+        .map(|ca| ca.downcast_iter().next().unwrap().values_iter())
+        .collect();
+    let hash_tbls = build_tables(right_slices);
 
-    let hash_tbls = build_tables(vals_right);
-
-    // we determine the offset so that we later know which index to store in the join tuples
-    let offsets = vals_left
+    // We determine the offset of each thread block so that we later know which
+    // index to store in the join tuples.
+    let offsets = splitted_left
         .iter()
         .map(|ph| ph.len())
         .scan(0, |state, val| {
@@ -384,122 +60,91 @@ where
     let n_tables = hash_tbls.len() as u64;
     debug_assert!(n_tables.is_power_of_two());
 
-    // next we probe the right relation
-    Ok(POOL.install(|| {
-        vals_left
-            .into_par_iter()
-            .zip(offsets)
-            // probes_hashes: Vec<u64> processed by this thread
-            // offset: offset index
-            .flat_map(|(vals_left, offset)| {
-                // local reference
-                let hash_tbls = &hash_tbls;
+    // Now we probe the right hand side for each left hand side.
+    Ok(POOL
+        .install(|| {
+            splitted_left
+                .into_par_iter()
+                .zip(offsets)
+                .flat_map(|(by_left, offset)| {
+                    let mut results = Vec::with_capacity(by_left.len());
+                    let mut group_states: PlHashMap<S::Native, A> =
+                        PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
 
-                // assume the result tuples equal length of the no. of hashes processed by this thread.
-                let mut results = Vec::with_capacity(vals_left.len());
+                    let by_left_chunk = by_left.downcast_iter().next().unwrap();
+                    for (rel_idx_left, opt_by_left_k) in by_left_chunk.iter().enumerate() {
+                        let Some(by_left_k) = opt_by_left_k else {
+                            results.push(None);
+                            continue;
+                        };
+                        let idx_left = (rel_idx_left + offset) as IdxSize;
+                        let Some(left_val) = left_val_arr.get(idx_left as usize) else {
+                            results.push(None);
+                            continue;
+                        };
 
-                let mut right_tbl_offsets = PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
+                        let group_probe_table = unsafe {
+                            get_hash_tbl_threaded_join_partitioned(
+                                by_left_k.as_u64(),
+                                &hash_tbls,
+                                n_tables,
+                            )
+                        };
+                        let Some(right_grp_idxs) = group_probe_table.get(by_left_k) else {
+                            results.push(None);
+                            continue;
+                        };
 
-                vals_left.iter().enumerate().for_each(|(idx_a, k)| {
-                    let idx_a = (idx_a + offset) as IdxSize;
-                    // probe table that contains the hashed value
-                    let current_probe_table = unsafe {
-                        get_hash_tbl_threaded_join_partitioned(k.as_u64(), hash_tbls, n_tables)
-                    };
-
-                    // we already hashed, so we don't have to hash again.
-                    let value = current_probe_table.get(k);
-
-                    match value {
-                        // left and right matches
-                        Some(indexes_b) => {
-                            process_group(
-                                *k,
-                                idx_a,
-                                tolerance,
-                                indexes_b,
-                                &mut right_tbl_offsets,
-                                join_asof_fn,
-                                left_asof,
-                                right_asof,
-                                &mut results,
-                                forward,
-                            );
-                        },
-                        // only left values, right = null
-                        None => results.push(None),
+                        let grp_state = group_states.entry(*by_left_k).or_default();
+                        let r_idx = grp_state.next(
+                            &left_val,
+                            |i| right_val_arr.get(right_grp_idxs[i as usize] as usize),
+                            right_grp_idxs.len() as IdxSize,
+                        );
+                        
+                        let ret = r_idx
+                            .map(|i| right_grp_idxs[i as usize])
+                            .filter(|i| {
+                                let right_val = right_val_arr.get(*i as usize).unwrap();
+                                filter(left_val, right_val)
+                            });
+                        results.push(ret);
                     }
-                });
-                results
-            })
-            .collect()
-    }))
+                    results
+                })
+        })
+        .collect())
 }
 
-fn asof_join_by_binary<T>(
+fn asof_join_by_binary<T, A, F>(
     by_left: &BinaryChunked,
     by_right: &BinaryChunked,
     left_asof: &ChunkedArray<T>,
     right_asof: &ChunkedArray<T>,
-    tolerance: Option<AnyValue<'static>>,
-    strategy: AsofStrategy,
+    filter: F,
 ) -> Vec<Option<IdxSize>>
 where
-    T: PolarsNumericType,
+    T: PolarsDataType,
+    A: for<'a> AsofJoinState<T::Physical<'a>>,
+    F: Sync + for<'a> Fn(T::Physical<'a>, T::Physical<'a>) -> bool,
 {
-    #[allow(clippy::type_complexity)]
-    let (join_asof_fn, tolerance, forward): (
-        unsafe fn(T::Native, &[T::Native], &[IdxSize], T::Native) -> (Option<IdxSize>, usize),
-        _,
-        _,
-    ) = match (tolerance, strategy) {
-        (Some(tolerance), AsofStrategy::Backward) => {
-            let tol = tolerance.extract::<T::Native>().unwrap();
-            (
-                join_asof_backward_with_indirection_and_tolerance,
-                tol,
-                false,
-            )
-        },
-        (None, AsofStrategy::Backward) => (
-            join_asof_backward_with_indirection,
-            T::Native::zero(),
-            false,
-        ),
-        (Some(tolerance), AsofStrategy::Forward) => {
-            let tol = tolerance.extract::<T::Native>().unwrap();
-            (join_asof_forward_with_indirection_and_tolerance, tol, true)
-        },
-        (None, AsofStrategy::Forward) => {
-            (join_asof_forward_with_indirection, T::Native::zero(), true)
-        },
-        (Some(tolerance), AsofStrategy::Nearest) => {
-            let tol = tolerance.extract::<T::Native>().unwrap();
-            (join_asof_nearest_with_indirection_and_tolerance, tol, false)
-        },
-        (None, AsofStrategy::Nearest) => {
-            (join_asof_nearest_with_indirection, T::Native::zero(), false)
-        },
-    };
-
     let left_asof = left_asof.rechunk();
-    let left_asof = left_asof.cont_slice().unwrap();
-
     let right_asof = right_asof.rechunk();
-    let right_asof = right_asof.cont_slice().unwrap();
+    let left_val_arr = left_asof.downcast_iter().next().unwrap();
+    let right_val_arr = right_asof.downcast_iter().next().unwrap();
 
     let n_threads = POOL.current_num_threads();
     let splitted_by_left = split_ca(by_left, n_threads).unwrap();
     let splitted_right = split_ca(by_right, n_threads).unwrap();
 
     let hb = RandomState::default();
-    let vals_left = prepare_bytes(&splitted_by_left, &hb);
-    let vals_right = prepare_bytes(&splitted_right, &hb);
+    let prep_by_left = prepare_bytes(&splitted_by_left, &hb);
+    let prep_by_right = prepare_bytes(&splitted_right, &hb);
+    let hash_tbls = build_tables(prep_by_right);
 
-    let hash_tbls = build_tables(vals_right);
-
-    // we determine the offset so that we later know which index to store in the join tuples
-    let offsets = vals_left
+    // We determine the offset of each thread block so that we later know which
+    // index to store in the join tuples.
+    let offsets = prep_by_left
         .iter()
         .map(|ph| ph.len())
         .scan(0, |state, val| {
@@ -512,58 +157,57 @@ where
     let n_tables = hash_tbls.len() as u64;
     debug_assert!(n_tables.is_power_of_two());
 
-    // next we probe the right relation
+    // Now we probe the right hand side for each left hand side.
     POOL.install(|| {
-        vals_left
+        prep_by_left
             .into_par_iter()
             .zip(offsets)
-            // probes_hashes: Vec<u64> processed by this thread
-            // offset: offset index
-            .flat_map(|(vals_left, offset)| {
-                // local reference
-                let hash_tbls = &hash_tbls;
+            .flat_map(|(by_left, offset)| {
+                let mut results = Vec::with_capacity(by_left.len());
+                let mut group_states: PlHashMap<_, A> =
+                    PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
 
-                // assume the result tuples equal length of the no. of hashes processed by this thread.
-                let mut results = Vec::with_capacity(vals_left.len());
-
-                let mut right_tbl_offsets = PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
-
-                vals_left.iter().enumerate().for_each(|(idx_a, k)| {
-                    let idx_a = (idx_a + offset) as IdxSize;
-                    // probe table that contains the hashed value
-                    let current_probe_table = unsafe {
-                        get_hash_tbl_threaded_join_partitioned(k.as_u64(), hash_tbls, n_tables)
+                for (rel_idx_left, by_left_k) in by_left.iter().enumerate() {
+                    let idx_left = (rel_idx_left + offset) as IdxSize;
+                    let Some(left_val) = left_val_arr.get(idx_left as usize) else {
+                        results.push(None);
+                        continue;
                     };
 
-                    // we already hashed, so we don't have to hash again.
-                    let value = current_probe_table.get(k);
+                    let group_probe_table = unsafe {
+                        get_hash_tbl_threaded_join_partitioned(
+                            by_left_k.as_u64(),
+                            &hash_tbls,
+                            n_tables,
+                        )
+                    };
+                    let Some(right_grp_idxs) = group_probe_table.get(by_left_k) else {
+                        results.push(None);
+                        continue;
+                    };
 
-                    match value {
-                        // left and right matches
-                        Some(indexes_b) => {
-                            process_group(
-                                *k,
-                                idx_a,
-                                tolerance,
-                                indexes_b,
-                                &mut right_tbl_offsets,
-                                join_asof_fn,
-                                left_asof,
-                                right_asof,
-                                &mut results,
-                                forward,
-                            );
-                        },
-                        // only left values, right = null
-                        None => results.push(None),
-                    }
-                });
+                    let grp_state = group_states.entry(*by_left_k).or_default();
+                    let r_idx = grp_state.next(
+                        &left_val,
+                        |i| right_val_arr.get(right_grp_idxs[i as usize] as usize),
+                        right_grp_idxs.len() as IdxSize,
+                    );
+                    
+                    let ret = r_idx
+                        .map(|i| right_grp_idxs[i as usize])
+                        .filter(|i| {
+                            let right_val = right_val_arr.get(*i as usize).unwrap();
+                            filter(left_val, right_val)
+                        });
+                    results.push(ret);
+                }
                 results
             })
             .collect()
     })
 }
 
+/*
 // TODO! optimize this. This does a full scan backwards. Use the same strategy as in the single `by`
 // implementations
 fn asof_join_by_multiple<T>(
@@ -693,16 +337,21 @@ where
             .collect()
     })
 }
+*/
 
 #[allow(clippy::too_many_arguments)]
-fn dispatch_join<T: PolarsNumericType>(
+fn dispatch_join_by_type<T, A, F>(
     left_asof: &ChunkedArray<T>,
     right_asof: &ChunkedArray<T>,
     left_by: &mut DataFrame,
     right_by: &mut DataFrame,
-    strategy: AsofStrategy,
-    tolerance: Option<AnyValue<'static>>,
-) -> PolarsResult<Vec<Option<IdxSize>>> {
+    filter: F,
+) -> PolarsResult<Vec<Option<IdxSize>>>
+where
+    T: PolarsDataType,
+    A: for<'a> AsofJoinState<T::Physical<'a>>,
+    F: Sync + for<'a> Fn(T::Physical<'a>, T::Physical<'a>) -> bool,
+{
     let out = if left_by.width() == 1 {
         let left_by_s = left_by.get_columns()[0].to_physical_repr().into_owned();
         let right_by_s = right_by.get_columns()[0].to_physical_repr().into_owned();
@@ -712,34 +361,28 @@ fn dispatch_join<T: PolarsNumericType>(
             ComputeError: "mismatching dtypes in 'by' parameter of asof-join: `{}` and `{}`", left_dtype, right_dtype
         );
         match left_dtype {
-            DataType::Utf8 => asof_join_by_binary(
-                &left_by_s.utf8().unwrap().as_binary(),
-                &right_by_s.utf8().unwrap().as_binary(),
-                left_asof,
-                right_asof,
-                tolerance,
-                strategy,
-            ),
-            DataType::Binary => asof_join_by_binary(
-                left_by_s.binary().unwrap(),
-                right_by_s.binary().unwrap(),
-                left_asof,
-                right_asof,
-                tolerance,
-                strategy,
-            ),
+            DataType::Utf8 => {
+                let left_by = &left_by_s.utf8().unwrap().as_binary();
+                let right_by = right_by_s.utf8().unwrap().as_binary();
+                asof_join_by_binary::<T, A, _>(&left_by, &right_by, left_asof, right_asof, filter)
+            },
+            DataType::Binary => {
+                let left_by = &left_by_s.binary().unwrap();
+                let right_by = right_by_s.binary().unwrap();
+                asof_join_by_binary::<T, A, _>(&left_by, &right_by, left_asof, right_asof, filter)
+            }
             _ => {
                 if left_by_s.bit_repr_is_large() {
                     let left_by = left_by_s.bit_repr_large();
                     let right_by = right_by_s.bit_repr_large();
-                    asof_join_by_numeric(
-                        &left_by, &right_by, left_asof, right_asof, tolerance, strategy,
+                    asof_join_by_numeric::<T, UInt64Type, A, _>(
+                        &left_by, &right_by, left_asof, right_asof, filter,
                     )?
                 } else {
                     let left_by = left_by_s.bit_repr_small();
                     let right_by = right_by_s.bit_repr_small();
-                    asof_join_by_numeric(
-                        &left_by, &right_by, left_asof, right_asof, tolerance, strategy,
+                    asof_join_by_numeric::<T, UInt32Type, A, _>(
+                        &left_by, &right_by, left_asof, right_asof, filter,
                     )?
                 }
             },
@@ -752,11 +395,141 @@ fn dispatch_join<T: PolarsNumericType>(
             #[cfg(feature = "dtype-categorical")]
             _check_categorical_src(lhs.dtype(), rhs.dtype())?;
         }
-        asof_join_by_multiple(
-            left_by, right_by, left_asof, right_asof, tolerance, strategy,
-        )
+        todo!()
+        // asof_join_by_multiple(
+        //     left_by, right_by, left_asof, right_asof, tolerance, strategy,
+        // )
     };
     Ok(out)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn dispatch_join_strategy<T: PolarsDataType>(
+    left_asof: &ChunkedArray<T>,
+    right_asof: &Series,
+    left_by: &mut DataFrame,
+    right_by: &mut DataFrame,
+    strategy: AsofStrategy,
+) -> PolarsResult<Vec<Option<IdxSize>>>
+where
+    for<'a> T::Physical<'a>: PartialOrd
+{
+    let right_asof = left_asof.unpack_series_matching_type(right_asof)?;
+
+    let filter = |_a: T::Physical<'_>, _b: T::Physical<'_>| true;
+    match strategy {
+        AsofStrategy::Backward => dispatch_join_by_type::<T, AsofJoinBackwardState, _>(
+            left_asof, right_asof, left_by, right_by, filter,
+        ),
+        AsofStrategy::Forward => dispatch_join_by_type::<T, AsofJoinForwardState, _>(
+            left_asof, right_asof, left_by, right_by, filter,
+        ),
+        AsofStrategy::Nearest => unimplemented!(),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn dispatch_join_strategy_numeric<T: PolarsNumericType>(
+    left_asof: &ChunkedArray<T>,
+    right_asof: &Series,
+    left_by: &mut DataFrame,
+    right_by: &mut DataFrame,
+    strategy: AsofStrategy,
+    tolerance: Option<AnyValue<'static>>,
+) -> PolarsResult<Vec<Option<IdxSize>>> {
+    let right_ca = left_asof.unpack_series_matching_type(right_asof)?;
+
+    if let Some(tol) = tolerance {
+        let native_tolerance: T::Native = tol.try_extract()?;
+        let abs_tolerance = native_tolerance.abs_diff(T::Native::zero());
+        let filter = |a: T::Native, b: T::Native| a.abs_diff(b) <= abs_tolerance;
+        match strategy {
+            AsofStrategy::Backward => dispatch_join_by_type::<T, AsofJoinBackwardState, _>(
+                left_asof, right_ca, left_by, right_by, filter,
+            ),
+            AsofStrategy::Forward => dispatch_join_by_type::<T, AsofJoinForwardState, _>(
+                left_asof, right_ca, left_by, right_by, filter,
+            ),
+            AsofStrategy::Nearest => dispatch_join_by_type::<T, AsofJoinNearestState, _>(
+                left_asof, right_ca, left_by, right_by, filter,
+            ),
+        }
+    } else {
+        let filter = |_a: T::Physical<'_>, _b: T::Physical<'_>| true;
+        match strategy {
+            AsofStrategy::Backward => dispatch_join_by_type::<T, AsofJoinBackwardState, _>(
+                left_asof, right_ca, left_by, right_by, filter,
+            ),
+            AsofStrategy::Forward => dispatch_join_by_type::<T, AsofJoinForwardState, _>(
+                left_asof, right_ca, left_by, right_by, filter,
+            ),
+            AsofStrategy::Nearest => dispatch_join_by_type::<T, AsofJoinNearestState, _>(
+                left_asof, right_ca, left_by, right_by, filter,
+            ),
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn dispatch_join_type(
+    left_asof: &Series,
+    right_asof: &Series,
+    left_by: &mut DataFrame,
+    right_by: &mut DataFrame,
+    strategy: AsofStrategy,
+    tolerance: Option<AnyValue<'static>>,
+) -> PolarsResult<Vec<Option<IdxSize>>> {
+    match left_asof.dtype() {
+        DataType::Int64 => {
+            let ca = left_asof.i64().unwrap();
+            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+        },
+        DataType::Int32 => {
+            let ca = left_asof.i32().unwrap();
+            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+        },
+        DataType::UInt64 => {
+            let ca = left_asof.u64().unwrap();
+            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+        },
+        DataType::UInt32 => {
+            let ca = left_asof.u32().unwrap();
+            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+        },
+        DataType::Float32 => {
+            let ca = left_asof.f32().unwrap();
+            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+        },
+        DataType::Float64 => {
+            let ca = left_asof.f64().unwrap();
+            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+        },
+        DataType::Boolean => {
+            let ca = left_asof.bool().unwrap();
+            dispatch_join_strategy::<BooleanType>(ca, &right_asof, left_by, right_by, strategy)
+        },
+        DataType::Binary => {
+            let ca = left_asof.binary().unwrap();
+            dispatch_join_strategy::<BinaryType>(ca, &right_asof, left_by, right_by, strategy)
+        },
+        DataType::Utf8 => {
+            let ca = left_asof.utf8().unwrap();
+            let right_binary = right_asof.cast(&DataType::Binary).unwrap();
+            dispatch_join_strategy::<BinaryType>(
+                &ca.as_binary(),
+                &right_binary,
+                left_by,
+                right_by,
+                strategy,
+            )
+        },
+        _ => {
+            let left_asof = left_asof.cast(&DataType::Int32).unwrap();
+            let right_asof = right_asof.cast(&DataType::Int32).unwrap();
+            let ca = left_asof.i32().unwrap();
+            dispatch_join_strategy_numeric(ca, &right_asof, left_by, right_by, strategy, tolerance)
+        },
+    }
 }
 
 pub trait AsofJoinBy: IntoDf {
@@ -790,7 +563,6 @@ pub trait AsofJoinBy: IntoDf {
         let right_asof = other_df.column(right_on)?.to_physical_repr();
         let right_asof_name = right_asof.name();
         let left_asof_name = left_asof.name();
-
         check_asof_columns(
             &left_asof,
             &right_asof,
@@ -814,19 +586,14 @@ pub trait AsofJoinBy: IntoDf {
             }
         }
 
-        let right_join_tuples = with_match_physical_numeric_polars_type!(left_asof.dtype(), |$T| {
-            let left_asof: &ChunkedArray<$T> = left_asof.as_ref().as_ref().as_ref();
-            let right_asof: &ChunkedArray<$T> = right_asof.as_ref().as_ref().as_ref();
-
-            dispatch_join(
-                left_asof,
-                right_asof,
-                &mut left_by,
-                &mut right_by,
-                strategy,
-                tolerance
-            )
-        })?;
+        let right_join_tuples = dispatch_join_type(
+            &*left_asof,
+            &*right_asof,
+            &mut left_by,
+            &mut right_by,
+            strategy,
+            tolerance,
+        )?;
 
         let mut drop_these = right_by.get_column_names();
         if left_asof_name == right_asof_name {

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -13,6 +13,44 @@ use smartstring::alias::String as SmartString;
 use super::*;
 use crate::frame::IntoDf;
 
+fn compute_len_offsets<I: IntoIterator<Item = usize>>(iter: I) -> Vec<usize> {
+    let mut cumlen = 0;
+    iter.into_iter()
+        .map(|l| {
+            let offset = cumlen;
+            cumlen += l;
+            offset
+        })
+        .collect()
+}
+
+fn asof_in_group<'a, T, A, F>(
+    left_val: T::Physical<'a>,
+    right_val_arr: &'a T::Array,
+    right_grp_idxs: &[IdxSize],
+    group_states: &mut PlHashMap<IdxSize, A>,
+    filter: F,
+) -> Option<IdxSize>
+where
+    T: PolarsDataType,
+    A: AsofJoinState<T::Physical<'a>>,
+    F: Fn(T::Physical<'a>, T::Physical<'a>) -> bool,
+{
+    // We use the index of the first element in a group as an identifier to
+    // associate with the group state.
+    let id = right_grp_idxs.first()?;
+    let grp_state = group_states.entry(*id).or_default();
+
+    let r_grp_idx = grp_state.next(
+        &left_val,
+        |i| right_val_arr.get(right_grp_idxs[i as usize] as usize),
+        right_grp_idxs.len() as IdxSize,
+    )?;
+
+    let r_idx = right_grp_idxs[r_grp_idx as usize];
+    let right_val = right_val_arr.get(r_idx as usize).unwrap();
+    filter(left_val, right_val).then_some(r_idx)
+}
 
 fn asof_join_by_numeric<T, S, A, F>(
     by_left: &ChunkedArray<S>,
@@ -34,41 +72,28 @@ where
     let right_val_arr = right_asof.downcast_iter().next().unwrap();
 
     let n_threads = POOL.current_num_threads();
-    let splitted_left = split_ca(by_left, n_threads).unwrap();
-    let splitted_right = split_ca(by_right, n_threads).unwrap();
+    let split_by_left = split_ca(by_left, n_threads).unwrap();
+    let split_by_right = split_ca(by_right, n_threads).unwrap();
+    let offsets = compute_len_offsets(split_by_left.iter().map(|s| s.len()));
 
     // TODO: handle nulls more efficiently. Right now we just join on the value
     // ignoring the validity mask, and ignore the nulls later.
-    let right_slices = splitted_right
+    let right_slices = split_by_right
         .iter()
         .map(|ca| ca.downcast_iter().next().unwrap().values_iter())
         .collect();
     let hash_tbls = build_tables(right_slices);
-
-    // We determine the offset of each thread block so that we later know which
-    // index to store in the join tuples.
-    let offsets = splitted_left
-        .iter()
-        .map(|ph| ph.len())
-        .scan(0, |state, val| {
-            let out = *state;
-            *state += val;
-            Some(out)
-        })
-        .collect::<Vec<_>>();
-
     let n_tables = hash_tbls.len() as u64;
-    debug_assert!(n_tables.is_power_of_two());
 
     // Now we probe the right hand side for each left hand side.
     Ok(POOL
         .install(|| {
-            splitted_left
+            split_by_left
                 .into_par_iter()
                 .zip(offsets)
                 .flat_map(|(by_left, offset)| {
                     let mut results = Vec::with_capacity(by_left.len());
-                    let mut group_states: PlHashMap<S::Native, A> =
+                    let mut group_states: PlHashMap<IdxSize, A> =
                         PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
 
                     let by_left_chunk = by_left.downcast_iter().next().unwrap();
@@ -84,31 +109,21 @@ where
                         };
 
                         let group_probe_table = unsafe {
-                            get_hash_tbl_threaded_join_partitioned(
-                                by_left_k.as_u64(),
-                                &hash_tbls,
-                                n_tables,
-                            )
+                            let h_left = by_left_k.as_u64();
+                            get_hash_tbl_threaded_join_partitioned(h_left, &hash_tbls, n_tables)
                         };
                         let Some(right_grp_idxs) = group_probe_table.get(by_left_k) else {
                             results.push(None);
                             continue;
                         };
 
-                        let grp_state = group_states.entry(*by_left_k).or_default();
-                        let r_idx = grp_state.next(
-                            &left_val,
-                            |i| right_val_arr.get(right_grp_idxs[i as usize] as usize),
-                            right_grp_idxs.len() as IdxSize,
-                        );
-                        
-                        let ret = r_idx
-                            .map(|i| right_grp_idxs[i as usize])
-                            .filter(|i| {
-                                let right_val = right_val_arr.get(*i as usize).unwrap();
-                                filter(left_val, right_val)
-                            });
-                        results.push(ret);
+                        results.push(asof_in_group::<T, A, &F>(
+                            left_val,
+                            right_val_arr,
+                            right_grp_idxs,
+                            &mut group_states,
+                            &filter,
+                        ));
                     }
                     results
                 })
@@ -134,28 +149,15 @@ where
     let right_val_arr = right_asof.downcast_iter().next().unwrap();
 
     let n_threads = POOL.current_num_threads();
-    let splitted_by_left = split_ca(by_left, n_threads).unwrap();
-    let splitted_right = split_ca(by_right, n_threads).unwrap();
+    let split_by_left = split_ca(by_left, n_threads).unwrap();
+    let split_by_right = split_ca(by_right, n_threads).unwrap();
+    let offsets = compute_len_offsets(split_by_left.iter().map(|s| s.len()));
 
     let hb = RandomState::default();
-    let prep_by_left = prepare_bytes(&splitted_by_left, &hb);
-    let prep_by_right = prepare_bytes(&splitted_right, &hb);
+    let prep_by_left = prepare_bytes(&split_by_left, &hb);
+    let prep_by_right = prepare_bytes(&split_by_right, &hb);
     let hash_tbls = build_tables(prep_by_right);
-
-    // We determine the offset of each thread block so that we later know which
-    // index to store in the join tuples.
-    let offsets = prep_by_left
-        .iter()
-        .map(|ph| ph.len())
-        .scan(0, |state, val| {
-            let out = *state;
-            *state += val;
-            Some(out)
-        })
-        .collect::<Vec<_>>();
-
     let n_tables = hash_tbls.len() as u64;
-    debug_assert!(n_tables.is_power_of_two());
 
     // Now we probe the right hand side for each left hand side.
     POOL.install(|| {
@@ -175,31 +177,21 @@ where
                     };
 
                     let group_probe_table = unsafe {
-                        get_hash_tbl_threaded_join_partitioned(
-                            by_left_k.as_u64(),
-                            &hash_tbls,
-                            n_tables,
-                        )
+                        let h_left = by_left_k.as_u64();
+                        get_hash_tbl_threaded_join_partitioned(h_left, &hash_tbls, n_tables)
                     };
                     let Some(right_grp_idxs) = group_probe_table.get(by_left_k) else {
                         results.push(None);
                         continue;
                     };
 
-                    let grp_state = group_states.entry(*by_left_k).or_default();
-                    let r_idx = grp_state.next(
-                        &left_val,
-                        |i| right_val_arr.get(right_grp_idxs[i as usize] as usize),
-                        right_grp_idxs.len() as IdxSize,
-                    );
-                    
-                    let ret = r_idx
-                        .map(|i| right_grp_idxs[i as usize])
-                        .filter(|i| {
-                            let right_val = right_val_arr.get(*i as usize).unwrap();
-                            filter(left_val, right_val)
-                        });
-                    results.push(ret);
+                    results.push(asof_in_group::<T, A, &F>(
+                        left_val,
+                        right_val_arr,
+                        &right_grp_idxs[..],
+                        &mut group_states,
+                        &filter,
+                    ));
                 }
                 results
             })
@@ -207,137 +199,95 @@ where
     })
 }
 
-/*
-// TODO! optimize this. This does a full scan backwards. Use the same strategy as in the single `by`
-// implementations
-fn asof_join_by_multiple<T>(
-    a: &mut DataFrame,
-    b: &mut DataFrame,
+fn asof_join_by_multiple<T, A, F>(
+    by_left: &mut DataFrame,
+    by_right: &mut DataFrame,
     left_asof: &ChunkedArray<T>,
     right_asof: &ChunkedArray<T>,
-    tolerance: Option<AnyValue<'static>>,
-    strategy: AsofStrategy,
+    filter: F,
 ) -> Vec<Option<IdxSize>>
 where
-    T: PolarsNumericType,
+    T: PolarsDataType,
+    A: for<'a> AsofJoinState<T::Physical<'a>>,
+    F: Sync + for<'a> Fn(T::Physical<'a>, T::Physical<'a>) -> bool,
 {
-    #[allow(clippy::type_complexity)]
-    let (join_asof_fn, tolerance, forward): (
-        unsafe fn(T::Native, &[T::Native], &[IdxSize], T::Native) -> (Option<IdxSize>, usize),
-        _,
-        _,
-    ) = match (tolerance, strategy) {
-        (Some(tolerance), AsofStrategy::Backward) => {
-            let tol = tolerance.extract::<T::Native>().unwrap();
-            (
-                join_asof_backward_with_indirection_and_tolerance,
-                tol,
-                false,
-            )
-        },
-        (None, AsofStrategy::Backward) => (
-            join_asof_backward_with_indirection,
-            T::Native::zero(),
-            false,
-        ),
-        (Some(tolerance), AsofStrategy::Forward) => {
-            let tol = tolerance.extract::<T::Native>().unwrap();
-            (join_asof_forward_with_indirection_and_tolerance, tol, true)
-        },
-        (None, AsofStrategy::Forward) => {
-            (join_asof_forward_with_indirection, T::Native::zero(), true)
-        },
-        (Some(tolerance), AsofStrategy::Nearest) => {
-            let tol = tolerance.extract::<T::Native>().unwrap();
-            (join_asof_nearest_with_indirection_and_tolerance, tol, false)
-        },
-        (None, AsofStrategy::Nearest) => {
-            (join_asof_nearest_with_indirection, T::Native::zero(), false)
-        },
-    };
     let left_asof = left_asof.rechunk();
-    let left_asof = left_asof.cont_slice().unwrap();
-
     let right_asof = right_asof.rechunk();
-    let right_asof = right_asof.cont_slice().unwrap();
+    let left_val_arr = left_asof.downcast_iter().next().unwrap();
+    let right_val_arr = right_asof.downcast_iter().next().unwrap();
 
     let n_threads = POOL.current_num_threads();
-    let dfs_a = split_df(a, n_threads).unwrap();
-    let dfs_b = split_df(b, n_threads).unwrap();
+    let split_by_left = split_df(by_left, n_threads).unwrap();
+    let split_by_right = split_df(by_right, n_threads).unwrap();
 
-    let (build_hashes, random_state) = _df_rows_to_hashes_threaded_vertical(&dfs_b, None).unwrap();
+    let (build_hashes, random_state) =
+        _df_rows_to_hashes_threaded_vertical(&split_by_right, None).unwrap();
     let (probe_hashes, _) =
-        _df_rows_to_hashes_threaded_vertical(&dfs_a, Some(random_state)).unwrap();
+        _df_rows_to_hashes_threaded_vertical(&split_by_left, Some(random_state)).unwrap();
 
-    let hash_tbls = mk::create_probe_table(&build_hashes, b);
-    // early drop to reduce memory pressure
-    drop(build_hashes);
-
-    let n_tables = hash_tbls.len() as u64;
+    let hash_tbls = mk::create_probe_table(&build_hashes, by_right);
+    drop(build_hashes); // Early drop to reduce memory pressure.
     let offsets = mk::get_offsets(&probe_hashes);
+    let n_tables = hash_tbls.len() as u64;
+    debug_assert!(n_tables.is_power_of_two());
 
-    // next we probe the other relation
-    // code duplication is because we want to only do the swap check once
+    // Now we probe the right hand side for each left hand side.
     POOL.install(|| {
         probe_hashes
             .into_par_iter()
             .zip(offsets)
-            .flat_map(|(probe_hashes, offset)| {
-                // local reference
-                let hash_tbls = &hash_tbls;
+            .flat_map(|(hash_by_left, offset)| {
+                let mut results = Vec::with_capacity(hash_by_left.len());
+                let mut group_states: PlHashMap<_, A> =
+                    PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
 
-                // assume the result tuples equal length of the no. of hashes processed by this thread.
-                let mut results = Vec::with_capacity(probe_hashes.len());
-                let mut right_tbl_offsets = PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
+                let mut ctr = 0;
+                for by_left_view in hash_by_left.data_views() {
+                    for h_left in by_left_view.iter().copied() {
+                        let idx_left = offset + ctr;
+                        ctr += 1;
+                        let opt_left_val = left_val_arr.get(idx_left as usize);
 
-                let local_offset = offset;
-
-                let mut idx_a = local_offset as IdxSize;
-                for probe_hashes in probe_hashes.data_views() {
-                    for (idx, &h) in probe_hashes.iter().enumerate() {
-                        debug_assert!(idx + offset < left_asof.len());
-                        // probe table that contains the hashed value
-                        let current_probe_table = unsafe {
-                            get_hash_tbl_threaded_join_partitioned(h, hash_tbls, n_tables)
+                        let Some(left_val) = opt_left_val else {
+                            results.push(None);
+                            continue;
                         };
 
-                        let entry = current_probe_table.raw_entry().from_hash(h, |idx_hash| {
-                            let idx_b = idx_hash.idx;
-                            // Safety:
-                            // indices in a join operation are always in bounds.
-                            unsafe { mk::compare_df_rows2(a, b, idx_a as usize, idx_b as usize) }
-                        });
+                        let group_probe_table = unsafe {
+                            get_hash_tbl_threaded_join_partitioned(h_left, &hash_tbls, n_tables)
+                        };
 
-                        match entry {
-                            // left and right matches
-                            Some((k, indexes_b)) => {
-                                process_group(
-                                    // take the first idx as unique identifier of that group.
-                                    k.idx,
-                                    idx_a,
-                                    tolerance,
-                                    indexes_b,
-                                    &mut right_tbl_offsets,
-                                    join_asof_fn,
-                                    left_asof,
-                                    right_asof,
-                                    &mut results,
-                                    forward,
-                                );
-                            },
-                            // only left values, right = null
-                            None => results.push(None),
-                        }
-                        idx_a += 1;
+                        let entry = group_probe_table.raw_entry().from_hash(h_left, |idx_hash| {
+                            let idx_right = idx_hash.idx;
+                            // SAFETY: indices in a join operation are always in bounds.
+                            unsafe {
+                                mk::compare_df_rows2(
+                                    by_left,
+                                    by_right,
+                                    idx_left as usize,
+                                    idx_right as usize,
+                                )
+                            }
+                        });
+                        let Some((_, right_grp_idxs)) = entry else {
+                            results.push(None);
+                            continue;
+                        };
+
+                        results.push(asof_in_group::<T, A, &F>(
+                            left_val,
+                            right_val_arr,
+                            &right_grp_idxs[..],
+                            &mut group_states,
+                            &filter,
+                        ));
                     }
                 }
-
                 results
             })
             .collect()
     })
 }
-*/
 
 #[allow(clippy::too_many_arguments)]
 fn dispatch_join_by_type<T, A, F>(
@@ -364,24 +314,24 @@ where
             DataType::Utf8 => {
                 let left_by = &left_by_s.utf8().unwrap().as_binary();
                 let right_by = right_by_s.utf8().unwrap().as_binary();
-                asof_join_by_binary::<T, A, _>(&left_by, &right_by, left_asof, right_asof, filter)
+                asof_join_by_binary::<T, A, F>(&left_by, &right_by, left_asof, right_asof, filter)
             },
             DataType::Binary => {
                 let left_by = &left_by_s.binary().unwrap();
                 let right_by = right_by_s.binary().unwrap();
-                asof_join_by_binary::<T, A, _>(&left_by, &right_by, left_asof, right_asof, filter)
-            }
+                asof_join_by_binary::<T, A, F>(&left_by, &right_by, left_asof, right_asof, filter)
+            },
             _ => {
                 if left_by_s.bit_repr_is_large() {
                     let left_by = left_by_s.bit_repr_large();
                     let right_by = right_by_s.bit_repr_large();
-                    asof_join_by_numeric::<T, UInt64Type, A, _>(
+                    asof_join_by_numeric::<T, UInt64Type, A, F>(
                         &left_by, &right_by, left_asof, right_asof, filter,
                     )?
                 } else {
                     let left_by = left_by_s.bit_repr_small();
                     let right_by = right_by_s.bit_repr_small();
-                    asof_join_by_numeric::<T, UInt32Type, A, _>(
+                    asof_join_by_numeric::<T, UInt32Type, A, F>(
                         &left_by, &right_by, left_asof, right_asof, filter,
                     )?
                 }
@@ -395,10 +345,7 @@ where
             #[cfg(feature = "dtype-categorical")]
             _check_categorical_src(lhs.dtype(), rhs.dtype())?;
         }
-        todo!()
-        // asof_join_by_multiple(
-        //     left_by, right_by, left_asof, right_asof, tolerance, strategy,
-        // )
+        asof_join_by_multiple::<T, A, F>(left_by, right_by, left_asof, right_asof, filter)
     };
     Ok(out)
 }
@@ -412,7 +359,7 @@ fn dispatch_join_strategy<T: PolarsDataType>(
     strategy: AsofStrategy,
 ) -> PolarsResult<Vec<Option<IdxSize>>>
 where
-    for<'a> T::Physical<'a>: PartialOrd
+    for<'a> T::Physical<'a>: PartialOrd,
 {
     let right_asof = left_asof.unpack_series_matching_type(right_asof)?;
 

--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use crate::frame::IntoDf;
 
-trait AsofJoinState<T> : Default {
+trait AsofJoinState<T>: Default {
     fn next<F: FnMut(IdxSize) -> Option<T>>(
         &mut self,
         left_val: &T,
@@ -106,7 +106,7 @@ impl<T: NumericNative> AsofJoinState<T> for AsofJoinNearestState {
                         let best_right_val = unsafe { right(best_idx).unwrap_unchecked() };
                         let best_diff = left_val.abs_diff(best_right_val);
                         let scan_diff = left_val.abs_diff(scan_right_val);
-                        
+
                         scan_diff <= best_diff
                     } else {
                         true
@@ -126,22 +126,21 @@ impl<T: NumericNative> AsofJoinState<T> for AsofJoinNearestState {
                                     break;
                                 }
                             }
-                            
+
                             self.scan_offset += 1;
                         }
                     }
-            
+
                     break;
                 }
             }
 
             self.scan_offset += 1;
         }
-        
+
         self.best_bound
     }
 }
-
 
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -159,7 +158,12 @@ pub struct AsOfOptions {
     pub right_by: Option<Vec<SmartString>>,
 }
 
-fn check_asof_columns(a: &Series, b: &Series, has_tolerance: bool, check_sorted: bool) -> PolarsResult<()> {
+fn check_asof_columns(
+    a: &Series,
+    b: &Series,
+    has_tolerance: bool,
+    check_sorted: bool,
+) -> PolarsResult<()> {
     let dtype_a = a.dtype();
     let dtype_b = b.dtype();
     if has_tolerance {
@@ -174,7 +178,6 @@ fn check_asof_columns(a: &Series, b: &Series, has_tolerance: bool, check_sorted:
             InvalidOperation:
             "asof join is only supported on primitive key typess"
         );
-
     }
     polars_ensure!(
         dtype_a == dtype_b,
@@ -199,7 +202,6 @@ pub enum AsofStrategy {
     /// selects the right in the right DataFrame whose 'on' key is nearest to the left's key.
     Nearest,
 }
-
 
 pub trait AsofJoin: IntoDf {
     #[doc(hidden)]

--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -6,7 +6,6 @@ use default::*;
 pub(super) use groups::AsofJoinBy;
 use polars_core::prelude::*;
 use polars_core::utils::ensure_sorted_arg;
-use polars_core::with_match_physical_numeric_polars_type;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use smartstring::alias::String as SmartString;

--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -176,7 +176,7 @@ fn check_asof_columns(
         polars_ensure!(
             dtype_a.to_physical().is_primitive() && dtype_b.to_physical().is_primitive(),
             InvalidOperation:
-            "asof join is only supported on primitive key typess"
+            "asof join is only supported on primitive key types"
         );
     }
     polars_ensure!(

--- a/crates/polars-utils/src/abs_diff.rs
+++ b/crates/polars-utils/src/abs_diff.rs
@@ -1,0 +1,55 @@
+use num_traits::Num;
+
+pub trait AbsDiff {
+    type Abs: Num + PartialOrd + Copy + std::fmt::Debug;
+
+    fn max_abs_diff() -> Self::Abs;
+    fn abs_diff(self, other: Self) -> Self::Abs;
+}
+
+macro_rules! impl_trivial_abs_diff {
+    ($T: ty, $max: expr) => {
+        impl AbsDiff for $T {
+            type Abs = $T;
+
+            fn max_abs_diff() -> Self::Abs {
+                $max
+            }
+
+            fn abs_diff(self, other: Self) -> Self::Abs {
+                if self > other { self - other } else { other - self }
+            }
+        }
+    }
+}
+
+macro_rules! impl_signed_abs_diff {
+    ($T: ty, $U: ty) => {
+        impl AbsDiff for $T {
+            type Abs = $U;
+
+            fn max_abs_diff() -> Self::Abs {
+                <$U>::MAX
+            }
+
+            fn abs_diff(self, other: Self) -> Self::Abs {
+                self.abs_diff(other)
+            }
+        }
+    }
+}
+
+impl_trivial_abs_diff!(u8, u8::MAX);
+impl_trivial_abs_diff!(u16, u16::MAX);
+impl_trivial_abs_diff!(u32, u32::MAX);
+impl_trivial_abs_diff!(u64, u64::MAX);
+impl_trivial_abs_diff!(u128, u128::MAX);
+impl_trivial_abs_diff!(usize, usize::MAX);
+impl_trivial_abs_diff!(f32, f32::INFINITY);
+impl_trivial_abs_diff!(f64, f64::INFINITY);
+impl_signed_abs_diff!(i8, u8);
+impl_signed_abs_diff!(i16, u16);
+impl_signed_abs_diff!(i32, u32);
+impl_signed_abs_diff!(i64, u64);
+impl_signed_abs_diff!(i128, u128);
+impl_signed_abs_diff!(isize, usize);

--- a/crates/polars-utils/src/abs_diff.rs
+++ b/crates/polars-utils/src/abs_diff.rs
@@ -1,7 +1,7 @@
 use num_traits::Num;
 
 pub trait AbsDiff {
-    type Abs: Num + PartialOrd + Copy + std::fmt::Debug;
+    type Abs: Num + PartialOrd + Copy + std::fmt::Debug + Send + Sync;
 
     fn max_abs_diff() -> Self::Abs;
     fn abs_diff(self, other: Self) -> Self::Abs;

--- a/crates/polars-utils/src/abs_diff.rs
+++ b/crates/polars-utils/src/abs_diff.rs
@@ -17,10 +17,14 @@ macro_rules! impl_trivial_abs_diff {
             }
 
             fn abs_diff(self, other: Self) -> Self::Abs {
-                if self > other { self - other } else { other - self }
+                if self > other {
+                    self - other
+                } else {
+                    other - self
+                }
             }
         }
-    }
+    };
 }
 
 macro_rules! impl_signed_abs_diff {
@@ -36,7 +40,7 @@ macro_rules! impl_signed_abs_diff {
                 self.abs_diff(other)
             }
         }
-    }
+    };
 }
 
 impl_trivial_abs_diff!(u8, u8::MAX);

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+pub mod abs_diff;
 pub mod arena;
 pub mod atomic;
 pub mod cache;

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1067,11 +1067,23 @@ def test_asof_join_nearest_by_date() -> None:
 
 def test_asof_join_string() -> None:
     left = pl.DataFrame({"x": [None, "a", "b", "c", None, "d", None]}).set_sorted("x")
-    right = pl.DataFrame({"x": ["apple", None, "chutney"], "y": [0, 1, 2]}).set_sorted("x")
+    right = pl.DataFrame({"x": ["apple", None, "chutney"], "y": [0, 1, 2]}).set_sorted(
+        "x"
+    )
     forward = left.join_asof(right, on="x", strategy="forward")
     backward = left.join_asof(right, on="x", strategy="backward")
-    forward_expected = pl.DataFrame({"x": [None, "a", "b", "c", None, "d", None], "y": [None, 0, 2, 2, None, None, None]})
-    backward_expected = pl.DataFrame({"x": [None, "a", "b", "c", None, "d", None], "y": [None, None, 0, 0, None, 2, None]})
+    forward_expected = pl.DataFrame(
+        {
+            "x": [None, "a", "b", "c", None, "d", None],
+            "y": [None, 0, 2, 2, None, None, None],
+        }
+    )
+    backward_expected = pl.DataFrame(
+        {
+            "x": [None, "a", "b", "c", None, "d", None],
+            "y": [None, None, 0, 0, None, 2, None],
+        }
+    )
     assert_frame_equal(forward, forward_expected)
     assert_frame_equal(backward, backward_expected)
 

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -1065,13 +1065,15 @@ def test_asof_join_nearest_by_date() -> None:
     assert_frame_equal(out, expected)
 
 
-def test_asof_join_string_err() -> None:
-    left = pl.DataFrame({"date_str": ["2023/02/15"]}).sort("date_str")
-    right = pl.DataFrame(
-        {"date_str": ["2023/01/31", "2023/02/28"], "value": [0, 1]}
-    ).sort("date_str")
-    with pytest.raises(pl.InvalidOperationError):
-        left.join_asof(right, on="date_str")
+def test_asof_join_string() -> None:
+    left = pl.DataFrame({"x": [None, "a", "b", "c", None, "d", None]}).set_sorted("x")
+    right = pl.DataFrame({"x": ["apple", None, "chutney"], "y": [0, 1, 2]}).set_sorted("x")
+    forward = left.join_asof(right, on="x", strategy="forward")
+    backward = left.join_asof(right, on="x", strategy="backward")
+    forward_expected = pl.DataFrame({"x": [None, "a", "b", "c", None, "d", None], "y": [None, 0, 2, 2, None, None, None]})
+    backward_expected = pl.DataFrame({"x": [None, "a", "b", "c", None, "d", None], "y": [None, None, 0, 0, None, 2, None]})
+    assert_frame_equal(forward, forward_expected)
+    assert_frame_equal(backward, backward_expected)
 
 
 def test_join_asof_by_argument_parsing() -> None:

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -8,6 +8,16 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 
+def test_asof_join_singular_right_11966() -> None:
+    df = pl.DataFrame({"id": [1, 2, 3], "time": [0.9, 2.1, 2.8]}).sort("time")
+    lookup = pl.DataFrame({"time": [2.0], "value": [100]}).sort("time")
+    joined = df.join_asof(lookup, on="time", strategy="nearest")
+    expected = pl.DataFrame(
+        {"id": [1, 2, 3], "time": [0.9, 2.1, 2.8], "value": [100, 100, 100]}
+    )
+    assert_frame_equal(joined, expected)
+
+
 def test_asof_join_inline_cast_6438() -> None:
     df_trades = pl.DataFrame(
         {

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -221,40 +221,6 @@ def test_filter_not_of_type_bool() -> None:
         df.filter(pl.col("json_val").str.json_path_match("$.a"))
 
 
-def test_err_asof_join_null_values() -> None:
-    n = 5
-    start_time = datetime(2021, 9, 30)
-
-    df_coor = pl.DataFrame(
-        {
-            "vessel_id": [1] * n + [2] * n,
-            "timestamp": [start_time + timedelta(hours=h) for h in range(n)]
-            + [start_time + timedelta(hours=h) for h in range(n)],
-        }
-    )
-
-    df_voyages = pl.DataFrame(
-        {
-            "vessel_id": [1, None],
-            "voyage_id": [1, None],
-            "voyage_start": [datetime(2022, 1, 1), None],
-            "voyage_end": [datetime(2022, 1, 20), None],
-        }
-    )
-    with pytest.raises(
-        pl.ComputeError, match=".sof join must not have null values in 'on' argument"
-    ):
-        (
-            df_coor.sort("timestamp").join_asof(
-                df_voyages.sort("voyage_start"),
-                right_on="voyage_start",
-                left_on="timestamp",
-                by="vessel_id",
-                strategy="backward",
-            )
-        )
-
-
 def test_is_nan_on_non_boolean() -> None:
     with pytest.raises(pl.InvalidOperationError):
         pl.Series(["1", "2", "3"]).fill_nan("2")  # type: ignore[arg-type]

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import io
 import re
-from datetime import date, datetime, time, timedelta
+from datetime import date, datetime, time
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 


### PR DESCRIPTION
This PR should reduce the code size and optimize the performance of the `asof_join`, as well as allow null and string keys.

Fixes https://github.com/pola-rs/polars/issues/11966.