### PR TITLE
fix: scan emtpy csv miss row_count

### DIFF
--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -552,7 +552,11 @@ impl<'a> CoreReader<'a> {
 
         // An empty file with a schema should return an empty DataFrame with that schema
         if bytes.is_empty() {
-            return Ok(DataFrame::from(self.schema.as_ref()));
+            let mut df = DataFrame::from(self.schema.as_ref());
+            if let Some(ref row_count) = self.row_count {
+                df.insert_at_idx(0, Series::new_empty(&row_count.name, &IDX_DTYPE))?;
+            }
+            return Ok(df);
         }
 
         // all the buffers returned from the threads

--- a/py-polars/tests/unit/io/test_lazy_csv.py
+++ b/py-polars/tests/unit/io/test_lazy_csv.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import OrderedDict
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -273,3 +274,14 @@ def test_scan_csv_slice_offset_zero(io_files_path: Path) -> None:
     lf = pl.scan_csv(io_files_path / "small.csv")
     result = lf.slice(0)
     assert result.collect().height == 4
+
+
+@pytest.mark.write_disk()
+def test_scan_empty_csv_with_row_count(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    file_path = tmp_path / "small.parquet"
+    df = pl.DataFrame({"a": []})
+    df.write_csv(file_path)
+
+    read = pl.scan_csv(file_path).with_row_count("idx")
+    assert read.collect().schema == OrderedDict([("idx", pl.UInt32), ("a", pl.Utf8)])


### PR DESCRIPTION
I tested it and found that not only `parquet`, but `scan_csv` also has the same problem, so give it a fix.