### PR TITLE
fix(python): streamline `align_frames` and fix edge-case where the identical frame object appears more than once

### DIFF
--- a/py-polars/polars/functions/eager.py
+++ b/py-polars/polars/functions/eager.py
@@ -3,14 +3,7 @@ from __future__ import annotations
 import contextlib
 from functools import reduce
 from itertools import chain
-from typing import (
-    TYPE_CHECKING,
-    Iterable,
-    List,
-    Sequence,
-    cast,
-    get_args,
-)
+from typing import TYPE_CHECKING, Iterable, List, Sequence, cast, get_args
 
 import polars._reexport as pl
 from polars import functions as F
@@ -258,42 +251,33 @@ def concat(
 
 
 def _alignment_join(
-    *frames: FrameType,
+    *idx_frames: tuple[int, FrameType],
     align_on: list[str],
     how: JoinStrategy = "outer",
     descending: bool | Sequence[bool] = False,
+    batch_size: int = 25,
 ) -> LazyFrame:
-    """Creates a single master frame with all rows aligned on the common key values."""
-    # note: can stackoverflow if the join becomes too large, so
-    # we branch when hitting a large enough number of frames
-    join_lazy = len(frames) < 250
+    """Create a single master frame with all rows aligned on the common key values."""
+    # note: can stackoverflow if the join becomes too large, so we
+    # collect eagerly when hitting a large enough number of frames
+    post_align_collect = len(idx_frames) >= 250
+    if how == "outer":
+        how = "outer_coalesce"
 
-    def join_func(x: FrameType, y: FrameType) -> FrameType:
-        if how != "outer":
-            # join key cols are merged/coalesced
-            return (x.lazy() if join_lazy else x).join(  # type: ignore[attr-defined]
-                y.lazy(), how=how, on=align_on, suffix=str(id(y))
-            )
-        else:
-            return (
-                (x.lazy() if join_lazy else x)
-                # type: ignore[attr-defined]
-                .join(y.lazy(), how=how, on=align_on, suffix=str(id(y)))
-                .with_columns(
-                    F.when(F.col(c).is_null())
-                    .then(F.col(f"{c}{id(y)!s}"))
-                    .otherwise(F.col(c))
-                    .alias(c)
-                    for c in align_on
-                )
-                .select(F.exclude(*(f"{c}{id(y)!s}" for c in align_on)))
-            )
+    def join_func(
+        idx_x: tuple[int, FrameType],
+        idx_y: tuple[int, FrameType],
+    ) -> tuple[int, LazyFrame]:
+        (_, x), (y_idx, y) = idx_x, idx_y
+        return y_idx, x.lazy().join(y.lazy(), how=how, on=align_on, suffix=f":{y_idx}")
 
-    df_joined = reduce(join_func, frames).sort(by=align_on, descending=descending)
-    if join_lazy:
-        return df_joined.collect(no_optimization=True).lazy()  # type: ignore[attr-defined]
-    else:
-        return df_joined.lazy()
+    df_joined = reduce(join_func, idx_frames)[1].sort(  # type: ignore[arg-type]
+        by=align_on, descending=descending
+    )
+    if post_align_collect:
+        df_joined = df_joined.collect(no_optimization=True)  # type: ignore[assignment,attr-defined]
+
+    return df_joined.lazy()
 
 
 def align_frames(
@@ -449,18 +433,16 @@ def align_frames(
 
     # create aligned master frame (this is the most expensive part; afterwards
     # we just subselect out the columns representing the component frames)
+    idx_frames = tuple(enumerate(frames))
     alignment_frame = _alignment_join(
-        *frames,
-        align_on=align_on,
-        how=how,
-        descending=descending,
+        *idx_frames, align_on=align_on, how=how, descending=descending
     )
 
     # select-out aligned components from the master frame
     aligned_cols = set(alignment_frame.columns)
     aligned_frames = []
-    for df in frames:
-        sfx = str(id(df))
+    for idx, df in idx_frames:
+        sfx = f":{idx}"
         df_cols = [
             F.col(f"{c}{sfx}").alias(c) if f"{c}{sfx}" in aligned_cols else F.col(c)
             for c in df.columns
@@ -470,7 +452,7 @@ def align_frames(
             f = f.select(select)
         aligned_frames.append(f)
 
-    eager = isinstance(frames[0], pl.DataFrame)
+    eager = isinstance(idx_frames[0][1], pl.DataFrame)
     return cast(
         List[FrameType], F.collect_all(aligned_frames) if eager else aligned_frames
     )


### PR DESCRIPTION
## Update
* Take advantage of `outer_coalesce` to streamline frame-alignment function.
* Don't rely on the frame object's `id` for column deduplication via "suffix" (this fixes an edge-case if the identical frame appears more than once in the alignment input).

## Example
```python
import polars as pl

df1 = pl.DataFrame( [[3, 5, 6], [5, 8, 9]], orient="row" )
df2 = pl.DataFrame( [[2, 5, 6], [3, 8, 9], [4, 2, 0]], orient="row" )

# note: 'df2' appears twice
pl.align_frames( df1, df2, df2, on="column_0" )
```
**Before**
```
DuplicateError: 
  unable to hstack, column with name "column_14438432720" already exists
```
**After**
```
[shape: (4, 3)
 ┌──────────┬──────────┬──────────┐
 │ column_0 ┆ column_1 ┆ column_2 │
 │ ---      ┆ ---      ┆ ---      │
 │ i64      ┆ i64      ┆ i64      │
 ╞══════════╪══════════╪══════════╡
 │ 2        ┆ null     ┆ null     │
 │ 3        ┆ 5        ┆ 6        │
 │ 4        ┆ null     ┆ null     │
 │ 5        ┆ 8        ┆ 9        │
 └──────────┴──────────┴──────────┘,
 shape: (4, 3)
 ┌──────────┬──────────┬──────────┐
 │ column_0 ┆ column_1 ┆ column_2 │
 │ ---      ┆ ---      ┆ ---      │
 │ i64      ┆ i64      ┆ i64      │
 ╞══════════╪══════════╪══════════╡
 │ 2        ┆ 5        ┆ 6        │
 │ 3        ┆ 8        ┆ 9        │
 │ 4        ┆ 2        ┆ 0        │
 │ 5        ┆ null     ┆ null     │
 └──────────┴──────────┴──────────┘,
 shape: (4, 3)
 ┌──────────┬──────────┬──────────┐
 │ column_0 ┆ column_1 ┆ column_2 │
 │ ---      ┆ ---      ┆ ---      │
 │ i64      ┆ i64      ┆ i64      │
 ╞══════════╪══════════╪══════════╡
 │ 2        ┆ 5        ┆ 6        │
 │ 3        ┆ 8        ┆ 9        │
 │ 4        ┆ 2        ┆ 0        │
 │ 5        ┆ null     ┆ null     │
 └──────────┴──────────┴──────────┘]
```