### PR TITLE
ci(python): Move script for testing map warning

### DIFF
--- a/.github/scripts/test_bytecode_parser.py
+++ b/.github/scripts/test_bytecode_parser.py
@@ -8,7 +8,7 @@ All that needs to be installed is pytest, numpy, and ipython.
 
 Usage:
 
-    $ PYTHONPATH=polars/utils pytest tests/udf_warning_test_script.py
+    $ PYTHONPATH="py-polars:py-polars/polars/utils" pytest .github/scripts/test_bytecode_parser.py
 
 Running it without `PYTHONPATH` set will result in the test being skipped.
 """

--- a/.github/scripts/test_bytecode_parser.py
+++ b/.github/scripts/test_bytecode_parser.py
@@ -1,5 +1,5 @@
 """
-Minimal test of the BytecodeParser class.
+Minimal testing script of the BytecodeParser class.
 
 This can be run without polars installed, and so can be easily run in CI
 over all supported Python versions.
@@ -8,7 +8,7 @@ All that needs to be installed is pytest, numpy, and ipython.
 
 Usage:
 
-    $ PYTHONPATH=polars/utils python -m pytest tests/test_udfs.py
+    $ PYTHONPATH=polars/utils pytest tests/udf_warning_test_script.py
 
 Running it without `PYTHONPATH` set will result in the test being skipped.
 """
@@ -18,7 +18,6 @@ from datetime import datetime  # noqa: F401
 from typing import Any, Callable
 
 import pytest
-
 from tests.unit.operations.map.test_inefficient_map_warning import (
     MY_DICT,
     NOOP_TEST_CASES,
@@ -31,15 +30,7 @@ from tests.unit.operations.map.test_inefficient_map_warning import (
     TEST_CASES,
 )
 def test_bytecode_parser_expression(col: str, func: str, expected: str) -> None:
-    try:
-        import udfs  # type: ignore[import-not-found]
-    except ModuleNotFoundError as exc:
-        assert "No module named 'udfs'" in str(exc)  # noqa: PT017
-        # Skip test if udfs can't be imported because it's not in the path.
-        # Prefer this over importorskip, so that if `udfs` can't be
-        # imported for some other reason, then the test
-        # won't be skipped.
-        return
+    import udfs  # type: ignore[import-not-found]
 
     bytecode_parser = udfs.BytecodeParser(eval(func), map_target="expr")
     result = bytecode_parser.to_expression(col)
@@ -53,15 +44,7 @@ def test_bytecode_parser_expression(col: str, func: str, expected: str) -> None:
 def test_bytecode_parser_expression_in_ipython(
     col: str, func: Callable[[Any], Any], expected: str
 ) -> None:
-    try:
-        import udfs  # noqa: F401
-    except ModuleNotFoundError as exc:
-        assert "No module named 'udfs'" in str(exc)  # noqa: PT017
-        # Skip test if udfs can't be imported because it's not in the path.
-        # Prefer this over importorskip, so that if `udfs` can't be
-        # imported for some other reason, then the test
-        # won't be skipped.
-        return
+    import udfs  # noqa: F401
 
     script = (
         "import udfs; "
@@ -83,15 +66,7 @@ def test_bytecode_parser_expression_in_ipython(
     NOOP_TEST_CASES,
 )
 def test_bytecode_parser_expression_noop(func: str) -> None:
-    try:
-        import udfs
-    except ModuleNotFoundError as exc:
-        assert "No module named 'udfs'" in str(exc)  # noqa: PT017
-        # Skip test if udfs can't be imported because it's not in the path.
-        # Prefer this over importorskip, so that if `udfs` can't be
-        # imported for some other reason, then the test
-        # won't be skipped.
-        return
+    import udfs
 
     parser = udfs.BytecodeParser(eval(func), map_target="expr")
     assert not parser.can_attempt_rewrite() or not parser.to_expression("x")
@@ -102,15 +77,7 @@ def test_bytecode_parser_expression_noop(func: str) -> None:
     NOOP_TEST_CASES,
 )
 def test_bytecode_parser_expression_noop_in_ipython(func: str) -> None:
-    try:
-        import udfs  # noqa: F401
-    except ModuleNotFoundError as exc:
-        assert "No module named 'udfs'" in str(exc)  # noqa: PT017
-        # Skip test if udfs can't be imported because it's not in the path.
-        # Prefer this over importorskip, so that if `udfs` can't be
-        # imported for some other reason, then the test
-        # won't be skipped.
-        return
+    import udfs  # noqa: F401
 
     script = (
         "import udfs; "
@@ -124,13 +91,10 @@ def test_bytecode_parser_expression_noop_in_ipython(func: str) -> None:
 
 
 def test_local_imports() -> None:
-    try:
-        import udfs
-    except ModuleNotFoundError as exc:
-        assert "No module named 'udfs'" in str(exc)  # noqa: PT017
-        return
     import datetime as dt  # noqa: F811
     import json
+
+    import udfs
 
     bytecode_parser = udfs.BytecodeParser(lambda x: json.loads(x), map_target="expr")
     result = bytecode_parser.to_expression("x")

--- a/.github/workflows/test-bytecode-parser.yml
+++ b/.github/workflows/test-bytecode-parser.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Run tests
         working-directory: py-polars
-        run: PYTHONPATH=polars/utils pytest tests/test_udfs.py
+        run: PYTHONPATH=polars/utils python -m tests/test_udfs.py

--- a/.github/workflows/test-bytecode-parser.yml
+++ b/.github/workflows/test-bytecode-parser.yml
@@ -30,5 +30,6 @@ jobs:
         run: pip install ipython numpy pytest
 
       - name: Run tests
-        working-directory: py-polars
-        run: PYTHONPATH=polars/utils python -m tests/test_udfs.py
+        env:
+          PYTHONPATH: py-polars:py-polars/polars/utils
+        run: pytest .github/scripts/test_bytecode_parser.py

--- a/.github/workflows/test-bytecode-parser.yml
+++ b/.github/workflows/test-bytecode-parser.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Run tests
         env:
-          PYTHONPATH: py-polars:py-polars/polars/utils
+          PYTHONPATH: py-polars
         run: pytest .github/scripts/test_bytecode_parser.py

--- a/py-polars/tests/test_udfs.py
+++ b/py-polars/tests/test_udfs.py
@@ -4,7 +4,7 @@ Minimal test of the BytecodeParser class.
 This can be run without polars installed, and so can be easily run in CI
 over all supported Python versions.
 
-All that needs to be installed is numpy and pytest.
+All that needs to be installed is pytest, numpy, and ipython.
 
 Usage:
 

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -15,7 +15,138 @@ from polars.exceptions import PolarsInefficientMapWarning
 from polars.testing import assert_frame_equal, assert_series_equal
 from polars.utils.udfs import _NUMPY_FUNCTIONS, BytecodeParser
 from polars.utils.various import in_terminal_that_supports_colour
-from tests.test_udfs import MY_CONSTANT, MY_DICT, MY_LIST, NOOP_TEST_CASES, TEST_CASES
+
+MY_CONSTANT = 3
+MY_DICT = {0: "a", 1: "b", 2: "c", 3: "d", 4: "e"}
+MY_LIST = [1, 2, 3]
+
+# column_name, function, expected_suggestion
+TEST_CASES = [
+    # ---------------------------------------------
+    # numeric expr: math, comparison, logic ops
+    # ---------------------------------------------
+    ("a", "lambda x: x + 1 - (2 / 3)", '(pl.col("a") + 1) - 0.6666666666666666'),
+    ("a", "lambda x: x // 1 % 2", '(pl.col("a") // 1) % 2'),
+    ("a", "lambda x: x & True", 'pl.col("a") & True'),
+    ("a", "lambda x: x | False", 'pl.col("a") | False'),
+    ("a", "lambda x: abs(x) != 3", 'pl.col("a").abs() != 3'),
+    ("a", "lambda x: int(x) > 1", 'pl.col("a").cast(pl.Int64) > 1'),
+    ("a", "lambda x: not (x > 1) or x == 2", '~(pl.col("a") > 1) | (pl.col("a") == 2)'),
+    ("a", "lambda x: x is None", 'pl.col("a") is None'),
+    ("a", "lambda x: x is not None", 'pl.col("a") is not None'),
+    (
+        "a",
+        "lambda x: ((x * -x) ** x) * 1.0",
+        '((pl.col("a") * -pl.col("a")) ** pl.col("a")) * 1.0',
+    ),
+    (
+        "a",
+        "lambda x: 1.0 * (x * (x**x))",
+        '1.0 * (pl.col("a") * (pl.col("a") ** pl.col("a")))',
+    ),
+    (
+        "a",
+        "lambda x: (x / x) + ((x * x) - x)",
+        '(pl.col("a") / pl.col("a")) + ((pl.col("a") * pl.col("a")) - pl.col("a"))',
+    ),
+    (
+        "a",
+        "lambda x: (10 - x) / (((x * 4) - x) // (2 + (x * (x - 1))))",
+        '(10 - pl.col("a")) / (((pl.col("a") * 4) - pl.col("a")) // (2 + (pl.col("a") * (pl.col("a") - 1))))',
+    ),
+    ("a", "lambda x: x in (2, 3, 4)", 'pl.col("a").is_in((2, 3, 4))'),
+    ("a", "lambda x: x not in (2, 3, 4)", '~pl.col("a").is_in((2, 3, 4))'),
+    (
+        "a",
+        "lambda x: x in (1, 2, 3, 4, 3) and x % 2 == 0 and x > 0",
+        'pl.col("a").is_in((1, 2, 3, 4, 3)) & ((pl.col("a") % 2) == 0) & (pl.col("a") > 0)',
+    ),
+    ("a", "lambda x: MY_CONSTANT + x", 'MY_CONSTANT + pl.col("a")'),
+    ("a", "lambda x: 0 + numpy.cbrt(x)", '0 + pl.col("a").cbrt()'),
+    ("a", "lambda x: np.sin(x) + 1", 'pl.col("a").sin() + 1'),
+    (
+        "a",  # note: functions operate on consts
+        "lambda x: np.sin(3.14159265358979) + (x - 1) + abs(-3)",
+        '(np.sin(3.14159265358979) + (pl.col("a") - 1)) + abs(-3)',
+    ),
+    (
+        "a",
+        "lambda x: (float(x) * int(x)) // 2",
+        '(pl.col("a").cast(pl.Float64) * pl.col("a").cast(pl.Int64)) // 2',
+    ),
+    # ---------------------------------------------
+    # logical 'and/or' (validate nesting levels)
+    # ---------------------------------------------
+    (
+        "a",
+        "lambda x: x > 1 or (x == 1 and x == 2)",
+        '(pl.col("a") > 1) | (pl.col("a") == 1) & (pl.col("a") == 2)',
+    ),
+    (
+        "a",
+        "lambda x: (x > 1 or x == 1) and x == 2",
+        '((pl.col("a") > 1) | (pl.col("a") == 1)) & (pl.col("a") == 2)',
+    ),
+    (
+        "a",
+        "lambda x: x > 2 or x != 3 and x not in (0, 1, 4)",
+        '(pl.col("a") > 2) | (pl.col("a") != 3) & ~pl.col("a").is_in((0, 1, 4))',
+    ),
+    (
+        "a",
+        "lambda x: x > 1 and x != 2 or x % 2 == 0 and x < 3",
+        '(pl.col("a") > 1) & (pl.col("a") != 2) | ((pl.col("a") % 2) == 0) & (pl.col("a") < 3)',
+    ),
+    (
+        "a",
+        "lambda x: x > 1 and (x != 2 or x % 2 == 0) and x < 3",
+        '(pl.col("a") > 1) & ((pl.col("a") != 2) | ((pl.col("a") % 2) == 0)) & (pl.col("a") < 3)',
+    ),
+    # ---------------------------------------------
+    # string expr: case/cast ops
+    # ---------------------------------------------
+    ("b", "lambda x: str(x).title()", 'pl.col("b").cast(pl.Utf8).str.to_titlecase()'),
+    (
+        "b",
+        'lambda x: x.lower() + ":" + x.upper() + ":" + x.title()',
+        '(((pl.col("b").str.to_lowercase() + \':\') + pl.col("b").str.to_uppercase()) + \':\') + pl.col("b").str.to_titlecase()',
+    ),
+    # ---------------------------------------------
+    # json expr: load/extract
+    # ---------------------------------------------
+    ("c", "lambda x: json.loads(x)", 'pl.col("c").str.json_extract()'),
+    # ---------------------------------------------
+    # map_dict
+    # ---------------------------------------------
+    ("a", "lambda x: MY_DICT[x]", 'pl.col("a").map_dict(MY_DICT)'),
+    (
+        "a",
+        "lambda x: MY_DICT[x - 1] + MY_DICT[1 + x]",
+        '(pl.col("a") - 1).map_dict(MY_DICT) + (1 + pl.col("a")).map_dict(MY_DICT)',
+    ),
+    # ---------------------------------------------
+    # standard library datetime parsing
+    # ---------------------------------------------
+    (
+        "d",
+        'lambda x: datetime.strptime(x, "%Y-%m-%d")',
+        'pl.col("d").str.to_datetime(format="%Y-%m-%d")',
+    ),
+    (
+        "d",
+        'lambda x: dt.datetime.strptime(x, "%Y-%m-%d")',
+        'pl.col("d").str.to_datetime(format="%Y-%m-%d")',
+    ),
+]
+
+NOOP_TEST_CASES = [
+    "lambda x: x",
+    "lambda x, y: x + y",
+    "lambda x: x[0] + 1",
+    "lambda x: MY_LIST[x]",
+    "lambda x: MY_DICT[1]",
+    'lambda x: "first" if x == 1 else "not first"',
+]
 
 EVAL_ENVIRONMENT = {
     "np": numpy,


### PR DESCRIPTION
#### Changes

* The code defining all test cases is moved to the test module in the test suite.
* The script for testing the bytecode without Polars installed is moved closer to the CI, as it's only purpose is to easily test on multiple Python versions.

Reason for this change is that we want to avoid doing relative imports when running the pytest suite. In fact, this fails when running on Python 3.12. I took it a step further and moved the testing script into the CI folder.