### PR TITLE
feat(python): add glob flag

### DIFF
--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -36,6 +36,7 @@ pub struct LazyCsvReader<'a> {
     row_count: Option<RowCount>,
     try_parse_dates: bool,
     raise_if_empty: bool,
+    use_glob: bool,
 }
 
 #[cfg(feature = "csv")]
@@ -70,6 +71,7 @@ impl<'a> LazyCsvReader<'a> {
             try_parse_dates: false,
             raise_if_empty: true,
             truncate_ragged_lines: false,
+            use_glob: true,
         }
     }
 
@@ -230,6 +232,13 @@ impl<'a> LazyCsvReader<'a> {
         self
     }
 
+    /// Truncate lines that are longer than the schema.
+    #[must_use]
+    pub fn use_glob(mut self, toggle: bool) -> Self {
+        self.use_glob = toggle;
+        self
+    }
+
     /// Modify a schema before we run the lazy scanning.
     ///
     /// Important! Run this function latest in the builder!
@@ -303,6 +312,7 @@ impl LazyFileListReader for LazyCsvReader<'_> {
             self.try_parse_dates,
             self.raise_if_empty,
             self.truncate_ragged_lines,
+            self.use_glob,
         )?
         .build()
         .into();

--- a/crates/polars-lazy/src/scan/ipc.rs
+++ b/crates/polars-lazy/src/scan/ipc.rs
@@ -12,6 +12,7 @@ pub struct ScanArgsIpc {
     pub rechunk: bool,
     pub row_count: Option<RowCount>,
     pub memmap: bool,
+    pub use_glob: bool,
 }
 
 impl Default for ScanArgsIpc {
@@ -22,6 +23,7 @@ impl Default for ScanArgsIpc {
             rechunk: true,
             row_count: None,
             memmap: true,
+            use_glob: true,
         }
     }
 }
@@ -58,6 +60,7 @@ impl LazyFileListReader for LazyIpcReader {
             args.cache,
             args.row_count.clone(),
             args.rechunk,
+            args.use_glob,
         )?
         .build()
         .into();

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -18,6 +18,7 @@ pub struct ScanArgsParquet {
     pub cloud_options: Option<CloudOptions>,
     pub use_statistics: bool,
     pub hive_partitioning: bool,
+    pub use_glob: bool,
 }
 
 impl Default for ScanArgsParquet {
@@ -32,6 +33,7 @@ impl Default for ScanArgsParquet {
             cloud_options: None,
             use_statistics: true,
             hive_partitioning: false,
+            use_glob: true,
         }
     }
 }
