### PR TITLE
chore(rust): Run `clippy` on all targets

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -42,7 +42,7 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Run cargo clippy with all features enabled
-        run: cargo clippy --workspace --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
   # Default feature set should compile on the stable toolchain
   clippy-stable:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ build-python: .venv  ## Compile and install Python Polars for development
 
 .PHONY: clippy
 clippy:  ## Run clippy with all features
-	cargo clippy --workspace --all-features --locked -- -D warnings
+	cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
 
 .PHONY: fmt
 fmt:  ## Run rustfmt and dprint

--- a/crates/polars-arrow/src/io/ipc/read/common.rs
+++ b/crates/polars-arrow/src/io/ipc/read/common.rs
@@ -291,29 +291,6 @@ pub fn read_dictionary<R: Read + Seek>(
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn project_iter() {
-        let iter = 1..6;
-        let iter = ProjectionIter::new(&[0, 2, 4], iter);
-        let result: Vec<_> = iter.collect();
-        use ProjectionResult::*;
-        assert_eq!(
-            result,
-            vec![
-                Selected(1),
-                NotSelected(2),
-                Selected(3),
-                NotSelected(4),
-                Selected(5)
-            ]
-        )
-    }
-}
-
 pub fn prepare_projection(
     fields: &[Field],
     mut projection: Vec<usize>,
@@ -360,4 +337,27 @@ pub fn apply_projection(
         .for_each(|(old, new)| new_arrays[*new] = arrays[*old].clone());
 
     Chunk::new(new_arrays)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn project_iter() {
+        let iter = 1..6;
+        let iter = ProjectionIter::new(&[0, 2, 4], iter);
+        let result: Vec<_> = iter.collect();
+        use ProjectionResult::*;
+        assert_eq!(
+            result,
+            vec![
+                Selected(1),
+                NotSelected(2),
+                Selected(3),
+                NotSelected(4),
+                Selected(5)
+            ]
+        )
+    }
 }

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -892,122 +892,6 @@ fn struct_to_avs_static(idx: usize, arr: &StructArray, fields: &[Field]) -> Vec<
     avs
 }
 
