### PR TITLE
docs(python): Fix various typos, grammar and formatting in docstrings and user guide

### DIFF
--- a/docs/user-guide/concepts/data-structures.md
+++ b/docs/user-guide/concepts/data-structures.md
@@ -1,6 +1,6 @@
 # Data structures
 
-The core base data structures provided by Polars are `Series` and `DataFrames`.
+The core base data structures provided by Polars are `Series` and `DataFrame`.
 
 ## Series
 

--- a/docs/user-guide/expressions/window.md
+++ b/docs/user-guide/expressions/window.md
@@ -18,7 +18,7 @@ are projected back to the original rows. Therefore, a window function will almos
 
 We will discuss later the cases where a window function can change the numbers of rows in a `DataFrame`.
 
-Note how we call `.over("Type 1")` and `.over(["Type 1", "Type 2"])`. Using window functions we can aggregate over different groups in a single `select` call! Note that, in Rust, the type of the argument to `over()` must be a collection, so even when you're only using one column, you must provided it in an array.
+Note how we call `.over("Type 1")` and `.over(["Type 1", "Type 2"])`. Using window functions we can aggregate over different groups in a single `select` call! Note that, in Rust, the type of the argument to `over()` must be a collection, so even when you're only using one column, you must provide it in an array.
 
 The best part is, this won't cost you anything. The computed groups are cached and shared between different `window` expressions.
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -221,7 +221,6 @@ class DataFrame:
     schema_overrides : dict, default None
         Support type specification or override of one or more columns; note that
         any dtypes inferred from the schema param will be overridden.
-        underlying data, the names given here will overwrite them.
 
         The number of entries in the schema should match the underlying data
         dimensions, unless a sequence of dictionaries is being passed, in which case
@@ -4629,7 +4628,7 @@ class DataFrame:
         """
         Return the `k` largest elements.
 
-        If 'descending=True` the smallest elements will be given.
+        If `descending=True` the smallest elements will be given.
 
         Parameters
         ----------
@@ -4639,7 +4638,7 @@ class DataFrame:
             Column(s) included in sort order. Accepts expression input.
             Strings are parsed as column names.
         descending
-            Return the 'k' smallest. Top-k by multiple columns can be specified
+            Return the `k` smallest. Top-k by multiple columns can be specified
             per column by passing a sequence of booleans.
         nulls_last
             Place null values last.
@@ -4720,7 +4719,7 @@ class DataFrame:
         """
         Return the `k` smallest elements.
 
-        If 'descending=True` the largest elements will be given.
+        If `descending=True` the largest elements will be given.
 
         Parameters
         ----------
@@ -4730,7 +4729,7 @@ class DataFrame:
             Column(s) included in sort order. Accepts expression input.
             Strings are parsed as column names.
         descending
-            Return the 'k' smallest. Top-k by multiple columns can be specified
+            Return the `k` largest. Bottom-k by multiple columns can be specified
             per column by passing a sequence of booleans.
         nulls_last
             Place null values last.
@@ -5897,14 +5896,14 @@ class DataFrame:
         Parameters
         ----------
         time_column
-            time column will be used to determine a date_range.
+            Time column will be used to determine a date_range.
             Note that this column has to be sorted for the output to make sense.
         every
-            interval will start 'every' duration
+            Interval will start 'every' duration.
         offset
-            change the start of the date_range by this offset.
+            Change the start of the date_range by this offset.
         by
-            First group by these columns and then upsample for every group
+            First group by these columns and then upsample for every group.
         maintain_order
             Keep the ordering predictable. This is slower.
 
