### PR TITLE
fix(rust): range/ranges output name should follow lhs rule

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/range/date_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/date_range.rs
@@ -22,9 +22,7 @@ pub(super) fn temporal_range(
     if s[0].dtype() == &DataType::Date && interval.is_full_days() {
         date_range(s, interval, closed)
     } else {
-        let mut s = datetime_range(s, interval, closed, time_unit, time_zone)?;
-        s.rename("date");
-        Ok(s)
+        datetime_range(s, interval, closed, time_unit, time_zone)
     }
 }
 
@@ -38,15 +36,14 @@ pub(super) fn temporal_ranges(
     if s[0].dtype() == &DataType::Date && interval.is_full_days() {
         date_ranges(s, interval, closed)
     } else {
-        let mut s = datetime_ranges(s, interval, closed, time_unit, time_zone)?;
-        s.rename("date_range");
-        Ok(s)
+        datetime_ranges(s, interval, closed, time_unit, time_zone)
     }
 }
 
 fn date_range(s: &[Series], interval: Duration, closed: ClosedWindow) -> PolarsResult<Series> {
     let start = &s[0];
     let end = &s[1];
+    let name = start.name();
 
     ensure_range_bounds_contain_exactly_one_value(start, end)?;
 
@@ -59,7 +56,7 @@ fn date_range(s: &[Series], interval: Duration, closed: ClosedWindow) -> PolarsR
         * MILLISECONDS_IN_DAY;
 
     let result = datetime_range_impl(
-        "date",
+        name,
         start,
         end,
         interval,
@@ -83,7 +80,7 @@ fn date_ranges(s: &[Series], interval: Duration, closed: ClosedWindow) -> Polars
     let end = end.i64().unwrap() * MILLISECONDS_IN_DAY;
 
     let mut builder = ListPrimitiveChunkedBuilder::<Int32Type>::new(
-        "date_range",
+        start.name(),
         start.len(),
         start.len() * CAPACITY_FACTOR,
         DataType::Int32,

--- a/crates/polars-plan/src/dsl/function_expr/range/datetime_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/datetime_range.rs
@@ -81,6 +81,7 @@ pub(super) fn datetime_range(
         _ => (start.cast(&dtype)?, end.cast(&dtype)?),
     };
 
+    let name = start.name();
     let start = temporal_series_to_i64_scalar(&start)
         .ok_or_else(|| polars_err!(ComputeError: "start is an out-of-range time."))?;
     let end = temporal_series_to_i64_scalar(&end)
@@ -93,7 +94,7 @@ pub(super) fn datetime_range(
                 Some(tz) => Some(parse_time_zone(tz)?),
                 _ => None,
             };
-            datetime_range_impl("datetime", start, end, interval, closed, tu, tz.as_ref())?
+            datetime_range_impl(name, start, end, interval, closed, tu, tz.as_ref())?
         },
         _ => unimplemented!(),
     };
@@ -185,7 +186,7 @@ pub(super) fn datetime_ranges(
     let out = match dtype {
         DataType::Datetime(tu, ref tz) => {
             let mut builder = ListPrimitiveChunkedBuilder::<Int64Type>::new(
-                "datetime_range",
+                start.name(),
                 start.len(),
                 start.len() * CAPACITY_FACTOR,
                 DataType::Int64,

--- a/crates/polars-plan/src/dsl/function_expr/range/int_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/int_range.rs
@@ -9,6 +9,7 @@ const CAPACITY_FACTOR: usize = 5;
 pub(super) fn int_range(s: &[Series], step: i64, dtype: DataType) -> PolarsResult<Series> {
     let mut start = &s[0];
     let mut end = &s[1];
+    let name = start.name();
 
     ensure_range_bounds_contain_exactly_one_value(start, end)?;
     polars_ensure!(dtype.is_integer(), ComputeError: "non-integer `dtype` passed to `int_range`: {:?}", dtype);
@@ -26,7 +27,7 @@ pub(super) fn int_range(s: &[Series], step: i64, dtype: DataType) -> PolarsResul
     with_match_physical_integer_polars_type!(dtype, |$T| {
         let start_v = get_first_series_value::<$T>(start)?;
         let end_v = get_first_series_value::<$T>(end)?;
-        int_range_impl::<$T>(start_v, end_v, step)
+        int_range_impl::<$T>(start_v, end_v, step, name)
     })
 }
 
@@ -40,14 +41,17 @@ where
     Ok(value)
 }
 
-fn int_range_impl<T>(start: T::Native, end: T::Native, step: i64) -> PolarsResult<Series>
+fn int_range_impl<T>(
+    start: T::Native,
+    end: T::Native,
+    step: i64,
+    name: &str,
+) -> PolarsResult<Series>
 where
     T: PolarsIntegerType,
     ChunkedArray<T>: IntoSeries,
     std::ops::Range<T::Native>: DoubleEndedIterator<Item = T::Native>,
 {
-    let name = "int";
-
     let mut ca = match step {
         0 => polars_bail!(InvalidOperation: "step must not be zero"),
         1 => ChunkedArray::<T>::from_iter_values(name, start..end),
@@ -85,7 +89,8 @@ pub(super) fn int_ranges(s: &[Series]) -> PolarsResult<Series> {
 
     let len = std::cmp::max(start.len(), end.len());
     let mut builder = ListPrimitiveChunkedBuilder::<Int64Type>::new(
-        "int_range",
+        // The name should follow our left hand rule.
+        start.name(),
         len,
         len * CAPACITY_FACTOR,
         DataType::Int64,

--- a/crates/polars-plan/src/dsl/function_expr/range/time_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/time_range.rs
@@ -16,6 +16,7 @@ pub(super) fn time_range(
 ) -> PolarsResult<Series> {
     let start = &s[0];
     let end = &s[1];
+    let name = start.name();
 
     ensure_range_bounds_contain_exactly_one_value(start, end)?;
 
@@ -25,7 +26,7 @@ pub(super) fn time_range(
     let end = temporal_series_to_i64_scalar(&end.cast(&dtype)?)
         .ok_or_else(|| polars_err!(ComputeError: "end is an out-of-range time."))?;
 
-    let out = time_range_impl("time", start, end, interval, closed)?;
+    let out = time_range_impl(name, start, end, interval, closed)?;
     Ok(out.cast(&dtype).unwrap().into_series())
 }
 
@@ -47,7 +48,7 @@ pub(super) fn time_ranges(
 
     let len = std::cmp::max(start.len(), end.len());
     let mut builder = ListPrimitiveChunkedBuilder::<Int64Type>::new(
-        "time_range",
+        start.name(),
         len,
         len * CAPACITY_FACTOR,
         DataType::Int64,

--- a/crates/polars/tests/it/lazy/expressions/apply.rs
+++ b/crates/polars/tests/it/lazy/expressions/apply.rs
@@ -12,7 +12,7 @@ fn test_int_range_agg() -> PolarsResult<()> {
         .with_columns([int_range(lit(0i32), count(), 1, DataType::Int64).over([col("x")])])
         .collect()?;
     assert_eq!(
-        Vec::from_iter(out.column("int")?.i64()?.into_no_null_iter()),
+        Vec::from_iter(out.column("literal")?.i64()?.into_no_null_iter()),
         &[0, 1, 0, 1, 0, 1]
     );
 

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -108,12 +108,16 @@ class ExprDateTimeNameSpace:
         Examples
         --------
         >>> from datetime import timedelta, datetime
-        >>> df = pl.datetime_range(
-        ...     datetime(2001, 1, 1),
-        ...     datetime(2001, 1, 2),
-        ...     timedelta(minutes=225),
-        ...     eager=True,
-        ... ).to_frame()
+        >>> df = (
+        ...     pl.datetime_range(
+        ...         datetime(2001, 1, 1),
+        ...         datetime(2001, 1, 2),
+        ...         timedelta(minutes=225),
+        ...         eager=True,
+        ...     )
+        ...     .alias("datetime")
+        ...     .to_frame()
+        ... )
         >>> df
         shape: (7, 1)
         ┌─────────────────────┐
@@ -149,9 +153,13 @@ class ExprDateTimeNameSpace:
         >>> truncate_str.equals(truncate_td)
         True
 
-        >>> df = pl.datetime_range(
-        ...     datetime(2001, 1, 1), datetime(2001, 1, 1, 1), "10m", eager=True
-        ... ).to_frame()
+        >>> df = (
+        ...     pl.datetime_range(
+        ...         datetime(2001, 1, 1), datetime(2001, 1, 1, 1), "10m", eager=True
+        ...     )
+        ...     .alias("datetime")
+        ...     .to_frame()
+        ... )
         >>> df.select(
         ...     "datetime", pl.col("datetime").dt.truncate("30m").alias("truncate")
         ... )
@@ -270,12 +278,16 @@ class ExprDateTimeNameSpace:
         Examples
         --------
         >>> from datetime import timedelta, datetime
-        >>> df = pl.datetime_range(
-        ...     datetime(2001, 1, 1),
-        ...     datetime(2001, 1, 2),
-        ...     timedelta(minutes=225),
-        ...     eager=True,
-        ... ).to_frame()
+        >>> df = (
+        ...     pl.datetime_range(
+        ...         datetime(2001, 1, 1),
+        ...         datetime(2001, 1, 2),
+        ...         timedelta(minutes=225),
+        ...         eager=True,
+        ...     )
+        ...     .alias("datetime")
+        ...     .to_frame()
+        ... )
         >>> df.with_columns(pl.col("datetime").dt.round("1h").alias("round"))
         shape: (7, 2)
         ┌─────────────────────┬─────────────────────┐
@@ -292,9 +304,13 @@ class ExprDateTimeNameSpace:
         │ 2001-01-01 22:30:00 ┆ 2001-01-01 23:00:00 │
         └─────────────────────┴─────────────────────┘
 
-        >>> df = pl.datetime_range(
-        ...     datetime(2001, 1, 1), datetime(2001, 1, 1, 1), "10m", eager=True
-        ... ).to_frame()
+        >>> df = (
+        ...     pl.datetime_range(
+        ...         datetime(2001, 1, 1), datetime(2001, 1, 1, 1), "10m", eager=True
+        ...     )
+        ...     .alias("datetime")
+        ...     .to_frame()
+        ... )
         >>> df.with_columns(pl.col("datetime").dt.round("30m").alias("round"))
         shape: (7, 2)
         ┌─────────────────────┬─────────────────────┐
@@ -1123,9 +1139,11 @@ class ExprDateTimeNameSpace:
         Examples
         --------
         >>> from datetime import date
-        >>> df = pl.date_range(
-        ...     date(2001, 1, 1), date(2001, 1, 3), eager=True
-        ... ).to_frame()
+        >>> df = (
+        ...     pl.date_range(date(2001, 1, 1), date(2001, 1, 3), eager=True)
+        ...     .alias("date")
+        ...     .to_frame()
+        ... )
         >>> df.with_columns(
         ...     pl.col("date").dt.epoch().alias("epoch_ns"),
         ...     pl.col("date").dt.epoch(time_unit="s").alias("epoch_s"),
@@ -1165,9 +1183,11 @@ class ExprDateTimeNameSpace:
         Examples
         --------
         >>> from datetime import date
-        >>> df = pl.date_range(
-        ...     date(2001, 1, 1), date(2001, 1, 3), eager=True
-        ... ).to_frame()
+        >>> df = (
+        ...     pl.date_range(date(2001, 1, 1), date(2001, 1, 3), eager=True)
+        ...     .alias("date")
+        ...     .to_frame()
+        ... )
         >>> df.with_columns(
         ...     pl.col("date").dt.timestamp().alias("timestamp_ns"),
         ...     pl.col("date").dt.timestamp("ms").alias("timestamp_ms"),

--- a/py-polars/polars/functions/range/date_range.py
+++ b/py-polars/polars/functions/range/date_range.py
@@ -141,7 +141,9 @@ def date_range(
     Using Polars duration string to specify the interval:
 
     >>> from datetime import date
-    >>> pl.date_range(date(2022, 1, 1), date(2022, 3, 1), "1mo", eager=True)
+    >>> pl.date_range(date(2022, 1, 1), date(2022, 3, 1), "1mo", eager=True).alias(
+    ...     "date"
+    ... )
     shape: (3,)
     Series: 'date' [date]
     [
@@ -158,7 +160,7 @@ def date_range(
     ...     date(1985, 1, 10),
     ...     timedelta(days=2),
     ...     eager=True,
-    ... )
+    ... ).alias("date")
     shape: (5,)
     Series: 'date' [date]
     [
@@ -303,7 +305,7 @@ def date_ranges(
     ...         "end": date(2022, 1, 3),
     ...     }
     ... )
-    >>> df.with_columns(pl.date_ranges("start", "end"))
+    >>> df.with_columns(date_range=pl.date_ranges("start", "end"))
     shape: (2, 3)
     ┌────────────┬────────────┬───────────────────────────────────┐
     │ start      ┆ end        ┆ date_range                        │

--- a/py-polars/polars/functions/range/datetime_range.py
+++ b/py-polars/polars/functions/range/datetime_range.py
@@ -127,7 +127,9 @@ def datetime_range(
     Using Polars duration string to specify the interval:
 
     >>> from datetime import datetime
-    >>> pl.datetime_range(datetime(2022, 1, 1), datetime(2022, 3, 1), "1mo", eager=True)
+    >>> pl.datetime_range(
+    ...     datetime(2022, 1, 1), datetime(2022, 3, 1), "1mo", eager=True
+    ... ).alias("datetime")
     shape: (3,)
     Series: 'datetime' [datetime[μs]]
     [
@@ -145,7 +147,7 @@ def datetime_range(
     ...     timedelta(days=1, hours=12),
     ...     time_unit="ms",
     ...     eager=True,
-    ... )
+    ... ).alias("datetime")
     shape: (7,)
     Series: 'datetime' [datetime[ms]]
     [
@@ -166,7 +168,7 @@ def datetime_range(
     ...     "1mo",
     ...     time_zone="America/New_York",
     ...     eager=True,
-    ... )
+    ... ).alias("datetime")
     shape: (3,)
     Series: 'datetime' [datetime[μs, America/New_York]]
     [

--- a/py-polars/polars/functions/range/int_range.py
+++ b/py-polars/polars/functions/range/int_range.py
@@ -93,7 +93,7 @@ def arange(
 
     Examples
     --------
-    >>> pl.arange(0, 3, eager=True)
+    >>> pl.arange(0, 3, eager=True).alias("int")
     shape: (3,)
     Series: 'int' [i64]
     [
@@ -177,7 +177,7 @@ def int_range(
 
     Examples
     --------
-    >>> pl.int_range(0, 3, eager=True)
+    >>> pl.int_range(0, 3, eager=True).alias("int")
     shape: (3,)
     Series: 'int' [i64]
     [
@@ -269,7 +269,7 @@ def int_ranges(
     Examples
     --------
     >>> df = pl.DataFrame({"start": [1, -1], "end": [3, 2]})
-    >>> df.with_columns(pl.int_ranges("start", "end"))
+    >>> df.with_columns(int_range=pl.int_ranges("start", "end"))
     shape: (2, 3)
     ┌───────┬─────┬────────────┐
     │ start ┆ end ┆ int_range  │

--- a/py-polars/polars/functions/range/time_range.py
+++ b/py-polars/polars/functions/range/time_range.py
@@ -124,7 +124,7 @@ def time_range(
     ...     start=time(14, 0),
     ...     interval=timedelta(hours=3, minutes=15),
     ...     eager=True,
-    ... )
+    ... ).alias("time")
     shape: (4,)
     Series: 'time' [time]
     [
@@ -263,7 +263,7 @@ def time_ranges(
     ...         "end": time(11, 0),
     ...     }
     ... )
-    >>> df.with_columns(pl.time_ranges("start", "end"))
+    >>> df.with_columns(time_range=pl.time_ranges("start", "end"))
     shape: (2, 3)
     ┌──────────┬──────────┬────────────────────────────────┐
     │ start    ┆ end      ┆ time_range                     │

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -66,7 +66,7 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> date = pl.datetime_range(
         ...     datetime(2001, 1, 1), datetime(2001, 1, 3), "1d", eager=True
-        ... )
+        ... ).alias("datetime")
         >>> date
         shape: (3,)
         Series: 'datetime' [datetime[μs]]
@@ -282,7 +282,7 @@ class DateTimeNameSpace:
         >>> from datetime import date
         >>> date = pl.date_range(
         ...     date(2001, 1, 1), date(2001, 4, 1), interval="1mo", eager=True
-        ... )
+        ... ).alias("date")
         >>> date.dt.quarter()
         shape: (4,)
         Series: 'date' [i8]
@@ -314,7 +314,7 @@ class DateTimeNameSpace:
         >>> from datetime import date
         >>> date = pl.date_range(
         ...     date(2001, 1, 1), date(2001, 4, 1), interval="1mo", eager=True
-        ... )
+        ... ).alias("date")
         >>> date.dt.month()
         shape: (4,)
         Series: 'date' [i8]
@@ -346,7 +346,7 @@ class DateTimeNameSpace:
         >>> from datetime import date
         >>> date = pl.date_range(
         ...     date(2001, 1, 1), date(2001, 4, 1), interval="1mo", eager=True
-        ... )
+        ... ).alias("date")
         >>> date.dt.week()
         shape: (4,)
         Series: 'date' [i8]
@@ -375,7 +375,9 @@ class DateTimeNameSpace:
         Examples
         --------
         >>> from datetime import date
-        >>> s = pl.date_range(date(2001, 1, 1), date(2001, 1, 7), eager=True)
+        >>> s = pl.date_range(date(2001, 1, 1), date(2001, 1, 7), eager=True).alias(
+        ...     "date"
+        ... )
         >>> s.dt.weekday()
         shape: (7,)
         Series: 'date' [i8]
@@ -410,7 +412,7 @@ class DateTimeNameSpace:
         >>> from datetime import date
         >>> s = pl.date_range(
         ...     date(2001, 1, 1), date(2001, 1, 9), interval="2d", eager=True
-        ... )
+        ... ).alias("date")
         >>> s.dt.day()
         shape: (5,)
         Series: 'date' [i8]
@@ -443,7 +445,7 @@ class DateTimeNameSpace:
         >>> from datetime import date
         >>> s = pl.date_range(
         ...     date(2001, 1, 1), date(2001, 3, 1), interval="1mo", eager=True
-        ... )
+        ... ).alias("date")
         >>> s.dt.ordinal_day()
         shape: (3,)
         Series: 'date' [i16]
@@ -566,7 +568,9 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> start = datetime(2001, 1, 1)
         >>> stop = datetime(2001, 1, 1, 3)
-        >>> date = pl.datetime_range(start, stop, interval="1h", eager=True)
+        >>> date = pl.datetime_range(start, stop, interval="1h", eager=True).alias(
+        ...     "datetime"
+        ... )
         >>> date
         shape: (4,)
         Series: 'datetime' [datetime[μs]]
@@ -606,7 +610,9 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> start = datetime(2001, 1, 1)
         >>> stop = datetime(2001, 1, 1, 0, 4, 0)
-        >>> date = pl.datetime_range(start, stop, interval="2m", eager=True)
+        >>> date = pl.datetime_range(start, stop, interval="2m", eager=True).alias(
+        ...     "datetime"
+        ... )
         >>> date
         shape: (3,)
         Series: 'datetime' [datetime[μs]]
@@ -692,7 +698,9 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> start = datetime(2001, 1, 1)
         >>> stop = datetime(2001, 1, 1, 0, 0, 4)
-        >>> s = pl.datetime_range(start, stop, interval="500ms", eager=True)
+        >>> s = pl.datetime_range(start, stop, interval="500ms", eager=True).alias(
+        ...     "datetime"
+        ... )
         >>> s.dt.millisecond()
         shape: (9,)
         Series: 'datetime' [i32]
@@ -726,7 +734,9 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> start = datetime(2001, 1, 1)
         >>> stop = datetime(2001, 1, 1, 0, 0, 4)
-        >>> date = pl.datetime_range(start, stop, interval="500ms", eager=True)
+        >>> date = pl.datetime_range(start, stop, interval="500ms", eager=True).alias(
+        ...     "datetime"
+        ... )
         >>> date
         shape: (9,)
         Series: 'datetime' [datetime[μs]]
@@ -774,7 +784,9 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> start = datetime(2001, 1, 1)
         >>> stop = datetime(2001, 1, 1, 0, 0, 4)
-        >>> date = pl.datetime_range(start, stop, interval="500ms", eager=True)
+        >>> date = pl.datetime_range(start, stop, interval="500ms", eager=True).alias(
+        ...     "datetime"
+        ... )
         >>> date
         shape: (9,)
         Series: 'datetime' [datetime[μs]]
@@ -820,7 +832,9 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> start = datetime(2001, 1, 1)
         >>> stop = datetime(2001, 1, 3)
-        >>> date = pl.datetime_range(start, stop, interval="1d", eager=True)
+        >>> date = pl.datetime_range(start, stop, interval="1d", eager=True).alias(
+        ...     "datetime"
+        ... )
         >>> date
         shape: (3,)
         Series: 'datetime' [datetime[μs]]
@@ -862,7 +876,9 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> start = datetime(2001, 1, 1)
         >>> stop = datetime(2001, 1, 3)
-        >>> date = pl.datetime_range(start, stop, interval="1d", eager=True)
+        >>> date = pl.datetime_range(start, stop, interval="1d", eager=True).alias(
+        ...     "datetime"
+        ... )
         >>> date
         shape: (3,)
         Series: 'datetime' [datetime[μs]]
@@ -935,7 +951,7 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> start = datetime(2001, 1, 1)
         >>> stop = datetime(2001, 1, 3)
-        >>> date = pl.datetime_range(start, stop, "1d", eager=True)
+        >>> date = pl.datetime_range(start, stop, "1d", eager=True).alias("datetime")
         >>> date
         shape: (3,)
         Series: 'datetime' [datetime[μs]]
@@ -977,7 +993,9 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> start = datetime(2020, 3, 1)
         >>> stop = datetime(2020, 5, 1)
-        >>> date = pl.datetime_range(start, stop, "1mo", time_zone="UTC", eager=True)
+        >>> date = pl.datetime_range(
+        ...     start, stop, "1mo", time_zone="UTC", eager=True
+        ... ).alias("datetime")
         >>> date
         shape: (3,)
         Series: 'datetime' [datetime[μs, UTC]]
@@ -1041,7 +1059,9 @@ class DateTimeNameSpace:
         ...             "1mo",
         ...             time_zone="UTC",
         ...             eager=True,
-        ...         ).dt.convert_time_zone(time_zone="Europe/London"),
+        ...         )
+        ...         .alias("datetime")
+        ...         .dt.convert_time_zone(time_zone="Europe/London"),
         ...     }
         ... )
         >>> df.select(
@@ -1112,7 +1132,7 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> date = pl.datetime_range(
         ...     datetime(2020, 3, 1), datetime(2020, 5, 1), "1mo", eager=True
-        ... )
+        ... ).alias("datetime")
         >>> date
         shape: (3,)
         Series: 'datetime' [datetime[μs]]
@@ -1146,7 +1166,7 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> date = pl.datetime_range(
         ...     datetime(2020, 1, 1), datetime(2020, 1, 4), "1d", eager=True
-        ... )
+        ... ).alias("datetime")
         >>> date
         shape: (4,)
         Series: 'datetime' [datetime[μs]]
@@ -1182,7 +1202,7 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> date = pl.datetime_range(
         ...     datetime(2020, 1, 1), datetime(2020, 1, 4), "1d", eager=True
-        ... )
+        ... ).alias("datetime")
         >>> date
         shape: (4,)
         Series: 'datetime' [datetime[μs]]
@@ -1218,7 +1238,7 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> date = pl.datetime_range(
         ...     datetime(2020, 1, 1), datetime(2020, 1, 1, 0, 4, 0), "1m", eager=True
-        ... )
+        ... ).alias("datetime")
         >>> date
         shape: (5,)
         Series: 'datetime' [datetime[μs]]
@@ -1259,7 +1279,7 @@ class DateTimeNameSpace:
         ...     datetime(2020, 1, 1, 0, 0, 1, 0),
         ...     "1ms",
         ...     eager=True,
-        ... )[:3]
+        ... ).alias("datetime")[:3]
         >>> date
         shape: (3,)
         Series: 'datetime' [datetime[μs]]
@@ -1296,7 +1316,7 @@ class DateTimeNameSpace:
         ...     datetime(2020, 1, 1, 0, 0, 1, 0),
         ...     "1ms",
         ...     eager=True,
-        ... )[:3]
+        ... ).alias("datetime")[:3]
         >>> date
         shape: (3,)
         Series: 'datetime' [datetime[μs]]
@@ -1333,7 +1353,7 @@ class DateTimeNameSpace:
         ...     datetime(2020, 1, 1, 0, 0, 1, 0),
         ...     "1ms",
         ...     eager=True,
-        ... )[:3]
+        ... ).alias("datetime")[:3]
         >>> date
         shape: (3,)
         Series: 'datetime' [datetime[μs]]
@@ -1394,7 +1414,7 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> dates = pl.datetime_range(
         ...     datetime(2000, 1, 1), datetime(2005, 1, 1), "1y", eager=True
-        ... )
+        ... ).alias("datetime")
         >>> dates
         shape: (6,)
         Series: 'datetime' [datetime[μs]]
@@ -1512,7 +1532,7 @@ class DateTimeNameSpace:
         ...     datetime(2001, 1, 2),
         ...     timedelta(minutes=165),
         ...     eager=True,
-        ... )
+        ... ).alias("datetime")
         >>> s
         shape: (9,)
         Series: 'datetime' [datetime[μs]]
