### PR TITLE
perf(python): add LRU cache to `is_polars_dtype`

### DIFF
--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -138,6 +138,7 @@ def _map_py_type_to_dtype(
     raise TypeError("invalid type")
 
 
+@functools.lru_cache
 def is_polars_dtype(dtype: Any, *, include_unknown: bool = False) -> bool:
     """Indicate whether the given input is a Polars dtype, or dtype specialisation."""
     try:


### PR DESCRIPTION
`pl.datatypes.is_polars_dtype` is called frequently, e.g. during DataFrame construction. Even though, each single call is lightweight, this adds unnecessary overhead. The range of arguments passed is fairly limited, which lends itself to caching.

Narrow benchmark shows 2.5x improvement:
```
python -m timeit -s "import polars as pl" "pl.datatypes.is_polars_dtype(pl.Float64)"
```

Dataframe construction benchmark shows 5% improvement:
```
python -m timeit -s "import polars as pl; N = 10000; schema = {f'col_{i}': pl.Float64 for i in range(N)}; data = tuple(tuple(range(100)) for _ in range(N))" "pl.DataFrame(data, schema=schema)"
```