### PR TITLE
feat(python): Add optional strict parameter to rename

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -391,7 +391,7 @@ impl LazyFrame {
     /// corresponding new column names. Renaming happens to all `existing` columns
     /// simultaneously, not iteratively. (In particular, all columns in `existing` must
     /// already exist in the `LazyFrame` when `rename` is called.)
-    /// `strict` throw an error if a column is not present
+    /// `strict` throw an error if a column is not present.
     pub fn rename<I, J, T, S>(self, existing: I, new: J, strict: Option<bool>) -> Self
     where
         I: IntoIterator<Item = T>,

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -411,7 +411,7 @@ impl LazyFrame {
             let new = new.as_ref();
             if new != existing {
                 if !strict.unwrap_or(true) && !schema.contains(existing) {
-                    continue
+                    continue;
                 }
                 existing_vec.push(existing.into());
                 new_vec.push(new.into());

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -391,6 +391,7 @@ impl LazyFrame {
     /// corresponding new column names. Renaming happens to all `existing` columns
     /// simultaneously, not iteratively. (In particular, all columns in `existing` must
     /// already exist in the `LazyFrame` when `rename` is called.)
+    /// `strict` throw an error if a column is not present
     pub fn rename<I, J, T, S>(self, existing: I, new: J, strict: Option<bool>) -> Self
     where
         I: IntoIterator<Item = T>,

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -410,10 +410,7 @@ impl LazyFrame {
         for (existing, new) in iter.zip(new) {
             let existing = existing.as_ref();
             let new = new.as_ref();
-            if new != existing {
-                if !strict.unwrap_or(true) && !schema.contains(existing) {
-                    continue;
-                }
+            if new != existing && (strict.unwrap_or(true) || schema.contains(existing)) {
                 existing_vec.push(existing.into());
                 new_vec.push(new.into());
             }

--- a/crates/polars-lazy/src/tests/cse.rs
+++ b/crates/polars-lazy/src/tests/cse.rs
@@ -281,7 +281,7 @@ fn test_cse_columns_projections() -> PolarsResult<()> {
 
     let left = left.cross_join(right.clone().select([col("A")]));
     let q = left.join(
-        right.rename(["B"], ["C"]),
+        right.rename(["B"], ["C"], None),
         [col("A"), col("C")],
         [col("A"), col("C")],
         JoinType::Left.into(),

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -318,7 +318,7 @@ fn test_lazy_filter_and_rename() {
     let lf = df
         .clone()
         .lazy()
-        .rename(["a"], ["x"])
+        .rename(["a"], ["x"], None)
         .filter(col("x").map(
             |s: Series| Ok(Some(s.gt(3)?.into_series())),
             GetOutput::from_type(DataType::Boolean),
@@ -332,7 +332,7 @@ fn test_lazy_filter_and_rename() {
     assert!(lf.collect().unwrap().equals(&correct));
 
     // now we check if the column is rename or added when we don't select
-    let lf = df.lazy().rename(["a"], ["x"]).filter(col("x").map(
+    let lf = df.lazy().rename(["a"], ["x"], None).filter(col("x").map(
         |s: Series| Ok(Some(s.gt(3)?.into_series())),
         GetOutput::from_type(DataType::Boolean),
     ));

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -165,7 +165,7 @@ impl SqlExprVisitor<'_> {
             let schema_entry = schema.get_at_index(0);
             if let Some((old_name, _)) = schema_entry {
                 let new_name = String::from(old_name.as_str()) + rand_string.as_str();
-                lf = lf.rename([old_name.to_string()], [new_name.clone()]);
+                lf = lf.rename([old_name.to_string()], [new_name.clone()], None);
 
                 return Ok(Expr::SubPlan(
                     SpecialEq::new(Arc::new(lf.logical_plan)),

--- a/crates/polars/tests/it/lazy/predicate_queries.rs
+++ b/crates/polars/tests/it/lazy/predicate_queries.rs
@@ -11,7 +11,7 @@ fn test_predicate_after_renaming() -> PolarsResult<()> {
         "bar" => [3, 2, 1]
     ]?
     .lazy()
-    .rename(["foo", "bar"], ["foo2", "bar2"])
+    .rename(["foo", "bar"], ["foo2", "bar2"], None)
     .filter(col("foo2").eq(col("bar2")))
     .collect()?;
 

--- a/crates/polars/tests/it/lazy/projection_queries.rs
+++ b/crates/polars/tests/it/lazy/projection_queries.rs
@@ -22,7 +22,7 @@ fn test_swap_rename() -> PolarsResult<()> {
         "b" => [2],
     ]?
     .lazy()
-    .rename(["a", "b"], ["b", "a"])
+    .rename(["a", "b"], ["b", "a"], None)
     .collect()?;
 
     let expected = df![

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3900,7 +3900,7 @@ class DataFrame:
         """
         return self.select(F.col("*").reverse())
 
-    def rename(self, mapping: dict[str, str], strict: bool = True) -> DataFrame:
+    def rename(self, mapping: dict[str, str], *, strict: bool = True) -> DataFrame:
         """
         Rename column names.
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3900,7 +3900,7 @@ class DataFrame:
         """
         return self.select(F.col("*").reverse())
 
-    def rename(self, mapping: dict[str, str]) -> DataFrame:
+    def rename(self, mapping: dict[str, str], strict: bool = True) -> DataFrame:
         """
         Rename column names.
 
@@ -3908,6 +3908,8 @@ class DataFrame:
         ----------
         mapping
             Key value pairs that map from old name to new name.
+        strict
+            Throw an error if a column is not present
 
         Examples
         --------
@@ -3927,7 +3929,7 @@ class DataFrame:
         └───────┴─────┴─────┘
 
         """
-        return self.lazy().rename(mapping).collect(_eager=True)
+        return self.lazy().rename(mapping, strict=strict).collect(_eager=True)
 
     def insert_column(self, index: int, column: Series) -> Self:
         """

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3909,7 +3909,7 @@ class DataFrame:
         mapping
             Key value pairs that map from old name to new name.
         strict
-            Throw an error if a column is not present
+            Throw an error if a column is not present.
 
         Examples
         --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4227,7 +4227,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         drop_cols = _expand_selectors(self, columns, *more_columns)
         return self._from_pyldf(self._ldf.drop(drop_cols))
 
-    def rename(self, mapping: dict[str, str]) -> Self:
+    def rename(self, mapping: dict[str, str], strict: bool = True) -> Self:
         """
         Rename column names.
 
@@ -4235,6 +4235,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ----------
         mapping
             Key value pairs that map from old name to new name.
+        strict
+            Throw an error if a column is not present
 
         Notes
         -----
@@ -4263,6 +4265,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └───────┴─────┴─────┘
 
         """
+        if strict is False:
+            mapping = {k: v for k, v in mapping.items() if k in self.columns}
+
         existing = list(mapping.keys())
         new = list(mapping.values())
         return self._from_pyldf(self._ldf.rename(existing, new))

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4236,7 +4236,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         mapping
             Key value pairs that map from old name to new name.
         strict
-            Throw an error if a column is not present
+            Throw an error if a column is not present.
 
         Notes
         -----

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4227,7 +4227,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         drop_cols = _expand_selectors(self, columns, *more_columns)
         return self._from_pyldf(self._ldf.drop(drop_cols))
 
-    def rename(self, mapping: dict[str, str], strict: bool = True) -> Self:
+    def rename(self, mapping: dict[str, str], *, strict: bool = True) -> Self:
         """
         Rename column names.
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4265,12 +4265,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         └───────┴─────┴─────┘
 
         """
-        if strict is False:
-            mapping = {k: v for k, v in mapping.items() if k in self.columns}
-
         existing = list(mapping.keys())
         new = list(mapping.values())
-        return self._from_pyldf(self._ldf.rename(existing, new))
+        return self._from_pyldf(self._ldf.rename(existing, new, strict))
 
     def reverse(self) -> Self:
         """

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -840,9 +840,9 @@ impl PyLazyFrame {
         ldf.with_columns_seq(exprs.to_exprs()).into()
     }
 
-    fn rename(&mut self, existing: Vec<String>, new: Vec<String>) -> Self {
+    fn rename(&mut self, existing: Vec<String>, new: Vec<String>, strict: bool) -> Self {
         let ldf = self.ldf.clone();
-        ldf.rename(existing, new).into()
+        ldf.rename(existing, new, Some(strict)).into()
     }
 
     fn reverse(&self) -> Self {

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2005,9 +2005,9 @@ def test_rename_strict() -> None:
         }
     )
     with pytest.raises(pl.exceptions.SchemaFieldNotFoundError):
-        df.rename({'a': 'c', 'd': 'e'})
+        df.rename({"a": "c", "d": "e"})
 
-    result = df.rename({'a': 'c', 'd': 'e'}, strict=False)
+    result = df.rename({"a": "c", "d": "e"}, strict=False)
     expected = pl.DataFrame(
         {
             "c": [1, 2, 3, 4, 5],

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1997,6 +1997,21 @@ def test_rename_same_name() -> None:
     }
 
 
+def test_rename_strict() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 5],
+            "b": ["A", "A", "B", "C", "B"],
+        }
+    )
+    with pytest.raises(pl.exceptions.SchemaFieldNotFoundError):
+        df.rename({'a': 'c', 'd': 'e'})
+
+    result = df.rename({'a': 'c', 'd': 'e'}, strict=False)
+    expected = df.rename({'a': 'c'})
+    assert_frame_equal(result, expected)
+
+
 def test_fill_null() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [3, None]})
     assert_frame_equal(df.fill_null(4), pl.DataFrame({"a": [1, 2], "b": [3, 4]}))

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2008,7 +2008,12 @@ def test_rename_strict() -> None:
         df.rename({'a': 'c', 'd': 'e'})
 
     result = df.rename({'a': 'c', 'd': 'e'}, strict=False)
-    expected = df.rename({'a': 'c'})
+    expected = pl.DataFrame(
+        {
+            "c": [1, 2, 3, 4, 5],
+            "b": ["A", "A", "B", "C", "B"],
+        }
+    )
     assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2004,7 +2004,7 @@ def test_rename_strict() -> None:
             "b": ["A", "A", "B", "C", "B"],
         }
     )
-    with pytest.raises(pl.exceptions.SchemaFieldNotFoundError):
+    with pytest.raises(pl.SchemaFieldNotFoundError):
         df.rename({"a": "c", "d": "e"})
 
     result = df.rename({"a": "c", "d": "e"}, strict=False)


### PR DESCRIPTION
Maybe it would be better to implement this on the Rust side to keep the api consistent between Rust and Python.
Let me know if you want this, I think I can do it.