### PR TITLE
feat(python): improve large Enum reprs

### DIFF
--- a/py-polars/src/polars/datatypes/classes.py
+++ b/py-polars/src/polars/datatypes/classes.py
@@ -905,7 +905,15 @@ class Enum(DataType):
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
-        return f"{class_name}(categories={self.categories.to_list()!r})"
+        if len(categories := self.categories) <= 6:
+            category_repr = ",".join(f"{cat!r}" for cat in categories)
+        else:
+            category_repr = (
+                ",".join(f"{cat!r}" for cat in categories[:3])
+                + " … "
+                + ",".join(f"{cat!r}" for cat in categories[-3:])
+            )
+        return f"{class_name}(categories=[{category_repr}])"
 
     def union(self, other: Enum) -> Enum:
         """Union of two Enums."""

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -531,6 +531,35 @@ def test_enum_cast_from_other_integer_dtype_oob() -> None:
         series.cast(enum_dtype)
 
 
+def test_enum_repr() -> None:
+    e1 = pl.Enum([f"c{i}" for i in range(6)])
+    e2 = pl.Enum([f"c{i}" for i in range(12)])
+    e3 = pl.Enum([f"c{i}" for i in range(24)])
+
+    assert repr(e1) == "Enum(categories=['c0','c1','c2','c3','c4','c5'])"
+    assert repr(e2) == "Enum(categories=['c0','c1','c2' … 'c9','c10','c11'])"
+    assert repr(e3) == "Enum(categories=['c0','c1','c2' … 'c21','c22','c23'])"
+
+
+def test_enum_creating_col_expr() -> None:
+    df = pl.DataFrame(
+        {
+            "col1": ["a", "b", "c"],
+            "col2": ["d", "e", "f"],
+            "col3": ["g", "h", "i"],
+        },
+        schema={
+            "col1": pl.Enum(["a", "b", "c"]),
+            "col2": pl.Categorical(),
+            "col3": pl.Enum(["g", "h", "i"]),
+        },
+    )
+
+    out = df.select(pl.col(pl.Enum))
+    expected = df.select("col1", "col3")
+    assert_frame_equal(out, expected)
+
+
 def test_enum_cse_eq() -> None:
     df = pl.DataFrame({"a": [1]})
 


### PR DESCRIPTION
Closes #13337.

Split-out from #13345 following some [insight](https://github.com/pola-rs/polars/pull/13345#discussion_r1438914420) from @stinodego, and contains only the improved `__repr__`.

## Examples

Improved repr for Enum with a large number of categories:
```python
import polars as pl

pl.Enum(f"c{i}" for i in range(5))
# Enum(categories=['c0','c1','c2','c3','c4'])

pl.Enum(f"c{i}" for i in range(500))
# Enum(categories=['c0','c1','c2' … 'c497','c498','c499'])
```
---

ℹ️ **RFC: DataType serialisation**

Parked this PR in Draft as there is apparently an implicit expectation that the DataType repr should be guaranteed to eval back to the equivalent instantiated object, acting as a form of serialisation. I think we need a real API point for this instead, as the repr is a fragile/non-standard way to handle that, and not obvious.

Given the desired use-case[^1] I think we might want to add `write_json` and `from_json` methods for DataType, which would decouple serialisation from the repr and offer a solid/consistent API for this use-case. We already have such methods available for Expr, for example.

[^1]: See #13152