### PR TITLE
feat(rust): Allow comparison of two local categories with the same hash

### DIFF
--- a/crates/polars-core/src/chunked_array/builder/list/categorical.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/categorical.rs
@@ -28,7 +28,7 @@ struct ListLocalCategoricalChunkedBuilder {
     inner: ListPrimitiveChunkedBuilder<UInt32Type>,
     idx_lookup: PlHashMap<KeyWrapper, ()>,
     categories: MutableUtf8Array<i64>,
-    categories_hash: u64,
+    categories_hash: u128,
 }
 
 // Wrap u32 key to avoid incorrect usage of hashmap with custom lookup
@@ -40,7 +40,7 @@ impl ListLocalCategoricalChunkedBuilder {
         RandomState::with_seed(0)
     }
 
-    pub(super) fn new(name: &str, capacity: usize, values_capacity: usize, hash: u64) -> Self {
+    pub(super) fn new(name: &str, capacity: usize, values_capacity: usize, hash: u128) -> Self {
         Self {
             inner: ListPrimitiveChunkedBuilder::new(
                 name,

--- a/crates/polars-core/src/chunked_array/builder/list/categorical.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/categorical.rs
@@ -68,8 +68,8 @@ impl ListBuilderTrait for ListLocalCategoricalChunkedBuilder {
         };
         let ca = s.categorical().unwrap();
 
-        // Fast path rev_maps are compatible.
-        if self.categories_hash == *new_hash {
+        // Fast path rev_maps are compatible & lookup is initialized
+        if self.categories_hash == *new_hash && !self.idx_lookup.is_empty() {
             return self.inner.append_series(s);
         }
 

--- a/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -150,6 +150,7 @@ impl RevMapping {
         }
     }
     /// Check if the categoricals have a compatible mapping
+    #[inline]
     pub fn same_src(&self, other: &Self) -> bool {
         match (self, other) {
             (RevMapping::Global(_, _, l), RevMapping::Global(_, _, r)) => *l == *r,

--- a/crates/polars-core/src/chunked_array/logical/categorical/from.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/from.rs
@@ -16,7 +16,7 @@ impl From<&CategoricalChunked> for DictionaryArray<u32> {
             false,
         );
         match map {
-            RevMapping::Local(arr) => {
+            RevMapping::Local(arr, _) => {
                 // Safety:
                 // the keys are in bounds
                 unsafe {
@@ -53,7 +53,7 @@ impl From<&CategoricalChunked> for DictionaryArray<i64> {
         match map {
             // Safety:
             // the keys are in bounds
-            RevMapping::Local(arr) => unsafe {
+            RevMapping::Local(arr, _) => unsafe {
                 DictionaryArray::try_new_unchecked(
                     dtype,
                     cast(keys, &ArrowDataType::Int64)
@@ -99,7 +99,7 @@ impl CategoricalChunked {
             CategoricalChunked::from_chunks_original(
                 name,
                 keys.clone(),
-                RevMapping::Local(values.clone()),
+                RevMapping::build_local(values.clone()),
             )
         }
     }

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -70,10 +70,10 @@ impl CategoricalChunked {
         let rev_map = self.get_rev_map();
         let (physical_map, categories) = match rev_map.as_ref() {
             RevMapping::Global(m, c, _) => (m, c),
-            RevMapping::Local(_) => return self.clone(),
+            RevMapping::Local(_, _) => return self.clone(),
         };
 
-        let local_rev_map = RevMapping::Local(categories.clone());
+        let local_rev_map = RevMapping::build_local(categories.clone());
         // TODO: A fast path can possibly be implemented here:
         // if all physical map keys are equal to their values,
         // we can skip the apply and only update the rev_map
@@ -346,7 +346,7 @@ mod test {
         );
         assert!(matches!(
             s.get(0)?,
-            AnyValue::Categorical(0, RevMapping::Local(_), _)
+            AnyValue::Categorical(0, RevMapping::Local(_, _), _)
         ));
 
         let groups = s.group_tuples(false, true);

--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
@@ -6,7 +6,7 @@ impl CategoricalChunked {
         let cat_map = self.get_rev_map();
         if self.can_fast_unique() {
             let ca = match &**cat_map {
-                RevMapping::Local(a) => {
+                RevMapping::Local(a, _) => {
                     UInt32Chunked::from_iter_values(self.physical().name(), 0..(a.len() as u32))
                 },
                 RevMapping::Global(map, _, _) => {

--- a/crates/polars-core/src/chunked_array/ops/compare_inner.rs
+++ b/crates/polars-core/src/chunked_array/ops/compare_inner.rs
@@ -158,7 +158,7 @@ impl<'a> IntoPartialOrdInner<'a> for &'a CategoricalChunked {
         let cats = self.physical();
         match &**self.get_rev_map() {
             RevMapping::Global(p1, p2, _) => Box::new(GlobalCategorical { p1, p2, cats }),
-            RevMapping::Local(rev_map) => Box::new(LocalCategorical { rev_map, cats }),
+            RevMapping::Local(rev_map, _) => Box::new(LocalCategorical { rev_map, cats }),
         }
     }
 }

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -825,8 +825,8 @@ impl PartialEq for AnyValue<'_> {
                 (RevMapping::Global(_, _, id_l), RevMapping::Global(_, _, id_r)) => {
                     id_l == id_r && idx_l == idx_r
                 },
-                (RevMapping::Local(arr_l), RevMapping::Local(arr_r)) => {
-                    std::ptr::eq(arr_l, arr_r) && idx_l == idx_r
+                (RevMapping::Local(_, id_l), RevMapping::Local(_, id_r)) => {
+                    id_l == id_r && idx_l == idx_r
                 },
                 _ => false,
             },

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -357,7 +357,7 @@ pub fn merge_dtypes(left: &DataType, right: &DataType) -> PolarsResult<DataType>
                     merger.merge_map(rev_map_r)?;
                     Categorical(Some(merger.finish()))
                 },
-                (RevMapping::Local(_), RevMapping::Local(_)) if rev_map_l.same_src(rev_map_r) => {
+                (RevMapping::Local(_, idl), RevMapping::Local(_, idr)) if idl == idr => {
                     left.clone()
                 },
                 _ => polars_bail!(string_cache_mismatch),

--- a/crates/polars-core/src/frame/group_by/perfect.rs
+++ b/crates/polars-core/src/frame/group_by/perfect.rs
@@ -199,7 +199,7 @@ impl CategoricalChunked {
         let cats = self.physical();
 
         let mut out = match &**rev_map {
-            RevMapping::Local(cached) => {
+            RevMapping::Local(cached, _) => {
                 if self.can_fast_unique() {
                     if verbose() {
                         eprintln!("grouping categoricals, run perfect hash function");

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -427,7 +427,7 @@ impl<'a> From<&AnyValue<'a>> for DataType {
                     DataType::Categorical(Some(Arc::new((*rev_map).clone())))
                 } else {
                     let array = unsafe { arr.deref_unchecked().clone() };
-                    let rev_map = RevMapping::Local(array);
+                    let rev_map = RevMapping::build_local(array);
                     DataType::Categorical(Some(Arc::new(rev_map)))
                 }
             },

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -855,7 +855,7 @@ impl Series {
         match self.dtype() {
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(Some(rv)) => match &**rv {
-                RevMapping::Local(arr) => size += estimated_bytes_size(arr),
+                RevMapping::Local(arr, _) => size += estimated_bytes_size(arr),
                 RevMapping::Global(map, arr, _) => {
                     size +=
                         map.capacity() * std::mem::size_of::<u32>() * 2 + estimated_bytes_size(arr);

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -577,16 +577,6 @@ def test_serde_validation() -> None:
         pl.read_json(f)
 
 
-def test_transpose_categorical_cached() -> None:
-    with pytest.raises(
-        pl.ComputeError,
-        match=r"'transpose' of categorical can only be done if all are from the same global string cache",
-    ):
-        pl.DataFrame(
-            {"b": pl.Series(["a", "b", "c"], dtype=pl.Categorical)}
-        ).transpose()
-
-
 def test_overflow_msg() -> None:
     with pytest.raises(
         pl.ComputeError,


### PR DESCRIPTION
fix #12502 

In the past we would only allow comparisons between two categoricals if the pointers are equal
This adds a hash to the local categorical, if two categories have the same hash we allow comparison. 

Note that this does not support comparison of arbritrary local categoricals as both have to have the same categories in the same order.