### PR TITLE
fix: Use Arrow schema for file readers

### DIFF
--- a/crates/polars-arrow/src/datatypes/field.rs
+++ b/crates/polars-arrow/src/datatypes/field.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "serde_types")]
-use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::{DataType, Metadata};
 
@@ -12,7 +12,7 @@ use super::{DataType, Metadata};
 /// Almost all IO in this crate uses [`Field`] to represent logical information about the data
 /// to be serialized.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
-#[cfg_attr(feature = "serde_types", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Field {
     /// Its name
     pub name: String,

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -9,9 +9,7 @@ use std::sync::Arc;
 
 pub use field::Field;
 pub use physical_type::*;
-pub use schema::{
-    ArrowSchema, ArrowSchemaRef
-};
+pub use schema::{ArrowSchema, ArrowSchemaRef};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/crates/polars-arrow/src/datatypes/physical_type.rs
+++ b/crates/polars-arrow/src/datatypes/physical_type.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "serde_types")]
-use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 pub use crate::types::PrimitiveType;
 
@@ -55,7 +55,7 @@ impl PhysicalType {
 /// the set of valid indices types of a dictionary-encoded Array.
 /// Each type corresponds to a variant of [`crate::array::DictionaryArray`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde_types", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum IntegerType {
     /// A signed 8-bit integer.
     Int8,

--- a/crates/polars-arrow/src/datatypes/schema.rs
+++ b/crates/polars-arrow/src/datatypes/schema.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/crates/polars-arrow/src/datatypes/schema.rs
+++ b/crates/polars-arrow/src/datatypes/schema.rs
@@ -1,24 +1,27 @@
-#[cfg(feature = "serde_types")]
-use serde_derive::{Deserialize, Serialize};
+use std::sync::Arc;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 
 use super::{Field, Metadata};
 
 /// An ordered sequence of [`Field`]s with associated [`Metadata`].
 ///
-/// [`Schema`] is an abstraction used to read from, and write to, Arrow IPC format,
+/// [`ArrowSchema`] is an abstraction used to read from, and write to, Arrow IPC format,
 /// Apache Parquet, and Apache Avro. All these formats have a concept of a schema
 /// with fields and metadata.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "serde_types", derive(Serialize, Deserialize))]
-pub struct Schema {
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ArrowSchema {
     /// The fields composing this schema.
     pub fields: Vec<Field>,
     /// Optional metadata.
     pub metadata: Metadata,
 }
 
-impl Schema {
-    /// Attaches a [`Metadata`] to [`Schema`]
+pub type ArrowSchemaRef = Arc<ArrowSchema>;
+
+impl ArrowSchema {
+    /// Attaches a [`Metadata`] to [`ArrowSchema`]
     #[inline]
     pub fn with_metadata(self, metadata: Metadata) -> Self {
         Self {
@@ -27,7 +30,17 @@ impl Schema {
         }
     }
 
-    /// Returns a new [`Schema`] with a subset of all fields whose `predicate`
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.fields.len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.fields.is_empty()
+    }
+
+    /// Returns a new [`ArrowSchema`] with a subset of all fields whose `predicate`
     /// evaluates to true.
     pub fn filter<F: Fn(usize, &Field) -> bool>(self, predicate: F) -> Self {
         let fields = self
@@ -43,14 +56,14 @@ impl Schema {
             })
             .collect();
 
-        Schema {
+        ArrowSchema {
             fields,
             metadata: self.metadata,
         }
     }
 }
 
-impl From<Vec<Field>> for Schema {
+impl From<Vec<Field>> for ArrowSchema {
     fn from(fields: Vec<Field>) -> Self {
         Self {
             fields,

--- a/crates/polars-arrow/src/io/avro/read/schema.rs
+++ b/crates/polars-arrow/src/io/avro/read/schema.rs
@@ -19,9 +19,9 @@ fn external_props(schema: &AvroSchema) -> Metadata {
     props
 }
 
-/// Infers an [`Schema`] from the root [`Record`].
+/// Infers an [`ArrowSchema`] from the root [`Record`].
 /// This
-pub fn infer_schema(record: &Record) -> PolarsResult<Schema> {
+pub fn infer_schema(record: &Record) -> PolarsResult<ArrowSchema> {
     Ok(record
         .fields
         .iter()

--- a/crates/polars-arrow/src/io/avro/write/schema.rs
+++ b/crates/polars-arrow/src/io/avro/write/schema.rs
@@ -6,8 +6,8 @@ use polars_error::{polars_bail, PolarsResult};
 
 use crate::datatypes::*;
 
-/// Converts a [`Schema`] to an Avro [`Record`].
-pub fn to_record(schema: &Schema) -> PolarsResult<Record> {
+/// Converts a [`ArrowSchema`] to an Avro [`Record`].
+pub fn to_record(schema: &ArrowSchema) -> PolarsResult<Record> {
     let mut name_counter: i32 = 0;
     let fields = schema
         .fields

--- a/crates/polars-arrow/src/io/flight/mod.rs
+++ b/crates/polars-arrow/src/io/flight/mod.rs
@@ -53,9 +53,9 @@ impl From<EncodedData> for FlightData {
     }
 }
 
-/// Serializes a [`Schema`] to [`SchemaResult`].
+/// Serializes a [`ArrowSchema`] to [`SchemaResult`].
 pub fn serialize_schema_to_result(
-    schema: &Schema,
+    schema: &ArrowSchema,
     ipc_fields: Option<&[IpcField]>,
 ) -> SchemaResult {
     SchemaResult {
@@ -63,17 +63,17 @@ pub fn serialize_schema_to_result(
     }
 }
 
-/// Serializes a [`Schema`] to [`FlightData`].
-pub fn serialize_schema(schema: &Schema, ipc_fields: Option<&[IpcField]>) -> FlightData {
+/// Serializes a [`ArrowSchema`] to [`FlightData`].
+pub fn serialize_schema(schema: &ArrowSchema, ipc_fields: Option<&[IpcField]>) -> FlightData {
     FlightData {
         data_header: _serialize_schema(schema, ipc_fields),
         ..Default::default()
     }
 }
 
-/// Convert a [`Schema`] to bytes in the format expected in [`arrow_format::flight::data::FlightInfo`].
+/// Convert a [`ArrowSchema`] to bytes in the format expected in [`arrow_format::flight::data::FlightInfo`].
 pub fn serialize_schema_to_info(
-    schema: &Schema,
+    schema: &ArrowSchema,
     ipc_fields: Option<&[IpcField]>,
 ) -> PolarsResult<Vec<u8>> {
     let encoded_data = if let Some(ipc_fields) = ipc_fields {
@@ -88,7 +88,7 @@ pub fn serialize_schema_to_info(
     Ok(schema)
 }
 
-fn _serialize_schema(schema: &Schema, ipc_fields: Option<&[IpcField]>) -> Vec<u8> {
+fn _serialize_schema(schema: &ArrowSchema, ipc_fields: Option<&[IpcField]>) -> Vec<u8> {
     if let Some(ipc_fields) = ipc_fields {
         write::schema_to_bytes(schema, ipc_fields)
     } else {
@@ -97,16 +97,16 @@ fn _serialize_schema(schema: &Schema, ipc_fields: Option<&[IpcField]>) -> Vec<u8
     }
 }
 
-fn schema_as_encoded_data(schema: &Schema, ipc_fields: &[IpcField]) -> EncodedData {
+fn schema_as_encoded_data(schema: &ArrowSchema, ipc_fields: &[IpcField]) -> EncodedData {
     EncodedData {
         ipc_message: write::schema_to_bytes(schema, ipc_fields),
         arrow_data: vec![],
     }
 }
 
-/// Deserialize an IPC message into [`Schema`], [`IpcSchema`].
+/// Deserialize an IPC message into [`ArrowSchema`], [`IpcSchema`].
 /// Use to deserialize [`FlightData::data_header`] and [`SchemaResult::schema`].
-pub fn deserialize_schemas(bytes: &[u8]) -> PolarsResult<(Schema, IpcSchema)> {
+pub fn deserialize_schemas(bytes: &[u8]) -> PolarsResult<(ArrowSchema, IpcSchema)> {
     read::deserialize_schema(bytes)
 }
 

--- a/crates/polars-arrow/src/io/ipc/read/file.rs
+++ b/crates/polars-arrow/src/io/ipc/read/file.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 use std::io::{Read, Seek, SeekFrom};
+use std::sync::Arc;
 
 use ahash::AHashMap;
 use arrow_format::ipc::planus::ReadAsRoot;
@@ -11,14 +12,14 @@ use super::schema::fb_to_schema;
 use super::{Dictionaries, OutOfSpecKind};
 use crate::array::Array;
 use crate::chunk::Chunk;
-use crate::datatypes::ArrowSchema;
+use crate::datatypes::ArrowSchemaRef;
 use crate::io::ipc::IpcSchema;
 
 /// Metadata of an Arrow IPC file, written in the footer of the file.
 #[derive(Debug, Clone)]
 pub struct FileMetadata {
     /// The schema that is read from the file footer
-    pub schema: ArrowSchema,
+    pub schema: ArrowSchemaRef,
 
     /// The files' [`IpcSchema`]
     pub ipc_schema: IpcSchema,
@@ -200,7 +201,7 @@ pub(super) fn deserialize_footer(footer_data: &[u8], size: u64) -> PolarsResult<
         .transpose()?;
 
     Ok(FileMetadata {
-        schema,
+        schema: Arc::new(schema),
         ipc_schema,
         blocks,
         dictionaries,

--- a/crates/polars-arrow/src/io/ipc/read/file.rs
+++ b/crates/polars-arrow/src/io/ipc/read/file.rs
@@ -11,14 +11,14 @@ use super::schema::fb_to_schema;
 use super::{Dictionaries, OutOfSpecKind};
 use crate::array::Array;
 use crate::chunk::Chunk;
-use crate::datatypes::Schema;
+use crate::datatypes::ArrowSchema;
 use crate::io::ipc::IpcSchema;
 
 /// Metadata of an Arrow IPC file, written in the footer of the file.
 #[derive(Debug, Clone)]
 pub struct FileMetadata {
     /// The schema that is read from the file footer
-    pub schema: Schema,
+    pub schema: ArrowSchema,
 
     /// The files' [`IpcSchema`]
     pub ipc_schema: IpcSchema,

--- a/crates/polars-arrow/src/io/ipc/read/file_async.rs
+++ b/crates/polars-arrow/src/io/ipc/read/file_async.rs
@@ -13,13 +13,13 @@ use super::file::{deserialize_footer, get_record_batch};
 use super::{Dictionaries, FileMetadata, OutOfSpecKind};
 use crate::array::*;
 use crate::chunk::Chunk;
-use crate::datatypes::{Field, Schema};
+use crate::datatypes::{Field, ArrowSchema};
 use crate::io::ipc::{IpcSchema, ARROW_MAGIC_V2, CONTINUATION_MARKER};
 
 /// Async reader for Arrow IPC files
 pub struct FileStream<'a> {
     stream: BoxStream<'a, PolarsResult<Chunk<Box<dyn Array>>>>,
-    schema: Option<Schema>,
+    schema: Option<ArrowSchema>,
     metadata: FileMetadata,
 }
 
@@ -39,7 +39,7 @@ impl<'a> FileStream<'a> {
     {
         let (projection, schema) = if let Some(projection) = projection {
             let (p, h, fields) = prepare_projection(&metadata.schema.fields, projection);
-            let schema = Schema {
+            let schema = ArrowSchema {
                 fields,
                 metadata: metadata.schema.metadata.clone(),
             };
@@ -62,7 +62,7 @@ impl<'a> FileStream<'a> {
     }
 
     /// Get the projected schema from the IPC file.
-    pub fn schema(&self) -> &Schema {
+    pub fn schema(&self) -> &ArrowSchema {
         self.schema.as_ref().unwrap_or(&self.metadata.schema)
     }
 

--- a/crates/polars-arrow/src/io/ipc/read/file_async.rs
+++ b/crates/polars-arrow/src/io/ipc/read/file_async.rs
@@ -13,7 +13,7 @@ use super::file::{deserialize_footer, get_record_batch};
 use super::{Dictionaries, FileMetadata, OutOfSpecKind};
 use crate::array::*;
 use crate::chunk::Chunk;
-use crate::datatypes::{Field, ArrowSchema};
+use crate::datatypes::{ArrowSchema, Field};
 use crate::io::ipc::{IpcSchema, ARROW_MAGIC_V2, CONTINUATION_MARKER};
 
 /// Async reader for Arrow IPC files

--- a/crates/polars-arrow/src/io/ipc/read/reader.rs
+++ b/crates/polars-arrow/src/io/ipc/read/reader.rs
@@ -7,7 +7,7 @@ use super::common::*;
 use super::{read_batch, read_file_dictionaries, Dictionaries, FileMetadata};
 use crate::array::Array;
 use crate::chunk::Chunk;
-use crate::datatypes::Schema;
+use crate::datatypes::ArrowSchema;
 
 /// An iterator of [`Chunk`]s from an Arrow IPC file.
 pub struct FileReader<R: Read + Seek> {
@@ -16,7 +16,7 @@ pub struct FileReader<R: Read + Seek> {
     // the dictionaries are going to be read
     dictionaries: Option<Dictionaries>,
     current_block: usize,
-    projection: Option<(Vec<usize>, AHashMap<usize, usize>, Schema)>,
+    projection: Option<(Vec<usize>, AHashMap<usize, usize>, ArrowSchema)>,
     remaining: usize,
     data_scratch: Vec<u8>,
     message_scratch: Vec<u8>,
@@ -34,7 +34,7 @@ impl<R: Read + Seek> FileReader<R> {
     ) -> Self {
         let projection = projection.map(|projection| {
             let (p, h, fields) = prepare_projection(&metadata.schema.fields, projection);
-            let schema = Schema {
+            let schema = ArrowSchema {
                 fields,
                 metadata: metadata.schema.metadata.clone(),
             };
@@ -53,7 +53,7 @@ impl<R: Read + Seek> FileReader<R> {
     }
 
     /// Return the schema of the file
-    pub fn schema(&self) -> &Schema {
+    pub fn schema(&self) -> &ArrowSchema {
         self.projection
             .as_ref()
             .map(|x| &x.2)

--- a/crates/polars-arrow/src/io/ipc/read/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/read/schema.rs
@@ -5,7 +5,7 @@ use polars_error::{polars_bail, polars_err, PolarsResult};
 use super::super::{IpcField, IpcSchema};
 use super::{OutOfSpecKind, StreamMetadata};
 use crate::datatypes::{
-    get_extension, DataType, Extension, Field, IntegerType, IntervalUnit, Metadata, ArrowSchema,
+    get_extension, ArrowSchema, DataType, Extension, Field, IntegerType, IntervalUnit, Metadata,
     TimeUnit, UnionMode,
 };
 

--- a/crates/polars-arrow/src/io/ipc/read/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/read/schema.rs
@@ -5,7 +5,7 @@ use polars_error::{polars_bail, polars_err, PolarsResult};
 use super::super::{IpcField, IpcSchema};
 use super::{OutOfSpecKind, StreamMetadata};
 use crate::datatypes::{
-    get_extension, DataType, Extension, Field, IntegerType, IntervalUnit, Metadata, Schema,
+    get_extension, DataType, Extension, Field, IntegerType, IntervalUnit, Metadata, ArrowSchema,
     TimeUnit, UnionMode,
 };
 
@@ -352,8 +352,8 @@ fn get_data_type(
     })
 }
 
-/// Deserialize an flatbuffers-encoded Schema message into [`Schema`] and [`IpcSchema`].
-pub fn deserialize_schema(message: &[u8]) -> PolarsResult<(Schema, IpcSchema)> {
+/// Deserialize an flatbuffers-encoded Schema message into [`ArrowSchema`] and [`IpcSchema`].
+pub fn deserialize_schema(message: &[u8]) -> PolarsResult<(ArrowSchema, IpcSchema)> {
     let message = arrow_format::ipc::MessageRef::read_as_root(message)
         .map_err(|_err| polars_err!(oos = "Unable deserialize message: {err:?}"))?;
 
@@ -371,7 +371,7 @@ pub fn deserialize_schema(message: &[u8]) -> PolarsResult<(Schema, IpcSchema)> {
 /// Deserialize the raw Schema table from IPC format to Schema data type
 pub(super) fn fb_to_schema(
     schema: arrow_format::ipc::SchemaRef,
-) -> PolarsResult<(Schema, IpcSchema)> {
+) -> PolarsResult<(ArrowSchema, IpcSchema)> {
     let fields = schema
         .fields()?
         .ok_or_else(|| polars_err!(oos = OutOfSpecKind::MissingFields))?;
@@ -400,7 +400,7 @@ pub(super) fn fb_to_schema(
     }
 
     Ok((
-        Schema { fields, metadata },
+        ArrowSchema { fields, metadata },
         IpcSchema {
             fields: ipc_fields,
             is_little_endian,

--- a/crates/polars-arrow/src/io/ipc/write/file_async.rs
+++ b/crates/polars-arrow/src/io/ipc/write/file_async.rs
@@ -30,7 +30,7 @@ pub struct FileSink<'a, W: AsyncWrite + Unpin + Send + 'a> {
     fields: Vec<IpcField>,
     record_blocks: Vec<Block>,
     dictionary_blocks: Vec<Block>,
-    schema: Schema,
+    schema: ArrowSchema,
 }
 
 impl<'a, W> FileSink<'a, W>
@@ -40,7 +40,7 @@ where
     /// Create a new file writer.
     pub fn new(
         writer: W,
-        schema: Schema,
+        schema: ArrowSchema,
         ipc_fields: Option<Vec<IpcField>>,
         options: WriteOptions,
     ) -> Self {

--- a/crates/polars-arrow/src/io/ipc/write/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/write/schema.rs
@@ -2,7 +2,7 @@ use arrow_format::ipc::planus::Builder;
 
 use super::super::IpcField;
 use crate::datatypes::{
-    DataType, Field, IntegerType, IntervalUnit, Metadata, ArrowSchema, TimeUnit, UnionMode,
+    ArrowSchema, DataType, Field, IntegerType, IntervalUnit, Metadata, TimeUnit, UnionMode,
 };
 use crate::io::ipc::endianness::is_native_little_endian;
 
@@ -21,7 +21,10 @@ pub fn schema_to_bytes(schema: &ArrowSchema, ipc_fields: &[IpcField]) -> Vec<u8>
     footer_data.to_vec()
 }
 
-pub fn serialize_schema(schema: &ArrowSchema, ipc_fields: &[IpcField]) -> arrow_format::ipc::Schema {
+pub fn serialize_schema(
+    schema: &ArrowSchema,
+    ipc_fields: &[IpcField],
+) -> arrow_format::ipc::Schema {
     let endianness = if is_native_little_endian() {
         arrow_format::ipc::Endianness::Little
     } else {

--- a/crates/polars-arrow/src/io/ipc/write/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/write/schema.rs
@@ -2,12 +2,12 @@ use arrow_format::ipc::planus::Builder;
 
 use super::super::IpcField;
 use crate::datatypes::{
-    DataType, Field, IntegerType, IntervalUnit, Metadata, Schema, TimeUnit, UnionMode,
+    DataType, Field, IntegerType, IntervalUnit, Metadata, ArrowSchema, TimeUnit, UnionMode,
 };
 use crate::io::ipc::endianness::is_native_little_endian;
 
-/// Converts a [Schema] and [IpcField]s to a flatbuffers-encoded [arrow_format::ipc::Message].
-pub fn schema_to_bytes(schema: &Schema, ipc_fields: &[IpcField]) -> Vec<u8> {
+/// Converts a [ArrowSchema] and [IpcField]s to a flatbuffers-encoded [arrow_format::ipc::Message].
+pub fn schema_to_bytes(schema: &ArrowSchema, ipc_fields: &[IpcField]) -> Vec<u8> {
     let schema = serialize_schema(schema, ipc_fields);
 
     let message = arrow_format::ipc::Message {
@@ -21,7 +21,7 @@ pub fn schema_to_bytes(schema: &Schema, ipc_fields: &[IpcField]) -> Vec<u8> {
     footer_data.to_vec()
 }
 
-pub fn serialize_schema(schema: &Schema, ipc_fields: &[IpcField]) -> arrow_format::ipc::Schema {
+pub fn serialize_schema(schema: &ArrowSchema, ipc_fields: &[IpcField]) -> arrow_format::ipc::Schema {
     let endianness = if is_native_little_endian() {
         arrow_format::ipc::Endianness::Little
     } else {

--- a/crates/polars-arrow/src/io/ipc/write/stream.rs
+++ b/crates/polars-arrow/src/io/ipc/write/stream.rs
@@ -53,7 +53,7 @@ impl<W: Write> StreamWriter<W> {
     /// Use `ipc_fields` to declare dictionary ids in the schema, for dictionary-reuse
     pub fn start(
         &mut self,
-        schema: &Schema,
+        schema: &ArrowSchema,
         ipc_fields: Option<Vec<IpcField>>,
     ) -> PolarsResult<()> {
         self.ipc_fields = Some(if let Some(ipc_fields) = ipc_fields {

--- a/crates/polars-arrow/src/io/ipc/write/stream_async.rs
+++ b/crates/polars-arrow/src/io/ipc/write/stream_async.rs
@@ -32,7 +32,7 @@ where
     /// Create a new [`StreamSink`].
     pub fn new(
         writer: W,
-        schema: &Schema,
+        schema: &ArrowSchema,
         ipc_fields: Option<Vec<IpcField>>,
         write_options: WriteOptions,
     ) -> Self {
@@ -52,7 +52,7 @@ where
 
     fn start(
         mut writer: W,
-        schema: &Schema,
+        schema: &ArrowSchema,
         ipc_fields: &[IpcField],
     ) -> BoxFuture<'a, PolarsResult<Option<W>>> {
         let message = EncodedData {

--- a/crates/polars-arrow/src/io/ipc/write/writer.rs
+++ b/crates/polars-arrow/src/io/ipc/write/writer.rs
@@ -26,7 +26,7 @@ pub struct FileWriter<W: Write> {
     /// IPC write options
     pub(crate) options: WriteOptions,
     /// A reference to the schema, used in validating record batches
-    pub(crate) schema: ArrowSchema,
+    pub(crate) schema: ArrowSchemaRef,
     pub(crate) ipc_fields: Vec<IpcField>,
     /// The number of bytes between each block of bytes, as an offset for random access
     pub(crate) block_offsets: usize,
@@ -46,7 +46,7 @@ impl<W: Write> FileWriter<W> {
     /// Creates a new [`FileWriter`] and writes the header to `writer`
     pub fn try_new(
         writer: W,
-        schema: ArrowSchema,
+        schema: ArrowSchemaRef,
         ipc_fields: Option<Vec<IpcField>>,
         options: WriteOptions,
     ) -> PolarsResult<Self> {
@@ -59,7 +59,7 @@ impl<W: Write> FileWriter<W> {
     /// Creates a new [`FileWriter`].
     pub fn new(
         writer: W,
-        schema: ArrowSchema,
+        schema: ArrowSchemaRef,
         ipc_fields: Option<Vec<IpcField>>,
         options: WriteOptions,
     ) -> Self {

--- a/crates/polars-arrow/src/io/ipc/write/writer.rs
+++ b/crates/polars-arrow/src/io/ipc/write/writer.rs
@@ -26,7 +26,7 @@ pub struct FileWriter<W: Write> {
     /// IPC write options
     pub(crate) options: WriteOptions,
     /// A reference to the schema, used in validating record batches
-    pub(crate) schema: Schema,
+    pub(crate) schema: ArrowSchema,
     pub(crate) ipc_fields: Vec<IpcField>,
     /// The number of bytes between each block of bytes, as an offset for random access
     pub(crate) block_offsets: usize,
@@ -46,7 +46,7 @@ impl<W: Write> FileWriter<W> {
     /// Creates a new [`FileWriter`] and writes the header to `writer`
     pub fn try_new(
         writer: W,
-        schema: Schema,
+        schema: ArrowSchema,
         ipc_fields: Option<Vec<IpcField>>,
         options: WriteOptions,
     ) -> PolarsResult<Self> {
@@ -59,7 +59,7 @@ impl<W: Write> FileWriter<W> {
     /// Creates a new [`FileWriter`].
     pub fn new(
         writer: W,
-        schema: Schema,
+        schema: ArrowSchema,
         ipc_fields: Option<Vec<IpcField>>,
         options: WriteOptions,
     ) -> Self {

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -122,7 +122,7 @@ bigidx = ["arrow/bigidx", "polars-utils/bigidx"]
 python = []
 
 serde = ["dep:serde", "smartstring/serde", "bitflags/serde"]
-serde-lazy = ["serde", "arrow/serde", "indexmap/serde", "smartstring/serde", "chrono/serde"]
+serde-lazy = ["serde", "arrow/serde", "indexmap/serde", "smartstring/serde", "chrono/serde", "arrow/serde"]
 
 docs-selection = [
   "ndarray",

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -122,7 +122,7 @@ bigidx = ["arrow/bigidx", "polars-utils/bigidx"]
 python = []
 
 serde = ["dep:serde", "smartstring/serde", "bitflags/serde"]
-serde-lazy = ["serde", "arrow/serde", "indexmap/serde", "smartstring/serde", "chrono/serde", "arrow/serde"]
+serde-lazy = ["serde", "arrow/serde", "indexmap/serde", "smartstring/serde", "chrono/serde"]
 
 docs-selection = [
   "ndarray",

--- a/crates/polars-core/src/frame/from.rs
+++ b/crates/polars-core/src/frame/from.rs
@@ -1,4 +1,3 @@
-use arrow_array::Array;
 use arrow::array::StructArray;
 
 use crate::prelude::*;
@@ -37,9 +36,10 @@ impl From<&Schema> for DataFrame {
 
 impl From<&ArrowSchema> for DataFrame {
     fn from(schema: &ArrowSchema) -> Self {
-        let cols = schema.fields
+        let cols = schema
+            .fields
             .iter()
-            .map(|(fld)| Series::new_empty(fld.name.as_str(), &(fld.data_type().into())))
+            .map(|fld| Series::new_empty(fld.name.as_str(), &(fld.data_type().into())))
             .collect();
         DataFrame::new_no_checks(cols)
     }

--- a/crates/polars-core/src/frame/from.rs
+++ b/crates/polars-core/src/frame/from.rs
@@ -1,3 +1,4 @@
+use arrow_array::Array;
 use arrow::array::StructArray;
 
 use crate::prelude::*;
@@ -29,6 +30,16 @@ impl From<&Schema> for DataFrame {
         let cols = schema
             .iter()
             .map(|(name, dtype)| Series::new_empty(name, dtype))
+            .collect();
+        DataFrame::new_no_checks(cols)
+    }
+}
+
+impl From<&ArrowSchema> for DataFrame {
+    fn from(schema: &ArrowSchema) -> Self {
+        let cols = schema.fields
+            .iter()
+            .map(|(fld)| Series::new_empty(fld.name.as_str(), &(fld.data_type().into())))
             .collect();
         DataFrame::new_no_checks(cols)
     }

--- a/crates/polars-core/src/prelude.rs
+++ b/crates/polars-core/src/prelude.rs
@@ -2,7 +2,7 @@
 pub use std::sync::Arc;
 
 pub(crate) use arrow::array::*;
-pub use arrow::datatypes::{Field as ArrowField, Schema as ArrowSchema};
+pub use arrow::datatypes::{Field as ArrowField, ArrowSchema as ArrowSchema};
 #[cfg(feature = "ewma")]
 pub use arrow::legacy::kernels::ewm::EWMOptions;
 pub use arrow::legacy::prelude::*;

--- a/crates/polars-core/src/prelude.rs
+++ b/crates/polars-core/src/prelude.rs
@@ -2,7 +2,7 @@
 pub use std::sync::Arc;
 
 pub(crate) use arrow::array::*;
-pub use arrow::datatypes::{Field as ArrowField, ArrowSchema as ArrowSchema};
+pub use arrow::datatypes::{ArrowSchema, Field as ArrowField};
 #[cfg(feature = "ewma")]
 pub use arrow::legacy::kernels::ewm::EWMOptions;
 pub use arrow::legacy::prelude::*;

--- a/crates/polars-core/src/schema.rs
+++ b/crates/polars-core/src/schema.rs
@@ -5,6 +5,7 @@ use indexmap::IndexMap;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
 use smartstring::alias::String as SmartString;
+use arrow::datatypes::ArrowSchemaRef;
 
 use crate::prelude::*;
 use crate::utils::try_get_supertype;
@@ -455,5 +456,28 @@ impl IndexOfSchema for ArrowSchema {
 
     fn get_names(&self) -> Vec<&str> {
         self.fields.iter().map(|f| f.name.as_str()).collect()
+    }
+}
+
+impl From<&ArrowSchema> for Schema {
+    fn from(value: &ArrowSchema) -> Self {
+        Self::from_iter(value.fields.iter())
+    }
+}
+impl From<ArrowSchema> for Schema {
+    fn from(value: ArrowSchema) -> Self {
+        Self::from(&value)
+    }
+}
+
+impl From<ArrowSchemaRef> for Schema {
+    fn from(value: ArrowSchemaRef) -> Self {
+        Self::from(value.as_ref())
+    }
+}
+
+impl From<&ArrowSchemaRef> for Schema {
+    fn from(value: &ArrowSchemaRef) -> Self {
+        Self::from(value.as_ref())
     }
 }

--- a/crates/polars-core/src/schema.rs
+++ b/crates/polars-core/src/schema.rs
@@ -1,11 +1,11 @@
 use std::fmt::{Debug, Formatter};
 
+use arrow::datatypes::ArrowSchemaRef;
 use indexmap::map::MutableKeys;
 use indexmap::IndexMap;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
 use smartstring::alias::String as SmartString;
-use arrow::datatypes::ArrowSchemaRef;
 
 use crate::prelude::*;
 use crate::utils::try_get_supertype;

--- a/crates/polars-io/src/ipc/ipc_file.rs
+++ b/crates/polars-io/src/ipc/ipc_file.rs
@@ -34,6 +34,7 @@
 //! ```
 use std::io::{Read, Seek};
 use std::sync::Arc;
+use arrow::datatypes::ArrowSchemaRef;
 
 use arrow::io::ipc::read;
 use polars_core::frame::ArrowChunk;
@@ -106,14 +107,8 @@ impl<R: MmapBytesReader> IpcReader<R> {
         Ok(self.metadata.as_ref().unwrap())
     }
 
-    /// Get schema of the Ipc File
-    pub fn schema(&mut self) -> PolarsResult<Schema> {
-        let metadata = self.get_metadata()?;
-        Ok(Schema::from_iter(&metadata.schema.fields))
-    }
-
-    /// Get arrow schema of the Ipc File, this is faster than creating a polars schema.
-    pub fn arrow_schema(&mut self) -> PolarsResult<ArrowSchema> {
+    /// Get arrow schema of the Ipc File.
+    pub fn schema(&mut self) -> PolarsResult<ArrowSchema> {
         let metadata = read::read_file_metadata(&mut self.reader)?;
         Ok(metadata.schema)
     }

--- a/crates/polars-io/src/ipc/ipc_file.rs
+++ b/crates/polars-io/src/ipc/ipc_file.rs
@@ -35,6 +35,7 @@
 use std::io::{Read, Seek};
 use std::sync::Arc;
 
+use arrow::datatypes::ArrowSchemaRef;
 use arrow::io::ipc::read;
 use polars_core::frame::ArrowChunk;
 use polars_core::prelude::*;
@@ -73,6 +74,7 @@ pub struct IpcReader<R: MmapBytesReader> {
     pub(super) row_count: Option<RowCount>,
     memmap: bool,
     metadata: Option<read::FileMetadata>,
+    schema: Option<ArrowSchemaRef>,
 }
 
 fn check_mmap_err(err: PolarsError) -> PolarsResult<()> {
@@ -101,15 +103,17 @@ impl<R: MmapBytesReader> IpcReader<R> {
     }
     fn get_metadata(&mut self) -> PolarsResult<&read::FileMetadata> {
         if self.metadata.is_none() {
-            self.metadata = Some(read::read_file_metadata(&mut self.reader)?);
+            let metadata = read::read_file_metadata(&mut self.reader)?;
+            self.schema = Some(metadata.schema.clone());
+            self.metadata = Some(metadata);
         }
         Ok(self.metadata.as_ref().unwrap())
     }
 
     /// Get arrow schema of the Ipc File.
-    pub fn schema(&mut self) -> PolarsResult<ArrowSchema> {
-        let metadata = read::read_file_metadata(&mut self.reader)?;
-        Ok(metadata.schema)
+    pub fn schema(&mut self) -> PolarsResult<ArrowSchemaRef> {
+        self.get_metadata()?;
+        Ok(self.schema.as_ref().unwrap().clone())
     }
     /// Stop reading when `n` rows are read.
     pub fn with_n_rows(mut self, num_rows: Option<usize>) -> Self {
@@ -162,7 +166,7 @@ impl<R: MmapBytesReader> IpcReader<R> {
         let metadata = read::read_file_metadata(&mut self.reader)?;
 
         let schema = if let Some(projection) = &self.projection {
-            apply_projection(&metadata.schema, projection)
+            Arc::new(apply_projection(&metadata.schema, projection))
         } else {
             metadata.schema.clone()
         };
@@ -193,6 +197,7 @@ impl<R: MmapBytesReader> SerReader<R> for IpcReader<R> {
             row_count: None,
             memmap: true,
             metadata: None,
+            schema: None,
         }
     }
 
@@ -218,7 +223,7 @@ impl<R: MmapBytesReader> SerReader<R> for IpcReader<R> {
         }
 
         let schema = if let Some(projection) = &self.projection {
-            apply_projection(&metadata.schema, projection)
+            Arc::new(apply_projection(&metadata.schema, projection))
         } else {
             metadata.schema.clone()
         };

--- a/crates/polars-io/src/ipc/ipc_file.rs
+++ b/crates/polars-io/src/ipc/ipc_file.rs
@@ -34,7 +34,6 @@
 //! ```
 use std::io::{Read, Seek};
 use std::sync::Arc;
-use arrow::datatypes::ArrowSchemaRef;
 
 use arrow::io::ipc::read;
 use polars_core::frame::ArrowChunk;

--- a/crates/polars-io/src/ipc/mmap.rs
+++ b/crates/polars-io/src/ipc/mmap.rs
@@ -85,7 +85,7 @@ impl<R: MmapBytesReader> IpcReader<R> {
                 }
 
                 let schema = if let Some(projection) = &self.projection {
-                    apply_projection(&metadata.schema, projection)
+                    Arc::new(apply_projection(&metadata.schema, projection))
                 } else {
                     metadata.schema.clone()
                 };

--- a/crates/polars-io/src/ipc/write.rs
+++ b/crates/polars-io/src/ipc/write.rs
@@ -44,7 +44,7 @@ impl<W: Write> IpcWriter<W> {
     pub fn batched(self, schema: &Schema) -> PolarsResult<BatchedWriter<W>> {
         let mut writer = write::FileWriter::new(
             self.writer,
-            schema.to_arrow(),
+            Arc::new(schema.to_arrow()),
             None,
             WriteOptions {
                 compression: self.compression.map(|c| c.into()),
@@ -70,7 +70,7 @@ where
     fn finish(&mut self, df: &mut DataFrame) -> PolarsResult<()> {
         let mut ipc_writer = write::FileWriter::try_new(
             &mut self.writer,
-            df.schema().to_arrow(),
+            Arc::new(df.schema().to_arrow()),
             None,
             WriteOptions {
                 compression: self.compression.map(|c| c.into()),

--- a/crates/polars-io/src/parquet/async_impl.rs
+++ b/crates/polars-io/src/parquet/async_impl.rs
@@ -15,6 +15,7 @@ use polars_core::schema::Schema;
 use polars_parquet::read::{self as parquet2_read, RowGroupMetaData};
 use polars_parquet::write::FileMetaData;
 use smartstring::alias::String as SmartString;
+use arrow::datatypes::ArrowSchemaRef;
 
 use super::cloud::{build_object_store, CloudLocation, CloudReader};
 use super::mmap;
@@ -61,12 +62,12 @@ impl ParquetObjectStore {
         Ok(())
     }
 
-    pub async fn schema(&mut self) -> PolarsResult<Schema> {
+    pub async fn schema(&mut self) -> PolarsResult<ArrowSchemaRef> {
         let metadata = self.get_metadata().await?;
 
         let arrow_schema = parquet2_read::infer_schema(metadata)?;
 
-        Ok(Schema::from_iter(&arrow_schema.fields))
+        Ok(Arc::new(arrow_schema))
     }
 
     /// Number of rows in the parquet file.
@@ -159,7 +160,7 @@ pub struct FetchRowGroupsFromObjectStore {
     row_groups_metadata: Vec<RowGroupMetaData>,
     projected_fields: Vec<SmartString>,
     predicate: Option<Arc<dyn PhysicalIoExpr>>,
-    schema: SchemaRef,
+    schema: ArrowSchemaRef,
     logging: bool,
 }
 
@@ -167,7 +168,7 @@ impl FetchRowGroupsFromObjectStore {
     pub fn new(
         reader: ParquetObjectStore,
         metadata: &FileMetaData,
-        schema: SchemaRef,
+        schema: ArrowSchemaRef,
         projection: Option<&[usize]>,
         predicate: Option<Arc<dyn PhysicalIoExpr>>,
     ) -> PolarsResult<Self> {
@@ -177,10 +178,10 @@ impl FetchRowGroupsFromObjectStore {
             .map(|projection| {
                 projection
                     .iter()
-                    .map(|i| schema.get_at_index(*i).unwrap().0.clone())
+                    .map(|i| SmartString::from(schema.fields[*i].name.as_str()))
                     .collect::<Vec<_>>()
             })
-            .unwrap_or_else(|| schema.iter().map(|tpl| tpl.0).cloned().collect());
+            .unwrap_or_else(|| schema.fields.iter().map(|fld| SmartString::from(fld.name.as_str())).collect());
 
         Ok(FetchRowGroupsFromObjectStore {
             reader: Arc::new(reader),

--- a/crates/polars-io/src/parquet/read.rs
+++ b/crates/polars-io/src/parquet/read.rs
@@ -1,13 +1,13 @@
 use std::io::{Read, Seek};
 use std::sync::Arc;
 
+use arrow::datatypes::ArrowSchemaRef;
 use polars_core::prelude::*;
 use polars_core::utils::accumulate_dataframes_vertical_unchecked;
 use polars_parquet::read;
 use polars_parquet::write::FileMetaData;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use arrow::datatypes::ArrowSchemaRef;
 
 use super::read_impl::FetchRowGroupsFromMmapReader;
 #[cfg(feature = "cloud")]
@@ -140,9 +140,7 @@ impl<R: MmapBytesReader> ParquetReader<R> {
             Some(schema) => Ok(schema.clone()),
             None => {
                 let metadata = self.get_metadata()?;
-                Ok(
-                    Arc::new(read::infer_schema(metadata)?)
-                )
+                Ok(Arc::new(read::infer_schema(metadata)?))
             },
         }
     }

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -5,13 +5,13 @@ use std::ops::{Deref, Range};
 use std::sync::Arc;
 
 use arrow::array::new_empty_array;
+use arrow::datatypes::ArrowSchemaRef;
 use polars_core::prelude::*;
 use polars_core::utils::{accumulate_dataframes_vertical, split_df};
 use polars_core::POOL;
 use polars_parquet::read;
 use polars_parquet::read::{ArrayIter, FileMetaData, RowGroupMetaData};
 use rayon::prelude::*;
-use arrow::datatypes::ArrowSchemaRef;
 
 use super::mmap::ColumnStore;
 use crate::mmap::{MmapBytesReader, ReaderBytes};

--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -1,7 +1,6 @@
 use polars_core::prelude::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use arrow::datatypes::ArrowSchemaRef;
 
 pub trait PhysicalIoExpr: Send + Sync {
     /// Take a [`DataFrame`] and produces a boolean [`Series`] that serves
@@ -163,12 +162,12 @@ impl ColumnStats {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct BatchStats {
-    schema: ArrowSchemaRef,
+    schema: SchemaRef,
     stats: Vec<ColumnStats>,
 }
 
 impl BatchStats {
-    pub fn new(schema: ArrowSchemaRef, stats: Vec<ColumnStats>) -> Self {
+    pub fn new(schema: SchemaRef, stats: Vec<ColumnStats>) -> Self {
         Self { schema, stats }
     }
 
@@ -176,7 +175,7 @@ impl BatchStats {
         self.schema.try_index_of(column).map(|i| &self.stats[i])
     }
 
-    pub fn schema(&self) -> &ArrowSchemaRef {
+    pub fn schema(&self) -> &SchemaRef {
         &self.schema
     }
 

--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -1,6 +1,7 @@
 use polars_core::prelude::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use arrow::datatypes::ArrowSchemaRef;
 
 pub trait PhysicalIoExpr: Send + Sync {
     /// Take a [`DataFrame`] and produces a boolean [`Series`] that serves
@@ -162,12 +163,12 @@ impl ColumnStats {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct BatchStats {
-    schema: SchemaRef,
+    schema: ArrowSchemaRef,
     stats: Vec<ColumnStats>,
 }
 
 impl BatchStats {
-    pub fn new(schema: SchemaRef, stats: Vec<ColumnStats>) -> Self {
+    pub fn new(schema: ArrowSchemaRef, stats: Vec<ColumnStats>) -> Self {
         Self { schema, stats }
     }
 
@@ -175,8 +176,8 @@ impl BatchStats {
         self.schema.try_index_of(column).map(|i| &self.stats[i])
     }
 
-    pub fn schema(&self) -> &Schema {
-        self.schema.as_ref()
+    pub fn schema(&self) -> &ArrowSchemaRef {
+        &self.schema
     }
 
     pub fn column_stats(&self) -> &[ColumnStats] {

--- a/crates/polars-io/src/utils.rs
+++ b/crates/polars-io/src/utils.rs
@@ -75,24 +75,6 @@ pub(crate) fn apply_projection(schema: &ArrowSchema, projection: &[usize]) -> Ar
     ArrowSchema::from(fields)
 }
 
-#[cfg(feature = "parquet")]
-pub(crate) fn apply_projection_pl_schema(schema: &Schema, projection: &[usize]) -> Schema {
-    Schema::from_iter(projection.iter().map(|idx| {
-        let (name, dt) = schema.get_at_index(*idx).unwrap();
-        Field::new(name.as_str(), dt.clone())
-    }))
-}
-
-#[cfg(feature = "parquet")]
-pub(crate) fn columns_to_projection_pl_schema(
-    columns: &[String],
-    schema: &Schema,
-) -> PolarsResult<Vec<usize>> {
-    columns
-        .iter()
-        .map(|name| schema.try_get_full(name).map(|(idx, _, _)| idx))
-        .collect()
-}
 
 #[cfg(any(
     feature = "ipc",

--- a/crates/polars-io/src/utils.rs
+++ b/crates/polars-io/src/utils.rs
@@ -75,7 +75,6 @@ pub(crate) fn apply_projection(schema: &ArrowSchema, projection: &[usize]) -> Ar
     ArrowSchema::from(fields)
 }
 
-
 #[cfg(any(
     feature = "ipc",
     feature = "ipc_streaming",

--- a/crates/polars-json/src/json/deserialize.rs
+++ b/crates/polars-json/src/json/deserialize.rs
@@ -4,7 +4,7 @@ use std::fmt::Write;
 use arrow::array::*;
 use arrow::bitmap::MutableBitmap;
 use arrow::chunk::Chunk;
-use arrow::datatypes::{DataType, Field, IntervalUnit, ArrowSchema};
+use arrow::datatypes::{ArrowSchema, DataType, Field, IntervalUnit};
 use arrow::legacy::prelude::*;
 use arrow::offset::{Offset, Offsets};
 use arrow::temporal_conversions;
@@ -438,7 +438,10 @@ fn allocate_array(f: &Field) -> Box<dyn MutableArray> {
 ///   * [`DataType::Struct`]
 ///   * [`DataType::Dictionary`]
 ///   * [`DataType::LargeList`]
-pub fn deserialize_records(json: &BorrowedValue, schema: &ArrowSchema) -> PolarsResult<Chunk<ArrayRef>> {
+pub fn deserialize_records(
+    json: &BorrowedValue,
+    schema: &ArrowSchema,
+) -> PolarsResult<Chunk<ArrayRef>> {
     let mut results = schema
         .fields
         .iter()

--- a/crates/polars-json/src/json/deserialize.rs
+++ b/crates/polars-json/src/json/deserialize.rs
@@ -4,7 +4,7 @@ use std::fmt::Write;
 use arrow::array::*;
 use arrow::bitmap::MutableBitmap;
 use arrow::chunk::Chunk;
-use arrow::datatypes::{DataType, Field, IntervalUnit, Schema};
+use arrow::datatypes::{DataType, Field, IntervalUnit, ArrowSchema};
 use arrow::legacy::prelude::*;
 use arrow::offset::{Offset, Offsets};
 use arrow::temporal_conversions;
@@ -438,7 +438,7 @@ fn allocate_array(f: &Field) -> Box<dyn MutableArray> {
 ///   * [`DataType::Struct`]
 ///   * [`DataType::Dictionary`]
 ///   * [`DataType::LargeList`]
-pub fn deserialize_records(json: &BorrowedValue, schema: &Schema) -> PolarsResult<Chunk<ArrayRef>> {
+pub fn deserialize_records(json: &BorrowedValue, schema: &ArrowSchema) -> PolarsResult<Chunk<ArrayRef>> {
     let mut results = schema
         .fields
         .iter()

--- a/crates/polars-json/src/json/infer_schema.rs
+++ b/crates/polars-json/src/json/infer_schema.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use arrow::datatypes::{DataType, Field, ArrowSchema};
+use arrow::datatypes::{ArrowSchema, DataType, Field};
 use indexmap::map::Entry;
 use indexmap::IndexMap;
 use simd_json::borrowed::Object;

--- a/crates/polars-json/src/json/infer_schema.rs
+++ b/crates/polars-json/src/json/infer_schema.rs
@@ -1,6 +1,6 @@
 use std::borrow::Borrow;
 
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::datatypes::{DataType, Field, ArrowSchema};
 use indexmap::map::Entry;
 use indexmap::IndexMap;
 use simd_json::borrowed::Object;
@@ -25,10 +25,10 @@ pub fn infer(json: &BorrowedValue) -> PolarsResult<DataType> {
     })
 }
 
-/// Infers [`Schema`] from JSON [`Value`][Value] in (pandas-compatible) records format.
+/// Infers [`ArrowSchema`] from JSON [`Value`][Value] in (pandas-compatible) records format.
 ///
 /// [Value]: simd_json::value::Value
-pub fn infer_records_schema(json: &BorrowedValue) -> PolarsResult<Schema> {
+pub fn infer_records_schema(json: &BorrowedValue) -> PolarsResult<ArrowSchema> {
     let outer_array = match json {
         BorrowedValue::Array(array) => Ok(array),
         _ => Err(PolarsError::ComputeError(
@@ -61,7 +61,7 @@ pub fn infer_records_schema(json: &BorrowedValue) -> PolarsResult<Schema> {
         )),
     }?;
 
-    Ok(Schema {
+    Ok(ArrowSchema {
         fields,
         metadata: Default::default(),
     })

--- a/crates/polars-json/src/json/write/mod.rs
+++ b/crates/polars-json/src/json/write/mod.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 
 use arrow::array::Array;
 use arrow::chunk::Chunk;
-use arrow::datatypes::Schema;
+use arrow::datatypes::ArrowSchema;
 use arrow::io::iterator::StreamingIterator;
 pub use fallible_streaming_iterator::*;
 use polars_error::{PolarsError, PolarsResult};
@@ -70,7 +70,7 @@ where
 /// # Implementation
 /// Advancing this iterator is CPU-bounded.
 pub struct RecordSerializer<'a> {
-    schema: Schema,
+    schema: ArrowSchema,
     index: usize,
     end: usize,
     iterators: Vec<Box<dyn StreamingIterator<Item = [u8]> + Send + Sync + 'a>>,
@@ -79,7 +79,7 @@ pub struct RecordSerializer<'a> {
 
 impl<'a> RecordSerializer<'a> {
     /// Creates a new [`RecordSerializer`].
-    pub fn new<A>(schema: Schema, chunk: &'a Chunk<A>, buffer: Vec<u8>) -> Self
+    pub fn new<A>(schema: ArrowSchema, chunk: &'a Chunk<A>, buffer: Vec<u8>) -> Self
     where
         A: AsRef<dyn Array>,
     {

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -156,7 +156,11 @@ impl ParquetExec {
     #[cfg(feature = "cloud")]
     async fn read_async(&mut self) -> PolarsResult<Vec<DataFrame>> {
         let verbose = verbose();
-        let first_schema = self.file_info.reader_schema.as_ref().expect("should be set");
+        let first_schema = self
+            .file_info
+            .reader_schema
+            .as_ref()
+            .expect("should be set");
         let first_metadata = &self.metadata;
         let cloud_options = self.cloud_options.as_ref();
 

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -87,7 +87,7 @@ impl ParquetExec {
 
                     let file = file?;
                     let mut reader = ParquetReader::new(file)
-                        .with_schema(Some(self.file_info.reader_schema.clone()))
+                        .with_schema(self.file_info.reader_schema.clone())
                         .read_parallel(parallel)
                         .set_low_memory(self.options.low_memory)
                         .use_statistics(self.options.use_statistics)
@@ -156,7 +156,7 @@ impl ParquetExec {
     #[cfg(feature = "cloud")]
     async fn read_async(&mut self) -> PolarsResult<Vec<DataFrame>> {
         let verbose = verbose();
-        let first_schema = &self.file_info.reader_schema;
+        let first_schema = self.file_info.reader_schema.as_ref().expect("should be set");
         let first_metadata = &self.metadata;
         let cloud_options = self.cloud_options.as_ref();
 
@@ -200,7 +200,7 @@ impl ParquetExec {
             let iter = paths.iter().enumerate().map(|(i, path)| async move {
                 let first_file = batch_idx == 0 && i == 0;
                 // use the cached one as this saves a cloud call
-                let (metadata, schema) = if first_file { (first_metadata.clone(), Some(first_schema.clone())) } else { (None, None) };
+                let (metadata, schema) = if first_file { (first_metadata.clone(), Some((*first_schema).clone())) } else { (None, None) };
                 let mut reader = ParquetAsyncReader::from_uri(
                     &path.to_string_lossy(),
                     cloud_options,

--- a/crates/polars-parquet/src/arrow/read/file.rs
+++ b/crates/polars-parquet/src/arrow/read/file.rs
@@ -2,7 +2,7 @@ use std::io::{Read, Seek};
 
 use arrow::array::Array;
 use arrow::chunk::Chunk;
-use arrow::datatypes::Schema;
+use arrow::datatypes::ArrowSchema;
 use polars_error::PolarsResult;
 
 use super::{RowGroupDeserializer, RowGroupMetaData};
@@ -27,7 +27,7 @@ impl<R: Read + Seek> FileReader<R> {
     pub fn new(
         reader: R,
         row_groups: Vec<RowGroupMetaData>,
-        schema: Schema,
+        schema: ArrowSchema,
         chunk_size: Option<usize>,
         limit: Option<usize>,
         page_indexes: Option<Vec<Vec<Vec<Vec<FilteredPage>>>>>,
@@ -57,8 +57,8 @@ impl<R: Read + Seek> FileReader<R> {
         Ok(result)
     }
 
-    /// Returns the [`Schema`] associated to this file.
-    pub fn schema(&self) -> &Schema {
+    /// Returns the [`ArrowSchema`] associated to this file.
+    pub fn schema(&self) -> &ArrowSchema {
         &self.row_groups.schema
     }
 }
@@ -112,7 +112,7 @@ impl<R: Read + Seek> Iterator for FileReader<R> {
 /// to memory and attaches [`RowGroupDeserializer`] to them so that they can be iterated in chunks.
 pub struct RowGroupReader<R: Read + Seek> {
     reader: R,
-    schema: Schema,
+    schema: ArrowSchema,
     row_groups: std::vec::IntoIter<RowGroupMetaData>,
     chunk_size: Option<usize>,
     remaining_rows: usize,
@@ -123,7 +123,7 @@ impl<R: Read + Seek> RowGroupReader<R> {
     /// Returns a new [`RowGroupReader`]
     pub fn new(
         reader: R,
-        schema: Schema,
+        schema: ArrowSchema,
         row_groups: Vec<RowGroupMetaData>,
         chunk_size: Option<usize>,
         limit: Option<usize>,

--- a/crates/polars-parquet/src/arrow/read/schema/metadata.rs
+++ b/crates/polars-parquet/src/arrow/read/schema/metadata.rs
@@ -1,4 +1,4 @@
-use arrow::datatypes::{Metadata, Schema};
+use arrow::datatypes::{Metadata, ArrowSchema};
 use arrow::io::ipc::read::deserialize_schema;
 use base64::engine::general_purpose;
 use base64::Engine as _;
@@ -10,7 +10,7 @@ pub use crate::parquet::metadata::KeyValue;
 /// Reads an arrow schema from Parquet's file metadata. Returns `None` if no schema was found.
 /// # Errors
 /// Errors iff the schema cannot be correctly parsed.
-pub fn read_schema_from_metadata(metadata: &mut Metadata) -> PolarsResult<Option<Schema>> {
+pub fn read_schema_from_metadata(metadata: &mut Metadata) -> PolarsResult<Option<ArrowSchema>> {
     metadata
         .remove(ARROW_SCHEMA_META_KEY)
         .map(|encoded| get_arrow_schema_from_metadata(&encoded))
@@ -18,7 +18,7 @@ pub fn read_schema_from_metadata(metadata: &mut Metadata) -> PolarsResult<Option
 }
 
 /// Try to convert Arrow schema metadata into a schema
-fn get_arrow_schema_from_metadata(encoded_meta: &str) -> PolarsResult<Schema> {
+fn get_arrow_schema_from_metadata(encoded_meta: &str) -> PolarsResult<ArrowSchema> {
     let decoded = general_purpose::STANDARD.decode(encoded_meta);
     match decoded {
         Ok(bytes) => {

--- a/crates/polars-parquet/src/arrow/read/schema/metadata.rs
+++ b/crates/polars-parquet/src/arrow/read/schema/metadata.rs
@@ -1,4 +1,4 @@
-use arrow::datatypes::{Metadata, ArrowSchema};
+use arrow::datatypes::{ArrowSchema, Metadata};
 use arrow::io::ipc::read::deserialize_schema;
 use base64::engine::general_purpose;
 use base64::Engine as _;

--- a/crates/polars-parquet/src/arrow/write/file.rs
+++ b/crates/polars-parquet/src/arrow/write/file.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 
-use arrow::datatypes::Schema;
+use arrow::datatypes::ArrowSchema;
 use polars_error::{PolarsError, PolarsResult};
 
 use super::schema::schema_to_metadata_key;
@@ -8,9 +8,9 @@ use super::{to_parquet_schema, ThriftFileMetaData, WriteOptions};
 use crate::parquet::metadata::{KeyValue, SchemaDescriptor};
 use crate::parquet::write::{RowGroupIter, WriteOptions as FileWriteOptions};
 
-/// Attaches [`Schema`] to `key_value_metadata`
+/// Attaches [`ArrowSchema`] to `key_value_metadata`
 pub fn add_arrow_schema(
-    schema: &Schema,
+    schema: &ArrowSchema,
     key_value_metadata: Option<Vec<KeyValue>>,
 ) -> Option<Vec<KeyValue>> {
     key_value_metadata
@@ -24,7 +24,7 @@ pub fn add_arrow_schema(
 /// An interface to write a parquet to a [`Write`]
 pub struct FileWriter<W: Write> {
     writer: crate::parquet::write::FileWriter<W>,
-    schema: Schema,
+    schema: ArrowSchema,
     options: WriteOptions,
 }
 
@@ -40,8 +40,8 @@ impl<W: Write> FileWriter<W> {
         self.writer.schema()
     }
 
-    /// The [`Schema`] assigned to this file
-    pub fn schema(&self) -> &Schema {
+    /// The [`ArrowSchema`] assigned to this file
+    pub fn schema(&self) -> &ArrowSchema {
         &self.schema
     }
 }
@@ -49,8 +49,8 @@ impl<W: Write> FileWriter<W> {
 impl<W: Write> FileWriter<W> {
     /// Returns a new [`FileWriter`].
     /// # Error
-    /// If it is unable to derive a parquet schema from [`Schema`].
-    pub fn try_new(writer: W, schema: Schema, options: WriteOptions) -> PolarsResult<Self> {
+    /// If it is unable to derive a parquet schema from [`ArrowSchema`].
+    pub fn try_new(writer: W, schema: ArrowSchema, options: WriteOptions) -> PolarsResult<Self> {
         let parquet_schema = to_parquet_schema(&schema)?;
 
         let created_by = Some("Arrow2 - Native Rust implementation of Arrow".to_string());

--- a/crates/polars-parquet/src/arrow/write/mod.rs
+++ b/crates/polars-parquet/src/arrow/write/mod.rs
@@ -108,8 +108,8 @@ fn decimal_length_from_precision(precision: usize) -> usize {
     (((10.0_f64.powi(precision as i32) + 1.0).log2() + 1.0) / 8.0).ceil() as usize
 }
 
-/// Creates a parquet [`SchemaDescriptor`] from a [`Schema`].
-pub fn to_parquet_schema(schema: &Schema) -> PolarsResult<SchemaDescriptor> {
+/// Creates a parquet [`SchemaDescriptor`] from a [`ArrowSchema`].
+pub fn to_parquet_schema(schema: &ArrowSchema) -> PolarsResult<SchemaDescriptor> {
     let parquet_types = schema
         .fields
         .iter()

--- a/crates/polars-parquet/src/arrow/write/row_group.rs
+++ b/crates/polars-parquet/src/arrow/write/row_group.rs
@@ -1,6 +1,6 @@
 use arrow::array::Array;
 use arrow::chunk::Chunk;
-use arrow::datatypes::Schema;
+use arrow::datatypes::ArrowSchema;
 use polars_error::{polars_bail, to_compute_err, PolarsError, PolarsResult};
 
 use super::{
@@ -78,7 +78,7 @@ impl<A: AsRef<dyn Array> + 'static, I: Iterator<Item = PolarsResult<Chunk<A>>>>
     /// * the length of the encodings is different from the number of fields in schema
     pub fn try_new(
         iter: I,
-        schema: &Schema,
+        schema: &ArrowSchema,
         options: WriteOptions,
         encodings: Vec<Vec<Encoding>>,
     ) -> PolarsResult<Self> {

--- a/crates/polars-parquet/src/arrow/write/schema.rs
+++ b/crates/polars-parquet/src/arrow/write/schema.rs
@@ -1,4 +1,4 @@
-use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use arrow::datatypes::{DataType, Field, ArrowSchema, TimeUnit};
 use arrow::io::ipc::write::{default_ipc_fields, schema_to_bytes};
 use base64::engine::general_purpose;
 use base64::Engine as _;
@@ -13,7 +13,7 @@ use crate::parquet::schema::types::{
 };
 use crate::parquet::schema::Repetition;
 
-pub fn schema_to_metadata_key(schema: &Schema) -> KeyValue {
+pub fn schema_to_metadata_key(schema: &ArrowSchema) -> KeyValue {
     let serialized_schema = schema_to_bytes(schema, &default_ipc_fields(&schema.fields));
 
     // manually prepending the length to the schema as arrow uses the legacy IPC format

--- a/crates/polars-parquet/src/arrow/write/schema.rs
+++ b/crates/polars-parquet/src/arrow/write/schema.rs
@@ -1,4 +1,4 @@
-use arrow::datatypes::{DataType, Field, ArrowSchema, TimeUnit};
+use arrow::datatypes::{ArrowSchema, DataType, Field, TimeUnit};
 use arrow::io::ipc::write::{default_ipc_fields, schema_to_bytes};
 use base64::engine::general_purpose;
 use base64::Engine as _;

--- a/crates/polars-parquet/src/arrow/write/sink.rs
+++ b/crates/polars-parquet/src/arrow/write/sink.rs
@@ -4,7 +4,7 @@ use std::task::Poll;
 use ahash::AHashMap;
 use arrow::array::Array;
 use arrow::chunk::Chunk;
-use arrow::datatypes::Schema;
+use arrow::datatypes::ArrowSchema;
 use futures::future::BoxFuture;
 use futures::{AsyncWrite, AsyncWriteExt, FutureExt, Sink, TryFutureExt};
 use polars_error::{polars_bail, to_compute_err, PolarsError, PolarsResult};
@@ -23,7 +23,7 @@ pub struct FileSink<'a, W: AsyncWrite + Send + Unpin> {
     task: Option<BoxFuture<'a, PolarsResult<Option<FileStreamer<W>>>>>,
     options: WriteOptions,
     encodings: Vec<Vec<Encoding>>,
-    schema: Schema,
+    schema: ArrowSchema,
     parquet_schema: SchemaDescriptor,
     /// Key-value metadata that will be written to the file on close.
     pub metadata: AHashMap<String, Option<String>>,
@@ -41,7 +41,7 @@ where
     /// * the length of the encodings is different from the number of fields in schema
     pub fn try_new(
         writer: W,
-        schema: Schema,
+        schema: ArrowSchema,
         encodings: Vec<Vec<Encoding>>,
         options: WriteOptions,
     ) -> PolarsResult<Self> {
@@ -73,8 +73,8 @@ where
         })
     }
 
-    /// The Arrow [`Schema`] for the file.
-    pub fn schema(&self) -> &Schema {
+    /// The Arrow [`ArrowSchema`] for the file.
+    pub fn schema(&self) -> &ArrowSchema {
         &self.schema
     }
 

--- a/crates/polars-pipe/src/executors/sources/parquet.rs
+++ b/crates/polars-pipe/src/executors/sources/parquet.rs
@@ -71,7 +71,7 @@ impl ParquetSource {
         }
 
         let reader_schema = if self.processed_paths == 0 {
-            Some(self.file_info.reader_schema.clone())
+            self.file_info.reader_schema.clone()
         } else {
             None
         };
@@ -116,7 +116,7 @@ impl ParquetSource {
                 .batched(chunk_size)?
         };
         if self.processed_paths >= 1 {
-            polars_ensure!(batched_reader.schema().as_ref() == self.file_info.reader_schema.as_ref(), ComputeError: "schema of all files in a single scan_parquet must be equal");
+            polars_ensure!(batched_reader.schema().as_ref() == self.file_info.reader_schema.as_ref().unwrap().as_ref(), ComputeError: "schema of all files in a single scan_parquet must be equal");
         }
         self.batched_reader = Some(batched_reader);
         self.processed_paths += 1;

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -189,7 +189,11 @@ impl LogicalPlanBuilder {
             )
         };
 
-        let mut file_info = FileInfo::new(schema, Some(reader_schema), (num_rows, num_rows.unwrap_or(0)));
+        let mut file_info = FileInfo::new(
+            schema,
+            Some(reader_schema),
+            (num_rows, num_rows.unwrap_or(0)),
+        );
 
         // We set the hive partitions of the first path to determine the schema.
         // On iteration the partition values will be re-set per file.
@@ -246,7 +250,11 @@ impl LogicalPlanBuilder {
         }
 
         let num_rows = reader._num_rows()?;
-        let file_info = FileInfo::new(Arc::new(schema), Some(Arc::new(reader_schema)), (None, num_rows));
+        let file_info = FileInfo::new(
+            Arc::new(schema),
+            Some(Arc::new(reader_schema)),
+            (None, num_rows),
+        );
 
         let file_options = FileScanOptions {
             with_columns: None,

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -85,12 +85,11 @@ macro_rules! try_delayed {
 }
 
 #[cfg(any(feature = "parquet", feature = "parquet_async",))]
-fn prepare_schema(mut schema: SchemaRef, row_count: Option<&RowCount>) -> SchemaRef {
-    let schema_mut = Arc::make_mut(&mut schema);
+fn prepare_schema(mut schema: Schema, row_count: Option<&RowCount>) -> SchemaRef {
     if let Some(rc) = row_count {
-        let _ = schema_mut.insert_at_index(0, rc.name.as_str().into(), IDX_DTYPE);
+        let _ = schema.insert_at_index(0, rc.name.as_str().into(), IDX_DTYPE);
     }
-    schema
+    Arc::new(schema)
 }
 
 impl LogicalPlanBuilder {
@@ -107,7 +106,7 @@ impl LogicalPlanBuilder {
             None => function.schema(infer_schema_length)?,
         };
 
-        let file_info = FileInfo::new(schema.clone(), (n_rows, n_rows.unwrap_or(usize::MAX)));
+        let file_info = FileInfo::new(schema.clone(), None, (n_rows, n_rows.unwrap_or(usize::MAX)));
         let file_options = FileScanOptions {
             n_rows,
             with_columns: None,
@@ -156,7 +155,7 @@ impl LogicalPlanBuilder {
         // Use first path to get schema.
         let path = &paths[0];
 
-        let (schema, num_rows, metadata) = if is_cloud_url(path) {
+        let (schema, reader_schema, num_rows, metadata) = if is_cloud_url(path) {
             #[cfg(not(feature = "cloud"))]
             panic!(
                 "One or more of the cloud storage features ('aws', 'gcp', ...) must be enabled."
@@ -169,24 +168,28 @@ impl LogicalPlanBuilder {
                     let mut reader =
                         ParquetAsyncReader::from_uri(&uri, cloud_options.as_ref(), None, None)
                             .await?;
-                    let schema = reader.schema().await?;
+                    let reader_schema = reader.schema().await?;
                     let num_rows = reader.num_rows().await?;
                     let metadata = reader.get_metadata().await?.clone();
 
-                    PolarsResult::Ok((schema, Some(num_rows), Some(metadata)))
+                    let schema = prepare_schema((&reader_schema).into(), row_count.as_ref());
+                    PolarsResult::Ok((schema, reader_schema, Some(num_rows), Some(metadata)))
                 })?
             }
         } else {
             let file = polars_utils::open_file(path)?;
             let mut reader = ParquetReader::new(file);
+            let reader_schema = reader.schema()?;
+            let schema = prepare_schema((&reader_schema).into(), row_count.as_ref());
             (
-                prepare_schema(reader.schema()?, row_count.as_ref()),
+                schema,
+                reader_schema,
                 Some(reader.num_rows()?),
                 Some(reader.get_metadata()?.clone()),
             )
         };
 
-        let mut file_info = FileInfo::new(schema, (num_rows, num_rows.unwrap_or(0)));
+        let mut file_info = FileInfo::new(schema, Some(reader_schema), (num_rows, num_rows.unwrap_or(0)));
 
         // We set the hive partitions of the first path to determine the schema.
         // On iteration the partition values will be re-set per file.
@@ -236,14 +239,14 @@ impl LogicalPlanBuilder {
         let file = polars_utils::open_file(&path)?;
         let mut reader = IpcReader::new(file);
 
-        let mut schema = reader.schema()?;
+        let reader_schema = reader.schema()?;
+        let mut schema: Schema = (&reader_schema).into();
         if let Some(rc) = &row_count {
             let _ = schema.insert_at_index(0, rc.name.as_str().into(), IDX_DTYPE);
         }
-        let schema = Arc::new(schema);
 
         let num_rows = reader._num_rows()?;
-        let file_info = FileInfo::new(schema, (None, num_rows));
+        let file_info = FileInfo::new(Arc::new(schema), Some(Arc::new(reader_schema)), (None, num_rows));
 
         let file_options = FileScanOptions {
             with_columns: None,
@@ -354,7 +357,7 @@ impl LogicalPlanBuilder {
         let estimated_n_rows = (rows_read as f64 / bytes_read as f64 * n_bytes as f64) as usize;
 
         skip_rows += skip_rows_after_header;
-        let file_info = FileInfo::new(schema, (None, estimated_n_rows));
+        let file_info = FileInfo::new(schema, None, (None, estimated_n_rows));
 
         let options = FileScanOptions {
             with_columns: None,

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -250,11 +250,7 @@ impl LogicalPlanBuilder {
         }
 
         let num_rows = reader._num_rows()?;
-        let file_info = FileInfo::new(
-            Arc::new(schema),
-            Some(Arc::new(reader_schema)),
-            (None, num_rows),
-        );
+        let file_info = FileInfo::new(Arc::new(schema), Some(reader_schema), (None, num_rows));
 
         let file_options = FileScanOptions {
             with_columns: None,

--- a/crates/polars-plan/src/logical_plan/hive.rs
+++ b/crates/polars-plan/src/logical_plan/hive.rs
@@ -74,7 +74,7 @@ impl HivePartitions {
         if partitions.is_empty() {
             None
         } else {
-            let schema: Schema = partitions.as_slice().into();
+            let schema = ArrowSchema::from(partitions.iter().map(|s| ArrowField::new(s.name(), s.dtype().to_arrow(), true)).collect::<Vec<_>>());
             let stats = BatchStats::new(
                 Arc::new(schema),
                 partitions
@@ -87,7 +87,7 @@ impl HivePartitions {
         }
     }
 
-    pub(crate) fn schema(&self) -> &Schema {
+    pub(crate) fn schema(&self) -> &ArrowSchema {
         self.get_statistics().schema()
     }
 

--- a/crates/polars-plan/src/logical_plan/hive.rs
+++ b/crates/polars-plan/src/logical_plan/hive.rs
@@ -74,7 +74,7 @@ impl HivePartitions {
         if partitions.is_empty() {
             None
         } else {
-            let schema = ArrowSchema::from(partitions.iter().map(|s| ArrowField::new(s.name(), s.dtype().to_arrow(), true)).collect::<Vec<_>>());
+            let schema: Schema = partitions.as_slice().into();
             let stats = BatchStats::new(
                 Arc::new(schema),
                 partitions
@@ -87,7 +87,7 @@ impl HivePartitions {
         }
     }
 
-    pub(crate) fn schema(&self) -> &ArrowSchema {
+    pub(crate) fn schema(&self) -> &SchemaRef {
         self.get_statistics().schema()
     }
 

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
@@ -410,9 +410,9 @@ impl ProjectionPushDown {
                         // parts are added at the proper place in the schema, which is at the end.
                         if let Some(parts) = file_info.hive_parts.as_deref() {
                             let partition_schema = parts.schema();
-                            for (name, _) in partition_schema.iter() {
-                                if let Some(dt) = schema.shift_remove(name) {
-                                    schema.with_column(name.clone(), dt);
+                            for field in partition_schema.fields.iter() {
+                                if let Some(dt) = schema.shift_remove(field.name.as_str()) {
+                                    schema.with_column((&field.name).into(), dt);
                                 }
                             }
                         }

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
@@ -410,9 +410,9 @@ impl ProjectionPushDown {
                         // parts are added at the proper place in the schema, which is at the end.
                         if let Some(parts) = file_info.hive_parts.as_deref() {
                             let partition_schema = parts.schema();
-                            for field in partition_schema.fields.iter() {
-                                if let Some(dt) = schema.shift_remove(field.name.as_str()) {
-                                    schema.with_column((&field.name).into(), dt);
+                            for (name, _) in partition_schema.iter() {
+                                if let Some(dt) = schema.shift_remove(name) {
+                                    schema.with_column(name.clone(), dt);
                                 }
                             }
                         }

--- a/crates/polars-plan/src/logical_plan/schema.rs
+++ b/crates/polars-plan/src/logical_plan/schema.rs
@@ -1,11 +1,11 @@
 use std::borrow::Cow;
 use std::path::Path;
 
+use arrow::datatypes::ArrowSchemaRef;
 use polars_core::prelude::*;
 use polars_utils::format_smartstring;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-use arrow::datatypes::ArrowSchemaRef;
 
 use crate::prelude::*;
 
@@ -56,7 +56,11 @@ pub struct FileInfo {
 }
 
 impl FileInfo {
-    pub fn new(schema: SchemaRef, reader_schema: Option<ArrowSchemaRef>, row_estimation: (Option<usize>, usize)) -> Self {
+    pub fn new(
+        schema: SchemaRef,
+        reader_schema: Option<ArrowSchemaRef>,
+        row_estimation: (Option<usize>, usize),
+    ) -> Self {
         Self {
             schema: schema.clone(),
             reader_schema,
@@ -69,7 +73,7 @@ impl FileInfo {
     pub fn init_hive_partitions(&mut self, url: &Path) {
         self.hive_parts = hive::HivePartitions::parse_url(url).map(|hive_parts| {
             let schema = Arc::make_mut(&mut self.schema);
-            schema.merge(hive_parts.get_statistics().schema().into());
+            schema.merge((**hive_parts.get_statistics().schema()).clone());
 
             Arc::new(hive_parts)
         });

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -137,7 +137,9 @@ def include_unknowns(
 ) -> MutableMapping[str, PolarsDataType]:
     """Complete partial schema dict by including Unknown type."""
     return {
-        col: (schema.get(col, Unknown) or Unknown)  # type: ignore[truthy-bool]
+        col: (
+            schema.get(col, Unknown) or Unknown  # type: ignore[truthy-bool]
+        )
         for col in cols
     }
 

--- a/py-polars/src/functions/io.rs
+++ b/py-polars/src/functions/io.rs
@@ -18,9 +18,9 @@ pub fn read_ipc_schema(py: Python, py_f: PyObject) -> PyResult<PyObject> {
     };
 
     let dict = PyDict::new(py);
-    for field in metadata.schema.fields {
+    for field in &metadata.schema.fields {
         let dt: Wrap<DataType> = Wrap((&field.data_type).into());
-        dict.set_item(field.name, dt.to_object(py))?;
+        dict.set_item(&field.name, dt.to_object(py))?;
     }
     Ok(dict.to_object(py))
 }

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import io
-from datetime import datetime, timezone
+from datetime import datetime, time, timezone
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -512,3 +512,12 @@ def test_nested_list_page_reads_to_end_11548() -> None:
 
     result = pl.read_parquet(f).select(pl.col("x").list.len())
     assert result.to_series().to_list() == [2048, 2048]
+
+
+def test_parquet_nano_second_schema() -> None:
+    value = time(9, 0, 0)
+    f = io.BytesIO()
+    df = pd.DataFrame({"Time": [value]})
+    df.to_parquet(f)
+    f.seek(0)
+    assert pl.read_parquet(f).item() == value

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -286,15 +286,21 @@ def test_bitwise_ops() -> None:
     # Note that the type annotations only allow Series to be passed in, but there is
     # specific code to deal with non-Series inputs.
     assert_series_equal(
-        (True & a),  # type: ignore[operator]
+        (
+            True & a  # type: ignore[operator]
+        ),
         pl.Series([True, False, True]),
     )
     assert_series_equal(
-        (True | a),  # type: ignore[operator]
+        (
+            True | a  # type: ignore[operator]
+        ),
         pl.Series([True, True, True]),
     )
     assert_series_equal(
-        (True ^ a),  # type: ignore[operator]
+        (
+            True ^ a  # type: ignore[operator]
+        ),
         pl.Series([False, True, False]),
     )
 


### PR DESCRIPTION
We need to use the arrow schema as the file can contain datatypes we don't support directly (for instance seconds).

fixes #12017