### PR TITLE
depr(python): Deprecate `Series.inner_dtype` property

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -403,7 +403,14 @@ class Series:
         DataType
 
         """
-        return self._s.inner_dtype()
+        issue_deprecation_warning(
+            "`Series.inner_dtype` is deprecated. Use `Series.dtype.inner` instead.",
+            version="0.19.14",
+        )
+        try:
+            return self.dtype.inner  # type: ignore[union-attr]
+        except AttributeError:
+            return None
 
     @property
     def name(self) -> str:

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -237,13 +237,6 @@ impl PySeries {
         Wrap(self.series.dtype().clone()).to_object(py)
     }
 
-    fn inner_dtype(&self, py: Python) -> Option<PyObject> {
-        self.series
-            .dtype()
-            .inner_dtype()
-            .map(|dt| Wrap(dt.clone()).to_object(py))
-    }
-
     fn set_sorted_flag(&self, descending: bool) -> Self {
         let mut out = self.series.clone();
         if descending {

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -18,7 +18,6 @@ def test_dtype() -> None:
     # inferred
     a = pl.Series("a", [[1, 2, 3], [2, 5], [6, 7, 8, 9]])
     assert a.dtype == pl.List
-    assert a.inner_dtype == pl.Int64
     assert a.dtype.inner == pl.Int64  # type: ignore[union-attr]
     assert a.dtype.is_(pl.List(pl.Int64))
 
@@ -76,8 +75,8 @@ def test_categorical() -> None:
         .to_series(3)
     )
 
-    assert out.inner_dtype == pl.Categorical
-    assert out.inner_dtype not in pl.NESTED_DTYPES
+    assert out.dtype.inner == pl.Categorical  # type: ignore[union-attr]
+    assert out.dtype.inner not in pl.NESTED_DTYPES  # type: ignore[union-attr]
 
 
 def test_cast_inner() -> None:
@@ -193,7 +192,7 @@ def test_local_categorical_list() -> None:
     values = [["a", "b"], ["c"], ["a", "d", "d"]]
     s = pl.Series(values, dtype=pl.List(pl.Categorical))
     assert s.dtype == pl.List
-    assert s.inner_dtype == pl.Categorical
+    assert s.dtype.inner == pl.Categorical  # type: ignore[union-attr]
     assert s.to_list() == values
 
     # Check that underlying physicals match


### PR DESCRIPTION
This property doesn't make much sense. Just use `Series.dtype` and call `.inner` on it if you know it's a List/Array.