### PR TITLE
feat: prune all/any_horizontals with single inputs

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_functions.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_functions.rs
@@ -59,6 +59,13 @@ pub(super) fn optimize_functions(
                 None
             }
         },
+        FunctionExpr::Boolean(BooleanFunction::AllHorizontal | BooleanFunction::AnyHorizontal) => {
+            if input.len() == 1 {
+                Some(expr_arena.get(input[0]).clone())
+            } else {
+                None
+            }
+        },
         FunctionExpr::Boolean(BooleanFunction::Not) => {
             let y = expr_arena.get(input[0]);
 

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -414,3 +414,9 @@ def test_predicate_reduction() -> None:
         )
         .explain()
     )
+
+
+def test_all_any_cleanup_at_single_predicate_case() -> None:
+    plan = pl.LazyFrame({"a": [1], "b": [2]}).select(["a"]).drop_nulls().explain()
+    assert "horizontal" not in plan
+    assert "all" not in plan


### PR DESCRIPTION
This creates cleaner logical plans and makes might enable downstream optimizations to trigger.