### PR TITLE
chore(rust): remove unwrap from group_by

### DIFF
--- a/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
@@ -63,7 +63,7 @@ where
         #[cfg(feature = "timezones")]
         Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
         _ => group_by_values_iter(period, time, closed_window, tu, None),
-    };
+    }?;
     rolling_apply_agg_window::<no_nulls::MinWindow<_>, _, _>(values, offset_iter, None)
 }
 
@@ -84,7 +84,7 @@ where
         #[cfg(feature = "timezones")]
         Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
         _ => group_by_values_iter(period, time, closed_window, tu, None),
-    };
+    }?;
     rolling_apply_agg_window::<no_nulls::MaxWindow<_>, _, _>(values, offset_iter, None)
 }
 
@@ -105,7 +105,7 @@ where
         #[cfg(feature = "timezones")]
         Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
         _ => group_by_values_iter(period, time, closed_window, tu, None),
-    };
+    }?;
     rolling_apply_agg_window::<no_nulls::SumWindow<_>, _, _>(values, offset_iter, None)
 }
 
@@ -126,7 +126,7 @@ where
         #[cfg(feature = "timezones")]
         Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
         _ => group_by_values_iter(period, time, closed_window, tu, None),
-    };
+    }?;
     rolling_apply_agg_window::<no_nulls::MeanWindow<_>, _, _>(values, offset_iter, None)
 }
 
@@ -147,7 +147,7 @@ where
         #[cfg(feature = "timezones")]
         Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
         _ => group_by_values_iter(period, time, closed_window, tu, None),
-    };
+    }?;
     rolling_apply_agg_window::<no_nulls::VarWindow<_>, _, _>(values, offset_iter, params)
 }
 
@@ -168,6 +168,6 @@ where
         #[cfg(feature = "timezones")]
         Some(tz) => group_by_values_iter(period, time, closed_window, tu, tz.parse::<Tz>().ok()),
         _ => group_by_values_iter(period, time, closed_window, tu, None),
-    };
+    }?;
     rolling_apply_agg_window::<no_nulls::QuantileWindow<_>, _, _>(values, offset_iter, params)
 }

--- a/crates/polars-time/src/windows/group_by.rs
+++ b/crates/polars-time/src/windows/group_by.rs
@@ -229,7 +229,7 @@ pub(crate) fn group_by_values_iter_lookbehind(
     tz: Option<Tz>,
     start_offset: usize,
     upper_bound: Option<usize>,
-) -> impl Iterator<Item = PolarsResult<(IdxSize, IdxSize)>> + TrustedLen + '_ {
+) -> PolarsResult<impl Iterator<Item = PolarsResult<(IdxSize, IdxSize)>> + TrustedLen + '_> {
     debug_assert!(offset.duration_ns() == period.duration_ns());
     debug_assert!(offset.negative);
     let add = match tu {
@@ -241,8 +241,8 @@ pub(crate) fn group_by_values_iter_lookbehind(
     let upper_bound = upper_bound.unwrap_or(time.len());
     // Use binary search to find the initial start as that is behind.
     let mut start = if let Some(&t) = time.get(start_offset) {
-        let lower = add(&offset, t, tz.as_ref()).unwrap();
-        let upper = add(&period, lower, tz.as_ref()).unwrap();
+        let lower = add(&offset, t, tz.as_ref())?;
+        let upper = add(&period, lower, tz.as_ref())?;
         let b = Bounds::new(lower, upper);
         let slice = &time[..start_offset];
         slice.partition_point(|v| !b.is_member(*v, closed_window))
@@ -250,7 +250,7 @@ pub(crate) fn group_by_values_iter_lookbehind(
         0
     };
     let mut end = start;
-    time[start_offset..upper_bound]
+    Ok(time[start_offset..upper_bound]
         .iter()
         .enumerate()
         .map(move |(mut i, t)| {
@@ -285,7 +285,7 @@ pub(crate) fn group_by_values_iter_lookbehind(
             let offset = start as IdxSize;
 
             Ok((offset, len as IdxSize))
-        })
+        }))
 }
 
 // this one is correct for all lookbehind/lookaheads, but is slower
@@ -446,7 +446,7 @@ pub(crate) fn group_by_values_iter(
     closed_window: ClosedWindow,
     tu: TimeUnit,
     tz: Option<Tz>,
-) -> impl Iterator<Item = PolarsResult<(IdxSize, IdxSize)>> + TrustedLen + '_ {
+) -> PolarsResult<impl Iterator<Item = PolarsResult<(IdxSize, IdxSize)>> + TrustedLen + '_> {
     let mut offset = period;
     offset.negative = true;
     // t is at the right endpoint of the window
@@ -509,7 +509,7 @@ pub fn group_by_values(
                             tz,
                             base_offset,
                             Some(upper_bound),
-                        );
+                        )?;
                         iter.map(|result| result.map(|(offset, len)| [offset, len]))
                             .collect::<PolarsResult<Vec<_>>>()
                     })

--- a/crates/polars-time/src/windows/test.rs
+++ b/crates/polars-time/src/windows/test.rs
@@ -764,6 +764,7 @@ fn test_rolling_lookback() {
             0,
             None,
         )
+        .unwrap()
         .collect::<PolarsResult<Vec<_>>>()
         .unwrap();
         let g1 = group_by_values_iter_partial_lookbehind(


### PR DESCRIPTION
Noticed this while addressing https://github.com/pola-rs/polars/issues/12218 - `add(&period, lower, tz.as_ref()).unwrap()` may indeed error