### PR TITLE
refactor(rust): rename the `DataType` in the polars-arrow  crate to `ArrowDataType` for clarity, preventing conflation with our own/native `DataType`

### DIFF
--- a/crates/polars-arrow/src/array/binary/mod.rs
+++ b/crates/polars-arrow/src/array/binary/mod.rs
@@ -5,7 +5,7 @@ use super::{Array, GenericBinaryArray};
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 use crate::bitmap::Bitmap;
 use crate::buffer::Buffer;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::{Offset, Offsets, OffsetsBuffer};
 use crate::trusted_len::TrustedLen;
 
@@ -55,7 +55,7 @@ mod data;
 /// * `len` is equal to `validity.len()`, when defined.
 #[derive(Clone)]
 pub struct BinaryArray<O: Offset> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     offsets: OffsetsBuffer<O>,
     values: Buffer<u8>,
     validity: Option<Bitmap>,
@@ -72,7 +72,7 @@ impl<O: Offset> BinaryArray<O> {
     /// # Implementation
     /// This function is `O(1)`
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
@@ -159,9 +159,9 @@ impl<O: Offset> BinaryArray<O> {
         }
     }
 
-    /// Returns the [`DataType`] of this array.
+    /// Returns the [`ArrowDataType`] of this array.
     #[inline]
-    pub fn data_type(&self) -> &DataType {
+    pub fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 
@@ -216,7 +216,7 @@ impl<O: Offset> BinaryArray<O> {
 
     /// Returns its internal representation
     #[must_use]
-    pub fn into_inner(self) -> (DataType, OffsetsBuffer<O>, Buffer<u8>, Option<Bitmap>) {
+    pub fn into_inner(self) -> (ArrowDataType, OffsetsBuffer<O>, Buffer<u8>, Option<Bitmap>) {
         let Self {
             data_type,
             offsets,
@@ -294,13 +294,13 @@ impl<O: Offset> BinaryArray<O> {
     }
 
     /// Creates an empty [`BinaryArray`], i.e. whose `.len` is zero.
-    pub fn new_empty(data_type: DataType) -> Self {
+    pub fn new_empty(data_type: ArrowDataType) -> Self {
         Self::new(data_type, OffsetsBuffer::new(), Buffer::new(), None)
     }
 
     /// Creates an null [`BinaryArray`], i.e. whose `.null_count() == .len()`.
     #[inline]
-    pub fn new_null(data_type: DataType, length: usize) -> Self {
+    pub fn new_null(data_type: ArrowDataType, length: usize) -> Self {
         Self::new(
             data_type,
             Offsets::new_zeroed(length).into(),
@@ -309,18 +309,18 @@ impl<O: Offset> BinaryArray<O> {
         )
     }
 
-    /// Returns the default [`DataType`], `DataType::Binary` or `DataType::LargeBinary`
-    pub fn default_data_type() -> DataType {
+    /// Returns the default [`ArrowDataType`], `DataType::Binary` or `DataType::LargeBinary`
+    pub fn default_data_type() -> ArrowDataType {
         if O::IS_LARGE {
-            DataType::LargeBinary
+            ArrowDataType::LargeBinary
         } else {
-            DataType::Binary
+            ArrowDataType::Binary
         }
     }
 
     /// Alias for unwrapping [`Self::try_new`]
     pub fn new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,

--- a/crates/polars-arrow/src/array/binary/mutable.rs
+++ b/crates/polars-arrow/src/array/binary/mutable.rs
@@ -8,7 +8,7 @@ use crate::array::physical_binary::*;
 use crate::array::{Array, MutableArray, TryExtend, TryExtendFromSelf, TryPush};
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 use crate::bitmap::{Bitmap, MutableBitmap};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::{Offset, Offsets};
 use crate::trusted_len::TrustedLen;
 
@@ -57,7 +57,7 @@ impl<O: Offset> MutableBinaryArray<O> {
     /// # Implementation
     /// This function is `O(1)`
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: Offsets<O>,
         values: Vec<u8>,
         validity: Option<MutableBitmap>,
@@ -80,7 +80,7 @@ impl<O: Offset> MutableBinaryArray<O> {
         Self::from_trusted_len_iter(slice.as_ref().iter().map(|x| x.as_ref()))
     }
 
-    fn default_data_type() -> DataType {
+    fn default_data_type() -> ArrowDataType {
         BinaryArray::<O>::default_data_type()
     }
 
@@ -202,7 +202,7 @@ impl<O: Offset> MutableArray for MutableBinaryArray<O> {
         array.arced()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         self.values.data_type()
     }
 

--- a/crates/polars-arrow/src/array/binary/mutable_values.rs
+++ b/crates/polars-arrow/src/array/binary/mutable_values.rs
@@ -10,7 +10,7 @@ use crate::array::{
     Array, ArrayAccessor, ArrayValuesIter, MutableArray, TryExtend, TryExtendFromSelf, TryPush,
 };
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::{Offset, Offsets};
 use crate::trusted_len::TrustedLen;
 
@@ -18,7 +18,7 @@ use crate::trusted_len::TrustedLen;
 /// from [`MutableBinaryArray`] in that it builds non-null [`BinaryArray`].
 #[derive(Debug, Clone)]
 pub struct MutableBinaryValuesArray<O: Offset> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     offsets: Offsets<O>,
     values: Vec<u8>,
 }
@@ -66,7 +66,7 @@ impl<O: Offset> MutableBinaryValuesArray<O> {
     /// # Implementation
     /// This function is `O(1)`
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: Offsets<O>,
         values: Vec<u8>,
     ) -> PolarsResult<Self> {
@@ -83,9 +83,9 @@ impl<O: Offset> MutableBinaryValuesArray<O> {
         })
     }
 
-    /// Returns the default [`DataType`] of this container: [`DataType::Utf8`] or [`DataType::LargeUtf8`]
+    /// Returns the default [`ArrowDataType`] of this container: [`ArrowDataType::Utf8`] or [`ArrowDataType::LargeUtf8`]
     /// depending on the generic [`Offset`].
-    pub fn default_data_type() -> DataType {
+    pub fn default_data_type() -> ArrowDataType {
         BinaryArray::<O>::default_data_type()
     }
 
@@ -186,7 +186,7 @@ impl<O: Offset> MutableBinaryValuesArray<O> {
     }
 
     /// Extract the low-end APIs from the [`MutableBinaryValuesArray`].
-    pub fn into_inner(self) -> (DataType, Offsets<O>, Vec<u8>) {
+    pub fn into_inner(self) -> (ArrowDataType, Offsets<O>, Vec<u8>) {
         (self.data_type, self.offsets, self.values)
     }
 }
@@ -210,7 +210,7 @@ impl<O: Offset> MutableArray for MutableBinaryValuesArray<O> {
         BinaryArray::new(data_type, offsets.into(), values.into(), None).arced()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-arrow/src/array/boolean/data.rs
+++ b/crates/polars-arrow/src/array/boolean/data.rs
@@ -3,7 +3,7 @@ use arrow_data::{ArrayData, ArrayDataBuilder};
 
 use crate::array::{Arrow2Arrow, BooleanArray};
 use crate::bitmap::Bitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 impl Arrow2Arrow for BooleanArray {
     fn to_data(&self) -> ArrayData {
@@ -28,7 +28,7 @@ impl Arrow2Arrow for BooleanArray {
         let values = Bitmap::from_null_buffer(NullBuffer::new(buffer));
 
         Self {
-            data_type: DataType::Boolean,
+            data_type: ArrowDataType::Boolean,
             values,
             validity: data.nulls().map(|n| Bitmap::from_null_buffer(n.clone())),
         }

--- a/crates/polars-arrow/src/array/boolean/mod.rs
+++ b/crates/polars-arrow/src/array/boolean/mod.rs
@@ -3,7 +3,7 @@ use either::Either;
 use super::Array;
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 use crate::bitmap::{Bitmap, MutableBitmap};
-use crate::datatypes::{DataType, PhysicalType};
+use crate::datatypes::{ArrowDataType, PhysicalType};
 use crate::trusted_len::TrustedLen;
 
 #[cfg(feature = "arrow_rs")]
@@ -45,7 +45,7 @@ use polars_error::{polars_bail, PolarsResult};
 /// ```
 #[derive(Clone)]
 pub struct BooleanArray {
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Bitmap,
     validity: Option<Bitmap>,
 }
@@ -57,7 +57,7 @@ impl BooleanArray {
     /// * The validity is not `None` and its length is different from `values`'s length
     /// * The `data_type`'s [`PhysicalType`] is not equal to [`PhysicalType::Boolean`].
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         values: Bitmap,
         validity: Option<Bitmap>,
     ) -> PolarsResult<Self> {
@@ -80,7 +80,7 @@ impl BooleanArray {
     }
 
     /// Alias to `Self::try_new().unwrap()`
-    pub fn new(data_type: DataType, values: Bitmap, validity: Option<Bitmap>) -> Self {
+    pub fn new(data_type: ArrowDataType, values: Bitmap, validity: Option<Bitmap>) -> Self {
         Self::try_new(data_type, values, validity).unwrap()
     }
 
@@ -115,9 +115,9 @@ impl BooleanArray {
         self.validity.as_ref()
     }
 
-    /// Returns the arrays' [`DataType`].
+    /// Returns the arrays' [`ArrowDataType`].
     #[inline]
-    pub fn data_type(&self) -> &DataType {
+    pub fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 
@@ -254,12 +254,12 @@ impl BooleanArray {
     }
 
     /// Returns a new empty [`BooleanArray`].
-    pub fn new_empty(data_type: DataType) -> Self {
+    pub fn new_empty(data_type: ArrowDataType) -> Self {
         Self::new(data_type, Bitmap::new(), None)
     }
 
     /// Returns a new [`BooleanArray`] whose all slots are null / `None`.
-    pub fn new_null(data_type: DataType, length: usize) -> Self {
+    pub fn new_null(data_type: ArrowDataType, length: usize) -> Self {
         let bitmap = Bitmap::new_zeroed(length);
         Self::new(data_type, bitmap.clone(), Some(bitmap))
     }
@@ -339,7 +339,7 @@ impl BooleanArray {
 
     /// Returns its internal representation
     #[must_use]
-    pub fn into_inner(self) -> (DataType, Bitmap, Option<Bitmap>) {
+    pub fn into_inner(self) -> (ArrowDataType, Bitmap, Option<Bitmap>) {
         let Self {
             data_type,
             values,
@@ -354,7 +354,7 @@ impl BooleanArray {
     /// # Safety
     /// Callers must ensure all invariants of this struct are upheld.
     pub unsafe fn from_inner_unchecked(
-        data_type: DataType,
+        data_type: ArrowDataType,
         values: Bitmap,
         validity: Option<Bitmap>,
     ) -> Self {

--- a/crates/polars-arrow/src/array/boolean/mutable.rs
+++ b/crates/polars-arrow/src/array/boolean/mutable.rs
@@ -7,7 +7,7 @@ use super::BooleanArray;
 use crate::array::physical_binary::extend_validity;
 use crate::array::{Array, MutableArray, TryExtend, TryExtendFromSelf, TryPush};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::{DataType, PhysicalType};
+use crate::datatypes::{ArrowDataType, PhysicalType};
 use crate::trusted_len::TrustedLen;
 
 /// The Arrow's equivalent to `Vec<Option<bool>>`, but with `1/16` of its size.
@@ -16,7 +16,7 @@ use crate::trusted_len::TrustedLen;
 /// This struct does not allocate a validity until one is required (i.e. push a null to it).
 #[derive(Debug, Clone)]
 pub struct MutableBooleanArray {
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: MutableBitmap,
     validity: Option<MutableBitmap>,
 }
@@ -56,7 +56,7 @@ impl MutableBooleanArray {
     /// * The validity is not `None` and its length is different from `values`'s length
     /// * The `data_type`'s [`PhysicalType`] is not equal to [`PhysicalType::Boolean`].
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         values: MutableBitmap,
         validity: Option<MutableBitmap>,
     ) -> PolarsResult<Self> {
@@ -85,7 +85,7 @@ impl MutableBooleanArray {
     /// Creates an new [`MutableBooleanArray`] with a capacity of values.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            data_type: DataType::Boolean,
+            data_type: ArrowDataType::Boolean,
             values: MutableBitmap::with_capacity(capacity),
             validity: None,
         }
@@ -245,7 +245,7 @@ impl MutableBooleanArray {
     #[inline]
     pub fn from_trusted_len_values_iter<I: TrustedLen<Item = bool>>(iterator: I) -> Self {
         Self::try_new(
-            DataType::Boolean,
+            ArrowDataType::Boolean,
             MutableBitmap::from_trusted_len_iter(iterator),
             None,
         )
@@ -264,7 +264,7 @@ impl MutableBooleanArray {
     ) -> Self {
         let mut mutable = MutableBitmap::new();
         mutable.extend_from_trusted_len_iter_unchecked(iterator);
-        MutableBooleanArray::try_new(DataType::Boolean, mutable, None).unwrap()
+        MutableBooleanArray::try_new(ArrowDataType::Boolean, mutable, None).unwrap()
     }
 
     /// Creates a new [`MutableBooleanArray`] from a slice of `bool`.
@@ -287,7 +287,7 @@ impl MutableBooleanArray {
     {
         let (validity, values) = trusted_len_unzip(iterator);
 
-        Self::try_new(DataType::Boolean, values, validity).unwrap()
+        Self::try_new(ArrowDataType::Boolean, values, validity).unwrap()
     }
 
     /// Creates a [`BooleanArray`] from a [`TrustedLen`].
@@ -321,7 +321,7 @@ impl MutableBooleanArray {
             None
         };
 
-        Ok(Self::try_new(DataType::Boolean, values, validity).unwrap())
+        Ok(Self::try_new(ArrowDataType::Boolean, values, validity).unwrap())
     }
 
     /// Creates a [`BooleanArray`] from a [`TrustedLen`].
@@ -471,7 +471,7 @@ impl<Ptr: std::borrow::Borrow<Option<bool>>> FromIterator<Ptr> for MutableBoolea
             None
         };
 
-        MutableBooleanArray::try_new(DataType::Boolean, values, validity).unwrap()
+        MutableBooleanArray::try_new(ArrowDataType::Boolean, values, validity).unwrap()
     }
 }
 
@@ -494,7 +494,7 @@ impl MutableArray for MutableBooleanArray {
         array.arced()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-arrow/src/array/dictionary/data.rs
+++ b/crates/polars-arrow/src/array/dictionary/data.rs
@@ -3,7 +3,7 @@ use arrow_data::{ArrayData, ArrayDataBuilder};
 use crate::array::{
     from_data, to_data, Arrow2Arrow, DictionaryArray, DictionaryKey, PrimitiveArray,
 };
-use crate::datatypes::{DataType, PhysicalType};
+use crate::datatypes::{ArrowDataType, PhysicalType};
 
 impl<K: DictionaryKey> Arrow2Arrow for DictionaryArray<K> {
     fn to_data(&self) -> ArrayData {
@@ -23,7 +23,7 @@ impl<K: DictionaryKey> Arrow2Arrow for DictionaryArray<K> {
             d => panic!("unsupported dictionary type {d}"),
         };
 
-        let data_type = DataType::from(data.data_type().clone());
+        let data_type = ArrowDataType::from(data.data_type().clone());
         assert_eq!(
             data_type.to_physical_type(),
             PhysicalType::Dictionary(K::KEY_TYPE)

--- a/crates/polars-arrow/src/array/dictionary/mod.rs
+++ b/crates/polars-arrow/src/array/dictionary/mod.rs
@@ -3,7 +3,7 @@ use std::hint::unreachable_unchecked;
 
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 use crate::bitmap::Bitmap;
-use crate::datatypes::{DataType, IntegerType};
+use crate::datatypes::{ArrowDataType, IntegerType};
 use crate::scalar::{new_scalar, Scalar};
 use crate::trusted_len::TrustedLen;
 use crate::types::NativeType;
@@ -104,17 +104,17 @@ unsafe impl DictionaryKey for u64 {
 /// use `unchecked` calls to retrieve the values
 #[derive(Clone)]
 pub struct DictionaryArray<K: DictionaryKey> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     keys: PrimitiveArray<K>,
     values: Box<dyn Array>,
 }
 
 fn check_data_type(
     key_type: IntegerType,
-    data_type: &DataType,
-    values_data_type: &DataType,
+    data_type: &ArrowDataType,
+    values_data_type: &ArrowDataType,
 ) -> PolarsResult<()> {
-    if let DataType::Dictionary(key, value, _) = data_type.to_logical_type() {
+    if let ArrowDataType::Dictionary(key, value, _) = data_type.to_logical_type() {
         if *key != key_type {
             polars_bail!(ComputeError: "DictionaryArray must be initialized with a DataType::Dictionary whose integer is compatible to its keys")
         }
@@ -138,7 +138,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// * the `data_type`'s values's data_type is not equal with `values.data_type()`
     /// * any of the keys's values is not represented in `usize` or is `>= values.len()`
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         keys: PrimitiveArray<K>,
         values: Box<dyn Array>,
     ) -> PolarsResult<Self> {
@@ -181,7 +181,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// # Safety
     /// The caller must ensure that every keys's values is represented in `usize` and is `< values.len()`
     pub unsafe fn try_new_unchecked(
-        data_type: DataType,
+        data_type: ArrowDataType,
         keys: PrimitiveArray<K>,
         values: Box<dyn Array>,
     ) -> PolarsResult<Self> {
@@ -195,7 +195,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     }
 
     /// Returns a new empty [`DictionaryArray`].
-    pub fn new_empty(data_type: DataType) -> Self {
+    pub fn new_empty(data_type: ArrowDataType) -> Self {
         let values = Self::try_get_child(&data_type).unwrap();
         let values = new_empty_array(values.clone());
         Self::try_new(
@@ -208,7 +208,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
 
     /// Returns an [`DictionaryArray`] whose all elements are null
     #[inline]
-    pub fn new_null(data_type: DataType, length: usize) -> Self {
+    pub fn new_null(data_type: ArrowDataType, length: usize) -> Self {
         let values = Self::try_get_child(&data_type).unwrap();
         let values = new_null_array(values.clone(), 1);
         Self::try_new(
@@ -265,9 +265,9 @@ impl<K: DictionaryKey> DictionaryArray<K> {
         Ok(ZipValidity::new_with_validity(values_iter, self.validity()))
     }
 
-    /// Returns the [`DataType`] of this [`DictionaryArray`]
+    /// Returns the [`ArrowDataType`] of this [`DictionaryArray`]
     #[inline]
-    pub fn data_type(&self) -> &DataType {
+    pub fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 
@@ -275,13 +275,13 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     #[inline]
     pub fn is_ordered(&self) -> bool {
         match self.data_type.to_logical_type() {
-            DataType::Dictionary(_, _, is_ordered) => *is_ordered,
+            ArrowDataType::Dictionary(_, _, is_ordered) => *is_ordered,
             _ => unreachable!(),
         }
     }
 
-    pub(crate) fn default_data_type(values_datatype: DataType) -> DataType {
-        DataType::Dictionary(K::KEY_TYPE, Box::new(values_datatype), false)
+    pub(crate) fn default_data_type(values_datatype: ArrowDataType) -> ArrowDataType {
+        ArrowDataType::Dictionary(K::KEY_TYPE, Box::new(values_datatype), false)
     }
 
     /// Slices this [`DictionaryArray`].
@@ -379,9 +379,9 @@ impl<K: DictionaryKey> DictionaryArray<K> {
         new_scalar(self.values.as_ref(), index)
     }
 
-    pub(crate) fn try_get_child(data_type: &DataType) -> PolarsResult<&DataType> {
+    pub(crate) fn try_get_child(data_type: &ArrowDataType) -> PolarsResult<&ArrowDataType> {
         Ok(match data_type.to_logical_type() {
-            DataType::Dictionary(_, values, _) => values.as_ref(),
+            ArrowDataType::Dictionary(_, values, _) => values.as_ref(),
             _ => {
                 polars_bail!(ComputeError: "Dictionaries must be initialized with DataType::Dictionary")
             },

--- a/crates/polars-arrow/src/array/dictionary/mutable.rs
+++ b/crates/polars-arrow/src/array/dictionary/mutable.rs
@@ -9,11 +9,11 @@ use crate::array::indexable::{AsIndexed, Indexable};
 use crate::array::primitive::MutablePrimitiveArray;
 use crate::array::{Array, MutableArray, TryExtend, TryPush};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 #[derive(Debug)]
 pub struct MutableDictionaryArray<K: DictionaryKey, M: MutableArray> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     map: ValueMap<K, M>,
     // invariant: `max(keys) < map.values().len()`
     keys: MutablePrimitiveArray<K>,
@@ -70,7 +70,7 @@ impl<K: DictionaryKey, M: MutableArray> MutableDictionaryArray<K, M> {
     fn from_value_map(value_map: ValueMap<K, M>) -> Self {
         let keys = MutablePrimitiveArray::<K>::new();
         let data_type =
-            DataType::Dictionary(K::KEY_TYPE, Box::new(value_map.data_type().clone()), false);
+            ArrowDataType::Dictionary(K::KEY_TYPE, Box::new(value_map.data_type().clone()), false);
         Self {
             data_type,
             map: value_map,
@@ -159,7 +159,7 @@ impl<K: DictionaryKey, M: 'static + MutableArray> MutableArray for MutableDictio
         Arc::new(self.take_into())
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-arrow/src/array/dictionary/value_map.rs
+++ b/crates/polars-arrow/src/array/dictionary/value_map.rs
@@ -9,7 +9,7 @@ use polars_error::{polars_bail, polars_err, PolarsResult};
 use super::DictionaryKey;
 use crate::array::indexable::{AsIndexed, Indexable};
 use crate::array::{Array, MutableArray};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// Hasher for pre-hashed values; similar to `hash_hasher` but with native endianness.
 ///
@@ -101,7 +101,7 @@ impl<K: DictionaryKey, M: MutableArray> ValueMap<K, M> {
         Ok(Self { values, map })
     }
 
-    pub fn data_type(&self) -> &DataType {
+    pub fn data_type(&self) -> &ArrowDataType {
         self.values.data_type()
     }
 

--- a/crates/polars-arrow/src/array/fixed_size_binary/data.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/data.rs
@@ -3,7 +3,7 @@ use arrow_data::{ArrayData, ArrayDataBuilder};
 use crate::array::{Arrow2Arrow, FixedSizeBinaryArray};
 use crate::bitmap::Bitmap;
 use crate::buffer::Buffer;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 impl Arrow2Arrow for FixedSizeBinaryArray {
     fn to_data(&self) -> ArrayData {
@@ -18,9 +18,9 @@ impl Arrow2Arrow for FixedSizeBinaryArray {
     }
 
     fn from_data(data: &ArrayData) -> Self {
-        let data_type: DataType = data.data_type().clone().into();
+        let data_type: ArrowDataType = data.data_type().clone().into();
         let size = match data_type {
-            DataType::FixedSizeBinary(size) => size,
+            ArrowDataType::FixedSizeBinary(size) => size,
             _ => unreachable!("must be FixedSizeBinary"),
         };
 

--- a/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
@@ -1,7 +1,7 @@
 use super::Array;
 use crate::bitmap::Bitmap;
 use crate::buffer::Buffer;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 #[cfg(feature = "arrow_rs")]
 mod data;
@@ -17,7 +17,7 @@ use polars_error::{polars_bail, polars_ensure, PolarsResult};
 #[derive(Clone)]
 pub struct FixedSizeBinaryArray {
     size: usize, // this is redundant with `data_type`, but useful to not have to deconstruct the data_type.
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Buffer<u8>,
     validity: Option<Bitmap>,
 }
@@ -31,7 +31,7 @@ impl FixedSizeBinaryArray {
     /// * The length of `values` is not a multiple of `size` in `data_type`
     /// * the validity's length is not equal to `values.len() / size`.
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
     ) -> PolarsResult<Self> {
@@ -67,17 +67,17 @@ impl FixedSizeBinaryArray {
     /// * The `data_type`'s physical type is not [`crate::datatypes::PhysicalType::FixedSizeBinary`]
     /// * The length of `values` is not a multiple of `size` in `data_type`
     /// * the validity's length is not equal to `values.len() / size`.
-    pub fn new(data_type: DataType, values: Buffer<u8>, validity: Option<Bitmap>) -> Self {
+    pub fn new(data_type: ArrowDataType, values: Buffer<u8>, validity: Option<Bitmap>) -> Self {
         Self::try_new(data_type, values, validity).unwrap()
     }
 
     /// Returns a new empty [`FixedSizeBinaryArray`].
-    pub fn new_empty(data_type: DataType) -> Self {
+    pub fn new_empty(data_type: ArrowDataType) -> Self {
         Self::new(data_type, Buffer::new(), None)
     }
 
     /// Returns a new null [`FixedSizeBinaryArray`].
-    pub fn new_null(data_type: DataType, length: usize) -> Self {
+    pub fn new_null(data_type: ArrowDataType, length: usize) -> Self {
         let size = Self::maybe_get_size(&data_type).unwrap();
         Self::new(
             data_type,
@@ -178,12 +178,12 @@ impl FixedSizeBinaryArray {
     /// # Panics
     /// Panics iff the data_type is not supported for the physical type.
     #[inline]
-    pub fn to(self, data_type: DataType) -> Self {
+    pub fn to(self, data_type: ArrowDataType) -> Self {
         match (
             data_type.to_logical_type(),
             self.data_type().to_logical_type(),
         ) {
-            (DataType::FixedSizeBinary(size_a), DataType::FixedSizeBinary(size_b))
+            (ArrowDataType::FixedSizeBinary(size_a), ArrowDataType::FixedSizeBinary(size_b))
                 if size_a == size_b => {},
             _ => panic!("Wrong DataType"),
         }
@@ -203,9 +203,9 @@ impl FixedSizeBinaryArray {
 }
 
 impl FixedSizeBinaryArray {
-    pub(crate) fn maybe_get_size(data_type: &DataType) -> PolarsResult<usize> {
+    pub(crate) fn maybe_get_size(data_type: &ArrowDataType) -> PolarsResult<usize> {
         match data_type.to_logical_type() {
-            DataType::FixedSizeBinary(size) => {
+            ArrowDataType::FixedSizeBinary(size) => {
                 polars_ensure!(*size != 0, ComputeError: "FixedSizeBinaryArray expects a positive size");
                 Ok(*size)
             },
@@ -215,7 +215,7 @@ impl FixedSizeBinaryArray {
         }
     }
 
-    pub fn get_size(data_type: &DataType) -> usize {
+    pub fn get_size(data_type: &ArrowDataType) -> usize {
         Self::maybe_get_size(data_type).unwrap()
     }
 }
@@ -255,7 +255,7 @@ impl FixedSizeBinaryArray {
     /// Creates a [`FixedSizeBinaryArray`] from a slice of arrays of bytes
     pub fn from_slice<const N: usize, P: AsRef<[[u8; N]]>>(a: P) -> Self {
         let values = a.as_ref().iter().flatten().copied().collect::<Vec<_>>();
-        Self::new(DataType::FixedSizeBinary(N), values.into(), None)
+        Self::new(ArrowDataType::FixedSizeBinary(N), values.into(), None)
     }
 
     /// Creates a new [`FixedSizeBinaryArray`] from a slice of optional `[u8]`.

--- a/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
@@ -6,7 +6,7 @@ use super::{FixedSizeBinaryArray, FixedSizeBinaryValues};
 use crate::array::physical_binary::extend_validity;
 use crate::array::{Array, MutableArray, TryExtendFromSelf};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// The Arrow's equivalent to a mutable `Vec<Option<[u8; size]>>`.
 /// Converting a [`MutableFixedSizeBinaryArray`] into a [`FixedSizeBinaryArray`] is `O(1)`.
@@ -14,7 +14,7 @@ use crate::datatypes::DataType;
 /// This struct does not allocate a validity until one is required (i.e. push a null to it).
 #[derive(Debug, Clone)]
 pub struct MutableFixedSizeBinaryArray {
-    data_type: DataType,
+    data_type: ArrowDataType,
     size: usize,
     values: Vec<u8>,
     validity: Option<MutableBitmap>,
@@ -39,7 +39,7 @@ impl MutableFixedSizeBinaryArray {
     /// * The length of `values` is not a multiple of `size` in `data_type`
     /// * the validity's length is not equal to `values.len() / size`.
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         values: Vec<u8>,
         validity: Option<MutableBitmap>,
     ) -> PolarsResult<Self> {
@@ -77,7 +77,7 @@ impl MutableFixedSizeBinaryArray {
     /// Creates a new [`MutableFixedSizeBinaryArray`] with capacity for `capacity` entries.
     pub fn with_capacity(size: usize, capacity: usize) -> Self {
         Self::try_new(
-            DataType::FixedSizeBinary(size),
+            ArrowDataType::FixedSizeBinary(size),
             Vec::<u8>::with_capacity(capacity * size),
             None,
         )
@@ -98,7 +98,7 @@ impl MutableFixedSizeBinaryArray {
             .iter()
             .map(|x| x.is_some())
             .collect::<MutableBitmap>();
-        Self::try_new(DataType::FixedSizeBinary(N), values, validity.into()).unwrap()
+        Self::try_new(ArrowDataType::FixedSizeBinary(N), values, validity.into()).unwrap()
     }
 
     /// tries to push a new entry to [`MutableFixedSizeBinaryArray`].
@@ -248,7 +248,7 @@ impl MutableArray for MutableFixedSizeBinaryArray {
 
     fn as_box(&mut self) -> Box<dyn Array> {
         FixedSizeBinaryArray::new(
-            DataType::FixedSizeBinary(self.size),
+            ArrowDataType::FixedSizeBinary(self.size),
             std::mem::take(&mut self.values).into(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
         )
@@ -257,14 +257,14 @@ impl MutableArray for MutableFixedSizeBinaryArray {
 
     fn as_arc(&mut self) -> Arc<dyn Array> {
         FixedSizeBinaryArray::new(
-            DataType::FixedSizeBinary(self.size),
+            ArrowDataType::FixedSizeBinary(self.size),
             std::mem::take(&mut self.values).into(),
             std::mem::take(&mut self.validity).map(|x| x.into()),
         )
         .arced()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-arrow/src/array/fixed_size_list/data.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/data.rs
@@ -2,7 +2,7 @@ use arrow_data::{ArrayData, ArrayDataBuilder};
 
 use crate::array::{from_data, to_data, Arrow2Arrow, FixedSizeListArray};
 use crate::bitmap::Bitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 impl Arrow2Arrow for FixedSizeListArray {
     fn to_data(&self) -> ArrayData {
@@ -17,9 +17,9 @@ impl Arrow2Arrow for FixedSizeListArray {
     }
 
     fn from_data(data: &ArrayData) -> Self {
-        let data_type: DataType = data.data_type().clone().into();
+        let data_type: ArrowDataType = data.data_type().clone().into();
         let size = match data_type {
-            DataType::FixedSizeList(_, size) => size,
+            ArrowDataType::FixedSizeList(_, size) => size,
             _ => unreachable!("must be FixedSizeList type"),
         };
 

--- a/crates/polars-arrow/src/array/fixed_size_list/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mod.rs
@@ -1,6 +1,6 @@
 use super::{new_empty_array, new_null_array, Array};
 use crate::bitmap::Bitmap;
-use crate::datatypes::{DataType, Field};
+use crate::datatypes::{ArrowDataType, Field};
 
 #[cfg(feature = "arrow_rs")]
 mod data;
@@ -17,7 +17,7 @@ use polars_error::{polars_bail, PolarsResult};
 #[derive(Clone)]
 pub struct FixedSizeListArray {
     size: usize, // this is redundant with `data_type`, but useful to not have to deconstruct the data_type.
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Box<dyn Array>,
     validity: Option<Bitmap>,
 }
@@ -32,7 +32,7 @@ impl FixedSizeListArray {
     /// * The length of `values` is not a multiple of `size` in `data_type`
     /// * the validity's length is not equal to `values.len() / size`.
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         values: Box<dyn Array>,
         validity: Option<Bitmap>,
     ) -> PolarsResult<Self> {
@@ -69,7 +69,7 @@ impl FixedSizeListArray {
     }
 
     /// Alias to `Self::try_new(...).unwrap()`
-    pub fn new(data_type: DataType, values: Box<dyn Array>, validity: Option<Bitmap>) -> Self {
+    pub fn new(data_type: ArrowDataType, values: Box<dyn Array>, validity: Option<Bitmap>) -> Self {
         Self::try_new(data_type, values, validity).unwrap()
     }
 
@@ -79,13 +79,13 @@ impl FixedSizeListArray {
     }
 
     /// Returns a new empty [`FixedSizeListArray`].
-    pub fn new_empty(data_type: DataType) -> Self {
+    pub fn new_empty(data_type: ArrowDataType) -> Self {
         let values = new_empty_array(Self::get_child_and_size(&data_type).0.data_type().clone());
         Self::new(data_type, values, None)
     }
 
     /// Returns a new null [`FixedSizeListArray`].
-    pub fn new_null(data_type: DataType, length: usize) -> Self {
+    pub fn new_null(data_type: ArrowDataType, length: usize) -> Self {
         let (field, size) = Self::get_child_and_size(&data_type);
 
         let values = new_null_array(field.data_type().clone(), length * size);
@@ -178,9 +178,9 @@ impl FixedSizeListArray {
 }
 
 impl FixedSizeListArray {
-    pub(crate) fn try_child_and_size(data_type: &DataType) -> PolarsResult<(&Field, usize)> {
+    pub(crate) fn try_child_and_size(data_type: &ArrowDataType) -> PolarsResult<(&Field, usize)> {
         match data_type.to_logical_type() {
-            DataType::FixedSizeList(child, size) => {
+            ArrowDataType::FixedSizeList(child, size) => {
                 if *size == 0 {
                     polars_bail!(ComputeError: "FixedSizeBinaryArray expects a positive size")
                 }
@@ -190,14 +190,14 @@ impl FixedSizeListArray {
         }
     }
 
-    pub(crate) fn get_child_and_size(data_type: &DataType) -> (&Field, usize) {
+    pub(crate) fn get_child_and_size(data_type: &ArrowDataType) -> (&Field, usize) {
         Self::try_child_and_size(data_type).unwrap()
     }
 
-    /// Returns a [`DataType`] consistent with [`FixedSizeListArray`].
-    pub fn default_datatype(data_type: DataType, size: usize) -> DataType {
+    /// Returns a [`ArrowDataType`] consistent with [`FixedSizeListArray`].
+    pub fn default_datatype(data_type: ArrowDataType, size: usize) -> ArrowDataType {
         let field = Box::new(Field::new("item", data_type, true));
-        DataType::FixedSizeList(field, size)
+        ArrowDataType::FixedSizeList(field, size)
     }
 }
 

--- a/crates/polars-arrow/src/array/fixed_size_list/mutable.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mutable.rs
@@ -6,12 +6,12 @@ use super::FixedSizeListArray;
 use crate::array::physical_binary::extend_validity;
 use crate::array::{Array, MutableArray, PushUnchecked, TryExtend, TryExtendFromSelf, TryPush};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::{DataType, Field};
+use crate::datatypes::{ArrowDataType, Field};
 
 /// The mutable version of [`FixedSizeListArray`].
 #[derive(Debug, Clone)]
 pub struct MutableFixedSizeListArray<M: MutableArray> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     size: usize,
     values: M,
     validity: Option<MutableBitmap>,
@@ -36,18 +36,18 @@ impl<M: MutableArray> MutableFixedSizeListArray<M> {
 
     /// Creates a new [`MutableFixedSizeListArray`] from a [`MutableArray`] and size.
     pub fn new_with_field(values: M, name: &str, nullable: bool, size: usize) -> Self {
-        let data_type = DataType::FixedSizeList(
+        let data_type = ArrowDataType::FixedSizeList(
             Box::new(Field::new(name, values.data_type().clone(), nullable)),
             size,
         );
         Self::new_from(values, data_type, size)
     }
 
-    /// Creates a new [`MutableFixedSizeListArray`] from a [`MutableArray`], [`DataType`] and size.
-    pub fn new_from(values: M, data_type: DataType, size: usize) -> Self {
+    /// Creates a new [`MutableFixedSizeListArray`] from a [`MutableArray`], [`ArrowDataType`] and size.
+    pub fn new_from(values: M, data_type: ArrowDataType, size: usize) -> Self {
         assert_eq!(values.len(), 0);
         match data_type {
-            DataType::FixedSizeList(..) => (),
+            ArrowDataType::FixedSizeList(..) => (),
             _ => panic!("data type must be FixedSizeList (got {data_type:?})"),
         };
         Self {
@@ -162,7 +162,7 @@ impl<M: MutableArray + 'static> MutableArray for MutableFixedSizeListArray<M> {
         .arced()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-arrow/src/array/growable/binary.rs
+++ b/crates/polars-arrow/src/array/growable/binary.rs
@@ -4,13 +4,13 @@ use super::utils::{build_extend_null_bits, extend_offset_values, ExtendNullBits}
 use super::Growable;
 use crate::array::{Array, BinaryArray};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::{Offset, Offsets};
 
 /// Concrete [`Growable`] for the [`BinaryArray`].
 pub struct GrowableBinary<'a, O: Offset> {
     arrays: Vec<&'a BinaryArray<O>>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     validity: MutableBitmap,
     values: Vec<u8>,
     offsets: Offsets<O>,

--- a/crates/polars-arrow/src/array/growable/boolean.rs
+++ b/crates/polars-arrow/src/array/growable/boolean.rs
@@ -4,12 +4,12 @@ use super::utils::{build_extend_null_bits, ExtendNullBits};
 use super::Growable;
 use crate::array::{Array, BooleanArray};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// Concrete [`Growable`] for the [`BooleanArray`].
 pub struct GrowableBoolean<'a> {
     arrays: Vec<&'a BooleanArray>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     validity: MutableBitmap,
     values: MutableBitmap,
     extend_null_bits: Vec<ExtendNullBits<'a>>,

--- a/crates/polars-arrow/src/array/growable/dictionary.rs
+++ b/crates/polars-arrow/src/array/growable/dictionary.rs
@@ -4,14 +4,14 @@ use super::utils::{build_extend_null_bits, ExtendNullBits};
 use super::{make_growable, Growable};
 use crate::array::{Array, DictionaryArray, DictionaryKey, PrimitiveArray};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// Concrete [`Growable`] for the [`DictionaryArray`].
 /// # Implementation
 /// This growable does not perform collision checks and instead concatenates
 /// the values of each [`DictionaryArray`] one after the other.
 pub struct GrowableDictionary<'a, K: DictionaryKey> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     keys_values: Vec<&'a [K]>,
     key_values: Vec<K>,
     key_validity: MutableBitmap,

--- a/crates/polars-arrow/src/array/growable/fixed_size_list.rs
+++ b/crates/polars-arrow/src/array/growable/fixed_size_list.rs
@@ -4,7 +4,7 @@ use super::utils::{build_extend_null_bits, ExtendNullBits};
 use super::{make_growable, Growable};
 use crate::array::{Array, FixedSizeListArray};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// Concrete [`Growable`] for the [`FixedSizeListArray`].
 pub struct GrowableFixedSizeList<'a> {
@@ -32,12 +32,13 @@ impl<'a> GrowableFixedSizeList<'a> {
             use_validity = true;
         };
 
-        let size =
-            if let DataType::FixedSizeList(_, size) = &arrays[0].data_type().to_logical_type() {
-                *size
-            } else {
-                unreachable!("`GrowableFixedSizeList` expects `DataType::FixedSizeList`")
-            };
+        let size = if let ArrowDataType::FixedSizeList(_, size) =
+            &arrays[0].data_type().to_logical_type()
+        {
+            *size
+        } else {
+            unreachable!("`GrowableFixedSizeList` expects `DataType::FixedSizeList`")
+        };
 
         let extend_null_bits = arrays
             .iter()

--- a/crates/polars-arrow/src/array/growable/mod.rs
+++ b/crates/polars-arrow/src/array/growable/mod.rs
@@ -73,7 +73,7 @@ macro_rules! dyn_growable {
 /// Creates a new [`Growable`] from an arbitrary number of [`Array`]s.
 /// # Panics
 /// This function panics iff
-/// * the arrays do not have the same [`DataType`].
+/// * the arrays do not have the same [`ArrowDataType`].
 /// * `arrays.is_empty()`.
 pub fn make_growable<'a>(
     arrays: &[&'a dyn Array],

--- a/crates/polars-arrow/src/array/growable/null.rs
+++ b/crates/polars-arrow/src/array/growable/null.rs
@@ -2,23 +2,23 @@ use std::sync::Arc;
 
 use super::Growable;
 use crate::array::{Array, NullArray};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// Concrete [`Growable`] for the [`NullArray`].
 pub struct GrowableNull {
-    data_type: DataType,
+    data_type: ArrowDataType,
     length: usize,
 }
 
 impl Default for GrowableNull {
     fn default() -> Self {
-        Self::new(DataType::Null)
+        Self::new(ArrowDataType::Null)
     }
 }
 
 impl GrowableNull {
     /// Creates a new [`GrowableNull`].
-    pub fn new(data_type: DataType) -> Self {
+    pub fn new(data_type: ArrowDataType) -> Self {
         Self {
             data_type,
             length: 0,

--- a/crates/polars-arrow/src/array/growable/primitive.rs
+++ b/crates/polars-arrow/src/array/growable/primitive.rs
@@ -4,12 +4,12 @@ use super::utils::{build_extend_null_bits, ExtendNullBits};
 use super::Growable;
 use crate::array::{Array, PrimitiveArray};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::types::NativeType;
 
 /// Concrete [`Growable`] for the [`PrimitiveArray`].
 pub struct GrowablePrimitive<'a, T: NativeType> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     arrays: Vec<&'a [T]>,
     validity: MutableBitmap,
     values: Vec<T>,

--- a/crates/polars-arrow/src/array/list/mutable.rs
+++ b/crates/polars-arrow/src/array/list/mutable.rs
@@ -6,14 +6,14 @@ use super::ListArray;
 use crate::array::physical_binary::extend_validity;
 use crate::array::{Array, MutableArray, TryExtend, TryExtendFromSelf, TryPush};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::{DataType, Field};
+use crate::datatypes::{ArrowDataType, Field};
 use crate::offset::{Offset, Offsets};
 use crate::trusted_len::TrustedLen;
 
 /// The mutable version of [`ListArray`].
 #[derive(Debug, Clone)]
 pub struct MutableListArray<O: Offset, M: MutableArray> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     offsets: Offsets<O>,
     values: M,
     validity: Option<MutableBitmap>,
@@ -109,7 +109,7 @@ where
 
 impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
     /// Creates a new [`MutableListArray`] from a [`MutableArray`] and capacity.
-    pub fn new_from(values: M, data_type: DataType, capacity: usize) -> Self {
+    pub fn new_from(values: M, data_type: ArrowDataType, capacity: usize) -> Self {
         let offsets = Offsets::<O>::with_capacity(capacity);
         assert_eq!(values.len(), 0);
         ListArray::<O>::get_child_field(&data_type);
@@ -125,9 +125,9 @@ impl<O: Offset, M: MutableArray> MutableListArray<O, M> {
     pub fn new_with_field(values: M, name: &str, nullable: bool) -> Self {
         let field = Box::new(Field::new(name, values.data_type().clone(), nullable));
         let data_type = if O::IS_LARGE {
-            DataType::LargeList(field)
+            ArrowDataType::LargeList(field)
         } else {
-            DataType::List(field)
+            ArrowDataType::List(field)
         };
         Self::new_from(values, data_type, 0)
     }
@@ -291,7 +291,7 @@ impl<O: Offset, M: MutableArray + 'static> MutableArray for MutableListArray<O, 
         .arced()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-arrow/src/array/map/mod.rs
+++ b/crates/polars-arrow/src/array/map/mod.rs
@@ -1,7 +1,7 @@
 use super::specification::try_check_offsets_bounds;
 use super::{new_empty_array, Array};
 use crate::bitmap::Bitmap;
-use crate::datatypes::{DataType, Field};
+use crate::datatypes::{ArrowDataType, Field};
 use crate::offset::OffsetsBuffer;
 
 #[cfg(feature = "arrow_rs")]
@@ -15,7 +15,7 @@ use polars_error::{polars_bail, PolarsResult};
 /// An array representing a (key, value), both of arbitrary logical types.
 #[derive(Clone)]
 pub struct MapArray {
-    data_type: DataType,
+    data_type: ArrowDataType,
     // invariant: field.len() == offsets.len()
     offsets: OffsetsBuffer<i32>,
     field: Box<dyn Array>,
@@ -32,7 +32,7 @@ impl MapArray {
     /// * The fields' `data_type` is not equal to the inner field of `data_type`
     /// * The validity is not `None` and its length is different from `offsets.len() - 1`.
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: OffsetsBuffer<i32>,
         field: Box<dyn Array>,
         validity: Option<Bitmap>,
@@ -40,7 +40,7 @@ impl MapArray {
         try_check_offsets_bounds(&offsets, field.len())?;
 
         let inner_field = Self::try_get_field(&data_type)?;
-        if let DataType::Struct(inner) = inner_field.data_type() {
+        if let ArrowDataType::Struct(inner) = inner_field.data_type() {
             if inner.len() != 2 {
                 polars_bail!(ComputeError: "MapArray's inner `Struct` must have 2 fields (keys and maps)")
             }
@@ -72,7 +72,7 @@ impl MapArray {
     /// * The `data_type`'s physical type is not [`crate::datatypes::PhysicalType::Map`],
     /// * The validity is not `None` and its length is different from `offsets.len() - 1`.
     pub fn new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: OffsetsBuffer<i32>,
         field: Box<dyn Array>,
         validity: Option<Bitmap>,
@@ -81,7 +81,7 @@ impl MapArray {
     }
 
     /// Returns a new null [`MapArray`] of `length`.
-    pub fn new_null(data_type: DataType, length: usize) -> Self {
+    pub fn new_null(data_type: ArrowDataType, length: usize) -> Self {
         let field = new_empty_array(Self::get_field(&data_type).data_type().clone());
         Self::new(
             data_type,
@@ -92,7 +92,7 @@ impl MapArray {
     }
 
     /// Returns a new empty [`MapArray`].
-    pub fn new_empty(data_type: DataType) -> Self {
+    pub fn new_empty(data_type: ArrowDataType) -> Self {
         let field = new_empty_array(Self::get_field(&data_type).data_type().clone());
         Self::new(data_type, OffsetsBuffer::default(), field, None)
     }
@@ -127,15 +127,15 @@ impl MapArray {
     impl_mut_validity!();
     impl_into_array!();
 
-    pub(crate) fn try_get_field(data_type: &DataType) -> PolarsResult<&Field> {
-        if let DataType::Map(field, _) = data_type.to_logical_type() {
+    pub(crate) fn try_get_field(data_type: &ArrowDataType) -> PolarsResult<&Field> {
+        if let ArrowDataType::Map(field, _) = data_type.to_logical_type() {
             Ok(field.as_ref())
         } else {
             polars_bail!(ComputeError: "The data_type's logical type must be DataType::Map")
         }
     }
 
-    pub(crate) fn get_field(data_type: &DataType) -> &Field {
+    pub(crate) fn get_field(data_type: &ArrowDataType) -> &Field {
         Self::try_get_field(data_type).unwrap()
     }
 }

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -4,13 +4,13 @@ use polars_error::{polars_bail, PolarsResult};
 
 use crate::array::{Array, FromFfi, MutableArray, ToFfi};
 use crate::bitmap::{Bitmap, MutableBitmap};
-use crate::datatypes::{DataType, PhysicalType};
+use crate::datatypes::{ArrowDataType, PhysicalType};
 use crate::ffi;
 
-/// The concrete [`Array`] of [`DataType::Null`].
+/// The concrete [`Array`] of [`ArrowDataType::Null`].
 #[derive(Clone)]
 pub struct NullArray {
-    data_type: DataType,
+    data_type: ArrowDataType,
     length: usize,
 }
 
@@ -19,7 +19,7 @@ impl NullArray {
     /// # Errors
     /// This function errors iff:
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to [`crate::datatypes::PhysicalType::Null`].
-    pub fn try_new(data_type: DataType, length: usize) -> PolarsResult<Self> {
+    pub fn try_new(data_type: ArrowDataType, length: usize) -> PolarsResult<Self> {
         if data_type.to_physical_type() != PhysicalType::Null {
             polars_bail!(ComputeError: "NullArray can only be initialized with a DataType whose physical type is Boolean");
         }
@@ -31,17 +31,17 @@ impl NullArray {
     /// # Panics
     /// This function errors iff:
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to [`crate::datatypes::PhysicalType::Null`].
-    pub fn new(data_type: DataType, length: usize) -> Self {
+    pub fn new(data_type: ArrowDataType, length: usize) -> Self {
         Self::try_new(data_type, length).unwrap()
     }
 
     /// Returns a new empty [`NullArray`].
-    pub fn new_empty(data_type: DataType) -> Self {
+    pub fn new_empty(data_type: ArrowDataType) -> Self {
         Self::new(data_type, 0)
     }
 
     /// Returns a new [`NullArray`].
-    pub fn new_null(data_type: DataType, length: usize) -> Self {
+    pub fn new_null(data_type: ArrowDataType, length: usize) -> Self {
         Self::new(data_type, length)
     }
 
@@ -98,7 +98,7 @@ impl MutableNullArray {
     /// # Panics
     /// This function errors iff:
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to [`crate::datatypes::PhysicalType::Null`].
-    pub fn new(data_type: DataType, length: usize) -> Self {
+    pub fn new(data_type: ArrowDataType, length: usize) -> Self {
         let inner = NullArray::try_new(data_type, length).unwrap();
         Self { inner }
     }
@@ -111,8 +111,8 @@ impl From<MutableNullArray> for NullArray {
 }
 
 impl MutableArray for MutableNullArray {
-    fn data_type(&self) -> &DataType {
-        &DataType::Null
+    fn data_type(&self) -> &ArrowDataType {
+        &ArrowDataType::Null
     }
 
     fn len(&self) -> usize {
@@ -193,7 +193,7 @@ mod arrow {
 
         /// Create this array from [`ArrayData`]
         pub fn from_data(data: &ArrayData) -> Self {
-            Self::new(DataType::Null, data.len())
+            Self::new(ArrowDataType::Null, data.len())
         }
     }
 }

--- a/crates/polars-arrow/src/array/primitive/fmt.rs
+++ b/crates/polars-arrow/src/array/primitive/fmt.rs
@@ -21,7 +21,7 @@ macro_rules! dyn_primitive {
 pub fn get_write_value<'a, T: NativeType, F: Write>(
     array: &'a PrimitiveArray<T>,
 ) -> Box<dyn Fn(&mut F, usize) -> Result + 'a> {
-    use crate::datatypes::DataType::*;
+    use crate::datatypes::ArrowDataType::*;
     match array.data_type().to_logical_type() {
         Int8 => Box::new(|f, index| write!(f, "{}", array.value(index))),
         Int16 => Box::new(|f, index| write!(f, "{}", array.value(index))),

--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -46,13 +46,13 @@ use polars_error::{polars_bail, PolarsResult};
 /// ```
 #[derive(Clone)]
 pub struct PrimitiveArray<T: NativeType> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Buffer<T>,
     validity: Option<Bitmap>,
 }
 
 pub(super) fn check<T: NativeType>(
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     values: &[T],
     validity_len: Option<usize>,
 ) -> PolarsResult<()> {
@@ -76,7 +76,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// * The validity is not `None` and its length is different from `values`'s length
     /// * The `data_type`'s [`PhysicalType`] is not equal to [`PhysicalType::Primitive(T::PRIMITIVE)`]
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         values: Buffer<T>,
         validity: Option<Bitmap>,
     ) -> PolarsResult<Self> {
@@ -90,14 +90,14 @@ impl<T: NativeType> PrimitiveArray<T> {
 
     /// Returns a new [`PrimitiveArray`] with a different logical type.
     ///
-    /// This function is useful to assign a different [`DataType`] to the array.
+    /// This function is useful to assign a different [`ArrowDataType`] to the array.
     /// Used to change the arrays' logical type (see example).
     /// # Example
     /// ```
     /// use polars_arrow::array::Int32Array;
-    /// use polars_arrow::datatypes::DataType;
+    /// use polars_arrow::datatypes::ArrowDataType;
     ///
-    /// let array = Int32Array::from(&[Some(1), None, Some(2)]).to(DataType::Date32);
+    /// let array = Int32Array::from(&[Some(1), None, Some(2)]).to(ArrowDataType::Date32);
     /// assert_eq!(
     ///    format!("{:?}", array),
     ///    "Date32[1970-01-02, None, 1970-01-03]"
@@ -107,7 +107,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// Panics iff the `data_type`'s [`PhysicalType`] is not equal to [`PhysicalType::Primitive(T::PRIMITIVE)`]
     #[inline]
     #[must_use]
-    pub fn to(self, data_type: DataType) -> Self {
+    pub fn to(self, data_type: ArrowDataType) -> Self {
         check(
             &data_type,
             &self.values,
@@ -165,9 +165,9 @@ impl<T: NativeType> PrimitiveArray<T> {
         self.validity.as_ref()
     }
 
-    /// Returns the arrays' [`DataType`].
+    /// Returns the arrays' [`ArrowDataType`].
     #[inline]
-    pub fn data_type(&self) -> &DataType {
+    pub fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 
@@ -273,7 +273,7 @@ impl<T: NativeType> PrimitiveArray<T> {
 
     /// Returns its internal representation
     #[must_use]
-    pub fn into_inner(self) -> (DataType, Buffer<T>, Option<Bitmap>) {
+    pub fn into_inner(self) -> (ArrowDataType, Buffer<T>, Option<Bitmap>) {
         let Self {
             data_type,
             values,
@@ -285,7 +285,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// Creates a `[PrimitiveArray]` from its internal representation.
     /// This is the inverted from `[PrimitiveArray::into_inner]`
     pub fn from_inner(
-        data_type: DataType,
+        data_type: ArrowDataType,
         values: Buffer<T>,
         validity: Option<Bitmap>,
     ) -> PolarsResult<Self> {
@@ -299,7 +299,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// # Safety
     /// Callers must ensure all invariants of this struct are upheld.
     pub unsafe fn from_inner_unchecked(
-        data_type: DataType,
+        data_type: ArrowDataType,
         values: Buffer<T>,
         validity: Option<Bitmap>,
     ) -> Self {
@@ -355,13 +355,13 @@ impl<T: NativeType> PrimitiveArray<T> {
     }
 
     /// Returns a new empty (zero-length) [`PrimitiveArray`].
-    pub fn new_empty(data_type: DataType) -> Self {
+    pub fn new_empty(data_type: ArrowDataType) -> Self {
         Self::new(data_type, Buffer::new(), None)
     }
 
     /// Returns a new [`PrimitiveArray`] where all slots are null / `None`.
     #[inline]
-    pub fn new_null(data_type: DataType, length: usize) -> Self {
+    pub fn new_null(data_type: ArrowDataType, length: usize) -> Self {
         Self::new(
             data_type,
             vec![T::default(); length].into(),
@@ -420,7 +420,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// This function errors iff:
     /// * The validity is not `None` and its length is different from `values`'s length
     /// * The `data_type`'s [`PhysicalType`] is not equal to [`PhysicalType::Primitive`].
-    pub fn new(data_type: DataType, values: Buffer<T>, validity: Option<Bitmap>) -> Self {
+    pub fn new(data_type: ArrowDataType, values: Buffer<T>, validity: Option<Bitmap>) -> Self {
         Self::try_new(data_type, values, validity).unwrap()
     }
 }

--- a/crates/polars-arrow/src/array/primitive/mutable.rs
+++ b/crates/polars-arrow/src/array/primitive/mutable.rs
@@ -7,7 +7,7 @@ use super::{check, PrimitiveArray};
 use crate::array::physical_binary::extend_validity;
 use crate::array::{Array, MutableArray, TryExtend, TryExtendFromSelf, TryPush};
 use crate::bitmap::{Bitmap, MutableBitmap};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::trusted_len::TrustedLen;
 use crate::types::NativeType;
 
@@ -15,7 +15,7 @@ use crate::types::NativeType;
 /// Converting a [`MutablePrimitiveArray`] into a [`PrimitiveArray`] is `O(1)`.
 #[derive(Debug, Clone)]
 pub struct MutablePrimitiveArray<T: NativeType> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Vec<T>,
     validity: Option<MutableBitmap>,
 }
@@ -61,7 +61,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     /// * The validity is not `None` and its length is different from `values`'s length
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to [`crate::datatypes::PhysicalType::Primitive(T::PRIMITIVE)`]
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         values: Vec<T>,
         validity: Option<MutableBitmap>,
     ) -> PolarsResult<Self> {
@@ -74,7 +74,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     }
 
     /// Extract the low-end APIs from the [`MutablePrimitiveArray`].
-    pub fn into_inner(self) -> (DataType, Vec<T>, Option<MutableBitmap>) {
+    pub fn into_inner(self) -> (ArrowDataType, Vec<T>, Option<MutableBitmap>) {
         (self.data_type, self.values, self.validity)
     }
 
@@ -98,8 +98,8 @@ impl<T: NativeType> Default for MutablePrimitiveArray<T> {
     }
 }
 
-impl<T: NativeType> From<DataType> for MutablePrimitiveArray<T> {
-    fn from(data_type: DataType) -> Self {
+impl<T: NativeType> From<ArrowDataType> for MutablePrimitiveArray<T> {
+    fn from(data_type: ArrowDataType) -> Self {
         assert!(data_type.to_physical_type().eq_primitive(T::PRIMITIVE));
         Self {
             data_type,
@@ -110,8 +110,8 @@ impl<T: NativeType> From<DataType> for MutablePrimitiveArray<T> {
 }
 
 impl<T: NativeType> MutablePrimitiveArray<T> {
-    /// Creates a new [`MutablePrimitiveArray`] from a capacity and [`DataType`].
-    pub fn with_capacity_from(capacity: usize, data_type: DataType) -> Self {
+    /// Creates a new [`MutablePrimitiveArray`] from a capacity and [`ArrowDataType`].
+    pub fn with_capacity_from(capacity: usize, data_type: ArrowDataType) -> Self {
         assert!(data_type.to_physical_type().eq_primitive(T::PRIMITIVE));
         Self {
             data_type,
@@ -256,12 +256,12 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
         self.validity = Some(validity)
     }
 
-    /// Changes the arrays' [`DataType`], returning a new [`MutablePrimitiveArray`].
+    /// Changes the arrays' [`ArrowDataType`], returning a new [`MutablePrimitiveArray`].
     /// Use to change the logical type without changing the corresponding physical Type.
     /// # Implementation
     /// This operation is `O(1)`.
     #[inline]
-    pub fn to(self, data_type: DataType) -> Self {
+    pub fn to(self, data_type: ArrowDataType) -> Self {
         Self::try_new(data_type, self.values, self.validity).unwrap()
     }
 
@@ -403,7 +403,7 @@ impl<T: NativeType> MutableArray for MutablePrimitiveArray<T> {
         .arced()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-arrow/src/array/struct_/mutable.rs
+++ b/crates/polars-arrow/src/array/struct_/mutable.rs
@@ -5,18 +5,18 @@ use polars_error::{polars_bail, PolarsResult};
 use super::StructArray;
 use crate::array::{Array, MutableArray};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// Converting a [`MutableStructArray`] into a [`StructArray`] is `O(1)`.
 #[derive(Debug)]
 pub struct MutableStructArray {
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Vec<Box<dyn MutableArray>>,
     validity: Option<MutableBitmap>,
 }
 
 fn check(
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     values: &[Box<dyn MutableArray>],
     validity: Option<usize>,
 ) -> PolarsResult<()> {
@@ -85,18 +85,18 @@ impl From<MutableStructArray> for StructArray {
 
 impl MutableStructArray {
     /// Creates a new [`MutableStructArray`].
-    pub fn new(data_type: DataType, values: Vec<Box<dyn MutableArray>>) -> Self {
+    pub fn new(data_type: ArrowDataType, values: Vec<Box<dyn MutableArray>>) -> Self {
         Self::try_new(data_type, values, None).unwrap()
     }
 
     /// Create a [`MutableStructArray`] out of low-end APIs.
     /// # Errors
     /// This function errors iff:
-    /// * `data_type` is not [`DataType::Struct`]
+    /// * `data_type` is not [`ArrowDataType::Struct`]
     /// * The inner types of `data_type` are not equal to those of `values`
     /// * `validity` is not `None` and its length is different from the `values`'s length
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         values: Vec<Box<dyn MutableArray>>,
         validity: Option<MutableBitmap>,
     ) -> PolarsResult<Self> {
@@ -109,7 +109,13 @@ impl MutableStructArray {
     }
 
     /// Extract the low-end APIs from the [`MutableStructArray`].
-    pub fn into_inner(self) -> (DataType, Vec<Box<dyn MutableArray>>, Option<MutableBitmap>) {
+    pub fn into_inner(
+        self,
+    ) -> (
+        ArrowDataType,
+        Vec<Box<dyn MutableArray>>,
+        Option<MutableBitmap>,
+    ) {
         (self.data_type, self.values, self.validity)
     }
 
@@ -218,7 +224,7 @@ impl MutableArray for MutableStructArray {
         .arced()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-arrow/src/array/union/data.rs
+++ b/crates/polars-arrow/src/array/union/data.rs
@@ -2,7 +2,7 @@ use arrow_data::{ArrayData, ArrayDataBuilder};
 
 use crate::array::{from_data, to_data, Arrow2Arrow, UnionArray};
 use crate::buffer::Buffer;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 impl Arrow2Arrow for UnionArray {
     fn to_data(&self) -> ArrayData {
@@ -30,7 +30,7 @@ impl Arrow2Arrow for UnionArray {
     }
 
     fn from_data(data: &ArrayData) -> Self {
-        let data_type: DataType = data.data_type().clone().into();
+        let data_type: ArrowDataType = data.data_type().clone().into();
 
         let fields = data.child_data().iter().map(from_data).collect();
         let buffers = data.buffers();
@@ -47,14 +47,14 @@ impl Arrow2Arrow for UnionArray {
 
         // Map from type id to array index
         let map = match &data_type {
-            DataType::Union(_, Some(ids), _) => {
+            ArrowDataType::Union(_, Some(ids), _) => {
                 let mut map = [0; 127];
                 for (pos, &id) in ids.iter().enumerate() {
                     map[id as usize] = pos;
                 }
                 Some(map)
             },
-            DataType::Union(_, None, _) => None,
+            ArrowDataType::Union(_, None, _) => None,
             _ => unreachable!("must be Union type"),
         };
 

--- a/crates/polars-arrow/src/array/utf8/mod.rs
+++ b/crates/polars-arrow/src/array/utf8/mod.rs
@@ -5,7 +5,7 @@ use super::{Array, GenericBinaryArray};
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 use crate::bitmap::Bitmap;
 use crate::buffer::Buffer;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::{Offset, Offsets, OffsetsBuffer};
 use crate::trusted_len::TrustedLen;
 
@@ -63,7 +63,7 @@ impl<T: AsRef<str>> AsRef<[u8]> for StrAsBytes<T> {
 /// * `len` is equal to `validity.len()`, when defined.
 #[derive(Clone)]
 pub struct Utf8Array<O: Offset> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     offsets: OffsetsBuffer<O>,
     values: Buffer<u8>,
     validity: Option<Bitmap>,
@@ -82,7 +82,7 @@ impl<O: Offset> Utf8Array<O> {
     /// # Implementation
     /// This function is `O(N)` - checking utf8 is `O(N)`
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
@@ -175,9 +175,9 @@ impl<O: Offset> Utf8Array<O> {
         }
     }
 
-    /// Returns the [`DataType`] of this array.
+    /// Returns the [`ArrowDataType`] of this array.
     #[inline]
-    pub fn data_type(&self) -> &DataType {
+    pub fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 
@@ -232,7 +232,7 @@ impl<O: Offset> Utf8Array<O> {
 
     /// Returns its internal representation
     #[must_use]
-    pub fn into_inner(self) -> (DataType, OffsetsBuffer<O>, Buffer<u8>, Option<Bitmap>) {
+    pub fn into_inner(self) -> (ArrowDataType, OffsetsBuffer<O>, Buffer<u8>, Option<Bitmap>) {
         let Self {
             data_type,
             offsets,
@@ -323,13 +323,13 @@ impl<O: Offset> Utf8Array<O> {
     ///
     /// The array is guaranteed to have no elements nor validity.
     #[inline]
-    pub fn new_empty(data_type: DataType) -> Self {
+    pub fn new_empty(data_type: ArrowDataType) -> Self {
         unsafe { Self::new_unchecked(data_type, OffsetsBuffer::new(), Buffer::new(), None) }
     }
 
     /// Returns a new [`Utf8Array`] whose all slots are null / `None`.
     #[inline]
-    pub fn new_null(data_type: DataType, length: usize) -> Self {
+    pub fn new_null(data_type: ArrowDataType, length: usize) -> Self {
         Self::new(
             data_type,
             Offsets::new_zeroed(length).into(),
@@ -338,12 +338,12 @@ impl<O: Offset> Utf8Array<O> {
         )
     }
 
-    /// Returns a default [`DataType`] of this array, which depends on the generic parameter `O`: `DataType::Utf8` or `DataType::LargeUtf8`
-    pub fn default_data_type() -> DataType {
+    /// Returns a default [`ArrowDataType`] of this array, which depends on the generic parameter `O`: `DataType::Utf8` or `DataType::LargeUtf8`
+    pub fn default_data_type() -> ArrowDataType {
         if O::IS_LARGE {
-            DataType::LargeUtf8
+            ArrowDataType::LargeUtf8
         } else {
-            DataType::Utf8
+            ArrowDataType::Utf8
         }
     }
 
@@ -360,7 +360,7 @@ impl<O: Offset> Utf8Array<O> {
     /// # Implementation
     /// This function is `O(1)`
     pub unsafe fn try_new_unchecked(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
@@ -400,7 +400,7 @@ impl<O: Offset> Utf8Array<O> {
     /// # Implementation
     /// This function is `O(N)` - checking utf8 is `O(N)`
     pub fn new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
@@ -422,7 +422,7 @@ impl<O: Offset> Utf8Array<O> {
     /// # Implementation
     /// This function is `O(1)`
     pub unsafe fn new_unchecked(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
@@ -533,9 +533,9 @@ unsafe impl<O: Offset> GenericBinaryArray<O> for Utf8Array<O> {
 impl<O: Offset> Default for Utf8Array<O> {
     fn default() -> Self {
         let data_type = if O::IS_LARGE {
-            DataType::LargeUtf8
+            ArrowDataType::LargeUtf8
         } else {
-            DataType::Utf8
+            ArrowDataType::Utf8
         };
         Utf8Array::new(data_type, Default::default(), Default::default(), None)
     }

--- a/crates/polars-arrow/src/array/utf8/mutable.rs
+++ b/crates/polars-arrow/src/array/utf8/mutable.rs
@@ -8,7 +8,7 @@ use crate::array::physical_binary::*;
 use crate::array::{Array, MutableArray, TryExtend, TryExtendFromSelf, TryPush};
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 use crate::bitmap::{Bitmap, MutableBitmap};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::{Offset, Offsets};
 use crate::trusted_len::TrustedLen;
 
@@ -57,7 +57,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     /// # Implementation
     /// This function is `O(N)` - checking utf8 is `O(N)`
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: Offsets<O>,
         values: Vec<u8>,
         validity: Option<MutableBitmap>,
@@ -82,7 +82,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     /// * The `offsets` and `values` are inconsistent
     /// * The validity is not `None` and its length is different from `offsets`'s length minus one.
     pub unsafe fn new_unchecked(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: Offsets<O>,
         values: Vec<u8>,
         validity: Option<MutableBitmap>,
@@ -100,7 +100,7 @@ impl<O: Offset> MutableUtf8Array<O> {
         Self::from_trusted_len_iter(slice.as_ref().iter().map(|x| x.as_ref()))
     }
 
-    fn default_data_type() -> DataType {
+    fn default_data_type() -> ArrowDataType {
         Utf8Array::<O>::default_data_type()
     }
 
@@ -198,7 +198,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     /// Extract the low-end APIs from the [`MutableUtf8Array`].
-    pub fn into_data(self) -> (DataType, Offsets<O>, Vec<u8>, Option<MutableBitmap>) {
+    pub fn into_data(self) -> (ArrowDataType, Offsets<O>, Vec<u8>, Option<MutableBitmap>) {
         let (data_type, offsets, values) = self.values.into_inner();
         (data_type, offsets, values, self.validity)
     }
@@ -261,11 +261,11 @@ impl<O: Offset> MutableArray for MutableUtf8Array<O> {
         array.arced()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         if O::IS_LARGE {
-            &DataType::LargeUtf8
+            &ArrowDataType::LargeUtf8
         } else {
-            &DataType::Utf8
+            &ArrowDataType::Utf8
         }
     }
 

--- a/crates/polars-arrow/src/array/utf8/mutable_values.rs
+++ b/crates/polars-arrow/src/array/utf8/mutable_values.rs
@@ -8,7 +8,7 @@ use crate::array::physical_binary::*;
 use crate::array::specification::{try_check_offsets_bounds, try_check_utf8};
 use crate::array::{Array, ArrayValuesIter, MutableArray, TryExtend, TryExtendFromSelf, TryPush};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::{Offset, Offsets};
 use crate::trusted_len::TrustedLen;
 
@@ -16,7 +16,7 @@ use crate::trusted_len::TrustedLen;
 /// from [`MutableUtf8Array`] in that it builds non-null [`Utf8Array`].
 #[derive(Debug, Clone)]
 pub struct MutableUtf8ValuesArray<O: Offset> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     offsets: Offsets<O>,
     values: Vec<u8>,
 }
@@ -73,7 +73,7 @@ impl<O: Offset> MutableUtf8ValuesArray<O> {
     /// # Implementation
     /// This function is `O(N)` - checking utf8 is `O(N)`
     pub fn try_new(
-        data_type: DataType,
+        data_type: ArrowDataType,
         offsets: Offsets<O>,
         values: Vec<u8>,
     ) -> PolarsResult<Self> {
@@ -101,7 +101,11 @@ impl<O: Offset> MutableUtf8ValuesArray<O> {
     /// * The `values` between two consecutive `offsets` are not valid utf8
     /// # Implementation
     /// This function is `O(1)`
-    pub unsafe fn new_unchecked(data_type: DataType, offsets: Offsets<O>, values: Vec<u8>) -> Self {
+    pub unsafe fn new_unchecked(
+        data_type: ArrowDataType,
+        offsets: Offsets<O>,
+        values: Vec<u8>,
+    ) -> Self {
         try_check_offsets_bounds(&offsets, values.len())
             .expect("The length of the values must be equal to the last offset value");
 
@@ -116,9 +120,9 @@ impl<O: Offset> MutableUtf8ValuesArray<O> {
         }
     }
 
-    /// Returns the default [`DataType`] of this container: [`DataType::Utf8`] or [`DataType::LargeUtf8`]
+    /// Returns the default [`ArrowDataType`] of this container: [`ArrowDataType::Utf8`] or [`ArrowDataType::LargeUtf8`]
     /// depending on the generic [`Offset`].
-    pub fn default_data_type() -> DataType {
+    pub fn default_data_type() -> ArrowDataType {
         Utf8Array::<O>::default_data_type()
     }
 
@@ -223,7 +227,7 @@ impl<O: Offset> MutableUtf8ValuesArray<O> {
     }
 
     /// Extract the low-end APIs from the [`MutableUtf8ValuesArray`].
-    pub fn into_inner(self) -> (DataType, Offsets<O>, Vec<u8>) {
+    pub fn into_inner(self) -> (ArrowDataType, Offsets<O>, Vec<u8>) {
         (self.data_type, self.offsets, self.values)
     }
 }
@@ -247,7 +251,7 @@ impl<O: Offset> MutableArray for MutableUtf8ValuesArray<O> {
         array.arced()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-arrow/src/compute/aggregate/min_max.rs
+++ b/crates/polars-arrow/src/compute/aggregate/min_max.rs
@@ -5,7 +5,7 @@ use polars_error::{polars_bail, PolarsResult};
 use crate::array::{Array, BinaryArray, BooleanArray, PrimitiveArray, Utf8Array};
 use crate::bitmap::utils::{BitChunkIterExact, BitChunksExact};
 use crate::bitmap::Bitmap;
-use crate::datatypes::{DataType, PhysicalType, PrimitiveType};
+use crate::datatypes::{ArrowDataType, PhysicalType, PrimitiveType};
 use crate::offset::Offset;
 use crate::scalar::*;
 use crate::types::simd::*;
@@ -367,7 +367,7 @@ pub fn min(array: &dyn Array) -> PolarsResult<Box<dyn Scalar>> {
 }
 
 /// Whether [`min`] supports `data_type`
-pub fn can_min(data_type: &DataType) -> bool {
+pub fn can_min(data_type: &ArrowDataType) -> bool {
     let physical = data_type.to_physical_type();
     if let PhysicalType::Primitive(primitive) = physical {
         use PrimitiveType::*;
@@ -382,6 +382,6 @@ pub fn can_min(data_type: &DataType) -> bool {
 }
 
 /// Whether [`max`] supports `data_type`
-pub fn can_max(data_type: &DataType) -> bool {
+pub fn can_max(data_type: &ArrowDataType) -> bool {
     can_min(data_type)
 }

--- a/crates/polars-arrow/src/compute/aggregate/sum.rs
+++ b/crates/polars-arrow/src/compute/aggregate/sum.rs
@@ -6,7 +6,7 @@ use polars_error::PolarsResult;
 use crate::array::{Array, PrimitiveArray};
 use crate::bitmap::utils::{BitChunkIterExact, BitChunksExact};
 use crate::bitmap::Bitmap;
-use crate::datatypes::{DataType, PhysicalType, PrimitiveType};
+use crate::datatypes::{ArrowDataType, PhysicalType, PrimitiveType};
 use crate::scalar::*;
 use crate::types::simd::*;
 use crate::types::NativeType;
@@ -103,7 +103,7 @@ where
 }
 
 /// Whether [`sum`] supports `data_type`
-pub fn can_sum(data_type: &DataType) -> bool {
+pub fn can_sum(data_type: &ArrowDataType) -> bool {
     if let PhysicalType::Primitive(primitive) = data_type.to_physical_type() {
         use PrimitiveType::*;
         matches!(

--- a/crates/polars-arrow/src/compute/arity.rs
+++ b/crates/polars-arrow/src/compute/arity.rs
@@ -5,7 +5,7 @@ use polars_error::PolarsResult;
 use super::utils::{check_same_len, combine_validities};
 use crate::array::PrimitiveArray;
 use crate::bitmap::{Bitmap, MutableBitmap};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::types::NativeType;
 
 /// Applies an unary and infallible function to a [`PrimitiveArray`]. This is the
@@ -18,7 +18,11 @@ use crate::types::NativeType;
 /// This implies that the operation must be infallible for any value of the
 /// corresponding type or this function may panic.
 #[inline]
-pub fn unary<I, F, O>(array: &PrimitiveArray<I>, op: F, data_type: DataType) -> PrimitiveArray<O>
+pub fn unary<I, F, O>(
+    array: &PrimitiveArray<I>,
+    op: F,
+    data_type: ArrowDataType,
+) -> PrimitiveArray<O>
 where
     I: NativeType,
     O: NativeType,
@@ -34,7 +38,7 @@ where
 pub fn try_unary<I, F, O>(
     array: &PrimitiveArray<I>,
     op: F,
-    data_type: DataType,
+    data_type: ArrowDataType,
 ) -> PolarsResult<PrimitiveArray<O>>
 where
     I: NativeType,
@@ -60,7 +64,7 @@ where
 pub fn unary_with_bitmap<I, F, O>(
     array: &PrimitiveArray<I>,
     op: F,
-    data_type: DataType,
+    data_type: ArrowDataType,
 ) -> (PrimitiveArray<O>, Bitmap)
 where
     I: NativeType,
@@ -92,7 +96,7 @@ where
 pub fn unary_checked<I, F, O>(
     array: &PrimitiveArray<I>,
     op: F,
-    data_type: DataType,
+    data_type: ArrowDataType,
 ) -> PrimitiveArray<O>
 where
     I: NativeType,
@@ -144,7 +148,7 @@ where
 pub fn binary<T, D, F>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveArray<D>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     op: F,
 ) -> PrimitiveArray<T>
 where
@@ -172,7 +176,7 @@ where
 pub fn try_binary<T, D, F>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveArray<D>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     op: F,
 ) -> PolarsResult<PrimitiveArray<T>>
 where
@@ -200,7 +204,7 @@ where
 pub fn binary_with_bitmap<T, D, F>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveArray<D>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     op: F,
 ) -> (PrimitiveArray<T>, Bitmap)
 where
@@ -238,7 +242,7 @@ where
 pub fn binary_checked<T, D, F>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveArray<D>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     op: F,
 ) -> PrimitiveArray<T>
 where

--- a/crates/polars-arrow/src/compute/boolean.rs
+++ b/crates/polars-arrow/src/compute/boolean.rs
@@ -2,7 +2,7 @@
 use super::utils::combine_validities;
 use crate::array::{Array, BooleanArray};
 use crate::bitmap::{Bitmap, MutableBitmap};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::scalar::BooleanScalar;
 
 fn assert_lengths(lhs: &BooleanArray, rhs: &BooleanArray) {
@@ -30,7 +30,7 @@ where
 
     let values = op(left_buffer, right_buffer);
 
-    BooleanArray::new(DataType::Boolean, values, validity)
+    BooleanArray::new(ArrowDataType::Boolean, values, validity)
 }
 
 /// Performs `&&` operation on two [`BooleanArray`], combining the validities.
@@ -131,7 +131,7 @@ pub fn or(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
 pub fn not(array: &BooleanArray) -> BooleanArray {
     let values = !array.values();
     let validity = array.validity().cloned();
-    BooleanArray::new(DataType::Boolean, values, validity)
+    BooleanArray::new(ArrowDataType::Boolean, values, validity)
 }
 
 /// Returns a non-null [`BooleanArray`] with whether each value of the array is null.
@@ -153,7 +153,7 @@ pub fn is_null(input: &dyn Array) -> BooleanArray {
         Some(buffer) => !buffer,
     };
 
-    BooleanArray::new(DataType::Boolean, values, None)
+    BooleanArray::new(ArrowDataType::Boolean, values, None)
 }
 
 /// Returns a non-null [`BooleanArray`] with whether each value of the array is not null.
@@ -175,7 +175,7 @@ pub fn is_not_null(input: &dyn Array) -> BooleanArray {
         },
         Some(buffer) => buffer.clone(),
     };
-    BooleanArray::new(DataType::Boolean, values, None)
+    BooleanArray::new(ArrowDataType::Boolean, values, None)
 }
 
 /// Performs `AND` operation on an array and a scalar value. If either left or right value
@@ -197,9 +197,9 @@ pub fn and_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray 
         Some(true) => array.clone(),
         Some(false) => {
             let values = Bitmap::new_zeroed(array.len());
-            BooleanArray::new(DataType::Boolean, values, array.validity().cloned())
+            BooleanArray::new(ArrowDataType::Boolean, values, array.validity().cloned())
         },
-        None => BooleanArray::new_null(DataType::Boolean, array.len()),
+        None => BooleanArray::new_null(ArrowDataType::Boolean, array.len()),
     }
 }
 
@@ -222,10 +222,14 @@ pub fn or_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray {
         Some(true) => {
             let mut values = MutableBitmap::new();
             values.extend_constant(array.len(), true);
-            BooleanArray::new(DataType::Boolean, values.into(), array.validity().cloned())
+            BooleanArray::new(
+                ArrowDataType::Boolean,
+                values.into(),
+                array.validity().cloned(),
+            )
         },
         Some(false) => array.clone(),
-        None => BooleanArray::new_null(DataType::Boolean, array.len()),
+        None => BooleanArray::new_null(ArrowDataType::Boolean, array.len()),
     }
 }
 

--- a/crates/polars-arrow/src/compute/boolean_kleene.rs
+++ b/crates/polars-arrow/src/compute/boolean_kleene.rs
@@ -1,7 +1,7 @@
 //! Boolean operators of [Kleene logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics).
 use crate::array::{Array, BooleanArray};
 use crate::bitmap::{binary, quaternary, ternary, unary, Bitmap, MutableBitmap};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::scalar::BooleanScalar;
 
 /// Logical 'or' operation on two arrays with [Kleene logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics)
@@ -84,7 +84,7 @@ pub fn or(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
         },
         (None, None) => None,
     };
-    BooleanArray::new(DataType::Boolean, lhs_values | rhs_values, validity)
+    BooleanArray::new(ArrowDataType::Boolean, lhs_values | rhs_values, validity)
 }
 
 /// Logical 'and' operation on two arrays with [Kleene logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics)
@@ -166,7 +166,7 @@ pub fn and(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
         },
         (None, None) => None,
     };
-    BooleanArray::new(DataType::Boolean, lhs_values & rhs_values, validity)
+    BooleanArray::new(ArrowDataType::Boolean, lhs_values & rhs_values, validity)
 }
 
 /// Logical 'or' operation on an array and a scalar value with [Kleene logic](https://en.wikipedia.org/wiki/Three-valued_logic#Kleene_and_Priest_logics)
@@ -187,7 +187,7 @@ pub fn or_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray {
         Some(true) => {
             let mut values = MutableBitmap::new();
             values.extend_constant(array.len(), true);
-            BooleanArray::new(DataType::Boolean, values.into(), None)
+            BooleanArray::new(ArrowDataType::Boolean, values.into(), None)
         },
         Some(false) => array.clone(),
         None => {
@@ -196,7 +196,7 @@ pub fn or_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray {
                 Some(validity) => binary(values, validity, |value, validity| validity & value),
                 None => unary(values, |value| value),
             };
-            BooleanArray::new(DataType::Boolean, values.clone(), Some(validity))
+            BooleanArray::new(ArrowDataType::Boolean, values.clone(), Some(validity))
         },
     }
 }
@@ -219,7 +219,7 @@ pub fn and_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray 
         Some(true) => array.clone(),
         Some(false) => {
             let values = Bitmap::new_zeroed(array.len());
-            BooleanArray::new(DataType::Boolean, values, None)
+            BooleanArray::new(ArrowDataType::Boolean, values, None)
         },
         None => {
             let values = array.values();
@@ -227,7 +227,11 @@ pub fn and_scalar(array: &BooleanArray, scalar: &BooleanScalar) -> BooleanArray 
                 Some(validity) => binary(values, validity, |value, validity| validity & !value),
                 None => unary(values, |value| !value),
             };
-            BooleanArray::new(DataType::Boolean, array.values().clone(), Some(validity))
+            BooleanArray::new(
+                ArrowDataType::Boolean,
+                array.values().clone(),
+                Some(validity),
+            )
         },
     }
 }

--- a/crates/polars-arrow/src/compute/cast/binary_to.rs
+++ b/crates/polars-arrow/src/compute/cast/binary_to.rs
@@ -2,12 +2,15 @@ use polars_error::PolarsResult;
 
 use super::CastOptions;
 use crate::array::*;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::{Offset, Offsets};
 use crate::types::NativeType;
 
 /// Conversion of binary
-pub fn binary_to_large_binary(from: &BinaryArray<i32>, to_data_type: DataType) -> BinaryArray<i64> {
+pub fn binary_to_large_binary(
+    from: &BinaryArray<i32>,
+    to_data_type: ArrowDataType,
+) -> BinaryArray<i64> {
     let values = from.values().clone();
     BinaryArray::<i64>::new(
         to_data_type,
@@ -20,7 +23,7 @@ pub fn binary_to_large_binary(from: &BinaryArray<i32>, to_data_type: DataType) -
 /// Conversion of binary
 pub fn binary_large_to_binary(
     from: &BinaryArray<i64>,
-    to_data_type: DataType,
+    to_data_type: ArrowDataType,
 ) -> PolarsResult<BinaryArray<i32>> {
     let values = from.values().clone();
     let offsets = from.offsets().try_into()?;
@@ -35,7 +38,7 @@ pub fn binary_large_to_binary(
 /// Conversion to utf8
 pub fn binary_to_utf8<O: Offset>(
     from: &BinaryArray<O>,
-    to_data_type: DataType,
+    to_data_type: ArrowDataType,
 ) -> PolarsResult<Utf8Array<O>> {
     Utf8Array::<O>::try_new(
         to_data_type,
@@ -50,7 +53,7 @@ pub fn binary_to_utf8<O: Offset>(
 /// This function errors if the values are not valid utf8
 pub fn binary_to_large_utf8(
     from: &BinaryArray<i32>,
-    to_data_type: DataType,
+    to_data_type: ArrowDataType,
 ) -> PolarsResult<Utf8Array<i64>> {
     let values = from.values().clone();
     let offsets = from.offsets().into();
@@ -61,7 +64,7 @@ pub fn binary_to_large_utf8(
 /// Casts a [`BinaryArray`] to a [`PrimitiveArray`] at best-effort using `lexical_core::parse_partial`, making any uncastable value as zero.
 pub fn partial_binary_to_primitive<O: Offset, T>(
     from: &BinaryArray<O>,
-    to: &DataType,
+    to: &ArrowDataType,
 ) -> PrimitiveArray<T>
 where
     T: NativeType + lexical_core::FromLexical,
@@ -74,7 +77,10 @@ where
 }
 
 /// Casts a [`BinaryArray`] to a [`PrimitiveArray`], making any uncastable value a Null.
-pub fn binary_to_primitive<O: Offset, T>(from: &BinaryArray<O>, to: &DataType) -> PrimitiveArray<T>
+pub fn binary_to_primitive<O: Offset, T>(
+    from: &BinaryArray<O>,
+    to: &ArrowDataType,
+) -> PrimitiveArray<T>
 where
     T: NativeType + lexical_core::FromLexical,
 {
@@ -87,7 +93,7 @@ where
 
 pub(super) fn binary_to_primitive_dyn<O: Offset, T>(
     from: &dyn Array,
-    to: &DataType,
+    to: &ArrowDataType,
     options: CastOptions,
 ) -> PolarsResult<Box<dyn Array>>
 where
@@ -135,7 +141,7 @@ fn fixed_size_to_offsets<O: Offset>(values_len: usize, fixed_size: usize) -> Off
 /// Conversion of `FixedSizeBinary` to `Binary`.
 pub fn fixed_size_binary_binary<O: Offset>(
     from: &FixedSizeBinaryArray,
-    to_data_type: DataType,
+    to_data_type: ArrowDataType,
 ) -> BinaryArray<O> {
     let values = from.values().clone();
     let offsets = fixed_size_to_offsets(values.len(), from.size());
@@ -148,9 +154,12 @@ pub fn fixed_size_binary_binary<O: Offset>(
 }
 
 /// Conversion of binary
-pub fn binary_to_list<O: Offset>(from: &BinaryArray<O>, to_data_type: DataType) -> ListArray<O> {
+pub fn binary_to_list<O: Offset>(
+    from: &BinaryArray<O>,
+    to_data_type: ArrowDataType,
+) -> ListArray<O> {
     let values = from.values().clone();
-    let values = PrimitiveArray::new(DataType::UInt8, values, None);
+    let values = PrimitiveArray::new(ArrowDataType::UInt8, values, None);
     ListArray::<O>::new(
         to_data_type,
         from.offsets().clone(),

--- a/crates/polars-arrow/src/compute/cast/mod.rs
+++ b/crates/polars-arrow/src/compute/cast/mod.rs
@@ -41,8 +41,8 @@ impl CastOptions {
 }
 
 /// Returns true if this type is numeric: (UInt*, Unit*, or Float*).
-fn is_numeric(t: &DataType) -> bool {
-    use DataType::*;
+fn is_numeric(t: &ArrowDataType) -> bool {
+    use ArrowDataType::*;
     matches!(
         t,
         UInt8 | UInt16 | UInt32 | UInt64 | Int8 | Int16 | Int32 | Int64 | Float32 | Float64
@@ -72,8 +72,8 @@ macro_rules! primitive_dyn {
 /// value of `to_type`. Note that such as cast may be lossy.
 ///
 /// If this function returns true to stay consistent with the `cast` kernel below.
-pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
-    use self::DataType::*;
+pub fn can_cast_types(from_type: &ArrowDataType, to_type: &ArrowDataType) -> bool {
+    use self::ArrowDataType::*;
     if from_type == to_type {
         return true;
     }
@@ -320,7 +320,7 @@ pub fn can_cast_types(from_type: &DataType, to_type: &DataType) -> bool {
 
 fn cast_list<O: Offset>(
     array: &ListArray<O>,
-    to_type: &DataType,
+    to_type: &ArrowDataType,
     options: CastOptions,
 ) -> PolarsResult<ListArray<O>> {
     let values = array.values();
@@ -338,7 +338,7 @@ fn cast_list<O: Offset>(
     ))
 }
 
-fn cast_list_to_large_list(array: &ListArray<i32>, to_type: &DataType) -> ListArray<i64> {
+fn cast_list_to_large_list(array: &ListArray<i32>, to_type: &ArrowDataType) -> ListArray<i64> {
     let offsets = array.offsets().into();
 
     ListArray::<i64>::new(
@@ -349,7 +349,7 @@ fn cast_list_to_large_list(array: &ListArray<i32>, to_type: &DataType) -> ListAr
     )
 }
 
-fn cast_large_to_list(array: &ListArray<i64>, to_type: &DataType) -> ListArray<i32> {
+fn cast_large_to_list(array: &ListArray<i64>, to_type: &ArrowDataType) -> ListArray<i32> {
     let offsets = array.offsets().try_into().expect("Convertme to error");
 
     ListArray::<i32>::new(
@@ -362,7 +362,7 @@ fn cast_large_to_list(array: &ListArray<i64>, to_type: &DataType) -> ListArray<i
 
 fn cast_fixed_size_list_to_list<O: Offset>(
     fixed: &FixedSizeListArray,
-    to_type: &DataType,
+    to_type: &ArrowDataType,
     options: CastOptions,
 ) -> PolarsResult<ListArray<O>> {
     let new_values = cast(
@@ -408,7 +408,7 @@ fn cast_list_to_fixed_size_list<O: Offset>(
             );
             let new_values = cast(sliced_values.as_ref(), inner.data_type(), options)?;
             Ok(FixedSizeListArray::new(
-                DataType::FixedSizeList(Box::new(inner.clone()), size),
+                ArrowDataType::FixedSizeList(Box::new(inner.clone()), size),
                 new_values,
                 list.validity().cloned(),
             ))
@@ -441,10 +441,10 @@ fn cast_list_to_fixed_size_list<O: Offset>(
 /// * Interval and duration
 pub fn cast(
     array: &dyn Array,
-    to_type: &DataType,
+    to_type: &ArrowDataType,
     options: CastOptions,
 ) -> PolarsResult<Box<dyn Array>> {
-    use DataType::*;
+    use ArrowDataType::*;
     let from_type = array.data_type();
 
     // clone array if types are the same
@@ -697,34 +697,32 @@ pub fn cast(
             ),
         },
 
-        (LargeBinary, _) => {
-            match to_type {
-                UInt8 => binary_to_primitive_dyn::<i64, u8>(array, to_type, options),
-                UInt16 => binary_to_primitive_dyn::<i64, u16>(array, to_type, options),
-                UInt32 => binary_to_primitive_dyn::<i64, u32>(array, to_type, options),
-                UInt64 => binary_to_primitive_dyn::<i64, u64>(array, to_type, options),
-                Int8 => binary_to_primitive_dyn::<i64, i8>(array, to_type, options),
-                Int16 => binary_to_primitive_dyn::<i64, i16>(array, to_type, options),
-                Int32 => binary_to_primitive_dyn::<i64, i32>(array, to_type, options),
-                Int64 => binary_to_primitive_dyn::<i64, i64>(array, to_type, options),
-                Float32 => binary_to_primitive_dyn::<i64, f32>(array, to_type, options),
-                Float64 => binary_to_primitive_dyn::<i64, f64>(array, to_type, options),
-                Binary => {
-                    binary_large_to_binary(array.as_any().downcast_ref().unwrap(), to_type.clone())
-                        .map(|x| x.boxed())
-                },
-                LargeUtf8 => {
-                    binary_to_utf8::<i64>(array.as_any().downcast_ref().unwrap(), to_type.clone())
-                        .map(|x| x.boxed())
-                },
-                LargeList(inner) if matches!(inner.data_type, DataType::UInt8) => Ok(
-                    binary_to_list::<i64>(array.as_any().downcast_ref().unwrap(), to_type.clone())
-                        .boxed(),
-                ),
-                _ => polars_bail!(InvalidOperation:
-                    "casting from {from_type:?} to {to_type:?} not supported",
-                ),
-            }
+        (LargeBinary, _) => match to_type {
+            UInt8 => binary_to_primitive_dyn::<i64, u8>(array, to_type, options),
+            UInt16 => binary_to_primitive_dyn::<i64, u16>(array, to_type, options),
+            UInt32 => binary_to_primitive_dyn::<i64, u32>(array, to_type, options),
+            UInt64 => binary_to_primitive_dyn::<i64, u64>(array, to_type, options),
+            Int8 => binary_to_primitive_dyn::<i64, i8>(array, to_type, options),
+            Int16 => binary_to_primitive_dyn::<i64, i16>(array, to_type, options),
+            Int32 => binary_to_primitive_dyn::<i64, i32>(array, to_type, options),
+            Int64 => binary_to_primitive_dyn::<i64, i64>(array, to_type, options),
+            Float32 => binary_to_primitive_dyn::<i64, f32>(array, to_type, options),
+            Float64 => binary_to_primitive_dyn::<i64, f64>(array, to_type, options),
+            Binary => {
+                binary_large_to_binary(array.as_any().downcast_ref().unwrap(), to_type.clone())
+                    .map(|x| x.boxed())
+            },
+            LargeUtf8 => {
+                binary_to_utf8::<i64>(array.as_any().downcast_ref().unwrap(), to_type.clone())
+                    .map(|x| x.boxed())
+            },
+            LargeList(inner) if matches!(inner.data_type, ArrowDataType::UInt8) => Ok(
+                binary_to_list::<i64>(array.as_any().downcast_ref().unwrap(), to_type.clone())
+                    .boxed(),
+            ),
+            _ => polars_bail!(InvalidOperation:
+                "casting from {from_type:?} to {to_type:?} not supported",
+            ),
         },
         (FixedSizeBinary(_), _) => match to_type {
             Binary => Ok(fixed_size_binary_binary::<i32>(
@@ -975,24 +973,24 @@ pub fn cast(
 /// K is the key type
 fn cast_to_dictionary<K: DictionaryKey>(
     array: &dyn Array,
-    dict_value_type: &DataType,
+    dict_value_type: &ArrowDataType,
     options: CastOptions,
 ) -> PolarsResult<Box<dyn Array>> {
     let array = cast(array, dict_value_type, options)?;
     let array = array.as_ref();
     match *dict_value_type {
-        DataType::Int8 => primitive_to_dictionary_dyn::<i8, K>(array),
-        DataType::Int16 => primitive_to_dictionary_dyn::<i16, K>(array),
-        DataType::Int32 => primitive_to_dictionary_dyn::<i32, K>(array),
-        DataType::Int64 => primitive_to_dictionary_dyn::<i64, K>(array),
-        DataType::UInt8 => primitive_to_dictionary_dyn::<u8, K>(array),
-        DataType::UInt16 => primitive_to_dictionary_dyn::<u16, K>(array),
-        DataType::UInt32 => primitive_to_dictionary_dyn::<u32, K>(array),
-        DataType::UInt64 => primitive_to_dictionary_dyn::<u64, K>(array),
-        DataType::Utf8 => utf8_to_dictionary_dyn::<i32, K>(array),
-        DataType::LargeUtf8 => utf8_to_dictionary_dyn::<i64, K>(array),
-        DataType::Binary => binary_to_dictionary_dyn::<i32, K>(array),
-        DataType::LargeBinary => binary_to_dictionary_dyn::<i64, K>(array),
+        ArrowDataType::Int8 => primitive_to_dictionary_dyn::<i8, K>(array),
+        ArrowDataType::Int16 => primitive_to_dictionary_dyn::<i16, K>(array),
+        ArrowDataType::Int32 => primitive_to_dictionary_dyn::<i32, K>(array),
+        ArrowDataType::Int64 => primitive_to_dictionary_dyn::<i64, K>(array),
+        ArrowDataType::UInt8 => primitive_to_dictionary_dyn::<u8, K>(array),
+        ArrowDataType::UInt16 => primitive_to_dictionary_dyn::<u16, K>(array),
+        ArrowDataType::UInt32 => primitive_to_dictionary_dyn::<u32, K>(array),
+        ArrowDataType::UInt64 => primitive_to_dictionary_dyn::<u64, K>(array),
+        ArrowDataType::Utf8 => utf8_to_dictionary_dyn::<i32, K>(array),
+        ArrowDataType::LargeUtf8 => utf8_to_dictionary_dyn::<i64, K>(array),
+        ArrowDataType::Binary => binary_to_dictionary_dyn::<i32, K>(array),
+        ArrowDataType::LargeBinary => binary_to_dictionary_dyn::<i64, K>(array),
         _ => polars_bail!(ComputeError:
             "unsupported output type for dictionary packing: {dict_value_type:?}"
         ),

--- a/crates/polars-arrow/src/compute/cast/primitive_to.rs
+++ b/crates/polars-arrow/src/compute/cast/primitive_to.rs
@@ -7,7 +7,7 @@ use super::CastOptions;
 use crate::array::*;
 use crate::bitmap::Bitmap;
 use crate::compute::arity::unary;
-use crate::datatypes::{DataType, IntervalUnit, TimeUnit};
+use crate::datatypes::{ArrowDataType, IntervalUnit, TimeUnit};
 use crate::offset::{Offset, Offsets};
 use crate::temporal_conversions::*;
 use crate::types::{days_ms, f16, months_days_ns, NativeType};
@@ -61,7 +61,7 @@ where
 /// Validity is preserved.
 pub fn primitive_to_boolean<T: NativeType>(
     from: &PrimitiveArray<T>,
-    to_type: DataType,
+    to_type: ArrowDataType,
 ) -> BooleanArray {
     let iter = from.values().iter().map(|v| *v != T::default());
     let values = Bitmap::from_trusted_len_iter(iter);
@@ -71,7 +71,7 @@ pub fn primitive_to_boolean<T: NativeType>(
 
 pub(super) fn primitive_to_boolean_dyn<T>(
     from: &dyn Array,
-    to_type: DataType,
+    to_type: ArrowDataType,
 ) -> PolarsResult<Box<dyn Array>>
 where
     T: NativeType,
@@ -127,7 +127,7 @@ where
 
 pub(super) fn primitive_to_primitive_dyn<I, O>(
     from: &dyn Array,
-    to_type: &DataType,
+    to_type: &ArrowDataType,
     options: CastOptions,
 ) -> PolarsResult<Box<dyn Array>>
 where
@@ -145,7 +145,7 @@ where
 /// Cast [`PrimitiveArray`] to a [`PrimitiveArray`] of another physical type via numeric conversion.
 pub fn primitive_to_primitive<I, O>(
     from: &PrimitiveArray<I>,
-    to_type: &DataType,
+    to_type: &ArrowDataType,
 ) -> PrimitiveArray<O>
 where
     I: NativeType + num_traits::NumCast,
@@ -183,7 +183,7 @@ pub fn integer_to_decimal<T: NativeType + AsPrimitive<i128>>(
     });
 
     PrimitiveArray::<i128>::from_trusted_len_iter(values)
-        .to(DataType::Decimal(to_precision, to_scale))
+        .to(ArrowDataType::Decimal(to_precision, to_scale))
 }
 
 pub(super) fn integer_to_decimal_dyn<T>(
@@ -228,7 +228,7 @@ where
     });
 
     PrimitiveArray::<i128>::from_trusted_len_iter(values)
-        .to(DataType::Decimal(to_precision, to_scale))
+        .to(ArrowDataType::Decimal(to_precision, to_scale))
 }
 
 pub(super) fn float_to_decimal_dyn<T>(
@@ -248,7 +248,7 @@ where
 /// Same as `number as to_number_type` in rust
 pub fn primitive_as_primitive<I, O>(
     from: &PrimitiveArray<I>,
-    to_type: &DataType,
+    to_type: &ArrowDataType,
 ) -> PrimitiveArray<O>
 where
     I: NativeType + num_traits::AsPrimitive<O>,
@@ -261,7 +261,7 @@ where
 /// This is O(1).
 pub fn primitive_to_same_primitive<T>(
     from: &PrimitiveArray<T>,
-    to_type: &DataType,
+    to_type: &ArrowDataType,
 ) -> PrimitiveArray<T>
 where
     T: NativeType,
@@ -277,7 +277,7 @@ where
 /// This is O(1).
 pub(super) fn primitive_to_same_primitive_dyn<T>(
     from: &dyn Array,
-    to_type: &DataType,
+    to_type: &ArrowDataType,
 ) -> PolarsResult<Box<dyn Array>>
 where
     T: NativeType,
@@ -321,39 +321,59 @@ const fn time_unit_multiple(unit: TimeUnit) -> i64 {
 
 /// Conversion of dates
 pub fn date32_to_date64(from: &PrimitiveArray<i32>) -> PrimitiveArray<i64> {
-    unary(from, |x| x as i64 * MILLISECONDS_IN_DAY, DataType::Date64)
+    unary(
+        from,
+        |x| x as i64 * MILLISECONDS_IN_DAY,
+        ArrowDataType::Date64,
+    )
 }
 
 /// Conversion of dates
 pub fn date64_to_date32(from: &PrimitiveArray<i64>) -> PrimitiveArray<i32> {
-    unary(from, |x| (x / MILLISECONDS_IN_DAY) as i32, DataType::Date32)
+    unary(
+        from,
+        |x| (x / MILLISECONDS_IN_DAY) as i32,
+        ArrowDataType::Date32,
+    )
 }
 
 /// Conversion of times
 pub fn time32s_to_time32ms(from: &PrimitiveArray<i32>) -> PrimitiveArray<i32> {
-    unary(from, |x| x * 1000, DataType::Time32(TimeUnit::Millisecond))
+    unary(
+        from,
+        |x| x * 1000,
+        ArrowDataType::Time32(TimeUnit::Millisecond),
+    )
 }
 
 /// Conversion of times
 pub fn time32ms_to_time32s(from: &PrimitiveArray<i32>) -> PrimitiveArray<i32> {
-    unary(from, |x| x / 1000, DataType::Time32(TimeUnit::Second))
+    unary(from, |x| x / 1000, ArrowDataType::Time32(TimeUnit::Second))
 }
 
 /// Conversion of times
 pub fn time64us_to_time64ns(from: &PrimitiveArray<i64>) -> PrimitiveArray<i64> {
-    unary(from, |x| x * 1000, DataType::Time64(TimeUnit::Nanosecond))
+    unary(
+        from,
+        |x| x * 1000,
+        ArrowDataType::Time64(TimeUnit::Nanosecond),
+    )
 }
 
 /// Conversion of times
 pub fn time64ns_to_time64us(from: &PrimitiveArray<i64>) -> PrimitiveArray<i64> {
-    unary(from, |x| x / 1000, DataType::Time64(TimeUnit::Microsecond))
+    unary(
+        from,
+        |x| x / 1000,
+        ArrowDataType::Time64(TimeUnit::Microsecond),
+    )
 }
 
 /// Conversion of timestamp
 pub fn timestamp_to_date64(from: &PrimitiveArray<i64>, from_unit: TimeUnit) -> PrimitiveArray<i64> {
     let from_size = time_unit_multiple(from_unit);
     let to_size = MILLISECONDS;
-    let to_type = DataType::Date64;
+    let to_type = ArrowDataType::Date64;
 
     // Scale time_array by (to_size / from_size) using a
     // single integer operation, but need to avoid integer
@@ -369,7 +389,7 @@ pub fn timestamp_to_date64(from: &PrimitiveArray<i64>, from_unit: TimeUnit) -> P
 /// Conversion of timestamp
 pub fn timestamp_to_date32(from: &PrimitiveArray<i64>, from_unit: TimeUnit) -> PrimitiveArray<i32> {
     let from_size = time_unit_multiple(from_unit) * SECONDS_IN_DAY;
-    unary(from, |x| (x / from_size) as i32, DataType::Date32)
+    unary(from, |x| (x / from_size) as i32, ArrowDataType::Date32)
 }
 
 /// Conversion of time
@@ -381,7 +401,11 @@ pub fn time32_to_time64(
     let from_size = time_unit_multiple(from_unit);
     let to_size = time_unit_multiple(to_unit);
     let divisor = to_size / from_size;
-    unary(from, |x| (x as i64 * divisor), DataType::Time64(to_unit))
+    unary(
+        from,
+        |x| (x as i64 * divisor),
+        ArrowDataType::Time64(to_unit),
+    )
 }
 
 /// Conversion of time
@@ -393,7 +417,11 @@ pub fn time64_to_time32(
     let from_size = time_unit_multiple(from_unit);
     let to_size = time_unit_multiple(to_unit);
     let divisor = from_size / to_size;
-    unary(from, |x| (x / divisor) as i32, DataType::Time32(to_unit))
+    unary(
+        from,
+        |x| (x / divisor) as i32,
+        ArrowDataType::Time32(to_unit),
+    )
 }
 
 /// Conversion of timestamp
@@ -405,7 +433,7 @@ pub fn timestamp_to_timestamp(
 ) -> PrimitiveArray<i64> {
     let from_size = time_unit_multiple(from_unit);
     let to_size = time_unit_multiple(to_unit);
-    let to_type = DataType::Timestamp(to_unit, tz.clone());
+    let to_type = ArrowDataType::Timestamp(to_unit, tz.clone());
     // we either divide or multiply, depending on size of each unit
     if from_size >= to_size {
         unary(from, |x| (x / (from_size / to_size)), to_type)
@@ -559,7 +587,7 @@ pub fn days_ms_to_months_days_ns(from: &PrimitiveArray<days_ms>) -> PrimitiveArr
     unary(
         from,
         days_ms_to_months_days_ns_scalar,
-        DataType::Interval(IntervalUnit::MonthDayNano),
+        ArrowDataType::Interval(IntervalUnit::MonthDayNano),
     )
 }
 
@@ -573,11 +601,11 @@ pub fn months_to_months_days_ns(from: &PrimitiveArray<i32>) -> PrimitiveArray<mo
     unary(
         from,
         months_to_months_days_ns_scalar,
-        DataType::Interval(IntervalUnit::MonthDayNano),
+        ArrowDataType::Interval(IntervalUnit::MonthDayNano),
     )
 }
 
 /// Casts f16 into f32
 pub fn f16_to_f32(from: &PrimitiveArray<f16>) -> PrimitiveArray<f32> {
-    unary(from, |x| x.to_f32(), DataType::Float32)
+    unary(from, |x| x.to_f32(), ArrowDataType::Float32)
 }

--- a/crates/polars-arrow/src/compute/cast/utf8_to.rs
+++ b/crates/polars-arrow/src/compute/cast/utf8_to.rs
@@ -3,7 +3,7 @@ use polars_error::PolarsResult;
 
 use super::CastOptions;
 use crate::array::*;
-use crate::datatypes::{DataType, TimeUnit};
+use crate::datatypes::{ArrowDataType, TimeUnit};
 use crate::offset::Offset;
 use crate::temporal_conversions::{
     utf8_to_naive_timestamp as utf8_to_naive_timestamp_, utf8_to_timestamp as utf8_to_timestamp_,
@@ -14,7 +14,7 @@ use crate::types::NativeType;
 const RFC3339: &str = "%Y-%m-%dT%H:%M:%S%.f%:z";
 
 /// Casts a [`Utf8Array`] to a [`PrimitiveArray`], making any uncastable value a Null.
-pub fn utf8_to_primitive<O: Offset, T>(from: &Utf8Array<O>, to: &DataType) -> PrimitiveArray<T>
+pub fn utf8_to_primitive<O: Offset, T>(from: &Utf8Array<O>, to: &ArrowDataType) -> PrimitiveArray<T>
 where
     T: NativeType + lexical_core::FromLexical,
 {
@@ -28,7 +28,7 @@ where
 /// Casts a [`Utf8Array`] to a [`PrimitiveArray`] at best-effort using `lexical_core::parse_partial`, making any uncastable value as zero.
 pub fn partial_utf8_to_primitive<O: Offset, T>(
     from: &Utf8Array<O>,
-    to: &DataType,
+    to: &ArrowDataType,
 ) -> PrimitiveArray<T>
 where
     T: NativeType + lexical_core::FromLexical,
@@ -42,7 +42,7 @@ where
 
 pub(super) fn utf8_to_primitive_dyn<O: Offset, T>(
     from: &dyn Array,
-    to: &DataType,
+    to: &ArrowDataType,
     options: CastOptions,
 ) -> PolarsResult<Box<dyn Array>>
 where
@@ -65,7 +65,7 @@ pub fn utf8_to_date32<O: Offset>(from: &Utf8Array<O>) -> PrimitiveArray<i32> {
                 .map(|x| x.num_days_from_ce() - EPOCH_DAYS_FROM_CE)
         })
     });
-    PrimitiveArray::<i32>::from_trusted_len_iter(iter).to(DataType::Date32)
+    PrimitiveArray::<i32>::from_trusted_len_iter(iter).to(ArrowDataType::Date32)
 }
 
 pub(super) fn utf8_to_date32_dyn<O: Offset>(from: &dyn Array) -> PolarsResult<Box<dyn Array>> {
@@ -82,7 +82,7 @@ pub fn utf8_to_date64<O: Offset>(from: &Utf8Array<O>) -> PrimitiveArray<i64> {
                 .map(|x| (x.num_days_from_ce() - EPOCH_DAYS_FROM_CE) as i64 * 86400000)
         })
     });
-    PrimitiveArray::from_trusted_len_iter(iter).to(DataType::Date64)
+    PrimitiveArray::from_trusted_len_iter(iter).to(ArrowDataType::Date64)
 }
 
 pub(super) fn utf8_to_date64_dyn<O: Offset>(from: &dyn Array) -> PolarsResult<Box<dyn Array>> {
@@ -169,7 +169,10 @@ pub fn utf8_large_to_utf8(from: &Utf8Array<i64>) -> PolarsResult<Utf8Array<i32>>
 }
 
 /// Conversion to binary
-pub fn utf8_to_binary<O: Offset>(from: &Utf8Array<O>, to_data_type: DataType) -> BinaryArray<O> {
+pub fn utf8_to_binary<O: Offset>(
+    from: &Utf8Array<O>,
+    to_data_type: ArrowDataType,
+) -> BinaryArray<O> {
     // Safety: erasure of an invariant is always safe
     unsafe {
         BinaryArray::<O>::new(

--- a/crates/polars-arrow/src/compute/comparison/binary.rs
+++ b/crates/polars-arrow/src/compute/comparison/binary.rs
@@ -3,7 +3,7 @@ use super::super::utils::combine_validities;
 use crate::array::{BinaryArray, BooleanArray};
 use crate::bitmap::Bitmap;
 use crate::compute::comparison::{finish_eq_validities, finish_neq_validities};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::Offset;
 
 /// Evaluate `op(lhs, rhs)` for [`BinaryArray`]s using a specified
@@ -23,7 +23,7 @@ where
         .map(|(lhs, rhs)| op(lhs, rhs));
     let values = Bitmap::from_trusted_len_iter(values);
 
-    BooleanArray::new(DataType::Boolean, values, validity)
+    BooleanArray::new(ArrowDataType::Boolean, values, validity)
 }
 
 /// Evaluate `op(lhs, rhs)` for [`BinaryArray`] and scalar using
@@ -38,7 +38,7 @@ where
     let values = lhs.values_iter().map(|lhs| op(lhs, rhs));
     let values = Bitmap::from_trusted_len_iter(values);
 
-    BooleanArray::new(DataType::Boolean, values, validity)
+    BooleanArray::new(ArrowDataType::Boolean, values, validity)
 }
 
 /// Perform `lhs == rhs` operation on [`BinaryArray`].

--- a/crates/polars-arrow/src/compute/comparison/boolean.rs
+++ b/crates/polars-arrow/src/compute/comparison/boolean.rs
@@ -3,7 +3,7 @@ use super::super::utils::combine_validities;
 use crate::array::BooleanArray;
 use crate::bitmap::{binary, unary, Bitmap};
 use crate::compute::comparison::{finish_eq_validities, finish_neq_validities};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// Evaluate `op(lhs, rhs)` for [`BooleanArray`]s using a specified
 /// comparison function.
@@ -16,7 +16,7 @@ where
 
     let values = binary(lhs.values(), rhs.values(), op);
 
-    BooleanArray::new(DataType::Boolean, values, validity)
+    BooleanArray::new(ArrowDataType::Boolean, values, validity)
 }
 
 /// Evaluate `op(left, right)` for [`BooleanArray`] and scalar using
@@ -28,7 +28,7 @@ where
     let rhs = if rhs { !0 } else { 0 };
 
     let values = unary(lhs.values(), |x| op(x, rhs));
-    BooleanArray::new(DataType::Boolean, values, lhs.validity().cloned())
+    BooleanArray::new(ArrowDataType::Boolean, values, lhs.validity().cloned())
 }
 
 /// Perform `lhs == rhs` operation on two [`BooleanArray`]s.
@@ -111,7 +111,7 @@ pub fn lt_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
         compare_op_scalar(lhs, rhs, |a, _| !a)
     } else {
         BooleanArray::new(
-            DataType::Boolean,
+            ArrowDataType::Boolean,
             Bitmap::new_zeroed(lhs.len()),
             lhs.validity().cloned(),
         )
@@ -145,7 +145,7 @@ pub fn gt(lhs: &BooleanArray, rhs: &BooleanArray) -> BooleanArray {
 pub fn gt_scalar(lhs: &BooleanArray, rhs: bool) -> BooleanArray {
     if rhs {
         BooleanArray::new(
-            DataType::Boolean,
+            ArrowDataType::Boolean,
             Bitmap::new_zeroed(lhs.len()),
             lhs.validity().cloned(),
         )

--- a/crates/polars-arrow/src/compute/comparison/mod.rs
+++ b/crates/polars-arrow/src/compute/comparison/mod.rs
@@ -1,7 +1,7 @@
 //! Contains comparison operators
 //!
 //! The module contains functions that compare either an [`Array`] and a [`Scalar`]
-//! or two [`Array`]s (of the same [`DataType`]). The scalar-oriented functions are
+//! or two [`Array`]s (of the same [`ArrowDataType`]). The scalar-oriented functions are
 //! suffixed with `_scalar`.
 //!
 //! The functions are organized in two variants:
@@ -45,7 +45,7 @@
 //! ```
 
 use crate::array::*;
-use crate::datatypes::{DataType, IntervalUnit};
+use crate::datatypes::{ArrowDataType, IntervalUnit};
 use crate::scalar::*;
 
 pub mod binary;
@@ -171,8 +171,8 @@ pub fn eq_and_validity(lhs: &dyn Array, rhs: &dyn Array) -> BooleanArray {
     compare!(lhs, rhs, eq_and_validity, match_eq)
 }
 
-/// Returns whether a [`DataType`] is comparable is supported by [`eq`].
-pub fn can_eq(data_type: &DataType) -> bool {
+/// Returns whether a [`ArrowDataType`] is comparable is supported by [`eq`].
+pub fn can_eq(data_type: &ArrowDataType) -> bool {
     can_partial_eq(data_type)
 }
 
@@ -198,8 +198,8 @@ pub fn neq_and_validity(lhs: &dyn Array, rhs: &dyn Array) -> BooleanArray {
     compare!(lhs, rhs, neq_and_validity, match_eq)
 }
 
-/// Returns whether a [`DataType`] is comparable is supported by [`neq`].
-pub fn can_neq(data_type: &DataType) -> bool {
+/// Returns whether a [`ArrowDataType`] is comparable is supported by [`neq`].
+pub fn can_neq(data_type: &ArrowDataType) -> bool {
     can_partial_eq(data_type)
 }
 
@@ -214,8 +214,8 @@ pub fn lt(lhs: &dyn Array, rhs: &dyn Array) -> BooleanArray {
     compare!(lhs, rhs, lt, match_eq_ord)
 }
 
-/// Returns whether a [`DataType`] is comparable is supported by [`lt`].
-pub fn can_lt(data_type: &DataType) -> bool {
+/// Returns whether a [`ArrowDataType`] is comparable is supported by [`lt`].
+pub fn can_lt(data_type: &ArrowDataType) -> bool {
     can_partial_eq_and_ord(data_type)
 }
 
@@ -230,8 +230,8 @@ pub fn lt_eq(lhs: &dyn Array, rhs: &dyn Array) -> BooleanArray {
     compare!(lhs, rhs, lt_eq, match_eq_ord)
 }
 
-/// Returns whether a [`DataType`] is comparable is supported by [`lt`].
-pub fn can_lt_eq(data_type: &DataType) -> bool {
+/// Returns whether a [`ArrowDataType`] is comparable is supported by [`lt`].
+pub fn can_lt_eq(data_type: &ArrowDataType) -> bool {
     can_partial_eq_and_ord(data_type)
 }
 
@@ -246,8 +246,8 @@ pub fn gt(lhs: &dyn Array, rhs: &dyn Array) -> BooleanArray {
     compare!(lhs, rhs, gt, match_eq_ord)
 }
 
-/// Returns whether a [`DataType`] is comparable is supported by [`gt`].
-pub fn can_gt(data_type: &DataType) -> bool {
+/// Returns whether a [`ArrowDataType`] is comparable is supported by [`gt`].
+pub fn can_gt(data_type: &ArrowDataType) -> bool {
     can_partial_eq_and_ord(data_type)
 }
 
@@ -262,8 +262,8 @@ pub fn gt_eq(lhs: &dyn Array, rhs: &dyn Array) -> BooleanArray {
     compare!(lhs, rhs, gt_eq, match_eq_ord)
 }
 
-/// Returns whether a [`DataType`] is comparable is supported by [`gt_eq`].
-pub fn can_gt_eq(data_type: &DataType) -> bool {
+/// Returns whether a [`ArrowDataType`] is comparable is supported by [`gt_eq`].
+pub fn can_gt_eq(data_type: &ArrowDataType) -> bool {
     can_partial_eq_and_ord(data_type)
 }
 
@@ -276,7 +276,7 @@ macro_rules! compare_scalar {
             rhs.data_type().to_logical_type()
         );
         if !rhs.is_valid() {
-            return BooleanArray::new_null(DataType::Boolean, lhs.len());
+            return BooleanArray::new_null(ArrowDataType::Boolean, lhs.len());
         }
 
         use crate::datatypes::PhysicalType::*;
@@ -335,8 +335,8 @@ pub fn eq_scalar_and_validity(lhs: &dyn Array, rhs: &dyn Scalar) -> BooleanArray
     compare_scalar!(lhs, rhs, eq_scalar_and_validity, match_eq)
 }
 
-/// Returns whether a [`DataType`] is supported by [`eq_scalar`].
-pub fn can_eq_scalar(data_type: &DataType) -> bool {
+/// Returns whether a [`ArrowDataType`] is supported by [`eq_scalar`].
+pub fn can_eq_scalar(data_type: &ArrowDataType) -> bool {
     can_partial_eq_scalar(data_type)
 }
 
@@ -360,8 +360,8 @@ pub fn neq_scalar_and_validity(lhs: &dyn Array, rhs: &dyn Scalar) -> BooleanArra
     compare_scalar!(lhs, rhs, neq_scalar_and_validity, match_eq)
 }
 
-/// Returns whether a [`DataType`] is supported by [`neq_scalar`].
-pub fn can_neq_scalar(data_type: &DataType) -> bool {
+/// Returns whether a [`ArrowDataType`] is supported by [`neq_scalar`].
+pub fn can_neq_scalar(data_type: &ArrowDataType) -> bool {
     can_partial_eq_scalar(data_type)
 }
 
@@ -375,8 +375,8 @@ pub fn lt_scalar(lhs: &dyn Array, rhs: &dyn Scalar) -> BooleanArray {
     compare_scalar!(lhs, rhs, lt_scalar, match_eq_ord)
 }
 
-/// Returns whether a [`DataType`] is supported by [`lt_scalar`].
-pub fn can_lt_scalar(data_type: &DataType) -> bool {
+/// Returns whether a [`ArrowDataType`] is supported by [`lt_scalar`].
+pub fn can_lt_scalar(data_type: &ArrowDataType) -> bool {
     can_partial_eq_and_ord_scalar(data_type)
 }
 
@@ -390,8 +390,8 @@ pub fn lt_eq_scalar(lhs: &dyn Array, rhs: &dyn Scalar) -> BooleanArray {
     compare_scalar!(lhs, rhs, lt_eq_scalar, match_eq_ord)
 }
 
-/// Returns whether a [`DataType`] is supported by [`lt_eq_scalar`].
-pub fn can_lt_eq_scalar(data_type: &DataType) -> bool {
+/// Returns whether a [`ArrowDataType`] is supported by [`lt_eq_scalar`].
+pub fn can_lt_eq_scalar(data_type: &ArrowDataType) -> bool {
     can_partial_eq_and_ord_scalar(data_type)
 }
 
@@ -405,8 +405,8 @@ pub fn gt_scalar(lhs: &dyn Array, rhs: &dyn Scalar) -> BooleanArray {
     compare_scalar!(lhs, rhs, gt_scalar, match_eq_ord)
 }
 
-/// Returns whether a [`DataType`] is supported by [`gt_scalar`].
-pub fn can_gt_scalar(data_type: &DataType) -> bool {
+/// Returns whether a [`ArrowDataType`] is supported by [`gt_scalar`].
+pub fn can_gt_scalar(data_type: &ArrowDataType) -> bool {
     can_partial_eq_and_ord_scalar(data_type)
 }
 
@@ -420,67 +420,67 @@ pub fn gt_eq_scalar(lhs: &dyn Array, rhs: &dyn Scalar) -> BooleanArray {
     compare_scalar!(lhs, rhs, gt_eq_scalar, match_eq_ord)
 }
 
-/// Returns whether a [`DataType`] is supported by [`gt_eq_scalar`].
-pub fn can_gt_eq_scalar(data_type: &DataType) -> bool {
+/// Returns whether a [`ArrowDataType`] is supported by [`gt_eq_scalar`].
+pub fn can_gt_eq_scalar(data_type: &ArrowDataType) -> bool {
     can_partial_eq_and_ord_scalar(data_type)
 }
 
 // The list of operations currently supported.
-fn can_partial_eq_and_ord_scalar(data_type: &DataType) -> bool {
-    if let DataType::Dictionary(_, values, _) = data_type.to_logical_type() {
+fn can_partial_eq_and_ord_scalar(data_type: &ArrowDataType) -> bool {
+    if let ArrowDataType::Dictionary(_, values, _) = data_type.to_logical_type() {
         return can_partial_eq_and_ord_scalar(values.as_ref());
     }
     can_partial_eq_and_ord(data_type)
 }
 
 // The list of operations currently supported.
-fn can_partial_eq_and_ord(data_type: &DataType) -> bool {
+fn can_partial_eq_and_ord(data_type: &ArrowDataType) -> bool {
     matches!(
         data_type,
-        DataType::Boolean
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Date32
-            | DataType::Time32(_)
-            | DataType::Interval(IntervalUnit::YearMonth)
-            | DataType::Int64
-            | DataType::Timestamp(_, _)
-            | DataType::Date64
-            | DataType::Time64(_)
-            | DataType::Duration(_)
-            | DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Float32
-            | DataType::Float64
-            | DataType::Utf8
-            | DataType::LargeUtf8
-            | DataType::Decimal(_, _)
-            | DataType::Binary
-            | DataType::LargeBinary
+        ArrowDataType::Boolean
+            | ArrowDataType::Int8
+            | ArrowDataType::Int16
+            | ArrowDataType::Int32
+            | ArrowDataType::Date32
+            | ArrowDataType::Time32(_)
+            | ArrowDataType::Interval(IntervalUnit::YearMonth)
+            | ArrowDataType::Int64
+            | ArrowDataType::Timestamp(_, _)
+            | ArrowDataType::Date64
+            | ArrowDataType::Time64(_)
+            | ArrowDataType::Duration(_)
+            | ArrowDataType::UInt8
+            | ArrowDataType::UInt16
+            | ArrowDataType::UInt32
+            | ArrowDataType::UInt64
+            | ArrowDataType::Float32
+            | ArrowDataType::Float64
+            | ArrowDataType::Utf8
+            | ArrowDataType::LargeUtf8
+            | ArrowDataType::Decimal(_, _)
+            | ArrowDataType::Binary
+            | ArrowDataType::LargeBinary
     )
 }
 
 // The list of operations currently supported.
-fn can_partial_eq(data_type: &DataType) -> bool {
+fn can_partial_eq(data_type: &ArrowDataType) -> bool {
     can_partial_eq_and_ord(data_type)
         || matches!(
             data_type.to_logical_type(),
-            DataType::Float16
-                | DataType::Interval(IntervalUnit::DayTime)
-                | DataType::Interval(IntervalUnit::MonthDayNano)
+            ArrowDataType::Float16
+                | ArrowDataType::Interval(IntervalUnit::DayTime)
+                | ArrowDataType::Interval(IntervalUnit::MonthDayNano)
         )
 }
 
 // The list of operations currently supported.
-fn can_partial_eq_scalar(data_type: &DataType) -> bool {
+fn can_partial_eq_scalar(data_type: &ArrowDataType) -> bool {
     can_partial_eq_and_ord_scalar(data_type)
         || matches!(
             data_type.to_logical_type(),
-            DataType::Interval(IntervalUnit::DayTime)
-                | DataType::Interval(IntervalUnit::MonthDayNano)
+            ArrowDataType::Interval(IntervalUnit::DayTime)
+                | ArrowDataType::Interval(IntervalUnit::MonthDayNano)
         )
 }
 
@@ -495,12 +495,12 @@ pub fn finish_eq_validities(
     match (validity_lhs, validity_rhs) {
         (None, None) => output_without_validities,
         (Some(lhs), None) => compute::boolean::and(
-            &BooleanArray::new(DataType::Boolean, lhs, None),
+            &BooleanArray::new(ArrowDataType::Boolean, lhs, None),
             &output_without_validities,
         ),
         (None, Some(rhs)) => compute::boolean::and(
             &output_without_validities,
-            &BooleanArray::new(DataType::Boolean, rhs, None),
+            &BooleanArray::new(ArrowDataType::Boolean, rhs, None),
         ),
         (Some(lhs), Some(rhs)) => {
             let lhs_validity_unset_bits = lhs.unset_bits();
@@ -510,8 +510,8 @@ pub fn finish_eq_validities(
             // these masked out values might differ and lead to a `eq == false` that has to
             // be corrected as both should be `null == null = true`
 
-            let lhs = BooleanArray::new(DataType::Boolean, lhs, None);
-            let rhs = BooleanArray::new(DataType::Boolean, rhs, None);
+            let lhs = BooleanArray::new(ArrowDataType::Boolean, lhs, None);
+            let rhs = BooleanArray::new(ArrowDataType::Boolean, rhs, None);
             let eq_validities = compute::comparison::boolean::eq(&lhs, &rhs);
 
             // validity_bits are equal AND values are equal
@@ -556,12 +556,12 @@ pub fn finish_neq_validities(
         (None, None) => output_without_validities,
         (Some(lhs), None) => {
             let lhs_negated =
-                compute::boolean::not(&BooleanArray::new(DataType::Boolean, lhs, None));
+                compute::boolean::not(&BooleanArray::new(ArrowDataType::Boolean, lhs, None));
             compute::boolean::or(&lhs_negated, &output_without_validities)
         },
         (None, Some(rhs)) => {
             let rhs_negated =
-                compute::boolean::not(&BooleanArray::new(DataType::Boolean, rhs, None));
+                compute::boolean::not(&BooleanArray::new(ArrowDataType::Boolean, rhs, None));
             compute::boolean::or(&output_without_validities, &rhs_negated)
         },
         (Some(lhs), Some(rhs)) => {
@@ -571,8 +571,8 @@ pub fn finish_neq_validities(
             // this branch is a bit more complicated as both arrays can have masked out values
             // these masked out values might differ and lead to a `neq == true` that has to
             // be corrected as both should be `null != null = false`
-            let lhs = BooleanArray::new(DataType::Boolean, lhs, None);
-            let rhs = BooleanArray::new(DataType::Boolean, rhs, None);
+            let lhs = BooleanArray::new(ArrowDataType::Boolean, lhs, None);
+            let rhs = BooleanArray::new(ArrowDataType::Boolean, rhs, None);
             let neq_validities = compute::comparison::boolean::neq(&lhs, &rhs);
 
             // validity_bits are not equal OR values not equal

--- a/crates/polars-arrow/src/compute/comparison/primitive.rs
+++ b/crates/polars-arrow/src/compute/comparison/primitive.rs
@@ -4,7 +4,7 @@ use super::simd::{Simd8, Simd8Lanes, Simd8PartialEq, Simd8PartialOrd};
 use crate::array::{BooleanArray, PrimitiveArray};
 use crate::bitmap::MutableBitmap;
 use crate::compute::comparison::{finish_eq_validities, finish_neq_validities};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::types::NativeType;
 
 pub(crate) fn compare_values_op<T, F>(lhs: &[T], rhs: &[T], op: F) -> MutableBitmap
@@ -71,7 +71,7 @@ where
 
     let values = compare_values_op(lhs.values(), rhs.values(), op);
 
-    BooleanArray::new(DataType::Boolean, values.into(), validity)
+    BooleanArray::new(ArrowDataType::Boolean, values.into(), validity)
 }
 
 /// Evaluate `op(left, right)` for [`PrimitiveArray`] and scalar using
@@ -85,7 +85,7 @@ where
 
     let values = compare_values_op_scalar(lhs.values(), rhs, op);
 
-    BooleanArray::new(DataType::Boolean, values.into(), validity)
+    BooleanArray::new(ArrowDataType::Boolean, values.into(), validity)
 }
 
 /// Perform `lhs == rhs` operation on two arrays.

--- a/crates/polars-arrow/src/compute/comparison/utf8.rs
+++ b/crates/polars-arrow/src/compute/comparison/utf8.rs
@@ -3,7 +3,7 @@ use super::super::utils::combine_validities;
 use crate::array::{BooleanArray, Utf8Array};
 use crate::bitmap::Bitmap;
 use crate::compute::comparison::{finish_eq_validities, finish_neq_validities};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::Offset;
 
 /// Evaluate `op(lhs, rhs)` for [`Utf8Array`]s using a specified
@@ -22,7 +22,7 @@ where
         .map(|(lhs, rhs)| op(lhs, rhs));
     let values = Bitmap::from_trusted_len_iter(values);
 
-    BooleanArray::new(DataType::Boolean, values, validity)
+    BooleanArray::new(ArrowDataType::Boolean, values, validity)
 }
 
 /// Evaluate `op(lhs, rhs)` for [`Utf8Array`] and scalar using
@@ -37,7 +37,7 @@ where
     let values = lhs.values_iter().map(|lhs| op(lhs, rhs));
     let values = Bitmap::from_trusted_len_iter(values);
 
-    BooleanArray::new(DataType::Boolean, values, validity)
+    BooleanArray::new(ArrowDataType::Boolean, values, validity)
 }
 
 /// Perform `lhs == rhs` operation on [`Utf8Array`].

--- a/crates/polars-arrow/src/compute/filter.rs
+++ b/crates/polars-arrow/src/compute/filter.rs
@@ -6,7 +6,7 @@ use crate::array::*;
 use crate::bitmap::utils::{BitChunkIterExact, BitChunksExact, SlicesIterator};
 use crate::bitmap::{Bitmap, MutableBitmap};
 use crate::chunk::Chunk;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::types::simd::Simd;
 use crate::types::{BitChunkOnes, NativeType};
 use crate::with_match_primitive_type_full;
@@ -271,7 +271,7 @@ pub fn filter(array: &dyn Array, filter: &BooleanArray) -> PolarsResult<Box<dyn 
     if let Some(validities) = filter.validity() {
         let values = filter.values();
         let new_values = values & validities;
-        let filter = BooleanArray::new(DataType::Boolean, new_values, None);
+        let filter = BooleanArray::new(ArrowDataType::Boolean, new_values, None);
         return crate::compute::filter::filter(array, &filter);
     }
 

--- a/crates/polars-arrow/src/compute/take/mod.rs
+++ b/crates/polars-arrow/src/compute/take/mod.rs
@@ -18,7 +18,7 @@
 //! Defines take kernel for [`Array`]
 
 use crate::array::{new_empty_array, Array, NullArray, PrimitiveArray};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::types::Index;
 
 mod binary;
@@ -95,43 +95,43 @@ pub fn take<O: Index>(
 /// # Examples
 /// ```
 /// use polars_arrow::compute::take::can_take;
-/// use polars_arrow::datatypes::{DataType};
+/// use polars_arrow::datatypes::{ArrowDataType};
 ///
-/// let data_type = DataType::Int8;
+/// let data_type = ArrowDataType::Int8;
 /// assert_eq!(can_take(&data_type), true);
 /// ```
-pub fn can_take(data_type: &DataType) -> bool {
+pub fn can_take(data_type: &ArrowDataType) -> bool {
     matches!(
         data_type,
-        DataType::Null
-            | DataType::Boolean
-            | DataType::Int8
-            | DataType::Int16
-            | DataType::Int32
-            | DataType::Date32
-            | DataType::Time32(_)
-            | DataType::Interval(_)
-            | DataType::Int64
-            | DataType::Date64
-            | DataType::Time64(_)
-            | DataType::Duration(_)
-            | DataType::Timestamp(_, _)
-            | DataType::UInt8
-            | DataType::UInt16
-            | DataType::UInt32
-            | DataType::UInt64
-            | DataType::Float16
-            | DataType::Float32
-            | DataType::Float64
-            | DataType::Decimal(_, _)
-            | DataType::Utf8
-            | DataType::LargeUtf8
-            | DataType::Binary
-            | DataType::LargeBinary
-            | DataType::Struct(_)
-            | DataType::List(_)
-            | DataType::LargeList(_)
-            | DataType::FixedSizeList(_, _)
-            | DataType::Dictionary(..)
+        ArrowDataType::Null
+            | ArrowDataType::Boolean
+            | ArrowDataType::Int8
+            | ArrowDataType::Int16
+            | ArrowDataType::Int32
+            | ArrowDataType::Date32
+            | ArrowDataType::Time32(_)
+            | ArrowDataType::Interval(_)
+            | ArrowDataType::Int64
+            | ArrowDataType::Date64
+            | ArrowDataType::Time64(_)
+            | ArrowDataType::Duration(_)
+            | ArrowDataType::Timestamp(_, _)
+            | ArrowDataType::UInt8
+            | ArrowDataType::UInt16
+            | ArrowDataType::UInt32
+            | ArrowDataType::UInt64
+            | ArrowDataType::Float16
+            | ArrowDataType::Float32
+            | ArrowDataType::Float64
+            | ArrowDataType::Decimal(_, _)
+            | ArrowDataType::Utf8
+            | ArrowDataType::LargeUtf8
+            | ArrowDataType::Binary
+            | ArrowDataType::LargeBinary
+            | ArrowDataType::Struct(_)
+            | ArrowDataType::List(_)
+            | ArrowDataType::LargeList(_)
+            | ArrowDataType::FixedSizeList(_, _)
+            | ArrowDataType::Dictionary(..)
     )
 }

--- a/crates/polars-arrow/src/compute/temporal.rs
+++ b/crates/polars-arrow/src/compute/temporal.rs
@@ -53,10 +53,10 @@ impl<T: chrono::TimeZone> U32IsoWeek for chrono::DateTime<T> {}
 macro_rules! date_like {
     ($extract:ident, $array:ident, $data_type:path) => {
         match $array.data_type().to_logical_type() {
-            DataType::Date32 | DataType::Date64 | DataType::Timestamp(_, None) => {
+            ArrowDataType::Date32 | ArrowDataType::Date64 | ArrowDataType::Timestamp(_, None) => {
                 date_variants($array, $data_type, |x| x.$extract())
             },
-            DataType::Timestamp(time_unit, Some(timezone_str)) => {
+            ArrowDataType::Timestamp(time_unit, Some(timezone_str)) => {
                 let array = $array.as_any().downcast_ref().unwrap();
 
                 if let Ok(timezone) = parse_offset(timezone_str) {
@@ -71,37 +71,37 @@ macro_rules! date_like {
 }
 
 /// Extracts the years of a temporal array as [`PrimitiveArray<i32>`].
-/// Use [`can_year`] to check if this operation is supported for the target [`DataType`].
+/// Use [`can_year`] to check if this operation is supported for the target [`ArrowDataType`].
 pub fn year(array: &dyn Array) -> PolarsResult<PrimitiveArray<i32>> {
-    date_like!(year, array, DataType::Int32)
+    date_like!(year, array, ArrowDataType::Int32)
 }
 
 /// Extracts the months of a temporal array as [`PrimitiveArray<u32>`].
 /// Value ranges from 1 to 12.
-/// Use [`can_month`] to check if this operation is supported for the target [`DataType`].
+/// Use [`can_month`] to check if this operation is supported for the target [`ArrowDataType`].
 pub fn month(array: &dyn Array) -> PolarsResult<PrimitiveArray<u32>> {
-    date_like!(month, array, DataType::UInt32)
+    date_like!(month, array, ArrowDataType::UInt32)
 }
 
 /// Extracts the days of a temporal array as [`PrimitiveArray<u32>`].
 /// Value ranges from 1 to 32 (Last day depends on month).
-/// Use [`can_day`] to check if this operation is supported for the target [`DataType`].
+/// Use [`can_day`] to check if this operation is supported for the target [`ArrowDataType`].
 pub fn day(array: &dyn Array) -> PolarsResult<PrimitiveArray<u32>> {
-    date_like!(day, array, DataType::UInt32)
+    date_like!(day, array, ArrowDataType::UInt32)
 }
 
 /// Extracts weekday of a temporal array as [`PrimitiveArray<u32>`].
 /// Monday is 1, Tuesday is 2, ..., Sunday is 7.
-/// Use [`can_weekday`] to check if this operation is supported for the target [`DataType`]
+/// Use [`can_weekday`] to check if this operation is supported for the target [`ArrowDataType`]
 pub fn weekday(array: &dyn Array) -> PolarsResult<PrimitiveArray<u32>> {
-    date_like!(u32_weekday, array, DataType::UInt32)
+    date_like!(u32_weekday, array, ArrowDataType::UInt32)
 }
 
 /// Extracts ISO week of a temporal array as [`PrimitiveArray<u32>`]
 /// Value ranges from 1 to 53 (Last week depends on the year).
-/// Use [`can_iso_week`] to check if this operation is supported for the target [`DataType`]
+/// Use [`can_iso_week`] to check if this operation is supported for the target [`ArrowDataType`]
 pub fn iso_week(array: &dyn Array) -> PolarsResult<PrimitiveArray<u32>> {
-    date_like!(u32_iso_week, array, DataType::UInt32)
+    date_like!(u32_iso_week, array, ArrowDataType::UInt32)
 }
 
 // Macro to avoid repetition in functions, that apply
@@ -109,13 +109,13 @@ pub fn iso_week(array: &dyn Array) -> PolarsResult<PrimitiveArray<u32>> {
 macro_rules! time_like {
     ($extract:ident, $array:ident, $data_type:path) => {
         match $array.data_type().to_logical_type() {
-            DataType::Date32 | DataType::Date64 | DataType::Timestamp(_, None) => {
+            ArrowDataType::Date32 | ArrowDataType::Date64 | ArrowDataType::Timestamp(_, None) => {
                 date_variants($array, $data_type, |x| x.$extract())
             },
-            DataType::Time32(_) | DataType::Time64(_) => {
-                time_variants($array, DataType::UInt32, |x| x.$extract())
+            ArrowDataType::Time32(_) | ArrowDataType::Time64(_) => {
+                time_variants($array, ArrowDataType::UInt32, |x| x.$extract())
             },
-            DataType::Timestamp(time_unit, Some(timezone_str)) => {
+            ArrowDataType::Timestamp(time_unit, Some(timezone_str)) => {
                 let array = $array.as_any().downcast_ref().unwrap();
 
                 if let Ok(timezone) = parse_offset(timezone_str) {
@@ -131,34 +131,34 @@ macro_rules! time_like {
 
 /// Extracts the hours of a temporal array as [`PrimitiveArray<u32>`].
 /// Value ranges from 0 to 23.
-/// Use [`can_hour`] to check if this operation is supported for the target [`DataType`].
+/// Use [`can_hour`] to check if this operation is supported for the target [`ArrowDataType`].
 pub fn hour(array: &dyn Array) -> PolarsResult<PrimitiveArray<u32>> {
-    time_like!(hour, array, DataType::UInt32)
+    time_like!(hour, array, ArrowDataType::UInt32)
 }
 
 /// Extracts the minutes of a temporal array as [`PrimitiveArray<u32>`].
 /// Value ranges from 0 to 59.
-/// Use [`can_minute`] to check if this operation is supported for the target [`DataType`].
+/// Use [`can_minute`] to check if this operation is supported for the target [`ArrowDataType`].
 pub fn minute(array: &dyn Array) -> PolarsResult<PrimitiveArray<u32>> {
-    time_like!(minute, array, DataType::UInt32)
+    time_like!(minute, array, ArrowDataType::UInt32)
 }
 
 /// Extracts the seconds of a temporal array as [`PrimitiveArray<u32>`].
 /// Value ranges from 0 to 59.
-/// Use [`can_second`] to check if this operation is supported for the target [`DataType`].
+/// Use [`can_second`] to check if this operation is supported for the target [`ArrowDataType`].
 pub fn second(array: &dyn Array) -> PolarsResult<PrimitiveArray<u32>> {
-    time_like!(second, array, DataType::UInt32)
+    time_like!(second, array, ArrowDataType::UInt32)
 }
 
 /// Extracts the nanoseconds of a temporal array as [`PrimitiveArray<u32>`].
-/// Use [`can_nanosecond`] to check if this operation is supported for the target [`DataType`].
+/// Use [`can_nanosecond`] to check if this operation is supported for the target [`ArrowDataType`].
 pub fn nanosecond(array: &dyn Array) -> PolarsResult<PrimitiveArray<u32>> {
-    time_like!(nanosecond, array, DataType::UInt32)
+    time_like!(nanosecond, array, ArrowDataType::UInt32)
 }
 
 fn date_variants<F, O>(
     array: &dyn Array,
-    data_type: DataType,
+    data_type: ArrowDataType,
     op: F,
 ) -> PolarsResult<PrimitiveArray<O>>
 where
@@ -166,21 +166,21 @@ where
     F: Fn(chrono::NaiveDateTime) -> O,
 {
     match array.data_type().to_logical_type() {
-        DataType::Date32 => {
+        ArrowDataType::Date32 => {
             let array = array
                 .as_any()
                 .downcast_ref::<PrimitiveArray<i32>>()
                 .unwrap();
             Ok(unary(array, |x| op(date32_to_datetime(x)), data_type))
         },
-        DataType::Date64 => {
+        ArrowDataType::Date64 => {
             let array = array
                 .as_any()
                 .downcast_ref::<PrimitiveArray<i64>>()
                 .unwrap();
             Ok(unary(array, |x| op(date64_to_datetime(x)), data_type))
         },
-        DataType::Timestamp(time_unit, None) => {
+        ArrowDataType::Timestamp(time_unit, None) => {
             let array = array
                 .as_any()
                 .downcast_ref::<PrimitiveArray<i64>>()
@@ -199,7 +199,7 @@ where
 
 fn time_variants<F, O>(
     array: &dyn Array,
-    data_type: DataType,
+    data_type: ArrowDataType,
     op: F,
 ) -> PolarsResult<PrimitiveArray<O>>
 where
@@ -207,28 +207,28 @@ where
     F: Fn(chrono::NaiveTime) -> O,
 {
     match array.data_type().to_logical_type() {
-        DataType::Time32(TimeUnit::Second) => {
+        ArrowDataType::Time32(TimeUnit::Second) => {
             let array = array
                 .as_any()
                 .downcast_ref::<PrimitiveArray<i32>>()
                 .unwrap();
             Ok(unary(array, |x| op(time32s_to_time(x)), data_type))
         },
-        DataType::Time32(TimeUnit::Millisecond) => {
+        ArrowDataType::Time32(TimeUnit::Millisecond) => {
             let array = array
                 .as_any()
                 .downcast_ref::<PrimitiveArray<i32>>()
                 .unwrap();
             Ok(unary(array, |x| op(time32ms_to_time(x)), data_type))
         },
-        DataType::Time64(TimeUnit::Microsecond) => {
+        ArrowDataType::Time64(TimeUnit::Microsecond) => {
             let array = array
                 .as_any()
                 .downcast_ref::<PrimitiveArray<i64>>()
                 .unwrap();
             Ok(unary(array, |x| op(time64us_to_time(x)), data_type))
         },
-        DataType::Time64(TimeUnit::Nanosecond) => {
+        ArrowDataType::Time64(TimeUnit::Nanosecond) => {
             let array = array
                 .as_any()
                 .downcast_ref::<PrimitiveArray<i64>>()
@@ -331,39 +331,39 @@ where
 /// # Examples
 /// ```
 /// use polars_arrow::compute::temporal::can_year;
-/// use polars_arrow::datatypes::{DataType};
+/// use polars_arrow::datatypes::{ArrowDataType};
 ///
-/// assert_eq!(can_year(&DataType::Date32), true);
-/// assert_eq!(can_year(&DataType::Int8), false);
+/// assert_eq!(can_year(&ArrowDataType::Date32), true);
+/// assert_eq!(can_year(&ArrowDataType::Int8), false);
 /// ```
-pub fn can_year(data_type: &DataType) -> bool {
+pub fn can_year(data_type: &ArrowDataType) -> bool {
     can_date(data_type)
 }
 
 /// Checks if an array of type `datatype` can perform month operation
-pub fn can_month(data_type: &DataType) -> bool {
+pub fn can_month(data_type: &ArrowDataType) -> bool {
     can_date(data_type)
 }
 
 /// Checks if an array of type `datatype` can perform day operation
-pub fn can_day(data_type: &DataType) -> bool {
+pub fn can_day(data_type: &ArrowDataType) -> bool {
     can_date(data_type)
 }
 
 /// Checks if an array of type `data_type` can perform weekday operation
-pub fn can_weekday(data_type: &DataType) -> bool {
+pub fn can_weekday(data_type: &ArrowDataType) -> bool {
     can_date(data_type)
 }
 
 /// Checks if an array of type `data_type` can perform ISO week operation
-pub fn can_iso_week(data_type: &DataType) -> bool {
+pub fn can_iso_week(data_type: &ArrowDataType) -> bool {
     can_date(data_type)
 }
 
-fn can_date(data_type: &DataType) -> bool {
+fn can_date(data_type: &ArrowDataType) -> bool {
     matches!(
         data_type,
-        DataType::Date32 | DataType::Date64 | DataType::Timestamp(_, _)
+        ArrowDataType::Date32 | ArrowDataType::Date64 | ArrowDataType::Timestamp(_, _)
     )
 }
 
@@ -372,39 +372,39 @@ fn can_date(data_type: &DataType) -> bool {
 /// # Examples
 /// ```
 /// use polars_arrow::compute::temporal::can_hour;
-/// use polars_arrow::datatypes::{DataType, TimeUnit};
+/// use polars_arrow::datatypes::{ArrowDataType, TimeUnit};
 ///
-/// assert_eq!(can_hour(&DataType::Time32(TimeUnit::Second)), true);
-/// assert_eq!(can_hour(&DataType::Int8), false);
+/// assert_eq!(can_hour(&ArrowDataType::Time32(TimeUnit::Second)), true);
+/// assert_eq!(can_hour(&ArrowDataType::Int8), false);
 /// ```
-pub fn can_hour(data_type: &DataType) -> bool {
+pub fn can_hour(data_type: &ArrowDataType) -> bool {
     can_time(data_type)
 }
 
 /// Checks if an array of type `datatype` can perform minute operation
-pub fn can_minute(data_type: &DataType) -> bool {
+pub fn can_minute(data_type: &ArrowDataType) -> bool {
     can_time(data_type)
 }
 
 /// Checks if an array of type `datatype` can perform second operation
-pub fn can_second(data_type: &DataType) -> bool {
+pub fn can_second(data_type: &ArrowDataType) -> bool {
     can_time(data_type)
 }
 
 /// Checks if an array of type `datatype` can perform nanosecond operation
-pub fn can_nanosecond(data_type: &DataType) -> bool {
+pub fn can_nanosecond(data_type: &ArrowDataType) -> bool {
     can_time(data_type)
 }
 
-fn can_time(data_type: &DataType) -> bool {
+fn can_time(data_type: &ArrowDataType) -> bool {
     matches!(
         data_type,
-        DataType::Time32(TimeUnit::Second)
-            | DataType::Time32(TimeUnit::Millisecond)
-            | DataType::Time64(TimeUnit::Microsecond)
-            | DataType::Time64(TimeUnit::Nanosecond)
-            | DataType::Date32
-            | DataType::Date64
-            | DataType::Timestamp(_, _)
+        ArrowDataType::Time32(TimeUnit::Second)
+            | ArrowDataType::Time32(TimeUnit::Millisecond)
+            | ArrowDataType::Time64(TimeUnit::Microsecond)
+            | ArrowDataType::Time64(TimeUnit::Nanosecond)
+            | ArrowDataType::Date32
+            | ArrowDataType::Date64
+            | ArrowDataType::Timestamp(_, _)
     )
 }

--- a/crates/polars-arrow/src/datatypes/field.rs
+++ b/crates/polars-arrow/src/datatypes/field.rs
@@ -1,12 +1,12 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use super::{DataType, Metadata};
+use super::{ArrowDataType, Metadata};
 
 /// Represents Arrow's metadata of a "column".
 ///
 /// A [`Field`] is the closest representation of the traditional "column": a logical type
-/// ([`DataType`]) with a name and nullability.
+/// ([`ArrowDataType`]) with a name and nullability.
 /// A Field has optional [`Metadata`] that can be used to annotate the field with custom metadata.
 ///
 /// Almost all IO in this crate uses [`Field`] to represent logical information about the data
@@ -16,8 +16,8 @@ use super::{DataType, Metadata};
 pub struct Field {
     /// Its name
     pub name: String,
-    /// Its logical [`DataType`]
-    pub data_type: DataType,
+    /// Its logical [`ArrowDataType`]
+    pub data_type: ArrowDataType,
     /// Its nullability
     pub is_nullable: bool,
     /// Additional custom (opaque) metadata.
@@ -26,7 +26,7 @@ pub struct Field {
 
 impl Field {
     /// Creates a new [`Field`].
-    pub fn new<T: Into<String>>(name: T, data_type: DataType, is_nullable: bool) -> Self {
+    pub fn new<T: Into<String>>(name: T, data_type: ArrowDataType, is_nullable: bool) -> Self {
         Field {
             name: name.into(),
             data_type,
@@ -46,9 +46,9 @@ impl Field {
         }
     }
 
-    /// Returns the [`Field`]'s [`DataType`].
+    /// Returns the [`Field`]'s [`ArrowDataType`].
     #[inline]
-    pub fn data_type(&self) -> &DataType {
+    pub fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 }

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -1,4 +1,4 @@
-//! Contains all metadata, such as [`PhysicalType`], [`DataType`], [`Field`] and [`ArrowSchema`].
+//! Contains all metadata, such as [`PhysicalType`], [`ArrowDataType`], [`Field`] and [`ArrowSchema`].
 
 mod field;
 mod physical_type;
@@ -22,13 +22,13 @@ pub(crate) type Extension = Option<(String, Option<String>)>;
 ///
 /// Each variant uniquely identifies a logical type, which define specific semantics to the data
 /// (e.g. how it should be represented).
-/// Each variant has a corresponding [`PhysicalType`], obtained via [`DataType::to_physical_type`],
+/// Each variant has a corresponding [`PhysicalType`], obtained via [`ArrowDataType::to_physical_type`],
 /// which declares the in-memory representation of data.
-/// The [`DataType::Extension`] is special in that it augments a [`DataType`] with metadata to support custom types.
+/// The [`ArrowDataType::Extension`] is special in that it augments a [`ArrowDataType`] with metadata to support custom types.
 /// Use `to_logical_type` to desugar such type and return its corresponding logical type.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum DataType {
+pub enum ArrowDataType {
     /// Null type
     Null,
     /// `true` and `false`.
@@ -103,7 +103,7 @@ pub enum DataType {
     FixedSizeList(Box<Field>, usize),
     /// A list of some logical data type whose offsets are represented as [`i64`].
     LargeList(Box<Field>),
-    /// A nested [`DataType`] with a given number of [`Field`]s.
+    /// A nested [`ArrowDataType`] with a given number of [`Field`]s.
     Struct(Vec<Field>),
     /// A nested datatype that can represent slots of differing types.
     /// Third argument represents mode
@@ -147,7 +147,7 @@ pub enum DataType {
     /// arrays or a limited set of primitive types as integers.
     ///
     /// The `bool` value indicates the `Dictionary` is sorted if set to `true`.
-    Dictionary(IntegerType, Box<DataType>, bool),
+    Dictionary(IntegerType, Box<ArrowDataType>, bool),
     /// Decimal value with precision and scale
     /// precision is the number of digits in the number and
     /// scale is the number of decimal places.
@@ -156,70 +156,74 @@ pub enum DataType {
     /// Decimal backed by 256 bits
     Decimal256(usize, usize),
     /// Extension type.
-    Extension(String, Box<DataType>, Option<String>),
+    Extension(String, Box<ArrowDataType>, Option<String>),
 }
 
 #[cfg(feature = "arrow_rs")]
-impl From<DataType> for arrow_schema::DataType {
-    fn from(value: DataType) -> Self {
+impl From<ArrowDataType> for arrow_schema::DataType {
+    fn from(value: ArrowDataType) -> Self {
         use arrow_schema::{Field as ArrowField, UnionFields};
 
         match value {
-            DataType::Null => Self::Null,
-            DataType::Boolean => Self::Boolean,
-            DataType::Int8 => Self::Int8,
-            DataType::Int16 => Self::Int16,
-            DataType::Int32 => Self::Int32,
-            DataType::Int64 => Self::Int64,
-            DataType::UInt8 => Self::UInt8,
-            DataType::UInt16 => Self::UInt16,
-            DataType::UInt32 => Self::UInt32,
-            DataType::UInt64 => Self::UInt64,
-            DataType::Float16 => Self::Float16,
-            DataType::Float32 => Self::Float32,
-            DataType::Float64 => Self::Float64,
-            DataType::Timestamp(unit, tz) => Self::Timestamp(unit.into(), tz.map(Into::into)),
-            DataType::Date32 => Self::Date32,
-            DataType::Date64 => Self::Date64,
-            DataType::Time32(unit) => Self::Time32(unit.into()),
-            DataType::Time64(unit) => Self::Time64(unit.into()),
-            DataType::Duration(unit) => Self::Duration(unit.into()),
-            DataType::Interval(unit) => Self::Interval(unit.into()),
-            DataType::Binary => Self::Binary,
-            DataType::FixedSizeBinary(size) => Self::FixedSizeBinary(size as _),
-            DataType::LargeBinary => Self::LargeBinary,
-            DataType::Utf8 => Self::Utf8,
-            DataType::LargeUtf8 => Self::LargeUtf8,
-            DataType::List(f) => Self::List(Arc::new((*f).into())),
-            DataType::FixedSizeList(f, size) => {
+            ArrowDataType::Null => Self::Null,
+            ArrowDataType::Boolean => Self::Boolean,
+            ArrowDataType::Int8 => Self::Int8,
+            ArrowDataType::Int16 => Self::Int16,
+            ArrowDataType::Int32 => Self::Int32,
+            ArrowDataType::Int64 => Self::Int64,
+            ArrowDataType::UInt8 => Self::UInt8,
+            ArrowDataType::UInt16 => Self::UInt16,
+            ArrowDataType::UInt32 => Self::UInt32,
+            ArrowDataType::UInt64 => Self::UInt64,
+            ArrowDataType::Float16 => Self::Float16,
+            ArrowDataType::Float32 => Self::Float32,
+            ArrowDataType::Float64 => Self::Float64,
+            ArrowDataType::Timestamp(unit, tz) => Self::Timestamp(unit.into(), tz.map(Into::into)),
+            ArrowDataType::Date32 => Self::Date32,
+            ArrowDataType::Date64 => Self::Date64,
+            ArrowDataType::Time32(unit) => Self::Time32(unit.into()),
+            ArrowDataType::Time64(unit) => Self::Time64(unit.into()),
+            ArrowDataType::Duration(unit) => Self::Duration(unit.into()),
+            ArrowDataType::Interval(unit) => Self::Interval(unit.into()),
+            ArrowDataType::Binary => Self::Binary,
+            ArrowDataType::FixedSizeBinary(size) => Self::FixedSizeBinary(size as _),
+            ArrowDataType::LargeBinary => Self::LargeBinary,
+            ArrowDataType::Utf8 => Self::Utf8,
+            ArrowDataType::LargeUtf8 => Self::LargeUtf8,
+            ArrowDataType::List(f) => Self::List(Arc::new((*f).into())),
+            ArrowDataType::FixedSizeList(f, size) => {
                 Self::FixedSizeList(Arc::new((*f).into()), size as _)
             },
-            DataType::LargeList(f) => Self::LargeList(Arc::new((*f).into())),
-            DataType::Struct(f) => Self::Struct(f.into_iter().map(ArrowField::from).collect()),
-            DataType::Union(fields, Some(ids), mode) => {
+            ArrowDataType::LargeList(f) => Self::LargeList(Arc::new((*f).into())),
+            ArrowDataType::Struct(f) => Self::Struct(f.into_iter().map(ArrowField::from).collect()),
+            ArrowDataType::Union(fields, Some(ids), mode) => {
                 let ids = ids.into_iter().map(|x| x as _);
                 let fields = fields.into_iter().map(ArrowField::from);
                 Self::Union(UnionFields::new(ids, fields), mode.into())
             },
-            DataType::Union(fields, None, mode) => {
+            ArrowDataType::Union(fields, None, mode) => {
                 let ids = 0..fields.len() as i8;
                 let fields = fields.into_iter().map(ArrowField::from);
                 Self::Union(UnionFields::new(ids, fields), mode.into())
             },
-            DataType::Map(f, ordered) => Self::Map(Arc::new((*f).into()), ordered),
-            DataType::Dictionary(key, value, _) => Self::Dictionary(
-                Box::new(DataType::from(key).into()),
+            ArrowDataType::Map(f, ordered) => Self::Map(Arc::new((*f).into()), ordered),
+            ArrowDataType::Dictionary(key, value, _) => Self::Dictionary(
+                Box::new(ArrowDataType::from(key).into()),
                 Box::new((*value).into()),
             ),
-            DataType::Decimal(precision, scale) => Self::Decimal128(precision as _, scale as _),
-            DataType::Decimal256(precision, scale) => Self::Decimal256(precision as _, scale as _),
-            DataType::Extension(_, d, _) => (*d).into(),
+            ArrowDataType::Decimal(precision, scale) => {
+                Self::Decimal128(precision as _, scale as _)
+            },
+            ArrowDataType::Decimal256(precision, scale) => {
+                Self::Decimal256(precision as _, scale as _)
+            },
+            ArrowDataType::Extension(_, d, _) => (*d).into(),
         }
     }
 }
 
 #[cfg(feature = "arrow_rs")]
-impl From<arrow_schema::DataType> for DataType {
+impl From<arrow_schema::DataType> for ArrowDataType {
     fn from(value: arrow_schema::DataType) -> Self {
         use arrow_schema::DataType;
         match value {
@@ -283,7 +287,7 @@ impl From<arrow_schema::DataType> for DataType {
     }
 }
 
-/// Mode of [`DataType::Union`]
+/// Mode of [`ArrowDataType::Union`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde_types", derive(Serialize, Deserialize))]
 pub enum UnionMode {
@@ -408,10 +412,10 @@ impl From<arrow_schema::IntervalUnit> for IntervalUnit {
     }
 }
 
-impl DataType {
-    /// the [`PhysicalType`] of this [`DataType`].
+impl ArrowDataType {
+    /// the [`PhysicalType`] of this [`ArrowDataType`].
     pub fn to_physical_type(&self) -> PhysicalType {
-        use DataType::*;
+        use ArrowDataType::*;
         match self {
             Null => PhysicalType::Null,
             Boolean => PhysicalType::Boolean,
@@ -452,11 +456,11 @@ impl DataType {
         }
     }
 
-    /// Returns `&self` for all but [`DataType::Extension`]. For [`DataType::Extension`],
-    /// (recursively) returns the inner [`DataType`].
-    /// Never returns the variant [`DataType::Extension`].
-    pub fn to_logical_type(&self) -> &DataType {
-        use DataType::*;
+    /// Returns `&self` for all but [`ArrowDataType::Extension`]. For [`ArrowDataType::Extension`],
+    /// (recursively) returns the inner [`ArrowDataType`].
+    /// Never returns the variant [`ArrowDataType::Extension`].
+    pub fn to_logical_type(&self) -> &ArrowDataType {
+        use ArrowDataType::*;
         match self {
             Extension(_, key, _) => key.to_logical_type(),
             _ => self,
@@ -464,39 +468,39 @@ impl DataType {
     }
 }
 
-impl From<IntegerType> for DataType {
+impl From<IntegerType> for ArrowDataType {
     fn from(item: IntegerType) -> Self {
         match item {
-            IntegerType::Int8 => DataType::Int8,
-            IntegerType::Int16 => DataType::Int16,
-            IntegerType::Int32 => DataType::Int32,
-            IntegerType::Int64 => DataType::Int64,
-            IntegerType::UInt8 => DataType::UInt8,
-            IntegerType::UInt16 => DataType::UInt16,
-            IntegerType::UInt32 => DataType::UInt32,
-            IntegerType::UInt64 => DataType::UInt64,
+            IntegerType::Int8 => ArrowDataType::Int8,
+            IntegerType::Int16 => ArrowDataType::Int16,
+            IntegerType::Int32 => ArrowDataType::Int32,
+            IntegerType::Int64 => ArrowDataType::Int64,
+            IntegerType::UInt8 => ArrowDataType::UInt8,
+            IntegerType::UInt16 => ArrowDataType::UInt16,
+            IntegerType::UInt32 => ArrowDataType::UInt32,
+            IntegerType::UInt64 => ArrowDataType::UInt64,
         }
     }
 }
 
-impl From<PrimitiveType> for DataType {
+impl From<PrimitiveType> for ArrowDataType {
     fn from(item: PrimitiveType) -> Self {
         match item {
-            PrimitiveType::Int8 => DataType::Int8,
-            PrimitiveType::Int16 => DataType::Int16,
-            PrimitiveType::Int32 => DataType::Int32,
-            PrimitiveType::Int64 => DataType::Int64,
-            PrimitiveType::UInt8 => DataType::UInt8,
-            PrimitiveType::UInt16 => DataType::UInt16,
-            PrimitiveType::UInt32 => DataType::UInt32,
-            PrimitiveType::UInt64 => DataType::UInt64,
-            PrimitiveType::Int128 => DataType::Decimal(32, 32),
-            PrimitiveType::Int256 => DataType::Decimal256(32, 32),
-            PrimitiveType::Float16 => DataType::Float16,
-            PrimitiveType::Float32 => DataType::Float32,
-            PrimitiveType::Float64 => DataType::Float64,
-            PrimitiveType::DaysMs => DataType::Interval(IntervalUnit::DayTime),
-            PrimitiveType::MonthDayNano => DataType::Interval(IntervalUnit::MonthDayNano),
+            PrimitiveType::Int8 => ArrowDataType::Int8,
+            PrimitiveType::Int16 => ArrowDataType::Int16,
+            PrimitiveType::Int32 => ArrowDataType::Int32,
+            PrimitiveType::Int64 => ArrowDataType::Int64,
+            PrimitiveType::UInt8 => ArrowDataType::UInt8,
+            PrimitiveType::UInt16 => ArrowDataType::UInt16,
+            PrimitiveType::UInt32 => ArrowDataType::UInt32,
+            PrimitiveType::UInt64 => ArrowDataType::UInt64,
+            PrimitiveType::Int128 => ArrowDataType::Decimal(32, 32),
+            PrimitiveType::Int256 => ArrowDataType::Decimal256(32, 32),
+            PrimitiveType::Float16 => ArrowDataType::Float16,
+            PrimitiveType::Float32 => ArrowDataType::Float32,
+            PrimitiveType::Float64 => ArrowDataType::Float64,
+            PrimitiveType::DaysMs => ArrowDataType::Interval(IntervalUnit::DayTime),
+            PrimitiveType::MonthDayNano => ArrowDataType::Interval(IntervalUnit::MonthDayNano),
         }
     }
 }

--- a/crates/polars-arrow/src/datatypes/physical_type.rs
+++ b/crates/polars-arrow/src/datatypes/physical_type.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 pub use crate::types::PrimitiveType;
 
 /// The set of physical types: unique in-memory representations of an Arrow array.
-/// A physical type has a one-to-many relationship with a [`crate::datatypes::DataType`] and
+/// A physical type has a one-to-many relationship with a [`crate::datatypes::ArrowDataType`] and
 /// a one-to-one mapping to each struct in this crate that implements [`crate::array::Array`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde_types", derive(Serialize, Deserialize))]

--- a/crates/polars-arrow/src/ffi/mmap.rs
+++ b/crates/polars-arrow/src/ffi/mmap.rs
@@ -5,7 +5,7 @@ use polars_error::{polars_bail, PolarsResult};
 
 use super::{ArrowArray, InternalArrowArray};
 use crate::array::{BooleanArray, FromFfi, PrimitiveArray};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::types::NativeType;
 
 #[allow(dead_code)]
@@ -171,7 +171,7 @@ pub unsafe fn bitmap(data: &[u8], offset: usize, length: usize) -> PolarsResult<
         None,
         Some(offset),
     );
-    let array = InternalArrowArray::new(array, DataType::Boolean);
+    let array = InternalArrowArray::new(array, ArrowDataType::Boolean);
 
     // safety: we just created a valid array
     Ok(unsafe { BooleanArray::try_from_ffi(array) }.unwrap())

--- a/crates/polars-arrow/src/ffi/mod.rs
+++ b/crates/polars-arrow/src/ffi/mod.rs
@@ -14,7 +14,7 @@ pub use stream::{export_iterator, ArrowArrayStreamReader};
 
 use self::schema::to_field;
 use crate::array::Array;
-use crate::datatypes::{DataType, Field};
+use crate::datatypes::{ArrowDataType, Field};
 
 /// Exports an [`Box<dyn Array>`] to the C data interface.
 pub fn export_array_to_c(array: Box<dyn Array>) -> ArrowArray {
@@ -40,7 +40,7 @@ pub unsafe fn import_field_from_c(field: &ArrowSchema) -> PolarsResult<Field> {
 /// being valid according to the [C data interface](https://arrow.apache.org/docs/format/CDataInterface.html) (FFI).
 pub unsafe fn import_array_from_c(
     array: ArrowArray,
-    data_type: DataType,
+    data_type: ArrowDataType,
 ) -> PolarsResult<Box<dyn Array>> {
     try_from(InternalArrowArray::new(array, data_type))
 }

--- a/crates/polars-arrow/src/ffi/schema.rs
+++ b/crates/polars-arrow/src/ffi/schema.rs
@@ -7,7 +7,7 @@ use polars_error::{polars_bail, polars_err, PolarsResult};
 
 use super::ArrowSchema;
 use crate::datatypes::{
-    DataType, Extension, Field, IntegerType, IntervalUnit, Metadata, TimeUnit, UnionMode,
+    ArrowDataType, Extension, Field, IntegerType, IntervalUnit, Metadata, TimeUnit, UnionMode,
 };
 
 #[allow(dead_code)]
@@ -39,20 +39,22 @@ unsafe extern "C" fn c_release_schema(schema: *mut ArrowSchema) {
 }
 
 /// allocate (and hold) the children
-fn schema_children(data_type: &DataType, flags: &mut i64) -> Box<[*mut ArrowSchema]> {
+fn schema_children(data_type: &ArrowDataType, flags: &mut i64) -> Box<[*mut ArrowSchema]> {
     match data_type {
-        DataType::List(field) | DataType::FixedSizeList(field, _) | DataType::LargeList(field) => {
+        ArrowDataType::List(field)
+        | ArrowDataType::FixedSizeList(field, _)
+        | ArrowDataType::LargeList(field) => {
             Box::new([Box::into_raw(Box::new(ArrowSchema::new(field.as_ref())))])
         },
-        DataType::Map(field, is_sorted) => {
+        ArrowDataType::Map(field, is_sorted) => {
             *flags += (*is_sorted as i64) * 4;
             Box::new([Box::into_raw(Box::new(ArrowSchema::new(field.as_ref())))])
         },
-        DataType::Struct(fields) | DataType::Union(fields, _, _) => fields
+        ArrowDataType::Struct(fields) | ArrowDataType::Union(fields, _, _) => fields
             .iter()
             .map(|field| Box::into_raw(Box::new(ArrowSchema::new(field))))
             .collect::<Box<[_]>>(),
-        DataType::Extension(_, inner, _) => schema_children(inner, flags),
+        ArrowDataType::Extension(_, inner, _) => schema_children(inner, flags),
         _ => Box::new([]),
     }
 }
@@ -69,7 +71,8 @@ impl ArrowSchema {
         let children_ptr = schema_children(field.data_type(), &mut flags);
         let n_children = children_ptr.len() as i64;
 
-        let dictionary = if let DataType::Dictionary(_, values, is_ordered) = field.data_type() {
+        let dictionary = if let ArrowDataType::Dictionary(_, values, is_ordered) = field.data_type()
+        {
             flags += *is_ordered as i64;
             // we do not store field info in the dict values, so can't recover it all :(
             let field = Field::new("", values.as_ref().clone(), true);
@@ -80,26 +83,27 @@ impl ArrowSchema {
 
         let metadata = &field.metadata;
 
-        let metadata = if let DataType::Extension(name, _, extension_metadata) = field.data_type() {
-            // append extension information.
-            let mut metadata = metadata.clone();
+        let metadata =
+            if let ArrowDataType::Extension(name, _, extension_metadata) = field.data_type() {
+                // append extension information.
+                let mut metadata = metadata.clone();
 
-            // metadata
-            if let Some(extension_metadata) = extension_metadata {
-                metadata.insert(
-                    "ARROW:extension:metadata".to_string(),
-                    extension_metadata.clone(),
-                );
-            }
+                // metadata
+                if let Some(extension_metadata) = extension_metadata {
+                    metadata.insert(
+                        "ARROW:extension:metadata".to_string(),
+                        extension_metadata.clone(),
+                    );
+                }
 
-            metadata.insert("ARROW:extension:name".to_string(), name.clone());
+                metadata.insert("ARROW:extension:name".to_string(), name.clone());
 
-            Some(metadata_to_bytes(&metadata))
-        } else if !metadata.is_empty() {
-            Some(metadata_to_bytes(metadata))
-        } else {
-            None
-        };
+                Some(metadata_to_bytes(&metadata))
+            } else if !metadata.is_empty() {
+                Some(metadata_to_bytes(metadata))
+            } else {
+                None
+            };
 
         let name = CString::new(name).unwrap();
         let format = CString::new(format).unwrap();
@@ -201,14 +205,14 @@ pub(crate) unsafe fn to_field(schema: &ArrowSchema) -> PolarsResult<Field> {
         let indices = to_integer_type(schema.format())?;
         let values = to_field(dictionary)?;
         let is_ordered = schema.flags & 1 == 1;
-        DataType::Dictionary(indices, Box::new(values.data_type().clone()), is_ordered)
+        ArrowDataType::Dictionary(indices, Box::new(values.data_type().clone()), is_ordered)
     } else {
         to_data_type(schema)?
     };
     let (metadata, extension) = unsafe { metadata_from_bytes(schema.metadata) };
 
     let data_type = if let Some((name, extension_metadata)) = extension {
-        DataType::Extension(name, Box::new(data_type), extension_metadata)
+        ArrowDataType::Extension(name, Box::new(data_type), extension_metadata)
     } else {
         data_type
     };
@@ -236,77 +240,81 @@ fn to_integer_type(format: &str) -> PolarsResult<IntegerType> {
     })
 }
 
-unsafe fn to_data_type(schema: &ArrowSchema) -> PolarsResult<DataType> {
+unsafe fn to_data_type(schema: &ArrowSchema) -> PolarsResult<ArrowDataType> {
     Ok(match schema.format() {
-        "n" => DataType::Null,
-        "b" => DataType::Boolean,
-        "c" => DataType::Int8,
-        "C" => DataType::UInt8,
-        "s" => DataType::Int16,
-        "S" => DataType::UInt16,
-        "i" => DataType::Int32,
-        "I" => DataType::UInt32,
-        "l" => DataType::Int64,
-        "L" => DataType::UInt64,
-        "e" => DataType::Float16,
-        "f" => DataType::Float32,
-        "g" => DataType::Float64,
-        "z" => DataType::Binary,
-        "Z" => DataType::LargeBinary,
-        "u" => DataType::Utf8,
-        "U" => DataType::LargeUtf8,
-        "tdD" => DataType::Date32,
-        "tdm" => DataType::Date64,
-        "tts" => DataType::Time32(TimeUnit::Second),
-        "ttm" => DataType::Time32(TimeUnit::Millisecond),
-        "ttu" => DataType::Time64(TimeUnit::Microsecond),
-        "ttn" => DataType::Time64(TimeUnit::Nanosecond),
-        "tDs" => DataType::Duration(TimeUnit::Second),
-        "tDm" => DataType::Duration(TimeUnit::Millisecond),
-        "tDu" => DataType::Duration(TimeUnit::Microsecond),
-        "tDn" => DataType::Duration(TimeUnit::Nanosecond),
-        "tiM" => DataType::Interval(IntervalUnit::YearMonth),
-        "tiD" => DataType::Interval(IntervalUnit::DayTime),
+        "n" => ArrowDataType::Null,
+        "b" => ArrowDataType::Boolean,
+        "c" => ArrowDataType::Int8,
+        "C" => ArrowDataType::UInt8,
+        "s" => ArrowDataType::Int16,
+        "S" => ArrowDataType::UInt16,
+        "i" => ArrowDataType::Int32,
+        "I" => ArrowDataType::UInt32,
+        "l" => ArrowDataType::Int64,
+        "L" => ArrowDataType::UInt64,
+        "e" => ArrowDataType::Float16,
+        "f" => ArrowDataType::Float32,
+        "g" => ArrowDataType::Float64,
+        "z" => ArrowDataType::Binary,
+        "Z" => ArrowDataType::LargeBinary,
+        "u" => ArrowDataType::Utf8,
+        "U" => ArrowDataType::LargeUtf8,
+        "tdD" => ArrowDataType::Date32,
+        "tdm" => ArrowDataType::Date64,
+        "tts" => ArrowDataType::Time32(TimeUnit::Second),
+        "ttm" => ArrowDataType::Time32(TimeUnit::Millisecond),
+        "ttu" => ArrowDataType::Time64(TimeUnit::Microsecond),
+        "ttn" => ArrowDataType::Time64(TimeUnit::Nanosecond),
+        "tDs" => ArrowDataType::Duration(TimeUnit::Second),
+        "tDm" => ArrowDataType::Duration(TimeUnit::Millisecond),
+        "tDu" => ArrowDataType::Duration(TimeUnit::Microsecond),
+        "tDn" => ArrowDataType::Duration(TimeUnit::Nanosecond),
+        "tiM" => ArrowDataType::Interval(IntervalUnit::YearMonth),
+        "tiD" => ArrowDataType::Interval(IntervalUnit::DayTime),
         "+l" => {
             let child = schema.child(0);
-            DataType::List(Box::new(to_field(child)?))
+            ArrowDataType::List(Box::new(to_field(child)?))
         },
         "+L" => {
             let child = schema.child(0);
-            DataType::LargeList(Box::new(to_field(child)?))
+            ArrowDataType::LargeList(Box::new(to_field(child)?))
         },
         "+m" => {
             let child = schema.child(0);
 
             let is_sorted = (schema.flags & 4) != 0;
-            DataType::Map(Box::new(to_field(child)?), is_sorted)
+            ArrowDataType::Map(Box::new(to_field(child)?), is_sorted)
         },
         "+s" => {
             let children = (0..schema.n_children as usize)
                 .map(|x| to_field(schema.child(x)))
                 .collect::<PolarsResult<Vec<_>>>()?;
-            DataType::Struct(children)
+            ArrowDataType::Struct(children)
         },
         other => {
             match other.splitn(2, ':').collect::<Vec<_>>()[..] {
                 // Timestamps with no timezone
-                ["tss", ""] => DataType::Timestamp(TimeUnit::Second, None),
-                ["tsm", ""] => DataType::Timestamp(TimeUnit::Millisecond, None),
-                ["tsu", ""] => DataType::Timestamp(TimeUnit::Microsecond, None),
-                ["tsn", ""] => DataType::Timestamp(TimeUnit::Nanosecond, None),
+                ["tss", ""] => ArrowDataType::Timestamp(TimeUnit::Second, None),
+                ["tsm", ""] => ArrowDataType::Timestamp(TimeUnit::Millisecond, None),
+                ["tsu", ""] => ArrowDataType::Timestamp(TimeUnit::Microsecond, None),
+                ["tsn", ""] => ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
 
                 // Timestamps with timezone
-                ["tss", tz] => DataType::Timestamp(TimeUnit::Second, Some(tz.to_string())),
-                ["tsm", tz] => DataType::Timestamp(TimeUnit::Millisecond, Some(tz.to_string())),
-                ["tsu", tz] => DataType::Timestamp(TimeUnit::Microsecond, Some(tz.to_string())),
-                ["tsn", tz] => DataType::Timestamp(TimeUnit::Nanosecond, Some(tz.to_string())),
+                ["tss", tz] => ArrowDataType::Timestamp(TimeUnit::Second, Some(tz.to_string())),
+                ["tsm", tz] => {
+                    ArrowDataType::Timestamp(TimeUnit::Millisecond, Some(tz.to_string()))
+                },
+                ["tsu", tz] => {
+                    ArrowDataType::Timestamp(TimeUnit::Microsecond, Some(tz.to_string()))
+                },
+                ["tsn", tz] => ArrowDataType::Timestamp(TimeUnit::Nanosecond, Some(tz.to_string())),
 
                 ["w", size_raw] => {
                     // Example: "w:42" fixed-width binary [42 bytes]
                     let size = size_raw
                         .parse::<usize>()
                         .map_err(|_| polars_err!(ComputeError: "size is not a valid integer"))?;
-                    DataType::FixedSizeBinary(size)
+                    ArrowDataType::FixedSizeBinary(size)
                 },
                 ["+w", size_raw] => {
                     // Example: "+w:123" fixed-sized list [123 items]
@@ -314,7 +322,7 @@ unsafe fn to_data_type(schema: &ArrowSchema) -> PolarsResult<DataType> {
                         .parse::<usize>()
                         .map_err(|_| polars_err!(ComputeError: "size is not a valid integer"))?;
                     let child = to_field(schema.child(0))?;
-                    DataType::FixedSizeList(Box::new(child), size)
+                    ArrowDataType::FixedSizeList(Box::new(child), size)
                 },
                 ["d", raw] => {
                     // Decimal
@@ -330,7 +338,7 @@ unsafe fn to_data_type(schema: &ArrowSchema) -> PolarsResult<DataType> {
                                 polars_err!(ComputeError: "Decimal bit width is not a valid integer")
                             })?;
                             if bit_width == 256 {
-                                return Ok(DataType::Decimal256(
+                                return Ok(ArrowDataType::Decimal256(
                                     precision_raw.parse::<usize>().map_err(|_| {
                                         polars_err!(ComputeError: "Decimal precision is not a valid integer")
                                     })?,
@@ -348,7 +356,7 @@ unsafe fn to_data_type(schema: &ArrowSchema) -> PolarsResult<DataType> {
                         },
                     };
 
-                    DataType::Decimal(
+                    ArrowDataType::Decimal(
                         precision.parse::<usize>().map_err(|_| {
                             polars_err!(ComputeError:
                             "Decimal precision is not a valid integer"
@@ -379,7 +387,7 @@ unsafe fn to_data_type(schema: &ArrowSchema) -> PolarsResult<DataType> {
                     let fields = (0..schema.n_children as usize)
                         .map(|x| to_field(schema.child(x)))
                         .collect::<PolarsResult<Vec<_>>>()?;
-                    DataType::Union(fields, Some(type_ids), mode)
+                    ArrowDataType::Union(fields, Some(type_ids), mode)
                 },
                 _ => {
                     polars_bail!(ComputeError:
@@ -392,47 +400,47 @@ unsafe fn to_data_type(schema: &ArrowSchema) -> PolarsResult<DataType> {
 }
 
 /// the inverse of [to_field]
-fn to_format(data_type: &DataType) -> String {
+fn to_format(data_type: &ArrowDataType) -> String {
     match data_type {
-        DataType::Null => "n".to_string(),
-        DataType::Boolean => "b".to_string(),
-        DataType::Int8 => "c".to_string(),
-        DataType::UInt8 => "C".to_string(),
-        DataType::Int16 => "s".to_string(),
-        DataType::UInt16 => "S".to_string(),
-        DataType::Int32 => "i".to_string(),
-        DataType::UInt32 => "I".to_string(),
-        DataType::Int64 => "l".to_string(),
-        DataType::UInt64 => "L".to_string(),
-        DataType::Float16 => "e".to_string(),
-        DataType::Float32 => "f".to_string(),
-        DataType::Float64 => "g".to_string(),
-        DataType::Binary => "z".to_string(),
-        DataType::LargeBinary => "Z".to_string(),
-        DataType::Utf8 => "u".to_string(),
-        DataType::LargeUtf8 => "U".to_string(),
-        DataType::Date32 => "tdD".to_string(),
-        DataType::Date64 => "tdm".to_string(),
-        DataType::Time32(TimeUnit::Second) => "tts".to_string(),
-        DataType::Time32(TimeUnit::Millisecond) => "ttm".to_string(),
-        DataType::Time32(_) => {
+        ArrowDataType::Null => "n".to_string(),
+        ArrowDataType::Boolean => "b".to_string(),
+        ArrowDataType::Int8 => "c".to_string(),
+        ArrowDataType::UInt8 => "C".to_string(),
+        ArrowDataType::Int16 => "s".to_string(),
+        ArrowDataType::UInt16 => "S".to_string(),
+        ArrowDataType::Int32 => "i".to_string(),
+        ArrowDataType::UInt32 => "I".to_string(),
+        ArrowDataType::Int64 => "l".to_string(),
+        ArrowDataType::UInt64 => "L".to_string(),
+        ArrowDataType::Float16 => "e".to_string(),
+        ArrowDataType::Float32 => "f".to_string(),
+        ArrowDataType::Float64 => "g".to_string(),
+        ArrowDataType::Binary => "z".to_string(),
+        ArrowDataType::LargeBinary => "Z".to_string(),
+        ArrowDataType::Utf8 => "u".to_string(),
+        ArrowDataType::LargeUtf8 => "U".to_string(),
+        ArrowDataType::Date32 => "tdD".to_string(),
+        ArrowDataType::Date64 => "tdm".to_string(),
+        ArrowDataType::Time32(TimeUnit::Second) => "tts".to_string(),
+        ArrowDataType::Time32(TimeUnit::Millisecond) => "ttm".to_string(),
+        ArrowDataType::Time32(_) => {
             unreachable!("Time32 is only supported for seconds and milliseconds")
         },
-        DataType::Time64(TimeUnit::Microsecond) => "ttu".to_string(),
-        DataType::Time64(TimeUnit::Nanosecond) => "ttn".to_string(),
-        DataType::Time64(_) => {
+        ArrowDataType::Time64(TimeUnit::Microsecond) => "ttu".to_string(),
+        ArrowDataType::Time64(TimeUnit::Nanosecond) => "ttn".to_string(),
+        ArrowDataType::Time64(_) => {
             unreachable!("Time64 is only supported for micro and nanoseconds")
         },
-        DataType::Duration(TimeUnit::Second) => "tDs".to_string(),
-        DataType::Duration(TimeUnit::Millisecond) => "tDm".to_string(),
-        DataType::Duration(TimeUnit::Microsecond) => "tDu".to_string(),
-        DataType::Duration(TimeUnit::Nanosecond) => "tDn".to_string(),
-        DataType::Interval(IntervalUnit::YearMonth) => "tiM".to_string(),
-        DataType::Interval(IntervalUnit::DayTime) => "tiD".to_string(),
-        DataType::Interval(IntervalUnit::MonthDayNano) => {
+        ArrowDataType::Duration(TimeUnit::Second) => "tDs".to_string(),
+        ArrowDataType::Duration(TimeUnit::Millisecond) => "tDm".to_string(),
+        ArrowDataType::Duration(TimeUnit::Microsecond) => "tDu".to_string(),
+        ArrowDataType::Duration(TimeUnit::Nanosecond) => "tDn".to_string(),
+        ArrowDataType::Interval(IntervalUnit::YearMonth) => "tiM".to_string(),
+        ArrowDataType::Interval(IntervalUnit::DayTime) => "tiD".to_string(),
+        ArrowDataType::Interval(IntervalUnit::MonthDayNano) => {
             todo!("Spec for FFI for MonthDayNano still not defined.")
         },
-        DataType::Timestamp(unit, tz) => {
+        ArrowDataType::Timestamp(unit, tz) => {
             let unit = match unit {
                 TimeUnit::Second => "s",
                 TimeUnit::Millisecond => "m",
@@ -445,14 +453,14 @@ fn to_format(data_type: &DataType) -> String {
                 tz.as_ref().map(|x| x.as_ref()).unwrap_or("")
             )
         },
-        DataType::Decimal(precision, scale) => format!("d:{precision},{scale}"),
-        DataType::Decimal256(precision, scale) => format!("d:{precision},{scale},256"),
-        DataType::List(_) => "+l".to_string(),
-        DataType::LargeList(_) => "+L".to_string(),
-        DataType::Struct(_) => "+s".to_string(),
-        DataType::FixedSizeBinary(size) => format!("w:{size}"),
-        DataType::FixedSizeList(_, size) => format!("+w:{size}"),
-        DataType::Union(f, ids, mode) => {
+        ArrowDataType::Decimal(precision, scale) => format!("d:{precision},{scale}"),
+        ArrowDataType::Decimal256(precision, scale) => format!("d:{precision},{scale},256"),
+        ArrowDataType::List(_) => "+l".to_string(),
+        ArrowDataType::LargeList(_) => "+L".to_string(),
+        ArrowDataType::Struct(_) => "+s".to_string(),
+        ArrowDataType::FixedSizeBinary(size) => format!("w:{size}"),
+        ArrowDataType::FixedSizeList(_, size) => format!("+w:{size}"),
+        ArrowDataType::Union(f, ids, mode) => {
             let sparsness = if mode.is_sparse() { 's' } else { 'd' };
             let mut r = format!("+u{sparsness}:");
             let ids = if let Some(ids) = ids {
@@ -465,21 +473,21 @@ fn to_format(data_type: &DataType) -> String {
             r.push_str(ids);
             r
         },
-        DataType::Map(_, _) => "+m".to_string(),
-        DataType::Dictionary(index, _, _) => to_format(&(*index).into()),
-        DataType::Extension(_, inner, _) => to_format(inner.as_ref()),
+        ArrowDataType::Map(_, _) => "+m".to_string(),
+        ArrowDataType::Dictionary(index, _, _) => to_format(&(*index).into()),
+        ArrowDataType::Extension(_, inner, _) => to_format(inner.as_ref()),
     }
 }
 
-pub(super) fn get_child(data_type: &DataType, index: usize) -> PolarsResult<DataType> {
+pub(super) fn get_child(data_type: &ArrowDataType, index: usize) -> PolarsResult<ArrowDataType> {
     match (index, data_type) {
-        (0, DataType::List(field)) => Ok(field.data_type().clone()),
-        (0, DataType::FixedSizeList(field, _)) => Ok(field.data_type().clone()),
-        (0, DataType::LargeList(field)) => Ok(field.data_type().clone()),
-        (0, DataType::Map(field, _)) => Ok(field.data_type().clone()),
-        (index, DataType::Struct(fields)) => Ok(fields[index].data_type().clone()),
-        (index, DataType::Union(fields, _, _)) => Ok(fields[index].data_type().clone()),
-        (index, DataType::Extension(_, subtype, _)) => get_child(subtype, index),
+        (0, ArrowDataType::List(field)) => Ok(field.data_type().clone()),
+        (0, ArrowDataType::FixedSizeList(field, _)) => Ok(field.data_type().clone()),
+        (0, ArrowDataType::LargeList(field)) => Ok(field.data_type().clone()),
+        (0, ArrowDataType::Map(field, _)) => Ok(field.data_type().clone()),
+        (index, ArrowDataType::Struct(fields)) => Ok(fields[index].data_type().clone()),
+        (index, ArrowDataType::Union(fields, _, _)) => Ok(fields[index].data_type().clone()),
+        (index, ArrowDataType::Extension(_, subtype, _)) => get_child(subtype, index),
         (child, data_type) => polars_bail!(ComputeError:
             "Requested child {child} to type {data_type:?} that has no such child",
         ),
@@ -550,60 +558,79 @@ mod tests {
     #[test]
     fn test_all() {
         let mut dts = vec![
-            DataType::Null,
-            DataType::Boolean,
-            DataType::UInt8,
-            DataType::UInt16,
-            DataType::UInt32,
-            DataType::UInt64,
-            DataType::Int8,
-            DataType::Int16,
-            DataType::Int32,
-            DataType::Int64,
-            DataType::Float32,
-            DataType::Float64,
-            DataType::Date32,
-            DataType::Date64,
-            DataType::Time32(TimeUnit::Second),
-            DataType::Time32(TimeUnit::Millisecond),
-            DataType::Time64(TimeUnit::Microsecond),
-            DataType::Time64(TimeUnit::Nanosecond),
-            DataType::Decimal(5, 5),
-            DataType::Utf8,
-            DataType::LargeUtf8,
-            DataType::Binary,
-            DataType::LargeBinary,
-            DataType::FixedSizeBinary(2),
-            DataType::List(Box::new(Field::new("example", DataType::Boolean, false))),
-            DataType::FixedSizeList(Box::new(Field::new("example", DataType::Boolean, false)), 2),
-            DataType::LargeList(Box::new(Field::new("example", DataType::Boolean, false))),
-            DataType::Struct(vec![
-                Field::new("a", DataType::Int64, true),
+            ArrowDataType::Null,
+            ArrowDataType::Boolean,
+            ArrowDataType::UInt8,
+            ArrowDataType::UInt16,
+            ArrowDataType::UInt32,
+            ArrowDataType::UInt64,
+            ArrowDataType::Int8,
+            ArrowDataType::Int16,
+            ArrowDataType::Int32,
+            ArrowDataType::Int64,
+            ArrowDataType::Float32,
+            ArrowDataType::Float64,
+            ArrowDataType::Date32,
+            ArrowDataType::Date64,
+            ArrowDataType::Time32(TimeUnit::Second),
+            ArrowDataType::Time32(TimeUnit::Millisecond),
+            ArrowDataType::Time64(TimeUnit::Microsecond),
+            ArrowDataType::Time64(TimeUnit::Nanosecond),
+            ArrowDataType::Decimal(5, 5),
+            ArrowDataType::Utf8,
+            ArrowDataType::LargeUtf8,
+            ArrowDataType::Binary,
+            ArrowDataType::LargeBinary,
+            ArrowDataType::FixedSizeBinary(2),
+            ArrowDataType::List(Box::new(Field::new(
+                "example",
+                ArrowDataType::Boolean,
+                false,
+            ))),
+            ArrowDataType::FixedSizeList(
+                Box::new(Field::new("example", ArrowDataType::Boolean, false)),
+                2,
+            ),
+            ArrowDataType::LargeList(Box::new(Field::new(
+                "example",
+                ArrowDataType::Boolean,
+                false,
+            ))),
+            ArrowDataType::Struct(vec![
+                Field::new("a", ArrowDataType::Int64, true),
                 Field::new(
                     "b",
-                    DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
+                    ArrowDataType::List(Box::new(Field::new("item", ArrowDataType::Int32, true))),
                     true,
                 ),
             ]),
-            DataType::Map(Box::new(Field::new("a", DataType::Int64, true)), true),
-            DataType::Union(
+            ArrowDataType::Map(Box::new(Field::new("a", ArrowDataType::Int64, true)), true),
+            ArrowDataType::Union(
                 vec![
-                    Field::new("a", DataType::Int64, true),
+                    Field::new("a", ArrowDataType::Int64, true),
                     Field::new(
                         "b",
-                        DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
+                        ArrowDataType::List(Box::new(Field::new(
+                            "item",
+                            ArrowDataType::Int32,
+                            true,
+                        ))),
                         true,
                     ),
                 ],
                 Some(vec![1, 2]),
                 UnionMode::Dense,
             ),
-            DataType::Union(
+            ArrowDataType::Union(
                 vec![
-                    Field::new("a", DataType::Int64, true),
+                    Field::new("a", ArrowDataType::Int64, true),
                     Field::new(
                         "b",
-                        DataType::List(Box::new(Field::new("item", DataType::Int32, true))),
+                        ArrowDataType::List(Box::new(Field::new(
+                            "item",
+                            ArrowDataType::Int32,
+                            true,
+                        ))),
                         true,
                     ),
                 ],
@@ -617,16 +644,19 @@ mod tests {
             TimeUnit::Microsecond,
             TimeUnit::Nanosecond,
         ] {
-            dts.push(DataType::Timestamp(time_unit, None));
-            dts.push(DataType::Timestamp(time_unit, Some("00:00".to_string())));
-            dts.push(DataType::Duration(time_unit));
+            dts.push(ArrowDataType::Timestamp(time_unit, None));
+            dts.push(ArrowDataType::Timestamp(
+                time_unit,
+                Some("00:00".to_string()),
+            ));
+            dts.push(ArrowDataType::Duration(time_unit));
         }
         for interval_type in [
             IntervalUnit::DayTime,
             IntervalUnit::YearMonth,
             //IntervalUnit::MonthDayNano, // not yet defined on the C data interface
         ] {
-            dts.push(DataType::Interval(interval_type));
+            dts.push(ArrowDataType::Interval(interval_type));
         }
 
         for expected in dts {

--- a/crates/polars-arrow/src/io/avro/read/nested.rs
+++ b/crates/polars-arrow/src/io/avro/read/nested.rs
@@ -8,14 +8,18 @@ use crate::offset::{Offset, Offsets};
 /// Auxiliary struct
 #[derive(Debug)]
 pub struct DynMutableListArray<O: Offset> {
-    data_type: DataType,
+    data_type: ArrowDataType,
     offsets: Offsets<O>,
     values: Box<dyn MutableArray>,
     validity: Option<MutableBitmap>,
 }
 
 impl<O: Offset> DynMutableListArray<O> {
-    pub fn new_from(values: Box<dyn MutableArray>, data_type: DataType, capacity: usize) -> Self {
+    pub fn new_from(
+        values: Box<dyn MutableArray>,
+        data_type: ArrowDataType,
+        capacity: usize,
+    ) -> Self {
         assert_eq!(values.len(), 0);
         ListArray::<O>::get_child_field(&data_type);
         Self {
@@ -94,7 +98,7 @@ impl<O: Offset> MutableArray for DynMutableListArray<O> {
         .arced()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 
@@ -122,7 +126,7 @@ impl<O: Offset> MutableArray for DynMutableListArray<O> {
 
 #[derive(Debug)]
 pub struct FixedItemsUtf8Dictionary {
-    data_type: DataType,
+    data_type: ArrowDataType,
     keys: MutablePrimitiveArray<i32>,
     values: Utf8Array<i32>,
 }
@@ -130,7 +134,7 @@ pub struct FixedItemsUtf8Dictionary {
 impl FixedItemsUtf8Dictionary {
     pub fn with_capacity(values: Utf8Array<i32>, capacity: usize) -> Self {
         Self {
-            data_type: DataType::Dictionary(
+            data_type: ArrowDataType::Dictionary(
                 IntegerType::Int32,
                 Box::new(values.data_type().clone()),
                 false,
@@ -181,7 +185,7 @@ impl MutableArray for FixedItemsUtf8Dictionary {
         )
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 
@@ -210,13 +214,13 @@ impl MutableArray for FixedItemsUtf8Dictionary {
 /// Auxiliary struct
 #[derive(Debug)]
 pub struct DynMutableStructArray {
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Vec<Box<dyn MutableArray>>,
     validity: Option<MutableBitmap>,
 }
 
 impl DynMutableStructArray {
-    pub fn new(values: Vec<Box<dyn MutableArray>>, data_type: DataType) -> Self {
+    pub fn new(values: Vec<Box<dyn MutableArray>>, data_type: ArrowDataType) -> Self {
         Self {
             data_type,
             values,
@@ -285,7 +289,7 @@ impl MutableArray for DynMutableStructArray {
         ))
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-arrow/src/io/avro/read/schema.rs
+++ b/crates/polars-arrow/src/io/avro/read/schema.rs
@@ -43,45 +43,49 @@ fn schema_to_field(
 ) -> PolarsResult<Field> {
     let mut nullable = false;
     let data_type = match schema {
-        AvroSchema::Null => DataType::Null,
-        AvroSchema::Boolean => DataType::Boolean,
+        AvroSchema::Null => ArrowDataType::Null,
+        AvroSchema::Boolean => ArrowDataType::Boolean,
         AvroSchema::Int(logical) => match logical {
             Some(logical) => match logical {
-                avro_schema::schema::IntLogical::Date => DataType::Date32,
-                avro_schema::schema::IntLogical::Time => DataType::Time32(TimeUnit::Millisecond),
+                avro_schema::schema::IntLogical::Date => ArrowDataType::Date32,
+                avro_schema::schema::IntLogical::Time => {
+                    ArrowDataType::Time32(TimeUnit::Millisecond)
+                },
             },
-            None => DataType::Int32,
+            None => ArrowDataType::Int32,
         },
         AvroSchema::Long(logical) => match logical {
             Some(logical) => match logical {
-                avro_schema::schema::LongLogical::Time => DataType::Time64(TimeUnit::Microsecond),
+                avro_schema::schema::LongLogical::Time => {
+                    ArrowDataType::Time64(TimeUnit::Microsecond)
+                },
                 avro_schema::schema::LongLogical::TimestampMillis => {
-                    DataType::Timestamp(TimeUnit::Millisecond, Some("00:00".to_string()))
+                    ArrowDataType::Timestamp(TimeUnit::Millisecond, Some("00:00".to_string()))
                 },
                 avro_schema::schema::LongLogical::TimestampMicros => {
-                    DataType::Timestamp(TimeUnit::Microsecond, Some("00:00".to_string()))
+                    ArrowDataType::Timestamp(TimeUnit::Microsecond, Some("00:00".to_string()))
                 },
                 avro_schema::schema::LongLogical::LocalTimestampMillis => {
-                    DataType::Timestamp(TimeUnit::Millisecond, None)
+                    ArrowDataType::Timestamp(TimeUnit::Millisecond, None)
                 },
                 avro_schema::schema::LongLogical::LocalTimestampMicros => {
-                    DataType::Timestamp(TimeUnit::Microsecond, None)
+                    ArrowDataType::Timestamp(TimeUnit::Microsecond, None)
                 },
             },
-            None => DataType::Int64,
+            None => ArrowDataType::Int64,
         },
-        AvroSchema::Float => DataType::Float32,
-        AvroSchema::Double => DataType::Float64,
+        AvroSchema::Float => ArrowDataType::Float32,
+        AvroSchema::Double => ArrowDataType::Float64,
         AvroSchema::Bytes(logical) => match logical {
             Some(logical) => match logical {
                 avro_schema::schema::BytesLogical::Decimal(precision, scale) => {
-                    DataType::Decimal(*precision, *scale)
+                    ArrowDataType::Decimal(*precision, *scale)
                 },
             },
-            None => DataType::Binary,
+            None => ArrowDataType::Binary,
         },
-        AvroSchema::String(_) => DataType::Utf8,
-        AvroSchema::Array(item_schema) => DataType::List(Box::new(schema_to_field(
+        AvroSchema::String(_) => ArrowDataType::Utf8,
+        AvroSchema::Array(item_schema) => ArrowDataType::List(Box::new(schema_to_field(
             item_schema,
             Some("item"), // default name for list items
             Metadata::default(),
@@ -105,7 +109,7 @@ fn schema_to_field(
                     .iter()
                     .map(|s| schema_to_field(s, None, Metadata::default()))
                     .collect::<PolarsResult<Vec<Field>>>()?;
-                DataType::Union(fields, None, UnionMode::Dense)
+                ArrowDataType::Union(fields, None, UnionMode::Dense)
             }
         },
         AvroSchema::Record(Record { fields, .. }) => {
@@ -119,25 +123,25 @@ fn schema_to_field(
                     schema_to_field(&field.schema, Some(&field.name), props)
                 })
                 .collect::<PolarsResult<_>>()?;
-            DataType::Struct(fields)
+            ArrowDataType::Struct(fields)
         },
         AvroSchema::Enum { .. } => {
             return Ok(Field::new(
                 name.unwrap_or_default(),
-                DataType::Dictionary(IntegerType::Int32, Box::new(DataType::Utf8), false),
+                ArrowDataType::Dictionary(IntegerType::Int32, Box::new(ArrowDataType::Utf8), false),
                 false,
             ))
         },
         AvroSchema::Fixed(Fixed { size, logical, .. }) => match logical {
             Some(logical) => match logical {
                 avro_schema::schema::FixedLogical::Decimal(precision, scale) => {
-                    DataType::Decimal(*precision, *scale)
+                    ArrowDataType::Decimal(*precision, *scale)
                 },
                 avro_schema::schema::FixedLogical::Duration => {
-                    DataType::Interval(IntervalUnit::MonthDayNano)
+                    ArrowDataType::Interval(IntervalUnit::MonthDayNano)
                 },
             },
-            None => DataType::FixedSizeBinary(*size),
+            None => ArrowDataType::FixedSizeBinary(*size),
         },
     };
 

--- a/crates/polars-arrow/src/io/avro/write/schema.rs
+++ b/crates/polars-arrow/src/io/avro/write/schema.rs
@@ -29,7 +29,7 @@ fn field_to_field(field: &Field, name_counter: &mut i32) -> PolarsResult<AvroFie
 }
 
 fn type_to_schema(
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     is_nullable: bool,
     name_counter: &mut i32,
 ) -> PolarsResult<AvroSchema> {
@@ -48,44 +48,48 @@ fn _get_field_name(name_counter: &mut i32) -> String {
     format!("r{name_counter}")
 }
 
-fn _type_to_schema(data_type: &DataType, name_counter: &mut i32) -> PolarsResult<AvroSchema> {
+fn _type_to_schema(data_type: &ArrowDataType, name_counter: &mut i32) -> PolarsResult<AvroSchema> {
     Ok(match data_type.to_logical_type() {
-        DataType::Null => AvroSchema::Null,
-        DataType::Boolean => AvroSchema::Boolean,
-        DataType::Int32 => AvroSchema::Int(None),
-        DataType::Int64 => AvroSchema::Long(None),
-        DataType::Float32 => AvroSchema::Float,
-        DataType::Float64 => AvroSchema::Double,
-        DataType::Binary => AvroSchema::Bytes(None),
-        DataType::LargeBinary => AvroSchema::Bytes(None),
-        DataType::Utf8 => AvroSchema::String(None),
-        DataType::LargeUtf8 => AvroSchema::String(None),
-        DataType::LargeList(inner) | DataType::List(inner) => AvroSchema::Array(Box::new(
-            type_to_schema(&inner.data_type, inner.is_nullable, name_counter)?,
-        )),
-        DataType::Struct(fields) => AvroSchema::Record(Record::new(
+        ArrowDataType::Null => AvroSchema::Null,
+        ArrowDataType::Boolean => AvroSchema::Boolean,
+        ArrowDataType::Int32 => AvroSchema::Int(None),
+        ArrowDataType::Int64 => AvroSchema::Long(None),
+        ArrowDataType::Float32 => AvroSchema::Float,
+        ArrowDataType::Float64 => AvroSchema::Double,
+        ArrowDataType::Binary => AvroSchema::Bytes(None),
+        ArrowDataType::LargeBinary => AvroSchema::Bytes(None),
+        ArrowDataType::Utf8 => AvroSchema::String(None),
+        ArrowDataType::LargeUtf8 => AvroSchema::String(None),
+        ArrowDataType::LargeList(inner) | ArrowDataType::List(inner) => {
+            AvroSchema::Array(Box::new(type_to_schema(
+                &inner.data_type,
+                inner.is_nullable,
+                name_counter,
+            )?))
+        },
+        ArrowDataType::Struct(fields) => AvroSchema::Record(Record::new(
             _get_field_name(name_counter),
             fields
                 .iter()
                 .map(|f| field_to_field(f, name_counter))
                 .collect::<PolarsResult<Vec<_>>>()?,
         )),
-        DataType::Date32 => AvroSchema::Int(Some(IntLogical::Date)),
-        DataType::Time32(TimeUnit::Millisecond) => AvroSchema::Int(Some(IntLogical::Time)),
-        DataType::Time64(TimeUnit::Microsecond) => AvroSchema::Long(Some(LongLogical::Time)),
-        DataType::Timestamp(TimeUnit::Millisecond, None) => {
+        ArrowDataType::Date32 => AvroSchema::Int(Some(IntLogical::Date)),
+        ArrowDataType::Time32(TimeUnit::Millisecond) => AvroSchema::Int(Some(IntLogical::Time)),
+        ArrowDataType::Time64(TimeUnit::Microsecond) => AvroSchema::Long(Some(LongLogical::Time)),
+        ArrowDataType::Timestamp(TimeUnit::Millisecond, None) => {
             AvroSchema::Long(Some(LongLogical::LocalTimestampMillis))
         },
-        DataType::Timestamp(TimeUnit::Microsecond, None) => {
+        ArrowDataType::Timestamp(TimeUnit::Microsecond, None) => {
             AvroSchema::Long(Some(LongLogical::LocalTimestampMicros))
         },
-        DataType::Interval(IntervalUnit::MonthDayNano) => {
+        ArrowDataType::Interval(IntervalUnit::MonthDayNano) => {
             let mut fixed = Fixed::new("", 12);
             fixed.logical = Some(FixedLogical::Duration);
             AvroSchema::Fixed(fixed)
         },
-        DataType::FixedSizeBinary(size) => AvroSchema::Fixed(Fixed::new("", *size)),
-        DataType::Decimal(p, s) => AvroSchema::Bytes(Some(BytesLogical::Decimal(*p, *s))),
+        ArrowDataType::FixedSizeBinary(size) => AvroSchema::Fixed(Fixed::new("", *size)),
+        ArrowDataType::Decimal(p, s) => AvroSchema::Bytes(Some(BytesLogical::Decimal(*p, *s))),
         other => polars_bail!(nyi = "write {other:?} to avro"),
     })
 }

--- a/crates/polars-arrow/src/io/avro/write/serialize.rs
+++ b/crates/polars-arrow/src/io/avro/write/serialize.rs
@@ -4,7 +4,7 @@ use avro_schema::write::encode;
 use super::super::super::iterator::*;
 use crate::array::*;
 use crate::bitmap::utils::ZipValidity;
-use crate::datatypes::{DataType, IntervalUnit, PhysicalType, PrimitiveType};
+use crate::datatypes::{ArrowDataType, IntervalUnit, PhysicalType, PrimitiveType};
 use crate::offset::Offset;
 use crate::types::months_days_ns;
 
@@ -498,8 +498,8 @@ pub fn new_serializer<'a>(array: &'a dyn Array, schema: &AvroSchema) -> BoxSeria
 }
 
 /// Whether [`new_serializer`] supports `data_type`.
-pub fn can_serialize(data_type: &DataType) -> bool {
-    use DataType::*;
+pub fn can_serialize(data_type: &ArrowDataType) -> bool {
+    use ArrowDataType::*;
     match data_type.to_logical_type() {
         List(inner) => return can_serialize(&inner.data_type),
         LargeList(inner) => return can_serialize(&inner.data_type),

--- a/crates/polars-arrow/src/io/ipc/read/array/binary.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/binary.rs
@@ -7,13 +7,13 @@ use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
 use crate::array::BinaryArray;
 use crate::buffer::Buffer;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::Offset;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_binary<O: Offset, R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     buffers: &mut VecDeque<IpcBuffer>,
     reader: &mut R,
     block_offset: u64,

--- a/crates/polars-arrow/src/io/ipc/read/array/boolean.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/boolean.rs
@@ -6,12 +6,12 @@ use polars_error::{polars_err, PolarsResult};
 use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
 use crate::array::BooleanArray;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_boolean<R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     buffers: &mut VecDeque<IpcBuffer>,
     reader: &mut R,
     block_offset: u64,

--- a/crates/polars-arrow/src/io/ipc/read/array/dictionary.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/dictionary.rs
@@ -8,12 +8,12 @@ use polars_error::{polars_bail, polars_err, PolarsResult};
 use super::super::{Compression, Dictionaries, IpcBuffer, Node};
 use super::{read_primitive, skip_primitive};
 use crate::array::{DictionaryArray, DictionaryKey};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_dictionary<T: DictionaryKey, R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     id: Option<i64>,
     buffers: &mut VecDeque<IpcBuffer>,
     reader: &mut R,

--- a/crates/polars-arrow/src/io/ipc/read/array/fixed_size_binary.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/fixed_size_binary.rs
@@ -6,12 +6,12 @@ use polars_error::{polars_err, PolarsResult};
 use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
 use crate::array::FixedSizeBinaryArray;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_fixed_size_binary<R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     buffers: &mut VecDeque<IpcBuffer>,
     reader: &mut R,
     block_offset: u64,

--- a/crates/polars-arrow/src/io/ipc/read/array/fixed_size_list.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/fixed_size_list.rs
@@ -8,12 +8,12 @@ use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
 use super::super::{Compression, Dictionaries, IpcBuffer, Node, Version};
 use crate::array::FixedSizeListArray;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_fixed_size_list<R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     ipc_field: &IpcField,
     buffers: &mut VecDeque<IpcBuffer>,
     reader: &mut R,
@@ -65,7 +65,7 @@ pub fn read_fixed_size_list<R: Read + Seek>(
 
 pub fn skip_fixed_size_list(
     field_nodes: &mut VecDeque<Node>,
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> PolarsResult<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {

--- a/crates/polars-arrow/src/io/ipc/read/array/list.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/list.rs
@@ -10,13 +10,13 @@ use super::super::read_basic::*;
 use super::super::{Compression, Dictionaries, IpcBuffer, Node, OutOfSpecKind, Version};
 use crate::array::ListArray;
 use crate::buffer::Buffer;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::Offset;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_list<O: Offset, R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     ipc_field: &IpcField,
     buffers: &mut VecDeque<IpcBuffer>,
     reader: &mut R,
@@ -89,7 +89,7 @@ where
 
 pub fn skip_list<O: Offset>(
     field_nodes: &mut VecDeque<Node>,
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> PolarsResult<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {

--- a/crates/polars-arrow/src/io/ipc/read/array/map.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/map.rs
@@ -9,12 +9,12 @@ use super::super::read_basic::*;
 use super::super::{Compression, Dictionaries, IpcBuffer, Node, OutOfSpecKind, Version};
 use crate::array::MapArray;
 use crate::buffer::Buffer;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_map<R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     ipc_field: &IpcField,
     buffers: &mut VecDeque<IpcBuffer>,
     reader: &mut R,
@@ -84,7 +84,7 @@ pub fn read_map<R: Read + Seek>(
 
 pub fn skip_map(
     field_nodes: &mut VecDeque<Node>,
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> PolarsResult<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {

--- a/crates/polars-arrow/src/io/ipc/read/array/null.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/null.rs
@@ -4,9 +4,12 @@ use polars_error::{polars_err, PolarsResult};
 
 use super::super::{Node, OutOfSpecKind};
 use crate::array::NullArray;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
-pub fn read_null(field_nodes: &mut VecDeque<Node>, data_type: DataType) -> PolarsResult<NullArray> {
+pub fn read_null(
+    field_nodes: &mut VecDeque<Node>,
+    data_type: ArrowDataType,
+) -> PolarsResult<NullArray> {
     let field_node = field_nodes.pop_front().ok_or_else(|| {
         polars_err!(oos =
             "IPC: unable to fetch the field for {data_type:?}. The file or stream is corrupted."

--- a/crates/polars-arrow/src/io/ipc/read/array/primitive.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/primitive.rs
@@ -7,13 +7,13 @@ use polars_error::{polars_err, PolarsResult};
 use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
 use crate::array::PrimitiveArray;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::types::NativeType;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_primitive<T: NativeType, R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     buffers: &mut VecDeque<IpcBuffer>,
     reader: &mut R,
     block_offset: u64,

--- a/crates/polars-arrow/src/io/ipc/read/array/struct_.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/struct_.rs
@@ -8,12 +8,12 @@ use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
 use super::super::{Compression, Dictionaries, IpcBuffer, Node, Version};
 use crate::array::StructArray;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_struct<R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     ipc_field: &IpcField,
     buffers: &mut VecDeque<IpcBuffer>,
     reader: &mut R,
@@ -70,7 +70,7 @@ pub fn read_struct<R: Read + Seek>(
 
 pub fn skip_struct(
     field_nodes: &mut VecDeque<Node>,
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> PolarsResult<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {

--- a/crates/polars-arrow/src/io/ipc/read/array/union.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/union.rs
@@ -8,13 +8,13 @@ use super::super::deserialize::{read, skip};
 use super::super::read_basic::*;
 use super::super::{Compression, Dictionaries, IpcBuffer, Node, OutOfSpecKind, Version};
 use crate::array::UnionArray;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::datatypes::UnionMode::Dense;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_union<R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     ipc_field: &IpcField,
     buffers: &mut VecDeque<IpcBuffer>,
     reader: &mut R,
@@ -54,7 +54,7 @@ pub fn read_union<R: Read + Seek>(
         scratch,
     )?;
 
-    let offsets = if let DataType::Union(_, _, mode) = data_type {
+    let offsets = if let ArrowDataType::Union(_, _, mode) = data_type {
         if !mode.is_sparse() {
             Some(read_buffer(
                 buffers,
@@ -100,7 +100,7 @@ pub fn read_union<R: Read + Seek>(
 
 pub fn skip_union(
     field_nodes: &mut VecDeque<Node>,
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> PolarsResult<()> {
     let _ = field_nodes.pop_front().ok_or_else(|| {
@@ -112,7 +112,7 @@ pub fn skip_union(
     let _ = buffers
         .pop_front()
         .ok_or_else(|| polars_err!(oos = "IPC: missing validity buffer."))?;
-    if let DataType::Union(_, _, Dense) = data_type {
+    if let ArrowDataType::Union(_, _, Dense) = data_type {
         let _ = buffers
             .pop_front()
             .ok_or_else(|| polars_err!(oos = "IPC: missing offsets buffer."))?;

--- a/crates/polars-arrow/src/io/ipc/read/array/utf8.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/utf8.rs
@@ -7,13 +7,13 @@ use super::super::read_basic::*;
 use super::super::{Compression, IpcBuffer, Node, OutOfSpecKind};
 use crate::array::Utf8Array;
 use crate::buffer::Buffer;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::Offset;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_utf8<O: Offset, R: Read + Seek>(
     field_nodes: &mut VecDeque<Node>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     buffers: &mut VecDeque<IpcBuffer>,
     reader: &mut R,
     block_offset: u64,

--- a/crates/polars-arrow/src/io/ipc/read/deserialize.rs
+++ b/crates/polars-arrow/src/io/ipc/read/deserialize.rs
@@ -7,7 +7,7 @@ use polars_error::PolarsResult;
 use super::array::*;
 use super::{Dictionaries, IpcBuffer, Node};
 use crate::array::*;
-use crate::datatypes::{DataType, Field, PhysicalType};
+use crate::datatypes::{ArrowDataType, Field, PhysicalType};
 use crate::io::ipc::IpcField;
 use crate::{match_integer_type, with_match_primitive_type_full};
 
@@ -230,7 +230,7 @@ pub fn read<R: Read + Seek>(
 
 pub fn skip(
     field_nodes: &mut VecDeque<Node>,
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     buffers: &mut VecDeque<IpcBuffer>,
 ) -> PolarsResult<()> {
     use PhysicalType::*;

--- a/crates/polars-arrow/src/io/ipc/read/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/read/schema.rs
@@ -5,8 +5,8 @@ use polars_error::{polars_bail, polars_err, PolarsResult};
 use super::super::{IpcField, IpcSchema};
 use super::{OutOfSpecKind, StreamMetadata};
 use crate::datatypes::{
-    get_extension, ArrowSchema, DataType, Extension, Field, IntegerType, IntervalUnit, Metadata,
-    TimeUnit, UnionMode,
+    get_extension, ArrowDataType, ArrowSchema, Extension, Field, IntegerType, IntervalUnit,
+    Metadata, TimeUnit, UnionMode,
 };
 
 fn try_unzip_vec<A, B, I: Iterator<Item = PolarsResult<(A, B)>>>(
@@ -82,14 +82,14 @@ fn deserialize_timeunit(time_unit: arrow_format::ipc::TimeUnit) -> PolarsResult<
     })
 }
 
-fn deserialize_time(time: TimeRef) -> PolarsResult<(DataType, IpcField)> {
+fn deserialize_time(time: TimeRef) -> PolarsResult<(ArrowDataType, IpcField)> {
     let unit = deserialize_timeunit(time.unit()?)?;
 
     let data_type = match (time.bit_width()?, unit) {
-        (32, TimeUnit::Second) => DataType::Time32(TimeUnit::Second),
-        (32, TimeUnit::Millisecond) => DataType::Time32(TimeUnit::Millisecond),
-        (64, TimeUnit::Microsecond) => DataType::Time64(TimeUnit::Microsecond),
-        (64, TimeUnit::Nanosecond) => DataType::Time64(TimeUnit::Nanosecond),
+        (32, TimeUnit::Second) => ArrowDataType::Time32(TimeUnit::Second),
+        (32, TimeUnit::Millisecond) => ArrowDataType::Time32(TimeUnit::Millisecond),
+        (64, TimeUnit::Microsecond) => ArrowDataType::Time64(TimeUnit::Microsecond),
+        (64, TimeUnit::Nanosecond) => ArrowDataType::Time64(TimeUnit::Nanosecond),
         (bits, precision) => {
             polars_bail!(ComputeError:
                 "Time type with bit width of {bits} and unit of {precision:?}"
@@ -99,16 +99,16 @@ fn deserialize_time(time: TimeRef) -> PolarsResult<(DataType, IpcField)> {
     Ok((data_type, IpcField::default()))
 }
 
-fn deserialize_timestamp(timestamp: TimestampRef) -> PolarsResult<(DataType, IpcField)> {
+fn deserialize_timestamp(timestamp: TimestampRef) -> PolarsResult<(ArrowDataType, IpcField)> {
     let timezone = timestamp.timezone()?.map(|tz| tz.to_string());
     let time_unit = deserialize_timeunit(timestamp.unit()?)?;
     Ok((
-        DataType::Timestamp(time_unit, timezone),
+        ArrowDataType::Timestamp(time_unit, timezone),
         IpcField::default(),
     ))
 }
 
-fn deserialize_union(union_: UnionRef, field: FieldRef) -> PolarsResult<(DataType, IpcField)> {
+fn deserialize_union(union_: UnionRef, field: FieldRef) -> PolarsResult<(ArrowDataType, IpcField)> {
     let mode = UnionMode::sparse(union_.mode()? == arrow_format::ipc::UnionMode::Sparse);
     let ids = union_.type_ids()?.map(|x| x.iter().collect());
 
@@ -127,10 +127,10 @@ fn deserialize_union(union_: UnionRef, field: FieldRef) -> PolarsResult<(DataTyp
         fields: ipc_fields,
         dictionary_id: None,
     };
-    Ok((DataType::Union(fields, ids, mode), ipc_field))
+    Ok((ArrowDataType::Union(fields, ids, mode), ipc_field))
 }
 
-fn deserialize_map(map: MapRef, field: FieldRef) -> PolarsResult<(DataType, IpcField)> {
+fn deserialize_map(map: MapRef, field: FieldRef) -> PolarsResult<(ArrowDataType, IpcField)> {
     let is_sorted = map.keys_sorted()?;
 
     let children = field
@@ -141,7 +141,7 @@ fn deserialize_map(map: MapRef, field: FieldRef) -> PolarsResult<(DataType, IpcF
         .ok_or_else(|| polars_err!(oos = "IPC: Map must contain one child"))??;
     let (field, ipc_field) = deserialize_field(inner)?;
 
-    let data_type = DataType::Map(Box::new(field), is_sorted);
+    let data_type = ArrowDataType::Map(Box::new(field), is_sorted);
     Ok((
         data_type,
         IpcField {
@@ -151,7 +151,7 @@ fn deserialize_map(map: MapRef, field: FieldRef) -> PolarsResult<(DataType, IpcF
     ))
 }
 
-fn deserialize_struct(field: FieldRef) -> PolarsResult<(DataType, IpcField)> {
+fn deserialize_struct(field: FieldRef) -> PolarsResult<(ArrowDataType, IpcField)> {
     let fields = field
         .children()?
         .ok_or_else(|| polars_err!(oos = "IPC: Struct must contain children"))?;
@@ -166,10 +166,10 @@ fn deserialize_struct(field: FieldRef) -> PolarsResult<(DataType, IpcField)> {
         fields: ipc_fields,
         dictionary_id: None,
     };
-    Ok((DataType::Struct(fields), ipc_field))
+    Ok((ArrowDataType::Struct(fields), ipc_field))
 }
 
-fn deserialize_list(field: FieldRef) -> PolarsResult<(DataType, IpcField)> {
+fn deserialize_list(field: FieldRef) -> PolarsResult<(ArrowDataType, IpcField)> {
     let children = field
         .children()?
         .ok_or_else(|| polars_err!(oos = "IPC: List must contain children"))?;
@@ -179,7 +179,7 @@ fn deserialize_list(field: FieldRef) -> PolarsResult<(DataType, IpcField)> {
     let (field, ipc_field) = deserialize_field(inner)?;
 
     Ok((
-        DataType::List(Box::new(field)),
+        ArrowDataType::List(Box::new(field)),
         IpcField {
             fields: vec![ipc_field],
             dictionary_id: None,
@@ -187,7 +187,7 @@ fn deserialize_list(field: FieldRef) -> PolarsResult<(DataType, IpcField)> {
     ))
 }
 
-fn deserialize_large_list(field: FieldRef) -> PolarsResult<(DataType, IpcField)> {
+fn deserialize_large_list(field: FieldRef) -> PolarsResult<(ArrowDataType, IpcField)> {
     let children = field
         .children()?
         .ok_or_else(|| polars_err!(oos = "IPC: List must contain children"))?;
@@ -197,7 +197,7 @@ fn deserialize_large_list(field: FieldRef) -> PolarsResult<(DataType, IpcField)>
     let (field, ipc_field) = deserialize_field(inner)?;
 
     Ok((
-        DataType::LargeList(Box::new(field)),
+        ArrowDataType::LargeList(Box::new(field)),
         IpcField {
             fields: vec![ipc_field],
             dictionary_id: None,
@@ -208,7 +208,7 @@ fn deserialize_large_list(field: FieldRef) -> PolarsResult<(DataType, IpcField)>
 fn deserialize_fixed_size_list(
     list: FixedSizeListRef,
     field: FieldRef,
-) -> PolarsResult<(DataType, IpcField)> {
+) -> PolarsResult<(ArrowDataType, IpcField)> {
     let children = field
         .children()?
         .ok_or_else(|| polars_err!(oos = "IPC: FixedSizeList must contain children"))?;
@@ -223,7 +223,7 @@ fn deserialize_fixed_size_list(
         .map_err(|_| polars_err!(oos = OutOfSpecKind::NegativeFooterLength))?;
 
     Ok((
-        DataType::FixedSizeList(Box::new(field), size),
+        ArrowDataType::FixedSizeList(Box::new(field), size),
         IpcField {
             fields: vec![ipc_field],
             dictionary_id: None,
@@ -236,7 +236,7 @@ fn get_data_type(
     field: arrow_format::ipc::FieldRef,
     extension: Extension,
     may_be_dictionary: bool,
-) -> PolarsResult<(DataType, IpcField)> {
+) -> PolarsResult<(ArrowDataType, IpcField)> {
     if let Some(dictionary) = field.dictionary()? {
         if may_be_dictionary {
             let int = dictionary
@@ -246,7 +246,7 @@ fn get_data_type(
             let (inner, mut ipc_field) = get_data_type(field, extension, false)?;
             ipc_field.dictionary_id = Some(dictionary.id()?);
             return Ok((
-                DataType::Dictionary(index_type, Box::new(inner), dictionary.is_ordered()?),
+                ArrowDataType::Dictionary(index_type, Box::new(inner), dictionary.is_ordered()?),
                 ipc_field,
             ));
         }
@@ -256,7 +256,7 @@ fn get_data_type(
         let (name, metadata) = extension;
         let (data_type, fields) = get_data_type(field, None, false)?;
         return Ok((
-            DataType::Extension(name, Box::new(data_type), metadata),
+            ArrowDataType::Extension(name, Box::new(data_type), metadata),
             fields,
         ));
     }
@@ -267,18 +267,18 @@ fn get_data_type(
 
     use arrow_format::ipc::TypeRef::*;
     Ok(match type_ {
-        Null(_) => (DataType::Null, IpcField::default()),
-        Bool(_) => (DataType::Boolean, IpcField::default()),
+        Null(_) => (ArrowDataType::Null, IpcField::default()),
+        Bool(_) => (ArrowDataType::Boolean, IpcField::default()),
         Int(int) => {
             let data_type = deserialize_integer(int)?.into();
             (data_type, IpcField::default())
         },
-        Binary(_) => (DataType::Binary, IpcField::default()),
-        LargeBinary(_) => (DataType::LargeBinary, IpcField::default()),
-        Utf8(_) => (DataType::Utf8, IpcField::default()),
-        LargeUtf8(_) => (DataType::LargeUtf8, IpcField::default()),
+        Binary(_) => (ArrowDataType::Binary, IpcField::default()),
+        LargeBinary(_) => (ArrowDataType::LargeBinary, IpcField::default()),
+        Utf8(_) => (ArrowDataType::Utf8, IpcField::default()),
+        LargeUtf8(_) => (ArrowDataType::LargeUtf8, IpcField::default()),
         FixedSizeBinary(fixed) => (
-            DataType::FixedSizeBinary(
+            ArrowDataType::FixedSizeBinary(
                 fixed
                     .byte_width()?
                     .try_into()
@@ -288,16 +288,16 @@ fn get_data_type(
         ),
         FloatingPoint(float) => {
             let data_type = match float.precision()? {
-                arrow_format::ipc::Precision::Half => DataType::Float16,
-                arrow_format::ipc::Precision::Single => DataType::Float32,
-                arrow_format::ipc::Precision::Double => DataType::Float64,
+                arrow_format::ipc::Precision::Half => ArrowDataType::Float16,
+                arrow_format::ipc::Precision::Single => ArrowDataType::Float32,
+                arrow_format::ipc::Precision::Double => ArrowDataType::Float64,
             };
             (data_type, IpcField::default())
         },
         Date(date) => {
             let data_type = match date.unit()? {
-                arrow_format::ipc::DateUnit::Day => DataType::Date32,
-                arrow_format::ipc::DateUnit::Millisecond => DataType::Date64,
+                arrow_format::ipc::DateUnit::Day => ArrowDataType::Date32,
+                arrow_format::ipc::DateUnit::Millisecond => ArrowDataType::Date64,
             };
             (data_type, IpcField::default())
         },
@@ -306,20 +306,20 @@ fn get_data_type(
         Interval(interval) => {
             let data_type = match interval.unit()? {
                 arrow_format::ipc::IntervalUnit::YearMonth => {
-                    DataType::Interval(IntervalUnit::YearMonth)
+                    ArrowDataType::Interval(IntervalUnit::YearMonth)
                 },
                 arrow_format::ipc::IntervalUnit::DayTime => {
-                    DataType::Interval(IntervalUnit::DayTime)
+                    ArrowDataType::Interval(IntervalUnit::DayTime)
                 },
                 arrow_format::ipc::IntervalUnit::MonthDayNano => {
-                    DataType::Interval(IntervalUnit::MonthDayNano)
+                    ArrowDataType::Interval(IntervalUnit::MonthDayNano)
                 },
             };
             (data_type, IpcField::default())
         },
         Duration(duration) => {
             let time_unit = deserialize_timeunit(duration.unit()?)?;
-            (DataType::Duration(time_unit), IpcField::default())
+            (ArrowDataType::Duration(time_unit), IpcField::default())
         },
         Decimal(decimal) => {
             let bit_width: usize = decimal
@@ -336,8 +336,8 @@ fn get_data_type(
                 .map_err(|_| polars_err!(oos = OutOfSpecKind::NegativeFooterLength))?;
 
             let data_type = match bit_width {
-                128 => DataType::Decimal(precision, scale),
-                256 => DataType::Decimal256(precision, scale),
+                128 => ArrowDataType::Decimal(precision, scale),
+                256 => ArrowDataType::Decimal256(precision, scale),
                 _ => return Err(polars_err!(oos = OutOfSpecKind::NegativeFooterLength)),
             };
 

--- a/crates/polars-arrow/src/io/ipc/write/common.rs
+++ b/crates/polars-arrow/src/io/ipc/write/common.rs
@@ -348,7 +348,7 @@ impl DictionaryTracker {
     ///   inserted.
     pub fn insert(&mut self, dict_id: i64, array: &dyn Array) -> PolarsResult<bool> {
         let values = match array.data_type() {
-            DataType::Dictionary(key_type, _, _) => {
+            ArrowDataType::Dictionary(key_type, _, _) => {
                 match_integer_type!(key_type, |$T| {
                     let array = array
                         .as_any()

--- a/crates/polars-arrow/src/io/ipc/write/mod.rs
+++ b/crates/polars-arrow/src/io/ipc/write/mod.rs
@@ -25,10 +25,10 @@ pub mod stream_async;
 pub mod file_async;
 
 use super::IpcField;
-use crate::datatypes::{DataType, Field};
+use crate::datatypes::{ArrowDataType, Field};
 
-fn default_ipc_field(data_type: &DataType, current_id: &mut i64) -> IpcField {
-    use crate::datatypes::DataType::*;
+fn default_ipc_field(data_type: &ArrowDataType, current_id: &mut i64) -> IpcField {
+    use crate::datatypes::ArrowDataType::*;
     match data_type.to_logical_type() {
         // single child => recurse
         Map(inner, ..) | FixedSizeList(inner, _) | LargeList(inner) | List(inner) => IpcField {

--- a/crates/polars-arrow/src/io/ipc/write/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/write/schema.rs
@@ -2,7 +2,7 @@ use arrow_format::ipc::planus::Builder;
 
 use super::super::IpcField;
 use crate::datatypes::{
-    ArrowSchema, DataType, Field, IntegerType, IntervalUnit, Metadata, TimeUnit, UnionMode,
+    ArrowDataType, ArrowSchema, Field, IntegerType, IntervalUnit, Metadata, TimeUnit, UnionMode,
 };
 use crate::io::ipc::endianness::is_native_little_endian;
 
@@ -97,28 +97,28 @@ fn write_extension(
 pub(crate) fn serialize_field(field: &Field, ipc_field: &IpcField) -> arrow_format::ipc::Field {
     // custom metadata.
     let mut kv_vec = vec![];
-    if let DataType::Extension(name, _, metadata) = field.data_type() {
+    if let ArrowDataType::Extension(name, _, metadata) = field.data_type() {
         write_extension(name, metadata, &mut kv_vec);
     }
 
     let type_ = serialize_type(field.data_type());
     let children = serialize_children(field.data_type(), ipc_field);
 
-    let dictionary = if let DataType::Dictionary(index_type, inner, is_ordered) = field.data_type()
-    {
-        if let DataType::Extension(name, _, metadata) = inner.as_ref() {
-            write_extension(name, metadata, &mut kv_vec);
-        }
-        Some(serialize_dictionary(
-            index_type,
-            ipc_field
-                .dictionary_id
-                .expect("All Dictionary types have `dict_id`"),
-            *is_ordered,
-        ))
-    } else {
-        None
-    };
+    let dictionary =
+        if let ArrowDataType::Dictionary(index_type, inner, is_ordered) = field.data_type() {
+            if let ArrowDataType::Extension(name, _, metadata) = inner.as_ref() {
+                write_extension(name, metadata, &mut kv_vec);
+            }
+            Some(serialize_dictionary(
+                index_type,
+                ipc_field
+                    .dictionary_id
+                    .expect("All Dictionary types have `dict_id`"),
+                *is_ordered,
+            ))
+        } else {
+            None
+        };
 
     write_metadata(&field.metadata, &mut kv_vec);
 
@@ -147,9 +147,9 @@ fn serialize_time_unit(unit: &TimeUnit) -> arrow_format::ipc::TimeUnit {
     }
 }
 
-fn serialize_type(data_type: &DataType) -> arrow_format::ipc::Type {
+fn serialize_type(data_type: &ArrowDataType) -> arrow_format::ipc::Type {
     use arrow_format::ipc;
-    use DataType::*;
+    use ArrowDataType::*;
     match data_type {
         Null => ipc::Type::Null(Box::new(ipc::Null {})),
         Boolean => ipc::Type::Bool(Box::new(ipc::Bool {})),
@@ -260,8 +260,11 @@ fn serialize_type(data_type: &DataType) -> arrow_format::ipc::Type {
     }
 }
 
-fn serialize_children(data_type: &DataType, ipc_field: &IpcField) -> Vec<arrow_format::ipc::Field> {
-    use DataType::*;
+fn serialize_children(
+    data_type: &ArrowDataType,
+    ipc_field: &IpcField,
+) -> Vec<arrow_format::ipc::Field> {
+    use ArrowDataType::*;
     match data_type {
         Null
         | Boolean

--- a/crates/polars-arrow/src/legacy/array/default_arrays.rs
+++ b/crates/polars-arrow/src/legacy/array/default_arrays.rs
@@ -1,7 +1,7 @@
 use crate::array::{BinaryArray, BooleanArray, PrimitiveArray, Utf8Array};
 use crate::bitmap::Bitmap;
 use crate::buffer::Buffer;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::OffsetsBuffer;
 use crate::types::NativeType;
 
@@ -11,7 +11,7 @@ pub trait FromData<T> {
 
 impl FromData<Bitmap> for BooleanArray {
     fn from_data_default(values: Bitmap, validity: Option<Bitmap>) -> BooleanArray {
-        BooleanArray::new(DataType::Boolean, values, validity)
+        BooleanArray::new(ArrowDataType::Boolean, values, validity)
     }
 }
 
@@ -39,7 +39,7 @@ impl FromDataUtf8 for Utf8Array<i64> {
         validity: Option<Bitmap>,
     ) -> Self {
         let offsets = OffsetsBuffer::new_unchecked(offsets);
-        Utf8Array::new_unchecked(DataType::LargeUtf8, offsets, values, validity)
+        Utf8Array::new_unchecked(ArrowDataType::LargeUtf8, offsets, values, validity)
     }
 }
 
@@ -60,6 +60,6 @@ impl FromDataBinary for BinaryArray<i64> {
         validity: Option<Bitmap>,
     ) -> Self {
         let offsets = OffsetsBuffer::new_unchecked(offsets);
-        BinaryArray::new(DataType::LargeBinary, offsets, values, validity)
+        BinaryArray::new(ArrowDataType::LargeBinary, offsets, values, validity)
     }
 }

--- a/crates/polars-arrow/src/legacy/array/fixed_size_list.rs
+++ b/crates/polars-arrow/src/legacy/array/fixed_size_list.rs
@@ -2,7 +2,7 @@ use polars_error::PolarsResult;
 
 use crate::array::FixedSizeListArray;
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::legacy::kernels::concatenate::concatenate_owned_unchecked;
 use crate::legacy::prelude::ArrayRef;
 
@@ -48,7 +48,7 @@ impl AnonymousBuilder {
         self.validity = Some(validity)
     }
 
-    pub fn finish(self, inner_dtype: Option<&DataType>) -> PolarsResult<FixedSizeListArray> {
+    pub fn finish(self, inner_dtype: Option<&ArrowDataType>) -> PolarsResult<FixedSizeListArray> {
         let values = concatenate_owned_unchecked(&self.arrays)?;
         let inner_dtype = inner_dtype.unwrap_or_else(|| self.arrays[0].data_type());
         let data_type = FixedSizeListArray::default_datatype(inner_dtype.clone(), self.width);

--- a/crates/polars-arrow/src/legacy/array/mod.rs
+++ b/crates/polars-arrow/src/legacy/array/mod.rs
@@ -2,7 +2,7 @@ use crate::array::{
     Array, BinaryArray, BooleanArray, FixedSizeListArray, ListArray, PrimitiveArray, Utf8Array,
 };
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::legacy::prelude::*;
 use crate::legacy::utils::CustomIterTools;
 use crate::offset::Offsets;
@@ -52,22 +52,22 @@ impl ValueSize for BinaryArray<i64> {
 impl ValueSize for ArrayRef {
     fn get_values_size(&self) -> usize {
         match self.data_type() {
-            DataType::LargeUtf8 => self
+            ArrowDataType::LargeUtf8 => self
                 .as_any()
                 .downcast_ref::<Utf8Array<i64>>()
                 .unwrap()
                 .get_values_size(),
-            DataType::FixedSizeList(_, _) => self
+            ArrowDataType::FixedSizeList(_, _) => self
                 .as_any()
                 .downcast_ref::<FixedSizeListArray>()
                 .unwrap()
                 .get_values_size(),
-            DataType::LargeList(_) => self
+            ArrowDataType::LargeList(_) => self
                 .as_any()
                 .downcast_ref::<ListArray<i64>>()
                 .unwrap()
                 .get_values_size(),
-            DataType::LargeBinary => self
+            ArrowDataType::LargeBinary => self
                 .as_any()
                 .downcast_ref::<BinaryArray<i64>>()
                 .unwrap()
@@ -106,7 +106,7 @@ pub trait ListFromIter {
     /// Will produce incorrect arrays if size hint is incorrect.
     unsafe fn from_iter_primitive_trusted_len<T, P, I>(
         iter: I,
-        data_type: DataType,
+        data_type: ArrowDataType,
     ) -> ListArray<i64>
     where
         T: NativeType,
@@ -156,7 +156,7 @@ pub trait ListFromIter {
         // Safety:
         // Offsets are monotonically increasing.
         ListArray::new(
-            ListArray::<i64>::default_datatype(DataType::Boolean),
+            ListArray::<i64>::default_datatype(ArrowDataType::Boolean),
             Offsets::new_unchecked(offsets).into(),
             Box::new(values),
             Some(validity.into()),
@@ -202,7 +202,7 @@ pub trait ListFromIter {
         // Safety:
         // offsets are monotonically increasing
         ListArray::new(
-            ListArray::<i64>::default_datatype(DataType::LargeUtf8),
+            ListArray::<i64>::default_datatype(ArrowDataType::LargeUtf8),
             Offsets::new_unchecked(offsets).into(),
             Box::new(values),
             Some(validity.into()),
@@ -248,7 +248,7 @@ pub trait ListFromIter {
         // Safety:
         // offsets are monotonically increasing
         ListArray::new(
-            ListArray::<i64>::default_datatype(DataType::LargeBinary),
+            ListArray::<i64>::default_datatype(ArrowDataType::LargeBinary),
             Offsets::new_unchecked(offsets).into(),
             Box::new(values),
             Some(validity.into()),

--- a/crates/polars-arrow/src/legacy/array/null.rs
+++ b/crates/polars-arrow/src/legacy/array/null.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use crate::array::{Array, MutableArray, NullArray};
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 #[derive(Debug, Default, Clone)]
 pub struct MutableNullArray {
@@ -10,8 +10,8 @@ pub struct MutableNullArray {
 }
 
 impl MutableArray for MutableNullArray {
-    fn data_type(&self) -> &DataType {
-        &DataType::Null
+    fn data_type(&self) -> &ArrowDataType {
+        &ArrowDataType::Null
     }
 
     fn len(&self) -> usize {
@@ -23,7 +23,7 @@ impl MutableArray for MutableNullArray {
     }
 
     fn as_box(&mut self) -> Box<dyn Array> {
-        Box::new(NullArray::new_null(DataType::Null, self.len))
+        Box::new(NullArray::new_null(ArrowDataType::Null, self.len))
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/polars-arrow/src/legacy/array/utf8.rs
+++ b/crates/polars-arrow/src/legacy/array/utf8.rs
@@ -1,5 +1,5 @@
 use crate::array::{BinaryArray, Utf8Array};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::legacy::trusted_len::TrustedLenPush;
 use crate::offset::Offsets;
 
@@ -62,7 +62,12 @@ pub trait Utf8FromIter {
         let iter = iter.map(StrAsBytes);
         let (offsets, values) = unsafe { fill_offsets_and_values(iter, size_hint, len) };
         unsafe {
-            Utf8Array::new_unchecked(DataType::LargeUtf8, offsets.into(), values.into(), None)
+            Utf8Array::new_unchecked(
+                ArrowDataType::LargeUtf8,
+                offsets.into(),
+                values.into(),
+                None,
+            )
         }
     }
 }
@@ -77,7 +82,12 @@ pub trait BinaryFromIter {
         I: Iterator<Item = S>,
     {
         let (offsets, values) = unsafe { fill_offsets_and_values(iter, value_cap, len) };
-        BinaryArray::new(DataType::LargeBinary, offsets.into(), values.into(), None)
+        BinaryArray::new(
+            ArrowDataType::LargeBinary,
+            offsets.into(),
+            values.into(),
+            None,
+        )
     }
 }
 

--- a/crates/polars-arrow/src/legacy/compute/arithmetics/decimal/add.rs
+++ b/crates/polars-arrow/src/legacy/compute/arithmetics/decimal/add.rs
@@ -10,7 +10,7 @@ pub fn add(
 pub fn add_scalar(
     lhs: &PrimitiveArray<i128>,
     rhs: i128,
-    rhs_dtype: &DataType,
+    rhs_dtype: &ArrowDataType,
 ) -> PolarsResult<PrimitiveArray<i128>> {
     commutative_scalar(lhs, rhs, rhs_dtype, |a, b| a + b)
 }

--- a/crates/polars-arrow/src/legacy/compute/arithmetics/decimal/commutative.rs
+++ b/crates/polars-arrow/src/legacy/compute/arithmetics/decimal/commutative.rs
@@ -2,7 +2,7 @@ use polars_error::*;
 
 use super::{get_parameters, max_value};
 use crate::array::PrimitiveArray;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::legacy::compute::{binary_mut, unary_mut};
 
 pub fn commutative<F>(
@@ -30,7 +30,7 @@ where
 pub fn commutative_scalar<F>(
     lhs: &PrimitiveArray<i128>,
     rhs: i128,
-    rhs_dtype: &DataType,
+    rhs_dtype: &ArrowDataType,
     op: F,
 ) -> PolarsResult<PrimitiveArray<i128>>
 where

--- a/crates/polars-arrow/src/legacy/compute/arithmetics/decimal/div.rs
+++ b/crates/polars-arrow/src/legacy/compute/arithmetics/decimal/div.rs
@@ -32,7 +32,7 @@ pub fn div(
 pub fn div_scalar(
     lhs: &PrimitiveArray<i128>,
     rhs: i128,
-    rhs_dtype: &DataType,
+    rhs_dtype: &ArrowDataType,
 ) -> PolarsResult<PrimitiveArray<i128>> {
     let (_, scale) = get_parameters(lhs.data_type(), rhs_dtype)?;
     let scale = 10i128.pow(scale as u32);
@@ -41,7 +41,7 @@ pub fn div_scalar(
 
 pub fn div_scalar_swapped(
     lhs: i128,
-    lhs_dtype: &DataType,
+    lhs_dtype: &ArrowDataType,
     rhs: &PrimitiveArray<i128>,
 ) -> PolarsResult<PrimitiveArray<i128>> {
     let (_, scale) = get_parameters(lhs_dtype, rhs.data_type())?;

--- a/crates/polars-arrow/src/legacy/compute/arithmetics/decimal/mod.rs
+++ b/crates/polars-arrow/src/legacy/compute/arithmetics/decimal/mod.rs
@@ -5,7 +5,7 @@ use commutative::{
 use polars_error::{PolarsError, PolarsResult};
 
 use crate::array::PrimitiveArray;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 mod add;
 mod commutative;
@@ -24,8 +24,8 @@ fn max_value(precision: usize) -> i128 {
     10i128.pow(precision as u32) - 1
 }
 
-fn get_parameters(lhs: &DataType, rhs: &DataType) -> PolarsResult<(usize, usize)> {
-    if let (DataType::Decimal(lhs_p, lhs_s), DataType::Decimal(rhs_p, rhs_s)) =
+fn get_parameters(lhs: &ArrowDataType, rhs: &ArrowDataType) -> PolarsResult<(usize, usize)> {
+    if let (ArrowDataType::Decimal(lhs_p, lhs_s), ArrowDataType::Decimal(rhs_p, rhs_s)) =
         (lhs.to_logical_type(), rhs.to_logical_type())
     {
         if lhs_p == rhs_p && lhs_s == rhs_s {

--- a/crates/polars-arrow/src/legacy/compute/arithmetics/decimal/mul.rs
+++ b/crates/polars-arrow/src/legacy/compute/arithmetics/decimal/mul.rs
@@ -33,7 +33,7 @@ pub fn mul(
 pub fn mul_scalar(
     lhs: &PrimitiveArray<i128>,
     rhs: i128,
-    rhs_dtype: &DataType,
+    rhs_dtype: &ArrowDataType,
 ) -> PolarsResult<PrimitiveArray<i128>> {
     let (_, scale) = get_parameters(lhs.data_type(), rhs_dtype)?;
     let scale = 10i128.pow(scale as u32);

--- a/crates/polars-arrow/src/legacy/compute/cast.rs
+++ b/crates/polars-arrow/src/legacy/compute/cast.rs
@@ -1,12 +1,14 @@
 use polars_error::PolarsResult;
 
 use crate::array::Array;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
-pub fn cast(array: &dyn Array, to_type: &DataType) -> PolarsResult<Box<dyn Array>> {
+pub fn cast(array: &dyn Array, to_type: &ArrowDataType) -> PolarsResult<Box<dyn Array>> {
     match to_type {
         #[cfg(feature = "dtype-decimal")]
-        DataType::Decimal(precision, scale) if matches!(array.data_type(), DataType::LargeUtf8) => {
+        ArrowDataType::Decimal(precision, scale)
+            if matches!(array.data_type(), ArrowDataType::LargeUtf8) =>
+        {
             let array = array.as_any().downcast_ref::<LargeStringArray>().unwrap();
             Ok(Box::new(cast_utf8_to_decimal(
                 array,

--- a/crates/polars-arrow/src/legacy/compute/mod.rs
+++ b/crates/polars-arrow/src/legacy/compute/mod.rs
@@ -1,5 +1,5 @@
 use crate::array::PrimitiveArray;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::legacy::utils::combine_validities_and;
 use crate::types::NativeType;
 
@@ -16,7 +16,7 @@ pub mod tile;
 pub fn binary_mut<T, D, F>(
     lhs: &PrimitiveArray<T>,
     rhs: &PrimitiveArray<D>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     mut op: F,
 ) -> PrimitiveArray<T>
 where
@@ -42,7 +42,7 @@ where
 pub fn unary_mut<I, F, O>(
     array: &PrimitiveArray<I>,
     mut op: F,
-    data_type: DataType,
+    data_type: ArrowDataType,
 ) -> PrimitiveArray<O>
 where
     I: NativeType,

--- a/crates/polars-arrow/src/legacy/compute/take/fixed_size_list.rs
+++ b/crates/polars-arrow/src/legacy/compute/take/fixed_size_list.rs
@@ -1,7 +1,7 @@
 use crate::array::growable::{Growable, GrowableFixedSizeList};
 use crate::array::{Array, FixedSizeListArray, PrimitiveArray};
 use crate::bitmap::{Bitmap, MutableBitmap};
-use crate::datatypes::{DataType, PhysicalType};
+use crate::datatypes::{ArrowDataType, PhysicalType};
 use crate::legacy::index::{IdxArr, IdxSize};
 use crate::legacy::prelude::ArrayRef;
 use crate::types::NativeType;
@@ -14,7 +14,7 @@ pub unsafe fn take_unchecked(values: &FixedSizeListArray, indices: &IdxArr) -> F
     ) {
         let idx = indices.values().as_slice();
         let child_values = values.values();
-        let DataType::FixedSizeList(_, width) = values.data_type() else {
+        let ArrowDataType::FixedSizeList(_, width) = values.data_type() else {
             unreachable!()
         };
 

--- a/crates/polars-arrow/src/legacy/compute/take/mod.rs
+++ b/crates/polars-arrow/src/legacy/compute/take/mod.rs
@@ -6,7 +6,7 @@ mod fixed_size_list;
 use crate::array::*;
 use crate::bitmap::MutableBitmap;
 use crate::buffer::Buffer;
-use crate::datatypes::{DataType, PhysicalType};
+use crate::datatypes::{ArrowDataType, PhysicalType};
 use crate::legacy::bit_util::unset_bit_raw;
 use crate::legacy::prelude::*;
 use crate::legacy::trusted_len::{TrustedLen, TrustedLenPush};
@@ -252,7 +252,11 @@ pub unsafe fn take_no_null_bool_iter_unchecked<I: IntoIterator<Item = usize>>(
         values.get_bit_unchecked(idx)
     });
     let mutable = MutableBitmap::from_trusted_len_iter_unchecked(iter);
-    Box::new(BooleanArray::new(DataType::Boolean, mutable.into(), None))
+    Box::new(BooleanArray::new(
+        ArrowDataType::Boolean,
+        mutable.into(),
+        None,
+    ))
 }
 
 /// Take kernel for single chunk and an iterator as index.

--- a/crates/polars-arrow/src/legacy/conversion.rs
+++ b/crates/polars-arrow/src/legacy/conversion.rs
@@ -1,11 +1,11 @@
 use crate::array::{PrimitiveArray, StructArray};
 use crate::chunk::Chunk;
-use crate::datatypes::{DataType, Field};
+use crate::datatypes::{ArrowDataType, Field};
 use crate::legacy::prelude::*;
 use crate::types::NativeType;
 
 pub fn chunk_to_struct(chunk: Chunk<ArrayRef>, fields: Vec<Field>) -> StructArray {
-    let dtype = DataType::Struct(fields);
+    let dtype = ArrowDataType::Struct(fields);
     StructArray::new(dtype, chunk.into_arrays(), None)
 }
 

--- a/crates/polars-arrow/src/legacy/kernels/list.rs
+++ b/crates/polars-arrow/src/legacy/kernels/list.rs
@@ -99,13 +99,13 @@ pub fn array_to_unit_list(array: ArrayRef) -> ListArray<i64> {
 mod test {
     use super::*;
     use crate::array::{Array, Int32Array, PrimitiveArray};
-    use crate::datatypes::DataType;
+    use crate::datatypes::ArrowDataType;
 
     fn get_array() -> ListArray<i64> {
         let values = Int32Array::from_slice([1, 2, 3, 4, 5, 6]);
         let offsets = OffsetsBuffer::try_from(vec![0i64, 3, 5, 6]).unwrap();
 
-        let dtype = ListArray::<i64>::default_datatype(DataType::Int32);
+        let dtype = ListArray::<i64>::default_datatype(ArrowDataType::Int32);
         ListArray::<i64>::new(dtype, offsets, Box::new(values), None)
     }
 
@@ -134,7 +134,7 @@ mod test {
         ]);
         let offsets = OffsetsBuffer::try_from(vec![0i64, 1, 2, 3, 6, 9, 11]).unwrap();
 
-        let dtype = ListArray::<i64>::default_datatype(DataType::Int32);
+        let dtype = ListArray::<i64>::default_datatype(ArrowDataType::Int32);
         let arr = ListArray::<i64>::new(dtype, offsets, Box::new(values), None);
 
         let out = sublist_get_indexes(&arr, 1);

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
@@ -17,7 +17,7 @@ pub use variance::*;
 
 use super::*;
 use crate::array::PrimitiveArray;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::legacy::error::{polars_bail, PolarsResult};
 use crate::legacy::utils::CustomIterTools;
 use crate::types::NativeType;
@@ -102,7 +102,7 @@ where
 
     let validity = create_validity(min_periods, len, window_size, det_offsets_fn);
     Ok(Box::new(PrimitiveArray::new(
-        DataType::from(T::PRIMITIVE),
+        ArrowDataType::from(T::PRIMITIVE),
         out.into(),
         validity.map(|b| b.into()),
     )))

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/mod.rs
@@ -93,14 +93,14 @@ mod test {
     use super::*;
     use crate::array::{Array, Int32Array};
     use crate::buffer::Buffer;
-    use crate::datatypes::DataType;
+    use crate::datatypes::ArrowDataType;
     use crate::legacy::kernels::rolling::nulls::mean::rolling_mean;
 
     fn get_null_arr() -> PrimitiveArray<f64> {
         // 1, None, -1, 4
         let buf = Buffer::from(vec![1.0, 0.0, -1.0, 4.0]);
         PrimitiveArray::new(
-            DataType::Float64,
+            ArrowDataType::Float64,
             buf,
             Some(Bitmap::from(&[true, false, true, true])),
         )
@@ -110,7 +110,7 @@ mod test {
     fn test_rolling_sum_nulls() {
         let buf = Buffer::from(vec![1.0, 2.0, 3.0, 4.0]);
         let arr = &PrimitiveArray::new(
-            DataType::Float64,
+            ArrowDataType::Float64,
             buf,
             Some(Bitmap::from(&[true, false, true, true])),
         );
@@ -207,7 +207,7 @@ mod test {
     fn test_rolling_max_no_nulls() {
         let buf = Buffer::from(vec![1.0, 2.0, 3.0, 4.0]);
         let arr = &PrimitiveArray::new(
-            DataType::Float64,
+            ArrowDataType::Float64,
             buf,
             Some(Bitmap::from(&[true, true, true, true])),
         );
@@ -228,7 +228,7 @@ mod test {
 
         let buf = Buffer::from(vec![4.0, 3.0, 2.0, 1.0]);
         let arr = &PrimitiveArray::new(
-            DataType::Float64,
+            ArrowDataType::Float64,
             buf,
             Some(Bitmap::from(&[true, true, true, true])),
         );
@@ -253,7 +253,7 @@ mod test {
         let window_size = 3;
         let min_periods = 3;
 
-        let arr = Int32Array::new(DataType::Int32, vals.into(), Some(validity.into()));
+        let arr = Int32Array::new(ArrowDataType::Int32, vals.into(), Some(validity.into()));
 
         let out = rolling_apply_agg_window::<MaxWindow<_>, _, _>(
             arr.values().as_slice(),

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/quantile.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/quantile.rs
@@ -140,14 +140,14 @@ where
 mod test {
     use super::*;
     use crate::buffer::Buffer;
-    use crate::datatypes::DataType;
+    use crate::datatypes::ArrowDataType;
     use crate::legacy::kernels::rolling::nulls::{rolling_max, rolling_min};
 
     #[test]
     fn test_rolling_median_nulls() {
         let buf = Buffer::from(vec![1.0, 2.0, 3.0, 4.0]);
         let arr = &PrimitiveArray::new(
-            DataType::Float64,
+            ArrowDataType::Float64,
             buf,
             Some(Bitmap::from(&[true, false, true, true])),
         );
@@ -187,7 +187,7 @@ mod test {
         // compare quantiles to corresponding min/max/median values
         let buf = Buffer::<f64>::from(vec![1.0, 2.0, 3.0, 4.0, 5.0]);
         let values = &PrimitiveArray::new(
-            DataType::Float64,
+            ArrowDataType::Float64,
             buf,
             Some(Bitmap::from(&[true, false, false, true, true])),
         );

--- a/crates/polars-arrow/src/legacy/kernels/set.rs
+++ b/crates/polars-arrow/src/legacy/kernels/set.rs
@@ -3,7 +3,7 @@ use std::ops::BitOr;
 use polars_error::polars_err;
 
 use crate::array::*;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::legacy::array::default_arrays::FromData;
 use crate::legacy::error::PolarsResult;
 use crate::legacy::index::IdxSize;
@@ -42,7 +42,7 @@ pub fn set_with_mask<T: NativeType>(
     array: &PrimitiveArray<T>,
     mask: &BooleanArray,
     value: T,
-    data_type: DataType,
+    data_type: ArrowDataType,
 ) -> PrimitiveArray<T> {
     let values = array.values();
 
@@ -70,7 +70,7 @@ pub fn set_at_idx_no_null<T, I>(
     array: &PrimitiveArray<T>,
     idx: I,
     set_value: T,
-    data_type: DataType,
+    data_type: ArrowDataType,
 ) -> PolarsResult<PrimitiveArray<T>>
 where
     T: NativeType,
@@ -106,7 +106,7 @@ mod test {
     fn test_set_mask() {
         let mask = BooleanArray::from_iter((0..86).map(|v| v > 68 && v != 85).map(Some));
         let val = UInt32Array::from_iter((0..86).map(Some));
-        let a = set_with_mask(&val, &mask, 100, DataType::UInt32);
+        let a = set_with_mask(&val, &mask, 100, ArrowDataType::UInt32);
         let slice = a.values();
 
         assert_eq!(slice[a.len() - 1], 85);
@@ -120,12 +120,12 @@ mod test {
             false, true, false, true, false, true, false, true, false, false,
         ]);
         let val = UInt32Array::from_slice([0; 10]);
-        let out = set_with_mask(&val, &mask, 1, DataType::UInt32);
+        let out = set_with_mask(&val, &mask, 1, ArrowDataType::UInt32);
         assert_eq!(out.values().as_slice(), &[0, 1, 0, 1, 0, 1, 0, 1, 0, 0]);
 
         let val = UInt32Array::from(&[None, None, None]);
         let mask = BooleanArray::from(&[Some(true), Some(true), None]);
-        let out = set_with_mask(&val, &mask, 1, DataType::UInt32);
+        let out = set_with_mask(&val, &mask, 1, ArrowDataType::UInt32);
         let out: Vec<_> = out.iter().map(|v| v.copied()).collect();
         assert_eq!(out, &[Some(1), Some(1), None])
     }
@@ -133,9 +133,9 @@ mod test {
     #[test]
     fn test_set_at_idx() {
         let val = UInt32Array::from_slice([1, 2, 3]);
-        let out = set_at_idx_no_null(&val, std::iter::once(1), 100, DataType::UInt32).unwrap();
+        let out = set_at_idx_no_null(&val, std::iter::once(1), 100, ArrowDataType::UInt32).unwrap();
         assert_eq!(out.values().as_slice(), &[1, 100, 3]);
-        let out = set_at_idx_no_null(&val, std::iter::once(100), 100, DataType::UInt32);
+        let out = set_at_idx_no_null(&val, std::iter::once(100), 100, ArrowDataType::UInt32);
         assert!(out.is_err())
     }
 }

--- a/crates/polars-arrow/src/legacy/kernels/string.rs
+++ b/crates/polars-arrow/src/legacy/kernels/string.rs
@@ -1,6 +1,6 @@
 use crate::array::{UInt32Array, Utf8Array};
 use crate::buffer::Buffer;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::legacy::prelude::*;
 use crate::legacy::trusted_len::TrustedLenPush;
 
@@ -11,13 +11,13 @@ pub fn string_len_bytes(array: &Utf8Array<i64>) -> ArrayRef {
         .windows(2)
         .map(|x| (x[1] - x[0]) as u32);
     let values: Buffer<_> = Vec::from_trusted_len_iter(values).into();
-    let array = UInt32Array::new(DataType::UInt32, values, array.validity().cloned());
+    let array = UInt32Array::new(ArrowDataType::UInt32, values, array.validity().cloned());
     Box::new(array)
 }
 
 pub fn string_len_chars(array: &Utf8Array<i64>) -> ArrayRef {
     let values = array.values_iter().map(|x| x.chars().count() as u32);
     let values: Buffer<_> = Vec::from_trusted_len_iter(values).into();
-    let array = UInt32Array::new(DataType::UInt32, values, array.validity().cloned());
+    let array = UInt32Array::new(ArrowDataType::UInt32, values, array.validity().cloned());
     Box::new(array)
 }

--- a/crates/polars-arrow/src/legacy/trusted_len/boolean.rs
+++ b/crates/polars-arrow/src/legacy/trusted_len/boolean.rs
@@ -1,6 +1,6 @@
 use crate::array::BooleanArray;
 use crate::bitmap::MutableBitmap;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::legacy::array::default_arrays::FromData;
 use crate::legacy::bit_util::{set_bit_raw, unset_bit_raw};
 use crate::legacy::trusted_len::{FromIteratorReversed, TrustedLen};
@@ -47,7 +47,7 @@ impl FromIteratorReversed<bool> for BooleanArray {
                 }
             });
         }
-        BooleanArray::new(DataType::Boolean, vals.into(), None)
+        BooleanArray::new(ArrowDataType::Boolean, vals.into(), None)
     }
 }
 
@@ -79,6 +79,6 @@ impl FromIteratorReversed<Option<bool>> for BooleanArray {
                 }
             });
         }
-        BooleanArray::new(DataType::Boolean, vals.into(), Some(validity.into()))
+        BooleanArray::new(ArrowDataType::Boolean, vals.into(), Some(validity.into()))
     }
 }

--- a/crates/polars-arrow/src/legacy/utils.rs
+++ b/crates/polars-arrow/src/legacy/utils.rs
@@ -2,7 +2,7 @@ use std::ops::{BitAnd, BitOr};
 
 use crate::array::PrimitiveArray;
 use crate::bitmap::{Bitmap, MutableBitmap};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::legacy::bit_util::unset_bit_raw;
 use crate::legacy::trusted_len::{FromIteratorReversed, TrustedLen, TrustedLenPush};
 use crate::types::NativeType;
@@ -177,7 +177,7 @@ impl<T: NativeType> FromIteratorReversed<T> for PrimitiveArray<T> {
             });
             vals.set_len(size)
         }
-        PrimitiveArray::new(DataType::from(T::PRIMITIVE), vals.into(), None)
+        PrimitiveArray::new(ArrowDataType::from(T::PRIMITIVE), vals.into(), None)
     }
 }
 
@@ -210,7 +210,7 @@ impl<T: NativeType> FromIteratorReversed<Option<T>> for PrimitiveArray<T> {
             vals.set_len(size)
         }
         PrimitiveArray::new(
-            DataType::from(T::PRIMITIVE),
+            ArrowDataType::from(T::PRIMITIVE),
             vals.into(),
             Some(validity.into()),
         )

--- a/crates/polars-arrow/src/mmap/array.rs
+++ b/crates/polars-arrow/src/mmap/array.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use polars_error::{polars_bail, polars_err, PolarsResult};
 
 use crate::array::{Array, DictionaryKey, FixedSizeListArray, ListArray, StructArray};
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::ffi::mmap::create_array;
 use crate::ffi::{export_array_to_c, try_from, ArrowArray, InternalArrowArray};
 use crate::io::ipc::read::{Dictionaries, IpcBuffer, Node, OutOfSpecKind};
@@ -120,9 +120,9 @@ fn mmap_fixed_size_binary<T: AsRef<[u8]>>(
     node: &Node,
     block_offset: usize,
     buffers: &mut VecDeque<IpcBuffer>,
-    data_type: &DataType,
+    data_type: &ArrowDataType,
 ) -> PolarsResult<ArrowArray> {
-    let bytes_per_row = if let DataType::FixedSizeBinary(bytes_per_row) = data_type {
+    let bytes_per_row = if let ArrowDataType::FixedSizeBinary(bytes_per_row) = data_type {
         bytes_per_row
     } else {
         polars_bail!(ComputeError: "out-of-spec {:?}", OutOfSpecKind::InvalidDataType);
@@ -231,7 +231,7 @@ fn mmap_list<O: Offset, T: AsRef<[u8]>>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     ipc_field: &IpcField,
     dictionaries: &Dictionaries,
     field_nodes: &mut VecDeque<Node>,
@@ -275,7 +275,7 @@ fn mmap_fixed_size_list<T: AsRef<[u8]>>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     ipc_field: &IpcField,
     dictionaries: &Dictionaries,
     field_nodes: &mut VecDeque<Node>,
@@ -318,7 +318,7 @@ fn mmap_struct<T: AsRef<[u8]>>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     ipc_field: &IpcField,
     dictionaries: &Dictionaries,
     field_nodes: &mut VecDeque<Node>,
@@ -366,7 +366,7 @@ fn mmap_dict<K: DictionaryKey, T: AsRef<[u8]>>(
     data: Arc<T>,
     node: &Node,
     block_offset: usize,
-    _: &DataType,
+    _: &ArrowDataType,
     ipc_field: &IpcField,
     dictionaries: &Dictionaries,
     _: &mut VecDeque<Node>,
@@ -401,7 +401,7 @@ fn mmap_dict<K: DictionaryKey, T: AsRef<[u8]>>(
 fn get_array<T: AsRef<[u8]>>(
     data: Arc<T>,
     block_offset: usize,
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     ipc_field: &IpcField,
     dictionaries: &Dictionaries,
     field_nodes: &mut VecDeque<Node>,
@@ -481,7 +481,7 @@ fn get_array<T: AsRef<[u8]>>(
 pub(crate) unsafe fn mmap<T: AsRef<[u8]>>(
     data: Arc<T>,
     block_offset: usize,
-    data_type: DataType,
+    data_type: ArrowDataType,
     ipc_field: &IpcField,
     dictionaries: &Dictionaries,
     field_nodes: &mut VecDeque<Node>,

--- a/crates/polars-arrow/src/mmap/mod.rs
+++ b/crates/polars-arrow/src/mmap/mod.rs
@@ -10,7 +10,7 @@ use polars_error::{polars_bail, polars_err, to_compute_err, PolarsResult};
 
 use crate::array::Array;
 use crate::chunk::Chunk;
-use crate::datatypes::{DataType, Field};
+use crate::datatypes::{ArrowDataType, Field};
 use crate::io::ipc::read::file::{get_dictionary_batch, get_record_batch};
 use crate::io::ipc::read::{
     first_dict_field, Dictionaries, FileMetadata, IpcBuffer, Node, OutOfSpecKind,
@@ -170,7 +170,7 @@ unsafe fn mmap_dictionary<T: AsRef<[u8]>>(
         .map_err(|err| polars_err!(ComputeError: "out-of-spec {:?}", OutOfSpecKind::InvalidFlatbufferData(err)))?
         .ok_or_else(|| polars_err!(ComputeError: "out-of-spec {:?}", OutOfSpecKind::MissingData))?;
 
-    let value_type = if let DataType::Dictionary(_, value_type, _) =
+    let value_type = if let ArrowDataType::Dictionary(_, value_type, _) =
         first_field.data_type.to_logical_type()
     {
         value_type.as_ref()

--- a/crates/polars-arrow/src/scalar/binary.rs
+++ b/crates/polars-arrow/src/scalar/binary.rs
@@ -1,5 +1,5 @@
 use super::Scalar;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::Offset;
 
 /// The [`Scalar`] implementation of binary ([`Option<Vec<u8>>`]).
@@ -45,11 +45,11 @@ impl<O: Offset> Scalar for BinaryScalar<O> {
     }
 
     #[inline]
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         if O::IS_LARGE {
-            &DataType::LargeBinary
+            &ArrowDataType::LargeBinary
         } else {
-            &DataType::Binary
+            &ArrowDataType::Binary
         }
     }
 }

--- a/crates/polars-arrow/src/scalar/boolean.rs
+++ b/crates/polars-arrow/src/scalar/boolean.rs
@@ -1,5 +1,5 @@
 use super::Scalar;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// The [`Scalar`] implementation of a boolean.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -33,8 +33,8 @@ impl Scalar for BooleanScalar {
     }
 
     #[inline]
-    fn data_type(&self) -> &DataType {
-        &DataType::Boolean
+    fn data_type(&self) -> &ArrowDataType {
+        &ArrowDataType::Boolean
     }
 }
 

--- a/crates/polars-arrow/src/scalar/dictionary.rs
+++ b/crates/polars-arrow/src/scalar/dictionary.rs
@@ -2,14 +2,14 @@ use std::any::Any;
 
 use super::Scalar;
 use crate::array::*;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// The [`DictionaryArray`] equivalent of [`Array`] for [`Scalar`].
 #[derive(Debug, Clone)]
 pub struct DictionaryScalar<K: DictionaryKey> {
     value: Option<Box<dyn Scalar>>,
     phantom: std::marker::PhantomData<K>,
-    data_type: DataType,
+    data_type: ArrowDataType,
 }
 
 impl<K: DictionaryKey> PartialEq for DictionaryScalar<K> {
@@ -25,7 +25,7 @@ impl<K: DictionaryKey> DictionaryScalar<K> {
     /// * the `data_type` is not `List` or `LargeList` (depending on this scalar's offset `O`)
     /// * the child of the `data_type` is not equal to the `values`
     #[inline]
-    pub fn new(data_type: DataType, value: Option<Box<dyn Scalar>>) -> Self {
+    pub fn new(data_type: ArrowDataType, value: Option<Box<dyn Scalar>>) -> Self {
         Self {
             value,
             phantom: std::marker::PhantomData,
@@ -48,7 +48,7 @@ impl<K: DictionaryKey> Scalar for DictionaryScalar<K> {
         self.value.is_some()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 }

--- a/crates/polars-arrow/src/scalar/fixed_size_binary.rs
+++ b/crates/polars-arrow/src/scalar/fixed_size_binary.rs
@@ -1,11 +1,11 @@
 use super::Scalar;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// The [`Scalar`] implementation of fixed size binary ([`Option<Box<[u8]>>`]).
 pub struct FixedSizeBinaryScalar {
     value: Option<Box<[u8]>>,
-    data_type: DataType,
+    data_type: ArrowDataType,
 }
 
 impl FixedSizeBinaryScalar {
@@ -15,7 +15,7 @@ impl FixedSizeBinaryScalar {
     /// * the `data_type` is not `FixedSizeBinary`
     /// * the size of child binary is not equal
     #[inline]
-    pub fn new<P: Into<Vec<u8>>>(data_type: DataType, value: Option<P>) -> Self {
+    pub fn new<P: Into<Vec<u8>>>(data_type: ArrowDataType, value: Option<P>) -> Self {
         assert_eq!(
             data_type.to_physical_type(),
             crate::datatypes::PhysicalType::FixedSizeBinary
@@ -25,7 +25,7 @@ impl FixedSizeBinaryScalar {
                 let x: Vec<u8> = x.into();
                 assert_eq!(
                     data_type.to_logical_type(),
-                    &DataType::FixedSizeBinary(x.len())
+                    &ArrowDataType::FixedSizeBinary(x.len())
                 );
                 x.into_boxed_slice()
             }),
@@ -52,7 +52,7 @@ impl Scalar for FixedSizeBinaryScalar {
     }
 
     #[inline]
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 }

--- a/crates/polars-arrow/src/scalar/fixed_size_list.rs
+++ b/crates/polars-arrow/src/scalar/fixed_size_list.rs
@@ -2,14 +2,14 @@ use std::any::Any;
 
 use super::Scalar;
 use crate::array::*;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// The scalar equivalent of [`FixedSizeListArray`]. Like [`FixedSizeListArray`], this struct holds a dynamically-typed
 /// [`Array`]. The only difference is that this has only one element.
 #[derive(Debug, Clone)]
 pub struct FixedSizeListScalar {
     values: Option<Box<dyn Array>>,
-    data_type: DataType,
+    data_type: ArrowDataType,
 }
 
 impl PartialEq for FixedSizeListScalar {
@@ -28,7 +28,7 @@ impl FixedSizeListScalar {
     /// * the child of the `data_type` is not equal to the `values`
     /// * the size of child array is not equal
     #[inline]
-    pub fn new(data_type: DataType, values: Option<Box<dyn Array>>) -> Self {
+    pub fn new(data_type: ArrowDataType, values: Option<Box<dyn Array>>) -> Self {
         let (field, size) = FixedSizeListArray::get_child_and_size(&data_type);
         let inner_data_type = field.data_type();
         let values = values.map(|x| {
@@ -54,7 +54,7 @@ impl Scalar for FixedSizeListScalar {
         self.values.is_some()
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 }

--- a/crates/polars-arrow/src/scalar/list.rs
+++ b/crates/polars-arrow/src/scalar/list.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use super::Scalar;
 use crate::array::*;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::Offset;
 
 /// The scalar equivalent of [`ListArray`]. Like [`ListArray`], this struct holds a dynamically-typed
@@ -12,7 +12,7 @@ pub struct ListScalar<O: Offset> {
     values: Box<dyn Array>,
     is_valid: bool,
     phantom: std::marker::PhantomData<O>,
-    data_type: DataType,
+    data_type: ArrowDataType,
 }
 
 impl<O: Offset> PartialEq for ListScalar<O> {
@@ -30,7 +30,7 @@ impl<O: Offset> ListScalar<O> {
     /// * the `data_type` is not `List` or `LargeList` (depending on this scalar's offset `O`)
     /// * the child of the `data_type` is not equal to the `values`
     #[inline]
-    pub fn new(data_type: DataType, values: Option<Box<dyn Array>>) -> Self {
+    pub fn new(data_type: ArrowDataType, values: Option<Box<dyn Array>>) -> Self {
         let inner_data_type = ListArray::<O>::get_child_type(&data_type);
         let (is_valid, values) = match values {
             Some(values) => {
@@ -62,7 +62,7 @@ impl<O: Offset> Scalar for ListScalar<O> {
         self.is_valid
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 }

--- a/crates/polars-arrow/src/scalar/map.rs
+++ b/crates/polars-arrow/src/scalar/map.rs
@@ -2,7 +2,7 @@ use std::any::Any;
 
 use super::Scalar;
 use crate::array::*;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// The scalar equivalent of [`MapArray`]. Like [`MapArray`], this struct holds a dynamically-typed
 /// [`Array`]. The only difference is that this has only one element.
@@ -10,7 +10,7 @@ use crate::datatypes::DataType;
 pub struct MapScalar {
     values: Box<dyn Array>,
     is_valid: bool,
-    data_type: DataType,
+    data_type: ArrowDataType,
 }
 
 impl PartialEq for MapScalar {
@@ -28,7 +28,7 @@ impl MapScalar {
     /// * the `data_type` is not `Map`
     /// * the child of the `data_type` is not equal to the `values`
     #[inline]
-    pub fn new(data_type: DataType, values: Option<Box<dyn Array>>) -> Self {
+    pub fn new(data_type: ArrowDataType, values: Option<Box<dyn Array>>) -> Self {
         let inner_field = MapArray::try_get_field(&data_type).unwrap();
         let inner_data_type = inner_field.data_type();
         let (is_valid, values) = match values {
@@ -60,7 +60,7 @@ impl Scalar for MapScalar {
         self.is_valid
     }
 
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 }

--- a/crates/polars-arrow/src/scalar/mod.rs
+++ b/crates/polars-arrow/src/scalar/mod.rs
@@ -33,7 +33,7 @@ pub use union::UnionScalar;
 
 use crate::{match_integer_type, with_match_primitive_type};
 
-/// Trait object declaring an optional value with a [`DataType`].
+/// Trait object declaring an optional value with a [`ArrowDataType`].
 /// This strait is often used in APIs that accept multiple scalar types.
 pub trait Scalar: std::fmt::Debug + Send + Sync + dyn_clone::DynClone + 'static {
     /// convert itself to
@@ -43,7 +43,7 @@ pub trait Scalar: std::fmt::Debug + Send + Sync + dyn_clone::DynClone + 'static 
     fn is_valid(&self) -> bool;
 
     /// the logical type.
-    fn data_type(&self) -> &DataType;
+    fn data_type(&self) -> &ArrowDataType;
 }
 
 dyn_clone::clone_trait_object!(Scalar);

--- a/crates/polars-arrow/src/scalar/null.rs
+++ b/crates/polars-arrow/src/scalar/null.rs
@@ -1,5 +1,5 @@
 use super::Scalar;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// The representation of a single entry of a [`crate::array::NullArray`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,7 +31,7 @@ impl Scalar for NullScalar {
     }
 
     #[inline]
-    fn data_type(&self) -> &DataType {
-        &DataType::Null
+    fn data_type(&self) -> &ArrowDataType {
+        &ArrowDataType::Null
     }
 }

--- a/crates/polars-arrow/src/scalar/primitive.rs
+++ b/crates/polars-arrow/src/scalar/primitive.rs
@@ -1,19 +1,19 @@
 use super::Scalar;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::types::NativeType;
 
 /// The implementation of [`Scalar`] for primitive, semantically equivalent to [`Option<T>`]
-/// with [`DataType`].
+/// with [`ArrowDataType`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrimitiveScalar<T: NativeType> {
     value: Option<T>,
-    data_type: DataType,
+    data_type: ArrowDataType,
 }
 
 impl<T: NativeType> PrimitiveScalar<T> {
     /// Returns a new [`PrimitiveScalar`].
     #[inline]
-    pub fn new(data_type: DataType, value: Option<T>) -> Self {
+    pub fn new(data_type: ArrowDataType, value: Option<T>) -> Self {
         if !data_type.to_physical_type().eq_primitive(T::PRIMITIVE) {
             panic!(
                 "Type {} does not support logical type {:?}",
@@ -30,10 +30,10 @@ impl<T: NativeType> PrimitiveScalar<T> {
         &self.value
     }
 
-    /// Returns a new `PrimitiveScalar` with the same value but different [`DataType`]
+    /// Returns a new `PrimitiveScalar` with the same value but different [`ArrowDataType`]
     /// # Panic
     /// This function panics if the `data_type` is not valid for self's physical type `T`.
-    pub fn to(self, data_type: DataType) -> Self {
+    pub fn to(self, data_type: ArrowDataType) -> Self {
         Self::new(data_type, self.value)
     }
 }
@@ -57,7 +57,7 @@ impl<T: NativeType> Scalar for PrimitiveScalar<T> {
     }
 
     #[inline]
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 }

--- a/crates/polars-arrow/src/scalar/struct_.rs
+++ b/crates/polars-arrow/src/scalar/struct_.rs
@@ -1,12 +1,12 @@
 use super::Scalar;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// A single entry of a [`crate::array::StructArray`].
 #[derive(Debug, Clone)]
 pub struct StructScalar {
     values: Vec<Box<dyn Scalar>>,
     is_valid: bool,
-    data_type: DataType,
+    data_type: ArrowDataType,
 }
 
 impl PartialEq for StructScalar {
@@ -20,7 +20,7 @@ impl PartialEq for StructScalar {
 impl StructScalar {
     /// Returns a new [`StructScalar`]
     #[inline]
-    pub fn new(data_type: DataType, values: Option<Vec<Box<dyn Scalar>>>) -> Self {
+    pub fn new(data_type: ArrowDataType, values: Option<Vec<Box<dyn Scalar>>>) -> Self {
         let is_valid = values.is_some();
         Self {
             values: values.unwrap_or_default(),
@@ -48,7 +48,7 @@ impl Scalar for StructScalar {
     }
 
     #[inline]
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 }

--- a/crates/polars-arrow/src/scalar/union.rs
+++ b/crates/polars-arrow/src/scalar/union.rs
@@ -1,18 +1,18 @@
 use super::Scalar;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 
 /// A single entry of a [`crate::array::UnionArray`].
 #[derive(Debug, Clone, PartialEq)]
 pub struct UnionScalar {
     value: Box<dyn Scalar>,
     type_: i8,
-    data_type: DataType,
+    data_type: ArrowDataType,
 }
 
 impl UnionScalar {
     /// Returns a new [`UnionScalar`]
     #[inline]
-    pub fn new(data_type: DataType, type_: i8, value: Box<dyn Scalar>) -> Self {
+    pub fn new(data_type: ArrowDataType, type_: i8, value: Box<dyn Scalar>) -> Self {
         Self {
             value,
             type_,
@@ -45,7 +45,7 @@ impl Scalar for UnionScalar {
     }
 
     #[inline]
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 }

--- a/crates/polars-arrow/src/scalar/utf8.rs
+++ b/crates/polars-arrow/src/scalar/utf8.rs
@@ -1,5 +1,5 @@
 use super::Scalar;
-use crate::datatypes::DataType;
+use crate::datatypes::ArrowDataType;
 use crate::offset::Offset;
 
 /// The implementation of [`Scalar`] for utf8, semantically equivalent to [`Option<String>`].
@@ -45,11 +45,11 @@ impl<O: Offset> Scalar for Utf8Scalar<O> {
     }
 
     #[inline]
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         if O::IS_LARGE {
-            &DataType::LargeUtf8
+            &ArrowDataType::LargeUtf8
         } else {
-            &DataType::Utf8
+            &ArrowDataType::Utf8
         }
     }
 }

--- a/crates/polars-arrow/src/temporal_conversions.rs
+++ b/crates/polars-arrow/src/temporal_conversions.rs
@@ -5,7 +5,7 @@ use chrono::{Datelike, Duration, FixedOffset, NaiveDate, NaiveDateTime, NaiveTim
 use polars_error::{polars_err, PolarsResult};
 
 use crate::array::{PrimitiveArray, Utf8Array};
-use crate::datatypes::{DataType, TimeUnit};
+use crate::datatypes::{ArrowDataType, TimeUnit};
 use crate::offset::Offset;
 use crate::types::months_days_ns;
 
@@ -380,7 +380,8 @@ fn utf8_to_timestamp_impl<O: Offset, T: chrono::TimeZone>(
         .iter()
         .map(|x| x.and_then(|x| utf8_to_timestamp_scalar(x, fmt, &tz, &time_unit)));
 
-    PrimitiveArray::from_trusted_len_iter(iter).to(DataType::Timestamp(time_unit, Some(time_zone)))
+    PrimitiveArray::from_trusted_len_iter(iter)
+        .to(ArrowDataType::Timestamp(time_unit, Some(time_zone)))
 }
 
 /// Parses `value` to a [`chrono_tz::Tz`] with the Arrow's definition of timestamp with a timezone.
@@ -450,7 +451,7 @@ pub fn utf8_to_naive_timestamp<O: Offset>(
         .iter()
         .map(|x| x.and_then(|x| utf8_to_naive_timestamp_scalar(x, fmt, &time_unit)));
 
-    PrimitiveArray::from_trusted_len_iter(iter).to(DataType::Timestamp(time_unit, None))
+    PrimitiveArray::from_trusted_len_iter(iter).to(ArrowDataType::Timestamp(time_unit, None))
 }
 
 fn add_month(year: i32, month: u32, months: i32) -> chrono::NaiveDate {

--- a/crates/polars-core/src/datatypes/_serde.rs
+++ b/crates/polars-core/src/datatypes/_serde.rs
@@ -3,7 +3,7 @@
 //!
 //! We could use [serde_1712](https://github.com/serde-rs/serde/issues/1712), but that gave problems caused by
 //! [rust_96956](https://github.com/rust-lang/rust/issues/96956), so we make a dummy type without static
-pub use arrow::datatypes::DataType as ArrowDataType;
+pub use arrow::datatypes::ArrowDataType;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::*;

--- a/crates/polars-core/src/datatypes/field.rs
+++ b/crates/polars-core/src/datatypes/field.rs
@@ -103,7 +103,7 @@ impl Field {
     /// ```rust
     /// # use polars_core::prelude::*;
     /// let f = Field::new("Value", DataType::Int64);
-    /// let af = arrow::datatypes::Field::new("Value", arrow::datatypes::DataType::Int64, true);
+    /// let af = arrow::datatypes::Field::new("Value", arrow::datatypes::ArrowDataType::Int64, true);
     ///
     /// assert_eq!(f.to_arrow(), af);
     /// ```

--- a/crates/polars-core/src/datatypes/mod.rs
+++ b/crates/polars-core/src/datatypes/mod.rs
@@ -26,7 +26,7 @@ pub use any_value::*;
 use arrow::compute::comparison::Simd8;
 #[cfg(feature = "dtype-categorical")]
 use arrow::datatypes::IntegerType;
-pub use arrow::datatypes::{DataType as ArrowDataType, TimeUnit as ArrowTimeUnit};
+pub use arrow::datatypes::{ArrowDataType, TimeUnit as ArrowTimeUnit};
 use arrow::legacy::data_types::IsFloat;
 use arrow::types::simd::Simd;
 use arrow::types::NativeType;

--- a/crates/polars-core/src/datatypes/static_array_collect.rs
+++ b/crates/polars-core/src/datatypes/static_array_collect.rs
@@ -484,7 +484,7 @@ impl<T: IntoBytes> ArrayFromIter<Option<T>> for BinaryArray<i64> {
 unsafe fn into_utf8array(arr: BinaryArray<i64>) -> Utf8Array<i64> {
     unsafe {
         let (_dt, offsets, values, validity) = arr.into_inner();
-        let dt = arrow::datatypes::DataType::LargeUtf8;
+        let dt = arrow::datatypes::ArrowDataType::LargeUtf8;
         Utf8Array::try_new_unchecked(dt, offsets, values, validity).unwrap_unchecked()
     }
 }
@@ -637,7 +637,7 @@ macro_rules! impl_collect_bool_validity {
 
 impl ArrayFromIter<bool> for BooleanArray {
     fn arr_from_iter<I: IntoIterator<Item = bool>>(iter: I) -> Self {
-        let dt = arrow::datatypes::DataType::Boolean;
+        let dt = arrow::datatypes::ArrowDataType::Boolean;
         let (values, _valid) = impl_collect_bool_validity!(iter, x, x, x, false, false);
         BooleanArray::new(dt, values, None)
     }
@@ -646,7 +646,7 @@ impl ArrayFromIter<bool> for BooleanArray {
     // fn arr_from_iter_trusted<I>(iter: I) -> Self
 
     fn try_arr_from_iter<E, I: IntoIterator<Item = Result<bool, E>>>(iter: I) -> Result<Self, E> {
-        let dt = arrow::datatypes::DataType::Boolean;
+        let dt = arrow::datatypes::ArrowDataType::Boolean;
         let (values, _valid) = impl_collect_bool_validity!(iter, x, x?, x, false, false);
         Ok(BooleanArray::new(dt, values, None))
     }
@@ -656,7 +656,7 @@ impl ArrayFromIter<bool> for BooleanArray {
 
 impl ArrayFromIter<Option<bool>> for BooleanArray {
     fn arr_from_iter<I: IntoIterator<Item = Option<bool>>>(iter: I) -> Self {
-        let dt = arrow::datatypes::DataType::Boolean;
+        let dt = arrow::datatypes::ArrowDataType::Boolean;
         let (values, valid) =
             impl_collect_bool_validity!(iter, x, x, x.unwrap_or(false), x.is_some(), true);
         BooleanArray::new(dt, values, valid)
@@ -667,7 +667,7 @@ impl ArrayFromIter<Option<bool>> for BooleanArray {
     fn try_arr_from_iter<E, I: IntoIterator<Item = Result<Option<bool>, E>>>(
         iter: I,
     ) -> Result<Self, E> {
-        let dt = arrow::datatypes::DataType::Boolean;
+        let dt = arrow::datatypes::ArrowDataType::Boolean;
         let (values, valid) =
             impl_collect_bool_validity!(iter, x, x?, x.unwrap_or(false), x.is_some(), true);
         Ok(BooleanArray::new(dt, values, valid))

--- a/crates/polars-io/src/parquet/write.rs
+++ b/crates/polars-io/src/parquet/write.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use arrow::array::Array;
 use arrow::chunk::Chunk;
-use arrow::datatypes::{DataType as ArrowDataType, PhysicalType};
+use arrow::datatypes::{ArrowDataType, PhysicalType};
 use polars_core::prelude::*;
 use polars_core::utils::{accumulate_dataframes_vertical_unchecked, split_df};
 use polars_core::POOL;

--- a/crates/polars-json/src/json/deserialize.rs
+++ b/crates/polars-json/src/json/deserialize.rs
@@ -4,7 +4,7 @@ use std::fmt::Write;
 use arrow::array::*;
 use arrow::bitmap::MutableBitmap;
 use arrow::chunk::Chunk;
-use arrow::datatypes::{ArrowSchema, DataType, Field, IntervalUnit};
+use arrow::datatypes::{ArrowDataType, ArrowSchema, Field, IntervalUnit};
 use arrow::legacy::prelude::*;
 use arrow::offset::{Offset, Offsets};
 use arrow::temporal_conversions;
@@ -72,7 +72,7 @@ fn deserialize_utf8_into<'a, O: Offset, A: Borrow<BorrowedValue<'a>>>(
 
 fn deserialize_list<'a, A: Borrow<BorrowedValue<'a>>>(
     rows: &[A],
-    data_type: DataType,
+    data_type: ArrowDataType,
 ) -> ListArray<i64> {
     let child = ListArray::<i64>::get_child_type(&data_type);
 
@@ -156,23 +156,43 @@ fn deserialize_into<'a, A: Borrow<BorrowedValue<'a>>>(
     rows: &[A],
 ) {
     match target.data_type() {
-        DataType::Boolean => generic_deserialize_into(target, rows, deserialize_boolean_into),
-        DataType::Float32 => primitive_dispatch::<_, f32>(target, rows, deserialize_primitive_into),
-        DataType::Float64 => primitive_dispatch::<_, f64>(target, rows, deserialize_primitive_into),
-        DataType::Int8 => primitive_dispatch::<_, i8>(target, rows, deserialize_primitive_into),
-        DataType::Int16 => primitive_dispatch::<_, i16>(target, rows, deserialize_primitive_into),
-        DataType::Int32 => primitive_dispatch::<_, i32>(target, rows, deserialize_primitive_into),
-        DataType::Int64 => primitive_dispatch::<_, i64>(target, rows, deserialize_primitive_into),
-        DataType::UInt8 => primitive_dispatch::<_, u8>(target, rows, deserialize_primitive_into),
-        DataType::UInt16 => primitive_dispatch::<_, u16>(target, rows, deserialize_primitive_into),
-        DataType::UInt32 => primitive_dispatch::<_, u32>(target, rows, deserialize_primitive_into),
-        DataType::UInt64 => primitive_dispatch::<_, u64>(target, rows, deserialize_primitive_into),
-        DataType::LargeUtf8 => generic_deserialize_into::<_, MutableUtf8Array<i64>>(
+        ArrowDataType::Boolean => generic_deserialize_into(target, rows, deserialize_boolean_into),
+        ArrowDataType::Float32 => {
+            primitive_dispatch::<_, f32>(target, rows, deserialize_primitive_into)
+        },
+        ArrowDataType::Float64 => {
+            primitive_dispatch::<_, f64>(target, rows, deserialize_primitive_into)
+        },
+        ArrowDataType::Int8 => {
+            primitive_dispatch::<_, i8>(target, rows, deserialize_primitive_into)
+        },
+        ArrowDataType::Int16 => {
+            primitive_dispatch::<_, i16>(target, rows, deserialize_primitive_into)
+        },
+        ArrowDataType::Int32 => {
+            primitive_dispatch::<_, i32>(target, rows, deserialize_primitive_into)
+        },
+        ArrowDataType::Int64 => {
+            primitive_dispatch::<_, i64>(target, rows, deserialize_primitive_into)
+        },
+        ArrowDataType::UInt8 => {
+            primitive_dispatch::<_, u8>(target, rows, deserialize_primitive_into)
+        },
+        ArrowDataType::UInt16 => {
+            primitive_dispatch::<_, u16>(target, rows, deserialize_primitive_into)
+        },
+        ArrowDataType::UInt32 => {
+            primitive_dispatch::<_, u32>(target, rows, deserialize_primitive_into)
+        },
+        ArrowDataType::UInt64 => {
+            primitive_dispatch::<_, u64>(target, rows, deserialize_primitive_into)
+        },
+        ArrowDataType::LargeUtf8 => generic_deserialize_into::<_, MutableUtf8Array<i64>>(
             target,
             rows,
             deserialize_utf8_into,
         ),
-        DataType::LargeList(_) => deserialize_list_into(
+        ArrowDataType::LargeList(_) => deserialize_list_into(
             target
                 .as_mut_any()
                 .downcast_mut::<MutableListArray<i64, Box<dyn MutableArray>>>()
@@ -187,7 +207,7 @@ fn deserialize_into<'a, A: Borrow<BorrowedValue<'a>>>(
 
 fn deserialize_struct<'a, A: Borrow<BorrowedValue<'a>>>(
     rows: &[A],
-    data_type: DataType,
+    data_type: ArrowDataType,
 ) -> StructArray {
     let fields = StructArray::get_fields(&data_type);
 
@@ -229,7 +249,7 @@ fn deserialize_struct<'a, A: Borrow<BorrowedValue<'a>>>(
 
 fn fill_array_from<B, T, A>(
     f: fn(&mut MutablePrimitiveArray<T>, &[B]),
-    data_type: DataType,
+    data_type: ArrowDataType,
     rows: &[B],
 ) -> Box<dyn Array>
 where
@@ -298,42 +318,43 @@ where
 
 pub(crate) fn _deserialize<'a, A: Borrow<BorrowedValue<'a>>>(
     rows: &[A],
-    data_type: DataType,
+    data_type: ArrowDataType,
 ) -> Box<dyn Array> {
     match &data_type {
-        DataType::Null => Box::new(NullArray::new(data_type, rows.len())),
-        DataType::Boolean => {
+        ArrowDataType::Null => Box::new(NullArray::new(data_type, rows.len())),
+        ArrowDataType::Boolean => {
             fill_generic_array_from::<_, _, BooleanArray>(deserialize_boolean_into, rows)
         },
-        DataType::Int8 => {
+        ArrowDataType::Int8 => {
             fill_array_from::<_, _, PrimitiveArray<i8>>(deserialize_primitive_into, data_type, rows)
         },
-        DataType::Int16 => fill_array_from::<_, _, PrimitiveArray<i16>>(
+        ArrowDataType::Int16 => fill_array_from::<_, _, PrimitiveArray<i16>>(
             deserialize_primitive_into,
             data_type,
             rows,
         ),
-        DataType::Int32
-        | DataType::Date32
-        | DataType::Time32(_)
-        | DataType::Interval(IntervalUnit::YearMonth) => {
+        ArrowDataType::Int32
+        | ArrowDataType::Date32
+        | ArrowDataType::Time32(_)
+        | ArrowDataType::Interval(IntervalUnit::YearMonth) => {
             fill_array_from::<_, _, PrimitiveArray<i32>>(
                 deserialize_primitive_into,
                 data_type,
                 rows,
             )
         },
-        DataType::Interval(IntervalUnit::DayTime) => {
+        ArrowDataType::Interval(IntervalUnit::DayTime) => {
             unimplemented!("There is no natural representation of DayTime in JSON.")
         },
-        DataType::Int64 | DataType::Date64 | DataType::Time64(_) | DataType::Duration(_) => {
-            fill_array_from::<_, _, PrimitiveArray<i64>>(
-                deserialize_primitive_into,
-                data_type,
-                rows,
-            )
-        },
-        DataType::Timestamp(tu, tz) => {
+        ArrowDataType::Int64
+        | ArrowDataType::Date64
+        | ArrowDataType::Time64(_)
+        | ArrowDataType::Duration(_) => fill_array_from::<_, _, PrimitiveArray<i64>>(
+            deserialize_primitive_into,
+            data_type,
+            rows,
+        ),
+        ArrowDataType::Timestamp(tu, tz) => {
             let iter = rows.iter().map(|row| match row.borrow() {
                 BorrowedValue::Static(StaticNode::I64(v)) => Some(*v),
                 BorrowedValue::String(v) => match (tu, tz) {
@@ -347,49 +368,49 @@ pub(crate) fn _deserialize<'a, A: Borrow<BorrowedValue<'a>>>(
             });
             Box::new(Int64Array::from_iter(iter).to(data_type))
         },
-        DataType::UInt8 => {
+        ArrowDataType::UInt8 => {
             fill_array_from::<_, _, PrimitiveArray<u8>>(deserialize_primitive_into, data_type, rows)
         },
-        DataType::UInt16 => fill_array_from::<_, _, PrimitiveArray<u16>>(
+        ArrowDataType::UInt16 => fill_array_from::<_, _, PrimitiveArray<u16>>(
             deserialize_primitive_into,
             data_type,
             rows,
         ),
-        DataType::UInt32 => fill_array_from::<_, _, PrimitiveArray<u32>>(
+        ArrowDataType::UInt32 => fill_array_from::<_, _, PrimitiveArray<u32>>(
             deserialize_primitive_into,
             data_type,
             rows,
         ),
-        DataType::UInt64 => fill_array_from::<_, _, PrimitiveArray<u64>>(
+        ArrowDataType::UInt64 => fill_array_from::<_, _, PrimitiveArray<u64>>(
             deserialize_primitive_into,
             data_type,
             rows,
         ),
-        DataType::Float16 => unreachable!(),
-        DataType::Float32 => fill_array_from::<_, _, PrimitiveArray<f32>>(
+        ArrowDataType::Float16 => unreachable!(),
+        ArrowDataType::Float32 => fill_array_from::<_, _, PrimitiveArray<f32>>(
             deserialize_primitive_into,
             data_type,
             rows,
         ),
-        DataType::Float64 => fill_array_from::<_, _, PrimitiveArray<f64>>(
+        ArrowDataType::Float64 => fill_array_from::<_, _, PrimitiveArray<f64>>(
             deserialize_primitive_into,
             data_type,
             rows,
         ),
-        DataType::LargeUtf8 => {
+        ArrowDataType::LargeUtf8 => {
             fill_generic_array_from::<_, _, Utf8Array<i64>>(deserialize_utf8_into, rows)
         },
-        DataType::LargeList(_) => Box::new(deserialize_list(rows, data_type)),
-        DataType::LargeBinary => Box::new(deserialize_binary(rows)),
-        DataType::Struct(_) => Box::new(deserialize_struct(rows, data_type)),
+        ArrowDataType::LargeList(_) => Box::new(deserialize_list(rows, data_type)),
+        ArrowDataType::LargeBinary => Box::new(deserialize_binary(rows)),
+        ArrowDataType::Struct(_) => Box::new(deserialize_struct(rows, data_type)),
         _ => todo!(),
     }
 }
 
-pub fn deserialize(json: &BorrowedValue, data_type: DataType) -> PolarsResult<Box<dyn Array>> {
+pub fn deserialize(json: &BorrowedValue, data_type: ArrowDataType) -> PolarsResult<Box<dyn Array>> {
     match json {
         BorrowedValue::Array(rows) => match data_type {
-            DataType::LargeList(inner) => Ok(_deserialize(rows, inner.data_type)),
+            ArrowDataType::LargeList(inner) => Ok(_deserialize(rows, inner.data_type)),
             _ => todo!("read an Array from a non-Array data type"),
         },
         _ => Ok(_deserialize(&[json], data_type)),
@@ -398,19 +419,19 @@ pub fn deserialize(json: &BorrowedValue, data_type: DataType) -> PolarsResult<Bo
 
 fn allocate_array(f: &Field) -> Box<dyn MutableArray> {
     match f.data_type() {
-        DataType::Int8 => Box::new(MutablePrimitiveArray::<i8>::new()),
-        DataType::Int16 => Box::new(MutablePrimitiveArray::<i16>::new()),
-        DataType::Int32 => Box::new(MutablePrimitiveArray::<i32>::new()),
-        DataType::Int64 => Box::new(MutablePrimitiveArray::<i64>::new()),
-        DataType::UInt8 => Box::new(MutablePrimitiveArray::<u8>::new()),
-        DataType::UInt16 => Box::new(MutablePrimitiveArray::<u16>::new()),
-        DataType::UInt32 => Box::new(MutablePrimitiveArray::<u32>::new()),
-        DataType::UInt64 => Box::new(MutablePrimitiveArray::<u64>::new()),
-        DataType::Float16 => Box::new(MutablePrimitiveArray::<f16>::new()),
-        DataType::Float32 => Box::new(MutablePrimitiveArray::<f32>::new()),
-        DataType::Float64 => Box::new(MutablePrimitiveArray::<f64>::new()),
-        DataType::LargeList(inner) => match inner.data_type() {
-            DataType::LargeList(_) => Box::new(MutableListArray::<i64, _>::new_from(
+        ArrowDataType::Int8 => Box::new(MutablePrimitiveArray::<i8>::new()),
+        ArrowDataType::Int16 => Box::new(MutablePrimitiveArray::<i16>::new()),
+        ArrowDataType::Int32 => Box::new(MutablePrimitiveArray::<i32>::new()),
+        ArrowDataType::Int64 => Box::new(MutablePrimitiveArray::<i64>::new()),
+        ArrowDataType::UInt8 => Box::new(MutablePrimitiveArray::<u8>::new()),
+        ArrowDataType::UInt16 => Box::new(MutablePrimitiveArray::<u16>::new()),
+        ArrowDataType::UInt32 => Box::new(MutablePrimitiveArray::<u32>::new()),
+        ArrowDataType::UInt64 => Box::new(MutablePrimitiveArray::<u64>::new()),
+        ArrowDataType::Float16 => Box::new(MutablePrimitiveArray::<f16>::new()),
+        ArrowDataType::Float32 => Box::new(MutablePrimitiveArray::<f32>::new()),
+        ArrowDataType::Float64 => Box::new(MutablePrimitiveArray::<f64>::new()),
+        ArrowDataType::LargeList(inner) => match inner.data_type() {
+            ArrowDataType::LargeList(_) => Box::new(MutableListArray::<i64, _>::new_from(
                 allocate_array(inner),
                 inner.data_type().clone(),
                 0,
@@ -435,9 +456,9 @@ fn allocate_array(f: &Field) -> Box<dyn MutableArray> {
 ///
 /// * `json` is not an [`Array`]
 /// * `data_type` contains any incompatible types:
-///   * [`DataType::Struct`]
-///   * [`DataType::Dictionary`]
-///   * [`DataType::LargeList`]
+///   * [`ArrowDataType::Struct`]
+///   * [`ArrowDataType::Dictionary`]
+///   * [`ArrowDataType::LargeList`]
 pub fn deserialize_records(
     json: &BorrowedValue,
     schema: &ArrowSchema,

--- a/crates/polars-json/src/json/write/serialize.rs
+++ b/crates/polars-json/src/json/write/serialize.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use arrow::array::*;
 use arrow::bitmap::utils::ZipValidity;
-use arrow::datatypes::{DataType, IntegerType, TimeUnit};
+use arrow::datatypes::{ArrowDataType, IntegerType, TimeUnit};
 use arrow::io::iterator::BufStreamingIterator;
 use arrow::offset::Offset;
 #[cfg(feature = "chrono-tz")]
@@ -374,59 +374,59 @@ pub(crate) fn new_serializer<'a>(
     take: usize,
 ) -> Box<dyn StreamingIterator<Item = [u8]> + 'a + Send + Sync> {
     match array.data_type().to_logical_type() {
-        DataType::Boolean => {
+        ArrowDataType::Boolean => {
             boolean_serializer(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::Int8 => {
+        ArrowDataType::Int8 => {
             primitive_serializer::<i8>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::Int16 => {
+        ArrowDataType::Int16 => {
             primitive_serializer::<i16>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::Int32 => {
+        ArrowDataType::Int32 => {
             primitive_serializer::<i32>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::Int64 => {
+        ArrowDataType::Int64 => {
             primitive_serializer::<i64>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::UInt8 => {
+        ArrowDataType::UInt8 => {
             primitive_serializer::<u8>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::UInt16 => {
+        ArrowDataType::UInt16 => {
             primitive_serializer::<u16>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::UInt32 => {
+        ArrowDataType::UInt32 => {
             primitive_serializer::<u32>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::UInt64 => {
+        ArrowDataType::UInt64 => {
             primitive_serializer::<u64>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::Float32 => {
+        ArrowDataType::Float32 => {
             float_serializer::<f32>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::Float64 => {
+        ArrowDataType::Float64 => {
             float_serializer::<f64>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::Utf8 => {
+        ArrowDataType::Utf8 => {
             utf8_serializer::<i32>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::LargeUtf8 => {
+        ArrowDataType::LargeUtf8 => {
             utf8_serializer::<i64>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::Struct(_) => {
+        ArrowDataType::Struct(_) => {
             struct_serializer(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::FixedSizeList(_, _) => {
+        ArrowDataType::FixedSizeList(_, _) => {
             fixed_size_list_serializer(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::List(_) => {
+        ArrowDataType::List(_) => {
             list_serializer::<i32>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        DataType::LargeList(_) => {
+        ArrowDataType::LargeList(_) => {
             list_serializer::<i64>(array.as_any().downcast_ref().unwrap(), offset, take)
         },
-        other @ DataType::Dictionary(k, v, _) => match (k, &**v) {
-            (IntegerType::UInt32, DataType::LargeUtf8) => {
+        other @ ArrowDataType::Dictionary(k, v, _) => match (k, &**v) {
+            (IntegerType::UInt32, ArrowDataType::LargeUtf8) => {
                 let array = array
                     .as_any()
                     .downcast_ref::<DictionaryArray<u32>>()
@@ -437,19 +437,19 @@ pub(crate) fn new_serializer<'a>(
                 todo!("Writing {:?} to JSON", other)
             },
         },
-        DataType::Date32 => date_serializer(
+        ArrowDataType::Date32 => date_serializer(
             array.as_any().downcast_ref().unwrap(),
             date32_to_date,
             offset,
             take,
         ),
-        DataType::Date64 => date_serializer(
+        ArrowDataType::Date64 => date_serializer(
             array.as_any().downcast_ref().unwrap(),
             date64_to_date,
             offset,
             take,
         ),
-        DataType::Timestamp(tu, None) => {
+        ArrowDataType::Timestamp(tu, None) => {
             let convert = match tu {
                 TimeUnit::Nanosecond => timestamp_ns_to_datetime,
                 TimeUnit::Microsecond => timestamp_us_to_datetime,
@@ -463,14 +463,14 @@ pub(crate) fn new_serializer<'a>(
                 take,
             )
         },
-        DataType::Timestamp(time_unit, Some(tz)) => timestamp_tz_serializer(
+        ArrowDataType::Timestamp(time_unit, Some(tz)) => timestamp_tz_serializer(
             array.as_any().downcast_ref().unwrap(),
             *time_unit,
             tz,
             offset,
             take,
         ),
-        DataType::Duration(tu) => {
+        ArrowDataType::Duration(tu) => {
             let convert = match tu {
                 TimeUnit::Nanosecond => duration_ns_to_duration,
                 TimeUnit::Microsecond => duration_us_to_duration,
@@ -484,7 +484,7 @@ pub(crate) fn new_serializer<'a>(
                 take,
             )
         },
-        DataType::Null => null_serializer(array.len(), offset, take),
+        ArrowDataType::Null => null_serializer(array.len(), offset, take),
         other => todo!("Writing {:?} to JSON", other),
     }
 }

--- a/crates/polars-json/src/ndjson/deserialize.rs
+++ b/crates/polars-json/src/ndjson/deserialize.rs
@@ -13,7 +13,7 @@ use super::*;
 /// This function errors iff any of the rows is not a valid JSON (i.e. the format is not valid NDJSON).
 pub fn deserialize_iter<'a>(
     rows: impl Iterator<Item = &'a str>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     buf_size: usize,
     count: usize,
 ) -> PolarsResult<ArrayRef> {

--- a/crates/polars-json/src/ndjson/file.rs
+++ b/crates/polars-json/src/ndjson/file.rs
@@ -1,6 +1,6 @@
 use std::io::BufRead;
 
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use fallible_streaming_iterator::FallibleStreamingIterator;
 use indexmap::IndexSet;
 use polars_error::*;
@@ -92,7 +92,7 @@ fn parse_value<'a>(scratch: &'a mut Vec<u8>, val: &[u8]) -> PolarsResult<Borrowe
         .map_err(|e| PolarsError::ComputeError(format!("{e}").into()))
 }
 
-/// Infers the [`DataType`] from an NDJSON file, optionally only using `number_of_rows` rows.
+/// Infers the [`ArrowDataType`] from an NDJSON file, optionally only using `number_of_rows` rows.
 ///
 /// # Implementation
 /// This implementation reads the file line by line and infers the type of each line.
@@ -100,7 +100,7 @@ fn parse_value<'a>(scratch: &'a mut Vec<u8>, val: &[u8]) -> PolarsResult<Borrowe
 pub fn infer<R: std::io::BufRead>(
     reader: &mut R,
     number_of_rows: Option<usize>,
-) -> PolarsResult<DataType> {
+) -> PolarsResult<ArrowDataType> {
     if reader.fill_buf().map(|b| b.is_empty())? {
         return Err(PolarsError::ComputeError(
             "Cannot infer NDJSON types on empty reader because empty string is not a valid JSON value".into(),
@@ -117,32 +117,32 @@ pub fn infer<R: std::io::BufRead>(
         let value = parse_value(&mut buf, rows[0].as_bytes())?;
         let data_type = crate::json::infer(&value)?;
 
-        if data_type != DataType::Null {
+        if data_type != ArrowDataType::Null {
             data_types.insert(data_type);
         }
     }
 
-    let v: Vec<&DataType> = data_types.iter().collect();
+    let v: Vec<&ArrowDataType> = data_types.iter().collect();
     Ok(crate::json::infer_schema::coerce_data_type(&v))
 }
 
-/// Infers the [`DataType`] from an iterator of JSON strings. A limited number of
+/// Infers the [`ArrowDataType`] from an iterator of JSON strings. A limited number of
 /// rows can be used by passing `rows.take(number_of_rows)` as an input.
 ///
 /// # Implementation
 /// This implementation infers each row by going through the entire iterator.
-pub fn infer_iter<A: AsRef<str>>(rows: impl Iterator<Item = A>) -> PolarsResult<DataType> {
+pub fn infer_iter<A: AsRef<str>>(rows: impl Iterator<Item = A>) -> PolarsResult<ArrowDataType> {
     let mut data_types = IndexSet::<_, ahash::RandomState>::default();
 
     let mut buf = vec![];
     for row in rows {
         let v = parse_value(&mut buf, row.as_ref().as_bytes())?;
         let data_type = crate::json::infer(&v)?;
-        if data_type != DataType::Null {
+        if data_type != ArrowDataType::Null {
             data_types.insert(data_type);
         }
     }
 
-    let v: Vec<&DataType> = data_types.iter().collect();
+    let v: Vec<&ArrowDataType> = data_types.iter().collect();
     Ok(crate::json::infer_schema::coerce_data_type(&v))
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
@@ -3,7 +3,7 @@ use std::default::Default;
 
 use arrow::array::{Array, BinaryArray, Utf8Array};
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::{DataType, PhysicalType};
+use arrow::datatypes::{ArrowDataType, PhysicalType};
 use arrow::offset::Offset;
 use polars_error::{to_compute_err, PolarsResult};
 
@@ -441,7 +441,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
 }
 
 pub(super) fn finish<O: Offset>(
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     mut values: Binary<O>,
     mut validity: MutableBitmap,
 ) -> PolarsResult<Box<dyn Array>> {
@@ -470,7 +470,7 @@ pub(super) fn finish<O: Offset>(
 
 pub struct Iter<O: Offset, I: Pages> {
     iter: I,
-    data_type: DataType,
+    data_type: ArrowDataType,
     items: VecDeque<(Binary<O>, MutableBitmap)>,
     dict: Option<Dict>,
     chunk_size: Option<usize>,
@@ -478,7 +478,12 @@ pub struct Iter<O: Offset, I: Pages> {
 }
 
 impl<O: Offset, I: Pages> Iter<O, I> {
-    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>, num_rows: usize) -> Self {
+    pub fn new(
+        iter: I,
+        data_type: ArrowDataType,
+        chunk_size: Option<usize>,
+        num_rows: usize,
+    ) -> Self {
         Self {
             iter,
             data_type,

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/dictionary.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use arrow::array::{Array, BinaryArray, DictionaryArray, DictionaryKey, Utf8Array};
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::{DataType, PhysicalType};
+use arrow::datatypes::{ArrowDataType, PhysicalType};
 use arrow::offset::Offset;
 use polars_error::PolarsResult;
 
@@ -22,7 +22,7 @@ where
     K: DictionaryKey,
 {
     iter: I,
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Option<Box<dyn Array>>,
     items: VecDeque<(Vec<K>, MutableBitmap)>,
     remaining: usize,
@@ -36,7 +36,12 @@ where
     O: Offset,
     I: Pages,
 {
-    pub fn new(iter: I, data_type: DataType, num_rows: usize, chunk_size: Option<usize>) -> Self {
+    pub fn new(
+        iter: I,
+        data_type: ArrowDataType,
+        num_rows: usize,
+        chunk_size: Option<usize>,
+    ) -> Self {
         Self {
             iter,
             data_type,
@@ -49,9 +54,9 @@ where
     }
 }
 
-fn read_dict<O: Offset>(data_type: DataType, dict: &DictPage) -> Box<dyn Array> {
+fn read_dict<O: Offset>(data_type: ArrowDataType, dict: &DictPage) -> Box<dyn Array> {
     let data_type = match data_type {
-        DataType::Dictionary(_, values, _) => *values,
+        ArrowDataType::Dictionary(_, values, _) => *values,
         _ => data_type,
     };
 
@@ -111,7 +116,7 @@ where
 {
     iter: I,
     init: Vec<InitNested>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Option<Box<dyn Array>>,
     items: VecDeque<(NestedState, (Vec<K>, MutableBitmap))>,
     remaining: usize,
@@ -128,7 +133,7 @@ where
     pub fn new(
         iter: I,
         init: Vec<InitNested>,
-        data_type: DataType,
+        data_type: ArrowDataType,
         num_rows: usize,
         chunk_size: Option<usize>,
     ) -> Self {

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/nested.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use arrow::array::Array;
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use arrow::offset::Offset;
 use polars_error::PolarsResult;
 
@@ -138,7 +138,7 @@ impl<'a, O: Offset> NestedDecoder<'a> for BinaryDecoder<O> {
 
 pub struct NestedIter<O: Offset, I: Pages> {
     iter: I,
-    data_type: DataType,
+    data_type: ArrowDataType,
     init: Vec<InitNested>,
     items: VecDeque<(NestedState, (Binary<O>, MutableBitmap))>,
     dict: Option<Dict>,
@@ -150,7 +150,7 @@ impl<O: Offset, I: Pages> NestedIter<O, I> {
     pub fn new(
         iter: I,
         init: Vec<InitNested>,
-        data_type: DataType,
+        data_type: ArrowDataType,
         num_rows: usize,
         chunk_size: Option<usize>,
     ) -> Self {

--- a/crates/polars-parquet/src/arrow/read/deserialize/boolean/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/boolean/basic.rs
@@ -3,7 +3,7 @@ use std::collections::VecDeque;
 use arrow::array::BooleanArray;
 use arrow::bitmap::utils::BitmapIter;
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use polars_error::PolarsResult;
 
 use super::super::utils::{
@@ -183,7 +183,11 @@ impl<'a> Decoder<'a> for BooleanDecoder {
     fn deserialize_dict(&self, _: &DictPage) -> Self::Dict {}
 }
 
-fn finish(data_type: &DataType, values: MutableBitmap, validity: MutableBitmap) -> BooleanArray {
+fn finish(
+    data_type: &ArrowDataType,
+    values: MutableBitmap,
+    validity: MutableBitmap,
+) -> BooleanArray {
     BooleanArray::new(data_type.clone(), values.into(), validity.into())
 }
 
@@ -191,14 +195,19 @@ fn finish(data_type: &DataType, values: MutableBitmap, validity: MutableBitmap) 
 #[derive(Debug)]
 pub struct Iter<I: Pages> {
     iter: I,
-    data_type: DataType,
+    data_type: ArrowDataType,
     items: VecDeque<(MutableBitmap, MutableBitmap)>,
     chunk_size: Option<usize>,
     remaining: usize,
 }
 
 impl<I: Pages> Iter<I> {
-    pub fn new(iter: I, data_type: DataType, chunk_size: Option<usize>, num_rows: usize) -> Self {
+    pub fn new(
+        iter: I,
+        data_type: ArrowDataType,
+        chunk_size: Option<usize>,
+        num_rows: usize,
+    ) -> Self {
         Self {
             iter,
             data_type,

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary/mod.rs
@@ -4,7 +4,7 @@ use std::collections::VecDeque;
 
 use arrow::array::{Array, DictionaryArray, DictionaryKey, PrimitiveArray};
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 
 use super::utils::{
     self, dict_indices_decoder, extend_from_decoder, get_selected_rows, DecodedState, Decoder,
@@ -240,7 +240,7 @@ pub(super) fn next_dict<K: DictionaryKey, I: Pages, F: Fn(&DictPage) -> Box<dyn 
     iter: &mut I,
     items: &mut VecDeque<(Vec<K>, MutableBitmap)>,
     dict: &mut Option<Box<dyn Array>>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     remaining: &mut usize,
     chunk_size: Option<usize>,
     read_dict: F,

--- a/crates/polars-parquet/src/arrow/read/deserialize/dictionary/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/dictionary/nested.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use arrow::array::{Array, DictionaryArray, DictionaryKey};
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use polars_error::{polars_err, PolarsResult};
 
 use super::super::super::Pages;
@@ -149,7 +149,7 @@ pub fn next_dict<K: DictionaryKey, I: Pages, F: Fn(&DictPage) -> Box<dyn Array>>
     remaining: &mut usize,
     init: &[InitNested],
     dict: &mut Option<Box<dyn Array>>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     chunk_size: Option<usize>,
     read_dict: F,
 ) -> MaybeNext<PolarsResult<(NestedState, DictionaryArray<K>)>> {

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/basic.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use arrow::array::FixedSizeBinaryArray;
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use polars_error::PolarsResult;
 
 use super::super::utils::{
@@ -270,7 +270,7 @@ impl<'a> Decoder<'a> for BinaryDecoder {
 }
 
 pub fn finish(
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     values: FixedSizeBinary,
     validity: MutableBitmap,
 ) -> FixedSizeBinaryArray {
@@ -279,7 +279,7 @@ pub fn finish(
 
 pub struct Iter<I: Pages> {
     iter: I,
-    data_type: DataType,
+    data_type: ArrowDataType,
     size: usize,
     items: VecDeque<(FixedSizeBinary, MutableBitmap)>,
     dict: Option<Dict>,
@@ -288,7 +288,12 @@ pub struct Iter<I: Pages> {
 }
 
 impl<I: Pages> Iter<I> {
-    pub fn new(iter: I, data_type: DataType, num_rows: usize, chunk_size: Option<usize>) -> Self {
+    pub fn new(
+        iter: I,
+        data_type: ArrowDataType,
+        num_rows: usize,
+        chunk_size: Option<usize>,
+    ) -> Self {
         let size = FixedSizeBinaryArray::get_size(&data_type);
         Self {
             iter,

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/dictionary.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use arrow::array::{Array, DictionaryArray, DictionaryKey, FixedSizeBinaryArray};
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use polars_error::PolarsResult;
 
 use super::super::dictionary::*;
@@ -19,7 +19,7 @@ where
     K: DictionaryKey,
 {
     iter: I,
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Option<Box<dyn Array>>,
     items: VecDeque<(Vec<K>, MutableBitmap)>,
     remaining: usize,
@@ -31,7 +31,12 @@ where
     K: DictionaryKey,
     I: Pages,
 {
-    pub fn new(iter: I, data_type: DataType, num_rows: usize, chunk_size: Option<usize>) -> Self {
+    pub fn new(
+        iter: I,
+        data_type: ArrowDataType,
+        num_rows: usize,
+        chunk_size: Option<usize>,
+    ) -> Self {
         Self {
             iter,
             data_type,
@@ -43,9 +48,9 @@ where
     }
 }
 
-fn read_dict(data_type: DataType, dict: &DictPage) -> Box<dyn Array> {
+fn read_dict(data_type: ArrowDataType, dict: &DictPage) -> Box<dyn Array> {
     let data_type = match data_type {
-        DataType::Dictionary(_, values, _) => *values,
+        ArrowDataType::Dictionary(_, values, _) => *values,
         _ => data_type,
     };
 
@@ -91,7 +96,7 @@ where
 {
     iter: I,
     init: Vec<InitNested>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Option<Box<dyn Array>>,
     items: VecDeque<(NestedState, (Vec<K>, MutableBitmap))>,
     remaining: usize,
@@ -106,7 +111,7 @@ where
     pub fn new(
         iter: I,
         init: Vec<InitNested>,
-        data_type: DataType,
+        data_type: ArrowDataType,
         num_rows: usize,
         chunk_size: Option<usize>,
     ) -> Self {

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/nested.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use arrow::array::FixedSizeBinaryArray;
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use polars_error::PolarsResult;
 
 use super::super::utils::{not_implemented, MaybeNext, PageState};
@@ -137,7 +137,7 @@ impl<'a> NestedDecoder<'a> for BinaryDecoder {
 
 pub struct NestedIter<I: Pages> {
     iter: I,
-    data_type: DataType,
+    data_type: ArrowDataType,
     size: usize,
     init: Vec<InitNested>,
     items: VecDeque<(NestedState, (FixedSizeBinary, MutableBitmap))>,
@@ -150,7 +150,7 @@ impl<I: Pages> NestedIter<I> {
     pub fn new(
         iter: I,
         init: Vec<InitNested>,
-        data_type: DataType,
+        data_type: ArrowDataType,
         num_rows: usize,
         chunk_size: Option<usize>,
     ) -> Self {

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested.rs
@@ -1,5 +1,5 @@
 use arrow::array::PrimitiveArray;
-use arrow::datatypes::{DataType, Field};
+use arrow::datatypes::{ArrowDataType, Field};
 use arrow::match_integer_type;
 use ethnum::I256;
 use polars_error::polars_bail;
@@ -233,7 +233,7 @@ where
             ))
         },
         _ => match field.data_type().to_logical_type() {
-            DataType::Dictionary(key_type, _, _) => {
+            ArrowDataType::Dictionary(key_type, _, _) => {
                 init.push(InitNested::Primitive(field.is_nullable));
                 let type_ = types.pop().unwrap();
                 let iter = columns.pop().unwrap();
@@ -242,9 +242,9 @@ where
                     dict_read::<$K, _>(iter, init, type_, data_type, num_rows, chunk_size)
                 })?
             },
-            DataType::List(inner)
-            | DataType::LargeList(inner)
-            | DataType::FixedSizeList(inner, _) => {
+            ArrowDataType::List(inner)
+            | ArrowDataType::LargeList(inner)
+            | ArrowDataType::FixedSizeList(inner, _) => {
                 init.push(InitNested::List(field.is_nullable));
                 let iter = columns_to_iter_recursive(
                     columns,
@@ -261,7 +261,7 @@ where
                 });
                 Box::new(iter) as _
             },
-            DataType::Decimal(_, _) => {
+            ArrowDataType::Decimal(_, _) => {
                 init.push(InitNested::Primitive(field.is_nullable));
                 let type_ = types.pop().unwrap();
                 match type_.physical_type {
@@ -290,7 +290,7 @@ where
                         let iter = fixed_size_binary::NestedIter::new(
                             columns.pop().unwrap(),
                             init,
-                            DataType::FixedSizeBinary(n),
+                            ArrowDataType::FixedSizeBinary(n),
                             num_rows,
                             chunk_size,
                         );
@@ -324,7 +324,7 @@ where
                     },
                 }
             },
-            DataType::Decimal256(_, _) => {
+            ArrowDataType::Decimal256(_, _) => {
                 init.push(InitNested::Primitive(field.is_nullable));
                 let type_ = types.pop().unwrap();
                 match type_.physical_type {
@@ -348,7 +348,7 @@ where
                         let iter = fixed_size_binary::NestedIter::new(
                             columns.pop().unwrap(),
                             init,
-                            DataType::FixedSizeBinary(n),
+                            ArrowDataType::FixedSizeBinary(n),
                             num_rows,
                             chunk_size,
                         );
@@ -379,7 +379,7 @@ where
                         let iter = fixed_size_binary::NestedIter::new(
                             columns.pop().unwrap(),
                             init,
-                            DataType::FixedSizeBinary(n),
+                            ArrowDataType::FixedSizeBinary(n),
                             num_rows,
                             chunk_size,
                         );
@@ -418,7 +418,7 @@ where
                     },
                 }
             },
-            DataType::Struct(fields) => {
+            ArrowDataType::Struct(fields) => {
                 let columns = fields
                     .iter()
                     .rev()
@@ -441,7 +441,7 @@ where
                 let columns = columns.into_iter().rev().collect();
                 Box::new(struct_::StructIterator::new(columns, fields.clone()))
             },
-            DataType::Map(inner, _) => {
+            ArrowDataType::Map(inner, _) => {
                 init.push(InitNested::List(field.is_nullable));
                 let iter = columns_to_iter_recursive(
                     columns,
@@ -471,11 +471,11 @@ fn dict_read<'a, K: DictionaryKey, I: 'a + Pages>(
     iter: I,
     init: Vec<InitNested>,
     _type_: &PrimitiveType,
-    data_type: DataType,
+    data_type: ArrowDataType,
     num_rows: usize,
     chunk_size: Option<usize>,
 ) -> PolarsResult<NestedArrayIter<'a>> {
-    use DataType::*;
+    use ArrowDataType::*;
     let values_data_type = if let Dictionary(_, v, _) = &data_type {
         v.as_ref()
     } else {

--- a/crates/polars-parquet/src/arrow/read/deserialize/null/mod.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/null/mod.rs
@@ -1,7 +1,7 @@
 mod nested;
 
 use arrow::array::NullArray;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 pub(super) use nested::NestedIter;
 
 use super::super::{ArrayIter, Pages};
@@ -10,7 +10,7 @@ use crate::parquet::page::Page;
 /// Converts [`Pages`] to an [`ArrayIter`]
 pub fn iter_to_arrays<'a, I>(
     mut iter: I,
-    data_type: DataType,
+    data_type: ArrowDataType,
     chunk_size: Option<usize>,
     num_rows: usize,
 ) -> ArrayIter<'a>
@@ -55,7 +55,7 @@ where
 #[cfg(test)]
 mod tests {
     use arrow::array::NullArray;
-    use arrow::datatypes::DataType;
+    use arrow::datatypes::ArrowDataType;
     use polars_error::*;
 
     use super::iter_to_arrays;
@@ -94,12 +94,14 @@ mod tests {
         let p2 = new_page(100);
         let pages = vec![Result::<_, ParquetError>::Ok(&p1), Ok(&p2)];
         let pages = fallible_streaming_iterator::convert(pages.into_iter());
-        let arrays = iter_to_arrays(pages, DataType::Null, Some(10), 101);
+        let arrays = iter_to_arrays(pages, ArrowDataType::Null, Some(10), 101);
 
         let arrays = arrays.collect::<PolarsResult<Vec<_>>>().unwrap();
-        let expected = std::iter::repeat(NullArray::new(DataType::Null, 10).boxed())
+        let expected = std::iter::repeat(NullArray::new(ArrowDataType::Null, 10).boxed())
             .take(10)
-            .chain(std::iter::once(NullArray::new(DataType::Null, 1).boxed()));
+            .chain(std::iter::once(
+                NullArray::new(ArrowDataType::Null, 1).boxed(),
+            ));
         assert_eq!(arrays, expected.collect::<Vec<_>>())
     }
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/null/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/null/nested.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
 use arrow::array::NullArray;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use polars_error::PolarsResult;
 
 use super::super::nested_utils::*;
@@ -72,7 +72,7 @@ where
 {
     iter: I,
     init: Vec<InitNested>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     items: VecDeque<(NestedState, usize)>,
     remaining: usize,
     chunk_size: Option<usize>,
@@ -86,7 +86,7 @@ where
     pub fn new(
         iter: I,
         init: Vec<InitNested>,
-        data_type: DataType,
+        data_type: ArrowDataType,
         num_rows: usize,
         chunk_size: Option<usize>,
     ) -> Self {

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use arrow::array::MutablePrimitiveArray;
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use arrow::types::NativeType;
 use polars_error::PolarsResult;
 
@@ -272,7 +272,7 @@ where
 }
 
 pub(super) fn finish<T: NativeType>(
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     values: Vec<T>,
     validity: MutableBitmap,
 ) -> MutablePrimitiveArray<T> {
@@ -294,7 +294,7 @@ where
     F: Fn(P) -> T,
 {
     iter: I,
-    data_type: DataType,
+    data_type: ArrowDataType,
     items: VecDeque<(Vec<T>, MutableBitmap)>,
     remaining: usize,
     chunk_size: Option<usize>,
@@ -313,7 +313,7 @@ where
 {
     pub fn new(
         iter: I,
-        data_type: DataType,
+        data_type: ArrowDataType,
         num_rows: usize,
         chunk_size: Option<usize>,
         op: F,

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/dictionary.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use arrow::array::{Array, DictionaryArray, DictionaryKey, PrimitiveArray};
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use arrow::types::NativeType;
 use polars_error::PolarsResult;
 
@@ -14,14 +14,14 @@ use super::basic::deserialize_plain;
 use crate::parquet::page::DictPage;
 use crate::parquet::types::NativeType as ParquetNativeType;
 
-fn read_dict<P, T, F>(data_type: DataType, op: F, dict: &DictPage) -> Box<dyn Array>
+fn read_dict<P, T, F>(data_type: ArrowDataType, op: F, dict: &DictPage) -> Box<dyn Array>
 where
     T: NativeType,
     P: ParquetNativeType,
     F: Copy + Fn(P) -> T,
 {
     let data_type = match data_type {
-        DataType::Dictionary(_, values, _) => *values,
+        ArrowDataType::Dictionary(_, values, _) => *values,
         _ => data_type,
     };
     let values = deserialize_plain(&dict.buffer, op);
@@ -40,7 +40,7 @@ where
     F: Fn(P) -> T,
 {
     iter: I,
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Option<Box<dyn Array>>,
     items: VecDeque<(Vec<K>, MutableBitmap)>,
     remaining: usize,
@@ -60,7 +60,7 @@ where
 {
     pub fn new(
         iter: I,
-        data_type: DataType,
+        data_type: ArrowDataType,
         num_rows: usize,
         chunk_size: Option<usize>,
         op: F,
@@ -119,7 +119,7 @@ where
 {
     iter: I,
     init: Vec<InitNested>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     values: Option<Box<dyn Array>>,
     items: VecDeque<(NestedState, (Vec<K>, MutableBitmap))>,
     remaining: usize,
@@ -140,7 +140,7 @@ where
     pub fn new(
         iter: I,
         init: Vec<InitNested>,
-        data_type: DataType,
+        data_type: ArrowDataType,
         num_rows: usize,
         chunk_size: Option<usize>,
         op: F,

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use arrow::array::MutablePrimitiveArray;
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use arrow::types::NativeType;
 use num_traits::AsPrimitive;
 use polars_error::{to_compute_err, PolarsResult};
@@ -198,7 +198,7 @@ where
     F: Fn(P) -> T,
 {
     iter: I,
-    data_type: DataType,
+    data_type: ArrowDataType,
     items: VecDeque<(Vec<T>, MutableBitmap)>,
     remaining: usize,
     chunk_size: Option<usize>,
@@ -217,7 +217,7 @@ where
 {
     pub fn new(
         iter: I,
-        data_type: DataType,
+        data_type: ArrowDataType,
         num_rows: usize,
         chunk_size: Option<usize>,
         op: F,

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/nested.rs
@@ -2,7 +2,7 @@ use std::collections::VecDeque;
 
 use arrow::array::PrimitiveArray;
 use arrow::bitmap::MutableBitmap;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use arrow::types::NativeType;
 use polars_error::PolarsResult;
 
@@ -160,7 +160,7 @@ where
 }
 
 fn finish<T: NativeType>(
-    data_type: &DataType,
+    data_type: &ArrowDataType,
     values: Vec<T>,
     validity: MutableBitmap,
 ) -> PrimitiveArray<T> {
@@ -179,7 +179,7 @@ where
 {
     iter: I,
     init: Vec<InitNested>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     items: VecDeque<(NestedState, (Vec<T>, MutableBitmap))>,
     dict: Option<Vec<T>>,
     remaining: usize,
@@ -198,7 +198,7 @@ where
     pub fn new(
         iter: I,
         init: Vec<InitNested>,
-        data_type: DataType,
+        data_type: ArrowDataType,
         num_rows: usize,
         chunk_size: Option<usize>,
         op: F,

--- a/crates/polars-parquet/src/arrow/read/deserialize/simple.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/simple.rs
@@ -1,5 +1,5 @@
 use arrow::array::{Array, DictionaryKey, MutablePrimitiveArray, PrimitiveArray};
-use arrow::datatypes::{DataType, IntervalUnit, TimeUnit};
+use arrow::datatypes::{ArrowDataType, IntervalUnit, TimeUnit};
 use arrow::match_integer_type;
 use arrow::types::{days_ms, i256, NativeType};
 use ethnum::I256;
@@ -48,15 +48,15 @@ where
 }
 
 /// An iterator adapter that maps an iterator of Pages into an iterator of Arrays
-/// of [`DataType`] `data_type` and length `chunk_size`.
+/// of [`ArrowDataType`] `data_type` and length `chunk_size`.
 pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
     pages: I,
     type_: &PrimitiveType,
-    data_type: DataType,
+    data_type: ArrowDataType,
     chunk_size: Option<usize>,
     num_rows: usize,
 ) -> PolarsResult<ArrayIter<'a>> {
-    use DataType::*;
+    use ArrowDataType::*;
 
     let physical_type = &type_.physical_type;
     let logical_type = &type_.logical_type;
@@ -130,7 +130,7 @@ pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
             let n = 12;
             let pages = fixed_size_binary::Iter::new(
                 pages,
-                DataType::FixedSizeBinary(n),
+                ArrowDataType::FixedSizeBinary(n),
                 num_rows,
                 chunk_size,
             );
@@ -155,7 +155,7 @@ pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
             let n = 12;
             let pages = fixed_size_binary::Iter::new(
                 pages,
-                DataType::FixedSizeBinary(n),
+                ArrowDataType::FixedSizeBinary(n),
                 num_rows,
                 chunk_size,
             );
@@ -200,7 +200,7 @@ pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
 
             let pages = fixed_size_binary::Iter::new(
                 pages,
-                DataType::FixedSizeBinary(n),
+                ArrowDataType::FixedSizeBinary(n),
                 num_rows,
                 chunk_size,
             );
@@ -240,7 +240,7 @@ pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
 
             let pages = fixed_size_binary::Iter::new(
                 pages,
-                DataType::FixedSizeBinary(n),
+                ArrowDataType::FixedSizeBinary(n),
                 num_rows,
                 chunk_size,
             );
@@ -266,7 +266,7 @@ pub fn page_iter_to_arrays<'a, I: Pages + 'a>(
 
             let pages = fixed_size_binary::Iter::new(
                 pages,
-                DataType::FixedSizeBinary(n),
+                ArrowDataType::FixedSizeBinary(n),
                 num_rows,
                 chunk_size,
             );
@@ -424,7 +424,7 @@ fn timestamp<'a, I: Pages + 'a>(
     pages: I,
     physical_type: &PhysicalType,
     logical_type: &Option<PrimitiveLogicalType>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     num_rows: usize,
     chunk_size: Option<usize>,
     time_unit: TimeUnit,
@@ -481,7 +481,7 @@ fn timestamp_dict<'a, K: DictionaryKey, I: Pages + 'a>(
     pages: I,
     physical_type: &PhysicalType,
     logical_type: &Option<PrimitiveLogicalType>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     num_rows: usize,
     chunk_size: Option<usize>,
     time_unit: TimeUnit,
@@ -495,14 +495,14 @@ fn timestamp_dict<'a, K: DictionaryKey, I: Pages + 'a>(
         return match (factor, is_multiplier) {
             (a, true) => Ok(dyn_iter(primitive::DictIter::<K, _, _, _, _>::new(
                 pages,
-                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
                 num_rows,
                 chunk_size,
                 move |x| int96_to_i64_ns(x) * a,
             ))),
             (a, false) => Ok(dyn_iter(primitive::DictIter::<K, _, _, _, _>::new(
                 pages,
-                DataType::Timestamp(TimeUnit::Nanosecond, None),
+                ArrowDataType::Timestamp(TimeUnit::Nanosecond, None),
                 num_rows,
                 chunk_size,
                 move |x| int96_to_i64_ns(x) / a,
@@ -533,11 +533,11 @@ fn dict_read<'a, K: DictionaryKey, I: Pages + 'a>(
     iter: I,
     physical_type: &PhysicalType,
     logical_type: &Option<PrimitiveLogicalType>,
-    data_type: DataType,
+    data_type: ArrowDataType,
     num_rows: usize,
     chunk_size: Option<usize>,
 ) -> PolarsResult<ArrayIter<'a>> {
-    use DataType::*;
+    use ArrowDataType::*;
     let values_data_type = if let Dictionary(_, v, _) = &data_type {
         v.as_ref()
     } else {

--- a/crates/polars-parquet/src/arrow/read/deserialize/struct_.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/struct_.rs
@@ -1,5 +1,5 @@
 use arrow::array::{Array, StructArray};
-use arrow::datatypes::{DataType, Field};
+use arrow::datatypes::{ArrowDataType, Field};
 use polars_error::PolarsResult;
 
 use super::nested_utils::{NestedArrayIter, NestedState};
@@ -50,7 +50,7 @@ impl<'a> Iterator for StructIterator<'a> {
         Some(Ok((
             nested,
             Box::new(StructArray::new(
-                DataType::Struct(self.fields.clone()),
+                ArrowDataType::Struct(self.fields.clone()),
                 new_values,
                 validity.and_then(|x| x.into()),
             )),

--- a/crates/polars-parquet/src/arrow/read/indexes/binary.rs
+++ b/crates/polars-parquet/src/arrow/read/indexes/binary.rs
@@ -1,5 +1,5 @@
 use arrow::array::{Array, BinaryArray, PrimitiveArray, Utf8Array};
-use arrow::datatypes::{DataType, PhysicalType};
+use arrow::datatypes::{ArrowDataType, PhysicalType};
 use arrow::trusted_len::TrustedLen;
 use polars_error::{to_compute_err, PolarsResult};
 
@@ -8,7 +8,7 @@ use crate::parquet::indexes::PageIndex;
 
 pub fn deserialize(
     indexes: &[PageIndex<Vec<u8>>],
-    data_type: &DataType,
+    data_type: &ArrowDataType,
 ) -> PolarsResult<ColumnPageStatistics> {
     Ok(ColumnPageStatistics {
         min: deserialize_binary_iter(indexes.iter().map(|index| index.min.as_ref()), data_type)?,
@@ -23,7 +23,7 @@ pub fn deserialize(
 
 fn deserialize_binary_iter<'a, I: TrustedLen<Item = Option<&'a Vec<u8>>>>(
     iter: I,
-    data_type: &DataType,
+    data_type: &ArrowDataType,
 ) -> PolarsResult<Box<dyn Array>> {
     match data_type.to_physical_type() {
         PhysicalType::LargeBinary => Ok(Box::new(BinaryArray::<i64>::from_iter(iter))),

--- a/crates/polars-parquet/src/arrow/read/indexes/fixed_len_binary.rs
+++ b/crates/polars-parquet/src/arrow/read/indexes/fixed_len_binary.rs
@@ -1,12 +1,15 @@
 use arrow::array::{Array, FixedSizeBinaryArray, MutableFixedSizeBinaryArray, PrimitiveArray};
-use arrow::datatypes::{DataType, PhysicalType, PrimitiveType};
+use arrow::datatypes::{ArrowDataType, PhysicalType, PrimitiveType};
 use arrow::trusted_len::TrustedLen;
 use arrow::types::{i256, NativeType};
 
 use super::ColumnPageStatistics;
 use crate::parquet::indexes::PageIndex;
 
-pub fn deserialize(indexes: &[PageIndex<Vec<u8>>], data_type: DataType) -> ColumnPageStatistics {
+pub fn deserialize(
+    indexes: &[PageIndex<Vec<u8>>],
+    data_type: ArrowDataType,
+) -> ColumnPageStatistics {
     ColumnPageStatistics {
         min: deserialize_binary_iter(
             indexes.iter().map(|index| index.min.as_ref()),
@@ -23,7 +26,7 @@ pub fn deserialize(indexes: &[PageIndex<Vec<u8>>], data_type: DataType) -> Colum
 
 fn deserialize_binary_iter<'a, I: TrustedLen<Item = Option<&'a Vec<u8>>>>(
     iter: I,
-    data_type: DataType,
+    data_type: ArrowDataType,
 ) -> Box<dyn Array> {
     match data_type.to_physical_type() {
         PhysicalType::Primitive(PrimitiveType::Int128) => {

--- a/crates/polars-parquet/src/arrow/read/statistics/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics/dictionary.rs
@@ -1,5 +1,5 @@
 use arrow::array::*;
-use arrow::datatypes::{DataType, PhysicalType};
+use arrow::datatypes::{ArrowDataType, PhysicalType};
 use arrow::match_integer_type;
 use polars_error::PolarsResult;
 
@@ -7,13 +7,13 @@ use super::make_mutable;
 
 #[derive(Debug)]
 pub struct DynMutableDictionary {
-    data_type: DataType,
+    data_type: ArrowDataType,
     pub inner: Box<dyn MutableArray>,
 }
 
 impl DynMutableDictionary {
-    pub fn try_with_capacity(data_type: DataType, capacity: usize) -> PolarsResult<Self> {
-        let inner = if let DataType::Dictionary(_, inner, _) = &data_type {
+    pub fn try_with_capacity(data_type: ArrowDataType, capacity: usize) -> PolarsResult<Self> {
+        let inner = if let ArrowDataType::Dictionary(_, inner, _) = &data_type {
             inner.as_ref()
         } else {
             unreachable!()
@@ -25,7 +25,7 @@ impl DynMutableDictionary {
 }
 
 impl MutableArray for DynMutableDictionary {
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-parquet/src/arrow/read/statistics/list.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics/list.rs
@@ -1,5 +1,5 @@
 use arrow::array::*;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use arrow::offset::Offsets;
 use polars_error::PolarsResult;
 
@@ -7,14 +7,14 @@ use super::make_mutable;
 
 #[derive(Debug)]
 pub struct DynMutableListArray {
-    data_type: DataType,
+    data_type: ArrowDataType,
     pub inner: Box<dyn MutableArray>,
 }
 
 impl DynMutableListArray {
-    pub fn try_with_capacity(data_type: DataType, capacity: usize) -> PolarsResult<Self> {
+    pub fn try_with_capacity(data_type: ArrowDataType, capacity: usize) -> PolarsResult<Self> {
         let inner = match data_type.to_logical_type() {
-            DataType::List(inner) | DataType::LargeList(inner) => inner.data_type(),
+            ArrowDataType::List(inner) | ArrowDataType::LargeList(inner) => inner.data_type(),
             _ => unreachable!(),
         };
         let inner = make_mutable(inner, capacity)?;
@@ -24,7 +24,7 @@ impl DynMutableListArray {
 }
 
 impl MutableArray for DynMutableListArray {
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 
@@ -40,7 +40,7 @@ impl MutableArray for DynMutableListArray {
         let inner = self.inner.as_box();
 
         match self.data_type.to_logical_type() {
-            DataType::List(_) => {
+            ArrowDataType::List(_) => {
                 let offsets =
                     Offsets::try_from_lengths(std::iter::repeat(1).take(inner.len())).unwrap();
                 Box::new(ListArray::<i32>::new(
@@ -50,7 +50,7 @@ impl MutableArray for DynMutableListArray {
                     None,
                 ))
             },
-            DataType::LargeList(_) => {
+            ArrowDataType::LargeList(_) => {
                 let offsets =
                     Offsets::try_from_lengths(std::iter::repeat(1).take(inner.len())).unwrap();
                 Box::new(ListArray::<i64>::new(

--- a/crates/polars-parquet/src/arrow/read/statistics/map.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics/map.rs
@@ -1,19 +1,19 @@
 use arrow::array::{Array, MapArray, MutableArray};
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use polars_error::PolarsResult;
 
 use super::make_mutable;
 
 #[derive(Debug)]
 pub struct DynMutableMapArray {
-    data_type: DataType,
+    data_type: ArrowDataType,
     pub inner: Box<dyn MutableArray>,
 }
 
 impl DynMutableMapArray {
-    pub fn try_with_capacity(data_type: DataType, capacity: usize) -> PolarsResult<Self> {
+    pub fn try_with_capacity(data_type: ArrowDataType, capacity: usize) -> PolarsResult<Self> {
         let inner = match data_type.to_logical_type() {
-            DataType::Map(inner, _) => inner,
+            ArrowDataType::Map(inner, _) => inner,
             _ => unreachable!(),
         };
         let inner = make_mutable(inner.data_type(), capacity)?;
@@ -23,7 +23,7 @@ impl DynMutableMapArray {
 }
 
 impl MutableArray for DynMutableMapArray {
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-parquet/src/arrow/read/statistics/struct_.rs
+++ b/crates/polars-parquet/src/arrow/read/statistics/struct_.rs
@@ -1,19 +1,19 @@
 use arrow::array::{Array, MutableArray, StructArray};
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use polars_error::PolarsResult;
 
 use super::make_mutable;
 
 #[derive(Debug)]
 pub struct DynMutableStructArray {
-    data_type: DataType,
+    data_type: ArrowDataType,
     pub inner: Vec<Box<dyn MutableArray>>,
 }
 
 impl DynMutableStructArray {
-    pub fn try_with_capacity(data_type: DataType, capacity: usize) -> PolarsResult<Self> {
+    pub fn try_with_capacity(data_type: ArrowDataType, capacity: usize) -> PolarsResult<Self> {
         let inners = match data_type.to_logical_type() {
-            DataType::Struct(inner) => inner,
+            ArrowDataType::Struct(inner) => inner,
             _ => unreachable!(),
         };
         let inner = inners
@@ -25,7 +25,7 @@ impl DynMutableStructArray {
     }
 }
 impl MutableArray for DynMutableStructArray {
-    fn data_type(&self) -> &DataType {
+    fn data_type(&self) -> &ArrowDataType {
         &self.data_type
     }
 

--- a/crates/polars-parquet/src/arrow/write/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/write/dictionary.rs
@@ -1,6 +1,6 @@
 use arrow::array::{Array, DictionaryArray, DictionaryKey};
 use arrow::bitmap::{Bitmap, MutableBitmap};
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use polars_error::{polars_bail, PolarsResult};
 
 use super::binary::{
@@ -181,23 +181,23 @@ pub fn array_to_pages<K: DictionaryKey>(
             // write DictPage
             let (dict_page, statistics): (_, Option<ParquetStatistics>) =
                 match array.values().data_type().to_logical_type() {
-                    DataType::Int8 => dyn_prim!(i8, i32, array, options, type_),
-                    DataType::Int16 => dyn_prim!(i16, i32, array, options, type_),
-                    DataType::Int32 | DataType::Date32 | DataType::Time32(_) => {
+                    ArrowDataType::Int8 => dyn_prim!(i8, i32, array, options, type_),
+                    ArrowDataType::Int16 => dyn_prim!(i16, i32, array, options, type_),
+                    ArrowDataType::Int32 | ArrowDataType::Date32 | ArrowDataType::Time32(_) => {
                         dyn_prim!(i32, i32, array, options, type_)
                     },
-                    DataType::Int64
-                    | DataType::Date64
-                    | DataType::Time64(_)
-                    | DataType::Timestamp(_, _)
-                    | DataType::Duration(_) => dyn_prim!(i64, i64, array, options, type_),
-                    DataType::UInt8 => dyn_prim!(u8, i32, array, options, type_),
-                    DataType::UInt16 => dyn_prim!(u16, i32, array, options, type_),
-                    DataType::UInt32 => dyn_prim!(u32, i32, array, options, type_),
-                    DataType::UInt64 => dyn_prim!(u64, i64, array, options, type_),
-                    DataType::Float32 => dyn_prim!(f32, f32, array, options, type_),
-                    DataType::Float64 => dyn_prim!(f64, f64, array, options, type_),
-                    DataType::Utf8 => {
+                    ArrowDataType::Int64
+                    | ArrowDataType::Date64
+                    | ArrowDataType::Time64(_)
+                    | ArrowDataType::Timestamp(_, _)
+                    | ArrowDataType::Duration(_) => dyn_prim!(i64, i64, array, options, type_),
+                    ArrowDataType::UInt8 => dyn_prim!(u8, i32, array, options, type_),
+                    ArrowDataType::UInt16 => dyn_prim!(u16, i32, array, options, type_),
+                    ArrowDataType::UInt32 => dyn_prim!(u32, i32, array, options, type_),
+                    ArrowDataType::UInt64 => dyn_prim!(u64, i64, array, options, type_),
+                    ArrowDataType::Float32 => dyn_prim!(f32, f32, array, options, type_),
+                    ArrowDataType::Float64 => dyn_prim!(f64, f64, array, options, type_),
+                    ArrowDataType::Utf8 => {
                         let array = array.values().as_any().downcast_ref().unwrap();
 
                         let mut buffer = vec![];
@@ -209,7 +209,7 @@ pub fn array_to_pages<K: DictionaryKey>(
                         };
                         (DictPage::new(buffer, array.len(), false), stats)
                     },
-                    DataType::LargeUtf8 => {
+                    ArrowDataType::LargeUtf8 => {
                         let array = array.values().as_any().downcast_ref().unwrap();
 
                         let mut buffer = vec![];
@@ -221,7 +221,7 @@ pub fn array_to_pages<K: DictionaryKey>(
                         };
                         (DictPage::new(buffer, array.len(), false), stats)
                     },
-                    DataType::Binary => {
+                    ArrowDataType::Binary => {
                         let array = array.values().as_any().downcast_ref().unwrap();
 
                         let mut buffer = vec![];
@@ -233,7 +233,7 @@ pub fn array_to_pages<K: DictionaryKey>(
                         };
                         (DictPage::new(buffer, array.len(), false), stats)
                     },
-                    DataType::LargeBinary => {
+                    ArrowDataType::LargeBinary => {
                         let values = array.values().as_any().downcast_ref().unwrap();
 
                         let mut buffer = vec![];
@@ -247,7 +247,7 @@ pub fn array_to_pages<K: DictionaryKey>(
                         };
                         (DictPage::new(buffer, values.len(), false), stats)
                     },
-                    DataType::FixedSizeBinary(_) => {
+                    ArrowDataType::FixedSizeBinary(_) => {
                         let mut buffer = vec![];
                         let array = array.values().as_any().downcast_ref().unwrap();
                         fixed_binary_encode_plain(array, false, &mut buffer);

--- a/crates/polars-parquet/src/arrow/write/pages.rs
+++ b/crates/polars-parquet/src/arrow/write/pages.rs
@@ -273,12 +273,12 @@ mod tests {
         let int = Int32Array::from_slice([42, 28, 19, 31]).boxed();
 
         let fields = vec![
-            Field::new("b", DataType::Boolean, false),
-            Field::new("c", DataType::Int32, false),
+            Field::new("b", ArrowDataType::Boolean, false),
+            Field::new("c", ArrowDataType::Int32, false),
         ];
 
         let array = StructArray::new(
-            DataType::Struct(fields),
+            ArrowDataType::Struct(fields),
             vec![boolean.clone(), int.clone()],
             Some(Bitmap::from([true, true, false, true])),
         );
@@ -337,12 +337,12 @@ mod tests {
         let int = Int32Array::from_slice([42, 28, 19, 31]).boxed();
 
         let fields = vec![
-            Field::new("b", DataType::Boolean, false),
-            Field::new("c", DataType::Int32, false),
+            Field::new("b", ArrowDataType::Boolean, false),
+            Field::new("c", ArrowDataType::Int32, false),
         ];
 
         let array = StructArray::new(
-            DataType::Struct(fields),
+            ArrowDataType::Struct(fields),
             vec![boolean.clone(), int.clone()],
             Some(Bitmap::from([true, true, false, true])),
         );
@@ -353,7 +353,7 @@ mod tests {
         ];
 
         let array = StructArray::new(
-            DataType::Struct(fields),
+            ArrowDataType::Struct(fields),
             vec![Box::new(array.clone()), Box::new(array)],
             None,
         );
@@ -440,18 +440,18 @@ mod tests {
         let int = Int32Array::from_slice([42, 28, 19, 31]).boxed();
 
         let fields = vec![
-            Field::new("b", DataType::Boolean, false),
-            Field::new("c", DataType::Int32, false),
+            Field::new("b", ArrowDataType::Boolean, false),
+            Field::new("c", ArrowDataType::Int32, false),
         ];
 
         let array = StructArray::new(
-            DataType::Struct(fields),
+            ArrowDataType::Struct(fields),
             vec![boolean.clone(), int.clone()],
             Some(Bitmap::from([true, true, false, true])),
         );
 
         let array = ListArray::new(
-            DataType::List(Box::new(Field::new("l", array.data_type().clone(), true))),
+            ArrowDataType::List(Box::new(Field::new("l", array.data_type().clone(), true))),
             vec![0i32, 2, 4].try_into().unwrap(),
             Box::new(array),
             None,
@@ -538,12 +538,12 @@ mod tests {
 
     #[test]
     fn test_map() {
-        let kv_type = DataType::Struct(vec![
-            Field::new("k", DataType::Utf8, false),
-            Field::new("v", DataType::Int32, false),
+        let kv_type = ArrowDataType::Struct(vec![
+            Field::new("k", ArrowDataType::Utf8, false),
+            Field::new("v", ArrowDataType::Int32, false),
         ]);
         let kv_field = Field::new("kv", kv_type.clone(), false);
-        let map_type = DataType::Map(Box::new(kv_field), false);
+        let map_type = ArrowDataType::Map(Box::new(kv_field), false);
 
         let key_array = Utf8Array::<i32>::from_slice(["k1", "k2", "k3", "k4", "k5", "k6"]).boxed();
         let val_array = Int32Array::from_slice([42, 28, 19, 31, 21, 17]).boxed();

--- a/crates/polars-parquet/src/arrow/write/schema.rs
+++ b/crates/polars-parquet/src/arrow/write/schema.rs
@@ -1,4 +1,4 @@
-use arrow::datatypes::{ArrowSchema, DataType, Field, TimeUnit};
+use arrow::datatypes::{ArrowDataType, ArrowSchema, Field, TimeUnit};
 use arrow::io::ipc::write::{default_ipc_fields, schema_to_bytes};
 use base64::engine::general_purpose;
 use base64::Engine as _;
@@ -42,7 +42,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
     };
     // create type from field
     match field.data_type().to_logical_type() {
-        DataType::Null => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Null => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int32,
             repetition,
@@ -50,7 +50,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             Some(PrimitiveLogicalType::Unknown),
             None,
         )?),
-        DataType::Boolean => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Boolean => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Boolean,
             repetition,
@@ -58,7 +58,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             None,
             None,
         )?),
-        DataType::Int32 => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Int32 => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int32,
             repetition,
@@ -66,8 +66,8 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             None,
             None,
         )?),
-        // DataType::Duration(_) has no parquet representation => do not apply any logical type
-        DataType::Int64 | DataType::Duration(_) => Ok(ParquetType::try_from_primitive(
+        // ArrowDataType::Duration(_) has no parquet representation => do not apply any logical type
+        ArrowDataType::Int64 | ArrowDataType::Duration(_) => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int64,
             repetition,
@@ -77,7 +77,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
         )?),
         // no natural representation in parquet; leave it as is.
         // arrow consumers MAY use the arrow schema in the metadata to parse them.
-        DataType::Date64 => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Date64 => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int64,
             repetition,
@@ -85,7 +85,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             None,
             None,
         )?),
-        DataType::Float32 => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Float32 => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Float,
             repetition,
@@ -93,7 +93,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             None,
             None,
         )?),
-        DataType::Float64 => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Float64 => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Double,
             repetition,
@@ -101,7 +101,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             None,
             None,
         )?),
-        DataType::Binary | DataType::LargeBinary => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Binary | ArrowDataType::LargeBinary => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::ByteArray,
             repetition,
@@ -109,7 +109,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             None,
             None,
         )?),
-        DataType::Utf8 | DataType::LargeUtf8 => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Utf8 | ArrowDataType::LargeUtf8 => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::ByteArray,
             repetition,
@@ -117,7 +117,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             Some(PrimitiveLogicalType::String),
             None,
         )?),
-        DataType::Date32 => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Date32 => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int32,
             repetition,
@@ -125,7 +125,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             Some(PrimitiveLogicalType::Date),
             None,
         )?),
-        DataType::Int8 => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Int8 => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int32,
             repetition,
@@ -133,7 +133,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             Some(PrimitiveLogicalType::Integer(IntegerType::Int8)),
             None,
         )?),
-        DataType::Int16 => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Int16 => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int32,
             repetition,
@@ -141,7 +141,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             Some(PrimitiveLogicalType::Integer(IntegerType::Int16)),
             None,
         )?),
-        DataType::UInt8 => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::UInt8 => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int32,
             repetition,
@@ -149,7 +149,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             Some(PrimitiveLogicalType::Integer(IntegerType::UInt8)),
             None,
         )?),
-        DataType::UInt16 => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::UInt16 => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int32,
             repetition,
@@ -157,7 +157,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             Some(PrimitiveLogicalType::Integer(IntegerType::UInt16)),
             None,
         )?),
-        DataType::UInt32 => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::UInt32 => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int32,
             repetition,
@@ -165,7 +165,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             Some(PrimitiveLogicalType::Integer(IntegerType::UInt32)),
             None,
         )?),
-        DataType::UInt64 => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::UInt64 => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int64,
             repetition,
@@ -175,7 +175,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
         )?),
         // no natural representation in parquet; leave it as is.
         // arrow consumers MAY use the arrow schema in the metadata to parse them.
-        DataType::Timestamp(TimeUnit::Second, _) => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Timestamp(TimeUnit::Second, _) => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int64,
             repetition,
@@ -183,7 +183,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             None,
             None,
         )?),
-        DataType::Timestamp(time_unit, zone) => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Timestamp(time_unit, zone) => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int64,
             repetition,
@@ -201,7 +201,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
         )?),
         // no natural representation in parquet; leave it as is.
         // arrow consumers MAY use the arrow schema in the metadata to parse them.
-        DataType::Time32(TimeUnit::Second) => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Time32(TimeUnit::Second) => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int32,
             repetition,
@@ -209,7 +209,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             None,
             None,
         )?),
-        DataType::Time32(TimeUnit::Millisecond) => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Time32(TimeUnit::Millisecond) => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int32,
             repetition,
@@ -220,7 +220,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             }),
             None,
         )?),
-        DataType::Time64(time_unit) => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Time64(time_unit) => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::Int64,
             repetition,
@@ -239,7 +239,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             }),
             None,
         )?),
-        DataType::Struct(fields) => {
+        ArrowDataType::Struct(fields) => {
             if fields.is_empty() {
                 polars_bail!(InvalidOperation:
                     "Parquet does not support writing empty structs".to_string(),
@@ -254,11 +254,11 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
                 name, repetition, None, None, fields, None,
             ))
         },
-        DataType::Dictionary(_, value, _) => {
+        ArrowDataType::Dictionary(_, value, _) => {
             let dict_field = Field::new(name.as_str(), value.as_ref().clone(), field.is_nullable);
             to_parquet_type(&dict_field)
         },
-        DataType::FixedSizeBinary(size) => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::FixedSizeBinary(size) => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::FixedLenByteArray(*size),
             repetition,
@@ -266,7 +266,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             None,
             None,
         )?),
-        DataType::Decimal(precision, scale) => {
+        ArrowDataType::Decimal(precision, scale) => {
             let precision = *precision;
             let scale = *scale;
             let logical_type = Some(PrimitiveLogicalType::Decimal(precision, scale));
@@ -288,7 +288,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
                 None,
             )?)
         },
-        DataType::Decimal256(precision, scale) => {
+        ArrowDataType::Decimal256(precision, scale) => {
             let precision = *precision;
             let scale = *scale;
             let logical_type = Some(PrimitiveLogicalType::Decimal(precision, scale));
@@ -332,7 +332,7 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
                 )?)
             }
         },
-        DataType::Interval(_) => Ok(ParquetType::try_from_primitive(
+        ArrowDataType::Interval(_) => Ok(ParquetType::try_from_primitive(
             name,
             PhysicalType::FixedLenByteArray(12),
             repetition,
@@ -340,24 +340,24 @@ pub fn to_parquet_type(field: &Field) -> PolarsResult<ParquetType> {
             None,
             None,
         )?),
-        DataType::List(f) | DataType::FixedSizeList(f, _) | DataType::LargeList(f) => {
-            Ok(ParquetType::from_group(
-                name,
-                repetition,
-                Some(GroupConvertedType::List),
-                Some(GroupLogicalType::List),
-                vec![ParquetType::from_group(
-                    "list".to_string(),
-                    Repetition::Repeated,
-                    None,
-                    None,
-                    vec![to_parquet_type(f)?],
-                    None,
-                )],
+        ArrowDataType::List(f)
+        | ArrowDataType::FixedSizeList(f, _)
+        | ArrowDataType::LargeList(f) => Ok(ParquetType::from_group(
+            name,
+            repetition,
+            Some(GroupConvertedType::List),
+            Some(GroupLogicalType::List),
+            vec![ParquetType::from_group(
+                "list".to_string(),
+                Repetition::Repeated,
                 None,
-            ))
-        },
-        DataType::Map(f, _) => Ok(ParquetType::from_group(
+                None,
+                vec![to_parquet_type(f)?],
+                None,
+            )],
+            None,
+        )),
+        ArrowDataType::Map(f, _) => Ok(ParquetType::from_group(
             name,
             repetition,
             Some(GroupConvertedType::Map),

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -1,4 +1,4 @@
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 
 use super::*;
 use crate::fixed::{decode_bool, decode_primitive};
@@ -11,7 +11,7 @@ use crate::variable::decode_binary;
 pub unsafe fn decode_rows_from_binary<'a>(
     arr: &'a BinaryArray<i64>,
     fields: &[SortField],
-    data_types: &[DataType],
+    data_types: &[ArrowDataType],
     rows: &mut Vec<&'a [u8]>,
 ) -> Vec<ArrayRef> {
     assert_eq!(arr.null_count(), 0);
@@ -28,7 +28,7 @@ pub unsafe fn decode_rows(
     // the rows will be updated while the data is decoded
     rows: &mut [&[u8]],
     fields: &[SortField],
-    data_types: &[DataType],
+    data_types: &[ArrowDataType],
 ) -> Vec<ArrayRef> {
     assert_eq!(fields.len(), data_types.len());
     data_types
@@ -38,24 +38,24 @@ pub unsafe fn decode_rows(
         .collect()
 }
 
-unsafe fn decode(rows: &mut [&[u8]], field: &SortField, data_type: &DataType) -> ArrayRef {
+unsafe fn decode(rows: &mut [&[u8]], field: &SortField, data_type: &ArrowDataType) -> ArrayRef {
     // not yet supported for fixed types
     assert!(!field.nulls_last, "not yet supported");
     match data_type {
-        DataType::Null => NullArray::new(DataType::Null, rows.len()).to_boxed(),
-        DataType::Boolean => decode_bool(rows, field).to_boxed(),
-        DataType::LargeBinary => decode_binary(rows, field).to_boxed(),
-        DataType::LargeUtf8 => {
+        ArrowDataType::Null => NullArray::new(ArrowDataType::Null, rows.len()).to_boxed(),
+        ArrowDataType::Boolean => decode_bool(rows, field).to_boxed(),
+        ArrowDataType::LargeBinary => decode_binary(rows, field).to_boxed(),
+        ArrowDataType::LargeUtf8 => {
             let arr = decode_binary(rows, field);
             Utf8Array::<i64>::new_unchecked(
-                DataType::LargeUtf8,
+                ArrowDataType::LargeUtf8,
                 arr.offsets().clone(),
                 arr.values().clone(),
                 arr.validity().cloned(),
             )
             .to_boxed()
         },
-        DataType::Struct(fields) => {
+        ArrowDataType::Struct(fields) => {
             let values = fields
                 .iter()
                 .map(|struct_fld| decode(rows, field, struct_fld.data_type()))

--- a/crates/polars-row/src/fixed.rs
+++ b/crates/polars-row/src/fixed.rs
@@ -3,7 +3,7 @@ use std::mem::MaybeUninit;
 
 use arrow::array::{BooleanArray, PrimitiveArray};
 use arrow::bitmap::Bitmap;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use arrow::types::NativeType;
 use arrow::util::total_ord::{canonical_f32, canonical_f64};
 use polars_utils::slice::*;
@@ -223,7 +223,7 @@ pub(super) unsafe fn decode_primitive<T: NativeType + FixedLengthEncoding>(
 where
     T::Encoded: FromSlice,
 {
-    let data_type: DataType = T::PRIMITIVE.into();
+    let data_type: ArrowDataType = T::PRIMITIVE.into();
     let mut has_nulls = false;
     let null_sentinel = get_null_sentinel(field);
 
@@ -291,7 +291,7 @@ pub(super) unsafe fn decode_bool(rows: &mut [&[u8]], field: &SortField) -> Boole
     let increment_len = bool::ENCODED_LEN;
 
     increment_row_counter(rows, increment_len);
-    BooleanArray::new(DataType::Boolean, values, validity)
+    BooleanArray::new(ArrowDataType::Boolean, values, validity)
 }
 unsafe fn increment_row_counter(rows: &mut [&[u8]], fixed_size: usize) {
     for row in rows {

--- a/crates/polars-row/src/row.rs
+++ b/crates/polars-row/src/row.rs
@@ -1,5 +1,5 @@
 use arrow::array::BinaryArray;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use arrow::ffi::mmap;
 use arrow::offset::{Offsets, OffsetsBuffer};
 
@@ -38,7 +38,7 @@ unsafe fn rows_to_array(buf: Vec<u8>, offsets: Vec<usize>) -> BinaryArray<i64> {
     // Safety: monotonically increasing
     let offsets = Offsets::new_unchecked(offsets);
 
-    BinaryArray::new(DataType::LargeBinary, offsets.into(), buf.into(), None)
+    BinaryArray::new(ArrowDataType::LargeBinary, offsets.into(), buf.into(), None)
 }
 
 impl RowsEncoded {
@@ -70,7 +70,7 @@ impl RowsEncoded {
             let (_, offsets, _) = mmap::slice(offsets).into_inner();
             let offsets = OffsetsBuffer::new_unchecked(offsets);
 
-            BinaryArray::new(DataType::LargeBinary, offsets, values, None)
+            BinaryArray::new(ArrowDataType::LargeBinary, offsets, values, None)
         }
     }
 

--- a/crates/polars-row/src/utils.rs
+++ b/crates/polars-row/src/utils.rs
@@ -3,7 +3,7 @@ macro_rules! with_match_arrow_primitive_type {(
     $key_type:expr, | $_:tt $T:ident | $($body:tt)*
 ) => ({
     macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use arrow::datatypes::DataType::*;
+    use arrow::datatypes::ArrowDataType::*;
     match $key_type {
         Int8 => __with_ty__! { i8 },
         Int16 => __with_ty__! { i16 },

--- a/crates/polars-row/src/variable.rs
+++ b/crates/polars-row/src/variable.rs
@@ -13,7 +13,7 @@
 use std::mem::MaybeUninit;
 
 use arrow::array::BinaryArray;
-use arrow::datatypes::DataType;
+use arrow::datatypes::ArrowDataType;
 use arrow::offset::Offsets;
 use polars_utils::slice::{GetSaferUnchecked, Slice2Uninit};
 
@@ -263,7 +263,7 @@ pub(super) unsafe fn decode_binary(rows: &mut [&[u8]], field: &SortField) -> Bin
     }
 
     BinaryArray::new(
-        DataType::LargeBinary,
+        ArrowDataType::LargeBinary,
         Offsets::new_unchecked(offsets).into(),
         values.into(),
         validity,


### PR DESCRIPTION
_"That escalated quickly..."_ 😅 

Having two different flavours of `DataType` wasn't ideal; now that we've brought the code inside (via `polars-arrow`) it makes sense to better distinguish between the two - easier to reason about at a glance with respect to function signatures and return types, easier to search for, etc. 

We already had various cases where the two names would have collided, which we were handling with:
`pub use arrow::datatypes::DataType as ArrowDataType`.

This PR formalises the distinction using that naming (following a quick sanity-check with @ritchie46). 

### Note

As you'd hope for something this size it is _only_ a rename/refactor - no functional code/logic changed. The only reason the `+/-` on this PR shows as positive is because the extra length of "ArrowDataType" vs "DataType" sometimes causes the formatting to break across extra lines, like so:

<img width="813" alt="diff_example" src="https://github.com/pola-rs/polars/assets/2613171/3ceeb357-b83e-4aef-83c5-edf2d983c001">
