### PR TITLE
fix(python): Ensure the `cs.temporal()` selector uses wildcard time zone matching for `Datetime`

### DIFF
--- a/py-polars/polars/datatypes/__init__.py
+++ b/py-polars/polars/datatypes/__init__.py
@@ -35,6 +35,7 @@ from polars.datatypes.classes import (
 )
 from polars.datatypes.constants import (
     DATETIME_DTYPES,
+    DATETIME_DTYPES_NO_WILDCARDS,
     DTYPE_TEMPORAL_UNITS,
     DURATION_DTYPES,
     FLOAT_DTYPES,
@@ -44,6 +45,7 @@ from polars.datatypes.constants import (
     NUMERIC_DTYPES,
     SIGNED_INTEGER_DTYPES,
     TEMPORAL_DTYPES,
+    TEMPORAL_DTYPES_NO_WILDCARDS,
     UNSIGNED_INTEGER_DTYPES,
 )
 from polars.datatypes.constructor import (
@@ -110,6 +112,7 @@ __all__ = [
     "Utf8",
     # constants
     "DATETIME_DTYPES",
+    "DATETIME_DTYPES_NO_WILDCARDS",
     "DTYPE_TEMPORAL_UNITS",
     "DURATION_DTYPES",
     "FLOAT_DTYPES",
@@ -119,6 +122,7 @@ __all__ = [
     "N_INFER_DEFAULT",
     "SIGNED_INTEGER_DTYPES",
     "TEMPORAL_DTYPES",
+    "TEMPORAL_DTYPES_NO_WILDCARDS",
     "UNSIGNED_INTEGER_DTYPES",
     # constructor
     "numpy_type_to_constructor",

--- a/py-polars/polars/datatypes/__init__.py
+++ b/py-polars/polars/datatypes/__init__.py
@@ -35,7 +35,6 @@ from polars.datatypes.classes import (
 )
 from polars.datatypes.constants import (
     DATETIME_DTYPES,
-    DATETIME_DTYPES_NO_WILDCARDS,
     DTYPE_TEMPORAL_UNITS,
     DURATION_DTYPES,
     FLOAT_DTYPES,
@@ -45,7 +44,6 @@ from polars.datatypes.constants import (
     NUMERIC_DTYPES,
     SIGNED_INTEGER_DTYPES,
     TEMPORAL_DTYPES,
-    TEMPORAL_DTYPES_NO_WILDCARDS,
     UNSIGNED_INTEGER_DTYPES,
 )
 from polars.datatypes.constructor import (
@@ -112,7 +110,6 @@ __all__ = [
     "Utf8",
     # constants
     "DATETIME_DTYPES",
-    "DATETIME_DTYPES_NO_WILDCARDS",
     "DTYPE_TEMPORAL_UNITS",
     "DURATION_DTYPES",
     "FLOAT_DTYPES",
@@ -122,7 +119,6 @@ __all__ = [
     "N_INFER_DEFAULT",
     "SIGNED_INTEGER_DTYPES",
     "TEMPORAL_DTYPES",
-    "TEMPORAL_DTYPES_NO_WILDCARDS",
     "UNSIGNED_INTEGER_DTYPES",
     # constructor
     "numpy_type_to_constructor",

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -422,8 +422,8 @@ class Datetime(TemporalType):
     time_zone
         Time zone string, as defined in zoneinfo (to see valid strings run
         `import zoneinfo; zoneinfo.available_timezones()` for a full list).
-        When using to match dtypes, can use "*" to check for Datetime columns
-        that have any timezone.
+        When used to match dtypes, can set this to "*" to check for Datetime
+        columns that have any (non-null) timezone.
 
     Notes
     -----

--- a/py-polars/polars/datatypes/constants.py
+++ b/py-polars/polars/datatypes/constants.py
@@ -36,6 +36,17 @@ DATETIME_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
         Datetime("ms"),
         Datetime("us"),
         Datetime("ns"),
+        Datetime("ms", "*"),
+        Datetime("us", "*"),
+        Datetime("ns", "*"),
+    ]
+)
+DATETIME_DTYPES_NO_WILDCARDS: frozenset[PolarsDataType] = DataTypeGroup(
+    [
+        Datetime,
+        Datetime("ms"),
+        Datetime("us"),
+        Datetime("ns"),
     ]
 )
 DURATION_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
@@ -48,6 +59,9 @@ DURATION_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
 )
 TEMPORAL_DTYPES: frozenset[PolarsTemporalType] = DataTypeGroup(
     frozenset([Date, Time]) | DATETIME_DTYPES | DURATION_DTYPES
+)
+TEMPORAL_DTYPES_NO_WILDCARDS: frozenset[PolarsTemporalType] = DataTypeGroup(
+    frozenset([Date, Time]) | DATETIME_DTYPES_NO_WILDCARDS | DURATION_DTYPES
 )
 SIGNED_INTEGER_DTYPES: frozenset[PolarsIntegerType] = DataTypeGroup(
     [

--- a/py-polars/polars/datatypes/constants.py
+++ b/py-polars/polars/datatypes/constants.py
@@ -41,14 +41,6 @@ DATETIME_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
         Datetime("ns", "*"),
     ]
 )
-DATETIME_DTYPES_NO_WILDCARDS: frozenset[PolarsDataType] = DataTypeGroup(
-    [
-        Datetime,
-        Datetime("ms"),
-        Datetime("us"),
-        Datetime("ns"),
-    ]
-)
 DURATION_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
     [
         Duration,
@@ -59,9 +51,6 @@ DURATION_DTYPES: frozenset[PolarsDataType] = DataTypeGroup(
 )
 TEMPORAL_DTYPES: frozenset[PolarsTemporalType] = DataTypeGroup(
     frozenset([Date, Time]) | DATETIME_DTYPES | DURATION_DTYPES
-)
-TEMPORAL_DTYPES_NO_WILDCARDS: frozenset[PolarsTemporalType] = DataTypeGroup(
-    frozenset([Date, Time]) | DATETIME_DTYPES_NO_WILDCARDS | DURATION_DTYPES
 )
 SIGNED_INTEGER_DTYPES: frozenset[PolarsIntegerType] = DataTypeGroup(
     [

--- a/py-polars/tests/unit/series/buffers/test_from_buffers.py
+++ b/py-polars/tests/unit/series/buffers/test_from_buffers.py
@@ -6,6 +6,7 @@ import pytest
 from hypothesis import given
 
 import polars as pl
+from polars.datatypes.constants import TEMPORAL_DTYPES_NO_WILDCARDS
 from polars.testing import assert_series_equal
 from polars.testing.parametric import series
 
@@ -34,7 +35,7 @@ def test_series_from_buffers_numeric(s: pl.Series) -> None:
     assert_series_equal(s, result)
 
 
-@given(s=series(allowed_dtypes=pl.TEMPORAL_DTYPES, chunked=False))
+@given(s=series(allowed_dtypes=TEMPORAL_DTYPES_NO_WILDCARDS, chunked=False))
 def test_series_from_buffers_temporal_with_validity(s: pl.Series) -> None:
     validity = s.is_not_null()
     physical = pl.Int32 if s.dtype == pl.Date else pl.Int64

--- a/py-polars/tests/unit/series/buffers/test_from_buffers.py
+++ b/py-polars/tests/unit/series/buffers/test_from_buffers.py
@@ -6,7 +6,7 @@ import pytest
 from hypothesis import given
 
 import polars as pl
-from polars.datatypes.constants import TEMPORAL_DTYPES_NO_WILDCARDS
+from polars.datatypes import TEMPORAL_DTYPES_NO_WILDCARDS
 from polars.testing import assert_series_equal
 from polars.testing.parametric import series
 

--- a/py-polars/tests/unit/series/buffers/test_from_buffers.py
+++ b/py-polars/tests/unit/series/buffers/test_from_buffers.py
@@ -6,9 +6,19 @@ import pytest
 from hypothesis import given
 
 import polars as pl
-from polars.datatypes import TEMPORAL_DTYPES_NO_WILDCARDS
 from polars.testing import assert_series_equal
 from polars.testing.parametric import series
+
+# TODO: Define data type groups centrally somewhere in the test suite
+DATETIME_DTYPES: set[pl.PolarsDataType] = {
+    pl.Datetime,
+    pl.Datetime("ms"),
+    pl.Datetime("us"),
+    pl.Datetime("ns"),
+}
+TEMPORAL_DTYPES: set[pl.PolarsDataType] = (
+    {pl.Date, pl.Time} | pl.DURATION_DTYPES | DATETIME_DTYPES
+)
 
 
 @given(
@@ -35,7 +45,7 @@ def test_series_from_buffers_numeric(s: pl.Series) -> None:
     assert_series_equal(s, result)
 
 
-@given(s=series(allowed_dtypes=TEMPORAL_DTYPES_NO_WILDCARDS, chunked=False))
+@given(s=series(allowed_dtypes=TEMPORAL_DTYPES, chunked=False))
 def test_series_from_buffers_temporal_with_validity(s: pl.Series) -> None:
     validity = s.is_not_null()
     physical = pl.Int32 if s.dtype == pl.Date else pl.Int64

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -376,20 +376,21 @@ def test_selector_temporal_13665() -> None:
         tokyo=pl.col("utc").dt.convert_time_zone("Asia/Tokyo"),
         hawaii=pl.col("utc").dt.convert_time_zone("US/Hawaii"),
     )
-    assert df.select(cs.temporal()).to_dict(as_series=False) == {
-        "utc": [
-            datetime(1950, 7, 5, 0, 0),
-            datetime(2099, 12, 31, 0, 0),
-        ],
-        "tokyo": [
-            datetime(1950, 7, 5, 10, 0, tzinfo=ZoneInfo(key="Asia/Tokyo")),
-            datetime(2099, 12, 31, 9, 0, tzinfo=ZoneInfo(key="Asia/Tokyo")),
-        ],
-        "hawaii": [
-            datetime(1950, 7, 4, 14, 0, tzinfo=ZoneInfo(key="US/Hawaii")),
-            datetime(2099, 12, 30, 14, 0, tzinfo=ZoneInfo(key="US/Hawaii")),
-        ],
-    }
+    for selector in (cs.datetime(), cs.datetime("us"), cs.temporal()):
+        assert df.select(selector).to_dict(as_series=False) == {
+            "utc": [
+                datetime(1950, 7, 5, 0, 0),
+                datetime(2099, 12, 31, 0, 0),
+            ],
+            "tokyo": [
+                datetime(1950, 7, 5, 10, 0, tzinfo=ZoneInfo(key="Asia/Tokyo")),
+                datetime(2099, 12, 31, 9, 0, tzinfo=ZoneInfo(key="Asia/Tokyo")),
+            ],
+            "hawaii": [
+                datetime(1950, 7, 4, 14, 0, tzinfo=ZoneInfo(key="US/Hawaii")),
+                datetime(2099, 12, 30, 14, 0, tzinfo=ZoneInfo(key="US/Hawaii")),
+            ],
+        }
 
 
 def test_selector_expansion() -> None:

--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -1,11 +1,21 @@
+import sys
+from datetime import datetime
 from typing import Any
 
 import pytest
 
 import polars as pl
 import polars.selectors as cs
+from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.selectors import expand_selector, is_selector
 from polars.testing import assert_frame_equal
+
+if sys.version_info >= (3, 9):
+    from zoneinfo import ZoneInfo
+elif _ZONEINFO_AVAILABLE:
+    # Import from submodule due to typing issue with backports.zoneinfo package:
+    # https://github.com/pganssle/zoneinfo/issues/125
+    from backports.zoneinfo._zoneinfo import ZoneInfo
 
 
 def assert_repr_equals(item: Any, expected: str) -> None:
@@ -354,6 +364,32 @@ def test_selector_temporal(df: pl.DataFrame) -> None:
     )
     assert df.select(cs.time()).schema == {"ghi": pl.Time}
     assert df.select(cs.date() | cs.time()).schema == {"ghi": pl.Time, "JJK": pl.Date}
+
+
+def test_selector_temporal_13665() -> None:
+    df = pl.DataFrame(
+        data={"utc": [datetime(1950, 7, 5), datetime(2099, 12, 31)]},
+        schema={"utc": pl.Datetime(time_zone="UTC")},
+    ).with_columns(
+        idx=pl.int_range(0, 2),
+        utc=pl.col("utc").dt.replace_time_zone(None),
+        tokyo=pl.col("utc").dt.convert_time_zone("Asia/Tokyo"),
+        hawaii=pl.col("utc").dt.convert_time_zone("US/Hawaii"),
+    )
+    assert df.select(cs.temporal()).to_dict(as_series=False) == {
+        "utc": [
+            datetime(1950, 7, 5, 0, 0),
+            datetime(2099, 12, 31, 0, 0),
+        ],
+        "tokyo": [
+            datetime(1950, 7, 5, 10, 0, tzinfo=ZoneInfo(key="Asia/Tokyo")),
+            datetime(2099, 12, 31, 9, 0, tzinfo=ZoneInfo(key="Asia/Tokyo")),
+        ],
+        "hawaii": [
+            datetime(1950, 7, 4, 14, 0, tzinfo=ZoneInfo(key="US/Hawaii")),
+            datetime(2099, 12, 30, 14, 0, tzinfo=ZoneInfo(key="US/Hawaii")),
+        ],
+    }
 
 
 def test_selector_expansion() -> None:


### PR DESCRIPTION
Closes  #13665.

We weren't matching `Datetime` dtypes _with_ time zones when using the `cs.temporal()` selector (or `DATETIME_DTYPES` and `TEMPORAL_DTYPES` dtype sets). Ensuring the match additionally uses the `time_zone="*"` wildcard fixes this.

## Example

```python
from datetime import datetime
import polars.selectors as cs
import polars as pl

df = pl.DataFrame(
    data = {"utc": [datetime(1950,7,5), datetime(2099,12,31)]},
    schema = {"utc": pl.Datetime(time_zone="UTC")},
).with_columns(
    idx = pl.int_range(0, 2),
    naive = pl.col("utc").dt.replace_time_zone(None),
    tokyo = pl.col("utc").dt.convert_time_zone("Asia/Tokyo"),
    hawaii = pl.col("utc").dt.convert_time_zone("US/Hawaii"),
)
```
**Before:** _(missing datetime dtypes that have timezones)_
```python
df.select(cs.temporal())
# shape: (2, 1)
# ┌─────────────────────┐
# │ naive               │
# │ ---                 │
# │ datetime[μs]        │
# ╞═════════════════════╡
# │ 1950-07-05 00:00:00 │
# │ 2099-12-31 00:00:00 │
# └─────────────────────┘
```
**After:** _(all datetime dtypes selected)_
```python
df.select(cs.temporal())
# shape: (2, 3)
# ┌─────────────────────┬──────────────────────────┬─────────────────────────┐
# │ naive               ┆ tokyo                    ┆ hawaii                  │
# │ ---                 ┆ ---                      ┆ ---                     │
# │ datetime[μs]        ┆ datetime[μs, Asia/Tokyo] ┆ datetime[μs, US/Hawaii] │
# ╞═════════════════════╪══════════════════════════╪═════════════════════════╡
# │ 1950-07-05 00:00:00 ┆ 1950-07-05 10:00:00 JDT  ┆ 1950-07-04 14:00:00 HST │
# │ 2099-12-31 00:00:00 ┆ 2099-12-31 09:00:00 JST  ┆ 2099-12-30 14:00:00 HST │
# └─────────────────────┴──────────────────────────┴─────────────────────────┘
```