### PR TITLE
add Windows build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ target/
 /docs/data/
 /docs/images/
 /docs/people.md
+
+# Windows
+/py-polars/rust-toolchain

--- a/make.cmd
+++ b/make.cmd
@@ -1,0 +1,181 @@
+@echo off
+
+set base_path=%~dp0
+set base_path=%base_path:~0,-1%
+set py_path=%base_path%\py-polars
+set VENV=%base_path%\.venv
+set VENV_BIN=%VENV%\Scripts
+
+:: Ensure py-polars/rust-toolchain.toml is symlinked or hardlinked
+:: This commonly fails on Windows, since users must both have administrator
+:: access and also must enable symbolic links when installing Git for Windows
+set SYMLINK=
+for /F "tokens=* USEBACKQ" %%f in (
+    `fsutil reparsepoint query "%py_path%\rust-toolchain.toml" ^| find "Symbolic Link" 2^>^&1 ^>nul ^&^& echo 1`
+) do set SYMLINK=%%f
+
+if not '%SYMLINK%'=='1' (
+    set HARDLINK=
+    for /F "tokens=* USEBACKQ" %%f in (
+        `fsutil hardlink list "%base_path%\rust-toolchain.toml" ^| find "polars\py-polars\rust-toolchain.toml" 2^>^&1 ^>nul ^&^& echo 1`
+    ) do set HARDLINK=%%f
+
+    if not '%HARDLINK%'=='1' (
+        if not exist "%base_path%\py-polars\rust-toolchain" (
+            echo py-polars\rust-toolchain.toml did not successfully link to rust-toolchain.toml; creating `rust-toolchain` override file.
+            mklink /H "%py_path%\rust-toolchain" "%base_path%\rust-toolchain.toml"
+        )
+    )
+)
+
+if %1==.venv                   call :.venv
+if %1==requirements            call :requirements
+if %1==build                   call :build
+if %1==build-debug-opt         call :build-debug-opt
+if %1==build-debug-opt-subset  call :build-debug-opt-subset
+if %1==build-opt               call :build-opt
+if %1==build-release           call :build-release
+if %1==build-native            call :build-native
+if %1==build-debug-opt-native  call :build-debug-opt-native
+if %1==clippy                  call :clippy
+if %1==clippy-default          call :clippy-default
+if %1==fmt                     call :fmt
+if %1==pre-commit              call :pre-commit
+if %1==clean                   call :clean
+if %1==help                    call :help
+exit /b
+
+:.venv
+:: Set up Python virtual environment and install requirements
+python -m venv %VENV%
+call :requirements
+exit /b
+
+:requirements
+:: Install/refresh Python project requirements
+%VENV_BIN%\python -m pip install --upgrade pip
+%VENV_BIN%\python -m pip install --upgrade -r %py_path%\requirements-dev.txt
+%VENV_BIN%\python -m pip install --upgrade -r %py_path%\requirements-lint.txt
+%VENV_BIN%\python -m pip install --upgrade -r %py_path%\docs\requirements-docs.txt
+%VENV_BIN%\python -m pip install --upgrade -r %base_path%\docs\requirements.txt
+powershell -command "iwr https://dprint.dev/install.ps1 -useb | iex"
+exit /b
+
+:build
+:: Compile and install Python Polars for development
+call :.venv
+set CONDA_PREFIX=
+%VENV_BIN%\activate && maturin develop -m %py_path%\Cargo.toml
+exit /b
+
+:build-debug-opt
+:: Compile and install Python Polars with minimal optimizations turned on
+call :.venv
+set CONDA_PREFIX=
+%VENV_BIN%\activate && maturin develop -m %py_path%\Cargo.toml --profile opt-dev
+exit /b
+
+:build-debug-opt-subset
+:: Compile and install Python Polars with minimal optimizations turned on and no default features
+call :.venv
+set CONDA_PREFIX=
+%VENV_BIN%\activate && maturin develop -m %py_path%\Cargo.toml --no-default-features --profile opt-dev
+exit /b
+
+:build-opt
+::Compile and install Python Polars with nearly full optimization on and debug assertions turned off, but with debug symbols on
+call :.venv
+set CONDA_PREFIX=
+%VENV_BIN%\activate && maturin develop -m %py_path%\Cargo.toml --profile debug-release
+exit /b
+
+:build-release
+:: Compile and install a faster Python Polars binary with full optimizations
+call :.venv
+set CONDA_PREFIX=
+%VENV_BIN%\activate && maturin develop -m %py_path%\Cargo.toml --release
+exit /b
+
+:build-native
+:: Same as build, except with native CPU optimizations turned on
+call :.venv
+set CONDA_PREFIX=
+%VENV_BIN%\activate && maturin develop -m %py_path%\Cargo.toml -- -C target-cpu=native
+exit /b
+
+:build-debug-opt-native
+:: Same as build-debug-opt, except with native CPU optimizations turned on
+call :.venv
+set CONDA_PREFIX=
+%VENV_BIN%\activate && maturin develop -m %py_path%\Cargo.toml --profile opt-dev -- -C target-cpu=native
+exit /b
+
+:build-opt-native
+:: Same as build-opt, except with native CPU optimizations turned on
+call :.venv
+set CONDA_PREFIX=
+%VENV_BIN%\activate && maturin develop -m %py_path%\Cargo.toml --profile debug-release -- -C target-cpu=native
+exit /b
+
+:build-release-native
+:: Same as build-release, except with native CPU optimizations turned on
+call :.venv
+set CONDA_PREFIX=
+%VENV_BIN%\activate && maturin develop -m %py_path%\Cargo.toml --release -- -C target-cpu=native
+exit /b
+
+:clippy
+:: ## Run clippy with all features
+cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+exit /b
+
+:clippy-default
+::Run clippy with default features
+cargo clippy --all-targets --locked -- -D warnings
+exit /b
+
+:fmt
+:: Run autoformatting and linting
+%VENV_BIN%\ruff check %base_path%  &^
+%VENV_BIN%\ruff format %base_path% &^
+cargo fmt --all                      &^
+dprint fmt                           &^
+%VENV_BIN%\typos                     &^
+exit /b
+
+:pre-commit
+:: Run all code quality checks
+call :fmt
+call :clippy
+call :clippy-default
+exit /b
+
+:clean
+:: Clean up caches and build artifacts
+if exist %base_path%\.venv ( rmdir %base_path%\.venv /s /q ) &^
+if exist %base_path%\target ( rmdir %base_path%\target /s /q ) &^
+if exist %base_path%\Cargo.lock ( del %base_path%\Cargo.lock /s /q ) &^
+cargo clean
+call %py_path%\make clean
+exit /b
+
+:help
+:: Display this help screen
+echo Available commands:
+echo  .venv                  Set up Python virtual environment and install requirements
+echo  build                  Compile and install Python Polars for development
+echo  build-debug-opt        Compile and install Python Polars with minimal optimizations turned on
+echo  build-debug-opt-native Same as build-debug-opt, except with native CPU optimizations turned on
+echo  build-debug-opt-subset Compile and install Python Polars with minimal optimizations turned on and no default features
+echo  build-native           Same as build, except with native CPU optimizations turned on
+echo  build-opt              Compile and install Python Polars with nearly full optimization on and debug assertions turned off, but with debug symbols on
+echo  build-opt-native       Same as build-opt, except with native CPU optimizations turned on
+echo  build-release          Compile and install a faster Python Polars binary with full optimizations
+echo  build-release-native   Same as build-release, except with native CPU optimizations turned on
+echo  clean                  Clean up caches and build artifacts
+echo  clippy                 Run clippy with all features
+echo  clippy-default         Run clippy with default features
+echo  fmt                    Run autoformatting and linting
+echo  help                   Display this help screen
+echo  pre-commit             Run all code quality checks
+echo  requirements           Install/refresh Python project requirements

