### PR TITLE
refactor(rust!): rename more take_* to gather_* methods

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -413,7 +413,7 @@ mod test {
 
         assert_eq!(s.n_unique().unwrap(), 3);
         // Make sure that it does not take the fast path after take/slice.
-        let out = s.take(&IdxCa::new("", [1, 2])).unwrap();
+        let out = s.gather(&IdxCa::new("", [1, 2])).unwrap();
         assert_eq!(out.n_unique().unwrap(), 2);
         let out = s.slice(1, 2);
         assert_eq!(out.n_unique().unwrap(), 2);

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -748,7 +748,7 @@ pub(crate) mod test {
     #[test]
     fn take() {
         let a = get_chunked_array();
-        let new = a.take(&[0 as IdxSize, 1]).unwrap();
+        let new = a.gather(&[0 as IdxSize, 1]).unwrap();
         assert_eq!(new.len(), 2)
     }
 

--- a/crates/polars-core/src/chunked_array/ops/gather.rs
+++ b/crates/polars-core/src/chunked_array/ops/gather.rs
@@ -42,11 +42,11 @@ where
     ChunkedArray<T>: ChunkTakeUnchecked<I>,
 {
     /// Gather values from ChunkedArray by index.
-    fn take(&self, indices: &I) -> PolarsResult<Self> {
+    fn gather(&self, indices: &I) -> PolarsResult<Self> {
         check_bounds(indices.as_ref(), self.len() as IdxSize)?;
 
         // SAFETY: we just checked the indices are valid.
-        Ok(unsafe { self.take_unchecked(indices) })
+        Ok(unsafe { self.gather_unchecked(indices) })
     }
 }
 
@@ -55,11 +55,11 @@ where
     ChunkedArray<T>: ChunkTakeUnchecked<IdxCa>,
 {
     /// Gather values from ChunkedArray by index.
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Self> {
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Self> {
         check_bounds_ca(indices, self.len() as IdxSize)?;
 
         // SAFETY: we just checked the indices are valid.
-        Ok(unsafe { self.take_unchecked(indices) })
+        Ok(unsafe { self.gather_unchecked(indices) })
     }
 }
 
@@ -144,7 +144,7 @@ unsafe fn gather_idx_array_unchecked<A: StaticArray>(
 
 impl<T: PolarsDataType, I: AsRef<[IdxSize]> + ?Sized> ChunkTakeUnchecked<I> for ChunkedArray<T> {
     /// Gather values from ChunkedArray by index.
-    unsafe fn take_unchecked(&self, indices: &I) -> Self {
+    unsafe fn gather_unchecked(&self, indices: &I) -> Self {
         let rechunked;
         let mut ca = self;
         if self.chunks().len() > BINARY_SEARCH_LIMIT {
@@ -164,7 +164,7 @@ impl<T: PolarsDataType, I: AsRef<[IdxSize]> + ?Sized> ChunkTakeUnchecked<I> for 
 
 impl<T: PolarsDataType> ChunkTakeUnchecked<IdxCa> for ChunkedArray<T> {
     /// Gather values from ChunkedArray by index.
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Self {
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Self {
         let rechunked;
         let mut ca = self;
         if self.chunks().len() > BINARY_SEARCH_LIMIT {

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -119,7 +119,7 @@ pub trait ChunkRollApply: AsRefDataType {
 
 pub trait ChunkTake<Idx: ?Sized>: ChunkTakeUnchecked<Idx> {
     /// Gather values from ChunkedArray by index.
-    fn take(&self, indices: &Idx) -> PolarsResult<Self>
+    fn gather(&self, indices: &Idx) -> PolarsResult<Self>
     where
         Self: Sized;
 }
@@ -129,7 +129,7 @@ pub trait ChunkTakeUnchecked<Idx: ?Sized> {
     ///
     /// # Safety
     /// The non-null indices must be valid.
-    unsafe fn take_unchecked(&self, indices: &Idx) -> Self;
+    unsafe fn gather_unchecked(&self, indices: &Idx) -> Self;
 }
 
 /// Create a `ChunkedArray` with new values by index or by boolean mask.

--- a/crates/polars-core/src/chunked_array/ops/reverse.rs
+++ b/crates/polars-core/src/chunked_array/ops/reverse.rs
@@ -83,6 +83,6 @@ impl ChunkReverse for ArrayChunked {
 impl<T: PolarsObject> ChunkReverse for ObjectChunked<T> {
     fn reverse(&self) -> Self {
         // SAFETY: we know we don't go out of bounds.
-        unsafe { self.take_unchecked(&(0..self.len() as IdxSize).rev().collect_ca("")) }
+        unsafe { self.gather_unchecked(&(0..self.len() as IdxSize).rev().collect_ca("")) }
     }
 }

--- a/crates/polars-core/src/chunked_array/random.rs
+++ b/crates/polars-core/src/chunked_array/random.rs
@@ -95,13 +95,13 @@ impl Series {
                 let idx = create_rand_index_with_replacement(n, len, seed);
                 debug_assert_eq!(len, self.len());
                 // SAFETY: we know that we never go out of bounds.
-                unsafe { Ok(self.take_unchecked(&idx)) }
+                unsafe { Ok(self.gather_unchecked(&idx)) }
             },
             false => {
                 let idx = create_rand_index_no_replacement(n, len, seed, shuffle);
                 debug_assert_eq!(len, self.len());
                 // SAFETY: we know that we never go out of bounds.
-                unsafe { Ok(self.take_unchecked(&idx)) }
+                unsafe { Ok(self.gather_unchecked(&idx)) }
             },
         }
     }
@@ -124,7 +124,7 @@ impl Series {
         let idx = create_rand_index_no_replacement(n, len, seed, true);
         debug_assert_eq!(len, self.len());
         // SAFETY: we know that we never go out of bounds.
-        unsafe { self.take_unchecked(&idx) }
+        unsafe { self.gather_unchecked(&idx) }
     }
 }
 
@@ -149,13 +149,13 @@ where
                 let idx = create_rand_index_with_replacement(n, len, seed);
                 debug_assert_eq!(len, self.len());
                 // SAFETY: we know that we never go out of bounds.
-                unsafe { Ok(self.take_unchecked(&idx)) }
+                unsafe { Ok(self.gather_unchecked(&idx)) }
             },
             false => {
                 let idx = create_rand_index_no_replacement(n, len, seed, shuffle);
                 debug_assert_eq!(len, self.len());
                 // SAFETY: we know that we never go out of bounds.
-                unsafe { Ok(self.take_unchecked(&idx)) }
+                unsafe { Ok(self.gather_unchecked(&idx)) }
             },
         }
     }

--- a/crates/polars-core/src/frame/group_by/aggregations/agg_list.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/agg_list.rs
@@ -157,7 +157,7 @@ impl AggList for BooleanChunked {
                 let mut builder =
                     ListBooleanChunkedBuilder::new(self.name(), groups.len(), self.len());
                 for idx in groups.all().iter() {
-                    let ca = { self.take_unchecked(idx) };
+                    let ca = { self.gather_unchecked(idx) };
                     builder.append(&ca)
                 }
                 builder.finish().into_series()
@@ -183,7 +183,7 @@ impl AggList for Utf8Chunked {
                 let mut builder =
                     ListUtf8ChunkedBuilder::new(self.name(), groups.len(), self.len());
                 for idx in groups.all().iter() {
-                    let ca = { self.take_unchecked(idx) };
+                    let ca = { self.gather_unchecked(idx) };
                     builder.append(&ca)
                 }
                 builder.finish().into_series()
@@ -208,7 +208,7 @@ impl AggList for BinaryChunked {
                 let mut builder =
                     ListBinaryChunkedBuilder::new(self.name(), groups.len(), self.len());
                 for idx in groups.all().iter() {
-                    let ca = { self.take_unchecked(idx) };
+                    let ca = { self.gather_unchecked(idx) };
                     builder.append(&ca)
                 }
                 builder.finish().into_series()
@@ -292,7 +292,7 @@ impl AggList for ListChunked {
                         // SAFETY:
                         // group tuples are in bounds
                         {
-                            let mut s = ca.take_unchecked(idx);
+                            let mut s = ca.gather_unchecked(idx);
                             let arr = s.chunks.pop().unwrap_unchecked_release();
                             list_values.push_unchecked(arr);
 
@@ -362,7 +362,7 @@ impl AggList for ArrayChunked {
 
                         // SAFETY: group tuples are in bounds
                         {
-                            let mut s = ca.take_unchecked(idx);
+                            let mut s = ca.gather_unchecked(idx);
                             let arr = s.chunks.pop().unwrap_unchecked_release();
                             list_values.push_unchecked(arr);
                         }
@@ -419,7 +419,7 @@ impl<T: PolarsObject> AggList for ObjectChunked<T> {
                         GroupsIndicator::Idx((_first, idx)) => {
                             // SAFETY:
                             // group tuples always in bounds
-                            let group_vals = self.take_unchecked(idx);
+                            let group_vals = self.gather_unchecked(idx);
 
                             (group_vals, idx.len() as IdxSize)
                         },
@@ -481,7 +481,7 @@ impl AggList for StructChunked {
                     Some(self.dtype().clone()),
                 );
                 for idx in groups.all().iter() {
-                    let taken = s.take_slice_unchecked(idx);
+                    let taken = s.gather_slice_unchecked(idx);
                     builder.append_series(&taken).unwrap();
                 }
                 builder.finish().into_series()

--- a/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
@@ -24,7 +24,7 @@ impl Series {
                 } else if !self.has_validity() {
                     Some(idx.len() as IdxSize)
                 } else {
-                    let take = unsafe { self.take_slice_unchecked(idx) };
+                    let take = unsafe { self.gather_slice_unchecked(idx) };
                     Some((take.len() - take.null_count()) as IdxSize)
                 }
             }),
@@ -61,7 +61,7 @@ impl Series {
                     )
                     .collect_ca("");
                 // SAFETY: groups are always in bounds.
-                self.take_unchecked(&indices)
+                self.gather_unchecked(&indices)
             },
             GroupsProxy::Slice { groups, .. } => {
                 let indices = groups
@@ -69,7 +69,7 @@ impl Series {
                     .map(|&[first, len]| if len == 0 { None } else { Some(first) })
                     .collect_ca("");
                 // SAFETY: groups are always in bounds.
-                self.take_unchecked(&indices)
+                self.gather_unchecked(&indices)
             },
         };
         if groups.is_sorted_flag() {
@@ -86,7 +86,7 @@ impl Series {
                 if idx.is_empty() {
                     None
                 } else {
-                    let take = self.take_slice_unchecked(idx);
+                    let take = self.gather_slice_unchecked(idx);
                     take.n_unique().ok().map(|v| v as IdxSize)
                 }
             }),
@@ -193,7 +193,7 @@ impl Series {
                         }
                     })
                     .collect_ca("");
-                self.take_unchecked(&indices)
+                self.gather_unchecked(&indices)
             },
             GroupsProxy::Slice { groups, .. } => {
                 let indices = groups
@@ -206,7 +206,7 @@ impl Series {
                         }
                     })
                     .collect_ca("");
-                self.take_unchecked(&indices)
+                self.gather_unchecked(&indices)
             },
         };
         self.restore_logical(out)

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -355,7 +355,7 @@ where
                 if idx.is_empty() {
                     return None;
                 }
-                let take = { ca.take_unchecked(idx) };
+                let take = { ca.gather_unchecked(idx) };
                 // checked with invalid quantile check
                 take._quantile(quantile, interpol).unwrap_unchecked()
             })
@@ -429,7 +429,7 @@ where
                 if idx.is_empty() {
                     return None;
                 }
-                let take = { ca.take_unchecked(idx) };
+                let take = { ca.gather_unchecked(idx) };
                 take._median()
             })
         },
@@ -956,7 +956,7 @@ where
                                 })
                             },
                             _ => {
-                                let take = { self.take_unchecked(idx) };
+                                let take = { self.gather_unchecked(idx) };
                                 take.mean()
                             },
                         }

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -272,7 +272,7 @@ impl<'df> GroupBy<'df> {
                     match groups {
                         GroupsProxy::Idx(groups) => {
                             // SAFETY: groups are always in bounds.
-                            let mut out = unsafe { s.take_slice_unchecked(groups.first()) };
+                            let mut out = unsafe { s.gather_slice_unchecked(groups.first()) };
                             if groups.sorted {
                                 out.set_sorted_flag(s.is_sorted_flag());
                             };
@@ -291,7 +291,7 @@ impl<'df> GroupBy<'df> {
 
                             let indices = groups.iter().map(|&[first, _len]| first).collect_ca("");
                             // SAFETY: groups are always in bounds.
-                            let mut out = unsafe { s.take_unchecked(&indices) };
+                            let mut out = unsafe { s.gather_unchecked(&indices) };
                             // Sliced groups are always in order of discovery.
                             out.set_sorted_flag(s.is_sorted_flag());
                             out

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -108,20 +108,20 @@ impl SeriesTrait for SeriesWrap<ArrayChunked> {
         self.0.take_opt_chunked_unchecked(by).into_series()
     }
 
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
-        Ok(self.0.take(indices)?.into_series())
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
+        Ok(self.0.gather(indices)?.into_series())
     }
 
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
-        self.0.take_unchecked(indices).into_series()
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
+        self.0.gather_unchecked(indices).into_series()
     }
 
-    fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
-        Ok(self.0.take(indices)?.into_series())
+    fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+        Ok(self.0.gather(indices)?.into_series())
     }
 
-    unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
-        self.0.take_unchecked(indices).into_series()
+    unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+        self.0.gather_unchecked(indices).into_series()
     }
 
     fn len(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -142,20 +142,20 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
         self.0.take_opt_chunked_unchecked(by).into_series()
     }
 
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
-        Ok(self.0.take(indices)?.into_series())
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
+        Ok(self.0.gather(indices)?.into_series())
     }
 
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
-        self.0.take_unchecked(indices).into_series()
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
+        self.0.gather_unchecked(indices).into_series()
     }
 
