### PR TITLE
perf: fix regression non-null asof join

### DIFF
--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -33,6 +33,7 @@ struct AsofJoinForwardState {
 }
 
 impl<T: PartialOrd> AsofJoinState<T> for AsofJoinForwardState {
+    #[inline]
     fn next<F: FnMut(IdxSize) -> Option<T>>(
         &mut self,
         left_val: &T,
@@ -59,6 +60,7 @@ struct AsofJoinBackwardState {
 }
 
 impl<T: PartialOrd> AsofJoinState<T> for AsofJoinBackwardState {
+    #[inline]
     fn next<F: FnMut(IdxSize) -> Option<T>>(
         &mut self,
         left_val: &T,
@@ -87,6 +89,7 @@ struct AsofJoinNearestState {
 }
 
 impl<T: NumericNative> AsofJoinState<T> for AsofJoinNearestState {
+    #[inline]
     fn next<F: FnMut(IdxSize) -> Option<T>>(
         &mut self,
         left_val: &T,


### PR DESCRIPTION
My previous PR gave a regression for inputs without any nulls, this resolves that.