### PR TITLE
fix(rust): fix melt panic when only one column is present

### DIFF
--- a/crates/polars-core/src/frame/explode.rs
+++ b/crates/polars-core/src/frame/explode.rs
@@ -288,6 +288,11 @@ impl DataFrame {
                 .get(v)
                 .ok_or_else(|| polars_err!(ColumnNotFound: "{}", v))
         });
+        // if there only is a single column, we return the original DataFrame
+        if value_vars.len() < 1 {
+            return Ok(self.clone());
+        }
+
         let mut st = iter.next().unwrap()?.clone();
         for dt in iter {
             st = try_get_supertype(&st, dt?)?;

--- a/crates/polars-core/src/frame/explode.rs
+++ b/crates/polars-core/src/frame/explode.rs
@@ -279,6 +279,10 @@ impl DataFrame {
                     }
                 })
                 .collect();
+            // if value_vars is still empty after attempting to populate it, return original dataframe
+            if value_vars.is_empty() {
+                return Ok(self.clone());
+            }
         }
 
         // values will all be placed in single column, so we must find their supertype
@@ -288,10 +292,6 @@ impl DataFrame {
                 .get(v)
                 .ok_or_else(|| polars_err!(ColumnNotFound: "{}", v))
         });
-        // if there only is a single column, we return the original DataFrame
-        if value_vars.len() < 1 {
-            return Ok(self.clone());
-        }
 
         let mut st = iter.next().unwrap()?.clone();
         for dt in iter {

--- a/py-polars/tests/unit/operations/test_melt.py
+++ b/py-polars/tests/unit/operations/test_melt.py
@@ -69,3 +69,8 @@ def test_melt_projection_pd_7747() -> None:
         }
     )
     assert_frame_equal(result, expected)
+
+def test_melt_single_column() -> None:
+    df = pl.DataFrame({'single_column': [1,2,3],})
+    result = df.melt('single_column')
+    assert_frame_equal(result, df)

--- a/py-polars/tests/unit/operations/test_melt.py
+++ b/py-polars/tests/unit/operations/test_melt.py
@@ -70,7 +70,12 @@ def test_melt_projection_pd_7747() -> None:
     )
     assert_frame_equal(result, expected)
 
+
 def test_melt_single_column() -> None:
-    df = pl.DataFrame({'single_column': [1,2,3],})
-    result = df.melt('single_column')
+    df = pl.DataFrame(
+        {
+            "single_column": [1, 2, 3],
+        }
+    )
+    result = df.melt("single_column")
     assert_frame_equal(result, df)


### PR DESCRIPTION
fix #10075

When looking at this issue, I thought of a couple ways we could handle this:

* **Return an empty DataFrame**: 

This could make sense if you interpret the melt operation as requiring at least two columns: one to serve as the identifier variable(s) and one to serve as the value variable(s). If there's only one column, there are no value variables to melt, so the result is an empty DataFrame.

* **Return the single column and its data**: 

This could make sense if you interpret the melt operation as collapsing all non-identifier columns into a single column. If there's only one column, it's already in the desired format, so the result is the original DataFrame.

* **Return a custom error**: 

This could make sense if you want to enforce that the melt operation should only be used on DataFrames with at least two columns. 

I chose to go for the second option, since the idea is of melt is to go from wide to long format, but with a single column it's already considered long


output:

```
df = pl.DataFrame({'single_column': [1,2,3],})
result = df.melt('single_column')
print(result)

shape: (3, 1)
┌───────────────┐
│ single_column │
│ ---           │
│ i64           │
╞═══════════════╡
│ 1             │
│ 2             │
│ 3             │
└───────────────┘
```