### PR TITLE
chore(rust): Update `make check` to only check `polars` crate

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - crates/**
+      - docs/src/rust/**
       - examples/**
       - py-polars/src/**
       - py-polars/Cargo.toml
@@ -14,6 +15,7 @@ on:
       - main
     paths:
       - crates/**
+      - docs/src/rust/**
       - examples/**
       - py-polars/src/**
       - py-polars/Cargo.toml

--- a/crates/Makefile
+++ b/crates/Makefile
@@ -10,7 +10,7 @@ fmt:  ## Run rustfmt and dprint
 
 .PHONY: check
 check:  ## Run cargo check with all features
-	cargo check --workspace --all-targets --all-features
+	cargo check -p polars --all-features
 
 .PHONY: clippy
 clippy:  ## Run clippy with all features


### PR DESCRIPTION
Should improve dev flow.

Also make sure to run the lint workflow when doc examples are changed.