### PR TITLE
perf(python): speedup initialising `Series` from a list of numpy arrays

### DIFF
--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -86,6 +86,29 @@ def _set_numpy_to_constructor() -> None:
     }
 
 
+@functools.lru_cache(maxsize=32)
+def _normalise_numpy_dtype(dtype: Any) -> tuple[Any, Any]:
+    normalised_dtype = (
+        np.dtype(dtype.base.name) if dtype.kind in ("i", "u", "f") else dtype
+    ).type
+    cast_as: Any = None
+    if normalised_dtype == np.float16:
+        normalised_dtype = cast_as = np.float32
+    elif normalised_dtype in (np.datetime64, np.timedelta64):
+        time_unit = np.datetime_data(dtype)[0]
+        if time_unit in dt.DTYPE_TEMPORAL_UNITS or (
+            time_unit == "D" and normalised_dtype == np.datetime64
+        ):
+            cast_as = np.int64
+        else:
+            raise ValueError(
+                "incorrect NumPy datetime resolution"
+                "\n\n'D' (datetime only), 'ms', 'us', and 'ns' resolutions are supported when converting from numpy.{datetime64,timedelta64}."
+                " Please cast to the closest supported unit before converting."
+            )
+    return normalised_dtype, cast_as
+
+
 def numpy_values_and_dtype(
     values: np.ndarray[Any, Any]
 ) -> tuple[np.ndarray[Any, Any], type]:
@@ -93,27 +116,9 @@ def numpy_values_and_dtype(
     # Create new dtype object from dtype base name so architecture specific
     # dtypes (np.longlong np.ulonglong np.intc np.uintc np.longdouble, ...)
     # get converted to their normalized dtype (np.int*, np.uint*, np.float*).
-    dtype = (
-        np.dtype(values.dtype.base.name).type
-        if values.dtype.kind in ("i", "u", "f")
-        else values.dtype.type
-    )
-
-    if dtype == np.float16:
-        values = values.astype(np.float32)
-        dtype = values.dtype.type
-    elif dtype in [np.datetime64, np.timedelta64]:
-        time_unit = np.datetime_data(values.dtype)[0]
-        if time_unit in dt.DTYPE_TEMPORAL_UNITS or (
-            time_unit == "D" and dtype == np.datetime64
-        ):
-            values = values.astype(np.int64)
-        else:
-            raise ValueError(
-                "incorrect NumPy datetime resolution"
-                "\n\n'D' (datetime only), 'ms', 'us', and 'ns' resolutions are supported when converting from numpy.{datetime64,timedelta64}."
-                " Please cast to the closest supported unit before converting."
-            )
+    dtype, cast_as = _normalise_numpy_dtype(values.dtype)
+    if cast_as:
+        values = values.astype(cast_as)
     return values, dtype
 
 

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -535,14 +535,24 @@ def sequence_to_pyseries(
             and isinstance(value, np.ndarray)
             and len(value.shape) == 1
         ):
-            return PySeries.new_series_list(
-                name,
-                [
-                    numpy_to_pyseries("", v, strict=strict, nan_to_null=nan_to_null)
-                    for v in values
-                ],
-                strict,
-            )
+            n_elems = len(value)
+            if all(len(v) == n_elems for v in values):
+                # can take (much) faster path if all lists are the same length
+                return numpy_to_pyseries(
+                    name,
+                    np.vstack(values),
+                    strict=strict,
+                    nan_to_null=nan_to_null,
+                )
+            else:
+                return PySeries.new_series_list(
+                    name,
+                    [
+                        numpy_to_pyseries("", v, strict=strict, nan_to_null=nan_to_null)
+                        for v in values
+                    ],
+                    strict,
+                )
 
         elif python_dtype in (list, tuple):
             if isinstance(dtype, Object):


### PR DESCRIPTION
Closes #12774.

The "20x" speed difference referenced in the linked isn't really accurate as the pandas implementation doesn't actually consolidate the arrays at init time, but rather later when an operation executes (so the cost is deferred/hidden). 

However, it _did_ make me go looking for some additional speedups, and I was able to lean on the [previous](https://github.com/pola-rs/polars/pull/12672) optimisation to get a nice gain here... (typically ~5-10x):

### Example

```python
import polars as pl
import numpy as np

data = np.random.rand(10_000_000, 2)

def get_data():
    return (row for row in data)

with Timer():
    df = pl.DataFrame({"x": get_data()})
```
Timings:
```
BEFORE: 46.632 seconds
 AFTER:  5.140 seconds
```