### PR TITLE
perf: properly push down slice before left/asof join

### DIFF
--- a/crates/polars-ops/src/frame/join/hash_join/mod.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/mod.rs
@@ -160,14 +160,14 @@ pub trait JoinDispatch: IntoDf {
                 if let Some((offset, len)) = args.slice {
                     left_idx = slice_slice(left_idx, offset, len);
                 }
-                ca_self._create_left_df_from_slice(&left_idx, true, true)
+                ca_self._create_left_df_from_slice(left_idx, true, true)
             },
             ChunkJoinIds::Right(left_idx) => unsafe {
                 let mut left_idx = &*left_idx;
                 if let Some((offset, len)) = args.slice {
                     left_idx = slice_slice(left_idx, offset, len);
                 }
-                ca_self.create_left_df_chunked(&left_idx, true)
+                ca_self.create_left_df_chunked(left_idx, true)
             },
         };
 
@@ -184,7 +184,7 @@ pub trait JoinDispatch: IntoDf {
                 if let Some((offset, len)) = args.slice {
                     right_idx = slice_slice(right_idx, offset, len);
                 }
-                other._take_opt_chunked_unchecked(&right_idx)
+                other._take_opt_chunked_unchecked(right_idx)
             },
         };
         let (df_left, df_right) = POOL.join(materialize_left, materialize_right);

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -188,7 +188,7 @@ pub trait DataFrameJoinOps: IntoDf {
             _check_categorical_src(l.dtype(), r.dtype())?
         }
 
-        // Single keys
+        // Single keys.
         if selected_left.len() == 1 {
             let s_left = left_df.column(selected_left[0].name())?;
             let s_right = other.column(selected_right[0].name())?;
@@ -255,12 +255,13 @@ pub trait DataFrameJoinOps: IntoDf {
             }
             new.unwrap()
         }
-        // make sure that we don't have logical types.
-        // we don't overwrite the original selected as that might be used to create a column in the new df
+
+        // Make sure that we don't have logical types.
+        // We don't overwrite the original selected as that might be used to create a column in the new df.
         let selected_left_physical = _to_physical_and_bit_repr(&selected_left);
         let selected_right_physical = _to_physical_and_bit_repr(&selected_right);
 
-        // multiple keys
+        // Multiple keys.
         match args.how {
             JoinType::Inner => {
                 let left = DataFrame::new_no_checks(selected_left_physical);
@@ -290,8 +291,11 @@ pub trait DataFrameJoinOps: IntoDf {
             JoinType::Left => {
                 let mut left = DataFrame::new_no_checks(selected_left_physical);
                 let mut right = DataFrame::new_no_checks(selected_right_physical);
-                let ids = _left_join_multiple_keys(&mut left, &mut right, None, None);
 
+                if let Some((offset, len)) = args.slice {
+                    left = left.slice(offset, len);
+                }
+                let ids = _left_join_multiple_keys(&mut left, &mut right, None, None);
                 left_df._finish_left_join(ids, &remove_selected(other, &selected_right), args)
             },
             JoinType::Outer => {

--- a/crates/polars-ops/src/series/ops/round.rs
+++ b/crates/polars-ops/src/series/ops/round.rs
@@ -72,7 +72,7 @@ impl RoundSeries for Series {}
 
 #[cfg(test)]
 mod test {
-    use crate::prelude::*;
+    use super::*;
 
     #[test]
     fn test_round_series() {


### PR DESCRIPTION
In the case of an asof join we can perform the slice before any join indices are calculated instead of right before the final materialization.

For a left join, if the slice is purely a LIMIT we can also LIMIT the left input side.