### PR TITLE
docs(python): Update `then` and `otherwise` docstrings with "strings are parsed as column names"

### DIFF
--- a/py-polars/polars/expr/whenthen.py
+++ b/py-polars/polars/expr/whenthen.py
@@ -35,7 +35,8 @@ class When:
         ----------
         statement
             The statement to apply if the corresponding condition is true.
-            Accepts expression input. Non-expression inputs are parsed as literals.
+            Accepts expression input. Strings are parsed as column names, other
+            non-expression inputs are parsed as literals.
         """
         statement_pyexpr = parse_as_expression(statement)
         return Then(self._when.then(statement_pyexpr))
@@ -74,7 +75,7 @@ class Then(Expr):
             Accepts one or more boolean expressions, which are implicitly combined with
             `&`. String input is parsed as a column name.
         constraints
-            Apply conditions as `colname = value` keyword arguments that are treated as
+            Apply conditions as `col_name = value` keyword arguments that are treated as
             equality matches, such as `x = 123`. As with the predicates parameter,
             multiple conditions are implicitly combined using `&`.
         """
@@ -89,7 +90,8 @@ class Then(Expr):
         ----------
         statement
             The statement to apply if all conditions are false.
-            Accepts expression input. Non-expression inputs are parsed as literals.
+            Accepts expression input. Strings are parsed as column names, other
+            non-expression inputs are parsed as literals.
         """
         statement_pyexpr = parse_as_expression(statement)
         return wrap_expr(self._then.otherwise(statement_pyexpr))
@@ -115,7 +117,8 @@ class ChainedWhen(Expr):
         ----------
         statement
             The statement to apply if the corresponding condition is true.
-            Accepts expression input. Non-expression inputs are parsed as literals.
+            Accepts expression input. Strings are parsed as column names, other
+            non-expression inputs are parsed as literals.
         """
         statement_pyexpr = parse_as_expression(statement)
         return ChainedThen(self._chained_when.then(statement_pyexpr))
@@ -154,7 +157,7 @@ class ChainedThen(Expr):
             Accepts one or more boolean expressions, which are implicitly combined with
             `&`. String input is parsed as a column name.
         constraints
-            Apply conditions as `colname = value` keyword arguments that are treated as
+            Apply conditions as `col_name = value` keyword arguments that are treated as
             equality matches, such as `x = 123`. As with the predicates parameter,
             multiple conditions are implicitly combined using `&`.
         """
@@ -169,7 +172,8 @@ class ChainedThen(Expr):
         ----------
         statement
             The statement to apply if all conditions are false.
-            Accepts expression input. Non-expression inputs are parsed as literals.
+            Accepts expression input. Strings are parsed as column names, other
+            non-expression inputs are parsed as literals.
         """
         statement_pyexpr = parse_as_expression(statement)
         return wrap_expr(self._chained_then.otherwise(statement_pyexpr))

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -24,7 +24,7 @@ def when(
     `pl.when(<condition>).then(<value if condition>)`., and optionally followed by
     chaining one or more `.when(<condition>).then(<value>)` statements.
 
-    Chained `when, thens` should be read as Python `if, elif, ... elif` blocks, not as
+    Chained `when, then`s should be read as Python `if, elif, ... elif` blocks, not as
     `if, if, ... if`, i.e. the first condition that evaluates to True will be picked.
 
     If none of the conditions are `True`, an optional `.otherwise(<value if all
@@ -38,7 +38,7 @@ def when(
         Accepts one or more boolean expressions, which are implicitly combined with
         `&`. String input is parsed as a column name.
     constraints
-        Apply conditions as `colname = value` keyword arguments that are treated as
+        Apply conditions as `col_name = value` keyword arguments that are treated as
         equality matches, such as `x = 123`. As with the predicates parameter, multiple
         conditions are implicitly combined using `&`.
 
@@ -66,7 +66,7 @@ def when(
     │ 4   ┆ 0   ┆ 1   │
     └─────┴─────┴─────┘
 
-    Or with multiple `when, thens` chained:
+    Or with multiple `when, then`s chained:
 
     >>> df.with_columns(
     ...     pl.when(pl.col("foo") > 2)

--- a/py-polars/polars/functions/whenthen.py
+++ b/py-polars/polars/functions/whenthen.py
@@ -24,8 +24,9 @@ def when(
     `pl.when(<condition>).then(<value if condition>)`., and optionally followed by
     chaining one or more `.when(<condition>).then(<value>)` statements.
 
-    Chained `when, then`s should be read as Python `if, elif, ... elif` blocks, not as
-    `if, if, ... if`, i.e. the first condition that evaluates to True will be picked.
+    Chained when-then operations should be read as Python `if, elif, ... elif` blocks,
+    not as `if, if, ... if`, i.e. the first condition that evaluates to True will be
+    picked.
 
     If none of the conditions are `True`, an optional `.otherwise(<value if all
     statements are false>)` can be appended at the end. If not appended, and none
@@ -66,7 +67,7 @@ def when(
     │ 4   ┆ 0   ┆ 1   │
     └─────┴─────┴─────┘
 
-    Or with multiple `when, then`s chained:
+    Or with multiple when-then operations chained:
 
     >>> df.with_columns(
     ...     pl.when(pl.col("foo") > 2)


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/13611

String inputs being parsed as literals for `when`, `then` and `otherwise` was removed in the last breaking release. This PR updates the docstrings for `then` and `otherwise` to note this. Updated wording is consistent with other existing docstrings.


Also has very minor updates in `when` docstrings with:
- `colname = value` -> `col_name = value`
- `when, thens` -> when-then operations ~`when, then`s~