### PR TITLE
fix(python,rust): don't panic when ambiguous is not utf8

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/dispatch.rs
+++ b/crates/polars-plan/src/dsl/function_expr/dispatch.rs
@@ -38,7 +38,7 @@ pub(super) fn set_sorted_flag(s: &Series, sorted: IsSorted) -> PolarsResult<Seri
 pub(super) fn replace_time_zone(s: &[Series], time_zone: Option<&str>) -> PolarsResult<Series> {
     let s1 = &s[0];
     let ca = s1.datetime().unwrap();
-    let s2 = &s[1].utf8().unwrap();
+    let s2 = &s[1].utf8()?;
     Ok(polars_ops::prelude::replace_time_zone(ca, time_zone, s2)?.into_series())
 }
 


### PR DESCRIPTION
I would get this error otherwise: 

```
thread '<unnamed>' panicked at crates/polars-plan/src/dsl/function_expr/dispatch.rs:41:27:
called `Result::unwrap()` on an `Err` value: SchemaMismatch(ErrString("invalid series dtype: expected `Utf8`, got `i32`"))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```