### PR TITLE
fix: revert ternary special broadcast, ensure broadcast is always to max height

### DIFF
--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -256,7 +256,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
                     self.chunks.first().unwrap().data_type().clone(),
                 )],
                 true,
-                false,
+                true,
             )
         }
     }

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -248,6 +248,19 @@ impl<T: PolarsDataType> ChunkedArray<T> {
         self.chunks = vec![concatenate_owned_unchecked(self.chunks.as_slice()).unwrap()];
     }
 
+    pub fn clear(&self) -> Self {
+        // SAFETY: we keep the correct dtype
+        unsafe {
+            self.copy_with_chunks(
+                vec![new_empty_array(
+                    self.chunks.first().unwrap().data_type().clone(),
+                )],
+                true,
+                false,
+            )
+        }
+    }
+
     /// Unpack a [`Series`] to the same physical type.
     ///
     /// # Safety

--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -120,6 +120,9 @@ impl<T: PolarsDataType> ChunkedArray<T> {
     /// and will slice the best match when offset, or length is out of bounds
     #[inline]
     pub fn slice(&self, offset: i64, length: usize) -> Self {
+        if length == 0 {
+            return self.clear();
+        }
         let (chunks, len) = slice(&self.chunks, offset, length, self.len());
         let mut out = unsafe { self.copy_with_chunks(chunks, true, true) };
         out.length = len as IdxSize;

--- a/crates/polars-core/src/chunked_array/ops/explode.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode.rs
@@ -446,10 +446,9 @@ mod test {
         assert_eq!(out, &[1, 2, 3, 3, 1, 2]);
 
         // sliced explode
-        // TODO! turn on when we have fast_explode_flag on list array
-        // let exploded = ca.slice(0, 1).explode()?;
-        // let out: Vec<_> = exploded.i32()?.into_no_null_iter().collect();
-        // assert_eq!(out, &[1, 2, 3, 3]);
+        let exploded = ca.slice(0, 1).explode()?;
+        let out: Vec<_> = exploded.i32()?.into_no_null_iter().collect();
+        assert_eq!(out, &[1, 2, 3, 3]);
 
         Ok(())
     }

--- a/crates/polars-core/src/chunked_array/ops/explode.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode.rs
@@ -446,9 +446,10 @@ mod test {
         assert_eq!(out, &[1, 2, 3, 3, 1, 2]);
 
         // sliced explode
-        let exploded = ca.slice(0, 1).explode()?;
-        let out: Vec<_> = exploded.i32()?.into_no_null_iter().collect();
-        assert_eq!(out, &[1, 2, 3, 3]);
+        // TODO! turn on when we have fast_explode_flag on list array
+        // let exploded = ca.slice(0, 1).explode()?;
+        // let out: Vec<_> = exploded.i32()?.into_no_null_iter().collect();
+        // assert_eq!(out, &[1, 2, 3, 3]);
 
         Ok(())
     }

--- a/crates/polars-core/src/chunked_array/ops/zip.rs
+++ b/crates/polars-core/src/chunked_array/ops/zip.rs
@@ -90,7 +90,7 @@ macro_rules! impl_ternary_broadcast {
             Ok(val)
         },
         (_, _, 0) => {
-            Ok($self.slice(0, 0))
+            Ok($self.clear())
         }
         (_, _, _) => Err(polars_err!(
                 ShapeMismatch: "shapes of `self`, `mask` and `other` are not suitable for `zip_with` operation"

--- a/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -37,8 +37,8 @@ impl TernaryExpr {
 
 fn expand_lengths(truthy: &mut Series, falsy: &mut Series, mask: &mut BooleanChunked) {
     if mask.is_empty() {
-        *truthy = truthy.slice(0, 0);
-        *falsy = falsy.slice(0, 0);
+        *truthy = truthy.clear();
+        *falsy = falsy.clear();
         return;
     };
 

--- a/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -36,32 +36,11 @@ impl TernaryExpr {
 }
 
 fn expand_lengths(truthy: &mut Series, falsy: &mut Series, mask: &mut BooleanChunked) {
-    match mask.len() {
-        0 => {
-            *truthy = Series::new_empty(truthy.name(), truthy.dtype());
-            *falsy = Series::new_empty(falsy.name(), falsy.dtype());
-
-            return;
-        },
-        1 => {
-            // Mask length 1 will broadcast to the matching branch.
-            let len = match mask.get(0) {
-                Some(true) => {
-                    *falsy = truthy.clone();
-                    truthy.len()
-                },
-                _ => {
-                    *truthy = falsy.clone();
-                    falsy.len()
-                },
-            };
-
-            *mask = mask.new_from_index(0, len);
-
-            return;
-        },
-        _ => {},
-    }
+    if mask.is_empty() {
+        *truthy = truthy.slice(0, 0);
+        *falsy = falsy.slice(0, 0);
+        return;
+    };
 
     let len = std::cmp::max(std::cmp::max(truthy.len(), falsy.len()), mask.len());
     if len > 1 {

--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -230,28 +230,6 @@ impl OptimizationRule for SimplifyBooleanRule {
                 Some(AExpr::Literal(LiteralValue::Boolean(true)))
             },
 
-            AExpr::Ternary {
-                truthy, predicate, ..
-            } if matches!(
-                expr_arena.get(*predicate),
-                AExpr::Literal(LiteralValue::Boolean(true))
-            ) =>
-            {
-                Some(expr_arena.get(*truthy).clone())
-            },
-            AExpr::Ternary {
-                truthy,
-                falsy,
-                predicate,
-            } if matches!(
-                expr_arena.get(*predicate),
-                AExpr::Literal(LiteralValue::Boolean(false))
-            ) =>
-            {
-                let names = aexpr_to_leaf_names(*truthy, expr_arena);
-                let name = names.get(0).map(Arc::clone).unwrap_or_else(|| "".into());
-                Some(AExpr::Alias(*falsy, name))
-            },
             AExpr::Function {
                 input,
                 function: FunctionExpr::Boolean(BooleanFunction::Not),


### PR DESCRIPTION
This PR would revert when-then broadcasting behavior introduced by https://github.com/pola-rs/polars/pull/12357. to the previous behavior:
- For any of the 3 `mask`, `truthy` and `falsy` that are of length-1, will be broadcasted to the max length of the 3. If there is more than 1 unique length > 1, then instead there will be a `ShapeMismatch` error.

Supersedes https://github.com/pola-rs/polars/pull/12381
Would re-open https://github.com/pola-rs/polars/issues/12354
