### PR TITLE
fix(rust): use different generics for `shift_and_fill` parameters

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -463,7 +463,7 @@ impl LazyFrame {
     /// with the result of the `fill_value` expression.
     ///
     /// See the method on [Series](polars_core::series::SeriesTrait::shift) for more info on the `shift` operation.
-    pub fn shift_and_fill<E: Into<Expr>>(self, n: E, fill_value: E) -> Self {
+    pub fn shift_and_fill<E: Into<Expr>, IE: Into<Expr>>(self, n: E, fill_value: IE) -> Self {
         self.select(vec![col("*").shift_and_fill(n.into(), fill_value.into())])
     }
 

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -177,6 +177,20 @@ fn test_shift_and_fill() -> PolarsResult<()> {
 }
 
 #[test]
+fn test_shift_and_fill_non_numeric() -> PolarsResult<()> {
+    let out = df![
+        "bool" => [true, false, true],
+    ]?
+    .lazy()
+    .select([col("bool").shift_and_fill(1, true)])
+    .collect()?;
+
+    let out = out.column("bool")?;
+    assert_eq!(Vec::from(out.bool()?), &[Some(true), Some(true), Some(false)]);
+    Ok(())
+}
+
+#[test]
 fn test_lazy_ternary_and_predicates() {
     let df = get_df();
     // test if this runs. This failed because is_not_null changes the schema name, so we

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -186,7 +186,10 @@ fn test_shift_and_fill_non_numeric() -> PolarsResult<()> {
     .collect()?;
 
     let out = out.column("bool")?;
-    assert_eq!(Vec::from(out.bool()?), &[Some(true), Some(true), Some(false)]);
+    assert_eq!(
+        Vec::from(out.bool()?),
+        &[Some(true), Some(true), Some(false)]
+    );
     Ok(())
 }
 

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -690,7 +690,7 @@ impl Expr {
     }
 
     /// Shift the values in the array by some period and fill the resulting empty values.
-    pub fn shift_and_fill<E: Into<Expr>>(self, n: E, fill_value: E) -> Self {
+    pub fn shift_and_fill<E: Into<Expr>, IE: Into<Expr>>(self, n: E, fill_value: IE) -> Self {
         self.apply_many_private(
             FunctionExpr::ShiftAndFill,
             &[n.into(), fill_value.into()],


### PR DESCRIPTION
Resolves #13363.