### PR TITLE
feat(python): add dedicated `Decimal` selector

### DIFF
--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -17,6 +17,7 @@ from polars.datatypes import (
     Categorical,
     Date,
     Datetime,
+    Decimal,
     Duration,
     Object,
     Time,
@@ -964,6 +965,60 @@ def datetime(
         name="datetime",
         parameters={"time_unit": time_unit, "time_zone": time_zone},
     )
+
+
+def decimal() -> SelectorType:
+    """
+    Select all decimal columns.
+
+    See Also
+    --------
+    float : Select all float columns.
+    integer : Select all integer columns.
+    numeric : Select all numeric columns.
+
+    Examples
+    --------
+    >>> from decimal import Decimal as D
+    >>> import polars.selectors as cs
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "foo": ["x", "y"],
+    ...         "bar": [D(123), D(456)],
+    ...         "baz": [D("2.0005"), D("-50.5555")],
+    ...     },
+    ...     schema_overrides={"baz": pl.Decimal(scale=5, precision=10)},
+    ... )
+
+    Select all decimal columns:
+
+    >>> df.select(cs.decimal())
+    shape: (2, 2)
+    ┌──────────────┬───────────────┐
+    │ bar          ┆ baz           │
+    │ ---          ┆ ---           │
+    │ decimal[*,0] ┆ decimal[10,5] │
+    ╞══════════════╪═══════════════╡
+    │ 123          ┆ 2.00050       │
+    │ 456          ┆ -50.55550     │
+    └──────────────┴───────────────┘
+
+    Select all columns *except* the decimal ones:
+
+    >>> df.select(~cs.decimal())
+    shape: (2, 1)
+    ┌─────┐
+    │ foo │
+    │ --- │
+    │ str │
+    ╞═════╡
+    │ x   │
+    │ y   │
+    └─────┘
+
+    """
+    # TODO: allow explicit selection by scale/precision?
+    return _selector_proxy_(F.col(Decimal), name="decimal")
 
 
 def duration(

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -175,6 +175,20 @@ def test_selector_datetime(df: pl.DataFrame) -> None:
     )
 
 
+def test_select_decimal(df: pl.DataFrame) -> None:
+    assert df.select(cs.decimal()).columns == []
+    df = pl.DataFrame(
+        schema={
+            "zz0": pl.Float64,
+            "zz1": pl.Decimal,
+            "zz2": pl.Decimal(10, 10),
+        }
+    )
+    assert df.select(cs.numeric()).columns == ["zz0", "zz1", "zz2"]
+    assert df.select(cs.decimal()).columns == ["zz1", "zz2"]
+    assert df.select(~cs.decimal()).columns == ["zz0"]
+
+
 def test_selector_drop(df: pl.DataFrame) -> None:
     dfd = df.drop(cs.numeric(), cs.temporal())
     assert dfd.columns == ["eee", "fgg", "qqR"]


### PR DESCRIPTION
Was reminded to add this missing selector by #12837  :)

## Example

```python
import polars as pl

df = pl.DataFrame(
    data = [],
    schema = {
        "flt": pl.Float64,
        "dec1": pl.Decimal,
        "dec2": pl.Decimal(10, 10),
    }
)
# shape: (0, 3)
# ┌─────┬──────────────┬────────────────┐
# │ flt ┆ dec1         ┆ dec2           │
# │ --- ┆ ---          ┆ ---            │
# │ f64 ┆ decimal[*,0] ┆ decimal[10,10] │
# ╞═════╪══════════════╪════════════════╡
# └─────┴──────────────┴────────────────┘

df.select(cs.numeric()).columns
# ['flt', 'dec1', 'dec2']

df.select(cs.decimal()).columns
# ['dec1', 'dec2']
```