### PR TITLE
docs(python): Use `.with_columns()` in all `.list` namespace examples

### DIFF
--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -1009,30 +1009,33 @@ class ExprListNameSpace:
         Convert list to struct with default field name assignment:
 
         >>> df = pl.DataFrame({"n": [[0, 1], [0, 1, 2]]})
-        >>> df.with_columns(struct=pl.col("n").list.to_struct())
+        >>> df.with_columns(
+        ...     struct=pl.col("n").list.to_struct()
+        ... )  # doctest: +IGNORE_RESULT
         shape: (2, 2)
         ┌───────────┬───────────┐
         │ n         ┆ struct    │
         │ ---       ┆ ---       │
-        │ list[i64] ┆ struct[2] │
+        │ list[i64] ┆ struct[2] │ # <- struct with 2 fields
         ╞═══════════╪═══════════╡
-        │ [0, 1]    ┆ {0,1}     │
-        │ [0, 1, 2] ┆ {0,1}     │
+        │ [0, 1]    ┆ {0,1}     │ # OK
+        │ [0, 1, 2] ┆ {0,1}     │ # NOT OK - last value missing
         └───────────┴───────────┘
 
-        In this case we must use the `max_width` strategy:
+        As the shorter sublist comes first, we must use the `max_width`
+        strategy to force a search for the longest.
 
         >>> df.with_columns(
         ...     struct=pl.col("n").list.to_struct(n_field_strategy="max_width")
-        ... )
+        ... )  # doctest: +IGNORE_RESULT
         shape: (2, 2)
         ┌───────────┬────────────┐
         │ n         ┆ struct     │
         │ ---       ┆ ---        │
-        │ list[i64] ┆ struct[3]  │
+        │ list[i64] ┆ struct[3]  │ # <- struct with 3 fields
         ╞═══════════╪════════════╡
-        │ [0, 1]    ┆ {0,1,null} │
-        │ [0, 1, 2] ┆ {0,1,2}    │
+        │ [0, 1]    ┆ {0,1,null} │ # OK
+        │ [0, 1, 2] ┆ {0,1,2}    │ # OK
         └───────────┴────────────┘
 
         Convert list to struct with field name assignment by function/index:

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -44,20 +44,20 @@ class ExprListNameSpace:
         >>> df = pl.DataFrame(
         ...     {"a": [[True, True], [False, True], [False, False], [None], [], None]}
         ... )
-        >>> df.select(pl.col("a").list.all())
-        shape: (6, 1)
-        ┌───────┐
-        │ a     │
-        │ ---   │
-        │ bool  │
-        ╞═══════╡
-        │ true  │
-        │ false │
-        │ false │
-        │ true  │
-        │ true  │
-        │ null  │
-        └───────┘
+        >>> df.with_columns(all=pl.col("a").list.all())
+        shape: (6, 2)
+        ┌────────────────┬───────┐
+        │ a              ┆ all   │
+        │ ---            ┆ ---   │
+        │ list[bool]     ┆ bool  │
+        ╞════════════════╪═══════╡
+        │ [true, true]   ┆ true  │
+        │ [false, true]  ┆ false │
+        │ [false, false] ┆ false │
+        │ [null]         ┆ true  │
+        │ []             ┆ true  │
+        │ null           ┆ null  │
+        └────────────────┴───────┘
 
         """
         return wrap_expr(self._pyexpr.list_all())
@@ -71,20 +71,20 @@ class ExprListNameSpace:
         >>> df = pl.DataFrame(
         ...     {"a": [[True, True], [False, True], [False, False], [None], [], None]}
         ... )
-        >>> df.select(pl.col("a").list.any())
-        shape: (6, 1)
-        ┌───────┐
-        │ a     │
-        │ ---   │
-        │ bool  │
-        ╞═══════╡
-        │ true  │
-        │ true  │
-        │ false │
-        │ false │
-        │ false │
-        │ null  │
-        └───────┘
+        >>> df.with_columns(any=pl.col("a").list.any())
+        shape: (6, 2)
+        ┌────────────────┬───────┐
+        │ a              ┆ any   │
+        │ ---            ┆ ---   │
+        │ list[bool]     ┆ bool  │
+        ╞════════════════╪═══════╡
+        │ [true, true]   ┆ true  │
+        │ [false, true]  ┆ true  │
+        │ [false, false] ┆ false │
+        │ [null]         ┆ false │
+        │ []             ┆ false │
+        │ null           ┆ null  │
+        └────────────────┴───────┘
 
         """
         return wrap_expr(self._pyexpr.list_any())
