### PR TITLE
feat(rust,python): Impl ordering ops for array namespace

### DIFF
--- a/crates/polars-core/src/chunked_array/array/iterator.rs
+++ b/crates/polars-core/src/chunked_array/array/iterator.rs
@@ -103,7 +103,7 @@ impl ArrayChunked {
     }
 
     /// Apply a closure `F` to each array.
-    /// SAFETY:
+    /// # Safety
     /// Return series of `F` must has the same dtype and number of elements as input.
     #[must_use]
     pub unsafe fn apply_amortized_same_type<'a, F>(&'a self, mut f: F) -> Self

--- a/crates/polars-ops/src/chunked_array/array/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/array/namespace.rs
@@ -4,6 +4,7 @@ use crate::chunked_array::array::sum_mean::sum_with_nulls;
 #[cfg(feature = "array_any_all")]
 use crate::prelude::array::any_all::{array_all, array_any};
 use crate::prelude::array::sum_mean::sum_array_numerical;
+use crate::series::ArgAgg;
 
 pub fn has_inner_nulls(ca: &ArrayChunked) -> bool {
     for arr in ca.downcast_iter() {
@@ -46,12 +47,12 @@ pub trait ArrayNameSpace: AsArray {
 
     fn array_unique(&self) -> PolarsResult<ListChunked> {
         let ca = self.as_array();
-        ca.try_apply_amortized(|s| s.as_ref().unique())
+        ca.try_apply_amortized_to_list(|s| s.as_ref().unique())
     }
 
     fn array_unique_stable(&self) -> PolarsResult<ListChunked> {
         let ca = self.as_array();
-        ca.try_apply_amortized(|s| s.as_ref().unique_stable())
+        ca.try_apply_amortized_to_list(|s| s.as_ref().unique_stable())
     }
 
     #[cfg(feature = "array_any_all")]
@@ -64,6 +65,32 @@ pub trait ArrayNameSpace: AsArray {
     fn array_all(&self) -> PolarsResult<Series> {
         let ca = self.as_array();
         array_all(ca)
+    }
+
+    fn array_sort(&self, options: SortOptions) -> ArrayChunked {
+        let ca = self.as_array();
+        // SAFETY: Sort only changes the order of the elements in each subarray.
+        unsafe { ca.apply_amortized_same_type(|s| s.as_ref().sort_with(options)) }
+    }
+
+    fn array_reverse(&self) -> ArrayChunked {
+        let ca = self.as_array();
+        // SAFETY: Reverse only changes the order of the elements in each subarray
+        unsafe { ca.apply_amortized_same_type(|s| s.as_ref().reverse()) }
+    }
+
+    fn array_arg_min(&self) -> IdxCa {
+        let ca = self.as_array();
+        ca.apply_amortized_generic(|opt_s| {
+            opt_s.and_then(|s| s.as_ref().arg_min().map(|idx| idx as IdxSize))
+        })
+    }
+
+    fn array_arg_max(&self) -> IdxCa {
+        let ca = self.as_array();
+        ca.apply_amortized_generic(|opt_s| {
+            opt_s.and_then(|s| s.as_ref().arg_max().map(|idx| idx as IdxSize))
+        })
     }
 }
 

--- a/crates/polars-plan/src/dsl/array.rs
+++ b/crates/polars-plan/src/dsl/array.rs
@@ -1,3 +1,5 @@
+use polars_core::prelude::SortOptions;
+
 use crate::dsl::function_expr::{ArrayFunction, FunctionExpr};
 use crate::prelude::*;
 
@@ -56,5 +58,25 @@ impl ArrayNameSpace {
     pub fn any(self) -> Expr {
         self.0
             .map_private(FunctionExpr::ArrayExpr(ArrayFunction::Any))
+    }
+
+    pub fn sort(self, options: SortOptions) -> Expr {
+        self.0
+            .map_private(FunctionExpr::ArrayExpr(ArrayFunction::Sort(options)))
+    }
+
+    pub fn reverse(self) -> Expr {
+        self.0
+            .map_private(FunctionExpr::ArrayExpr(ArrayFunction::Reverse))
+    }
+
+    pub fn arg_min(self) -> Expr {
+        self.0
+            .map_private(FunctionExpr::ArrayExpr(ArrayFunction::ArgMin))
+    }
+
+    pub fn arg_max(self) -> Expr {
+        self.0
+            .map_private(FunctionExpr::ArrayExpr(ArrayFunction::ArgMax))
     }
 }

--- a/py-polars/docs/source/reference/expressions/array.rst
+++ b/py-polars/docs/source/reference/expressions/array.rst
@@ -16,3 +16,7 @@ The following methods are available under the `expr.arr` attribute.
     Expr.arr.unique
     Expr.arr.all
     Expr.arr.any
+    Expr.arr.sort
+    Expr.arr.reverse
+    Expr.arr.arg_min
+    Expr.arr.arg_max

--- a/py-polars/docs/source/reference/series/array.rst
+++ b/py-polars/docs/source/reference/series/array.rst
@@ -16,3 +16,7 @@ The following methods are available under the `Series.arr` attribute.
     Series.arr.unique
     Series.arr.all
     Series.arr.any
+    Series.arr.sort
+    Series.arr.reverse
+    Series.arr.arg_min
+    Series.arr.arg_max

--- a/py-polars/polars/expr/array.py
+++ b/py-polars/polars/expr/array.py
@@ -216,3 +216,134 @@ class ExprArrayNameSpace:
 
         """
         return wrap_expr(self._pyexpr.arr_all())
+
+    def sort(self, *, descending: bool = False) -> Expr:
+        """
+        Sort the arrays in this column.
+
+        Parameters
+        ----------
+        descending
+            Sort in descending order.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [[3, 2, 1], [9, 1, 2]],
+        ...     },
+        ...     schema={"a": pl.Array(pl.Int64, 3)},
+        ... )
+        >>> df.with_columns(sort=pl.col("a").arr.sort())
+        shape: (2, 2)
+        ┌───────────────┬───────────────┐
+        │ a             ┆ sort          │
+        │ ---           ┆ ---           │
+        │ array[i64, 3] ┆ array[i64, 3] │
+        ╞═══════════════╪═══════════════╡
+        │ [3, 2, 1]     ┆ [1, 2, 3]     │
+        │ [9, 1, 2]     ┆ [1, 2, 9]     │
+        └───────────────┴───────────────┘
+        >>> df.with_columns(sort=pl.col("a").arr.sort(descending=True))
+        shape: (2, 2)
+        ┌───────────────┬───────────────┐
+        │ a             ┆ sort          │
+        │ ---           ┆ ---           │
+        │ array[i64, 3] ┆ array[i64, 3] │
+        ╞═══════════════╪═══════════════╡
+        │ [3, 2, 1]     ┆ [3, 2, 1]     │
+        │ [9, 1, 2]     ┆ [9, 2, 1]     │
+        └───────────────┴───────────────┘
+
+        """
+        return wrap_expr(self._pyexpr.arr_sort(descending))
+
+    def reverse(self) -> Expr:
+        """
+        Reverse the arrays in this column.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [[3, 2, 1], [9, 1, 2]],
+        ...     },
+        ...     schema={"a": pl.Array(pl.Int64, 3)},
+        ... )
+        >>> df.with_columns(reverse=pl.col("a").arr.reverse())
+        shape: (2, 2)
+        ┌───────────────┬───────────────┐
+        │ a             ┆ reverse       │
+        │ ---           ┆ ---           │
+        │ array[i64, 3] ┆ array[i64, 3] │
+        ╞═══════════════╪═══════════════╡
+        │ [3, 2, 1]     ┆ [1, 2, 3]     │
+        │ [9, 1, 2]     ┆ [2, 1, 9]     │
+        └───────────────┴───────────────┘
+
+        """
+        return wrap_expr(self._pyexpr.arr_reverse())
+
+    def arg_min(self) -> Expr:
+        """
+        Retrieve the index of the minimal value in every sub-array.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`UInt32` or :class:`UInt64`
+            (depending on compilation).
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [[1, 2], [2, 1]],
+        ...     },
+        ...     schema={"a": pl.Array(pl.Int64, 2)},
+        ... )
+        >>> df.with_columns(arg_min=pl.col("a").arr.arg_min())
+        shape: (2, 2)
+        ┌───────────────┬─────────┐
+        │ a             ┆ arg_min │
+        │ ---           ┆ ---     │
+        │ array[i64, 2] ┆ u32     │
+        ╞═══════════════╪═════════╡
+        │ [1, 2]        ┆ 0       │
+        │ [2, 1]        ┆ 1       │
+        └───────────────┴─────────┘
+
+        """
+        return wrap_expr(self._pyexpr.arr_arg_min())
+
+    def arg_max(self) -> Expr:
+        """
+        Retrieve the index of the maximum value in every sub-array.
+
+        Returns
+        -------
+        Expr
+            Expression of data type :class:`UInt32` or :class:`UInt64`
+            (depending on compilation).
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [[1, 2], [2, 1]],
+        ...     },
+        ...     schema={"a": pl.Array(pl.Int64, 2)},
+        ... )
+        >>> df.with_columns(arg_max=pl.col("a").arr.arg_max())
+        shape: (2, 2)
+        ┌───────────────┬─────────┐
+        │ a             ┆ arg_max │
+        │ ---           ┆ ---     │
+        │ array[i64, 2] ┆ u32     │
+        ╞═══════════════╪═════════╡
+        │ [1, 2]        ┆ 1       │
+        │ [2, 1]        ┆ 0       │
+        └───────────────┴─────────┘
+
+        """
+        return wrap_expr(self._pyexpr.arr_arg_max())

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -181,3 +181,94 @@ class ArrayNameSpace:
         ]
 
         """
