### PR TITLE
feat(rust,python): Allow order operators (<,>,>=,<=) on Enum types

### DIFF
--- a/crates/polars-core/src/chunked_array/comparison/categorical.rs
+++ b/crates/polars-core/src/chunked_array/comparison/categorical.rs
@@ -1,3 +1,7 @@
+use arrow::bitmap::Bitmap;
+use arrow::legacy::utils::FromTrustedLenIterator;
+use polars_compute::comparisons::TotalOrdKernel;
+
 use crate::prelude::*;
 
 #[cfg(feature = "dtype-categorical")]
@@ -76,35 +80,73 @@ impl ChunkCompare<&CategoricalChunked> for CategoricalChunked {
     }
 }
 
-// Huidige gedrag
-// Equality comparisons
-// If len == 1 => Convert it to phys and then apply on phys
-// If len > 1 => Convert cat to str and then apply on string
-// Ordering comparisons
-// Convert to str and then apply on string
-
-fn cat_str_equality_helper<'a, ComparePhys, CompareString>(
+fn cat_str_equality_helper<'a, Missing, CompareCat, ComparePhys, CompareString>(
     lhs: &'a CategoricalChunked,
     rhs: &'a Utf8Chunked,
     fill_value: bool,
+    missing_compare_function: Missing,
+    cat_compare_function: CompareCat,
     phys_compare_function: ComparePhys,
     str_compare_function: CompareString,
 ) -> PolarsResult<BooleanChunked>
 where
