### PR TITLE
fix(python): dont raise when partial function is passed to map_elements

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -836,8 +836,11 @@ class RewrittenInstructions:
 
 def _is_raw_function(function: Callable[[Any], Any]) -> tuple[str, str]:
     """Identify translatable calls that aren't wrapped inside a lambda/function."""
-    func_module = function.__class__.__module__
-    func_name = function.__name__
+    try:
+        func_module = function.__class__.__module__
+        func_name = function.__name__
+    except AttributeError:
+        return "", ""
 
     # numpy function calls
     if func_module == "numpy" and func_name in _NUMPY_FUNCTIONS:

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -4,6 +4,7 @@ import datetime as dt
 import json
 import re
 from datetime import datetime
+from functools import partial
 from typing import Any, Callable
 
 import numpy
@@ -406,3 +407,13 @@ def test_expr_exact_warning_message() -> None:
         df.select(pl.col("a").map_elements(lambda x: x + 1))
 
     assert len(warnings) == 1
+
+
+def test_partial_functions_13523() -> None:
+    def plus(value, amount: int):  # type: ignore[no-untyped-def]
+        return value + amount
+
+    data = {"a": [1, 2], "b": [3, 4]}
+    df = pl.DataFrame(data)
+    # should not warn
+    _ = df["a"].map_elements(partial(plus, amount=1))


### PR DESCRIPTION
closes #13523

this regressed in https://github.com/pola-rs/polars/pull/13221 , sorry about that - but hey, increased test coverage now