### PR TITLE
chore: Filter unhelpful messages in `make build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,39 +24,57 @@ requirements: .venv  ## Install/refresh Python project requirements
 
 .PHONY: build
 build: .venv  ## Compile and install Python Polars for development
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	&& maturin develop -m py-polars/Cargo.toml \
+	| grep -v "don't match your environment" || true
 
 .PHONY: build-debug-opt
 build-debug-opt: .venv  ## Compile and install Python Polars with minimal optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --profile opt-dev
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	 && maturin develop -m py-polars/Cargo.toml --profile opt-dev \
+	| grep -v "don't match your environment" || true
 
 .PHONY: build-debug-opt-subset
 build-debug-opt-subset: .venv  ## Compile and install Python Polars with minimal optimizations turned on and no default features
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --no-default-features --profile opt-dev
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	&& maturin develop -m py-polars/Cargo.toml --no-default-features --profile opt-dev \
+	| grep -v "don't match your environment" || true
 
 .PHONY: build-opt
 build-opt: .venv  ## Compile and install Python Polars with nearly full optimization on and debug assertions turned off, but with debug symbols on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --profile debug-release
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	&& maturin develop -m py-polars/Cargo.toml --profile debug-release \
+	| grep -v "don't match your environment" || true
 
 .PHONY: build-release
 build-release: .venv  ## Compile and install a faster Python Polars binary with full optimizations
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --release
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	&& maturin develop -m py-polars/Cargo.toml --release \
+	| grep -v "don't match your environment" || true
 
 .PHONY: build-native
 build-native: .venv  ## Same as build, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml -- -C target-cpu=native
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	&& maturin develop -m py-polars/Cargo.toml -- -C target-cpu=native \
+	| grep -v "don't match your environment" || true
 
 .PHONY: build-debug-opt-native
 build-debug-opt-native: .venv  ## Same as build-debug-opt, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --profile opt-dev -- -C target-cpu=native
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	&& maturin develop -m py-polars/Cargo.toml --profile opt-dev -- -C target-cpu=native \
+	| grep -v "don't match your environment" || true
 
 .PHONY: build-opt-native
 build-opt-native: .venv  ## Same as build-opt, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --profile debug-release -- -C target-cpu=native
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	&& maturin develop -m py-polars/Cargo.toml --profile debug-release -- -C target-cpu=native \
+	| grep -v "don't match your environment" || true
 
 .PHONY: build-release-native
 build-release-native: .venv  ## Same as build-release, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate && maturin develop -m py-polars/Cargo.toml --release -- -C target-cpu=native
+	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	&& maturin develop -m py-polars/Cargo.toml --release -- -C target-cpu=native \
+	| grep -v "don't match your environment" || true
 
 .PHONY: clippy
 clippy:  ## Run clippy with all features


### PR DESCRIPTION
Before:

```
$ make build
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.8
🐍 Not using a specific python interpreter
Ignoring adbc_driver_sqlite: markers 'extra == "adbc"' don't match your environment
Ignoring cloudpickle: markers 'extra == "cloudpickle"' don't match your environment
Ignoring connectorx: markers 'extra == "connectorx"' don't match your environment
Ignoring deltalake: markers 'extra == "deltalake"' don't match your environment
Ignoring fsspec: markers 'extra == "fsspec"' don't match your environment
Ignoring gevent: markers 'extra == "gevent"' don't match your environment
Ignoring hvplot: markers 'extra == "plot"' don't match your environment
Ignoring matplotlib: markers 'extra == "matplotlib"' don't match your environment
Ignoring numpy: markers 'extra == "numpy"' don't match your environment
Ignoring openpyxl: markers 'extra == "openpyxl"' don't match your environment
Ignoring pyarrow: markers 'extra == "pandas"' don't match your environment
Ignoring pandas: markers 'extra == "pandas"' don't match your environment
Ignoring pyarrow: markers 'extra == "pyarrow"' don't match your environment
Ignoring pydantic: markers 'extra == "pydantic"' don't match your environment
Ignoring pyiceberg: markers 'extra == "pyiceberg"' don't match your environment
Ignoring pyxlsb: markers 'extra == "pyxlsb"' don't match your environment
Ignoring sqlalchemy: markers 'extra == "sqlalchemy"' don't match your environment
Ignoring pandas: markers 'extra == "sqlalchemy"' don't match your environment
Ignoring backports.zoneinfo: markers 'python_version < "3.9" and extra == "timezone"' don't match your environment
Ignoring tzdata: markers 'platform_system == "Windows" and extra == "timezone"' don't match your environment
Ignoring xlsx2csv: markers 'extra == "xlsx2csv"' don't match your environment
Ignoring xlsxwriter: markers 'extra == "xlsxwriter"' don't match your environment
Ignoring polars: markers 'extra == "all"' don't match your environment
    Finished dev [unoptimized + debuginfo] target(s) in 0.12s
📦 Built wheel for abi3 Python ≥ 3.8 to /tmp/.tmppnfZQr/polars-0.20.3-cp38-abi3-linux_x86_64.whl
🛠 Installed polars-0.20.3
```

After:
```
$ make build
🍹 Building a mixed python/rust project
🔗 Found pyo3 bindings with abi3 support for Python ≥ 3.8
🐍 Not using a specific python interpreter
    Finished dev [unoptimized + debuginfo] target(s) in 0.12s
📦 Built wheel for abi3 Python ≥ 3.8 to /tmp/.tmp5MoWf9/polars-0.20.3-cp38-abi3-linux_x86_64.whl
🛠 Installed polars-0.20.3
```

Apparently, this has to do with how `pip` works and `maturin` cannot cleanly handle this:
https://github.com/PyO3/maturin/discussions/1698

So I updated our Makefile to ignore those messages.