### PR TITLE
feat(rust): Implement wasm Pool::scope

### DIFF
--- a/crates/polars-utils/src/wasm.rs
+++ b/crates/polars-utils/src/wasm.rs
@@ -37,4 +37,12 @@ impl Pool {
     {
         rayon::spawn(func);
     }
+
+    pub fn scope<'scope, OP, R>(&self, op: OP) -> R
+    where
+        OP: FnOnce(&rayon::Scope<'scope>) -> R + Send,
+        R: Send,
+    {
+        rayon::scope(op)
+    }
 }


### PR DESCRIPTION
👋 First PR here.
With this, `streaming` and `ipc_streaming` features work on `wasm32-wasi`. 
