### PR TITLE
fix: Use the name of the leftmost expression in horizontal operations

### DIFF
--- a/crates/polars-ops/src/series/ops/horizontal.rs
+++ b/crates/polars-ops/src/series/ops/horizontal.rs
@@ -1,34 +1,14 @@
-use std::borrow::Cow;
 use std::ops::{BitAnd, BitOr};
 
+use polars_core::frame::NullStrategy;
 use polars_core::prelude::*;
 use polars_core::POOL;
 use rayon::prelude::*;
 
-pub fn sum_horizontal(s: &[Series]) -> PolarsResult<Series> {
-    let sum_fn = |acc: &Series, s: &Series| {
-        PolarsResult::Ok(
-            acc.fill_null(FillNullStrategy::Zero)? + s.fill_null(FillNullStrategy::Zero)?,
-        )
-    };
-    let out = match s.len() {
-        0 => Ok(UInt32Chunked::new("", &[0u32]).into_series()),
-        1 => Ok(s[0].clone()),
-        2 => sum_fn(&s[0], &s[1]),
-        _ => {
-            // the try_reduce_with is a bit slower in parallelism,
-            // but I don't think it matters here as we parallelize over series, not over elements
-            POOL.install(|| {
-                s.par_iter()
-                    .map(|s| Ok(Cow::Borrowed(s)))
-                    .try_reduce_with(|l, r| sum_fn(&l, &r).map(Cow::Owned))
-                    // we can unwrap the option, because we are certain there is a series
-                    .unwrap()
-                    .map(|cow| cow.into_owned())
-            })
-        },
-    };
-    out.map(|ok| ok.with_name("sum"))
+pub fn sum_horizontal(s: &[Series]) -> PolarsResult<Option<Series>> {
+    let df = DataFrame::new_no_checks(Vec::from(s));
+    df.sum_horizontal(NullStrategy::Ignore)
+        .map(|opt_s| opt_s.map(|res| res.with_name(s[0].name())))
 }
 
 pub fn any_horizontal(s: &[Series]) -> PolarsResult<Series> {
@@ -70,13 +50,13 @@ pub fn all_horizontal(s: &[Series]) -> PolarsResult<Series> {
 pub fn max_horizontal(s: &[Series]) -> PolarsResult<Option<Series>> {
     let df = DataFrame::new_no_checks(Vec::from(s));
     df.max_horizontal()
-        .map(|opt_s| opt_s.map(|s| s.with_name("max")))
+        .map(|opt_s| opt_s.map(|res| res.with_name(s[0].name())))
 }
 
 pub fn min_horizontal(s: &[Series]) -> PolarsResult<Option<Series>> {
     let df = DataFrame::new_no_checks(Vec::from(s));
     df.min_horizontal()
-        .map(|opt_s| opt_s.map(|s| s.with_name("min")))
+        .map(|opt_s| opt_s.map(|res| res.with_name(s[0].name())))
 }
 
 pub fn coalesce_series(s: &[Series]) -> PolarsResult<Series> {

--- a/crates/polars-plan/src/dsl/function_expr/dispatch.rs
+++ b/crates/polars-plan/src/dsl/function_expr/dispatch.rs
@@ -73,7 +73,7 @@ pub(super) fn forward_fill(s: &Series, limit: FillNullLimit) -> PolarsResult<Ser
     s.fill_null(FillNullStrategy::Forward(limit))
 }
 
-pub(super) fn sum_horizontal(s: &[Series]) -> PolarsResult<Series> {
+pub(super) fn sum_horizontal(s: &mut [Series]) -> PolarsResult<Option<Series>> {
     polars_ops::prelude::sum_horizontal(s)
 }
 

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -1027,7 +1027,7 @@ impl From<FunctionExpr> for SpecialEq<Arc<dyn SeriesUdf>> {
             },
             BackwardFill { limit } => map!(dispatch::backward_fill, limit),
             ForwardFill { limit } => map!(dispatch::forward_fill, limit),
-            SumHorizontal => map_as_slice!(dispatch::sum_horizontal),
+            SumHorizontal => wrap!(dispatch::sum_horizontal),
             MaxHorizontal => wrap!(dispatch::max_horizontal),
             MinHorizontal => wrap!(dispatch::min_horizontal),
             #[cfg(feature = "ewma")]

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -8349,7 +8349,7 @@ class DataFrame:
                 6.0
         ]
         """
-        return self.select(F.max_horizontal(F.all())).to_series()
+        return self.select(max=F.max_horizontal(F.all())).to_series()
 
     @overload
     def min(self, axis: Literal[0] | None = ...) -> Self:
@@ -8438,7 +8438,7 @@ class DataFrame:
                 3.0
         ]
         """
-        return self.select(F.min_horizontal(F.all())).to_series()
+        return self.select(min=F.min_horizontal(F.all())).to_series()
 
     @overload
     def sum(

--- a/py-polars/polars/functions/aggregation/horizontal.py
+++ b/py-polars/polars/functions/aggregation/horizontal.py
@@ -111,7 +111,7 @@ def max_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     ...         "c": ["x", "y", "z"],
     ...     }
     ... )
-    >>> df.with_columns(pl.max_horizontal("a", "b"))
+    >>> df.with_columns(max=pl.max_horizontal("a", "b"))
     shape: (3, 4)
     ┌─────┬──────┬─────┬─────┐
     │ a   ┆ b    ┆ c   ┆ max │
@@ -147,7 +147,7 @@ def min_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     ...         "c": ["x", "y", "z"],
     ...     }
     ... )
