### PR TITLE
fix: Update offsets of null value correctly for all `from_iter_xxx_trusted_len`

### DIFF
--- a/crates/polars-arrow/src/legacy/array/mod.rs
+++ b/crates/polars-arrow/src/legacy/array/mod.rs
@@ -29,6 +29,7 @@ macro_rules! iter_to_values {
                 },
                 None => {
                     $validity.push(false);
+                    $offsets.push($length_so_far);
                     None
                 },
             })
@@ -131,6 +132,7 @@ pub trait ListFromIter {
                 },
                 None => {
                     validity.push(false);
+                    offsets.push(length_so_far);
                     None
                 },
             })

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import date, datetime, time, timedelta
 from typing import Any
 
@@ -156,8 +158,17 @@ def test_repeat_by_logical_dtype() -> None:
         assert_frame_equal(out, expected_df)
 
 
-def test_repeat_by_none_13053() -> None:
-    df = pl.DataFrame({"x": ["a", "b", None], "by": [2, None, 3]})
+@pytest.mark.parametrize(
+    ("data", "expected_data"),
+    [
+        (["a", "b", None], [["a", "a"], None, [None, None, None]]),
+        ([1, 2, None], [[1, 1], None, [None, None, None]]),
+        ([1.1, 2.2, None], [[1.1, 1.1], None, [None, None, None]]),
+        ([True, False, None], [[True, True], None, [None, None, None]]),
+    ],
+)
+def test_repeat_by_none_13053(data: list[Any], expected_data: list[list[Any]]) -> None:
+    df = pl.DataFrame({"x": data, "by": [2, None, 3]})
     res = df.select(repeat=pl.col("x").repeat_by("by"))
-    expected = pl.Series("repeat", [["a", "a"], None, [None, None, None]])
+    expected = pl.Series("repeat", expected_data)
     assert_series_equal(res.to_series(), expected)


### PR DESCRIPTION
The same as #13105. Somehow I forgot to fix other similar branches. 😞 