### PR TITLE
depr(rust!,python): Rename `write_csv` parameter `has_header` to `include_header`

### DIFF
--- a/crates/polars-io/src/csv/mod.rs
+++ b/crates/polars-io/src/csv/mod.rs
@@ -17,7 +17,7 @@
 //!     let mut file = File::create("example.csv").expect("could not create file");
 //!
 //!     CsvWriter::new(&mut file)
-//!     .has_header(true)
+//!     .include_header(true)
 //!     .with_separator(b',')
 //!     .finish(df)
 //! }

--- a/crates/polars-io/src/csv/write.rs
+++ b/crates/polars-io/src/csv/write.rs
@@ -64,8 +64,8 @@ where
     W: Write,
 {
     /// Set whether to write headers.
-    pub fn has_header(mut self, has_header: bool) -> Self {
-        self.header = has_header;
+    pub fn include_header(mut self, include_header: bool) -> Self {
+        self.header = include_header;
         self
     }
 

--- a/crates/polars-pipe/src/executors/sinks/file_sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/file_sink.rs
@@ -181,7 +181,7 @@ impl CsvSink {
     pub fn new(path: &Path, options: CsvWriterOptions, schema: &Schema) -> PolarsResult<FilesSink> {
         let file = std::fs::File::create(path)?;
         let writer = CsvWriter::new(file)
-            .has_header(options.has_header)
+            .include_header(options.include_header)
             .with_separator(options.serialize_options.separator)
             .with_line_terminator(options.serialize_options.line_terminator)
             .with_quote_char(options.serialize_options.quote_char)

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -78,7 +78,7 @@ pub struct IpcWriterOptions {
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CsvWriterOptions {
-    pub has_header: bool,
+    pub include_header: bool,
     pub batch_size: usize,
     pub maintain_order: bool,
     pub serialize_options: SerializeOptions,

--- a/crates/polars/src/docs/eager.rs
+++ b/crates/polars/src/docs/eager.rs
@@ -576,7 +576,7 @@
 //!
 //! // write DataFrame to file
 //! CsvWriter::new(&mut file)
-//!     .has_header(true)
+//!     .include_header(true)
 //!     .with_separator(b',')
 //!     .finish(df);
 //! # Ok(())

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -12,7 +12,7 @@ fn write_csv() {
     let mut df = create_df();
 
     CsvWriter::new(&mut buf)
-        .has_header(true)
+        .include_header(true)
         .finish(&mut df)
         .expect("csv written");
     let csv = std::str::from_utf8(&buf).unwrap();
@@ -20,7 +20,7 @@ fn write_csv() {
 
     let mut buf: Vec<u8> = Vec::new();
     CsvWriter::new(&mut buf)
-        .has_header(false)
+        .include_header(false)
         .finish(&mut df)
         .expect("csv written");
     let csv = std::str::from_utf8(&buf).unwrap();
@@ -28,7 +28,7 @@ fn write_csv() {
 
     let mut buf: Vec<u8> = Vec::new();
     CsvWriter::new(&mut buf)
-        .has_header(false)
+        .include_header(false)
         .with_line_terminator("\r\n".into())
         .finish(&mut df)
         .expect("csv written");

--- a/docs/src/rust/user-guide/basics/reading-writing.rs
+++ b/docs/src/rust/user-guide/basics/reading-writing.rs
@@ -22,7 +22,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [start:csv]
     let mut file = File::create("docs/data/output.csv").expect("could not create file");
     CsvWriter::new(&mut file)
-        .has_header(true)
+        .include_header(true)
         .with_separator(b',')
         .finish(&mut df)?;
     let df_csv = CsvReader::from_path("docs/data/output.csv")?
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [start:csv2]
     let mut file = File::create("docs/data/output.csv").expect("could not create file");
     CsvWriter::new(&mut file)
-        .has_header(true)
+        .include_header(true)
         .with_separator(b',')
         .finish(&mut df)?;
     let df_csv = CsvReader::from_path("docs/data/output.csv")?

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3124,7 +3124,12 @@ class DataFrame:
         # finally, inject any sparklines into the table
         for column, params in (sparklines or {}).items():
             _xl_inject_sparklines(
-                ws, df, table_start, column, include_header=include_header, params=params
+                ws,
+                df,
+                table_start,
+                column,
+                include_header=include_header,
+                params=params,
             )
 
         # worksheet options

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2455,7 +2455,7 @@ class DataFrame:
         self,
         file: None = None,
         *,
-        has_header: bool = ...,
+        include_header: bool = ...,
         separator: str = ...,
         line_terminator: str = ...,
         quote_char: str = ...,
@@ -2474,7 +2474,7 @@ class DataFrame:
         self,
         file: BytesIO | TextIOWrapper | str | Path,
         *,
-        has_header: bool = ...,
+        include_header: bool = ...,
         separator: str = ...,
         line_terminator: str = ...,
         quote_char: str = ...,
@@ -2489,11 +2489,12 @@ class DataFrame:
         ...
 
     @deprecate_renamed_parameter("quote", "quote_char", version="0.19.8")
+    @deprecate_renamed_parameter("has_header", "include_header", version="0.19.13")
     def write_csv(
         self,
         file: BytesIO | TextIOWrapper | str | Path | None = None,
         *,
-        has_header: bool = True,
+        include_header: bool = True,
         separator: str = ",",
         line_terminator: str = "\n",
         quote_char: str = '"',
@@ -2513,7 +2514,7 @@ class DataFrame:
         file
             File path or writeable file-like object to which the result will be written.
             If set to `None` (default), the output is returned as a string instead.
-        has_header
+        include_header
             Whether to include header in the CSV output.
         separator
             Separate CSV fields with this symbol.
@@ -2590,7 +2591,7 @@ class DataFrame:
 
         self._df.write_csv(
             file,
-            has_header,
+            include_header,
             ord(separator),
             line_terminator,
             ord(quote_char),
@@ -2650,6 +2651,7 @@ class DataFrame:
 
         self._df.write_avro(file, compression, name)
 
+    @deprecate_renamed_parameter("has_header", "include_header", version="0.19.13")
     def write_excel(
         self,
         workbook: Workbook | BytesIO | Path | str | None = None,
@@ -2669,7 +2671,7 @@ class DataFrame:
         sparklines: dict[str, Sequence[str] | dict[str, Any]] | None = None,
         formulas: dict[str, str | dict[str, str]] | None = None,
         float_precision: int = 3,
-        has_header: bool = True,
+        include_header: bool = True,
         autofilter: bool = True,
         autofit: bool = False,
         hidden_columns: Sequence[str] | SelectorType | None = None,
@@ -2760,7 +2762,7 @@ class DataFrame:
             rows (if providing a dictionary) or all rows (if providing an integer) that
             intersect with the table body (including any header and total row) in
             integer pixel units. Note that `row_index` starts at zero and will be
-            the header row (unless `has_headers` is False).
+            the header row (unless `include_header` is False).
         sparklines : dict
             A `{colname:list,}` or `{colname:dict,}` dictionary defining one or more
             sparklines to be written into a new column in the table.
@@ -2789,7 +2791,7 @@ class DataFrame:
         float_precision : int
             Default number of decimals displayed for floating point columns (note that
             this is purely a formatting directive; the actual values are not rounded).
-        has_header : bool
+        include_header : bool
             Indicate if the table should be created with a header row.
         autofilter : bool
             If the table has headers, provide autofilter capability.
@@ -3049,20 +3051,20 @@ class DataFrame:
             table_start[0]
             + len(df)
             + int(is_empty)
-            - int(not has_header)
+            - int(not include_header)
             + int(bool(column_totals)),
             table_start[1] + len(df.columns) - 1,
         )
 
         # write table structure and formats into the target sheet
-        if not is_empty or has_header:
+        if not is_empty or include_header:
             ws.add_table(
                 *table_start,
                 *table_finish,
                 {
                     "style": table_style,
                     "columns": table_columns,
-                    "header_row": has_header,
+                    "header_row": include_header,
                     "autofilter": autofilter,
                     "total_row": bool(column_totals) and not is_empty,
                     "name": table_name,
@@ -3072,7 +3074,7 @@ class DataFrame:
 
             # write data into the table range, column-wise
             if not is_empty:
-                column_start = [table_start[0] + int(has_header), table_start[1]]
+                column_start = [table_start[0] + int(include_header), table_start[1]]
                 for c in df.columns:
                     if c in self.columns:
                         ws.write_column(
@@ -3089,7 +3091,7 @@ class DataFrame:
                     ws=ws,
                     conditional_formats=conditional_formats,
                     table_start=table_start,
-                    has_header=has_header,
+                    include_header=include_header,
                     format_cache=fmt_cache,
                 )
         # additional column-level properties
@@ -3122,7 +3124,7 @@ class DataFrame:
         # finally, inject any sparklines into the table
         for column, params in (sparklines or {}).items():
             _xl_inject_sparklines(
-                ws, df, table_start, column, has_header=has_header, params=params
+                ws, df, table_start, column, include_header=include_header, params=params
             )
 
         # worksheet options

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -559,9 +559,9 @@ def read_csv_batched(
     ...     for group, df in partition_dfs.items():
     ...         if group in seen_groups:
     ...             with open(f"./data/{group}.csv", "a") as fh:
-    ...                 fh.write(df.write_csv(file=None, has_header=False))
+    ...                 fh.write(df.write_csv(file=None, include_header=False))
     ...         else:
-    ...             df.write_csv(file=f"./data/{group}.csv", has_header=True)
+    ...             df.write_csv(file=f"./data/{group}.csv", include_header=True)
     ...         seen_groups.add(group)
     ...
     ...     batches = reader.next_batches(100)

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -212,10 +212,14 @@ def _xl_column_multi_range(
     m: dict[str, Any] = {}
     if _adjacent_cols(df, cols, min_max=m):
         return _xl_column_range(
-            df, table_start, (m["min"]["idx"], m["max"]["idx"]), include_header=include_header
+            df,
+            table_start,
+            (m["min"]["idx"], m["max"]["idx"]),
+            include_header=include_header,
         )
     return " ".join(
-        _xl_column_range(df, table_start, col, include_header=include_header) for col in cols
+        _xl_column_range(df, table_start, col, include_header=include_header)
+        for col in cols
     )
 
 

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -110,7 +110,7 @@ def _xl_apply_conditional_formats(
     *,
     conditional_formats: ConditionalFormatDict,
     table_start: tuple[int, int],
-    has_header: bool,
+    include_header: bool,
     format_cache: _XLFormatCache,
 ) -> None:
     """Take all conditional formatting options and apply them to the table/range."""
@@ -129,17 +129,17 @@ def _xl_apply_conditional_formats(
                 fmt = {"type": fmt}
             if isinstance(cols, str):
                 col_range = _xl_column_range(
-                    df, table_start, cols, has_header=has_header
+                    df, table_start, cols, include_header=include_header
                 )
             else:
                 col_range = _xl_column_multi_range(
-                    df, table_start, cols, has_header=has_header
+                    df, table_start, cols, include_header=include_header
                 )
                 if " " in col_range:
                     col = next(iter(cols))
                     fmt["multi_range"] = col_range
                     col_range = _xl_column_range(
-                        df, table_start, col, has_header=has_header
+                        df, table_start, col, include_header=include_header
                     )
 
             if "format" in fmt:
@@ -160,7 +160,7 @@ def _xl_column_range(
     table_start: tuple[int, int],
     col: str | tuple[int, int],
     *,
-    has_header: bool,
+    include_header: bool,
     as_range: Literal[True] = ...,
 ) -> str:
     ...
@@ -172,7 +172,7 @@ def _xl_column_range(
     table_start: tuple[int, int],
     col: str | tuple[int, int],
     *,
-    has_header: bool,
+    include_header: bool,
     as_range: Literal[False],
 ) -> tuple[int, int, int, int]:
     ...
@@ -183,12 +183,12 @@ def _xl_column_range(
     table_start: tuple[int, int],
     col: str | tuple[int, int],
     *,
-    has_header: bool,
+    include_header: bool,
     as_range: bool = True,
 ) -> tuple[int, int, int, int] | str:
     """Return the excel sheet range of a named column, accounting for all offsets."""
     col_start = (
-        table_start[0] + int(has_header),
+        table_start[0] + int(include_header),
         table_start[1] + df.find_idx_by_name(col) if isinstance(col, str) else col[0],
     )
     col_finish = (
@@ -206,16 +206,16 @@ def _xl_column_multi_range(
     table_start: tuple[int, int],
     cols: Iterable[str],
     *,
-    has_header: bool,
+    include_header: bool,
 ) -> str:
     """Return column ranges as an xlsxwriter 'multi_range' string, or spanning range."""
     m: dict[str, Any] = {}
     if _adjacent_cols(df, cols, min_max=m):
         return _xl_column_range(
-            df, table_start, (m["min"]["idx"], m["max"]["idx"]), has_header=has_header
+            df, table_start, (m["min"]["idx"], m["max"]["idx"]), include_header=include_header
         )
     return " ".join(
-        _xl_column_range(df, table_start, col, has_header=has_header) for col in cols
+        _xl_column_range(df, table_start, col, include_header=include_header) for col in cols
     )
 
 
@@ -272,7 +272,7 @@ def _xl_inject_sparklines(
     table_start: tuple[int, int],
     col: str,
     *,
-    has_header: bool,
+    include_header: bool,
     params: Sequence[str] | dict[str, Any],
 ) -> None:
     """Inject sparklines into (previously-created) empty table columns."""
@@ -286,7 +286,7 @@ def _xl_inject_sparklines(
         raise RuntimeError("sparkline data range/cols must all be adjacent")
 
     spk_row, spk_col, _, _ = _xl_column_range(
-        df, table_start, col, has_header=has_header, as_range=False
+        df, table_start, col, include_header=include_header, as_range=False
     )
     data_start_col = table_start[1] + m["min"]["idx"]
     data_end_col = table_start[1] + m["max"]["idx"]

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2105,11 +2105,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         )
 
     @deprecate_renamed_parameter("quote", "quote_char", version="0.19.8")
+    @deprecate_renamed_parameter("has_header", "include_header", version="0.19.13")
     def sink_csv(
         self,
         path: str | Path,
         *,
-        has_header: bool = True,
+        include_header: bool = True,
         separator: str = ",",
         line_terminator: str = "\n",
         quote_char: str = '"',
@@ -2137,7 +2138,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ----------
         path
             File path to which the file should be written.
-        has_header
+        include_header
             Whether to include header in the CSV output.
         separator
             Separate CSV fields with this symbol.
@@ -2224,7 +2225,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return lf.sink_csv(
             path=path,
-            has_header=has_header,
+            include_header=include_header,
             separator=ord(separator),
             line_terminator=line_terminator,
             quote_char=ord(quote_char),

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -600,7 +600,7 @@ impl PyDataFrame {
         &mut self,
         py: Python,
         py_f: PyObject,
-        has_header: bool,
+        include_header: bool,
         separator: u8,
         line_terminator: String,
         quote_char: u8,
@@ -619,7 +619,7 @@ impl PyDataFrame {
                 let f = std::fs::File::create(s).unwrap();
                 // No need for a buffered writer, because the csv writer does internal buffering.
                 CsvWriter::new(f)
-                    .has_header(has_header)
+                    .include_header(include_header)
                     .with_separator(separator)
                     .with_line_terminator(line_terminator)
                     .with_quote_char(quote_char)
@@ -636,7 +636,7 @@ impl PyDataFrame {
         } else {
             let mut buf = get_file_like(py_f, true)?;
             CsvWriter::new(&mut buf)
-                .has_header(has_header)
+                .include_header(include_header)
                 .with_separator(separator)
                 .with_line_terminator(line_terminator)
                 .with_quote_char(quote_char)

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -577,12 +577,12 @@ impl PyLazyFrame {
     }
 
     #[cfg(all(feature = "streaming", feature = "csv"))]
-    #[pyo3(signature = (path, has_header, separator, line_terminator, quote_char, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style, maintain_order))]
+    #[pyo3(signature = (path, include_header, separator, line_terminator, quote_char, batch_size, datetime_format, date_format, time_format, float_precision, null_value, quote_style, maintain_order))]
     fn sink_csv(
         &self,
         py: Python,
         path: PathBuf,
-        has_header: bool,
+        include_header: bool,
         separator: u8,
         line_terminator: String,
         quote_char: u8,
@@ -611,7 +611,7 @@ impl PyLazyFrame {
         };
 
         let options = CsvWriterOptions {
-            has_header,
+            include_header,
             maintain_order,
             batch_size,
             serialize_options,

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -444,7 +444,7 @@ def test_read_excel_all_sheets_with_sheet_name(path_xlsx: Path, engine: str) -> 
             "row_totals": {"tot": True},
             "hidden_columns": ["str"],
             "hide_gridlines": True,
-            "has_header": False,
+            "include_header": False,
         },
     ],
 )
@@ -458,7 +458,7 @@ def test_excel_round_trip(write_params: dict[str, Any]) -> None:
     )
     header_opts = (
         {}
-        if write_params.get("has_header", True)
+        if write_params.get("include_header", True)
         else {"has_header": False, "new_columns": ["dtm", "str", "val"]}
     )
     fmt_strptime = "%Y-%m-%d"

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -125,7 +125,7 @@ def test_sink_csv_with_options() -> None:
     with unittest.mock.patch.object(df, "_ldf") as ldf:
         df.sink_csv(
             "path",
-            has_header=False,
+            include_header=False,
             separator=";",
             line_terminator="|",
             quote_char="$",
@@ -141,7 +141,7 @@ def test_sink_csv_with_options() -> None:
 
         ldf.optimization_toggle().sink_csv.assert_called_with(
             path="path",
-            has_header=False,
+            include_header=False,
             separator=ord(";"),
             line_terminator="|",
             quote_char=ord("$"),


### PR DESCRIPTION
This PR is a follow up on #12253

As a result of the discussion in the PR, `has_header` is renamed to `include_header`, because include sounds more suitable for writing side.
