### PR TITLE
perf: use online algorithm for cov/corr `~2x`

### DIFF
--- a/crates/polars-ops/src/chunked_array/cov.rs
+++ b/crates/polars-ops/src/chunked_array/cov.rs
@@ -4,29 +4,71 @@ use arrow::compute;
 use arrow::types::simd::Simd;
 use num_traits::ToPrimitive;
 use polars_core::prelude::*;
-use polars_core::utils::coalesce_nulls;
+use polars_core::utils::align_chunks_binary;
 
 /// Compute the covariance between two columns.
-pub fn cov<T>(a: &ChunkedArray<T>, b: &ChunkedArray<T>) -> Option<f64>
+pub fn cov<T>(a: &ChunkedArray<T>, b: &ChunkedArray<T>, ddof: u8) -> Option<f64>
 where
     T: PolarsNumericType,
     T::Native: ToPrimitive,
-    <T::Native as Simd>::Simd: Add<Output = <T::Native as Simd>::Simd>
-        + compute::aggregate::Sum<T::Native>
-        + compute::aggregate::SimdOrd<T::Native>,
 {
     if a.len() != b.len() {
         None
     } else {
-        let a_mean = a.mean()?;
-        let b_mean = b.mean()?;
-        let a: Float64Chunked = a.apply_values_generic(|a| a.to_f64().unwrap() - a_mean);
-        let b: Float64Chunked = b.apply_values_generic(|b| b.to_f64().unwrap() - b_mean);
+        let (a, b) = align_chunks_binary(a, b);
 
-        let tmp = a * b;
-        let n = tmp.len() - tmp.null_count();
-        Some(tmp.sum()? / (n - 1) as f64)
+        let out = if a.null_count() > 0 || b.null_count() > 0 {
+            let iters = a
+                .downcast_iter()
+                .zip(b.downcast_iter())
+                .map(|(a, b)| {
+                    a.into_iter().zip(b).filter_map(|(a, b)| match (a, b) {
+                        (Some(a), Some(b)) => Some((*a, *b)),
+                        _ => None,
+                    })
+                })
+                .collect::<Vec<_>>();
+            online_cov(iters.as_slice(), ddof)
+        } else {
+            let iters = a
+                .downcast_iter()
+                .zip(b.downcast_iter())
+                .map(|(a, b)| a.values_iter().copied().zip(b.values_iter().copied()))
+                .collect::<Vec<_>>();
+            online_cov(iters.as_slice(), ddof)
+        };
+        Some(out)
     }
+}
+
+/// # Arguments
+/// `iter` - Iterator over `T` tuple where any `Option<T>` would skip the tuple.
+fn online_cov<I, T>(iters: &[I], ddof: u8) -> f64
+where
+    I: IntoIterator<Item = (T, T)> + Clone,
+    T: ToPrimitive,
+{
+    let mut mean_x = 0.0;
+    let mut mean_y = 0.0;
+    let mut c = 0.0;
+    let mut n = 0.0;
+
+    for iter in iters {
+        let iter = iter.clone().into_iter();
+        for (x, y) in iter {
+            let x = x.to_f64().unwrap();
+            let y = y.to_f64().unwrap();
+
+            n += 1.0;
+
+            let dx = x - mean_x;
+            mean_x += dx / n;
+            mean_y += (y - mean_y) / n;
+            c += dx * (y - mean_y)
+        }
+    }
+
+    c / (n - ddof as f64)
 }
 
 /// Compute the pearson correlation between two columns.
