### PR TITLE
docs: Remove recommended setting from IDE docs

### DIFF
--- a/docs/development/contributing/ide.md
+++ b/docs/development/contributing/ide.md
@@ -16,7 +16,6 @@ For it to work well for the Polars code base, add the following settings to your
 ```json
 {
     "rust-analyzer.cargo.features": "all",
-    "rust-analyzer.linkedProjects": ["py-polars/Cargo.toml"],
 }
 ```
 


### PR DESCRIPTION
Setting this is no longer required with `py-polars` part of the workspace.