### PR TITLE
test(python): Increase timeout for gevent async test

### DIFF
--- a/py-polars/tests/unit/test_async.py
+++ b/py-polars/tests/unit/test_async.py
@@ -176,7 +176,7 @@ def test_gevent_collect_async_switch(
     def main() -> Any:
         result = get_result()
         gevent.sleep(0.1)
-        return result.get(block=False, timeout=3)
+        return result.get(block=False, timeout=10)
 
     _gevent_run(main, raises)
 


### PR DESCRIPTION
Closes #13297

Not 100% sure how these tests work but I expect this should dramatically reduce the spurious test failures.