### PR TITLE
perf: remove extra multiplication in hash_to_partition

### DIFF
--- a/crates/polars-core/src/frame/group_by/perfect.rs
+++ b/crates/polars-core/src/frame/group_by/perfect.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use arrow::array::Array;
 use arrow::legacy::bit_util::round_upto_multiple_of_64;
-use num_traits::FromPrimitive;
+use num_traits::{FromPrimitive, ToPrimitive};
 use polars_utils::slice::GetSaferUnchecked;
 use polars_utils::sync::SyncPtr;
 use polars_utils::IdxSize;
@@ -11,14 +11,13 @@ use rayon::prelude::*;
 #[cfg(all(feature = "dtype-categorical", feature = "performant"))]
 use crate::config::verbose;
 use crate::datatypes::*;
-use crate::hashing::AsU64;
 use crate::prelude::*;
 use crate::POOL;
 
 impl<T> ChunkedArray<T>
 where
     T: PolarsIntegerType,
-    T::Native: AsU64 + FromPrimitive + Debug,
+    T::Native: ToPrimitive + FromPrimitive + Debug,
 {
     // Use the indexes as perfect groups
     pub fn group_tuples_perfect(
@@ -87,7 +86,7 @@ where
                             if arr.null_count() == 0 {
                                 for &cat in arr.values().as_slice() {
                                     if cat >= start && cat < end {
-                                        let cat = cat.as_u64() as usize;
+                                        let cat = cat.to_usize().unwrap();
                                         let buf = unsafe { groups.get_unchecked_release_mut(cat) };
                                         buf.push(row_nr);
 
@@ -106,7 +105,7 @@ where
                                     if let Some(&cat) = opt_cat {
                                         // cannot factor out due to bchk
                                         if cat >= start && cat < end {
-                                            let cat = cat.as_u64() as usize;
+                                            let cat = cat.to_usize().unwrap();
                                             let buf =
                                                 unsafe { groups.get_unchecked_release_mut(cat) };
                                             buf.push(row_nr);
@@ -155,7 +154,7 @@ where
             for arr in self.downcast_iter() {
                 for opt_cat in arr.iter() {
                     if let Some(cat) = opt_cat {
-                        let group_id = cat.as_u64() as usize;
+                        let group_id = cat.to_usize().unwrap();
                         let buf = unsafe { groups.get_unchecked_release_mut(group_id) };
                         buf.push(row_nr);
 

--- a/crates/polars-core/src/hashing/partition.rs
+++ b/crates/polars-core/src/hashing/partition.rs
@@ -66,7 +66,7 @@ impl AsU64 for i32 {
 impl AsU64 for i64 {
     #[inline]
     fn as_u64(self) -> u64 {
-        (unsafe { std::mem::transmute::<_, u64>(self) }).wrapping_mul(RANDOM_ODD)
+        (self as u64).wrapping_mul(RANDOM_ODD)
     }
 }
 
@@ -74,15 +74,16 @@ impl<T: AsU64 + Copy> AsU64 for Option<&T> {
     #[inline]
     fn as_u64(self) -> u64 {
         match self {
-            Some(v) => v.as_u64().wrapping_mul(RANDOM_ODD),
-            None => RANDOM_ODD,
+            Some(v) => v.as_u64(),
+            // just a number safe from overflow
+            None => u64::MAX >> 2,
         }
     }
 }
 
 impl<T: AsU64 + Copy> AsU64 for &T {
     fn as_u64(self) -> u64 {
-        (*self).as_u64().wrapping_mul(RANDOM_ODD)
+        (*self).as_u64()
     }
 }
 
@@ -91,7 +92,8 @@ impl AsU64 for Option<u32> {
     fn as_u64(self) -> u64 {
         match self {
             Some(v) => (v as u64).wrapping_mul(RANDOM_ODD),
-            None => RANDOM_ODD,
+            // just a number safe from overflow
+            None => u64::MAX >> 2,
         }
     }
 }
@@ -102,7 +104,8 @@ impl AsU64 for Option<u8> {
     fn as_u64(self) -> u64 {
         match self {
             Some(v) => (v as u64).wrapping_mul(RANDOM_ODD),
-            None => RANDOM_ODD,
+            // just a number safe from overflow
+            None => u64::MAX >> 2,
         }
     }
 }
@@ -113,7 +116,8 @@ impl AsU64 for Option<u16> {
     fn as_u64(self) -> u64 {
         match self {
             Some(v) => (v as u64).wrapping_mul(RANDOM_ODD),
-            None => RANDOM_ODD,
+            // just a number safe from overflow
+            None => u64::MAX >> 2,
         }
     }
 }
@@ -123,7 +127,8 @@ impl AsU64 for Option<u64> {
     fn as_u64(self) -> u64 {
         match self {
             Some(v) => v.wrapping_mul(RANDOM_ODD),
-            None => RANDOM_ODD,
+            // just a number safe from overflow
+            None => u64::MAX >> 2,
         }
     }
 }

--- a/crates/polars-core/src/hashing/partition.rs
+++ b/crates/polars-core/src/hashing/partition.rs
@@ -9,45 +9,49 @@ pub trait AsU64 {
     fn as_u64(self) -> u64;
 }
 
+// Identity gives a poorly distributed hash. So we spread values around by a simple wrapping
+// multiplication by a 'random' odd number.
+const RANDOM_ODD: u64 = 0x55fbfd6bfc5458e9;
+
 impl AsU64 for u8 {
     #[inline]
     fn as_u64(self) -> u64 {
-        self as u64
+        (self as u64).wrapping_mul(RANDOM_ODD)
     }
 }
 
 impl AsU64 for u16 {
     #[inline]
     fn as_u64(self) -> u64 {
-        self as u64
+        (self as u64).wrapping_mul(RANDOM_ODD)
     }
 }
 
 impl AsU64 for u32 {
     #[inline]
     fn as_u64(self) -> u64 {
-        self as u64
+        (self as u64).wrapping_mul(RANDOM_ODD)
     }
 }
 
 impl AsU64 for u64 {
     #[inline]
     fn as_u64(self) -> u64 {
-        self
+        self.wrapping_mul(RANDOM_ODD)
     }
 }
 
 impl AsU64 for i8 {
     #[inline]
     fn as_u64(self) -> u64 {
-        self as u64
+        (self as u64).wrapping_mul(RANDOM_ODD)
     }
 }
 
 impl AsU64 for i16 {
     #[inline]
     fn as_u64(self) -> u64 {
-        self as u64
+        (self as u64).wrapping_mul(RANDOM_ODD)
     }
 }
 
@@ -55,14 +59,14 @@ impl AsU64 for i32 {
     #[inline]
     fn as_u64(self) -> u64 {
         let asu32: u32 = unsafe { std::mem::transmute(self) };
-        asu32 as u64
+        (asu32 as u64).wrapping_mul(RANDOM_ODD)
     }
 }
 
 impl AsU64 for i64 {
     #[inline]
     fn as_u64(self) -> u64 {
-        unsafe { std::mem::transmute(self) }
+        (unsafe { std::mem::transmute::<_, u64>(self) }).wrapping_mul(RANDOM_ODD)
     }
 }
 
@@ -70,16 +74,15 @@ impl<T: AsU64 + Copy> AsU64 for Option<&T> {
     #[inline]
     fn as_u64(self) -> u64 {
         match self {
-            Some(v) => v.as_u64(),
-            // just a number safe from overflow
-            None => u64::MAX >> 2,
+            Some(v) => v.as_u64().wrapping_mul(RANDOM_ODD),
+            None => RANDOM_ODD,
         }
     }
 }
 
 impl<T: AsU64 + Copy> AsU64 for &T {
     fn as_u64(self) -> u64 {
-        (*self).as_u64()
+        (*self).as_u64().wrapping_mul(RANDOM_ODD)
     }
 }
 
@@ -87,9 +90,8 @@ impl AsU64 for Option<u32> {
     #[inline]
     fn as_u64(self) -> u64 {
         match self {
-            Some(v) => v as u64,
-            // just a number safe from overflow
-            None => u64::MAX >> 2,
+            Some(v) => (v as u64).wrapping_mul(RANDOM_ODD),
+            None => RANDOM_ODD,
         }
     }
 }
@@ -99,9 +101,8 @@ impl AsU64 for Option<u8> {
     #[inline]
     fn as_u64(self) -> u64 {
         match self {
-            Some(v) => v as u64,
-            // just a number safe from overflow
-            None => u64::MAX >> 2,
+            Some(v) => (v as u64).wrapping_mul(RANDOM_ODD),
+            None => RANDOM_ODD,
         }
     }
 }
@@ -111,9 +112,8 @@ impl AsU64 for Option<u16> {
     #[inline]
     fn as_u64(self) -> u64 {
         match self {
-            Some(v) => v as u64,
-            // just a number safe from overflow
-            None => u64::MAX >> 2,
+            Some(v) => (v as u64).wrapping_mul(RANDOM_ODD),
+            None => RANDOM_ODD,
         }
     }
 }
@@ -121,7 +121,10 @@ impl AsU64 for Option<u16> {
 impl AsU64 for Option<u64> {
     #[inline]
     fn as_u64(self) -> u64 {
-        self.unwrap_or(u64::MAX >> 2)
+        match self {
+            Some(v) => v.wrapping_mul(RANDOM_ODD),
+            None => RANDOM_ODD,
+        }
     }
 }
 

--- a/crates/polars-core/src/hashing/partition.rs
+++ b/crates/polars-core/src/hashing/partition.rs
@@ -58,8 +58,7 @@ impl AsU64 for i16 {
 impl AsU64 for i32 {
     #[inline]
     fn as_u64(self) -> u64 {
-        let asu32: u32 = unsafe { std::mem::transmute(self) };
-        (asu32 as u64).wrapping_mul(RANDOM_ODD)
+        (self as u64).wrapping_mul(RANDOM_ODD)
     }
 }
 

--- a/crates/polars-utils/src/functions.rs
+++ b/crates/polars-utils/src/functions.rs
@@ -13,11 +13,6 @@ pub fn flatten<T: Clone, R: AsRef<[T]>>(bufs: &[R], len: Option<usize>) -> Vec<T
 
 #[inline]
 pub fn hash_to_partition(h: u64, n_partitions: usize) -> usize {
-    // FIXME: we currently use an identity hash in some places, giving a very
-    // poorly distributed hash. So we spread values around by a simple wrapping
-    // multiplication by a 'random' odd number.
-    let h = h.wrapping_mul(0x55fbfd6bfc5458e9);
-
     // Now, assuming h is a 64-bit random number, we note that
     // h / 2^64 is almost a uniform random number in [0, 1), and thus
     // floor(h * n_partitions / 2^64) is almost a uniform random integer in

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1645,7 +1645,7 @@ def test_reproducible_hash_with_seeds() -> None:
     if platform.mac_ver()[-1] != "arm64":
         expected = pl.Series(
             "s",
-            [13477868900383131459, 6344663067812082469, 16840582678788620208],
+            [924615033311830428, 6344663067812082469, 12712849352301301328],
             dtype=pl.UInt64,
         )
         result = df.hash_rows(*seeds)


### PR DESCRIPTION
This ensures we improve `as_u64` to not return an identity, but always spread the values by doing a wrapping multiply. 

This elides that multiply in hash values that are already properly randomized.