### PR TITLE
fix: output name of ternary expr

### DIFF
--- a/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -48,17 +48,19 @@ fn expand_lengths(truthy: &mut Series, falsy: &mut Series, mask: &mut BooleanChu
             let len = match mask.get(0) {
                 Some(true) => {
                     let len = truthy.len();
-                    *falsy = match falsy.len() < len {
-                        true => Series::full_null(falsy.name(), len, falsy.dtype()),
-                        false => falsy.slice(0, len),
+                    *falsy = if falsy.len() < len {
+                        Series::full_null(falsy.name(), len, falsy.dtype())
+                    } else {
+                        falsy.slice(0, len)
                     };
                     len
                 },
                 _ => {
                     let len = falsy.len();
-                    *truthy = match truthy.len() < len {
-                        true => Series::full_null(truthy.name(), len, truthy.dtype()),
-                        false => truthy.slice(0, len),
+                    *truthy = if truthy.len() < len {
+                        Series::full_null(truthy.name(), len, truthy.dtype())
+                    } else {
+                        truthy.slice(0, len)
                     };
                     len
                 },

--- a/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -47,12 +47,14 @@ fn expand_lengths(truthy: &mut Series, falsy: &mut Series, mask: &mut BooleanChu
             // Mask length 1 will broadcast to the matching branch.
             let len = match mask.get(0) {
                 Some(true) => {
-                    *falsy = truthy.clone();
-                    truthy.len()
+                    let len = truthy.len();
+                    *falsy = Series::full_null(falsy.name(), len, falsy.dtype());
+                    len
                 },
                 _ => {
-                    *truthy = falsy.clone();
-                    falsy.len()
+                    let len = falsy.len();
+                    *truthy = Series::full_null(truthy.name(), len, truthy.dtype());
+                    len
                 },
             };
 

--- a/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -48,12 +48,18 @@ fn expand_lengths(truthy: &mut Series, falsy: &mut Series, mask: &mut BooleanChu
             let len = match mask.get(0) {
                 Some(true) => {
                     let len = truthy.len();
-                    *falsy = Series::full_null(falsy.name(), len, falsy.dtype());
+                    *falsy = match falsy.len() < len {
+                        true => Series::full_null(falsy.name(), len, falsy.dtype()),
+                        false => falsy.slice(0, len),
+                    };
                     len
                 },
                 _ => {
                     let len = falsy.len();
-                    *truthy = Series::full_null(truthy.name(), len, truthy.dtype());
+                    *truthy = match truthy.len() < len {
+                        true => Series::full_null(truthy.name(), len, truthy.dtype()),
+                        false => truthy.slice(0, len),
+                    };
                     len
                 },
             };

--- a/py-polars/tests/unit/functions/test_whenthen.py
+++ b/py-polars/tests/unit/functions/test_whenthen.py
@@ -295,3 +295,22 @@ def test_broadcast_zero_len_12354() -> None:
 
     # should not panic on NULL 1-length predicate
     assert pl.select(pl.when(pl.lit(None, dtype=pl.Boolean)).then(1)).item() is None
+
+
+def test_when_then_output_name_12380() -> None:
+    df = pl.DataFrame(
+        {"x": range(5), "y": range(5, 10)}, schema={"x": pl.Int8, "y": pl.Int64}
+    ).with_columns(true=True, false=False)
+
+    expect = df.select(pl.col("x").cast(pl.Int64))
+    for true_expr in (pl.first("true"), pl.col("true"), pl.lit(True)):
+        assert_frame_equal(
+            expect,
+            df.select(pl.when(true_expr).then(pl.col("x")).otherwise(pl.col("y"))),
+        )
+    expect = df.select(pl.col("y").alias("x"))
+    for false_expr in (pl.first("false"), pl.col("false"), pl.lit(False)):
+        assert_frame_equal(
+            expect,
+            df.select(pl.when(false_expr).then(pl.col("x")).otherwise(pl.col("y"))),
+        )

--- a/py-polars/tests/unit/functions/test_whenthen.py
+++ b/py-polars/tests/unit/functions/test_whenthen.py
@@ -280,6 +280,9 @@ def test_broadcast_zero_len_12354() -> None:
     for out_true, out_false in (
         (pl.col("x").head(0), pl.col("x")),
         (pl.col("x"), pl.col("x").head(0)),
+        # If the len of the non-matching branch >= the matching branch,
+        # a `slice` operation is used instead of allocating a new series.
+        (pl.col("x"), pl.col("x")),
     ):
         for predicate, expected in (
             # true


### PR DESCRIPTION
Fixes issue https://github.com/pola-rs/polars/issues/12380 (introduced by https://github.com/pola-rs/polars/pull/12357).

The previous PR lost the series name and dtype for the non-matching branch, but they need to be preserved to have the correct output name and dtype even if the values are never used.
