### PR TITLE
docs(python): Update version switcher for `0.20`

### DIFF
--- a/py-polars/docs/source/_static/version_switcher.json
+++ b/py-polars/docs/source/_static/version_switcher.json
@@ -5,10 +5,15 @@
         "url": "https://pola-rs.github.io/polars/docs/python/dev/"
     },
     {
-        "name": "0.19 (stable)",
-        "version": "0.19",
+        "name": "0.20 (stable)",
+        "version": "0.20",
         "url": "https://pola-rs.github.io/polars/py-polars/html/",
         "preferred": true
+    },
+    {
+        "name": "0.19",
+        "version": "0.19",
+        "url": "https://pola-rs.github.io/polars/docs/python/version/0.19/"
     },
     {
         "name": "0.18",


### PR DESCRIPTION
This should be the last commit merged before the `0.20.0` version bump and subsequent release.