### PR TITLE
fix: supertype for datetime, datetime(tz)

### DIFF
--- a/crates/polars-core/src/utils/supertype.rs
+++ b/crates/polars-core/src/utils/supertype.rs
@@ -162,6 +162,10 @@ pub fn get_supertype(l: &DataType, r: &DataType) -> Option<DataType> {
             (Datetime(_, _), Float32) => Some(Float64),
             #[cfg(feature = "dtype-datetime")]
             (Datetime(_, _), Float64) => Some(Float64),
+            #[cfg(feature = "dtype-datetime")]
+            (Datetime(tu1, Some(tz)), Datetime(tu2, None)) if tu1 == tu2 => Some(Datetime(*tu1, Some(tz.clone()))),
+            #[cfg(feature = "dtype-datetime")]
+            (Datetime(tu1, None), Datetime(tu2, Some(tz))) if tu1 == tu2 => Some(Datetime(*tu2, Some(tz.clone()))),
             #[cfg(all(feature = "dtype-datetime", feature = "dtype=date"))]
             (Datetime(tu, tz), Date) => Some(Datetime(*tu, tz.clone())),
 


### PR DESCRIPTION
closes https://github.com/pola-rs/polars/issues/12959

I'm not 100%, but this seems like a reasonable supertype. 

If comparing 2 datetime columns where one has a timezone, and the other doesnt, The supertype would use the timezone from the one with a timezone. Maybe there's some scenarios where this would not be preferred? 