### PR TITLE
fix: avoid integer overflow in offsets_to_groups when bigidx is enabled

### DIFF
--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -23,7 +23,7 @@ impl IntoListNameSpace for ListNameSpace {
 fn offsets_to_groups(offsets: &[i64]) -> Option<GroupsProxy> {
     let mut start = offsets[0];
     let end = *offsets.last().unwrap();
-    let fits_into_idx = (end - start) <= IdxSize::MAX as i64;
+    let fits_into_idx = IdxSize::try_from(end - start).unwrap() <= IdxSize::MAX;
     if !fits_into_idx {
         return None;
     }

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -23,9 +23,8 @@ impl IntoListNameSpace for ListNameSpace {
 fn offsets_to_groups(offsets: &[i64]) -> Option<GroupsProxy> {
     let mut start = offsets[0];
     let end = *offsets.last().unwrap();
-    match IdxSize::try_from(end - start) {
-        Err(_) => return None,
-        Ok(_) => (),
+    if IdxSize::try_from(end - start).is_err() {
+        return None;
     }
     let groups = offsets
         .iter()

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -23,11 +23,10 @@ impl IntoListNameSpace for ListNameSpace {
 fn offsets_to_groups(offsets: &[i64]) -> Option<GroupsProxy> {
     let mut start = offsets[0];
     let end = *offsets.last().unwrap();
-    let fits_into_idx = IdxSize::try_from(end - start).unwrap() <= IdxSize::MAX;
-    if !fits_into_idx {
-        return None;
+    match IdxSize::try_from(end - start) {
+        Err(_) => return None,
+        Ok(_) => (),
     }
-
     let groups = offsets
         .iter()
         .skip(1)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/11782

1. I have no rust background, so make sure this is the correct fix
2. I assume the reason this bug wasn't caught is that no testing is done for bigidx builds. Is that something worth exploring? Since `polars-u64-idx` builds are published on pypi, I was assuming some level of testing was done.