### PR TITLE
depr(python): Deprecate `nans_compare_equal` parameter in assert utils

### DIFF
--- a/py-polars/polars/testing/asserts/frame.py
+++ b/py-polars/polars/testing/asserts/frame.py
@@ -7,6 +7,7 @@ from polars.exceptions import ComputeError, InvalidAssert
 from polars.lazyframe import LazyFrame
 from polars.testing.asserts.series import _assert_series_values_equal
 from polars.testing.asserts.utils import raise_assertion_error
+from polars.utils.deprecation import issue_deprecation_warning
 
 
 def assert_frame_equal(
@@ -19,8 +20,8 @@ def assert_frame_equal(
     check_exact: bool = False,
     rtol: float = 1e-5,
     atol: float = 1e-8,
-    nans_compare_equal: bool = True,
     categorical_as_str: bool = False,
+    nans_compare_equal: bool | None = None,
 ) -> None:
     """
     Assert that the left and right frame are equal.
@@ -52,11 +53,15 @@ def assert_frame_equal(
         Relative tolerance for inexact checking. Fraction of values in ``right``.
     atol
         Absolute tolerance for inexact checking.
-    nans_compare_equal
-        Consider NaN values to be equal.
     categorical_as_str
         Cast categorical columns to string before comparing. Enabling this helps
         compare columns that do not share the same string cache.
+    nans_compare_equal
+        Consider NaN values to be equal.
+
+        .. deprecated: 0.19.12
+            This parameter will be removed. Default behaviour will remain as though it
+            were set to ``True``.
 
     See Also
     --------
@@ -89,6 +94,15 @@ def assert_frame_equal(
     AssertionError: values for column 'a' are different
 
     """
+    if nans_compare_equal is not None:
+        issue_deprecation_warning(
+            "The `nans_compare_equal` parameter for `assert_frame_equal` is deprecated."
+            " Default behaviour will remain as though it were set to `True`.",
+            version="0.19.12",
+        )
+    else:
+        nans_compare_equal = True
+
     lazy = _assert_correct_input_type(left, right)
     objects = "LazyFrames" if lazy else "DataFrames"
 
@@ -202,8 +216,8 @@ def assert_frame_not_equal(
     check_exact: bool = False,
     rtol: float = 1e-5,
     atol: float = 1e-8,
-    nans_compare_equal: bool = True,
     categorical_as_str: bool = False,
+    nans_compare_equal: bool | None = None,
 ) -> None:
     """
     Assert that the left and right frame are **not** equal.
@@ -234,11 +248,15 @@ def assert_frame_not_equal(
         Relative tolerance for inexact checking. Fraction of values in ``right``.
     atol
         Absolute tolerance for inexact checking.
-    nans_compare_equal
-        Consider NaN values to be equal.
     categorical_as_str
         Cast categorical columns to string before comparing. Enabling this helps
         compare columns that do not share the same string cache.
+    nans_compare_equal
+        Consider NaN values to be equal.
+
+        .. deprecated: 0.19.12
+            This parameter will be removed. Default behaviour will remain as though it
+            were set to ``True``.
 
     See Also
     --------

--- a/py-polars/polars/testing/asserts/series.py
+++ b/py-polars/polars/testing/asserts/series.py
@@ -18,6 +18,7 @@ from polars.datatypes import (
 from polars.exceptions import ComputeError
 from polars.series import Series
 from polars.testing.asserts.utils import raise_assertion_error
+from polars.utils.deprecation import issue_deprecation_warning
 
 if TYPE_CHECKING:
     from polars.type_aliases import PolarsDataType
@@ -32,8 +33,8 @@ def assert_series_equal(
     check_exact: bool = False,
     rtol: float = 1e-5,
     atol: float = 1e-8,
-    nans_compare_equal: bool = True,
     categorical_as_str: bool = False,
+    nans_compare_equal: bool | None = None,
 ) -> None:
     """
     Assert that the left and right Series are equal.
@@ -60,11 +61,15 @@ def assert_series_equal(
         ``right``.
     atol
         Absolute tolerance for inexact checking.
-    nans_compare_equal
-        Consider NaN values to be equal.
     categorical_as_str
         Cast categorical columns to string before comparing. Enabling this helps
         compare columns that do not share the same string cache.
+    nans_compare_equal
+        Consider NaN values to be equal.
+
+        .. deprecated: 0.19.12
+            This parameter will be removed. Default behaviour will remain as though it
+            were set to ``True``.
 
     See Also
     --------
@@ -91,6 +96,15 @@ def assert_series_equal(
     [right]: [1, 5, 3]
 
     """
+    if nans_compare_equal is not None:
+        issue_deprecation_warning(
+            "The `nans_compare_equal` parameter for `assert_frame_equal` is deprecated."
+            " Default behaviour will remain as though it were set to `True`.",
+            version="0.19.12",
+        )
+    else:
+        nans_compare_equal = True
+
     if not (isinstance(left, Series) and isinstance(right, Series)):  # type: ignore[redundant-expr]
         raise_assertion_error(
             "inputs",
@@ -347,8 +361,8 @@ def assert_series_not_equal(
     check_exact: bool = False,
     rtol: float = 1e-5,
     atol: float = 1e-8,
-    nans_compare_equal: bool = True,
     categorical_as_str: bool = False,
+    nans_compare_equal: bool | None = None,
 ) -> None:
     """
     Assert that the left and right Series are **not** equal.
@@ -374,11 +388,15 @@ def assert_series_not_equal(
         ``right``.
     atol
         Absolute tolerance for inexact checking.
-    nans_compare_equal
-        Consider NaN values to be equal.
     categorical_as_str
         Cast categorical columns to string before comparing. Enabling this helps
         compare columns that do not share the same string cache.
+    nans_compare_equal
+        Consider NaN values to be equal.
+
+        .. deprecated: 0.19.12
+            This parameter will be removed. Default behaviour will remain as though it
+            were set to ``True``.
 
     See Also
     --------

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -607,7 +607,7 @@ def test_init_ndarray(monkeypatch: Any) -> None:
         data={"x": np.array([1.0, 2.5, np.nan]), "y": np.array([4.0, np.nan, 6.5])},
         nan_to_null=True,
     )
-    assert_frame_equal(df0, df1, nans_compare_equal=True)
+    assert_frame_equal(df0, df1)
     assert df2.rows() == [(1.0, 4.0), (2.5, None), (None, 6.5)]
 
 
@@ -714,7 +714,7 @@ def test_init_series() -> None:
     s1 = pl.Series("n", np.array([1.0, 2.5, float("nan")]))
     s2 = pl.Series("n", np.array([1.0, 2.5, float("nan")]), nan_to_null=True)
 
-    assert_series_equal(s0, s1, nans_compare_equal=True)
+    assert_series_equal(s0, s1)
     assert s2.to_list() == [1.0, 2.5, None]
 
 

--- a/py-polars/tests/unit/testing/test_assert_frame_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_frame_equal.py
@@ -9,6 +9,8 @@ import polars as pl
 from polars.exceptions import InvalidAssert
 from polars.testing import assert_frame_equal, assert_frame_not_equal
 
+nan = float("NaN")
+
 
 @pytest.mark.parametrize(
     ("df1", "df2", "kwargs"),
@@ -104,22 +106,10 @@ from polars.testing import assert_frame_equal, assert_frame_not_equal
             id="list_of_none_and_float_integer_rtol",
         ),
         pytest.param(
-            pl.DataFrame({"a": [[None, 1.3]]}),
-            pl.DataFrame({"a": [[None, 0.9]]}),
-            {"rtol": 1, "nans_compare_equal": False},
-            id="list_of_none_and_float_integer_rtol",
-        ),
-        pytest.param(
             pl.DataFrame({"a": [[[0.2, 3.0]]]}),
             pl.DataFrame({"a": [[[0.2, 3.00000001]]]}),
-            {"atol": 0.1, "nans_compare_equal": True},
-            id="nested_list_of_float_atol_high_nans_compare_equal_true",
-        ),
-        pytest.param(
-            pl.DataFrame({"a": [[[0.2, 3.0]]]}),
-            pl.DataFrame({"a": [[[0.2, 3.00000001]]]}),
-            {"atol": 0.1, "nans_compare_equal": False},
-            id="nested_list_of_float_atol_high_nans_compare_equal_false",
+            {"atol": 0.1},
+            id="nested_list_of_float_atol_high",
         ),
     ],
 )
@@ -161,12 +151,6 @@ def test_assert_frame_equal_passes_assertion(
             id="list_of_float_negative_atol",
         ),
         pytest.param(
-            pl.DataFrame({"a": [[math.nan, 1.3]]}),
-            pl.DataFrame({"a": [[math.nan, 0.9]]}),
-            {"rtol": 1, "nans_compare_equal": False},
-            id="list_of_nan_and_float_integer_rtol",
-        ),
-        pytest.param(
             pl.DataFrame({"a": [[2.0, 3.0]]}),
             pl.DataFrame({"a": [[2, 3]]}),
             {"check_exact": False, "check_dtype": True},
@@ -175,50 +159,20 @@ def test_assert_frame_equal_passes_assertion(
         pytest.param(
             pl.DataFrame({"a": [[[0.2, math.nan, 3.0]]]}),
             pl.DataFrame({"a": [[[0.2, math.nan, 3.11]]]}),
-            {"atol": 0.1, "rtol": 0, "nans_compare_equal": True},
-            id="nested_list_of_float_and_nan_atol_high_nans_compare_equal_true",
-        ),
-        pytest.param(
-            pl.DataFrame({"a": [[[0.2, math.nan, 3.0]]]}),
-            pl.DataFrame({"a": [[[0.2, math.nan, 3.0]]]}),
-            {"nans_compare_equal": False},
-            id="nested_list_of_float_and_nan_atol_high_nans_compare_equal_false",
-        ),
-        pytest.param(
-            pl.DataFrame({"a": [[[0.2, 3.0]]]}),
-            pl.DataFrame({"a": [[[0.2, 3.11]]]}),
-            {"atol": 0.1, "nans_compare_equal": False},
-            id="nested_list_of_float_atol_high_nans_compare_equal_false",
+            {"atol": 0.1, "rtol": 0},
+            id="nested_list_of_float_and_nan_atol_high",
         ),
         pytest.param(
             pl.DataFrame({"a": [[[[0.2, 3.0]]]]}),
             pl.DataFrame({"a": [[[[0.2, 3.11]]]]}),
-            {"atol": 0.1, "rtol": 0, "nans_compare_equal": True},
-            id="double_nested_list_of_float_atol_high_nans_compare_equal_true",
-        ),
-        pytest.param(
-            pl.DataFrame({"a": [[[[0.2, math.nan, 3.0]]]]}),
-            pl.DataFrame({"a": [[[[0.2, math.nan, 3.0]]]]}),
-            {"atol": 0.1, "nans_compare_equal": False},
-            id="double_nested_list_of_float_and_nan_atol_high_nans_compare_equal_false",
-        ),
-        pytest.param(
-            pl.DataFrame({"a": [[[[0.2, 3.0]]]]}),
-            pl.DataFrame({"a": [[[[0.2, 3.11]]]]}),
-            {"atol": 0.1, "rtol": 0, "nans_compare_equal": False},
-            id="double_nested_list_of_float_atol_high_nans_compare_equal_false",
+            {"atol": 0.1, "rtol": 0},
+            id="double_nested_list_of_float_atol_high",
         ),
         pytest.param(
             pl.DataFrame({"a": [[[[[0.2, 3.0]]]]]}),
             pl.DataFrame({"a": [[[[[0.2, 3.11]]]]]}),
-            {"atol": 0.1, "rtol": 0, "nans_compare_equal": True},
-            id="triple_nested_list_of_float_atol_high_nans_compare_equal_true",
-        ),
-        pytest.param(
-            pl.DataFrame({"a": [[[[[0.2, math.nan, 3.0]]]]]}),
-            pl.DataFrame({"a": [[[[[0.2, math.nan, 3.0]]]]]}),
-            {"atol": 0.1, "nans_compare_equal": False},
-            id="triple_nested_list_of_float_and_nan_atol_high_nans_compare_equal_true",
+            {"atol": 0.1, "rtol": 0},
+            id="triple_nested_list_of_float_atol_high",
         ),
     ],
 )
@@ -233,7 +187,6 @@ def test_assert_frame_equal_raises_assertion_error(
 
 
 def test_compare_frame_equal_nans() -> None:
-    nan = float("NaN")
     df1 = pl.DataFrame(
         data={"x": [1.0, nan], "y": [nan, 2.0]},
         schema=[("x", pl.Float32), ("y", pl.Float64)],
@@ -250,8 +203,6 @@ def test_compare_frame_equal_nans() -> None:
 
 
 def test_compare_frame_equal_nested_nans() -> None:
-    nan = float("NaN")
-
     # list dtype
     df1 = pl.DataFrame(
         data={"x": [[1.0, nan]], "y": [[nan, 2.0]]},
@@ -306,10 +257,13 @@ def test_compare_frame_equal_nested_nans() -> None:
     )
 
     assert_frame_equal(df3, df3)
-    assert_frame_not_equal(df3, df3, nans_compare_equal=False)
+    with pytest.deprecated_call():
+        assert_frame_not_equal(df3, df3, nans_compare_equal=False)
 
     assert_frame_equal(df4, df4)
-    assert_frame_not_equal(df4, df4, nans_compare_equal=False)
+
+    with pytest.deprecated_call():
+        assert_frame_not_equal(df4, df4, nans_compare_equal=False)
 
     assert_frame_not_equal(df3, df4)
     for check_dtype in (True, False):
@@ -418,3 +372,83 @@ def test_assert_frame_not_equal() -> None:
     df = pl.DataFrame({"a": [1, 2]})
     with pytest.raises(AssertionError, match="frames are equal"):
         assert_frame_not_equal(df, df)
+
+
+@pytest.mark.parametrize(
+    ("df1", "df2", "kwargs"),
+    [
+        pytest.param(
+            pl.DataFrame({"a": [[None, 1.3]]}),
+            pl.DataFrame({"a": [[None, 0.9]]}),
+            {"rtol": 1},
+            id="list_of_none_and_float_integer_rtol",
+        ),
+        pytest.param(
+            pl.DataFrame({"a": [[[0.2, 3.0]]]}),
+            pl.DataFrame({"a": [[[0.2, 3.00000001]]]}),
+            {"atol": 0.1},
+            id="nested_list_of_float_atol_high_nans_compare_equal_false",
+        ),
+    ],
+)
+def test_assert_frame_equal_passes_assertion_deprecated_nans_compare_equal_false(
+    df1: pl.DataFrame,
+    df2: pl.DataFrame,
+    kwargs: dict[str, Any],
+) -> None:
+    with pytest.deprecated_call():
+        assert_frame_equal(df1, df2, nans_compare_equal=False, **kwargs)
+    with pytest.raises(AssertionError), pytest.deprecated_call():
+        assert_frame_not_equal(df1, df2, nans_compare_equal=False, **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("df1", "df2", "kwargs"),
+    [
+        pytest.param(
+            pl.DataFrame({"a": [[math.nan, 1.3]]}),
+            pl.DataFrame({"a": [[math.nan, 0.9]]}),
+            {"rtol": 1},
+            id="list_of_nan_and_float_integer_rtol",
+        ),
+        pytest.param(
+            pl.DataFrame({"a": [[[0.2, math.nan, 3.0]]]}),
+            pl.DataFrame({"a": [[[0.2, math.nan, 3.0]]]}),
+            {},
+            id="nested_list_of_float_and_nan_atol_high",
+        ),
+        pytest.param(
+            pl.DataFrame({"a": [[[0.2, 3.0]]]}),
+            pl.DataFrame({"a": [[[0.2, 3.11]]]}),
+            {"atol": 0.1},
+            id="nested_list_of_float_atol_high",
+        ),
+        pytest.param(
+            pl.DataFrame({"a": [[[[0.2, math.nan, 3.0]]]]}),
+            pl.DataFrame({"a": [[[[0.2, math.nan, 3.0]]]]}),
+            {"atol": 0.1},
+            id="double_nested_list_of_float_and_nan_atol_high",
+        ),
+        pytest.param(
+            pl.DataFrame({"a": [[[[0.2, 3.0]]]]}),
+            pl.DataFrame({"a": [[[[0.2, 3.11]]]]}),
+            {"atol": 0.1, "rtol": 0},
+            id="double_nested_list_of_float_atol_high",
+        ),
+        pytest.param(
+            pl.DataFrame({"a": [[[[[0.2, math.nan, 3.0]]]]]}),
+            pl.DataFrame({"a": [[[[[0.2, math.nan, 3.0]]]]]}),
+            {"atol": 0.1},
+            id="triple_nested_list_of_float_and_nan_atol_high",
+        ),
+    ],
+)
+def test_assert_frame_equal_raises_assertion_error_deprecated_nans_compare_equal_false(
+    df1: pl.DataFrame,
+    df2: pl.DataFrame,
+    kwargs: dict[str, Any],
+) -> None:
+    with pytest.raises(AssertionError), pytest.deprecated_call():
+        assert_frame_equal(df1, df2, nans_compare_equal=False, **kwargs)
+    with pytest.deprecated_call():
+        assert_frame_not_equal(df1, df2, nans_compare_equal=False, **kwargs)

--- a/py-polars/tests/unit/testing/test_assert_series_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_series_equal.py
@@ -9,6 +9,8 @@ import pytest
 import polars as pl
 from polars.testing import assert_series_equal, assert_series_not_equal
 
+nan = float("NaN")
+
 
 def test_compare_series_value_mismatch() -> None:
     srs1 = pl.Series([1, 2, 3])
@@ -32,8 +34,6 @@ def test_compare_series_empty_equal() -> None:
 
 def test_compare_series_nans_assert_equal() -> None:
     # note: NaN values do not _compare_ equal, but should _assert_ equal (by default)
-    nan = float("NaN")
-
     srs1 = pl.Series([1.0, 2.0, nan, 4.0, None, 6.0])
     srs2 = pl.Series([1.0, nan, 3.0, 4.0, None, 6.0])
     srs3 = pl.Series([1.0, 2.0, 3.0, 4.0, None, 6.0])
@@ -42,33 +42,16 @@ def test_compare_series_nans_assert_equal() -> None:
         assert_series_equal(srs, srs)
         assert_series_equal(srs, srs, check_exact=True)
 
-    with pytest.raises(AssertionError):
-        assert_series_equal(srs1, srs1, nans_compare_equal=False)
-    assert_series_not_equal(srs1, srs1, nans_compare_equal=False)
-
-    with pytest.raises(AssertionError):
-        assert_series_equal(srs1, srs1, nans_compare_equal=False, check_exact=True)
-    assert_series_not_equal(srs1, srs1, nans_compare_equal=False, check_exact=True)
-
-    for check_exact, nans_equal in (
-        (False, False),
-        (False, True),
-        (True, False),
-        (True, True),
-    ):
+    for check_exact in (False, True):
         if check_exact:
             check_msg = "exact value mismatch"
         else:
             check_msg = "Series are different.*value mismatch.*"
 
         with pytest.raises(AssertionError, match=check_msg):
-            assert_series_equal(
-                srs1, srs2, check_exact=check_exact, nans_compare_equal=nans_equal
-            )
+            assert_series_equal(srs1, srs2, check_exact=check_exact)
         with pytest.raises(AssertionError, match=check_msg):
-            assert_series_equal(
-                srs1, srs3, check_exact=check_exact, nans_compare_equal=nans_equal
-            )
+            assert_series_equal(srs1, srs3, check_exact=check_exact)
 
     srs4 = pl.Series([1.0, 2.0, 3.0, 4.0, None, 6.0])
     srs5 = pl.Series([1.0, 2.0, 3.0, 4.0, nan, 6.0])
@@ -231,8 +214,8 @@ def test_assert_series_equal_temporal(data1: Any, data2: Any) -> None:
             id="approx_equal_float_integer_atol",
         ),
         pytest.param(
-            pl.Series([1.0, 2.0, float("nan")]),
-            pl.Series([1.005, 2.005, float("nan")]),
+            pl.Series([1.0, 2.0, nan]),
+            pl.Series([1.005, 2.005, nan]),
             {"atol": 1e-2, "rtol": 0.0},
             id="approx_equal_float_nan_atol",
         ),
@@ -243,14 +226,8 @@ def test_assert_series_equal_temporal(data1: Any, data2: Any) -> None:
             id="approx_equal_float_none_atol",
         ),
         pytest.param(
-            pl.Series([1.0, 2.0, None]),
-            pl.Series([1.005, 2.005, None]),
-            {"atol": 1e-2, "nans_compare_equal": False},
-            id="approx_equal_float_none_atol_with_nans_compare_equal_false",
-        ),
-        pytest.param(
-            pl.Series([1.0, 2.0, float("nan")]),
-            pl.Series([1.005, 2.015, float("nan")]),
+            pl.Series([1.0, 2.0, nan]),
+            pl.Series([1.005, 2.015, nan]),
             {"atol": 0.0, "rtol": 1e-2},
             id="approx_equal_float_nan_rtol",
         ),
@@ -259,12 +236,6 @@ def test_assert_series_equal_temporal(data1: Any, data2: Any) -> None:
             pl.Series([1.005, 2.015, None]),
             {"rtol": 1e-2},
             id="approx_equal_float_none_rtol",
-        ),
-        pytest.param(
-            pl.Series([1.0, 2.0, None]),
-            pl.Series([1.005, 2.015, None]),
-            {"rtol": 1e-2, "nans_compare_equal": False},
-            id="approx_equal_float_none_rtol_with_nans_compare_equal_false",
         ),
         pytest.param(
             pl.Series([0.0, 1.0, 2.0], dtype=pl.Float64),
@@ -327,12 +298,6 @@ def test_assert_series_equal_temporal(data1: Any, data2: Any) -> None:
             id="list_of_none_and_float_integer_rtol",
         ),
         pytest.param(
-            pl.Series([[None, 1.3]]),
-            pl.Series([[None, 0.9]]),
-            {"rtol": 1, "nans_compare_equal": False},
-            id="list_of_none_and_float_integer_rtol",
-        ),
-        pytest.param(
             pl.Series([[None, 1]], dtype=pl.List(pl.Int64)),
             pl.Series([[None, 1]], dtype=pl.List(pl.Int64)),
             {"rtol": 1},
@@ -341,7 +306,7 @@ def test_assert_series_equal_temporal(data1: Any, data2: Any) -> None:
         pytest.param(
             pl.Series([[math.nan, 1.3]]),
             pl.Series([[math.nan, 0.9]]),
-            {"rtol": 1, "nans_compare_equal": True},
+            {"rtol": 1},
             id="list_of_none_and_float_integer_rtol",
         ),
         pytest.param(
@@ -353,56 +318,38 @@ def test_assert_series_equal_temporal(data1: Any, data2: Any) -> None:
         pytest.param(
             pl.Series([[[0.2, 3.0]]]),
             pl.Series([[[0.2, 3.00000001]]]),
-            {"atol": 0.1, "nans_compare_equal": True},
-            id="nested_list_of_float_atol_high_nans_compare_equal_true",
+            {"atol": 0.1},
+            id="nested_list_of_float_atol_high",
         ),
         pytest.param(
             pl.Series([[[0.2, math.nan, 3.0]]]),
             pl.Series([[[0.2, math.nan, 3.00000001]]]),
-            {"atol": 0.1, "nans_compare_equal": True},
-            id="nested_list_of_float_and_nan_atol_high_nans_compare_equal_true",
-        ),
-        pytest.param(
-            pl.Series([[[0.2, 3.0]]]),
-            pl.Series([[[0.2, 3.00000001]]]),
-            {"atol": 0.1, "nans_compare_equal": False},
-            id="nested_list_of_float_atol_high_nans_compare_equal_false",
+            {"atol": 0.1},
+            id="nested_list_of_float_and_nan_atol_high",
         ),
         pytest.param(
             pl.Series([[[[0.2, 3.0]]]]),
             pl.Series([[[[0.2, 3.00000001]]]]),
-            {"atol": 0.1, "nans_compare_equal": True},
-            id="double_nested_list_of_float_atol_high_nans_compare_equal_true",
+            {"atol": 0.1},
+            id="double_nested_list_of_float_atol_high",
         ),
         pytest.param(
             pl.Series([[[[0.2, math.nan, 3.0]]]]),
             pl.Series([[[[0.2, math.nan, 3.00000001]]]]),
-            {"atol": 0.1, "nans_compare_equal": True},
-            id="double_nested_list_of_float__and_nan_atol_high_nans_compare_equal_true",
-        ),
-        pytest.param(
-            pl.Series([[[[0.2, 3.0]]]]),
-            pl.Series([[[[0.2, 3.00000001]]]]),
-            {"atol": 0.1, "nans_compare_equal": False},
-            id="double_nested_list_of_float_atol_high_nans_compare_equal_false",
+            {"atol": 0.1},
+            id="double_nested_list_of_float__and_nan_atol_high",
         ),
         pytest.param(
             pl.Series([[[[[0.2, 3.0]]]]]),
             pl.Series([[[[[0.2, 3.00000001]]]]]),
-            {"atol": 0.1, "nans_compare_equal": True},
-            id="triple_nested_list_of_float_atol_high_nans_compare_equal_true",
+            {"atol": 0.1},
+            id="triple_nested_list_of_float_atol_high",
         ),
         pytest.param(
             pl.Series([[[[[0.2, math.nan, 3.0]]]]]),
             pl.Series([[[[[0.2, math.nan, 3.00000001]]]]]),
-            {"atol": 0.1, "nans_compare_equal": True},
-            id="triple_nested_list_of_float_and_nan_atol_high_nans_compare_equal_true",
-        ),
-        pytest.param(
-            pl.Series([[[[[0.2, 3.0]]]]]),
-            pl.Series([[[[[0.2, 3.00000001]]]]]),
-            {"atol": 0.1, "nans_compare_equal": False},
-            id="triple_nested_list_of_float_atol_high_nans_compare_equal_false",
+            {"atol": 0.1},
+            id="triple_nested_list_of_float_and_nan_atol_high",
         ),
         pytest.param(
             pl.struct(a=0, b=1, eager=True),
@@ -431,7 +378,7 @@ def test_assert_series_equal_temporal(data1: Any, data2: Any) -> None:
         pytest.param(
             pl.struct(a=0, b=[0.0, math.nan], eager=True),
             pl.struct(a=0, b=[0.0, math.nan], eager=True),
-            {"atol": 0.1, "nans_compare_equal": True},
+            {"atol": 0.1},
             id="struct_with_list_with_nan_compare_equal_true",
         ),
     ],
@@ -474,64 +421,28 @@ def test_assert_series_equal_passes_assertion(
             id="equal_int_float_integer_check_dtype",
         ),
         pytest.param(
-            pl.Series([1.0, 2.0, float("nan")]),
-            pl.Series([1.005, 2.005, float("nan")]),
-            {"atol": 1e-2, "rtol": 0.0, "nans_compare_equal": False},
-            id="approx_equal_float_nan_atol_with_nan_compare_equal_false",
-        ),
-        pytest.param(
-            pl.Series([1.0, 2.0, float("nan")]),
+            pl.Series([1.0, 2.0, nan]),
             pl.Series([1.005, 2.005, 3.005]),
             {"atol": 1e-2, "rtol": 0.0},
             id="approx_equal_float_left_nan_atol",
         ),
         pytest.param(
-            pl.Series([1.0, 2.0, float("nan")]),
-            pl.Series([1.005, 2.005, 3.005]),
-            {"atol": 1e-2, "rtol": 0.0, "nans_compare_equal": False},
-            id="approx_equal_float_left_nan_atol_with_nan_compare_equal_false",
-        ),
-        pytest.param(
             pl.Series([1.0, 2.0, 3.0]),
-            pl.Series([1.005, 2.005, float("nan")]),
+            pl.Series([1.005, 2.005, nan]),
             {"atol": 1e-2, "rtol": 0.0},
             id="approx_equal_float_right_nan_atol",
         ),
         pytest.param(
-            pl.Series([1.0, 2.0, 3.0]),
-            pl.Series([1.005, 2.005, float("nan")]),
-            {"atol": 1e-2, "rtol": 0.0, "nans_compare_equal": False},
-            id="approx_equal_float_right_nan_atol_with_nan_compare_equal_false",
-        ),
-        pytest.param(
-            pl.Series([1.0, 2.0, float("nan")]),
-            pl.Series([1.005, 2.015, float("nan")]),
-            {"atol": 0.0, "rtol": 1e-2, "nans_compare_equal": False},
-            id="approx_equal_float_nan_rtol_with_nan_compare_equal_false",
-        ),
-        pytest.param(
-            pl.Series([1.0, 2.0, float("nan")]),
+            pl.Series([1.0, 2.0, nan]),
             pl.Series([1.005, 2.015, 3.025]),
             {"atol": 0.0, "rtol": 1e-2},
             id="approx_equal_float_left_nan_rtol",
         ),
         pytest.param(
-            pl.Series([1.0, 2.0, float("nan")]),
-            pl.Series([1.005, 2.015, 3.025]),
-            {"atol": 0.0, "rtol": 1e-2, "nans_compare_equal": False},
-            id="approx_equal_float_left_nan_rtol_with_nan_compare_equal_false",
-        ),
-        pytest.param(
             pl.Series([1.0, 2.0, 3.0]),
-            pl.Series([1.005, 2.015, float("nan")]),
+            pl.Series([1.005, 2.015, nan]),
             {"atol": 0.0, "rtol": 1e-2},
             id="approx_equal_float_right_nan_rtol",
-        ),
-        pytest.param(
-            pl.Series([1.0, 2.0, 3.0]),
-            pl.Series([1.005, 2.015, float("nan")]),
-            {"atol": 0.0, "rtol": 1e-2, "nans_compare_equal": False},
-            id="approx_equal_float_right_nan_rtol_with_nan_compare_equal_false",
         ),
         pytest.param(
             pl.Series([[0.2, 0.3]]),
@@ -558,12 +469,6 @@ def test_assert_series_equal_passes_assertion(
             id="list_of_float_negative_atol",
         ),
         pytest.param(
-            pl.Series([[math.nan, 1.3]]),
-            pl.Series([[math.nan, 0.9]]),
-            {"rtol": 1, "nans_compare_equal": False},
-            id="list_of_nan_and_float_integer_rtol",
-        ),
-        pytest.param(
             pl.Series([[2.0, 3.0]]),
             pl.Series([[2, 3]]),
             {"check_exact": False, "check_dtype": True},
@@ -574,12 +479,6 @@ def test_assert_series_equal_passes_assertion(
             pl.struct(a=0, b=1, eager=True),
             {"atol": 0.1, "rtol": 0, "check_dtype": True},
             id="struct_approx_equal_different_type",
-        ),
-        pytest.param(
-            pl.struct(a=0, b=[0.0, math.nan], eager=True),
-            pl.struct(a=0, b=[0.0, math.nan], eager=True),
-            {"atol": 0.1, "nans_compare_equal": False},
-            id="struct_with_list_with_nan_compare_equal_false",
         ),
     ],
 )
@@ -663,26 +562,20 @@ def test_assert_series_equal_nested_struct_float() -> None:
 
 
 def test_assert_series_equal_nested_list_full_null() -> None:
-    # First entry has only integers
-    s1 = pl.Series([None, None], dtype=pl.List(pl.Float64))
-    s2 = pl.Series([None, None], dtype=pl.List(pl.Float64))
-
-    assert_series_equal(s1, s2)
+    s = pl.Series([None, None], dtype=pl.List(pl.Float64))
+    assert_series_equal(s, s)
 
 
 def test_assert_series_equal_nested_list_nan() -> None:
-    s1 = pl.Series([[1.0, 2.0], [3.0, float("nan")]], dtype=pl.List(pl.Float64))
-    s2 = pl.Series([[1.0, 2.0], [3.0, float("nan")]], dtype=pl.List(pl.Float64))
-
-    with pytest.raises(AssertionError):
-        assert_series_equal(s1, s2, nans_compare_equal=False)
+    s = pl.Series([[1.0, 2.0], [3.0, nan]], dtype=pl.List(pl.Float64))
+    assert_series_equal(s, s)
 
 
 def test_assert_series_equal_nested_list_none() -> None:
     s1 = pl.Series([[1.0, 2.0], None], dtype=pl.List(pl.Float64))
     s2 = pl.Series([[1.0, 2.0], None], dtype=pl.List(pl.Float64))
 
-    assert_series_equal(s1, s2, nans_compare_equal=False)
+    assert_series_equal(s1, s2)
 
 
 def test_assert_series_equal_full_none_nested_not_nested() -> None:
@@ -706,3 +599,150 @@ def test_assert_series_equal_array_equal(check_exact: bool) -> None:
 
     with pytest.raises(AssertionError):
         assert_series_equal(s1, s2, check_exact=check_exact)
+
+
+def test_compare_series_nans_assert_equal_deprecated() -> None:
+    srs1 = pl.Series([1.0, 2.0, nan, 4.0, None, 6.0])
+    srs2 = pl.Series([1.0, nan, 3.0, 4.0, None, 6.0])
+    srs3 = pl.Series([1.0, 2.0, 3.0, 4.0, None, 6.0])
+
+    with pytest.raises(AssertionError), pytest.deprecated_call():
+        assert_series_equal(srs1, srs1, nans_compare_equal=False)
+    with pytest.deprecated_call():
+        assert_series_not_equal(srs1, srs1, nans_compare_equal=False)
+
+    with pytest.raises(AssertionError), pytest.deprecated_call():
+        assert_series_equal(srs1, srs1, nans_compare_equal=False, check_exact=True)
+    with pytest.deprecated_call():
+        assert_series_not_equal(srs1, srs1, nans_compare_equal=False, check_exact=True)
+
+    for check_exact in (False, True):
+        if check_exact:
+            check_msg = "exact value mismatch"
+        else:
+            check_msg = "Series are different.*value mismatch.*"
+
+        with pytest.raises(AssertionError, match=check_msg), pytest.deprecated_call():
+            assert_series_equal(
+                srs1, srs2, check_exact=check_exact, nans_compare_equal=False
+            )
+        with pytest.raises(AssertionError, match=check_msg), pytest.deprecated_call():
+            assert_series_equal(
+                srs1, srs3, check_exact=check_exact, nans_compare_equal=False
+            )
+
+
+@pytest.mark.parametrize(
+    ("s1", "s2", "kwargs"),
+    [
+        pytest.param(
+            pl.Series([1.0, 2.0, None]),
+            pl.Series([1.005, 2.005, None]),
+            {"atol": 1e-2},
+            id="approx_equal_float_none_atol",
+        ),
+        pytest.param(
+            pl.Series([1.0, 2.0, None]),
+            pl.Series([1.005, 2.015, None]),
+            {"rtol": 1e-2},
+            id="approx_equal_float_none_rtol",
+        ),
+        pytest.param(
+            pl.Series([[None, 1.3]]),
+            pl.Series([[None, 0.9]]),
+            {"rtol": 1},
+            id="list_of_none_and_float_integer_rtol",
+        ),
+        pytest.param(
+            pl.Series([[[0.2, 3.0]]]),
+            pl.Series([[[0.2, 3.00000001]]]),
+            {"atol": 0.1},
+            id="nested_list_of_float_atol_high",
+        ),
+        pytest.param(
+            pl.Series([[[[0.2, 3.0]]]]),
+            pl.Series([[[[0.2, 3.00000001]]]]),
+            {"atol": 0.1},
+            id="double_nested_list_of_float_atol_high",
+        ),
+        pytest.param(
+            pl.Series([[[[[0.2, 3.0]]]]]),
+            pl.Series([[[[[0.2, 3.00000001]]]]]),
+            {"atol": 0.1},
+            id="triple_nested_list_of_float_atol_high",
+        ),
+    ],
+)
+def test_assert_series_equal_passes_assertion_deprecated_nans_compare_equal_false(
+    s1: pl.Series,
+    s2: pl.Series,
+    kwargs: Any,
+) -> None:
+    with pytest.deprecated_call():
+        assert_series_equal(s1, s2, nans_compare_equal=False, **kwargs)
+    with pytest.raises(AssertionError), pytest.deprecated_call():
+        assert_series_not_equal(s1, s2, nans_compare_equal=False, **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("s1", "s2", "kwargs"),
+    [
+        pytest.param(
+            pl.Series([1.0, 2.0, nan]),
+            pl.Series([1.005, 2.005, nan]),
+            {"atol": 1e-2, "rtol": 0.0},
+            id="approx_equal_float_nan_atol",
+        ),
+        pytest.param(
+            pl.Series([1.0, 2.0, nan]),
+            pl.Series([1.005, 2.005, 3.005]),
+            {"atol": 1e-2, "rtol": 0.0},
+            id="approx_equal_float_left_nan_atol",
+        ),
+        pytest.param(
+            pl.Series([1.0, 2.0, 3.0]),
+            pl.Series([1.005, 2.005, nan]),
+            {"atol": 1e-2, "rtol": 0.0},
+            id="approx_equal_float_right_nan_atol",
+        ),
+        pytest.param(
+            pl.Series([1.0, 2.0, nan]),
+            pl.Series([1.005, 2.015, nan]),
+            {"atol": 0.0, "rtol": 1e-2},
+            id="approx_equal_float_nan_rtol",
+        ),
+        pytest.param(
+            pl.Series([1.0, 2.0, nan]),
+            pl.Series([1.005, 2.015, 3.025]),
+            {"atol": 0.0, "rtol": 1e-2},
+            id="approx_equal_float_left_nan_rtol",
+        ),
+        pytest.param(
+            pl.Series([1.0, 2.0, 3.0]),
+            pl.Series([1.005, 2.015, nan]),
+            {"atol": 0.0, "rtol": 1e-2},
+            id="approx_equal_float_right_nan_rtol",
+        ),
+        pytest.param(
+            pl.Series([[math.nan, 1.3]]),
+            pl.Series([[math.nan, 0.9]]),
+            {"rtol": 1},
+            id="list_of_nan_and_float_integer_rtol",
+        ),
+        pytest.param(
+            pl.struct(a=0, b=[0.0, math.nan], eager=True),
+            pl.struct(a=0, b=[0.0, math.nan], eager=True),
+            {"atol": 0.1},
+            id="struct_with_list",
+        ),
+    ],
+)
+def test_assert_series_equal_raises_assertion_error_deprecated_nans_compare_equal_false(
+    s1: pl.Series,
+    s2: pl.Series,
+    kwargs: Any,
+) -> None:
+    with pytest.raises(AssertionError), pytest.deprecated_call():
+        assert_series_equal(s1, s2, nans_compare_equal=False, **kwargs)
+    with pytest.deprecated_call():
+        assert_series_not_equal(s1, s2, nans_compare_equal=False, **kwargs)


### PR DESCRIPTION
With the upcoming fix that makes NaN values equal by default, this parameter is no longer useful.

If people really want the functionality of unequal NaNs, they can fill the NaNs in one of the frames/series with a sentinel value.

Removing this option will greatly simplify the assert utils code.