### PR TITLE
fix: with_row_count should block predicate push down for lazy csv

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -260,7 +260,13 @@ impl<'a> PredicatePushDown<'a> {
                 file_options: options,
                 output_schema
             } => {
-                let local_predicates = partition_by_full_context(&mut acc_predicates, expr_arena);
+                let mut local_predicates = partition_by_full_context(&mut acc_predicates, expr_arena);
+                if let Some(ref row_count) = options.row_count{
+                    let mut row_count_predicates = transfer_to_local_by_name(expr_arena, &mut acc_predicates, |name| {
+                        name.as_ref() == &row_count.name
+                    });
+                    local_predicates.append(&mut row_count_predicates);
+                }
                 let predicate = predicate_at_scan(acc_predicates, predicate, expr_arena);
 
                 if let (true, Some(predicate)) = (file_info.hive_parts.is_some(), predicate) {

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -262,10 +262,10 @@ impl<'a> PredicatePushDown<'a> {
             } => {
                 let mut local_predicates = partition_by_full_context(&mut acc_predicates, expr_arena);
                 if let Some(ref row_count) = options.row_count{
-                    let mut row_count_predicates = transfer_to_local_by_name(expr_arena, &mut acc_predicates, |name| {
+                    let row_count_predicates = transfer_to_local_by_name(expr_arena, &mut acc_predicates, |name| {
                         name.as_ref() == row_count.name
                     });
-                    local_predicates.append(&mut row_count_predicates);
+                    local_predicates.extend_from_slice(&row_count_predicates);
                 }
                 let predicate = predicate_at_scan(acc_predicates, predicate, expr_arena);
 

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -263,7 +263,7 @@ impl<'a> PredicatePushDown<'a> {
                 let mut local_predicates = partition_by_full_context(&mut acc_predicates, expr_arena);
                 if let Some(ref row_count) = options.row_count{
                     let mut row_count_predicates = transfer_to_local_by_name(expr_arena, &mut acc_predicates, |name| {
-                        name.as_ref() == &row_count.name
+                        name.as_ref() == row_count.name
                     });
                     local_predicates.append(&mut row_count_predicates);
                 }


### PR DESCRIPTION
This fixes #12186.

This is the simplest fix, but it will affect the optimization of predicates unrelated to `row_count`. A more complex approach might be that we allow the optimization here, but re-evaluate all predicates(or identify predicates containing only `row_count`, but this may be more complicated) after all chunks have been accumulated. I haven't thought carefully about whether the latter option is completely feasible, but the current solution is at least feasible. So it's up to you.