### PR TITLE
fix(python,rust): str.concat on empty list

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/concat.rs
+++ b/crates/polars-ops/src/chunked_array/strings/concat.rs
@@ -4,7 +4,11 @@ use polars_core::prelude::*;
 
 // Vertically concatenate all strings in a Utf8Chunked.
 pub fn str_concat(ca: &Utf8Chunked, delimiter: &str) -> Utf8Chunked {
-    if ca.len() <= 1 {
+    if ca.is_empty() {
+        return Utf8Chunked::new(ca.name(), &[""]);
+    }
+
+    if ca.len() == 1 {
         return ca.clone();
     }
 

--- a/py-polars/tests/unit/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/namespaces/string/test_string.py
@@ -28,6 +28,31 @@ def test_str_concat2() -> None:
     assert cast(str, df.item()) == "1-null-2"
 
 
+def test_str_concat_empty_list() -> None:
+    s = pl.Series([], dtype=pl.Utf8)
+    result = s.str.concat()
+    expected = pl.Series([""])
+    assert_series_equal(result, expected)
+
+
+def test_str_concat_empty_list2() -> None:
+    s = pl.Series([], dtype=pl.Utf8)
+    df = pl.DataFrame({"foo": s})
+    result = df.select(pl.col("foo").str.concat()).item()
+    expected = ""
+    assert result == expected
+
+
+def test_str_concat_empty_list_agg_context() -> None:
+    df = pl.DataFrame(
+        data={"i": [1], "v": [None]},
+        schema_overrides={"v": pl.Utf8}
+    )
+    result = df.group_by("i").agg(pl.col("v").drop_nulls().str.concat())["v"].item()
+    expected = ""
+    assert result == expected
+
+
 def test_str_concat_datetime() -> None:
     df = pl.DataFrame({"d": [datetime(2020, 1, 1), None, datetime(2022, 1, 1)]})
     df = df.select(pl.col("d").str.concat("|"))

--- a/py-polars/tests/unit/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/namespaces/string/test_string.py
@@ -44,10 +44,7 @@ def test_str_concat_empty_list2() -> None:
 
 
 def test_str_concat_empty_list_agg_context() -> None:
-    df = pl.DataFrame(
-        data={"i": [1], "v": [None]},
-        schema_overrides={"v": pl.Utf8}
-    )
+    df = pl.DataFrame(data={"i": [1], "v": [None]}, schema_overrides={"v": pl.Utf8})
     result = df.group_by("i").agg(pl.col("v").drop_nulls().str.concat())["v"].item()
     expected = ""
     assert result == expected


### PR DESCRIPTION
aggregation methods should always return a single value, otherwise it can lead to unexpected behavior and bugs (e.g. #12053)

current behavior:
- empty list: return Series of shape (0,) >>>>> this is the bug
- otherwise: return Series of shape (1,) with the concatenated/joined string

PR:
- always return Series of shape (1,) with the concatenated/joined string
- if empty list, return empty string (as discussed here:https://github.com/pola-rs/polars/issues/10814#issuecomment-1700971115)

```python
pl.Series([], dtype=pl.Utf8).str.concat()

# OLD
shape: (0,)
Series: '' [str]
[
]

# NEW
shape: (1,)
Series: '' [str]
[
	""
]
```

Note: this does not address the issue of skipping nulls (#10814) but only fixes the bug for empty lists