### PR TITLE
docs(python): update URI prefix in examples (prefer "postgresql" to "postgres")

### DIFF
--- a/docs/src/python/user-guide/io/database.py
+++ b/docs/src/python/user-guide/io/database.py
@@ -2,7 +2,7 @@
 # --8<-- [start:read_uri]
 import polars as pl
 
-uri = "postgres://username:password@server:port/database"
+uri = "postgresql://username:password@server:port/database"
 query = "SELECT * FROM foo"
 
 pl.read_database_uri(query=query, uri=uri)
@@ -21,21 +21,21 @@ pl.read_database(query=query, connection=conn.connect())
 
 
 # --8<-- [start:adbc]
-uri = "postgres://username:password@server:port/database"
+uri = "postgresql://username:password@server:port/database"
 query = "SELECT * FROM foo"
 
 pl.read_database_uri(query=query, uri=uri, engine="adbc")
 # --8<-- [end:adbc]
 
 # --8<-- [start:write]
-uri = "postgres://username:password@server:port/database"
+uri = "postgresql://username:password@server:port/database"
 df = pl.DataFrame({"foo": [1, 2, 3]})
 
 df.write_database(table_name="records",  uri=uri)
 # --8<-- [end:write]
 
 # --8<-- [start:write_adbc]
-uri = "postgres://username:password@server:port/database"
+uri = "postgresql://username:password@server:port/database"
 df = pl.DataFrame({"foo": [1, 2, 3]})
 
 df.write_database(table_name="records", uri=uri, engine="adbc")


### PR DESCRIPTION
Closes #12697. While `libpq` typically allows both forms [^1], "postgresql" is the official URI prefix used by PostgreSQL itself, and should be preferred for maximum compatibility.

[^1]: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS