### PR TITLE
refactor: convert all recursive parquet deserialize to iterative

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/dictionary.rs
@@ -159,21 +159,23 @@ where
     type Item = PolarsResult<(NestedState, DictionaryArray<K>)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let maybe_state = nested_next_dict(
-            &mut self.iter,
-            &mut self.items,
-            &mut self.remaining,
-            &self.init,
-            &mut self.values,
-            self.data_type.clone(),
-            self.chunk_size,
-            |dict| read_dict::<O>(self.data_type.clone(), dict),
-        );
-        match maybe_state {
-            MaybeNext::Some(Ok(dict)) => Some(Ok(dict)),
-            MaybeNext::Some(Err(e)) => Some(Err(e)),
-            MaybeNext::None => None,
-            MaybeNext::More => self.next(),
+        loop {
+            let maybe_state = nested_next_dict(
+                &mut self.iter,
+                &mut self.items,
+                &mut self.remaining,
+                &self.init,
+                &mut self.values,
+                self.data_type.clone(),
+                self.chunk_size,
+                |dict| read_dict::<O>(self.data_type.clone(), dict),
+            );
+            match maybe_state {
+                MaybeNext::Some(Ok(dict)) => return Some(Ok(dict)),
+                MaybeNext::Some(Err(e)) => return Some(Err(e)),
+                MaybeNext::None => return None,
+                MaybeNext::More => continue,
+            }
         }
     }
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/boolean/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/boolean/basic.rs
@@ -222,21 +222,23 @@ impl<I: Pages> Iterator for Iter<I> {
     type Item = PolarsResult<BooleanArray>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let maybe_state = next(
-            &mut self.iter,
-            &mut self.items,
-            &mut None,
-            &mut self.remaining,
-            self.chunk_size,
-            &BooleanDecoder::default(),
-        );
-        match maybe_state {
-            MaybeNext::Some(Ok((values, validity))) => {
-                Some(Ok(finish(&self.data_type, values, validity)))
-            },
-            MaybeNext::Some(Err(e)) => Some(Err(e)),
-            MaybeNext::None => None,
-            MaybeNext::More => self.next(),
+        loop {
+            let maybe_state = next(
+                &mut self.iter,
+                &mut self.items,
+                &mut None,
+                &mut self.remaining,
+                self.chunk_size,
+                &BooleanDecoder::default(),
+            );
+            match maybe_state {
+                MaybeNext::Some(Ok((values, validity))) => {
+                    return Some(Ok(finish(&self.data_type, values, validity)))
+                },
+                MaybeNext::Some(Err(e)) => return Some(Err(e)),
+                MaybeNext::None => return None,
+                MaybeNext::More => continue,
+            }
         }
     }
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/boolean/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/boolean/nested.rs
@@ -136,23 +136,27 @@ impl<I: Pages> Iterator for NestedIter<I> {
     type Item = PolarsResult<(NestedState, BooleanArray)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let maybe_state = next(
-            &mut self.iter,
-            &mut self.items,
-            &mut None,
-            &mut self.remaining,
-            &self.init,
-            self.chunk_size,
-            &BooleanDecoder::default(),
-        );
-        match maybe_state {
-            MaybeNext::Some(Ok((nested, (values, validity)))) => Some(Ok((
-                nested,
-                finish(&ArrowDataType::Boolean, values, validity),
-            ))),
-            MaybeNext::Some(Err(e)) => Some(Err(e)),
-            MaybeNext::None => None,
-            MaybeNext::More => self.next(),
+        loop {
+            let maybe_state = next(
+                &mut self.iter,
+                &mut self.items,
+                &mut None,
+                &mut self.remaining,
+                &self.init,
+                self.chunk_size,
+                &BooleanDecoder::default(),
+            );
+            match maybe_state {
+                MaybeNext::Some(Ok((nested, (values, validity)))) => {
+                    return Some(Ok((
+                        nested,
+                        finish(&ArrowDataType::Boolean, values, validity),
+                    )))
+                },
+                MaybeNext::Some(Err(e)) => return Some(Err(e)),
+                MaybeNext::None => return None,
+                MaybeNext::More => continue,
+            }
         }
     }
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/basic.rs
@@ -311,21 +311,23 @@ impl<I: Pages> Iterator for Iter<I> {
     type Item = PolarsResult<FixedSizeBinaryArray>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let maybe_state = next(
-            &mut self.iter,
-            &mut self.items,
-            &mut self.dict,
-            &mut self.remaining,
-            self.chunk_size,
-            &BinaryDecoder { size: self.size },
-        );
-        match maybe_state {
-            MaybeNext::Some(Ok((values, validity))) => {
-                Some(Ok(finish(&self.data_type, values, validity)))
-            },
-            MaybeNext::Some(Err(e)) => Some(Err(e)),
-            MaybeNext::None => None,
-            MaybeNext::More => self.next(),
+        loop {
+            let maybe_state = next(
+                &mut self.iter,
+                &mut self.items,
+                &mut self.dict,
+                &mut self.remaining,
+                self.chunk_size,
+                &BinaryDecoder { size: self.size },
+            );
+            match maybe_state {
+                MaybeNext::Some(Ok((values, validity))) => {
+                    return Some(Ok(finish(&self.data_type, values, validity)))
+                },
+                MaybeNext::Some(Err(e)) => return Some(Err(e)),
+                MaybeNext::None => return None,
+                MaybeNext::More => continue,
+            }
         }
     }
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/dictionary.rs
@@ -135,21 +135,23 @@ where
     type Item = PolarsResult<(NestedState, DictionaryArray<K>)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let maybe_state = nested_next_dict(
-            &mut self.iter,
-            &mut self.items,
-            &mut self.remaining,
-            &self.init,
-            &mut self.values,
-            self.data_type.clone(),
-            self.chunk_size,
-            |dict| read_dict(self.data_type.clone(), dict),
-        );
-        match maybe_state {
-            MaybeNext::Some(Ok(dict)) => Some(Ok(dict)),
-            MaybeNext::Some(Err(e)) => Some(Err(e)),
-            MaybeNext::None => None,
-            MaybeNext::More => self.next(),
+        loop {
+            let maybe_state = nested_next_dict(
+                &mut self.iter,
+                &mut self.items,
+                &mut self.remaining,
+                &self.init,
+                &mut self.values,
+                self.data_type.clone(),
+                self.chunk_size,
+                |dict| read_dict(self.data_type.clone(), dict),
+            );
+            match maybe_state {
+                MaybeNext::Some(Ok(dict)) => return Some(Ok(dict)),
+                MaybeNext::Some(Err(e)) => return Some(Err(e)),
+                MaybeNext::None => return None,
+                MaybeNext::More => continue,
+            }
         }
     }
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/nested.rs
@@ -172,22 +172,24 @@ impl<I: Pages> Iterator for NestedIter<I> {
     type Item = PolarsResult<(NestedState, FixedSizeBinaryArray)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let maybe_state = next(
-            &mut self.iter,
-            &mut self.items,
-            &mut self.dict,
-            &mut self.remaining,
-            &self.init,
-            self.chunk_size,
-            &BinaryDecoder { size: self.size },
-        );
-        match maybe_state {
-            MaybeNext::Some(Ok((nested, decoded))) => {
-                Some(Ok((nested, finish(&self.data_type, decoded.0, decoded.1))))
-            },
-            MaybeNext::Some(Err(e)) => Some(Err(e)),
-            MaybeNext::None => None,
-            MaybeNext::More => self.next(),
+        loop {
+            let maybe_state = next(
+                &mut self.iter,
+                &mut self.items,
+                &mut self.dict,
+                &mut self.remaining,
+                &self.init,
+                self.chunk_size,
+                &BinaryDecoder { size: self.size },
+            );
+            match maybe_state {
+                MaybeNext::Some(Ok((nested, decoded))) => {
+                    return Some(Ok((nested, finish(&self.data_type, decoded.0, decoded.1))))
+                },
+                MaybeNext::Some(Err(e)) => return Some(Err(e)),
+                MaybeNext::None => return None,
+                MaybeNext::More => continue,
+            }
         }
     }
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/dictionary.rs
@@ -170,21 +170,23 @@ where
     type Item = PolarsResult<(NestedState, DictionaryArray<K>)>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let maybe_state = nested_next_dict(
-            &mut self.iter,
-            &mut self.items,
-            &mut self.remaining,
-            &self.init,
-            &mut self.values,
-            self.data_type.clone(),
-            self.chunk_size,
-            |dict| read_dict::<P, T, _>(self.data_type.clone(), self.op, dict),
-        );
-        match maybe_state {
-            MaybeNext::Some(Ok(dict)) => Some(Ok(dict)),
-            MaybeNext::Some(Err(e)) => Some(Err(e)),
-            MaybeNext::None => None,
-            MaybeNext::More => self.next(),
+        loop {
+            let maybe_state = nested_next_dict(
+                &mut self.iter,
+                &mut self.items,
+                &mut self.remaining,
+                &self.init,
+                &mut self.values,
+                self.data_type.clone(),
+                self.chunk_size,
+                |dict| read_dict::<P, T, _>(self.data_type.clone(), self.op, dict),
+            );
+            match maybe_state {
+                MaybeNext::Some(Ok(dict)) => return Some(Ok(dict)),
+                MaybeNext::Some(Err(e)) => return Some(Err(e)),
+                MaybeNext::None => return None,
+                MaybeNext::More => continue,
+            }
         }
     }
 }


### PR DESCRIPTION
https://github.com/pola-rs/polars/pull/11471 converted binary deserialize to iterative, this PR applies the same change for all of the others.