### PR TITLE
feat: Add `struct.prefix` and `struct.suffix`

### DIFF
--- a/crates/polars-plan/src/dsl/struct_.rs
+++ b/crates/polars-plan/src/dsl/struct_.rs
@@ -28,11 +28,27 @@ impl StructNameSpace {
             })
     }
 
+    /// Add prefix to the field names of the [`StructChunked`].
+    pub fn prefix(self, prefix: &str) -> Expr {
+        self.0
+            .map_private(FunctionExpr::StructExpr(StructFunction::Prefix(Arc::from(
+                prefix,
+            ))))
+    }
+
     /// Rename the fields of the [`StructChunked`].
     pub fn rename_fields(self, names: Vec<String>) -> Expr {
         self.0
             .map_private(FunctionExpr::StructExpr(StructFunction::RenameFields(
                 Arc::from(names),
             )))
+    }
+
+    /// Add suffix to the field names of the [`StructChunked`].
+    pub fn suffix(self, suffix: &str) -> Expr {
+        self.0
+            .map_private(FunctionExpr::StructExpr(StructFunction::Suffix(Arc::from(
+                suffix,
+            ))))
     }
 }

--- a/py-polars/docs/source/reference/expressions/struct.rst
+++ b/py-polars/docs/source/reference/expressions/struct.rst
@@ -10,4 +10,6 @@ The following methods are available under the `expr.struct` attribute.
    :template: autosummary/accessor_method.rst
 
     Expr.struct.field
+    Expr.struct.prefix
     Expr.struct.rename_fields
+    Expr.struct.suffix

--- a/py-polars/docs/source/reference/series/struct.rst
+++ b/py-polars/docs/source/reference/series/struct.rst
@@ -10,7 +10,9 @@ The following methods are available under the `Series.struct` attribute.
    :template: autosummary/accessor_method.rst
 
     Series.struct.field
+    Series.struct.prefix
     Series.struct.rename_fields
+    Series.struct.suffix
     Series.struct.unnest
 
 .. autosummary::

--- a/py-polars/polars/expr/struct.py
+++ b/py-polars/polars/expr/struct.py
@@ -86,6 +86,39 @@ class ExprStructNameSpace:
         """
         return wrap_expr(self._pyexpr.struct_field_by_name(name))
 
+    def prefix(self, prefix: str) -> Expr:
+        """
+        Add a prefix to the fields of the struct.
+
+        Parameters
+        ----------
+        prefix
+            Prefix to add to the struct's fields.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [{"x": 1, "y": 10}, {"x": 2, "y": 20}],
+        ...         "b": [{"x": 3, "y": 30}, {"x": 4, "y": 40}],
+        ...     }
+        ... )
+        >>> df.with_columns(
+        ...     pl.col("a").struct.prefix("a_"),
+        ...     pl.col("b").struct.prefix("b_"),
+        ... ).unnest("a", "b")
+        shape: (2, 4)
+        ┌─────┬─────┬─────┬─────┐
+        │ a_x ┆ a_y ┆ b_x ┆ b_y │
+        │ --- ┆ --- ┆ --- ┆ --- │
+        │ i64 ┆ i64 ┆ i64 ┆ i64 │
+        ╞═════╪═════╪═════╪═════╡
+        │ 1   ┆ 10  ┆ 3   ┆ 30  │
+        │ 2   ┆ 20  ┆ 4   ┆ 40  │
+        └─────┴─────┴─────┴─────┘
+        """
+        return wrap_expr(self._pyexpr.struct_prefix(prefix))
+
     def rename_fields(self, names: Sequence[str]) -> Expr:
         """
         Rename the fields of the struct.
@@ -150,3 +183,36 @@ class ExprStructNameSpace:
 
         """
         return wrap_expr(self._pyexpr.struct_rename_fields(names))
+
+    def suffix(self, suffix: str) -> Expr:
+        """
+        Add a suffix to the fields of the struct.
+
+        Parameters
+        ----------
+        suffix
+            Suffix to add to the struct's fields.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [{"x": 1, "y": 10}, {"x": 2, "y": 20}],
+        ...         "b": [{"x": 3, "y": 30}, {"x": 4, "y": 40}],
+        ...     }
+        ... )
+        >>> df.with_columns(
+        ...     pl.col("a").struct.suffix("_a"),
+        ...     pl.col("b").struct.suffix("_b"),
+        ... ).unnest("a", "b")
+        shape: (2, 4)
+        ┌─────┬─────┬─────┬─────┐
+        │ x_a ┆ y_a ┆ x_b ┆ y_b │
+        │ --- ┆ --- ┆ --- ┆ --- │
+        │ i64 ┆ i64 ┆ i64 ┆ i64 │
+        ╞═════╪═════╪═════╪═════╡
+        │ 1   ┆ 10  ┆ 3   ┆ 30  │
+        │ 2   ┆ 20  ┆ 4   ┆ 40  │
+        └─────┴─────┴─────┴─────┘
+        """
+        return wrap_expr(self._pyexpr.struct_suffix(suffix))

--- a/py-polars/polars/series/struct.py
+++ b/py-polars/polars/series/struct.py
@@ -54,6 +54,16 @@ class StructNameSpace:
 
         """
 
