### PR TITLE
ci(python): Fix ruff linting invocation

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -28,11 +28,14 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r requirements-lint.txt
 
-      - name: Lint Python
-        run: |
-          ruff check --diff .
-          ruff format --diff .
-          blackdoc --diff .
+      - name: Run ruff linter
+        run: ruff check --no-fix .
+
+      - name: Run ruff formatter
+        run: ruff format --diff .
+
+      - name: Run blackdoc
+        run: blackdoc --diff .
 
   mypy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Turns out `ruff check --diff` will exit 0 if there are errors but Ruff cannot autofix them. This is undesirable. Passing `--no-fix` will exit non-zero if there are any lint failures.