### PR TITLE
Fix feature name

### DIFF
--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -125,7 +125,7 @@ semi_anti_join = ["polars-plan/semi_anti_join"]
 cse = ["polars-plan/cse"]
 propagate_nans = ["polars-plan/propagate_nans"]
 coalesce = ["polars-plan/coalesce"]
-regex = ["polars-plan/regex"]
+regex = ["polars-plan/lazy_regex"]
 serde = [
   "polars-plan/serde",
   "arrow/serde",

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -79,7 +79,7 @@ list_take = ["polars-ops/list_take"]
 list_count = ["polars-ops/list_count"]
 trigonometry = []
 sign = []
-timezones = ["chrono-tz", "polars-time/timezones", "polars-core/timezones", "regex"]
+timezones = ["chrono-tz", "polars-time/timezones", "polars-core/timezones", "lazy_regex"]
 binary_encoding = ["polars-ops/binary_encoding"]
 true_div = []
 nightly = ["polars-utils/nightly", "polars-ops/nightly"]
@@ -147,6 +147,7 @@ peaks = ["polars-ops/peaks"]
 bigidx = ["polars-core/bigidx"]
 
 panic_on_schema = []
+lazy_regex = ["regex"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -878,7 +878,7 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
     fn from(func: StringFunction) -> Self {
         use StringFunction::*;
         match func {
-            #[cfg(feature = "regex")]
+            #[cfg(feature = "lazy_regex")]
             Contains { literal, strict } => map_as_slice!(strings::contains, literal, strict),
             CountMatches(literal) => {
                 map_as_slice!(strings::count_matches, literal)
@@ -924,7 +924,7 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             ConcatVertical(delimiter) => map!(strings::concat, &delimiter),
             #[cfg(feature = "concat_str")]
             ConcatHorizontal(delimiter) => map_as_slice!(strings::concat_hor, &delimiter),
-            #[cfg(feature = "regex")]
+            #[cfg(feature = "lazy_regex")]
             Replace { n, literal } => map_as_slice!(strings::replace, literal, n),
             Uppercase => map!(strings::uppercase),
             Lowercase => map!(strings::lowercase),

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -5,7 +5,7 @@ pub struct StringNameSpace(pub(crate) Expr);
 
 impl StringNameSpace {
     /// Check if a string value contains a literal substring.
-    #[cfg(feature = "regex")]
+    #[cfg(feature = "lazy_regex")]
     pub fn contains_literal(self, pat: Expr) -> Expr {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::Contains {
@@ -20,7 +20,7 @@ impl StringNameSpace {
 
     /// Check if this column of strings contains a Regex. If `strict` is `true`, then it is an error if any `pat` is
     /// an invalid regex, whereas if `strict` is `false`, an invalid regex will simply evaluate to `false`.
-    #[cfg(feature = "regex")]
+    #[cfg(feature = "lazy_regex")]
     pub fn contains(self, pat: Expr, strict: bool) -> Expr {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::Contains {
@@ -258,7 +258,7 @@ impl StringNameSpace {
             .map_many_private(StringFunction::SplitN(n).into(), &[by], false, false)
     }
 
-    #[cfg(feature = "regex")]
+    #[cfg(feature = "lazy_regex")]
     /// Replace values that match a regex `pat` with a `value`.
     pub fn replace(self, pat: Expr, value: Expr, literal: bool) -> Expr {
         self.0.map_many_private(
@@ -269,7 +269,7 @@ impl StringNameSpace {
         )
     }
 
-    #[cfg(feature = "regex")]
+    #[cfg(feature = "lazy_regex")]
     /// Replace values that match a regex `pat` with a `value`.
     pub fn replace_n(self, pat: Expr, value: Expr, literal: bool, n: i64) -> Expr {
         self.0.map_many_private(
@@ -280,7 +280,7 @@ impl StringNameSpace {
         )
     }
 
-    #[cfg(feature = "regex")]
+    #[cfg(feature = "lazy_regex")]
     /// Replace all values that match a regex `pat` with a `value`.
     pub fn replace_all(self, pat: Expr, value: Expr, literal: bool) -> Expr {
         self.0.map_many_private(

--- a/docs/_build/API_REFERENCE_LINKS.yml
+++ b/docs/_build/API_REFERENCE_LINKS.yml
@@ -333,7 +333,7 @@ rust:
   str.contains:
     name: str.contains
     link: https://pola-rs.github.io/polars/docs/rust/dev/polars_lazy/dsl/string/struct.StringNameSpace.html#method.contains
-    feature_flags: [regex]
+    feature_flags: [lazy_regex]
   str.extract:
     name: str.extract
     link: https://pola-rs.github.io/polars/docs/rust/dev/polars_lazy/dsl/string/struct.StringNameSpace.html#method.extract
@@ -343,11 +343,11 @@ rust:
   str.replace:
     name: str.replace
     link: https://pola-rs.github.io/polars/docs/rust/dev/polars_lazy/dsl/string/struct.StringNameSpace.html#method.replace
-    feature_flags: [regex]
+    feature_flags: [lazy_regex]
   str.replace_all:
     name: str.replace_all
     link: https://pola-rs.github.io/polars/docs/rust/dev/polars_lazy/dsl/string/struct.StringNameSpace.html#method.replace_all
-    feature_flags: [regex]
+    feature_flags: [lazy_regex]
   str.starts_with: https://pola-rs.github.io/polars/docs/rust/dev/polars_lazy/dsl/string/struct.StringNameSpace.html#method.starts_with
   str.ends_with: https://pola-rs.github.io/polars/docs/rust/dev/polars_lazy/dsl/string/struct.StringNameSpace.html#method.ends_with
   str.split:


### PR DESCRIPTION
# Problems(#11178)

- a difference in feature name on [UserGuide](https://pola-rs.github.io/polars/user-guide/expressions/strings/#extract-a-pattern)
- a difference in feature name on [Docs(Rust)](https://pola-rs.github.io/polars/docs/rust/dev/polars_lazy/dsl/string/struct.StringNameSpace.html#method.replace_all)

# Change

- API_REFERENCE_LINK
- [polars-plan] Add feature name wrapper for `regex`