### PR TITLE
perf: drasticly improve performance of limit on async parquet datasets

### DIFF
--- a/crates/polars-core/src/prelude.rs
+++ b/crates/polars-core/src/prelude.rs
@@ -30,6 +30,8 @@ pub use crate::chunked_array::ops::*;
 pub use crate::chunked_array::temporal::conversion::*;
 pub(crate) use crate::chunked_array::ChunkIdIter;
 pub use crate::chunked_array::ChunkedArray;
+#[cfg(feature = "dtype-categorical")]
+pub use crate::datatypes::string_cache::StringCacheHolder;
 pub use crate::datatypes::{ArrayCollectIterExt, *};
 pub use crate::error::{
     polars_bail, polars_ensure, polars_err, polars_warn, PolarsError, PolarsResult,

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -329,12 +329,27 @@ fn rg_to_dfs_par_over_rg(
     Ok(dfs.into_iter().flatten().collect())
 }
 
+fn materialize_empty_df(
+    projection: Option<&[usize]>,
+    reader_schema: &Schema,
+    hive_partition_columns: Option<&[Series]>,
+) -> DataFrame {
+    let schema = if let Some(projection) = projection {
+        Cow::Owned(apply_projection_pl_schema(reader_schema, projection))
+    } else {
+        Cow::Borrowed(reader_schema)
+    };
+    let mut df = DataFrame::from(schema.as_ref());
+    materialize_hive_partitions(&mut df, hive_partition_columns, 0);
+    df
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn read_parquet<R: MmapBytesReader>(
     mut reader: R,
     mut limit: usize,
     projection: Option<&[usize]>,
-    schema: &SchemaRef,
+    reader_schema: &SchemaRef,
     metadata: Option<FileMetaDataRef>,
     predicate: Option<&dyn PhysicalIoExpr>,
     mut parallel: ParallelStrategy,
@@ -343,10 +358,12 @@ pub fn read_parquet<R: MmapBytesReader>(
     hive_partition_columns: Option<&[Series]>,
 ) -> PolarsResult<DataFrame> {
     // Fast path.
-    if limit == 0 && hive_partition_columns.is_none() {
-        let mut df = DataFrame::from(schema.as_ref());
-        materialize_hive_partitions(&mut df, hive_partition_columns, 0);
-        return Ok(df);
+    if limit == 0 {
+        return Ok(materialize_empty_df(
+            projection,
+            reader_schema,
+            hive_partition_columns,
+        ));
     }
 
     let file_metadata = metadata
@@ -370,19 +387,20 @@ pub fn read_parquet<R: MmapBytesReader>(
         None
     };
 
-    let projection = projection
+    let materialized_projection = projection
         .map(Cow::Borrowed)
-        .unwrap_or_else(|| Cow::Owned((0usize..schema.len()).collect::<Vec<_>>()));
+        .unwrap_or_else(|| Cow::Owned((0usize..reader_schema.len()).collect::<Vec<_>>()));
 
     if let ParallelStrategy::Auto = parallel {
-        if n_row_groups > projection.len() || n_row_groups > POOL.current_num_threads() {
+        if n_row_groups > materialized_projection.len() || n_row_groups > POOL.current_num_threads()
+        {
             parallel = ParallelStrategy::RowGroups;
         } else {
             parallel = ParallelStrategy::Columns;
         }
     }
 
-    if let (ParallelStrategy::Columns, true) = (parallel, projection.len() == 1) {
+    if let (ParallelStrategy::Columns, true) = (parallel, materialized_projection.len() == 1) {
         parallel = ParallelStrategy::None;
     }
 
@@ -397,27 +415,21 @@ pub fn read_parquet<R: MmapBytesReader>(
         n_row_groups,
         &mut limit,
         &file_metadata,
-        schema,
+        reader_schema,
         predicate,
         row_count,
         parallel,
-        &projection,
+        &materialized_projection,
         use_statistics,
         hive_partition_columns,
     )?;
 
     if dfs.is_empty() {
-        let schema = if let Cow::Borrowed(_) = projection {
-            Cow::Owned(Arc::new(apply_projection_pl_schema(
-                schema.as_ref(),
-                &projection,
-            )))
-        } else {
-            Cow::Borrowed(schema)
-        };
-        let mut df = DataFrame::from(schema.as_ref().as_ref());
-        materialize_hive_partitions(&mut df, hive_partition_columns, 0);
-        Ok(df)
+        Ok(materialize_empty_df(
+            projection,
+            reader_schema,
+            hive_partition_columns,
+        ))
     } else {
         accumulate_dataframes_vertical(dfs)
     }
@@ -492,6 +504,8 @@ pub struct BatchedParquetReader {
     chunk_size: usize,
     use_statistics: bool,
     hive_partition_columns: Option<Vec<Series>>,
+    /// Has returned at least one materialized frame.
+    has_returned: bool,
 }
 
 impl BatchedParquetReader {
@@ -534,10 +548,15 @@ impl BatchedParquetReader {
             chunk_size,
             use_statistics,
             hive_partition_columns,
+            has_returned: false,
         })
     }
 
     pub async fn next_batches(&mut self, n: usize) -> PolarsResult<Option<Vec<DataFrame>>> {
+        if self.limit == 0 && self.has_returned {
+            return Ok(None);
+        }
+
         // fill up fifo stack
         if self.row_group_offset <= self.n_row_groups && self.chunks_fifo.len() < n {
             let row_group_start = self.row_group_offset;
@@ -600,6 +619,7 @@ impl BatchedParquetReader {
                 }
             }
 
+            self.has_returned |= true;
             Ok(Some(chunks))
         }
     }

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use polars_core::config::verbose;
 use polars_core::utils::accumulate_dataframes_vertical;
 use polars_core::utils::arrow::io::parquet::read::FileMetaData;
 use polars_io::cloud::CloudOptions;
@@ -154,97 +155,140 @@ impl ParquetExec {
 
     #[cfg(feature = "cloud")]
     async fn read_async(&mut self) -> PolarsResult<Vec<DataFrame>> {
+        let verbose = verbose();
         let first_schema = &self.file_info.reader_schema;
         let first_metadata = &self.metadata;
         let cloud_options = self.cloud_options.as_ref();
-        // First initialize the readers and get the metadata concurrently.
-        let iter = self.paths.iter().enumerate().map(|(i, path)| async move {
-            // use the cached one as this saves a cloud call
-            let metadata = if i == 0 { first_metadata.clone() } else { None };
-            let mut reader = ParquetAsyncReader::from_uri(
-                &path.to_string_lossy(),
-                cloud_options,
-                // Schema must be the same for all files. The hive partitions are included in this schema.
-                Some(first_schema.clone()),
-                metadata,
-            )
-            .await?;
-            let num_rows = reader.num_rows().await?;
-            PolarsResult::Ok((num_rows, reader))
-        });
-        let readers_and_metadata = futures::future::try_join_all(iter).await?;
+        dbg!(self.file_options.n_rows);
 
-        // Then compute `n_rows` to be taken per file up front, so we can actually read concurrently
-        // after this.
-        let n_rows_to_read = self.file_options.n_rows.unwrap_or(usize::MAX);
-        let iter = readers_and_metadata
-            .iter()
-            .map(|(num_rows, _)| num_rows)
-            .copied();
+        let mut result = vec![];
 
-        let rows_statistics = get_sequential_row_statistics(iter, n_rows_to_read);
+        let mut remaining_rows_to_read = self.file_options.n_rows.unwrap_or(usize::MAX);
+        let mut base_row_count = self.file_options.row_count.take();
+        let mut processed = 0;
+        for paths in self
+            .paths
+            .chunks(std::cmp::min(POOL.current_num_threads(), 128))
+        {
+            if remaining_rows_to_read == 0 && !result.is_empty() {
+                return Ok(result);
+            }
+            processed += paths.len();
+            if verbose {
+                eprintln!(
+                    "querying metadata of {}/{} files...",
+                    processed,
+                    self.paths.len()
+                );
+            }
 
-        // Now read the actual data.
-        let base_row_count = &self.file_options.row_count;
-        let file_info = &self.file_info;
-        let file_options = &self.file_options;
-        let paths = &self.paths;
-        let use_statistics = self.options.use_statistics;
-        let predicate = &self.predicate;
+            // First initialize the readers and get the metadata concurrently.
+            let iter = paths.iter().enumerate().map(|(i, path)| async move {
+                // use the cached one as this saves a cloud call
+                let metadata = if i == 0 { first_metadata.clone() } else { None };
+                let mut reader = ParquetAsyncReader::from_uri(
+                    &path.to_string_lossy(),
+                    cloud_options,
+                    // Schema must be the same for all files. The hive partitions are included in this schema.
+                    Some(first_schema.clone()),
+                    metadata,
+                )
+                .await?;
+                let num_rows = reader.num_rows().await?;
+                PolarsResult::Ok((num_rows, reader))
+            });
+            let readers_and_metadata = futures::future::try_join_all(iter).await?;
 
-        let iter = readers_and_metadata
-            .into_iter()
-            .zip(rows_statistics.iter())
-            .zip(paths.as_ref().iter())
-            .map(
-                |(
-                    ((num_rows_this_file, reader), (remaining_rows_to_read, cumulative_read)),
-                    path,
-                )| async move {
-                    let mut file_info = file_info.clone();
-                    let remaining_rows_to_read = *remaining_rows_to_read;
-                    let remaining_rows_to_read = if num_rows_this_file < remaining_rows_to_read {
-                        None
-                    } else {
-                        Some(remaining_rows_to_read)
-                    };
-                    let row_count = base_row_count.as_ref().map(|rc| RowCount {
-                        name: rc.name.clone(),
-                        offset: rc.offset + *cumulative_read as IdxSize,
-                    });
+            // Then compute `n_rows` to be taken per file up front, so we can actually read concurrently
+            // after this.
+            let iter = readers_and_metadata
+                .iter()
+                .map(|(num_rows, _)| num_rows)
+                .copied();
 
-                    file_info.update_hive_partitions(path);
+            let rows_statistics = get_sequential_row_statistics(iter, remaining_rows_to_read);
 
-                    let hive_partitions = file_info
-                        .hive_parts
-                        .as_ref()
-                        .map(|hive| hive.materialize_partition_columns());
+            // Now read the actual data.
+            let file_info = &self.file_info;
+            let file_options = &self.file_options;
+            let use_statistics = self.options.use_statistics;
+            let predicate = &self.predicate;
+            let base_row_count_ref = &base_row_count;
 
-                    let (_, projection, predicate) = prepare_scan_args(
-                        Path::new(""),
-                        predicate,
-                        &mut file_options.with_columns.clone(),
-                        &mut file_info.schema.clone(),
-                        row_count.is_some(),
-                        hive_partitions.as_deref(),
-                    );
+            if verbose {
+                eprintln!("reading of {}/{} file...", processed, self.paths.len());
+            }
 
-                    reader
-                        .with_n_rows(remaining_rows_to_read)
-                        .with_row_count(row_count)
-                        .with_projection(projection)
-                        .use_statistics(use_statistics)
-                        .with_predicate(predicate)
-                        .set_rechunk(false)
-                        .with_hive_partition_columns(hive_partitions)
-                        .finish()
-                        .await
-                        .map(Some)
-                },
-            );
+            let iter = readers_and_metadata
+                .into_iter()
+                .zip(rows_statistics.iter())
+                .zip(paths.as_ref().iter())
+                .map(
+                    |(
+                        ((num_rows_this_file, reader), (remaining_rows_to_read, cumulative_read)),
+                        path,
+                    )| async move {
+                        dbg!(remaining_rows_to_read);
+                        let mut file_info = file_info.clone();
+                        let remaining_rows_to_read = *remaining_rows_to_read;
+                        let remaining_rows_to_read = if num_rows_this_file < remaining_rows_to_read
+                        {
+                            None
+                        } else {
+                            Some(remaining_rows_to_read)
+                        };
+                        dbg!(remaining_rows_to_read);
+                        let row_count = base_row_count_ref.as_ref().map(|rc| RowCount {
+                            name: rc.name.clone(),
+                            offset: rc.offset + *cumulative_read as IdxSize,
+                        });
 
-        let dfs = futures::future::try_join_all(iter).await?;
-        Ok(dfs.into_iter().flatten().collect())
+                        file_info.update_hive_partitions(path);
+
+                        let hive_partitions = file_info
+                            .hive_parts
+                            .as_ref()
+                            .map(|hive| hive.materialize_partition_columns());
+
+                        let (_, projection, predicate) = prepare_scan_args(
+                            Path::new(""),
+                            predicate,
+                            &mut file_options.with_columns.clone(),
+                            &mut file_info.schema.clone(),
+                            row_count.is_some(),
+                            hive_partitions.as_deref(),
+                        );
+
+                        let now = std::time::Instant::now();
+                        let out = reader
+                            .with_n_rows(remaining_rows_to_read)
+                            .with_row_count(row_count)
+                            .with_projection(projection)
+                            .use_statistics(use_statistics)
+                            .with_predicate(predicate)
+                            .set_rechunk(false)
+                            .with_hive_partition_columns(hive_partitions)
+                            .finish()
+                            .await
+                            .map(Some);
+                        dbg!(now.elapsed().as_millis());
+                        out
+                    },
+                );
+
+            let dfs = futures::future::try_join_all(iter).await?;
+            let n_read = dfs
+                .iter()
+                .map(|opt_df| opt_df.as_ref().map(|df| df.height()).unwrap_or(0))
+                .sum();
+            remaining_rows_to_read = remaining_rows_to_read.saturating_sub(n_read);
+            if let Some(rc) = &mut base_row_count {
+                rc.offset += n_read as IdxSize;
+            }
+            result.extend(dfs.into_iter().flatten())
+        }
+
+        Ok(result)
     }
 
     fn read(&mut self) -> PolarsResult<DataFrame> {

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -3179,8 +3179,3 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "ahash"
-version = "0.8.3"
-source = "git+https://github.com/orlp/aHash?branch=fix-arm-intrinsics#80685f88d3c120ef39fb3fde1c7786b044af5e8b"


### PR DESCRIPTION
we first downloaded all the files before we applied the limit. This also ensures we will batch reads by the number of threads we have. E.g. not that we start downloading 2000 files concurrently and completely smother.