### PR TITLE
feat: Implement `count` for DataFrame/LazyFrame

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1672,8 +1672,8 @@ impl LazyFrame {
     }
 
     /// Return the number of non-null elements in all the columns.
-    pub fn count(self) -> PolarsResult<LazyFrame> {
-        self.stats_helper(|dt| dt.is_ord(), |name| col(name).count())
+    pub fn count(self) -> LazyFrame {
+        self.select(vec![col("*").count()])
     }
 
     /// Unnest the given `Struct` columns: the fields of the `Struct` type will be

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1671,7 +1671,7 @@ impl LazyFrame {
         }
     }
 
-    /// Return the number of non-null elements in all the columns.
+    /// Return the number of non-null elements for each column.
     pub fn count(self) -> LazyFrame {
         self.select(vec![col("*").count()])
     }

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1671,6 +1671,11 @@ impl LazyFrame {
         }
     }
 
+    /// Return the number of non-null elements in all the columns.
+    pub fn count(self) -> PolarsResult<LazyFrame> {
+        self.stats_helper(|dt| dt.is_ord(), |name| col(name).count())
+    }
+
     /// Unnest the given `Struct` columns: the fields of the `Struct` type will be
     /// inserted as columns.
     #[cfg(feature = "dtype-struct")]

--- a/py-polars/docs/source/reference/dataframe/aggregation.rst
+++ b/py-polars/docs/source/reference/dataframe/aggregation.rst
@@ -6,6 +6,7 @@ Aggregation
 .. autosummary::
    :toctree: api/
 
+    DataFrame.count
     DataFrame.max
     DataFrame.max_horizontal
     DataFrame.mean

--- a/py-polars/docs/source/reference/lazyframe/aggregation.rst
+++ b/py-polars/docs/source/reference/lazyframe/aggregation.rst
@@ -6,6 +6,7 @@ Aggregation
 .. autosummary::
    :toctree: api/
 
+    LazyFrame.count
     LazyFrame.max
     LazyFrame.mean
     LazyFrame.median

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10398,6 +10398,27 @@ class DataFrame:
             .collect(_eager=True)
         )
 