-    >>> df.with_columns(pl.min_horizontal("a", "b"))
+    >>> df.with_columns(min=pl.min_horizontal("a", "b"))
     shape: (3, 4)
     ┌─────┬──────┬─────┬─────┐
     │ a   ┆ b    ┆ c   ┆ min │
@@ -183,7 +183,7 @@ def sum_horizontal(*exprs: IntoExpr | Iterable[IntoExpr]) -> Expr:
     ...         "c": ["x", "y", "z"],
     ...     }
     ... )
-    >>> df.with_columns(pl.sum_horizontal("a", "b"))
+    >>> df.with_columns(sum=pl.sum_horizontal("a", "b"))
     shape: (3, 4)
     ┌─────┬──────┬─────┬─────┐
     │ a   ┆ b    ┆ c   ┆ sum │

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1601,7 +1601,7 @@ def select(*exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr) -> Da
     --------
     >>> foo = pl.Series("foo", [1, 2, 3])
     >>> bar = pl.Series("bar", [3, 2, 1])
-    >>> pl.select(pl.min_horizontal(foo, bar))
+    >>> pl.select(min=pl.min_horizontal(foo, bar))
     shape: (3, 1)
     ┌─────┐
     │ min │

--- a/py-polars/tests/unit/functions/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/functions/aggregation/test_horizontal.py
@@ -288,3 +288,32 @@ def test_horizontal_expr_use_left_name() -> None:
     assert df.select(pl.min_horizontal("b", "a")).columns == ["b"]
     assert df.select(pl.any_horizontal("b", "a")).columns == ["b"]
     assert df.select(pl.all_horizontal("a", "b")).columns == ["a"]
+
+
+def test_horizontal_broadcasting() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [1, 3],
+            "b": [3, 6],
+        }
+    )
+
+    assert_series_equal(
+        df.select(sum=pl.sum_horizontal(1, "a", "b")).to_series(),
+        pl.Series("sum", [5, 10]),
+    )
+    assert_series_equal(
+        df.select(max=pl.max_horizontal(4, "*")).to_series(), pl.Series("max", [4, 6])
+    )
+    assert_series_equal(
+        df.select(min=pl.min_horizontal(2, "b", "a")).to_series(),
+        pl.Series("min", [1, 2]),
+    )
+    assert_series_equal(
+        df.select(any=pl.any_horizontal(False, pl.Series([True, False]))).to_series(),
+        pl.Series("any", [True, False]),
+    )
+    assert_series_equal(
+        df.select(all=pl.all_horizontal(True, pl.Series([True, False]))).to_series(),
+        pl.Series("all", [True, False]),
+    )


### PR DESCRIPTION
As we discussed before, expression shouldn't have a specific name.