### PR TITLE
fix: don't get mutable if buffer is sliced

### DIFF
--- a/crates/polars-arrow/src/buffer/immutable.rs
+++ b/crates/polars-arrow/src/buffer/immutable.rs
@@ -201,6 +201,10 @@ impl<T> Buffer<T> {
     /// * has not been imported from the c data interface (FFI)
     #[inline]
     pub fn into_mut(mut self) -> Either<Self, Vec<T>> {
+        // We loose information if the data is sliced.
+        if self.length != self.data.len() {
+            return Either::Left(self);
+        }
         match Arc::get_mut(&mut self.data)
             .and_then(|b| b.get_vec())
             .map(std::mem::take)

--- a/py-polars/tests/unit/series/test_extend.py
+++ b/py-polars/tests/unit/series/test_extend.py
@@ -44,3 +44,10 @@ def test_extend_with_null_series() -> None:
     assert_series_equal(a, expected)
     assert_series_equal(result, expected)
     assert a.n_chunks() == 1
+
+
+def test_extend_sliced_12968() -> None:
+    assert pl.Series(["a", "b"]).slice(0, 1).extend(pl.Series(["c"])).to_list() == [
+        "a",
+        "c",
+    ]


### PR DESCRIPTION
fixes #12968