### PR TITLE
fix(python): Fix formatting in `describe` for precise quantiles

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4404,7 +4404,7 @@ class DataFrame:
                 expr = F.col(c).quantile(p) if c in stat_cols else F.lit(None)
                 expr = expr.alias(f"{p}:{c}")
                 percentile_exprs.append(expr)
-            metrics.append(f"{p:.0%}")
+            metrics.append(f"{p*100:g}%")
         metrics.append("max")
 
         mean_exprs = [

--- a/py-polars/tests/unit/dataframe/test_describe.py
+++ b/py-polars/tests/unit/dataframe/test_describe.py
@@ -157,3 +157,12 @@ def test_df_describe_empty() -> None:
         TypeError, match="cannot describe a DataFrame without any columns"
     ):
         df.describe()
+
+
+def test_df_describe_quantile_precision() -> None:
+    df = pl.DataFrame({"a": range(10)})
+    result = df.describe(percentiles=[0.99, 0.999, 0.9999])
+    result_metrics = result.get_column("describe").to_list()
+    expected_metrics = ["99%", "99.9%", "99.99%"]
+    for m in expected_metrics:
+        assert m in result_metrics


### PR DESCRIPTION
Supersedes #12336

Credit to @chrstfer for signalling this issue.