### PR TITLE
fix: invalid schema outer join after projection pd

### DIFF
--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -25,7 +25,6 @@ mod string;
 #[cfg(feature = "dtype-struct")]
 mod struct_;
 
-#[cfg(feature = "object")]
 use std::any::Any;
 use std::borrow::Cow;
 use std::ops::{BitAnd, BitOr, BitXor, Deref};
@@ -427,7 +426,6 @@ macro_rules! impl_dyn_series {
                 self.0.checked_div(rhs)
             }
 
-            #[cfg(feature = "object")]
             fn as_any(&self) -> &dyn Any {
                 &self.0
             }

--- a/crates/polars-plan/src/dsl/function_expr/range/datetime_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/datetime_range.rs
@@ -41,7 +41,7 @@ pub(super) fn datetime_range(
         (DataType::Datetime(_, _), None) => start.dtype().clone(),
         // overwrite time unit, keep timezone
         (DataType::Datetime(_, tz), Some(tu)) => DataType::Datetime(tu, tz.clone()),
-        _ => unreachable!(),
+        (dt, _) => polars_bail!(InvalidOperation: "expected a temporal datatype, got {}", dt),
     };
 
     // overwrite time zone, if specified

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/joins.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/joins.rs
@@ -258,8 +258,8 @@ pub(super) fn process_join(
             .unwrap();
             already_added_local_to_local_projected.insert(local_name);
         }
-        // in outer joins both columns remain. So `add_local=true` also for the right table
-        let add_local = matches!(options.args.how, JoinType::Outer { .. });
+        // In outer joins both columns remain. So `add_local=true` also for the right table
+        let add_local = matches!(options.args.how, JoinType::Outer { coalesce: false });
         for e in &right_on {
             add_keys_to_accumulated_state(
                 *e,

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/joins.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/joins.rs
@@ -258,6 +258,8 @@ pub(super) fn process_join(
             .unwrap();
             already_added_local_to_local_projected.insert(local_name);
         }
+        // in outer joins both columns remain. So `add_local=true` also for the right table
+        let add_local = matches!(options.args.how, JoinType::Outer { .. });
         for e in &right_on {
             add_keys_to_accumulated_state(
                 *e,
@@ -265,7 +267,7 @@ pub(super) fn process_join(
                 &mut local_projection,
                 &mut names_right,
                 expr_arena,
-                false,
+                add_local,
             );
         }
 

--- a/py-polars/tests/unit/test_projections.py
+++ b/py-polars/tests/unit/test_projections.py
@@ -354,3 +354,17 @@ def test_projection_count_11841() -> None:
     pl.LazyFrame({"x": 1}).select(records=pl.count()).select(
         pl.lit(1).alias("x"), pl.all()
     ).collect()
+
+
+def test_schema_outer_join_projection_pd_13287() -> None:
+    lf = pl.LazyFrame({"a": [1, 1], "b": [2, 3]})
+    lf2 = pl.LazyFrame({"a": [1, 1], "c": [2, 3]})
+
+    assert lf.join(
+        lf2,
+        how="outer",
+        left_on="a",
+        right_on="c",
+    ).with_columns(
+        pl.col("a").fill_null(pl.col("c")),
+    ).select("a").collect().to_dict(as_series=False) == {"a": [2, 3, 1, 1]}


### PR DESCRIPTION
0.20 introduced new behavior for outer joins. This introduced a bug in the projection pushdown optimizer. 

Fixes #13287