### PR TITLE
feat: Allow `end` before `start` in `date/time_range`

### DIFF
--- a/crates/polars-time/src/date_range.rs
+++ b/crates/polars-time/src/date_range.rs
@@ -111,7 +111,13 @@ pub(crate) fn datetime_range_i64(
     tu: TimeUnit,
     tz: Option<&Tz>,
 ) -> PolarsResult<Vec<i64>> {
-    check_range_bounds(start, end, interval)?;
+    if start > end {
+        return Ok(Vec::new());
+    }
+    polars_ensure!(
+        !interval.negative && !interval.is_zero(),
+        ComputeError: "`interval` must be positive"
+    );
 
     let size: usize;
     let offset_fn: fn(&Duration, i64, Option<&Tz>) -> PolarsResult<i64>;
@@ -156,10 +162,4 @@ pub(crate) fn datetime_range_i64(
     }
     debug_assert!(size >= ts.len());
     Ok(ts)
-}
-
-fn check_range_bounds(start: i64, end: i64, interval: Duration) -> PolarsResult<()> {
-    polars_ensure!(end >= start, ComputeError: "`end` must be equal to or greater than `start`");
-    polars_ensure!(!interval.negative && !interval.is_zero(), ComputeError: "`interval` must be positive");
-    Ok(())
 }

--- a/py-polars/tests/unit/functions/range/test_date_range.py
+++ b/py-polars/tests/unit/functions/range/test_date_range.py
@@ -338,11 +338,10 @@ def test_date_range_input_shape_multiple_values() -> None:
         pl.date_range(multiple, multiple, eager=True)
 
 
-def test_date_range_invalid_start_end() -> None:
-    with pytest.raises(
-        pl.ComputeError, match="`end` must be equal to or greater than `start`"
-    ):
-        pl.date_range(date(2000, 3, 20), date(2000, 3, 5), eager=True)
+def test_date_range_start_later_than_end() -> None:
+    result = pl.date_range(date(2000, 3, 20), date(2000, 3, 5), eager=True)
+    expected = pl.Series("date", dtype=pl.Date)
+    assert_series_equal(result, expected)
 
 
 def test_date_range_24h_interval_results_in_datetime() -> None:

--- a/py-polars/tests/unit/functions/range/test_time_range.py
+++ b/py-polars/tests/unit/functions/range/test_time_range.py
@@ -109,11 +109,10 @@ def test_time_range_start_equals_end_open(closed: ClosedInterval) -> None:
     assert_series_equal(result, expected)
 
 
-def test_time_range_invalid_start_end() -> None:
-    with pytest.raises(
-        pl.ComputeError, match="`end` must be equal to or greater than `start`"
-    ):
-        pl.time_range(time(12), time(11), eager=True)
+def test_time_range_start_later_than_end() -> None:
+    result = pl.time_range(time(12), time(11), eager=True)
+    expected = pl.Series("time", dtype=pl.Time)
+    assert_series_equal(result, expected)
 
 
 @pytest.mark.parametrize("interval", [timedelta(0), timedelta(minutes=-10)])


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/11892

Instead of erroring, this will return an empty Series.