### PR TITLE
chore: Add `Documentation` / `Build system` sections to the changelog

### DIFF
--- a/.github/release-drafter-python.yml
+++ b/.github/release-drafter-python.yml
@@ -29,8 +29,9 @@ categories:
     labels: enhancement
   - title: 🐞 Bug fixes
     labels: fix
+  - title: 📖 Documentation
+    labels: documentation
+  - title: 📦 Build system
+    labels: build
   - title: 🛠️ Other improvements
-    labels:
-      - build
-      - documentation
-      - internal
+    labels: internal

--- a/.github/release-drafter-rust.yml
+++ b/.github/release-drafter-rust.yml
@@ -27,9 +27,11 @@ categories:
     labels: enhancement
   - title: 🐞 Bug fixes
     labels: fix
+  - title: 📖 Documentation
+    labels: documentation
+  - title: 📦 Build system
+    labels: build
   - title: 🛠️ Other improvements
     labels:
-      - build
       - deprecation
-      - documentation
       - internal


### PR DESCRIPTION
I think it's useful to have these in the changelog separately.