### PR TITLE
feat(rust,python,cli): support common variant spelling `STDEV` in the SQL engine

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -602,9 +602,9 @@ impl PolarsSqlFunctions {
             "last" => Self::Last,
             "max" => Self::Max,
             "min" => Self::Min,
-            "stddev" | "stddev_samp" => Self::StdDev,
+            "stdev" | "stddev" | "stdev_samp" | "stddev_samp" => Self::StdDev,
             "sum" => Self::Sum,
-            "variance" | "var_samp" => Self::Variance,
+            "var" | "variance" | "var_samp" => Self::Variance,
 
             // ----
             // Array functions

--- a/py-polars/tests/unit/sql/test_sql.py
+++ b/py-polars/tests/unit/sql/test_sql.py
@@ -671,6 +671,49 @@ def test_sql_non_equi_joins(constraint: str) -> None:
         )
 
 
+def test_sql_stddev_variance() -> None:
+    df = pl.DataFrame(
+        {
+            "v1": [-1.0, 0.0, 1.0],
+            "v2": [5.5, 0.0, 3.0],
+            "v3": [-10, None, 10],
+            "v4": [-100, 0.0, -50.0],
+        }
+    )
+    with pl.SQLContext(df=df) as ctx:
+        # note: we support all common aliases for std/var
+        out = ctx.execute(
+            """
+            SELECT
+              STDEV(v1) AS "v1_std",
+              STDDEV(v2) AS "v2_std",
+              STDEV_SAMP(v3) AS "v3_std",
+              STDDEV_SAMP(v4) AS "v4_std",
+              VAR(v1) AS "v1_var",
+              VARIANCE(v2) AS "v2_var",
+              VARIANCE(v3) AS "v3_var",
+              VAR_SAMP(v4) AS "v4_var"
+            FROM df
+            """
+        ).collect()
+
+        assert_frame_equal(
+            out,
+            pl.DataFrame(
+                {
+                    "v1_std": [1.0],
+                    "v2_std": [2.7537852736431],
+                    "v3_std": [14.142135623731],
+                    "v4_std": [50.0],
+                    "v1_var": [1.0],
+                    "v2_var": [7.5833333333333],
+                    "v3_var": [200.0],
+                    "v4_var": [2500.0],
+                }
+            ),
+        )
+
+
 def test_sql_is_between(foods_ipc_path: Path) -> None:
     lf = pl.scan_ipc(foods_ipc_path)
 


### PR DESCRIPTION
Closes #13302.

It's a coin-flip as to which spelling ("stdev" or "stddev") is used in different database dialects, and there's no harm in supporting both; will make it a little more accessible if you're not a longtime PostgreSQL user (also added support for "var" as an alias for "variance" for much the same reason - didn't add "std" for "stddev" as it is a little more ambiguous and less widely used).

Added new test coverage for both "stddev" and "variance".