### PR TITLE
fix(rust,python): only exclude final output names of group_by key expressions

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -31,7 +31,7 @@ use polars_plan::global::FETCH_ROWS;
 #[cfg(any(feature = "ipc", feature = "parquet", feature = "csv"))]
 use polars_plan::logical_plan::collect_fingerprints;
 use polars_plan::logical_plan::optimize;
-use polars_plan::utils::expr_to_leaf_column_names;
+use polars_plan::utils::expr_output_name;
 use smartstring::alias::String as SmartString;
 
 use crate::fallible;
@@ -1674,10 +1674,10 @@ impl LazyGroupBy {
         let keys = self
             .keys
             .iter()
-            .flat_map(|k| expr_to_leaf_column_names(k).into_iter())
+            .filter_map(|expr| expr_output_name(expr).ok())
             .collect::<Vec<_>>();
 
-        self.agg([col("*").exclude(&keys).head(n).keep_name()])
+        self.agg([col("*").exclude(&keys).head(n)])
             .explode([col("*").exclude(&keys)])
     }
 
@@ -1686,10 +1686,10 @@ impl LazyGroupBy {
         let keys = self
             .keys
             .iter()
-            .flat_map(|k| expr_to_leaf_column_names(k).into_iter())
+            .filter_map(|expr| expr_output_name(expr).ok())
             .collect::<Vec<_>>();
 
-        self.agg([col("*").exclude(&keys).tail(n).keep_name()])
+        self.agg([col("*").exclude(&keys).tail(n)])
             .explode([col("*").exclude(&keys)])
     }
 

--- a/crates/polars-plan/src/logical_plan/projection.rs
+++ b/crates/polars-plan/src/logical_plan/projection.rs
@@ -4,6 +4,7 @@ use polars_core::utils::get_supertype;
 
 use super::*;
 use crate::prelude::function_expr::FunctionExpr;
+use crate::utils::expr_output_name;
 
 /// This replace the wildcard Expr with a Column Expr. It also removes the Exclude Expr from the
 /// expression chain.
@@ -354,21 +355,9 @@ fn prepare_excluded(
     }
 
     // exclude group_by keys
-    for mut expr in keys.iter() {
-        // Allow a number of aliases of a column expression, still exclude column from aggregation
-        loop {
-            match expr {
-                Expr::Column(name) => {
-                    exclude.insert(name.clone());
-                    break;
-                },
-                Expr::Alias(e, _) => {
-                    expr = e;
-                },
-                _ => {
-                    break;
-                },
-            }
+    for expr in keys.iter() {
+        if let Ok(name) = expr_output_name(expr) {
+            exclude.insert(name.clone());
         }
     }
     Ok(exclude)

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -788,3 +788,11 @@ def test_group_by_list_scalar_11749() -> None:
         "group_name": ["a;b", "c;d"],
         "eq": [[True, True, True, True], [True, False]],
     }
+
+
+def test_group_by_with_expr_as_key() -> None:
+    gb = pl.select(x=1).group_by(pl.col("x").alias("key"))
+    assert gb.agg(pl.all().first()).frame_equal(gb.agg(pl.first("x")))
+
+    # tests: 11766
+    assert gb.head(0).frame_equal(gb.agg(pl.col("x").head(0)).explode("x"))

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -796,3 +796,6 @@ def test_group_by_with_expr_as_key() -> None:
 
     # tests: 11766
     assert gb.head(0).frame_equal(gb.agg(pl.col("x").head(0)).explode("x"))
+
+    # tests: 11766
+    assert gb.tail(0).frame_equal(gb.agg(pl.col("x").tail(0)).explode("x"))

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -796,6 +796,4 @@ def test_group_by_with_expr_as_key() -> None:
 
     # tests: 11766
     assert gb.head(0).frame_equal(gb.agg(pl.col("x").head(0)).explode("x"))
-
-    # tests: 11766
     assert gb.tail(0).frame_equal(gb.agg(pl.col("x").tail(0)).explode("x"))


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/11762 and https://github.com/pola-rs/polars/issues/11766.