### PR TITLE
chore: dprint/markdown link checker minor updates

### DIFF
--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -103,12 +103,10 @@ The opt-in features are:
     are less cache efficient.
     - `cse` - Activate common subplan elimination optimization
 - IO related:
-  <!-- markdown-link-check-disable -->
     - `serde` - Support for [serde](https://crates.io/crates/serde) serialization and deserialization.
     Can be used for JSON and more serde supported serialization formats.
     - `serde-lazy` - Support for [serde](https://crates.io/crates/serde) serialization and deserialization.
     Can be used for JSON and more serde supported serialization formats.
-  <!-- markdown-link-check-enable -->
     - `parquet` - Read Apache Parquet format
     - `json` - JSON serialization
     - `ipc` - Arrow's IPC format serialization

--- a/dprint.json
+++ b/dprint.json
@@ -11,7 +11,7 @@
         "py-polars/.ruff_cache/"
     ],
     "plugins": [
-        "https://plugins.dprint.dev/markdown-0.16.0.wasm",
+        "https://plugins.dprint.dev/markdown-0.16.2.wasm",
         "https://plugins.dprint.dev/toml-0.5.4.wasm"
     ]
 }


### PR DESCRIPTION
Just bumping the markdown linter (hoped the nested bullet points would be fixed in a newer version, but alas no such luck).

Also removed some unnecessary pragma comments for MLC as the config file takes care of this.