### PR TITLE
feat: Introduce ignore_nulls for str.concat

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/concat.rs
+++ b/crates/polars-ops/src/chunked_array/strings/concat.rs
@@ -3,9 +3,14 @@ use arrow::legacy::array::default_arrays::FromDataUtf8;
 use polars_core::prelude::*;
 
 // Vertically concatenate all strings in a Utf8Chunked.
-pub fn str_concat(ca: &Utf8Chunked, delimiter: &str) -> Utf8Chunked {
+pub fn str_concat(ca: &Utf8Chunked, delimiter: &str, ignore_nulls: bool) -> Utf8Chunked {
     if ca.is_empty() {
         return Utf8Chunked::new(ca.name(), &[""]);
+    }
+
+    // Propagate null value.
+    if !ignore_nulls && ca.null_count() != 0 {
+        return Utf8Chunked::full_null(ca.name(), 1);
     }
 
     if ca.len() == 1 {
@@ -13,27 +18,19 @@ pub fn str_concat(ca: &Utf8Chunked, delimiter: &str) -> Utf8Chunked {
     }
 
     // Calculate capacity.
-    let null_str_len = 4;
-    let capacity =
-        ca.get_values_size() + ca.null_count() * null_str_len + delimiter.len() * (ca.len() - 1);
+    let capacity = ca.get_values_size() + delimiter.len() * (ca.len() - 1);
 
     let mut buf = String::with_capacity(capacity);
     let mut first = true;
-    for arr in ca.downcast_iter() {
-        for val in arr.into_iter() {
+    ca.for_each(|val| {
+        if let Some(val) = val {
             if !first {
                 buf.push_str(delimiter);
             }
-
-            if let Some(s) = val {
-                buf.push_str(s);
-            } else {
-                buf.push_str("null");
-            }
-
+            buf.push_str(val);
             first = false;
         }
-    }
+    });
 
     let buf = buf.into_bytes();
     let offsets = vec![0, buf.len() as i64];
@@ -135,10 +132,10 @@ mod test {
     fn test_str_concat() {
         let ca = Int32Chunked::new("foo", &[Some(1), None, Some(3)]);
         let ca_str = ca.cast(&DataType::Utf8).unwrap();
-        let out = str_concat(&ca_str.utf8().unwrap(), "-");
+        let out = str_concat(&ca_str.utf8().unwrap(), "-", true);
 
         let out = out.get(0);
-        assert_eq!(out, Some("1-null-3"));
+        assert_eq!(out, Some("1-3"));
     }
 
     #[test]

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -1076,7 +1076,10 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "dtype-struct")]
             SplitN(n) => map_as_slice!(strings::splitn, n),
             #[cfg(feature = "concat_str")]
-            ConcatVertical(delimiter) => map!(strings::concat, &delimiter),
+            ConcatVertical {
+                delimiter,
+                ignore_nulls,
+            } => map!(strings::concat, &delimiter, ignore_nulls),
             #[cfg(feature = "concat_str")]
             ConcatHorizontal(delimiter) => map_as_slice!(strings::concat_hor, &delimiter),
             #[cfg(feature = "regex")]

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -23,7 +23,10 @@ pub enum StringFunction {
     #[cfg(feature = "concat_str")]
     ConcatHorizontal(String),
     #[cfg(feature = "concat_str")]
-    ConcatVertical(String),
+    ConcatVertical {
+        delimiter: String,
+        ignore_nulls: bool,
+    },
     #[cfg(feature = "regex")]
     Contains {
         literal: bool,
@@ -100,7 +103,7 @@ impl StringFunction {
         use StringFunction::*;
         match self {
             #[cfg(feature = "concat_str")]
-            ConcatVertical(_) | ConcatHorizontal(_) => mapper.with_dtype(DataType::Utf8),
+            ConcatVertical { .. } | ConcatHorizontal(_) => mapper.with_dtype(DataType::Utf8),
             #[cfg(feature = "regex")]
             Contains { .. } => mapper.with_dtype(DataType::Boolean),
             CountMatches(_) => mapper.with_dtype(DataType::UInt32),
@@ -162,7 +165,7 @@ impl Display for StringFunction {
             #[cfg(feature = "concat_str")]
             StringFunction::ConcatHorizontal(_) => "concat_horizontal",
             #[cfg(feature = "concat_str")]
-            StringFunction::ConcatVertical(_) => "concat_vertical",
+            StringFunction::ConcatVertical { .. } => "concat_vertical",
             StringFunction::Explode => "explode",
             StringFunction::ExtractAll => "extract_all",
             #[cfg(feature = "extract_groups")]
@@ -548,9 +551,9 @@ fn to_time(s: &Series, options: &StrptimeOptions) -> PolarsResult<Series> {
 }
 
 #[cfg(feature = "concat_str")]
-pub(super) fn concat(s: &Series, delimiter: &str) -> PolarsResult<Series> {
+pub(super) fn concat(s: &Series, delimiter: &str, ignore_nulls: bool) -> PolarsResult<Series> {
     let str_s = s.cast(&DataType::Utf8)?;
-    let concat = polars_ops::chunked_array::str_concat(str_s.utf8()?, delimiter);
+    let concat = polars_ops::chunked_array::str_concat(str_s.utf8()?, delimiter, ignore_nulls);
     Ok(concat.into_series())
 }
 

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -208,9 +208,15 @@ impl StringNameSpace {
     ///
     /// * `delimiter` - A string that will act as delimiter between values.
     #[cfg(feature = "concat_str")]
-    pub fn concat(self, delimiter: &str) -> Expr {
+    pub fn concat(self, delimiter: &str, ignore_nulls: bool) -> Expr {
         self.0
-            .apply_private(StringFunction::ConcatVertical(delimiter.to_owned()).into())
+            .apply_private(
+                StringFunction::ConcatVertical {
+                    delimiter: delimiter.to_owned(),
+                    ignore_nulls,
+                }
+                .into(),
+            )
             .with_function_options(|mut options| {
                 options.returns_scalar = true;
                 options.collect_groups = ApplyOptions::GroupWise;

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -453,7 +453,7 @@ class ExprStringNameSpace:
         """
         return wrap_expr(self._pyexpr.str_len_chars())
 
-    def concat(self, delimiter: str = "-") -> Expr:
+    def concat(self, delimiter: str = "-", *, ignore_nulls: bool = True) -> Expr:
         """
         Vertically concat the values in the Series to a single string value.
 
@@ -461,6 +461,11 @@ class ExprStringNameSpace:
         ----------
         delimiter
             The delimiter to insert between consecutive string values.
+        ignore_nulls
+            Ignore null values (default).
+
+            If set to ``False``, null values will be propagated.
+            if the column contains any null values, the output is ``None``.
 
         Returns
         -------
@@ -472,16 +477,26 @@ class ExprStringNameSpace:
         >>> df = pl.DataFrame({"foo": [1, None, 2]})
         >>> df.select(pl.col("foo").str.concat("-"))
         shape: (1, 1)
-        ┌──────────┐
-        │ foo      │
-        │ ---      │
-        │ str      │
-        ╞══════════╡
-        │ 1-null-2 │
-        └──────────┘
+        ┌─────┐
+        │ foo │
+        │ --- │
+        │ str │
+        ╞═════╡
+        │ 1-2 │
+        └─────┘
+        >>> df = pl.DataFrame({"foo": [1, None, 2]})
+        >>> df.select(pl.col("foo").str.concat("-", ignore_nulls=False))
+        shape: (1, 1)
+        ┌──────┐
+        │ foo  │
+        │ ---  │
+        │ str  │
+        ╞══════╡
+        │ null │
+        └──────┘
 
         """
-        return wrap_expr(self._pyexpr.str_concat(delimiter))
+        return wrap_expr(self._pyexpr.str_concat(delimiter, ignore_nulls))
 
     def to_uppercase(self) -> Expr:
         """

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -390,7 +390,7 @@ class StringNameSpace:
 
         """
 
-    def concat(self, delimiter: str = "-") -> Series:
+    def concat(self, delimiter: str = "-", *, ignore_nulls: bool = True) -> Series:
         """
         Vertically concat the values in the Series to a single string value.
 
@@ -398,6 +398,11 @@ class StringNameSpace:
         ----------
         delimiter
             The delimiter to insert between consecutive string values.
+        ignore_nulls
+            Ignore null values (default).
+
+            If set to ``False``, null values will be propagated.
+            if the column contains any null values, the output is ``None``.
 
         Returns
         -------
@@ -406,8 +411,18 @@ class StringNameSpace:
 
         Examples
         --------
-        >>> pl.Series([1, None, 2]).str.concat("-")[0]
-        '1-null-2'
+        >>> pl.Series([1, None, 2]).str.concat("-")
+        shape: (1,)
+        Series: '' [str]
+        [
+            "1-2"
+        ]
+        >>> pl.Series([1, None, 2]).str.concat("-", ignore_nulls=False)
+        shape: (1,)
+        Series: '' [str]
+        [
+            null
+        ]
 
         """
 

--- a/py-polars/src/expr/string.rs
+++ b/py-polars/src/expr/string.rs
@@ -7,8 +7,12 @@ use crate::PyExpr;
 
 #[pymethods]
 impl PyExpr {
-    fn str_concat(&self, delimiter: &str) -> Self {
-        self.inner.clone().str().concat(delimiter).into()
+    fn str_concat(&self, delimiter: &str, ignore_nulls: bool) -> Self {
+        self.inner
+            .clone()
+            .str()
+            .concat(delimiter, ignore_nulls)
+            .into()
     }
 
     #[pyo3(signature = (format, strict, exact, cache))]


### PR DESCRIPTION
This closes #6919.
Per comment(https://github.com/pola-rs/polars/issues/10814#issuecomment-1700983024) and our discuss in discord channel.

Please note that this change the behavior of `str.concat` contains `null` values as we no longer display null as string `"null"`. So this might be a breaking change, do I need to do some extra steps on the python side to mark this behavior change?