### PR TITLE
chore: Fix Cargo warning for parquet2 dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ arrow-array = { version = ">=41", default-features = false }
 arrow-buffer = { version = ">=41", default-features = false }
 arrow-data = { version = ">=41", default-features = false }
 arrow-schema = { version = ">=41", default-features = false }
-parquet2 = { version = "0.17.2", features = ["async"] }
+parquet2 = { version = "0.17.2", features = ["async"], default-features = false }
 avro-schema = { version = "0.3" }
 
 [workspace.dependencies.arrow]

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -74,7 +74,7 @@ arrow-array = { workspace = true, optional = true }
 arrow-buffer = { workspace = true, optional = true }
 arrow-data = { workspace = true, optional = true }
 arrow-schema = { workspace = true, optional = true }
-parquet2 = { workspace = true, optional = true, features = ["async"] }
+parquet2 = { workspace = true, optional = true, default-features = true, features = ["async"] }
 
 [dev-dependencies]
 avro-rs = { version = "0.13", features = ["snappy"] }

--- a/crates/polars-error/Cargo.toml
+++ b/crates/polars-error/Cargo.toml
@@ -11,8 +11,8 @@ description = "Error definitions for the Polars DataFrame library"
 [dependencies]
 arrow-format = { version = "0.8.1", optional = true }
 avro-schema = { workspace = true, optional = true }
-object_store = { workspace = true, default-features = false, optional = true }
-parquet2 = { workspace = true, optional = true, default-features = false }
+object_store = { workspace = true, optional = true }
+parquet2 = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 simdutf8 = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -10,7 +10,7 @@ description = "IO related logic for the Polars DataFrame library"
 
 [dependencies]
 polars-core = { workspace = true }
-polars-error = { workspace = true, default-features = false }
+polars-error = { workspace = true }
 polars-json = { workspace = true, optional = true }
 polars-time = { workspace = true, features = [], optional = true }
 polars-utils = { workspace = true }

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -10,7 +10,7 @@ description = "Lazy query engine for the Polars DataFrame library"
 
 [dependencies]
 arrow = { workspace = true }
-polars-core = { workspace = true, features = ["lazy", "zip_with", "random"], default-features = false }
+polars-core = { workspace = true, features = ["lazy", "zip_with", "random"] }
 polars-io = { workspace = true, features = ["lazy"] }
 polars-json = { workspace = true, optional = true }
 polars-ops = { workspace = true }

--- a/crates/polars-ops/Cargo.toml
+++ b/crates/polars-ops/Cargo.toml
@@ -9,10 +9,10 @@ repository = { workspace = true }
 description = "More operations on Polars data structures"
 
 [dependencies]
-polars-core = { workspace = true, features = ["algorithm_group_by"], default-features = false }
+polars-core = { workspace = true, features = ["algorithm_group_by"] }
 polars-error = { workspace = true }
 polars-json = { workspace = true, optional = true }
-polars-utils = { workspace = true, default-features = false }
+polars-utils = { workspace = true }
 
 ahash = { workspace = true }
 argminmax = { version = "0.6.1", default-features = false, features = ["float"] }

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -13,10 +13,10 @@ doctest = false
 
 [dependencies]
 libloading = { version = "0.8.0", optional = true }
-polars-core = { workspace = true, features = ["lazy", "zip_with", "random"], default-features = false }
+polars-core = { workspace = true, features = ["lazy", "zip_with", "random"] }
 polars-ffi = { workspace = true, optional = true }
-polars-io = { workspace = true, features = ["lazy"], default-features = false }
-polars-ops = { workspace = true, features = ["zip_with"], default-features = false }
+polars-io = { workspace = true, features = ["lazy"] }
+polars-ops = { workspace = true, features = ["zip_with"] }
 polars-time = { workspace = true, optional = true }
 polars-utils = { workspace = true }
 

--- a/crates/polars-time/Cargo.toml
+++ b/crates/polars-time/Cargo.toml
@@ -10,7 +10,7 @@ description = "Time related code for the Polars DataFrame library"
 
 [dependencies]
 arrow = { workspace = true, features = ["compute", "temporal"] }
-polars-core = { workspace = true, default-features = false, features = ["dtype-datetime", "dtype-duration", "dtype-time", "dtype-date"] }
+polars-core = { workspace = true, features = ["dtype-datetime", "dtype-duration", "dtype-time", "dtype-date"] }
 polars-error = { workspace = true }
 polars-ops = { workspace = true }
 polars-utils = { workspace = true }

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -14,7 +14,7 @@ description = "DataFrame library based on Apache Arrow"
 polars-algo = { workspace = true, optional = true }
 polars-core = { workspace = true }
 polars-io = { workspace = true, optional = true }
-polars-lazy = { workspace = true, default-features = false, optional = true }
+polars-lazy = { workspace = true, optional = true }
 polars-ops = { workspace = true }
 polars-sql = { workspace = true, optional = true }
 polars-time = { workspace = true, optional = true }


### PR DESCRIPTION
Fixes the following warning that appears with every build:
```
warning: /home/stijn/code/polars/crates/polars-error/Cargo.toml: `default-features` is ignored for parquet2, since `default-features` was true for `workspace.dependencies.parquet2`, this could become a hard error in the future
```

Unfortunately there is no way to turn these warnings into errors 😕 
https://github.com/rust-lang/cargo/issues/2568

Also remove some useless `default-features = false` entries for dependencies where this is already specified on the workspace level.