### PR TITLE
feat!: Change `value_counts` resulting column name to `count`

### DIFF
--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -13,17 +13,17 @@ pub trait SeriesMethods: SeriesSealed {
     fn value_counts(&self, sort: bool, parallel: bool) -> PolarsResult<DataFrame> {
         let s = self.as_series();
         polars_ensure!(
-            s.name() != "counts",
-            Duplicate: "using `value_counts` on a column named 'counts' would lead to duplicate column names"
+            s.name() != "count",
+            Duplicate: "using `value_counts` on a column named 'count' would lead to duplicate column names"
         );
         // we need to sort here as well in case of `maintain_order` because duplicates behavior is undefined
         let groups = s.group_tuples(parallel, sort)?;
         let values = unsafe { s.agg_first(&groups) };
-        let counts = groups.group_lengths("counts");
+        let counts = groups.group_lengths("count");
         let cols = vec![values, counts.into_series()];
         let df = DataFrame::new_no_checks(cols);
         if sort {
-            df.sort(["counts"], true, false)
+            df.sort(["count"], true, false)
         } else {
             Ok(df)
         }

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -89,7 +89,7 @@ impl FunctionExpr {
             ValueCounts { .. } => mapper.map_dtype(|dt| {
                 DataType::Struct(vec![
                     Field::new(fields[0].name().as_str(), dt.clone()),
-                    Field::new("counts", IDX_DTYPE),
+                    Field::new("count", IDX_DTYPE),
                 ])
             }),
             #[cfg(feature = "unique_counts")]

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2400,29 +2400,29 @@ class Series:
         >>> s = pl.Series("color", ["red", "blue", "red", "green", "blue", "blue"])
         >>> s.value_counts()  # doctest: +IGNORE_RESULT
         shape: (3, 2)
-        ┌───────┬────────┐
-        │ color ┆ counts │
-        │ ---   ┆ ---    │
-        │ str   ┆ u32    │
-        ╞═══════╪════════╡
-        │ red   ┆ 2      │
-        │ green ┆ 1      │
-        │ blue  ┆ 3      │
-        └───────┴────────┘
+        ┌───────┬───────┐
+        │ color ┆ count │
+        │ ---   ┆ ---   │
+        │ str   ┆ u32   │
+        ╞═══════╪═══════╡
+        │ red   ┆ 2     │
+        │ green ┆ 1     │
+        │ blue  ┆ 3     │
+        └───────┴───────┘
 
         Sort the output by count.
 
+        >>> s.value_counts(sort=True)
         shape: (3, 2)
-        ┌───────┬────────┐
-        │ color ┆ counts │
-        │ ---   ┆ ---    │
-        │ str   ┆ u32    │
-        ╞═══════╪════════╡
-        │ blue  ┆ 3      │
-        │ red   ┆ 2      │
-        │ green ┆ 1      │
-        └───────┴────────┘
-
+        ┌───────┬───────┐
+        │ color ┆ count │
+        │ ---   ┆ ---   │
+        │ str   ┆ u32   │
+        ╞═══════╪═══════╡
+        │ blue  ┆ 3     │
+        │ red   ┆ 2     │
+        │ green ┆ 1     │
+        └───────┴───────┘
         """
         return (
             self.to_frame()

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -204,9 +204,9 @@ def test_categorical_in_struct_nulls() -> None:
     df = pl.DataFrame([s])
     s = (df.select(pl.col("job").value_counts(sort=True)))["job"]
 
-    assert s[0] == {"job": None, "counts": 3}
-    assert s[1] == {"job": "doctor", "counts": 2}
-    assert s[2] == {"job": "waiter", "counts": 1}
+    assert s[0] == {"job": None, "count": 3}
+    assert s[1] == {"job": "doctor", "count": 2}
+    assert s[2] == {"job": "waiter", "count": 1}
 
 
 def test_cast_inner_categorical() -> None:

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -472,7 +472,7 @@ def test_logical_parallel_list_collect() -> None:
     assert out.to_dict(as_series=False) == {
         "Group": ["GroupA", "GroupA"],
         "Values": ["Value1", "Value2"],
-        "counts": [2, 1],
+        "count": [2, 1],
     }
 
 

--- a/py-polars/tests/unit/datatypes/test_struct.py
+++ b/py-polars/tests/unit/datatypes/test_struct.py
@@ -618,9 +618,9 @@ def test_struct_categorical_5843() -> None:
     result = df.select(pl.col("foo").value_counts(sort=True))
     assert result.to_dict(as_series=False) == {
         "foo": [
-            {"foo": "a", "counts": 2},
-            {"foo": "b", "counts": 1},
-            {"foo": "c", "counts": 1},
+            {"foo": "a", "count": 2},
+            {"foo": "b", "count": 1},
+            {"foo": "c", "count": 1},
         ]
     }
 
@@ -820,25 +820,20 @@ def test_struct_name_passed_in_agg_apply() -> None:
 
     assert df.group_by("k").agg(
         pl.struct(
-            [
-                pl.col("val").value_counts(sort=True).struct.field("val").alias("val"),
-                pl.col("val")
-                .value_counts(sort=True)
-                .struct.field("counts")
-                .alias("counts"),
-            ]
+            pl.col("val").value_counts(sort=True).struct.field("val").alias("val"),
+            pl.col("val").value_counts(sort=True).struct.field("count").alias("count"),
         )
     ).to_dict(as_series=False) == {
         "k": [0],
         "val": [
             [
-                {"val": -3, "counts": 1},
-                {"val": -2, "counts": 1},
-                {"val": -1, "counts": 1},
-                {"val": 0, "counts": 1},
-                {"val": 1, "counts": 1},
-                {"val": 2, "counts": 1},
-                {"val": 3, "counts": 1},
+                {"val": -3, "count": 1},
+                {"val": -2, "count": 1},
+                {"val": -1, "count": 1},
+                {"val": 0, "count": 1},
+                {"val": 1, "count": 1},
+                {"val": 2, "count": 1},
+                {"val": 3, "count": 1},
             ]
         ],
     }

--- a/py-polars/tests/unit/io/test_lazy_parquet.py
+++ b/py-polars/tests/unit/io/test_lazy_parquet.py
@@ -369,7 +369,7 @@ def test_parquet_struct_categorical(tmp_path: Path) -> None:
 
     with pl.StringCache():
         out = pl.read_parquet(file_path).select(pl.col("b").value_counts())
-    assert out.to_dict(as_series=False) == {"b": [{"b": "foo", "counts": 1}]}
+    assert out.to_dict(as_series=False) == {"b": [{"b": "foo", "count": 1}]}
 
 
 def test_glob_n_rows(io_files_path: Path) -> None:

--- a/py-polars/tests/unit/operations/test_value_counts.py
+++ b/py-polars/tests/unit/operations/test_value_counts.py
@@ -10,7 +10,7 @@ def test_value_counts() -> None:
     s = pl.Series("a", [1, 2, 2, 3])
     result = s.value_counts()
     expected = pl.DataFrame(
-        {"a": [1, 2, 3], "counts": [1, 2, 1]}, schema_overrides={"counts": pl.UInt32}
+        {"a": [1, 2, 3], "count": [1, 2, 1]}, schema_overrides={"count": pl.UInt32}
     )
     result_sorted = result.sort("a")
     assert_frame_equal(result_sorted, expected)
@@ -34,10 +34,10 @@ def test_value_counts_expr() -> None:
     )
     out = df.select(pl.col("id").value_counts(sort=True)).to_series().to_list()
     assert out == [
-        {"id": "c", "counts": 3},
-        {"id": "b", "counts": 2},
-        {"id": "d", "counts": 2},
-        {"id": "a", "counts": 1},
+        {"id": "c", "count": 3},
+        {"id": "b", "count": 2},
+        {"id": "d", "count": 2},
+        {"id": "a", "count": 1},
     ]
 
     # nested value counts. Then the series needs the name
@@ -47,11 +47,11 @@ def test_value_counts_expr() -> None:
 
     assert df.group_by("session").agg(
         pl.col("id").value_counts(sort=True).first()
-    ).to_dict(as_series=False) == {"session": [1], "id": [{"id": 2, "counts": 2}]}
+    ).to_dict(as_series=False) == {"session": [1], "id": [{"id": 2, "count": 2}]}
 
 
 def test_value_counts_duplicate_name() -> None:
-    s = pl.Series("counts", [1])
+    s = pl.Series("count", [1])
 
-    with pytest.raises(pl.DuplicateError, match="counts"):
+    with pytest.raises(pl.DuplicateError, match="count"):
         s.value_counts()


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/11462

#### Changes

* The resulting struct field for the `value_counts` method has been renamed from `counts` to `count`.

**Before**
```pycon
>>> s = pl.Series("a", ["x", "x", "y"])
>>> s.value_counts()
shape: (2, 2)
┌─────┬────────┐
│ a   ┆ counts │
│ --- ┆ ---    │
│ str ┆ u32    │
╞═════╪════════╡
│ x   ┆ 2      │
│ y   ┆ 1      │
└─────┴────────┘
```

**After**
```pycon
>>> s.value_counts()
shape: (2, 2)
┌─────┬───────┐
│ a   ┆ count │
│ --- ┆ ---   │
│ str ┆ u32   │
╞═════╪═══════╡
│ x   ┆ 2     │
│ y   ┆ 1     │
└─────┴───────┘
```