### PR TITLE
fix(python): More accurate type hinting for `collect_all` functions

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1542,7 +1542,7 @@ def arg_sort_by(
     "common_subplan_elimination", "comm_subplan_elim", version="0.18.9"
 )
 def collect_all(
-    lazy_frames: Sequence[LazyFrame],
+    lazy_frames: Iterable[LazyFrame],
     *,
     type_coercion: bool = True,
     predicate_pushdown: bool = True,
@@ -1621,7 +1621,7 @@ def collect_all(
 
 @overload
 def collect_all_async(
-    lazy_frames: Sequence[LazyFrame],
+    lazy_frames: Iterable[LazyFrame],
     *,
     gevent: Literal[True],
     type_coercion: bool = True,
@@ -1639,7 +1639,7 @@ def collect_all_async(
 
 @overload
 def collect_all_async(
-    lazy_frames: Sequence[LazyFrame],
+    lazy_frames: Iterable[LazyFrame],
     *,
     gevent: Literal[False] = False,
     type_coercion: bool = True,
@@ -1656,7 +1656,7 @@ def collect_all_async(
 
 
 def collect_all_async(
-    lazy_frames: Sequence[LazyFrame],
+    lazy_frames: Iterable[LazyFrame],
     *,
     gevent: bool = False,
     type_coercion: bool = True,


### PR DESCRIPTION
Closes #12793.
Both functions can accept _any_ Iterable of `lazy_frames`; doesn't have to be Sequence.