### PR TITLE
depr(python,rust!): Rename `dt.seconds` to `dt.total_seconds` (likewise for days, hours, minutes, milliseconds, microseconds, and nanoseconds)

### DIFF
--- a/docs/src/python/user-guide/transformations/time-series/rolling.py
+++ b/docs/src/python/user-guide/transformations/time-series/rolling.py
@@ -31,7 +31,7 @@ df = (
 
 out = df.group_by_dynamic("time", every="1mo", period="1mo", closed="left").agg(
     pl.col("time").cumcount().reverse().head(3).alias("day/eom"),
-    ((pl.col("time") - pl.col("time").first()).last().dt.days() + 1).alias(
+    ((pl.col("time") - pl.col("time").first()).last().dt.total_days() + 1).alias(
         "days_in_month"
     ),
 )

--- a/py-polars/docs/source/reference/expressions/temporal.rst
+++ b/py-polars/docs/source/reference/expressions/temporal.rst
@@ -16,34 +16,41 @@ The following methods are available under the `expr.dt` attribute.
     Expr.dt.date
     Expr.dt.datetime
     Expr.dt.day
-    Expr.dt.total_days
+    Expr.dt.days
     Expr.dt.dst_offset
     Expr.dt.epoch
     Expr.dt.hour
-    Expr.dt.total_hours
+    Expr.dt.hours
     Expr.dt.is_leap_year
     Expr.dt.iso_year
     Expr.dt.microsecond
-    Expr.dt.total_microseconds
+    Expr.dt.microseconds
     Expr.dt.millisecond
-    Expr.dt.total_milliseconds
+    Expr.dt.milliseconds
     Expr.dt.minute
-    Expr.dt.total_minutes
+    Expr.dt.minutes
     Expr.dt.month
     Expr.dt.month_start
     Expr.dt.month_end
     Expr.dt.nanosecond
-    Expr.dt.total_nanoseconds
+    Expr.dt.nanoseconds
     Expr.dt.offset_by
     Expr.dt.ordinal_day
     Expr.dt.quarter
     Expr.dt.round
     Expr.dt.second
-    Expr.dt.total_seconds
+    Expr.dt.seconds
     Expr.dt.strftime
     Expr.dt.time
     Expr.dt.timestamp
     Expr.dt.to_string
+    Expr.dt.total_days
+    Expr.dt.total_hours
+    Expr.dt.total_microseconds
+    Expr.dt.total_milliseconds
+    Expr.dt.total_minutes
+    Expr.dt.total_nanoseconds
+    Expr.dt.total_seconds
     Expr.dt.truncate
     Expr.dt.week
     Expr.dt.weekday

--- a/py-polars/docs/source/reference/expressions/temporal.rst
+++ b/py-polars/docs/source/reference/expressions/temporal.rst
@@ -16,30 +16,30 @@ The following methods are available under the `expr.dt` attribute.
     Expr.dt.date
     Expr.dt.datetime
     Expr.dt.day
-    Expr.dt.days
+    Expr.dt.total_days
     Expr.dt.dst_offset
     Expr.dt.epoch
     Expr.dt.hour
-    Expr.dt.hours
+    Expr.dt.total_hours
     Expr.dt.is_leap_year
     Expr.dt.iso_year
     Expr.dt.microsecond
-    Expr.dt.microseconds
+    Expr.dt.total_microseconds
     Expr.dt.millisecond
-    Expr.dt.milliseconds
+    Expr.dt.total_milliseconds
     Expr.dt.minute
-    Expr.dt.minutes
+    Expr.dt.total_minutes
     Expr.dt.month
     Expr.dt.month_start
     Expr.dt.month_end
     Expr.dt.nanosecond
-    Expr.dt.nanoseconds
+    Expr.dt.total_nanoseconds
     Expr.dt.offset_by
     Expr.dt.ordinal_day
     Expr.dt.quarter
     Expr.dt.round
     Expr.dt.second
-    Expr.dt.seconds
+    Expr.dt.total_seconds
     Expr.dt.strftime
     Expr.dt.time
     Expr.dt.timestamp

--- a/py-polars/docs/source/reference/series/temporal.rst
+++ b/py-polars/docs/source/reference/series/temporal.rst
@@ -16,34 +16,34 @@ The following methods are available under the `Series.dt` attribute.
     Series.dt.date
     Series.dt.datetime
     Series.dt.day
-    Series.dt.days
+    Series.dt.total_days
     Series.dt.dst_offset
     Series.dt.epoch
     Series.dt.hour
-    Series.dt.hours
+    Series.dt.total_hours
     Series.dt.is_leap_year
     Series.dt.iso_year
     Series.dt.max
     Series.dt.mean
     Series.dt.median
     Series.dt.microsecond
-    Series.dt.microseconds
+    Series.dt.total_microseconds
     Series.dt.millisecond
-    Series.dt.milliseconds
+    Series.dt.total_milliseconds
     Series.dt.min
     Series.dt.minute
-    Series.dt.minutes
+    Series.dt.total_minutes
     Series.dt.month
     Series.dt.month_start
     Series.dt.month_end
     Series.dt.nanosecond
-    Series.dt.nanoseconds
+    Series.dt.total_nanoseconds
     Series.dt.offset_by
     Series.dt.ordinal_day
     Series.dt.quarter
     Series.dt.round
     Series.dt.second
-    Series.dt.seconds
+    Series.dt.total_seconds
     Series.dt.strftime
     Series.dt.time
     Series.dt.timestamp

--- a/py-polars/docs/source/reference/series/temporal.rst
+++ b/py-polars/docs/source/reference/series/temporal.rst
@@ -16,38 +16,45 @@ The following methods are available under the `Series.dt` attribute.
     Series.dt.date
     Series.dt.datetime
     Series.dt.day
-    Series.dt.total_days
+    Series.dt.days
     Series.dt.dst_offset
     Series.dt.epoch
     Series.dt.hour
-    Series.dt.total_hours
+    Series.dt.hours
     Series.dt.is_leap_year
     Series.dt.iso_year
     Series.dt.max
     Series.dt.mean
     Series.dt.median
     Series.dt.microsecond
-    Series.dt.total_microseconds
+    Series.dt.microseconds
     Series.dt.millisecond
-    Series.dt.total_milliseconds
+    Series.dt.milliseconds
     Series.dt.min
     Series.dt.minute
-    Series.dt.total_minutes
+    Series.dt.minutes
     Series.dt.month
     Series.dt.month_start
     Series.dt.month_end
     Series.dt.nanosecond
-    Series.dt.total_nanoseconds
+    Series.dt.nanoseconds
     Series.dt.offset_by
     Series.dt.ordinal_day
     Series.dt.quarter
     Series.dt.round
     Series.dt.second
-    Series.dt.total_seconds
+    Series.dt.seconds
     Series.dt.strftime
     Series.dt.time
     Series.dt.timestamp
     Series.dt.to_string
+    Series.dt.total_days
+    Series.dt.total_hours
+    Series.dt.total_microseconds
+    Series.dt.total_milliseconds
+    Series.dt.total_minutes
+    Series.dt.total_nanoseconds
+    Series.dt.total_seconds
     Series.dt.truncate
     Series.dt.week
     Series.dt.weekday

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -1457,17 +1457,6 @@ class ExprDateTimeNameSpace:
             self._pyexpr.dt_replace_time_zone(time_zone, ambiguous._pyexpr)
         )
 
-    @deprecate_renamed_function("total_days", version="0.19.3")
-    def days(self) -> Expr:
-        """
-        Extract the total days from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_days` instead.
-
-        """
-        return self.total_days()
-
     def total_days(self) -> Expr:
         """
         Extract the total days from a Duration type.
@@ -1506,17 +1495,6 @@ class ExprDateTimeNameSpace:
 
         """
         return wrap_expr(self._pyexpr.duration_days())
-
-    @deprecate_renamed_function("total_hours", version="0.19.3")
-    def hours(self) -> Expr:
-        """
-        Extract the total hours from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_hours` instead.
-
-        """
-        return self.total_hours()
 
     def total_hours(self) -> Expr:
         """
@@ -1558,17 +1536,6 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.duration_hours())
 
-    @deprecate_renamed_function("total_minutes", version="0.19.3")
-    def minutes(self) -> Expr:
-        """
-        Extract the total minutes from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_minutes` instead.
-
-        """
-        return self.total_minutes()
-
     def total_minutes(self) -> Expr:
         """
         Extract the total minutes from a Duration type.
@@ -1608,17 +1575,6 @@ class ExprDateTimeNameSpace:
 
         """
         return wrap_expr(self._pyexpr.duration_minutes())
-
-    @deprecate_renamed_function("total_seconds", version="0.19.3")
-    def seconds(self) -> Expr:
-        """
-        Extract the total seconds from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_seconds` instead.
-
-        """
-        return self.total_seconds()
 
     def total_seconds(self) -> Expr:
         """
@@ -1661,17 +1617,6 @@ class ExprDateTimeNameSpace:
 
         """
         return wrap_expr(self._pyexpr.duration_seconds())
-
-    @deprecate_renamed_function("total_milliseconds", version="0.19.3")
-    def milliseconds(self) -> Expr:
-        """
-        Extract the total milliseconds from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_milliseconds` instead.
-
-        """
-        return self.total_milliseconds()
 
     def total_milliseconds(self) -> Expr:
         """
@@ -1719,17 +1664,6 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.duration_milliseconds())
 
-    @deprecate_renamed_function("total_microseconds", version="0.19.3")
-    def microseconds(self) -> Expr:
-        """
-        Extract the total microseconds from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_microseconds` instead.
-
-        """
-        return self.total_microseconds()
-
     def total_microseconds(self) -> Expr:
         """
         Extract the total microseconds from a Duration type.
@@ -1775,17 +1709,6 @@ class ExprDateTimeNameSpace:
 
         """
         return wrap_expr(self._pyexpr.duration_microseconds())
-
-    @deprecate_renamed_function("total_nanoseconds", version="0.19.3")
-    def nanoseconds(self) -> Expr:
-        """
-        Extract the total nanoseconds from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_nanoseconds` instead.
-
-        """
-        return self.total_nanoseconds()
 
     def total_nanoseconds(self) -> Expr:
         """
@@ -2090,3 +2013,80 @@ class ExprDateTimeNameSpace:
         └─────────────────────────────┴──────────────┘
         """
         return wrap_expr(self._pyexpr.dt_dst_offset())
+
+    @deprecate_renamed_function("total_days", version="0.19.13")
+    def days(self) -> Expr:
+        """
+        Extract the total days from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_days` instead.
+
+        """
+        return self.total_days()
+
+    @deprecate_renamed_function("total_hours", version="0.19.13")
+    def hours(self) -> Expr:
+        """
+        Extract the total hours from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_hours` instead.
+
+        """
+        return self.total_hours()
+
+    @deprecate_renamed_function("total_minutes", version="0.19.13")
+    def minutes(self) -> Expr:
+        """
+        Extract the total minutes from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_minutes` instead.
+
+        """
+        return self.total_minutes()
+
+    @deprecate_renamed_function("total_seconds", version="0.19.13")
+    def seconds(self) -> Expr:
+        """
+        Extract the total seconds from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_seconds` instead.
+
+        """
+        return self.total_seconds()
+
+    @deprecate_renamed_function("total_milliseconds", version="0.19.13")
+    def milliseconds(self) -> Expr:
+        """
+        Extract the total milliseconds from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_milliseconds` instead.
+
+        """
+        return self.total_milliseconds()
+
+    @deprecate_renamed_function("total_microseconds", version="0.19.13")
+    def microseconds(self) -> Expr:
+        """
+        Extract the total microseconds from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_microseconds` instead.
+
+        """
+        return self.total_microseconds()
+
+    @deprecate_renamed_function("total_nanoseconds", version="0.19.13")
+    def nanoseconds(self) -> Expr:
+        """
+        Extract the total nanoseconds from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_nanoseconds` instead.
+
+        """
+        return self.total_nanoseconds()

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -9,7 +9,10 @@ from polars.datatypes import DTYPE_TEMPORAL_UNITS, Date, Int32
 from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
 from polars.utils.convert import _timedelta_to_pl_duration
-from polars.utils.deprecation import rename_use_earliest_to_ambiguous
+from polars.utils.deprecation import (
+    deprecate_renamed_function,
+    rename_use_earliest_to_ambiguous,
+)
 
 if TYPE_CHECKING:
     from datetime import timedelta
@@ -1454,9 +1457,20 @@ class ExprDateTimeNameSpace:
             self._pyexpr.dt_replace_time_zone(time_zone, ambiguous._pyexpr)
         )
 
+    @deprecate_renamed_function("total_days", version="0.19.3")
     def days(self) -> Expr:
         """
-        Extract the days from a Duration type.
+        Extract the total days from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_days` instead.
+
+        """
+        return self.total_days()
+
+    def total_days(self) -> Expr:
+        """
+        Extract the total days from a Duration type.
 
         Returns
         -------
@@ -1476,7 +1490,7 @@ class ExprDateTimeNameSpace:
         >>> df.select(
         ...     [
         ...         pl.col("date"),
-        ...         pl.col("date").diff().dt.days().alias("days_diff"),
+        ...         pl.col("date").diff().dt.total_days().alias("days_diff"),
         ...     ]
         ... )
         shape: (3, 2)
@@ -1493,9 +1507,20 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.duration_days())
 
+    @deprecate_renamed_function("total_hours", version="0.19.3")
     def hours(self) -> Expr:
         """
-        Extract the hours from a Duration type.
+        Extract the total hours from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_hours` instead.
+
+        """
+        return self.total_hours()
+
+    def total_hours(self) -> Expr:
+        """
+        Extract the total hours from a Duration type.
 
         Returns
         -------
@@ -1515,7 +1540,7 @@ class ExprDateTimeNameSpace:
         >>> df.select(
         ...     [
         ...         pl.col("date"),
-        ...         pl.col("date").diff().dt.hours().alias("hours_diff"),
+        ...         pl.col("date").diff().dt.total_hours().alias("hours_diff"),
         ...     ]
         ... )
         shape: (4, 2)
@@ -1533,9 +1558,20 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.duration_hours())
 
