### PR TITLE
perf(rust,python,cli): optimise SQL engine string concat

### DIFF
--- a/crates/polars-sql/Cargo.toml
+++ b/crates/polars-sql/Cargo.toml
@@ -12,7 +12,7 @@ description = "SQL transpiler for Polars. Converts SQL to Polars logical plans"
 arrow = { workspace = true }
 polars-core = { workspace = true }
 polars-error = { workspace = true }
-polars-lazy = { workspace = true, features = ["abs", "binary_encoding", "cross_join", "cum_agg", "dtype-date", "is_in", "log", "meta", "regex", "round_series", "sign", "string_reverse", "strings", "trigonometry"] }
+polars-lazy = { workspace = true, features = ["abs", "binary_encoding", "concat_str", "cross_join", "cum_agg", "dtype-date", "is_in", "log", "meta", "regex", "round_series", "sign", "string_reverse", "strings", "trigonometry"] }
 polars-plan = { workspace = true }
 
 hex = { workspace = true }

--- a/py-polars/tests/unit/sql/test_strings.py
+++ b/py-polars/tests/unit/sql/test_strings.py
@@ -54,7 +54,7 @@ def test_string_concat() -> None:
           CONCAT("x", "x", "y")         AS c3,
           CONCAT("x", "y", ("z" * 2))   AS c4,
           CONCAT_WS(':', "x", "y", "z") AS c5,
-          CONCAT_WS("x", "y", "z", '!') AS c6
+          CONCAT_WS('', "y", "z", '!')  AS c6
         FROM data
         """,
         eager=True,
@@ -66,7 +66,7 @@ def test_string_concat() -> None:
         "c3": ["aad", None, "ccf"],
         "c4": ["ad2", None, "cf6"],
         "c5": ["a:d:1", None, "c:f:3"],
-        "c6": ["da1a!", None, "fc3c!"],
+        "c6": ["d1!", "e2!", "f3!"],
     }
 
 


### PR DESCRIPTION
Apparently when I committed this the first time I had forgotten that `concat_str` exists in Rust too...😅 Reworked the new `CONCAT` and `CONCAT_WS` functions to take advantage of the dedicated fast path.