### PR TITLE
fix(rust): panic on hive scan from cloud

### DIFF
--- a/crates/polars-io/src/parquet/read.rs
+++ b/crates/polars-io/src/parquet/read.rs
@@ -129,7 +129,8 @@ impl<R: MmapBytesReader> ParquetReader<R> {
         self
     }
 
-    /// Set the [`Schema`] if already known.
+    /// Set the [`Schema`] if already known. This must be exactly the same as
+    /// the schema in the file itself.
     pub fn with_schema(mut self, schema: Option<SchemaRef>) -> Self {
         self.schema = schema;
         self

--- a/crates/polars-io/src/parquet/read.rs
+++ b/crates/polars-io/src/parquet/read.rs
@@ -129,6 +129,12 @@ impl<R: MmapBytesReader> ParquetReader<R> {
         self
     }
 
+    /// Set the [`Schema`] if already known.
+    pub fn with_schema(mut self, schema: Option<SchemaRef>) -> Self {
+        self.schema = schema;
+        self
+    }
+
     /// [`Schema`] of the file.
     pub fn schema(&mut self) -> PolarsResult<SchemaRef> {
         match &self.schema {

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -57,6 +57,7 @@ impl ParquetExec {
 
         if let Some(file) = file {
             ParquetReader::new(file)
+                .with_schema(Some(self.file_info.reader_schema.clone()))
                 .with_n_rows(n_rows)
                 .read_parallel(self.options.parallel)
                 .with_row_count(mem::take(&mut self.file_options.row_count))
@@ -72,7 +73,7 @@ impl ParquetExec {
                     let reader = ParquetAsyncReader::from_uri(
                         &self.path.to_string_lossy(),
                         self.cloud_options.as_ref(),
-                        Some(self.file_info.schema.clone()),
+                        Some(self.file_info.reader_schema.clone()),
                         self.metadata.clone(),
                     )
                     .await?

--- a/crates/polars-pipe/src/executors/sources/parquet.rs
+++ b/crates/polars-pipe/src/executors/sources/parquet.rs
@@ -80,7 +80,7 @@ impl ParquetSource {
                     ParquetAsyncReader::from_uri(
                         &uri,
                         self.cloud_options.as_ref(),
-                        Some(self.file_info.schema.clone()),
+                        Some(self.file_info.reader_schema.clone()),
                         self.metadata.clone(),
                     )
                     .await?
@@ -102,6 +102,7 @@ impl ParquetSource {
             let file = std::fs::File::open(path).unwrap();
 
             ParquetReader::new(file)
+                .with_schema(Some(self.file_info.reader_schema.clone()))
                 .with_n_rows(file_options.n_rows)
                 .with_row_count(file_options.row_count)
                 .with_projection(projection)

--- a/crates/polars-plan/src/logical_plan/schema.rs
+++ b/crates/polars-plan/src/logical_plan/schema.rs
@@ -45,6 +45,9 @@ impl LogicalPlan {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FileInfo {
     pub schema: SchemaRef,
+    // Stores the schema used for the reader, as the main schema can contain
+    // extra hive columns.
+    pub reader_schema: SchemaRef,
     // - known size
     // - estimated size
     pub row_estimation: (Option<usize>, usize),
@@ -54,7 +57,8 @@ pub struct FileInfo {
 impl FileInfo {
     pub fn new(schema: SchemaRef, row_estimation: (Option<usize>, usize)) -> Self {
         Self {
-            schema,
+            schema: schema.clone(),
+            reader_schema: schema.clone(),
             row_estimation,
             hive_parts: None,
         }


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/11809.

This is probably the simplest way to fix it, but I'm unsure whether it's the best way. It appears the async parquet reader gets passed a schema to reduce metadata scanning from cloud, but currently the schema can contain extra hive columns that don't exist in the parquet file, which leads to oob.

This also adds `.with_schema()` to the standard parquet reader - this is purely to align the behavior with the async reader so that the unit tests can catch any potential errors, as currently it appears there isn't any way to directly test the cloud readers.