+    @deprecate_renamed_function("total_minutes", version="0.19.3")
     def minutes(self) -> Expr:
         """
-        Extract the minutes from a Duration type.
+        Extract the total minutes from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_minutes` instead.
+
+        """
+        return self.total_minutes()
+
+    def total_minutes(self) -> Expr:
+        """
+        Extract the total minutes from a Duration type.
 
         Returns
         -------
@@ -1555,7 +1591,7 @@ class ExprDateTimeNameSpace:
         >>> df.select(
         ...     [
         ...         pl.col("date"),
-        ...         pl.col("date").diff().dt.minutes().alias("minutes_diff"),
+        ...         pl.col("date").diff().dt.total_minutes().alias("minutes_diff"),
         ...     ]
         ... )
         shape: (4, 2)
@@ -1573,9 +1609,20 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.duration_minutes())
 
+    @deprecate_renamed_function("total_seconds", version="0.19.3")
     def seconds(self) -> Expr:
         """
-        Extract the seconds from a Duration type.
+        Extract the total seconds from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_seconds` instead.
+
+        """
+        return self.total_seconds()
+
+    def total_seconds(self) -> Expr:
+        """
+        Extract the total seconds from a Duration type.
 
         Returns
         -------
@@ -1596,10 +1643,8 @@ class ExprDateTimeNameSpace:
         ...     }
         ... )
         >>> df.select(
-        ...     [
-        ...         pl.col("date"),
-        ...         pl.col("date").diff().dt.seconds().alias("seconds_diff"),
-        ...     ]
+        ...     pl.col("date"),
+        ...     pl.col("date").diff().dt.total_seconds().alias("seconds_diff"),
         ... )
         shape: (5, 2)
         ┌─────────────────────┬──────────────┐
@@ -1617,9 +1662,20 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.duration_seconds())
 
+    @deprecate_renamed_function("total_milliseconds", version="0.19.3")
     def milliseconds(self) -> Expr:
         """
-        Extract the milliseconds from a Duration type.
+        Extract the total milliseconds from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_milliseconds` instead.
+
+        """
+        return self.total_milliseconds()
+
+    def total_milliseconds(self) -> Expr:
+        """
+        Extract the total milliseconds from a Duration type.
 
         Returns
         -------
