### PR TITLE
fix: fixup repr of Expr.gather (which was still showing deprecated take)

### DIFF
--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -286,7 +286,7 @@ impl Debug for Expr {
                 if *returns_scalar {
                     write!(f, "{expr:?}.get({idx:?})")
                 } else {
-                    write!(f, "{expr:?}.take({idx:?})")
+                    write!(f, "{expr:?}.gather({idx:?})")
                 }
             },
             SubPlan(lf, _) => {

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -789,3 +789,10 @@ def test_repr_long_expression() -> None:
     expected = "<Expr ['dtype_columns([Utf8]).str.coun…'] at "
     assert result == expected
     assert repr(expr).endswith(">")
+
+
+def test_repr_gather() -> None:
+    result = repr(pl.col("a").gather(0))
+    assert 'col("a").gather(0)' in result
+    result = repr(pl.col("a").get(0))
+    assert 'col("a").get(0)' in result


### PR DESCRIPTION
On the latest release we see
```python

In [43]: print(pl.col('a').gather(0))
col("a").take(0)
```