### PR TITLE
docs(python): Update `polars-hash` reference

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -5386,8 +5386,6 @@ class Expr:
         This implementation of :func:`rows` does not guarantee stable results
         across different Polars versions. Its stability is only guaranteed within a
         single version.
-        For use-cases where stability across versions is required, you can use
-        the `polars-hash <https://github.com/ion-elgreco/polars-hash>`_ plugin.
 
         Examples
         --------


### PR DESCRIPTION
Keep mention in the docs, but keep docstrings about native polars implementation.