### PR TITLE
docs(rust): Clarify doc summary of `upsample_stable`

### DIFF
--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -46,7 +46,7 @@ pub trait PolarsUpsample {
         offset: Duration,
     ) -> PolarsResult<DataFrame>;
 
-    /// Similar to [`upsample`], but order of the DataFrame is maintained when `by` is specified.
+    /// Similar to `upsample`, but order of the DataFrame is maintained when `by` is specified.
     ///
     /// # Arguments
     /// * `by` - First group by these columns and then upsample for every group

--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -46,7 +46,7 @@ pub trait PolarsUpsample {
         offset: Duration,
     ) -> PolarsResult<DataFrame>;
 
-    /// Upsample a DataFrame at a regular frequency.
+    /// Similar to [`upsample`], but order of the DataFrame is maintained when `by` is specified.
     ///
     /// # Arguments
     /// * `by` - First group by these columns and then upsample for every group

--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -46,7 +46,10 @@ pub trait PolarsUpsample {
         offset: Duration,
     ) -> PolarsResult<DataFrame>;
 
-    /// Similar to `upsample`, but order of the DataFrame is maintained when `by` is specified.
+    /// Upsample a [`DataFrame`] at a regular frequency.
+    ///
+    /// Similar to [`upsample`][PolarsUpsample::upsample], but order of the
+    /// DataFrame is maintained when `by` is specified.
     ///
     /// # Arguments
     /// * `by` - First group by these columns and then upsample for every group


### PR DESCRIPTION
The current documentation of the `upsample_stable` is identical to the `upsample`.
So users can not know what the difference is between `upsample` and `upsample_stable.`

I think this should be fixed.