### PR TITLE
feat: don't rechunk by default in lazy scans

### DIFF
--- a/crates/polars-lazy/src/scan/csv.rs
+++ b/crates/polars-lazy/src/scan/csv.rs
@@ -63,7 +63,7 @@ impl<'a> LazyCsvReader<'a> {
             null_values: None,
             missing_is_null: true,
             infer_schema_length: Some(100),
-            rechunk: true,
+            rechunk: false,
             skip_rows_after_header: 0,
             encoding: CsvEncoding::Utf8,
             row_count: None,

--- a/crates/polars-lazy/src/scan/ipc.rs
+++ b/crates/polars-lazy/src/scan/ipc.rs
@@ -19,7 +19,7 @@ impl Default for ScanArgsIpc {
         Self {
             n_rows: None,
             cache: true,
-            rechunk: true,
+            rechunk: false,
             row_count: None,
             memmap: true,
         }

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -30,7 +30,7 @@ impl LazyJsonLineReader {
             paths: Arc::new([]),
             batch_size: None,
             low_memory: false,
-            rechunk: true,
+            rechunk: false,
             schema: None,
             row_count: None,
             infer_schema_length: Some(100),

--- a/crates/polars-lazy/src/scan/parquet.rs
+++ b/crates/polars-lazy/src/scan/parquet.rs
@@ -26,7 +26,7 @@ impl Default for ScanArgsParquet {
             n_rows: None,
             cache: true,
             parallel: Default::default(),
-            rechunk: true,
+            rechunk: false,
             row_count: None,
             low_memory: false,
             cloud_options: None,

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -43,7 +43,7 @@ def read_csv(
     n_rows: int | None = None,
     encoding: CsvEncoding | str = "utf8",
     low_memory: bool = False,
-    rechunk: bool = True,
+    rechunk: bool = False,
     use_pyarrow: bool = False,
     storage_options: dict[str, Any] | None = None,
     skip_rows_after_header: int = 0,

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -211,7 +211,7 @@ def scan_ipc(
     *,
     n_rows: int | None = None,
     cache: bool = True,
-    rechunk: bool = True,
+    rechunk: bool = False,
     row_count_name: str | None = None,
     row_count_offset: int = 0,
     storage_options: dict[str, Any] | None = None,

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -216,7 +216,7 @@ def scan_parquet(
     parallel: ParallelStrategy = "auto",
     use_statistics: bool = True,
     hive_partitioning: bool = True,
-    rechunk: bool = True,
+    rechunk: bool = False,
     low_memory: bool = False,
     cache: bool = True,
     storage_options: dict[str, Any] | None = None,


### PR DESCRIPTION
This will likely be faster in some cases. A rechunk can always be triggered when needed.