### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 /crates/  @ritchie46 @orlp
 /crates/polars-sql/  @ritchie46 @orlp @universalmind303
 /crates/polars-time/  @ritchie46 @orlp @MarcoGorelli
-/py-polars/  @ritchie46 @stinodego @alexander-beedie
-/docs/  @ritchie46 @c-peters @braaannigan
+/py-polars/  @ritchie46 @stinodego @alexander-beedie @MarcoGorelli
+/docs/  @ritchie46 @c-peters @stinodego


### PR DESCRIPTION
Adding myself as owner of the `docs` folder, and @MarcoGorelli for the Python side.

I also noticed that @braaannigan no longer has write access to the repo and thus cannot be a code owner. I think that's fine for now since Liam's work is mostly opening PRs with docs improvements, which you don't need write access for. Let me know though if I am missing something!