### PR TITLE
feat(python): Omit time zone from `Datetime` repr if None

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -447,9 +447,10 @@ class Datetime(TemporalType):
 
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
-        return (
-            f"{class_name}(time_unit={self.time_unit!r}, time_zone={self.time_zone!r})"
-        )
+        if self.time_zone is None:
+            return f"{class_name}(time_unit={self.time_unit!r})"
+        else:
+            return f"{class_name}(time_unit={self.time_unit!r}, time_zone={self.time_zone!r})"
 
 
 class Duration(TemporalType):


### PR DESCRIPTION
Before:

```pycon
Datetime(time_unit='us', time_zone=None)
Datetime(time_unit='ns', time_zone='UTC')
```

After:

```pycon
Datetime(time_unit='us')
Datetime(time_unit='ns', time_zone='UTC')
```

Other option:

```
Datetime('us')
Datetime('ns', 'UTC')
```

Or in between:

```
Datetime('us')
Datetime('ns', time_zone='UTC')
```

Any comments? @MarcoGorelli 