### PR TITLE
fix: ensure filter predicate inputs exist in schema

### DIFF
--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -630,9 +630,10 @@ impl LogicalPlanBuilder {
         // SELECT [col("x").alias("y")] FROM
         //   DF ["x"]; PROJECT 1/1 COLUMNS; SELECTION: "[(col(\"x\")) == (1)]"
         //                                             ^^^
-        // 'x' is incorrectly pushed down even though it didn't exist after selection
+        // "x" is incorrectly pushed down even though it didn't exist after SELECT
         try_delayed!(
-            expressions_to_schema(&[predicate.clone()], &schema, Context::Default),
+            expr_to_leaf_column_names_iter(&predicate)
+                .try_for_each(|c| schema.try_index_of(&c).and(Ok(()))),
             &self.0,
             into
         );

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -632,7 +632,7 @@ impl LogicalPlanBuilder {
         //                                             ^^^
         // 'x' is incorrectly pushed down even though it didn't exist after selection
         try_delayed!(
-            expressions_to_schema(&[predicate.clone()], &*schema, Context::Default),
+            expressions_to_schema(&[predicate.clone()], &schema, Context::Default),
             &self.0,
             into
         );

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1211,11 +1211,11 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         --------
         >>> lf = pl.LazyFrame({"foo": [1, 1, -2, 3]})
         >>> (
-        ...     lf.select(pl.col("foo").cumsum().alias("bar"))
+        ...     lf.with_columns(pl.col("foo").cumsum().alias("bar"))
         ...     .inspect()  # print the node before the filter
         ...     .filter(pl.col("bar") == pl.col("foo"))
         ... )  # doctest: +ELLIPSIS
-        <LazyFrame [1 col, {"bar": Int64}] at ...>
+        <LazyFrame [2 cols, {"foo": Int64, "bar": Int64}] at ...>
 
         """
 

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -691,3 +691,12 @@ def test_sort_by_error() -> None:
 def test_non_existent_expr_inputs_in_lazy() -> None:
     with pytest.raises(pl.ColumnNotFoundError):
         pl.LazyFrame().filter(pl.col("x") == 1).explain()  # tests: 12074
+
+    lf = pl.LazyFrame({"foo": [1, 1, -2, 3]})
+
+    with pytest.raises(pl.ColumnNotFoundError):
+        (
+            lf.select(pl.col("foo").cumsum().alias("bar"))
+            .filter(pl.col("bar") == pl.col("foo"))
+            .explain()
+        )

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -133,7 +133,10 @@ def test_join_lazy_on_df() -> None:
 
 
 def test_projection_update_schema_missing_column() -> None:
-    with pytest.raises(pl.ColumnNotFoundError, match="not found: colC"):
+    with pytest.raises(
+        pl.ColumnNotFoundError,
+        match='unable to find column "colC"',
+    ):
         (
             pl.DataFrame({"colA": ["a", "b", "c"], "colB": [1, 2, 3]})
             .lazy()

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -133,9 +133,7 @@ def test_join_lazy_on_df() -> None:
 
 
 def test_projection_update_schema_missing_column() -> None:
-    with pytest.raises(
-        pl.ComputeError, match="column 'colC' not available in schema Schema:*"
-    ):
+    with pytest.raises(pl.ColumnNotFoundError, match="not found: colC"):
         (
             pl.DataFrame({"colA": ["a", "b", "c"], "colB": [1, 2, 3]})
             .lazy()
@@ -685,3 +683,8 @@ def test_sort_by_error() -> None:
         df.group_by("id", maintain_order=True).agg(
             pl.col("cost").filter(pl.col("type") == "A").sort_by("number")
         )
+
+
+def test_non_existent_expr_inputs_in_lazy() -> None:
+    with pytest.raises(pl.ColumnNotFoundError):
+        pl.LazyFrame().filter(pl.col("x") == 1).explain()  # tests: 12074

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -7,7 +7,6 @@ from typing import Any, Iterator, Mapping
 import pytest
 
 import polars as pl
-import polars.exceptions
 from polars.testing import assert_frame_equal
 
 
@@ -544,8 +543,3 @@ def test_lit_iter_schema() -> None:
         "key": ["A"],
         "dates": [[date(1970, 1, 2), date(1970, 1, 3), date(1970, 1, 4)]],
     }
-
-
-def test_non_existent_expr_inputs_in_lazy() -> None:
-    with pytest.raises(polars.exceptions.ColumnNotFoundError):
-        pl.LazyFrame().filter(pl.col("x") == 1).explain()

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -543,3 +543,8 @@ def test_lit_iter_schema() -> None:
         "key": ["A"],
         "dates": [[date(1970, 1, 2), date(1970, 1, 3), date(1970, 1, 4)]],
     }
+
+
+def test_non_existent_expr_inputs_in_lazy() -> None:
+    with pytest.raises(Exception):
+        pl.LazyFrame().filter(pl.col("x") == 1).explain()

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -7,6 +7,7 @@ from typing import Any, Iterator, Mapping
 import pytest
 
 import polars as pl
+import polars.exceptions
 from polars.testing import assert_frame_equal
 
 
@@ -546,5 +547,5 @@ def test_lit_iter_schema() -> None:
 
 
 def test_non_existent_expr_inputs_in_lazy() -> None:
-    with pytest.raises(Exception):
+    with pytest.raises(polars.exceptions.ColumnNotFoundError):
         pl.LazyFrame().filter(pl.col("x") == 1).explain()


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/12074.

This makes `LogicalPlanBuilder::filter` error immediately if `.filter()` is passed non-existent columns, whereas previously the error would only be raised after executing the physical plan (or not raised at all if `PredicatePushDown::push_down`  sent it to a `Node` where the column name existed).

Note there are multiple other functions under `LogicalPlanBuilder` that also currently don't error:

```python
>>> pl.LazyFrame().sort("x")
<LazyFrame [0 cols, {}] at 0x7F78FF5E1590>
>>> pl.LazyFrame().drop_nulls("x")  # notably under discussion https://github.com/pola-rs/polars/issues/11913
<LazyFrame [0 cols, {}] at 0x7F78F15046D0>
```
