### PR TITLE
feat(rust,python): add new `str.find` expression, returning the index of a regex pattern or literal substring

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -14,7 +14,7 @@ impl<T> ChunkedArray<T>
 where
     T: PolarsDataType,
 {
-    // Applies a function to all elements , regardless of whether they
+    // Applies a function to all elements, regardless of whether they
     // are null or not, after which the null mask is copied from the
     // original array.
     pub fn apply_values_generic<'a, U, K, F>(&'a self, mut op: F) -> ChunkedArray<U>

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -172,9 +172,11 @@ pub trait StringNameSpaceImpl: AsString {
             return Ok(UInt32Chunked::full_null(ca.name(), ca.len().max(pat.len())));
         }
         if literal {
-            Ok(broadcast_binary_elementwise_values(ca, pat, |src, pat| {
-                src.find(pat).map(|idx| idx as u32)
-            }))
+            Ok(broadcast_binary_elementwise(
+                ca,
+                pat,
+                |src: Option<&str>, pat: Option<&str>| src?.find(pat?).map(|idx| idx as u32),
+            ))
         } else {
             // note: sqrt(n) regex cache is not too small, not too large.
             let mut rx_cache = FastFixedCache::new((ca.len() as f64).sqrt() as usize);

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -192,6 +192,34 @@ impl StringNameSpace {
         self.0.map_private(StringFunction::ZFill(length).into())
     }
 
+    /// Find the index of a literal substring within another string value.
+    #[cfg(feature = "regex")]
+    pub fn find_literal(self, pat: Expr) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::StringExpr(StringFunction::Find {
+                literal: true,
+                strict: false,
+            }),
+            &[pat],
+            false,
+            true,
+        )
+    }
+
+    /// Find the index of a substring defined by a regular expressons within another string value.
+    #[cfg(feature = "regex")]
+    pub fn find(self, pat: Expr, strict: bool) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::StringExpr(StringFunction::Find {
+                literal: false,
+                strict,
+            }),
+            &[pat],
+            false,
+            true,
+        )
+    }
+
     /// Extract each successive non-overlapping match in an individual string as an array
     pub fn extract_all(self, pat: Expr) -> Expr {
         self.0

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1026,7 +1026,7 @@ class ExprStringNameSpace:
         """
         Return the index position of the first substring matching a pattern.
 
-        If the pattern is not present, returns None.
+        If the pattern is not found, returns None.
 
         Parameters
         ----------

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -954,7 +954,7 @@ class ExprStringNameSpace:
         self, pattern: str | Expr, *, literal: bool = False, strict: bool = True
     ) -> Expr:
         """
-        Check if string contains a substring that matches a regex.
+        Check if string contains a substring that matches a pattern.
 
         Parameters
         ----------
@@ -995,18 +995,19 @@ class ExprStringNameSpace:
         --------
         starts_with : Check if string values start with a substring.
         ends_with : Check if string values end with a substring.
+        find: Return the index of the first substring matching a pattern.
 
         Examples
         --------
-        >>> df = pl.DataFrame({"a": ["Crab", "cat and dog", "rab$bit", None]})
+        >>> df = pl.DataFrame({"txt": ["Crab", "cat and dog", "rab$bit", None]})
         >>> df.select(
-        ...     pl.col("a"),
-        ...     pl.col("a").str.contains("cat|bit").alias("regex"),
-        ...     pl.col("a").str.contains("rab$", literal=True).alias("literal"),
+        ...     pl.col("txt"),
+        ...     pl.col("txt").str.contains("cat|bit").alias("regex"),
+        ...     pl.col("txt").str.contains("rab$", literal=True).alias("literal"),
         ... )
         shape: (4, 3)
         ┌─────────────┬───────┬─────────┐
-        │ a           ┆ regex ┆ literal │
+        │ txt         ┆ regex ┆ literal │
         │ ---         ┆ ---   ┆ ---     │
         │ str         ┆ bool  ┆ bool    │
         ╞═════════════╪═══════╪═════════╡
@@ -1018,6 +1019,99 @@ class ExprStringNameSpace:
         """
         pattern = parse_as_expression(pattern, str_as_lit=True)
         return wrap_expr(self._pyexpr.str_contains(pattern, literal, strict))
+
+    def find(
+        self, pattern: str | Expr, *, literal: bool = False, strict: bool = True
+    ) -> Expr:
+        """
+        Return the index position of the first substring matching a pattern.
+
+        If the pattern is not present, returns None.
+
+        Parameters
+        ----------
+        pattern
+            A valid regular expression pattern, compatible with the `regex crate
+            <https://docs.rs/regex/latest/regex/>`_.
+        literal
+            Treat `pattern` as a literal string, not as a regular expression.
+        strict
+            Raise an error if the underlying pattern is not a valid regex,
+            otherwise mask out with a null value.
+
+        Notes
+        -----
+        To modify regular expression behaviour (such as case-sensitivity) with
+        flags, use the inline `(?iLmsuxU)` syntax. For example:
+
+        >>> pl.DataFrame({"s": ["AAA", "aAa", "aaa"]}).with_columns(
+        ...     default_match=pl.col("s").str.find("Aa"),
+        ...     insensitive_match=pl.col("s").str.find("(?i)Aa"),
+        ... )
+        shape: (3, 3)
+        ┌─────┬───────────────┬───────────────────┐
+        │ s   ┆ default_match ┆ insensitive_match │
+        │ --- ┆ ---           ┆ ---               │
+        │ str ┆ i64           ┆ i64               │
+        ╞═════╪═══════════════╪═══════════════════╡
+        │ AAA ┆ null          ┆ 0                 │
+        │ aAa ┆ 1             ┆ 0                 │
+        │ aaa ┆ null          ┆ 0                 │
+        └─────┴───────────────┴───────────────────┘
+
+        See the regex crate's section on `grouping and flags
+        <https://docs.rs/regex/latest/regex/#grouping-and-flags>`_ for
+        additional information about the use of inline expression modifiers.
+
+        See Also
+        --------
+        contains : Check if string contains a substring that matches a regex.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "txt": ["Crab", "Lobster", None, "Crustaceon"],
+        ...         "pat": ["a[bc]", "b.t", "[aeiuo]", "(?i)A[BC]"],
+        ...     }
+        ... )
+
+        Find the index of the first substring matching a regex or literal pattern:
+
+        >>> df.select(
+        ...     pl.col("txt"),
+        ...     pl.col("txt").str.find("a|e").alias("a|e (regex)"),
+        ...     pl.col("txt").str.find("e", literal=True).alias("e (lit)"),
+        ... )
+        shape: (4, 3)
+        ┌────────────┬─────────────┬─────────┐
+        │ txt        ┆ a|e (regex) ┆ e (lit) │
+        │ ---        ┆ ---         ┆ ---     │
+        │ str        ┆ i64         ┆ i64     │
+        ╞════════════╪═════════════╪═════════╡
+        │ Crab       ┆ 2           ┆ null    │
+        │ Lobster    ┆ 5           ┆ 5       │
+        │ null       ┆ null        ┆ null    │
+        │ Crustaceon ┆ 5           ┆ 7       │
+        └────────────┴─────────────┴─────────┘
+
+        Match against a pattern found in another column or (expression):
+
+        >>> df.with_columns(pl.col("txt").str.find(pl.col("pat")).alias("find_pat"))
+        shape: (4, 3)
+        ┌────────────┬───────────┬──────────┐
+        │ txt        ┆ pat       ┆ find_pat │
+        │ ---        ┆ ---       ┆ ---      │
+        │ str        ┆ str       ┆ i64      │
+        ╞════════════╪═══════════╪══════════╡
+        │ Crab       ┆ a[bc]     ┆ 2        │
+        │ Lobster    ┆ b.t       ┆ 2        │
+        │ null       ┆ [aeiuo]   ┆ null     │
+        │ Crustaceon ┆ (?i)A[BC] ┆ 5        │
+        └────────────┴───────────┴──────────┘
+        """
+        pattern = parse_as_expression(pattern, str_as_lit=True)
+        return wrap_expr(self._pyexpr.str_find(pattern, literal, strict))
 
     def ends_with(self, suffix: str | Expr) -> Expr:
         """
