### PR TITLE
feat(python): extend recent `filter` syntax upgrades to `when/then` construct

### DIFF
--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -169,6 +169,7 @@ class ChainedThen(Expr):
     ) -> ChainedWhen:
         """
         Add another condition to the `when-then-otherwise` expression.
+
         Parameters
         ----------
         predicates

--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterable
 
 import polars.functions as F
 from polars.expr.expr import Expr
-from polars.utils._parse_expr_input import parse_as_expression
+from polars.utils._parse_expr_input import (
+    parse_as_expression,
+    parse_when_constraint_expressions,
+)
 from polars.utils._wrap import wrap_expr
 from polars.utils.deprecation import (
     deprecate_renamed_parameter,
@@ -67,18 +70,27 @@ class Then(Expr):
         return self._then.otherwise(F.lit(None)._pyexpr)
 
     @deprecate_renamed_parameter("predicate", "condition", version="0.18.9")
-    def when(self, condition: IntoExpr) -> ChainedWhen:
+    def when(
+        self,
+        *predicates: IntoExpr | Iterable[IntoExpr],
+        **constraints: Any,
+    ) -> ChainedWhen:
         """
         Add a condition to the `when-then-otherwise` expression.
 
         Parameters
         ----------
-        condition
-            The condition for applying the subsequent statement.
-            Accepts a boolean expression. String input is parsed as a column name.
+        predicates
+            Condition(s) that must be met in order to apply the subsequent statement.
+            Accepts one or more boolean expressions, which are implicitly combined with
+            `&`. String input is parsed as a column name.
+        constraints
+            Apply conditions as `colname = value` keyword arguments that are treated as
+            equality matches, such as `x = 123`. As with the predicates parameter,
+            multiple conditions are implicitly combined using `&`.
 
         """
-        condition_pyexpr = parse_as_expression(condition)
+        condition_pyexpr = parse_when_constraint_expressions(*predicates, **constraints)
         return ChainedWhen(self._then.when(condition_pyexpr))
 
     @deprecate_renamed_parameter("expr", "statement", version="0.18.9")
@@ -150,18 +162,26 @@ class ChainedThen(Expr):
         return self._chained_then.otherwise(F.lit(None)._pyexpr)
 
     @deprecate_renamed_parameter("predicate", "condition", version="0.18.9")
-    def when(self, condition: IntoExpr) -> ChainedWhen:
+    def when(
+        self,
+        *predicates: IntoExpr | Iterable[IntoExpr],
+        **constraints: Any,
+    ) -> ChainedWhen:
         """
         Add another condition to the `when-then-otherwise` expression.
-
         Parameters
         ----------
-        condition
-            The condition for applying the subsequent statement.
-            Accepts a boolean expression. String input is parsed as a column name.
+        predicates
+            Condition(s) that must be met in order to apply the subsequent statement.
+            Accepts one or more boolean expressions, which are implicitly combined with
+            `&`. String input is parsed as a column name.
+        constraints
+            Apply conditions as `colname = value` keyword arguments that are treated as
+            equality matches, such as `x = 123`. As with the predicates parameter,
+            multiple conditions are implicitly combined using `&`.
 
         """
-        condition_pyexpr = parse_as_expression(condition)
+        condition_pyexpr = parse_when_constraint_expressions(*predicates, **constraints)
         return ChainedWhen(self._chained_then.when(condition_pyexpr))
 
     @deprecate_renamed_parameter("expr", "statement", version="0.18.9")


### PR DESCRIPTION
Closes #12577.

Coming at you from ~12km altitude and a speed of ~950km/h on some awful (but free) in-flight WiFi... (heading back home after a few days in Madrid ;))

Preserves existing behaviour of `when` (with a suitable `DeprecationWarning`), but now allows for the same convenient/flexible multi-predicate & kwargs syntax that was recently afforded to `filter`, eg:

## Example
Using kwargs -
```python
df = pl.DataFrame(
    {
        "x": [10, 20, 30, 40],
        "y": [15, -20, None, 1],
        "z": ["a", "b", "c", "d"],
    }
)
df.with_columns(
    matched = pl.when( x=40, y=1, z="d" ).then( pl.lit(":)") ).otherwise( pl.lit(":(") )
)
# shape: (4, 4)
# ┌─────┬──────┬─────┬─────────┐
# │ x   ┆ y    ┆ z   ┆ matched │
# │ --- ┆ ---  ┆ --- ┆ ---     │
# │ i64 ┆ i64  ┆ str ┆ str     │
# ╞═════╪══════╪═════╪═════════╡
# │ 10  ┆ 15   ┆ a   ┆ :(      │
# │ 20  ┆ -20  ┆ b   ┆ :(      │
# │ 30  ┆ null ┆ c   ┆ :(      │
# │ 40  ┆ 1    ┆ d   ┆ :)      │
# └─────┴──────┴─────┴─────────┘
```
Multiple predicates -
```python
df.with_columns(
    matched=pl.when(
        pl.col("x") <= 30,
        pl.col("y").is_not_null(),
        pl.col("z").is_in(["b", "c", "d"]),
    )
    .then(":)")
    .otherwise(":(")
)
# shape: (4, 4)
# ┌─────┬──────┬─────┬─────────┐
# │ x   ┆ y    ┆ z   ┆ matched │
# │ --- ┆ ---  ┆ --- ┆ ---     │
# │ i64 ┆ i64  ┆ str ┆ str     │
# ╞═════╪══════╪═════╪═════════╡
# │ 10  ┆ 15   ┆ a   ┆ :(      │
# │ 20  ┆ -20  ┆ b   ┆ :)      │
# │ 30  ┆ null ┆ c   ┆ :(      │
# │ 40  ┆ 1    ┆ d   ┆ :(      │
# └─────┴──────┴─────┴─────────┘
```
(And can freely mix & match the two where it makes ergonomic sense, as with `filter`).

![airborne_commit](https://github.com/pola-rs/polars/assets/2613171/6511b00d-1f69-4249-8a5c-44e60ddb32a1)