+    def count(self) -> DataFrame:
+        """
+        Return the number of non-null elements in all the columns.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {"a": [1, 2, 3, 4], "b": [1, 2, 1, None], "c": [None, None, None, None]}
+        ... )
+        >>> df.count()
+        shape: (1, 3)
+        ┌─────┬─────┬─────┐
+        │ a   ┆ b   ┆ c   │
+        │ --- ┆ --- ┆ --- │
+        │ u32 ┆ u32 ┆ u32 │
+        ╞═════╪═════╪═════╡
+        │ 4   ┆ 3   ┆ 0   │
+        └─────┴─────┴─────┘
+        """
+        return self.lazy().count().collect(_eager=True)
+
     @deprecate_renamed_function("group_by", version="0.19.0")
     def groupby(
         self,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10400,7 +10400,7 @@ class DataFrame:
 
     def count(self) -> DataFrame:
         """
-        Return the number of non-null elements in all the columns.
+        Return the number of non-null elements for each column.
 
         Examples
         --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5889,7 +5889,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ┌─────┬─────┬─────┐
         │ a   ┆ b   ┆ c   │
         │ --- ┆ --- ┆ --- │
-        │ i64 ┆ i64 ┆ i64 │
+        │ u32 ┆ u32 ┆ u32 │
         ╞═════╪═════╪═════╡
         │ 4   ┆ 3   ┆ 0   │
         └─────┴─────┴─────┘

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5877,7 +5877,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def count(self) -> Self:
         """
-        Return the number of non-null elements in all the columns.
+        Return the number of non-null elements for each column.
 
         Examples
         --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -5875,6 +5875,27 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self._from_pyldf(result._ldf)
 
+    def count(self) -> Self:
+        """
+        Return the number of non-null elements in all the columns.
+
+        Examples
+        --------
+        >>> lf = pl.LazyFrame(
+        ...     {"a": [1, 2, 3, 4], "b": [1, 2, 1, None], "c": [None, None, None, None]}
+        ... )
+        >>> lf.count().collect()
+        shape: (1, 3)
+        ┌─────┬─────┬─────┐
+        │ a   ┆ b   ┆ c   │
+        │ --- ┆ --- ┆ --- │
+        │ i64 ┆ i64 ┆ i64 │
+        ╞═════╪═════╪═════╡
+        │ 4   ┆ 3   ┆ 0   │
+        └─────┴─────┴─────┘
+        """
+        return self._from_pyldf(self._ldf.count())
+
     @deprecate_renamed_function("group_by", version="0.19.0")
     def groupby(
         self,

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -1071,10 +1071,9 @@ impl PyLazyFrame {
         Ok(self.get_schema()?.len())
     }
 
-    fn count(&self) -> PyResult<Self> {
+    fn count(&self) -> Self {
         let ldf = self.ldf.clone();
-        let out = ldf.count().map_err(PyPolarsErr::from)?;
-        Ok(out.into())
+        ldf.count().into()
     }
 
     #[cfg(feature = "merge_sorted")]

--- a/py-polars/src/lazyframe.rs
+++ b/py-polars/src/lazyframe.rs
@@ -1071,6 +1071,12 @@ impl PyLazyFrame {
         Ok(self.get_schema()?.len())
     }
 
+    fn count(&self) -> PyResult<Self> {
+        let ldf = self.ldf.clone();
+        let out = ldf.count().map_err(PyPolarsErr::from)?;
+        Ok(out.into())
+    }
+
     #[cfg(feature = "merge_sorted")]
     fn merge_sorted(&self, other: Self, key: &str) -> PyResult<Self> {
         let out = self

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -135,3 +135,26 @@ def test_quantile(fruits_cars: pl.DataFrame) -> None:
 
     assert fruits_cars.lazy().quantile(0.24, "linear").collect()["A"][0] == 1.96
     assert fruits_cars.select(pl.col("A").quantile(0.24, "linear"))["A"][0] == 1.96
+
+
+def test_count(fruits_cars: pl.DataFrame) -> None:
+    lf = pl.LazyFrame(
+        {
+            "nulls": [None, None, None],
+            "one_null_str": ["one", None, "three"],
+            "one_null_float": [1.0, 2.0, None],
+            "no_nulls_int": [1, 2, 3],
+        }
+    )
+
+    result = lf.count().collect()
+
+    expected = pl.DataFrame(
+        {
+            "nulls": [0],
+            "one_null_str": [2],
+            "one_null_float": [2],
+            "no_nulls_int": [3],
+        },
+    ).cast(pl.UInt32)
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -137,7 +137,7 @@ def test_quantile(fruits_cars: pl.DataFrame) -> None:
     assert fruits_cars.select(pl.col("A").quantile(0.24, "linear"))["A"][0] == 1.96
 
 
-def test_count(fruits_cars: pl.DataFrame) -> None:
+def test_count() -> None:
     lf = pl.LazyFrame(
         {
             "nulls": [None, None, None],
@@ -146,8 +146,10 @@ def test_count(fruits_cars: pl.DataFrame) -> None:
             "no_nulls_int": [1, 2, 3],
         }
     )
+    df = lf.collect()
 
-    result = lf.count().collect()
+    lf_result = lf.count().collect()
+    df_result = df.count()
 
     expected = pl.DataFrame(
         {
@@ -157,4 +159,5 @@ def test_count(fruits_cars: pl.DataFrame) -> None:
             "no_nulls_int": [3],
         },
     ).cast(pl.UInt32)
-    assert_frame_equal(result, expected)
+    assert_frame_equal(lf_result, expected)
+    assert_frame_equal(df_result, expected)

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -148,10 +148,10 @@ def test_count() -> None:
     )
     df = lf.collect()
 
-    lf_result = lf.count().collect()
+    lf_result = lf.count()
     df_result = df.count()
 
-    expected = pl.DataFrame(
+    expected = pl.LazyFrame(
         {
             "nulls": [0],
             "one_null_str": [2],
@@ -160,4 +160,4 @@ def test_count() -> None:
         },
     ).cast(pl.UInt32)
     assert_frame_equal(lf_result, expected)
-    assert_frame_equal(df_result, expected)
+    assert_frame_equal(df_result, expected.collect())


### PR DESCRIPTION
Closes #13145

To-do's:

- [x] Add `count()` to LazyFrame
- [x] Create test for LazyFrame
- [x] Fix usage of stats_helper (which might set the col to Null, and requirement is_ord is wrong)
- [x] LazyFrame test succesful
- [x] Add `count()` to DataFrame
- [x] Create test for DataFrame
- [x] DataFrame test succesful