### PR TITLE
perf: reduce allocations in hash join

### DIFF
--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -128,7 +128,7 @@ where
                         results.push(asof_in_group::<T, A, &F>(
                             left_val,
                             right_val_arr,
-                            right_grp_idxs,
+                            right_grp_idxs.as_slice(),
                             &mut group_states,
                             &filter,
                         ));
@@ -195,7 +195,7 @@ where
                     results.push(asof_in_group::<T, A, &F>(
                         left_val,
                         right_val_arr,
-                        &right_grp_idxs[..],
+                        right_grp_idxs.as_slice(),
                         &mut group_states,
                         &filter,
                     ));

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys.rs
@@ -120,8 +120,7 @@ where
                 let partition_range = partition_offsets[p]..partition_offsets[p + 1];
                 let full_size = partition_range.len();
                 let mut conservative_size = _HASHMAP_INIT_SIZE.max(full_size / 64);
-                let mut hm: PlHashMap<T, IdxVec> =
-                    PlHashMap::with_capacity(conservative_size);
+                let mut hm: PlHashMap<T, IdxVec> = PlHashMap::with_capacity(conservative_size);
 
                 unsafe {
                     for i in partition_range {

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_inner.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_inner.rs
@@ -1,5 +1,6 @@
 use polars_core::utils::flatten;
 use polars_utils::hashing::{hash_to_partition, DirtyHash};
+use polars_utils::idx_vec::IdxVec;
 use polars_utils::iter::EnumerateIdxTrait;
 use polars_utils::sync::SyncPtr;
 
@@ -7,7 +8,7 @@ use super::*;
 
 pub(super) fn probe_inner<T, F, I>(
     probe: I,
-    hash_tbls: &[PlHashMap<T, Vec<IdxSize>>],
+    hash_tbls: &[PlHashMap<T, IdxVec>],
     results: &mut Vec<(IdxSize, IdxSize)>,
     local_offset: IdxSize,
     n_tables: usize,

--- a/crates/polars-utils/src/idx_vec.rs
+++ b/crates/polars-utils/src/idx_vec.rs
@@ -12,8 +12,8 @@ pub struct IdxVec {
     data: *mut IdxSize,
 }
 
-unsafe impl Send for IdxVec { }
-unsafe impl Sync for IdxVec { }
+unsafe impl Send for IdxVec {}
+unsafe impl Sync for IdxVec {}
 
 impl IdxVec {
     #[inline(always)]
@@ -49,6 +49,11 @@ impl IdxVec {
     #[inline(always)]
     pub fn len(&self) -> usize {
         self.len
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
     }
 
     #[inline(always)]
@@ -100,17 +105,17 @@ impl IdxVec {
     }
 
     pub fn iter(&self) -> std::slice::Iter<'_, IdxSize> {
-        self.as_slice().into_iter()
+        self.as_slice().iter()
     }
 
     pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, IdxSize> {
-        self.as_mut_slice().into_iter()
+        self.as_mut_slice().iter_mut()
     }
-    
+
     pub fn as_slice(&self) -> &[IdxSize] {
         self.as_ref()
     }
-    
+
     pub fn as_mut_slice(&mut self) -> &mut [IdxSize] {
         self.as_mut()
     }
@@ -124,7 +129,11 @@ impl Drop for IdxVec {
 
 impl Default for IdxVec {
     fn default() -> Self {
-        Self { len: 0, capacity: NonZeroUsize::new(1).unwrap(), data: std::ptr::null_mut() }
+        Self {
+            len: 0,
+            capacity: NonZeroUsize::new(1).unwrap(),
+            data: std::ptr::null_mut(),
+        }
     }
 }
 
@@ -136,8 +145,6 @@ impl AsRef<[IdxSize]> for IdxVec {
 
 impl AsMut<[IdxSize]> for IdxVec {
     fn as_mut(&mut self) -> &mut [IdxSize] {
-        unsafe {
-            std::slice::from_raw_parts_mut(self.data_ptr_mut(), self.len)
-        }
+        unsafe { std::slice::from_raw_parts_mut(self.data_ptr_mut(), self.len) }
     }
 }

--- a/crates/polars-utils/src/idx_vec.rs
+++ b/crates/polars-utils/src/idx_vec.rs
@@ -3,7 +3,7 @@ use std::num::NonZeroUsize;
 
 use crate::IdxSize;
 
-/// A type logically equivalent to Vec<IdxSize>, but which does not do a
+/// A type logically equivalent to `Vec<IdxSize>`, but which does not do a
 /// memory allocation until at least two elements have been pushed, storing the
 /// first element in the data pointer directly.
 pub struct IdxVec {

--- a/crates/polars-utils/src/idx_vec.rs
+++ b/crates/polars-utils/src/idx_vec.rs
@@ -1,0 +1,143 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::num::NonZeroUsize;
+
+use crate::IdxSize;
+
+/// A type logically equivalent to Vec<IdxSize>, but which does not do a
+/// memory allocation until at least two elements have been pushed, storing the
+/// first element in the data pointer directly.
+pub struct IdxVec {
+    len: usize,
+    capacity: NonZeroUsize,
+    data: *mut IdxSize,
+}
+
+unsafe impl Send for IdxVec { }
+unsafe impl Sync for IdxVec { }
+
+impl IdxVec {
+    #[inline(always)]
+    fn data_ptr_mut(&mut self) -> *mut IdxSize {
+        let external = self.data;
+        let inline = &mut self.data as *mut *mut IdxSize as *mut IdxSize;
+        if self.capacity.get() == 1 {
+            inline
+        } else {
+            external
+        }
+    }
+
+    #[inline(always)]
+    fn data_ptr(&self) -> *const IdxSize {
+        let external = self.data;
+        let inline = &self.data as *const *mut IdxSize as *mut IdxSize;
+        if self.capacity.get() == 1 {
+            inline
+        } else {
+            external
+        }
+    }
+
+    pub fn new() -> Self {
+        Self {
+            len: 0,
+            capacity: NonZeroUsize::new(1).unwrap(),
+            data: std::ptr::null_mut(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    #[inline(always)]
+    pub fn capacity(&self) -> usize {
+        self.capacity.get()
+    }
+
+    #[inline(always)]
+    pub fn push(&mut self, idx: IdxSize) {
+        if self.len == self.capacity.get() {
+            self.reserve(1);
+        }
+
+        unsafe {
+            self.data_ptr_mut().add(self.len).write(idx);
+            self.len += 1;
+        }
+    }
+
+    #[cold]
+    #[inline(never)]
+    pub fn reserve(&mut self, additional: usize) {
+        if self.len + additional > self.capacity.get() {
+            let double = self.capacity.get() * 2;
+            self.realloc(double.max(self.len + additional).max(8));
+        }
+    }
+
+    fn realloc(&mut self, new_cap: usize) {
+        assert!(new_cap >= self.len);
+        unsafe {
+            let layout = Layout::array::<IdxSize>(new_cap).unwrap();
+            let buffer = System.alloc(layout) as *mut IdxSize;
+            std::ptr::copy(self.data_ptr(), buffer, self.len);
+            self.dealloc();
+            self.data = buffer;
+            self.capacity = NonZeroUsize::new(new_cap).unwrap();
+        }
+    }
+
+    fn dealloc(&mut self) {
+        unsafe {
+            if self.capacity.get() > 1 {
+                let layout = Layout::array::<IdxSize>(self.capacity.get()).unwrap();
+                System.dealloc(self.data as *mut u8, layout);
+                self.capacity = NonZeroUsize::new(1).unwrap();
+            }
+        }
+    }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, IdxSize> {
+        self.as_slice().into_iter()
+    }
+
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, IdxSize> {
+        self.as_mut_slice().into_iter()
+    }
+    
+    pub fn as_slice(&self) -> &[IdxSize] {
+        self.as_ref()
+    }
+    
+    pub fn as_mut_slice(&mut self) -> &mut [IdxSize] {
+        self.as_mut()
+    }
+}
+
+impl Drop for IdxVec {
+    fn drop(&mut self) {
+        self.dealloc()
+    }
+}
+
+impl Default for IdxVec {
+    fn default() -> Self {
+        Self { len: 0, capacity: NonZeroUsize::new(1).unwrap(), data: std::ptr::null_mut() }
+    }
+}
+
+impl AsRef<[IdxSize]> for IdxVec {
+    fn as_ref(&self) -> &[IdxSize] {
+        unsafe { std::slice::from_raw_parts(self.data_ptr(), self.len) }
+    }
+}
+
+impl AsMut<[IdxSize]> for IdxVec {
+    fn as_mut(&mut self) -> &mut [IdxSize] {
+        unsafe {
+            std::slice::from_raw_parts_mut(self.data_ptr_mut(), self.len)
+        }
+    }
+}

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -8,6 +8,7 @@ pub mod contention_pool;
 mod error;
 pub mod functions;
 pub mod hashing;
+pub mod idx_vec;
 pub mod mem;
 pub mod slice;
 pub mod sort;


### PR DESCRIPTION
We can probably use the `IdxVec` in more places, but first a small PR.

```python
0.19.2
cardinality n:n
3.281125207999139
cardinality n:1
1.9747477909986628

main
cardinality n:n
2.5034849580115406
cardinality n:1
1.27836137500708

idx_vec
cardinality n:n
1.7044463330239523
cardinality n:1
0.7827337920025457
```

With this small micro-benchmark:

```python
import polars as pl
import numpy as np
from timeit import timeit

n = 1_000_000

ids1 = np.arange(n)
ids2 = np.arange(n)
np.random.shuffle(ids1)
np.random.shuffle(ids2)
ids3 = np.random.randint(100, size=n)
ids4 = np.zeros(n, dtype=int)

df1 = pl.DataFrame({"x": ids1, "f": np.random.random(len(ids1))})
df2 = pl.DataFrame({"x": ids2, "g": np.random.random(len(ids2))})
df3 = pl.DataFrame({"x": ids3, "i": np.random.random(len(ids3))})
df4 = pl.DataFrame({"x": ids4, "i": np.random.random(len(ids4))})

print("cardinality n:n")
print(timeit("""df1.join(df2, on="x")""", globals=globals(), number=100))
print("cardinality n:100")
print(timeit("""df1.join(df3, on="x")""", globals=globals(), number=100))
print("cardinality n:1")
print(timeit("""df1.join(df4, on="x")""", globals=globals(), number=100))
```