### PR TITLE
feat(python,rust!): Add dedicated horizontal aggregation methods to `DataFrame`

### DIFF
--- a/crates/polars-ops/src/series/ops/horizontal.rs
+++ b/crates/polars-ops/src/series/ops/horizontal.rs
@@ -70,11 +70,13 @@ pub fn all_horizontal(s: &[Series]) -> PolarsResult<Series> {
 #[cfg(feature = "zip_with")]
 pub fn max_horizontal(s: &[Series]) -> PolarsResult<Option<Series>> {
     let df = DataFrame::new_no_checks(Vec::from(s));
-    df.hmax().map(|opt_s| opt_s.map(|s| s.with_name("max")))
+    df.max_horizontal()
+        .map(|opt_s| opt_s.map(|s| s.with_name("max")))
 }
 
 #[cfg(feature = "zip_with")]
 pub fn min_horizontal(s: &[Series]) -> PolarsResult<Option<Series>> {
     let df = DataFrame::new_no_checks(Vec::from(s));
-    df.hmin().map(|opt_s| opt_s.map(|s| s.with_name("min")))
+    df.min_horizontal()
+        .map(|opt_s| opt_s.map(|s| s.with_name("min")))
 }

--- a/py-polars/docs/source/reference/dataframe/aggregation.rst
+++ b/py-polars/docs/source/reference/dataframe/aggregation.rst
@@ -7,11 +7,15 @@ Aggregation
    :toctree: api/
 
     DataFrame.max
+    DataFrame.max_horizontal
     DataFrame.mean
+    DataFrame.mean_horizontal
     DataFrame.median
     DataFrame.min
+    DataFrame.min_horizontal
     DataFrame.product
     DataFrame.quantile
     DataFrame.std
     DataFrame.sum
+    DataFrame.sum_horizontal
     DataFrame.var

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8304,7 +8304,7 @@ class DataFrame:
                 raise ValueError(
                     f"`null_strategy` must be one of {{'ignore', 'propagate'}}, got {null_strategy}"
                 )
-            return self.sum_horizontal(ignore_nulls)
+            return self.sum_horizontal(ignore_nulls=ignore_nulls)
         raise ValueError("axis should be 0 or 1")
 
     def sum_horizontal(self, *, ignore_nulls: bool = True) -> Series:
@@ -8432,7 +8432,7 @@ class DataFrame:
                 raise ValueError(
                     f"`null_strategy` must be one of {{'ignore', 'propagate'}}, got {null_strategy}"
                 )
-            return self.mean_horizontal(ignore_nulls)
+            return self.mean_horizontal(ignore_nulls=ignore_nulls)
         raise ValueError("axis should be 0 or 1")
 
     def mean_horizontal(self, *, ignore_nulls: bool = True) -> Series:

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8123,7 +8123,7 @@ class DataFrame:
                 6.0
         ]
         """
-        return self.select(F.max_horizontal(F.all()))
+        return self.select(F.max_horizontal(F.all())).to_series()
 
     @overload
     def min(self, axis: Literal[0] | None = ...) -> Self:
@@ -8212,7 +8212,7 @@ class DataFrame:
                 3.0
         ]
         """
-        return self.select(F.min_horizontal(F.all()))
+        return self.select(F.min_horizontal(F.all())).to_series()
 
     @overload
     def sum(
@@ -8339,7 +8339,7 @@ class DataFrame:
                 9.0
         ]
         """
-        return wrap_s(self._df.sum_horizontal(ignore_nulls))
+        return wrap_s(self._df.sum_horizontal(ignore_nulls)).alias("sum")
 
     @overload
     def mean(
@@ -8467,7 +8467,7 @@ class DataFrame:
                 4.5
         ]
         """
-        return wrap_s(self._df.mean_horizontal(ignore_nulls))
+        return wrap_s(self._df.mean_horizontal(ignore_nulls)).alias("mean")
 
     def std(self, ddof: int = 1) -> Self:
         """

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -88,6 +88,7 @@ from polars.utils.deprecation import (
     deprecate_renamed_function,
     deprecate_renamed_parameter,
     deprecate_saturating,
+    issue_deprecation_warning,
 )
 from polars.utils.various import (
     _prepare_row_count_args,
@@ -8047,9 +8048,19 @@ class DataFrame:
     def max(self, axis: int = 0) -> Self | Series:
         ...
 
-    def max(self, axis: int = 0) -> Self | Series:
+    def max(self, axis: int | None = None) -> Self | Series:
         """
         Aggregate the columns of this DataFrame to their maximum value.
