### PR TITLE
ci: Fix triggers for docs deployment

### DIFF
--- a/.github/workflows/docs-global.yml
+++ b/.github/workflows/docs-global.yml
@@ -6,9 +6,9 @@ on:
       - docs/**
       - mkdocs.yml
       - .github/workflows/docs-global.yml
-  push:
-    tags:
-      - py-**
+  repository_dispatch:
+    types:
+      - python-release
   # Allow manual trigger until we have properly versioned docs
   workflow_dispatch:
 
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.client_payload.sha }}
     - uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:
         config-file: docs/mlc-config.json
@@ -26,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.sha }}
       - uses: psf/black@stable
         with:
           src: docs/src/python
@@ -35,6 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -75,12 +81,12 @@ jobs:
         run: mkdocs build
 
       - name: Add .nojekyll
-        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch'
         working-directory: site
         run: touch .nojekyll
 
       - name: Deploy docs
-        if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: site

--- a/.github/workflows/docs-python.yml
+++ b/.github/workflows/docs-python.yml
@@ -13,8 +13,9 @@ on:
       - py-polars/docs/**
       - py-polars/polars/**
       - .github/workflows/docs-python.yml
-    tags:
-      - py-**
+  repository_dispatch:
+    types:
+      - python-release
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -40,7 +43,7 @@ jobs:
         working-directory: py-polars/docs
         env:
           SPHINXOPTS: -W --jobs=auto
-          POLARS_VERSION: ${{ github.ref_name }}
+          POLARS_VERSION: ${{ github.event.client_payload.tag }}
         run: make html
 
       - name: Deploy Python docs for latest development version
@@ -53,17 +56,17 @@ jobs:
 
       - name: Parse the tag to find the major/minor version of Polars
         id: version
-        if: ${{ github.ref_type == 'tag' }}
+        if: github.event_name == 'repository_dispatch'
         shell: bash
         run: |
-          tag="${{ github.ref_name }}"
+          tag="${{ github.event.client_payload.tag }}"
           regex="py-([0-9]+\.[0-9]+)\.[0-9]+.*"
           [[ $tag =~ $regex ]]
           version=${BASH_REMATCH[1]}
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Deploy Python docs for latest release version - versioned
-        if: ${{ github.ref_type == 'tag' }}
+        if: github.event_name == 'repository_dispatch'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html
@@ -71,7 +74,7 @@ jobs:
           single-commit: true
 
       - name: Deploy Python docs for latest release version - stable
-        if: ${{ github.ref_type == 'tag' }}
+        if: github.event_name == 'repository_dispatch'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: py-polars/docs/build/html

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -248,3 +248,15 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.github-release.outputs.tag_name }}
+
+      - name: Trigger other workflows related to the release
+        if: inputs.dry-run == false && steps.version.outputs.is_prerelease == false
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          event-type: python-release
+          client-payload: >
+            {
+              "version": "${{ steps.version.outputs.version }}",
+              "tag": "${{ steps.github-release.outputs.tag_name }}",
+              "sha": "${{ inputs.sha || github.sha }}"
+            }


### PR DESCRIPTION
Closes #12152

The tags created by the new release workflow did not trigger the docs deployment workflows. So I set up a "repository dispatch" to trigger them.

Note that we'll have to wait until the new Python release before the stable API reference is updated.