### PR TITLE
docs(python): show `datetime.date` import in code block

### DIFF
--- a/docs/src/python/user-guide/expressions/aggregation.py
+++ b/docs/src/python/user-guide/expressions/aggregation.py
@@ -87,6 +87,7 @@ def compute_age():
             # subtract a year if we have surpassed their birth anniversary
             (today.month > m) | ((today.month == m) & (today.day > d))
         )
+        - 1
     )
 
 

--- a/docs/src/python/user-guide/expressions/aggregation.py
+++ b/docs/src/python/user-guide/expressions/aggregation.py
@@ -75,20 +75,7 @@ from datetime import date
 
 
 def compute_age():
-    today = date.today()
-
-    y = pl.col("birthday").dt.year()
-    m = pl.col("birthday").dt.month()
-    d = pl.col("birthday").dt.date()
-    return (
-        today.year
-        - y
-        - (
-            # subtract a year if we have surpassed their birth anniversary
-            (today.month > m) | ((today.month == m) & (today.day > d))
-        )
-        - 1
-    )
+    return date.today().year - pl.col("birthday").dt.year()
 
 
 def avg_birthday(gender: str) -> pl.Expr:

--- a/docs/src/python/user-guide/expressions/aggregation.py
+++ b/docs/src/python/user-guide/expressions/aggregation.py
@@ -1,6 +1,5 @@
 # --8<-- [start:setup]
 import polars as pl
-from datetime import date
 
 # --8<-- [end:setup]
 
@@ -72,8 +71,23 @@ print(df)
 
 
 # --8<-- [start:filter]
-def compute_age() -> pl.Expr:
-    return date(2021, 1, 1).year - pl.col("birthday").dt.year()
+from datetime import date
+
+
+def compute_age():
+    today = date.today()
+
+    y = pl.col("birthday").dt.year()
+    m = pl.col("birthday").dt.month()
+    d = pl.col("birthday").dt.date()
+    return (
+        today.year
+        - y
+        - (
+            # subtract a year if we have surpassed their birth anniversary
+            (today.month > m) | ((today.month == m) & (today.day > d))
+        )
+    )
 
 
 def avg_birthday(gender: str) -> pl.Expr:


### PR DESCRIPTION
Resolves #13418.

The "proper" age calculation looks pretty messy with the standard black formatter but the old formula, while simple, was incorrect.

Also, this points out that the imports used in the setup blocks of our code snippets aren't rendered in the documentation (note the word "import" isn't found anywhere in the [doc page](https://docs.pola.rs/user-guide/expressions/aggregation)). This caused me confusion when I first came to polars, as our code snippets used modules without any mention of importing them.