### PR TITLE
feat(python): improve Enum repr, check Enum categories are valid

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -554,8 +554,9 @@ class Enum(DataType):
         unique_categories, dupes = ordered_unique(categories, return_duplicates=True)
         if (n_dupes := len(dupes)) > 0:
             dupe = dupes.most_common(1)[0][0]  # type: ignore[union-attr]
+            plural = "s" if n_dupes > 1 else ""
             raise ValueError(
-                f"Enum categories must be unique; found {n_dupes} duplicates, eg: {dupe!r}"
+                f"Enum categories must be unique; found {n_dupes} duplicate{plural}, eg: {dupe!r}"
             )
         for cat in unique_categories:
             if not isinstance(cat, str):

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -248,7 +248,17 @@ def parse_version(version: Sequence[str | int]) -> tuple[int, ...]:
 def ordered_unique(
     values: Iterable[Any], *, return_duplicates: bool = False
 ) -> list[Any] | tuple[list[Any], dict[Any, int]]:
-    """Return unique list of sequence values, maintaining their order of appearance."""
+    """
+    Return unique list of sequence values, maintaining their order of appearance.
+
+    Parameters
+    ----------
+    values
+        Sequence of values to be made unique.
+    return_duplicates
+        If True, also return a dictionary of duplicate values and their counts.
+
+    """
     seen: set[Any] = set()
     add_ = seen.add
     if not return_duplicates:

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -1,6 +1,7 @@
 import operator
+from datetime import date
 from textwrap import dedent
-from typing import Callable
+from typing import Any, Callable
 
 import pytest
 
@@ -303,3 +304,27 @@ def test_different_enum_comparison_order() -> None:
             match="can only compare categoricals of the same type",
         ):
             df_enum.filter(op(pl.col("a_cat"), pl.col("b_cat")))
+
+
+@pytest.mark.parametrize(
+    "categories",
+    [[None], [date.today()], [-10, 10], ["x", "y", None]],
+)
+def test_valid_enum_category_types(categories: Any) -> None:
+    with pytest.raises(TypeError, match="Enum categories"):
+        pl.Enum(categories)
+
+
+def test_enum_categories_unique() -> None:
+    with pytest.raises(ValueError, match="must be unique; found 2 duplicates"):
+        pl.Enum(["a", "a", "b", "b", "b", "c"])
+
+
+def test_enum_repr() -> None:
+    e1 = pl.Enum(f"c{i}" for i in range(6))
+    e2 = pl.Enum(f"c{i}" for i in range(12))
+    e3 = pl.Enum(f"c{i}" for i in range(24))
+
+    assert repr(e1) == "Enum(categories=['c0','c1','c2','c3','c4','c5'])"
+    assert repr(e2) == "Enum(categories=['c0','c1','c2' … 'c9','c10','c11'])"
+    assert repr(e3) == "Enum(categories=['c0','c1','c2' … 'c21','c22','c23'])"


### PR DESCRIPTION
Closes #13337.

* A large number of Enum categories leads to an unwieldy `repr`; truncate displayed category values to manage this.
* No validation of the input category types or values was being done; now types and uniqueness are validated.

## Examples
Improved repr:
```python
import polars as pl

pl.Enum(f"c{i}" for i in range(5))
# Enum(categories=['c0','c1','c2','c3','c4'])

pl.Enum(f"c{i}" for i in range(500))
# Enum(categories=['c0','c1','c2' … 'c497','c498','c499'])
```
Category type check:
```python
pl.Enum([1.234, 5.678])
# TypeError: Enum categories must be strings; found 1.234
```
Category uniqueness check:
```python
pl.Enum(["misc", "value", "value", "other"])
# ValueError: Enum categories must be unique; found 1 duplicates, eg: 'value'
```