### PR TITLE
fix(rust,python,cli): fix SQL substring indexing

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -755,9 +755,10 @@ impl SqlFunctionVisitor<'_> {
             },
             StartsWith => self.visit_binary(|e, s| e.str().starts_with(s)),
             Substring => match function.args.len() {
+                // note that SQL is 1-indexed, not 0-indexed
                 2 => self.try_visit_binary(|e, start| {
                     Ok(e.str().slice(match start {
-                        Expr::Literal(LiteralValue::Int64(n)) => n,
+                        Expr::Literal(LiteralValue::Int64(n)) => n - 1 ,
                         _ => {
                             polars_bail!(InvalidOperation: "Invalid 'start' for Substring: {}", function.args[1]);
                         }
@@ -766,7 +767,7 @@ impl SqlFunctionVisitor<'_> {
                 3 => self.try_visit_ternary(|e, start, length| {
                     Ok(e.str().slice(
                         match start {
-                            Expr::Literal(LiteralValue::Int64(n)) => n,
+                            Expr::Literal(LiteralValue::Int64(n)) => n - 1,
                             _ => {
                                 polars_bail!(InvalidOperation: "Invalid 'start' for Substring: {}", function.args[1]);
                             }

--- a/py-polars/tests/unit/sql/test_sql.py
+++ b/py-polars/tests/unit/sql/test_sql.py
@@ -8,6 +8,7 @@ import pytest
 
 import polars as pl
 import polars.selectors as cs
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -70,7 +71,7 @@ def test_sql_cast() -> None:
         (5.0, 5.0, 5, 5, 5, 1, "5", "5.5", b"e", b"e", "true"),
     ]
 
-    with pytest.raises(pl.ComputeError, match="unsupported use of FORMAT in CAST"):
+    with pytest.raises(ComputeError, match="unsupported use of FORMAT in CAST"):
         pl.SQLContext(df=df, eager_execution=True).execute(
             "SELECT CAST(a AS STRING FORMAT 'HEX') FROM df"
         )
@@ -148,7 +149,7 @@ def test_sql_distinct() -> None:
 
     # test unregistration
     ctx.unregister("df")
-    with pytest.raises(pl.ComputeError, match=".*'df'.*not found"):
+    with pytest.raises(ComputeError, match=".*'df'.*not found"):
         ctx.execute("SELECT * FROM df")
 
 
@@ -522,7 +523,7 @@ def test_sql_left() -> None:
         "scol:left2": ["ab", "ab", "a", None],
     }
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match="Invalid 'length' for Left: 'xyz'",
     ):
         ctx.execute(
@@ -658,7 +659,7 @@ def test_sql_join_left() -> None:
 def test_sql_non_equi_joins(constraint: str) -> None:
     # no support (yet) for non equi-joins in polars joins
     with pytest.raises(
-        pl.InvalidOperationError,
+        InvalidOperationError,
         match=r"SQL interface \(currently\) only supports basic equi-join constraints",
     ), pl.SQLContext({"tbl": pl.DataFrame({"a": [1, 2, 3], "b": [4, 3, 2]})}) as ctx:
         ctx.execute(
@@ -733,11 +734,11 @@ def test_sql_regex_operators_error() -> None:
     df = pl.LazyFrame({"sval": ["ABC", "abc", "000", "A0C", "a0c"]})
     with pl.SQLContext(df=df, eager_execution=True) as ctx:
         with pytest.raises(
-            pl.ComputeError, match="Invalid pattern for '~' operator: 12345"
+            ComputeError, match="Invalid pattern for '~' operator: 12345"
         ):
             ctx.execute("SELECT * FROM df WHERE sval ~ 12345")
         with pytest.raises(
-            pl.ComputeError,
+            ComputeError,
             match=r"""Invalid pattern for '!~\*' operator: col\("abcde"\)""",
         ):
             ctx.execute("SELECT * FROM df WHERE sval !~* abcde")
@@ -777,19 +778,19 @@ def test_sql_regexp_like(
 def test_sql_regexp_like_errors() -> None:
     with pl.SQLContext(df=pl.DataFrame({"scol": ["xyz"]})) as ctx:
         with pytest.raises(
-            pl.InvalidOperationError,
+            InvalidOperationError,
             match="Invalid/empty 'flags' for RegexpLike",
         ):
             ctx.execute("SELECT * FROM df WHERE REGEXP_LIKE(scol,'[x-z]+','')")
 
         with pytest.raises(
-            pl.InvalidOperationError,
+            InvalidOperationError,
             match="Invalid arguments for RegexpLike",
         ):
             ctx.execute("SELECT * FROM df WHERE REGEXP_LIKE(scol,999,999)")
 
         with pytest.raises(
-            pl.InvalidOperationError,
+            InvalidOperationError,
             match="Invalid number of arguments for RegexpLike",
         ):
             ctx.execute("SELECT * FROM df WHERE REGEXP_LIKE(scol)")
@@ -821,7 +822,7 @@ def test_sql_round_ndigits(decimals: int, expected: list[float]) -> None:
 def test_sql_round_ndigits_errors() -> None:
     df = pl.DataFrame({"n": [99.999]})
     with pl.SQLContext(df=df, eager_execution=True) as ctx, pytest.raises(
-        pl.InvalidOperationError, match="Invalid 'decimals' for Round: -1"
+        InvalidOperationError, match="Invalid 'decimals' for Round: -1"
     ):
         ctx.execute("SELECT ROUND(n,-1) AS n FROM df")
 
@@ -871,15 +872,12 @@ def test_sql_string_lengths() -> None:
 
 
 def test_sql_substr() -> None:
-    df = pl.DataFrame(
-        {
-            "scol": ["abcdefg", "abcde", "abc", None],
-        }
-    )
+    df = pl.DataFrame({"scol": ["abcdefg", "abcde", "abc", None]})
     with pl.SQLContext(df=df) as ctx:
         res = ctx.execute(
             """
             SELECT
+              -- note: sql is 1-indexed
               SUBSTR(scol,1) AS s1,
               SUBSTR(scol,2) AS s2,
               SUBSTR(scol,3) AS s3,
@@ -891,13 +889,21 @@ def test_sql_substr() -> None:
         ).collect()
 
     assert res.to_dict(as_series=False) == {
-        "s1": ["bcdefg", "bcde", "bc", None],
-        "s2": ["cdefg", "cde", "c", None],
-        "s3": ["defg", "de", "", None],
-        "s1_5": ["bcdef", "bcde", "bc", None],
-        "s2_2": ["cd", "cd", "c", None],
-        "s3_1": ["d", "d", "", None],
+        "s1": ["abcdefg", "abcde", "abc", None],
+        "s2": ["bcdefg", "bcde", "bc", None],
+        "s3": ["cdefg", "cde", "c", None],
+        "s1_5": ["abcde", "abcde", "abc", None],
+        "s2_2": ["bc", "bc", "bc", None],
+        "s3_1": ["c", "c", "c", None],
     }
+
+    # negative indexes are expected to be invalid
+    with pytest.raises(
+        InvalidOperationError,
+        match="Invalid 'start' for Substring: -1",
+    ):
+        with pl.SQLContext(df=df) as ctx:
+            ctx.execute("SELECT SUBSTR(scol,-1) FROM df")
 
 
 def test_sql_trim(foods_ipc_path: Path) -> None:
@@ -913,7 +919,10 @@ def test_sql_trim(foods_ipc_path: Path) -> None:
     assert out.to_dict(as_series=False) == {
         "new_category": ["seafood", "ruit", "egetables", "eat"]
     }
-    with pytest.raises(pl.ComputeError, match="unsupported TRIM"):
+    with pytest.raises(
+        ComputeError,
+        match="unsupported TRIM",
+    ):
         # currently unsupported (snowflake) trim syntax
         pl.SQLContext(foods=lf).execute(
             """
@@ -1183,7 +1192,7 @@ def test_sql_expr() -> None:
         [
             "MIN(a)",
             "POWER(a,a) AS aa",
-            "SUBSTR(b,1,2) AS b2",
+            "SUBSTR(b,2,2) AS b2",
         ]
     )
     result = df.select(*sql_exprs)
@@ -1195,7 +1204,7 @@ def test_sql_expr() -> None:
     # expect expressions that can't reasonably be parsed as expressions to raise
     # (for example: those that explicitly reference tables and/or use wildcards)
     with pytest.raises(
-        pl.InvalidOperationError, match=r"Unable to parse 'xyz\.\*' as Expr"
+        InvalidOperationError, match=r"Unable to parse 'xyz\.\*' as Expr"
     ):
         pl.sql_expr("xyz.*")
 

--- a/py-polars/tests/unit/sql/test_sql.py
+++ b/py-polars/tests/unit/sql/test_sql.py
@@ -901,9 +901,8 @@ def test_sql_substr() -> None:
     with pytest.raises(
         InvalidOperationError,
         match="Invalid 'start' for Substring: -1",
-    ):
-        with pl.SQLContext(df=df) as ctx:
-            ctx.execute("SELECT SUBSTR(scol,-1) FROM df")
+    ), pl.SQLContext(df=df) as ctx:
+        ctx.execute("SELECT SUBSTR(scol,-1) FROM df")
 
 
 def test_sql_trim(foods_ipc_path: Path) -> None:


### PR DESCRIPTION
Closes #13011.

SQL is 1-indexed on strings/arrays, not 0-indexed.

Validated the updated test results here against SQLite; when I have a little more time I plan to follow up with a new assert/utility that actually executes the query being tested against both polars _and_ SQLite (or, better, a local/ephemeral PostgreSQL instance [^1]) so we can avoid similar gremlins in the future 🤔

[^1]: #12815