### PR TITLE
chore(rust): use unwrap_or_else and get_unchecked_release in rolling kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,6 +2658,7 @@ dependencies = [
  "multiversion",
  "num-traits",
  "polars-error",
+ "polars-utils",
  "proptest",
  "rand 0.8.5",
  "regex",

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -26,6 +26,7 @@ foreign_vec = { version = "0.1" }
 hashbrown = { workspace = true }
 num-traits = { workspace = true }
 polars-error = { workspace = true }
+polars-utils = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 simdutf8 = { workspace = true }
 

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/mod.rs
@@ -49,14 +49,12 @@ where
     // Safety; we are in bounds
     let mut agg_window = unsafe { Agg::new(values, validity, start, end, params) };
 
-    let mut validity = match create_validity(min_periods, len, window_size, det_offsets_fn) {
-        Some(v) => v,
-        None => {
+    let mut validity = create_validity(min_periods, len, window_size, det_offsets_fn)
+        .unwrap_or_else(|| {
             let mut validity = MutableBitmap::with_capacity(len);
             validity.extend_constant(len, true);
             validity
-        },
-    };
+        });
 
     let out = (0..len)
         .map(|idx| {


### PR DESCRIPTION
factoring out some more "chore"-like bits from https://github.com/pola-rs/polars/pull/11750