### PR TITLE
perf(python): Avoid dispatching `Series.head/tail` to the expression engine

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2948,7 +2948,7 @@ class Series:
         """
         if n < 0:
             n = max(0, self.len() + n)
-        return self.to_frame().select(F.col(self.name).head(n)).to_series()
+        return self._from_pyseries(self._s.head(n))
 
     def tail(self, n: int = 10) -> Series:
         """
@@ -2989,7 +2989,7 @@ class Series:
         """
         if n < 0:
             n = max(0, self.len() + n)
-        return self.to_frame().select(F.col(self.name).tail(n)).to_series()
+        return self._from_pyseries(self._s.tail(n))
 
     def limit(self, n: int = 10) -> Series:
         """

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -679,12 +679,12 @@ impl PySeries {
         self.series.clear().into()
     }
 
-    fn head(&self, n: Option<usize>) -> Self {
-        self.series.head(n).into()
+    fn head(&self, n: usize) -> Self {
+        self.series.head(Some(n)).into()
     }
 
-    fn tail(&self, n: Option<usize>) -> Self {
-        self.series.tail(n).into()
+    fn tail(&self, n: usize) -> Self {
+        self.series.tail(Some(n)).into()
     }
 
     fn hist(&self, bins: Option<Self>, bin_count: Option<usize>) -> PyResult<PyDataFrame> {

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -679,6 +679,14 @@ impl PySeries {
         self.series.clear().into()
     }
 
+    fn head(&self, n: Option<usize>) -> Self {
+        self.series.head(n).into()
+    }
+
+    fn tail(&self, n: Option<usize>) -> Self {
+        self.series.tail(n).into()
+    }
+
     fn hist(&self, bins: Option<Self>, bin_count: Option<usize>) -> PyResult<PyDataFrame> {
         let bins = bins.map(|s| s.series);
         let out = hist(&self.series, bins.as_ref(), bin_count).map_err(PyPolarsErr::from)?;


### PR DESCRIPTION
Resolves #12928.