### PR TITLE
fix(rust):  Support index upsampling

### DIFF
--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -135,7 +135,7 @@ fn upsample_impl(
                 .unwrap()
         })
         .unwrap();
-        let mut out = upsample_impl(&df, by, index_column, every, offset, stable).unwrap();
+        let mut out = upsample_impl(&df, by, index_column, every, offset, stable)?;
         out.apply(index_column, |s| s.cast(time_type).unwrap())
             .unwrap();
         Ok(out)
@@ -152,7 +152,7 @@ fn upsample_impl(
                 .unwrap()
         })
         .unwrap();
-        let mut out = upsample_impl(&df, by, index_column, every, offset, stable).unwrap();
+        let mut out = upsample_impl(&df, by, index_column, every, offset, stable)?;
         out.apply(index_column, |s| s.cast(time_type).unwrap())
             .unwrap();
         Ok(out)
@@ -163,7 +163,7 @@ fn upsample_impl(
                 .unwrap()
         })
         .unwrap();
-        let mut out = upsample_impl(&df, by, index_column, every, offset, stable).unwrap();
+        let mut out = upsample_impl(&df, by, index_column, every, offset, stable)?;
         out.apply(index_column, |s| s.cast(time_type).unwrap())
             .unwrap();
         Ok(out)

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -822,7 +822,6 @@ def test_upsample_index(
                 .fill_null(strategy=fill)
                 .sort(["groups", "index"])
             )
-            print(result)
             assert_frame_equal(result, _expected)
     else:
         with pytest.raises(ComputeError):

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -867,9 +867,7 @@ def test_upsample_index_invalid(
             "groups": ["a"] * 3 + ["b"] * 2,
         }
     ).set_sorted("index")
-    with pytest.raises(
-        ComputeError, match=r"cannot combine time .* integer"
-    ):
+    with pytest.raises(ComputeError, match=r"cannot combine time .* integer"):
         df.upsample(time_column="index", every=every, offset=offset)
 
 


### PR DESCRIPTION
fix #12207 

In this PR, I try to fix to support upsampling by index (ex. every="1i").
The upsampling document says upsample supports regular frequency that includes "1i", but it is not working now (#12207).

For the implementation, I referred to the group_by_dynamic function that supports "1i" freq.
https://github.com/pola-rs/polars/blob/a8bdc76000c059afdac1f215e3b95654a0057712/crates/polars-time/src/group_by/dynamic.rs#L198

Any comments and suggestions are welcome.