### PR TITLE
feat(rust!): rename map to map_batches and appy to map_elements

### DIFF
--- a/crates/polars-lazy/src/dsl/eval.rs
+++ b/crates/polars-lazy/src/dsl/eval.rs
@@ -117,7 +117,7 @@ pub trait ExprEvalExtension: IntoExpr + Sized {
             }
         };
 
-        this.apply(
+        this.map_elements(
             func,
             GetOutput::map_field(move |f| eval_field_to_dtype(f, &expr2, false)),
         )

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -193,7 +193,7 @@ pub trait ListNameSpaceExtension: IntoListNameSpace + Sized {
         };
 
         this.0
-            .map(
+            .map_batches(
                 func,
                 GetOutput::map_field(move |f| eval_field_to_dtype(f, &expr2, true)),
             )

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1571,7 +1571,7 @@ impl LazyFrame {
     /// The function has access to the whole materialized DataFrame at the time it is
     /// called.
     ///
-    /// To apply specific functions to specific columns, use [`Expr::map`] in conjunction
+    /// To apply specific functions to specific columns, use [`Expr::map_batches`] in conjunction
     /// with `LazyFrame::with_column` or `with_columns`.
     ///
     /// ## Warning

--- a/crates/polars-lazy/src/lib.rs
+++ b/crates/polars-lazy/src/lib.rs
@@ -146,7 +146,7 @@
 //!     .with_column(
 //!         col("column_a")
 //!         // apply a custom closure Series => Result<Series>
-//!         .map(|_s| {
+//!         .map_batches(|_s| {
 //!             Ok(Some(Series::new("", &[6.0f32, 6.0, 6.0, 6.0, 6.0])))
 //!         },
 //!         // return type of the closure

--- a/crates/polars-lazy/src/tests/aggregations.rs
+++ b/crates/polars-lazy/src/tests/aggregations.rs
@@ -31,7 +31,7 @@ fn test_agg_exprs() -> PolarsResult<()> {
         .lazy()
         .group_by_stable([col("cars")])
         .agg([(lit(1) - col("A"))
-            .map(|s| Ok(Some(&s * 2)), GetOutput::same_type())
+            .map_batches(|s| Ok(Some(&s * 2)), GetOutput::same_type())
             .alias("foo")])
         .collect()?;
     let ca = out.column("foo")?.list()?;

--- a/crates/polars-lazy/src/tests/optimization_checks.rs
+++ b/crates/polars-lazy/src/tests/optimization_checks.rs
@@ -319,7 +319,7 @@ fn test_lazy_filter_and_rename() {
         .clone()
         .lazy()
         .rename(["a"], ["x"])
-        .filter(col("x").map(
+        .filter(col("x").map_batches(
             |s: Series| Ok(Some(s.gt(3)?.into_series())),
             GetOutput::from_type(DataType::Boolean),
         ))
@@ -332,7 +332,7 @@ fn test_lazy_filter_and_rename() {
     assert!(lf.collect().unwrap().equals(&correct));
 
     // now we check if the column is rename or added when we don't select
-    let lf = df.lazy().rename(["a"], ["x"]).filter(col("x").map(
+    let lf = df.lazy().rename(["a"], ["x"]).filter(col("x").map_batches(
         |s: Series| Ok(Some(s.gt(3)?.into_series())),
         GetOutput::from_type(DataType::Boolean),
     ));

--- a/crates/polars-lazy/src/tests/predicate_queries.rs
+++ b/crates/polars-lazy/src/tests/predicate_queries.rs
@@ -71,7 +71,7 @@ fn test_pass_unrelated_apply() -> PolarsResult<()> {
 
     let q = df
         .lazy()
-        .with_column(col("A").map(
+        .with_column(col("A").map_batches(
             |s| Ok(Some(s.is_null().into_series())),
             GetOutput::from_type(DataType::Boolean),
         ))

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -90,7 +90,7 @@ fn test_lazy_udf() {
     let df = get_df();
     let new = df
         .lazy()
-        .select([col("sepal.width").map(|s| Ok(Some(s * 200.0)), GetOutput::same_type())])
+        .select([col("sepal.width").map_batches(|s| Ok(Some(s * 200.0)), GetOutput::same_type())])
         .collect()
         .unwrap();
     assert_eq!(
@@ -222,7 +222,7 @@ fn test_lazy_query_2() {
     let df = load_df();
     let ldf = df
         .lazy()
-        .with_column(col("a").map(|s| Ok(Some(s * 2)), GetOutput::same_type()))
+        .with_column(col("a").map_batches(|s| Ok(Some(s * 2)), GetOutput::same_type()))
         .filter(col("a").lt(lit(2)))
         .select([col("b"), col("a")]);
 
@@ -258,7 +258,7 @@ fn test_lazy_query_4() {
         .agg([
             col("day").alias("day"),
             col("cumcases")
-                .apply(
+                .map_elements(
                     |s: Series| Ok(Some(&s - &(s.shift(1)))),
                     GetOutput::same_type(),
                 )
@@ -697,7 +697,7 @@ fn test_lazy_group_by_apply() {
 
     df.lazy()
         .group_by([col("fruits")])
-        .agg([col("cars").apply(
+        .agg([col("cars").map_elements(
             |s: Series| Ok(Some(Series::new("", &[s.len() as u32]))),
             GetOutput::same_type(),
         )])

--- a/crates/polars-plan/src/dsl/functions/arity.rs
+++ b/crates/polars-plan/src/dsl/functions/arity.rs
@@ -24,7 +24,7 @@ where
 
 /// Like [`map_binary`], but used in a group_by-aggregation context.
 ///
-/// See [`Expr::apply`] for the difference between [`map`](Expr::map) and [`apply`](Expr::apply).
+/// See [`Expr::map_elements`] for the difference between [`map_batches`](Expr::map_batches) and [`map_elements`](Expr::map_elements).
 pub fn apply_binary<F: 'static>(a: Expr, b: Expr, f: F, output_type: GetOutput) -> Expr
 where
     F: Fn(Series, Series) -> PolarsResult<Option<Series>> + Send + Sync,

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -258,7 +258,7 @@ impl ListNameSpace {
         let out_dtype = Arc::new(RwLock::new(None::<DataType>));
 
         self.0
-            .map(
+            .map_batches(
                 move |s| {
                     s.list()?
                         .to_struct(n_fields, name_generator.clone())

--- a/crates/polars/tests/it/lazy/expressions/arity.rs
+++ b/crates/polars/tests/it/lazy/expressions/arity.rs
@@ -53,7 +53,7 @@ fn includes_null_predicate_3038() -> PolarsResult<()> {
     let res = df
         .lazy()
         .with_column(
-            when(col("a").map(
+            when(col("a").map_batches(
                 move |s| {
                     s.utf8()?
                         .to_lowercase()
@@ -83,7 +83,7 @@ fn includes_null_predicate_3038() -> PolarsResult<()> {
     let res = df
         .lazy()
         .with_column(
-            when(col("b").map(
+            when(col("b").map_batches(
                 move |s| {
                     s.utf8()?
                         .to_lowercase()

--- a/crates/polars/tests/it/lazy/expressions/filter.rs
+++ b/crates/polars/tests/it/lazy/expressions/filter.rs
@@ -26,7 +26,7 @@ fn test_filter_in_group_by_agg() -> PolarsResult<()> {
         .group_by([col("a")])
         .agg([(col("b")
             .filter(col("b").eq(lit(100)))
-            .map(|v| Ok(Some(v)), GetOutput::same_type()))
+            .map_batches(|v| Ok(Some(v)), GetOutput::same_type()))
         .mean()
         .alias("b_mean")])
         .collect()?;

--- a/docs/src/rust/user-guide/expressions/user-defined-functions.rs
+++ b/docs/src/rust/user-guide/expressions/user-defined-functions.rs
@@ -13,7 +13,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .group_by(["keys"])
         .agg([
             col("values")
-                .map(|s| Ok(Some(s.shift(1))), GetOutput::default())
+                .map_batches(|s| Ok(Some(s.shift(1))), GetOutput::default())
                 .alias("shift_map"),
             col("values").shift(lit(1)).alias("shift_expression"),
         ])
@@ -29,7 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .group_by([col("keys")])
         .agg([
             col("values")
-                .apply(|s| Ok(Some(s.shift(1))), GetOutput::default())
+                .map_elements(|s| Ok(Some(s.shift(1))), GetOutput::default())
                 .alias("shift_map"),
             col("values").shift(lit(1)).alias("shift_expression"),
         ])
@@ -48,7 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // pack to struct to get access to multiple fields in a custom `apply/map`
             as_struct(vec![col("keys"), col("values")])
                 // we will compute the len(a) + b
-                .apply(
+                .map_elements(
                     |s| {
                         // downcast to struct
                         let ca = s.struct_()?;

--- a/docs/src/rust/user-guide/transformations/time-series/rolling.rs
+++ b/docs/src/rust/user-guide/transformations/time-series/rolling.rs
@@ -82,7 +82,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .reverse()
                 .head(Some(3))
                 .alias("day/eom"),
-            ((col("time").last() - col("time").first()).map(
+            ((col("time").last() - col("time").first()).map_batches(
                 // had to use map as .duration().days() is not available
                 |s| {
                     Ok(Some(

--- a/py-polars/src/expr/datetime.rs
+++ b/py-polars/src/expr/datetime.rs
@@ -17,7 +17,7 @@ impl PyExpr {
     fn dt_epoch_seconds(&self) -> Self {
         self.inner
             .clone()
-            .map(
+            .map_batches(
                 |s| {
                     s.timestamp(TimeUnit::Milliseconds)
                         .map(|ca| Some((ca / 1000).into_series()))
@@ -144,7 +144,7 @@ impl PyExpr {
     fn dt_total_days(&self) -> Self {
         self.inner
             .clone()
-            .map(
+            .map_batches(
                 |s| Ok(Some(s.duration()?.days().into_series())),
                 GetOutput::from_type(DataType::Int64),
             )
@@ -153,7 +153,7 @@ impl PyExpr {
     fn dt_total_hours(&self) -> Self {
         self.inner
             .clone()
-            .map(
+            .map_batches(
                 |s| Ok(Some(s.duration()?.hours().into_series())),
                 GetOutput::from_type(DataType::Int64),
             )
@@ -162,7 +162,7 @@ impl PyExpr {
     fn dt_total_minutes(&self) -> Self {
         self.inner
             .clone()
-            .map(
+            .map_batches(
                 |s| Ok(Some(s.duration()?.minutes().into_series())),
                 GetOutput::from_type(DataType::Int64),
             )
@@ -171,7 +171,7 @@ impl PyExpr {
     fn dt_total_seconds(&self) -> Self {
         self.inner
             .clone()
-            .map(
+            .map_batches(
                 |s| Ok(Some(s.duration()?.seconds().into_series())),
                 GetOutput::from_type(DataType::Int64),
             )
@@ -180,7 +180,7 @@ impl PyExpr {
     fn dt_total_milliseconds(&self) -> Self {
         self.inner
             .clone()
-            .map(
+            .map_batches(
                 |s| Ok(Some(s.duration()?.milliseconds().into_series())),
                 GetOutput::from_type(DataType::Int64),
             )
@@ -189,7 +189,7 @@ impl PyExpr {
     fn dt_total_microseconds(&self) -> Self {
         self.inner
             .clone()
-            .map(
+            .map_batches(
                 |s| Ok(Some(s.duration()?.microseconds().into_series())),
                 GetOutput::from_type(DataType::Int64),
             )
@@ -198,7 +198,7 @@ impl PyExpr {
     fn dt_total_nanoseconds(&self) -> Self {
         self.inner
             .clone()
-            .map(
+            .map_batches(
                 |s| Ok(Some(s.duration()?.nanoseconds().into_series())),
                 GetOutput::from_type(DataType::Int64),
             )

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -360,7 +360,7 @@ impl PyExpr {
         Ok(self
             .inner
             .clone()
-            .apply(
+            .map_elements(
                 move |s| s.fill_null(strat).map(Some),
                 GetOutput::same_type(),
             )
@@ -419,7 +419,7 @@ impl PyExpr {
     fn gather_every(&self, n: usize) -> Self {
         self.inner
             .clone()
-            .map(
+            .map_batches(
                 move |s: Series| {
                     polars_ensure!(n > 0, InvalidOperation: "gather_every(n): n can't be zero");
                     Ok(Some(s.gather_every(n)))
@@ -448,7 +448,7 @@ impl PyExpr {
     fn rechunk(&self) -> Self {
         self.inner
             .clone()
-            .map(|s| Ok(Some(s.rechunk())), GetOutput::same_type())
+            .map_batches(|s| Ok(Some(s.rechunk())), GetOutput::same_type())
             .into()
     }
 
@@ -689,7 +689,7 @@ impl PyExpr {
         };
         self.inner
             .clone()
-            .map(function, GetOutput::from_type(dt))
+            .map_batches(function, GetOutput::from_type(dt))
             .into()
     }
     fn mode(&self) -> Self {
@@ -823,7 +823,7 @@ impl PyExpr {
         let value = value.into_py(py);
         self.inner
             .clone()
-            .apply(
+            .map_elements(
                 move |s| {
                     Python::with_gil(|py| {
                         let value = value.extract::<Wrap<AnyValue>>(py).unwrap().0;

--- a/py-polars/src/expr/string.rs
+++ b/py-polars/src/expr/string.rs
@@ -226,7 +226,7 @@ impl PyExpr {
         };
         self.inner
             .clone()
-            .map(function, GetOutput::from_type(DataType::Utf8))
+            .map_batches(function, GetOutput::from_type(DataType::Utf8))
             .with_fmt("str.json_path_match")
             .into()
     }


### PR DESCRIPTION
Noticed while looking into #13071 - the Rust names are still `map` and `apply`