### PR TITLE
docs: take pl.concat out of StringCache context manager in "mismatched string cache" error message

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -232,8 +232,8 @@ Help: if you're using Python, this may look something like:
         # Initialize Categoricals.
         df1 = pl.DataFrame({'a': ['1', '2']}, schema={'a': pl.Categorical})
         df2 = pl.DataFrame({'a': ['1', '3']}, schema={'a': pl.Categorical})
-        # Your operations go here.
-        pl.concat([df1, df2])
+    # Your operations go here.
+    pl.concat([df1, df2])
 
 Alternatively, if the performance cost is acceptable, you could just set:
 


### PR DESCRIPTION
the context manager is only needed for initialising the categories, operations can be done outside of it