### PR TITLE
feat(python): improve Series/DataFrame init from existing Series/DataFrame objects

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -83,6 +83,7 @@ from polars.utils._construction import (
     _post_apply_columns,
     arrow_to_pydf,
     dict_to_pydf,
+    frame_to_pydf,
     iterable_to_pydf,
     numpy_to_idxs,
     numpy_to_pydf,
@@ -381,6 +382,7 @@ class DataFrame:
                 orient=orient,
                 infer_schema_length=infer_schema_length,
             )
+
         elif isinstance(data, pl.Series):
             self._df = series_to_pydf(
                 data, schema=schema, schema_overrides=schema_overrides
@@ -412,6 +414,11 @@ class DataFrame:
                 schema_overrides=schema_overrides,
                 orient=orient,
                 infer_schema_length=infer_schema_length,
+            )
+
+        elif isinstance(data, pl.DataFrame):
+            self._df = frame_to_pydf(
+                data, schema=schema, schema_overrides=schema_overrides
             )
         else:
             raise TypeError(

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -336,7 +336,7 @@ class Series:
             )
 
         elif isinstance(values, pl.DataFrame):
-            to_struct = len(values.columns) > 1
+            to_struct = values.width > 1
             name = (
                 values.columns[0] if (original_name is None and not to_struct) else name
             )

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -264,9 +264,12 @@ class Series:
             )
 
         # Handle case where values are passed as the first argument
+        original_name: str | None = None
         if name is None:
             name = ""
-        elif not isinstance(name, str):
+        elif isinstance(name, str):
+            original_name = name
+        else:
             if values is None:
                 values = name
                 name = ""
@@ -277,11 +280,13 @@ class Series:
             self._s = sequence_to_pyseries(
                 name, [], dtype=dtype, dtype_if_empty=dtype_if_empty
             )
-        elif isinstance(values, Series):
-            self._s = series_to_pyseries(name, values)
 
         elif isinstance(values, range):
             self._s = range_to_series(name, values, dtype=dtype)._s
+
+        elif isinstance(values, Series):
+            name = values.name if original_name is None else name
+            self._s = series_to_pyseries(name, values, dtype=dtype, strict=strict)
 
         elif isinstance(values, Sequence):
             self._s = sequence_to_pyseries(
@@ -292,6 +297,7 @@ class Series:
                 dtype_if_empty=dtype_if_empty,
                 nan_to_null=nan_to_null,
             )
+
         elif _check_for_numpy(values) and isinstance(values, np.ndarray):
             self._s = numpy_to_pyseries(
                 name, values, strict=strict, nan_to_null=nan_to_null
@@ -328,6 +334,17 @@ class Series:
                 dtype_if_empty=dtype_if_empty,
                 strict=strict,
             )
+
+        elif isinstance(values, pl.DataFrame):
+            to_struct = len(values.columns) > 1
+            name = (
+                values.columns[0] if (original_name is None and not to_struct) else name
+            )
+            s = values.to_struct(name) if to_struct else values.to_series().rename(name)
+            if dtype is not None and dtype != s.dtype:
+                s = s.cast(dtype)
+            self._s = s._s
+
         else:
             raise TypeError(
                 f"Series constructor called with unsupported type {type(values).__name__!r}"


### PR DESCRIPTION
Closes  #13338.

Various init enhancements. Can already init Series and DataFrame objects directly from an existing Series; now we can additionally init both DataFrame _and_ Series from an existing DataFrame (improving cross-class constructor consistency). 

Also now preserves Series name on Series(Series) init, and adds some (marginal) fast-paths if neither "schema" nor "schema_overrides" params are passed to the DataFrame constructor when initialising from either type (if these parameters _are_ passed, they are handled appropriately).

## Examples

```python
import polars as pl

df1 = pl.DataFrame( {"id": [0, 1], "misc": ["a", "b"], "val": [-10, 10]} )
# ┌─────┬──────┬─────┐
# │ id  ┆ misc ┆ val │
# │ --- ┆ ---  ┆ --- │
# │ i64 ┆ str  ┆ i64 │
# ╞═════╪══════╪═════╡
# │ 0   ┆ a    ┆ -10 │
# │ 1   ┆ b    ┆ 10  │
# └─────┴──────┴─────┘

df2 = pl.DataFrame( df1, schema=["a", "b", "c"], schema_overrides={"val": pl.Int8} )
# ┌─────┬─────┬─────┐
# │ a   ┆ b   ┆ c   │
# │ --- ┆ --- ┆ --- │
# │ i64 ┆ str ┆ i8  │
# ╞═════╪═════╪═════╡
# │ 0   ┆ a   ┆ -10 │
# │ 1   ┆ b   ┆ 10  │
# └─────┴─────┴─────┘

s1 = pl.Series( "s", df2 )
# Series: 's' [struct[3]]
# [
#   {0,"a",-10}
#   {1,"b",10}
# ]

s2 = pl.Series( s1 )
# Series: 's' [struct[3]]
# [
#   {0,"a",-10}
#   {1,"b",10}
# ]
```