@@ -103,16 +103,16 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [[1, 2, None], [5]]})
-        >>> df.select(pl.col("a").list.len())
-        shape: (2, 1)
-        ┌─────┐
-        │ a   │
-        │ --- │
-        │ u32 │
-        ╞═════╡
-        │ 3   │
-        │ 1   │
-        └─────┘
+        >>> df.with_columns(len=pl.col("a").list.len())
+        shape: (2, 2)
+        ┌──────────────┬─────┐
+        │ a            ┆ len │
+        │ ---          ┆ --- │
+        │ list[i64]    ┆ u32 │
+        ╞══════════════╪═════╡
+        │ [1, 2, null] ┆ 3   │
+        │ [5]          ┆ 1   │
+        └──────────────┴─────┘
 
         """
         return wrap_expr(self._pyexpr.list_len())
@@ -126,17 +126,17 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"values": [[None, 1, None, 2], [None], [3, 4]]})
-        >>> df.select(pl.col("values").list.drop_nulls())
-        shape: (3, 1)
-        ┌───────────┐
-        │ values    │
-        │ ---       │
-        │ list[i64] │
-        ╞═══════════╡
-        │ [1, 2]    │
-        │ []        │
-        │ [3, 4]    │
-        └───────────┘
+        >>> df.with_columns(drop_nulls=pl.col("values").list.drop_nulls())
+        shape: (3, 2)
+        ┌────────────────┬────────────┐
+        │ values         ┆ drop_nulls │
+        │ ---            ┆ ---        │
+        │ list[i64]      ┆ list[i64]  │
+        ╞════════════════╪════════════╡
+        │ [null, 1, … 2] ┆ [1, 2]     │
+        │ [null]         ┆ []         │
+        │ [3, 4]         ┆ [3, 4]     │
+        └────────────────┴────────────┘
 
         """
         return wrap_expr(self._pyexpr.list_drop_nulls())
@@ -171,16 +171,16 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"values": [[1, 2, 3], [4, 5]], "n": [2, 1]})
-        >>> df.select(pl.col("values").list.sample(n=pl.col("n"), seed=1))
-        shape: (2, 1)
-        ┌───────────┐
-        │ values    │
-        │ ---       │
-        │ list[i64] │
-        ╞═══════════╡
-        │ [2, 1]    │
-        │ [5]       │
-        └───────────┘
+        >>> df.with_columns(sample=pl.col("values").list.sample(n=pl.col("n"), seed=1))
+        shape: (2, 3)
+        ┌───────────┬─────┬───────────┐
+        │ values    ┆ n   ┆ sample    │
+        │ ---       ┆ --- ┆ ---       │
+        │ list[i64] ┆ i64 ┆ list[i64] │
+        ╞═══════════╪═════╪═══════════╡
+        │ [1, 2, 3] ┆ 2   ┆ [2, 1]    │
+        │ [4, 5]    ┆ 1   ┆ [5]       │
+        └───────────┴─────┴───────────┘
 
         """
         if n is not None and fraction is not None:
@@ -206,16 +206,16 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"values": [[1], [2, 3]]})
-        >>> df.select(pl.col("values").list.sum())
-        shape: (2, 1)
-        ┌────────┐
-        │ values │
-        │ ---    │
-        │ i64    │
-        ╞════════╡
-        │ 1      │
-        │ 5      │
-        └────────┘
+        >>> df.with_columns(sum=pl.col("values").list.sum())
+        shape: (2, 2)
+        ┌───────────┬─────┐
+        │ values    ┆ sum │
+        │ ---       ┆ --- │
+        │ list[i64] ┆ i64 │
+        ╞═══════════╪═════╡
+        │ [1]       ┆ 1   │
+        │ [2, 3]    ┆ 5   │
+        └───────────┴─────┘
 
         """
         return wrap_expr(self._pyexpr.list_sum())
@@ -227,16 +227,16 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"values": [[1], [2, 3]]})
-        >>> df.select(pl.col("values").list.max())
-        shape: (2, 1)
-        ┌────────┐
-        │ values │
-        │ ---    │
-        │ i64    │
-        ╞════════╡
-        │ 1      │
-        │ 3      │
-        └────────┘
+        >>> df.with_columns(max=pl.col("values").list.max())
+        shape: (2, 2)
+        ┌───────────┬─────┐
+        │ values    ┆ max │
+        │ ---       ┆ --- │
+        │ list[i64] ┆ i64 │
+        ╞═══════════╪═════╡
+        │ [1]       ┆ 1   │
+        │ [2, 3]    ┆ 3   │
+        └───────────┴─────┘
 
         """
         return wrap_expr(self._pyexpr.list_max())
@@ -248,16 +248,16 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"values": [[1], [2, 3]]})
-        >>> df.select(pl.col("values").list.min())
-        shape: (2, 1)
-        ┌────────┐
-        │ values │
-        │ ---    │
-        │ i64    │
-        ╞════════╡
-        │ 1      │
-        │ 2      │
-        └────────┘
+        >>> df.with_columns(min=pl.col("values").list.min())
+        shape: (2, 2)
+        ┌───────────┬─────┐
+        │ values    ┆ min │
+        │ ---       ┆ --- │
+        │ list[i64] ┆ i64 │
+        ╞═══════════╪═════╡
+        │ [1]       ┆ 1   │
+        │ [2, 3]    ┆ 2   │
+        └───────────┴─────┘
 
         """
         return wrap_expr(self._pyexpr.list_min())
