### PR TITLE
fix(python,rust!): Fix `scan_csv` error type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3088,6 +3088,7 @@ dependencies = [
  "polars-ops",
  "polars-parquet",
  "polars-plan",
+ "polars-utils",
  "pyo3",
  "pyo3-built",
  "serde_json",

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -299,15 +299,7 @@ impl LogicalPlanBuilder {
         truncate_ragged_lines: bool,
     ) -> PolarsResult<Self> {
         let path = path.into();
-        let mut file = polars_utils::open_file(&path).map_err(|e| {
-            let path = path.to_string_lossy();
-            if path.len() > 88 {
-                let path: String = path.chars().skip(path.len() - 88).collect();
-                polars_err!(ComputeError: "error open file: ...{}, {}", path, e)
-            } else {
-                polars_err!(ComputeError: "error open file: {}, {}", path, e)
-            }
-        })?;
+        let mut file = polars_utils::open_file(&path)?;
 
         let paths = Arc::new([path]);
 

--- a/crates/polars-utils/src/io.rs
+++ b/crates/polars-utils/src/io.rs
@@ -10,6 +10,12 @@ where
 {
     std::fs::File::open(&path).map_err(|err| {
         let path = path.as_ref().to_string_lossy();
-        PolarsError::Io(Error::new(err.kind(), format!("{err}: {path}")))
+        let msg = if path.len() > 88 {
+            let truncated_path: String = path.chars().skip(path.len() - 88).collect();
+            format!("{err}: ...{truncated_path}")
+        } else {
+            format!("{err}: {path}")
+        };
+        PolarsError::Io(Error::new(err.kind(), msg))
     })
 }

--- a/crates/polars-utils/src/io.rs
+++ b/crates/polars-utils/src/io.rs
@@ -1,4 +1,5 @@
 use std::fs::File;
+use std::io::Error;
 use std::path::Path;
 
 use polars_error::*;
@@ -7,13 +8,11 @@ pub fn open_file<P>(path: P) -> PolarsResult<File>
 where
     P: AsRef<Path>,
 {
-    std::fs::File::open(&path).map_err(|e| {
+    std::fs::File::open(&path).map_err(|err| {
         let path = path.as_ref().to_string_lossy();
-        if path.len() > 88 {
-            let path: String = path.chars().skip(path.len() - 88).collect();
-            polars_err!(ComputeError: "error open file: ...{}, {}", path, e)
-        } else {
-            polars_err!(ComputeError: "error open file: {}, {}", path, e)
-        }
+        PolarsError::Io(Error::new(
+            err.kind(),
+            format!("error opening file: {path} ({err})"),
+        ))
     })
 }

--- a/crates/polars-utils/src/io.rs
+++ b/crates/polars-utils/src/io.rs
@@ -10,9 +10,6 @@ where
 {
     std::fs::File::open(&path).map_err(|err| {
         let path = path.as_ref().to_string_lossy();
-        PolarsError::Io(Error::new(
-            err.kind(),
-            format!("error opening file: {path} ({err})"),
-        ))
+        PolarsError::Io(Error::new(err.kind(), format!("{err}: {path}")))
     })
 }

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -15,6 +15,7 @@ polars-lazy = { path = "../crates/polars-lazy", default-features = false, featur
 polars-ops = { path = "../crates/polars-ops", default-features = false, features = ["convert_index"] }
 polars-parquet = { path = "../crates/polars-parquet", default-features = false, optional = true }
 polars-plan = { path = "../crates/polars-plan", default-features = false }
+polars-utils = { path = "../crates/polars-utils", default-features = false }
 
 ahash = { workspace = true }
 ciborium = { workspace = true }

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -8,14 +8,14 @@ name = "polars"
 crate-type = ["cdylib"]
 
 [dependencies]
-polars-algo = { path = "../crates/polars-algo", default-features = false }
-polars-core = { path = "../crates/polars-core", default-features = false, features = ["python"] }
-polars-error = { path = "../crates/polars-error" }
-polars-lazy = { path = "../crates/polars-lazy", default-features = false, features = ["python"] }
-polars-ops = { path = "../crates/polars-ops", default-features = false, features = ["convert_index"] }
-polars-parquet = { path = "../crates/polars-parquet", default-features = false, optional = true }
-polars-plan = { path = "../crates/polars-plan", default-features = false }
-polars-utils = { path = "../crates/polars-utils", default-features = false }
+polars-algo = { workspace = true }
+polars-core = { workspace = true, features = ["python"] }
+polars-error = { workspace = true }
+polars-lazy = { workspace = true, features = ["python"] }
+polars-ops = { workspace = true, features = ["convert_index"] }
+polars-parquet = { workspace = true, optional = true }
+polars-plan = { workspace = true }
+polars-utils = { workspace = true }
 
 ahash = { workspace = true }
 ciborium = { workspace = true }

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -190,13 +190,7 @@ pub enum EitherRustPythonFile {
 }
 
 fn no_such_file_err(file_path: &str) -> PyResult<()> {
-    let msg = if file_path.len() > 88 {
-        let file_path: String = file_path.chars().skip(file_path.len() - 88).collect();
-        format!("No such file or directory: ...{file_path}",)
-    } else {
-        format!("No such file or directory: {file_path}",)
-    };
-
+    let msg = format!("No such file or directory: {file_path}");
     Err(PyErr::new::<PyFileNotFoundError, _>(msg))
 }
 

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -3,10 +3,12 @@ use std::io;
 use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
 
 use polars::io::mmap::MmapBytesReader;
-use pyo3::exceptions::{PyFileNotFoundError, PyTypeError};
+use polars_utils::open_file;
+use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
 
+use crate::error::PyPolarsErr;
 use crate::prelude::resolve_homedir;
 
 #[derive(Clone)]
@@ -189,11 +191,6 @@ pub enum EitherRustPythonFile {
     Rust(BufReader<File>),
 }
 
-fn no_such_file_err(file_path: &str) -> PyResult<()> {
-    let msg = format!("No such file or directory: {file_path}");
-    Err(PyErr::new::<PyFileNotFoundError, _>(msg))
-}
-
 ///
 /// # Arguments
 /// * `truncate` - open or create a new file.
@@ -204,17 +201,12 @@ pub fn get_either_file(py_f: PyObject, truncate: bool) -> PyResult<EitherRustPyt
             let file_path = std::path::Path::new(&s);
             let file_path = resolve_homedir(file_path);
             let f = if truncate {
-                BufReader::new(File::create(file_path)?)
+                File::create(file_path)?
             } else {
-                match File::open(&file_path) {
-                    Ok(file) => BufReader::new(file),
-                    Err(_e) => {
-                        no_such_file_err(s)?;
-                        unreachable!();
-                    },
-                }
+                open_file(&file_path).map_err(PyPolarsErr::from)?
             };
-            Ok(EitherRustPythonFile::Rust(f))
+            let reader = BufReader::new(f);
+            Ok(EitherRustPythonFile::Rust(reader))
         } else {
             let f = PyFileLikeObject::with_requirements(py_f, !truncate, truncate, !truncate)?;
             Ok(EitherRustPythonFile::Py(f))
@@ -240,13 +232,7 @@ pub fn get_mmap_bytes_reader<'a>(py_f: &'a PyAny) -> PyResult<Box<dyn MmapBytesR
         let s = pstring.to_str()?;
         let p = std::path::Path::new(&s);
         let p = resolve_homedir(p);
-        let f = match File::open(p) {
-            Ok(file) => file,
-            Err(_e) => {
-                no_such_file_err(s)?;
-                unreachable!();
-            },
-        };
+        let f = open_file(p).map_err(PyPolarsErr::from)?;
         Ok(Box::new(f))
     }
     // a normal python file: with open(...) as f:.

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -3,7 +3,6 @@ use std::io;
 use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
 
 use polars::io::mmap::MmapBytesReader;
-use polars_utils::open_file;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
@@ -203,7 +202,7 @@ pub fn get_either_file(py_f: PyObject, truncate: bool) -> PyResult<EitherRustPyt
             let f = if truncate {
                 File::create(file_path)?
             } else {
-                open_file(&file_path).map_err(PyPolarsErr::from)?
+                polars_utils::open_file(&file_path).map_err(PyPolarsErr::from)?
             };
             let reader = BufReader::new(f);
             Ok(EitherRustPythonFile::Rust(reader))
@@ -232,7 +231,7 @@ pub fn get_mmap_bytes_reader<'a>(py_f: &'a PyAny) -> PyResult<Box<dyn MmapBytesR
         let s = pstring.to_str()?;
         let p = std::path::Path::new(&s);
         let p = resolve_homedir(p);
-        let f = open_file(p).map_err(PyPolarsErr::from)?;
+        let f = polars_utils::open_file(p).map_err(PyPolarsErr::from)?;
         Ok(Box::new(f))
     }
     // a normal python file: with open(...) as f:.

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -504,14 +504,6 @@ def test_file_buffer() -> None:
         pl.read_parquet(f)
 
 
-@pytest.mark.parametrize(
-    "read_function", [pl.read_parquet, pl.read_csv, pl.read_ipc, pl.read_avro]
-)
-def test_read_missing_file(read_function: Callable[[Any], pl.DataFrame]) -> None:
-    with pytest.raises(FileNotFoundError, match="fake_file"):
-        read_function("fake_file")
-
-
 def test_shift() -> None:
     df = pl.DataFrame({"A": ["a", "b", "c"], "B": [1, 3, 5]})
     a = df.shift(1)

--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -34,6 +34,15 @@ def test_read_missing_file(read_function: Callable[[Any], pl.DataFrame]) -> None
         read_function("fake_file_path")
 
 
+def test_read_missing_file_path_truncated() -> None:
+    content = "lskdfj".join(str(i) for i in range(25))
+    with pytest.raises(
+        FileNotFoundError,
+        match="\\.\\.\\.lskdfj14lskdfj15lskdfj16lskdfj17lskdfj18lskdfj19lskdfj20lskdfj21lskdfj22lskdfj23lskdfj24",
+    ):
+        pl.read_csv(content)
+
+
 def test_copy() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": ["a", None], "c": [True, False]})
     assert_frame_equal(copy.copy(df), df)

--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import sys
 from pathlib import Path
 from typing import Any, Callable, cast
 
@@ -24,10 +25,13 @@ from polars.testing import assert_frame_equal, assert_series_equal
     ],
 )
 def test_read_missing_file(read_function: Callable[[Any], pl.DataFrame]) -> None:
