### PR TITLE
feat: warn if `by` column is not sorted in rolling aggregations (as opposed to raising), add warn_if_unsorted argument

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/rolling.rs
+++ b/crates/polars-plan/src/dsl/function_expr/rolling.rs
@@ -90,16 +90,17 @@ fn convert<'a>(
             dt => polars_bail!(opq = expr_name, got = dt, expected = "date/datetime"),
         };
         if by.is_sorted_flag() != IsSorted::Ascending && options.warn_if_unsorted {
-            polars_warn!(
-                "Series is not known to be sorted by `by` column.\n\
+            polars_warn!(format!(
+                "Series is not known to be sorted by `by` column in {} operation.\n\
                 \n\
                 To silence this warning, you may want to try:\n\
                 - sorting your data by your `by` column beforehand;\n\
                 - setting `.set_sorted()` if you already know your data is sorted;\n\
                 - passing `warn_if_unsorted=False` if this warning is a false-positive\n  \
-                    (this is known to happen if combining rolling aggregations and `over`);\n\n\
-                before passing calling the rolling aggregation function.\n"
-            );
+                    (this is known to happen when combining rolling aggregations with `over`);\n\n\
+                before passing calling the rolling aggregation function.\n",
+                expr_name
+            ));
         }
         let by = by.datetime().unwrap();
         let by_values = by.cont_slice().map_err(|_| {

--- a/crates/polars-plan/src/dsl/function_expr/rolling.rs
+++ b/crates/polars-plan/src/dsl/function_expr/rolling.rs
@@ -89,7 +89,18 @@ fn convert<'a>(
             ),
             dt => polars_bail!(opq = expr_name, got = dt, expected = "date/datetime"),
         };
