### PR TITLE
refactor(python): Minor cleanup in Expr class

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -124,12 +124,10 @@ class Expr:
         return expr
 
     def _to_pyexpr(self, other: Any) -> PyExpr:
-        return self._to_expr(other)._pyexpr
-
-    def _to_expr(self, other: Any) -> Expr:
         if isinstance(other, Expr):
-            return other
-        return F.lit(other)
+            return other._pyexpr
+        else:
+            return F.lit(other)._pyexpr
 
     def _repr_html_(self) -> str:
         return self._pyexpr.to_str()
@@ -161,7 +159,7 @@ class Expr:
         return self._from_pyexpr(self._to_pyexpr(other)._and(self._pyexpr))
 
     def __eq__(self, other: Any) -> Self:  # type: ignore[override]
-        return self._from_pyexpr(self._pyexpr.eq(self._to_expr(other)._pyexpr))
+        return self._from_pyexpr(self._pyexpr.eq(self._to_pyexpr(other)))
 
     def __floordiv__(self, other: Any) -> Self:
         return self._from_pyexpr(self._pyexpr // self._to_pyexpr(other))
@@ -170,19 +168,19 @@ class Expr:
         return self._from_pyexpr(self._to_pyexpr(other) // self._pyexpr)
 
     def __ge__(self, other: Any) -> Self:
-        return self._from_pyexpr(self._pyexpr.gt_eq(self._to_expr(other)._pyexpr))
+        return self._from_pyexpr(self._pyexpr.gt_eq(self._to_pyexpr(other)))
 
     def __gt__(self, other: Any) -> Self:
-        return self._from_pyexpr(self._pyexpr.gt(self._to_expr(other)._pyexpr))
+        return self._from_pyexpr(self._pyexpr.gt(self._to_pyexpr(other)))
 
     def __invert__(self) -> Self:
         return self.not_()
 
     def __le__(self, other: Any) -> Self:
-        return self._from_pyexpr(self._pyexpr.lt_eq(self._to_expr(other)._pyexpr))
+        return self._from_pyexpr(self._pyexpr.lt_eq(self._to_pyexpr(other)))
 
     def __lt__(self, other: Any) -> Self:
-        return self._from_pyexpr(self._pyexpr.lt(self._to_expr(other)._pyexpr))
+        return self._from_pyexpr(self._pyexpr.lt(self._to_pyexpr(other)))
 
     def __mod__(self, other: Any) -> Self:
         return self._from_pyexpr(self._pyexpr % self._to_pyexpr(other))
@@ -197,7 +195,7 @@ class Expr:
         return self._from_pyexpr(self._to_pyexpr(other) * self._pyexpr)
 
     def __ne__(self, other: Any) -> Self:  # type: ignore[override]
-        return self._from_pyexpr(self._pyexpr.neq(self._to_expr(other)._pyexpr))
+        return self._from_pyexpr(self._pyexpr.neq(self._to_pyexpr(other)))
 
     def __neg__(self) -> Expr:
         neg_expr = F.lit(0) - self
@@ -4634,7 +4632,7 @@ class Expr:
         └──────┴──────┴────────┴────────────────┘
 
         """
-        return self._from_pyexpr(self._pyexpr.eq_missing(self._to_expr(other)._pyexpr))
+        return self._from_pyexpr(self._pyexpr.eq_missing(self._to_pyexpr(other)))
 
     def ge(self, other: Any) -> Self:
         """
@@ -4849,7 +4847,7 @@ class Expr:
         └──────┴──────┴────────┴────────────────┘
 
         """
-        return self._from_pyexpr(self._pyexpr.neq_missing(self._to_expr(other)._pyexpr))
+        return self._from_pyexpr(self._pyexpr.neq_missing(self._to_pyexpr(other)))
 
     def add(self, other: Any) -> Self:
         """

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -31,6 +31,9 @@ def parse_as_list_of_expressions(
     __structify
         Convert multi-column expressions to a single struct expression.
 
+    Returns
+    -------
+    list of PyExpr
     """
     exprs = _parse_regular_inputs(inputs, structify=__structify)
     if named_inputs:
@@ -77,7 +80,7 @@ def parse_as_expression(
     *,
     str_as_lit: bool = False,
     structify: bool = False,
-) -> PyExpr | Expr:
+) -> PyExpr:
     """
     Parse a single input into an expression.
 
@@ -91,6 +94,9 @@ def parse_as_expression(
     structify
         Convert multi-column expressions to a single struct expression.
 
+    Returns
+    -------
+    PyExpr
     """
     if isinstance(input, pl.Expr):
         expr = input


### PR DESCRIPTION
We should use the `parse_as_expression` util here but there's some more work to be done before we can do that.