### PR TITLE
ci(python): Prefer explicit `--no-cov` flag for py3.12/ubuntu test workflow (vs implicit/omitted)

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -81,7 +81,7 @@ jobs:
           # TODO: Re-enable coverage for for Ubuntu + Python 3.12 tests
           # Currently skipped due to performance issues in coverage:
           # https://github.com/nedbat/coveragepy/issues/1665
-          COV: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12') && '--cov' || '' }}
+          COV: ${{ !(matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12') && '--cov' || '--no-cov' }}
         run: pytest $COV -n auto --dist loadgroup -m "not benchmark and not docs"
 
       - name: Run tests async reader tests


### PR DESCRIPTION
Possible solution for the apparent recurrence of slow import timings under 3.12:
 https://github.com/pola-rs/polars/actions/runs/7077482382/job/19261866922?pr=12878
 
@stinodego: Haven't been able to replicate those slow timings in any other way than by turning on coverage, so it's at least _somewhat_ plausible that a default/config/library setting is getting through in the absence of an explicit `--no-cov` directive. Clearer than omitting `--cov`, though I haven't been able to confirm this is the issue; still, worth trying 🤔 