### PR TITLE
test(python): Add test for `scan_csv` plus `slice`

### DIFF
--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -266,3 +266,10 @@ def test_csv_list_arg(io_files_path: Path) -> None:
     assert df.shape == (54, 4)
     assert df.row(-1) == ("seafood", 194, 12.0, 1)
     assert df.row(0) == ("vegetables", 45, 0.5, 2)
+
+
+# https://github.com/pola-rs/polars/issues/9887
+def test_scan_csv_slice_offset_zero(io_files_path: Path) -> None:
+    lf = pl.scan_csv(io_files_path / "small.csv")
+    result = lf.slice(0)
+    assert result.collect().height == 4


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/9887

@jonashaag if I understand correctly, the bug in the linked issue was fixed, but you want to add a test to make sure behavior stays correct.

I'm not sure this test will do it, as the bug apparently pops up in very specific circumstances. But it's better than nothing. Maybe in the future we will run the test suite on various platforms before releasing the wheel, then this test will be valuable.