-    ComparePhys: Fn(&'a UInt32Chunked, u32) -> BooleanChunked,
+    Missing: Fn(&CategoricalChunked) -> BooleanChunked,
+    ComparePhys: Fn(&UInt32Chunked, u32) -> BooleanChunked,
+    CompareCat: Fn(&CategoricalChunked, &CategoricalChunked) -> PolarsResult<BooleanChunked>,
     CompareString: Fn(&Utf8Chunked, &'a Utf8Chunked) -> BooleanChunked,
 {
     let rev_map = lhs.get_rev_map();
-
-    if rhs.len() == 1 {
-        if let Some(Some(idx)) = rhs.get(0).map(|s| rev_map.find(s)) {
-            Ok(phys_compare_function(lhs.physical(), idx))
-        } else {
-            Ok(BooleanChunked::full(lhs.name(), fill_value, lhs.len()))
-        }
+    if rev_map.is_enum() {
+        let rhs_cat = rhs.cast(lhs.dtype())?;
+        cat_compare_function(lhs, rhs_cat.categorical().unwrap())
     } else {
-        let lhs_string = lhs.cast(&DataType::Utf8)?;
-        Ok(str_compare_function(lhs_string.utf8().unwrap(), rhs))
+        if rhs.len() == 1 {
+            match rhs.get(0) {
+                None => Ok(missing_compare_function(&lhs)),
+                Some(s) => {
+                    cat_single_str_equality_helper(lhs, s, fill_value, phys_compare_function)
+                },
+            }
+        } else {
+            let lhs_string = lhs.cast(&DataType::Utf8)?;
+            Ok(str_compare_function(lhs_string.utf8().unwrap(), rhs))
+        }
+    }
+}
+
+fn cat_str_compare_helper<'a, CompareCat, ComparePhys, CompareStringSingle, CompareString>(
+    lhs: &'a CategoricalChunked,
+    rhs: &'a Utf8Chunked,
+    cat_compare_function: CompareCat,
+    phys_compare_function: ComparePhys,
+    str_single_compare_function: CompareStringSingle,
+    str_compare_function: CompareString,
+) -> PolarsResult<BooleanChunked>
+where
+    CompareStringSingle: Fn(&Utf8Array<i64>, &str) -> Bitmap,
+    ComparePhys: Fn(&UInt32Chunked, u32) -> BooleanChunked,
+    CompareCat: Fn(&CategoricalChunked, &CategoricalChunked) -> PolarsResult<BooleanChunked>,
+    CompareString: Fn(&Utf8Chunked, &'a Utf8Chunked) -> BooleanChunked,
+{
+    let rev_map = lhs.get_rev_map();
+    if rev_map.is_enum() {
+        let rhs_cat = rhs.cast(lhs.dtype())?;
+        cat_compare_function(lhs, rhs_cat.categorical().unwrap())
+    } else {
+        if rhs.len() == 1 {
+            match rhs.get(0) {
+                None => Ok(BooleanChunked::full_null(lhs.name(), lhs.len())),
+                Some(s) => cat_single_str_compare_helper(
+                    lhs,
+                    s,
+                    phys_compare_function,
+                    str_single_compare_function,
+                ),
+            }
+        } else {
+            let lhs_string = lhs.cast(&DataType::Utf8)?;
+            Ok(str_compare_function(lhs_string.utf8().unwrap(), rhs))
+        }
     }
 }
 
@@ -112,14 +154,23 @@ impl ChunkCompare<&Utf8Chunked> for CategoricalChunked {
     type Item = PolarsResult<BooleanChunked>;
 
     fn equal(&self, rhs: &Utf8Chunked) -> Self::Item {
-        cat_str_equality_helper(self, rhs, false, UInt32Chunked::equal, Utf8Chunked::equal)
+        cat_str_equality_helper(
+            self,
+            rhs,
+            false,
+            |lhs| BooleanChunked::full_null(lhs.name(), lhs.len()),
+            |s1, s2| CategoricalChunked::equal(s1, s2),
+            UInt32Chunked::equal,
+            Utf8Chunked::equal,
+        )
     }
-
     fn equal_missing(&self, rhs: &Utf8Chunked) -> Self::Item {
         cat_str_equality_helper(
             self,
             rhs,
             false,
+            |lhs| lhs.physical().is_null(),
+            |s1, s2| CategoricalChunked::equal_missing(s1, s2),
             UInt32Chunked::equal_missing,
             Utf8Chunked::equal_missing,
         )
@@ -130,34 +181,183 @@ impl ChunkCompare<&Utf8Chunked> for CategoricalChunked {
             self,
             rhs,
             true,
+            |lhs| BooleanChunked::full_null(lhs.name(), lhs.len()),
+            |s1, s2| CategoricalChunked::not_equal(s1, s2),
             UInt32Chunked::not_equal,
             Utf8Chunked::not_equal,
         )
     }
-
     fn not_equal_missing(&self, rhs: &Utf8Chunked) -> Self::Item {
         cat_str_equality_helper(
             self,
             rhs,
             true,
+            |lhs| !lhs.physical().is_null(),
+            |s1, s2| CategoricalChunked::not_equal_missing(s1, s2),
             UInt32Chunked::not_equal_missing,
             Utf8Chunked::not_equal_missing,
         )
     }
 
     fn gt(&self, rhs: &Utf8Chunked) -> Self::Item {
-        todo!()
+        cat_str_compare_helper(
+            self,
+            rhs,
+            |s1, s2| CategoricalChunked::gt(s1, s2),
+            UInt32Chunked::gt,
+            Utf8Array::tot_gt_kernel_broadcast,
+            Utf8Chunked::gt,
+        )
     }
 
     fn gt_eq(&self, rhs: &Utf8Chunked) -> Self::Item {
-        todo!()
+        cat_str_compare_helper(
+            self,
+            rhs,
+            |s1, s2| CategoricalChunked::gt_eq(s1, s2),
+            UInt32Chunked::gt_eq,
+            Utf8Array::tot_ge_kernel_broadcast,
+            Utf8Chunked::gt_eq,
+        )
     }
 
     fn lt(&self, rhs: &Utf8Chunked) -> Self::Item {
-        todo!()
+        cat_str_compare_helper(
+            self,
+            rhs,
+            |s1, s2| CategoricalChunked::lt(s1, s2),
+            UInt32Chunked::lt,
+            Utf8Array::tot_lt_kernel_broadcast,
+            Utf8Chunked::lt,
+        )
     }
 
     fn lt_eq(&self, rhs: &Utf8Chunked) -> Self::Item {
-        todo!()
+        cat_str_compare_helper(
+            self,
+            rhs,
+            |s1, s2| CategoricalChunked::lt_eq(s1, s2),
+            UInt32Chunked::lt_eq,
+            Utf8Array::tot_le_kernel_broadcast,
+            Utf8Chunked::lt_eq,
+        )
+    }
+}
+
+fn cat_single_str_equality_helper<'a, ComparePhys>(
+    lhs: &'a CategoricalChunked,
+    rhs: &'a str,
+    fill_value: bool,
+    phys_compare_function: ComparePhys,
+) -> PolarsResult<BooleanChunked>
+where
+    ComparePhys: Fn(&UInt32Chunked, u32) -> BooleanChunked,
+{
+    let rev_map = lhs.get_rev_map();
+    if rev_map.is_enum() {
+        match rev_map.find(rhs) {
+            None => {
+                polars_bail!(ComputeError: "value '{}' is not present in Enum: {:?}",rhs,rev_map.get_categories())
+            },
+            Some(idx) => Ok(phys_compare_function(lhs.physical(), idx)),
+        }
+    } else {
+        match rev_map.find(rhs) {
+            None => Ok(BooleanChunked::full(lhs.name(), fill_value, lhs.len())),
+            Some(idx) => Ok(phys_compare_function(lhs.physical(), idx)),
+        }
+    }
+}
+
+fn cat_single_str_compare_helper<'a, ComparePhys, CompareStringSingle>(
+    lhs: &'a CategoricalChunked,
+    rhs: &'a str,
+    phys_compare_function: ComparePhys,
+    str_single_compare_function: CompareStringSingle,
+) -> PolarsResult<BooleanChunked>
+where
+    CompareStringSingle: Fn(&Utf8Array<i64>, &str) -> Bitmap,
+    ComparePhys: Fn(&UInt32Chunked, u32) -> BooleanChunked,
+{
+    let rev_map = lhs.get_rev_map();
+    if rev_map.is_enum() {
+        match rev_map.find(rhs) {
+            None => {
+                polars_bail!(
+                    not_in_enum,
+                    value = rhs,
+                    categories = rev_map.get_categories()
+                )
+            },
+            Some(idx) => Ok(phys_compare_function(lhs.physical(), idx)),
+        }
+    } else {
+        // Apply comparison on categories map and then do a lookup
+        let bitmap = str_single_compare_function(lhs.get_rev_map().get_categories(), rhs);
+
+        Ok(BooleanChunked::from_iter_trusted_length(
+            lhs.physical().into_iter().map(|opt_idx| {
+                // Safety: indexing into bitmap with same length as original array
+                opt_idx.map_or(None, |idx| unsafe {
+                    Some(bitmap.get_bit_unchecked(idx as usize))
+                })
+            }),
+        ))
+    }
+}
+
+impl ChunkCompare<&str> for CategoricalChunked {
+    type Item = PolarsResult<BooleanChunked>;
+
+    fn equal(&self, rhs: &str) -> Self::Item {
+        cat_single_str_equality_helper(self, rhs, false, UInt32Chunked::equal)
+    }
+
+    fn equal_missing(&self, rhs: &str) -> Self::Item {
+        self.equal(rhs)
+    }
+
+    fn not_equal(&self, rhs: &str) -> Self::Item {
+        cat_single_str_equality_helper(self, rhs, true, UInt32Chunked::not_equal)
+    }
+
+    fn not_equal_missing(&self, rhs: &str) -> Self::Item {
+        self.not_equal(rhs)
+    }
+
+    fn gt(&self, rhs: &str) -> Self::Item {
+        cat_single_str_compare_helper(
+            self,
+            rhs,
+            UInt32Chunked::gt,
+            Utf8Array::tot_gt_kernel_broadcast,
+        )
+    }
+
+    fn gt_eq(&self, rhs: &str) -> Self::Item {
+        cat_single_str_compare_helper(
+            self,
+            rhs,
+            UInt32Chunked::gt_eq,
+            Utf8Array::tot_ge_kernel_broadcast,
+        )
+    }
+
+    fn lt(&self, rhs: &str) -> Self::Item {
+        cat_single_str_compare_helper(
+            self,
+            rhs,
+            UInt32Chunked::lt,
+            Utf8Array::tot_lt_kernel_broadcast,
+        )
+    }
+
+    fn lt_eq(&self, rhs: &str) -> Self::Item {
+        cat_single_str_compare_helper(
+            self,
+            rhs,
+            UInt32Chunked::lt_eq,
+            Utf8Array::tot_le_kernel_broadcast,
+        )
     }
 }

--- a/crates/polars-core/src/chunked_array/comparison/categorical.rs
+++ b/crates/polars-core/src/chunked_array/comparison/categorical.rs
@@ -1,0 +1,163 @@
+use crate::prelude::*;
+
+#[cfg(feature = "dtype-categorical")]
+fn cat_equality_helper<'a, Compare>(
+    lhs: &'a CategoricalChunked,
+    rhs: &'a CategoricalChunked,
+    fill_value: bool,
+    compare_function: Compare,
+) -> PolarsResult<BooleanChunked>
+where
+    Compare: Fn(&'a UInt32Chunked, &'a UInt32Chunked) -> BooleanChunked,
+{
+    let rev_map_l = lhs.get_rev_map();
+    polars_ensure!(rev_map_l.same_src(rhs.get_rev_map()), string_cache_mismatch);
+    let rhs = rhs.physical();
+
+    // Fast path for globals
+    if rhs.len() == 1 && rhs.null_count() == 0 {
+        let rhs = rhs.get(0).unwrap();
+        if rev_map_l.get_optional(rhs).is_none() {
+            return Ok(BooleanChunked::full(lhs.name(), fill_value, lhs.len()));
+        }
+    }
+    Ok(compare_function(lhs.physical(), rhs))
+}
+
+fn cat_compare_helper<'a, Compare>(
+    lhs: &'a CategoricalChunked,
+    rhs: &'a CategoricalChunked,
+    compare_function: Compare,
+) -> PolarsResult<BooleanChunked>
+where
+    Compare: Fn(&'a UInt32Chunked, &'a UInt32Chunked) -> BooleanChunked,
+{
+    let rev_map_l = lhs.get_rev_map();
+    let rev_map_r = rhs.get_rev_map();
+    polars_ensure!(rev_map_l.is_enum() && rev_map_r.is_enum(), ComputeError: "can not compare (<, <=, >, >=) two categoricals, unless they are of Enum type");
+    polars_ensure!(rev_map_l.same_src(rev_map_r), ComputeError: "can only compare Enum types with the same categories {:?} vs {:?}", rev_map_l.get_categories(), rev_map_r.get_categories());
+
+    Ok(compare_function(lhs.physical(), rhs.physical()))
+}
+
+impl ChunkCompare<&CategoricalChunked> for CategoricalChunked {
+    type Item = PolarsResult<BooleanChunked>;
+
+    fn equal(&self, rhs: &CategoricalChunked) -> Self::Item {
+        cat_equality_helper(self, rhs, false, UInt32Chunked::equal)
+    }
+
+    fn equal_missing(&self, rhs: &CategoricalChunked) -> Self::Item {
+        cat_equality_helper(self, rhs, false, UInt32Chunked::equal_missing)
+    }
+
+    fn not_equal(&self, rhs: &CategoricalChunked) -> Self::Item {
+        cat_equality_helper(self, rhs, true, UInt32Chunked::not_equal)
+    }
+
+    fn not_equal_missing(&self, rhs: &CategoricalChunked) -> Self::Item {
+        cat_equality_helper(self, rhs, true, UInt32Chunked::not_equal_missing)
+    }
+
+    fn gt(&self, rhs: &CategoricalChunked) -> Self::Item {
+        cat_compare_helper(self, rhs, UInt32Chunked::gt)
+    }
+
+    fn gt_eq(&self, rhs: &CategoricalChunked) -> Self::Item {
+        cat_compare_helper(self, rhs, UInt32Chunked::gt_eq)
+    }
+
+    fn lt(&self, rhs: &CategoricalChunked) -> Self::Item {
+        cat_compare_helper(self, rhs, UInt32Chunked::lt)
+    }
+
+    fn lt_eq(&self, rhs: &CategoricalChunked) -> Self::Item {
+        cat_compare_helper(self, rhs, UInt32Chunked::lt_eq)
+    }
+}
+
+// Huidige gedrag
+// Equality comparisons
+// If len == 1 => Convert it to phys and then apply on phys
+// If len > 1 => Convert cat to str and then apply on string
+// Ordering comparisons
+// Convert to str and then apply on string
+
+fn cat_str_equality_helper<'a, ComparePhys, CompareString>(
+    lhs: &'a CategoricalChunked,
+    rhs: &'a Utf8Chunked,
+    fill_value: bool,
+    phys_compare_function: ComparePhys,
+    str_compare_function: CompareString,
+) -> PolarsResult<BooleanChunked>
+where
+    ComparePhys: Fn(&'a UInt32Chunked, u32) -> BooleanChunked,
+    CompareString: Fn(&Utf8Chunked, &'a Utf8Chunked) -> BooleanChunked,
+{
+    let rev_map = lhs.get_rev_map();
+
+    if rhs.len() == 1 {
+        if let Some(Some(idx)) = rhs.get(0).map(|s| rev_map.find(s)) {
+            Ok(phys_compare_function(lhs.physical(), idx))
+        } else {
+            Ok(BooleanChunked::full(lhs.name(), fill_value, lhs.len()))
+        }
+    } else {
+        let lhs_string = lhs.cast(&DataType::Utf8)?;
+        Ok(str_compare_function(lhs_string.utf8().unwrap(), rhs))
+    }
+}
+
+impl ChunkCompare<&Utf8Chunked> for CategoricalChunked {
+    type Item = PolarsResult<BooleanChunked>;
+
+    fn equal(&self, rhs: &Utf8Chunked) -> Self::Item {
+        cat_str_equality_helper(self, rhs, false, UInt32Chunked::equal, Utf8Chunked::equal)
+    }
+
+    fn equal_missing(&self, rhs: &Utf8Chunked) -> Self::Item {
+        cat_str_equality_helper(
+            self,
+            rhs,
+            false,
+            UInt32Chunked::equal_missing,
+            Utf8Chunked::equal_missing,
+        )
+    }
+
+    fn not_equal(&self, rhs: &Utf8Chunked) -> Self::Item {
+        cat_str_equality_helper(
+            self,
+            rhs,
+            true,
+            UInt32Chunked::not_equal,
+            Utf8Chunked::not_equal,
+        )
+    }
+
+    fn not_equal_missing(&self, rhs: &Utf8Chunked) -> Self::Item {
+        cat_str_equality_helper(
+            self,
+            rhs,
+            true,
+            UInt32Chunked::not_equal_missing,
+            Utf8Chunked::not_equal_missing,
+        )
+    }
+
+    fn gt(&self, rhs: &Utf8Chunked) -> Self::Item {
+        todo!()
+    }
+
+    fn gt_eq(&self, rhs: &Utf8Chunked) -> Self::Item {
+        todo!()
+    }
+
+    fn lt(&self, rhs: &Utf8Chunked) -> Self::Item {
+        todo!()
+    }
+
+    fn lt_eq(&self, rhs: &Utf8Chunked) -> Self::Item {
+        todo!()
+    }
+}

--- a/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -587,9 +587,9 @@ impl CategoricalChunked {
             .map(|opt_s: Option<&str>| {
                 opt_s
                     .map(|s| {
-                        map.get(s).copied().ok_or_else(
-                            || polars_err!(ComputeError: "value '{}' is not present in Enum: {:?}",s,categories),
-                        )
+                        map.get(s).copied().ok_or_else(|| {
+                            polars_err!(not_in_enum, value = s, categories = categories)
+                        })
                     })
                     .transpose()
             })

--- a/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -106,6 +106,7 @@ impl RevMapping {
         matches!(self, Self::Local(_, _))
     }
 
+    #[inline]
     pub fn is_enum(&self) -> bool {
         matches!(self, Self::Enum(_, _))
     }

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -150,7 +150,19 @@ impl CategoricalChunked {
         let new_phys: UInt32Chunked = self
             .physical()
             .into_iter()
-            .map(|opt_v: Option<u32>| opt_v.map(|v| idx_map.get(&v).copied().ok_or_else(|| polars_err!(ComputeError: "value '{}' is not present in Enum {:?}",old_rev_map.get(v),&categories))).transpose())
+            .map(|opt_v: Option<u32>| {
+                opt_v
+                    .map(|v| {
+                        idx_map.get(&v).copied().ok_or_else(|| {
+                            polars_err!(
+                                not_in_enum,
+                                value = old_rev_map.get(v),
+                                categories = &categories
+                            )
+                        })
+                    })
+                    .transpose()
+            })
             .collect::<PolarsResult<_>>()?;
 
         Ok(

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -151,17 +151,19 @@ impl CategoricalChunked {
             .physical()
             .into_iter()
             .map(|opt_v: Option<u32>| {
-                opt_v
-                    .map(|v| {
-                        idx_map.get(&v).copied().ok_or_else(|| {
-                            polars_err!(
-                                not_in_enum,
-                                value = old_rev_map.get(v),
-                                categories = &categories
-                            )
-                        })
-                    })
-                    .transpose()
+                let Some(v) = opt_v else {
+                    return Ok(None);
+                };
+
+                let Some(idx) = idx_map.get(&v) else {
+                    polars_bail!(
+                        not_in_enum,
+                        value = old_rev_map.get(v),
+                        categories = &categories
+                    );
+                };
+
+                Ok(Some(*idx))
             })
             .collect::<PolarsResult<_>>()?;
 

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -29,7 +29,7 @@ pub mod gather;
 mod interpolate;
 #[cfg(feature = "zip_with")]
 pub(crate) mod min_max_binary;
-mod nulls;
+pub(crate) mod nulls;
 mod reverse;
 pub(crate) mod rolling_window;
 mod set;

--- a/crates/polars-core/src/chunked_array/ops/nulls.rs
+++ b/crates/polars-core/src/chunked_array/ops/nulls.rs
@@ -49,6 +49,18 @@ pub fn is_null(name: &str, chunks: &[ArrayRef]) -> BooleanChunked {
     BooleanChunked::from_chunk_iter(name, chunks)
 }
 
+pub fn replace_non_null(name: &str, chunks: &[ArrayRef], default: bool) -> BooleanChunked {
+    BooleanChunked::from_chunk_iter(
+        name,
+        chunks.iter().map(|el| {
+            BooleanArray::from_data_default(
+                Bitmap::new_with_value(default, el.len()),
+                el.validity().cloned(),
+            )
+        }),
+    )
+}
+
 pub(crate) fn coalesce_nulls(chunks: &[ArrayRef], other: &[ArrayRef]) -> Vec<ArrayRef> {
     assert_eq!(chunks.len(), other.len());
     chunks

--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -11,6 +11,8 @@ use crate::series::arithmetic::coerce_lhs_rhs;
 macro_rules! impl_compare {
     ($self:expr, $rhs:expr, $method:ident) => {{
         let (lhs, rhs) = ($self, $rhs);
+
+        #[cfg(feature = "dtype-categorical")]
         if matches!(lhs.dtype(), DataType::Categorical(_, _))
             && matches!(lhs.dtype(), DataType::Categorical(_, _))
         {

--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -14,7 +14,7 @@ macro_rules! impl_compare {
 
         #[cfg(feature = "dtype-categorical")]
         if matches!(lhs.dtype(), DataType::Categorical(_, _))
-            && matches!(lhs.dtype(), DataType::Categorical(_, _))
+            && matches!(rhs.dtype(), DataType::Categorical(_, _))
         {
             return lhs
                 .categorical()

--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -219,7 +219,7 @@ macro_rules! polars_err {
     (unpack) => {
         polars_err!(SchemaMismatch: "cannot unpack series, data types don't match")
     };
-    (not_in_enum,value=$value:ident,categories=$categories:expr) =>{
+    (not_in_enum,value=$value:expr,categories=$categories:expr) =>{
         polars_err!(ComputeError: "value '{}' is not present in Enum: {:?}",$value,$categories)
     };
     (string_cache_mismatch) => {

--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -219,6 +219,9 @@ macro_rules! polars_err {
     (unpack) => {
         polars_err!(SchemaMismatch: "cannot unpack series, data types don't match")
     };
+    (not_in_enum,value=$value:ident,categories=$categories:expr) =>{
+        polars_err!(ComputeError: "value '{}' is not present in Enum: {:?}",$value,$categories)
+    };
     (string_cache_mismatch) => {
         polars_err!(StringCacheMismatch: r#"
 cannot compare categoricals coming from different sources, consider setting a global StringCache.

--- a/docs/src/python/user-guide/concepts/data-types/categoricals.py
+++ b/docs/src/python/user-guide/concepts/data-types/categoricals.py
@@ -1,5 +1,6 @@
 # --8<-- [start:setup]
 import polars as pl
+
 # --8<-- [end:setup]
 
 # --8<-- [start:example]
@@ -83,7 +84,9 @@ print(cat_series <= cat_series_utf)
 
 # --8<-- [start:str_enum_compare_error]
 try:
-    cat_series = pl.Series(["Low", "Medium", "High"], dtype=pl.Enum(["Low", "Medium", "High"]))
+    cat_series = pl.Series(
+        ["Low", "Medium", "High"], dtype=pl.Enum(["Low", "Medium", "High"])
+    )
     cat_series <= "Excellent"
 except Exception as e:
     print(e)
@@ -101,4 +104,3 @@ cat_series = pl.Series(["Low", "Medium", "High"], dtype=dtype)
 cat_series2 = pl.Series(["High", "High", "Low"], dtype=dtype)
 print(cat_series <= cat_series2)
 # --8<-- [end:str_enum_compare]
-

--- a/docs/src/python/user-guide/concepts/data-types/categoricals.py
+++ b/docs/src/python/user-guide/concepts/data-types/categoricals.py
@@ -1,4 +1,6 @@
+# --8<-- [start:setup]
 import polars as pl
+# --8<-- [end:setup]
 
 # --8<-- [start:example]
 enum_dtype = pl.Enum(["Polar", "Panda", "Brown"])
@@ -16,7 +18,7 @@ cat_series = pl.Series(
 cat2_series = pl.Series(
     ["Panda", "Brown", "Brown", "Polar", "Polar"], dtype=pl.Categorical
 )
-cat_series.append(cat2_series)
+print(cat_series.append(cat2_series))
 # --8<-- [end:append]
 
 
@@ -28,7 +30,7 @@ with pl.StringCache():
     cat2_series = pl.Series(
         ["Panda", "Brown", "Brown", "Polar", "Polar"], dtype=pl.Categorical
     )
-    cat_series.append(cat2_series)
+    print(cat_series.append(cat2_series))
 # --8<-- [end:global_append]
 
 
@@ -36,7 +38,7 @@ with pl.StringCache():
 dtype = pl.Enum(["Polar", "Panda", "Brown"])
 cat_series = pl.Series(["Polar", "Panda", "Brown", "Brown", "Polar"], dtype=dtype)
 cat2_series = pl.Series(["Panda", "Brown", "Brown", "Polar", "Polar"], dtype=dtype)
-cat_series.append(cat2_series)
+print(cat_series.append(cat2_series))
 # --8<-- [end:enum_append]
 
 # --8<-- [start:enum_error]
@@ -46,3 +48,57 @@ try:
 except Exception as e:
     print(e)
 # --8<-- [end:enum_error]
+
+# --8<-- [start:equality]
+dtype = pl.Enum(["Polar", "Panda", "Brown"])
+cat_series = pl.Series(["Brown", "Panda", "Polar"], dtype=dtype)
+cat_series2 = pl.Series(["Polar", "Panda", "Brown"], dtype=dtype)
+print(cat_series == cat_series2)
+# --8<-- [end:equality]
+
+# --8<-- [start:global_equality]
+with pl.StringCache():
+    cat_series = pl.Series(["Brown", "Panda", "Polar"], dtype=pl.Categorical)
+    cat_series2 = pl.Series(["Polar", "Panda", "Black"], dtype=pl.Categorical)
+    print(cat_series == cat_series2)
+# --8<-- [end:global_equality]
+
+# --8<-- [start:equality]
+dtype = pl.Enum(["Polar", "Panda", "Brown"])
+cat_series = pl.Series(["Brown", "Panda", "Polar"], dtype=dtype)
+cat_series2 = pl.Series(["Polar", "Panda", "Brown", "Black"], dtype=dtype)
+print(cat_series == cat_series2)
+# --8<-- [end:equality]
+
+# --8<-- [start:str_compare_single]
+cat_series = pl.Series(["Brown", "Panda", "Polar"], dtype=pl.Categorical)
+print(cat_series <= "Cat")
+# --8<-- [end:str_compare_single]
+
+# --8<-- [start:str_compare]
+cat_series = pl.Series(["Brown", "Panda", "Polar"], dtype=pl.Categorical)
+cat_series_utf = pl.Series(["Panda", "Panda", "Polar"])
+print(cat_series <= cat_series_utf)
+# --8<-- [end:str_compare]
+
+# --8<-- [start:str_enum_compare_error]
+try:
+    cat_series = pl.Series(["Low", "Medium", "High"], dtype=pl.Enum(["Low", "Medium", "High"]))
+    cat_series <= "Excellent"
+except Exception as e:
+    print(e)
+# --8<-- [end:str_enum_compare_error]
+
+# --8<-- [start:str_enum_compare_single]
+dtype = pl.Enum(["Low", "Medium", "High"])
+cat_series = pl.Series(["Low", "Medium", "High"], dtype=dtype)
+print(cat_series <= "Medium")
+# --8<-- [end:str_enum_compare_single]
+
+# --8<-- [start:str_enum_compare]
+dtype = pl.Enum(["Low", "Medium", "High"])
+cat_series = pl.Series(["Low", "Medium", "High"], dtype=dtype)
+cat_series2 = pl.Series(["High", "High", "Low"], dtype=dtype)
+print(cat_series <= cat_series2)
+# --8<-- [end:str_enum_compare]
+

--- a/docs/src/python/user-guide/concepts/data-types/categoricals.py
+++ b/docs/src/python/user-guide/concepts/data-types/categoricals.py
@@ -19,6 +19,7 @@ cat_series = pl.Series(
 cat2_series = pl.Series(
     ["Panda", "Brown", "Brown", "Polar", "Polar"], dtype=pl.Categorical
 )
+# Triggers a CategoricalRemappingWarning: Local categoricals have different encodings, expensive re-encoding is done
 print(cat_series.append(cat2_series))
 # --8<-- [end:append]
 
@@ -67,7 +68,7 @@ with pl.StringCache():
 # --8<-- [start:equality]
 dtype = pl.Enum(["Polar", "Panda", "Brown"])
 cat_series = pl.Series(["Brown", "Panda", "Polar"], dtype=dtype)
-cat_series2 = pl.Series(["Polar", "Panda", "Brown", "Black"], dtype=dtype)
+cat_series2 = pl.Series(["Polar", "Panda", "Brown"], dtype=dtype)
 print(cat_series == cat_series2)
 # --8<-- [end:equality]
 

--- a/docs/user-guide/concepts/data-types/categoricals.md
+++ b/docs/user-guide/concepts/data-types/categoricals.md
@@ -258,3 +258,72 @@ In the `Enum` data type we specify the categories in advance. This way we ensure
 Polars will raise an `OutOfBounds` error when a value is encountered which is not specified in the `Enum`.
 
 {{code_block('user-guide/concepts/data-types/categoricals','enum_error',[])}}
+
+```python exec="on" result="text" session="user-guide/datatypes/categoricals"
+--8<-- "python/user-guide/concepts/data-types/categoricals.py:setup"
+--8<-- "python/user-guide/concepts/data-types/categoricals.py:enum_error"
+```
+### Comparisons
+
+The following types of comparisons operators are allowed for categorical data:
+
+- Categorical vs Categorical
+- Categorical vs Utf8
+
+#### `Categorical` Type
+
+For the `Categorical` type comparisons are valid if they have the same global cache set or if they have the same underlying categories in the same order.  
+
+{{code_block('user-guide/concepts/data-types/categoricals','global_equality',[])}}
+
+```python exec="on" result="text" session="user-guide/datatypes/categoricals"
+--8<-- "python/user-guide/concepts/data-types/categoricals.py:setup"
+--8<-- "python/user-guide/concepts/data-types/categoricals.py:global_equality"
+```
+
+For `Categorical` vs `Utf8` comparisons Polars uses lexical ordering to determine the result:
+
+{{code_block('user-guide/concepts/data-types/categoricals','str_compare_single',[])}}
+
+```python exec="on" result="text" session="user-guide/datatypes/categoricals"
+--8<-- "python/user-guide/concepts/data-types/categoricals.py:str_compare_single"
+```
+
+{{code_block('user-guide/concepts/data-types/categoricals','str_compare',[])}}
+
+```python exec="on" result="text" session="user-guide/datatypes/categoricals"
+--8<-- "python/user-guide/concepts/data-types/categoricals.py:str_compare"
+```
+
+#### `Enum` Type
+
+For `Enum` type comparisons are valid if they have the same categories.
+
+{{code_block('user-guide/concepts/data-types/categoricals','equality',[])}}
+
+```python exec="on" result="text" session="user-guide/datatypes/categoricals"
+--8<-- "python/user-guide/concepts/data-types/categoricals.py:equality"
+```
+
+For `Enum` vs `Utf8` comparisons the order within the categories is used instead of lexical ordering. In order for a comparison to be valid all values in the `Utf8` column should be present in the `Enum` categories list.
+
+{{code_block('user-guide/concepts/data-types/categoricals','str_enum_compare_error',[])}}
+
+
+```python exec="on" result="text" session="user-guide/datatypes/categoricals"
+--8<-- "python/user-guide/concepts/data-types/categoricals.py:str_enum_compare_error"
+```
+
+{{code_block('user-guide/concepts/data-types/categoricals','str_enum_compare_single',[])}}
+
+
+```python exec="on" result="text" session="user-guide/datatypes/categoricals"
+--8<-- "python/user-guide/concepts/data-types/categoricals.py:str_enum_compare_single"
+```
+
+{{code_block('user-guide/concepts/data-types/categoricals','str_enum_compare',[])}}
+
+
+```python exec="on" result="text" session="user-guide/datatypes/categoricals"
+--8<-- "python/user-guide/concepts/data-types/categoricals.py:str_enum_compare"
+```

--- a/docs/user-guide/concepts/data-types/categoricals.md
+++ b/docs/user-guide/concepts/data-types/categoricals.md
@@ -263,6 +263,7 @@ Polars will raise an `OutOfBounds` error when a value is encountered which is no
 --8<-- "python/user-guide/concepts/data-types/categoricals.py:setup"
 --8<-- "python/user-guide/concepts/data-types/categoricals.py:enum_error"
 ```
+
 ### Comparisons
 
 The following types of comparisons operators are allowed for categorical data:
@@ -272,7 +273,7 @@ The following types of comparisons operators are allowed for categorical data:
 
 #### `Categorical` Type
 
-For the `Categorical` type comparisons are valid if they have the same global cache set or if they have the same underlying categories in the same order.  
+For the `Categorical` type comparisons are valid if they have the same global cache set or if they have the same underlying categories in the same order.
 
 {{code_block('user-guide/concepts/data-types/categoricals','global_equality',[])}}
 
@@ -309,20 +310,17 @@ For `Enum` vs `Utf8` comparisons the order within the categories is used instead
 
 {{code_block('user-guide/concepts/data-types/categoricals','str_enum_compare_error',[])}}
 
-
 ```python exec="on" result="text" session="user-guide/datatypes/categoricals"
 --8<-- "python/user-guide/concepts/data-types/categoricals.py:str_enum_compare_error"
 ```
 
 {{code_block('user-guide/concepts/data-types/categoricals','str_enum_compare_single',[])}}
 
-
 ```python exec="on" result="text" session="user-guide/datatypes/categoricals"
 --8<-- "python/user-guide/concepts/data-types/categoricals.py:str_enum_compare_single"
 ```
 
 {{code_block('user-guide/concepts/data-types/categoricals','str_enum_compare',[])}}
-
 
 ```python exec="on" result="text" session="user-guide/datatypes/categoricals"
 --8<-- "python/user-guide/concepts/data-types/categoricals.py:str_enum_compare"

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -29,6 +29,7 @@ from polars.datatypes import (
     Datetime,
     Decimal,
     Duration,
+    Enum,
     Float64,
     Int8,
     Int16,
@@ -533,7 +534,7 @@ class Series:
             assert f is not None
             return self._from_pyseries(f(td))
 
-        elif self.dtype == Categorical and not isinstance(other, Series):
+        elif self.dtype in [Categorical, Enum] and not isinstance(other, Series):
             other = Series([other])
 
         elif isinstance(other, date) and self.dtype == Date:

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import io
+import operator
+import re
 from typing import TYPE_CHECKING, Any
 
-import re
 import pytest
-import operator
 
 import polars as pl
 from polars import StringCache
@@ -125,18 +125,24 @@ def test_unset_sorted_on_append() -> None:
     df = pl.concat([df1, df2], rechunk=False)
     assert df.group_by("key").count()["count"].to_list() == [4, 4]
 
+
 def test_categorical_equality() -> None:
     df_cat = pl.DataFrame(
         [
-            pl.Series("a_cat", ["a", "b", "c", "c", "b","a"], dtype=pl.Categorical),
-            pl.Series("b_cat", ["a", "b", "c", "a", "b","c"], dtype=pl.Categorical),
+            pl.Series("a_cat", ["a", "b", "c", "c", "b", "a"], dtype=pl.Categorical),
+            pl.Series("b_cat", ["a", "b", "c", "a", "b", "c"], dtype=pl.Categorical),
         ]
     )
     df_cat_eq = df_cat.filter(pl.col("a_cat") == pl.col("b_cat"))
-    assert df_cat_eq.select(pl.col("a_cat")).to_dict(as_series=False) == {"a_cat":["a","b","c","b"]}
+    assert df_cat_eq.select(pl.col("a_cat")).to_dict(as_series=False) == {
+        "a_cat": ["a", "b", "c", "b"]
+    }
 
     df_cat_neq = df_cat.filter(pl.col("a_cat") != pl.col("b_cat"))
-    assert df_cat_neq.select(pl.col("a_cat")).to_dict(as_series=False) == {"a_cat":["c","a"]}
+    assert df_cat_neq.select(pl.col("a_cat")).to_dict(as_series=False) == {
+        "a_cat": ["c", "a"]
+    }
+
 
 def test_categorical_error_on_local_ordering() -> None:
     df_cat = pl.DataFrame(
@@ -145,44 +151,54 @@ def test_categorical_error_on_local_ordering() -> None:
             pl.Series("b_cat", ["c", "a", "b", "c", "b"], dtype=pl.Categorical),
         ]
     )
-    for op in [operator.gt,operator.ge, operator.lt,operator.le]:
+    for op in [operator.gt, operator.ge, operator.lt, operator.le]:
         with pytest.raises(
-                pl.ComputeError,
-                match=re.escape("can not compare (<, <=, >, >=) two categoricals, unless they are of Enum type"),
+            pl.ComputeError,
+            match=re.escape(
+                "can not compare (<, <=, >, >=) two categoricals, unless they are of Enum type"
+            ),
         ):
-            df_cat.filter(op(pl.col("a_cat"),pl.col("b_cat")))
+            df_cat.filter(op(pl.col("a_cat"), pl.col("b_cat")))
+
 
 def test_different_enum_comparison_order() -> None:
     df_enum = pl.DataFrame(
         [
-            pl.Series("a_cat", ["c", "a", "b", "c", "b"], dtype=pl.Enum(["a","b","c"])),
-            pl.Series("b_cat", ["F", "G", "E", "G", "G"], dtype=pl.Enum(["F","G","E"])),
+            pl.Series(
+                "a_cat", ["c", "a", "b", "c", "b"], dtype=pl.Enum(["a", "b", "c"])
+            ),
+            pl.Series(
+                "b_cat", ["F", "G", "E", "G", "G"], dtype=pl.Enum(["F", "G", "E"])
+            ),
         ]
     )
-    for op in [operator.gt,operator.ge, operator.lt,operator.le]:
+    for op in [operator.gt, operator.ge, operator.lt, operator.le]:
         with pytest.raises(
-                pl.ComputeError,
-                match="can only compare Enum types with the same categories",
+            pl.ComputeError,
+            match="can only compare Enum types with the same categories",
         ):
             df_enum.filter(op(pl.col("a_cat"), pl.col("b_cat")))
 
+
 def test_enum_comparison_order() -> None:
-    dtype=pl.Enum(["LOW","MEDIUM","HIGH"])
+    dtype = pl.Enum(["LOW", "MEDIUM", "HIGH"])
     df_enum = pl.DataFrame(
         [
-            pl.Series("a_cat", ["LOW", "MEDIUM", "MEDIUM", "HIGH", "MEDIUM"],dtype=dtype),
+            pl.Series(
+                "a_cat", ["LOW", "MEDIUM", "MEDIUM", "HIGH", "MEDIUM"], dtype=dtype
+            ),
             pl.Series("b_cat", ["HIGH", "HIGH", "MEDIUM", "LOW", "LOW"], dtype=dtype),
         ]
     )
 
     df_cmp = df_enum.select((pl.col("a_cat") <= pl.col("b_cat")).alias("cmp"))
-    assert df_cmp.to_dict(as_series=False) == {"cmp":[True,True,True,False,False]}
+    assert df_cmp.to_dict(as_series=False) == {"cmp": [True, True, True, False, False]}
 
     df_cmp = df_enum.select((pl.col("a_cat") > pl.col("b_cat")).alias("cmp"))
-    assert df_cmp.to_dict(as_series=False) == {"cmp":[False,False,False,True,True]}
+    assert df_cmp.to_dict(as_series=False) == {"cmp": [False, False, False, True, True]}
 
     df_cmp = df_enum.select((pl.col("a_cat") >= pl.col("b_cat")).alias("cmp"))
-    assert df_cmp.to_dict(as_series=False) == {"cmp":[False,False,True,True,True]}
+    assert df_cmp.to_dict(as_series=False) == {"cmp": [False, False, True, True, True]}
 
 
 def test_categorical_error_on_local_cmp() -> None:

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -152,3 +152,19 @@ def test_series_init_uninstantiated_enum() -> None:
         TypeError, match="Enum types must be instantiated with a list of categories"
     ):
         pl.Series(["a", "b", "a"], dtype=pl.Enum)
+
+
+def test_equality_enum() -> None:
+    s = pl.Series([None, "a", "b", "c"], dtype=pl.Enum(["a", "b", "c"]))
+    s2 = pl.Series([None, "c", "b", "c"], dtype=pl.Enum(["a", "b", "c"]))
+
+    expected = pl.Series([None, False, True, True], dtype=pl.Boolean)
+    assert_series_equal(s == s2, expected)
+
+    s_utf = pl.Series(["c"], dtype=pl.Utf8)
+    expected = pl.Series([None, True, False, True], dtype=pl.Boolean)
+    assert_series_equal(s2 == s_utf, expected)
+
+    s_utf = pl.Series(["d", "d", "d", "c"], dtype=pl.Utf8)
+    expected = pl.Series([None, False, False, True], dtype=pl.Boolean)
+    assert_series_equal(s2 == s_utf, expected)

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -1,4 +1,5 @@
 import operator
+from typing import Callable
 
 import pytest
 
@@ -167,38 +168,47 @@ def test_equality_enum() -> None:
     expected = pl.Series([None, True, False, True], dtype=pl.Boolean)
     assert_series_equal(s2 == s_utf, expected)
 
-    with pytest.raises(pl.ComputeError,match="value 'd' is not present in Enum"):
-        pl.Series(["d", "d", "d", "c"], dtype=pl.Utf8) == s2
+    with pytest.raises(pl.ComputeError, match="value 'd' is not present in Enum"):
+        _ = pl.Series(["d", "d", "d", "c"], dtype=pl.Utf8) == s2
 
 
-@pytest.mark.parametrize(("op","expected"),[
-    (operator.le, pl.Series([None, True, True, True])),
-    (operator.lt, pl.Series([None, True, False, False])),
-    (operator.ge, pl.Series([None, False, True, True])),
-    (operator.gt, pl.Series([None, False, False, False]))
-
-])
-def test_compare_enum(op,expected) -> None:
+@pytest.mark.parametrize(
+    ("op", "expected"),
+    [
+        (operator.le, pl.Series([None, True, True, True])),
+        (operator.lt, pl.Series([None, True, False, False])),
+        (operator.ge, pl.Series([None, False, True, True])),
+        (operator.gt, pl.Series([None, False, False, False])),
+    ],
+)
+def test_compare_enum(
+    op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
+) -> None:
     s = pl.Series([None, "a", "b", "c"], dtype=pl.Enum(["a", "b", "c"]))
     s2 = pl.Series([None, "c", "b", "c"], dtype=pl.Enum(["a", "b", "c"]))
 
-    assert_series_equal(op(s,s2), expected)
+    assert_series_equal(op(s, s2), expected)
 
     s2_string = s2.cast(pl.Utf8)
-    assert_series_equal(op(s,s2_string), expected)
+    assert_series_equal(op(s, s2_string), expected)
 
 
-@pytest.mark.parametrize(("op","expected"),[
-    (operator.le, pl.Series([None, True, True, True])),
-    (operator.lt, pl.Series([None, True, False, False])),
-    (operator.ge, pl.Series([None, False, True, True])),
-    (operator.gt, pl.Series([None, False, False, False]))
-])
-def test_compare_enum_str(op,expected) -> None:
+@pytest.mark.parametrize(
+    ("op", "expected"),
+    [
+        (operator.le, pl.Series([None, True, True, True])),
+        (operator.lt, pl.Series([None, True, False, False])),
+        (operator.ge, pl.Series([None, False, True, True])),
+        (operator.gt, pl.Series([None, False, False, False])),
+    ],
+)
+def test_compare_enum_str(
+    op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
+) -> None:
     s = pl.Series([None, "a", "b", "c"], dtype=pl.Enum(["a", "b", "c"]))
     s2 = pl.Series([None, "c", "b", "c"])
 
-    assert_series_equal(op(s,s2), expected)
+    assert_series_equal(op(s, s2), expected)
 
 
 def test_compare_enum_str_raise() -> None:
@@ -206,7 +216,9 @@ def test_compare_enum_str_raise() -> None:
     s2 = pl.Series([None, "d", "d", "d"])
     s_broadcast = pl.Series(["d"])
 
-    for s_compare in [s2,s_broadcast]:
-        for op in [operator.le,operator.gt,operator.ge,operator.lt]:
-            with pytest.raises(pl.ComputeError,match="value 'd' is not present in Enum"):
-                op(s,s_compare)
+    for s_compare in [s2, s_broadcast]:
+        for op in [operator.le, operator.gt, operator.ge, operator.lt]:
+            with pytest.raises(
+                pl.ComputeError, match="value 'd' is not present in Enum"
+            ):
+                op(s, s_compare)


### PR DESCRIPTION
relates to #7636 

Allow users to compare two Enums based on order in categories
```python
dtype = pl.Enum(["LOW", "MEDIUM", "HIGH"])
df_enum = pl.DataFrame(
    [
        pl.Series("a_cat", ["LOW", "MEDIUM", "MEDIUM", "HIGH", "MEDIUM"], dtype=dtype),
        pl.Series("b_cat", ["HIGH", "HIGH", "MEDIUM", "LOW", "LOW"], dtype=dtype),
    ]
)
df_cmp = df_enum.select((pl.col("a_cat") <= pl.col("b_cat")).alias("cmp"))
```
```
shape: (5, 1)
┌───────┐
│ cmp   │
│ ---   │
│ bool  │
╞═══════╡
│ true  │
│ true  │
│ true  │
│ false │
│ false │
└───────┘
```

```
df_cmp = df_enum.select((pl.col("a_cat") <= "MEDIUM").alias("cmp"))
```

```
shape: (5, 1)
┌───────┐
│ cmp   │
│ ---   │
│ bool  │
╞═══════╡
│ true  │
│ true  │
│ true  │
│ false │
│ true  │
└───────┘
```



### Changes in comparison with regards to categoricals

It also changes behaviour when comparing two categoricals. Right now we simply apply the operation on the physicals (which does not make any sense unless they are equal, but we don't check for equality), with this PR we raise an error (see test suite)
