### PR TITLE
feat(rust,python,cli): add SQL engine support for string cast to `json`

### DIFF
--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -439,9 +439,13 @@ impl SQLExprVisitor<'_> {
         if format.is_some() {
             return Err(polars_err!(ComputeError: "unsupported use of FORMAT in CAST expression"));
         }
-        let polars_type = map_sql_polars_datatype(data_type)?;
         let expr = self.visit_expr(expr)?;
 
+        #[cfg(feature = "json")]
+        if data_type == &SQLDataType::JSON {
+            return Ok(expr.str().json_decode(None, None));
+        }
+        let polars_type = map_sql_polars_datatype(data_type)?;
         Ok(expr.cast(polars_type))
     }
 


### PR DESCRIPTION
Adds support for `<jsonstr>::json` and `CAST(<jsonstr> AS JSON)` syntax.

## Example

```python
import polars as pl

df = pl.DataFrame({
    "txt":['{"a":[1,2,3], "b":["x","y","z"], "c":5.0}']
})
with pl.SQLContext(df=df, eager_execution=True) as ctx:
    res = ctx.execute("SELECT txt::json AS jsn FROM df")
    # shape: (1, 1)
    # ┌─────────────────────────────────┐
    # │ jsn                             │
    # │ ---                             │
    # │ struct[3]                       │
    # ╞═════════════════════════════════╡
    # │ {[1, 2, 3],["x", "y", "z"],5.0} │
    # └─────────────────────────────────┘

    res.unnest("jsn")
    # shape: (1, 3)
    # ┌───────────┬─────────────────┬─────┐
    # │ a         ┆ b               ┆ c   │
    # │ ---       ┆ ---             ┆ --- │
    # │ list[i64] ┆ list[str]       ┆ f64 │
    # ╞═══════════╪═════════════════╪═════╡
    # │ [1, 2, 3] ┆ ["x", "y", "z"] ┆ 5.0 │
    # └───────────┴─────────────────┴─────┘
```