### PR TITLE
fix(python): address DataFrame construction error with lists of `numpy` arrays

### DIFF
--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -445,6 +445,10 @@ def _read_spreadsheet(
         if hasattr(parser, "close"):
             parser.close()
 
+    if not parsed_sheets:
+        param, value = ("id", sheet_id) if sheet_name is None else ("name", sheet_name)
+        raise ValueError(f"no matching sheets found when `sheet_{param}` is {value!r}")
+
     if return_multi:
         return parsed_sheets
     return next(iter(parsed_sheets.values()))

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1024,7 +1024,11 @@ def _sequence_of_sequence_to_pydf(
         local_schema_override = (
             include_unknowns(schema_overrides, column_names) if schema_overrides else {}
         )
-        if column_names and first_element and len(first_element) != len(column_names):
+        if (
+            column_names
+            and len(first_element) > 0
+            and len(first_element) != len(column_names)
+        ):
             raise ShapeError("the row data does not match the number of columns")
 
         unpack_nested = False

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -592,6 +592,10 @@ def test_init_ndarray(monkeypatch: Any) -> None:
     assert df.shape == (2, 1)
     assert df.rows() == [([0, 1, 2, 3, 4],), ([5, 6, 7, 8, 9],)]
 
+    test_rows = [(1, 2), (3, 4)]
+    df = pl.DataFrame([np.array(test_rows[0]), np.array(test_rows[1])], orient="row")
+    assert_frame_equal(df, pl.DataFrame(test_rows, orient="row"))
+
     # numpy arrays containing NaN
     df0 = pl.DataFrame(
         data={"x": [1.0, 2.5, float("nan")], "y": [4.0, float("nan"), 6.5]},

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -105,7 +105,7 @@ def test_string_numeric_comp_err() -> None:
 def test_panic_error() -> None:
     with pytest.raises(
         pl.PolarsPanicError,
-        match="""dimensions cannot be empty""",
+        match="dimensions cannot be empty",
     ):
         pl.Series("a", [1, 2, 3]).reshape(())
 


### PR DESCRIPTION
Closes #11896.

Straightforward fix; avoid implicit boolean inference (we _know_ we have a sequence at this point, but that sequence may be a numpy array which -quite rightly- doesn't like implicit bool usage). Also adds the missing test coverage.