### PR TITLE
fix(rust,python): make python `schema_overrides` information available to the rust-side inference code when initialising from records/dicts

### DIFF
--- a/crates/polars-core/src/schema.rs
+++ b/crates/polars-core/src/schema.rs
@@ -382,6 +382,13 @@ impl Schema {
         self.inner.iter().map(|(_name, dtype)| dtype)
     }
 
+    /// Iterates over mut references to the dtypes in this schema
+    pub fn iter_dtypes_mut(
+        &mut self,
+    ) -> impl Iterator<Item = &mut DataType> + '_ + ExactSizeIterator {
+        self.inner.iter_mut().map(|(_name, dtype)| dtype)
+    }
+
     /// Iterates over references to the names in this schema
     pub fn iter_names(&self) -> impl Iterator<Item = &SmartString> + '_ + ExactSizeIterator {
         self.inner.iter().map(|(name, _dtype)| name)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -425,7 +425,9 @@ class DataFrame:
         schema_overrides: SchemaDict | None = None,
         infer_schema_length: int | None = N_INFER_DEFAULT,
     ) -> Self:
-        pydf = PyDataFrame.read_dicts(data, infer_schema_length, schema)
+        pydf = PyDataFrame.read_dicts(
+            data, infer_schema_length, schema, schema_overrides
+        )
         if schema or schema_overrides:
             pydf = _post_apply_columns(
                 pydf, list(schema or pydf.columns()), schema_overrides=schema_overrides

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1148,7 +1148,9 @@ def _sequence_of_dict_to_pydf(
         if column_names
         else None
     )
-    pydf = PyDataFrame.read_dicts(data, infer_schema_length, dicts_schema)
+    pydf = PyDataFrame.read_dicts(
+        data, infer_schema_length, dicts_schema, schema_overrides
+    )
 
     # TODO: we can remove this `schema_overrides` block completely
     #  once https://github.com/pola-rs/polars/issues/11044 is fixed

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -50,14 +50,15 @@ impl PyDataFrame {
     fn finish_from_rows(
         rows: Vec<Row>,
         infer_schema_length: Option<usize>,
-        schema_overwrite: Option<Schema>,
+        schema: Option<Schema>,
+        schema_overrides_by_idx: Option<PlHashMap<usize, DataType>>,
     ) -> PyResult<Self> {
         // Object builder must be registered, this is done on import.
-        let schema =
-            rows_to_schema_supertypes(&rows, infer_schema_length.map(|n| std::cmp::max(1, n)))
-                .map_err(PyPolarsErr::from)?;
+        let s = rows_to_schema_supertypes(&rows, infer_schema_length.map(|n| std::cmp::max(1, n)))
+            .map_err(PyPolarsErr::from)?;
+
         // Replace inferred nulls with boolean and erase scale from inferred decimals.
-        let fields = schema.iter_fields().map(|mut fld| match fld.data_type() {
+        let fields = s.iter_fields().map(|mut fld| match fld.data_type() {
             DataType::Null => {
                 fld.coerce(DataType::Boolean);
                 fld
@@ -68,11 +69,11 @@ impl PyDataFrame {
             },
             _ => fld,
         });
-        let mut schema = Schema::from_iter(fields);
 
-        if let Some(schema_overwrite) = schema_overwrite {
-            for (i, (name, dtype)) in schema_overwrite.into_iter().enumerate() {
-                if let Some((name_, dtype_)) = schema.get_at_index_mut(i) {
+        let mut final_schema = Schema::from_iter(fields);
+        if let Some(schema) = schema {
+            for (i, (name, dtype)) in schema.into_iter().enumerate() {
+                if let Some((name_, dtype_)) = final_schema.get_at_index_mut(i) {
                     *name_ = name;
 
                     // If user sets dtype unknown, we use the inferred datatype.
@@ -80,12 +81,22 @@ impl PyDataFrame {
                         *dtype_ = dtype;
                     }
                 } else {
-                    schema.with_column(name, dtype);
+                    final_schema.with_column(name, dtype);
                 }
             }
         }
-
-        let df = DataFrame::from_rows_and_schema(&rows, &schema).map_err(PyPolarsErr::from)?;
+        // Optional per-field overrides; supersede default/inferred dtypes.
+        if let Some(overrides) = schema_overrides_by_idx {
+            for (i, dtype) in overrides {
+                if let Some((_, dtype_)) = final_schema.get_at_index_mut(i) {
+                    if !matches!(dtype, DataType::Unknown) {
+                        *dtype_ = dtype;
+                    }
+                }
+            }
+        }
+        let df =
+            DataFrame::from_rows_and_schema(&rows, &final_schema).map_err(PyPolarsErr::from)?;
         Ok(df.into())
     }
 
@@ -512,35 +523,41 @@ impl PyDataFrame {
     pub fn read_rows(
         rows: Vec<Wrap<Row>>,
         infer_schema_length: Option<usize>,
-        schema_overwrite: Option<Wrap<Schema>>,
+        schema: Option<Wrap<Schema>>,
     ) -> PyResult<Self> {
         // SAFETY: Wrap<T> is transparent.
         let rows = unsafe { std::mem::transmute::<Vec<Wrap<Row>>, Vec<Row>>(rows) };
-        Self::finish_from_rows(
-            rows,
-            infer_schema_length,
-            schema_overwrite.map(|wrap| wrap.0),
-        )
+        Self::finish_from_rows(rows, infer_schema_length, schema.map(|wrap| wrap.0), None)
     }
 
     #[staticmethod]
     pub fn read_dicts(
         dicts: &PyAny,
         infer_schema_length: Option<usize>,
-        schema_overwrite: Option<Wrap<Schema>>,
+        schema: Option<Wrap<Schema>>,
+        schema_overrides: Option<Wrap<Schema>>,
     ) -> PyResult<Self> {
         // If given, read dict fields in schema order.
         let mut schema_columns = PlIndexSet::new();
-        if let Some(schema) = &schema_overwrite {
-            schema_columns.extend(schema.0.iter_names().map(|n| n.to_string()))
+        if let Some(s) = &schema {
+            schema_columns.extend(s.0.iter_names().map(|n| n.to_string()))
         }
         let (rows, names) = dicts_to_rows(dicts, infer_schema_length, schema_columns)?;
+
+        let mut schema_overrides_by_idx: PlHashMap<usize, DataType> = PlHashMap::new();
+        if let Some(overrides) = schema_overrides {
+            for (idx, name) in names.iter().enumerate() {
+                if let Some(dtype) = overrides.0.get(name) {
+                    schema_overrides_by_idx.insert(idx, dtype.clone());
+                }
+            }
+        }
         let mut pydf = Self::finish_from_rows(
             rows,
             infer_schema_length,
-            schema_overwrite.map(|wrap| wrap.0),
+            schema.map(|wrap| wrap.0),
+            Some(schema_overrides_by_idx),
         )?;
-
         unsafe {
             for (s, name) in pydf.df.get_columns_mut().iter_mut().zip(&names) {
                 s.rename(name);


### PR DESCRIPTION
Closes #12032.

* We weren't passing information available in the user-provided "schema_overrides" param down into the Rust-side functions where the initial type inference occurs; consequently large UInt64 values would first get inferred as Float64 _before_ being cast back to UInt64, thereby losing accuracy.

* This PR enhances the Rust-side `read_dicts` and `finish_from_rows` methods, allowing them to integrate the additional/optional information so that they can establish the correct dtypes for overridden columns _without_ first mediating via an inferred type.

## Before

```python
import polars as pl
recs = [
    {"id":9187643043065364490, "misc":333},
    {"id":9223671840084328467, "misc":666},
    {"id":9187643043065364505, "misc":999},
]
df = pl.from_records( recs, schema_overrides={"id":pl.UInt64} )
```

```python
df
# shape: (3, 2)
# ┌─────────────────────┬──────┐
# │ id                  ┆ misc │
# │ ---                 ┆ ---  │
# │ u64                 ┆ i64  │
# ╞═════════════════════╪══════╡
# │ 9187643043065364480 ┆ 333  │   << all "id" values are wrong as
# │ 9223671840084328448 ┆ 666  │      they were cast back from f64
# │ 9187643043065364480 ┆ 999  │
# └─────────────────────┴──────┘
```

## After

```python
df
# shape: (3, 2)
# ┌─────────────────────┬──────┐
# │ id                  ┆ misc │
# │ ---                 ┆ ---  │
# │ u64                 ┆ i64  │
# ╞═════════════════════╪══════╡
# │ 9187643043065364490 ┆ 333  │   << all "id" values are now correct
# │ 9223671840084328467 ┆ 666  │      (avoided intermediate type/cast)
# │ 9187643043065364505 ┆ 999  │
# └─────────────────────┴──────┘
```
Note that if "schema_overrides" is _not_ provided, the column is loaded as Float64, so the user should see that they need to provide an explicit override, where applicable.

---

🚀 As well as fixing this edge case, we should also get a little extra performance when loading from dicts where only _partial_ type information is provided (via "schema_overrides"), as the effected columns will no longer trigger a post-init cast - they will be directly loaded as the correct type.

👀 Note: if the whole schema is given up-front (via the "schema" param) then none of these issues apply and everything is loaded correctly/efficiently.