### PR TITLE
fix(rust,python): Consistently propagate nulls for `numpy` ufuncs

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/set.rs
+++ b/crates/polars-core/src/chunked_array/ops/set.rs
@@ -114,7 +114,8 @@ where
                     Some(true) => value,
                     _ => opt_val,
                 })
-                .collect_trusted();
+                .collect_trusted::<Self>()
+                .with_name(self.name());
             Ok(ca)
         }
     }
@@ -166,7 +167,8 @@ impl<'a> ChunkSet<'a, bool, bool> for BooleanChunked {
                 Some(true) => value,
                 _ => opt_val,
             })
-            .collect_trusted();
+            .collect_trusted::<Self>()
+            .with_name(self.name());
         Ok(ca)
     }
 }
@@ -229,7 +231,8 @@ impl<'a> ChunkSet<'a, &'a str, String> for Utf8Chunked {
                 Some(true) => value,
                 _ => opt_val,
             })
-            .collect_trusted();
+            .collect_trusted::<Self>()
+            .with_name(self.name());
         Ok(ca)
     }
 }
@@ -293,7 +296,8 @@ impl<'a> ChunkSet<'a, &'a [u8], Vec<u8>> for BinaryChunked {
                 Some(true) => value,
                 _ => opt_val,
             })
-            .collect_trusted();
+            .collect_trusted::<Self>()
+            .with_name(self.name());
         Ok(ca)
     }
 }

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4395,7 +4395,7 @@ class Series:
         f = get_ffi_func("set_with_mask_<>", self.dtype, self._s)
         if f is None:
             return NotImplemented
-        return self._from_pyseries(f(filter._s, value)).rename(self.name)
+        return self._from_pyseries(f(filter._s, value))
 
     def set_at_idx(
         self,

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -846,6 +846,13 @@ def test_ufunc() -> None:
         pl.Series("a", [3.0, None, 9.0, 12.0, 15.0, None]),
     )
 
+    # Test if nulls propagate through ufuncs
+    a3 = pl.Series("a", [None, None, 3, 3])
+    b3 = pl.Series("b", [None, 3, None, 3])
+    assert_series_equal(
+        cast(pl.Series, np.maximum(a3, b3)), pl.Series("a", [None, None, None, 3])
+    )
+
 
 def test_numpy_string_array() -> None:
     s_utf8 = pl.Series("a", ["aa", "bb", "cc", "dd"], dtype=pl.Utf8)
@@ -894,7 +901,7 @@ def test_set() -> None:
     a = pl.Series("a", [True, False, True])
     mask = pl.Series("msk", [True, False, True])
     a[mask] = False
-    assert_series_equal(a, pl.Series("", [False] * 3))
+    assert_series_equal(a, pl.Series("a", [False] * 3))
 
 
 def test_set_value_as_list_fail() -> None:


### PR DESCRIPTION
Closes #10233 

When applying a `numpy` ufunc to a series, the resulting series would get its validity mask from only the first series in the argument list. If there were multiple series arguments, then the null values in those other series would all be treated like zeros.

This PR makes sure that output will be null anywhere one of the inputs is null, not just where the first one is. Sometimes ufuncs will treat nulls like the equivalent polars functions, like how both `numpy.add` and series addition propagate null values. However, that's not the case for the function in the linked issue, where `numpy.maximum` propagates null values but `pl.max_horizontal` ignores them. At least `numpy.maximum` won't depend on the argument order anymore.

In the course of fixing this bug, I also added boolean and null values to the type hint for `Series.set`. Both work, since `set_with_mask_bool` supports `bool` values and all the `set_with_mask_` functions can take null values. In those cases, I noticed that `set` was dropping the name of the series and fixed that.