### PR TITLE
fix(python): don't lose track of `ones` and `zeros` dtype, improve use with `Array`, raise error if dtype invalid

### DIFF
--- a/py-polars/polars/functions/repeat.py
+++ b/py-polars/polars/functions/repeat.py
@@ -7,6 +7,7 @@ from polars import functions as F
 from polars.datatypes import (
     FLOAT_DTYPES,
     INTEGER_DTYPES,
+    Array,
     Boolean,
     Float64,
     List,
@@ -137,6 +138,7 @@ _ones_zeros = {
 for dtype in INTEGER_DTYPES | FLOAT_DTYPES:
     _ones_zeros[dtype] = (0, 1)
     _ones_zeros[List(dtype)] = ([0], [1])
+    _ones_zeros[Array(dtype, width=1)] = ([0], [1])
 
 
 @overload
@@ -212,14 +214,11 @@ def ones(
     ]
 
     """
-    value: Any
-    if (one_zero := _ones_zeros.get(dtype)) is not None:
-        value = one_zero[1]
-    else:
-        raise TypeError(
-            f"invalid dtype for `ones`, consider using `repeat` instead; found {dtype})"
-        )
-    return repeat(value, n=n, dtype=dtype, eager=eager).alias("ones")
+    if (one_zero := _ones_zeros.get(dtype)) is None:
+        raise TypeError(f"invalid dtype for `ones`; found {dtype})")
+
+    one: Any = one_zero[1]
+    return repeat(one, n=n, dtype=dtype, eager=eager).alias("ones")
 
 
 @overload
@@ -295,11 +294,8 @@ def zeros(
     ]
 
     """
-    value: Any
-    if (one_zero := _ones_zeros.get(dtype)) is not None:
-        value = one_zero[0]
-    else:
-        raise TypeError(
-            f"invalid dtype for `zeros`, consider using `repeat` instead; found {dtype})"
-        )
-    return repeat(value, n=n, dtype=dtype, eager=eager).alias("zeros")
+    if (one_zero := _ones_zeros.get(dtype)) is None:
+        raise TypeError(f"invalid dtype for `zeros`; found {dtype})")
+
+    zero: Any = one_zero[0]
+    return repeat(zero, n=n, dtype=dtype, eager=eager).alias("zeros")

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -11,7 +11,7 @@ from polars.utils.deprecation import issue_deprecation_warning
 if TYPE_CHECKING:
     from polars import Expr
     from polars.polars import PyExpr
-    from polars.type_aliases import IntoExpr
+    from polars.type_aliases import IntoExpr, PolarsDataType
 
 
 def parse_as_list_of_expressions(
@@ -82,6 +82,7 @@ def parse_as_expression(
     str_as_lit: bool = False,
     list_as_lit: bool = True,
     structify: bool = False,
+    dtype: PolarsDataType | None = None,
 ) -> PyExpr:
     """
     Parse a single input into an expression.
@@ -98,6 +99,9 @@ def parse_as_expression(
         lists are parsed as `Series` literals.
     structify
         Convert multi-column expressions to a single struct expression.
+    dtype
+        If the input is expected to resolve to a literal with a known dtype, pass
+        this to the `lit` constructor.
 
     Returns
     -------
@@ -109,10 +113,10 @@ def parse_as_expression(
         expr = F.col(input)
         structify = False
     elif isinstance(input, list) and not list_as_lit:
-        expr = F.lit(pl.Series(input))
+        expr = F.lit(pl.Series(input), dtype=dtype)
         structify = False
     else:
-        expr = F.lit(input)
+        expr = F.lit(input, dtype=dtype)
         structify = False
 
     if structify:

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -88,13 +88,14 @@ def test_repeat_n_negative() -> None:
 @pytest.mark.parametrize(
     ("n", "value", "dtype"),
     [
-        (2, 1, pl.UInt8),
-        (0, 1, pl.Int32),
+        (2, 1, pl.UInt32),
+        (0, 1, pl.Int16),
         (3, 1, pl.Float32),
         (1, "1", pl.Utf8),
         (2, ["1"], pl.List(pl.Utf8)),
         (4, True, pl.Boolean),
         (2, [True], pl.List(pl.Boolean)),
+        (2, [1], pl.Array(pl.Int16, width=1)),
         (1, [1], pl.List(pl.UInt32)),
     ],
 )
@@ -122,6 +123,7 @@ def test_ones(
         (2, ["0"], pl.List(pl.Utf8)),
         (4, False, pl.Boolean),
         (2, [False], pl.List(pl.Boolean)),
+        (3, [0], pl.Array(pl.UInt32, width=1)),
         (1, [0], pl.List(pl.UInt32)),
     ],
 )

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -96,6 +96,7 @@ def test_repeat_n_negative() -> None:
         (4, True, pl.Boolean),
         (2, [True], pl.List(pl.Boolean)),
         (2, [1], pl.Array(pl.Int16, width=1)),
+        (2, [1, 1, 1], pl.Array(pl.Int8, width=3)),
         (1, [1], pl.List(pl.UInt32)),
     ],
 )
@@ -124,6 +125,7 @@ def test_ones(
         (4, False, pl.Boolean),
         (2, [False], pl.List(pl.Boolean)),
         (3, [0], pl.Array(pl.UInt32, width=1)),
+        (2, [0, 0, 0], pl.Array(pl.UInt32, width=3)),
         (1, [0], pl.List(pl.UInt32)),
     ],
 )


### PR DESCRIPTION
Various minor fixes/improvements to the `ones` and `zeros` convenience functions.
(Follow up from https://github.com/pola-rs/polars/issues/13121#issuecomment-1864318096).

* Raise a suitable error on invalid/unsuitable "dtype" value instead of returning a series of `null` values.
* Ensure proper "dtype" pass-through from `repeat` → `parse_as_list_of_expressions` → `lit`.
* Extended test coverage to include error conditions, expected defaults, additional dtypes.
* Improve handling of `Array` dtype (get width and create 1/0 arrays of that length).


## Examples

#### Improve handling of Array dtype:
```python
pl.ones(n=2, dtype=pl.Array(pl.UInt8,width=3), eager=True)
```
Before
```
shape: (2,)
Series: 'ones' [null]
[
    null
    null
]
```
After
```
shape: (2,)
Series: 'ones' [array[u8, 3]]
[
   [1, 1, 1]
   [1, 1, 1]
]
```
#### Raise on unsuitable/invalid dtype:
```python
pl.zeros(n=2, dtype=pl.Struct({"x": pl.Null, "y": pl.Duration}), eager=True) 
```
Before
```
shape: (2,)
Series: 'zeros' [struct[2]]
[
    {null,null}
    {null,null}
]
```
After
```
TypeError: invalid dtype for `zeros`; found Struct({'x': Null, 'y': Duration}))
```