### PR TITLE
fix(python): Raise a proper python typed exception when the CSV writer tries to write to an non existent folder

### DIFF
--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -22,6 +22,7 @@ use polars_core::utils::try_get_supertype;
 use polars_lazy::frame::pivot::{pivot, pivot_stable};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
+use pyo3::exceptions::PyOSError;
 
 #[cfg(feature = "parquet")]
 use crate::conversion::parse_parquet_compression;
@@ -617,7 +618,10 @@ impl PyDataFrame {
 
         if let Ok(s) = py_f.extract::<&str>(py) {
             py.allow_threads(|| {
-                let f = std::fs::File::create(s).unwrap();
+                // let f = std::fs::File::create(s)?;
+                let f = std::fs::File::create(s).map_err(|e| PyOSError::new_err(e.to_string()))?;
+                // let f = std::fs::File::create(s)?;
+                
                 // No need for a buffered writer, because the csv writer does internal buffering.
                 CsvWriter::new(f)
                     .include_bom(include_bom)

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -618,9 +618,7 @@ impl PyDataFrame {
 
         if let Ok(s) = py_f.extract::<&str>(py) {
             py.allow_threads(|| {
-                // let f = std::fs::File::create(s)?;
                 let f = std::fs::File::create(s).map_err(|e| PyOSError::new_err(e.to_string()))?;
-                // let f = std::fs::File::create(s)?;
                 
                 // No need for a buffered writer, because the csv writer does internal buffering.
                 CsvWriter::new(f)

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -22,7 +22,6 @@ use polars_core::utils::try_get_supertype;
 use polars_lazy::frame::pivot::{pivot, pivot_stable};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyList, PyTuple};
-use pyo3::exceptions::PyOSError;
 
 #[cfg(feature = "parquet")]
 use crate::conversion::parse_parquet_compression;
@@ -618,8 +617,8 @@ impl PyDataFrame {
 
         if let Ok(s) = py_f.extract::<&str>(py) {
             py.allow_threads(|| {
-                let f = std::fs::File::create(s).map_err(|e| PolarsError::Io(e))?;
-                
+                let f = std::fs::File::create(s).map_err(PolarsError::Io)?;
+
                 // No need for a buffered writer, because the csv writer does internal buffering.
                 CsvWriter::new(f)
                     .include_bom(include_bom)

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -618,7 +618,7 @@ impl PyDataFrame {
 
         if let Ok(s) = py_f.extract::<&str>(py) {
             py.allow_threads(|| {
-                let f = std::fs::File::create(s).map_err(|e| PyOSError::new_err(e.to_string()))?;
+                let f = std::fs::File::create(s).map_err(|e| PolarsError::Io(e))?;
                 
                 // No need for a buffered writer, because the csv writer does internal buffering.
                 CsvWriter::new(f)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1718,5 +1718,5 @@ def test_write_csv_no_location_raise_io_exception() -> None:
         pytest.fail(
             "Testing on a non existing path failed because the path does exist."
         )
-    with pytest.raises(IOError):
+    with pytest.raises(FileNotFoundError):
         df.write_csv(non_existing_path)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1711,10 +1711,9 @@ def test_csv_no_new_line_last() -> None:
         "b": [1.0, 2.0, 2.1],
     }
 
+
 def test_write_csv_no_location_raise_io_exception() -> None:
-    df = pl.DataFrame({'a':[1]})
+    df = pl.DataFrame({"a": [1]})
     # TODO: check dir don't exists before writing
     with pytest.raises(IOError):
         df.write_csv("non/existing/path/file.csv")
-
-

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -6,6 +6,7 @@ import sys
 import textwrap
 import zlib
 from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
 import numpy as np
@@ -19,8 +20,6 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from polars.utils.various import normalize_filepath
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from polars.type_aliases import TimeUnit
 
 
@@ -1714,6 +1713,10 @@ def test_csv_no_new_line_last() -> None:
 
 def test_write_csv_no_location_raise_io_exception() -> None:
     df = pl.DataFrame({"a": [1]})
-    # TODO: check dir don't exists before writing
+    non_existing_path = Path("non", "existing", "path", "file.csv")
+    if non_existing_path.exists():
+        pytest.fail(
+            "Testing on a non existing path failed because the path does exist."
+        )
     with pytest.raises(IOError):
-        df.write_csv("non/existing/path/file.csv")
+        df.write_csv(non_existing_path)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1710,3 +1710,11 @@ def test_csv_no_new_line_last() -> None:
         "a": [1, 2, 3],
         "b": [1.0, 2.0, 2.1],
     }
+
+def test_write_csv_no_location_raise_io_exception() -> None:
+    df = pl.DataFrame({'a':[1]})
+    # TODO: check dir don't exists before writing
+    with pytest.raises(IOError):
+        df.write_csv("non/existing/path/file.csv")
+
+


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/12901 