### PR TITLE
perf: speed up cov/corr with SIMD + strength-reduction `~3x 0.19.13/ ~2x numpy`

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -20,6 +20,7 @@ use crate::series::implementations::SeriesWrap;
 use crate::series::IsSorted;
 
 mod float_sum;
+pub use float_sum::f64 as sum_f64;
 
 /// Aggregations that return [`Series`] of unit length. Those can be used in broadcasting operations.
 pub trait ChunkAggSeries {

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -45,5 +45,5 @@ def test_correlation_cast_supertype() -> None:
     df = pl.DataFrame({"a": [1, 8, 3], "b": [4.0, 5.0, 2.0]})
     df = df.with_columns(pl.col("b"))
     assert df.select(pl.corr("a", "b")).to_dict(as_series=False) == {
-        "a": [0.5447047794019223]
+        "a": [0.5447047794019221]
     }


### PR DESCRIPTION
After #12412 @orlp recommended an algorithm that can utilize SIMD and amortizes division to only 2 per block.

I've left the iterators as is, so there is a data copy. For now I think it is fine.

We are now `~2x` faster than numpy and about `~3x` faster than 0.19.13.