### PR TITLE
fix(python): ensure explicit "return_dtype" is respected by `map_dicts`

### DIFF
--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -768,6 +768,24 @@ def test_map_dict() -> None:
         ),
     )
 
+    lf = pl.LazyFrame({"a": [1, 2, 3]})
+    assert_frame_equal(
+        lf.select(
+            pl.col("a").cast(pl.UInt8).map_dict({1: 11, 2: 22}, default=99)
+        ).collect(),
+        pl.DataFrame({"a": [11, 22, 99]}, schema_overrides={"a": pl.UInt8}),
+    )
+
+    df = (
+        pl.LazyFrame({"a": ["one", "two"]})
+        .with_columns(pl.col("a").map_dict({"one": 1}, return_dtype=pl.UInt32))
+        .fill_null(999)
+        .collect()
+    )
+    assert_frame_equal(
+        df, pl.DataFrame({"a": [1, 999]}, schema_overrides={"a": pl.UInt32})
+    )
+
 
 def test_lit_dtypes() -> None:
     def lit_series(value: Any, dtype: pl.PolarsDataType | None) -> pl.Series:


### PR DESCRIPTION
Closes #12410, partially addresses #11332.

* Significantly streamlined `map_dicts` implementation to avoid a lot of copy/paste and make it a little easier to reason about.

* Fixed issue where an explicitly-provided "result_dtype" value was not being passed through to the underlying `map_batches` expression, and added some coverage.


Note: only partially addresses #11332 as we should probably be able to do better with inference in the absence of an explicit "result_dtype", such that the `fill_null` succeeds (it currently fails as the expression dtype is considered "Unknown" and it is looking for numeric columns to fill, ref: #7700).