@@ -269,16 +269,16 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"values": [[1], [2, 3]]})
-        >>> df.select(pl.col("values").list.mean())
-        shape: (2, 1)
-        ┌────────┐
-        │ values │
-        │ ---    │
-        │ f64    │
-        ╞════════╡
-        │ 1.0    │
-        │ 2.5    │
-        └────────┘
+        >>> df.with_columns(min=pl.col("values").list.mean())
+        shape: (2, 2)
+        ┌───────────┬─────┐
+        │ values    ┆ min │
+        │ ---       ┆ --- │
+        │ list[i64] ┆ f64 │
+        ╞═══════════╪═════╡
+        │ [1]       ┆ 1.0 │
+        │ [2, 3]    ┆ 2.5 │
+        └───────────┴─────┘
 
         """
         return wrap_expr(self._pyexpr.list_mean())
@@ -299,26 +299,26 @@ class ExprListNameSpace:
         ...         "a": [[3, 2, 1], [9, 1, 2]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").list.sort())
-        shape: (2, 1)
-        ┌───────────┐
-        │ a         │
-        │ ---       │
-        │ list[i64] │
-        ╞═══════════╡
-        │ [1, 2, 3] │
-        │ [1, 2, 9] │
-        └───────────┘
-        >>> df.select(pl.col("a").list.sort(descending=True))
-        shape: (2, 1)
-        ┌───────────┐
-        │ a         │
-        │ ---       │
-        │ list[i64] │
-        ╞═══════════╡
-        │ [3, 2, 1] │
-        │ [9, 2, 1] │
-        └───────────┘
+        >>> df.with_columns(sort=pl.col("a").list.sort())
+        shape: (2, 2)
+        ┌───────────┬───────────┐
+        │ a         ┆ sort      │
+        │ ---       ┆ ---       │
+        │ list[i64] ┆ list[i64] │
+        ╞═══════════╪═══════════╡
+        │ [3, 2, 1] ┆ [1, 2, 3] │
+        │ [9, 1, 2] ┆ [1, 2, 9] │
+        └───────────┴───────────┘
+        >>> df.with_columns(sort=pl.col("a").list.sort(descending=True))
+        shape: (2, 2)
+        ┌───────────┬───────────┐
+        │ a         ┆ sort      │
+        │ ---       ┆ ---       │
+        │ list[i64] ┆ list[i64] │
+        ╞═══════════╪═══════════╡
+        │ [3, 2, 1] ┆ [3, 2, 1] │
+        │ [9, 1, 2] ┆ [9, 2, 1] │
+        └───────────┴───────────┘
 
         """
         return wrap_expr(self._pyexpr.list_sort(descending))
