### PR TITLE
feat(python): typing overloads for Series operator methods `ge, gt, ...`

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -644,13 +644,37 @@ class Series:
             return F.lit(self).__le__(other)
         return self._comp(other, "lt_eq")
 
+    @overload
+    def le(self, other: Expr) -> Expr:  # type: ignore[overload-overlap]
+        ...
+
+    @overload
+    def le(self, other: Any) -> Series:
+        ...
+
     def le(self, other: Any) -> Self | Expr:
         """Method equivalent of operator expression `series <= other`."""
         return self.__le__(other)
 
+    @overload
+    def lt(self, other: Expr) -> Expr:  # type: ignore[overload-overlap]
+        ...
+
+    @overload
+    def lt(self, other: Any) -> Series:
+        ...
+
     def lt(self, other: Any) -> Self | Expr:
         """Method equivalent of operator expression `series < other`."""
         return self.__lt__(other)
+
+    @overload
+    def eq(self, other: Expr) -> Expr:  # type: ignore[overload-overlap]
+        ...
+
+    @overload
+    def eq(self, other: Any) -> Series:
+        ...
 
     def eq(self, other: Any) -> Self | Expr:
         """Method equivalent of operator expression `series == other`."""
@@ -754,9 +778,25 @@ class Series:
 
         """
 
+    @overload
+    def ge(self, other: Expr) -> Expr:  # type: ignore[overload-overlap]
+        ...
+
+    @overload
+    def ge(self, other: Any) -> Series:
+        ...
+
     def ge(self, other: Any) -> Self | Expr:
         """Method equivalent of operator expression `series >= other`."""
         return self.__ge__(other)
+
+    @overload
+    def gt(self, other: Expr) -> Expr:  # type: ignore[overload-overlap]
+        ...
+
+    @overload
+    def gt(self, other: Any) -> Series:
+        ...
 
     def gt(self, other: Any) -> Self | Expr:
         """Method equivalent of operator expression `series > other`."""

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -685,7 +685,7 @@ class Series:
         ...
 
     @overload
-    def eq_missing(self, other: Expr) -> Expr:  # type: ignore[overload-overlap]
+    def eq_missing(self, other: Expr) -> Expr:  # type: ignore[misc]
         ...
 
     def eq_missing(self, other: Any) -> Self | Expr:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -727,6 +727,14 @@ class Series:
 
         """
 
+    @overload
+    def ne(self, other: Expr) -> Expr:  # type: ignore[overload-overlap]
+        ...
+
+    @overload
+    def ne(self, other: Any) -> Series:
+        ...
+
     def ne(self, other: Any) -> Self | Expr:
         """Method equivalent of operator expression `series != other`."""
         return self.__ne__(other)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -685,7 +685,7 @@ class Series:
         ...
 
     @overload
-    def eq_missing(self, other: Expr) -> Expr:  # type: ignore[misc]
+    def eq_missing(self, other: Expr) -> Expr:  # type: ignore[overload-overlap]
         ...
 
     def eq_missing(self, other: Any) -> Self | Expr:


### PR DESCRIPTION
Would close #13166, if this is found to be a valid issue.