### PR TITLE
perf: improve parquet utf8 validation

### DIFF
--- a/crates/polars-arrow/src/array/growable/utf8.rs
+++ b/crates/polars-arrow/src/array/growable/utf8.rs
@@ -47,7 +47,7 @@ impl<'a, O: Offset> GrowableUtf8<'a, O> {
 
         #[cfg(debug_assertions)]
         {
-            crate::array::specification::try_check_utf8(&offsets, &values).unwrap();
+            crate::array::specification::try_check_utf8(offsets.as_slice(), &values).unwrap();
         }
 
         unsafe {

--- a/crates/polars-arrow/src/array/growable/utf8.rs
+++ b/crates/polars-arrow/src/array/growable/utf8.rs
@@ -51,13 +51,12 @@ impl<'a, O: Offset> GrowableUtf8<'a, O> {
         }
 
         unsafe {
-            Utf8Array::<O>::try_new_unchecked(
+            Utf8Array::<O>::new_unchecked(
                 self.arrays[0].data_type().clone(),
                 offsets.into(),
                 values.into(),
                 validity.into(),
             )
-            .unwrap()
         }
     }
 }

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -667,7 +667,7 @@ mod list;
 mod map;
 mod null;
 mod primitive;
-mod specification;
+pub mod specification;
 mod struct_;
 mod union;
 mod utf8;

--- a/crates/polars-arrow/src/array/specification.rs
+++ b/crates/polars-arrow/src/array/specification.rs
@@ -4,7 +4,7 @@ use crate::array::DictionaryKey;
 use crate::offset::{Offset, Offsets, OffsetsBuffer};
 
 /// Helper trait to support `Offset` and `OffsetBuffer`
-pub(crate) trait OffsetsContainer<O> {
+pub trait OffsetsContainer<O> {
     fn last(&self) -> usize;
     fn as_slice(&self) -> &[O];
 }
@@ -33,11 +33,11 @@ impl<O: Offset> OffsetsContainer<O> for Offsets<O> {
     }
 }
 
-pub(crate) fn try_check_offsets_bounds<O: Offset, C: OffsetsContainer<O>>(
-    offsets: &C,
+pub(crate) fn try_check_offsets_bounds<O: Offset>(
+    offsets: &[O],
     values_len: usize,
 ) -> PolarsResult<()> {
-    if offsets.last() > values_len {
+    if offsets.last().unwrap().to_usize() > values_len {
         polars_bail!(ComputeError: "offsets must not exceed the values length")
     } else {
         Ok(())
@@ -47,17 +47,15 @@ pub(crate) fn try_check_offsets_bounds<O: Offset, C: OffsetsContainer<O>>(
 /// # Error
 /// * any offset is larger or equal to `values_len`.
 /// * any slice of `values` between two consecutive pairs from `offsets` is invalid `utf8`, or
-pub(crate) fn try_check_utf8<O: Offset, C: OffsetsContainer<O>>(
-    offsets: &C,
-    values: &[u8],
-) -> PolarsResult<()> {
-    if offsets.as_slice().len() == 1 {
+pub fn try_check_utf8<O: Offset>(offsets: &[O], values: &[u8]) -> PolarsResult<()> {
+    if offsets.len() == 1 {
         return Ok(());
     }
+    assert!(offsets.len() > 1);
+    let end = offsets.last().unwrap().to_usize();
+    let start = offsets.first().unwrap().to_usize();
 
     try_check_offsets_bounds(offsets, values.len())?;
-    let end = offsets.last();
-    let start = offsets.as_slice()[0].to_usize();
     let values_range = &values[start..end];
 
     if values_range.is_ascii() {
@@ -70,7 +68,6 @@ pub(crate) fn try_check_utf8<O: Offset, C: OffsetsContainer<O>>(
         // Example:
         // values.len() = 10
         // offsets = [0, 5, 10, 10]
-        let offsets = offsets.as_slice();
         let last = offsets
             .iter()
             .enumerate()
@@ -165,12 +162,12 @@ mod tests {
         fn check_utf8_validation(values in binary_strategy()) {
 
             for offset in 0..values.len() - 1 {
-                let offsets = vec![0, offset as i32, values.len() as i32].try_into().unwrap();
+                let offsets: OffsetsBuffer<i32> = vec![0, offset as i32, values.len() as i32].try_into().unwrap();
 
                 let mut is_valid = std::str::from_utf8(&values[..offset]).is_ok();
                 is_valid &= std::str::from_utf8(&values[offset..]).is_ok();
 
-                assert_eq!(try_check_utf8::<i32, Offsets<i32>>(&offsets, &values).is_ok(), is_valid)
+                assert_eq!(try_check_utf8::<i32>(&offsets, &values).is_ok(), is_valid)
             }
         }
     }

--- a/crates/polars-arrow/src/array/utf8/mod.rs
+++ b/crates/polars-arrow/src/array/utf8/mod.rs
@@ -1,6 +1,6 @@
 use either::Either;
 
-use super::specification::{try_check_utf8};
+use super::specification::try_check_utf8;
 use super::{Array, GenericBinaryArray};
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 use crate::bitmap::Bitmap;
@@ -359,12 +359,12 @@ impl<O: Offset> Utf8Array<O> {
     /// * The `values` between two consecutive `offsets` are not valid utf8
     /// # Implementation
     /// This function is `O(1)`
-    pub unsafe fn try_new_unchecked(
+    pub unsafe fn new_unchecked(
         data_type: ArrowDataType,
         offsets: OffsetsBuffer<O>,
         values: Buffer<u8>,
         validity: Option<Bitmap>,
-    ) -> PolarsResult<Self> {
+    ) -> Self {
         debug_assert!(
             offsets.last().to_usize() <= values.len(),
             "offsets must not exceed the values length"
@@ -380,12 +380,12 @@ impl<O: Offset> Utf8Array<O> {
             "Utf8Array can only be initialized with DataType::Utf8 or DataType::LargeUtf8"
         );
 
-        Ok(Self {
+        Self {
             data_type,
             offsets,
             values,
             validity,
-        })
+        }
     }
 
     /// Creates a new [`Utf8Array`].
@@ -404,28 +404,6 @@ impl<O: Offset> Utf8Array<O> {
         validity: Option<Bitmap>,
     ) -> Self {
         Self::try_new(data_type, offsets, values, validity).unwrap()
-    }
-
-    /// Creates a new [`Utf8Array`] without checking for offsets monotinicity.
-    ///
-    /// # Errors
-    /// This function returns an error iff:
-    /// * The last offset is not equal to the values' length.
-    /// * the validity's length is not equal to `offsets.len()`.
-    /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either `Utf8` or `LargeUtf8`.
-    /// # Safety
-    /// This function is unsound iff:
-    /// * the offsets are not monotonically increasing
-    /// * The `values` between two consecutive `offsets` are not valid utf8
-    /// # Implementation
-    /// This function is `O(1)`
-    pub unsafe fn new_unchecked(
-        data_type: ArrowDataType,
-        offsets: OffsetsBuffer<O>,
-        values: Buffer<u8>,
-        validity: Option<Bitmap>,
-    ) -> Self {
-        Self::try_new_unchecked(data_type, offsets, values, validity).unwrap()
     }
 
     /// Returns a (non-null) [`Utf8Array`] created from a [`TrustedLen`] of `&str`.

--- a/crates/polars-arrow/src/array/utf8/mod.rs
+++ b/crates/polars-arrow/src/array/utf8/mod.rs
@@ -1,6 +1,6 @@
 use either::Either;
 
-use super::specification::{try_check_offsets_bounds, try_check_utf8};
+use super::specification::{try_check_utf8};
 use super::{Array, GenericBinaryArray};
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 use crate::bitmap::Bitmap;
@@ -349,8 +349,8 @@ impl<O: Offset> Utf8Array<O> {
 
     /// Creates a new [`Utf8Array`] without checking for offsets monotinicity nor utf8-validity
     ///
-    /// # Errors
-    /// This function returns an error iff:
+    /// # Panic
+    /// This function panics (in debug mode only) iff:
     /// * The last offset is not equal to the values' length.
     /// * the validity's length is not equal to `offsets.len()`.
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either `Utf8` or `LargeUtf8`.
@@ -365,22 +365,20 @@ impl<O: Offset> Utf8Array<O> {
         values: Buffer<u8>,
         validity: Option<Bitmap>,
     ) -> PolarsResult<Self> {
-        try_check_offsets_bounds(&offsets, values.len())?;
-
-        if validity
-            .as_ref()
-            .map_or(false, |validity| validity.len() != offsets.len_proxy())
-        {
-            polars_bail!(ComputeError:
-                "validity mask length must match the number of values",
-            )
-        }
-
-        if data_type.to_physical_type() != Self::default_data_type().to_physical_type() {
-            polars_bail!(ComputeError:
-                "BinaryArray can only be initialized with DataType::Utf8 or DataType::LargeUtf8",
-            )
-        }
+        debug_assert!(
+            offsets.last().to_usize() <= values.len(),
+            "offsets must not exceed the values length"
+        );
+        debug_assert!(
+            validity
+                .as_ref()
+                .map_or(true, |validity| validity.len() == offsets.len_proxy()),
+            "validity mask length must match the number of values"
+        );
+        debug_assert!(
+            data_type.to_physical_type() == Self::default_data_type().to_physical_type(),
+            "Utf8Array can only be initialized with DataType::Utf8 or DataType::LargeUtf8"
+        );
 
         Ok(Self {
             data_type,

--- a/crates/polars-arrow/src/lib.rs
+++ b/crates/polars-arrow/src/lib.rs
@@ -12,6 +12,8 @@
 #![cfg_attr(feature = "simd", feature(portable_simd))]
 #![cfg_attr(feature = "nightly", allow(clippy::non_canonical_partial_ord_impl))] // Remove once stable.
 
+extern crate core;
+
 #[macro_use]
 pub mod array;
 pub mod bitmap;

--- a/crates/polars-arrow/src/offset.rs
+++ b/crates/polars-arrow/src/offset.rs
@@ -1,5 +1,6 @@
 //! Contains the declaration of [`Offset`]
 use std::hint::unreachable_unchecked;
+use std::ops::Deref;
 
 use polars_error::{polars_bail, polars_err, PolarsError, PolarsResult};
 
@@ -17,6 +18,14 @@ impl<O: Offset> Default for Offsets<O> {
     #[inline]
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<O: Offset> Deref for Offsets<O> {
+    type Target = [O];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
     }
 }
 

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -237,13 +237,12 @@ impl ChunkCast for Utf8Chunked {
 unsafe fn binary_to_utf8_unchecked(from: &BinaryArray<i64>) -> Utf8Array<i64> {
     let values = from.values().clone();
     let offsets = from.offsets().clone();
-    Utf8Array::<i64>::try_new_unchecked(
+    Utf8Array::<i64>::new_unchecked(
         ArrowDataType::LargeUtf8,
         offsets,
         values,
         from.validity().cloned(),
     )
-    .unwrap()
 }
 
 impl BinaryChunked {

--- a/crates/polars-core/src/datatypes/static_array_collect.rs
+++ b/crates/polars-core/src/datatypes/static_array_collect.rs
@@ -485,7 +485,7 @@ unsafe fn into_utf8array(arr: BinaryArray<i64>) -> Utf8Array<i64> {
     unsafe {
         let (_dt, offsets, values, validity) = arr.into_inner();
         let dt = arrow::datatypes::ArrowDataType::LargeUtf8;
-        Utf8Array::try_new_unchecked(dt, offsets, values, validity).unwrap_unchecked()
+        Utf8Array::new_unchecked(dt, offsets, values, validity)
     }
 }
 

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
@@ -319,7 +319,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
         match (page.encoding(), dict, is_optional, is_filtered) {
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, false) => {
                 if is_string {
-                    arrow::array::specification::try_check_utf8(dict.offsets(), dict.values())?;
+                    try_check_utf8(dict.offsets(), dict.values())?;
                 }
                 Ok(State::RequiredDictionary(RequiredDictionary::try_new(
                     page, dict,
@@ -327,7 +327,7 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
             },
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, false) => {
                 if is_string {
-                    arrow::array::specification::try_check_utf8(dict.offsets(), dict.values())?;
+                    try_check_utf8(dict.offsets(), dict.values())?;
                 }
                 Ok(State::OptionalDictionary(
                     OptionalPageValidity::try_new(page)?,
@@ -336,14 +336,14 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
             },
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, true) => {
                 if is_string {
-                    arrow::array::specification::try_check_utf8(dict.offsets(), dict.values())?;
+                    try_check_utf8(dict.offsets(), dict.values())?;
                 }
                 FilteredRequiredDictionary::try_new(page, dict)
                     .map(State::FilteredRequiredDictionary)
             },
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, true) => {
                 if is_string {
-                    arrow::array::specification::try_check_utf8(dict.offsets(), dict.values())?;
+                    try_check_utf8(dict.offsets(), dict.values())?;
                 }
                 Ok(State::FilteredOptionalDictionary(
                     FilteredOptionalPageValidity::try_new(page)?,
@@ -574,13 +574,13 @@ pub(super) fn finish<O: Offset>(
         )
         .map(|x| x.boxed()),
         PhysicalType::Utf8 | PhysicalType::LargeUtf8 => unsafe {
-            Utf8Array::<O>::try_new_unchecked(
+            Ok(Utf8Array::<O>::new_unchecked(
                 data_type.clone(),
                 values.offsets.into(),
                 values.values.into(),
                 validity.into(),
             )
-            .map(|x| x.boxed())
+            .boxed())
         },
         _ => unreachable!(),
     }

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
@@ -573,13 +573,15 @@ pub(super) fn finish<O: Offset>(
             validity.into(),
         )
         .map(|x| x.boxed()),
-        PhysicalType::Utf8 | PhysicalType::LargeUtf8 => Utf8Array::<O>::try_new(
-            data_type.clone(),
-            values.offsets.into(),
-            values.values.into(),
-            validity.into(),
-        )
-        .map(|x| x.boxed()),
+        PhysicalType::Utf8 | PhysicalType::LargeUtf8 => unsafe {
+            Utf8Array::<O>::try_new_unchecked(
+                data_type.clone(),
+                values.offsets.into(),
+                values.values.into(),
+                validity.into(),
+            )
+            .map(|x| x.boxed())
+        },
         _ => unreachable!(),
     }
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/basic.rs
@@ -1,6 +1,8 @@
+use std::cell::Cell;
 use std::collections::VecDeque;
 use std::default::Default;
 
+use arrow::array::specification::try_check_utf8;
 use arrow::array::{Array, BinaryArray, MutableBinaryValuesArray, Utf8Array};
 use arrow::bitmap::MutableBitmap;
 use arrow::datatypes::{ArrowDataType, PhysicalType};
@@ -17,7 +19,7 @@ use crate::parquet::deserialize::SliceFilteredIter;
 use crate::parquet::encoding::{delta_bitpacked, delta_length_byte_array, hybrid_rle, Encoding};
 use crate::parquet::page::{split_buffer, DataPage, DictPage};
 use crate::parquet::schema::Repetition;
-use crate::read::ParquetError;
+use crate::read::{ParquetError, PrimitiveLogicalType};
 
 #[derive(Debug)]
 pub(super) struct Required<'a> {
@@ -291,6 +293,7 @@ impl<O: Offset> DecodedState for (Binary<O>, MutableBitmap) {
 #[derive(Debug, Default)]
 struct BinaryDecoder<O: Offset> {
     phantom_o: std::marker::PhantomData<O>,
+    check_utf8: Cell<bool>,
 }
 
 impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
@@ -307,21 +310,41 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
             page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
         let is_filtered = page.selected_rows().is_some();
 
+        let is_string = matches!(
+            page.descriptor.primitive_type.logical_type,
+            Some(PrimitiveLogicalType::String)
+        );
+        self.check_utf8.set(is_string);
+
         match (page.encoding(), dict, is_optional, is_filtered) {
-            (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, false) => Ok(
-                State::RequiredDictionary(RequiredDictionary::try_new(page, dict)?),
-            ),
+            (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, false) => {
+                if is_string {
+                    arrow::array::specification::try_check_utf8(dict.offsets(), dict.values())?;
+                }
+                Ok(State::RequiredDictionary(RequiredDictionary::try_new(
+                    page, dict,
+                )?))
+            },
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, false) => {
+                if is_string {
+                    arrow::array::specification::try_check_utf8(dict.offsets(), dict.values())?;
+                }
                 Ok(State::OptionalDictionary(
                     OptionalPageValidity::try_new(page)?,
                     ValuesDictionary::try_new(page, dict)?,
                 ))
             },
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false, true) => {
+                if is_string {
+                    arrow::array::specification::try_check_utf8(dict.offsets(), dict.values())?;
+                }
                 FilteredRequiredDictionary::try_new(page, dict)
                     .map(State::FilteredRequiredDictionary)
             },
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true, true) => {
+                if is_string {
+                    arrow::array::specification::try_check_utf8(dict.offsets(), dict.values())?;
+                }
                 Ok(State::FilteredOptionalDictionary(
                     FilteredOptionalPageValidity::try_new(page)?,
                     ValuesDictionary::try_new(page, dict)?,
@@ -383,8 +406,10 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
         state: &mut Self::State,
         decoded: &mut Self::DecodedState,
         additional: usize,
-    ) {
+    ) -> PolarsResult<()> {
         let (values, validity) = decoded;
+        let mut validate_utf8 = self.check_utf8.take();
+        let len_before = values.offsets.len();
         match state {
             State::Optional(page_validity, page_values) => extend_from_decoder(
                 validity,
@@ -433,6 +458,8 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 }
             },
             State::OptionalDictionary(page_validity, page_values) => {
+                // Already done on the dict.
+                validate_utf8 = false;
                 let page_dict = &page_values.dict;
                 utils::extend_from_decoder(
                     validity,
@@ -446,6 +473,8 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 )
             },
             State::RequiredDictionary(page) => {
+                // Already done on the dict.
+                validate_utf8 = false;
                 let page_dict = &page.dict;
 
                 for x in page
@@ -476,6 +505,8 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 );
             },
             State::FilteredRequiredDictionary(page) => {
+                // Already done on the dict.
+                validate_utf8 = false;
                 let page_dict = &page.dict;
                 for x in page
                     .values
@@ -487,6 +518,8 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                 }
             },
             State::FilteredOptionalDictionary(page_validity, page_values) => {
+                // Already done on the dict.
+                validate_utf8 = false;
                 let page_dict = &page_values.dict;
                 utils::extend_from_decoder(
                     validity,
@@ -508,6 +541,13 @@ impl<'a, O: Offset> utils::Decoder<'a> for BinaryDecoder<O> {
                     page_values,
                 )
             },
+        }
+
+        if validate_utf8 {
+            let offsets = &values.offsets.as_slice()[len_before..];
+            try_check_utf8(offsets, &values.values)
+        } else {
+            Ok(())
         }
     }
 
@@ -575,6 +615,7 @@ impl<O: Offset, I: PagesIter> Iterator for Iter<O, I> {
     type Item = PolarsResult<Box<dyn Array>>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        let decoder = BinaryDecoder::<O>::default();
         loop {
             let maybe_state = next(
                 &mut self.iter,
@@ -582,7 +623,7 @@ impl<O: Offset, I: PagesIter> Iterator for Iter<O, I> {
                 &mut self.dict,
                 &mut self.remaining,
                 self.chunk_size,
-                &BinaryDecoder::<O>::default(),
+                &decoder,
             );
             match maybe_state {
                 MaybeNext::Some(Ok((values, validity))) => {

--- a/crates/polars-parquet/src/arrow/read/deserialize/boolean/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/boolean/basic.rs
@@ -147,7 +147,7 @@ impl<'a> Decoder<'a> for BooleanDecoder {
         state: &mut Self::State,
         decoded: &mut Self::DecodedState,
         remaining: usize,
-    ) {
+    ) -> PolarsResult<()> {
         let (values, validity) = decoded;
         match state {
             State::Optional(page_validity, page_values) => extend_from_decoder(
@@ -178,6 +178,7 @@ impl<'a> Decoder<'a> for BooleanDecoder {
                 );
             },
         }
+        Ok(())
     }
 
     fn deserialize_dict(&self, _: &DictPage) -> Self::Dict {}

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/basic.rs
@@ -209,7 +209,7 @@ impl<'a> Decoder<'a> for BinaryDecoder {
         decoded: &mut Self::DecodedState,
 
         remaining: usize,
-    ) {
+    ) -> PolarsResult<()> {
         let (values, validity) = decoded;
         match state {
             State::Optional(page) => extend_from_decoder(
@@ -262,6 +262,7 @@ impl<'a> Decoder<'a> for BinaryDecoder {
                 );
             },
         }
+        Ok(())
     }
 
     fn deserialize_dict(&self, page: &DictPage) -> Self::Dict {

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/basic.rs
@@ -208,7 +208,7 @@ where
         state: &mut Self::State,
         decoded: &mut Self::DecodedState,
         remaining: usize,
-    ) {
+    ) -> PolarsResult<()> {
         let (values, validity) = decoded;
         match state {
             State::Optional(page_validity, page_values) => utils::extend_from_decoder(
@@ -266,6 +266,7 @@ where
                 );
             },
         }
+        Ok(())
     }
 
     fn deserialize_dict(&self, page: &DictPage) -> Self::Dict {

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/integer.rs
@@ -136,10 +136,10 @@ where
         state: &mut Self::State,
         decoded: &mut Self::DecodedState,
         remaining: usize,
-    ) {
+    ) -> PolarsResult<()> {
         let (values, validity) = decoded;
         match state {
-            State::Common(state) => self.0.extend_from_state(state, decoded, remaining),
+            State::Common(state) => self.0.extend_from_state(state, decoded, remaining)?,
             State::DeltaBinaryPackedRequired(state) => {
                 values.extend(
                     state
@@ -182,6 +182,7 @@ where
                 );
             },
         }
+        Ok(())
     }
 
     fn deserialize_dict(&self, page: &DictPage) -> Self::Dict {


### PR DESCRIPTION
When deserialising UTF8 columns/pages in parquet to an arrow buffer UTF8 validation was done at the end when the final buffer was finished.

For dictionary pages this is highly ineffective, as we can just validate the dictionary to hold valid UTF8 strings and then elide the checks when the page gets decoded.