### PR TITLE
docs(rust): Build and verify Rust examples in docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2841,6 +2841,7 @@ dependencies = [
  "chrono",
  "polars",
  "rand 0.8.5",
+ "reqwest",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,6 +296,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-config"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7489a72550db3712fe3a0a92068f832d6270ff82f518b84a800af131f99570d7"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http",
+ "hyper",
+ "ring",
+ "time",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80009846d61a0a4f9070d789cf0e64db284cba6984fae3871050d044e6569cd2"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-creds"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,6 +353,339 @@ dependencies = [
  "thiserror",
  "time",
  "url",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e65730b741a5f6422fd338bf6f76b7956b090affeaa045e78fca8c4186e0fd5"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2414b96071ae840b97c0cc1d44b248d5607d648593cdf474f3fb5465572898"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "fastrand",
+ "http",
+ "percent-encoding",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84022763485483ea17d417f9832d5da198bc36829b59f086c0d35ecd2ce59991"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "http",
+ "http-body",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "341a5b00567d0f350025501c8fd36e1ca8055744a2d17e351f0b254f84eba48a"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd4bffbd26f66269933bcd26123f2d6860769c0f769b6d3fc10eda025d287d8"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b1a8ae5c7098502a3e6d4130dbee1e1d3fcb8dc5d65cecab39e01d595f90f6"
+dependencies = [
+ "aws-credential-types",
+ "aws-http",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "http",
+ "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3347c738e0a8449020877d319cda56da74d6e8aba9fff210720fac66cae3c7f4"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http",
+ "num-bigint",
+ "once_cell",
+ "p256",
+ "percent-encoding",
+ "regex",
+ "ring",
+ "sha2",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b65a284265d3eec6cc9f1daef2d0cc3b78684b712cb6c7f1d0f665456b7604"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d40f1d5a222ba11ac7d6b20f3668ae282970e50615fa5ee1dd8ac8180c0c1803"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc32c",
+ "crc32fast",
+ "hex",
+ "http",
+ "http-body",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16e7ecebc2b083a1b138868a46a343204a6097f343c4830a8b22b3a0d30013e"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715aeb61fb743848d5d398ce6fb1259f5eba5e13dceec5d5064cada1a181d38d"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de21d368dcd5cab17033406ea6e7351b091164b208381de837510bd7558c0f30"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ace389c7e4def130bff7275647481c8d49b867909ca61d5dc9a809b3632f3"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4395310662d10f1847324af5fe43e621922cba03b1aa6d26c21096e18a4e79"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "rustls",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e27594c06f5b36e97d18ef26ed693f1d4c7167b9bbb544b3a9bb653f9f7035"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d36f1723ed61e82094498e7283510fe21484b73c215c33874c81a84411b5bdc"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68225c8d3e3e6c565a3cf764aa82440837ef15c33d1dd7205e15715444e4b4ad"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc27aac60f715bab25f5d758ba5651b80aae791c48e9871ffe298683f00a2b"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http",
+ "rustc_version",
+ "tracing",
 ]
 
 [[package]]
@@ -328,10 +704,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bincode"
@@ -429,6 +827,16 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cargo-lock"
@@ -582,6 +990,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
 name = "const-random"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +1041,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -640,6 +1063,15 @@ name = "crc-catalog"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
+
+[[package]]
+name = "crc32c"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f48d60e5b4d2c53d5c2b1d8a58c849a70ae5e5509b08a48d047e3b65714a74"
+dependencies = [
+ "rustc_version",
+]
 
 [[package]]
 name = "crc32fast"
@@ -768,6 +1200,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +1226,16 @@ name = "dary_heap"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
 
 [[package]]
 name = "deranged"
@@ -801,6 +1255,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -825,10 +1280,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
 
 [[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "der",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -869,9 +1356,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -900,6 +1387,16 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "flate2"
@@ -1064,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1099,6 +1596,17 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -1197,6 +1705,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,7 +1795,9 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
+ "log",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
 ]
@@ -1635,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+checksum = "969488b55f8ac402214f3f5fd243ebb7206cf82de60d3172994707a4bcc2b829"
 
 [[package]]
 name = "lock_api"
@@ -1683,6 +2202,16 @@ checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
 ]
 
 [[package]]
@@ -2023,6 +2552,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2119,6 +2665,16 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2280,9 +2836,12 @@ dependencies = [
 name = "polars-doc-examples"
 version = "0.34.2"
 dependencies = [
+ "aws-config",
+ "aws-sdk-s3",
  "chrono",
  "polars",
  "rand 0.8.5",
+ "tokio",
 ]
 
 [[package]]
@@ -3059,6 +3618,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint",
+ "hmac",
+ "zeroize",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3132,6 +3702,18 @@ dependencies = [
  "ring",
  "rustls-webpki",
  "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3246,6 +3828,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3334,6 +3930,47 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3448,6 +4085,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "sqlparser"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3508,6 +4155,12 @@ dependencies = [
  "rustversion",
  "syn 2.0.39",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
@@ -3696,6 +4349,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.5.5",
  "tokio-macros",
  "windows-sys",
@@ -3897,6 +4551,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "uuid"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3928,6 +4588,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -4183,6 +4849,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
 name = "xxhash-rust"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4207,6 +4879,12 @@ dependencies = [
  "quote",
  "syn 2.0.39",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,6 +2277,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "polars-doc-examples"
+version = "0.34.2"
+dependencies = [
+ "chrono",
+ "polars",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "polars-error"
 version = "0.34.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
   "crates/*",
+  "docs/src/rust",
   "examples/*",
   "py-polars",
 ]

--- a/crates/polars-arrow/src/io/ipc/compression.rs
+++ b/crates/polars-arrow/src/io/ipc/compression.rs
@@ -1,4 +1,6 @@
-use polars_error::{to_compute_err, PolarsResult};
+#[cfg(feature = "io_ipc_compression")]
+use polars_error::to_compute_err;
+use polars_error::PolarsResult;
 
 #[cfg(feature = "io_ipc_compression")]
 #[cfg_attr(docsrs, doc(cfg(feature = "io_ipc_compression")))]

--- a/crates/polars-core/src/datatypes/time_unit.rs
+++ b/crates/polars-core/src/datatypes/time_unit.rs
@@ -58,6 +58,7 @@ impl TimeUnit {
     }
 }
 
+#[cfg(feature = "rows")]
 #[cfg(any(feature = "dtype-datetime", feature = "dtype-duration"))]
 #[inline]
 pub(crate) fn convert_time_units(v: i64, tu_l: TimeUnit, tu_r: TimeUnit) -> i64 {

--- a/crates/polars-io/src/lib.rs
+++ b/crates/polars-io/src/lib.rs
@@ -48,7 +48,6 @@ use polars_core::prelude::*;
 
 #[cfg(any(
     feature = "ipc",
-    feature = "json",
     feature = "avro",
     feature = "ipc_streaming",
 ))]
@@ -96,7 +95,6 @@ pub trait ArrowReader {
 
 #[cfg(any(
     feature = "ipc",
-    feature = "json",
     feature = "avro",
     feature = "ipc_streaming",
 ))]

