### PR TITLE
docs: fix horizontal concatenation documentation

### DIFF
--- a/docs/src/python/user-guide/transformations/concatenation.py
+++ b/docs/src/python/user-guide/transformations/concatenation.py
@@ -50,6 +50,29 @@ df_horizontal_concat = pl.concat(
 print(df_horizontal_concat)
 # --8<-- [end:horizontal]
 
+# --8<-- [start:horizontal_different_lengths]
+df_h1 = pl.DataFrame(
+    {
+        "l1": [1, 2],
+        "l2": [3, 4],
+    }
+)
+df_h2 = pl.DataFrame(
+    {
+        "r1": [5, 6, 7],
+        "r2": [8, 9, 10],
+    }
+)
+df_horizontal_concat = pl.concat(
+    [
+        df_h1,
+        df_h2,
+    ],
+    how="horizontal",
+)
+print(df_horizontal_concat)
+# --8<-- [end:horizontal_different_lengths]
+
 # --8<-- [start:cross]
 df_d1 = pl.DataFrame(
     {

--- a/docs/src/rust/user-guide/transformations/concatenation.rs
+++ b/docs/src/rust/user-guide/transformations/concatenation.rs
@@ -33,6 +33,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let df_horizontal_concat = polars::functions::concat_df_horizontal(&[df_h1, df_h2])?;
     println!("{}", &df_horizontal_concat);
     // --8<-- [end:horizontal]
+    //
+    // --8<-- [start:horizontal_different_lengths]
+    let df_h1 = df!(
+            "l1"=> &[1, 2],
+            "l2"=> &[3, 4],
+    )?;
+    let df_h2 = df!(
+            "r1"=> &[5, 6, 7],
+            "r2"=> &[8, 9, 10],
+    )?;
+    let df_horizontal_concat = polars::functions::concat_df_horizontal(&[df_h1, df_h2])?;
+    println!("{}", &df_horizontal_concat);
+    // --8<-- [end:horizontal_different_lengths]
 
     // --8<-- [start:cross]
     let df_d1 = df!(

--- a/docs/user-guide/transformations/concatenation.md
+++ b/docs/user-guide/transformations/concatenation.md
@@ -3,7 +3,7 @@
 There are a number of ways to concatenate data from separate DataFrames:
 
 - two dataframes with **the same columns** can be **vertically** concatenated to make a **longer** dataframe
-- two dataframes with the **same number of rows** and **non-overlapping columns** can be **horizontally** concatenated to make a **wider** dataframe
+- two dataframes with **non-overlapping columns** can be **horizontally** concatenated to make a **wider** dataframe
 - two dataframes with **different numbers of rows and columns** can be **diagonally** concatenated to make a dataframe which might be longer and/ or wider. Where column names overlap values will be vertically concatenated. Where column names do not overlap new rows and columns will be added. Missing values will be set as `null`
 
 ## Vertical concatenation - getting longer
@@ -29,7 +29,15 @@ In a horizontal concatenation you combine all of the columns from a list of `Dat
 --8<-- "python/user-guide/transformations/concatenation.py:horizontal"
 ```
 
-Horizontal concatenation fails when dataframes have overlapping columns or a different number of rows.
+Horizontal concatenation fails when dataframes have overlapping columns.
+
+When dataframes have different numbers of rows, columns will be padded with `null` values at the end up to the maximum length.
+
+{{code_block('user-guide/transformations/concatenation','horizontal_different_lengths',['concat'])}}
+
+```python exec="on" result="text" session="user-guide/transformations/concatenation"
+--8<-- "python/user-guide/transformations/concatenation.py:horizontal_different_lengths"
+```
 
 ## Diagonal concatenation - getting longer, wider and `null`ier
 

--- a/docs/user-guide/transformations/concatenation.md
+++ b/docs/user-guide/transformations/concatenation.md
@@ -31,7 +31,8 @@ In a horizontal concatenation you combine all of the columns from a list of `Dat
 
 Horizontal concatenation fails when dataframes have overlapping columns.
 
-When dataframes have different numbers of rows, columns will be padded with `null` values at the end up to the maximum length.
+When dataframes have different numbers of rows,
+columns will be padded with `null` values at the end up to the maximum length.
 
 {{code_block('user-guide/transformations/concatenation','horizontal_different_lengths',['concat'])}}
 


### PR DESCRIPTION
The horizontal concatenation documentation in the user guide states that it is an error to concatenate DataFrames of different lengths, but columns will actually be padded with nulls at the end if lengths are different.