### PR TITLE
feat(python)!: Change `DataType.is_nested` from property to classmethod

### DIFF
--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -42,7 +42,7 @@ def test_dtype() -> None:
         "dt": pl.List(pl.Date),
         "dtm": pl.List(pl.Datetime),
     }
-    assert all(tp in pl.NESTED_DTYPES for tp in df.dtypes)
+    assert all(tp.is_nested() for tp in df.dtypes)
     assert df.schema["i"].inner == pl.Int8  # type: ignore[union-attr]
     assert df.rows() == [
         (
@@ -76,7 +76,7 @@ def test_categorical() -> None:
     )
 
     assert out.dtype.inner == pl.Categorical  # type: ignore[union-attr]
-    assert out.dtype.inner not in pl.NESTED_DTYPES  # type: ignore[union-attr]
+    assert out.dtype.inner.is_nested() is False  # type: ignore[union-attr]
 
 
 def test_cast_inner() -> None:
@@ -593,9 +593,8 @@ def test_list_inner_cast_physical_11513() -> None:
 @pytest.mark.parametrize(
     ("dtype", "expected"), [(pl.List, True), (pl.Struct, True), (pl.Utf8, False)]
 )
-def test_list_is_nested_deprecated(dtype: PolarsDataType, expected: bool) -> None:
-    with pytest.deprecated_call():
-        assert dtype.is_nested is expected
+def test_datatype_is_nested(dtype: PolarsDataType, expected: bool) -> None:
+    assert dtype.is_nested() is expected
 
 
 def test_list_series_construction_with_dtype_11849_11878() -> None:

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -153,7 +153,7 @@ def test_struct_unnest_multiple() -> None:
     # List input
     result = df_structs.unnest(["s1", "s2"])
     assert_frame_equal(result, df)
-    assert all(tp in pl.NESTED_DTYPES for tp in df_structs.dtypes)
+    assert all(tp.is_nested() for tp in df_structs.dtypes)
 
     # Positional input
     result = df_structs.unnest("s1", "s2")


### PR DESCRIPTION
**THIS IS A BREAKING CHANGE**

Ref https://github.com/pola-rs/polars/issues/12196

This completes the data type checking methods.

Note this is an accellerated breaking change because the intended usage could not be introduced without breaking the previous usage.

#### Example

**Before**

```
>>> pl.List(pl.Int8).is_nested
True
```

**After**

```
>>> pl.List(pl.Int8).is_nested()
True
```
