### PR TITLE
fix: rolling_quantile can get incorrect state

### DIFF
--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -831,3 +831,18 @@ def test_rolling_median() -> None:
             assert_series_equal(
                 a.rolling_median(k), pl.from_pandas(a.to_pandas().rolling(k).median())
             )
+
+
+@pytest.mark.slow()
+def test_rolling_median_2() -> None:
+    np.random.seed(12)
+    n = 1000
+    df = pl.DataFrame({"x": np.random.normal(0, 1, n)})
+    assert (
+        df.select(pl.col("x").rolling_median(window_size=10).sum()).item()
+        == 5.139429061527812
+    )
+    assert (
+        df.select(pl.col("x").rolling_median(window_size=100).sum()).item()
+        == 26.60506093611384
+    )

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -838,11 +838,10 @@ def test_rolling_median_2() -> None:
     np.random.seed(12)
     n = 1000
     df = pl.DataFrame({"x": np.random.normal(0, 1, n)})
-    assert (
-        df.select(pl.col("x").rolling_median(window_size=10).sum()).item()
-        == 5.139429061527812
-    )
-    assert (
-        df.select(pl.col("x").rolling_median(window_size=100).sum()).item()
-        == 26.60506093611384
-    )
+    # this can differ because simd sizes and non-associativity of floats.
+    assert df.select(
+        pl.col("x").rolling_median(window_size=10).sum()
+    ).item() == pytest.approx(5.139429061527812)
+    assert df.select(
+        pl.col("x").rolling_median(window_size=100).sum()
+    ).item() == pytest.approx(26.60506093611384)


### PR DESCRIPTION
This needs a patch. The rolling quantile introduced a rather complicated algorithm and got in a incorrect state. This fixes that.