### PR TITLE
perf: optimize dict binary decoding in parquet

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/dictionary.rs
@@ -9,9 +9,10 @@ use polars_error::PolarsResult;
 use super::super::dictionary::*;
 use super::super::utils::MaybeNext;
 use super::super::PagesIter;
-use super::utils::{Binary, SizedBinaryIter};
+use super::utils::Binary;
 use crate::arrow::read::deserialize::nested_utils::{InitNested, NestedState};
 use crate::parquet::page::DictPage;
+use crate::read::deserialize::binary::utils::BinaryIter;
 
 /// An iterator adapter over [`PagesIter`] assumed to be encoded as parquet's dictionary-encoded binary representation
 #[derive(Debug)]
@@ -60,7 +61,7 @@ fn read_dict<O: Offset>(data_type: ArrowDataType, dict: &DictPage) -> Box<dyn Ar
         _ => data_type,
     };
 
-    let values = SizedBinaryIter::new(&dict.buffer, dict.num_values);
+    let values = BinaryIter::new(&dict.buffer).take(dict.num_values);
 
     let mut data = Binary::<O>::with_capacity(dict.num_values);
     data.values = Vec::with_capacity(dict.buffer.len() - 4 * dict.num_values);

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/nested.rs
@@ -107,7 +107,7 @@ impl<'a, O: Offset> NestedDecoder<'a> for BinaryDecoder<O> {
                 let item = page
                     .values
                     .next()
-                    .map(|index| dict_values[index.unwrap() as usize].as_ref())
+                    .map(|index| dict_values.value(index.unwrap() as usize))
                     .unwrap_or_default();
                 values.push(item);
             },
@@ -116,7 +116,7 @@ impl<'a, O: Offset> NestedDecoder<'a> for BinaryDecoder<O> {
                 let item = page
                     .values
                     .next()
-                    .map(|index| dict_values[index.unwrap() as usize].as_ref())
+                    .map(|index| dict_values.value(index.unwrap() as usize))
                     .unwrap_or_default();
                 values.push(item);
                 validity.push(true);

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/utils.rs
@@ -134,37 +134,3 @@ impl<'a> Iterator for BinaryIter<'a> {
         Some(result)
     }
 }
-
-#[derive(Debug)]
-pub struct SizedBinaryIter<'a> {
-    iter: BinaryIter<'a>,
-    remaining: usize,
-}
-
-impl<'a> SizedBinaryIter<'a> {
-    pub fn new(values: &'a [u8], size: usize) -> Self {
-        let iter = BinaryIter::new(values);
-        Self {
-            iter,
-            remaining: size,
-        }
-    }
-}
-
-impl<'a> Iterator for SizedBinaryIter<'a> {
-    type Item = &'a [u8];
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.remaining == 0 {
-            return None;
-        } else {
-            self.remaining -= 1
-        };
-        self.iter.next()
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.remaining, Some(self.remaining))
-    }
-}


### PR DESCRIPTION
Don't allocate a vec of vec, but inline the bytes in single allocation.