### PR TITLE
fix(rust) return empty final fields from SplitFields

### DIFF
--- a/crates/polars-io/src/csv/splitfields.rs
+++ b/crates/polars-io/src/csv/splitfields.rs
@@ -54,8 +54,10 @@ mod inner {
 
         #[inline]
         fn next(&mut self) -> Option<(&'a [u8], bool)> {
-            if self.v.is_empty() || self.finished {
+            if self.finished {
                 return None;
+            } else if self.v.is_empty() {
+                return self.finish(false);
             }
 
             let mut needs_escaping = false;
@@ -214,8 +216,10 @@ mod inner {
 
         #[inline]
         fn next(&mut self) -> Option<(&'a [u8], bool)> {
-            if self.v.is_empty() || self.finished {
+            if self.finished {
                 return None;
+            } else if self.v.is_empty() {
+                return self.finish(false);
             }
 
             let mut needs_escaping = false;

--- a/crates/polars-io/src/csv/utils.rs
+++ b/crates/polars-io/src/csv/utils.rs
@@ -222,16 +222,10 @@ pub fn infer_file_schema_inner(
             }
             final_headers
         } else {
-            let mut column_names: Vec<String> = byterecord
+            byterecord
                 .enumerate()
                 .map(|(i, _s)| format!("column_{}", i + 1))
-                .collect();
-            // needed because SplitLines does not return the \n char, so SplitFields does not catch
-            // the latest value if ending with a separator.
-            if header_line.ends_with(&[separator]) {
-                column_names.push(format!("column_{}", column_names.len() + 1))
-            }
-            column_names
+                .collect::<Vec<String>>()
         }
     } else if has_header && !bytes.is_empty() && recursion_count == 0 {
         // there was no new line char. So we copy the whole buf and add one

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -998,6 +998,50 @@ fn test_empty_string_cols() -> PolarsResult<()> {
 }
 
 #[test]
+fn test_empty_col_names() -> PolarsResult<()> {
+    let csv = "a,b,c\n1,2,3";
+    let file = Cursor::new(csv);
+    let df = CsvReader::new(file).finish()?;
+    let expected = df![
+        "a" => [1i64],
+        "b" => [2i64],
+        "c" => [3i64]
+    ]?;
+    assert!(df.equals(&expected));
+
+    let csv = "a,,c\n1,2,3";
+    let file = Cursor::new(csv);
+    let df = CsvReader::new(file).finish()?;
+    let expected = df![
+        "a" => [1i64],
+        "" => [2i64],
+        "c" => [3i64]
+    ]?;
+    assert!(df.equals(&expected));
+
+    let csv = "a,b,\n1,2,3";
+    let file = Cursor::new(csv);
+    let df = CsvReader::new(file).finish()?;
+    let expected = df![
+        "a" => [1i64],
+        "b" => [2i64],
+        "" => [3i64]
+    ]?;
+    assert!(df.equals(&expected));
+
+    let csv = "a,b,,\n1,2,3";
+    let file = Cursor::new(csv);
+    let df_result = CsvReader::new(file).finish()?;
+    assert_eq!(df_result.shape(), (1, 4));
+
+    let csv = "a,b\n1,2,3";
+    let file = Cursor::new(csv);
+    let df_result = CsvReader::new(file).finish();
+    assert!(df_result.is_err());
+    Ok(())
+}
+
+#[test]
 fn test_trailing_empty_string_cols() -> PolarsResult<()> {
     let csv = "colx\nabc\nxyz\n\"\"";
     let file = Cursor::new(csv);


### PR DESCRIPTION
fix #13537 

Fixes `SplitFields` not returning an empty field from a CSV line. I.e. a line like this `a,b,` would yield `["a", "b"]` rather than `["a", "b", ""]`.  Now if there are no bytes left to process but iteration has not been marked as finished the iterator yields an empty slice and then finishes rather than finishing immediately.

Also adds a test for variations of empty column names `test_empty_col_names`.