### PR TITLE
fix(rust): slice for `NullChunked` no longer force single chunk

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -9,7 +9,7 @@ use crate::chunked_array::object::builder::ObjectChunkedBuilder;
 use crate::utils::slice_offsets;
 
 #[inline]
-fn slice(
+pub(crate) fn slice(
     chunks: &[ArrayRef],
     offset: i64,
     slice_length: usize,

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -11,7 +11,6 @@ use crate::prelude::explode::ExplodeByOffsets;
 use crate::prelude::*;
 use crate::series::private::{PrivateSeries, PrivateSeriesNumeric};
 use crate::series::*;
-use crate::utils::slice_offsets;
 
 impl Series {
     pub fn new_null(name: &str, len: usize) -> Series {
@@ -165,8 +164,13 @@ impl SeriesTrait for NullChunked {
     }
 
     fn slice(&self, offset: i64, length: usize) -> Series {
-        let (_, length) = slice_offsets(offset, length, self.len());
-        NullChunked::new(self.name.clone(), length).into_series()
+        let (chunks, len) = chunkops::slice(&self.chunks, offset, length, self.len());
+        NullChunked {
+            name: self.name.clone(),
+            length: len as IdxSize,
+            chunks,
+        }
+        .into_series()
     }
 
     fn is_null(&self) -> BooleanChunked {

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -618,3 +618,18 @@ def test_null_parquet(tmp_path: Path) -> None:
     df.write_parquet(file_path)
     out = pl.read_parquet(file_path)
     assert_frame_equal(out, df)
+
+
+@pytest.mark.write_disk()
+def test_write_parquet_with_null_col(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    df1 = pl.DataFrame({"nulls": [None] * 2, "ints": [1] * 2})
+    df2 = pl.DataFrame({"nulls": [None] * 2, "ints": [1] * 2})
+    df3 = pl.DataFrame({"nulls": [None] * 3, "ints": [1] * 3})
+    df = df1.vstack(df2)
+    df = df.vstack(df3)
+    file_path = tmp_path / "with_null.parquet"
+    df.write_parquet(file_path, row_group_size=3)
+    out = pl.read_parquet(file_path)
+    assert_frame_equal(out, df)


### PR DESCRIPTION
Just to show that there is a bug here. I wonder do we have a better way to avoid `rechunk`.

This fixes #13170.