### PR TITLE
chore(rust): upgrade zstd to 0.13 in `polars-parquet`

### DIFF
--- a/crates/polars-parquet/Cargo.toml
+++ b/crates/polars-parquet/Cargo.toml
@@ -35,7 +35,7 @@ flate2 = { version = "^1.0", optional = true, default-features = false }
 lz4 = { version = "1.24", optional = true }
 serde = { version = "^1.0", optional = true, features = ["derive"] }
 snap = { version = "^1.1", optional = true }
-zstd = { version = "^0.12", optional = true, default-features = false }
+zstd = { version = "^0.13", optional = true, default-features = false }
 
 xxhash-rust = { version = "0.8", optional = true, features = ["xxh64"] }
 

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1606,7 +1606,7 @@ dependencies = [
  "simdutf8",
  "streaming-iterator",
  "strength_reduce",
- "zstd 0.13.0",
+ "zstd",
 ]
 
 [[package]]
@@ -1802,7 +1802,7 @@ dependencies = [
  "simdutf8",
  "snap",
  "streaming-decompression",
- "zstd 0.12.4",
+ "zstd",
 ]
 
 [[package]]
@@ -3139,30 +3139,11 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
-dependencies = [
- "zstd-safe 6.0.6",
-]
-
-[[package]]
-name = "zstd"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
 dependencies = [
- "zstd-safe 7.0.0",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "6.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
-dependencies = [
- "libc",
- "zstd-sys",
+ "zstd-safe",
 ]
 
 [[package]]


### PR DESCRIPTION
`polars-arrow` is already using zstd 0.13:
https://github.com/pola-rs/polars/blob/51e3d9a980f9f2543b32ffba4173a524990a4e5b/crates/polars-arrow/Cargo.toml#L49