### PR TITLE
fix: expr_output_name include literal

### DIFF
--- a/crates/polars-lazy/src/physical_plan/expressions/literal.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/literal.rs
@@ -4,6 +4,7 @@ use std::ops::Deref;
 use polars_core::frame::group_by::GroupsProxy;
 use polars_core::prelude::*;
 use polars_core::utils::NoNull;
+use polars_plan::dsl::consts::LITERAL_NAME;
 
 use crate::physical_plan::state::ExecutionState;
 use crate::prelude::*;
@@ -21,25 +22,24 @@ impl PhysicalExpr for LiteralExpr {
         Some(&self.1)
     }
     fn evaluate(&self, _df: &DataFrame, _state: &ExecutionState) -> PolarsResult<Series> {
-        const NAME: &str = "literal";
         use LiteralValue::*;
         let s = match &self.0 {
             #[cfg(feature = "dtype-i8")]
-            Int8(v) => Int8Chunked::full(NAME, *v, 1).into_series(),
+            Int8(v) => Int8Chunked::full(LITERAL_NAME, *v, 1).into_series(),
             #[cfg(feature = "dtype-i16")]
-            Int16(v) => Int16Chunked::full(NAME, *v, 1).into_series(),
-            Int32(v) => Int32Chunked::full(NAME, *v, 1).into_series(),
-            Int64(v) => Int64Chunked::full(NAME, *v, 1).into_series(),
+            Int16(v) => Int16Chunked::full(LITERAL_NAME, *v, 1).into_series(),
+            Int32(v) => Int32Chunked::full(LITERAL_NAME, *v, 1).into_series(),
+            Int64(v) => Int64Chunked::full(LITERAL_NAME, *v, 1).into_series(),
             #[cfg(feature = "dtype-u8")]
-            UInt8(v) => UInt8Chunked::full(NAME, *v, 1).into_series(),
+            UInt8(v) => UInt8Chunked::full(LITERAL_NAME, *v, 1).into_series(),
             #[cfg(feature = "dtype-u16")]
-            UInt16(v) => UInt16Chunked::full(NAME, *v, 1).into_series(),
-            UInt32(v) => UInt32Chunked::full(NAME, *v, 1).into_series(),
-            UInt64(v) => UInt64Chunked::full(NAME, *v, 1).into_series(),
-            Float32(v) => Float32Chunked::full(NAME, *v, 1).into_series(),
-            Float64(v) => Float64Chunked::full(NAME, *v, 1).into_series(),
-            Boolean(v) => BooleanChunked::full(NAME, *v, 1).into_series(),
-            Null => polars_core::prelude::Series::new_null(NAME, 1),
+            UInt16(v) => UInt16Chunked::full(LITERAL_NAME, *v, 1).into_series(),
+            UInt32(v) => UInt32Chunked::full(LITERAL_NAME, *v, 1).into_series(),
+            UInt64(v) => UInt64Chunked::full(LITERAL_NAME, *v, 1).into_series(),
+            Float32(v) => Float32Chunked::full(LITERAL_NAME, *v, 1).into_series(),
+            Float64(v) => Float64Chunked::full(LITERAL_NAME, *v, 1).into_series(),
+            Boolean(v) => BooleanChunked::full(LITERAL_NAME, *v, 1).into_series(),
+            Null => polars_core::prelude::Series::new_null(LITERAL_NAME, 1),
             Range {
                 low,
                 high,
@@ -75,20 +75,24 @@ impl PhysicalExpr for LiteralExpr {
                     InvalidOperation: "datatype `{}` is not supported as range", dt
                 ),
             },
-            Utf8(v) => Utf8Chunked::full(NAME, v, 1).into_series(),
-            Binary(v) => BinaryChunked::full(NAME, v, 1).into_series(),
+            Utf8(v) => Utf8Chunked::full(LITERAL_NAME, v, 1).into_series(),
+            Binary(v) => BinaryChunked::full(LITERAL_NAME, v, 1).into_series(),
             #[cfg(feature = "dtype-datetime")]
-            DateTime(timestamp, tu, tz) => Int64Chunked::full(NAME, *timestamp, 1)
+            DateTime(timestamp, tu, tz) => Int64Chunked::full(LITERAL_NAME, *timestamp, 1)
                 .into_datetime(*tu, tz.clone())
                 .into_series(),
             #[cfg(feature = "dtype-duration")]
-            Duration(v, tu) => Int64Chunked::full(NAME, *v, 1)
+            Duration(v, tu) => Int64Chunked::full(LITERAL_NAME, *v, 1)
                 .into_duration(*tu)
                 .into_series(),
             #[cfg(feature = "dtype-date")]
-            Date(v) => Int32Chunked::full(NAME, *v, 1).into_date().into_series(),
+            Date(v) => Int32Chunked::full(LITERAL_NAME, *v, 1)
+                .into_date()
+                .into_series(),
             #[cfg(feature = "dtype-datetime")]
-            Time(v) => Int64Chunked::full(NAME, *v, 1).into_time().into_series(),
+            Time(v) => Int64Chunked::full(LITERAL_NAME, *v, 1)
+                .into_time()
+                .into_series(),
             Series(series) => series.deref().clone(),
         };
         Ok(s)

--- a/crates/polars-plan/src/dsl/consts.rs
+++ b/crates/polars-plan/src/dsl/consts.rs
@@ -1,1 +1,3 @@
 pub const COUNT: &str = "count";
+
+pub const LITERAL_NAME: &str = "literal";

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -8,7 +8,7 @@ use smartstring::alias::String as SmartString;
 
 use crate::logical_plan::iterator::ArenaExprIter;
 use crate::logical_plan::Context;
-use crate::prelude::consts::COUNT;
+use crate::prelude::consts::{COUNT, LITERAL_NAME};
 use crate::prelude::*;
 
 /// Utility to write comma delimited strings
@@ -182,6 +182,12 @@ pub fn expr_output_name(expr: &Expr) -> PolarsResult<Arc<str>> {
                 "this expression may produce multiple output names"
             ),
             Expr::Count => return Ok(Arc::from(COUNT)),
+            Expr::Literal(val) => {
+                return match val {
+                    LiteralValue::Series(s) => Ok(Arc::from(s.name())),
+                    _ => Ok(Arc::from(LITERAL_NAME)),
+                }
+            },
             _ => {},
         }
     }

