### PR TITLE
feat(python, rust): SQL Subqueries for `JOIN` and `FROM` 

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -594,6 +594,16 @@ impl SQLContext {
                     polars_bail!(ComputeError: "relation '{}' was not found", tbl_name);
                 }
             },
+            TableFactor::Derived { lateral, subquery, alias } => {
+                polars_ensure!(!(*lateral), ComputeError: "LATERAL not supported");
+                if let Some(alias) = alias {
+                    let lf = self.execute_query_no_ctes(subquery)?;
+                    self.table_map.insert(alias.name.value.clone(), lf.clone());
+                    Ok((alias.name.value.clone(), lf))
+                } else {
+                    polars_bail!(ComputeError: "Derived tables must have aliases");
+                }
+            },
             // Support bare table, optional with alias for now
             _ => polars_bail!(ComputeError: "not implemented"),
         }

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -594,7 +594,11 @@ impl SQLContext {
                     polars_bail!(ComputeError: "relation '{}' was not found", tbl_name);
                 }
             },
-            TableFactor::Derived { lateral, subquery, alias } => {
+            TableFactor::Derived {
+                lateral,
+                subquery,
+                alias,
+            } => {
                 polars_ensure!(!(*lateral), ComputeError: "LATERAL not supported");
                 if let Some(alias) = alias {
                     let lf = self.execute_query_no_ctes(subquery)?;

--- a/py-polars/tests/unit/sql/test_subqueries.py
+++ b/py-polars/tests/unit/sql/test_subqueries.py
@@ -3,6 +3,65 @@ import pytest
 import polars as pl
 from polars.testing import assert_frame_equal
 
+def test_sql_join_on_subquery() -> None:
+    df1 = pl.DataFrame(
+        {
+            "x": [-1, 0, 1, 2, 3, 4],
+        }
+    )
+
+    df2 = pl.DataFrame(
+        {
+            "y": [0, 1, 2, 3],
+        }
+    )
+
+    sql = pl.SQLContext(df1=df1, df2=df2)
+    res = sql.execute(
+        """
+        SELECT
+        *
+        FROM df1
+        INNER JOIN (SELECT * FROM df2) AS df2
+        ON df1.x = df2.y
+        """
+        , eager = True)
+    
+    df_expected_join = pl.DataFrame({"x": [0, 1, 2, 3]})
+    assert_frame_equal(
+        left=res,
+        right=df_expected_join,
+    )
+
+def test_sql_from_subquery() -> None:
+    df1 = pl.DataFrame(
+        {
+            "x": [-1, 0, 1, 2, 3, 4],
+        }
+    )
+
+    df2 = pl.DataFrame(
+        {
+            "y": [0, 1, 2, 3],
+        }
+    )
+
+    sql = pl.SQLContext(df1=df1, df2=df2)
+    res = sql.execute(
+        """
+        SELECT
+        *
+        FROM (SELECT * FROM df1) AS df1
+        INNER JOIN (SELECT * FROM df2) AS df2
+        ON df1.x = df2.y
+        """
+        , eager = True)
+    
+    df_expected_join = pl.DataFrame({"x": [0, 1, 2, 3]})
+    assert_frame_equal(
+        left=res,
+        right=df_expected_join,
+    )
 
 def test_sql_in_subquery() -> None:
     df = pl.DataFrame(

--- a/py-polars/tests/unit/sql/test_subqueries.py
+++ b/py-polars/tests/unit/sql/test_subqueries.py
@@ -3,6 +3,7 @@ import pytest
 import polars as pl
 from polars.testing import assert_frame_equal
 
+
 def test_sql_join_on_subquery() -> None:
     df1 = pl.DataFrame(
         {
@@ -24,14 +25,16 @@ def test_sql_join_on_subquery() -> None:
         FROM df1
         INNER JOIN (SELECT * FROM df2) AS df2
         ON df1.x = df2.y
-        """
-        , eager = True)
-    
+        """,
+        eager=True,
+    )
+
     df_expected_join = pl.DataFrame({"x": [0, 1, 2, 3]})
     assert_frame_equal(
         left=res,
         right=df_expected_join,
     )
+
 
 def test_sql_from_subquery() -> None:
     df1 = pl.DataFrame(
@@ -54,14 +57,16 @@ def test_sql_from_subquery() -> None:
         FROM (SELECT * FROM df1) AS df1
         INNER JOIN (SELECT * FROM df2) AS df2
         ON df1.x = df2.y
-        """
-        , eager = True)
-    
+        """,
+        eager=True,
+    )
+
     df_expected_join = pl.DataFrame({"x": [0, 1, 2, 3]})
     assert_frame_equal(
         left=res,
         right=df_expected_join,
     )
+
 
 def test_sql_in_subquery() -> None:
     df = pl.DataFrame(


### PR DESCRIPTION
Adds the ability to use subqueries in `JOIN` and `FROM`. 

```SQL
df1 = pl.DataFrame(
    {
        "x": [-1, 0, 1, 2, 3, 4],
    }
)

df2 = pl.DataFrame(
    {
        "y": [0, 1, 2, 3],
    }
)

sql = pl.SQLContext(register_globals=True)
res = sql.execute(
    """
    SELECT
    *
    FROM (SELECT * FROM df1) AS df3
    INNER JOIN (SELECT * FROM df2) AS df4
    ON df3.x = df4.y
    """
	, eager = True)
print(res)
```
