### PR TITLE
feat(python): additional multi-column support for `pl.<function>` entries

### DIFF
--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -12,7 +12,10 @@ from polars.utils._parse_expr_input import (
     parse_as_list_of_expressions,
 )
 from polars.utils._wrap import wrap_df, wrap_expr
-from polars.utils.deprecation import deprecate_renamed_function
+from polars.utils.deprecation import (
+    deprecate_parameter_as_positional,
+    deprecate_renamed_function,
+)
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -28,7 +31,6 @@ if TYPE_CHECKING:
         IntoExpr,
         PolarsDataType,
         RollingInterpolationMethod,
-        SelectorType,
     )
 
 
@@ -40,7 +42,12 @@ def element() -> Expr:
     --------
     A horizontal rank computation by taking the elements of a list
 
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...     }
+    ... )
     >>> df.with_columns(
     ...     pl.concat_list(["a", "b"]).list.eval(pl.element().rank()).alias("rank")
     ... )
@@ -57,7 +64,12 @@ def element() -> Expr:
 
     A mathematical operation on array elements
 
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...     }
+    ... )
     >>> df.with_columns(
     ...     pl.concat_list(["a", "b"]).list.eval(pl.element() * 2).alias("a_b_doubled")
     ... )
@@ -75,20 +87,19 @@ def element() -> Expr:
     return F.col("")
 
 
-def count(column: str | None = None) -> Expr:
+def count(*columns: str) -> Expr:
     """
     Either return the number of rows in the context, or return the number of non-null values in the column.
 
-    If no arguments are passed, returns the number of rows in the context.
-    Rows containing null values count towards the total.
-    This is similar to `COUNT(*)` in SQL.
+    If no arguments are passed, returns the number of rows in the context; note that rows
+    containing null values count towards the total (this is similar to `COUNT(*)` in SQL).
 
     Otherwise, this function is syntactic sugar for `col(column).count()`.
 
     Parameters
     ----------
-    column
-        Column name.
+    *columns
+        One or more column names.
 
     Returns
     -------
@@ -104,7 +115,13 @@ def count(column: str | None = None) -> Expr:
     Return the number of rows in a context. Note that rows containing null values are
     counted towards the total.
 
-    >>> df = pl.DataFrame({"a": [1, 2, None], "b": [3, None, None]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 2, None],
+    ...         "b": [3, None, None],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     }
+    ... )
     >>> df.select(pl.count())
     shape: (1, 1)
     ┌───────┐
@@ -127,30 +144,42 @@ def count(column: str | None = None) -> Expr:
     │ 2   │
     └─────┘
 
+    Return the number of non-null values in multiple columns.
+
+    >>> df.select(pl.count("b", "c"))
+    shape: (1, 2)
+    ┌─────┬─────┐
+    │ b   ┆ c   │
+    │ --- ┆ --- │
+    │ u32 ┆ u32 │
+    ╞═════╪═════╡
+    │ 1   ┆ 3   │
+    └─────┴─────┘
+
     Generate an index column using `count` in conjunction with :func:`int_range`.
 
     >>> df.select(
     ...     pl.int_range(pl.count(), dtype=pl.UInt32).alias("index"),
     ...     pl.all(),
     ... )
-    shape: (3, 3)
-    ┌───────┬──────┬──────┐
-    │ index ┆ a    ┆ b    │
-    │ ---   ┆ ---  ┆ ---  │
-    │ u32   ┆ i64  ┆ i64  │
-    ╞═══════╪══════╪══════╡
-    │ 0     ┆ 1    ┆ 3    │
-    │ 1     ┆ 2    ┆ null │
-    │ 2     ┆ null ┆ null │
-    └───────┴──────┴──────┘
+    shape: (3, 4)
+    ┌───────┬──────┬──────┬─────┐
+    │ index ┆ a    ┆ b    ┆ c   │
+    │ ---   ┆ ---  ┆ ---  ┆ --- │
+    │ u32   ┆ i64  ┆ i64  ┆ str │
+    ╞═══════╪══════╪══════╪═════╡
+    │ 0     ┆ 1    ┆ 3    ┆ foo │
+    │ 1     ┆ 2    ┆ null ┆ bar │
+    │ 2     ┆ null ┆ null ┆ foo │
+    └───────┴──────┴──────┴─────┘
+
     """  # noqa: W505
-    if column is None:
+    if not columns:
         return wrap_expr(plr.count())
+    return F.col(*columns).count()
 
-    return F.col(column).count()
 
