### PR TITLE
ci: Temporarily disable aarch linux wheel in Python release workflow

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -96,6 +96,11 @@ jobs:
         exclude:
           - os: windows-32gb-ram
             architecture: aarch64
+          # Temporarily disable linux aarch64 cross compilation
+          # TODO: Renable this when issue is fixed
+          # https://github.com/pola-rs/polars/issues/12180
+          - os: ubuntu-latest
+            architecture: aarch64
 
     steps:
       - uses: actions/checkout@v4

--- a/py-polars/Cargo.lock
+++ b/py-polars/Cargo.lock
@@ -1962,7 +1962,6 @@ dependencies = [
  "polars-plan",
  "pyo3",
  "pyo3-built",
- "ring 0.17.4",
  "serde_json",
  "smartstring",
  "thiserror",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -26,8 +26,6 @@ numpy = { version = "0.20", default-features = false }
 once_cell = "1"
 pyo3 = { version = "0.20", features = ["abi3-py38", "extension-module", "multiple-pymethods"] }
 pyo3-built = { version = "0.4", optional = true }
-# Remove once release compiles without
-ring = { version = '=0.17.4' }
 serde_json = { version = "1", optional = true }
 smartstring = "1"
 thiserror = "1"


### PR DESCRIPTION
Related to https://github.com/pola-rs/polars/issues/12180