### PR TITLE
fix: Fix lazy schema for `group_by_dynamic` and `rolling`

### DIFF
--- a/crates/polars-plan/src/logical_plan/builder_alp.rs
+++ b/crates/polars-plan/src/logical_plan/builder_alp.rs
@@ -124,13 +124,6 @@ impl<'a> ALogicalPlanBuilder<'a> {
 
         let mut schema =
             aexprs_to_schema(&keys, &current_schema, Context::Default, self.expr_arena);
-        let other = aexprs_to_schema(
-            &aggs,
-            &current_schema,
-            Context::Aggregation,
-            self.expr_arena,
-        );
-        schema.merge(other);
 
         #[cfg(feature = "dynamic_group_by")]
         {
@@ -149,6 +142,14 @@ impl<'a> ALogicalPlanBuilder<'a> {
                 schema.with_column(name.clone(), dtype.clone());
             }
         }
+
+        let agg_schema = aexprs_to_schema(
+            &aggs,
+            &current_schema,
+            Context::Aggregation,
+            self.expr_arena,
+        );
+        schema.merge(agg_schema);
 
         let lp = ALogicalPlan::Aggregate {
             input: self.root,

--- a/crates/polars-plan/src/logical_plan/builder_alp.rs
+++ b/crates/polars-plan/src/logical_plan/builder_alp.rs
@@ -127,18 +127,17 @@ impl<'a> ALogicalPlanBuilder<'a> {
 
         #[cfg(feature = "dynamic_group_by")]
         {
-            let index_columns = &[
-                options
-                    .rolling
-                    .as_ref()
-                    .map(|options| &options.index_column),
-                options
-                    .dynamic
-                    .as_ref()
-                    .map(|options| &options.index_column),
-            ];
-            for &name in index_columns.iter().flatten() {
+            if let Some(options) = options.rolling.as_ref() {
+                let name = &options.index_column;
                 let dtype = current_schema.get(name).unwrap();
+                schema.with_column(name.clone(), dtype.clone());
+            } else if let Some(options) = options.dynamic.as_ref() {
+                let name = &options.index_column;
+                let dtype = current_schema.get(name).unwrap();
+                if options.include_boundaries {
+                    schema.with_column("_lower_boundary".into(), dtype.clone());
+                    schema.with_column("_upper_boundary".into(), dtype.clone());
+                }
                 schema.with_column(name.clone(), dtype.clone());
             }
         }


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/11339

#### Changes

* Fixes the ordering of columns in the schema - aggregation columns should be at the end.
* Properly inserts `_lower_bound` and `_upper_bound` into the schema when `include_boundaries` is specified for `group_by_dynamic` _(Should these columns have better names?_ 🤔 
* Refactor some related tests