@@ -1544,7 +1564,7 @@ class DateTimeNameSpace:
 
         >>> s = pl.datetime_range(
         ...     datetime(2001, 1, 1), datetime(2001, 1, 1, 1), "10m", eager=True
-        ... )
+        ... ).alias("datetime")
         >>> s
         shape: (7,)
         Series: 'datetime' [datetime[μs]]
@@ -1646,7 +1666,9 @@ class DateTimeNameSpace:
         >>> from datetime import timedelta, datetime
         >>> start = datetime(2001, 1, 1)
         >>> stop = datetime(2001, 1, 2)
-        >>> s = pl.datetime_range(start, stop, timedelta(minutes=165), eager=True)
+        >>> s = pl.datetime_range(
+        ...     start, stop, timedelta(minutes=165), eager=True
+        ... ).alias("datetime")
         >>> s
         shape: (9,)
         Series: 'datetime' [datetime[μs]]
@@ -1682,7 +1704,7 @@ class DateTimeNameSpace:
 
         >>> start = datetime(2001, 1, 1)
         >>> stop = datetime(2001, 1, 1, 1)
-        >>> s = pl.datetime_range(start, stop, "10m", eager=True)
+        >>> s = pl.datetime_range(start, stop, "10m", eager=True).alias("datetime")
         >>> s.dt.round("30m")
         shape: (7,)
         Series: 'datetime' [datetime[μs]]