-        ensure_sorted_arg(&by, expr_name)?;
+        if by.is_sorted_flag() != IsSorted::Ascending && options.warn_if_unsorted {
+            polars_warn!(
+                "Series is not known to be sorted by `by` column.\n\
+                \n\
+                To silence this warning, you may want to try:\n\
+                - sorting your data by your `by` column beforehand;\n\
+                - setting `.set_sorted()` if you already know your data is sorted;\n\
+                - passing `warn_if_unsorted=False` if this warning is a false-positive\n  \
+                    (this is known to happen if combining rolling aggregations and `over`);\n\n\
+                before passing calling the rolling aggregation function.\n"
+            );
+        }
         let by = by.datetime().unwrap();
         let by_values = by.cont_slice().map_err(|_| {
             polars_err!(

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1,7 +1,5 @@
 #![allow(ambiguous_glob_reexports)]
 //! Domain specific language for the Lazy API.
-#[cfg(feature = "rolling_window")]
-use polars_core::utils::ensure_sorted_arg;
 #[cfg(feature = "dtype-categorical")]
 pub mod cat;
 #[cfg(feature = "dtype-categorical")]

--- a/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/mod.rs
@@ -31,6 +31,8 @@ pub struct RollingOptions {
     /// Optional parameters for the rolling function
     #[cfg_attr(feature = "serde", serde(skip))]
     pub fn_params: DynArgs,
+    /// Warn if data is not known to be sorted by `by` column (if passed)
+    pub warn_if_unsorted: bool,
 }
 
 impl Default for RollingOptions {
@@ -43,6 +45,7 @@ impl Default for RollingOptions {
             by: None,
             closed_window: None,
             fn_params: None,
+            warn_if_unsorted: true,
         }
     }
 }

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5636,7 +5636,8 @@ class Expr:
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
+            Warn if data is not known to be sorted by `by` column (if passed).
+            Experimental.
 
         Warnings
         --------
@@ -5842,7 +5843,8 @@ class Expr:
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
+            Warn if data is not known to be sorted by `by` column (if passed).
+            Experimental.
 
         Warnings
         --------
@@ -6079,7 +6081,8 @@ class Expr:
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
+            Warn if data is not known to be sorted by `by` column (if passed).
+            Experimental.
 
         Warnings
         --------
@@ -6318,7 +6321,8 @@ class Expr:
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
+            Warn if data is not known to be sorted by `by` column (if passed).
+            Experimental.
 
         Warnings
         --------
@@ -6554,7 +6558,8 @@ class Expr:
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
+            Warn if data is not known to be sorted by `by` column (if passed).
+            Experimental.
 
         Warnings
         --------
@@ -6797,7 +6802,8 @@ class Expr:
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
+            Warn if data is not known to be sorted by `by` column (if passed).
+            Experimental.
 
         Warnings
         --------
@@ -7037,7 +7043,8 @@ class Expr:
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
+            Warn if data is not known to be sorted by `by` column (if passed).
+            Experimental.
 
         Warnings
         --------
@@ -7202,7 +7209,8 @@ class Expr:
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
+            Warn if data is not known to be sorted by `by` column (if passed).
+            Experimental.
 
         Warnings
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5636,7 +5636,7 @@ class Expr:
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
+            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
 
         Warnings
         --------
@@ -5842,7 +5842,7 @@ class Expr:
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
+            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
 
         Warnings
         --------
@@ -6079,7 +6079,7 @@ class Expr:
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
+            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
 
         Warnings
         --------
@@ -6318,7 +6318,7 @@ class Expr:
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
+            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
 
         Warnings
         --------
@@ -6554,7 +6554,7 @@ class Expr:
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
+            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
 
         Warnings
         --------
@@ -6797,7 +6797,7 @@ class Expr:
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
+            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
 
         Warnings
         --------
@@ -7037,7 +7037,7 @@ class Expr:
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
+            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
 
         Warnings
         --------
@@ -7202,7 +7202,7 @@ class Expr:
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
         warn_if_unsorted
-            Warn if data is not known to be sorted by `by` column (if passed).
+            Warn if data is not known to be sorted by `by` column (if passed). Experimental.
 
         Warnings
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5567,6 +5567,7 @@ class Expr:
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval = "left",
+        warn_if_unsorted: bool = True,
     ) -> Self:
         """
         Apply a rolling min (moving min) over the values in this array.
@@ -5634,6 +5635,8 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
+        warn_if_unsorted
+            Warn if data is not known to be sorted by `by` column (if passed).
 
         Warnings
         --------
@@ -5760,7 +5763,7 @@ class Expr:
         )
         return self._from_pyexpr(
             self._pyexpr.rolling_min(
-                window_size, weights, min_periods, center, by, closed
+                window_size, weights, min_periods, center, by, closed, warn_if_unsorted
             )
         )
 
@@ -5774,6 +5777,7 @@ class Expr:
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval = "left",
+        warn_if_unsorted: bool = True,
     ) -> Self:
         """
         Apply a rolling max (moving max) over the values in this array.
@@ -5837,6 +5841,8 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
+        warn_if_unsorted
+            Warn if data is not known to be sorted by `by` column (if passed).
 
         Warnings
         --------
@@ -5990,7 +5996,7 @@ class Expr:
         )
         return self._from_pyexpr(
             self._pyexpr.rolling_max(
-                window_size, weights, min_periods, center, by, closed
+                window_size, weights, min_periods, center, by, closed, warn_if_unsorted
             )
         )
 
@@ -6004,6 +6010,7 @@ class Expr:
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval = "left",
+        warn_if_unsorted: bool = True,
     ) -> Self:
         """
         Apply a rolling mean (moving mean) over the values in this array.
@@ -6071,6 +6078,8 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
+        warn_if_unsorted
+            Warn if data is not known to be sorted by `by` column (if passed).
 
         Warnings
         --------
@@ -6224,7 +6233,13 @@ class Expr:
         )
         return self._from_pyexpr(
             self._pyexpr.rolling_mean(
-                window_size, weights, min_periods, center, by, closed
+                window_size,
+                weights,
+                min_periods,
+                center,
+                by,
+                closed,
+                warn_if_unsorted,
             )
         )
 
@@ -6238,6 +6253,7 @@ class Expr:
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval = "left",
+        warn_if_unsorted: bool = True,
     ) -> Self:
         """
         Apply a rolling sum (moving sum) over the values in this array.
@@ -6301,6 +6317,8 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
+        warn_if_unsorted
+            Warn if data is not known to be sorted by `by` column (if passed).
 
         Warnings
         --------
@@ -6454,7 +6472,7 @@ class Expr:
         )
         return self._from_pyexpr(
             self._pyexpr.rolling_sum(
-                window_size, weights, min_periods, center, by, closed
+                window_size, weights, min_periods, center, by, closed, warn_if_unsorted
             )
         )
 
@@ -6469,6 +6487,7 @@ class Expr:
         by: str | None = None,
         closed: ClosedInterval = "left",
         ddof: int = 1,
