### PR TITLE
fix(python): ignore IDE-mediated DeprecationWarning when debugging tests under 3.12

### DIFF
--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -214,6 +214,8 @@ filterwarnings = [
   # Ignore warnings issued by dependency internals
   "ignore:.*is_sparse is deprecated.*:FutureWarning",
   "ignore:FigureCanvasAgg is non-interactive:UserWarning",
+  # Introspection under PyCharm IDE can generate this in 3.12
+  "ignore:.*co_lnotab is deprecated, use co_lines.*:DeprecationWarning",
 ]
 xfail_strict = true
 


### PR DESCRIPTION
Ref: #12314.

Closing in on the last two `BytecodeParser` test failures - had to add this "filterwarnings" entry in order to debug tests under py3.12, as PyCharm introspection would trigger a _"co_lnotab is deprecated, use co_lines instead"_ `DeprecationWarning`.