### PR TITLE
fix: panic reading parquet nested struct column

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested_utils.rs
@@ -377,16 +377,13 @@ pub(super) fn extend<'a, D: NestedDecoder<'a>>(
         "Should have yielded already completed item before reading more."
     );
 
+    let chunk_size = chunk_size.unwrap_or(usize::MAX);
     let mut first_item_is_fully_read = false;
 
     loop {
         if let Some((mut nested, mut decoded)) = items.pop_back() {
             let existing = nested.len();
-
-            let additional = chunk_size
-                .unwrap_or(*remaining)
-                .min(*remaining)
-                .saturating_sub(existing);
+            let additional = (chunk_size - existing).min(*remaining);
 
             let is_fully_read = extend_offsets2(
                 &mut page,
@@ -413,7 +410,7 @@ pub(super) fn extend<'a, D: NestedDecoder<'a>>(
         // * There are more pages.
         // * The remaining rows have not been fully read.
         // * The deque is empty, or the last item already holds completed data.
-        let nested = init_nested(init, chunk_size.unwrap_or(*remaining).min(*remaining));
+        let nested = init_nested(init, chunk_size.min(*remaining));
         let decoded = decoder.with_capacity(0);
         items.push_back((nested, decoded));
     }

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -524,12 +524,19 @@ def test_parquet_nano_second_schema() -> None:
 
 
 def test_nested_struct_read_12610() -> None:
-    expect = pl.select(
-        a=pl.repeat(1, 200_000), b=pl.int_range(0, 200_000)
-    ).with_columns(c=pl.struct("a", "b"))
+    n = 1_025
+    expect = pl.select(a=pl.int_range(0, n), b=pl.repeat(1, n)).with_columns(
+        struct=pl.struct(pl.all())
+    )
 
     f = io.BytesIO()
-    expect.write_parquet(f)
+    expect.write_parquet(
+        f,
+        use_pyarrow=True,
+        pyarrow_options={
+            "data_page_size": 500,
+        },
+    )
     f.seek(0)
 
     actual = pl.read_parquet(f)

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -521,3 +521,16 @@ def test_parquet_nano_second_schema() -> None:
     df.to_parquet(f)
     f.seek(0)
     assert pl.read_parquet(f).item() == value
+
+
+def test_nested_struct_read_12610() -> None:
+    expect = pl.select(
+        a=pl.repeat(1, 200_000), b=pl.int_range(0, 200_000)
+    ).with_columns(c=pl.struct("a", "b"))
+
+    f = io.BytesIO()
+    expect.write_parquet(f)
+    f.seek(0)
+
+    actual = pl.read_parquet(f)
+    assert_frame_equal(expect, actual)


### PR DESCRIPTION
Fix https://github.com/pola-rs/polars/issues/12610

Issue caused by https://github.com/pola-rs/polars/pull/12569 - it accidentally subtracted twice 😓.
