### PR TITLE
docs: The orders of the df columns in user guide - Migrating: Coming from Pandas

### DIFF
--- a/docs/user-guide/migration/pandas.md
+++ b/docs/user-guide/migration/pandas.md
@@ -225,8 +225,8 @@ In `Pandas` we have:
 
 ```python
 df = pd.DataFrame({
-    "type": ["m", "n", "o", "m", "m", "n", "n"],
     "c": [1, 1, 1, 2, 2, 2, 2],
+    "type": ["m", "n", "o", "m", "m", "n", "n"],
 })
 
 df["size"] = df.groupby("c")["type"].transform(len)


### PR DESCRIPTION
## `Pandas` transform
Based on the `df` output, it seems that the order of columns should be ["c", "type"] rather than ["type", "c"].

```
   c type size
0  1    m    3
1  1    n    3
2  1    o    3
3  2    m    4
4  2    m    4
5  2    n    4
6  2    n    4
```