### PR TITLE
fix(rust): LazyFrame.drop_columns overflow issue when columns.len()>schema.len()

### DIFF
--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -369,7 +369,7 @@ impl LogicalPlanBuilder {
     pub fn drop_columns(self, to_drop: PlHashSet<String>) -> Self {
         let schema = try_delayed!(self.0.schema(), &self.0, into);
 
-        let mut output_schema = Schema::with_capacity(schema.len() - to_drop.len());
+        let mut output_schema = Schema::with_capacity(schema.len().saturating_sub(to_drop.len()));
         let columns = schema
             .iter()
             .filter_map(|(col_name, dtype)| {


### PR DESCRIPTION
fixes https://github.com/pola-rs/polars/issues/11697.
There's a PanicException overflow when using `ldf.drop_columns(columns)` with `columns.len() > ldf.schema.len()`, because of the substraction of two `usize` integers. Using `saturating_sub` to clamp the difference solves the issue.

I greped for the `*.len() - *.len()` pattern, and found a couple of  subtraction between `usize`s , but they're not as dangerous as this one. This search does not exhaust the `usize-usize` pattern, so there are probably better methods to look for it!