### PR TITLE
feat: Add `.list.to_array` expression

### DIFF
--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -231,6 +231,13 @@ impl ListNameSpace {
         self.slice(lit(0i64) - n.clone().cast(DataType::Int64), n)
     }
 
+    #[cfg(feature = "dtype-array")]
+    /// Convert a List column into an Array column with the same inner data type.
+    pub fn to_array(self, width: usize) -> Expr {
+        self.0
+            .map_private(FunctionExpr::ListExpr(ListFunction::ToArray(width)))
+    }
+
     #[cfg(feature = "list_to_struct")]
     #[allow(clippy::wrong_self_convention)]
     /// Convert this `List` to a `Series` of type `Struct`. The width will be determined according to

--- a/py-polars/docs/source/reference/expressions/list.rst
+++ b/py-polars/docs/source/reference/expressions/list.rst
@@ -46,6 +46,7 @@ The following methods are available under the `expr.list` attribute.
     Expr.list.symmetric_difference
     Expr.list.tail
     Expr.list.take
+    Expr.list.to_array
     Expr.list.to_struct
     Expr.list.union
     Expr.list.unique

--- a/py-polars/docs/source/reference/series/list.rst
+++ b/py-polars/docs/source/reference/series/list.rst
@@ -46,6 +46,7 @@ The following methods are available under the `Series.list` attribute.
     Series.list.symmetric_difference
     Series.list.tail
     Series.list.take
+    Series.list.to_array
     Series.list.to_struct
     Series.list.union
     Series.list.unique

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -905,6 +905,40 @@ class ExprListNameSpace:
         element = parse_as_expression(element, str_as_lit=True)
         return wrap_expr(self._pyexpr.list_count_matches(element))
 
+    def to_array(self, width: int) -> Expr:
+        """
+        Convert a List column into an Array column with the same inner data type.
+
+        Parameters
+        ----------
+        width
+            Width of the resulting Array column.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`Array`.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     data={"a": [[1, 2], [3, 4]]},
+        ...     schema={"a": pl.List(pl.Int8)},
+        ... )
+        >>> df.select(pl.col("a").list.to_array(2))
+        shape: (2, 1)
+        ┌──────────────┐
+        │ a            │
+        │ ---          │
+        │ array[i8, 2] │
+        ╞══════════════╡
+        │ [1, 2]       │
+        │ [3, 4]       │
+        └──────────────┘
+
+        """
+        return wrap_expr(self._pyexpr.list_to_array(width))
+
     def to_struct(
         self,
         n_field_strategy: ToStructStrategy = "first_non_null",
@@ -1134,7 +1168,6 @@ class ExprListNameSpace:
         ----------
         other
             Right hand side of the set operation.
-
 
         Examples
         --------

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -114,7 +114,7 @@ class ArrayNameSpace:
 
         Returns
         -------
-        Expr
+        Series
             Series of data type :class:`List`.
 
         Examples

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -541,6 +541,33 @@ class ListNameSpace:
 
         """
 
+    def to_array(self, width: int) -> Series:
+        """
+        Convert a List column into an Array column with the same inner data type.
+
+        Parameters
+        ----------
+        width
+            Width of the resulting Array column.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`Array`.
+
+        Examples
+        --------
+        >>> s = pl.Series([[1, 2], [3, 4]], dtype=pl.List(pl.Int8))
+        >>> s.list.to_array(2)
+        shape: (2,)
+        Series: '' [array[i8, 2]]
+        [
+                [1, 2]
+                [3, 4]
+        ]
+
+        """
+
     def to_struct(
         self,
         n_field_strategy: ToStructStrategy = "first_non_null",

--- a/py-polars/src/expr/list.rs
+++ b/py-polars/src/expr/list.rs
@@ -154,6 +154,10 @@ impl PyExpr {
             .into()
     }
 
+    fn list_to_array(&self, width: usize) -> Self {
+        self.inner.clone().list().to_array(width).into()
+    }
+
     #[pyo3(signature = (width_strat, name_gen, upper_bound))]
     fn list_to_struct(
         &self,

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -663,3 +663,25 @@ def test_list_lengths_deprecated() -> None:
         result = s.list.lengths()
     expected = pl.Series([3, 1], dtype=pl.UInt32)
     assert_series_equal(result, expected)
+
+
+def test_list_to_array() -> None:
+    data = [[1.0, 2.0], [3.0, 4.0]]
+    s = pl.Series(data, dtype=pl.List(pl.Float32))
+
+    result = s.list.to_array(2)
+
+    expected = pl.Series(data, dtype=pl.Array(inner=pl.Float32, width=2))
+    assert_series_equal(result, expected)
+
+
+def test_list_to_array_wrong_lengths() -> None:
+    s = pl.Series([[1.0, 2.0], [3.0, 4.0]], dtype=pl.List(pl.Float32))
+    with pytest.raises(pl.ComputeError, match="incompatible offsets in source list"):
+        s.list.to_array(3)
+
+
+def test_list_to_array_wrong_dtype() -> None:
+    s = pl.Series([1.0, 2.0])
+    with pytest.raises(pl.ComputeError, match="expected List dtype"):
+        s.list.to_array(2)


### PR DESCRIPTION
Related to https://github.com/pola-rs/polars/issues/9978

To be honest, I'm having doubts about the usefulness of this expression.

In lazy mode, we cannot infer the width from the data, so we'll have to provide it as an argument. And at that point, we might as well just use `cast` and provide the inner dtype too. So the usefulness is limited.

Anyway, I already put in the work so let me know what you think.

