### PR TITLE
perf: add fastpaths for UTC in temporal truncate and add functions

### DIFF
--- a/crates/polars-time/src/windows/duration.rs
+++ b/crates/polars-time/src/windows/duration.rs
@@ -459,7 +459,8 @@ impl Duration {
     {
         match tz {
             #[cfg(feature = "timezones")]
-            Some(tz) => {
+            // for UTC, use fastpath below (same as naive)
+            Some(tz) if tz != &chrono_tz::UTC => {
                 let original_dt_utc = _timestamp_to_datetime(t);
                 let original_dt_local = unlocalize_datetime(original_dt_utc, tz);
                 let t = _datetime_to_timestamp(original_dt_local);
@@ -499,7 +500,8 @@ impl Duration {
         let _original_dt_local: Option<NaiveDateTime>;
         let t = match tz {
             #[cfg(feature = "timezones")]
-            Some(tz) => {
+            // for UTC, use fastpath below (same as naive)
+            Some(tz) if tz != &chrono_tz::UTC => {
                 _original_dt_utc = Some(_timestamp_to_datetime(t));
                 _original_dt_local = Some(unlocalize_datetime(_original_dt_utc.unwrap(), tz));
                 _datetime_to_timestamp(_original_dt_local.unwrap())
@@ -522,7 +524,8 @@ impl Duration {
         let result_t_local = t - remainder;
         match tz {
             #[cfg(feature = "timezones")]
-            Some(tz) => {
+            // for UTC, use fastpath below (same as naive)
+            Some(tz) if tz != &chrono_tz::UTC => {
                 let result_dt_local = _timestamp_to_datetime(result_t_local);
                 let result_dt_utc = self.localize_result(
                     _original_dt_local.unwrap(),
@@ -550,7 +553,8 @@ impl Duration {
         let original_dt_local;
         match tz {
             #[cfg(feature = "timezones")]
-            Some(tz) => {
+            // for UTC, use fastpath below (same as naive)
+            Some(tz) if tz != &chrono_tz::UTC => {
                 original_dt_utc = timestamp_to_datetime(t);
                 original_dt_local = unlocalize_datetime(original_dt_utc, tz);
             },
@@ -575,7 +579,8 @@ impl Duration {
         ))?;
         match tz {
             #[cfg(feature = "timezones")]
-            Some(tz) => {
+            // for UTC, use fastpath below (same as naive)
+            Some(tz) if tz != &chrono_tz::UTC => {
                 let result_dt_utc =
                     self.localize_result(original_dt_local, original_dt_utc, result_dt_local, tz);
                 Ok(datetime_to_timestamp(result_dt_utc))
@@ -698,13 +703,19 @@ impl Duration {
         if d.months > 0 {
             let ts = match tz {
                 #[cfg(feature = "timezones")]
-                Some(tz) => unlocalize_datetime(timestamp_to_datetime(t), tz),
+                // for UTC, use fastpath below (same as naive)
+                Some(tz) if tz != &chrono_tz::UTC => {
+                    unlocalize_datetime(timestamp_to_datetime(t), tz)
+                },
                 _ => timestamp_to_datetime(t),
             };
             let dt = Self::add_month(ts, d.months, d.negative);
             new_t = match tz {
                 #[cfg(feature = "timezones")]
-                Some(tz) => datetime_to_timestamp(try_localize_datetime(dt, tz, Ambiguous::Raise)?),
+                // for UTC, use fastpath below (same as naive)
+                Some(tz) if tz != &chrono_tz::UTC => {
+                    datetime_to_timestamp(try_localize_datetime(dt, tz, Ambiguous::Raise)?)
+                },
                 _ => datetime_to_timestamp(dt),
             };
         }
@@ -713,7 +724,8 @@ impl Duration {
             let t_weeks = nsecs_to_unit(NS_WEEK) * self.weeks;
             match tz {
                 #[cfg(feature = "timezones")]
-                Some(tz) => {
+                // for UTC, use fastpath below (same as naive)
+                Some(tz) if tz != &chrono_tz::UTC => {
                     new_t =
                         datetime_to_timestamp(unlocalize_datetime(timestamp_to_datetime(t), tz));
                     new_t += if d.negative { -t_weeks } else { t_weeks };
@@ -731,7 +743,8 @@ impl Duration {
             let t_days = nsecs_to_unit(NS_DAY) * self.days;
             match tz {
                 #[cfg(feature = "timezones")]
-                Some(tz) => {
+                // for UTC, use fastpath below (same as naive)
+                Some(tz) if tz != &chrono_tz::UTC => {
                     new_t =
                         datetime_to_timestamp(unlocalize_datetime(timestamp_to_datetime(t), tz));
                     new_t += if d.negative { -t_days } else { t_days };

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -316,7 +316,7 @@ def test_group_by_dynamic_flat_agg_4814() -> None:
         (timedelta(seconds=10), "100s"),
     ],
 )
-@pytest.mark.parametrize("time_zone", [None, "Asia/Kathmandu"])
+@pytest.mark.parametrize("time_zone", [None, "UTC", "Asia/Kathmandu"])
 def test_group_by_dynamic_overlapping_groups_flat_apply_multiple_5038(
     every: str | timedelta, period: str | timedelta, time_zone: str | None
 ) -> None:

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -100,7 +100,7 @@ def test_dynamic_group_by_timezone_awareness(
     ).dtypes == [pl.Datetime("ns", "UTC")] * 3 + [pl.Int64]
 
 
-@pytest.mark.parametrize("tzinfo", [None, ZoneInfo("Asia/Kathmandu")])
+@pytest.mark.parametrize("tzinfo", [None, ZoneInfo("UTC"), ZoneInfo("Asia/Kathmandu")])
 def test_group_by_dynamic_startby_5599(tzinfo: ZoneInfo | None) -> None:
     # start by datapoint
     start = datetime(2022, 12, 16, tzinfo=tzinfo)
@@ -404,7 +404,7 @@ def test_groupby_dynamic_deprecated() -> None:
     assert_frame_equal(result_lazy, expected, check_row_order=False)
 
 
-@pytest.mark.parametrize("time_zone", [None, "Asia/Kathmandu"])
+@pytest.mark.parametrize("time_zone", [None, "UTC", "Asia/Kathmandu"])
 def test_group_by_dynamic_elementwise_following_mean_agg_6904(
     time_zone: str | None,
 ) -> None:
@@ -438,7 +438,7 @@ def test_group_by_dynamic_elementwise_following_mean_agg_6904(
 
 
 @pytest.mark.parametrize("every", ["1h", timedelta(hours=1)])
-@pytest.mark.parametrize("tzinfo", [None, ZoneInfo("Asia/Kathmandu")])
+@pytest.mark.parametrize("tzinfo", [None, ZoneInfo("UTC"), ZoneInfo("Asia/Kathmandu")])
 def test_group_by_dynamic_lazy(every: str | timedelta, tzinfo: ZoneInfo | None) -> None:
     ldf = pl.LazyFrame(
         {
@@ -518,7 +518,7 @@ def test_no_sorted_err() -> None:
         df.group_by_dynamic("dt", every="1h").agg(pl.all().count().name.suffix("_foo"))
 
 
-@pytest.mark.parametrize("tzinfo", [None, ZoneInfo("Asia/Kathmandu")])
+@pytest.mark.parametrize("tzinfo", [None, ZoneInfo("UTC"), ZoneInfo("Asia/Kathmandu")])
 def test_truncate_negative_offset(tzinfo: ZoneInfo | None) -> None:
     time_zone = tzinfo.key if tzinfo is not None else None
     df = pl.DataFrame(
@@ -678,7 +678,7 @@ def test_group_by_dynamic_when_conversion_crosses_dates_7274() -> None:
     assert_frame_equal(result, expected)
 
 
-@pytest.mark.parametrize("time_zone", [None, "Asia/Kathmandu"])
+@pytest.mark.parametrize("time_zone", [None, "UTC", "Asia/Kathmandu"])
 def test_default_negative_every_offset_dynamic_group_by(time_zone: str | None) -> None:
     # 2791
     dts = [
@@ -858,7 +858,7 @@ def test_group_by_dynamic_2d_9333() -> None:
 
 
 @pytest.mark.parametrize("every", ["1h", timedelta(hours=1)])
-@pytest.mark.parametrize("tzinfo", [None, ZoneInfo("Asia/Kathmandu")])
+@pytest.mark.parametrize("tzinfo", [None, ZoneInfo("UTC"), ZoneInfo("Asia/Kathmandu")])
 def test_group_by_dynamic_iter(every: str | timedelta, tzinfo: ZoneInfo | None) -> None:
     time_zone = tzinfo.key if tzinfo is not None else None
     df = pl.DataFrame(


### PR DESCRIPTION
this gives about a 4% improvement for `truncate`, from a benchmark I ran here https://www.kaggle.com/code/marcogorelli/polars-timing/notebook?scriptVersionId=154169901

nothing major, but nice to have IMO - no offense taken if it's too minor