### PR TITLE
fix(python): raw HTML output alignment was incorrect for dtype in header

### DIFF
--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -159,8 +159,8 @@ class NotebookFormatter(HTMLFormatter):
     def write_style(self) -> None:
         style = """\
             <style>
-            .dataframe > thead > tr > th,
-            .dataframe > tbody > tr > td {
+            .dataframe > thead > tr,
+            .dataframe > tbody > tr {
               text-align: right;
               white-space: pre-wrap;
             }


### PR DESCRIPTION
We don't need to over-specify the CSS selectors here; while some environments restyle frame tables (so the issue isn't seen there) others take the raw HTML"as-is" and could see misaligned dtype descriptions (as the dtype sits inside a `td`, not a `th`).

**First:** misaligned dtype.
**Second:** after the fix.

<img width="141" alt="Screenshot showing misaligned dtype" src="https://github.com/pola-rs/polars/assets/2613171/3e2bfa6e-d5f4-490a-944a-965b472b82d3">

<img width="141" alt="Screenshot showing fixed dtype alignment" src="https://github.com/pola-rs/polars/assets/2613171/00ca4b40-c1ce-4147-88d3-7eb92c56a3a8">