+
+    def sort(self, *, descending: bool = False) -> Series:
+        """
+        Sort the arrays in this column.
+
+        Parameters
+        ----------
+        descending
+            Sort in descending order.
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [[3, 2, 1], [9, 1, 2]], dtype=pl.Array(pl.Int64, 3))
+        >>> s.arr.sort()
+        shape: (2,)
+        Series: 'a' [array[i64, 3]]
+        [
+            [1, 2, 3]
+            [1, 2, 9]
+        ]
+        >>> s.arr.sort(descending=True)
+        shape: (2,)
+        Series: 'a' [array[i64, 3]]
+        [
+            [3, 2, 1]
+            [9, 2, 1]
+        ]
+
+        """
+
+    def reverse(self) -> Series:
+        """
+        Reverse the arrays in this column.
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [[3, 2, 1], [9, 1, 2]], dtype=pl.Array(pl.Int64, 3))
+        >>> s.arr.reverse()
+        Series: 'a' [array[i64, 3]]
+        [
+            [1, 2, 3]
+            [2, 1, 9]
+        ]
+
+        """
+
+    def arg_min(self) -> Series:
+        """
+        Retrieve the index of the minimal value in every sub-array.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`UInt32` or :class:`UInt64`
+            (depending on compilation).
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [[3, 2, 1], [9, 1, 2]], dtype=pl.Array(pl.Int64, 3))
+        >>> s.arr.arg_min()
+        shape: (2,)
+        Series: 'a' [u32]
+        [
+            2
+            1
+        ]
+
+        """
+
+    def arg_max(self) -> Series:
+        """
+        Retrieve the index of the maximum value in every sub-array.
+
+        Returns
+        -------
+        Series
+            Series of data type :class:`UInt32` or :class:`UInt64`
+            (depending on compilation).
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [[0, 9, 3], [9, 1, 2]], dtype=pl.Array(pl.Int64, 3))
+        >>> s.arr.arg_max()
+        shape: (2,)
+        Series: 'a' [u32]
+        [
+            1
+            0
+        ]
+
+        """

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -219,6 +219,7 @@ class ArrayNameSpace:
         --------
         >>> s = pl.Series("a", [[3, 2, 1], [9, 1, 2]], dtype=pl.Array(pl.Int64, 3))
         >>> s.arr.reverse()
