### PR TITLE
chore(rust): Remove `polars-algo` reference in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,9 +81,8 @@ xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 zstd = "0.13"
 
 polars = { version = "0.35.4", path = "crates/polars", default-features = false }
-polars-algo = { version = "0.35.4", path = "crates/polars-algo", default-features = false }
-polars-core = { version = "0.35.4", path = "crates/polars-core", default-features = false }
 polars-compute = { version = "0.35.4", path = "crates/polars-compute", default-features = false }
+polars-core = { version = "0.35.4", path = "crates/polars-core", default-features = false }
 polars-error = { version = "0.35.4", path = "crates/polars-error", default-features = false }
 polars-ffi = { version = "0.35.4", path = "crates/polars-ffi", default-features = false }
 polars-io = { version = "0.35.4", path = "crates/polars-io", default-features = false }


### PR DESCRIPTION
It no longer exists. I'm surprised Cargo doesn't throw a warning or error. It trips up dependabot though so I am removing it.