### PR TITLE
fix(python): fix issue with invalid `Mapping` objects used as schema being silently ignored

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -549,6 +549,7 @@ class LazyFrame:
         else:
             sources = [normalize_filepath(source) for source in source]
             source = None  # type: ignore[assignment]
+
         self = cls.__new__(cls)
         self._ldf = PyLazyFrame.new_from_ndjson(
             source,
@@ -566,13 +567,13 @@ class LazyFrame:
     @classmethod
     def _scan_python_function(
         cls,
-        schema: pa.schema | dict[str, PolarsDataType],
+        schema: pa.schema | Mapping[str, PolarsDataType],
         scan_fn: Any,
         *,
         pyarrow: bool = False,
     ) -> Self:
         self = cls.__new__(cls)
-        if isinstance(schema, dict):
+        if isinstance(schema, Mapping):
             self._ldf = PyLazyFrame.scan_from_python_function_pl_schema(
                 list(schema.items()), scan_fn, pyarrow
             )

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -724,7 +724,7 @@ def _unpack_schema(
         )
 
     # determine column names from schema
-    if isinstance(schema, dict):
+    if isinstance(schema, Mapping):
         column_names: list[str] = list(schema)
         # coerce schema to list[str | tuple[str, PolarsDataType | PythonDataType | None]
         schema = list(schema.items())
@@ -841,7 +841,7 @@ def dict_to_pydf(
     nan_to_null: bool = False,
 ) -> PyDataFrame:
     """Construct a PyDataFrame from a dictionary of sequences."""
-    if isinstance(schema, dict) and data:
+    if isinstance(schema, Mapping) and data:
         if not all((col in schema) for col in data):
             raise ValueError(
                 "the given column-schema names do not match the data dictionary"

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 from collections import OrderedDict
-from collections.abc import Mapping
 from datetime import date, timedelta
-from typing import Any, Iterator
+from typing import Any, Iterator, Mapping
 
 import pytest
 

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -1,12 +1,48 @@
 from __future__ import annotations
 
+from collections import OrderedDict
+from collections.abc import Mapping
 from datetime import date, timedelta
-from typing import Any
+from typing import Any, Iterator
 
 import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal
+
+
+class CustomSchema(Mapping[str, Any]):
+    """Dummy schema object for testing compatibility with Mapping."""
+
+    _entries: dict[str, Any]
+
+    def __init__(self, **named_entries: Any) -> None:
+        self._items = OrderedDict(named_entries.items())
+
+    def __getitem__(self, key: str) -> Any:
+        return self._items[key]
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __iter__(self) -> Iterator[str]:
+        yield from self._items
+
+
+def test_custom_schema() -> None:
+    schema = CustomSchema(bool=pl.Boolean, misc=pl.UInt8)
+
+    df = pl.DataFrame(
+        data={"bool": [True, False, None], "misc": [12, 34, 56]},
+        schema=schema,
+    )
+    assert df.schema == OrderedDict([("bool", pl.Boolean), ("misc", pl.UInt8)])
+
+    with pytest.raises(ValueError):
+        pl.DataFrame(
+            data={"bool": [True, False, None], "misc": [12, 34, 56]},
+            schema=CustomSchema(bool="boolean", misc="unsigned int"),
+        )
 
 
 def test_schema_on_agg() -> None:

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -29,19 +29,11 @@ class CustomSchema(Mapping[str, Any]):
 
 
 def test_custom_schema() -> None:
-    schema = CustomSchema(bool=pl.Boolean, misc=pl.UInt8)
-
-    df = pl.DataFrame(
-        data={"bool": [True, False, None], "misc": [12, 34, 56]},
-        schema=schema,
-    )
+    df = pl.DataFrame(schema=CustomSchema(bool=pl.Boolean, misc=pl.UInt8))
     assert df.schema == OrderedDict([("bool", pl.Boolean), ("misc", pl.UInt8)])
 
     with pytest.raises(ValueError):
-        pl.DataFrame(
-            data={"bool": [True, False, None], "misc": [12, 34, 56]},
-            schema=CustomSchema(bool="boolean", misc="unsigned int"),
-        )
+        pl.DataFrame(schema=CustomSchema(bool="boolean", misc="unsigned int"))
 
 
 def test_schema_on_agg() -> None:


### PR DESCRIPTION
We had a slight inconsistency with schema typing: both `SchemaDefinition` and `SchemaDict` are defined as `Mapping`, but there were a handful of internal checks being made against `dict` instead.

This allowed otherwise invalid schema-like objects to be passed to most constructors _without_ triggering an error; the given object would mostly just be ignored (a colleague hit this one at work just now ;)

Have fixed the `isinstance` checks and added explicit coverage of schema objects derived from `Mapping`.

### Before
```python
df = pl.DataFrame(schema=MappingSchema(colx="eggs", coly="sausages"))
# no error; bogus schema/types ignored
```
### After
```
ValueError: cannot infer dtype from 'eggs' (type: 'str')
```