### PR TITLE
depr(python): Deprecate `Series.view`

### DIFF
--- a/docs/user-guide/expressions/numpy.md
+++ b/docs/user-guide/expressions/numpy.md
@@ -19,4 +19,4 @@ Polars `Series` have support for NumPy universal functions (ufuncs). Element-wis
 
 However, as a Polars-specific remark: missing values are a separate bitmask and are not visible by NumPy. This can lead to a window function or a `np.convolve()` giving flawed or incomplete results.
 
-Convert a Polars `Series` to a NumPy array with the `.to_numpy()` method. Missing values will be replaced by `np.nan` during the conversion. If the `Series` does not include missing values, or those values are not desired anymore, the `.view()` method can be used instead, providing a zero-copy NumPy array of the data.
+Convert a Polars `Series` to a NumPy array with the `.to_numpy()` method. Missing values will be replaced by `np.nan` during the conversion.

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -757,11 +757,6 @@ def test_numpy_preserve_uint64_4112() -> None:
     assert df.to_numpy(structured=True).dtype == np.dtype([("a", "uint64")])
 
 
-def test_view_ub() -> None:
-    # this would be UB if the series was dropped and not passed to the view
-    assert np.sum(pl.Series([3, 1, 5]).sort().view()) == 9
-
-
 def test_arrow_list_null_5697() -> None:
     # Create a pyarrow table with a list[null] column.
     pa_table = pa.table([[[None]]], names=["mycol"])

--- a/py-polars/tests/unit/interop/test_numpy.py
+++ b/py-polars/tests/unit/interop/test_numpy.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+
+import polars as pl
+
+
+def test_view() -> None:
+    s = pl.Series("a", [1.0, 2.5, 3.0])
+    result = s._view()
+    assert isinstance(result, np.ndarray)
+    assert np.all(result == np.array([1.0, 2.5, 3.0]))
+
+
+def test_view_nulls() -> None:
+    s = pl.Series("b", [1, 2, None])
+    assert s.has_validity()
+    with pytest.raises(AssertionError):
+        s._view()
+
+
+def test_view_nulls_sliced() -> None:
+    s = pl.Series("b", [1, 2, None])
+    sliced = s[:2]
+    assert np.all(sliced._view() == np.array([1, 2]))
+    assert not sliced.has_validity()
+
+
+def test_view_ub() -> None:
+    # this would be UB if the series was dropped and not passed to the view
+    s = pl.Series([3, 1, 5])
+    result = s.sort()._view()
+    assert np.sum(result) == 9
+
+
+def test_view_deprecated() -> None:
+    s = pl.Series("a", [1.0, 2.5, 3.0])
+    with pytest.deprecated_call():
+        result = s.view()
+    assert isinstance(result, np.ndarray)
+    assert np.all(result == np.array([1.0, 2.5, 3.0]))

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -778,20 +778,6 @@ def test_arrow() -> None:
             )
 
 
-def test_view() -> None:
-    a = pl.Series("a", [1.0, 2.5, 3.0])
-    assert isinstance(a.view(), np.ndarray)
-    assert np.all(a.view() == np.array([1.0, 2.5, 3.0]))
-
-    b = pl.Series("b", [1, 2, None])
-    assert b.has_validity()
-    with pytest.raises(AssertionError):
-        b.view()
-
-    assert np.all(b[:2].view() == np.array([1, 2]))
-    assert not b[:2].has_validity()
-
-
 def test_ufunc() -> None:
     # test if output dtype is calculated correctly.
     s_float32 = pl.Series("a", [1.0, 2.0, 3.0, 4.0], dtype=pl.Float32)


### PR DESCRIPTION
As mention in our meeting.

I'm not sure what exactly `view` would be used for, but it seems like it's used as a way to get a NumPy zero copy array, so we can use `to_numpy(zero_copy_only=True)` for that.

For now it's converted to a private method.