### PR TITLE
build: update `sqlparser-rs` to `0.39`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ serde = "1.0.188"
 serde_json = "1"
 simd-json = { version = "0.12", features = ["known-key"] }
 smartstring = "1"
-sqlparser = "0.38"
+sqlparser = "0.39"
 strum_macros = "0.25"
 thiserror = "1"
 tokio = "1.26"

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -223,13 +223,11 @@ impl SQLContext {
                 concatenated.map(|lf| lf.unique(None, UniqueKeepStrategy::Any))
             },
             // UNION ALL BY NAME
-            // TODO: add recognition for SetQuantifier::DistinctByName
-            //  when "https://github.com/sqlparser-rs/sqlparser-rs/pull/997" is available
             #[cfg(feature = "diagonal_concat")]
             SetQuantifier::AllByName => concat_lf_diagonal(vec![left, right], opts),
             // UNION [DISTINCT] BY NAME
             #[cfg(feature = "diagonal_concat")]
-            SetQuantifier::ByName => {
+            SetQuantifier::ByName | SetQuantifier::DistinctByName => {
                 let concatenated = concat_lf_diagonal(vec![left, right], opts);
                 concatenated.map(|lf| lf.unique(None, UniqueKeepStrategy::Any))
             },

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -2513,9 +2513,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqlparser"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0272b7bb0a225320170c99901b4b5fb3a4384e255a7f2cc228f61e2ba3893e75"
+checksum = "743b4dc2cbde11890ccb254a8fc9d537fa41b36da00de2a1c5e9848c9bc42bd7"
 dependencies = [
  "log",
 ]


### PR DESCRIPTION
Follow-up to https://github.com/pola-rs/polars/pull/11597; enables [support](https://github.com/sqlparser-rs/sqlparser-rs/pull/997) for `UNION [DISTINCT] BY NAME`. Needed a few minor code updates on our side, following enhancements to `ARRAY`, `CAST`, and `TRIM` parsing support.