@@ -1298,8 +1392,8 @@ class ExprStringNameSpace:
         Parameters
         ----------
         pattern
-            A valid regular expression pattern, compatible with the `regex crate
-            <https://docs.rs/regex/latest/regex/>`_.
+            A valid regular expression pattern containing at least one capture group,
+            compatible with the `regex crate <https://docs.rs/regex/latest/regex/>`_.
         group_index
             Index of the targeted capture group.
             Group 0 means the whole pattern, the first group begins at index 1.
@@ -1466,8 +1560,8 @@ class ExprStringNameSpace:
         Parameters
         ----------
         pattern
-            A valid regular expression pattern, compatible with the `regex crate
-            <https://docs.rs/regex/latest/regex/>`_.
+            A valid regular expression pattern containing at least one capture group,
+            compatible with the `regex crate <https://docs.rs/regex/latest/regex/>`_.
 
         Notes
         -----

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -1052,7 +1052,7 @@ class ExprStringNameSpace:
         ┌─────┬───────────────┬───────────────────┐
         │ s   ┆ default_match ┆ insensitive_match │
         │ --- ┆ ---           ┆ ---               │
-        │ str ┆ i64           ┆ i64               │
+        │ str ┆ u32           ┆ u32               │
         ╞═════╪═══════════════╪═══════════════════╡
         │ AAA ┆ null          ┆ 0                 │
         │ aAa ┆ 1             ┆ 0                 │
