### PR TITLE
perf: support multiple files in a single scan parquet node.

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -72,6 +72,10 @@ jobs:
         if: github.ref_name != 'main'
         run: pytest --cov -n auto --dist loadgroup -m "not benchmark and not docs"
 
+      - name: Run tests async reader tests
+        if: github.ref_name != 'main'
+        run: POLARS_FORCE_ASYNC=1 pytest --cov -n auto --dist loadgroup -m "not benchmark and not docs" ../.venv/bin/pytest tests/unit/io/
+
       - name: Run doctests
         if: github.ref_name != 'main'
         run: |

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Run tests async reader tests
         if: github.ref_name != 'main'
-        run: POLARS_FORCE_ASYNC=1 pytest --cov -n auto --dist loadgroup -m "not benchmark and not docs" ../.venv/bin/pytest tests/unit/io/
+        run: POLARS_FORCE_ASYNC=1 pytest -m "not benchmark and not docs" tests/unit/io/
 
       - name: Run doctests
         if: github.ref_name != 'main'

--- a/crates/polars-core/src/config.rs
+++ b/crates/polars-core/src/config.rs
@@ -22,12 +22,9 @@ pub(crate) const DECIMAL_ACTIVE: &str = "POLARS_ACTIVATE_DECIMAL";
 
 #[cfg(feature = "dtype-decimal")]
 pub(crate) fn decimal_is_active() -> bool {
-    match std::env::var(DECIMAL_ACTIVE) {
-        Ok(val) => val == "1",
-        _ => false,
-    }
+    std::env::var(DECIMAL_ACTIVE).as_deref().unwrap_or("") == "1"
 }
 
 pub fn verbose() -> bool {
-    std::env::var("POLARS_VERBOSE").as_deref().unwrap_or("0") == "1"
+    std::env::var("POLARS_VERBOSE").as_deref().unwrap_or("") == "1"
 }

