### PR TITLE
depr(python): Rename `shift` parameter from `periods` to `n`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7456,13 +7456,14 @@ class DataFrame:
 
         return partitions
 
-    def shift(self, periods: int) -> Self:
+    @deprecate_renamed_parameter("periods", "n", version="0.19.11")
+    def shift(self, n: int = 1) -> Self:
         """
-        Shift values by the given period.
+        Shift values by the given number of places.
 
         Parameters
         ----------
-        periods
+        n
             Number of places to shift (may be negative).
 
         See Also
@@ -7478,7 +7479,7 @@ class DataFrame:
         ...         "ham": ["a", "b", "c"],
         ...     }
         ... )
-        >>> df.shift(periods=1)
+        >>> df.shift(1)
         shape: (3, 3)
         ┌──────┬──────┬──────┐
         │ foo  ┆ bar  ┆ ham  │
@@ -7489,7 +7490,7 @@ class DataFrame:
         │ 1    ┆ 6    ┆ a    │
         │ 2    ┆ 7    ┆ b    │
         └──────┴──────┴──────┘
-        >>> df.shift(periods=-1)
+        >>> df.shift(-1)
         shape: (3, 3)
         ┌──────┬──────┬──────┐
         │ foo  ┆ bar  ┆ ham  │
@@ -7502,22 +7503,23 @@ class DataFrame:
         └──────┴──────┴──────┘
 
         """
-        return self._from_pydf(self._df.shift(periods))
+        return self._from_pydf(self._df.shift(n))
 
+    @deprecate_renamed_parameter("periods", "n", version="0.19.11")
     def shift_and_fill(
         self,
         fill_value: int | str | float,
         *,
-        periods: int = 1,
+        n: int = 1,
     ) -> DataFrame:
         """
-        Shift the values by a given period and fill the resulting null values.
+        Shift values by the given number of places and fill the resulting null values.
 
         Parameters
         ----------
         fill_value
             fill None values with this value.
-        periods
+        n
             Number of places to shift (may be negative).
 
         Examples
@@ -7529,7 +7531,7 @@ class DataFrame:
         ...         "ham": ["a", "b", "c"],
         ...     }
         ... )
-        >>> df.shift_and_fill(periods=1, fill_value=0)
+        >>> df.shift_and_fill(n=1, fill_value=0)
         shape: (3, 3)
         ┌─────┬─────┬─────┐
         │ foo ┆ bar ┆ ham │
@@ -7543,9 +7545,7 @@ class DataFrame:
 
         """
         return (
-            self.lazy()
-            .shift_and_fill(fill_value=fill_value, periods=periods)
-            .collect(_eager=True)
+            self.lazy().shift_and_fill(fill_value=fill_value, n=n).collect(_eager=True)
         )
 
     def is_duplicated(self) -> Series:

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7457,7 +7457,7 @@ class DataFrame:
         return partitions
 
     @deprecate_renamed_parameter("periods", "n", version="0.19.11")
-    def shift(self, n: int = 1) -> Self:
+    def shift(self, n: int = 1) -> DataFrame:
         """
         Shift values by the given number of places.
 
@@ -7503,7 +7503,7 @@ class DataFrame:
         └──────┴──────┴──────┘
 
         """
