### PR TITLE
fix(python): `Series.eq_missing` should return an Expr when the input is an Expr

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -109,7 +109,6 @@ from polars.utils.deprecation import (
 from polars.utils.various import (
     _prepare_row_index_args,
     _process_null_values,
-    _warn_null_comparison,
     handle_projection_columns,
     is_bool_sequence,
     is_int_sequence,
@@ -119,6 +118,7 @@ from polars.utils.various import (
     parse_version,
     range_to_slice,
     scale_bytes,
+    warn_null_comparison,
 )
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -1440,7 +1440,7 @@ class DataFrame:
         op: ComparisonOperator,
     ) -> DataFrame:
         """Compare a DataFrame with a non-DataFrame object."""
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         if op == "eq":
             return self.select(F.all() == other)
         elif op == "neq":

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -57,9 +57,9 @@ from polars.utils.deprecation import (
 )
 from polars.utils.meta import threadpool_size
 from polars.utils.various import (
-    _warn_null_comparison,
     no_default,
     sphinx_accessor,
+    warn_null_comparison,
 )
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -170,7 +170,7 @@ class Expr:
         return self._from_pyexpr(self._to_pyexpr(other)._and(self._pyexpr))
 
     def __eq__(self, other: Any) -> Self:  # type: ignore[override]
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         return self._from_pyexpr(self._pyexpr.eq(self._to_pyexpr(other)))
 
     def __floordiv__(self, other: Any) -> Self:
@@ -180,22 +180,22 @@ class Expr:
         return self._from_pyexpr(self._to_pyexpr(other) // self._pyexpr)
 
     def __ge__(self, other: Any) -> Self:
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         return self._from_pyexpr(self._pyexpr.gt_eq(self._to_pyexpr(other)))
 
     def __gt__(self, other: Any) -> Self:
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         return self._from_pyexpr(self._pyexpr.gt(self._to_pyexpr(other)))
 
     def __invert__(self) -> Self:
         return self.not_()
 
     def __le__(self, other: Any) -> Self:
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         return self._from_pyexpr(self._pyexpr.lt_eq(self._to_pyexpr(other)))
 
     def __lt__(self, other: Any) -> Self:
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         return self._from_pyexpr(self._pyexpr.lt(self._to_pyexpr(other)))
 
     def __mod__(self, other: Any) -> Self:
@@ -211,7 +211,7 @@ class Expr:
         return self._from_pyexpr(self._to_pyexpr(other) * self._pyexpr)
 
     def __ne__(self, other: Any) -> Self:  # type: ignore[override]
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         return self._from_pyexpr(self._pyexpr.neq(self._to_pyexpr(other)))
 
     def __neg__(self) -> Expr:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -819,11 +819,11 @@ class Series:
         return self.__eq__(other)
 
     @overload
-    def eq_missing(self, other: Any) -> Self:
+    def eq_missing(self, other: Expr) -> Expr:  # type: ignore[overload-overlap]
         ...
 
     @overload
-    def eq_missing(self, other: Expr) -> Expr:  # type: ignore[misc]
+    def eq_missing(self, other: Any) -> Self:
         ...
 
     def eq_missing(self, other: Any) -> Self | Expr:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -790,7 +790,7 @@ class Series:
     def le(self, other: Any) -> Series:
         ...
 
-    def le(self, other: Any) -> Self | Expr:
+    def le(self, other: Any) -> Series | Expr:
         """Method equivalent of operator expression `series <= other`."""
         return self.__le__(other)
 
@@ -802,7 +802,7 @@ class Series:
     def lt(self, other: Any) -> Series:
         ...
 
-    def lt(self, other: Any) -> Self | Expr:
+    def lt(self, other: Any) -> Series | Expr:
         """Method equivalent of operator expression `series < other`."""
         return self.__lt__(other)
 
@@ -814,7 +814,7 @@ class Series:
     def eq(self, other: Any) -> Series:
         ...
 
-    def eq(self, other: Any) -> Self | Expr:
+    def eq(self, other: Any) -> Series | Expr:
         """Method equivalent of operator expression `series == other`."""
         return self.__eq__(other)
 
@@ -823,10 +823,10 @@ class Series:
         ...
 
     @overload
-    def eq_missing(self, other: Any) -> Self:
+    def eq_missing(self, other: Any) -> Series:
         ...
 
-    def eq_missing(self, other: Any) -> Self | Expr:
+    def eq_missing(self, other: Any) -> Series | Expr:
         """
         Method equivalent of equality operator `series == other` where `None == None`.
 
@@ -872,7 +872,7 @@ class Series:
     def ne(self, other: Any) -> Series:
         ...
 
-    def ne(self, other: Any) -> Self | Expr:
+    def ne(self, other: Any) -> Series | Expr:
         """Method equivalent of operator expression `series != other`."""
         return self.__ne__(other)
 
@@ -881,10 +881,10 @@ class Series:
         ...
 
     @overload
-    def ne_missing(self, other: Any) -> Self:
+    def ne_missing(self, other: Any) -> Series:
         ...
 
-    def ne_missing(self, other: Any) -> Self | Expr:
+    def ne_missing(self, other: Any) -> Series | Expr:
         """
         Method equivalent of equality operator `series != other` where `None == None`.
 
@@ -930,7 +930,7 @@ class Series:
     def ge(self, other: Any) -> Series:
         ...
 
-    def ge(self, other: Any) -> Self | Expr:
+    def ge(self, other: Any) -> Series | Expr:
         """Method equivalent of operator expression `series >= other`."""
         return self.__ge__(other)
 
@@ -942,7 +942,7 @@ class Series:
     def gt(self, other: Any) -> Series:
         ...
 
-    def gt(self, other: Any) -> Self | Expr:
+    def gt(self, other: Any) -> Series | Expr:
         """Method equivalent of operator expression `series > other`."""
         return self.__gt__(other)
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -99,7 +99,6 @@ from polars.utils.deprecation import (
 from polars.utils.meta import get_index_type
 from polars.utils.various import (
     _is_generator,
-    _warn_null_comparison,
     no_default,
     parse_percentiles,
     parse_version,
@@ -107,6 +106,7 @@ from polars.utils.various import (
     range_to_slice,
     scale_bytes,
     sphinx_accessor,
+    warn_null_comparison,
 )
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
@@ -707,7 +707,7 @@ class Series:
         ...
 
     def __eq__(self, other: Any) -> Series | Expr:
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         if isinstance(other, pl.Expr):
             return F.lit(self).__eq__(other)
         return self._comp(other, "eq")
@@ -721,7 +721,7 @@ class Series:
         ...
 
     def __ne__(self, other: Any) -> Series | Expr:
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         if isinstance(other, pl.Expr):
             return F.lit(self).__ne__(other)
         return self._comp(other, "neq")
@@ -735,7 +735,7 @@ class Series:
         ...
 
     def __gt__(self, other: Any) -> Series | Expr:
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         if isinstance(other, pl.Expr):
             return F.lit(self).__gt__(other)
         return self._comp(other, "gt")
@@ -749,7 +749,7 @@ class Series:
         ...
 
     def __lt__(self, other: Any) -> Series | Expr:
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         if isinstance(other, pl.Expr):
             return F.lit(self).__lt__(other)
         return self._comp(other, "lt")
@@ -763,7 +763,7 @@ class Series:
         ...
 
     def __ge__(self, other: Any) -> Series | Expr:
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         if isinstance(other, pl.Expr):
             return F.lit(self).__ge__(other)
         return self._comp(other, "gt_eq")
@@ -777,7 +777,7 @@ class Series:
         ...
 
     def __le__(self, other: Any) -> Series | Expr:
-        _warn_null_comparison(other)
+        warn_null_comparison(other)
         if isinstance(other, pl.Expr):
             return F.lit(self).__le__(other)
         return self._comp(other, "lt_eq")

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -863,6 +863,9 @@ class Series:
             true
         ]
         """
+        if isinstance(other, pl.Expr):
+            return F.lit(self).eq_missing(other)
+        return self.to_frame().select(F.col(self.name).eq_missing(other)).to_series()
 
     @overload
     def ne(self, other: Expr) -> Expr:  # type: ignore[overload-overlap]
@@ -921,6 +924,9 @@ class Series:
             false
         ]
         """
+        if isinstance(other, pl.Expr):
+            return F.lit(self).ne_missing(other)
+        return self.to_frame().select(F.col(self.name).ne_missing(other)).to_series()
 
     @overload
     def ge(self, other: Expr) -> Expr:  # type: ignore[overload-overlap]

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -127,7 +127,8 @@ def is_column(obj: Any) -> bool:
     return isinstance(obj, Expr) and obj.meta.is_column()
 
 
-def _warn_null_comparison(obj: Any) -> None:
+def warn_null_comparison(obj: Any) -> None:
+    """Warn for possibly unintentional comparisons with None."""
     if obj is None:
         warnings.warn(
             "Comparisons with None always result in null. Consider using `.is_null()` or `.is_not_null()`.",

--- a/py-polars/tests/unit/series/test_equals.py
+++ b/py-polars/tests/unit/series/test_equals.py
@@ -70,3 +70,23 @@ def test_eq_list() -> None:
     result = s == 1
     expected = pl.Series([True, True])
     assert_series_equal(result, expected)
+
+
+def test_eq_missing_expr() -> None:
+    s = pl.Series([1, None])
+    result = s.eq_missing(pl.lit(1))
+
+    assert isinstance(result, pl.Expr)
+    result_evaluated = pl.select(result).to_series()
+    expected = pl.Series([True, False])
+    assert_series_equal(result_evaluated, expected)
+
+
+def test_ne_missing_expr() -> None:
+    s = pl.Series([1, None])
+    result = s.ne_missing(pl.lit(1))
+
+    assert isinstance(result, pl.Expr)
+    result_evaluated = pl.select(result).to_series()
+    expected = pl.Series([False, True])
+    assert_series_equal(result_evaluated, expected)


### PR DESCRIPTION
#### Changes

* Make `Series.eq_missing` and `ne_missing` return an expression when the input is an expression. This is consistent with `eq` and `ne` and other comparisons.
* Fix some type hints
* Rename a util (remove the 'private' marker)