### PR TITLE
fix: support `append`/`extend` with null series (#11824)

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -3435,7 +3435,7 @@ fn ensure_can_extend(left: &Series, right: &Series) -> PolarsResult<()> {
         left.name(), right.name(),
     );
     polars_ensure!(
-        left.dtype() == right.dtype(),
+        left.dtype() == right.dtype() || *right.dtype() == DataType::Null,
         ShapeMismatch: "unable to vstack, dtypes for column {:?} don't match: `{}` and `{}`",
         left.name(), left.dtype(), right.dtype(),
     );

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -251,7 +251,12 @@ impl Series {
     ///
     /// See [`ChunkedArray::append`] and [`ChunkedArray::extend`].
     pub fn append(&mut self, other: &Series) -> PolarsResult<&mut Self> {
-        self._get_inner_mut().append(other)?;
+        if *other.dtype() == DataType::Null && *self.dtype() != DataType::Null {
+            let other_null = Series::full_null(other.name(), other.len(), self.dtype());
+            self._get_inner_mut().append(&other_null)?
+        } else {
+            self._get_inner_mut().append(other)?
+        }
         Ok(self)
     }
 
@@ -264,7 +269,12 @@ impl Series {
     ///
     /// See [`ChunkedArray::extend`] and [`ChunkedArray::append`].
     pub fn extend(&mut self, other: &Series) -> PolarsResult<&mut Self> {
-        self._get_inner_mut().extend(other)?;
+        if *other.dtype() == DataType::Null && *self.dtype() != DataType::Null {
+            let other_null = Series::full_null(other.name(), other.len(), self.dtype());
+            self._get_inner_mut().extend(&other_null)?
+        } else {
+            self._get_inner_mut().extend(other)?
+        }
         Ok(self)
     }
 

--- a/py-polars/tests/unit/dataframe/test_vstack.py
+++ b/py-polars/tests/unit/dataframe/test_vstack.py
@@ -58,3 +58,16 @@ def test_vstack_column_name_mismatch(df1: pl.DataFrame) -> None:
 
     with pytest.raises(pl.ShapeError):
         df1.vstack(df2)
+
+
+def test_vstack_with_null_column() -> None:
+    df1 = pl.DataFrame({"x": [3.5]}, schema={"x": pl.Float64})
+    df2 = pl.DataFrame({"x": [None]}, schema={"x": pl.Null})
+
+    result = df1.vstack(df2)
+    expected = pl.DataFrame({"x": [3.5, None]}, schema={"x": pl.Float64})
+
+    assert_frame_equal(result, expected)
+
+    with pytest.raises(pl.ShapeError):
+        df2.vstack(df1)

--- a/py-polars/tests/unit/series/test_append.py
+++ b/py-polars/tests/unit/series/test_append.py
@@ -94,3 +94,15 @@ def test_struct_schema_on_append_extend_3452() -> None:
         ),
     ):
         housing1.extend(housing2)
+
+
+def test_append_null_series() -> None:
+    a = pl.Series("a", [1, 2], pl.Int64)
+    b = pl.Series("b", [None, None], pl.Null)
+
+    result = a.append(b)
+
+    expected = pl.Series("a", [1, 2, None, None], pl.Int64)
+    assert_series_equal(a, expected)
+    assert_series_equal(result, expected)
+    assert a.n_chunks() == 2

--- a/py-polars/tests/unit/series/test_extend.py
+++ b/py-polars/tests/unit/series/test_extend.py
@@ -32,3 +32,15 @@ def test_extend_bad_input() -> None:
 
     with pytest.raises(AttributeError):
         a.extend(b)  # type: ignore[arg-type]
+
+
+def test_extend_with_null_series() -> None:
+    a = pl.Series("a", [1, 2], pl.Int64)
+    b = pl.Series("b", [None, None], pl.Null)
+
+    result = a.extend(b)
+
+    expected = pl.Series("a", [1, 2, None, None], pl.Int64)
+    assert_series_equal(a, expected)
+    assert_series_equal(result, expected)
+    assert a.n_chunks() == 1


### PR DESCRIPTION
This PR is a partial fix for issue https://github.com/pola-rs/polars/issues/11824. It solves the case when one cannot `df1.vstack(df2)` because eg. `df1["x"].dtype == pl.Int64` but `df2["x"].dtype == pl.Null`.

https://github.com/pola-rs/polars/issues/11824 also mentions a more complex example, when we get conflict between eg. `List[Int64]` and `List[Null]`. This is related to behaviour introduced by PR https://github.com/pola-rs/polars/pull/12677 which produces these `List[Null]` columns when parsing empty JSON arrays.