@@ -1087,7 +1087,7 @@ class ExprStringNameSpace:
         ┌────────────┬─────────────┬─────────┐
         │ txt        ┆ a|e (regex) ┆ e (lit) │
         │ ---        ┆ ---         ┆ ---     │
-        │ str        ┆ i64         ┆ i64     │
+        │ str        ┆ u32         ┆ u32     │
         ╞════════════╪═════════════╪═════════╡
         │ Crab       ┆ 2           ┆ null    │
         │ Lobster    ┆ 5           ┆ 5       │
@@ -1102,7 +1102,7 @@ class ExprStringNameSpace:
         ┌────────────┬───────────┬──────────┐
         │ txt        ┆ pat       ┆ find_pat │
         │ ---        ┆ ---       ┆ ---      │
-        │ str        ┆ str       ┆ i64      │
+        │ str        ┆ str       ┆ u32      │
         ╞════════════╪═══════════╪══════════╡
         │ Crab       ┆ a[bc]     ┆ 2        │
         │ Lobster    ┆ b.t       ┆ 2        │

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -194,18 +194,16 @@ def read_csv(
     --------
     >>> pl.read_csv("data.csv", separator="|")  # doctest: +SKIP
 
-    Reproducible example using BytesIO object, parsing dates.
+    Demonstrate use against a BytesIO object, parsing string dates.
 
-    >>> import io  # doctest: +SKIP
-    >>> source = io.BytesIO(
-    ...     (
-    ...         "ID,Name,Birthday\n"
-    ...         "1,Alice,1995-07-12\n"
-    ...         "2,Bob,1990-09-20\n"
-    ...         "3,Charlie,2002-03-08"
-    ...     ).encode()
-    ... )  # doctest: +SKIP
-    >>> pl.read_csv(source, try_parse_dates=True)  # doctest: +SKIP
+    >>> from io import BytesIO
+    >>> data = BytesIO(
+    ...     b"ID,Name,Birthday\n"
+    ...     b"1,Alice,1995-07-12\n"
+    ...     b"2,Bob,1990-09-20\n"
+    ...     b"3,Charlie,2002-03-08\n"
+    ... )
+    >>> pl.read_csv(data, try_parse_dates=True)
     shape: (3, 3)
     ┌─────┬─────────┬────────────┐
     │ ID  ┆ Name    ┆ Birthday   │

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -538,7 +538,7 @@ class StringNameSpace:
 
         >>> s.str.find("a|e").rename("idx_rx")
         shape: (4,)
-        Series: 'idx_rx' [i64]
+        Series: 'idx_rx' [u32]
         [
             2
             5
@@ -550,9 +550,9 @@ class StringNameSpace:
 
         >>> s.str.find("e", literal=True).rename("idx_lit")
         shape: (4,)
-        Series: 'idx_lit' [i64]
+        Series: 'idx_lit' [u32]
         [
-            -1
+            null
             5
             null
             7
@@ -563,7 +563,7 @@ class StringNameSpace:
         >>> p = pl.Series("pat", ["a[bc]", "b.t", "[aeiuo]", "(?i)A[BC]"])
         >>> s.str.find(p).rename("idx")
         shape: (4,)
-        Series: 'idx' [i64]
+        Series: 'idx' [u32]
         [
             2
             2

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -492,7 +492,7 @@ class StringNameSpace:
         """
         Return the index of the first substring in Series strings matching a pattern.
 
-        If the pattern is not present, returns None.
+        If the pattern is not found, returns None.
 
         Parameters
         ----------

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -486,6 +486,92 @@ class StringNameSpace:
         ]
         """
 
+    def find(
+        self, pattern: str | Expr, *, literal: bool = False, strict: bool = True
+    ) -> Expr:
+        """
+        Return the index of the first substring in Series strings matching a pattern.
+
+        If the pattern is not present, returns None.
+
+        Parameters
+        ----------
+        pattern
+            A valid regular expression pattern, compatible with the `regex crate
+            <https://docs.rs/regex/latest/regex/>`_.
+        literal
+            Treat `pattern` as a literal string, not as a regular expression.
+        strict
+            Raise an error if the underlying pattern is not a valid regex,
+            otherwise mask out with a null value.
+
+        Notes
+        -----
+        To modify regular expression behaviour (such as case-sensitivity) with
+        flags, use the inline `(?iLmsuxU)` syntax. For example:
+
+        >>> s = pl.Series("s", ["AAA", "aAa", "aaa"])
+
+        Default (case-sensitive) match:
+
+        >>> s.str.find("Aa").to_list()
+        [None, 1, None]
+
+        Case-insensitive match, using an inline flag:
+
+        >>> s.str.find("(?i)Aa").to_list()
+        [0, 0, 0]
+
+        See the regex crate's section on `grouping and flags
+        <https://docs.rs/regex/latest/regex/#grouping-and-flags>`_ for
+        additional information about the use of inline expression modifiers.
+
+        See Also
+        --------
+        contains : Check if string contains a substring that matches a regex.
+
+        Examples
+        --------
+        >>> s = pl.Series("txt", ["Crab", "Lobster", None, "Crustaceon"])
+
+        Find the index of the first substring matching a regex pattern:
+
+        >>> s.str.find("a|e").rename("idx_rx")
+        shape: (4,)
+        Series: 'idx_rx' [i64]
+        [
+            2
+            5
+            null
+            5
+        ]
+
+        Find the index of the first substring matching a literal pattern:
+
+        >>> s.str.find("e", literal=True).rename("idx_lit")
+        shape: (4,)
+        Series: 'idx_lit' [i64]
+        [
+            -1
+            5
+            null
+            7
+        ]
+
+        Match against a pattern found in another column or (expression):
+
+        >>> p = pl.Series("pat", ["a[bc]", "b.t", "[aeiuo]", "(?i)A[BC]"])
+        >>> s.str.find(p).rename("idx")
+        shape: (4,)
+        Series: 'idx' [i64]
+        [
+            2
+            2
+            null
+            5
+        ]
+        """
+
     def ends_with(self, suffix: str | Expr) -> Series:
         """
         Check if string values end with a substring.
@@ -660,8 +746,8 @@ class StringNameSpace:
         Parameters
         ----------
         pattern
-            A valid regular expression pattern, compatible with the `regex crate
-            <https://docs.rs/regex/latest/regex/>`_.
+            A valid regular expression pattern containing at least one capture group,
+            compatible with the `regex crate <https://docs.rs/regex/latest/regex/>`_.
         group_index
             Index of the targeted capture group.
             Group 0 means the whole pattern, the first group begins at index 1.
@@ -794,8 +880,8 @@ class StringNameSpace:
         Parameters
         ----------
         pattern
-            A valid regular expression pattern, compatible with the `regex crate
-            <https://docs.rs/regex/latest/regex/>`_.
+            A valid regular expression pattern containing at least one capture group,
+            compatible with the `regex crate <https://docs.rs/regex/latest/regex/>`_.
 
         Notes
         -----

--- a/py-polars/src/expr/string.rs
+++ b/py-polars/src/expr/string.rs
@@ -166,6 +166,15 @@ impl PyExpr {
         }
     }
 
+    #[pyo3(signature = (pat, literal, strict))]
+    #[cfg(feature = "lazy_regex")]
+    fn str_find(&self, pat: Self, literal: Option<bool>, strict: bool) -> Self {
+        match literal {
+            Some(true) => self.inner.clone().str().find_literal(pat.inner).into(),
+            _ => self.inner.clone().str().find(pat.inner, strict).into(),
+        }
+    }
+
     fn str_ends_with(&self, sub: Self) -> Self {
         self.inner.clone().str().ends_with(sub.inner).into()
     }


### PR DESCRIPTION
Implements expressified `str.find` string functionality for `Expr` and `Series`, returning the index/position of a given pattern (regex or literal) in the underlying string. Returns ~~`-1`~~ _(updated)_ `None` if the pattern is not found.

(Also closes #13552 by adding a note about requiring a capture group in the given regex in the `extract` and `extract_groups` docstrings).

## Example

```python
import polars as pl

df = pl.DataFrame(
    data=[
        ("Dubai", 3564931, "b[ai]"),
        ("Abu Dhabi", 1807000, "b[ai]"),
        ("Sharjah", 1405000, "[ai]n"),
        ("Al Ain", 846747, "[ai]+n"),
        ("Ajman", 490035, "[ai]n"),
        ("Ras Al Khaimah", 191753, "a.+a"),
        ("Fujairah", 118933, "a.+a"),
        ("Umm Al Quwain", 59098, "a.+a"),
    ],
    schema={"city": pl.String, "population": pl.Int32, "pattern": pl.String},
)

df.with_columns(
    rx_a = pl.col("city").str.find("(?i)a"),
    lit_a = pl.col("city").str.find("a", literal=True),
    lit_00 = pl.col("population").cast(pl.String).str.find("00", literal=True),
    find_col = pl.col("city").str.find(pl.col("pattern")),
)
# shape: (8, 7)
# ┌────────────────┬────────────┬─────────┬──────┬───────┬────────┬──────────┐
# │ city           ┆ population ┆ pattern ┆ rx_a ┆ lit_a ┆ lit_00 ┆ find_col │
# │ ---            ┆ ---        ┆ ---     ┆ ---  ┆ ---   ┆ ---    ┆ ---      │
# │ str            ┆ i32        ┆ str     ┆ u32  ┆ u32   ┆ u32    ┆ u32      │
# ╞════════════════╪════════════╪═════════╪══════╪═══════╪════════╪══════════╡
# │ Dubai          ┆ 3564931    ┆ b[ai]   ┆ 3    ┆ 3     ┆ null   ┆ 2        │
# │ Abu Dhabi      ┆ 1807000    ┆ b[ai]   ┆ 0    ┆ 6     ┆ 4      ┆ 7        │
# │ Sharjah        ┆ 1405000    ┆ [ai]n   ┆ 2    ┆ 2     ┆ 4      ┆ null     │
# │ Al Ain         ┆ 846747     ┆ [ai]n   ┆ 0    ┆ null  ┆ null   ┆ 4        │
# │ Ajman          ┆ 490035     ┆ [ai]n   ┆ 0    ┆ 3     ┆ 2      ┆ 3        │
# │ Ras Al Khaimah ┆ 191753     ┆ a.+a    ┆ 1    ┆ 1     ┆ null   ┆ 1        │
# │ Fujairah       ┆ 118933     ┆ a.+a    ┆ 3    ┆ 3     ┆ null   ┆ 3        │
# │ Umm Al Quwain  ┆ 59098      ┆ a.+a    ┆ 4    ┆ 10    ┆ null   ┆ null     │
# └────────────────┴────────────┴─────────┴──────┴───────┴────────┴──────────┘
```