### PR TITLE
chore(rust): Version `polars-arrow` with the other crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ avro-schema = { version = "0.3" }
 
 [workspace.dependencies.arrow]
 package = "polars-arrow"
-version = "0.1.0"
+version = "0.33.2"
 path = "crates/polars-arrow"
 default-features = false
 features = [

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "polars-arrow"
-version = "0.1.0"
+version = { workspace = true }
 authors = [
   "Jorge C. Leitao <jorgecarleitao@gmail.com>",
   "Apache Arrow <dev@arrow.apache.org>",

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "polars-arrow"
-version = "0.1.0"
+version = "0.33.2"
 dependencies = [
  "ahash",
  "arrow-format",


### PR DESCRIPTION
The `polars-arrow` crate should be versioned together with the other Polars crates.

I also noticed the license for arrow2 is slightly different from our license; not sure if there's something we can do about that?