### PR TITLE
fix(rust): make 100 * pl.col(pl.Boolean).mean() work

### DIFF
--- a/crates/polars-plan/src/logical_plan/aexpr/schema.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/schema.rs
@@ -127,7 +127,11 @@ impl AExpr {
                     Mean(expr) => {
                         let mut field =
                             arena.get(*expr).to_field(schema, Context::Default, arena)?;
-                        float_type(&mut field);
+                        if matches!(&field.dtype, DataType::Boolean) {
+                            field.coerce(DataType::Float64);
+                        } else {
+                            float_type(&mut field);
+                        }
                         Ok(field)
                     },
                     Implode(expr) => {

--- a/crates/polars-plan/src/logical_plan/aexpr/schema.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/schema.rs
@@ -1,7 +1,9 @@
 use super::*;
 
 fn float_type(field: &mut Field) {
-    if field.dtype.is_numeric() && !matches!(&field.dtype, DataType::Float32) {
+    if (field.dtype.is_numeric() || field.dtype == DataType::Boolean)
+        && field.dtype != DataType::Float32
+    {
         field.coerce(DataType::Float64)
     }
 }
@@ -127,11 +129,7 @@ impl AExpr {
                     Mean(expr) => {
                         let mut field =
                             arena.get(*expr).to_field(schema, Context::Default, arena)?;
-                        if matches!(&field.dtype, DataType::Boolean) {
-                            field.coerce(DataType::Float64);
-                        } else {
-                            float_type(&mut field);
-                        }
+                        float_type(&mut field);
                         Ok(field)
                     },
                     Implode(expr) => {

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -80,7 +80,7 @@ def test_streaming_group_by_types() -> None:
             "str_sum": pl.String,
             "bool_first": pl.Boolean,
             "bool_last": pl.Boolean,
-            "bool_mean": pl.Boolean,
+            "bool_mean": pl.Float64,
             "bool_sum": pl.UInt32,
             "date_sum": pl.Date,
             "date_mean": pl.Date,


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/7651 based on the implementation suggested by @advoet [here](https://github.com/pola-rs/polars/issues/7651#issuecomment-1491398261).

Before:

```python
pl.DataFrame({"a": [True, True, True, False, False]}).select(100 * pl.col("a").mean())
shape: (1, 1)
┌─────────┐
│ literal │
│ ---     │
│ i32     │
╞═════════╡
│ 0       │
└─────────┘
```

After:

```python
>>> pl.DataFrame({"a": [True, True, True, False, False]}).select(100 * pl.col("a").mean())
shape: (1, 1)
┌─────────┐
│ literal │
│ ---     │
│ f64     │
╞═════════╡
│ 60.0    │
└─────────┘
```