-
-def cum_count(*names: str, reverse: bool = False) -> Expr:
+def cum_count(*columns: str, reverse: bool = False) -> Expr:
     """
     Return the cumulative count of the values in the column or of the context.
 
@@ -161,7 +190,7 @@ def cum_count(*names: str, reverse: bool = False) -> Expr:
 
     Parameters
     ----------
-    *names
+    *columns
         Name(s) of the columns to use.
     reverse
         Reverse the operation.
@@ -198,12 +227,13 @@ def cum_count(*names: str, reverse: bool = False) -> Expr:
     │ 2   │
     └─────┘
     """
-    if not names:
+    if not columns:
         return wrap_expr(plr.cum_count(reverse=reverse))
-    return F.col(*names).cum_count(reverse=reverse)
+    return F.col(*columns).cum_count(reverse=reverse)
 
 
-def implode(name: str) -> Expr:
+@deprecate_parameter_as_positional("column", version="0.20.4")
+def implode(*columns: str) -> Expr:
     """
     Aggregate all column values into a list.
 
@@ -211,10 +241,39 @@ def implode(name: str) -> Expr:
 
     Parameters
     ----------
-    name
-        Column name.
+    *columns
+        One or more column names.
+
+    Examples
+    --------
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 2, 3],
+    ...         "b": [9, 8, 7],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     }
+    ... )
+    >>> df.select(pl.implode("a"))
+    shape: (1, 1)
+    ┌───────────┐
+    │ a         │
+    │ ---       │
+    │ list[i64] │
+    ╞═══════════╡
+    │ [1, 2, 3] │
+    └───────────┘
+    >>> df.select(pl.implode("b", "c"))
+    shape: (1, 2)
+    ┌───────────┬───────────────────────┐
+    │ b         ┆ c                     │
+    │ ---       ┆ ---                   │
+    │ list[i64] ┆ list[str]             │
+    ╞═══════════╪═══════════════════════╡
+    │ [9, 8, 7] ┆ ["foo", "bar", "foo"] │
+    └───────────┴───────────────────────┘
+
     """
-    return F.col(name).implode()
+    return F.col(*columns).implode()
 
 
 def std(column: str, ddof: int = 1) -> Expr:
@@ -234,7 +293,13 @@ def std(column: str, ddof: int = 1) -> Expr:
 
     Examples
     --------
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     }
+    ... )
     >>> df.select(pl.std("a"))
     shape: (1, 1)
     ┌──────────┐
@@ -267,7 +332,13 @@ def var(column: str, ddof: int = 1) -> Expr:
 
     Examples
     --------
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     },
+    ... )
     >>> df.select(pl.var("a"))
     shape: (1, 1)
     ┌──────┐
@@ -283,20 +354,27 @@ def var(column: str, ddof: int = 1) -> Expr:
     return F.col(column).var(ddof)
 
 
-def mean(column: str) -> Expr:
+@deprecate_parameter_as_positional("column", version="0.20.4")
+def mean(*columns: str) -> Expr:
     """
     Get the mean value.
 
-    This function is syntactic sugar for `pl.col(column).mean()`.
+    This function is syntactic sugar for `pl.col(columns).mean()`.
 
     Parameters
     ----------
-    column
-        Column name.
+    *columns
+        One or more column names.
 
     Examples
     --------
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     }
+    ... )
     >>> df.select(pl.mean("a"))
     shape: (1, 1)
     ┌─────┐
@@ -306,19 +384,41 @@ def mean(column: str) -> Expr:
     ╞═════╡
     │ 4.0 │
     └─────┘
+    >>> df.select(pl.mean("a", "b"))
+    shape: (1, 2)
+    ┌─────┬──────────┐
+    │ a   ┆ b        │
+    │ --- ┆ ---      │
+    │ f64 ┆ f64      │
+    ╞═════╪══════════╡
+    │ 4.0 ┆ 3.666667 │
+    └─────┴──────────┘
+
     """
-    return F.col(column).mean()
+    return F.col(*columns).mean()
 
 
-def median(column: str) -> Expr:
+@deprecate_parameter_as_positional("column", version="0.20.4")
+def median(*columns: str) -> Expr:
     """
     Get the median value.
 
-    This function is syntactic sugar for `pl.col(column).median()`.
+    This function is syntactic sugar for `pl.col(columns).median()`.
+
+    Parameters
+    ----------
+    columns
+        One or more column names.
 
     Examples
     --------
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     }
+    ... )
     >>> df.select(pl.median("a"))
     shape: (1, 1)
     ┌─────┐
@@ -328,24 +428,41 @@ def median(column: str) -> Expr:
     ╞═════╡
     │ 3.0 │
     └─────┘
+    >>> df.select(pl.median("a", "b"))
+    shape: (1, 2)
+    ┌─────┬─────┐
+    │ a   ┆ b   │
+    │ --- ┆ --- │
+    │ f64 ┆ f64 │
+    ╞═════╪═════╡
+    │ 3.0 ┆ 4.0 │
+    └─────┴─────┘
+
     """
