### PR TITLE
fix(python): Revert type hint change on expression inputs

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2385,7 +2385,7 @@ class Expr:
         ):
             indices_lit = F.lit(pl.Series("", indices, dtype=UInt32))._pyexpr
         else:
-            indices_lit = parse_as_expression(indices)
+            indices_lit = parse_as_expression(indices)  # type: ignore[arg-type]
         return self._from_pyexpr(self._pyexpr.gather(indices_lit))
 
     def get(self, index: int | Expr) -> Self:

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -69,7 +69,7 @@ PythonLiteral: TypeAlias = Union[
     NumericLiteral, TemporalLiteral, str, bool, bytes, List[Any]
 ]
 # Inputs that can convert into a `col` expression
-IntoExprColumn: TypeAlias = Union["Expr", "Series", str, "np.ndarray"]
+IntoExprColumn: TypeAlias = Union["Expr", "Series", str]
 # Inputs that can convert into an expression
 IntoExpr: TypeAlias = Union[PythonLiteral, IntoExprColumn, None]
 

--- a/py-polars/tests/unit/interop/test_numpy.py
+++ b/py-polars/tests/unit/interop/test_numpy.py
@@ -42,7 +42,10 @@ def test_view_deprecated() -> None:
 
 def test_numpy_disambiguation() -> None:
     a = np.array([1, 2])
-    assert pl.DataFrame({"a": a}).with_columns(b=a).to_dict(as_series=False) == {
+    df = pl.DataFrame({"a": a})
+    result = df.with_columns(b=a).to_dict(as_series=False)  # type: ignore[arg-type]
+    expected = {
         "a": [1, 2],
         "b": [1, 2],
     }
+    assert result == expected


### PR DESCRIPTION
Closes #12782

Reverts the type hint change in #12709

This change basically meant that type hinting was disabled for anyone that did not have NumPy installed, as `np.ndarray` is treated as `Any`.

I am not sure what the best way to go about this is, but I'd rather have some false positives on NumPy inputs (that you can mute by wrapping with `lit`) than no type hinting at all. We can revisit this at a later point.