+        warn_if_unsorted: bool = True,
     ) -> Self:
         """
         Compute a rolling standard deviation.
@@ -6534,6 +6553,8 @@ class Expr:
             applicable if `by` has been set.
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
+        warn_if_unsorted
+            Warn if data is not known to be sorted by `by` column (if passed).
 
         Warnings
         --------
@@ -6687,7 +6708,14 @@ class Expr:
         )
         return self._from_pyexpr(
             self._pyexpr.rolling_std(
-                window_size, weights, min_periods, center, by, closed, ddof
+                window_size,
+                weights,
+                min_periods,
+                center,
+                by,
+                closed,
+                ddof,
+                warn_if_unsorted,
             )
         )
 
@@ -6702,6 +6730,7 @@ class Expr:
         by: str | None = None,
         closed: ClosedInterval = "left",
         ddof: int = 1,
+        warn_if_unsorted: bool = True,
     ) -> Self:
         """
         Compute a rolling variance.
@@ -6767,6 +6796,8 @@ class Expr:
             applicable if `by` has been set.
         ddof
             "Delta Degrees of Freedom": The divisor for a length N window is N - ddof
+        warn_if_unsorted
+            Warn if data is not known to be sorted by `by` column (if passed).
 
         Warnings
         --------
@@ -6927,6 +6958,7 @@ class Expr:
                 by,
                 closed,
                 ddof,
+                warn_if_unsorted,
             )
         )
 
@@ -6940,6 +6972,7 @@ class Expr:
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval = "left",
+        warn_if_unsorted: bool = True,
     ) -> Self:
         """
         Compute a rolling median.
@@ -7003,6 +7036,8 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
+        warn_if_unsorted
+            Warn if data is not known to be sorted by `by` column (if passed).
 
         Warnings
         --------
@@ -7082,7 +7117,7 @@ class Expr:
         )
         return self._from_pyexpr(
             self._pyexpr.rolling_median(
-                window_size, weights, min_periods, center, by, closed
+                window_size, weights, min_periods, center, by, closed, warn_if_unsorted
             )
         )
 
@@ -7098,6 +7133,7 @@ class Expr:
         center: bool = False,
         by: str | None = None,
         closed: ClosedInterval = "left",
+        warn_if_unsorted: bool = True,
     ) -> Self:
         """
         Compute a rolling quantile.
@@ -7165,6 +7201,8 @@ class Expr:
         closed : {'left', 'right', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive); only
             applicable if `by` has been set.
+        warn_if_unsorted
+            Warn if data is not known to be sorted by `by` column (if passed).
 
         Warnings
         --------
@@ -7280,6 +7318,7 @@ class Expr:
                 center,
                 by,
                 closed,
+                warn_if_unsorted,
             )
         )
 

