### PR TITLE
chore: Update `auto_explode` param name to `returns_scalar`

### DIFF
--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -620,7 +620,7 @@ impl Expr {
         self,
         function_expr: FunctionExpr,
         arguments: &[Expr],
-        auto_explode: bool,
+        returns_scalar: bool,
         cast_to_supertypes: bool,
     ) -> Self {
         let mut input = Vec::with_capacity(arguments.len() + 1);
@@ -632,7 +632,7 @@ impl Expr {
             function: function_expr,
             options: FunctionOptions {
                 collect_groups: ApplyOptions::GroupWise,
-                returns_scalar: auto_explode,
+                returns_scalar,
                 cast_to_supertypes,
                 ..Default::default()
             },

--- a/py-polars/tests/unit/namespaces/string/test_string.py
+++ b/py-polars/tests/unit/namespaces/string/test_string.py
@@ -558,11 +558,10 @@ def test_extract_binary() -> None:
     assert out[0] == "aron"
 
 
-def test_auto_explode() -> None:
+def test_str_concat_returns_scalar() -> None:
     df = pl.DataFrame(
         [pl.Series("val", ["A", "B", "C", "D"]), pl.Series("id", [1, 1, 2, 2])]
     )
-    pl.col("val").str.concat(delimiter=",")
     grouped = (
         df.group_by("id")
         .agg(pl.col("val").str.concat(delimiter=",").alias("grouped"))


### PR DESCRIPTION
Minor clean up. remove the legacy param name `auto_explode`.