### PR TITLE
fix: Don't check map length if input is literal

### DIFF
--- a/crates/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -423,7 +423,8 @@ fn apply_multiple_elementwise<'a>(
             ac.with_series(out.into_series(), true, None)?;
             Ok(ac)
         },
-        _ => {
+        first_as => {
+            let check_lengths = check_lengths && !matches!(first_as, AggState::Literal(_));
             let mut s = acs
                 .iter_mut()
                 .enumerate()

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -851,3 +851,12 @@ def test_group_by_when_then_no_aggregation_predicate() -> None:
         "pos": [5, 5],
         "neg": [-8, 0],
     }
+
+
+def test_group_by_apply_first_input_is_literal() -> None:
+    df = pl.DataFrame({"x": [1, 2, 3, 4, 5], "g": [1, 1, 2, 2, 2]})
+    pow = df.group_by("g").agg(2 ** pl.col("x"))
+    assert pow.sort("g").to_dict(as_series=False) == {
+        "g": [1, 2],
+        "x": [[2.0, 4.0], [8.0, 16.0, 32.0]],
+    }


### PR DESCRIPTION
This fixes #13082.