@@ -334,16 +334,16 @@ class ExprListNameSpace:
         ...         "a": [[3, 2, 1], [9, 1, 2]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").list.reverse())
-        shape: (2, 1)
-        ┌───────────┐
-        │ a         │
-        │ ---       │
-        │ list[i64] │
-        ╞═══════════╡
-        │ [1, 2, 3] │
-        │ [2, 1, 9] │
-        └───────────┘
+        >>> df.with_columns(reverse=pl.col("a").list.reverse())
+        shape: (2, 2)
+        ┌───────────┬───────────┐
+        │ a         ┆ reverse   │
+        │ ---       ┆ ---       │
+        │ list[i64] ┆ list[i64] │
+        ╞═══════════╪═══════════╡
+        │ [3, 2, 1] ┆ [1, 2, 3] │
+        │ [9, 1, 2] ┆ [2, 1, 9] │
+        └───────────┴───────────┘
 
         """
         return wrap_expr(self._pyexpr.list_reverse())
@@ -364,15 +364,15 @@ class ExprListNameSpace:
         ...         "a": [[1, 1, 2]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").list.unique())
-        shape: (1, 1)
-        ┌───────────┐
-        │ a         │
-        │ ---       │
-        │ list[i64] │
-        ╞═══════════╡
-        │ [1, 2]    │
-        └───────────┘
+        >>> df.with_columns(unique=pl.col("a").list.unique())
+        shape: (1, 2)
+        ┌───────────┬───────────┐
+        │ a         ┆ unique    │
+        │ ---       ┆ ---       │
+        │ list[i64] ┆ list[i64] │
+        ╞═══════════╪═══════════╡
+        │ [1, 1, 2] ┆ [1, 2]    │
+        └───────────┴───────────┘
 
         """
         return wrap_expr(self._pyexpr.list_unique(maintain_order))
@@ -394,16 +394,16 @@ class ExprListNameSpace:
         ...         "b": [["b", "c"], ["y", "z"]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").list.concat("b"))
-        shape: (2, 1)
-        ┌─────────────────┐
-        │ a               │
-        │ ---             │
-        │ list[str]       │
-        ╞═════════════════╡
-        │ ["a", "b", "c"] │
-        │ ["x", "y", "z"] │
-        └─────────────────┘
+        >>> df.with_columns(concat=pl.col("a").list.concat("b"))
+        shape: (2, 3)
+        ┌───────────┬────────────┬─────────────────┐
+        │ a         ┆ b          ┆ concat          │
+        │ ---       ┆ ---        ┆ ---             │
+        │ list[str] ┆ list[str]  ┆ list[str]       │
+        ╞═══════════╪════════════╪═════════════════╡
+        │ ["a"]     ┆ ["b", "c"] ┆ ["a", "b", "c"] │
+        │ ["x"]     ┆ ["y", "z"] ┆ ["x", "y", "z"] │
+        └───────────┴────────────┴─────────────────┘
 
         """
         if isinstance(other, list) and (
@@ -432,18 +432,18 @@ class ExprListNameSpace:
 
         Examples
         --------
-        >>> df = pl.DataFrame({"foo": [[3, 2, 1], [], [1, 2]]})
-        >>> df.select(pl.col("foo").list.get(0))
-        shape: (3, 1)
-        ┌──────┐
-        │ foo  │
-        │ ---  │
-        │ i64  │
-        ╞══════╡
-        │ 3    │
-        │ null │
-        │ 1    │
-        └──────┘
+        >>> df = pl.DataFrame({"a": [[3, 2, 1], [], [1, 2]]})
+        >>> df.with_columns(get=pl.col("a").list.get(0))
+        shape: (3, 2)
+        ┌───────────┬──────┐
+        │ a         ┆ get  │
+        │ ---       ┆ ---  │
+        │ list[i64] ┆ i64  │
+        ╞═══════════╪══════╡
+        │ [3, 2, 1] ┆ 3    │
+        │ []        ┆ null │
+        │ [1, 2]    ┆ 1    │
+        └───────────┴──────┘
 
         """
         index = parse_as_expression(index)
@@ -471,6 +471,21 @@ class ExprListNameSpace:
             False -> raise an error
             Note that defaulting to raising an error is much cheaper
 
+        Examples
+        --------
+        >>> df = pl.DataFrame({"a": [[3, 2, 1], [], [1, 2, 3, 4, 5]]})
+        >>> df.with_columns(take=pl.col("a").list.take([0, 4], null_on_oob=True))
+        shape: (3, 2)
+        ┌─────────────┬──────────────┐
+        │ a           ┆ take         │
+        │ ---         ┆ ---          │
+        │ list[i64]   ┆ list[i64]    │
+        ╞═════════════╪══════════════╡
+        │ [3, 2, 1]   ┆ [3, null]    │
+        │ []          ┆ [null, null] │
+        │ [1, 2, … 5] ┆ [1, 5]       │
+        └─────────────┴──────────────┘
+
         """
         if isinstance(index, list):
             index = pl.Series(index)
@@ -483,18 +498,18 @@ class ExprListNameSpace:
 
         Examples
         --------
-        >>> df = pl.DataFrame({"foo": [[3, 2, 1], [], [1, 2]]})
-        >>> df.select(pl.col("foo").list.first())
-        shape: (3, 1)
-        ┌──────┐
-        │ foo  │
-        │ ---  │
-        │ i64  │
-        ╞══════╡
-        │ 3    │
-        │ null │
-        │ 1    │
-        └──────┘
+        >>> df = pl.DataFrame({"a": [[3, 2, 1], [], [1, 2]]})
+        >>> df.with_columns(first=pl.col("a").list.first())
+        shape: (3, 2)
+        ┌───────────┬───────┐
+        │ a         ┆ first │
+        │ ---       ┆ ---   │
+        │ list[i64] ┆ i64   │
+        ╞═══════════╪═══════╡
+        │ [3, 2, 1] ┆ 3     │
+        │ []        ┆ null  │
+        │ [1, 2]    ┆ 1     │
+        └───────────┴───────┘
 
         """
         return self.get(0)
@@ -505,18 +520,18 @@ class ExprListNameSpace:
 
         Examples
         --------
-        >>> df = pl.DataFrame({"foo": [[3, 2, 1], [], [1, 2]]})
-        >>> df.select(pl.col("foo").list.last())
-        shape: (3, 1)
-        ┌──────┐
-        │ foo  │
-        │ ---  │
-        │ i64  │
-        ╞══════╡
-        │ 1    │
-        │ null │
-        │ 2    │
-        └──────┘
+        >>> df = pl.DataFrame({"a": [[3, 2, 1], [], [1, 2]]})
+        >>> df.with_columns(last=pl.col("a").list.last())
+        shape: (3, 2)
+        ┌───────────┬──────┐
+        │ a         ┆ last │
+        │ ---       ┆ ---  │
+        │ list[i64] ┆ i64  │
+        ╞═══════════╪══════╡
+        │ [3, 2, 1] ┆ 1    │
+        │ []        ┆ null │
+        │ [1, 2]    ┆ 2    │
+        └───────────┴──────┘
 
         """
         return self.get(-1)
@@ -539,18 +554,18 @@ class ExprListNameSpace:
 
         Examples
         --------
-        >>> df = pl.DataFrame({"foo": [[3, 2, 1], [], [1, 2]]})
-        >>> df.select(pl.col("foo").list.contains(1))
-        shape: (3, 1)
-        ┌───────┐
-        │ foo   │
-        │ ---   │
-        │ bool  │
-        ╞═══════╡
-        │ true  │
-        │ false │
-        │ true  │
-        └───────┘
+        >>> df = pl.DataFrame({"a": [[3, 2, 1], [], [1, 2]]})
+        >>> df.with_columns(contains=pl.col("a").list.contains(1))
+        shape: (3, 2)
+        ┌───────────┬──────────┐
+        │ a         ┆ contains │
+        │ ---       ┆ ---      │
+        │ list[i64] ┆ bool     │
+        ╞═══════════╪══════════╡
+        │ [3, 2, 1] ┆ true     │
+        │ []        ┆ false    │
+        │ [1, 2]    ┆ true     │
+        └───────────┴──────────┘
 
         """
         item = parse_as_expression(item, str_as_lit=True)
@@ -575,30 +590,31 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"s": [["a", "b", "c"], ["x", "y"]]})
-        >>> df.select(pl.col("s").list.join(" "))
-        shape: (2, 1)
-        ┌───────┐
-        │ s     │
-        │ ---   │
-        │ str   │
-        ╞═══════╡
-        │ a b c │
-        │ x y   │
-        └───────┘
+        >>> df.with_columns(join=pl.col("s").list.join(" "))
+        shape: (2, 2)
+        ┌─────────────────┬───────┐
+        │ s               ┆ join  │
+        │ ---             ┆ ---   │
+        │ list[str]       ┆ str   │
+        ╞═════════════════╪═══════╡
+        │ ["a", "b", "c"] ┆ a b c │
+        │ ["x", "y"]      ┆ x y   │
+        └─────────────────┴───────┘
 
         >>> df = pl.DataFrame(
         ...     {"s": [["a", "b", "c"], ["x", "y"]], "separator": ["*", "_"]}
         ... )
