### PR TITLE
docs(python): Fix emphasis formatting in docstring

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6072,7 +6072,7 @@ class DataFrame:
 
         The UDF will receive each row as a tuple of values: `udf(row)`.
 
-        Implementing logic using a Python function is almost always _significantly_
+        Implementing logic using a Python function is almost always *significantly*
         slower and more memory intensive than implementing the same logic using
         the native expression API because:
 


### PR DESCRIPTION
I suspect that `_significantly_` is a typo and should be used with asterisks for emphasis, like `*significantly*`.