### PR TITLE
fix(rust,python): updated Display trait for enum categoricals

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -387,16 +387,9 @@ impl Display for DataType {
             #[cfg(feature = "object")]
             DataType::Object(s, _) => s,
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(rev_map, _) => {
-                if let Some(rev_map) = rev_map {
-                    if rev_map.is_enum() {
-                        "enum"
-                    } else {
-                        "cat"
-                    }
-                } else {
-                    "cat"
-                }
+            DataType::Categorical(rev_map, _) => match rev_map {
+                Some(r) if r.is_enum() => "enum",
+                _ => "cat",
             },
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(fields) => return write!(f, "struct[{}]", fields.len()),

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -387,7 +387,17 @@ impl Display for DataType {
             #[cfg(feature = "object")]
             DataType::Object(s, _) => s,
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, _) => "cat",
+            DataType::Categorical(rev_map, _) => {
+                if let Some(rev_map) = rev_map {
+                    if rev_map.is_enum() {
+                        "enum"
+                    } else {
+                        "cat"
+                    }
+                } else {
+                    "cat"
+                }
+            },
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(fields) => return write!(f, "struct[{}]", fields.len()),
             DataType::Unknown => "unknown",

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -1,4 +1,5 @@
 import operator
+from textwrap import dedent
 from typing import Callable
 
 import pytest
@@ -28,6 +29,14 @@ def test_enum_from_schema_argument() -> None:
         {"col1": ["a", "b", "c"]}, schema={"col1": pl.Enum(["a", "b", "c"])}
     )
     assert df.get_column("col1").dtype == pl.Enum
+    assert dedent(
+        """
+        │ col1 │
+        │ ---  │
+        │ enum │
+        ╞══════╡
+        """
+    ) in str(df)
 
 
 def test_equality_of_two_separately_constructed_enums() -> None:


### PR DESCRIPTION
Closes #13330.

Updated `DataType::Display` trait for enum categoricals.

## Example

```python
import polars as pl
compass_points = ["North", "East", "South", "West"]

df = pl.DataFrame(
    data = {"directions": compass_points},
    schema_overrides = {"directions": pl.Enum(compass_points)},
)
print( df )
# shape: (4, 1)
# ┌────────────┐
# │ directions │
# │ ---        │
# │ enum       │  << previously showed 'cat'
# ╞════════════╡
# │ North      │
# │ East       │
# │ South      │
# │ West       │
# └────────────┘

```