### PR TITLE
docs(python): clarify contains selector

### DIFF
--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -684,7 +684,7 @@ def categorical() -> SelectorType:
 
 def contains(substring: str | Collection[str]) -> SelectorType:
     """
-    Select columns that contain the given literal substring(s).
+    Select columns whose names contain the given literal substring(s).
 
     Parameters
     ----------


### PR DESCRIPTION
We should be very explicit that it does not select based on whether the data contains anything.