### PR TITLE
fix(python): Fix `group_by` iteration when grouping by certain selectors

### DIFF
--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -97,9 +97,8 @@ class GroupBy:
         temp_col = "__POLARS_GB_GROUP_INDICES"
         groups_df = (
             self.df.lazy()
-            .with_row_count(name=temp_col)
             .group_by(self.by, *self.more_by, maintain_order=self.maintain_order)
-            .agg(F.col(temp_col))
+            .agg(F.first().agg_groups().alias(temp_col))
             .collect(no_optimization=True)
         )
 
@@ -793,7 +792,6 @@ class RollingGroupBy:
         temp_col = "__POLARS_GB_GROUP_INDICES"
         groups_df = (
             self.df.lazy()
-            .with_row_count(name=temp_col)
             .rolling(
                 index_column=self.time_column,
                 period=self.period,
@@ -802,7 +800,7 @@ class RollingGroupBy:
                 by=self.by,
                 check_sorted=self.check_sorted,
             )
-            .agg(F.col(temp_col))
+            .agg(F.first().agg_groups().alias(temp_col))
             .collect(no_optimization=True)
         )
 
@@ -979,7 +977,6 @@ class DynamicGroupBy:
         temp_col = "__POLARS_GB_GROUP_INDICES"
         groups_df = (
             self.df.lazy()
-            .with_row_count(name=temp_col)
             .group_by_dynamic(
                 index_column=self.time_column,
                 every=self.every,
@@ -993,7 +990,7 @@ class DynamicGroupBy:
                 start_by=self.start_by,
                 check_sorted=self.check_sorted,
             )
-            .agg(F.col(temp_col))
+            .agg(F.first().agg_groups().alias(temp_col))
             .collect(no_optimization=True)
         )
 

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -727,3 +727,9 @@ def test_group_by_apply_first_input_is_literal() -> None:
         "g": [1, 2],
         "x": [[2.0, 4.0], [8.0, 16.0, 32.0]],
     }
+
+
+def test_group_by_all_12869() -> None:
+    df = pl.DataFrame({"a": [1]})
+    result = next(iter(df.group_by(pl.all())))[1]
+    assert_frame_equal(df, result)


### PR DESCRIPTION
fix #12869

As `temp_col` is added before the `.group_by` it's possible for column selectors to pick it up.

Use `.agg_groups()` instead to avoid the issue.