-#[cfg(test)]
-mod test {
-    #[cfg(feature = "dtype-categorical")]
-    use super::*;
-
-    #[test]
-    #[cfg(feature = "dtype-categorical")]
-    fn test_arrow_dtypes_to_polars() {
-        let dtypes = [
-            (
-                ArrowDataType::Duration(ArrowTimeUnit::Nanosecond),
-                DataType::Duration(TimeUnit::Nanoseconds),
-            ),
-            (
-                ArrowDataType::Duration(ArrowTimeUnit::Millisecond),
-                DataType::Duration(TimeUnit::Milliseconds),
-            ),
-            (
-                ArrowDataType::Date64,
-                DataType::Datetime(TimeUnit::Milliseconds, None),
-            ),
-            (
-                ArrowDataType::Timestamp(ArrowTimeUnit::Nanosecond, None),
-                DataType::Datetime(TimeUnit::Nanoseconds, None),
-            ),
-            (
-                ArrowDataType::Timestamp(ArrowTimeUnit::Microsecond, None),
-                DataType::Datetime(TimeUnit::Microseconds, None),
-            ),
-            (
-                ArrowDataType::Timestamp(ArrowTimeUnit::Millisecond, None),
-                DataType::Datetime(TimeUnit::Milliseconds, None),
-            ),
-            (
-                ArrowDataType::Timestamp(ArrowTimeUnit::Second, None),
-                DataType::Datetime(TimeUnit::Milliseconds, None),
-            ),
-            (
-                ArrowDataType::Timestamp(ArrowTimeUnit::Second, Some("".to_string())),
-                DataType::Datetime(TimeUnit::Milliseconds, Some("".to_string())),
-            ),
-            (ArrowDataType::LargeUtf8, DataType::Utf8),
-            (ArrowDataType::Utf8, DataType::Utf8),
-            (ArrowDataType::LargeBinary, DataType::Binary),
-            (ArrowDataType::Binary, DataType::Binary),
-            (
-                ArrowDataType::Time64(ArrowTimeUnit::Nanosecond),
-                DataType::Time,
-            ),
-            (
-                ArrowDataType::Time64(ArrowTimeUnit::Millisecond),
-                DataType::Time,
-            ),
-            (
-                ArrowDataType::Time64(ArrowTimeUnit::Microsecond),
-                DataType::Time,
-            ),
-            (ArrowDataType::Time64(ArrowTimeUnit::Second), DataType::Time),
-            (
-                ArrowDataType::Time32(ArrowTimeUnit::Nanosecond),
-                DataType::Time,
-            ),
-            (
-                ArrowDataType::Time32(ArrowTimeUnit::Millisecond),
-                DataType::Time,
-            ),
-            (
-                ArrowDataType::Time32(ArrowTimeUnit::Microsecond),
-                DataType::Time,
-            ),
-            (ArrowDataType::Time32(ArrowTimeUnit::Second), DataType::Time),
-            (
-                ArrowDataType::List(Box::new(ArrowField::new(
-                    "item",
-                    ArrowDataType::Float64,
-                    true,
-                ))),
-                DataType::List(DataType::Float64.into()),
-            ),
-            (
-                ArrowDataType::LargeList(Box::new(ArrowField::new(
-                    "item",
-                    ArrowDataType::Float64,
-                    true,
-                ))),
-                DataType::List(DataType::Float64.into()),
-            ),
-            (
-                ArrowDataType::Dictionary(IntegerType::UInt32, ArrowDataType::Utf8.into(), false),
-                DataType::Categorical(None),
-            ),
-            (
-                ArrowDataType::Dictionary(
-                    IntegerType::UInt32,
-                    ArrowDataType::LargeUtf8.into(),
-                    false,
-                ),
-                DataType::Categorical(None),
-            ),
-            (
-                ArrowDataType::Dictionary(
-                    IntegerType::UInt64,
-                    ArrowDataType::LargeUtf8.into(),
-                    false,
-                ),
-                DataType::Categorical(None),
-            ),
-        ];
-
-        for (dt_a, dt_p) in dtypes {
-            let dt: DataType = (&dt_a).into();
-
-            assert_eq!(dt_p, dt);
-        }
-    }
-}
 pub trait GetAnyValue {
     /// # Safety
     ///
@@ -1181,6 +1065,123 @@ impl<K: NumericNative> From<K> for AnyValue<'_> {
                 // not supported by polars
                 _ => unreachable!(),
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "dtype-categorical")]
+    use super::*;
+
+    #[test]
+    #[cfg(feature = "dtype-categorical")]
+    fn test_arrow_dtypes_to_polars() {
+        let dtypes = [
+            (
+                ArrowDataType::Duration(ArrowTimeUnit::Nanosecond),
+                DataType::Duration(TimeUnit::Nanoseconds),
+            ),
+            (
+                ArrowDataType::Duration(ArrowTimeUnit::Millisecond),
+                DataType::Duration(TimeUnit::Milliseconds),
+            ),
+            (
+                ArrowDataType::Date64,
+                DataType::Datetime(TimeUnit::Milliseconds, None),
+            ),
+            (
+                ArrowDataType::Timestamp(ArrowTimeUnit::Nanosecond, None),
+                DataType::Datetime(TimeUnit::Nanoseconds, None),
+            ),
+            (
+                ArrowDataType::Timestamp(ArrowTimeUnit::Microsecond, None),
+                DataType::Datetime(TimeUnit::Microseconds, None),
+            ),
+            (
+                ArrowDataType::Timestamp(ArrowTimeUnit::Millisecond, None),
+                DataType::Datetime(TimeUnit::Milliseconds, None),
+            ),
+            (
+                ArrowDataType::Timestamp(ArrowTimeUnit::Second, None),
+                DataType::Datetime(TimeUnit::Milliseconds, None),
+            ),
+            (
+                ArrowDataType::Timestamp(ArrowTimeUnit::Second, Some("".to_string())),
+                DataType::Datetime(TimeUnit::Milliseconds, Some("".to_string())),
+            ),
+            (ArrowDataType::LargeUtf8, DataType::Utf8),
+            (ArrowDataType::Utf8, DataType::Utf8),
+            (ArrowDataType::LargeBinary, DataType::Binary),
+            (ArrowDataType::Binary, DataType::Binary),
+            (
+                ArrowDataType::Time64(ArrowTimeUnit::Nanosecond),
+                DataType::Time,
+            ),
+            (
+                ArrowDataType::Time64(ArrowTimeUnit::Millisecond),
+                DataType::Time,
+            ),
+            (
+                ArrowDataType::Time64(ArrowTimeUnit::Microsecond),
+                DataType::Time,
+            ),
+            (ArrowDataType::Time64(ArrowTimeUnit::Second), DataType::Time),
+            (
+                ArrowDataType::Time32(ArrowTimeUnit::Nanosecond),
+                DataType::Time,
+            ),
+            (
+                ArrowDataType::Time32(ArrowTimeUnit::Millisecond),
+                DataType::Time,
+            ),
+            (
+                ArrowDataType::Time32(ArrowTimeUnit::Microsecond),
+                DataType::Time,
+            ),
+            (ArrowDataType::Time32(ArrowTimeUnit::Second), DataType::Time),
+            (
+                ArrowDataType::List(Box::new(ArrowField::new(
+                    "item",
+                    ArrowDataType::Float64,
+                    true,
+                ))),
+                DataType::List(DataType::Float64.into()),
+            ),
+            (
+                ArrowDataType::LargeList(Box::new(ArrowField::new(
+                    "item",
+                    ArrowDataType::Float64,
+                    true,
+                ))),
+                DataType::List(DataType::Float64.into()),
+            ),
+            (
+                ArrowDataType::Dictionary(IntegerType::UInt32, ArrowDataType::Utf8.into(), false),
+                DataType::Categorical(None),
+            ),
+            (
+                ArrowDataType::Dictionary(
+                    IntegerType::UInt32,
+                    ArrowDataType::LargeUtf8.into(),
+                    false,
+                ),
+                DataType::Categorical(None),
+            ),
+            (
+                ArrowDataType::Dictionary(
+                    IntegerType::UInt64,
+                    ArrowDataType::LargeUtf8.into(),
+                    false,
+                ),
+                DataType::Categorical(None),
+            ),
+        ];
+
+        for (dt_a, dt_p) in dtypes {
+            let dt: DataType = (&dt_a).into();
+
+            assert_eq!(dt_p, dt);
         }
     }
 }

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1139,7 +1139,7 @@ fn test_fill_forward() -> PolarsResult<()> {
         .lazy()
         .select([col("b")
             .forward_fill(None)
-            .over_with_options([col("a")], WindowMapping::Join.into())])
+            .over_with_options([col("a")], WindowMapping::Join)])
         .collect()?;
     let agg = out.column("b")?.list()?;
 
