### PR TITLE
feat(python): clarify "inefficient map_elements warning" message

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -432,22 +432,24 @@ class BytecodeParser:
                 apitype = "series"
                 clsname = "Series"
 
-            before_after_suggestion = (
+            before, after = (
                 (
-                    f"  \033[31m- {target_name}.map_elements({func_name})\033[0m\n"
-                    f"  \033[32m+ {suggested_expression}\033[0m\n{addendum}"
+                    f"  \033[31m- {target_name}.map_elements({func_name})\033[0m\n",
+                    f"  \033[32m+ {suggested_expression}\033[0m\n{addendum}",
                 )
                 if in_terminal_that_supports_colour()
                 else (
-                    f"  - {target_name}.map_elements({func_name})\n"
-                    f"  + {suggested_expression}\n{addendum}"
+                    f"  - {target_name}.map_elements({func_name})\n",
+                    f"  + {suggested_expression}\n{addendum}",
                 )
             )
             warnings.warn(
                 f"\n{clsname}.map_elements is significantly slower than the native {apitype} API.\n"
                 "Only use if you absolutely CANNOT implement your logic otherwise.\n"
-                "In this case, you can replace your `map_elements` with the following:\n"
-                f"{before_after_suggestion}",
+                "Don't do this:\n"
+                f"{before}"
+                "Do this instead:\n"
+                f"{after}",
                 PolarsInefficientMapWarning,
                 stacklevel=find_stacklevel(),
             )

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -446,9 +446,9 @@ class BytecodeParser:
             warnings.warn(
                 f"\n{clsname}.map_elements is significantly slower than the native {apitype} API.\n"
                 "Only use if you absolutely CANNOT implement your logic otherwise.\n"
-                "Don't do this:\n"
+                "Replace this expression...\n"
                 f"{before}"
-                "Do this instead:\n"
+                "with this one instead:\n"
                 f"{after}",
                 PolarsInefficientMapWarning,
                 stacklevel=find_stacklevel(),

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -199,7 +199,7 @@ def test_parse_invalid_function(func: str) -> None:
 def test_parse_apply_functions(col: str, func: str, expr_repr: str) -> None:
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r"(?s)Expr\.map_elements.*Do this instead",
+        match=r"(?s)Expr\.map_elements.*with this one instead",
     ):
         parser = BytecodeParser(eval(func), map_target="expr")
         suggested_expression = parser.to_expression(col)
@@ -238,7 +238,7 @@ def test_parse_apply_raw_functions() -> None:
         # ...but we ARE still able to warn
         with pytest.warns(
             PolarsInefficientMapWarning,
-            match=rf"(?s)Expr\.map_elements.*Don't do this.*np\.{func_name}",
+            match=rf"(?s)Expr\.map_elements.*Replace this expression.*np\.{func_name}",
         ):
             df1 = lf.select(pl.col("a").map_elements(func)).collect()
             df2 = lf.select(getattr(pl.col("a"), func_name)()).collect()
@@ -248,7 +248,7 @@ def test_parse_apply_raw_functions() -> None:
     result_frames = []
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r"(?s)Expr\.map_elements.*Do this instead:.*\.str\.json_decode",
+        match=r"(?s)Expr\.map_elements.*with this one instead:.*\.str\.json_decode",
     ):
         for expr in (
             pl.col("value").str.json_decode(),
@@ -267,7 +267,7 @@ def test_parse_apply_raw_functions() -> None:
     for py_cast, pl_dtype in ((str, pl.Utf8), (int, pl.Int64), (float, pl.Float64)):
         with pytest.warns(
             PolarsInefficientMapWarning,
-            match=rf'(?s)Do this instead.*pl\.col\("a"\)\.cast\(pl\.{pl_dtype.__name__}\)',
+            match=rf'(?s)with this one instead.*pl\.col\("a"\)\.cast\(pl\.{pl_dtype.__name__}\)',
         ):
             assert_frame_equal(
                 lf.select(pl.col("a").map_elements(py_cast)).collect(),
@@ -294,7 +294,7 @@ def test_parse_apply_miscellaneous() -> None:
     # literals as method parameters
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r"(?s)Series\.map_elements.*Do this instead.*\(np\.cos\(3\) \+ s\) - abs\(-1\)",
+        match=r"(?s)Series\.map_elements.*with this one instead.*\(np\.cos\(3\) \+ s\) - abs\(-1\)",
     ):
         pl_series = pl.Series("srs", [0, 1, 2, 3, 4])
         assert_series_equal(
@@ -358,9 +358,9 @@ def test_expr_exact_warning_message() -> None:
         "\n"
         "Expr.map_elements is significantly slower than the native expressions API.\n"
         "Only use if you absolutely CANNOT implement your logic otherwise.\n"
-        "Don't do this:\n"
+        "Replace this expression...\n"
         f'  {red}- pl.col("a").map_elements(lambda x: ...){end_escape}\n'
-        "Do this instead:\n"
+        "with this one instead:\n"
         f'  {green}+ pl.col("a") + 1{end_escape}\n'
     )
     # Check the EXACT warning message. If modifying the message in the future,

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -199,7 +199,7 @@ def test_parse_invalid_function(func: str) -> None:
 def test_parse_apply_functions(col: str, func: str, expr_repr: str) -> None:
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r"(?s)Expr\.map_elements.*In this case, you can replace",
+        match=r"(?s)Expr\.map_elements.*Do this instead",
     ):
         parser = BytecodeParser(eval(func), map_target="expr")
         suggested_expression = parser.to_expression(col)
