### PR TITLE
Reverted df.explode back to 0.19.2

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6823,7 +6823,7 @@ class DataFrame:
         └──────┴──────┘
 
         """
-        return self.lazy().fill_nan(value).collect(_eager=True)
+        return self.lazy().fill_nan(value).collect(no_optimization=True)
 
     def explode(
         self,


### PR DESCRIPTION
`.commit()` does not accept `_eager` or `eager` kwargs so df.explode is broken from 0.19.2 until present. Fixed by just reverting it back to no_optimization which is how it was before the breaking change was introduced.