### PR TITLE
fix(python, rust): don't move right endpoint of windows in rolling in default `offset==-period` case

### DIFF
--- a/crates/polars-time/src/windows/group_by.rs
+++ b/crates/polars-time/src/windows/group_by.rs
@@ -242,7 +242,7 @@ pub(crate) fn group_by_values_iter_lookbehind(
     // Use binary search to find the initial start as that is behind.
     let mut start = if let Some(&t) = time.get(start_offset) {
         let lower = add(&offset, t, tz.as_ref()).unwrap();
-        let upper = add(&period, lower, tz.as_ref()).unwrap();
+        let upper = t; // period == -offset, so `t + offset + period` is equal to `t`
         let b = Bounds::new(lower, upper);
         let slice = &time[..start_offset];
         slice.partition_point(|v| !b.is_member(*v, closed_window))
@@ -256,7 +256,7 @@ pub(crate) fn group_by_values_iter_lookbehind(
         .map(move |(mut i, t)| {
             i += start_offset;
             let lower = add(&offset, *t, tz.as_ref())?;
-            let upper = add(&period, lower, tz.as_ref())?;
+            let upper = *t; // period == -offset, so `t + offset + period` is equal to `t`
 
             let b = Bounds::new(lower, upper);
 

--- a/crates/polars-time/src/windows/group_by.rs
+++ b/crates/polars-time/src/windows/group_by.rs
@@ -242,9 +242,9 @@ pub(crate) fn group_by_values_iter_lookbehind(
     // Use binary search to find the initial start as that is behind.
     let mut start = if let Some(&t) = time.get(start_offset) {
         let lower = add(&offset, t, tz.as_ref())?;
-        // period == -offset, so `t + offset + period` is equal to `t` and `upper`
-        // is trivially equal to `t` itself. Using the trivial calculation, instead
-        // of `upper = lower + period`, avoids issues around
+        // We have `period == -offset`, so `t + offset + period` is equal to `t`,
+        // and `upper` is trivially equal to `t` itself. Using the trivial calculation,
+        // instead of `upper = lower + period`, avoids issues around
         // `t - 1mo_saturating + 1mo_saturating` not round-tripping.
         let upper = t;
         let b = Bounds::new(lower, upper);

--- a/crates/polars-time/src/windows/group_by.rs
+++ b/crates/polars-time/src/windows/group_by.rs
@@ -243,7 +243,7 @@ pub(crate) fn group_by_values_iter_lookbehind(
     let mut start = if let Some(&t) = time.get(start_offset) {
         let lower = add(&offset, t, tz.as_ref())?;
         // period == -offset, so `t + offset + period` is equal to `t` and `upper`
-        // is trivially equal to `t` itself. Using the trivial calculating, instead
+        // is trivially equal to `t` itself. Using the trivial calculation, instead
         // of `upper = lower + period`, avoids issues around
         // `t - 1mo_saturating + 1mo_saturating` not round-tripping.
         let upper = t;

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5172,6 +5172,13 @@ class DataFrame:
             * ...
             * (t_n - period, t_n]
 
+        whereas if you pass a non-default `offset`, then the windows will be
+
+            * (t_0 + offset, t_0 + offset + period]
+            * (t_1 + offset, t_1 + offset + period]
+            * ...
+            * (t_n + offset, t_n + offset + period]
+
         The `period` and `offset` arguments are created either from a timedelta, or
         by using the following string language:
 

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3284,6 +3284,13 @@ class Expr:
             * ...
             * (t_n - period, t_n]
 
+        whereas if you pass a non-default `offset`, then the windows will be
+
+            * (t_0 + offset, t_0 + offset + period]
+            * (t_1 + offset, t_1 + offset + period]
+            * ...
+            * (t_n + offset, t_n + offset + period]
+
         The `period` and `offset` arguments are created either from a timedelta, or
         by using the following string language:
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2993,6 +2993,13 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             * ...
             * (t_n - period, t_n]
 
+        whereas if you pass a non-default `offset`, then the windows will be
+
+            * (t_0 + offset, t_0 + offset + period]
+            * (t_1 + offset, t_1 + offset + period]
+            * ...
+            * (t_n + offset, t_n + offset + period]
+
         The `period` and `offset` arguments are created either from a timedelta, or
         by using the following string language:
 


### PR DESCRIPTION
closes #12218