-        return self._from_pydf(self._df.shift(n))
+        return self.lazy().shift(n=n).collect(_eager=True)
 
     @deprecate_renamed_parameter("periods", "n", version="0.19.11")
     def shift_and_fill(

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2354,7 +2354,7 @@ class Expr:
     @deprecate_renamed_parameter("periods", "n", version="0.19.11")
     def shift(self, n: int = 1) -> Self:
         """
-        Shift the values by a given period.
+        Shift values by the given number of places.
 
         Parameters
         ----------
@@ -2388,7 +2388,7 @@ class Expr:
         n: int = 1,
     ) -> Self:
         """
-        Shift the values by a given period and fill the resulting null values.
+        Shift values by the given number of places and fill the resulting null values.
 
         Parameters
         ----------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2351,13 +2351,14 @@ class Expr:
             indices_lit = parse_as_expression(indices)  # type: ignore[arg-type]
         return self._from_pyexpr(self._pyexpr.take(indices_lit))
 
-    def shift(self, periods: int = 1) -> Self:
+    @deprecate_renamed_parameter("periods", "n", version="0.19.11")
+    def shift(self, n: int = 1) -> Self:
         """
         Shift the values by a given period.
 
         Parameters
         ----------
-        periods
+        n
             Number of places to shift (may be negative).
 
         Examples
@@ -2377,13 +2378,14 @@ class Expr:
         └─────┴─────────────┘
 
         """
-        return self._from_pyexpr(self._pyexpr.shift(periods))
+        return self._from_pyexpr(self._pyexpr.shift(n))
 
+    @deprecate_renamed_parameter("periods", "n", version="0.19.11")
     def shift_and_fill(
         self,
         fill_value: IntoExpr,
         *,
-        periods: int = 1,
+        n: int = 1,
     ) -> Self:
         """
         Shift the values by a given period and fill the resulting null values.
@@ -2392,13 +2394,13 @@ class Expr:
         ----------
         fill_value
             Fill None values with the result of this expression.
-        periods
+        n
             Number of places to shift (may be negative).
 
         Examples
         --------
         >>> df = pl.DataFrame({"foo": [1, 2, 3, 4]})
-        >>> df.with_columns(foo_shifted=pl.col("foo").shift_and_fill("a", periods=1))
+        >>> df.with_columns(foo_shifted=pl.col("foo").shift_and_fill("a", n=1))
         shape: (4, 2)
         ┌─────┬─────────────┐
         │ foo ┆ foo_shifted │
@@ -2413,7 +2415,7 @@ class Expr:
 
         """
         fill_value = parse_as_expression(fill_value, str_as_lit=True)
-        return self._from_pyexpr(self._pyexpr.shift_and_fill(periods, fill_value))
+        return self._from_pyexpr(self._pyexpr.shift_and_fill(n, fill_value))
 
     def fill_null(
         self,

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -718,7 +718,7 @@ class ExprListNameSpace:
     @deprecate_renamed_parameter("periods", "n", version="0.19.11")
     def shift(self, n: int | IntoExprColumn = 1) -> Expr:
         """
-        Shift values by the given period.
+        Shift values by the given number of places.
 
         Parameters
         ----------

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -7,7 +7,10 @@ import polars._reexport as pl
 from polars import functions as F
 from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
-from polars.utils.deprecation import deprecate_renamed_function
+from polars.utils.deprecation import (
+    deprecate_renamed_function,
+    deprecate_renamed_parameter,
+)
 
 if TYPE_CHECKING:
     from datetime import date, datetime, time
@@ -712,13 +715,14 @@ class ExprListNameSpace:
         """
         return wrap_expr(self._pyexpr.list_diff(n, null_behavior))
 
-    def shift(self, periods: int | IntoExprColumn = 1) -> Expr:
+    @deprecate_renamed_parameter("periods", "n", version="0.19.11")
+    def shift(self, n: int | IntoExprColumn = 1) -> Expr:
         """
         Shift values by the given period.
 
         Parameters
         ----------
-        periods
+        n
             Number of places to shift (may be negative).
 
         Examples
@@ -733,8 +737,8 @@ class ExprListNameSpace:
         ]
 
         """
-        periods = parse_as_expression(periods)
-        return wrap_expr(self._pyexpr.list_shift(periods))
+        n = parse_as_expression(n)
+        return wrap_expr(self._pyexpr.list_shift(n))
 
     def slice(
         self, offset: int | str | Expr, length: int | str | Expr | None = None

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4206,13 +4206,14 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         return self._from_pyldf(self._ldf.reverse())
 
-    def shift(self, periods: int) -> Self:
+    @deprecate_renamed_parameter("periods", "n", version="0.19.11")
+    def shift(self, n: int = 1) -> Self:
         """
-        Shift the values by a given period.
+        Shift values by the given number of places.
 
         Parameters
         ----------
-        periods
+        n
             Number of places to shift (may be negative).
 
         Examples
@@ -4223,7 +4224,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...         "b": [2, 4, 6],
         ...     }
         ... )
-        >>> lf.shift(periods=1).collect()
+        >>> lf.shift(1).collect()
         shape: (3, 2)
         ┌──────┬──────┐
         │ a    ┆ b    │
@@ -4234,7 +4235,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 1    ┆ 2    │
         │ 3    ┆ 4    │
         └──────┴──────┘
-        >>> lf.shift(periods=-1).collect()
+        >>> lf.shift(-1).collect()
         shape: (3, 2)
         ┌──────┬──────┐
         │ a    ┆ b    │
@@ -4247,22 +4248,23 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └──────┴──────┘
 
         """
-        return self._from_pyldf(self._ldf.shift(periods))
+        return self._from_pyldf(self._ldf.shift(n))
 
+    @deprecate_renamed_parameter("periods", "n", version="0.19.11")
     def shift_and_fill(
         self,
         fill_value: Expr | int | str | float,
         *,
-        periods: int = 1,
+        n: int = 1,
     ) -> Self:
         """
-        Shift the values by a given period and fill the resulting null values.
+        Shift values by the given number of places and fill the resulting null values.
 
         Parameters
         ----------
         fill_value
             fill None values with the result of this expression.
-        periods
+        n
             Number of places to shift (may be negative).
 
         Examples
@@ -4273,7 +4275,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...         "b": [2, 4, 6],
         ...     }
         ... )
-        >>> lf.shift_and_fill(fill_value=0, periods=1).collect()
+        >>> lf.shift_and_fill(fill_value=0, n=1).collect()
         shape: (3, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │
@@ -4284,7 +4286,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 1   ┆ 2   │
         │ 3   ┆ 4   │
         └─────┴─────┘
-        >>> lf.shift_and_fill(periods=-1, fill_value=0).collect()
+        >>> lf.shift_and_fill(fill_value=0, n=-1).collect()
         shape: (3, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │
@@ -4299,7 +4301,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         if not isinstance(fill_value, pl.Expr):
             fill_value = F.lit(fill_value)
-        return self._from_pyldf(self._ldf.shift_and_fill(periods, fill_value._pyexpr))
+        return self._from_pyldf(self._ldf.shift_and_fill(n, fill_value._pyexpr))
 
     def slice(self, offset: int, length: int | None = None) -> Self:
         """

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -5,7 +5,10 @@ from typing import TYPE_CHECKING, Any, Callable, Sequence
 from polars import functions as F
 from polars.series.utils import expr_dispatch
 from polars.utils._wrap import wrap_s
-from polars.utils.deprecation import deprecate_renamed_function
+from polars.utils.deprecation import (
+    deprecate_renamed_function,
+    deprecate_renamed_parameter,
+)
 
 if TYPE_CHECKING:
     from datetime import date, datetime, time
@@ -385,13 +388,14 @@ class ListNameSpace:
 
         """
 
-    def shift(self, periods: int | IntoExprColumn = 1) -> Series:
+    @deprecate_renamed_parameter("periods", "n", version="0.19.11")
+    def shift(self, n: int | IntoExprColumn = 1) -> Series:
         """
         Shift values by the given period.
 
         Parameters
         ----------
-        periods
+        n
             Number of places to shift (may be negative).
 
         Examples

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -391,7 +391,7 @@ class ListNameSpace:
     @deprecate_renamed_parameter("periods", "n", version="0.19.11")
     def shift(self, n: int | IntoExprColumn = 1) -> Series:
         """
-        Shift values by the given period.
+        Shift values by the given number of places.
 
         Parameters
         ----------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5085,7 +5085,7 @@ class Series:
     @deprecate_renamed_parameter("periods", "n", version="0.19.11")
     def shift(self, n: int = 1) -> Series:
         """
-        Shift the values by a given period.
+        Shift values by the given number of places.
 
         Parameters
         ----------
@@ -5122,7 +5122,7 @@ class Series:
         n: int = 1,
     ) -> Series:
         """
-        Shift the values by a given period and fill the resulting null values.
+        Shift values by the given number of places and fill the resulting null values.
 
         Parameters
         ----------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5082,14 +5082,20 @@ class Series:
             self._s.apply_lambda(function, pl_return_dtype, skip_nulls)
         )
 
-    def shift(self, periods: int = 1) -> Series:
+    @deprecate_renamed_parameter("periods", "n", version="0.19.11")
+    def shift(self, n: int = 1) -> Series:
         """
         Shift the values by a given period.
+
+        Parameters
+        ----------
+        n
+            Number of places to shift (may be negative).
 
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3])
-        >>> s.shift(periods=1)
+        >>> s.shift(1)
         shape: (3,)
         Series: 'a' [i64]
         [
@@ -5097,7 +5103,7 @@ class Series:
                 1
                 2
         ]
