### PR TITLE
fix(python): Handle empty inputs to Enum constructor

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -544,6 +544,10 @@ class Enum(DataType):
         if not isinstance(categories, pl.Series):
             categories = pl.Series(values=categories)
 
+        if categories.is_empty():
+            self.categories = pl.Series(name="categories", dtype=String)
+            return
+
         if categories.null_count() > 0:
             msg = "Enum categories must not contain null values"
             raise TypeError(msg)

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -27,6 +27,13 @@ def test_enum_creation() -> None:
     assert e.categories.to_list() == ["a", "b", "c", "d", "e"]
 
 
+@pytest.mark.parametrize("categories", [[], pl.Series("foo", dtype=pl.Int16), None])
+def test_enum_init_empty(categories: pl.Series | list[str] | None) -> None:
+    dtype = pl.Enum(categories)  # type: ignore[arg-type]
+    expected = pl.Series("categories", dtype=pl.String)
+    assert_series_equal(dtype.categories, expected)
+
+
 def test_enum_non_existent() -> None:
     with pytest.raises(
         pl.ComputeError,


### PR DESCRIPTION
`pl.Enum([])` would error on the dtype check - now it passes.