### PR TITLE
fix: Fix index column name of rolling/dynamic group by

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -907,9 +907,11 @@ impl LazyFrame {
         if let Expr::Column(name) = index_column {
             options.index_column = name.as_ref().into();
         } else {
-            let name = expr_output_name(&index_column).unwrap();
+            let output_field = index_column
+                .to_field(&self.schema().unwrap(), Context::Default)
+                .unwrap();
             return self.with_column(index_column).group_by_rolling(
-                Expr::Column(name),
+                Expr::Column(Arc::from(output_field.name().as_str())),
                 by,
                 options,
             );
@@ -950,9 +952,11 @@ impl LazyFrame {
         if let Expr::Column(name) = index_column {
             options.index_column = name.as_ref().into();
         } else {
-            let name = expr_output_name(&index_column).unwrap();
+            let output_field = index_column
+                .to_field(&self.schema().unwrap(), Context::Default)
+                .unwrap();
             return self.with_column(index_column).group_by_dynamic(
-                Expr::Column(name),
+                Expr::Column(Arc::from(output_field.name().as_str())),
                 by,
                 options,
             );

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -770,3 +770,14 @@ def test_index_expr_with_literal() -> None:
     )
     expected = pl.DataFrame({"literal": [5, 10, 15], "b": [["a"], ["b"], ["c"]]})
     assert_frame_equal(out, expected)
+
+
+def test_index_expr_output_name_12244() -> None:
+    df = pl.DataFrame({"A": [1, 2, 3]})
+
+    # pl.int_range's output name is: `int`.
+    out = df.rolling(pl.int_range(0, pl.count()), period="2i").agg("A")
+    assert out.to_dict(as_series=False) == {
+        "int": [0, 1, 2],
+        "A": [[1], [1, 2], [2, 3]],
+    }


### PR DESCRIPTION
We use `expr_output_name` to get the name of `index_column`, but it will not always return the correct name as the lack of `schema`. For example: `pl.int_range(pl.col("a"), 10)`'s output name is `int`, instead of `a`, this will result in wrong result or raise error(`ColumnNotFound`), but user have no idea about this...

This fixes #12244.