### PR TITLE
docs(python): Expand docstrings for `count`

### DIFF
--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -453,33 +453,28 @@ class GroupBy:
 
     def count(self) -> DataFrame:
         """
-        Count the number of values in each group.
+        Return the number of rows in each group.
 
-        .. warning::
-            `null` is deemed a value in this context.
+        Rows containing null values count towards the total.
 
         Examples
         --------
         >>> df = pl.DataFrame(
         ...     {
-        ...         "a": [1, 2, 2, 3, 4, 5],
-        ...         "b": [0.5, 0.5, 4, 10, 13, 14],
-        ...         "c": [True, True, True, False, False, True],
-        ...         "d": ["Apple", "Orange", "Apple", "Apple", "Banana", "Banana"],
+        ...         "a": ["apple", "apple", "orange"],
+        ...         "b": [1, None, 2],
         ...     }
         ... )
-        >>> df.group_by("d", maintain_order=True).count()
-        shape: (3, 2)
+        >>> df.group_by("a").count()  # doctest: +SKIP
+        shape: (2, 2)
         ┌────────┬───────┐
-        │ d      ┆ count │
+        │ a      ┆ count │
         │ ---    ┆ ---   │
         │ str    ┆ u32   │
         ╞════════╪═══════╡
-        │ Apple  ┆ 3     │
-        │ Orange ┆ 1     │
-        │ Banana ┆ 2     │
+        │ apple  ┆ 2     │
+        │ orange ┆ 1     │
         └────────┴───────┘
-
         """
         return self.agg(F.count())
 

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -1269,9 +1269,18 @@ class Expr:
         """
         Return the number of non-null elements in the column.
 
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`UInt32`.
+
+        See Also
+        --------
+        len
+
         Examples
         --------
-        >>> df = pl.DataFrame({"a": [8, 9, 10], "b": [None, 4, 4]})
+        >>> df = pl.DataFrame({"a": [1, 2, 3], "b": [None, 4, 4]})
         >>> df.select(pl.all().count())
         shape: (1, 2)
         ┌─────┬─────┐
@@ -1281,7 +1290,6 @@ class Expr:
         ╞═════╪═════╡
         │ 3   ┆ 2   │
         └─────┴─────┘
-
         """
         return self._from_pyexpr(self._pyexpr.count())
 
@@ -1289,11 +1297,20 @@ class Expr:
         """
         Return the number of elements in the column.
 
-        Null values are treated like regular elements in this context.
+        Null values count towards the total.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`UInt32`.
+
+        See Also
+        --------
+        count
 
         Examples
         --------
-        >>> df = pl.DataFrame({"a": [8, 9, 10], "b": [None, 4, 4]})
+        >>> df = pl.DataFrame({"a": [1, 2, 3], "b": [None, 4, 4]})
         >>> df.select(pl.all().len())
         shape: (1, 2)
         ┌─────┬─────┐
@@ -1303,7 +1320,6 @@ class Expr:
         ╞═════╪═════╡
         │ 3   ┆ 3   │
         └─────┴─────┘
-
         """
         return self._from_pyexpr(self._pyexpr.len())
 

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -93,7 +93,7 @@ class ExprListNameSpace:
         """
         Return the number of elements in each list.
 
-        Null values are treated like regular elements in this context.
+        Null values count towards the total.
 
         Returns
         -------

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -77,25 +77,34 @@ def element() -> Expr:
 
 def count(column: str | None = None) -> Expr:
     """
-    Count the number of values in this column/context.
+    Either return the number of rows in the context, or return the number of non-null values in the column.
 
-    This function has different behavior depending on the input type:
+    If no arguments are passed, returns the number of rows in the context.
+    Rows containing null values count towards the total.
+    This is similar to `COUNT(*)` in SQL.
 
-    - `None` -> Expression to count the number of values in this context.
-    - `str` -> Syntactic sugar for `pl.col(column).count()`.
-
-    .. warning::
-        `null` is deemed a value in this context.
+    Otherwise, this function is syntactic sugar for `col(column).count()`.
 
     Parameters
     ----------
     column
-        Column name. If set to `None` (default), returns an expression to take the first
-        column of the context instead.
+        Column name.
+
+    Returns
+    -------
+    Expr
+        Expression of data type :class:`UInt32`.
+
+    See Also
+    --------
+    Expr.count
 
     Examples
     --------
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    Return the number of rows in a context. Note that rows containing null values are
+    counted towards the total.
+
+    >>> df = pl.DataFrame({"a": [1, 2, None], "b": [3, None, None]})
     >>> df.select(pl.count())
     shape: (1, 1)
     ┌───────┐
