### PR TITLE
depr(python): Deprecate `dt.datetime`

### DIFF
--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -10,6 +10,7 @@ from polars.utils._parse_expr_input import parse_as_expression
 from polars.utils._wrap import wrap_expr
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.deprecation import (
+    deprecate_function,
     deprecate_renamed_function,
     deprecate_saturating,
     issue_deprecation_warning,
@@ -923,9 +924,13 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.dt_date())
 
+    @deprecate_function("Use `dt.replace_time_zone(None)` instead.", version="0.20.4")
     def datetime(self) -> Expr:
         """
         Return datetime.
+
+        .. deprecated:: 0.20.4
+            Use `dt.replace_time_zone(None)` instead.
 
         Applies to Datetime columns.
 
@@ -947,7 +952,7 @@ class ExprDateTimeNameSpace:
         ...     },
         ...     schema={"datetime UTC": pl.Datetime(time_zone="UTC")},
         ... )
-        >>> df.with_columns(
+        >>> df.with_columns(  # doctest: +SKIP
         ...     pl.col("datetime UTC").dt.datetime().alias("datetime (no timezone)"),
         ... )
         shape: (3, 2)

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -6,7 +6,7 @@ from polars.datatypes import Date, Datetime
 from polars.series.utils import expr_dispatch
 from polars.utils._wrap import wrap_s
 from polars.utils.convert import _to_python_date, _to_python_datetime
-from polars.utils.deprecation import deprecate_renamed_function
+from polars.utils.deprecation import deprecate_function, deprecate_renamed_function
 
 if TYPE_CHECKING:
     import datetime as dt
@@ -508,9 +508,13 @@ class DateTimeNameSpace:
         ]
         """
 
+    @deprecate_function("Use `dt.replace_time_zone(None)` instead.", version="0.20.4")
     def datetime(self) -> Series:
         """
         Extract (local) datetime.
+
+        .. deprecated:: 0.20.4
+            Use `dt.replace_time_zone(None)` instead.
 
         Applies to Datetime columns.
 
@@ -531,7 +535,7 @@ class DateTimeNameSpace:
         [
                 2021-01-02 05:00:00 +0545
         ]
-        >>> ser.dt.datetime()
+        >>> ser.dt.datetime()  # doctest: +SKIP
         shape: (1,)
         Series: '' [datetime[μs]]
         [


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/13505

We already have `dt.replace_time_zone(None)` which does exactly the same and is much more explicit.