### PR TITLE
fix: use total float ordering in is_in

### DIFF
--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -1,13 +1,12 @@
-use std::hash::Hash;
-
 use polars_core::prelude::*;
 use polars_core::utils::{try_get_supertype, CustomIterTools};
-use polars_core::with_match_physical_integer_polars_type;
+use polars_core::with_match_physical_numeric_polars_type;
+use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
 
 fn is_in_helper<'a, T>(ca: &'a ChunkedArray<T>, other: &Series) -> PolarsResult<BooleanChunked>
 where
     T: PolarsDataType,
-    T::Physical<'a>: Hash + Eq + Copy,
+    T::Physical<'a>: TotalHash + TotalEq + Copy,
 {
     let mut set = PlHashSet::with_capacity(other.len());
 
@@ -15,17 +14,17 @@ where
     other.downcast_iter().for_each(|iter| {
         iter.iter().for_each(|opt_val| {
             if let Some(v) = opt_val {
-                set.insert(v);
+                set.insert(TotalOrdWrap(v));
             }
         })
     });
-    Ok(ca.apply_values_generic(|val| set.contains(&val)))
+    Ok(ca.apply_values_generic(|val| set.contains(&TotalOrdWrap(val))))
 }
 
 fn is_in_numeric<T>(ca_in: &ChunkedArray<T>, other: &Series) -> PolarsResult<BooleanChunked>
 where
-    T: PolarsIntegerType,
-    T::Native: Hash + Eq,
+    T: PolarsNumericType,
+    T::Native: TotalHash + TotalEq,
 {
     // We check implicitly cast to supertype here
     match other.dtype() {
@@ -363,43 +362,9 @@ pub fn is_in(s: &Series, other: &Series) -> PolarsResult<BooleanChunked> {
             let ca = s.bool().unwrap();
             is_in_boolean(ca, other)
         },
-        DataType::Float32 => {
-            let other = match other.dtype() {
-                DataType::List(_) => {
-                    let other = other.cast(&DataType::List(Box::new(DataType::Float32)))?;
-                    let other = other.list().unwrap();
-                    other.reinterpret_unsigned()
-                },
-                _ => {
-                    let other = other.cast(&DataType::Float32)?;
-                    let other = other.f32().unwrap();
-                    other.reinterpret_unsigned()
-                },
-            };
-            let ca = s.f32().unwrap();
-            let s = ca.reinterpret_unsigned();
-            is_in(&s, &other)
-        },
-        DataType::Float64 => {
-            let other = match other.dtype() {
-                DataType::List(_) => {
-                    let other = other.cast(&DataType::List(Box::new(DataType::Float64)))?;
-                    let other = other.list().unwrap();
-                    other.reinterpret_unsigned()
-                },
-                _ => {
-                    let other = other.cast(&DataType::Float64)?;
-                    let other = other.f64().unwrap();
-                    other.reinterpret_unsigned()
-                },
-            };
-            let ca = s.f64().unwrap();
-            let s = ca.reinterpret_unsigned();
-            is_in(&s, &other)
-        },
-        dt if dt.to_physical().is_integer() => {
+        dt if dt.to_physical().is_numeric() => {
             let s = s.to_physical_repr();
-            with_match_physical_integer_polars_type!(s.dtype(), |$T| {
+            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
                 let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
                 is_in_numeric(ca, other)
             })

--- a/crates/polars-utils/src/total_ord.rs
+++ b/crates/polars-utils/src/total_ord.rs
@@ -11,7 +11,7 @@ pub fn canonical_f32(x: f32) -> f32 {
     if convert_zero.is_nan() {
         f32::from_bits(0x7fc00000) // Canonical quiet NaN.
     } else {
-        x
+        convert_zero
     }
 }
 
@@ -23,7 +23,7 @@ pub fn canonical_f64(x: f64) -> f64 {
     if convert_zero.is_nan() {
         f64::from_bits(0x7ff8000000000000) // Canonical quiet NaN.
     } else {
-        x
+        convert_zero
     }
 }
 

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -165,6 +165,14 @@ def test_is_in_invalid_shape() -> None:
         pl.Series("a", [1, 2, 3]).is_in([[]])
 
 
+@pytest.mark.parametrize("dtype", [pl.Float32, pl.Float64])
+def test_is_in_float(dtype: pl.PolarsDataType) -> None:
+    s = pl.Series([float("nan"), 0.0], dtype=dtype)
+    result = s.is_in([-0.0, -float("nan")])
+    expected = pl.Series([True, True], dtype=pl.Boolean)
+    assert_series_equal(result, expected)
+
+
 @pytest.mark.parametrize(
     ("df", "matches", "expected_error"),
     [


### PR DESCRIPTION
Now all nans and signed zeros correctly match each other in `is_in`.