### PR TITLE
docs(python): Fix docstring for `diff` methods

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -7409,7 +7409,7 @@ class Expr:
 
     def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Self:
         """
-        Calculate the n-th discrete difference.
+        Calculate the first discrete difference between shifted items.
 
         Parameters
         ----------

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -664,7 +664,7 @@ class ExprListNameSpace:
 
     def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Expr:
         """
-        Calculate the n-th discrete difference of every sublist.
+        Calculate the first discrete difference between shifted items of every sublist.
 
         Parameters
         ----------

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -347,7 +347,7 @@ class ListNameSpace:
 
     def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Series:
         """
-        Calculate the n-th discrete difference of every sublist.
+        Calculate the first discrete difference between shifted items of every sublist.
 
         Parameters
         ----------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -6003,7 +6003,7 @@ class Series:
 
     def diff(self, n: int = 1, null_behavior: NullBehavior = "ignore") -> Series:
         """
-        Calculate the n-th discrete difference.
+        Calculate the first discrete difference between shifted items.
 
         Parameters
         ----------


### PR DESCRIPTION
Addressing docs issue described in #11874. 

Different PR #11875 was failing on Windows, possibly for some CRLF issue, or potentially something even more subtle. Created this instead.