### PR TITLE
fix: Better handle mismatched dtypes in `replace`

### DIFF
--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -33,7 +33,7 @@ pub fn replace(
         return Ok(default);
     }
 
-    let old = old.cast(s.dtype())?;
+    let old = old.strict_cast(s.dtype())?;
     let new = new.cast(&return_dtype)?;
 
     if new.len() == 1 {

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -58,7 +58,7 @@ build-release-native: .venv  ## Same as build-release, except with native CPU op
 fmt: .venv  ## Run autoformatting and linting
 	$(VENV_BIN)/ruff check .
 	$(VENV_BIN)/ruff format .
-	$(VENV_BIN)/typos ..
+	$(VENV_BIN)/typos
 	cargo fmt --all
 	-dprint fmt
 	-$(VENV_BIN)/mypy

--- a/py-polars/tests/unit/operations/test_replace.py
+++ b/py-polars/tests/unit/operations/test_replace.py
@@ -90,6 +90,41 @@ def test_replace_str_to_cat() -> None:
     assert_series_equal(result, expected, categorical_as_str=True)
 
 
+def test_replace_enum() -> None:
+    dtype = pl.Enum(["a", "b", "c", "d"])
+    s = pl.Series(["a", "b", "c"], dtype=dtype)
+    old = ["a", "b"]
+    new = pl.Series(["c", "d"], dtype=dtype)
+
+    result = s.replace(old, new)
+
+    expected = pl.Series(["c", "d", "c"], dtype=dtype)
+    assert_series_equal(result, expected)
+
+
+def test_replace_enum_to_str() -> None:
+    dtype = pl.Enum(["a", "b", "c", "d"])
+    s = pl.Series(["a", "b", "c"], dtype=dtype)
+
+    result = s.replace({"a": "c", "b": "d"})
+
+    expected = pl.Series(["c", "d", "c"], dtype=pl.Utf8)
+    assert_series_equal(result, expected)
+
+
+def test_replace_enum_to_new_enum() -> None:
+    s = pl.Series(["a", "b", "c"], dtype=pl.Enum(["a", "b", "c", "d"]))
+    old = ["a", "b"]
+
+    new_dtype = pl.Enum(["a", "b", "c", "d", "e"])
+    new = pl.Series(["c", "e"], dtype=new_dtype)
+
+    result = s.replace(old, new)
+
+    expected = pl.Series(["c", "e", "c"], dtype=new_dtype)
+    assert_series_equal(result, expected)
+
+
 @pl.StringCache()
 def test_replace_cat_to_cat(str_mapping: dict[str | None, str]) -> None:
     lf = pl.LazyFrame(
@@ -108,6 +143,13 @@ def test_replace_cat_to_cat(str_mapping: dict[str | None, str]) -> None:
         schema_overrides={"replaced": pl.Categorical},
     )
     assert_frame_equal(result, expected)
+
+
+def test_replace_invalid_old_dtype() -> None:
+    lf = pl.LazyFrame({"a": [1, 2, 3]})
+    mapping = {"a": 10, "b": 20}
+    with pytest.raises(pl.ComputeError, match="conversion from `str` to `i64` failed"):
+        lf.select(pl.col("a").replace(mapping)).collect()
 
 
 def test_replace_int_to_int() -> None:


### PR DESCRIPTION
Using a strict cast solves some obscure behavior due to values being set to null and then replacing null values.