### PR TITLE
feat(rust,python,cli): support `REGEXP` and `RLIKE` pattern matching in SQL engine

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -7,7 +7,7 @@ use polars_lazy::prelude::*;
 use polars_plan::prelude::*;
 use polars_plan::utils::expressions_to_schema;
 use sqlparser::ast::{
-    Distinct, ExcludeSelectItem, Expr as SqlExpr, FunctionArg, GroupByExpr, JoinOperator,
+    Distinct, ExcludeSelectItem, Expr as SQLExpr, FunctionArg, GroupByExpr, JoinOperator,
     ObjectName, ObjectType, Offset, OrderByExpr, Query, Select, SelectItem, SetExpr, SetOperator,
     SetQuantifier, Statement, TableAlias, TableFactor, TableWithJoins, Value as SQLValue,
     WildcardAdditionalOptions,
@@ -391,7 +391,7 @@ impl SQLContext {
         if let GroupByExpr::Expressions(group_by_exprs) = &select_stmt.group_by {
             group_by_keys = group_by_exprs.iter()
                 .map(|e| match e {
-                    SqlExpr::Value(SQLValue::Number(idx, _)) => {
+                    SQLExpr::Value(SQLValue::Number(idx, _)) => {
                         let idx = match idx.parse::<usize>() {
                             Ok(0) | Err(_) => Err(polars_err!(
                                 ComputeError:
@@ -402,7 +402,7 @@ impl SQLContext {
                         }?;
                         Ok(projections[idx].clone())
                     },
-                    SqlExpr::Value(_) => Err(polars_err!(
+                    SQLExpr::Value(_) => Err(polars_err!(
                         ComputeError:
                         "group_by error: a positive number or an expression expected",
                     )),
@@ -713,16 +713,16 @@ impl SQLContext {
     fn process_limit_offset(
         &self,
         lf: LazyFrame,
-        limit: &Option<SqlExpr>,
+        limit: &Option<SQLExpr>,
         offset: &Option<Offset>,
     ) -> PolarsResult<LazyFrame> {
         match (offset, limit) {
             (
                 Some(Offset {
-                    value: SqlExpr::Value(SQLValue::Number(offset, _)),
+                    value: SQLExpr::Value(SQLValue::Number(offset, _)),
                     ..
                 }),
-                Some(SqlExpr::Value(SQLValue::Number(limit, _))),
+                Some(SQLExpr::Value(SQLValue::Number(limit, _))),
             ) => Ok(lf.slice(
                 offset
                     .parse()
@@ -733,7 +733,7 @@ impl SQLContext {
             )),
             (
                 Some(Offset {
-                    value: SqlExpr::Value(SQLValue::Number(offset, _)),
+                    value: SQLExpr::Value(SQLValue::Number(offset, _)),
                     ..
                 }),
                 None,
@@ -743,7 +743,7 @@ impl SQLContext {
                     .map_err(|e| polars_err!(ComputeError: "OFFSET conversion error: {}", e))?,
                 IdxSize::MAX,
             )),
-            (None, Some(SqlExpr::Value(SQLValue::Number(limit, _)))) => Ok(lf.limit(
+            (None, Some(SQLExpr::Value(SQLValue::Number(limit, _)))) => Ok(lf.limit(
                 limit
                     .parse()
                     .map_err(|e| polars_err!(ComputeError: "LIMIT conversion error: {}", e))?,

--- a/crates/polars-sql/src/keywords.rs
+++ b/crates/polars-sql/src/keywords.rs
@@ -5,14 +5,14 @@
 //! This module defines:
 //! - all Polars SQL keywords [`all_keywords`]
 //! - all of polars SQL functions [`all_functions`]
-use crate::functions::PolarsSqlFunctions;
+use crate::functions::PolarsSQLFunctions;
 use crate::table_functions::PolarsTableFunctions;
 
 /// Get all keywords that are supported by Polars SQL
 pub fn all_keywords() -> Vec<&'static str> {
     let mut keywords = vec![];
     keywords.extend_from_slice(PolarsTableFunctions::keywords());
-    keywords.extend_from_slice(PolarsSqlFunctions::keywords());
+    keywords.extend_from_slice(PolarsSQLFunctions::keywords());
     use sqlparser::keywords;
     let sql_keywords = &[
         keywords::AND,
@@ -49,7 +49,9 @@ pub fn all_keywords() -> Vec<&'static str> {
         keywords::OR,
         keywords::ORDER,
         keywords::OUTER,
+        keywords::REGEXP,
         keywords::RIGHT,
+        keywords::RLIKE,
         keywords::SELECT,
         keywords::SEMI,
         keywords::SHOW,
@@ -71,6 +73,6 @@ pub fn all_keywords() -> Vec<&'static str> {
 pub fn all_functions() -> Vec<&'static str> {
     let mut functions = vec![];
     functions.extend_from_slice(PolarsTableFunctions::keywords());
-    functions.extend_from_slice(PolarsSqlFunctions::keywords());
+    functions.extend_from_slice(PolarsSQLFunctions::keywords());
     functions
 }

--- a/crates/polars-sql/src/table_functions.rs
+++ b/crates/polars-sql/src/table_functions.rs
@@ -103,10 +103,10 @@ impl PolarsTableFunctions {
 
     #[allow(dead_code)]
     fn get_file_path_from_arg(&self, arg: &FunctionArg) -> PolarsResult<String> {
-        use sqlparser::ast::{Expr as SqlExpr, Value as SqlValue};
+        use sqlparser::ast::{Expr as SQLExpr, Value as SQLValue};
         match arg {
-            FunctionArg::Unnamed(FunctionArgExpr::Expr(SqlExpr::Value(
-                SqlValue::SingleQuotedString(s),
+            FunctionArg::Unnamed(FunctionArgExpr::Expr(SQLExpr::Value(
+                SQLValue::SingleQuotedString(s),
             ))) => Ok(s.to_string()),
             _ => polars_bail!(
                 ComputeError:


### PR DESCRIPTION
* Adds polars SQL engine support for `REGEXP` and `RLIKE` pattern matching (functionally identical to each other).
* Minor tidy-up; inconsistent use of "Sql" vs "SQL" in the crate's object/func names - standardised on "SQL".
* Bonus unit test coverage for `CASE … WHEN … ELSE … END` and `COALESCE`.

## Examples

Literal pattern match:
```python
lf = pl.LazyFrame({
    "idx": [0, 1, 2, 3, 4],
    "val": ["ABC", "abc", "000", "A0C", "a0c"],
})
with pl.SQLContext(test_data=lf, eager_execution=True) as ctx:
    print( ctx.execute("SELECT * FROM test_data WHERE val NOT REGEXP '.*c$'") )

# shape: (3, 2)
# ┌─────┬─────┐
# │ idx ┆ val │
# │ --- ┆ --- │
# │ i64 ┆ str │
# ╞═════╪═════╡
# │ 0   ┆ ABC │
# │ 2   ┆ 000 │
# │ 3   ┆ A0C │
# └─────┴─────┘
```
Expression pattern match (new: not available through the existing `~`, `~*`, etc regex ops):
```python
lf = pl.LazyFrame({
    "idx": [0, 1, 2, 3, 4],
    "val": ["ABC", "abc", "000", "A0C", "a0c"],
    "pat": ["^A", "^A", "^A", r"[AB]\d.*$", ".*xxx$"],
})
with pl.SQLContext(test_data=lf, eager_execution=True) as ctx:
    print( ctx.execute(f"SELECT idx,val FROM test_data WHERE val REGEXP pat") )

# shape: (2, 2)
# ┌─────┬─────┐
# │ idx ┆ val │
# │ --- ┆ --- │
# │ i64 ┆ str │
# ╞═════╪═════╡
# │ 0   ┆ ABC │
# │ 3   ┆ A0C │
# └─────┴─────┘
```
