### PR TITLE
docs(python): Add `set_fmt_table_cell_list_len` to API docs

### DIFF
--- a/py-polars/docs/source/reference/config.rst
+++ b/py-polars/docs/source/reference/config.rst
@@ -13,6 +13,7 @@ Config options
     Config.set_ascii_tables
     Config.set_fmt_float
     Config.set_fmt_str_lengths
+    Config.set_fmt_table_cell_list_len
     Config.set_streaming_chunk_size
     Config.set_tbl_cell_alignment
     Config.set_tbl_cols


### PR DESCRIPTION
Closes #11935 
Added set_fmt_table_cell_len to API docs folder