@@ -1299,7 +1299,7 @@ fn test_filter_after_shift_in_groups() -> PolarsResult<()> {
             col("B")
                 .shift(lit(1))
                 .filter(col("B").shift(lit(1)).gt(lit(4)))
-                .over_with_options([col("fruits")], WindowMapping::Join.into())
+                .over_with_options([col("fruits")], WindowMapping::Join)
                 .alias("filtered"),
         ])
         .collect()?;
@@ -1660,7 +1660,7 @@ fn test_single_ranked_group() -> PolarsResult<()> {
                 },
                 None,
             )
-            .over_with_options([col("group")], WindowMapping::Join.into())])
+            .over_with_options([col("group")], WindowMapping::Join)])
         .collect()?;
 
     let out = out.column("value")?.explode()?;

--- a/crates/polars-ops/src/chunked_array/gather_skip_nulls.rs
+++ b/crates/polars-ops/src/chunked_array/gather_skip_nulls.rs
@@ -185,7 +185,7 @@ mod test {
     fn test_equal_ref(ca: &UInt32Chunked, idx_ca: &IdxCa) {
         let ref_ca: Vec<Option<u32>> = ca.into_iter().collect();
         let ref_idx_ca: Vec<Option<usize>> =
-            (&idx_ca).into_iter().map(|i| Some(i? as usize)).collect();
+            idx_ca.into_iter().map(|i| Some(i? as usize)).collect();
         let gather = ca.gather_skip_nulls(idx_ca).ok();
         let ref_gather = ref_gather_nulls(ref_ca, ref_idx_ca);
         assert_eq!(gather.map(|ca| ca.into_iter().collect()), ref_gather);
@@ -212,12 +212,12 @@ mod test {
             let num_idx_chunks = rng.gen_range(1..10);
             let idx_chunks: Vec<_> = (0..num_idx_chunks).map(|_| random_vec(&mut rng, 0..num_nonnull_elems as IdxSize, 0..200)).collect();
             let null_idx_chunks: Vec<_> = idx_chunks.iter().map(|c| random_filter(&mut rng, c, 0.7..1.0)).collect();
-            
+
             let nonnull_ca = UInt32Chunked::from_chunk_iter("", elem_chunks.iter().cloned().map(|v| v.into_iter().collect_arr()));
             let ca = UInt32Chunked::from_chunk_iter("", null_elem_chunks.iter().cloned().map(|v| v.into_iter().collect_arr()));
             let nonnull_idx_ca = IdxCa::from_chunk_iter("", idx_chunks.iter().cloned().map(|v| v.into_iter().collect_arr()));
             let idx_ca = IdxCa::from_chunk_iter("", null_idx_chunks.iter().cloned().map(|v| v.into_iter().collect_arr()));
-            
+
             gather_skip_nulls_check(&ca, &idx_ca);
             gather_skip_nulls_check(&ca, &nonnull_idx_ca);
             gather_skip_nulls_check(&nonnull_ca, &idx_ca);

--- a/crates/polars-ops/src/chunked_array/strings/concat.rs
+++ b/crates/polars-ops/src/chunked_array/strings/concat.rs
@@ -132,7 +132,7 @@ mod test {
     fn test_str_concat() {
         let ca = Int32Chunked::new("foo", &[Some(1), None, Some(3)]);
         let ca_str = ca.cast(&DataType::Utf8).unwrap();
-        let out = str_concat(&ca_str.utf8().unwrap(), "-", true);
+        let out = str_concat(ca_str.utf8().unwrap(), "-", true);
 
         let out = out.get(0);
         assert_eq!(out, Some("1-3"));

--- a/crates/polars-ops/src/frame/join/asof/default.rs
+++ b/crates/polars-ops/src/frame/join/asof/default.rs
@@ -152,8 +152,8 @@ mod test {
 
     #[test]
     fn test_asof_backward() {
-        let a = PrimitiveArray::from_slice(&[-1, 2, 3, 3, 3, 4]);
-        let b = PrimitiveArray::from_slice(&[1, 2, 3, 3]);
+        let a = PrimitiveArray::from_slice([-1, 2, 3, 3, 3, 4]);
+        let b = PrimitiveArray::from_slice([1, 2, 3, 3]);
 
         let tuples = join_asof_backward::<Int32Type, _>(&a, &b, |_, _| true);
         assert_eq!(tuples.len(), a.len());
@@ -162,23 +162,23 @@ mod test {
             &[None, Some(1), Some(3), Some(3), Some(3), Some(3)]
         );
 
-        let b = PrimitiveArray::from_slice(&[1, 2, 4, 5]);
+        let b = PrimitiveArray::from_slice([1, 2, 4, 5]);
         let tuples = join_asof_backward::<Int32Type, _>(&a, &b, |_, _| true);
         assert_eq!(
             tuples.to_vec(),
             &[None, Some(1), Some(1), Some(1), Some(1), Some(2)]
         );
 
-        let a = PrimitiveArray::from_slice(&[2, 4, 4, 4]);
-        let b = PrimitiveArray::from_slice(&[1, 2, 3, 3]);
+        let a = PrimitiveArray::from_slice([2, 4, 4, 4]);
+        let b = PrimitiveArray::from_slice([1, 2, 3, 3]);
         let tuples = join_asof_backward::<Int32Type, _>(&a, &b, |_, _| true);
         assert_eq!(tuples.to_vec(), &[Some(1), Some(3), Some(3), Some(3)]);
     }
 
     #[test]
     fn test_asof_backward_tolerance() {
-        let a = PrimitiveArray::from_slice(&[-1, 20, 25, 30, 30, 40]);
-        let b = PrimitiveArray::from_slice(&[10, 20, 30, 30]);
+        let a = PrimitiveArray::from_slice([-1, 20, 25, 30, 30, 40]);
+        let b = PrimitiveArray::from_slice([10, 20, 30, 30]);
         let tuples = join_asof_backward::<Int32Type, _>(&a, &b, |l, r| l.abs_diff(r) <= 4u32);
         assert_eq!(
             tuples.to_vec(),
@@ -188,8 +188,8 @@ mod test {
 
     #[test]
     fn test_asof_forward_tolerance() {
-        let a = PrimitiveArray::from_slice(&[-1, 20, 25, 30, 30, 40, 52]);
-        let b = PrimitiveArray::from_slice(&[10, 20, 33, 55]);
+        let a = PrimitiveArray::from_slice([-1, 20, 25, 30, 30, 40, 52]);
+        let b = PrimitiveArray::from_slice([10, 20, 33, 55]);
         let tuples = join_asof_forward::<Int32Type, _>(&a, &b, |l, r| l.abs_diff(r) <= 4u32);
         assert_eq!(
             tuples.to_vec(),
@@ -199,8 +199,8 @@ mod test {
 
     #[test]
     fn test_asof_forward() {
-        let a = PrimitiveArray::from_slice(&[-1, 1, 2, 4, 6]);
-        let b = PrimitiveArray::from_slice(&[1, 2, 4, 5]);
+        let a = PrimitiveArray::from_slice([-1, 1, 2, 4, 6]);
+        let b = PrimitiveArray::from_slice([1, 2, 4, 5]);
 
         let tuples = join_asof_forward::<Int32Type, _>(&a, &b, |_, _| true);
         assert_eq!(tuples.len(), a.len());

--- a/crates/polars-parquet/src/parquet/encoding/delta_length_byte_array/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/delta_length_byte_array/mod.rs
@@ -44,7 +44,7 @@ mod tests {
         assert_eq!(result, expected_lengths);
 
         let result = iter.into_values();
-        assert_eq!(result, expected_values.as_str().as_bytes());
+        assert_eq!(result, expected_values.as_bytes());
         Ok(())
     }
 }

--- a/crates/polars-parquet/src/parquet/encoding/hybrid_rle/decoder.rs
+++ b/crates/polars-parquet/src/parquet/encoding/hybrid_rle/decoder.rs
@@ -72,7 +72,7 @@ mod tests {
     fn basics_1() {
         let bit_width = 1usize;
         let length = 5;
-        let values = vec![
+        let values = [
             2, 0, 0, 0, // length
             0b00000011, 0b00001011, // data
         ];
@@ -97,7 +97,7 @@ mod tests {
         // This test was validated by the result of what pyarrow3 outputs when
         // the bitmap is used.
         let bit_width = 1;
-        let values = vec![
+        let values = [
             3, 0, 0, 0, // length
             0b00000101, 0b11101011, 0b00000010, // data
         ];
@@ -122,7 +122,7 @@ mod tests {
     fn basics_3() {
         let bit_width = 1;
         let length = 8;
-        let values = vec![
+        let values = [
             2, 0, 0, 0,          // length
             0b00010000, // data
             0b00000001,


### PR DESCRIPTION
Tests were ignored by `clippy` and there were a few warnings there. I fixed those and enabled linting for all targets.