### PR TITLE
refactor: add missing polars-ops tests to CI

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -45,27 +45,29 @@ jobs:
       - name: Compile tests
         run: >
           cargo test --all-features --no-run
-          -p polars-lazy
-          -p polars-plan
-          -p polars-io
           -p polars-core
-          -p polars-time
-          -p polars-utils
+          -p polars-io
+          -p polars-lazy
+          -p polars-ops
+          -p polars-plan
           -p polars-row
           -p polars-sql
+          -p polars-time
+          -p polars-utils
 
       - name: Run tests
         if: github.ref_name != 'main'
         run: >
           cargo test --all-features
-          -p polars-lazy
-          -p polars-plan
-          -p polars-io
           -p polars-core
-          -p polars-time
-          -p polars-utils
+          -p polars-io
+          -p polars-lazy
+          -p polars-ops
+          -p polars-plan
           -p polars-row
           -p polars-sql
+          -p polars-time
+          -p polars-utils
 
   integration-test:
     runs-on: ${{ matrix.os }}

--- a/crates/Makefile
+++ b/crates/Makefile
@@ -42,30 +42,30 @@ miri:  ## Run miri
 .PHONY: test
 test:  ## Run tests
 	cargo test --all-features \
-		-p polars-lazy \
-		-p polars-io \
 		-p polars-core \
-		-p polars-time \
-		-p polars-utils \
-		-p polars-row \
-		-p polars-sql \
+		-p polars-io \
+		-p polars-lazy \
 		-p polars-ops \
 		-p polars-plan \
+		-p polars-row \
+		-p polars-sql \
+		-p polars-time \
+		-p polars-utils \
 		-- \
 		--test-threads=2
 
 .PHONY: nextest
 nextest:  ## Run tests with nextest
 	cargo nextest run --all-features \
-		-p polars-lazy \
-		-p polars-io \
 		-p polars-core \
-		-p polars-time \
-		-p polars-utils \
-		-p polars-row \
-		-p polars-sql \
+		-p polars-io \
+		-p polars-lazy \
 		-p polars-ops \
 		-p polars-plan \
+		-p polars-row \
+		-p polars-sql \
+		-p polars-time \
+		-p polars-utils \
 
 .PHONY: integration-tests
 integration-tests:  ## Run integration tests

--- a/crates/polars-ops/src/chunked_array/interpolate.rs
+++ b/crates/polars-ops/src/chunked_array/interpolate.rs
@@ -261,7 +261,15 @@ mod test {
         let out = out.f64().unwrap();
         assert_eq!(
             Vec::from(out),
-            &[None, Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0), None]
+            &[
+                None,
+                Some(1.0),
+                Some(2.0),
+                Some(3.0),
+                Some(4.0),
+                Some(5.0),
+                None
+            ]
         );
         let ca = UInt32Chunked::new("", &[None, Some(1), None, None, Some(4), Some(5), None]);
         let out = interpolate(&ca.into_series(), InterpolationMethod::Nearest);
@@ -277,7 +285,10 @@ mod test {
         let ca = UInt32Chunked::new("", &[Some(4), None, None, Some(1)]);
         let out = interpolate(&ca.into_series(), InterpolationMethod::Linear);
         let out = out.f64().unwrap();
-        assert_eq!(Vec::from(out), &[Some(4.0), Some(3.0), Some(2.0), Some(1.0)])
+        assert_eq!(
+            Vec::from(out),
+            &[Some(4.0), Some(3.0), Some(2.0), Some(1.0)]
+        )
     }
 
     #[test]

--- a/crates/polars-ops/src/chunked_array/interpolate.rs
+++ b/crates/polars-ops/src/chunked_array/interpolate.rs
@@ -242,26 +242,26 @@ mod test {
     fn test_interpolate() {
         let ca = UInt32Chunked::new("", &[Some(1), None, None, Some(4), Some(5)]);
         let out = interpolate(&ca.into_series(), InterpolationMethod::Linear);
-        let out = out.u32().unwrap();
+        let out = out.f64().unwrap();
         assert_eq!(
             Vec::from(out),
-            &[Some(1), Some(2), Some(3), Some(4), Some(5)]
+            &[Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0)]
         );
 
         let ca = UInt32Chunked::new("", &[None, Some(1), None, None, Some(4), Some(5)]);
         let out = interpolate(&ca.into_series(), InterpolationMethod::Linear);
-        let out = out.u32().unwrap();
+        let out = out.f64().unwrap();
         assert_eq!(
             Vec::from(out),
-            &[None, Some(1), Some(2), Some(3), Some(4), Some(5)]
+            &[None, Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0)]
         );
 
         let ca = UInt32Chunked::new("", &[None, Some(1), None, None, Some(4), Some(5), None]);
         let out = interpolate(&ca.into_series(), InterpolationMethod::Linear);
-        let out = out.u32().unwrap();
+        let out = out.f64().unwrap();
         assert_eq!(
             Vec::from(out),
-            &[None, Some(1), Some(2), Some(3), Some(4), Some(5), None]
+            &[None, Some(1.0), Some(2.0), Some(3.0), Some(4.0), Some(5.0), None]
         );
         let ca = UInt32Chunked::new("", &[None, Some(1), None, None, Some(4), Some(5), None]);
         let out = interpolate(&ca.into_series(), InterpolationMethod::Nearest);
