### PR TITLE
depr(python): Rename `group_by_rolling` to `rolling`

### DIFF
--- a/py-polars/docs/source/reference/dataframe/modify_select.rst
+++ b/py-polars/docs/source/reference/dataframe/modify_select.rst
@@ -47,6 +47,7 @@ Manipulation/selection
     DataFrame.replace
     DataFrame.replace_at_idx
     DataFrame.reverse
+    DataFrame.rolling
     DataFrame.row
     DataFrame.rows
     DataFrame.rows_by_key

--- a/py-polars/docs/source/reference/lazyframe/modify_select.rst
+++ b/py-polars/docs/source/reference/lazyframe/modify_select.rst
@@ -36,6 +36,7 @@ Manipulation/selection
     LazyFrame.merge_sorted
     LazyFrame.rename
     LazyFrame.reverse
+    LazyFrame.rolling
     LazyFrame.select
     LazyFrame.select_seq
     LazyFrame.set_sorted

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5177,7 +5177,7 @@ class DataFrame:
         not be 24 hours, due to daylight savings). Similarly for "calendar week",
         "calendar month", "calendar quarter", and "calendar year".
 
-        In case of a group_by_rolling on an integer column, the windows are defined by:
+        In case of a rolling operation on an integer column, the windows are defined by:
 
         - **"1i"      # length 1**
         - **"10i"     # length 10**
@@ -5190,7 +5190,7 @@ class DataFrame:
             This column must be sorted in ascending order (or, if `by` is specified,
             then it must be sorted in ascending order within each group).
 
-            In case of a rolling group by on indices, dtype needs to be one of
+            In case of a rolling operation on indices, dtype needs to be one of
             {Int32, Int64}. Note that Int32 gets temporarily cast to Int64, so if
             performance matters use an Int64 column.
         period
@@ -5232,7 +5232,7 @@ class DataFrame:
         >>> df = pl.DataFrame({"dt": dates, "a": [3, 7, 5, 9, 2, 1]}).with_columns(
         ...     pl.col("dt").str.strptime(pl.Datetime).set_sorted()
         ... )