-    fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
-        Ok(self.0.take(indices)?.into_series())
+    fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+        Ok(self.0.gather(indices)?.into_series())
     }
 
-    unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
-        self.0.take_unchecked(indices).into_series()
+    unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+        self.0.gather_unchecked(indices).into_series()
     }
 
     fn len(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -178,20 +178,20 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         self.0.take_opt_chunked_unchecked(by).into_series()
     }
 
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
-        Ok(self.0.take(indices)?.into_series())
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
+        Ok(self.0.gather(indices)?.into_series())
     }
 
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
-        self.0.take_unchecked(indices).into_series()
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
+        self.0.gather_unchecked(indices).into_series()
     }
 
-    fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
-        Ok(self.0.take(indices)?.into_series())
+    fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+        Ok(self.0.gather(indices)?.into_series())
     }
 
-    unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
-        self.0.take_unchecked(indices).into_series()
+    unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+        self.0.gather_unchecked(indices).into_series()
     }
 
     fn len(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -199,23 +199,23 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         self.finish_with_state(false, cats).into_series()
     }
 
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
-        self.try_with_state(false, |cats| cats.take(indices))
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
+        self.try_with_state(false, |cats| cats.gather(indices))
             .map(|ca| ca.into_series())
     }
 
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
-        self.with_state(false, |cats| cats.take_unchecked(indices))
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
+        self.with_state(false, |cats| cats.gather_unchecked(indices))
             .into_series()
     }
 