@@ -276,8 +276,8 @@ mod test {
     fn test_interpolate_decreasing_unsigned() {
         let ca = UInt32Chunked::new("", &[Some(4), None, None, Some(1)]);
         let out = interpolate(&ca.into_series(), InterpolationMethod::Linear);
-        let out = out.u32().unwrap();
-        assert_eq!(Vec::from(out), &[Some(4), Some(3), Some(2), Some(1)])
+        let out = out.f64().unwrap();
+        assert_eq!(Vec::from(out), &[Some(4.0), Some(3.0), Some(2.0), Some(1.0)])
     }
 
     #[test]

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -52,12 +52,13 @@ pub trait DataFrameJoinOps: IntoDf {
     ///
     /// ```no_run
     /// # use polars_core::prelude::*;
+    /// # use polars_ops::prelude::*;
     /// let df1: DataFrame = df!("Fruit" => &["Apple", "Banana", "Pear"],
     ///                          "Phosphorus (mg/100g)" => &[11, 22, 12])?;
     /// let df2: DataFrame = df!("Name" => &["Apple", "Banana", "Pear"],
     ///                          "Potassium (mg/100g)" => &[107, 358, 115])?;
     ///
-    /// let df3: DataFrame = df1.join(&df2, ["Fruit"], ["Name"], JoinType::Inner, None)?;
+    /// let df3: DataFrame = df1.join(&df2, ["Fruit"], ["Name"], JoinArgs::new(JoinType::Inner))?;
     /// assert_eq!(df3.shape(), (3, 3));
     /// println!("{}", df3);
     /// # Ok::<(), PolarsError>(())
@@ -369,6 +370,7 @@ pub trait DataFrameJoinOps: IntoDf {
     ///
     /// ```
     /// # use polars_core::prelude::*;
+    /// # use polars_ops::prelude::*;
     /// fn join_dfs(left: &DataFrame, right: &DataFrame) -> PolarsResult<DataFrame> {
     ///     left.inner_join(right, ["join_column_left"], ["join_column_right"])
     /// }
@@ -391,6 +393,7 @@ pub trait DataFrameJoinOps: IntoDf {
     ///
     /// ```no_run
     /// # use polars_core::prelude::*;
+    /// # use polars_ops::prelude::*;
     /// let df1: DataFrame = df!("Wavelength (nm)" => &[480.0, 650.0, 577.0, 1201.0, 100.0])?;
     /// let df2: DataFrame = df!("Color" => &["Blue", "Yellow", "Red"],
     ///                          "Wavelength nm" => &[480.0, 577.0, 650.0])?;
@@ -433,6 +436,7 @@ pub trait DataFrameJoinOps: IntoDf {
     ///
     /// ```
     /// # use polars_core::prelude::*;
+    /// # use polars_ops::prelude::*;
     /// fn join_dfs(left: &DataFrame, right: &DataFrame) -> PolarsResult<DataFrame> {
     ///     left.outer_join(right, ["join_column_left"], ["join_column_right"])
     /// }

--- a/crates/polars-ops/src/series/ops/approx_algo/hyperloglogplus.rs
+++ b/crates/polars-ops/src/series/ops/approx_algo/hyperloglogplus.rs
@@ -9,6 +9,7 @@
 //! # Examples
 //!
 //! ```
+//!     # use polars_ops::prelude::*;
 //!     let mut hllp = HyperLogLog::new();
 //!     hllp.add(&12345);
 //!     hllp.add(&23456);

--- a/crates/polars-ops/src/series/ops/round.rs
+++ b/crates/polars-ops/src/series/ops/round.rs
@@ -72,7 +72,7 @@ impl RoundSeries for Series {}
 
 #[cfg(test)]
 mod test {
-    use crate::prelude::*;
+    use super::*;
 
     #[test]
     fn test_round_series() {

--- a/crates/polars-plan/src/dsl/functions/temporal.rs
+++ b/crates/polars-plan/src/dsl/functions/temporal.rs
@@ -156,6 +156,7 @@ pub fn datetime(args: DatetimeArgs) -> Expr {
 /// their default value of `lit(0)`, as demonstrated below.
 ///
 /// ```
+/// # use polars_plan::prelude::*;
 /// let args = DurationArgs {
 ///     days: lit(5),
 ///     hours: col("num_hours"),
@@ -165,6 +166,7 @@ pub fn datetime(args: DatetimeArgs) -> Expr {
 /// ```
 /// If you prefer builder syntax, `with_*` methods are also available.
 /// ```
+/// # use polars_plan::prelude::*;
 /// let args = DurationArgs::new().with_weeks(lit(42)).with_hours(lit(84));
 /// ```
 #[derive(Debug, Clone)]

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1141,6 +1141,7 @@ impl Expr {
     /// Keep the original root name
     ///
     /// ```rust,no_run
+    /// # use polars_core::prelude::*;
     /// # use polars_plan::prelude::*;
     /// fn example(df: LazyFrame) -> LazyFrame {
     ///     df.select([
@@ -1181,21 +1182,6 @@ impl Expr {
     /// Exclude a column from a wildcard/regex selection.
     ///
     /// You may also use regexes in the exclude as long as they start with `^` and end with `$`/
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use polars_core::prelude::*;
-    /// use polars_lazy::prelude::*;
-    ///
-    /// // Select all columns except foo.
-    /// fn example(df: DataFrame) -> LazyFrame {
-    ///       df.lazy()
-    ///         .select(&[
-    ///                 col("*").exclude(&["foo"])
-    ///                 ])
-    /// }
-    /// ```
     pub fn exclude(self, columns: impl IntoVec<String>) -> Expr {
         let v = columns
             .into_vec()


### PR DESCRIPTION
We somehow weren't running the `polars-ops` tests in the CI.