@@ -1748,7 +1770,7 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> s = pl.datetime_range(
         ...     datetime(2000, 1, 2, 2), datetime(2000, 4, 2, 2), "1mo", eager=True
-        ... )
+        ... ).alias("datetime")
         >>> s.dt.month_start()
         shape: (4,)
         Series: 'datetime' [datetime[μs]]
@@ -1779,7 +1801,7 @@ class DateTimeNameSpace:
         >>> from datetime import datetime
         >>> s = pl.datetime_range(
         ...     datetime(2000, 1, 2, 2), datetime(2000, 4, 2, 2), "1mo", eager=True
-        ... )
+        ... ).alias("datetime")
         >>> s.dt.month_end()
         shape: (4,)
         Series: 'datetime' [datetime[μs]]
@@ -1817,7 +1839,7 @@ class DateTimeNameSpace:
         ...     "2d",
         ...     time_zone="Pacific/Apia",
         ...     eager=True,
-        ... )
+        ... ).alias("datetime")
         >>> s
         shape: (2,)
         Series: 'datetime' [datetime[μs, Pacific/Apia]]
@@ -1855,7 +1877,7 @@ class DateTimeNameSpace:
         ...     datetime(2020, 10, 26),
         ...     time_zone="Europe/London",
         ...     eager=True,
