### PR TITLE
depr(python): Deprecate `DataFrame.as_dict` positional input

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1919,7 +1919,7 @@ class DataFrame:
     ) -> dict[str, Series] | dict[str, list[Any]]:
         ...
 
-    # TODO: Make `as_series` keyword-only
+    @deprecate_nonkeyword_arguments(version="0.19.13")
     def to_dict(
         self,
         as_series: bool = True,  # noqa: FBT001

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -911,7 +911,7 @@ def test_cast_frame() -> None:
     ]
 
     # cast all fields to a single type
-    assert df.cast(pl.Utf8).to_dict(False) == {
+    assert df.cast(pl.Utf8).to_dict(as_series=False) == {
         "a": ["1.0", "2.5", "3.0"],
         "b": ["4", "5", None],
         "c": ["true", "false", "true"],
@@ -973,7 +973,7 @@ def test_describe() -> None:
         }
     )
 
-    assert df.describe().to_dict(False) == {
+    assert df.describe().to_dict(as_series=False) == {
         "describe": [
             "count",
             "null_count",
@@ -1360,7 +1360,7 @@ def test_from_generator_or_iterable() -> None:
             "itms": d.items(),
         }
     )
-    assert df.to_dict(False) == {
+    assert df.to_dict(as_series=False) == {
         "keys": [0, 1, 2],
         "vals": ["x", "y", "z"],
         "itms": [(0, "x"), (1, "y"), (2, "z")],
@@ -1373,7 +1373,7 @@ def test_from_generator_or_iterable() -> None:
                 "rev_itms": reversed(d.items()),
             }
         )
-        assert df.to_dict(False) == {
+        assert df.to_dict(as_series=False) == {
             "rev_keys": [2, 1, 0],
             "rev_vals": ["z", "y", "x"],
             "rev_itms": [(2, "z"), (1, "y"), (0, "x")],
@@ -1928,7 +1928,7 @@ def test_rename_swap() -> None:
     # Select some columns
     ldf = ldf.select(["priority", "weekday", "round_number"])
 
-    assert ldf.collect().to_dict(False) == {
+    assert ldf.collect().to_dict(as_series=False) == {
         "priority": [1],
         "weekday": [2],
         "round_number": [3],
@@ -1944,7 +1944,9 @@ def test_rename_same_name() -> None:
     ).lazy()
     df = df.rename({"groups": "groups"})
     df = df.select(["groups"])
-    assert df.collect().to_dict(False) == {"groups": ["A", "A", "B", "C", "B"]}
+    assert df.collect().to_dict(as_series=False) == {
+        "groups": ["A", "A", "B", "C", "B"]
+    }
     df = pl.DataFrame(
         {
             "nrs": [1, 2, 3, 4, 5],
@@ -1955,7 +1957,9 @@ def test_rename_same_name() -> None:
     df = df.rename({"nrs": "nrs", "groups": "groups"})
     df = df.select(["groups"])
     df.collect()
-    assert df.collect().to_dict(False) == {"groups": ["A", "A", "B", "C", "B"]}
+    assert df.collect().to_dict(as_series=False) == {
+        "groups": ["A", "A", "B", "C", "B"]
+    }
 
 
 def test_fill_null() -> None:
@@ -1986,7 +1990,7 @@ def test_fill_null() -> None:
             pl.all().forward_fill().name.suffix("_forward"),
             pl.all().backward_fill().name.suffix("_backward"),
         ]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "c_forward": [
             ["Apple", "Orange"],
             ["Apple", "Orange"],
@@ -2148,11 +2152,11 @@ def test_df_series_division() -> None:
         }
     )
     s = pl.Series([2, 2, 2, 2, 2, 2])
-    assert (df / s).to_dict(False) == {
+    assert (df / s).to_dict(as_series=False) == {
         "a": [1.0, 1.0, 2.0, 2.0, 3.0, 3.0],
         "b": [1.0, 1.0, 5.0, 2.5, 3.0, 3.0],
     }
-    assert (df // s).to_dict(False) == {
+    assert (df // s).to_dict(as_series=False) == {
         "a": [1, 1, 2, 2, 3, 3],
         "b": [1, 1, 5, 2, 3, 3],
     }
@@ -2503,7 +2507,10 @@ def test_explode_empty() -> None:
         .group_by("x", maintain_order=True)
         .agg(pl.col("y").take([]))
     )
-    assert df.explode("y").to_dict(False) == {"x": ["a", "b"], "y": [None, None]}
+    assert df.explode("y").to_dict(as_series=False) == {
+        "x": ["a", "b"],
+        "y": [None, None],
+    }
 
     df = pl.DataFrame({"x": ["1", "2", "4"], "y": [["a", "b", "c"], ["d"], []]})
     assert_frame_equal(
@@ -2517,7 +2524,10 @@ def test_explode_empty() -> None:
             "numbers": [[]],
         }
     )
-    assert df.explode("numbers").to_dict(False) == {"letters": ["a"], "numbers": [None]}
+    assert df.explode("numbers").to_dict(as_series=False) == {
+        "letters": ["a"],
+        "numbers": [None],
+    }
 
 
 def test_asof_by_multiple_keys() -> None:
@@ -2560,10 +2570,12 @@ def test_partition_by() -> None:
         {"foo": ["C"], "N": [2], "bar": ["l"]},
     ]
     assert [
-        a.to_dict(False) for a in df.partition_by("foo", "bar", maintain_order=True)
+        a.to_dict(as_series=False)
+        for a in df.partition_by("foo", "bar", maintain_order=True)
     ] == expected
     assert [
-        a.to_dict(False) for a in df.partition_by(cs.string(), maintain_order=True)
+        a.to_dict(as_series=False)
+        for a in df.partition_by(cs.string(), maintain_order=True)
     ] == expected
 
     expected = [
@@ -2573,26 +2585,30 @@ def test_partition_by() -> None:
         {"N": [2]},
     ]
     assert [
-        a.to_dict(False)
+        a.to_dict(as_series=False)
         for a in df.partition_by(["foo", "bar"], maintain_order=True, include_key=False)
     ] == expected
     assert [
-        a.to_dict(False)
+        a.to_dict(as_series=False)
         for a in df.partition_by("foo", "bar", maintain_order=True, include_key=False)
     ] == expected
 
-    assert [a.to_dict(False) for a in df.partition_by("foo", maintain_order=True)] == [
+    assert [
+        a.to_dict(as_series=False) for a in df.partition_by("foo", maintain_order=True)
+    ] == [
         {"foo": ["A", "A"], "N": [1, 2], "bar": ["k", "l"]},
         {"foo": ["B", "B"], "N": [2, 4], "bar": ["m", "m"]},
         {"foo": ["C"], "N": [2], "bar": ["l"]},
     ]
 
     df = pl.DataFrame({"a": ["one", "two", "one", "two"], "b": [1, 2, 3, 4]})
-    assert df.partition_by(cs.all(), as_dict=True)["one", 1].to_dict(False) == {
+    assert df.partition_by(cs.all(), as_dict=True)["one", 1].to_dict(
+        as_series=False
+    ) == {
         "a": ["one"],
         "b": [1],
     }
-    assert df.partition_by(["a"], as_dict=True)["one"].to_dict(False) == {
+    assert df.partition_by(["a"], as_dict=True)["one"].to_dict(as_series=False) == {
         "a": ["one", "one"],
         "b": [1, 3],
     }
@@ -2624,9 +2640,9 @@ def test_list_of_list_of_struct() -> None:
 
 
 def test_concat_to_empty() -> None:
-    assert pl.concat([pl.DataFrame([]), pl.DataFrame({"a": [1]})]).to_dict(False) == {
-        "a": [1]
-    }
+    assert pl.concat([pl.DataFrame([]), pl.DataFrame({"a": [1]})]).to_dict(
+        as_series=False
+    ) == {"a": [1]}
 
 
 def test_fill_null_limits() -> None:
@@ -2641,7 +2657,7 @@ def test_fill_null_limits() -> None:
             pl.all().fill_null(strategy="forward", limit=2),
             pl.all().fill_null(strategy="backward", limit=2).name.suffix("_backward"),
         ]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "a": [1, 1, 1, None, 5, 6, 6, 6, None, 10],
         "b": ["a", "a", "a", None, "b", "c", "c", "c", None, "d"],
         "c": [True, True, True, None, False, True, True, True, None, False],
@@ -2709,18 +2725,22 @@ def test_selection_regex_and_multicol() -> None:
     )
 
     # Multi * Single
-    assert test_df.select(pl.col(["a", "b", "c"]) * pl.col("foo")).to_dict(False) == {
+    assert test_df.select(pl.col(["a", "b", "c"]) * pl.col("foo")).to_dict(
+        as_series=False
+    ) == {
         "a": [13, 28, 45, 64],
         "b": [65, 84, 105, 128],
         "c": [117, 140, 165, 192],
     }
-    assert test_df.select(pl.all().exclude("foo") * pl.col("foo")).to_dict(False) == {
+    assert test_df.select(pl.all().exclude("foo") * pl.col("foo")).to_dict(
+        as_series=False
+    ) == {
         "a": [13, 28, 45, 64],
         "b": [65, 84, 105, 128],
         "c": [117, 140, 165, 192],
     }
 
-    assert test_df.select(pl.col("^\\w$") * pl.col("foo")).to_dict(False) == {
+    assert test_df.select(pl.col("^\\w$") * pl.col("foo")).to_dict(as_series=False) == {
         "a": [13, 28, 45, 64],
         "b": [65, 84, 105, 128],
         "c": [117, 140, 165, 192],
@@ -2730,12 +2750,16 @@ def test_selection_regex_and_multicol() -> None:
     assert test_df.select(pl.col(["a", "b", "c"]) * pl.col(["a", "b", "c"])).to_dict(
         False
     ) == {"a": [1, 4, 9, 16], "b": [25, 36, 49, 64], "c": [81, 100, 121, 144]}
-    assert test_df.select(pl.exclude("foo") * pl.exclude("foo")).to_dict(False) == {
+    assert test_df.select(pl.exclude("foo") * pl.exclude("foo")).to_dict(
+        as_series=False
+    ) == {
         "a": [1, 4, 9, 16],
         "b": [25, 36, 49, 64],
         "c": [81, 100, 121, 144],
     }
-    assert test_df.select(pl.col("^\\w$") * pl.col("^\\w$")).to_dict(False) == {
+    assert test_df.select(pl.col("^\\w$") * pl.col("^\\w$")).to_dict(
+        as_series=False
+    ) == {
         "a": [1, 4, 9, 16],
         "b": [25, 36, 49, 64],
         "c": [81, 100, 121, 144],
@@ -2852,7 +2876,7 @@ def test_indexing_set() -> None:
     df[0, "nr"] = 100
     df[0, "str"] = "foo"
 
-    assert df.to_dict(False) == {
+    assert df.to_dict(as_series=False) == {
         "bool": [False, True],
         "str": ["foo", "N/A"],
         "nr": [100, 2],
@@ -3297,7 +3321,7 @@ def test_deadlocks_3409() -> None:
                 pl.element().map_elements(lambda x: x, return_dtype=pl.Int64)
             )
         )
-        .to_dict(False)
+        .to_dict(as_series=False)
     ) == {"col1": [[1, 2, 3]]}
 
     assert (
@@ -3305,7 +3329,7 @@ def test_deadlocks_3409() -> None:
         .with_columns(
             [pl.col("col1").cumulative_eval(pl.element().map_batches(lambda x: 0))]
         )
-        .to_dict(False)
+        .to_dict(as_series=False)
     ) == {"col1": [0, 0, 0]}
 
 
@@ -3434,7 +3458,7 @@ def test_unstack() -> None:
             "col3": pl.int_range(-9, 0, eager=True),
         }
     )
-    assert df.unstack(step=3, how="vertical").to_dict(False) == {
+    assert df.unstack(step=3, how="vertical").to_dict(as_series=False) == {
         "col1_0": ["A", "B", "C"],
         "col1_1": ["D", "E", "F"],
         "col1_2": ["G", "H", "I"],
@@ -3446,7 +3470,7 @@ def test_unstack() -> None:
         "col3_2": [-3, -2, -1],
     }
 
-    assert df.unstack(step=3, how="horizontal").to_dict(False) == {
+    assert df.unstack(step=3, how="horizontal").to_dict(as_series=False) == {
         "col1_0": ["A", "D", "G"],
         "col1_1": ["B", "E", "H"],
         "col1_2": ["C", "F", "I"],
@@ -3463,7 +3487,7 @@ def test_unstack() -> None:
             step=3,
             how="horizontal",
             columns=column_subset,  # type: ignore[arg-type]
-        ).to_dict(False) == {
+        ).to_dict(as_series=False) == {
             "col2_0": [0, 3, 6],
             "col2_1": [1, 4, 7],
             "col2_2": [2, 5, 8],

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -607,9 +607,11 @@ def test_to_dummies() -> None:
         assert_frame_equal(result, expected)
 
     # test sorted fast path
-    assert pl.DataFrame({"x": pl.arange(0, 3, eager=True)}).to_dummies("x").to_dict(
-        False
-    ) == {"x_0": [1, 0, 0], "x_1": [0, 1, 0], "x_2": [0, 0, 1]}
+    result = pl.DataFrame({"x": pl.arange(0, 3, eager=True)}).to_dummies("x")
+    expected = pl.DataFrame(
+        {"x_0": [1, 0, 0], "x_1": [0, 1, 0], "x_2": [0, 0, 1]}
+    ).with_columns(pl.all().cast(pl.UInt8))
+    assert_frame_equal(result, expected)
 
 
 def test_to_dummies_drop_first() -> None:
@@ -2747,9 +2749,10 @@ def test_selection_regex_and_multicol() -> None:
     }
 
     # Multi * Multi
-    assert test_df.select(pl.col(["a", "b", "c"]) * pl.col(["a", "b", "c"])).to_dict(
-        False
-    ) == {"a": [1, 4, 9, 16], "b": [25, 36, 49, 64], "c": [81, 100, 121, 144]}
+    result = test_df.select(pl.col(["a", "b", "c"]) * pl.col(["a", "b", "c"]))
+    expected = {"a": [1, 4, 9, 16], "b": [25, 36, 49, 64], "c": [81, 100, 121, 144]}
+    assert result.to_dict(as_series=False) == expected
+
     assert test_df.select(pl.exclude("foo") * pl.exclude("foo")).to_dict(
         as_series=False
     ) == {

--- a/py-polars/tests/unit/dataframe/test_from_dict.py
+++ b/py-polars/tests/unit/dataframe/test_from_dict.py
@@ -41,7 +41,7 @@ def test_from_dict_with_scalars() -> None:
     df1 = pl.DataFrame(
         {"key": ["aa", "bb", "cc"], "misc": "xyz", "other": None, "value": 0}
     )
-    assert df1.to_dict(False) == {
+    assert df1.to_dict(as_series=False) == {
         "key": ["aa", "bb", "cc"],
         "misc": ["xyz", "xyz", "xyz"],
         "other": [None, None, None],
@@ -50,7 +50,7 @@ def test_from_dict_with_scalars() -> None:
 
     # edge-case: all scalars
     df2 = pl.DataFrame({"key": "aa", "misc": "xyz", "other": None, "value": 0})
-    assert df2.to_dict(False) == {
+    assert df2.to_dict(as_series=False) == {
         "key": ["aa"],
         "misc": ["xyz"],
         "other": [None],
@@ -59,7 +59,7 @@ def test_from_dict_with_scalars() -> None:
 
     # edge-case: single unsized generator
     df3 = pl.DataFrame({"vals": map(float, [1, 2, 3])})
-    assert df3.to_dict(False) == {"vals": [1.0, 2.0, 3.0]}
+    assert df3.to_dict(as_series=False) == {"vals": [1.0, 2.0, 3.0]}
 
     # ensure we don't accidentally consume or expand map/range/generator
     # cols, and can properly apply schema dtype/ordering directives
@@ -78,7 +78,7 @@ def test_from_dict_with_scalars() -> None:
         },
     )
     assert df4.columns == ["value", "other", "misc", "key"]
-    assert df4.to_dict(False) == {
+    assert df4.to_dict(as_series=False) == {
         "value": ["x", "y", "z"],
         "other": [7.0, 8.0, 9.0],
         "misc": [4, 5, 6],

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -79,7 +79,10 @@ def test_array_in_group_by() -> None:
             "g": pl.Int64,
             "a": pl.List(pl.Array(inner=pl.Int64, width=2)),
         }
-        assert out.to_dict(False) == {"g": [1, 2], "a": [[[1, 2], [2, 2]], [[1, 4]]]}
+        assert out.to_dict(as_series=False) == {
+            "g": [1, 2],
+            "a": [[[1, 2], [2, 2]], [[1, 4]]],
+        }
 
 
 def test_array_invalid_operation() -> None:
@@ -101,7 +104,7 @@ def test_array_concat() -> None:
     b_df = pl.DataFrame({"a": [[1, 1], [0, 0]]}).select(
         pl.col("a").cast(pl.Array(inner=pl.Int32, width=2))
     )
-    assert pl.concat([a_df, b_df]).to_dict(False) == {
+    assert pl.concat([a_df, b_df]).to_dict(as_series=False) == {
         "a": [[0, 1], [1, 0], [1, 1], [0, 0]]
     }
 

--- a/py-polars/tests/unit/datatypes/test_binary.py
+++ b/py-polars/tests/unit/datatypes/test_binary.py
@@ -9,7 +9,7 @@ def test_binary_filter() -> None:
             "content": [b"aa", b"aaabbb", b"aa", b"\xc6i\xea"],
         }
     )
-    assert df.filter(pl.col("content") == b"\xc6i\xea").to_dict(False) == {
+    assert df.filter(pl.col("content") == b"\xc6i\xea").to_dict(as_series=False) == {
         "name": ["d"],
         "content": [b"\xc6i\xea"],
     }

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -66,7 +66,7 @@ def test_read_csv_categorical() -> None:
 def test_cat_to_dummies() -> None:
     df = pl.DataFrame({"foo": [1, 2, 3, 4], "bar": ["a", "b", "a", "c"]})
     df = df.with_columns(pl.col("bar").cast(pl.Categorical))
-    assert df.to_dummies().to_dict(False) == {
+    assert df.to_dummies().to_dict(as_series=False) == {
         "foo_1": [1, 0, 0, 0],
         "foo_2": [0, 1, 0, 0],
         "foo_3": [0, 0, 1, 0],
@@ -94,7 +94,7 @@ def test_categorical_is_in_list() -> None:
     ).with_columns(pl.col("b").cast(pl.Categorical))
 
     cat_list = ("a", "b", "c")
-    assert df.filter(pl.col("b").is_in(cat_list)).to_dict(False) == {
+    assert df.filter(pl.col("b").is_in(cat_list)).to_dict(as_series=False) == {
         "a": [1, 2, 3],
         "b": ["a", "b", "c"],
     }
@@ -153,7 +153,7 @@ def test_merge_lit_under_global_cache_4491() -> None:
         pl.when(pl.col("value") > 5)
         .then(pl.col("label"))
         .otherwise(pl.lit(None, pl.Categorical))
-    ).to_dict(False) == {"label": [None, "bar"], "value": [3, 9]}
+    ).to_dict(as_series=False) == {"label": [None, "bar"], "value": [3, 9]}
 
 
 def test_nested_cache_composition() -> None:
@@ -194,7 +194,7 @@ def test_categorical_max_null_5437() -> None:
         pl.DataFrame({"strings": ["c", "b", "a", "c"], "values": [0, 1, 2, 3]})
         .with_columns(pl.col("strings").cast(pl.Categorical).alias("cats"))
         .select(pl.all().max())
-    ).to_dict(False) == {"strings": ["c"], "values": [3], "cats": [None]}
+    ).to_dict(as_series=False) == {"strings": ["c"], "values": [3], "cats": [None]}
 
 
 def test_categorical_in_struct_nulls() -> None:
@@ -231,7 +231,7 @@ def test_stringcache() -> None:
         df = pl.DataFrame({"cats": pl.arange(0, N, eager=True)}).select(
             [pl.col("cats").cast(pl.Utf8).cast(pl.Categorical)]
         )
-        assert df.filter(pl.col("cats").is_in(["1", "2"])).to_dict(False) == {
+        assert df.filter(pl.col("cats").is_in(["1", "2"])).to_dict(as_series=False) == {
             "cats": ["1", "2"]
         }
 
@@ -301,7 +301,7 @@ def test_nested_categorical_aggregation_7848() -> None:
         maintain_order=True, by=["group"]
     ).all().with_columns(pl.col("letter").list.len().alias("c_group")).group_by(
         by=["c_group"], maintain_order=True
-    ).agg(pl.col("letter")).to_dict(False) == {
+    ).agg(pl.col("letter")).to_dict(as_series=False) == {
         "c_group": [2, 3],
         "letter": [[["a", "b"], ["f", "g"]], [["c", "d", "e"]]],
     }
@@ -349,7 +349,7 @@ def test_categorical_fill_null_stringcache() -> None:
     )
     a = df.select(pl.col("cat").fill_null("hi")).collect()
 
-    assert a.to_dict(False) == {"cat": ["a", "b", "hi"]}
+    assert a.to_dict(as_series=False) == {"cat": ["a", "b", "hi"]}
     assert a.dtypes == [pl.Categorical]
 
 
@@ -389,7 +389,7 @@ def test_list_builder_different_categorical_rev_maps() -> None:
         s1 = pl.Series(["a", "b"], dtype=pl.Categorical)
         s2 = pl.Series(["c", "d"], dtype=pl.Categorical)
 
-    assert pl.DataFrame({"c": [s1, s2]}).to_dict(False) == {
+    assert pl.DataFrame({"c": [s1, s2]}).to_dict(as_series=False) == {
         "c": [["a", "b"], ["c", "d"]]
     }
 
@@ -402,7 +402,7 @@ def test_categorical_collect_11408() -> None:
 
     assert df.group_by("groups").agg(
         pl.col("cats").filter(pl.col("amount") == pl.col("amount").min()).first()
-    ).sort("groups").to_dict(False) == {
+    ).sort("groups").to_dict(as_series=False) == {
         "groups": ["a", "b", "c"],
         "cats": ["a", "b", "c"],
     }

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -331,14 +331,10 @@ def test_struct_categorical_nesting() -> None:
 
 def test_categorical_fill_null_existing_category() -> None:
     # ensure physical types align
-    assert pl.DataFrame(
-        {"col": ["a", None, "a"]}, schema={"col": pl.Categorical}
-    ).fill_null("a").with_columns(pl.col("col").to_physical().alias("code")).to_dict(
-        False
-    ) == {
-        "col": ["a", "a", "a"],
-        "code": [0, 0, 0],
-    }
+    df = pl.DataFrame({"col": ["a", None, "a"]}, schema={"col": pl.Categorical})
+    result = df.fill_null("a").with_columns(pl.col("col").to_physical().alias("code"))
+    expected = {"col": ["a", "a", "a"], "code": [0, 0, 0]}
+    assert result.to_dict(as_series=False) == expected
 
 
 @StringCache()

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -196,7 +196,7 @@ def test_decimal_arithmetic() -> None:
         pl.Decimal(precision=None, scale=2),
     ]
 
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "out1": [D("2.01"), D("102.91"), D("3921.39")],
         "out2": [D("20.20"), D("20.29"), D("139.22")],
         "out3": [D("0.00"), D("0.99"), D("2.55")],
@@ -216,7 +216,7 @@ def test_decimal_aggregations() -> None:
         sum=pl.sum("a"),
         min=pl.min("a"),
         max=pl.max("a"),
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "g": [1, 2],
         "sum": [D("10.20"), D("9100.13")],
         "min": [D("0.10"), D("100.01")],
@@ -227,7 +227,7 @@ def test_decimal_aggregations() -> None:
         sum=pl.sum("a"),
         min=pl.min("a"),
         max=pl.max("a"),
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "sum": [D("9110.33")],
         "min": [D("0.10")],
         "max": [D("9000.12")],

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -122,9 +122,10 @@ def test_decimal_cast() -> None:
             "decimals": [D("2"), D("2"), D("-1.5")],
         }
     )
-    assert df.with_columns(pl.col("decimals").cast(pl.Float32).alias("b2")).to_dict(
-        False
-    ) == {"decimals": [D("2"), D("2"), D("-1.5")], "b2": [2.0, 2.0, -1.5]}
+
+    result = df.with_columns(pl.col("decimals").cast(pl.Float32).alias("b2"))
+    expected = {"decimals": [D("2"), D("2"), D("-1.5")], "b2": [2.0, 2.0, -1.5]}
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_decimal_scale_precision_roundtrip(monkeypatch: Any) -> None:

--- a/py-polars/tests/unit/datatypes/test_duration.py
+++ b/py-polars/tests/unit/datatypes/test_duration.py
@@ -6,7 +6,7 @@ import polars as pl
 def test_duration_cumsum() -> None:
     df = pl.DataFrame({"A": [timedelta(days=1), timedelta(days=2)]})
 
-    assert df.select(pl.col("A").cumsum()).to_dict(False) == {
+    assert df.select(pl.col("A").cumsum()).to_dict(as_series=False) == {
         "A": [timedelta(days=1), timedelta(days=3)]
     }
     assert df.schema["A"].is_(pl.Duration(time_unit="us"))

--- a/py-polars/tests/unit/datatypes/test_float.py
+++ b/py-polars/tests/unit/datatypes/test_float.py
@@ -25,10 +25,10 @@ def test_nan_aggregations() -> None:
     ]
 
     assert (
-        str(df.select(aggs).to_dict(False))
+        str(df.select(aggs).to_dict(as_series=False))
         == "{'max': [3.0], 'min': [1.0], 'nan_max': [nan], 'nan_min': [nan]}"
     )
     assert (
-        str(df.group_by("b").agg(aggs).to_dict(False))
+        str(df.group_by("b").agg(aggs).to_dict(as_series=False))
         == "{'b': [1], 'max': [3.0], 'min': [1.0], 'nan_max': [nan], 'nan_min': [nan]}"
     )

--- a/py-polars/tests/unit/datatypes/test_integer.py
+++ b/py-polars/tests/unit/datatypes/test_integer.py
@@ -7,7 +7,7 @@ def test_integer_float_functions() -> None:
         infinite=pl.all().is_infinite(),
         nan=pl.all().is_nan(),
         not_na=pl.all().is_not_nan(),
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "finite": [True, True],
         "infinite": [False, False],
         "nan": [False, False],

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -124,7 +124,7 @@ def test_list_empty_group_by_result_3521() -> None:
         left.join(right, on="join_column", how="left")
         .group_by("group_by_column")
         .agg(pl.col("n_unique_column").drop_nulls())
-    ).to_dict(False) == {"group_by_column": [1], "n_unique_column": [[]]}
+    ).to_dict(as_series=False) == {"group_by_column": [1], "n_unique_column": [[]]}
 
 
 def test_list_fill_null() -> None:
@@ -147,7 +147,7 @@ def test_list_fill_list() -> None:
             .otherwise(pl.col("a"))
             .alias("filled")
         ]
-    ).to_dict(False) == {"filled": [[1, 2, 3], [5]]}
+    ).to_dict(as_series=False) == {"filled": [[1, 2, 3], [5]]}
 
 
 def test_empty_list_construction() -> None:
@@ -174,7 +174,7 @@ def test_list_diagonal_concat() -> None:
 
     df2 = pl.DataFrame({"b": [[1]]})
 
-    assert pl.concat([df1, df2], how="diagonal").to_dict(False) == {
+    assert pl.concat([df1, df2], how="diagonal").to_dict(as_series=False) == {
         "a": [1, 2, None],
         "b": [None, None, [1]],
     }
@@ -196,7 +196,9 @@ def test_group_by_list_column() -> None:
         .agg(pl.col("a").alias("a_list"))
     )
 
-    assert df.group_by("a_list", maintain_order=True).first().to_dict(False) == {
+    assert df.group_by("a_list", maintain_order=True).first().to_dict(
+        as_series=False
+    ) == {
         "a_list": [["a", "a"], ["b"]],
         "a": ["a", "b"],
     }
@@ -214,7 +216,7 @@ def test_group_by_multiple_keys_contains_list_column() -> None:
         .group_by(["a", "b"], maintain_order=True)
         .agg(pl.all())
     )
-    assert df.to_dict(False) == {
+    assert df.to_dict(as_series=False) == {
         "a": ["x", "y", "y"],
         "b": [[1, 2], [3, 4, 5], [6]],
         "c": [[3, 2], [1], [0]],
@@ -260,7 +262,7 @@ def test_fast_explode_on_list_struct_6208() -> None:
     )
 
     assert not df["parents"].flags["FAST_EXPLODE"]
-    assert df.explode("parents").to_dict(False) == {
+    assert df.explode("parents").to_dict(as_series=False) == {
         "label": ["l", "l"],
         "tag": ["t", "t"],
         "ref": [1, 1],
@@ -276,7 +278,7 @@ def test_flat_aggregation_to_list_conversion_6918() -> None:
 
     assert df.group_by("a", maintain_order=True).agg(
         pl.concat_list([pl.col("b").list.get(i).mean().implode() for i in range(2)])
-    ).to_dict(False) == {"a": [1, 2], "b": [[[0.0, 1.0]], [[3.0, 4.0]]]}
+    ).to_dict(as_series=False) == {"a": [1, 2], "b": [[[0.0, 1.0]], [[3.0, 4.0]]]}
 
 
 def test_list_count_matches_deprecated() -> None:
@@ -292,10 +294,10 @@ def test_list_count_matches_deprecated() -> None:
 def test_list_count_matches() -> None:
     assert pl.DataFrame({"listcol": [[], [1], [1, 2, 3, 2], [1, 2, 1], [4, 4]]}).select(
         pl.col("listcol").list.count_matches(2).alias("number_of_twos")
-    ).to_dict(False) == {"number_of_twos": [0, 0, 2, 1, 0]}
+    ).to_dict(as_series=False) == {"number_of_twos": [0, 0, 2, 1, 0]}
     assert pl.DataFrame({"listcol": [[], [1], [1, 2, 3, 2], [1, 2, 1], [4, 4]]}).select(
         pl.col("listcol").list.count_matches(2).alias("number_of_twos")
-    ).to_dict(False) == {"number_of_twos": [0, 0, 2, 1, 0]}
+    ).to_dict(as_series=False) == {"number_of_twos": [0, 0, 2, 1, 0]}
 
 
 def test_list_sum_and_dtypes() -> None:
@@ -320,22 +322,26 @@ def test_list_sum_and_dtypes() -> None:
         assert summed.item() == 32
         assert df.select(pl.col("a").list.sum()).dtypes == [dt_out]
 
-    assert df.select(pl.col("a").list.sum()).to_dict(False) == {"a": [1, 6, 10, 15]}
+    assert df.select(pl.col("a").list.sum()).to_dict(as_series=False) == {
+        "a": [1, 6, 10, 15]
+    }
 
     # include nulls
     assert pl.DataFrame(
         {"a": [[1], [1, 2, 3], [1, 2, 3, 4], [1, 2, 3, 4, 5], None]}
-    ).select(pl.col("a").list.sum()).to_dict(False) == {"a": [1, 6, 10, 15, None]}
+    ).select(pl.col("a").list.sum()).to_dict(as_series=False) == {
+        "a": [1, 6, 10, 15, None]
+    }
 
 
 def test_list_mean() -> None:
     assert pl.DataFrame({"a": [[1], [1, 2, 3], [1, 2, 3, 4], [1, 2, 3, 4, 5]]}).select(
         pl.col("a").list.mean()
-    ).to_dict(False) == {"a": [1.0, 2.0, 2.5, 3.0]}
+    ).to_dict(as_series=False) == {"a": [1.0, 2.0, 2.5, 3.0]}
 
     assert pl.DataFrame({"a": [[1], [1, 2, 3], [1, 2, 3, 4], None]}).select(
         pl.col("a").list.mean()
-    ).to_dict(False) == {"a": [1.0, 2.0, 2.5, None]}
+    ).to_dict(as_series=False) == {"a": [1.0, 2.0, 2.5, None]}
 
 
 def test_list_all() -> None:
@@ -351,7 +357,7 @@ def test_list_all() -> None:
                 [],
             ]
         }
