### PR TITLE
fix(rust): raise InvalidOperationerror when using sort/arg_sort on objects

### DIFF
--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -688,12 +688,13 @@ pub(crate) mod test {
         let a = Int32Chunked::new("a", &[1, 9, 3, 2]);
         let b = a
             .sort(false)
+            .unwrap()
             .into_iter()
             .map(|opt| opt.unwrap())
             .collect::<Vec<_>>();
         assert_eq!(b, [1, 2, 3, 9]);
         let a = Utf8Chunked::new("a", &["b", "a", "c"]);
-        let a = a.sort(false);
+        let a = a.sort(false).unwrap();
         let b = a.into_iter().collect::<Vec<_>>();
         assert_eq!(b, [Some("a"), Some("b"), Some("c")]);
         assert!(a.is_sorted_ascending_flag());
@@ -791,24 +792,24 @@ pub(crate) mod test {
     #[test]
     fn sorting() {
         let s = UInt32Chunked::new("", &[9, 2, 4]);
-        let sorted = s.sort(false);
+        let sorted = s.sort(false).unwrap();
         assert_slice_equal(&sorted, &[2, 4, 9]);
-        let sorted = s.sort(true);
+        let sorted = s.sort(true).unwrap();
         assert_slice_equal(&sorted, &[9, 4, 2]);
 
         let s: Utf8Chunked = ["b", "a", "z"].iter().collect();
-        let sorted = s.sort(false);
+        let sorted = s.sort(false).unwrap();
         assert_eq!(
             sorted.into_iter().collect::<Vec<_>>(),
             &[Some("a"), Some("b"), Some("z")]
         );
-        let sorted = s.sort(true);
+        let sorted = s.sort(true).unwrap();
         assert_eq!(
             sorted.into_iter().collect::<Vec<_>>(),
             &[Some("z"), Some("b"), Some("a")]
         );
         let s: Utf8Chunked = [Some("b"), None, Some("z")].iter().copied().collect();
-        let sorted = s.sort(false);
+        let sorted = s.sort(false).unwrap();
         assert_eq!(
             sorted.into_iter().collect::<Vec<_>>(),
             &[None, Some("b"), Some("z")]

--- a/crates/polars-core/src/chunked_array/ops/aggregate/quantile.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/quantile.rs
@@ -123,7 +123,7 @@ where
     }
 
     let (idx, float_idx, top_idx) = quantile_idx(quantile, length, null_count, interpol);
-    let sorted = ca.sort(false);
+    let sorted = ca.sort(false).unwrap();
     let lower = sorted.get(idx).map(|v| v.to_f64().unwrap());
 
     let opt = match interpol {

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -391,13 +391,13 @@ impl Default for SortOptions {
 /// Sort operations on `ChunkedArray`.
 pub trait ChunkSort<T: PolarsDataType> {
     #[allow(unused_variables)]
-    fn sort_with(&self, options: SortOptions) -> ChunkedArray<T>;
+    fn sort_with(&self, options: SortOptions) -> PolarsResult<ChunkedArray<T>>;
 
     /// Returned a sorted `ChunkedArray`.
-    fn sort(&self, descending: bool) -> ChunkedArray<T>;
+    fn sort(&self, descending: bool) -> PolarsResult<ChunkedArray<T>>;
 
     /// Retrieve the indexes needed to sort this array.
-    fn arg_sort(&self, options: SortOptions) -> IdxCa;
+    fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa>;
 
     /// Retrieve the indexes need to sort this and the other arrays.
     fn arg_sort_multiple(&self, _options: &SortMultipleOptions) -> PolarsResult<IdxCa> {

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -37,7 +37,7 @@ impl CategoricalChunked {
                 )
             };
         }
-        let cats = self.physical().sort_with(options);
+        let cats = self.physical().sort_with(options).unwrap();
         // safety:
         // we only reordered the indexes so we are still in bounds
         unsafe {
@@ -72,7 +72,7 @@ impl CategoricalChunked {
                 self.len(),
             )
         } else {
-            self.physical().arg_sort(options)
+            self.physical().arg_sort(options).unwrap()
         }
     }
 

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -628,20 +628,24 @@ mod test {
                 Some(1), // 7
             ],
         );
-        let idx = a.arg_sort(SortOptions {
-            descending: false,
-            ..Default::default()
-        });
-        let idx = idx.unwrap().cont_slice().unwrap();
+        let idx = a
+            .arg_sort(SortOptions {
+                descending: false,
+                ..Default::default()
+            })
+            .unwrap();
+        let idx = idx.cont_slice().unwrap();
 
         let expected = [2, 4, 0, 3, 7, 6, 5, 1];
         assert_eq!(idx, expected);
 
-        let idx = a.arg_sort(SortOptions {
-            descending: true,
-            ..Default::default()
-        });
-        let idx = idx.unwrap().cont_slice().unwrap();
+        let idx = a
+            .arg_sort(SortOptions {
+                descending: true,
+                ..Default::default()
+            })
+            .unwrap();
+        let idx = idx.cont_slice().unwrap();
         // the duplicates are in reverse order of appearance, so we cannot reverse expected
         let expected = [4, 2, 1, 5, 6, 0, 3, 7];
         assert_eq!(idx, expected);

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -205,7 +205,13 @@ where
         let iter = ca
             .downcast_iter()
             .map(|arr| arr.iter().map(|opt| opt.copied()));
-        Ok(arg_sort::arg_sort(ca.name(), iter, options, ca.null_count(), ca.len()))
+        Ok(arg_sort::arg_sort(
+            ca.name(),
+            iter,
+            options,
+            ca.null_count(),
+            ca.len(),
+        ))
     }
 }
 
@@ -245,11 +251,11 @@ impl<T> ChunkSort<T> for ChunkedArray<T>
 where
     T: PolarsNumericType,
 {
-    fn sort_with(&self, options: SortOptions) -> PolarsResult<ChunkedArray<T>>{
+    fn sort_with(&self, options: SortOptions) -> PolarsResult<ChunkedArray<T>> {
         sort_with_numeric(self, options)
     }
 
-    fn sort(&self, descending: bool) ->PolarsResult< ChunkedArray<T>> {
+    fn sort(&self, descending: bool) -> PolarsResult<ChunkedArray<T>> {
         self.sort_with(SortOptions {
             descending,
             ..Default::default()
@@ -546,7 +552,6 @@ impl<T: PolarsObject> ChunkSort<ObjectType<T>> for ObjectChunked<T> {
     fn arg_sort(&self, _options: SortOptions) -> PolarsResult<IdxCa> {
         polars_bail!(opq = arg_sort, self.dtype());
     }
-
 }
 
 pub(crate) fn convert_sort_column_multi_sort(s: &Series) -> PolarsResult<Series> {

--- a/crates/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -289,6 +289,7 @@ mod test {
             ca.unique()
                 .unwrap()
                 .sort(false)
+                .unwrap()
                 .into_iter()
                 .collect::<Vec<_>>(),
             vec![Some(1), Some(2), Some(3)]
@@ -301,7 +302,7 @@ mod test {
 
         let ca = Utf8Chunked::new("", &[Some("a"), None, Some("a"), Some("b"), None]);
         assert_eq!(
-            Vec::from(&ca.unique().unwrap().sort(false)),
+            Vec::from(&ca.unique().unwrap().sort(false).unwrap()),
             &[None, Some("a"), Some("b")]
         );
     }

--- a/crates/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -123,7 +123,7 @@ where
                 }
             },
             IsSorted::Not => {
-                let sorted = self.sort(false);
+                let sorted = self.sort(false)?;
                 sorted.unique()
             },
         }
@@ -164,7 +164,7 @@ where
                 }
             },
             IsSorted::Not => {
-                let sorted = self.sort(false);
+                let sorted = self.sort(false)?;
                 sorted.n_unique()
             },
         }

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -1066,14 +1066,28 @@ mod test {
         // is equal, then, the grouped columns shall be equal and in the same order.
         for series_name in &series_names {
             assert_eq!(
-                Vec::from(&adf.column(series_name).unwrap().utf8().unwrap().sort(false)),
+                Vec::from(
+                    &adf.column(series_name)
+                        .unwrap()
+                        .utf8()
+                        .unwrap()
+                        .sort(false)
+                        .unwrap()
+                ),
                 &[Some("A"), Some("B"), Some("C")]
             );
         }
 
         // Check the aggregated column is the expected one.
         assert_eq!(
-            Vec::from(&adf.column("N_sum").unwrap().i32().unwrap().sort(false)),
+            Vec::from(
+                &adf.column("N_sum")
+                    .unwrap()
+                    .i32()
+                    .unwrap()
+                    .sort(false)
+                    .unwrap()
+            ),
             &[Some(3), Some(4), Some(6)]
         );
     }

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -1020,7 +1020,14 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            Vec::from(&adf.column("N_sum").unwrap().i32().unwrap().sort(false)),
+            Vec::from(
+                &adf.column("N_sum")
+                    .unwrap()
+                    .i32()
+                    .unwrap()
+                    .sort(false)
+                    .unwrap()
+            ),
             &[Some(1), Some(2), Some(2), Some(6)]
         );
     }

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1849,14 +1849,14 @@ impl DataFrame {
                 // no need to compute the sort indices and then take by these indices
                 // simply sort and return as frame
                 if df.width() == 1 && df.check_name_to_idx(s.name()).is_ok() {
-                    let mut out = s.sort_with(options);
+                    let mut out = s.sort_with(options)?;
                     if let Some((offset, len)) = slice {
                         out = out.slice(offset, len);
                     }
 
                     return Ok(out.into_frame());
                 }
-                s.arg_sort(options)
+                s.arg_sort(options)?
             },
             _ => {
                 if nulls_last || has_struct || std::env::var("POLARS_ROW_FMT_SORT").is_ok() {
@@ -2702,7 +2702,7 @@ impl DataFrame {
                     },
                 };
 
-                let last_idx = last_idx.sort(false);
+                let last_idx = last_idx.sort(false).unwrap();
                 return Ok(unsafe { df.take_unchecked(&last_idx) });
             },
             (UniqueKeepStrategy::First | UniqueKeepStrategy::Any, false) => {

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -184,7 +184,9 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
     }
 
     fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
-        Ok(ChunkSort::sort_with(&self.0, options).unwrap().into_series())
+        Ok(ChunkSort::sort_with(&self.0, options)
+            .unwrap()
+            .into_series())
     }
 
     fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -183,12 +183,12 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
         self.0.get_any_value_unchecked(index)
     }
 
