### PR TITLE
fix: recursively apply `cast_unchecked` in lists

### DIFF
--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -888,7 +888,8 @@ impl Series {
     /// Packs every element into a list.
     pub fn as_list(&self) -> ListChunked {
         let s = self.rechunk();
-        let values = s.to_arrow(0);
+        // don't  use `to_arrow` as we need the physical types
+        let values = s.chunks()[0].clone();
         let offsets = (0i64..(s.len() as i64 + 1)).collect::<Vec<_>>();
         let offsets = unsafe { Offsets::new_unchecked(offsets) };
 

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -422,3 +422,8 @@ def test_categorical_collect_11408() -> None:
         "groups": ["a", "b", "c"],
         "cats": ["a", "b", "c"],
     }
+
+
+def test_categorical_nested_cast_unchecked() -> None:
+    s = pl.Series("cat", [["cat"]]).cast(pl.List(pl.Categorical))
+    assert pl.Series([s]).to_list() == [[["cat"]]]


### PR DESCRIPTION
fixes #11792

supersedes: #11826