### PR TITLE
feat(python): validate Enum categories

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -538,7 +538,7 @@ class Enum(DataType):
 
     categories: list[str]
 
-    def __init__(self, categories: list[str] | Iterator[str]):
+    def __init__(self, categories: Iterable[str]):
         """
         A fixed set categorical encoding of a set of strings.
 
@@ -548,7 +548,7 @@ class Enum(DataType):
             Valid categories in the dataset.
 
         """
-        if isinstance(categories, Iterator):
+        if not isinstance(categories, list):
             categories = list(categories)
 
         seen: set[str] = set()

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -5,19 +5,10 @@ import os
 import re
 import sys
 import warnings
-from collections import Counter
 from collections.abc import MappingView, Sized
 from enum import Enum
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generator,
-    Iterable,
-    Literal,
-    Sequence,
-    TypeVar,
-)
+from typing import TYPE_CHECKING, Any, Generator, Iterable, Literal, Sequence, TypeVar
 
 import polars as pl
 from polars import functions as F
@@ -245,35 +236,11 @@ def parse_version(version: Sequence[str | int]) -> tuple[int, ...]:
     return tuple(int(re.sub(r"\D", "", str(v))) for v in version)
 
 
-def ordered_unique(
-    values: Iterable[Any], *, return_duplicates: bool = False
-) -> list[Any] | tuple[list[Any], dict[Any, int]]:
-    """
-    Return unique list of sequence values, maintaining their order of appearance.
-
-    Parameters
-    ----------
-    values
-        Sequence of values to be made unique.
-    return_duplicates
-        If True, also return a dictionary of duplicate values and their counts.
-
-    """
+def ordered_unique(values: Sequence[Any]) -> list[Any]:
+    """Return unique list of sequence values, maintaining their order of appearance."""
     seen: set[Any] = set()
     add_ = seen.add
-    if not return_duplicates:
-        return [v for v in values if not (v in seen or add_(v))]
-    else:
-        count: dict[Any, int] = Counter()
-        unique = []
-        for v in values:
-            count[v] += 1
-            if v not in seen:
-                unique.append(v)
-                seen.add(v)
-
-        dupes = Counter({k: v for k, v in count.items() if v > 1})
-        return unique, dupes
+    return [v for v in values if not (v in seen or add_(v))]
 
 
 def scale_bytes(sz: int, unit: SizeUnit) -> int | float:

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -5,10 +5,19 @@ import os
 import re
 import sys
 import warnings
+from collections import Counter
 from collections.abc import MappingView, Sized
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator, Iterable, Literal, Sequence, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Generator,
+    Iterable,
+    Literal,
+    Sequence,
+    TypeVar,
+)
 
 import polars as pl
 from polars import functions as F
@@ -236,11 +245,35 @@ def parse_version(version: Sequence[str | int]) -> tuple[int, ...]:
     return tuple(int(re.sub(r"\D", "", str(v))) for v in version)
 
 
-def ordered_unique(values: Sequence[Any]) -> list[Any]:
-    """Return unique list of sequence values, maintaining their order of appearance."""
+def ordered_unique(
+    values: Iterable[Any], *, return_duplicates: bool = False
+) -> list[Any] | tuple[list[Any], dict[Any, int]]:
+    """
+    Return unique list of sequence values, maintaining their order of appearance.
+
+    Parameters
+    ----------
+    values
+        Sequence of values to be made unique.
+    return_duplicates
+        If True, also return a dictionary of duplicate values and their counts.
+
+    """
     seen: set[Any] = set()
     add_ = seen.add
-    return [v for v in values if not (v in seen or add_(v))]
+    if not return_duplicates:
+        return [v for v in values if not (v in seen or add_(v))]
+    else:
+        count: dict[Any, int] = Counter()
+        unique = []
+        for v in values:
+            count[v] += 1
+            if v not in seen:
+                unique.append(v)
+                seen.add(v)
+
+        dupes = Counter({k: v for k, v in count.items() if v > 1})
+        return unique, dupes
 
 
 def scale_bytes(sz: int, unit: SizeUnit) -> int | float:

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -1,6 +1,7 @@
 import operator
+from datetime import date
 from textwrap import dedent
-from typing import Callable
+from typing import Any, Callable
 
 import pytest
 
@@ -303,3 +304,17 @@ def test_different_enum_comparison_order() -> None:
             match="can only compare categoricals of the same type",
         ):
             df_enum.filter(op(pl.col("a_cat"), pl.col("b_cat")))
+
+
+@pytest.mark.parametrize(
+    "categories",
+    [[None], [date.today()], [-10, 10], ["x", "y", None]],
+)
+def test_valid_enum_category_types(categories: Any) -> None:
+    with pytest.raises(TypeError, match="Enum categories"):
+        pl.Enum(categories)
+
+
+def test_enum_categories_unique() -> None:
+    with pytest.raises(ValueError, match="must be unique; found 2 duplicates"):
+        pl.Enum(["a", "a", "b", "b", "b", "c"])

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -16,9 +16,12 @@ def test_enum_creation() -> None:
     assert s.len() == 3
     assert s.dtype == pl.Enum(categories=["a", "b"])
 
-    # from iterator
+    # from iterables
     e = pl.Enum(f"x{i}" for i in range(5))
     assert e.categories == ["x0", "x1", "x2", "x3", "x4"]
+
+    e = pl.Enum("abcde")
+    assert e.categories == ["a", "b", "c", "d", "e"]
 
 
 def test_enum_non_existent() -> None:

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -16,6 +16,10 @@ def test_enum_creation() -> None:
     assert s.len() == 3
     assert s.dtype == pl.Enum(categories=["a", "b"])
 
+    # from iterator
+    e = pl.Enum(f"x{i}" for i in range(5))
+    assert e.categories == ["x0", "x1", "x2", "x3", "x4"]
+
 
 def test_enum_non_existent() -> None:
     with pytest.raises(

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -316,5 +316,5 @@ def test_valid_enum_category_types(categories: Any) -> None:
 
 
 def test_enum_categories_unique() -> None:
-    with pytest.raises(ValueError, match="must be unique; found 2 duplicates"):
+    with pytest.raises(ValueError, match="must be unique; found duplicate 'a'"):
         pl.Enum(["a", "a", "b", "b", "b", "c"])


### PR DESCRIPTION
Split-out from #13345, and contains only the category-validation checks.
Prevents creation of invalid Enums (eg: with categories of the wrong type or duplicate values).

## Examples

Category type check:
```python
pl.Enum([1.234, 5.678])
# TypeError: Enum categories must be strings; found 1.234
```

Category uniqueness check:
```python
pl.Enum(["misc", "value", "value", "other"])
# ValueError: Enum categories must be unique; found 1 duplicates, eg: 'value'
```