+
+        Parameters
+        ----------
+        axis
+            Either 0 (vertical) or 1 (horizontal).
+
+            .. deprecated:: 0.19.14
+                This argument will be removed in a future version. This method will only
+                support vertical aggregation, as if `axis` were set to `0`.
+                To perform horizontal aggregation, use :meth:`max_horizontal`.
 
         Examples
         --------
@@ -8071,14 +8082,51 @@ class DataFrame:
         └─────┴─────┴─────┘
 
         """
+        if axis is not None:
+            issue_deprecation_warning(
+                "The `axis` parameter for `DataFrame.max` is deprecated."
+                " Use `DataFrame.max_horizontal()` to perform horizontal aggregation.",
+                version="0.19.14",
+            )
+        else:
+            axis = 0
+
         if axis == 0:
             return self._from_pydf(self._df.max())
         if axis == 1:
-            return wrap_s(self._df.hmax())
+            return wrap_s(self._df.max_horizontal())
         raise ValueError("axis should be 0 or 1")
 
+    def max_horizontal(self) -> Series:
+        """
+        Get the maximum value horizontally across columns.
+
+        Returns
+        -------
+        Series
+            A Series named `"max"`.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "foo": [1, 2, 3],
+        ...         "bar": [4.0, 5.0, 6.0],
+        ...     }
+        ... )
+        >>> df.max_horizontal()
+        shape: (3,)
+        Series: 'max' [f64]
+        [
+                4.0
+                5.0
+                6.0
+        ]
+        """
+        return self.select(F.max_horizontal(F.all()))
+
     @overload
-    def min(self, axis: Literal[0] = ...) -> Self:
+    def min(self, axis: Literal[0] | None = ...) -> Self:
         ...
 
     @overload
@@ -8086,12 +8134,22 @@ class DataFrame:
         ...
 
     @overload
-    def min(self, axis: int = 0) -> Self | Series:
+    def min(self, axis: int) -> Self | Series:
         ...
 
-    def min(self, axis: int = 0) -> Self | Series:
+    def min(self, axis: int | None = None) -> Self | Series:
         """
         Aggregate the columns of this DataFrame to their minimum value.
+
+        Parameters
+        ----------
+        axis
+            Either 0 (vertical) or 1 (horizontal).
+
+            .. deprecated:: 0.19.14
+                This argument will be removed in a future version. This method will only
+                support vertical aggregation, as if `axis` were set to `0`.
+                To perform horizontal aggregation, use :meth:`min_horizontal`.
 
         Examples
         --------
@@ -8113,11 +8171,48 @@ class DataFrame:
         └─────┴─────┴─────┘
 
         """
+        if axis is not None:
+            issue_deprecation_warning(
+                "The `axis` parameter for `DataFrame.min` is deprecated."
+                " Use `DataFrame.min_horizontal()` to perform horizontal aggregation.",
+                version="0.19.14",
+            )
+        else:
+            axis = 0
+
         if axis == 0:
             return self._from_pydf(self._df.min())
         if axis == 1:
-            return wrap_s(self._df.hmin())
+            return wrap_s(self._df.min_horizontal())
         raise ValueError("axis should be 0 or 1")
+
+    def min_horizontal(self) -> Series:
+        """
+        Get the minimum value horizontally across columns.
+
+        Returns
+        -------
+        Series
+            A Series named `"min"`.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "foo": [1, 2, 3],
+        ...         "bar": [4.0, 5.0, 6.0],
+        ...     }
+        ... )
+        >>> df.min_horizontal()
+        shape: (3,)
+        Series: 'min' [f64]
+        [
+                1.0
+                2.0
+                3.0
+        ]
+        """
+        return self.select(F.min_horizontal(F.all()))
 
     @overload
     def sum(
@@ -8141,7 +8236,7 @@ class DataFrame:
     def sum(
         self,
         *,
-        axis: int = 0,
+        axis: int,
         null_strategy: NullStrategy = "ignore",
     ) -> Self | Series:
         ...
@@ -8149,7 +8244,7 @@ class DataFrame:
     def sum(
         self,
         *,
-        axis: int = 0,
+        axis: int | None = None,
         null_strategy: NullStrategy = "ignore",
     ) -> Self | Series:
         """
