### PR TITLE
perf: Reduce compute in error message for failed datetime parsing

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -445,7 +445,7 @@ fn handle_temporal_parsing_error(
     }
     polars_bail!(
         ComputeError:
-        "strict {} parsing failed for {} value(s) (first 3 failures: {})\n\
+        "strict {} parsing failed for {} value(s) (first few failures: {})\n\
         \n\
         You might want to try:\n\
         - setting `strict=False`\n\

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -427,9 +427,8 @@ fn handle_temporal_parsing_error(
 ) -> PolarsResult<()> {
     let failure_mask = !ca.is_null() & out.is_null();
     let all_failures = ca.filter(&failure_mask)?;
-    let first_failures = all_failures.unique()?.slice(0, 10).sort(false);
+    let first_failures = all_failures.slice(0, 3);
     let n_failures = all_failures.len();
-    let n_failures_unique = all_failures.n_unique()?;
     let exact_addendum = if has_non_exact_option {
         "- setting `exact=False` (note: this is much slower!)\n"
     } else {
@@ -446,7 +445,7 @@ fn handle_temporal_parsing_error(
     }
     polars_bail!(
         ComputeError:
-        "strict {} parsing failed for {} value(s) ({} unique): {}\n\
+        "strict {} parsing failed for {} value(s) (first 3 failures: {})\n\
         \n\
         You might want to try:\n\
         - setting `strict=False`\n\
@@ -454,7 +453,6 @@ fn handle_temporal_parsing_error(
         {}",
         out.dtype(),
         n_failures,
-        n_failures_unique,
         first_failures.into_series().fmt_list(),
         exact_addendum,
         format_addendum,


### PR DESCRIPTION
Addendum to https://github.com/pola-rs/polars/pull/10298#issuecomment-1786722819 in light of comments from https://github.com/pola-rs/polars/pull/10671

In https://buttondown.email/NotANumber/archive/faster-development-with-polars-and-a-bit-of/, this error message was praised:

> I rather like the short error report on [" Nov 2013", "June 2022"]

This keeps the part which was praised:
```python
In [1]: pl.Series(
   ...:     name='date',
   ...:     values=['2019-01-01', 'a', 'b', '2019-01-02', '2019-01-03', 'c', 'd', 'e', 'a', 'a'],
   ...: ).str.to_date(exact=False)
---------------------------------------------------------------------------
ComputeError: strict date parsing failed for 7 value(s) (first 3 failures: ["a", "b", "c"])

You might want to try:
- setting `strict=False`
- setting `exact=False` (note: this is much slower!)
- explicitly specifying `format`
```
whilst reducing the amount of compute (thus making for a better try/except experience)