### PR TITLE
feat(python): Avoid importing interchange module by default

### DIFF
--- a/py-polars/docs/source/reference/functions.rst
+++ b/py-polars/docs/source/reference/functions.rst
@@ -9,13 +9,13 @@ Conversion
    :toctree: api/
 
     from_arrow
-    from_dataframe
     from_dict
     from_dicts
     from_numpy
     from_pandas
     from_records
     from_repr
+    interchange.from_dataframe
 
 Miscellaneous
 ~~~~~~~~~~~~~~~~~~~~

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -160,7 +160,6 @@ from polars.functions import (
     when,
     zeros,
 )
-from polars.interchange.from_dataframe import from_dataframe
 from polars.io import (
     read_avro,
     read_csv,
@@ -383,7 +382,6 @@ __all__ = [
     "set_random_seed",
     # polars.convert
     "from_arrow",
-    "from_dataframe",
     "from_dict",
     "from_dicts",
     "from_numpy",

--- a/py-polars/polars/interchange/__init__.py
+++ b/py-polars/polars/interchange/__init__.py
@@ -4,3 +4,6 @@ Module containing the implementation of the Python dataframe interchange protoco
 Details on the protocol:
 https://data-apis.org/dataframe-protocol/latest/index.html
 """
+from polars.interchange.from_dataframe_ import from_dataframe
+
+__all__ = ["from_dataframe"]

--- a/py-polars/polars/interchange/from_dataframe_.py
+++ b/py-polars/polars/interchange/from_dataframe_.py
@@ -47,10 +47,11 @@ def from_dataframe(df: SupportsInterchange, *, allow_copy: bool = True) -> DataF
     --------
     Convert a pandas dataframe to Polars through the interchange protocol.
 
+    >>> import polars.interchange
     >>> import pandas as pd
     >>> df_pd = pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0], "c": ["x", "y"]})
     >>> dfi = df_pd.__dataframe__()
-    >>> pl.from_dataframe(dfi)
+    >>> pl.interchange.from_dataframe(dfi)
     shape: (2, 3)
     ┌─────┬─────┬─────┐
     │ a   ┆ b   ┆ c   │


### PR DESCRIPTION
Closes #12377