-    return F.col(column).median()
+    return F.col(*columns).median()
 
 
-def n_unique(column: str) -> Expr:
+@deprecate_parameter_as_positional("column", version="0.20.4")
+def n_unique(*columns: str) -> Expr:
     """
     Count unique values.
 
-    This function is syntactic sugar for `pl.col(column).n_unique()`.
+    This function is syntactic sugar for `pl.col(columns).n_unique()`.
 
     Parameters
     ----------
-    column
-        Column name.
+    columns
+        One or more column names.
 
     Examples
     --------
-    >>> df = pl.DataFrame({"a": [1, 8, 1], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 1],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     }
+    ... )
     >>> df.select(pl.n_unique("a"))
     shape: (1, 1)
     ┌─────┐
@@ -355,24 +472,42 @@ def n_unique(column: str) -> Expr:
     ╞═════╡
     │ 2   │
     └─────┘
+    >>> df.select(pl.n_unique("b", "c"))
+    shape: (1, 2)
+    ┌─────┬─────┐
+    │ b   ┆ c   │
+    │ --- ┆ --- │
+    │ u32 ┆ u32 │
+    ╞═════╪═════╡
+    │ 3   ┆ 2   │
+    └─────┴─────┘
+
     """
-    return F.col(column).n_unique()
+    return F.col(*columns).n_unique()
 
 
-def approx_n_unique(column: str | Expr) -> Expr:
+@deprecate_parameter_as_positional("column", version="0.20.4")
+def approx_n_unique(*columns: str) -> Expr:
     """
     Approximate count of unique values.
 
-    This is done using the HyperLogLog++ algorithm for cardinality estimation.
+    This function is syntactic sugar for `pl.col(columns).approx_n_unique()`, and
+    uses the HyperLogLog++ algorithm for cardinality estimation.
 
     Parameters
     ----------
-    column
-        Column name.
+    columns
+        One or more column names.
 
     Examples
     --------
-    >>> df = pl.DataFrame({"a": [1, 8, 1], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 1],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     }
+    ... )
     >>> df.select(pl.approx_n_unique("a"))
     shape: (1, 1)
     ┌─────┐
@@ -382,30 +517,45 @@ def approx_n_unique(column: str | Expr) -> Expr:
     ╞═════╡
     │ 2   │
     └─────┘
+    >>> df.select(pl.approx_n_unique("b", "c"))
+    shape: (1, 2)
+    ┌─────┬─────┐
+    │ b   ┆ c   │
+    │ --- ┆ --- │
+    │ u32 ┆ u32 │
+    ╞═════╪═════╡
+    │ 3   ┆ 2   │
+    └─────┴─────┘
+
     """
-    if isinstance(column, pl.Expr):
-        return column.approx_n_unique()
-    return F.col(column).approx_n_unique()
+    return F.col(*columns).approx_n_unique()
 
 
-def first(column: str | None = None) -> Expr:
+@deprecate_parameter_as_positional("column", version="0.20.4")
+def first(*columns: str) -> Expr:
     """
     Get the first value.
 
     This function has different behavior depending on the input type:
 
-    - `None` -> Expression to take first column of a context.
-    - `str` -> Syntactic sugar for `pl.col(column).first()`.
+    - `None` -> Takes first column of a context (equivalent to `cs.first()`).
+    - `str` or `[str,]` -> Syntactic sugar for `pl.col(columns).first()`.
 
     Parameters
     ----------
-    column
-        Column name. If set to `None` (default), returns an expression to take the first
-        column of the context instead.
+    *columns
+        One or more column names. If not provided (default), returns an expression
+        to take the first column of the context instead.
 
     Examples
     --------
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "baz"],
+    ...     }
+    ... )
     >>> df.select(pl.first())
     shape: (3, 1)
     ┌─────┐
@@ -417,40 +567,57 @@ def first(column: str | None = None) -> Expr:
     │ 8   │
     │ 3   │
     └─────┘
-    >>> df.select(pl.first("a"))
+    >>> df.select(pl.first("b"))
     shape: (1, 1)
     ┌─────┐
-    │ a   │
+    │ b   │
     │ --- │
     │ i64 │
     ╞═════╡
-    │ 1   │
+    │ 4   │
     └─────┘
+    >>> df.select(pl.first("a", "c"))
+    shape: (1, 2)
+    ┌─────┬─────┐
+    │ a   ┆ c   │
+    │ --- ┆ --- │
+    │ i64 ┆ str │
+    ╞═════╪═════╡
+    │ 1   ┆ foo │
+    └─────┴─────┘
+
     """
