### PR TITLE
fix(python): Raise error on `replace` categoricals with strings

### DIFF
--- a/py-polars/tests/unit/operations/test_replace.py
+++ b/py-polars/tests/unit/operations/test_replace.py
@@ -76,6 +76,14 @@ def test_replace_cat_to_str_fast_path_err() -> None:
         s.replace(mapping)
 
 
+def test_replace_str_to_cat() -> None:
+    s = pl.Series(["a", "b", "c"])
+    mapping = {"a": "c", "b": "d"}
+    result = s.replace(mapping, return_dtype=pl.Categorical)
+    expected = pl.Series(["c", "d", "c"], dtype=pl.Categorical)
+    assert_series_equal(result, expected, categorical_as_str=True)
+
+
 @pl.StringCache()
 def test_replace_cat_to_cat(str_mapping: dict[str | None, str]) -> None:
     lf = pl.LazyFrame(

--- a/py-polars/tests/unit/operations/test_replace.py
+++ b/py-polars/tests/unit/operations/test_replace.py
@@ -56,7 +56,7 @@ def test_replace_str_to_str_default_other(str_mapping: dict[str | None, str]) ->
 
 
 @pl.StringCache()
-def test_replace_cat_to_str(str_mapping: dict[str | None, str]) -> None:
+def test_replace_cat_to_str_err(str_mapping: dict[str | None, str]) -> None:
     df = pl.DataFrame(
         {"country_code": ["FR", None, "ES", "DE"]},
         schema={"country_code": pl.Categorical},
@@ -64,6 +64,16 @@ def test_replace_cat_to_str(str_mapping: dict[str | None, str]) -> None:
 
     with pytest.raises(pl.InvalidOperationError):
         df.select(pl.col("country_code").replace(str_mapping))
+
+
+# https://github.com/pola-rs/polars/issues/13164
+@pl.StringCache()
+def test_replace_cat_to_str_fast_path_err() -> None:
+    s = pl.Series(["a", "b"], dtype=pl.Categorical)
+    mapping = {"a": "c"}
+
+    with pytest.raises(pl.InvalidOperationError):
+        s.replace(mapping)
 
 
 @pl.StringCache()

--- a/py-polars/tests/unit/operations/test_replace.py
+++ b/py-polars/tests/unit/operations/test_replace.py
@@ -62,7 +62,10 @@ def test_replace_cat_to_str_err(str_mapping: dict[str | None, str]) -> None:
         schema={"country_code": pl.Categorical},
     )
 
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(
+        pl.InvalidOperationError,
+        match="casting to a non-enum variant with rev map is not supported for the user",
+    ):
         df.select(pl.col("country_code").replace(str_mapping))
 
 
@@ -72,7 +75,10 @@ def test_replace_cat_to_str_fast_path_err() -> None:
     s = pl.Series(["a", "b"], dtype=pl.Categorical)
     mapping = {"a": "c"}
 
-    with pytest.raises(pl.InvalidOperationError):
+    with pytest.raises(
+        pl.InvalidOperationError,
+        match="casting to a non-enum variant with rev map is not supported for the user",
+    ):
         s.replace(mapping)
 
 


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/13164

I'm not too happy with the error message here, but I hope we can actually support this rather than raise an error, so I'm not putting in more effort into cleaning up this error message for now.