### PR TITLE
chore(python): Disable type checking for `dataframe_api_compat` dependency

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -102,6 +102,7 @@ ignore_missing_imports = true
 module = [
   "IPython.*",
   "matplotlib.*",
+  "dataframe_api_compat.*",
 ]
 follow_imports = "skip"
 


### PR DESCRIPTION
This is the second time this package breaks our CI due to type hint issues.

I opened a [PR](https://github.com/data-apis/dataframe-api-compat/pull/18) in the repo to fix this specific one, but it seems that there is no type checking in their CI. So I think it's best to turn off type checking for this package until the type hints are more reliable.

@MarcoGorelli FYI - I don't mind helping out a bit in that repo with regards to type hints, with the Polars side of things at least. Let me know if there is something I can help you with.