### PR TITLE
fix: respect hive_partitioning flag when dealing with multiple files

### DIFF
--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -69,7 +69,7 @@ impl ParquetExec {
                 .iter()
                 .map(|path| {
                     let mut file_info = self.file_info.clone();
-                    file_info.update_hive_partitions(path);
+                    file_info.update_hive_partitions(path)?;
 
                     let hive_partitions = file_info
                         .hive_parts
@@ -252,7 +252,7 @@ impl ParquetExec {
                             offset: rc.offset + *cumulative_read as IdxSize,
                         });
 
-                        file_info.update_hive_partitions(path);
+                        file_info.update_hive_partitions(path)?;
 
                         let hive_partitions = file_info
                             .hive_parts

--- a/crates/polars-pipe/src/executors/sources/parquet.rs
+++ b/crates/polars-pipe/src/executors/sources/parquet.rs
@@ -52,7 +52,7 @@ impl ParquetSource {
         let file_options = self.file_options.clone();
         let schema = self.file_info.schema.clone();
 
-        self.file_info.update_hive_partitions(path);
+        self.file_info.update_hive_partitions(path)?;
         let hive_partitions = self
             .file_info
             .hive_parts

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -293,7 +293,7 @@ impl<'a> PredicatePushDown<'a> {
 
 
                             for path in paths.as_ref().iter() {
-                                file_info.update_hive_partitions(path);
+                                file_info.update_hive_partitions(path)?;
                                 let hive_part_stats = file_info.hive_parts.as_deref().ok_or_else(|| polars_err!(ComputeError: "cannot combine hive partitioned directories with non-hive partitioned ones"))?;
 
                                 if stats_evaluator.should_read(hive_part_stats.get_statistics())? {

--- a/crates/polars-plan/src/logical_plan/schema.rs
+++ b/crates/polars-plan/src/logical_plan/schema.rs
@@ -87,20 +87,20 @@ impl FileInfo {
     }
 
     /// Updates the statistics, but not the schema.
-    pub fn update_hive_partitions(&mut self, url: &Path) {
-        let new = hive::HivePartitions::parse_url(url);
-
-        match (&mut self.hive_parts, new) {
-            (Some(current), Some(new)) => match Arc::get_mut(current) {
+    pub fn update_hive_partitions(&mut self, url: &Path) -> PolarsResult<()> {
+        if let Some(current) = &mut self.hive_parts {
+            let new = hive::HivePartitions::parse_url(url).ok_or_else(|| polars_err!(ComputeError: "expected hive partitioned path, got {}\n\n\
+            This error occurs if 'hive_partitioning=true' some paths are hive partitioned and some paths are not.", url.display()))?;
+            match Arc::get_mut(current) {
                 Some(current) => {
                     *current = new;
                 },
                 _ => {
                     *current = Arc::new(new);
                 },
-            },
-            (_, new) => self.hive_parts = new.map(Arc::new),
+            }
         }
+        Ok(())
     }
 }
 

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -9,7 +9,7 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 
-@pytest.mark.write_disk()
+# @pytest.mark.write_disk()
 def test_hive_partitioned_predicate_pushdown(
     io_files_path: Path, tmp_path: Path, monkeypatch: Any, capfd: Any
 ) -> None:
@@ -27,7 +27,10 @@ def test_hive_partitioned_predicate_pushdown(
         use_legacy_dataset=True,
     )
     q = pl.scan_parquet(root / "**/*.parquet", hive_partitioning=False)
+    # checks schema
     assert q.columns == ["calories", "sugars_g"]
+    # checks materialization
+    assert q.collect().columns == ["calories", "sugars_g"]
 
     q = pl.scan_parquet(root / "**/*.parquet", hive_partitioning=True)
     assert q.columns == ["calories", "sugars_g", "category", "fats_g"]


### PR DESCRIPTION
`update_hive...` always set the hive partitions irregardless of user settings.