### PR TITLE
build: Use latest `atoi_simd` release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,8 +261,9 @@ dependencies = [
 
 [[package]]
 name = "atoi_simd"
-version = "0.15.3"
-source = "git+https://github.com/orlp/atoi_simd?branch=fix-parse-skipped-zeroes#4856ac9924e70a8b9b56d6088c8421abae6aca03"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccfc14f5c3e34de57539a7ba9c18ecde3d9bbde48d232ea1da3e468adb307fd0"
 
 [[package]]
 name = "autocfg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ hashbrown = { version = "0.14", features = ["rayon", "ahash"] }
 hex = "0.4.3"
 indexmap = { version = "2", features = ["std"] }
 itoa = "1.0.6"
-atoi_simd = "0.15"
+atoi_simd = "0.15.5"
 fast-float = { version = "0.2" }
 memchr = "2.6"
 multiversion = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,7 +113,6 @@ features = [
 ]
 
 [patch.crates-io]
-atoi_simd = { git = "https://github.com/orlp/atoi_simd", branch = "fix-parse-skipped-zeroes" }
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }
 # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
 


### PR DESCRIPTION
atoi_simd has been fixed and released, so no `[patch.crates-io]` is required

Initial #12744