-    fn sort_with(&self, options: SortOptions) -> Series {
-        ChunkSort::sort_with(&self.0, options).into_series()
+    fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
+        Ok(ChunkSort::sort_with(&self.0, options).unwrap().into_series())
     }
 
-    fn arg_sort(&self, options: SortOptions) -> IdxCa {
-        ChunkSort::arg_sort(&self.0, options)
+    fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
+        Ok(ChunkSort::arg_sort(&self.0, options).unwrap())
     }
 
     fn null_count(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -219,12 +219,12 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
         self.0.get_any_value_unchecked(index)
     }
 
-    fn sort_with(&self, options: SortOptions) -> Series {
-        ChunkSort::sort_with(&self.0, options).into_series()
+    fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
+        Ok(ChunkSort::sort_with(&self.0, options).unwrap().into_series())
     }
 
-    fn arg_sort(&self, options: SortOptions) -> IdxCa {
-        ChunkSort::arg_sort(&self.0, options)
+    fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
+        Ok(ChunkSort::arg_sort(&self.0, options).unwrap())
     }
 
     fn null_count(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -220,7 +220,9 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
     }
 
     fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
-        Ok(ChunkSort::sort_with(&self.0, options).unwrap().into_series())
+        Ok(ChunkSort::sort_with(&self.0, options)
+            .unwrap()
+            .into_series())
     }
 
     fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -247,12 +247,12 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
         self.0.get_any_value_unchecked(index)
     }
 
