### PR TITLE
ci(python): Run doctests before other tests

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -75,6 +75,12 @@ jobs:
           source activate
           maturin develop
 
+      - name: Run doctests
+        if: github.ref_name != 'main' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
+        run: |
+          python tests/docs/run_doctest.py
+          pytest tests/docs/test_user_guide.py -m docs
+  
       - name: Run tests and report coverage
         if: github.ref_name != 'main'
         env:
@@ -87,12 +93,6 @@ jobs:
       - name: Run tests async reader tests
         if: github.ref_name != 'main' && matrix.os != 'windows-latest'
         run: POLARS_FORCE_ASYNC=1 pytest -m "not benchmark and not docs" tests/unit/io/
-
-      - name: Run doctests
-        if: github.ref_name != 'main' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'
-        run: |
-          python tests/docs/run_doctest.py
-          pytest tests/docs/test_user_guide.py -m docs
 
       - name: Check import without optional dependencies
         if: github.ref_name != 'main' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -29,7 +29,7 @@ defaults:
     shell: bash
 
 jobs:
-  ubuntu:
+  test-python:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
It happens relatively often that all tests pass but you forgot to update the doctests. This will give you slightly faster feedback in that case.