### PR TITLE
feat(python): Support decimals in assert utils

### DIFF
--- a/py-polars/polars/testing/asserts/frame.py
+++ b/py-polars/polars/testing/asserts/frame.py
@@ -127,10 +127,11 @@ def assert_frame_equal(
         left, right = _sort_dataframes(left, right)
 
     for c in left.columns:
+        s_left, s_right = left.get_column(c), right.get_column(c)
         try:
             _assert_series_values_equal(
-                left.get_column(c),
-                right.get_column(c),
+                s_left,
+                s_right,
                 check_exact=check_exact,
                 rtol=rtol,
                 atol=atol,
@@ -138,8 +139,13 @@ def assert_frame_equal(
                 categorical_as_str=categorical_as_str,
             )
         except AssertionError as exc:
-            msg = f"values for column {c!r} are different"
-            raise AssertionError(msg) from exc
+            raise_assertion_error(
+                objects,
+                f"value mismatch for column {c!r}",
+                s_left.to_list(),
+                s_right.to_list(),
+                cause=exc,
+            )
 
 
 def _assert_correct_input_type(

--- a/py-polars/polars/testing/asserts/series.py
+++ b/py-polars/polars/testing/asserts/series.py
@@ -170,15 +170,25 @@ def _assert_series_values_equal(
 
     # Check nested dtypes in separate function
     if _comparing_nested_numerics(left.dtype, right.dtype):
-        if _assert_series_nested(
-            left=left.filter(unequal),
-            right=right.filter(unequal),
-            check_exact=check_exact,
-            rtol=rtol,
-            atol=atol,
-            nans_compare_equal=nans_compare_equal,
-            categorical_as_str=categorical_as_str,
-        ):
+        try:
+            _assert_series_nested_values_equal(
+                left=left.filter(unequal),
+                right=right.filter(unequal),
+                check_exact=check_exact,
+                rtol=rtol,
+                atol=atol,
+                nans_compare_equal=nans_compare_equal,
+                categorical_as_str=categorical_as_str,
+            )
+        except AssertionError as exc:
+            raise_assertion_error(
+                "Series",
+                "nested value mismatch",
+                left=left.to_list(),
+                right=right.to_list(),
+                cause=exc,
+            )
+        else:  # All nested values match
             return
 
     # If no differences found during exact checking, we're done
@@ -192,10 +202,7 @@ def _assert_series_values_equal(
         or right.dtype not in NUMERIC_DTYPES
     ):
         raise_assertion_error(
-            "Series",
-            "exact value mismatch",
-            left=left.to_list(),
-            right=right.to_list(),
+            "Series", "exact value mismatch", left=left.to_list(), right=right.to_list()
         )
 
     _assert_series_null_values_match(left, right)
@@ -207,6 +214,47 @@ def _assert_series_values_equal(
         rtol=rtol,
         atol=atol,
     )
+
+
+def _assert_series_nested_values_equal(
+    left: Series,
+    right: Series,
+    *,
+    check_exact: bool,
+    rtol: float,
+    atol: float,
+    nans_compare_equal: bool,
+    categorical_as_str: bool,
+) -> None:
+    # compare nested lists element-wise
+    if _comparing_lists(left.dtype, right.dtype):
+        for s1, s2 in zip(left, right):
+            if s1 is None or s2 is None:
+                raise_assertion_error("Series", "nested value mismatch", s1, s2)
+
+            _assert_series_values_equal(
+                s1,
+                s2,
+                check_exact=check_exact,
+                rtol=rtol,
+                atol=atol,
+                nans_compare_equal=nans_compare_equal,
+                categorical_as_str=categorical_as_str,
+            )
+
+    # unnest structs as series and compare
+    else:
+        ls, rs = left.struct.unnest(), right.struct.unnest()
+        for s1, s2 in zip(ls, rs):
+            _assert_series_values_equal(
+                s1,
+                s2,
+                check_exact=check_exact,
+                rtol=rtol,
+                atol=atol,
+                nans_compare_equal=nans_compare_equal,
+                categorical_as_str=categorical_as_str,
+            )
 
 
 def _assert_series_null_values_match(left: Series, right: Series) -> None:
@@ -240,53 +288,6 @@ def _assert_series_nan_values_match(
             left.to_list(),
             right.to_list(),
         )
-
-
-def _assert_series_nested(
-    left: Series,
-    right: Series,
-    *,
-    check_exact: bool,
-    rtol: float,
-    atol: float,
-    nans_compare_equal: bool,
-    categorical_as_str: bool,
-) -> bool:
-    # compare nested lists element-wise
-    if _comparing_lists(left.dtype, right.dtype):
-        for s1, s2 in zip(left, right):
-            if (s1 is None and s2 is not None) or (s2 is None and s1 is not None):
-                raise_assertion_error("Series", "nested value mismatch", s1, s2)
-
-            _assert_series_values_equal(
-                s1,
-                s2,
-                check_exact=check_exact,
-                rtol=rtol,
-                atol=atol,
-                nans_compare_equal=nans_compare_equal,
-                categorical_as_str=categorical_as_str,
-            )
-        return True
-
-    # unnest structs as series and compare
-    elif _comparing_structs(left.dtype, right.dtype):
-        ls, rs = left.struct.unnest(), right.struct.unnest()
-        for s1, s2 in zip(ls, rs):
-            _assert_series_values_equal(
-                s1,
-                s2,
-                check_exact=check_exact,
-                rtol=rtol,
-                atol=atol,
-                nans_compare_equal=nans_compare_equal,
-                categorical_as_str=categorical_as_str,
-            )
-        return True
-    else:
-        # fall-back to outer codepath (if mismatched dtypes we would expect
-        # the equality check to fail - unless ALL series values are null)
-        return False
 
 
 def _comparing_floats(left: PolarsDataType, right: PolarsDataType) -> bool:

--- a/py-polars/polars/testing/asserts/series.py
+++ b/py-polars/polars/testing/asserts/series.py
@@ -8,6 +8,8 @@ from polars.datatypes import (
     UNSIGNED_INTEGER_DTYPES,
     Array,
     Categorical,
+    Decimal,
+    Float64,
     Int64,
     List,
     Struct,
@@ -150,6 +152,14 @@ def _assert_series_values_equal(
             left = left.cast(Utf8)
         if right.dtype == Categorical:
             right = right.cast(Utf8)
+
+    # Handle decimals
+    # TODO: Delete this branch when Decimal equality is implemented
+    # https://github.com/pola-rs/polars/issues/12118
+    if left.dtype == Decimal:
+        left = left.cast(Float64)
+    if right.dtype == Decimal:
+        right = right.cast(Float64)
 
     # Determine unequal elements
     try:

--- a/py-polars/tests/unit/testing/test_assert_frame_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_frame_equal.py
@@ -198,7 +198,7 @@ def test_compare_frame_equal_nans() -> None:
         schema=[("x", pl.Float32), ("y", pl.Float64)],
     )
     assert_frame_not_equal(df1, df2)
-    with pytest.raises(AssertionError, match="values for column 'y' are different"):
+    with pytest.raises(AssertionError, match="value mismatch for column 'y'"):
         assert_frame_equal(df1, df2, check_exact=True)
 
 
@@ -215,7 +215,7 @@ def test_compare_frame_equal_nested_nans() -> None:
         schema=[("x", pl.List(pl.Float32)), ("y", pl.List(pl.Float64))],
     )
     assert_frame_not_equal(df1, df2)
-    with pytest.raises(AssertionError, match="values for column 'y' are different"):
+    with pytest.raises(AssertionError, match="value mismatch for column 'y'"):
         assert_frame_equal(df1, df2, check_exact=True)
 
     # struct dtype
@@ -328,7 +328,7 @@ def test_assert_frame_equal_ignore_row_order() -> None:
     df1 = pl.DataFrame({"a": [1, 2], "b": [4, 3]})
     df2 = pl.DataFrame({"a": [2, 1], "b": [3, 4]})
     df3 = pl.DataFrame({"b": [3, 4], "a": [2, 1]})
-    with pytest.raises(AssertionError, match="values for column 'a' are different"):
+    with pytest.raises(AssertionError, match="value mismatch for column 'a'"):
         assert_frame_equal(df1, df2)
 
     assert_frame_equal(df1, df2, check_row_order=False)


### PR DESCRIPTION
Closes #11771

#### Changes

* Some refactoring of assertion of nested values.
* Improved some tracebacks.
* Support for Decimal types (through casting to float - until https://github.com/pola-rs/polars/issues/12118 is fixed)

Done with the improvements to this util for now. I'll wait until NaNs equality is fixed and the nan equality parameter is removed - then we can achieve some good improvements.