### PR TITLE
feat: In explain(), rename PIPELINE to STREAMING so it's clearer what it means

### DIFF
--- a/crates/polars-plan/src/logical_plan/functions/mod.rs
+++ b/crates/polars-plan/src/logical_plan/functions/mod.rs
@@ -385,12 +385,12 @@ impl Display for FunctionNode {
             MergeSorted { .. } => write!(f, "MERGE SORTED"),
             Pipeline { original, .. } => {
                 if let Some(original) = original {
-                    writeln!(f, "--- PIPELINE")?;
+                    writeln!(f, "--- STREAMING")?;
                     write!(f, "{:?}", original.as_ref())?;
                     let indent = 2;
-                    writeln!(f, "{:indent$}--- END PIPELINE", "")
+                    writeln!(f, "{:indent$}--- END STREAMING", "")
                 } else {
-                    writeln!(f, "PIPELINE")
+                    writeln!(f, "STREAMING")
                 }
             },
             Rename { .. } => write!(f, "RENAME"),

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -176,7 +176,7 @@ def test_streaming_ternary() -> None:
             pl.when(pl.col("a") >= 2).then(pl.col("a")).otherwise(None).alias("b"),
         )
         .explain(streaming=True)
-        .startswith("--- PIPELINE")
+        .startswith("--- STREAMING")
     )
 
 

--- a/py-polars/tests/unit/streaming/test_streaming_cse.py
+++ b/py-polars/tests/unit/streaming/test_streaming_cse.py
@@ -79,7 +79,7 @@ def test_cse_expr_group_by() -> None:
     # check if it uses CSE_expr
     # and is a complete pipeline
     assert "__POLARS_CSER" in s
-    assert s.startswith("--- PIPELINE")
+    assert s.startswith("--- STREAMING")
 
     expected = pl.DataFrame(
         {"a": [1, 2, 3, 4], "sum": [1, 4, 9, 16], "min": [1, 4, 9, 16]}

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -392,7 +392,7 @@ def test_streaming_restart_non_streamable_group_by() -> None:
         )  # non-streamable UDF + nested_agg
     )
 
-    assert """--- PIPELINE""" in res.explain(streaming=True)
+    assert """--- STREAMING""" in res.explain(streaming=True)
 
 
 def test_group_by_min_max_string_type() -> None:


### PR DESCRIPTION
Replacement for #12456