-    fn sort_with(&self, options: SortOptions) -> Series {
-        self.0.sort_with(options).into_series()
+    fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
+        Ok(self.0.sort_with(options).into_series())
     }
 
-    fn arg_sort(&self, options: SortOptions) -> IdxCa {
-        self.0.arg_sort(options)
+    fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
+        Ok(self.0.arg_sort(options))
     }
 
     fn null_count(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/dates_time.rs
+++ b/crates/polars-core/src/series/implementations/dates_time.rs
@@ -294,12 +294,12 @@ macro_rules! impl_dyn_series {
                 self.0.get_any_value_unchecked(index)
             }
 
-            fn sort_with(&self, options: SortOptions) -> Series {
-                self.0.sort_with(options).$into_logical().into_series()
+            fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
+                Ok(self.0.sort_with(options).unwrap().$into_logical().into_series())
             }
 
-            fn arg_sort(&self, options: SortOptions) -> IdxCa {
-                self.0.arg_sort(options)
+            fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
+                Ok(self.0.arg_sort(options).unwrap())
             }
 
             fn null_count(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -288,7 +288,8 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
     }
 
     fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
-        Ok(self.0
+        Ok(self
+            .0
             .sort_with(options)
             .unwrap()
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -287,15 +287,16 @@ impl SeriesTrait for SeriesWrap<DatetimeChunked> {
         self.0.get_any_value_unchecked(index)
     }
 
-    fn sort_with(&self, options: SortOptions) -> Series {
-        self.0
+    fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
+        Ok(self.0
             .sort_with(options)
+            .unwrap()
             .into_datetime(self.0.time_unit(), self.0.time_zone().clone())
-            .into_series()
+            .into_series())
     }
 
-    fn arg_sort(&self, options: SortOptions) -> IdxCa {
-        self.0.arg_sort(options)
+    fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
+        Ok(self.0.arg_sort(options).unwrap())
     }
 
     fn null_count(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -336,7 +336,8 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
     }
 
     fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
-        Ok(self.0
+        Ok(self
+            .0
             .sort_with(options)
             .unwrap()
             .into_duration(self.0.time_unit())

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -335,15 +335,16 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
         self.0.get_any_value_unchecked(index)
     }
 
-    fn sort_with(&self, options: SortOptions) -> Series {
-        self.0
+    fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
+        Ok(self.0
             .sort_with(options)
+            .unwrap()
             .into_duration(self.0.time_unit())
-            .into_series()
+            .into_series())
     }
 
-    fn arg_sort(&self, options: SortOptions) -> IdxCa {
-        self.0.arg_sort(options)
+    fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
+        Ok(self.0.arg_sort(options).unwrap())
     }
 
     fn null_count(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -245,7 +245,9 @@ macro_rules! impl_dyn_series {
             }
 
             fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
-                Ok(ChunkSort::sort_with(&self.0, options).unwrap().into_series())
+                Ok(ChunkSort::sort_with(&self.0, options)
+                    .unwrap()
+                    .into_series())
             }
 
             fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -244,12 +244,12 @@ macro_rules! impl_dyn_series {
                 self.0.get_any_value_unchecked(index)
             }
 
-            fn sort_with(&self, options: SortOptions) -> Series {
-                ChunkSort::sort_with(&self.0, options).into_series()
+            fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
+                Ok(ChunkSort::sort_with(&self.0, options).unwrap().into_series())
             }
 
-            fn arg_sort(&self, options: SortOptions) -> IdxCa {
-                ChunkSort::arg_sort(&self.0, options)
+            fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
+                Ok(ChunkSort::arg_sort(&self.0, options).unwrap())
             }
 
             fn null_count(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -343,12 +343,12 @@ macro_rules! impl_dyn_series {
                 self.0.get_any_value_unchecked(index)
             }
 
-            fn sort_with(&self, options: SortOptions) -> Series {
-                ChunkSort::sort_with(&self.0, options).into_series()
+            fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
+                Ok(ChunkSort::sort_with(&self.0, options).unwrap().into_series())
             }
 
-            fn arg_sort(&self, options: SortOptions) -> IdxCa {
-                ChunkSort::arg_sort(&self.0, options)
+            fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
+                Ok(ChunkSort::arg_sort(&self.0, options).unwrap())
             }
 
             fn null_count(&self) -> usize {

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -344,7 +344,9 @@ macro_rules! impl_dyn_series {
             }
 
             fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
-                Ok(ChunkSort::sort_with(&self.0, options).unwrap().into_series())
+                Ok(ChunkSort::sort_with(&self.0, options)
+                    .unwrap()
+                    .into_series())
             }
 
             fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -197,6 +197,14 @@ where
         ChunkUnique::arg_unique(&self.0)
     }
 
+    fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
+        ChunkSort::sort_with(&self.0, options).map(|ca| ca.into_series())
+    }
+
+    fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
+        ChunkSort::arg_sort(&self.0, options)
+    }
+
     fn is_null(&self) -> BooleanChunked {
         ObjectChunked::is_null(&self.0)
     }

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -197,13 +197,13 @@ where
         ChunkUnique::arg_unique(&self.0)
     }
 
-    fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
-        ChunkSort::sort_with(&self.0, options).map(|ca| ca.into_series())
-    }
+    // fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
+    //     ChunkSort::sort_with(&self.0, options).map(|ca| ca.into_series())
+    // }
 