-    ).select(pl.col("a").list.all()).to_dict(False) == {
+    ).select(pl.col("a").list.all()).to_dict(as_series=False) == {
         "a": [True, False, True, False, False, True, True]
     }
 
@@ -369,7 +375,7 @@ def test_list_any() -> None:
                 [],
             ]
         }
-    ).select(pl.col("a").list.any()).to_dict(False) == {
+    ).select(pl.col("a").list.any()).to_dict(as_series=False) == {
         "a": [True, False, True, True, False, False, False]
     }
 
@@ -392,10 +398,12 @@ def test_list_min_max() -> None:
     df = pl.DataFrame(
         {"a": [[1], [1, 5, -1, 3], [1, 2, 3, 4], [1, 2, 3, 4, 5], None]},
     )
-    assert df.select(pl.col("a").list.min()).to_dict(False) == {
+    assert df.select(pl.col("a").list.min()).to_dict(as_series=False) == {
         "a": [1, -1, 1, 1, None]
     }
-    assert df.select(pl.col("a").list.max()).to_dict(False) == {"a": [1, 5, 4, 5, None]}
+    assert df.select(pl.col("a").list.max()).to_dict(as_series=False) == {
+        "a": [1, 5, 4, 5, None]
+    }
 
 
 def test_fill_null_empty_list() -> None:
@@ -405,7 +413,7 @@ def test_fill_null_empty_list() -> None:
 def test_nested_logical() -> None:
     assert pl.select(
         pl.lit(pl.Series(["a", "b"], dtype=pl.Categorical)).implode().implode()
-    ).to_dict(False) == {"": [[["a", "b"]]]}
+    ).to_dict(as_series=False) == {"": [[["a", "b"]]]}
 
 
 def test_null_list_construction_and_materialization() -> None:
@@ -445,7 +453,7 @@ def test_logical_parallel_list_collect() -> None:
         .unnest("Values")
     )
     assert out.dtypes == [pl.Utf8, pl.Categorical, pl.UInt32]
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "Group": ["GroupA", "GroupA"],
         "Values": ["Value1", "Value2"],
         "counts": [2, 1],
@@ -519,7 +527,9 @@ def test_list_null_pickle() -> None:
 
 def test_struct_with_nulls_as_list() -> None:
     df = pl.DataFrame([[{"a": 1, "b": 2}], [{"c": 3, "d": None}]])
-    assert df.select(pl.concat_list(pl.all()).alias("as_list")).to_dict(False) == {
+    assert df.select(pl.concat_list(pl.all()).alias("as_list")).to_dict(
+        as_series=False
+    ) == {
         "as_list": [
             [
                 {"a": 1, "b": 2, "c": None, "d": None},
@@ -539,7 +549,7 @@ def test_list_amortized_iter_clear_settings_10126() -> None:
         .sort("a")
     )
 
-    assert out.to_dict(False) == {"a": [1, 2], "b": [[1, 2, 3], [4]]}
+    assert out.to_dict(as_series=False) == {"a": [1, 2], "b": [[1, 2, 3], [4]]}
 
 
 def test_list_inner_cast_physical_11513() -> None:
@@ -560,7 +570,9 @@ def test_list_inner_cast_physical_11513() -> None:
             )
         },
     )
-    assert df.select(pl.col("struct").take(0)).to_dict(False) == {"struct": [[]]}
+    assert df.select(pl.col("struct").take(0)).to_dict(as_series=False) == {
+        "struct": [[]]
+    }
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -152,9 +152,10 @@ def test_list_fill_list() -> None:
 
 def test_empty_list_construction() -> None:
     assert pl.Series([[]]).to_list() == [[]]
-    assert pl.DataFrame([{"array": [], "not_array": 1234}], orient="row").to_dict(
-        False
-    ) == {"array": [[]], "not_array": [1234]}
+
+    df = pl.DataFrame([{"array": [], "not_array": 1234}], orient="row")
+    expected = {"array": [[]], "not_array": [1234]}
+    assert df.to_dict(as_series=False) == expected
 
     df = pl.DataFrame(schema=[("col", pl.List)])
     assert df.schema == {"col": pl.List}
@@ -282,13 +283,14 @@ def test_flat_aggregation_to_list_conversion_6918() -> None:
 
 
 def test_list_count_matches_deprecated() -> None:
+    df = pl.DataFrame({"listcol": [[], [1], [1, 2, 3, 2], [1, 2, 1], [4, 4]]})
     with pytest.deprecated_call():
-        # Your test code here
-        assert pl.DataFrame(
-            {"listcol": [[], [1], [1, 2, 3, 2], [1, 2, 1], [4, 4]]}
-        ).select(pl.col("listcol").list.count_match(2).alias("number_of_twos")).to_dict(
-            False
-        ) == {"number_of_twos": [0, 0, 2, 1, 0]}
+        result = df.select(
+            pl.col("listcol").list.count_match(2).alias("number_of_twos")
+        )
+
+    expected = {"number_of_twos": [0, 0, 2, 1, 0]}
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_list_count_matches() -> None:

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -29,7 +29,7 @@ def test_object_in_struct() -> None:
     np_b = np.array([4, 5, 6])
     df = pl.DataFrame({"A": [1, 2], "B": pl.Series([np_a, np_b], dtype=pl.Object)})
 
-    out = df.select([pl.struct(["B"]).alias("foo")]).to_dict(False)
+    out = df.select([pl.struct(["B"]).alias("foo")]).to_dict(as_series=False)
     arr = out["foo"][0]["B"]
     assert isinstance(arr, np.ndarray)
     assert (arr == np_a).sum() == 3
@@ -79,7 +79,7 @@ def test_object_concat() -> None:
     catted = pl.concat([df1, df2])
     assert catted.shape == (6, 1)
     assert catted.dtypes == [pl.Object]
-    assert catted.to_dict(False) == {"a": [1, 2, 3, 1, 4, 3]}
+    assert catted.to_dict(as_series=False) == {"a": [1, 2, 3, 1, 4, 3]}
 
 
 def test_object_row_construction() -> None:

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -298,7 +298,9 @@ def test_list_to_struct() -> None:
 
 
 def test_sort_df_with_list_struct() -> None:
-    assert pl.DataFrame([{"a": 1, "b": [{"c": 1}]}]).sort("a").to_dict(False) == {
+    assert pl.DataFrame([{"a": 1, "b": [{"c": 1}]}]).sort("a").to_dict(
+        as_series=False
+    ) == {
         "a": [1],
         "b": [[{"c": 1}]],
     }
@@ -317,7 +319,7 @@ def test_struct_list_head_tail() -> None:
             pl.col("list_of_struct").list.head(1).alias("head"),
             pl.col("list_of_struct").list.tail(1).alias("tail"),
         ]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "list_of_struct": [
             [{"a": 1, "b": 4}, {"a": 3, "b": 6}],
             [{"a": 10, "b": 40}, {"a": 20, "b": 50}, {"a": 30, "b": 60}],
@@ -341,7 +343,7 @@ def test_struct_agg_all() -> None:
         }
     )
 
-    assert df.group_by("group", maintain_order=True).all().to_dict(False) == {
+    assert df.group_by("group", maintain_order=True).all().to_dict(as_series=False) == {
         "group": ["a", "b"],
         "col1": [
             [{"x": 1, "y": 100}, {"x": 2, "y": 200}],
@@ -353,13 +355,13 @@ def test_struct_agg_all() -> None:
 def test_struct_empty_list_creation() -> None:
     payload = [[], [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], []]
 
-    assert pl.DataFrame({"list_struct": payload}).to_dict(False) == {
+    assert pl.DataFrame({"list_struct": payload}).to_dict(as_series=False) == {
         "list_struct": [[], [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], []]
     }
 
     # pop first
     payload = payload[1:]
-    assert pl.DataFrame({"list_struct": payload}).to_dict(False) == {
+    assert pl.DataFrame({"list_struct": payload}).to_dict(as_series=False) == {
         "list_struct": [[{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}], []]
     }
 
@@ -374,13 +376,13 @@ def test_struct_arr_methods() -> None:
             ],
         }
     )
-    assert df.select([pl.col("list_struct").list.first()]).to_dict(False) == {
+    assert df.select([pl.col("list_struct").list.first()]).to_dict(as_series=False) == {
         "list_struct": [{"a": 1, "b": 2}, {"a": 1, "b": 2}, {"a": 1, "b": 2}]
     }
-    assert df.select([pl.col("list_struct").list.last()]).to_dict(False) == {
+    assert df.select([pl.col("list_struct").list.last()]).to_dict(as_series=False) == {
         "list_struct": [{"a": 5, "b": 6}, {"a": 3, "b": 4}, {"a": 1, "b": 2}]
     }
-    assert df.select([pl.col("list_struct").list.get(0)]).to_dict(False) == {
+    assert df.select([pl.col("list_struct").list.get(0)]).to_dict(as_series=False) == {
         "list_struct": [{"a": 1, "b": 2}, {"a": 1, "b": 2}, {"a": 1, "b": 2}]
     }
 
@@ -413,7 +415,7 @@ def test_struct_arr_reverse() -> None:
                 [{"a": 30, "b": 40}, {"a": 10, "b": 20}, {"a": 50, "b": 60}],
             ],
         }
-    ).with_columns([pl.col("list_struct").list.reverse()]).to_dict(False) == {
+    ).with_columns([pl.col("list_struct").list.reverse()]).to_dict(as_series=False) == {
         "list_struct": [
             [{"a": 5, "b": 6}, {"a": 3, "b": 4}, {"a": 1, "b": 2}],
             [{"a": 50, "b": 60}, {"a": 10, "b": 20}, {"a": 30, "b": 40}],
@@ -450,7 +452,7 @@ def test_struct_comparison() -> None:
             "col2": [{"a": 2, "b": 2}, {"a": 3, "b": 4}],
         }
     )
-    assert df.filter(pl.col("col1") == pl.col("col2")).to_dict(False) == {
+    assert df.filter(pl.col("col1") == pl.col("col2")).to_dict(as_series=False) == {
         "col1": [{"a": 3, "b": 4}],
         "col2": [{"a": 3, "b": 4}],
     }
@@ -487,7 +489,7 @@ def test_struct_arr_eval() -> None:
     )
     assert df.with_columns(
         pl.col("col_struct").list.eval(pl.element().first()).alias("first")
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "col_struct": [[{"a": 1, "b": 11}, {"a": 2, "b": 12}, {"a": 1, "b": 11}]],
         "first": [[{"a": 1, "b": 11}]],
     }
@@ -521,7 +523,7 @@ def test_nested_explode_4026() -> None:
         }
     )
 
-    assert df.explode("data").to_dict(False) == {
+    assert df.explode("data").to_dict(as_series=False) == {
         "data": [
             {"account_id": 10, "values": [1, 2]},
             {"account_id": 11, "values": [10, 20]},
@@ -585,13 +587,13 @@ def test_struct_getitem() -> None:
     assert pl.Series([{"a": 1, "b": 2}]).struct[-1].name == "b"
     assert pl.Series([{"a": 1, "b": 2}]).to_frame().select(
         [pl.col("").struct[0]]
-    ).to_dict(False) == {"a": [1]}
+    ).to_dict(as_series=False) == {"a": [1]}
 
 
 def test_struct_supertype() -> None:
     assert pl.from_dicts(
         [{"vehicle": {"auto": "car"}}, {"vehicle": {"auto": None}}]
-    ).to_dict(False) == {"vehicle": [{"auto": "car"}, {"auto": None}]}
+    ).to_dict(as_series=False) == {"vehicle": [{"auto": "car"}, {"auto": None}]}
 
 
 def test_struct_any_value_get_after_append() -> None:
@@ -612,7 +614,7 @@ def test_struct_categorical_5843() -> None:
         pl.col("foo").cast(pl.Categorical)
     )
     result = df.select(pl.col("foo").value_counts(sort=True))
-    assert result.to_dict(False) == {
+    assert result.to_dict(as_series=False) == {
         "foo": [
             {"foo": "a", "counts": 2},
             {"foo": "b", "counts": 1},
@@ -624,15 +626,15 @@ def test_struct_categorical_5843() -> None:
 def test_empty_struct() -> None:
     # List<struct>
     df = pl.DataFrame({"a": [[{}]]})
-    assert df.to_dict(False) == {"a": [[{"": None}]]}
+    assert df.to_dict(as_series=False) == {"a": [[{"": None}]]}
 
     # Struct one not empty
     df = pl.DataFrame({"a": [[{}, {"a": 10}]]})
-    assert df.to_dict(False) == {"a": [[{"a": None}, {"a": 10}]]}
+    assert df.to_dict(as_series=False) == {"a": [[{"a": None}, {"a": 10}]]}
 
     # Empty struct
     df = pl.DataFrame({"a": [{}]})
-    assert df.to_dict(False) == {"a": [{"": None}]}
+    assert df.to_dict(as_series=False) == {"a": [{"": None}]}
 
 
 @pytest.mark.parametrize(
@@ -704,7 +706,7 @@ def test_struct_null_cast() -> None:
         .lazy()
         .select([pl.lit(None, dtype=pl.Null).cast(dtype, strict=True)])
         .collect()
-    ).to_dict(False) == {"literal": [{"a": None, "b": None, "c": None}]}
+    ).to_dict(as_series=False) == {"literal": [{"a": None, "b": None, "c": None}]}
 
 
 def test_nested_struct_in_lists_cast() -> None:
@@ -715,7 +717,7 @@ def test_nested_struct_in_lists_cast() -> None:
                 [{"nodes": []}],
             ]
         }
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "node_groups": [[{"nodes": [{"id": 1, "is_started": True}]}], [{"nodes": []}]]
     }
 
@@ -733,13 +735,15 @@ def test_struct_concat_self_no_rechunk() -> None:
     df = pl.DataFrame([{"A": {"a": 1}}])
     out = pl.concat([df, df], rechunk=False)
     assert out.dtypes == [pl.Struct([pl.Field("a", pl.Int64)])]
-    assert out.to_dict(False) == {"A": [{"a": 1}, {"a": 1}]}
+    assert out.to_dict(as_series=False) == {"A": [{"a": 1}, {"a": 1}]}
 
 
 def test_sort_structs() -> None:
     assert pl.DataFrame(
         {"sex": ["male", "female", "female"], "age": [22, 38, 26]}
-    ).select(pl.struct(["sex", "age"]).sort()).unnest("sex").to_dict(False) == {
+    ).select(pl.struct(["sex", "age"]).sort()).unnest("sex").to_dict(
+        as_series=False
+    ) == {
         "sex": ["female", "female", "male"],
         "age": [26, 38, 22],
     }
@@ -752,7 +756,7 @@ def test_struct_applies_as_map() -> None:
     # but it runs the test: #7286
     assert df.select(
         pl.struct([pl.col("x"), pl.col("y") + pl.col("y")]).over("id")
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "x": [{"x": "a", "y": "dd"}, {"x": "b", "y": "ee"}, {"x": "c", "y": "ff"}]
     }
 
@@ -802,7 +806,7 @@ def test_struct_name_passed_in_agg_apply() -> None:
 
     assert pl.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6], "C": [1, 2, 2]}).group_by(
         "C"
-    ).agg(struct_expr).sort("C", descending=True).to_dict(False) == {
+    ).agg(struct_expr).sort("C", descending=True).to_dict(as_series=False) == {
         "C": [2, 1],
         "index": [
             [{"A": 2, "B": 0}, {"A": 2, "B": 0}],
@@ -822,7 +826,7 @@ def test_struct_name_passed_in_agg_apply() -> None:
                 .alias("counts"),
             ]
         )
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "k": [0],
         "val": [
             [

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -459,9 +459,9 @@ def test_struct_comparison() -> None:
 
 
 def test_struct_order() -> None:
-    assert pl.DataFrame({"col1": [{"a": 1, "b": 2}, {"b": 4, "a": 3}]}).to_dict(
-        False
-    ) == {"col1": [{"a": 1, "b": 2}, {"a": 3, "b": 4}]}
+    df = pl.DataFrame({"col1": [{"a": 1, "b": 2}, {"b": 4, "a": 3}]})
+    expected = {"col1": [{"a": 1, "b": 2}, {"a": 3, "b": 4}]}
+    assert df.to_dict(as_series=False) == expected
 
     # null values should not trigger this
     assert (
@@ -575,9 +575,10 @@ def test_nested_struct_sliced_append() -> None:
 
 def test_struct_group_by_field_agg_4216() -> None:
     df = pl.DataFrame([{"a": {"b": 1}, "c": 0}])
-    assert df.group_by("c").agg(pl.col("a").struct.field("b").count()).to_dict(
-        False
-    ) == {"c": [0], "b": [1]}
+
+    result = df.group_by("c").agg(pl.col("a").struct.field("b").count())
+    expected = {"c": [0], "b": [1]}
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_struct_getitem() -> None:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1945,7 +1945,7 @@ def test_unlocalize() -> None:
 
 
 def test_tz_aware_truncate() -> None:
-    test = pl.DataFrame(
+    df = pl.DataFrame(
         {
             "dt": pl.datetime_range(
                 start=datetime(2022, 11, 1),
@@ -1955,9 +1955,8 @@ def test_tz_aware_truncate() -> None:
             ).dt.replace_time_zone("America/New_York")
         }
     )
-    assert test.with_columns(pl.col("dt").dt.truncate("1d").alias("trunced")).to_dict(
-        False
-    ) == {
+    result = df.with_columns(pl.col("dt").dt.truncate("1d").alias("trunced"))
+    expected = {
         "dt": [
             datetime(2022, 11, 1, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
             datetime(2022, 11, 1, 12, 0, tzinfo=ZoneInfo(key="America/New_York")),
@@ -1977,6 +1976,7 @@ def test_tz_aware_truncate() -> None:
             datetime(2022, 11, 4, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
         ],
     }
+    assert result.to_dict(as_series=False) == expected
 
     # 5507
     lf = pl.DataFrame(
@@ -2057,9 +2057,8 @@ def test_tz_aware_to_string() -> None:
             ).dt.replace_time_zone("America/New_York")
         }
     )
-    assert df.with_columns(pl.col("dt").dt.to_string("%c").alias("fmt")).to_dict(
-        False
-    ) == {
+    result = df.with_columns(pl.col("dt").dt.to_string("%c").alias("fmt"))
+    expected = {
         "dt": [
             datetime(2022, 11, 1, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
             datetime(2022, 11, 2, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
@@ -2073,6 +2072,7 @@ def test_tz_aware_to_string() -> None:
             "Fri Nov  4 00:00:00 2022",
         ],
     }
+    assert result.to_dict(as_series=False) == expected
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1176,7 +1176,7 @@ def test_duration_aggregations() -> None:
             pl.col("duration").median().alias("median"),
             pl.col("duration").alias("list"),
         ]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "group": ["A", "B"],
         "mean": [timedelta(days=2), timedelta(days=2)],
         "sum": [timedelta(days=4), timedelta(days=4)],
@@ -1263,7 +1263,7 @@ def test_unique_counts_on_dates() -> None:
             pl.col("dt_ns").dt.cast_time_unit("ms").alias("dt_ms"),
             pl.col("dt_ns").cast(pl.Date).alias("date"),
         ]
-    ).select(pl.all().unique_counts().sum()).to_dict(False) == {
+    ).select(pl.all().unique_counts().sum()).to_dict(as_series=False) == {
         "dt_ns": [3],
         "dt_us": [3],
         "dt_ms": [3],
@@ -1300,7 +1300,7 @@ def test_rolling_by_ordering() -> None:
         [
             pl.col("val").sum().alias("sum val"),
         ]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "key": ["A", "A", "A", "A", "B", "B", "B"],
         "dt": [
             datetime(2022, 1, 1, 0, 1),
@@ -1338,7 +1338,7 @@ def test_rolling_by_() -> None:
         .agg([pl.count().alias("count")])
     )
     assert_frame_equal(out.sort(["group", "datetime"]), expected)
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "group": [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2],
         "datetime": [
             datetime(2020, 1, 1, 0, 0),
@@ -1368,7 +1368,7 @@ def test_sorted_unique() -> None:
         )
         .sort("dt")
         .unique()
-    ).to_dict(False) == {"dt": [date(2015, 6, 23), date(2015, 6, 24)]}
+    ).to_dict(as_series=False) == {"dt": [date(2015, 6, 23), date(2015, 6, 24)]}
 
 
 def test_date_to_time_cast_5111() -> None:
@@ -1396,7 +1396,7 @@ def test_sum_duration() -> None:
         ]
     ).select(
         [pl.col("duration").sum(), pl.col("duration").dt.seconds().alias("sec").sum()]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "duration": [timedelta(seconds=150)],
         "sec": [150],
     }
@@ -1433,10 +1433,16 @@ def test_date_arr_concat() -> None:
 
     # type date
     df = pl.DataFrame({"d": [date(2000, 1, 1)]})
-    assert df.select(pl.col("d").list.concat(pl.col("d"))).to_dict(False) == expected
+    assert (
+        df.select(pl.col("d").list.concat(pl.col("d"))).to_dict(as_series=False)
+        == expected
+    )
     # type list[date]
     df = pl.DataFrame({"d": [[date(2000, 1, 1)]]})
-    assert df.select(pl.col("d").list.concat(pl.col("d"))).to_dict(False) == expected
+    assert (
+        df.select(pl.col("d").list.concat(pl.col("d"))).to_dict(as_series=False)
+        == expected
+    )
 
 
 def test_date_timedelta() -> None:
@@ -1448,7 +1454,7 @@ def test_date_timedelta() -> None:
             (pl.col("date") + timedelta(days=1)).alias("date_plus_one"),
             (pl.col("date") - timedelta(days=1)).alias("date_min_one"),
         ]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "date": [date(2001, 1, 1), date(2001, 1, 2), date(2001, 1, 3)],
         "date_plus_one": [date(2001, 1, 2), date(2001, 1, 3), date(2001, 1, 4)],
         "date_min_one": [date(2000, 12, 31), date(2001, 1, 1), date(2001, 1, 2)],
@@ -1500,7 +1506,7 @@ def test_replace_time_zone() -> None:
     ny = ZoneInfo("America/New_York")
     assert pl.DataFrame({"a": [datetime(2022, 9, 25, 14)]}).with_columns(
         pl.col("a").dt.replace_time_zone("America/New_York").alias("b")
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "a": [datetime(2022, 9, 25, 14, 0)],
         "b": [datetime(2022, 9, 25, 14, 0, tzinfo=ny)],
     }
@@ -1618,7 +1624,7 @@ def test_tz_datetime_duration_arithm_5221() -> None:
     )
     out = out.with_columns(pl.col("run_datetime") + pl.duration(days=1))
     utc = ZoneInfo("UTC")
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "run_datetime": [
             datetime(2022, 1, 2, 0, 0, tzinfo=utc),
             datetime(2022, 1, 3, 0, 0, tzinfo=utc),
@@ -1656,7 +1662,7 @@ def test_logical_nested_take() -> None:
         pl.List(pl.Time),
         pl.List(pl.Duration("us")),
     ]
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "ix": [1, 2],
         "dt": [[datetime(2001, 1, 2, 0, 0)], [datetime(2001, 1, 1, 0, 0)]],
         "d": [[date(2001, 1, 1)], [date(2001, 1, 1)]],
