### PR TITLE
docs(python): Add note on hash stability and mention `polars-hash`

### DIFF
--- a/docs/user-guide/expressions/plugins.md
+++ b/docs/user-guide/expressions/plugins.md
@@ -249,3 +249,4 @@ That's all you need to know to get started. Take a look at this [repo](https://g
 Here is a curated (non-exhaustive) list of community implemented plugins.
 
 - [polars-business](https://github.com/MarcoGorelli/polars-business) Polars extension offering utilities for business day operations
+- [polars-hash](https://github.com/ion-elgreco/polars-hash) Stable non-cryptographic and cryptographic hashing functions for Polars

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9485,6 +9485,10 @@ class DataFrame:
         seed_3
             Random seed parameter. Defaults to `seed` if not set.
 
+        .. note::
+            This implementation of :func:`hash_rows` does not guarantee stable results
+            across Polars versions. It only has guaranteed stability within one version.
+
         Examples
         --------
         >>> df = pl.DataFrame(

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9485,9 +9485,11 @@ class DataFrame:
         seed_3
             Random seed parameter. Defaults to `seed` if not set.
 
-        .. note::
-            This implementation of :func:`hash_rows` does not guarantee stable results
-            across Polars versions. It only has guaranteed stability within one version.
+        Notes
+        -----
+        This implementation of :func:`hash_rows` does not guarantee stable results
+        across different Polars versions. Its stability is only guaranteed within a
+        single version.
 
         Examples
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5370,6 +5370,12 @@ class Expr:
 
         The hash value is of type `UInt64`.
 
+        .. note::
+            This implementation of :func:`hash` does not guarantee stable results
+            across polars versions. It only has guaranteed stability within one version.
+            For use-cases where you require stability across version you can use
+            the following plugin: `polars-hash <https://github.com/ion-elgreco/polars-hash>`_.
+
         Parameters
         ----------
         seed

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5372,8 +5372,8 @@ class Expr:
 
         .. note::
             This implementation of :func:`hash` does not guarantee stable results
-            across polars versions. It only has guaranteed stability within one version.
-            For use-cases where you require stability across version you can use
+            across Polars versions. It only has guaranteed stability within one version.
+            For use-cases where you require stability across versions, you can use
             the following plugin: `polars-hash <https://github.com/ion-elgreco/polars-hash>`_.
 
         Parameters

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5381,11 +5381,13 @@ class Expr:
         seed_3
             Random seed parameter. Defaults to `seed` if not set.
 
-        .. note::
-            This implementation of :func:`hash` does not guarantee stable results
-            across Polars versions. It only has guaranteed stability within one version.
-            For use-cases where you require stability across versions, you can use
-            the following plugin: `polars-hash <https://github.com/ion-elgreco/polars-hash>`_.
+        Notes
+        -----
+        This implementation of :func:`rows` does not guarantee stable results
+        across different Polars versions. Its stability is only guaranteed within a
+        single version.
+        For use-cases where stability across versions is required, you can use
+        the `polars-hash <https://github.com/ion-elgreco/polars-hash>`_ plugin.
 
         Examples
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5370,12 +5370,6 @@ class Expr:
 
         The hash value is of type `UInt64`.
 
-        .. note::
-            This implementation of :func:`hash` does not guarantee stable results
-            across Polars versions. It only has guaranteed stability within one version.
-            For use-cases where you require stability across versions, you can use
-            the following plugin: `polars-hash <https://github.com/ion-elgreco/polars-hash>`_.
-
         Parameters
         ----------
         seed
@@ -5386,6 +5380,12 @@ class Expr:
             Random seed parameter. Defaults to `seed` if not set.
         seed_3
             Random seed parameter. Defaults to `seed` if not set.
+
+        .. note::
+            This implementation of :func:`hash` does not guarantee stable results
+            across Polars versions. It only has guaranteed stability within one version.
+            For use-cases where you require stability across versions, you can use
+            the following plugin: `polars-hash <https://github.com/ion-elgreco/polars-hash>`_.
 
         Examples
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5800,9 +5800,11 @@ class Series:
         seed_3
             Random seed parameter. Defaults to `seed` if not set.
 
-        .. note::
-            This implementation of :func:`hash` does not guarantee stable results
-            across Polars versions. It only has guaranteed stability within one version.
+        Notes
+        -----
+        This implementation of :func:`hash` does not guarantee stable results
+        across different Polars versions. Its stability is only guaranteed within a
+        single version.
 
         Examples
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5800,6 +5800,10 @@ class Series:
         seed_3
             Random seed parameter. Defaults to `seed` if not set.
 
+        .. note::
+            This implementation of :func:`hash` does not guarantee stable results
+            across Polars versions. It only has guaranteed stability within one version.
+
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3])


### PR DESCRIPTION
As per discussion on discord @MarcoGorelli, adding a note on the instability of `hash` across versions and mentioning they can use polars-hash if they require stability.