### PR TITLE
Add logic for no reversal

### DIFF
--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -222,19 +222,23 @@ pub fn cum_count(s: &Series, reverse: bool) -> PolarsResult<Series> {
         return Ok(out);
     }
 
-    let mut count = 0 as IdxSize;
-    let f = |v: bool| {
-        if v {
-            count += 1
-        }
-        count
-    };
-
     let ca = s.is_not_null();
     let out: IdxCa = if reverse {
-        ca.reverse().apply_values_generic(f).reverse()
+        let mut count = (s.len() - s.null_count()) as IdxSize;
+        let mut decr: IdxSize = 0;
+        ca.apply_values_generic(|v: bool| {
+            count -= decr;
+            decr = v as IdxSize;
+            count
+        })
     } else {
-        ca.apply_values_generic(f)
+        let mut count = 0 as IdxSize;
+        ca.apply_values_generic(|v: bool| {
+            if v {
+                count += 1;
+            }
+            count
+        })
     };
     Ok(out.into())
 }


### PR DESCRIPTION
@stinodego here's the alternative impl with no reversals, you can probably improve it but it's a decent proof-of-concept. Using your doc test:

```python
import polars as pl

df = pl.DataFrame({"a": ["x", "k", None, "d"]})

df.with_columns(
    pl.col("a").cum_count().alias("cum_count"),
    pl.col("a").cum_count(reverse=True).alias("cum_count_reverse"),
)
```
```
shape: (4, 3)
┌──────┬───────────┬───────────────────┐
│ a    ┆ cum_count ┆ cum_count_reverse │
│ ---  ┆ ---       ┆ ---               │
│ str  ┆ u32       ┆ u32               │
╞══════╪═══════════╪═══════════════════╡
│ x    ┆ 1         ┆ 3                 │
│ k    ┆ 2         ┆ 2                 │
│ null ┆ 2         ┆ 1                 │
│ d    ┆ 3         ┆ 1                 │
└──────┴───────────┴───────────────────┘
```