-    if column is None:
+    if not columns:
         return wrap_expr(plr.first())
 
-    return F.col(column).first()
+    return F.col(*columns).first()
 
 
-def last(column: str | None = None) -> Expr:
+@deprecate_parameter_as_positional("column", version="0.20.4")
+def last(*columns: str) -> Expr:
     """
     Get the last value.
 
     This function has different behavior depending on the input type:
 
-    - `None` -> Expression to take last column of a context.
-    - `str` -> Syntactic sugar for `pl.col(column).last()`.
+    - `None` -> Takes last column of a context (equivalent to `cs.last()`).
+    - `str` or `[str,]` -> Syntactic sugar for `pl.col(columns).last()`.
 
     Parameters
     ----------
-    column
-        Column name. If set to `None` (default), returns an expression to take the last
-        column of the context instead.
+    *columns
+        One or more column names. If set to `None` (default), returns an expression
+        to take the last column of the context instead.
 
     Examples
     --------
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "baz"],
+    ...     }
+    ... )
     >>> df.select(pl.last())
     shape: (3, 1)
     ┌─────┐
@@ -460,7 +627,7 @@ def last(column: str | None = None) -> Expr:
     ╞═════╡
     │ foo │
     │ bar │
-    │ foo │
+    │ baz │
     └─────┘
     >>> df.select(pl.last("a"))
     shape: (1, 1)
@@ -471,11 +638,21 @@ def last(column: str | None = None) -> Expr:
     ╞═════╡
     │ 3   │
     └─────┘
+    >>> df.select(pl.last("b", "c"))
+    shape: (1, 2)
+    ┌─────┬─────┐
+    │ b   ┆ c   │
+    │ --- ┆ --- │
+    │ i64 ┆ str │
+    ╞═════╪═════╡
+    │ 2   ┆ baz │
+    └─────┴─────┘
+
     """
-    if column is None:
+    if not columns:
         return wrap_expr(plr.last())
 
-    return F.col(column).last()
+    return F.col(*columns).last()
 
 
 def head(column: str, n: int = 10) -> Expr:
@@ -493,7 +670,13 @@ def head(column: str, n: int = 10) -> Expr:
 
     Examples
     --------
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     }
+    ... )
     >>> df.select(pl.head("a"))
     shape: (3, 1)
     ┌─────┐
@@ -534,7 +717,13 @@ def tail(column: str, n: int = 10) -> Expr:
 
     Examples
     --------
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     }
+    ... )
     >>> df.select(pl.tail("a"))
     shape: (3, 1)
     ┌─────┐
@@ -592,7 +781,13 @@ def corr(
     --------
     Pearson's correlation:
 
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     }
+    ... )
     >>> df.select(pl.corr("a", "b"))
     shape: (1, 1)
     ┌──────────┐
@@ -605,7 +800,13 @@ def corr(
 
     Spearman rank correlation:
 
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     }
+    ... )
     >>> df.select(pl.corr("a", "b", method="spearman"))
     shape: (1, 1)
     ┌─────┐
@@ -646,7 +847,13 @@ def cov(a: IntoExpr, b: IntoExpr, ddof: int = 1) -> Expr:
 
     Examples
     --------
-    >>> df = pl.DataFrame({"a": [1, 8, 3], "b": [4, 5, 2], "c": ["foo", "bar", "foo"]})
+    >>> df = pl.DataFrame(
+    ...     {
+    ...         "a": [1, 8, 3],
+    ...         "b": [4, 5, 2],
+    ...         "c": ["foo", "bar", "foo"],
+    ...     },
+    ... )
     >>> df.select(pl.cov("a", "b"))
     shape: (1, 1)
     ┌─────┐
