### PR TITLE
feat: add cancellable queries

### DIFF
--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -137,7 +137,6 @@ mod test {
     use polars_utils::idxvec;
 
     use super::*;
-    use crate::chunked_array::object::registry::register_object_builder;
 
     #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
     struct Foo {

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -135,9 +135,9 @@ mod test {
     use std::fmt::{Display, Formatter};
 
     use polars_utils::idxvec;
-    use crate::chunked_array::object::registry::register_object_builder;
 
     use super::*;
+    use crate::chunked_array::object::registry::register_object_builder;
 
     #[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
     struct Foo {

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -135,6 +135,7 @@ mod test {
     use std::fmt::{Display, Formatter};
 
     use polars_utils::idxvec;
+    use crate::chunked_array::object::registry::register_object_builder;
 
     use super::*;
 

--- a/crates/polars-lazy/src/frame/exitable.rs
+++ b/crates/polars-lazy/src/frame/exitable.rs
@@ -1,0 +1,51 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use super::*;
+use polars_core::POOL;
+use std::sync::mpsc::{channel, Receiver};
+use std::sync::Mutex;
+
+impl LazyFrame {
+    pub fn collect_concurrently(self) -> PolarsResult<InProcessQuery> {
+        let (mut state, mut physical_plan, _) = self.prepare_collect(false)?;
+
+        let (tx, rx) = channel();
+        let token = state.cancel_token();
+        POOL.spawn(move || {
+            let result = physical_plan.execute(&mut state);
+            tx.send(result).unwrap();
+        });
+
+        Ok(InProcessQuery {
+            rx: Arc::new(Mutex::new(rx)),
+            token
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct InProcessQuery {
+    rx: Arc<Mutex<Receiver<PolarsResult<DataFrame>>>>,
+    token: Arc<AtomicBool>
+}
+
+impl InProcessQuery {
+    pub fn cancel(&self) {
+        self.token.store(true, Ordering::Relaxed)
+    }
+
+    pub fn fetch(&self) -> Option<PolarsResult<DataFrame>> {
+        let rx = self.rx.lock().unwrap();
+        rx.try_recv().ok()
+    }
+
+    pub fn fetch_blocking(&self) -> PolarsResult<DataFrame> {
+        let rx = self.rx.lock().unwrap();
+        rx.recv().unwrap()
+    }
+}
+
+impl Drop for InProcessQuery {
+    fn drop(&mut self) {
+        self.token.store(true, Ordering::Relaxed);
+    }
+}

--- a/crates/polars-lazy/src/frame/exitable.rs
+++ b/crates/polars-lazy/src/frame/exitable.rs
@@ -12,7 +12,7 @@ impl LazyFrame {
 
         let (tx, rx) = channel();
         let token = state.cancel_token();
-        POOL.spawn(move || {
+        POOL.spawn_fifo(move || {
             let result = physical_plan.execute(&mut state);
             tx.send(result).unwrap();
         });

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -5,6 +5,7 @@ mod python;
 mod err;
 #[cfg(feature = "pivot")]
 pub mod pivot;
+mod exitable;
 
 use std::borrow::Cow;
 #[cfg(any(
@@ -50,6 +51,7 @@ use crate::physical_plan::state::ExecutionState;
 #[cfg(feature = "streaming")]
 use crate::physical_plan::streaming::insert_streaming_nodes;
 use crate::prelude::*;
+pub use exitable::*;
 
 pub trait IntoLazy {
     fn lazy(self) -> LazyFrame;

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -3,6 +3,7 @@
 mod python;
 
 mod err;
+#[cfg(not(target = "wasm32-unknown-unknown"))]
 mod exitable;
 #[cfg(feature = "pivot")]
 pub mod pivot;
@@ -21,6 +22,7 @@ pub use anonymous_scan::*;
 use arrow::legacy::prelude::QuantileInterpolOptions;
 #[cfg(feature = "csv")]
 pub use csv::*;
+#[cfg(not(target = "wasm32-unknown-unknown"))]
 pub use exitable::*;
 pub use file_list_reader::*;
 #[cfg(feature = "ipc")]

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -3,9 +3,9 @@
 mod python;
 
 mod err;
+mod exitable;
 #[cfg(feature = "pivot")]
 pub mod pivot;
-mod exitable;
 
 use std::borrow::Cow;
 #[cfg(any(
@@ -21,6 +21,7 @@ pub use anonymous_scan::*;
 use arrow::legacy::prelude::QuantileInterpolOptions;
 #[cfg(feature = "csv")]
 pub use csv::*;
+pub use exitable::*;
 pub use file_list_reader::*;
 #[cfg(feature = "ipc")]
 pub use ipc::*;
@@ -51,7 +52,6 @@ use crate::physical_plan::state::ExecutionState;
 #[cfg(feature = "streaming")]
 use crate::physical_plan::streaming::insert_streaming_nodes;
 use crate::prelude::*;
-pub use exitable::*;
 
 pub trait IntoLazy {
     fn lazy(self) -> LazyFrame;

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -3,7 +3,7 @@
 mod python;
 
 mod err;
-#[cfg(not(target = "wasm32-unknown-unknown"))]
+#[cfg(not(target_arch = "wasm32"))]
 mod exitable;
 #[cfg(feature = "pivot")]
 pub mod pivot;
@@ -22,7 +22,7 @@ pub use anonymous_scan::*;
 use arrow::legacy::prelude::QuantileInterpolOptions;
 #[cfg(feature = "csv")]
 pub use csv::*;
-#[cfg(not(target = "wasm32-unknown-unknown"))]
+#[cfg(not(target_arch = "wasm32"))]
 pub use exitable::*;
 pub use file_list_reader::*;
 #[cfg(feature = "ipc")]

--- a/crates/polars-lazy/src/physical_plan/executors/filter.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/filter.rs
@@ -23,6 +23,7 @@ impl FilterExec {
 
 impl Executor for FilterExec {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         #[cfg(debug_assertions)]
         {
             if state.verbose() {

--- a/crates/polars-lazy/src/physical_plan/executors/group_by.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/group_by.rs
@@ -115,6 +115,7 @@ impl GroupByExec {
 
 impl Executor for GroupByExec {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         #[cfg(debug_assertions)]
         {
             if state.verbose() {

--- a/crates/polars-lazy/src/physical_plan/executors/group_by_dynamic.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/group_by_dynamic.rs
@@ -82,6 +82,7 @@ impl Executor for GroupByDynamicExec {
 
     #[cfg(feature = "dynamic_group_by")]
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         #[cfg(debug_assertions)]
         {
             if state.verbose() {

--- a/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
@@ -363,6 +363,7 @@ impl PartitionGroupByExec {
 
 impl Executor for PartitionGroupByExec {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         #[cfg(debug_assertions)]
         {
             if state.verbose() {

--- a/crates/polars-lazy/src/physical_plan/executors/group_by_rolling.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/group_by_rolling.rs
@@ -101,6 +101,7 @@ impl Executor for GroupByRollingExec {
 
     #[cfg(feature = "dynamic_group_by")]
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         #[cfg(debug_assertions)]
         {
             if state.verbose() {

--- a/crates/polars-lazy/src/physical_plan/executors/join.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/join.rs
@@ -34,6 +34,7 @@ impl JoinExec {
 
 impl Executor for JoinExec {
     fn execute<'a>(&'a mut self, state: &'a mut ExecutionState) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         #[cfg(debug_assertions)]
         {
             if state.verbose() {

--- a/crates/polars-lazy/src/physical_plan/executors/projection.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/projection.rs
@@ -47,6 +47,7 @@ impl ProjectionExec {
 
 impl Executor for ProjectionExec {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         #[cfg(debug_assertions)]
         {
             if state.verbose() {

--- a/crates/polars-lazy/src/physical_plan/executors/python_scan.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/python_scan.rs
@@ -8,10 +8,11 @@ pub(crate) struct PythonScanExec {
 }
 
 impl Executor for PythonScanExec {
-    fn execute(&mut self, _state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+    fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         #[cfg(debug_assertions)]
         {
-            if _state.verbose() {
+            if state.verbose() {
                 println!("run PythonScanExec")
             }
         }

--- a/crates/polars-lazy/src/physical_plan/executors/sort.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/sort.rs
@@ -12,6 +12,7 @@ impl SortExec {
         state: &ExecutionState,
         mut df: DataFrame,
     ) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         df.as_single_chunk_par();
 
         let by_columns = self

--- a/crates/polars-lazy/src/physical_plan/executors/stack.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/stack.rs
@@ -34,6 +34,7 @@ impl StackExec {
 
 impl Executor for StackExec {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         #[cfg(debug_assertions)]
         {
             if state.verbose() {

--- a/crates/polars-lazy/src/physical_plan/executors/udf.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/udf.rs
@@ -7,6 +7,7 @@ pub(crate) struct UdfExec {
 
 impl Executor for UdfExec {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         #[cfg(debug_assertions)]
         {
             if state.verbose() {

--- a/crates/polars-lazy/src/physical_plan/executors/union.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/union.rs
@@ -10,6 +10,7 @@ pub(crate) struct UnionExec {
 
 impl Executor for UnionExec {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         #[cfg(debug_assertions)]
         {
             if state.verbose() {

--- a/crates/polars-lazy/src/physical_plan/executors/unique.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/unique.rs
@@ -7,6 +7,7 @@ pub(crate) struct UniqueExec {
 
 impl Executor for UniqueExec {
     fn execute(&mut self, state: &mut ExecutionState) -> PolarsResult<DataFrame> {
+        state.should_stop()?;
         #[cfg(debug_assertions)]
         {
             if state.verbose() {

--- a/crates/polars-lazy/src/physical_plan/state.rs
+++ b/crates/polars-lazy/src/physical_plan/state.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::sync::atomic::{AtomicU8, Ordering, AtomicU32, AtomicBool, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Mutex, RwLock};
 
 use bitflags::bitflags;
@@ -92,7 +92,7 @@ pub struct ExecutionState {
     pub(super) flags: AtomicU8,
     pub(super) ext_contexts: Arc<Vec<DataFrame>>,
     node_timer: Option<NodeTimer>,
-    stop: Arc<AtomicBool>
+    stop: Arc<AtomicBool>,
 }
 
 impl ExecutionState {
@@ -105,10 +105,10 @@ impl ExecutionState {
             df_cache: Default::default(),
             schema_cache: Default::default(),
             #[cfg(any(
-            feature = "ipc",
-            feature = "parquet",
-            feature = "csv",
-            feature = "json"
+                feature = "ipc",
+                feature = "parquet",
+                feature = "csv",
+                feature = "json"
             ))]
             file_cache: FileCache::new(None),
             group_tuples: Default::default(),
@@ -117,7 +117,7 @@ impl ExecutionState {
             flags: AtomicU8::new(StateFlags::init().as_u8()),
             ext_contexts: Default::default(),
             node_timer: None,
-            stop: Arc::new(AtomicBool::new(false))
+            stop: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -176,7 +176,7 @@ impl ExecutionState {
             flags: AtomicU8::new(self.flags.load(Ordering::Relaxed)),
             ext_contexts: self.ext_contexts.clone(),
             node_timer: self.node_timer.clone(),
-            stop: self.stop.clone()
+            stop: self.stop.clone(),
         }
     }
 
@@ -198,7 +198,7 @@ impl ExecutionState {
             flags: AtomicU8::new(self.flags.load(Ordering::Relaxed)),
             ext_contexts: self.ext_contexts.clone(),
             node_timer: self.node_timer.clone(),
-            stop: self.stop.clone()
+            stop: self.stop.clone(),
         }
     }
 

--- a/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
@@ -245,6 +245,10 @@ impl SExecutionContext for ExecutionState {
     fn as_any(&self) -> &dyn Any {
         self
     }
+
+    fn should_stop(&self) -> PolarsResult<()> {
+        ExecutionState::should_stop(self)
+    }
 }
 
 fn get_pipeline_node(

--- a/crates/polars-pipe/src/operators/context.rs
+++ b/crates/polars-pipe/src/operators/context.rs
@@ -1,7 +1,11 @@
 use std::any::Any;
 
+use polars_core::prelude::*;
+
 pub trait SExecutionContext: Send + Sync {
     fn as_any(&self) -> &dyn Any;
+
+    fn should_stop(&self) -> PolarsResult<()>;
 }
 
 pub struct PExecutionContext {

--- a/crates/polars-pipe/src/pipeline/dispatcher.rs
+++ b/crates/polars-pipe/src/pipeline/dispatcher.rs
@@ -352,6 +352,9 @@ impl PipeLine {
                 let mut next_batches = src.get_batches(ec)?;
 
                 while let SourceResult::GotMoreData(chunks) = next_batches {
+                    // Every batches iteration we check if we must continue.
+                    ec.execution_state.should_stop()?;
+
                     let (sink_result, next_batches2) = self.par_process_chunks(
                         chunks,
                         &mut sink,
@@ -368,6 +371,9 @@ impl PipeLine {
                     }
                 }
             }
+
+            // Before we reduce we also check if we should continue.
+            ec.execution_state.should_stop()?;
 
             // The sinks have taken all chunks thread locally, now we reduce them into a single
             // result sink.

--- a/py-polars/docs/source/reference/lazyframe/in_process
+++ b/py-polars/docs/source/reference/lazyframe/in_process
@@ -1,0 +1,14 @@
+==============
+InProcessQuery
+==============
+
+This namespace comes available by calling `LazyFrame.collect(background=True)`.
+
+.. currentmodule:: polars.lazyframe.in_process
+
+.. autosummary::
+   :toctree: api/
+
+    InProcessQuery.cancel
+    InProcessQuery.fetch
+    InProcessQuery.fetch_blocking

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -185,7 +185,7 @@ from polars.io import (
     scan_parquet,
     scan_pyarrow_dataset,
 )
-from polars.lazyframe import LazyFrame
+from polars.lazyframe import InProcessQuery, LazyFrame
 from polars.series import Series
 from polars.sql import SQLContext
 from polars.string_cache import (
@@ -228,6 +228,7 @@ __all__ = [
     "Expr",
     "LazyFrame",
     "Series",
+    "InProcessQuery",
     # polars.datatypes
     "Array",
     "Binary",

--- a/py-polars/polars/lazyframe/__init__.py
+++ b/py-polars/polars/lazyframe/__init__.py
@@ -1,5 +1,4 @@
 from polars.lazyframe.frame import LazyFrame
+from polars.lazyframe.in_process import InProcessQuery
 
-__all__ = [
-    "LazyFrame",
-]
+__all__ = ["LazyFrame", "InProcessQuery"]

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1593,6 +1593,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         comm_subexpr_elim: bool = True,
         no_optimization: bool = False,
         streaming: bool = False,
+        background: bool = False,
         _eager: bool = False,
     ) -> DataFrame:
         """
@@ -1630,6 +1631,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             .. note::
                 Use :func:`explain` to see if Polars can process the query in streaming
                 mode.
+        background
+            Run the query in the background and get a handle to the query. This handle can
+            be used to fetch the result or cancel the query.
 
         Returns
         -------
@@ -1702,6 +1706,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             streaming,
             _eager,
         )
+        if background:
+            return ldf.collect_concurrently()
+
         return wrap_df(ldf.collect())
 
     @overload

--- a/py-polars/polars/lazyframe/in_process.py
+++ b/py-polars/polars/lazyframe/in_process.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from polars.utils._wrap import wrap_df
+
+if TYPE_CHECKING:
+    from polars import DataFrame
+    from polars.polars import PyInProcessQuery
+
+
+class InProcessQuery:
+    """
+    A placeholder for an in process query.
+
+    This can be used to do something else while a query is running.
+    The queries can be cancelled. You can peek if the query is finished,
+    or you can await the result.
+    """
+
+    def __init__(self, ipq: PyInProcessQuery) -> None:
+        self.ipq = ipq
+
+    def cancel(self) -> None:
+        """Cancel the query at earliest convenience."""
+        self.ipq.cancel()
+
+    def fetch(self) -> DataFrame | None:
+        """
+        Fetch the result.
+
+        If it is ready, a materialized DataFrame is returned.
+        If it is not ready it will return `None`.
+        """
+        out = self.ipq.fetch()
+        if out is not None:
+            return wrap_df(out)
+        return None
+
+    def fetch_blocking(self) -> DataFrame:
+        """Await the result synchronously."""
+        return wrap_df(self.ipq.fetch_blocking())

--- a/py-polars/src/lazyframe/exitable.rs
+++ b/py-polars/src/lazyframe/exitable.rs
@@ -20,17 +20,17 @@ pub struct PyInProcessQuery {
 
 #[pymethods]
 impl PyInProcessQuery {
-    pub fn cancel(&self) {
-        self.ipq.cancel();
+    pub fn cancel(&self, py: Python) {
+        py.allow_threads(|| self.ipq.cancel())
     }
 
-    pub fn fetch(&self) -> PyResult<Option<PyDataFrame>> {
-        let out = self.ipq.fetch().transpose().map_err(PyPolarsErr::from)?;
+    pub fn fetch(&self, py: Python) -> PyResult<Option<PyDataFrame>> {
+        let out = py.allow_threads(|| self.ipq.fetch().transpose().map_err(PyPolarsErr::from))?;
         Ok(out.map(|df| df.into()))
     }
 
-    pub fn fetch_blocking(&self) -> PyResult<PyDataFrame> {
-        let out = self.ipq.fetch_blocking().map_err(PyPolarsErr::from)?;
+    pub fn fetch_blocking(&self, py: Python) -> PyResult<PyDataFrame> {
+        let out = py.allow_threads(|| self.ipq.fetch_blocking().map_err(PyPolarsErr::from))?;
         Ok(out.into())
     }
 }

--- a/py-polars/src/lazyframe/exitable.rs
+++ b/py-polars/src/lazyframe/exitable.rs
@@ -1,0 +1,38 @@
+use super::*;
+
+#[pymethods]
+impl PyLazyFrame {
+    fn collect_concurrently(&self, py: Python) -> PyResult<PyInProcessQuery> {
+        let ipq = py.allow_threads(|| {
+            let ldf = self.ldf.clone();
+            ldf.collect_concurrently().map_err(PyPolarsErr::from)
+        })?;
+        Ok(PyInProcessQuery{ipq})
+    }
+}
+
+#[pyclass]
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct PyInProcessQuery {
+    pub ipq: InProcessQuery
+}
+
+#[pymethods]
+impl PyInProcessQuery {
+    pub fn cancel(&self) {
+        self.ipq.cancel();
+    }
+
+    pub fn fetch(&self) -> PyResult<Option<PyDataFrame>> {
+        let out = self.ipq.fetch().transpose().map_err(PyPolarsErr::from)?;
+        Ok(out.map(|df| df.into()))
+    }
+
+    pub fn fetch_blocking(&self) -> PyResult<PyDataFrame> {
+        let out = self.ipq.fetch_blocking().map_err(PyPolarsErr::from)?;
+        Ok(out.into())
+    }
+
+
+}

--- a/py-polars/src/lazyframe/exitable.rs
+++ b/py-polars/src/lazyframe/exitable.rs
@@ -7,7 +7,7 @@ impl PyLazyFrame {
             let ldf = self.ldf.clone();
             ldf.collect_concurrently().map_err(PyPolarsErr::from)
         })?;
-        Ok(PyInProcessQuery{ipq})
+        Ok(PyInProcessQuery { ipq })
     }
 }
 
@@ -15,7 +15,7 @@ impl PyLazyFrame {
 #[repr(transparent)]
 #[derive(Clone)]
 pub struct PyInProcessQuery {
-    pub ipq: InProcessQuery
+    pub ipq: InProcessQuery,
 }
 
 #[pymethods]
@@ -33,6 +33,4 @@ impl PyInProcessQuery {
         let out = self.ipq.fetch_blocking().map_err(PyPolarsErr::from)?;
         Ok(out.into())
     }
-
-
 }

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -1,3 +1,5 @@
+mod exitable;
+
 use std::collections::HashMap;
 use std::io::BufWriter;
 use std::path::PathBuf;

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::io::BufWriter;
 use std::path::PathBuf;
 
+pub use exitable::PyInProcessQuery;
 #[cfg(feature = "csv")]
 use polars::io::csv::SerializeOptions;
 use polars::io::RowCount;

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -58,7 +58,7 @@ use crate::error::{
 };
 use crate::expr::PyExpr;
 use crate::functions::PyStringCacheHolder;
-use crate::lazyframe::PyLazyFrame;
+use crate::lazyframe::{PyInProcessQuery, PyLazyFrame};
 use crate::lazygroupby::PyLazyGroupBy;
 use crate::series::PySeries;
 #[cfg(feature = "sql")]
@@ -78,6 +78,7 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<PySeries>().unwrap();
     m.add_class::<PyDataFrame>().unwrap();
     m.add_class::<PyLazyFrame>().unwrap();
+    m.add_class::<PyInProcessQuery>().unwrap();
     m.add_class::<PyLazyGroupBy>().unwrap();
     m.add_class::<PyExpr>().unwrap();
     m.add_class::<PyStringCacheHolder>().unwrap();


### PR DESCRIPTION
This gives you an `InProcessQuery` handler that allows you to cancel the query
```python
import polars as pl
import time

def sleep(df: pl.DataFrame) -> pl.DataFrame:
    time.sleep(1)
    return df
    
ipq = pl.LazyFrame({"a": [1]}).map_batches(sleep).map_batches(sleep).collect(background=True)

# do some other work in the meantime

# check if query is finished
# Note that if you use python UDFs, you actually have to call this sometimes (or fetch_blocking)
# to give the running process a hold to the GIL. As long as you hold it we cannot run python UDFs.
# So minimize lambdas. :)
out = ipq.fetch()

if out is not None:
     print("query finished", df)

# we can cancel the query if we need to
# note that deleting the `InProcessQuery` object will also cancel it, so keep it alive
if condition():
   ipq.cancel()
    
# do more work

# nothing left to do, let's block the thread until the query is finished
ipq.fetch_blocking()

```