### PR TITLE
fix: Do not cast lit if has same dtype

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -681,6 +681,9 @@ fn inline_cast(input: &AExpr, dtype: &DataType, strict: bool) -> PolarsResult<Op
                 let Some(av) = lv.to_anyvalue() else {
                     return Ok(None);
                 };
+                if dtype == &av.dtype() {
+                    return Ok(Some(input.clone()));
+                }
                 match (av, dtype) {
                     // casting null always remains null
                     (AnyValue::Null, _) => return Ok(None),


### PR DESCRIPTION
This fixes #12340.

I'm not introduce the support of casting `Utf8` `AnyValue` to other dtypes in this PR(perhaps we can consider it in future PR). Our release build has a fallback mechanism here, so it will not cause any problems indeed. But I think our goal should be to gradually remove the fallback, so this may be one of the steps.