### PR TITLE
fix(rust,python): fix `csv` parser error when commented-out rows precede the header row

### DIFF
--- a/crates/polars-io/src/csv/parser.rs
+++ b/crates/polars-io/src/csv/parser.rs
@@ -157,15 +157,11 @@ where
     &input[read..]
 }
 
+/// Remove whitespace from the start of buffer.
 /// Makes sure that the bytes stream starts with
 ///     'field_1,field_2'
 /// and not with
 ///     '\nfield_1,field_1'
-pub(crate) fn skip_header(input: &[u8], quote: Option<u8>, eol_char: u8) -> &[u8] {
-    skip_this_line(input, quote, eol_char)
-}
-
-/// Remove whitespace from the start of buffer.
 #[inline]
 pub(crate) fn skip_whitespace(input: &[u8]) -> &[u8] {
     skip_condition(input, is_whitespace)
@@ -338,7 +334,7 @@ fn find_quoted(bytes: &[u8], quote_char: u8, needle: u8) -> Option<usize> {
 }
 
 #[inline]
-fn skip_this_line(bytes: &[u8], quote: Option<u8>, eol_char: u8) -> &[u8] {
+pub(crate) fn skip_this_line(bytes: &[u8], quote: Option<u8>, eol_char: u8) -> &[u8] {
     let pos = match quote {
         Some(quote) => find_quoted(bytes, quote, eol_char),
         None => bytes.iter().position(|x| *x == eol_char),

--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -327,11 +327,7 @@ impl<'a> CoreReader<'a> {
             bytes = skip_line_ending(bytes, eol_char)
         }
 
-        // If there is a header we skip it.
-        if self.has_header {
-            bytes = skip_header(bytes, quote_char, eol_char);
-        }
-
+        // skip 'n' leading rows
         if self.skip_rows_before_header > 0 {
             for _ in 0..self.skip_rows_before_header {
                 let pos = next_line_position_naive(bytes, eol_char)
@@ -339,7 +335,11 @@ impl<'a> CoreReader<'a> {
                 bytes = &bytes[pos..];
             }
         }
-
+        // skip header row
+        if self.has_header {
+            bytes = skip_this_line(bytes, quote_char, eol_char);
+        }
+        // skip 'n' rows following the header
         if self.skip_rows_after_header > 0 {
             for _ in 0..self.skip_rows_after_header {
                 let pos = if is_comment_line(bytes, self.comment_prefix.as_ref()) {

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -591,6 +591,16 @@ def test_csv_multi_char_comment() -> None:
     expected = pl.DataFrame({"A": ["#a"], "B": ["b"]})
     assert_frame_equal(df, expected)
 
+    # check comment interaction with headers/skip_rows
+    for skip_rows, b in (
+        (1, io.BytesIO(b"<filemeta>\n#!skip\n#!skip\nCol1\tCol2\n")),
+        (0, io.BytesIO(b"\n#!skip\n#!skip\nCol1\tCol2")),
+        (0, io.BytesIO(b"#!skip\nCol1\tCol2\n#!skip\n")),
+        (0, io.BytesIO(b"#!skip\nCol1\tCol2")),
+    ):
+        df = pl.read_csv(b, separator="\t", comment_prefix="#!", skip_rows=skip_rows)
+        assert_frame_equal(df, pl.DataFrame(schema=["Col1", "Col2"]).cast(pl.Utf8))
+
 
 def test_csv_quote_char() -> None:
     expected = pl.DataFrame(


### PR DESCRIPTION
Closes #13022.

The linked issue mentions `raise_if_empty` but that's a red herring; the real issue is that we were trying to skip the header row _before_ we had skipped the pre-header rows (including comments), instead of after. Reordering those two operations so that the correct lines are skipped solves the error.

Added some additional comment/skip permutations to the existing test coverage.

Also: the slightly misleadingly-named `skip_header` function didn't actually have any header-specific logic; was just a simple redirect to `skip_this_line`, so we may as well just call that directly.