### PR TITLE
chore(python): minor updates to lint-related dependencies

### DIFF
--- a/.github/workflows/lint-global.yml
+++ b/.github/workflows/lint-global.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Lint Markdown and TOML
         uses: dprint/check@v2.2
       - name: Spell Check with Typos
-        uses: crate-ci/typos@v1.16.20
+        uses: crate-ci/typos@v1.16.21

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,4 +1,4 @@
 blackdoc==0.3.8
-mypy==1.6.0
-ruff==0.1.2
-typos==1.16.20
+mypy==1.6.1
+ruff==0.1.3
+typos==1.16.21

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -437,7 +437,7 @@ def test_power() -> None:
     assert_series_equal(a**a, pl.Series([1.0, 4.0], dtype=Float64))
     assert_series_equal(b**b, pl.Series([None, 4.0], dtype=Float64))
     assert_series_equal(a**b, pl.Series([None, 4.0], dtype=Float64))
-    assert_series_equal(a ** None, pl.Series([None] * len(a), dtype=Float64))
+    assert_series_equal(a**None, pl.Series([None] * len(a), dtype=Float64))
     with pytest.raises(TypeError):
         c**2
     with pytest.raises(pl.ColumnNotFoundError):


### PR DESCRIPTION
Was starting to integrate these further into our codebase at work, so spotted the new releases...
Only a single line of code changed.

All minor point updates:

* `ruff`: 0.1.2 → 0.1.3
* `mypy`: 1.60 → 1.61
* `typos`: 1.16.20 → 1.16.21

@stinodego: Looks like the `ruff` update includes a fix for something 
that I think you spotted earlier? (unexpected spacing around `**`) 😄  