@@ -8158,9 +8253,17 @@ class DataFrame:
         Parameters
         ----------
         axis
-            Either 0 or 1.
+            Either 0 (vertical) or 1 (horizontal).
+
+            .. deprecated:: 0.19.14
+                This argument will be removed in a future version. This method will only
+                support vertical aggregation, as if `axis` were set to `0`.
+                To perform horizontal aggregation, use :meth:`sum_horizontal`.
         null_strategy : {'ignore', 'propagate'}
-            This argument is only used if axis == 1.
+            This argument is only used if `axis == 1`.
+
+            .. deprecated:: 0.19.14
+                This argument will be removed in a future version.
 
         Examples
         --------
@@ -8180,21 +8283,63 @@ class DataFrame:
         ╞═════╪═════╪══════╡
         │ 6   ┆ 21  ┆ null │
         └─────┴─────┴──────┘
-        >>> df.sum(axis=1)
-        shape: (3,)
-        Series: 'foo' [str]
-        [
-                "16a"
-                "27b"
-                "38c"
-        ]
-
         """
+        if axis is not None:
+            issue_deprecation_warning(
+                "The `axis` parameter for `DataFrame.sum` is deprecated."
+                " Use `DataFrame.min_horizontal()` to perform horizontal aggregation.",
+                version="0.19.14",
+            )
+        else:
+            axis = 0
+
         if axis == 0:
             return self._from_pydf(self._df.sum())
         if axis == 1:
-            return wrap_s(self._df.hsum(null_strategy))
+            if null_strategy == "ignore":
+                ignore_nulls = True
+            elif null_strategy == "propagate":
+                ignore_nulls = False
+            else:
+                raise ValueError(
+                    f"`null_strategy` must be one of {{'ignore', 'propagate'}}, got {null_strategy}"
+                )
+            return self.sum_horizontal(ignore_nulls)
         raise ValueError("axis should be 0 or 1")
+
+    def sum_horizontal(self, *, ignore_nulls: bool = True) -> Series:
+        """
+        Sum all values horizontally across columns.
+
+        Parameters
+        ----------
+        ignore_nulls
+            Ignore null values (default).
+            If set to `False`, any null value in the input will lead to a null output.
+
+        Returns
+        -------
+        Series
+            A Series named `"sum"`.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "foo": [1, 2, 3],
+        ...         "bar": [4.0, 5.0, 6.0],
+        ...     }
+        ... )
+        >>> df.sum_horizontal()
+        shape: (3,)
+        Series: 'sum' [f64]
+        [
+                5.0
+                7.0
+                9.0
+        ]
+        """
+        return wrap_s(self._df.sum_horizontal(ignore_nulls))
 
     @overload
     def mean(
@@ -8218,7 +8363,7 @@ class DataFrame:
     def mean(
         self,
         *,
-        axis: int = 0,
+        axis: int,
         null_strategy: NullStrategy = "ignore",
     ) -> Self | Series:
         ...
@@ -8226,7 +8371,7 @@ class DataFrame:
     def mean(
         self,
         *,
-        axis: int = 0,
+        axis: int | None = None,
         null_strategy: NullStrategy = "ignore",
     ) -> Self | Series:
         """
@@ -8235,9 +8380,17 @@ class DataFrame:
         Parameters
         ----------
         axis
-            Either 0 or 1.
+            Either 0 (vertical) or 1 (horizontal).
+
+            .. deprecated:: 0.19.14
+                This argument will be removed in a future version. This method will only
+                support vertical aggregation, as if `axis` were set to `0`.
+                To perform horizontal aggregation, use :meth:`mean_horizontal`.
         null_strategy : {'ignore', 'propagate'}
-            This argument is only used if axis == 1.
+            This argument is only used if `axis == 1`.
+
+            .. deprecated:: 0.19.14
+                This argument will be removed in a future version.
 
         Examples
         --------
@@ -8258,21 +8411,63 @@ class DataFrame:
         ╞═════╪═════╪══════╪══════╡
         │ 2.0 ┆ 7.0 ┆ null ┆ 0.5  │
         └─────┴─────┴──────┴──────┘