@@ -1677,7 +1683,7 @@ def test_replace_time_zone_from_naive() -> None:
 
     assert df.select(
         pl.col("date").cast(pl.Datetime).dt.replace_time_zone("America/New_York")
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "date": [
             datetime(2022, 1, 1, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
             datetime(2022, 1, 2, 0, 0, tzinfo=ZoneInfo(key="America/New_York")),
@@ -1986,7 +1992,7 @@ def test_tz_aware_truncate() -> None:
     lf = lf.with_columns(pl.col("naive").dt.replace_time_zone("UTC").alias("UTC"))
     lf = lf.with_columns(pl.col("UTC").dt.convert_time_zone("US/Central").alias("CST"))
     lf = lf.with_columns(pl.col("CST").dt.truncate("1d").alias("CST truncated"))
-    assert lf.collect().to_dict(False) == {
+    assert lf.collect().to_dict(as_series=False) == {
         "naive": [
             datetime(2021, 12, 31, 23, 0),
             datetime(2022, 1, 1, 0, 0),
@@ -2105,7 +2111,7 @@ def test_tz_aware_filter_lit() -> None:
             pl.col("date").dt.replace_time_zone("America/New_York").alias("nyc")
         )
         .filter(pl.col("nyc") < dt)
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "date": [
             datetime(1970, 1, 1, 0, 0),
             datetime(1970, 1, 1, 1, 0),
@@ -2138,7 +2144,7 @@ def test_asof_join_by_forward() -> None:
         right_on="value_two",
         by="category",
         strategy="forward",
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "category": ["a", "a", "a", "a", "a"],
         "value_one": [1, 2, 3, 5, 12],
         "value_two": [3, 3, 3, None, None],
@@ -2162,7 +2168,7 @@ def test_truncate_expr() -> None:
     every_expr = df.select(
         pl.col("date").dt.truncate(every=pl.col("every"), ambiguous=pl.lit("raise"))
     )
-    assert every_expr.to_dict(False) == {
+    assert every_expr.to_dict(as_series=False) == {
         "date": [
             datetime(2022, 1, 1),
             datetime(2023, 10, 1),
@@ -2174,7 +2180,7 @@ def test_truncate_expr() -> None:
     all_lit = df.select(
         pl.col("date").dt.truncate(every=pl.lit("1mo"), ambiguous=pl.lit("raise"))
     )
-    assert all_lit.to_dict(False) == {
+    assert all_lit.to_dict(as_series=False) == {
         "date": [
             datetime(2022, 11, 1),
             datetime(2023, 10, 1),
@@ -2208,7 +2214,7 @@ def test_truncate_expr() -> None:
     ambiguous_expr = df.select(
         pl.col("date").dt.truncate(every=pl.lit("30m"), ambiguous=pl.col("ambiguous"))
     )
-    assert ambiguous_expr.to_dict(False) == {
+    assert ambiguous_expr.to_dict(as_series=False) == {
         "date": [
             datetime(2020, 10, 25, tzinfo=ZoneInfo(key="Europe/London")),
             datetime(2020, 10, 25, 0, 30, tzinfo=ZoneInfo(key="Europe/London")),
@@ -2223,7 +2229,7 @@ def test_truncate_expr() -> None:
     all_expr = df.select(
         pl.col("date").dt.truncate(every=pl.col("every"), ambiguous=pl.col("ambiguous"))
     )
-    assert all_expr.to_dict(False) == {
+    assert all_expr.to_dict(as_series=False) == {
         "date": [
             datetime(2020, 10, 25, tzinfo=ZoneInfo(key="Europe/London")),
             datetime(2020, 10, 25, 0, 45, tzinfo=ZoneInfo(key="Europe/London")),
@@ -2250,18 +2256,18 @@ def test_truncate_propagate_null() -> None:
     )
     assert df.select(
         pl.col("date").dt.truncate(every=pl.col("every"), ambiguous="raise")
-    ).to_dict(False) == {"date": [None, None, datetime(2022, 3, 20, 5, 7, 0)]}
+    ).to_dict(as_series=False) == {"date": [None, None, datetime(2022, 3, 20, 5, 7, 0)]}
     assert df.select(
         pl.col("date").dt.truncate(every="1mo", ambiguous=pl.col("ambiguous"))
-    ).to_dict(False) == {"date": [None, datetime(2022, 11, 1), None]}
+    ).to_dict(as_series=False) == {"date": [None, datetime(2022, 11, 1), None]}
     assert df.select(
         pl.col("date").dt.truncate(every=pl.col("every"), ambiguous=pl.col("ambiguous"))
-    ).to_dict(False) == {"date": [None, None, None]}
+    ).to_dict(as_series=False) == {"date": [None, None, None]}
     assert df.select(
         pl.col("date").dt.truncate(
             every=pl.lit(None, dtype=pl.Utf8), ambiguous=pl.lit(None, dtype=pl.Utf8)
         )
-    ).to_dict(False) == {"date": [None, None, None]}
+    ).to_dict(as_series=False) == {"date": [None, None, None]}
 
 
 def test_truncate_by_calendar_weeks() -> None:
@@ -2274,7 +2280,7 @@ def test_truncate_by_calendar_weeks() -> None:
         .alias("date")
         .to_frame()
         .select([pl.col("date").dt.truncate("1w")])
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "date": [
             datetime(2022, 11, 14),
             datetime(2022, 11, 14),
@@ -2294,7 +2300,7 @@ def test_truncate_by_calendar_weeks() -> None:
         }
     )
 
-    assert df.select(pl.col("date").dt.truncate("1w")).to_dict(False) == {
+    assert df.select(pl.col("date").dt.truncate("1w")).to_dict(as_series=False) == {
         "date": [
             date(1768, 2, 29),
             date(2022, 12, 26),
@@ -2325,7 +2331,7 @@ def test_truncate_by_multiple_weeks() -> None:
                 pl.col("date").dt.truncate("17w").alias("17w"),
             ]
         )
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "2w": [date(2022, 4, 11), date(2022, 11, 21)],
         "3w": [date(2022, 4, 4), date(2022, 11, 14)],
         "4w": [date(2022, 3, 28), date(2022, 11, 7)],
@@ -2413,7 +2419,7 @@ def test_round_ambiguous() -> None:
     )
 
     df = df.select(pl.col("date").dt.round("30m", ambiguous=pl.col("ambiguous")))
-    assert df.to_dict(False) == {
+    assert df.to_dict(as_series=False) == {
         "date": [
             datetime(2020, 10, 25, 0, 30, tzinfo=ZoneInfo(key="Europe/London")),
             datetime(2020, 10, 25, 1, tzinfo=ZoneInfo(key="Europe/London")),
@@ -2446,7 +2452,7 @@ def test_round_by_week() -> None:
                 pl.col("date").dt.round("1w").alias("1w"),
             ]
         )
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "7d": [date(1998, 4, 9), date(2022, 12, 1)],
         "1w": [date(1998, 4, 13), date(2022, 11, 28)],
     }
@@ -2493,7 +2499,7 @@ def test_tz_aware_day_weekday() -> None:
             pl.col("tyo_date").dt.weekday().alias("tyo_weekday"),
             pl.col("ny_date").dt.weekday().alias("ny_weekday"),
         ]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "day": [1, 4, 7],
         "tyo_day": [1, 4, 7],
         "ny_day": [31, 3, 6],
@@ -2525,7 +2531,7 @@ def test_datetime_cum_agg_schema() -> None:
             (pl.col("cummax") + pl.duration(hours=24)).alias("cummax+24"),
         )
         .collect()
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "timestamp": [
             datetime(2023, 1, 1, 0, 0),
             datetime(2023, 1, 2, 0, 0),
@@ -2575,7 +2581,7 @@ def test_rolling_group_by_empty_groups_by_take_6330() -> None:
             by="Event",
             closed="left",
         ).agg([pl.count()])
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "Event": ["Rain", "Rain", "Rain", "Rain", "Sun", "Sun", "Sun", "Sun"],
         "Date": [1, 2, 3, 4, 1, 2, 3, 4],
         "count": [0, 1, 2, 2, 0, 1, 2, 2],

--- a/py-polars/tests/unit/functions/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/functions/aggregation/test_horizontal.py
@@ -227,7 +227,9 @@ def test_cumsum_fold() -> None:
         }
     )
     result = df.select(pl.cumsum_horizontal("a", "c"))
-    assert result.to_dict(False) == {"cumsum": [{"a": 1, "c": 6}, {"a": 2, "c": 8}]}
+    assert result.to_dict(as_series=False) == {
+        "cumsum": [{"a": 1, "c": 6}, {"a": 2, "c": 8}]
+    }
 
 
 def test_sum_dtype_12028() -> None:

--- a/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
@@ -118,13 +118,13 @@ def test_list_concat() -> None:
 def test_concat_list_with_lit() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
 
-    assert df.select(pl.concat_list([pl.col("a"), pl.lit(1)]).alias("a")).to_dict(
-        False
-    ) == {"a": [[1, 1], [2, 1], [3, 1]]}
+    result = df.select(pl.concat_list([pl.col("a"), pl.lit(1)]).alias("a"))
+    expected = {"a": [[1, 1], [2, 1], [3, 1]]}
+    assert result.to_dict(as_series=False) == expected
 
-    assert df.select(pl.concat_list([pl.lit(1), pl.col("a")]).alias("a")).to_dict(
-        False
-    ) == {"a": [[1, 1], [1, 2], [1, 3]]}
+    result = df.select(pl.concat_list([pl.lit(1), pl.col("a")]).alias("a"))
+    expected = {"a": [[1, 1], [1, 2], [1, 3]]}
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_concat_list_empty_raises() -> None:

--- a/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
@@ -155,7 +155,7 @@ def test_concat_list_in_agg_6397() -> None:
             # this casts every element to a list
             pl.concat_list(pl.col("value")),
         ]
-    ).sort("group").to_dict(False) == {
+    ).sort("group").to_dict(as_series=False) == {
         "group": [1, 2, 3],
         "value": [[["a"]], [["b"], ["c"]], [["d"]]],
     }
@@ -165,7 +165,7 @@ def test_concat_list_in_agg_6397() -> None:
         [
             pl.concat_list(pl.col("value").implode()).alias("result"),
         ]
-    ).sort("group").to_dict(False) == {
+    ).sort("group").to_dict(as_series=False) == {
         "group": [1, 2, 3],
         "result": [[["a"]], [["b", "c"]], [["d"]]],
     }
@@ -186,7 +186,7 @@ def test_categorical_list_concat_4762() -> None:
 
     q = df.lazy().select([pl.concat_list([pl.col("x").cast(pl.Categorical)] * 2)])
     with pl.StringCache():
-        assert q.collect().to_dict(False) == expected
+        assert q.collect().to_dict(as_series=False) == expected
 
 
 def test_list_concat_rolling_window() -> None:
@@ -286,17 +286,21 @@ def test_struct_with_lit() -> None:
     expr = pl.struct([pl.col("a"), pl.lit(1).alias("b")])
 
     assert (
-        pl.DataFrame({"a": pl.Series([], dtype=pl.Int64)}).select(expr).to_dict(False)
+        pl.DataFrame({"a": pl.Series([], dtype=pl.Int64)})
+        .select(expr)
+        .to_dict(as_series=False)
     ) == {"a": []}
 
     assert (
-        pl.DataFrame({"a": pl.Series([1], dtype=pl.Int64)}).select(expr).to_dict(False)
+        pl.DataFrame({"a": pl.Series([1], dtype=pl.Int64)})
+        .select(expr)
+        .to_dict(as_series=False)
     ) == {"a": [{"a": 1, "b": 1}]}
 
     assert (
         pl.DataFrame({"a": pl.Series([1, 2], dtype=pl.Int64)})
         .select(expr)
-        .to_dict(False)
+        .to_dict(as_series=False)
     ) == {"a": [{"a": 1, "b": 1}, {"a": 2, "b": 1}]}
 
 
@@ -435,14 +439,16 @@ def test_struct_broadcasting() -> None:
                 ]
             ).alias("my_struct")
         )
-    ).to_dict(False) == {"my_struct": [{"a": "a", "col1": 1}, {"a": "a", "col1": 2}]}
+    ).to_dict(as_series=False) == {
+        "my_struct": [{"a": "a", "col1": 1}, {"a": "a", "col1": 2}]
+    }
 
 
 def test_struct_list_cat_8235() -> None:
     df = pl.DataFrame(
         {"values": [["a", "b", "c"]]}, schema={"values": pl.List(pl.Categorical)}
     )
-    assert df.select(pl.struct("values")).to_dict(False) == {
+    assert df.select(pl.struct("values")).to_dict(as_series=False) == {
         "values": [{"values": ["a", "b", "c"]}]
     }
 
@@ -491,7 +497,7 @@ def test_suffix_in_struct_creation() -> None:
                 "c": [5, 6],
             }
         ).select(pl.struct(pl.col(["a", "c"]).name.suffix("_foo")).alias("bar"))
-    ).unnest("bar").to_dict(False) == {"a_foo": [1, 2], "c_foo": [5, 6]}
+    ).unnest("bar").to_dict(as_series=False) == {"a_foo": [1, 2], "c_foo": [5, 6]}
 
 
 def test_concat_str() -> None:

--- a/py-polars/tests/unit/functions/as_datatype/test_duration.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_duration.py
@@ -109,7 +109,7 @@ def test_date_duration_offset() -> None:
         (pl.col("date") + pl.duration(weeks="offset")).alias("add_weeks"),
         (pl.col("date") - pl.duration(weeks="offset")).alias("sub_weeks"),
     )
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "add_days": [date(11, 1, 1), date(2000, 7, 12), date(9990, 11, 30)],
         "sub_days": [date(9, 1, 1), date(2000, 6, 28), date(9991, 1, 31)],
         "add_weeks": [date(16, 12, 30), date(2000, 8, 23), date(9990, 5, 28)],
@@ -132,7 +132,7 @@ def test_add_duration_3786() -> None:
             "add_milliseconds"
         ),
         (pl.col("datetime") + pl.duration(hours="add")).alias("add_hours"),
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "datetime": [datetime(2022, 1, 1, 0, 0)],
         "add": [1],
         "add_weeks": [datetime(2022, 1, 8, 0, 0)],