-    fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
-        ChunkSort::arg_sort(&self.0, options)
-    }
+    // fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
+    //     ChunkSort::arg_sort(&self.0, options)
+    // }
 
     fn is_null(&self) -> BooleanChunked {
         ObjectChunked::is_null(&self.0)

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -329,7 +329,7 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
         &self.0
     }
 
-    fn sort_with(&self, options: SortOptions) -> Series {
+    fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
         let df = self.0.clone().unnest();
 
         let desc = if options.descending {
@@ -347,10 +347,10 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
                 options.multithreaded,
             )
             .unwrap();
-        StructChunked::new_unchecked(self.name(), &out.columns).into_series()
+        Ok(StructChunked::new_unchecked(self.name(), &out.columns).into_series())
     }
 
-    fn arg_sort(&self, options: SortOptions) -> IdxCa {
-        self.0.arg_sort(options)
+    fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
+        Ok(self.0.arg_sort(options).unwrap())
     }
 }

--- a/crates/polars-core/src/series/implementations/utf8.rs
+++ b/crates/polars-core/src/series/implementations/utf8.rs
@@ -201,7 +201,9 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
     }
 
     fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
-        Ok(ChunkSort::sort_with(&self.0, options).unwrap().into_series())
+        Ok(ChunkSort::sort_with(&self.0, options)
+            .unwrap()
+            .into_series())
     }
 
     fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {

--- a/crates/polars-core/src/series/implementations/utf8.rs
+++ b/crates/polars-core/src/series/implementations/utf8.rs
@@ -200,12 +200,12 @@ impl SeriesTrait for SeriesWrap<Utf8Chunked> {
         self.0.get_any_value_unchecked(index)
     }
 
-    fn sort_with(&self, options: SortOptions) -> Series {
-        ChunkSort::sort_with(&self.0, options).into_series()
+    fn sort_with(&self, options: SortOptions) -> PolarsResult<Series> {
+        Ok(ChunkSort::sort_with(&self.0, options).unwrap().into_series())
     }
 
-    fn arg_sort(&self, options: SortOptions) -> IdxCa {
-        ChunkSort::arg_sort(&self.0, options)
+    fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
+        Ok(ChunkSort::arg_sort(&self.0, options).unwrap())
     }
 
     fn null_count(&self) -> usize {

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -282,11 +282,11 @@ impl Series {
         Ok(self)
     }
 
-    pub fn sort(&self, descending: bool) -> Self {
+    pub fn sort(&self, descending: bool) -> PolarsResult<Self> {
         self.sort_with(SortOptions {
             descending,
             ..Default::default()
-        }).unwrap()
+        })
     }
 
     /// Only implemented for numeric types

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -286,7 +286,7 @@ impl Series {
         self.sort_with(SortOptions {
             descending,
             ..Default::default()
-        })
+        }).unwrap()
     }
 
     /// Only implemented for numeric types

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -334,13 +334,13 @@ pub trait SeriesTrait:
     }
 
     fn sort_with(&self, _options: SortOptions) -> PolarsResult<Series> {
-        invalid_operation_panic!(sort_with, self)
+        polars_bail!(opq = sort_with, self.dtype());
     }
 
     /// Retrieve the indexes needed for a sort.
     #[allow(unused)]
     fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