-        >>> df.mean(axis=1)
-        shape: (3,)
-        Series: 'foo' [f64]
-        [
-            2.666667
-            3.0
-            5.5
-        ]
-
         """
+        if axis is not None:
+            issue_deprecation_warning(
+                "The `axis` parameter for `DataFrame.mean` is deprecated."
+                " Use `DataFrame.mean_horizontal()` to perform horizontal aggregation.",
+                version="0.19.14",
+            )
+        else:
+            axis = 0
+
         if axis == 0:
             return self._from_pydf(self._df.mean())
         if axis == 1:
-            return wrap_s(self._df.hmean(null_strategy))
+            if null_strategy == "ignore":
+                ignore_nulls = True
+            elif null_strategy == "propagate":
+                ignore_nulls = False
+            else:
+                raise ValueError(
+                    f"`null_strategy` must be one of {{'ignore', 'propagate'}}, got {null_strategy}"
+                )
+            return self.mean_horizontal(ignore_nulls)
         raise ValueError("axis should be 0 or 1")
+
+    def mean_horizontal(self, *, ignore_nulls: bool = True) -> Series:
+        """
+        Take the mean of all values horizontally across columns.
+
+        Parameters
+        ----------
+        ignore_nulls
+            Ignore null values (default).
+            If set to `False`, any null value in the input will lead to a null output.
+
+        Returns
+        -------
+        Series
+            A Series named `"mean"`.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "foo": [1, 2, 3],
+        ...         "bar": [4.0, 5.0, 6.0],
+        ...     }
+        ... )
+        >>> df.mean_horizontal()
+        shape: (3,)
+        Series: 'mean' [f64]
+        [
+                2.5
+                3.5
+                4.5
+        ]
+        """
+        return wrap_s(self._df.mean_horizontal(ignore_nulls))
 
     def std(self, ddof: int = 1) -> Self:
         """

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1278,23 +1278,29 @@ impl PyDataFrame {
         self.df.median().into()
     }
 