-    with pytest.raises(
-        FileNotFoundError, match="No such file or directory \\(os error 2\\): fake_file"
-    ):
-        read_function("fake_file")
+    match = "\\(os error 2\\): fake_file_path"
+    # The message associated with OS error 2 may differ per platform
+    if sys.platform == "linux":
+        match = "No such file or directory " + match
+
+    with pytest.raises(FileNotFoundError, match=match):
+        read_function("fake_file_path")
 
 
 def test_copy() -> None:

--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -2,10 +2,32 @@ from __future__ import annotations
 
 import copy
 from pathlib import Path
-from typing import cast
+from typing import Any, Callable, cast
+
+import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
+
+
+@pytest.mark.parametrize(
+    "read_function",
+    [
+        pl.read_csv,
+        pl.read_ipc,
+        pl.read_json,
+        pl.read_parquet,
+        pl.read_avro,
+        pl.scan_csv,
+        pl.scan_ipc,
+        pl.scan_parquet,
+    ],
+)
+def test_read_missing_file(read_function: Callable[[Any], pl.DataFrame]) -> None:
+    with pytest.raises(
+        FileNotFoundError, match="No such file or directory \\(os error 2\\): fake_file"
+    ):
+        read_function("fake_file")
 
 
 def test_copy() -> None:

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -692,16 +692,3 @@ def test_non_existent_expr_inputs_in_lazy() -> None:
             .filter(pl.col("bar") == pl.col("foo"))
             .explain()
         )
