### PR TITLE
fix(python): Enable special casing of sequence in list_to_struct

### DIFF
--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -1055,13 +1055,11 @@ class ExprListNameSpace:
         """
         if isinstance(fields, Sequence):
             field_names = list(fields)
-
-            def fields(idx: int) -> str:
-                return field_names[idx]
-
-        return wrap_expr(
-            self._pyexpr.list_to_struct(n_field_strategy, fields, upper_bound)
-        )
+            pyexpr = self._pyexpr.list_to_struct(n_field_strategy, None, upper_bound)
+            return wrap_expr(pyexpr).struct.rename_fields(field_names)
+        else:
+            pyexpr = self._pyexpr.list_to_struct(n_field_strategy, fields, upper_bound)
+            return wrap_expr(pyexpr)
 
     def eval(self, expr: Expr, *, parallel: bool = False) -> Expr:
         """

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -521,6 +521,15 @@ def test_list_to_struct() -> None:
     ]
 
 
+def test_select_from_list_to_struct_11143() -> None:
+    ldf = pl.LazyFrame({"some_col": [[1.0, 2.0], [1.5, 3.0]]})
+    ldf = ldf.select(
+        pl.col("some_col").list.to_struct(fields=["a", "b"], upper_bound=2)
+    )
+    df = ldf.select(pl.col("some_col").struct.field("a")).collect()
+    assert df.equals(pl.DataFrame({"a": [1.0, 1.5]}))
+
+
 def test_list_arr_get_8810() -> None:
     assert pl.DataFrame(pl.Series("a", [None], pl.List(pl.Int64))).select(
         pl.col("a").list.get(0)


### PR DESCRIPTION
This change enables `list_to_struct` with `fields` to work in a lazy context, closes https://github.com/pola-rs/polars/issues/11143