### PR TITLE
fix(python): Rename Enum categories internal series to "category"

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -545,7 +545,7 @@ class Enum(DataType):
             categories = pl.Series(values=categories)
 
         if categories.is_empty():
-            self.categories = pl.Series(name="categories", dtype=String)
+            self.categories = pl.Series(name="category", dtype=String)
             return
 
         if categories.null_count() > 0:
@@ -561,7 +561,7 @@ class Enum(DataType):
             msg = f"Enum categories must be unique; found duplicate {duplicate!r}"
             raise ValueError(msg)
 
-        self.categories = categories.rechunk().alias("categories")
+        self.categories = categories.rechunk().alias("category")
 
     def __eq__(self, other: PolarsDataType) -> bool:  # type: ignore[override]
         # allow comparing object instances to class

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -397,7 +397,7 @@ impl ToPyObject for Wrap<DataType> {
                 if let Some(rev_map) = rev_map {
                     if let RevMapping::Enum(categories, _) = &**rev_map {
                         let class = pl.getattr(intern!(py, "Enum")).unwrap();
-                        let s = Series::from_arrow("categories", categories.to_boxed()).unwrap();
+                        let s = Series::from_arrow("category", categories.to_boxed()).unwrap();
                         let series = to_series(py, s.into());
                         return class.call1((series,)).unwrap().into();
                     }

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -30,7 +30,7 @@ def test_enum_creation() -> None:
 @pytest.mark.parametrize("categories", [[], pl.Series("foo", dtype=pl.Int16), None])
 def test_enum_init_empty(categories: pl.Series | list[str] | None) -> None:
     dtype = pl.Enum(categories)  # type: ignore[arg-type]
-    expected = pl.Series("categories", dtype=pl.String)
+    expected = pl.Series("category", dtype=pl.String)
     assert_series_equal(dtype.categories, expected)
 
 
@@ -347,7 +347,7 @@ def test_enum_categories_unique() -> None:
 def test_enum_categories_series_input() -> None:
     categories = pl.Series("a", ["x", "y", "z"])
     dtype = pl.Enum(categories)
-    assert_series_equal(dtype.categories, categories.alias("categories"))
+    assert_series_equal(dtype.categories, categories.alias("category"))
 
 
 def test_enum_categories_series_zero_copy() -> None:


### PR DESCRIPTION
This doesn't matter much, but the singular form is probably more correct than plural. We had similar issues in the past with "count" vs "counts".