### PR TITLE
feat(python)!: Update `lit` behavior for list/tuple inputs

### DIFF
--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -121,10 +121,10 @@ def lit(
         return e.alias(name)
 
     elif _check_for_numpy(value) and isinstance(value, np.ndarray):
-        return lit(pl.Series("literal", value))
+        return lit(pl.Series("literal", value, dtype=dtype))
 
     elif isinstance(value, (list, tuple)):
-        return lit(pl.Series("literal", [value]))
+        return lit(pl.Series("literal", [value], dtype=dtype))
 
     if dtype:
         return wrap_expr(plr.lit(value, allow_object)).cast(dtype)

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -121,7 +121,7 @@ def lit(
         return e.alias(name)
 
     elif _check_for_numpy(value) and isinstance(value, np.ndarray):
-        return lit(pl.Series("", value))
+        return lit(pl.Series("literal", value))
 
     elif isinstance(value, (list, tuple)):
         return lit(pl.Series("literal", [value]))

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -113,12 +113,8 @@ def lit(
         return lit(datetime(value.year, value.month, value.day)).cast(Date)
 
     elif isinstance(value, pl.Series):
-        name = value.name
         value = value._s
-        e = wrap_expr(plr.lit(value, allow_object))
-        if name == "":
-            return e
-        return e.alias(name)
+        return wrap_expr(plr.lit(value, allow_object))
 
     elif _check_for_numpy(value) and isinstance(value, np.ndarray):
         return lit(pl.Series("literal", value, dtype=dtype))

--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -14,7 +14,6 @@ from polars.utils.convert import (
     _time_to_pl_time,
     _timedelta_to_pl_timedelta,
 )
-from polars.utils.deprecation import issue_deprecation_warning
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -125,13 +124,7 @@ def lit(
         return lit(pl.Series("", value))
 
     elif isinstance(value, (list, tuple)):
-        issue_deprecation_warning(
-            "Behavior for `lit` will change for sequence inputs."
-            " The result will change to be a literal of type List."
-            " To retain the old behavior, pass a Series instead, e.g. `Series(sequence)`.",
-            version="0.18.14",
-        )
-        return lit(pl.Series("", value))
+        return lit(pl.Series("literal", [value]))
 
     if dtype:
         return wrap_expr(plr.lit(value, allow_object)).cast(dtype)

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import date, datetime, time, timedelta
 from typing import TYPE_CHECKING, Any, Iterable
 
 import polars._reexport as pl
@@ -13,9 +12,6 @@ if TYPE_CHECKING:
     from polars import Expr
     from polars.polars import PyExpr
     from polars.type_aliases import IntoExpr
-
-from polars.dependencies import _check_for_numpy
-from polars.dependencies import numpy as np
 
 
 def parse_as_list_of_expressions(
@@ -108,25 +104,9 @@ def parse_as_expression(
     elif isinstance(input, str) and not str_as_lit:
         expr = F.col(input)
         structify = False
-    elif (
-        isinstance(
-            input, (int, float, str, bytes, pl.Series, datetime, date, time, timedelta)
-        )
-        or input is None
-    ):
+    else:
         expr = F.lit(input)
         structify = False
-    elif isinstance(input, (list, tuple)):
-        expr = F.lit(pl.Series("literal", [input]))
-        structify = False
-    elif _check_for_numpy(input) and isinstance(input, np.ndarray):
-        expr = F.lit(pl.Series("literal", input))
-        structify = False
-    else:
-        raise TypeError(
-            f"did not expect value {input!r} of type {type(input).__name__!r}"
-            "\n\nTry disambiguating with `lit` or `col`."
-        )
 
     if structify:
         expr = _structify_expression(expr)

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -1,7 +1,7 @@
 use polars::lazy::dsl;
 use polars::lazy::dsl::Expr;
 use polars::prelude::*;
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBool, PyBytes, PyFloat, PyInt, PyString};
 
@@ -394,8 +394,8 @@ pub fn lit(value: &PyAny, allow_object: bool) -> PyResult<PyExpr> {
         });
         Ok(dsl::lit(s).into())
     } else {
-        Err(PyValueError::new_err(format!(
-            "could not convert value {:?} as a Literal",
+        Err(PyTypeError::new_err(format!(
+            "invalid literal value: {:?}",
             value.str()?
         )))
     }

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from typing import Any, Sequence
+from typing import Any
 
 import numpy as np
 import pytest
@@ -11,15 +11,32 @@ from polars.testing import assert_frame_equal
 
 
 @pytest.mark.parametrize(
-    "sequence",
+    "input",
     [
         [[1, 2], [3, 4, 5]],
+        [1, 2, 3],
+    ],
+)
+def test_lit_list_input(input: list[Any]) -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+    result = df.with_columns(pl.lit(input))
+    expected = pl.DataFrame({"a": [1, 2], "literal": [input, input]})
+    assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "input",
+    [
+        ([1, 2], [3, 4, 5]),
         (1, 2, 3),
     ],
 )
-def test_lit_deprecated_sequence_input(sequence: Sequence[Any]) -> None:
-    with pytest.deprecated_call():
-        pl.lit(sequence)
+def test_lit_tuple_input(input: tuple[Any, ...]) -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+    result = df.with_columns(pl.lit(input))
+
+    expected = pl.DataFrame({"a": [1, 2], "literal": [list(input), list(input)]})
+    assert_frame_equal(result, expected)
 
 
 def test_lit_ambiguous_datetimes_11379() -> None:

--- a/py-polars/tests/unit/functions/test_lit.py
+++ b/py-polars/tests/unit/functions/test_lit.py
@@ -39,6 +39,16 @@ def test_lit_tuple_input(input: tuple[Any, ...]) -> None:
     assert_frame_equal(result, expected)
 
 
+def test_lit_numpy_array_input() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+    input = np.array([3, 4])
+
+    result = df.with_columns(pl.lit(input, dtype=pl.Int64))
+
+    expected = pl.DataFrame({"a": [1, 2], "literal": [3, 4]})
+    assert_frame_equal(result, expected)
+
+
 def test_lit_ambiguous_datetimes_11379() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -187,7 +187,7 @@ def test_getitem_errs() -> None:
 def test_err_bubbling_up_to_lit() -> None:
     df = pl.DataFrame({"date": [date(2020, 1, 1)], "value": [42]})
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         df.filter(pl.col("date") == pl.Date("2020-01-01"))
 
 


### PR DESCRIPTION
This behavior was previously deprecated - this introduces the breaking change.

#### Changes

* List and tuple inputs to `lit` now result in a `List` type literal where each element corresponds to the given input.
* NumPy array inputs to `lit` are now named `"literal"` rather than having an empty name.
* `dtype` argument now correctly works for list/tuple/NumPy inputs

#### Example

**Before**

```pycon
>>> df = pl.DataFrame({"a": [1, 2]})
>>> df.with_columns( pl.lit([5,6]) )
shape: (2, 2)
┌─────┬─────┐
│ a   ┆     │
│ --- ┆ --- │
│ i64 ┆ i64 │
╞═════╪═════╡
│ 1   ┆ 5   │
│ 2   ┆ 6   │
└─────┴─────┘

```

**After**

```pycon
>>> df.with_columns( pl.lit([5,6]) )
shape: (2, 2)
┌─────┬───────────┐
│ a   ┆ literal   │
│ --- ┆ ---       │
│ i64 ┆ list[i64] │
╞═════╪═══════════╡
│ 1   ┆ [5, 6]    │
│ 2   ┆ [5, 6]    │
└─────┴───────────┘
```