@@ -1246,28 +1453,21 @@ def arctan2d(y: str | Expr, x: str | Expr) -> Expr:
 
 
 def exclude(
-    columns: (
-        str
-        | PolarsDataType
-        | SelectorType
-        | Expr
-        | Collection[str | PolarsDataType | SelectorType | Expr]
-    ),
-    *more_columns: str | PolarsDataType | SelectorType | Expr,
+    columns: str | PolarsDataType | Collection[str] | Collection[PolarsDataType],
+    *more_columns: str | PolarsDataType,
 ) -> Expr:
     """
-    Select all columns except those matching the given columns, datatypes, or selectors.
+    Represent all columns except for the given columns.
 
-    .. versionchanged:: 0.20.3
-        This function is now a simple redirect to the `cs.exclude()` selector.
+    Syntactic sugar for `pl.all().exclude(columns)`.
 
     Parameters
     ----------
     columns
-        One or more columns (col or name), datatypes, columns, or selectors representing
-        the columns to exclude.
+        The name or datatype of the column(s) to exclude. Accepts regular expression
+        input. Regular expressions should start with `^` and end with `$`.
     *more_columns
-        Additional columns, datatypes, or selectors to exclude, specified as positional
+        Additional names or datatypes of columns to exclude, specified as positional
         arguments.
 
     Examples
@@ -1281,7 +1481,7 @@ def exclude(
     ...         "cc": [None, 2.5, 1.5],
     ...     }
     ... )
-    >>> df.select(pl.exclude("ba", "xx"))
+    >>> df.select(pl.exclude("ba"))
     shape: (3, 2)
     ┌─────┬──────┐
     │ aa  ┆ cc   │
@@ -1309,7 +1509,7 @@ def exclude(
 
     Exclude by dtype(s), e.g. removing all columns of type Int64 or Float64:
 
-    >>> df.select(pl.exclude(pl.Int64, pl.Float64))
+    >>> df.select(pl.exclude([pl.Int64, pl.Float64]))
     shape: (3, 1)
     ┌──────┐
     │ ba   │
@@ -1321,24 +1521,8 @@ def exclude(
     │ null │
     └──────┘
 
-    Exclude column using a compound selector:
-
-    >>> import polars.selectors as cs
-    >>> df.select(pl.exclude(cs.first() | cs.last()))
-    shape: (3, 1)
-    ┌──────┐
-    │ ba   │
-    │ ---  │
-    │ str  │
-    ╞══════╡
-    │ a    │
-    │ b    │
-    │ null │
-    └──────┘
     """
