### PR TITLE
feat(python): Implement `PySeries.from_buffer` for numeric types

### DIFF
--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -309,7 +309,7 @@ impl PySeries {
     }
 
     #[staticmethod]
-    unsafe fn from_buffer(
+    unsafe fn _from_buffer(
         py: Python,
         pointer: usize,
         length: usize,

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -309,7 +309,7 @@ impl PySeries {
     }
 
     #[staticmethod]
-    fn from_buffer(
+    unsafe fn from_buffer(
         py: Python,
         pointer: usize,
         length: usize,
@@ -320,16 +320,16 @@ impl PySeries {
         let base = base.to_object(py);
 
         let arr_boxed = match dtype {
-            DataType::Int8 => from_buffer_impl::<i8>(pointer, length, base),
-            DataType::Int16 => from_buffer_impl::<i16>(pointer, length, base),
-            DataType::Int32 => from_buffer_impl::<i32>(pointer, length, base),
-            DataType::Int64 => from_buffer_impl::<i64>(pointer, length, base),
-            DataType::UInt8 => from_buffer_impl::<u8>(pointer, length, base),
-            DataType::UInt16 => from_buffer_impl::<u16>(pointer, length, base),
-            DataType::UInt32 => from_buffer_impl::<u32>(pointer, length, base),
-            DataType::UInt64 => from_buffer_impl::<u64>(pointer, length, base),
-            DataType::Float32 => from_buffer_impl::<f32>(pointer, length, base),
-            DataType::Float64 => from_buffer_impl::<f64>(pointer, length, base),
+            DataType::Int8 => unsafe { from_buffer_impl::<i8>(pointer, length, base) },
+            DataType::Int16 => unsafe { from_buffer_impl::<i16>(pointer, length, base) },
+            DataType::Int32 => unsafe { from_buffer_impl::<i32>(pointer, length, base) },
+            DataType::Int64 => unsafe { from_buffer_impl::<i64>(pointer, length, base) },
+            DataType::UInt8 => unsafe { from_buffer_impl::<u8>(pointer, length, base) },
+            DataType::UInt16 => unsafe { from_buffer_impl::<u16>(pointer, length, base) },
+            DataType::UInt32 => unsafe { from_buffer_impl::<u32>(pointer, length, base) },
+            DataType::UInt64 => unsafe { from_buffer_impl::<u64>(pointer, length, base) },
+            DataType::Float32 => unsafe { from_buffer_impl::<f32>(pointer, length, base) },
+            DataType::Float64 => unsafe { from_buffer_impl::<f64>(pointer, length, base) },
             DataType::Boolean => {
                 return Err(PyNotImplementedError::new_err(
                     "`from_buffer` is not yet implemented for boolean types",
@@ -347,7 +347,7 @@ impl PySeries {
     }
 }
 
-fn from_buffer_impl<T: NativeType>(
+unsafe fn from_buffer_impl<T: NativeType>(
     pointer: usize,
     length: usize,
     base: Py<PyAny>,

--- a/py-polars/tests/unit/series/test_from_buffer.py
+++ b/py-polars/tests/unit/series/test_from_buffer.py
@@ -20,7 +20,7 @@ from polars.utils._wrap import wrap_s
 )
 def test_series_from_buffer(s: pl.Series) -> None:
     offset, length, pointer = s._s.get_ptr()
-    result = wrap_s(PySeries.from_buffer(pointer, length, s.dtype, base=s))
+    result = wrap_s(PySeries._from_buffer(pointer, length, s.dtype, base=s))
     assert_series_equal(s, result)
 
 
@@ -32,4 +32,4 @@ def test_series_from_buffer_unsupported() -> None:
         TypeError,
         match="`from_buffer` requires a physical type as input for `dtype`, got date",
     ):
-        wrap_s(PySeries.from_buffer(pointer, length, pl.Date, base=s))
+        wrap_s(PySeries._from_buffer(pointer, length, pl.Date, base=s))

--- a/py-polars/tests/unit/series/test_from_buffer.py
+++ b/py-polars/tests/unit/series/test_from_buffer.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+from hypothesis import given
+
+import polars as pl
+from polars.polars import PySeries
+from polars.testing import assert_series_equal
+from polars.testing.parametric import series
+from polars.utils._wrap import wrap_s
+
+
+@given(
+    s=series(
+        allowed_dtypes=(pl.INTEGER_DTYPES | pl.FLOAT_DTYPES),  # TODO: Add booleans
+        chunked=False,
+    )
+)
+def test_series_from_buffer(s: pl.Series) -> None:
+    offset, length, pointer = s._s.get_ptr()
+    result = wrap_s(PySeries.from_buffer(pointer, length, s.dtype, base=s))
+    assert_series_equal(s, result)
+
+
+def test_series_from_buffer_unsupported() -> None:
+    s = pl.Series([date(2020, 1, 1), date(2020, 2, 5)])
+    offset, length, pointer = s._s.get_ptr()
+
+    with pytest.raises(
+        TypeError,
+        match="`from_buffer` requires a physical type as input for `dtype`, got date",
+    ):
+        wrap_s(PySeries.from_buffer(pointer, length, pl.Date, base=s))


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/10718

Implements zero-copy foreign buffer for integer and float types.

TODO: Booleans.