--- a/make.cmd
+++ b/make.cmd
@@ -58,7 +58,7 @@ exit /b
 %VENV_BIN%\python -m pip install --upgrade -r %py_path%\requirements-lint.txt
 %VENV_BIN%\python -m pip install --upgrade -r %py_path%\docs\requirements-docs.txt
 %VENV_BIN%\python -m pip install --upgrade -r %base_path%\docs\requirements.txt
-powershell -command "iwr https://dprint.dev/install.ps1 -useb | iex"
+::powershell -command "iwr https://dprint.dev/install.ps1 -useb | iex"
 exit /b
 
 :build
@@ -139,9 +139,9 @@ exit /b
 %VENV_BIN%\ruff check %base_path%  &^
 %VENV_BIN%\ruff format %base_path% &^
 cargo fmt --all &^
-if exist %USERPROFILE%\.dprint\bin\dprint.exe (
-    %USERPROFILE%\.dprint\bin\dprint.exe fmt --excludes py-polars/rust-toolchain.toml
-) &^
+::if exist %USERPROFILE%\.dprint\bin\dprint.exe (
+::    %USERPROFILE%\.dprint\bin\dprint.exe fmt --excludes py-polars/rust-toolchain.toml
+::) &^
 %VENV_BIN%\typos &^
 exit /b
 

