### PR TITLE
bug(python): dont warn about inefficient map_elements replacement for lshift/rshift

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -114,6 +114,9 @@ _PYTHON_METHODS_MAP = {
     "upper": "str.to_uppercase",
 }
 
+# Python binary operations which don't (yet?) have a Polars equivalent
+UNSUPPORTED_BINARY_OPS = frozenset({"<<", ">>"})
+
 FUNCTION_KINDS: list[dict[str, list[AbstractSet[str]]]] = [
     # lambda x: module.func(CONSTANT)
     {
@@ -317,6 +320,12 @@ class BytecodeParser:
                         if inst.opname == "RETURN_VALUE"
                     )
                     == 1
+                    # exclude binary operations not supported by Polars expressions
+                    and not any(
+                        inst.opname == "BINARY_OP"
+                        and inst.argrepr in UNSUPPORTED_BINARY_OPS
+                        for inst in self.original_instructions
+                    )
                 )
 
         return self._can_attempt_rewrite[self._map_target]

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -146,6 +146,7 @@ NOOP_TEST_CASES = [
     "lambda x: MY_LIST[x]",
     "lambda x: MY_DICT[1]",
     'lambda x: "first" if x == 1 else "not first"',
+    "lambda x: 0xffffffff << (32-x)",
 ]
 
 EVAL_ENVIRONMENT = {


### PR DESCRIPTION
closes #12384 