+    def prefix(self, prefix: str) -> Series:
+        """
+        Add a prefix to the field names of the struct.
+
+        Parameters
+        ----------
+        prefix
+            Prefix to add to the field names
+        """
+
     def rename_fields(self, names: Sequence[str]) -> Series:
         """
         Rename the fields of the struct.
@@ -62,7 +72,6 @@ class StructNameSpace:
         ----------
         names
             New names in the order of the struct's fields
-
         """
 
     @property
@@ -71,6 +80,16 @@ class StructNameSpace:
         if getattr(self, "_s", None) is None:
             return {}
         return OrderedDict(self._s.dtype().to_schema())
+
+    def suffix(self, suffix: str) -> Series:
+        """
+        Add a suffix to the field names  of the struct.
+
+        Parameters
+        ----------
+        suffix
+            Suffix to add to the field names.
+        """
 
     def unnest(self) -> DataFrame:
         """

--- a/py-polars/src/expr/struct.rs
+++ b/py-polars/src/expr/struct.rs
@@ -12,7 +12,15 @@ impl PyExpr {
         self.inner.clone().struct_().field_by_name(name).into()
     }
 
+    fn struct_prefix(&self, prefix: &str) -> Self {
+        self.inner.clone().struct_().prefix(prefix).into()
+    }
+
     fn struct_rename_fields(&self, names: Vec<String>) -> Self {
         self.inner.clone().struct_().rename_fields(names).into()
+    }
+
+    fn struct_suffix(&self, suffix: &str) -> Self {
+        self.inner.clone().struct_().suffix(suffix).into()
     }
 }

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -889,3 +889,49 @@ def test_struct_null_count_10130() -> None:
 
     s = pl.Series([{"a": None}])
     assert s.null_count() == 1
+
+
+def test_struct_prefix_suffix() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [
+                {"x": 1, "y": 10},
+                {"x": 2, "y": 20},
+            ],
+            "b": [
+                {"x": 3, "y": 30},
+                {"x": 4, "y": 40},
+            ],
+        }
+    )
+    expected = pl.DataFrame(
+        {
+            "a_x": [1, 2],
+            "a_y": [10, 20],
+            "b_x": [3, 4],
+            "b_y": [30, 40],
+        }
+    )
+
+    result = df.with_columns(
+        pl.col("a").struct.prefix("a_"),
+        pl.col("b").struct.prefix("b_"),
+    ).unnest("a", "b")
+
+    assert_frame_equal(expected, result)
+
+    expected = pl.DataFrame(
+        {
+            "x_a": [1, 2],
+            "y_a": [10, 20],
+            "x_b": [3, 4],
+            "y_b": [30, 40],
+        }
+    )
+
+    result = df.with_columns(
+        pl.col("a").struct.suffix("_a"),
+        pl.col("b").struct.suffix("_b"),
+    ).unnest("a", "b")
+
+    assert_frame_equal(expected, result)

--- a/py-polars/tests/unit/namespaces/test_struct.py
+++ b/py-polars/tests/unit/namespaces/test_struct.py
@@ -28,3 +28,15 @@ def test_rename_fields() -> None:
         "a",
         "b",
     ]
+
+
+def test_struct_prefix_suffix() -> None:
+    df = pl.DataFrame({"int": [1], "str": ["a"], "bool": [True], "list": [[3]]})
+
+    expected = pl.DataFrame({f"p_{col.name}": col for col in df})
+
+    assert_frame_equal(df.to_struct("").struct.prefix("p_").struct.unnest(), expected)
+
+    expected = pl.DataFrame({f"{col.name}_s": col for col in df})
+
+    assert_frame_equal(df.to_struct("").struct.suffix("_s").struct.unnest(), expected)


### PR DESCRIPTION
Closes #5169 as discussed in https://github.com/pola-rs/polars/issues/10919#issuecomment-1706776422

```python
df = pl.DataFrame({
    "x": [{"a": 1, "b": 2}, {"a": 3, "b": 4}],
    "y": [{"a": 5, "b": 6}, {"a": 7, "b": 8}]
})

df.with_columns(
    pl.col("x").struct.prefix("x."),
    pl.col("y").struct.suffix(".y"),
).unnest("x", "y")

# shape: (2, 4)
# ┌─────┬─────┬─────┬─────┐
# │ x.a ┆ x.b ┆ a.y ┆ b.y │
# │ --- ┆ --- ┆ --- ┆ --- │
# │ i64 ┆ i64 ┆ i64 ┆ i64 │
# ╞═════╪═════╪═════╪═════╡
# │ 1   ┆ 2   ┆ 5   ┆ 6   │
# │ 3   ┆ 4   ┆ 7   ┆ 8   │
# └─────┴─────┴─────┴─────┘
```