@@ -1640,10 +1696,8 @@ class ExprDateTimeNameSpace:
         ...     }
         ... )
         >>> df.select(
-        ...     [
-        ...         pl.col("date"),
-        ...         pl.col("date").diff().dt.milliseconds().alias("milliseconds_diff"),
-        ...     ]
+        ...     pl.col("date"),
+        ...     milliseconds_diff=pl.col("date").diff().dt.total_milliseconds(),
         ... )
         shape: (1_001, 2)
         ┌─────────────────────────┬───────────────────┐
@@ -1665,9 +1719,20 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.duration_milliseconds())
 
+    @deprecate_renamed_function("total_microseconds", version="0.19.3")
     def microseconds(self) -> Expr:
         """
-        Extract the microseconds from a Duration type.
+        Extract the total microseconds from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_microseconds` instead.
+
+        """
+        return self.total_microseconds()
+
+    def total_microseconds(self) -> Expr:
+        """
+        Extract the total microseconds from a Duration type.
 
         Returns
         -------
@@ -1688,10 +1753,8 @@ class ExprDateTimeNameSpace:
         ...     }
         ... )
         >>> df.select(
-        ...     [
-        ...         pl.col("date"),
-        ...         pl.col("date").diff().dt.microseconds().alias("microseconds_diff"),
-        ...     ]
+        ...     pl.col("date"),
+        ...     microseconds_diff=pl.col("date").diff().dt.total_microseconds(),
         ... )
         shape: (1_001, 2)
         ┌─────────────────────────┬───────────────────┐
@@ -1713,9 +1776,20 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.duration_microseconds())
 
+    @deprecate_renamed_function("total_nanoseconds", version="0.19.3")
     def nanoseconds(self) -> Expr:
         """
