### PR TITLE
docs(python): Fix docstring for deprecated `list.take`

### DIFF
--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -851,7 +851,7 @@ class ListNameSpace:
         Take sublists by multiple indices.
 
         .. deprecated:: 0.19.14
-            This method has been renamed to :func:`len`.
+            This method has been renamed to :func:`gather`.
 
         Parameters
         ----------


### PR DESCRIPTION
Currently: `Series.list.take` deprecation docstring refers to `:func:'len'`.
Corrected to `:func:'gather'`.