### PR TITLE
Update lib.rs

### DIFF
--- a/crates/polars-parquet/src/lib.rs
+++ b/crates/polars-parquet/src/lib.rs
@@ -1,4 +1,4 @@
 #![allow(clippy::len_without_is_empty)]
 pub mod arrow;
-pub use arrow::{read, write};
+pub use crate::arrow::{read, write};
 pub mod parquet;


### PR DESCRIPTION
Explicit use of crate:: to avoid 

error[E0659]: `arrow` is ambiguous
 --> /Users/olo/.cargo/git/checkouts/polars-.../4a58499/crates/polars-parquet/src/lib.rs:3:9
  |
3 | pub use arrow::{read, write};
  |         ^^^^^ ambiguous name

When compiling with project that already has arrow