### PR TITLE
feat(python): rework `pl.exclude` as a pure selector, allowing other selectors as input

### DIFF
--- a/crates/polars-plan/src/dsl/meta.rs
+++ b/crates/polars-plan/src/dsl/meta.rs
@@ -28,6 +28,7 @@ impl MetaNameSpace {
     pub fn root_names(&self) -> Vec<Arc<str>> {
         expr_to_leaf_column_names(&self.0)
     }
+
     /// A projection that only takes a column or a column + alias.
     pub fn is_simple_projection(&self) -> bool {
         let mut arena = Arena::with_capacity(8);
@@ -59,7 +60,7 @@ impl MetaNameSpace {
         self.0
     }
 
-    /// Whether this expression expands to multiple expressions.
+    /// Indicate if this expression expands to multiple expressions.
     pub fn has_multiple_outputs(&self) -> bool {
         self.0.into_iter().any(|e| match e {
             Expr::Selector(_) | Expr::Wildcard | Expr::Columns(_) | Expr::DtypeColumn(_) => true,
@@ -68,7 +69,15 @@ impl MetaNameSpace {
         })
     }
 
-    /// Whether this expression expands to multiple expressions with regex expansion.
+    /// Indicate if this expression is a basic (non-regex) column.
+    pub fn is_column(&self) -> bool {
+        match &self.0 {
+            Expr::Column(name) => !is_regex_projection(name),
+            _ => false,
+        }
+    }
+
+    /// Indicate if this expression expands to multiple expressions with regex expansion.
     pub fn is_regex_projection(&self) -> bool {
         self.0.into_iter().any(|e| match e {
             Expr::Column(name) => is_regex_projection(name),

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -933,7 +933,7 @@ class Expr:
             else:
                 raise TypeError(
                     "invalid input for `exclude`"
-                    f"\n\nExpected one or more `str`, `DataType`, or selector; found {type(item).__name__!r} instead."
+                    f"\n\nExpected one or more `str` or `DataType`; found {item!r} instead."
                 )
 
         if exclude_cols and exclude_dtypes:

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -65,7 +65,7 @@ class ExprMetaNameSpace:
 
     def has_multiple_outputs(self) -> bool:
         """
-        Whether this expression expands into multiple expressions.
+        Indicate if this expression expands into multiple expressions.
 
         Examples
         --------
@@ -76,9 +76,28 @@ class ExprMetaNameSpace:
         """
         return self._pyexpr.meta_has_multiple_outputs()
 
+    def is_column(self) -> bool:
+        r"""
+        Indicate if this expression is a basic (non-regex) unaliased column.
+
+        Examples
+        --------
+        >>> e = pl.col("foo")
+        >>> e.meta.is_column()
+        True
+        >>> e = pl.col("foo") * pl.col("bar")
+        >>> e.meta.is_column()
+        False
+        >>> e = pl.col(r"^col.*\d+$")
+        >>> e.meta.is_column()
+        False
+
+        """
+        return self._pyexpr.meta_is_column()
+
     def is_regex_projection(self) -> bool:
         """
-        Whether this expression expands to columns that match a regex pattern.
+        Indicate if this expression expands to columns that match a regex pattern.
 
         Examples
         --------

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
         IntoExpr,
         PolarsDataType,
         RollingInterpolationMethod,
+        SelectorType,
     )
 
 
@@ -1195,21 +1196,28 @@ def arctan2d(y: str | Expr, x: str | Expr) -> Expr:
 
 
 def exclude(
-    columns: str | PolarsDataType | Collection[str] | Collection[PolarsDataType],
-    *more_columns: str | PolarsDataType,
+    columns: (
+        str
+        | PolarsDataType
+        | SelectorType
+        | Expr
+        | Collection[str | PolarsDataType | SelectorType | Expr]
+    ),
+    *more_columns: str | PolarsDataType | SelectorType | Expr,
 ) -> Expr:
     """
-    Represent all columns except for the given columns.
+    Select all columns except those matching the given columns, datatypes, or selectors.
 
-    Syntactic sugar for `pl.all().exclude(columns)`.
+    .. versionchanged:: 0.20.3
+        This function is now a simple redirect to the `cs.exclude()` selector.
 
     Parameters
     ----------
     columns
-        The name or datatype of the column(s) to exclude. Accepts regular expression
-        input. Regular expressions should start with `^` and end with `$`.
+        One or more columns (col or name), datatypes, columns, or selectors representing
+        the columns to exclude.
     *more_columns
-        Additional names or datatypes of columns to exclude, specified as positional
+        Additional columns, datatypes, or selectors to exclude, specified as positional
         arguments.
 
     Examples
@@ -1223,7 +1231,7 @@ def exclude(
     ...         "cc": [None, 2.5, 1.5],
     ...     }
     ... )
-    >>> df.select(pl.exclude("ba"))
+    >>> df.select(pl.exclude("ba", "xx"))
     shape: (3, 2)
     ┌─────┬──────┐
     │ aa  ┆ cc   │
@@ -1251,7 +1259,22 @@ def exclude(
 
     Exclude by dtype(s), e.g. removing all columns of type Int64 or Float64:
 
-    >>> df.select(pl.exclude([pl.Int64, pl.Float64]))
+    >>> df.select(pl.exclude(pl.Int64, pl.Float64))
+    shape: (3, 1)
+    ┌──────┐
+    │ ba   │
+    │ ---  │
+    │ str  │
+    ╞══════╡
+    │ a    │
+    │ b    │
+    │ null │
+    └──────┘
+
+    Exclude column using a compound selector:
+
+    >>> import polars.selectors as cs
+    >>> df.select(pl.exclude(cs.first() | cs.last()))
     shape: (3, 1)
     ┌──────┐
     │ ba   │
@@ -1264,7 +1287,9 @@ def exclude(
     └──────┘
 
     """
-    return F.col("*").exclude(columns, *more_columns)
+    from polars.selectors import exclude
+
+    return exclude(columns, *more_columns)
 
 
 def groups(column: str) -> Expr:

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import re
 from datetime import timezone
+from functools import reduce
+from operator import or_
 from typing import TYPE_CHECKING, Any, Collection, Literal, Mapping, overload
 
 from polars import functions as F
@@ -26,6 +28,7 @@ from polars.datatypes import (
 )
 from polars.expr import Expr
 from polars.utils.deprecation import deprecate_nonkeyword_arguments
+from polars.utils.various import is_column
 
 if TYPE_CHECKING:
     import sys
@@ -190,6 +193,66 @@ def _expand_selector_dicts(
     return expanded
 
 
+def _combine_as_selector(
+    items: (
+        str
+        | Expr
+        | PolarsDataType
+        | SelectorType
+        | Collection[str | Expr | PolarsDataType | SelectorType]
+    ),
+    *more_items: str | Expr | PolarsDataType | SelectorType,
+) -> SelectorType:
+    """Create a combined selector from cols, names, dtypes, and/or other selectors."""
+    names: list[str] = []
+    regexes = list[str]()
+    dtypes: list[PolarsDataType] = []
+    selectors: list[SelectorType] = []
+
+    for item in (
+        *(
+            items
+            if isinstance(items, Collection) and not isinstance(items, str)
+            else [items]
+        ),
+        *more_items,
+    ):
+        if is_selector(item):
+            selectors.append(item)
+        elif is_polars_dtype(item):
+            dtypes.append(item)  # type: ignore[arg-type]
+        elif isinstance(item, str):
+            if item.startswith("^") and item.endswith("$"):
+                regexes.append(item)
+            else:
+                names.append(item)
+        elif is_column(item):
+            names.append(item.meta.output_name())  # type: ignore[union-attr]
+        else:
+            raise TypeError(
+                "invalid input for `exclude`"
+                f"\n\nExpected one or more `str`, `DataType` or selector; found {item!r} instead."
+            )
+
+    selected = []
+    if names:
+        selected.append(by_name(*names))
+    if dtypes:
+        selected.append(by_dtype(*dtypes))
+    if regexes:
+        selected.append(
+            matches(
+                regexes[0]
+                if len(regexes) > 1
+                else "|".join(f"({rx})" for rx in regexes)
+            )
+        )
+    if selectors:
+        selected.extend(selectors)
+
+    return reduce(or_, selected)
+
+
 class _selector_proxy_(Expr):
     """Base column selector expression/proxy."""
 
@@ -243,6 +306,8 @@ class _selector_proxy_(Expr):
                 return f"cs.{selector_name}({str_params})"
 
     def __sub__(self, other: Any) -> SelectorType | Expr:  # type: ignore[override]
+        if is_column(other):
+            other = by_name(other.meta.output_name())
         if isinstance(other, _selector_proxy_) and hasattr(other, "_attrs"):
             return _selector_proxy_(
                 self.meta._as_selector().meta._selector_sub(other),
@@ -253,6 +318,8 @@ class _selector_proxy_(Expr):
             return self.as_expr().__sub__(other)
 
     def __and__(self, other: Any) -> SelectorType | Expr:  # type: ignore[override]
+        if is_column(other):
+            other = by_name(other.meta.output_name())
         if isinstance(other, _selector_proxy_) and hasattr(other, "_attrs"):
             return _selector_proxy_(
                 self.meta._as_selector().meta._selector_and(other),
@@ -263,6 +330,8 @@ class _selector_proxy_(Expr):
             return self.as_expr().__and__(other)
 
     def __or__(self, other: Any) -> SelectorType | Expr:  # type: ignore[override]
+        if is_column(other):
+            other = by_name(other.meta.output_name())
         if isinstance(other, _selector_proxy_) and hasattr(other, "_attrs"):
             return _selector_proxy_(
                 self.meta._as_selector().meta._selector_add(other),
@@ -274,6 +343,8 @@ class _selector_proxy_(Expr):
 
     def __rand__(self, other: Any) -> SelectorType | Expr:  # type: ignore[override]
         # order of operation doesn't matter
+        if is_column(other):
+            other = by_name(other.meta.output_name())
         if isinstance(other, _selector_proxy_) and hasattr(other, "_attrs"):
             return self.__and__(other)
         else:
@@ -281,6 +352,8 @@ class _selector_proxy_(Expr):
 
     def __ror__(self, other: Any) -> SelectorType | Expr:  # type: ignore[override]
         # order of operation doesn't matter
+        if is_column(other):
+            other = by_name(other.meta.output_name())
         if isinstance(other, _selector_proxy_) and hasattr(other, "_attrs"):
             return self.__or__(other)
         else:
@@ -296,10 +369,10 @@ class _selector_proxy_(Expr):
         return Expr._from_pyexpr(self._pyexpr)
 
 
-def _re_string(string: str | Collection[str]) -> str:
+def _re_string(string: str | Collection[str], *, escape: bool = True) -> str:
     """Return escaped regex, potentially representing multiple string fragments."""
     if isinstance(string, str):
-        rx = f"{re.escape(string)}"
+        rx = f"{re.escape(string)}" if escape else string
     else:
         strings: list[str] = []
         for st in string:
@@ -307,7 +380,7 @@ def _re_string(string: str | Collection[str]) -> str:
                 strings.extend(st)
             else:
                 strings.append(st)
-        rx = "|".join(re.escape(x) for x in strings)
+        rx = "|".join((re.escape(x) if escape else x) for x in strings)
     return f"({rx})"
 
 
@@ -1184,6 +1257,74 @@ def ends_with(*suffix: str) -> SelectorType:
         name="ends_with",
         parameters={"*suffix": escaped_suffix},
     )
+
+
+def exclude(
+    columns: (
+        str
+        | PolarsDataType
+        | SelectorType
+        | Expr
+        | Collection[str | PolarsDataType | SelectorType | Expr]
+    ),
+    *more_columns: str | PolarsDataType | SelectorType | Expr,
+) -> Expr:
+    """
+    Select all columns except those matching the given columns, datatypes, or selectors.
+
+    Parameters
+    ----------
+    columns
+        One or more columns (col or name), datatypes, columns, or selectors representing
+        the columns to exclude.
+    *more_columns
+        Additional columns, datatypes, or selectors to exclude, specified as positional
+        arguments.
+
+    Notes
+    -----
+    If excluding a single selector it is simpler to write as `~selector` instead.
+
+    Examples
+    --------
+    Exclude by column name(s):
+
+    >>> import polars.selectors as cs
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "aa": [1, 2, 3],
+    ...         "ba": ["a", "b", None],
+    ...         "cc": [None, 2.5, 1.5],
+    ...     }
+    ... )
+    >>> df.select(cs.exclude("ba", "xx"))
+    shape: (3, 2)
+    ┌─────┬──────┐
+    │ aa  ┆ cc   │
+    │ --- ┆ ---  │
+    │ i64 ┆ f64  │
+    ╞═════╪══════╡
+    │ 1   ┆ null │
+    │ 2   ┆ 2.5  │
+    │ 3   ┆ 1.5  │
+    └─────┴──────┘
+
+    Exclude using a column name, a selector, and a dtype:
+
+    >>> df.select(cs.exclude("aa", cs.string(), pl.UInt32))
+    shape: (3, 1)
+    ┌──────┐
+    │ cc   │
+    │ ---  │
+    │ f64  │
+    ╞══════╡
+    │ null │
+    │ 2.5  │
+    │ 1.5  │
+    └──────┘
+
+    """
+    return ~_combine_as_selector(columns, *more_columns)
 
 
 def first() -> SelectorType:

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -204,11 +204,7 @@ def _combine_as_selector(
     *more_items: str | Expr | PolarsDataType | SelectorType,
 ) -> SelectorType:
     """Create a combined selector from cols, names, dtypes, and/or other selectors."""
-    names: list[str] = []
-    regexes = list[str]()
-    dtypes: list[PolarsDataType] = []
-    selectors: list[SelectorType] = []
-
+    names, regexes, dtypes, selectors = [], [], [], []  # type: ignore[var-annotated]
     for item in (
         *(
             items
@@ -220,7 +216,7 @@ def _combine_as_selector(
         if is_selector(item):
             selectors.append(item)
         elif is_polars_dtype(item):
-            dtypes.append(item)  # type: ignore[arg-type]
+            dtypes.append(item)
         elif isinstance(item, str):
             if item.startswith("^") and item.endswith("$"):
                 regexes.append(item)
@@ -238,7 +234,7 @@ def _combine_as_selector(
     if names:
         selected.append(by_name(*names))
     if dtypes:
-        selected.append(by_dtype(*dtypes))
+        selected.append(by_dtype(*dtypes))  # type: ignore[arg-type]
     if regexes:
         selected.append(
             matches(

--- a/py-polars/polars/utils/__init__.py
+++ b/py-polars/polars/utils/__init__.py
@@ -19,7 +19,7 @@ from polars.utils.convert import (
 )
 from polars.utils.meta import get_index_type, threadpool_size
 from polars.utils.show_versions import show_versions
-from polars.utils.various import NoDefault, _polars_warn, no_default
+from polars.utils.various import NoDefault, _polars_warn, is_column, no_default
 
 __all__ = [
     "NoDefault",
@@ -27,6 +27,7 @@ __all__ = [
     "build_info",
     "show_versions",
     "get_index_type",
+    "is_column",
     "threadpool_size",
     # Required for Rust bindings
     "_date_to_pl_date",

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -120,6 +120,13 @@ def is_str_sequence(
     return isinstance(val, Sequence) and _is_iterable_of(val, str)
 
 
+def is_column(obj: Any) -> bool:
+    """Indicate if the given object is a basic/unaliased column."""
+    from polars.expr import Expr
+
+    return isinstance(obj, Expr) and obj.meta.is_column()
+
+
 def _warn_null_comparison(obj: Any) -> None:
     if obj is None:
         warnings.warn(

--- a/py-polars/src/expr/meta.rs
+++ b/py-polars/src/expr/meta.rs
@@ -46,6 +46,10 @@ impl PyExpr {
         self.inner.clone().meta().has_multiple_outputs()
     }
 
+    fn meta_is_column(&self) -> bool {
+        self.inner.clone().meta().is_column()
+    }
+
     fn meta_is_regex_projection(&self) -> bool {
         self.inner.clone().meta().is_regex_projection()
     }

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2642,7 +2642,8 @@ def test_selection_regex_and_multicol() -> None:
             "b": [5, 6, 7, 8],
             "c": [9, 10, 11, 12],
             "foo": [13, 14, 15, 16],
-        }
+        },
+        schema_overrides={"foo": pl.UInt8},
     )
 
     # Selection only
@@ -2679,22 +2680,14 @@ def test_selection_regex_and_multicol() -> None:
     # Multi * Multi
     result = test_df.select(pl.col(["a", "b", "c"]) * pl.col(["a", "b", "c"]))
     expected = {"a": [1, 4, 9, 16], "b": [25, 36, 49, 64], "c": [81, 100, 121, 144]}
-    assert result.to_dict(as_series=False) == expected
 
-    assert test_df.select(pl.exclude("foo") * pl.exclude("foo")).to_dict(
-        as_series=False
-    ) == {
-        "a": [1, 4, 9, 16],
-        "b": [25, 36, 49, 64],
-        "c": [81, 100, 121, 144],
-    }
-    assert test_df.select(pl.col("^\\w$") * pl.col("^\\w$")).to_dict(
-        as_series=False
-    ) == {
-        "a": [1, 4, 9, 16],
-        "b": [25, 36, 49, 64],
-        "c": [81, 100, 121, 144],
-    }
+    assert result.to_dict(as_series=False) == expected
+    for multi_op in (
+        pl.col("^\\w$") * pl.col("^\\w$"),
+        pl.exclude("foo") * pl.exclude("foo"),
+        pl.exclude(cs.last()) * pl.exclude(cs.by_dtype(pl.UInt8)),
+    ):
+        assert test_df.select(multi_op).to_dict(as_series=False) == expected
 
     # kwargs
     with pl.Config() as cfg:

--- a/py-polars/tests/unit/namespaces/test_meta.py
+++ b/py-polars/tests/unit/namespaces/test_meta.py
@@ -69,10 +69,26 @@ def test_meta_has_multiple_outputs() -> None:
     assert e.meta.has_multiple_outputs()
 
 
+def test_is_column() -> None:
+    e = pl.col("foo")
+    assert e.meta.is_column()
+
+    e = pl.col("foo").alias("bar")
+    assert not e.meta.is_column()
+
+    e = pl.col("foo") * pl.col("bar")
+    assert not e.meta.is_column()
+
+
 def test_meta_is_regex_projection() -> None:
     e = pl.col("^.*$").alias("bar")
     assert e.meta.is_regex_projection()
     assert e.meta.has_multiple_outputs()
+
+    e = pl.col("^.*")  # no trailing '$'
+    assert not e.meta.is_regex_projection()
+    assert not e.meta.has_multiple_outputs()
+    assert e.meta.is_column()
 
 
 def test_meta_tree_format(namespace_files_path: Path) -> None:


### PR DESCRIPTION
Closes #13247.

* Implemented `pl.exclude` as a dedicated selector (it now redirects to the new `cs.exclude`); adds flexibility, combining all input names/dtypes/selectors into a single/compound selector expression before subtracting that from `cs.all()`.
* Adds `expr.meta.is_column()`, as it's useful to know if an expression is a simple column or not; this allows for some parsing simplifications/extensions here, and a follow-up PR taking additional advantage is coming shortly.

## Note

We can consider retiring `pl.exclude` in the future as it is now a pure redirect to the more capable `cs.exclude`.

## Example

```python
import polars.selectors as cs
import polars as pl

df = pl.DataFrame({"a": [1], "b": [2], "c": [3]})

df.with_columns(
    pl.exclude(cs.first(), cs.last()) + 100
)
# shape: (1, 3)
# ┌─────┬─────┬─────┐
# │ a   ┆ b   ┆ c   │
# │ --- ┆ --- ┆ --- │
# │ i64 ┆ i64 ┆ i64 │
# ╞═════╪═════╪═════╡
# │ 1   ┆ 102 ┆ 3   │
# └─────┴─────┴─────┘
```