--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -18,7 +18,7 @@ where
     T: Into<Cow<'static, str>>,
 {
     fn from(msg: T) -> Self {
-        if env::var("POLARS_PANIC_ON_ERR").is_ok() {
+        if env::var("POLARS_PANIC_ON_ERR").as_deref().unwrap_or("") == "1" {
             panic!("{}", msg.into())
         } else {
             ErrString(msg.into())

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -86,18 +86,16 @@ pub struct CloudLocation {
 }
 
 impl CloudLocation {
-    /// Parse a CloudLocation from an url.
-    pub fn new(url: &str) -> PolarsResult<CloudLocation> {
-        let parsed = Url::parse(url).map_err(to_compute_err)?;
+    pub fn from_url(parsed: &Url) -> PolarsResult<CloudLocation> {
         let is_local = parsed.scheme() == "file";
         let (bucket, key) = if is_local {
-            ("".into(), url[7..].into())
+            ("".into(), parsed.path())
         } else {
             let key = parsed.path();
             let bucket = parsed
                 .host()
                 .ok_or_else(
-                    || polars_err!(ComputeError: "cannot parse bucket (host) from url: {}", url),
+                    || polars_err!(ComputeError: "cannot parse bucket (host) from url: {}", parsed),
                 )?
                 .to_string();
             (bucket, key)
@@ -116,6 +114,12 @@ impl CloudLocation {
             prefix,
             expansion,
         })
+    }
+
+    /// Parse a CloudLocation from an url.
+    pub fn new(url: &str) -> PolarsResult<CloudLocation> {
+        let parsed = Url::parse(url).map_err(to_compute_err)?;
+        Self::from_url(&parsed)
     }
 }
 

--- a/crates/polars-io/src/cloud/mod.rs
+++ b/crates/polars-io/src/cloud/mod.rs
@@ -3,8 +3,6 @@
 #[cfg(feature = "cloud")]
 use std::borrow::Cow;
 #[cfg(feature = "cloud")]
-use std::str::FromStr;
-#[cfg(feature = "cloud")]
 use std::sync::Arc;
 
 #[cfg(feature = "cloud")]

--- a/crates/polars-io/src/cloud/object_store_setup.rs
+++ b/crates/polars-io/src/cloud/object_store_setup.rs
@@ -1,5 +1,6 @@
 use once_cell::sync::Lazy;
 pub use options::*;
+use polars_error::to_compute_err;
 use tokio::sync::RwLock;
 
 use super::*;
@@ -25,7 +26,8 @@ fn err_missing_feature(feature: &str, scheme: &str) -> BuildResult {
 
 /// Build an [`ObjectStore`] based on the URL and passed in url. Return the cloud location and an implementation of the object store.
 pub async fn build_object_store(url: &str, options: Option<&CloudOptions>) -> BuildResult {
-    let cloud_location = CloudLocation::new(url)?;
+    let parsed = parse_url(url).map_err(to_compute_err)?;
+    let cloud_location = CloudLocation::from_url(&parsed)?;
 
     let options = options.cloned();
     let key = (url.to_string(), options);
@@ -39,17 +41,14 @@ pub async fn build_object_store(url: &str, options: Option<&CloudOptions>) -> Bu
         }
     }
 
-    let cloud_type = CloudType::from_str(url)?;
     let options = key
         .1
         .as_ref()
         .map(Cow::Borrowed)
         .unwrap_or_else(|| Cow::Owned(Default::default()));
+
+    let cloud_type = CloudType::from_url(&parsed)?;
     let store = match cloud_type {
-        CloudType::File => {
-            let local = LocalFileSystem::new();
-            Ok::<_, PolarsError>(Arc::new(local) as Arc<dyn ObjectStore>)
-        },
         CloudType::Aws => {
             #[cfg(feature = "aws")]
             {
@@ -78,6 +77,10 @@ pub async fn build_object_store(url: &str, options: Option<&CloudOptions>) -> Bu
             }
             #[cfg(not(feature = "azure"))]
             return err_missing_feature("azure", &cloud_location.scheme);
+        },
+        CloudType::File => {
+            let local = LocalFileSystem::new();
+            Ok::<_, PolarsError>(Arc::new(local) as Arc<dyn ObjectStore>)
         },
     }?;
     let mut cache = OBJECT_STORE_CACHE.write().await;

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -83,12 +83,9 @@ pub enum CloudType {
     Gcp,
 }
 
-impl FromStr for CloudType {
-    type Err = PolarsError;
-
+impl CloudType {
     #[cfg(feature = "cloud")]
-    fn from_str(url: &str) -> Result<Self, Self::Err> {
-        let parsed = Url::parse(url).map_err(to_compute_err)?;
+    pub(crate) fn from_url(parsed: &Url) -> PolarsResult<Self> {
         Ok(match parsed.scheme() {
             "s3" | "s3a" => Self::Aws,
             "az" | "azure" | "adl" | "abfs" | "abfss" => Self::Azure,
@@ -96,6 +93,34 @@ impl FromStr for CloudType {
             "file" => Self::File,
             _ => polars_bail!(ComputeError: "unknown url scheme"),
         })
+    }
+}
+
+#[cfg(feature = "cloud")]
+pub(crate) fn parse_url(url: &str) -> std::result::Result<Url, url::ParseError> {
+    match Url::parse(url) {
+        Err(err) => match err {
+            url::ParseError::RelativeUrlWithoutBase => {
+                let parsed = Url::parse(&format!(
+                    "file://{}",
+                    std::env::current_dir().unwrap().to_string_lossy()
+                ))
+                .unwrap();
+                parsed.join(url)
+            },
+            err => Err(err),
+        },
+        parsed => parsed,
+    }
+}
+
+impl FromStr for CloudType {
+    type Err = PolarsError;
+
+    #[cfg(feature = "cloud")]
+    fn from_str(url: &str) -> Result<Self, Self::Err> {
+        let parsed = parse_url(url).map_err(to_compute_err)?;
+        Self::from_url(&parsed)
     }
 
     #[cfg(not(feature = "cloud"))]

--- a/crates/polars-io/src/parquet/read.rs
+++ b/crates/polars-io/src/parquet/read.rs
@@ -334,12 +334,15 @@ impl ParquetAsyncReader {
 
     pub async fn batched(mut self, chunk_size: usize) -> PolarsResult<BatchedParquetReader> {
         let metadata = self.reader.get_metadata().await?.clone();
-        let schema = self.schema().await?;
+        let schema = match self.schema {
+            Some(schema) => schema,
+            None => self.schema().await?,
+        };
         // row group fetched deals with projection
         let row_group_fetcher = FetchRowGroupsFromObjectStore::new(
             self.reader,
             &metadata,
-            self.schema.unwrap(),
+            schema.clone(),
             self.projection.as_deref(),
             self.predicate.clone(),
         )?

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -99,7 +99,7 @@ pub(super) fn array_iter_to_series(
 /// We have a special num_rows arg, as df can be empty when a projection contains
 /// only hive partition columns.
 /// Safety: num_rows equals the height of the df when the df height is non-zero.
-fn materialize_hive_partitions(
+pub(crate) fn materialize_hive_partitions(
     df: &mut DataFrame,
     hive_partition_columns: Option<&[Series]>,
     num_rows: usize,
@@ -416,12 +416,7 @@ pub fn read_parquet<R: MmapBytesReader>(
             Cow::Borrowed(schema)
         };
         let mut df = DataFrame::from(schema.as_ref().as_ref());
-        if let Some(parts) = hive_partition_columns {
-            for s in parts {
-                // SAFETY: length is equal
-                unsafe { df.with_column_unchecked(s.clear()) };
-            }
-        }
+        materialize_hive_partitions(&mut df, hive_partition_columns, 0);
         Ok(df)
     } else {
         accumulate_dataframes_vertical(dfs)

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -342,6 +342,10 @@ pub fn read_parquet<R: MmapBytesReader>(
     use_statistics: bool,
     hive_partition_columns: Option<&[Series]>,
 ) -> PolarsResult<DataFrame> {
+    if limit == 0 {
+        return Ok(DataFrame::from(schema.as_ref()));
+    }
+
     let file_metadata = metadata
         .map(Ok)
         .unwrap_or_else(|| read::read_metadata(&mut reader).map(Arc::new))?;

--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -10,6 +10,7 @@ description = "Lazy query engine for the Polars DataFrame library"
 
 [dependencies]
 arrow = { workspace = true }
+futures = { workspace = true, optional = true }
 polars-core = { workspace = true, features = ["lazy", "zip_with", "random"] }
 polars-io = { workspace = true, features = ["lazy"] }
 polars-json = { workspace = true, optional = true }
@@ -43,7 +44,7 @@ async = [
   "polars-io/cloud",
   "polars-pipe?/async",
 ]
-cloud = ["async", "polars-pipe?/cloud", "polars-plan/cloud", "tokio"]
+cloud = ["async", "polars-pipe?/cloud", "polars-plan/cloud", "tokio", "futures"]
 cloud_write = ["cloud"]
 ipc = ["polars-io/ipc", "polars-plan/ipc", "polars-pipe?/ipc"]
 json = ["polars-io/json", "polars-plan/json", "polars-json"]

--- a/crates/polars-lazy/src/physical_plan/executors/scan/ipc.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/ipc.rs
@@ -12,17 +12,16 @@ pub struct IpcExec {
 
 impl IpcExec {
     fn read(&mut self, verbose: bool) -> PolarsResult<DataFrame> {
-        let (file, projection, n_rows, predicate) = prepare_scan_args(
+        let (file, projection, predicate) = prepare_scan_args(
             &self.path,
             &self.predicate,
             &mut self.file_options.with_columns,
             &mut self.schema,
-            self.file_options.n_rows,
             self.file_options.row_count.is_some(),
             None,
         );
         IpcReader::new(file.unwrap())
-            .with_n_rows(n_rows)
+            .with_n_rows(self.file_options.n_rows)
             .with_row_count(std::mem::take(&mut self.file_options.row_count))
             .set_rechunk(self.file_options.rechunk)
             .with_projection(projection)

--- a/crates/polars-lazy/src/physical_plan/executors/scan/mod.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/mod.rs
@@ -30,8 +30,6 @@ use crate::prelude::*;
 #[cfg(any(feature = "ipc", feature = "parquet"))]
 type Projection = Option<Vec<usize>>;
 #[cfg(any(feature = "ipc", feature = "parquet"))]
-type StopNRows = Option<usize>;
-#[cfg(any(feature = "ipc", feature = "parquet"))]
 type Predicate = Option<Arc<dyn PhysicalIoExpr>>;
 
 #[cfg(any(feature = "ipc", feature = "parquet"))]
@@ -40,10 +38,9 @@ fn prepare_scan_args(
     predicate: &Option<Arc<dyn PhysicalExpr>>,
     with_columns: &mut Option<Arc<Vec<String>>>,
     schema: &mut SchemaRef,
-    n_rows: Option<usize>,
     has_row_count: bool,
     hive_partitions: Option<&[Series]>,
-) -> (Option<std::fs::File>, Projection, StopNRows, Predicate) {
+) -> (Option<std::fs::File>, Projection, Predicate) {
     let file = std::fs::File::open(path).ok();
 
     let with_columns = mem::take(with_columns);
@@ -56,10 +53,9 @@ fn prepare_scan_args(
         has_row_count,
     );
 
-    let n_rows = _set_n_rows_for_scan(n_rows);
     let predicate = predicate.clone().map(phys_expr_to_io_expr);
 
-    (file, projection, n_rows, predicate)
+    (file, projection, predicate)
 }
 
 /// Producer of an in memory DataFrame

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -46,92 +46,18 @@ impl ParquetExec {
             },
             identity => identity,
         };
-        let n_rows = self.file_options.n_rows;
 
-        // self.paths.iter().map(|path| {
-        //     let (file, projection, predicate) = prepare_scan_args(
-        //         path,
-        //         &self.predicate,
-        //         &mut self.file_options.with_columns.clone(),
-        //         &mut self.file_info.schema.clone(),
-        //         self.file_options.row_count.is_some(),
-        //         hive_partitions.as_deref(),
-        //     );
-        //
-        //     let reader = if let Some(file) = file {
-        //         ParquetReader::new(file)
-        //             .with_schema(Some(self.file_info.reader_schema.clone()))
-        //             .read_parallel(parallel)
-        //             .set_low_memory(self.options.low_memory)
-        //             .use_statistics(self.options.use_statistics)
-        //             .with_hive_partition_columns(hive_partitions);
-        //             )
-        //     } else {
-        //         polars_bail!(ComputeError: "could not read {}", path.display())
-        //     }?;
-        //
-        //
-        //
-        // })
-
-        POOL.install(|| {
-            self.paths
-                .par_iter()
-                .map(|path| {
-                    let mut file_info = self.file_info.clone();
-                    file_info.update_hive_partitions(path);
-
-                    let hive_partitions = file_info
-                        .hive_parts
-                        .as_ref()
-                        .map(|hive| hive.materialize_partition_columns());
-
-                    let (file, projection, predicate) = prepare_scan_args(
-                        path,
-                        &self.predicate,
-                        &mut self.file_options.with_columns.clone(),
-                        &mut self.file_info.schema.clone(),
-                        self.file_options.row_count.is_some(),
-                        hive_partitions.as_deref(),
-                    );
-
-                    let df = if let Some(file) = file {
-                        ParquetReader::new(file)
-                            .with_schema(Some(self.file_info.reader_schema.clone()))
-                            .read_parallel(parallel)
-                            .with_n_rows(n_rows)
-                            .set_low_memory(self.options.low_memory)
-                            .use_statistics(self.options.use_statistics)
-                            .with_hive_partition_columns(hive_partitions)
-                            ._finish_with_scan_ops(
-                                predicate,
-                                projection.as_ref().map(|v| v.as_ref()),
-                            )
-                    } else {
-                        polars_bail!(ComputeError: "could not read {}", path.display())
-                    }?;
-                    Ok(df)
-                })
-                .collect()
-        })
-    }
-
-    fn read_seq(&mut self) -> PolarsResult<Vec<DataFrame>> {
-        let mut base_offset = 0 as IdxSize;
-        let mut n_rows_total = self.file_options.n_rows;
-
-        self.paths
+        // First initialize the readers, predicates and metadata.
+        // This will be used to determine the slices. That way we can actually read all the
+        // files in parallel even when we add row counts or slices.
+        let readers_and_metadata = self
+            .paths
             .iter()
             .map(|path| {
-                let row_count = self.file_options.row_count.as_ref().map(|rc| RowCount {
-                    name: rc.name.clone(),
-                    offset: rc.offset + base_offset,
-                });
+                let mut file_info = self.file_info.clone();
+                file_info.update_hive_partitions(path);
 
-                self.file_info.update_hive_partitions(path);
-
-                let hive_partitions = self
-                    .file_info
+                let hive_partitions = file_info
                     .hive_parts
                     .as_ref()
                     .map(|hive| hive.materialize_partition_columns());
@@ -145,27 +71,66 @@ impl ParquetExec {
                     hive_partitions.as_deref(),
                 );
 
-                let df = if let Some(file) = file {
-                    ParquetReader::new(file)
-                        .with_schema(Some(self.file_info.reader_schema.clone()))
-                        .with_n_rows(n_rows_total)
-                        .read_parallel(self.options.parallel)
-                        .with_row_count(row_count)
-                        .set_low_memory(self.options.low_memory)
-                        .use_statistics(self.options.use_statistics)
-                        .with_hive_partition_columns(hive_partitions)
-                        ._finish_with_scan_ops(predicate, projection.as_ref().map(|v| v.as_ref()))
+                let mut reader = if let Some(file) = file {
+                    PolarsResult::Ok(
+                        ParquetReader::new(file)
+                            .with_schema(Some(self.file_info.reader_schema.clone()))
+                            .read_parallel(parallel)
+                            .set_low_memory(self.options.low_memory)
+                            .use_statistics(self.options.use_statistics)
+                            .set_rechunk(false)
+                            .with_hive_partition_columns(hive_partitions),
+                    )
                 } else {
                     polars_bail!(ComputeError: "could not read {}", path.display())
                 }?;
-                let read = df.height();
-                base_offset += read as IdxSize;
-                if let Some(total) = n_rows_total.as_mut() {
-                    *total -= read
-                }
-                Ok(df)
+
+                reader
+                    .num_rows()
+                    .map(|num_rows| (reader, num_rows, predicate, projection))
             })
-            .collect()
+            .collect::<PolarsResult<Vec<_>>>()?;
+
+        let n_rows_to_read = self.file_options.n_rows.unwrap_or(usize::MAX);
+        let iter = readers_and_metadata
+            .iter()
+            .map(|(_, num_rows, _, _)| *num_rows);
+
+        let rows_statistics = get_sequential_row_statistics(iter, n_rows_to_read);
+        let base_row_count = &self.file_options.row_count;
+
+        POOL.install(|| {
+            readers_and_metadata
+                .into_par_iter()
+                .zip(rows_statistics.par_iter())
+                .map(
+                    |(
+                        (reader, num_rows_this_file, predicate, projection),
+                        (remaining_rows_to_read, cumulative_read),
+                    )| {
+                        let remaining_rows_to_read = *remaining_rows_to_read;
+                        let remaining_rows_to_read = if num_rows_this_file < remaining_rows_to_read
+                        {
+                            None
+                        } else {
+                            Some(remaining_rows_to_read)
+                        };
+                        let row_count = base_row_count.as_ref().map(|rc| RowCount {
+                            name: rc.name.clone(),
+                            offset: rc.offset + *cumulative_read as IdxSize,
+                        });
+
+                        reader
+                            .with_n_rows(remaining_rows_to_read)
+                            .with_row_count(row_count)
+                            ._finish_with_scan_ops(
+                                predicate.clone(),
+                                projection.as_ref().map(|v| v.as_ref()),
+                            )
+                    },
+                )
+                .collect()
+        })
     }
 
     #[cfg(feature = "cloud")]
@@ -251,6 +216,7 @@ impl ParquetExec {
                         .with_projection(projection)
                         .use_statistics(use_statistics)
                         .with_predicate(predicate)
+                        .set_rechunk(false)
                         .with_hive_partition_columns(hive_partitions)
                         .finish()
                         .await
@@ -266,30 +232,25 @@ impl ParquetExec {
         let is_cloud = is_cloud_url(self.paths[0].as_path());
         let force_async = std::env::var("POLARS_FORCE_ASYNC").as_deref().unwrap_or("") == "1";
 
-        let out = if self.file_options.n_rows.is_some()
-            || self.file_options.row_count.is_some()
-            || is_cloud
-            || force_async
-        {
-            if is_cloud || force_async {
-                #[cfg(not(feature = "cloud"))]
-                {
-                    panic!("activate cloud feature")
-                }
+        let out = if is_cloud || force_async {
+            #[cfg(not(feature = "cloud"))]
+            {
+                panic!("activate cloud feature")
+            }
 
-                #[cfg(feature = "cloud")]
-                {
-                    polars_io::pl_async::get_runtime()
-                        .block_on_potential_spawn(self.read_async())?
-                }
-            } else {
-                self.read_seq()?
+            #[cfg(feature = "cloud")]
+            {
+                polars_io::pl_async::get_runtime().block_on_potential_spawn(self.read_async())?
             }
         } else {
             self.read_par()?
         };
 
-        accumulate_dataframes_vertical(out)
+        let mut out = accumulate_dataframes_vertical(out)?;
+        if self.file_options.rechunk {
+            out.as_single_chunk_par();
+        }
+        Ok(out)
     }
 }
 

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
 
-use arrow::io::parquet::read::read_metadata_async;
 use polars_core::utils::accumulate_dataframes_vertical;
 use polars_core::utils::arrow::io::parquet::read::FileMetaData;
 use polars_io::cloud::CloudOptions;
@@ -60,7 +59,7 @@ impl ParquetExec {
                         .as_ref()
                         .map(|hive| hive.materialize_partition_columns());
 
-                    let (file, projection, n_rows, predicate) = prepare_scan_args(
+                    let (file, projection, _, predicate) = prepare_scan_args(
                         path,
                         &self.predicate,
                         &mut self.file_options.with_columns.clone(),
@@ -135,7 +134,9 @@ impl ParquetExec {
                 }?;
                 let read = df.height();
                 base_offset += read as IdxSize;
-                n_rows_total.as_mut().map(|total| *total -= read);
+                if let Some(total) = n_rows_total.as_mut() {
+                    *total -= read
+                }
                 Ok(df)
             })
             .collect()
@@ -143,14 +144,22 @@ impl ParquetExec {
 
     #[cfg(feature = "cloud")]
     async fn read_async(&mut self) -> PolarsResult<Vec<DataFrame>> {
-        let mut n_rows_total = self.file_options.n_rows;
-
-        let iter = self.paths.iter().map(|path| async {
+        let first_schema = &self.file_info.reader_schema;
+        let first_metadata = &self.metadata;
+        let cloud_options = self.cloud_options.as_ref();
+        // First initialize the readers and get the metadata concurrently.
+        let iter = self.paths.iter().enumerate().map(|(i, path)| async move {
+            // use the cached one as this saves a cloud call
+            let (schema, metadata) = if i == 0 {
+                (Some(first_schema.clone()), first_metadata.clone())
+            } else {
+                (None, None)
+            };
             let mut reader = ParquetAsyncReader::from_uri(
                 &path.to_string_lossy(),
-                self.cloud_options.as_ref(),
-                None,
-                None,
+                cloud_options,
+                schema,
+                metadata,
             )
             .await?;
             let num_rows = reader.num_rows().await?;
@@ -158,7 +167,9 @@ impl ParquetExec {
         });
         let readers_and_metadata = futures::future::try_join_all(iter).await?;
 
-        let mut n_rows_to_read = n_rows_total.unwrap_or(usize::MAX);
+        // Then compute `n_rows` to be take per file up front, so we can actually read concurrently
+        // after this.
+        let mut n_rows_to_read = self.file_options.n_rows.unwrap_or(usize::MAX);
         let mut cumulative_read = 0;
         let row_counts = readers_and_metadata
             .iter()
@@ -171,18 +182,14 @@ impl ParquetExec {
             })
             .collect::<Vec<_>>();
 
-        let base_row_count = std::mem::take(&mut self.file_options.row_count);
-        let base_row_count = &base_row_count;
-        let mut file_info = std::mem::take(&mut self.file_info);
-        let file_info = &file_info;
-        let reader_schema = file_info.reader_schema.clone();
-        let reader_schema = &reader_schema;
-        let file_options = std::mem::take(&mut self.file_options);
-        let file_options = &file_options;
-        let paths = self.paths.clone();
+        // Now read the actual data.
+        let base_row_count = &self.file_options.row_count;
+        let file_info = &self.file_info;
+        let reader_schema = &file_info.reader_schema;
+        let file_options = &self.file_options;
+        let paths = &self.paths;
         let use_statistics = self.options.use_statistics;
-        let predicate = self.predicate.clone();
-        let predicate = &predicate;
+        let predicate = &self.predicate;
 
         let iter = readers_and_metadata
             .into_iter()
@@ -203,7 +210,7 @@ impl ParquetExec {
                     };
                     let row_count = base_row_count.as_ref().map(|rc| RowCount {
                         name: rc.name.clone(),
-                        offset: rc.offset + row_count as IdxSize,
+                        offset: rc.offset + *cumulative_read as IdxSize,
                     });
 
                     file_info.update_hive_partitions(path);
@@ -215,7 +222,7 @@ impl ParquetExec {
 
                     let (_, projection, n_rows, predicate) = prepare_scan_args(
                         Path::new(""),
-                        &predicate,
+                        predicate,
                         &mut file_options.with_columns.clone(),
                         &mut reader_schema.clone(),
                         n_rows,
@@ -242,10 +249,12 @@ impl ParquetExec {
 
     fn read(&mut self) -> PolarsResult<DataFrame> {
         let is_cloud = is_cloud_url(self.paths[0].as_path());
+        let force_async = std::env::var("POLARS_FORCE_ASYNC").as_deref().unwrap_or("") == "1";
 
         let out = if self.file_options.n_rows.is_some()
             || self.file_options.row_count.is_some()
             || is_cloud
+            || force_async
         {
             if is_cloud {
                 #[cfg(not(feature = "cloud"))]
@@ -264,71 +273,6 @@ impl ParquetExec {
         } else {
             self.read_par()?
         };
-
-        //     let mut out = Vec::with_capacity(self.paths.len());
-        //
-        //     for path in self.paths.iter() {
-        //         self.file_info.update_hive_partitions(path);
-        //
-        //         let hive_partitions = self
-        //             .file_info
-        //             .hive_parts
-        //             .as_ref()
-        //             .map(|hive| hive.materialize_partition_columns());
-        //
-        //         let (file, projection, n_rows, predicate) = prepare_scan_args(
-        //             path,
-        //             &self.predicate,
-        //             &mut self.file_options.with_columns.clone(),
-        //             &mut self.file_info.schema.clone(),
-        //             self.file_options.n_rows,
-        //             self.file_options.row_count.is_some(),
-        //             hive_partitions.as_deref(),
-        //         );
-        //
-        //         let df = if let Some(file) = file {
-        //             ParquetReader::new(file)
-        //                 .with_schema(Some(self.file_info.reader_schema.clone()))
-        //                 .with_n_rows(n_rows)
-        //                 .read_parallel(self.options.parallel)
-        //                 .with_row_count(self.file_options.row_count.clone())
-        //                 .set_rechunk(self.file_options.rechunk)
-        //                 .set_low_memory(self.options.low_memory)
-        //                 .use_statistics(self.options.use_statistics)
-        //                 .with_hive_partition_columns(hive_partitions)
-        //                 ._finish_with_scan_ops(predicate, projection.as_ref().map(|v| v.as_ref()))
-        //         } else if is_cloud_url(path.as_path()) {
-        //             #[cfg(feature = "cloud")]
-        //             {
-        //                 polars_io::pl_async::get_runtime().block_on_potential_spawn(async {
-        //                     let reader = ParquetAsyncReader::from_uri(
-        //                         &path.to_string_lossy(),
-        //                         self.cloud_options.as_ref(),
-        //                         Some(self.file_info.reader_schema.clone()),
-        //                         self.metadata.clone(),
-        //                     )
-        //                         .await?
-        //                         .with_n_rows(n_rows)
-        //                         .with_row_count(self.file_options.row_count.clone())
-        //                         .with_projection(projection)
-        //                         .use_statistics(self.options.use_statistics)
-        //                         .with_predicate(predicate)
-        //                         .with_hive_partition_columns(hive_partitions);
-        //
-        //                     reader.finish().await
-        //                 })
-        //             }
-        //             #[cfg(not(feature = "cloud"))]
-        //             {
-        //                 panic!("activate cloud feature")
-        //             }
-        //         } else {
-        //             polars_bail!(ComputeError: "could not read {}", path.display())
-        //         }?;
-        //         out.push(df)
-        //     }
-        //     out
-        // };
 
         accumulate_dataframes_vertical(out)
     }

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -256,7 +256,7 @@ impl ParquetExec {
             || is_cloud
             || force_async
         {
-            if is_cloud {
+            if is_cloud || force_async {
                 #[cfg(not(feature = "cloud"))]
                 {
                     panic!("activate cloud feature")

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -1,9 +1,10 @@
-use std::path::PathBuf;
-use polars_core::utils::accumulate_dataframes_vertical;
+use std::path::{Path, PathBuf};
 
+use arrow::io::parquet::read::read_metadata_async;
+use polars_core::utils::accumulate_dataframes_vertical;
 use polars_core::utils::arrow::io::parquet::read::FileMetaData;
 use polars_io::cloud::CloudOptions;
-use polars_io::is_cloud_url;
+use polars_io::{is_cloud_url, RowCount};
 
 use super::*;
 
@@ -39,69 +40,296 @@ impl ParquetExec {
         }
     }
 
-    fn read(&mut self) -> PolarsResult<DataFrame> {
-        let mut out = Vec::with_capacity(self.paths.len());
+    fn read_par(&mut self) -> PolarsResult<Vec<DataFrame>> {
+        let parallel = match self.options.parallel {
+            ParallelStrategy::Auto if self.paths.len() > POOL.current_num_threads() => {
+                ParallelStrategy::RowGroups
+            },
+            identity => identity,
+        };
 
-        for path in self.paths.iter() {
+        POOL.install(|| {
+            self.paths
+                .par_iter()
+                .map(|path| {
+                    let mut file_info = self.file_info.clone();
+                    file_info.update_hive_partitions(path);
 
-            let hive_partitions = self
-                .file_info
-                .hive_parts
-                .as_ref()
-                .map(|hive| hive.materialize_partition_columns());
+                    let hive_partitions = file_info
+                        .hive_parts
+                        .as_ref()
+                        .map(|hive| hive.materialize_partition_columns());
 
-            let (file, projection, n_rows, predicate) = prepare_scan_args(
-                path,
-                &self.predicate,
-                &mut self.file_options.with_columns,
-                &mut self.file_info.schema.clone(),
-                self.file_options.n_rows,
-                self.file_options.row_count.is_some(),
-                hive_partitions.as_deref(),
+                    let (file, projection, n_rows, predicate) = prepare_scan_args(
+                        path,
+                        &self.predicate,
+                        &mut self.file_options.with_columns.clone(),
+                        &mut self.file_info.schema.clone(),
+                        None,
+                        self.file_options.row_count.is_some(),
+                        hive_partitions.as_deref(),
+                    );
+
+                    let df = if let Some(file) = file {
+                        ParquetReader::new(file)
+                            .with_schema(Some(self.file_info.reader_schema.clone()))
+                            .read_parallel(parallel)
+                            .set_low_memory(self.options.low_memory)
+                            .use_statistics(self.options.use_statistics)
+                            .with_hive_partition_columns(hive_partitions)
+                            ._finish_with_scan_ops(
+                                predicate,
+                                projection.as_ref().map(|v| v.as_ref()),
+                            )
+                    } else {
+                        polars_bail!(ComputeError: "could not read {}", path.display())
+                    }?;
+                    Ok(df)
+                })
+                .collect()
+        })
+    }
+
+    fn read_seq(&mut self) -> PolarsResult<Vec<DataFrame>> {
+        let mut base_offset = 0 as IdxSize;
+        let mut n_rows_total = self.file_options.n_rows;
+
+        self.paths
+            .iter()
+            .map(|path| {
+                let row_count = self.file_options.row_count.as_ref().map(|rc| RowCount {
+                    name: rc.name.clone(),
+                    offset: rc.offset + base_offset,
+                });
+
+                self.file_info.update_hive_partitions(path);
+
+                let hive_partitions = self
+                    .file_info
+                    .hive_parts
+                    .as_ref()
+                    .map(|hive| hive.materialize_partition_columns());
+
+                let (file, projection, n_rows, predicate) = prepare_scan_args(
+                    path,
+                    &self.predicate,
+                    &mut self.file_options.with_columns.clone(),
+                    &mut self.file_info.schema.clone(),
+                    n_rows_total,
+                    self.file_options.row_count.is_some(),
+                    hive_partitions.as_deref(),
+                );
+
+                let df = if let Some(file) = file {
+                    ParquetReader::new(file)
+                        .with_schema(Some(self.file_info.reader_schema.clone()))
+                        .with_n_rows(n_rows)
+                        .read_parallel(self.options.parallel)
+                        .with_row_count(row_count)
+                        .set_low_memory(self.options.low_memory)
+                        .use_statistics(self.options.use_statistics)
+                        .with_hive_partition_columns(hive_partitions)
+                        ._finish_with_scan_ops(predicate, projection.as_ref().map(|v| v.as_ref()))
+                } else {
+                    polars_bail!(ComputeError: "could not read {}", path.display())
+                }?;
+                let read = df.height();
+                base_offset += read as IdxSize;
+                n_rows_total.as_mut().map(|total| *total -= read);
+                Ok(df)
+            })
+            .collect()
+    }
+
+    #[cfg(feature = "cloud")]
+    async fn read_async(&mut self) -> PolarsResult<Vec<DataFrame>> {
+        let mut n_rows_total = self.file_options.n_rows;
+
+        let iter = self.paths.iter().map(|path| async {
+            let mut reader = ParquetAsyncReader::from_uri(
+                &path.to_string_lossy(),
+                self.cloud_options.as_ref(),
+                None,
+                None,
+            )
+            .await?;
+            let num_rows = reader.num_rows().await?;
+            PolarsResult::Ok((num_rows, reader))
+        });
+        let readers_and_metadata = futures::future::try_join_all(iter).await?;
+
+        let mut n_rows_to_read = n_rows_total.unwrap_or(usize::MAX);
+        let mut cumulative_read = 0;
+        let row_counts = readers_and_metadata
+            .iter()
+            .map(|(num_rows, _)| {
+                let n_rows = n_rows_to_read;
+                n_rows_to_read -= n_rows_to_read.saturating_sub(*num_rows);
+                cumulative_read += num_rows;
+
+                (n_rows, cumulative_read)
+            })
+            .collect::<Vec<_>>();
+
+        let base_row_count = std::mem::take(&mut self.file_options.row_count);
+        let base_row_count = &base_row_count;
+        let mut file_info = std::mem::take(&mut self.file_info);
+        let file_info = &file_info;
+        let reader_schema = file_info.reader_schema.clone();
+        let reader_schema = &reader_schema;
+        let file_options = std::mem::take(&mut self.file_options);
+        let file_options = &file_options;
+        let paths = self.paths.clone();
+        let use_statistics = self.options.use_statistics;
+        let predicate = self.predicate.clone();
+        let predicate = &predicate;
+
+        let iter = readers_and_metadata
+            .into_iter()
+            .zip(row_counts.iter())
+            .zip(paths.as_ref().iter())
+            .map(
+                |(((row_count, reader), (n_rows, cumulative_read)), path)| async move {
+                    let mut file_info = file_info.clone();
+                    let n_rows = *n_rows;
+                    if n_rows == 0 {
+                        return Ok(None);
+                    }
+
+                    let n_rows = if row_count < n_rows {
+                        None
+                    } else {
+                        Some(n_rows)
+                    };
+                    let row_count = base_row_count.as_ref().map(|rc| RowCount {
+                        name: rc.name.clone(),
+                        offset: rc.offset + row_count as IdxSize,
+                    });
+
+                    file_info.update_hive_partitions(path);
+
+                    let hive_partitions = file_info
+                        .hive_parts
+                        .as_ref()
+                        .map(|hive| hive.materialize_partition_columns());
+
+                    let (_, projection, n_rows, predicate) = prepare_scan_args(
+                        Path::new(""),
+                        &predicate,
+                        &mut file_options.with_columns.clone(),
+                        &mut reader_schema.clone(),
+                        n_rows,
+                        row_count.is_some(),
+                        hive_partitions.as_deref(),
+                    );
+
+                    reader
+                        .with_n_rows(n_rows)
+                        .with_row_count(row_count)
+                        .with_projection(projection)
+                        .use_statistics(use_statistics)
+                        .with_predicate(predicate)
+                        .with_hive_partition_columns(hive_partitions)
+                        .finish()
+                        .await
+                        .map(Some)
+                },
             );
 
-            let df = if let Some(file) = file {
-                ParquetReader::new(file)
-                    .with_schema(Some(self.file_info.reader_schema.clone()))
-                    .with_n_rows(n_rows)
-                    .read_parallel(self.options.parallel)
-                    .with_row_count(mem::take(&mut self.file_options.row_count))
-                    .set_rechunk(self.file_options.rechunk)
-                    .set_low_memory(self.options.low_memory)
-                    .use_statistics(self.options.use_statistics)
-                    .with_hive_partition_columns(hive_partitions)
-                    ._finish_with_scan_ops(predicate, projection.as_ref().map(|v| v.as_ref()))
-            } else if is_cloud_url(path.as_path()) {
-                #[cfg(feature = "cloud")]
-                {
-                    polars_io::pl_async::get_runtime().block_on_potential_spawn(async {
-                        let reader = ParquetAsyncReader::from_uri(
-                            &path.to_string_lossy(),
-                            self.cloud_options.as_ref(),
-                            Some(self.file_info.reader_schema.clone()),
-                            self.metadata.clone(),
-                        )
-                            .await?
-                            .with_n_rows(n_rows)
-                            .with_row_count(mem::take(&mut self.file_options.row_count))
-                            .with_projection(projection)
-                            .use_statistics(self.options.use_statistics)
-                            .with_predicate(predicate)
-                            .with_hive_partition_columns(hive_partitions);
+        let dfs = futures::future::try_join_all(iter).await?;
+        Ok(dfs.into_iter().flatten().collect())
+    }
 
-                        reader.finish().await
-                    })
-                }
+    fn read(&mut self) -> PolarsResult<DataFrame> {
+        let is_cloud = is_cloud_url(self.paths[0].as_path());
+
+        let out = if self.file_options.n_rows.is_some()
+            || self.file_options.row_count.is_some()
+            || is_cloud
+        {
+            if is_cloud {
                 #[cfg(not(feature = "cloud"))]
                 {
                     panic!("activate cloud feature")
                 }
-            } else {
-                polars_bail!(ComputeError: "could not read {}", path.display())
-            }?;
-            out.push(df)
 
-        }
+                #[cfg(feature = "cloud")]
+                {
+                    polars_io::pl_async::get_runtime()
+                        .block_on_potential_spawn(self.read_async())?
+                }
+            } else {
+                self.read_seq()?
+            }
+        } else {
+            self.read_par()?
+        };
+
+        //     let mut out = Vec::with_capacity(self.paths.len());
+        //
+        //     for path in self.paths.iter() {
+        //         self.file_info.update_hive_partitions(path);
+        //
+        //         let hive_partitions = self
+        //             .file_info
+        //             .hive_parts
+        //             .as_ref()
+        //             .map(|hive| hive.materialize_partition_columns());
+        //
+        //         let (file, projection, n_rows, predicate) = prepare_scan_args(
+        //             path,
+        //             &self.predicate,
+        //             &mut self.file_options.with_columns.clone(),
+        //             &mut self.file_info.schema.clone(),
+        //             self.file_options.n_rows,
+        //             self.file_options.row_count.is_some(),
+        //             hive_partitions.as_deref(),
+        //         );
+        //
+        //         let df = if let Some(file) = file {
+        //             ParquetReader::new(file)
+        //                 .with_schema(Some(self.file_info.reader_schema.clone()))
+        //                 .with_n_rows(n_rows)
+        //                 .read_parallel(self.options.parallel)
+        //                 .with_row_count(self.file_options.row_count.clone())
+        //                 .set_rechunk(self.file_options.rechunk)
+        //                 .set_low_memory(self.options.low_memory)
+        //                 .use_statistics(self.options.use_statistics)
+        //                 .with_hive_partition_columns(hive_partitions)
+        //                 ._finish_with_scan_ops(predicate, projection.as_ref().map(|v| v.as_ref()))
+        //         } else if is_cloud_url(path.as_path()) {
+        //             #[cfg(feature = "cloud")]
+        //             {
+        //                 polars_io::pl_async::get_runtime().block_on_potential_spawn(async {
+        //                     let reader = ParquetAsyncReader::from_uri(
+        //                         &path.to_string_lossy(),
+        //                         self.cloud_options.as_ref(),
+        //                         Some(self.file_info.reader_schema.clone()),
+        //                         self.metadata.clone(),
+        //                     )
+        //                         .await?
+        //                         .with_n_rows(n_rows)
+        //                         .with_row_count(self.file_options.row_count.clone())
+        //                         .with_projection(projection)
+        //                         .use_statistics(self.options.use_statistics)
+        //                         .with_predicate(predicate)
+        //                         .with_hive_partition_columns(hive_partitions);
+        //
+        //                     reader.finish().await
+        //                 })
+        //             }
+        //             #[cfg(not(feature = "cloud"))]
+        //             {
+        //                 panic!("activate cloud feature")
+        //             }
+        //         } else {
+        //             polars_bail!(ComputeError: "could not read {}", path.display())
+        //         }?;
+        //         out.push(df)
+        //     }
+        //     out
+        // };
+
         accumulate_dataframes_vertical(out)
     }
 }

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -245,17 +245,15 @@ pub fn create_physical_plan(
                     options,
                     cloud_options,
                     metadata,
-                } => {
-                    Ok(Box::new(executors::ParquetExec::new(
-                        paths,
-                        file_info,
-                        predicate,
-                        options,
-                        cloud_options,
-                        file_options,
-                        metadata,
-                    )))
-                },
+                } => Ok(Box::new(executors::ParquetExec::new(
+                    paths,
+                    file_info,
+                    predicate,
+                    options,
+                    cloud_options,
+                    file_options,
+                    metadata,
+                ))),
                 FileScan::Anonymous { function, .. } => {
                     Ok(Box::new(executors::AnonymousScanExec {
                         function,

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -1,5 +1,6 @@
 use polars_core::prelude::*;
 use polars_core::POOL;
+use polars_plan::global::_set_n_rows_for_scan;
 
 use super::super::executors::{self, Executor};
 use super::*;
@@ -198,8 +199,9 @@ pub fn create_physical_plan(
             output_schema,
             scan_type,
             predicate,
-            file_options,
+            mut file_options,
         } => {
+            file_options.n_rows = _set_n_rows_for_scan(file_options.n_rows);
             let mut state = ExpressionConversionState::default();
             let predicate = predicate
                 .map(|pred| {

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -246,10 +246,8 @@ pub fn create_physical_plan(
                     cloud_options,
                     metadata,
                 } => {
-                    assert_eq!(paths.len(), 1);
-                    let path = paths[0].clone();
                     Ok(Box::new(executors::ParquetExec::new(
-                        path,
+                        paths,
                         file_info,
                         predicate,
                         options,

--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -13,7 +13,7 @@ use crate::prelude::*;
 #[cfg(feature = "csv")]
 pub struct LazyCsvReader<'a> {
     path: PathBuf,
-    paths: Vec<PathBuf>,
+    paths: Arc<[PathBuf]>,
     separator: u8,
     has_header: bool,
     ignore_errors: bool,
@@ -40,14 +40,14 @@ pub struct LazyCsvReader<'a> {
 
 #[cfg(feature = "csv")]
 impl<'a> LazyCsvReader<'a> {
-    pub fn new_paths(paths: Vec<PathBuf>) -> Self {
+    pub fn new_paths(paths: Arc<[PathBuf]>) -> Self {
         Self::new("").with_paths(paths)
     }
 
     pub fn new(path: impl AsRef<Path>) -> Self {
         LazyCsvReader {
             path: path.as_ref().to_owned(),
-            paths: vec![],
+            paths: Arc::new([]),
             separator: b',',
             has_header: true,
             ignore_errors: false,
@@ -317,7 +317,7 @@ impl LazyFileListReader for LazyCsvReader<'_> {
         self
     }
 
-    fn with_paths(mut self, paths: Vec<PathBuf>) -> Self {
+    fn with_paths(mut self, paths: Arc<[PathBuf]>) -> Self {
         self.paths = paths;
         self
     }

--- a/crates/polars-lazy/src/scan/ipc.rs
+++ b/crates/polars-lazy/src/scan/ipc.rs
@@ -30,7 +30,7 @@ impl Default for ScanArgsIpc {
 struct LazyIpcReader {
     args: ScanArgsIpc,
     path: PathBuf,
-    paths: Vec<PathBuf>,
+    paths: Arc<[PathBuf]>,
 }
 
 impl LazyIpcReader {
@@ -38,7 +38,7 @@ impl LazyIpcReader {
         Self {
             args,
             path,
-            paths: vec![],
+            paths: Arc::new([]),
         }
     }
 }
@@ -84,7 +84,7 @@ impl LazyFileListReader for LazyIpcReader {
         self
     }
 
-    fn with_paths(mut self, paths: Vec<PathBuf>) -> Self {
+    fn with_paths(mut self, paths: Arc<[PathBuf]>) -> Self {
         self.paths = paths;
         self
     }
@@ -113,7 +113,7 @@ impl LazyFrame {
         LazyIpcReader::new(path.as_ref().to_owned(), args).finish()
     }
 
-    pub fn scan_ipc_files(paths: Vec<PathBuf>, args: ScanArgsIpc) -> PolarsResult<Self> {
+    pub fn scan_ipc_files(paths: Arc<[PathBuf]>, args: ScanArgsIpc) -> PolarsResult<Self> {
         LazyIpcReader::new(PathBuf::new(), args)
             .with_paths(paths)
             .finish()

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -9,7 +9,7 @@ use crate::prelude::{LazyFrame, ScanArgsAnonymous};
 #[derive(Clone)]
 pub struct LazyJsonLineReader {
     pub(crate) path: PathBuf,
-    paths: Vec<PathBuf>,
+    paths: Arc<[PathBuf]>,
     pub(crate) batch_size: Option<usize>,
     pub(crate) low_memory: bool,
     pub(crate) rechunk: bool,
@@ -20,14 +20,14 @@ pub struct LazyJsonLineReader {
 }
 
 impl LazyJsonLineReader {
-    pub fn new_paths(paths: Vec<PathBuf>) -> Self {
+    pub fn new_paths(paths: Arc<[PathBuf]>) -> Self {
         Self::new(PathBuf::new()).with_paths(paths)
     }
 
     pub fn new(path: impl AsRef<Path>) -> Self {
         LazyJsonLineReader {
             path: path.as_ref().to_path_buf(),
-            paths: vec![],
+            paths: Arc::new([]),
             batch_size: None,
             low_memory: false,
             rechunk: true,
@@ -107,7 +107,7 @@ impl LazyFileListReader for LazyJsonLineReader {
         self
     }
 
-    fn with_paths(mut self, paths: Vec<PathBuf>) -> Self {
+    fn with_paths(mut self, paths: Arc<[PathBuf]>) -> Self {
         self.paths = paths;
         self
     }

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -41,7 +41,6 @@ struct LazyParquetReader {
     args: ScanArgsParquet,
     path: PathBuf,
     paths: Arc<[PathBuf]>,
-    known_schema: Option<SchemaRef>,
 }
 
 impl LazyParquetReader {
@@ -50,7 +49,6 @@ impl LazyParquetReader {
             args,
             path,
             paths: Arc::new([]),
-            known_schema: None,
         }
     }
 }
@@ -94,7 +92,6 @@ impl LazyFileListReader for LazyParquetReader {
         if let Some(row_count) = row_count {
             lf = lf.with_row_count(&row_count.name, Some(row_count.offset))
         }
-        self.known_schema = Some(lf.schema()?);
 
         lf.opt_state.file_caching = true;
         Ok(lf)

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -65,7 +65,7 @@ impl LazyFileListReader for LazyParquetReader {
         self.finish_no_glob()
     }
 
-    fn finish_no_glob(mut self) -> PolarsResult<LazyFrame> {
+    fn finish_no_glob(self) -> PolarsResult<LazyFrame> {
         let row_count = self.args.row_count;
 
         let paths = if self.paths.is_empty() {

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -40,7 +40,7 @@ impl Default for ScanArgsParquet {
 struct LazyParquetReader {
     args: ScanArgsParquet,
     path: PathBuf,
-    paths: Vec<PathBuf>,
+    paths: Arc<[PathBuf]>,
     known_schema: Option<SchemaRef>,
 }
 
@@ -49,19 +49,34 @@ impl LazyParquetReader {
         Self {
             args,
             path,
-            paths: vec![],
+            paths: Arc::new([]),
             known_schema: None,
         }
     }
 }
 
 impl LazyFileListReader for LazyParquetReader {
+    /// Get the final [LazyFrame].
+    fn finish(mut self) -> PolarsResult<LazyFrame> {
+        if let Some(paths) = self.iter_paths()? {
+            let paths = paths
+                .into_iter()
+                .collect::<PolarsResult<Arc<[PathBuf]>>>()?;
+            self.paths = paths;
+        }
+        self.finish_no_glob()
+    }
+
     fn finish_no_glob(mut self) -> PolarsResult<LazyFrame> {
-        let known_schema = self.known_schema();
         let row_count = self.args.row_count;
-        let path = self.path;
+
+        let paths = if self.paths.is_empty() {
+            Arc::new([self.path]) as Arc<[PathBuf]>
+        } else {
+            self.paths
+        };
         let mut lf: LazyFrame = LogicalPlanBuilder::scan_parquet(
-            path,
+            paths,
             self.args.n_rows,
             self.args.cache,
             self.args.parallel,
@@ -71,7 +86,6 @@ impl LazyFileListReader for LazyParquetReader {
             self.args.cloud_options,
             self.args.use_statistics,
             self.args.hive_partitioning,
-            known_schema,
         )?
         .build()
         .into();
@@ -99,7 +113,7 @@ impl LazyFileListReader for LazyParquetReader {
         self
     }
 
-    fn with_paths(mut self, paths: Vec<PathBuf>) -> Self {
+    fn with_paths(mut self, paths: Arc<[PathBuf]>) -> Self {
         self.paths = paths;
         self
     }
@@ -121,13 +135,6 @@ impl LazyFileListReader for LazyParquetReader {
         self.args.n_rows
     }
 
-    fn known_schema(&self) -> Option<SchemaRef> {
-        self.known_schema.clone()
-    }
-    fn set_known_schema(&mut self, known_schema: SchemaRef) {
-        self.known_schema = Some(known_schema);
-    }
-
     fn row_count(&self) -> Option<&RowCount> {
         self.args.row_count.as_ref()
     }
@@ -140,7 +147,7 @@ impl LazyFrame {
     }
 
     /// Create a LazyFrame directly from a parquet scan.
-    pub fn scan_parquet_files(paths: Vec<PathBuf>, args: ScanArgsParquet) -> PolarsResult<Self> {
+    pub fn scan_parquet_files(paths: Arc<[PathBuf]>, args: ScanArgsParquet) -> PolarsResult<Self> {
         LazyParquetReader::new(PathBuf::new(), args)
             .with_paths(paths)
             .finish()

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -103,9 +103,8 @@ where
                     cloud_options,
                     metadata,
                 } => {
-                    assert_eq!(paths.len(), 1);
                     let src = sources::ParquetSource::new(
-                        paths[0].clone(),
+                        paths,
                         parquet_options,
                         cloud_options,
                         metadata,

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -151,7 +151,7 @@ impl LogicalPlanBuilder {
         use polars_io::{is_cloud_url, SerReader as _};
 
         let paths = paths.into();
-        polars_ensure!(paths.len() > 1, ComputeError: "expected at least 1 path");
+        polars_ensure!(paths.len() >= 1, ComputeError: "expected at least 1 path");
 
         // Use first path to get schema.
         let path = &paths[0];

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -136,8 +136,8 @@ impl LogicalPlanBuilder {
 
     #[cfg(any(feature = "parquet", feature = "parquet_async"))]
     #[allow(clippy::too_many_arguments)]
-    pub fn scan_parquet<P: Into<std::path::PathBuf>>(
-        path: P,
+    pub fn scan_parquet<P: Into<Arc<[std::path::PathBuf]>>>(
+        paths: P,
         n_rows: Option<usize>,
         cache: bool,
         parallel: polars_io::parquet::ParallelStrategy,
@@ -147,22 +147,23 @@ impl LogicalPlanBuilder {
         cloud_options: Option<CloudOptions>,
         use_statistics: bool,
         hive_partitioning: bool,
-        // used to prevent multiple cloud calls
-        known_schema: Option<SchemaRef>,
     ) -> PolarsResult<Self> {
         use polars_io::{is_cloud_url, SerReader as _};
 
-        let path = path.into();
-        let (schema, num_rows, metadata) = if is_cloud_url(&path) {
+        let paths = paths.into();
+        polars_ensure!(paths.len() > 1, ComputeError: "expected at least 1 path");
+
+        // Use first path to get schema.
+        let path = &paths[0];
+
+        let (schema, num_rows, metadata) = if is_cloud_url(path) {
             #[cfg(not(feature = "cloud"))]
             panic!(
                 "One or more of the cloud storage features ('aws', 'gcp', ...) must be enabled."
             );
 
             #[cfg(feature = "cloud")]
-            if let Some(known_schema) = known_schema {
-                (known_schema, None, None)
-            } else {
+            {
                 let uri = path.to_string_lossy();
                 get_runtime().block_on(async {
                     let mut reader =
@@ -176,7 +177,7 @@ impl LogicalPlanBuilder {
                 })?
             }
         } else {
-            let file = polars_utils::open_file(&path)?;
+            let file = polars_utils::open_file(path)?;
             let mut reader = ParquetReader::new(file);
             (
                 prepare_schema(reader.schema()?, row_count.as_ref()),
@@ -201,7 +202,7 @@ impl LogicalPlanBuilder {
             hive_partitioning,
         };
         Ok(LogicalPlan::Scan {
-            paths: Arc::new([path]),
+            paths,
             file_info,
             file_options: options,
             predicate: None,

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -188,8 +188,10 @@ impl LogicalPlanBuilder {
 
         let mut file_info = FileInfo::new(schema, (num_rows, num_rows.unwrap_or(0)));
 
+        // We set the hive partitions of the first path to determine the schema.
+        // On iteration the partition values will be re-set per file.
         if hive_partitioning {
-            file_info.set_hive_partitions(path.as_path());
+            file_info.init_hive_partitions(path.as_path());
         }
 
         let options = FileScanOptions {

--- a/crates/polars-plan/src/logical_plan/file_scan.rs
+++ b/crates/polars-plan/src/logical_plan/file_scan.rs
@@ -50,6 +50,16 @@ impl PartialEq for FileScan {
 }
 
 impl FileScan {
+    pub(crate) fn remove_metadata(&mut self) {
+        match self {
+            #[cfg(feature = "parquet")]
+            Self::Parquet { metadata, .. } => {
+                *metadata = None;
+            },
+            _ => {},
+        }
+    }
+
     pub(crate) fn skip_rows(&self) -> usize {
         #[allow(unreachable_patterns)]
         match self {

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -228,7 +228,7 @@ impl<'a> PredicatePushDown<'a> {
                 mut paths,
                 mut file_info,
                 predicate,
-                scan_type,
+                mut scan_type,
                 file_options: options,
                 output_schema
             } => {
@@ -250,8 +250,11 @@ impl<'a> PredicatePushDown<'a> {
                                 }
                             }
 
-                            if self.verbose && paths.len() != new_paths.len() {
-                                eprintln!("hive partitioning: skipped {} files, first file : {}", paths.len() - new_paths.len(), paths[0].display())
+                            if paths.len() != new_paths.len() {
+                                if self.verbose {
+                                    eprintln!("hive partitioning: skipped {} files, first file : {}", paths.len() - new_paths.len(), paths[0].display())
+                                }
+                                scan_type.remove_metadata();
                             }
                             if paths.is_empty() {
                                 let schema = output_schema.as_ref().unwrap_or(&file_info.schema);

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -90,7 +90,7 @@ pub struct IpcScanOptions {
     pub memmap: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 /// Generic options for all file types
 pub struct FileScanOptions {

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -40,7 +40,7 @@ pub struct CsvParserOptions {
 }
 
 #[cfg(feature = "parquet")]
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Copy)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct ParquetOptions {
     pub parallel: polars_io::parquet::ParallelStrategy,

--- a/crates/polars-plan/src/logical_plan/schema.rs
+++ b/crates/polars-plan/src/logical_plan/schema.rs
@@ -41,7 +41,7 @@ impl LogicalPlan {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FileInfo {
     pub schema: SchemaRef,
@@ -79,15 +79,13 @@ impl FileInfo {
         let new = hive::HivePartitions::parse_url(url);
 
         match (&mut self.hive_parts, new) {
-            (Some(current), Some(new)) => {
-                match Arc::get_mut(current) {
-                    Some(current) => {
-                        *current = new;
-                    },
-                    _ => {
-                        *current = Arc::new(new);
-                    }
-                }
+            (Some(current), Some(new)) => match Arc::get_mut(current) {
+                Some(current) => {
+                    *current = new;
+                },
+                _ => {
+                    *current = Arc::new(new);
+                },
             },
             (_, new) => self.hive_parts = new.map(Arc::new),
         }

--- a/crates/polars-plan/src/logical_plan/schema.rs
+++ b/crates/polars-plan/src/logical_plan/schema.rs
@@ -64,13 +64,33 @@ impl FileInfo {
         }
     }
 
-    pub fn set_hive_partitions(&mut self, url: &Path) {
+    /// Updates the statistics and merges the hive partitions schema with the file one.
+    pub fn init_hive_partitions(&mut self, url: &Path) {
         self.hive_parts = hive::HivePartitions::parse_url(url).map(|hive_parts| {
             let schema = Arc::make_mut(&mut self.schema);
             schema.merge(hive_parts.get_statistics().schema().clone());
 
             Arc::new(hive_parts)
         });
+    }
+
+    /// Updates the statistics, but not the schema.
+    pub fn update_hive_partitions(&mut self, url: &Path) {
+        let new = hive::HivePartitions::parse_url(url);
+
+        match (&mut self.hive_parts, new) {
+            (Some(current), Some(new)) => {
+                match Arc::get_mut(current) {
+                    Some(current) => {
+                        *current = new;
+                    },
+                    _ => {
+                        *current = Arc::new(new);
+                    }
+                }
+            },
+            (_, new) => self.hive_parts = new.map(Arc::new),
+        }
     }
 }
 

--- a/crates/polars-plan/src/logical_plan/schema.rs
+++ b/crates/polars-plan/src/logical_plan/schema.rs
@@ -45,11 +45,11 @@ impl LogicalPlan {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct FileInfo {
     pub schema: SchemaRef,
-    // Stores the schema used for the reader, as the main schema can contain
-    // extra hive columns.
+    /// Stores the schema used for the reader, as the main schema can contain
+    /// extra hive columns.
     pub reader_schema: SchemaRef,
-    // - known size
-    // - estimated size
+    /// - known size
+    /// - estimated size
     pub row_estimation: (Option<usize>, usize),
     pub hive_parts: Option<Arc<hive::HivePartitions>>,
 }

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1750,6 +1750,7 @@ version = "0.33.2"
 dependencies = [
  "ahash",
  "bitflags 2.4.0",
+ "futures",
  "glob",
  "once_cell",
  "polars-arrow",

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -306,7 +306,7 @@ impl PyLazyFrame {
         let lf = if path.is_some() {
             LazyFrame::scan_parquet(first_path, args)
         } else {
-            LazyFrame::scan_parquet_files(paths, args)
+            LazyFrame::scan_parquet_files(Arc::from(paths), args)
         }
         .map_err(PyPolarsErr::from)?;
         Ok(lf.into())

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -128,7 +128,7 @@ impl PyLazyFrame {
         let r = if let Some(path) = &path {
             LazyJsonLineReader::new(path)
         } else {
-            LazyJsonLineReader::new_paths(paths)
+            LazyJsonLineReader::new_paths(paths.into())
         };
 
         let lf = r
@@ -197,7 +197,7 @@ impl PyLazyFrame {
         let r = if let Some(path) = path.as_ref() {
             LazyCsvReader::new(path)
         } else {
-            LazyCsvReader::new_paths(paths)
+            LazyCsvReader::new_paths(paths.into())
         };
 
         let mut r = r
@@ -336,7 +336,7 @@ impl PyLazyFrame {
         let lf = if let Some(path) = &path {
             LazyFrame::scan_ipc(path, args)
         } else {
-            LazyFrame::scan_ipc_files(paths, args)
+            LazyFrame::scan_ipc_files(paths.into(), args)
         }
         .map_err(PyPolarsErr::from)?;
         Ok(lf.into())

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -406,7 +406,9 @@ def test_fetch_union(tmp_path: Path) -> None:
     expected = pl.DataFrame({"a": [0], "b": [1]})
     assert_frame_equal(result_one, expected)
 
-    expected = pl.DataFrame({"a": [0, 3], "b": [1, 4]})
+    # Both fetch 1 per file or 1 per dataset would be ok, as we don't guarantee anything
+    # currently we have one per dataset.
+    expected = pl.DataFrame({"a": [0], "b": [1]})
     assert_frame_equal(result_glob, expected)
 
 


### PR DESCRIPTION
This will amortize the dag cost and ensures we can run aysync on a single runtime.