### PR TITLE
feat(python): default `to_struct` Series name made consistent with the usual default Series name (empty string)

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9990,7 +9990,7 @@ class DataFrame:
         """
         return self.height == 0
 
-    def to_struct(self, name: str) -> Series:
+    def to_struct(self, name: str = "") -> Series:
         """
         Convert a `DataFrame` to a `Series` of type `Struct`.
 

--- a/py-polars/tests/unit/namespaces/test_struct.py
+++ b/py-polars/tests/unit/namespaces/test_struct.py
@@ -18,16 +18,19 @@ def test_struct_various() -> None:
     assert s.struct["list"].to_list() == [[1, 2], [3]]
     assert s.struct["int"].to_list() == [1, 2]
 
-    assert_frame_equal(df.to_struct("my_struct").struct.unnest(), df)
-    assert s.struct._ipython_key_completions_() == s.struct.fields
+    for s, expected_name in (
+        (df.to_struct(), ""),
+        (df.to_struct("my_struct"), "my_struct"),
+    ):
+        assert s.name == expected_name
+        assert_frame_equal(s.struct.unnest(), df)
+        assert s.struct._ipython_key_completions_() == s.struct.fields
 
 
 def test_rename_fields() -> None:
     df = pl.DataFrame({"int": [1, 2], "str": ["a", "b"], "bool": [True, None]})
-    assert df.to_struct("my_struct").struct.rename_fields(["a", "b"]).struct.fields == [
-        "a",
-        "b",
-    ]
+    s = df.to_struct("my_struct").struct.rename_fields(["a", "b"])
+    assert s.struct.fields == ["a", "b"]
 
 
 def test_struct_json_encode() -> None:


### PR DESCRIPTION
Closes #12947.

Seems reasonable to be consistent here; the standard behaviour when creating a Series directly (without giving it an explicit name) is to assign the default name as the empty string.

## Example
The following now  behave consistently:
```python
struct_data = [ {'a':1,'b':2}, {'a':2,'b':4} ]

pl.Series( values=struct_data )
pl.DataFrame( struct_data ).to_struct()

# shape: (2,)
# Series: '' [struct[2]]
# [
#   {1,2}
#   {2,4}
# ]
```
Previously the second of these would result in the following error:
```
TypeError: DataFrame.to_struct() missing 1 required positional argument: 'name'
```