### PR TITLE
release(python): Python Polars 0.20.3-rc.1 (pre-release)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "py-polars"
-version = "0.20.2"
+version = "0.20.3-rc.1"
 dependencies = [
  "ahash",
  "built",

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-polars"
-version = "0.20.2"
+version = "0.20.3-rc.1"
 edition = "2021"
 
 [lib]

--- a/py-polars/tests/unit/test_consortium_standard.py
+++ b/py-polars/tests/unit/test_consortium_standard.py
@@ -4,7 +4,11 @@ Test some basic methods of the dataframe consortium standard.
 Full testing is done at https://github.com/data-apis/dataframe-api-compat,
 this is just to check that the entry point works as expected.
 """
+import pytest
+
 import polars as pl
+
+pytestmark = pytest.mark.skip(reason="Bug in version parsing of dataframe-api-compat")
 
 
 def test_dataframe() -> None:


### PR DESCRIPTION
We made some updates to the build system we want to try out.

We now check whether or not your CPU can run Polars (https://github.com/pola-rs/polars/pull/13134). If not, we throw a warning. We want to make sure this check does not cause problems for our users. If you can, please install the pre-release version and see if everything runs correctly for you!

Some tests failed due to a dependency not handling pre-release versions, these are skipped now and an issue has been created: https://github.com/data-apis/dataframe-api-compat/issues/62