### PR TITLE
feat: Join operations on local categoricals

### DIFF
--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -422,7 +422,8 @@ def test_categorical_update_lengths() -> None:
 def test_categorical_zip_append_local_different_rev_map() -> None:
     s1 = pl.Series(["cat1", "cat2", "cat1"], dtype=pl.Categorical)
     s2 = pl.Series(["cat2", "cat2", "cat3"], dtype=pl.Categorical)
-    s3 = s1.append(s2)
+    with pytest.warns(UserWarning, match="Local categoricals have different encodings"):
+        s3 = s1.append(s2)
     categories = s3.cat.get_categories()
     assert len(categories) == 3
     assert set(categories) == {"cat1", "cat2", "cat3"}
@@ -431,7 +432,8 @@ def test_categorical_zip_append_local_different_rev_map() -> None:
 def test_categorical_zip_extend_local_different_rev_map() -> None:
     s1 = pl.Series(["cat1", "cat2", "cat1"], dtype=pl.Categorical)
     s2 = pl.Series(["cat2", "cat2", "cat3"], dtype=pl.Categorical)
-    s3 = s1.extend(s2)
+    with pytest.warns(UserWarning, match="Local categoricals have different encodings"):
+        s3 = s1.extend(s2)
     categories = s3.cat.get_categories()
     assert len(categories) == 3
     assert set(categories) == {"cat1", "cat2", "cat3"}
@@ -441,7 +443,8 @@ def test_categorical_zip_with_local_different_rev_map() -> None:
     s1 = pl.Series(["cat1", "cat2", "cat1"], dtype=pl.Categorical)
     mask = pl.Series([True, False, False])
     s2 = pl.Series(["cat2", "cat2", "cat3"], dtype=pl.Categorical)
-    s3 = s1.zip_with(mask, s2)
+    with pytest.warns(UserWarning, match="Local categoricals have different encodings"):
+        s3 = s1.zip_with(mask, s2)
     categories = s3.cat.get_categories()
     assert len(categories) == 3
     assert set(categories) == {"cat1", "cat2", "cat3"}
@@ -450,8 +453,8 @@ def test_categorical_zip_with_local_different_rev_map() -> None:
 def test_categorical_vstack_with_local_different_rev_map() -> None:
     df1 = pl.DataFrame({"a": pl.Series(["a", "b", "c"], dtype=pl.Categorical)})
     df2 = pl.DataFrame({"a": pl.Series(["d", "e", "f"], dtype=pl.Categorical)})
-
-    df3 = df1.vstack(df2)
+    with pytest.warns(UserWarning, match="Local categoricals have different encodings"):
+        df3 = df1.vstack(df2)
     assert df3.get_column("a").cat.get_categories().to_list() == [
         "a",
         "b",

--- a/py-polars/tests/unit/test_string_cache.py
+++ b/py-polars/tests/unit/test_string_cache.py
@@ -3,7 +3,6 @@ from typing import Iterator
 import pytest
 
 import polars as pl
-from polars.exceptions import StringCacheMismatchError
 from polars.testing import assert_frame_equal
 
 
@@ -119,16 +118,23 @@ def test_string_cache_enable_arg_deprecated() -> None:
 
 def test_string_cache_join() -> None:
     df1 = pl.DataFrame({"a": ["foo", "bar", "ham"], "b": [1, 2, 3]})
-    df2 = pl.DataFrame({"a": ["foo", "spam", "eggs"], "c": [3, 2, 2]})
+    df2 = pl.DataFrame({"a": ["eggs", "spam", "foo"], "c": [2, 2, 3]})
 
     # ensure cache is off when casting to categorical; the join will fail
     pl.disable_string_cache()
     assert pl.using_string_cache() is False
 
-    df1a = df1.with_columns(pl.col("a").cast(pl.Categorical))
-    df2a = df2.with_columns(pl.col("a").cast(pl.Categorical))
-    with pytest.raises(StringCacheMismatchError):
-        _ = df1a.join(df2a, on="a", how="inner")
+    with pytest.warns(UserWarning, match="Local categoricals have different encodings"):
+        df1a = df1.with_columns(pl.col("a").cast(pl.Categorical))
+        df2a = df2.with_columns(pl.col("a").cast(pl.Categorical))
+        out = df1a.join(df2a, on="a", how="inner")
+
+    expected = pl.DataFrame(
+        {"a": ["foo"], "b": [1], "c": [3]}, schema_overrides={"a": pl.Categorical}
+    )
+
+    # Can not do equality checks on local categoricals with different categories
+    assert_frame_equal(out, expected, categorical_as_str=True)
 
     # now turn on the cache
     pl.enable_string_cache()


### PR DESCRIPTION
fix #7632 

With this PR it becomes possible to join on two different local categoricals. Polars will make the mapping from the rhs compatible with the lhs and throw a performance warning. 