### PR TITLE
fix: fix download ranges in parquet

### DIFF
--- a/crates/polars-io/src/parquet/async_impl.rs
+++ b/crates/polars-io/src/parquet/async_impl.rs
@@ -187,7 +187,7 @@ async fn download_row_group(
         .unwrap();
 
     let result = async_reader
-        .get_range(offset as usize, (max_offset + len) as usize)
+        .get_range(offset as usize, (max_offset - offset + len) as usize)
         .await
         .map(|bytes| {
             let base_offset = offset;

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -416,3 +416,12 @@ def test_parquet_list_arg(io_files_path: Path) -> None:
     assert df.shape == (54, 4)
     assert df.row(-1) == ("seafood", 194, 12.0, 1)
     assert df.row(0) == ("vegetables", 45, 0.5, 2)
+
+
+@pytest.mark.write_disk()
+def test_parquet_many_row_groups_12297(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    file_path = tmp_path / "foo.parquet"
+    df = pl.DataFrame({"x": range(100)})
+    df.write_parquet(file_path, row_group_size=5, use_pyarrow=True)
+    assert_frame_equal(pl.scan_parquet(file_path).collect(), df)


### PR DESCRIPTION
fixes #12297 

Also improves performance as we accidentally downloaded more than we needed.