--- a/make.cmd
+++ b/make.cmd
@@ -138,9 +138,11 @@ exit /b
 :: Run autoformatting and linting
 %VENV_BIN%\ruff check %base_path%  &^
 %VENV_BIN%\ruff format %base_path% &^
-cargo fmt --all                      &^
-dprint fmt                           &^
-%VENV_BIN%\typos                     &^
+cargo fmt --all &^
+if exist %USERPROFILE%\.dprint\bin\dprint.exe (
+    %USERPROFILE%\.dprint\bin\dprint.exe fmt --excludes py-polars/rust-toolchain.toml
+) &^
+%VENV_BIN%\typos &^
 exit /b
 
 :pre-commit

--- a/py-polars/.gitignore
+++ b/py-polars/.gitignore
@@ -5,3 +5,4 @@ venv/
 .hypothesis
 .DS_Store
 .ruff_cache/
+rust-toolchain

--- a/py-polars/make.cmd
+++ b/py-polars/make.cmd
@@ -1,0 +1,162 @@
+@echo off
+
+set py_path=%~dp0
+set py_path=%py_path:~0,-1%
+for %%i in ("%~dp0..") do set base_path=%%~fi
+set VENV=%base_path%\.venv
+set VENV_BIN=%VENV%\Scripts
+
+if %1==.venv                   call :.venv %1
+if %1==requirements            call :requirements %1
+if %1==build                   call :build %1
+if %1==build-debug-opt         call :build-debug-opt %1
+if %1==build-debug-opt-subset  call :build-debug-opt-subset %1
+if %1==build-opt               call :build-opt %1
+if %1==build-release           call :build-release %1
+if %1==build-native            call :build-native %1
+if %1==build-debug-opt-native  call :build-debug-opt-native %1
+if %1==clippy                  call :clippy %1
+if %1==clippy-default          call :clippy-default %1
+if %1==fmt                     call :fmt %1
+if %1==pre-commit              call :pre-commit %1
+if %1==test                    call :test %1
+if %1==doctest                 call :doctest %1
+if %1==test-all                call :test-all %1
+if %1==coverage                call :coverage %1
+if %1==clean                   call :clean %1
+if %1==help                    call :help %1
+exit /b
+
+:.venv
+:: Set up virtual environment and install requirements
+call %base_path%\make %1
+exit /b
+
+:requirements
+:: Install/refresh all project requirements
+::call %base_path%\make %1
+exit /b
+
+:build
+:: Compile and install Polars for development
+call %base_path%\make %1
+exit /b
+
+:build-debug-opt
+:: Compile and install Polars with minimal optimizations turned on
+call %base_path%\make %1
+exit /b
+
+:build-debug-opt-subset
+:: Compile and install Polars with minimal optimizations turned on and no default features
+call %base_path%\make %1
+exit /b
+
+:build-opt
+:: Compile and install Polars with nearly full optimization on and debug assertions turned off, but with debug symbols on
+call %base_path%\make %1
+exit /b
+
+:build-release
+:: Compile and install a faster Polars binary with full optimizations
+call %base_path%\make %1
+exit /b
+
+:build-native
+:: Same as build, except with native CPU optimizations turned on
+call %base_path%\make %1
+exit /b
+
+:build-debug-opt-native
+:: Same as build-debug-opt, except with native CPU optimizations turned on
+call %base_path%\make %1
+exit /b
+
+:build-opt-native
+:: Same as build-opt, except with native CPU optimizations turned on
+call %base_path%\make %1
+exit /b
+
+:build-release-native
+:: Same as build-release, except with native CPU optimizations turned on
+call %base_path%\make %1
+exit /b
+
+:fmt
+:: Run autoformatting and linting
+call %base_path%\make %1
+exit /b
+
+:clippy
+:: Run clippy
+call %base_path%\make %1
+exit /b
+
+:pre-commit
+:: Run all code quality checks
+call %base_path%\make %1
+exit /b
+
+:test
+:: Run fast unittests
+%VENV_BIN%\pytest %pypath%/tests -n auto --dist loadgroup
+exit /b
+
+:doctest
+:: Run doctests
+%VENV_BIN%\python %pypath%/tests/docs/run_doctest.py
+%VENV_BIN%\pytest %pypath%/tests/docs/test_user_guide.py -m docs
+exit /b
+
+:test-all
+:: Run all tests
+%VENV_BIN%\pytest %pypath%/tests -n auto --dist loadgroup -m "slow or not slow"
+%VENV_BIN%\python %pypath%/tests/docs/run_doctest.py
+exit /b
+
+:coverage
+:: Run tests and report coverage
+%VENV_BIN%\pytest %pypath%/tests --cov -n auto --dist loadgroup -m "not benchmark"
+exit /b
+
+:clean
+:: Clean up caches and build artifacts
+if exist %py_path%\target ( rmdir %py_path%\target /s /q )
+if exist %py_path%\target ( rmdir %py_path%\target /s /q )
+if exist %py_path%\docs\build ( rmdir %py_path%\docs\build /s /q )
+if exist %py_path%\docs\source\reference\api ( rmdir %py_path%\docs\source\reference\api /s /q )
+if exist %py_path%\.hypothesis ( rmdir %py_path%\.hypothesis /s /q )
+if exist %py_path%\.mypy_cache ( rmdir %py_path%\.mypy_cache /s /q )
+if exist %py_path%\.pytest_cache ( rmdir %py_path%\.pytest_cache /s /q )
+if exist %py_path%\.ruff_cache ( rmdir %py_path%\.ruff_cache /s /q )
+if exist %py_path%\.coverage ( rmdir %py_path%\.coverage /s /q )
+if exist %py_path%/coverage.xml ( del %py_path%/coverage.xml /s /q )
+if exist %py_path%/polars/polars.abi3.so ( del %py_path%/polars/polars.abi3.so /s /q )
+del /s /q *.pyc 2>nul
+del /s /q *.pyo 2>nul
+cargo clean
+exit /b
+
+:help
+:: Display this help screen
+echo Available Commands:
+echo  .venv                  Set up virtual environment and install requirements
+echo  build                  Compile and install Polars for development
+echo  build-debug-opt        Compile and install Polars with minimal optimizations turned on
+echo  build-debug-opt-native Same as build-debug-opt, except with native CPU optimizations turned on
+echo  build-debug-opt-subset Compile and install Polars with minimal optimizations turned on and no default features
+echo  build-native           Same as build, except with native CPU optimizations turned on
+echo  build-opt              Compile and install Polars with nearly full optimization on and debug assertions turned off, but with debug symbols on
+echo  build-opt-native       Same as build-opt, except with native CPU optimizations turned on
+echo  build-release          Compile and install a faster Polars binary with full optimizations
+echo  build-release-native   Same as build-release, except with native CPU optimizations turned on
+echo  clean                  Clean up caches and build artifacts
+echo  clippy                 Run clippy
+echo  coverage               Run tests and report coverage
+echo  doctest                Run doctests
+echo  fmt                    Run autoformatting and linting
+echo  help                   Display this help screen
+echo  pre-commit             Run all code quality checks
+echo  requirements           Install/refresh all project requirements
+echo  test                   Run fast unittests
+echo  test-all               Run all tests