-        ... )
+        ... ).alias("datetime")
         >>> s
         shape: (2,)
         Series: 'datetime' [datetime[μs, Europe/London]]

--- a/py-polars/tests/benchmark/test_release.py
+++ b/py-polars/tests/benchmark/test_release.py
@@ -155,7 +155,7 @@ def test_max_statistic_parquet_writer() -> None:
     n = 150_000
 
     # int64 is important to hit the page size
-    df = pl.int_range(0, n, eager=True, dtype=pl.Int64).to_frame()
+    df = pl.int_range(0, n, eager=True, dtype=pl.Int64).alias("int").to_frame()
     f = "/tmp/tmp.parquet"
     df.write_parquet(f, statistics=True, use_pyarrow=False, row_group_size=n)
     result = pl.scan_parquet(f).filter(pl.col("int") > n - 3).collect()

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2342,36 +2342,48 @@ def test_truncate_by_multiple_weeks_diffs() -> None:
 
 
 def test_truncate_use_earliest() -> None:
-    ser = pl.datetime_range(
-        date(2020, 10, 25),
-        datetime(2020, 10, 25, 2),
-        "30m",
-        eager=True,
-        time_zone="Europe/London",
-    ).dt.offset_by("15m")
+    ser = (
+        pl.datetime_range(
+            date(2020, 10, 25),
+            datetime(2020, 10, 25, 2),
+            "30m",
+            eager=True,
+            time_zone="Europe/London",
+        )
+        .alias("datetime")
+        .dt.offset_by("15m")
+    )
     df = ser.to_frame()
     df = df.with_columns(
         use_earliest=pl.col("datetime").dt.dst_offset() == pl.duration(hours=1)
     )
     result = df.select(pl.col("datetime").dt.truncate("30m"))
