### PR TITLE
perf(python): Refactor expression parsing logic of predicates/constraints

### DIFF
--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -6,7 +6,7 @@ import polars.functions as F
 from polars.expr.expr import Expr
 from polars.utils._parse_expr_input import (
     parse_as_expression,
-    parse_when_constraint_expressions,
+    parse_when_inputs,
 )
 from polars.utils._wrap import wrap_expr
 
@@ -78,7 +78,7 @@ class Then(Expr):
             equality matches, such as `x = 123`. As with the predicates parameter,
             multiple conditions are implicitly combined using `&`.
         """
-        condition_pyexpr = parse_when_constraint_expressions(*predicates, **constraints)
+        condition_pyexpr = parse_when_inputs(*predicates, **constraints)
         return ChainedWhen(self._then.when(condition_pyexpr))
 
     def otherwise(self, statement: IntoExpr) -> Expr:
@@ -158,7 +158,7 @@ class ChainedThen(Expr):
             equality matches, such as `x = 123`. As with the predicates parameter,
             multiple conditions are implicitly combined using `&`.
         """
-        condition_pyexpr = parse_when_constraint_expressions(*predicates, **constraints)
+        condition_pyexpr = parse_when_inputs(*predicates, **constraints)
         return ChainedWhen(self._chained_then.when(condition_pyexpr))
 
     def otherwise(self, statement: IntoExpr) -> Expr:

--- a/py-polars/polars/functions/aggregation/horizontal.py
+++ b/py-polars/polars/functions/aggregation/horizontal.py
@@ -12,7 +12,6 @@ from polars.utils.deprecation import deprecate_renamed_function
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
 
-
 if TYPE_CHECKING:
     from polars import Expr
     from polars.type_aliases import IntoExpr

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -4,7 +4,7 @@ import contextlib
 from typing import TYPE_CHECKING, Any, Iterable
 
 import polars._reexport as pl
-from polars.utils._parse_expr_input import parse_when_constraint_expressions
+from polars.utils._parse_expr_input import parse_when_inputs
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -141,5 +141,5 @@ def when(
     │ 4   ┆ 0   ┆ 99  │
     └─────┴─────┴─────┘
     """
-    condition = parse_when_constraint_expressions(*predicates, **constraints)
+    condition = parse_when_inputs(*predicates, **constraints)
     return pl.When(plr.when(condition))

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2669,9 +2669,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 err = (
                     f"Series(…, dtype={p.dtype})"
                     if isinstance(p, pl.Series)
-                    else f"{p!r}"
+                    else repr(p)
                 )
-                raise ValueError(f"invalid predicate for `filter`: {err}")
+                raise TypeError(f"invalid predicate for `filter`: {err}")
             else:
                 all_predicates.extend(
                     wrap_expr(x) for x in parse_as_list_of_expressions(p)
@@ -2700,7 +2700,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             F.col(name).eq_missing(value) for name, value in constraints.items()
         )
         if not (all_predicates or boolean_masks):
-            raise ValueError("No predicates or constraints provided to `filter`.")
+            raise TypeError("at least one predicate or constraint must be provided")
 
         # if multiple predicates, combine as 'horizontal' expression
         combined_predicate = (

--- a/py-polars/polars/utils/_parse_expr_input.py
+++ b/py-polars/polars/utils/_parse_expr_input.py
@@ -45,23 +45,28 @@ def parse_as_list_of_expressions(
 
 
 def _parse_regular_inputs(
-    inputs: tuple[IntoExpr | Iterable[IntoExpr], ...],
+    inputs: tuple[IntoExpr, ...] | tuple[Iterable[IntoExpr]],
     *,
     structify: bool = False,
 ) -> list[PyExpr]:
-    if not inputs:
-        return []
-
-    inputs_iter: Iterable[IntoExpr]
-    if len(inputs) == 1 and _is_iterable(inputs[0]):
-        inputs_iter = inputs[0]  # type: ignore[assignment]
-    else:
-        inputs_iter = inputs  # type: ignore[assignment]
-
+    inputs_iter = _parse_inputs_as_iterable(inputs)
     return [parse_as_expression(e, structify=structify) for e in inputs_iter]
 
 
-def _is_iterable(input: IntoExpr | Iterable[IntoExpr]) -> bool:
+def _parse_inputs_as_iterable(
+    inputs: tuple[Any, ...] | tuple[Iterable[Any]],
+) -> Iterable[Any]:
+    if not inputs:
+        return []
+
+    # Treat input of a single iterable as separate inputs
+    if len(inputs) == 1 and _is_iterable(inputs[0]):
+        return inputs[0]
+
+    return inputs
+
+
+def _is_iterable(input: Any | Iterable[Any]) -> bool:
     return isinstance(input, Iterable) and not isinstance(
         input, (str, bytes, pl.Series)
     )

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -233,7 +233,7 @@ def test_no_predicate_push_down_with_cast_and_alias_11883() -> None:
 )
 def test_invalid_filter_predicates(predicate: Any) -> None:
     df = pl.DataFrame({"colx": ["aa", "bb", "cc", "dd"]})
-    with pytest.raises(ValueError, match="invalid predicate"):
+    with pytest.raises(TypeError, match="invalid predicate"):
         df.filter(predicate)
 
 


### PR DESCRIPTION
I am refactoring some of the input parsing that has gotten quite complex.

This has some performance benefits as I am skipping a second round of input checks in `all_horizontal` by going straight to Rust.

I still have to do `LazyFrame.filter` - it is more complicated for some reason.