### PR TITLE
fix(python): allow timeunit-less dtype in `pl.lit` creation

### DIFF
--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -101,7 +101,8 @@ def lit(
             return e
 
     elif isinstance(value, timedelta):
-        time_unit = "us" if dtype is None else getattr(dtype, "time_unit", "us")
+        if dtype is None or (time_unit := getattr(dtype, "time_unit", "us")) is None:
+            time_unit = "us"
         return lit(_timedelta_to_pl_timedelta(value, time_unit)).cast(
             Duration(time_unit)
         )

--- a/py-polars/tests/unit/test_exprs.py
+++ b/py-polars/tests/unit/test_exprs.py
@@ -551,6 +551,16 @@ def test_lit_dtypes() -> None:
     )
 
 
+def test_lit_empty_tu() -> None:
+    td = timedelta(1)
+    assert pl.select(pl.lit(td, dtype=pl.Duration)).item() == td
+    assert pl.select(pl.lit(td, dtype=pl.Duration)).dtypes[0].time_unit == "us"  # type: ignore[attr-defined]
+
+    t = datetime(2023, 1, 1)
+    assert pl.select(pl.lit(t, dtype=pl.Datetime)).item() == t
+    assert pl.select(pl.lit(t, dtype=pl.Datetime)).dtypes[0].time_unit == "us"  # type: ignore[attr-defined]
+
+
 def test_incompatible_lit_dtype() -> None:
     with pytest.raises(
         TypeError,


### PR DESCRIPTION
Resolves #12995.