### PR TITLE
depr(python): Switch args for `Decimal` and set default `scale=0`

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -296,7 +296,9 @@ class Decimal(FractionalType):
     """
     Decimal 128-bit type with an optional precision and non-negative scale.
 
-    NOTE: this is an experimental work-in-progress feature and may not work as expected.
+    .. warning::
+        This is an experimental work-in-progress feature and may not work as expected.
+
     """
 
     precision: int | None

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -302,7 +302,28 @@ class Decimal(FractionalType):
     precision: int | None
     scale: int
 
-    def __init__(self, scale: int, precision: int | None = None):
+    def __init__(
+        self,
+        *args,
+        precision: int | None = None,
+        scale: int = 0,
+    ):
+        from polars.utils.deprecation import issue_deprecation_warning
+
+        if args:
+            # TODO: When removing this deprecation, update the `to_object`
+            # implementation in py-polars/src/conversion.rs to use `call1` instead of
+            # `call`
+            issue_deprecation_warning(
+                "`Decimal` parameters `scale` and `precision` will change positions in the next breaking release."
+                " Use keyword arguments to keep current behavior and silence this warning.",
+                version="0.19.13",
+            )
+            if len(args) == 1:
+                scale = args[0]
+            else:
+                scale, precision = args[:2]
+
         self.precision = precision
         self.scale = scale
 
@@ -526,8 +547,8 @@ class Array(NestedType):
     def __init__(  # noqa: D417
         self,
         *args: Any,
-        width: int | None = None,
         inner: PolarsDataType | PythonDataType | None = None,
+        width: int | None = None,
     ):
         """
         Fixed length list type.
@@ -560,7 +581,7 @@ class Array(NestedType):
             # implementation in py-polars/src/conversion.rs to use `call1` instead of
             # `call`
             issue_deprecation_warning(
-                "Parameters `inner` and `width` will change positions in the next breaking release."
+                "`Array` parameters `width` and `inner` will change positions in the next breaking release."
                 " Use keyword arguments to keep current behavior and silence this warning.",
                 version="0.19.11",
             )

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -306,7 +306,7 @@ class Decimal(FractionalType):
 
     def __init__(
         self,
-        *args,
+        *args: Any,
         precision: int | None = None,
         scale: int = 0,
     ):

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -300,12 +300,16 @@ impl ToPyObject for Wrap<DataType> {
             DataType::UInt64 => pl.getattr(intern!(py, "UInt64")).unwrap().into(),
             DataType::Float32 => pl.getattr(intern!(py, "Float32")).unwrap().into(),
             DataType::Float64 => pl.getattr(intern!(py, "Float64")).unwrap().into(),
-            DataType::Decimal(precision, scale) => pl
-                .getattr(intern!(py, "Decimal"))
-                .unwrap()
-                .call1((*scale, *precision))
-                .unwrap()
-                .into(),
+            DataType::Decimal(precision, scale) => {
+                let kwargs = PyDict::new(py);
+                kwargs.set_item("precision", *precision).unwrap();
+                kwargs.set_item("scale", *scale).unwrap();
+                pl.getattr(intern!(py, "Decimal"))
+                    .unwrap()
+                    .call((), Some(kwargs))
+                    .unwrap()
+                    .into()
+            },
             DataType::Boolean => pl.getattr(intern!(py, "Boolean")).unwrap().into(),
             DataType::Utf8 => pl.getattr(intern!(py, "Utf8")).unwrap().into(),
             DataType::Binary => pl.getattr(intern!(py, "Binary")).unwrap().into(),

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -220,7 +220,7 @@ def test_from_arrow(monkeypatch: Any) -> None:
         "c": pl.Datetime("us"),
         "d": pl.Datetime("ns"),
         "e": pl.Int32,
-        "decimal1": pl.Decimal(1, 2),
+        "decimal1": pl.Decimal(precision=2, scale=1),
     }
     expected_data = [
         (

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -33,7 +33,7 @@ def test_series_from_pydecimal_and_ints(
     # TODO: check what happens if there are strings, floats arrow scalars in the list
     for data in permutations_int_dec_none:
         s = pl.Series("name", data)
-        assert s.dtype == pl.Decimal(7)  # inferred scale = 7, precision = None
+        assert s.dtype == pl.Decimal(scale=7)  # inferred scale = 7, precision = None
         assert s.name == "name"
         assert s.null_count() == 1
         for i, d in enumerate(data):
@@ -60,7 +60,7 @@ def test_frame_from_pydecimal_and_ints(
             for ctor in (pl.DataFrame, pl.from_records):
                 df = ctor(data=list(map(cls, data)))  # type: ignore[operator]
                 assert df.schema == {
-                    "a": pl.Decimal(7),
+                    "a": pl.Decimal(scale=7),
                 }
                 assert df.rows() == row_data
 
@@ -146,7 +146,7 @@ def test_utf8_to_decimal() -> None:
             "-62.44",
         ]
     ).str.to_decimal()
-    assert s.dtype == pl.Decimal(2)
+    assert s.dtype == pl.Decimal(scale=2)
 
     assert s.to_list() == [
         D("40.12"),
@@ -168,7 +168,7 @@ def test_read_csv_decimal(monkeypatch: Any) -> None:
     0.01,a"""
 
     df = pl.read_csv(csv.encode(), dtypes={"a": pl.Decimal(scale=2)})