--- a/py-polars/tests/unit/namespaces/test_meta.py
+++ b/py-polars/tests/unit/namespaces/test_meta.py
@@ -85,3 +85,14 @@ def test_meta_tree_format(namespace_files_path: Path) -> None:
         result = e.meta.tree_format(return_as_string=True)
         result = "\n".join(s.rstrip() for s in result.split("\n"))
         assert result.strip() == tree_fmt.strip()
+
+
+def test_literal_output_name() -> None:
+    e = pl.lit(1)
+    assert e.meta.output_name() == "literal"
+
+    e = pl.lit(pl.Series("abc", [1, 2, 3]))
+    assert e.meta.output_name() == "abc"
+
+    e = pl.lit(pl.Series([1, 2, 3]))
+    assert e.meta.output_name() == ""

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -760,3 +760,12 @@ def test_rolling_by_1mo_saturating_12216() -> None:
         }
     )
     assert_frame_equal(result, expected)
+
+
+def test_index_expr_with_literal() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]}).sort("a")
+    out = df.rolling(index_column=(5 * pl.col("a")).set_sorted(), period="2i").agg(
+        pl.col("b")
+    )
+    expected = pl.DataFrame({"literal": [5, 10, 15], "b": [["a"], ["b"], ["c"]]})
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
This fix the bug posted in comment(https://github.com/pola-rs/polars/issues/12326#issuecomment-1803146105). Also fixes the original issue #12326.