### PR TITLE
feat(rust, python): expressify `offset` and `length` parameters for `str.slice`

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -526,7 +526,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     /// `start` can be negative, in which case the start counts from the end of the string.
     fn str_slice(&self, start: &Int64Chunked, length: &UInt64Chunked) -> Utf8Chunked {
         let ca = self.as_utf8();
-        super::substring::utf8_substring(ca, start, length)
+        substring::utf8_substring(ca, start, length)
     }
 }
 

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -526,7 +526,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     /// `start` can be negative, in which case the start counts from the end of the string.
     fn str_slice(&self, start: &Int64Chunked, length: &UInt64Chunked) -> Utf8Chunked {
         let ca = self.as_utf8();
-        super::substring::utf8_substring(ca, start, length).into()
+        super::substring::utf8_substring(ca, start, length)
     }
 }
 

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -524,12 +524,9 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
     ///
     /// Determines a substring starting from `start` and with optional length `length` of each of the elements in `array`.
     /// `start` can be negative, in which case the start counts from the end of the string.
-    fn str_slice(&self, start: i64, length: Option<u64>) -> Utf8Chunked {
+    fn str_slice(&self, start: &Int64Chunked, length: &UInt64Chunked) -> Utf8Chunked {
         let ca = self.as_utf8();
-        let iter = ca
-            .downcast_iter()
-            .map(|c| substring::utf8_substring(c, start, &length));
-        Utf8Chunked::from_chunk_iter_like(ca, iter)
+        super::substring::utf8_substring(ca, start, length).into()
     }
 }
 

--- a/crates/polars-ops/src/chunked_array/strings/substring.rs
+++ b/crates/polars-ops/src/chunked_array/strings/substring.rs
@@ -2,8 +2,6 @@ use polars_core::prelude::arity::{binary_elementwise, ternary_elementwise};
 
 use crate::chunked_array::{Int64Chunked, UInt64Chunked, Utf8Chunked};
 
-/// Returns a Utf8Array<O> with a substring starting from `start` and with optional length `length` of each of the elements in `array`.
-/// `offset` can be negative, in which case the offset counts from the end of the string.
 fn utf8_substring_ternary<'a>(
     opt_str_val: Option<&'a str>,
     opt_offset: Option<i64>,
