### PR TITLE
depr(python): Deprecate DataType method `is_not`

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -148,6 +148,9 @@ class DataType(metaclass=DataTypeClass):
         """
         Check if this DataType is NOT the same as another DataType.
 
+        .. deprecated:: 0.19.14
+            Use `not dtype.is_(...)` instead.
+
         This is a stricter check than `self != other`, as it enforces an exact
         match of all dtype attributes for nested and/or uninitialised dtypes.
 
@@ -160,10 +163,17 @@ class DataType(metaclass=DataTypeClass):
         --------
         >>> pl.List != pl.List(pl.Int32)
         False
-        >>> pl.List.is_not(pl.List(pl.Int32))
+        >>> pl.List.is_not(pl.List(pl.Int32))  # doctest: +SKIP
         True
 
         """
+        from polars.utils.deprecation import issue_deprecation_warning
+
+        issue_deprecation_warning(
+            "`DataType.is_not` is deprecated and will be removed in the next breaking release."
+            " Use `not dtype.is_(...)` instead.",
+            version="0.19.14",
+        )
         return not self.is_(other)
 
     @classproperty

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -542,7 +542,7 @@ def sequence_to_pyseries(
                 return PySeries.new_object(name, values, strict)
             if dtype:
                 srs = sequence_from_anyvalue_and_dtype_or_object(name, values, dtype)
-                if dtype.is_not(srs.dtype()):
+                if not dtype.is_(srs.dtype()):
                     srs = srs.cast(dtype, strict=False)
                 return srs
             return sequence_from_anyvalue_or_object(name, values)

--- a/py-polars/tests/unit/datatypes/test_duration.py
+++ b/py-polars/tests/unit/datatypes/test_duration.py
@@ -15,4 +15,4 @@ def test_duration_cumsum() -> None:
         pl.Duration(time_unit="ms"),
         pl.Duration(time_unit="ns"),
     ):
-        assert df.schema["A"].is_not(duration_dtype)  # type: ignore[arg-type]
+        assert df.schema["A"].is_(duration_dtype) is False  # type: ignore[arg-type]

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -85,8 +85,9 @@ def test_struct_equality_strict() -> None:
     )
 
     # strict
-    assert not (s1.is_(s2))
-    assert s1.is_not(s2)
+    assert s1.is_(s2) is False
+    with pytest.deprecated_call():
+        assert s1.is_not(s2) is True
 
     # permissive (default)
     assert s1 == s2


### PR DESCRIPTION
This method does not offer anything that `DataType.is_` does not already offer us. We don't offer `is_not_integer`, `is_not_nested` etc. either, so I think we're better off without this method. It's not like this is used so commonly that the method is a must-have.

@alexander-beedie I think you introduced this one - what are your thoughts on this?