-        invalid_operation_panic!(arg_sort, self)
+        polars_bail!(opq = arg_sort, self.dtype());
     }
 
     /// Count the null values.

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -333,13 +333,13 @@ pub trait SeriesTrait:
         invalid_operation_panic!(get_unchecked, self)
     }
 
-    fn sort_with(&self, _options: SortOptions) -> Series {
+    fn sort_with(&self, _options: SortOptions) -> PolarsResult<Series> {
         invalid_operation_panic!(sort_with, self)
     }
 
     /// Retrieve the indexes needed for a sort.
     #[allow(unused)]
-    fn arg_sort(&self, options: SortOptions) -> IdxCa {
+    fn arg_sort(&self, options: SortOptions) -> PolarsResult<IdxCa> {
         invalid_operation_panic!(arg_sort, self)
     }
 

--- a/crates/polars-lazy/src/physical_plan/expressions/sort.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/sort.rs
@@ -54,7 +54,7 @@ impl PhysicalExpr for SortExpr {
     }
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
         let series = self.physical_expr.evaluate(df, state)?;
-        Ok(series.sort_with(self.options))
+        series.sort_with(self.options)
     }
 
     #[allow(clippy::ptr_arg)]
@@ -85,7 +85,7 @@ impl PhysicalExpr for SortExpr {
                                     // SAFETY: group tuples are always in bounds.
                                     let group = unsafe { series.take_slice_unchecked(idx) };
 
-                                    let sorted_idx = group.arg_sort(sort_options);
+                                    let sorted_idx = group.arg_sort(sort_options).unwrap();
                                     let new_idx = map_sorted_indices_to_group_idx(&sorted_idx, idx);
                                     (new_idx.first().copied().unwrap_or(first), new_idx)
                                 })