-    assert df.dtypes == [pl.Decimal(2, None), pl.Utf8]
+    assert df.dtypes == [pl.Decimal(precision=None, scale=2), pl.Utf8]
     assert df["a"].to_list() == [
         D("123.12"),
         D("1.10"),

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -531,7 +531,7 @@ def test_series_dtype_is() -> None:
     s = pl.Series("s", ["testing..."])
     assert s.is_utf8()
 
-    s = pl.Series("s", [], dtype=pl.Decimal(scale=15, precision=20))
+    s = pl.Series("s", [], dtype=pl.Decimal(precision=20, scale=15))
     assert not s.is_float()
     assert s.is_numeric()
     assert s.is_empty()

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -228,7 +228,7 @@ def test_init_structured_objects(monkeypatch: Any) -> None:
             assert df.schema == {
                 "timestamp": pl.Datetime("us"),
                 "ticker": pl.Utf8,
-                "price": pl.Decimal(1),
+                "price": pl.Decimal(scale=1),
                 "size": pl.Int64,
             }
             assert df.rows() == raw_data
@@ -241,7 +241,7 @@ def test_init_structured_objects(monkeypatch: Any) -> None:
             assert df.schema == {
                 "timestamp": pl.Datetime("ms"),
                 "ticker": pl.Utf8,
-                "price": pl.Decimal(1),
+                "price": pl.Decimal(scale=1),
                 "size": pl.Int32,
             }
 
@@ -251,14 +251,14 @@ def test_init_structured_objects(monkeypatch: Any) -> None:
             schema=[
                 ("ts", pl.Datetime("ms")),
                 ("tk", pl.Categorical),
-                ("pc", pl.Decimal(1)),
+                ("pc", pl.Decimal(scale=1)),
                 ("sz", pl.UInt16),
             ],
         )
         assert df.schema == {
             "ts": pl.Datetime("ms"),
             "tk": pl.Categorical,
-            "pc": pl.Decimal(1),
+            "pc": pl.Decimal(scale=1),
             "sz": pl.UInt16,
         }
         assert df.rows() == raw_data


### PR DESCRIPTION
Having `precision` as the second argument is inconsistent with our own code on the Rust side, as well as with literally every other API I could find (Arrow / SQL / ...). So I'm doing the same trick as with `Array` to switch the arguments.

Setting a default value of 0 for `scale` also follows Arrow / SQL defaults.