### PR TITLE
fix(python): Fix `scatter` to allow single temporal inputs

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4522,23 +4522,8 @@ class Series:
 
     def scatter(
         self,
-        indices: Series | np.ndarray[Any, Any] | Sequence[int] | int,
-        values: (
-            int
-            | float
-            | str
-            | bool
-            | date
-            | datetime
-            | Sequence[int]
-            | Sequence[float]
-            | Sequence[bool]
-            | Sequence[str]
-            | Sequence[date]
-            | Sequence[datetime]
-            | Series
-            | None
-        ),
+        indices: Series | Iterable[int] | int | np.ndarray[Any, Any],
+        values: Series | Iterable[PythonLiteral] | PythonLiteral | None,
     ) -> Series:
         """
         Set values at the index locations.
@@ -4584,20 +4569,17 @@ class Series:
         │ 3       │
         └─────────┘
         """
-        if isinstance(indices, int):
-            indices = [indices]
-        if len(indices) == 0:
+        if not isinstance(indices, Iterable):
+            indices = [indices]  # type: ignore[list-item]
+        indices = Series(values=indices)
+        if indices.is_empty():
             return self
 
-        indices = Series("", indices)
-        if isinstance(values, (int, float, bool, str)) or (values is None):
-            values = Series("", [values])
+        if not isinstance(values, Series):
+            if not isinstance(values, Iterable) or isinstance(values, str):
+                values = [values]
+            values = Series(values=values)
 
-            # if we need to set more than a single value, we extend it
-            if len(indices) > 0:
-                values = values.extend_constant(values[0], len(indices) - 1)
-        elif not isinstance(values, Series):
-            values = Series("", values)
         self._s.scatter(indices._s, values._s)
         return self
 

--- a/py-polars/src/series/scatter.rs
+++ b/py-polars/src/series/scatter.rs
@@ -36,7 +36,12 @@ fn scatter(mut s: Series, idx: &Series, values: &Series) -> PolarsResult<Series>
 
     let idx = idx.values().as_slice();
 
-    let values = values.to_physical_repr().cast(&s.dtype().to_physical())?;
+    let mut values = values.to_physical_repr().cast(&s.dtype().to_physical())?;
+
+    // Broadcast values input
+    if values.len() == 1 && idx.len() > 1 {
+        values = values.new_from_index(0, idx.len());
+    }
 
     // do not shadow, otherwise s is not dropped immediately
     // and we want to have mutable access

--- a/py-polars/tests/unit/series/test_scatter.py
+++ b/py-polars/tests/unit/series/test_scatter.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import numpy as np
 import pytest
 
@@ -56,4 +58,11 @@ def test_set_at_idx_deprecated() -> None:
     with pytest.deprecated_call():
         result = s.set_at_idx(1, 10)
     expected = pl.Series("s", [1, 10, 3])
+    assert_series_equal(result, expected)
+
+
+def test_scatter_datetime() -> None:
+    s = pl.Series("dt", [None, datetime(2024, 1, 31)])
+    result = s.scatter(0, datetime(2022, 2, 2))
+    expected = pl.Series("dt", [datetime(2022, 2, 2), datetime(2024, 1, 31)])
     assert_series_equal(result, expected)


### PR DESCRIPTION
Ref #13547 (not a fix, just running into issues as I look into this)