@@ -7999,7 +7998,7 @@ class DataFrame:
         self, *exprs: IntoExpr | Iterable[IntoExpr], **named_exprs: IntoExpr
     ) -> DataFrame:
         """
-        Select columns from this LazyFrame.
+        Select columns from this DataFrame.
 
         This will run all expression sequentially instead of in parallel.
         Use this when the work per expression is cheap.
@@ -8193,8 +8192,8 @@ class DataFrame:
 
         Returns
         -------
-        LazyFrame
-            A new LazyFrame with the columns added.
+        DataFrame
+            A new DataFrame with the columns added.
 
         See Also
         --------

--- a/py-polars/polars/io/json.py
+++ b/py-polars/polars/io/json.py
@@ -44,7 +44,6 @@ def read_json(
     schema_overrides : dict, default None
         Support type specification or override of one or more columns; note that
         any dtypes inferred from the schema param will be overridden.
-        underlying data, the names given here will overwrite them.
 
     See Also
     --------

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -42,7 +42,6 @@ def read_ndjson(
     schema_overrides : dict, default None
         Support type specification or override of one or more columns; note that
         any dtypes inferred from the schema param will be overridden.
-        underlying data, the names given here will overwrite them.
     ignore_errors
         Return `Null` if parsing fails because of schema mismatches.
     """

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -140,7 +140,7 @@ class LazyFrame:
         Two-dimensional data in various forms; dict input must contain Sequences,
         Generators, or a `range`. Sequence may contain Series or other Sequences.
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
-        The DataFrame schema may be declared in several ways:
+        The LazyFrame schema may be declared in several ways:
 
         * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
@@ -152,7 +152,6 @@ class LazyFrame:
     schema_overrides : dict, default None
         Support type specification or override of one or more columns; note that
         any dtypes inferred from the schema param will be overridden.
-        underlying data, the names given here will overwrite them.
 
         The number of entries in the schema should match the underlying data
         dimensions, unless a sequence of dictionaries is being passed, in which case
@@ -1116,8 +1115,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Inspect a node in the computation graph.
 
-        Print the value that this node in the computation graph evaluates to and passes
-        on the value.
+        Print the value that this node in the computation graph evaluates to and pass on
+        the value.
 
         Examples
         --------
@@ -1147,7 +1146,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         maintain_order: bool = False,
     ) -> Self:
         """
-        Sort the DataFrame by the given columns.
+        Sort the LazyFrame by the given columns.
 
         Parameters
         ----------
@@ -1261,7 +1260,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Return the `k` largest elements.
 
-        If 'descending=True` the smallest elements will be given.
+        If `descending=True` the smallest elements will be given.
 
         Parameters
         ----------
@@ -1271,7 +1270,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Column(s) included in sort order. Accepts expression input.
             Strings are parsed as column names.
         descending
-            Return the 'k' smallest. Top-k by multiple columns can be specified
+            Return the `k` smallest. Top-k by multiple columns can be specified
             per column by passing a sequence of booleans.
         nulls_last
             Place null values last.
@@ -1346,7 +1345,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Return the `k` smallest elements.
 
-        If 'descending=True` the largest elements will be given.
+        If `descending=True` the largest elements will be given.
 
         Parameters
         ----------
@@ -1356,7 +1355,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Column(s) included in sort order. Accepts expression input.
             Strings are parsed as column names.
         descending
-            Return the 'k' smallest. Top-k by multiple columns can be specified
+            Return the `k` largest. Bottom-k by multiple columns can be specified
             per column by passing a sequence of booleans.
         nulls_last
             Place null values last.
@@ -2205,7 +2204,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             File path to which the file should be written.
         maintain_order
             Maintain the order in which data is processed.
-            Setting this to `False` will  be slightly faster.
+            Setting this to `False` will be slightly faster.
         type_coercion
             Do type coercion optimization.
         predicate_pushdown
@@ -3850,7 +3849,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         **named_exprs: IntoExpr,
     ) -> Self:
         """
-        Add columns to this DataFrame.
+        Add columns to this LazyFrame.
 
         Added columns will replace existing columns with the same name.
 
@@ -4003,7 +4002,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         **named_exprs: IntoExpr,
     ) -> Self:
         """
-        Add columns to this DataFrame.
+        Add columns to this LazyFrame.
 
         Added columns will replace existing columns with the same name.
 

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -664,7 +664,7 @@ class StringNameSpace:
             <https://docs.rs/regex/latest/regex/>`_.
         group_index
             Index of the targeted capture group.
-            Group 0 means the whole pattern, the first group begin at index 1.
+            Group 0 means the whole pattern, the first group begins at index 1.
             Defaults to the first capture group.
 
         Returns


### PR DESCRIPTION
Changes include
- Typos, grammar, punctuation, formatting
- Erroneous "underlying data, the names given here will overwrite them." line was repeated in docstrings
- Fix some "smallest" / "largest" references in `top_k` / `bottom_k`
- References to a `LazyFrame` being a `DataFrame` and vice-versa

I did notice a few more references to a `LazyFrame` being a `DataFrame` and vice-versa (for example in `LazyFrame.join`), but will leave for another PR to keep the size manageable.