### PR TITLE
feat!: Smaller integer data types for datetime components

### DIFF
--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -49,7 +49,15 @@ cloud_write = ["cloud"]
 ipc = ["polars-io/ipc", "polars-plan/ipc", "polars-pipe?/ipc"]
 json = ["polars-io/json", "polars-plan/json", "polars-json", "polars-pipe/json"]
 csv = ["polars-io/csv", "polars-plan/csv", "polars-pipe?/csv"]
-temporal = ["dtype-datetime", "dtype-date", "dtype-time", "dtype-duration", "polars-plan/temporal"]
+temporal = [
+  "dtype-datetime",
+  "dtype-date",
+  "dtype-time",
+  "dtype-i8",
+  "dtype-i16",
+  "dtype-duration",
+  "polars-plan/temporal",
+]
 # debugging purposes
 fmt = ["polars-core/fmt", "polars-plan/fmt"]
 strings = ["polars-plan/strings"]

--- a/crates/polars-plan/Cargo.toml
+++ b/crates/polars-plan/Cargo.toml
@@ -59,7 +59,7 @@ cloud = ["async", "polars-io/cloud"]
 ipc = ["polars-io/ipc"]
 json = ["polars-io/json", "polars-json"]
 csv = ["polars-io/csv"]
-temporal = ["polars-core/temporal", "dtype-date", "dtype-datetime", "dtype-time"]
+temporal = ["polars-core/temporal", "dtype-date", "dtype-datetime", "dtype-time", "dtype-i8", "dtype-i16"]
 # debugging purposes
 fmt = ["polars-core/fmt"]
 strings = ["polars-core/strings", "polars-ops/strings"]

