### PR TITLE
depr(python): Deprecate default value for `DataFrame.to_dict`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -88,6 +88,7 @@ from polars.utils.deprecation import (
     deprecate_nonkeyword_arguments,
     deprecate_renamed_function,
     deprecate_renamed_parameter,
+    issue_deprecation_warning,
 )
 from polars.utils.various import (
     _prepare_row_count_args,
@@ -1915,14 +1916,14 @@ class DataFrame:
     @overload
     def to_dict(
         self,
-        as_series: bool,  # noqa: FBT001
+        as_series: bool | None,
     ) -> dict[str, Series] | dict[str, list[Any]]:
         ...
 
     @deprecate_nonkeyword_arguments(version="0.19.13")
     def to_dict(
         self,
-        as_series: bool = True,  # noqa: FBT001
+        as_series: bool | None = None,
     ) -> dict[str, Series] | dict[str, list[Any]]:
         """
         Convert DataFrame to a dictionary mapping column name to values.
@@ -2007,6 +2008,14 @@ class DataFrame:
         ]}
 
         """
+        if as_series is None:
+            issue_deprecation_warning(
+                "The default value for the `as_series` parameter of `DataFrame.to_dict` will be changed to `False`."
+                " Pass `as_series=True` to keep current behavior and silence this warning.",
+                version="0.19.13",
+            )
+            as_series = True
+
         if as_series:
             return {s.name: s for s in self}
         else:

--- a/py-polars/tests/unit/dataframe/test_to_dict.py
+++ b/py-polars/tests/unit/dataframe/test_to_dict.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from hypothesis import given
 
 import polars as pl
@@ -12,3 +13,14 @@ def test_to_dict(df: pl.DataFrame) -> None:
     d = df.to_dict(as_series=False)
     result = pl.from_dict(d, schema=df.schema)
     assert_frame_equal(df, result, categorical_as_str=True)
+
+
+def test_to_dict_deprecated_positional() -> None:
+    with pytest.deprecated_call():
+        pl.DataFrame({"a": [1, 2]}).to_dict(False)
+
+
+def test_to_dict_deprecated_default() -> None:
+    with pytest.deprecated_call():
+        result = pl.DataFrame({"a": [1, 2]}).to_dict()
+    assert isinstance(result["a"], pl.Series)


### PR DESCRIPTION
I have discussed this with @alexander-beedie before. This PR prepares to change the default of `DataFrame.to_dict` from returning Series to returning lists.

The main reason for this change is that `df.to_dict(as_series=True)` isn't really useful for anything. A DataFrame already sort-of functions as a dictionary of Series, in the sense that you can do `df["col"]` and get the Series for that column name. So when would you really need a true dictionary of Series?

On the other hand, `df.to_dict(as_series=False)` is quite useful to get the full contents of the DataFrame as Python objects.

So therefore I think it makes a lot of sense to change the default here to `as_series=False`.

This does go against the principle that performant code should be easier to write than slow code (returning Series is basically free, while returning lists is expensive). But in this case, I think it's warranted.

Since this has been discussed in the past, I think it's good if @ritchie46 signs off on this one before it's merged.