### PR TITLE
fix(rust): `AnyValue::StructOwned` panic when hashing

### DIFF
--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -651,13 +651,15 @@ impl AnyValue<'_> {
             #[cfg(feature = "object")]
             ObjectOwned(_) => {},
             #[cfg(feature = "dtype-struct")]
-            Struct(_, _, _) | StructOwned(_) => {
+            Struct(_, _, _) => {
                 if !cheap {
-                    let mut buf = vec![];
+                    let mut buf: Vec<AnyValue<'_>> = vec![];
                     self._materialize_struct_av(&mut buf);
                     buf.hash(state)
                 }
             },
+            #[cfg(feature = "dtype-struct")]
+            StructOwned(v) => v.0.hash(state),
             #[cfg(feature = "dtype-decimal")]
             Decimal(v, k) => {
                 v.hash(state);

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -653,7 +653,7 @@ impl AnyValue<'_> {
             #[cfg(feature = "dtype-struct")]
             Struct(_, _, _) => {
                 if !cheap {
-                    let mut buf: Vec<AnyValue<'_>> = vec![];
+                    let mut buf = vec![];
                     self._materialize_struct_av(&mut buf);
                     buf.hash(state)
                 }


### PR DESCRIPTION
Fixes #12455 .

`AnyValue::Struct` and `AnyValue::StructOwned` had the same underlying hash impl which involved code to create an iterator over all of the `AnyValue` fields in `AnyValue::Struct` struct. However, this code only handled matching `AnyValue::Struct` and thus panicked when given an `AnyValue::StructOwned` value. Fixed by separating `AnyValue::StructOwned` to have its own hash impl separate from the more complex logic necessary for `AnyValue::Struct`.