### PR TITLE
fix: Allow null dtype when infer object for json

### DIFF
--- a/crates/polars-json/src/json/infer_schema.rs
+++ b/crates/polars-json/src/json/infer_schema.rs
@@ -78,11 +78,7 @@ fn filter_map_nulls(dt: DataType) -> Option<DataType> {
 fn infer_object(inner: &Object) -> PolarsResult<DataType> {
     let fields = inner
         .iter()
-        .filter_map(|(key, value)| {
-            infer(value)
-                .map(|dt| filter_map_nulls(dt).map(|dt| (key, dt)))
-                .transpose()
-        })
+        .filter_map(|(key, value)| infer(value).map(|dt| Some((key, dt))).transpose())
         .map(|maybe_dt| {
             let (key, dt) = maybe_dt?;
             Ok(Field::new(key.as_ref(), dt, true))

--- a/crates/polars/tests/it/io/json.rs
+++ b/crates/polars/tests/it/io/json.rs
@@ -178,6 +178,7 @@ fn test_read_ndjson_iss_5875_part2() {
         "struct".into(),
         DataType::Struct(vec![field_int_list_inner, field_float, field_str_list]),
     );
+    schema.with_column("int_opt".into(), DataType::Null);
     schema.with_column(
         "float_list_outer".into(),
         field_float_list.data_type().clone(),

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -183,6 +183,18 @@ def test_json_supertype_infer() -> None:
     assert_frame_equal(python_infer, polars_infer)
 
 
+def test_read_json_with_null_column() -> None:
+    json_string = """[
+    {"a": null, "b": 1, "c": null},
+    {"a": null, "b": 2, "c": null},
+    {"a": null, "b": 3, "c": null}
+    ]"""
+
+    df = pl.read_json(io.StringIO(json_string))
+
+    assert df.schema == {"a": pl.Null, "b": pl.Int64, "c": pl.Null}
+
+
 def test_json_sliced_list_serialization() -> None:
     data = {"col1": [0, 2], "col2": [[3, 4, 5], [6, 7, 8]]}
     df = pl.DataFrame(data)


### PR DESCRIPTION
This fixes #11860.