### PR TITLE
fix(rust): Upsample - Forward fill group

### DIFF
--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -3,7 +3,6 @@ use chrono_tz::Tz;
 use polars_core::prelude::*;
 use polars_core::utils::ensure_sorted_arg;
 use polars_ops::prelude::*;
-use chrono::NaiveDate;
 
 use crate::prelude::*;
 #[cfg(feature = "timezones")]


### PR DESCRIPTION
Previously, upsampling using the*by* parameter resulted in a DataFrame with null value for each newly added row.
Now, the group values are being forward filled, allowing the user to perform any further operation over the groups.

With the test I've wrote, the following data frame:

│ time                              ┆ groups ┆ values │
│ 2021-12-16 00:00:00 ┆ a           ┆ 1.0    │
│ 2021-12-16 00:30:00 ┆ a           ┆ 2.0    │
│ 2021-12-16 01:00:00 ┆ b           ┆ 3.0    │
│ 2021-12-16 01:30:00 ┆ b           ┆ 4.0    │
│ 2021-12-16 02:00:00 ┆ b          ┆ 5.0    │


Would have resulted in this:

│ 2021-12-16 00:00:00 ┆ a      ┆ 1.0    │
│ 2021-12-16 00:15:00 ┆ null     ┆ null   │
│ 2021-12-16 00:30:00 ┆ a      ┆ 2.0    │
│ 2021-12-16 01:00:00 ┆ b      ┆ 3.0    │
│ 2021-12-16 01:15:00 ┆ null      ┆ null   │
│ 2021-12-16 01:30:00 ┆ b      ┆ 4.0    │
│ 2021-12-16 01:45:00 ┆ null     ┆ null   │
│ 2021-12-16 02:00:00 ┆ b      ┆ 5.0    │

And will now result in this:

│ 2021-12-16 00:00:00 ┆ a      ┆ 1.0    │
│ 2021-12-16 00:15:00 ┆ a      ┆ null   │
│ 2021-12-16 00:30:00 ┆ a      ┆ 2.0    │
│ 2021-12-16 01:00:00 ┆ b      ┆ 3.0    │
│ 2021-12-16 01:15:00 ┆ b      ┆ null   │
│ 2021-12-16 01:30:00 ┆ b      ┆ 4.0    │
│ 2021-12-16 01:45:00 ┆ b      ┆ null   │
│ 2021-12-16 02:00:00 ┆ b      ┆ 5.0    │

This issue was mentioned in #5159 

