### PR TITLE
perf: don't needlessly allocate validity in concat/rechunk

### DIFF
--- a/crates/polars-arrow/src/array/growable/binary.rs
+++ b/crates/polars-arrow/src/array/growable/binary.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
-use super::utils::{build_extend_null_bits, extend_offset_values, ExtendNullBits};
+use super::utils::extend_offset_values;
 use super::Growable;
+use crate::array::growable::utils::{extend_validity, prepare_validity};
 use crate::array::{Array, BinaryArray};
 use crate::bitmap::MutableBitmap;
 use crate::datatypes::ArrowDataType;
@@ -11,10 +12,9 @@ use crate::offset::{Offset, Offsets};
 pub struct GrowableBinary<'a, O: Offset> {
     arrays: Vec<&'a BinaryArray<O>>,
     data_type: ArrowDataType,
-    validity: MutableBitmap,
+    validity: Option<MutableBitmap>,
     values: Vec<u8>,
     offsets: Offsets<O>,
-    extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a, O: Offset> GrowableBinary<'a, O> {
@@ -30,18 +30,12 @@ impl<'a, O: Offset> GrowableBinary<'a, O> {
             use_validity = true;
         };
 
-        let extend_null_bits = arrays
-            .iter()
-            .map(|array| build_extend_null_bits(*array, use_validity))
-            .collect();
-
         Self {
             arrays,
             data_type,
             values: Vec::with_capacity(0),
             offsets: Offsets::with_capacity(capacity),
-            validity: MutableBitmap::with_capacity(capacity),
-            extend_null_bits,
+            validity: prepare_validity(use_validity, capacity),
         }
     }
 
@@ -51,15 +45,20 @@ impl<'a, O: Offset> GrowableBinary<'a, O> {
         let offsets = std::mem::take(&mut self.offsets);
         let values = std::mem::take(&mut self.values);
 
-        BinaryArray::<O>::new(data_type, offsets.into(), values.into(), validity.into())
+        BinaryArray::<O>::new(
+            data_type,
+            offsets.into(),
+            values.into(),
+            validity.map(|v| v.into()),
+        )
     }
 }
 
 impl<'a, O: Offset> Growable<'a> for GrowableBinary<'a, O> {
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        (self.extend_null_bits[index])(&mut self.validity, start, len);
-
         let array = self.arrays[index];
+        extend_validity(&mut self.validity, array, start, len);
+
         let offsets = array.offsets();
         let values = array.values();
 
@@ -73,7 +72,9 @@ impl<'a, O: Offset> Growable<'a> for GrowableBinary<'a, O> {
 
     fn extend_validity(&mut self, additional: usize) {
         self.offsets.extend_constant(additional);
-        self.validity.extend_constant(additional, false);
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
     }
 
     #[inline]
@@ -96,7 +97,7 @@ impl<'a, O: Offset> From<GrowableBinary<'a, O>> for BinaryArray<O> {
             val.data_type,
             val.offsets.into(),
             val.values.into(),
-            val.validity.into(),
+            val.validity.map(|v| v.into()),
         )
     }
 }

--- a/crates/polars-arrow/src/array/growable/primitive.rs
+++ b/crates/polars-arrow/src/array/growable/primitive.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use super::utils::{build_extend_null_bits, ExtendNullBits};
 use super::Growable;
+use crate::array::growable::utils::{extend_validity, prepare_validity};
 use crate::array::{Array, PrimitiveArray};
 use crate::bitmap::MutableBitmap;
 use crate::datatypes::ArrowDataType;
@@ -10,10 +10,9 @@ use crate::types::NativeType;
 /// Concrete [`Growable`] for the [`PrimitiveArray`].
 pub struct GrowablePrimitive<'a, T: NativeType> {
     data_type: ArrowDataType,
-    arrays: Vec<&'a [T]>,
-    validity: MutableBitmap,
+    arrays: Vec<&'a PrimitiveArray<T>>,
+    validity: Option<MutableBitmap>,
     values: Vec<T>,
