### PR TITLE
feat: make python `map_batches` safer

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3975,6 +3975,7 @@ class Expr:
         return_dtype: PolarsDataType | None = None,
         *,
         agg_list: bool = False,
+        is_elementwise: bool = False,
     ) -> Self:
         """
         Apply a custom python function to a whole Series or sequence of Series.
@@ -3996,6 +3997,9 @@ class Expr:
             Lambda/function to apply.
         return_dtype
             Dtype of the output Series.
+        is_elementwise
+            If set to true this can run in the streaming engine, but may yield
+            incorrect results in group-by. Ensure you know what you are doing!
         agg_list
             Aggregate list.
 
@@ -4031,7 +4035,7 @@ class Expr:
         if return_dtype is not None:
             return_dtype = py_type_to_dtype(return_dtype)
         return self._from_pyexpr(
-            self._pyexpr.map_batches(function, return_dtype, agg_list)
+            self._pyexpr.map_batches(function, return_dtype, agg_list, is_elementwise)
         )
 
     def map_elements(

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -666,14 +666,15 @@ impl PyExpr {
         self.inner.clone().shrink_dtype().into()
     }
 
-    #[pyo3(signature = (lambda, output_type, agg_list))]
+    #[pyo3(signature = (lambda, output_type, agg_list, is_elementwise))]
     fn map_batches(
         &self,
         lambda: PyObject,
         output_type: Option<Wrap<DataType>>,
         agg_list: bool,
+        is_elementwise: bool,
     ) -> Self {
-        map_single(self, lambda, output_type, agg_list)
+        map_single(self, lambda, output_type, agg_list, is_elementwise)
     }
 
     fn dot(&self, other: Self) -> Self {

--- a/py-polars/src/map/lazy.rs
+++ b/py-polars/src/map/lazy.rs
@@ -128,10 +128,11 @@ pub fn map_single(
     lambda: PyObject,
     output_type: Option<Wrap<DataType>>,
     agg_list: bool,
+    is_elementwise: bool,
 ) -> PyExpr {
     let output_type = output_type.map(|wrap| wrap.0);
 
-    let func = python_udf::PythonUdfExpression::new(lambda, output_type);
+    let func = python_udf::PythonUdfExpression::new(lambda, output_type, is_elementwise);
     pyexpr.inner.clone().map_python(func, agg_list).into()
 }
 

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -54,10 +54,20 @@ def test_error_on_reducing_map() -> None:
         df.select(
             pl.col("x")
             .map_batches(
-                lambda x: x.cut(breaks=[1, 2, 3], include_breaks=True).struct.unnest()
+                lambda x: x.cut(breaks=[1, 2, 3], include_breaks=True).struct.unnest(),
+                is_elementwise=True,
             )
             .over("group")
         )
+
+
+def test_map_batches_group() -> None:
+    df = pl.DataFrame(
+        {"id": [0, 0, 0, 1, 1, 1], "t": [2, 4, 5, 10, 11, 14], "y": [0, 1, 1, 2, 3, 4]}
+    )
+    assert df.group_by("id").agg(pl.col("t").map_batches(lambda s: s.sum())).sort(
+        "id"
+    ).to_dict(as_series=False) == {"id": [0, 1], "t": [[11], [35]]}
 
 
 def test_map_deprecated() -> None:

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -47,7 +47,8 @@ def test_error_on_reducing_map() -> None:
         df.select(
             pl.col("x")
             .map_batches(
-                lambda x: x.cut(breaks=[1, 2, 3], include_breaks=True).struct.unnest()
+                lambda x: x.cut(breaks=[1, 2, 3], include_breaks=True).struct.unnest(),
+                is_elementwise=True,
             )
             .over("group")
         )


### PR DESCRIPTION
This will default to a safer version of `map_batches`. We will now assume you cannot run on batches. E.g. don't merely do an elementwise operation like `+` or `pow`, but do something that requires all data. E.g. `sort`, `sum`, `rolling_min`, etc.

`map_batches` will now not run by default on the streaming engine unless you set `is_elementwise=True`. In that case it can produce wrong results in a group-by, but hey, you said it was elementwise. :shrug: 

