### PR TITLE
Request for preliminary directional check-in: making file loading much better factored

### DIFF
--- a/crates/polars-io/src/mmap.rs
+++ b/crates/polars-io/src/mmap.rs
@@ -101,7 +101,7 @@ pub enum ReaderFactory {
     },
     /// A cloud URL of a remote file, to be used with async APIs
     RemoteFile {
-        location: String,
+        uri: String,
     },
     // /// A wrapper around a Python callable that returns a file-like object.
     // PyFileFactory { factory: PythonFunction }
@@ -111,7 +111,7 @@ impl Display for ReaderFactory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ReaderFactory::LocalFile { path, .. } => write!(f, "{}", path.to_string_lossy()),
-            ReaderFactory::RemoteFile { location } => write!(f, "{location}"),
+            ReaderFactory::RemoteFile { uri: location } => write!(f, "{location}"),
         }
     }
 }

--- a/crates/polars-io/src/mmap.rs
+++ b/crates/polars-io/src/mmap.rs
@@ -117,13 +117,14 @@ impl Display for ReaderFactory {
 }
 
 impl ReaderFactory {
+    /// Open the underlying file. Only works for non-RemoteFile.
     pub fn mmapbytesreader(&self) -> PolarsResult<Box<dyn MmapBytesReader>> {
         match self {
             ReaderFactory::LocalFile { path, .. } => {
                 let file = polars_utils::open_file(path)?;
                 Ok(Box::new(file))
             },
-            ReaderFactory::RemoteFile { .. } => todo!("Still haven't figured out how async works"),
+            ReaderFactory::RemoteFile { .. } => panic!("RemoteFile needs to be handled by async code, not as MmapBytesReader"),
         }
     }
 }

--- a/crates/polars-io/src/mmap.rs
+++ b/crates/polars-io/src/mmap.rs
@@ -93,6 +93,7 @@ impl<'a, T: 'a + MmapBytesReader> From<&'a T> for ReaderBytes<'a> {
 }
 
 /// Create MmapBytesReaders for a specific "file", either locally or remotely.
+#[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum ReaderFactory {
     /// A specific local file on the filesystem:

--- a/crates/polars-lazy/src/scan/file_list_reader.rs
+++ b/crates/polars-lazy/src/scan/file_list_reader.rs
@@ -1,31 +1,158 @@
-use std::path::{Path, PathBuf};
+use std::fmt::Display;
+use std::fs::File;
+use std::path::{PathBuf, Path};
 
 use polars_core::error::to_compute_err;
 use polars_core::prelude::*;
 use polars_io::cloud::CloudOptions;
+use polars_io::mmap::MmapBytesReader;
 use polars_io::{is_cloud_url, RowCount};
 
 use crate::prelude::*;
 
-pub type PathIterator = Box<dyn Iterator<Item = PolarsResult<PathBuf>>>;
+/// Read a specific file, either locally or remotely.
+enum Reader {
+    Local {
+        path: PathBuf,
+        reader: Box<dyn MmapBytesReader>,
+    },
+    Remote {
+        location: String,
+    },
+}
+
+impl Display for Reader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Reader::Local { path, .. } => write!(f, "{}", path.to_string_lossy()),
+            Reader::Remote { location } => write!(f, "{location}"),
+        }
+    }
+}
+
+pub type ReaderIterator = Box<dyn Iterator<Item = PolarsResult<Reader>>>;
 
 // cloud_options is used only with async feature
 #[allow(unused_variables)]
