### PR TITLE
docs(python): Move `Series.struct.json_encode` to methods in Sphinx autosummary

### DIFF
--- a/py-polars/docs/source/reference/series/struct.rst
+++ b/py-polars/docs/source/reference/series/struct.rst
@@ -10,6 +10,7 @@ The following methods are available under the `Series.struct` attribute.
    :template: autosummary/accessor_method.rst
 
     Series.struct.field
+    Series.struct.json_encode
     Series.struct.rename_fields
     Series.struct.unnest
 
@@ -18,5 +19,4 @@ The following methods are available under the `Series.struct` attribute.
    :template: autosummary/accessor_attribute.rst
 
     Series.struct.fields
-    Series.struct.json_encode
     Series.struct.schema


### PR DESCRIPTION
Method `Series.struct.json_encode` is now in the attributes section of autosummary and as a result, it's not rendered correctly.