-        Extract the nanoseconds from a Duration type.
+        Extract the total nanoseconds from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_nanoseconds` instead.
+
+        """
+        return self.total_nanoseconds()
+
+    def total_nanoseconds(self) -> Expr:
+        """
+        Extract the total nanoseconds from a Duration type.
 
         Returns
         -------
@@ -1736,10 +1810,8 @@ class ExprDateTimeNameSpace:
         ...     }
         ... )
         >>> df.select(
-        ...     [
-        ...         pl.col("date"),
-        ...         pl.col("date").diff().dt.nanoseconds().alias("nanoseconds_diff"),
-        ...     ]
+        ...     pl.col("date"),
+        ...     nanoseconds_diff=pl.col("date").diff().dt.total_nanoseconds(),
         ... )
         shape: (1_001, 2)
         ┌─────────────────────────┬──────────────────┐

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -1494,7 +1494,7 @@ class ExprDateTimeNameSpace:
         └─────────────────────┴───────────┘
 
         """
-        return wrap_expr(self._pyexpr.duration_days())
+        return wrap_expr(self._pyexpr.dt_total_days())
 
     def total_hours(self) -> Expr:
         """
@@ -1534,7 +1534,7 @@ class ExprDateTimeNameSpace:
         └─────────────────────┴────────────┘
 
         """
-        return wrap_expr(self._pyexpr.duration_hours())
+        return wrap_expr(self._pyexpr.dt_total_hours())
 
     def total_minutes(self) -> Expr:
         """
@@ -1574,7 +1574,7 @@ class ExprDateTimeNameSpace:
         └─────────────────────┴──────────────┘
 
         """
-        return wrap_expr(self._pyexpr.duration_minutes())
+        return wrap_expr(self._pyexpr.dt_total_minutes())
 
     def total_seconds(self) -> Expr:
         """
@@ -1616,7 +1616,7 @@ class ExprDateTimeNameSpace:
         └─────────────────────┴──────────────┘
 
         """
-        return wrap_expr(self._pyexpr.duration_seconds())
+        return wrap_expr(self._pyexpr.dt_total_seconds())
 
     def total_milliseconds(self) -> Expr:
         """
@@ -1662,7 +1662,7 @@ class ExprDateTimeNameSpace:
         └─────────────────────────┴───────────────────┘
 
         """
-        return wrap_expr(self._pyexpr.duration_milliseconds())
+        return wrap_expr(self._pyexpr.dt_total_milliseconds())
 
     def total_microseconds(self) -> Expr:
         """
@@ -1708,7 +1708,7 @@ class ExprDateTimeNameSpace:
         └─────────────────────────┴───────────────────┘
 
         """
-        return wrap_expr(self._pyexpr.duration_microseconds())
+        return wrap_expr(self._pyexpr.dt_total_microseconds())
 
     def total_nanoseconds(self) -> Expr:
         """
@@ -1754,7 +1754,7 @@ class ExprDateTimeNameSpace:
         └─────────────────────────┴──────────────────┘
 
         """
-        return wrap_expr(self._pyexpr.duration_nanoseconds())
+        return wrap_expr(self._pyexpr.dt_total_nanoseconds())
 
     def offset_by(self, by: str | Expr) -> Expr:
         """

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -6,6 +6,7 @@ from polars.datatypes import Date
 from polars.series.utils import expr_dispatch
 from polars.utils._wrap import wrap_s
 from polars.utils.convert import _to_python_date, _to_python_datetime
+from polars.utils.deprecation import deprecate_renamed_function
 
 if TYPE_CHECKING:
     import datetime as dt
@@ -1097,9 +1098,20 @@ class DateTimeNameSpace:
 
         """
 
+    @deprecate_renamed_function("total_days", version="0.19.3")
     def days(self) -> Series:
         """
-        Extract the days from a Duration type.
+        Extract the total days from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_days` instead.
+
+        """
+        return self.total_days()
+
+    def total_days(self) -> Series:
+        """
+        Extract the total days from a Duration type.
 
         Returns
         -------
