### PR TITLE
feat(python,rust) Consistent Decimal dtype parameters between Python and Rust, conversions, and inferred vs fixed scale

### DIFF
--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -237,7 +237,7 @@ impl ChunkCast for StringChunked {
                 (_, None) => {
                     polars_warn!("when inferring scale in string->decimal cast, precision is currently ignored");
                     self.to_decimal(100)
-                }
+                },
             },
             #[cfg(feature = "dtype-date")]
             DataType::Date => {

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -234,9 +234,10 @@ impl ChunkCast for StringChunked {
                         .into_series())
                 },
                 (None, None) => self.to_decimal(100),
-                _ => {
-                    polars_bail!(ComputeError: "expected 'precision' or 'scale' when casting to Decimal")
-                },
+                (_, None) => {
+                    polars_warn!("when inferring scale in string->decimal cast, precision is currently ignored");
+                    self.to_decimal(100)
+                }
             },
             #[cfg(feature = "dtype-date")]
             DataType::Date => {

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -58,7 +58,7 @@ fn any_values_to_decimal(
                     polars_bail!(
                         ComputeError: "conversion of any-value of dtype {} to decimal must specify scale", av.dtype(),
                     );
-                }
+                },
             }
         } else if matches!(av, AnyValue::Null) {
             continue;

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -342,12 +342,12 @@ class Decimal(NumericType):
     """
 
     precision: int | None
-    scale: int
+    scale: int | None
 
     def __init__(
         self,
         precision: int | None = None,
-        scale: int = 0,
+        scale: int | None = None,
     ):
         self.precision = precision
         self.scale = scale

--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -32,7 +32,6 @@ if not _DOCUMENTING:
         dt.UInt16: PySeries.new_opt_u16,
         dt.UInt32: PySeries.new_opt_u32,
         dt.UInt64: PySeries.new_opt_u64,
-        dt.Decimal: PySeries.new_decimal,
         dt.Date: PySeries.new_opt_i32,
         dt.Datetime: PySeries.new_opt_i64,
         dt.Duration: PySeries.new_opt_i64,
@@ -57,6 +56,8 @@ def polars_type_to_constructor(
         # upon construction
         if base_type == dt.Array:
             return functools.partial(PySeries.new_array, dtype.width, dtype.inner)  # type: ignore[union-attr]
+        if base_type == dt.Decimal:
+            return functools.partial(PySeries.new_decimal, getattr(dtype, 'precision', None), getattr(dtype, 'scale', None))
 
         return _POLARS_TYPE_TO_CONSTRUCTOR[base_type]
     except KeyError:  # pragma: no cover
@@ -143,7 +144,7 @@ if not _DOCUMENTING:
         int: PySeries.new_opt_i64,
         str: PySeries.new_str,
         bool: PySeries.new_opt_bool,
-        PyDecimal: PySeries.new_decimal,
+        PyDecimal: functools.partial(PySeries.new_decimal, None, None),
     }
 
 

--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -57,7 +57,11 @@ def polars_type_to_constructor(
         if base_type == dt.Array:
             return functools.partial(PySeries.new_array, dtype.width, dtype.inner)  # type: ignore[union-attr]
         if base_type == dt.Decimal:
-            return functools.partial(PySeries.new_decimal, getattr(dtype, 'precision', None), getattr(dtype, 'scale', None))
+            return functools.partial(
+                PySeries.new_decimal,
+                getattr(dtype, "precision", None),
+                getattr(dtype, "scale", None),
+            )
 
         return _POLARS_TYPE_TO_CONSTRUCTOR[base_type]
     except KeyError:  # pragma: no cover

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -326,12 +326,12 @@ class ExprStringNameSpace:
         """
         Convert a String column into a Decimal column.
 
-        This method infers the needed parameters `precision` and `scale`.
+        This method infers the needed parameter `scale`, using default precision.
 
         Parameters
         ----------
         inference_length
-            Number of elements to parse to determine the `precision` and `scale`.
+            Number of elements to parse to determine the `scale`.
 
         Examples
         --------

--- a/py-polars/src/conversion.rs
+++ b/py-polars/src/conversion.rs
@@ -535,7 +535,7 @@ impl FromPyObject<'_> for Wrap<DataType> {
             "Decimal" => {
                 let precision = ob.getattr(intern!(py, "precision"))?.extract()?;
                 let scale = ob.getattr(intern!(py, "scale"))?.extract()?;
-                DataType::Decimal(precision, Some(scale))
+                DataType::Decimal(precision, scale)
             },
             "List" => {
                 let inner = ob.getattr(intern!(py, "inner")).unwrap();

--- a/py-polars/src/datatypes.rs
+++ b/py-polars/src/datatypes.rs
@@ -31,7 +31,7 @@ pub(crate) enum PyDataType {
     Categorical,
     Struct,
     Binary,
-    Decimal(Option<usize>, usize),
+    Decimal(Option<usize>, Option<usize>),
     Array(usize),
     Enum(Utf8Array<i64>),
 }
@@ -50,7 +50,7 @@ impl From<&DataType> for PyDataType {
             DataType::UInt64 => UInt64,
             DataType::Float32 => Float32,
             DataType::Float64 => Float64,
-            DataType::Decimal(p, s) => Decimal(*p, s.expect("unexpected null decimal scale")),
+            DataType::Decimal(p, s) => Decimal(*p, *s),
             DataType::Boolean => Bool,
             DataType::String => String,
             DataType::Binary => Binary,
@@ -113,7 +113,7 @@ impl From<PyDataType> for DataType {
             PyDataType::Categorical => Categorical(None, Default::default()),
             PyDataType::Enum(categories) => create_enum_data_type(categories),
             PyDataType::Struct => Struct(vec![]),
-            PyDataType::Decimal(p, s) => Decimal(p, Some(s)),
+            PyDataType::Decimal(p, s) => Decimal(p, s),
             PyDataType::Array(width) => Array(DataType::Null.into(), width),
         }
     }

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -286,7 +286,13 @@ impl PySeries {
 
     #[pyo3(signature = (precision, scale, name, val, strict))]
     #[staticmethod]
-    fn new_decimal(precision: Option<usize>, scale: Option<usize>, name: &str, val: Vec<Wrap<AnyValue<'_>>>, strict: bool) -> PyResult<PySeries> {
+    fn new_decimal(
+        precision: Option<usize>,
+        scale: Option<usize>,
+        name: &str,
+        val: Vec<Wrap<AnyValue<'_>>>,
+        strict: bool,
+    ) -> PyResult<PySeries> {
         // TODO: do we have to respect 'strict' here? It's possible if we want to.
         let avs = slice_extract_wrapped(&val);
         // Create a fake dtype with a placeholder "none" scale, to be inferred later.

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -284,12 +284,13 @@ impl PySeries {
         }
     }
 
+    #[pyo3(signature = (precision, scale, name, val, strict))]
     #[staticmethod]
-    fn new_decimal(name: &str, val: Vec<Wrap<AnyValue<'_>>>, strict: bool) -> PyResult<PySeries> {
+    fn new_decimal(precision: Option<usize>, scale: Option<usize>, name: &str, val: Vec<Wrap<AnyValue<'_>>>, strict: bool) -> PyResult<PySeries> {
         // TODO: do we have to respect 'strict' here? It's possible if we want to.
         let avs = slice_extract_wrapped(&val);
         // Create a fake dtype with a placeholder "none" scale, to be inferred later.
-        let dtype = DataType::Decimal(None, None);
+        let dtype = DataType::Decimal(precision, scale);
         let s = Series::from_any_values_and_dtype(name, avs, &dtype, strict)
             .map_err(PyPolarsErr::from)?;
         Ok(s.into())


### PR DESCRIPTION
This is an implementation of the suggestions in #13572.  I realize this is rather premature, but as I had been playing around with it, I thought I may as well make a draft PR to show what the changes would be like.

The core idea here is to replace the current `pl.Decimal(precision: int | None = None, scale: int = 0)` in Python with `pl.Decimal(precision: int | None = None, scale: int | None = None)`, which is consistent with Rust's `Decimal(Option<usize>, Option<usize>)`.  Doing this then allows several changes that I think are improvements in handling of conversions and inferred vs. fixed scale, allowing behaviour to be changed so that the user can more reliably choose to set a fixed scale, or have the scale inferred in a conversion.

In this change:

- Before, `pl.Series([D("1.5")], dtype=pl.Decimal(scale=5))` has a dtype of `pl.Decimal(scale=1)`.  After, it has `pl.Decimal(scale=5)`.
- Before, `pl.Series(["1.5"]).cast(pl.Decimal)` has a scale of 1, but `pl.Series(["1.5"]).cast(pl.Decimal(scale=0))` fails, even though intuitively `pl.Decimal` would seem equivalent to `pl.Decimal(precision=None, scale=0)`.  There is no way to cast to a precision but infer scale.  After, `scale=None` (the default) causes inference, and `scale=0` fails.
- Before, `pl.Series([1.5]).cast(pl.Decimal)` silently just uses `scale=0` for the cast, creating a `Decimal(scale=0)` series of `[1]`.  After, it fails, because there is no safe cast between a float and decimal unless scale is specified, ensuring that the user realizes this: it's unlikely they want `scale=0` in most cases.
- Before `pl.Series([1], dtype=pl.Decimal(scale=5))` works (subject to the above disregard of scale), but `pl.Series([1.5], dtype=pl.Decimal(scale=5))` does not, even though both involve type conversions and the latter is not ambiguous (use float at scale 5).  I'm actually not as sure this is a good idea.