### PR TITLE
feat: implement RLE_DICT encoding for utf8/binary columns (reduced parquet file size)

### DIFF
--- a/crates/polars-arrow/src/array/dictionary/mutable.rs
+++ b/crates/polars-arrow/src/array/dictionary/mutable.rs
@@ -187,7 +187,7 @@ impl<K: DictionaryKey, M: 'static + MutableArray> MutableArray for MutableDictio
 impl<K, M, T> TryExtend<Option<T>> for MutableDictionaryArray<K, M>
 where
     K: DictionaryKey,
-    M: MutableArray + Indexable + TryExtend<Option<T>>,
+    M: MutableArray + Indexable + TryExtend<Option<T>> + TryPush<Option<T>>,
     T: AsIndexed<M>,
     M::Type: Eq + Hash,
 {
@@ -196,7 +196,7 @@ where
             if let Some(value) = value {
                 let key = self
                     .map
-                    .try_push_valid(value, |arr, v| arr.try_extend(std::iter::once(Some(v))))?;
+                    .try_push_valid(value, |arr, v| arr.try_push(Some(v)))?;
                 self.keys.try_push(Some(key))?;
             } else {
                 self.push_null();

--- a/crates/polars-arrow/src/compute/cast/mod.rs
+++ b/crates/polars-arrow/src/compute/cast/mod.rs
@@ -969,9 +969,7 @@ fn cast_to_dictionary<K: DictionaryKey>(
         ArrowDataType::UInt16 => primitive_to_dictionary_dyn::<u16, K>(array),
         ArrowDataType::UInt32 => primitive_to_dictionary_dyn::<u32, K>(array),
         ArrowDataType::UInt64 => primitive_to_dictionary_dyn::<u64, K>(array),
-        ArrowDataType::Utf8 => utf8_to_dictionary_dyn::<i32, K>(array),
         ArrowDataType::LargeUtf8 => utf8_to_dictionary_dyn::<i64, K>(array),
-        ArrowDataType::Binary => binary_to_dictionary_dyn::<i32, K>(array),
         ArrowDataType::LargeBinary => binary_to_dictionary_dyn::<i64, K>(array),
         _ => polars_bail!(ComputeError:
             "unsupported output type for dictionary packing: {dict_value_type:?}"

--- a/crates/polars-io/src/parquet/write.rs
+++ b/crates/polars-io/src/parquet/write.rs
@@ -232,7 +232,9 @@ fn get_encodings(schema: &ArrowSchema) -> Vec<Vec<Encoding>> {
 /// Declare encodings
 fn encoding_map(data_type: &ArrowDataType) -> Encoding {
     match data_type.to_physical_type() {
-        PhysicalType::Dictionary(_) => Encoding::RleDictionary,
+        PhysicalType::Dictionary(_) | PhysicalType::LargeBinary | PhysicalType::LargeUtf8 => {
+            Encoding::RleDictionary
+        },
         // remaining is plain
         _ => Encoding::Plain,
     }

--- a/crates/polars-parquet/src/arrow/write/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/write/binary/basic.rs
@@ -17,6 +17,7 @@ pub(crate) fn encode_plain<O: Offset>(
     is_optional: bool,
     buffer: &mut Vec<u8>,
 ) {
+    buffer.reserve(array.values().len());
     // append the non-null values
     if is_optional {
         array.iter().for_each(|x| {

--- a/crates/polars-parquet/src/arrow/write/pages.rs
+++ b/crates/polars-parquet/src/arrow/write/pages.rs
@@ -8,9 +8,14 @@ use polars_error::{polars_bail, PolarsResult};
 
 use super::{array_to_pages, Encoding, WriteOptions};
 use crate::arrow::read::schema::is_nullable;
-use crate::parquet::page::Page;
+use crate::parquet::page::{DataPage, DictPage, Page};
 use crate::parquet::schema::types::{ParquetType, PrimitiveType as ParquetPrimitiveType};
-use crate::parquet::write::DynIter;
+use crate::write::FlatIter;
+
+pub enum PageResult {
+    Data(Page),
+    DictAndData { dict: DictPage, data: DataPage },
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ListNested<O: Offset> {
@@ -238,7 +243,7 @@ pub fn array_to_columns<A: AsRef<dyn Array> + Send + Sync>(
     type_: ParquetType,
     options: WriteOptions,
     encoding: &[Encoding],
-) -> PolarsResult<Vec<DynIter<'static, PolarsResult<Page>>>> {
+) -> PolarsResult<Vec<FlatIter>> {
     let array = array.as_ref();
     let nested = to_nested(array, &type_)?;
 

--- a/crates/polars-parquet/src/arrow/write/pages.rs
+++ b/crates/polars-parquet/src/arrow/write/pages.rs
@@ -33,13 +33,18 @@ impl<O: Offset> ListNested<O> {
 #[derive(Debug, Clone, PartialEq)]
 pub enum Nested {
     /// a primitive (leaf or parquet column)
-    /// bitmap, _, length
+    /// - validity
+    /// - is_optional
+    /// - length
     Primitive(Option<Bitmap>, bool, usize),
     /// a list
     List(ListNested<i32>),
     /// a list
     LargeList(ListNested<i64>),
     /// a struct
+    /// - validity
+    /// - is_optional
+    /// - length
     Struct(Option<Bitmap>, bool, usize),
 }
 

--- a/crates/polars-parquet/src/parquet/page/mod.rs
+++ b/crates/polars-parquet/src/parquet/page/mod.rs
@@ -11,6 +11,11 @@ pub use crate::parquet::thrift_format::{
     DataPageHeader as DataPageHeaderV1, DataPageHeaderV2, PageHeader as ParquetPageHeader,
 };
 
+pub enum PageResult {
+    Single(Page),
+    Two { dict: DictPage, data: DataPage },
+}
+
 /// A [`CompressedDataPage`] is compressed, encoded representation of a Parquet data page.
 /// It holds actual data and thus cloning it is expensive.
 #[derive(Debug)]
@@ -239,21 +244,16 @@ pub enum Page {
 }
 
 impl Page {
-    pub(crate) fn is_dict(&self) -> bool {
-        matches!(self, Page::Dict(_))
-    }
-
-    pub(crate) fn len(&self) -> usize {
-        match self {
-            Self::Data(page) => page.buffer.len(),
-            Self::Dict(page) => page.buffer.len(),
-        }
-    }
-
     pub(crate) fn buffer(&mut self) -> &mut Vec<u8> {
         match self {
             Self::Data(page) => &mut page.buffer,
             Self::Dict(page) => &mut page.buffer,
+        }
+    }
+    pub(crate) fn unwrap_data(self) -> DataPage {
+        match self {
+            Self::Data(page) => page,
+            _ => panic!(),
         }
     }
 }

--- a/crates/polars-parquet/src/parquet/page/mod.rs
+++ b/crates/polars-parquet/src/parquet/page/mod.rs
@@ -239,6 +239,17 @@ pub enum Page {
 }
 
 impl Page {
+    pub(crate) fn is_dict(&self) -> bool {
+        matches!(self, Page::Dict(_))
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            Self::Data(page) => page.buffer.len(),
+            Self::Dict(page) => page.buffer.len(),
+        }
+    }
+
     pub(crate) fn buffer(&mut self) -> &mut Vec<u8> {
         match self {
             Self::Data(page) => &mut page.buffer,


### PR DESCRIPTION
…rquet file size)

Parquet files written by polars are much larger than the pyarrow counterparts because they are written mostly wo/ any encoding. This enables RLE_DICTIONARY encoding for utf8 and binary columns and will fallback to PLAIN if the dictionaries get too big or there is a cardinality higher than 75%.

Pyarrow also uses this for integers, I will follow up with that as well.