-    extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a, T: NativeType> GrowablePrimitive<'a, T> {
@@ -33,22 +32,11 @@ impl<'a, T: NativeType> GrowablePrimitive<'a, T> {
 
         let data_type = arrays[0].data_type().clone();
 
-        let extend_null_bits = arrays
-            .iter()
-            .map(|array| build_extend_null_bits(*array, use_validity))
-            .collect();
-
-        let arrays = arrays
-            .iter()
-            .map(|array| array.values().as_slice())
-            .collect::<Vec<_>>();
-
         Self {
             data_type,
             arrays,
             values: Vec::with_capacity(capacity),
-            validity: MutableBitmap::with_capacity(capacity),
-            extend_null_bits,
+            validity: prepare_validity(use_validity, capacity),
         }
     }
 
@@ -57,16 +45,21 @@ impl<'a, T: NativeType> GrowablePrimitive<'a, T> {
         let validity = std::mem::take(&mut self.validity);
         let values = std::mem::take(&mut self.values);
 
-        PrimitiveArray::<T>::new(self.data_type.clone(), values.into(), validity.into())
+        PrimitiveArray::<T>::new(
+            self.data_type.clone(),
+            values.into(),
+            validity.map(|v| v.into()),
+        )
     }
 }
 
 impl<'a, T: NativeType> Growable<'a> for GrowablePrimitive<'a, T> {
     #[inline]
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        (self.extend_null_bits[index])(&mut self.validity, start, len);
+        let array = self.arrays[index];
+        extend_validity(&mut self.validity, array, start, len);
 
-        let values = self.arrays[index];
+        let values = array.values().as_slice();
         self.values.extend_from_slice(&values[start..start + len]);
     }
 
@@ -74,7 +67,9 @@ impl<'a, T: NativeType> Growable<'a> for GrowablePrimitive<'a, T> {
     fn extend_validity(&mut self, additional: usize) {
         self.values
             .resize(self.values.len() + additional, T::default());
-        self.validity.extend_constant(additional, false);
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
     }
 
     #[inline]
@@ -96,6 +91,10 @@ impl<'a, T: NativeType> Growable<'a> for GrowablePrimitive<'a, T> {
 impl<'a, T: NativeType> From<GrowablePrimitive<'a, T>> for PrimitiveArray<T> {
     #[inline]
     fn from(val: GrowablePrimitive<'a, T>) -> Self {
-        PrimitiveArray::<T>::new(val.data_type, val.values.into(), val.validity.into())
+        PrimitiveArray::<T>::new(
+            val.data_type,
+            val.values.into(),
+            val.validity.map(|v| v.into()),
+        )
     }
 }

--- a/crates/polars-arrow/src/array/growable/structure.rs
+++ b/crates/polars-arrow/src/array/growable/structure.rs
@@ -1,16 +1,15 @@
 use std::sync::Arc;
 
-use super::utils::{build_extend_null_bits, ExtendNullBits};
 use super::{make_growable, Growable};
+use crate::array::growable::utils::{extend_validity, prepare_validity};
 use crate::array::{Array, StructArray};
 use crate::bitmap::MutableBitmap;
 
 /// Concrete [`Growable`] for the [`StructArray`].
 pub struct GrowableStruct<'a> {
     arrays: Vec<&'a StructArray>,
-    validity: MutableBitmap,
+    validity: Option<MutableBitmap>,
     values: Vec<Box<dyn Growable<'a> + 'a>>,
