### PR TITLE
fix: object store path derivation for local URL

### DIFF
--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -102,7 +102,7 @@ pub(crate) fn parse_url(url: &str) -> std::result::Result<Url, url::ParseError> 
         Err(err) => match err {
             url::ParseError::RelativeUrlWithoutBase => {
                 let parsed = Url::parse(&format!(
-                    "file://{}",
+                    "file://{}/",
                     std::env::current_dir().unwrap().to_string_lossy()
                 ))
                 .unwrap();

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import pandas as pd
@@ -9,8 +10,6 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from polars.type_aliases import ParallelStrategy
 
 
@@ -27,6 +26,13 @@ def foods_parquet_path(io_files_path: Path) -> Path:
 def test_scan_parquet(parquet_file_path: Path) -> None:
     df = pl.scan_parquet(parquet_file_path)
     assert df.collect().shape == (4, 3)
+
+
+def test_scan_parquet_local_with_async(
+    monkeypatch: Any, foods_parquet_path: Path
+) -> None:
+    monkeypatch.setenv("POLARS_FORCE_ASYNC", "1")
+    pl.scan_parquet(foods_parquet_path.relative_to(Path.cwd())).head(1).collect()
 
 
 def test_row_count(foods_parquet_path: Path) -> None:


### PR DESCRIPTION
path resolution incorrectly went up by 1 directory. E.g. if `PWD=/home/user/polars/` and the relative path `x/data.parquet` is used, then it would resolve to `/home/user/x/data.parquet` instead of `/home/user/polars/x/data.parquet`
