### PR TITLE
fix: fix take return dtype in group context.

### DIFF
--- a/crates/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -36,6 +36,7 @@ impl ApplyExpr {
         allow_threading: bool,
         input_schema: Option<SchemaRef>,
     ) -> Self {
+        #[cfg(debug_assertions)]
         if matches!(options.collect_groups, ApplyOptions::ElementWise) && options.returns_scalar {
             panic!("expr {} is not implemented correctly. 'returns_scalar' and 'elementwise' are mutually exclusive", expr)
         }

--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -302,7 +302,7 @@ impl WindowExpr {
                         },
                         Expr::Function { options, .. }
                         | Expr::AnonymousFunction { options, .. } => {
-                            if options.auto_explode
+                            if options.returns_scalar
                                 && matches!(options.collect_groups, ApplyOptions::ApplyGroups)
                             {
                                 agg_col = true;

--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -303,7 +303,7 @@ impl WindowExpr {
                         Expr::Function { options, .. }
                         | Expr::AnonymousFunction { options, .. } => {
                             if options.returns_scalar
-                                && matches!(options.collect_groups, ApplyOptions::ApplyGroups)
+                                && matches!(options.collect_groups, ApplyOptions::GroupWise)
                             {
                                 agg_col = true;
                             }

--- a/crates/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/expr.rs
@@ -462,8 +462,8 @@ pub(crate) fn create_physical_expr(
             output_type: _,
             options,
         } => {
-            let is_reducing_aggregation =
-                options.auto_explode && matches!(options.collect_groups, ApplyOptions::ApplyGroups);
+            let is_reducing_aggregation = options.returns_scalar
+                && matches!(options.collect_groups, ApplyOptions::ApplyGroups);
             // will be reset in the function so get that here
             let has_window = state.local.has_window;
             let input = create_physical_expressions_check_state(
@@ -478,19 +478,14 @@ pub(crate) fn create_physical_expr(
                 },
             )?;
 
-            Ok(Arc::new(ApplyExpr {
-                inputs: input,
+            Ok(Arc::new(ApplyExpr::new(
+                input,
                 function,
-                expr: node_to_expr(expression, expr_arena),
-                collect_groups: options.collect_groups,
-                auto_explode: options.auto_explode,
-                allow_rename: options.allow_rename,
-                pass_name_to_apply: options.pass_name_to_apply,
-                input_schema: schema.cloned(),
-                allow_threading: !state.has_cache,
-                check_lengths: options.check_lengths(),
-                allow_group_aware: options.allow_group_aware,
-            }))
+                node_to_expr(expression, expr_arena),
+                options,
+                !state.has_cache,
+                schema.cloned(),
+            )))
         },
         Function {
             input,
@@ -498,8 +493,8 @@ pub(crate) fn create_physical_expr(
             options,
             ..
         } => {
-            let is_reducing_aggregation =
-                options.auto_explode && matches!(options.collect_groups, ApplyOptions::ApplyGroups);
+            let is_reducing_aggregation = options.returns_scalar
+                && matches!(options.collect_groups, ApplyOptions::ApplyGroups);
             // will be reset in the function so get that here
             let has_window = state.local.has_window;
             let input = create_physical_expressions_check_state(
@@ -514,19 +509,14 @@ pub(crate) fn create_physical_expr(
                 },
             )?;
 
-            Ok(Arc::new(ApplyExpr {
-                inputs: input,
-                function: function.into(),
-                expr: node_to_expr(expression, expr_arena),
-                collect_groups: options.collect_groups,
-                auto_explode: options.auto_explode,
-                allow_rename: options.allow_rename,
-                pass_name_to_apply: options.pass_name_to_apply,
-                input_schema: schema.cloned(),
-                allow_threading: !state.has_cache,
-                check_lengths: options.check_lengths(),
-                allow_group_aware: options.allow_group_aware,
-            }))
+            Ok(Arc::new(ApplyExpr::new(
+                input,
+                function.into(),
+                node_to_expr(expression, expr_arena),
+                options,
+                !state.has_cache,
+                schema.cloned(),
+            )))
         },
         Slice {
             input,

--- a/crates/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/expr.rs
@@ -192,13 +192,18 @@ pub(crate) fn create_physical_expr(
                 node_to_expr(expression, expr_arena),
             )))
         },
-        Take { expr, idx } => {
+        Take {
+            expr,
+            idx,
+            returns_scalar,
+        } => {
             let phys_expr = create_physical_expr(expr, ctxt, expr_arena, schema, state)?;
             let phys_idx = create_physical_expr(idx, ctxt, expr_arena, schema, state)?;
             Ok(Arc::new(TakeExpr {
                 phys_expr,
                 idx: phys_idx,
                 expr: node_to_expr(expression, expr_arena),
+                returns_scalar,
             }))
         },
         SortBy {

--- a/crates/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/expr.rs
@@ -391,7 +391,7 @@ pub(crate) fn create_physical_expr(
                         vec![input],
                         function,
                         node_to_expr(expression, expr_arena),
-                        ApplyOptions::ApplyFlat,
+                        ApplyOptions::ElementWise,
                     )))
                 },
                 _ => {
@@ -462,8 +462,8 @@ pub(crate) fn create_physical_expr(
             output_type: _,
             options,
         } => {
-            let is_reducing_aggregation = options.returns_scalar
-                && matches!(options.collect_groups, ApplyOptions::ApplyGroups);
+            let is_reducing_aggregation =
+                options.returns_scalar && matches!(options.collect_groups, ApplyOptions::GroupWise);
             // will be reset in the function so get that here
             let has_window = state.local.has_window;
             let input = create_physical_expressions_check_state(
@@ -493,8 +493,8 @@ pub(crate) fn create_physical_expr(
             options,
             ..
         } => {
-            let is_reducing_aggregation = options.returns_scalar
-                && matches!(options.collect_groups, ApplyOptions::ApplyGroups);
+            let is_reducing_aggregation =
+                options.returns_scalar && matches!(options.collect_groups, ApplyOptions::GroupWise);
             // will be reset in the function so get that here
             let has_window = state.local.has_window;
             let input = create_physical_expressions_check_state(
@@ -543,7 +543,7 @@ pub(crate) fn create_physical_expr(
                 vec![input],
                 function,
                 node_to_expr(expression, expr_arena),
-                ApplyOptions::ApplyGroups,
+                ApplyOptions::GroupWise,
             )))
         },
         Wildcard => panic!("should be no wildcard at this point"),

--- a/crates/polars-lazy/src/physical_plan/planner/lp.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/lp.rs
@@ -94,7 +94,7 @@ fn partitionable_gb(
                                         )
                         },
                         Function {input, options, ..} => {
-                            matches!(options.collect_groups, ApplyOptions::ApplyFlat) && input.len() == 1 &&
+                            matches!(options.collect_groups, ApplyOptions::ElementWise) && input.len() == 1 &&
                                 !has_aggregation(input[0])
                         }
                         BinaryExpr {left, right, ..} => {

--- a/crates/polars-lazy/src/physical_plan/streaming/checks.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/checks.rs
@@ -29,9 +29,9 @@ pub(super) fn is_streamable(node: Node, expr_arena: &Arena<AExpr>, context: Cont
         {
             Context::Default => matches!(
                 options.collect_groups,
-                ApplyOptions::ApplyFlat | ApplyOptions::ApplyList
+                ApplyOptions::ElementWise | ApplyOptions::ApplyList
             ),
-            Context::Aggregation => matches!(options.collect_groups, ApplyOptions::ApplyFlat),
+            Context::Aggregation => matches!(options.collect_groups, ApplyOptions::ElementWise),
         },
         AExpr::Column(_) => {
             seen_column = true;

--- a/crates/polars-lazy/src/tests/aggregations.rs
+++ b/crates/polars-lazy/src/tests/aggregations.rs
@@ -421,7 +421,7 @@ fn take_aggregations() -> PolarsResult<()> {
         .clone()
         .lazy()
         .group_by([col("user")])
-        .agg([col("book").take(col("count").arg_max()).alias("fav_book")])
+        .agg([col("book").get(col("count").arg_max()).alias("fav_book")])
         .sort("user", Default::default())
         .collect()?;
 
@@ -460,7 +460,7 @@ fn take_aggregations() -> PolarsResult<()> {
     let out = df
         .lazy()
         .group_by([col("user")])
-        .agg([col("book").take(lit(0)).alias("take_lit")])
+        .agg([col("book").get(lit(0)).alias("take_lit")])
         .sort("user", Default::default())
         .collect()?;
 
@@ -484,7 +484,7 @@ fn test_take_consistency() -> PolarsResult<()> {
                 multithreaded: true,
                 maintain_order: false,
             })
-            .take(lit(0))])
+            .get(lit(0))])
         .collect()?;
 
     let a = out.column("A")?;
@@ -502,7 +502,7 @@ fn test_take_consistency() -> PolarsResult<()> {
                 multithreaded: true,
                 maintain_order: false,
             })
-            .take(lit(0))])
+            .get(lit(0))])
         .collect()?;
 
     let out = out.column("A")?;
