### PR TITLE
docs(python): now that `scan_parquet` supports hive partitioning, remove note pointing to `scan_pyarrow_dataset`

### DIFF
--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -182,16 +182,10 @@ def scan_parquet(
     retries: int = 0,
 ) -> LazyFrame:
     """
-    Lazily read from a parquet file or multiple files via glob patterns.
+    Lazily read from a local or cloud-hosted parquet file (or files).
 
-    This allows the query optimizer to push down predicates and projections to the scan
-    level, thereby potentially reducing memory overhead.
-
-    Notes
-    -----
-    * Partitioned files:
-        If you have a directory-nested (hive-style) partitioned dataset, you should
-        use the :func:`scan_pyarrow_dataset` method to read that data instead.
+    This function allows the query optimizer to push down predicates and projections to
+    the scan level, typically increasing performance and reducing memory overhead.
 
     Parameters
     ----------


### PR DESCRIPTION
Reading from hive partitioned data now supported natively:
```
hive_partitioning (bool: True)
    Infer statistics and schema from hive partitioned URL and use them
    to prune reads.
```