### PR TITLE
perf(python): Add `__slots__` to most Polars classes

### DIFF
--- a/py-polars/polars/api.py
+++ b/py-polars/polars/api.py
@@ -43,7 +43,6 @@ class NameSpace:
             return self._ns
 
         ns_instance = self._ns(instance)  # type: ignore[call-arg]
-        setattr(instance, self._accessor, ns_instance)
         return ns_instance
 
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -347,6 +347,8 @@ class DataFrame:
     False
     """
 
+    __slots__ = ("_df",)
+    _df: PyDataFrame
     _accessors: ClassVar[set[str]] = {"plot"}
 
     def __init__(

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -90,6 +90,8 @@ class DataTypeClass(type):
 class DataType(metaclass=DataTypeClass):
     """Base class for all Polars data types."""
 
+    __slots__ = ()
+
     def __reduce__(self) -> Any:
         return (_custom_reconstruct, (type(self), object, None), self.__dict__)
 
@@ -267,69 +269,103 @@ class DataTypeGroup(frozenset):  # type: ignore[type-arg]
 class NumericType(DataType):
     """Base class for numeric data types."""
 
+    __slots__ = ()
+
 
 class IntegerType(NumericType):
     """Base class for integer data types."""
+
+    __slots__ = ()
 
 
 class SignedIntegerType(IntegerType):
     """Base class for signed integer data types."""
 
+    __slots__ = ()
+
 
 class UnsignedIntegerType(IntegerType):
     """Base class for unsigned integer data types."""
+
+    __slots__ = ()
 
 
 class FloatType(NumericType):
     """Base class for float data types."""
 
+    __slots__ = ()
+
 
 class TemporalType(DataType):
     """Base class for temporal data types."""
+
+    __slots__ = ()
 
 
 class NestedType(DataType):
     """Base class for nested data types."""
 
+    __slots__ = ()
+
 
 class Int8(SignedIntegerType):
     """8-bit signed integer type."""
+
+    __slots__ = ()
 
 
 class Int16(SignedIntegerType):
     """16-bit signed integer type."""
 
+    __slots__ = ()
+
 
 class Int32(SignedIntegerType):
     """32-bit signed integer type."""
+
+    __slots__ = ()
 
 
 class Int64(SignedIntegerType):
     """64-bit signed integer type."""
 
+    __slots__ = ()
+
 
 class UInt8(UnsignedIntegerType):
     """8-bit unsigned integer type."""
+
+    __slots__ = ()
 
 
 class UInt16(UnsignedIntegerType):
     """16-bit unsigned integer type."""
 
+    __slots__ = ()
+
 
 class UInt32(UnsignedIntegerType):
     """32-bit unsigned integer type."""
+
+    __slots__ = ()
 
 
 class UInt64(UnsignedIntegerType):
     """64-bit unsigned integer type."""
 
+    __slots__ = ()
+
 
 class Float32(FloatType):
     """32-bit floating point type."""
 
+    __slots__ = ()
+
 
 class Float64(FloatType):
     """64-bit floating point type."""
+
+    __slots__ = ()
 
 
 class Decimal(NumericType):
@@ -341,6 +377,8 @@ class Decimal(NumericType):
         It is a work-in-progress feature and may not always work as expected.
         It may be changed at any point without it being considered a breaking change.
     """
+
+    __slots__ = ("precision", "scale")
 
     precision: int | None
     scale: int
@@ -383,9 +421,13 @@ class Decimal(NumericType):
 class Boolean(DataType):
     """Boolean type."""
 
+    __slots__ = ()
+
 
 class String(DataType):
     """UTF-8 encoded string type."""
+
+    __slots__ = ()
 
 
 # Allow Utf8 as an alias for String
@@ -395,13 +437,19 @@ Utf8 = String
 class Binary(DataType):
     """Binary type."""
 
+    __slots__ = ()
+
 
 class Date(TemporalType):
     """Calendar date type."""
 
+    __slots__ = ()
+
 
 class Time(TemporalType):
     """Time of day type."""
+
+    __slots__ = ()
 
 
 class Datetime(TemporalType):
@@ -606,13 +654,19 @@ class Enum(DataType):
 class Object(DataType):
     """Type for wrapping arbitrary Python objects."""
 
+    __slots__ = ()
+
 
 class Null(DataType):
     """Type representing Null / None values."""
 
+    __slots__ = ()
+
 
 class Unknown(DataType):
     """Type representing Datatype values that could not be determined statically."""
+
+    __slots__ = ()
 
 
 class List(NestedType):
@@ -738,6 +792,10 @@ class Array(NestedType):
 class Field:
     """Definition of a single field within a `Struct` DataType."""
 
