### PR TITLE
fix: default csv writer options

### DIFF
--- a/crates/polars-io/src/csv/write.rs
+++ b/crates/polars-io/src/csv/write.rs
@@ -76,7 +76,14 @@ where
     }
 
     /// Set the batch size to use while writing the CSV.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `batch_size` is zero.
     pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        if batch_size == 0 {
+            panic!("csv write batch size must not be greater than zero");
+        }
         self.batch_size = batch_size;
         self
     }

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -75,13 +75,25 @@ pub struct IpcWriterOptions {
 }
 
 #[cfg(feature = "csv")]
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CsvWriterOptions {
     pub has_header: bool,
     pub batch_size: usize,
     pub maintain_order: bool,
     pub serialize_options: SerializeOptions,
+}
+
+#[cfg(feature = "csv")]
+impl Default for CsvWriterOptions {
+    fn default() -> Self {
+        Self {
+            has_header: false,
+            batch_size: 1024, // same as CsvWriter default.
+            maintain_order: false,
+            serialize_options: SerializeOptions::default(),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]


### PR DESCRIPTION
`CsvWriterOptions`'s `batch_size` was defaulting to zero leading to infinite wait when using `sink_csv`.
The batch size is used by `CsvWriter` to calculate the number of output threads which becomes zero.