@@ -95,7 +95,7 @@ impl PhysicalExpr for SortExpr {
                             .par_iter()
                             .map(|&[first, len]| {
                                 let group = series.slice(first as i64, len as usize);
-                                let sorted_idx = group.arg_sort(sort_options);
+                                let sorted_idx = group.arg_sort(sort_options).unwrap();
                                 let new_idx = map_sorted_indices_to_group_slice(&sorted_idx, first);
                                 (new_idx.first().copied().unwrap_or(first), new_idx)
                             })

--- a/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -62,22 +62,26 @@ fn sort_by_groups_single_by(
             // SAFETY: group tuples are always in bounds.
             let group = unsafe { sort_by_s.take_slice_unchecked(idx) };
 
-            let sorted_idx = group.arg_sort(SortOptions {
-                descending: descending[0],
-                // We are already in par iter.
-                multithreaded: false,
-                ..Default::default()
-            }).unwrap();
+            let sorted_idx = group
+                .arg_sort(SortOptions {
+                    descending: descending[0],
+                    // We are already in par iter.
+                    multithreaded: false,
+                    ..Default::default()
+                })
+                .unwrap();
             map_sorted_indices_to_group_idx(&sorted_idx, idx)
         },
         GroupsIndicator::Slice([first, len]) => {
             let group = sort_by_s.slice(first as i64, len as usize);
-            let sorted_idx = group.arg_sort(SortOptions {
-                descending: descending[0],
-                // We are already in par iter.
-                multithreaded: false,
-                ..Default::default()
-            }).unwrap();
+            let sorted_idx = group
+                .arg_sort(SortOptions {
+                    descending: descending[0],
+                    // We are already in par iter.
+                    multithreaded: false,
+                    ..Default::default()
+                })
+                .unwrap();
             map_sorted_indices_to_group_slice(&sorted_idx, first)
         },
     };

--- a/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -67,7 +67,7 @@ fn sort_by_groups_single_by(
                 // We are already in par iter.
                 multithreaded: false,
                 ..Default::default()
-            });
+            }).unwrap();
             map_sorted_indices_to_group_idx(&sorted_idx, idx)
         },
         GroupsIndicator::Slice([first, len]) => {
@@ -77,7 +77,7 @@ fn sort_by_groups_single_by(
                 // We are already in par iter.
                 multithreaded: false,
                 ..Default::default()
-            });
+            }).unwrap();
             map_sorted_indices_to_group_slice(&sorted_idx, first)
         },
     };
@@ -110,7 +110,7 @@ fn sort_by_groups_no_match_single<'a>(
                         // We are already in par iter.
                         multithreaded: false,
                         ..Default::default()
-                    });
+                    }).unwrap();
                     Ok(Some(unsafe { s.take_unchecked(&idx) }))
                 },
                 _ => Ok(None),
@@ -176,11 +176,11 @@ impl PhysicalExpr for SortByExpr {
 
         let (series, sorted_idx) = if self.by.len() == 1 {
             let sorted_idx_f = || {
-                let s_sort_by = self.by[0].evaluate(df, state)?;
-                Ok(s_sort_by.arg_sort(SortOptions {
+                let s_sort_by = self.by[0].evaluate(df, state).unwrap();
+                s_sort_by.arg_sort(SortOptions {
                     descending: descending[0],
                     ..Default::default()
-                }))
+                })
             };
             POOL.install(|| rayon::join(series_f, sorted_idx_f))
         } else {

--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -28,7 +28,7 @@ where
         breaks.sort_unstable_by_key(|k| TotalOrdWrap(*k));
         breaks.push(f64::INFINITY);
 
-        let sorted = ca.sort(false);
+        let sorted = ca.sort(false).unwrap();
 
         let mut count: Vec<IdxSize> = Vec::with_capacity(breaks.len());
         let mut current_count: IdxSize = 0;

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -216,7 +216,7 @@ pub trait ListNameSpaceImpl: AsList {
     #[must_use]
     fn lst_sort(&self, options: SortOptions) -> ListChunked {
         let ca = self.as_list();
-        let out = ca.apply_amortized(|s| s.as_ref().sort_with(options));
+        let out = ca.apply_amortized(|s| s.as_ref().sort_with(options).unwrap());
         self.same_type(out)
     }
 

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -74,7 +74,7 @@ pub trait Utf8NameSpaceImpl: AsUtf8 {
             let failure_mask = !ca.is_null() & out.is_null();
             let all_failures = ca.filter(&failure_mask)?;
             let n_failures = all_failures.len();
-            let some_failures = all_failures.unique()?.slice(0, 10).sort(false);
+            let some_failures = all_failures.unique()?.slice(0, 10).sort(false).unwrap();
             let some_error_msg = some_failures
                 .get(0)
                 .and_then(|s| <i64 as Num>::from_str_radix(s, base).err())

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -20,7 +20,7 @@ where
     ChunkedArray<T>: ChunkSort<T>,
 {
     if k >= ca.len() {
-        return ca.sort(!descending);
+        return ca.sort(!descending).unwrap();
     }
 
     // descending is opposite from sort as top-k returns largest

--- a/crates/polars-ops/src/frame/join/hash_join/sort_merge.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/sort_merge.rs
@@ -227,7 +227,7 @@ pub fn _sort_or_hash_inner(
                 nulls_last: false,
                 multithreaded: true,
                 maintain_order: false,
-            });
+            }).unwrap();
             let s_right = unsafe { s_right.take_unchecked(&sort_idx) };
             let ids = par_sorted_merge_inner_no_nulls(s_left, &s_right);
             let reverse_idx_map = create_reverse_map_from_arg_sort(sort_idx);
@@ -254,7 +254,7 @@ pub fn _sort_or_hash_inner(
                 nulls_last: false,
                 multithreaded: true,
                 maintain_order: false,
-            });
+            }).unwrap();
             let s_left = unsafe { s_left.take_unchecked(&sort_idx) };
             let ids = par_sorted_merge_inner_no_nulls(&s_left, s_right);
             let reverse_idx_map = create_reverse_map_from_arg_sort(sort_idx);