+    __slots__ = ("name", "dtype")
+    name: str
+    dtype: PolarsDataType
+
     def __init__(self, name: str, dtype: PolarsDataType):
         """
         Definition of a single field within a `Struct` DataType.
@@ -766,6 +824,7 @@ class Field:
 class Struct(NestedType):
     """Struct composite type."""
 
+    __slots__ = ("fields",)
     fields: list[Field]
 
     def __init__(self, fields: Sequence[Field] | SchemaDict):

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -237,6 +237,7 @@ def _custom_reconstruct(
 class DataTypeGroup(frozenset):  # type: ignore[type-arg]
     """Group of data types."""
 
+    __slots__ = ("_match_base_type",)
     _match_base_type: bool
 
     def __new__(
@@ -379,7 +380,6 @@ class Decimal(NumericType):
     """
 
     __slots__ = ("precision", "scale")
-
     precision: int | None
     scale: int
 
@@ -558,6 +558,7 @@ class Categorical(DataType):
             or string value (lexical).
     """
 
+    __slots__ = ("ordering",)
     ordering: CategoricalOrdering | None
 
     def __init__(
@@ -592,6 +593,7 @@ class Enum(DataType):
         It may be changed at any point without it being considered a breaking change.
     """
 
+    __slots__ = ("categories",)
     categories: Series
 
     def __init__(self, categories: Series | Iterable[str]):

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -109,7 +109,8 @@ elif BUILDING_SPHINX_DOCS:
 class Expr:
     """Expressions that can be used in various contexts."""
 
-    _pyexpr: PyExpr = None
+    __slots__ = ("_pyexpr",)
+    _pyexpr: PyExpr
     _accessors: ClassVar[set[str]] = {
         "arr",
         "cat",

--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -24,6 +24,8 @@ class When:
     In this state, `then` must be called to continue to finish the expression.
     """
 
+    __slots__ = ("_when",)
+
     def __init__(self, when: Any):
         self._when = when
 
@@ -48,6 +50,8 @@ class Then(Expr):
 
     Represents the state of the expression after `pl.when(...).then(...)` is called.
     """
+
+    __slots__ = ("_then",)
 
     def __init__(self, then: Any):
         self._then = then
@@ -106,6 +110,8 @@ class ChainedWhen(Expr):
     In this state, `then` must be called to continue to finish the expression.
     """
 
+    __slots__ = ("_chained_when",)
+
     def __init__(self, chained_when: Any):
         self._chained_when = chained_when
 
@@ -130,6 +136,8 @@ class ChainedThen(Expr):
 
     Represents the state of the expression after an additional `then` is called.
     """
+
+    __slots__ = ("_chained_then",)
 
     def __init__(self, chained_then: Any):
         self._chained_then = chained_then

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -286,6 +286,7 @@ class LazyFrame:
     └─────┴─────┴─────┘
     """
 
+    __slots__ = ("_ldf",)
     _ldf: PyLazyFrame
     _accessors: ClassVar[set[str]] = set()
 

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -242,6 +242,7 @@ def _combine_as_selector(
 class _selector_proxy_(Expr):
     """Base column selector expression/proxy."""
 
+    __slots__ = ("_attrs", "_repr_override")
     _attrs: dict[str, Any]
     _repr_override: str
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -237,7 +237,8 @@ class Series:
     ]
     """
 
-    _s: PySeries = None
+    __slots__ = ("_s",)
+    _s: PySeries
     _accessors: ClassVar[set[str]] = {
         "arr",
         "cat",


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/13198

In this PR are "safe" additions of `__slots__`. Mostly for classes that are not usually subclassed by users -  `pl.Expr`, its subclasses and build in namespaces.
`polars.datatypes.classes` also really good candidates, since they are instantiated now, but not included in this PR (yet?). 

Adding `__slots__` for LazyFrame (and `DataFrame`/`Series`) turned out to be a breaking change because of subclassing.
Using `ldf.__class__ = SubClassedLazyFrame`, like in [test_preservation_of_subclasses](https://github.com/pola-rs/polars/blob/bb0081236ec05af304ec36dcf38673b36fdad706/py-polars/tests/unit/test_lazy.py#L1105) is an error because of different object layouts. And even if subclass were to define `__slots__` - they can only be empty, without additional attributes on instance to keep this assigment valid.
That can't be solved without specific conversion mechanism to subclasses to properly create a new instance (like `pl.LazyFrame.as_subclass(SubClassedLazyFrame, *args, **kwargs)`) where `_ldf` attribute itself would be passed/assigned to new instance of subclass.
Also using `ldf.__class__ = SubClassedLazyFrame` a dirty hack anyway and if polars were to properly support subclassing of frames, I think something similar should be in place - then `__slots__` on them can be added safely.

Deeper description about `__slots__` and benefits\downsides can be found [here](https://stackoverflow.com/questions/472000/usage-of-slots).
Also in issue were not mentioned memory usage benefits aside from slightly faster attribute access.
 ([sqlalchemy](https://docs.sqlalchemy.org/en/20/changelog/migration_10.html#significant-improvements-in-structural-memory-use) claimed 46% less memory usage for it's internal structures). Even though in latest python versions this gap should be smaller, due to more compact dict.