### PR TITLE
perf: allow non-power-of-two partitions

### DIFF
--- a/crates/polars-core/src/frame/group_by/hashing.rs
+++ b/crates/polars-core/src/frame/group_by/hashing.rs
@@ -188,7 +188,6 @@ where
     T: Send + Hash + Eq + Sync + Copy + AsU64,
     IntoSlice: AsRef<[T]> + Send + Sync,
 {
-    assert!(n_partitions.is_power_of_two());
     let init_size = get_init_size();
 
     // We will create a hashtable in every thread.
@@ -252,7 +251,6 @@ where
     I::IntoIter: ExactSizeIterator,
     T: Send + Hash + Eq + Sync + Copy + AsU64,
 {
-    assert!(n_partitions.is_power_of_two());
     let init_size = get_init_size();
 
     // We will create a hashtable in every thread.

--- a/crates/polars-core/src/hashing/partition.rs
+++ b/crates/polars-core/src/hashing/partition.rs
@@ -1,3 +1,5 @@
+use polars_utils::hash_to_partition;
+
 use super::*;
 
 // Used to to get a u64 from the hashing keys
@@ -130,9 +132,6 @@ impl<'a> AsU64 for BytesHash<'a> {
 }
 
 #[inline]
-/// For partitions that are a power of 2 we can use a bitshift instead of a modulo.
 pub fn this_partition(h: u64, thread_no: u64, n_partitions: u64) -> bool {
-    debug_assert!(n_partitions.is_power_of_two());
-    // n % 2^i = n & (2^i - 1)
-    (h & n_partitions.wrapping_sub(1)) == thread_no
+    hash_to_partition(h, n_partitions as usize) as u64 == thread_no
 }

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -30,19 +30,7 @@ impl<T> Deref for Wrap<T> {
 }
 
 pub fn _set_partition_size() -> usize {
-    let mut n_partitions = POOL.current_num_threads();
-    if n_partitions == 1 {
-        return 1;
-    }
-    // set n_partitions to closest 2^n size
-    loop {
-        if n_partitions.is_power_of_two() {
-            break;
-        } else {
-            n_partitions -= 1;
-        }
-    }
-    n_partitions
+    POOL.current_num_threads()
 }
 
 /// Just a wrapper structure. Useful for certain impl specializations

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -237,7 +237,6 @@ where
     drop(build_hashes); // Early drop to reduce memory pressure.
     let offsets = mk::get_offsets(&probe_hashes);
     let n_tables = hash_tbls.len() as u64;
-    debug_assert!(n_tables.is_power_of_two());
 
     // Now we probe the right hand side for each left hand side.
     POOL.install(|| {

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_inner.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_inner.rs
@@ -17,7 +17,6 @@ pub(super) fn probe_inner<T, F, I>(
     // <I as IntoIterator>::IntoIter: TrustedLen,
     F: Fn(IdxSize, IdxSize) -> (IdxSize, IdxSize),
 {
-    assert!(hash_tbls.len().is_power_of_two());
     probe.into_iter().enumerate_idx().for_each(|(idx_a, k)| {
         let idx_a = idx_a + local_offset;
         // probe table that contains the hashed value
@@ -61,7 +60,6 @@ where
     };
 
     let n_tables = hash_tbls.len() as u64;
-    debug_assert!(n_tables.is_power_of_two());
     let offsets = probe_to_offsets(&probe);
     // next we probe the other relation
     // code duplication is because we want to only do the swap check once

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_left.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_left.rs
@@ -128,7 +128,6 @@ where
     let offsets = probe_to_offsets(&probe);
 
     let n_tables = hash_tbls.len() as u64;
-    debug_assert!(n_tables.is_power_of_two());
 
     // next we probe the other relation
     let result: Vec<LeftJoinIds> = POOL.install(move || {

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_outer.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_outer.rs
@@ -22,7 +22,6 @@ fn probe_outer<T, F, G, H>(
     H: Fn(IdxSize) -> (Option<IdxSize>, Option<IdxSize>),
 {
     // needed for the partition shift instead of modulo to make sense
-    assert!(n_tables.is_power_of_two());
     let mut idx_a = 0;
     for probe_hashes in probe_hashes {
         for (h, key) in probe_hashes {

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_semi_anti.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_semi_anti.rs
@@ -46,7 +46,6 @@ where
     let offsets = probe_to_offsets(&probe);
 
     let n_tables = hash_sets.len() as u64;
-    debug_assert!(n_tables.is_power_of_two());
 
     // next we probe the other relation
     POOL.install(move || {


### PR DESCRIPTION
This should improve performance for machines with a number of cores that isn't divisible exactly by a power of two for partitioned operations. E.g. if you have a 14-core machine a partitioned join can now use 14 cores instead of only 8.

There is a small bit overhead because it uses two multiplications (one of which is kind of necessary to fix some bad hashing we have in places for the moment anyway) instead of a binary AND, but I did not find that to be meaningful.