-    fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
-        self.try_with_state(false, |cats| cats.take(indices))
+    fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+        self.try_with_state(false, |cats| cats.gather(indices))
             .map(|ca| ca.into_series())
     }
 
-    unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
-        self.with_state(false, |cats| cats.take_unchecked(indices))
+    unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+        self.with_state(false, |cats| cats.gather_unchecked(indices))
             .into_series()
     }
 

--- a/crates/polars-core/src/series/implementations/dates_time.rs
+++ b/crates/polars-core/src/series/implementations/dates_time.rs
@@ -218,20 +218,20 @@ macro_rules! impl_dyn_series {
                 ca.$into_logical().into_series()
             }
 
-            fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
-                Ok(self.0.take(indices)?.$into_logical().into_series())
+            fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
+                Ok(self.0.gather(indices)?.$into_logical().into_series())
             }
 
-            unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
-                self.0.take_unchecked(indices).$into_logical().into_series()
+            unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
+                self.0.gather_unchecked(indices).$into_logical().into_series()
             }
 
-            fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
-                Ok(self.0.take(indices)?.$into_logical().into_series())
+            fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+                Ok(self.0.gather(indices)?.$into_logical().into_series())
             }
 
-            unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
-                self.0.take_unchecked(indices).$into_logical().into_series()
+            unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+                self.0.gather_unchecked(indices).$into_logical().into_series()
             }
 
             fn len(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -219,28 +219,28 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
             .into_series()
     }
 
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
-        let ca = self.0.take(indices)?;
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
+        let ca = self.0.gather(indices)?;
         Ok(ca
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
             .into_series())
     }
 
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
-        let ca = self.0.take_unchecked(indices);
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
+        let ca = self.0.gather_unchecked(indices);
         ca.into_datetime(self.0.time_unit(), self.0.time_zone().clone())
             .into_series()
     }
 
