### PR TITLE
perf(python): drop the pyarrow conversion path in `iter_rows`; we can now do fully native conversion ~2-3x faster

### DIFF
--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -23,9 +23,8 @@ from polars.datatypes import (
     Int64,
     Time,
     Utf8,
-    unpack_dtypes,
 )
-from polars.dependencies import _PYARROW_AVAILABLE, _check_for_numpy
+from polars.dependencies import _check_for_numpy
 from polars.dependencies import numpy as np
 
 if TYPE_CHECKING:
@@ -208,18 +207,6 @@ def arrlen(obj: Any) -> int | None:
         return None if isinstance(obj, str) else len(obj)
     except TypeError:
         return None
-
-
-def can_create_dicts_with_pyarrow(dtypes: Sequence[PolarsDataType]) -> bool:
-    """Check if the given dtypes can be used to create dicts with pyarrow fast path."""
-    # TODO: have our own fast-path for dict iteration in Rust
-    return (
-        _PYARROW_AVAILABLE
-        # note: 'ns' precision instantiates values as pandas types - avoid
-        and not any(
-            (getattr(tp, "time_unit", None) == "ns") for tp in unpack_dtypes(*dtypes)
-        )
-    )
 
 
 def normalize_filepath(path: str | Path, *, check_not_directory: bool = True) -> str:


### PR DESCRIPTION
Closes #13097.

Several wins here:

* Can drop the pyarrow[^1] conversion path completely, omitting another implicit (though optional) legacy dependency.
* We can do this because new benchmarking shows fully-native conversion to dicts is now ~2-3x faster than pyarrow  ;)

## Example

Using the schema provided in the linked issue:

```python
from datetime import datetime
import polars as pl

df = pl.DataFrame({
    "Col0": range(60_000),
    "Col1": datetime.now(),
    "Col2": "xxx",
    "Col3": "yyy",
    "Col4": "zzz",
    "Col5": 5.5,
    "Col6": 6.6,
    "Col7": 7.7,
    "Col8": "!!!",
    "Col9": "###",
})

%timeit df.to_dicts()
# 91.6 ms ± 926 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit list(df.iter_rows(named=True))
# 90.5 ms ± 601 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit df.to_arrow().to_pylist()
# 262 ms ± 3.81 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
The last of those used to be a fast path inside `iter_rows`; since then our own/native conversion has become a lot more streamlined and it is now a slow path - in light of the above timings I've been able to drop it completely, simplifying the code _and_ speeding things up ;)

[^1]: Note that pyarrow wasn't required here; would only be used is already installed.
