### PR TITLE
perf: apply predicates and statistics of parquet files in streaming mode

### DIFF
--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -624,7 +624,7 @@ impl<'a> CoreReader<'a> {
                             };
 
                             cast_columns(&mut local_df, &self.to_cast, false, self.ignore_errors)?;
-                            let s = predicate.evaluate(&local_df)?;
+                            let s = predicate.evaluate_io(&local_df)?;
                             let mask = s.bool()?;
                             local_df = local_df.filter(mask)?;
 

--- a/crates/polars-io/src/lib.rs
+++ b/crates/polars-io/src/lib.rs
@@ -113,7 +113,7 @@ pub(crate) fn finish_reader<R: ArrowReader>(
         }
 
         if let Some(predicate) = &predicate {
-            let s = predicate.evaluate(&df)?;
+            let s = predicate.evaluate_io(&df)?;
             let mask = s.bool().expect("filter predicates was not of type boolean");
             df = df.filter(mask)?;
         }

--- a/crates/polars-io/src/parquet/read.rs
+++ b/crates/polars-io/src/parquet/read.rs
@@ -54,43 +54,12 @@ pub struct ParquetReader<R: Read + Seek> {
     row_count: Option<RowCount>,
     low_memory: bool,
     metadata: Option<Arc<FileMetaData>>,
+    predicate: Option<Arc<dyn PhysicalIoExpr>>,
     hive_partition_columns: Option<Vec<Series>>,
     use_statistics: bool,
 }
 
 impl<R: MmapBytesReader> ParquetReader<R> {
-    #[cfg(feature = "lazy")]
-    // todo! hoist to lazy crate
-    pub fn _finish_with_scan_ops(
-        mut self,
-        predicate: Option<Arc<dyn PhysicalIoExpr>>,
-        projection: Option<&[usize]>,
-    ) -> PolarsResult<DataFrame> {
-        // this path takes predicates and parallelism into account
-        let metadata = self.get_metadata()?.clone();
-        let schema = self.schema()?;
-
-        let rechunk = self.rechunk;
-        read_parquet(
-            self.reader,
-            self.n_rows.unwrap_or(usize::MAX),
-            projection,
-            &schema,
-            Some(metadata),
-            predicate.as_deref(),
-            self.parallel,
-            self.row_count,
-            self.use_statistics,
-            self.hive_partition_columns.as_deref(),
-        )
-        .map(|mut df| {
-            if rechunk {
-                df.as_single_chunk_par();
-            };
-            df
-        })
-    }
-
     /// Try to reduce memory pressure at the expense of performance. If setting this does not reduce memory
     /// enough, turn off parallelization.
     pub fn set_low_memory(mut self, low_memory: bool) -> Self {
@@ -172,6 +141,11 @@ impl<R: MmapBytesReader> ParquetReader<R> {
         }
         Ok(self.metadata.as_ref().unwrap())
     }
+
+    pub fn with_predicate(mut self, predicate: Option<Arc<dyn PhysicalIoExpr>>) -> Self {
+        self.predicate = predicate;
+        self
+    }
 }
 
 impl<R: MmapBytesReader + 'static> ParquetReader<R> {
@@ -186,7 +160,7 @@ impl<R: MmapBytesReader + 'static> ParquetReader<R> {
             schema,
             self.n_rows.unwrap_or(usize::MAX),
             self.projection,
-            None,
+            self.predicate.clone(),
             self.row_count,
             chunk_size,
             self.use_statistics,
