### PR TITLE
docs(python): add deprecation notices to the docs for expressions moved into the new `name` namespace

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -632,6 +632,9 @@ class Expr:
         """
         Rename the output of an expression by mapping a function over the root name.
 
+        .. deprecated:: 0.19.12
+            This method has been renamed to :func:`name.map`.
+
         Parameters
         ----------
         function
@@ -639,7 +642,7 @@ class Expr:
 
         See Also
         --------
-        alias
+        keep_name
         prefix
         suffix
 
@@ -674,6 +677,9 @@ class Expr:
     def prefix(self, prefix: str) -> Self:
         """
         Add a prefix to the root column name of the expression.
+
+        .. deprecated:: 0.19.12
+            This method has been renamed to :func:`name.prefix`.
 
         Parameters
         ----------
@@ -719,6 +725,9 @@ class Expr:
         """
         Add a suffix to the root column name of the expression.
 
+        .. deprecated:: 0.19.12
+            This method has been renamed to :func:`name.suffix`.
+
         Parameters
         ----------
         suffix
@@ -762,6 +771,9 @@ class Expr:
     def keep_name(self) -> Self:
         """
         Keep the original root name of the expression.
+
+        .. deprecated:: 0.19.12
+            This method has been renamed to :func:`name.keep`.
 
         Notes
         -----

--- a/py-polars/polars/expr/name.py
+++ b/py-polars/polars/expr/name.py
@@ -27,6 +27,7 @@ class ExprNameNameSpace:
         See Also
         --------
         alias
+        map
 
         Examples
         --------
@@ -76,7 +77,7 @@ class ExprNameNameSpace:
 
         See Also
         --------
-        alias
+        keep
         prefix
         suffix
 


### PR DESCRIPTION
Adds some versioned deprecation notices to the docs (with a link to the new location) and fixes some "see also" links.

<img width="1011" alt="Updated docs" src="https://github.com/pola-rs/polars/assets/2613171/dd5dc115-e857-41d1-8a61-abd28e0f6096">
