### PR TITLE
build(python): Include `rust-toolchain.toml` with sdist/wheels

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -51,9 +51,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Fix README symlink
-        run: rm py-polars/README.md && cp README.md py-polars/README.md
-
       - name: Install yq
         if: matrix.package != 'polars'
         run: pip install yq
@@ -74,8 +71,6 @@ jobs:
 
       - name: Test sdist
         run: |
-          TOOLCHAIN=$(grep -oP 'channel = "\K[^"]+' rust-toolchain.toml)
-          rustup default $TOOLCHAIN
           pip install --force-reinstall --verbose dist/*.tar.gz
           python -c 'import polars'
 
@@ -113,9 +108,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
-
-      - name: Fix README symlink
-        run: rm py-polars/README.md && cp README.md py-polars/README.md
 
       - name: Install yq
         if: matrix.package != 'polars'

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -60,6 +60,9 @@ all = [
   "polars[pyarrow,pandas,numpy,fsspec,connectorx,xlsx2csv,deltalake,timezone,matplotlib,pydantic,pyiceberg,sqlalchemy,xlsxwriter,adbc,cloudpickle,gevent]",
 ]
 
+[tool.maturin]
+include = ["rust-toolchain.toml"]
+
 [tool.mypy]
 files = ["polars", "tests"]
 strict = true

--- a/py-polars/rust-toolchain.toml
+++ b/py-polars/rust-toolchain.toml
@@ -1,0 +1,1 @@
+../rust-toolchain.toml


### PR DESCRIPTION
#### Changes

* Include `rust-toolchain.toml` with sdist/wheels. This allows maturin to find the right toolchain when building from source during a `pip install` of the sdist.
  * A symlink to the toplevel `rust-toolchain.toml` was added to the py-polars directory. maturin automatically includes the real file.
* Remove the step to replace the symlinked README with the real README. maturin does this automatically for the sdist. The wheels do not include the README anyway.