@@ -1120,7 +1132,7 @@ class DateTimeNameSpace:
                 2020-04-01 00:00:00
                 2020-05-01 00:00:00
         ]
-        >>> date.diff().dt.days()
+        >>> date.diff().dt.total_days()
         shape: (3,)
         Series: 'datetime' [i64]
         [
@@ -1131,9 +1143,20 @@ class DateTimeNameSpace:
 
         """
 
+    @deprecate_renamed_function("total_hours", version="0.19.3")
     def hours(self) -> Series:
         """
-        Extract the hours from a Duration type.
+        Extract the total hours from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_hours` instead.
+
+        """
+        return self.total_hours()
+
+    def total_hours(self) -> Series:
+        """
+        Extract the total hours from a Duration type.
 
         Returns
         -------
@@ -1155,7 +1178,7 @@ class DateTimeNameSpace:
                 2020-01-03 00:00:00
                 2020-01-04 00:00:00
         ]
-        >>> date.diff().dt.hours()
+        >>> date.diff().dt.total_hours()
         shape: (4,)
         Series: 'datetime' [i64]
         [
@@ -1167,9 +1190,20 @@ class DateTimeNameSpace:
 
         """
 
+    @deprecate_renamed_function("total_minutes", version="0.19.3")
     def minutes(self) -> Series:
         """
-        Extract the minutes from a Duration type.
+        Extract the total minutes from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_minutes` instead.
+
+        """
+        return self.total_minutes()
+
+    def total_minutes(self) -> Series:
+        """
+        Extract the total minutes from a Duration type.
 
         Returns
         -------
@@ -1191,7 +1225,7 @@ class DateTimeNameSpace:
                 2020-01-03 00:00:00
                 2020-01-04 00:00:00
         ]
-        >>> date.diff().dt.minutes()
+        >>> date.diff().dt.total_minutes()
         shape: (4,)
         Series: 'datetime' [i64]
         [
@@ -1203,9 +1237,20 @@ class DateTimeNameSpace:
 
         """
 
+    @deprecate_renamed_function("total_seconds", version="0.19.3")
     def seconds(self) -> Series:
         """
-        Extract the seconds from a Duration type.
+        Extract the total seconds from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_seconds` instead.
+
+        """
+        return self.total_seconds()
+
+    def total_seconds(self) -> Series:
+        """
+        Extract the total seconds from a Duration type.
 
         Returns
         -------
@@ -1228,7 +1273,7 @@ class DateTimeNameSpace:
                 2020-01-01 00:03:00
                 2020-01-01 00:04:00
         ]
-        >>> date.diff().dt.seconds()
+        >>> date.diff().dt.total_seconds()
         shape: (5,)
         Series: 'datetime' [i64]
         [
@@ -1241,9 +1286,20 @@ class DateTimeNameSpace:
 
         """
 
+    @deprecate_renamed_function("total_milliseconds", version="0.19.3")
     def milliseconds(self) -> Series:
         """
-        Extract the milliseconds from a Duration type.
+        Extract the total milliseconds from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_milliseconds` instead.
+
+        """
+        return self.total_milliseconds()
+
+    def total_milliseconds(self) -> Series:
+        """
+        Extract the total milliseconds from a Duration type.
 
         Returns
         -------
@@ -1267,7 +1323,7 @@ class DateTimeNameSpace:
                 2020-01-01 00:00:00.001
                 2020-01-01 00:00:00.002
         ]
