### PR TITLE
feat(rust!): Rename `is_signed` to `is_signed_integer`

### DIFF
--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -118,8 +118,9 @@ where
                 // this may still fail with overflow?
                 let dtype = self.dtype();
 
-                let to_signed = data_type.is_signed();
-                let unsigned2unsigned = dtype.is_unsigned() && data_type.is_unsigned();
+                let to_signed = data_type.is_signed_integer();
+                let unsigned2unsigned =
+                    dtype.is_unsigned_integer() && data_type.is_unsigned_integer();
                 let allowed = to_signed || unsigned2unsigned;
 
                 if (allowed)

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -428,14 +428,14 @@ impl<'a> AnyValue<'a> {
         })
     }
 
-    pub fn is_signed(&self) -> bool {
+    pub fn is_signed_integer(&self) -> bool {
         matches!(
             self,
             AnyValue::Int8(_) | AnyValue::Int16(_) | AnyValue::Int32(_) | AnyValue::Int64(_)
         )
     }
 
-    pub fn is_unsigned(&self) -> bool {
+    pub fn is_unsigned_integer(&self) -> bool {
         matches!(
             self,
             AnyValue::UInt8(_) | AnyValue::UInt16(_) | AnyValue::UInt32(_) | AnyValue::UInt64(_)
@@ -476,8 +476,8 @@ impl<'a> AnyValue<'a> {
         let new_av = match self {
             AnyValue::Boolean(v) => cast_to!(*v as u8),
             AnyValue::Float32(_) | AnyValue::Float64(_) => cast_to!(self.extract::<f64>().unwrap()),
-            av if av.is_signed() => cast_to!(av.extract::<i64>().unwrap()),
-            av if av.is_unsigned() => cast_to!(av.extract::<u64>().unwrap()),
+            av if av.is_signed_integer() => cast_to!(av.extract::<i64>().unwrap()),
+            av if av.is_unsigned_integer() => cast_to!(av.extract::<u64>().unwrap()),
             #[cfg(feature = "dtype-datetime")]
             AnyValue::Datetime(v, tu, None) => match dtype {
                 DataType::Int64 => AnyValue::Int64(*v),

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -186,20 +186,27 @@ impl DataType {
         )
     }
 
-    pub fn is_signed(&self) -> bool {
+    pub fn is_signed_integer(&self) -> bool {
         // allow because it cannot be replaced when object feature is activated
-        #[allow(clippy::match_like_matches_macro)]
         match self {
+            DataType::Int64 | DataType::Int32 => true,
             #[cfg(feature = "dtype-i8")]
             DataType::Int8 => true,
             #[cfg(feature = "dtype-i16")]
             DataType::Int16 => true,
-            DataType::Int32 | DataType::Int64 => true,
             _ => false,
         }
     }
-    pub fn is_unsigned(&self) -> bool {
-        self.is_numeric() && !self.is_signed()
+
+    pub fn is_unsigned_integer(&self) -> bool {
+        match self {
+            DataType::UInt64 | DataType::UInt32 => true,
+            #[cfg(feature = "dtype-u8")]
+            DataType::UInt8 => true,
+            #[cfg(feature = "dtype-u16")]
+            DataType::UInt16 => true,
+            _ => false,
+        }
     }
 
     /// Convert to an Arrow data type.

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -47,7 +47,7 @@ fn any_values_to_decimal(
     // two-pass approach, first we scan and record the scales, then convert (or not)
     let mut scale_range: Option<(usize, usize)> = None;
     for av in avs {
-        let s_av = if av.is_signed() || av.is_unsigned() {
+        let s_av = if av.is_signed_integer() || av.is_unsigned_integer() {
             0 // integers are treated as decimals with scale of zero
         } else if let AnyValue::Decimal(_, scale) = av {
             *scale
@@ -80,7 +80,7 @@ fn any_values_to_decimal(
     let mut builder = PrimitiveChunkedBuilder::<Int128Type>::new("", avs.len());
     let is_equally_scaled = s_min == s_max && s_max == scale;
     for av in avs {
-        let (v, s_av) = if av.is_signed() || av.is_unsigned() {
+        let (v, s_av) = if av.is_signed_integer() || av.is_unsigned_integer() {
             (
                 av.try_extract::<i128>().unwrap_or_else(|_| unreachable!()),
                 0,

--- a/crates/polars-core/src/utils/supertype.rs
+++ b/crates/polars-core/src/utils/supertype.rs
@@ -265,7 +265,7 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
                 Some(Struct(new_fields))
             }
             #[cfg(feature = "dtype-decimal")]
-            (d @ Decimal(_, _), dt) if dt.is_signed() || dt.is_unsigned() => Some(d.clone()),
+            (d @ Decimal(_, _), dt) if dt.is_signed_integer() || dt.is_unsigned_integer() => Some(d.clone()),
             #[cfg(feature = "dtype-decimal")]
             (Decimal(p1, s1), Decimal(p2, s2)) => {
                 Some(Decimal((*p1).zip(*p2).map(|(p1, p2)| p1.max(p2)), (*s1).max(*s2)))

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -370,7 +370,7 @@ pub trait ListNameSpaceImpl: AsList {
                 Ok(out.into_series())
             },
             UInt32 | UInt64 => index_typed_index(idx),
-            dt if dt.is_signed() => {
+            dt if dt.is_signed_integer() => {
                 if let Some(min) = idx.min::<i64>() {
                     if min >= 0 {
                         index_typed_index(idx)
@@ -713,7 +713,7 @@ fn cast_index(idx: Series, len: usize, null_on_oob: bool) -> PolarsResult<Series
                 idx
             }
         },
-        dt if dt.is_unsigned() => idx.cast(&IDX_DTYPE).unwrap(),
+        dt if dt.is_unsigned_integer() => idx.cast(&IDX_DTYPE).unwrap(),
         Int8 => {
             let a = idx.i8().unwrap();
             cast_signed_index_ca(a, len)

--- a/crates/polars-ops/src/series/ops/index.rs
+++ b/crates/polars-ops/src/series/ops/index.rs
@@ -37,7 +37,7 @@ where
 pub fn convert_to_unsigned_index(s: &Series, target_len: usize) -> PolarsResult<IdxCa> {
     let dtype = s.dtype();
     polars_ensure!(dtype.is_integer(), InvalidOperation: "expected integers as index");
-    if dtype.is_unsigned() {
+    if dtype.is_unsigned_integer() {
         let out = s.cast(&IDX_DTYPE).unwrap();
         return Ok(out.idx().unwrap().clone());
     }

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -133,7 +133,7 @@ impl FunctionExpr {
                     if dt.is_numeric() {
                         if dt.is_float() {
                             DataType::Float32
-                        } else if dt.is_unsigned() {
+                        } else if dt.is_unsigned_integer() {
                             DataType::Int8
                         } else {
                             DataType::UInt8

--- a/crates/polars-plan/src/dsl/function_expr/shrink_type.rs
+++ b/crates/polars-plan/src/dsl/function_expr/shrink_type.rs
@@ -4,7 +4,7 @@ pub(super) fn shrink(s: Series) -> PolarsResult<Series> {
     if s.dtype().is_numeric() {
         if s.dtype().is_float() {
             s.cast(&DataType::Float32)
-        } else if s.dtype().is_unsigned() {
+        } else if s.dtype().is_unsigned_integer() {
             let max = s
                 .max_as_series()
                 .get(0)


### PR DESCRIPTION
`is_signed` and `is_unsigned` were for checking signed/unsigned integer types. The name is actually a misnomer as floats and decimals are also signed, but they weren't included.

This renames:
* `is_signed` -> `is_signed_integer`
* `is_unsigned` -> `is_unsigned_integer`

This renames the functions in line with https://github.com/pola-rs/polars/pull/12200