### PR TITLE
refactor(rust): rename new_from_owned_with_null_bitmap

### DIFF
--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -273,12 +273,8 @@ where
         Self::with_chunk(name, to_primitive::<T>(v, None))
     }
 
-    /// Nullify values in slice with an existing null bitmap
-    pub fn new_from_owned_with_null_bitmap(
-        name: &str,
-        values: Vec<T::Native>,
-        buffer: Option<Bitmap>,
-    ) -> Self {
+    /// Create a new ChunkedArray from a Vec and a validity mask.
+    pub fn from_vec_validity(name: &str, values: Vec<T::Native>, buffer: Option<Bitmap>) -> Self {
         let arr = to_array::<T>(values, buffer);
         let mut out = ChunkedArray {
             field: Arc::new(Field::new(name, T::get_dtype())),

--- a/crates/polars-ops/src/series/ops/rank.rs
+++ b/crates/polars-ops/src/series/ops/rank.rs
@@ -113,7 +113,7 @@ fn rank(s: &Series, method: RankMethod, descending: bool, seed: Option<u64>) -> 
                 rank += 1;
             }
         }
-        IdxCa::new_from_owned_with_null_bitmap(s.name(), out, validity).into_series()
+        IdxCa::from_vec_validity(s.name(), out, validity).into_series()
     } else {
         let sorted_values = unsafe { s.take_unchecked(&sort_idx_ca) };
         let not_consecutive_same = sorted_values
@@ -136,7 +136,7 @@ fn rank(s: &Series, method: RankMethod, descending: bool, seed: Option<u64>) -> 
                         rank += 1;
                     }
                 });
-                IdxCa::new_from_owned_with_null_bitmap(s.name(), out, validity).into_series()
+                IdxCa::from_vec_validity(s.name(), out, validity).into_series()
             },
             Average => unsafe {
                 let mut out = vec![0.0; s.len()];
@@ -149,8 +149,7 @@ fn rank(s: &Series, method: RankMethod, descending: bool, seed: Option<u64>) -> 
                         *out.get_unchecked_mut(*i as usize) = avg;
                     }
                 });
-                Float64Chunked::new_from_owned_with_null_bitmap(s.name(), out, validity)
-                    .into_series()
+                Float64Chunked::from_vec_validity(s.name(), out, validity).into_series()
             },
             Min => unsafe {
                 let mut out = vec![0 as IdxSize; s.len()];
@@ -160,7 +159,7 @@ fn rank(s: &Series, method: RankMethod, descending: bool, seed: Option<u64>) -> 
                     }
                     rank += ties.len() as IdxSize;
                 });
-                IdxCa::new_from_owned_with_null_bitmap(s.name(), out, validity).into_series()
+                IdxCa::from_vec_validity(s.name(), out, validity).into_series()
             },
             Max => unsafe {
                 let mut out = vec![0 as IdxSize; s.len()];
@@ -170,7 +169,7 @@ fn rank(s: &Series, method: RankMethod, descending: bool, seed: Option<u64>) -> 
                         *out.get_unchecked_mut(*i as usize) = rank - 1;
                     }
                 });
-                IdxCa::new_from_owned_with_null_bitmap(s.name(), out, validity).into_series()
+                IdxCa::from_vec_validity(s.name(), out, validity).into_series()
             },
             Dense => unsafe {
                 let mut out = vec![0 as IdxSize; s.len()];
@@ -180,7 +179,7 @@ fn rank(s: &Series, method: RankMethod, descending: bool, seed: Option<u64>) -> 
                     }
                     rank += 1;
                 });
-                IdxCa::new_from_owned_with_null_bitmap(s.name(), out, validity).into_series()
+                IdxCa::from_vec_validity(s.name(), out, validity).into_series()
             },
             Ordinal => unreachable!(),
         }

--- a/py-polars/src/series/numpy_ufunc.rs
+++ b/py-polars/src/series/numpy_ufunc.rs
@@ -86,7 +86,7 @@ macro_rules! impl_ufuncs {
                             assert_eq!(get_refcnt(out_array), 3);
 
                             let validity = self.series.chunks()[0].validity().cloned();
-                            let ca = ChunkedArray::<$type>::new_from_owned_with_null_bitmap(
+                            let ca = ChunkedArray::<$type>::from_vec_validity(
                                 self.name(),
                                 av,
                                 validity,

--- a/py-polars/src/series/numpy_ufunc.rs
+++ b/py-polars/src/series/numpy_ufunc.rs
@@ -86,11 +86,8 @@ macro_rules! impl_ufuncs {
                             assert_eq!(get_refcnt(out_array), 3);
 
                             let validity = self.series.chunks()[0].validity().cloned();
-                            let ca = ChunkedArray::<$type>::from_vec_validity(
-                                self.name(),
-                                av,
-                                validity,
-                            );
+                            let ca =
+                                ChunkedArray::<$type>::from_vec_validity(self.name(), av, validity);
                             PySeries::new(ca.into_series())
                         },
                         Err(e) => {


### PR DESCRIPTION
Found this name a bit long/outdated.