### PR TITLE
build(python): Use `manylinux_2_17` for building `x86-64` wheel

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -150,7 +150,7 @@ jobs:
             --release
             --manifest-path py-polars/Cargo.toml
             --out dist
-          manylinux: '2_24'
+          manylinux: ${{ matrix.architecture == 'aarch64' && '2_24' || 'auto' }}
 
       - name: Upload wheel
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Closes #12390

Lesson learned: take backwards compatibility seriously, even for 8+ year old systems.

PyPI release for Polars 0.19.13 has been updated.