### PR TITLE
fix(rust): Raise if *_horizontal without inputs

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1412,14 +1412,15 @@ impl LazyFrame {
     /// columns are considered.
     pub fn drop_nulls(self, subset: Option<Vec<Expr>>) -> LazyFrame {
         match subset {
-            None => self.filter(all_horizontal([col("*").is_not_null()])),
+            None => self.filter(all_horizontal([col("*").is_not_null()]).unwrap()),
             Some(subset) => {
                 let predicate = all_horizontal(
                     subset
                         .into_iter()
                         .map(|e| e.is_not_null())
                         .collect::<Vec<_>>(),
-                );
+                )
+                .unwrap();
                 self.filter(predicate)
             },
         }

--- a/crates/polars-plan/src/dsl/functions/horizontal.rs
+++ b/crates/polars-plan/src/dsl/functions/horizontal.rs
@@ -193,9 +193,11 @@ where
 /// Create a new column with the the bitwise-and of the elements in each row.
 ///
 /// The name of the resulting column will be "all"; use [`alias`](Expr::alias) to choose a different name.
-pub fn all_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
+pub fn all_horizontal<E: AsRef<[Expr]>>(exprs: E) -> PolarsResult<Expr> {
     let exprs = exprs.as_ref().to_vec();
-    Expr::Function {
+    polars_ensure!(!exprs.is_empty(), ComputeError: "cannot return empty fold because the number of output rows is unknown");
+
+    Ok(Expr::Function {
         input: exprs,
         function: FunctionExpr::Boolean(BooleanFunction::AllHorizontal),
         options: FunctionOptions {
@@ -206,15 +208,17 @@ pub fn all_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
             allow_rename: true,
             ..Default::default()
         },
-    }
+    })
 }
 
 /// Create a new column with the the bitwise-or of the elements in each row.
 ///
 /// The name of the resulting column will be "any"; use [`alias`](Expr::alias) to choose a different name.
-pub fn any_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
+pub fn any_horizontal<E: AsRef<[Expr]>>(exprs: E) -> PolarsResult<Expr> {
     let exprs = exprs.as_ref().to_vec();
-    Expr::Function {
+    polars_ensure!(!exprs.is_empty(), ComputeError: "cannot return empty fold because the number of output rows is unknown");
+
+    Ok(Expr::Function {
         input: exprs,
         function: FunctionExpr::Boolean(BooleanFunction::AnyHorizontal),
         options: FunctionOptions {
@@ -225,19 +229,17 @@ pub fn any_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
             allow_rename: true,
             ..Default::default()
         },
-    }
+    })
 }
 
 /// Create a new column with the the maximum value per row.
 ///
 /// The name of the resulting column will be `"max"`; use [`alias`](Expr::alias) to choose a different name.
-pub fn max_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
+pub fn max_horizontal<E: AsRef<[Expr]>>(exprs: E) -> PolarsResult<Expr> {
     let exprs = exprs.as_ref().to_vec();
-    if exprs.is_empty() {
-        return Expr::Columns(Vec::new());
-    }
+    polars_ensure!(!exprs.is_empty(), ComputeError: "cannot return empty fold because the number of output rows is unknown");
 
-    Expr::Function {
+    Ok(Expr::Function {
         input: exprs,
         function: FunctionExpr::MaxHorizontal,
         options: FunctionOptions {
@@ -247,19 +249,17 @@ pub fn max_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
             allow_rename: true,
             ..Default::default()
         },
-    }
+    })
 }
 
 /// Create a new column with the the minimum value per row.
 ///
 /// The name of the resulting column will be `"min"`; use [`alias`](Expr::alias) to choose a different name.
-pub fn min_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
+pub fn min_horizontal<E: AsRef<[Expr]>>(exprs: E) -> PolarsResult<Expr> {
     let exprs = exprs.as_ref().to_vec();
-    if exprs.is_empty() {
-        return Expr::Columns(Vec::new());
-    }
+    polars_ensure!(!exprs.is_empty(), ComputeError: "cannot return empty fold because the number of output rows is unknown");
 
-    Expr::Function {
+    Ok(Expr::Function {
         input: exprs,
         function: FunctionExpr::MinHorizontal,
         options: FunctionOptions {
@@ -269,16 +269,17 @@ pub fn min_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
             allow_rename: true,
             ..Default::default()
         },
-    }
+    })
 }
 
 /// Create a new column with the the sum of the values in each row.
 ///
 /// The name of the resulting column will be `"sum"`; use [`alias`](Expr::alias) to choose a different name.
-pub fn sum_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
+pub fn sum_horizontal<E: AsRef<[Expr]>>(exprs: E) -> PolarsResult<Expr> {
     let exprs = exprs.as_ref().to_vec();
+    polars_ensure!(!exprs.is_empty(), ComputeError: "cannot return empty fold because the number of output rows is unknown");
 
-    Expr::Function {
+    Ok(Expr::Function {
         input: exprs,
         function: FunctionExpr::SumHorizontal,
         options: FunctionOptions {
@@ -289,7 +290,7 @@ pub fn sum_horizontal<E: AsRef<[Expr]>>(exprs: E) -> Expr {
             allow_rename: true,
             ..Default::default()
         },
-    }
+    })
 }
 
 /// Folds the expressions from left to right keeping the first non-null values.

--- a/crates/polars-plan/src/dsl/functions/mod.rs
+++ b/crates/polars-plan/src/dsl/functions/mod.rs
@@ -5,7 +5,7 @@ mod arity;
 mod coerce;
 mod concat;
 mod correlation;
-mod horizontal;
+pub(crate) mod horizontal;
 mod index;
 #[cfg(feature = "range")]
 mod range;

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -29,6 +29,7 @@ use polars_io::{
 };
 
 use super::builder_functions::*;
+use crate::dsl::all_horizontal;
 use crate::logical_plan::functions::FunctionNode;
 use crate::logical_plan::projection::{is_regex_projection, rewrite_projections};
 use crate::logical_plan::schema::{det_join_schema, FileInfo};
@@ -476,6 +477,29 @@ impl LogicalPlanBuilder {
             .map(|name| col(name).fill_null(fill_value.clone()))
             .collect();
         self.project(exprs, Default::default())
+    }
+
+    pub fn drop_nulls(self, subset: Option<Vec<Expr>>) -> Self {
+        match subset {
+            None => {
+                let predicate =
+                    try_delayed!(all_horizontal([col("*").is_not_null()]), &self.0, into);
+                self.filter(predicate)
+            },
+            Some(subset) => {
+                let predicate = try_delayed!(
+                    all_horizontal(
+                        subset
+                            .into_iter()
+                            .map(|e| e.is_not_null())
+                            .collect::<Vec<_>>(),
+                    ),
+                    &self.0,
+                    into
+                );
+                self.filter(predicate)
+            },
+        }
     }
 
     pub fn fill_nan(self, fill_value: Expr) -> Self {

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -29,7 +29,7 @@ use polars_io::{
 };
 
 use super::builder_functions::*;
-use crate::dsl::all_horizontal;
+use crate::dsl::functions::horizontal::all_horizontal;
 use crate::logical_plan::functions::FunctionNode;
 use crate::logical_plan::projection::{is_regex_projection, rewrite_projections};
 use crate::logical_plan::schema::{det_join_schema, FileInfo};

--- a/crates/polars/tests/it/lazy/folds.rs
+++ b/crates/polars/tests/it/lazy/folds.rs
@@ -21,7 +21,7 @@ fn test_fold_wildcard() -> PolarsResult<()> {
     // test if we don't panic due to wildcard
     let _out = df1
         .lazy()
-        .select([polars_lazy::dsl::all_horizontal([col("*").is_not_null()])])
+        .select([polars_lazy::dsl::all_horizontal([col("*").is_not_null()])?])
         .collect()?;
     Ok(())
 }

--- a/py-polars/src/functions/aggregation.rs
+++ b/py-polars/src/functions/aggregation.rs
@@ -1,35 +1,41 @@
 use polars::lazy::dsl;
 use pyo3::prelude::*;
 
+use crate::error::PyPolarsErr;
 use crate::expr::ToExprs;
 use crate::PyExpr;
 
 #[pyfunction]
-pub fn all_horizontal(exprs: Vec<PyExpr>) -> PyExpr {
+pub fn all_horizontal(exprs: Vec<PyExpr>) -> PyResult<PyExpr> {
     let exprs = exprs.to_exprs();
-    dsl::all_horizontal(exprs).into()
+    let e = dsl::all_horizontal(exprs).map_err(PyPolarsErr::from)?;
+    Ok(e.into())
 }
 
 #[pyfunction]
-pub fn any_horizontal(exprs: Vec<PyExpr>) -> PyExpr {
+pub fn any_horizontal(exprs: Vec<PyExpr>) -> PyResult<PyExpr> {
     let exprs = exprs.to_exprs();
-    dsl::any_horizontal(exprs).into()
+    let e = dsl::any_horizontal(exprs).map_err(PyPolarsErr::from)?;
+    Ok(e.into())
 }
 
 #[pyfunction]
-pub fn max_horizontal(exprs: Vec<PyExpr>) -> PyExpr {
+pub fn max_horizontal(exprs: Vec<PyExpr>) -> PyResult<PyExpr> {
     let exprs = exprs.to_exprs();
-    dsl::max_horizontal(exprs).into()
+    let e = dsl::max_horizontal(exprs).map_err(PyPolarsErr::from)?;
+    Ok(e.into())
 }
 
 #[pyfunction]
-pub fn min_horizontal(exprs: Vec<PyExpr>) -> PyExpr {
+pub fn min_horizontal(exprs: Vec<PyExpr>) -> PyResult<PyExpr> {
     let exprs = exprs.to_exprs();
-    dsl::min_horizontal(exprs).into()
+    let e = dsl::min_horizontal(exprs).map_err(PyPolarsErr::from)?;
+    Ok(e.into())
 }
 
 #[pyfunction]
-pub fn sum_horizontal(exprs: Vec<PyExpr>) -> PyExpr {
+pub fn sum_horizontal(exprs: Vec<PyExpr>) -> PyResult<PyExpr> {
     let exprs = exprs.to_exprs();
-    dsl::sum_horizontal(exprs).into()
+    let e = dsl::sum_horizontal(exprs).map_err(PyPolarsErr::from)?;
+    Ok(e.into())
 }

--- a/py-polars/tests/unit/functions/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/functions/aggregation/test_horizontal.py
@@ -94,6 +94,20 @@ def test_nested_min_max() -> None:
     assert_frame_equal(result, expected)
 
 
+def test_empty_inputs_raise() -> None:
+    with pytest.raises(
+        pl.ComputeError,
+        match="cannot return empty fold because the number of output rows is unknown",
+    ):
+        pl.select(pl.any_horizontal())
+
+    with pytest.raises(
+        pl.ComputeError,
+        match="cannot return empty fold because the number of output rows is unknown",
+    ):
+        pl.select(pl.all_horizontal())
+
+
 def test_max_min_wildcard_columns(fruits_cars: pl.DataFrame) -> None:
     result = fruits_cars.select(pl.col(pl.datatypes.Int64)).select(
         pl.min_horizontal("*")


### PR DESCRIPTION
This fixes #12093.

Currently, `all/any/sum_horizontal` will raise: `expression: '{method_name}' didn't get any inputs`. But `min/max_horizontal` does not. I'm not sure whether we should raise an error here or not, in other words whether we allow `*_horizontal` without any inputs. But I think they should at least maintain consistent behavior in this case. 

This PR tend to raise in this case, but If all of them shouldn't raise an error, then I would modify `all/any/sum_horizontal` instead. 

Another thing to note is that in the Python API they all allow no parameters to be passed in(as only have `*` args):

```python
def *_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
```
So if we decide to raise, perhaps corresponding modifications should also be made here.