### PR TITLE
test(python): Future-proof consortium standard test

### DIFF
--- a/py-polars/tests/unit/test_consortium_standard.py
+++ b/py-polars/tests/unit/test_consortium_standard.py
@@ -24,8 +24,6 @@ def test_lazyframe() -> None:
 
 
 def test_series() -> None:
-    ser = pl.Series([1, 2, 3])
+    ser = pl.Series("a", [1, 2, 3])
     col = ser.__column_consortium_standard__()
-    result = col.get_value(1)
-    expected = 2
-    assert result == expected
+    assert col.name == "a"


### PR DESCRIPTION
It's quite likely that the dataframe api will have a `Scalar` class, and that `Column.get_value` will return that

I'm suggesting to just simplify the test to make an assertion about `Column.name`, which realistically isn't going to change

---

corresponding pandas PR: https://github.com/pandas-dev/pandas/pull/55993