### PR TITLE
fix(python): Fix `Array` dtype equality

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -613,8 +613,8 @@ class Array(NestedType):
         ]
 
         """
-        self.width = width
         self.inner = polars.datatypes.py_type_to_dtype(inner)
+        self.width = width
 
     def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
         # This equality check allows comparison of type classes and type instances.
@@ -627,7 +627,9 @@ class Array(NestedType):
         if type(other) is DataTypeClass and issubclass(other, Array):
             return True
         if isinstance(other, Array):
-            if self.inner is None or other.inner is None:
+            if self.width != other.width:
+                return False
+            elif self.inner is None or other.inner is None:
                 return True
             else:
                 return self.inner == other.inner

--- a/py-polars/tests/unit/datatypes/test_array.py
+++ b/py-polars/tests/unit/datatypes/test_array.py
@@ -141,3 +141,11 @@ def test_array_in_list() -> None:
         dtype=pl.List(pl.Array(pl.Int8, 2)),
     )
     assert s.dtype == pl.List(pl.Array(pl.Int8, 2))
+
+
+def test_array_data_type_equality() -> None:
+    assert pl.Array(pl.Int64, 2) == pl.Array
+    assert pl.Array(pl.Int64, 2) == pl.Array(pl.Int64, 2)
+    assert pl.Array(pl.Int64, 2) != pl.Array(pl.Int64, 3)
+    assert pl.Array(pl.Int64, 2) != pl.Array(pl.Utf8, 2)
+    assert pl.Array(pl.Int64, 2) != pl.List(pl.Int64)


### PR DESCRIPTION
The implementation was copied over from `List` and it lacked a check for the `width` property.