### PR TITLE
fix(python): address a numpy ndarray init regression

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1404,12 +1404,12 @@ def numpy_to_pydf(
                 if n_schema_cols == shape[0] and n_schema_cols != shape[1]:
                     orient = "col"
                     n_columns = shape[0]
-                elif data.flags["C_CONTIGUOUS"]:
+                elif data.flags["F_CONTIGUOUS"] and shape[0] == shape[1]:
+                    orient = "col"
+                    n_columns = n_schema_cols
+                else:
                     orient = "row"
                     n_columns = shape[1]
-                else:
-                    orient = "col"
-                    n_columns = shape[0]
 
             elif orient == "row":
                 n_columns = shape[1]

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -563,6 +563,14 @@ def test_init_ndarray() -> None:
     df = pl.DataFrame([np.array(test_rows[0]), np.array(test_rows[1])], orient="row")
     assert_frame_equal(df, pl.DataFrame(test_rows, orient="row"))
 
+    # round trip export/init
+    for shape in ((4, 4), (4, 8), (8, 4)):
+        np_ones = np.ones(shape=shape, dtype=np.float64)
+        names = [f"c{i}" for i in range(shape[1])]
+
+        df = pl.DataFrame(np_ones, schema=names)
+        assert_frame_equal(df, pl.DataFrame(np.asarray(df), schema=names))
+
 
 def test_init_ndarray_errors() -> None:
     # 2D array: orientation conflicts with columns


### PR DESCRIPTION
Closes #12696.

Tweaked/fixed square numpy array tiebreak resolution; could bleed out into non-square arrays. Fixed the bug and added the missing test coverage. (Strongly tempted to try simplifying the whole function later, as it is feeling a bit tangled 🤔)