### PR TITLE
fix: fix and improve ternary evaluation on groups

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
@@ -3,6 +3,17 @@ use arrow::bitmap::MutableBitmap;
 use super::*;
 
 impl ChunkExplode for ListChunked {
+    fn offsets(&self) -> PolarsResult<OffsetsBuffer<i64>> {
+        let ca = self.rechunk();
+        let listarr: &LargeListArray = ca
+            .downcast_iter()
+            .next()
+            .ok_or_else(|| polars_err!(NoData: "cannot explode empty list"))?;
+        let offsets = listarr.offsets().clone();
+
+        Ok(offsets)
+    }
+
     fn explode_and_offsets(&self) -> PolarsResult<(Series, OffsetsBuffer<i64>)> {
         // A list array's memory layout is actually already 'exploded', so we can just take the values array
         // of the list. And we also return a slice of the offsets. This slice can be used to find the old
@@ -76,6 +87,17 @@ impl ChunkExplode for ListChunked {
 }
 
 impl ChunkExplode for Utf8Chunked {
+    fn offsets(&self) -> PolarsResult<OffsetsBuffer<i64>> {
+        let ca = self.rechunk();
+        let array: &Utf8Array<i64> = ca
+            .downcast_iter()
+            .next()
+            .ok_or_else(|| polars_err!(NoData: "cannot explode empty str"))?;
+        let offsets = array.offsets().clone();
+
+        Ok(offsets)
+    }
+
     fn explode_and_offsets(&self) -> PolarsResult<(Series, OffsetsBuffer<i64>)> {
         // A list array's memory layout is actually already 'exploded', so we can just take the values array
         // of the list. And we also return a slice of the offsets. This slice can be used to find the old
@@ -191,15 +213,7 @@ impl ChunkExplode for Utf8Chunked {
 
 #[cfg(feature = "dtype-array")]
 impl ChunkExplode for ArrayChunked {
-    fn explode(&self) -> PolarsResult<Series> {
-        let ca = self.rechunk();
-        let arr = ca.downcast_iter().next().unwrap();
-        Ok(Series::try_from((self.name(), arr.values().clone())).unwrap())
-    }
-
-    fn explode_and_offsets(&self) -> PolarsResult<(Series, OffsetsBuffer<i64>)> {
-        let s = self.explode().unwrap();
-
+    fn offsets(&self) -> PolarsResult<OffsetsBuffer<i64>> {
         let width = self.width() as i64;
         let offsets = (0..self.len() + 1)
             .map(|i| {
@@ -210,6 +224,18 @@ impl ChunkExplode for ArrayChunked {
         // safety: monotonically increasing
         let offsets = unsafe { OffsetsBuffer::new_unchecked(offsets.into()) };
 
-        Ok((s, offsets))
+        Ok(offsets)
+    }
+
+    fn explode(&self) -> PolarsResult<Series> {
+        let ca = self.rechunk();
+        let arr = ca.downcast_iter().next().unwrap();
+        Ok(Series::try_from((self.name(), arr.values().clone())).unwrap())
+    }
+
+    fn explode_and_offsets(&self) -> PolarsResult<(Series, OffsetsBuffer<i64>)> {
+        let s = self.explode().unwrap();
+
+        Ok((s, self.offsets()?))
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
@@ -5,10 +5,7 @@ use super::*;
 impl ChunkExplode for ListChunked {
     fn offsets(&self) -> PolarsResult<OffsetsBuffer<i64>> {
         let ca = self.rechunk();
-        let listarr: &LargeListArray = ca
-            .downcast_iter()
-            .next()
-            .ok_or_else(|| polars_err!(NoData: "cannot explode empty list"))?;
+        let listarr: &LargeListArray = ca.downcast_iter().next().unwrap();
         let offsets = listarr.offsets().clone();
 
         Ok(offsets)
@@ -19,10 +16,7 @@ impl ChunkExplode for ListChunked {
         // of the list. And we also return a slice of the offsets. This slice can be used to find the old
         // list layout or indexes to expand the DataFrame in the same manner as the 'explode' operation
         let ca = self.rechunk();
-        let listarr: &LargeListArray = ca
-            .downcast_iter()
-            .next()
-            .ok_or_else(|| polars_err!(NoData: "cannot explode empty list"))?;
+        let listarr: &LargeListArray = ca.downcast_iter().next().unwrap();
         let offsets_buf = listarr.offsets().clone();
         let offsets = listarr.offsets().as_slice();
         let mut values = listarr.values().clone();
@@ -89,10 +83,7 @@ impl ChunkExplode for ListChunked {
 impl ChunkExplode for Utf8Chunked {
     fn offsets(&self) -> PolarsResult<OffsetsBuffer<i64>> {
         let ca = self.rechunk();
-        let array: &Utf8Array<i64> = ca
-            .downcast_iter()
-            .next()
-            .ok_or_else(|| polars_err!(NoData: "cannot explode empty str"))?;
+        let array: &Utf8Array<i64> = ca.downcast_iter().next().unwrap();
         let offsets = array.offsets().clone();
 
         Ok(offsets)
@@ -103,10 +94,7 @@ impl ChunkExplode for Utf8Chunked {
         // of the list. And we also return a slice of the offsets. This slice can be used to find the old
         // list layout or indexes to expand the DataFrame in the same manner as the 'explode' operation
         let ca = self.rechunk();
-        let array: &Utf8Array<i64> = ca
-            .downcast_iter()
-            .next()
-            .ok_or_else(|| polars_err!(NoData: "cannot explode empty str"))?;
+        let array: &Utf8Array<i64> = ca.downcast_iter().next().unwrap();
 
         let values = array.values();
         let old_offsets = array.offsets().clone();

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -92,6 +92,7 @@ pub trait ChunkExplode {
     fn explode(&self) -> PolarsResult<Series> {
         self.explode_and_offsets().map(|t| t.0)
     }
+    fn offsets(&self) -> PolarsResult<OffsetsBuffer<i64>>;
     fn explode_and_offsets(&self) -> PolarsResult<(Series, OffsetsBuffer<i64>)>;
 }
 

--- a/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -255,10 +255,6 @@ impl PhysicalExpr for AggregationExpr {
     fn as_partitioned_aggregator(&self) -> Option<&dyn PartitionedAggregation> {
         Some(self)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        true
-    }
 }
 
 fn rename_series(mut s: Series, name: &str) -> Series {
@@ -538,9 +534,5 @@ impl PhysicalExpr for AggQuantileExpr {
 
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.input.to_field(input_schema)
-    }
-
-    fn is_valid_aggregation(&self) -> bool {
-        true
     }
 }

--- a/crates/polars-lazy/src/physical_plan/expressions/alias.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/alias.rs
@@ -68,10 +68,6 @@ impl PhysicalExpr for AliasExpr {
     fn as_partitioned_aggregator(&self) -> Option<&dyn PartitionedAggregation> {
         Some(self)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        self.physical_expr.is_valid_aggregation()
-    }
 }
 
 impl PartitionedAggregation for AliasExpr {

--- a/crates/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -373,9 +373,6 @@ impl PhysicalExpr for ApplyExpr {
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.expr.to_field(input_schema, Context::Default)
     }
-    fn is_valid_aggregation(&self) -> bool {
-        matches!(self.collect_groups, ApplyOptions::GroupWise)
-    }
     #[cfg(feature = "parquet")]
     fn as_stats_evaluator(&self) -> Option<&dyn polars_io::predicates::StatsEvaluator> {
         let function = match &self.expr {

--- a/crates/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -251,13 +251,6 @@ impl PhysicalExpr for BinaryExpr {
     fn as_stats_evaluator(&self) -> Option<&dyn polars_io::predicates::StatsEvaluator> {
         Some(self)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        // We don't want: col(a) == lit(1).
-        // We do want col(a).sum() == lit(1).
-        (!self.left.is_literal() && self.left.is_valid_aggregation())
-            || (!self.right.is_literal() && self.right.is_valid_aggregation())
-    }
 }
 
 #[cfg(feature = "parquet")]

--- a/crates/polars-lazy/src/physical_plan/expressions/cast.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/cast.rs
@@ -85,10 +85,6 @@ impl PhysicalExpr for CastExpr {
     fn as_partitioned_aggregator(&self) -> Option<&dyn PartitionedAggregation> {
         Some(self)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        self.input.is_valid_aggregation()
-    }
 }
 
 impl PartitionedAggregation for CastExpr {

--- a/crates/polars-lazy/src/physical_plan/expressions/column.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/column.rs
@@ -192,10 +192,6 @@ impl PhysicalExpr for ColumnExpr {
             )
         })
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        false
-    }
 }
 
 impl PartitionedAggregation for ColumnExpr {

--- a/crates/polars-lazy/src/physical_plan/expressions/count.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/count.rs
@@ -43,10 +43,6 @@ impl PhysicalExpr for CountExpr {
     fn as_partitioned_aggregator(&self) -> Option<&dyn PartitionedAggregation> {
         Some(self)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        true
-    }
 }
 
 impl PartitionedAggregation for CountExpr {

--- a/crates/polars-lazy/src/physical_plan/expressions/filter.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/filter.rs
@@ -140,8 +140,4 @@ impl PhysicalExpr for FilterExpr {
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.input.to_field(input_schema)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        self.input.is_valid_aggregation()
-    }
 }

--- a/crates/polars-lazy/src/physical_plan/expressions/literal.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/literal.rs
@@ -117,10 +117,6 @@ impl PhysicalExpr for LiteralExpr {
         let dtype = self.0.get_datatype();
         Ok(Field::new("literal", dtype))
     }
-    fn is_valid_aggregation(&self) -> bool {
-        // literals can be both
-        true
-    }
     fn is_literal(&self) -> bool {
         true
     }

--- a/crates/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -612,10 +612,6 @@ pub trait PhysicalExpr: Send + Sync {
     fn as_stats_evaluator(&self) -> Option<&dyn polars_io::predicates::StatsEvaluator> {
         None
     }
-
-    //
-    fn is_valid_aggregation(&self) -> bool;
-
     fn is_literal(&self) -> bool {
         false
     }

--- a/crates/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -97,7 +97,7 @@ impl AggState {
 
 // lazy update strategy
 #[cfg_attr(debug_assertions, derive(Debug))]
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone, Copy)]
 pub(crate) enum UpdateGroups {
     /// don't update groups
     No,

--- a/crates/polars-lazy/src/physical_plan/expressions/rolling.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/rolling.rs
@@ -51,8 +51,4 @@ impl PhysicalExpr for RollingExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        false
-    }
 }

--- a/crates/polars-lazy/src/physical_plan/expressions/slice.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/slice.rs
@@ -254,8 +254,4 @@ impl PhysicalExpr for SliceExpr {
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.input.to_field(input_schema)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        true
-    }
 }

--- a/crates/polars-lazy/src/physical_plan/expressions/sort.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/sort.rs
@@ -113,8 +113,4 @@ impl PhysicalExpr for SortExpr {
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.physical_expr.to_field(input_schema)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        true
-    }
 }

--- a/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -315,8 +315,4 @@ impl PhysicalExpr for SortByExpr {
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.input.to_field(input_schema)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        true
-    }
 }

--- a/crates/polars-lazy/src/physical_plan/expressions/take.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/take.rs
@@ -205,8 +205,4 @@ impl PhysicalExpr for TakeExpr {
     fn to_field(&self, input_schema: &Schema) -> PolarsResult<Field> {
         self.phys_expr.to_field(input_schema)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        true
-    }
 }

--- a/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -238,6 +238,9 @@ impl PhysicalExpr for TernaryExpr {
 
                 let out = truthy.zip_with(mask.bool()?, &falsy)?;
 
+                // The output series is guaranteed to be aligned with expected
+                // offsets buffer of the result, so we construct the result
+                // ListChunked directly from the 2.
                 let out = out.rechunk();
                 let values = out.array_ref(0);
                 let offsets = ac_target.series().list().unwrap().offsets()?;

--- a/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -287,10 +287,6 @@ impl PhysicalExpr for TernaryExpr {
     fn as_partitioned_aggregator(&self) -> Option<&dyn PartitionedAggregation> {
         Some(self)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        self.truthy.is_valid_aggregation() || self.falsy.is_valid_aggregation()
-    }
 }
 
 impl PartitionedAggregation for TernaryExpr {

--- a/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -137,9 +137,10 @@ impl PhysicalExpr for TernaryExpr {
                         break;
                     }
                 },
-                _ => {
+                NotAggregated(_) => {
                     let _ = ac.aggregated();
                 },
+                _ => {},
             }
         }
 

--- a/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -218,20 +218,20 @@ impl PhysicalExpr for TernaryExpr {
                     }
                 }
 
-                let truthy = if matches!(ac_truthy.agg_state(), AggregatedList(_)) {
-                    ac_truthy.series().list().unwrap().get_inner()
+                let truthy = if let AggregatedList(s) = ac_truthy.agg_state() {
+                    s.list().unwrap().get_inner()
                 } else {
                     ac_truthy.series().clone()
                 };
 
-                let falsy = if matches!(ac_falsy.agg_state(), AggregatedList(_)) {
-                    ac_falsy.series().list().unwrap().get_inner()
+                let falsy = if let AggregatedList(s) = ac_falsy.agg_state() {
+                    s.list().unwrap().get_inner()
                 } else {
                     ac_falsy.series().clone()
                 };
 
-                let mask = if matches!(ac_mask.agg_state(), AggregatedList(_)) {
-                    ac_mask.series().list().unwrap().get_inner()
+                let mask = if let AggregatedList(s) = ac_mask.agg_state() {
+                    s.list().unwrap().get_inner()
                 } else {
                     ac_mask.series().clone()
                 };
@@ -253,13 +253,9 @@ impl PhysicalExpr for TernaryExpr {
                 let mut out = ListChunked::with_chunk(truthy.name(), out);
                 out.to_logical(inner_type.clone());
 
-                if let AggregatedList(s) = ac_target.agg_state() {
-                    if s.list().unwrap()._can_fast_explode() {
-                        out.set_fast_explode();
-                    }
-                } else {
-                    unreachable!();
-                }
+                if ac_target.series().list().unwrap()._can_fast_explode() {
+                    out.set_fast_explode();
+                };
 
                 let out = out.into_series();
 

--- a/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/ternary.rs
@@ -147,7 +147,7 @@ impl PhysicalExpr for TernaryExpr {
         if has_non_unit_literal {
             // Non-unit literals must be materialized per-group.
             if state.verbose() {
-                println!("ternary agg: finish as iters due to non-unit literal")
+                eprintln!("ternary agg: finish as iters due to non-unit literal")
             }
             return finish_as_iters(ac_truthy, ac_falsy, ac_mask);
         }
@@ -163,7 +163,7 @@ impl PhysicalExpr for TernaryExpr {
         if non_literal_acs.is_empty() {
             // All unit literals.
             if state.verbose() {
-                println!(
+                eprintln!(
                     "ternary agg: finish all unit literals - expression could have been simplified"
                 )
             }
@@ -184,7 +184,7 @@ impl PhysicalExpr for TernaryExpr {
                 // list of the same length as the corresponding AggregatedList
                 // row.
                 if state.verbose() {
-                    println!("ternary agg: finish as iters due to mix of AggregatedScalar and AggregatedList")
+                    eprintln!("ternary agg: finish as iters due to mix of AggregatedScalar and AggregatedList")
                 }
                 return finish_as_iters(ac_truthy, ac_falsy, ac_mask);
             }
@@ -200,7 +200,7 @@ impl PhysicalExpr for TernaryExpr {
                 // Ternary can be applied directly on the flattened series,
                 // given that their offsets have been checked to be equal.
                 if state.verbose() {
-                    println!("ternary agg: finish AggregatedList")
+                    eprintln!("ternary agg: finish AggregatedList")
                 }
 
                 for (ac_l, ac_r) in non_literal_acs.iter().zip(non_literal_acs.iter().skip(1)) {
@@ -263,7 +263,7 @@ impl PhysicalExpr for TernaryExpr {
             },
             AggregatedScalar(_) => {
                 if state.verbose() {
-                    println!("ternary agg: finish AggregatedScalar")
+                    eprintln!("ternary agg: finish AggregatedScalar")
                 }
 
                 let out = ac_truthy

--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -623,10 +623,6 @@ impl PhysicalExpr for WindowExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
-
-    fn is_valid_aggregation(&self) -> bool {
-        false
-    }
 }
 
 fn materialize_column(join_opt_ids: &ChunkJoinOptIds, out_column: &Series) -> Series {

--- a/crates/polars/tests/it/lazy/expressions/arity.rs
+++ b/crates/polars/tests/it/lazy/expressions/arity.rs
@@ -306,7 +306,7 @@ fn test_ternary_aggregation_set_literals() -> PolarsResult<()> {
     );
     assert_eq!(
         out.get(1)?,
-        AnyValue::List(Series::new("", &[10 as IdxSize]))
+        AnyValue::List(Series::new("", &[10 as IdxSize, 10 as IdxSize]))
     );
 
     let out = df
@@ -326,7 +326,7 @@ fn test_ternary_aggregation_set_literals() -> PolarsResult<()> {
     );
     assert_eq!(
         out.get(0)?,
-        AnyValue::List(Series::new("", &[10 as IdxSize]))
+        AnyValue::List(Series::new("", &[10 as IdxSize, 10 as IdxSize]))
     );
 
     let out = df
@@ -341,7 +341,7 @@ fn test_ternary_aggregation_set_literals() -> PolarsResult<()> {
 
     let out = out.column("value")?;
     assert!(matches!(out.get(0)?, AnyValue::List(_)));
-    assert_eq!(out.get(1)?, AnyValue::Null);
+    assert!(matches!(out.get(1)?, AnyValue::List(_)));
 
     // swapped branch
     let out = df
@@ -355,7 +355,7 @@ fn test_ternary_aggregation_set_literals() -> PolarsResult<()> {
 
     let out = out.column("value")?;
     assert!(matches!(out.get(1)?, AnyValue::List(_)));
-    assert_eq!(out.get(0)?, AnyValue::Null);
+    assert!(matches!(out.get(0)?, AnyValue::List(_)));
 
     Ok(())
 }

--- a/py-polars/tests/unit/functions/test_whenthen.py
+++ b/py-polars/tests/unit/functions/test_whenthen.py
@@ -418,7 +418,7 @@ def test_when_then_non_unit_literal_predicate_agg_broadcast_12382() -> None:
     assert_frame_equal(expect, actual)
 
 
-def test_when_then_binary_op_predicate_12526() -> None:
+def test_when_then_binary_op_predicate_agg_12526() -> None:
     df = pl.DataFrame(
         {
             "a": [1, 1, 1],

--- a/py-polars/tests/unit/functions/test_whenthen.py
+++ b/py-polars/tests/unit/functions/test_whenthen.py
@@ -372,3 +372,73 @@ def test_when_then_output_name_12380() -> None:
             expect,
             df.select(pl.when(false_expr).then(pl.col("x")).otherwise(pl.col("y"))),
         )
+
+
+def test_when_then_nested_non_unit_literal_predicate_agg_broadcast_12242() -> None:
+    df = pl.DataFrame(
+        {
+            "array_name": ["A", "A", "A", "B", "B"],
+            "array_idx": [5, 0, 3, 7, 2],
+            "array_val": [1, 2, 3, 4, 5],
+        }
+    )
+
+    int_range = pl.int_range(pl.min("array_idx"), pl.max("array_idx") + 1)
+
+    is_valid_idx = int_range.is_in("array_idx")
+
+    idxs = is_valid_idx.cumsum() - 1
+
+    ternary_expr = pl.when(is_valid_idx).then(pl.col("array_val").take(idxs))
+
+    expect = pl.DataFrame(
+        [
+            pl.Series("array_name", ["A", "B"], dtype=pl.Utf8),
+            pl.Series(
+                "array_val",
+                [[1, None, None, 2, None, 3], [4, None, None, None, None, 5]],
+                dtype=pl.List(pl.Int64),
+            ),
+        ]
+    )
+
+    assert_frame_equal(
+        expect, df.group_by("array_name").agg(ternary_expr).sort("array_name")
+    )
+
+
+def test_when_then_non_unit_literal_predicate_agg_broadcast_12382() -> None:
+    df = pl.DataFrame({"id": [1, 1], "value": [0, 3]})
+
+    expect = pl.DataFrame({"id": [1], "literal": [["yes", None, None, "yes", None]]})
+    actual = df.group_by("id").agg(
+        pl.when(pl.int_range(0, 5).is_in("value")).then(pl.lit("yes"))
+    )
+
+    assert_frame_equal(expect, actual)
+
+
+def test_when_then_binary_op_predicate_12526() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [1, 1, 1],
+            "b": [1, 2, 5],
+        }
+    )
+
+    expect = pl.DataFrame(
+        {"a": [1], "col": [None]}, schema={"a": pl.Int64, "col": pl.Utf8}
+    )
+
+    actual = df.group_by("a").agg(
+        col=(
+            pl.when(pl.col("a").shift(1) > 2)
+            .then(pl.lit("abc"))
+            .when(pl.col("a").shift(1) > 1)
+            .then(pl.lit("def"))
+            .otherwise(pl.lit(None))
+            .first()
+        )
+    )
+
+    assert_frame_equal(expect, actual)


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/12242, https://github.com/pola-rs/polars/issues/12382, https://github.com/pola-rs/polars/issues/12526.

#### Changes to `TernaryExpr::evaluate_on_groups`
Execution is now done w.r.t the agg states of the predicate, truthy and falsy - it previously only looked at the agg states of the truthy and falsy, and for the predicate relied on `is_valid_aggregation`, which didn't capture / didn't make sense for some edge cases (a separate interesting issue is that `is_in` isn't setting `auto_explode` properly).

#### Other changes
##### Consolidate ternary broadcasting logic, moving them to `chunked_array::ops::zip`
The `expand_lengths` function is moved to `zip.rs` as a macro. It was previously always being called before a `zip_with` from `ternary.rs`, but this is now changed to only be called when doing `zip_with` operations on `ListChunked` and `PolarsObject` types as they cannot use `impl_ternary_broadcast!`. This means the new, more efficient `impl_ternary_broadcast` is now being used, and allows for `ternary.rs` to (almost) directly call `zip_with` without needing to handle broadcasting.
##### Expose an `offsets` function on `ChunkExplode` implementors
This is to support comparing that 2 `ListChunked` arrays have equal offsets - there was an existing `explode_and_offsets` but it would potentially materialize using non-`fast_explode`.

#### Other comments
* `PhysicalExpr::is_valid_aggregation` would no longer be used after this change. I think we should only need to be looking at `.agg_state()` to determine behavior, so maybe it can be removed?
