### PR TITLE
fix(python): address issue with inadvertently shared options dict in `read_excel`

### DIFF
--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -28,7 +28,7 @@ def read_excel(
     engine: Literal["xlsx2csv", "openpyxl", "pyxlsb"] | None = ...,
     xlsx2csv_options: dict[str, Any] | None = ...,
     read_csv_options: dict[str, Any] | None = ...,
-    schema_overrides: SchemaDict | None = None,
+    schema_overrides: SchemaDict | None = ...,
     raise_if_empty: bool = ...,
 ) -> pl.DataFrame:
     ...
@@ -43,7 +43,7 @@ def read_excel(
     engine: Literal["xlsx2csv", "openpyxl", "pyxlsb"] | None = ...,
     xlsx2csv_options: dict[str, Any] | None = ...,
     read_csv_options: dict[str, Any] | None = ...,
-    schema_overrides: SchemaDict | None = None,
+    schema_overrides: SchemaDict | None = ...,
     raise_if_empty: bool = ...,
 ) -> pl.DataFrame:
     ...
@@ -58,7 +58,7 @@ def read_excel(
     engine: Literal["xlsx2csv", "openpyxl", "pyxlsb"] | None = ...,
     xlsx2csv_options: dict[str, Any] | None = ...,
     read_csv_options: dict[str, Any] | None = ...,
-    schema_overrides: SchemaDict | None = None,
+    schema_overrides: SchemaDict | None = ...,
     raise_if_empty: bool = ...,
 ) -> NoReturn:
     ...
@@ -75,7 +75,7 @@ def read_excel(
     engine: Literal["xlsx2csv", "openpyxl", "pyxlsb"] | None = ...,
     xlsx2csv_options: dict[str, Any] | None = ...,
     read_csv_options: dict[str, Any] | None = ...,
-    schema_overrides: SchemaDict | None = None,
+    schema_overrides: SchemaDict | None = ...,
     raise_if_empty: bool = ...,
 ) -> dict[str, pl.DataFrame]:
     ...
@@ -90,7 +90,7 @@ def read_excel(
     engine: Literal["xlsx2csv", "openpyxl", "pyxlsb"] | None = ...,
     xlsx2csv_options: dict[str, Any] | None = ...,
     read_csv_options: dict[str, Any] | None = ...,
-    schema_overrides: SchemaDict | None = None,
+    schema_overrides: SchemaDict | None = ...,
     raise_if_empty: bool = ...,
 ) -> pl.DataFrame:
     ...
@@ -105,7 +105,7 @@ def read_excel(
     engine: Literal["xlsx2csv", "openpyxl", "pyxlsb"] | None = ...,
     xlsx2csv_options: dict[str, Any] | None = ...,
     read_csv_options: dict[str, Any] | None = ...,
-    schema_overrides: SchemaDict | None = None,
+    schema_overrides: SchemaDict | None = ...,
     raise_if_empty: bool = ...,
 ) -> dict[str, pl.DataFrame]:
     ...
@@ -548,6 +548,7 @@ def _csv_buffer_to_frame(
             raise ParameterCollisionError(
                 "cannot specify columns in both `schema_overrides` and `read_csv_options['dtypes']`"
             )
+        read_csv_options = read_csv_options.copy()
         read_csv_options["dtypes"] = {**csv_dtypes, **schema_overrides}
 
     # otherwise rewind the buffer and parse as csv


### PR DESCRIPTION
Closes #11850.

Need to take a shallow-copy of "read_csv_options" before modifying/updating it, or reading from multiple sheets with the default engine (when we have "schema_overrides") fails with an inadvertent `ParameterCollisionError`.