### PR TITLE
feat(python): Improve `write_database`, accounting for latest `adbc` fixes/updates

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3469,11 +3469,18 @@ class DataFrame:
             return schema, tbl
 
         if engine == "adbc":
-            import adbc_driver_manager
+            try:
+                import adbc_driver_manager
 
-            adbc_version = parse_version(
-                getattr(adbc_driver_manager, "__version__", "0.0")
-            )
+                adbc_version = parse_version(
+                    getattr(adbc_driver_manager, "__version__", "0.0")
+                )
+            except ModuleNotFoundError as exc:
+                raise ModuleNotFoundError(
+                    "adbc_driver_manager not found"
+                    "\n\nInstall Polars with: pip install adbc_driver_manager"
+                ) from exc
+
             if if_exists == "fail":
                 # if the table exists, 'create' will raise an error,
                 # resulting in behaviour equivalent to 'fail'

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -190,10 +190,10 @@ class ConnectionExecutor:
             if conn.driver == "databricks-sql-python":  # type: ignore[union-attr]
                 # take advantage of the raw connection to get arrow integration
                 self.driver_name = "databricks"
-                return conn.raw_connection().cursor()  # type: ignore[union-attr]
+                return conn.raw_connection().cursor()  # type: ignore[union-attr, return-value]
             else:
                 # sqlalchemy engine; direct use is deprecated, so prefer the connection