-    fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
-        let ca = self.0.take(indices)?;
+    fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+        let ca = self.0.gather(indices)?;
         Ok(ca
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
             .into_series())
     }
 
-    unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
-        let ca = self.0.take_unchecked(indices);
+    unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+        let ca = self.0.gather_unchecked(indices);
         ca.into_datetime(self.0.time_unit(), self.0.time_zone().clone())
             .into_series()
     }

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -162,32 +162,32 @@ impl SeriesTrait for SeriesWrap<DecimalChunked> {
         self.apply_physical(|ca| ca.take_opt_chunked_unchecked(by))
     }
 
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
         Ok(self
             .0
-            .take(indices)?
+            .gather(indices)?
             .into_decimal_unchecked(self.0.precision(), self.0.scale())
             .into_series())
     }
 
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
         self.0
-            .take_unchecked(indices)
+            .gather_unchecked(indices)
             .into_decimal_unchecked(self.0.precision(), self.0.scale())
             .into_series()
     }
 
-    fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+    fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
         Ok(self
             .0
-            .take(indices)?
+            .gather(indices)?
             .into_decimal_unchecked(self.0.precision(), self.0.scale())
             .into_series())
     }
 
-    unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+    unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
         self.0
-            .take_unchecked(indices)
+            .gather_unchecked(indices)
             .into_decimal_unchecked(self.0.precision(), self.0.scale())
             .into_series()
     }

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -274,32 +274,32 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
         ca.into_duration(self.0.time_unit()).into_series()
     }
 
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
         Ok(self
             .0
-            .take(indices)?
+            .gather(indices)?
             .into_duration(self.0.time_unit())
             .into_series())
     }
 
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
         self.0
-            .take_unchecked(indices)
+            .gather_unchecked(indices)
             .into_duration(self.0.time_unit())
             .into_series()
     }
 
-    fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+    fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
         Ok(self
             .0
-            .take(indices)?
+            .gather(indices)?
             .into_duration(self.0.time_unit())
             .into_series())
     }
 
-    unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+    unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
         self.0
-            .take_unchecked(indices)
+            .gather_unchecked(indices)
             .into_duration(self.0.time_unit())
             .into_series()
     }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -203,20 +203,20 @@ macro_rules! impl_dyn_series {
                 self.0.take_opt_chunked_unchecked(by).into_series()
             }
 
-            fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
-                Ok(self.0.take(indices)?.into_series())
+            fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
+                Ok(self.0.gather(indices)?.into_series())
             }
 
-            unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
-                self.0.take_unchecked(indices).into_series()
+            unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
+                self.0.gather_unchecked(indices).into_series()
             }
 
-            fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
-                Ok(self.0.take(indices)?.into_series())
+            fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+                Ok(self.0.gather(indices)?.into_series())
             }
 
-            unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
-                self.0.take_unchecked(indices).into_series()
+            unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+                self.0.gather_unchecked(indices).into_series()
             }
 
             fn len(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -127,20 +127,20 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         self.0.take_opt_chunked_unchecked(by).into_series()
     }
 
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
-        Ok(self.0.take(indices)?.into_series())
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
+        Ok(self.0.gather(indices)?.into_series())
     }
 
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
-        self.0.take_unchecked(indices).into_series()
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
+        self.0.gather_unchecked(indices).into_series()
     }
 
-    fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
-        Ok(self.0.take(indices)?.into_series())
+    fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+        Ok(self.0.gather(indices)?.into_series())
     }
 
-    unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
-        self.0.take_unchecked(indices).into_series()
+    unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+        self.0.gather_unchecked(indices).into_series()
     }
 
     fn len(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -302,20 +302,20 @@ macro_rules! impl_dyn_series {
                 self.0.take_opt_chunked_unchecked(by).into_series()
             }
 
-            fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
-                Ok(self.0.take(indices)?.into_series())
+            fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
+                Ok(self.0.gather(indices)?.into_series())
             }
 
-            unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
-                self.0.take_unchecked(indices).into_series()
+            unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
+                self.0.gather_unchecked(indices).into_series()
             }
 
-            fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
-                Ok(self.0.take(indices)?.into_series())
+            fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+                Ok(self.0.gather(indices)?.into_series())
             }
 
-            unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
-                self.0.take_unchecked(indices).into_series()
+            unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+                self.0.gather_unchecked(indices).into_series()
             }
 
             fn len(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -107,19 +107,19 @@ impl SeriesTrait for NullChunked {
         NullChunked::new(self.name.clone(), by.len()).into_series()
     }
 
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
         Ok(NullChunked::new(self.name.clone(), indices.len()).into_series())
     }
 
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
         NullChunked::new(self.name.clone(), indices.len()).into_series()
     }
 
-    fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+    fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
         Ok(NullChunked::new(self.name.clone(), indices.len()).into_series())
     }
 
