### PR TITLE
chore(python): Copy Makefile build commands to top level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,39 @@ requirements: .venv  ## Install/refresh Python project requirements
 
 .PHONY: build
 build: .venv  ## Compile and install Python Polars for development
-	@$(MAKE) -s -C py-polars build
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml
+
+.PHONY: build-debug-opt
+build-debug-opt: .venv  ## Compile and install Python Polars with minimal optimizations turned on
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --profile opt-dev
+
+.PHONY: build-debug-opt-subset
+build-debug-opt-subset: .venv  ## Compile and install Python Polars with minimal optimizations turned on and no default features
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --no-default-features --profile opt-dev
+
+.PHONY: build-opt
+build-opt: .venv  ## Compile and install Python Polars with nearly full optimization on and debug assertions turned off, but with debug symbols on
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --profile debug-release
+
+.PHONY: build-release
+build-release: .venv  ## Compile and install a faster Python Polars binary with full optimizations
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --release
+
+.PHONY: build-native
+build-native: .venv  ## Same as build, except with native CPU optimizations turned on
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml -- -C target-cpu=native
+
+.PHONY: build-debug-opt-native
+build-debug-opt-native: .venv  ## Same as build-debug-opt, except with native CPU optimizations turned on
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --profile opt-dev -- -C target-cpu=native
+
+.PHONY: build-opt-native
+build-opt-native: .venv  ## Same as build-opt, except with native CPU optimizations turned on
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --profile debug-release -- -C target-cpu=native
+
+.PHONY: build-release-native
+build-release-native: .venv  ## Same as build-release, except with native CPU optimizations turned on
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --release -- -C target-cpu=native
 
 .PHONY: clippy
 clippy:  ## Run clippy with all features

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -20,39 +20,39 @@ requirements: .venv  ## Install/refresh all project requirements
 
 .PHONY: build
 build: .venv  ## Compile and install Polars for development
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop
+	@$(MAKE) -s -C .. $@
 
 .PHONY: build-debug-opt
 build-debug-opt: .venv  ## Compile and install Polars with minimal optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --profile opt-dev
+	@$(MAKE) -s -C .. $@
 
 .PHONY: build-debug-opt-subset
 build-debug-opt-subset: .venv  ## Compile and install Polars with minimal optimizations turned on and no default features
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --no-default-features --profile opt-dev
+	@$(MAKE) -s -C .. $@
 
 .PHONY: build-opt
 build-opt: .venv  ## Compile and install Polars with nearly full optimization on and debug assertions turned off, but with debug symbols on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --profile debug-release
+	@$(MAKE) -s -C .. $@
 
 .PHONY: build-release
 build-release: .venv  ## Compile and install a faster Polars binary with full optimizations
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --release
+	@$(MAKE) -s -C .. $@
 
 .PHONY: build-native
 build-native: .venv  ## Same as build, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -- -C target-cpu=native
+	@$(MAKE) -s -C .. $@
 
 .PHONY: build-debug-opt-native
 build-debug-opt-native: .venv  ## Same as build-debug-opt, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --profile opt-dev -- -C target-cpu=native
+	@$(MAKE) -s -C .. $@
 
 .PHONY: build-opt-native
 build-opt-native: .venv  ## Same as build-opt, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --profile debug-release -- -C target-cpu=native
+	@$(MAKE) -s -C .. $@
 
 .PHONY: build-release-native
 build-release-native: .venv  ## Same as build-release, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop --release -- -C target-cpu=native
+	@$(MAKE) -s -C .. $@
 
 .PHONY: fmt
 fmt: .venv  ## Run autoformatting and linting


### PR DESCRIPTION
I want to be able to do everything from the repo root. For convenience, commands are still available in `py-polars`.