### PR TITLE
fix(python): Fix invalid DeprecationWarning generated from `date_range` defined with 'saturating' interval

### DIFF
--- a/py-polars/polars/functions/range/date_range.py
+++ b/py-polars/polars/functions/range/date_range.py
@@ -389,11 +389,11 @@ def _warn_for_deprecated_date_range_use(
     if (
         isinstance(start, datetime)
         or isinstance(end, datetime)
-        or "s" in interval
-        or "h" in interval
-        or ("m" in interval and "mo" not in interval)
         or time_unit is not None
         or time_zone is not None
+        or ("h" in interval)
+        or ("m" in interval and "mo" not in interval)
+        or ("s" in interval.replace("saturating", ""))
     ):
         issue_deprecation_warning(
             "Creating Datetime ranges using `date_range(s)` is deprecated."

--- a/py-polars/polars/functions/range/date_range.py
+++ b/py-polars/polars/functions/range/date_range.py
@@ -392,7 +392,7 @@ def _warn_for_deprecated_date_range_use(
         or time_unit is not None
         or time_zone is not None
         or ("h" in interval)
-        or ("m" in interval and "mo" not in interval)
+        or ("m" in interval.replace("mo", ""))
         or ("s" in interval.replace("saturating", ""))
     ):
         issue_deprecation_warning(


### PR DESCRIPTION
Closes #12303.

The "s" in "saturating" was triggering an invalid `DeprecationWarning` ;)