### PR TITLE
fix(rust,python): make `PyLazyGroupby` reusable

### DIFF
--- a/py-polars/src/lazygroupby.rs
+++ b/py-polars/src/lazygroupby.rs
@@ -19,18 +19,18 @@ pub struct PyLazyGroupBy {
 #[pymethods]
 impl PyLazyGroupBy {
     fn agg(&mut self, aggs: Vec<PyExpr>) -> PyLazyFrame {
-        let lgb = self.lgb.take().unwrap();
+        let lgb = self.lgb.clone().unwrap();
         let aggs = aggs.to_exprs();
         lgb.agg(aggs).into()
     }
 
     fn head(&mut self, n: usize) -> PyLazyFrame {
-        let lgb = self.lgb.take().unwrap();
+        let lgb = self.lgb.clone().unwrap();
         lgb.head(Some(n)).into()
     }
 
     fn tail(&mut self, n: usize) -> PyLazyFrame {
-        let lgb = self.lgb.take().unwrap();
+        let lgb = self.lgb.clone().unwrap();
         lgb.tail(Some(n)).into()
     }
 
@@ -39,7 +39,7 @@ impl PyLazyGroupBy {
         lambda: PyObject,
         schema: Option<Wrap<Schema>>,
     ) -> PyResult<PyLazyFrame> {
-        let lgb = self.lgb.take().unwrap();
+        let lgb = self.lgb.clone().unwrap();
         let schema = match schema {
             Some(schema) => Arc::new(schema.0),
             None => LazyFrame::from(lgb.logical_plan.clone())

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -822,3 +822,10 @@ def test_group_by_with_expr_as_key() -> None:
     # tests: 11766
     assert gb.head(0).frame_equal(gb.agg(pl.col("x").head(0)).explode("x"))
     assert gb.tail(0).frame_equal(gb.agg(pl.col("x").tail(0)).explode("x"))
+
+
+def test_lazy_group_by_reuse_11767() -> None:
+    lgb = pl.select(x=1).lazy().group_by("x")
+    a = lgb.count()
+    b = lgb.count()
+    assert a.collect().frame_equal(b.collect())


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/10793.