### PR TITLE
fix: fallback to cast kernel if `inline_cast` AnyValue raise

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -539,11 +539,12 @@ fn inline_cast(input: &AExpr, dtype: &DataType, strict: bool) -> PolarsResult<Op
                     #[cfg(feature = "dtype-struct")]
                     (_, DataType::Struct(_)) => return Ok(None),
                     (av, _) => {
-                        let out = if strict {
-                            av.strict_cast(dtype)
-                        } else {
-                            av.cast(dtype)
-                        }?;
+                        let out = {
+                            match av.strict_cast(dtype) {
+                                Ok(out) => out,
+                                Err(_) => return Ok(None),
+                            }
+                        };
                         out.try_into()?
                     },
                 }


### PR DESCRIPTION
This fixes #13588.

To be safe, it's best to keep the fallback mechanism and gradually align inline_cast and cast kernels.

I'll implement the string/binary type AnyValue to numeric type conversion later.