-
-
-def test_read_csv_file_not_found_error() -> None:
-    with pytest.raises(FileNotFoundError, match="test.csv"):
-        pl.read_csv("test.csv")
-
-
-def test_scan_csv_file_not_found_error() -> None:
-    with pytest.raises(
-        FileNotFoundError,
-        match="No such file or directory \\(os error 2\\): test.csv",
-    ):
-        pl.scan_csv("test.csv")

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -702,6 +702,6 @@ def test_read_csv_file_not_found_error() -> None:
 def test_scan_csv_file_not_found_error() -> None:
     with pytest.raises(
         FileNotFoundError,
-        match=r"error opening file: test.csv \(No such file or directory \(os error 2\)\)",
+        match="No such file or directory \\(os error 2\\): test.csv",
     ):
         pl.scan_csv("test.csv")

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -453,15 +453,6 @@ def test_string_numeric_arithmetic_err() -> None:
         df.select(pl.col("s") + 1)
 
 
-def test_file_path_truncate_err() -> None:
-    content = "lskdfj".join(str(i) for i in range(25))
-    with pytest.raises(
-        FileNotFoundError,
-        match=r"\.\.\.lskdfj14lskdfj15lskdfj16lskdfj17lskdfj18lskdfj19lskdfj20lskdfj21lskdfj22lskdfj23lskdfj24",
-    ):
-        pl.read_csv(content)
-
-
 def test_ambiguous_filter_err() -> None:
     df = pl.DataFrame({"a": [None, "2", "3"], "b": [None, None, "z"]})
     with pytest.raises(
@@ -703,9 +694,14 @@ def test_non_existent_expr_inputs_in_lazy() -> None:
         )
 
 
+def test_read_csv_file_not_found_error() -> None:
+    with pytest.raises(FileNotFoundError, match="test.csv"):
+        pl.read_csv("test.csv")
+
+
 def test_scan_csv_file_not_found_error() -> None:
     with pytest.raises(
         FileNotFoundError,
-        match="error opening file: test.csv \\(No such file or directory \\(os error 2\\)\\)",
+        match=r"error opening file: test.csv \(No such file or directory \(os error 2\)\)",
     ):
         pl.scan_csv("test.csv")

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -701,3 +701,11 @@ def test_non_existent_expr_inputs_in_lazy() -> None:
             .filter(pl.col("bar") == pl.col("foo"))
             .explain()
         )
+
+
+def test_scan_csv_file_not_found_error() -> None:
+    with pytest.raises(
+        FileNotFoundError,
+        match="error opening file: test.csv \\(No such file or directory \\(os error 2\\)\\)",
+    ):
+        pl.scan_csv("test.csv")


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/10640

Inspired by @romanovacca 's work in #11976

#### Changes

* All IO functions now use the `open_file` util from polars-utils _(there were 3 competing implementations)_
* Revisit the `open_file` util to raise a Polars IO error rather than a ComputeError.
* Translate Polars IO errors to specific Python IO errors such as `FileNotFoundError`.
* ~Remove truncation of the path to 88 characters. Paths may be long sometimes, but I am definitely interested in the full path if it turns out there is an error.~