### PR TITLE
fix: Treat Python `None` as null value for `Object` dtype

### DIFF
--- a/crates/polars-core/src/chunked_array/object/builder.rs
+++ b/crates/polars-core/src/chunked_array/object/builder.rs
@@ -163,6 +163,27 @@ where
         }
     }
 
+    pub fn new_from_vec_and_validity(name: &str, v: Vec<T>, validity: Bitmap) -> Self {
+        let field = Arc::new(Field::new(name, DataType::Object(T::type_name(), None)));
+        let len = v.len();
+        let null_count = validity.unset_bits();
+        let arr = Box::new(ObjectArray {
+            values: Arc::new(v),
+            null_bitmap: Some(validity),
+            offset: 0,
+            len,
+        });
+
+        ObjectChunked {
+            field,
+            chunks: vec![arr],
+            phantom: PhantomData,
+            bit_settings: Default::default(),
+            length: len as IdxSize,
+            null_count: null_count as IdxSize,
+        }
+    }
+
     pub fn new_empty(name: &str) -> Self {
         Self::new_from_vec(name, vec![])
     }

--- a/crates/polars-core/src/chunked_array/ops/any_value.rs
+++ b/crates/polars-core/src/chunked_array/ops/any_value.rs
@@ -277,10 +277,7 @@ impl<T: PolarsObject> ChunkAnyValue for ObjectChunked<T> {
     }
 
     fn get_any_value(&self, index: usize) -> PolarsResult<AnyValue> {
-        match self.get_object(index) {
-            None => Err(polars_err!(ComputeError: "index is out of bounds")),
-            Some(v) => Ok(AnyValue::Object(v)),
-        }
+        get_any_value!(self, index)
     }
 }
 

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -410,7 +410,7 @@ pub fn lit(value: &PyAny, allow_object: bool) -> PyResult<PyExpr> {
         Ok(dsl::lit(value.as_bytes()).into())
     } else if allow_object {
         let s = Python::with_gil(|py| {
-            PySeries::new_object("", vec![ObjectValue::from(value.into_py(py))], false).series
+            PySeries::new_object(py, "", vec![ObjectValue::from(value.into_py(py))], false).series
         });
         Ok(dsl::lit(s).into())
     } else {

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -37,6 +37,37 @@ def test_object_in_struct() -> None:
     assert (arr == np_b).sum() == 3
 
 
+def test_nullable_object_13538() -> None:
+    df = pl.DataFrame(
+        data=[
+            ({"a": 1},),
+            ({"b": 3},),
+            (None,),
+        ],
+        schema=[
+            ("blob", pl.Object),
+        ],
+        orient="row",
+    )
+
+    df = df.select(
+        is_null=pl.col("blob").is_null(), is_not_null=pl.col("blob").is_not_null()
+    )
+    assert df.to_dict(as_series=False) == {
+        "is_null": [False, False, True],
+        "is_not_null": [True, True, False],
+    }
+
+    df = pl.DataFrame({"col": pl.Series([0, 1, 2, None], dtype=pl.Object)})
+    df = df.select(
+        is_null=pl.col("col").is_null(), is_not_null=pl.col("col").is_not_null()
+    )
+    assert df.to_dict(as_series=False) == {
+        "is_null": [False, False, False, True],
+        "is_not_null": [True, True, True, False],
+    }
+
+
 def test_empty_sort() -> None:
     df = pl.DataFrame(
         data=[

--- a/py-polars/tests/unit/datatypes/test_object.py
+++ b/py-polars/tests/unit/datatypes/test_object.py
@@ -131,3 +131,25 @@ def test_object_apply_to_struct() -> None:
     s = pl.Series([0, 1, 2], dtype=pl.Object)
     out = s.map_elements(lambda x: {"a": str(x), "b": x})
     assert out.dtype == pl.Struct([pl.Field("a", pl.String), pl.Field("b", pl.Int64)])
+
+
+def test_null_obj_str_13512() -> None:
+    df1 = pl.DataFrame(
+        {
+            "key": [1],
+        }
+    )
+    df2 = pl.DataFrame({"key": [2], "a": pl.Series([1], dtype=pl.Object)})
+
+    out = df1.join(df2, on="key", how="left")
+    s = str(out)
+    assert s == (
+        "shape: (1, 2)\n"
+        "┌─────┬────────┐\n"
+        "│ key ┆ a      │\n"
+        "│ --- ┆ ---    │\n"
+        "│ i64 ┆ object │\n"
+        "╞═════╪════════╡\n"
+        "│ 1   ┆ null   │\n"
+        "└─────┴────────┘"
+    )


### PR DESCRIPTION
This fixes #13538.

Alos fixes #13512.