### PR TITLE
docs(python): Fix display of overloaded signatures

### DIFF
--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -16,5 +16,6 @@ sphinx-autosummary-accessors==2023.4.0
 sphinx-copybutton==0.5.2
 sphinx-design==0.5.0
 sphinx-favicon==1.0.1
+sphinx-toolbox==3.5.0
 
 livereload==2.6.3

--- a/py-polars/docs/source/conf.py
+++ b/py-polars/docs/source/conf.py
@@ -44,6 +44,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "sphinx_favicon",
+    "sphinx_toolbox.more_autodoc.overloads",
 ]
 
 # Render docstring text in `single backticks` as code.
@@ -60,6 +61,11 @@ templates_path = ["_templates", sphinx_autosummary_accessors.templates_path]
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ["Thumbs.db", ".DS_Store"]
+
+# Hide overload type signatures
+# sphinx_toolbox - Box of handy tools for Sphinx
+# https://sphinx-toolbox.readthedocs.io/en/latest/
+overloads_location = ["bottom"]
 
 # -- Extension settings  -----------------------------------------------------
 


### PR DESCRIPTION
This removes typing overloads from the API reference.

See the `read_excel` docs to find out why it's currently a problem:
https://pola-rs.github.io/polars/docs/python/dev/reference/api/polars.read_excel.html

After this update:
![image](https://github.com/pola-rs/polars/assets/3502351/18ca60f8-e4c0-45f1-8752-e14a734fcb7e)