@@ -11,7 +9,7 @@ fn utf8_substring_ternary<'a>(
 ) -> Option<&'a str> {
     match (opt_str_val, opt_offset) {
         (Some(str_val), Some(offset)) => {
-            // compute where we should offset slicing this entry.
+            // if `offset` is negative, it counts from the end of the string
             let offset = if offset >= 0 {
                 offset as usize
             } else {
@@ -26,7 +24,6 @@ fn utf8_substring_ternary<'a>(
 
             let mut iter_chars = str_val.char_indices();
             if let Some((offset_idx, _)) = iter_chars.nth(offset) {
-                // length of the str
                 let len_end = str_val.len() - offset_idx;
 
                 // slice to end of str if no length given
@@ -38,7 +35,7 @@ fn utf8_substring_ternary<'a>(
                 if length == 0 {
                     return Some("");
                 }
-                // compute
+
                 let end_idx = iter_chars
                     .nth(length.saturating_sub(1))
                     .map(|(idx, _)| idx)
@@ -62,8 +59,32 @@ pub(super) fn utf8_substring(
         (1, 1) => ca.apply_generic(|opt_str_val| {
             utf8_substring_ternary(opt_str_val, offset.get(0), length.get(0))
         }),
-        //(1, _) => binary_elementwise(ca, length, |opt_str_val, opt_length| utf8_substring_ternary(opt_str_val, offset.get(0), opt_length)),
-        //(_, 1) => binary_elementwise(ca, offset, |opt_str_val, opt_offset| utf8_substring_ternary(opt_str_val, opt_offset, length.get(0))),
+        (1, _) => {
+            fn infer<F: for<'a> FnMut(Option<&'a str>, Option<u64>) -> Option<&'a str>>(f: F) -> F where
+            {
+                f
+            }
+
+            let off = offset.get(0);
+            binary_elementwise(
+                ca,
+                length,
+                infer(|val, len| utf8_substring_ternary(val, off, len)),
+            )
+        },
+        (_, 1) => {
+            fn infer<F: for<'a> FnMut(Option<&'a str>, Option<i64>) -> Option<&'a str>>(f: F) -> F where
+            {
+                f
+            }
+
+            let len = length.get(0);
+            binary_elementwise(
+                ca,
+                offset,
+                infer(|val, off| utf8_substring_ternary(val, off, len)),
+            )
+        },
         _ => ternary_elementwise(ca, offset, length, utf8_substring_ternary),
     }
 }

--- a/crates/polars-ops/src/chunked_array/strings/substring.rs
+++ b/crates/polars-ops/src/chunked_array/strings/substring.rs
@@ -2,11 +2,11 @@ use polars_core::prelude::arity::{binary_elementwise, ternary_elementwise};
 
 use crate::chunked_array::{Int64Chunked, UInt64Chunked, Utf8Chunked};
 
-fn utf8_substring_ternary<'a>(
-    opt_str_val: Option<&'a str>,
+fn utf8_substring_ternary(
+    opt_str_val: Option<&str>,
     opt_offset: Option<i64>,
     opt_length: Option<u64>,
-) -> Option<&'a str> {
+) -> Option<&str> {
     match (opt_str_val, opt_offset) {
         (Some(str_val), Some(offset)) => {
             // if `offset` is negative, it counts from the end of the string

--- a/crates/polars-ops/src/chunked_array/strings/substring.rs
+++ b/crates/polars-ops/src/chunked_array/strings/substring.rs
@@ -4,11 +4,11 @@ use crate::chunked_array::{Int64Chunked, UInt64Chunked, Utf8Chunked};
 
 /// Returns a Utf8Array<O> with a substring starting from `start` and with optional length `length` of each of the elements in `array`.
 /// `offset` can be negative, in which case the offset counts from the end of the string.
-fn utf8_substring_ternary<'a>(
-    opt_str_val: Option<&'a str>,
+fn utf8_substring_ternary(
+    opt_str_val: Option<&str>,
     opt_offset: Option<i64>,
     opt_length: Option<u64>,
-) -> Option<&'a str> {
+) -> Option<&str> {
     match (opt_str_val, opt_offset) {
         (Some(str_val), Some(offset)) => {
             // compute where we should offset slicing this entry.

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -1078,7 +1078,7 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             StripSuffix => map_as_slice!(strings::strip_suffix),
             #[cfg(feature = "string_from_radix")]
             FromRadix(radix, strict) => map!(strings::from_radix, radix, strict),
-            Slice(start, length) => map!(strings::str_slice, start, length),
+            Slice => map_as_slice!(strings::str_slice),
             Explode => map!(strings::explode),
             #[cfg(feature = "dtype-decimal")]
             ToDecimal(infer_len) => map!(strings::to_decimal, infer_len),

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -730,43 +730,24 @@ pub(super) fn from_radix(s: &Series, radix: u32, strict: bool) -> PolarsResult<S
 pub(super) fn str_slice(s: &[Series]) -> PolarsResult<Series> {
     let ca = s[0].utf8()?;
 
-    let s1 = &s[1];
-    let s2 = &s[2];
-
     polars_ensure!(
-        s1.len() <= ca.len(),
+        s[1].len() <= ca.len(),
         ComputeError:
         "too many `offset` values ({}) for column length ({})",
-        s1.len(), ca.len(),
+        s[1].len(), ca.len(),
     );
 
     polars_ensure!(
-        s2.len() <= ca.len(),
+        s[2].len() <= ca.len(),
         ComputeError:
         "too many `length` values ({}) for column length ({})",
-        s2.len(), ca.len(),
+        s[2].len(), ca.len(),
     );
 
-    let offset = match s1.len() {
-        1 => {
-            let offset = s1.get(0).unwrap();
-            s1.clear().extend_constant(offset, ca.len()).unwrap()
-        },
-        _ => s1.clone(),
-    };
-
-    let offset = offset.cast(&DataType::Int64)?;
+    let offset = s[1].cast(&DataType::Int64)?;
     let offset = offset.i64()?;
 
-    let length = match s2.len() {
-        1 => {
-            let length = s2.get(0).unwrap();
-            s2.clear().extend_constant(length, ca.len()).unwrap()
-        },
-        _ => s2.clone(),
-    };
-
-    let length = length.cast(&DataType::UInt64)?;
+    let length = s[2].cast(&DataType::UInt64)?;
     let length = length.u64()?;
 
     Ok(ca.str_slice(offset, length).into_series())

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -402,11 +402,13 @@ impl StringNameSpace {
     }
 
     /// Slice the string values.
-    pub fn slice(self, start: i64, length: Option<u64>) -> Expr {
-        self.0
-            .map_private(FunctionExpr::StringExpr(StringFunction::Slice(
-                start, length,
-            )))
+    pub fn slice(self, offset: Expr, length: Expr) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::StringExpr(StringFunction::Slice),
+            &[offset, length],
+            false,
+            false,
+        )
     }
 
     pub fn explode(self) -> Expr {

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -703,7 +703,7 @@ impl SqlFunctionVisitor<'_> {
             InitCap => self.visit_unary(|e| e.str().to_titlecase()),
             Left => self.try_visit_binary(|e, length| {
                 Ok(match length {
-                    Expr::Literal(LiteralValue::Int64(_n)) => {
+                    Expr::Literal(LiteralValue::Int64(_)) => {
                         e.str().slice(lit(0), length)
                     },
                     _ => {

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1852,7 +1852,7 @@ class ExprStringNameSpace:
         value = parse_as_expression(value, str_as_lit=True)
         return wrap_expr(self._pyexpr.str_replace_all(pattern, value, literal))
 
-    def slice(self, offset: int, length: int | None = None) -> Expr:
+    def slice(self, offset: IntoExpr, length: IntoExpr | None = None) -> Expr:
         """
         Create subslices of the string values of a Utf8 Series.
 
@@ -1905,6 +1905,8 @@ class ExprStringNameSpace:
         └─────────────┴──────────┘
 
         """
+        offset = parse_as_expression(offset)
+        length = parse_as_expression(length)
         return wrap_expr(self._pyexpr.str_slice(offset, length))
 
     def explode(self) -> Expr:

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1426,7 +1426,7 @@ class StringNameSpace:
 
         """
 
-    def slice(self, offset: int, length: int | None = None) -> Series:
+    def slice(self, offset: IntoExpr, length: IntoExpr | None = None) -> Series:
         """
         Create subslices of the string values of a Utf8 Series.
 

--- a/py-polars/src/expr/string.rs
+++ b/py-polars/src/expr/string.rs
@@ -90,8 +90,12 @@ impl PyExpr {
         self.inner.clone().str().strip_suffix(suffix.inner).into()
     }
 
-    fn str_slice(&self, start: i64, length: Option<u64>) -> Self {
-        self.inner.clone().str().slice(start, length).into()
+    fn str_slice(&self, offset: Self, length: Self) -> Self {
+        self.inner
+            .clone()
+            .str()
+            .slice(offset.inner, length.inner)
+            .into()
     }
 
     fn str_explode(&self) -> Self {

--- a/py-polars/tests/unit/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/namespaces/string/test_string.py
@@ -15,6 +15,20 @@ def test_str_slice() -> None:
     assert df.select([pl.col("a").str.slice(2, 4)])["a"].to_list() == ["obar", "rfoo"]
 
 
+def test_str_slice_expressions() -> None:
+    df = pl.DataFrame({"a": ["foobar", "barfoo"], "offset": [1, 3], "length": [3, 4]})
+
+    out = df.select(pl.col("a").str.slice("offset", "length"))
+
+    expected = pl.DataFrame({"a": ["oob", "foo"]})
+    assert out.frame_equal(expected)
+
+    out = df.select(pl.col("a").str.slice(-3, "length"))
+
+    expected = pl.DataFrame({"a": ["bar", "foo"]})
+    assert out.frame_equal(expected)
+
+
 def test_str_concat() -> None:
     s = pl.Series(["1", None, "2"])
     result = s.str.concat()


### PR DESCRIPTION
Attempts to resolve #10890

I see it had been previously self-assigned @orlp - hopefully I'm not intruding here. 

(I imagine you had more important things to work on.)

```python
df = pl.DataFrame({
   "foo": ["abcde", "fghijk"],
   "offset": [1, 2],
   "length": [3, 4],
})

df.with_columns(slice = pl.col("foo").str.slice("offset", "length"))

# shape: (2, 4)
# ┌────────┬────────┬────────┬───────┐
# │ foo    ┆ offset ┆ length ┆ slice │
# │ ---    ┆ ---    ┆ ---    ┆ ---   │
# │ str    ┆ i64    ┆ i64    ┆ str   │
# ╞════════╪════════╪════════╪═══════╡
# │ abcde  ┆ 1      ┆ 3      ┆ bcd   │
# │ fghijk ┆ 2      ┆ 4      ┆ hijk  │
# └────────┴────────┴────────┴───────┘
```

I used the `strip_prefix` impl as a guide/template https://github.com/pola-rs/polars/blob/main/crates/polars-ops/src/chunked_array/strings/strip.rs 

Some things I'm not sure about if anybody wants to give feedback:

- Instead of all the length checks, I just broadcasted `offset` and  `length` using `.clear().extend_constant()` - is this an acceptable approach or is it a bad idea + performance concern?
- Is there a way to "typecheck" the params, or is it okay to just `.cast()`?
- Is `UInt64` the correct type for `length`?
- The param name is `offset` but internally `start` is used, I changed everything to `offset`, is this the right approach?
- I had to modify `polars-sql` as it used `.slice()` (incidentally, that uses `start` as the param name, should it be `start` everywhere instead of `offset`?)
- Is it okay to use `!matches!`?
- As `length` is a param name, I had to re-jig the error format a bit to avoid ending up with `length value length`.
