### PR TITLE
docs(rust): Add feature flag for `list.eval`

### DIFF
--- a/docs/_build/API_REFERENCE_LINKS.yml
+++ b/docs/_build/API_REFERENCE_LINKS.yml
@@ -330,8 +330,11 @@ rust:
     link: https://pola-rs.github.io/polars/docs/rust/dev/polars_lazy/dsl/dt/struct.DateLikeNameSpace.html#method.day
     feature_flags: [temporal]
 
-  list.eval: https://pola-rs.github.io/polars/docs/rust/dev/polars_lazy/dsl/trait.ListNameSpaceExtension.html#method.eval
-
+  list.eval: 
+    name: list.eval
+    link: https://pola-rs.github.io/polars/docs/rust/dev/polars_lazy/dsl/trait.ListNameSpaceExtension.html#method.eval
+    feature_flags: [list_eval]
+    
   str.contains:
     name: str.contains
     link: https://pola-rs.github.io/polars/docs/rust/dev/polars_lazy/dsl/string/struct.StringNameSpace.html#method.contains


### PR DESCRIPTION
The document lacks feature flag `list.eval` for [eval (ListNameSpace)](https://pola-rs.github.io/polars/docs/rust/dev/polars/prelude/trait.ListNameSpaceExtension.html#method.eval) in Rust, which also makes the user guide incomplete, for example  https://pola-rs.github.io/polars/user-guide/expressions/lists/#row-wise-computations.