### PR TITLE
fix(rust,python): ensure projections containing only hive columns are projected

### DIFF
--- a/crates/polars-arrow/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/crates/polars-arrow/src/io/parquet/read/deserialize/nested_utils.rs
@@ -499,15 +499,13 @@ where
     D: NestedDecoder<'a>,
 {
     // front[a1, a2, a3, ...]back
-    if items.len() > 1 {
+    if *remaining == 0 && items.len() == 0 {
+        return MaybeNext::None;
+    }
+    if items.len() > 0 && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX) {
         return MaybeNext::Some(Ok(items.pop_front().unwrap()));
     }
-    if *remaining == 0 {
-        return match items.pop_front() {
-            Some(decoded) => MaybeNext::Some(Ok(decoded)),
-            None => MaybeNext::None,
-        };
-    }
+
     match iter.next() {
         Err(e) => MaybeNext::Some(Err(e.into())),
         Ok(None) => {
@@ -541,8 +539,8 @@ where
                 Err(e) => return MaybeNext::Some(Err(e)),
             };
 
-            if (items.len() == 1)
-                && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX)
+            // if possible, return the value immediately.
+            if items.len() > 0 && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX)
             {
                 MaybeNext::Some(Ok(items.pop_front().unwrap()))
             } else {

--- a/crates/polars-arrow/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/crates/polars-arrow/src/io/parquet/read/deserialize/nested_utils.rs
@@ -499,7 +499,7 @@ where
     D: NestedDecoder<'a>,
 {
     // front[a1, a2, a3, ...]back
-    if *remaining == 0 && items.len() == 0 {
+    if *remaining == 0 && items.is_empty() {
         return MaybeNext::None;
     }
     if !items.is_empty() && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX) {

--- a/crates/polars-arrow/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/crates/polars-arrow/src/io/parquet/read/deserialize/nested_utils.rs
@@ -502,8 +502,7 @@ where
     if *remaining == 0 && items.len() == 0 {
         return MaybeNext::None;
     }
-    if !items.len().is_empty() && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX)
-    {
+    if !items.is_empty() && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX) {
         return MaybeNext::Some(Ok(items.pop_front().unwrap()));
     }
 
@@ -541,7 +540,7 @@ where
             };
 
             // if possible, return the value immediately.
-            if !items.len().is_empty()
+            if !items.is_empty()
                 && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX)
             {
                 MaybeNext::Some(Ok(items.pop_front().unwrap()))

--- a/crates/polars-arrow/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/crates/polars-arrow/src/io/parquet/read/deserialize/nested_utils.rs
@@ -502,7 +502,8 @@ where
     if *remaining == 0 && items.len() == 0 {
         return MaybeNext::None;
     }
-    if items.len() > 0 && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX) {
+    if !items.len().is_empty() && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX)
+    {
         return MaybeNext::Some(Ok(items.pop_front().unwrap()));
     }
 
@@ -540,7 +541,8 @@ where
             };
 
             // if possible, return the value immediately.
-            if items.len() > 0 && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX)
+            if !items.len().is_empty()
+                && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX)
             {
                 MaybeNext::Some(Ok(items.pop_front().unwrap()))
             } else {

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -230,7 +230,7 @@ fn rg_to_dfs_optionally_par_over_columns(
                 .collect::<PolarsResult<Vec<_>>>()?
         };
 
-        *remaining_rows = *remaining_rows - projection_height;
+        *remaining_rows -= projection_height;
 
         let mut df = DataFrame::new_no_checks(columns);
         if let Some(rc) = &row_count {

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -278,7 +278,7 @@ fn rg_to_dfs_par_over_rg(
             let num_rows = rg_md.num_rows();
             *previous_row_count += num_rows as IdxSize;
             let projection_height = (*remaining_rows).min(num_rows);
-            *remaining_rows = *remaining_rows - projection_height;
+            *remaining_rows -= projection_height;
 
             (rg_idx, rg_md, projection_height, row_count_start)
         })

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -98,3 +98,17 @@ def test_hive_partitioned_projection_pushdown(
     columns = ["sugars_g", "category"]
     for streaming in [True, False]:
         assert q.select(columns).collect(streaming=streaming).columns == columns
+
+    # test that hive partition columns are projected with the correct height when
+    # the projection contains only hive partition columns (11796)
+    for parallel in ("columns", "row_groups"):
+        q = pl.scan_parquet(
+            root / "**/*.parquet", hive_partitioning=True, parallel=parallel
+        )
+
+        assert_frame_equal(
+            q.select("category").collect(), q.collect().select("category")
+        )
+        assert_frame_equal(
+            q.select("category").collect(), q.collect().select("category")
+        )

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -101,14 +101,11 @@ def test_hive_partitioned_projection_pushdown(
 
     # test that hive partition columns are projected with the correct height when
     # the projection contains only hive partition columns (11796)
-    for parallel in ("columns", "row_groups"):
+    for parallel in ("row_groups", "columns"):
         q = pl.scan_parquet(
-            root / "**/*.parquet", hive_partitioning=True, parallel=parallel
+            root / "**/*.parquet", hive_partitioning=True, parallel=parallel  # type: ignore[arg-type]
         )
 
-        assert_frame_equal(
-            q.select("category").collect(), q.collect().select("category")
-        )
-        assert_frame_equal(
-            q.select("category").collect(), q.collect().select("category")
+        assert (
+            q.select("category").collect().frame_equal(q.collect().select("category"))
         )

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -106,6 +106,7 @@ def test_hive_partitioned_projection_pushdown(
             root / "**/*.parquet", hive_partitioning=True, parallel=parallel  # type: ignore[arg-type]
         )
 
-        assert (
-            q.select("category").collect().frame_equal(q.collect().select("category"))
-        )
+        expect = q.collect().select("category")
+        actual = q.select("category").collect()
+
+        assert expect.frame_equal(actual)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/11796 (regression introduced by https://github.com/pola-rs/polars/pull/11690).

This adds back the `num_rows` arg and includes some more detail in the comment above the function, as well as a test case.

Also did some refactoring around to calculate the `projection_height` upfront, which ended up causing the test from https://github.com/pola-rs/polars/pull/11578 to fail. This PR also improves on that fix to make it more robust.

I'm not actually certain exactly why it fails, but it's likely that the fix done by https://github.com/pola-rs/polars/pull/11578 was happened to produce the correct results because row groups prior to the last were always calling `column_idx_to_series` with the total number of rows remaining to read from the current row group as well as all subsequent row groups (`*remaining_rows`), which would always be `> md.num_rows`. However this PR changes that to call `column_idx_to_series` with `projection_height`, which is now always `<= md.num_rows()`.