@@ -325,7 +325,7 @@ pub(super) fn sort_or_hash_left(
                 nulls_last: false,
                 multithreaded: true,
                 maintain_order: false,
-            });
+            }).unwrap();
             let s_right = unsafe { s_right.take_unchecked(&sort_idx) };
 
             let ids = par_sorted_merge_left(s_left, &s_right);

--- a/crates/polars-ops/src/frame/join/hash_join/sort_merge.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/sort_merge.rs
@@ -222,12 +222,14 @@ pub fn _sort_or_hash_inner(
                 eprintln!("right key will be descending sorted in inner join operation.")
             }
 
-            let sort_idx = s_right.arg_sort(SortOptions {
-                descending: false,
-                nulls_last: false,
-                multithreaded: true,
-                maintain_order: false,
-            }).unwrap();
+            let sort_idx = s_right
+                .arg_sort(SortOptions {
+                    descending: false,
+                    nulls_last: false,
+                    multithreaded: true,
+                    maintain_order: false,
+                })
+                .unwrap();
             let s_right = unsafe { s_right.take_unchecked(&sort_idx) };
             let ids = par_sorted_merge_inner_no_nulls(s_left, &s_right);
             let reverse_idx_map = create_reverse_map_from_arg_sort(sort_idx);
@@ -249,12 +251,14 @@ pub fn _sort_or_hash_inner(
                 eprintln!("left key will be descending sorted in inner join operation.")
             }
 
-            let sort_idx = s_left.arg_sort(SortOptions {
-                descending: false,
-                nulls_last: false,
-                multithreaded: true,
-                maintain_order: false,
-            }).unwrap();
+            let sort_idx = s_left
+                .arg_sort(SortOptions {
+                    descending: false,
+                    nulls_last: false,
+                    multithreaded: true,
+                    maintain_order: false,
+                })
+                .unwrap();
             let s_left = unsafe { s_left.take_unchecked(&sort_idx) };
             let ids = par_sorted_merge_inner_no_nulls(&s_left, s_right);
             let reverse_idx_map = create_reverse_map_from_arg_sort(sort_idx);
@@ -320,12 +324,14 @@ pub(super) fn sort_or_hash_left(
                 eprintln!("right key will be reverse sorted in left join operation.")
             }
 
-            let sort_idx = s_right.arg_sort(SortOptions {
-                descending: false,
-                nulls_last: false,
-                multithreaded: true,
-                maintain_order: false,
-            }).unwrap();
+            let sort_idx = s_right
+                .arg_sort(SortOptions {
+                    descending: false,
+                    nulls_last: false,
+                    multithreaded: true,
+                    maintain_order: false,
+                })
+                .unwrap();
             let s_right = unsafe { s_right.take_unchecked(&sort_idx) };
 
             let ids = par_sorted_merge_left(s_left, &s_right);

--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -104,7 +104,7 @@ pub fn qcut(
     include_breaks: bool,
 ) -> PolarsResult<Series> {
     let s = s.cast(&DataType::Float64)?;
-    let s2 = s.sort(false);
+    let s2 = s.sort(false).unwrap();
     let ca = s2.f64()?;
     let f = |&p| {
         ca.quantile(p, QuantileInterpolOptions::Linear)

--- a/crates/polars-ops/src/series/ops/rank.rs
+++ b/crates/polars-ops/src/series/ops/rank.rs
@@ -97,7 +97,8 @@ fn rank(s: &Series, method: RankMethod, descending: bool, seed: Option<u64>) -> 
             descending,
             nulls_last: true,
             ..Default::default()
-        }).unwrap()
+        })
+        .unwrap()
         .slice(0, len - null_count);
 
     let chunk_refs: Vec<_> = s.chunks().iter().map(|c| &**c).collect();

