### PR TITLE
refactor(rust): remove redundant if branch in nested parquet

### DIFF
--- a/crates/polars-arrow/src/io/parquet/read/deserialize/nested_utils.rs
+++ b/crates/polars-arrow/src/io/parquet/read/deserialize/nested_utils.rs
@@ -502,9 +502,6 @@ where
     if *remaining == 0 && items.is_empty() {
         return MaybeNext::None;
     }
-    if !items.is_empty() && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX) {
-        return MaybeNext::Some(Ok(items.pop_front().unwrap()));
-    }
 
     match iter.next() {
         Err(e) => MaybeNext::Some(Err(e.into())),
@@ -539,7 +536,8 @@ where
                 Err(e) => return MaybeNext::Some(Err(e)),
             };
 
-            // if possible, return the value immediately.
+            // this comparison is strictly greater to ensure the contents of the
+            // row are fully read.
             if !items.is_empty()
                 && items.front().unwrap().0.len() > chunk_size.unwrap_or(usize::MAX)
             {


### PR DESCRIPTION
small cleanup after https://github.com/pola-rs/polars/pull/11803 - the if branch is never executed, so remove it to avoid confusing the next person that reads this.