### PR TITLE
fix: Fix `scatter` for null values

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -60,10 +60,22 @@ impl<T: PolarsDataType> ChunkedArray<T> {
         self.length as usize
     }
 
-    /// Count the null values.
+    /// Return the number of null values in the ChunkedArray.
     #[inline]
     pub fn null_count(&self) -> usize {
         self.null_count as usize
+    }
+
+    /// Set the null count directly.
+    ///
+    /// This can be useful after mutably adjusting the validity of the
+    /// underlying arrays.
+    ///
+    /// # Safety
+    /// The new null count must match the total null count of the underlying
+    /// arrays.
+    pub unsafe fn set_null_count(&mut self, null_count: IdxSize) {
+        self.null_count = null_count;
     }
 
     /// Check if ChunkedArray is empty.

--- a/crates/polars-ops/src/chunked_array/scatter.rs
+++ b/crates/polars-ops/src/chunked_array/scatter.rs
@@ -125,6 +125,11 @@ where
                 arr.set_values(new_values.into());
             },
         };
+
+        // The null count may have changed - make sure to update the ChunkedArray
+        let new_null_count = arr.null_count();
+        unsafe { ca.set_null_count(new_null_count.try_into().unwrap()) };
+
         Ok(ca.into_series())
     }
 }

--- a/py-polars/tests/unit/series/test_scatter.py
+++ b/py-polars/tests/unit/series/test_scatter.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 
 import numpy as np
 import pytest
@@ -65,4 +65,11 @@ def test_scatter_datetime() -> None:
     s = pl.Series("dt", [None, datetime(2024, 1, 31)])
     result = s.scatter(0, datetime(2022, 2, 2))
     expected = pl.Series("dt", [datetime(2022, 2, 2), datetime(2024, 1, 31)])
+    assert_series_equal(result, expected)
+
+
+def test_scatter_logical_all_null() -> None:
+    s = pl.Series("dt", [None, None], dtype=pl.Date)
+    result = s.scatter(0, date(2022, 2, 2))
+    expected = pl.Series("dt", [date(2022, 2, 2), None])
     assert_series_equal(result, expected)


### PR DESCRIPTION
Closes #13547