-    pub fn hmean(&self, null_strategy: Wrap<NullStrategy>) -> PyResult<Option<PySeries>> {
-        let s = self.df.hmean(null_strategy.0).map_err(PyPolarsErr::from)?;
+    pub fn mean_horizontal(&self, null_strategy: Wrap<NullStrategy>) -> PyResult<Option<PySeries>> {
+        let s = self
+            .df
+            .mean_horizontal(null_strategy.0)
+            .map_err(PyPolarsErr::from)?;
         Ok(s.map(|s| s.into()))
     }
 
-    pub fn hmax(&self) -> PyResult<Option<PySeries>> {
-        let s = self.df.hmax().map_err(PyPolarsErr::from)?;
+    pub fn max_horizontal(&self) -> PyResult<Option<PySeries>> {
+        let s = self.df.max_horizontal().map_err(PyPolarsErr::from)?;
         Ok(s.map(|s| s.into()))
     }
 
-    pub fn hmin(&self) -> PyResult<Option<PySeries>> {
-        let s = self.df.hmin().map_err(PyPolarsErr::from)?;
+    pub fn min_horizontal(&self) -> PyResult<Option<PySeries>> {
+        let s = self.df.min_horizontal().map_err(PyPolarsErr::from)?;
         Ok(s.map(|s| s.into()))
     }
 
-    pub fn hsum(&self, null_strategy: Wrap<NullStrategy>) -> PyResult<Option<PySeries>> {
-        let s = self.df.hsum(null_strategy.0).map_err(PyPolarsErr::from)?;
+    pub fn sum_horizontal(&self, null_strategy: Wrap<NullStrategy>) -> PyResult<Option<PySeries>> {
+        let s = self
+            .df
+            .sum_horizontal(null_strategy.0)
+            .map_err(PyPolarsErr::from)?;
         Ok(s.map(|s| s.into()))
     }
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1713,12 +1713,12 @@ def test_panic() -> None:
 def test_horizontal_agg() -> None:
     df = pl.DataFrame({"a": [1, None, 3], "b": [1, 2, 3]})
 
-    assert_series_equal(df.sum_horizontal(), pl.Series("a", [2, 2, 6]))
+    assert_series_equal(df.sum_horizontal(), pl.Series("sum", [2, 2, 6]))
     assert_series_equal(
-        df.sum_horizontal(ignore_nulls=False), pl.Series("a", [2, None, 6])
+        df.sum_horizontal(ignore_nulls=False), pl.Series("sum", [2, None, 6])
     )
     assert_series_equal(
-        df.mean_horizontal(ignore_nulls=False), pl.Series("a", [1.0, None, 3.0])
+        df.mean_horizontal(ignore_nulls=False), pl.Series("mean", [1.0, None, 3.0])
     )
 
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -676,10 +676,10 @@ def test_df_fold() -> None:
 
     df = pl.DataFrame({"a": [3, 2, 1], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
     # just check dispatch. values are tested on rust side.
-    assert len(df.sum(axis=1)) == 3
-    assert len(df.mean(axis=1)) == 3
-    assert len(df.min(axis=1)) == 3
-    assert len(df.max(axis=1)) == 3
+    assert len(df.sum_horizontal()) == 3
+    assert len(df.mean_horizontal()) == 3
+    assert len(df.min_horizontal()) == 3
+    assert len(df.max_horizontal()) == 3
 
     df_width_one = df[["a"]]
     assert_series_equal(df_width_one.fold(lambda s1, s2: s1), df["a"])
@@ -1710,17 +1710,15 @@ def test_panic() -> None:
     a.filter(pl.col("col1") != "b")
 
 
-def test_h_agg() -> None:
+def test_horizontal_agg() -> None:
     df = pl.DataFrame({"a": [1, None, 3], "b": [1, 2, 3]})
 
+    assert_series_equal(df.sum_horizontal(), pl.Series("a", [2, 2, 6]))
     assert_series_equal(
-        df.sum(axis=1, null_strategy="ignore"), pl.Series("a", [2, 2, 6])
+        df.sum_horizontal(ignore_nulls=False), pl.Series("a", [2, None, 6])
     )
     assert_series_equal(
-        df.sum(axis=1, null_strategy="propagate"), pl.Series("a", [2, None, 6])
-    )
-    assert_series_equal(
-        df.mean(axis=1, null_strategy="propagate"), pl.Series("a", [1.0, None, 3.0])
+        df.mean_horizontal(ignore_nulls=False), pl.Series("a", [1.0, None, 3.0])
     )
 
 

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -78,7 +78,7 @@ def test_duration_aggs() -> None:
 def test_mean_horizontal_with_str_column() -> None:
     assert pl.DataFrame(
         {"int": [1, 2, 3], "bool": [True, True, None], "str": ["a", "b", "c"]}
-    ).mean(axis=1).to_list() == [1.0, 1.5, 3.0]
+    ).mean_horizontal().to_list() == [1.0, 1.5, 3.0]
 
 
 def test_list_aggregation_that_filters_all_data_6017() -> None:

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -75,7 +75,7 @@ def test_duration_aggs() -> None:
     }
 
 
-def test_hmean_with_str_column() -> None:
+def test_mean_horizontal_with_str_column() -> None:
     assert pl.DataFrame(
         {"int": [1, 2, 3], "bool": [True, True, None], "str": ["a", "b", "c"]}
     ).mean(axis=1).to_list() == [1.0, 1.5, 3.0]

--- a/py-polars/tests/unit/operations/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/test_arithmetic.py
@@ -206,7 +206,9 @@ def test_literal_no_upcast() -> None:
 
 
 def test_boolean_addition() -> None:
-    s = pl.DataFrame({"a": [True, False, False], "b": [True, False, True]}).sum(axis=1)
+    s = pl.DataFrame(
+        {"a": [True, False, False], "b": [True, False, True]}
+    ).sum_horizontal()
 
     assert s.dtype == pl.utils.get_index_type()
     assert s.to_list() == [2, 0, 1]

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -468,11 +468,9 @@ def test_ewm_with_multiple_chunks() -> None:
     assert df1.n_chunks() == 2
 
     ewm_std = df1.with_columns(
-        [
-            pl.all().ewm_std(com=20).name.prefix("ewm_"),
-        ]
+        pl.all().ewm_std(com=20).name.prefix("ewm_"),
     )
-    assert ewm_std.null_count().sum(axis=1)[0] == 4
+    assert ewm_std.null_count().sum_horizontal()[0] == 4
 
 
 def test_map_dict() -> None:


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/12484

#### Changes

- Add the following `DataFrame` methods:
  - `sum_horizontal`
  - `mean_horizontal`
  - `max_horizontal`
  - `min_horizontal`
- On the Rust side, rename `hsum/hmean/hmax/hmin` to the names above.
- On the Python side, deprecate the horizontal component of the overloaded `sum/mean/max/min` methods.

There is more cleanup to be done around these methods (e.g. add LazyFrame methods, proper dispatching), but at least this takes care of the deprecation and public API.