### PR TITLE
docs(python): Link to latest object_store docs in api doc

### DIFF
--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -78,9 +78,9 @@ def read_parquet(
         The cloud providers currently supported are AWS, GCP, and Azure.
         See supported keys here:
 
-        * `aws <https://docs.rs/object_store/0.7.0/object_store/aws/enum.AmazonS3ConfigKey.html>`_
-        * `gcp <https://docs.rs/object_store/0.7.0/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/0.7.0/object_store/azure/enum.AzureConfigKey.html>`_
+        * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
+        * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
 
         If `storage_options` is not provided, Polars will try to infer the information
         from environment variables.
@@ -265,9 +265,9 @@ def scan_parquet(
         The cloud providers currently supported are AWS, GCP, and Azure.
         See supported keys here:
 
-        * `aws <https://docs.rs/object_store/0.7.0/object_store/aws/enum.AmazonS3ConfigKey.html>`_
-        * `gcp <https://docs.rs/object_store/0.7.0/object_store/gcp/enum.GoogleConfigKey.html>`_
-        * `azure <https://docs.rs/object_store/0.7.0/object_store/azure/enum.AzureConfigKey.html>`_
+        * `aws <https://docs.rs/object_store/latest/object_store/aws/enum.AmazonS3ConfigKey.html>`_
+        * `gcp <https://docs.rs/object_store/latest/object_store/gcp/enum.GoogleConfigKey.html>`_
+        * `azure <https://docs.rs/object_store/latest/object_store/azure/enum.AzureConfigKey.html>`_
 
         If `storage_options` is not provided, Polars will try to infer the information
         from environment variables.


### PR DESCRIPTION
The Python read/scan_parquet api docs for storage_options link to version 0.7.0 of object_store while polars uses 0.8.
Instead of putting a fixed version in there, `latest` might be better.

resolves #13175