### PR TITLE
fix(rust): match_chunks shouldn't change the dtype

### DIFF
--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -481,7 +481,8 @@ where
                 })
                 .collect();
 
-            unsafe { Self::from_chunks(self.name(), chunks) }
+            // SAFETY: We just slice the original chunks, their type will not change.
+            unsafe { Self::from_chunks_and_dtype(self.name(), chunks, self.dtype().clone()) }
         };
 
         if self.chunks.len() != 1 {

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 
 import polars as pl
@@ -201,3 +203,36 @@ def test_agg_function_of_filter_10565() -> None:
     assert df_str.lazy().filter(pl.col("a").n_unique().over("a") == 1).collect(
         predicate_pushdown=False
     ).to_dict(as_series=False) == {"a": []}
+
+
+def test_filter_logical_type_13194() -> None:
+    data = {
+        "id": [1, 1, 2],
+        "date": [
+            [datetime(year=2021, month=1, day=1)],
+            [datetime(year=2021, month=1, day=1)],
+            [datetime(year=2025, month=1, day=30)],
+        ],
+        "cat": [
+            ["a", "b", "c"],
+            ["a", "b", "c"],
+            ["d", "e", "f"],
+        ],
+    }
+
+    df = pl.DataFrame(data).with_columns(pl.col("cat").cast(pl.List(pl.Categorical())))
+
+    df = df.filter(pl.col("id") == pl.col("id").shift(1))
+    expected_df = pl.DataFrame(
+        {
+            "id": [1],
+            "date": [[datetime(year=2021, month=1, day=1)]],
+            "cat": [["a", "b", "c"]],
+        },
+        schema={
+            "id": pl.Int64,
+            "date": pl.List(pl.Datetime),
+            "cat": pl.List(pl.Categorical),
+        },
+    )
+    assert_frame_equal(df, expected_df)


### PR DESCRIPTION
This fixes #13194.