### PR TITLE
feat(python): extend `filter` capabilities with new support for `*args` predicates, `**kwargs` constraints, and chained boolean masks

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -136,6 +136,7 @@ if TYPE_CHECKING:
         FrameInitTypes,
         IndexOrder,
         IntoExpr,
+        IntoExprColumn,
         IpcCompression,
         JoinStrategy,
         JoinValidation,
@@ -3988,11 +3989,7 @@ class DataFrame:
         └─────┴─────┴─────┘
 
         """
-        return (
-            self.lazy()
-            .filter(*predicates, **constraints)  # type: ignore[arg-type]
-            .collect(_eager=True)
-        )
+        return self.lazy().filter(*predicates, **constraints).collect(_eager=True)
 
     @overload
     def glimpse(

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3900,7 +3900,13 @@ class DataFrame:
 
     def filter(
         self,
-        *predicates: IntoExprColumn | bool | list[bool] | np.ndarray[Any, Any],
+        *predicates: (
+            IntoExprColumn
+            | Iterable[IntoExprColumn]
+            | bool
+            | list[bool]
+            | np.ndarray[Any, Any]
+        ),
         **constraints: Any,
     ) -> DataFrame:
         """

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3899,7 +3899,8 @@ class DataFrame:
 
     def filter(
         self,
-        predicate: (Expr | str | Series | list[bool] | np.ndarray[Any, Any] | bool),
+        *predicates: IntoExpr | list[bool] | np.ndarray[Any, Any],
+        **constraints: Any,
     ) -> DataFrame:
         """
         Filter the rows in the DataFrame based on a predicate expression.
@@ -3908,8 +3909,10 @@ class DataFrame:
 
         Parameters
         ----------
-        predicate
+        predicates
             Expression that evaluates to a boolean Series.
+        constraints
+            Column filters. Use name=value to filter column name by the supplied value.
 
         Examples
         --------
@@ -3923,18 +3926,18 @@ class DataFrame:
 
         Filter on one condition:
 
-        >>> df.filter(pl.col("foo") < 3)
+        >>> df.filter(pl.col("foo") > 1)
         shape: (2, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
         │ --- ┆ --- ┆ --- │
         │ i64 ┆ i64 ┆ str │
         ╞═════╪═════╪═════╡
-        │ 1   ┆ 6   ┆ a   │
         │ 2   ┆ 7   ┆ b   │
+        │ 3   ┆ 8   ┆ c   │
         └─────┴─────┴─────┘
 
-        Filter on multiple conditions:
+        Filter on multiple conditions, combined with and/or operators:
 
         >>> df.filter((pl.col("foo") < 3) & (pl.col("ham") == "a"))
         shape: (1, 3)
@@ -3945,8 +3948,6 @@ class DataFrame:
         ╞═════╪═════╪═════╡
         │ 1   ┆ 6   ┆ a   │
         └─────┴─────┴─────┘
-
-        Filter on an OR condition:
 
         >>> df.filter((pl.col("foo") == 1) | (pl.col("ham") == "c"))
         shape: (2, 3)
@@ -3959,12 +3960,38 @@ class DataFrame:
         │ 3   ┆ 8   ┆ c   │
         └─────┴─────┴─────┘
 
-        """
-        if _check_for_numpy(predicate) and isinstance(predicate, np.ndarray):
-            predicate = pl.Series(predicate)
+        Provide multiple filters using `*args` syntax:
 
+        >>> df.filter(
+        ...     pl.col("foo") == 1,
+        ...     pl.col("ham") == "a",
+        ... )
+        shape: (1, 3)
+        ┌─────┬─────┬─────┐
+        │ foo ┆ bar ┆ ham │
+        │ --- ┆ --- ┆ --- │
+        │ i64 ┆ i64 ┆ str │
+        ╞═════╪═════╪═════╡
+        │ 1   ┆ 6   ┆ a   │
+        └─────┴─────┴─────┘
+
+        Provide multiple filters using `**kwargs` syntax:
+
+        >>> df.filter(foo=1, ham="a")
+        shape: (1, 3)
+        ┌─────┬─────┬─────┐
+        │ foo ┆ bar ┆ ham │
+        │ --- ┆ --- ┆ --- │
+        │ i64 ┆ i64 ┆ str │
+        ╞═════╪═════╪═════╡
+        │ 1   ┆ 6   ┆ a   │
+        └─────┴─────┴─────┘
+
+        """
         return (
-            self.lazy().filter(predicate).collect(_eager=True)  # type: ignore[arg-type]
+            self.lazy()
+            .filter(*predicates, **constraints)  # type: ignore[arg-type]
+            .collect(_eager=True)
         )
 
     @overload

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3899,7 +3899,7 @@ class DataFrame:
 
     def filter(
         self,
-        *predicates: IntoExpr | list[bool] | np.ndarray[Any, Any],
+        *predicates: IntoExprColumn | bool | list[bool] | np.ndarray[Any, Any],
         **constraints: Any,
     ) -> DataFrame:
         """

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2659,7 +2659,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 if is_mask:
                     boolean_masks.append(pl.Series(p, dtype=Boolean))
                 else:
