### PR TITLE
feat(rust,python,cli): add SQL engine support for `POSITION` and `STRPOS`

### DIFF
--- a/py-polars/docs/source/reference/expressions/string.rst
+++ b/py-polars/docs/source/reference/expressions/string.rst
@@ -21,6 +21,7 @@ The following methods are available under the `expr.str` attribute.
     Expr.str.extract
     Expr.str.extract_all
     Expr.str.extract_groups
+    Expr.str.find
     Expr.str.json_decode
     Expr.str.json_extract
     Expr.str.json_path_match


### PR DESCRIPTION
Building on `str.find` (and adding its missing API docs entry!), this PR adds SQL support for the `POSITION` and `STRPOS`[^1] functions.

## Example

```python
import polars as pl

df = pl.DataFrame({"txt": ["AbCdEXz", "XyzFDkE"]})

with pl.SQLContext(txt=df) as ctx:
    print(ctx.execute(
        """
        SELECT
          txt,
          POSITION('C' IN txt) AS find_C,
          POSITION('E' IN txt) AS find_E,
          STRPOS(txt,'D') AS find_D,
          STRPOS(txt,'X') AS find_X
        FROM txt
        """
    ).collect())

    # shape: (2, 5)
    # ┌─────────┬────────┬────────┬────────┬────────┐
    # │ txt     ┆ find_C ┆ find_E ┆ find_D ┆ find_X │
    # │ ---     ┆ ---    ┆ ---    ┆ ---    ┆ ---    │
    # │ str     ┆ u32    ┆ u32    ┆ u32    ┆ u32    │
    # ╞═════════╪════════╪════════╪════════╪════════╡
    # │ AbCdEXz ┆ 3      ┆ 5      ┆ 0      ┆ 6      │
    # │ XyzFDkE ┆ 0      ┆ 7      ┆ 5      ┆ 1      │
    # └─────────┴────────┴────────┴────────┴────────┘
```
[^1]: https://www.postgresql.org/docs/current/functions-string.html#FUNCTIONS-STRING-SQL