### PR TITLE
fix(rust): Fix bug when casting to a local Categorical

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -125,6 +125,21 @@ impl CategoricalChunked {
     }
 
     /// Create a [`CategoricalChunked`] from an array of `idx` and an existing [`RevMapping`]:  `rev_map`.
+    pub(crate) fn from_cats_and_rev_map(
+        idx: UInt32Chunked,
+        rev_map: Arc<RevMapping>,
+    ) -> PolarsResult<CategoricalChunked> {
+        let len = rev_map.len() as u32;
+        let oob_check = idx.into_iter().flatten().any(|cat| cat >= len);
+        polars_ensure!(
+            !oob_check,
+            ComputeError:
+            "cannot construct Categorical from these categories; at least one of them is out of bounds"
+        );
+        Ok(unsafe { Self::from_cats_and_rev_map_unchecked(idx, rev_map) })
+    }
+
+    /// Create a [`CategoricalChunked`] from an array of `idx` and an existing [`RevMapping`]:  `rev_map`.
     ///
     /// # Safety
     /// Invariant in `v < rev_map.len() for v in idx` must hold.

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -422,3 +422,8 @@ def test_categorical_collect_11408() -> None:
         "groups": ["a", "b", "c"],
         "cats": ["a", "b", "c"],
     }
+
+
+def test_categorical_deeply_nested_11792() -> None:
+    s = pl.Series("col", [[["a"]]], dtype=pl.List(pl.List(pl.Categorical)))
+    assert s.dtype == pl.List(pl.List(pl.Categorical))


### PR DESCRIPTION
When doing certain operations (e.g. first on an aggregation) we use the physicals in the categorical and later on cast them back. Casting from a `UInt32` to a `Categorical` now incorrectly assumes that the categorical is using the global string cache. Adjusted the cast to use the provided `rev_map` in the `dtype` which can either be global or local. 

This should be faster for global categoricals as there is no need to reconstruct the categories / mappings from the global cache (`from_global_indices`), however it does lead to slightly bigger maps / categoricals as they are not 'flattened' to the subset of values in the `UInt32Chunked`. There is a trade off here.

fix #11810
fix #11792


