### PR TITLE
perf(python): Use `select_seq` for expression dispatch

### DIFF
--- a/py-polars/polars/series/utils.py
+++ b/py-polars/polars/series/utils.py
@@ -97,7 +97,7 @@ def call_expr(func: SeriesMethod) -> SeriesMethod:
         if namespace is not None:
             expr = getattr(expr, namespace)
         f = getattr(expr, func.__name__)
-        return s.to_frame().select(f(*args, **kwargs)).to_series()
+        return s.to_frame().select_seq(f(*args, **kwargs)).to_series()
 
     # note: applying explicit '__signature__' helps IDEs (especially PyCharm)
     # with proper autocomplete, in addition to what @functools.wraps does


### PR DESCRIPTION
This should reduce some overhead in dispatching Series methods to the expression engine.