### PR TITLE
feat(python): enhance expression-level `filter` syntax with support for multiple predicates and kwargs

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4102,16 +4102,18 @@ class DataFrame:
         **constraints: Any,
     ) -> DataFrame:
         """
-        Filter the rows in the DataFrame based on a predicate expression.
+        Filter the rows in the DataFrame based on one or more predicate expressions.
 
         The original order of the remaining rows is preserved.
 
         Parameters
         ----------
         predicates
-            Expression that evaluates to a boolean Series.
+            Expression(s) that evaluates to a boolean Series.
         constraints
-            Column filters. Use name=value to filter column name by the supplied value.
+            Column filters; use `name = value` to filter columns by the supplied value.
+            Each constraint will behave the same as `pl.col(name).eq(value)`, and
+            will be implicitly joined with the other filter conditions using `&`.
 
         Examples
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -45,6 +45,7 @@ from polars.utils._parse_expr_input import (
     parse_as_expression,
     parse_as_list_of_expressions,
 )
+from polars.utils._wrap import wrap_expr
 from polars.utils.convert import _negate_duration, _timedelta_to_pl_duration
 from polars.utils.deprecation import (
     deprecate_function,
@@ -52,6 +53,7 @@ from polars.utils.deprecation import (
     deprecate_renamed_function,
     deprecate_renamed_parameter,
     deprecate_saturating,
+    issue_deprecation_warning,
 )
 from polars.utils.meta import threadpool_size
 from polars.utils.various import (
@@ -3892,9 +3894,13 @@ class Expr:
         """
         return self._from_pyexpr(self._pyexpr.rle_id())
 
-    def filter(self, predicate: Expr) -> Self:
+    def filter(
+        self,
+        *predicates: IntoExprColumn | Iterable[IntoExprColumn],
+        **constraints: Any,
+    ) -> Self:
         """
-        Filter a single column.
+        Filter the expression based on one or more predicate expressions.
 
         The original order of the remaining elements is preserved.
 
@@ -3903,8 +3909,12 @@ class Expr:
 
         Parameters
         ----------
-        predicate
-            Boolean expression.
+        predicates
+            Expression(s) that evaluates to a boolean Series.
+        constraints
+            Column filters; use `name = value` to filter columns by the supplied value.
+            Each constraint will behave the same as `pl.col(name).eq(value)`, and
+            will be implicitly joined with the other filter conditions using `&`.
 
         Examples
         --------
@@ -3928,8 +3938,52 @@ class Expr:
         │ g2        ┆ 0   ┆ 3   │
         └───────────┴─────┴─────┘
 
+        Filter expressions can also take constraints as keyword arguments.
+
+        >>> import polars.selectors as cs
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "key": ["a", "a", "a", "a", "b", "b", "b", "b", "b"],
+        ...         "n": [1, 2, 2, 3, 1, 3, 3, 2, 3],
+        ...     },
+        ... )
+        >>> df.group_by("key").agg(
+        ...     n_1=pl.col("n").filter(n=1).sum(),
+        ...     n_2=pl.col("n").filter(n=2).sum(),
+        ...     n_3=pl.col("n").filter(n=3).sum(),
+        ... ).sort(by="key")
+        shape: (2, 4)
+        ┌─────┬─────┬─────┬─────┐
+        │ key ┆ n_1 ┆ n_2 ┆ n_3 │
+        │ --- ┆ --- ┆ --- ┆ --- │
+        │ str ┆ i64 ┆ i64 ┆ i64 │
+        ╞═════╪═════╪═════╪═════╡
+        │ a   ┆ 1   ┆ 4   ┆ 3   │
+        │ b   ┆ 1   ┆ 2   ┆ 9   │
+        └─────┴─────┴─────┴─────┘
+
         """