-fn polars_glob(pattern: &str, cloud_options: Option<&CloudOptions>) -> PolarsResult<PathIterator> {
+fn polars_glob(
+    pattern: &str,
+    cloud_options: Option<&CloudOptions>,
+) -> PolarsResult<ReaderIterator> {
     if is_cloud_url(pattern) {
         #[cfg(feature = "async")]
         {
             let paths = polars_io::async_glob(pattern, cloud_options)?;
-            Ok(Box::new(paths.into_iter().map(|a| Ok(PathBuf::from(&a)))))
+            Ok(Box::new(
+                paths
+                    .into_iter()
+                    .map(|a| Ok(Reader::Remote { location: a })),
+            ))
         }
         #[cfg(not(feature = "async"))]
         panic!("Feature `async` must be enabled to use globbing patterns with cloud urls.")
     } else {
         let paths = glob::glob(pattern)
             .map_err(|_| polars_err!(ComputeError: "invalid glob pattern given"))?;
-        let paths = paths.map(|v| v.map_err(to_compute_err));
+        let paths = paths.map(|v| {
+            v.map_err(to_compute_err).and_then(|p| {
+                File::open(p)
+                    .map(|f| Reader::Local {
+                        path: p,
+                        reader: Box::new(f),
+                    })
+                    .map_err(to_compute_err)
+            })
+        });
         Ok(Box::new(paths))
     }
+}
+
+/// The source for one or more files (or remote files).
+pub enum ReaderSources {
+    /// A path that can be globbed to get multiple files.
+    GlobPath { path: PathBuf },
+    /// Multiple specific file paths.
+    SpecificPaths { paths: Vec<PathBuf> },
+    // TODO eventually also support things that aren't paths, e.g. Python
+    // file-like objects.
+}
+
+impl Display for ReaderSources {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReaderSources::GlobPath { path } => write!(f, "{}", path.to_string_lossy()),
+            ReaderSources::SpecificPaths { paths } => {
+                write!(f, "[")?;
+                for path in paths {
+                    write!(f, "{}, ", path.to_string_lossy())?;
+                }
+                write!(f, "]")
+            },
+        }
+    }
+}
+
+impl ReaderSources {
+    /// Create a new ReaderSources with a specific glob path.
+    pub fn new_glob(path: impl AsRef<Path>) -> Self {
+        Self::GlobPath { path: path.as_ref().to_owned() }
+    }
+
+    /// Create a new ReaderSources with a set of specific, non-glob paths.
+    pub fn new_paths(paths: Vec<PathBuf>) -> Self {
+        Self::SpecificPaths { paths }
+    }
+
+    /// Get list of readers.
+    ///
+    /// Returns [None] if path is not a glob pattern.
+    fn iter_readers(&self, cloud_options: Option<&CloudOptions>) -> PolarsResult<ReaderIterator> {
+        match self {
+            ReaderSources::GlobPath { path } => {
+                let path_str = path.to_string_lossy();
+                polars_glob(&path_str, cloud_options)
+            },
+            ReaderSources::SpecificPaths { paths } => {
+                Ok(Box::new(paths.clone().into_iter().map(|path| {
+                    let path_str = path.to_string_lossy();
+                    if is_cloud_url(path_str.as_ref()) {
+                        Ok(Reader::Remote {
+                            location: path_str.to_string(),
+                        })
+                    } else {
+                        let f = File::open(path)?;
+                        Ok(Reader::Local {
+                            path,
+                            reader: Box::new(f),
+                        })
+                    }
+                })))
+            },
+        }
+        // if paths.is_empty() {
+        //     let path_str = self.path().to_string_lossy();
+        //     if path_str.contains('*') || path_str.contains('?') || path_str.contains('[') {
+        //         polars_glob(&path_str, self.cloud_options()).map(Some)
+        //     } else {
+        //         Ok(None)
+        //     }
+        // } else {
+        //     polars_ensure!(self.path().to_string_lossy() == "", InvalidOperation: "expected only a single path argument");
+        //     // Lint is incorrect as we need static lifetime.
+        //     #[allow(clippy::unnecessary_to_owned)]
+        //     Ok(Some(Box::new(paths.to_vec().into_iter().map(Ok))))
+        // }
+    }
+}
+/// A LazyFileListReader can be in one of two states: either it has a FileList
+/// it needs to iterate over, or it has a single, specific MmapBytesReader. In
+/// practice this is a bad design and there should really be separate structs
+/// for the two states, a builder and a final state, but that's a bit of a
+/// refactoring.
+#[derive(Clone)]
+pub(crate) enum ReaderOrSources {
+    Reader { reader: Arc<Box<dyn MmapBytesReader>> },
+    Sources { sources: Arc<ReaderSources> },
 }
 
 /// Reads [LazyFrame] from a filesystem or a cloud storage.
