### PR TITLE
perf(rust): Improve performance of `cot` (cotangent)

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
+++ b/crates/polars-plan/src/dsl/function_expr/trigonometry.rs
@@ -177,7 +177,7 @@ where
     T::Native: Float,
     ChunkedArray<T>: IntoSeries,
 {
-    Ok(ca.apply_values(|v| v.cos() / v.sin()).into_series())
+    Ok(ca.apply_values(|v| v.tan().powi(-1)).into_series())
 }
 
 fn sin<T>(ca: &ChunkedArray<T>) -> PolarsResult<Series>

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -7858,6 +7858,31 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.tan())
 
+    def cot(self) -> Self:
+        """
+        Compute the element-wise value for the cotangent.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`Float64`.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": [1.0]})
+        >>> df.select(pl.col("a").cot().round(2))
+        shape: (1, 1)
+        ┌──────┐
+        │ a    │
+        │ ---  │
+        │ f64  │
+        ╞══════╡
+        │ 0.64 │
+        └──────┘
+
+        """
+        return self._from_pyexpr(self._pyexpr.cot())
+
     def arcsin(self) -> Self:
         """
         Compute the element-wise value for the inverse sine.

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4793,6 +4793,25 @@ class Series:
 
         """
 
+    def cot(self) -> Series:
+        """
+        Compute the element-wise value for the cotangent.
+
+        Examples
+        --------
+        >>> import math
+        >>> s = pl.Series("a", [0.0, math.pi / 2.0, math.pi])
+        >>> s.cot()
+        shape: (3,)
+        Series: 'a' [f64]
+        [
+            inf
+            6.1232e-17
+            -8.1656e15
+        ]
+
+        """
+
     def arcsin(self) -> Series:
         """
         Compute the element-wise value for the inverse sine.

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -490,6 +490,11 @@ impl PyExpr {
     }
 
     #[cfg(feature = "trigonometry")]
+    fn cot(&self) -> Self {
+        self.clone().inner.cot().into()
+    }
+
+    #[cfg(feature = "trigonometry")]
     fn arcsin(&self) -> Self {
         self.clone().inner.arcsin().into()
     }

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2027,6 +2027,14 @@ def test_trigonometric(f: str) -> None:
     assert_series_equal(result, expected)
 
 
+@pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning")
+def test_trigonometric_cot() -> None:
+    # cotangent is not available in numpy...
+    s = pl.Series("a", [0.0, math.pi, None, math.nan])
+    expected = pl.Series("a", [math.inf, -8.1656e15, None, math.nan])
+    assert_series_equal(s.cot(), expected)
+
+
 def test_trigonometric_invalid_input() -> None:
     # String
     s = pl.Series("a", ["1", "2", "3"])


### PR DESCRIPTION
During the adjustments of the docs, I noticed that `cot` was implemented as `cos/sin`.
But actually cotangent is just the inverse of tangent. So I was wondering what the effect would be of taking the tangent and inverse it.

Here are the results against the "build-opt" binary on wsl:
_original:_ Time taken to execute 1000000x the collect: 11.39s
_new:_ Time taken to execute 1000000x the collect: 11.10s

I was wondering why I couldn't do `1.0 / tan(v)`... As that might even be faster than what I made here.
And I know it's not much gain, but any gain is good right? 😁


**test script**
```python
import timeit

import polars as pl

df = pl.DataFrame(
    {
        "a": [-4, -3, -2, -1.00001, 0, 1.00001, 2, 3, 4],
    }
)

ctx = pl.SQLContext(df=df, eager_execution=False)
res = ctx.execute(
    """
    SELECT
    cot(a) AS "cot",
    FROM df
    """,
    eager=False,
)

print(ctx.execute('SELECT cot(a) as "cot", cos(a) / sin(a) as "cot_original" from df').collect())

print(f'Time taken to execute {timeit.default_number}x the collect: {timeit.timeit("res.collect()", globals=globals()):.2f}s')
```