### PR TITLE
fix: dont raise for datetime_range if starting on ambiguous datetime and earliest was specified

### DIFF
--- a/crates/polars-core/src/chunked_array/temporal/mod.rs
+++ b/crates/polars-core/src/chunked_array/temporal/mod.rs
@@ -35,3 +35,13 @@ pub(crate) fn validate_time_zone(tz: &str) -> PolarsResult<()> {
         },
     }
 }
+
+#[cfg(feature = "timezones")]
+pub fn parse_time_zone(tz: &str) -> PolarsResult<Tz> {
+    match tz.parse::<Tz>() {
+        Ok(tz) => Ok(tz),
+        Err(_) => {
+            polars_bail!(ComputeError: "unable to parse time zone: '{}'. Please check the Time Zone Database for a list of available time zones", tz)
+        },
+    }
+}

--- a/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
+++ b/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
@@ -5,14 +5,10 @@ use arrow::temporal_conversions::{
     timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
 };
 use chrono::NaiveDateTime;
-use chrono_tz::{Tz, UTC};
+use chrono_tz::UTC;
 use polars_core::chunked_array::ops::arity::try_binary_elementwise;
+use polars_core::chunked_array::temporal::parse_time_zone;
 use polars_core::prelude::*;
-
-fn parse_time_zone(s: &str) -> PolarsResult<Tz> {
-    s.parse()
-        .map_err(|e| polars_err!(ComputeError: format!("unable to parse time zone: '{s}': {e}")))
-}
 
 pub fn replace_time_zone(
     datetime: &Logical<DatetimeType, Int64Type>,

--- a/crates/polars-time/src/date_range.rs
+++ b/crates/polars-time/src/date_range.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "timezones")]
-use arrow::legacy::kernels::Ambiguous;
 use arrow::legacy::time_zone::Tz;
 use chrono::{Datelike, NaiveDateTime, NaiveTime};
 use polars_core::chunked_array::temporal::time_to_time64ns;
@@ -7,8 +5,6 @@ use polars_core::prelude::*;
 use polars_core::series::IsSorted;
 
 use crate::prelude::*;
