### PR TITLE
fix(rust): use `FunctionExpr`'s scalar return type for `is_in`

### DIFF
--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1025,7 +1025,7 @@ impl Expr {
         let has_literal = has_leaf_literal(&other);
 
         // lit(true).is_in() returns a scalar.
-        let returns_scalar = all_leaf_literal(&self);
+        let returns_scalar = all_return_scalar(&self);
 
         let arguments = &[other];
         // we don't have to apply on groups, so this is faster

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -148,11 +148,12 @@ pub(crate) fn has_leaf_literal(e: &Expr) -> bool {
         },
     }
 }
-/// Check if leaf expression is a literal
+/// Check if leaf expression returns a scalar
 #[cfg(feature = "is_in")]
-pub(crate) fn all_leaf_literal(e: &Expr) -> bool {
+pub(crate) fn all_return_scalar(e: &Expr) -> bool {
     match e {
         Expr::Literal(_) => true,
+        Expr::Function { options: opt, .. } => opt.returns_scalar,
         _ => {
             let roots = expr_to_root_column_exprs(e);
             roots.iter().all(|e| matches!(e, Expr::Literal(_)))

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -1,7 +1,6 @@
 use std::fmt::Formatter;
 use std::iter::FlatMap;
 use std::sync::Arc;
-use std::vec::IntoIter;
 
 use polars_core::prelude::*;
 use smartstring::alias::String as SmartString;
@@ -142,22 +141,18 @@ where
 pub(crate) fn has_leaf_literal(e: &Expr) -> bool {
     match e {
         Expr::Literal(_) => true,
-        _ => {
-            let roots = expr_to_root_column_exprs(e);
-            roots.iter().any(|e| matches!(e, Expr::Literal(_)))
-        },
+        _ => expr_to_leaf_column_exprs_iter(e).any(|e| matches!(e, Expr::Literal(_))),
     }
 }
 /// Check if leaf expression returns a scalar
 #[cfg(feature = "is_in")]
 pub(crate) fn all_return_scalar(e: &Expr) -> bool {
     match e {
-        Expr::Literal(_) => true,
+        Expr::Literal(lv) => lv.projects_as_scalar(),
         Expr::Function { options: opt, .. } => opt.returns_scalar,
-        _ => {
-            let roots = expr_to_root_column_exprs(e);
-            roots.iter().all(|e| matches!(e, Expr::Literal(_)))
-        },
+        Expr::Agg(_) => true,
+        Expr::Column(_) => false,
+        _ => expr_to_leaf_column_exprs_iter(e).all(all_return_scalar),
     }
 }
 
@@ -219,12 +214,8 @@ pub(crate) fn get_single_leaf(expr: &Expr) -> PolarsResult<Arc<str>> {
 }
 
 #[allow(clippy::type_complexity)]
-pub fn expr_to_leaf_column_names_iter(
-    expr: &Expr,
-) -> FlatMap<IntoIter<Expr>, Option<Arc<str>>, fn(Expr) -> Option<Arc<str>>> {
-    expr_to_root_column_exprs(expr)
-        .into_iter()
-        .flat_map(|e| expr_to_leaf_column_name(&e).ok())
+pub fn expr_to_leaf_column_names_iter(expr: &Expr) -> impl Iterator<Item = Arc<str>> + '_ {
+    expr_to_leaf_column_exprs_iter(expr).flat_map(|e| expr_to_leaf_column_name(e).ok())
 }
 
 /// This should gradually replace expr_to_root_column as this will get all names in the tree.
@@ -234,10 +225,10 @@ pub fn expr_to_leaf_column_names(expr: &Expr) -> Vec<Arc<str>> {
 
 /// unpack alias(col) to name of the root column name
 pub fn expr_to_leaf_column_name(expr: &Expr) -> PolarsResult<Arc<str>> {
-    let mut roots = expr_to_root_column_exprs(expr);
-    polars_ensure!(roots.len() <= 1, ComputeError: "found more than one root column name");
-    match roots.pop() {
-        Some(Expr::Column(name)) => Ok(name),
+    let mut leaves = expr_to_leaf_column_exprs_iter(expr).collect::<Vec<_>>();
+    polars_ensure!(leaves.len() <= 1, ComputeError: "found more than one root column name");
+    match leaves.pop() {
+        Some(Expr::Column(name)) => Ok(name.clone()),
         Some(Expr::Wildcard) => polars_bail!(
             ComputeError: "wildcard has no root column name",
         ),
@@ -317,16 +308,12 @@ pub(crate) fn aexpr_assign_renamed_leaf(
     panic!("should be a root column that is renamed");
 }
 
-/// Get all root column expressions in the expression tree.
-pub(crate) fn expr_to_root_column_exprs(expr: &Expr) -> Vec<Expr> {
-    let mut out = vec![];
-    expr.into_iter().for_each(|e| match e {
-        Expr::Column(_) | Expr::Wildcard => {
-            out.push(e.clone());
-        },
-        _ => {},
-    });
-    out
+/// Get all leaf column expressions in the expression tree.
+pub(crate) fn expr_to_leaf_column_exprs_iter(expr: &Expr) -> impl Iterator<Item = &Expr> {
+    expr.into_iter().flat_map(|e| match e {
+        Expr::Column(_) | Expr::Wildcard => Some(e),
+        _ => None,
+    })
 }
 
 /// Take a list of expressions and a schema and determine the output schema.

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -222,3 +222,23 @@ def test_is_in_null_series() -> None:
     result = df.select(pl.col("a").is_in([None]))
     expected = pl.DataFrame({"a": [False, False, None]})
     assert_frame_equal(result, expected)
+
+
+def test_is_in_int_range() -> None:
+    r = pl.int_range(0, 3, eager=False)
+    out = pl.select(r.is_in([1, 2])).to_series()
+    assert out.to_list() == [False, True, True]
+
+    r = pl.int_range(0, 3, eager=True)  # type: ignore[assignment]
+    out = r.is_in([1, 2])  # type: ignore[assignment]
+    assert out.to_list() == [False, True, True]
+
+
+def test_is_in_date_range() -> None:
+    r = pl.date_range(date(2023, 1, 1), date(2023, 1, 3), eager=False)
+    out = pl.select(r.is_in([date(2023, 1, 2), date(2023, 1, 3)])).to_series()
+    assert out.to_list() == [False, True, True]
+
+    r = pl.date_range(date(2023, 1, 1), date(2023, 1, 3), eager=True)  # type: ignore[assignment]
+    out = r.is_in([date(2023, 1, 2), date(2023, 1, 3)])  # type: ignore[assignment]
+    assert out.to_list() == [False, True, True]


### PR DESCRIPTION
Resolves #13084

The function is called `all_leaf_literal` but its intent is to determine whether a scalar should be returned (the only place this function is ever called is in the `is_in` function:

```python
// lit(true).is_in() returns a scalar.
let returns_scalar = all_leaf_literal(&self);
```

This function was returning true ([here](https://github.com/pola-rs/polars/blob/main/crates/polars-plan/src/utils.rs#L151-L161)) when there were no leaf literals because `all([]) == true`, as is the case when self is a `Range` expr. If our node is a `Function` we should look up whether it's expected to return a scalar.