### PR TITLE
Rename diff() argument: n -> periods.

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -7409,7 +7409,7 @@ class Expr:
 
     def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Self:
         """
-        Calculate the n-th discrete difference.
+        Calculate the first discrete difference between shifted elements.
 
         Parameters
         ----------

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -664,7 +664,7 @@ class ExprListNameSpace:
 
     def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Expr:
         """
-        Calculate the n-th discrete difference of every sublist.
+        Compute the first discrete difference between shifted elements of every sublist.
 
         Parameters
         ----------

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -347,7 +347,7 @@ class ListNameSpace:
 
     def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Series:
         """
-        Calculate the n-th discrete difference of every sublist.
+        Compute the first discrete difference between shifted elements of every sublist.
 
         Parameters
         ----------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5988,7 +5988,7 @@ class Series:
 
     def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Series:
         """
-        Calculate the n-th discrete difference.
+        Calculate the first discrete difference between shifted elements.
 
         Parameters
         ----------


### PR DESCRIPTION
Fixing documentation of `pl.Expr.diff`/`pl.Series.diff` to resolve the issue described in #11874.

Additionally, changing argument `n` to `periods` to add more consistency with `pl.Expr.shift` method and `pd.Series.diff` API. More details are provided in the issue linked above.