-        >>> df.select(pl.col("s").list.join(pl.col("separator")))
-        shape: (2, 1)
-        ┌───────┐
-        │ s     │
-        │ ---   │
-        │ str   │
-        ╞═══════╡
-        │ a*b*c │
-        │ x_y   │
-        └───────┘
+        >>> df.with_columns(join=pl.col("s").list.join(pl.col("separator")))
+        shape: (2, 3)
+        ┌─────────────────┬───────────┬───────┐
+        │ s               ┆ separator ┆ join  │
+        │ ---             ┆ ---       ┆ ---   │
+        │ list[str]       ┆ str       ┆ str   │
+        ╞═════════════════╪═══════════╪═══════╡
+        │ ["a", "b", "c"] ┆ *         ┆ a*b*c │
+        │ ["x", "y"]      ┆ _         ┆ x_y   │
+        └─────────────────┴───────────┴───────┘
+
         """
         separator = parse_as_expression(separator, str_as_lit=True)
         return wrap_expr(self._pyexpr.list_join(separator))
@@ -620,16 +636,16 @@ class ExprListNameSpace:
         ...         "a": [[1, 2], [2, 1]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").list.arg_min())
-        shape: (2, 1)
-        ┌─────┐
-        │ a   │
-        │ --- │
-        │ u32 │
-        ╞═════╡
-        │ 0   │
-        │ 1   │
-        └─────┘
+        >>> df.with_columns(arg_min=pl.col("a").list.arg_min())
+        shape: (2, 2)
+        ┌───────────┬─────────┐
+        │ a         ┆ arg_min │
+        │ ---       ┆ ---     │
+        │ list[i64] ┆ u32     │
+        ╞═══════════╪═════════╡
+        │ [1, 2]    ┆ 0       │
+        │ [2, 1]    ┆ 1       │
+        └───────────┴─────────┘
 
         """
         return wrap_expr(self._pyexpr.list_arg_min())
@@ -651,16 +667,16 @@ class ExprListNameSpace:
         ...         "a": [[1, 2], [2, 1]],
         ...     }
         ... )
