### PR TITLE
feat: Improve error messages on attempted Arrow conversions involving incompatible/unknown dtypes

### DIFF
--- a/crates/polars-arrow/src/ffi/stream.rs
+++ b/crates/polars-arrow/src/ffi/stream.rs
@@ -66,7 +66,7 @@ impl<Iter: DerefMut<Target = ArrowArrayStream>> ArrowArrayStreamReader<Iter> {
         };
 
         if iter.get_next.is_none() {
-            polars_bail!(InvalidOperation: "the c stream must contain a non-null get_next")
+            polars_bail!(InvalidOperation: "the C stream must contain a non-null get_next")
         };
 
         if iter.get_last_error.is_none() {

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -262,7 +262,7 @@ impl DataType {
             Null => Ok(ArrowDataType::Null),
             #[cfg(feature = "object")]
             Object(_) => {
-                polars_bail!(InvalidOperation: "cannot convert data with Object dtype to Arrow")
+                polars_bail!(InvalidOperation: "cannot convert Object dtype data to Arrow")
             },
             #[cfg(feature = "dtype-categorical")]
             Categorical(_) => Ok(ArrowDataType::Dictionary(
@@ -276,7 +276,7 @@ impl DataType {
                 Ok(ArrowDataType::Struct(fields))
             },
             Unknown => {
-                polars_bail!(InvalidOperation: "cannot convert data with Unknown dtype to Arrow")
+                polars_bail!(InvalidOperation: "cannot convert Unknown dtype data to Arrow")
             },
         }
     }

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -253,7 +253,11 @@ impl DataType {
             Time => Ok(ArrowDataType::Time64(ArrowTimeUnit::Nanosecond)),
             #[cfg(feature = "dtype-array")]
             Array(dt, size) => Ok(ArrowDataType::FixedSizeList(
-                Box::new(arrow::datatypes::Field::new("item", dt.to_arrow(), true)),
+                Box::new(arrow::datatypes::Field::new(
+                    "item",
+                    dt.try_to_arrow()?,
+                    true,
+                )),
                 *size,
             )),
             List(dt) => Ok(ArrowDataType::LargeList(Box::new(

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -258,7 +258,7 @@ impl DataType {
             ))),
             Null => ArrowDataType::Null,
             #[cfg(feature = "object")]
-            Object(_) => panic!("cannot convert object to arrow"),
+            Object(_) => panic!("cannot convert data with Object dtype to Arrow"),
             #[cfg(feature = "dtype-categorical")]
             Categorical(_) => ArrowDataType::Dictionary(
                 IntegerType::UInt32,
@@ -270,7 +270,7 @@ impl DataType {
                 let fields = fields.iter().map(|fld| fld.to_arrow()).collect();
                 ArrowDataType::Struct(fields)
             },
-            Unknown => unreachable!(),
+            Unknown => panic!("cannot convert data with Unknown dtype to Arrow"),
         }
     }
 

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -221,56 +221,63 @@ impl DataType {
     /// Convert to an Arrow data type.
     #[inline]
     pub fn to_arrow(&self) -> ArrowDataType {
+        self.try_to_arrow().unwrap()
+    }
+
+    #[inline]
+    pub fn try_to_arrow(&self) -> PolarsResult<ArrowDataType> {
         use DataType::*;
         match self {
-            Boolean => ArrowDataType::Boolean,
-            UInt8 => ArrowDataType::UInt8,
-            UInt16 => ArrowDataType::UInt16,
-            UInt32 => ArrowDataType::UInt32,
-            UInt64 => ArrowDataType::UInt64,
-            Int8 => ArrowDataType::Int8,
-            Int16 => ArrowDataType::Int16,
-            Int32 => ArrowDataType::Int32,
-            Int64 => ArrowDataType::Int64,
-            Float32 => ArrowDataType::Float32,
-            Float64 => ArrowDataType::Float64,
+            Boolean => Ok(ArrowDataType::Boolean),
+            UInt8 => Ok(ArrowDataType::UInt8),
+            UInt16 => Ok(ArrowDataType::UInt16),
+            UInt32 => Ok(ArrowDataType::UInt32),
+            UInt64 => Ok(ArrowDataType::UInt64),
+            Int8 => Ok(ArrowDataType::Int8),
+            Int16 => Ok(ArrowDataType::Int16),
+            Int32 => Ok(ArrowDataType::Int32),
+            Int64 => Ok(ArrowDataType::Int64),
+            Float32 => Ok(ArrowDataType::Float32),
+            Float64 => Ok(ArrowDataType::Float64),
             #[cfg(feature = "dtype-decimal")]
             // note: what else can we do here other than setting precision to 38?..
-            Decimal(precision, scale) => ArrowDataType::Decimal(
+            Decimal(precision, scale) => Ok(ArrowDataType::Decimal(
                 (*precision).unwrap_or(38),
                 scale.unwrap_or(0), // and what else can we do here?
-            ),
-            Utf8 => ArrowDataType::LargeUtf8,
-            Binary => ArrowDataType::LargeBinary,
-            Date => ArrowDataType::Date32,
-            Datetime(unit, tz) => ArrowDataType::Timestamp(unit.to_arrow(), tz.clone()),
-            Duration(unit) => ArrowDataType::Duration(unit.to_arrow()),
-            Time => ArrowDataType::Time64(ArrowTimeUnit::Nanosecond),
+            )),
+            Utf8 => Ok(ArrowDataType::LargeUtf8),
+            Binary => Ok(ArrowDataType::LargeBinary),
+            Date => Ok(ArrowDataType::Date32),
+            Datetime(unit, tz) => Ok(ArrowDataType::Timestamp(unit.to_arrow(), tz.clone())),
+            Duration(unit) => Ok(ArrowDataType::Duration(unit.to_arrow())),
+            Time => Ok(ArrowDataType::Time64(ArrowTimeUnit::Nanosecond)),
             #[cfg(feature = "dtype-array")]
-            Array(dt, size) => ArrowDataType::FixedSizeList(
+            Array(dt, size) => Ok(ArrowDataType::FixedSizeList(
                 Box::new(arrow::datatypes::Field::new("item", dt.to_arrow(), true)),
                 *size,
-            ),
-            List(dt) => ArrowDataType::LargeList(Box::new(arrow::datatypes::Field::new(
-                "item",
-                dt.to_arrow(),
-                true,
+            )),
+            List(dt) => Ok(ArrowDataType::LargeList(Box::new(
+                arrow::datatypes::Field::new("item", dt.to_arrow(), true),
             ))),
-            Null => ArrowDataType::Null,
+            Null => Ok(ArrowDataType::Null),
             #[cfg(feature = "object")]
-            Object(_) => panic!("cannot convert data with Object dtype to Arrow"),
+            Object(_) => {
+                polars_bail!(InvalidOperation: "cannot convert data with Object dtype to Arrow")
+            },
             #[cfg(feature = "dtype-categorical")]
-            Categorical(_) => ArrowDataType::Dictionary(
+            Categorical(_) => Ok(ArrowDataType::Dictionary(
                 IntegerType::UInt32,
                 Box::new(ArrowDataType::LargeUtf8),
                 false,
-            ),
+            )),
             #[cfg(feature = "dtype-struct")]
             Struct(fields) => {
                 let fields = fields.iter().map(|fld| fld.to_arrow()).collect();
-                ArrowDataType::Struct(fields)
+                Ok(ArrowDataType::Struct(fields))
             },
-            Unknown => panic!("cannot convert data with Unknown dtype to Arrow"),
+            Unknown => {
+                polars_bail!(InvalidOperation: "cannot convert data with Unknown dtype to Arrow")
+            },
         }
     }
 

--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -55,7 +55,7 @@ pub(super) fn extract_groups(
             .map(|ca| ca.into_series());
     }
 
-    let data_type = dtype.to_arrow();
+    let data_type = dtype.try_to_arrow()?;
     let DataType::Struct(fields) = dtype else {
         unreachable!() // Implementation error if it isn't a struct.
     };


### PR DESCRIPTION
The `unreachable!` throw could cause confusion; clarified that the error is being raised as dtype being `Unknown` at this point (which likely indicates that the schema is not bring properly tracked through the query plan for some reason; raising a better error here should make it more obvious what's really at fault).

**Update**:

* As suggested, adds fallible `try_to_arrow` variant, which `to_arrow` now calls and unwraps.
* The `panic!` (on Object) and `unreachable!` (on Unknown) are now both `polars_bail!(InvalidOperation: <err>`).