### PR TITLE
fix(python): support parameterised `read_database` calls against cursors that only take positional args

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2061,7 +2061,6 @@ class DataFrame:
         structured
             Optionally return a structured array, with field names and
             dtypes that correspond to the DataFrame schema.
-
         order
             The index order of the returned NumPy array, either C-like or
             Fortran-like. In general, using the Fortran-like index order is faster.
@@ -2106,7 +2105,7 @@ class DataFrame:
         array([(1, 6.5, 'a'), (2, 7. , 'b'), (3, 8.5, 'c')],
               dtype=[('foo', 'u1'), ('bar', '<f4'), ('ham', '<U1')])
 
-        ...optionally zero-copying as a record array view:
+        ...optionally going on to view as a record array:
 
         >>> import numpy as np
         >>> df.to_numpy(structured=True).view(np.recarray)

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import sys
 from importlib import import_module
+from inspect import Parameter, signature
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Sequence, TypedDict, overload
 
 from polars.convert import from_arrow
@@ -332,9 +333,26 @@ class ConnectionExecutor:
 
                 query = text(query)  # type: ignore[assignment]
 
-        if (result := cursor_execute(query, **options)) is None:
-            result = self.cursor  # some cursors execute in-place
+        # note: some cursor execute methods (eg: sqlite3) only take positional
+        # params, hence the slightly convoluted resolution of the 'options' dict
+        try:
+            params = signature(cursor_execute).parameters
+        except ValueError:
+            params = {}
 
+        if not options or any(
+            p.kind in (Parameter.KEYWORD_ONLY, Parameter.POSITIONAL_OR_KEYWORD)
+            for p in params.values()
+        ):
+            result = cursor_execute(query, **options)
+        else:
+            positional_options = (
+                options[o] for o in (params or options) if (not options or o in options)
+            )
+            result = cursor_execute(query, *positional_options)
+
+        # note: some cursors execute in-place
+        result = self.cursor if result is None else result
         self.result = result
         return self
 

--- a/py-polars/tests/unit/io/test_database_read.py
+++ b/py-polars/tests/unit/io/test_database_read.py
@@ -21,7 +21,12 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     import pyarrow as pa
 
-    from polars.type_aliases import DbReadEngine, SchemaDefinition, SchemaDict
+    from polars.type_aliases import (
+        ConnectionOrCursor,
+        DbReadEngine,
+        SchemaDefinition,
+        SchemaDict,
+    )
 
 
 def adbc_sqlite_connect(*args: Any, **kwargs: Any) -> Any:
@@ -364,11 +369,15 @@ def test_read_database_alchemy_selectable(tmp_path: Path) -> None:
     )
 
 
-def test_read_database_parameterisd(tmp_path: Path) -> None:
+def test_read_database_parameterised(tmp_path: Path) -> None:
     # setup underlying test data
     tmp_path.mkdir(exist_ok=True)
     create_temp_sqlite_db(test_db := str(tmp_path / "test.db"))
-    conn = create_engine(f"sqlite:///{test_db}")
+
+    # raw cursor "execute" only takes positional params, alchemy cursor takes kwargs
+    raw_conn: ConnectionOrCursor = sqlite3.connect(test_db)
+    alchemy_conn: ConnectionOrCursor = create_engine(f"sqlite:///{test_db}").connect()
+    test_conns = (alchemy_conn, raw_conn)
 
     # establish parameterised queries and validate usage
     query = """
@@ -381,14 +390,15 @@ def test_read_database_parameterisd(tmp_path: Path) -> None:
         ("?", (0,)),
         ("?", [0]),
     ):
-        assert_frame_equal(
-            pl.read_database(
-                query.format(n=param),
-                connection=conn.connect(),
-                execute_options={"parameters": param_value},
-            ),
-            pl.DataFrame({"year": [2021], "name": ["other"], "value": [-99.5]}),
-        )
+        for conn in test_conns:
+            assert_frame_equal(
+                pl.read_database(
+                    query.format(n=param),
+                    connection=conn,
+                    execute_options={"parameters": param_value},
+                ),
+                pl.DataFrame({"year": [2021], "name": ["other"], "value": [-99.5]}),
+            )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #12951.

The update is generic, not `sqlite3` specific, so if there are any other similar cursor "execute" methods out there (that don't take keyword args), we will now handle those transparently/correctly too. 

Added suitable test coverage.