### PR TITLE
fix: Fix segfault / memory corruption after plugins return `Err` result

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/plugin.rs
+++ b/crates/polars-plan/src/dsl/function_expr/plugin.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::ffi::CStr;
 use std::process::abort;
 use std::sync::RwLock;
 
@@ -41,11 +41,11 @@ fn get_lib(lib: &str) -> PolarsResult<&'static PluginAndVersion> {
     }
 }
 
-unsafe fn retrieve_error_msg(lib: &Library) -> CString {
+unsafe fn retrieve_error_msg(lib: &Library) -> &CStr {
     let symbol: libloading::Symbol<unsafe extern "C" fn() -> *mut std::os::raw::c_char> =
         lib.get(b"_polars_plugin_get_last_error_message\0").unwrap();
     let msg_ptr = symbol();
-    CString::from_raw(msg_ptr)
+    CStr::from_ptr(msg_ptr)
 }
 
 pub(super) unsafe fn call_plugin(


### PR DESCRIPTION
https://github.com/MarcoGorelli/polars-business/issues/34

MRE at https://github.com/MarcoGorelli/mcve-segfaulty-plugin

Do not take ownership of the error message, as otherwise it presumably led to a double-free - the valgrind output seems to indicate a NULL pointer dereference `0x0` during de-allocation:

```
==43399==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==43399== 
==43399==
==43399== Process terminating with default action of signal 11 (SIGSEGV)
==43399==  Access not within mapped region at address 0x0
==43399==    at 0xB4456B2: edata_arena_ind_get (edata.h:258)
==43399==    by 0xB4456B2: tcache_bin_flush_impl (tcache.c:350)
==43399==    by 0xB4456B2: tcache_bin_flush_bottom (tcache.c:519)
==43399==    by 0xB4456B2: _rjem_je_tcache_bin_flush_small (tcache.c:529)
==43399==    by 0xB446BEE: tcache_gc_small (tcache.c:148)
==43399==    by 0xB448CB1: _rjem_je_tcache_gc_dalloc_event_handler (in /home/ubuntu/git/mcve-segfaulty-plugin/polars_business/venv/lib/python3.11/site-packages/polars/polars.abi3.so)
==43399==    by 0xB44B54F: _rjem_je_te_event_trigger (thread_event.c:299)
==43399==    by 0xB3E547C: te_event_advance (thread_event.h:287)
==43399==    by 0xB3E547C: thread_dalloc_event (thread_event.h:293)
==43399==    by 0xB3E547C: isfree (jemalloc.c:2991)
==43399==    by 0xB3E547C: _rjem_je_sdallocx_default (jemalloc.c:3928)
```