### PR TITLE
docs: fix linking to feature flags in user guide

### DIFF
--- a/docs/_build/scripts/macro.py
+++ b/docs/_build/scripts/macro.py
@@ -35,7 +35,7 @@ def create_feature_flag_link(feature_name: str) -> str:
     Returns:
         str: Markdown formatted string with a link and the feature flag message
     """
-    return f'[:material-flag-plus:  Available on feature {feature_name}](/polars/user-guide/installation/#feature-flags "To use this functionality enable the feature flag {feature_name}"){{.feature-flag}}'
+    return f'[:material-flag-plus:  Available on feature {feature_name}](/user-guide/installation/#feature-flags "To use this functionality enable the feature flag {feature_name}"){{.feature-flag}}'
 
 
 def create_feature_flag_links(language: str, api_functions: List[str]) -> List[str]:


### PR DESCRIPTION
minor fix to ensure that the links work again when a user clicks the 'Available on feature xxxx'. this currently gives a 404 as the URL doesn't exist.

for example here: 
<img width="725" alt="image" src="https://github.com/pola-rs/polars/assets/18343213/d883af1b-4b89-47d0-ab4b-8228944ad949">

https://docs.pola.rs/user-guide/io/bigquery/