### PR TITLE
feat: specific performance warnings from rust to python

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
@@ -118,7 +118,7 @@ fn merge_local_rhs_categorical<'a>(
     // In case of local categorical we also need to change the physicals not only the revmap
 
     polars_warn!(
-        PerformanceCategoricalRemappingWarning,
+        CategoricalRemappingWarning,
         "Local categoricals have different encodings, expensive re-encoding is done \
     to perform this merge operation. Consider using a StringCache or an Enum type \
     if the categories are known in advance"

--- a/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
@@ -118,6 +118,7 @@ fn merge_local_rhs_categorical<'a>(
     // In case of local categorical we also need to change the physicals not only the revmap
 
     polars_warn!(
+        PerformanceCategoricalRemappingWarning,
         "Local categoricals have different encodings, expensive re-encoding is done \
     to perform this merge operation. Consider using a StringCache or an Enum type \
     if the categories are known in advance"

--- a/crates/polars-error/src/warning.rs
+++ b/crates/polars-error/src/warning.rs
@@ -13,7 +13,7 @@ pub unsafe fn set_warning_function(function: WarningFunction) {
 #[derive(Debug)]
 pub enum PolarsWarning {
     UserWarning,
-    PerformanceCategoricalRemappingWarning,
+    CategoricalRemappingWarning,
 }
 
 fn eprintln(fmt: &str, warning: PolarsWarning) {

--- a/crates/polars-error/src/warning.rs
+++ b/crates/polars-error/src/warning.rs
@@ -1,4 +1,4 @@
-type WarningFunction = fn(&str);
+type WarningFunction = fn(&str, PolarsWarning);
 static mut WARNING_FUNCTION: Option<WarningFunction> = None;
 
 /// Set the function that will be called by the `polars_warn!` macro.
@@ -10,9 +10,14 @@ static mut WARNING_FUNCTION: Option<WarningFunction> = None;
 pub unsafe fn set_warning_function(function: WarningFunction) {
     WARNING_FUNCTION = Some(function)
 }
+#[derive(Debug)]
+pub enum PolarsWarning {
+    UserWarning,
+    PerformanceCategoricalRemappingWarning,
+}
 
-fn eprintln(fmt: &str) {
-    eprintln!("{}", fmt);
+fn eprintln(fmt: &str, warning: PolarsWarning) {
+    eprintln!("{:?}: {}", warning, fmt);
 }
 
 pub fn get_warning_function() -> WarningFunction {
@@ -20,10 +25,17 @@ pub fn get_warning_function() -> WarningFunction {
 }
 #[macro_export]
 macro_rules! polars_warn {
+    ($variant:ident, $fmt:literal $(, $arg:tt)*) => {
+        {{
+        let func = $crate::get_warning_function();
+        let warn = $crate::PolarsWarning::$variant;
+        func(format!($fmt, $($arg)*).as_ref(), warn)
+        }}
+    };
     ($fmt:literal, $($arg:tt)+) => {
         {{
         let func = $crate::get_warning_function();
-        func(format!($fmt, $($arg)+).as_ref())
+        func(format!($fmt, $($arg)+).as_ref(), $crate::PolarsWarning::UserWarning)
         }}
     };
     ($($arg:tt)+) => {

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -74,6 +74,7 @@ from polars.exceptions import (
     SchemaFieldNotFoundError,
     ShapeError,
     StructFieldNotFoundError,
+    PerformanceWarningCategoricalRemapping
 )
 from polars.expr import Expr
 from polars.functions import (
@@ -220,6 +221,8 @@ __all__ = [
     "SchemaFieldNotFoundError",
     "ShapeError",
     "StructFieldNotFoundError",
+    # warnings
+    "PerformanceWarningCategoricalRemapping",
     # core classes
     "DataFrame",
     "Expr",

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -69,12 +69,12 @@ from polars.exceptions import (
     InvalidOperationError,
     NoDataError,
     OutOfBoundsError,
+    PerformanceWarningCategoricalRemapping,
     PolarsPanicError,
     SchemaError,
     SchemaFieldNotFoundError,
     ShapeError,
     StructFieldNotFoundError,
-    PerformanceWarningCategoricalRemapping
 )
 from polars.expr import Expr
 from polars.functions import (

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -62,6 +62,7 @@ from polars.datatypes import (
 )
 from polars.exceptions import (
     ArrowError,
+    CategoricalRemappingWarning,
     ChronoFormatWarning,
     ColumnNotFoundError,
     ComputeError,
@@ -69,7 +70,6 @@ from polars.exceptions import (
     InvalidOperationError,
     NoDataError,
     OutOfBoundsError,
-    PerformanceWarningCategoricalRemapping,
     PolarsPanicError,
     SchemaError,
     SchemaFieldNotFoundError,
@@ -222,7 +222,7 @@ __all__ = [
     "ShapeError",
     "StructFieldNotFoundError",
     # warnings
-    "PerformanceWarningCategoricalRemapping",
+    "CategoricalRemappingWarning",
     # core classes
     "DataFrame",
     "Expr",

--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -6,6 +6,7 @@ try:
         InvalidOperationError,
         NoDataError,
         OutOfBoundsError,
+        PerformanceWarningCategoricalRemapping,
         PolarsPanicError,
         SchemaError,
         SchemaFieldNotFoundError,
@@ -52,6 +53,9 @@ except ImportError:
 
     class StructFieldNotFoundError(Exception):  # type: ignore[no-redef]
         """Exception raised when a specified schema field is not found."""
+
+    class PerformanceWarningCategoricalRemapping(Warning):  # type: ignore[no-redef]
+        """Warning raised when a categorical needs to be remapped to be compatible with another categorical."""  # noqa: W505
 
 
 class ChronoFormatWarning(Warning):
@@ -113,6 +117,7 @@ __all__ = [
     "NoRowsReturnedError",
     "OutOfBoundsError",
     "PolarsInefficientMapWarning",
+    "PerformanceWarningCategoricalRemapping",
     "PolarsPanicError",
     "RowsError",
     "SchemaError",

--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -1,12 +1,12 @@
 try:
     from polars.polars import (
+        CategoricalRemappingWarning,
         ColumnNotFoundError,
         ComputeError,
         DuplicateError,
         InvalidOperationError,
         NoDataError,
         OutOfBoundsError,
-        PerformanceWarningCategoricalRemapping,
         PolarsPanicError,
         SchemaError,
         SchemaFieldNotFoundError,
@@ -54,7 +54,7 @@ except ImportError:
     class StructFieldNotFoundError(Exception):  # type: ignore[no-redef]
         """Exception raised when a specified schema field is not found."""
 
-    class PerformanceWarningCategoricalRemapping(Warning):  # type: ignore[no-redef]
+    class CategoricalRemappingWarning(Warning):  # type: ignore[no-redef]
         """Warning raised when a categorical needs to be remapped to be compatible with another categorical."""  # noqa: W505
 
 
@@ -117,7 +117,7 @@ __all__ = [
     "NoRowsReturnedError",
     "OutOfBoundsError",
     "PolarsInefficientMapWarning",
-    "PerformanceWarningCategoricalRemapping",
+    "CategoricalRemappingWarning",
     "PolarsPanicError",
     "RowsError",
     "SchemaError",

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -505,9 +505,10 @@ def _get_stack_locals(
 
 
 # this is called from rust
-def _polars_warn(msg: str) -> None:
+def _polars_warn(msg: str, category: type[Warning] = UserWarning) -> None:
     warnings.warn(
         msg,
+        category=category,
         stacklevel=find_stacklevel(),
     )
 

--- a/py-polars/src/error.rs
+++ b/py-polars/src/error.rs
@@ -85,11 +85,7 @@ create_exception!(polars.exceptions, SchemaFieldNotFoundError, PyException);
 create_exception!(polars.exceptions, ShapeError, PyException);
 create_exception!(polars.exceptions, StringCacheMismatchError, PyException);
 create_exception!(polars.exceptions, StructFieldNotFoundError, PyException);
-create_exception!(
-    polars.exceptions,
-    PerformanceWarningCategoricalRemapping,
-    PyWarning
-);
+create_exception!(polars.exceptions, CategoricalRemappingWarning, PyWarning);
 
 #[macro_export]
 macro_rules! raise_err(
@@ -102,8 +98,8 @@ macro_rules! raise_err(
 impl IntoPy<PyObject> for Wrap<PolarsWarning> {
     fn into_py(self, py: Python<'_>) -> PyObject {
         match self.0 {
-            PolarsWarning::PerformanceCategoricalRemappingWarning => {
-                PerformanceWarningCategoricalRemapping::type_object(py).to_object(py)
+            PolarsWarning::CategoricalRemappingWarning => {
+                CategoricalRemappingWarning::type_object(py).to_object(py)
             },
             PolarsWarning::UserWarning => PyUserWarning::type_object(py).to_object(py),
         }

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -51,8 +51,8 @@ use pyo3::wrap_pyfunction;
 use crate::conversion::Wrap;
 use crate::dataframe::PyDataFrame;
 use crate::error::{
-    ColumnNotFoundError, ComputeError, DuplicateError, InvalidOperationError, NoDataError,
-    OutOfBoundsError, PerformanceWarningCategoricalRemapping, PyPolarsErr, SchemaError,
+    CategoricalRemappingWarning, ColumnNotFoundError, ComputeError, DuplicateError,
+    InvalidOperationError, NoDataError, OutOfBoundsError, PyPolarsErr, SchemaError,
     SchemaFieldNotFoundError, StructFieldNotFoundError,
 };
 use crate::expr::PyExpr;
@@ -274,8 +274,8 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     .unwrap();
     m.add("NoDataError", py.get_type::<NoDataError>()).unwrap();
     m.add(
-        "PerformanceWarningCategoricalRemapping",
-        py.get_type::<PerformanceWarningCategoricalRemapping>(),
+        "CategoricalRemappingWarning",
+        py.get_type::<CategoricalRemappingWarning>(),
     )
     .unwrap();
     m.add("OutOfBoundsError", py.get_type::<OutOfBoundsError>())

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -52,7 +52,8 @@ use crate::conversion::Wrap;
 use crate::dataframe::PyDataFrame;
 use crate::error::{
     ColumnNotFoundError, ComputeError, DuplicateError, InvalidOperationError, NoDataError,
-    OutOfBoundsError, PyPolarsErr, SchemaError, SchemaFieldNotFoundError, StructFieldNotFoundError,
+    OutOfBoundsError, PerformanceWarningCategoricalRemapping, PyPolarsErr, SchemaError,
+    SchemaFieldNotFoundError, StructFieldNotFoundError,
 };
 use crate::expr::PyExpr;
 use crate::functions::string_cache::PyStringCacheHolder;
@@ -272,6 +273,11 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     )
     .unwrap();
     m.add("NoDataError", py.get_type::<NoDataError>()).unwrap();
+    m.add(
+        "PerformanceWarningCategoricalRemapping",
+        py.get_type::<PerformanceWarningCategoricalRemapping>(),
+    )
+    .unwrap();
     m.add("OutOfBoundsError", py.get_type::<OutOfBoundsError>())
         .unwrap();
     m.add("PolarsPanicError", py.get_type::<PanicException>())

--- a/py-polars/src/on_startup.rs
+++ b/py-polars/src/on_startup.rs
@@ -8,6 +8,7 @@ use polars_core::chunked_array::object::registry::AnonymousObjectBuilder;
 use polars_core::error::PolarsError::ComputeError;
 use polars_core::error::PolarsResult;
 use polars_core::frame::DataFrame;
+use polars_error::PolarsWarning;
 use pyo3::intern;
 use pyo3::prelude::*;
 
@@ -57,14 +58,14 @@ fn python_function_caller_df(df: DataFrame, lambda: &PyObject) -> PolarsResult<D
     })
 }
 
-fn warning_function(msg: &str) {
+fn warning_function(msg: &str, warning: PolarsWarning) {
     Python::with_gil(|py| {
         let warn_fn = UTILS
             .as_ref(py)
             .getattr(intern!(py, "_polars_warn"))
             .unwrap();
 
-        if let Err(e) = warn_fn.call1((msg,)) {
+        if let Err(e) = warn_fn.call1((msg, Wrap(warning))) {
             eprintln!("{e}")
         }
     });

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -7,7 +7,10 @@ import pytest
 
 import polars as pl
 from polars import StringCache
-from polars.exceptions import StringCacheMismatchError
+from polars.exceptions import (
+    PerformanceWarningCategoricalRemapping,
+    StringCacheMismatchError,
+)
 from polars.testing import assert_frame_equal
 
 
@@ -422,7 +425,10 @@ def test_categorical_update_lengths() -> None:
 def test_categorical_zip_append_local_different_rev_map() -> None:
     s1 = pl.Series(["cat1", "cat2", "cat1"], dtype=pl.Categorical)
     s2 = pl.Series(["cat2", "cat2", "cat3"], dtype=pl.Categorical)
-    with pytest.warns(UserWarning, match="Local categoricals have different encodings"):
+    with pytest.warns(
+        PerformanceWarningCategoricalRemapping,
+        match="Local categoricals have different encodings",
+    ):
         s3 = s1.append(s2)
     categories = s3.cat.get_categories()
     assert len(categories) == 3
@@ -432,7 +438,10 @@ def test_categorical_zip_append_local_different_rev_map() -> None:
 def test_categorical_zip_extend_local_different_rev_map() -> None:
     s1 = pl.Series(["cat1", "cat2", "cat1"], dtype=pl.Categorical)
     s2 = pl.Series(["cat2", "cat2", "cat3"], dtype=pl.Categorical)
-    with pytest.warns(UserWarning, match="Local categoricals have different encodings"):
+    with pytest.warns(
+        PerformanceWarningCategoricalRemapping,
+        match="Local categoricals have different encodings",
+    ):
         s3 = s1.extend(s2)
     categories = s3.cat.get_categories()
     assert len(categories) == 3
@@ -443,7 +452,10 @@ def test_categorical_zip_with_local_different_rev_map() -> None:
     s1 = pl.Series(["cat1", "cat2", "cat1"], dtype=pl.Categorical)
     mask = pl.Series([True, False, False])
     s2 = pl.Series(["cat2", "cat2", "cat3"], dtype=pl.Categorical)
-    with pytest.warns(UserWarning, match="Local categoricals have different encodings"):
+    with pytest.warns(
+        PerformanceWarningCategoricalRemapping,
+        match="Local categoricals have different encodings",
+    ):
         s3 = s1.zip_with(mask, s2)
     categories = s3.cat.get_categories()
     assert len(categories) == 3
@@ -453,7 +465,10 @@ def test_categorical_zip_with_local_different_rev_map() -> None:
 def test_categorical_vstack_with_local_different_rev_map() -> None:
     df1 = pl.DataFrame({"a": pl.Series(["a", "b", "c"], dtype=pl.Categorical)})
     df2 = pl.DataFrame({"a": pl.Series(["d", "e", "f"], dtype=pl.Categorical)})
-    with pytest.warns(UserWarning, match="Local categoricals have different encodings"):
+    with pytest.warns(
+        PerformanceWarningCategoricalRemapping,
+        match="Local categoricals have different encodings",
+    ):
         df3 = df1.vstack(df2)
     assert df3.get_column("a").cat.get_categories().to_list() == [
         "a",

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -8,7 +8,7 @@ import pytest
 import polars as pl
 from polars import StringCache
 from polars.exceptions import (
-    PerformanceWarningCategoricalRemapping,
+    CategoricalRemappingWarning,
     StringCacheMismatchError,
 )
 from polars.testing import assert_frame_equal
@@ -426,7 +426,7 @@ def test_categorical_zip_append_local_different_rev_map() -> None:
     s1 = pl.Series(["cat1", "cat2", "cat1"], dtype=pl.Categorical)
     s2 = pl.Series(["cat2", "cat2", "cat3"], dtype=pl.Categorical)
     with pytest.warns(
-        PerformanceWarningCategoricalRemapping,
+        CategoricalRemappingWarning,
         match="Local categoricals have different encodings",
     ):
         s3 = s1.append(s2)
@@ -439,7 +439,7 @@ def test_categorical_zip_extend_local_different_rev_map() -> None:
     s1 = pl.Series(["cat1", "cat2", "cat1"], dtype=pl.Categorical)
     s2 = pl.Series(["cat2", "cat2", "cat3"], dtype=pl.Categorical)
     with pytest.warns(
-        PerformanceWarningCategoricalRemapping,
+        CategoricalRemappingWarning,
         match="Local categoricals have different encodings",
     ):
         s3 = s1.extend(s2)
@@ -453,7 +453,7 @@ def test_categorical_zip_with_local_different_rev_map() -> None:
     mask = pl.Series([True, False, False])
     s2 = pl.Series(["cat2", "cat2", "cat3"], dtype=pl.Categorical)
     with pytest.warns(
-        PerformanceWarningCategoricalRemapping,
+        CategoricalRemappingWarning,
         match="Local categoricals have different encodings",
     ):
         s3 = s1.zip_with(mask, s2)
@@ -466,7 +466,7 @@ def test_categorical_vstack_with_local_different_rev_map() -> None:
     df1 = pl.DataFrame({"a": pl.Series(["a", "b", "c"], dtype=pl.Categorical)})
     df2 = pl.DataFrame({"a": pl.Series(["d", "e", "f"], dtype=pl.Categorical)})
     with pytest.warns(
-        PerformanceWarningCategoricalRemapping,
+        CategoricalRemappingWarning,
         match="Local categoricals have different encodings",
     ):
         df3 = df1.vstack(df2)

--- a/py-polars/tests/unit/test_string_cache.py
+++ b/py-polars/tests/unit/test_string_cache.py
@@ -3,7 +3,7 @@ from typing import Iterator
 import pytest
 
 import polars as pl
-from polars.exceptions import PerformanceWarningCategoricalRemapping
+from polars.exceptions import CategoricalRemappingWarning
 from polars.testing import assert_frame_equal
 
 
@@ -126,7 +126,7 @@ def test_string_cache_join() -> None:
     assert pl.using_string_cache() is False
 
     with pytest.warns(
-        PerformanceWarningCategoricalRemapping,
+        CategoricalRemappingWarning,
         match="Local categoricals have different encodings",
     ):
         df1a = df1.with_columns(pl.col("a").cast(pl.Categorical))

--- a/py-polars/tests/unit/test_string_cache.py
+++ b/py-polars/tests/unit/test_string_cache.py
@@ -3,6 +3,7 @@ from typing import Iterator
 import pytest
 
 import polars as pl
+from polars.exceptions import PerformanceWarningCategoricalRemapping
 from polars.testing import assert_frame_equal
 
 
@@ -124,7 +125,10 @@ def test_string_cache_join() -> None:
     pl.disable_string_cache()
     assert pl.using_string_cache() is False
 
-    with pytest.warns(UserWarning, match="Local categoricals have different encodings"):
+    with pytest.warns(
+        PerformanceWarningCategoricalRemapping,
+        match="Local categoricals have different encodings",
+    ):
         df1a = df1.with_columns(pl.col("a").cast(pl.Categorical))
         df2a = df2.with_columns(pl.col("a").cast(pl.Categorical))
         out = df1a.join(df2a, on="a", how="inner")


### PR DESCRIPTION
fix #12753 

Right now, we issue warnings from rust to python. These all lead to the base `UserWarning` class which is not very user friendly for ignoring certain warnings. This PR introduces a way to issue specific warnings from Rust to python and uses the categorical remapping as a start

```python
import polars as pl
s = pl.Series(['a','b'],dtype=pl.Categorical)
s2 = pl.Series(['b','a'],dtype=pl.Categorical)
s.append(s2)
```
```
PerformanceWarningCategoricalRemapping: Local categoricals have different encodings, expensive re-encoding is done to perform this merge operation. Consider using a StringCache or an Enum type if the categories are known in advance
```

You can now ignore this warning with
```python
import warnings
warnings.simplefilter('ignore',pl.PerformanceWarningCategoricalRemapping)
```