### PR TITLE
perf: add fast path to `count_bits_set_by_offsets`

### DIFF
--- a/crates/polars-ops/src/chunked_array/list/count.rs
+++ b/crates/polars-ops/src/chunked_array/list/count.rs
@@ -23,8 +23,12 @@ fn count_bits_set_by_offsets(values: &Bitmap, offset: &[i64]) -> Vec<IdxSize> {
 
             let len = (end - current_offset) as usize;
 
-            let set_ones = len - count_zeros(bits, bitmap_offset + current_offset as usize, len);
-            set_ones as IdxSize
+            // Fast path where all bits are set.
+            if values.unset_bits() == 0 {
+                return len as IdxSize;
+            }
+
+            (len - count_zeros(bits, bitmap_offset + current_offset as usize, len)) as IdxSize
         })
         .collect_trusted()
 }

--- a/crates/polars-ops/src/chunked_array/list/count.rs
+++ b/crates/polars-ops/src/chunked_array/list/count.rs
@@ -6,6 +6,11 @@ use arrow::legacy::utils::CustomIterTools;
 use super::*;
 
 fn count_bits_set_by_offsets(values: &Bitmap, offset: &[i64]) -> Vec<IdxSize> {
+    // Fast path where all bits are unset.
+    if values.unset_bits() == values.len() {
+        return vec![0 as IdxSize; offset.len() - 1];
+    }
+
     let (bits, bitmap_offset, _) = values.as_slice();
 
     let mut running_offset = offset[0];

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -358,6 +358,10 @@ def test_list_sum_and_dtypes() -> None:
         {"a": [[False], [False, False], [False, False, False]]},
     ).select(pl.col("a").list.sum()).to_dict(as_series=False) == {"a": [0, 0, 0]}
 
+    assert pl.DataFrame(
+        {"a": [[True], [True, True], [True, True, True]]},
+    ).select(pl.col("a").list.sum()).to_dict(as_series=False) == {"a": [1, 2, 3]}
+
 
 def test_list_mean() -> None:
     assert pl.DataFrame({"a": [[1], [1, 2, 3], [1, 2, 3, 4], [1, 2, 3, 4, 5]]}).select(

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -349,6 +349,15 @@ def test_list_sum_and_dtypes() -> None:
         "a": [1, 6, 10, 15, None]
     }
 
+    # Booleans
+    assert pl.DataFrame(
+        {"a": [[True], [True, True], [True, False, True], [True, True, True, None]]},
+    ).select(pl.col("a").list.sum()).to_dict(as_series=False) == {"a": [1, 2, 2, 3]}
+
+    assert pl.DataFrame(
+        {"a": [[False], [False, False], [False, False, False]]},
+    ).select(pl.col("a").list.sum()).to_dict(as_series=False) == {"a": [0, 0, 0]}
+
 
 def test_list_mean() -> None:
     assert pl.DataFrame({"a": [[1], [1, 2, 3], [1, 2, 3, 4], [1, 2, 3, 4, 5]]}).select(


### PR DESCRIPTION
Add fast path to `count_bits_set_by_offsets` when all bits are either set or cleared.

Some benchmarks:

```python
# Mixed True's and False's
df = pl.DataFrame({'A': [[False, True] * 100, [True] * 200] * 500})
%timeit df.with_columns(sum=pl.col('A').list.sum())
304 µs ± 2.34 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)


# All False
df = pl.DataFrame({'A': [[False, False] * 100, [False] * 200] * 500})
%timeit df.with_columns(sum=pl.col('A').list.sum())
68.7 µs ± 301 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)


# All True
df = pl.DataFrame({'A': [[True, True] * 100, [True] * 200] * 500})
%timeit df.with_columns(pl.col('A').list.sum())
72.4 µs ± 392 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```