### PR TITLE
build(python): Build Python wheels on `manylinux_2_28`

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -91,11 +91,6 @@ jobs:
         exclude:
           - os: windows-32gb-ram
             architecture: aarch64
-          # Temporarily disable linux aarch64 cross compilation
-          # TODO: Renable this when issue is fixed
-          # https://github.com/pola-rs/polars/issues/12180
-          - os: ubuntu-latest
-            architecture: aarch64
 
     steps:
       - uses: actions/checkout@v4
@@ -155,7 +150,7 @@ jobs:
             --release
             --manifest-path py-polars/Cargo.toml
             --out dist
-          manylinux: auto
+          manylinux: '2_28'
 
       - name: Upload wheel
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Closes #12180

Tested this on my fork, the wheel builds fine using `manylinux_2_28` 👌 thanks for investigating @orlp !