@@ -105,18 +114,19 @@ def count(column: str | None = None) -> Expr:
     ╞═══════╡
     │ 3     │
     └───────┘
-    >>> df.group_by("c", maintain_order=True).agg(pl.count())
-    shape: (2, 2)
-    ┌─────┬───────┐
-    │ c   ┆ count │
-    │ --- ┆ ---   │
-    │ str ┆ u32   │
-    ╞═════╪═══════╡
-    │ foo ┆ 2     │
-    │ bar ┆ 1     │
-    └─────┴───────┘
 
-    """
+    Return the number of non-null values in a column.
+
+    >>> df.select(pl.count("a"))
+    shape: (1, 1)
+    ┌─────┐
+    │ a   │
+    │ --- │
+    │ u32 │
+    ╞═════╡
+    │ 2   │
+    └─────┘
+    """  # noqa: W505
     if column is None:
         return wrap_expr(plr.count())
 

--- a/py-polars/polars/lazyframe/group_by.py
+++ b/py-polars/polars/lazyframe/group_by.py
@@ -341,33 +341,28 @@ class LazyGroupBy:
 
     def count(self) -> LazyFrame:
         """
-        Count the number of values in each group.
+        Return the number of rows in each group.
 
-        .. warning::
-            `null` is deemed a value in this context.
+        Rows containing null values count towards the total.
 
         Examples
         --------
-        >>> ldf = pl.DataFrame(
+        >>> lf = pl.LazyFrame(
         ...     {
-        ...         "a": [1, 2, 2, 3, 4, 5],
-        ...         "b": [0.5, 0.5, 4, 10, 13, 14],
-        ...         "c": [True, True, True, False, False, True],
-        ...         "d": ["Apple", "Orange", "Apple", "Apple", "Banana", "Banana"],
+        ...         "a": ["apple", "apple", "orange"],
+        ...         "b": [1, None, 2],
         ...     }
-        ... ).lazy()
-        >>> ldf.group_by("d", maintain_order=True).count().collect()
-        shape: (3, 2)
+        ... )
+        >>> lf.group_by("a").count().collect()  # doctest: +SKIP
+        shape: (2, 2)
         ┌────────┬───────┐
-        │ d      ┆ count │
+        │ a      ┆ count │
         │ ---    ┆ ---   │
         │ str    ┆ u32   │
         ╞════════╪═══════╡
-        │ Apple  ┆ 3     │
-        │ Orange ┆ 1     │
-        │ Banana ┆ 2     │
+        │ apple  ┆ 2     │
+        │ orange ┆ 1     │
         └────────┴───────┘
-
         """
         return self.agg(F.count())
 

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -88,7 +88,7 @@ class ListNameSpace:
         """
         Return the number of elements in each list.
 
-        Null values are treated like regular elements in this context.
+        Null values count towards the total.
 
         Returns
         -------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3737,21 +3737,6 @@ class Series:
         """
         return self._s.equals(other._s, null_equal, strict)
 
-    def len(self) -> int:
-        """
-        Return the number of elements in this Series.
-
-        Null values are treated like regular elements in this context.
-
-        Examples
-        --------
-        >>> s = pl.Series("a", [1, 2, None])
-        >>> s.len()
-        3
-
-        """
-        return self._s.len()
-
     def cast(
         self,
         dtype: (PolarsDataType | type[int] | type[float] | type[str] | type[bool]),
@@ -4233,8 +4218,38 @@ class Series:
         )
 
     def count(self) -> int:
-        """Return the number of non-null elements in the column."""
-        return len(self) - self.null_count()
+        """
+        Return the number of non-null elements in the column.
+
+        See Also
+        --------
+        len
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [1, 2, None])
+        >>> s.count()
+        2
+        """
+        return self.len() - self.null_count()
+
+    def len(self) -> int:
+        """
+        Return the number of elements in the Series.
+
+        Null values count towards the total.
+
+        See Also
+        --------
+        count
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [1, 2, None])
+        >>> s.len()
+        3
+        """
+        return self._s.len()
 
     def set(self, filter: Series, value: int | float | str | bool | None) -> Series:
         """


### PR DESCRIPTION
Followup of #12934, slightly improving docstrings and examples of `count` methods/function.