### PR TITLE
chore(python): include the "build" dir when running `make clean` for docs

### DIFF
--- a/py-polars/docs/Makefile
+++ b/py-polars/docs/Makefile
@@ -19,6 +19,7 @@ help:
 clean:
 	@rm -rf source/reference/*/api/
 	@rm -rf source/reference/api/
+	@rm -rf "$(BUILDDIR)"
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).


### PR DESCRIPTION
If we're going to `make clean`, let's make it _really_ clean  ;)