### PR TITLE
fix(rust, python)!: return nan instead of None for std when ddof>=n_values

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/aggregate/var.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/var.rs
@@ -17,7 +17,7 @@ where
     fn var(&self, ddof: u8) -> Option<f64> {
         let n_values = self.len() - self.null_count();
         if n_values <= ddof as usize {
-            return None;
+            return Some(f64::NAN);
         }
 
         let mean = self.mean()?;

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from datetime import date, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pytest
@@ -102,7 +102,7 @@ def test_median() -> None:
 
 def test_single_element_std() -> None:
     s = pl.Series([1])
-    assert math.isnan(s.std(ddof=1))
+    assert math.isnan(cast(float, s.std(ddof=1)))
     assert s.std(ddof=0) == 0.0
 
 

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -101,7 +102,7 @@ def test_median() -> None:
 
 def test_single_element_std() -> None:
     s = pl.Series([1])
-    assert s.std(ddof=1) is None
+    assert math.isnan(s.std(ddof=1))
     assert s.std(ddof=0) == 0.0
 
 


### PR DESCRIPTION
This came up in https://github.com/pola-rs/polars/issues/8718 but it looks like `None` is currently returned as opposed to `float('nan')`

