### PR TITLE
fix(python): raise a suitable error from `read_excel` and/or `read_ods` when target sheet does not exist

### DIFF
--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -445,6 +445,10 @@ def _read_spreadsheet(
         if hasattr(parser, "close"):
             parser.close()
 
+    if not parsed_sheets:
+        param, value = ("id", sheet_id) if sheet_name is None else ("name", sheet_name)
+        raise ValueError(f"no matching sheets found when `sheet_{param}` is {value!r}")
+
     if return_multi:
         return parsed_sheets
     return next(iter(parsed_sheets.values()))


### PR DESCRIPTION
Closes #11877.

Raises a _much_ more helpful error if the requested sheet is not found.

### Before:
```python
pl.read_excel("test.xlsx", sheet_id=999)

#     return next(iter(parsed_sheets.values()))
#            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# StopIteration
```

### After:
```python
# ValueError: no matching sheets found when `sheet_id` is 999
```