### PR TITLE
depr: Deprecate `dt.with_time_unit` in favor of `cast(pl.Int64).cast(pl.Datetime(time_unit, time_zone))`

### DIFF
--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -1327,12 +1327,19 @@ class ExprDateTimeNameSpace:
         """
         return wrap_expr(self._pyexpr.dt_timestamp(time_unit))
 
+    @deprecate_function(
+        "Use `cast(pl.Int64).cast(pl.Datetime(time_unit, time_zone))` instead.",
+        version="0.20.4",
+    )
     def with_time_unit(self, time_unit: TimeUnit) -> Expr:
         """
         Set time unit of an expression of dtype Datetime or Duration.
 
         This does not modify underlying data, and should be used to fix an incorrect
         time unit.
+
+        .. deprecated:: 0.20.4
+            Use ``cast(pl.Int64).cast(pl.Datetime(time_unit, time_zone))`` instead.
 
         Parameters
         ----------
@@ -1358,7 +1365,7 @@ class ExprDateTimeNameSpace:
         ...         pl.col("date"),
         ...         pl.col("date").dt.with_time_unit("us").alias("time_unit_us"),
         ...     ]
-        ... )
+        ... )  # doctest: +SKIP
         shape: (3, 2)
         ┌─────────────────────┬───────────────────────┐
         │ date                ┆ time_unit_us          │

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -1328,23 +1328,23 @@ class ExprDateTimeNameSpace:
         return wrap_expr(self._pyexpr.dt_timestamp(time_unit))
 
     @deprecate_function(
-        "Use `cast(pl.Int64).cast(pl.Datetime(time_unit, time_zone))` instead.",
-        version="0.20.4",
+        "Instead, first cast to `Int64` and then cast to the desired data type.",
+        version="0.20.5",
     )
     def with_time_unit(self, time_unit: TimeUnit) -> Expr:
         """
         Set time unit of an expression of dtype Datetime or Duration.
 
+        .. deprecated:: 0.20.5
+            First cast to `Int64` and then cast to the desired data type.
+
         This does not modify underlying data, and should be used to fix an incorrect
         time unit.
-
-        .. deprecated:: 0.20.4
-            Use ``cast(pl.Int64).cast(pl.Datetime(time_unit, time_zone))`` instead.
 
         Parameters
         ----------
         time_unit : {'ns', 'us', 'ms'}
-            Unit of time for the `Datetime` expression.
+            Unit of time for the `Datetime` or `Duration` expression.
 
         Examples
         --------
@@ -1361,10 +1361,8 @@ class ExprDateTimeNameSpace:
         ...     }
         ... )
         >>> df.select(
-        ...     [
-        ...         pl.col("date"),
-        ...         pl.col("date").dt.with_time_unit("us").alias("time_unit_us"),
-        ...     ]
+        ...     pl.col("date"),
+        ...     pl.col("date").dt.with_time_unit("us").alias("time_unit_us"),
         ... )  # doctest: +SKIP
         shape: (3, 2)
         ┌─────────────────────┬───────────────────────┐

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -898,6 +898,9 @@ class DateTimeNameSpace:
         This does not modify underlying data, and should be used to fix an incorrect
         time unit.
 
+        .. deprecated:: 0.20.4
+            Use ``cast(pl.Int64).cast(pl.Datetime(time_unit, time_zone))`` instead.
+
         Parameters
         ----------
         time_unit : {'ns', 'us', 'ms'}
@@ -911,7 +914,7 @@ class DateTimeNameSpace:
         ...     [datetime(2001, 1, 1), datetime(2001, 1, 2), datetime(2001, 1, 3)],
         ...     dtype=pl.Datetime(time_unit="ns"),
         ... )
-        >>> s.dt.with_time_unit("us")
+        >>> s.dt.with_time_unit("us")  # doctest: +SKIP
         shape: (3,)
         Series: 'datetime' [datetime[μs]]
         [

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -895,16 +895,16 @@ class DateTimeNameSpace:
         """
         Set time unit a Series of dtype Datetime or Duration.
 
+        .. deprecated:: 0.20.5
+            First cast to `Int64` and then cast to the desired data type.
+
         This does not modify underlying data, and should be used to fix an incorrect
         time unit.
-
-        .. deprecated:: 0.20.4
-            Use ``cast(pl.Int64).cast(pl.Datetime(time_unit, time_zone))`` instead.
 
         Parameters
         ----------
         time_unit : {'ns', 'us', 'ms'}
-            Unit of time for the `Datetime` Series.
+            Unit of time for the `Datetime` or `Duration` Series.
 
         Examples
         --------

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -467,11 +467,12 @@ def test_to_list() -> None:
 
 def test_rows() -> None:
     s0 = pl.Series("date", [123543, 283478, 1243]).cast(pl.Date)
-    s1 = (
-        pl.Series("datetime", [a * 1_000_000 for a in [123543, 283478, 1243]])
-        .cast(pl.Datetime)
-        .dt.with_time_unit("ns")
-    )
+    with pytest.deprecated_call(match="`with_time_unit` is deprecated"):
+        s1 = (
+            pl.Series("datetime", [a * 1_000_000 for a in [123543, 283478, 1243]])
+            .cast(pl.Datetime)
+            .dt.with_time_unit("ns")
+        )
     df = pl.DataFrame([s0, s1])
 
     rows = df.rows()


### PR DESCRIPTION
closes #13209 