### PR TITLE
fix(python): improve ingest from `numpy` scalar values

### DIFF
--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -299,6 +299,7 @@ class _DataTypeMappings:
     def NUMPY_KIND_AND_ITEMSIZE_TO_DTYPE(self) -> dict[tuple[str, int], PolarsDataType]:
         return {
             # (np.dtype().kind, np.dtype().itemsize)
+            ("b", 1): Boolean,
             ("i", 1): Int8,
             ("i", 2): Int16,
             ("i", 4): Int32,

--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -207,20 +207,28 @@ def _might_be(cls: type, type_: str) -> bool:
         return False
 
 
-def _check_for_numpy(obj: Any) -> bool:
-    return _NUMPY_AVAILABLE and _might_be(cast(Hashable, type(obj)), "numpy")
+def _check_for_numpy(obj: Any, *, check_type: bool = True) -> bool:
+    return _NUMPY_AVAILABLE and _might_be(
+        cast(Hashable, type(obj) if check_type else obj), "numpy"
+    )
 
 
-def _check_for_pandas(obj: Any) -> bool:
-    return _PANDAS_AVAILABLE and _might_be(cast(Hashable, type(obj)), "pandas")
+def _check_for_pandas(obj: Any, *, check_type: bool = True) -> bool:
+    return _PANDAS_AVAILABLE and _might_be(
+        cast(Hashable, type(obj) if check_type else obj), "pandas"
+    )
 
 
-def _check_for_pyarrow(obj: Any) -> bool:
-    return _PYARROW_AVAILABLE and _might_be(cast(Hashable, type(obj)), "pyarrow")
+def _check_for_pyarrow(obj: Any, *, check_type: bool = True) -> bool:
+    return _PYARROW_AVAILABLE and _might_be(
+        cast(Hashable, type(obj) if check_type else obj), "pyarrow"
+    )
 
 
-def _check_for_pydantic(obj: Any) -> bool:
-    return _PYDANTIC_AVAILABLE and _might_be(cast(Hashable, type(obj)), "pydantic")
+def _check_for_pydantic(obj: Any, *, check_type: bool = True) -> bool:
+    return _PYDANTIC_AVAILABLE and _might_be(
+        cast(Hashable, type(obj) if check_type else obj), "pydantic"
+    )
 
 
 __all__ = [

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import sys
-from collections import namedtuple
+from collections import OrderedDict, namedtuple
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal
 from random import shuffle
@@ -609,6 +609,21 @@ def test_init_ndarray(monkeypatch: Any) -> None:
     )
     assert_frame_equal(df0, df1, nans_compare_equal=True)
     assert df2.rows() == [(1.0, 4.0), (2.5, None), (None, 6.5)]
+
+
+def test_init_numpy_scalars() -> None:
+    df = pl.DataFrame(
+        {
+            "bool": [np.bool_(True), np.bool_(False)],
+            "i8": [np.int8(16), np.int8(64)],
+            "u32": [np.uint32(1234), np.uint32(9876)],
+        }
+    )
+    df_expected = pl.from_records(
+        data=[(True, 16, 1234), (False, 64, 9876)],
+        schema=OrderedDict([("bool", pl.Boolean), ("i8", pl.Int8), ("u32", pl.UInt32)]),
+    )
+    assert_frame_equal(df, df_expected)
 
 
 def test_null_array_print_format() -> None:


### PR DESCRIPTION
Closes #12007.

Something of an edge-case as you'd usually expect numpy values in `np.array` form, not as a list of scalars; in this case we load via AnyValue (as before), and then refine the type (new).