### PR TITLE
fix: Correctly process subseconds in `pl.duration`

### DIFF
--- a/crates/polars-plan/src/dsl/functions/temporal.rs
+++ b/crates/polars-plan/src/dsl/functions/temporal.rs
@@ -255,10 +255,6 @@ impl DurationArgs {
 /// Construct a column of [`Duration`] from the provided [`DurationArgs`]
 #[cfg(feature = "temporal")]
 pub fn duration(args: DurationArgs) -> Expr {
-    println!("{}", args.milliseconds);
-    println!("{}", args.microseconds);
-    println!("{}", args.nanoseconds);
-
     let function = SpecialEq::new(Arc::new(move |s: &mut [Series]| {
         if s.iter().any(|s| s.is_empty()) {
             return Ok(Some(Series::new_empty(
@@ -299,6 +295,9 @@ pub fn duration(args: DurationArgs) -> Expr {
                 if is_scalar(&microseconds) {
                     microseconds = microseconds.new_from_index(0, max_len);
                 }
+                if is_not_zero_scalar(&nanoseconds) {
+                    microseconds = microseconds + (nanoseconds / 1_000);
+                }
                 if is_not_zero_scalar(&milliseconds) {
                     microseconds = microseconds + (milliseconds * 1_000);
                 }
@@ -307,6 +306,12 @@ pub fn duration(args: DurationArgs) -> Expr {
             TimeUnit::Milliseconds => {
                 if is_scalar(&milliseconds) {
                     milliseconds = milliseconds.new_from_index(0, max_len);
+                }
+                if is_not_zero_scalar(&nanoseconds) {
+                    milliseconds = milliseconds + (nanoseconds / 1_000_000);
+                }
+                if is_not_zero_scalar(&microseconds) {
+                    milliseconds = milliseconds + (microseconds / 1_000);
                 }
                 milliseconds
             },

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -817,111 +817,6 @@ def test_asof_join_tolerance_grouper() -> None:
     assert_frame_equal(out, expected)
 
 
-def test_datetime_duration_offset() -> None:
-    df = pl.DataFrame(
-        {
-            "datetime": [
-                datetime(1999, 1, 1, 7),
-                datetime(2022, 1, 2, 14),
-                datetime(3000, 12, 31, 21),
-            ],
-            "add": [1, 2, -1],
-        }
-    )
-    out = df.select(
-        [
-            (pl.col("datetime") + pl.duration(weeks="add")).alias("add_weeks"),
-            (pl.col("datetime") + pl.duration(days="add")).alias("add_days"),
-            (pl.col("datetime") + pl.duration(hours="add")).alias("add_hours"),
-            (pl.col("datetime") + pl.duration(seconds="add")).alias("add_seconds"),
-            (pl.col("datetime") + pl.duration(microseconds=pl.col("add") * 1000)).alias(
-                "add_usecs"
-            ),
-        ]
-    )
-    expected = pl.DataFrame(
-        {
-            "add_weeks": [
-                datetime(1999, 1, 8, 7),
-                datetime(2022, 1, 16, 14),
-                datetime(3000, 12, 24, 21),
-            ],
-            "add_days": [
-                datetime(1999, 1, 2, 7),
-                datetime(2022, 1, 4, 14),
-                datetime(3000, 12, 30, 21),
-            ],
-            "add_hours": [
-                datetime(1999, 1, 1, hour=8),
-                datetime(2022, 1, 2, hour=16),
-                datetime(3000, 12, 31, hour=20),
-            ],
-            "add_seconds": [
-                datetime(1999, 1, 1, 7, second=1),
-                datetime(2022, 1, 2, 14, second=2),
-                datetime(3000, 12, 31, 20, 59, 59),
-            ],
-            "add_usecs": [
-                datetime(1999, 1, 1, 7, microsecond=1000),
-                datetime(2022, 1, 2, 14, microsecond=2000),
-                datetime(3000, 12, 31, 20, 59, 59, 999000),
-            ],
-        }
-    )
-    assert_frame_equal(out, expected)
-
-
-def test_date_duration_offset() -> None:
-    df = pl.DataFrame(
-        {
-            "date": [date(10, 1, 1), date(2000, 7, 5), date(9990, 12, 31)],
-            "offset": [365, 7, -31],
-        }
-    )
-    out = df.select(
-        [
-            (pl.col("date") + pl.duration(days="offset")).alias("add_days"),
-            (pl.col("date") - pl.duration(days="offset")).alias("sub_days"),
-            (pl.col("date") + pl.duration(weeks="offset")).alias("add_weeks"),
-            (pl.col("date") - pl.duration(weeks="offset")).alias("sub_weeks"),
-        ]
-    )
-    assert out.to_dict(False) == {
-        "add_days": [date(11, 1, 1), date(2000, 7, 12), date(9990, 11, 30)],
-        "sub_days": [date(9, 1, 1), date(2000, 6, 28), date(9991, 1, 31)],
-        "add_weeks": [date(16, 12, 30), date(2000, 8, 23), date(9990, 5, 28)],
-        "sub_weeks": [date(3, 1, 3), date(2000, 5, 17), date(9991, 8, 5)],
-    }
-
-
-def test_add_duration_3786() -> None:
-    df = pl.DataFrame(
-        {
-            "datetime": [datetime(2022, 1, 1), datetime(2022, 1, 2)],
-            "add": [1, 2],
-        }
-    )
-    assert df.slice(0, 1).with_columns(
-        [
-            (pl.col("datetime") + pl.duration(weeks="add")).alias("add_weeks"),
-            (pl.col("datetime") + pl.duration(days="add")).alias("add_days"),
-            (pl.col("datetime") + pl.duration(seconds="add")).alias("add_seconds"),
-            (pl.col("datetime") + pl.duration(milliseconds="add")).alias(
-                "add_milliseconds"
-            ),
-            (pl.col("datetime") + pl.duration(hours="add")).alias("add_hours"),
-        ]
-    ).to_dict(False) == {
-        "datetime": [datetime(2022, 1, 1, 0, 0)],
-        "add": [1],
-        "add_weeks": [datetime(2022, 1, 8, 0, 0)],
-        "add_days": [datetime(2022, 1, 2, 0, 0)],
-        "add_seconds": [datetime(2022, 1, 1, 0, 0, 1)],
-        "add_milliseconds": [datetime(2022, 1, 1, 0, 0, 0, 1000)],
-        "add_hours": [datetime(2022, 1, 1, 1, 0)],
-    }
-
-
 def test_rolling_group_by_by_argument() -> None:
     df = pl.DataFrame({"times": range(10), "groups": [1] * 4 + [2] * 6})
 
@@ -2644,16 +2539,12 @@ def test_datetime_cum_agg_schema() -> None:
     assert (
         df.lazy()
         .with_columns(
-            [
-                (pl.col("timestamp").cummin()).alias("cummin"),
-                (pl.col("timestamp").cummax()).alias("cummax"),
-            ]
+            (pl.col("timestamp").cummin()).alias("cummin"),
+            (pl.col("timestamp").cummax()).alias("cummax"),
         )
         .with_columns(
-            [
-                (pl.col("cummin") + pl.duration(hours=24)).alias("cummin+24"),
-                (pl.col("cummax") + pl.duration(hours=24)).alias("cummax+24"),
-            ]
+            (pl.col("cummin") + pl.duration(hours=24)).alias("cummin+24"),
+            (pl.col("cummax") + pl.duration(hours=24)).alias("cummax+24"),
         )
         .collect()
     ).to_dict(False) == {

--- a/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from typing import TYPE_CHECKING
 
 import pytest
@@ -94,36 +94,6 @@ def test_time() -> None:
     assert_series_equal(out["ms2"], df["micro"].rename("ms2"))
 
 
-def test_empty_duration() -> None:
-    s = pl.DataFrame([], {"days": pl.Int32}).select(pl.duration(days="days"))
-    assert s.dtypes == [pl.Duration("us")]
-    assert s.shape == (0, 1)
-
-
-@pytest.mark.parametrize(
-    ("time_unit", "expected"),
-    [
-        ("ms", timedelta(days=1, minutes=2, seconds=3, milliseconds=4)),
-        ("us", timedelta(days=1, minutes=2, seconds=3, milliseconds=4, microseconds=5)),
-        ("ns", timedelta(days=1, minutes=2, seconds=3, milliseconds=4, microseconds=5)),
-    ],
-)
-def test_duration_time_units(time_unit: TimeUnit, expected: timedelta) -> None:
-    result = pl.LazyFrame().select(
-        pl.duration(
-            days=1,
-            minutes=2,
-            seconds=3,
-            milliseconds=4,
-            microseconds=5,
-            nanoseconds=6,
-            time_unit=time_unit,
-        )
-    )
-    assert result.schema["duration"] == pl.Duration(time_unit)
-    assert result.collect()["duration"].item() == expected
-    if time_unit == "ns":
-        assert result.collect()["duration"].dt.nanoseconds().item() == 86523004005006
 
 
 def test_list_concat() -> None:

--- a/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
@@ -94,8 +94,6 @@ def test_time() -> None:
     assert_series_equal(out["ms2"], df["micro"].rename("ms2"))
 
 
-
-
 def test_list_concat() -> None:
     s0 = pl.Series("a", [[1, 2]])
     s1 = pl.Series("b", [[3, 4, 5]])

--- a/py-polars/tests/unit/functions/as_datatype/test_duration.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_duration.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+if TYPE_CHECKING:
+    from polars.type_aliases import TimeUnit
+
+
+def test_empty_duration() -> None:
+    s = pl.DataFrame([], {"days": pl.Int32}).select(pl.duration(days="days"))
+    assert s.dtypes == [pl.Duration("us")]
+    assert s.shape == (0, 1)
+
+
+@pytest.mark.parametrize(
+    ("time_unit", "expected"),
+    [
+        ("ms", timedelta(days=1, minutes=2, seconds=3, milliseconds=4)),
+        ("us", timedelta(days=1, minutes=2, seconds=3, milliseconds=4, microseconds=5)),
+        ("ns", timedelta(days=1, minutes=2, seconds=3, milliseconds=4, microseconds=5)),
+    ],
+)
+def test_duration_time_units(time_unit: TimeUnit, expected: timedelta) -> None:
+    result = pl.LazyFrame().select(
+        pl.duration(
+            days=1,
+            minutes=2,
+            seconds=3,
+            milliseconds=4,
+            microseconds=5,
+            nanoseconds=6,
+            time_unit=time_unit,
+        )
+    )
+    assert result.schema["duration"] == pl.Duration(time_unit)
+    assert result.collect()["duration"].item() == expected
+    if time_unit == "ns":
+        assert result.collect()["duration"].dt.nanoseconds().item() == 86523004005006
+
+
+def test_datetime_duration_offset() -> None:
+    df = pl.DataFrame(
+        {
+            "datetime": [
+                datetime(1999, 1, 1, 7),
+                datetime(2022, 1, 2, 14),
+                datetime(3000, 12, 31, 21),
+            ],
+            "add": [1, 2, -1],
+        }
+    )
+    out = df.select(
+        (pl.col("datetime") + pl.duration(weeks="add")).alias("add_weeks"),
+        (pl.col("datetime") + pl.duration(days="add")).alias("add_days"),
+        (pl.col("datetime") + pl.duration(hours="add")).alias("add_hours"),
+        (pl.col("datetime") + pl.duration(seconds="add")).alias("add_seconds"),
+        (pl.col("datetime") + pl.duration(microseconds=pl.col("add") * 1000)).alias(
+            "add_usecs"
+        ),
+    )
+    expected = pl.DataFrame(
+        {
+            "add_weeks": [
+                datetime(1999, 1, 8, 7),
+                datetime(2022, 1, 16, 14),
+                datetime(3000, 12, 24, 21),
+            ],
+            "add_days": [
+                datetime(1999, 1, 2, 7),
+                datetime(2022, 1, 4, 14),
+                datetime(3000, 12, 30, 21),
+            ],
+            "add_hours": [
+                datetime(1999, 1, 1, hour=8),
+                datetime(2022, 1, 2, hour=16),
+                datetime(3000, 12, 31, hour=20),
+            ],
+            "add_seconds": [
+                datetime(1999, 1, 1, 7, second=1),
+                datetime(2022, 1, 2, 14, second=2),
+                datetime(3000, 12, 31, 20, 59, 59),
+            ],
+            "add_usecs": [
+                datetime(1999, 1, 1, 7, microsecond=1000),
+                datetime(2022, 1, 2, 14, microsecond=2000),
+                datetime(3000, 12, 31, 20, 59, 59, 999000),
+            ],
+        }
+    )
+    assert_frame_equal(out, expected)
+
+
+def test_date_duration_offset() -> None:
+    df = pl.DataFrame(
+        {
+            "date": [date(10, 1, 1), date(2000, 7, 5), date(9990, 12, 31)],
+            "offset": [365, 7, -31],
+        }
+    )
+    out = df.select(
+        (pl.col("date") + pl.duration(days="offset")).alias("add_days"),
+        (pl.col("date") - pl.duration(days="offset")).alias("sub_days"),
+        (pl.col("date") + pl.duration(weeks="offset")).alias("add_weeks"),
+        (pl.col("date") - pl.duration(weeks="offset")).alias("sub_weeks"),
+    )
+    assert out.to_dict(False) == {
+        "add_days": [date(11, 1, 1), date(2000, 7, 12), date(9990, 11, 30)],
+        "sub_days": [date(9, 1, 1), date(2000, 6, 28), date(9991, 1, 31)],
+        "add_weeks": [date(16, 12, 30), date(2000, 8, 23), date(9990, 5, 28)],
+        "sub_weeks": [date(3, 1, 3), date(2000, 5, 17), date(9991, 8, 5)],
+    }
+
+
+def test_add_duration_3786() -> None:
+    df = pl.DataFrame(
+        {
+            "datetime": [datetime(2022, 1, 1), datetime(2022, 1, 2)],
+            "add": [1, 2],
+        }
+    )
+    assert df.slice(0, 1).with_columns(
+        (pl.col("datetime") + pl.duration(weeks="add")).alias("add_weeks"),
+        (pl.col("datetime") + pl.duration(days="add")).alias("add_days"),
+        (pl.col("datetime") + pl.duration(seconds="add")).alias("add_seconds"),
+        (pl.col("datetime") + pl.duration(milliseconds="add")).alias(
+            "add_milliseconds"
+        ),
+        (pl.col("datetime") + pl.duration(hours="add")).alias("add_hours"),
+    ).to_dict(False) == {
+        "datetime": [datetime(2022, 1, 1, 0, 0)],
+        "add": [1],
+        "add_weeks": [datetime(2022, 1, 8, 0, 0)],
+        "add_days": [datetime(2022, 1, 2, 0, 0)],
+        "add_seconds": [datetime(2022, 1, 1, 0, 0, 1)],
+        "add_milliseconds": [datetime(2022, 1, 1, 0, 0, 0, 1000)],
+        "add_hours": [datetime(2022, 1, 1, 1, 0)],
+    }

--- a/py-polars/tests/unit/functions/as_datatype/test_duration.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_duration.py
@@ -141,3 +141,21 @@ def test_add_duration_3786() -> None:
         "add_milliseconds": [datetime(2022, 1, 1, 0, 0, 0, 1000)],
         "add_hours": [datetime(2022, 1, 1, 1, 0)],
     }
+
+
+@pytest.mark.parametrize(
+    ("time_unit", "ms", "us", "ns"),
+    [
+        ("ms", 11, 0, 0),
+        ("us", 0, 11_007, 0),
+        ("ns", 0, 0, 11_007_003),
+    ],
+)
+def test_duration_subseconds_us(time_unit: TimeUnit, ms: int, us: int, ns: int) -> None:
+    result = pl.duration(
+        milliseconds=6, microseconds=4_005, nanoseconds=1_002_003, time_unit=time_unit
+    )
+    expected = pl.duration(
+        milliseconds=ms, microseconds=us, nanoseconds=ns, time_unit=time_unit
+    )
+    assert_frame_equal(pl.select(result), pl.select(expected))

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -182,29 +182,32 @@ def test_duration_function_literal() -> None:
     df = pl.DataFrame(
         {
             "A": ["x", "x", "y", "y", "y"],
-            "T": [date(2022, m, 1) for m in range(1, 6)],
+            "T": pl.datetime_range(
+                date(2022, 1, 1), date(2022, 5, 1), interval="1mo", eager=True
+            ),
             "S": [1, 2, 4, 8, 16],
         }
-    ).with_columns(
-        [
-            pl.col("T").cast(pl.Datetime),
-        ]
+    )
+
+    result = df.group_by("A", maintain_order=True).agg(
+        (pl.col("T").max() + pl.duration(seconds=1)) - pl.col("T")
     )
 
     # this checks if the `pl.duration` is flagged as AggState::Literal
-    assert df.group_by("A", maintain_order=True).agg(
-        [((pl.col("T").max() + pl.duration(seconds=1)) - pl.col("T"))]
-    ).to_dict(False) == {
-        "A": ["x", "y"],
-        "T": [
-            [timedelta(days=31, seconds=1), timedelta(seconds=1)],
-            [
-                timedelta(days=61, seconds=1),
-                timedelta(days=30, seconds=1),
-                timedelta(seconds=1),
+    expected = pl.DataFrame(
+        {
+            "A": ["x", "y"],
+            "T": [
+                [timedelta(days=31, seconds=1), timedelta(seconds=1)],
+                [
+                    timedelta(days=61, seconds=1),
+                    timedelta(days=30, seconds=1),
+                    timedelta(seconds=1),
+                ],
             ],
-        ],
-    }
+        }
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_string_par_materialize_8207() -> None:

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -251,15 +251,13 @@ def test_shrink_dtype() -> None:
 
 
 def test_diff_duration_dtype() -> None:
-    dates = ["2022-01-01", "2022-01-02", "2022-01-03", "2022-01-03"]
-    df = pl.DataFrame({"date": pl.Series(dates).str.strptime(pl.Date, "%Y-%m-%d")})
+    data = ["2022-01-01", "2022-01-02", "2022-01-03", "2022-01-03"]
+    df = pl.Series("date", data).str.to_date("%Y-%m-%d").to_frame()
 
-    assert df.select(pl.col("date").diff() < pl.duration(days=1))["date"].to_list() == [
-        None,
-        False,
-        False,
-        True,
-    ]
+    result = df.select(pl.col("date").diff() < pl.duration(days=1))
+
+    expected = pl.Series("date", [None, False, False, True]).to_frame()
+    assert_frame_equal(result, expected)
 
 
 def test_schema_owned_arithmetic_5669() -> None:


### PR DESCRIPTION
Closes #11747

#### Changes

* Refactor the function and related tests
* Add new test and fix the bug