@@ -521,10 +521,10 @@ fn test_take_consistency() -> PolarsResult<()> {
                     multithreaded: true,
                     maintain_order: false,
                 })
-                .take(lit(0))
+                .get(lit(0))
                 .alias("1"),
             col("A")
-                .take(
+                .get(
                     col("A")
                         .arg_sort(SortOptions {
                             descending: true,
@@ -532,7 +532,7 @@ fn test_take_consistency() -> PolarsResult<()> {
                             multithreaded: true,
                             maintain_order: false,
                         })
-                        .take(lit(0)),
+                        .get(lit(0)),
                 )
                 .alias("2"),
         ])
@@ -556,10 +556,7 @@ fn test_take_in_groups() -> PolarsResult<()> {
     let out = df
         .lazy()
         .sort("fruits", Default::default())
-        .select([col("B")
-            .take(lit(Series::new("", &[0u32])))
-            .over([col("fruits")])
-            .alias("taken")])
+        .select([col("B").get(lit(0u32)).over([col("fruits")]).alias("taken")])
         .collect()?;
 
     assert_eq!(

--- a/crates/polars-plan/src/dsl/binary.rs
+++ b/crates/polars-plan/src/dsl/binary.rs
@@ -9,7 +9,7 @@ impl BinaryNameSpace {
         self.0.map_many_private(
             FunctionExpr::BinaryExpr(BinaryFunction::Contains),
             &[pat],
-            true,
+            false,
             true,
         )
     }
@@ -19,7 +19,7 @@ impl BinaryNameSpace {
         self.0.map_many_private(
             FunctionExpr::BinaryExpr(BinaryFunction::EndsWith),
             &[sub],
-            true,
+            false,
             true,
         )
     }
@@ -29,7 +29,7 @@ impl BinaryNameSpace {
         self.0.map_many_private(
             FunctionExpr::BinaryExpr(BinaryFunction::StartsWith),
             &[sub],
-            true,
+            false,
             true,
         )
     }

--- a/crates/polars-plan/src/dsl/dt.rs
+++ b/crates/polars-plan/src/dsl/dt.rs
@@ -172,7 +172,7 @@ impl DateLikeNameSpace {
         self.0.map_many_private(
             FunctionExpr::TemporalExpr(TemporalFunction::Truncate(offset)),
             &[every, ambiguous],
-            true,
+            false,
             false,
         )
     }

--- a/crates/polars-plan/src/dsl/expr.rs
+++ b/crates/polars-plan/src/dsl/expr.rs
@@ -89,6 +89,7 @@ pub enum Expr {
     Take {
         expr: Box<Expr>,
         idx: Box<Expr>,
+        returns_scalar: bool,
     },
     SortBy {
         expr: Box<Expr>,

--- a/crates/polars-plan/src/dsl/functions/coerce.rs
+++ b/crates/polars-plan/src/dsl/functions/coerce.rs
@@ -10,7 +10,7 @@ pub fn as_struct(exprs: Vec<Expr>) -> Expr {
         options: FunctionOptions {
             input_wildcard_expansion: true,
             pass_name_to_apply: true,
-            collect_groups: ApplyOptions::ApplyFlat,
+            collect_groups: ApplyOptions::ElementWise,
             ..Default::default()
         },
     }

--- a/crates/polars-plan/src/dsl/functions/concat.rs
+++ b/crates/polars-plan/src/dsl/functions/concat.rs
@@ -12,7 +12,7 @@ pub fn concat_str<E: AsRef<[Expr]>>(s: E, separator: &str) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: true,
-            auto_explode: true,
+            returns_scalar: true,
             ..Default::default()
         },
     }

--- a/crates/polars-plan/src/dsl/functions/concat.rs
+++ b/crates/polars-plan/src/dsl/functions/concat.rs
@@ -10,7 +10,7 @@ pub fn concat_str<E: AsRef<[Expr]>>(s: E, separator: &str) -> Expr {
         input,
         function: StringFunction::ConcatHorizontal(separator).into(),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyFlat,
+            collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
             returns_scalar: true,
             ..Default::default()
@@ -58,7 +58,7 @@ pub fn concat_list<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> PolarsResult
         input: s,
         function: FunctionExpr::ListExpr(ListFunction::Concat),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             input_wildcard_expansion: true,
             ..Default::default()
         },
@@ -76,7 +76,7 @@ pub fn concat_expr<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(
         input: s,
         function: FunctionExpr::ConcatExpr(rechunk),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             input_wildcard_expansion: true,
             cast_to_supertypes: true,
             ..Default::default()

--- a/crates/polars-plan/src/dsl/functions/concat.rs
+++ b/crates/polars-plan/src/dsl/functions/concat.rs
@@ -12,7 +12,7 @@ pub fn concat_str<E: AsRef<[Expr]>>(s: E, separator: &str) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
-            returns_scalar: true,
+            returns_scalar: false,
             ..Default::default()
         },
     }

--- a/crates/polars-plan/src/dsl/functions/correlation.rs
+++ b/crates/polars-plan/src/dsl/functions/correlation.rs
@@ -13,7 +13,7 @@ pub fn cov(a: Expr, b: Expr) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
             cast_to_supertypes: true,
-            auto_explode: true,
+            returns_scalar: true,
             ..Default::default()
         },
     }
