### PR TITLE
chore(python): Update ruff & ruff settings

### DIFF
--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -111,7 +111,7 @@ def _normalise_numpy_dtype(dtype: Any) -> tuple[Any, Any]:
 
 
 def numpy_values_and_dtype(
-    values: np.ndarray[Any, Any]
+    values: np.ndarray[Any, Any],
 ) -> tuple[np.ndarray[Any, Any], type]:
     """Return numpy values and their associated dtype, adjusting if required."""
     # Create new dtype object from dtype base name so architecture specific

--- a/py-polars/polars/io/spreadsheet/_write_utils.py
+++ b/py-polars/polars/io/spreadsheet/_write_utils.py
@@ -89,7 +89,7 @@ def _adjacent_cols(df: DataFrame, cols: Iterable[str], min_max: dict[str, Any]) 
 
 
 def _unpack_multi_column_dict(
-    d: dict[str | Sequence[str], Any] | Any
+    d: dict[str | Sequence[str], Any] | Any,
 ) -> dict[str, Any] | Any:
     """Unpack multi-col dictionary into equivalent single-col definitions."""
     if not isinstance(d, dict):
@@ -495,7 +495,7 @@ def _xl_setup_table_columns(
 
 
 def _xl_setup_table_options(
-    table_style: dict[str, Any] | str | None
+    table_style: dict[str, Any] | str | None,
 ) -> tuple[dict[str, Any] | str | None, dict[str, Any]]:
     """Setup table options, distinguishing style name from other formatting."""
     if isinstance(table_style, dict):

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -130,6 +130,9 @@ select = [
   "B", # flake8-bugbear
   "C4", # flake8-comprehensions
   "D", # flake8-docstrings
+  "D213", # Augment NumPy docstring convention: Multi-line docstring summary should start at the second line
+  "D413", # Augment NumPy docstring convention: Missing blank line after last section
+  "D417", # Augment NumPy docstring convention: Missing argument descriptions
   "I", # isort
   "SIM", # flake8-simplify
   "TCH", # flake8-type-checking
@@ -149,14 +152,7 @@ ignore = [
   # Line length regulated by formatter
   "E501",
   # pydocstyle: http://www.pydocstyle.org/en/stable/error_codes.html
-  # numpy convention with a few additional lints
-  "D107",
-  "D203",
-  "D212",
-  "D401",
-  "D402",
-  "D415",
-  "D416",
+  "D401", # Relax NumPy docstring convention: First line should be in imperative mood
   # flake8-pytest-style:
   "PT011", # pytest.raises({exception}) is too broad, set the match parameter or use a more specific exception
   # flake8-simplify
@@ -179,9 +175,11 @@ ignore = [
   "D206",
   "W191",
 ]
-
 [tool.ruff.pycodestyle]
 max-doc-length = 88
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
 
 [tool.ruff.flake8-tidy-imports]
 ban-relative-imports = "all"

--- a/py-polars/requirements-lint.txt
+++ b/py-polars/requirements-lint.txt
@@ -1,4 +1,4 @@
 blackdoc==0.3.8
 mypy==1.7.1
-ruff==0.1.3
+ruff==0.1.9
 typos==1.16.21

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -31,7 +31,7 @@ def permutations_int_dec_none() -> list[tuple[D | int | None, ...]]:
 
 @pytest.mark.slow()
 def test_series_from_pydecimal_and_ints(
-    permutations_int_dec_none: list[tuple[D | int | None, ...]]
+    permutations_int_dec_none: list[tuple[D | int | None, ...]],
 ) -> None:
     # TODO: check what happens if there are strings, floats arrow scalars in the list
     for data in permutations_int_dec_none:

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -251,7 +251,7 @@ def test_equality_missing_enum_none_scalar() -> None:
 
 @pytest.mark.parametrize(("op"), [operator.le, operator.lt, operator.ge, operator.gt])
 def test_compare_enum_str_single_raise(
-    op: Callable[[pl.Series, pl.Series], pl.Series]
+    op: Callable[[pl.Series, pl.Series], pl.Series],
 ) -> None:
     s = pl.Series(
         [None, "HIGH", "MEDIUM", "LOW"], dtype=pl.Enum(["LOW", "MEDIUM", "HIGH"])

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -483,7 +483,7 @@ def test_excel_round_trip(write_params: dict[str, Any]) -> None:
 
 @pytest.mark.parametrize("engine", ["xlsx2csv", "openpyxl"])
 def test_excel_compound_types(
-    engine: Literal["xlsx2csv", "openpyxl", "pyxlsb"]
+    engine: Literal["xlsx2csv", "openpyxl", "pyxlsb"],
 ) -> None:
     df = pl.DataFrame(
         {"x": [[1, 2], [3, 4], [5, 6]], "y": ["a", "b", "c"], "z": [9, 8, 7]}

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1498,7 +1498,7 @@ def test_compare_aggregation_between_lazy_and_eager_6904(
     ],
 )
 def test_lazy_comparison_operators(
-    comparators: tuple[str, Callable[[pl.LazyFrame, Any], NoReturn]]
+    comparators: tuple[str, Callable[[pl.LazyFrame, Any], NoReturn]],
 ) -> None:
     # we cannot compare lazy frames, so all should raise a TypeError
     with pytest.raises(


### PR DESCRIPTION
Newest ruff has a nicer way to specify docstring conventions.

Apparently, we also get some additional commas :)