### PR TITLE
fix(python): Raise a proper python typed exception when IO writers try to write to an non existent folder

### DIFF
--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -616,9 +616,8 @@ impl PyDataFrame {
         let null = null_value.unwrap_or_default();
 
         if let Ok(s) = py_f.extract::<&str>(py) {
+            let f = std::fs::File::create(s)?;
             py.allow_threads(|| {
-                let f = std::fs::File::create(s).map_err(PolarsError::Io)?;
-
                 // No need for a buffered writer, because the csv writer does internal buffering.
                 CsvWriter::new(f)
                     .include_bom(include_bom)
@@ -666,8 +665,8 @@ impl PyDataFrame {
         compression: Wrap<Option<IpcCompression>>,
     ) -> PyResult<()> {
         if let Ok(s) = py_f.extract::<&str>(py) {
+            let f = std::fs::File::create(s)?;
             py.allow_threads(|| {
-                let f = std::fs::File::create(s).map_err(PolarsError::Io)?;
                 IpcWriter::new(f)
                     .with_compression(compression.0)
                     .finish(&mut self.df)
@@ -692,8 +691,8 @@ impl PyDataFrame {
         compression: Wrap<Option<IpcCompression>>,
     ) -> PyResult<()> {
         if let Ok(s) = py_f.extract::<&str>(py) {
+            let f = std::fs::File::create(s)?;
             py.allow_threads(|| {
-                let f = std::fs::File::create(s).map_err(PolarsError::Io)?;
                 IpcStreamWriter::new(f)
                     .with_compression(compression.0)
                     .finish(&mut self.df)

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -6,7 +6,6 @@ import sys
 import textwrap
 import zlib
 from datetime import date, datetime, time, timedelta, timezone
-from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
 import numpy as np
@@ -20,6 +19,8 @@ from polars.testing import assert_frame_equal, assert_series_equal
 from polars.utils.various import normalize_filepath
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from polars.type_aliases import TimeUnit
 
 
@@ -1709,4 +1710,3 @@ def test_csv_no_new_line_last() -> None:
         "a": [1, 2, 3],
         "b": [1.0, 2.0, 2.1],
     }
-

--- a/py-polars/tests/unit/io/test_other.py
+++ b/py-polars/tests/unit/io/test_other.py
@@ -33,10 +33,13 @@ def test_read_missing_file(read_function: Callable[[Any], pl.DataFrame]) -> None
     with pytest.raises(FileNotFoundError, match=match):
         read_function("fake_file_path")
 
+
 @pytest.mark.parametrize(
     "write_method_name",
     [
-        # "write_excel" not included because it already raises a FileCreateError from the underlying library dependecy
+        # "write_excel" not included
+        # because it already raises a FileCreateError
+        # from the underlying library dependency
         "write_csv",
         "write_ipc",
         "write_ipc_stream",
@@ -53,10 +56,9 @@ def test_write_missing_directory(write_method_name: str) -> None:
         pytest.fail(
             "Testing on a non existing path failed because the path does exist."
         )
+    write_method = getattr(df, write_method_name)
     with pytest.raises(FileNotFoundError):
-        write_method = getattr(df, write_method_name)
         write_method(non_existing_path)
-
 
 
 def test_read_missing_file_path_truncated() -> None:


### PR DESCRIPTION
Fixes: https://github.com/pola-rs/polars/issues/12901 

Follow-up from PR: https://github.com/pola-rs/polars/pull/12919 
Doing the same fix for other IO writers