@@ -208,6 +182,7 @@ impl<R: MmapBytesReader> SerReader<R> for ParquetReader<R> {
             row_count: None,
             low_memory: false,
             metadata: None,
+            predicate: None,
             schema: None,
             use_statistics: true,
             hive_partition_columns: None,
@@ -233,7 +208,7 @@ impl<R: MmapBytesReader> SerReader<R> for ParquetReader<R> {
             self.projection.as_deref(),
             &schema,
             Some(metadata),
-            None,
+            self.predicate.as_deref(),
             self.parallel,
             self.row_count,
             self.use_statistics,

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -284,7 +284,8 @@ fn rg_to_dfs_par_over_rg(
         .collect::<Vec<_>>();
 
     let dfs = row_groups
-        .into_par_iter()
+        // .into_par_iter()
+        .into_iter()
         .map(|(rg_idx, md, projection_height, row_count_start)| {
             if projection_height == 0
                 || use_statistics
@@ -602,6 +603,7 @@ impl BatchedParquetReader {
             return Ok(None);
         }
 
+        let mut skipped_all_rgs = false;
         // fill up fifo stack
         if self.row_group_offset <= self.n_row_groups && self.chunks_fifo.len() < n {
             // Ensure we apply the limit on the metadata, before we download the row-groups.
@@ -650,6 +652,7 @@ impl BatchedParquetReader {
             // TODO! this is slower than it needs to be
             // we also need to parallelize over row groups here.
 
+            skipped_all_rgs |= dfs.is_empty();
             for mut df in dfs {
                 // make sure that the chunks are not too large
                 let n = df.shape().0 / self.chunk_size;
@@ -664,7 +667,16 @@ impl BatchedParquetReader {
         };
 
         if self.chunks_fifo.is_empty() {
-            Ok(None)
+            if skipped_all_rgs {
+                Ok(Some(vec![materialize_empty_df(
+                    Some(self.projection.as_slice()),
+                    self.schema(),
+                    self.hive_partition_columns.as_deref(),
+                    self.row_count.as_ref(),
+                )]))
+            } else {
+                Ok(None)
+            }
         } else {
             let mut chunks = Vec::with_capacity(n);
             let mut i = 0;

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -605,7 +605,7 @@ impl BatchedParquetReader {
 
         let mut skipped_all_rgs = false;
         // fill up fifo stack
-        if self.row_group_offset <= self.n_row_groups && self.chunks_fifo.len() < n {
+        if self.row_group_offset < self.n_row_groups && self.chunks_fifo.len() < n {
             // Ensure we apply the limit on the metadata, before we download the row-groups.
             let row_group_start = self.row_group_offset;
             let row_group_end = compute_row_group_range(

--- a/crates/polars-io/src/predicates.rs
+++ b/crates/polars-io/src/predicates.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub trait PhysicalIoExpr: Send + Sync {
     /// Take a [`DataFrame`] and produces a boolean [`Series`] that serves
     /// as a predicate mask
-    fn evaluate(&self, df: &DataFrame) -> PolarsResult<Series>;
+    fn evaluate_io(&self, df: &DataFrame) -> PolarsResult<Series>;
 
     /// Can take &dyn Statistics and determine of a file should be
     /// read -> `true`
@@ -26,7 +26,7 @@ pub(crate) fn apply_predicate(
     parallel: bool,
 ) -> PolarsResult<()> {
     if let (Some(predicate), false) = (&predicate, df.is_empty()) {
-        let s = predicate.evaluate(df)?;
+        let s = predicate.evaluate_io(df)?;
         let mask = s.bool().expect("filter predicates was not of type boolean");
 
         if parallel {

--- a/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/parquet.rs
@@ -134,10 +134,9 @@ impl ParquetExec {
                             reader
                                 .with_n_rows(remaining_rows_to_read)
                                 .with_row_count(row_count)
-                                ._finish_with_scan_ops(
-                                    predicate.clone(),
-                                    projection.as_ref().map(|v| v.as_ref()),
-                                )
+                                .with_predicate(predicate.clone())
+                                .with_projection(projection.clone())
+                                .finish()
                         },
                     )
                     .collect::<PolarsResult<Vec<_>>>()

--- a/crates/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -639,7 +639,7 @@ pub struct PhysicalIoHelper {
 }
 
 impl PhysicalIoExpr for PhysicalIoHelper {
-    fn evaluate(&self, df: &DataFrame) -> PolarsResult<Series> {
+    fn evaluate_io(&self, df: &DataFrame) -> PolarsResult<Series> {
         let mut state: ExecutionState = Default::default();
         if self.has_window_function {
             state.insert_has_window_function_flag();

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 
 use polars_core::datatypes::Field;
 use polars_core::error::PolarsResult;
+use polars_core::frame::DataFrame;
 use polars_core::prelude::{DataType, SchemaRef, Series, IDX_DTYPE};
 use polars_core::schema::Schema;
+use polars_io::predicates::PhysicalIoExpr;
 use polars_plan::dsl::Expr;
 use polars_plan::logical_plan::{ArenaExprIter, Context};
 use polars_plan::prelude::{AAggExpr, AExpr};
@@ -23,6 +25,11 @@ use crate::operators::DataChunk;
 
 struct Count {}
 
+impl PhysicalIoExpr for Count {
+    fn evaluate_io(&self, _df: &DataFrame) -> PolarsResult<Series> {
+        unimplemented!()
+    }
+}
 impl PhysicalPipedExpr for Count {
     fn evaluate(&self, chunk: &DataChunk, _lazy_state: &dyn Any) -> PolarsResult<Series> {
         // the length must match the chunks as the operators expect that

--- a/crates/polars-pipe/src/expressions.rs
+++ b/crates/polars-pipe/src/expressions.rs
@@ -1,11 +1,12 @@
 use std::any::Any;
 
 use polars_core::prelude::*;
+use polars_io::predicates::PhysicalIoExpr;
 use polars_plan::dsl::Expr;
 
 use crate::operators::DataChunk;
 
-pub trait PhysicalPipedExpr: Send + Sync {
+pub trait PhysicalPipedExpr: PhysicalIoExpr + Send + Sync {
     /// Take a [`DataFrame`] and produces a boolean [`Series`] that serves
     /// as a predicate mask
     fn evaluate(&self, chunk: &DataChunk, lazy_state: &dyn Any) -> PolarsResult<Series>;

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use hashbrown::hash_map::Entry;
 use polars_core::prelude::*;
 use polars_core::with_match_physical_integer_polars_type;
+#[cfg(feature = "parquet")]
 use polars_io::predicates::{PhysicalIoExpr, StatsEvaluator};
 use polars_ops::prelude::JoinType;
 use polars_plan::prelude::*;


### PR DESCRIPTION
It turned out we didn't push the predicates all the way in the readers for streaming queries. Meaning that we still loaded, and worse, downloaded files we don't need.

closes #12419