### PR TITLE
fix(rust): fix nearest join_asof if right df only has single row

### DIFF
--- a/crates/polars-ops/src/frame/join/asof/default.rs
+++ b/crates/polars-ops/src/frame/join/asof/default.rs
@@ -308,7 +308,7 @@ pub(super) fn join_asof_nearest<T: PartialOrd + Copy + Debug + Sub<Output = T> +
                 },
 
                 None => {
-                    if offset > 1 {
+                    if offset >= 1 {
                         // we've reached the end with no matches, so the last item is the nearest for all remaining
                         out.extend(
                             std::iter::repeat(Some(offset - 1)).take(left.len() - out.len()),


### PR DESCRIPTION
This fixes #11966.