### PR TITLE
build(python): Use manylinux 2.24 instead of 2.28 for compatibility reasons

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -150,7 +150,7 @@ jobs:
             --release
             --manifest-path py-polars/Cargo.toml
             --out dist
-          manylinux: '2_28'
+          manylinux: '2_24'
 
       - name: Upload wheel
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Recently we had to ditch manylinux2014 because of an issue with one of our dependencies:
https://github.com/pola-rs/polars/pull/12211

Maturin offers three options: 2014 (oldest version), 2.24, and 2.28:
https://github.com/PyO3/maturin-action#manylinux-docker-container

We switched to manylinux 2.28, but 2.24 also seems to work. After a complaint from a user about compatibility issues with 2.28 (their gclib version was 2.26), I tested if 2.24 also works and it does. So let's use that instead.

I have also updated the 0.19.13 PyPI release to include the 2.24 wheels.