### PR TITLE
feat(rust,python): Add `name=` in `.write_avro` to set schema name

### DIFF
--- a/crates/polars-arrow/src/io/avro/write/schema.rs
+++ b/crates/polars-arrow/src/io/avro/write/schema.rs
@@ -7,7 +7,7 @@ use polars_error::{polars_bail, PolarsResult};
 use crate::datatypes::*;
 
 /// Converts a [`ArrowSchema`] to an Avro [`Record`].
-pub fn to_record(schema: &ArrowSchema) -> PolarsResult<Record> {
+pub fn to_record(schema: &ArrowSchema, name: &str) -> PolarsResult<Record> {
     let mut name_counter: i32 = 0;
     let fields = schema
         .fields
@@ -15,7 +15,7 @@ pub fn to_record(schema: &ArrowSchema) -> PolarsResult<Record> {
         .map(|f| field_to_field(f, &mut name_counter))
         .collect::<PolarsResult<_>>()?;
     Ok(Record {
-        name: "".to_string(),
+        name: name.to_string(),
         namespace: None,
         doc: None,
         aliases: vec![],

--- a/crates/polars-arrow/src/io/avro/write/schema.rs
+++ b/crates/polars-arrow/src/io/avro/write/schema.rs
@@ -7,7 +7,7 @@ use polars_error::{polars_bail, PolarsResult};
 use crate::datatypes::*;
 
 /// Converts a [`ArrowSchema`] to an Avro [`Record`].
-pub fn to_record(schema: &ArrowSchema, name: &str) -> PolarsResult<Record> {
+pub fn to_record(schema: &ArrowSchema, name: String) -> PolarsResult<Record> {
     let mut name_counter: i32 = 0;
     let fields = schema
         .fields
@@ -15,7 +15,7 @@ pub fn to_record(schema: &ArrowSchema, name: &str) -> PolarsResult<Record> {
         .map(|f| field_to_field(f, &mut name_counter))
         .collect::<PolarsResult<_>>()?;
     Ok(Record {
-        name: name.to_string(),
+        name,
         namespace: None,
         doc: None,
         aliases: vec![],

--- a/crates/polars-io/src/avro/write.rs
+++ b/crates/polars-io/src/avro/write.rs
@@ -29,6 +29,7 @@ use super::*;
 pub struct AvroWriter<W> {
     writer: W,
     compression: Option<AvroCompression>,
+    name: String,
 }
 
 impl<W> AvroWriter<W>
@@ -38,6 +39,11 @@ where
     /// Set the compression used. Defaults to None.
     pub fn with_compression(mut self, compression: Option<AvroCompression>) -> Self {
         self.compression = compression;
+        self
+    }
+
+    pub fn with_name(mut self, name: String) -> Self {
+        self.name = name;
         self
     }
 }
@@ -50,12 +56,13 @@ where
         Self {
             writer,
             compression: None,
+            name: "".to_string(),
         }
     }
 
     fn finish(&mut self, df: &mut DataFrame) -> PolarsResult<()> {
         let schema = df.schema().to_arrow();
-        let record = write::to_record(&schema)?;
+        let record = write::to_record(&schema, &self.name)?;
 
         let mut data = vec![];
         let mut compressed_block = avro_schema::file::CompressedBlock::default();

--- a/crates/polars-io/src/avro/write.rs
+++ b/crates/polars-io/src/avro/write.rs
@@ -62,7 +62,7 @@ where
 
     fn finish(&mut self, df: &mut DataFrame) -> PolarsResult<()> {
         let schema = df.schema().to_arrow();
-        let record = write::to_record(&schema, &self.name)?;
+        let record = write::to_record(&schema, self.name.clone())?;
 
         let mut data = vec![];
         let mut compressed_block = avro_schema::file::CompressedBlock::default();

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2611,6 +2611,7 @@ class DataFrame:
         self,
         file: BinaryIO | BytesIO | str | Path,
         compression: AvroCompression = "uncompressed",
+        name: str = "",
     ) -> None:
         """
         Write to Apache Avro file.
@@ -2621,6 +2622,8 @@ class DataFrame:
             File path or writeable file-like object to which the data will be written.
         compression : {'uncompressed', 'snappy', 'deflate'}
             Compression method. Defaults to "uncompressed".
+        name
+            Schema name. Defaults to empty string.
 
         Examples
         --------
@@ -2641,8 +2644,10 @@ class DataFrame:
             compression = "uncompressed"
         if isinstance(file, (str, Path)):
             file = normalize_filepath(file)
+        if name is None:
+            name = ""
 
-        self._df.write_avro(file, compression)
+        self._df.write_avro(file, compression, name)
 
     def write_excel(
         self,

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -380,12 +380,13 @@ impl PyDataFrame {
     }
 
     #[cfg(feature = "avro")]
-    #[pyo3(signature = (py_f, compression))]
+    #[pyo3(signature = (py_f, compression, name))]
     pub fn write_avro(
         &mut self,
         py: Python,
         py_f: PyObject,
         compression: Wrap<Option<AvroCompression>>,
+        name: String,
     ) -> PyResult<()> {
         use polars::io::avro::AvroWriter;
 
@@ -393,12 +394,14 @@ impl PyDataFrame {
             let f = std::fs::File::create(s).unwrap();
             AvroWriter::new(f)
                 .with_compression(compression.0)
+                .with_name(name)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         } else {
             let mut buf = get_file_like(py_f, true)?;
             AvroWriter::new(&mut buf)
                 .with_compression(compression.0)
+                .with_name(name)
                 .finish(&mut self.df)
                 .map_err(PyPolarsErr::from)?;
         }

--- a/py-polars/tests/unit/io/test_avro.py
+++ b/py-polars/tests/unit/io/test_avro.py
@@ -68,3 +68,24 @@ def test_select_projection() -> None:
 
     read_df = pl.read_avro(f, columns=[1, 2])
     assert_frame_equal(expected, read_df)
+
+
+def test_with_name() -> None:
+    df = pl.DataFrame({"a": [1]})
+    expected = pl.DataFrame(
+        {
+            "type": ["record"],
+            "name": ["my_schema_name"],
+            "fields": [[{"name": "a", "type": ["null", "long"]}]],
+        }
+    )
+
+    f = io.BytesIO()
+    df.write_avro(f, name="my_schema_name")
+
+    f.seek(0)
+    raw = f.read()
+
+    read_df = pl.read_json(raw[raw.find(b"{") : raw.rfind(b"}") + 1])
+
+    assert_frame_equal(expected, read_df)

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -437,7 +437,7 @@ def test_power() -> None:
     assert_series_equal(a**a, pl.Series([1.0, 4.0], dtype=Float64))
     assert_series_equal(b**b, pl.Series([None, 4.0], dtype=Float64))
     assert_series_equal(a**b, pl.Series([None, 4.0], dtype=Float64))
-    assert_series_equal(a**None, pl.Series([None] * len(a), dtype=Float64))
+    assert_series_equal(a ** None, pl.Series([None] * len(a), dtype=Float64))
     with pytest.raises(TypeError):
         c**2
     with pytest.raises(pl.ColumnNotFoundError):

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -437,7 +437,7 @@ def test_power() -> None:
     assert_series_equal(a**a, pl.Series([1.0, 4.0], dtype=Float64))
     assert_series_equal(b**b, pl.Series([None, 4.0], dtype=Float64))
     assert_series_equal(a**b, pl.Series([None, 4.0], dtype=Float64))
-    assert_series_equal(a ** None, pl.Series([None] * len(a), dtype=Float64))
+    assert_series_equal(a**None, pl.Series([None] * len(a), dtype=Float64))
     with pytest.raises(TypeError):
         c**2
     with pytest.raises(pl.ColumnNotFoundError):


### PR DESCRIPTION
Attempts to resolve #9446 

I've not used AVRO but apparently an empty schema name can cause issues with data ingestion downstream.

https://github.com/pola-rs/polars/blob/99472416b4b330768b72ed0fee792720434a5f7a/crates/polars-arrow/src/io/avro/write/schema.rs#L18

```python
import io
import polars as pl

f = io.BytesIO()
pl.DataFrame({"foo":[]}).write_avro(f)
f.seek(0)
f.read()[:60]

# b'Obj\x01\x02\x16avro.schema\x9a\x01{"type":"record","name":"","fields":[{"na'
                                                              ^^
```
With this patch:
```python
f = io.BytesIO()
pl.DataFrame({"foo":[]}).write_avro(f, name="my name")
f.seek(0)
f.read()[:60]

# b'Obj\x01\x02\x16avro.schema\xa8\x01{"type":"record","name":"my name","fields'
                                                              ^^^^^^^^^
```

The original issue just got a bump, so some additional discussion may be required.