### PR TITLE
docs(python): Be more explicit about behaviour in `str.strip_chars` / `strip_chars_start` / `strip_chars_end` docstrings

### DIFF
--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -562,8 +562,8 @@ class ExprStringNameSpace:
         ----------
         characters
             The set of characters to be removed. All combinations of this set of
-            characters will be stripped. If set to None (default), all whitespace is
-            removed instead.
+            characters will be stripped from the start and end of the string. If set to
+            None (default), all leading and trailing whitespace is removed instead.
 
         Examples
         --------
@@ -625,8 +625,8 @@ class ExprStringNameSpace:
         ----------
         characters
             The set of characters to be removed. All combinations of this set of
-            characters will be stripped. If set to None (default), all whitespace is
-            removed instead.
+            characters will be stripped from the start of the string. If set to None
+            (default), all leading whitespace is removed instead.
 
         See Also
         --------
@@ -694,8 +694,8 @@ class ExprStringNameSpace:
         ----------
         characters
             The set of characters to be removed. All combinations of this set of
-            characters will be stripped. If set to None (default), all whitespace is
-            removed instead.
+            characters will be stripped from the end of the string. If set to None
+            (default), all trailing whitespace is removed instead.
 
         See Also
         --------

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -1208,8 +1208,8 @@ class StringNameSpace:
         ----------
         characters
             The set of characters to be removed. All combinations of this set of
-            characters will be stripped. If set to None (default), all whitespace is
-            removed instead.
+            characters will be stripped from the start and end of the string. If set to
+            None (default), all leading and trailing whitespace is removed instead.
 
         Examples
         --------
@@ -1243,8 +1243,8 @@ class StringNameSpace:
         ----------
         characters
             The set of characters to be removed. All combinations of this set of
-            characters will be stripped. If set to None (default), all whitespace is
-            removed instead.
+            characters will be stripped from the start of the string. If set to None
+            (default), all leading whitespace is removed instead.
 
         Examples
         --------
@@ -1277,8 +1277,8 @@ class StringNameSpace:
         ----------
         characters
             The set of characters to be removed. All combinations of this set of
-            characters will be stripped. If set to None (default), all whitespace is
-            removed instead.
+            characters will be stripped from the end of the string. If set to None
+            (default), all trailing whitespace is removed instead.
 
         Examples
         --------


### PR DESCRIPTION
I found the following sentence in the docstring to (primarily in the case of `strip_chars`) make it sound like characters anywhere in the string can be stripped, rather than just leading/trailing.

> All combinations of this set of characters will be stripped. If set to None (default), all whitespace is removed instead.

With `strip_chars` I missed the "Remove leading and trailing characters." sentence that provides all the additional context.


This PR makes the behaviour of the methods more explicit throughout the docstring and removes wording that could pontentially be understood as conflicting.