--- a/crates/polars-ops/src/series/ops/rank.rs
+++ b/crates/polars-ops/src/series/ops/rank.rs
@@ -97,7 +97,7 @@ fn rank(s: &Series, method: RankMethod, descending: bool, seed: Option<u64>) -> 
             descending,
             nulls_last: true,
             ..Default::default()
-        })
+        }).unwrap()
         .slice(0, len - null_count);
 
     let chunk_refs: Vec<_> = s.chunks().iter().map(|c| &**c).collect();

--- a/crates/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -174,12 +174,14 @@ impl Sink for SortSink {
             let io_thread = lock.as_ref().unwrap();
 
             let dist = Series::from_any_values("", &self.dist_sample, false).unwrap();
-            let dist = dist.sort_with(SortOptions {
-                descending: self.sort_args.descending[0],
-                nulls_last: self.sort_args.nulls_last,
-                multithreaded: true,
-                maintain_order: self.sort_args.maintain_order,
-            }).unwrap();
+            let dist = dist
+                .sort_with(SortOptions {
+                    descending: self.sort_args.descending[0],
+                    nulls_last: self.sort_args.nulls_last,
+                    multithreaded: true,
+                    maintain_order: self.sort_args.maintain_order,
+                })
+                .unwrap();
 
             block_thread_until_io_thread_done(io_thread);
 

--- a/crates/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -179,7 +179,7 @@ impl Sink for SortSink {
                 nulls_last: self.sort_args.nulls_last,
                 multithreaded: true,
                 maintain_order: self.sort_args.maintain_order,
-            });
+            }).unwrap();
 
             block_thread_until_io_thread_done(io_thread);
 

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -351,7 +351,7 @@ impl Expr {
         };
 
         self.function_with_options(
-            move |s: Series| Ok(Some(s.arg_sort(sort_options).into_series())),
+            move |s: Series| Ok(Some(s.arg_sort(sort_options).unwrap().into_series())),
             GetOutput::from_type(IDX_DTYPE),
             options,
         )

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -351,7 +351,12 @@ impl Expr {
         };
 
         self.function_with_options(
-            move |s: Series| Ok(Some(s.arg_sort(sort_options).unwrap().into_series())),
+            move |s: Series| {
+                match s.arg_sort(sort_options) { 
+                    Ok(sorted) => Ok(Some(sorted.into_series())),
+                    Err(e) => Err(e),
+                }
+            },
             GetOutput::from_type(IDX_DTYPE),
             options,
         )

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -351,11 +351,9 @@ impl Expr {
         };
 
         self.function_with_options(
-            move |s: Series| {
-                match s.arg_sort(sort_options) { 
-                    Ok(sorted) => Ok(Some(sorted.into_series())),
-                    Err(e) => Err(e),
-                }
+            move |s: Series| match s.arg_sort(sort_options) {
+                Ok(sorted) => Ok(Some(sorted.into_series())),
+                Err(e) => Err(e),
             },
             GetOutput::from_type(IDX_DTYPE),
             options,

--- a/crates/polars-sql/tests/iss_8395.rs
+++ b/crates/polars-sql/tests/iss_8395.rs
@@ -19,7 +19,7 @@ fn iss_8395() -> PolarsResult<()> {
     let df = res.collect()?;
 
     // assert that the df only contains [vegetables, seafood]
-    let s = df.column("category")?.unique()?.sort(false);
+    let s = df.column("category")?.unique()?.sort(false)?;
     let expected = Series::new("category", &["seafood", "vegetables"]);
     assert!(s.equals(&expected));
     Ok(())

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -282,8 +282,11 @@ impl PySeries {
         }
     }
 
-    fn sort(&mut self, descending: bool) -> Self {
-        self.series.sort(descending).into()
+    fn sort(&mut self, descending: bool) -> PyResult<Self> {
+        match self.series.sort(descending) {
+            Ok(sorted) => Ok(sorted.into()),
+            Err(e) => Err(PyPolarsErr::from(e).into()),
+        }
     }
 
     fn take_with_series(&self, indices: &PySeries) -> PyResult<Self> {


### PR DESCRIPTION
fix #12956

I mimicked the implementation of `.unique()` on ObjectChunked objects to generate the error in the same way. This lead to a lot of changes and unwraps, since sort now return a Result.

was:
```
pyo3_runtime.PanicException: `sort_with` operation not supported for dtype `object`
pyo3_runtime.PanicException: `arg_sort` operation not supported for dtype `object`
```

now
```
polars.exceptions.InvalidOperationError: `sort_with` operation not supported for dtype `object`
polars.exceptions.InvalidOperationError: `arg_sort` operation not supported for dtype `object`
```