-        >>> df.select(pl.col("a").list.arg_max())
-        shape: (2, 1)
-        ┌─────┐
-        │ a   │
-        │ --- │
-        │ u32 │
-        ╞═════╡
-        │ 1   │
-        │ 0   │
-        └─────┘
+        >>> df.with_columns(arg_max=pl.col("a").list.arg_max())
+        shape: (2, 2)
+        ┌───────────┬─────────┐
+        │ a         ┆ arg_max │
+        │ ---       ┆ ---     │
+        │ list[i64] ┆ u32     │
+        ╞═══════════╪═════════╡
+        │ [1, 2]    ┆ 1       │
+        │ [2, 1]    ┆ 0       │
+        └───────────┴─────────┘
 
         """
         return wrap_expr(self._pyexpr.list_arg_max())
@@ -679,38 +695,38 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"n": [[1, 2, 3, 4], [10, 2, 1]]})
-        >>> df.select(pl.col("n").list.diff())
-        shape: (2, 1)
-        ┌────────────────┐
-        │ n              │
-        │ ---            │
-        │ list[i64]      │
-        ╞════════════════╡
-        │ [null, 1, … 1] │
-        │ [null, -8, -1] │
-        └────────────────┘
+        >>> df.with_columns(diff=pl.col("n").list.diff())
+        shape: (2, 2)
+        ┌─────────────┬────────────────┐
+        │ n           ┆ diff           │
+        │ ---         ┆ ---            │
+        │ list[i64]   ┆ list[i64]      │
+        ╞═════════════╪════════════════╡
+        │ [1, 2, … 4] ┆ [null, 1, … 1] │
+        │ [10, 2, 1]  ┆ [null, -8, -1] │
+        └─────────────┴────────────────┘
 
-        >>> df.select(pl.col("n").list.diff(n=2))
-        shape: (2, 1)
-        ┌───────────────────┐
-        │ n                 │
-        │ ---               │
-        │ list[i64]         │
-        ╞═══════════════════╡
-        │ [null, null, … 2] │
-        │ [null, null, -9]  │
-        └───────────────────┘
+        >>> df.with_columns(diff=pl.col("n").list.diff(n=2))
+        shape: (2, 2)
+        ┌─────────────┬───────────────────┐
+        │ n           ┆ diff              │
+        │ ---         ┆ ---               │
+        │ list[i64]   ┆ list[i64]         │
+        ╞═════════════╪═══════════════════╡
+        │ [1, 2, … 4] ┆ [null, null, … 2] │
+        │ [10, 2, 1]  ┆ [null, null, -9]  │
+        └─────────────┴───────────────────┘
 
-        >>> df.select(pl.col("n").list.diff(n=2, null_behavior="drop"))
-        shape: (2, 1)
-        ┌───────────┐
-        │ n         │
-        │ ---       │
-        │ list[i64] │
-        ╞═══════════╡
-        │ [2, 2]    │
-        │ [-9]      │
-        └───────────┘
+        >>> df.with_columns(diff=pl.col("n").list.diff(n=2, null_behavior="drop"))
+        shape: (2, 2)
+        ┌─────────────┬───────────┐
+        │ n           ┆ diff      │
+        │ ---         ┆ ---       │
+        │ list[i64]   ┆ list[i64] │
+        ╞═════════════╪═══════════╡
+        │ [1, 2, … 4] ┆ [2, 2]    │
+        │ [10, 2, 1]  ┆ [-9]      │
+        └─────────────┴───────────┘
 
         """
         return wrap_expr(self._pyexpr.list_diff(n, null_behavior))
@@ -780,14 +796,17 @@ class ExprListNameSpace:
 
         Examples
         --------
-        >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
-        >>> s.list.slice(1, 2)
-        shape: (2,)
-        Series: 'a' [list[i64]]
-        [
-            [2, 3]
-            [2, 1]
-        ]
+        >>> df = pl.DataFrame({"a": [[1, 2, 3, 4], [10, 2, 1]]})
+        >>> df.with_columns(slice=pl.col("a").list.slice(1, 2))
+        shape: (2, 2)
+        ┌─────────────┬───────────┐
+        │ a           ┆ slice     │
+        │ ---         ┆ ---       │
+        │ list[i64]   ┆ list[i64] │
+        ╞═════════════╪═══════════╡
+        │ [1, 2, … 4] ┆ [2, 3]    │
+        │ [10, 2, 1]  ┆ [2, 1]    │
+        └─────────────┴───────────┘
 
         """
         offset = parse_as_expression(offset)
@@ -805,14 +824,17 @@ class ExprListNameSpace:
 
         Examples
         --------
-        >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
-        >>> s.list.head(2)
-        shape: (2,)
-        Series: 'a' [list[i64]]
-        [
-            [1, 2]
-            [10, 2]
-        ]
+        >>> df = pl.DataFrame({"a": [[1, 2, 3, 4], [10, 2, 1]]})
+        >>> df.with_columns(head=pl.col("a").list.head(2))
+        shape: (2, 2)
+        ┌─────────────┬───────────┐
+        │ a           ┆ head      │
+        │ ---         ┆ ---       │
+        │ list[i64]   ┆ list[i64] │
+        ╞═════════════╪═══════════╡
+        │ [1, 2, … 4] ┆ [1, 2]    │
+        │ [10, 2, 1]  ┆ [10, 2]   │
+        └─────────────┴───────────┘
 
         """
         return self.slice(0, n)