--- a/py-polars/tests/unit/functions/range/test_date_range.py
+++ b/py-polars/tests/unit/functions/range/test_date_range.py
@@ -101,7 +101,7 @@ def test_date_range_lazy_with_expressions(
 
     result_df = df.with_columns(pl.date_ranges(low, high, interval="1d").alias("dts"))
 
-    assert result_df.to_dict(False) == {
+    assert result_df.to_dict(as_series=False) == {
         "start": [date(2000, 1, 1), date(2022, 6, 1)],
         "stop": [date(2000, 1, 2), date(2022, 6, 2)],
         "dts": [

--- a/py-polars/tests/unit/functions/range/test_datetime_range.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_range.py
@@ -139,7 +139,7 @@ def test_datetime_range_lazy_with_expressions(
         pl.datetime_ranges(low, high, interval="1d").alias("dts")
     )
 
-    assert result_df.to_dict(False) == {
+    assert result_df.to_dict(as_series=False) == {
         "start": [datetime(2000, 1, 1, 0, 0), datetime(2022, 6, 1, 0, 0)],
         "stop": [datetime(2000, 1, 2, 0, 0), datetime(2022, 6, 2, 0, 0)],
         "dts": [

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -300,7 +300,7 @@ def test_overflow_diff() -> None:
             "a": [20, 10, 30],
         }
     )
-    assert df.select(pl.col("a").cast(pl.UInt64).diff()).to_dict(False) == {
+    assert df.select(pl.col("a").cast(pl.UInt64).diff()).to_dict(as_series=False) == {
         "a": [None, -10, 20]
     }
 
@@ -319,7 +319,7 @@ def test_fill_null_unknown_output_type() -> None:
     )
     assert df.with_columns(
         np.exp(pl.col("a")).fill_null(pl.lit(1, pl.Float64))
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "a": [
             1.0,
             7.38905609893065,

--- a/py-polars/tests/unit/functions/test_whenthen.py
+++ b/py-polars/tests/unit/functions/test_whenthen.py
@@ -123,7 +123,7 @@ def test_nested_when_then_and_wildcard_expansion_6284() -> None:
     )
 
     assert_frame_equal(out0, out1)
-    assert out0.to_dict(False) == {
+    assert out0.to_dict(as_series=False) == {
         "1": ["a", "b"],
         "2": ["c", "d"],
         "result": ["a", "d"],
@@ -196,7 +196,7 @@ def test_when_then_edge_cases_3994() -> None:
             .name.keep()
         )
         .collect()
-    ).to_dict(False) == {"id": [1], "type": [[2, 2]]}
+    ).to_dict(as_series=False) == {"id": [1], "type": [[2, 2]]}
 
     # this tests ternary with an empty argument
     assert (
@@ -209,7 +209,7 @@ def test_when_then_edge_cases_3994() -> None:
             .otherwise(pl.col("type"))
             .name.keep()
         )
-    ).to_dict(False) == {"id": [], "type": []}
+    ).to_dict(as_series=False) == {"id": [], "type": []}
 
 
 def test_object_when_then_4702() -> None:
@@ -221,7 +221,7 @@ def test_object_when_then_4702() -> None:
         .then(pl.lit(pl.UInt16, allow_object=True))
         .otherwise(pl.lit(pl.UInt8, allow_object=True))
         .alias("New_Type")
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "Row": [1, 2],
         "Type": [pl.Date, pl.UInt8],
         "New_Type": [pl.UInt16, pl.UInt8],

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -893,9 +893,8 @@ def test_glob_csv(df_no_lists: pl.DataFrame, tmp_path: Path) -> None:
 
 def test_csv_whitespace_separator_at_start_do_not_skip() -> None:
     csv = "\t\t\t\t0\t1"
-    assert pl.read_csv(csv.encode(), separator="\t", has_header=False).to_dict(
-        False
-    ) == {
+    result = pl.read_csv(csv.encode(), separator="\t", has_header=False)
+    expected = {
         "column_1": [None],
         "column_2": [None],
         "column_3": [None],
@@ -903,13 +902,13 @@ def test_csv_whitespace_separator_at_start_do_not_skip() -> None:
         "column_5": [0],
         "column_6": [1],
     }
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_csv_whitespace_separator_at_end_do_not_skip() -> None:
     csv = "0\t1\t\t\t\t"
-    assert pl.read_csv(csv.encode(), separator="\t", has_header=False).to_dict(
-        False
-    ) == {
+    result = pl.read_csv(csv.encode(), separator="\t", has_header=False)
+    expected = {
         "column_1": [0],
         "column_2": [1],
         "column_3": [None],
@@ -917,6 +916,7 @@ def test_csv_whitespace_separator_at_end_do_not_skip() -> None:
         "column_5": [None],
         "column_6": [None],
     }
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_csv_multiple_null_values() -> None:

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -987,7 +987,7 @@ def test_skip_new_line_embedded_lines() -> None:
             infer_schema_length=0,
             missing_utf8_is_empty_string=empty_string,
         )
-        assert df.to_dict(False) == {
+        assert df.to_dict(as_series=False) == {
             "a": ["4", "7"],
             "b": ["5", "8"],
             "c": ["6", missing_value],
@@ -1157,7 +1157,7 @@ def test_skip_rows_different_field_len() -> None:
         csv.seek(0)
         assert pl.read_csv(
             csv, skip_rows_after_header=2, missing_utf8_is_empty_string=empty_string
-        ).to_dict(False) == {
+        ).to_dict(as_series=False) == {
             "a": [3, 4],
             "b": ["B", missing_value],
         }
@@ -1197,7 +1197,7 @@ def test_csv_categorical_lifetime() -> None:
 
     df = pl.read_csv(csv.encode(), dtypes={"a": pl.Categorical, "b": pl.Categorical})
     assert df.dtypes == [pl.Categorical, pl.Categorical]
-    assert df.to_dict(False) == {
+    assert df.to_dict(as_series=False) == {
         "a": ["needs_escape", ' "needs escape foo', ' "needs escape foo'],
         "b": ["b", "b", None],
     }
@@ -1221,13 +1221,13 @@ def test_batched_csv_reader(foods_file_path: Path) -> None:
 
     assert batches is not None
     assert len(batches) == 5
-    assert batches[0].to_dict(False) == {
+    assert batches[0].to_dict(as_series=False) == {
         "category": ["vegetables", "seafood", "meat", "fruit", "seafood", "meat"],
         "calories": [45, 150, 100, 60, 140, 120],
         "fats_g": [0.5, 5.0, 5.0, 0.0, 5.0, 10.0],
         "sugars_g": [2, 0, 0, 11, 1, 1],
     }
-    assert batches[-1].to_dict(False) == {
+    assert batches[-1].to_dict(as_series=False) == {
         "category": ["fruit", "meat", "vegetables", "fruit"],
         "calories": [130, 100, 30, 50],
         "fats_g": [0.0, 7.0, 0.0, 0.0],
@@ -1296,7 +1296,7 @@ def test_csv_single_categorical_null() -> None:
     )
 
     assert df.dtypes == [pl.Utf8, pl.Categorical, pl.Utf8]
-    assert df.to_dict(False) == {"x": ["A"], "y": [None], "z": ["A"]}
+    assert df.to_dict(as_series=False) == {"x": ["A"], "y": [None], "z": ["A"]}
 
 
 def test_csv_quoted_missing() -> None:
@@ -1550,7 +1550,7 @@ def test_ignore_errors_casting_dtypes() -> None:
         source=io.StringIO(csv),
         dtypes={"inventory": pl.Int8},
         ignore_errors=True,
-    ).to_dict(False) == {"inventory": [10, None, None, 90]}
+    ).to_dict(as_series=False) == {"inventory": [10, None, None, 90]}
 
     with pytest.raises(pl.ComputeError):
         pl.read_csv(
@@ -1575,13 +1575,13 @@ def test_csv_ragged_lines() -> None:
     assert (
         pl.read_csv(
             io.StringIO("A\nB,ragged\nC"), has_header=False, truncate_ragged_lines=True
-        ).to_dict(False)
+        ).to_dict(as_series=False)
         == expected
     )
     assert (
         pl.read_csv(
             io.StringIO("A\nB\nC,ragged"), has_header=False, truncate_ragged_lines=True
-        ).to_dict(False)
+        ).to_dict(as_series=False)
         == expected
     )
 
@@ -1598,7 +1598,7 @@ def test_provide_schema() -> None:
         io.StringIO("A\nB,ragged\nC"),
         has_header=False,
         schema={"A": pl.Utf8, "B": pl.Utf8, "C": pl.Utf8},
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "A": ["A", "B", "C"],
         "B": [None, "ragged", None],
         "C": [None, None, None],

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -259,9 +259,8 @@ def test_ndjson_ignore_errors() -> None:
     }
 
     # schema_overrides argument does schema inference, but overrides Fields
-    assert pl.read_ndjson(buf, schema_overrides=schema, ignore_errors=True).to_dict(
-        False
-    ) == {
+    result = pl.read_ndjson(buf, schema_overrides=schema, ignore_errors=True)
+    expected = {
         "Type": ["insert", "insert"],
         "Key": [[1], [1]],
         "SeqNo": [1, 1],
@@ -271,6 +270,7 @@ def test_ndjson_ignore_errors() -> None:
             [{"Name": "added_id", "Value": 2}, {"Name": "body", "Value": None}],
         ],
     }
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_write_json_duration() -> None:

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -140,9 +140,9 @@ def test_write_ndjson_with_trailing_newline() -> None:
 
 
 def test_read_ndjson_empty_array() -> None:
-    assert pl.read_ndjson(io.StringIO("""{"foo": {"bar": []}}""")).to_dict(False) == {
-        "foo": [{"": None}]
-    }
+    assert pl.read_ndjson(io.StringIO("""{"foo": {"bar": []}}""")).to_dict(
+        as_series=False
+    ) == {"foo": [{"": None}]}
 
 
 def test_ndjson_nested_null() -> None:
@@ -152,12 +152,12 @@ def test_ndjson_nested_null() -> None:
     # 'bar' represents an empty list of structs; check the schema is correct (eg: picks
     # up that it IS a list of structs), but confirm that list is empty (ref: #11301)
     assert df.schema == {"foo": pl.Struct([pl.Field("bar", pl.List(pl.Struct([])))])}
-    assert df.to_dict(False) == {"foo": [{"bar": []}]}
+    assert df.to_dict(as_series=False) == {"foo": [{"bar": []}]}
 
 
 def test_ndjson_nested_utf8_int() -> None:
     ndjson = """{"Accumulables":[{"Value":32395888},{"Value":"539454"}]}"""
-    assert pl.read_ndjson(io.StringIO(ndjson)).to_dict(False) == {
+    assert pl.read_ndjson(io.StringIO(ndjson)).to_dict(as_series=False) == {
         "Accumulables": [[{"Value": "32395888"}, {"Value": "539454"}]]
     }
 
@@ -210,7 +210,7 @@ def test_json_deserialize_9687() -> None:
 
     result = pl.read_json(json.dumps(response).encode())
 
-    assert result.to_dict(False) == {k: [v] for k, v in response.items()}
+    assert result.to_dict(as_series=False) == {k: [v] for k, v in response.items()}
 
 
 def test_json_infer_schema_length_11148() -> None:
@@ -232,7 +232,7 @@ def test_ndjson_ignore_errors() -> None:
     buf = io.BytesIO(jsonl.encode())
 
     # check if we can replace with nulls
-    assert pl.read_ndjson(buf, ignore_errors=True).to_dict(False) == {
+    assert pl.read_ndjson(buf, ignore_errors=True).to_dict(as_series=False) == {
         "Type": ["insert", "insert"],
         "Key": [[1], [1]],
         "SeqNo": [1, 1],
@@ -249,7 +249,9 @@ def test_ndjson_ignore_errors() -> None:
         )
     }
     # schema argument only parses Fields
-    assert pl.read_ndjson(buf, schema=schema, ignore_errors=True).to_dict(False) == {
+    assert pl.read_ndjson(buf, schema=schema, ignore_errors=True).to_dict(
+        as_series=False
+    ) == {
         "Fields": [
             [{"Name": "added_id", "Value": 2}, {"Name": "body", "Value": None}],
             [{"Name": "added_id", "Value": 2}, {"Name": "body", "Value": None}],

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -182,7 +182,7 @@ def test_lazy_n_rows(foods_file_path: Path) -> None:
         .filter(pl.col("idx") > 2)
         .collect()
     )
-    assert df.to_dict(False) == {
+    assert df.to_dict(as_series=False) == {
         "idx": [3],
         "category": ["fruit"],
         "calories": [60],
@@ -208,7 +208,7 @@ foo,bar,baz
     """
         )
     file_path = tmp_path / "*.csv"
-    assert pl.read_csv(file_path, skip_rows=2).to_dict(False) == {
+    assert pl.read_csv(file_path, skip_rows=2).to_dict(as_series=False) == {
         "foo": [1, 4, 7, 1, 4, 7],
         "bar": [2, 5, 8, 2, 5, 8],
         "baz": [3, 6, 9, 3, 6, 9],
@@ -223,7 +223,7 @@ def test_glob_n_rows(io_files_path: Path) -> None:
     assert df.shape == (40, 4)
 
     # take first and last rows
-    assert df[[0, 39]].to_dict(False) == {
+    assert df[[0, 39]].to_dict(as_series=False) == {
         "category": ["vegetables", "seafood"],
         "calories": [45, 146],
         "fats_g": [0.5, 6.0],

--- a/py-polars/tests/unit/io/test_lazy_ipc.py
+++ b/py-polars/tests/unit/io/test_lazy_ipc.py
@@ -69,7 +69,7 @@ def test_glob_n_rows(io_files_path: Path) -> None:
     assert df.shape == (40, 4)
 
     # take first and last rows
-    assert df[[0, 39]].to_dict(False) == {
+    assert df[[0, 39]].to_dict(as_series=False) == {
         "category": ["vegetables", "seafood"],
         "calories": [45, 146],
         "fats_g": [0.5, 6.0],

--- a/py-polars/tests/unit/io/test_lazy_json.py
+++ b/py-polars/tests/unit/io/test_lazy_json.py
@@ -107,7 +107,7 @@ def test_glob_n_rows(io_files_path: Path) -> None:
     assert df.shape == (40, 4)
 
     # take first and last rows
-    assert df[[0, 39]].to_dict(False) == {
+    assert df[[0, 39]].to_dict(as_series=False) == {
         "category": ["vegetables", "seafood"],
         "calories": [45, 146],
         "fats_g": [0.5, 6.0],

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -359,7 +359,7 @@ def test_parquet_struct_categorical(tmp_path: Path) -> None:
 
     with pl.StringCache():
         out = pl.read_parquet(file_path).select(pl.col("b").value_counts())
-    assert out.to_dict(False) == {"b": [{"b": "foo", "counts": 1}]}
+    assert out.to_dict(as_series=False) == {"b": [{"b": "foo", "counts": 1}]}
 
 
 def test_glob_n_rows(io_files_path: Path) -> None:
@@ -370,7 +370,7 @@ def test_glob_n_rows(io_files_path: Path) -> None:
     assert df.shape == (40, 4)
 
     # take first and last rows
-    assert df[[0, 39]].to_dict(False) == {
+    assert df[[0, 39]].to_dict(as_series=False) == {
         "category": ["vegetables", "seafood"],
         "calories": [45, 146],
         "fats_g": [0.5, 6.0],
@@ -388,7 +388,7 @@ def test_parquet_statistics_filter_9925(tmp_path: Path) -> None:
     q = pl.scan_parquet(file_path).filter(
         (pl.col("code").floordiv(100_000)).is_in([0, 3])
     )
-    assert q.collect().to_dict(False) == {"code": [300964, 300972, 26]}
+    assert q.collect().to_dict(as_series=False) == {"code": [300964, 300972, 26]}
 
 
 @pytest.mark.write_disk()

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -396,9 +396,10 @@ def test_parquet_statistics_filter_11069(tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)
     file_path = tmp_path / "foo.parquet"
     pl.DataFrame({"x": [1, None]}).write_parquet(file_path, statistics=False)
-    assert pl.scan_parquet(file_path).filter(pl.col("x").is_null()).collect().to_dict(
-        False
-    ) == {"x": [None]}
+
+    result = pl.scan_parquet(file_path).filter(pl.col("x").is_null()).collect()
+    expected = {"x": [None]}
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_parquet_list_arg(io_files_path: Path) -> None:

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -473,7 +473,7 @@ def test_parquet_nested_list_pandas() -> None:
     f.seek(0)
     df = pl.read_parquet(f)
     assert df.dtypes == [pl.List(pl.Null)]
-    assert df.to_dict(False) == {"listcol": [[]]}
+    assert df.to_dict(as_series=False) == {"listcol": [[]]}
 
 
 def test_parquet_string_cache() -> None:

--- a/py-polars/tests/unit/io/test_pyarrow_dataset.py
+++ b/py-polars/tests/unit/io/test_pyarrow_dataset.py
@@ -196,4 +196,6 @@ def test_pyarrow_dataset_comm_subplan_elim(tmp_path: Path) -> None:
     lf0 = pl.scan_pyarrow_dataset(ds0)
     lf1 = pl.scan_pyarrow_dataset(ds1)
 
-    assert lf0.join(lf1, on="a", how="inner").collect().to_dict(False) == {"a": [1, 2]}
+    assert lf0.join(lf1, on="a", how="inner").collect().to_dict(as_series=False) == {
+        "a": [1, 2]
+    }

--- a/py-polars/tests/unit/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/namespaces/string/test_string.py
@@ -900,9 +900,10 @@ def test_decode_strict() -> None:
     df = pl.DataFrame(
         {"strings": ["0IbQvTc3", "0J%2FQldCf0JA%3D", "0J%2FRgNC%2B0YHRgtC%2B"]}
     )
-    assert df.select(pl.col("strings").str.decode("base64", strict=False)).to_dict(
-        False
-    ) == {"strings": [b"\xd0\x86\xd0\xbd77", None, None]}
+    result = df.select(pl.col("strings").str.decode("base64", strict=False))
+    expected = {"strings": [b"\xd0\x86\xd0\xbd77", None, None]}
+    assert result.to_dict(as_series=False) == expected
+
     with pytest.raises(pl.ComputeError):
         df.select(pl.col("strings").str.decode("base64", strict=True))
 

--- a/py-polars/tests/unit/namespaces/test_binary.py
+++ b/py-polars/tests/unit/namespaces/test_binary.py
@@ -9,7 +9,7 @@ def test_binary_conversions() -> None:
         pl.col("blob").cast(pl.Utf8).alias("decoded_blob")
     )
 
-    assert df.to_dict(False) == {
+    assert df.to_dict(as_series=False) == {
         "blob": [b"abc", None, b"cde"],
         "decoded_blob": ["abc", None, "cde"],
     }
@@ -62,7 +62,7 @@ def test_contains_with_expr() -> None:
             pl.col("bin").bin.contains(pl.col("lit2")).alias("contains_2"),
             pl.col("bin").bin.contains(pl.lit(None)).alias("contains_3"),
         ]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "contains_1": [True, True, False, None],
         "contains_2": [None, True, False, None],
         "contains_3": [None, None, None, None],
@@ -85,7 +85,7 @@ def test_starts_ends_with() -> None:
             pl.col("a").bin.ends_with(pl.lit(None)).alias("start_none"),
             pl.col("a").bin.starts_with(pl.col("start")).alias("start_expr"),
         ]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "end_lit": [False, False, True, None],
         "end_none": [None, None, None, None],
         "end_expr": [True, False, None, None],

--- a/py-polars/tests/unit/namespaces/test_categorical.py
+++ b/py-polars/tests/unit/namespaces/test_categorical.py
@@ -78,9 +78,9 @@ def test_sort_categoricals_6014() -> None:
         )
 
     out = df1.sort("key")
-    assert out.to_dict(False) == {"key": ["bbb", "aaa", "ccc"]}
+    assert out.to_dict(as_series=False) == {"key": ["bbb", "aaa", "ccc"]}
     out = df2.sort("key")
-    assert out.to_dict(False) == {"key": ["aaa", "bbb", "ccc"]}
+    assert out.to_dict(as_series=False) == {"key": ["aaa", "bbb", "ccc"]}
 
 
 def test_categorical_get_categories() -> None:

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -565,7 +565,7 @@ def test_date_time_combine(tzinfo: ZoneInfo | None, time_zone: str | None) -> No
             datetime(2022, 7, 5, 4, 5, 6),
         ],
     }
-    assert df.to_dict(False) == expected_dict
+    assert df.to_dict(as_series=False) == expected_dict
 
     expected_schema = {
         "d1": pl.Datetime("us", time_zone),
@@ -735,7 +735,7 @@ def test_offset_by_broadcasting() -> None:
         ],
         "d5": [None, None, None, None],
     }
-    assert result.to_dict(False) == expected_dict
+    assert result.to_dict(as_series=False) == expected_dict
 
     # test broadcast rhs
     df = pl.DataFrame({"dt": [datetime(2020, 10, 25), datetime(2021, 1, 2), None]})
@@ -757,11 +757,11 @@ def test_offset_by_broadcasting() -> None:
         ],
         "d4": [datetime(2021, 11, 26).date(), datetime(2022, 2, 3).date(), None],
     }
-    assert result.to_dict(False) == expected_dict
+    assert result.to_dict(as_series=False) == expected_dict
 
     # test all literal
     result = df.select(d=pl.lit(datetime(2021, 11, 26)).dt.offset_by("1mo1d"))
-    assert result.to_dict(False) == {"d": [datetime(2021, 12, 27)]}
+    assert result.to_dict(as_series=False) == {"d": [datetime(2021, 12, 27)]}
 
 
 def test_offset_by_expressions() -> None:

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -39,7 +39,7 @@ def test_list_arr_get() -> None:
         {"a": [[1], [2], [3], [4, 5, 6], [7, 8, 9], [None, 11]]}
     ).with_columns(
         [pl.col("a").list.get(i).alias(f"get_{i}") for i in range(4)]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "a": [[1], [2], [3], [4, 5, 6], [7, 8, 9], [None, 11]],
         "get_0": [1, 2, 3, 4, 7, None],
         "get_1": [None, None, None, 5, 8, 11],
@@ -50,7 +50,7 @@ def test_list_arr_get() -> None:
     # get by indexes where some are out of bounds
     df = pl.DataFrame({"cars": [[1, 2, 3], [2, 3], [4], []], "indexes": [-2, 1, -3, 0]})
 
-    assert df.select([pl.col("cars").list.get("indexes")]).to_dict(False) == {
+    assert df.select([pl.col("cars").list.get("indexes")]).to_dict(as_series=False) == {
         "cars": [2, 3, None, None]
     }
     # exact on oob boundary
@@ -61,12 +61,12 @@ def test_list_arr_get() -> None:
         }
     )
 
-    assert df.select(pl.col("lists").list.get(3)).to_dict(False) == {
+    assert df.select(pl.col("lists").list.get(3)).to_dict(as_series=False) == {
         "lists": [None, None, 4]
     }
-    assert df.select(pl.col("lists").list.get(pl.col("index"))).to_dict(False) == {
-        "lists": [None, None, 4]
-    }
+    assert df.select(pl.col("lists").list.get(pl.col("index"))).to_dict(
+        as_series=False
+    ) == {"lists": [None, None, 4]}
 
 
 def test_contains() -> None:
@@ -100,9 +100,9 @@ def test_list_join() -> None:
         }
     )
     out = df.select(pl.col("a").list.join("-"))
-    assert out.to_dict(False) == {"a": ["ab-c-d", "e-f", "g", "", None]}
+    assert out.to_dict(as_series=False) == {"a": ["ab-c-d", "e-f", "g", "", None]}
     out = df.select(pl.col("a").list.join(pl.col("separator")))
-    assert out.to_dict(False) == {"a": ["ab&c&d", None, "g", "", None]}
+    assert out.to_dict(as_series=False) == {"a": ["ab&c&d", None, "g", "", None]}
 
 
 def test_list_arr_empty() -> None:
@@ -267,7 +267,7 @@ def test_list_ternary_concat() -> None:
         .then(pl.col("list1").list.concat(pl.col("list2")))
         .otherwise(pl.col("list2"))
         .alias("result")
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "list1": [["123", "456"], None],
         "list2": [["789"], ["zzz"]],
         "result": [["789"], None],
@@ -278,7 +278,7 @@ def test_list_ternary_concat() -> None:
         .then(pl.col("list2"))
         .otherwise(pl.col("list1").list.concat(pl.col("list2")))
         .alias("result")
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "list1": [["123", "456"], None],
         "list2": [["789"], ["zzz"]],
         "result": [["123", "456", "789"], ["zzz"]],
@@ -310,7 +310,7 @@ def test_list_eval_type_coercion() -> None:
             .list.eval(last_non_null_value, parallel=False)
             .alias("col_last")
         ]
-    ).to_dict(False) == {"col_last": [[3]]}
+    ).to_dict(as_series=False) == {"col_last": [[3]]}
 
 
 def test_list_slice() -> None:
@@ -322,15 +322,15 @@ def test_list_slice() -> None:
         }
     )
 
-    assert df.select([pl.col("lst").list.slice("offset", "len")]).to_dict(False) == {
-        "lst": [[2, 3, 4], [1]]
-    }
-    assert df.select([pl.col("lst").list.slice("offset", 1)]).to_dict(False) == {
-        "lst": [[2], [1]]
-    }
-    assert df.select([pl.col("lst").list.slice(-2, "len")]).to_dict(False) == {
-        "lst": [[3, 4], [2, 1]]
-    }
+    assert df.select([pl.col("lst").list.slice("offset", "len")]).to_dict(
+        as_series=False
+    ) == {"lst": [[2, 3, 4], [1]]}
+    assert df.select([pl.col("lst").list.slice("offset", 1)]).to_dict(
+        as_series=False
+    ) == {"lst": [[2], [1]]}
+    assert df.select([pl.col("lst").list.slice(-2, "len")]).to_dict(
+        as_series=False
+    ) == {"lst": [[3, 4], [2, 1]]}
 
 
 def test_list_sliced_get_5186() -> None:
@@ -430,9 +430,9 @@ def test_list_eval_all_null() -> None:
         pl.col("bar").cast(pl.List(pl.Utf8))
     )
 
-    assert df.select(pl.col("bar").list.eval(pl.element())).to_dict(False) == {
-        "bar": [None, None, None]
-    }
+    assert df.select(pl.col("bar").list.eval(pl.element())).to_dict(
+        as_series=False
+    ) == {"bar": [None, None, None]}
 
 
 def test_list_function_group_awareness() -> None:
@@ -451,7 +451,7 @@ def test_list_function_group_awareness() -> None:
             pl.col("a").implode().list.take([0]).alias("implode_take"),
             pl.col("a").implode().list.slice(0, 3).alias("implode_slice"),
         ]
-    ).sort("group").to_dict(False) == {
+    ).sort("group").to_dict(as_series=False) == {
         "group": [0, 1, 2],
         "get_scalar": [100, 105, 100],
         "take_no_implode": [[100], [105], [100]],
@@ -469,7 +469,9 @@ def test_list_get_logical_types() -> None:
         }
     )
 
-    assert df.select(pl.all().list.get(1).name.suffix("_element_1")).to_dict(False) == {
+    assert df.select(pl.all().list.get(1).name.suffix("_element_1")).to_dict(
+        as_series=False
+    ) == {
         "date_col_element_1": [date(2023, 2, 2)],
         "datetime_col_element_1": [datetime(2023, 2, 2, 0, 0)],
     }
@@ -482,7 +484,7 @@ def test_list_take_logical_type() -> None:
 
     df = pl.concat([df, df], rechunk=False)
     assert df.n_chunks() == 2
-    assert df.select(pl.all().take([0, 1])).to_dict(False) == {
+    assert df.select(pl.all().take([0, 1])).to_dict(as_series=False) == {
         "foo": [["foo", "foo", "bar"], ["foo", "foo", "bar"]],
         "bar": [[5.0, 10.0, 12.0], [5.0, 10.0, 12.0]],
     }
@@ -522,7 +524,7 @@ def test_list_to_struct() -> None:
 def test_list_arr_get_8810() -> None:
     assert pl.DataFrame(pl.Series("a", [None], pl.List(pl.Int64))).select(
         pl.col("a").list.get(0)
-    ).to_dict(False) == {"a": [None]}
+    ).to_dict(as_series=False) == {"a": [None]}
 
 
 def test_list_tail_underflow_9087() -> None:
@@ -611,16 +613,16 @@ def test_list_set_operations_broadcast() -> None:
 
     assert df.with_columns(
         pl.col("a").list.set_intersection(pl.lit(pl.Series([[1, 2]])))
-    ).to_dict(False) == {"a": [[2], [1], [1, 2]]}
+    ).to_dict(as_series=False) == {"a": [[2], [1], [1, 2]]}
     assert df.with_columns(
         pl.col("a").list.set_union(pl.lit(pl.Series([[1, 2]])))
-    ).to_dict(False) == {"a": [[2, 3, 1], [3, 1, 2], [1, 2, 3]]}
+    ).to_dict(as_series=False) == {"a": [[2, 3, 1], [3, 1, 2], [1, 2, 3]]}
     assert df.with_columns(
         pl.col("a").list.set_difference(pl.lit(pl.Series([[1, 2]])))
-    ).to_dict(False) == {"a": [[3], [3], [3]]}
+    ).to_dict(as_series=False) == {"a": [[3], [3], [3]]}
     assert df.with_columns(
         pl.lit(pl.Series("a", [[1, 2]])).list.set_difference("a")
-    ).to_dict(False) == {"a": [[1], [2], []]}
+    ).to_dict(as_series=False) == {"a": [[1], [2], []]}
 
 
 def test_list_take_oob_10079() -> None:
@@ -640,7 +642,7 @@ def test_utf8_empty_series_arg_min_max_10703() -> None:
         pl.all().list.arg_min().alias("arg_min"),
         pl.all().list.arg_max().alias("arg_max"),
     )
-    assert res.to_dict(False) == {
+    assert res.to_dict(as_series=False) == {
         "list": [["a"], []],
         "arg_min": [0, None],
         "arg_max": [0, None],

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -291,9 +291,10 @@ def test_arr_contains_categorical() -> None:
     ).lazy()
     df = df.with_columns(pl.col("str").cast(pl.Categorical))
     df_groups = df.group_by("group").agg([pl.col("str").alias("str_list")])
-    assert df_groups.filter(pl.col("str_list").list.contains("C")).collect().to_dict(
-        False
-    ) == {"group": [2], "str_list": [["A", "C"]]}
+
+    result = df_groups.filter(pl.col("str_list").list.contains("C")).collect()
+    expected = {"group": [2], "str_list": [["A", "C"]]}
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_list_eval_type_coercion() -> None:

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -103,7 +103,7 @@ def test_timezone_aware_strptime(tz_string: str, timedelta: timedelta) -> None:
     )
     assert times.with_columns(
         pl.col("delivery_datetime").str.to_datetime(format="%Y-%m-%d %H:%M:%S%z")
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "delivery_datetime": [
             datetime(2021, 12, 5, 6, 0, tzinfo=timezone(timedelta)),
             datetime(2021, 12, 5, 7, 0, tzinfo=timezone(timedelta)),

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -87,9 +87,9 @@ def test_map_elements_list_anyvalue_fallback() -> None:
         match=r'(?s)replace your `map_elements` with.*pl.col\("text"\).str.json_extract()',
     ):
         df = pl.DataFrame({"text": ['[{"x": 1, "y": 2}, {"x": 3, "y": 4}]']})
-        assert df.select(pl.col("text").map_elements(json.loads)).to_dict(False) == {
-            "text": [[{"x": 1, "y": 2}, {"x": 3, "y": 4}]]
-        }
+        assert df.select(pl.col("text").map_elements(json.loads)).to_dict(
+            as_series=False
+        ) == {"text": [[{"x": 1, "y": 2}, {"x": 3, "y": 4}]]}
 
         # starts with empty list '[]'
         df = pl.DataFrame(
@@ -101,9 +101,9 @@ def test_map_elements_list_anyvalue_fallback() -> None:
                 ]
             }
         )
-        assert df.select(pl.col("text").map_elements(json.loads)).to_dict(False) == {
-            "text": [[], [{"x": 1, "y": 2}, {"x": 3, "y": 4}], [{"x": 1, "y": 2}]]
-        }
+        assert df.select(pl.col("text").map_elements(json.loads)).to_dict(
+            as_series=False
+        ) == {"text": [[], [{"x": 1, "y": 2}, {"x": 3, "y": 4}], [{"x": 1, "y": 2}]]}
 
 
 def test_map_elements_all_types() -> None:
@@ -143,7 +143,7 @@ def test_map_elements_type_propagation() -> None:
                 .otherwise(None)
             ]
         )
-    ).to_dict(False) == {"a": [1, 2, 3], "b": [1.0, 2.0, None]}
+    ).to_dict(as_series=False) == {"a": [1, 2, 3], "b": [1.0, 2.0, None]}
 
 
 def test_empty_list_in_map_elements() -> None:
@@ -155,7 +155,7 @@ def test_empty_list_in_map_elements() -> None:
         pl.struct(["a", "b"]).map_elements(
             lambda row: list(set(row["a"]) & set(row["b"]))
         )
-    ).to_dict(False) == {"a": [[], [1, 2], [], [5]]}
+    ).to_dict(as_series=False) == {"a": [[], [1, 2], [], [5]]}
 
 
 def test_map_elements_skip_nulls() -> None:
@@ -188,7 +188,7 @@ def test_map_elements_object_dtypes() -> None:
                 .map_elements(lambda x: isinstance(x, (int, float)))
                 .alias("is_numeric_infer"),
             ]
-        ).to_dict(False) == {
+        ).to_dict(as_series=False) == {
             "a": [2, 4, "aa", 8, 10],
             "is_numeric1": [True, True, False, True, True],
             "is_numeric_infer": [True, True, False, True, True],
@@ -205,7 +205,7 @@ def test_map_elements_explicit_list_output_type() -> None:
     )
 
     assert out.dtypes == [pl.List(pl.Int64)]
-    assert out.to_dict(False) == {"str": [[1, 2, 3], [1, 2, 3]]}
+    assert out.to_dict(as_series=False) == {"str": [[1, 2, 3], [1, 2, 3]]}
 
 
 def test_map_elements_dict() -> None:
@@ -214,12 +214,12 @@ def test_map_elements_dict() -> None:
         match=r'(?s)replace your `map_elements` with.*pl.col\("abc"\).str.json_extract()',
     ):
         df = pl.DataFrame({"abc": ['{"A":"Value1"}', '{"B":"Value2"}']})
-        assert df.select(pl.col("abc").map_elements(json.loads)).to_dict(False) == {
-            "abc": [{"A": "Value1", "B": None}, {"A": None, "B": "Value2"}]
-        }
+        assert df.select(pl.col("abc").map_elements(json.loads)).to_dict(
+            as_series=False
+        ) == {"abc": [{"A": "Value1", "B": None}, {"A": None, "B": "Value2"}]}
         assert pl.DataFrame(
             {"abc": ['{"A":"Value1", "B":"Value2"}', '{"B":"Value3"}']}
-        ).select(pl.col("abc").map_elements(json.loads)).to_dict(False) == {
+        ).select(pl.col("abc").map_elements(json.loads)).to_dict(as_series=False) == {
             "abc": [{"A": "Value1", "B": "Value2"}, {"A": None, "B": "Value3"}]
         }
 
@@ -239,13 +239,13 @@ def test_map_elements_pass_name() -> None:
 
     assert df.group_by("bar", maintain_order=True).agg(
         pl.col("foo").map_elements(element_mapper, pass_name=True),
-    ).to_dict(False) == {"bar": [1, 2], "foo": [["foo1"], ["foo1"]]}
+    ).to_dict(as_series=False) == {"bar": [1, 2], "foo": [["foo1"], ["foo1"]]}
 
 
 def test_map_elements_binary() -> None:
     assert pl.DataFrame({"bin": [b"\x11" * 12, b"\x22" * 12, b"\xaa" * 12]}).select(
         pl.col("bin").map_elements(bytes.hex)
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "bin": [
             "111111111111111111111111",
             "222222222222222222222222",
@@ -264,7 +264,7 @@ def test_map_elements_set_datetime_output_8984() -> None:
 
 def test_map_elements_dict_order_10128() -> None:
     df = pl.select(pl.lit("").map_elements(lambda x: {"c": 1, "b": 2, "a": 3}))
-    assert df.to_dict(False) == {"literal": [{"c": 1, "b": 2, "a": 3}]}
+    assert df.to_dict(as_series=False) == {"literal": [{"c": 1, "b": 2, "a": 3}]}
 
 
 def test_map_elements_10237() -> None:
@@ -281,7 +281,7 @@ def test_map_elements_on_empty_col_10639() -> None:
         .map_elements(lambda x: x, return_dtype=pl.Int32, strategy="threading")
         .alias("Foo")
     )
-    assert res.to_dict(False) == {
+    assert res.to_dict(as_series=False) == {
         "B": [],
         "Foo": [],
     }
@@ -290,7 +290,7 @@ def test_map_elements_on_empty_col_10639() -> None:
         .map_elements(lambda x: x, return_dtype=pl.Int32, strategy="thread_local")
         .alias("Foo")
     )
-    assert res.to_dict(False) == {
+    assert res.to_dict(as_series=False) == {
         "B": [],
         "Foo": [],
     }

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -230,14 +230,14 @@ def test_rolling_extrema() -> None:
         ]
     )
 
-    assert df.select([pl.all().rolling_min(3)]).to_dict(False) == {
+    assert df.select([pl.all().rolling_min(3)]).to_dict(as_series=False) == {
         "col1": [None, None, 0, 1, 2, 3, 4],
         "col2": [None, None, 4, 3, 2, 1, 0],
         "col1_nulls": [None, None, None, None, 2, 3, 4],
         "col2_nulls": [None, None, None, None, 2, 1, 0],
     }
 
-    assert df.select([pl.all().rolling_max(3)]).to_dict(False) == {
+    assert df.select([pl.all().rolling_max(3)]).to_dict(as_series=False) == {
         "col1": [None, None, 2, 3, 4, 5, 6],
         "col2": [None, None, 6, 5, 4, 3, 2],
         "col1_nulls": [None, None, None, None, 4, 5, 6],
@@ -246,14 +246,14 @@ def test_rolling_extrema() -> None:
 
     # shuffled data triggers other kernels
     df = df.select([pl.all().shuffle(0)])
-    assert df.select([pl.all().rolling_min(3)]).to_dict(False) == {
+    assert df.select([pl.all().rolling_min(3)]).to_dict(as_series=False) == {
         "col1": [None, None, 0, 0, 1, 2, 2],
         "col2": [None, None, 0, 2, 1, 1, 1],
         "col1_nulls": [None, None, None, None, None, 2, 2],
         "col2_nulls": [None, None, None, None, None, 1, 1],
     }
 
-    assert df.select([pl.all().rolling_max(3)]).to_dict(False) == {
+    assert df.select([pl.all().rolling_max(3)]).to_dict(as_series=False) == {
         "col1": [None, None, 6, 4, 5, 5, 5],
         "col2": [None, None, 6, 6, 5, 4, 4],
         "col1_nulls": [None, None, None, None, None, 5, 5],
@@ -285,7 +285,7 @@ def test_rolling_group_by_extrema() -> None:
             ]
         )
         .select(["col1_list", "col1_min", "col1_max", "col1_first", "col1_last"])
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "col1_list": [
             [6],
             [6, 5],
@@ -324,7 +324,7 @@ def test_rolling_group_by_extrema() -> None:
             ]
         )
         .select(["col1_list", "col1_min", "col1_max", "col1_first", "col1_last"])
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "col1_list": [
             [0],
             [0, 1],
@@ -360,7 +360,7 @@ def test_rolling_group_by_extrema() -> None:
             ]
         )
         .select(["col1_list", "col1_min", "col1_max"])
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "col1_list": [
             [3],
             [3, 4],
@@ -386,7 +386,7 @@ def test_rolling_slice_pushdown() -> None:
         )
         .agg([(pl.col("c") - pl.col("c").shift(fill_value=0)).sum().alias("c")])
     )
-    assert df.head(2).collect().to_dict(False) == {
+    assert df.head(2).collect().to_dict(as_series=False) == {
         "b": ["a", "a"],
         "a": [1, 2],
         "c": [1, 3],
@@ -407,7 +407,7 @@ def test_overlapping_groups_4628() -> None:
                 (pl.col("val") - pl.col("val").shift(1)).alias("val - val.shift"),
             ]
         )
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "index": [1, 2, 3, 4, 5, 6],
         "val.diff": [
             [None],
@@ -539,7 +539,7 @@ def test_rolling_cov_corr() -> None:
             pl.rolling_cov("x", "y", window_size=3).alias("cov"),
             pl.rolling_corr("x", "y", window_size=3).alias("corr"),
         ]
-    ).to_dict(False)
+    ).to_dict(as_series=False)
     assert res["cov"][2:] == pytest.approx([0.0, 0.0, 5.333333333333336])
     assert res["corr"][2:] == pytest.approx([nan, nan, 0.9176629354822473], nan_ok=True)
     assert res["cov"][:2] == [None] * 2

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -30,13 +30,13 @@ def test_boolean_aggs() -> None:
         pl.std("bool").alias("std"),
         pl.var("bool").alias("var"),
     ]
-    assert df.select(aggs).to_dict(False) == {
+    assert df.select(aggs).to_dict(as_series=False) == {
         "mean": [0.6666666666666666],
         "std": [0.5773502588272095],
         "var": [0.3333333432674408],
     }
 
-    assert df.group_by(pl.lit(1)).agg(aggs).to_dict(False) == {
+    assert df.group_by(pl.lit(1)).agg(aggs).to_dict(as_series=False) == {
         "literal": [1],
         "mean": [0.6666666666666666],
         "std": [0.5773502691896258],
@@ -64,10 +64,12 @@ def test_duration_aggs() -> None:
 
     df = df.with_columns((pl.col("time2") - pl.col("time1")).alias("time_difference"))
 
-    assert df.select("time_difference").mean().to_dict(False) == {
+    assert df.select("time_difference").mean().to_dict(as_series=False) == {
         "time_difference": [timedelta(days=31)]
     }
-    assert df.group_by(pl.lit(1)).agg(pl.mean("time_difference")).to_dict(False) == {
+    assert df.group_by(pl.lit(1)).agg(pl.mean("time_difference")).to_dict(
+        as_series=False
+    ) == {
         "literal": [1],
         "time_difference": [timedelta(days=31)],
     }
@@ -91,7 +93,7 @@ def test_list_aggregation_that_filters_all_data_6017() -> None:
     )
 
     assert out.schema == {"col_to_group_by": pl.Int64, "calc": pl.List(pl.Float64)}
-    assert out.to_dict(False) == {"col_to_group_by": [2], "calc": [[]]}
+    assert out.to_dict(as_series=False) == {"col_to_group_by": [2], "calc": [[]]}
 
 
 def test_median() -> None:
@@ -217,7 +219,9 @@ def test_string_par_materialize_8207() -> None:
         }
     )
 
-    assert df.group_by(["a"]).agg(pl.min("b")).sort("a").collect().to_dict(False) == {
+    assert df.group_by(["a"]).agg(pl.min("b")).sort("a").collect().to_dict(
+        as_series=False
+    ) == {
         "a": ["a", "b", "c", "d", "e"],
         "b": ["P", "L", "T", "R", "a long string"],
     }
@@ -253,7 +257,7 @@ def test_err_on_implode_and_agg() -> None:
     # implode + function should be allowed in group_by
     assert df.group_by("type", maintain_order=True).agg(
         pl.col("type").implode().list.head().alias("foo")
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "type": ["water", "fire", "earth"],
         "foo": [[["water", "water"]], [["fire"]], [["earth"]]],
     }
@@ -270,7 +274,10 @@ def test_mapped_literal_to_literal_9217() -> None:
     df = pl.DataFrame({"unique_id": ["a", "b"]})
     assert df.group_by(True).agg(
         pl.struct(pl.lit("unique_id").alias("unique_id"))
-    ).to_dict(False) == {"literal": [True], "unique_id": [{"unique_id": "unique_id"}]}
+    ).to_dict(as_series=False) == {
+        "literal": [True],
+        "unique_id": [{"unique_id": "unique_id"}],
+    }
 
 
 def test_sum_empty_and_null_set() -> None:

--- a/py-polars/tests/unit/operations/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/test_arithmetic.py
@@ -55,26 +55,26 @@ def test_struct_arithmetic() -> None:
             "c": [5, 6],
         }
     ).select(pl.cumsum_horizontal("a", "c"))
-    assert df.select(pl.col("cumsum") * 2).to_dict(False) == {
+    assert df.select(pl.col("cumsum") * 2).to_dict(as_series=False) == {
         "cumsum": [{"a": 2, "c": 12}, {"a": 4, "c": 16}]
     }
-    assert df.select(pl.col("cumsum") - 2).to_dict(False) == {
+    assert df.select(pl.col("cumsum") - 2).to_dict(as_series=False) == {
         "cumsum": [{"a": -1, "c": 4}, {"a": 0, "c": 6}]
     }
-    assert df.select(pl.col("cumsum") + 2).to_dict(False) == {
+    assert df.select(pl.col("cumsum") + 2).to_dict(as_series=False) == {
         "cumsum": [{"a": 3, "c": 8}, {"a": 4, "c": 10}]
     }
-    assert df.select(pl.col("cumsum") / 2).to_dict(False) == {
+    assert df.select(pl.col("cumsum") / 2).to_dict(as_series=False) == {
         "cumsum": [{"a": 0.5, "c": 3.0}, {"a": 1.0, "c": 4.0}]
     }
-    assert df.select(pl.col("cumsum") // 2).to_dict(False) == {
+    assert df.select(pl.col("cumsum") // 2).to_dict(as_series=False) == {
         "cumsum": [{"a": 0, "c": 3}, {"a": 1, "c": 4}]
     }
 
     # inline, this check cumsum reports the right output type
     assert pl.DataFrame({"a": [1, 2], "b": [3, 4], "c": [5, 6]}).select(
         pl.cumsum_horizontal("a", "c") * 3
-    ).to_dict(False) == {"cumsum": [{"a": 3, "c": 18}, {"a": 6, "c": 24}]}
+    ).to_dict(as_series=False) == {"cumsum": [{"a": 3, "c": 18}, {"a": 6, "c": 24}]}
 
 
 def test_simd_float_sum_determinism() -> None:
@@ -156,7 +156,10 @@ def test_fused_arithm() -> None:
         """col("c").fma([col("a"), col("b")]).alias("a"), col("a").fma([col("b"), col("c")]).alias("2")"""
         in q.explain()
     )
-    assert q.collect().to_dict(False) == {"a": [15, 45, 95], "2": [51, 102, 153]}
+    assert q.collect().to_dict(as_series=False) == {
+        "a": [15, 45, 95],
+        "2": [51, 102, 153],
+    }
     # fsm
     q = df.lazy().select(pl.col("a") - pl.col("b") * pl.col("c"))
     assert """col("a").fsm([col("b"), col("c")])""" in q.explain()
@@ -226,4 +229,4 @@ def test_bitwise_6311() -> None:
             .then(pl.col("flag") | 4)
             .otherwise(pl.col("flag"))
         )
-    ).to_dict(False) == {"col1": [0, 1, 2, 3], "flag": [6, 4, 4, 6]}
+    ).to_dict(as_series=False) == {"col1": [0, 1, 2, 3], "flag": [6, 4, 4, 6]}

--- a/py-polars/tests/unit/operations/test_clip.py
+++ b/py-polars/tests/unit/operations/test_clip.py
@@ -23,7 +23,7 @@ def test_clip() -> None:
         }
     )
 
-    assert df.select(clip_exprs).to_dict(False) == {
+    assert df.select(clip_exprs).to_dict(as_series=False) == {
         "clip": [1, 1, 4, None, None],
         "clip_min": [1, 2, 4, None, 5],
         "clip_max": [1, 1, 3, 4, None],
@@ -37,7 +37,7 @@ def test_clip() -> None:
         }
     )
 
-    assert df.select(clip_exprs).to_dict(False) == {
+    assert df.select(clip_exprs).to_dict(as_series=False) == {
         "clip": [1.0, 1.0, 4.0, None, None],
         "clip_min": [1.0, 2.0, 4.0, None, 5.0],
         "clip_max": [1.0, 1.0, 3.0, 4.0, None],
@@ -72,7 +72,7 @@ def test_clip() -> None:
         }
     )
 
-    assert df.select(clip_exprs).to_dict(False) == {
+    assert df.select(clip_exprs).to_dict(as_series=False) == {
         "clip": [
             datetime(1995, 6, 5, 10, 30),
             datetime(1996, 6, 5),

--- a/py-polars/tests/unit/operations/test_cut.py
+++ b/py-polars/tests/unit/operations/test_cut.py
@@ -87,7 +87,7 @@ def test_cut_deprecated_as_series() -> None:
         out = a.cut(breaks=[-1, 1], as_series=False)
 
     assert out.shape == (12, 3)
-    assert out.filter(pl.col("break_point") < 1e9).to_dict(False) == {
+    assert out.filter(pl.col("break_point") < 1e9).to_dict(as_series=False) == {
         "a": [-3.0, -2.5, -2.0, -1.5, -1.0, -0.5, 0.0, 0.5, 1.0],
         "break_point": [-1.0, -1.0, -1.0, -1.0, -1.0, 1.0, 1.0, 1.0, 1.0],
         "category": [

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -23,7 +23,7 @@ def test_drop_explode_6641() -> None:
         .drop(["identifier", "alternate"])
         .select(pl.concat_list([pl.col("test"), pl.col("test")]))
         .collect()
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "test": [
             [
                 {"identifier": "chr1:10426:10429:ACC>A", "alternate": "A"},

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -82,7 +82,7 @@ def test_explode_empty_list_4003() -> None:
             {"id": 3, "nested": [2]},
         ]
     )
-    assert df.explode("nested").to_dict(False) == {
+    assert df.explode("nested").to_dict(as_series=False) == {
         "id": [1, 2, 3],
         "nested": [None, 1, 2],
     }
@@ -219,7 +219,7 @@ def test_explode_in_agg_context() -> None:
         .explode("idxs")
         .group_by("row_nr")
         .agg(pl.col("array").flatten())
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "row_nr": [0, 1, 2],
         "array": [[0.0, 3.5], [4.6, 0.0], [0.0, 7.8, 0.0, 0.0, 7.8, 0.0]],
     }
@@ -234,7 +234,10 @@ def test_explode_inner_lists_3985() -> None:
         df.group_by("id")
         .agg(pl.col("categories"))
         .with_columns(pl.col("categories").list.eval(pl.element().list.explode()))
-    ).collect().to_dict(False) == {"id": [1], "categories": [["a", "b", "a", "c"]]}
+    ).collect().to_dict(as_series=False) == {
+        "id": [1],
+        "categories": [["a", "b", "a", "c"]],
+    }
 
 
 def test_list_struct_explode_6905() -> None:
@@ -342,7 +345,7 @@ def test_explode_null_struct() -> None:
         },
     ]
 
-    assert pl.DataFrame(df).explode("col1").to_dict(False) == {
+    assert pl.DataFrame(df).explode("col1").to_dict(as_series=False) == {
         "col1": [
             {"field1": None, "field2": None, "field3": None},
             {"field1": None, "field2": None, "field3": None},

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -34,7 +34,11 @@ def test_melt_values_predicate_pushdown() -> None:
         lf.melt("id", ["asset_key_1", "asset_key_2", "asset_key_3"])
         .filter(pl.col("value") == pl.lit("123"))
         .collect()
-    ).to_dict(False) == {"id": [1], "variable": ["asset_key_1"], "value": ["123"]}
+    ).to_dict(as_series=False) == {
+        "id": [1],
+        "variable": ["asset_key_1"],
+        "value": ["123"],
+    }
 
 
 def test_group_by_filter_all_true() -> None:
@@ -50,7 +54,7 @@ def test_group_by_filter_all_true() -> None:
         .agg([pl.col("order").filter(pl.col("type") == 1).n_unique().alias("n_unique")])
         .select("n_unique")
     )
-    assert out.to_dict(False) == {"n_unique": [1, 1]}
+    assert out.to_dict(as_series=False) == {"n_unique": [1, 1]}
 
 
 def test_filter_is_in_4572() -> None:
@@ -104,7 +108,7 @@ def test_filter_aggregation_any() -> None:
         .sort("group")
     )
 
-    assert result.to_dict(False) == {
+    assert result.to_dict(as_series=False) == {
         "group": [1, 2],
         "any": [[False, True, True], [True]],
         "filtered": [[3, 4], [2]],
@@ -124,7 +128,7 @@ def test_predicate_order_explode_5950() -> None:
         .explode("i")
         .filter(pl.col("n").count().over(["i"]) == 2)
         .filter(pl.col("n").is_not_null())
-    ).collect().to_dict(False) == {"i": [1], "n": [0]}
+    ).collect().to_dict(as_series=False) == {"i": [1], "n": [0]}
 
 
 def test_binary_simplification_5971() -> None:
@@ -160,7 +164,7 @@ def test_categorical_string_comparison_6283() -> None:
         }
     )
 
-    assert scores.filter(scores["zone"] == "North").to_dict(False) == {
+    assert scores.filter(scores["zone"] == "North").to_dict(as_series=False) == {
         "zone": ["North", "North", "North"],
         "funding": ["yes", "yes", "no"],
         "score": [78, 39, 76],
@@ -177,20 +181,23 @@ def test_clear_window_cache_after_filter_10499() -> None:
 
     assert df.lazy().filter((pl.col("a").null_count() < pl.count()).over("b")).filter(
         ((pl.col("a") == 0).sum() < pl.count()).over("b")
-    ).collect().to_dict(False) == {"a": [3, None, 5, 0, 9, 10], "b": [2, 2, 3, 3, 5, 5]}
+    ).collect().to_dict(as_series=False) == {
+        "a": [3, None, 5, 0, 9, 10],
+        "b": [2, 2, 3, 3, 5, 5],
+    }
 
 
 def test_agg_function_of_filter_10565() -> None:
     df_int = pl.DataFrame(data={"a": []}, schema={"a": pl.Int16})
-    assert df_int.filter(pl.col("a").n_unique().over("a") == 1).to_dict(False) == {
-        "a": []
-    }
+    assert df_int.filter(pl.col("a").n_unique().over("a") == 1).to_dict(
+        as_series=False
+    ) == {"a": []}
 
     df_str = pl.DataFrame(data={"a": []}, schema={"a": pl.Utf8})
-    assert df_str.filter(pl.col("a").n_unique().over("a") == 1).to_dict(False) == {
-        "a": []
-    }
+    assert df_str.filter(pl.col("a").n_unique().over("a") == 1).to_dict(
+        as_series=False
+    ) == {"a": []}
 
     assert df_str.lazy().filter(pl.col("a").n_unique().over("a") == 1).collect(
         predicate_pushdown=False
-    ).to_dict(False) == {"a": []}
+    ).to_dict(as_series=False) == {"a": []}

--- a/py-polars/tests/unit/operations/test_folds.py
+++ b/py-polars/tests/unit/operations/test_folds.py
@@ -27,14 +27,14 @@ def test_cumfold() -> None:
 
     assert df.select(
         [pl.cumfold(pl.lit(0), lambda a, b: a + b, pl.all()).alias("folded")]
-    ).unnest("folded").to_dict(False) == {
+    ).unnest("folded").to_dict(as_series=False) == {
         "a": [1, 2, 3, 4],
         "b": [6, 8, 10, 12],
         "c": [16, 28, 40, 52],
     }
     assert df.select(
         [pl.cumreduce(lambda a, b: a + b, pl.all()).alias("folded")]
-    ).unnest("folded").to_dict(False) == {
+    ).unnest("folded").to_dict(as_series=False) == {
         "a": [1, 2, 3, 4],
         "b": [6, 8, 10, 12],
         "c": [16, 28, 40, 52],

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -485,9 +485,9 @@ def test_overflow_mean_partitioned_group_by_5194(dtype: pl.PolarsDataType) -> No
             pl.Series("group", [1, 2] * 50_000, dtype=dtype),
         ]
     )
-    assert df.group_by("group").agg(pl.col("data").mean()).sort(by="group").to_dict(
-        False
-    ) == {"group": [1, 2], "data": [10000000.0, 10000000.0]}
+    result = df.group_by("group").agg(pl.col("data").mean()).sort(by="group")
+    expected = {"group": [1, 2], "data": [10000000.0, 10000000.0]}
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_group_by_multiple_column_reference() -> None:
@@ -645,10 +645,8 @@ def test_perfect_hash_table_null_values_8663() -> None:
         ],
         dtype=pl.Categorical,
     )
-
-    assert s.to_frame("a").group_by("a").agg(pl.col("a").alias("agg")).to_dict(
-        False
-    ) == {
+    result = s.to_frame("a").group_by("a").agg(pl.col("a").alias("agg"))
+    expected = {
         "a": [
             "3",
             "41",
@@ -734,6 +732,7 @@ def test_perfect_hash_table_null_values_8663() -> None:
             [None, None, None],
         ],
     }
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_group_by_partitioned_ending_cast(monkeypatch: Any) -> None:

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -271,7 +271,7 @@ def test_apply_after_take_in_group_by_3869() -> None:
         .agg(
             pl.col("v").get(pl.col("t").arg_max()).sqrt()
         )  # <- fails for sqrt, exp, log, pow, etc.
-    ).to_dict(False) == {"k": ["a", "b"], "v": [1.4142135623730951, 2.0]}
+    ).to_dict(as_series=False) == {"k": ["a", "b"], "v": [1.4142135623730951, 2.0]}
 
 
 def test_group_by_signed_transmutes() -> None:
@@ -284,7 +284,7 @@ def test_group_by_signed_transmutes() -> None:
             .agg(pl.col("bar").median())
         )
 
-        assert df.to_dict(False) == {
+        assert df.to_dict(as_series=False) == {
             "foo": [-1, -2, -3, -4, -5],
             "bar": [500.0, 600.0, 700.0, 800.0, 900.0],
         }
@@ -320,11 +320,15 @@ def test_arg_sort_sort_by_groups_update__4360() -> None:
 
 def test_unique_order() -> None:
     df = pl.DataFrame({"a": [1, 2, 1]}).with_row_count()
-    assert df.unique(keep="last", subset="a", maintain_order=True).to_dict(False) == {
+    assert df.unique(keep="last", subset="a", maintain_order=True).to_dict(
+        as_series=False
+    ) == {
         "row_nr": [1, 2],
         "a": [2, 1],
     }
-    assert df.unique(keep="first", subset="a", maintain_order=True).to_dict(False) == {
+    assert df.unique(keep="first", subset="a", maintain_order=True).to_dict(
+        as_series=False
+    ) == {
         "row_nr": [0, 1],
         "a": [1, 2],
     }
@@ -339,7 +343,7 @@ def test_group_by_dynamic_flat_agg_4814() -> None:
             (pl.col("b").last() / pl.col("a").last()).alias("last_ratio_1"),
             (pl.col("b") / pl.col("a")).last().alias("last_ratio_2"),
         ]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "a": [0, 1, 2],
         "sum_ratio_1": [1.0, 4.2, 5.0],
         "last_ratio_1": [1.0, 6.0, 6.0],
@@ -377,7 +381,7 @@ def test_group_by_dynamic_overlapping_groups_flat_apply_multiple_5038(
         )
         .collect()
         .sum()
-        .to_dict(False)
+        .to_dict(as_series=False)
     )
 
     assert res["corr"] == pytest.approx([9.148920923684765])
@@ -388,7 +392,7 @@ def test_take_in_group_by() -> None:
     df = pl.DataFrame({"group": [1, 1, 1, 2, 2, 2], "values": [10, 200, 3, 40, 500, 6]})
     assert df.group_by("group").agg(
         pl.col("values").get(1) - pl.col("values").get(2)
-    ).sort("group").to_dict(False) == {"group": [1, 2], "values": [197, 494]}
+    ).sort("group").to_dict(as_series=False) == {"group": [1, 2], "values": [197, 494]}
 
 
 def test_group_by_wildcard() -> None:
@@ -400,7 +404,7 @@ def test_group_by_wildcard() -> None:
     )
     assert df.group_by([pl.col("*")], maintain_order=True).agg(
         [pl.col("a").first().name.suffix("_agg")]
-    ).to_dict(False) == {"a": [1, 2], "b": [1, 2], "a_agg": [1, 2]}
+    ).to_dict(as_series=False) == {"a": [1, 2], "b": [1, 2], "a_agg": [1, 2]}
 
 
 def test_group_by_all_masked_out() -> None:
@@ -424,7 +428,10 @@ def test_group_by_null_propagation_6185() -> None:
 
     expected = {"B": [1, 2], "A": [None, None]}
     assert (
-        df_1.group_by("B").agg((expr - expr.mean()).mean()).sort("B").to_dict(False)
+        df_1.group_by("B")
+        .agg((expr - expr.mean()).mean())
+        .sort("B")
+        .to_dict(as_series=False)
         == expected
     )
 
@@ -437,7 +444,7 @@ def test_group_by_when_then_with_binary_and_agg_in_pred_6202() -> None:
         df.group_by("code", maintain_order=True).agg(
             [pl.when(pl.col("xx") > pl.min("xx")).then(True).otherwise(False)]
         )
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "code": ["a", "b"],
         "literal": [[False, True], [True, True, False]],
     }
@@ -449,21 +456,24 @@ def test_group_by_binary_agg_with_literal() -> None:
     out = df.group_by("id", maintain_order=True).agg(
         pl.col("value") + pl.Series([1, 3])
     )
-    assert out.to_dict(False) == {"id": ["a", "b"], "value": [[2, 5], [4, 7]]}
+    assert out.to_dict(as_series=False) == {"id": ["a", "b"], "value": [[2, 5], [4, 7]]}
 
     out = df.group_by("id", maintain_order=True).agg(pl.col("value") + pl.lit(1))
-    assert out.to_dict(False) == {"id": ["a", "b"], "value": [[2, 3], [4, 5]]}
+    assert out.to_dict(as_series=False) == {"id": ["a", "b"], "value": [[2, 3], [4, 5]]}
 
     out = df.group_by("id", maintain_order=True).agg(pl.lit(1) + pl.lit(2))
-    assert out.to_dict(False) == {"id": ["a", "b"], "literal": [3, 3]}
+    assert out.to_dict(as_series=False) == {"id": ["a", "b"], "literal": [3, 3]}
 
     out = df.group_by("id", maintain_order=True).agg(pl.lit(1) + pl.Series([2, 3]))
-    assert out.to_dict(False) == {"id": ["a", "b"], "literal": [[3, 4], [3, 4]]}
+    assert out.to_dict(as_series=False) == {
+        "id": ["a", "b"],
+        "literal": [[3, 4], [3, 4]],
+    }
 
     out = df.group_by("id", maintain_order=True).agg(
         value=pl.lit(pl.Series([1, 2])) + pl.lit(pl.Series([3, 4]))
     )
-    assert out.to_dict(False) == {"id": ["a", "b"], "value": [[4, 6], [4, 6]]}
+    assert out.to_dict(as_series=False) == {"id": ["a", "b"], "value": [[4, 6], [4, 6]]}
 
 
 @pytest.mark.slow()
@@ -492,7 +502,7 @@ def test_group_by_multiple_column_reference() -> None:
         pl.col("val") + pl.col("val").shift().fill_null(0),
     )
 
-    assert res.sort("gr").to_dict(False) == {
+    assert res.sort("gr").to_dict(as_series=False) == {
         "gr": ["a", "b"],
         "val": [[1, 101, 10100], [20, 2020, 202000]],
     }
@@ -808,7 +818,7 @@ def test_group_by_multiple_keys_one_literal() -> None:
             .agg(pl.col("b").max())
             .sort(["a", "b"])
             .collect(streaming=streaming)
-            .to_dict(False)
+            .to_dict(as_series=False)
             == expected
         )
 
@@ -832,7 +842,7 @@ def test_group_by_list_scalar_11749() -> None:
         df.group_by("group_name").agg(
             (pl.col("measurement").first() == pl.col("measurement")).alias("eq"),
         )
-    ).sort("group_name").to_dict(False) == {
+    ).sort("group_name").to_dict(as_series=False) == {
         "group_name": ["a;b", "c;d"],
         "eq": [[True, True, True, True], [True, False]],
     }

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -113,7 +113,7 @@ def test_group_by_dynamic_startby_5599(tzinfo: ZoneInfo | None) -> None:
         include_boundaries=True,
         label="datapoint",
         start_by="datapoint",
-    ).agg(pl.count()).to_dict(False) == {
+    ).agg(pl.count()).to_dict(as_series=False) == {
         "_lower_boundary": [
             datetime(2022, 12, 16, 0, 0, tzinfo=tzinfo),
             datetime(2022, 12, 16, 0, 31, tzinfo=tzinfo),
@@ -157,7 +157,7 @@ def test_group_by_dynamic_startby_5599(tzinfo: ZoneInfo | None) -> None:
         start_by="monday",
         label="datapoint",
     ).agg([pl.count(), pl.col("day").first().alias("data_day")])
-    assert result.to_dict(False) == {
+    assert result.to_dict(as_series=False) == {
         "_lower_boundary": [
             datetime(2022, 1, 3, 0, 0, tzinfo=tzinfo),
             datetime(2022, 1, 10, 0, 0, tzinfo=tzinfo),
@@ -182,7 +182,7 @@ def test_group_by_dynamic_startby_5599(tzinfo: ZoneInfo | None) -> None:
         start_by="saturday",
         label="datapoint",
     ).agg([pl.count(), pl.col("day").first().alias("data_day")])
-    assert result.to_dict(False) == {
+    assert result.to_dict(as_series=False) == {
         "_lower_boundary": [
             datetime(2022, 1, 1, 0, 0, tzinfo=tzinfo),
             datetime(2022, 1, 8, 0, 0, tzinfo=tzinfo),
@@ -221,7 +221,7 @@ def test_group_by_dynamic_by_monday_and_offset_5444() -> None:
         "date", every="1w", offset="1d", by="label", start_by="monday"
     ).agg(pl.col("value").sum())
 
-    assert result.to_dict(False) == {
+    assert result.to_dict(as_series=False) == {
         "label": ["a", "a", "b", "b"],
         "date": [
             date(2022, 11, 1),
@@ -321,7 +321,7 @@ def test_group_by_dynamic_slice_pushdown() -> None:
         .group_by_dynamic("a", by="b", every="2i")
         .agg((pl.col("c") - pl.col("c").shift(fill_value=0)).sum().alias("c"))
     )
-    assert df.head(2).collect().to_dict(False) == {
+    assert df.head(2).collect().to_dict(as_series=False) == {
         "b": ["a", "a"],
         "a": [0, 2],
         "c": [1, 3],
@@ -336,7 +336,7 @@ def test_rolling_kernels_group_by_dynamic_7548() -> None:
         pl.col("value").min().alias("min_value"),
         pl.col("value").max().alias("max_value"),
         pl.col("value").sum().alias("sum_value"),
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "time": [-1, 0, 1, 2, 3],
         "value": [[0, 1], [0, 1, 2], [1, 2, 3], [2, 3], [3]],
         "min_value": [0, 0, 1, 2, 3],
@@ -619,7 +619,7 @@ def test_groupy_by_dynamic_median_10695() -> None:
         index_column="timestamp",
         every="60s",
         period="3m",
-    ).agg(pl.col("foo").median()).to_dict(False) == {
+    ).agg(pl.col("foo").median()).to_dict(as_series=False) == {
         "timestamp": [
             datetime(2023, 8, 22, 15, 43),
             datetime(2023, 8, 22, 15, 44),

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -32,7 +32,7 @@ def test_struct_logical_is_in() -> None:
 def test_is_in_bool() -> None:
     vals = [True, None]
     df = pl.DataFrame({"A": [True, False, None]})
-    assert df.select(pl.col("A").is_in(vals)).to_dict(False) == {
+    assert df.select(pl.col("A").is_in(vals)).to_dict(as_series=False) == {
         "A": [True, False, None]
     }
 
@@ -67,7 +67,9 @@ def test_is_in_struct() -> None:
         }
     )
 
-    assert df.filter(pl.col("struct_elem").is_in("struct_list")).to_dict(False) == {
+    assert df.filter(pl.col("struct_elem").is_in("struct_list")).to_dict(
+        as_series=False
+    ) == {
         "struct_elem": [{"a": 1, "b": 11}],
         "struct_list": [[{"a": 1, "b": 11}, {"a": 2, "b": 12}, {"a": 3, "b": 13}]],
     }
@@ -106,9 +108,9 @@ def test_is_in_float_list_10764() -> None:
             "n": [3.0, 2.0],
         }
     )
-    assert df.select(pl.col("n").is_in("lst").alias("is_in")).to_dict(False) == {
-        "is_in": [True, False]
-    }
+    assert df.select(pl.col("n").is_in("lst").alias("is_in")).to_dict(
+        as_series=False
+    ) == {"is_in": [True, False]}
 
 
 def test_is_in_df() -> None:

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -29,18 +29,13 @@ def test_semi_anti_join() -> None:
     }
 
     # lazy
-    assert df_a.lazy().join(df_b.lazy(), on="key", how="anti").collect().to_dict(
-        False
-    ) == {
-        "key": [1, 2],
-        "payload": ["f", "i"],
-    }
-    assert df_a.lazy().join(df_b.lazy(), on="key", how="semi").collect().to_dict(
-        False
-    ) == {
-        "key": [3],
-        "payload": [None],
-    }
+    result = df_a.lazy().join(df_b.lazy(), on="key", how="anti").collect()
+    expected_values = {"key": [1, 2], "payload": ["f", "i"]}
+    assert result.to_dict(as_series=False) == expected_values
+
+    result = df_a.lazy().join(df_b.lazy(), on="key", how="semi").collect()
+    expected_values = {"key": [3], "payload": [None]}
+    assert result.to_dict(as_series=False) == expected_values
 
     df_a = pl.DataFrame(
         {"a": [1, 2, 3, 1], "b": ["a", "b", "c", "a"], "payload": [10, 20, 30, 40]}

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -164,13 +164,14 @@ def test_join_asof_mismatched_dtypes() -> None:
 def test_join_asof_floats() -> None:
     df1 = pl.DataFrame({"a": [1.0, 2.0, 3.0], "b": ["lrow1", "lrow2", "lrow3"]})
     df2 = pl.DataFrame({"a": [0.59, 1.49, 2.89], "b": ["rrow1", "rrow2", "rrow3"]})
-    assert df1.join_asof(df2, on=pl.col("a").set_sorted(), strategy="backward").to_dict(
-        False
-    ) == {
+
+    result = df1.join_asof(df2, on=pl.col("a").set_sorted(), strategy="backward")
+    expected = {
         "a": [1.0, 2.0, 3.0],
         "b": ["lrow1", "lrow2", "lrow3"],
         "b_right": ["rrow1", "rrow2", "rrow3"],
     }
+    assert result.to_dict(as_series=False) == expected
 
     # with by argument
     # 5740
@@ -376,9 +377,10 @@ def test_asof_join_by_logical_types() -> None:
         .head(9)
     )
     x = pl.DataFrame({"a": dates, "b": map(float, range(9)), "c": ["1", "2", "3"] * 3})
-    assert x.join_asof(x, on=pl.col("b").set_sorted(), by=["c", "a"]).to_dict(
-        False
-    ) == {
+
+    result = x.join_asof(x, on=pl.col("b").set_sorted(), by=["c", "a"])
+
+    expected = {
         "a": [
             datetime(2022, 1, 1, 0, 0),
             datetime(2022, 1, 1, 2, 0),
@@ -393,6 +395,7 @@ def test_asof_join_by_logical_types() -> None:
         "b": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0],
         "c": ["1", "2", "3", "1", "2", "3", "1", "2", "3"],
     }
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_join_asof_projection_7481() -> None:

--- a/py-polars/tests/unit/operations/test_join_asof.py
+++ b/py-polars/tests/unit/operations/test_join_asof.py
@@ -47,7 +47,7 @@ def test_asof_join_inline_cast_6438() -> None:
 
     assert df_trades.join_asof(
         df_quotes, on=pl.col("time").cast(pl.Datetime("ns")).set_sorted(), by="stock"
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "time": [
             datetime(2020, 1, 1, 9, 1),
             datetime(2020, 1, 1, 9, 1),
@@ -183,7 +183,9 @@ def test_join_asof_floats() -> None:
             "c": ["x", "x", "x", "y", "y", "y", "y"],
         }
     ).with_columns(pl.col("val").alias("b"))
-    assert df1.join_asof(df2, on=pl.col("b").set_sorted(), by="c").to_dict(False) == {
+    assert df1.join_asof(df2, on=pl.col("b").set_sorted(), by="c").to_dict(
+        as_series=False
+    ) == {
         "b": [
             0.0,
             0.8333333333333334,
@@ -227,7 +229,7 @@ def test_join_asof_tolerance() -> None:
 
     assert df_trades.join_asof(
         df_quotes, on="time", by="stock", tolerance="2s"
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "time": [
             datetime(2020, 1, 1, 9, 0, 1),
             datetime(2020, 1, 1, 9, 0, 1),
@@ -241,7 +243,7 @@ def test_join_asof_tolerance() -> None:
 
     assert df_trades.join_asof(
         df_quotes, on="time", by="stock", tolerance="1s"
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "time": [
             datetime(2020, 1, 1, 9, 0, 1),
             datetime(2020, 1, 1, 9, 0, 1),
@@ -285,7 +287,7 @@ def test_join_asof_tolerance_forward() -> None:
 
     assert df_quotes.join_asof(
         df_trades, on="time", by="stock", tolerance="2s", strategy="forward"
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "time": [
             datetime(2020, 1, 1, 9, 0, 0),
             datetime(2020, 1, 1, 9, 0, 2),
@@ -300,7 +302,7 @@ def test_join_asof_tolerance_forward() -> None:
 
     assert df_quotes.join_asof(
         df_trades, on="time", by="stock", tolerance="1s", strategy="forward"
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "time": [
             datetime(2020, 1, 1, 9, 0, 0),
             datetime(2020, 1, 1, 9, 0, 2),
@@ -316,7 +318,7 @@ def test_join_asof_tolerance_forward() -> None:
     # Sanity check that this gives us equi-join
     assert df_quotes.join_asof(
         df_trades, on="time", by="stock", tolerance="0s", strategy="forward"
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "time": [
             datetime(2020, 1, 1, 9, 0, 0),
             datetime(2020, 1, 1, 9, 0, 2),
@@ -351,7 +353,7 @@ def test_join_asof_projection() -> None:
         (
             df1.lazy().join_asof(df2.lazy(), left_on="df1_date", right_on="df2_date")
         ).select([pl.col("df2_date"), "df1_date"])
-    ).collect().to_dict(False) == {
+    ).collect().to_dict(as_series=False) == {
         "df2_date": [None, 20221012, 20221012, 20221012, 20221015],
         "df1_date": [20221011, 20221012, 20221013, 20221014, 20221016],
     }
@@ -359,7 +361,7 @@ def test_join_asof_projection() -> None:
         df1.lazy().join_asof(
             df2.lazy(), by="key", left_on="df1_date", right_on="df2_date"
         )
-    ).select(["df2_date", "df1_date"]).collect().to_dict(False) == {
+    ).select(["df2_date", "df1_date"]).collect().to_dict(as_series=False) == {
         "df2_date": [None, None, None, 20221012, 20221015],
         "df1_date": [20221011, 20221012, 20221013, 20221014, 20221016],
     }
@@ -399,7 +401,10 @@ def test_join_asof_projection_7481() -> None:
 
     assert (
         ldf1.join_asof(ldf2, left_on="a", right_on="b").select("a", "b")
-    ).collect().to_dict(False) == {"a": [1, 2, 2], "b": ["bleft", "bleft", "bleft"]}
+    ).collect().to_dict(as_series=False) == {
+        "a": [1, 2, 2],
+        "b": ["bleft", "bleft", "bleft"],
+    }
 
 
 def test_asof_join_sorted_by_group(capsys: Any) -> None:

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -108,13 +108,13 @@ def test_pivot_categorical_index() -> None:
 
     result = df.pivot(values="B", index=["A"], columns="B", aggregate_function="count")
     expected = {"A": ["Fire", "Water"], "Car": [1, 2], "Ship": [1, None]}
-    assert result.to_dict(False) == expected
+    assert result.to_dict(as_series=False) == expected
 
     # test expression dispatch
     result = df.pivot(
         values="B", index=["A"], columns="B", aggregate_function=pl.count()
     )
-    assert result.to_dict(False) == expected
+    assert result.to_dict(as_series=False) == expected
 
     df = pl.DataFrame(
         {
@@ -133,7 +133,7 @@ def test_pivot_categorical_index() -> None:
         "Car": [1, 2],
         "Ship": [1, None],
     }
-    assert result.to_dict(False) == expected
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_pivot_multiple_values_column_names_5116() -> None:
@@ -169,7 +169,7 @@ def test_pivot_multiple_values_column_names_5116() -> None:
         "x2|c2|C": [8, 7],
         "x2|c2|D": [6, 5],
     }
-    assert result.to_dict(False) == expected
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_pivot_duplicate_names_7731() -> None:
@@ -187,7 +187,7 @@ def test_pivot_duplicate_names_7731() -> None:
         index=cs.float(),
         columns=cs.string(),
         aggregate_function="first",
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "b": [1.5, 2.5],
         "a_c_x": [1, 4],
         "d_c_x": [7, 8],
@@ -222,7 +222,7 @@ def test_pivot_floats() -> None:
         "5.0": [2.0, None, None],
         "7.5": [6.0, None, None],
     }
-    assert result.to_dict(False) == expected
+    assert result.to_dict(as_series=False) == expected
 
     result = df.pivot(
         values="price",
@@ -237,7 +237,7 @@ def test_pivot_floats() -> None:
         "5.0": [2.0, None, None, None],
         "7.5": [None, None, 6.0, None],
     }
-    assert result.to_dict(False) == expected
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_pivot_reinterpret_5907() -> None:
@@ -253,7 +253,7 @@ def test_pivot_reinterpret_5907() -> None:
         index=["A"], values=["C"], columns=["B"], aggregate_function=pl.element().sum()
     )
     expected = {"A": [3, -2], "x": [100, 50], "y": [500, -80]}
-    assert result.to_dict(False) == expected
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_pivot_subclassed_df() -> None:
@@ -277,7 +277,7 @@ def test_pivot_temporal_logical_types() -> None:
     )
     assert df.pivot(
         index="idx", columns="foo", values="value", aggregate_function=None
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "idx": [
             datetime(1977, 1, 1, 0, 0),
             datetime(1978, 1, 1, 0, 0),
@@ -302,7 +302,7 @@ def test_pivot_negative_duration() -> None:
     )
     assert df.pivot(
         index="delta", columns="root", values="value", aggregate_function=None
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "delta": [
             timedelta(days=-2),
             timedelta(days=-1),
@@ -333,7 +333,7 @@ def test_pivot_struct() -> None:
 
     assert df.pivot(
         values="nums", index="id", columns="week", aggregate_function="first"
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "id": ["a", "b", "c"],
         "1": [
             {"num1": 1, "num2": 4},

--- a/py-polars/tests/unit/operations/test_shift.py
+++ b/py-polars/tests/unit/operations/test_shift.py
@@ -59,21 +59,21 @@ def test_shift_expr() -> None:
 
     # use exprs
     out = ldf.select(pl.col("a").shift(n=pl.col("b").min())).collect()
-    assert out.to_dict(False) == {"a": [None, 1, 2, 3, 4]}
+    assert out.to_dict(as_series=False) == {"a": [None, 1, 2, 3, 4]}
 
     out = ldf.select(
         pl.col("a").shift(pl.col("b").min(), fill_value=pl.col("b").max())
     ).collect()
-    assert out.to_dict(False) == {"a": [5, 1, 2, 3, 4]}
+    assert out.to_dict(as_series=False) == {"a": [5, 1, 2, 3, 4]}
 
     # use df method
     out = ldf.shift(pl.lit(3)).collect()
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "a": [None, None, None, 1, 2],
         "b": [None, None, None, 1, 2],
     }
     out = ldf.shift(pl.lit(2), fill_value=pl.col("b").max()).collect()
-    assert out.to_dict(False) == {"a": [5, 5, 1, 2, 3], "b": [5, 5, 1, 2, 3]}
+    assert out.to_dict(as_series=False) == {"a": [5, 5, 1, 2, 3], "b": [5, 5, 1, 2, 3]}
 
 
 def test_shift_categorical() -> None:

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -13,7 +13,7 @@ def test_tail_union() -> None:
         )
         .tail(1)
         .collect()
-    ).to_dict(False) == {"a": [6]}
+    ).to_dict(as_series=False) == {"a": [6]}
 
 
 def test_python_slicing_data_frame() -> None:

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -124,7 +124,7 @@ def test_sort_by_exps_nulls_last() -> None:
         }
     ).with_row_count()
 
-    assert df.sort(pl.col("a") ** 2, nulls_last=True).to_dict(False) == {
+    assert df.sort(pl.col("a") ** 2, nulls_last=True).to_dict(as_series=False) == {
         "row_nr": [0, 4, 2, 1, 3],
         "a": [1, 1, -2, 3, None],
     }
@@ -148,7 +148,7 @@ def test_sort_aggregation_fast_paths() -> None:
         ]
     )
 
-    assert expected.to_dict(False) == {
+    assert expected.to_dict(as_series=False) == {
         "a_max": [3],
         "b_max": [3],
         "c_max": [3],
@@ -190,11 +190,11 @@ def test_sorted_join_and_dtypes() -> None:
         pl.col("a").cast(dt).set_sorted()
     )
 
-    assert df_a.join(df_b, on="a", how="inner").to_dict(False) == {
+    assert df_a.join(df_b, on="a", how="inner").to_dict(as_series=False) == {
         "row_nr": [1, 2, 3, 5],
         "a": [-2, 3, 3, 10],
     }
-    assert df_a.join(df_b, on="a", how="left").to_dict(False) == {
+    assert df_a.join(df_b, on="a", how="left").to_dict(as_series=False) == {
         "row_nr": [0, 1, 2, 3, 4, 5],
         "a": [-5, -2, 3, 3, 9, 10],
     }
@@ -265,7 +265,7 @@ def test_arg_sort_rank_nans() -> None:
             ]
         )
         .select(["rank", "arg_sort"])
-    ).to_dict(False) == {"rank": [1.0, 2.0], "arg_sort": [0, 1]}
+    ).to_dict(as_series=False) == {"rank": [1.0, 2.0], "arg_sort": [0, 1]}
 
 
 def test_top_k() -> None:
@@ -335,7 +335,7 @@ def test_sorted_flag_unset_by_arithmetic_4937() -> None:
             (pl.col("price") * pl.col("mask")).max().alias("pmax"),
             (pl.col("price") * pl.col("mask")).min().alias("pmin"),
         ]
-    ).sort("ts").to_dict(False) == {
+    ).sort("ts").to_dict(as_series=False) == {
         "ts": [0, 1],
         "pmax": [3.6, 3.5],
         "pmin": [3.6, 0.0],
@@ -350,7 +350,7 @@ def test_unset_sorted_flag_after_extend() -> None:
     assert not df1["Add"].flags["SORTED_ASC"]
     df = df1.group_by("Add").agg([pl.col("Batch").min()]).sort("Add")
     assert df["Add"].flags["SORTED_ASC"]
-    assert df.to_dict(False) == {"Add": [37, 41], "Batch": [48, 49]}
+    assert df.to_dict(as_series=False) == {"Add": [37, 41], "Batch": [48, 49]}
 
 
 def test_set_sorted_schema() -> None:
@@ -367,7 +367,7 @@ def test_sort_slice_fast_path_5245() -> None:
         }
     ).lazy()
 
-    assert df.sort("foo").limit(1).select("foo").collect().to_dict(False) == {
+    assert df.sort("foo").limit(1).select("foo").collect().to_dict(as_series=False) == {
         "foo": ["a"]
     }
 
@@ -428,7 +428,7 @@ def test_sort_by_in_over_5499() -> None:
             pl.col("idx").sort_by("a").over("group").alias("sorted_1"),
             pl.col("idx").shift(1).sort_by("a").over("group").alias("sorted_2"),
         ]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "sorted_1": [0, 2, 1, 4, 5, 3],
         "sorted_2": [None, 1, 0, 3, 4, None],
     }
@@ -453,7 +453,7 @@ def test_merge_sorted() -> None:
     )
     out = df_a.merge_sorted(df_b, key="range")
     assert out["range"].is_sorted()
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "row_nr": [0, 0, 1, 2, 10, 3, 4, 20, 5, 6, 30, 7, 8, 40, 9, 10, 50, 11],
         "range": [
             datetime(2022, 1, 1, 0, 0),
@@ -513,7 +513,7 @@ def test_sort_args() -> None:
 
 def test_sort_type_coercion_6892() -> None:
     df = pl.DataFrame({"a": [2, 1], "b": [2, 3]})
-    assert df.lazy().sort(pl.col("a") // 2).collect().to_dict(False) == {
+    assert df.lazy().sort(pl.col("a") // 2).collect().to_dict(as_series=False) == {
         "a": [1, 2],
         "b": [3, 2],
     }
@@ -557,18 +557,18 @@ def test_sort_by_logical() -> None:
     )
     assert df.group_by("name").agg([pl.col("num").sort_by(["dt1", "dt2"])]).sort(
         "name"
-    ).to_dict(False) == {"name": ["a", "b"], "num": [[3, 1], [4]]}
+    ).to_dict(as_series=False) == {"name": ["a", "b"], "num": [[3, 1], [4]]}
 
 
 def test_limit_larger_than_sort() -> None:
-    assert pl.LazyFrame({"a": [1]}).sort("a").limit(30).collect().to_dict(False) == {
-        "a": [1]
-    }
+    assert pl.LazyFrame({"a": [1]}).sort("a").limit(30).collect().to_dict(
+        as_series=False
+    ) == {"a": [1]}
 
 
 def test_sort_by_struct() -> None:
     df = pl.Series([{"a": 300}, {"a": 20}, {"a": 55}]).to_frame("st").with_row_count()
-    assert df.sort("st").to_dict(False) == {
+    assert df.sort("st").to_dict(as_series=False) == {
         "row_nr": [1, 2, 0],
         "st": [{"a": 20}, {"a": 55}, {"a": 300}],
     }
@@ -660,7 +660,7 @@ def test_sort_top_k_fast_path() -> None:
         }
     )
     # this triggers fast path as head is equal to n-rows
-    assert df.lazy().sort("b").head(3).collect().to_dict(False) == {
+    assert df.lazy().sort("b").head(3).collect().to_dict(as_series=False) == {
         "a": [None, 2, 1],
         "b": [4.0, 5.0, 6.0],
         "c": ["b", "c", "a"],
@@ -714,4 +714,4 @@ def test_sort_by_11653() -> None:
         .sort_by("other")
         .sum()
         .alias("sort_by"),
-    ).sort("id").to_dict(False) == {"id": [0, 1], "sort_by": [1.0, 1.0]}
+    ).sort("id").to_dict(as_series=False) == {"id": [0, 1], "sort_by": [1.0, 1.0]}

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -24,7 +24,7 @@ def test_corr() -> None:
 def test_hist() -> None:
     a = pl.Series("a", [1, 3, 8, 8, 2, 1, 3])
     assert (
-        str(a.hist(bin_count=4).to_dict(False))
+        str(a.hist(bin_count=4).to_dict(as_series=False))
         == "{'break_point': [0.0, 2.25, 4.5, 6.75, inf], 'category': ['(-inf, 0.0]', '(0.0, 2.25]', '(2.25, 4.5]', '(4.5, 6.75]', '(6.75, inf]'], 'a_count': [0, 3, 2, 0, 2]}"
     )
 
@@ -44,4 +44,6 @@ def test_median_quantile_duration() -> None:
 def test_correlation_cast_supertype() -> None:
     df = pl.DataFrame({"a": [1, 8, 3], "b": [4.0, 5.0, 2.0]})
     df = df.with_columns(pl.col("b"))
-    assert df.select(pl.corr("a", "b")).to_dict(False) == {"a": [0.5447047794019223]}
+    assert df.select(pl.corr("a", "b")).to_dict(as_series=False) == {
+        "a": [0.5447047794019223]
+    }

--- a/py-polars/tests/unit/operations/test_unique.py
+++ b/py-polars/tests/unit/operations/test_unique.py
@@ -31,7 +31,7 @@ def test_unique_predicate_pd() -> None:
 def test_unique_on_list_df() -> None:
     assert pl.DataFrame(
         {"a": [1, 2, 3, 4, 4], "b": [[1, 1], [2], [3], [4, 4], [4, 4]]}
-    ).unique(maintain_order=True).to_dict(False) == {
+    ).unique(maintain_order=True).to_dict(as_series=False) == {
         "a": [1, 2, 3, 4],
         "b": [[1, 1], [2], [3], [4, 4]],
     }

--- a/py-polars/tests/unit/operations/test_value_counts.py
+++ b/py-polars/tests/unit/operations/test_value_counts.py
@@ -47,7 +47,7 @@ def test_value_counts_expr() -> None:
 
     assert df.group_by("session").agg(
         pl.col("id").value_counts(sort=True).first()
-    ).to_dict(False) == {"session": [1], "id": [{"id": 2, "counts": 2}]}
+    ).to_dict(as_series=False) == {"session": [1], "id": [{"id": 2, "counts": 2}]}
 
 
 def test_value_counts_duplicate_name() -> None:

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -373,7 +373,7 @@ def test_cached_windows_sync_8803() -> None:
             b=pl.col("is_valid").sum().gt(0).over("id"),
         )
         .sum()
-    ).to_dict(False) == {"id": [28], "is_valid": [1], "a": [3], "b": [3]}
+    ).to_dict(as_series=False) == {"id": [28], "is_valid": [1], "a": [3], "b": [3]}
 
 
 def test_window_filtered_aggregation() -> None:
@@ -423,4 +423,4 @@ def test_window_10417() -> None:
             pl.col("b") - pl.col("b").mean().over("a"),
             pl.col("c") - pl.col("c").mean().over("a"),
         ]
-    ).collect().to_dict(False) == {"a": [1], "b": [0.0], "c": [0.0]}
+    ).collect().to_dict(as_series=False) == {"a": [1], "b": [0.0], "c": [0.0]}

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1007,7 +1007,7 @@ def test_fill_null() -> None:
 
     assert df.fill_null(0, matches_supertype=False).fill_null("bar").fill_null(
         False
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "i32": [1, 2, None],
         "i64": [1, 2, 0],
         "f32": [1.0, 2.0, None],
@@ -1018,7 +1018,7 @@ def test_fill_null() -> None:
 
     assert df.fill_null(0, matches_supertype=True).fill_null("bar").fill_null(
         False
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "i32": [1, 2, 0],
         "i64": [1, 2, 0],
         "f32": [1.0, 2.0, 0.0],
@@ -1037,7 +1037,7 @@ def test_fill_null() -> None:
         ]
     ).fill_null(3)
 
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "a": [1, 3, 2, 3],
         "u8": [1, 3, 2, 3],
         "u16": [1, 3, 2, 3],

--- a/py-polars/tests/unit/sql/test_sql.py
+++ b/py-polars/tests/unit/sql/test_sql.py
@@ -99,7 +99,7 @@ def test_sql_any_all() -> None:
         eager=True,
     )
 
-    assert res.to_dict(False) == {
+    assert res.to_dict(as_series=False) == {
         "All Geq": [0, 0, 0, 0, 1, 1],
         "All G": [0, 0, 0, 0, 0, 1],
         "All L": [1, 0, 0, 0, 0, 0],
@@ -136,7 +136,7 @@ def test_sql_distinct() -> None:
         ORDER BY two_a ASC, half_b DESC
         """,
     )
-    assert res2.to_dict(False) == {
+    assert res2.to_dict(as_series=False) == {
         "two_a": [2, 2, 4, 6],
         "half_b": [1, 0, 2, 3],
     }
@@ -199,7 +199,7 @@ def test_sql_equal_not_equal() -> None:
     assert out.select(cs.contains("_aware").null_count().sum()).row(0) == (0, 0, 0)
     assert out.select(cs.contains("_unaware").null_count().sum()).row(0) == (2, 2, 2)
 
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "1_eq_unaware": [True, None, True, False, None],
         "2_neq_unaware": [False, None, False, True, None],
         "3_neq_unaware": [False, None, False, True, None],
@@ -474,7 +474,7 @@ def test_sql_group_by(foods_ipc_path: Path) -> None:
         ORDER BY n, category DESC
         """
     )
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "category": ["vegetables", "fruit", "seafood"],
         "n": [7, 7, 8],
         "calories": [45, 130, 200],
@@ -502,7 +502,7 @@ def test_sql_group_by(foods_ipc_path: Path) -> None:
         HAVING n_dist_attr > 1
         """
     )
-    assert out.to_dict(False) == {"grp": ["c"], "n_dist_attr": [2]}
+    assert out.to_dict(as_series=False) == {"grp": ["c"], "n_dist_attr": [2]}
 
 
 def test_sql_left() -> None:
@@ -512,7 +512,7 @@ def test_sql_left() -> None:
         'SELECT scol, LEFT(scol,2) AS "scol:left2" FROM df',
     ).collect()
 
-    assert res.to_dict(False) == {
+    assert res.to_dict(as_series=False) == {
         "scol": ["abcde", "abc", "a", None],
         "scol:left2": ["ab", "ab", "a", None],
     }
@@ -612,7 +612,7 @@ def test_sql_join_inner(foods_ipc_path: Path, join_clause: str) -> None:
         LIMIT 2
         """
     )
-    assert out.collect().to_dict(False) == {
+    assert out.collect().to_dict(as_series=False) == {
         "category": ["vegetables", "vegetables"],
         "calories": [45, 20],
         "fats_g": [0.5, 0.0],
@@ -836,7 +836,7 @@ def test_sql_string_case() -> None:
             """
         ).collect()
 
-        assert res.to_dict(False) == {
+        assert res.to_dict(as_series=False) == {
             "words": ["Test SOME words"],
             "cap": ["Test Some Words"],
             "upper": ["TEST SOME WORDS"],
@@ -858,7 +858,7 @@ def test_sql_string_lengths() -> None:
             """
         ).collect()
 
-    assert res.to_dict(False) == {
+    assert res.to_dict(as_series=False) == {
         "words": ["Café", None, "東京"],
         "n_chars": [4, None, 2],
         "n_bytes": [5, None, 6],
@@ -885,7 +885,7 @@ def test_sql_substr() -> None:
             """
         ).collect()
 
-    assert res.to_dict(False) == {
+    assert res.to_dict(as_series=False) == {
         "s1": ["bcdefg", "bcde", "bc", None],
         "s2": ["cdefg", "cde", "c", None],
         "s3": ["defg", "de", "", None],
@@ -904,7 +904,7 @@ def test_sql_trim(foods_ipc_path: Path) -> None:
         """,
         eager=True,
     )
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "new_category": ["seafood", "ruit", "egetables", "eat"]
     }
 
@@ -993,7 +993,7 @@ def test_sql_nullif_coalesce(foods_ipc_path: Path) -> None:
         eager=True,
     )
 
-    assert res.to_dict(False) == {
+    assert res.to_dict(as_series=False) == {
         "coal": [1, 4, 2, 3, None, 4],
         "nullif x_y": [1, None, 2, None, None, 4],
         "nullif y_z": [5, None, None, None, None, 2],
@@ -1018,7 +1018,7 @@ def test_sql_order_by(foods_ipc_path: Path) -> None:
         """,
         eager=True,
     )
-    assert order_by_distinct_res.to_dict(False) == {
+    assert order_by_distinct_res.to_dict(as_series=False) == {
         "category": ["vegetables", "seafood", "meat", "fruit"]
     }
 
@@ -1031,7 +1031,7 @@ def test_sql_order_by(foods_ipc_path: Path) -> None:
         """,
         eager=True,
     )
-    assert order_by_group_by_res.to_dict(False) == {
+    assert order_by_group_by_res.to_dict(as_series=False) == {
         "category": ["vegetables", "seafood", "meat", "fruit"]
     }
 
@@ -1044,7 +1044,7 @@ def test_sql_order_by(foods_ipc_path: Path) -> None:
         """,
         eager=True,
     )
-    assert order_by_constructed_group_by_res.to_dict(False) == {
+    assert order_by_constructed_group_by_res.to_dict(as_series=False) == {
         "category": ["seafood", "meat", "fruit", "vegetables"],
         "summed_calories": [1250, 540, 410, 192],
     }
@@ -1058,7 +1058,7 @@ def test_sql_order_by(foods_ipc_path: Path) -> None:
         """,
         eager=True,
     )
-    assert order_by_unselected_res.to_dict(False) == {
+    assert order_by_unselected_res.to_dict(as_series=False) == {
         "summed_calories": [1250, 540, 410, 192],
     }
 
@@ -1072,7 +1072,7 @@ def test_sql_order_by(foods_ipc_path: Path) -> None:
         """,
         eager=True,
     )
-    assert order_by_unselected_nums_res.to_dict(False) == {
+    assert order_by_unselected_nums_res.to_dict(as_series=False) == {
         "x": [3, 2, 1],
         "y_alias": [2, 3, 4],
     }
@@ -1087,7 +1087,7 @@ def test_sql_order_by(foods_ipc_path: Path) -> None:
         """,
         eager=True,
     )
-    assert order_by_wildcard_res.to_dict(False) == {
+    assert order_by_wildcard_res.to_dict(as_series=False) == {
         "x": [3, 2, 1],
         "y": [2, 3, 4],
         "y_alias": [2, 3, 4],
@@ -1102,7 +1102,7 @@ def test_sql_order_by(foods_ipc_path: Path) -> None:
         """,
         eager=True,
     )
-    assert order_by_qualified_wildcard_res.to_dict(False) == {
+    assert order_by_qualified_wildcard_res.to_dict(as_series=False) == {
         "x": [3, 2, 1],
         "y": [2, 3, 4],
     }
@@ -1116,7 +1116,7 @@ def test_sql_order_by(foods_ipc_path: Path) -> None:
         """,
         eager=True,
     )
-    assert order_by_exclude_res.to_dict(False) == {
+    assert order_by_exclude_res.to_dict(as_series=False) == {
         "x": [3, 2, 1],
     }
 
@@ -1129,7 +1129,7 @@ def test_sql_order_by(foods_ipc_path: Path) -> None:
         """,
         eager=True,
     )
-    assert order_by_qualified_exclude_res.to_dict(False) == {
+    assert order_by_qualified_exclude_res.to_dict(as_series=False) == {
         "x": [3, 2, 1],
     }
 
@@ -1142,7 +1142,7 @@ def test_sql_order_by(foods_ipc_path: Path) -> None:
         """,
         eager=True,
     )
-    assert order_by_expression_res.to_dict(False) == {
+    assert order_by_expression_res.to_dict(as_series=False) == {
         "modded": [1, 1, 2],
     }
 
@@ -1201,7 +1201,7 @@ def test_sql_unary_ops_8890(match_float: bool) -> None:
             FROM df WHERE a IN {in_values}
             """
         )
-        assert res.collect().to_dict(False) == {
+        assert res.collect().to_dict(as_series=False) == {
             "a": [-1, 2],
             "b": ["x", "z"],
             "c": [-3, -3],
@@ -1223,7 +1223,7 @@ def test_sql_in_no_ops_11946() -> None:
     out = ctx.execute(
         "SELECT * FROM frame_data WHERE i1 in (1, 3)", eager=False
     ).collect()
-    assert out.to_dict(False) == {"i1": [1, 3]}
+    assert out.to_dict(as_series=False) == {"i1": [1, 3]}
 
 
 def test_sql_date() -> None:

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -41,7 +41,7 @@ def test_streaming_categoricals_5921() -> None:
 
     for out in [out_eager, out_lazy]:
         assert out.dtypes == [pl.Categorical, pl.Int64]
-        assert out.to_dict(False) == {"X": ["a", "b"], "Y": [2, 1]}
+        assert out.to_dict(as_series=False) == {"X": ["a", "b"], "Y": [2, 1]}
 
 
 def test_streaming_block_on_literals_6054() -> None:
@@ -50,7 +50,7 @@ def test_streaming_block_on_literals_6054() -> None:
 
     assert df.lazy().with_columns(s).group_by("col_1").agg(pl.all().first()).collect(
         streaming=True
-    ).sort("col_1").to_dict(False) == {"col_1": [0, 1], "col_2": [0, 5]}
+    ).sort("col_1").to_dict(as_series=False) == {"col_1": [0, 1], "col_2": [0, 5]}
 
 
 def test_streaming_streamable_functions(monkeypatch: Any, capfd: Any) -> None:
@@ -63,7 +63,10 @@ def test_streaming_streamable_functions(monkeypatch: Any, capfd: Any) -> None:
             schema={"a": pl.Int64, "b": pl.Int64},
             streamable=True,
         )
-    ).collect(streaming=True).to_dict(False) == {"a": [1, 2, 3], "b": [1, 2, 3]}
+    ).collect(streaming=True).to_dict(as_series=False) == {
+        "a": [1, 2, 3],
+        "b": [1, 2, 3],
+    }
 
     (_, err) = capfd.readouterr()
     assert "df -> function -> ordered_sink" in err
@@ -94,19 +97,19 @@ def test_streaming_literal_expansion() -> None:
         z=pl.col("z"),
     )
 
-    assert q.collect(streaming=True).to_dict(False) == {
+    assert q.collect(streaming=True).to_dict(as_series=False) == {
         "x": ["constant", "constant"],
         "y": ["a", "b"],
         "z": [1, 2],
     }
     assert q.group_by(["x", "y"]).agg(pl.mean("z")).sort("y").collect(
         streaming=True
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "x": ["constant", "constant"],
         "y": ["a", "b"],
         "z": [1.0, 2.0],
     }
-    assert q.group_by(["x"]).agg(pl.mean("z")).collect().to_dict(False) == {
+    assert q.group_by(["x"]).agg(pl.mean("z")).collect().to_dict(as_series=False) == {
         "x": ["constant"],
         "z": [1.5],
     }
@@ -190,7 +193,10 @@ def test_streaming_sortedness_propagation_9494() -> None:
         .group_by_dynamic("when", every="1mo")
         .agg(pl.col("what").sum())
         .collect(streaming=True)
-    ).to_dict(False) == {"when": [date(2023, 5, 1), date(2023, 6, 1)], "what": [3, 3]}
+    ).to_dict(as_series=False) == {
+        "when": [date(2023, 5, 1), date(2023, 6, 1)],
+        "what": [3, 3],
+    }
 
 
 @pytest.mark.write_disk()
@@ -272,13 +278,13 @@ def test_streaming_empty_df() -> None:
         .collect(streaming=True)
     )
 
-    assert result.to_dict(False) == {"a": [], "b": [], "b_right": []}
+    assert result.to_dict(as_series=False) == {"a": [], "b": [], "b_right": []}
 
 
 def test_streaming_duplicate_cols_5537() -> None:
     assert pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]}).lazy().with_columns(
         [(pl.col("a") * 2).alias("foo"), (pl.col("a") * 3)]
-    ).collect(streaming=True).to_dict(False) == {
+    ).collect(streaming=True).to_dict(as_series=False) == {
         "a": [3, 6, 9],
         "b": [1, 2, 3],
         "foo": [2, 4, 6],
@@ -292,7 +298,9 @@ def test_null_sum_streaming_10455() -> None:
             "y": [None] * 10,
         }
     )
-    assert df.lazy().group_by("x").sum().collect(streaming=True).to_dict(False) == {
+    assert df.lazy().group_by("x").sum().collect(streaming=True).to_dict(
+        as_series=False
+    ) == {
         "x": [1],
         "y": [0.0],
     }
@@ -323,4 +331,4 @@ def test_streaming_11219() -> None:
 
     assert lf.with_context([lf_other, lf_other2]).select(
         pl.col("b") + pl.col("c").first()
-    ).collect(streaming=True).to_dict(False) == {"b": ["afoo", "cfoo", None]}
+    ).collect(streaming=True).to_dict(as_series=False) == {"b": ["afoo", "cfoo", None]}

--- a/py-polars/tests/unit/streaming/test_streaming_categoricals.py
+++ b/py-polars/tests/unit/streaming/test_streaming_categoricals.py
@@ -8,7 +8,7 @@ def test_streaming_nested_categorical() -> None:
         .group_by("numbers")
         .agg(pl.col("cat").first())
         .sort("numbers")
-    ).collect(streaming=True).to_dict(False) == {
+    ).collect(streaming=True).to_dict(as_series=False) == {
         "numbers": [1, 2],
         "cat": [["str"], ["bar"]],
     }

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -29,7 +29,10 @@ def test_streaming_group_by_sorted_fast_path_nulls_10273() -> None:
         .agg(pl.count())
         .collect(streaming=True)
         .sort("x")
-    ).to_dict(False) == {"x": [None, 0, 1, 2, 3], "count": [100, 100, 100, 100, 100]}
+    ).to_dict(as_series=False) == {
+        "x": [None, 0, 1, 2, 3],
+        "count": [100, 100, 100, 100, 100],
+    }
 
 
 def test_streaming_group_by_types() -> None:
