### PR TITLE
fix(python): dont emit potentially incorrect "inefficient map_elements" warning for "lambda x: str(x)"

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -133,7 +133,7 @@ _NUMPY_FUNCTIONS = frozenset(
 )
 
 # python functions that we can map to native expressions
-_PYTHON_CASTS_MAP = {"float": "Float64", "int": "Int64", "str": "Utf8"}
+_PYTHON_CASTS_MAP = {"float": "Float64", "int": "Int64"}
 _PYTHON_BUILTINS = frozenset(_PYTHON_CASTS_MAP) | {"abs"}
 _PYTHON_METHODS_MAP = {
     "lower": "str.to_lowercase",

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -350,9 +350,9 @@ def test_parse_apply_miscellaneous() -> None:
     ("data", "func", "expr_repr"),
     [
         (
-            [1, 2, 3],
-            lambda x: str(x),
-            "s.cast(pl.Utf8)",
+            [1., 2., 3.],
+            lambda x: int(x),
+            "s.cast(pl.Int64)",
         ),
         (
             [-20, -12, -5, 0, 5, 12, 20],

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -295,7 +295,7 @@ def test_parse_apply_raw_functions() -> None:
     assert_frame_equal(*result_frames)
 
     # test primitive python casts
-    for py_cast, pl_dtype in ((str, pl.Utf8), (int, pl.Int64), (float, pl.Float64)):
+    for py_cast, pl_dtype in ((int, pl.Int64), (float, pl.Float64)):
         with pytest.warns(
             PolarsInefficientMapWarning,
             match=rf'(?s)with this one instead.*pl\.col\("a"\)\.cast\(pl\.{pl_dtype.__name__}\)',

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -129,7 +129,7 @@ TEST_CASES = [
     # ---------------------------------------------
     # string expr: case/cast ops
     # ---------------------------------------------
-    ("b", "lambda x: str(x).title()", 'pl.col("b").cast(pl.Utf8).str.to_titlecase()'),
+    ("b", "lambda x: x.title()", 'pl.col("b").str.to_titlecase()'),
     (
         "b",
         'lambda x: x.lower() + ":" + x.upper() + ":" + x.title()',
@@ -194,6 +194,7 @@ NOOP_TEST_CASES = [
     "lambda x: MY_DICT[1]",
     'lambda x: "first" if x == 1 else "not first"',
     'lambda x: np.sign(x, casting="unsafe")',
+    "lambda x: str(x)",
 ]
 
 EVAL_ENVIRONMENT = {


### PR DESCRIPTION
closes #10269 
closes #13246 

This has come up a couple times - seems this warning isn't necessary correct, depending on the dtype of the column of the dataframe that the expression is evaluated in
So I'd suggest just removing this particular one