-#[cfg(feature = "timezones")]
-use crate::utils::try_localize_timestamp;
 
 pub fn in_nanoseconds_window(ndt: &NaiveDateTime) -> bool {
     // ~584 year around 1970
@@ -23,7 +19,7 @@ pub fn date_range(
     interval: Duration,
     closed: ClosedWindow,
     tu: TimeUnit,
-    tz: Option<TimeZone>,
+    tz: Option<&Tz>,
 ) -> PolarsResult<DatetimeChunked> {
     let (start, end) = match tu {
         TimeUnit::Nanoseconds => (
@@ -33,7 +29,7 @@ pub fn date_range(
         TimeUnit::Microseconds => (start.timestamp_micros(), end.timestamp_micros()),
         TimeUnit::Milliseconds => (start.timestamp_millis(), end.timestamp_millis()),
     };
-    datetime_range_impl(name, start, end, interval, closed, tu, tz.as_ref())
+    datetime_range_impl(name, start, end, interval, closed, tu, tz)
 }
 
 #[doc(hidden)]
@@ -44,27 +40,16 @@ pub fn datetime_range_impl(
     interval: Duration,
     closed: ClosedWindow,
     tu: TimeUnit,
-    _tz: Option<&TimeZone>,
+    tz: Option<&Tz>,
 ) -> PolarsResult<DatetimeChunked> {
-    let mut out = match _tz {
+    let out = Int64Chunked::new_vec(
+        name,
+        datetime_range_i64(start, end, interval, closed, tu, tz)?,
+    );
+    let mut out = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => match tz.parse::<chrono_tz::Tz>() {
-            Ok(tz) => {
-                let start = try_localize_timestamp(start, tu, tz, Ambiguous::Raise);
-                let end = try_localize_timestamp(end, tu, tz, Ambiguous::Raise);
-                Int64Chunked::new_vec(
-                    name,
-                    datetime_range_i64(start?, end?, interval, closed, tu, Some(&tz))?,
-                )
-                .into_datetime(tu, _tz.cloned())
-            },
-            Err(_) => polars_bail!(ComputeError: "unable to parse time zone: '{}'", tz),
-        },
-        _ => Int64Chunked::new_vec(
-            name,
-            datetime_range_i64(start, end, interval, closed, tu, None)?,
-        )
-        .into_datetime(tu, None),
+        Some(tz) => out.into_datetime(tu, Some(tz.to_string())),
+        _ => out.into_datetime(tu, None),
     };
 
     out.set_sorted_flag(IsSorted::Ascending);

--- a/crates/polars-time/src/utils.rs
+++ b/crates/polars-time/src/utils.rs
@@ -3,15 +3,11 @@ use arrow::legacy::kernels::{convert_to_naive_local, convert_to_naive_local_opt,
 #[cfg(feature = "timezones")]
 use arrow::legacy::time_zone::Tz;
 #[cfg(feature = "timezones")]
-use arrow::temporal_conversions::{
-    timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
-};
-#[cfg(feature = "timezones")]
 use chrono::NaiveDateTime;
 #[cfg(feature = "timezones")]
 use chrono::TimeZone;
 #[cfg(feature = "timezones")]
-use polars_core::prelude::{PolarsResult, TimeUnit};
+use polars_core::prelude::PolarsResult;
 
 #[cfg(feature = "timezones")]
 pub(crate) fn try_localize_datetime(
@@ -37,52 +33,4 @@ pub(crate) fn localize_datetime_opt(
 pub(crate) fn unlocalize_datetime(ndt: NaiveDateTime, tz: &Tz) -> NaiveDateTime {
     // e.g. '2021-01-01 03:00CDT' -> '2021-01-01 03:00'
     tz.from_utc_datetime(&ndt).naive_local()
-}
-
-#[cfg(feature = "timezones")]
-pub(crate) fn try_localize_timestamp(
-    timestamp: i64,
-    tu: TimeUnit,
-    tz: Tz,
-    ambiguous: Ambiguous,
-) -> PolarsResult<i64> {
-    match tu {
-        TimeUnit::Nanoseconds => Ok(convert_to_naive_local(
-            &chrono_tz::UTC,
-            &tz,
-            timestamp_ns_to_datetime(timestamp),
-            ambiguous,
-        )?
-        .timestamp_nanos_opt()
-        .unwrap()),
-        TimeUnit::Microseconds => Ok(convert_to_naive_local(
-            &chrono_tz::UTC,
-            &tz,
-            timestamp_us_to_datetime(timestamp),
-            ambiguous,
-        )?
-        .timestamp_micros()),
-        TimeUnit::Milliseconds => Ok(convert_to_naive_local(
-            &chrono_tz::UTC,
-            &tz,
-            timestamp_ms_to_datetime(timestamp),
-            ambiguous,
-        )?
-        .timestamp_millis()),
-    }
-}
-
-#[cfg(feature = "timezones")]
-pub(crate) fn unlocalize_timestamp(timestamp: i64, tu: TimeUnit, tz: Tz) -> i64 {
-    match tu {
-        TimeUnit::Nanoseconds => unlocalize_datetime(timestamp_ns_to_datetime(timestamp), &tz)
-            .timestamp_nanos_opt()
-            .unwrap(),
-        TimeUnit::Microseconds => {
-            unlocalize_datetime(timestamp_us_to_datetime(timestamp), &tz).timestamp_micros()
-        },
-        TimeUnit::Milliseconds => {
-            unlocalize_datetime(timestamp_ms_to_datetime(timestamp), &tz).timestamp_millis()
-        },
-    }
 }

--- a/py-polars/tests/unit/functions/range/test_datetime_range.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_range.py
@@ -454,6 +454,19 @@ def test_datetime_range_schema_upcasts_to_datetime(
     )
     assert_frame_equal(result.collect(), expected)
 
+    # check datetime_range too
+    result_single = pl.datetime_range(
+        date(2020, 1, 1),
+        date(2020, 1, 3),
+        interval=interval,
+        time_unit=input_time_unit,
+        time_zone=input_time_zone,
+        eager=True,
+    )
+    assert_series_equal(
+        result_single, expected["datetime_range"].explode().rename("datetime")
+    )
+
 
 def test_datetime_ranges_no_alias_schema_9037() -> None:
     df = pl.DataFrame(
@@ -525,3 +538,37 @@ def test_datetime_ranges_broadcasting() -> None:
         }
     )
     assert_frame_equal(result, expected)
+
+
+def test_datetime_range_specifying_ambiguous_11713() -> None:
+    result = pl.datetime_range(
+        pl.datetime(2023, 10, 29, 2, 0).dt.replace_time_zone(
+            "Europe/Madrid", ambiguous="earliest"
+        ),
+        pl.datetime(2023, 10, 29, 3, 0).dt.replace_time_zone("Europe/Madrid"),
+        "1h",
+        eager=True,
+    )
+    expected = pl.Series(
+        "datetime",
+        [
+            datetime(2023, 10, 29, 2),
+            datetime(2023, 10, 29, 2),
+            datetime(2023, 10, 29, 3),
+        ],
+    ).dt.replace_time_zone(
+        "Europe/Madrid", ambiguous=pl.Series(["earliest", "latest", "raise"])
+    )
+    assert_series_equal(result, expected)
+    result = pl.datetime_range(
+        pl.datetime(2023, 10, 29, 2, 0).dt.replace_time_zone(
+            "Europe/Madrid", ambiguous="latest"
+        ),
+        pl.datetime(2023, 10, 29, 3, 0).dt.replace_time_zone("Europe/Madrid"),
+        "1h",
+        eager=True,
+    )
+    expected = pl.Series(
+        "datetime", [datetime(2023, 10, 29, 2), datetime(2023, 10, 29, 3)]
+    ).dt.replace_time_zone("Europe/Madrid", ambiguous=pl.Series(["latest", "raise"]))
+    assert_series_equal(result, expected)


### PR DESCRIPTION
closes #11713

This was _so_ satisfying

There gist of the change is to avoid a "remove time zone, then put it back again" cycle, thus avoiding running into ambiguous datetimes

By doing that, quite a lot of unnecessary functions and logic can be removed - always nice to fix a bug by removing code!