--- a/crates/polars-io/src/lib.rs
+++ b/crates/polars-io/src/lib.rs
@@ -46,11 +46,7 @@ pub use options::*;
 use polars_core::frame::ArrowChunk;
 use polars_core::prelude::*;
 
-#[cfg(any(
-    feature = "ipc",
-    feature = "avro",
-    feature = "ipc_streaming",
-))]
+#[cfg(any(feature = "ipc", feature = "avro", feature = "ipc_streaming",))]
 use crate::predicates::PhysicalIoExpr;
 
 pub trait SerReader<R>
@@ -93,11 +89,7 @@ pub trait ArrowReader {
     fn next_record_batch(&mut self) -> PolarsResult<Option<ArrowChunk>>;
 }
 
-#[cfg(any(
-    feature = "ipc",
-    feature = "avro",
-    feature = "ipc_streaming",
-))]
+#[cfg(any(feature = "ipc", feature = "avro", feature = "ipc_streaming",))]
 pub(crate) fn finish_reader<R: ArrowReader>(
     mut reader: R,
     rechunk: bool,

--- a/crates/polars-io/src/parquet/mmap.rs
+++ b/crates/polars-io/src/parquet/mmap.rs
@@ -1,4 +1,5 @@
 use arrow::datatypes::Field;
+#[cfg(feature = "async")]
 use bytes::Bytes;
 #[cfg(feature = "async")]
 use polars_core::datatypes::PlHashMap;

--- a/crates/polars-io/src/parquet/read.rs
+++ b/crates/polars-io/src/parquet/read.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use arrow::datatypes::ArrowSchemaRef;
 use polars_core::prelude::*;
+#[cfg(feature = "cloud")]
 use polars_core::utils::accumulate_dataframes_vertical_unchecked;
 use polars_parquet::read;
 use polars_parquet::write::FileMetaData;
@@ -17,8 +18,10 @@ use crate::mmap::MmapBytesReader;
 use crate::parquet::async_impl::FetchRowGroupsFromObjectStore;
 #[cfg(feature = "cloud")]
 use crate::parquet::async_impl::ParquetObjectStore;
+#[cfg(feature = "cloud")]
+use crate::parquet::read_impl::materialize_empty_df;
+use crate::parquet::read_impl::read_parquet;
 pub use crate::parquet::read_impl::BatchedParquetReader;
-use crate::parquet::read_impl::{materialize_empty_df, read_parquet};
 use crate::predicates::PhysicalIoExpr;
 use crate::prelude::*;
 use crate::RowCount;

--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -19,7 +19,7 @@ pub trait StatsEvaluator {
     fn should_read(&self, stats: &BatchStats) -> PolarsResult<bool>;
 }
 
-#[cfg(any(feature = "parquet", feature = "json",))]
+#[cfg(feature = "parquet")]
 pub(crate) fn apply_predicate(
     df: &mut DataFrame,
     predicate: Option<&dyn PhysicalIoExpr>,

--- a/crates/polars-lazy/src/physical_plan/executors/scan/mod.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/mod.rs
@@ -8,7 +8,7 @@ mod ndjson;
 mod parquet;
 
 use std::mem;
-#[cfg(any(feature = "parquet", feature = "csv", feature = "ipc", feature = "cse"))]
+#[cfg(any(feature = "parquet", feature = "ipc", feature = "cse"))]
 use std::ops::Deref;
 
 #[cfg(feature = "csv")]

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -1,5 +1,8 @@
-use std::path::{Path, PathBuf};
+#[cfg(feature = "cloud")]
+use std::path::Path;
+use std::path::PathBuf;
 
+#[cfg(feature = "cloud")]
 use polars_core::config::{get_file_prefetch_size, verbose};
 use polars_core::utils::accumulate_dataframes_vertical;
 use polars_io::cloud::CloudOptions;
@@ -16,6 +19,7 @@ pub struct ParquetExec {
     #[allow(dead_code)]
     cloud_options: Option<CloudOptions>,
     file_options: FileScanOptions,
+    #[allow(dead_code)]
     metadata: Option<Arc<FileMetaData>>,
 }
 

--- a/crates/polars-ops/src/frame/join/asof/mod.rs
+++ b/crates/polars-ops/src/frame/join/asof/mod.rs
@@ -3,7 +3,7 @@ mod groups;
 use std::borrow::Cow;
 
 use default::*;
-pub(super) use groups::AsofJoinBy;
+pub use groups::AsofJoinBy;
 use polars_core::prelude::*;
 use polars_core::utils::ensure_sorted_arg;
 #[cfg(feature = "serde")]

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -18,9 +18,7 @@ use ahash::RandomState;
 pub use args::*;
 use arrow::legacy::trusted_len::TrustedLen;
 #[cfg(feature = "asof_join")]
-use asof::AsofJoinBy;
-#[cfg(feature = "asof_join")]
-pub use asof::{AsOfOptions, AsofJoin, AsofStrategy};
+pub use asof::{AsOfOptions, AsofJoin, AsofJoinBy, AsofStrategy};
 #[cfg(feature = "dtype-categorical")]
 pub(crate) use checks::*;
 pub use cross_join::CrossJoin;

--- a/docs/src/rust/Cargo.toml
+++ b/docs/src/rust/Cargo.toml
@@ -60,5 +60,19 @@ required-features = ["polars/lazy"]
 name = "user-guide-io-cloud-storage"
 path = "user-guide/io/cloud-storage.rs"
 required-features = ["polars/csv"]
+[[bin]]
+name = "user-guide-io-csv"
+path = "user-guide/io/csv.rs"
+required-features = ["polars/csv"]
+[[bin]]
+name = "user-guide-io-json"
+path = "user-guide/io/json.rs"
+required-features = ["polars/json"]
+[[bin]]
+name = "user-guide-io-parquet"
+path = "user-guide/io/parquet.rs"
+required-features = ["polars/parquet"]
+
+
 
 

--- a/docs/src/rust/Cargo.toml
+++ b/docs/src/rust/Cargo.toml
@@ -73,6 +73,39 @@ name = "user-guide-io-parquet"
 path = "user-guide/io/parquet.rs"
 required-features = ["polars/parquet"]
 
+[[bin]]
+name = "user-guide-transformations-concatenation"
+path = "user-guide/transformations/concatenation.rs"
+required-features = ["polars/lazy"]
+# [[bin]]
+# name = "user-guide-transformations-joins"
+# path = "user-guide/transformations/joins.rs"
+# required-features = ["polars/lazy", "polars/asof_join"]
+[[bin]]
+name = "user-guide-transformations-melt"
+path = "user-guide/transformations/melt.rs"
+[[bin]]
+name = "user-guide-transformations-pivot"
+path = "user-guide/transformations/pivot.rs"
+required-features = ["polars/lazy"]
 
-
-
+[[bin]]
+name = "user-guide-transformations-time-series-filter"
+path = "user-guide/transformations/time-series/filter.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-transformations-time-series-parsing"
+path = "user-guide/transformations/time-series/parsing.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-transformations-time-series-resampling"
+path = "user-guide/transformations/time-series/resampling.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-transformations-time-series-rolling"
+path = "user-guide/transformations/time-series/rolling.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-transformations-time-series-timezones"
+path = "user-guide/transformations/time-series/timezones.rs"
+required-features = ["polars/lazy"]

--- a/docs/src/rust/Cargo.toml
+++ b/docs/src/rust/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "polars-doc-examples"
+version = { workspace = true }
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
+description = "Code examples included in the Polars documentation website"
+
+[dependencies]
+chrono = { workspace = true }
+rand = { workspace = true }
+
+[dependencies.polars]
+workspace = true
+
+[[bin]]
+name = "home"
+path = "home/example.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-basics-expressions"
+path = "user-guide/basics/expressions.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-basics-joins"
+path = "user-guide/basics/joins.rs"
+[[bin]]
+name = "user-guide-basics-reading-writing"
+path = "user-guide/basics/reading-writing.rs"
+required-features = ["polars/json"]
+[[bin]]
+name = "user-guide-basics-series-dataframes"
+path = "user-guide/basics/series-dataframes.rs"
+required-features = ["polars/describe"]
+

--- a/docs/src/rust/Cargo.toml
+++ b/docs/src/rust/Cargo.toml
@@ -127,10 +127,10 @@ required-features = ["polars/parquet"]
 name = "user-guide-transformations-concatenation"
 path = "user-guide/transformations/concatenation.rs"
 required-features = ["polars/lazy"]
-# [[bin]]
-# name = "user-guide-transformations-joins"
-# path = "user-guide/transformations/joins.rs"
-# required-features = ["polars/lazy", "polars/asof_join"]
+[[bin]]
+name = "user-guide-transformations-joins"
+path = "user-guide/transformations/joins.rs"
+required-features = ["polars/lazy"]
 [[bin]]
 name = "user-guide-transformations-melt"
 path = "user-guide/transformations/melt.rs"

--- a/docs/src/rust/Cargo.toml
+++ b/docs/src/rust/Cargo.toml
@@ -11,6 +11,9 @@ description = "Code examples included in the Polars documentation website"
 [dependencies]
 chrono = { workspace = true }
 rand = { workspace = true }
+tokio = { workspace = true }
+aws-config = { version = "0.57" }
+aws-sdk-s3 = { version = "0.35" }
 
 [dependencies.polars]
 workspace = true
@@ -19,6 +22,7 @@ workspace = true
 name = "home"
 path = "home/example.rs"
 required-features = ["polars/lazy"]
+
 [[bin]]
 name = "user-guide-basics-expressions"
 path = "user-guide/basics/expressions.rs"
@@ -34,4 +38,27 @@ required-features = ["polars/json"]
 name = "user-guide-basics-series-dataframes"
 path = "user-guide/basics/series-dataframes.rs"
 required-features = ["polars/describe"]
+
+[[bin]]
+name = "user-guide-concepts-contexts"
+path = "user-guide/concepts/contexts.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-concepts-expressions"
+path = "user-guide/concepts/expressions.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-concepts-lazy-vs-eager"
+path = "user-guide/concepts/lazy-vs-eager.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-concepts-streaming"
+path = "user-guide/concepts/streaming.rs"
+required-features = ["polars/lazy"]
+
+[[bin]]
+name = "user-guide-io-cloud-storage"
+path = "user-guide/io/cloud-storage.rs"
+required-features = ["polars/csv"]
+
 

--- a/docs/src/rust/Cargo.toml
+++ b/docs/src/rust/Cargo.toml
@@ -101,10 +101,10 @@ required-features = ["polars/lazy"]
 name = "user-guide-expressions-user-defined-functions"
 path = "user-guide/expressions/user-defined-functions.rs"
 required-features = ["polars/lazy"]
-# [[bin]]
-# name = "user-guide-expressions-window"
-# path = "user-guide/expressions/window.rs"
-# required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-expressions-window"
+path = "user-guide/expressions/window.rs"
+required-features = ["polars/lazy"]
 
 [[bin]]
 name = "user-guide-io-cloud-storage"

--- a/docs/src/rust/Cargo.toml
+++ b/docs/src/rust/Cargo.toml
@@ -9,11 +9,12 @@ repository = { workspace = true }
 description = "Code examples included in the Polars documentation website"
 
 [dependencies]
-chrono = { workspace = true }
-rand = { workspace = true }
-tokio = { workspace = true }
 aws-config = { version = "0.57" }
 aws-sdk-s3 = { version = "0.35" }
+chrono = { workspace = true }
+rand = { workspace = true }
+reqwest = { workspace = true, features = ["blocking"] }
+tokio = { workspace = true }
 
 [dependencies.polars]
 workspace = true
@@ -55,6 +56,55 @@ required-features = ["polars/lazy"]
 name = "user-guide-concepts-streaming"
 path = "user-guide/concepts/streaming.rs"
 required-features = ["polars/lazy"]
+
+[[bin]]
+name = "user-guide-expressions-aggregation"
+path = "user-guide/expressions/aggregation.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-expressions-casting"
+path = "user-guide/expressions/casting.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-expressions-column-selections"
+path = "user-guide/expressions/column-selections.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-expressions-folds"
+path = "user-guide/expressions/folds.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-expressions-functions"
+path = "user-guide/expressions/functions.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-expressions-lists"
+path = "user-guide/expressions/lists.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-expressions-null"
+path = "user-guide/expressions/null.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-expressions-operators"
+path = "user-guide/expressions/operators.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-expressions-strings"
+path = "user-guide/expressions/strings.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-expressions-structs"
+path = "user-guide/expressions/structs.rs"
+required-features = ["polars/lazy"]
+[[bin]]
+name = "user-guide-expressions-user-defined-functions"
+path = "user-guide/expressions/user-defined-functions.rs"
+required-features = ["polars/lazy"]
+# [[bin]]
+# name = "user-guide-expressions-window"
+# path = "user-guide/expressions/window.rs"
+# required-features = ["polars/lazy"]
 
 [[bin]]
 name = "user-guide-io-cloud-storage"

--- a/docs/src/rust/home/example.rs
+++ b/docs/src/rust/home/example.rs
@@ -9,8 +9,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .group_by(vec![col("species")])
         .agg([col("*").sum()]);
 
-    let df = q.collect();
+    let df = q.collect()?;
     // --8<-- [end:example]
+
+    println!("{}", df);
 
     Ok(())
 }

--- a/docs/src/rust/user-guide/basics/expressions.rs
+++ b/docs/src/rust/user-guide/basics/expressions.rs
@@ -5,7 +5,8 @@ use rand::Rng;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut rng = rand::thread_rng();
 
-    let df: DataFrame = df!("a" => 0..8,
+    let df: DataFrame = df!(
+        "a" => 0..8,
         "b"=> (0..8).map(|_| rng.gen::<f64>()).collect::<Vec<f64>>(),
         "c"=> [
             NaiveDate::from_ymd_opt(2022, 12, 1).unwrap().and_hms_opt(0, 0, 0).unwrap(),
@@ -19,7 +20,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ],
         "d"=> [Some(1.0), Some(2.0), None, None, Some(0.0), Some(-5.0), Some(-42.), None]
     )
-    .expect("should not fail");
+    .unwrap();
 
     // --8<-- [start:select]
     let out = df.clone().lazy().select([col("*")]).collect()?;

--- a/docs/src/rust/user-guide/basics/joins.rs
+++ b/docs/src/rust/user-guide/basics/joins.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "y"=> &["A", "A", "A", "B", "B", "C", "X", "X"],
     )
     .unwrap();
-    let joined = df.join(&df2, ["a"], ["x"], JoinType::Left, None)?;
+    let joined = df.join(&df2, ["a"], ["x"], JoinType::Left.into())?;
     println!("{}", joined);
     // --8<-- [end:join]
 

--- a/docs/src/rust/user-guide/basics/reading-writing.rs
+++ b/docs/src/rust/user-guide/basics/reading-writing.rs
@@ -15,7 +15,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ],
         "float" => &[4.0, 5.0, 6.0]
     )