@@ -87,7 +90,7 @@ def test_streaming_group_by_types() -> None:
             "date_max": pl.Date,
         }
 
-        assert out.to_dict(False) == {
+        assert out.to_dict(as_series=False) == {
             "str_first": ["bob"],
             "str_last": ["foo"],
             "str_mean": [None],
@@ -288,7 +291,7 @@ def test_streaming_group_by_struct_key() -> None:
     df1 = df.lazy().with_columns(pl.struct(["A", "C"]).alias("tuples"))
     assert df1.group_by("tuples").agg(pl.count(), pl.col("B").first()).sort(
         "B"
-    ).collect(streaming=True).to_dict(False) == {
+    ).collect(streaming=True).to_dict(as_series=False) == {
         "tuples": [{"A": 3, "C": 4}, {"A": 1, "C": 2}, {"A": 2, "C": 3}],
         "count": [1, 1, 2],
         "B": ["apple", "google", "ms"],
@@ -346,7 +349,7 @@ def test_streaming_group_by_categorical_aggregate() -> None:
             .collect(streaming=True)
         )
 
-    assert out.sort("b").to_dict(False) == {
+    assert out.sort("b").to_dict(as_series=False) == {
         "a": ["a", "a", "b", "b", "c", "c", None, None],
         "b": [
             date(2023, 4, 28),
@@ -369,7 +372,7 @@ def test_streaming_group_by_list_9758() -> None:
         .group_by("a")
         .first()
         .collect(streaming=True)
-        .to_dict(False)
+        .to_dict(as_series=False)
         == payload
     )
 
@@ -404,7 +407,7 @@ def test_group_by_min_max_string_type() -> None:
             .agg([pl.min("b").alias("min"), pl.max("b").alias("max")])
             .collect(streaming=streaming)
             .sort("a")
-            .to_dict(False)
+            .to_dict(as_series=False)
             == expected
         )
 
@@ -418,7 +421,7 @@ def test_streaming_group_by_literal(literal: Any) -> None:
             pl.col("a").count().alias("a_count"),
             pl.col("a").sum().alias("a_sum"),
         ]
-    ).collect(streaming=True).to_dict(False) == {
+    ).collect(streaming=True).to_dict(as_series=False) == {
         "literal": [literal],
         "a_count": [20],
         "a_sum": [190],

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -76,7 +76,7 @@ def test_sink_parquet_10115(tmp_path: Path) -> None:
         .sink_parquet(out_path)  #
     )
 
-    assert pl.read_parquet(out_path).to_dict(False) == {
+    assert pl.read_parquet(out_path).to_dict(as_series=False) == {
         "x": [1],
         "y": ["foo"],
         "z": ["_"],
@@ -173,7 +173,7 @@ def test_sink_csv_exception_for_quote(value: str) -> None:
 def test_scan_csv_only_header_10792(io_files_path: Path) -> None:
     foods_file_path = io_files_path / "only_header.csv"
     df = pl.scan_csv(foods_file_path).collect(streaming=True)
-    assert df.to_dict(False) == {"Name": [], "Address": []}
+    assert df.to_dict(as_series=False) == {"Name": [], "Address": []}
 
 
 def test_scan_empty_csv_10818(io_files_path: Path) -> None:

--- a/py-polars/tests/unit/streaming/test_streaming_sort.py
+++ b/py-polars/tests/unit/streaming/test_streaming_sort.py
@@ -105,7 +105,7 @@ def test_out_of_core_sort_9503(monkeypatch: Any) -> None:
     df = q.collect(streaming=True)
     assert df.shape == (1_000_000, 2)
     assert df["column_0"].flags["SORTED_ASC"]
-    assert df.head(20).to_dict(False) == {
+    assert df.head(20).to_dict(as_series=False) == {
         "column_0": [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         "column_1": [
             242,

--- a/py-polars/tests/unit/test_cse.py
+++ b/py-polars/tests/unit/test_cse.py
@@ -412,7 +412,7 @@ def test_cse_quantile_10815() -> None:
         ),
     )
     assert "__POLARS_CSE" not in q.explain()
-    assert q.collect().to_dict(False) == {
+    assert q.collect().to_dict(as_series=False) == {
         "a_3": [0.40689473946662197],
         "b_3": [0.6145786693120769],
         "a_1": [0.16650805109739197],
@@ -435,7 +435,7 @@ def test_cse_nan_10824() -> None:
                 .lazy()
                 .select(magic)
                 .collect(comm_subexpr_elim=True)
-            ).to_dict(False)
+            ).to_dict(as_series=False)
         )
         == "{'literal': [nan]}"
     )
@@ -473,7 +473,7 @@ def test_cse_count_in_group_by() -> None:
     )
 
     assert "POLARS_CSER" not in q.explain()
-    assert q.collect().sort("a").to_dict(False) == {
+    assert q.collect().sort("a").to_dict(as_series=False) == {
         "a": [1, 2],
         "b": [[1], []],
         "c": [[40], []],
@@ -513,7 +513,7 @@ def test_no_cse_in_with_context() -> None:
                 pl.col("date_start").search_sorted("timestamp") - 1
             ),
         )
-    ).collect().to_dict(False) == {
+    ).collect().to_dict(as_series=False) == {
         "date_start": [
             datetime(2022, 12, 31, 0, 0),
             datetime(2023, 1, 2, 0, 0),
@@ -533,7 +533,7 @@ def test_cse_slice_11594() -> None:
 
     assert "__POLARS_CSE" in q.explain(comm_subexpr_elim=True)
 
-    assert q.collect(comm_subexpr_elim=True).to_dict(False) == {
+    assert q.collect(comm_subexpr_elim=True).to_dict(as_series=False) == {
         "1": [2, 1, 2, 1, 2],
         "2": [2, 1, 2, 1, 2],
     }
@@ -545,7 +545,7 @@ def test_cse_slice_11594() -> None:
 
     assert "__POLARS_CSE" in q.explain(comm_subexpr_elim=True)
 
-    assert q.collect(comm_subexpr_elim=True).to_dict(False) == {
+    assert q.collect(comm_subexpr_elim=True).to_dict(as_series=False) == {
         "1": [2, 1, 2, 1, 2],
         "2": [1, 2, 1, 2, 1],
     }
@@ -571,7 +571,7 @@ def test_cse_is_in_11489() -> None:
         .otherwise(None)
         .alias("val")
     )
-    assert df.select("cond", any_cond, val).collect().to_dict(False) == {
+    assert df.select("cond", any_cond, val).collect().to_dict(as_series=False) == {
         "cond": [1, 2, 3, 2, 1],
         "any_cond": [False, True, True, True, False],
         "val": [0.0, 1.0, 1.0, 1.0, 0.0],
@@ -588,7 +588,7 @@ def test_cse_11958() -> None:
 
     q = df.select(vector_losses)
     assert "__POLARS_CSE" in q.explain(comm_subexpr_elim=True)
-    assert q.collect(comm_subexpr_elim=True).to_dict(False) == {
+    assert q.collect(comm_subexpr_elim=True).to_dict(as_series=False) == {
         "diff1": [None, 10, 10, 10, 10],
         "diff2": [None, None, 20, 20, 20],
         "diff3": [None, None, None, 30, 30],

--- a/py-polars/tests/unit/test_expr_multi_cols.py
+++ b/py-polars/tests/unit/test_expr_multi_cols.py
@@ -99,7 +99,7 @@ def test_regex_in_cols() -> None:
         "matched_val2": ["A", "B", "C"],
     }
     assert df.select(pl.col("^col.*$", "val1").name.prefix("matched_")).to_dict(
-        False
+        as_series=False
     ) == {
         "matched_col1": [1, 2, 3],
         "matched_col2": [4, 5, 6],

--- a/py-polars/tests/unit/test_expr_multi_cols.py
+++ b/py-polars/tests/unit/test_expr_multi_cols.py
@@ -23,7 +23,7 @@ def test_fold_regex_expand() -> None:
         pl.fold(
             acc=pl.lit(0), function=lambda acc, x: acc + x, exprs=pl.col("^y_.*$")
         ).alias("y_sum"),
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "x": [0, 1, 2],
         "y_1": [1.1, 2.2, 3.3],
         "y_2": [1.0, 2.5, 3.5],
@@ -41,13 +41,13 @@ def test_arg_sort_argument_expansion() -> None:
     )
     assert df.select(
         pl.col("col1").sort_by(pl.col("sort_order").arg_sort()).name.suffix("_suffix")
-    ).to_dict(False) == {"col1_suffix": [3, 2, 1]}
+    ).to_dict(as_series=False) == {"col1_suffix": [3, 2, 1]}
     assert df.select(
         pl.col("^col.*$").sort_by(pl.col("sort_order")).arg_sort()
-    ).to_dict(False) == {"col1": [2, 1, 0], "col2": [2, 1, 0]}
+    ).to_dict(as_series=False) == {"col1": [2, 1, 0], "col2": [2, 1, 0]}
     assert df.select(
         pl.all().exclude("sort_order").sort_by(pl.col("sort_order")).arg_sort()
-    ).to_dict(False) == {"col1": [2, 1, 0], "col2": [2, 1, 0]}
+    ).to_dict(as_series=False) == {"col1": [2, 1, 0], "col2": [2, 1, 0]}
 
 
 def test_multiple_columns_length_9137() -> None:
@@ -61,7 +61,9 @@ def test_multiple_columns_length_9137() -> None:
     # list is larger than groups
     cmp_list = ["a", "b", "c"]
 
-    assert df.group_by("a").agg(pl.col("b").is_in(cmp_list)).to_dict(False) == {
+    assert df.group_by("a").agg(pl.col("b").is_in(cmp_list)).to_dict(
+        as_series=False
+    ) == {
         "a": [1],
         "b": [[True, False]],
     }
@@ -77,14 +79,16 @@ def test_regex_in_cols() -> None:
         }
     )
 
-    assert df.select(pl.col("^col.*$").name.prefix("matched_")).to_dict(False) == {
+    assert df.select(pl.col("^col.*$").name.prefix("matched_")).to_dict(
+        as_series=False
+    ) == {
         "matched_col1": [1, 2, 3],
         "matched_col2": [4, 5, 6],
     }
 
     assert df.with_columns(
         pl.col("^col.*$", "^val.*$").name.prefix("matched_")
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "col1": [1, 2, 3],
         "col2": [4, 5, 6],
         "val1": ["a", "b", "c"],
@@ -102,7 +106,9 @@ def test_regex_in_cols() -> None:
         "matched_val1": ["a", "b", "c"],
     }
 
-    assert df.select(pl.col("^col.*$", "val1").exclude("col2")).to_dict(False) == {
+    assert df.select(pl.col("^col.*$", "val1").exclude("col2")).to_dict(
+        as_series=False
+    ) == {
         "col1": [1, 2, 3],
         "val1": ["a", "b", "c"],
     }

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -242,7 +242,7 @@ def test_list_eval_expression() -> None:
             pl.concat_list(["a", "b"])
             .list.eval(pl.first().rank(), parallel=parallel)
             .alias("rank")
-        ).to_dict(False) == {
+        ).to_dict(as_series=False) == {
             "a": [1, 8, 3],
             "b": [4, 5, 2],
             "rank": [[1.0, 2.0], [2.0, 1.0], [2.0, 1.0]],
@@ -256,7 +256,10 @@ def test_list_eval_expression() -> None:
 def test_null_count_expr() -> None:
     df = pl.DataFrame({"key": ["a", "b", "b", "a"], "val": [1, 2, None, 1]})
 
-    assert df.select([pl.all().null_count()]).to_dict(False) == {"key": [0], "val": [1]}
+    assert df.select([pl.all().null_count()]).to_dict(as_series=False) == {
+        "key": [0],
+        "val": [1],
+    }
 
 
 def test_pos_neg() -> None:
@@ -268,7 +271,7 @@ def test_pos_neg() -> None:
     ).with_columns(-pl.col("x"), +pl.col("y"), -pl.lit(1))
 
     # #11149: ensure that we preserve the output name (where available)
-    assert df.to_dict(False) == {
+    assert df.to_dict(as_series=False) == {
         "x": [-3, -2, -1],
         "y": [6, 7, 8],
         "literal": [-1, -1, -1],
@@ -331,7 +334,7 @@ def test_arr_contains() -> None:
     )
     assert df_groups.lazy().filter(
         pl.col("str_list").list.contains("cat")
-    ).collect().to_dict(False) == {
+    ).collect().to_dict(as_series=False) == {
         "str_list": [["cat", "mouse", "dog"], ["dog", "mouse", "cat"]]
     }
 
@@ -367,7 +370,7 @@ def test_rank_so_4109() -> None:
             pl.col("rank").rank(method="dense").alias("dense"),
             pl.col("rank").rank(method="average").alias("average"),
         ]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "id": [1, 2, 3, 4],
         "original": [[None, 2, 3, 4], [1, 2, 3, 4], [None, 1, 3, 4], [None, 1, 3, 4]],
         "dense": [[None, 1, 2, 3], [1, 2, 3, 4], [None, 1, 2, 3], [None, 1, 2, 3]],
@@ -964,18 +967,26 @@ def test_operators_vs_expressions() -> None:
 
 def test_head() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
-    assert df.select(pl.col("a").head(0)).to_dict(False) == {"a": []}
-    assert df.select(pl.col("a").head(3)).to_dict(False) == {"a": [1, 2, 3]}
-    assert df.select(pl.col("a").head(10)).to_dict(False) == {"a": [1, 2, 3, 4, 5]}
-    assert df.select(pl.col("a").head(pl.count() / 2)).to_dict(False) == {"a": [1, 2]}
+    assert df.select(pl.col("a").head(0)).to_dict(as_series=False) == {"a": []}
+    assert df.select(pl.col("a").head(3)).to_dict(as_series=False) == {"a": [1, 2, 3]}
+    assert df.select(pl.col("a").head(10)).to_dict(as_series=False) == {
+        "a": [1, 2, 3, 4, 5]
+    }
+    assert df.select(pl.col("a").head(pl.count() / 2)).to_dict(as_series=False) == {
+        "a": [1, 2]
+    }
 
 
 def test_tail() -> None:
     df = pl.DataFrame({"a": [1, 2, 3, 4, 5]})
-    assert df.select(pl.col("a").tail(0)).to_dict(False) == {"a": []}
-    assert df.select(pl.col("a").tail(3)).to_dict(False) == {"a": [3, 4, 5]}
-    assert df.select(pl.col("a").tail(10)).to_dict(False) == {"a": [1, 2, 3, 4, 5]}
-    assert df.select(pl.col("a").tail(pl.count() / 2)).to_dict(False) == {"a": [4, 5]}
+    assert df.select(pl.col("a").tail(0)).to_dict(as_series=False) == {"a": []}
+    assert df.select(pl.col("a").tail(3)).to_dict(as_series=False) == {"a": [3, 4, 5]}
+    assert df.select(pl.col("a").tail(10)).to_dict(as_series=False) == {
+        "a": [1, 2, 3, 4, 5]
+    }
+    assert df.select(pl.col("a").tail(pl.count() / 2)).to_dict(as_series=False) == {
+        "a": [4, 5]
+    }
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -397,7 +397,7 @@ def test_from_dicts_struct() -> None:
         as_series=False
     ) == {"a": [[{"y": None, "x": 1}], [{"y": 1, "x": None}]]}
     assert pl.from_dicts([{"a": [{"x": 1}, {"y": 2}]}, {"a": [{"y": 1}]}]).to_dict(
-        False
+        as_series=False
     ) == {"a": [[{"y": None, "x": 1}, {"y": 2, "x": None}], [{"y": 1, "x": None}]]}
 
 

--- a/py-polars/tests/unit/test_interop.py
+++ b/py-polars/tests/unit/test_interop.py
@@ -191,16 +191,19 @@ def test_from_pandas_include_indexes() -> None:
     pd_df = pd.DataFrame(data)
 
     df = pl.from_pandas(pd_df.set_index(["dtm"]))
-    assert df.to_dict(False) == {"val": [100, 200, 300], "misc": ["x", "y", "z"]}
+    assert df.to_dict(as_series=False) == {
+        "val": [100, 200, 300],
+        "misc": ["x", "y", "z"],
+    }
 
     df = pl.from_pandas(pd_df.set_index(["dtm", "val"]))
-    assert df.to_dict(False) == {"misc": ["x", "y", "z"]}
+    assert df.to_dict(as_series=False) == {"misc": ["x", "y", "z"]}
 
     df = pl.from_pandas(pd_df.set_index(["dtm"]), include_index=True)
-    assert df.to_dict(False) == data
+    assert df.to_dict(as_series=False) == data
 
     df = pl.from_pandas(pd_df.set_index(["dtm", "val"]), include_index=True)
-    assert df.to_dict(False) == data
+    assert df.to_dict(as_series=False) == data
 
 
 def test_from_pandas_duplicated_columns() -> None:
@@ -390,9 +393,9 @@ def test_from_dicts_struct() -> None:
     assert df["a"][1] == {"b": 3, "c": 4}
 
     # 5649
-    assert pl.from_dicts([{"a": [{"x": 1}]}, {"a": [{"y": 1}]}]).to_dict(False) == {
-        "a": [[{"y": None, "x": 1}], [{"y": 1, "x": None}]]
-    }
+    assert pl.from_dicts([{"a": [{"x": 1}]}, {"a": [{"y": 1}]}]).to_dict(
+        as_series=False
+    ) == {"a": [[{"y": None, "x": 1}], [{"y": 1, "x": None}]]}
     assert pl.from_dicts([{"a": [{"x": 1}, {"y": 2}]}, {"a": [{"y": 1}]}]).to_dict(
         False
     ) == {"a": [[{"y": None, "x": 1}, {"y": 2, "x": None}], [{"y": 1, "x": None}]]}
@@ -778,7 +781,9 @@ def test_from_pandas_null_struct_6412() -> None:
         {"a": None},
     ]
     df_pandas = pd.DataFrame(data)
-    assert pl.from_pandas(df_pandas).to_dict(False) == {"a": [{"b": None}, {"b": None}]}
+    assert pl.from_pandas(df_pandas).to_dict(as_series=False) == {
+        "a": [{"b": None}, {"b": None}]
+    }
 
 
 def test_from_pyarrow_map() -> None:
@@ -790,7 +795,7 @@ def test_from_pyarrow_map() -> None:
     )
 
     result = cast(pl.DataFrame, pl.from_arrow(pa_table))
-    assert result.to_dict(False) == {
+    assert result.to_dict(as_series=False) == {
         "idx": [1, 2],
         "mapping": [
             [{"key": "a", "value": "something"}],
@@ -1091,7 +1096,7 @@ def test_to_init_repr() -> None:
 
 def test_untrusted_categorical_input() -> None:
     df = pd.DataFrame({"x": pd.Categorical(["x"], ["x", "y"])})
-    assert pl.from_pandas(df).group_by("x").count().to_dict(False) == {
+    assert pl.from_pandas(df).group_by("x").count().to_dict(as_series=False) == {
         "x": ["x"],
         "count": [1],
     }
@@ -1115,12 +1120,12 @@ def test_sliced_struct_from_arrow() -> None:
     # slice the table
     # check if FFI correctly reads sliced
     result = cast(pl.DataFrame, pl.from_arrow(tbl.slice(1, 2)))
-    assert result.to_dict(False) == {
+    assert result.to_dict(as_series=False) == {
         "struct_col": [{"a": 2, "b": "bar"}, {"a": 3, "b": "baz"}]
     }
 
     result = cast(pl.DataFrame, pl.from_arrow(tbl.slice(1, 1)))
-    assert result.to_dict(False) == {"struct_col": [{"a": 2, "b": "bar"}]}
+    assert result.to_dict(as_series=False) == {"struct_col": [{"a": 2, "b": "bar"}]}
 
 
 def test_from_arrow_invalid_time_zone() -> None:

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -185,9 +185,14 @@ def test_is_in_join_blocked() -> None:
     ).lazy()
 
     df_all = df2.join(df1, left_on="values20", right_on="values0", how="left")
-    assert df_all.filter(~pl.col("Groups").is_in(["A", "B", "F"])).collect().to_dict(
-        False
-    ) == {"values22": [None, 4, 5], "values20": [3, 4, 5], "Groups": ["C", "D", "E"]}
+
+    result = df_all.filter(~pl.col("Groups").is_in(["A", "B", "F"])).collect()
+    expected = {
+        "values22": [None, 4, 5],
+        "values20": [3, 4, 5],
+        "Groups": ["C", "D", "E"],
+    }
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_predicate_pushdown_group_by_keys() -> None:

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -24,7 +24,9 @@ def test_predicate_4906() -> None:
     assert ldf.filter(
         pl.min_horizontal((pl.col("dt") + one_day), date(2022, 9, 30))
         > date(2022, 9, 10)
-    ).collect().to_dict(False) == {"dt": [date(2022, 9, 10), date(2022, 9, 20)]}
+    ).collect().to_dict(as_series=False) == {
+        "dt": [date(2022, 9, 10), date(2022, 9, 20)]
+    }
 
 
 def test_predicate_null_block_asof_join() -> None:
@@ -65,7 +67,7 @@ def test_predicate_null_block_asof_join() -> None:
 
     assert left.join_asof(right, by="id", on="timestamp").filter(
         pl.col("value").is_not_null()
-    ).collect().to_dict(False) == {
+    ).collect().to_dict(as_series=False) == {
         "id": [1, 2, 3],
         "timestamp": [
             datetime(2022, 1, 1, 10, 0),
@@ -83,7 +85,7 @@ def test_predicate_strptime_6558() -> None:
         .select(pl.col("date").str.strptime(pl.Date, format="%F"))
         .filter((pl.col("date").dt.year() == 2022) & (pl.col("date").dt.month() == 1))
         .collect()
-    ).to_dict(False) == {"date": [date(2022, 1, 3)]}
+    ).to_dict(as_series=False) == {"date": [date(2022, 1, 3)]}
 
 
 def test_predicate_arr_first_6573() -> None:
@@ -100,7 +102,7 @@ def test_predicate_arr_first_6573() -> None:
         .with_columns(pl.col("a").list.first())
         .filter(pl.col("a") == pl.col("b"))
         .collect()
-    ).to_dict(False) == {"a": [1], "b": [1]}
+    ).to_dict(as_series=False) == {"a": [1], "b": [1]}
 
 
 def test_fast_path_comparisons() -> None:
@@ -122,7 +124,11 @@ def test_predicate_pushdown_block_8661() -> None:
     )
     assert df.lazy().sort(["g", "t"]).filter(
         (pl.col("x").shift() > 20).over("g")
-    ).collect().to_dict(False) == {"g": [1, 2, 2], "t": [4, 2, 3], "x": [40, 30, 20]}
+    ).collect().to_dict(as_series=False) == {
+        "g": [1, 2, 2],
+        "t": [4, 2, 3],
+        "x": [40, 30, 20],
+    }
 
 
 def test_predicate_pushdown_with_context_11014() -> None:
