### PR TITLE
docs: Link to `expand_selector` in user guide

### DIFF
--- a/docs/_build/API_REFERENCE_LINKS.yml
+++ b/docs/_build/API_REFERENCE_LINKS.yml
@@ -121,7 +121,6 @@ python:
   cs.contains: https://pola-rs.github.io/polars/py-polars/html/reference/selectors.html#polars.selectors.contains
   cs.matches: https://pola-rs.github.io/polars/py-polars/html/reference/selectors.html#polars.selectors.matches
   is_selector: https://pola-rs.github.io/polars/py-polars/html/reference/selectors.html#polars.selectors.is_selector
-  selector_column_names: https://pola-rs.github.io/polars/py-polars/html/reference/selectors.html#polars.selectors.selector_column_names
   expand_selector: https://pola-rs.github.io/polars/py-polars/html/reference/selectors.html#polars.selectors.expand_selector
 
   dt.convert_time_zone:
@@ -230,7 +229,7 @@ rust:
     link: https://pola-rs.github.io/polars/docs/rust/dev/polars_io/prelude/struct.IpcReader.html
     feature_flags: ['ipc']
   scan_pyarrow_dataset: https://pola-rs.github.io/polars/py-polars/html/reference/api/polars.scan_pyarrow_dataset.html
-  
+
   min: https://pola-rs.github.io/polars/docs/rust/dev/polars/series/struct.Series.html#method.min
   max: https://pola-rs.github.io/polars/docs/rust/dev/polars/series/struct.Series.html#method.max
   struct:
@@ -309,7 +308,7 @@ rust:
   cs.contains: https://github.com/pola-rs/polars/issues/10594
   cs.matches: https://github.com/pola-rs/polars/issues/10594
   is_selector: https://github.com/pola-rs/polars/issues/10594
-  selector_column_names: https://github.com/pola-rs/polars/issues/10594
+  expand_selector: https://github.com/pola-rs/polars/issues/10594
 
   dt.convert_time_zone:
     name: dt.convert_time_zone

--- a/docs/_build/API_REFERENCE_LINKS.yml
+++ b/docs/_build/API_REFERENCE_LINKS.yml
@@ -122,6 +122,7 @@ python:
   cs.matches: https://pola-rs.github.io/polars/py-polars/html/reference/selectors.html#polars.selectors.matches
   is_selector: https://pola-rs.github.io/polars/py-polars/html/reference/selectors.html#polars.selectors.is_selector
   selector_column_names: https://pola-rs.github.io/polars/py-polars/html/reference/selectors.html#polars.selectors.selector_column_names
+  expand_selector: https://pola-rs.github.io/polars/py-polars/html/reference/selectors.html#polars.selectors.expand_selector
 
   dt.convert_time_zone:
     name: dt.convert_time_zone

--- a/docs/user-guide/expressions/column-selections.md
+++ b/docs/user-guide/expressions/column-selections.md
@@ -117,7 +117,7 @@ What if we want to apply a specific operation on the selected columns (i.e. get 
 
 ### Debugging `selectors`
 
-Polars also provides two helpful utility functions to aid with using selectors: `is_selector` and `selector_column_names`:
+Polars also provides two helpful utility functions to aid with using selectors: `is_selector` and `expand_selector`:
 
 {{code_block('user-guide/expressions/column-selections','selectors_is_selector_utility',['is_selector'])}}
 

--- a/docs/user-guide/expressions/column-selections.md
+++ b/docs/user-guide/expressions/column-selections.md
@@ -127,7 +127,7 @@ Polars also provides two helpful utility functions to aid with using selectors: 
 
 To predetermine the column names that are selected, which is especially useful for a LazyFrame object:
 
-{{code_block('user-guide/expressions/column-selections','selectors_colnames_utility',['selector_column_names'])}}
+{{code_block('user-guide/expressions/column-selections','selectors_colnames_utility',['expand_selector'])}}
 
 ```python exec="on" result="text" session="user-guide/column-selections"
 --8<-- "python/user-guide/expressions/column-selections.py:selectors_colnames_utility"


### PR DESCRIPTION
This PR updates the user guide to point to `expand_selector`, which is referenced by the code snippet:

https://github.com/pola-rs/polars/blob/abd758653c02a18e5b6d5bdbd8cbdcf7a0ff0433/docs/src/python/user-guide/expressions/column-selections.py#L86-L91