-    .expect("should not fail");
+    .unwrap();
     println!("{}", df);
     // --8<-- [end:dataframe]
 
@@ -24,7 +24,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     CsvWriter::new(&mut file)
         .has_header(true)
         .with_separator(b',')
-        .finish(&mut df);
+        .finish(&mut df)?;
     let df_csv = CsvReader::from_path("docs/data/output.csv")?
         .infer_schema(None)
         .has_header(true)
@@ -37,19 +37,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     CsvWriter::new(&mut file)
         .has_header(true)
         .with_separator(b',')
-        .finish(&mut df);
+        .finish(&mut df)?;
     let df_csv = CsvReader::from_path("docs/data/output.csv")?
         .infer_schema(None)
         .has_header(true)
-        .with_parse_dates(true)
+        .with_try_parse_dates(true)
         .finish()?;
     println!("{}", df_csv);
     // --8<-- [end:csv2]
 
     // --8<-- [start:json]
     let mut file = File::create("docs/data/output.json").expect("could not create file");
-    JsonWriter::new(&mut file).finish(&mut df);
-    let mut f = File::open("docs/data/output.json")?;
+    JsonWriter::new(&mut file).finish(&mut df)?;
+    let f = File::open("docs/data/output.json")?;
     let df_json = JsonReader::new(f)
         .with_json_format(JsonFormat::JsonLines)
         .finish()?;