-    unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+    unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
         NullChunked::new(self.name.clone(), indices.len()).into_series()
     }
 

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -135,20 +135,20 @@ where
         self.0.take_opt_chunked_unchecked(by).into_series()
     }
 
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
-        Ok(self.0.take(indices)?.into_series())
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
+        Ok(self.0.gather(indices)?.into_series())
     }
 
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
-        self.0.take_unchecked(indices).into_series()
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
+        self.0.gather_unchecked(indices).into_series()
     }
 
-    fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
-        Ok(self.0.take(indices)?.into_series())
+    fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+        Ok(self.0.gather(indices)?.into_series())
     }
 
-    unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
-        self.0.take_unchecked(indices).into_series()
+    unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+        self.0.gather_unchecked(indices).into_series()
     }
 
     fn len(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -192,27 +192,27 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
             .into_series()
     }
 
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
         self.0
-            .try_apply_fields(|s| s.take(indices))
+            .try_apply_fields(|s| s.gather(indices))
             .map(|ca| ca.into_series())
     }
 
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
         self.0
-            .apply_fields(|s| s.take_unchecked(indices))
+            .apply_fields(|s| s.gather_unchecked(indices))
             .into_series()
     }
 
-    fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+    fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
         self.0
-            .try_apply_fields(|s| s.take_slice(indices))
+            .try_apply_fields(|s| s.gather_slice(indices))
             .map(|ca| ca.into_series())
     }
 
-    unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+    unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
         self.0
-            .apply_fields(|s| s.take_slice_unchecked(indices))
+            .apply_fields(|s| s.gather_slice_unchecked(indices))
             .into_series()
     }
 

--- a/crates/polars-core/src/series/implementations/utf8.rs
+++ b/crates/polars-core/src/series/implementations/utf8.rs
@@ -159,20 +159,20 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         self.0.take_opt_chunked_unchecked(by).into_series()
     }
 
-    fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
-        Ok(self.0.take(indices)?.into_series())
+    fn gather(&self, indices: &IdxCa) -> PolarsResult<Series> {
+        Ok(self.0.gather(indices)?.into_series())
     }
 