-    from polars.selectors import exclude
-
-    return exclude(columns, *more_columns)
+    return F.col("*").exclude(columns, *more_columns)
 
 
 def groups(column: str) -> Expr:

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -224,8 +224,7 @@ def _combine_as_selector(
             names.append(item.meta.output_name())  # type: ignore[union-attr]
         else:
             raise TypeError(
-                "invalid input for `exclude`"
-                f"\n\nExpected one or more `str`, `DataType` or selector; found {item!r} instead."
+                f"expected one or more `str`, `DataType` or selector; found {item!r} instead."
             )
 
     selected = []

--- a/py-polars/polars/utils/__init__.py
+++ b/py-polars/polars/utils/__init__.py
@@ -23,15 +23,18 @@ from polars.utils.various import NoDefault, _polars_warn, is_column, no_default
 
 __all__ = [
     "NoDefault",
-    "no_default",
     "build_info",
-    "show_versions",
     "get_index_type",
     "is_column",
+    "no_default",
+    "show_versions",
     "threadpool_size",
     # Required for Rust bindings
     "_date_to_pl_date",
+    "_datetime_for_anyvalue",
+    "_datetime_for_anyvalue_windows",
     "_execute_from_rust",
+    "_polars_warn",
     "_time_to_pl_time",
     "_timedelta_to_pl_timedelta",
     "_to_python_date",
@@ -39,7 +42,4 @@ __all__ = [
     "_to_python_decimal",
     "_to_python_time",
     "_to_python_timedelta",
-    "_datetime_for_anyvalue",
-    "_datetime_for_anyvalue_windows",
-    "_polars_warn",
 ]

--- a/py-polars/polars/utils/deprecation.py
+++ b/py-polars/polars/utils/deprecation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import inspect
 import warnings
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, TypeVar
+from typing import TYPE_CHECKING, Callable, Sequence, TypeVar
 
 from polars.utils.various import find_stacklevel
 
@@ -76,6 +76,41 @@ def deprecate_renamed_function(
     )
 
 
+def deprecate_parameter_as_positional(
+    old_name: str, *, version: str
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """
+    Decorator to mark a function argument as deprecated due to being made positinoal.
+
+    Use as follows::
+
+        @deprecate_parameter_as_positional("column", version="0.20.4")
+        def myfunc(new_name):
+            ...
+    """
+
+    def decorate(function: Callable[P, T]) -> Callable[P, T]:
+        @wraps(function)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            if param_args := kwargs.pop(old_name, []):
+                issue_deprecation_warning(
+                    f"`named {old_name}` param is deprecated; use positional `*args` instead.",
+                    version=version,
+                )
+            if param_args:
+                if not isinstance(param_args, Sequence) or isinstance(param_args, str):
+                    param_args = (param_args,)
+                elif not isinstance(param_args, tuple):
+                    param_args = tuple(param_args)
+                args = args + param_args  # type: ignore[assignment]
+            return function(*args, **kwargs)
+
+        wrapper.__signature__ = inspect.signature(function)  # type: ignore[attr-defined]
+        return wrapper
+
+    return decorate
+
+
 def deprecate_renamed_parameter(
     old_name: str, new_name: str, *, version: str
 ) -> Callable[[Callable[P, T]], Callable[P, T]]:
@@ -84,7 +119,7 @@ def deprecate_renamed_parameter(
 
     Use as follows::
 
-        @deprecate_renamed_parameter("old_name", "new_name", version="0.1.2")
+        @deprecate_renamed_parameter("old_name", "new_name", version="0.20.4")
         def myfunc(new_name):
             ...
     """

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2682,12 +2682,20 @@ def test_selection_regex_and_multicol() -> None:
     expected = {"a": [1, 4, 9, 16], "b": [25, 36, 49, 64], "c": [81, 100, 121, 144]}
 
     assert result.to_dict(as_series=False) == expected
-    for multi_op in (
-        pl.col("^\\w$") * pl.col("^\\w$"),
-        pl.exclude("foo") * pl.exclude("foo"),
-        pl.exclude(cs.last()) * pl.exclude(cs.by_dtype(pl.UInt8)),
-    ):
-        assert test_df.select(multi_op).to_dict(as_series=False) == expected
+    assert test_df.select(pl.exclude("foo") * pl.exclude("foo")).to_dict(
+        as_series=False
+    ) == {
+        "a": [1, 4, 9, 16],
+        "b": [25, 36, 49, 64],
+        "c": [81, 100, 121, 144],
+    }
+    assert test_df.select(pl.col("^\\w$") * pl.col("^\\w$")).to_dict(
+        as_series=False
+    ) == {
+        "a": [1, 4, 9, 16],
+        "b": [25, 36, 49, 64],
+        "c": [81, 100, 121, 144],
+    }
 
     # kwargs
     with pl.Config() as cfg:

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import pytest
@@ -404,73 +404,72 @@ def test_approx_n_unique() -> None:
     )
 
     assert_frame_equal(
-        df1.select(pl.approx_n_unique(pl.col("b"))),
-        pl.DataFrame({"b": pl.Series(values=[3], dtype=pl.UInt32)}),
-    )
-
-    assert_frame_equal(
         df1.select(pl.col("b").approx_n_unique()),
         pl.DataFrame({"b": pl.Series(values=[3], dtype=pl.UInt32)}),
     )
 
 
 def test_lazy_functions() -> None:
-    df = pl.DataFrame({"a": ["foo", "bar", "2"], "b": [1, 2, 3], "c": [1.0, 2.0, 3.0]})
-    out = df.select(pl.count("a"))
-    assert list(out["a"]) == [3]
-    out = df.select(
-        [
-            pl.var("b").alias("1"),
-            pl.std("b").alias("2"),
-            pl.max("b").alias("3"),
-            pl.min("b").alias("4"),
-            pl.sum("b").alias("5"),
-            pl.mean("b").alias("6"),
-            pl.median("b").alias("7"),
-            pl.n_unique("b").alias("8"),
-            pl.first("b").alias("9"),
-            pl.last("b").alias("10"),
-        ]
+    df = pl.DataFrame(
+        {
+            "a": ["foo", "bar", "foo"],
+            "b": [1, 2, 3],
+            "c": [-1, 2.0, 4.0],
+        }
     )
-    expected = 1.0
-    assert np.isclose(out.to_series(0), expected)
-    assert np.isclose(df["b"].var(), expected)  # type: ignore[arg-type]
 
-    expected = 1.0
-    assert np.isclose(out.to_series(1), expected)
-    assert np.isclose(df["b"].std(), expected)  # type: ignore[arg-type]
+    # test function expressions against frame
+    out = df.select(
+        pl.var("b").name.suffix("_var"),
+        pl.std("b").name.suffix("_std"),
+        pl.max("a", "b").name.suffix("_max"),
+        pl.min("a", "b").name.suffix("_min"),
+        pl.sum("b", "c").name.suffix("_sum"),
+        pl.mean("b", "c").name.suffix("_mean"),
+        pl.median("c", "b").name.suffix("_median"),
+        pl.n_unique("b", "a").name.suffix("_n_unique"),
+        pl.first("a").name.suffix("_first"),
+        pl.first("b", "c").name.suffix("_first"),
+        pl.last("c", "b", "a").name.suffix("_last"),
+    )
+    expected: dict[str, list[Any]] = {
+        "b_var": [1.0],
+        "b_std": [1.0],
+        "a_max": ["foo"],
+        "b_max": [3],
+        "a_min": ["bar"],
+        "b_min": [1],
+        "b_sum": [6],
+        "c_sum": [5.0],
+        "b_mean": [2.0],
+        "c_mean": [5 / 3],
+        "c_median": [2.0],
+        "b_median": [2.0],
+        "b_n_unique": [3],
+        "a_n_unique": [2],
+        "a_first": ["foo"],
+        "b_first": [1],
+        "c_first": [-1.0],
+        "c_last": [4.0],
+        "b_last": [3],
+        "a_last": ["foo"],
+    }
+    assert_frame_equal(
+        out,
+        pl.DataFrame(
+            data=expected,
+            schema_overrides={
+                "a_n_unique": pl.UInt32,
+                "b_n_unique": pl.UInt32,
+            },
+        ),
+    )
 
-    expected = 3
-    assert np.isclose(out.to_series(2), expected)
-    assert np.isclose(df["b"].max(), expected)  # type: ignore[arg-type]
-
-    expected = 1
-    assert np.isclose(out.to_series(3), expected)
-    assert np.isclose(df["b"].min(), expected)  # type: ignore[arg-type]
-
-    expected = 6
-    assert np.isclose(out.to_series(4), expected)
-    assert np.isclose(df["b"].sum(), expected)
-
-    expected = 2
-    assert np.isclose(out.to_series(5), expected)
-    assert np.isclose(df["b"].mean(), expected)  # type: ignore[arg-type]
-
-    expected = 2
-    assert np.isclose(out.to_series(6), expected)
-    assert np.isclose(df["b"].median(), expected)  # type: ignore[arg-type]
-
-    expected = 3
-    assert np.isclose(out.to_series(7), expected)
-    assert np.isclose(df["b"].n_unique(), expected)
-
-    expected = 1
-    assert np.isclose(out.to_series(8), expected)
-    assert np.isclose(df["b"][0], expected)
-
-    expected = 3
-    assert np.isclose(out.to_series(9), expected)
-    assert np.isclose(df["b"][-1], expected)
+    # test function expressions against series
+    for name, value in expected.items():
+        col, fn = name.split("_", 1)
+        if series_fn := getattr(df[col], fn, None):
+            assert series_fn() == value[0]
 
     # regex selection
     out = df.select(
@@ -481,8 +480,21 @@ def test_lazy_functions() -> None:
         ]
     )
     assert out.rows() == [
-        ({"a": "foo", "b": 3}, {"b": 1, "c": 1.0}, {"a": None, "c": 6.0})
+        ({"a": "foo", "b": 3}, {"b": 1, "c": -1.0}, {"a": None, "c": 5.0})
     ]
+
+
+def test_count() -> None:
+    df = pl.DataFrame({"a": [1, 1, 1], "b": [None, "xx", "yy"]})
+    out = df.select(pl.count("a"))
+    assert list(out["a"]) == [3]
+
+    for count_expr in (
+        pl.count("b", "a"),
+        [pl.count("b"), pl.count("a")],
+    ):
+        out = df.select(count_expr)  # type: ignore[arg-type]
+        assert out.rows() == [(2, 3)]
 
 
 def test_head_tail(fruits_cars: pl.DataFrame) -> None:

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -28,7 +28,7 @@ def test_init_signature_match() -> None:
     assert signature(pl.DataFrame.__init__) == signature(pl.LazyFrame.__init__)
 
 
-def test_lazy() -> None:
+def test_lazy_misc() -> None:
     ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
     _ = ldf.with_columns(pl.lit(1).alias("foo")).select([pl.col("a"), pl.col("foo")])
 
@@ -37,9 +37,24 @@ def test_lazy() -> None:
         when(pl.col("a") > pl.lit(2)).then(pl.lit(10)).otherwise(pl.lit(1)).alias("new")
     ).collect()
 
-    # test if pl.list is available, this is `to_list` re-exported as list
-    eager = ldf.group_by("a").agg(pl.implode("b")).collect()
-    assert sorted(eager.rows()) == [(1, [[1.0]]), (2, [[2.0]]), (3, [[3.0]])]
+
+def test_implode() -> None:
+    ldf = pl.LazyFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
+    eager = (
+        ldf.group_by(pl.col("a").alias("grp"), maintain_order=True)
+        .agg(pl.implode("a", "b").name.suffix("_imp"))
+        .collect()
+    )
+    assert_frame_equal(
+        eager,
+        pl.DataFrame(
+            {
+                "grp": [1, 2, 3],
+                "a_imp": [[[1]], [[2]], [[3]]],
+                "b_imp": [[[1.0]], [[2.0]], [[3.0]]],
+            }
+        ),
+    )
 
 
 @pytest.mark.parametrize(
@@ -173,7 +188,6 @@ def test_filter_multiple_predicates() -> None:
         }
     )
 
-    # using multiple predicates
     # multiple predicates
     expected = pl.DataFrame({"a": [1, 1, 1], "b": [1, 1, 2], "c": [1, 1, 2]})
     for out in (
@@ -195,7 +209,7 @@ def test_filter_multiple_predicates() -> None:
     )
 
     # check 'predicate' keyword deprecation:
-    # note: can disambiguate new/old usage - only expect warning on old-style usage
+    # note: we can disambiguate new/old usage (only expect warning on old-style usage)
     with pytest.warns(
         DeprecationWarning,
         match="`filter` no longer takes a 'predicate' parameter",
@@ -251,16 +265,24 @@ def test_apply_custom_function() -> None:
 
 
 def test_group_by() -> None:
-    ldf = pl.LazyFrame({"a": [1.0, None, 3.0, 4.0], "groups": ["a", "a", "b", "b"]})
+    ldf = pl.LazyFrame(
+        {
+            "a": [1.0, None, 3.0, 4.0],
+            "b": [5.0, 2.5, -3.0, 2.0],
+            "grp": ["a", "a", "b", "b"],
+        }
+    )
+    expected_a = pl.DataFrame({"grp": ["a", "b"], "a": [1.0, 3.5]})
+    expected_a_b = pl.DataFrame({"grp": ["a", "b"], "a": [1.0, 3.5], "b": [3.75, -0.5]})
 
-    expected = pl.DataFrame({"groups": ["a", "b"], "a": [1.0, 3.5]})
+    for out in (
+        ldf.group_by("grp").agg(pl.mean("a")).collect(),
+        ldf.group_by(pl.col("grp")).agg(pl.mean("a")).collect(),
+    ):
+        assert_frame_equal(out.sort(by="grp"), expected_a)
 
-    out = ldf.group_by("groups").agg(pl.mean("a")).collect()
-    assert_frame_equal(out.sort(by="groups"), expected)
-
-    # refer to column via pl.Expr
-    out = ldf.group_by(pl.col("groups")).agg(pl.mean("a")).collect()
-    assert_frame_equal(out.sort(by="groups"), expected)
+    out = ldf.group_by("grp").agg(pl.mean("a", "b")).collect()
+    assert_frame_equal(out.sort(by="grp"), expected_a_b)
 
 
 def test_arg_unique() -> None:


### PR DESCRIPTION
All of the following `pl.<function>` entries have been extended with support for multiple column names (and remain backwards compatible with existing single-column calling syntax, so there is no breakage):

* `approx_n_unique`,
* `count`
* `first`
* `implode`
* `last`
* `mean`
* `median`
* `n_unique`

In addition, all functions in the updated module (and vertical aggregations) can now take bare `pl.col("name")` expressions as well as `"name"` strings, bringing them a little closer to more generic functions such as `pl.all_horizontal`.

Added new docstring examples for each, and extended test coverage accordingly.

## Examples

```python
import polars as pl

df = pl.DataFrame({
    "a": [1, 2, None],
    "b": [9, 8, 7],
    "c": ["foo", "bar", "foo"],
})
df.select( pl.count("a", "b") )
```
Before:
```
TypeError: 
  count() takes from 0 to 1 positional arguments but 2 were given
```
After:
```
shape: (1, 2)
┌─────┬─────┐
│ a   ┆ b   │
│ --- ┆ --- │
│ u32 ┆ u32 │
╞═════╪═════╡
│ 2   ┆ 3   │
└─────┴─────┘
```