@@ -39,9 +81,72 @@ where
         + compute::aggregate::SimdOrd<T::Native>,
     ChunkedArray<T>: ChunkVar,
 {
-    let (a, b) = coalesce_nulls(a, b);
-    let a = a.as_ref();
-    let b = b.as_ref();
+    let (a, b) = align_chunks_binary(a, b);
 
-    Some(cov(a, b)? / (a.std(ddof)? * b.std(ddof)?))
+    let out = if a.null_count() > 0 || b.null_count() > 0 {
+        let iters = a
+            .downcast_iter()
+            .zip(b.downcast_iter())
+            .map(|(a, b)| {
+                a.into_iter().zip(b).filter_map(|(a, b)| match (a, b) {
+                    (Some(a), Some(b)) => Some((*a, *b)),
+                    _ => None,
+                })
+            })
+            .collect::<Vec<_>>();
+        online_pearson_corr(iters.as_slice(), ddof)
+    } else {
+        let iters = a
+            .downcast_iter()
+            .zip(b.downcast_iter())
+            .map(|(a, b)| a.values_iter().copied().zip(b.values_iter().copied()))
+            .collect::<Vec<_>>();
+        online_pearson_corr(iters.as_slice(), ddof)
+    };
+    Some(out)
+}
+
+/// # Arguments
+/// `iter` - Iterator over `T` tuple where any `Option<T>` would skip the tuple.
+fn online_pearson_corr<I, T>(iters: &[I], ddof: u8) -> f64
+where
+    I: IntoIterator<Item = (T, T)> + Clone,
+    T: ToPrimitive,
+{
+    let mut mean_x = 0.0;
+    let mut mean_y = 0.0;
+    let mut c = 0.0;
+    let mut n = 0.0;
+
+    let mut m2x = 0.0;
+    let mut m2y = 0.0;
+
+    for iter in iters {
+        let iter = iter.clone().into_iter();
+        for (x, y) in iter {
+            let x = x.to_f64().unwrap();
+            let y = y.to_f64().unwrap();
+
+            n += 1.0;
+
+            let dx = x - mean_x;
+            let dy = y - mean_y;
+            mean_x += dx / n;
+            mean_y += dy / n;
+
+            let d2x = x - mean_x;
+            let d2y = y - mean_y;
+
+            m2x += dx * d2x;
+            m2y += dy * d2y;
+            c += dx * (y - mean_y)
+        }
+    }
+
+    let sample_n = n - ddof as f64;
+    let sample_cov = c / sample_n;
+    let sample_std_x = (m2x / sample_n).sqrt();
+    let sample_std_y = (m2y / sample_n).sqrt();
+
+    sample_cov / (sample_std_x * sample_std_y)
 }

--- a/crates/polars-plan/src/dsl/function_expr/correlation.rs
+++ b/crates/polars-plan/src/dsl/function_expr/correlation.rs
@@ -32,27 +32,27 @@ pub(super) fn corr(s: &[Series], ddof: u8, method: CorrelationMethod) -> PolarsR
         CorrelationMethod::SpearmanRank(propagate_nans) => {
             spearman_rank_corr(s, ddof, propagate_nans)
         },
-        CorrelationMethod::Covariance => covariance(s),
+        CorrelationMethod::Covariance => covariance(s, ddof),
     }
 }
 
