### PR TITLE
fix: avoid duplicate column names in pivot

### DIFF
--- a/crates/polars-ops/src/frame/pivot/mod.rs
+++ b/crates/polars-ops/src/frame/pivot/mod.rs
@@ -244,7 +244,7 @@ fn pivot_impl(
 
                 let headers = column_agg.unique_stable()?.cast(&DataType::String)?;
                 let mut headers = headers.str().unwrap().clone();
-                if values.len() > 1 {
+                if values.len() > 1 || columns.len() > 1 {
                     headers = headers.apply_values(|v| Cow::from(format!("{value_col_name}{sep}{column_column_name}{sep}{v}")))
                 }
 


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/11663.

Here's a before and after, using the example from https://github.com/pola-rs/polars/issues/13470.

Before:

```python
>>> pl.DataFrame({'a': ['A'], 'b': ['B'], 'c': ['C'], 'd': ['C']}).pivot(values=['a', 'b'], index='c', columns='d')
shape: (1, 3)
┌─────┬───────┬───────┐
│ c   ┆ a_d_C ┆ b_d_C │
│ --- ┆ ---   ┆ ---   │
│ str ┆ str   ┆ str   │
╞═════╪═══════╪═══════╡
│ C   ┆ A     ┆ B     │
└─────┴───────┴───────┘
>>> pl.DataFrame({'a': ['A'], 'b': ['B'], 'c': ['C'], 'd': ['C']}).pivot(values='a', index='b', columns=['c', 'd'])
shape: (1, 3)
┌─────┬─────┬─────┐
│ b   ┆ C   ┆ C   │
│ --- ┆ --- ┆ --- │
│ str ┆ str ┆ str │
╞═════╪═════╪═════╡
│ B   ┆ A   ┆ A   │
└─────┴─────┴─────┘
```

After:

```python
>>> pl.DataFrame({'a': ['A'], 'b': ['B'], 'c': ['C'], 'd': ['C']}).pivot(values=['a', 'b'], index='c', columns='d')
shape: (1, 3)
┌─────┬───────┬───────┐
│ c   ┆ a_d_C ┆ b_d_C │
│ --- ┆ ---   ┆ ---   │
│ str ┆ str   ┆ str   │
╞═════╪═══════╪═══════╡
│ C   ┆ A     ┆ B     │
└─────┴───────┴───────┘
>>> pl.DataFrame({'a': ['A'], 'b': ['B'], 'c': ['C'], 'd': ['C']}).pivot(values='a', index='b', columns=['c', 'd'])
shape: (1, 3)
┌─────┬───────┬───────┐
│ b   ┆ a_c_C ┆ a_d_C │  --> this is the only part that's different
│ --- ┆ ---   ┆ ---   │
│ str ┆ str   ┆ str   │
╞═════╪═══════╪═══════╡
│ B   ┆ A     ┆ A     │
└─────┴───────┴───────┘
```