### PR TITLE
docs(python): define file-like object in read_parquet docstring

### DIFF
--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -43,7 +43,9 @@ def read_parquet(
     Parameters
     ----------
     source
-        Path to a file, or a file-like object. If the path is a directory, files in that
+        Path to a file, or a file-like object (by file-like object, we refer to objects
+        that have a `read()` method, such as a file handler (e.g. via builtin `open`
+        function) or `BytesIO`). If the path is a directory, files in that
         directory will all be read.
     columns
         Columns to select. Accepts a list of column indices (starting at zero) or a list


### PR DESCRIPTION
Explain file-like object in the docstring for the `read_parquet` function's source param to make it consistent with the other `read_*` functions (all of which have the same explanatory note that read_parquet doesn't have.)