-fn covariance(s: &[Series]) -> PolarsResult<Series> {
+fn covariance(s: &[Series], ddof: u8) -> PolarsResult<Series> {
     let a = &s[0];
     let b = &s[1];
     let name = "cov";
 
     use polars_ops::chunked_array::cov::cov;
     let ret = match a.dtype() {
-        DataType::Float32 => cov(a.f32().unwrap(), b.f32().unwrap()),
-        DataType::Float64 => cov(a.f64().unwrap(), b.f64().unwrap()),
-        DataType::Int32 => cov(a.i32().unwrap(), b.i32().unwrap()),
-        DataType::Int64 => cov(a.i64().unwrap(), b.i64().unwrap()),
-        DataType::UInt32 => cov(a.u32().unwrap(), b.u32().unwrap()),
-        DataType::UInt64 => cov(a.u64().unwrap(), b.u64().unwrap()),
+        DataType::Float32 => cov(a.f32().unwrap(), b.f32().unwrap(), ddof),
+        DataType::Float64 => cov(a.f64().unwrap(), b.f64().unwrap(), ddof),
+        DataType::Int32 => cov(a.i32().unwrap(), b.i32().unwrap(), ddof),
+        DataType::Int64 => cov(a.i64().unwrap(), b.i64().unwrap(), ddof),
+        DataType::UInt32 => cov(a.u32().unwrap(), b.u32().unwrap(), ddof),
+        DataType::UInt64 => cov(a.u64().unwrap(), b.u64().unwrap(), ddof),
         _ => {
             let a = a.cast(&DataType::Float64)?;
             let b = b.cast(&DataType::Float64)?;
-            cov(a.f64().unwrap(), b.f64().unwrap())
+            cov(a.f64().unwrap(), b.f64().unwrap(), ddof)
         },
     };
     Ok(Series::new(name, &[ret]))

--- a/crates/polars-plan/src/dsl/functions/correlation.rs
+++ b/crates/polars-plan/src/dsl/functions/correlation.rs
@@ -1,11 +1,11 @@
 use super::*;
 
 /// Compute the covariance between two columns.
-pub fn cov(a: Expr, b: Expr) -> Expr {
+pub fn cov(a: Expr, b: Expr, ddof: u8) -> Expr {
     let input = vec![a, b];
     let function = FunctionExpr::Correlation {
         method: CorrelationMethod::Covariance,
-        ddof: 0,
+        ddof,
     };
     Expr::Function {
         input,

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -676,8 +676,8 @@ def tail(column: str | Series, n: int = 10) -> Expr | Series:
 
 
 def corr(
-    a: str | Expr,
-    b: str | Expr,
+    a: IntoExpr,
+    b: IntoExpr,
     *,
     method: CorrelationMethod = "pearson",
     ddof: int = 1,
@@ -731,24 +731,20 @@ def corr(
     │ 0.5 │
     └─────┘
     """
-    if isinstance(a, str):
-        a = F.col(a)
-    if isinstance(b, str):
-        b = F.col(b)
+    a = parse_as_expression(a)
+    b = parse_as_expression(b)
 
     if method == "pearson":
-        return wrap_expr(plr.pearson_corr(a._pyexpr, b._pyexpr, ddof))
+        return wrap_expr(plr.pearson_corr(a, b, ddof))
     elif method == "spearman":
-        return wrap_expr(
-            plr.spearman_rank_corr(a._pyexpr, b._pyexpr, ddof, propagate_nans)
-        )
+        return wrap_expr(plr.spearman_rank_corr(a, b, ddof, propagate_nans))
     else:
         raise ValueError(
             f"method must be one of {{'pearson', 'spearman'}}, got {method!r}"
         )
 
 
-def cov(a: str | Expr, b: str | Expr) -> Expr:
+def cov(a: IntoExpr, b: IntoExpr, ddof: int = 1) -> Expr:
     """
     Compute the covariance between two columns/ expressions.
 
@@ -758,6 +754,10 @@ def cov(a: str | Expr, b: str | Expr) -> Expr:
         Column name or Expression.
     b
         Column name or Expression.
+    ddof
+        "Delta Degrees of Freedom": the divisor used in the calculation is N - ddof,
+        where N represents the number of elements.
+        By default ddof is 1.
 
     Examples
     --------
@@ -773,11 +773,9 @@ def cov(a: str | Expr, b: str | Expr) -> Expr:
     └─────┘
 
     """
-    if isinstance(a, str):
-        a = F.col(a)
-    if isinstance(b, str):
-        b = F.col(b)
-    return wrap_expr(plr.cov(a._pyexpr, b._pyexpr))
+    a = parse_as_expression(a)
+    b = parse_as_expression(b)
+    return wrap_expr(plr.cov(a, b, ddof))
 
 
 def map_batches(

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -188,8 +188,8 @@ pub fn count() -> PyExpr {
 }
 
 #[pyfunction]
-pub fn cov(a: PyExpr, b: PyExpr) -> PyExpr {
-    dsl::cov(a.inner, b.inner).into()
+pub fn cov(a: PyExpr, b: PyExpr, ddof: u8) -> PyExpr {
+    dsl::cov(a.inner, b.inner, ddof).into()
 }
 
 #[pyfunction]

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -981,7 +981,7 @@ def test_spearman_corr_ties() -> None:
     df = pl.DataFrame({"a": [1, 1, 1, 2, 3, 7, 4], "b": [4, 3, 2, 2, 4, 3, 1]})
 
     result = df.select(
-        pl.corr("a", "b", method="spearman").alias("a1"),
+        pl.corr("a", "b", method="spearman", ddof=0).alias("a1"),
         pl.corr(pl.col("a").rank("min"), pl.col("b").rank("min")).alias("a2"),
         pl.corr(pl.col("a").rank(), pl.col("b").rank()).alias("a3"),
     )
@@ -1006,9 +1006,9 @@ def test_pearson_corr() -> None:
 
     out = (
         ldf.group_by("era", maintain_order=True).agg(
-            pl.corr(pl.col("prediction"), pl.col("target"), method="pearson").alias(
-                "c"
-            ),
+            pl.corr(
+                pl.col("prediction"), pl.col("target"), method="pearson", ddof=0
+            ).alias("c"),
         )
     ).collect()["c"]
     assert out.to_list() == pytest.approx([0.6546536707079772, -5.477514993831792e-1])
@@ -1016,7 +1016,7 @@ def test_pearson_corr() -> None:
     # we can also pass in column names directly
     out = (
         ldf.group_by("era", maintain_order=True).agg(
-            pl.corr("prediction", "target", method="pearson").alias("c"),
+            pl.corr("prediction", "target", method="pearson", ddof=0).alias("c"),
         )
     ).collect()["c"]
     assert out.to_list() == pytest.approx([0.6546536707079772, -5.477514993831792e-1])


### PR DESCRIPTION
Fill in on this promise ;) : https://www.reddit.com/r/Python/comments/17rjedo/comment/k8x0c3d/?utm_source=share&utm_medium=web2x&context=3


This makes us `2x` faster than before and `~35%` faster than numpy.
