### PR TITLE
perf(python): Improve `DataFrame.get_column` performance by ~35%

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6674,11 +6674,7 @@ class DataFrame:
         ]
 
         """
-        if not isinstance(name, str):
-            raise TypeError(
-                f"column name {name!r} should be be a string, but is {type(name).__name__!r}"
-            )
-        return self[name]
+        return wrap_s(self._df.column(name))
 
     def fill_null(
         self,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1666,7 +1666,7 @@ class DataFrame:
         # select single column
         # df["foo"]
         if isinstance(item, str):
-            return wrap_s(self._df.column(item))
+            return self.get_column(item)
 
         # df[idx]
         if isinstance(item, int):
@@ -1864,7 +1864,7 @@ class DataFrame:
         s = (
             self._df.select_at_idx(column)
             if isinstance(column, int)
-            else self._df.column(column)
+            else self._df.get_column(column)
         )
         if s is None:
             raise IndexError(f"column index {column!r} is out of bounds")
@@ -6650,12 +6650,16 @@ class DataFrame:
 
     def get_column(self, name: str) -> Series:
         """
-        Get a single column as Series by name.
+        Get a single column by name.
 
         Parameters
         ----------
         name : str
             Name of the column to retrieve.
+
+        Returns
+        -------
+        Series
 
         See Also
         --------
@@ -6674,7 +6678,7 @@ class DataFrame:
         ]
 
         """
-        return wrap_s(self._df.column(name))
+        return wrap_s(self._df.get_column(name))
 
     def fill_null(
         self,

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1030,7 +1030,7 @@ impl PyDataFrame {
         self.df.find_idx_by_name(name)
     }
 
-    pub fn column(&self, name: &str) -> PyResult<PySeries> {
+    pub fn get_column(&self, name: &str) -> PyResult<PySeries> {
         let series = self
             .df
             .column(name)


### PR DESCRIPTION
`DataFrame.get_column(name)` simply called `self[name]` under the hood, which went through a bunch of checks until it finally called `wrap_s(self._df.column(name))`.

Instead, we should call the PySeries method directly, and `__getitem__` should dispatch to `DataFrame.get_column`.