-    expected = pl.datetime_range(
-        date(2020, 10, 25),
-        datetime(2020, 10, 25, 2),
-        "30m",
-        eager=True,
-        time_zone="Europe/London",
-    ).to_frame()
+    expected = (
+        pl.datetime_range(
+            date(2020, 10, 25),
+            datetime(2020, 10, 25, 2),
+            "30m",
+            eager=True,
+            time_zone="Europe/London",
+        )
+        .alias("datetime")
+        .to_frame()
+    )
     assert_frame_equal(result, expected)
 
 
 def test_truncate_ambiguous() -> None:
-    ser = pl.datetime_range(
-        date(2020, 10, 25),
-        datetime(2020, 10, 25, 2),
-        "30m",
-        eager=True,
-        time_zone="Europe/London",
-    ).dt.offset_by("15m")
+    ser = (
+        pl.datetime_range(
+            date(2020, 10, 25),
+            datetime(2020, 10, 25, 2),
+            "30m",
+            eager=True,
+            time_zone="Europe/London",
+        )
+        .alias("datetime")
+        .dt.offset_by("15m")
+    )
     result = ser.dt.truncate("30m")
     expected = (
         pl.Series(
@@ -2393,13 +2405,17 @@ def test_truncate_ambiguous() -> None:
 
 
 def test_round_ambiguous() -> None:
-    t = pl.datetime_range(
-        date(2020, 10, 25),
-        datetime(2020, 10, 25, 2),
-        "30m",
-        eager=True,
-        time_zone="Europe/London",
-    ).dt.offset_by("15m")
+    t = (
+        pl.datetime_range(
+            date(2020, 10, 25),
+            datetime(2020, 10, 25, 2),
+            "30m",
+            eager=True,
+            time_zone="Europe/London",
+        )
+        .alias("datetime")
+        .dt.offset_by("15m")
+    )
     result = t.dt.round("30m")
     expected = (
         pl.Series(

--- a/py-polars/tests/unit/functions/range/test_date_range.py
+++ b/py-polars/tests/unit/functions/range/test_date_range.py
@@ -158,29 +158,29 @@ def test_date_range_end_of_month_5441(
     start = date(2020, 1, 31)
     stop = date(2020, 3, 31)
     result = pl.date_range(start, stop, interval="1mo", closed=closed, eager=True)
-    expected = pl.Series("date", expected_values)
+    expected = pl.Series("literal", expected_values)
     assert_series_equal(result, expected)
 
 
 def test_date_range_name() -> None:
-    expected_name = "date"
     result_eager = pl.date_range(date(2020, 1, 1), date(2020, 1, 3), eager=True)
-    assert result_eager.name == expected_name
+    assert result_eager.name == "literal"
 
+    start = pl.Series("left", [date(2020, 1, 1)])
     result_lazy = pl.select(
-        pl.date_range(date(2020, 1, 1), date(2020, 1, 3), eager=False)
+        pl.date_range(start, date(2020, 1, 3), eager=False)
     ).to_series()
-    assert result_lazy.name == expected_name
+    assert result_lazy.name == "left"
 
 
 def test_date_ranges_eager() -> None:
-    start = pl.Series([date(2022, 1, 1), date(2022, 1, 2)])
-    end = pl.Series([date(2022, 1, 4), date(2022, 1, 3)])
+    start = pl.Series("start", [date(2022, 1, 1), date(2022, 1, 2)])
+    end = pl.Series("end", [date(2022, 1, 4), date(2022, 1, 3)])
 
     result = pl.date_ranges(start, end, eager=True)
 
     expected = pl.Series(
-        "date_range",
+        "start",
         [
             [date(2022, 1, 1), date(2022, 1, 2), date(2022, 1, 3), date(2022, 1, 4)],
             [date(2022, 1, 2), date(2022, 1, 3)],
@@ -190,12 +190,14 @@ def test_date_ranges_eager() -> None:
 
 
 def test_date_range_eager() -> None:
-    start = pl.Series([date(2022, 1, 1)])
-    end = pl.Series([date(2022, 1, 3)])
+    start = pl.Series("start", [date(2022, 1, 1)])
+    end = pl.Series("end", [date(2022, 1, 3)])
 
     result = pl.date_range(start, end, eager=True)
 
-    expected = pl.Series("date", [date(2022, 1, 1), date(2022, 1, 2), date(2022, 1, 3)])
+    expected = pl.Series(
+        "start", [date(2022, 1, 1), date(2022, 1, 2), date(2022, 1, 3)]
+    )
     assert_series_equal(result, expected)
 
 
@@ -340,14 +342,14 @@ def test_date_range_input_shape_multiple_values() -> None:
 
 def test_date_range_start_later_than_end() -> None:
     result = pl.date_range(date(2000, 3, 20), date(2000, 3, 5), eager=True)
-    expected = pl.Series("date", dtype=pl.Date)
+    expected = pl.Series("literal", dtype=pl.Date)
     assert_series_equal(result, expected)
 
 
 def test_date_range_24h_interval_results_in_datetime() -> None:
     with pytest.deprecated_call():
         result = pl.LazyFrame().select(
-            pl.date_range(date(2022, 1, 1), date(2022, 1, 3), interval="24h")
+            date=pl.date_range(date(2022, 1, 1), date(2022, 1, 3), interval="24h")
         )
 
     assert result.schema == {"date": pl.Datetime}

--- a/py-polars/tests/unit/functions/range/test_datetime_range.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_range.py
@@ -316,7 +316,7 @@ def test_datetime_ranges_schema(
         .lazy()
     )
     result = df.with_columns(
-        pl.datetime_ranges(
+        datetime_range=pl.datetime_ranges(
             pl.col("start"),
             pl.col("end"),
             time_zone=input_time_zone,
@@ -421,7 +421,7 @@ def test_datetime_range_schema_upcasts_to_datetime(
 ) -> None:
     df = pl.DataFrame({"start": [date(2020, 1, 1)], "end": [date(2020, 1, 3)]}).lazy()
     result = df.with_columns(
-        pl.datetime_ranges(
+        datetime_range=pl.datetime_ranges(
             pl.col("start"),
             pl.col("end"),
             interval=interval,
@@ -462,7 +462,7 @@ def test_datetime_range_schema_upcasts_to_datetime(
         time_unit=input_time_unit,
         time_zone=input_time_zone,
         eager=True,
-    )
+    ).alias("datetime")
     assert_series_equal(
         result_single, expected["datetime_range"].explode().rename("datetime")
     )
@@ -474,9 +474,8 @@ def test_datetime_ranges_no_alias_schema_9037() -> None:
     ).lazy()
     result = df.with_columns(pl.datetime_ranges(pl.col("start"), pl.col("end")))
     expected_schema = {
-        "start": pl.Datetime(time_unit="us", time_zone=None),
+        "start": pl.List(pl.Datetime(time_unit="us", time_zone=None)),
         "end": pl.Datetime(time_unit="us", time_zone=None),
-        "datetime_range": pl.List(pl.Datetime(time_unit="us", time_zone=None)),
     }
     assert result.schema == expected_schema
     assert result.collect().schema == expected_schema
@@ -505,7 +504,7 @@ def test_datetime_range_end_of_month_5441(
     start = date(2020, 1, 31)
     stop = date(2020, 3, 31)
     result = pl.datetime_range(start, stop, interval="1mo", closed=closed, eager=True)
-    expected = pl.Series("datetime", expected_values)
+    expected = pl.Series("literal", expected_values)
     assert_series_equal(result, expected)
 
 

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -33,18 +33,18 @@ def test_int_range_expr() -> None:
 
 def test_int_range() -> None:
     result = pl.int_range(0, 3)
-    expected = pl.Series("int", [0, 1, 2])
-    assert_series_equal(pl.select(result).to_series(), expected)
+    expected = pl.Series("int_range", [0, 1, 2])
+    assert_series_equal(pl.select(int_range=result).to_series(), expected)
 
 
 def test_int_range_eager() -> None:
     result = pl.int_range(0, 3, eager=True)
-    expected = pl.Series("int", [0, 1, 2])
+    expected = pl.Series("literal", [0, 1, 2])
     assert_series_equal(result, expected)
 
 
 def test_int_range_schema() -> None:
-    result = pl.LazyFrame().select(pl.int_range(-3, 3))
+    result = pl.LazyFrame().select(int=pl.int_range(-3, 3))
 
     expected_schema = {"int": pl.Int64}
     assert result.schema == expected_schema
@@ -54,9 +54,9 @@ def test_int_range_schema() -> None:
 @pytest.mark.parametrize(
     ("start", "end", "expected"),
     [
-        ("a", "b", pl.Series("int_range", [[1, 2], [2, 3]])),
-        (-1, "a", pl.Series("int_range", [[-1, 0], [-1, 0, 1]])),
-        ("b", 4, pl.Series("int_range", [[3], []])),
+        ("a", "b", pl.Series("a", [[1, 2], [2, 3]])),
+        (-1, "a", pl.Series("literal", [[-1, 0], [-1, 0, 1]])),
+        ("b", 4, pl.Series("b", [[3], []])),
     ],
 )
 def test_int_ranges(start: Any, end: Any, expected: pl.Series) -> None:
@@ -67,7 +67,7 @@ def test_int_ranges(start: Any, end: Any, expected: pl.Series) -> None:
 
 
 def test_int_ranges_decreasing() -> None:
-    expected = pl.Series("int_range", [[5, 4, 3, 2, 1]], dtype=pl.List(pl.Int64))
+    expected = pl.Series("literal", [[5, 4, 3, 2, 1]], dtype=pl.List(pl.Int64))
     assert_series_equal(pl.int_ranges(5, 0, -1, eager=True), expected)
     assert_series_equal(pl.select(pl.int_ranges(5, 0, -1)).to_series(), expected)
 
@@ -83,27 +83,27 @@ def test_int_ranges_decreasing() -> None:
 def test_int_ranges_empty(start: int, end: int, step: int) -> None:
     assert_series_equal(
         pl.int_range(start, end, step, eager=True),
-        pl.Series("int", [], dtype=pl.Int64),
+        pl.Series("literal", [], dtype=pl.Int64),
     )
     assert_series_equal(
         pl.int_ranges(start, end, step, eager=True),
-        pl.Series("int_range", [[]], dtype=pl.List(pl.Int64)),
+        pl.Series("literal", [[]], dtype=pl.List(pl.Int64)),
     )
     assert_series_equal(
         pl.Series("int", [], dtype=pl.Int64),
-        pl.select(pl.int_range(start, end, step)).to_series(),
+        pl.select(int=pl.int_range(start, end, step)).to_series(),
     )
     assert_series_equal(
         pl.Series("int_range", [[]], dtype=pl.List(pl.Int64)),
-        pl.select(pl.int_ranges(start, end, step)).to_series(),
+        pl.select(int_range=pl.int_ranges(start, end, step)).to_series(),
     )
 
 
 def test_int_ranges_eager() -> None:
-    start = pl.Series([1, 2])
+    start = pl.Series("s", [1, 2])
     result = pl.int_ranges(start, 4, eager=True)
 
-    expected = pl.Series("int_range", [[1, 2, 3], [2, 3]])
+    expected = pl.Series("s", [[1, 2, 3], [2, 3]])
     assert_series_equal(result, expected)
 
 
@@ -112,7 +112,7 @@ def test_int_ranges_schema_dtype_default() -> None:
 
     result = lf.select(pl.int_ranges("start", "end"))
 
-    expected_schema = {"int_range": pl.List(pl.Int64)}
+    expected_schema = {"start": pl.List(pl.Int64)}
     assert result.schema == expected_schema
     assert result.collect().schema == expected_schema
 
@@ -122,7 +122,7 @@ def test_int_ranges_schema_dtype_arg() -> None:
 
     result = lf.select(pl.int_ranges("start", "end", dtype=pl.UInt16))
 
-    expected_schema = {"int_range": pl.List(pl.UInt16)}
+    expected_schema = {"start": pl.List(pl.UInt16)}
     assert result.schema == expected_schema
     assert result.collect().schema == expected_schema
 
@@ -165,8 +165,8 @@ def test_int_range_input_shape_multiple_values() -> None:
 
 # https://github.com/pola-rs/polars/issues/10867
 def test_int_range_index_type_negative() -> None:
-    result = pl.select(pl.int_range(pl.lit(3).cast(pl.UInt32), -1, -1))
-    expected = pl.DataFrame({"int": [3, 2, 1, 0]})
+    result = pl.select(pl.int_range(pl.lit(3).cast(pl.UInt32).alias("start"), -1, -1))
+    expected = pl.DataFrame({"start": [3, 2, 1, 0]})
     assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -815,10 +815,9 @@ def test_index_expr_with_literal() -> None:
 def test_index_expr_output_name_12244() -> None:
     df = pl.DataFrame({"A": [1, 2, 3]})
 
-    # pl.int_range's output name is: `int`.
     out = df.rolling(pl.int_range(0, pl.count()), period="2i").agg("A")
     assert out.to_dict(as_series=False) == {
-        "int": [0, 1, 2],
+        "literal": [0, 1, 2],
         "A": [[1], [1, 2], [2, 3]],
     }
 

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -119,13 +119,13 @@ def test_window_function_cache() -> None:
 def test_window_range_no_rows() -> None:
     df = pl.DataFrame({"x": [5, 5, 4, 4, 2, 2]})
     expr = pl.int_range(0, pl.count()).over("x")
-    out = df.with_columns(expr)
+    out = df.with_columns(int=expr)
     assert_frame_equal(
         out, pl.DataFrame({"x": [5, 5, 4, 4, 2, 2], "int": [0, 1, 0, 1, 0, 1]})
     )
 
     df = pl.DataFrame({"x": []}, schema={"x": pl.Float32})
-    out = df.with_columns(expr)
+    out = df.with_columns(int=expr)
 
     expected = pl.DataFrame(schema={"x": pl.Float32, "int": pl.Int64})
     assert_frame_equal(out, expected)


### PR DESCRIPTION
This fixes #13314.

Maybe one could argue that It's weird that `pl.int_ranges(5, 0, -1)`'s name is `literal`. But we prefer to follow the same leftmost rule as the other expressions.