@@ -828,14 +850,17 @@ class ExprListNameSpace:
 
         Examples
         --------
-        >>> s = pl.Series("a", [[1, 2, 3, 4], [10, 2, 1]])
-        >>> s.list.tail(2)
-        shape: (2,)
-        Series: 'a' [list[i64]]
-        [
-            [3, 4]
-            [2, 1]
-        ]
+        >>> df = pl.DataFrame({"a": [[1, 2, 3, 4], [10, 2, 1]]})
+        >>> df.with_columns(tail=pl.col("a").list.tail(2))
+        shape: (2, 2)
+        ┌─────────────┬───────────┐
+        │ a           ┆ tail      │
+        │ ---         ┆ ---       │
+        │ list[i64]   ┆ list[i64] │
+        ╞═════════════╪═══════════╡
+        │ [1, 2, … 4] ┆ [3, 4]    │
+        │ [10, 2, 1]  ┆ [2, 1]    │
+        └─────────────┴───────────┘
 
         """
         n = parse_as_expression(n)
@@ -886,20 +911,20 @@ class ExprListNameSpace:
 
         Examples
         --------
-        >>> df = pl.DataFrame({"listcol": [[0], [1], [1, 2, 3, 2], [1, 2, 1], [4, 4]]})
-        >>> df.select(pl.col("listcol").list.count_matches(2).alias("number_of_twos"))
-        shape: (5, 1)
-        ┌────────────────┐
-        │ number_of_twos │
-        │ ---            │
-        │ u32            │
-        ╞════════════════╡
-        │ 0              │
-        │ 0              │
-        │ 2              │
-        │ 1              │
-        │ 0              │
-        └────────────────┘
+        >>> df = pl.DataFrame({"a": [[0], [1], [1, 2, 3, 2], [1, 2, 1], [4, 4]]})
+        >>> df.with_columns(number_of_twos=pl.col("a").list.count_matches(2))
+        shape: (5, 2)
+        ┌─────────────┬────────────────┐
+        │ a           ┆ number_of_twos │
+        │ ---         ┆ ---            │
+        │ list[i64]   ┆ u32            │
+        ╞═════════════╪════════════════╡
+        │ [0]         ┆ 0              │
+        │ [1]         ┆ 0              │
+        │ [1, 2, … 2] ┆ 2              │
+        │ [1, 2, 1]   ┆ 1              │
+        │ [4, 4]      ┆ 0              │
+        └─────────────┴────────────────┘
 
         """
         element = parse_as_expression(element, str_as_lit=True)
@@ -925,16 +950,16 @@ class ExprListNameSpace:
         ...     data={"a": [[1, 2], [3, 4]]},
         ...     schema={"a": pl.List(pl.Int8)},
         ... )
