### PR TITLE
test(python): Add parametric test for `df.to_dict`/`series.to_list`

### DIFF
--- a/py-polars/tests/unit/dataframe/test_to_dict.py
+++ b/py-polars/tests/unit/dataframe/test_to_dict.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from hypothesis import given
+
+import polars as pl
+from polars.testing import assert_frame_equal
+from polars.testing.parametric import dataframes
+
+
+@given(
+    df=dataframes(
+        # TODO: Remove exclusion when bug is fixed.
+        # https://github.com/pola-rs/polars/issues/11744
+        excluded_dtypes=[pl.Duration]
+    )
+)
+def test_to_dict(df: pl.DataFrame) -> None:
+    d = df.to_dict(as_series=False)
+    result = pl.from_dict(d, schema=df.schema)
+    assert_frame_equal(df, result, categorical_as_str=True)

--- a/py-polars/tests/unit/series/test_to_list.py
+++ b/py-polars/tests/unit/series/test_to_list.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from hypothesis import given
+
+import polars as pl
+from polars.testing import assert_series_equal
+from polars.testing.parametric import series
+
+
+@given(
+    s=series(
+        # TODO: Remove exclusion when bug is fixed.
+        # https://github.com/pola-rs/polars/issues/11744
+        excluded_dtypes=[pl.Duration]
+    )
+)
+def test_to_list(s: pl.Series) -> None:
+    values = s.to_list()
+    result = pl.Series(values, dtype=s.dtype)
+    assert_series_equal(s, result, categorical_as_str=True)


### PR DESCRIPTION
I am unhappy with many of our unit tests using `df.to_dict(False)`, for a number of reasons:

1. It doesn't verify dtypes (integer bit width, datetime precision, etc.)
2. It doesn't verify column order (python dictionaries are unordered)
3. It often results in poor test code formatting
4. It prohibits making the `as_series` argument keyword-only, which all booleans should be.

The main argument for using `to_dict(False)` was that the `to_dict` calls passingly test AnyValue conversion, which has caught bugs in the past.

To solve this, I added a proper parametric test for `to_dict` and `to_list`. With this covered, and `to_dict`/AnyValue conversion tested properly, we can now write the rest of our test suite using proper assert tooling (`assert_frame_equal` / `assert_series_equal`).