@@ -58,8 +58,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // --8<-- [start:parquet]
     let mut file = File::create("docs/data/output.parquet").expect("could not create file");
-    ParquetWriter::new(&mut file).finish(&mut df);
-    let mut f = File::open("docs/data/output.parquet")?;
+    ParquetWriter::new(&mut file).finish(&mut df)?;
+    let f = File::open("docs/data/output.parquet")?;
     let df_parquet = ParquetReader::new(f).finish()?;
     println!("{}", df_parquet);
     // --8<-- [end:parquet]

--- a/docs/src/rust/user-guide/basics/series-dataframes.rs
+++ b/docs/src/rust/user-guide/basics/series-dataframes.rs
@@ -49,7 +49,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [end:tail]
 
     // --8<-- [start:sample]
-    println!("{}", df.sample_n(2, false, true, None)?);
+    let n = Series::new("n", [2]);
+    println!("{}", df.sample_n(&n, false, true, None)?);
     // --8<-- [end:sample]
 
     // --8<-- [start:describe]

--- a/docs/src/rust/user-guide/concepts/expressions.rs
+++ b/docs/src/rust/user-guide/concepts/expressions.rs
@@ -1,6 +1,4 @@
-use chrono::prelude::*;
 use polars::prelude::*;
-use rand::Rng;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let df = df! (
@@ -9,7 +7,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     )?;
 
     // --8<-- [start:example1]
