### PR TITLE
docs(python): Doc examples for `threadpool_size` and `get_index_type`

### DIFF
--- a/py-polars/polars/utils/meta.py
+++ b/py-polars/polars/utils/meta.py
@@ -20,6 +20,11 @@ def get_index_type() -> DataTypeClass:
     -------
     DataType
         :class:`UInt32` in regular Polars, :class:`UInt64` in bigidx Polars.
+
+    Examples
+    --------
+    >>> pl.get_index_type()
+    UInt32
     """
     return _get_index_type()
 
@@ -36,5 +41,10 @@ def threadpool_size() -> int:
     be temporarily setting max threads to a low value before importing polars in a
     pyspark UDF or similar context. Otherwise, it is strongly recommended not to
     override this value as it will be set automatically by the engine.
+
+    Examples
+    --------
+    >>> pl.threadpool_size() # doctest: +SKIP
+    24
     """
     return _threadpool_size()

--- a/py-polars/polars/utils/meta.py
+++ b/py-polars/polars/utils/meta.py
@@ -44,7 +44,7 @@ def threadpool_size() -> int:
 
     Examples
     --------
-    >>> pl.threadpool_size() # doctest: +SKIP
+    >>> pl.threadpool_size()  # doctest: +SKIP
     24
     """
     return _threadpool_size()


### PR DESCRIPTION
A portion of #13161.

Questions:

- Should `polars.get_index_type` be included in doctest or skipped?