### PR TITLE
test(python): Fix some test failures/slowdowns

### DIFF
--- a/py-polars/tests/unit/io/test_delta.py
+++ b/py-polars/tests/unit/io/test_delta.py
@@ -340,6 +340,7 @@ def test_write_delta_w_compatible_schema(series: pl.Series, tmp_path: Path) -> N
     assert tbl.version() == 1
 
 
+@pytest.mark.write_disk()
 def test_write_delta_with_schema_10540(tmp_path: Path) -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
 
@@ -347,6 +348,7 @@ def test_write_delta_with_schema_10540(tmp_path: Path) -> None:
     df.write_delta(tmp_path, delta_write_options={"schema": pa_schema})
 
 
+@pytest.mark.write_disk()
 @pytest.mark.parametrize(
     "expr",
     [
@@ -382,6 +384,7 @@ def test_write_delta_with_merge_and_no_table(tmp_path: Path) -> None:
         )
 
 
+@pytest.mark.write_disk()
 def test_write_delta_with_merge(tmp_path: Path) -> None:
     df = pl.DataFrame({"a": [1, 2, 3]})
 

--- a/py-polars/tests/unit/namespaces/test_plot.py
+++ b/py-polars/tests/unit/namespaces/test_plot.py
@@ -5,6 +5,10 @@ import pytest
 import polars as pl
 from polars.exceptions import PolarsPanicError
 
+# Calling `plot` the first time is slow
+# https://github.com/pola-rs/polars/issues/13500
+pytestmark = pytest.mark.slow
+
 
 def test_dataframe_scatter() -> None:
     df = pl.DataFrame(

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -659,6 +659,7 @@ def test_outer_join_list_() -> None:
     }
 
 
+@pytest.mark.slow()
 def test_join_validation() -> None:
     def test_each_join_validation(
         unique: pl.DataFrame, duplicate: pl.DataFrame, how: JoinStrategy

--- a/py-polars/tests/unit/test_async.py
+++ b/py-polars/tests/unit/test_async.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 import time
 from functools import partial
 from typing import Any, Callable
@@ -169,6 +170,7 @@ def test_gevent_collect_async_with_hub(
     _gevent_run(main, raises)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="May time out on Windows")
 @_gevent_collect
 def test_gevent_collect_async_switch(
     get_result: Callable[[], Any], raises: Exception | None
@@ -176,7 +178,7 @@ def test_gevent_collect_async_switch(
     def main() -> Any:
         result = get_result()
         gevent.sleep(0.1)
-        return result.get(block=False, timeout=10)
+        return result.get(block=False, timeout=3)
 
     _gevent_run(main, raises)
 

--- a/py-polars/tests/unit/test_polars_import.py
+++ b/py-polars/tests/unit/test_polars_import.py
@@ -10,10 +10,10 @@ import pytest
 import polars as pl
 from polars import selectors as cs
 
-# set a maximum cutoff at 0.2 secs; note that we are typically much faster
+# set a maximum cutoff at 0.25 secs; note that we are typically much faster
 # than this (more like ~0.07 secs, depending on hardware), but we allow a
 # margin of error to account for frequent noise from slow/contended CI.
-MAX_ALLOWED_IMPORT_TIME = 200_000  # << microseconds
+MAX_ALLOWED_IMPORT_TIME = 250_000  # << microseconds
 
 
 def _import_time_from_frame(tm: pl.DataFrame) -> int:

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -124,6 +124,7 @@ def test_parse_version(v1: Any, v2: Any) -> None:
     assert parse_version(v2) < parse_version(v1)
 
 
+@pytest.mark.slow()
 def test_in_notebook() -> None:
     # private function, but easier to test this separately and mock it in the callers
     assert not _in_notebook()


### PR DESCRIPTION
Closes #13297

I increased the import time restriction to 250ms as I saw a bunch of spurious failures at 205ms.

Plus a workaround for #13500 slowing down the test suite.