### PR TITLE
fix: fix carrying over infinity into other windows

### DIFF
--- a/crates/polars-arrow/src/legacy/data_types.rs
+++ b/crates/polars-arrow/src/legacy/data_types.rs
@@ -20,6 +20,13 @@ pub unsafe trait IsFloat: private::Sealed {
     {
         false
     }
+    #[allow(clippy::wrong_self_convention)]
+    fn is_finite(&self) -> bool
+    where
+        Self: Sized,
+    {
+        false
+    }
 }
 
 unsafe impl IsFloat for i8 {}
@@ -74,6 +81,11 @@ macro_rules! impl_is_float {
             #[inline]
             fn is_nan(&self) -> bool {
                 <$tp>::is_nan(*self)
+            }
+
+            #[inline]
+            fn is_finite(&self) -> bool {
+                <$tp>::is_finite(*self)
             }
         }
     };

--- a/crates/polars-arrow/src/legacy/data_types.rs
+++ b/crates/polars-arrow/src/legacy/data_types.rs
@@ -25,7 +25,7 @@ pub unsafe trait IsFloat: private::Sealed {
     where
         Self: Sized,
     {
-        false
+        true
     }
 }
 

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/sum.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/sum.rs
@@ -36,7 +36,7 @@ impl<'a, T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign>
                 // we are in bounds
                 let leaving_value = self.slice.get_unchecked(idx);
 
-                if T::is_float() && leaving_value.is_nan() {
+                if T::is_float() && !leaving_value.is_finite() {
                     recompute_sum = true;
                     break;
                 }

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/variance.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/variance.rs
@@ -43,7 +43,7 @@ impl<'a, T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign + Mul<
                 // we are in bounds
                 let leaving_value = self.slice.get_unchecked(idx);
 
-                if T::is_float() && leaving_value.is_nan() {
+                if T::is_float() && !leaving_value.is_finite() {
                     recompute_sum = true;
                     break;
                 }

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/sum.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/sum.rs
@@ -73,7 +73,7 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T>> RollingAgg
                     let leaving_value = self.slice.get_unchecked(idx);
 
                     // if the leaving value is nan we need to recompute the window
-                    if T::is_float() && leaving_value.is_nan() {
+                    if T::is_float() && !leaving_value.is_finite() {
                         recompute_sum = true;
                         break;
                     }

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/variance.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/variance.rs
@@ -74,7 +74,7 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T> + Mul<Outpu
                     let leaving_value = *self.slice.get_unchecked(idx);
 
                     // if the leaving value is nan we need to recompute the window
-                    if T::is_float() && leaving_value.is_nan() {
+                    if T::is_float() && !leaving_value.is_finite() {
                         recompute_sum = true;
                         break;
                     }

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -212,6 +212,13 @@ def test_rolling_crossing_dst(
     assert_frame_equal(result, expected)
 
 
+def test_rolling_infinity() -> None:
+    s = pl.Series("col", ["-inf", "5", "5"]).cast(pl.Float64)
+    s = s.rolling_mean(2)
+    expected = pl.Series("col", [None, "-inf", "5"]).cast(pl.Float64)
+    assert_series_equal(s, expected)
+
+
 def test_rolling_extrema() -> None:
     # sorted data and nulls flags trigger different kernels
     df = (


### PR DESCRIPTION
fix #12682 12682

infinity skips the `is_nan` check and is carried over to non-related windows. 