### PR TITLE
perf: improve cov/corr algorithm

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -19,7 +19,7 @@ use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
 use crate::series::IsSorted;
 
-mod float_sum;
+pub mod float_sum;
 
 /// Aggregations that return [`Series`] of unit length. Those can be used in broadcasting operations.
 pub trait ChunkAggSeries {

--- a/crates/polars-ops/src/chunked_array/cov.rs
+++ b/crates/polars-ops/src/chunked_array/cov.rs
@@ -6,6 +6,15 @@ use num_traits::ToPrimitive;
 use polars_core::prelude::*;
 use polars_core::utils::align_chunks_binary;
 
+const COV_BUF_SIZE: usize = 64;
+
+/// Calculates the sum of x[i] * y[i] from 0..k.
+fn multiply_sum(x: &[f64; COV_BUF_SIZE], y: &[f64; COV_BUF_SIZE], k: usize) -> f64 {
+    assert!(k <= COV_BUF_SIZE);
+    let tmp: [f64; COV_BUF_SIZE] = std::array::from_fn(|i| x[i] * y[i]);
+    float_sum::f64::sum(&tmp[..k])
+}
+
 /// Compute the covariance between two columns.
 pub fn cov<T>(a: &ChunkedArray<T>, b: &ChunkedArray<T>, ddof: u8) -> Option<f64>
 where
@@ -44,27 +53,51 @@ where
     J: IntoIterator<Item = (T, T)> + Clone,
     T: ToPrimitive,
 {
+    // The algorithm is derived from
+    // https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Weighted_batched_version
+    // We simply set the weights to 1.0. This allows us to simplify the expressions
+    // a lot, and move out subtractions out of sums.
     let mut mean_x = 0.0;
     let mut mean_y = 0.0;
-    let mut c = 0.0;
+    let mut cxy = 0.0;
     let mut n = 0.0;
 
+    let mut x_tmp = [0.0; COV_BUF_SIZE];
+    let mut y_tmp = [0.0; COV_BUF_SIZE];
+
     for iter in iters {
-        let iter = iter.clone().into_iter();
-        for (x, y) in iter {
-            let x = x.to_f64().unwrap();
-            let y = y.to_f64().unwrap();
+        let mut iter = iter.clone().into_iter();
 
-            n += 1.0;
+        loop {
+            let mut k = 0;
+            for (x, y) in iter.by_ref().take(COV_BUF_SIZE) {
+                let x = x.to_f64().unwrap();
+                let y = y.to_f64().unwrap();
 
-            let dx = x - mean_x;
-            mean_x += dx / n;
-            mean_y += (y - mean_y) / n;
-            c += dx * (y - mean_y)
+                x_tmp[k] = x;
+                y_tmp[k] = y;
+                k += 1;
+            }
+            if k == 0 {
+                break;
+            }
+            
+            // TODO: combine these all in one SIMD'ized pass.
+            let xsum = float_sum::f64::sum(&x_tmp[..k]);
+            let ysum = float_sum::f64::sum(&y_tmp[..k]);
+            let xysum = multiply_sum(&x_tmp, &y_tmp, k);
+
+            let old_mean_x = mean_x;
+            let old_mean_y = mean_y;
+            n += k as f64;
+            mean_x += (xsum - k as f64*old_mean_x) / n;
+            mean_y += (ysum - k as f64*old_mean_y) / n;
+
+            cxy += xysum - xsum*old_mean_y - ysum*mean_x + mean_x*old_mean_y*(k as f64);
         }
     }
 
-    c / (n - ddof as f64)
+    cxy / (n - ddof as f64)
 }
 
 /// Compute the pearson correlation between two columns.
@@ -105,40 +138,59 @@ where
     J: IntoIterator<Item = (T, T)> + Clone,
     T: ToPrimitive,
 {
+    // Algorithm is same as cov, we just maintain cov(X, X), cov(X, Y), and
+    // cov(Y, Y), noting that var(X) = cov(X, X).
+    // Then corr(X, Y) = cov(X, Y)/(std(X) * std(Y)).
     let mut mean_x = 0.0;
     let mut mean_y = 0.0;
-    let mut c = 0.0;
+    let mut cxy = 0.0;
+    let mut cxx = 0.0;
+    let mut cyy = 0.0;
     let mut n = 0.0;
 
-    let mut m2x = 0.0;
-    let mut m2y = 0.0;
+    let mut x_tmp = [0.0; COV_BUF_SIZE];
+    let mut y_tmp = [0.0; COV_BUF_SIZE];
 
     for iter in iters {
-        let iter = iter.clone().into_iter();
-        for (x, y) in iter {
-            let x = x.to_f64().unwrap();
-            let y = y.to_f64().unwrap();
+        let mut iter = iter.clone().into_iter();
 
-            n += 1.0;
+        loop {
+            let mut k = 0;
+            for (x, y) in iter.by_ref().take(COV_BUF_SIZE) {
+                let x = x.to_f64().unwrap();
+                let y = y.to_f64().unwrap();
 
-            let dx = x - mean_x;
-            let dy = y - mean_y;
-            mean_x += dx / n;
-            mean_y += dy / n;
+                x_tmp[k] = x;
+                y_tmp[k] = y;
+                k += 1;
+            }
+            if k == 0 {
+                break;
+            }
 
-            let d2x = x - mean_x;
-            let d2y = y - mean_y;
+            // TODO: combine these all in one SIMD'ized pass.
+            let xsum = float_sum::f64::sum(&x_tmp[..k]);
+            let ysum = float_sum::f64::sum(&y_tmp[..k]);
+            let xxsum = multiply_sum(&x_tmp, &x_tmp, k);
+            let xysum = multiply_sum(&x_tmp, &y_tmp, k);
+            let yysum = multiply_sum(&y_tmp, &y_tmp, k);
+            
+            let old_mean_x = mean_x;
+            let old_mean_y = mean_y;
+            n += k as f64;
+            mean_x += (xsum - k as f64*old_mean_x) / n;
+            mean_y += (ysum - k as f64*old_mean_y) / n;
 
-            m2x += dx * d2x;
-            m2y += dy * d2y;
-            c += dx * (y - mean_y)
+            cxx += xxsum - xsum*old_mean_x - xsum*mean_x + mean_x*old_mean_x*(k as f64);
+            cxy += xysum - xsum*old_mean_y - ysum*mean_x + mean_x*old_mean_y*(k as f64);
+            cyy += yysum - ysum*old_mean_y - ysum*mean_y + mean_y*old_mean_y*(k as f64);
         }
     }
 
     let sample_n = n - ddof as f64;
-    let sample_cov = c / sample_n;
-    let sample_std_x = (m2x / sample_n).sqrt();
-    let sample_std_y = (m2y / sample_n).sqrt();
+    let sample_cov = cxy / sample_n;
+    let sample_std_x = (cxx / sample_n).sqrt();
+    let sample_std_y = (cyy / sample_n).sqrt();
 
     sample_cov / (sample_std_x * sample_std_y)
 }

--- a/crates/polars-ops/src/chunked_array/cov.rs
+++ b/crates/polars-ops/src/chunked_array/cov.rs
@@ -81,7 +81,7 @@ where
             if k == 0 {
                 break;
             }
-            
+
             // TODO: combine these all in one SIMD'ized pass.
             let xsum = float_sum::f64::sum(&x_tmp[..k]);
             let ysum = float_sum::f64::sum(&y_tmp[..k]);
@@ -90,10 +90,10 @@ where
             let old_mean_x = mean_x;
             let old_mean_y = mean_y;
             n += k as f64;
-            mean_x += (xsum - k as f64*old_mean_x) / n;
-            mean_y += (ysum - k as f64*old_mean_y) / n;
+            mean_x += (xsum - k as f64 * old_mean_x) / n;
+            mean_y += (ysum - k as f64 * old_mean_y) / n;
 
-            cxy += xysum - xsum*old_mean_y - ysum*mean_x + mean_x*old_mean_y*(k as f64);
+            cxy += xysum - xsum * old_mean_y - ysum * mean_x + mean_x * old_mean_y * (k as f64);
         }
     }
 
@@ -174,16 +174,16 @@ where
             let xxsum = multiply_sum(&x_tmp, &x_tmp, k);
             let xysum = multiply_sum(&x_tmp, &y_tmp, k);
             let yysum = multiply_sum(&y_tmp, &y_tmp, k);
-            
+
             let old_mean_x = mean_x;
             let old_mean_y = mean_y;
             n += k as f64;
-            mean_x += (xsum - k as f64*old_mean_x) / n;
-            mean_y += (ysum - k as f64*old_mean_y) / n;
+            mean_x += (xsum - k as f64 * old_mean_x) / n;
+            mean_y += (ysum - k as f64 * old_mean_y) / n;
 
-            cxx += xxsum - xsum*old_mean_x - xsum*mean_x + mean_x*old_mean_x*(k as f64);
-            cxy += xysum - xsum*old_mean_y - ysum*mean_x + mean_x*old_mean_y*(k as f64);
-            cyy += yysum - ysum*old_mean_y - ysum*mean_y + mean_y*old_mean_y*(k as f64);
+            cxx += xxsum - xsum * old_mean_x - xsum * mean_x + mean_x * old_mean_x * (k as f64);
+            cxy += xysum - xsum * old_mean_y - ysum * mean_x + mean_x * old_mean_y * (k as f64);
+            cyy += yysum - ysum * old_mean_y - ysum * mean_y + mean_y * old_mean_y * (k as f64);
         }
     }
 

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -45,5 +45,5 @@ def test_correlation_cast_supertype() -> None:
     df = pl.DataFrame({"a": [1, 8, 3], "b": [4.0, 5.0, 2.0]})
     df = df.with_columns(pl.col("b"))
     assert df.select(pl.corr("a", "b")).to_dict(as_series=False) == {
-        "a": [0.5447047794019223]
+        "a": [0.5447047794019219]
     }


### PR DESCRIPTION
The [previous PR](https://github.com/pola-rs/polars/pull/12471) which was reverted did not implement the new algorithm completely correctly. This PR does, with a relative error of ~1.2e-15 compared to numpy for the correlation query found in the H2OAI benchmark. It should be a bit faster still because it does not subtract in a loop either, it computes the sums of `x`, `y`, `x^2`, `y^2` and `xy` per batch and updates the online covariances using these aggregates.