@@ -146,7 +152,7 @@ def test_predicate_pushdown_with_context_11014() -> None:
         .collect(predicate_pushdown=True)
     )
 
-    assert out.to_dict(False) == {"df1_c1": [2, 3], "df1_c2": [3, 4]}
+    assert out.to_dict(as_series=False) == {"df1_c1": [2, 3], "df1_c2": [3, 4]}
 
 
 def test_predicate_pushdown_cumsum_9566() -> None:
@@ -165,7 +171,7 @@ def test_predicate_pushdown_join_fill_null_10058() -> None:
         ids.join(filters, how="left", on="id")
         .filter(pl.col("filter").fill_null(True))
         .collect()
-        .to_dict(False)["id"]
+        .to_dict(as_series=False)["id"]
     ) == [0, 2]
 
 

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -16,7 +16,7 @@ def test_projection_on_semi_join_4789() -> None:
 
     q = ab.join(intermediate_agg, on="a")
 
-    assert q.collect().to_dict(False) == {"a": [1], "p": [1], "seq": [[1]]}
+    assert q.collect().to_dict(as_series=False) == {"a": [1], "p": [1], "seq": [[1]]}
 
 
 def test_melt_projection_pd_block_4997() -> None:
@@ -28,7 +28,7 @@ def test_melt_projection_pd_block_4997() -> None:
         .group_by("row_nr")
         .agg(pl.col("variable").alias("result"))
         .collect()
