### PR TITLE
fix(rust,python): parse json_decode per max buffer length

### DIFF
--- a/crates/polars-json/src/ndjson/deserialize.rs
+++ b/crates/polars-json/src/ndjson/deserialize.rs
@@ -37,7 +37,7 @@ pub fn deserialize_iter<'a>(
         buf.push_str(row);
         buf.push(',');
 
-        if buf.len() + row.len() > std::u32::MAX as usize {
+        if buf.len() + row.len() > (std::u32::MAX << 1) as usize {
             let _ = buf.pop();
             buf.push(']');
             arr.push(_deserializer(&mut buf, data_type.clone())?);

--- a/crates/polars-json/src/ndjson/deserialize.rs
+++ b/crates/polars-json/src/ndjson/deserialize.rs
@@ -53,15 +53,5 @@ pub fn deserialize_iter<'a>(
     buf.push(']');
 
     arr.push(_deserializer(buf, data_type.clone())?);
-    // let slice = unsafe { buf.as_bytes_mut() };
-    // let out = simd_json::to_borrowed_value(slice)
-    //     .map_err(|e| PolarsError::ComputeError(format!("json parsing error: '{e}'").into()))?;
-    // if let BorrowedValue::Array(rows) = out {
-    //     arr.push(super::super::json::deserialize::_deserialize(
-    //         &rows, data_type,
-    //     ))
-    // } else {
-    //     unreachable!()
-    // };
     concatenate(&arr.clone().iter().map(|v| v.as_ref()).collect::<Vec<_>>())
 }

--- a/crates/polars-json/src/ndjson/deserialize.rs
+++ b/crates/polars-json/src/ndjson/deserialize.rs
@@ -50,7 +50,7 @@ pub fn deserialize_iter<'a>(
     }
     buf.push(']');
 
