### PR TITLE
refactor(rust): use enum for Ambiguous

### DIFF
--- a/crates/polars-arrow/src/legacy/kernels/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/mod.rs
@@ -21,11 +21,11 @@ pub mod sorted_join;
 #[cfg(feature = "strings")]
 pub mod string;
 pub mod take_agg;
-#[cfg(feature = "timezones")]
 mod time;
 
 #[cfg(feature = "timezones")]
 pub use time::convert_to_naive_local;
+pub use time::Ambiguous;
 
 /// Internal state of [SlicesIterator]
 #[derive(Debug, PartialEq)]

--- a/crates/polars-arrow/src/legacy/kernels/time.rs
+++ b/crates/polars-arrow/src/legacy/kernels/time.rs
@@ -1,27 +1,51 @@
-use chrono::{LocalResult, NaiveDateTime, TimeZone};
-use chrono_tz::Tz;
-use polars_error::{polars_bail, PolarsResult};
+use std::str::FromStr;
 
+#[cfg(feature = "timezones")]
+use chrono::{LocalResult, NaiveDateTime, TimeZone};
+#[cfg(feature = "timezones")]
+use chrono_tz::Tz;
+#[cfg(feature = "timezones")]
+use polars_error::PolarsResult;
+use polars_error::{polars_bail, PolarsError};
+
+pub enum Ambiguous {
+    Earliest,
+    Latest,
+    Raise,
+}
+impl FromStr for Ambiguous {
+    type Err = PolarsError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "earliest" => Ok(Ambiguous::Earliest),
+            "latest" => Ok(Ambiguous::Latest),
+            "raise" => Ok(Ambiguous::Raise),
+            s => polars_bail!(InvalidOperation:
+                "Invalid argument {}, expected one of: \"earliest\", \"latest\", \"raise\"", s
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "timezones")]
 pub fn convert_to_naive_local(
     from_tz: &Tz,
     to_tz: &Tz,
     ndt: NaiveDateTime,
-    ambiguous: &str,
+    ambiguous: Ambiguous,
 ) -> PolarsResult<NaiveDateTime> {
     let ndt = from_tz.from_utc_datetime(&ndt).naive_local();
     match to_tz.from_local_datetime(&ndt) {
         LocalResult::Single(dt) => Ok(dt.naive_utc()),
         LocalResult::Ambiguous(dt_earliest, dt_latest) => match ambiguous {
-            "earliest" => Ok(dt_earliest.naive_utc()),
-            "latest" => Ok(dt_latest.naive_utc()),
-            "raise" => {
-                polars_bail!(InvalidOperation: "datetime '{}' is ambiguous in time zone '{}'. Please use `ambiguous` to tell how it should be localized.", ndt, to_tz)
+            Ambiguous::Earliest => Ok(dt_earliest.naive_utc()),
+            Ambiguous::Latest => Ok(dt_latest.naive_utc()),
+            Ambiguous::Raise => {
+                polars_bail!(ComputeError: "datetime '{}' is ambiguous in time zone '{}'. Please use `ambiguous` to tell how it should be localized.", ndt, to_tz)
             },
-            ambiguous => polars_bail!(InvalidOperation:
-                "Invalid argument {}, expected one of: \"earliest\", \"latest\", \"raise\"", ambiguous
-            ),
         },
-        LocalResult::None => polars_bail!(InvalidOperation:
+        LocalResult::None => polars_bail!(ComputeError:
                 "datetime '{}' is non-existent in time zone '{}'. Non-existent datetimes are not yet supported",
                 ndt, to_tz
         ),

--- a/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
+++ b/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
@@ -1,4 +1,6 @@
-use arrow::legacy::kernels::convert_to_naive_local;
+use std::str::FromStr;
+
+use arrow::legacy::kernels::{convert_to_naive_local, Ambiguous};
 use arrow::temporal_conversions::{
     timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
 };
@@ -46,7 +48,10 @@ pub fn replace_time_zone(
             Some(ambiguous) => datetime.0.try_apply(|timestamp| {
                 let ndt = timestamp_to_datetime(timestamp);
                 Ok(datetime_to_timestamp(convert_to_naive_local(
-                    &from_tz, &to_tz, ndt, ambiguous,
+                    &from_tz,
+                    &to_tz,
+                    ndt,
+                    Ambiguous::from_str(ambiguous)?,
                 )?))
             }),
             _ => Ok(datetime.0.apply(|_| None)),
@@ -56,7 +61,10 @@ pub fn replace_time_zone(
                 (Some(timestamp), Some(ambiguous)) => {
                     let ndt = timestamp_to_datetime(timestamp);
                     Ok(Some(datetime_to_timestamp(convert_to_naive_local(
-                        &from_tz, &to_tz, ndt, ambiguous,
+                        &from_tz,
+                        &to_tz,
+                        ndt,
+                        Ambiguous::from_str(ambiguous)?,
                     )?)))
                 },
                 _ => Ok(None),

--- a/crates/polars-time/src/month_start.rs
+++ b/crates/polars-time/src/month_start.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "timezones")]
+use arrow::legacy::kernels::Ambiguous;
 use arrow::legacy::time_zone::Tz;
 use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use polars_core::prelude::*;
@@ -45,7 +47,7 @@ pub(crate) fn roll_backward(
     let ndt = NaiveDateTime::new(date, time);
     let t = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => datetime_to_timestamp(localize_datetime(ndt, tz, "raise")?),
+        Some(tz) => datetime_to_timestamp(localize_datetime(ndt, tz, Ambiguous::Raise)?),
         _ => datetime_to_timestamp(ndt),
     };
     Ok(t)

--- a/crates/polars-time/src/utils.rs
+++ b/crates/polars-time/src/utils.rs
@@ -1,44 +1,26 @@
 #[cfg(feature = "timezones")]
+use arrow::legacy::kernels::{convert_to_naive_local, Ambiguous};
+#[cfg(feature = "timezones")]
 use arrow::legacy::time_zone::Tz;
 #[cfg(feature = "timezones")]
 use arrow::temporal_conversions::{
     timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
 };
 #[cfg(feature = "timezones")]
+use chrono::NaiveDateTime;
+#[cfg(feature = "timezones")]
 use chrono::TimeZone;
 #[cfg(feature = "timezones")]
-use chrono::{LocalResult, NaiveDateTime};
-#[cfg(feature = "timezones")]
-use polars_core::prelude::{polars_bail, PolarsResult, TimeUnit};
+use polars_core::prelude::{PolarsResult, TimeUnit};
 
 #[cfg(feature = "timezones")]
 pub(crate) fn localize_datetime(
     ndt: NaiveDateTime,
     tz: &Tz,
-    ambiguous: &str,
+    ambiguous: Ambiguous,
 ) -> PolarsResult<NaiveDateTime> {
     // e.g. '2021-01-01 03:00' -> '2021-01-01 03:00CDT'
-    match tz.from_local_datetime(&ndt) {
-        LocalResult::Single(tz) => Ok(tz.naive_utc()),
-        LocalResult::Ambiguous(dt_earliest, dt_latest) => match ambiguous {
-            "earliest" => Ok(dt_earliest.naive_utc()),
-            "latest" => Ok(dt_latest.naive_utc()),
-            "raise" => polars_bail!(ComputeError:
-                format!("datetime '{}' is ambiguous in time zone '{}'. \
-                    Please use `ambiguous` to tell how it should be localized. \
-                    If you got here from a function which doesn't have a `ambiguous` argument, \
-                    please open an issue at https://github.com/pola-rs/polars/issues.", ndt, tz)
-            ),
-            ambiguous => polars_bail!(ComputeError:
-                format!("Invalid argument {}, expected one of: \"earliest\", \"latest\", \"raise\"", ambiguous)
-            ),
-        },
-        LocalResult::None => {
-            polars_bail!(
-                ComputeError: format!("datetime '{}' is non-existent in time zone '{}'. Non-existent datetimes are not yet supported", ndt, tz)
-            )
-        },
-    }
+    convert_to_naive_local(&chrono_tz::UTC, tz, ndt, ambiguous)
 }
 
 #[cfg(feature = "timezones")]
@@ -50,25 +32,28 @@ pub(crate) fn unlocalize_datetime(ndt: NaiveDateTime, tz: &Tz) -> NaiveDateTime 
 #[cfg(feature = "timezones")]
 pub(crate) fn localize_timestamp(timestamp: i64, tu: TimeUnit, tz: Tz) -> PolarsResult<i64> {
     match tu {
-        TimeUnit::Nanoseconds => {
-            Ok(
-                localize_datetime(timestamp_ns_to_datetime(timestamp), &tz, "raise")?
-                    .timestamp_nanos_opt()
-                    .unwrap(),
-            )
-        },
-        TimeUnit::Microseconds => {
-            Ok(
-                localize_datetime(timestamp_us_to_datetime(timestamp), &tz, "raise")?
-                    .timestamp_micros(),
-            )
-        },
-        TimeUnit::Milliseconds => {
-            Ok(
-                localize_datetime(timestamp_ms_to_datetime(timestamp), &tz, "raise")?
-                    .timestamp_millis(),
-            )
-        },
+        TimeUnit::Nanoseconds => Ok(convert_to_naive_local(
+            &chrono_tz::UTC,
+            &tz,
+            timestamp_ns_to_datetime(timestamp),
+            Ambiguous::Raise,
+        )?
+        .timestamp_nanos_opt()
+        .unwrap()),
+        TimeUnit::Microseconds => Ok(convert_to_naive_local(
+            &chrono_tz::UTC,
+            &tz,
+            timestamp_us_to_datetime(timestamp),
+            Ambiguous::Raise,
+        )?
+        .timestamp_micros()),
+        TimeUnit::Milliseconds => Ok(convert_to_naive_local(
+            &chrono_tz::UTC,
+            &tz,
+            timestamp_ms_to_datetime(timestamp),
+            Ambiguous::Raise,
+        )?
+        .timestamp_millis()),
     }
 }
 

--- a/crates/polars-time/src/windows/duration.rs
+++ b/crates/polars-time/src/windows/duration.rs
@@ -1,6 +1,7 @@
 use std::cmp::Ordering;
 use std::ops::Mul;
 
+use arrow::legacy::kernels::Ambiguous;
 use arrow::legacy::time_zone::Tz;
 use arrow::temporal_conversions::{
     timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime, MILLISECONDS,
@@ -446,7 +447,7 @@ impl Duration {
         nsecs_to_unit: F,
         timestamp_to_datetime: G,
         datetime_to_timestamp: J,
-        _ambiguous: &str,
+        _ambiguous: Ambiguous,
     ) -> PolarsResult<i64>
     where
         F: Fn(i64) -> i64,
@@ -562,7 +563,7 @@ impl Duration {
 
     // Truncate the given ns timestamp by the window boundary.
     #[inline]
-    pub fn truncate_ns(&self, t: i64, tz: Option<&Tz>, ambiguous: &str) -> PolarsResult<i64> {
+    pub fn truncate_ns(&self, t: i64, tz: Option<&Tz>, ambiguous: Ambiguous) -> PolarsResult<i64> {
         self.truncate_impl(
             t,
             tz,
@@ -575,7 +576,7 @@ impl Duration {
 
     // Truncate the given ns timestamp by the window boundary.
     #[inline]
-    pub fn truncate_us(&self, t: i64, tz: Option<&Tz>, ambiguous: &str) -> PolarsResult<i64> {
+    pub fn truncate_us(&self, t: i64, tz: Option<&Tz>, ambiguous: Ambiguous) -> PolarsResult<i64> {
         self.truncate_impl(
             t,
             tz,
@@ -588,7 +589,7 @@ impl Duration {
 
     // Truncate the given ms timestamp by the window boundary.
     #[inline]
-    pub fn truncate_ms(&self, t: i64, tz: Option<&Tz>, ambiguous: &str) -> PolarsResult<i64> {
+    pub fn truncate_ms(&self, t: i64, tz: Option<&Tz>, ambiguous: Ambiguous) -> PolarsResult<i64> {
         self.truncate_impl(
             t,
             tz,
@@ -624,7 +625,7 @@ impl Duration {
             let dt = Self::add_month(ts, d.months, d.negative, d.saturating)?;
             new_t = match tz {
                 #[cfg(feature = "timezones")]
-                Some(tz) => datetime_to_timestamp(localize_datetime(dt, tz, "raise")?),
+                Some(tz) => datetime_to_timestamp(localize_datetime(dt, tz, Ambiguous::Raise)?),
                 _ => datetime_to_timestamp(dt),
             };
         }
@@ -640,7 +641,7 @@ impl Duration {
                     new_t = datetime_to_timestamp(localize_datetime(
                         timestamp_to_datetime(new_t),
                         tz,
-                        "raise",
+                        Ambiguous::Raise,
                     )?);
                 },
                 _ => new_t += if d.negative { -t_weeks } else { t_weeks },
@@ -658,7 +659,7 @@ impl Duration {
                     new_t = datetime_to_timestamp(localize_datetime(
                         timestamp_to_datetime(new_t),
                         tz,
-                        "raise",
+                        Ambiguous::Raise,
                     )?);
                 },
                 _ => new_t += if d.negative { -t_days } else { t_days },

--- a/crates/polars-time/src/windows/window.rs
+++ b/crates/polars-time/src/windows/window.rs
@@ -1,3 +1,4 @@
+use arrow::legacy::kernels::Ambiguous;
 use arrow::legacy::time_zone::Tz;
 use arrow::temporal_conversions::*;
 use chrono::NaiveDateTime;
@@ -31,50 +32,50 @@ impl Window {
     }
 
     /// Truncate the given ns timestamp by the window boundary.
-    pub fn truncate_ns(&self, t: i64, tz: Option<&Tz>, ambiguous: &str) -> PolarsResult<i64> {
+    pub fn truncate_ns(&self, t: i64, tz: Option<&Tz>, ambiguous: Ambiguous) -> PolarsResult<i64> {
         let t = self.every.truncate_ns(t, tz, ambiguous)?;
         self.offset.add_ns(t, tz)
     }
 
     pub fn truncate_no_offset_ns(&self, t: i64, tz: Option<&Tz>) -> PolarsResult<i64> {
-        self.every.truncate_ns(t, tz, "raise")
+        self.every.truncate_ns(t, tz, Ambiguous::Raise)
     }
 
     /// Truncate the given us timestamp by the window boundary.
-    pub fn truncate_us(&self, t: i64, tz: Option<&Tz>, ambiguous: &str) -> PolarsResult<i64> {
+    pub fn truncate_us(&self, t: i64, tz: Option<&Tz>, ambiguous: Ambiguous) -> PolarsResult<i64> {
         let t = self.every.truncate_us(t, tz, ambiguous)?;
         self.offset.add_us(t, tz)
     }
 
     pub fn truncate_no_offset_us(&self, t: i64, tz: Option<&Tz>) -> PolarsResult<i64> {
-        self.every.truncate_us(t, tz, "raise")
+        self.every.truncate_us(t, tz, Ambiguous::Raise)
     }
 
-    pub fn truncate_ms(&self, t: i64, tz: Option<&Tz>, ambiguous: &str) -> PolarsResult<i64> {
+    pub fn truncate_ms(&self, t: i64, tz: Option<&Tz>, ambiguous: Ambiguous) -> PolarsResult<i64> {
         let t = self.every.truncate_ms(t, tz, ambiguous)?;
         self.offset.add_ms(t, tz)
     }
 
     #[inline]
     pub fn truncate_no_offset_ms(&self, t: i64, tz: Option<&Tz>) -> PolarsResult<i64> {
-        self.every.truncate_ms(t, tz, "raise")
+        self.every.truncate_ms(t, tz, Ambiguous::Raise)
     }
 
     /// Round the given ns timestamp by the window boundary.
-    pub fn round_ns(&self, t: i64, tz: Option<&Tz>, ambiguous: &str) -> PolarsResult<i64> {
+    pub fn round_ns(&self, t: i64, tz: Option<&Tz>, ambiguous: Ambiguous) -> PolarsResult<i64> {
         let t = t + self.every.duration_ns() / 2_i64;
         self.truncate_ns(t, tz, ambiguous)
     }
 
     /// Round the given us timestamp by the window boundary.
-    pub fn round_us(&self, t: i64, tz: Option<&Tz>, ambiguous: &str) -> PolarsResult<i64> {
+    pub fn round_us(&self, t: i64, tz: Option<&Tz>, ambiguous: Ambiguous) -> PolarsResult<i64> {
         let t = t + self.every.duration_ns()
             / (2 * timeunit_scale(ArrowTimeUnit::Nanosecond, ArrowTimeUnit::Microsecond) as i64);
         self.truncate_us(t, tz, ambiguous)
     }
 
     /// Round the given ms timestamp by the window boundary.
-    pub fn round_ms(&self, t: i64, tz: Option<&Tz>, ambiguous: &str) -> PolarsResult<i64> {
+    pub fn round_ms(&self, t: i64, tz: Option<&Tz>, ambiguous: Ambiguous) -> PolarsResult<i64> {
         let t = t + self.every.duration_ns()
             / (2 * timeunit_scale(ArrowTimeUnit::Nanosecond, ArrowTimeUnit::Millisecond) as i64);
         self.truncate_ms(t, tz, ambiguous)
@@ -84,20 +85,20 @@ impl Window {
     /// that contains the given time t.  For underlapping windows that
     /// do not contain time t, the window directly after time t will be returned.
     pub fn get_earliest_bounds_ns(&self, t: i64, tz: Option<&Tz>) -> PolarsResult<Bounds> {
-        let start = self.truncate_ns(t, tz, "raise")?;
+        let start = self.truncate_ns(t, tz, Ambiguous::Raise)?;
         let stop = self.period.add_ns(start, tz)?;
 
         Ok(Bounds::new_checked(start, stop))
     }
 
     pub fn get_earliest_bounds_us(&self, t: i64, tz: Option<&Tz>) -> PolarsResult<Bounds> {
-        let start = self.truncate_us(t, tz, "raise")?;
+        let start = self.truncate_us(t, tz, Ambiguous::Raise)?;
         let stop = self.period.add_us(start, tz)?;
         Ok(Bounds::new_checked(start, stop))
     }
 
     pub fn get_earliest_bounds_ms(&self, t: i64, tz: Option<&Tz>) -> PolarsResult<Bounds> {
-        let start = self.truncate_ms(t, tz, "raise")?;
+        let start = self.truncate_ms(t, tz, Ambiguous::Raise)?;
         let stop = self.period.add_ms(start, tz)?;
 
         Ok(Bounds::new_checked(start, stop))

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1715,7 +1715,7 @@ def test_replace_time_zone_ambiguous_with_use_earliest(
 def test_replace_time_zone_ambiguous_raises() -> None:
     ts = pl.Series(["2018-10-28 02:30:00"]).str.strptime(pl.Datetime)
     with pytest.raises(
-        pl.InvalidOperationError,
+        pl.ComputeError,
         match="Please use `ambiguous` to tell how it should be localized",
     ):
         ts.dt.replace_time_zone("Europe/Brussels")

--- a/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
+++ b/py-polars/tests/unit/functions/as_datatype/test_as_datatype.py
@@ -56,7 +56,7 @@ def test_datetime_time_zone(time_zone: str | None) -> None:
 def test_datetime_ambiguous_time_zone() -> None:
     expr = pl.datetime(2018, 10, 28, 2, 30, time_zone="Europe/Brussels")
 
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(pl.ComputeError):
         pl.select(expr)
 
 

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -459,14 +459,14 @@ def test_strptime_invalid_timezone() -> None:
 
 def test_to_datetime_ambiguous_or_non_existent() -> None:
     with pytest.raises(
-        pl.InvalidOperationError,
+        pl.ComputeError,
         match="datetime '2021-11-07 01:00:00' is ambiguous in time zone 'US/Central'",
     ):
         pl.Series(["2021-11-07 01:00"]).str.to_datetime(
             time_unit="us", time_zone="US/Central"
         )
     with pytest.raises(
-        pl.InvalidOperationError,
+        pl.ComputeError,
         match="datetime '2021-03-28 02:30:00' is non-existent in time zone 'Europe/Warsaw'",
     ):
         pl.Series(["2021-03-28 02:30"]).str.to_datetime(
@@ -643,7 +643,7 @@ def test_to_datetime_use_earliest(exact: bool) -> None:
     )
     expected = datetime(2020, 10, 25, 1, fold=1, tzinfo=ZoneInfo("Europe/London"))
     assert result == expected
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(pl.ComputeError):
         pl.Series(["2020-10-25 01:00"]).str.to_datetime(
             time_zone="Europe/London",
             exact=exact,
@@ -670,7 +670,7 @@ def test_strptime_use_earliest(exact: bool) -> None:
     )
     expected = datetime(2020, 10, 25, 1, fold=1, tzinfo=ZoneInfo("Europe/London"))
     assert result == expected
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(pl.ComputeError):
         pl.Series(["2020-10-25 01:00"]).str.strptime(
             pl.Datetime("us", "Europe/London"),
             exact=exact,


### PR DESCRIPTION
Ahead of addressing #12149 

Currently `"raise"` is often allocated within a loop - it should be cheaper to just pass `Ambiguous::Raise`, right? At least from [this test](https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=dba8520f3633806d2a309dae5d72ef51) I'm seeing a nearly 4x improvement