### PR TITLE
numpy array with 2 dimensions with a schema of same second dimension give a DataFrame with same dimension and same type, even with only one column

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1463,7 +1463,11 @@ def numpy_to_pydf(
             data_series = [
                 pl.Series(
                     name=column_names[i],
-                    values=(data if two_d and n_columns == 1 and shape[1] > 1 else data[:, i]),
+                    values=(
+                        data
+                        if two_d and n_columns == 1 and shape[1] > 1
+                        else data[:, i]
+                    ),
                     dtype=schema_overrides.get(column_names[i]),
                     nan_to_null=nan_to_null,
                 )._s
@@ -1473,7 +1477,9 @@ def numpy_to_pydf(
             data_series = [
                 pl.Series(
                     name=column_names[i],
-                    values=(data if two_d and n_columns == 1 and shape[1] > 1 else data[i]),
+                    values=(
+                        data if two_d and n_columns == 1 and shape[1] > 1 else data[i]
+                    ),
                     dtype=schema_overrides.get(column_names[i]),
                     nan_to_null=nan_to_null,
                 )._s

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1463,7 +1463,7 @@ def numpy_to_pydf(
             data_series = [
                 pl.Series(
                     name=column_names[i],
-                    values=(data if two_d and n_columns == 1 else data[:, i]),
+                    values=(data if two_d and n_columns == 1 and shape[1] > 1 else data[:, i]),
                     dtype=schema_overrides.get(column_names[i]),
                     nan_to_null=nan_to_null,
                 )._s
@@ -1473,7 +1473,7 @@ def numpy_to_pydf(
             data_series = [
                 pl.Series(
                     name=column_names[i],
-                    values=(data if two_d and n_columns == 1 else data[i]),
+                    values=(data if two_d and n_columns == 1 and shape[1] > 1 else data[i]),
                     dtype=schema_overrides.get(column_names[i]),
                     nan_to_null=nan_to_null,
                 )._s

--- a/py-polars/tests/unit/test_constructors.py
+++ b/py-polars/tests/unit/test_constructors.py
@@ -544,7 +544,8 @@ def test_init_ndarray() -> None:
 
     # List column from 2D array with single-column schema
     df = pl.DataFrame(np.arange(4).reshape(-1, 1).astype(np.int64), schema=["a"])
-    assert_frame_equal(df, pl.DataFrame({"a": [[0], [1], [2], [3]]}))
+    assert_frame_equal(df, pl.DataFrame({"a": [0, 1, 2, 3]}))
+    assert np.array_equal(df.to_numpy(), np.arange(4).reshape(-1, 1).astype(np.int64))
 
     df = pl.DataFrame(np.arange(4).reshape(-1, 2).astype(np.int64), schema=["a"])
     assert_frame_equal(df, pl.DataFrame({"a": [[0, 1], [2, 3]]}))


### PR DESCRIPTION
This PR is related to the Issue #12718. 

I modified 

Since version 0.19.16, this code (`DataFrame(np.zeros((2, 1)))`) has a new behavior.

```python
>>> arr = np.zeros((2, 1))
>>> DataFrame(arr)
... ┌───────────┐
... │ column_0  │
... │ ---       │
... │ list[i32] │
... ╞═══════════╡
... │ [0]       │
... │ [0]       │
... └───────────┘
```

Function `numpy_to_pydf` of file `_construction.py` has been changed, that a numpy array with 2 dimensions, one column and a consistent schema, to have the previous behaviour (`if two_d and n_columns == 1 and shape[1] > 1 else ...`)


```python
>>> arr = np.zeros((2, 1))
>>> DataFrame(arr)
... ┌──────────┐
... │ column_0 │
... │ ---      │
... │ i32      │
... ╞══════════╡
... │ 0        │
... │ 0        │
... └──────────┘
```

Then this code does not fail, 

```pycon
>>> arr = np.zeros((2, 1))
>>> pl.from_numpy(arr).to_numpy()
```