-    ).to_dict(False) == {"row_nr": [0], "result": [["col1", "col2"]]}
+    ).to_dict(as_series=False) == {"row_nr": [0], "result": [["col1", "col2"]]}
 
 
 def test_double_projection_pushdown() -> None:
@@ -76,7 +76,7 @@ def test_unnest_projection_pushdown() -> None:
             pl.col("value"),
         ]
     )
-    out = mlf.collect().to_dict(False)
+    out = mlf.collect().to_dict(as_series=False)
     assert out == {
         "row": ["y", "y", "b", "b"],
         "col": ["z", "z", "c", "c"],
@@ -104,7 +104,7 @@ def test_unnest_columns_available() -> None:
     ).unnest("genres")
 
     out = q.collect()
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "title": ["Avatar", "spectre", "King Kong"],
         "content_rating": ["PG-13", "PG-13", "PG-13"],
         "genre1": ["Action", "Action", "Action"],
@@ -140,7 +140,7 @@ def test_double_projection_union() -> None:
     q = pl.concat([q, lf2])
 
     q = q.group_by("c", maintain_order=True).agg([pl.col("a")])
-    assert q.collect().to_dict(False) == {
+    assert q.collect().to_dict(as_series=False) == {
         "c": [1, 2, 3],
         "a": [[1, 2, 5, 7], [3, 4, 6], [8]],
     }
@@ -192,7 +192,7 @@ def test_asof_join_projection_() -> None:
     dirty_lf1 = lf1.select(expressions)
 
     concatted = pl.concat([joined, dirty_lf1])
-    assert concatted.select(["b", "a"]).collect().to_dict(False) == {
+    assert concatted.select(["b", "a"]).collect().to_dict(as_series=False) == {
         "b": [
             0.0,
             0.8333333333333334,
@@ -240,7 +240,7 @@ def test_merge_sorted_projection_pd() -> None:
 
     assert (
         lf.merge_sorted(lf2, key="foo").reverse().select(["bar"])
-    ).collect().to_dict(False) == {
+    ).collect().to_dict(as_series=False) == {
         "bar": ["false", "nice", "afk", "onion", "lukas", "patrick"]
     }
 
@@ -254,7 +254,7 @@ def test_distinct_projection_pd_7578() -> None:
     )
 
     q = df.lazy().unique().group_by("bar").agg(pl.count())
-    assert q.collect().sort("bar").to_dict(False) == {
+    assert q.collect().sort("bar").to_dict(as_series=False) == {
         "bar": ["a", "b"],
         "count": [3, 2],
     }
@@ -277,7 +277,7 @@ def test_join_suffix_collision_9562() -> None:
     df.join(other_df, on="ham")
     assert df.lazy().join(
         other_df.lazy(), how="inner", left_on="ham", right_on="ham", suffix="m"
-    ).select("ham").collect().to_dict(False) == {"ham": ["a", "b"]}
+    ).select("ham").collect().to_dict(as_series=False) == {"ham": ["a", "b"]}
 
 
 def test_projection_join_names_9955() -> None:

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -35,7 +35,7 @@ def test_repeat_expansion_in_group_by() -> None:
         pl.DataFrame({"g": [1, 2, 2, 3, 3, 3]})
         .group_by("g", maintain_order=True)
         .agg(pl.repeat(1, pl.count()).cumsum())
-        .to_dict(False)
+        .to_dict(as_series=False)
     )
     assert out == {"g": [1, 2, 3], "repeat": [[1], [1, 2], [1, 2, 3]]}
 
@@ -73,7 +73,7 @@ def test_overflow_uint16_agg_mean() -> None:
         )
         .group_by(["col1"])
         .agg(pl.col("col3").mean())
-        .to_dict(False)
+        .to_dict(as_series=False)
     ) == {"col1": ["A"], "col3": [64.0]}
 
 
