### PR TITLE
feat(python): Extend quantile label precision in `describe`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4188,7 +4188,7 @@ class DataFrame:
         percentile_exprs = []
         for p in parse_percentiles(percentiles):
             percentile_exprs.append(F.all().quantile(p).name.prefix(f"{p}:"))
-            metrics.append(f"{p:.0%}")
+            metrics.append(f"{p:.000%}")
         metrics.append("max")
 
         # execute metrics in parallel


### PR DESCRIPTION
Having 99.99% rounded to 100% was bothering me. Haven't tested, but I don't see why this would break anything.