-        return self._from_pyexpr(self._pyexpr.filter(predicate._pyexpr))
+        all_predicates: list[pl.Expr] = []
+        for p in predicates:
+            all_predicates.extend(wrap_expr(x) for x in parse_as_list_of_expressions(p))
+
+        if "predicate" in constraints:
+            if isinstance(constraints["predicate"], pl.Expr):
+                all_predicates.append(constraints.pop("predicate"))
+                issue_deprecation_warning(
+                    "`filter` no longer takes a 'predicate' parameter.\n"
+                    "To silence this warning you should omit the keyword and pass "
+                    "as a positional argument instead.",
+                    version="0.19.17",
+                )
+        all_predicates.extend(
+            F.col(name).eq_missing(value) for name, value in constraints.items()
+        )
+        if not all_predicates:
+            raise ValueError("No predicates or constraints provided to `filter`.")
+
+        combined_predicate = F.all_horizontal(*all_predicates)
+        return self._from_pyexpr(self._pyexpr.filter(combined_predicate._pyexpr))
 
     def where(self, predicate: Expr) -> Self:
         """

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2592,7 +2592,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         predicates
             Expression that evaluates to a boolean Series.
         constraints
-            Column filters. Use name=value to filter column name by the supplied value.
+            Column filters; use `name = value` to filter columns by the supplied value.
+            Each constraint will behave the same as `pl.col(name).eq(value)`, and
+            will be implicitly joined with the other filter conditions using `&`.
 
         Examples
         --------
@@ -2724,7 +2726,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         # unpack equality constraints from kwargs
         all_predicates.extend(
-            F.col(name).eq(value) for name, value in constraints.items()
+            F.col(name).eq_missing(value) for name, value in constraints.items()
         )
         if not (all_predicates or boolean_masks):
             raise ValueError("No predicates or constraints provided to `filter`.")

--- a/py-polars/tests/unit/functions/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/functions/aggregation/test_horizontal.py
@@ -36,6 +36,14 @@ def test_all_any_horizontally() -> None:
     )
     assert_frame_equal(result, expected)
 
+    # note: a kwargs filter will use an internal call to all_horizontal
+    dfltr = df.lazy().filter(var1=None, var3=False)
+    assert dfltr.collect().rows() == [(None, None, False)]
+
+    # confirm that we reduce the horizontal filter components
+    # (eg: explain does not contain an "all_horizontal" node)
+    assert "horizontal" not in dfltr.explain().lower()
+
 
 def test_all_any_accept_expr() -> None:
     lf = pl.LazyFrame(

--- a/py-polars/tests/unit/namespaces/test_meta.py
+++ b/py-polars/tests/unit/namespaces/test_meta.py
@@ -26,7 +26,7 @@ def test_root_and_output_names() -> None:
     assert e.meta.output_name() == "foo"
     assert e.meta.root_names() == ["foo", "bar"]
 
-    e = pl.col("foo").filter(pl.col("bar") == 13)
+    e = pl.col("foo").filter(bar=13)
     assert e.meta.output_name() == "foo"
     assert e.meta.root_names() == ["foo", "bar"]
 

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -85,11 +85,7 @@ def test_list_aggregation_that_filters_all_data_6017() -> None:
     out = (
         pl.DataFrame({"col_to_group_by": [2], "flt": [1672740910.967138], "col3": [1]})
         .group_by("col_to_group_by")
-        .agg(
-            (pl.col("flt").filter(pl.col("col3") == 0).diff() * 1000)
-            .diff()
-            .alias("calc")
-        )
+        .agg((pl.col("flt").filter(col3=0).diff() * 1000).diff().alias("calc"))
     )
 
     assert out.schema == {"col_to_group_by": pl.Int64, "calc": pl.List(pl.Float64)}

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -53,7 +53,14 @@ def test_group_by_filter_all_true() -> None:
     )
     out = (
         df.group_by("name")
-        .agg([pl.col("order").filter(pl.col("type") == 1).n_unique().alias("n_unique")])
+        .agg(
+            [
+                pl.col("order")
+                .filter(pl.col("order") > 0, type=1)
+                .n_unique()
+                .alias("n_unique")
+            ]
+        )
         .select("n_unique")
     )
     assert out.to_dict(as_series=False) == {"n_unique": [1, 1]}
@@ -61,11 +68,7 @@ def test_group_by_filter_all_true() -> None:
 
 def test_filter_is_in_4572() -> None:
     df = pl.DataFrame({"id": [1, 2, 1, 2], "k": ["a"] * 2 + ["b"] * 2})
-    expected = (
-        df.group_by("id")
-        .agg(pl.col("k").filter(pl.col("k") == "a").implode())
-        .sort("id")
-    )
+    expected = df.group_by("id").agg(pl.col("k").filter(k="a").implode()).sort("id")
     result = (
         df.group_by("id")
         .agg(pl.col("k").filter(pl.col("k").is_in(["a"])).implode())


### PR DESCRIPTION
Closes #12577 (following up #12603).

Adds the same support for multiple predicates and kwargs as recently added to frame-level `filter` and `when/then`.

### Example
```python
import polars as pl

df = pl.DataFrame({
    "key": ["a", "a", "a", "a", "b", "b", "b", "b", "b"],
    "n": [1, 2, 2, 3, 1, 3, 3, 2, 3],
})

df.group_by("key").agg(
    n_0 = pl.col("n").filter( n=1 ).sum(),
    n_1 = pl.col("n").filter( n=2 ).sum(),
    n_2 = pl.col("n").filter( n=3 ).sum(),
).sort(by="key")

# shape: (2, 4)
# ┌─────┬─────┬─────┬─────┐
# │ key ┆ n_0 ┆ n_1 ┆ n_2 │
# │ --- ┆ --- ┆ --- ┆ --- │
# │ str ┆ i64 ┆ i64 ┆ i64 │
# ╞═════╪═════╪═════╪═════╡
# │ a   ┆ 1   ┆ 4   ┆ 3   │
# │ b   ┆ 1   ┆ 2   ┆ 9   │
# └─────┴─────┴─────┴─────┘
```