-        >>> s.shift(periods=-1)
+        >>> s.shift(-1)
         shape: (3,)
         Series: 'a' [i64]
         [
@@ -5106,18 +5112,14 @@ class Series:
                 null
         ]
 
-        Parameters
-        ----------
-        periods
-            Number of places to shift (may be negative).
-
         """
 
+    @deprecate_renamed_parameter("periods", "n", version="0.19.11")
     def shift_and_fill(
         self,
         fill_value: int | Expr,
         *,
-        periods: int = 1,
+        n: int = 1,
     ) -> Series:
         """
         Shift the values by a given period and fill the resulting null values.
@@ -5126,7 +5128,7 @@ class Series:
         ----------
         fill_value
             Fill None values with the result of this expression.
-        periods
+        n
             Number of places to shift (may be negative).
 
         """

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1229,10 +1229,6 @@ impl PyDataFrame {
         Ok(unsafe { std::mem::transmute::<Vec<DataFrame>, Vec<PyDataFrame>>(out) })
     }
 
-    pub fn shift(&self, periods: i64) -> Self {
-        self.df.shift(periods).into()
-    }
-
     pub fn lazy(&self) -> PyLazyFrame {
         self.df.clone().lazy().into()
     }

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -335,13 +335,13 @@ impl PyExpr {
         self.clone().inner.forward_fill(limit).into()
     }
 
-    fn shift(&self, periods: i64) -> Self {
-        self.clone().inner.shift(periods).into()
+    fn shift(&self, n: i64) -> Self {
+        self.clone().inner.shift(n).into()
     }
-    fn shift_and_fill(&self, periods: i64, fill_value: Self) -> Self {
+    fn shift_and_fill(&self, n: i64, fill_value: Self) -> Self {
         self.clone()
             .inner
-            .shift_and_fill(periods, fill_value.inner)
+            .shift_and_fill(n, fill_value.inner)
             .into()
     }
 

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -834,14 +834,14 @@ impl PyLazyFrame {
         ldf.reverse().into()
     }
 
-    fn shift(&self, periods: i64) -> Self {
+    fn shift(&self, n: i64) -> Self {
         let ldf = self.ldf.clone();
-        ldf.shift(periods).into()
+        ldf.shift(n).into()
     }
 
-    fn shift_and_fill(&self, periods: i64, fill_value: PyExpr) -> Self {
+    fn shift_and_fill(&self, n: i64, fill_value: PyExpr) -> Self {
         let ldf = self.ldf.clone();
-        ldf.shift_and_fill(periods, fill_value.inner).into()
+        ldf.shift_and_fill(n, fill_value.inner).into()
     }
 
     fn fill_nan(&self, fill_value: PyExpr) -> Self {

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2047,7 +2047,7 @@ def test_shift_and_fill() -> None:
             "ham": ["a", "b", "c"],
         }
     )
-    result = df.shift_and_fill(fill_value=0, periods=1)
+    result = df.shift_and_fill(fill_value=0, n=1)
     expected = pl.DataFrame(
         {
             "foo": [0, 1, 2],

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -146,7 +146,7 @@ def test_shift_and_fill() -> None:
         [pl.col("a").cast(pl.Categorical)]
     )
 
-    s = df.with_columns(pl.col("a").shift_and_fill("c", periods=1))["a"]
+    s = df.with_columns(pl.col("a").shift_and_fill("c", n=1))["a"]
     assert s.dtype == pl.Categorical
     assert s.to_list() == ["c", "a"]
 

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1421,7 +1421,7 @@ def test_supertype_timezones_4174() -> None:
 
     # test if this runs without error
     date_to_fill = df["dt_London"][0]
-    df.with_columns(df["dt_London"].shift_and_fill(date_to_fill, periods=1))
+    df.with_columns(df["dt_London"].shift_and_fill(date_to_fill, n=1))
 
 
 @pytest.mark.skip(reason="from_dicts cannot yet infer timezones")
@@ -1446,7 +1446,7 @@ def test_shift_and_fill_group_logicals() -> None:
         schema=["d", "s"],
     )
     assert df.select(
-        pl.col("d").shift_and_fill(pl.col("d").max(), periods=-1).over("s")
+        pl.col("d").shift_and_fill(pl.col("d").max(), n=-1).over("s")
     ).dtypes == [pl.Date]
 
 

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -22,7 +22,7 @@ def test_map_no_dtype_set_8531() -> None:
     df = pl.DataFrame({"a": [1]})
 
     result = df.with_columns(
-        pl.col("a").map_batches(lambda x: x * 2).shift_and_fill(fill_value=0, periods=0)
+        pl.col("a").map_batches(lambda x: x * 2).shift_and_fill(fill_value=0, n=0)
     )
 
     expected = pl.DataFrame({"a": [2]})

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -386,7 +386,7 @@ def test_rolling_slice_pushdown() -> None:
         )
         .agg(
             [
-                (pl.col("c") - pl.col("c").shift_and_fill(fill_value=0, periods=1))
+                (pl.col("c") - pl.col("c").shift_and_fill(fill_value=0, n=1))
                 .sum()
                 .alias("c")
             ]

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -320,7 +320,7 @@ def test_group_by_dynamic_slice_pushdown() -> None:
         df.sort("a")
         .group_by_dynamic("a", by="b", every="2i")
         .agg(
-            (pl.col("c") - pl.col("c").shift_and_fill(fill_value=0, periods=1))
+            (pl.col("c") - pl.col("c").shift_and_fill(fill_value=0, n=1))
             .sum()
             .alias("c")
         )

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -243,15 +243,11 @@ def test_window_functions_list_types() -> None:
     # as it is the same as shift.
     # that's why we don't add it to the allowed types.
     assert (
-        df.select(
-            pl.col("col_list").shift_and_fill(None, periods=1).alias("list_shifted")
-        )
+        df.select(pl.col("col_list").shift_and_fill(None, n=1).alias("list_shifted"))
     )["list_shifted"].to_list() == [None, [1], [1], [2]]
 
     assert (
-        df.select(
-            pl.col("col_list").shift_and_fill([], periods=1).alias("list_shifted")
-        )
+        df.select(pl.col("col_list").shift_and_fill([], n=1).alias("list_shifted"))
     )["list_shifted"].to_list() == [[], [1], [1], [2]]
 
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1085,7 +1085,7 @@ def test_shift() -> None:
     assert_series_equal(a.shift(1), pl.Series("a", [None, 1, 2]))
     assert_series_equal(a.shift(-1), pl.Series("a", [2, 3, None]))
     assert_series_equal(a.shift(-2), pl.Series("a", [3, None, None]))
-    assert_series_equal(a.shift_and_fill(10, periods=-1), pl.Series("a", [2, 3, 10]))
+    assert_series_equal(a.shift_and_fill(10, n=-1), pl.Series("a", [2, 3, 10]))
 
 
 def test_object() -> None:

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -289,12 +289,12 @@ def test_shift_and_fill() -> None:
 
     # use exprs
     out = ldf.with_columns(
-        pl.col("a").shift_and_fill(pl.col("b").mean(), periods=-2)
+        pl.col("a").shift_and_fill(pl.col("b").mean(), n=-2)
     ).collect()
     assert out["a"].null_count() == 0
 
     # use df method
-    out = ldf.shift_and_fill(pl.col("b").std(), periods=2).collect()
+    out = ldf.shift_and_fill(pl.col("b").std(), n=2).collect()
     assert out["a"].null_count() == 0
 
 


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/11874

The parameter should align with `diff`. As discussed in the linked issue, the name `periods` doesn't make much sense here. `n` is simpler and easy to understand in this context.

Also added a default value to `DataFrame.shift` and dispatch it to the lazy implementation.