-    df.column("foo")?.sort(false).head(Some(2));
+    let _ = col("foo").sort(Default::default()).head(Some(2));
     // --8<-- [end:example1]
 
     // --8<-- [start:example2]

--- a/docs/src/rust/user-guide/concepts/lazy-vs-eager.rs
+++ b/docs/src/rust/user-guide/concepts/lazy-vs-eager.rs
@@ -8,6 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .unwrap();
     let mask = df.column("sepal_length")?.f64()?.gt(5.0);
     let df_small = df.filter(&mask)?;
+    #[allow(deprecated)]
     let df_agg = df_small
         .group_by(["species"])?
         .select(["sepal_width"])

--- a/docs/src/rust/user-guide/concepts/streaming.rs
+++ b/docs/src/rust/user-guide/concepts/streaming.rs
@@ -1,6 +1,4 @@
-use chrono::prelude::*;
 use polars::prelude::*;
-use rand::Rng;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [start:streaming]

--- a/docs/src/rust/user-guide/expressions/aggregation.rs
+++ b/docs/src/rust/user-guide/expressions/aggregation.rs
@@ -9,19 +9,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let url = "https://theunitedstates.io/congress-legislators/legislators-historical.csv";
 
     let mut schema = Schema::new();
-    schema.with_column("first_name".to_string(), DataType::Categorical(None));
-    schema.with_column("gender".to_string(), DataType::Categorical(None));
-    schema.with_column("type".to_string(), DataType::Categorical(None));
-    schema.with_column("state".to_string(), DataType::Categorical(None));
-    schema.with_column("party".to_string(), DataType::Categorical(None));
-    schema.with_column("birthday".to_string(), DataType::Date);
+    schema.with_column("first_name".into(), DataType::Categorical(None));
+    schema.with_column("gender".into(), DataType::Categorical(None));
+    schema.with_column("type".into(), DataType::Categorical(None));
+    schema.with_column("state".into(), DataType::Categorical(None));
+    schema.with_column("party".into(), DataType::Categorical(None));
+    schema.with_column("birthday".into(), DataType::Date);
 
     let data: Vec<u8> = Client::new().get(url).send()?.text()?.bytes().collect();
 
     let dataset = CsvReader::new(Cursor::new(data))
         .has_header(true)
-        .with_dtypes(Some(&schema))
-        .with_parse_dates(true)
+        .with_dtypes(Some(Arc::new(schema)))
+        .with_try_parse_dates(true)
         .finish()?;
 
     println!("{}", &dataset);
@@ -32,12 +32,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .clone()
         .lazy()
         .group_by(["first_name"])
-        .agg([count(), col("gender").list(), col("last_name").first()])
+        .agg([count(), col("gender"), col("last_name").first()])
         .sort(
             "count",
             SortOptions {
                 descending: true,
                 nulls_last: true,
+                ..Default::default()
             },
         )
         .limit(5)
@@ -64,6 +65,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             SortOptions {
                 descending: true,
                 nulls_last: false,
+                ..Default::default()
             },
         )
         .limit(5)
@@ -88,6 +90,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             SortOptions {
                 descending: true,
                 nulls_last: true,
+                ..Default::default()
             },
         )
         .limit(5)
@@ -137,6 +140,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             SortOptions {
                 descending: true,
                 nulls_last: true,
+                ..Default::default()
             },
         )
         .group_by(["state"])
