### PR TITLE
docs: fix incorrect example of valid time zones

### DIFF
--- a/docs/user-guide/transformations/time-series/timezones.md
+++ b/docs/user-guide/transformations/time-series/timezones.md
@@ -12,13 +12,11 @@ hide:
 The `Datetime` datatype can have a time zone associated with it.
 Examples of valid time zones are:
 
-- `None`: no time zone, also known as "time zone naive";
-- `UTC`: Coordinated Universal Time;
+- `None`: no time zone, also known as "time zone naive".
+- `UTC`: Coordinated Universal Time.
 - `Asia/Kathmandu`: time zone in "area/location" format.
   See the [list of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
-  to see what's available;
-- `+01:00`: fixed offsets. May be useful when parsing, but you almost certainly want the "Area/Location"
-  format above instead as it will deal with irregularities such as DST (Daylight Saving Time) for you.
+  to see what's available.
 
 Note that, because a `Datetime` can only have a single time zone, it is
 impossible to have a column with multiple time zones. If you are parsing data
@@ -27,8 +25,8 @@ them all to a common time zone (`UTC`), see [parsing dates and times](parsing.md
 
 The main methods for setting and converting between time zones are:
 
-- `dt.convert_time_zone`: convert from one time zone to another;
-- `dt.replace_time_zone`: set/unset/change time zone;
+- `dt.convert_time_zone`: convert from one time zone to another.
+- `dt.replace_time_zone`: set/unset/change time zone.
 
 Let's look at some examples of common operations:
 

--- a/docs/user-guide/transformations/time-series/timezones.md
+++ b/docs/user-guide/transformations/time-series/timezones.md
@@ -18,6 +18,8 @@ Examples of valid time zones are:
   See the [list of tz database time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
   to see what's available.
 
+Caution: Fixed offsets such as +02:00, should not be used for handling time zones. It's advised to use the "Area/Location" format mentioned above, as it can manage timezones more effectively.
+
 Note that, because a `Datetime` can only have a single time zone, it is
 impossible to have a column with multiple time zones. If you are parsing data
 with multiple offsets, you may want to pass `utc=True` to convert


### PR DESCRIPTION
fix #11774

Doubt the `;` were intended, so replaced them by `.`