### PR TITLE
feat(python): Allow drop with no inputs as a no-op

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -100,6 +100,7 @@ from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.deprecation import (
     deprecate_function,
     deprecate_nonkeyword_arguments,
+    deprecate_parameter_as_positional,
     deprecate_renamed_function,
     deprecate_renamed_parameter,
     deprecate_saturating,
@@ -6665,21 +6666,18 @@ class DataFrame:
                 raise
         return self
 
+    @deprecate_parameter_as_positional("columns", version="0.20.4")
     def drop(
-        self,
-        columns: ColumnNameOrSelector | Collection[ColumnNameOrSelector],
-        *more_columns: ColumnNameOrSelector,
+        self, *columns: ColumnNameOrSelector | Iterable[ColumnNameOrSelector]
     ) -> DataFrame:
         """
         Remove columns from the dataframe.
 
         Parameters
         ----------
-        columns
-            Names of the columns that should be removed from the dataframe, or
-            a selector that determines the columns to drop.
-        *more_columns
-            Additional columns to drop, specified as positional arguments.
+        *columns
+            Names of the columns that should be removed from the dataframe.
+            Accepts column selector input.
 
         Examples
         --------
@@ -6747,7 +6745,7 @@ class DataFrame:
         │ 8.0 │
         └─────┘
         """
-        return self.lazy().drop(columns, *more_columns).collect(_eager=True)
+        return self.lazy().drop(*columns).collect(_eager=True)
 
     def drop_in_place(self, name: str) -> Series:
         """

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -87,6 +87,7 @@ def element() -> Expr:
     return F.col("")
 
 
+@deprecate_parameter_as_positional("column", version="0.20.4")
 def count(*columns: str) -> Expr:
     """
     Either return the number of rows in the context, or return the number of non-null values in the column.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -64,6 +64,7 @@ from polars.utils._wrap import wrap_df, wrap_expr
 from polars.utils.convert import _negate_duration, _timedelta_to_pl_duration
 from polars.utils.deprecation import (
     deprecate_function,
+    deprecate_parameter_as_positional,
     deprecate_renamed_function,
     deprecate_renamed_parameter,
     deprecate_saturating,
@@ -4094,20 +4095,18 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         return self._from_pyldf(self._ldf.with_context([lf._ldf for lf in other]))
 
+    @deprecate_parameter_as_positional("columns", version="0.20.4")
     def drop(
-        self,
-        columns: ColumnNameOrSelector | Collection[ColumnNameOrSelector],
-        *more_columns: ColumnNameOrSelector,
+        self, *columns: ColumnNameOrSelector | Iterable[ColumnNameOrSelector]
     ) -> Self:
         """
         Remove columns from the DataFrame.
 
         Parameters
         ----------
-        columns
-            Name of the column(s) that should be removed from the DataFrame.
-        *more_columns
-            Additional columns to drop, specified as positional arguments.
+        *columns
+            Names of the columns that should be removed from the dataframe.
+            Accepts column selector input.
 
         Examples
         --------
@@ -4161,7 +4160,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ 8.0 │
         └─────┘
         """
-        drop_cols = _expand_selectors(self, columns, *more_columns)
+        drop_cols = _expand_selectors(self, *columns)
         return self._from_pyldf(self._ldf.drop(drop_cols))
 
     def rename(self, mapping: dict[str, str]) -> Self:

--- a/py-polars/polars/selectors.py
+++ b/py-polars/polars/selectors.py
@@ -27,6 +27,7 @@ from polars.datatypes import (
     is_polars_dtype,
 )
 from polars.expr import Expr
+from polars.utils._parse_expr_input import _parse_inputs_as_iterable
 from polars.utils.deprecation import deprecate_nonkeyword_arguments
 from polars.utils.various import is_column
 
@@ -124,9 +125,7 @@ def expand_selector(
     return tuple(target.select(selector).columns)
 
 
-def _expand_selectors(
-    frame: DataFrame | LazyFrame, items: Any, *more_items: Any
-) -> list[Any]:
+def _expand_selectors(frame: DataFrame | LazyFrame, *items: Any) -> list[Any]:
     """
     Internal function that expands any selectors to column names in the given input.
 
@@ -149,15 +148,10 @@ def _expand_selectors(
     >>> _expand_selectors(df, cs.string(), cs.float())
     ['colw', 'colx', 'colz']
     """
+    items_iter = _parse_inputs_as_iterable(items)
+
     expanded: list[Any] = []
-    for item in (
-        *(
-            items
-            if isinstance(items, Collection) and not isinstance(items, str)
-            else [items]
-        ),
-        *more_items,
-    ):
+    for item in items_iter:
         if is_selector(item):
             selector_cols = expand_selector(frame, item)
             expanded.extend(selector_cols)

--- a/py-polars/polars/utils/deprecation.py
+++ b/py-polars/polars/utils/deprecation.py
@@ -94,7 +94,7 @@ def deprecate_parameter_as_positional(
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
             if param_args := kwargs.pop(old_name, []):
                 issue_deprecation_warning(
-                    f"`named {old_name}` param is deprecated; use positional `*args` instead.",
+                    f"named `{old_name}` param is deprecated; use positional `*args` instead.",
                     version=version,
                 )
             if param_args:

--- a/py-polars/tests/unit/operations/test_drop.py
+++ b/py-polars/tests/unit/operations/test_drop.py
@@ -70,7 +70,7 @@ def test_drop_nulls(subset: Any) -> None:
 
 def test_drop() -> None:
     df = pl.DataFrame({"a": [2, 1, 3], "b": ["a", "b", "c"], "c": [1, 2, 3]})
-    df = df.drop(columns="a")
+    df = df.drop("a")
     assert df.shape == (3, 2)
 
     df = pl.DataFrame({"a": [2, 1, 3], "b": ["a", "b", "c"], "c": [1, 2, 3]})
@@ -106,7 +106,7 @@ def test_drop_columns() -> None:
     out2 = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).drop("a", "b")
     assert out2.columns == ["c"]
 
-    out2 = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).drop({"a"}, "b", "c")
+    out2 = pl.DataFrame({"a": [1], "b": [2], "c": [3]}).drop({"a", "b", "c"})
     assert out2.columns == []
 
 
@@ -119,3 +119,21 @@ def test_drop_nan_ignore_null_3525() -> None:
         3.0,
         4.0,
     ]
+
+
+def test_drop_without_parameters() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+    assert_frame_equal(df.drop(), df)
+    assert_frame_equal(df.lazy().drop(*[]), df.lazy())
+
+
+def test_drop_keyword_deprecated() -> None:
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    expected = df.select("b")
+    with pytest.deprecated_call():
+        result_df = df.drop(columns="a")
+    assert_frame_equal(result_df, expected)
+
+    with pytest.deprecated_call():
+        result_lf = df.lazy().drop(columns="a")
+    assert_frame_equal(result_lf, expected.lazy())


### PR DESCRIPTION
Closes #11746

This also deprecates keyword input, e.g.: `df.drop(columns="x")`

Technically we can do this without the deprecation (see the first commit), but I like simplifying the function signature (commit 2). Feedback is welcome.