-        >>> date.diff().dt.milliseconds()
+        >>> date.diff().dt.total_milliseconds()
         shape: (3,)
         Series: 'datetime' [i64]
         [
@@ -1278,9 +1334,20 @@ class DateTimeNameSpace:
 
         """
 
+    @deprecate_renamed_function("total_microseconds", version="0.19.3")
     def microseconds(self) -> Series:
         """
-        Extract the microseconds from a Duration type.
+        Extract the total microseconds from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_microseconds` instead.
+
+        """
+        return self.total_microseconds()
+
+    def total_microseconds(self) -> Series:
+        """
+        Extract the total microseconds from a Duration type.
 
         Returns
         -------
@@ -1304,7 +1371,7 @@ class DateTimeNameSpace:
                 2020-01-01 00:00:00.001
                 2020-01-01 00:00:00.002
         ]
-        >>> date.diff().dt.microseconds()
+        >>> date.diff().dt.total_microseconds()
         shape: (3,)
         Series: 'datetime' [i64]
         [
@@ -1315,9 +1382,20 @@ class DateTimeNameSpace:
 
         """
 
+    @deprecate_renamed_function("total_nanoseconds", version="0.19.3")
     def nanoseconds(self) -> Series:
         """
-        Extract the nanoseconds from a Duration type.
+        Extract the total nanoseconds from a Duration type.
+
+        .. deprecated:: 0.19.3
+            Use :meth:`total_nanoseconds` instead.
+
+        """
+        return self.total_nanoseconds()
+
+    def total_nanoseconds(self) -> Series:
+        """
+        Extract the total nanoseconds from a Duration type.
 
         Returns
         -------
@@ -1341,7 +1419,7 @@ class DateTimeNameSpace:
                 2020-01-01 00:00:00.001
                 2020-01-01 00:00:00.002
         ]
-        >>> date.diff().dt.nanoseconds()
+        >>> date.diff().dt.total_nanoseconds()
         shape: (3,)
         Series: 'datetime' [i64]
         [

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1098,17 +1098,6 @@ class DateTimeNameSpace:
 
         """
 
-    @deprecate_renamed_function("total_days", version="0.19.3")
-    def days(self) -> Series:
-        """
-        Extract the total days from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_days` instead.
-
-        """
-        return self.total_days()
-
     def total_days(self) -> Series:
         """
         Extract the total days from a Duration type.
@@ -1142,17 +1131,6 @@ class DateTimeNameSpace:
         ]
 
         """
-
-    @deprecate_renamed_function("total_hours", version="0.19.3")
-    def hours(self) -> Series:
-        """
-        Extract the total hours from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_hours` instead.
-
-        """
-        return self.total_hours()
 
     def total_hours(self) -> Series:
         """
@@ -1190,17 +1168,6 @@ class DateTimeNameSpace:
 
         """
 
-    @deprecate_renamed_function("total_minutes", version="0.19.3")
-    def minutes(self) -> Series:
-        """
-        Extract the total minutes from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_minutes` instead.
-
-        """
-        return self.total_minutes()
-
     def total_minutes(self) -> Series:
         """
         Extract the total minutes from a Duration type.
@@ -1236,17 +1203,6 @@ class DateTimeNameSpace:
         ]
 
         """
-
-    @deprecate_renamed_function("total_seconds", version="0.19.3")
-    def seconds(self) -> Series:
-        """
-        Extract the total seconds from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_seconds` instead.
-
-        """
-        return self.total_seconds()
 
     def total_seconds(self) -> Series:
         """
@@ -1286,17 +1242,6 @@ class DateTimeNameSpace:
 
         """
 
-    @deprecate_renamed_function("total_milliseconds", version="0.19.3")
-    def milliseconds(self) -> Series:
-        """
-        Extract the total milliseconds from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_milliseconds` instead.
-
-        """
-        return self.total_milliseconds()
-
     def total_milliseconds(self) -> Series:
         """
         Extract the total milliseconds from a Duration type.
