### PR TITLE
fix(python): Fix DataType initialization for some cases

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -91,13 +91,6 @@ class DataTypeClass(type):
 class DataType(metaclass=DataTypeClass):
     """Base class for all Polars data types."""
 
-    def __new__(cls, *args: Any, **kwargs: Any) -> PolarsDataType:  # type: ignore[misc]  # noqa: D102
-        # this formulation allows for equivalent use of "pl.Type" and "pl.Type()", while
-        # still respecting types that take initialisation params (eg: Duration/Datetime)
-        if args or kwargs:
-            return super().__new__(cls)
-        return cls
-
     def __reduce__(self) -> Any:
         return (_custom_reconstruct, (type(self), object, None), self.__dict__)
 
@@ -280,6 +273,10 @@ class NumericType(DataType):
 class IntegerType(NumericType):
     """Base class for integer data types."""
 
+    def __new__(cls) -> DataTypeClass:  # type: ignore[misc]
+        """Convert new instances of this class to a class object."""
+        return cls
+
 
 class SignedIntegerType(IntegerType):
     """Base class for signed integer data types."""
@@ -291,6 +288,10 @@ class UnsignedIntegerType(IntegerType):
 
 class FloatType(NumericType):
     """Base class for float data types."""
+
+    def __new__(cls) -> DataTypeClass:  # type: ignore[misc]
+        """Convert new instances of this class to a class object."""
+        return cls
 
 
 class TemporalType(DataType):
@@ -418,21 +419,41 @@ class Decimal(NumericType):
 class Boolean(DataType):
     """Boolean type."""
 
+    def __new__(cls) -> DataTypeClass:  # type: ignore[misc]
+        """Convert new instances of this class to a class object."""
+        return cls
+
 
 class Utf8(DataType):
     """UTF-8 encoded string type."""
+
+    def __new__(cls) -> DataTypeClass:  # type: ignore[misc]
+        """Convert new instances of this class to a class object."""
+        return cls
 
 
 class Binary(DataType):
     """Binary type."""
 
+    def __new__(cls) -> DataTypeClass:  # type: ignore[misc]
+        """Convert new instances of this class to a class object."""
+        return cls
+
 
 class Date(TemporalType):
     """Calendar date type."""
 
+    def __new__(cls) -> DataTypeClass:  # type: ignore[misc]
+        """Convert new instances of this class to a class object."""
+        return cls
+
 
 class Time(TemporalType):
     """Time of day type."""
+
+    def __new__(cls) -> DataTypeClass:  # type: ignore[misc]
+        """Convert new instances of this class to a class object."""
+        return cls
 
 
 class Datetime(TemporalType):
@@ -533,17 +554,33 @@ class Duration(TemporalType):
 class Categorical(DataType):
     """A categorical encoding of a set of strings."""
 
+    def __new__(cls) -> DataTypeClass:  # type: ignore[misc]
+        """Convert new instances of this class to a class object."""
+        return cls
+
 
 class Object(DataType):
     """Type for wrapping arbitrary Python objects."""
+
+    def __new__(cls) -> DataTypeClass:  # type: ignore[misc]
+        """Convert new instances of this class to a class object."""
+        return cls
 
 
 class Null(DataType):
     """Type representing Null / None values."""
 
+    def __new__(cls) -> DataTypeClass:  # type: ignore[misc]
+        """Convert new instances of this class to a class object."""
+        return cls
+
 
 class Unknown(DataType):
     """Type representing Datatype values that could not be determined statically."""
+
+    def __new__(cls) -> DataTypeClass:  # type: ignore[misc]
+        """Convert new instances of this class to a class object."""
+        return cls
 
 
 class List(NestedType):

--- a/py-polars/tests/unit/test_datatypes.py
+++ b/py-polars/tests/unit/test_datatypes.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import inspect
 import pickle
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -9,7 +11,6 @@ import polars as pl
 from polars import datatypes
 from polars.datatypes import (
     DTYPE_TEMPORAL_UNITS,
-    DataTypeClass,
     DataTypeGroup,
     Field,
     Int64,
@@ -18,16 +19,42 @@ from polars.datatypes import (
     py_type_to_dtype,
 )
 
+if TYPE_CHECKING:
+    from polars.datatypes import DataTypeClass
 
-def test_dtype_init_equivalence() -> None:
-    # check "DataType.__new__" behaviour for all datatypes
-    all_datatypes = {
-        dtype
-        for dtype in (getattr(datatypes, attr) for attr in dir(datatypes))
-        if isinstance(dtype, DataTypeClass)
+SIMPLE_DTYPES: list[DataTypeClass] = list(
+    pl.INTEGER_DTYPES  # type: ignore[arg-type]
+    | pl.FLOAT_DTYPES
+    | {
+        pl.Boolean,
+        pl.Utf8,
+        pl.Binary,
+        pl.Time,
+        pl.Date,
+        pl.Categorical,
+        pl.Object,
+        pl.Null,
+        pl.Unknown,
     }
-    for dtype in all_datatypes:
-        assert dtype == dtype()
+)
+
+
+def test_simple_dtype_init_returns_class() -> None:
+    for dtype in SIMPLE_DTYPES:
+        result = dtype()
+        assert inspect.isclass(result)
+
+
+def test_simple_dtype_init_takes_no_args() -> None:
+    for dtype in SIMPLE_DTYPES:
+        with pytest.raises(TypeError):
+            dtype(10)
+
+
+def test_complex_dtype_init_returns_instance() -> None:
+    dtype = pl.Datetime()
+    assert isinstance(dtype, pl.Datetime)
+    assert dtype.time_unit == "us"
 
 
 def test_dtype_temporal_units() -> None:
@@ -36,8 +63,8 @@ def test_dtype_temporal_units() -> None:
         assert pl.Datetime == pl.Datetime(time_unit)
         assert pl.Duration == pl.Duration(time_unit)
 
-        assert pl.Datetime(time_unit) == pl.Datetime()
-        assert pl.Duration(time_unit) == pl.Duration()
+        assert pl.Datetime(time_unit) == pl.Datetime
+        assert pl.Duration(time_unit) == pl.Duration
 
     assert pl.Datetime("ms") != pl.Datetime("ns")
     assert pl.Duration("ns") != pl.Duration("us")

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -187,8 +187,8 @@ def test_getitem_errs() -> None:
 def test_err_bubbling_up_to_lit() -> None:
     df = pl.DataFrame({"date": [date(2020, 1, 1)], "value": [42]})
 
-    with pytest.raises(ValueError):
-        df.filter(pl.col("date") == pl.Date("2020-01-01"))
+    with pytest.raises(TypeError):
+        df.filter(pl.col("date") == pl.Date("2020-01-01"))  # type: ignore[call-arg]
 
 
 def test_error_on_double_agg() -> None:


### PR DESCRIPTION
Previously:

```pycon
>>> pl.Int8(10)
<polars.datatypes.classes.Int8 object at 0x7f4b477dd710>
>>> pl.Datetime()
Datetime  
```

After

```pycon
>>> pl.Int8(10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: IntegerType.__new__() takes 1 positional argument but 2 were given

>>> pl.Datetime()
Datetime(time_unit='us', time_zone=None)   
```

I want to get rid of the logic that converts `Int8() -> Int8`, but this PR is a quick fix that already relieves some of the friction.