@@ -36,7 +36,7 @@ pub fn pearson_corr(a: Expr, b: Expr, ddof: u8) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
             cast_to_supertypes: true,
-            auto_explode: true,
+            returns_scalar: true,
             ..Default::default()
         },
     }
@@ -64,7 +64,7 @@ pub fn spearman_rank_corr(a: Expr, b: Expr, ddof: u8, propagate_nans: bool) -> E
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
             cast_to_supertypes: true,
-            auto_explode: true,
+            returns_scalar: true,
             ..Default::default()
         },
     }

--- a/crates/polars-plan/src/dsl/functions/correlation.rs
+++ b/crates/polars-plan/src/dsl/functions/correlation.rs
@@ -11,7 +11,7 @@ pub fn cov(a: Expr, b: Expr) -> Expr {
         input,
         function,
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             cast_to_supertypes: true,
             returns_scalar: true,
             ..Default::default()
@@ -34,7 +34,7 @@ pub fn pearson_corr(a: Expr, b: Expr, ddof: u8) -> Expr {
         input,
         function,
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             cast_to_supertypes: true,
             returns_scalar: true,
             ..Default::default()
@@ -62,7 +62,7 @@ pub fn spearman_rank_corr(a: Expr, b: Expr, ddof: u8, propagate_nans: bool) -> E
         input,
         function,
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             cast_to_supertypes: true,
             returns_scalar: true,
             ..Default::default()

--- a/crates/polars-plan/src/dsl/functions/horizontal.rs
+++ b/crates/polars-plan/src/dsl/functions/horizontal.rs
@@ -201,7 +201,7 @@ pub fn all_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
-            returns_scalar: true,
+            returns_scalar: false,
             cast_to_supertypes: false,
             allow_rename: true,
             ..Default::default()
@@ -220,7 +220,7 @@ pub fn any_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
-            returns_scalar: true,
+            returns_scalar: false,
             cast_to_supertypes: false,
             allow_rename: true,
             ..Default::default()
@@ -243,7 +243,7 @@ pub fn max_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
-            returns_scalar: true,
+            returns_scalar: false,
             allow_rename: true,
             ..Default::default()
         },
@@ -265,7 +265,7 @@ pub fn min_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
-            returns_scalar: true,
+            returns_scalar: false,
             allow_rename: true,
             ..Default::default()
         },
@@ -284,7 +284,7 @@ pub fn sum_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
-            returns_scalar: true,
+            returns_scalar: false,
             cast_to_supertypes: false,
             allow_rename: true,
             ..Default::default()

--- a/crates/polars-plan/src/dsl/functions/horizontal.rs
+++ b/crates/polars-plan/src/dsl/functions/horizontal.rs
@@ -46,7 +46,7 @@ where
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
             input_wildcard_expansion: true,
-            auto_explode: true,
+            returns_scalar: true,
             fmt_str: "fold",
             ..Default::default()
         },
@@ -89,7 +89,7 @@ where
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
             input_wildcard_expansion: true,
-            auto_explode: true,
+            returns_scalar: true,
             fmt_str: "reduce",
             ..Default::default()
         },
@@ -134,7 +134,7 @@ where
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
             input_wildcard_expansion: true,
-            auto_explode: true,
+            returns_scalar: true,
             fmt_str: "cumreduce",
             ..Default::default()
         },
@@ -183,7 +183,7 @@ where
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
             input_wildcard_expansion: true,
-            auto_explode: true,
+            returns_scalar: true,
             fmt_str: "cumfold",
             ..Default::default()
         },
@@ -201,7 +201,7 @@ pub fn all_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: true,
-            auto_explode: true,
+            returns_scalar: true,
             cast_to_supertypes: false,
             allow_rename: true,
             ..Default::default()
@@ -220,7 +220,7 @@ pub fn any_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: true,
-            auto_explode: true,
+            returns_scalar: true,
             cast_to_supertypes: false,
             allow_rename: true,
             ..Default::default()
@@ -243,7 +243,7 @@ pub fn max_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: true,
-            auto_explode: true,
+            returns_scalar: true,
             allow_rename: true,
             ..Default::default()
         },
@@ -265,7 +265,7 @@ pub fn min_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: true,
-            auto_explode: true,
+            returns_scalar: true,
             allow_rename: true,
             ..Default::default()
         },
@@ -284,7 +284,7 @@ pub fn sum_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyFlat,
             input_wildcard_expansion: true,
-            auto_explode: true,
+            returns_scalar: true,
             cast_to_supertypes: false,
             allow_rename: true,
             ..Default::default()

--- a/crates/polars-plan/src/dsl/functions/horizontal.rs
+++ b/crates/polars-plan/src/dsl/functions/horizontal.rs
@@ -44,7 +44,7 @@ where
         function,
         output_type: GetOutput::super_type(),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             input_wildcard_expansion: true,
             returns_scalar: true,
             fmt_str: "fold",
@@ -87,7 +87,7 @@ where
         function,
         output_type: GetOutput::super_type(),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             input_wildcard_expansion: true,
             returns_scalar: true,
             fmt_str: "reduce",
@@ -132,7 +132,7 @@ where
         function,
         output_type: cumfold_dtype(),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             input_wildcard_expansion: true,
             returns_scalar: true,
             fmt_str: "cumreduce",
@@ -181,7 +181,7 @@ where
         function,
         output_type: cumfold_dtype(),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             input_wildcard_expansion: true,
             returns_scalar: true,
             fmt_str: "cumfold",
@@ -199,7 +199,7 @@ pub fn all_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         input: exprs,
         function: FunctionExpr::Boolean(BooleanFunction::AllHorizontal),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyFlat,
+            collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
             returns_scalar: true,
             cast_to_supertypes: false,
@@ -218,7 +218,7 @@ pub fn any_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         input: exprs,
         function: FunctionExpr::Boolean(BooleanFunction::AnyHorizontal),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyFlat,
