### PR TITLE
chore(python): reverse condtion order in udfs _expr function

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -515,14 +515,14 @@ class InstructionTranslator:
             e1 = self._expr(value.left_operand, col, param_name, depth + 1)
             if value.operator_arity == 1:
                 if op not in OpNames.UNARY_VALUES:
-                    if not e1.startswith("pl.col("):
-                        # support use of consts as numpy/builtin params, eg:
-                        # "np.sin(3) + np.cos(x)", or "len('const_string') + len(x)"
-                        pfx = "np." if op in _NUMPY_FUNCTIONS else ""
-                        return f"{pfx}{op}({e1})"
+                    if e1.startswith("pl.col("):
+                        call = "" if op.endswith(")") else "()"
+                        return f"{e1}.{op}{call}"
 
-                    call = "" if op.endswith(")") else "()"
-                    return f"{e1}.{op}{call}"
+                    # support use of consts as numpy/builtin params, eg:
+                    # "np.sin(3) + np.cos(x)", or "len('const_string') + len(x)"
+                    pfx = "np." if op in _NUMPY_FUNCTIONS else ""
+                    return f"{pfx}{op}({e1})"
                 return f"{op}{e1}"
             else:
                 e2 = self._expr(value.right_operand, col, param_name, depth + 1)


### PR DESCRIPTION
instead of
```
if not condition:
    logic_1
logic_2
```
do
```
if condition:
    logic_2
logic_1
```

Super-minor, I know, but it helps simplify things ahead of further complexity from https://github.com/pola-rs/polars/pull/13347