### PR TITLE
fix(python): Fix interchange protocol boolean buffer size

### DIFF
--- a/py-polars/polars/interchange/buffer.py
+++ b/py-polars/polars/interchange/buffer.py
@@ -47,15 +47,17 @@ class PolarsBuffer(Buffer):
 
         if dtype[0] == DtypeKind.STRING:
             return self._data.str.len_bytes().sum()  # type: ignore[return-value]
+        elif dtype[0] == DtypeKind.BOOL:
+            offset, length, _pointer = self._data._s.get_ptr()
+            n_bits = offset + length
+            n_bytes, rest = divmod(n_bits, 8)
+            # Round up to the nearest byte
+            if rest:
+                return n_bytes + 1
+            else:
+                return n_bytes
 
-        n_bits = self._data.len() * dtype[1]
-
-        result, rest = divmod(n_bits, 8)
-        # Round up to the nearest byte
-        if rest:
-            return result + 1
-        else:
-            return result
+        return self._data.len() * (dtype[1] // 8)
 
     @property
     def ptr(self) -> int:

--- a/py-polars/tests/unit/interchange/test_buffer.py
+++ b/py-polars/tests/unit/interchange/test_buffer.py
@@ -42,6 +42,7 @@ def test_init_invalid_input() -> None:
         (pl.Series(["a", "b", "a", "c", "a"], dtype=pl.Categorical), 20),
         (pl.Series([True, False], dtype=pl.Boolean), 1),
         (pl.Series([True] * 9, dtype=pl.Boolean), 2),
+        (pl.Series([True] * 9, dtype=pl.Boolean)[5:], 2),
     ],
 )
 def test_bufsize(data: pl.Series, expected: int) -> None:


### PR DESCRIPTION
As of pyarrow 14, we can now roundtrip booleans. This caught a bug for boolean buffers with an offset.