### PR TITLE
fix: convert `run_pipeline_no_finalize` from recursive to iterative in order to avoid stack overflows

### DIFF
--- a/crates/polars-lazy/src/tests/streaming.rs
+++ b/crates/polars-lazy/src/tests/streaming.rs
@@ -24,6 +24,7 @@ fn assert_streaming_with_default(q: LazyFrame, total: bool, check_shape_only: bo
     }
     let q_expected = q.with_streaming(false);
     let out = q_streaming.collect().unwrap();
+    dbg!("Non-streaming");
     let expected = q_expected.collect().unwrap();
     if check_shape_only {
         assert_eq!(out.shape(), expected.shape())

--- a/crates/polars-lazy/src/tests/streaming.rs
+++ b/crates/polars-lazy/src/tests/streaming.rs
@@ -24,7 +24,6 @@ fn assert_streaming_with_default(q: LazyFrame, total: bool, check_shape_only: bo
     }
     let q_expected = q.with_streaming(false);
     let out = q_streaming.collect().unwrap();
-    dbg!("Non-streaming");
     let expected = q_expected.collect().unwrap();
     if check_shape_only {
         assert_eq!(out.shape(), expected.shape())

--- a/crates/polars-pipe/src/pipeline/dispatcher.rs
+++ b/crates/polars-pipe/src/pipeline/dispatcher.rs
@@ -512,7 +512,7 @@ fn run_pipeline_no_finalize_iterative(
                     unreachable!()
                 },
             }
-            Self::iteration_init(
+            let (shared_count, reduced_sink) = Self::iteration_init(
                 self.pipeline.deref_mut(),
                 ec,
                 sink,
@@ -522,6 +522,8 @@ fn run_pipeline_no_finalize_iterative(
                 &mut self.sink_finished,
             )?;
             self.operator_start = operator_end;
+            self.shared_sink_count = shared_count;
+            self.reduced_sink = reduced_sink;
             Ok(Some(()))
         }
 

--- a/crates/polars-pipe/src/pipeline/dispatcher.rs
+++ b/crates/polars-pipe/src/pipeline/dispatcher.rs
@@ -537,7 +537,7 @@ fn run_pipeline_no_finalize_iterative(
             operator_end: usize,
             sink_finished: &mut bool,
         ) -> PolarsResult<(u32, Box<dyn Sink>)> {
-            for src in &mut std::mem::take(&mut pipeline.sources) {
+            'outer: for src in &mut std::mem::take(&mut pipeline.sources) {
                 let mut next_batches = src.get_batches(ec)?;
 
                 while let SourceResult::GotMoreData(chunks) = next_batches {
@@ -553,7 +553,7 @@ fn run_pipeline_no_finalize_iterative(
 
                     if let Some(SinkResult::Finished) = sink_result {
                         *sink_finished = true;
-                        break;
+                        break 'outer;
                     }
                 }
             }


### PR DESCRIPTION
I ran into a stack overflow using `polars` in one of our projects—I was able to pin it down to `run_pipeline_no_finalize`, which is indeed recursive.

![image](https://github.com/pola-rs/polars/assets/20745048/b9bd416b-d1fc-492e-999d-f17b399d1c07)

I've converted the algorithm to be iterative, which was not super-straightforward. Happy to iterate (pun intended) on the code to clean it up however you think it's best.