-    if arr.len() == 0 {
+    if arr.is_empty() {
         _deserializer(&mut buf, data_type.clone())
     } else {
         arr.push(_deserializer(&mut buf, data_type.clone())?);

--- a/crates/polars-json/src/ndjson/deserialize.rs
+++ b/crates/polars-json/src/ndjson/deserialize.rs
@@ -1,5 +1,5 @@
 use arrow::array::Array;
-use arrow::compute::concatenate::concatenate;
+use arrow::legacy::kernels::concatenate::concatenate_owned_unchecked;
 use simd_json::BorrowedValue;
 
 use super::*;
@@ -41,7 +41,7 @@ pub fn deserialize_iter<'a>(
         buf.push(',');
 
         let next_row_length = row_iter.peek().map(|row| row.len()).unwrap_or(0);
-        if buf.len() + next_row_length > (std::u32::MAX << 1) as usize {
+        if buf.len() + next_row_length > std::u32::MAX as usize {
             let _ = buf.pop();
             buf.push(']');
             arr.push(_deserializer(&mut buf, data_type.clone())?);
@@ -58,6 +58,6 @@ pub fn deserialize_iter<'a>(
         _deserializer(&mut buf, data_type.clone())
     } else {
         arr.push(_deserializer(&mut buf, data_type.clone())?);
-        concatenate(&arr.clone().iter().map(|v| v.as_ref()).collect::<Vec<_>>())
+        concatenate_owned_unchecked(&arr)
     }
 }

--- a/crates/polars-json/src/ndjson/deserialize.rs
+++ b/crates/polars-json/src/ndjson/deserialize.rs
@@ -21,7 +21,7 @@ pub fn deserialize_iter<'a>(
     let mut buf = String::with_capacity(std::u32::MAX as usize);
     buf.push('[');
 
-    fn _deserializer(s: &mut String, data_type: ArrowDataType) -> PolarsResult<Box<dyn Array>> {
+    fn _deserializer(s: &mut str, data_type: ArrowDataType) -> PolarsResult<Box<dyn Array>> {
         // let mut buf = s.clone();
         let slice = unsafe { s.as_bytes_mut() };
         let out = simd_json::to_borrowed_value(slice)

--- a/crates/polars-json/src/ndjson/deserialize.rs
+++ b/crates/polars-json/src/ndjson/deserialize.rs
@@ -42,19 +42,7 @@ pub fn deserialize_iter<'a>(
                 let _ = buf.pop();
             }
             buf.push(']');
-            let copy_buf = buf.clone();
-
-            // let slice = unsafe { copy_buf.as_bytes_mut()};
-            // let out = simd_json::to_borrowed_value(slice)
-            //     .map_err(|e| PolarsError::ComputeError(format!("json parsing error: '{e}'").into()))?;
-            // let json_arr = if let BorrowedValue::Array(rows) = out {
-            //     super::super::json::deserialize::_deserialize(
-            //         &rows, data_type.clone(),
-            //     )
-            // } else {
-            //     unreachable!()
-            // };
-            arr.push(_deserializer(copy_buf, data_type.clone())?);
+            arr.push(_deserializer(buf.clone(), data_type.clone())?);
             buf.clear();
             buf.push('[');
         }

--- a/crates/polars-json/src/ndjson/deserialize.rs
+++ b/crates/polars-json/src/ndjson/deserialize.rs
@@ -37,7 +37,7 @@ pub fn deserialize_iter<'a>(
         buf.push_str(row);
         buf.push(',');
 
-        if buf.len() + row.len() > 5000000 {
+        if buf.len() + row.len() > std::u32::MAX as usize {
             if buf.len() > 1 {
                 let _ = buf.pop();
             }

--- a/crates/polars-json/src/ndjson/deserialize.rs
+++ b/crates/polars-json/src/ndjson/deserialize.rs
@@ -41,7 +41,7 @@ pub fn deserialize_iter<'a>(
         buf.push(',');
 
         let next_row_length = row_iter.peek().map(|row| row.len()).unwrap_or(0);
-        if buf.len() + next_row_length > std::u32::MAX as usize {
+        if buf.len() + next_row_length >= std::u32::MAX as usize {
             let _ = buf.pop();
             buf.push(']');
             arr.push(_deserializer(&mut buf, data_type.clone())?);

--- a/crates/polars-ops/src/chunked_array/strings/json_path.rs
+++ b/crates/polars-ops/src/chunked_array/strings/json_path.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use arrow::array::ValueSize;
 use jsonpath_lib::PathCompiled;
 use serde_json::Value;
 

--- a/crates/polars-ops/src/chunked_array/strings/json_path.rs
+++ b/crates/polars-ops/src/chunked_array/strings/json_path.rs
@@ -75,17 +75,10 @@ pub trait Utf8JsonPathImpl: AsUtf8 {
             Some(dt) => dt,
             None => ca.json_infer(infer_schema_len)?,
         };
-
-        let buf_size = ca.get_values_size() + ca.null_count() * "null".len();
         let iter = ca.into_iter().map(|x| x.unwrap_or("null"));
 
-        let array = polars_json::ndjson::deserialize::deserialize_iter(
-            iter,
-            dtype.to_arrow(),
-            buf_size,
-            ca.len(),
-        )
-        .map_err(|e| polars_err!(ComputeError: "error deserializing JSON: {}", e))?;
+        let array = polars_json::ndjson::deserialize::deserialize_iter(iter, dtype.to_arrow())
+            .map_err(|e| polars_err!(ComputeError: "error deserializing JSON: {}", e))?;
         Series::try_from(("", array))
     }
 

--- a/crates/polars-ops/src/chunked_array/strings/json_path.rs
+++ b/crates/polars-ops/src/chunked_array/strings/json_path.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use arrow::array::ValueSize;
 use jsonpath_lib::PathCompiled;
 use serde_json::Value;
 
@@ -74,10 +75,16 @@ pub trait Utf8JsonPathImpl: AsUtf8 {
             Some(dt) => dt,
             None => ca.json_infer(infer_schema_len)?,
         };
+        let buf_size = ca.get_values_size() + ca.null_count() * "null".len();
         let iter = ca.into_iter().map(|x| x.unwrap_or("null"));
 
-        let array = polars_json::ndjson::deserialize::deserialize_iter(iter, dtype.to_arrow())
-            .map_err(|e| polars_err!(ComputeError: "error deserializing JSON: {}", e))?;
+        let array = polars_json::ndjson::deserialize::deserialize_iter(
+            iter,
+            dtype.to_arrow(),
+            buf_size,
+            ca.len(),
+        )
+        .map_err(|e| polars_err!(ComputeError: "error deserializing JSON: {}", e))?;
         Series::try_from(("", array))
     }
 


### PR DESCRIPTION
Simd-json had a max::u32 buffer length, so I am just parsing per max buffer length and then concatenating all the arrays at at the end.

closes https://github.com/pola-rs/polars/issues/13028