+        shape: (2,)
         Series: 'a' [array[i64, 3]]
         [
             [1, 2, 3]

--- a/py-polars/src/expr/array.rs
+++ b/py-polars/src/expr/array.rs
@@ -1,3 +1,4 @@
+use polars::prelude::*;
 use pyo3::pymethods;
 
 use crate::expr::PyExpr;
@@ -34,5 +35,28 @@ impl PyExpr {
 
     fn arr_any(&self) -> Self {
         self.inner.clone().arr().any().into()
+    }
+
+    fn arr_sort(&self, descending: bool) -> Self {
+        self.inner
+            .clone()
+            .arr()
+            .sort(SortOptions {
+                descending,
+                ..Default::default()
+            })
+            .into()
+    }
+
+    fn arr_reverse(&self) -> Self {
+        self.inner.clone().arr().reverse().into()
+    }
+
+    fn arr_arg_min(&self) -> Self {
+        self.inner.clone().arr().arg_min().into()
+    }
+
+    fn arr_arg_max(&self) -> Self {
+        self.inner.clone().arr().arg_max().into()
     }
 }

--- a/py-polars/tests/unit/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/namespaces/array/test_array.py
@@ -74,3 +74,31 @@ def test_array_any_all() -> None:
         s.arr.any()
     with pytest.raises(ComputeError, match="expected boolean elements in array"):
         s.arr.all()
+
+
+def test_array_sort() -> None:
+    s = pl.Series([[2, None, 1], [1, 3, 2]], dtype=pl.Array(pl.UInt32, 3))
+
+    desc = s.arr.sort(descending=True)
+    expected = pl.Series([[None, 2, 1], [3, 2, 1]], dtype=pl.Array(pl.UInt32, 3))
+    assert_series_equal(desc, expected)
+
+    asc = s.arr.sort(descending=False)
+    expected = pl.Series([[None, 1, 2], [1, 2, 3]], dtype=pl.Array(pl.UInt32, 3))
+    assert_series_equal(asc, expected)
+
+
+def test_array_reverse() -> None:
+    s = pl.Series([[2, None, 1], [1, None, 2]], dtype=pl.Array(pl.UInt32, 3))
+
+    s = s.arr.reverse()
+    expected = pl.Series([[1, None, 2], [2, None, 1]], dtype=pl.Array(pl.UInt32, 3))
+    assert_series_equal(s, expected)
+
+
+def test_array_arg_min_max() -> None:
+    s = pl.Series("a", [[1, 2, 4], [3, 2, 1]], dtype=pl.Array(pl.UInt32, 3))
+    expected = pl.Series("a", [0, 2], dtype=pl.UInt32)
+    assert_series_equal(s.arr.arg_min(), expected)
+    expected = pl.Series("a", [2, 0], dtype=pl.UInt32)
+    assert_series_equal(s.arr.arg_max(), expected)

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -739,3 +739,26 @@ def test_list_to_array_wrong_dtype() -> None:
     s = pl.Series([1.0, 2.0])
     with pytest.raises(pl.ComputeError, match="expected List dtype"):
         s.list.to_array(2)
+
+
+def test_list_lengths() -> None:
+    s = pl.Series("a", [[1, 2], [1, 2, 3]])
+    assert_series_equal(s.list.len(), pl.Series("a", [2, 3], dtype=pl.UInt32))
+    df = pl.DataFrame([s])
+    assert_series_equal(
+        df.select(pl.col("a").list.len())["a"], pl.Series("a", [2, 3], dtype=pl.UInt32)
+    )
+
+
+def test_list_arithmetic() -> None:
+    s = pl.Series("a", [[1, 2], [1, 2, 3]])
+    assert_series_equal(s.list.sum(), pl.Series("a", [3, 6]))
+    assert_series_equal(s.list.mean(), pl.Series("a", [1.5, 2.0]))
+    assert_series_equal(s.list.max(), pl.Series("a", [2, 3]))
+    assert_series_equal(s.list.min(), pl.Series("a", [1, 1]))
+
+
+def test_list_ordering() -> None:
+    s = pl.Series("a", [[2, 1], [1, 3, 2]])
+    assert_series_equal(s.list.sort(), pl.Series("a", [[1, 2], [1, 2, 3]]))
+    assert_series_equal(s.list.reverse(), pl.Series("a", [[1, 2], [2, 3, 1]]))

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1336,29 +1336,6 @@ def test_kurtosis() -> None:
     assert np.isclose(df.select(pl.col("a").kurtosis())["a"][0], expected)
 
 
-def test_list_lengths() -> None:
-    s = pl.Series("a", [[1, 2], [1, 2, 3]])
-    assert_series_equal(s.list.len(), pl.Series("a", [2, 3], dtype=UInt32))
-    df = pl.DataFrame([s])
-    assert_series_equal(
-        df.select(pl.col("a").list.len())["a"], pl.Series("a", [2, 3], dtype=UInt32)
-    )
-
-
-def test_list_arithmetic() -> None:
-    s = pl.Series("a", [[1, 2], [1, 2, 3]])
-    assert_series_equal(s.list.sum(), pl.Series("a", [3, 6]))
-    assert_series_equal(s.list.mean(), pl.Series("a", [1.5, 2.0]))
-    assert_series_equal(s.list.max(), pl.Series("a", [2, 3]))
-    assert_series_equal(s.list.min(), pl.Series("a", [1, 1]))
-
-
-def test_list_ordering() -> None:
-    s = pl.Series("a", [[2, 1], [1, 3, 2]])
-    assert_series_equal(s.list.sort(), pl.Series("a", [[1, 2], [1, 2, 3]]))
-    assert_series_equal(s.list.reverse(), pl.Series("a", [[1, 2], [2, 3, 1]]))
-
-
 def test_sqrt() -> None:
     s = pl.Series("a", [1, 2])
     assert_series_equal(s.sqrt(), pl.Series("a", [1.0, np.sqrt(2)]))


### PR DESCRIPTION
Implements some missed ordering ops `sort`/`reverse`/`arg_min`/`arg_max`.