### PR TITLE
feat: Add supertype for `List`/`Array`

### DIFF
--- a/crates/polars-core/src/utils/supertype.rs
+++ b/crates/polars-core/src/utils/supertype.rs
@@ -230,6 +230,11 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
                 let st = get_supertype(inner_left, inner_right)?;
                 Some(DataType::List(Box::new(st)))
             }
+            #[cfg(feature = "dtype-array")]
+            (List(inner_left), Array(inner_right, _)) | (Array(inner_left, _), List(inner_right))=> {
+                let st = get_supertype(inner_left, inner_right)?;
+                Some(DataType::List(Box::new(st)))
+            }
             // todo! check if can be removed
             (List(inner), other) | (other, List(inner)) => {
                 let st = get_supertype(inner, other)?;

--- a/crates/polars-core/src/utils/supertype.rs
+++ b/crates/polars-core/src/utils/supertype.rs
@@ -231,13 +231,23 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
                 Some(DataType::List(Box::new(st)))
             }
             #[cfg(feature = "dtype-array")]
-            (List(inner_left), Array(inner_right, _)) | (Array(inner_left, _), List(inner_right))=> {
+            (List(inner_left), Array(inner_right, _)) | (Array(inner_left, _), List(inner_right)) => {
                 let st = get_supertype(inner_left, inner_right)?;
                 Some(DataType::List(Box::new(st)))
             }
             // todo! check if can be removed
             (List(inner), other) | (other, List(inner)) => {
                 let st = get_supertype(inner, other)?;
+                Some(DataType::List(Box::new(st)))
+            }
+            #[cfg(feature = "dtype-array")]
+            (Array(inner_left, width_left), Array(inner_right, width_right)) if *width_left == *width_right => {
+                let st = get_supertype(inner_left, inner_right)?;
+                Some(DataType::Array(Box::new(st), *width_left))
+            }
+            #[cfg(feature = "dtype-array")]
+            (Array(inner_left, _), Array(inner_right, _)) => {
+                let st = get_supertype(inner_left, inner_right)?;
                 Some(DataType::List(Box::new(st)))
             }
             (_, Unknown) => Some(Unknown),

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -115,3 +115,13 @@ def test_array_init_deprecation() -> None:
         pl.Array(2, inner=pl.Utf8)
     with pytest.deprecated_call():
         pl.Array(width=2)
+
+
+def test_array_list_supertype() -> None:
+    s1 = pl.Series([[1, 2], [3, 4]], dtype=pl.Array(width=2, inner=pl.Int64))
+    s2 = pl.Series([[1.0, 2.0], [3.0, 4.5]], dtype=pl.List(inner=pl.Float64))
+
+    result = s1 == s2
+
+    expected = pl.Series([True, False])
+    assert_series_equal(result, expected)


### PR DESCRIPTION
Partially addresses #12012

This allows operations between List and Array types by casting to List.

Also should allow operations between Array types (though they are not implemented, so I cannot test for this...).