### PR TITLE
fix(python)!: default to microsecond time_unit in to_datetime for "%f" and "%.f"

### DIFF
--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -238,11 +238,7 @@ impl StringNameSpace {
         let time_unit = match (&options.format, time_unit) {
             (_, Some(time_unit)) => time_unit,
             (Some(format), None) => {
-                if format.contains("%.9f")
-                    || format.contains("%9f")
-                    || format.contains("%f")
-                    || format.contains("%.f")
-                {
+                if format.contains("%.9f") || format.contains("%9f") {
                     TimeUnit::Nanoseconds
                 } else if format.contains("%.3f") || format.contains("%3f") {
                     TimeUnit::Milliseconds

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -686,3 +686,16 @@ def test_to_datetime_out_of_range_13401(time_unit: TimeUnit) -> None:
         s.str.to_datetime("%Y-%B-%d %H:%M:%S", strict=False, time_unit=time_unit).item()
         is None
     )
+
+
+def test_out_of_ns_range_no_tu_specified_13592() -> None:
+    df = pl.DataFrame({"dates": ["2022-08-31 00:00:00.0", "0920-09-18 00:00:00.0"]})
+    result = df.select(pl.col("dates").str.to_datetime(format="%Y-%m-%d %H:%M:%S%.f"))[
+        "dates"
+    ]
+    expected = pl.Series(
+        "dates",
+        [datetime(2022, 8, 31, 0, 0), datetime(920, 9, 18, 0, 0)],
+        dtype=pl.Datetime("us"),
+    )
+    assert_series_equal(result, expected)


### PR DESCRIPTION
closes #13592   

I'd suggest waiting til 1.0 for this