--- a/py-polars/src/expr/rolling.rs
+++ b/py-polars/src/expr/rolling.rs
@@ -11,7 +11,7 @@ use crate::{PyExpr, PySeries};
 
 #[pymethods]
 impl PyExpr {
-    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed))]
+    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed, warn_if_unsorted))]
     fn rolling_sum(
         &self,
         window_size: &str,
@@ -20,6 +20,7 @@ impl PyExpr {
         center: bool,
         by: Option<String>,
         closed: Option<Wrap<ClosedWindow>>,
+        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptions {
             window_size: Duration::parse(window_size),
@@ -28,12 +29,13 @@ impl PyExpr {
             center,
             by,
             closed_window: closed.map(|c| c.0),
+            warn_if_unsorted,
             ..Default::default()
         };
         self.inner.clone().rolling_sum(options).into()
     }
 
-    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed))]
+    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed, warn_if_unsorted))]
     fn rolling_min(
         &self,
         window_size: &str,
@@ -42,6 +44,7 @@ impl PyExpr {
         center: bool,
         by: Option<String>,
         closed: Option<Wrap<ClosedWindow>>,
+        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptions {
             window_size: Duration::parse(window_size),
@@ -50,12 +53,13 @@ impl PyExpr {
             center,
             by,
             closed_window: closed.map(|c| c.0),
+            warn_if_unsorted,
             ..Default::default()
         };
         self.inner.clone().rolling_min(options).into()
     }
 
-    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed))]
+    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed, warn_if_unsorted))]
     fn rolling_max(
         &self,
         window_size: &str,
@@ -64,6 +68,7 @@ impl PyExpr {
         center: bool,
         by: Option<String>,
         closed: Option<Wrap<ClosedWindow>>,
+        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptions {
             window_size: Duration::parse(window_size),
@@ -72,12 +77,13 @@ impl PyExpr {
             center,
             by,
             closed_window: closed.map(|c| c.0),
+            warn_if_unsorted,
             ..Default::default()
         };
         self.inner.clone().rolling_max(options).into()
     }
 
-    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed))]
+    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed, warn_if_unsorted))]
     fn rolling_mean(
         &self,
         window_size: &str,
@@ -86,6 +92,7 @@ impl PyExpr {
         center: bool,
         by: Option<String>,
         closed: Option<Wrap<ClosedWindow>>,
+        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptions {
             window_size: Duration::parse(window_size),
@@ -94,13 +101,14 @@ impl PyExpr {
             center,
             by,
             closed_window: closed.map(|c| c.0),
+            warn_if_unsorted,
             ..Default::default()
         };
 
         self.inner.clone().rolling_mean(options).into()
     }
 
-    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed, ddof))]
+    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed, ddof, warn_if_unsorted))]
     fn rolling_std(
         &self,
         window_size: &str,
@@ -110,6 +118,7 @@ impl PyExpr {
         by: Option<String>,
         closed: Option<Wrap<ClosedWindow>>,
         ddof: u8,
+        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptions {
             window_size: Duration::parse(window_size),
@@ -119,12 +128,13 @@ impl PyExpr {
             by,
             closed_window: closed.map(|c| c.0),
             fn_params: Some(Arc::new(RollingVarParams { ddof }) as Arc<dyn Any + Send + Sync>),
+            warn_if_unsorted,
         };
 
         self.inner.clone().rolling_std(options).into()
     }
 
-    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed, ddof))]
+    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed, ddof, warn_if_unsorted))]
     fn rolling_var(
         &self,
         window_size: &str,
@@ -134,6 +144,7 @@ impl PyExpr {
         by: Option<String>,
         closed: Option<Wrap<ClosedWindow>>,
         ddof: u8,
+        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptions {
             window_size: Duration::parse(window_size),
@@ -143,12 +154,13 @@ impl PyExpr {
             by,
             closed_window: closed.map(|c| c.0),
             fn_params: Some(Arc::new(RollingVarParams { ddof }) as Arc<dyn Any + Send + Sync>),
+            warn_if_unsorted,
         };
 
         self.inner.clone().rolling_var(options).into()
     }
 
-    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed))]
+    #[pyo3(signature = (window_size, weights, min_periods, center, by, closed, warn_if_unsorted))]
     fn rolling_median(
         &self,
         window_size: &str,
@@ -157,6 +169,7 @@ impl PyExpr {
         center: bool,
         by: Option<String>,
         closed: Option<Wrap<ClosedWindow>>,
+        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptions {
             window_size: Duration::parse(window_size),
@@ -169,11 +182,12 @@ impl PyExpr {
                 prob: 0.5,
                 interpol: QuantileInterpolOptions::Linear,
             }) as Arc<dyn Any + Send + Sync>),
+            warn_if_unsorted,
         };
         self.inner.clone().rolling_quantile(options).into()
     }
 
-    #[pyo3(signature = (quantile, interpolation, window_size, weights, min_periods, center, by, closed))]
+    #[pyo3(signature = (quantile, interpolation, window_size, weights, min_periods, center, by, closed, warn_if_unsorted))]
     fn rolling_quantile(
         &self,
         quantile: f64,
@@ -184,6 +198,7 @@ impl PyExpr {
         center: bool,
         by: Option<String>,
         closed: Option<Wrap<ClosedWindow>>,
+        warn_if_unsorted: bool,
     ) -> Self {
         let options = RollingOptions {
             window_size: Duration::parse(window_size),
@@ -196,6 +211,7 @@ impl PyExpr {
                 prob: quantile,
                 interpol: interpolation.0,
             }) as Arc<dyn Any + Send + Sync>),
+            warn_if_unsorted,
         };
 
         self.inner.clone().rolling_quantile(options).into()


### PR DESCRIPTION
closes #11225

Even if #11134 were addressed, then the warning would still show, because the sortedness flags don't propagate during `over`