### PR TITLE
chore(python): Remove pinned `aiohttp` dependency

### DIFF
--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -33,9 +33,6 @@ connectorx; python_version <= '3.11'
 cloudpickle
 fsspec
 s3fs[boto3]
-# TODO: Unpin and remove aiohttp here when 3.9.0 is released:
-# https://github.com/aio-libs/aiohttp/issues/7739
-aiohttp==3.9.0
 # Spreadsheet
 ezodf
 lxml


### PR DESCRIPTION
Latest release now supports Python 3.12, so we can drop this (it will still be installed as a transitive dependency).