### PR TITLE
Add quotes to pip install with dependencies

### DIFF
--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -42,7 +42,7 @@ By using the above command you install the core of Polars onto your system. Howe
 
 ```text
 # For example
-pip install polars[numpy, fsspec]
+pip install 'polars[numpy,fsspec]'
 ```
 
 | Tag        | Description                                                                                                                           |


### PR DESCRIPTION
Prior to this fix the pip command fails on both zsh and bash.