### PR TITLE
feat(python) Support arithmetic between Decimal Series and Python Decimal or int.

### DIFF
--- a/crates/polars-arrow/src/legacy/compute/arithmetics/decimal/commutative.rs
+++ b/crates/polars-arrow/src/legacy/compute/arithmetics/decimal/commutative.rs
@@ -13,7 +13,7 @@ pub fn commutative<F>(
 where
     F: Fn(i128, i128) -> i128,
 {
-    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type()).unwrap();
+    let (precision, _) = get_parameters(lhs.data_type(), rhs.data_type())?;
 
     let max = max_value(precision);
     let mut overflow = false;
@@ -36,7 +36,7 @@ pub fn commutative_scalar<F>(
 where
     F: Fn(i128, i128) -> i128,
 {
-    let (precision, _) = get_parameters(lhs.data_type(), rhs_dtype).unwrap();
+    let (precision, _) = get_parameters(lhs.data_type(), rhs_dtype)?;
 
     let max = max_value(precision);
     let mut overflow = false;

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4,6 +4,7 @@ import contextlib
 import math
 import os
 from datetime import date, datetime, time, timedelta
+from decimal import Decimal as PyDecimal
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -895,6 +896,14 @@ class Series:
             and not self.dtype.is_float()
         ):
             _s = sequence_to_pyseries(self.name, [other])
+            if "rhs" in op_ffi:
+                return self._from_pyseries(getattr(_s, op_s)(self._s))
+            else:
+                return self._from_pyseries(getattr(self._s, op_s)(_s))
+        if isinstance(other, (PyDecimal, int)) and self.dtype.is_decimal():
+            _s = sequence_to_pyseries(self.name, [other], self.dtype).cast(
+                self.dtype, strict=True
+            )
             if "rhs" in op_ffi:
                 return self._from_pyseries(getattr(_s, op_s)(self._s))
             else:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -18,6 +18,7 @@ from typing import (
     NoReturn,
     Sequence,
     Union,
+    cast,
     overload,
 )
 
@@ -901,9 +902,20 @@ class Series:
             else:
                 return self._from_pyseries(getattr(self._s, op_s)(_s))
         if isinstance(other, (PyDecimal, int)) and self.dtype.is_decimal():
-            _s = sequence_to_pyseries(self.name, [other], self.dtype).cast(
-                self.dtype, strict=True
+            # Infer the number's scale.  Then use the max of the inferred scale and the
+            # Series' scale.  At present, this will cause arithmetic to fail with a
+            # PyDecimal that has a scale greater than the Series' scale, but will ensure
+            # that scale is not lost.
+            _s = sequence_to_pyseries(self.name, [other], dtype=Decimal)
+            _s = _s.cast(
+                Decimal(
+                    scale=max(
+                        cast(Decimal, _s.dtype()).scale, cast(Decimal, self.dtype).scale
+                    )
+                ),
+                strict=True,
             )
+
             if "rhs" in op_ffi:
                 return self._from_pyseries(getattr(_s, op_s)(self._s))
             else:

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -217,6 +217,34 @@ def test_decimal_arithmetic() -> None:
     }
 
 
+def test_decimal_series_value_arithmetic() -> None:
+    s = pl.Series([D("0.10"), D("10.10"), D("100.01")])
+
+    out1 = s + 10
+    out2 = s + D("10")
+    with pytest.raises(pl.InvalidOperationError):
+        s + D("10.0001")
+    out4 = s * 2 / 3
+    out5 = s / D("1.5")
+    out6 = s - 5
+
+    assert out1.dtype == pl.Decimal(precision=None, scale=2)
+    assert out2.dtype == pl.Decimal(precision=None, scale=2)
+    assert out4.dtype == pl.Decimal(precision=None, scale=2)
+    assert out5.dtype == pl.Decimal(precision=None, scale=2)
+    assert out6.dtype == pl.Decimal(precision=None, scale=2)
+
+    assert out1.to_list() == [D("10.1"), D("20.1"), D("110.01")]
+    assert out2.to_list() == [D("10.1"), D("20.1"), D("110.01")]
+    assert out4.to_list() == [
+        D("0.06"),
+        D("6.73"),
+        D("66.67"),
+    ]  # TODO: do we want floor instead of round?
+    assert out5.to_list() == [D("0.06"), D("6.73"), D("66.67")]
+    assert out6.to_list() == [D("-4.9"), D("5.1"), D("95.01")]
+
+
 def test_decimal_aggregations() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
Currently, while arithmetic between two Series with Decimal dtype is possible, the conversion for Python Decimals  and its isn't implemented within _arithmetic to allow them to be used for Series/number arithmetic.  This PR implements conversion to allow things like

```python
import polars as pl
from decimal import Decimal as D

pl.Series([D("1.2"), D("2.35")]) * D(4.3)
pl.Series([D("1.2"), D("2.35")]) * 43 / 10
```

Note that this does not work normally with DataFrames yet, as `pl.lit` is not implemented for decimals (eg, #13341).

In the process of writing tests for this, found an unnecessary panic, so closes #13651.

The code here uses scale inference for the PyDecimal (or, for ints, just 0), then casts to the max of the Series' scale and the PyDecimal scale.  This has the effect at the moment of causing an InvalidOperationError if the PyDecimal has an inferred scale larger than the Series' scale, which is the correct action at the moment, while likely requiring no change if that case is later handled.

I'd note, however, that this choice is not entirely obvious.  It may be better to simply cast the PyDecimal to whatever scale the Series dtype has.  Either can be a bit awkward, as PyDecimals simply don't have the same concept of scale.

- With max, `pl.Series([D("1.2")]) * D("1.00")` fails, and some things stop being associative, eg, `(pl.Series([D("1.2")]) * D("1.0")) / D("4.0")` works, and `pl.Series([D("1.2")]) * (D("1.0") / D("4.0"))` fails.
- With the Series' scale, `pl.Series([D("1.2")]) * D("1.09")` results in `pl.Series([D("1.2")])`.

Max seems safer because it causes potentially unexpected failures, while Series' scale causes potentially unexpected results.
