### PR TITLE
fix: Keep logical type when getting values from list

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -399,7 +399,7 @@ pub(super) fn get(s: &mut [Series]) -> PolarsResult<Option<Series>> {
             if let Some(index) = index {
                 ca.lst_get(index).map(Some)
             } else {
-                polars_bail!(ComputeError: "unexpected null index received in `arr.get`")
+                polars_bail!(ComputeError: "unexpected null index received in `list.get`")
             }
         },
         len if len == ca.len() => {
@@ -424,11 +424,13 @@ pub(super) fn get(s: &mut [Series]) -> PolarsResult<Option<Series>> {
                 })
                 .collect::<IdxCa>();
             let s = Series::try_from((ca.name(), arr.values().clone())).unwrap();
-            unsafe { Ok(Some(s.take_unchecked(&take_by))) }
+            unsafe { s.take_unchecked(&take_by) }
+                .cast(&ca.inner_dtype())
+                .map(Some)
         },
         len => polars_bail!(
             ComputeError:
-            "`arr.get` expression got an index array of length {} while the list has {} elements",
+            "`list.get` expression got an index array of length {} while the list has {} elements",
             len, ca.len()
         ),
     }

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -762,3 +762,30 @@ def test_list_ordering() -> None:
     s = pl.Series("a", [[2, 1], [1, 3, 2]])
     assert_series_equal(s.list.sort(), pl.Series("a", [[1, 2], [1, 2, 3]]))
     assert_series_equal(s.list.reverse(), pl.Series("a", [[1, 2], [2, 3, 1]]))
+
+
+def test_list_get_logical_type() -> None:
+    s = pl.Series(
+        "a",
+        [
+            [date(1999, 1, 1), date(2000, 1, 1)],
+            [date(2001, 10, 1), None],
+        ],
+        dtype=pl.List(pl.Date),
+    )
+
+    out = s.list.get(0)
+    expected = pl.Series(
+        "a",
+        [date(1999, 1, 1), date(2001, 10, 1)],
+        dtype=pl.Date,
+    )
+    assert_series_equal(out, expected)
+
+    out = s.list.get(pl.Series([1, -2]))
+    expected = pl.Series(
+        "a",
+        [date(2000, 1, 1), date(2001, 10, 1)],
+        dtype=pl.Date,
+    )
+    assert_series_equal(out, expected)


### PR DESCRIPTION
Will implement `arr.get` in the next PR.