### PR TITLE
fix(python): Fix subsecond parsing in timedelta conversions

### DIFF
--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -128,6 +128,7 @@ def _date_to_pl_date(d: date) -> int:
 
 
 def _timedelta_to_pl_timedelta(td: timedelta, time_unit: TimeUnit | None) -> int:
+    """Convert a Python timedelta object to a total number of subseconds."""
     if time_unit == "ns":
         subseconds = td.microseconds * 1_000
         subseconds_per_second = 1_000_000_000

--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -127,20 +127,16 @@ def _date_to_pl_date(d: date) -> int:
     return int(dt.timestamp()) // (3600 * 24)
 
 
-def _timedelta_to_pl_timedelta(td: timedelta, time_unit: TimeUnit | None = None) -> int:
-    if time_unit is None or time_unit == "us":
-        subseconds = td.microseconds
-        subseconds_per_second = 1_000_000
-    elif time_unit == "ns":
+def _timedelta_to_pl_timedelta(td: timedelta, time_unit: TimeUnit | None) -> int:
+    if time_unit == "ns":
         subseconds = td.microseconds * 1_000
         subseconds_per_second = 1_000_000_000
     elif time_unit == "ms":
         subseconds = td.microseconds // 1_000
         subseconds_per_second = 1_000
     else:
-        raise ValueError(
-            f"`time_unit` must be one of {{'ns', 'us', 'ms'}}, got {time_unit!r}"
-        )
+        subseconds = td.microseconds
+        subseconds_per_second = 1_000_000
 
     subseconds += td.seconds * subseconds_per_second
     subseconds += td.days * SECONDS_PER_DAY * subseconds_per_second

--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -71,24 +71,24 @@ def _timedelta_to_pl_duration(td: timedelta | str | None) -> str | None:
     """Convert python timedelta to a polars duration string."""
     if td is None or isinstance(td, str):
         return td
-    else:
-        if td.days >= 0:
-            d = td.days and f"{td.days}d" or ""
-            s = td.seconds and f"{td.seconds}s" or ""
-            us = td.microseconds and f"{td.microseconds}us" or ""
-        else:
-            if not td.seconds and not td.microseconds:
-                d = td.days and f"{td.days}d" or ""
-                s = ""
-                us = ""
-            else:
-                corrected_d = td.days + 1
-                d = corrected_d and f"{corrected_d}d" or "-"
-                corrected_seconds = 24 * 3600 - (td.seconds + (td.microseconds > 0))
-                s = corrected_seconds and f"{corrected_seconds}s" or ""
-                us = td.microseconds and f"{10**6 - td.microseconds}us" or ""
 
-        return f"{d}{s}{us}"
+    if td.days >= 0:
+        d = td.days and f"{td.days}d" or ""
+        s = td.seconds and f"{td.seconds}s" or ""
+        us = td.microseconds and f"{td.microseconds}us" or ""
+    else:
+        if not td.seconds and not td.microseconds:
+            d = td.days and f"{td.days}d" or ""
+            s = ""
+            us = ""
+        else:
+            corrected_d = td.days + 1
+            d = corrected_d and f"{corrected_d}d" or "-"
+            corrected_seconds = 24 * 3600 - (td.seconds + (td.microseconds > 0))
+            s = corrected_seconds and f"{corrected_seconds}s" or ""
+            us = td.microseconds and f"{10**6 - td.microseconds}us" or ""
+
+    return f"{d}{s}{us}"
 
 
 def _negate_duration(duration: str) -> str:

--- a/py-polars/tests/unit/dataframe/test_from_dict.py
+++ b/py-polars/tests/unit/dataframe/test_from_dict.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_from_dict_with_column_order() -> None:
@@ -190,3 +191,10 @@ def test_from_dict_with_scalars_mixed() -> None:
     assert dfx[:5].rows() == dfx[5:10].rows()
     assert dfx[-10:-5].rows() == dfx[-5:].rows()
     assert dfx.row(n_range // 2, named=True) == mixed_dtype_data
+
+
+def test_from_dict_duration_subseconds() -> None:
+    d = {"duration": [timedelta(seconds=1, microseconds=1000)]}
+    result = pl.from_dict(d)
+    expected = pl.select(pl.duration(seconds=1, microseconds=1000))
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/dataframe/test_to_dict.py
+++ b/py-polars/tests/unit/dataframe/test_to_dict.py
@@ -7,13 +7,7 @@ from polars.testing import assert_frame_equal
 from polars.testing.parametric import dataframes
 
 
-@given(
-    df=dataframes(
-        # TODO: Remove exclusion when bug is fixed.
-        # https://github.com/pola-rs/polars/issues/11744
-        excluded_dtypes=[pl.Duration]
-    )
-)
+@given(df=dataframes())
 def test_to_dict(df: pl.DataFrame) -> None:
     d = df.to_dict(as_series=False)
     result = pl.from_dict(d, schema=df.schema)

--- a/py-polars/tests/unit/series/test_to_list.py
+++ b/py-polars/tests/unit/series/test_to_list.py
@@ -7,13 +7,7 @@ from polars.testing import assert_series_equal
 from polars.testing.parametric import series
 
 
-@given(
-    s=series(
-        # TODO: Remove exclusion when bug is fixed.
-        # https://github.com/pola-rs/polars/issues/11744
-        excluded_dtypes=[pl.Duration]
-    )
-)
+@given(s=series())
 def test_to_list(s: pl.Series) -> None:
     values = s.to_list()
     result = pl.Series(values, dtype=s.dtype)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/11744

The culprit was float arithmetic. To illustrate:

```
>>> td = timedelta(seconds=1, microseconds=1000)
>>> td.total_seconds()
1.001
>>> td.total_seconds() * 1_000
1000.9999999999999
>>> int(td.total_seconds() * 1_000)
1000
```

So we cannot use `timedelta.total_seconds()` here - we have to compute the number of subseconds from the `day`/`second`/`microsecond` components.