### PR TITLE
docs(python): fixup links in deprecation notes

### DIFF
--- a/py-polars/docs/source/reference/expressions/string.rst
+++ b/py-polars/docs/source/reference/expressions/string.rst
@@ -50,6 +50,7 @@ The following methods are available under the `expr.str` attribute.
     Expr.str.to_date
     Expr.str.to_datetime
     Expr.str.to_decimal
+    Expr.str.to_integer
     Expr.str.to_lowercase
     Expr.str.to_titlecase
     Expr.str.to_time

--- a/py-polars/docs/source/reference/series/string.rst
+++ b/py-polars/docs/source/reference/series/string.rst
@@ -50,6 +50,7 @@ The following methods are available under the `Series.str` attribute.
     Series.str.to_date
     Series.str.to_datetime
     Series.str.to_decimal
+    Series.str.to_integer
     Series.str.to_lowercase
     Series.str.to_time
     Series.str.to_titlecase

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -1244,7 +1244,7 @@ class ExprListNameSpace:
         Compute the SET UNION between the elements in this list and the elements of `other`.
 
         .. deprecated:: 0.18.10
-            This method has been renamed to `Expr.list.set_union`.
+            This method has been renamed to :meth:`set_union`.
 
         """  # noqa: W505
         return self.set_union(other)
@@ -1255,7 +1255,7 @@ class ExprListNameSpace:
         Compute the SET DIFFERENCE between the elements in this list and the elements of `other`.
 
         .. deprecated:: 0.18.10
-            This method has been renamed to `Expr.list.set_difference`.
+            This method has been renamed to :meth:`set_difference`.
 
         """  # noqa: W505
         return self.set_difference(other)
@@ -1266,7 +1266,7 @@ class ExprListNameSpace:
         Compute the SET INTERSECTION between the elements in this list and the elements of `other`.
 
         .. deprecated:: 0.18.10
-            This method has been renamed to `Expr.list.set_intersection`.
+            This method has been renamed to :meth:`set_intersection`.
 
         """  # noqa: W505
         return self.set_intersection(other)
@@ -1277,7 +1277,7 @@ class ExprListNameSpace:
         Compute the SET SYMMETRIC DIFFERENCE between the elements in this list and the elements of `other`.
 
         .. deprecated:: 0.18.10
-            This method has been renamed to `Expr.list.set_symmetric_difference`.
+            This method has been renamed to :meth:`set_symmetric_difference`.
 
         """  # noqa: W505
         return self.set_symmetric_difference(other)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -617,7 +617,7 @@ class LazyFrame:
         Read a logical plan from a JSON file to construct a LazyFrame.
 
         .. deprecated:: 0.18.12
-            This class method has been renamed to `deserialize`.
+            This class method has been renamed to :meth:`deserialize`.
 
         Parameters
         ----------

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -774,7 +774,7 @@ class ListNameSpace:
         Compute the SET UNION between the elements in this list and the elements of `other`.
 
         .. deprecated:: 0.18.10
-            This method has been renamed to `Series.list.set_union`.
+            This method has been renamed to :meth:`set_union`.
 
         """  # noqa: W505
         return self.set_union(other)
@@ -785,7 +785,7 @@ class ListNameSpace:
         Compute the SET DIFFERENCE between the elements in this list and the elements of `other`.
 
         .. deprecated:: 0.18.10
-            This method has been renamed to `Series.list.set_difference`.
+            This method has been renamed to :meth:`set_difference`.
 
         """  # noqa: W505
         return self.set_difference(other)
@@ -796,7 +796,7 @@ class ListNameSpace:
         Compute the SET INTERSECTION between the elements in this list and the elements of `other`.
 
         .. deprecated:: 0.18.10
-            This method has been renamed to `Series.list.set_intersection`.
+            This method has been renamed to :meth:`set_intersection`.
 
         """  # noqa: W505
         return self.set_intersection(other)
@@ -807,7 +807,7 @@ class ListNameSpace:
         Compute the SET SYMMETRIC DIFFERENCE between the elements in this list and the elements of `other`.
 
         .. deprecated:: 0.18.10
-            This method has been renamed to `Series.list.set_symmetric_difference`.
+            This method has been renamed to :meth:`set_symmetric_difference`.
 
         """  # noqa: W505
         return self.set_symmetric_difference(other)


### PR DESCRIPTION
These links don't work in the current docs https://pola-rs.github.io/polars/py-polars/html/reference/expressions/api/polars.Expr.list.intersection.html#polars.Expr.list.intersection

This fixes them, I built the docs locally to check