### PR TITLE
fix: fix panic when writing `Decimal` type to parquet

### DIFF
--- a/crates/polars-arrow/src/compute/aggregate/memory.rs
+++ b/crates/polars-arrow/src/compute/aggregate/memory.rs
@@ -1,7 +1,7 @@
 use crate::array::*;
 use crate::bitmap::Bitmap;
 use crate::datatypes::PhysicalType;
-use crate::{match_integer_type, with_match_primitive_type};
+use crate::{match_integer_type, with_match_primitive_type_full};
 
 fn validity_size(validity: Option<&Bitmap>) -> usize {
     validity.as_ref().map(|b| b.as_slice().0.len()).unwrap_or(0)
@@ -42,7 +42,7 @@ pub fn estimated_bytes_size(array: &dyn Array) -> usize {
             let array = array.as_any().downcast_ref::<BooleanArray>().unwrap();
             array.values().as_slice().0.len() + validity_size(array.validity())
         },
-        Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
             let array = array
                 .as_any()
                 .downcast_ref::<PrimitiveArray<$T>>()

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import io
 import itertools
 from dataclasses import dataclass
 from decimal import Decimal as D
@@ -255,3 +256,13 @@ def test_decimal_in_filter() -> None:
         "foo": [2, 3],
         "bar": [D("7"), D("8")],
     }
+
+
+def test_decimal_write_parquet_12375() -> None:
+    f = io.BytesIO()
+    df = pl.DataFrame(
+        {"hi": [True, False, True, False], "bye": [1, 2, 3, D(47283957238957239875)]}
+    )
+    assert df["bye"].dtype == pl.Decimal
+
+    df.write_parquet(f)


### PR DESCRIPTION
fixes #12375

When adding the test, I was reading the result back but the precision changes, so I took it out.

```python
>>> df.lazy()
<LazyFrame [2 cols, {"hi": Boolean, "bye": Decimal(precision=None, scale=0)}] at 0x120FF7590>
>>> pl.scan_parquet("decimal_test.parquet")
<LazyFrame [2 cols, {"hi": Boolean, "bye": Decimal(precision=38, scale=0)}] at 0x134B4EB90>
```

I've not used decimals so I'm not sure if this is expected behaviour or not.