### PR TITLE
chore: Remove extra line break between checkboxes in GitHub bug report issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_python.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_python.yml
@@ -8,10 +8,10 @@ body:
     attributes:
       label: Checks
       options:
-        - label: >
+        - label:
             I have checked that this issue has not already been reported.
           required: true
-        - label: >
+        - label:
             I have confirmed this bug exists on the
             [latest version](https://pypi.org/project/polars/) of Polars.
           required: true

--- a/.github/ISSUE_TEMPLATE/bug_report_python.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_python.yml
@@ -8,12 +8,9 @@ body:
     attributes:
       label: Checks
       options:
-        - label:
-            I have checked that this issue has not already been reported.
+        - label: I have checked that this issue has not already been reported.
           required: true
-        - label:
-            I have confirmed this bug exists on the
-            [latest version](https://pypi.org/project/polars/) of Polars.
+        - label: I have confirmed this bug exists on the [latest version](https://pypi.org/project/polars/) of Polars.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report_rust.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_rust.yml
@@ -8,12 +8,9 @@ body:
     attributes:
       label: Checks
       options:
-        - label:
-            I have checked that this issue has not already been reported.
+        - label: I have checked that this issue has not already been reported.
           required: true
-        - label:
-            I have confirmed this bug exists on the
-            [latest version](https://crates.io/crates/polars) of Polars.
+        - label: I have confirmed this bug exists on the [latest version](https://crates.io/crates/polars) of Polars.
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report_rust.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_rust.yml
@@ -8,10 +8,10 @@ body:
     attributes:
       label: Checks
       options:
-        - label: >
+        - label:
             I have checked that this issue has not already been reported.
           required: true
-        - label: >
+        - label:
             I have confirmed this bug exists on the
             [latest version](https://crates.io/crates/polars) of Polars.
           required: true


### PR DESCRIPTION
I'm not sure if this actually fixes the issue since the [preview in the main branch](https://github.com/pola-rs/polars/blob/main/.github/ISSUE_TEMPLATE/bug_report_python.yml) doesn't actually show the extra line break, but you can see it when you click on almost any issue.

I looked up the yaml specs and the [section on scalars](https://yaml.org/spec/1.2.2/#23-scalars) seems to indicate that using > where the next line has indented code causes a newline, so my hope is that this removes the extra newline. But I'm not really sure how to test this.