@@ -96,7 +96,7 @@ def test_binary_on_list_agg_3345() -> None:
                 ).sum()
             ]
         )
-        .to_dict(False)
+        .to_dict(as_series=False)
     ) == {"group": ["A", "B"], "id": [0.6365141682948128, 1.0397207708399179]}
 
 
@@ -167,7 +167,7 @@ def test_group_by_agg_equals_zero_3535() -> None:
     # group by the key, aggregating the two numeric cols
     assert df.group_by(pl.col("key"), maintain_order=True).agg(
         [pl.col("val1").sum(), pl.col("val2").sum()]
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "key": ["aa", "bb", "cc"],
         "val1": [10, 0, -99],
         "val2": [0.0, 0.0, 10.5],
@@ -196,7 +196,7 @@ def test_arithmetic_in_aggregation_3739() -> None:
                 demean_dot(),
             ]
         )
-    ).to_dict(False) == {"key": ["a"], "demean_dot": [0.0]}
+    ).to_dict(as_series=False) == {"key": ["a"], "demean_dot": [0.0]}
 
 
 def test_dtype_concat_3735() -> None:
@@ -241,7 +241,10 @@ def test_opaque_filter_on_lists_3784() -> None:
                 and variant.to_list().index(pre) < variant.to_list().index(succ)
             )
         )
-    ).collect().to_dict(False) == {"group": [1], "str_list": [["A", "B", "B"]]}
+    ).collect().to_dict(as_series=False) == {
+        "group": [1],
+        "str_list": [["A", "B", "B"]],
+    }
 
 
 def test_ternary_none_struct() -> None:
@@ -265,7 +268,7 @@ def test_ternary_none_struct() -> None:
         pl.DataFrame({"groups": [1, 2, 3, 4], "values": [None, None, 1, 2]})
         .group_by("groups", maintain_order=True)
         .agg([map_expr("values")])
-    ).to_dict(False) == {
+    ).to_dict(as_series=False) == {
         "groups": [1, 2, 3, 4],
         "out": [
             {"sum": None, "count": None},

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -109,9 +109,10 @@ def test_maintain_order_after_sampling() -> None:
             "value": [1, 3, 2, 3, 4, 5, 3, 4],
         }
     )
-    assert df.group_by("type", maintain_order=True).agg(pl.col("value").sum()).to_dict(
-        False
-    ) == {"type": ["A", "B", "C", "D"], "value": [5, 8, 5, 7]}
+
+    result = df.group_by("type", maintain_order=True).agg(pl.col("value").sum())
+    expected = {"type": ["A", "B", "C", "D"], "value": [5, 8, 5, 7]}
+    assert result.to_dict(as_series=False) == expected
 
 
 def test_sorted_group_by_optimization(monkeypatch: Any) -> None:

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -109,16 +109,16 @@ def test_with_context() -> None:
 
     assert (
         df_a.with_context(df_b.lazy()).select([pl.col("b") + pl.col("c").first()])
-    ).collect().to_dict(False) == {"b": ["afoo", "cfoo", None]}
+    ).collect().to_dict(as_series=False) == {"b": ["afoo", "cfoo", None]}
 
     with pytest.raises(pl.ComputeError):
         (df_a.with_context(df_b.lazy()).select(["a", "c"])).collect()
 
 
 def test_from_dicts_nested_nulls() -> None:
-    assert pl.from_dicts([{"a": [None, None]}, {"a": [1, 2]}]).to_dict(False) == {
-        "a": [[None, None], [1, 2]]
-    }
+    assert pl.from_dicts([{"a": [None, None]}, {"a": [1, 2]}]).to_dict(
+        as_series=False
+    ) == {"a": [[None, None], [1, 2]]}
 
 
 def test_group_schema_err() -> None:
@@ -129,11 +129,13 @@ def test_group_schema_err() -> None:
 
 def test_schema_inference_from_rows() -> None:
     # these have to upcast to float
-    assert pl.from_records([[1, 2.1, 3], [4, 5, 6.4]]).to_dict(False) == {
+    assert pl.from_records([[1, 2.1, 3], [4, 5, 6.4]]).to_dict(as_series=False) == {
         "column_0": [1.0, 2.1, 3.0],
         "column_1": [4.0, 5.0, 6.4],
     }
-    assert pl.from_dicts([{"a": 1, "b": 2}, {"a": 3.1, "b": 4.5}]).to_dict(False) == {
+    assert pl.from_dicts([{"a": 1, "b": 2}, {"a": 3.1, "b": 4.5}]).to_dict(
+        as_series=False
+    ) == {
         "a": [1.0, 3.1],
         "b": [2.0, 4.5],
     }
@@ -168,7 +170,7 @@ def test_lazy_map_schema() -> None:
 
     assert df.lazy().map_batches(
         custom2, validate_output_schema=False
-    ).collect().to_dict(False) == {"a": ["1", "2", "3"], "b": ["a", "b", "c"]}
+    ).collect().to_dict(as_series=False) == {"a": ["1", "2", "3"], "b": ["a", "b", "c"]}
 
 
 def test_join_as_of_by_schema() -> None:
@@ -190,7 +192,7 @@ def test_unknown_map_elements() -> None:
         ]
     )
 
-    assert q.collect().to_dict(False) == {
+    assert q.collect().to_dict(as_series=False) == {
         "Amount": [10, 1, 1, 5],
         "Flour": [10.0, 100.0, 100.0, 20.0],
     }
@@ -262,7 +264,7 @@ def test_shrink_dtype() -> None:
         pl.Float32,
     ]
 
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "a": [1, 2, 3],
         "b": [1, 2, 8589934592],
         "c": [-1, 2, 1073741824],
@@ -310,7 +312,7 @@ def test_lazy_rename() -> None:
 
     assert (
         df.lazy().rename({"y": "x", "x": "y"}).select(["x", "y"]).collect()
-    ).to_dict(False) == {"x": [2], "y": [1]}
+    ).to_dict(as_series=False) == {"x": [2], "y": [1]}
 
 
 def test_all_null_cast_5826() -> None:
@@ -377,7 +379,7 @@ def test_duration_division_schema() -> None:
     )
 
     assert q.schema == {"a": pl.Float64}
-    assert q.collect().to_dict(False) == {"a": [1.0]}
+    assert q.collect().to_dict(as_series=False) == {"a": [1.0]}
 
 
 def test_int_operator_stability() -> None:
@@ -496,13 +498,13 @@ def test_concat_vertically_relaxed() -> None:
     )
     out = pl.concat([a, b], how="vertical_relaxed")
     assert out.schema == {"a": pl.Int16, "b": pl.Int64}
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "a": [1, 2, 3, 43, 2, 3],
         "b": [1, 0, None, 32, 1, None],
     }
     out = pl.concat([b, a], how="vertical_relaxed")
     assert out.schema == {"a": pl.Int16, "b": pl.Int64}
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "a": [43, 2, 3, 1, 2, 3],
         "b": [32, 1, None, 1, 0, None],
     }
@@ -512,13 +514,13 @@ def test_concat_vertically_relaxed() -> None:
 
     out = pl.concat([c, d], how="vertical_relaxed")
     assert out.schema == {"a": pl.Float64, "b": pl.Float64}
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "a": [1.0, 2.0, 1.0, 0.2],
         "b": [2.0, 1.0, None, 0.1],
     }
     out = pl.concat([d, c], how="vertical_relaxed")
     assert out.schema == {"a": pl.Float64, "b": pl.Float64}
-    assert out.to_dict(False) == {
+    assert out.to_dict(as_series=False) == {
         "a": [1.0, 0.2, 1.0, 2.0],
         "b": [None, 0.1, 2.0, 1.0],
     }

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -539,9 +539,9 @@ def test_lit_iter_schema() -> None:
         }
     )
 
-    assert df.group_by("key").agg(pl.col("dates").unique() + timedelta(days=1)).to_dict(
-        False
-    ) == {
+    result = df.group_by("key").agg(pl.col("dates").unique() + timedelta(days=1))
+    expected = {
         "key": ["A"],
         "dates": [[date(1970, 1, 2), date(1970, 1, 3), date(1970, 1, 4)]],
     }
+    assert result.to_dict(as_series=False) == expected


### PR DESCRIPTION
This was the last public function that still allowed a positional boolean input. I finally bit the bullet and marked it as keyword-only. Had to do some search&replace in our test suite as many legacy tests still use `to_dict(False)`.

> [!NOTE]  
> If you used `to_dict` extensively in your test suite, it is recommended to use our assertion utility function `assert_frame_equal` instead.