@@ -35,39 +162,35 @@ fn polars_glob(pattern: &str, cloud_options: Option<&CloudOptions>) -> PolarsRes
 pub trait LazyFileListReader: Clone {
     /// Get the final [LazyFrame].
     fn finish(self) -> PolarsResult<LazyFrame> {
-        if let Some(paths) = self.iter_paths()? {
-            let lfs = paths
-                .map(|r| {
-                    let path = r?;
-                    self.clone()
-                        .with_path(path.clone())
-                        .with_rechunk(false)
-                        .finish_no_glob()
-                        .map_err(|e| {
-                            polars_err!(
-                                ComputeError: "error while reading {}: {}", path.display(), e
-                            )
-                        })
-                })
-                .collect::<PolarsResult<Vec<_>>>()?;
+        let readers = self.sources().iter_readers(self.cloud_options())?;
+        let lfs = readers
+            .map(|r| {
+                let r = r?;
+                self.clone()
+                    .with_rechunk(false)
+                    .finish_no_glob(r)
+                    .map_err(|e| {
+                        polars_err!(
+                            ComputeError: "error while reading {}: {}", r, e
+                        )
+                    })
+            })
+            .collect::<PolarsResult<Vec<_>>>()?;
 
-            polars_ensure!(
-                !lfs.is_empty(),
-                ComputeError: "no matching files found in {}", self.path().display()
-            );
+        polars_ensure!(
+            !lfs.is_empty(),
+            ComputeError: "no matching files found in {}", self.sources()
+        );
 
-            let mut lf = self.concat_impl(lfs)?;
-            if let Some(n_rows) = self.n_rows() {
-                lf = lf.slice(0, n_rows as IdxSize)
-            };
-            if let Some(rc) = self.row_count() {
-                lf = lf.with_row_count(&rc.name, Some(rc.offset))
-            };
+        let mut lf = self.concat_impl(lfs)?;
+        if let Some(n_rows) = self.n_rows() {
+            lf = lf.slice(0, n_rows as IdxSize)
+        };
+        if let Some(rc) = self.row_count() {
+            lf = lf.with_row_count(&rc.name, Some(rc.offset))
+        };
 
-            Ok(lf)
-        } else {
-            self.finish_no_glob()
-        }
+        Ok(lf)
     }
 
     /// Recommended concatenation of [LazyFrame]s from many input files.
@@ -82,23 +205,22 @@ pub trait LazyFileListReader: Clone {
     /// This method assumes, that path is *not* a glob.
     ///
     /// It is recommended to always use [LazyFileListReader::finish] method.
-    fn finish_no_glob(self) -> PolarsResult<LazyFrame>;
+    fn finish_no_glob(self, reader: Reader) -> PolarsResult<LazyFrame>;
 
-    /// Path of the scanned file.
-    /// It can be potentially a glob pattern.
-    fn path(&self) -> &Path;
+    /// Reader of the scanned file.
+    fn reader(&self) -> &Reader;
 
-    fn paths(&self) -> &[PathBuf];
+    /// A source of multiple readers.
+    fn sources(&self) -> &ReaderSources;
 
     /// Set path of the scanned file.
     /// Support glob patterns.
     #[must_use]
-    fn with_path(self, path: PathBuf) -> Self;
+    fn with_reader(self, reader: Reader) -> Self;
 
-    /// Set paths of the scanned files.
-    /// Doesn't glob patterns.
+    /// Set sources of the scanned files.
     #[must_use]
-    fn with_paths(self, paths: Arc<[PathBuf]>) -> Self;
+    fn with_sources(self, sources: Arc<ReaderSources>) -> Self;
 
     /// Rechunk the memory to contiguous chunks when parsing is done.
     fn rechunk(&self) -> bool;
@@ -117,25 +239,5 @@ pub trait LazyFileListReader: Clone {
     /// [CloudOptions] used to list files.
     fn cloud_options(&self) -> Option<&CloudOptions> {
         None
-    }
-
-    /// Get list of files referenced by this reader.
-    ///
-    /// Returns [None] if path is not a glob pattern.
-    fn iter_paths(&self) -> PolarsResult<Option<PathIterator>> {
-        let paths = self.paths();
-        if paths.is_empty() {
-            let path_str = self.path().to_string_lossy();
-            if path_str.contains('*') || path_str.contains('?') || path_str.contains('[') {
-                polars_glob(&path_str, self.cloud_options()).map(Some)
-            } else {
-                Ok(None)
-            }
-        } else {
-            polars_ensure!(self.path().to_string_lossy() == "", InvalidOperation: "expected only a single path argument");
-            // Lint is incorrect as we need static lifetime.
-            #[allow(clippy::unnecessary_to_owned)]
-            Ok(Some(Box::new(paths.to_vec().into_iter().map(Ok))))
-        }
     }
 }

--- a/crates/polars-lazy/src/scan/ipc.rs
+++ b/crates/polars-lazy/src/scan/ipc.rs
@@ -44,9 +44,8 @@ impl LazyIpcReader {
 }
 
 impl LazyFileListReader for LazyIpcReader {
-    fn finish_no_glob(self) -> PolarsResult<LazyFrame> {
+    fn finish_no_glob(self, path: &Path) -> PolarsResult<LazyFrame> {
         let args = self.args;
-        let path = self.path;
 
         let options = IpcScanOptions {
             memmap: args.memmap,

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -81,7 +81,7 @@ impl LazyJsonLineReader {
 }
 
 impl LazyFileListReader for LazyJsonLineReader {
-    fn finish_no_glob(self) -> PolarsResult<LazyFrame> {
+    fn finish_no_glob(self, path: &Path) -> PolarsResult<LazyFrame> {
         let options = ScanArgsAnonymous {
             name: "JSON SCAN",
             infer_schema_length: self.infer_schema_length,

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -56,7 +56,7 @@ impl LazyParquetReader {
 impl LazyFileListReader for LazyParquetReader {
     /// Get the final [LazyFrame].
     fn finish(mut self) -> PolarsResult<LazyFrame> {
-        if let Some(paths) = self.iter_paths()? {
+        if let Some(paths) = self.iter_readers()? {
             let paths = paths
                 .into_iter()
                 .collect::<PolarsResult<Arc<[PathBuf]>>>()?;

--- a/crates/polars-plan/src/dot.rs
+++ b/crates/polars-plan/src/dot.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::fmt::{Display, Write};
-use std::path::PathBuf;
 
 use polars_core::prelude::*;
 
@@ -313,7 +312,7 @@ impl LogicalPlan {
                 }
             },
             Scan {
-                reader_factories: paths,
+                reader_factories,
                 file_info,
                 predicate,
                 scan_type,
@@ -325,7 +324,7 @@ impl LogicalPlan {
                     acc_str,
                     prev_node,
                     name,
-                    paths.as_ref(),
+                    reader_factories.iter().map(|rf|rf.to_string()).collect::<Vec<String>>().as_ref(),
                     options.with_columns.as_ref().map(|cols| cols.as_slice()),
                     file_info.schema.len(),
                     predicate,
@@ -410,7 +409,7 @@ impl LogicalPlan {
         acc_str: &mut String,
         prev_node: DotNode,
         name: &str,
-        path: &[PathBuf],
+        paths: &[String],
         with_columns: Option<&[String]>,
         total_columns: usize,
         predicate: &Option<P>,
@@ -423,14 +422,14 @@ impl LogicalPlan {
             n_columns_fmt = format!("{}", columns.len());
         }
 
-        let path_fmt = match path.len() {
-            1 => path[0].to_string_lossy(),
+        let path_fmt = match paths.len() {
+            1 => paths[0],
             0 => "".into(),
-            _ => Cow::Owned(format!(
+            _ => format!(
                 "{} files: first file: {}",
-                path.len(),
-                path[0].to_string_lossy()
-            )),
+                paths.len(),
+                paths[0]
+            ),
         };
 
         let pred = fmt_predicate(predicate.as_ref());

--- a/crates/polars-plan/src/dot.rs
+++ b/crates/polars-plan/src/dot.rs
@@ -313,7 +313,7 @@ impl LogicalPlan {
                 }
             },
             Scan {
-                paths,
+                reader_factories: paths,
                 file_info,
                 predicate,
                 scan_type,

--- a/crates/polars-plan/src/logical_plan/alp.rs
+++ b/crates/polars-plan/src/logical_plan/alp.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use polars_core::prelude::*;
+use polars_io::mmap::ReaderFactory;
 use polars_utils::arena::{Arena, Node};
 
 use super::projection_expr::*;
@@ -30,7 +30,7 @@ pub enum ALogicalPlan {
         predicate: Node,
     },
     Scan {
-        paths: Arc<[PathBuf]>,
+        reader_factories: Arc<[ReaderFactory]>,
         file_info: FileInfo,
         predicate: Option<Node>,
         /// schema of the projected file
@@ -293,7 +293,7 @@ impl ALogicalPlan {
                 options: *options,
             },
             Scan {
-                paths,
+                reader_factories,
                 file_info,
                 output_schema,
                 predicate,
@@ -305,7 +305,7 @@ impl ALogicalPlan {
                     new_predicate = exprs.pop()
                 }
                 Scan {
-                    paths: paths.clone(),
+                    reader_factories: reader_factories.clone(),
                     file_info: file_info.clone(),
                     output_schema: output_schema.clone(),
                     file_options: options.clone(),

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -313,7 +313,7 @@ impl LogicalPlanBuilder {
         truncate_ragged_lines: bool,
     ) -> PolarsResult<Self> {
         let mut reader = reader_factory.mmapbytesreader()?;
-        let paths = Arc::new([reader_factory]);
+        let reader_factories = Arc::new([reader_factory]);
         let mut magic_nr = [0u8; 2];
         let res = reader.read_exact(&mut magic_nr);
         if raise_if_empty {
@@ -377,7 +377,7 @@ impl LogicalPlanBuilder {
             hive_partitioning: false,
         };
         Ok(LogicalPlan::Scan {
-            reader_factories: paths,
+            reader_factories,
             file_info,
             file_options: options,
             predicate: None,

--- a/crates/polars-plan/src/logical_plan/conversion.rs
+++ b/crates/polars-plan/src/logical_plan/conversion.rs
@@ -173,7 +173,7 @@ pub fn to_alp(
     let v = match lp {
         LogicalPlan::Scan {
             file_info,
-            paths,
+            reader_factories: paths,
             predicate,
             scan_type,
             file_options: options,
@@ -614,7 +614,7 @@ impl ALogicalPlan {
                 output_schema: _,
                 file_options: options,
             } => LogicalPlan::Scan {
-                paths,
+                reader_factories: paths,
                 file_info,
                 predicate: predicate.map(|n| node_to_expr(n, expr_arena)),
                 scan_type,

--- a/crates/polars-plan/src/logical_plan/conversion.rs
+++ b/crates/polars-plan/src/logical_plan/conversion.rs
@@ -607,14 +607,14 @@ impl ALogicalPlan {
         };
         match lp {
             ALogicalPlan::Scan {
-                paths,
+                reader_factories,
                 file_info,
                 predicate,
                 scan_type,
                 output_schema: _,
                 file_options: options,
             } => LogicalPlan::Scan {
-                reader_factories: paths,
+                reader_factories,
                 file_info,
                 predicate: predicate.map(|n| node_to_expr(n, expr_arena)),
                 scan_type,

--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -101,7 +101,7 @@ impl LogicalPlan {
                 input._format(f, sub_indent)
             },
             Scan {
-                paths,
+                reader_factories: paths,
                 file_info,
                 predicate,
                 scan_type,

--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -1,10 +1,10 @@
 use std::fmt::Debug;
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use polars_core::prelude::*;
 #[cfg(any(feature = "cloud", feature = "parquet"))]
 use polars_io::cloud::CloudOptions;
+use polars_io::mmap::ReaderFactory;
 
 use crate::logical_plan::LogicalPlan::DataFrameScan;
 use crate::prelude::*;
@@ -162,7 +162,7 @@ pub enum LogicalPlan {
         count: usize,
     },
     Scan {
-        paths: Arc<[PathBuf]>,
+        reader_factories: Arc<[ReaderFactory]>,
         file_info: FileInfo,
         predicate: Option<Expr>,
         file_options: FileScanOptions,


### PR DESCRIPTION
# Motivation

## User stories

* Users want to be able to load CSVs from file-like Python objects (#12617)
* Likewise for Parquet (#10413)

## Issues with the current code

### Structural issues

* In `polars-lazy`, the various lazy file readers had a bad pattern where there was both a `path` and `paths` on the structs.
    * The `path` had two completely different meanings: a glob, and a specific file. A glob would be converted to a specific file with a specific `path`.
    * The `paths` would also be converted into specific files with a specific `path`.
    * In short, this is an implicit state machine with ... 6 states? Some of which were never addressed.
* In addition, any time time a `PathBuf` was used for a specific path to a file, it had two potential meanings: a local path on the filesystem, or a cloud URI. Dispatch was done based on `is_cloud_url()`.

Both these cases ought to be exposed via the type system.

### Functionality issues

Because all loading was assumed to be from a PathBuf, loading from a Python file-like object is not possible.

# Proposed design changes

1. Switch from `path` + `paths` in `LazyFileListReader` to a single `ReaderOrSources`. This is still not great, since there's still a requirement for the code to do things in a certain order if it doesn't want a panic; a better refactor would involve splitting the classes into a builder phase and a final phase. But it's a large enough branch as it is, and at least now there's only _two_ states instead of six!
2. Use of `PathBuf` for things to load is replaced with a `ReaderFactory`; for now it's either a filesystem path or a URI, but a Python factory function that returns file-like objects could be added. It's a factory to allow opening a file multiple times, and because of the need for (de)serialization.
* `mmap.rs` is probably the wrong place for `ReaderFactory`, it should probably be elsewhere.

I did some of the refactoring, but there's a lot more, and it will percolate throughout the code base, so this seemed like a good place to get some feedback.