### PR TITLE
fix(python): Add `include_nulls` parameter to `update`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9756,13 +9756,19 @@ class DataFrame:
         left_on: str | Sequence[str] | None = None,
         right_on: str | Sequence[str] | None = None,
         how: Literal["left", "inner", "outer"] = "left",
+        include_nulls: bool | None = False,
     ) -> DataFrame:
         """
-        Update the values in this `DataFrame` with the non-null values in `other`.
+        Update the values in this `DataFrame` with the values in `other`.
+
+        By default, null values in the right dataframe are ignored. Use
+        `ignore_nulls=False` to overwrite values in this frame with null values in other
+        frame.
 
         Notes
         -----
-        This is syntactic sugar for a left/inner join + coalesce
+        This is syntactic sugar for a left/inner join, with an optional coalesce when
+        `include_nulls = False`.
 
         Warnings
         --------
@@ -9786,6 +9792,9 @@ class DataFrame:
             * 'inner' keeps only those rows where the key exists in both frames.
             * 'outer' will update existing rows where the key matches while also
               adding any new rows contained in the given frame.
+        include_nulls
+            If True, null values from the right dataframe will be used to update the
+            left dataframe.
 
         Examples
         --------
@@ -9861,10 +9870,29 @@ class DataFrame:
         │ 5   ┆ -66 │
         └─────┴─────┘
 
+        Update `df` values including null values in `new_df`, using an outer join
+        strategy that defines explicit join columns in each frame:
+
+        >>> df.update(
+        ...     new_df, left_on="A", right_on="C", how="outer", include_nulls=True
+        ... )
+        shape: (5, 2)
+        ┌─────┬──────┐
+        │ A   ┆ B    │
+        │ --- ┆ ---  │
+        │ i64 ┆ i64  │
+        ╞═════╪══════╡
+        │ 1   ┆ -99  │
+        │ 2   ┆ 500  │
+        │ 3   ┆ null │
+        │ 4   ┆ 700  │
+        │ 5   ┆ -66  │
+        └─────┴──────┘
+
         """
         return (
             self.lazy()
-            .update(other.lazy(), on, left_on, right_on, how)
+            .update(other.lazy(), on, left_on, right_on, how, include_nulls)
             .collect(_eager=True)
         )
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -561,6 +561,28 @@ def test_update() -> None:
         a.update(b.rename({"b": "a"}), how="outer", on="a").collect().to_series()
     )
 
+    # check behavior of include_nulls=True
+    df = pl.DataFrame(
+        {
+            "A": [1, 2, 3, 4],
+            "B": [400, 500, 600, 700],
+        }
+    )
+    new_df = pl.DataFrame(
+        {
+            "B": [-66, None, -99],
+            "C": [5, 3, 1],
+        }
+    )
+    out = df.update(new_df, left_on="A", right_on="C", how="outer", include_nulls=True)
+    expected = pl.DataFrame(
+        {
+            "A": [1, 2, 3, 4, 5],
+            "B": [-99, 500, None, 700, -66],
+        }
+    )
+    assert_frame_equal(out, expected)
+
     # edge-case #11684
     x = pl.DataFrame({"a": [0, 1]})
     y = pl.DataFrame({"a": [2, 3]})


### PR DESCRIPTION
Resolves #11821

Currently, `DataFrame.update` only uses non-null values from the right frame. This parameter allows a call to `df.update(other, include_nulls=True)` to include null values from `other`, which is conceivably useful in many cases.