@@ -159,6 +163,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             SortOptions {
                 descending: true,
                 nulls_last: true,
+                ..Default::default()
             },
         )
         .group_by(["state"])
@@ -182,6 +187,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             SortOptions {
                 descending: true,
                 nulls_last: true,
+                ..Default::default()
             },
         )
         .group_by(["state"])

--- a/docs/src/rust/user-guide/expressions/casting.rs
+++ b/docs/src/rust/user-guide/expressions/casting.rs
@@ -133,29 +133,44 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [end:bool]
 
     // --8<-- [start:dates]
-
     use chrono::prelude::*;
-    use polars::time::*;
+
+    let date = polars::time::date_range(
+        "date",
+        NaiveDate::from_ymd_opt(2022, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+        NaiveDate::from_ymd_opt(2022, 1, 5)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+        Duration::parse("1d"),
+        ClosedWindow::Both,
+        TimeUnit::Milliseconds,
+        None,
+    )?
+    .cast(&DataType::Date)?;
+
+    let datetime = polars::time::date_range(
+        "datetime",
+        NaiveDate::from_ymd_opt(2022, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+        NaiveDate::from_ymd_opt(2022, 1, 5)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+        Duration::parse("1d"),
+        ClosedWindow::Both,
+        TimeUnit::Milliseconds,
+        None,
+    )?;
 
     let df = df! (
-        "date" => date_range(
-            "date",
-            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap(),
-            NaiveDate::from_ymd_opt(2022, 1, 5).unwrap().and_hms_opt(0, 0, 0).unwrap(),
-            Duration::parse("1d"),
-            ClosedWindow::Both,
-            TimeUnit::Milliseconds,
-            None
-        )?.cast(&DataType::Date)?,
-        "datetime" => datetime_range(
-            "datetime",
-            NaiveDate::from_ymd_opt(2022, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap(),
-            NaiveDate::from_ymd_opt(2022, 1, 5).unwrap().and_hms_opt(0, 0, 0).unwrap(),
-            Duration::parse("1d"),
-            ClosedWindow::Both,
-            TimeUnit::Milliseconds,
-            None
-        )?,
+        "date" => date,
+        "datetime" => datetime,
     )?;
 
     let out = df
@@ -170,10 +185,24 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [end:dates]
 
     // --8<-- [start:dates2]
+    let date = polars::time::date_range(
+        "date",
+        NaiveDate::from_ymd_opt(2022, 1, 1)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+        NaiveDate::from_ymd_opt(2022, 1, 5)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+        Duration::parse("1d"),
+        ClosedWindow::Both,
+        TimeUnit::Milliseconds,
+        None,
+    )?;
 
     let df = df! (
-            "date" => date_range("date",
-                    NaiveDate::from_ymd_opt(2022, 1, 1).unwrap().and_hms_opt(0, 0, 0).unwrap(), NaiveDate::from_ymd_opt(2022, 1, 5).unwrap().and_hms_opt(0, 0, 0).unwrap(), Duration::parse("1d"),ClosedWindow::Both, TimeUnit::Milliseconds, None)?,
+            "date" => date,
             "string" => &[
                 "2022-01-01",
                 "2022-01-02",
@@ -189,7 +218,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .select([
             col("date").dt().to_string("%Y-%m-%d"),
             col("string").str().to_datetime(
-                TimeUnit::Microseconds,
+                Some(TimeUnit::Microseconds),
                 None,
                 StrptimeOptions::default(),
                 lit("raise"),

--- a/docs/src/rust/user-guide/expressions/column-selections.rs
+++ b/docs/src/rust/user-guide/expressions/column-selections.rs
@@ -22,6 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // --8<-- [start:all]
     let out = df.clone().lazy().select([col("*")]).collect()?;
+    println!("{}", &out);
 
     // Is equivalent to
     let out = df.clone().lazy().select([all()]).collect()?;

--- a/docs/src/rust/user-guide/expressions/lists.rs
+++ b/docs/src/rust/user-guide/expressions/lists.rs
@@ -47,7 +47,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .list()
                 .slice(lit(-3), lit(3))
                 .alias("bottom_3"),
-            col("temperatures").list().lengths().alias("obs"),
+            col("temperatures").list().len().alias("obs"),
         ])
         .collect()?;
     println!("{}", &out);

--- a/docs/src/rust/user-guide/expressions/structs.rs
+++ b/docs/src/rust/user-guide/expressions/structs.rs
@@ -78,7 +78,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out = ratings
         .clone()
         .lazy()
-        .with_columns([as_struct(&[col("Count"), col("Avg_Rating")])
+        .with_columns([as_struct(vec![col("Count"), col("Avg_Rating")])
             .rank(
                 RankOptions {
                     method: RankMethod::Dense,

--- a/docs/src/rust/user-guide/expressions/window.rs
+++ b/docs/src/rust/user-guide/expressions/window.rs
@@ -1,5 +1,3 @@
-use polars::prelude::*;
-
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [start:pokemon]
     use polars::prelude::*;
@@ -65,17 +63,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [start:rules]
     // aggregate and broadcast within a group
     // output type: -> i32
-    sum("foo").over([col("groups")]);
+    let _ = sum("foo").over([col("groups")]);
     // sum within a group and multiply with group elements
     // output type: -> i32
-    (col("x").sum() * col("y"))
+    let _ = (col("x").sum() * col("y"))
         .over([col("groups")])
         .alias("x1");
     // sum within a group and multiply with group elements
     // and aggregate the group to a list
     // output type: -> ChunkedArray<i32>
-    (col("x").sum() * col("y"))
-        .list()
+    let _ = (col("x").sum() * col("y"))
         .over([col("groups")])
         .alias("x2");
     // note that it will require an explicit `list()` call
@@ -84,11 +81,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // the flatten call explodes that list
 
     // This is the fastest method to do things over groups when the groups are sorted
-    (col("x").sum() * col("y"))
-    .list()
-    .over([col("groups")])
-    .flatten()
-    .alias("x3");
+    let _ = (col("x").sum() * col("y"))
+        .over([col("groups")])
+        .flatten()
+        .alias("x3");
     // --8<-- [end:rules]
 
     // --8<-- [start:examples]
@@ -96,29 +92,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .clone()
         .lazy()
         .select([
-            col("Type 1")
-                .head(Some(3))
-                .list()
-                .over(["Type 1"])
-                .flatten(),
+            col("Type 1").head(Some(3)).over(["Type 1"]).flatten(),
             col("Name")
                 .sort_by(["Speed"], [true])
                 .head(Some(3))
-                .list()
                 .over(["Type 1"])
                 .flatten()
                 .alias("fastest/group"),
             col("Name")
                 .sort_by(["Attack"], [true])
                 .head(Some(3))
-                .list()
                 .over(["Type 1"])
                 .flatten()
                 .alias("strongest/group"),
             col("Name")
                 .sort(false)
                 .head(Some(3))
-                .list()
                 .over(["Type 1"])
                 .flatten()
                 .alias("sorted_by_alphabet"),

--- a/docs/src/rust/user-guide/expressions/window.rs
+++ b/docs/src/rust/user-guide/expressions/window.rs
@@ -65,19 +65,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [start:rules]
     // aggregate and broadcast within a group
     // output type: -> i32
-    sum("foo").over([col("groups")])
+    sum("foo").over([col("groups")]);
     // sum within a group and multiply with group elements
     // output type: -> i32
     (col("x").sum() * col("y"))
         .over([col("groups")])
-        .alias("x1")
+        .alias("x1");
     // sum within a group and multiply with group elements
     // and aggregate the group to a list
     // output type: -> ChunkedArray<i32>
     (col("x").sum() * col("y"))
         .list()
         .over([col("groups")])
-        .alias("x2")
+        .alias("x2");
     // note that it will require an explicit `list()` call
     // sum within a group and multiply with group elements
     // and aggregate the group to a list

--- a/docs/src/rust/user-guide/io/cloud-storage.rs
+++ b/docs/src/rust/user-guide/io/cloud-storage.rs
@@ -1,8 +1,4 @@
 // --8<-- [start:read_parquet]
-use std::borrow::Cow;
-
-use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_s3::{Client, Region};
 use polars::prelude::*;
 
 #[tokio::main]
@@ -10,17 +6,20 @@ async fn main() {
     let bucket = "<YOUR_BUCKET>";
     let path = "<YOUR_PATH>";
 
-    let config = aws_config::from_env().load().await;
-    let client = Client::new(&config);
+    let config = aws_config::load_from_env().await;
+    let client = aws_sdk_s3::Client::new(&config);
 
-    let req = client.get_object().bucket(bucket).key(path);
+    let object = client
+        .get_object()
+        .bucket(bucket)
+        .key(path)
+        .send()
+        .await
+        .unwrap();
 
-    let res = req.clone().send().await.unwrap();
-    let bytes = res.body.collect().await.unwrap();
-    let bytes = bytes.into_bytes();
+    let bytes = object.body.collect().await.unwrap().into_bytes();
 
     let cursor = std::io::Cursor::new(bytes);
-
     let df = CsvReader::new(cursor).finish().unwrap();
 
     println!("{:?}", df);

--- a/docs/src/rust/user-guide/io/csv.rs
+++ b/docs/src/rust/user-guide/io/csv.rs
@@ -9,6 +9,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .finish()
         .unwrap();
     // --8<-- [end:read]
+    println!("{}", df);
 
     // --8<-- [start:write]
     let mut df = df!(
@@ -22,8 +23,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [end:write]
 
     // --8<-- [start:scan]
-    let df = LazyCsvReader::new("./test.csv").finish().unwrap();
+    let lf = LazyCsvReader::new("./test.csv").finish().unwrap();
     // --8<-- [end:scan]
+    println!("{}", lf.collect()?);
 
     Ok(())
 }

--- a/docs/src/rust/user-guide/io/json.rs
+++ b/docs/src/rust/user-guide/io/json.rs
@@ -7,11 +7,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut file = std::fs::File::open("docs/data/path.json").unwrap();
     let df = JsonReader::new(&mut file).finish().unwrap();
     // --8<-- [end:read]
+    println!("{}", df);
 
     // --8<-- [start:readnd]
     let mut file = std::fs::File::open("docs/data/path.json").unwrap();
     let df = JsonLineReader::new(&mut file).finish().unwrap();
     // --8<-- [end:readnd]
+    println!("{}", df);
 
     // --8<-- [start:write]
     let mut df = df!(
@@ -36,10 +38,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [end:write]
 
     // --8<-- [start:scan]
-    let df = LazyJsonLineReader::new("docs/data/path.json".to_string())
+    let lf = LazyJsonLineReader::new("docs/data/path.json")
         .finish()
         .unwrap();
     // --8<-- [end:scan]
+    println!("{}", lf.collect()?);
 
     Ok(())
 }

--- a/docs/src/rust/user-guide/io/parquet.rs
+++ b/docs/src/rust/user-guide/io/parquet.rs
@@ -6,6 +6,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let df = ParquetReader::new(&mut file).finish().unwrap();
     // --8<-- [end:read]
+    println!("{}", df);
 
     // --8<-- [start:write]
     let mut df = df!(
@@ -20,8 +21,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // --8<-- [start:scan]
     let args = ScanArgsParquet::default();
-    let df = LazyFrame::scan_parquet("./file.parquet", args).unwrap();
+    let lf = LazyFrame::scan_parquet("./file.parquet", args).unwrap();
     // --8<-- [end:scan]
+    println!("{}", lf.collect()?);
 
     Ok(())
 }

--- a/docs/src/rust/user-guide/transformations/time-series/filter.rs
+++ b/docs/src/rust/user-guide/transformations/time-series/filter.rs
@@ -45,7 +45,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     .with_column(
         col("ts")
             .str()
-            .to_date(StrptimeOptions::default(), lit("raise")),
+            .to_date(StrptimeOptions::default()),
     )
     .collect()?;
 

--- a/docs/src/rust/user-guide/transformations/time-series/filter.rs
+++ b/docs/src/rust/user-guide/transformations/time-series/filter.rs
@@ -42,11 +42,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	"ts"=> &["-1300-05-23", "-1400-03-02"],
 	"values"=> &[3, 4])?
     .lazy()
-    .with_column(
-        col("ts")
-            .str()
-            .to_date(StrptimeOptions::default()),
-    )
+    .with_column(col("ts").str().to_date(StrptimeOptions::default()))
     .collect()?;
 
     let negative_dates_filtered_df = negative_dates_df

--- a/docs/src/rust/user-guide/transformations/time-series/parsing.rs
+++ b/docs/src/rust/user-guide/transformations/time-series/parsing.rs
@@ -23,9 +23,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let df = df
         .clone()
         .lazy()
-        .with_columns([col("Date")
-            .str()
-            .to_date(StrptimeOptions::default())])
+        .with_columns([col("Date").str().to_date(StrptimeOptions::default())])
         .collect()?;
     println!("{}", &df);
     // --8<-- [end:cast]

--- a/docs/src/rust/user-guide/transformations/time-series/parsing.rs
+++ b/docs/src/rust/user-guide/transformations/time-series/parsing.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .lazy()
         .with_columns([col("Date")
             .str()
-            .to_date(StrptimeOptions::default(), lit("raise"))])
+            .to_date(StrptimeOptions::default())])
         .collect()?;
     println!("{}", &df);
     // --8<-- [end:cast]
@@ -58,7 +58,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let q = col("date")
         .str()
         .to_datetime(
-            TimeUnit::Microseconds,
+            Some(TimeUnit::Microseconds),
             None,
             StrptimeOptions {
                 format: Some("%Y-%m-%dT%H:%M:%S%z".to_string()),

--- a/docs/src/rust/user-guide/transformations/time-series/resampling.rs
+++ b/docs/src/rust/user-guide/transformations/time-series/resampling.rs
@@ -1,20 +1,27 @@
 // --8<-- [start:setup]
 use chrono::prelude::*;
-use polars::io::prelude::*;
 use polars::prelude::*;
-use polars::time::prelude::*;
 // --8<-- [end:setup]
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [start:df]
-    let df = df!(
-    "time" => date_range(
+    let time = polars::time::date_range(
         "time",
-        NaiveDate::from_ymd_opt(2021, 12, 16).unwrap().and_hms_opt(0, 0, 0).unwrap(),
-        NaiveDate::from_ymd_opt(2021, 12, 16).unwrap().and_hms_opt(3, 0, 0).unwrap(),
+        NaiveDate::from_ymd_opt(2021, 12, 16)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap(),
+        NaiveDate::from_ymd_opt(2021, 12, 16)
+            .unwrap()
+            .and_hms_opt(3, 0, 0)
+            .unwrap(),
         Duration::parse("30m"),
         ClosedWindow::Both,
-        TimeUnit::Milliseconds, None)?,
+        TimeUnit::Milliseconds,
+        None,
+    )?;
+    let df = df!(
+        "time" => time,
         "groups" => &["a", "a", "a", "b", "b", "a", "a"],
         "values" => &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
     )?;

--- a/docs/src/rust/user-guide/transformations/time-series/timezones.rs
+++ b/docs/src/rust/user-guide/transformations/time-series/timezones.rs
@@ -9,14 +9,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let time_zones_df = DataFrame::new(vec![tz_naive])?
         .lazy()
         .select([col("tz_naive").str().to_datetime(
-            TimeUnit::Milliseconds,
+            Some(TimeUnit::Milliseconds),
             None,
             StrptimeOptions::default(),
             lit("raise"),
         )])
         .with_columns([col("tz_naive")
             .dt()
-            .replace_time_zone(Some("UTC".to_string()), None)
+            .replace_time_zone(Some("UTC".to_string()), lit("raise"))
             .alias("tz_aware")])
         .collect()?;
 
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .select([
             col("tz_aware")
                 .dt()
-                .replace_time_zone(Some("Europe/Brussels".to_string()), None)
+                .replace_time_zone(Some("Europe/Brussels".to_string()), lit("raise"))
                 .alias("replace time zone"),
             col("tz_aware")
                 .dt()
@@ -37,7 +37,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .alias("convert time zone"),
             col("tz_aware")
                 .dt()
-                .replace_time_zone(None, None)
+                .replace_time_zone(None, lit("raise"))
                 .alias("unset time zone"),
         ])
         .collect()?;


### PR DESCRIPTION
Closes [#11112](https://github.com/pola-rs/polars/issues/11112)

#### Changes

* Make the `docs/src/rust` folder into a crate called `polars-doc-examples`. Add all the scripts in the folder as `bin` targets.
* Add the crate to the workspace as a non-default member
* Run clippy on all doc examples and fix them
* Fix some feature flags in the Rust code
* Expose `AsofJoinBy` in the `polars` prelude (this was used in the example but not actually publically available)