### PR DESCRIPTION
We've had a few people coming from windows that have been instructed to use WSL. While WSL is the preferred way of developing, being able to compile polars in Windows out of the box might lower the bar for entry. I've added two Windows scripts, `make.cmd` and `py-polars/make.cmd` that mimic the Makefiles found in those two locations. They can be run from the command prompt with exactly the same inputs and options as the Makefiles, and moreover they do not interfere with running the Makefiles in linux:

```shell
C:\Projects\polars>make build
C:\Projects\polars>make pre-commit
C:\Projects\polars>make clean
...etc.
```

This also resolves #13466. There is an issue with Windows where symbolic links cannot be made without administrator access (and thus a `git clone` does not properly create a symbolic link between `rust-toolchain.toml` and `py-polars/rust-toolchain.toml`), so this implements a workaround: according to the [rustup book](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file), if a file called `rust-toolchain` (without toml extension) exists, it takes precendence over a rust-toolchain.toml file. The make scripts above first check whether or not `py-polars/rust-toolchain.toml` is a symbolic or hard link. If it is neither, indicating that git did not properly configure the file, then the root `rust-toolchain.toml` is hard-linked to `py-polars/rust-toolchain` (with no extension). `maturin` commands now work properly. In addition, this does not clobber anything in the repository, as this "generated" file lives alongside the `rust-toolchain.toml`. I've updated the `.gitignore` so that the repository is also blind to this file.

One small difference between this script and the make file is that this script installs `dprint` automatically. This can easily be removed.