-        >>> df.select(pl.col("a").list.to_array(2))
-        shape: (2, 1)
-        ┌──────────────┐
-        │ a            │
-        │ ---          │
-        │ array[i8, 2] │
-        ╞══════════════╡
-        │ [1, 2]       │
-        │ [3, 4]       │
-        └──────────────┘
+        >>> df.with_columns(array=pl.col("a").list.to_array(2))
+        shape: (2, 2)
+        ┌──────────┬──────────────┐
+        │ a        ┆ array        │
+        │ ---      ┆ ---          │
+        │ list[i8] ┆ array[i8, 2] │
+        ╞══════════╪══════════════╡
+        │ [1, 2]   ┆ [1, 2]       │
+        │ [3, 4]   ┆ [3, 4]       │
+        └──────────┴──────────────┘
 
         """
         return wrap_expr(self._pyexpr.list_to_array(width))
@@ -972,36 +997,58 @@ class ExprListNameSpace:
             tracked or pre-determined, as the result will be eagerly evaluated,
             so you can leave this parameter unset.
 
+        Notes
+        -----
+        For performance reasons, the length of the first non-null sublist is used
+        to determine the number of output fields. If the sublists can be of different
+        lengths then `n_field_strategy="max_width"` must be used to obtain the expected
+        result.
+
         Examples
         --------
         Convert list to struct with default field name assignment:
 
-        >>> df = pl.DataFrame({"n": [[0, 1, 2], [0, 1]]})
-        >>> df.select(pl.col("n").list.to_struct())
-        shape: (2, 1)
-        ┌────────────┐
-        │ n          │
-        │ ---        │
-        │ struct[3]  │
-        ╞════════════╡
-        │ {0,1,2}    │
-        │ {0,1,null} │
-        └────────────┘
+        >>> df = pl.DataFrame({"n": [[0, 1], [0, 1, 2]]})
+        >>> df.with_columns(struct=pl.col("n").list.to_struct())
+        shape: (2, 2)
+        ┌───────────┬───────────┐
+        │ n         ┆ struct    │
+        │ ---       ┆ ---       │
+        │ list[i64] ┆ struct[2] │
+        ╞═══════════╪═══════════╡
+        │ [0, 1]    ┆ {0,1}     │
+        │ [0, 1, 2] ┆ {0,1}     │
+        └───────────┴───────────┘
+
+        In this case we must use the `max_width` strategy:
+
+        >>> df.with_columns(
+        ...     struct=pl.col("n").list.to_struct(n_field_strategy="max_width")
+        ... )
+        shape: (2, 2)
+        ┌───────────┬────────────┐
+        │ n         ┆ struct     │
+        │ ---       ┆ ---        │
+        │ list[i64] ┆ struct[3]  │
+        ╞═══════════╪════════════╡
+        │ [0, 1]    ┆ {0,1,null} │
+        │ [0, 1, 2] ┆ {0,1,2}    │
+        └───────────┴────────────┘
 
         Convert list to struct with field name assignment by function/index:
 
+        >>> df = pl.DataFrame({"n": [[0, 1], [2, 3]]})
         >>> df.select(pl.col("n").list.to_struct(fields=lambda idx: f"n{idx}")).rows(
         ...     named=True
         ... )
-        [{'n': {'n0': 0, 'n1': 1, 'n2': 2}}, {'n': {'n0': 0, 'n1': 1, 'n2': None}}]
+        [{'n': {'n0': 0, 'n1': 1}}, {'n': {'n0': 2, 'n1': 3}}]
 
         Convert list to struct with field name assignment by index from a list of names:
 
-        >>> df.select(pl.col("n").list.to_struct(fields=["one", "two", "three"])).rows(
+        >>> df.select(pl.col("n").list.to_struct(fields=["one", "two"])).rows(
         ...     named=True
         ... )
-        [{'n': {'one': 0, 'two': 1, 'three': 2}},
-        {'n': {'one': 0, 'two': 1, 'three': None}}]
+        [{'n': {'one': 0, 'two': 1}}, {'n': {'one': 2, 'two': 3}}]
 
         """
         if isinstance(fields, Sequence):
@@ -1034,7 +1081,7 @@ class ExprListNameSpace:
         --------
         >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
         >>> df.with_columns(
-        ...     pl.concat_list(["a", "b"]).list.eval(pl.element().rank()).alias("rank")
+        ...     rank=pl.concat_list("a", "b").list.eval(pl.element().rank())
         ... )
         shape: (3, 3)
         ┌─────┬─────┬────────────┐
@@ -1068,7 +1115,7 @@ class ExprListNameSpace:
         ...     }
         ... )
         >>> df.with_columns(
-        ...     pl.col("a").list.set_union("b").alias("union")
+        ...     union=pl.col("a").list.set_union("b")
         ... )  # doctest: +IGNORE_RESULT
         shape: (4, 3)
         ┌───────────┬──────────────┬───────────────┐
@@ -1103,7 +1150,7 @@ class ExprListNameSpace:
         ...         "b": [[2, 3, 4], [3], [3, 4, None], [6, 8]],
         ...     }
         ... )
-        >>> df.with_columns(pl.col("a").list.set_difference("b").alias("difference"))
+        >>> df.with_columns(difference=pl.col("a").list.set_difference("b"))
         shape: (4, 3)
         ┌───────────┬──────────────┬────────────┐
         │ a         ┆ b            ┆ difference │
@@ -1141,9 +1188,7 @@ class ExprListNameSpace:
         ...         "b": [[2, 3, 4], [3], [3, 4, None], [6, 8]],
         ...     }
         ... )
-        >>> df.with_columns(
-        ...     pl.col("a").list.set_intersection("b").alias("intersection")
-        ... )
+        >>> df.with_columns(intersection=pl.col("a").list.set_intersection("b"))
         shape: (4, 3)
         ┌───────────┬──────────────┬──────────────┐
         │ a         ┆ b            ┆ intersection │
@@ -1177,9 +1222,7 @@ class ExprListNameSpace:
         ...         "b": [[2, 3, 4], [3], [3, 4, None], [6, 8]],
         ...     }
         ... )
-        >>> df.with_columns(
-        ...     pl.col("b").list.set_symmetric_difference("a").alias("sdiff")
-        ... )
+        >>> df.with_columns(sdiff=pl.col("b").list.set_symmetric_difference("a"))
         shape: (4, 3)
         ┌───────────┬──────────────┬───────────┐
         │ a         ┆ b            ┆ sdiff     │


### PR DESCRIPTION
Not sure if I need to make an issue for this first:

I noticed `.select()` was used when checking the docs for `.list.join` so I thought I'd update all the examples.

A couple of other changes:

- replaced all `.alias()` calls with named expressions
- a few examples used `pl.Series` so I changed them to `pl.DataFrame`
- `.list.take()` had no example, so I added one
- I added some `max_width` examples/notes to `.list.to_struct()`
