### PR TITLE
fix(python): ensure df.corr() diagonals equal 1

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10220,7 +10220,9 @@ class DataFrame:
         │ 1.0  ┆ -1.0 ┆ 1.0  │
         └──────┴──────┴──────┘
         """
-        return DataFrame(np.corrcoef(self.to_numpy().T, **kwargs), schema=self.columns)
+        correlation_matrix = np.corrcoef(self.to_numpy(), rowvar=False, **kwargs)
+        np.fill_diagonal(correlation_matrix, 1)
+        return DataFrame(correlation_matrix, schema=self.columns)
 
     def merge_sorted(self, other: DataFrame, key: str) -> DataFrame:
         """


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/12078.

(I also took the liberty of adding `rowvar=False` in `np.corrcoef()`, to avoid having to transpose the array before correlating.)