### PR TITLE
feat(python)!: Update `update` signature

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10188,27 +10188,22 @@ class DataFrame:
         self,
         other: DataFrame,
         on: str | Sequence[str] | None = None,
+        how: Literal["left", "inner", "outer"] = "left",
+        *,
         left_on: str | Sequence[str] | None = None,
         right_on: str | Sequence[str] | None = None,
-        how: Literal["left", "inner", "outer"] = "left",
-        include_nulls: bool | None = False,
+        include_nulls: bool = False,
     ) -> DataFrame:
         """
         Update the values in this `DataFrame` with the values in `other`.
 
+        .. warning::
+            This functionality is experimental and may change without it being
+            considered a breaking change.
+
         By default, null values in the right frame are ignored. Use
         `include_nulls=False` to overwrite values in this frame with
         null values in the other frame.
-
-        Notes
-        -----
-        This is syntactic sugar for a left/inner join, with an optional coalesce
-        when `include_nulls = False`
-
-        Warnings
-        --------
-        This functionality is experimental and may change without it being considered a
-        breaking change.
 
         Parameters
         ----------
@@ -10217,19 +10212,24 @@ class DataFrame:
         on
             Column names that will be joined on.
             If none given the row count is used.
-        left_on
-           Join column(s) of the left DataFrame.
-        right_on
-           Join column(s) of the right DataFrame.
         how : {'left', 'inner', 'outer'}
             * 'left' will keep all rows from the left table; rows may be duplicated
               if multiple rows in the right frame match the left row's key.
             * 'inner' keeps only those rows where the key exists in both frames.
             * 'outer' will update existing rows where the key matches while also
               adding any new rows contained in the given frame.
+        left_on
+           Join column(s) of the left DataFrame.
+        right_on
+           Join column(s) of the right DataFrame.
         include_nulls
             If True, null values from the right dataframe will be used to update the
             left dataframe.
+
+        Notes
+        -----
+        This is syntactic sugar for a left/inner join, with an optional coalesce
+        when `include_nulls = False`
 
         Examples
         --------
@@ -10327,7 +10327,14 @@ class DataFrame:
         """
         return (
             self.lazy()
-            .update(other.lazy(), on, left_on, right_on, how, include_nulls)
+            .update(
+                other.lazy(),
+                on,
+                how,
+                left_on=left_on,
+                right_on=right_on,
+                include_nulls=include_nulls,
+            )
             .collect(_eager=True)
         )
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5636,13 +5636,18 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         self,
         other: LazyFrame,
         on: str | Sequence[str] | None = None,
+        how: Literal["left", "inner", "outer"] = "left",
+        *,
         left_on: str | Sequence[str] | None = None,
         right_on: str | Sequence[str] | None = None,
-        how: Literal["left", "inner", "outer"] = "left",
-        include_nulls: bool | None = False,
+        include_nulls: bool = False,
     ) -> Self:
         """
         Update the values in this `LazyFrame` with the non-null values in `other`.
+
+        .. warning::
+            This functionality is experimental and may change without it being
+            considered a breaking change.
 
         Parameters
         ----------
@@ -5651,16 +5656,16 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         on
             Column names that will be joined on; if given `None` the implicit row
             index is used as a join key instead.
-        left_on
-           Join column(s) of the left DataFrame.
-        right_on
-           Join column(s) of the right DataFrame.
         how : {'left', 'inner', 'outer'}
             * 'left' will keep all rows from the left table; rows may be duplicated
               if multiple rows in the right frame match the left row's key.
             * 'inner' keeps only those rows where the key exists in both frames.
             * 'outer' will update existing rows where the key matches while also
               adding any new rows contained in the given frame.
+        left_on
+           Join column(s) of the left DataFrame.
+        right_on
+           Join column(s) of the right DataFrame.
         include_nulls
             If True, null values from the right DataFrame will be used to update the
             left DataFrame.


### PR DESCRIPTION
#### Changes

- Better align the method signature with `join`
- Properly add the "experimental" warning.
  - It was argued before that the experimental status should be stripped, however, I would suggest this method be fully implemented in Rust before stripping experimental status.

There is no deprecation for this as it was considered experimental (though not properly indicated on the `LazyFrame` variant...).