--- a/crates/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/crates/polars-plan/src/dsl/function_expr/datetime.rs
@@ -60,8 +60,11 @@ impl TemporalFunction {
         use TemporalFunction::*;
         match self {
             Year | IsoYear => mapper.with_dtype(DataType::Int32),
-            Month | Quarter | Week | WeekDay | Day | OrdinalDay | Hour | Minute | Millisecond
-            | Microsecond | Nanosecond | Second => mapper.with_dtype(DataType::UInt32),
+            OrdinalDay => mapper.with_dtype(DataType::Int16),
+            Month | Quarter | Week | WeekDay | Day | Hour | Minute | Second => {
+                mapper.with_dtype(DataType::Int8)
+            },
+            Millisecond | Microsecond | Nanosecond => mapper.with_dtype(DataType::Int32),
             ToString(_) => mapper.with_dtype(DataType::Utf8),
             WithTimeUnit(_) => mapper.with_same_dtype(),
             CastTimeUnit(tu) => mapper.try_map_dtype(|dt| match dt {

--- a/crates/polars-time/src/chunkedarray/date.rs
+++ b/crates/polars-time/src/chunkedarray/date.rs
@@ -35,7 +35,7 @@ pub trait DateMethods: AsDate {
 
     /// Extract month from underlying NaiveDateTime representation.
     /// Quarters range from 1 to 4.
-    fn quarter(&self) -> UInt32Chunked {
+    fn quarter(&self) -> Int8Chunked {
         let months = self.month();
         months_to_quarters(months)
     }
@@ -44,40 +44,40 @@ pub trait DateMethods: AsDate {
     /// Returns the month number starting from 1.
     ///
     /// The return value ranges from 1 to 12.
-    fn month(&self) -> UInt32Chunked {
+    fn month(&self) -> Int8Chunked {
         let ca = self.as_date();
-        ca.apply_kernel_cast::<UInt32Type>(&date_to_month)
+        ca.apply_kernel_cast::<Int8Type>(&date_to_month)
     }
 
     /// Extract ISO weekday from underlying NaiveDate representation.
     /// Returns the weekday number where monday = 1 and sunday = 7
-    fn weekday(&self) -> UInt32Chunked {
+    fn weekday(&self) -> Int8Chunked {
         let ca = self.as_date();
-        ca.apply_kernel_cast::<UInt32Type>(&date_to_iso_weekday)
+        ca.apply_kernel_cast::<Int8Type>(&date_to_iso_weekday)
     }
 
     /// Returns the ISO week number starting from 1.
     /// The return value ranges from 1 to 53. (The last week of year differs by years.)
-    fn week(&self) -> UInt32Chunked {
+    fn week(&self) -> Int8Chunked {
         let ca = self.as_date();
-        ca.apply_kernel_cast::<UInt32Type>(&date_to_iso_week)
+        ca.apply_kernel_cast::<Int8Type>(&date_to_iso_week)
     }
 
     /// Extract day from underlying NaiveDate representation.
     /// Returns the day of month starting from 1.
     ///
     /// The return value ranges from 1 to 31. (The last day of month differs by months.)
-    fn day(&self) -> UInt32Chunked {
+    fn day(&self) -> Int8Chunked {
         let ca = self.as_date();
-        ca.apply_kernel_cast::<UInt32Type>(&date_to_day)
+        ca.apply_kernel_cast::<Int8Type>(&date_to_day)
     }
 
     /// Returns the day of year starting from 1.
     ///
     /// The return value ranges from 1 to 366. (The last day of year differs by years.)
-    fn ordinal(&self) -> UInt32Chunked {
+    fn ordinal(&self) -> Int16Chunked {
         let ca = self.as_date();
-        ca.apply_kernel_cast::<UInt32Type>(&date_to_ordinal)
+        ca.apply_kernel_cast::<Int16Type>(&date_to_ordinal)
     }
 
     fn parse_from_str_slice(name: &str, v: &[&str], fmt: &str) -> DateChunked;

--- a/crates/polars-time/src/chunkedarray/datetime.rs
+++ b/crates/polars-time/src/chunkedarray/datetime.rs
@@ -60,7 +60,7 @@ pub trait DatetimeMethods: AsDatetime {
 
     /// Extract quarter from underlying NaiveDateTime representation.
     /// Quarters range from 1 to 4.
-    fn quarter(&self) -> UInt32Chunked {
+    fn quarter(&self) -> Int8Chunked {
         let months = self.month();
         months_to_quarters(months)
     }
@@ -69,19 +69,19 @@ pub trait DatetimeMethods: AsDatetime {
     /// Returns the month number starting from 1.
     ///
     /// The return value ranges from 1 to 12.
-    fn month(&self) -> UInt32Chunked {
+    fn month(&self) -> Int8Chunked {
         cast_and_apply(self.as_datetime(), temporal::month)
     }
 
     /// Extract ISO weekday from underlying NaiveDateTime representation.
     /// Returns the weekday number where monday = 1 and sunday = 7
-    fn weekday(&self) -> UInt32Chunked {
+    fn weekday(&self) -> Int8Chunked {
         cast_and_apply(self.as_datetime(), temporal::weekday)
     }
 
     /// Returns the ISO week number starting from 1.
     /// The return value ranges from 1 to 53. (The last week of year differs by years.)
-    fn week(&self) -> UInt32Chunked {
+    fn week(&self) -> Int8Chunked {
         cast_and_apply(self.as_datetime(), temporal::iso_week)
     }
 
@@ -89,46 +89,46 @@ pub trait DatetimeMethods: AsDatetime {
     /// Returns the day of month starting from 1.
     ///
     /// The return value ranges from 1 to 31. (The last day of month differs by months.)
-    fn day(&self) -> UInt32Chunked {
+    fn day(&self) -> Int8Chunked {
         cast_and_apply(self.as_datetime(), temporal::day)
     }
 
     /// Extract hour from underlying NaiveDateTime representation.
     /// Returns the hour number from 0 to 23.
-    fn hour(&self) -> UInt32Chunked {
+    fn hour(&self) -> Int8Chunked {
         cast_and_apply(self.as_datetime(), temporal::hour)
     }
 
     /// Extract minute from underlying NaiveDateTime representation.
     /// Returns the minute number from 0 to 59.
-    fn minute(&self) -> UInt32Chunked {
+    fn minute(&self) -> Int8Chunked {
         cast_and_apply(self.as_datetime(), temporal::minute)
     }
 
     /// Extract second from underlying NaiveDateTime representation.
     /// Returns the second number from 0 to 59.
-    fn second(&self) -> UInt32Chunked {
+    fn second(&self) -> Int8Chunked {
         cast_and_apply(self.as_datetime(), temporal::second)
     }
 
     /// Extract second from underlying NaiveDateTime representation.
     /// Returns the number of nanoseconds since the whole non-leap second.
     /// The range from 1,000,000,000 to 1,999,999,999 represents the leap second.
-    fn nanosecond(&self) -> UInt32Chunked {
+    fn nanosecond(&self) -> Int32Chunked {
         cast_and_apply(self.as_datetime(), temporal::nanosecond)
     }
 
     /// Returns the day of year starting from 1.
     ///
     /// The return value ranges from 1 to 366. (The last day of year differs by years.)
-    fn ordinal(&self) -> UInt32Chunked {
+    fn ordinal(&self) -> Int16Chunked {
         let ca = self.as_datetime();
         let f = match ca.time_unit() {
             TimeUnit::Nanoseconds => datetime_to_ordinal_ns,
             TimeUnit::Microseconds => datetime_to_ordinal_us,
             TimeUnit::Milliseconds => datetime_to_ordinal_ms,
         };
-        ca.apply_kernel_cast::<UInt32Type>(&f)
+        ca.apply_kernel_cast::<Int16Type>(&f)
     }
 
     fn parse_from_str_slice(name: &str, v: &[&str], fmt: &str, tu: TimeUnit) -> DatetimeChunked {

--- a/crates/polars-time/src/chunkedarray/kernels.rs
+++ b/crates/polars-time/src/chunkedarray/kernels.rs
@@ -14,17 +14,17 @@ use super::super::windows::calendar::*;
 use super::*;
 
 trait PolarsIso {
-    fn p_weekday(&self) -> u32;
-    fn week(&self) -> u32;
+    fn p_weekday(&self) -> i8;
+    fn week(&self) -> i8;
     fn iso_year(&self) -> i32;
 }
 
 impl PolarsIso for NaiveDateTime {
-    fn p_weekday(&self) -> u32 {
-        self.weekday() as u32 + 1
+    fn p_weekday(&self) -> i8 {
+        self.weekday().number_from_monday().try_into().unwrap()
     }
-    fn week(&self) -> u32 {
-        self.iso_week().week()
+    fn week(&self) -> i8 {
+        self.iso_week().week().try_into().unwrap()
     }
     fn iso_year(&self) -> i32 {
         self.iso_week().year()
@@ -32,11 +32,11 @@ impl PolarsIso for NaiveDateTime {
 }
 
 impl PolarsIso for NaiveDate {
-    fn p_weekday(&self) -> u32 {
-        self.weekday() as u32 + 1
+    fn p_weekday(&self) -> i8 {
+        self.weekday().number_from_monday().try_into().unwrap()
     }
-    fn week(&self) -> u32 {
-        self.iso_week().week()
+    fn week(&self) -> i8 {
+        self.iso_week().week().try_into().unwrap()
     }
     fn iso_year(&self) -> i32 {
         self.iso_week().year()
@@ -53,7 +53,7 @@ macro_rules! to_temporal_unit {
                 arr,
                 |value| {
                     $to_datetime_fn(value)
-                        .map(|dt| dt.$chrono_method())
+                        .map(|dt| dt.$chrono_method() as $primitive_out)
                         .unwrap_or(value as $primitive_out)
                 },
                 $dtype_out,
@@ -90,8 +90,8 @@ to_temporal_unit!(
     week,
     date32_to_datetime_opt,
     i32,
-    u32,
-    ArrowDataType::UInt32
+    i8,
+    ArrowDataType::Int8
 );
 #[cfg(feature = "dtype-date")]
 to_temporal_unit!(
@@ -108,8 +108,8 @@ to_temporal_unit!(
     p_weekday,
     date32_to_datetime_opt,
     i32,
-    u32,
-    ArrowDataType::UInt32
+    i8,
+    ArrowDataType::Int8
 );
 #[cfg(feature = "dtype-date")]
 to_temporal_unit!(
@@ -134,8 +134,8 @@ to_temporal_unit!(
     month,
     date32_to_datetime_opt,
     i32,
-    u32,
-    ArrowDataType::UInt32
+    i8,
+    ArrowDataType::Int8
 );
 #[cfg(feature = "dtype-date")]
 to_temporal_unit!(
@@ -143,8 +143,8 @@ to_temporal_unit!(
     day,
     date32_to_datetime_opt,
     i32,
-    u32,
-    ArrowDataType::UInt32
+    i8,
+    ArrowDataType::Int8
 );
 #[cfg(feature = "dtype-date")]
 to_temporal_unit!(
@@ -152,8 +152,8 @@ to_temporal_unit!(
     ordinal,
     date32_to_datetime_opt,
     i32,
-    u32,
-    ArrowDataType::UInt32
+    i16,
+    ArrowDataType::Int16
 );
 
 // Times
@@ -163,8 +163,8 @@ to_temporal_unit!(
     hour,
     time64ns_to_time_opt,
     i64,
-    u32,
-    ArrowDataType::UInt32
+    i8,
+    ArrowDataType::Int8
 );
 #[cfg(feature = "dtype-time")]
 to_temporal_unit!(
@@ -172,8 +172,8 @@ to_temporal_unit!(
     minute,
     time64ns_to_time_opt,
     i64,
-    u32,
-    ArrowDataType::UInt32
+    i8,
+    ArrowDataType::Int8
 );
 #[cfg(feature = "dtype-time")]
 to_temporal_unit!(
@@ -181,8 +181,8 @@ to_temporal_unit!(
     second,
     time64ns_to_time_opt,
     i64,
-    u32,
-    ArrowDataType::UInt32
+    i8,
+    ArrowDataType::Int8
 );
 #[cfg(feature = "dtype-time")]
 to_temporal_unit!(
@@ -190,8 +190,8 @@ to_temporal_unit!(
     nanosecond,
     time64ns_to_time_opt,
     i64,
-    u32,
-    ArrowDataType::UInt32
+    i32,
+    ArrowDataType::Int32
 );
 
 #[cfg(feature = "dtype-datetime")]
@@ -200,8 +200,8 @@ to_temporal_unit!(
     ordinal,
     timestamp_ns_to_datetime_opt,
     i64,
-    u32,
-    ArrowDataType::UInt32
+    i16,
+    ArrowDataType::Int16
 );
 
 #[cfg(feature = "dtype-datetime")]
@@ -210,8 +210,8 @@ to_temporal_unit!(
     ordinal,
     timestamp_ms_to_datetime_opt,
     i64,
-    u32,
-    ArrowDataType::UInt32
+    i16,
+    ArrowDataType::Int16
 );
 #[cfg(feature = "dtype-datetime")]
 to_temporal_unit!(
@@ -219,8 +219,8 @@ to_temporal_unit!(
     ordinal,
     timestamp_us_to_datetime_opt,
     i64,
-    u32,
-    ArrowDataType::UInt32
+    i16,
+    ArrowDataType::Int16
 );
 
 #[cfg(feature = "dtype-datetime")]

--- a/crates/polars-time/src/chunkedarray/mod.rs
+++ b/crates/polars-time/src/chunkedarray/mod.rs
@@ -34,7 +34,7 @@ pub fn unix_time() -> NaiveDateTime {
 
 // a separate function so that it is not compiled twice
 #[cfg(any(feature = "dtype-date", feature = "dtype-datetime"))]
-pub(crate) fn months_to_quarters(mut ca: UInt32Chunked) -> UInt32Chunked {
+pub(crate) fn months_to_quarters(mut ca: Int8Chunked) -> Int8Chunked {
     ca.apply_mut(|month| (month + 2) / 3);
     ca
 }

--- a/crates/polars-time/src/chunkedarray/time.rs
+++ b/crates/polars-time/src/chunkedarray/time.rs
@@ -5,20 +5,20 @@ use super::*;
 pub trait TimeMethods {
     /// Extract hour from underlying NaiveDateTime representation.
     /// Returns the hour number from 0 to 23.
-    fn hour(&self) -> UInt32Chunked;
+    fn hour(&self) -> Int8Chunked;
 
     /// Extract minute from underlying NaiveDateTime representation.
     /// Returns the minute number from 0 to 59.
-    fn minute(&self) -> UInt32Chunked;
+    fn minute(&self) -> Int8Chunked;
 
     /// Extract second from underlying NaiveDateTime representation.
     /// Returns the second number from 0 to 59.
-    fn second(&self) -> UInt32Chunked;
+    fn second(&self) -> Int8Chunked;
 
     /// Extract second from underlying NaiveDateTime representation.
     /// Returns the number of nanoseconds since the whole non-leap second.
     /// The range from 1,000,000,000 to 1,999,999,999 represents the leap second.
-    fn nanosecond(&self) -> UInt32Chunked;
+    fn nanosecond(&self) -> Int32Chunked;
 
     fn parse_from_str_slice(name: &str, v: &[&str], fmt: &str) -> TimeChunked;
 }
@@ -26,27 +26,27 @@ pub trait TimeMethods {
 impl TimeMethods for TimeChunked {
     /// Extract hour from underlying NaiveDateTime representation.
     /// Returns the hour number from 0 to 23.
-    fn hour(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<UInt32Type>(&time_to_hour)
+    fn hour(&self) -> Int8Chunked {
+        self.apply_kernel_cast::<Int8Type>(&time_to_hour)
     }
 
     /// Extract minute from underlying NaiveDateTime representation.
     /// Returns the minute number from 0 to 59.
-    fn minute(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<UInt32Type>(&time_to_minute)
+    fn minute(&self) -> Int8Chunked {
+        self.apply_kernel_cast::<Int8Type>(&time_to_minute)
     }
 
     /// Extract second from underlying NaiveDateTime representation.
     /// Returns the second number from 0 to 59.
-    fn second(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<UInt32Type>(&time_to_second)
+    fn second(&self) -> Int8Chunked {
+        self.apply_kernel_cast::<Int8Type>(&time_to_second)
     }
 
     /// Extract second from underlying NaiveDateTime representation.
     /// Returns the number of nanoseconds since the whole non-leap second.
     /// The range from 1,000,000,000 to 1,999,999,999 represents the leap second.
-    fn nanosecond(&self) -> UInt32Chunked {
-        self.apply_kernel_cast::<UInt32Type>(&time_to_nanosecond)
+    fn nanosecond(&self) -> Int32Chunked {
+        self.apply_kernel_cast::<Int32Type>(&time_to_nanosecond)
     }
 
     fn parse_from_str_slice(name: &str, v: &[&str], fmt: &str) -> TimeChunked {

--- a/crates/polars-time/src/series/mod.rs
+++ b/crates/polars-time/src/series/mod.rs
@@ -17,7 +17,7 @@ impl AsSeries for Series {
 pub trait TemporalMethods: AsSeries {
     /// Extract hour from underlying NaiveDateTime representation.
     /// Returns the hour number from 0 to 23.
-    fn hour(&self) -> PolarsResult<UInt32Chunked> {
+    fn hour(&self) -> PolarsResult<Int8Chunked> {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-datetime")]
@@ -30,7 +30,7 @@ pub trait TemporalMethods: AsSeries {
 
     /// Extract minute from underlying NaiveDateTime representation.
     /// Returns the minute number from 0 to 59.
-    fn minute(&self) -> PolarsResult<UInt32Chunked> {
+    fn minute(&self) -> PolarsResult<Int8Chunked> {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-datetime")]
@@ -43,7 +43,7 @@ pub trait TemporalMethods: AsSeries {
 
     /// Extract second from underlying NaiveDateTime representation.
     /// Returns the second number from 0 to 59.
-    fn second(&self) -> PolarsResult<UInt32Chunked> {
+    fn second(&self) -> PolarsResult<Int8Chunked> {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-datetime")]
@@ -56,7 +56,7 @@ pub trait TemporalMethods: AsSeries {
 
     /// Returns the number of nanoseconds since the whole non-leap second.
     /// The range from 1,000,000,000 to 1,999,999,999 represents the leap second.
-    fn nanosecond(&self) -> PolarsResult<UInt32Chunked> {
+    fn nanosecond(&self) -> PolarsResult<Int32Chunked> {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-datetime")]
@@ -71,7 +71,7 @@ pub trait TemporalMethods: AsSeries {
     /// Returns the day of month starting from 1.
     ///
     /// The return value ranges from 1 to 31. (The last day of month differs by months.)
-    fn day(&self) -> PolarsResult<UInt32Chunked> {
+    fn day(&self) -> PolarsResult<Int8Chunked> {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-date")]
@@ -82,7 +82,7 @@ pub trait TemporalMethods: AsSeries {
         }
     }
     /// Returns the ISO weekday number where monday = 1 and sunday = 7
-    fn weekday(&self) -> PolarsResult<UInt32Chunked> {
+    fn weekday(&self) -> PolarsResult<Int8Chunked> {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-date")]
@@ -95,7 +95,7 @@ pub trait TemporalMethods: AsSeries {
 
     /// Returns the ISO week number starting from 1.
     /// The return value ranges from 1 to 53. (The last week of year differs by years.)
-    fn week(&self) -> PolarsResult<UInt32Chunked> {
+    fn week(&self) -> PolarsResult<Int8Chunked> {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-date")]
@@ -109,7 +109,7 @@ pub trait TemporalMethods: AsSeries {
     /// Returns the day of year starting from 1.
     ///
     /// The return value ranges from 1 to 366. (The last day of year differs by years.)
-    fn ordinal_day(&self) -> PolarsResult<UInt32Chunked> {
+    fn ordinal_day(&self) -> PolarsResult<Int16Chunked> {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-date")]
@@ -172,7 +172,7 @@ pub trait TemporalMethods: AsSeries {
 
     /// Extract quarter from underlying NaiveDateTime representation.
     /// Quarters range from 1 to 4.
-    fn quarter(&self) -> PolarsResult<UInt32Chunked> {
+    fn quarter(&self) -> PolarsResult<Int8Chunked> {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-date")]
@@ -187,7 +187,7 @@ pub trait TemporalMethods: AsSeries {
     /// Returns the month number starting from 1.
     ///
     /// The return value ranges from 1 to 12.
-    fn month(&self) -> PolarsResult<UInt32Chunked> {
+    fn month(&self) -> PolarsResult<Int8Chunked> {
         let s = self.as_series();
         match s.dtype() {
             #[cfg(feature = "dtype-date")]

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -607,7 +607,7 @@ class ExprDateTimeNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`UInt32`.
+            Expression of data type :class:`Int8`.
 
         Examples
         --------
@@ -620,7 +620,7 @@ class ExprDateTimeNameSpace:
         ┌────────────┬─────────┐
         │ date       ┆ quarter │
         │ ---        ┆ ---     │
-        │ date       ┆ u32     │
+        │ date       ┆ i8      │
         ╞════════════╪═════════╡
         │ 2001-01-01 ┆ 1       │
         │ 2001-06-30 ┆ 2       │
@@ -642,7 +642,7 @@ class ExprDateTimeNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`UInt32`.
+            Expression of data type :class:`Int8`.
 
         Examples
         --------
@@ -655,7 +655,7 @@ class ExprDateTimeNameSpace:
         ┌────────────┬───────┐
         │ date       ┆ month │
         │ ---        ┆ ---   │
-        │ date       ┆ u32   │
+        │ date       ┆ i8    │
         ╞════════════╪═══════╡
         │ 2001-01-01 ┆ 1     │
         │ 2001-06-30 ┆ 6     │
@@ -677,7 +677,7 @@ class ExprDateTimeNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`UInt32`.
+            Expression of data type :class:`Int8`.
 
         Examples
         --------
@@ -690,7 +690,7 @@ class ExprDateTimeNameSpace:
         ┌────────────┬──────┐
         │ date       ┆ week │
         │ ---        ┆ ---  │
-        │ date       ┆ u32  │
+        │ date       ┆ i8   │
         ╞════════════╪══════╡
         │ 2001-01-01 ┆ 1    │
         │ 2001-06-30 ┆ 26   │
@@ -711,7 +711,7 @@ class ExprDateTimeNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`UInt32`.
+            Expression of data type :class:`Int8`.
 
         See Also
         --------
@@ -720,7 +720,7 @@ class ExprDateTimeNameSpace:
 
         Examples
         --------
-        >>> from datetime import timedelta, date
+        >>> from datetime import date
         >>> df = pl.DataFrame(
         ...     {
         ...         "date": pl.date_range(
@@ -737,7 +737,7 @@ class ExprDateTimeNameSpace:
         ┌────────────┬─────────┬──────────────┬─────────────┐
         │ date       ┆ weekday ┆ day_of_month ┆ day_of_year │
         │ ---        ┆ ---     ┆ ---          ┆ ---         │
-        │ date       ┆ u32     ┆ u32          ┆ u32         │
+        │ date       ┆ i8      ┆ i8           ┆ i16         │
         ╞════════════╪═════════╪══════════════╪═════════════╡
         │ 2001-12-22 ┆ 6       ┆ 22           ┆ 356         │
         │ 2001-12-23 ┆ 7       ┆ 23           ┆ 357         │
@@ -760,7 +760,7 @@ class ExprDateTimeNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`UInt32`.
+            Expression of data type :class:`Int8`.
 
         See Also
         --------
@@ -769,7 +769,7 @@ class ExprDateTimeNameSpace:
 
         Examples
         --------
-        >>> from datetime import timedelta, date
+        >>> from datetime import date
         >>> df = pl.DataFrame(
         ...     {
         ...         "date": pl.date_range(
@@ -786,7 +786,7 @@ class ExprDateTimeNameSpace:
         ┌────────────┬─────────┬──────────────┬─────────────┐
         │ date       ┆ weekday ┆ day_of_month ┆ day_of_year │
         │ ---        ┆ ---     ┆ ---          ┆ ---         │
-        │ date       ┆ u32     ┆ u32          ┆ u32         │
+        │ date       ┆ i8      ┆ i8           ┆ i16         │
         ╞════════════╪═════════╪══════════════╪═════════════╡
         │ 2001-12-22 ┆ 6       ┆ 22           ┆ 356         │
         │ 2001-12-23 ┆ 7       ┆ 23           ┆ 357         │
@@ -809,7 +809,7 @@ class ExprDateTimeNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`UInt32`.
+            Expression of data type :class:`Int16`.
 
         See Also
         --------
@@ -818,7 +818,7 @@ class ExprDateTimeNameSpace:
 
         Examples
         --------
-        >>> from datetime import timedelta, date
+        >>> from datetime import date
         >>> df = pl.DataFrame(
         ...     {
         ...         "date": pl.date_range(
@@ -835,7 +835,7 @@ class ExprDateTimeNameSpace:
         ┌────────────┬─────────┬──────────────┬─────────────┐
         │ date       ┆ weekday ┆ day_of_month ┆ day_of_year │
         │ ---        ┆ ---     ┆ ---          ┆ ---         │
-        │ date       ┆ u32     ┆ u32          ┆ u32         │
+        │ date       ┆ i8      ┆ i8           ┆ i16         │
         ╞════════════╪═════════╪══════════════╪═════════════╡
         │ 2001-12-22 ┆ 6       ┆ 22           ┆ 356         │
         │ 2001-12-23 ┆ 7       ┆ 23           ┆ 357         │
@@ -899,7 +899,7 @@ class ExprDateTimeNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`UInt32`.
+            Expression of data type :class:`Int8`.
 
         Examples
         --------
@@ -918,7 +918,7 @@ class ExprDateTimeNameSpace:
         ┌─────────────────────┬──────┐
         │ datetime            ┆ hour │
         │ ---                 ┆ ---  │
-        │ datetime[μs]        ┆ u32  │
+        │ datetime[μs]        ┆ i8   │
         ╞═════════════════════╪══════╡
         │ 2001-01-01 00:00:00 ┆ 0    │
         │ 2010-01-01 15:30:45 ┆ 15   │
@@ -939,7 +939,7 @@ class ExprDateTimeNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`UInt32`.
+            Expression of data type :class:`Int8`.
 
         Examples
         --------
@@ -958,7 +958,7 @@ class ExprDateTimeNameSpace:
         ┌─────────────────────┬────────┐
         │ datetime            ┆ minute │
         │ ---                 ┆ ---    │
-        │ datetime[μs]        ┆ u32    │
+        │ datetime[μs]        ┆ i8     │
         ╞═════════════════════╪════════╡
         │ 2001-01-01 00:00:00 ┆ 0      │
         │ 2010-01-01 15:30:45 ┆ 30     │
@@ -986,7 +986,7 @@ class ExprDateTimeNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`UInt32` or :class:`Float64`.
+            Expression of data type :class:`Int8` or :class:`Float64`.
 
         Examples
         --------
@@ -1005,7 +1005,7 @@ class ExprDateTimeNameSpace:
         ┌────────────────────────────┬────────┐
         │ datetime                   ┆ second │
         │ ---                        ┆ ---    │
-        │ datetime[μs]               ┆ u32    │
+        │ datetime[μs]               ┆ i8     │
         ╞════════════════════════════╪════════╡
         │ 2000-01-01 00:00:00.456789 ┆ 0      │
         │ 2000-01-01 00:00:03.111110 ┆ 3      │
@@ -1042,7 +1042,7 @@ class ExprDateTimeNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`UInt32`.
+            Expression of data type :class:`Int32`.
 
         """
         return wrap_expr(self._pyexpr.dt_millisecond())
@@ -1056,7 +1056,7 @@ class ExprDateTimeNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`UInt32`.
+            Expression of data type :class:`Int32`.
 
         Examples
         --------
@@ -1074,25 +1074,25 @@ class ExprDateTimeNameSpace:
         >>> df.select(
         ...     [
         ...         pl.col("date"),
-        ...         pl.col("date").dt.microsecond().alias("microseconds"),
+        ...         pl.col("date").dt.microsecond().alias("microsecond"),
         ...     ]
         ... )
         shape: (1_001, 2)
-        ┌─────────────────────────┬──────────────┐
-        │ date                    ┆ microseconds │
-        │ ---                     ┆ ---          │
-        │ datetime[μs]            ┆ u32          │
-        ╞═════════════════════════╪══════════════╡
-        │ 2020-01-01 00:00:00     ┆ 0            │
-        │ 2020-01-01 00:00:00.001 ┆ 1000         │
-        │ 2020-01-01 00:00:00.002 ┆ 2000         │
-        │ 2020-01-01 00:00:00.003 ┆ 3000         │
-        │ …                       ┆ …            │
-        │ 2020-01-01 00:00:00.997 ┆ 997000       │
-        │ 2020-01-01 00:00:00.998 ┆ 998000       │
-        │ 2020-01-01 00:00:00.999 ┆ 999000       │
-        │ 2020-01-01 00:00:01     ┆ 0            │
-        └─────────────────────────┴──────────────┘
+        ┌─────────────────────────┬─────────────┐
+        │ date                    ┆ microsecond │
+        │ ---                     ┆ ---         │
+        │ datetime[μs]            ┆ i32         │
+        ╞═════════════════════════╪═════════════╡
+        │ 2020-01-01 00:00:00     ┆ 0           │
+        │ 2020-01-01 00:00:00.001 ┆ 1000        │
+        │ 2020-01-01 00:00:00.002 ┆ 2000        │
+        │ 2020-01-01 00:00:00.003 ┆ 3000        │
+        │ …                       ┆ …           │
+        │ 2020-01-01 00:00:00.997 ┆ 997000      │
+        │ 2020-01-01 00:00:00.998 ┆ 998000      │
+        │ 2020-01-01 00:00:00.999 ┆ 999000      │
+        │ 2020-01-01 00:00:01     ┆ 0           │
+        └─────────────────────────┴─────────────┘
 
         """
         return wrap_expr(self._pyexpr.dt_microsecond())
@@ -1106,7 +1106,7 @@ class ExprDateTimeNameSpace:
         Returns
         -------
         Expr
-            Expression of data type :class:`UInt32`.
+            Expression of data type :class:`Int32`.
 
         """
         return wrap_expr(self._pyexpr.dt_nanosecond())

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -275,7 +275,7 @@ class DateTimeNameSpace:
         Returns
         -------
         Series
-            Series of data type :class:`UInt32`.
+            Series of data type :class:`Int8`.
 
         Examples
         --------
@@ -285,7 +285,7 @@ class DateTimeNameSpace:
         ... )
         >>> date.dt.quarter()
         shape: (4,)
-        Series: 'date' [u32]
+        Series: 'date' [i8]
         [
                 1
                 1
@@ -307,7 +307,7 @@ class DateTimeNameSpace:
         Returns
         -------
         Series
-            Series of data type :class:`UInt32`.
+            Series of data type :class:`Int8`.
 
         Examples
         --------
@@ -317,7 +317,7 @@ class DateTimeNameSpace:
         ... )
         >>> date.dt.month()
         shape: (4,)
-        Series: 'date' [u32]
+        Series: 'date' [i8]
         [
                 1
                 2
@@ -339,7 +339,7 @@ class DateTimeNameSpace:
         Returns
         -------
         Series
-            Series of data type :class:`UInt32`.
+            Series of data type :class:`Int8`.
 
         Examples
         --------
@@ -349,7 +349,7 @@ class DateTimeNameSpace:
         ... )
         >>> date.dt.week()
         shape: (4,)
-        Series: 'date' [u32]
+        Series: 'date' [i8]
         [
                 1
                 5
@@ -370,7 +370,7 @@ class DateTimeNameSpace:
         Returns
         -------
         Series
-            Series of data type :class:`UInt32`.
+            Series of data type :class:`Int8`.
 
         Examples
         --------
@@ -378,7 +378,7 @@ class DateTimeNameSpace:
         >>> s = pl.date_range(date(2001, 1, 1), date(2001, 1, 7), eager=True)
         >>> s.dt.weekday()
         shape: (7,)
-        Series: 'date' [u32]
+        Series: 'date' [i8]
         [
                 1
                 2
@@ -403,7 +403,7 @@ class DateTimeNameSpace:
         Returns
         -------
         Series
-            Series of data type :class:`UInt32`.
+            Series of data type :class:`Int8`.
 
         Examples
         --------
@@ -413,7 +413,7 @@ class DateTimeNameSpace:
         ... )
         >>> s.dt.day()
         shape: (5,)
-        Series: 'date' [u32]
+        Series: 'date' [i8]
         [
                 1
                 3
@@ -436,7 +436,7 @@ class DateTimeNameSpace:
         Returns
         -------
         Series
-            Series of data type :class:`UInt32`.
+            Series of data type :class:`Int16`.
 
         Examples
         --------
@@ -446,7 +446,7 @@ class DateTimeNameSpace:
         ... )
         >>> s.dt.ordinal_day()
         shape: (3,)
-        Series: 'date' [u32]
+        Series: 'date' [i16]
         [
                 1
                 32
@@ -559,7 +559,7 @@ class DateTimeNameSpace:
         Returns
         -------
         Series
-            Series of data type :class:`UInt32`.
+            Series of data type :class:`Int8`.
 
         Examples
         --------
@@ -578,7 +578,7 @@ class DateTimeNameSpace:
         ]
         >>> date.dt.hour()
         shape: (4,)
-        Series: 'datetime' [u32]
+        Series: 'datetime' [i8]
         [
                 0
                 1
@@ -599,7 +599,7 @@ class DateTimeNameSpace:
         Returns
         -------
         Series
-            Series of data type :class:`UInt32`.
+            Series of data type :class:`Int8`.
 
         Examples
         --------
@@ -617,7 +617,7 @@ class DateTimeNameSpace:
         ]
         >>> date.dt.minute()
         shape: (3,)
-        Series: 'datetime' [u32]
+        Series: 'datetime' [i8]
         [
                 0
                 2
@@ -644,7 +644,7 @@ class DateTimeNameSpace:
         Returns
         -------
         Series
-            Series of data type :class:`UInt32` or :class:`Float64`.
+            Series of data type :class:`Int8` or :class:`Float64`.
 
         Examples
         --------
@@ -659,7 +659,7 @@ class DateTimeNameSpace:
         ... )
         >>> s.dt.second()
         shape: (3,)
-        Series: 'datetime' [u32]
+        Series: 'datetime' [i8]
         [
                 0
                 3
@@ -685,7 +685,7 @@ class DateTimeNameSpace:
         Returns
         -------
         Series
-            Series of data type :class:`UInt32`.
+            Series of data type :class:`Int32`.
 
         Examples
         --------
@@ -695,7 +695,7 @@ class DateTimeNameSpace:
         >>> s = pl.datetime_range(start, stop, interval="500ms", eager=True)
         >>> s.dt.millisecond()
         shape: (9,)
-        Series: 'datetime' [u32]
+        Series: 'datetime' [i32]
         [
                 0
                 500
@@ -719,7 +719,7 @@ class DateTimeNameSpace:
         Returns
         -------
         Series
-            Series of data type :class:`UInt32`.
+            Series of data type :class:`Int32`.
 
         Examples
         --------
@@ -743,7 +743,7 @@ class DateTimeNameSpace:
         ]
         >>> date.dt.microsecond()
         shape: (9,)
-        Series: 'datetime' [u32]
+        Series: 'datetime' [i32]
         [
                 0
                 500000
@@ -767,7 +767,7 @@ class DateTimeNameSpace:
         Returns
         -------
         Series
-            Series of data type :class:`UInt32`.
+            Series of data type :class:`Int32`.
 
         Examples
         --------
@@ -791,7 +791,7 @@ class DateTimeNameSpace:
         ]
         >>> date.dt.nanosecond()
         shape: (9,)
-        Series: 'datetime' [u32]
+        Series: 'datetime' [i32]
         [
                 0
                 500000000

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -47,13 +47,16 @@ def test_dt_to_string(series_of_int_dates: pl.Series) -> None:
     ("unit_attr", "expected"),
     [
         ("year", pl.Series(values=[1997, 2024, 2052], dtype=pl.Int32)),
-        ("month", pl.Series(values=[5, 10, 2], dtype=pl.UInt32)),
-        ("week", pl.Series(values=[21, 40, 8], dtype=pl.UInt32)),
-        ("day", pl.Series(values=[19, 4, 20], dtype=pl.UInt32)),
-        ("ordinal_day", pl.Series(values=[139, 278, 51], dtype=pl.UInt32)),
+        ("iso_year", pl.Series(values=[1997, 2024, 2052], dtype=pl.Int32)),
+        ("quarter", pl.Series(values=[2, 4, 1], dtype=pl.Int8)),
+        ("month", pl.Series(values=[5, 10, 2], dtype=pl.Int8)),
+        ("week", pl.Series(values=[21, 40, 8], dtype=pl.Int8)),
+        ("day", pl.Series(values=[19, 4, 20], dtype=pl.Int8)),
+        ("weekday", pl.Series(values=[1, 5, 2], dtype=pl.Int8)),
+        ("ordinal_day", pl.Series(values=[139, 278, 51], dtype=pl.Int16)),
     ],
 )
-def test_dt_extract_year_month_week_day_ordinal_day(
+def test_dt_extract_datetime_component(
     unit_attr: str,
     expected: pl.Series,
     series_of_int_dates: pl.Series,
@@ -64,12 +67,12 @@ def test_dt_extract_year_month_week_day_ordinal_day(
 @pytest.mark.parametrize(
     ("unit_attr", "expected"),
     [
-        ("hour", pl.Series(values=[0, 3], dtype=pl.UInt32)),
-        ("minute", pl.Series(values=[0, 20], dtype=pl.UInt32)),
-        ("second", pl.Series(values=[0, 10], dtype=pl.UInt32)),
-        ("millisecond", pl.Series(values=[0, 987], dtype=pl.UInt32)),
-        ("microsecond", pl.Series(values=[0, 987654], dtype=pl.UInt32)),
-        ("nanosecond", pl.Series(values=[0, 987654321], dtype=pl.UInt32)),
+        ("hour", pl.Series(values=[0, 3], dtype=pl.Int8)),
+        ("minute", pl.Series(values=[0, 20], dtype=pl.Int8)),
+        ("second", pl.Series(values=[0, 10], dtype=pl.Int8)),
+        ("millisecond", pl.Series(values=[0, 987], dtype=pl.Int32)),
+        ("microsecond", pl.Series(values=[0, 987654], dtype=pl.Int32)),
+        ("nanosecond", pl.Series(values=[0, 987654321], dtype=pl.Int32)),
     ],
 )
 def test_strptime_extract_times(


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE**

Closes #6079, closes https://github.com/jorgecarleitao/arrow2/issues/1372

Updates the return type for datetime components as follows:

| method      | dtype old | dtype new |
|-------------|-----------|-----------|
| year        | i32       | i32       |
| iso_year        | i32       | i32       |
| quarter     | u32       | i8        |
| month       | u32       | i8        |
| week        | u32       | i8        |
| day         | u32       | i8        |
| weekday     | u32       | i8        |
| ordinal_day | u32       | i16       |
| hour        | u32       | i8        |
| minute      | u32       | i8        |
| second      | u32       | i8        |
| millisecond | u32       | i32*       |
| microsecond | u32       | i32       |
| nanosecond  | u32       | i32       |

_*Technically, `millisecond` can be an `i16`, but it's computed from `nanosecond` so I figured I'd leave all subseconds on `i32`. I am open to changing this._

Main benefits:
* Fewer bits = less memory consumption
* Signed integers are easier to use in arithmetic than unsigned
