### PR TITLE
docs: Remove excessive code formatting from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ shape: (5, 8)
  └────────┴────────┘
 >>> ## OPTION 2
 >>> # Don't materialize the query, but return as LazyFrame
->>> # and continue in python
+>>> # and continue in Python
 >>> lf = context.execute(query)
 >>> (lf.join(other_table)
 ...      .group_by("foo")
@@ -249,7 +249,7 @@ Note that the Rust crate implementing the Python bindings is called `py-polars` 
 Rust crate `polars` itself. However, both the Python package and the Python module are named `polars`, so you
 can `pip install polars` and `import polars`.
 
-## Use custom Rust function in python?
+## Use custom Rust function in Python?
 
 Extending polars with UDFs compiled in Rust is easy. We expose pyo3 extensions for `DataFrame` and `Series`
 data structures. See more in https://github.com/pola-rs/pyo3-polars.
@@ -258,7 +258,7 @@ data structures. See more in https://github.com/pola-rs/pyo3-polars.
 
 Do you expect more than `2^32` ~4,2 billion rows? Compile polars with the `bigidx` feature flag.
 
-Or for python users install `pip install polars-u64-idx`.
+Or for Python users install `pip install polars-u64-idx`.
 
 Don't use this unless you hit the row boundary as the default polars is faster and consumes less memory.
 

--- a/README.md
+++ b/README.md
@@ -200,8 +200,8 @@ You can also install the dependencies directly.
 | Tag        | Description                                                                  |
 | ---------- | ---------------------------------------------------------------------------- |
 | **all**    | Install all optional dependencies (all of the following)                     |
-| pandas     | Install with Pandas for converting data to and from Pandas DataFrames/Series |
-| numpy      | Install with numpy for converting data to and from numpy arrays              |
+| pandas     | Install with pandas for converting data to and from pandas DataFrames/Series |
+| numpy      | Install with NumPy for converting data to and from NumPy arrays              |
 | pyarrow    | Reading data formats using PyArrow                                           |
 | fsspec     | Support for reading from remote file systems                                 |
 | connectorx | Support for reading from SQL databases                                       |

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Refer to the [Polars CLI repository](https://github.com/pola-rs/polars-cli) for 
 Polars is very fast. In fact, it is one of the best performing solutions available.
 See the results in [DuckDB's db-benchmark](https://duckdblabs.github.io/db-benchmark/).
 
-In the [TPCH benchmarks](https://www.pola.rs/benchmarks.html) polars is orders of magnitudes faster than pandas, dask, modin and vaex
+In the [TPCH benchmarks](https://www.pola.rs/benchmarks.html) Polars is orders of magnitudes faster than pandas, dask, modin and vaex
 on full queries (including IO).
 
 ### Lightweight
@@ -228,9 +228,9 @@ Required Rust version `>=1.71`.
 
 Want to contribute? Read our [contribution guideline](/CONTRIBUTING.md).
 
-## Python: compile polars from source
+## Python: compile Polars from source
 
-If you want a bleeding edge release or maximal performance you should compile **polars** from source.
+If you want a bleeding edge release or maximal performance you should compile **Polars** from source.
 
 This can be done by going through the following steps in sequence:
 
@@ -251,7 +251,7 @@ can `pip install polars` and `import polars`.
 
 ## Use custom Rust function in Python?
 
-Extending polars with UDFs compiled in Rust is easy. We expose pyo3 extensions for `DataFrame` and `Series`
+Extending Polars with UDFs compiled in Rust is easy. We expose pyo3 extensions for `DataFrame` and `Series`
 data structures. See more in https://github.com/pola-rs/pyo3-polars.
 
 ## Going big...
@@ -260,13 +260,13 @@ Do you expect more than `2^32` ~4,2 billion rows? Compile polars with the `bigid
 
 Or for Python users install `pip install polars-u64-idx`.
 
-Don't use this unless you hit the row boundary as the default polars is faster and consumes less memory.
+Don't use this unless you hit the row boundary as the default Polars is faster and consumes less memory.
 
 ## Legacy
 
-Do you want polars to run on an old CPU (e.g. dating from before 2011), or on an `x86-64` build
+Do you want Polars to run on an old CPU (e.g. dating from before 2011), or on an `x86-64` build
 of Python on Apple Silicon under Rosetta? Install `pip install polars-lts-cpu`. This version of
-polars is compiled without [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) target
+Polars is compiled without [AVX](https://en.wikipedia.org/wiki/Advanced_Vector_Extensions) target
 features.
 
 ## Sponsors

--- a/docs/getting-started/expressions.md
+++ b/docs/getting-started/expressions.md
@@ -1,6 +1,6 @@
 # Expressions
 
-`Expressions` are the core strength of `Polars`. The `expressions` offer a versatile structure that both solves easy queries and is easily extended to complex ones. Below we will cover the basic components that serve as building block (or in `Polars` terminology contexts) for all your queries:
+`Expressions` are the core strength of Polars. The `expressions` offer a versatile structure that both solves easy queries and is easily extended to complex ones. Below we will cover the basic components that serve as building block (or in Polars terminology contexts) for all your queries:
 
 - `select`
 - `filter`

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ Polars is a highly performant DataFrame library for manipulating structured data
 
 ## About this guide
 
-The Polars user guide is intended to live alongside the API documentation. Its purpose is to explain (new) users how to use `Polars` and to provide meaningful examples. The guide is split into two parts:
+The Polars user guide is intended to live alongside the API documentation. Its purpose is to explain (new) users how to use Polars and to provide meaningful examples. The guide is split into two parts:
 
 - [Getting started](getting-started/intro.md): A 10 minute helicopter view of the library and its primary function.
 - [User guide](user-guide/index.md): A detailed explanation of how the library is setup and how to use it most effectively.

--- a/docs/releases/upgrade/index.md
+++ b/docs/releases/upgrade/index.md
@@ -10,4 +10,4 @@ A full list of all changes is available in the [changelog](../changelog.md).
 !!! rust "Note"
 
     There is no upgrade guide yet for Rust releases.
-    It will be added once the rate of breaking changes to the rust API slows down and a [deprecation policy](../../development/versioning.md#deprecation-period) is added.
+    It will be added once the rate of breaking changes to the Rust API slows down and a [deprecation policy](../../development/versioning.md#deprecation-period) is added.

--- a/docs/releases/upgrade/index.md
+++ b/docs/releases/upgrade/index.md
@@ -9,5 +9,5 @@ A full list of all changes is available in the [changelog](../changelog.md).
 
 !!! rust "Note"
 
-    There is no upgrade guide yet for Rust releases.
-    It will be added once the rate of breaking changes to the Rust API slows down and a [deprecation policy](../../development/versioning.md#deprecation-period) is added.
+    There are no upgrade guides yet for Rust releases.
+    These will be added once the rate of breaking changes to the Rust API slows down and a [deprecation policy](../../development/versioning.md#deprecation-period) is added.

--- a/docs/user-guide/concepts/data-types.md
+++ b/docs/user-guide/concepts/data-types.md
@@ -1,8 +1,8 @@
 # Data types
 
-Polars is entirely based on `Arrow` data types and backed by `Arrow` memory arrays. This makes data processing
+Polars is entirely based on Arrow data types and backed by Arrow memory arrays. This makes data processing
 cache-efficient and well-supported for Inter Process Communication. Most data types follow the exact implementation
-from `Arrow`, with the exception of `Utf8` (this is actually `LargeUtf8`), `Categorical`, and `Object` (support is limited). The data types are:
+from Arrow, with the exception of `Utf8` (this is actually `LargeUtf8`), `Categorical`, and `Object` (support is limited). The data types are:
 
 | Group    | Type          | Details                                                                                                                                |
 | -------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
@@ -17,18 +17,18 @@ from `Arrow`, with the exception of `Utf8` (this is actually `LargeUtf8`), `Cate
 |          | `Float32`     | 32-bit floating point.                                                                                                                 |
 |          | `Float64`     | 64-bit floating point.                                                                                                                 |
 | Nested   | `Struct`      | A struct array is represented as a `Vec<Series>` and is useful to pack multiple/heterogenous values in a single column.                |
-|          | `List`        | A list array contains a child array containing the list values and an offset array. (this is actually `Arrow` `LargeList` internally). |
+|          | `List`        | A list array contains a child array containing the list values and an offset array. (this is actually Arrow `LargeList` internally). |
 | Temporal | `Date`        | Date representation, internally represented as days since UNIX epoch encoded by a 32-bit signed integer.                               |
 |          | `Datetime`    | Datetime representation, internally represented as microseconds since UNIX epoch encoded by a 64-bit signed integer.                   |
 |          | `Duration`    | A timedelta type, internally represented as microseconds. Created when subtracting `Date/Datetime`.                                    |
 |          | `Time`        | Time representation, internally represented as nanoseconds since midnight.                                                             |
 | Other    | `Boolean`     | Boolean type effectively bit packed.                                                                                                   |
-|          | `Utf8`        | String data (this is actually `Arrow` `LargeUtf8` internally).                                                                         |
+|          | `Utf8`        | String data (this is actually Arrow `LargeUtf8` internally).                                                                         |
 |          | `Binary`      | Store data as bytes.                                                                                                                   |
 |          | `Object`      | A limited supported data type that can be any value.                                                                                   |
 |          | `Categorical` | A categorical encoding of a set of strings.                                                                                            |
 
-To learn more about the internal representation of these data types, check the [`Arrow` columnar format](https://arrow.apache.org/docs/format/Columnar.html).
+To learn more about the internal representation of these data types, check the [Arrow columnar format](https://arrow.apache.org/docs/format/Columnar.html).
 
 ## Floating Point
 

--- a/docs/user-guide/concepts/data-types.md
+++ b/docs/user-guide/concepts/data-types.md
@@ -1,6 +1,6 @@
 # Data types
 
-`Polars` is entirely based on `Arrow` data types and backed by `Arrow` memory arrays. This makes data processing
+Polars is entirely based on `Arrow` data types and backed by `Arrow` memory arrays. This makes data processing
 cache-efficient and well-supported for Inter Process Communication. Most data types follow the exact implementation
 from `Arrow`, with the exception of `Utf8` (this is actually `LargeUtf8`), `Categorical`, and `Object` (support is limited). The data types are:
 
@@ -32,7 +32,7 @@ To learn more about the internal representation of these data types, check the [
 
 ## Floating Point
 
-`Polars` generally follows the IEEE 754 floating point standard for `Float32` and `Float64`, with some exceptions:
+Polars generally follows the IEEE 754 floating point standard for `Float32` and `Float64`, with some exceptions:
 
 - Any NaN compares equal to any other NaN, and greater than any non-NaN value.
 - Operations do not guarantee any particular behavior on the sign of zero or NaN,
@@ -40,6 +40,6 @@ To learn more about the internal representation of these data types, check the [
   e.g. a sort or group by operation may canonicalize all zeroes to +0 and all NaNs
   to a positive NaN without payload for efficient equality checks.
 
-`Polars` always attempts to provide reasonably accurate results for floating point computations, but does not provide guarantees
+Polars always attempts to provide reasonably accurate results for floating point computations, but does not provide guarantees
 on the error unless mentioned otherwise. Generally speaking 100% accurate results are infeasibly expensive to acquire (requiring
 much larger internal representations than 64-bit floats), and thus some error is always to be expected.

--- a/docs/user-guide/concepts/data-types.md
+++ b/docs/user-guide/concepts/data-types.md
@@ -4,29 +4,29 @@ Polars is entirely based on Arrow data types and backed by Arrow memory arrays. 
 cache-efficient and well-supported for Inter Process Communication. Most data types follow the exact implementation
 from Arrow, with the exception of `Utf8` (this is actually `LargeUtf8`), `Categorical`, and `Object` (support is limited). The data types are:
 
-| Group    | Type          | Details                                                                                                                                |
-| -------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Numeric  | `Int8`        | 8-bit signed integer.                                                                                                                  |
-|          | `Int16`       | 16-bit signed integer.                                                                                                                 |
-|          | `Int32`       | 32-bit signed integer.                                                                                                                 |
-|          | `Int64`       | 64-bit signed integer.                                                                                                                 |
-|          | `UInt8`       | 8-bit unsigned integer.                                                                                                                |
-|          | `UInt16`      | 16-bit unsigned integer.                                                                                                               |
-|          | `UInt32`      | 32-bit unsigned integer.                                                                                                               |
-|          | `UInt64`      | 64-bit unsigned integer.                                                                                                               |
-|          | `Float32`     | 32-bit floating point.                                                                                                                 |
-|          | `Float64`     | 64-bit floating point.                                                                                                                 |
-| Nested   | `Struct`      | A struct array is represented as a `Vec<Series>` and is useful to pack multiple/heterogenous values in a single column.                |
+| Group    | Type          | Details                                                                                                                              |
+| -------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Numeric  | `Int8`        | 8-bit signed integer.                                                                                                                |
+|          | `Int16`       | 16-bit signed integer.                                                                                                               |
+|          | `Int32`       | 32-bit signed integer.                                                                                                               |
+|          | `Int64`       | 64-bit signed integer.                                                                                                               |
+|          | `UInt8`       | 8-bit unsigned integer.                                                                                                              |
+|          | `UInt16`      | 16-bit unsigned integer.                                                                                                             |
+|          | `UInt32`      | 32-bit unsigned integer.                                                                                                             |
+|          | `UInt64`      | 64-bit unsigned integer.                                                                                                             |
+|          | `Float32`     | 32-bit floating point.                                                                                                               |
+|          | `Float64`     | 64-bit floating point.                                                                                                               |
+| Nested   | `Struct`      | A struct array is represented as a `Vec<Series>` and is useful to pack multiple/heterogenous values in a single column.              |
 |          | `List`        | A list array contains a child array containing the list values and an offset array. (this is actually Arrow `LargeList` internally). |
-| Temporal | `Date`        | Date representation, internally represented as days since UNIX epoch encoded by a 32-bit signed integer.                               |
-|          | `Datetime`    | Datetime representation, internally represented as microseconds since UNIX epoch encoded by a 64-bit signed integer.                   |
-|          | `Duration`    | A timedelta type, internally represented as microseconds. Created when subtracting `Date/Datetime`.                                    |
-|          | `Time`        | Time representation, internally represented as nanoseconds since midnight.                                                             |
-| Other    | `Boolean`     | Boolean type effectively bit packed.                                                                                                   |
+| Temporal | `Date`        | Date representation, internally represented as days since UNIX epoch encoded by a 32-bit signed integer.                             |
+|          | `Datetime`    | Datetime representation, internally represented as microseconds since UNIX epoch encoded by a 64-bit signed integer.                 |
+|          | `Duration`    | A timedelta type, internally represented as microseconds. Created when subtracting `Date/Datetime`.                                  |
+|          | `Time`        | Time representation, internally represented as nanoseconds since midnight.                                                           |
+| Other    | `Boolean`     | Boolean type effectively bit packed.                                                                                                 |
 |          | `Utf8`        | String data (this is actually Arrow `LargeUtf8` internally).                                                                         |
-|          | `Binary`      | Store data as bytes.                                                                                                                   |
-|          | `Object`      | A limited supported data type that can be any value.                                                                                   |
-|          | `Categorical` | A categorical encoding of a set of strings.                                                                                            |
+|          | `Binary`      | Store data as bytes.                                                                                                                 |
+|          | `Object`      | A limited supported data type that can be any value.                                                                                 |
+|          | `Categorical` | A categorical encoding of a set of strings.                                                                                          |
 
 To learn more about the internal representation of these data types, check the [Arrow columnar format](https://arrow.apache.org/docs/format/Columnar.html).
 

--- a/docs/user-guide/concepts/expressions.md
+++ b/docs/user-guide/concepts/expressions.md
@@ -1,6 +1,6 @@
 # Expressions
 
-`Polars` has a powerful concept called expressions that is central to its very fast performance.
+Polars has a powerful concept called expressions that is central to its very fast performance.
 
 Expressions are at the core of many data science operations:
 
@@ -16,12 +16,12 @@ However, expressions are also used within other operations:
 - calculating the size of groups in a `group_by` operation
 - taking the sum horizontally across columns
 
-`Polars` performs these core data transformations very quickly by:
+Polars performs these core data transformations very quickly by:
 
 - automatic query optimization on each expression
 - automatic parallelization of expressions on many columns
 
-Polars expressions are a mapping from a series to a series (or mathematically `Fn(Series) -> Series`). As expressions have a `Series` as an input and a `Series` as an output then it is straightforward to do a sequence of expressions (similar to method chaining in `Pandas`).
+Polars expressions are a mapping from a series to a series (or mathematically `Fn(Series) -> Series`). As expressions have a `Series` as an input and a `Series` as an output then it is straightforward to do a sequence of expressions (similar to method chaining in pandas).
 
 ## Examples
 
@@ -36,13 +36,13 @@ The snippet above says:
 1. Then take the first two values of the sorted output
 
 The power of expressions is that every expression produces a new expression, and that they
-can be _piped_ together. You can run an expression by passing them to one of `Polars` execution contexts.
+can be _piped_ together. You can run an expression by passing them to one of Polars execution contexts.
 
 Here we run two expressions by running `df.select`:
 
 {{code_block('user-guide/concepts/expressions','example2',['select'])}}
 
-All expressions are run in parallel, meaning that separate `Polars` expressions are **embarrassingly parallel**. Note that within an expression there may be more parallelization going on.
+All expressions are run in parallel, meaning that separate Polars expressions are **embarrassingly parallel**. Note that within an expression there may be more parallelization going on.
 
 ## Conclusion
 

--- a/docs/user-guide/concepts/lazy-vs-eager.md
+++ b/docs/user-guide/concepts/lazy-vs-eager.md
@@ -1,6 +1,6 @@
 # Lazy / eager API
 
-`Polars` supports two modes of operation: lazy and eager. In the eager API the query is executed immediately while in the lazy API the query is only evaluated once it is 'needed'. Deferring the execution to the last minute can have significant performance advantages that is why the Lazy API is preferred in most cases. Let us demonstrate this with an example:
+Polars supports two modes of operation: lazy and eager. In the eager API the query is executed immediately while in the lazy API the query is only evaluated once it is 'needed'. Deferring the execution to the last minute can have significant performance advantages that is why the Lazy API is preferred in most cases. Let us demonstrate this with an example:
 
 {{code_block('user-guide/concepts/lazy-vs-eager','eager',['read_csv'])}}
 
@@ -17,7 +17,7 @@ Every step is executed immediately returning the intermediate results. This can 
 
 {{code_block('user-guide/concepts/lazy-vs-eager','lazy',['scan_csv'])}}
 
-These will significantly lower the load on memory & CPU thus allowing you to fit bigger datasets in memory and process faster. Once the query is defined you call `collect` to inform `Polars` that you want to execute it. In the section on Lazy API we will go into more details on its implementation.
+These will significantly lower the load on memory & CPU thus allowing you to fit bigger datasets in memory and process faster. Once the query is defined you call `collect` to inform Polars that you want to execute it. In the section on Lazy API we will go into more details on its implementation.
 
 !!! info "Eager API"
 

--- a/docs/user-guide/concepts/streaming.md
+++ b/docs/user-guide/concepts/streaming.md
@@ -1,6 +1,6 @@
 # Streaming API
 
-One additional benefit of the lazy API is that it allows queries to be executed in a streaming manner. Instead of processing the data all-at-once `Polars` can execute the query in batches allowing you to process datasets that are larger-than-memory.
+One additional benefit of the lazy API is that it allows queries to be executed in a streaming manner. Instead of processing the data all-at-once Polars can execute the query in batches allowing you to process datasets that are larger-than-memory.
 
 To tell Polars we want to execute a query in streaming mode we pass the `streaming=True` argument to `collect`
 

--- a/docs/user-guide/expressions/aggregation.md
+++ b/docs/user-guide/expressions/aggregation.md
@@ -1,6 +1,6 @@
 # Aggregation
 
-`Polars` implements a powerful syntax defined not only in its lazy API, but also in its eager API. Let's take a look at what that means.
+Polars implements a powerful syntax defined not only in its lazy API, but also in its eager API. Let's take a look at what that means.
 
 We can start with the simple [US congress `dataset`](https://github.com/unitedstates/congress-legislators).
 
@@ -64,7 +64,7 @@ In the example below we show how this can be done.
 
 !!! note
 
-    Note that we can make `Python` functions for clarity. These functions don't cost us anything. That is because we only create `Polars` expressions, we don't apply a custom function over a `Series` during runtime of the query. Of course, you can make functions that return expressions in Rust, too.
+    Note that we can make Python functions for clarity. These functions don't cost us anything. That is because we only create Polars expressions, we don't apply a custom function over a `Series` during runtime of the query. Of course, you can make functions that return expressions in Rust, too.
 
 {{code_block('user-guide/expressions/aggregation','filter',['group_by'])}}
 
@@ -102,21 +102,21 @@ We can even sort by another column in the `group_by` context. If we want to know
 
 !!! warning "Python Users Only"
 
-    The following section is specific to `Python`, and doesn't apply to `Rust`. Within `Rust`, blocks and closures (lambdas) can, and will, be executed concurrently.
+    The following section is specific to Python, and doesn't apply to Rust. Within Rust, blocks and closures (lambdas) can, and will, be executed concurrently.
 
-We have all heard that `Python` is slow, and does "not scale." Besides the overhead of
-running "slow" bytecode, `Python` has to remain within the constraints of the Global
-Interpreter Lock (GIL). This means that if you were to use a `lambda` or a custom `Python`
-function to apply during a parallelized phase, `Polars` speed is capped running `Python`
+We have all heard that Python is slow, and does "not scale." Besides the overhead of
+running "slow" bytecode, Python has to remain within the constraints of the Global
+Interpreter Lock (GIL). This means that if you were to use a `lambda` or a custom Python
+function to apply during a parallelized phase, Polars speed is capped running Python
 code preventing any multiple threads from executing the function.
 
 This all feels terribly limiting, especially because we often need those `lambda` functions in a
-`.group_by()` step, for example. This approach is still supported by `Polars`, but
+`.group_by()` step, for example. This approach is still supported by Polars, but
 keeping in mind bytecode **and** the GIL costs have to be paid. It is recommended to try to solve your queries using the expression syntax before moving to `lambdas`. If you want to learn more about using `lambdas`, go to the [user defined functions section](./user-defined-functions.md).
 
 ### Conclusion
 
-In the examples above we've seen that we can do a lot by combining expressions. By doing so we delay the use of custom `Python` functions that slow down the queries (by the slow nature of Python AND the GIL).
+In the examples above we've seen that we can do a lot by combining expressions. By doing so we delay the use of custom Python functions that slow down the queries (by the slow nature of Python AND the GIL).
 
 If we are missing a type expression let us know by opening a
 [feature request](https://github.com/pola-rs/polars/issues/new/choose)!

--- a/docs/user-guide/expressions/casting.md
+++ b/docs/user-guide/expressions/casting.md
@@ -1,6 +1,6 @@
 # Casting
 
-Casting converts the underlying [`DataType`](../concepts/data-types.md) of a column to a new one. Polars uses Arrow to manage the data in memory and relies on the compute kernels in the [rust implementation](https://github.com/jorgecarleitao/arrow2) to do the conversion. Casting is available with the `cast()` method.
+Casting converts the underlying [`DataType`](../concepts/data-types.md) of a column to a new one. Polars uses Arrow to manage the data in memory and relies on the compute kernels in the [Rust implementation](https://github.com/jorgecarleitao/arrow2) to do the conversion. Casting is available with the `cast()` method.
 
 The `cast` method includes a `strict` parameter that determines how Polars behaves when it encounters a value that can't be converted from the source `DataType` to the target `DataType`. By default, `strict=True`, which means that Polars will throw an error to notify the user of the failed conversion and provide details on the values that couldn't be cast. On the other hand, if `strict=False`, any values that can't be converted to the target `DataType` will be quietly converted to `null`.
 

--- a/docs/user-guide/expressions/folds.md
+++ b/docs/user-guide/expressions/folds.md
@@ -1,7 +1,7 @@
 # Folds
 
-`Polars` provides expressions/methods for horizontal aggregations like `sum`,`min`, `mean`,
-etc. However, when you need a more complex aggregation the default methods `Polars` supplies may not be sufficient. That's when `folds` come in handy.
+Polars provides expressions/methods for horizontal aggregations like `sum`,`min`, `mean`,
+etc. However, when you need a more complex aggregation the default methods Polars supplies may not be sufficient. That's when `folds` come in handy.
 
 The `fold` expression operates on columns for maximum speed. It utilizes the data layout very efficiently and often has vectorized execution.
 

--- a/docs/user-guide/expressions/functions.md
+++ b/docs/user-guide/expressions/functions.md
@@ -1,6 +1,6 @@
 # Functions
 
-`Polars` expressions have a large number of built in functions. These allow you to create complex queries without the need for [user defined functions](user-defined-functions.md). There are too many to go through here, but we will cover some of the more popular use cases. If you want to view all the functions go to the API Reference for your programming language.
+Polars expressions have a large number of built in functions. These allow you to create complex queries without the need for [user defined functions](user-defined-functions.md). There are too many to go through here, but we will cover some of the more popular use cases. If you want to view all the functions go to the API Reference for your programming language.
 
 In the examples below we will use the following `DataFrame`:
 
@@ -46,7 +46,7 @@ In case of multiple columns for example when using `all()` or `col(*)` you can a
 
 ## Count unique values
 
-There are two ways to count unique values in `Polars`: an exact methodology and an approximation. The approximation uses the [HyperLogLog++](https://en.wikipedia.org/wiki/HyperLogLog) algorithm to approximate the cardinality and is especially useful for very large datasets where an approximation is good enough.
+There are two ways to count unique values in Polars: an exact methodology and an approximation. The approximation uses the [HyperLogLog++](https://en.wikipedia.org/wiki/HyperLogLog) algorithm to approximate the cardinality and is especially useful for very large datasets where an approximation is good enough.
 
 {{code_block('user-guide/expressions/functions','countunique',['n_unique','approx_n_unique'])}}
 
@@ -56,7 +56,7 @@ There are two ways to count unique values in `Polars`: an exact methodology and 
 
 ## Conditionals
 
-`Polars` supports if-else like conditions in expressions with the `when`, `then`, `otherwise` syntax. The predicate is placed in the `when` clause and when this evaluates to `true` the `then` expression is applied otherwise the `otherwise` expression is applied (row-wise).
+Polars supports if-else like conditions in expressions with the `when`, `then`, `otherwise` syntax. The predicate is placed in the `when` clause and when this evaluates to `true` the `then` expression is applied otherwise the `otherwise` expression is applied (row-wise).
 
 {{code_block('user-guide/expressions/functions','conditional',['when'])}}
 

--- a/docs/user-guide/expressions/lists.md
+++ b/docs/user-guide/expressions/lists.md
@@ -1,6 +1,6 @@
 # Lists and Arrays
 
-Polars has first-class support for `List` columns: that is, columns where each row is a list of homogeneous elements, of varying lengths. Polars also has an `Array` datatype, which is analogous to `numpy`'s `ndarray` objects, where the length is identical across rows.
+Polars has first-class support for `List` columns: that is, columns where each row is a list of homogeneous elements, of varying lengths. Polars also has an `Array` datatype, which is analogous to NumPy's `ndarray` objects, where the length is identical across rows.
 
 Note: this is different from Python's `list` object, where the elements can be of any type. Polars can store these within columns, but as a generic `Object` datatype that doesn't have the special list manipulation features that we're about to discuss.
 

--- a/docs/user-guide/expressions/lists.md
+++ b/docs/user-guide/expressions/lists.md
@@ -74,7 +74,7 @@ What if we chose the regex route (i.e. recognizing the presence of _any_ alphabe
 --8<-- "python/user-guide/expressions/lists.py:count_errors_regex"
 ```
 
-If you're unfamiliar with the `(?i)`, it's a good time to look at the documentation for the `str.contains` function in Polars! The rust regex crate provides a lot of additional regex flags that might come in handy.
+If you're unfamiliar with the `(?i)`, it's a good time to look at the documentation for the `str.contains` function in Polars! The Rust regex crate provides a lot of additional regex flags that might come in handy.
 
 ## Row-wise computations
 

--- a/docs/user-guide/expressions/lists.md
+++ b/docs/user-guide/expressions/lists.md
@@ -1,6 +1,6 @@
 # Lists and Arrays
 
-`Polars` has first-class support for `List` columns: that is, columns where each row is a list of homogeneous elements, of varying lengths. `Polars` also has an `Array` datatype, which is analogous to `numpy`'s `ndarray` objects, where the length is identical across rows.
+Polars has first-class support for `List` columns: that is, columns where each row is a list of homogeneous elements, of varying lengths. Polars also has an `Array` datatype, which is analogous to `numpy`'s `ndarray` objects, where the length is identical across rows.
 
 Note: this is different from Python's `list` object, where the elements can be of any type. Polars can store these within columns, but as a generic `Object` datatype that doesn't have the special list manipulation features that we're about to discuss.
 
@@ -88,7 +88,7 @@ We can apply **any** Polars operations on the elements of the list with the `lis
 --8<-- "python/user-guide/expressions/lists.py:weather_by_day"
 ```
 
-Let's do something interesting, where we calculate the percentage rank of the temperatures by day, measured across stations. Pandas allows you to compute the percentages of the `rank` values. `Polars` doesn't provide a special function to do this directly, but because expressions are so versatile we can create our own percentage rank expression for highest temperature. Let's try that!
+Let's do something interesting, where we calculate the percentage rank of the temperatures by day, measured across stations. Pandas allows you to compute the percentages of the `rank` values. Polars doesn't provide a special function to do this directly, but because expressions are so versatile we can create our own percentage rank expression for highest temperature. Let's try that!
 
 {{code_block('user-guide/expressions/lists','weather_by_day_rank',['list.eval'])}}
 

--- a/docs/user-guide/expressions/null.md
+++ b/docs/user-guide/expressions/null.md
@@ -1,12 +1,12 @@
 # Missing data
 
-This page sets out how missing data is represented in `Polars` and how missing data can be filled.
+This page sets out how missing data is represented in Polars and how missing data can be filled.
 
 ## `null` and `NaN` values
 
-Each column in a `DataFrame` (or equivalently a `Series`) is an Arrow array or a collection of Arrow arrays [based on the Apache Arrow format](https://arrow.apache.org/docs/format/Columnar.html#null-count). Missing data is represented in Arrow and `Polars` with a `null` value. This `null` missing value applies for all data types including numerical values.
+Each column in a `DataFrame` (or equivalently a `Series`) is an Arrow array or a collection of Arrow arrays [based on the Apache Arrow format](https://arrow.apache.org/docs/format/Columnar.html#null-count). Missing data is represented in Arrow and Polars with a `null` value. This `null` missing value applies for all data types including numerical values.
 
-`Polars` also allows `NotaNumber` or `NaN` values for float columns. These `NaN` values are considered to be a type of floating point data rather than missing data. We discuss `NaN` values separately below.
+Polars also allows `NotaNumber` or `NaN` values for float columns. These `NaN` values are considered to be a type of floating point data rather than missing data. We discuss `NaN` values separately below.
 
 You can manually define a missing value with the python `None` value:
 
@@ -19,11 +19,11 @@ You can manually define a missing value with the python `None` value:
 
 !!! info
 
-    In `Pandas` the value for missing data depends on the dtype of the column. In `Polars` missing data is always represented as a `null` value.
+    In pandas the value for missing data depends on the dtype of the column. In Polars missing data is always represented as a `null` value.
 
 ## Missing data metadata
 
-Each Arrow array used by `Polars` stores two kinds of metadata related to missing data. This metadata allows `Polars` to quickly show how many missing values there are and which values are missing.
+Each Arrow array used by Polars stores two kinds of metadata related to missing data. This metadata allows Polars to quickly show how many missing values there are and which values are missing.
 
 The first piece of metadata is the `null_count` - this is the number of rows with `null` values in the column:
 
@@ -36,7 +36,7 @@ The first piece of metadata is the `null_count` - this is the number of rows wit
 The `null_count` method can be called on a `DataFrame`, a column from a `DataFrame` or a `Series`. The `null_count` method is a cheap operation as `null_count` is already calculated for the underlying Arrow array.
 
 The second piece of metadata is an array called a _validity bitmap_ that indicates whether each data value is valid or missing.
-The validity bitmap is memory efficient as it is bit encoded - each value is either a 0 or a 1. This bit encoding means the memory overhead per array is only (array length / 8) bytes. The validity bitmap is used by the `is_null` method in `Polars`.
+The validity bitmap is memory efficient as it is bit encoded - each value is either a 0 or a 1. This bit encoding means the memory overhead per array is only (array length / 8) bytes. The validity bitmap is used by the `is_null` method in Polars.
 
 You can return a `Series` based on the validity bitmap for a column in a `DataFrame` or a `Series` with the `is_null` method:
 
@@ -122,14 +122,14 @@ Missing data in a `Series` has a `null` value. However, you can use `NotaNumber`
 
 !!! info
 
-    In `Pandas` by default a `NaN` value in an integer column causes the column to be cast to float. This does not happen in `Polars` - instead an exception is raised.
+    In pandas by default a `NaN` value in an integer column causes the column to be cast to float. This does not happen in Polars - instead an exception is raised.
 
-`NaN` values are considered to be a type of floating point data and are **not considered to be missing data** in `Polars`. This means:
+`NaN` values are considered to be a type of floating point data and are **not considered to be missing data** in Polars. This means:
 
 - `NaN` values are **not** counted with the `null_count` method
 - `NaN` values are filled when you use `fill_nan` method but are **not** filled with the `fill_null` method
 
-`Polars` has `is_nan` and `fill_nan` methods which work in a similar way to the `is_null` and `fill_null` methods. The underlying Arrow arrays do not have a pre-computed validity bitmask for `NaN` values so this has to be computed for the `is_nan` method.
+Polars has `is_nan` and `fill_nan` methods which work in a similar way to the `is_null` and `fill_null` methods. The underlying Arrow arrays do not have a pre-computed validity bitmask for `NaN` values so this has to be computed for the `is_nan` method.
 
 One further difference between `null` and `NaN` values is that taking the `mean` of a column with `null` values excludes the `null` values from the calculation but with `NaN` values taking the mean results in a `NaN`. This behaviour can be avoided by replacing the `NaN` values with `null` values;
 

--- a/docs/user-guide/expressions/numpy.md
+++ b/docs/user-guide/expressions/numpy.md
@@ -1,9 +1,9 @@
 # Numpy
 
-`Polars` expressions support `NumPy` [ufuncs](https://numpy.org/doc/stable/reference/ufuncs.html). See [here](https://numpy.org/doc/stable/reference/ufuncs.html#available-ufuncs)
+Polars expressions support NumPy [ufuncs](https://numpy.org/doc/stable/reference/ufuncs.html). See [here](https://numpy.org/doc/stable/reference/ufuncs.html#available-ufuncs)
 for a list on all supported numpy functions.
 
-This means that if a function is not provided by `Polars`, we can use `NumPy` and we still have fast columnar operation through the `NumPy` API.
+This means that if a function is not provided by Polars, we can use NumPy and we still have fast columnar operation through the NumPy API.
 
 ### Example
 

--- a/docs/user-guide/expressions/plugins.md
+++ b/docs/user-guide/expressions/plugins.md
@@ -1,7 +1,7 @@
 # Expression plugins
 
 Expression plugins are the preferred way to create user defined functions. They allow you to compile a Rust function
-and register that as an expression into the polars library. The polars engine will dynamically link your function at runtime
+and register that as an expression into the Polars library. The Polars engine will dynamically link your function at runtime
 and your expression will run almost as fast as native expressions. Note that this works without any interference of Python
 and thus no GIL contention.
 
@@ -85,9 +85,9 @@ named `expression_lib` and we create an `expression_lib/__init__.py`. The result
 ```
 
 Then we create a new class `Language` that will hold the expressions for our new `expr.language` namespace. The function
-name of our expression can be registered. Note that it is important that this name is correct, otherwise the main polars
-package cannot resolve the function name. Furthermore we can set additional keyword arguments that explain to polars how
-this expression behaves. In this case we tell polars that this function is elementwise. This allows polars to run this
+name of our expression can be registered. Note that it is important that this name is correct, otherwise the main Polars
+package cannot resolve the function name. Furthermore we can set additional keyword arguments that explain to Polars how
+this expression behaves. In this case we tell Polars that this function is elementwise. This allows Polars to run this
 expression in batches. Whereas for other operations this would not be allowed, think for instance of a sort, or a slice.
 
 ```python
@@ -96,7 +96,7 @@ import polars as pl
 from polars.type_aliases import IntoExpr
 from polars.utils.udfs import _get_shared_lib_location
 
-# boilerplate needed to inform polars of the location of binary wheel.
+# Boilerplate needed to inform Polars of the location of binary wheel.
 lib = _get_shared_lib_location(__file__)
 
 @pl.api.register_expr_namespace("language")

--- a/docs/user-guide/expressions/plugins.md
+++ b/docs/user-guide/expressions/plugins.md
@@ -1,8 +1,8 @@
 # Expression plugins
 
-Expression plugins are the preferred way to create user defined functions. They allow you to compile a rust function
+Expression plugins are the preferred way to create user defined functions. They allow you to compile a Rust function
 and register that as an expression into the polars library. The polars engine will dynamically link your function at runtime
-and your expression will run almost as fast as native expressions. Note that this works without any interference of python
+and your expression will run almost as fast as native expressions. Note that this works without any interference of Python
 and thus no GIL contention.
 
 They will benefit from the same benefits default expressions have:
@@ -68,8 +68,8 @@ fn pig_latinnify(inputs: &[Series]) -> PolarsResult<Series> {
 }
 ```
 
-This is all that is needed on the rust side. On the python side we must setup a folder with the same name as defined in
-the `Cargo.toml`, in this case "expression_lib". We will create a folder in the same directory as our rust `src` folder
+This is all that is needed on the Rust side. On the Python side we must setup a folder with the same name as defined in
+the `Cargo.toml`, in this case "expression_lib". We will create a folder in the same directory as our Rust `src` folder
 named `expression_lib` and we create an `expression_lib/__init__.py`. The resulting file structure should look something like this:
 
 ```
@@ -134,7 +134,7 @@ out = df.with_columns(
 
 ## Accepting kwargs
 
-If you want to accept `kwargs` (keyword arguments) in a polars expression, all you have to do is define a rust `struct`
+If you want to accept `kwargs` (keyword arguments) in a polars expression, all you have to do is define a Rust `struct`
 and make sure that it derives `serde::Deserialize`.
 
 ```rust
@@ -150,7 +150,7 @@ pub struct MyKwargs {
 
 /// If you want to accept `kwargs`. You define a `kwargs` argument
 /// on the second position in you plugin. You can provide any custom struct that is deserializable
-/// with the pickle protocol (on the rust side).
+/// with the pickle protocol (on the Rust side).
 #[polars_expr(output_type=Utf8)]
 fn append_kwargs(input: &[Series], kwargs: MyKwargs) -> PolarsResult<Series> {
     let input = &input[0];
@@ -170,14 +170,14 @@ fn append_kwargs(input: &[Series], kwargs: MyKwargs) -> PolarsResult<Series> {
 }
 ```
 
-On the python side the kwargs can be passed when we register the plugin.
+On the Python side the kwargs can be passed when we register the plugin.
 
 ```python
 @pl.api.register_expr_namespace("my_expr")
 class MyCustomExpr:
     def __init__(self, expr: pl.Expr):
         self._expr = expr
-        
+
     def append_args(
             self,
             float_arg: float,

--- a/docs/user-guide/expressions/strings.md
+++ b/docs/user-guide/expressions/strings.md
@@ -1,6 +1,6 @@
 # Strings
 
-The following section discusses operations performed on `Utf8` strings, which are a frequently used `DataType` when working with `DataFrames`. However, processing strings can often be inefficient due to their unpredictable memory size, causing the CPU to access many random memory locations. To address this issue, Polars utilizes `Arrow` as its backend, which stores all strings in a contiguous block of memory. As a result, string traversal is cache-optimal and predictable for the CPU.
+The following section discusses operations performed on `Utf8` strings, which are a frequently used `DataType` when working with `DataFrames`. However, processing strings can often be inefficient due to their unpredictable memory size, causing the CPU to access many random memory locations. To address this issue, Polars utilizes Arrow as its backend, which stores all strings in a contiguous block of memory. As a result, string traversal is cache-optimal and predictable for the CPU.
 
 String processing functions are available in the `str` namespace.
 

--- a/docs/user-guide/expressions/strings.md
+++ b/docs/user-guide/expressions/strings.md
@@ -17,7 +17,7 @@ The `str` namespace can be accessed through the `.str` attribute of a column wit
 
 #### String parsing
 
-`Polars` offers multiple methods for checking and parsing elements of a string. Firstly, we can use the `contains` method to check whether a given pattern exists within a substring. Subsequently, we can extract these patterns and replace them using other methods, which will be demonstrated in upcoming examples.
+Polars offers multiple methods for checking and parsing elements of a string. Firstly, we can use the `contains` method to check whether a given pattern exists within a substring. Subsequently, we can extract these patterns and replace them using other methods, which will be demonstrated in upcoming examples.
 
 ##### Check for existence of a pattern
 

--- a/docs/user-guide/expressions/user-defined-functions.md
+++ b/docs/user-guide/expressions/user-defined-functions.md
@@ -160,7 +160,7 @@ In Python, those would be passed as `dict` to the calling Python function and ca
 
 ### Return types?
 
-Custom Python functions are black boxes for polars. We really don't know what kind of black arts you are doing, so we have
+Custom Python functions are black boxes for Polars. We really don't know what kind of black arts you are doing, so we have
 to infer and try our best to understand what you meant.
 
 As a user it helps to understand what we do to better utilize custom functions.
@@ -168,7 +168,7 @@ As a user it helps to understand what we do to better utilize custom functions.
 The data type is automatically inferred. We do that by waiting for the first non-null value. That value will then be used
 to determine the type of the `Series`.
 
-The mapping of Python types to polars data types is as follows:
+The mapping of Python types to Polars data types is as follows:
 
 - `int` -> `Int64`
 - `float` -> `Float64`

--- a/docs/user-guide/expressions/user-defined-functions.md
+++ b/docs/user-guide/expressions/user-defined-functions.md
@@ -113,7 +113,7 @@ And observe, a valid result! 🎉
 
 ## `apply` in the `select` context
 
-In the `select` context, the `apply` expression passes elements of the column to the python function.
+In the `select` context, the `apply` expression passes elements of the column to the Python function.
 
 _Note that you are now running Python, this will be slow._
 
@@ -148,7 +148,7 @@ type. This data type collects those columns as fields in the `struct`. So if we'
 ]
 ```
 
-In Python, those would be passed as `dict` to the calling python function and can thus be indexed by `field: str`. In rust, you'll get a `Series` with the `Struct` type. The fields of the struct can then be indexed and downcast.
+In Python, those would be passed as `dict` to the calling Python function and can thus be indexed by `field: str`. In Rust, you'll get a `Series` with the `Struct` type. The fields of the struct can then be indexed and downcast.
 
 {{code_block('user-guide/expressions/user-defined-functions','combine',['apply','struct'])}}
 
@@ -160,7 +160,7 @@ In Python, those would be passed as `dict` to the calling python function and ca
 
 ### Return types?
 
-Custom python functions are black boxes for polars. We really don't know what kind of black arts you are doing, so we have
+Custom Python functions are black boxes for polars. We really don't know what kind of black arts you are doing, so we have
 to infer and try our best to understand what you meant.
 
 As a user it helps to understand what we do to better utilize custom functions.
@@ -168,7 +168,7 @@ As a user it helps to understand what we do to better utilize custom functions.
 The data type is automatically inferred. We do that by waiting for the first non-null value. That value will then be used
 to determine the type of the `Series`.
 
-The mapping of python types to polars data types is as follows:
+The mapping of Python types to polars data types is as follows:
 
 - `int` -> `Int64`
 - `float` -> `Float64`

--- a/docs/user-guide/expressions/window.md
+++ b/docs/user-guide/expressions/window.md
@@ -51,7 +51,7 @@ that each pokemon within a group are sorted by `Speed` in `ascending` order. Unf
 --8<-- "python/user-guide/expressions/window.py:sort"
 ```
 
-`Polars` keeps track of each group's location and maps the expressions to the proper row locations. This will also work over different groups in a single `select`.
+Polars keeps track of each group's location and maps the expressions to the proper row locations. This will also work over different groups in a single `select`.
 
 The power of window expressions is that you often don't need a `group_by -> explode` combination, but you can put the logic in a single expression. It also makes the API cleaner. If properly used a:
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -3,7 +3,7 @@
 This User Guide is an introduction to the [Polars DataFrame library](https://github.com/pola-rs/polars). Its goal is to introduce you to Polars by going through examples and comparing it to other
 solutions. Some design choices are introduced here. The guide will also introduce you to optimal usage of Polars.
 
-Even though Polars is completely written in [Rust](https://www.rust-lang.org/) (no runtime overhead!) and uses [`Arrow`](https://arrow.apache.org/) -- the
+Even though Polars is completely written in [Rust](https://www.rust-lang.org/) (no runtime overhead!) and uses [Arrow](https://arrow.apache.org/) -- the
 [native arrow2 Rust implementation](https://github.com/jorgecarleitao/arrow2) -- as its foundation, the examples presented in this guide will be mostly using its higher-level language
 bindings. Higher-level bindings only serve as a thin wrapper for functionality implemented in the core library.
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,17 +1,17 @@
 # Introduction
 
-This User Guide is an introduction to the [`Polars` DataFrame library](https://github.com/pola-rs/polars). Its goal is to introduce you to `Polars` by going through examples and comparing it to other
-solutions. Some design choices are introduced here. The guide will also introduce you to optimal usage of `Polars`.
+This User Guide is an introduction to the [Polars DataFrame library](https://github.com/pola-rs/polars). Its goal is to introduce you to Polars by going through examples and comparing it to other
+solutions. Some design choices are introduced here. The guide will also introduce you to optimal usage of Polars.
 
-Even though `Polars` is completely written in [`Rust`](https://www.rust-lang.org/) (no runtime overhead!) and uses [`Arrow`](https://arrow.apache.org/) -- the
-[native arrow2 `Rust` implementation](https://github.com/jorgecarleitao/arrow2) -- as its foundation, the examples presented in this guide will be mostly using its higher-level language
+Even though Polars is completely written in [Rust](https://www.rust-lang.org/) (no runtime overhead!) and uses [`Arrow`](https://arrow.apache.org/) -- the
+[native arrow2 Rust implementation](https://github.com/jorgecarleitao/arrow2) -- as its foundation, the examples presented in this guide will be mostly using its higher-level language
 bindings. Higher-level bindings only serve as a thin wrapper for functionality implemented in the core library.
 
-For [`Pandas`](https://pandas.pydata.org/) users, our [Python package](https://pypi.org/project/polars/) will offer the easiest way to get started with `Polars`.
+For [pandas](https://pandas.pydata.org/) users, our [Python package](https://pypi.org/project/polars/) will offer the easiest way to get started with Polars.
 
 ### Philosophy
 
-The goal of `Polars` is to provide a lightning fast `DataFrame` library that:
+The goal of Polars is to provide a lightning fast `DataFrame` library that:
 
 - Utilizes all available cores on your machine.
 - Optimizes queries to reduce unneeded work/memory allocations.
@@ -22,7 +22,7 @@ The goal of `Polars` is to provide a lightning fast `DataFrame` library that:
 Polars is written in Rust which gives it C/C++ performance and allows it to fully control performance critical parts
 in a query engine.
 
-As such `Polars` goes to great lengths to:
+As such Polars goes to great lengths to:
 
 - Reduce redundant copies.
 - Traverse memory cache efficiently.

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -36,7 +36,7 @@ To use the library import it into your project
 
 ## Feature Flags
 
-By using the above command you install the core of `Polars` onto your system. However depending on your use case you might want to install the optional dependencies as well. These are made optional to minimize the footprint. The flags are different depending on the programming language. Throughout the user guide we will mention when a functionality is used that requires an additional dependency.
+By using the above command you install the core of Polars onto your system. However depending on your use case you might want to install the optional dependencies as well. These are made optional to minimize the footprint. The flags are different depending on the programming language. Throughout the user guide we will mention when a functionality is used that requires an additional dependency.
 
 ### Python
 

--- a/docs/user-guide/io/csv.md
+++ b/docs/user-guide/io/csv.md
@@ -12,10 +12,10 @@ Writing a CSV file is similar with the `write_csv` function:
 
 ## Scan
 
-`Polars` allows you to _scan_ a CSV input. Scanning delays the actual parsing of the
+Polars allows you to _scan_ a CSV input. Scanning delays the actual parsing of the
 file and instead returns a lazy computation holder called a `LazyFrame`.
 
 {{code_block('user-guide/io/csv','scan',['scan_csv'])}}
 
-If you want to know why this is desirable, you can read more about these `Polars`
+If you want to know why this is desirable, you can read more about these Polars
 optimizations [here](../concepts/lazy-vs-eager.md).

--- a/docs/user-guide/io/json.md
+++ b/docs/user-guide/io/json.md
@@ -24,7 +24,7 @@ Polars can read an NDJSON file into a `DataFrame` using the `read_ndjson` functi
 
 ## Scan
 
-`Polars` allows you to _scan_ a JSON input **only for newline delimited json**. Scanning delays the actual parsing of the
+Polars allows you to _scan_ a JSON input **only for newline delimited json**. Scanning delays the actual parsing of the
 file and instead returns a lazy computation holder called a `LazyFrame`.
 
 {{code_block('user-guide/io/json','scan',['scan_ndjson'])}}

--- a/docs/user-guide/io/json.md
+++ b/docs/user-guide/io/json.md
@@ -12,7 +12,7 @@ Reading a JSON file should look familiar:
 
 ### Newline Delimited JSON
 
-JSON objects that are delimited by newlines can be read into polars in a much more performant way than standard json.
+JSON objects that are delimited by newlines can be read into Polars in a much more performant way than standard json.
 
 Polars can read an NDJSON file into a `DataFrame` using the `read_ndjson` function:
 

--- a/docs/user-guide/io/multiple.md
+++ b/docs/user-guide/io/multiple.md
@@ -18,7 +18,7 @@ To read multiple files into a single `DataFrame`, we can use globbing patterns:
 ```
 
 To see how this works we can take a look at the query plan. Below we see that all files are read separately and
-concatenated into a single `DataFrame`. `Polars` will try to parallelize the reading.
+concatenated into a single `DataFrame`. Polars will try to parallelize the reading.
 
 {{code_block('user-guide/io/multiple','graph',['show_graph'])}}
 
@@ -29,7 +29,7 @@ concatenated into a single `DataFrame`. `Polars` will try to parallelize the rea
 ## Reading and processing in parallel
 
 If your files don't have to be in a single table you can also build a query plan for each file and execute them in parallel
-on the `Polars` thread pool.
+on the Polars thread pool.
 
 All query plan execution is embarrassingly parallel and doesn't require any communication.
 

--- a/docs/user-guide/io/parquet.md
+++ b/docs/user-guide/io/parquet.md
@@ -16,10 +16,10 @@ We can read a `Parquet` file into a `DataFrame` using the `read_parquet` functio
 
 ## Scan
 
-`Polars` allows you to _scan_ a `Parquet` input. Scanning delays the actual parsing of the file and instead returns a lazy computation holder called a `LazyFrame`.
+Polars allows you to _scan_ a `Parquet` input. Scanning delays the actual parsing of the file and instead returns a lazy computation holder called a `LazyFrame`.
 
 {{code_block('user-guide/io/parquet','scan',['scan_parquet'])}}
 
-If you want to know why this is desirable, you can read more about those `Polars` optimizations [here](../concepts/lazy-vs-eager.md).
+If you want to know why this is desirable, you can read more about those Polars optimizations [here](../concepts/lazy-vs-eager.md).
 
 When we scan a `Parquet` file stored in the cloud, we can also apply predicate and projection pushdowns. This can significantly reduce the amount of data that needs to be downloaded. For scanning a Parquet file in the cloud, see [Cloud storage](cloud-storage.md/#scanning-from-cloud-storage-with-query-optimisation).

--- a/docs/user-guide/lazy/optimizations.md
+++ b/docs/user-guide/lazy/optimizations.md
@@ -1,6 +1,6 @@
 # Optimizations
 
-If you use `Polars`' lazy API, `Polars` will run several optimizations on your query. Some of them are executed up front,
+If you use Polars' lazy API, Polars will run several optimizations on your query. Some of them are executed up front,
 others are determined just in time as the materialized data comes in.
 
 Here is a non-complete overview of optimizations done by polars, what they do and how often they run.

--- a/docs/user-guide/lazy/query-plan.md
+++ b/docs/user-guide/lazy/query-plan.md
@@ -1,6 +1,6 @@
 # Query plan
 
-For any lazy query `Polars` has both:
+For any lazy query Polars has both:
 
 - a non-optimized plan with the set of steps code as we provided it and
 - an optimized plan with changes made by the query optimizer

--- a/docs/user-guide/migration/pandas.md
+++ b/docs/user-guide/migration/pandas.md
@@ -21,7 +21,7 @@ Operations like resampling will be done by specialized functions or methods that
 stating the columns that that 'verb' operates on. As such, it is our conviction that not having indices make things simpler,
 more explicit, more readable and less error-prone.
 
-Note that an 'index' data structure as known in databases will be used by polars as an optimization technique.
+Note that an 'index' data structure as known in databases will be used by Polars as an optimization technique.
 
 ### Polars uses Apache Arrow arrays to represent data in memory while pandas uses NumPy arrays
 

--- a/docs/user-guide/migration/pandas.md
+++ b/docs/user-guide/migration/pandas.md
@@ -1,15 +1,15 @@
 # Coming from Pandas
 
-Here we set out the key points that anyone who has experience with `Pandas` and wants to
-try `Polars` should know. We include both differences in the concepts the libraries are
-built on and differences in how you should write `Polars` code compared to `Pandas`
+Here we set out the key points that anyone who has experience with pandas and wants to
+try Polars should know. We include both differences in the concepts the libraries are
+built on and differences in how you should write Polars code compared to pandas
 code.
 
-## Differences in concepts between `Polars` and `Pandas`
+## Differences in concepts between Polars and pandas
 
-### `Polars` does not have a multi-index/index
+### Polars does not have a multi-index/index
 
-`Pandas` gives a label to each row with an index. `Polars` does not use an index and
+pandas gives a label to each row with an index. Polars does not use an index and
 each row is indexed by its integer position in the table.
 
 Polars aims to have predictable results and readable queries, as such we think an index does not help us reach that
@@ -23,30 +23,30 @@ more explicit, more readable and less error-prone.
 
 Note that an 'index' data structure as known in databases will be used by polars as an optimization technique.
 
-### `Polars` uses Apache Arrow arrays to represent data in memory while `Pandas` uses `Numpy` arrays
+### Polars uses Apache Arrow arrays to represent data in memory while pandas uses NumPy arrays
 
-`Polars` represents data in memory with Arrow arrays while `Pandas` represents data in
-memory with `Numpy` arrays. Apache Arrow is an emerging standard for in-memory columnar
+Polars represents data in memory with Arrow arrays while pandas represents data in
+memory with NumPy arrays. Apache Arrow is an emerging standard for in-memory columnar
 analytics that can accelerate data load times, reduce memory usage and accelerate
 calculations.
 
-`Polars` can convert data to `Numpy` format with the `to_numpy` method.
+Polars can convert data to NumPy format with the `to_numpy` method.
 
-### `Polars` has more support for parallel operations than `Pandas`
+### Polars has more support for parallel operations than pandas
 
-`Polars` exploits the strong support for concurrency in Rust to run many operations in
-parallel. While some operations in `Pandas` are multi-threaded the core of the library
+Polars exploits the strong support for concurrency in Rust to run many operations in
+parallel. While some operations in pandas are multi-threaded the core of the library
 is single-threaded and an additional library such as `Dask` must be used to parallelize
 operations.
 
-### `Polars` can lazily evaluate queries and apply query optimization
+### Polars can lazily evaluate queries and apply query optimization
 
 Eager evaluation is when code is evaluated as soon as you run the code. Lazy evaluation
 is when running a line of code means that the underlying logic is added to a query plan
 rather than being evaluated.
 
-`Polars` supports eager evaluation and lazy evaluation whereas `Pandas` only supports
-eager evaluation. The lazy evaluation mode is powerful because `Polars` carries out
+Polars supports eager evaluation and lazy evaluation whereas pandas only supports
+eager evaluation. The lazy evaluation mode is powerful because Polars carries out
 automatic query optimization when it examines the query plan and looks for ways to
 accelerate the query or reduce memory usage.
 
@@ -55,66 +55,66 @@ does not carry out query optimization on the query plan.
 
 ## Key syntax differences
 
-Users coming from `Pandas` generally need to know one thing...
+Users coming from pandas generally need to know one thing...
 
 ```
 polars != pandas
 ```
 
-If your `Polars` code looks like it could be `Pandas` code, it might run, but it likely
+If your Polars code looks like it could be pandas code, it might run, but it likely
 runs slower than it should.
 
-Let's go through some typical `Pandas` code and see how we might rewrite it in `Polars`.
+Let's go through some typical pandas code and see how we might rewrite it in Polars.
 
 ### Selecting data
 
-As there is no index in `Polars` there is no `.loc` or `iloc` method in `Polars` - and
-there is also no `SettingWithCopyWarning` in `Polars`.
+As there is no index in Polars there is no `.loc` or `iloc` method in Polars - and
+there is also no `SettingWithCopyWarning` in Polars.
 
-However, the best way to select data in `Polars` is to use the expression API. For
-example, if you want to select a column in `Pandas` you can do one of the following:
+However, the best way to select data in Polars is to use the expression API. For
+example, if you want to select a column in pandas you can do one of the following:
 
 ```python
 df['a']
 df.loc[:,'a']
 ```
 
-but in `Polars` you would use the `.select` method:
+but in Polars you would use the `.select` method:
 
 ```python
 df.select('a')
 ```
 
-If you want to select rows based on the values then in `Polars` you use the `.filter`
+If you want to select rows based on the values then in Polars you use the `.filter`
 method:
 
 ```python
 df.filter(pl.col('a') < 10)
 ```
 
-As noted in the section on expressions below, `Polars` can run operations in `.select`
-and `filter` in parallel and `Polars` can carry out query optimization on the full set
+As noted in the section on expressions below, Polars can run operations in `.select`
+and `filter` in parallel and Polars can carry out query optimization on the full set
 of data selection criteria.
 
 ### Be lazy
 
 Working in lazy evaluation mode is straightforward and should be your default in
-`Polars` as the lazy mode allows `Polars` to do query optimization.
+Polars as the lazy mode allows Polars to do query optimization.
 
 We can run in lazy mode by either using an implicitly lazy function (such as `scan_csv`)
 or explicitly using the `lazy` method.
 
 Take the following simple example where we read a CSV file from disk and do a group by.
 The CSV file has numerous columns but we just want to do a group by on one of the id
-columns (`id1`) and then sum by a value column (`v1`). In `Pandas` this would be:
+columns (`id1`) and then sum by a value column (`v1`). In pandas this would be:
 
 ```python
 df = pd.read_csv(csv_file, usecols=['id1','v1'])
 grouped_df = df.loc[:,['id1','v1']].groupby('id1').sum('v1')
 ```
 
-In `Polars` you can build this query in lazy mode with query optimization and evaluate
-it by replacing the eager `Pandas` function `read_csv` with the implicitly lazy `Polars`
+In Polars you can build this query in lazy mode with query optimization and evaluate
+it by replacing the eager pandas function `read_csv` with the implicitly lazy Polars
 function `scan_csv`:
 
 ```python
@@ -122,20 +122,20 @@ df = pl.scan_csv(csv_file)
 grouped_df = df.group_by('id1').agg(pl.col('v1').sum()).collect()
 ```
 
-`Polars` optimizes this query by identifying that only the `id1` and `v1` columns are
+Polars optimizes this query by identifying that only the `id1` and `v1` columns are
 relevant and so will only read these columns from the CSV. By calling the `.collect`
-method at the end of the second line we instruct `Polars` to eagerly evaluate the query.
+method at the end of the second line we instruct Polars to eagerly evaluate the query.
 
 If you do want to run this query in eager mode you can just replace `scan_csv` with
-`read_csv` in the `Polars` code.
+`read_csv` in the Polars code.
 
 Read more about working with lazy evaluation in the
 [lazy API](../lazy/using.md) section.
 
 ### Express yourself
 
-A typical `Pandas` script consists of multiple data transformations that are executed
-sequentially. However, in `Polars` these transformations can be executed in parallel
+A typical pandas script consists of multiple data transformations that are executed
+sequentially. However, in Polars these transformations can be executed in parallel
 using expressions.
 
 #### Column assignment
@@ -144,7 +144,7 @@ We have a dataframe `df` with a column called `value`. We want to add two new co
 column called `tenXValue` where the `value` column is multiplied by 10 and a column
 called `hundredXValue` where the `value` column is multiplied by 100.
 
-In `Pandas` this would be:
+In pandas this would be:
 
 ```python
 df.assign(
@@ -155,7 +155,7 @@ df.assign(
 
 These column assignments are executed sequentially.
 
-In `Polars` we add columns to `df` using the `.with_columns` method:
+In Polars we add columns to `df` using the `.with_columns` method:
 
 ```python
 df.with_columns(
@@ -172,13 +172,13 @@ In this case we have a dataframe `df` with columns `a`,`b` and `c`. We want to r
 the values in column `a` based on a condition. When the value in column `c` is equal to
 2 then we replace the value in `a` with the value in `b`.
 
-In `Pandas` this would be:
+In pandas this would be:
 
 ```python
 df.assign(a=lambda df_: df_.a.where(df_.c != 2, df_.b))
 ```
 
-while in `Polars` this would be:
+while in Polars this would be:
 
 ```python
 df.with_columns(
@@ -188,20 +188,20 @@ df.with_columns(
 )
 ```
 
-`Polars` can compute every branch of an `if -> then -> otherwise` in
+Polars can compute every branch of an `if -> then -> otherwise` in
 parallel. This is valuable, when the branches get more expensive to compute.
 
 #### Filtering
 
 We want to filter the dataframe `df` with housing data based on some criteria.
 
-In `Pandas` you filter the dataframe by passing Boolean expressions to the `query` method:
+In pandas you filter the dataframe by passing Boolean expressions to the `query` method:
 
 ```python
 df.query('m2_living > 2500 and price < 300000')
 ```
 
-while in `Polars` you call the `filter` method:
+while in Polars you call the `filter` method:
 
 ```python
 df.filter(
@@ -209,16 +209,16 @@ df.filter(
 )
 ```
 
-The query optimizer in `Polars` can also detect if you write multiple filters separately
+The query optimizer in Polars can also detect if you write multiple filters separately
 and combine them into a single filter in the optimized plan.
 
-## `Pandas` transform
+## pandas transform
 
-The `Pandas` documentation demonstrates an operation on a group by called `transform`. In
+The pandas documentation demonstrates an operation on a group by called `transform`. In
 this case we have a dataframe `df` and we want a new column showing the number of rows
 in each group.
 
-In `Pandas` we have:
+In pandas we have:
 
 ```python
 df = pd.DataFrame({
@@ -229,7 +229,7 @@ df = pd.DataFrame({
 df["size"] = df.groupby("c")["type"].transform(len)
 ```
 
-Here `Pandas` does a group by on `"c"`, takes column `"type"`, computes the group length
+Here pandas does a group by on `"c"`, takes column `"type"`, computes the group length
 and then joins the result back to the original `DataFrame` producing:
 
 ```
@@ -243,7 +243,7 @@ and then joins the result back to the original `DataFrame` producing:
 6  2    n    4
 ```
 
-In `Polars` the same can be achieved with `window` functions:
+In Polars the same can be achieved with `window` functions:
 
 ```python
 df.select(
@@ -278,7 +278,7 @@ shape: (7, 3)
 Because we can store the whole operation in a single expression, we can combine several
 `window` functions and even combine different groups!
 
-`Polars` will cache window expressions that are applied over the same group, so storing
+Polars will cache window expressions that are applied over the same group, so storing
 them in a single `select` is both convenient **and** optimal. In the following example
 we look at a case where we are calculating group statistics over `"c"` twice:
 
@@ -316,10 +316,10 @@ shape: (7, 5)
 
 ## Missing data
 
-`Pandas` uses `NaN` and/or `None` values to indicate missing values depending on the dtype of the column. In addition the behaviour in `Pandas` varies depending on whether the default dtypes or optional nullable arrays are used. In `Polars` missing data corresponds to a `null` value for all data types.
+pandas uses `NaN` and/or `None` values to indicate missing values depending on the dtype of the column. In addition the behaviour in pandas varies depending on whether the default dtypes or optional nullable arrays are used. In Polars missing data corresponds to a `null` value for all data types.
 
-For float columns `Polars` permits the use of `NaN` values. These `NaN` values are not considered to be missing data but instead a special floating point value.
+For float columns Polars permits the use of `NaN` values. These `NaN` values are not considered to be missing data but instead a special floating point value.
 
-In `Pandas` an integer column with missing values is cast to be a float column with `NaN` values for the missing values (unless using optional nullable integer dtypes). In `Polars` any missing values in an integer column are simply `null` values and the column remains an integer column.
+In pandas an integer column with missing values is cast to be a float column with `NaN` values for the missing values (unless using optional nullable integer dtypes). In Polars any missing values in an integer column are simply `null` values and the column remains an integer column.
 
 See the [missing data](../expressions/null.md) section for more details.

--- a/docs/user-guide/migration/spark.md
+++ b/docs/user-guide/migration/spark.md
@@ -2,7 +2,7 @@
 
 ## Column-based API vs. Row-based API
 
-Whereas the `Spark` `DataFrame` is analogous to a collection of rows, a `Polars` `DataFrame` is closer to a collection of columns. This means that you can combine columns in `Polars` in ways that are not possible in `Spark`, because `Spark` preserves the relationship of the data in each row.
+Whereas the `Spark` `DataFrame` is analogous to a collection of rows, a Polars `DataFrame` is closer to a collection of columns. This means that you can combine columns in Polars in ways that are not possible in `Spark`, because `Spark` preserves the relationship of the data in each row.
 
 Consider this sample dataset:
 
@@ -28,7 +28,7 @@ dfs = spark.createDataFrame(
 
 ### Example 1: Combining `head` and `sum`
 
-In `Polars` you can write something like this:
+In Polars you can write something like this:
 
 ```python
 df.select(
@@ -89,7 +89,7 @@ Output:
 
 ### Example 2: Combining Two `head`s
 
-In `Polars` you can combine two different `head` expressions on the same DataFrame, provided that they return the same number of values.
+In Polars you can combine two different `head` expressions on the same DataFrame, provided that they return the same number of values.
 
 ```python
 df.select(

--- a/docs/user-guide/misc/alternatives.md
+++ b/docs/user-guide/misc/alternatives.md
@@ -20,7 +20,7 @@ These are some tools that share similar functionality to what polars does.
   therefore has less control over low level performance and semantics.
   Those libraries are treated like a black box.
   On a single machine the parallelization effort can also be seriously stalled by pandas strings.
-  Pandas strings, by default, are stored as python objects in
+  Pandas strings, by default, are stored as Python objects in
   numpy arrays meaning that any operation on them is GIL bound and therefore single threaded. This can be circumvented
   by multi-processing but has a non-trivial cost.
 

--- a/docs/user-guide/misc/alternatives.md
+++ b/docs/user-guide/misc/alternatives.md
@@ -16,7 +16,7 @@ These are some tools that share similar functionality to what polars does.
 
 - Dask
 
-  Parallelizes existing single-threaded libraries like `NumPy` and `Pandas`. As a consumer of those libraries Dask
+  Parallelizes existing single-threaded libraries like NumPy and pandas. As a consumer of those libraries Dask
   therefore has less control over low level performance and semantics.
   Those libraries are treated like a black box.
   On a single machine the parallelization effort can also be seriously stalled by pandas strings.

--- a/docs/user-guide/misc/alternatives.md
+++ b/docs/user-guide/misc/alternatives.md
@@ -1,6 +1,6 @@
 # Alternatives
 
-These are some tools that share similar functionality to what polars does.
+These are some tools that share similar functionality to what Polars does.
 
 - Pandas
 

--- a/docs/user-guide/transformations/joins.md
+++ b/docs/user-guide/transformations/joins.md
@@ -2,7 +2,7 @@
 
 ## Join strategies
 
-`Polars` supports the following join strategies by specifying the `strategy` argument:
+Polars supports the following join strategies by specifying the `strategy` argument:
 
 | Strategy | Description                                                                                                                                                                                                |
 | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -142,7 +142,7 @@ Continuing this example, an alternative question might be: which of the cars hav
 ### Asof join
 
 An `asof` join is like a left join except that we match on nearest key rather than equal keys.
-In `Polars` we can do an asof join with the `join` method and specifying `strategy="asof"`. However, for more flexibility we can use the `join_asof` method.
+In Polars we can do an asof join with the `join` method and specifying `strategy="asof"`. However, for more flexibility we can use the `join_asof` method.
 
 Consider the following scenario: a stock market broker has a `DataFrame` called `df_trades` showing transactions it has made for different stocks.
 

--- a/docs/user-guide/transformations/pivot.md
+++ b/docs/user-guide/transformations/pivot.md
@@ -32,7 +32,7 @@ aggregation.
 
 ## Lazy
 
-A polars `LazyFrame` always need to know the schema of a computation statically (before collecting the query).
+A Polars `LazyFrame` always need to know the schema of a computation statically (before collecting the query).
 As a pivot's output schema depends on the data, and it is therefore impossible to determine the schema without
 running the query.
 

--- a/docs/user-guide/transformations/time-series/parsing.md
+++ b/docs/user-guide/transformations/time-series/parsing.md
@@ -8,7 +8,7 @@ Polars has the following datetime datatypes:
 
 - `Date`: Date representation e.g. 2014-07-08. It is internally represented as days since UNIX epoch encoded by a 32-bit signed integer.
 - `Datetime`: Datetime representation e.g. 2014-07-08 07:00:00. It is internally represented as a 64 bit integer since the Unix epoch and can have different units such as ns, us, ms.
-- `Duration`: A time delta type that is created when subtracting `Date/Datetime`. Similar to `timedelta` in python.
+- `Duration`: A time delta type that is created when subtracting `Date/Datetime`. Similar to `timedelta` in Python.
 - `Time`: Time representation, internally represented as nanoseconds since midnight.
 
 ## Parsing dates from a file

--- a/docs/user-guide/transformations/time-series/parsing.md
+++ b/docs/user-guide/transformations/time-series/parsing.md
@@ -4,7 +4,7 @@ Polars has native support for parsing time series data and doing more sophistica
 
 ## Datatypes
 
-`Polars` has the following datetime datatypes:
+Polars has the following datetime datatypes:
 
 - `Date`: Date representation e.g. 2014-07-08. It is internally represented as days since UNIX epoch encoded by a 32-bit signed integer.
 - `Datetime`: Datetime representation e.g. 2014-07-08 07:00:00. It is internally represented as a 64 bit integer since the Unix epoch and can have different units such as ns, us, ms.
@@ -13,7 +13,7 @@ Polars has native support for parsing time series data and doing more sophistica
 
 ## Parsing dates from a file
 
-When loading from a CSV file `Polars` attempts to parse dates and times if the `try_parse_dates` flag is set to `True`:
+When loading from a CSV file Polars attempts to parse dates and times if the `try_parse_dates` flag is set to `True`:
 
 {{code_block('user-guide/transformations/time-series/parsing','df',['read_csv'])}}
 
@@ -22,7 +22,7 @@ When loading from a CSV file `Polars` attempts to parse dates and times if the `
 --8<-- "python/user-guide/transformations/time-series/parsing.py:df"
 ```
 
-On the other hand binary formats such as parquet have a schema that is respected by `Polars`.
+On the other hand binary formats such as parquet have a schema that is respected by Polars.
 
 ## Casting strings to dates
 

--- a/docs/user-guide/transformations/time-series/resampling.md
+++ b/docs/user-guide/transformations/time-series/resampling.md
@@ -8,7 +8,7 @@ We can resample by either:
 
 ## Downsampling to a lower frequency
 
-`Polars` views downsampling as a special case of the **group_by** operation and you can do this with `group_by_dynamic` and `group_by_rolling` - [see the temporal group by page for examples](rolling.md).
+Polars views downsampling as a special case of the **group_by** operation and you can do this with `group_by_dynamic` and `group_by_rolling` - [see the temporal group by page for examples](rolling.md).
 
 ## Upsampling to a higher frequency
 

--- a/examples/python_rust_compiled_function/README.md
+++ b/examples/python_rust_compiled_function/README.md
@@ -1,4 +1,4 @@
-# Compile Custom Rust functions and use in python polars
+# Compile Custom Rust functions and use in Python Polars
 
 ## Compile a development binary in your current environment
 


### PR DESCRIPTION
#### Changes

* Correctly name projects:
  * polars -> Polars
  * Pandas -> pandas
  * numpy -> NumPy
  * rust -> Rust
  * python -> Python
* Remove backticks around project names. These do not need to have code formatting everywhere.