### PR TITLE
feat: Support `Array` dtype AnyValue Series construction

### DIFF
--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -235,6 +235,9 @@ impl Series {
                 any_values_to_decimal(av, *precision, *scale)?.into_series()
             },
             DataType::List(inner) => any_values_to_list(av, inner, strict)?.into_series(),
+            DataType::Array(inner, size) => any_values_to_list(av, inner, strict)?
+                .into_series()
+                .cast(&DataType::Array(inner.clone(), *size))?,
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(dtype_fields) => {
                 // fast path for empty structs

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -235,6 +235,7 @@ impl Series {
                 any_values_to_decimal(av, *precision, *scale)?.into_series()
             },
             DataType::List(inner) => any_values_to_list(av, inner, strict)?.into_series(),
+            #[cfg(feature = "dtype-array")]
             DataType::Array(inner, size) => any_values_to_list(av, inner, strict)?
                 .into_series()
                 .cast(&DataType::Array(inner.clone(), *size))?,

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -51,6 +51,16 @@ def test_array_construction() -> None:
     ]
     assert df.rows() == []
 
+    # from dicts
+    rows = [
+        {"row_id": "a", "data": [1, 2, 3]},
+        {"row_id": "b", "data": [2, 3, 4]},
+    ]
+    schema = {"row_id": pl.Utf8(), "data": pl.Array(inner=pl.Int64, width=3)}
+    df = pl.from_dicts(rows, schema=schema)
+    assert df.schema == schema
+    assert df.rows() == [("a", [1, 2, 3]), ("b", [2, 3, 4])]
+
 
 def test_array_in_group_by() -> None:
     df = pl.DataFrame(


### PR DESCRIPTION
Closes #12719.

Observationally the cast from `List` to `Array` is (as expected) _extremely_ cheap (eg: a  "with_columns" cast of a 25_000_000 x 4 `List` col to `Array` only takes 0.0096 secs), so this PR seems to be a simple/minimal way to support `Array` AnyValues (absent a dedicated micro-optimised path 🤔)

This opens up `Array` usage to additional constructors, such as `pl.from_dicts` in the linked issue, which otherwise fail.