-    extend_null_bits: Vec<ExtendNullBits<'a>>,
 }
 
 impl<'a> GrowableStruct<'a> {
@@ -25,11 +24,6 @@ impl<'a> GrowableStruct<'a> {
         if arrays.iter().any(|array| array.null_count() > 0) {
             use_validity = true;
         };
-
-        let extend_null_bits = arrays
-            .iter()
-            .map(|array| build_extend_null_bits(*array, use_validity))
-            .collect();
 
         let arrays = arrays
             .iter()
@@ -53,8 +47,7 @@ impl<'a> GrowableStruct<'a> {
         Self {
             arrays,
             values,
-            validity: MutableBitmap::with_capacity(capacity),
-            extend_null_bits,
+            validity: prepare_validity(use_validity, capacity),
         }
     }
 
@@ -63,15 +56,19 @@ impl<'a> GrowableStruct<'a> {
         let values = std::mem::take(&mut self.values);
         let values = values.into_iter().map(|mut x| x.as_box()).collect();
 
-        StructArray::new(self.arrays[0].data_type().clone(), values, validity.into())
+        StructArray::new(
+            self.arrays[0].data_type().clone(),
+            values,
+            validity.map(|v| v.into()),
+        )
     }
 }
 
 impl<'a> Growable<'a> for GrowableStruct<'a> {
     fn extend(&mut self, index: usize, start: usize, len: usize) {
-        (self.extend_null_bits[index])(&mut self.validity, start, len);
-
         let array = self.arrays[index];
+        extend_validity(&mut self.validity, array, start, len);
+
         if array.null_count() == 0 {
             self.values
                 .iter_mut()
@@ -95,18 +92,17 @@ impl<'a> Growable<'a> for GrowableStruct<'a> {
         self.values
             .iter_mut()
             .for_each(|child| child.extend_validity(additional));
-        self.validity.extend_constant(additional, false);
+        if let Some(validity) = &mut self.validity {
+            validity.extend_constant(additional, false);
+        }
     }
 
     #[inline]
     fn len(&self) -> usize {
-        // All children should have the same indexing, so just use the first
-        // one. If we don't have children, we might still have a validity
-        // array, so use that.
         if let Some(child) = self.values.first() {
             child.len()
         } else {
-            self.validity.len()
+            unreachable!()
         }
     }
 
@@ -126,7 +122,7 @@ impl<'a> From<GrowableStruct<'a>> for StructArray {
         StructArray::new(
             val.arrays[0].data_type().clone(),
             values,
-            val.validity.into(),
+            val.validity.map(|v| v.into()),
         )
     }
 }

--- a/crates/polars-arrow/src/array/growable/utils.rs
+++ b/crates/polars-arrow/src/array/growable/utils.rs
@@ -2,29 +2,6 @@ use crate::array::Array;
 use crate::bitmap::MutableBitmap;
 use crate::offset::Offset;
 
-// function used to extend nulls from arrays. This function's lifetime is bound to the array
-// because it reads nulls from it.
-pub(super) type ExtendNullBits<'a> = Box<dyn Fn(&mut MutableBitmap, usize, usize) + 'a>;
-
-pub(super) fn build_extend_null_bits(array: &dyn Array, use_validity: bool) -> ExtendNullBits {
-    if let Some(bitmap) = array.validity() {
-        Box::new(move |validity, start, len| {
-            debug_assert!(start + len <= bitmap.len());
-            let (slice, offset, _) = bitmap.as_slice();
-            // safety: invariant offset + length <= slice.len()
-            unsafe {
-                validity.extend_from_slice_unchecked(slice, start + offset, len);
-            }
-        })
-    } else if use_validity {
-        Box::new(|validity, _, len| {
-            validity.extend_constant(len, true);
-        })
-    } else {
-        Box::new(|_, _, _| {})
-    }
-}
-
 #[inline]
 pub(super) fn extend_offset_values<O: Offset>(
     buffer: &mut Vec<u8>,
@@ -37,4 +14,33 @@ pub(super) fn extend_offset_values<O: Offset>(
     let end_values = offsets[start + len].to_usize();
     let new_values = &values[start_values..end_values];
     buffer.extend_from_slice(new_values);
+}
+
+pub(super) fn prepare_validity(use_validity: bool, capacity: usize) -> Option<MutableBitmap> {
+    if use_validity {
+        Some(MutableBitmap::with_capacity(capacity))
+    } else {
+        None
+    }
+}
+
+pub(super) fn extend_validity(
+    mutable_validity: &mut Option<MutableBitmap>,
+    array: &dyn Array,
+    start: usize,
+    len: usize,
+) {
+    if let Some(mutable_validity) = mutable_validity {
+        match array.validity() {
+            None => mutable_validity.extend_constant(len, true),
+            Some(validity) => {
+                debug_assert!(start + len <= validity.len());
+                let (slice, offset, _) = validity.as_slice();
+                // safety: invariant offset + length <= slice.len()
+                unsafe {
+                    mutable_validity.extend_from_slice_unchecked(slice, start + offset, len);
+                }
+            },
+        }
+    }
 }


### PR DESCRIPTION
This came to light in #13243. During a concat/rechunk, we always allocate (and write/copy to) a `validity` buffer, even when there are no nulls.

This ensures we don't.