### PR TITLE
perf: make `.dt.truncate('*mo')` more than 3x faster

### DIFF
--- a/crates/polars-time/src/windows/calendar.rs
+++ b/crates/polars-time/src/windows/calendar.rs
@@ -1,22 +1,8 @@
-const LAST_DAYS_MONTH: [u32; 12] = [
-    31, // January:   31,
-    28, // February:  28,
-    31, // March:     31,
-    30, // April:     30,
-    31, // May:       31,
-    30, // June:      30,
-    31, // July:      31,
-    31, // August:    31,
-    30, // September: 30,
-    31, // October:   31,
-    30, // November:  30,
-    31, // December:  31,
+pub(crate) const DAYS_PER_MONTH: [[i64; 12]; 2] = [
+    //J   F   M   A   M   J   J   A   S   O   N   D
+    [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31], // non-leap year
+    [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31], // leap year
 ];
-
-pub(crate) const fn last_day_of_month(month: i32) -> u32 {
-    // month is 1 indexed
-    LAST_DAYS_MONTH[(month - 1) as usize]
-}
 
 pub(crate) const fn is_leap_year(year: i32) -> bool {
     year % 400 == 0 || (year % 4 == 0 && year % 100 != 0)

--- a/py-polars/tests/parametric/time_series/test_truncate.py
+++ b/py-polars/tests/parametric/time_series/test_truncate.py
@@ -1,0 +1,21 @@
+import datetime as dt
+
+import hypothesis.strategies as st
+from hypothesis import given
+
+import polars as pl
+
+
+@given(
+    value=st.datetimes(min_value=dt.datetime(1000, 1, 1), max_value=dt.datetime(3000, 1, 1)),
+    n=st.integers(min_value=1, max_value=100),
+)
+def test_truncate_monthly(value: dt.date, n: int) -> None:
+    result = pl.Series([value]).dt.truncate(f"{n}mo").item()
+    # manual calculation
+    total = value.year * 12 + value.month - 1
+    remainder = total % n
+    total -= remainder
+    year, month = (total // 12), ((total % 12) + 1)
+    expected = dt.datetime(year, month, 1)
+    assert result == expected

--- a/py-polars/tests/parametric/time_series/test_truncate.py
+++ b/py-polars/tests/parametric/time_series/test_truncate.py
@@ -7,7 +7,9 @@ import polars as pl
 
 
 @given(
-    value=st.datetimes(min_value=dt.datetime(1000, 1, 1), max_value=dt.datetime(3000, 1, 1)),
+    value=st.datetimes(
+        min_value=dt.datetime(1000, 1, 1), max_value=dt.datetime(3000, 1, 1)
+    ),
     n=st.integers(min_value=1, max_value=100),
 )
 def test_truncate_monthly(value: dt.date, n: int) -> None:


### PR DESCRIPTION
closes #13157 

benchmark: https://www.kaggle.com/code/marcogorelli/polars-timing?scriptVersionId=155987273

going to take my time on this one, as there's a few details which are easy to get wrong and I don't think the current test coverage covers everything...looks promising though