+            collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
             returns_scalar: true,
             cast_to_supertypes: false,
@@ -241,7 +241,7 @@ pub fn max_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         input: exprs,
         function: FunctionExpr::MaxHorizontal,
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyFlat,
+            collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
             returns_scalar: true,
             allow_rename: true,
@@ -263,7 +263,7 @@ pub fn min_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         input: exprs,
         function: FunctionExpr::MinHorizontal,
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyFlat,
+            collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
             returns_scalar: true,
             allow_rename: true,
@@ -282,7 +282,7 @@ pub fn sum_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
         input: exprs,
         function: FunctionExpr::SumHorizontal,
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyFlat,
+            collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
             returns_scalar: true,
             cast_to_supertypes: false,
@@ -301,7 +301,7 @@ pub fn coalesce(exprs: &[Expr]) -> Expr {
         input,
         function: FunctionExpr::Coalesce,
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyFlat,
+            collect_groups: ApplyOptions::ElementWise,
             cast_to_supertypes: true,
             input_wildcard_expansion: true,
             ..Default::default()

--- a/crates/polars-plan/src/dsl/functions/index.rs
+++ b/crates/polars-plan/src/dsl/functions/index.rs
@@ -22,7 +22,7 @@ pub fn arg_where<E: Into<Expr>>(condition: E) -> Expr {
         input: vec![condition],
         function: FunctionExpr::ArgWhere,
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             ..Default::default()
         },
     }

--- a/crates/polars-plan/src/dsl/functions/range.rs
+++ b/crates/polars-plan/src/dsl/functions/range.rs
@@ -56,7 +56,7 @@ pub fn date_range(
             time_zone,
         }),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             cast_to_supertypes: true,
             allow_rename: true,
             ..Default::default()
@@ -85,7 +85,7 @@ pub fn date_ranges(
             time_zone,
         }),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             cast_to_supertypes: true,
             allow_rename: true,
             ..Default::default()
@@ -114,7 +114,7 @@ pub fn datetime_range(
             time_zone,
         }),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             cast_to_supertypes: true,
             allow_rename: true,
             ..Default::default()
@@ -143,7 +143,7 @@ pub fn datetime_ranges(
             time_zone,
         }),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             cast_to_supertypes: true,
             allow_rename: true,
             ..Default::default()
@@ -160,7 +160,7 @@ pub fn time_range(start: Expr, end: Expr, interval: Duration, closed: ClosedWind
         input,
         function: FunctionExpr::Range(RangeFunction::TimeRange { interval, closed }),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             allow_rename: true,
             ..Default::default()
         },
@@ -176,7 +176,7 @@ pub fn time_ranges(start: Expr, end: Expr, interval: Duration, closed: ClosedWin
         input,
         function: FunctionExpr::Range(RangeFunction::TimeRanges { interval, closed }),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             allow_rename: true,
             ..Default::default()
         },

--- a/crates/polars-plan/src/dsl/functions/temporal.rs
+++ b/crates/polars-plan/src/dsl/functions/temporal.rs
@@ -141,7 +141,7 @@ pub fn datetime(args: DatetimeArgs) -> Expr {
             time_zone,
         }),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyFlat,
+            collect_groups: ApplyOptions::ElementWise,
             allow_rename: true,
             input_wildcard_expansion: true,
             fmt_str: "datetime",
@@ -359,7 +359,7 @@ pub fn duration(args: DurationArgs) -> Expr {
         function,
         output_type: GetOutput::from_type(DataType::Duration(args.time_unit)),
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyFlat,
+            collect_groups: ApplyOptions::ElementWise,
             input_wildcard_expansion: true,
             fmt_str: "duration",
             ..Default::default()

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -137,7 +137,7 @@ impl ListNameSpace {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Get),
             &[index],
-            true,
+            false,
             false,
         )
     }
@@ -152,7 +152,7 @@ impl ListNameSpace {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Take(null_on_oob)),
             &[index],
-            true,
+            false,
             false,
         )
     }
@@ -216,7 +216,7 @@ impl ListNameSpace {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Slice),
             &[offset, length],
-            true,
+            false,
             false,
         )
     }
