### PR TITLE
depr(python): Deprecate non-keyword args for `ewm` methods

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -8367,7 +8367,6 @@ class Expr:
                   :math:`1-\alpha` and :math:`1` if ``adjust=True``,
                   and :math:`1-\alpha` and :math:`\alpha` if ``adjust=False``.
 
-
         Examples
         --------
         >>> df = pl.DataFrame({"a": [1, 2, 3]})

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -8300,6 +8300,7 @@ class Expr:
             self._pyexpr.sample_n(n, with_replacement, shuffle, seed)
         )
 
+    @deprecate_nonkeyword_arguments(version="0.19.10")
     def ewm_mean(
         self,
         com: float | None = None,
@@ -8388,6 +8389,7 @@ class Expr:
             self._pyexpr.ewm_mean(alpha, adjust, min_periods, ignore_nulls)
         )
 
+    @deprecate_nonkeyword_arguments(version="0.19.10")
     def ewm_std(
         self,
         com: float | None = None,
@@ -8480,6 +8482,7 @@ class Expr:
             self._pyexpr.ewm_std(alpha, adjust, bias, min_periods, ignore_nulls)
         )
 
+    @deprecate_nonkeyword_arguments(version="0.19.10")
     def ewm_var(
         self,
         com: float | None = None,

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -6413,6 +6413,7 @@ class Series:
 
         """
 
+    @deprecate_nonkeyword_arguments(version="0.19.10")
     def ewm_mean(
         self,
         com: float | None = None,
@@ -6494,6 +6495,7 @@ class Series:
 
         """
 
+    @deprecate_nonkeyword_arguments(version="0.19.10")
     def ewm_std(
         self,
         com: float | None = None,
@@ -6579,6 +6581,7 @@ class Series:
 
         """
 
+    @deprecate_nonkeyword_arguments(version="0.19.10")
     def ewm_var(
         self,
         com: float | None = None,

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -6480,6 +6480,18 @@ class Series:
                   :math:`1-\alpha` and :math:`1` if ``adjust=True``,
                   and :math:`1-\alpha` and :math:`\alpha` if ``adjust=False``.
 
+        Examples
+        --------
+        >>> s = pl.Series([1,2,3])
+        >>> s.ewm_mean(com=1)
+        shape: (3,)
+        Series: '' [f64]
+        [
+                1.0
+                1.666667
+                2.428571
+        ]
+
         """
 
     def ewm_std(

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -6483,7 +6483,7 @@ class Series:
 
         Examples
         --------
-        >>> s = pl.Series([1,2,3])
+        >>> s = pl.Series([1, 2, 3])
         >>> s.ewm_mean(com=1)
         shape: (3,)
         Series: '' [f64]

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2136,7 +2136,7 @@ def test_ewm_mean() -> None:
 def test_ewm_mean_leading_nulls() -> None:
     for min_periods in [1, 2, 3]:
         assert (
-            pl.Series([1, 2, 3, 4]).ewm_mean(3, min_periods=min_periods).null_count()
+            pl.Series([1, 2, 3, 4]).ewm_mean(com=3, min_periods=min_periods).null_count()
             == min_periods - 1
         )
     assert pl.Series([None, 1.0, 1.0, 1.0]).ewm_mean(

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -2136,7 +2136,9 @@ def test_ewm_mean() -> None:
 def test_ewm_mean_leading_nulls() -> None:
     for min_periods in [1, 2, 3]:
         assert (
-            pl.Series([1, 2, 3, 4]).ewm_mean(com=3, min_periods=min_periods).null_count()
+            pl.Series([1, 2, 3, 4])
+            .ewm_mean(com=3, min_periods=min_periods)
+            .null_count()
             == min_periods - 1
         )
     assert pl.Series([None, 1.0, 1.0, 1.0]).ewm_mean(


### PR DESCRIPTION
Since the first four arguments are mutually exclusive, they should be keyword-only.