### PR TITLE
ci(python): Clean up Python test workflow

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -30,11 +30,15 @@ defaults:
 
 jobs:
   ubuntu:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest]
         python-version: ['3.8', '3.11']
+        exclude:
+          - os: windows-latest
+            python-version: '3.8'
 
     steps:
       - uses: actions/checkout@v4
@@ -48,9 +52,11 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v1
 
       - name: Create virtual environment
+        env:
+          BIN: ${{ matrix.os == 'windows-latest' && 'Scripts' || 'bin' }}
         run: |
           python -m venv .venv
-          echo "$GITHUB_WORKSPACE/py-polars/.venv/bin" >> $GITHUB_PATH
+          echo "$GITHUB_WORKSPACE/py-polars/.venv/$BIN" >> $GITHUB_PATH
 
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
@@ -78,7 +84,7 @@ jobs:
         run: POLARS_FORCE_ASYNC=1 pytest -m "not benchmark and not docs" tests/unit/io/
 
       - name: Run doctests
-        if: github.ref_name != 'main'
+        if: github.ref_name != 'main' && matrix.os != 'windows-latest'
         run: |
           python tests/docs/run_doctest.py
           pytest tests/docs/test_user_guide.py -m docs
@@ -102,54 +108,3 @@ jobs:
             pip uninstall "$d" -y
             python -c 'import polars'
           done
-
-  windows:
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.11']
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Create virtual environment
-        run: |
-          python -m venv .venv
-          echo "$GITHUB_WORKSPACE/py-polars/.venv/Scripts" >> $GITHUB_PATH
-
-      - name: Install Python dependencies
-        run: pip install -r requirements-dev.txt
-
-      - name: Set up Rust
-        run: rustup show
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: py-polars
-          save-if: ${{ github.ref_name == 'main' }}
-
-      - name: Install Polars
-        run: |
-          source activate
-          maturin develop
-
-      - name: Run tests
-        if: github.ref_name != 'main'
-        run: pytest -n auto --dist loadgroup -m "not benchmark and not docs"
-
-      - name: Check import without optional dependencies
-        if: github.ref_name != 'main'
-        run: |
-          pip uninstall pandas -y
-          python -c 'import polars'
-          pip uninstall numpy -y
-          python -c 'import polars'
-          pip uninstall pyarrow -y
-          python -c 'import polars'

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -80,7 +80,7 @@ jobs:
         run: pytest --cov -n auto --dist loadgroup -m "not benchmark and not docs"
 
       - name: Run tests async reader tests
-        if: github.ref_name != 'main'
+        if: github.ref_name != 'main' && matrix.os != 'windows-latest'
         run: POLARS_FORCE_ASYNC=1 pytest -m "not benchmark and not docs" tests/unit/io/
 
       - name: Run doctests
@@ -90,7 +90,7 @@ jobs:
           pytest tests/docs/test_user_guide.py -m docs
 
       - name: Check import without optional dependencies
-        if: github.ref_name != 'main'
+        if: github.ref_name != 'main' && matrix.os != 'windows-latest'
         run: |
           declare -a deps=("pandas"
           "pyarrow"

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -26,6 +26,7 @@ env:
 defaults:
   run:
     working-directory: py-polars
+    shell: bash
 
 jobs:
   ubuntu:
@@ -117,6 +118,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Create virtual environment
+        run: |
+          python -m venv .venv
+          echo "$GITHUB_WORKSPACE/py-polars/.venv/Scripts" >> $GITHUB_PATH
+
       - name: Install Python dependencies
         run: pip install -r requirements-dev.txt
 
@@ -130,10 +136,9 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Install Polars
-        shell: bash
         run: |
-          maturin build
-          pip install ../target/wheels/polars-*.whl
+          source activate
+          maturin develop
 
       - name: Run tests
         if: github.ref_name != 'main'


### PR DESCRIPTION
We can use `maturin develop` rather than `maturin build` on Windows - this allows simplifying the workflow.

The async tests don't run on Windows - we should look into that.

The doctest / import tests are skipped, as it's not really necessary to test on Windows, and this saves some time on what is currently the slowest workflow out of the three.

_Workflows ran exceptionally slow here, probably due to the cache missing. If we Windows test remains slower with `maturin develop`, we can revert._