-        >>> out = df.group_by_rolling(index_column="dt", period="2d").agg(
+        >>> out = df.rolling(index_column="dt", period="2d").agg(
         ...     [
         ...         pl.sum("a").alias("sum_a"),
         ...         pl.min("a").alias("min_a"),
@@ -5370,7 +5370,7 @@ class DataFrame:
 
         See Also
         --------
-        group_by_rolling
+        rolling
 
         Notes
         -----

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5125,7 +5125,7 @@ class DataFrame:
         """
         return GroupBy(self, by, *more_by, maintain_order=maintain_order)
 
-    def group_by_rolling(
+    def rolling(
         self,
         index_column: IntoExpr,
         *,
@@ -9906,7 +9906,7 @@ class DataFrame:
         """
         return self.group_by(by, *more_by, maintain_order=maintain_order)
 
-    @deprecate_renamed_function("group_by_rolling", version="0.19.0")
+    @deprecate_renamed_function("rolling", version="0.19.0")
     def groupby_rolling(
         self,
         index_column: IntoExpr,
@@ -9921,7 +9921,7 @@ class DataFrame:
         Create rolling groups based on a time, Int32, or Int64 column.
 
         .. deprecated:: 0.19.0
-            This method has been renamed to :func:`DataFrame.group_by_rolling`.
+            This method has been renamed to :func:`DataFrame.rolling`.
 
         Parameters
         ----------
@@ -9950,7 +9950,60 @@ class DataFrame:
             Doing so incorrectly will lead to incorrect output
 
         """
-        return self.group_by_rolling(
+        return self.rolling(
+            index_column,
+            period=period,
+            offset=offset,
+            closed=closed,
+            by=by,
+            check_sorted=check_sorted,
+        )
+
+    @deprecate_renamed_function("rolling", version="0.19.9")
+    def group_by_rolling(
+        self,
+        index_column: IntoExpr,
+        *,
+        period: str | timedelta,
+        offset: str | timedelta | None = None,
+        closed: ClosedInterval = "right",
+        by: IntoExpr | Iterable[IntoExpr] | None = None,
+        check_sorted: bool = True,
+    ) -> RollingGroupBy:
+        """
+        Create rolling groups based on a time, Int32, or Int64 column.
+
+        .. deprecated:: 0.19.9
+            This method has been renamed to :func:`DataFrame.rolling`.
+
+        Parameters
+        ----------
+        index_column
+            Column used to group based on the time window.
+            Often of type Date/Datetime.
+            This column must be sorted in ascending order (or, if `by` is specified,
+            then it must be sorted in ascending order within each group).
+
+            In case of a rolling group by on indices, dtype needs to be one of
+            {Int32, Int64}. Note that Int32 gets temporarily cast to Int64, so if
+            performance matters use an Int64 column.
+        period
+            length of the window - must be non-negative
+        offset
+            offset of the window. Default is -period
+        closed : {'right', 'left', 'both', 'none'}
+            Define which sides of the temporal interval are closed (inclusive).
+        by
+            Also group by this column/these columns
+        check_sorted
+            When the ``by`` argument is given, polars can not check sortedness
+            by the metadata and has to do a full scan on the index column to
+            verify data is sorted. This is expensive. If you are sure the
+            data within the by groups is sorted, you can set this to ``False``.
+            Doing so incorrectly will lead to incorrect output
+
+        """
+        return self.rolling(
             index_column,
             period=period,
             offset=offset,

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -800,7 +800,7 @@ class RollingGroupBy:
         groups_df = (
             self.df.lazy()
             .with_row_count(name=temp_col)
-            .group_by_rolling(
+            .rolling(
                 index_column=self.time_column,
                 period=self.period,
                 offset=self.offset,
@@ -859,7 +859,7 @@ class RollingGroupBy:
         """
         return (
             self.df.lazy()
-            .group_by_rolling(
+            .rolling(
                 index_column=self.time_column,
                 period=self.period,
                 offset=self.offset,
@@ -903,7 +903,7 @@ class RollingGroupBy:
         """
         return (
             self.df.lazy()
-            .group_by_rolling(
+            .rolling(
                 index_column=self.time_column,
                 period=self.period,
                 offset=self.offset,

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3225,7 +3225,7 @@ class Expr:
         not be 24 hours, due to daylight savings). Similarly for "calendar week",
         "calendar month", "calendar quarter", and "calendar year".
 
-        In case of a group_by_rolling on an integer column, the windows are defined by:
+        In case of a rolling operation on an integer column, the windows are defined by:
 
         - "1i"      # length 1
         - "10i"     # length 10
@@ -5530,7 +5530,7 @@ class Expr:
         Notes
         -----
         If you want to compute multiple aggregation statistics over the same dynamic
-        window, consider using `group_by_rolling` this method can cache the window size
+        window, consider using `rolling` - this method can cache the window size
         computation.
 
         Examples
@@ -5736,7 +5736,7 @@ class Expr:
         Notes
         -----
         If you want to compute multiple aggregation statistics over the same dynamic
-        window, consider using `group_by_rolling` this method can cache the window size
+        window, consider using `rolling` - this method can cache the window size
         computation.
 
         Examples
@@ -5973,7 +5973,7 @@ class Expr:
         Notes
         -----
         If you want to compute multiple aggregation statistics over the same dynamic
-        window, consider using `group_by_rolling` this method can cache the window size
+        window, consider using `rolling` - this method can cache the window size
         computation.
 
         Examples
@@ -6206,7 +6206,7 @@ class Expr:
         Notes
         -----
         If you want to compute multiple aggregation statistics over the same dynamic
-        window, consider using `group_by_rolling` this method can cache the window size
+        window, consider using `rolling` - this method can cache the window size
         computation.
 
         Examples
@@ -6442,7 +6442,7 @@ class Expr:
         Notes
         -----
         If you want to compute multiple aggregation statistics over the same dynamic
-        window, consider using `group_by_rolling` this method can cache the window size
+        window, consider using `rolling` - this method can cache the window size
         computation.
 
         Examples
@@ -6678,7 +6678,7 @@ class Expr:
         Notes
         -----
         If you want to compute multiple aggregation statistics over the same dynamic
-        window, consider using `group_by_rolling` this method can cache the window size
+        window, consider using `rolling` - this method can cache the window size
         computation.
 
         Examples
@@ -6917,7 +6917,7 @@ class Expr:
         Notes
         -----
         If you want to compute multiple aggregation statistics over the same dynamic
-        window, consider using `group_by_rolling` this method can cache the window size
+        window, consider using `rolling` - this method can cache the window size
         computation.
 
         Examples
@@ -7082,7 +7082,7 @@ class Expr:
         Notes
         -----
         If you want to compute multiple aggregation statistics over the same dynamic
-        window, consider using `group_by_rolling` this method can cache the window size
+        window, consider using `rolling` - this method can cache the window size
         computation.
 
         Examples

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2998,7 +2998,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         not be 24 hours, due to daylight savings). Similarly for "calendar week",
         "calendar month", "calendar quarter", and "calendar year".
 
-        In case of a group_by_rolling on an integer column, the windows are defined by:
+        In case of a rolling operation on an integer column, the windows are defined by:
 
         - "1i"      # length 1
         - "10i"     # length 10
@@ -3054,19 +3054,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     pl.col("dt").str.strptime(pl.Datetime).set_sorted()
         ... )
         >>> out = (
-        ...     df.group_by_rolling(index_column="dt", period="2d")
+        ...     df.rolling(index_column="dt", period="2d")
         ...     .agg(
-        ...         [
-        ...             pl.sum("a").alias("sum_a"),
-        ...             pl.min("a").alias("min_a"),
-        ...             pl.max("a").alias("max_a"),
-        ...         ]
+        ...         pl.sum("a").alias("sum_a"),
+        ...         pl.min("a").alias("min_a"),
+        ...         pl.max("a").alias("max_a"),
         ...     )
         ...     .collect()
         ... )
-        >>> assert out["sum_a"].to_list() == [3, 10, 15, 24, 11, 1]
-        >>> assert out["max_a"].to_list() == [3, 7, 7, 9, 9, 1]
-        >>> assert out["min_a"].to_list() == [3, 3, 3, 3, 2, 1]
         >>> out
         shape: (6, 4)
         ┌─────────────────────┬───────┬───────┬───────┐
@@ -3091,7 +3086,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         period = _timedelta_to_pl_duration(period)
         offset = _timedelta_to_pl_duration(offset)
 
-        lgb = self._ldf.group_by_rolling(
+        lgb = self._ldf.rolling(
             index_column, period, offset, closed, pyexprs_by, check_sorted
         )
         return LazyGroupBy(lgb)
@@ -3198,7 +3193,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         See Also
         --------
-        group_by_rolling
+        rolling
 
         Notes
         -----

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -661,7 +661,7 @@ impl PyLazyFrame {
         PyLazyGroupBy { lgb: Some(lazy_gb) }
     }
 
-    fn group_by_rolling(
+    fn rolling(
         &mut self,
         index_column: PyExpr,
         period: &str,

--- a/py-polars/tests/parametric/test_groupby_rolling.py
+++ b/py-polars/tests/parametric/test_groupby_rolling.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     data=st.data(),
     time_unit=strategy_time_unit,
 )
-def test_group_by_rolling(
+def test_rolling(
     period: str,
     offset: str,
     closed: ClosedInterval,
@@ -57,7 +57,7 @@ def test_group_by_rolling(
         )
     )
     df = dataframe.sort("ts")
-    result = df.group_by_rolling("ts", period=period, offset=offset, closed=closed).agg(
+    result = df.rolling("ts", period=period, offset=offset, closed=closed).agg(
         pl.col("value")
     )
 

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -612,7 +612,7 @@ def test_rolling() -> None:
 
     period: str | timedelta
     for period in ("2d", timedelta(days=2)):  # type: ignore[assignment]
-        out = df.group_by_rolling(index_column="dt", period=period).agg(
+        out = df.rolling(index_column="dt", period=period).agg(
             [
                 pl.sum("a").alias("sum_a"),
                 pl.min("a").alias("min_a"),
@@ -820,7 +820,7 @@ def test_asof_join_tolerance_grouper() -> None:
 def test_rolling_group_by_by_argument() -> None:
     df = pl.DataFrame({"times": range(10), "groups": [1] * 4 + [2] * 6})
 
-    out = df.group_by_rolling("times", period="5i", by=["groups"]).agg(
+    out = df.rolling("times", period="5i", by=["groups"]).agg(
         pl.col("times").alias("agg_list")
     )
 
@@ -846,7 +846,7 @@ def test_rolling_group_by_by_argument() -> None:
     assert_frame_equal(out, expected)
 
 
-def test_group_by_rolling_mean_3020() -> None:
+def test_rolling_mean_3020() -> None:
     df = pl.DataFrame(
         {
             "Date": [
@@ -864,7 +864,7 @@ def test_group_by_rolling_mean_3020() -> None:
 
     period: str | timedelta
     for period in ("1w", timedelta(days=7)):  # type: ignore[assignment]
-        result = df.group_by_rolling(index_column="Date", period=period).agg(
+        result = df.rolling(index_column="Date", period=period).agg(
             pl.col("val").mean().alias("val_mean")
         )
         expected = pl.DataFrame(
@@ -1275,7 +1275,7 @@ def test_unique_counts_on_dates() -> None:
     }
 
 
-def test_group_by_rolling_by_ordering() -> None:
+def test_rolling_by_ordering() -> None:
     # we must check that the keys still match the time labels after the rolling window
     # with a `by` argument.
     df = pl.DataFrame(
@@ -1294,7 +1294,7 @@ def test_group_by_rolling_by_ordering() -> None:
         }
     ).set_sorted("dt")
 
-    assert df.group_by_rolling(
+    assert df.rolling(
         index_column="dt",
         period="2m",
         closed="both",
@@ -1321,7 +1321,7 @@ def test_group_by_rolling_by_ordering() -> None:
     }
 
 
-def test_group_by_rolling_by_() -> None:
+def test_rolling_by_() -> None:
     df = pl.DataFrame({"group": pl.arange(0, 3, eager=True)}).join(
         pl.DataFrame(
             {
@@ -1334,13 +1334,13 @@ def test_group_by_rolling_by_() -> None:
     )
     out = (
         df.sort("datetime")
-        .group_by_rolling(index_column="datetime", by="group", period=timedelta(days=3))
+        .rolling(index_column="datetime", by="group", period=timedelta(days=3))
         .agg([pl.count().alias("count")])
     )
 
     expected = (
         df.sort(["group", "datetime"])
-        .group_by_rolling(index_column="datetime", by="group", period="3d")
+        .rolling(index_column="datetime", by="group", period="3d")
         .agg([pl.count().alias("count")])
     )
     assert_frame_equal(out.sort(["group", "datetime"]), expected)
@@ -2590,7 +2590,7 @@ def test_rolling_group_by_empty_groups_by_take_6330() -> None:
         .set_sorted("Date")
     )
     assert (
-        df.group_by_rolling(
+        df.rolling(
             index_column="Date",
             period="2i",
             offset="-2i",
@@ -2752,7 +2752,7 @@ def test_pytime_conversion(tm: time) -> None:
     assert s.to_list() == [tm]
 
 
-def test_group_by_rolling_duplicates() -> None:
+def test_rolling_duplicates() -> None:
     df = pl.DataFrame(
         {
             "ts": [datetime(2000, 1, 1, 0, 0), datetime(2000, 1, 1, 0, 0)],

--- a/py-polars/tests/unit/operations/map/test_map_groups.py
+++ b/py-polars/tests/unit/operations/map/test_map_groups.py
@@ -49,9 +49,7 @@ def test_map_groups_rolling() -> None:
             pl.col("b").max(),
         )
 
-    result = df.group_by_rolling("a", period="2i").map_groups(
-        function, schema=df.schema
-    )
+    result = df.rolling("a", period="2i").map_groups(function, schema=df.schema)
 
     expected = pl.DataFrame(
         [
@@ -162,7 +160,7 @@ def test_apply_deprecated() -> None:
     with pytest.deprecated_call():
         df.group_by("a").apply(lambda x: x)
     with pytest.deprecated_call():
-        df.group_by_rolling("a", period="2i").apply(lambda x: x, schema=None)
+        df.rolling("a", period="2i").apply(lambda x: x, schema=None)
     with pytest.deprecated_call():
         df.group_by_dynamic("a", every="2i").apply(lambda x: x, schema=None)
     with pytest.deprecated_call():

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -36,7 +36,7 @@ def example_df() -> pl.DataFrame:
     ["1d", "2d", "3d", timedelta(days=1), timedelta(days=2), timedelta(days=3)],
 )
 @pytest.mark.parametrize("closed", ["left", "right", "none", "both"])
-def test_rolling_kernels_and_group_by_rolling(
+def test_rolling_kernels_and_rolling(
     example_df: pl.DataFrame, period: str | timedelta, closed: ClosedInterval
 ) -> None:
     out1 = example_df.set_sorted("dt").select(
@@ -56,7 +56,7 @@ def test_rolling_kernels_and_group_by_rolling(
     )
     out2 = (
         example_df.set_sorted("dt")
-        .group_by_rolling("dt", period=period, closed=closed)
+        .rolling("dt", period=period, closed=closed)
         .agg(
             [
                 pl.col("values").sum().alias("sum"),
@@ -145,7 +145,7 @@ def test_rolling_negative_offset(
             "value": [1, 2, 3, 4],
         }
     )
-    result = df.group_by_rolling("ts", period="2d", offset=offset, closed=closed).agg(
+    result = df.rolling("ts", period="2d", offset=offset, closed=closed).agg(
         pl.col("value")
     )
     expected = pl.DataFrame(
@@ -271,7 +271,7 @@ def test_rolling_group_by_extrema() -> None:
     ).with_columns(pl.col("col1").reverse().alias("row_nr"))
 
     assert (
-        df.group_by_rolling(
+        df.rolling(
             index_column="row_nr",
             period="3i",
         )
@@ -310,7 +310,7 @@ def test_rolling_group_by_extrema() -> None:
     ).with_columns(pl.col("col1").alias("row_nr"))
 
     assert (
-        df.group_by_rolling(
+        df.rolling(
             index_column="row_nr",
             period="3i",
         )
@@ -348,7 +348,7 @@ def test_rolling_group_by_extrema() -> None:
     ).with_columns(pl.col("col1").sort().alias("row_nr"))
 
     assert (
-        df.group_by_rolling(
+        df.rolling(
             index_column="row_nr",
             period="3i",
         )
@@ -379,7 +379,7 @@ def test_rolling_slice_pushdown() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "a", "b"], "c": [1, 3, 5]}).lazy()
     df = (
         df.sort("a")
-        .group_by_rolling(
+        .rolling(
             "a",
             by="b",
             period="2i",
@@ -407,7 +407,7 @@ def test_overlapping_groups_4628() -> None:
         }
     )
     assert (
-        df.group_by_rolling(index_column=pl.col("index").set_sorted(), period="3i").agg(
+        df.rolling(index_column=pl.col("index").set_sorted(), period="3i").agg(
             [
                 pl.col("val").diff(n=1).alias("val.diff"),
                 (pl.col("val") - pl.col("val").shift(1)).alias("val - val.shift"),
@@ -473,7 +473,7 @@ def test_rolling_var_numerical_stability_5197() -> None:
     assert res[:4] == [None] * 4
 
 
-def test_group_by_rolling_iter() -> None:
+def test_rolling_iter() -> None:
     df = pl.DataFrame(
         {
             "date": [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 5)],
@@ -485,7 +485,7 @@ def test_group_by_rolling_iter() -> None:
     # Without 'by' argument
     result1 = [
         (name, data.shape)
-        for name, data in df.group_by_rolling(index_column="date", period="2d")
+        for name, data in df.rolling(index_column="date", period="2d")
     ]
     expected1 = [
         (date(2020, 1, 1), (1, 3)),
@@ -497,7 +497,7 @@ def test_group_by_rolling_iter() -> None:
     # With 'by' argument
     result2 = [
         (name, data.shape)
-        for name, data in df.group_by_rolling(index_column="date", period="2d", by="a")
+        for name, data in df.rolling(index_column="date", period="2d", by="a")
     ]
     expected2 = [
         ((1, date(2020, 1, 1)), (1, 3)),
@@ -507,18 +507,18 @@ def test_group_by_rolling_iter() -> None:
     assert result2 == expected2
 
 
-def test_group_by_rolling_negative_period() -> None:
+def test_rolling_negative_period() -> None:
     df = pl.DataFrame({"ts": [datetime(2020, 1, 1)], "value": [1]}).with_columns(
         pl.col("ts").set_sorted()
     )
     with pytest.raises(
         ComputeError, match="rolling window period should be strictly positive"
     ):
-        df.group_by_rolling("ts", period="-1d", offset="-1d").agg(pl.col("value"))
+        df.rolling("ts", period="-1d", offset="-1d").agg(pl.col("value"))
     with pytest.raises(
         ComputeError, match="rolling window period should be strictly positive"
     ):
-        df.lazy().group_by_rolling("ts", period="-1d", offset="-1d").agg(
+        df.lazy().rolling("ts", period="-1d", offset="-1d").agg(
             pl.col("value")
         ).collect()
     with pytest.raises(ComputeError, match="window size should be strictly positive"):

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -744,7 +744,32 @@ def test_groupby_rolling_deprecated() -> None:
             .collect()
         )
 
-    expected = df.group_by_rolling("date", period="2d").agg(pl.sum("value"))
+    expected = df.rolling("date", period="2d").agg(pl.sum("value"))
+    assert_frame_equal(result, expected, check_row_order=False)
+    assert_frame_equal(result_lazy, expected, check_row_order=False)
+
+
+def test_group_by_rolling_deprecated() -> None:
+    df = pl.DataFrame(
+        {
+            "date": pl.datetime_range(
+                datetime(2020, 1, 1), datetime(2020, 1, 5), eager=True
+            ),
+            "value": [1, 2, 3, 4, 5],
+        }
+    )
+
+    with pytest.deprecated_call():
+        result = df.group_by_rolling("date", period="2d").agg(pl.sum("value"))
+    with pytest.deprecated_call():
+        result_lazy = (
+            df.lazy()
+            .groupby_rolling("date", period="2d")
+            .agg(pl.sum("value"))
+            .collect()
+        )
+
+    expected = df.rolling("date", period="2d").agg(pl.sum("value"))
     assert_frame_equal(result, expected, check_row_order=False)
     assert_frame_equal(result_lazy, expected, check_row_order=False)
 

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -364,7 +364,7 @@ def test_sorted_flag_group_by_dynamic() -> None:
     )
 
 
-def test_group_by_rolling_dynamic_sortedness_check() -> None:
+def test_rolling_dynamic_sortedness_check() -> None:
     # when the by argument is passed, the sortedness flag
     # will be unset as the take shuffles data, so we must explicitly
     # check the sortedness


### PR DESCRIPTION
Addresses  #11432

This is just the Python side.

It's not entirely clear to me whether it's still a group-by type operation or not. It's baked into the GroupBy architecture quite firmly on the Rust side 🤔 