### PR TITLE
fix: incorrect super type for literals in nested binary exprs

### DIFF
--- a/crates/polars-plan/src/logical_plan/aexpr/schema.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/schema.rs
@@ -255,20 +255,6 @@ fn get_arithmetic_field(
             IDX_DTYPE
         },
         _ => {
-            match (left_ae, right_ae) {
-                (AExpr::Literal(_), AExpr::Literal(_)) => {},
-                (AExpr::Literal(_), _) => {
-                    // literal will be coerced to match right type
-                    let right_type = right_ae.get_type(schema, ctxt, arena)?;
-                    left_field.coerce(right_type);
-                    return Ok(left_field);
-                },
-                (_, AExpr::Literal(_)) => {
-                    // literal will be coerced to match right type
-                    return Ok(left_field);
-                },
-                _ => {},
-            }
             let right_type = right_ae.get_type(schema, ctxt, arena)?;
             try_get_supertype(&left_field.dtype, &right_type)?
         },

--- a/crates/polars-plan/src/logical_plan/aexpr/schema.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/schema.rs
@@ -264,7 +264,6 @@ fn get_arithmetic_field(
                     (AExpr::Literal(_), AExpr::Literal(_)) => {},
                     (AExpr::Literal(_), _) => {
                         // literal will be coerced to match right type
-                        let right_type = right_ae.get_type(schema, ctxt, arena)?;
                         left_field.coerce(right_type);
                         return Ok(left_field);
                     },

--- a/crates/polars-plan/src/logical_plan/aexpr/schema.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/schema.rs
@@ -257,9 +257,11 @@ fn get_arithmetic_field(
         _ => {
             let right_type = right_ae.get_type(schema, ctxt, arena)?;
 
-            // Avoid needlessly type casting integer columns during arithmetic
-            // with integer literals.
-            if left_field.dtype.is_integer() && right_type.is_integer() {
+            // Avoid needlessly type casting numeric columns during arithmetic
+            // with literals.
+            if (left_field.dtype.is_integer() && right_type.is_integer())
+                || (left_field.dtype.is_float() && right_type.is_float())
+            {
                 match (left_ae, right_ae) {
                     (AExpr::Literal(_), AExpr::Literal(_)) => {},
                     (AExpr::Literal(_), _) => {

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -1050,13 +1050,3 @@ def test_is_not_deprecated() -> None:
 
     expected = pl.DataFrame({"a": [False, True, False]})
     assert_frame_equal(result, expected)
-
-
-def test_literal_super_type_12227() -> None:
-    assert pl.select(x=1).select(y=pl.lit(0) + ((pl.col("x") > 0) * 0.1)).item() == 0.1
-    assert (
-        pl.select(
-            (pl.lit(0) + (pl.lit(0) == pl.lit(0)) * pl.lit(0.1)) + pl.lit(0)
-        ).item()
-        == 0.1
-    )

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -1050,3 +1050,13 @@ def test_is_not_deprecated() -> None:
 
     expected = pl.DataFrame({"a": [False, True, False]})
     assert_frame_equal(result, expected)
+
+
+def test_literal_super_type_12227() -> None:
+    assert pl.select(x=1).select(y=pl.lit(0) + ((pl.col("x") > 0) * 0.1)).item() == 0.1
+    assert (
+        pl.select(
+            (pl.lit(0) + (pl.lit(0) == pl.lit(0)) * pl.lit(0.1)) + pl.lit(0)
+        ).item()
+        == 0.1
+    )

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -545,3 +545,17 @@ def test_lit_iter_schema() -> None:
         "dates": [[date(1970, 1, 2), date(1970, 1, 3), date(1970, 1, 4)]],
     }
     assert result.to_dict(as_series=False) == expected
+
+
+def test_nested_binary_literal_super_type_12227() -> None:
+    # The `.alias` is important here to trigger the bug.
+    assert (
+        pl.select(x=1).select((pl.lit(0) + ((pl.col("x") > 0) * 0.1)).alias("x")).item()
+        == 0.1
+    )
+    assert (
+        pl.select(
+            (pl.lit(0) + (pl.lit(0) == pl.lit(0)) * pl.lit(0.1)) + pl.lit(0)
+        ).item()
+        == 0.1
+    )


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/12227.

There was a match block that unconditionally gave priority to the non-literal side for the case when one side was a literal and the other was not, which became incorrect when the type of the `Literal` was the super type.

This fix adds an additional check to make it so that the type of the `Literal` is ignored only when both sides are integer types.