### PR TITLE
feat(python): Use `OrderedDict` for schemas

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -404,11 +404,6 @@ def from_repr(tbl: str) -> DataFrame | Series:
     │ 123456780       ┆ 9876543210        ┆ a:b:c ┆ 2023-03-25 10:56:59.663053 JST │
     │ 803065983       ┆ 2055938745        ┆ x:y:z ┆ 2023-03-25 12:38:18.050545 JST │
     └─────────────────┴───────────────────┴───────┴────────────────────────────────┘
-    >>> df.schema
-    {'source_actor_id': Int32,
-     'source_channel_id': Int64,
-     'ident': Utf8,
-     'timestamp': Datetime(time_unit='us', time_zone='Asia/Tokyo')}
 
     From Series repr:
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import contextlib
 import os
 import random
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
 from collections.abc import Sized
 from io import BytesIO, StringIO, TextIOWrapper
 from operator import itemgetter
@@ -1253,10 +1253,10 @@ class DataFrame:
         ...     }
         ... )
         >>> df.schema
-        {'foo': Int64, 'bar': Float64, 'ham': Utf8}
+        OrderedDict([('foo', Int64), ('bar', Float64), ('ham', Utf8)])
 
         """
-        return dict(zip(self.columns, self.dtypes))
+        return OrderedDict(zip(self.columns, self.dtypes))
 
     def __array__(self, dtype: Any = None) -> np.ndarray[Any, Any]:
         """

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -459,7 +459,7 @@ def struct(
     Use keyword arguments to easily name each struct field.
 
     >>> df.select(pl.struct(p="int", q="bool").alias("my_struct")).schema
-    {'my_struct': Struct([Field('p', Int64), Field('q', Boolean)])}
+    OrderedDict([('my_struct', Struct([Field('p', Int64), Field('q', Boolean)]))])
 
     """
     pyexprs = parse_as_list_of_expressions(*exprs, **named_exprs)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import os
 import warnings
+from collections import OrderedDict
 from datetime import date, datetime, time, timedelta
 from io import BytesIO, StringIO
 from pathlib import Path
@@ -723,10 +724,10 @@ class LazyFrame:
         ...     }
         ... )
         >>> lf.schema
-        {'foo': Int64, 'bar': Float64, 'ham': Utf8}
+        OrderedDict([('foo', Int64), ('bar', Float64), ('ham', Utf8)])
 
         """
-        return self._ldf.schema()
+        return OrderedDict(self._ldf.schema())
 
     def __dataframe_consortium_standard__(
         self, *, api_version: str | None = None

--- a/py-polars/polars/series/struct.py
+++ b/py-polars/polars/series/struct.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from collections import OrderedDict
 from typing import TYPE_CHECKING, Sequence
 
 from polars.series.utils import expr_dispatch
@@ -9,8 +10,8 @@ from polars.utils.various import sphinx_accessor
 
 if TYPE_CHECKING:
     from polars import DataFrame, Series
-    from polars.datatypes import PolarsDataType
     from polars.polars import PySeries
+    from polars.type_aliases import SchemaDict
 elif os.getenv("BUILDING_SPHINX_DOCS"):
     property = sphinx_accessor
 
@@ -65,11 +66,11 @@ class StructNameSpace:
         """
 
     @property
-    def schema(self) -> dict[str, PolarsDataType]:
+    def schema(self) -> SchemaDict:
         """Get the struct definition as a name/dtype schema dict."""
         if getattr(self, "_s", None) is None:
             return {}
-        return self._s.dtype().to_schema()
+        return OrderedDict(self._s.dtype().to_schema())
 
     def unnest(self) -> DataFrame:
         """

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1839,6 +1839,14 @@ def test_schema() -> None:
     assert df.schema == expected
 
 
+def test_schema_equality() -> None:
+    lf = pl.LazyFrame({"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0]})
+    lf_rev = lf.select("bar", "foo")
+
+    assert lf.schema != lf_rev.schema
+    assert lf.collect().schema != lf_rev.collect().schema
+
+
 def test_df_schema_unique() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
     with pytest.raises(pl.DuplicateError):


### PR DESCRIPTION
I was writing some tests and found out that our schemas aren't ordered, e.g.:

```python
df = pl.DataFrame({"foo": [1, 2, 3], "bar": [6.0, 7.0, 8.0]})
df_rev = df.select("bar", "foo")
assert df.schema == df_rev.schema   # passes ?!
```

The order of columns might not always be relevant, but it definitely is in some cases. And the schema shouldn't be considered equal if the column order is different.

The simple fix is to use `OrderedDict` for our schemas instead of a regular `dict`. Amazingly, switching doesn't cause any of our tests/lints to fail - only some doctests as the repr is different.

@alexander-beedie Anything I'm missing here, or is this just a quick win?