### PR TITLE
fix(rust)!: Rename `not_` expression to `not` on the Rust side

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/crates/polars-plan/src/dsl/function_expr/boolean.rs
@@ -70,7 +70,7 @@ impl Display for BooleanFunction {
             IsIn => "is_in",
             AnyHorizontal => "any_horizontal",
             AllHorizontal => "all_horizontal",
-            Not => "not_",
+            Not => "not",
         };
         write!(f, "{s}")
     }
@@ -100,7 +100,7 @@ impl From<BooleanFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             IsIn => wrap!(is_in),
             AllHorizontal => map_as_slice!(all_horizontal),
             AnyHorizontal => map_as_slice!(any_horizontal),
-            Not => map!(not_),
+            Not => map!(not),
         }
     }
 }
@@ -188,6 +188,6 @@ fn all_horizontal(s: &[Series]) -> PolarsResult<Series> {
     polars_ops::prelude::all_horizontal(s)
 }
 
-fn not_(s: &Series) -> PolarsResult<Series> {
+fn not(s: &Series) -> PolarsResult<Series> {
     Ok(s.bool()?.not().into_series())
 }


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/pull/10838#issuecomment-1818741317

The expression should be named `not` on the Rust side. In Python, it has to be named `not_` due to naming conflict with language defaults.