### PR TITLE
fix(python): raise suitable error on invalid predicates passed to `filter` method

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2653,7 +2653,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         boolean_masks = []
 
         # no-op; immediately matches all rows
-        if predicates == (True,) and not constraints:
+        if len(predicates) == 1 and predicates[0] is True and not constraints:
             return self.clone()
 
         # note: identify masks separately from predicates

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2658,8 +2658,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         # note: identify masks separately from predicates
         for p in predicates:
-            if p is False:
-                # immediately disallows all rows
+            if p is False:  # immediately disallows all rows
                 return self.clear()  # type: ignore[return-value]
             elif p is True:
                 continue  # no-op; matches all rows
@@ -2668,7 +2667,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             elif (
                 (is_seq := is_sequence(p))
                 and any(not isinstance(x, pl.Expr) for x in p)
-            ) or (not is_seq and not isinstance(p, pl.Expr) and p not in self.columns):
+            ) or (
+                not is_seq
+                and not isinstance(p, pl.Expr)
+                and not (isinstance(p, str) and p in self.columns)
+            ):
                 err = (
                     f"Series(…, dtype={p.dtype})"
                     if isinstance(p, pl.Series)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -74,6 +74,7 @@ from polars.utils.various import (
     _process_null_values,
     find_stacklevel,
     is_bool_sequence,
+    is_sequence,
     normalize_filepath,
 )
 
@@ -2651,10 +2652,29 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         all_predicates: list[pl.Expr] = []
         boolean_masks = []
 
+        # no-op; immediately matches all rows
+        if predicates == (True,) and not constraints:
+            return self.clone()
+
         # note: identify masks separately from predicates
         for p in predicates:
-            if is_bool_sequence(p):
+            if p is False:
+                # immediately disallows all rows
+                return self.clear()  # type: ignore[return-value]
+            elif p is True:
+                continue  # no-op; matches all rows
+            elif is_bool_sequence(p, include_series=True):
                 boolean_masks.append(pl.Series(p, dtype=Boolean))
+            elif (
+                (is_seq := is_sequence(p))
+                and any(not isinstance(x, pl.Expr) for x in p)
+            ) or (not is_seq and not isinstance(p, pl.Expr) and p not in self.columns):
+                err = (
+                    f"Series(…, dtype={p.dtype})"
+                    if isinstance(p, pl.Series)
+                    else f"{p!r}"
+                )
+                raise ValueError(f"invalid predicate for `filter`: {err}")
             else:
                 all_predicates.extend(
                     wrap_expr(x) for x in parse_as_list_of_expressions(p)

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -28,7 +28,7 @@ from polars.dependencies import numpy as np
 if TYPE_CHECKING:
     from collections.abc import Reversible
 
-    from polars import DataFrame, Series
+    from polars import DataFrame
     from polars.type_aliases import PolarsDataType, PolarsIntegerType, SizeUnit
 
     if sys.version_info >= (3, 10):
@@ -67,22 +67,41 @@ def _is_iterable_of(val: Iterable[object], eltype: type | tuple[type, ...]) -> b
     return all(isinstance(x, eltype) for x in val)
 
 
-def is_bool_sequence(val: object) -> TypeGuard[Sequence[bool]]:
+def is_bool_sequence(
+    val: object, *, include_series: bool = False
+) -> TypeGuard[Sequence[bool]]:
     """Check whether the given sequence is a sequence of booleans."""
     if _check_for_numpy(val) and isinstance(val, np.ndarray):
         return val.dtype == np.bool_
+    elif include_series and isinstance(val, pl.Series):
+        return val.dtype == pl.Boolean
     return isinstance(val, Sequence) and _is_iterable_of(val, bool)
 
 
-def is_int_sequence(val: object) -> TypeGuard[Sequence[int]]:
+def is_int_sequence(
+    val: object, *, include_series: bool = False
+) -> TypeGuard[Sequence[int]]:
     """Check whether the given sequence is a sequence of integers."""
     if _check_for_numpy(val) and isinstance(val, np.ndarray):
         return np.issubdtype(val.dtype, np.integer)
+    elif include_series and isinstance(val, pl.Series):
+        return val.dtype in pl.INTEGER_DTYPES
     return isinstance(val, Sequence) and _is_iterable_of(val, int)
 
 
+def is_sequence(
+    val: object, *, include_series: bool = False
+) -> TypeGuard[Sequence[Any]]:
+    """Check whether the given input is a numpy array or python sequence."""
+    return (
+        (_check_for_numpy(val) and isinstance(val, np.ndarray))
+        or isinstance(val, (pl.Series, Sequence) if include_series else Sequence)
+        and not isinstance(val, str)
+    )
+
+
 def is_str_sequence(
-    val: object, *, allow_str: bool = False
+    val: object, *, allow_str: bool = False, include_series: bool = False
 ) -> TypeGuard[Sequence[str]]:
     """
     Check that `val` is a sequence of strings.
@@ -92,12 +111,16 @@ def is_str_sequence(
     """
     if allow_str is False and isinstance(val, str):
         return False
+    elif _check_for_numpy(val) and isinstance(val, np.ndarray):
+        return np.issubdtype(val.dtype, np.str_)
+    elif include_series and isinstance(val, pl.Series):
+        return val.dtype == pl.Utf8
     return isinstance(val, Sequence) and _is_iterable_of(val, str)
 
 
 def range_to_series(
     name: str, rng: range, dtype: PolarsIntegerType | None = None
-) -> Series:
+) -> pl.Series:
     """Fast conversion of the given range to a Series."""
     dtype = dtype or Int64
     return F.int_range(

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -1,8 +1,11 @@
 from datetime import date, datetime, timedelta
+from typing import Any
 
 import numpy as np
+import pytest
 
 import polars as pl
+from polars.testing import assert_frame_equal
 
 
 def test_predicate_4906() -> None:
@@ -203,3 +206,26 @@ def test_no_predicate_push_down_with_cast_and_alias_11883() -> None:
         .filter((pl.col("b") >= 1) & (pl.col("b") < 1))
     )
     assert 'SELECTION: "None"' in out.explain(predicate_pushdown=True)
+
+
+@pytest.mark.parametrize(
+    "predicate",
+    [
+        0,
+        "x",
+        [2, 3],
+        {"x": 1},
+        pl.Series([1, 2, 3]),
+        None,
+    ],
+)
+def test_invalid_filter_predicates(predicate: Any) -> None:
+    df = pl.DataFrame({"colx": ["aa", "bb", "cc", "dd"]})
+    with pytest.raises(ValueError, match="invalid predicate"):
+        df.filter(predicate)
+
+
+def test_fast_path_boolean_filter_predicates() -> None:
+    df = pl.DataFrame({"colx": ["aa", "bb", "cc", "dd"]})
+    assert_frame_equal(df.filter(False), pl.DataFrame(schema={"colx": pl.Utf8}))
+    assert_frame_equal(df.filter(True), df)

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, Sequence
 
+import numpy as np
 import pytest
 
 import polars as pl
@@ -13,7 +14,15 @@ from polars.utils.convert import (
     _timedelta_to_pl_duration,
     _timedelta_to_pl_timedelta,
 )
-from polars.utils.various import _in_notebook, parse_percentiles, parse_version
+from polars.utils.various import (
+    _in_notebook,
+    is_bool_sequence,
+    is_int_sequence,
+    is_sequence,
+    is_str_sequence,
+    parse_percentiles,
+    parse_version,
+)
 
 if TYPE_CHECKING:
     from polars.type_aliases import TimeUnit
@@ -149,3 +158,72 @@ def test_parse_percentiles(
 def test_parse_percentiles_errors(percentiles: Sequence[float] | float | None) -> None:
     with pytest.raises(ValueError):
         parse_percentiles(percentiles)
+
+
+@pytest.mark.parametrize(
+    ("sequence", "include_series", "expected"),
+    [
+        (pl.Series(["xx", "yy"]), True, False),
+        (pl.Series([True, False]), False, False),
+        (pl.Series([True, False]), True, True),
+        (np.array([False, True]), False, True),
+        (np.array([False, True]), True, True),
+        ([True, False], False, True),
+        (["xx", "yy"], False, False),
+        (True, False, False),
+    ],
+)
+def test_is_bool_sequence_check(
+    sequence: Any,
+    include_series: bool,
+    expected: bool,
+) -> None:
+    assert is_bool_sequence(sequence, include_series=include_series) == expected
+    if expected:
+        assert is_sequence(sequence, include_series=include_series)
+
+
+@pytest.mark.parametrize(
+    ("sequence", "include_series", "expected"),
+    [
+        (pl.Series(["xx", "yy"]), True, False),
+        (pl.Series([123, 345]), False, False),
+        (pl.Series([123, 345]), True, True),
+        (np.array([123, 345]), False, True),
+        (np.array([123, 345]), True, True),
+        (["xx", "yy"], False, False),
+        ([123, 456], False, True),
+        (123, False, False),
+    ],
+)
+def test_is_int_sequence_check(
+    sequence: Any,
+    include_series: bool,
+    expected: bool,
+) -> None:
+    assert is_int_sequence(sequence, include_series=include_series) == expected
+    if expected:
+        assert is_sequence(sequence, include_series=include_series)
+
+
+@pytest.mark.parametrize(
+    ("sequence", "include_series", "expected"),
+    [
+        (pl.Series(["xx", "yy"]), False, False),
+        (pl.Series(["xx", "yy"]), True, True),
+        (pl.Series([123, 345]), True, False),
+        (np.array(["xx", "yy"]), False, True),
+        (np.array(["xx", "yy"]), True, True),
+        (["xx", "yy"], False, True),
+        ([123, 456], False, False),
+        ("xx", False, False),
+    ],
+)
+def test_is_str_sequence_check(
+    sequence: Any,
+    include_series: bool,
+    expected: bool,
+) -> None:
+    assert is_str_sequence(sequence, include_series=include_series) == expected
+    if expected:
+        assert is_sequence(sequence, include_series=include_series)


### PR DESCRIPTION
## Updates

* Noticed we were accepting (and essentially ignoring) invalid predicates, returning _all_ rows instead of raising an error. 
* Codified the existing behaviour of `filter(True)` and `filter(False)` with dedicated fast-paths and new unit tests.
* Added test coverage for a number of utility functions (and marginally enhanced them).

## Example

```python
import polars as pl
df = pl.DataFrame({"colx": ["aa", "bb", "cc"]})
```

#### Before
```python
df.filter( 1, 2, 3, 4, 5, 6, 7 )
# shape: (3, 1)
# ┌──────┐
# │ colx │
# │ ---  │
# │ str  │
# ╞══════╡
# │ aa   │
# │ bb   │
# │ cc   │
# └──────┘
```

#### After
```
ValueError: Invalid predicate for `filter`: 1
```