### PR TITLE
feat: improve `rolling()` expression formatting

### DIFF
--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -254,8 +254,19 @@ impl Debug for Expr {
             Window {
                 function,
                 partition_by,
-                ..
-            } => write!(f, "{function:?}.over({partition_by:?})"),
+                options,
+            } => match options {
+                WindowType::Rolling(options) => {
+                    write!(
+                        f,
+                        "{:?}.rolling(by='{}', offset={}, period={})",
+                        function, options.index_column, options.offset, options.period
+                    )
+                },
+                _ => {
+                    write!(f, "{function:?}.over({partition_by:?})")
+                },
+            },
             Nth(i) => write!(f, "nth({i})"),
             Count => write!(f, "count()"),
             Explode(expr) => write!(f, "{expr:?}.explode()"),

--- a/crates/polars-time/src/windows/duration.rs
+++ b/crates/polars-time/src/windows/duration.rs
@@ -1,4 +1,5 @@
 use std::cmp::Ordering;
+use std::fmt::{Display, Formatter};
 use std::ops::Mul;
 
 #[cfg(feature = "timezones")]
@@ -50,6 +51,40 @@ impl PartialOrd<Self> for Duration {
 impl Ord for Duration {
     fn cmp(&self, other: &Self) -> Ordering {
         self.duration_ns().cmp(&other.duration_ns())
+    }
+}
+
+impl Display for Duration {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.is_zero() {
+            return write!(f, "0s");
+        }
+        if self.negative {
+            write!(f, "-")?
+        }
+        if self.months > 0 {
+            write!(f, "{}m", self.months)?
+        }
+        if self.weeks > 0 {
+            write!(f, "{}w", self.weeks)?
+        }
+        if self.days > 0 {
+            write!(f, "{}d", self.days)?
+        }
+        if self.nsecs > 0 {
+            let secs = self.nsecs / 1_000_000;
+            if secs * 1_000_000 == self.nsecs {
+                write!(f, "{}s", secs)?
+            } else {
+                let us = self.nsecs / 1_000;
+                if us * 1_000 == self.nsecs {
+                    write!(f, "{}us", us)?
+                } else {
+                    write!(f, "{}ns", self.nsecs)?
+                }
+            }
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
from `col("price").mean().over([])` to `col("price").mean().rolling(by='timestamp', offset=0s, period=1000s)`