### PR TITLE
docs(python): Minor tweak in code example in section Expressions/Missing data

### DIFF
--- a/docs/src/python/user-guide/expressions/null.py
+++ b/docs/src/python/user-guide/expressions/null.py
@@ -40,12 +40,8 @@ print(df)
 
 
 # --8<-- [start:fill]
-fill_literal_df = (
-    df.with_columns(
-        pl.col("col2").fill_null(
-            pl.lit(2),
-        ),
-    ),
+fill_literal_df = df.with_columns(
+    pl.col("col2").fill_null(pl.lit(2)),
 )
 print(fill_literal_df)
 # --8<-- [end:fill]


### PR DESCRIPTION
It can be observed that the output format of `fill_literal_df` is not consistent with other examples in this section. This inconsistency is due to the presence of an extra comma. Instead of simply removing the extra comma, I would suggest rewriting the code as proposed, which aligns with the format of other code examples in this section.

```python
fill_literal_df = (
    df.with_columns(
        pl.col("col2").fill_null(
            pl.lit(2),
        ),
    ), # <= extra comma
)
print(fill_literal_df)
```
```
(shape: (3, 2)
┌──────┬──────┐
│ col1 ┆ col2 │
│ ---  ┆ ---  │
│ i64  ┆ i64  │
╞══════╪══════╡
│ 1    ┆ 1    │
│ 2    ┆ 2    │
│ 3    ┆ 3    │
└──────┴──────┘,)
```