### PR TITLE
feat(rust)!: Rename `frame_equal`/`series_equal` to `equals`

### DIFF
--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -722,7 +722,7 @@ impl ChunkCompare<&ListChunked> for ListChunked {
     type Item = BooleanChunked;
     fn equal(&self, rhs: &ListChunked) -> BooleanChunked {
         let _series_equal = |lhs: Option<&Series>, rhs: Option<&Series>| match (lhs, rhs) {
-            (Some(l), Some(r)) => Some(l.series_equal(r)),
+            (Some(l), Some(r)) => Some(l.equals(r)),
             _ => None,
         };
 
@@ -741,7 +741,7 @@ impl ChunkCompare<&ListChunked> for ListChunked {
 
     fn not_equal(&self, rhs: &ListChunked) -> BooleanChunked {
         let _series_not_equal = |lhs: Option<&Series>, rhs: Option<&Series>| match (lhs, rhs) {
-            (Some(l), Some(r)) => Some(!l.series_equal(r)),
+            (Some(l), Some(r)) => Some(!l.equals(r)),
             _ => None,
         };
 

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -731,7 +731,7 @@ impl ChunkCompare<&ListChunked> for ListChunked {
 
     fn equal_missing(&self, rhs: &ListChunked) -> BooleanChunked {
         let _series_equal_missing = |lhs: Option<&Series>, rhs: Option<&Series>| match (lhs, rhs) {
-            (Some(l), Some(r)) => Some(l.series_equal_missing(r)),
+            (Some(l), Some(r)) => Some(l.equals_missing(r)),
             (None, None) => Some(true),
             _ => Some(false),
         };
@@ -751,7 +751,7 @@ impl ChunkCompare<&ListChunked> for ListChunked {
     fn not_equal_missing(&self, rhs: &ListChunked) -> BooleanChunked {
         let _series_not_equal_missing =
             |lhs: Option<&Series>, rhs: Option<&Series>| match (lhs, rhs) {
-                (Some(l), Some(r)) => Some(!l.series_equal_missing(r)),
+                (Some(l), Some(r)) => Some(!l.equals_missing(r)),
                 (None, None) => Some(false),
                 _ => Some(true),
             };

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -721,22 +721,22 @@ where
 impl ChunkCompare<&ListChunked> for ListChunked {
     type Item = BooleanChunked;
     fn equal(&self, rhs: &ListChunked) -> BooleanChunked {
-        let _series_equal = |lhs: Option<&Series>, rhs: Option<&Series>| match (lhs, rhs) {
+        let _series_equals = |lhs: Option<&Series>, rhs: Option<&Series>| match (lhs, rhs) {
             (Some(l), Some(r)) => Some(l.equals(r)),
             _ => None,
         };
 
-        _list_comparison_helper(self, rhs, _series_equal)
+        _list_comparison_helper(self, rhs, _series_equals)
     }
 
     fn equal_missing(&self, rhs: &ListChunked) -> BooleanChunked {
-        let _series_equal_missing = |lhs: Option<&Series>, rhs: Option<&Series>| match (lhs, rhs) {
+        let _series_equals_missing = |lhs: Option<&Series>, rhs: Option<&Series>| match (lhs, rhs) {
             (Some(l), Some(r)) => Some(l.equals_missing(r)),
             (None, None) => Some(true),
             _ => Some(false),
         };
 
-        _list_comparison_helper(self, rhs, _series_equal_missing)
+        _list_comparison_helper(self, rhs, _series_equals_missing)
     }
 
     fn not_equal(&self, rhs: &ListChunked) -> BooleanChunked {

--- a/crates/polars-core/src/chunked_array/list/iterator.rs
+++ b/crates/polars-core/src/chunked_array/list/iterator.rs
@@ -355,7 +355,7 @@ mod test {
         // SAFETY: unstable series never lives longer than the iterator.
         unsafe {
             ca.amortized_iter().zip(&ca).for_each(|(s1, s2)| {
-                assert!(s1.unwrap().as_ref().series_equal(&s2.unwrap()));
+                assert!(s1.unwrap().as_ref().equals(&s2.unwrap()));
             })
         };
     }

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -1083,7 +1083,7 @@ mod test {
     fn test_median_floats() {
         let a = Series::new("a", &[1.0f64, 2.0, 3.0]);
         let expected = Series::new("a", [2.0f64]);
-        assert!(a.median_as_series().series_equal_missing(&expected));
+        assert!(a.median_as_series().equals_missing(&expected));
         assert_eq!(a.median(), Some(2.0f64))
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -829,7 +829,7 @@ mod test {
             "a" => ["a", "a", "b", "b", "c", "c"],
             "b" => [3, 5, 4, 4, 2, 5]
         )?;
-        assert!(out.frame_equal(&expected));
+        assert!(out.equals(&expected));
 
         let df = df!(
             "groups" => [1, 2, 3],
@@ -841,14 +841,14 @@ mod test {
             "groups" => [3, 2, 1],
             "values" => ["b", "a", "a"]
         )?;
-        assert!(out.frame_equal(&expected));
+        assert!(out.equals(&expected));
 
         let out = df.sort(["values", "groups"], vec![false, true], false)?;
         let expected = df!(
             "groups" => [2, 1, 3],
             "values" => ["a", "a", "b"]
         )?;
-        assert!(out.frame_equal(&expected));
+        assert!(out.equals(&expected));
 
         Ok(())
     }

--- a/crates/polars-core/src/frame/explode.rs
+++ b/crates/polars-core/src/frame/explode.rs
@@ -399,7 +399,7 @@ mod test {
             "C" => [1, 1, 1, 1, 1, 1, 1],
         ]?;
 
-        assert!(out.frame_equal_missing(&expected));
+        assert!(out.equals_missing(&expected));
 
         let list = Series::new("foo", [s0.clone(), s1.clear(), s1.clone()]);
         let df = DataFrame::new(vec![list, s0, s1])?;
@@ -410,7 +410,7 @@ mod test {
             "C" => [1, 1, 1, 1, 1, 1, 1],
         ]?;
 
-        assert!(out.frame_equal_missing(&expected));
+        assert!(out.equals_missing(&expected));
         Ok(())
     }
 

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1285,8 +1285,8 @@ impl DataFrame {
     ///     "2" => &[2, 2, 2]
     /// }?;
     ///
-    /// assert!(df.select(&["0", "1"])?.frame_equal(&df.select_by_range(0..=1)?));
-    /// assert!(df.frame_equal(&df.select_by_range(..)?));
+    /// assert!(df.select(&["0", "1"])?.equals(&df.select_by_range(0..=1)?));
+    /// assert!(df.equals(&df.select_by_range(..)?));
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn select_by_range<R>(&self, range: R) -> PolarsResult<Self>

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -3564,7 +3564,7 @@ mod test {
             "str" => ["a", "b", "c"]
         }
         .unwrap();
-        assert!(df.frame_equal(&valid));
+        assert!(df.equals(&valid));
     }
 
     #[test]

--- a/crates/polars-core/src/frame/row/transpose.rs
+++ b/crates/polars-core/src/frame/row/transpose.rs
@@ -270,7 +270,7 @@ mod test {
             "column_2" => [3, 30],
 
         ]?;
-        assert!(out.frame_equal_missing(&expected));
+        assert!(out.equals_missing(&expected));
 
         let df = df![
             "a" => [Some(1), None, Some(3)],
@@ -283,7 +283,7 @@ mod test {
             "column_2" => [Some(3), None],
 
         ]?;
-        assert!(out.frame_equal_missing(&expected));
+        assert!(out.equals_missing(&expected));
 
         let df = df![
             "a" => ["a", "b", "c"],
@@ -296,7 +296,7 @@ mod test {
             "column_2" => [Some("c"), None],
 
         ]?;
-        assert!(out.frame_equal_missing(&expected));
+        assert!(out.equals_missing(&expected));
         Ok(())
     }
 }

--- a/crates/polars-core/src/serde/mod.rs
+++ b/crates/polars-core/src/serde/mod.rs
@@ -66,7 +66,7 @@ mod test {
         let df = sample_dataframe();
         let json = serde_json::to_string(&df).unwrap();
         let out = serde_json::from_str::<DataFrame>(&json).unwrap(); // uses `Deserialize<'de>`
-        assert!(df.frame_equal_missing(&out));
+        assert!(df.equals_missing(&out));
     }
 
     #[test]
@@ -74,7 +74,7 @@ mod test {
         let df = sample_dataframe();
         let bytes = bincode::serialize(&df).unwrap();
         let out = bincode::deserialize::<DataFrame>(&bytes).unwrap(); // uses `Deserialize<'de>`
-        assert!(df.frame_equal_missing(&out));
+        assert!(df.equals_missing(&out));
     }
 
     /// test using the `DeserializedOwned` trait
@@ -84,7 +84,7 @@ mod test {
         let json = serde_json::to_string(&df).unwrap();
 
         let out = serde_json::from_reader::<_, DataFrame>(json.as_bytes()).unwrap(); // uses `DeserializeOwned`
-        assert!(df.frame_equal_missing(&out));
+        assert!(df.equals_missing(&out));
     }
 
     #[test]
@@ -100,7 +100,7 @@ mod test {
         let df = DataFrame::new(vec![s1]).unwrap();
         let bytes = bincode::serialize(&df).unwrap();
         let out = bincode::deserialize_from::<_, DataFrame>(bytes.as_slice()).unwrap();
-        assert!(df.frame_equal_missing(&out));
+        assert!(df.equals_missing(&out));
     }
 
     #[test]
@@ -139,7 +139,7 @@ mod test {
 
         let df_str = serde_json::to_string(&df).unwrap();
         let out = serde_json::from_str::<DataFrame>(&df_str).unwrap();
-        assert!(df.frame_equal_missing(&out));
+        assert!(df.equals_missing(&out));
     }
     /// test using the `DeserializedOwned` trait
     #[test]
@@ -147,6 +147,6 @@ mod test {
         let df = sample_dataframe();
         let bytes = bincode::serialize(&df).unwrap();
         let out = bincode::deserialize_from::<_, DataFrame>(bytes.as_slice()).unwrap(); // uses `DeserializeOwned`
-        assert!(df.frame_equal_missing(&out));
+        assert!(df.equals_missing(&out));
     }
 }

--- a/crates/polars-core/src/serde/mod.rs
+++ b/crates/polars-core/src/serde/mod.rs
@@ -15,14 +15,14 @@ mod test {
         let json = serde_json::to_string(&ca).unwrap();
 
         let out = serde_json::from_str::<Series>(&json).unwrap();
-        assert!(ca.into_series().series_equal_missing(&out));
+        assert!(ca.into_series().equals_missing(&out));
 
         let ca = Utf8Chunked::new("foo", &[Some("foo"), None, Some("bar")]);
 
         let json = serde_json::to_string(&ca).unwrap();
 
         let out = serde_json::from_str::<Series>(&json).unwrap(); // uses `Deserialize<'de>`
-        assert!(ca.into_series().series_equal_missing(&out));
+        assert!(ca.into_series().equals_missing(&out));
 
         Ok(())
     }
@@ -35,7 +35,7 @@ mod test {
         let json = serde_json::to_string(&ca).unwrap();
 
         let out = serde_json::from_reader::<_, Series>(json.as_bytes()).unwrap(); // uses `DeserializeOwned`
-        assert!(ca.into_series().series_equal_missing(&out));
+        assert!(ca.into_series().equals_missing(&out));
     }
 
     fn sample_dataframe() -> DataFrame {

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -135,7 +135,7 @@ pub struct Series(pub Arc<dyn SeriesTrait>);
 
 impl PartialEq for Wrap<Series> {
     fn eq(&self, other: &Self) -> bool {
-        self.0.series_equal_missing(other)
+        self.0.equals_missing(other)
     }
 }
 

--- a/crates/polars-core/src/series/ops/to_list.rs
+++ b/crates/polars-core/src/series/ops/to_list.rs
@@ -137,7 +137,7 @@ mod test {
         let expected = builder.finish();
 
         let out = s.implode()?;
-        assert!(expected.into_series().series_equal(&out.into_series()));
+        assert!(expected.into_series().equals(&out.into_series()));
 
         Ok(())
     }

--- a/crates/polars-core/src/testing.rs
+++ b/crates/polars-core/src/testing.rs
@@ -64,7 +64,7 @@ impl PartialEq for Series {
 
 impl DataFrame {
     /// Check if [`DataFrame`]' schemas are equal.
-    pub fn frame_equal_schema(&self, other: &DataFrame) -> PolarsResult<()> {
+    pub fn schema_equal(&self, other: &DataFrame) -> PolarsResult<()> {
         for (lhs, rhs) in self.iter().zip(other.iter()) {
             polars_ensure!(
                 lhs.name() == rhs.name(),

--- a/crates/polars-core/src/testing.rs
+++ b/crates/polars-core/src/testing.rs
@@ -91,7 +91,7 @@ impl DataFrame {
     /// let df2: DataFrame = df!("Atomic number" => &[1, 51, 300],
     ///                         "Element" => &[Some("Hydrogen"), Some("Antimony"), None])?;
     ///
-    /// assert!(!df1.frame_equal(&df2));
+    /// assert!(!df1.equals(&df2));
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn equals(&self, other: &DataFrame) -> bool {
@@ -117,7 +117,7 @@ impl DataFrame {
     /// let df2: DataFrame = df!("Atomic number" => &[1, 51, 300],
     ///                         "Element" => &[Some("Hydrogen"), Some("Antimony"), None])?;
     ///
-    /// assert!(df1.frame_equal_missing(&df2));
+    /// assert!(df1.equals_missing(&df2));
     /// # Ok::<(), PolarsError>(())
     /// ```
     pub fn equals_missing(&self, other: &DataFrame) -> bool {
@@ -169,7 +169,7 @@ mod test {
     use crate::prelude::*;
 
     #[test]
-    fn test_series_equal() {
+    fn test_series_equals() {
         let a = Series::new("a", &[1_u32, 2, 3]);
         let b = Series::new("a", &[1_u32, 2, 3]);
         assert!(a.equals(&b));

--- a/crates/polars-core/src/testing.rs
+++ b/crates/polars-core/src/testing.rs
@@ -9,14 +9,14 @@ impl Series {
         if self.null_count() > 0 || other.null_count() > 0 || self.dtype() != other.dtype() {
             false
         } else {
-            self.series_equal_missing(other)
+            self.equals_missing(other)
         }
     }
 
     /// Check if all values in series are equal where `None == None` evaluates to `true`.
     /// Two [`Datetime`](DataType::Datetime) series are *not* equal if their timezones are different, regardless
     /// if they represent the same UTC time or not.
-    pub fn series_equal_missing(&self, other: &Series) -> bool {
+    pub fn equals_missing(&self, other: &Series) -> bool {
         match (self.dtype(), other.dtype()) {
             #[cfg(feature = "timezones")]
             (DataType::Datetime(_, tz_lhs), DataType::Datetime(_, tz_rhs)) => {
@@ -58,7 +58,7 @@ impl Series {
 
 impl PartialEq for Series {
     fn eq(&self, other: &Self) -> bool {
-        self.series_equal_missing(other)
+        self.equals_missing(other)
     }
 }
 
@@ -125,7 +125,7 @@ impl DataFrame {
             return false;
         }
         for (left, right) in self.get_columns().iter().zip(other.get_columns()) {
-            if !left.series_equal_missing(right) {
+            if !left.equals_missing(right) {
                 return false;
             }
         }
@@ -160,7 +160,7 @@ impl PartialEq for DataFrame {
                 .columns
                 .iter()
                 .zip(other.columns.iter())
-                .all(|(s1, s2)| s1.series_equal_missing(s2))
+                .all(|(s1, s2)| s1.equals_missing(s2))
     }
 }
 
@@ -175,7 +175,7 @@ mod test {
         assert!(a.equals(&b));
 
         let s = Series::new("foo", &[None, Some(1i64)]);
-        assert!(s.series_equal_missing(&s));
+        assert!(s.equals_missing(&s));
     }
 
     #[test]

--- a/crates/polars-core/src/testing.rs
+++ b/crates/polars-core/src/testing.rs
@@ -120,7 +120,7 @@ impl DataFrame {
     /// assert!(df1.frame_equal_missing(&df2));
     /// # Ok::<(), PolarsError>(())
     /// ```
-    pub fn frame_equal_missing(&self, other: &DataFrame) -> bool {
+    pub fn equals_missing(&self, other: &DataFrame) -> bool {
         if self.shape() != other.shape() {
             return false;
         }

--- a/crates/polars-core/src/testing.rs
+++ b/crates/polars-core/src/testing.rs
@@ -5,7 +5,7 @@ use crate::prelude::*;
 
 impl Series {
     /// Check if series are equal. Note that `None == None` evaluates to `false`
-    pub fn series_equal(&self, other: &Series) -> bool {
+    pub fn equals(&self, other: &Series) -> bool {
         if self.null_count() > 0 || other.null_count() > 0 || self.dtype() != other.dtype() {
             false
         } else {
@@ -99,7 +99,7 @@ impl DataFrame {
             return false;
         }
         for (left, right) in self.get_columns().iter().zip(other.get_columns()) {
-            if !left.series_equal(right) {
+            if !left.equals(right) {
                 return false;
             }
         }
@@ -172,7 +172,7 @@ mod test {
     fn test_series_equal() {
         let a = Series::new("a", &[1_u32, 2, 3]);
         let b = Series::new("a", &[1_u32, 2, 3]);
-        assert!(a.series_equal(&b));
+        assert!(a.equals(&b));
 
         let s = Series::new("foo", &[None, Some(1i64)]);
         assert!(s.series_equal_missing(&s));
@@ -182,7 +182,7 @@ mod test {
     fn test_series_dtype_noteq() {
         let s_i32 = Series::new("a", &[1_i32, 2_i32]);
         let s_i64 = Series::new("a", &[1_i64, 2_i64]);
-        assert!(!s_i32.series_equal(&s_i64));
+        assert!(!s_i32.equals(&s_i64));
     }
 
     #[test]

--- a/crates/polars-core/src/testing.rs
+++ b/crates/polars-core/src/testing.rs
@@ -94,7 +94,7 @@ impl DataFrame {
     /// assert!(!df1.frame_equal(&df2));
     /// # Ok::<(), PolarsError>(())
     /// ```
-    pub fn frame_equal(&self, other: &DataFrame) -> bool {
+    pub fn equals(&self, other: &DataFrame) -> bool {
         if self.shape() != other.shape() {
             return false;
         }
@@ -191,7 +191,7 @@ mod test {
         let b = Series::new("b", [1, 2, 3].as_ref());
 
         let df1 = DataFrame::new(vec![a, b]).unwrap();
-        assert!(df1.frame_equal(&df1))
+        assert!(df1.equals(&df1))
     }
 
     #[test]

--- a/crates/polars-io/src/avro/mod.rs
+++ b/crates/polars-io/src/avro/mod.rs
@@ -39,7 +39,7 @@ mod test {
             buf.set_position(0);
 
             let read_df = AvroReader::new(buf).finish()?;
-            assert!(write_df.frame_equal(&read_df));
+            assert!(write_df.equals(&read_df));
         }
 
         Ok(())
@@ -67,7 +67,7 @@ mod test {
             .with_projection(Some(vec![0, 1]))
             .finish()?;
 
-        assert!(expected_df.frame_equal(&read_df));
+        assert!(expected_df.equals(&read_df));
 
         Ok(())
     }
@@ -94,7 +94,7 @@ mod test {
             .with_columns(Some(vec!["i64".to_string(), "utf8".to_string()]))
             .finish()?;
 
-        assert!(expected_df.frame_equal(&read_df));
+        assert!(expected_df.equals(&read_df));
 
         Ok(())
     }

--- a/crates/polars-io/src/csv/read_impl/batched_read.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_read.rs
@@ -445,6 +445,6 @@ mod test {
         assert_eq!(batches.len(), 5);
         let df = concat_df(&batches).unwrap();
         let expected = CsvReader::new(file).finish().unwrap();
-        assert!(df.frame_equal(&expected))
+        assert!(df.equals(&expected))
     }
 }

--- a/crates/polars-io/src/ipc/ipc_file.rs
+++ b/crates/polars-io/src/ipc/ipc_file.rs
@@ -30,7 +30,7 @@
 //!
 //! // read the buffer into a DataFrame
 //! let df_read = IpcReader::new(buf).finish().unwrap();
-//! assert!(df.frame_equal(&df_read));
+//! assert!(df.equals(&df_read));
 //! ```
 use std::io::{Read, Seek};
 use std::sync::Arc;

--- a/crates/polars-io/src/ipc/ipc_stream.rs
+++ b/crates/polars-io/src/ipc/ipc_stream.rs
@@ -31,7 +31,7 @@
 //!
 //! // read the buffer into a DataFrame
 //! let df_read = IpcStreamReader::new(buf).finish().unwrap();
-//! assert!(df.frame_equal(&df_read));
+//! assert!(df.equals(&df_read));
 //! ```
 use std::io::{Read, Write};
 use std::path::PathBuf;

--- a/crates/polars-io/src/ipc/write.rs
+++ b/crates/polars-io/src/ipc/write.rs
@@ -196,7 +196,7 @@ mod test {
         buf.set_position(0);
 
         let df_read = IpcReader::new(buf).finish().unwrap();
-        assert!(df.frame_equal(&df_read));
+        assert!(df.equals(&df_read));
     }
 
     #[test]
@@ -215,7 +215,7 @@ mod test {
             .finish()
             .unwrap();
         assert_eq!(df_read.shape(), (3, 2));
-        df_read.frame_equal(&expected);
+        df_read.equals(&expected);
     }
 
     #[test]
@@ -233,7 +233,7 @@ mod test {
             .with_columns(Some(vec!["c".to_string(), "b".to_string()]))
             .finish()
             .unwrap();
-        df_read.frame_equal(&expected);
+        df_read.equals(&expected);
 
         let mut buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
         let mut df = df![
@@ -263,7 +263,7 @@ mod test {
             ]))
             .finish()
             .unwrap();
-        assert!(df_read.frame_equal(&expected));
+        assert!(df_read.equals(&expected));
     }
 
     #[test]
@@ -283,7 +283,7 @@ mod test {
             let df_read = IpcReader::new(buf)
                 .finish()
                 .unwrap_or_else(|_| panic!("IPC reader: {:?}", compression));
-            assert!(df.frame_equal(&df_read));
+            assert!(df.equals(&df_read));
         }
     }
 
@@ -299,6 +299,6 @@ mod test {
         buf.set_position(0);
 
         let df_read = IpcReader::new(buf).finish().unwrap();
-        assert!(df.frame_equal(&df_read));
+        assert!(df.equals(&df_read));
     }
 }

--- a/crates/polars-io/src/parquet/mod.rs
+++ b/crates/polars-io/src/parquet/mod.rs
@@ -98,7 +98,7 @@ mod test {
         f.seek(SeekFrom::Start(0))?;
 
         let read = ParquetReader::new(f).finish()?;
-        assert!(read.frame_equal_missing(&df));
+        assert!(read.equals_missing(&df));
         Ok(())
     }
 

--- a/crates/polars-io/src/parquet/mod.rs
+++ b/crates/polars-io/src/parquet/mod.rs
@@ -118,7 +118,7 @@ mod test {
             .finish()
             .unwrap();
         assert_eq!(df_read.shape(), (3, 2));
-        df_read.frame_equal(&expected);
+        df_read.equals(&expected);
     }
 
     #[test]
@@ -137,6 +137,6 @@ mod test {
             .finish()
             .unwrap();
         assert_eq!(df_read.shape(), (3, 2));
-        df_read.frame_equal(&expected);
+        df_read.equals(&expected);
     }
 }

--- a/crates/polars-io/src/partition.rs
+++ b/crates/polars-io/src/partition.rs
@@ -177,7 +177,7 @@ mod test {
             assert_eq!(ipc_paths.len(), 1);
             let reader = BufReader::new(polars_utils::open_file(&ipc_paths[0])?);
             let df = IpcReader::new(reader).finish()?;
-            assert!(expected_df.frame_equal(&df));
+            assert!(expected_df.equals(&df));
         }
 
         Ok(())

--- a/crates/polars-lazy/src/dsl/functions.rs
+++ b/crates/polars-lazy/src/dsl/functions.rs
@@ -249,7 +249,7 @@ mod test {
             "d" => [None, None, None, None, Some(1), Some(2)]
         ]?;
 
-        assert!(out.frame_equal_missing(&expected));
+        assert!(out.equals_missing(&expected));
 
         Ok(())
     }

--- a/crates/polars-lazy/src/lib.rs
+++ b/crates/polars-lazy/src/lib.rs
@@ -60,7 +60,7 @@
 //!
 //! assert!(new.column("new_column")
 //!     .unwrap()
-//!     .series_equal(
+//!     .equals(
 //!         &Series::new("new_column", &[50, 40, 30, 20, 10])
 //!     )
 //! );
@@ -93,7 +93,7 @@
 //!
 //! assert!(new.column("new_column")
 //!     .unwrap()
-//!     .series_equal(
+//!     .equals(
 //!         &Series::new("new_column", &[100, 100, 3, 4, 5])
 //!     )
 //! );

--- a/crates/polars-lazy/src/tests/aggregations.rs
+++ b/crates/polars-lazy/src/tests/aggregations.rs
@@ -76,12 +76,12 @@ fn test_agg_unique_first() -> PolarsResult<()> {
 fn test_lazy_agg_scan() {
     let lf = scan_foods_csv;
     let df = lf().min().collect().unwrap();
-    assert!(df.frame_equal_missing(&lf().collect().unwrap().min()));
+    assert!(df.equals_missing(&lf().collect().unwrap().min()));
     let df = lf().max().collect().unwrap();
-    assert!(df.frame_equal_missing(&lf().collect().unwrap().max()));
+    assert!(df.equals_missing(&lf().collect().unwrap().max()));
     // mean is not yet aggregated at scan.
     let df = lf().mean().collect().unwrap();
-    assert!(df.frame_equal_missing(&lf().collect().unwrap().mean()));
+    assert!(df.equals_missing(&lf().collect().unwrap().mean()));
 }
 
 #[test]

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -241,7 +241,7 @@ fn test_csv_globbing() -> PolarsResult<()> {
     let df = lf.clone().collect()?;
     assert_eq!(df.shape(), (100, 4));
     let df = LazyCsvReader::new(glob).finish()?.slice(20, 60).collect()?;
-    assert!(full_df.slice(20, 60).frame_equal(&df));
+    assert!(full_df.slice(20, 60).equals(&df));
 
     let mut expr_arena = Arena::with_capacity(16);
     let mut lp_arena = Arena::with_capacity(8);

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -165,7 +165,7 @@ fn test_no_left_join_pass() -> PolarsResult<()> {
         "bar" => [5, 5],
     ]?;
 
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
     Ok(())
 }
 
@@ -329,7 +329,7 @@ fn test_lazy_filter_and_rename() {
         "x" => &[4, 5]
     }
     .unwrap();
-    assert!(lf.collect().unwrap().frame_equal(&correct));
+    assert!(lf.collect().unwrap().equals(&correct));
 
     // now we check if the column is rename or added when we don't select
     let lf = df.lazy().rename(["a"], ["x"]).filter(col("x").map(
@@ -359,7 +359,7 @@ fn test_with_row_count_opts() -> PolarsResult<()> {
         "a" => [5, 6, 7, 8, 9],
     ]?;
 
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
     let out = df
         .clone()
         .lazy()

--- a/crates/polars-lazy/src/tests/predicate_queries.rs
+++ b/crates/polars-lazy/src/tests/predicate_queries.rs
@@ -187,7 +187,7 @@ fn test_filter_nulls_created_by_join() -> PolarsResult<()> {
         "bar" => [1],
         "flag" => &[None, Some(true)][0..1]
     ]?;
-    assert!(out.frame_equal_missing(&expected));
+    assert!(out.equals_missing(&expected));
 
     let out = a
         .lazy()
@@ -195,7 +195,7 @@ fn test_filter_nulls_created_by_join() -> PolarsResult<()> {
         .filter(col("flag").eq(lit(NULL)))
         .with_predicate_pushdown(false)
         .collect()?;
-    assert!(out.frame_equal_missing(&expected));
+    assert!(out.equals_missing(&expected));
 
     Ok(())
 }
@@ -217,7 +217,7 @@ fn test_filter_null_creation_by_cast() -> PolarsResult<()> {
         "int" => [3],
         "empty" => &[None, Some(1i32)][..1]
     ]?;
-    assert!(out.frame_equal_missing(&expected));
+    assert!(out.equals_missing(&expected));
 
     Ok(())
 }

--- a/crates/polars-lazy/src/tests/projection_queries.rs
+++ b/crates/polars-lazy/src/tests/projection_queries.rs
@@ -60,7 +60,7 @@ fn test_cross_join_pd() -> PolarsResult<()> {
         "total" => [13, 12, 10, 9]
     ]?;
 
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
     Ok(())
 }
 
@@ -82,7 +82,7 @@ fn test_row_count_pd() -> PolarsResult<()> {
         "x" => [3i32, 6, 9]
     ]?;
 
-    assert!(df.frame_equal(&expected));
+    assert!(df.equals(&expected));
 
     Ok(())
 }

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -82,7 +82,7 @@ fn test_lazy_drop_nulls() {
         "bar" => &[Some(1)]
     }
     .unwrap();
-    assert!(new.frame_equal(&out));
+    assert!(new.equals(&out));
 }
 
 #[test]
@@ -597,7 +597,7 @@ fn test_lazy_fill_null() {
         "b" => &[Some(1.0), Some(10.0)]
     }
     .unwrap();
-    assert!(out.frame_equal(&correct));
+    assert!(out.equals(&correct));
     assert_eq!(out.get_column_names(), vec!["a", "b"])
 }
 
@@ -1091,7 +1091,7 @@ fn test_filter_and_alias() -> PolarsResult<()> {
     ]?;
     println!("{:?}", out);
     println!("{:?}", expected);
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
     Ok(())
 }
 
@@ -1771,7 +1771,7 @@ fn test_partitioned_gb_1() -> PolarsResult<()> {
     .sort("keys", Default::default())
     .collect()?;
 
-    assert!(out.frame_equal(&df![
+    assert!(out.equals(&df![
         "keys" => [1, 2],
         "eq_a" => [2 as IdxSize, 1],
         "eq_b" => [1 as IdxSize, 0],
@@ -1795,7 +1795,7 @@ fn test_partitioned_gb_count() -> PolarsResult<()> {
     ])
     .collect()?;
 
-    assert!(out.frame_equal(&df![
+    assert!(out.equals(&df![
         "col" => [0],
         "counted" => [100 as IdxSize],
         "count2" => [100 as IdxSize],
@@ -1842,7 +1842,7 @@ fn test_partitioned_gb_binary() -> PolarsResult<()> {
         .agg([(col("col") + lit(10)).sum().alias("sum")])
         .collect()?;
 
-    assert!(out.frame_equal(&df![
+    assert!(out.equals(&df![
         "col" => [0],
         "sum" => [200],
     ]?));
@@ -1855,7 +1855,7 @@ fn test_partitioned_gb_binary() -> PolarsResult<()> {
             .alias("sum")])
         .collect()?;
 
-    assert!(out.frame_equal(&df![
+    assert!(out.equals(&df![
         "col" => [0],
         "sum" => [200.0_f32],
     ]?));
@@ -1881,7 +1881,7 @@ fn test_partitioned_gb_ternary() -> PolarsResult<()> {
             .alias("sum")])
         .collect()?;
 
-    assert!(out.frame_equal(&df![
+    assert!(out.equals(&df![
         "col" => [0],
         "sum" => [9],
     ]?));
@@ -1902,7 +1902,7 @@ fn test_sort_maintain_order_true() -> PolarsResult<()> {
         .slice(0, 3)
         .collect()?;
     println!("{:?}", res);
-    assert!(res.frame_equal(&df![
+    assert!(res.equals(&df![
         "A" => [1, 1, 1],
         "B" => ["A", "B", "C"],
     ]?));

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -581,7 +581,7 @@ fn test_lazy_reverse() {
         .reverse()
         .collect()
         .unwrap()
-        .frame_equal_missing(&df.reverse()))
+        .equals_missing(&df.reverse()))
 }
 
 #[test]

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -430,7 +430,7 @@ fn test_lazy_query_10() {
         TimeUnit::Nanoseconds,
     )
     .into();
-    assert!(out.column("z").unwrap().series_equal(&z));
+    assert!(out.column("z").unwrap().equals(&z));
     let x: Series = DatetimeChunked::from_naive_datetime(
         "x",
         [
@@ -460,7 +460,7 @@ fn test_lazy_query_10() {
     assert!(out
         .column("z")
         .unwrap()
-        .series_equal(&z.cast(&DataType::Duration(TimeUnit::Milliseconds)).unwrap()));
+        .equals(&z.cast(&DataType::Duration(TimeUnit::Milliseconds)).unwrap()));
 }
 
 #[test]
@@ -992,7 +992,7 @@ fn test_group_by_sort_slice() -> PolarsResult<()> {
         .sort("groups", SortOptions::default())
         .collect()?;
 
-    assert!(out1.column("foo")?.series_equal(out2.column("foo")?));
+    assert!(out1.column("foo")?.equals(out2.column("foo")?));
     Ok(())
 }
 
@@ -1144,9 +1144,9 @@ fn test_fill_forward() -> PolarsResult<()> {
     let agg = out.column("b")?.list()?;
 
     let a: Series = agg.get_as_series(0).unwrap();
-    assert!(a.series_equal(&Series::new("b", &[1, 1])));
+    assert!(a.equals(&Series::new("b", &[1, 1])));
     let a: Series = agg.get_as_series(2).unwrap();
-    assert!(a.series_equal(&Series::new("b", &[1, 1])));
+    assert!(a.equals(&Series::new("b", &[1, 1])));
     let a: Series = agg.get_as_series(1).unwrap();
     assert_eq!(a.null_count(), 1);
     Ok(())
@@ -1462,7 +1462,7 @@ fn test_list_in_select_context() -> PolarsResult<()> {
     let out = df.lazy().select([col("a").implode()]).collect()?;
 
     let s = out.column("a")?;
-    assert!(s.series_equal(&expected));
+    assert!(s.equals(&expected));
 
     Ok(())
 }

--- a/crates/polars-lazy/src/tests/streaming.rs
+++ b/crates/polars-lazy/src/tests/streaming.rs
@@ -382,7 +382,7 @@ fn test_sort_maintain_order_streaming() -> PolarsResult<()> {
         .slice(0, 3)
         .with_streaming(true)
         .collect()?;
-    assert!(res.frame_equal(&df![
+    assert!(res.equals(&df![
         "A" => [1, 1, 1],
         "B" => ["A", "B", "C"],
     ]?));

--- a/crates/polars-ops/src/chunked_array/strings/json_path.rs
+++ b/crates/polars-ops/src/chunked_array/strings/json_path.rs
@@ -190,11 +190,11 @@ mod tests {
         assert!(ca
             .json_decode(None, None)
             .unwrap()
-            .series_equal_missing(&expected_series));
+            .equals_missing(&expected_series));
         assert!(ca
             .json_decode(Some(expected_dtype), None)
             .unwrap()
-            .series_equal_missing(&expected_series));
+            .equals_missing(&expected_series));
     }
 
     #[test]
@@ -214,7 +214,7 @@ mod tests {
             .json_path_select("$")
             .unwrap()
             .into_series()
-            .series_equal_missing(&s));
+            .equals_missing(&s));
 
         let b_series = Series::new(
             "json",
@@ -229,14 +229,14 @@ mod tests {
             .json_path_select("$.b")
             .unwrap()
             .into_series()
-            .series_equal_missing(&b_series));
+            .equals_missing(&b_series));
 
         let c_series = Series::new("json", [None, Some(r#"[0,1]"#), Some(r#"[2,5]"#), None]);
         assert!(ca
             .json_path_select("$.b[:].c")
             .unwrap()
             .into_series()
-            .series_equal_missing(&c_series));
+            .equals_missing(&c_series));
     }
 
     #[test]
@@ -266,6 +266,6 @@ mod tests {
             .json_path_extract("$.b[:].c", None, None)
             .unwrap()
             .into_series()
-            .series_equal_missing(&c_series));
+            .equals_missing(&c_series));
     }
 }

--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -10,7 +10,7 @@ pub fn _merge_sorted_dfs(
     check_schema: bool,
 ) -> PolarsResult<DataFrame> {
     if check_schema {
-        left.frame_equal_schema(right)?;
+        left.schema_equal(right)?;
     }
     let dtype_lhs = left_s.dtype();
     let dtype_rhs = right_s.dtype();

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -96,7 +96,7 @@ impl SQLContext {
     ///
     /// ctx.register("df", df.clone().lazy());
     /// let sql_df = ctx.execute("SELECT * FROM df").unwrap().collect().unwrap();
-    /// assert!(sql_df.frame_equal(&df));
+    /// assert!(sql_df.equals(&df));
     /// # }
     ///```
     pub fn execute(&mut self, query: &str) -> PolarsResult<LazyFrame> {

--- a/crates/polars-sql/tests/functions_cumulative.rs
+++ b/crates/polars-sql/tests/functions_cumulative.rs
@@ -47,7 +47,7 @@ fn test_cumulative_sum() {
     let sql_expr = "SUM(Sales) OVER (ORDER BY Sales DESC)";
     let (expected, actual) = create_expected(expr, sql_expr);
 
-    assert!(expected.frame_equal(&actual))
+    assert!(expected.equals(&actual))
 }
 
 #[test]
@@ -57,7 +57,7 @@ fn test_cumulative_min() {
     let sql_expr = "MIN(Sales) OVER (ORDER BY Sales DESC)";
     let (expected, actual) = create_expected(expr, sql_expr);
 
-    assert!(expected.frame_equal(&actual))
+    assert!(expected.equals(&actual))
 }
 
 #[test]
@@ -67,5 +67,5 @@ fn test_cumulative_max() {
     let sql_expr = "MAX(Sales) OVER (ORDER BY Sales DESC)";
     let (expected, actual) = create_expected(expr, sql_expr);
 
-    assert!(expected.frame_equal(&actual))
+    assert!(expected.equals(&actual))
 }

--- a/crates/polars-sql/tests/functions_io.rs
+++ b/crates/polars-sql/tests/functions_io.rs
@@ -18,7 +18,7 @@ fn read_csv_tbl_func() {
         "Response" => ["Create Table"]
     }
     .unwrap();
-    assert!(df_sql.frame_equal(&create_tbl_res));
+    assert!(df_sql.equals(&create_tbl_res));
     let df_2 = context
         .execute(r#"SELECT * FROM foods1"#)
         .unwrap()
@@ -43,7 +43,7 @@ fn read_csv_tbl_func_inline() {
         .select(&[col("category")])
         .collect()
         .unwrap();
-    assert!(df_sql.frame_equal(&expected));
+    assert!(df_sql.equals(&expected));
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn read_csv_tbl_func_inline_2() {
         .select(&[col("category")])
         .collect()
         .unwrap();
-    assert!(df_sql.frame_equal(&expected));
+    assert!(df_sql.equals(&expected));
 }
 
 #[test]
@@ -77,7 +77,7 @@ fn read_parquet_tbl() {
         "Response" => ["Create Table"]
     }
     .unwrap();
-    assert!(df_sql.frame_equal(&create_tbl_res));
+    assert!(df_sql.equals(&create_tbl_res));
     let df_2 = context
         .execute(r#"SELECT * FROM foods1"#)
         .unwrap()
@@ -100,7 +100,7 @@ fn read_ipc_tbl() {
         "Response" => ["Create Table"]
     }
     .unwrap();
-    assert!(df_sql.frame_equal(&create_tbl_res));
+    assert!(df_sql.equals(&create_tbl_res));
     let df_2 = context
         .execute(r#"SELECT * FROM foods1"#)
         .unwrap()

--- a/crates/polars-sql/tests/functions_math.rs
+++ b/crates/polars-sql/tests/functions_math.rs
@@ -56,5 +56,5 @@ fn test_math_functions() {
         .unwrap();
     println!("{}", df_pl.head(Some(10)));
     println!("{}", df_sql.head(Some(10)));
-    assert!(df_sql.frame_equal_missing(&df_pl));
+    assert!(df_sql.equals_missing(&df_pl));
 }

--- a/crates/polars-sql/tests/functions_string.rs
+++ b/crates/polars-sql/tests/functions_string.rs
@@ -79,7 +79,7 @@ fn test_string_functions() {
         ])
         .collect()
         .unwrap();
-    assert!(df_sql.frame_equal_missing(&df_pl));
+    assert!(df_sql.equals_missing(&df_pl));
 }
 
 #[test]
@@ -122,5 +122,5 @@ fn array_to_string() {
         .collect()
         .unwrap();
 
-    assert!(df_sql.frame_equal_missing(&df_pl));
+    assert!(df_sql.equals_missing(&df_pl));
 }

--- a/crates/polars-sql/tests/iss_7436.rs
+++ b/crates/polars-sql/tests/iss_7436.rs
@@ -36,5 +36,5 @@ fn iss_7436() {
         .limit(5)
         .collect()
         .unwrap();
-    assert!(df_sql.frame_equal(&expected));
+    assert!(df_sql.equals(&expected));
 }

--- a/crates/polars-sql/tests/iss_7437.rs
+++ b/crates/polars-sql/tests/iss_7437.rs
@@ -33,6 +33,6 @@ fn iss_7437() -> PolarsResult<()> {
         .collect()?
         .sort(["category"], vec![false], false)?;
 
-    assert!(df_sql.frame_equal(&expected));
+    assert!(df_sql.equals(&expected));
     Ok(())
 }

--- a/crates/polars-sql/tests/iss_7440.rs
+++ b/crates/polars-sql/tests/iss_7440.rs
@@ -23,5 +23,5 @@ fn iss_7440() {
         ])
         .collect()
         .unwrap();
-    assert!(df_sql.frame_equal_missing(&df_pl));
+    assert!(df_sql.equals_missing(&df_pl));
 }

--- a/crates/polars-sql/tests/iss_8395.rs
+++ b/crates/polars-sql/tests/iss_8395.rs
@@ -21,6 +21,6 @@ fn iss_8395() -> PolarsResult<()> {
     // assert that the df only contains [vegetables, seafood]
     let s = df.column("category")?.unique()?.sort(false);
     let expected = Series::new("category", &["seafood", "vegetables"]);
-    assert!(s.series_equal(&expected));
+    assert!(s.equals(&expected));
     Ok(())
 }

--- a/crates/polars-sql/tests/iss_8419.rs
+++ b/crates/polars-sql/tests/iss_8419.rs
@@ -41,5 +41,5 @@ fn iss_8419() {
     "#;
     let df = ctx.execute(query).unwrap().collect().unwrap();
 
-    assert!(df.frame_equal(&expected))
+    assert!(df.equals(&expected))
 }

--- a/crates/polars-sql/tests/ops_distinct_on.rs
+++ b/crates/polars-sql/tests/ops_distinct_on.rs
@@ -37,5 +37,5 @@ fn test_distinct_on() {
         .group_by_stable(vec![col("Name")])
         .agg(vec![col("*").first()]);
     let expected = expected.collect().unwrap();
-    assert!(actual.frame_equal(&expected))
+    assert!(actual.equals(&expected))
 }

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -151,7 +151,7 @@ fn test_literal_exprs() {
         ])
         .collect()
         .unwrap();
-    assert!(df_sql.frame_equal_missing(&df_pl));
+    assert!(df_sql.equals_missing(&df_pl));
 }
 
 #[test]
@@ -245,7 +245,7 @@ fn test_null_exprs_in_where() {
         .collect()
         .unwrap();
 
-    assert!(df_sql.frame_equal_missing(&df_pl));
+    assert!(df_sql.equals_missing(&df_pl));
 }
 
 #[test]

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -13,7 +13,7 @@ fn assert_sql_to_polars(df: &DataFrame, sql: &str, f: impl FnOnce(LazyFrame) -> 
     context.register("df", df.clone().lazy());
     let df_sql = context.execute(sql).unwrap().collect().unwrap();
     let df_pl = f(df.clone().lazy()).collect().unwrap();
-    assert!(df_sql.frame_equal(&df_pl));
+    assert!(df_sql.equals(&df_pl));
 }
 
 #[test]
@@ -123,7 +123,7 @@ fn test_cast_exprs() {
         ])
         .collect()
         .unwrap();
-    assert!(df_sql.frame_equal(&df_pl));
+    assert!(df_sql.equals(&df_pl));
 }
 
 #[test]
@@ -170,7 +170,7 @@ fn test_prefixed_column_names() {
         .select(&[col("a").alias("a"), col("b").alias("b")])
         .collect()
         .unwrap();
-    assert!(df_sql.frame_equal(&df_pl));
+    assert!(df_sql.equals(&df_pl));
 }
 
 #[test]
@@ -189,7 +189,7 @@ fn test_prefixed_column_names_2() {
         .select(&[col("a").alias("a"), col("b").alias("b")])
         .collect()
         .unwrap();
-    assert!(df_sql.frame_equal(&df_pl));
+    assert!(df_sql.equals(&df_pl));
 }
 
 #[test]
@@ -219,7 +219,7 @@ fn test_null_exprs() {
         ])
         .collect()
         .unwrap();
-    assert!(df_sql.frame_equal(&df_pl));
+    assert!(df_sql.equals(&df_pl));
 }
 
 #[test]
@@ -337,7 +337,7 @@ fn test_agg_functions() {
         ])
         .collect()
         .unwrap();
-    assert!(df_sql.frame_equal(&df_pl));
+    assert!(df_sql.equals(&df_pl));
 }
 
 #[test]
@@ -354,7 +354,7 @@ fn create_table() {
         "Response" => ["Create Table"]
     }
     .unwrap();
-    assert!(df_sql.frame_equal(&create_tbl_res));
+    assert!(df_sql.equals(&create_tbl_res));
     let df_2 = context
         .execute(r#"SELECT a FROM df2"#)
         .unwrap()
@@ -362,7 +362,7 @@ fn create_table() {
         .unwrap();
     let expected = df.lazy().select(&[col("a")]).collect().unwrap();
 
-    assert!(df_2.frame_equal(&expected));
+    assert!(df_2.equals(&expected));
 }
 
 #[test]
@@ -381,7 +381,7 @@ fn test_unary_minus_0() {
         .filter(col("value").lt(lit(-1)))
         .collect()
         .unwrap();
-    assert!(df_sql.frame_equal(&df_pl));
+    assert!(df_sql.equals(&df_pl));
 }
 
 #[test]
@@ -397,7 +397,7 @@ fn test_unary_minus_1() {
     let df_sql = context.execute(sql).unwrap().collect().unwrap();
     let neg_value = lit(0) - col("value");
     let df_pl = df.lazy().filter(neg_value.lt(lit(1))).collect().unwrap();
-    assert!(df_sql.frame_equal(&df_pl));
+    assert!(df_sql.equals(&df_pl));
 }
 
 #[test]
@@ -500,7 +500,7 @@ fn test_group_by_2() -> PolarsResult<()> {
         )
         .limit(2);
     let expected = expected.collect()?;
-    assert!(df_sql.frame_equal(&expected));
+    assert!(df_sql.equals(&expected));
     Ok(())
 }
 
@@ -525,7 +525,7 @@ fn test_case_expr() {
         .otherwise(lit("no match"))
         .alias("sign");
     let df_pl = df.lazy().select(&[case_expr]).collect().unwrap();
-    assert!(df_sql.frame_equal(&df_pl));
+    assert!(df_sql.equals(&df_pl));
 }
 
 #[test]
@@ -549,7 +549,7 @@ fn test_case_expr_with_expression() {
         .otherwise(lit("No?"))
         .alias("parity");
     let df_pl = df.lazy().select(&[case_expr]).collect().unwrap();
-    assert!(df_sql.frame_equal(&df_pl));
+    assert!(df_sql.equals(&df_pl));
 }
 
 #[test]
@@ -558,7 +558,7 @@ fn test_sql_expr() {
     let expr = sql_expr("MIN(a)").unwrap();
     let actual = df.clone().lazy().select(&[expr]).collect().unwrap();
     let expected = df.lazy().select(&[col("a").min()]).collect().unwrap();
-    assert!(actual.frame_equal(&expected));
+    assert!(actual.equals(&expected));
 }
 
 #[test]

--- a/crates/polars-sql/tests/statements.rs
+++ b/crates/polars-sql/tests/statements.rs
@@ -80,13 +80,13 @@ fn select_qualified_wildcard() {
     ctx.register("test2", df2.lazy());
 
     let sql = r#"
-    SELECT test.* 
-    FROM test 
-    INNER JOIN test2 
+    SELECT test.*
+    FROM test
+    INNER JOIN test2
     USING(a)
     "#;
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
-    assert!(actual.frame_equal(&expected));
+    assert!(actual.equals(&expected));
 }
 
 #[test]
@@ -114,12 +114,12 @@ fn select_qualified_column() {
 
     let sql = r#"
     SELECT test.b, test2.*
-    FROM test 
-    INNER JOIN test2 
+    FROM test
+    INNER JOIN test2
     USING(a)
     "#;
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
-    assert!(actual.frame_equal(&expected));
+    assert!(actual.equals(&expected));
 }
 
 #[test]
@@ -158,7 +158,7 @@ fn test_union_all() {
     .unwrap();
 
     let actual = ctx.execute(sql).unwrap().collect().unwrap();
-    assert!(actual.frame_equal(&expected));
+    assert!(actual.equals(&expected));
 }
 
 #[test]
@@ -192,5 +192,5 @@ fn iss_9560_join_as() {
     }
     .unwrap();
 
-    assert!(actual.frame_equal(&expected));
+    assert!(actual.equals(&expected));
 }

--- a/crates/polars-sql/tests/udf.rs
+++ b/crates/polars-sql/tests/udf.rs
@@ -97,7 +97,7 @@ fn test_udfs() -> PolarsResult<()> {
         "b" => &[1, 2, 3],
         "my_div" => &[1, 1, 1]
     }?;
-    assert!(expected.frame_equal_missing(&res));
+    assert!(expected.equals_missing(&res));
 
     Ok(())
 }

--- a/crates/polars-time/src/group_by/dynamic.rs
+++ b/crates/polars-time/src/group_by/dynamic.rs
@@ -956,7 +956,7 @@ mod test {
             .unwrap();
         time_key.rename("");
         let lower_bound = keys[1].clone().with_name("");
-        assert!(time_key.series_equal(&lower_bound));
+        assert!(time_key.equals(&lower_bound));
         Ok(())
     }
 }

--- a/crates/polars/tests/it/core/date_like.rs
+++ b/crates/polars/tests/it/core/date_like.rs
@@ -165,5 +165,5 @@ fn test_duration_date_arithmetic() {
 }
 
 fn assert_series_eq(s1: &Series, s2: &Series) {
-    assert!(s1.series_equal(s2))
+    assert!(s1.equals(s2))
 }

--- a/crates/polars/tests/it/core/joins.rs
+++ b/crates/polars/tests/it/core/joins.rs
@@ -240,7 +240,7 @@ fn test_join_multiple_columns() {
     assert!(joined_inner_hack
         .column("ham")
         .unwrap()
-        .series_equal_missing(joined_inner.column("ham").unwrap()));
+        .equals_missing(joined_inner.column("ham").unwrap()));
 
     let joined_outer_hack = df_a.outer_join(&df_b, ["dummy"], ["dummy"]).unwrap();
     let joined_outer = df_a
@@ -249,7 +249,7 @@ fn test_join_multiple_columns() {
     assert!(joined_outer_hack
         .column("ham")
         .unwrap()
-        .series_equal_missing(joined_outer.column("ham").unwrap()));
+        .equals_missing(joined_outer.column("ham").unwrap()));
 }
 
 #[test]

--- a/crates/polars/tests/it/core/joins.rs
+++ b/crates/polars/tests/it/core/joins.rs
@@ -32,7 +32,7 @@ fn test_chunked_left_join() -> PolarsResult<()> {
         "plays" => ["guitar", "bass", "guitar"],
         "band" => [Some("beatles"), Some("beatles"), None],
     ]?;
-    assert!(out.frame_equal_missing(&expected));
+    assert!(out.equals_missing(&expected));
 
     Ok(())
 }

--- a/crates/polars/tests/it/core/joins.rs
+++ b/crates/polars/tests/it/core/joins.rs
@@ -71,7 +71,7 @@ fn test_inner_join() {
         .unwrap();
 
         println!("{}", joined);
-        assert!(joined.frame_equal(&true_df));
+        assert!(joined.equals(&true_df));
     }
 }
 
@@ -377,7 +377,7 @@ fn unit_df_join() -> PolarsResult<()> {
         "b" => [2],
         "b_right" => [1]
     ]?;
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
     Ok(())
 }
 

--- a/crates/polars/tests/it/core/ops/take.rs
+++ b/crates/polars/tests/it/core/ops/take.rs
@@ -10,5 +10,5 @@ fn test_list_gather_nulls_and_empty() {
         .collect_ca("");
     let out = b.take(&indices).unwrap();
     let expected = Series::new("", &[None, Some(a), None]);
-    assert!(out.series_equal_missing(&expected))
+    assert!(out.equals_missing(&expected))
 }

--- a/crates/polars/tests/it/core/pivot.rs
+++ b/crates/polars/tests/it/core/pivot.rs
@@ -241,7 +241,7 @@ fn test_pivot_datetime() -> PolarsResult<()> {
         "x" => [150],
         "y" => [420]
     ]?;
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
 
     Ok(())
 }

--- a/crates/polars/tests/it/core/pivot.rs
+++ b/crates/polars/tests/it/core/pivot.rs
@@ -19,7 +19,7 @@ fn test_pivot_date() -> PolarsResult<()> {
         "B" => [8i32, 2, 3, 6],
         "1972-09-27" => [first, 3, 2, 2]
     ]?;
-    assert!(out.frame_equal_missing(&expected));
+    assert!(out.equals_missing(&expected));
 
     let mut out = pivot_stable(&df, ["C"], ["B"], ["A"], true, Some(PivotAgg::First), None)?;
     out.try_apply("1", |s| {
@@ -31,7 +31,7 @@ fn test_pivot_date() -> PolarsResult<()> {
         "B" => [8i32, 2, 3, 6],
         "1" => ["1972-27-09", "1972-27-09", "1972-27-09", "1972-27-09"]
     ]?;
-    assert!(out.frame_equal_missing(&expected));
+    assert!(out.equals_missing(&expected));
 
     Ok(())
 }
@@ -161,7 +161,7 @@ fn test_pivot_new() -> PolarsResult<()> {
         "large" => [Some(4), None, Some(4), Some(7)],
         "small" => [1, 6, 5, 6],
     ]?;
-    assert!(out.frame_equal_missing(&expected));
+    assert!(out.equals_missing(&expected));
 
     let out = pivot_stable(
         &df,
@@ -181,7 +181,7 @@ fn test_pivot_new() -> PolarsResult<()> {
         "jam" => [1, 3, 4, 13],
         "potato" => [None, None, Some(5), None]
     ]?;
-    assert!(out.frame_equal_missing(&expected));
+    assert!(out.equals_missing(&expected));
 
     Ok(())
 }
@@ -209,7 +209,7 @@ fn test_pivot_2() -> PolarsResult<()> {
         "act" => [None, None, Some(1.)],
         "test" => [Some(0.4), Some(0.2), None],
     ]?;
-    assert!(out.frame_equal_missing(&expected));
+    assert!(out.equals_missing(&expected));
 
     Ok(())
 }

--- a/crates/polars/tests/it/core/utils.rs
+++ b/crates/polars/tests/it/core/utils.rs
@@ -14,6 +14,6 @@ fn test_df_macro_trailing_commas() -> PolarsResult<()> {
         "c" => &[1, 2],
     }?;
 
-    assert!(a.frame_equal(&b));
+    assert!(a.equals(&b));
     Ok(())
 }

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -197,7 +197,7 @@ fn test_missing_data() {
     assert!(df
         .column("column_2")
         .unwrap()
-        .series_equal_missing(&Series::new("column_2", &[Some(2_i64), None])));
+        .equals_missing(&Series::new("column_2", &[Some(2_i64), None])));
     assert!(df
         .column("column_3")
         .unwrap()

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -193,7 +193,7 @@ fn test_missing_data() {
     assert!(df
         .column("column_1")
         .unwrap()
-        .series_equal(&Series::new("column_1", &[1_i64, 1])));
+        .equals(&Series::new("column_1", &[1_i64, 1])));
     assert!(df
         .column("column_2")
         .unwrap()
@@ -201,7 +201,7 @@ fn test_missing_data() {
     assert!(df
         .column("column_3")
         .unwrap()
-        .series_equal(&Series::new("column_3", &[3_i64, 3])));
+        .equals(&Series::new("column_3", &[3_i64, 3])));
 }
 
 #[test]
@@ -216,7 +216,7 @@ fn test_escape_comma() {
     assert!(df
         .column("column_3")
         .unwrap()
-        .series_equal(&Series::new("column_3", &[11_i64, 12])));
+        .equals(&Series::new("column_3", &[11_i64, 12])));
 }
 
 #[test]
@@ -228,7 +228,7 @@ fn test_escape_double_quotes() {
     let file = Cursor::new(csv);
     let df = CsvReader::new(file).finish().unwrap();
     assert_eq!(df.shape(), (2, 3));
-    assert!(df.column("column_2").unwrap().series_equal(&Series::new(
+    assert!(df.column("column_2").unwrap().equals(&Series::new(
         "column_2",
         &[
             r#"with "double quotes" US"#,
@@ -285,7 +285,7 @@ hello,","," ",world,"!"
         assert!(df
             .column(col)
             .unwrap()
-            .series_equal(&Series::new(col, &[&**val; 4])));
+            .equals(&Series::new(col, &[&**val; 4])));
     }
 }
 
@@ -304,7 +304,7 @@ versions of Lorem Ipsum.",11
     let file = Cursor::new(csv);
     let df = CsvReader::new(file).finish().unwrap();
 
-    assert!(df.column("column_2").unwrap().series_equal(&Series::new(
+    assert!(df.column("column_2").unwrap().equals(&Series::new(
         "column_2",
         &[
             r#"Lorem Ipsum is simply dummy text of the printing and typesetting

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -607,7 +607,7 @@ bar,bar";
         "a" => ["foo", "bar"],
         "b" => ["foo", "bar"]
     ]?;
-    assert!(df.frame_equal(&expect));
+    assert!(df.equals(&expect));
     Ok(())
 }
 
@@ -1097,7 +1097,7 @@ fn test_whitespace_skipping() -> PolarsResult<()> {
         "a" => [12i64],
         "b" => [1435i64],
     ]?;
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
 
     Ok(())
 }

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -526,7 +526,7 @@ fn test_missing_fields() -> PolarsResult<()> {
         "column_4" => [Some(4), None, Some(4), None],
         "column_5" => [Some(5), None, Some(5), None]
     ]?;
-    assert!(df.frame_equal_missing(&expect));
+    assert!(df.equals_missing(&expect));
     Ok(())
 }
 
@@ -917,7 +917,7 @@ fn test_quoted_bool_ints() -> PolarsResult<()> {
         "bar" => [4, 5, 6],
         "baz" => [false, false, true],
     ]?;
-    assert!(df.frame_equal_missing(&expected));
+    assert!(df.equals_missing(&expected));
 
     Ok(())
 }
@@ -993,7 +993,7 @@ fn test_empty_string_cols() -> PolarsResult<()> {
         "column_1" => [None, Some("abc"), None, Some("xyz")],
         "column_2" => [None, Some(333i64), Some(666), Some(999)]
     ]?;
-    assert!(df.frame_equal_missing(&expected));
+    assert!(df.equals_missing(&expected));
     Ok(())
 }
 

--- a/crates/polars/tests/it/io/ipc_stream.rs
+++ b/crates/polars/tests/it/io/ipc_stream.rs
@@ -23,7 +23,7 @@ mod test {
         buf.set_position(0);
 
         let df_read = IpcStreamReader::new(buf).finish().unwrap();
-        assert!(df.frame_equal(&df_read));
+        assert!(df.equals(&df_read));
     }
 
     #[test]
@@ -42,7 +42,7 @@ mod test {
             .finish()
             .unwrap();
         assert_eq!(df_read.shape(), (3, 2));
-        df_read.frame_equal(&expected);
+        df_read.equals(&expected);
     }
 
     #[test]
@@ -60,7 +60,7 @@ mod test {
             .with_columns(Some(vec!["c".to_string(), "b".to_string()]))
             .finish()
             .unwrap();
-        df_read.frame_equal(&expected);
+        df_read.equals(&expected);
 
         let mut buf: Cursor<Vec<u8>> = Cursor::new(Vec::new());
         let mut df = df![
@@ -90,7 +90,7 @@ mod test {
             ]))
             .finish()
             .unwrap();
-        df_read.frame_equal(&expected);
+        df_read.equals(&expected);
     }
 
     #[test]
@@ -117,7 +117,7 @@ mod test {
             let df_read = IpcStreamReader::new(buf)
                 .finish()
                 .unwrap_or_else(|_| panic!("IPC reader: {:?}", compression));
-            assert!(df.frame_equal(&df_read));
+            assert!(df.equals(&df_read));
         }
     }
 
@@ -133,6 +133,6 @@ mod test {
         buf.set_position(0);
 
         let df_read = IpcStreamReader::new(buf).finish().unwrap();
-        assert!(df.frame_equal(&df_read));
+        assert!(df.equals(&df_read));
     }
 }

--- a/crates/polars/tests/it/io/json.rs
+++ b/crates/polars/tests/it/io/json.rs
@@ -126,7 +126,7 @@ fn read_ndjson_with_trailing_newline() {
         "Column1" => ["Value1"]
     }
     .unwrap();
-    assert!(expected.frame_equal(&df));
+    assert!(expected.equals(&df));
 }
 #[test]
 #[cfg(feature = "dtype-struct")]

--- a/crates/polars/tests/it/io/parquet.rs
+++ b/crates/polars/tests/it/io/parquet.rs
@@ -15,6 +15,6 @@ fn test_vstack_empty_3220() -> PolarsResult<()> {
     let mut buf = Cursor::new(Vec::new());
     ParquetWriter::new(&mut buf).finish(&mut stacked)?;
     let read_df = ParquetReader::new(buf).finish()?;
-    assert!(stacked.frame_equal(&read_df));
+    assert!(stacked.equals(&read_df));
     Ok(())
 }

--- a/crates/polars/tests/it/lazy/aggregation.rs
+++ b/crates/polars/tests/it/lazy/aggregation.rs
@@ -10,21 +10,21 @@ fn test_lazy_df_aggregations() {
         .min()
         .collect()
         .unwrap()
-        .frame_equal_missing(&df.min()));
+        .equals_missing(&df.min()));
     assert!(df
         .clone()
         .lazy()
         .median()
         .collect()
         .unwrap()
-        .frame_equal_missing(&df.median()));
+        .equals_missing(&df.median()));
     assert!(df
         .clone()
         .lazy()
         .quantile(lit(0.5), QuantileInterpolOptions::default())
         .collect()
         .unwrap()
-        .frame_equal_missing(
+        .equals_missing(
             &df.quantile(0.5, QuantileInterpolOptions::default())
                 .unwrap()
         ));

--- a/crates/polars/tests/it/lazy/cse.rs
+++ b/crates/polars/tests/it/lazy/cse.rs
@@ -34,7 +34,7 @@ fn test_cse_union_schema_6504() -> PolarsResult<()> {
         "a" => [1, 0],
         "b" => [2, 1],
     ]?;
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
 
     Ok(())
 }

--- a/crates/polars/tests/it/lazy/expressions/apply.rs
+++ b/crates/polars/tests/it/lazy/expressions/apply.rs
@@ -78,7 +78,7 @@ fn test_expand_list() -> PolarsResult<()> {
         "b" => [2, 5]
     ]?;
 
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
 
     Ok(())
 }

--- a/crates/polars/tests/it/lazy/expressions/arity.rs
+++ b/crates/polars/tests/it/lazy/expressions/arity.rs
@@ -74,7 +74,7 @@ fn includes_null_predicate_3038() -> PolarsResult<()> {
         "a" => [Some("a1"), None, None],
         "b" => [Some("good hit"), None, None],
     }?;
-    assert!(res.frame_equal_missing(&exp_df));
+    assert!(res.equals_missing(&exp_df));
 
     let df = df! {
         "a" => ["a1", "a2", "a3", "a4", "a2"],
@@ -108,7 +108,7 @@ fn includes_null_predicate_3038() -> PolarsResult<()> {
         "b" => [Some("tree"), None, None, None, None],
         "c" => ["ok1", "ok2", "ft", "ft", "ok2"]
     }?;
-    assert!(res.frame_equal_missing(&exp_df));
+    assert!(res.equals_missing(&exp_df));
 
     Ok(())
 }
@@ -173,7 +173,7 @@ fn test_when_then_otherwise_single_bool() -> PolarsResult<()> {
         "sum_null_prop" => [Some(1), None]
     ]?;
 
-    assert!(out.frame_equal_missing(&expected));
+    assert!(out.equals_missing(&expected));
 
     Ok(())
 }
@@ -225,7 +225,7 @@ fn test_when_then_otherwise_sum_in_agg() -> PolarsResult<()> {
         "dist_a" => [None, Some(1.0f64)],
         "dist_b" => [Some(1.0f64), None]
     ]?;
-    assert!(q.collect()?.frame_equal_missing(&expected));
+    assert!(q.collect()?.equals_missing(&expected));
 
     Ok(())
 }

--- a/crates/polars/tests/it/lazy/expressions/arity.rs
+++ b/crates/polars/tests/it/lazy/expressions/arity.rs
@@ -200,7 +200,7 @@ fn test_update_groups_in_cast() -> PolarsResult<()> {
         "id"=> [AnyValue::List(Series::new("", [-2i64, -1])), AnyValue::List(Series::new("", [-2i64, -1, -1]))]
     ]?;
 
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
     Ok(())
 }
 

--- a/crates/polars/tests/it/lazy/expressions/expand.rs
+++ b/crates/polars/tests/it/lazy/expressions/expand.rs
@@ -40,7 +40,7 @@ fn test_expand_datetimes_3042() -> PolarsResult<()> {
         "dt1" => ["01/01/2020", "01/08/2020", "01/15/2020"],
         "dt2" => ["01/01/2020", "01/08/2020", "01/15/2020"],
     ]?;
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
 
     Ok(())
 }

--- a/crates/polars/tests/it/lazy/expressions/window.rs
+++ b/crates/polars/tests/it/lazy/expressions/window.rs
@@ -243,7 +243,7 @@ fn test_window_mapping() -> PolarsResult<()> {
         ])
         .collect()?;
     let expected = Series::new("foo", [None, Some(3), None, Some(-1), Some(-1)]);
-    assert!(out.column("foo")?.series_equal_missing(&expected));
+    assert!(out.column("foo")?.equals_missing(&expected));
 
     // now sorted
     // this will trigger a fast path
@@ -286,7 +286,7 @@ fn test_window_mapping() -> PolarsResult<()> {
         .collect()?;
 
     let expected = Series::new("foo", [None, Some(-1), None, Some(3), Some(-1)]);
-    assert!(out.column("foo")?.series_equal_missing(&expected));
+    assert!(out.column("foo")?.equals_missing(&expected));
 
     Ok(())
 }

--- a/crates/polars/tests/it/lazy/expressions/window.rs
+++ b/crates/polars/tests/it/lazy/expressions/window.rs
@@ -196,7 +196,7 @@ fn test_window_mapping() -> PolarsResult<()> {
         .select([col("A").over([col("fruits")])])
         .collect()?;
 
-    assert!(out.column("A")?.series_equal(df.column("A")?));
+    assert!(out.column("A")?.equals(df.column("A")?));
 
     let out = df
         .clone()
@@ -213,7 +213,7 @@ fn test_window_mapping() -> PolarsResult<()> {
         .collect()?;
 
     let expected = Series::new("foo", [11, 12, 13, 14, 15]);
-    assert!(out.column("foo")?.series_equal(&expected));
+    assert!(out.column("foo")?.equals(&expected));
 
     let out = df
         .clone()
@@ -228,7 +228,7 @@ fn test_window_mapping() -> PolarsResult<()> {
         ])
         .collect()?;
     let expected = Series::new("foo", [11, 12, 8, 9, 15]);
-    assert!(out.column("foo")?.series_equal(&expected));
+    assert!(out.column("foo")?.equals(&expected));
 
     let out = df
         .clone()
@@ -255,7 +255,7 @@ fn test_window_mapping() -> PolarsResult<()> {
         .select([(lit(10) + col("A")).alias("foo").over([col("fruits")])])
         .collect()?;
     let expected = Series::new("foo", [13, 14, 11, 12, 15]);
-    assert!(out.column("foo")?.series_equal(&expected));
+    assert!(out.column("foo")?.equals(&expected));
 
     let out = df
         .clone()
@@ -271,7 +271,7 @@ fn test_window_mapping() -> PolarsResult<()> {
         .collect()?;
 
     let expected = Series::new("foo", [8, 9, 11, 12, 15]);
-    assert!(out.column("foo")?.series_equal(&expected));
+    assert!(out.column("foo")?.equals(&expected));
 
     let out = df
         .lazy()

--- a/crates/polars/tests/it/lazy/expressions/window.rs
+++ b/crates/polars/tests/it/lazy/expressions/window.rs
@@ -64,7 +64,7 @@ fn test_shift_and_fill_window_function() -> PolarsResult<()> {
         ])
         .collect()?;
 
-    assert!(out1.frame_equal(&out2));
+    assert!(out1.equals(&out2));
 
     Ok(())
 }
@@ -331,7 +331,7 @@ fn test_window_exprs_in_binary_exprs() -> PolarsResult<()> {
         "stdized3" => [0]
     ]?;
 
-    assert!(df.frame_equal(&expected));
+    assert!(df.equals(&expected));
 
     Ok(())
 }
@@ -353,7 +353,7 @@ fn test_window_exprs_any_all() -> PolarsResult<()> {
         "any" => [false, true, false, false, true, true, true, true],
         "all" => [false, true, false, false, false, false, true, true],
     ]?;
-    assert!(df.frame_equal(&expected));
+    assert!(df.equals(&expected));
     Ok(())
 }
 

--- a/crates/polars/tests/it/lazy/functions.rs
+++ b/crates/polars/tests/it/lazy/functions.rs
@@ -24,5 +24,5 @@ fn test_format_str() {
     ]
     .unwrap();
 
-    assert!(out.frame_equal_missing(&expected));
+    assert!(out.equals_missing(&expected));
 }

--- a/crates/polars/tests/it/lazy/group_by.rs
+++ b/crates/polars/tests/it/lazy/group_by.rs
@@ -50,7 +50,7 @@ fn test_filter_after_tail() -> PolarsResult<()> {
         "a" => ["bar"],
         "b" => [3]
     ]?;
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
 
     Ok(())
 }

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -48,7 +48,7 @@ fn filter_true_lit() -> PolarsResult<()> {
         .collect()?;
     let res = with_true.vstack(&with_not_true)?;
     let res = res.vstack(&with_null)?;
-    assert!(res.frame_equal_missing(&df));
+    assert!(res.equals_missing(&df));
     Ok(())
 }
 
@@ -169,7 +169,7 @@ fn test_predicate_pushdown_blocked_by_outer_join() -> PolarsResult<()> {
         "b" => ["b1"],
         "c" => [null],
     ]?;
-    assert!(out.frame_equal_missing(&expected));
+    assert!(out.equals_missing(&expected));
     Ok(())
 }
 

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -19,7 +19,7 @@ fn test_predicate_after_renaming() -> PolarsResult<()> {
         "foo2" => [2],
         "bar2" => [2],
     ]?;
-    assert!(df.frame_equal(&expected));
+    assert!(df.equals(&expected));
 
     Ok(())
 }
@@ -147,7 +147,7 @@ fn test_is_in_categorical_3420() -> PolarsResult<()> {
         "b" => [1, 2, 3]
     ]?;
     expected.try_apply("a", |s| s.cast(&DataType::Categorical(None)))?;
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
     Ok(())
 }
 
@@ -220,7 +220,7 @@ fn test_count_blocked_at_union_3963() -> PolarsResult<()> {
         .filter(count().over([col("k")]).gt(lit(1)))
         .collect()?;
 
-        assert!(out.frame_equal(&expected));
+        assert!(out.equals(&expected));
     }
 
     Ok(())

--- a/crates/polars/tests/it/lazy/projection_queries.rs
+++ b/crates/polars/tests/it/lazy/projection_queries.rs
@@ -29,7 +29,7 @@ fn test_swap_rename() -> PolarsResult<()> {
         "b" => [1],
         "a" => [2],
     ]?;
-    assert!(df.frame_equal(&expected));
+    assert!(df.equals(&expected));
     Ok(())
 }
 
@@ -114,7 +114,7 @@ fn test_many_aliasing_projections_5070() -> PolarsResult<()> {
         "val" => [2, 3],
         "output" => [0, 1],
     ]?;
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
 
     Ok(())
 }
@@ -151,7 +151,7 @@ fn test_projection_5086() -> PolarsResult<()> {
         "keep" => [true, false, false, true]
     ]?;
 
-    assert!(out.frame_equal(&expected));
+    assert!(out.equals(&expected));
 
     Ok(())
 }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1127,7 +1127,7 @@ impl PyDataFrame {
 
     pub fn equals(&self, other: &PyDataFrame, null_equal: bool) -> bool {
         if null_equal {
-            self.df.frame_equal_missing(&other.df)
+            self.df.equals_missing(&other.df)
         } else {
             self.df.equals(&other.df)
         }

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1129,7 +1129,7 @@ impl PyDataFrame {
         if null_equal {
             self.df.frame_equal_missing(&other.df)
         } else {
-            self.df.frame_equal(&other.df)
+            self.df.equals(&other.df)
         }
     }
 

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -308,7 +308,7 @@ impl PySeries {
         if null_equal {
             self.series.series_equal_missing(&other.series)
         } else {
-            self.series.series_equal(&other.series)
+            self.series.equals(&other.series)
         }
     }
 

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -306,7 +306,7 @@ impl PySeries {
             return false;
         }
         if null_equal {
-            self.series.series_equal_missing(&other.series)
+            self.series.equals_missing(&other.series)
         } else {
             self.series.equals(&other.series)
         }


### PR DESCRIPTION
Followup of #12618 for the Rust side.

This mostly hits testing code.

#### Changes

Rename the following methods:
* `series_equal` -> `equals`
* `series_equal_missing` -> `equals_missing`
* `frame_equal` -> `equals`
* `frame_equal_missing` -> `equals_missing`
* `frame_equal_schema` -> `schema_equal` (wasn't quite sure about this one - it checks schema equality)