### PR TITLE
fix: incorrect values from parquet RLE decoding

### DIFF
--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -564,13 +564,13 @@ def test_decimal_parquet(tmp_path: Path) -> None:
 
 def test_parquet_rle_non_nullable_12814() -> None:
     column = (
-        pl.select(x=pl.arange(0, 493569, dtype=pl.Int64) // 10).to_series().to_arrow()
+        pl.select(x=pl.arange(0, 1025, dtype=pl.Int64) // 10).to_series().to_arrow()
     )
     schema = pa.schema([pa.field("foo", pa.int64(), nullable=False)])
     table = pa.Table.from_arrays([column], schema=schema)
 
     f = io.BytesIO()
-    pq.write_table(table, f)
+    pq.write_table(table, f, data_page_size=1)
     f.seek(0)
 
     expect = pl.DataFrame(table).tail(10)

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -560,3 +560,20 @@ def test_decimal_parquet(tmp_path: Path) -> None:
     df.write_parquet(path, statistics=True)
     out = pl.scan_parquet(path).filter(foo=2).collect().to_dict(as_series=False)
     assert out == {"foo": [2], "bar": [Decimal("7")]}
+
+
+def test_parquet_rle_non_nullable_12814() -> None:
+    column = (
+        pl.select(x=pl.arange(0, 493569, dtype=pl.Int64) // 10).to_series().to_arrow()
+    )
+    schema = pa.schema([pa.field("foo", pa.int64(), nullable=False)])
+    table = pa.Table.from_arrays([column], schema=schema)
+
+    f = io.BytesIO()
+    pq.write_table(table, f)
+    f.seek(0)
+
+    expect = pl.DataFrame(table).tail(10)
+    actual = pl.read_parquet(f).tail(10)
+
+    assert_frame_equal(expect, actual)


### PR DESCRIPTION
Fix https://github.com/pola-rs/polars/issues/12814, https://github.com/pola-rs/polars/issues/12788

Comparing the 2 match blocks, the 2nd match block forgot to `.take` out of `Single`. This PR introduces a loop to re-use the same match.