### PR TITLE
feat(python): favour showing "adbc_driver_manager" over "adbc_driver_sqlite" in `show_versions`

### DIFF
--- a/py-polars/polars/utils/show_versions.py
+++ b/py-polars/polars/utils/show_versions.py
@@ -14,31 +14,32 @@ def show_versions() -> None:
     --------
     >>> pl.show_versions()  # doctest: +SKIP
     --------Version info---------
-    Polars:               0.19.3
+    Polars:               0.19.16
     Index type:           UInt32
-    Platform:             macOS-13.5.2-arm64-arm-64bit
-    Python:               3.11.5 (main, Aug 24 2023, 15:09:45) [Clang 14.0.3 (clang-1403.0.22.14.1)]
+    Platform:             macOS-14.1.1-arm64-arm-64bit
+    Python:               3.11.6 (main, Oct  2 2023, 13:45:54) [Clang 15.0.0 (clang-1500.0.40.1)]
     ----Optional dependencies----
-    adbc_driver_sqlite:   0.6.0
-    cloudpickle:          2.2.1
+    adbc_driver_manager:  0.8.0
+    cloudpickle:          3.0.0
     connectorx:           0.3.2
-    deltalake:            0.10.1
-    fsspec:               2023.9.1
+    deltalake:            0.13.0
+    fsspec:               2023.10.0
     gevent:               23.9.1
-    matplotlib:           3.8.0
-    numpy:                1.26.0
+    matplotlib:           3.8.2
+    numpy:                1.26.2
     openpyxl:             3.1.2
-    pandas:               2.1.0
-    pyarrow:              13.0.0
-    pydantic:             2.3.0
-    pyiceberg:            0.5.0
-    pyxlsb:               <not installed>
-    sqlalchemy:           2.0.21
+    pandas:               2.1.3
+    pyarrow:              14.0.1
+    pydantic:             2.5.2
+    pyiceberg:            0.5.1
+    pyxlsb:               1.0.10
+    sqlalchemy:           2.0.23
     xlsx2csv:             0.8.1
-    xlsxwriter:           3.1.4
+    xlsxwriter:           3.1.9
 
     """  # noqa: W505
-    # note: we import 'platform' here as a micro-optimisation for initial import
+    # note: we import 'platform' here (rather than at the top of the
+    # module) as a micro-optimisation for polars' initial import
     import platform
 
     deps = _get_dependency_info()
@@ -59,7 +60,7 @@ def show_versions() -> None:
 def _get_dependency_info() -> dict[str, str]:
     # see the list of dependencies in pyproject.toml
     opt_deps = [
-        "adbc_driver_sqlite",
+        "adbc_driver_manager",
         "cloudpickle",
         "connectorx",
         "deltalake",


### PR DESCRIPTION
More meaningful/useful to show the `adbc` driver manager version.