### PR TITLE
chore: ensure we git-ignore ALL `.venv` dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ polars/vendor
 .hypothesis/
 .mypy_cache/
 .pytest_cache/
-.venv/
+.venv*
 __pycache__/
 .coverage
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,7 @@ polars/vendor
 .hypothesis/
 .mypy_cache/
 .pytest_cache/
-.venv*
+.venv*/
 __pycache__/
 .coverage
 


### PR DESCRIPTION
Almost accidentally committed 26,000 files from my `.venv_312` dir just now... 
Let's not let that one happen 🤣