### PR TITLE
chore(python): clean up bytecode parsing a bit

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -365,7 +365,7 @@ class BytecodeParser:
     def to_expression(self, col: str) -> str | None:
         """Translate postfix bytecode instructions to polars expression/string."""
         self._map_target_name = None
-        if not self.can_attempt_rewrite() or self._param_name is None:
+        if self._param_name is None:
             return None
 
         # decompose bytecode into logical 'and'/'or' expression blocks (if present)


### PR DESCRIPTION
There's 3 cleanups I'm suggesting here:

1. make `try` blocks smaller. I think this is uncontroversial
2. remove an unused `try` block in `_is_raw_function`. The whole test suite passes without it, I think it the code can be simplified by just removing it
3. removing the `_can_attempt_rewrite` dict. I think this was originally introduced for performance reasons, but:
   - I'm not seeing any perf difference here vs on `main` (timing `pl.col('a').map_elements(lambda x: abs(x))` here and on `main` takes about `8.988900013459247e-05` seconds on my laptop
   - it adds quite a lot of complexity
   
   It's already super-fast, I don't think the extra complexity is warranted