### PR TITLE
feat: enable partial predicate pushdown past window exprs

### DIFF
--- a/crates/polars-plan/src/logical_plan/lit.rs
+++ b/crates/polars-plan/src/logical_plan/lit.rs
@@ -63,6 +63,14 @@ impl LiteralValue {
         matches!(self, LiteralValue::Float32(_) | LiteralValue::Float64(_))
     }
 
+    pub(crate) fn projects_as_scalar(&self) -> bool {
+        match self {
+            LiteralValue::Range { low, high, .. } => high.saturating_sub(*low) == 1,
+            LiteralValue::Series(s) => s.len() == 1,
+            _ => true,
+        }
+    }
+
     pub fn to_anyvalue(&self) -> Option<AnyValue> {
         use LiteralValue::*;
         let av = match self {

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -88,7 +88,7 @@ impl<'a> PredicatePushDown<'a> {
 
             let local_predicates = match eligibility {
                 PushdownEligibility::Full => vec![],
-                PushdownEligibility::Partial(to_local) => {
+                PushdownEligibility::Partial { to_local } => {
                     let mut out = Vec::<Node>::with_capacity(to_local.len());
                     for key in to_local {
                         out.push(acc_predicates.remove(&key).unwrap());
@@ -242,7 +242,7 @@ impl<'a> PredicatePushDown<'a> {
 
                 let local_predicates = match pushdown_eligibility(lp.schema(lp_arena).as_ref(), &vec![], &acc_predicates, expr_arena)?.0 {
                     PushdownEligibility::Full => vec![],
-                    PushdownEligibility::Partial(to_local) => {
+                    PushdownEligibility::Partial { to_local } => {
                         let mut out = Vec::<Node>::with_capacity(to_local.len());
                         for key in to_local {
                             out.push(acc_predicates.remove(&key).unwrap());

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -75,28 +75,66 @@ impl<'a> PredicatePushDown<'a> {
         let exprs = lp.get_exprs();
 
         if has_projections {
-            // This checks the exprs in the projections at this level.
-            if exprs
-                .iter()
-                .any(|e_n| aexpr_blocks_predicate_pushdown(*e_n, expr_arena))
-            {
-                return self.no_pushdown_restart_opt(lp, acc_predicates, lp_arena, expr_arena);
-            }
-
             // projections should only have a single input.
             if inputs.len() > 1 {
                 // except for ExtContext
                 assert!(matches!(lp, ALogicalPlan::ExtContext { .. }));
             }
             let input = inputs[inputs.len() - 1];
-            let (local_predicates, projections) =
-                rewrite_projection_node(expr_arena, lp_arena, &mut acc_predicates, exprs, input);
+            let input_schema = lp_arena.get(input).schema(lp_arena);
+
+            let (eligibility, alias_rename_map) =
+                pushdown_eligibility(input_schema.as_ref(), &exprs, &acc_predicates, expr_arena)?;
+
+            let local_predicates = match eligibility {
+                PushdownEligibility::Full => vec![],
+                PushdownEligibility::Partial(to_local) => {
+                    let mut out = Vec::<Node>::with_capacity(to_local.len());
+                    for key in to_local {
+                        out.push(acc_predicates.remove(&key).unwrap());
+                    }
+                    out
+                },
+                PushdownEligibility::NoPushdown => {
+                    return self.no_pushdown_restart_opt(lp, acc_predicates, lp_arena, expr_arena)
+                },
+            };
+
+            if !alias_rename_map.is_empty() {
+                for (_, node) in acc_predicates.iter_mut() {
+                    let mut needs_rename = false;
+
+                    for (_, ae) in (&*expr_arena).iter(*node) {
+                        if let AExpr::Column(name) = ae {
+                            needs_rename |= alias_rename_map.contains_key(name);
+
+                            if needs_rename {
+                                break;
+                            }
+                        }
+                    }
+
+                    if needs_rename {
+                        let mut new_expr = node_to_expr(*node, expr_arena);
+                        new_expr.mutate().apply(|e| {
+                            if let Expr::Column(name) = e {
+                                if let Some(rename_to) = alias_rename_map.get(name) {
+                                    *name = rename_to.clone();
+                                };
+                            };
+                            true
+                        });
+                        let predicate = to_aexpr(new_expr, expr_arena);
+                        *node = predicate;
+                    }
+                }
+            }
 
             let alp = lp_arena.take(input);
             let alp = self.push_down(alp, acc_predicates, lp_arena, expr_arena)?;
             lp_arena.replace(input, alp);
 
-            let lp = lp.with_exprs_and_input(projections, inputs);
+            let lp = lp.with_exprs_and_input(exprs, inputs);
             Ok(self.optional_apply_predicate(lp, local_predicates, lp_arena, expr_arena))
         } else {
             let mut local_predicates = Vec::with_capacity(acc_predicates.len());
@@ -191,40 +229,36 @@ impl<'a> PredicatePushDown<'a> {
 
         match lp {
             Selection { predicate, input } => {
-                insert_and_combine_predicate(&mut acc_predicates, predicate, expr_arena);
+                // Use a tmp_key to avoid inadvertently combining predicates that otherwise would have
+                // been partially pushed:
+                //
+                // (1) .filter(pl.count().over("key") == 1)
+                // (2) .filter(pl.col("key") == 1)
+                //
+                // (2) can be pushed past (1) but they both have the same predicate
+                // key name in the hashtable.
+                let tmp_key = Arc::<str>::from(&*temporary_unique_key(&acc_predicates));
+                acc_predicates.insert(tmp_key.clone(), predicate);
 
-                // If the result of any predicate depends on the predicates that
-                // occur before it, then we must stop pushdown of all accumulated
-                // predicates at this level. Otherwise, if they are pushed past
-                // the boundary predicate, then the value of the boundary
-                // predicate itself will change and become incorrect.
-                // For example:
-                // (unoptimized)
-                // filter(y > 1) --> filter(x == min(x)) --> filter(y > 2)
-                //
-                // (incorrectly optimized)
-                // filter(y > 1) & filter(y > 2) --> filter(x == min(x))
-                // incorrect as min(x) in the subset where y > 2 may not be equal
-                // to min(x) in the subset where y > 1
-                //
-                // (correctly optimized)
-                // filter(y > 1) --> filter(x == min(x)) & filter(y > 2)
-                // pushdown of filter(y > 2) is correctly stopped at the boundary
-                //
-                // Assuming all predicates originate from the `Selection` node
-                // at the beginning of optimization, applying this step here
-                // guarantees that boundary predicates will not appear in other
-                // contexts. Note boundary projections are handled elsewhere.
-                let local_predicates = if acc_predicates
-                    .values()
-                    .any(|node| aexpr_blocks_predicate_pushdown(*node, expr_arena))
-                {
-                    let local_predicates = acc_predicates.values().copied().collect::<Vec<_>>();
-                    acc_predicates.clear();
-                    local_predicates
-                } else {
-                    vec![]
+                let local_predicates = match pushdown_eligibility(lp.schema(lp_arena).as_ref(), &vec![], &acc_predicates, expr_arena)?.0 {
+                    PushdownEligibility::Full => vec![],
+                    PushdownEligibility::Partial(to_local) => {
+                        let mut out = Vec::<Node>::with_capacity(to_local.len());
+                        for key in to_local {
+                            out.push(acc_predicates.remove(&key).unwrap());
+                        }
+                        out
+                    },
+                    PushdownEligibility::NoPushdown  => {
+                        let out = acc_predicates.values().copied().collect();
+                        acc_predicates.clear();
+                        out
+                    },
                 };
+
+                if let Some(predicate) = acc_predicates.remove(&tmp_key) {
+                    insert_and_combine_predicate(&mut acc_predicates, predicate, expr_arena);
+                }
 
                 let alp = lp_arena.take(input);
                 let new_input = self.push_down(alp, acc_predicates, lp_arena, expr_arena)?;

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
@@ -253,7 +253,7 @@ fn get_maybe_aliased_projection_to_input_name_map(
 pub enum PushdownEligibility {
     Full,
     // Partial can happen when there are window exprs.
-    Partial(Vec<Arc<str>>),
+    Partial { to_local: Vec<Arc<str>> },
     NoPushdown,
 }
 
@@ -473,7 +473,7 @@ pub fn pushdown_eligibility(
         len if len == acc_predicates.len() => {
             Ok((PushdownEligibility::NoPushdown, alias_to_col_map))
         },
-        _ => Ok((PushdownEligibility::Partial(to_local), alias_to_col_map)),
+        _ => Ok((PushdownEligibility::Partial { to_local }, alias_to_col_map)),
     }
 }
 

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
@@ -4,7 +4,7 @@ use polars_core::prelude::*;
 use super::keys::*;
 use crate::logical_plan::Context;
 use crate::prelude::*;
-use crate::utils::{aexpr_to_leaf_names, check_input_node, has_aexpr, rename_aexpr_leaf_names};
+use crate::utils::{aexpr_to_leaf_names, has_aexpr};
 
 trait Dsl {
     fn and(self, right: Node, arena: &mut Arena<AExpr>) -> Node;
@@ -39,6 +39,17 @@ pub(super) fn insert_and_combine_predicate(
             *existing_predicate = node
         })
         .or_insert_with(|| predicate);
+}
+
+pub(super) fn temporary_unique_key(acc_predicates: &PlHashMap<Arc<str>, Node>) -> String {
+    let mut out_key = '\u{1D17A}'.to_string();
+    let mut existing_keys = acc_predicates.keys();
+
+    while acc_predicates.contains_key(&*out_key) {
+        out_key.push_str(existing_keys.next().unwrap());
+    }
+
+    out_key
 }
 
 pub(super) fn combine_predicates<I>(iter: I, arena: &mut Arena<AExpr>) -> Node
@@ -104,200 +115,6 @@ pub(super) fn predicate_is_sort_boundary(node: Node, expr_arena: &Arena<AExpr>) 
     has_aexpr(node, expr_arena, matches)
 }
 
-/// Predicates can be renamed during pushdown to support being pushed through
-/// aliases, however this is permitted only if the alias is not preceded by any
-/// operations that change the column values. For example:
-///
-/// `col(A).alias(B)` - predicates referring to column B can be re-written to
-/// use column A, since they have the same values.
-///
-/// `col(A).sort().alias(B)` - predicates referring to column B cannot be
-/// re-written to use column A as they have different values.
-pub(super) fn projection_allows_aliased_predicate_pushdown(
-    node: Node,
-    expr_arena: &Arena<AExpr>,
-) -> bool {
-    !has_aexpr(node, expr_arena, |ae| {
-        !matches!(ae, AExpr::Column(_) | AExpr::Alias(_, _))
-    })
-}
-
-enum LoopBehavior {
-    Continue,
-    Nothing,
-}
-
-fn rename_predicate_columns_due_to_aliased_projection(
-    expr_arena: &mut Arena<AExpr>,
-    acc_predicates: &mut PlHashMap<Arc<str>, Node>,
-    projection_node: Node,
-    allow_aliased_pushdown: bool,
-    local_predicates: &mut Vec<Node>,
-) -> LoopBehavior {
-    let projection_aexpr = expr_arena.get(projection_node);
-    if let AExpr::Alias(_, alias_name) = projection_aexpr {
-        let alias_name = alias_name.clone();
-        let projection_leaves = aexpr_to_leaf_names(projection_node, expr_arena);
-
-        // this means the leaf is a literal
-        if projection_leaves.is_empty() {
-            return LoopBehavior::Nothing;
-        }
-
-        // if this alias refers to one of the predicates in the upper nodes
-        // we rename the column of the predicate before we push it downwards.
-        if let Some(predicate) = acc_predicates.remove(&alias_name) {
-            if !allow_aliased_pushdown {
-                local_predicates.push(predicate);
-                remove_predicate_refers_to_alias(acc_predicates, local_predicates, &alias_name);
-                return LoopBehavior::Continue;
-            }
-            if projection_leaves.len() == 1 {
-                // we were able to rename the alias column with the root column name
-                // before pushing down the predicate
-                let predicate =
-                    rename_aexpr_leaf_names(predicate, expr_arena, projection_leaves[0].clone());
-
-                insert_and_combine_predicate(acc_predicates, predicate, expr_arena);
-            } else {
-                // this may be a complex binary function. The predicate may only be valid
-                // on this projected column so we do filter locally.
-                local_predicates.push(predicate)
-            }
-        }
-
-        remove_predicate_refers_to_alias(acc_predicates, local_predicates, &alias_name);
-    }
-    LoopBehavior::Nothing
-}
-
-/// we could not find the alias name
-/// that could still mean that a predicate that is a complicated binary expression
-/// refers to the aliased name. If we find it, we remove it for now
-/// TODO! rename the expression.
-fn remove_predicate_refers_to_alias(
-    acc_predicates: &mut PlHashMap<Arc<str>, Node>,
-    local_predicates: &mut Vec<Node>,
-    alias_name: &str,
-) {
-    let mut remove_names = vec![];
-    for (composed_name, _) in acc_predicates.iter() {
-        if key_has_name(composed_name, alias_name) {
-            remove_names.push(composed_name.clone());
-            break;
-        }
-    }
-
-    for composed_name in remove_names {
-        let predicate = acc_predicates.remove(&composed_name).unwrap();
-        local_predicates.push(predicate)
-    }
-}
-
-/// Implementation for both Hstack and Projection
-pub(super) fn rewrite_projection_node(
-    expr_arena: &mut Arena<AExpr>,
-    lp_arena: &Arena<ALogicalPlan>,
-    acc_predicates: &mut PlHashMap<Arc<str>, Node>,
-    projections: Vec<Node>,
-    input: Node,
-) -> (Vec<Node>, Vec<Node>)
-where
-{
-    let mut local_predicates = Vec::with_capacity(acc_predicates.len());
-
-    // maybe update predicate name if a projection is an alias
-    // aliases change the column names and because we push the predicates downwards
-    // this may be problematic as the aliased column may not yet exist.
-    for projection_node in &projections {
-        // only if a predicate refers to this projection's output column.
-        let allow_aliased_pushdown =
-            projection_allows_aliased_predicate_pushdown(*projection_node, expr_arena);
-
-        {
-            // if this alias refers to one of the predicates in the upper nodes
-            // we rename the column of the predicate before we push it downwards.
-            match rename_predicate_columns_due_to_aliased_projection(
-                expr_arena,
-                acc_predicates,
-                *projection_node,
-                allow_aliased_pushdown,
-                &mut local_predicates,
-            ) {
-                LoopBehavior::Continue => continue,
-                LoopBehavior::Nothing => {},
-            }
-        }
-        let input_schema = lp_arena.get(input).schema(lp_arena);
-        let projection_expr = expr_arena.get(*projection_node);
-        let output_field = projection_expr
-            .to_field(&input_schema, Context::Default, expr_arena)
-            .unwrap();
-
-        // should have been handled earlier by `pushdown_and_continue`.
-        debug_assert_aexpr_allows_predicate_pushdown(*projection_node, expr_arena);
-
-        // remove predicates that cannot be done on the input above
-        let to_local = acc_predicates
-            .iter()
-            .filter_map(|(name, predicate)| {
-                if !key_has_name(name, output_field.name()) {
-                    // Predicate has nothing to do with this projection.
-                    return None;
-                }
-
-                if
-                // checks that the column does not change value compared to the
-                // node above
-                allow_aliased_pushdown
-                // checks that the column exists in the node above
-                && check_input_node(*predicate, &input_schema, expr_arena)
-                {
-                    None
-                } else {
-                    Some(name.clone())
-                }
-            })
-            .collect::<Vec<_>>();
-
-        for name in to_local {
-            let local = acc_predicates.remove(&name).unwrap();
-            local_predicates.push(local);
-        }
-
-        // remove predicates that are based on column modifications
-        no_pushdown_preds(
-            *projection_node,
-            expr_arena,
-            |e| matches!(e, AExpr::Explode(_)) || matches!(e, AExpr::Ternary { .. }),
-            &mut local_predicates,
-            acc_predicates,
-        );
-    }
-    (local_predicates, projections)
-}
-
-pub(super) fn no_pushdown_preds<F>(
-    // node that is projected | hstacked
-    node: Node,
-    arena: &Arena<AExpr>,
-    matches: F,
-    // predicates that will be filtered at this node in the LP
-    local_predicates: &mut Vec<Node>,
-    acc_predicates: &mut PlHashMap<Arc<str>, Node>,
-) where
-    F: Fn(&AExpr) -> bool,
-{
-    // matching expr are typically explode, shift, etc. expressions that mess up predicates when pushed down
-    if has_aexpr(node, arena, matches) {
-        // columns that are projected. We check if we can push down the predicates past this projection
-        let columns = aexpr_to_leaf_names(node, arena);
-
-        let condition = |name: Arc<str>| columns.contains(&name);
-        local_predicates.extend(transfer_to_local_by_name(arena, acc_predicates, condition));
-    }
-}
-
 /// Transfer a predicate from `acc_predicates` that will be pushed down
 /// to a local_predicates vec based on a condition.
 pub(super) fn transfer_to_local_by_name<F>(
@@ -328,36 +145,21 @@ where
     local_predicates
 }
 
-/// An expression blocks predicates from being pushed past it if its results for
-/// the subset where the predicate evaluates as true becomes different compared
-/// to if it was performed before the predicate was applied. This is in general
-/// any expression that produces outputs based on groups of values
-/// (i.e. groups-wise) rather than individual values (i.e. element-wise).
-///
-/// Examples of expressions whose results would change, and thus block push-down:
-/// - any aggregation - sum, mean, first, last, min, max etc.
-/// - sorting - as the sort keys would change between filters
-pub(super) fn aexpr_blocks_predicate_pushdown(node: Node, expr_arena: &Arena<AExpr>) -> bool {
-    let mut stack = Vec::<Node>::with_capacity(4);
-    stack.push(node);
-
-    // Cannot use `has_aexpr` because we need to ignore any literals in the RHS
-    // of an `is_in` operation.
-    while let Some(node) = stack.pop() {
-        let ae = expr_arena.get(node);
-
-        if match ae {
-            // These literals do not come from the RHS of an is_in, meaning that
-            // they are projected as either columns or predicates, both of which
-            // rely on the height of the dataframe at this level and thus need
-            // to block pushdown.
-            AExpr::Literal(LiteralValue::Range { .. }) => true,
-            AExpr::Literal(LiteralValue::Series(s)) => s.len() > 1,
-            ae => ae.groups_sensitive(),
-        } {
-            return true;
-        }
-
+fn check_and_extend_predicate_pd_nodes(
+    stack: &mut Vec<Node>,
+    ae: &AExpr,
+    expr_arena: &Arena<AExpr>,
+) -> bool {
+    if match ae {
+        // These literals do not come from the RHS of an is_in, meaning that
+        // they are projected as either columns or predicates, both of which
+        // rely on the height of the dataframe at this level and thus need
+        // to block pushdown.
+        AExpr::Literal(lit) => !lit.projects_as_scalar(),
+        ae => ae.groups_sensitive(),
+    } {
+        false
+    } else {
         match ae {
             #[cfg(feature = "is_in")]
             AExpr::Function {
@@ -379,16 +181,300 @@ pub(super) fn aexpr_blocks_predicate_pushdown(node: Node, expr_arena: &Arena<AEx
                     }
                 };
                 if !transferred_local_nodes {
-                    ae.nodes(&mut stack);
+                    ae.nodes(stack);
                 }
             },
             ae => {
-                ae.nodes(&mut stack);
+                ae.nodes(stack);
             },
         };
+        true
+    }
+}
+
+/// An expression blocks predicates from being pushed past it if its results for
+/// the subset where the predicate evaluates as true becomes different compared
+/// to if it was performed before the predicate was applied. This is in general
+/// any expression that produces outputs based on groups of values
+/// (i.e. groups-wise) rather than individual values (i.e. element-wise).
+///
+/// Examples of expressions whose results would change, and thus block push-down:
+/// - any aggregation - sum, mean, first, last, min, max etc.
+/// - sorting - as the sort keys would change between filters
+pub(super) fn aexpr_blocks_predicate_pushdown(node: Node, expr_arena: &Arena<AExpr>) -> bool {
+    let mut stack = Vec::<Node>::with_capacity(4);
+    stack.push(node);
+
+    // Cannot use `has_aexpr` because we need to ignore any literals in the RHS
+    // of an `is_in` operation.
+    while let Some(node) = stack.pop() {
+        let ae = expr_arena.get(node);
+
+        if !check_and_extend_predicate_pd_nodes(&mut stack, ae, expr_arena) {
+            return true;
+        }
+    }
+    false
+}
+
+/// * `col(A).alias(B).alias(C) => (C, A)`
+/// * `col(A)                   => (A, A)`
+/// * `col(A).sum().alias(B)    => None`
+fn get_maybe_aliased_projection_to_input_name_map(
+    node: Node,
+    expr_arena: &Arena<AExpr>,
+) -> Option<(Arc<str>, Arc<str>)> {
+    let mut curr_node = node;
+    let mut curr_alias: Option<Arc<str>> = None;
+
+    loop {
+        match expr_arena.get(curr_node) {
+            AExpr::Alias(node, alias) => {
+                if curr_alias.is_none() {
+                    curr_alias = Some(alias.clone());
+                }
+
+                curr_node = *node;
+            },
+            AExpr::Column(name) => {
+                return if let Some(alias) = curr_alias {
+                    Some((alias, name.clone()))
+                } else {
+                    Some((name.clone(), name.clone()))
+                }
+            },
+            _ => break,
+        }
     }
 
-    false
+    None
+}
+
+pub enum PushdownEligibility {
+    Full,
+    // Partial can happen when there are window exprs.
+    Partial(Vec<Arc<str>>),
+    NoPushdown,
+}
+
+#[allow(clippy::type_complexity)]
+pub fn pushdown_eligibility(
+    input_schema: &Schema,
+    projection_nodes: &Vec<Node>,
+    acc_predicates: &PlHashMap<Arc<str>, Node>,
+    expr_arena: &mut Arena<AExpr>,
+) -> PolarsResult<(PushdownEligibility, PlHashMap<Arc<str>, Arc<str>>)> {
+    let mut ae_nodes_stack = Vec::<Node>::with_capacity(4);
+
+    let mut alias_to_col_map =
+        optimizer::init_hashmap::<Arc<str>, Arc<str>>(Some(projection_nodes.len()));
+    let mut col_to_alias_map = alias_to_col_map.clone();
+
+    let mut modified_projection_columns =
+        PlHashSet::<Arc<str>>::with_capacity(projection_nodes.len());
+    let mut has_window = false;
+    let mut common_window_inputs = PlHashSet::<Arc<str>>::new();
+
+    // Important: Names inserted into any data structure by this function are
+    // all non-aliased.
+    // This function returns false if pushdown cannot be performed.
+    let process_projection_or_predicate =
+        |ae_nodes_stack: &mut Vec<Node>,
+         has_window: &mut bool,
+         common_window_inputs: &mut PlHashSet<Arc<str>>| {
+            debug_assert_eq!(ae_nodes_stack.len(), 1);
+
+            while let Some(node) = ae_nodes_stack.pop() {
+                let ae = expr_arena.get(node);
+
+                match ae {
+                    AExpr::Window {
+                        partition_by,
+                        #[cfg(feature = "dynamic_group_by")]
+                        options,
+                        // The function is not checked for groups-sensitivity because
+                        // it is applied over the windows.
+                        ..
+                    } => {
+                        #[cfg(feature = "dynamic_group_by")]
+                        if matches!(options, WindowType::Rolling(..)) {
+                            return false;
+                        };
+
+                        let mut partition_by_names =
+                            PlHashSet::<Arc<str>>::with_capacity(partition_by.len());
+
+                        for node in partition_by.iter() {
+                            // Only accept col() or col().alias()
+                            if let Some((_, name)) =
+                                get_maybe_aliased_projection_to_input_name_map(*node, expr_arena)
+                            {
+                                partition_by_names.insert(name.clone());
+                            } else {
+                                // Nested windows can also qualify for push down.
+                                // e.g.:
+                                // * expr1 = min().over(A)
+                                // * expr2 = sum().over(A, expr1)
+                                // Both exprs window over A, so predicates referring
+                                // to A can still be pushed.
+                                ae_nodes_stack.push(*node);
+                            }
+                        }
+
+                        if !*has_window {
+                            for name in partition_by_names.into_iter() {
+                                common_window_inputs.insert(name);
+                            }
+
+                            *has_window = true;
+                        } else {
+                            common_window_inputs.retain(|k| partition_by_names.contains(k))
+                        }
+
+                        // Cannot push into disjoint windows:
+                        // e.g.:
+                        // * sum().over(A)
+                        // * sum().over(B)
+                        if common_window_inputs.is_empty() {
+                            return false;
+                        }
+                    },
+                    _ => {
+                        if !check_and_extend_predicate_pd_nodes(ae_nodes_stack, ae, expr_arena) {
+                            return false;
+                        }
+                    },
+                }
+            }
+
+            true
+        };
+
+    for node in projection_nodes.iter() {
+        if let Some((alias, column_name)) =
+            get_maybe_aliased_projection_to_input_name_map(*node, expr_arena)
+        {
+            if alias != column_name {
+                alias_to_col_map.insert(alias.clone(), column_name.clone());
+                col_to_alias_map.insert(column_name, alias);
+            }
+            continue;
+        }
+
+        modified_projection_columns.insert(Arc::<str>::from(
+            expr_arena
+                .get(*node)
+                .to_field(input_schema, Context::Default, expr_arena)?
+                .name()
+                .as_str(),
+        ));
+
+        debug_assert!(ae_nodes_stack.is_empty());
+        ae_nodes_stack.push(*node);
+
+        if !process_projection_or_predicate(
+            &mut ae_nodes_stack,
+            &mut has_window,
+            &mut common_window_inputs,
+        ) {
+            return Ok((PushdownEligibility::NoPushdown, alias_to_col_map));
+        }
+    }
+
+    if has_window && !col_to_alias_map.is_empty() {
+        // Rename to aliased names.
+        let mut new = PlHashSet::<Arc<str>>::with_capacity(2 * common_window_inputs.len());
+
+        for key in common_window_inputs.into_iter() {
+            if let Some(aliased) = col_to_alias_map.get(&key) {
+                new.insert(aliased.clone());
+            }
+            // Ensure predicate does not refer to a different column that
+            // got aliased to the same name as the window column. E.g.:
+            // .with_columns(col(A).alias(C), sum=sum().over(C))
+            // .filter(col(C) == ..)
+            if !alias_to_col_map.contains_key(&key) {
+                new.insert(key);
+            }
+        }
+
+        if new.is_empty() {
+            return Ok((PushdownEligibility::NoPushdown, alias_to_col_map));
+        }
+
+        common_window_inputs = new;
+    }
+
+    for node in acc_predicates.values() {
+        debug_assert!(ae_nodes_stack.is_empty());
+        ae_nodes_stack.push(*node);
+
+        if !process_projection_or_predicate(
+            &mut ae_nodes_stack,
+            &mut has_window,
+            &mut common_window_inputs,
+        ) {
+            return Ok((PushdownEligibility::NoPushdown, alias_to_col_map));
+        }
+    }
+
+    // Should have returned early.
+    debug_assert!(!common_window_inputs.is_empty() || !has_window);
+
+    if !has_window && projection_nodes.is_empty() {
+        return Ok((PushdownEligibility::Full, alias_to_col_map));
+    }
+
+    // Note: has_window is constant.
+    let can_use_column = |col: &Arc<str>| {
+        if has_window {
+            common_window_inputs.contains(col)
+        } else {
+            !modified_projection_columns.contains(col)
+        }
+    };
+
+    let to_local = acc_predicates
+        .iter()
+        .filter_map(|(key, &node)| {
+            debug_assert!(ae_nodes_stack.is_empty());
+
+            ae_nodes_stack.push(node);
+
+            let mut can_pushdown = true;
+
+            while let Some(node) = ae_nodes_stack.pop() {
+                let ae = expr_arena.get(node);
+
+                can_pushdown &= if let AExpr::Column(name) = ae {
+                    can_use_column(name)
+                } else {
+                    // May still contain window expressions that need to be blocked.
+                    check_and_extend_predicate_pd_nodes(&mut ae_nodes_stack, ae, expr_arena)
+                };
+
+                if !can_pushdown {
+                    break;
+                };
+            }
+
+            ae_nodes_stack.clear();
+
+            if !can_pushdown {
+                Some(key.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    match to_local.len() {
+        0 => Ok((PushdownEligibility::Full, alias_to_col_map)),
+        len if len == acc_predicates.len() => {
+            Ok((PushdownEligibility::NoPushdown, alias_to_col_map))
+        },
+        _ => Ok((PushdownEligibility::Partial(to_local), alias_to_col_map)),
+    }
 }
 
 /// Used in places that previously handled blocking exprs before refactoring.

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -269,27 +269,6 @@ pub(crate) fn aexpr_to_column_nodes(root: Node, arena: &Arena<AExpr>) -> Vec<Nod
     aexpr_to_column_nodes_iter(root, arena).collect()
 }
 
-/// Rename the roots of the expression to a single name.
-/// Most of the times used with columns that have a single root.
-/// In some cases we can have multiple roots.
-/// For instance in predicate pushdown the predicates are combined by their root column
-/// When combined they may be a binary expression with the same root columns
-pub(crate) fn rename_aexpr_leaf_names(
-    node: Node,
-    arena: &mut Arena<AExpr>,
-    new_name: Arc<str>,
-) -> Node {
-    // we convert to expression as we cannot easily copy the aexpr.
-    let mut new_expr = node_to_expr(node, arena);
-    new_expr.mutate().apply(|e| {
-        if let Expr::Column(name) = e {
-            *name = new_name.clone()
-        }
-        true
-    });
-    to_aexpr(new_expr, arena)
-}
-
 /// If the leaf names match `current`, the node will be replaced
 /// with a renamed expression.
 pub(crate) fn rename_matching_aexpr_leaf_names(

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -384,9 +384,8 @@ def test_predicate_pushdown_with_window_projections_12637() -> None:
     assert "FILTER" in plan
     assert 'SELECTION: "None"' in plan
 
-    # The window input names are extracted from window expressions to allow
-    # predicates to be pushed down if they only refer to the window inputs, but
-    # the must also not be window expressions themselves.
+    # Ensure the implementation doesn't accidentally push a window expression
+    # that only refers to the common window keys.
     actual = lf.with_columns(
         (pl.col("value") * 2).over("key").alias("value_2"),
     ).filter(pl.count().over("key") == 1)

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -293,3 +293,110 @@ def test_literal_series_expr_predicate_pushdown() -> None:
 
     assert "FILTER" not in lf.explain()
     assert lf.collect().to_series().to_list() == [1]
+
+
+def test_multi_alias_pushdown() -> None:
+    lf = pl.LazyFrame({"a": [1], "b": [1]})
+
+    actual = lf.with_columns(m="a", n="b").filter((pl.col("m") + pl.col("n")) < 2)
+
+    plan = actual.explain()
+    assert "FILTER" not in plan
+    assert r'SELECTION: "[([(col(\"a\")) + (col(\"b\"))]) < (2)]' in plan
+
+
+def test_predicate_pushdown_with_window_projections_12637() -> None:
+    lf = pl.LazyFrame(
+        {
+            "key": [1],
+            "key_2": [1],
+            "key_3": [1],
+            "value": [1],
+            "value_2": [1],
+            "value_3": [1],
+        }
+    )
+
+    actual = lf.with_columns(
+        (pl.col("value") * 2).over("key").alias("value_2"),
+        (pl.col("value") * 2).over("key").alias("value_3"),
+    ).filter(pl.col("key") == 5)
+
+    plan = actual.explain()
+    assert "FILTER" not in plan
+    assert r'SELECTION: "[(col(\"key\")) == (5)]"' in plan
+
+    actual = (
+        lf.with_columns(
+            (pl.col("value") * 2).over("key", "key_2").alias("value_2"),
+            (pl.col("value") * 2).over("key", "key_2").alias("value_3"),
+        )
+        .filter(pl.col("key") == 5)
+        .filter(pl.col("key_2") == 5)
+    )
+
+    plan = actual.explain()
+    assert "FILTER" not in plan
+    assert (
+        # hashbrown::HashMap is unordered.
+        r'SELECTION: "[([(col(\"key\")) == (5)]) & ([(col(\"key_2\")) == (5)])]"'
+        in plan
+        or r'SELECTION: "[([(col(\"key_2\")) == (5)]) & ([(col(\"key\")) == (5)])]"'
+        in plan
+    )
+
+    actual = (
+        lf.with_columns(
+            (pl.col("value") * 2).over("key", "key_2").alias("value_2"),
+            (pl.col("value") * 2).over("key", "key_3").alias("value_3"),
+        )
+        .filter(pl.col("key") == 5)
+        .filter(pl.col("key_2") == 5)
+    )
+
+    plan = actual.explain()
+    assert "FILTER" in plan
+    assert r'SELECTION: "[(col(\"key\")) == (5)]"' in plan
+
+    actual = (
+        lf.with_columns(
+            (pl.col("value") * 2).over("key", pl.col("key_2") + 1).alias("value_2"),
+            (pl.col("value") * 2).over("key", "key_2").alias("value_3"),
+        )
+        .filter(pl.col("key") == 5)
+        .filter(pl.col("key_2") == 5)
+    )
+    plan = actual.explain()
+    assert "FILTER" in plan
+    assert r'SELECTION: "[(col(\"key\")) == (5)]"' in plan
+
+    # Should block when .over() contains groups-sensitive expr
+    actual = (
+        lf.with_columns(
+            (pl.col("value") * 2).over("key", pl.sum("key_2")).alias("value_2"),
+            (pl.col("value") * 2).over("key", "key_2").alias("value_3"),
+        )
+        .filter(pl.col("key") == 5)
+        .filter(pl.col("key_2") == 5)
+    )
+
+    plan = actual.explain()
+    assert "FILTER" in plan
+    assert 'SELECTION: "None"' in plan
+
+    # The window input names are extracted from window expressions to allow
+    # predicates to be pushed down if they only refer to the window inputs, but
+    # the must also not be window expressions themselves.
+    actual = lf.with_columns(
+        (pl.col("value") * 2).over("key").alias("value_2"),
+    ).filter(pl.count().over("key") == 1)
+
+    plan = actual.explain()
+    assert r'FILTER [(count().over([col("key")])) == (1)]' in plan
+    assert 'SELECTION: "None"' in plan
+
+    # Test window in filter
+    actual = lf.filter(pl.count().over("key") == 1).filter(pl.col("key") == 1)
+    plan = actual.explain()
+    assert r'FILTER [(count().over([col("key")])) == (1)]' in plan
+    assert r'SELECTION: "[(col(\"key\")) == (1)]"' in plan


### PR DESCRIPTION
Would close https://github.com/pola-rs/polars/issues/12637.

This PR would enable a partial pushdown of predicates past window expressions in both projections and predicates (at the expense of code complexity):

* unoptimized
```javascript
FILTER [(col("key")) == (1)] FROM
FILTER [(count().over([col("key")])) == (1)] FROM
DF ["key", "value"]; PROJECT */2 COLUMNS; SELECTION: "None"
```
* `0.19.16`
```javascript
FILTER [([(count().over([col("key")])) == (1)]) & ([(col("key")) == (1)])] FROM
DF ["key", "value"]; PROJECT */2 COLUMNS; SELECTION: "None"
```
* this PR
```rust
FILTER [(count().over([col("key")])) == (1)] FROM
DF ["key", "value"]; PROJECT */2 COLUMNS; SELECTION: "[(col(\"key\")) == (1)]"
```
Other changes:
* improves predicate re-naming
