### PR TITLE
chore(python): Narrow type hint for `get_index_type` util

### DIFF
--- a/py-polars/polars/utils/meta.py
+++ b/py-polars/polars/utils/meta.py
@@ -9,10 +9,10 @@ with contextlib.suppress(ImportError):  # Module not available when building doc
     from polars.polars import threadpool_size as _threadpool_size
 
 if TYPE_CHECKING:
-    from polars.datatypes import DataTypeClass
+    from polars.datatypes import DataType
 
 
-def get_index_type() -> DataTypeClass:
+def get_index_type() -> DataType:
     """
     Get the datatype used for Polars indexing.
 

--- a/py-polars/polars/utils/meta.py
+++ b/py-polars/polars/utils/meta.py
@@ -5,8 +5,7 @@ import contextlib
 from typing import TYPE_CHECKING
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
-    from polars.polars import get_index_type as _get_index_type
-    from polars.polars import threadpool_size as _threadpool_size
+    import polars.polars as plr
 
 if TYPE_CHECKING:
     from polars.datatypes import DataType
@@ -26,7 +25,7 @@ def get_index_type() -> DataType:
     >>> pl.get_index_type()
     UInt32
     """
-    return _get_index_type()
+    return plr.get_index_type()
 
 
 def threadpool_size() -> int:
@@ -47,4 +46,4 @@ def threadpool_size() -> int:
     >>> pl.threadpool_size()  # doctest: +SKIP
     24
     """
-    return _threadpool_size()
+    return plr.threadpool_size()


### PR DESCRIPTION
It returns an instantiated type now.