@@ -238,7 +238,7 @@ def test_parse_apply_raw_functions() -> None:
         # ...but we ARE still able to warn
         with pytest.warns(
             PolarsInefficientMapWarning,
-            match=rf"(?s)Expr\.map_elements.*In this case, you can replace.*np\.{func_name}",
+            match=rf"(?s)Expr\.map_elements.*Don't do this.*np\.{func_name}",
         ):
             df1 = lf.select(pl.col("a").map_elements(func)).collect()
             df2 = lf.select(getattr(pl.col("a"), func_name)()).collect()
@@ -248,7 +248,7 @@ def test_parse_apply_raw_functions() -> None:
     result_frames = []
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r"(?s)Expr\.map_elements.*In this case, you can replace.*\.str\.json_decode",
+        match=r"(?s)Expr\.map_elements.*Do this instead:.*\.str\.json_decode",
     ):
         for expr in (
             pl.col("value").str.json_decode(),
@@ -267,7 +267,7 @@ def test_parse_apply_raw_functions() -> None:
     for py_cast, pl_dtype in ((str, pl.Utf8), (int, pl.Int64), (float, pl.Float64)):
         with pytest.warns(
             PolarsInefficientMapWarning,
-            match=rf'(?s)replace.*pl\.col\("a"\)\.cast\(pl\.{pl_dtype.__name__}\)',
+            match=rf'(?s)Do this instead.*pl\.col\("a"\)\.cast\(pl\.{pl_dtype.__name__}\)',
         ):
             assert_frame_equal(
                 lf.select(pl.col("a").map_elements(py_cast)).collect(),
@@ -294,7 +294,7 @@ def test_parse_apply_miscellaneous() -> None:
     # literals as method parameters
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r"(?s)Series\.map_elements.*replace.*\(np\.cos\(3\) \+ s\) - abs\(-1\)",
+        match=r"(?s)Series\.map_elements.*Do this instead.*\(np\.cos\(3\) \+ s\) - abs\(-1\)",
     ):
         pl_series = pl.Series("srs", [0, 1, 2, 3, 4])
         assert_series_equal(
@@ -358,8 +358,9 @@ def test_expr_exact_warning_message() -> None:
         "\n"
         "Expr.map_elements is significantly slower than the native expressions API.\n"
         "Only use if you absolutely CANNOT implement your logic otherwise.\n"
-        "In this case, you can replace your `map_elements` with the following:\n"
+        "Don't do this:\n"
         f'  {red}- pl.col("a").map_elements(lambda x: ...){end_escape}\n'
+        "Do this instead:\n"
         f'  {green}+ pl.col("a") + 1{end_escape}\n'
     )
     # Check the EXACT warning message. If modifying the message in the future,

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -24,7 +24,7 @@ def test_map_elements_infer_list() -> None:
 
 def test_map_elements_arithmetic_consistency() -> None:
     df = pl.DataFrame({"A": ["a", "a"], "B": [2, 3]})
-    with pytest.warns(PolarsInefficientMapWarning, match="Do this instead"):
+    with pytest.warns(PolarsInefficientMapWarning, match="with this one instead"):
         assert df.group_by("A").agg(pl.col("B").map_elements(lambda x: x + 1.0))[
             "B"
         ].to_list() == [[3.0, 4.0]]
@@ -82,7 +82,7 @@ def test_datelike_identity() -> None:
 def test_map_elements_list_anyvalue_fallback() -> None:
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r'(?s)Do this instead:.*pl.col\("text"\).str.json_decode()',
+        match=r'(?s)with this one instead:.*pl.col\("text"\).str.json_decode()',
     ):
         df = pl.DataFrame({"text": ['[{"x": 1, "y": 2}, {"x": 3, "y": 4}]']})
         assert df.select(pl.col("text").map_elements(json.loads)).to_dict(
@@ -170,7 +170,7 @@ def test_map_elements_skip_nulls() -> None:
 def test_map_elements_object_dtypes() -> None:
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r"(?s)Don't do this:.*lambda x:",
+        match=r"(?s)Replace this expression.*lambda x:",
     ):
         assert pl.DataFrame(
             {"a": pl.Series([1, 2, "a", 4, 5], dtype=pl.Object)}
@@ -209,7 +209,7 @@ def test_map_elements_explicit_list_output_type() -> None:
 def test_map_elements_dict() -> None:
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r'(?s)Do this instead:.*pl.col\("abc"\).str.json_decode()',
+        match=r'(?s)with this one instead:.*pl.col\("abc"\).str.json_decode()',
     ):
         df = pl.DataFrame({"abc": ['{"A":"Value1"}', '{"B":"Value2"}']})
         assert df.select(pl.col("abc").map_elements(json.loads)).to_dict(

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -24,9 +24,7 @@ def test_map_elements_infer_list() -> None:
 
 def test_map_elements_arithmetic_consistency() -> None:
     df = pl.DataFrame({"A": ["a", "a"], "B": [2, 3]})
-    with pytest.warns(
-        PolarsInefficientMapWarning, match="In this case, you can replace"
-    ):
+    with pytest.warns(PolarsInefficientMapWarning, match="Do this instead"):
         assert df.group_by("A").agg(pl.col("B").map_elements(lambda x: x + 1.0))[
             "B"
         ].to_list() == [[3.0, 4.0]]
@@ -84,7 +82,7 @@ def test_datelike_identity() -> None:
 def test_map_elements_list_anyvalue_fallback() -> None:
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r'(?s)replace your `map_elements` with.*pl.col\("text"\).str.json_decode()',
+        match=r'(?s)Do this instead:.*pl.col\("text"\).str.json_decode()',
     ):
         df = pl.DataFrame({"text": ['[{"x": 1, "y": 2}, {"x": 3, "y": 4}]']})
         assert df.select(pl.col("text").map_elements(json.loads)).to_dict(
@@ -172,7 +170,7 @@ def test_map_elements_skip_nulls() -> None:
 def test_map_elements_object_dtypes() -> None:
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r"(?s)replace your `map_elements` with.*lambda x:",
+        match=r"(?s)Don't do this:.*lambda x:",
     ):
         assert pl.DataFrame(
             {"a": pl.Series([1, 2, "a", 4, 5], dtype=pl.Object)}
@@ -211,7 +209,7 @@ def test_map_elements_explicit_list_output_type() -> None:
 def test_map_elements_dict() -> None:
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r'(?s)replace your `map_elements` with.*pl.col\("abc"\).str.json_decode()',
+        match=r'(?s)Do this instead:.*pl.col\("abc"\).str.json_decode()',
     ):
         df = pl.DataFrame({"abc": ['{"A":"Value1"}', '{"B":"Value2"}']})
         assert df.select(pl.col("abc").map_elements(json.loads)).to_dict(

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -157,7 +157,7 @@ def test_streaming_apply(monkeypatch: Any, capfd: Any) -> None:
 
     q = pl.DataFrame({"a": [1, 2]}).lazy()
 
-    with pytest.warns(PolarsInefficientMapWarning, match="Do this instead"):
+    with pytest.warns(PolarsInefficientMapWarning, match="with this one instead"):
         (
             q.select(
                 pl.col("a").map_elements(lambda x: x * 2, return_dtype=pl.Int64)

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -157,9 +157,7 @@ def test_streaming_apply(monkeypatch: Any, capfd: Any) -> None:
 
     q = pl.DataFrame({"a": [1, 2]}).lazy()
 
-    with pytest.warns(
-        PolarsInefficientMapWarning, match="In this case, you can replace"
-    ):
+    with pytest.warns(PolarsInefficientMapWarning, match="Do this instead"):
         (
             q.select(
                 pl.col("a").map_elements(lambda x: x * 2, return_dtype=pl.Int64)

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -75,7 +75,7 @@ def test_apply() -> None:
     assert_frame_equal(new, expected)
     assert_frame_equal(new.collect(), expected.collect())
 
-    with pytest.warns(PolarsInefficientMapWarning, match="Do this instead"):
+    with pytest.warns(PolarsInefficientMapWarning, match="with this one instead"):
         for strategy in ["thread_local", "threading"]:
             ldf = pl.LazyFrame({"a": [1, 2, 3] * 20, "b": [1.0, 2.0, 3.0] * 20})
             new = ldf.with_columns(

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -75,9 +75,7 @@ def test_apply() -> None:
     assert_frame_equal(new, expected)
     assert_frame_equal(new.collect(), expected.collect())
 
-    with pytest.warns(
-        PolarsInefficientMapWarning, match="In this case, you can replace"
-    ):
+    with pytest.warns(PolarsInefficientMapWarning, match="Do this instead"):
         for strategy in ["thread_local", "threading"]:
             ldf = pl.LazyFrame({"a": [1, 2, 3] * 20, "b": [1.0, 2.0, 3.0] * 20})
             new = ldf.with_columns(


### PR DESCRIPTION
This came up on Discord:

> because when you read it, it's quite strange. Replace map_elements by more map_elements

To be fair, the current message:
```diff
In this case, you can replace your `map_elements` with the following:
- pl.col("a").map_elements(lambda x: ...)
+ ((pl.col("a") * 9) / 5) + 32
```
might be confusing if you don't immediately recognise it as a git diff

I'm suggesting to make it much simpler:
```diff
Don't do this:
- pl.col("a").map_elements(lambda x: ...)
Do this instead:
+ ((pl.col("a") * 9) / 5) + 32
```