@@ -84,6 +86,7 @@ impl LazyFileListReader for LazyParquetReader {
             self.args.cloud_options,
             self.args.use_statistics,
             self.args.hive_partitioning,
+            self.args.use_glob,
         )?
         .build()
         .into();

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -203,6 +203,7 @@ fn test_ipc_globbing() -> PolarsResult<()> {
             rechunk: false,
             row_count: None,
             memmap: true,
+            use_glob: true,
         },
     )?
     .collect()?;

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -116,6 +116,7 @@ impl LogicalPlanBuilder {
             rechunk: false,
             file_counter: Default::default(),
             hive_partitioning: false,
+            use_glob: false,
         };
 
         Ok(LogicalPlan::Scan {
@@ -147,6 +148,7 @@ impl LogicalPlanBuilder {
         cloud_options: Option<CloudOptions>,
         use_statistics: bool,
         hive_partitioning: bool,
+        use_glob: bool,
     ) -> PolarsResult<Self> {
         use polars_io::{is_cloud_url, SerReader as _};
 
@@ -201,7 +203,6 @@ impl LogicalPlanBuilder {
         if hive_partitioning {
             file_info.init_hive_partitions(path.as_path())?;
         }
-
         let options = FileScanOptions {
             with_columns: None,
             cache,
@@ -210,6 +211,7 @@ impl LogicalPlanBuilder {
             row_count,
             file_counter: Default::default(),
             hive_partitioning,
+            use_glob,
         };
         Ok(LogicalPlan::Scan {
             paths,
@@ -237,6 +239,7 @@ impl LogicalPlanBuilder {
         cache: bool,
         row_count: Option<RowCount>,
         rechunk: bool,
+        use_glob: bool,
     ) -> PolarsResult<Self> {
         use polars_io::SerReader as _;
 
@@ -262,6 +265,7 @@ impl LogicalPlanBuilder {
             file_counter: Default::default(),
             // TODO! add
             hive_partitioning: false,
+            use_glob,
         };
         Ok(LogicalPlan::Scan {
             paths: Arc::new([path]),
@@ -298,6 +302,7 @@ impl LogicalPlanBuilder {
         try_parse_dates: bool,
         raise_if_empty: bool,
         truncate_ragged_lines: bool,
+        use_glob: bool,
     ) -> PolarsResult<Self> {
         let path = path.into();
         let mut file = polars_utils::open_file(&path)?;
@@ -365,6 +370,7 @@ impl LogicalPlanBuilder {
             file_counter: Default::default(),
             // TODO! add
             hive_partitioning: false,
+            use_glob,
         };
         Ok(LogicalPlan::Scan {
             paths,

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -110,6 +110,7 @@ pub struct FileScanOptions {
     pub rechunk: bool,
     pub file_counter: FileCount,
     pub hive_partitioning: bool,
+    pub use_glob: bool,
 }
 
 #[derive(Clone, Debug, Copy, Default, Eq, PartialEq)]

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -53,6 +53,7 @@ def read_csv(
     eol_char: str = "\n",
     raise_if_empty: bool = True,
     truncate_ragged_lines: bool = False,
+    use_glob: bool = True,
 ) -> DataFrame:
     r"""
     Read a CSV file into a DataFrame.
@@ -171,6 +172,8 @@ def read_csv(
         is set to False, an empty DataFrame (with no columns) is returned instead.
     truncate_ragged_lines
         Truncate lines that are longer than the schema.
+    use_glob
+        If `source` is a glob pattern, use it to match files.
 
     Returns
     -------
@@ -394,6 +397,7 @@ def read_csv(
             eol_char=eol_char,
             raise_if_empty=raise_if_empty,
             truncate_ragged_lines=truncate_ragged_lines,
+            use_glob=use_glob,
         )
 
     if new_columns:
@@ -731,6 +735,7 @@ def scan_csv(
     new_columns: Sequence[str] | None = None,
     raise_if_empty: bool = True,
     truncate_ragged_lines: bool = False,
+    use_glob: bool = True,
 ) -> LazyFrame:
     r"""
     Lazily read from a CSV file or multiple files via glob patterns.
@@ -823,6 +828,8 @@ def scan_csv(
         is set to False, an empty LazyFrame (with no columns) is returned instead.
     truncate_ragged_lines
         Truncate lines that are longer than the schema.
+    use_glob
+        If `source` is a glob pattern, use it to match files.
 
     Returns
     -------
@@ -942,4 +949,5 @@ def scan_csv(
         eol_char=eol_char,
         raise_if_empty=raise_if_empty,
         truncate_ragged_lines=truncate_ragged_lines,
+        use_glob=use_glob,
     )

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -35,6 +35,7 @@ def read_parquet(
     pyarrow_options: dict[str, Any] | None = None,
     use_statistics: bool = True,
     rechunk: bool = True,
+    use_glob: bool = True,
 ) -> DataFrame:
     """
     Read into a DataFrame from a parquet file.
@@ -90,6 +91,8 @@ def read_parquet(
     rechunk
         Make sure that all columns are contiguous in memory by
         aggregating the chunks into a single array.
+    use_glob
+        If `source` is a glob pattern, use it to match files.
 
     See Also
     --------
@@ -138,6 +141,7 @@ def read_parquet(
             low_memory=low_memory,
             use_statistics=use_statistics,
             rechunk=rechunk,
+            use_glob=use_glob,
         )
 
 

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -184,6 +184,7 @@ def scan_parquet(
     use_statistics: bool = True,
     hive_partitioning: bool = True,
     retries: int = 0,
+    use_glob: bool = True,
 ) -> LazyFrame:
     """
     Lazily read from a local or cloud-hosted parquet file (or files).
@@ -234,6 +235,8 @@ def scan_parquet(
         to prune reads.
     retries
         Number of retries if accessing a cloud instance fails.
+    use_glob
+        If `source` is a glob pattern, use it to match files.
 
     See Also
     --------
@@ -276,4 +279,5 @@ def scan_parquet(
         use_statistics=use_statistics,
         hive_partitioning=hive_partitioning,
         retries=retries,
+        use_glob=use_glob,
     )

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -442,7 +442,7 @@ class LazyFrame:
             can_use_fsspec
             and not _is_local_file(source)  # type: ignore[arg-type]
             and not _is_supported_cloud(source)  # type: ignore[arg-type]
-            # and use_glob
+            and use_glob
         ):
             scan = _scan_parquet_fsspec(source, storage_options)  # type: ignore[arg-type]
             if n_rows:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -345,6 +345,7 @@ class LazyFrame:
         eol_char: str = "\n",
         raise_if_empty: bool = True,
         truncate_ragged_lines: bool = True,
+        use_glob: bool = True,
     ) -> Self:
         """
         Lazily read from a CSV file or multiple files via glob patterns.
@@ -392,6 +393,7 @@ class LazyFrame:
             encoding,
             _prepare_row_count_args(row_count_name, row_count_offset),
             try_parse_dates,
+            use_glob,
             eol_char=eol_char,
             raise_if_empty=raise_if_empty,
             truncate_ragged_lines=truncate_ragged_lines,
@@ -415,6 +417,7 @@ class LazyFrame:
         use_statistics: bool = True,
         hive_partitioning: bool = True,
         retries: int = 0,
+        use_glob: bool = True,
     ) -> Self:
         """
         Lazily read from a parquet file or multiple files via glob patterns.
@@ -439,6 +442,7 @@ class LazyFrame:
             can_use_fsspec
             and not _is_local_file(source)  # type: ignore[arg-type]
             and not _is_supported_cloud(source)  # type: ignore[arg-type]
+            # and use_glob
         ):
             scan = _scan_parquet_fsspec(source, storage_options)  # type: ignore[arg-type]
             if n_rows:
@@ -464,6 +468,7 @@ class LazyFrame:
             use_statistics=use_statistics,
             hive_partitioning=hive_partitioning,
             retries=retries,
+            use_glob=use_glob,
         )
         return self
 
@@ -479,6 +484,7 @@ class LazyFrame:
         row_count_offset: int = 0,
         storage_options: dict[str, object] | None = None,
         memory_map: bool = True,
+        use_glob: bool = True,
     ) -> Self:
         """
         Lazily read from an Arrow IPC (Feather v2) file.
@@ -516,6 +522,7 @@ class LazyFrame:
             cache,
             rechunk,
             _prepare_row_count_args(row_count_name, row_count_offset),
+            use_glob,
             memory_map=memory_map,
         )
         return self

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -150,7 +150,7 @@ impl PyLazyFrame {
     #[pyo3(signature = (path, paths, separator, has_header, ignore_errors, skip_rows, n_rows, cache, overwrite_dtype,
         low_memory, comment_prefix, quote_char, null_values, missing_utf8_is_empty_string,
         infer_schema_length, with_schema_modify, rechunk, skip_rows_after_header,
-        encoding, row_count, try_parse_dates, eol_char, raise_if_empty, truncate_ragged_lines, schema
+        encoding, row_count, try_parse_dates, use_glob, eol_char, raise_if_empty, truncate_ragged_lines, schema
     )
     )]
     fn new_from_csv(
@@ -175,6 +175,7 @@ impl PyLazyFrame {
         encoding: Wrap<CsvEncoding>,
         row_count: Option<(String, IdxSize)>,
         try_parse_dates: bool,
+        use_glob: bool,
         eol_char: &str,
         raise_if_empty: bool,
         truncate_ragged_lines: bool,
@@ -221,7 +222,8 @@ impl PyLazyFrame {
             .with_null_values(null_values)
             .with_missing_is_null(!missing_utf8_is_empty_string)
             .truncate_ragged_lines(truncate_ragged_lines)
-            .raise_if_empty(raise_if_empty);
+            .raise_if_empty(raise_if_empty)
+            .use_glob(use_glob);
 
         if let Some(lambda) = with_schema_modify {
             let f = |schema: Schema| {
@@ -252,7 +254,7 @@ impl PyLazyFrame {
     #[cfg(feature = "parquet")]
     #[staticmethod]
     #[pyo3(signature = (path, paths, n_rows, cache, parallel, rechunk, row_count,
-        low_memory, cloud_options, use_statistics, hive_partitioning, retries)
+        low_memory, cloud_options, use_statistics, hive_partitioning, retries, use_glob)
     )]
     fn new_from_parquet(
         path: Option<PathBuf>,
@@ -267,6 +269,7 @@ impl PyLazyFrame {
         use_statistics: bool,
         hive_partitioning: bool,
         retries: usize,
+        use_glob: bool,
     ) -> PyResult<Self> {
         let first_path = if let Some(path) = &path {
             path
@@ -300,6 +303,7 @@ impl PyLazyFrame {
             cloud_options,
             use_statistics,
             hive_partitioning,
+            use_glob,
         };
 
         let lf = if path.is_some() {
@@ -313,7 +317,7 @@ impl PyLazyFrame {
 
     #[cfg(feature = "ipc")]
     #[staticmethod]
-    #[pyo3(signature = (path, paths, n_rows, cache, rechunk, row_count, memory_map))]
+    #[pyo3(signature = (path, paths, n_rows, cache, rechunk, row_count, use_glob, memory_map))]
     fn new_from_ipc(
         path: Option<PathBuf>,
         paths: Vec<PathBuf>,
@@ -321,6 +325,7 @@ impl PyLazyFrame {
         cache: bool,
         rechunk: bool,
         row_count: Option<(String, IdxSize)>,
+        use_glob: bool,
         memory_map: bool,
     ) -> PyResult<Self> {
         let row_count = row_count.map(|(name, offset)| RowCount { name, offset });
@@ -329,6 +334,7 @@ impl PyLazyFrame {
             cache,
             rechunk,
             row_count,
+            use_glob,
             memmap: memory_map,
         };
 

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -215,8 +215,22 @@ def test_glob_parquet(df: pl.DataFrame, tmp_path: Path) -> None:
     df.write_parquet(file_path)
 
     path_glob = tmp_path / "small*.parquet"
-    assert pl.read_parquet(path_glob).shape == (3, 16)
-    assert pl.scan_parquet(path_glob).collect().shape == (3, 16)
+    assert pl.read_parquet(path_glob, use_glob=True).shape == (3, 16)
+    assert pl.scan_parquet(path_glob, use_glob=True).collect().shape == (3, 16)
+
+
+def test_glob_flag(df: pl.DataFrame, tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+    file_path = tmp_path / "type..hash.[36]string.parquet"
+    df.write_parquet(file_path)
+
+    assert pl.read_parquet(file_path, use_glob=False).shape == (3, 16)
+
+    # TODO: this should raise ComputeError, but with the current implementation
+    # this leads to a recursion error. See #12876
+
+    # with pytest.raises(pl.ComputeError):
+    #     pl.read_parquet(file_path, use_glob=True)
 
 
 def test_chunked_round_trip() -> None:

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -216,7 +216,7 @@ def test_glob_parquet(df: pl.DataFrame, tmp_path: Path) -> None:
 
     path_glob = tmp_path / "small*.parquet"
     assert pl.read_parquet(path_glob, use_glob=True).shape == (3, 16)
-    assert pl.scan_parquet(path_glob, use_glob=True).collect().shape == (3, 16)
+    assert pl.scan_parquet(path_glob).collect().shape == (3, 16)
 
 
 def test_glob_flag(df: pl.DataFrame, tmp_path: Path) -> None:


### PR DESCRIPTION
Partially resolves #12876.

It adds a `use_glob` flag for `read_parquet` as mentioned in the issue. 
This issue does NOT address the recursion problem mentioned in the issue.

Do we want to add this logic also for `read_csv`? If so, should I add it in this PR or make another?