### PR TITLE
ci(python): Fix release tag

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -23,7 +23,7 @@ jobs:
         uses: release-drafter/release-drafter@v5
         with:
           config-name: release-drafter-rust.yml
-          commitish: ${{ inputs.sha }}
+          commitish: ${{ inputs.sha || github.sha }}
           disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
         uses: release-drafter/release-drafter@v5
         with:
           config-name: release-drafter-python.yml
-          commitish: ${{ inputs.sha }}
+          commitish: ${{ inputs.sha || github.sha }}
           disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -230,7 +230,7 @@ jobs:
           tag: py-${{ steps.version.outputs.version }}
           version: ${{ steps.version.outputs.version }}
           prerelease: ${{ steps.version.outputs.is_prerelease }}
-          commitish: ${{ inputs.sha }}
+          commitish: ${{ inputs.sha || github.sha }}
           disable-autolabeler: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
If new commits were merged while the release workflow was running, the GitHub release would pick up those new commits and end up tagging the wrong commit. This fixes the issue.