-                return conn.connect()  # type: ignore[union-attr]
+                return conn.connect()  # type: ignore[union-attr, return-value]
 
         elif hasattr(conn, "cursor"):
             # connection has a dedicated cursor; prefer over direct execute

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -21,6 +21,8 @@ from typing import (
 if TYPE_CHECKING:
     import sys
 
+    from sqlalchemy import Engine
+
     from polars import DataFrame, Expr, LazyFrame, Series
     from polars.datatypes import DataType, DataTypeClass, IntegerType, TemporalType
     from polars.dependencies import numpy as np
@@ -233,4 +235,4 @@ class Cursor(BasicCursor):  # noqa: D101
         """Fetch results in batches."""
 
 
-ConnectionOrCursor = Union[BasicConnection, BasicCursor, Cursor]
+ConnectionOrCursor = Union[BasicConnection, BasicCursor, Cursor, "Engine"]

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -79,7 +79,7 @@ disable_error_code = [
 [[tool.mypy.overrides]]
 module = [
   "IPython.*",
-  "adbc_driver_postgresql.*",
+  "adbc_driver_manager.*",
   "adbc_driver_sqlite.*",
   "arrow_odbc",
   "backports",

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -25,6 +25,7 @@ backports.zoneinfo; python_version < '3.9'
 tzdata; platform_system == 'Windows'
 # Database
 SQLAlchemy
+adbc_driver_manager; python_version >= '3.9' and platform_system != 'Windows'
 adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'
 # TODO: Remove version constraint for connectorx when Python 3.12 is supported:
 # https://github.com/sfu-db/connector-x/issues/527

--- a/py-polars/tests/unit/io/test_database_write.py
+++ b/py-polars/tests/unit/io/test_database_write.py
@@ -4,7 +4,6 @@ import sys
 from typing import TYPE_CHECKING
 
 import pytest
-from adbc_driver_manager import InternalError
 
 import polars as pl
 from polars.testing import assert_frame_equal
@@ -58,6 +57,8 @@ def test_write_database_create(engine: DbWriteEngine, tmp_path: Path) -> None:
 @pytest.mark.write_disk()
 @pytest.mark.parametrize("engine", ["adbc", "sqlalchemy"])
 def test_write_database_append_replace(engine: DbWriteEngine, tmp_path: Path) -> None:
+    from adbc_driver_manager import InternalError
+
     df = pl.DataFrame(
         {
             "key": ["xx", "yy", "zz"],

--- a/py-polars/tests/unit/io/test_database_write.py
+++ b/py-polars/tests/unit/io/test_database_write.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import sys
-from contextlib import suppress
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pytest
+from adbc_driver_manager import InternalError
 
 import polars as pl
 from polars.testing import assert_frame_equal
@@ -15,16 +15,8 @@ if TYPE_CHECKING:
     from polars.type_aliases import DbWriteEngine
 
 
-def adbc_sqlite_driver_version(*args: Any, **kwargs: Any) -> str:
-    with suppress(ModuleNotFoundError):  # not available on 3.8/windows
-        import adbc_driver_sqlite
-
-        return getattr(adbc_driver_sqlite, "__version__", "n/a")
-    return "n/a"
-
-
 @pytest.mark.skipif(
-    sys.version_info > (3, 11),
+    sys.version_info >= (3, 12),
     reason="connectorx cannot be installed on Python 3.12 yet.",
 )
 @pytest.mark.skipif(
@@ -43,20 +35,20 @@ def test_write_database_create(engine: DbWriteEngine, tmp_path: Path) -> None:
     )
     tmp_path.mkdir(exist_ok=True)
     test_db = str(tmp_path / f"test_{engine}.db")
+    test_db_uri = f"sqlite:///{test_db}"
     table_name = "test_create"
 
     df.write_database(
         table_name=table_name,
-        connection=f"sqlite:///{test_db}",
-        if_exists="replace",
+        connection=test_db_uri,
         engine=engine,
     )
-    result = pl.read_database_uri(f"SELECT * FROM {table_name}", f"sqlite:///{test_db}")
+    result = pl.read_database_uri(f"SELECT * FROM {table_name}", test_db_uri)
     assert_frame_equal(result, df)
 
 
 @pytest.mark.skipif(
-    sys.version_info > (3, 11),
+    sys.version_info >= (3, 12),
     reason="connectorx cannot be installed on Python 3.12 yet.",
 )
 @pytest.mark.skipif(
@@ -65,7 +57,7 @@ def test_write_database_create(engine: DbWriteEngine, tmp_path: Path) -> None:
 )
 @pytest.mark.write_disk()
 @pytest.mark.parametrize("engine", ["adbc", "sqlalchemy"])
-def test_write_database_append(engine: DbWriteEngine, tmp_path: Path) -> None:
+def test_write_database_append_replace(engine: DbWriteEngine, tmp_path: Path) -> None:
     df = pl.DataFrame(
         {
             "key": ["xx", "yy", "zz"],
@@ -76,31 +68,40 @@ def test_write_database_append(engine: DbWriteEngine, tmp_path: Path) -> None:
 
     tmp_path.mkdir(exist_ok=True)
     test_db = str(tmp_path / f"test_{engine}.db")
+    test_db_uri = f"sqlite:///{test_db}"
     table_name = "test_append"
 
     df.write_database(
         table_name=table_name,
-        connection=f"sqlite:///{test_db}",
-        if_exists="replace",
+        connection=test_db_uri,
         engine=engine,
     )
 
-    ExpectedError = NotImplementedError if engine == "adbc" else ValueError
+    ExpectedError = InternalError if engine == "adbc" else ValueError
     with pytest.raises(ExpectedError):
         df.write_database(
             table_name=table_name,
-            connection=f"sqlite:///{test_db}",
+            connection=test_db_uri,
             if_exists="fail",
             engine=engine,
         )
 
     df.write_database(
         table_name=table_name,
-        connection=f"sqlite:///{test_db}",
+        connection=test_db_uri,
+        if_exists="replace",
+        engine=engine,
+    )
+    result = pl.read_database_uri(f"SELECT * FROM {table_name}", test_db_uri)
+    assert_frame_equal(result, df)
+
+    df.write_database(
+        table_name=table_name,
+        connection=test_db_uri,
         if_exists="append",
         engine=engine,
     )
-    result = pl.read_database_uri(f"SELECT * FROM {table_name}", f"sqlite:///{test_db}")
+    result = pl.read_database_uri(f"SELECT * FROM {table_name}", test_db_uri)
     assert_frame_equal(result, pl.concat([df, df]))
 
 
@@ -112,16 +113,11 @@ def test_write_database_append(engine: DbWriteEngine, tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "engine",
     [
-        pytest.param(
-            "adbc",
-            marks=pytest.mark.xfail(  # see: https://github.com/apache/arrow-adbc/issues/1000
-                reason="ADBC SQLite driver has a bug with quoted/qualified table names",
-            ),
-        ),
+        "adbc",
         pytest.param(
             "sqlalchemy",
             marks=pytest.mark.skipif(
-                sys.version_info > (3, 11),
+                sys.version_info >= (3, 12),
                 reason="connectorx cannot be installed on Python 3.12 yet.",
             ),
         ),
@@ -134,17 +130,23 @@ def test_write_database_create_quoted_tablename(
 
     tmp_path.mkdir(exist_ok=True)
     test_db = str(tmp_path / f"test_{engine}.db")
+    test_db_uri = f"sqlite:///{test_db}"
 
     # table name requires quoting, and is qualified with the implicit 'main' schema
     table_name = 'main."test-append"'
 
     df.write_database(
         table_name=table_name,
-        connection=f"sqlite:///{test_db}",
+        connection=test_db_uri,
+        engine=engine,
+    )
+    df.write_database(
+        table_name=table_name,
+        connection=test_db_uri,
         if_exists="replace",
         engine=engine,
     )
-    result = pl.read_database_uri(f"SELECT * FROM {table_name}", f"sqlite:///{test_db}")
+    result = pl.read_database_uri(f"SELECT * FROM {table_name}", test_db_uri)
     assert_frame_equal(result, df)
 
 
@@ -157,16 +159,6 @@ def test_write_database_errors() -> None:
     ):
         df.write_database(
             connection="sqlite:///:memory:", table_name="w.x.y.z", engine="sqlalchemy"
-        )
-
-    with pytest.raises(
-        NotImplementedError, match="`if_exists = 'fail'` not supported for ADBC engine"
-    ):
-        df.write_database(
-            connection="sqlite:///:memory:",
-            table_name="test_errs",
-            if_exists="fail",
-            engine="adbc",
         )
 
     with pytest.raises(ValueError, match="'do_something' is not valid for if_exists"):


### PR DESCRIPTION
Closes #12684.
Ref: https://github.com/pola-rs/polars/pull/10763, https://github.com/pola-rs/polars/pull/11282#issuecomment-1736224273.

## Enhancements

Updates `pl.write_database` and associated tests with various improvements now that some key issues (https://github.com/apache/arrow-adbc/issues/1000, https://github.com/apache/arrow-adbc/issues/1109) have been resolved in the ADBC `0.7` and `0.8` releases, respectively.

* Enables correct resolution of schema-qualified names (eg: `schema.table_name`).
* Adds ADBC engine support for `if_exists = "fail"` (simulated).
* Adds ADBC engine support for `if_exists = "replace"` (native).
* All write tests now able to run under Python `3.12`.

Requires that the caller has installed at least ADBC version `0.7` for "replace" support, or `0.8` if using schema-qualified names, as these versions contain the related/required fixes (if not doing either of these things earlier versions of ADBC continue to work fine).

## Note 
In addition to SQLite (what we run in CI), I was able to validate these updates against a local PostgreSQL instance.