### PR TITLE
feat(python): Add `infer_schema_length` to `pl.read_json`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1036,6 +1036,7 @@ class DataFrame:
         cls,
         source: str | Path | IOBase | bytes,
         *,
+        infer_schema_length: int | None = N_INFER_DEFAULT,
         schema: SchemaDefinition | None = None,
         schema_overrides: SchemaDefinition | None = None,
     ) -> Self:
@@ -1056,7 +1057,10 @@ class DataFrame:
 
         self = cls.__new__(cls)
         self._df = PyDataFrame.read_json(
-            source, schema=schema, schema_overrides=schema_overrides
+            source,
+            infer_schema_length=infer_schema_length,
+            schema=schema,
+            schema_overrides=schema_overrides,
         )
         return self
 

--- a/py-polars/polars/io/json.py
+++ b/py-polars/polars/io/json.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import polars._reexport as pl
+from polars.datatypes import N_INFER_DEFAULT
 
 if TYPE_CHECKING:
     from io import IOBase
@@ -15,6 +16,7 @@ if TYPE_CHECKING:
 def read_json(
     source: str | Path | IOBase | bytes,
     *,
+    infer_schema_length: int | None = N_INFER_DEFAULT,
     schema: SchemaDefinition | None = None,
     schema_overrides: SchemaDefinition | None = None,
 ) -> DataFrame:
@@ -27,6 +29,8 @@ def read_json(
         Path to a file or a file-like object (by file-like object, we refer to objects
         that have a ``read()`` method, such as a file handler (e.g. via builtin ``open``
         function) or ``BytesIO``).
+    infer_schema_length
+        Infer the schema from the first ``infer_schema_length`` rows.
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 
@@ -48,5 +52,8 @@ def read_json(
 
     """
     return pl.DataFrame._read_json(
-        source, schema=schema, schema_overrides=schema_overrides
+        source,
+        infer_schema_length=infer_schema_length,
+        schema=schema,
+        schema_overrides=schema_overrides,
     )

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -403,6 +403,7 @@ impl PyDataFrame {
     #[cfg(feature = "json")]
     pub fn read_json(
         py_f: &PyAny,
+        infer_schema_length: Option<usize>,
         schema: Option<Wrap<Schema>>,
         schema_overrides: Option<Wrap<Schema>>,
     ) -> PyResult<Self> {
@@ -421,8 +422,9 @@ impl PyDataFrame {
                     let e = PyPolarsErr::from(PolarsError::ComputeError(msg.into()));
                     Err(PyErr::from(e))
                 } else {
-                    let mut builder =
-                        JsonReader::new(mmap_bytes_r).with_json_format(JsonFormat::Json);
+                    let mut builder = JsonReader::new(mmap_bytes_r)
+                        .with_json_format(JsonFormat::Json)
+                        .infer_schema_len(infer_schema_length);
 
                     if let Some(schema) = schema {
                         builder = builder.with_schema(Arc::new(schema.0));

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -214,8 +214,13 @@ def test_json_deserialize_9687() -> None:
 
 
 def test_json_infer_schema_length_11148() -> None:
-    response = [{"col1": 1}] * 100 + [{"col1": 1, "col2": 2}] * 50
-    result = pl.read_json(json.dumps(response).encode(), infer_schema_length=101)
+    response = [{"col1": 1}] * 2 + [{"col1": 1, "col2": 2}] * 1
+    result = pl.read_json(json.dumps(response).encode(), infer_schema_length=2)
+    with pytest.raises(AssertionError):
+        assert set(result.columns) == {"col1", "col2"}
+
+    response = [{"col1": 1}] * 2 + [{"col1": 1, "col2": 2}] * 1
+    result = pl.read_json(json.dumps(response).encode(), infer_schema_length=3)
     assert set(result.columns) == {"col1", "col2"}
 
 

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -213,6 +213,12 @@ def test_json_deserialize_9687() -> None:
     assert result.to_dict(False) == {k: [v] for k, v in response.items()}
 
 
+def test_json_infer_schema_length_11148() -> None:
+    response = [{"col1": 1}] * 100 + [{"col1": 1, "col2": 2}] * 50
+    result = pl.read_json(json.dumps(response).encode(), infer_schema_length=101)
+    assert set(result.columns) == {"col1", "col2"}
+
+
 def test_ndjson_ignore_errors() -> None:
     # this schema is inconsistent as "value" is string and object
     jsonl = r"""{"Type":"insert","Key":[1],"SeqNo":1,"Timestamp":1,"Fields":[{"Name":"added_id","Value":2},{"Name":"body","Value":{"a": 1}}]}


### PR DESCRIPTION
This PR partially fixes #11148 

The following operations are now supported, (taken from unit tests)

```
def test_json_infer_schema_length_11148() -> None:
    response = [{"col1": 1}] * 100 + [{"col1": 1, "col2": 2}] * 50
    result = pl.read_json(json.dumps(response).encode(), infer_schema_length=101)
    assert set(result.columns) == {"col1", "col2"}
```