### PR TITLE
fix(python): fix plugins system on Windows

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -870,7 +870,7 @@ def warn_on_inefficient_map(
 
 
 def is_shared_lib(file: str) -> bool:
-    return file.endswith((".so", ".dll"))
+    return file.endswith((".so", ".dll", ".pyd"))
 
 
 def _get_shared_lib_location(main_file: Any) -> str:


### PR DESCRIPTION
closes https://github.com/MarcoGorelli/polars-business/issues/23

With this fix, it works on Windows:
```python
(base) C:\Users\User>python
Python 3.10.6 | packaged by conda-forge | (main, Aug 22 2022, 20:30:19) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import polars
>>> polars.__file__
'C:\\Users\\User\\mambaforge\\lib\\site-packages\\polars\\__init__.py'
>>> import os
>>> os.listdir('C:\\Users\\User\\mambaforge\\lib\\site-packages\\polars_business')
['polars_business.cp310-win_amd64.pyd', 'py.typed', 'ranges.py', '__init__.py', '__pycache__']
>>> from datetime import date
>>> import polars_business as plb
>>>
>>> print(plb.date_range(date(2023, 1, 1), date(2023, 1, 10), eager=True))
shape: (7,)
Series: 'date' [date]
[
        2023-01-02
        2023-01-03
        2023-01-04
        2023-01-05
        2023-01-06
        2023-01-09
        2023-01-10
]
```