-    unsafe fn take_unchecked(&self, indices: &IdxCa) -> Series {
-        self.0.take_unchecked(indices).into_series()
+    unsafe fn gather_unchecked(&self, indices: &IdxCa) -> Series {
+        self.0.gather_unchecked(indices).into_series()
     }
 
-    fn take_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
-        Ok(self.0.take(indices)?.into_series())
+    fn gather_slice(&self, indices: &[IdxSize]) -> PolarsResult<Series> {
+        Ok(self.0.gather(indices)?.into_series())
     }
 
-    unsafe fn take_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
-        self.0.take_unchecked(indices).into_series()
+    unsafe fn gather_slice_unchecked(&self, indices: &[IdxSize]) -> Series {
+        self.0.gather_unchecked(indices).into_series()
     }
 
     fn len(&self) -> usize {

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -255,22 +255,22 @@ pub trait SeriesTrait:
     unsafe fn _take_opt_chunked_unchecked(&self, by: &[Option<ChunkId>]) -> Series;
 
     /// Take by index. This operation is clone.
-    fn take(&self, _indices: &IdxCa) -> PolarsResult<Series>;
+    fn gather(&self, _indices: &IdxCa) -> PolarsResult<Series>;
 
     /// Take by index.
     ///
     /// # Safety
     /// This doesn't check any bounds.
-    unsafe fn take_unchecked(&self, _idx: &IdxCa) -> Series;
+    unsafe fn gather_unchecked(&self, _idx: &IdxCa) -> Series;
 
-    /// Take by index. This operation is clone.
-    fn take_slice(&self, _indices: &[IdxSize]) -> PolarsResult<Series>;
+    /// Take by index. This operation clones.
+    fn gather_slice(&self, _indices: &[IdxSize]) -> PolarsResult<Series>;
 
     /// Take by index.
     ///
     /// # Safety
     /// This doesn't check any bounds.
-    unsafe fn take_slice_unchecked(&self, _idx: &[IdxSize]) -> Series;
+    unsafe fn gather_slice_unchecked(&self, _idx: &[IdxSize]) -> Series;
 
     /// Get length of series.
     fn len(&self) -> usize;

--- a/crates/polars-lazy/src/physical_plan/executors/group_by_rolling.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/group_by_rolling.rs
@@ -32,7 +32,7 @@ unsafe fn update_keys(keys: &mut [Series], groups: &GroupsProxy) {
         GroupsProxy::Slice { groups, .. } => {
             for key in keys.iter_mut() {
                 let indices = groups.iter().map(|[first, _len]| *first).collect_ca("");
-                *key = key.take_unchecked(&indices);
+                *key = key.gather_unchecked(&indices);
             }
         },
     }

--- a/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -410,7 +410,7 @@ impl PartitionedAggregation for AggregationExpr {
                             let ca = unsafe {
                                 // Safety
                                 // The indexes of the group_by operation are never out of bounds
-                                ca.take_unchecked(idx)
+                                ca.gather_unchecked(idx)
                             };
                             process_group(ca)?;
                         }

--- a/crates/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -13,7 +13,7 @@ mod rolling;
 mod slice;
 mod sort;
 mod sortby;
-mod take;
+mod gather;
 mod ternary;
 mod window;
 
@@ -39,7 +39,7 @@ pub(crate) use rolling::RollingExpr;
 pub(crate) use slice::*;
 pub(crate) use sort::*;
 pub(crate) use sortby::*;
-pub(crate) use take::*;
+pub(crate) use gather::*;
 pub(crate) use ternary::*;
 pub(crate) use window::*;
 

--- a/crates/polars-lazy/src/physical_plan/expressions/sort.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/sort.rs
@@ -83,7 +83,7 @@ impl PhysicalExpr for SortExpr {
                                 .par_iter()
                                 .map(|(first, idx)| {
                                     // SAFETY: group tuples are always in bounds.
-                                    let group = unsafe { series.take_slice_unchecked(idx) };
+                                    let group = unsafe { series.gather_slice_unchecked(idx) };
 
                                     let sorted_idx = group.arg_sort(sort_options);
                                     let new_idx = map_sorted_indices_to_group_idx(&sorted_idx, idx);

--- a/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -60,7 +60,7 @@ fn sort_by_groups_single_by(
     let new_idx = match indicator {
         GroupsIndicator::Idx((_, idx)) => {
             // SAFETY: group tuples are always in bounds.
-            let group = unsafe { sort_by_s.take_slice_unchecked(idx) };
+            let group = unsafe { sort_by_s.gather_slice_unchecked(idx) };
 
             let sorted_idx = group.arg_sort(SortOptions {
                 descending: descending[0],
@@ -111,7 +111,7 @@ fn sort_by_groups_no_match_single<'a>(
                         multithreaded: false,
                         ..Default::default()
                     });
-                    Ok(Some(unsafe { s.take_unchecked(&idx) }))
+                    Ok(Some(unsafe { s.gather_unchecked(&idx) }))
                 },
                 _ => Ok(None),
             })
@@ -132,7 +132,7 @@ fn sort_by_groups_multiple_by(
             // SAFETY: group tuples are always in bounds.
             let groups = sort_by_s
                 .iter()
-                .map(|s| unsafe { s.take_slice_unchecked(idx) })
+                .map(|s| unsafe { s.gather_slice_unchecked(idx) })
                 .collect::<Vec<_>>();
 
             let options = SortMultipleOptions {
@@ -215,7 +215,7 @@ impl PhysicalExpr for SortByExpr {
         );
 
         // SAFETY: sorted index are within bounds.
-        unsafe { Ok(series.take_unchecked(&sorted_idx)) }
+        unsafe { Ok(series.gather_unchecked(&sorted_idx)) }
     }
 
     #[allow(clippy::ptr_arg)]

--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -121,7 +121,7 @@ impl WindowExpr {
 
         // Safety:
         // groups should always be in bounds.
-        unsafe { Ok(flattened.take_unchecked(&idx)) }
+        unsafe { Ok(flattened.gather_unchecked(&idx)) }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -632,7 +632,7 @@ fn materialize_column(join_opt_ids: &ChunkJoinOptIds, out_column: &Series) -> Se
 
         match join_opt_ids {
             Either::Left(ids) => unsafe {
-                out_column.take_unchecked(&ids.iter().copied().collect_ca(""))
+                out_column.gather_unchecked(&ids.iter().copied().collect_ca(""))
             },
             Either::Right(ids) => unsafe { out_column._take_opt_chunked_unchecked(ids) },
         }

--- a/crates/polars-lazy/src/physical_plan/planner/expr.rs
+++ b/crates/polars-lazy/src/physical_plan/planner/expr.rs
@@ -199,7 +199,7 @@ pub(crate) fn create_physical_expr(
         } => {
             let phys_expr = create_physical_expr(expr, ctxt, expr_arena, schema, state)?;
             let phys_idx = create_physical_expr(idx, ctxt, expr_arena, schema, state)?;
-            Ok(Arc::new(TakeExpr {
+            Ok(Arc::new(GatherExpr {
                 phys_expr,
                 idx: phys_idx,
                 expr: node_to_expr(expression, expr_arena),

--- a/crates/polars-ops/src/chunked_array/gather_skip_nulls.rs
+++ b/crates/polars-ops/src/chunked_array/gather_skip_nulls.rs
@@ -73,7 +73,7 @@ where
 {
     fn gather_skip_nulls(&self, indices: &[IdxSize]) -> PolarsResult<Self> {
         if self.null_count() == 0 {
-            return self.take(indices);
+            return self.gather(indices);
         }
 
         // If we want many indices it's probably better to do a normal gather on
@@ -81,7 +81,7 @@ where
         if indices.len() >= self.len() / 4 {
             return ChunkFilter::filter(self, &self.is_not_null())
                 .unwrap()
-                .take(indices);
+                .gather(indices);
         }
 
         let bound = self.len() - self.null_count();
@@ -105,7 +105,7 @@ where
 {
     fn gather_skip_nulls(&self, indices: &IdxCa) -> PolarsResult<Self> {
         if self.null_count() == 0 {
-            return self.take(indices);
+            return self.gather(indices);
         }
 
         // If we want many indices it's probably better to do a normal gather on
@@ -113,7 +113,7 @@ where
         if indices.len() >= self.len() / 4 {
             return ChunkFilter::filter(self, &self.is_not_null())
                 .unwrap()
-                .take(indices);
+                .gather(indices);
         }
 
         let bound = self.len() - self.null_count();

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -638,7 +638,7 @@ fn take_series(s: &Series, idx: Series, null_on_oob: bool) -> PolarsResult<Serie
     let len = s.len();
     let idx = cast_index(idx, len, null_on_oob)?;
     let idx = idx.idx().unwrap();
-    s.take(idx)
+    s.gather(idx)
 }
 
 #[cfg(feature = "list_gather")]

--- a/crates/polars-ops/src/chunked_array/mode.rs
+++ b/crates/polars-ops/src/chunked_array/mode.rs
@@ -16,7 +16,7 @@ where
 
     // Safety:
     // group indices are in bounds
-    Ok(unsafe { ca.take_unchecked(idx.as_slice()) })
+    Ok(unsafe { ca.gather_unchecked(idx.as_slice()) })
 }
 
 fn mode_f32(ca: &Float32Chunked) -> PolarsResult<Float32Chunked> {

--- a/crates/polars-ops/src/chunked_array/nan_propagating_aggregate.rs
+++ b/crates/polars-ops/src/chunked_array/nan_propagating_aggregate.rs
@@ -83,7 +83,7 @@ where
                         MinMax::max_propagate_nan,
                     ),
                     _ => {
-                        let take = { ca.take_unchecked(idx) };
+                        let take = { ca.gather_unchecked(idx) };
                         ca_nan_agg(&take, MinMax::max_propagate_nan)
                     },
                 }
@@ -152,7 +152,7 @@ where
                         MinMax::min_propagate_nan,
                     ),
                     _ => {
-                        let take = { ca.take_unchecked(idx) };
+                        let take = { ca.gather_unchecked(idx) };
                         ca_nan_agg(&take, MinMax::min_propagate_nan)
                     },
                 }

--- a/crates/polars-ops/src/frame/join/hash_join/sort_merge.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/sort_merge.rs
@@ -226,7 +226,7 @@ pub fn _sort_or_hash_inner(
                 multithreaded: true,
                 maintain_order: false,
             });
-            let s_right = unsafe { s_right.take_unchecked(&sort_idx) };
+            let s_right = unsafe { s_right.gather_unchecked(&sort_idx) };
             let ids = par_sorted_merge_inner_no_nulls(s_left, &s_right);
             let reverse_idx_map = create_reverse_map_from_arg_sort(sort_idx);
 
@@ -253,7 +253,7 @@ pub fn _sort_or_hash_inner(
                 multithreaded: true,
                 maintain_order: false,
             });
-            let s_left = unsafe { s_left.take_unchecked(&sort_idx) };
+            let s_left = unsafe { s_left.gather_unchecked(&sort_idx) };
             let ids = par_sorted_merge_inner_no_nulls(&s_left, s_right);
             let reverse_idx_map = create_reverse_map_from_arg_sort(sort_idx);
 
@@ -322,7 +322,7 @@ pub(super) fn sort_or_hash_left(
                 multithreaded: true,
                 maintain_order: false,
             });
-            let s_right = unsafe { s_right.take_unchecked(&sort_idx) };
+            let s_right = unsafe { s_right.gather_unchecked(&sort_idx) };
 
             let ids = par_sorted_merge_left(s_left, &s_right);
             let reverse_idx_map = create_reverse_map_from_arg_sort(sort_idx);

--- a/crates/polars-ops/src/series/ops/rank.rs
+++ b/crates/polars-ops/src/series/ops/rank.rs
@@ -115,7 +115,7 @@ fn rank(s: &Series, method: RankMethod, descending: bool, seed: Option<u64>) -> 
         }
         IdxCa::from_vec_validity(s.name(), out, validity).into_series()
     } else {
-        let sorted_values = unsafe { s.take_unchecked(&sort_idx_ca) };
+        let sorted_values = unsafe { s.gather_unchecked(&sort_idx_ca) };
         let not_consecutive_same = sorted_values
             .slice(1, sorted_values.len() - 1)
             .not_equal(&sorted_values.slice(0, sorted_values.len() - 1))

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -424,7 +424,7 @@ pub(super) fn get(s: &mut [Series]) -> PolarsResult<Option<Series>> {
                 })
                 .collect::<IdxCa>();
             let s = Series::try_from((ca.name(), arr.values().clone())).unwrap();
-            unsafe { Ok(Some(s.take_unchecked(&take_by))) }
+            unsafe { Ok(Some(s.gather_unchecked(&take_by))) }
         },
         len => polars_bail!(
             ComputeError:

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -147,7 +147,7 @@ impl ListNameSpace {
     /// - `null_on_oob`: Return a null when an index is out of bounds.
     /// This behavior is more expensive than defaulting to returning an `Error`.
     #[cfg(feature = "list_gather")]
-    pub fn take(self, index: Expr, null_on_oob: bool) -> Expr {
+    pub fn gather(self, index: Expr, null_on_oob: bool) -> Expr {
         self.0.map_many_private(
             FunctionExpr::ListExpr(ListFunction::Gather(null_on_oob)),
             &[index],

--- a/crates/polars-time/src/group_by/dynamic.rs
+++ b/crates/polars-time/src/group_by/dynamic.rs
@@ -341,7 +341,7 @@ impl Wrap<&DataFrame> {
                         let ir = groups
                             .par_iter()
                             .map(|base_g| {
-                                let dt = unsafe { dt.take_unchecked(base_g.1) };
+                                let dt = unsafe { dt.gather_unchecked(base_g.1) };
                                 let vals = dt.downcast_iter().next().unwrap();
                                 let ts = vals.values().as_slice();
                                 if options.check_sorted
@@ -420,7 +420,7 @@ impl Wrap<&DataFrame> {
                         let groupsidx = groups
                             .par_iter()
                             .map(|base_g| {
-                                let dt = unsafe { dt.take_unchecked(base_g.1) };
+                                let dt = unsafe { dt.gather_unchecked(base_g.1) };
                                 let vals = dt.downcast_iter().next().unwrap();
                                 let ts = vals.values().as_slice();
                                 if options.check_sorted
@@ -565,7 +565,7 @@ impl Wrap<&DataFrame> {
                     let idx = groups
                         .par_iter()
                         .map(|base_g| {
-                            let dt = unsafe { dt_local.take_unchecked(base_g.1) };
+                            let dt = unsafe { dt_local.gather_unchecked(base_g.1) };
                             let vals = dt.downcast_iter().next().unwrap();
                             let ts = vals.values().as_slice();
                             if options.check_sorted

--- a/crates/polars/tests/it/core/ops/take.rs
+++ b/crates/polars/tests/it/core/ops/take.rs
@@ -8,7 +8,7 @@ fn test_list_gather_nulls_and_empty() {
     let indices = [Some(0 as IdxSize), Some(1), None]
         .into_iter()
         .collect_ca("");
-    let out = b.take(&indices).unwrap();
+    let out = b.gather(&indices).unwrap();
     let expected = Series::new("", &[None, Some(a), None]);
     assert!(out.equals_missing(&expected))
 }

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1534,8 +1534,8 @@ class DataFrame:
         else:
             return self.shape[dim] + idx
 
-    def _take_with_series(self, s: Series) -> DataFrame:
-        return self._from_pydf(self._df.take_with_series(s._s))
+    def _gather_with_series(self, s: Series) -> DataFrame:
+        return self._from_pydf(self._df.gather_with_series(s._s))
 
     @overload
     def __getitem__(self, item: str) -> Series:
@@ -1699,7 +1699,7 @@ class DataFrame:
                 raise TypeError("multi-dimensional NumPy arrays not supported as index")
             if item.dtype.kind in ("i", "u"):
                 # Numpy array with signed or unsigned integers.
-                return self._take_with_series(numpy_to_idxs(item, self.shape[0]))
+                return self._gather_with_series(numpy_to_idxs(item, self.shape[0]))
             if isinstance(item[0], str):
                 return self._from_pydf(self._df.select(item))
 
@@ -1715,7 +1715,7 @@ class DataFrame:
             if dtype == Utf8:
                 return self._from_pydf(self._df.select(item))
             elif dtype.is_integer():
-                return self._take_with_series(item._pos_idxs(self.shape[0]))
+                return self._gather_with_series(item._pos_idxs(self.shape[0]))
 
         # if no data has been returned, the operation is not supported
         raise TypeError(

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1041,8 +1041,8 @@ class Series:
 
         return self.cast(idx_type)
 
-    def _take_with_series(self, s: Series) -> Series:
-        return self._from_pyseries(self._s.take_with_series(s._s))
+    def _gather_with_series(self, s: Series) -> Series:
+        return self._from_pyseries(self._s.gather_with_series(s._s))
 
     @overload
     def __getitem__(self, item: int) -> Any:
@@ -1060,10 +1060,10 @@ class Series:
         item: (int | Series | range | slice | np.ndarray[Any, Any] | list[int]),
     ) -> Any:
         if isinstance(item, Series) and item.dtype.is_integer():
-            return self._take_with_series(item._pos_idxs(self.len()))
+            return self._gather_with_series(item._pos_idxs(self.len()))
 
         elif _check_for_numpy(item) and isinstance(item, np.ndarray):
-            return self._take_with_series(numpy_to_idxs(item, self.len()))
+            return self._gather_with_series(numpy_to_idxs(item, self.len()))
 
         # Integer
         elif isinstance(item, int):
@@ -1086,7 +1086,7 @@ class Series:
                 raise ValueError(
                     "cannot use `__getitem__` with index values containing nulls"
                 )
-            return self._take_with_series(idx_series)
+            return self._gather_with_series(idx_series)
 
         raise TypeError(
             f"cannot use `__getitem__` on Series of dtype {self.dtype!r}"

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1070,13 +1070,13 @@ impl PyDataFrame {
     pub fn gather(&self, indices: Wrap<Vec<IdxSize>>) -> PyResult<Self> {
         let indices = indices.0;
         let indices = IdxCa::from_vec("", indices);
-        let df = self.df.take(&indices).map_err(PyPolarsErr::from)?;
+        let df = self.df.gather(&indices).map_err(PyPolarsErr::from)?;
         Ok(PyDataFrame::new(df))
     }
 
-    pub fn take_with_series(&self, indices: &PySeries) -> PyResult<Self> {
+    pub fn gather_with_series(&self, indices: &PySeries) -> PyResult<Self> {
         let idx = indices.series.idx().map_err(PyPolarsErr::from)?;
-        let df = self.df.take(idx).map_err(PyPolarsErr::from)?;
+        let df = self.df.gather(idx).map_err(PyPolarsErr::from)?;
         Ok(PyDataFrame::new(df))
     }
 

--- a/py-polars/src/expr/list.rs
+++ b/py-polars/src/expr/list.rs
@@ -150,7 +150,7 @@ impl PyExpr {
         self.inner
             .clone()
             .list()
-            .take(index.inner, null_on_oob)
+            .gather(index.inner, null_on_oob)
             .into()
     }
 

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -287,9 +287,9 @@ impl PySeries {
         self.series.sort(descending).into()
     }
 
-    fn take_with_series(&self, indices: &PySeries) -> PyResult<Self> {
+    fn gather_with_series(&self, indices: &PySeries) -> PyResult<Self> {
         let idx = indices.series.idx().map_err(PyPolarsErr::from)?;
-        let take = self.series.take(idx).map_err(PyPolarsErr::from)?;
+        let take = self.series.gather(idx).map_err(PyPolarsErr::from)?;
         Ok(take.into())
     }
 


### PR DESCRIPTION
there's currently quite a few inconsistencies, e.g. a file called `crates/polars-core/src/chunked_array/ops/gather.rs` but the function inside it is `take`

will come back to it, it's gonna take a bit to get all the details, maybe I need to split it up