### PR TITLE
feat(rust,python,cli): add SQL engine support for `MOD` function

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -89,6 +89,12 @@ pub(crate) enum PolarsSQLFunctions {
     /// SELECT POW(column_1, 2) from df;
     /// ```
     Pow,
+    /// SQL 'mod' function
+    /// Returns the remainder of a numeric expression divided by another numeric expression.
+    /// ```sql
+    /// SELECT MOD(column_1, 2) from df;
+    /// ```
+    Mod,
     /// SQL 'sqrt' function
     /// Returns the square root (√) of a number.
     /// ```sql
@@ -601,6 +607,7 @@ impl PolarsSQLFunctions {
             "log10" => Self::Log10,
             "log1p" => Self::Log1p,
             "log2" => Self::Log2,
+            "mod" => Self::Mod,
             "pi" => Self::Pi,
             "pow" | "power" => Self::Pow,
             "round" => Self::Round,
@@ -742,6 +749,7 @@ impl SQLFunctionVisitor<'_> {
             Log10 => self.visit_unary(|e| e.log(10.0)),
             Log1p => self.visit_unary(Expr::log1p),
             Log2 => self.visit_unary(|e| e.log(2.0)),
+            Mod => self.visit_binary(|e1, e2| e1 % e2),
             Pow => self.visit_binary::<Expr>(Expr::pow),
             Sqrt => self.visit_unary(Expr::sqrt),
             Cbrt => self.visit_unary(Expr::cbrt),

--- a/py-polars/tests/unit/sql/test_numeric.py
+++ b/py-polars/tests/unit/sql/test_numeric.py
@@ -7,6 +7,71 @@ from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
+def test_modulo() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [1.5, None, 3.0, 13 / 3, 5.0],
+            "b": [6, 7, 8, 9, 10],
+            "c": [11, 12, 13, 14, 15],
+            "d": [16.5, 17.0, 18.5, None, 20.0],
+        }
+    )
+    with pl.SQLContext(df=df) as ctx:
+        out = ctx.execute(
+            """
+            SELECT
+              a % 2 AS a2,
+              b % 3 AS b3,
+              MOD(c, 4) AS c4,
+              MOD(d, 5.5) AS d55
+            FROM df
+            """
+        ).collect()
+
+        assert_frame_equal(
+            out,
+            pl.DataFrame(
+                {
+                    "a2": [1.5, None, 1.0, 1 / 3, 1.0],
+                    "b3": [0, 1, 2, 0, 1],
+                    "c4": [3, 0, 1, 2, 3],
+                    "d55": [0.0, 0.5, 2.0, None, 3.5],
+                }
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("decimals", "expected"),
+    [
+        (0, [-8192.0, -4.0, -2.0, 2.0, 4.0, 8193.0]),
+        (1, [-8192.5, -4.0, -1.5, 2.5, 3.6, 8192.5]),
+        (2, [-8192.5, -3.96, -1.54, 2.46, 3.6, 8192.5]),
+        (3, [-8192.499, -3.955, -1.543, 2.457, 3.599, 8192.5]),
+        (4, [-8192.499, -3.955, -1.5432, 2.4568, 3.599, 8192.5001]),
+    ],
+)
+def test_round_ndigits(decimals: int, expected: list[float]) -> None:
+    df = pl.DataFrame(
+        {"n": [-8192.499, -3.9550, -1.54321, 2.45678, 3.59901, 8192.5001]},
+    )
+    with pl.SQLContext(df=df, eager_execution=True) as ctx:
+        if decimals == 0:
+            out = ctx.execute("SELECT ROUND(n) AS n FROM df")
+            assert_series_equal(out["n"], pl.Series("n", values=expected))
+
+        out = ctx.execute(f'SELECT ROUND("n",{decimals}) AS n FROM df')
+        assert_series_equal(out["n"], pl.Series("n", values=expected))
+
+
+def test_round_ndigits_errors() -> None:
+    df = pl.DataFrame({"n": [99.999]})
+    with pl.SQLContext(df=df, eager_execution=True) as ctx, pytest.raises(
+        InvalidOperationError, match="Invalid 'decimals' for Round: -1"
+    ):
+        ctx.execute("SELECT ROUND(n,-1) AS n FROM df")
+
+
 def test_stddev_variance() -> None:
     df = pl.DataFrame(
         {
@@ -48,34 +113,3 @@ def test_stddev_variance() -> None:
                 }
             ),
         )
-
-
-@pytest.mark.parametrize(
-    ("decimals", "expected"),
-    [
-        (0, [-8192.0, -4.0, -2.0, 2.0, 4.0, 8193.0]),
-        (1, [-8192.5, -4.0, -1.5, 2.5, 3.6, 8192.5]),
-        (2, [-8192.5, -3.96, -1.54, 2.46, 3.6, 8192.5]),
-        (3, [-8192.499, -3.955, -1.543, 2.457, 3.599, 8192.5]),
-        (4, [-8192.499, -3.955, -1.5432, 2.4568, 3.599, 8192.5001]),
-    ],
-)
-def test_round_ndigits(decimals: int, expected: list[float]) -> None:
-    df = pl.DataFrame(
-        {"n": [-8192.499, -3.9550, -1.54321, 2.45678, 3.59901, 8192.5001]},
-    )
-    with pl.SQLContext(df=df, eager_execution=True) as ctx:
-        if decimals == 0:
-            out = ctx.execute("SELECT ROUND(n) AS n FROM df")
-            assert_series_equal(out["n"], pl.Series("n", values=expected))
-
-        out = ctx.execute(f'SELECT ROUND("n",{decimals}) AS n FROM df')
-        assert_series_equal(out["n"], pl.Series("n", values=expected))
-
-
-def test_round_ndigits_errors() -> None:
-    df = pl.DataFrame({"n": [99.999]})
-    with pl.SQLContext(df=df, eager_execution=True) as ctx, pytest.raises(
-        InvalidOperationError, match="Invalid 'decimals' for Round: -1"
-    ):
-        ctx.execute("SELECT ROUND(n,-1) AS n FROM df")


### PR DESCRIPTION
Adds SQL support for `MOD`[^1] as a function, in addition to the existing support for the modulo `%` operator.

## Example

```python
import polars as pl

df = pl.DataFrame({
    "a": [1.5, None, 3.0, 10.0, 5.0],
    "b": [6, 7, 8, 9, None],
})
with pl.SQLContext(df=df) as ctx:
    out = ctx.execute(
        """
        SELECT
          a % 2 AS a_mod_2,
          MOD(b,3) AS b_mod_3,
        FROM df
        """
    ).collect()

    # shape: (5, 2)
    # ┌─────────┬─────────┐
    # │ a_mod_2 ┆ b_mod_3 │
    # │ ---     ┆ ---     │
    # │ f64     ┆ i64     │
    # ╞═════════╪═════════╡
    # │ 1.5     ┆ 0       │
    # │ null    ┆ 1       │
    # │ 1.0     ┆ 2       │
    # │ 0.0     ┆ 0       │
    # │ 1.0     ┆ null    │
    # └─────────┴─────────┘
```
[^1]: `MOD` function: https://www.postgresql.org/docs/current/functions-math.html#id-1.5.8.9.6.2.2.19.1.1.1