### PR TITLE
fix: parquet: do not extend existing nested that is already complete

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -450,7 +450,7 @@ fn extend_offsets2<'a, D: NestedDecoder<'a>>(
         // yield batches of pages. This means e.g. it could be that the very
         // first page is a new row, and the existing nested state has already
         // contains all data from the additional rows.
-        if page.iter.peek().unwrap().0.as_ref().copied().unwrap_or(1) == 0 {
+        if page.iter.peek().unwrap().0.as_ref().copied().unwrap() == 0 {
             if rows == additional {
                 return Ok(true);
             }

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -390,14 +390,16 @@ pub(super) fn extend<'a, D: NestedDecoder<'a>>(
             *remaining -= nested.len() - existing;
             items.push_back((nested, decoded));
 
+            if page.len() == 0 {
+                // No more pages.
+                break;
+            }
+
             if is_fully_read && *remaining == 0 {
+                // Requested amount has been fully read.
                 break;
             };
         };
-
-        if page.len() == 0 {
-            break;
-        }
 
         let nested = init_nested(init, chunk_size.unwrap_or(*remaining).min(*remaining));
         let decoded = decoder.with_capacity(0);

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -387,7 +387,7 @@ pub(super) fn extend<'a, D: NestedDecoder<'a>>(
                 additional,
             )?;
             first_item_fully_read |= is_fully_read;
-            *remaining = remaining.wrapping_sub(nested.len() - existing);
+            *remaining -= nested.len() - existing;
             items.push_back((nested, decoded));
 
             if is_fully_read && *remaining == 0 {

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -411,8 +411,7 @@ pub(super) fn extend<'a, D: NestedDecoder<'a>>(
         // At this point:
         // * There are more pages.
         // * The remaining rows have not been fully read.
-        // * There is no last nested state in the deque, or there is one but it
-        //   already holds completed data.
+        // * The deque is empty, or the last item already holds completed data.
         let nested = init_nested(init, chunk_size.unwrap_or(*remaining).min(*remaining));
         let decoded = decoder.with_capacity(0);
         items.push_back((nested, decoded));


### PR DESCRIPTION
Handle a potential case where `extend_offsets2` gets called with an existing `nested` state that is already complete after the previous call returned `Ok(false)` due to not being able to see the next page. This is done by moving the `peek` of the repetition level to the first step after refactoring the loop.

Also does some refactoring to make it more robust:
* in `extend`, use a single loop to remove the duplicated code in the `while` loop, this ensures the return value of `extend_offsets2` is always respected
* correct `wrapping_sub` with (it was supposed to be) `saturating_sub` (what on earth was I doing before 😅😅). This is also only needed to be a `saturating_sub` when calculating `additional` - the below `*remaining -= ..` is restored.