-                    all_predicates += (p,)
+                    all_predicates.append(p)
 
         # unpack equality constraints from kwargs
         all_predicates.extend(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2641,7 +2641,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             if is_bool_sequence(p):
                 boolean_masks.append(pl.Series(p, dtype=Boolean))
             else:
-                all_predicates.append(parse_as_expression(p, wrap=True))
+                all_predicates.append(wrap_expr(parse_as_expression(p)))
 
         # identify deprecated usage of 'predicate' parameter
         if "predicate" in constraints:
@@ -2659,7 +2659,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 if is_mask:
                     boolean_masks.append(pl.Series(p, dtype=Boolean))
                 else:
-                    all_predicates.append(p)
+                    all_predicates.append(p)  # type: ignore[arg-type]
 
         # unpack equality constraints from kwargs
         all_predicates.extend(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2647,16 +2647,17 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └─────┴─────┴─────┘
 
         """
-        # note: identify masks separately from predicates
         all_predicates: list[pl.Expr] = []
         boolean_masks = []
+
+        # note: identify masks separately from predicates
         for p in predicates:
             if is_bool_sequence(p):
                 boolean_masks.append(pl.Series(p, dtype=Boolean))
-            elif isinstance(p, Sequence) and all(isinstance(x, pl.Expr) for x in p):
-                all_predicates.extend(wrap_expr(parse_as_expression(x)) for x in p)
             else:
-                all_predicates.append(wrap_expr(parse_as_expression(p)))  # type: ignore[arg-type]
+                all_predicates.extend(
+                    wrap_expr(x) for x in parse_as_list_of_expressions(p)
+                )
 
         # identify deprecated usage of 'predicate' parameter
         if "predicate" in constraints:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -87,6 +87,7 @@ if TYPE_CHECKING:
     import pyarrow as pa
 
     from polars import DataFrame, Expr
+    from polars.dependencies import numpy as np
     from polars.type_aliases import (
         AsofJoinStrategy,
         ClosedInterval,
@@ -96,6 +97,7 @@ if TYPE_CHECKING:
         FillNullStrategy,
         FrameInitTypes,
         IntoExpr,
+        IntoExprColumn,
         JoinStrategy,
         JoinValidation,
         Label,
@@ -2546,7 +2548,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         return self._from_pyldf(self._ldf.clone())
 
-    def filter(self, *predicates: IntoExpr, **constraints: Any) -> Self:
+    def filter(
+        self,
+        *predicates: IntoExprColumn | bool | list[bool] | np.ndarray[Any, Any],
+        **constraints: Any,
+    ) -> Self:
         """
         Filter the rows in the LazyFrame based on a predicate expression.
 
@@ -2641,7 +2647,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             if is_bool_sequence(p):
                 boolean_masks.append(pl.Series(p, dtype=Boolean))
             else:
-                all_predicates.append(wrap_expr(parse_as_expression(p)))
+                all_predicates.append(wrap_expr(parse_as_expression(p)))  # type: ignore[arg-type]
 
         # identify deprecated usage of 'predicate' parameter
         if "predicate" in constraints:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -65,6 +65,7 @@ from polars.utils.deprecation import (
     deprecate_function,
     deprecate_renamed_function,
     deprecate_renamed_parameter,
+    issue_deprecation_warning,
 )
 from polars.utils.various import (
     _in_notebook,
@@ -2649,12 +2650,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 is_mask := is_bool_sequence(p)
             ):
                 p = constraints.pop("predicate")
-                warnings.warn(
+                issue_deprecation_warning(
                     "`filter` no longer takes a 'predicate' parameter.\n"
                     "To silence this warning you should omit the keyword and pass "
                     "as a positional argument instead.",
-                    DeprecationWarning,
-                    stacklevel=find_stacklevel(),
+                    version="0.19.9",
                 )
                 if is_mask:
                     boolean_masks.append(pl.Series(p, dtype=Boolean))

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -77,7 +77,6 @@ def parse_as_expression(
     *,
     str_as_lit: bool = False,
     structify: bool = False,
-    wrap: bool = False,
 ) -> PyExpr | Expr:
     """
     Parse a single input into an expression.
@@ -91,8 +90,6 @@ def parse_as_expression(
         strings are parsed as column names.
     structify
         Convert multi-column expressions to a single struct expression.
-    wrap
-        Return an ``Expr`` object rather than a ``PyExpr`` object.
 
     """
     if isinstance(input, pl.Expr):
@@ -120,7 +117,7 @@ def parse_as_expression(
     if structify:
         expr = _structify_expression(expr)
 
-    return expr if wrap else expr._pyexpr
+    return expr._pyexpr
 
 
 def _structify_expression(expr: Expr) -> Expr:

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -77,6 +77,7 @@ def parse_as_expression(
     *,
     str_as_lit: bool = False,
     structify: bool = False,
+    wrap: bool = False,
 ) -> PyExpr | Expr:
     """
     Parse a single input into an expression.
@@ -119,7 +120,7 @@ def parse_as_expression(
     if structify:
         expr = _structify_expression(expr)
 
-    return expr._pyexpr
+    return expr if wrap else expr._pyexpr
 
 
 def _structify_expression(expr: Expr) -> Expr:

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -22,7 +22,8 @@ from polars.datatypes import (
     Utf8,
     unpack_dtypes,
 )
-from polars.dependencies import _PYARROW_AVAILABLE
+from polars.dependencies import _PYARROW_AVAILABLE, _check_for_numpy
+from polars.dependencies import numpy as np
 
 if TYPE_CHECKING:
     from collections.abc import Reversible
@@ -68,11 +69,15 @@ def _is_iterable_of(val: Iterable[object], eltype: type | tuple[type, ...]) -> b
 
 def is_bool_sequence(val: object) -> TypeGuard[Sequence[bool]]:
     """Check whether the given sequence is a sequence of booleans."""
+    if _check_for_numpy(val) and isinstance(val, np.ndarray):
+        return val.dtype == np.bool_
     return isinstance(val, Sequence) and _is_iterable_of(val, bool)
 
 
 def is_int_sequence(val: object) -> TypeGuard[Sequence[int]]:
     """Check whether the given sequence is a sequence of integers."""
+    if _check_for_numpy(val) and isinstance(val, np.ndarray):
+        return np.issubdtype(val.dtype, np.integer)
     return isinstance(val, Sequence) and _is_iterable_of(val, int)
 
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2816,38 +2816,39 @@ def test_filter_sequence() -> None:
 
 def test_filter_multiple_predicates() -> None:
     df = pl.DataFrame(
-        {"a": [1, 1, 1, 2, 2], "b": [1, 1, 2, 2, 2], "c": [1, 1, 2, 3, 4]}
+        {
+            "a": [1, 1, 1, 2, 2],
+            "b": [1, 1, 2, 2, 2],
+            "c": [1, 1, 2, 3, 4],
+        }
     )
 
-    # using multiple predicates
-    out = df.filter(pl.col("a") == 1, pl.col("b") <= 2)  # positional
+    # multiple predicates
     expected = pl.DataFrame({"a": [1, 1, 1], "b": [1, 1, 2], "c": [1, 1, 2]})
-    assert_frame_equal(out, expected)
+    for out in (
+        df.filter(pl.col("a") == 1, pl.col("b") <= 2),  # positional/splat
+        df.filter([pl.col("a") == 1, pl.col("b") <= 2]),  # as list
+    ):
+        assert_frame_equal(out, expected)
 
-    out = df.filter([pl.col("a") == 1, pl.col("b") <= 2])  # as list
-    expected = pl.DataFrame({"a": [1, 1, 1], "b": [1, 1, 2], "c": [1, 1, 2]})
-    assert_frame_equal(out, expected)
+    # multiple kwargs
+    assert_frame_equal(
+        df.filter(a=1, b=2),
+        pl.DataFrame({"a": [1], "b": [2], "c": [2]}),
+    )
 
-    out = df.filter(*[pl.col("a") == 1, pl.col("b") <= 2])  # *splat
-    expected = pl.DataFrame({"a": [1, 1, 1], "b": [1, 1, 2], "c": [1, 1, 2]})
-    assert_frame_equal(out, expected)
+    # both positional and keyword args
+    assert_frame_equal(
+        pl.DataFrame({"a": [2], "b": [2], "c": [3]}),
+        df.filter(pl.col("c") < 4, a=2, b=2),
+    )
 
-    # using multiple kwargs
-    out = df.filter(a=1, b=2)
-    expected = pl.DataFrame({"a": [1], "b": [2], "c": [2]})
-    assert_frame_equal(out, expected)
-
-    # using both
-    out = df.filter(pl.col("a") == 1, pl.col("b") <= 2, a=1, b=2)
-    expected = pl.DataFrame({"a": [1], "b": [2], "c": [2]})
-    assert_frame_equal(out, expected)
-
-    # using boolean mask
+    # boolean mask
     out = df.filter([True, False, False, False, True])
     expected = pl.DataFrame({"a": [1, 2], "b": [1, 2], "c": [1, 4]})
     assert_frame_equal(out, expected)
 
-    # using multiple boolean masks
+    # multiple boolean masks
     out = df.filter(
         np.array([True, True, False, True, False]),
         np.array([True, False, True, True, False]),

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2820,7 +2820,15 @@ def test_filter_multiple_predicates() -> None:
     )
 
     # using multiple predicates
-    out = df.filter(pl.col("a") == 1, pl.col("b") <= 2)
+    out = df.filter(pl.col("a") == 1, pl.col("b") <= 2)  # positional
+    expected = pl.DataFrame({"a": [1, 1, 1], "b": [1, 1, 2], "c": [1, 1, 2]})
+    assert_frame_equal(out, expected)
+
+    out = df.filter([pl.col("a") == 1, pl.col("b") <= 2])  # as list
+    expected = pl.DataFrame({"a": [1, 1, 1], "b": [1, 1, 2], "c": [1, 1, 2]})
+    assert_frame_equal(out, expected)
+
+    out = df.filter(*[pl.col("a") == 1, pl.col("b") <= 2])  # *splat
     expected = pl.DataFrame({"a": [1, 1, 1], "b": [1, 1, 2], "c": [1, 1, 2]})
     assert_frame_equal(out, expected)
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2814,6 +2814,40 @@ def test_filter_sequence() -> None:
     assert df.filter(np.array([True, False, True]))["a"].to_list() == [1, 3]
 
 
+def test_filter_multiple_predicates() -> None:
+    df = pl.DataFrame(
+        {"a": [1, 1, 1, 2, 2], "b": [1, 1, 2, 2, 2], "c": [1, 1, 2, 3, 4]}
+    )
+
+    # using multiple predicates
+    out = df.filter(pl.col("a") == 1, pl.col("b") <= 2)
+    expected = pl.DataFrame({"a": [1, 1, 1], "b": [1, 1, 2], "c": [1, 1, 2]})
+    assert_frame_equal(out, expected)
+
+    # using multiple kwargs
+    out = df.filter(a=1, b=2)
+    expected = pl.DataFrame({"a": [1], "b": [2], "c": [2]})
+    assert_frame_equal(out, expected)
+
+    # using both
+    out = df.filter(pl.col("a") == 1, pl.col("b") <= 2, a=1, b=2)
+    expected = pl.DataFrame({"a": [1], "b": [2], "c": [2]})
+    assert_frame_equal(out, expected)
+
+    # using boolean mask
+    out = df.filter([True, False, False, False, True])
+    expected = pl.DataFrame({"a": [1, 2], "b": [1, 2], "c": [1, 4]})
+    assert_frame_equal(out, expected)
+
+    # using multiple boolean masks
+    out = df.filter(
+        np.array([True, True, False, True, False]),
+        np.array([True, False, True, True, False]),
+    )
+    expected = pl.DataFrame({"a": [1, 2], "b": [1, 2], "c": [1, 3]})
+    assert_frame_equal(out, expected)
+
+
 def test_indexing_set() -> None:
     df = pl.DataFrame({"bool": [True, True], "str": ["N/A", "N/A"], "nr": [1, 2]})
 

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -161,6 +161,45 @@ def test_filter_str() -> None:
     assert_frame_equal(result, expected)
 
 
+def test_filter_multiple_predicates() -> None:
+    ldf = pl.LazyFrame(
+        {"a": [1, 1, 1, 2, 2], "b": [1, 1, 2, 2, 2], "c": [1, 1, 2, 3, 4]}
+    )
+
+    # using multiple predicates
+    out = ldf.filter(pl.col("a") == 1, pl.col("b") <= 2).collect()
+    expected = pl.DataFrame({"a": [1, 1, 1], "b": [1, 1, 2], "c": [1, 1, 2]})
+    assert_frame_equal(out, expected)
+
+    # using multiple kwargs
+    out = ldf.filter(a=1, b=2).collect()
+    expected = pl.DataFrame({"a": [1], "b": [2], "c": [2]})
+    assert_frame_equal(out, expected)
+
+    # using both
+    out = ldf.filter(pl.col("a") == 1, pl.col("b") <= 2, a=1, b=2).collect()
+    expected = pl.DataFrame({"a": [1], "b": [2], "c": [2]})
+    assert_frame_equal(out, expected)
+
+    # check 'predicate' keyword deprecation:
+    # note: can disambiguate new/old usage - only warn on old-style usage
+    with pytest.warns(
+        DeprecationWarning,
+        match="`filter` no longer takes a 'predicate' parameter",
+    ):
+        ldf.filter(
+            predicate=pl.col("a").ge(1),
+        ).collect()
+
+    ldf = pl.LazyFrame(
+        {
+            "description": ["eq", "gt", "ge"],
+            "predicate": ["==", ">", ">="],
+        },
+    )
+    assert ldf.filter(predicate="==").select("description").collect().item() == "eq"
+
+
 def test_apply_custom_function() -> None:
     ldf = pl.LazyFrame(
         {


### PR DESCRIPTION
Closes #11642, supersedes #11674.

Ended up going a little deeper down the rabbit hole so moved it into my own branch to finish off as I was having issues rebasing / force-pushing to a branch I don't own (some sort of credentials/token issue? 🤷); kudos to @mcrumiller for getting things started with the initial implementation!

## Miscellaneous

* Turns out we can cleanly disambiguate new/old usage of the `predicate` keyword, so only warns on old-style usage.
* Noticed a fast-path for recognising numpy-based boolean masks (and int sequences), so integrated this too.
* The `parse_as_expression` docstring claimed it had a "wrap" param but it didn't - so I added it (and used it) ;)

## New Features

Adds support for:
* `*predicates` (one _or more_ predicates as positional arguments).
* `**constraints` (`col == value` matches as keyword arguments).
* resolves _chains_ of boolean masks (previously only allowed one).

## Examples
More than one predicate, now we have a positional args option.
Implicitly combines predicates with `all_horizontal`:
```python
df.filter( 
    pl.col("a") >= 0, 
    pl.col("b").is_not_null(),
    pl.col("").str.starts_with("!"),
 )
```
Splat predicates assembled elsewhere straight into filter without having to combine them yourself:
```python
df.filter( *conditions )
```
Constrain rows using `**kwargs` format (essentially the same API that we offer in `with_columns`):
```python
df.filter( 
    x = 0,
    y = "xxx",
    z = date.today(),
)
```
Mix and match the two formats freely:
```python
df.filter( *conditions, value=0, start_date=date.today() )
```
Easily filter against a Pydantic/FastAPI `Model` object:
```python
from pydantic import BaseModel
from datetime import date
import polars as pl

class DataModel(BaseModel):
    x: date
    y: str
    z: int
    
model_data = [
    DataModel( x=date.today(), y="aa", z=123 ),
    DataModel( x=date.today(), y="bb", z=456 ),
    DataModel( x=date.today(), y="cc", z=789 ),
]

df = pl.DataFrame( data=model_data )
# shape: (3, 3)
# ┌────────────┬─────┬─────┐
# │ x          ┆ y   ┆ z   │
# │ ---        ┆ --- ┆ --- │
# │ date       ┆ str ┆ i64 │
# ╞════════════╪═════╪═════╡
# │ 2023-10-14 ┆ aa  ┆ 123 │
# │ 2023-10-14 ┆ bb  ┆ 456 │
# │ 2023-10-14 ┆ cc  ┆ 789 │
# └────────────┴─────┴─────┘

df.filter( **model_data[1].model_dump() )
# shape: (1, 3)
# ┌────────────┬─────┬─────┐
# │ x          ┆ y   ┆ z   │
# │ ---        ┆ --- ┆ --- │
# │ date       ┆ str ┆ i64 │
# ╞════════════╪═════╪═════╡
# │ 2023-10-14 ┆ bb  ┆ 456 │
# └────────────┴─────┴─────┘
```
Chain boolean masks (previously only allowed one per `filter` invocation):
```python
mask1 = [True, False, True]
mask2 = [False, True, True]

df.filter( mask1, mask2 )
# shape: (1, 3)
# ┌────────────┬─────┬─────┐
# │ x          ┆ y   ┆ z   │
# │ ---        ┆ --- ┆ --- │
# │ date       ┆ str ┆ i64 │
# ╞════════════╪═════╪═════╡
# │ 2023-10-14 ┆ cc  ┆ 789 │
# └────────────┴─────┴─────┘
```
