### PR TITLE
feat(python): Implement `PySeries.from_buffer` for boolean buffers

### DIFF
--- a/py-polars/polars/interchange/buffer.py
+++ b/py-polars/polars/interchange/buffer.py
@@ -52,10 +52,10 @@ class PolarsBuffer(Buffer):
             n_bits = offset + length
             n_bytes, rest = divmod(n_bits, 8)
             # Round up to the nearest byte
-            if rest:
-                return n_bytes + 1
-            else:
+            if rest == 0:
                 return n_bytes
+            else:
+                return n_bytes + 1
 
         return self._data.len() * (dtype[1] // 8)
 


### PR DESCRIPTION
Ref #10718

Followup of https://github.com/pola-rs/polars/pull/12646

#### Changes

* Reading in foreign boolean buffers (bitmaps) in `PySeries._from_buffer` is now supported.