@@ -296,7 +296,7 @@ impl ListNameSpace {
             .map_many_private(
                 FunctionExpr::ListExpr(ListFunction::Contains),
                 &[other],
-                true,
+                false,
                 false,
             )
             .with_function_options(|mut options| {
@@ -313,7 +313,7 @@ impl ListNameSpace {
             .map_many_private(
                 FunctionExpr::ListExpr(ListFunction::CountMatches),
                 &[other],
-                true,
+                false,
                 false,
             )
             .with_function_options(|mut options| {

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -349,7 +349,7 @@ impl Expr {
     /// Get the index value that has the minimum value.
     pub fn arg_min(self) -> Self {
         let options = FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             returns_scalar: true,
             fmt_str: "arg_min",
             ..Default::default()
@@ -370,7 +370,7 @@ impl Expr {
     /// Get the index value that has the maximum value.
     pub fn arg_max(self) -> Self {
         let options = FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             returns_scalar: true,
             fmt_str: "arg_max",
             ..Default::default()
@@ -391,7 +391,7 @@ impl Expr {
     /// Get the index values that would sort this expression.
     pub fn arg_sort(self, sort_options: SortOptions) -> Self {
         let options = FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             fmt_str: "arg_sort",
             ..Default::default()
         };
@@ -411,7 +411,7 @@ impl Expr {
             input: vec![self, element],
             function: FunctionExpr::SearchSorted(side),
             options: FunctionOptions {
-                collect_groups: ApplyOptions::ApplyGroups,
+                collect_groups: ApplyOptions::GroupWise,
                 returns_scalar: true,
                 fmt_str: "search_sorted",
                 cast_to_supertypes: true,
@@ -507,7 +507,7 @@ impl Expr {
             function: SpecialEq::new(Arc::new(f)),
             output_type,
             options: FunctionOptions {
-                collect_groups: ApplyOptions::ApplyFlat,
+                collect_groups: ApplyOptions::ElementWise,
                 fmt_str: "map",
                 ..Default::default()
             },
@@ -519,7 +519,7 @@ impl Expr {
             input: vec![self],
             function: function_expr,
             options: FunctionOptions {
-                collect_groups: ApplyOptions::ApplyFlat,
+                collect_groups: ApplyOptions::ElementWise,
                 ..Default::default()
             },
         }
@@ -540,7 +540,7 @@ impl Expr {
             function: SpecialEq::new(Arc::new(function)),
             output_type,
             options: FunctionOptions {
-                collect_groups: ApplyOptions::ApplyFlat,
+                collect_groups: ApplyOptions::ElementWise,
                 fmt_str: "",
                 ..Default::default()
             },
@@ -612,7 +612,7 @@ impl Expr {
             function: SpecialEq::new(Arc::new(f)),
             output_type,
             options: FunctionOptions {
-                collect_groups: ApplyOptions::ApplyGroups,
+                collect_groups: ApplyOptions::GroupWise,
                 fmt_str: "",
                 ..Default::default()
             },
@@ -624,7 +624,7 @@ impl Expr {
             input: vec![self],
             function: function_expr,
             options: FunctionOptions {
-                collect_groups: ApplyOptions::ApplyGroups,
+                collect_groups: ApplyOptions::GroupWise,
                 ..Default::default()
             },
         }
@@ -645,7 +645,7 @@ impl Expr {
             function: SpecialEq::new(Arc::new(function)),
             output_type,
             options: FunctionOptions {
-                collect_groups: ApplyOptions::ApplyGroups,
+                collect_groups: ApplyOptions::GroupWise,
                 fmt_str: "",
                 ..Default::default()
             },
@@ -667,7 +667,7 @@ impl Expr {
             input,
             function: function_expr,
             options: FunctionOptions {
-                collect_groups: ApplyOptions::ApplyGroups,
+                collect_groups: ApplyOptions::GroupWise,
                 returns_scalar: auto_explode,
                 cast_to_supertypes,
                 ..Default::default()
@@ -690,7 +690,7 @@ impl Expr {
             input,
             function: function_expr,
             options: FunctionOptions {
-                collect_groups: ApplyOptions::ApplyFlat,
+                collect_groups: ApplyOptions::ElementWise,
                 returns_scalar: auto_explode,
                 cast_to_supertypes,
                 ..Default::default()
@@ -768,7 +768,7 @@ impl Expr {
     /// Get the product aggregation of an expression.
     pub fn product(self) -> Self {
         let options = FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             returns_scalar: true,
             fmt_str: "product",
             ..Default::default()
@@ -962,7 +962,7 @@ impl Expr {
                 super_type: DataType::Unknown,
             },
             options: FunctionOptions {
-                collect_groups: ApplyOptions::ApplyFlat,
+                collect_groups: ApplyOptions::ElementWise,
                 cast_to_supertypes: true,
                 ..Default::default()
             },
@@ -1810,7 +1810,7 @@ where
         function: SpecialEq::new(Arc::new(function)),
         output_type,
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyFlat,
+            collect_groups: ApplyOptions::ElementWise,
             fmt_str: "",
             ..Default::default()
         },
@@ -1870,7 +1870,7 @@ where
         function: SpecialEq::new(Arc::new(function)),
         output_type,
         options: FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             // don't set this to true
             // this is for the caller to decide
             returns_scalar,

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -350,7 +350,7 @@ impl Expr {
     pub fn arg_min(self) -> Self {
         let options = FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
-            auto_explode: true,
+            returns_scalar: true,
             fmt_str: "arg_min",
             ..Default::default()
         };
@@ -371,7 +371,7 @@ impl Expr {
     pub fn arg_max(self) -> Self {
         let options = FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
-            auto_explode: true,
+            returns_scalar: true,
             fmt_str: "arg_max",
             ..Default::default()
         };
@@ -412,7 +412,7 @@ impl Expr {
             function: FunctionExpr::SearchSorted(side),
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyGroups,
-                auto_explode: true,
+                returns_scalar: true,
                 fmt_str: "search_sorted",
                 cast_to_supertypes: true,
                 ..Default::default()
@@ -668,7 +668,7 @@ impl Expr {
             function: function_expr,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyGroups,
-                auto_explode,
+                returns_scalar: auto_explode,
                 cast_to_supertypes,
                 ..Default::default()
             },
@@ -691,7 +691,7 @@ impl Expr {
             function: function_expr,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::ApplyFlat,
-                auto_explode,
+                returns_scalar: auto_explode,
                 cast_to_supertypes,
                 ..Default::default()
             },
@@ -769,7 +769,7 @@ impl Expr {
     pub fn product(self) -> Self {
         let options = FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
-            auto_explode: true,
+            returns_scalar: true,
             fmt_str: "product",
             ..Default::default()
         };
@@ -1019,7 +1019,7 @@ impl Expr {
     pub fn approx_n_unique(self) -> Self {
         self.apply_private(FunctionExpr::ApproxNUnique)
             .with_function_options(|mut options| {
-                options.auto_explode = true;
+                options.returns_scalar = true;
                 options
             })
     }
@@ -1558,7 +1558,7 @@ impl Expr {
     pub fn skew(self, bias: bool) -> Expr {
         self.apply_private(FunctionExpr::Skew(bias))
             .with_function_options(|mut options| {
-                options.auto_explode = true;
+                options.returns_scalar = true;
                 options
             })
     }
@@ -1574,7 +1574,7 @@ impl Expr {
     pub fn kurtosis(self, fisher: bool, bias: bool) -> Expr {
         self.apply_private(FunctionExpr::Kurtosis(fisher, bias))
             .with_function_options(|mut options| {
-                options.auto_explode = true;
+                options.returns_scalar = true;
                 options
             })
     }
@@ -1644,7 +1644,7 @@ impl Expr {
     pub fn any(self, ignore_nulls: bool) -> Self {
         self.apply_private(BooleanFunction::Any { ignore_nulls }.into())
             .with_function_options(|mut opt| {
-                opt.auto_explode = true;
+                opt.returns_scalar = true;
                 opt
             })
     }
@@ -1659,7 +1659,7 @@ impl Expr {
     pub fn all(self, ignore_nulls: bool) -> Self {
         self.apply_private(BooleanFunction::All { ignore_nulls }.into())
             .with_function_options(|mut opt| {
-                opt.auto_explode = true;
+                opt.returns_scalar = true;
                 opt
             })
     }
@@ -1714,7 +1714,7 @@ impl Expr {
     pub fn entropy(self, base: f64, normalize: bool) -> Self {
         self.apply_private(FunctionExpr::Entropy { base, normalize })
             .with_function_options(|mut options| {
-                options.auto_explode = true;
+                options.returns_scalar = true;
                 options
             })
     }
@@ -1722,7 +1722,7 @@ impl Expr {
     pub fn null_count(self) -> Expr {
         self.apply_private(FunctionExpr::NullCount)
             .with_function_options(|mut options| {
-                options.auto_explode = true;
+                options.returns_scalar = true;
                 options
             })
     }
@@ -1837,7 +1837,7 @@ where
         output_type,
         options: FunctionOptions {
             collect_groups: ApplyOptions::ApplyList,
-            auto_explode: true,
+            returns_scalar: true,
             fmt_str: "",
             ..Default::default()
         },
@@ -1873,7 +1873,7 @@ where
             collect_groups: ApplyOptions::ApplyGroups,
             // don't set this to true
             // this is for the caller to decide
-            auto_explode: returns_scalar,
+            returns_scalar,
             fmt_str: "",
             ..Default::default()
         },

--- a/crates/polars-plan/src/dsl/python_udf.rs
+++ b/crates/polars-plan/src/dsl/python_udf.rs
@@ -205,7 +205,7 @@ impl Expr {
         let (collect_groups, name) = if agg_list {
             (ApplyOptions::ApplyList, MAP_LIST_NAME)
         } else {
-            (ApplyOptions::ApplyFlat, "python_udf")
+            (ApplyOptions::ElementWise, "python_udf")
         };
 
         let return_dtype = func.output_type.clone();

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -206,7 +206,7 @@ impl StringNameSpace {
         self.0
             .apply_private(StringFunction::ConcatVertical(delimiter.to_owned()).into())
             .with_function_options(|mut options| {
-                options.auto_explode = true;
+                options.returns_scalar = true;
                 options
             })
     }

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -13,7 +13,7 @@ impl StringNameSpace {
                 strict: false,
             }),
             &[pat],
-            true,
+            false,
             true,
         )
     }
@@ -28,7 +28,7 @@ impl StringNameSpace {
                 strict,
             }),
             &[pat],
-            true,
+            false,
             true,
         )
     }
@@ -38,7 +38,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::EndsWith),
             &[sub],
-            true,
+            false,
             true,
         )
     }
@@ -48,7 +48,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             FunctionExpr::StringExpr(StringFunction::StartsWith),
             &[sub],
-            true,
+            false,
             true,
         )
     }
@@ -131,7 +131,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             StringFunction::CountMatches(literal).into(),
             &[pat],
-            true,
+            false,
             false,
         )
     }
@@ -142,7 +142,7 @@ impl StringNameSpace {
         self.0.map_many_private(
             StringFunction::Strptime(dtype, options).into(),
             &[ambiguous],
-            true,
+            false,
             false,
         )
     }
@@ -207,6 +207,7 @@ impl StringNameSpace {
             .apply_private(StringFunction::ConcatVertical(delimiter.to_owned()).into())
             .with_function_options(|mut options| {
                 options.returns_scalar = true;
+                options.collect_groups = ApplyOptions::GroupWise;
                 options
             })
     }

--- a/crates/polars-plan/src/logical_plan/aexpr/mod.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/mod.rs
@@ -146,6 +146,7 @@ pub enum AExpr {
     Take {
         expr: Node,
         idx: Node,
+        returns_scalar: bool,
     },
     SortBy {
         expr: Node,
@@ -267,7 +268,7 @@ impl AExpr {
             },
             Cast { expr, .. } => container.push(*expr),
             Sort { expr, .. } => container.push(*expr),
-            Take { expr, idx } => {
+            Take { expr, idx, .. } => {
                 container.push(*idx);
                 // latest, so that it is popped first
                 container.push(*expr);
@@ -346,7 +347,7 @@ impl AExpr {
                 *left = inputs[1];
                 return self;
             },
-            Take { expr, idx } => {
+            Take { expr, idx, .. } => {
                 *idx = inputs[0];
                 *expr = inputs[1];
                 return self;

--- a/crates/polars-plan/src/logical_plan/conversion.rs
+++ b/crates/polars-plan/src/logical_plan/conversion.rs
@@ -31,9 +31,14 @@ pub fn to_aexpr(expr: Expr, arena: &mut Arena<AExpr>) -> Node {
             data_type,
             strict,
         },
-        Expr::Take { expr, idx } => AExpr::Take {
+        Expr::Take {
+            expr,
+            idx,
+            returns_scalar,
+        } => AExpr::Take {
             expr: to_aexpr(*expr, arena),
             idx: to_aexpr(*idx, arena),
+            returns_scalar,
         },
         Expr::Sort { expr, options } => AExpr::Sort {
             expr: to_aexpr(*expr, arena),
@@ -399,12 +404,17 @@ pub fn node_to_expr(node: Node, expr_arena: &Arena<AExpr>) -> Expr {
                 options,
             }
         },
-        AExpr::Take { expr, idx } => {
+        AExpr::Take {
+            expr,
+            idx,
+            returns_scalar,
+        } => {
             let expr = node_to_expr(expr, expr_arena);
             let idx = node_to_expr(idx, expr_arena);
             Expr::Take {
                 expr: Box::new(expr),
                 idx: Box::new(idx),
+                returns_scalar,
             }
         },
         AExpr::SortBy {

--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -278,8 +278,16 @@ impl Debug for Expr {
             Filter { input, by } => {
                 write!(f, "{input:?}.filter({by:?})")
             },
-            Take { expr, idx } => {
-                write!(f, "{expr:?}.take({idx:?})")
+            Take {
+                expr,
+                idx,
+                returns_scalar,
+            } => {
+                if *returns_scalar {
+                    write!(f, "{expr:?}.get({idx:?})")
+                } else {
+                    write!(f, "{expr:?}.take({idx:?})")
+                }
             },
             SubPlan(lf, _) => {
                 write!(f, ".subplan({lf:?})")

--- a/crates/polars-plan/src/logical_plan/iterator.rs
+++ b/crates/polars-plan/src/logical_plan/iterator.rs
@@ -15,7 +15,7 @@ macro_rules! push_expr {
             },
             Cast { expr, .. } => $push(expr),
             Sort { expr, .. } => $push(expr),
-            Take { expr, idx } => {
+            Take { expr, idx, .. } => {
                 $push(idx);
                 $push(expr);
             },

--- a/crates/polars-plan/src/logical_plan/optimizer/fused.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/fused.rs
@@ -4,7 +4,7 @@ pub struct FusedArithmetic {}
 
 fn get_expr(input: Vec<Node>, op: FusedOperator) -> AExpr {
     let mut options = FunctionOptions {
-        collect_groups: ApplyOptions::ApplyFlat,
+        collect_groups: ApplyOptions::ElementWise,
         cast_to_supertypes: true,
         ..Default::default()
     };

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
@@ -120,8 +120,8 @@ pub(super) fn predicate_is_pushdown_boundary(node: Node, expr_arena: &Arena<AExp
             | AExpr::Agg(_) // an aggregation needs all rows
             // Apply groups can be something like shift, sort, or an aggregation like skew
             // both need all values
-            | AExpr::AnonymousFunction {options: FunctionOptions { collect_groups: ApplyOptions::ApplyGroups, .. }, ..}
-            | AExpr::Function {options: FunctionOptions { collect_groups: ApplyOptions::ApplyGroups, .. }, ..}
+            | AExpr::AnonymousFunction {options: FunctionOptions { collect_groups: ApplyOptions::GroupWise, .. }, ..}
+            | AExpr::Function {options: FunctionOptions { collect_groups: ApplyOptions::GroupWise, .. }, ..}
             | AExpr::Explode {..}
             // A group_by needs all rows for aggregation
             | AExpr::Window {..}
@@ -150,8 +150,8 @@ pub(super) fn projection_is_definite_pushdown_boundary(
              Agg(_) // an aggregation needs all rows
             // Apply groups can be something like shift, sort, or an aggregation like skew
             // both need all values
-            | AnonymousFunction {options: FunctionOptions { collect_groups: ApplyOptions::ApplyGroups, .. }, ..}
-            | Function {options: FunctionOptions { collect_groups: ApplyOptions::ApplyGroups, .. }, ..}
+            | AnonymousFunction {options: FunctionOptions { collect_groups: ApplyOptions::GroupWise, .. }, ..}
+            | Function {options: FunctionOptions { collect_groups: ApplyOptions::GroupWise, .. }, ..}
             // still need to investigate this one
             | Explode {..}
             | Count

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
@@ -97,7 +97,7 @@ pub(super) fn predicate_is_sort_boundary(node: Node, expr_arena: &Arena<AExpr>) 
             // group sensitive and doesn't auto-explode (e.g. is a reduction/aggregation
             // like sum, min, etc).
             // function that match this are `cumsum`, `shift`, `sort`, etc.
-            options.is_groups_sensitive() && !options.auto_explode
+            options.is_groups_sensitive() && !options.returns_scalar
         },
         _ => false,
     };

--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -400,7 +400,7 @@ fn string_addition_to_linear_concat(
                     input: vec![left_ae, right_ae],
                     function: StringFunction::ConcatHorizontal("".to_string()).into(),
                     options: FunctionOptions {
-                        collect_groups: ApplyOptions::ApplyFlat,
+                        collect_groups: ApplyOptions::ElementWise,
                         input_wildcard_expansion: true,
                         returns_scalar: true,
                         ..Default::default()
@@ -558,7 +558,7 @@ impl OptimizationRule for SimplifyExprRule {
                         input: vec![*right],
                         function: BooleanFunction::IsNull.into(),
                         options: FunctionOptions {
-                            collect_groups: ApplyOptions::ApplyGroups,
+                            collect_groups: ApplyOptions::GroupWise,
                             ..Default::default()
                         },
                     }),
@@ -567,7 +567,7 @@ impl OptimizationRule for SimplifyExprRule {
                         input: vec![*left],
                         function: BooleanFunction::IsNull.into(),
                         options: FunctionOptions {
-                            collect_groups: ApplyOptions::ApplyGroups,
+                            collect_groups: ApplyOptions::GroupWise,
                             ..Default::default()
                         },
                     }),
@@ -576,7 +576,7 @@ impl OptimizationRule for SimplifyExprRule {
                         input: vec![*right],
                         function: BooleanFunction::IsNotNull.into(),
                         options: FunctionOptions {
-                            collect_groups: ApplyOptions::ApplyGroups,
+                            collect_groups: ApplyOptions::GroupWise,
                             ..Default::default()
                         },
                     }),
@@ -585,7 +585,7 @@ impl OptimizationRule for SimplifyExprRule {
                         input: vec![*left],
                         function: BooleanFunction::IsNotNull.into(),
                         options: FunctionOptions {
-                            collect_groups: ApplyOptions::ApplyGroups,
+                            collect_groups: ApplyOptions::GroupWise,
                             ..Default::default()
                         },
                     }),

--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -402,7 +402,7 @@ fn string_addition_to_linear_concat(
                     options: FunctionOptions {
                         collect_groups: ApplyOptions::ElementWise,
                         input_wildcard_expansion: true,
-                        returns_scalar: true,
+                        returns_scalar: false,
                         ..Default::default()
                     },
                 }),

--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -402,7 +402,7 @@ fn string_addition_to_linear_concat(
                     options: FunctionOptions {
                         collect_groups: ApplyOptions::ApplyFlat,
                         input_wildcard_expansion: true,
-                        auto_explode: true,
+                        returns_scalar: true,
                         ..Default::default()
                     },
                 }),

--- a/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_expr.rs
@@ -71,7 +71,7 @@ impl OptimizationRule for SlicePushDown {
                     })
                 },
                 m @ AnonymousFunction { options, .. }
-                    if matches!(options.collect_groups, ApplyOptions::ApplyFlat) =>
+                    if matches!(options.collect_groups, ApplyOptions::ElementWise) =>
                 {
                     if let AnonymousFunction {
                         input,

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -148,13 +148,13 @@ pub enum ApplyOptions {
     /// Collect groups to a list and apply the function over the groups.
     /// This can be important in aggregation context.
     // e.g. [g1, g1, g2] -> [[g1, g1], g2]
-    ApplyGroups,
+    GroupWise,
     // collect groups to a list and then apply
     // e.g. [g1, g1, g2] -> list([g1, g1, g2])
     ApplyList,
     // do not collect before apply
     // e.g. [g1, g1, g2] -> [g1, g1, g2]
-    ApplyFlat,
+    ElementWise,
 }
 
 // a boolean that can only be set to `false` safely
@@ -225,7 +225,7 @@ impl FunctionOptions {
     /// - Sorts
     /// - Counts
     pub fn is_groups_sensitive(&self) -> bool {
-        matches!(self.collect_groups, ApplyOptions::ApplyGroups)
+        matches!(self.collect_groups, ApplyOptions::GroupWise)
     }
 
     #[cfg(feature = "fused")]
@@ -240,7 +240,7 @@ impl FunctionOptions {
 impl Default for FunctionOptions {
     fn default() -> Self {
         FunctionOptions {
-            collect_groups: ApplyOptions::ApplyGroups,
+            collect_groups: ApplyOptions::GroupWise,
             input_wildcard_expansion: false,
             returns_scalar: false,
             fmt_str: "",

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -191,7 +191,7 @@ pub struct FunctionOptions {
     ///
     /// this also accounts for regex expansion
     pub input_wildcard_expansion: bool,
-    /// automatically explode on unit length it ran as final aggregation.
+    /// Automatically explode on unit length if it ran as final aggregation.
     ///
     /// this is the case for aggregations like sum, min, covariance etc.
     /// We need to know this because we cannot see the difference between
@@ -201,7 +201,7 @@ pub struct FunctionOptions {
     ///
     /// head_1(x) -> {1}
     /// sum(x) -> {4}
-    pub auto_explode: bool,
+    pub returns_scalar: bool,
     // if the expression and its inputs should be cast to supertypes
     pub cast_to_supertypes: bool,
     // The physical expression may rename the output of this function.
@@ -242,7 +242,7 @@ impl Default for FunctionOptions {
         FunctionOptions {
             collect_groups: ApplyOptions::ApplyGroups,
             input_wildcard_expansion: false,
-            auto_explode: false,
+            returns_scalar: false,
             fmt_str: "",
             cast_to_supertypes: false,
             allow_rename: false,

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -147,6 +147,17 @@ pub(crate) fn has_leaf_literal(e: &Expr) -> bool {
         },
     }
 }
+/// Check if leaf expression is a literal
+#[cfg(feature = "is_in")]
+pub(crate) fn all_leaf_literal(e: &Expr) -> bool {
+    match e {
+        Expr::Literal(_) => true,
+        _ => {
+            let roots = expr_to_root_column_exprs(e);
+            roots.iter().all(|e| matches!(e, Expr::Literal(_)))
+        },
+    }
+}
 
 pub fn has_null(current_expr: &Expr) -> bool {
     has_expr(current_expr, |e| {

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -99,7 +99,7 @@ pub(crate) fn aexpr_is_elementwise(current_node: Node, arena: &Arena<AExpr>) -> 
         use AExpr::*;
         match e {
             AnonymousFunction { options, .. } | Function { options, .. } => {
-                !matches!(options.collect_groups, ApplyOptions::ApplyGroups)
+                !matches!(options.collect_groups, ApplyOptions::GroupWise)
             },
             Column(_)
             | Alias(_, _)

--- a/py-polars/docs/source/reference/expressions/modify_select.rst
+++ b/py-polars/docs/source/reference/expressions/modify_select.rst
@@ -27,6 +27,7 @@ Manipulation/selection
     Expr.flatten
     Expr.floor
     Expr.forward_fill
+    Expr.get
     Expr.head
     Expr.inspect
     Expr.interpolate

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -322,6 +322,10 @@ impl PyExpr {
         self.clone().inner.take(idx.inner).into()
     }
 
+    fn get(&self, idx: Self) -> Self {
+        self.clone().inner.get(idx.inner).into()
+    }
+
     fn sort_by(&self, by: Vec<Self>, descending: Vec<bool>) -> Self {
         let by = by.into_iter().map(|e| e.inner).collect::<Vec<_>>();
         self.clone().inner.sort_by(by, descending).into()

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -895,7 +895,7 @@ impl PyExpr {
         kwargs: Vec<u8>,
         is_elementwise: bool,
         input_wildcard_expansion: bool,
-        auto_explode: bool,
+        returns_scalar: bool,
         cast_to_supertypes: bool,
     ) -> PyResult<Self> {
         use polars_plan::prelude::*;
@@ -922,7 +922,7 @@ impl PyExpr {
             options: FunctionOptions {
                 collect_groups,
                 input_wildcard_expansion,
-                auto_explode,
+                returns_scalar,
                 cast_to_supertypes,
                 ..Default::default()
             },

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -902,9 +902,9 @@ impl PyExpr {
         let inner = self.inner.clone();
 
         let collect_groups = if is_elementwise {
-            ApplyOptions::ApplyFlat
+            ApplyOptions::ElementWise
         } else {
-            ApplyOptions::ApplyGroups
+            ApplyOptions::GroupWise
         };
         let mut input = Vec::with_capacity(args.len() + 1);
         input.push(inner);

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -420,7 +420,7 @@ def test_take_misc(fruits_cars: pl.DataFrame) -> None:
         assert out[4, "B"].to_list() == [1, 4]
 
     out = df.sort("fruits").select(
-        [pl.col("B").reverse().take(pl.lit(1)).over("fruits"), "fruits"]
+        [pl.col("B").reverse().get(pl.lit(1)).over("fruits"), "fruits"]
     )
     assert out[0, "B"] == 3
     assert out[4, "B"] == 4

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -447,15 +447,19 @@ def test_list_function_group_awareness() -> None:
 
     assert df.group_by("group").agg(
         [
-            pl.col("a").implode().list.get(0).alias("get"),
-            pl.col("a").implode().list.take([0]).alias("take"),
-            pl.col("a").implode().list.slice(0, 3).alias("slice"),
+            pl.col("a").get(0).alias("get_scalar"),
+            pl.col("a").take([0]).alias("take_no_implode"),
+            pl.col("a").implode().list.get(0).alias("implode_get"),
+            pl.col("a").implode().list.take([0]).alias("implode_take"),
+            pl.col("a").implode().list.slice(0, 3).alias("implode_slice"),
         ]
     ).sort("group").to_dict(False) == {
         "group": [0, 1, 2],
-        "get": [100, 105, 100],
-        "take": [[100], [105], [100]],
-        "slice": [[100, 103], [105, 106, 105], [100, 102]],
+        "get_scalar": [100, 105, 100],
+        "take_no_implode": [[100], [105], [100]],
+        "implode_get": [[100], [105], [100]],
+        "implode_take": [[[100]], [[105]], [[100]]],
+        "implode_slice": [[[100, 103]], [[105, 106, 105]], [[100, 102]]],
     }
 
 

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -255,7 +255,7 @@ def test_err_on_implode_and_agg() -> None:
         pl.col("type").implode().list.head().alias("foo")
     ).to_dict(False) == {
         "type": ["water", "fire", "earth"],
-        "foo": [["water", "water"], ["fire"], ["earth"]],
+        "foo": [[["water", "water"]], [["fire"]], [["earth"]]],
     }
 
     # but not during a window function as the groups cannot be mapped back

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -269,7 +269,7 @@ def test_apply_after_take_in_group_by_3869() -> None:
         )
         .group_by("k", maintain_order=True)
         .agg(
-            pl.col("v").take(pl.col("t").arg_max()).sqrt()
+            pl.col("v").get(pl.col("t").arg_max()).sqrt()
         )  # <- fails for sqrt, exp, log, pow, etc.
     ).to_dict(False) == {"k": ["a", "b"], "v": [1.4142135623730951, 2.0]}
 
@@ -387,7 +387,7 @@ def test_group_by_dynamic_overlapping_groups_flat_apply_multiple_5038(
 def test_take_in_group_by() -> None:
     df = pl.DataFrame({"group": [1, 1, 1, 2, 2, 2], "values": [10, 200, 3, 40, 500, 6]})
     assert df.group_by("group").agg(
-        pl.col("values").take(1) - pl.col("values").take(2)
+        pl.col("values").get(1) - pl.col("values").get(2)
     ).sort("group").to_dict(False) == {"group": [1, 2], "values": [197, 494]}
 
 


### PR DESCRIPTION
Take made the cardinal sin of letting the return dtype depend on the data. This is now fixed. `take` with a single element will now correctly return `list<T>`. If you want to have a `T`, consider using the newly added `get` expression.