@@ -1334,17 +1279,6 @@ class DateTimeNameSpace:
 
         """
 
-    @deprecate_renamed_function("total_microseconds", version="0.19.3")
-    def microseconds(self) -> Series:
-        """
-        Extract the total microseconds from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_microseconds` instead.
-
-        """
-        return self.total_microseconds()
-
     def total_microseconds(self) -> Series:
         """
         Extract the total microseconds from a Duration type.
@@ -1381,17 +1315,6 @@ class DateTimeNameSpace:
         ]
 
         """
-
-    @deprecate_renamed_function("total_nanoseconds", version="0.19.3")
-    def nanoseconds(self) -> Series:
-        """
-        Extract the total nanoseconds from a Duration type.
-
-        .. deprecated:: 0.19.3
-            Use :meth:`total_nanoseconds` instead.
-
-        """
-        return self.total_nanoseconds()
 
     def total_nanoseconds(self) -> Series:
         """
@@ -1985,3 +1908,80 @@ class DateTimeNameSpace:
         ]
 
         """
+
+    @deprecate_renamed_function("total_days", version="0.19.13")
+    def days(self) -> Series:
+        """
+        Extract the total days from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_days` instead.
+
+        """
+        return self.total_days()
+
+    @deprecate_renamed_function("total_hours", version="0.19.13")
+    def hours(self) -> Series:
+        """
+        Extract the total hours from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_hours` instead.
+
+        """
+        return self.total_hours()
+
+    @deprecate_renamed_function("total_minutes", version="0.19.13")
+    def minutes(self) -> Series:
+        """
+        Extract the total minutes from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_minutes` instead.
+
+        """
+        return self.total_minutes()
+
+    @deprecate_renamed_function("total_seconds", version="0.19.13")
+    def seconds(self) -> Series:
+        """
+        Extract the total seconds from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_seconds` instead.
+
+        """
+        return self.total_seconds()
+
+    @deprecate_renamed_function("total_milliseconds", version="0.19.13")
+    def milliseconds(self) -> Series:
+        """
+        Extract the total milliseconds from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_milliseconds` instead.
+
+        """
+        return self.total_milliseconds()
+
+    @deprecate_renamed_function("total_microseconds", version="0.19.13")
+    def microseconds(self) -> Series:
+        """
+        Extract the total microseconds from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_microseconds` instead.
+
+        """
+        return self.total_microseconds()
+
+    @deprecate_renamed_function("total_nanoseconds", version="0.19.13")
+    def nanoseconds(self) -> Series:
+        """
+        Extract the total nanoseconds from a Duration type.
+
+        .. deprecated:: 0.19.13
+            Use :meth:`total_nanoseconds` instead.
+
+        """
+        return self.total_nanoseconds()

--- a/py-polars/src/expr/datetime.rs
+++ b/py-polars/src/expr/datetime.rs
@@ -149,7 +149,7 @@ impl PyExpr {
         self.inner.clone().dt().timestamp(time_unit.0).into()
     }
 
-    fn duration_days(&self) -> Self {
+    fn dt_total_days(&self) -> Self {
         self.inner
             .clone()
             .map(
@@ -158,7 +158,7 @@ impl PyExpr {
             )
             .into()
     }
-    fn duration_hours(&self) -> Self {
+    fn dt_total_hours(&self) -> Self {
         self.inner
             .clone()
             .map(
@@ -167,7 +167,7 @@ impl PyExpr {
             )
             .into()
     }
-    fn duration_minutes(&self) -> Self {
+    fn dt_total_minutes(&self) -> Self {
         self.inner
             .clone()
             .map(
@@ -176,7 +176,7 @@ impl PyExpr {
             )
             .into()
     }
-    fn duration_seconds(&self) -> Self {
+    fn dt_total_seconds(&self) -> Self {
         self.inner
             .clone()
             .map(
@@ -185,7 +185,7 @@ impl PyExpr {
             )
             .into()
     }
-    fn duration_milliseconds(&self) -> Self {
+    fn dt_total_milliseconds(&self) -> Self {
         self.inner
             .clone()
             .map(
@@ -194,7 +194,7 @@ impl PyExpr {
             )
             .into()
     }
-    fn duration_microseconds(&self) -> Self {
+    fn dt_total_microseconds(&self) -> Self {
         self.inner
             .clone()
             .map(
@@ -203,7 +203,7 @@ impl PyExpr {
             )
             .into()
     }
-    fn duration_nanoseconds(&self) -> Self {
+    fn dt_total_nanoseconds(&self) -> Self {
         self.inner
             .clone()
             .map(

--- a/py-polars/tests/parametric/test_series.py
+++ b/py-polars/tests/parametric/test_series.py
@@ -132,9 +132,9 @@ def test_series_datetime_timeunits(
 def test_series_duration_timeunits(
     s: pl.Series,
 ) -> None:
-    nanos = s.dt.nanoseconds().to_list()
-    micros = s.dt.microseconds().to_list()
-    millis = s.dt.milliseconds().to_list()
+    nanos = s.dt.total_nanoseconds().to_list()
+    micros = s.dt.total_microseconds().to_list()
+    millis = s.dt.total_milliseconds().to_list()
 
     scale = {
         "ns": 1,
@@ -147,14 +147,14 @@ def test_series_duration_timeunits(
 
     # special handling for ns timeunit (as we may generate a microsecs-based
     # timedelta that results in 64bit overflow on conversion to nanosecs)
-    micros = s.dt.microseconds().to_list()
+    micros = s.dt.total_microseconds().to_list()
     lower_bound, upper_bound = -(2**63), (2**63) - 1
     if all(
         (lower_bound <= (us * 1000) <= upper_bound)
         for us in micros
         if isinstance(us, int)
     ):
-        for ns, us in zip(s.dt.nanoseconds(), micros):
+        for ns, us in zip(s.dt.total_nanoseconds(), micros):
             assert ns == (us * 1000)
 
 

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -245,7 +245,9 @@ def test_int_to_python_datetime() -> None:
     assert df.select(
         [pl.col(col).dt.timestamp() for col in ("c", "d", "e")]
         + [
-            getattr(pl.col("b").cast(pl.Duration).dt, unit)().alias(f"u[{unit}]")
+            getattr(pl.col("b").cast(pl.Duration).dt, f"total_{unit}")().alias(
+                f"u[{unit}]"
+            )
             for unit in ("milliseconds", "microseconds", "nanoseconds")
         ]
     ).rows() == [
@@ -1395,7 +1397,10 @@ def test_sum_duration() -> None:
             {"name": "Jen", "duration": timedelta(seconds=60)},
         ]
     ).select(
-        [pl.col("duration").sum(), pl.col("duration").dt.seconds().alias("sec").sum()]
+        [
+            pl.col("duration").sum(),
+            pl.col("duration").dt.total_seconds().alias("sec").sum(),
+        ]
     ).to_dict(as_series=False) == {
         "duration": [timedelta(seconds=150)],
         "sec": [150],

--- a/py-polars/tests/unit/functions/as_datatype/test_duration.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_duration.py
@@ -41,7 +41,9 @@ def test_duration_time_units(time_unit: TimeUnit, expected: timedelta) -> None:
     assert result.schema["duration"] == pl.Duration(time_unit)
     assert result.collect()["duration"].item() == expected
     if time_unit == "ns":
-        assert result.collect()["duration"].dt.nanoseconds().item() == 86523004005006
+        assert (
+            result.collect()["duration"].dt.total_nanoseconds().item() == 86523004005006
+        )
 
 
 def test_datetime_duration_offset() -> None:

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -400,13 +400,13 @@ def test_strptime_fractional_seconds(series_of_str_dates: pl.Series) -> None:
 @pytest.mark.parametrize(
     ("unit_attr", "expected"),
     [
-        ("days", pl.Series([1])),
-        ("hours", pl.Series([24])),
-        ("minutes", pl.Series([24 * 60])),
-        ("seconds", pl.Series([3600 * 24])),
-        ("milliseconds", pl.Series([3600 * 24 * int(1e3)])),
-        ("microseconds", pl.Series([3600 * 24 * int(1e6)])),
-        ("nanoseconds", pl.Series([3600 * 24 * int(1e9)])),
+        ("total_days", pl.Series([1])),
+        ("total_hours", pl.Series([24])),
+        ("total_minutes", pl.Series([24 * 60])),
+        ("total_seconds", pl.Series([3600 * 24])),
+        ("total_milliseconds", pl.Series([3600 * 24 * int(1e3)])),
+        ("total_microseconds", pl.Series([3600 * 24 * int(1e6)])),
+        ("total_nanoseconds", pl.Series([3600 * 24 * int(1e9)])),
     ],
 )
 def test_duration_extract_times(
@@ -416,6 +416,32 @@ def test_duration_extract_times(
     duration = pl.Series([datetime(2022, 1, 2)]) - pl.Series([datetime(2022, 1, 1)])
 
     assert_series_equal(getattr(duration.dt, unit_attr)(), expected)
+
+
+@pytest.mark.parametrize(
+    ("unit_attr", "expected"),
+    [
+        ("days", pl.Series([1])),
+        ("hours", pl.Series([24])),
+        ("minutes", pl.Series([24 * 60])),
+        ("seconds", pl.Series([3600 * 24])),
+        ("milliseconds", pl.Series([3600 * 24 * int(1e3)])),
+        ("microseconds", pl.Series([3600 * 24 * int(1e6)])),
+        ("nanoseconds", pl.Series([3600 * 24 * int(1e9)])),
+    ],
+)
+def test_duration_extract_times_deprecated_methods(
+    unit_attr: str,
+    expected: pl.Series,
+) -> None:
+    duration = pl.Series([datetime(2022, 1, 2)]) - pl.Series([datetime(2022, 1, 1)])
+
+    with pytest.deprecated_call():
+        assert_series_equal(getattr(duration.dt, unit_attr)(), expected)
+    with pytest.deprecated_call():
+        # Test Expr case too
+        result_df = pl.select(getattr(pl.lit(duration).dt, unit_attr)())
+        assert_series_equal(result_df[result_df.columns[0]], expected)
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -144,7 +144,7 @@ def test_median_on_shifted_col_3522() -> None:
             ]
         }
     )
-    diffs = df.select(pl.col("foo").diff().dt.seconds())
+    diffs = df.select(pl.col("foo").diff().dt.total_seconds())
     assert diffs.select(pl.col("foo").median()).to_series()[0] == 36828.5
 
 


### PR DESCRIPTION
closes #6445 

as mentioned in the issue, `.seconds` looks like `.seconds` from pandas / Python stdlib, but it actually equivalent to `.total_seconds`