### PR TITLE
feat(rust,python,cli): add SQL engine support for `EXTRACT` and `DATE_PART`

### DIFF
--- a/py-polars/tests/unit/sql/test_temporal.py
+++ b/py-polars/tests/unit/sql/test_temporal.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime, time
+from typing import Any
+
+import pytest
 
 import polars as pl
 from polars.testing import assert_frame_equal
@@ -26,3 +29,55 @@ def test_date() -> None:
     result = pl.select(pl.sql_expr("""CAST(DATE('2023-03', '%Y-%m') as STRING)"""))
     expected = pl.DataFrame({"literal": ["2023-03-01"]})
     assert_frame_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("part", "dtype", "expected"),
+    [
+        ("decade", pl.Int32, [202, 202, 200]),
+        ("isoyear", pl.Int32, [2024, 2020, 2005]),
+        ("year", pl.Int32, [2024, 2020, 2006]),
+        ("quarter", pl.Int8, [1, 4, 1]),
+        ("month", pl.Int8, [1, 12, 1]),
+        ("week", pl.Int8, [1, 53, 52]),
+        ("doy", pl.Int16, [7, 365, 1]),
+        ("isodow", pl.Int8, [7, 3, 7]),
+        ("dow", pl.Int8, [0, 3, 0]),
+        ("day", pl.Int8, [7, 30, 1]),
+        ("hour", pl.Int8, [1, 10, 23]),
+        ("minute", pl.Int8, [2, 30, 59]),
+        ("second", pl.Int8, [3, 45, 59]),
+        ("millisecond", pl.Float64, [3123.456, 45987.654, 59555.555]),
+        ("microsecond", pl.Float64, [3123456.0, 45987654.0, 59555555.0]),
+        ("nanosecond", pl.Float64, [3123456000.0, 45987654000.0, 59555555000.0]),
+        (
+            "time",
+            pl.Time,
+            [time(1, 2, 3, 123456), time(10, 30, 45, 987654), time(23, 59, 59, 555555)],
+        ),
+        (
+            "epoch",
+            pl.Float64,
+            [1704589323.123456, 1609324245.987654, 1136159999.555555],
+        ),
+    ],
+)
+def test_extract_datepart(part: str, dtype: pl.DataType, expected: list[Any]) -> None:
+    df = pl.DataFrame(
+        {
+            "dt": [
+                # note: these values test several edge-cases, such as isoyear,
+                # the mon/sun wrapping of dow vs isodow, epoch rounding, etc,
+                # and the results have been validated against postgresql.
+                datetime(2024, 1, 7, 1, 2, 3, 123456),
+                datetime(2020, 12, 30, 10, 30, 45, 987654),
+                datetime(2006, 1, 1, 23, 59, 59, 555555),
+            ],
+        }
+    )
+    with pl.SQLContext(frame_data=df, eager_execution=True) as ctx:
+        for func in (f"EXTRACT({part} FROM dt)", f"DATE_PART(dt,'{part}')"):
+            res = ctx.execute(f"SELECT {func} AS {part} FROM frame_data").to_series()
+
+            assert res.dtype == dtype
+            assert res.to_list() == expected


### PR DESCRIPTION
The SQL string functions have had some love recently, but the temporal functions could do with some more attention; this PR adds support for the key `EXTRACT` and `DATE_PART` funcs (which are equivalent to each other, with just a minor difference in syntax):

* `EXTRACT(year FROM date_col)`
* `DATE_PART(date_col,'year')`

## Supported parts/fields:

First cut supports most of the major parts; I don't think people will be knocking down the door for "century", but it can always be added later 😅 

* "day" 
* "dayofweek" | "dow"
* "dayofyear" | "doy"
* "decade"
* "epoch" 
* "hour" 
* "isodow"
* "isoweek" | "week" 
* "isoyear"
* "microsecond(s)"
* "millisecond(s)"
* "nanosecond(s)"
* "minute" 
* "month" 
* "quarter" 
* "second"
* "time"
* "year" 

Validated the unit test results against a PostgreSQL instance.

## Example

```python
import polars as pl

df = pl.DataFrame({
  "dt": [
    datetime(2024,  1, 10,  1,  2,  3, 123456),
    datetime(2020, 12, 30, 10, 30, 45, 987654),
    datetime(2006,  1,  1, 23, 59, 59, 555555),
  ],
})

with pl.SQLContext(data=df) as ctx:
  print(ctx.execute(
    """
    SELECT
      dt,
      EXTRACT(year FROM dt)    AS year,
      EXTRACT(isoyear FROM dt) AS isoyear,
      EXTRACT(isoweek FROM dt) AS isoweek,
      DATE_PART(dt,'month')    AS month,
      DATE_PART(dt,'day')      AS day 
    FROM data
    """
  ).collect())

  # shape: (3, 6)
  # ┌────────────────────────────┬──────┬─────────┬─────────┬───────┬─────┐
  # │ dt                         ┆ year ┆ isoyear ┆ isoweek ┆ month ┆ day │
  # │ ---                        ┆ ---  ┆ ---     ┆ ---     ┆ ---   ┆ --- │
  # │ datetime[μs]               ┆ i32  ┆ i32     ┆ i8      ┆ i8    ┆ i8  │
  # ╞════════════════════════════╪══════╪═════════╪═════════╪═══════╪═════╡
  # │ 2024-01-10 01:02:03.123456 ┆ 2024 ┆ 2024    ┆ 2       ┆ 1     ┆ 10  │
  # │ 2020-12-30 10:30:45.987654 ┆ 2020 ┆ 2020    ┆ 53      ┆ 12    ┆ 30  │
  # │ 2006-01-01 23:59:59.555555 ┆ 2006 ┆ 2005    ┆ 52      ┆ 1     ┆ 1   │
  # └────────────────────────────┴──────┴─────────┴─────────┴───────┴─────┘
```