### PR TITLE
fix: Use `NonZeroUsize` for `batch_size` parameter in `write_csv/sink_csv/scan_ndjson`

### DIFF
--- a/crates/polars-io/src/csv/write.rs
+++ b/crates/polars-io/src/csv/write.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use polars_core::POOL;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -30,7 +32,7 @@ pub struct CsvWriter<W: Write> {
     options: write_impl::SerializeOptions,
     header: bool,
     bom: bool,
-    batch_size: usize,
+    batch_size: NonZeroUsize,
     n_threads: usize,
 }
 
@@ -50,7 +52,7 @@ where
             options,
             header: true,
             bom: false,
-            batch_size: 1024,
+            batch_size: NonZeroUsize::new(1024).unwrap(),
             n_threads: POOL.current_num_threads(),
         }
     }
@@ -66,7 +68,7 @@ where
         write_impl::write(
             &mut self.buffer,
             df,
-            self.batch_size,
+            self.batch_size.into(),
             &self.options,
             self.n_threads,
         )
@@ -96,7 +98,7 @@ where
     }
 
     /// Set the batch size to use while writing the CSV.
-    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+    pub fn with_batch_size(mut self, batch_size: NonZeroUsize) -> Self {
         self.batch_size = batch_size;
         self
     }
@@ -200,7 +202,7 @@ impl<W: Write> BatchedWriter<W> {
         write_impl::write(
             &mut self.writer.buffer,
             df,
-            self.writer.batch_size,
+            self.writer.batch_size.into(),
             &self.writer.options,
             self.writer.n_threads,
         )?;

--- a/crates/polars-io/src/json/mod.rs
+++ b/crates/polars-io/src/json/mod.rs
@@ -8,6 +8,7 @@
 //! use polars_core::prelude::*;
 //! use polars_io::prelude::*;
 //! use std::io::Cursor;
+//! use std::num::NonZeroUsize;
 //!
 //! let basic_json = r#"{"a":1, "b":2.0, "c":false, "d":"4"}
 //! {"a":-10, "b":-3.5, "c":true, "d":"4"}
@@ -25,7 +26,7 @@
 //! let df = JsonReader::new(file)
 //! .with_json_format(JsonFormat::JsonLines)
 //! .infer_schema_len(Some(3))
-//! .with_batch_size(3)
+//! .with_batch_size(NonZeroUsize::new(3).unwrap())
 //! .finish()
 //! .unwrap();
 //!
@@ -65,6 +66,7 @@ pub(crate) mod infer;
 
 use std::convert::TryFrom;
 use std::io::Write;
+use std::num::NonZeroUsize;
 use std::ops::Deref;
 
 use arrow::array::{ArrayRef, StructArray};
@@ -193,7 +195,7 @@ where
     rechunk: bool,
     ignore_errors: bool,
     infer_schema_len: Option<usize>,
-    batch_size: usize,
+    batch_size: NonZeroUsize,
     projection: Option<Vec<String>>,
     schema: Option<SchemaRef>,
     schema_overwrite: Option<&'a Schema>,
@@ -210,7 +212,7 @@ where
             rechunk: true,
             ignore_errors: false,
             infer_schema_len: Some(100),
-            batch_size: 8192,
+            batch_size: NonZeroUsize::new(8192).unwrap(),
             projection: None,
             schema: None,
             schema_overwrite: None,
@@ -300,7 +302,7 @@ where
                     self.schema_overwrite,
                     None,
                     1024, // sample size
-                    1 << 18,
+                    NonZeroUsize::new(1 << 18).unwrap(),
                     false,
                     self.infer_schema_len,
                     self.ignore_errors,
@@ -354,7 +356,7 @@ where
     /// Set the batch size (number of records to load at one time)
     ///
     /// This heavily influences loading time.
-    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+    pub fn with_batch_size(mut self, batch_size: NonZeroUsize) -> Self {
         self.batch_size = batch_size;
         self
     }

--- a/crates/polars-io/src/ndjson/core.rs
+++ b/crates/polars-io/src/ndjson/core.rs
@@ -1,5 +1,6 @@
 use std::fs::File;
 use std::io::Cursor;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 pub use arrow::array::StructArray;
@@ -26,7 +27,7 @@ where
     n_rows: Option<usize>,
     n_threads: Option<usize>,
     infer_schema_len: Option<usize>,
-    chunk_size: usize,
+    chunk_size: NonZeroUsize,
     schema: Option<SchemaRef>,
     schema_overwrite: Option<&'a Schema>,
     path: Option<PathBuf>,
@@ -72,7 +73,7 @@ where
         self
     }
     /// Sets the chunk size used by the parser. This influences performance
-    pub fn with_chunk_size(mut self, chunk_size: Option<usize>) -> Self {
+    pub fn with_chunk_size(mut self, chunk_size: Option<NonZeroUsize>) -> Self {
         if let Some(chunk_size) = chunk_size {
             self.chunk_size = chunk_size;
         };
@@ -115,7 +116,7 @@ where
             schema: None,
             schema_overwrite: None,
             path: None,
-            chunk_size: 1 << 18,
+            chunk_size: NonZeroUsize::new(1 << 18).unwrap(),
             low_memory: false,
             ignore_errors: false,
         }
@@ -150,7 +151,7 @@ pub(crate) struct CoreJsonReader<'a> {
     schema: SchemaRef,
     n_threads: Option<usize>,
     sample_size: usize,
-    chunk_size: usize,
+    chunk_size: NonZeroUsize,
     low_memory: bool,
     ignore_errors: bool,
 }
@@ -163,7 +164,7 @@ impl<'a> CoreJsonReader<'a> {
         schema_overwrite: Option<&Schema>,
         n_threads: Option<usize>,
         sample_size: usize,
-        chunk_size: usize,
+        chunk_size: NonZeroUsize,
         low_memory: bool,
         infer_schema_len: Option<usize>,
         ignore_errors: bool,
@@ -223,7 +224,7 @@ impl<'a> CoreJsonReader<'a> {
 
         let max_proxy = bytes.len() / n_threads / 2;
         let capacity = if self.low_memory {
-            self.chunk_size
+            usize::from(self.chunk_size)
         } else {
             std::cmp::min(rows_per_thread, max_proxy)
         };

--- a/crates/polars-lazy/src/physical_plan/executors/scan/ndjson.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/ndjson.rs
@@ -14,7 +14,6 @@ impl AnonymousScan for LazyJsonLineReader {
             .low_memory(self.low_memory)
             .with_n_rows(scan_opts.n_rows)
             .with_ignore_errors(self.ignore_errors)
-            .with_chunk_size(self.batch_size)
             .finish()
     }
 

--- a/crates/polars-lazy/src/scan/ndjson.rs
+++ b/crates/polars-lazy/src/scan/ndjson.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 
@@ -11,7 +12,7 @@ use crate::prelude::{LazyFrame, ScanArgsAnonymous};
 pub struct LazyJsonLineReader {
     pub(crate) path: PathBuf,
     paths: Arc<[PathBuf]>,
-    pub(crate) batch_size: Option<usize>,
+    pub(crate) batch_size: Option<NonZeroUsize>,
     pub(crate) low_memory: bool,
     pub(crate) rechunk: bool,
     pub(crate) schema: Arc<RwLock<Option<SchemaRef>>>,
@@ -84,7 +85,7 @@ impl LazyJsonLineReader {
     }
 
     #[must_use]
-    pub fn with_batch_size(mut self, batch_size: Option<usize>) -> Self {
+    pub fn with_batch_size(mut self, batch_size: Option<NonZeroUsize>) -> Self {
         self.batch_size = batch_size;
         self
     }

--- a/crates/polars-plan/src/logical_plan/options.rs
+++ b/crates/polars-plan/src/logical_plan/options.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "csv")]
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 use polars_core::prelude::*;
@@ -75,14 +77,27 @@ pub struct IpcWriterOptions {
 }
 
 #[cfg(feature = "csv")]
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct CsvWriterOptions {
     pub include_bom: bool,
     pub include_header: bool,
-    pub batch_size: usize,
+    pub batch_size: NonZeroUsize,
     pub maintain_order: bool,
     pub serialize_options: SerializeOptions,
+}
+
+#[cfg(feature = "csv")]
+impl Default for CsvWriterOptions {
+    fn default() -> Self {
+        Self {
+            include_bom: false,
+            include_header: true,
+            batch_size: NonZeroUsize::new(1024).unwrap(),
+            maintain_order: false,
+            serialize_options: SerializeOptions::default(),
+        }
+    }
 }
 
 #[cfg(feature = "json")]

--- a/crates/polars/tests/it/io/json.rs
+++ b/crates/polars/tests/it/io/json.rs
@@ -1,4 +1,5 @@
 use std::io::Cursor;
+use std::num::NonZeroUsize;
 
 use super::*;
 
@@ -21,7 +22,7 @@ fn read_json() {
     let df = JsonReader::new(file)
         .infer_schema_len(Some(3))
         .with_json_format(JsonFormat::JsonLines)
-        .with_batch_size(3)
+        .with_batch_size(NonZeroUsize::new(3).unwrap())
         .finish()
         .unwrap();
     assert_eq!("a", df.get_columns()[0].name());
@@ -49,7 +50,7 @@ fn read_json_with_whitespace() {
     let df = JsonReader::new(file)
         .infer_schema_len(Some(3))
         .with_json_format(JsonFormat::JsonLines)
-        .with_batch_size(3)
+        .with_batch_size(NonZeroUsize::new(3).unwrap())
         .finish()
         .unwrap();
     assert_eq!("a", df.get_columns()[0].name());
@@ -103,7 +104,7 @@ fn read_unordered_json() {
     let df = JsonReader::new(file)
         .infer_schema_len(Some(3))
         .with_json_format(JsonFormat::JsonLines)
-        .with_batch_size(3)
+        .with_batch_size(NonZeroUsize::new(3).unwrap())
         .finish()
         .unwrap();
     assert_eq!("a", df.get_columns()[0].name());

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1,4 +1,5 @@
 use std::io::{BufWriter, Cursor};
+use std::num::NonZeroUsize;
 use std::ops::Deref;
 
 use either::Either;
@@ -605,7 +606,7 @@ impl PyDataFrame {
         separator: u8,
         line_terminator: String,
         quote_char: u8,
-        batch_size: usize,
+        batch_size: NonZeroUsize,
         datetime_format: Option<String>,
         date_format: Option<String>,
         time_format: Option<String>,

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -121,7 +121,7 @@ impl PyLazyFrame {
         paths: Vec<PathBuf>,
         infer_schema_length: Option<usize>,
         schema: Option<Wrap<Schema>>,
-        batch_size: Option<usize>,
+        batch_size: Option<NonZeroUsize>,
         n_rows: Option<usize>,
         low_memory: bool,
         rechunk: bool,

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -2,6 +2,7 @@ mod exitable;
 
 use std::collections::HashMap;
 use std::io::BufWriter;
+use std::num::NonZeroUsize;
 use std::path::PathBuf;
 
 pub use exitable::PyInProcessQuery;
@@ -591,7 +592,7 @@ impl PyLazyFrame {
         separator: u8,
         line_terminator: String,
         quote_char: u8,
-        batch_size: usize,
+        batch_size: NonZeroUsize,
         datetime_format: Option<String>,
         date_format: Option<String>,
         time_format: Option<String>,

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1712,6 +1712,13 @@ def test_write_csv_bom() -> None:
     assert f.read() == b"\xef\xbb\xbfa,b\n1,1\n2,2\n3,3\n"
 
 
+def test_write_csv_batch_size_zero() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
+    f = io.BytesIO()
+    with pytest.raises(ValueError, match="invalid zero value"):
+        df.write_csv(f, batch_size=0)
+
+
 def test_empty_csv_no_raise() -> None:
     assert pl.read_csv(io.StringIO(), raise_if_empty=False, has_header=False).shape == (
         0,

--- a/py-polars/tests/unit/io/test_lazy_json.py
+++ b/py-polars/tests/unit/io/test_lazy_json.py
@@ -56,6 +56,11 @@ def test_scan_ndjson_with_schema(foods_ndjson_path: Path) -> None:
     assert df["sugars_g"].dtype == pl.Float64
 
 
+def test_scan_ndjson_batch_size_zero() -> None:
+    with pytest.raises(ValueError, match="invalid zero value"):
+        pl.scan_ndjson("test.ndjson", batch_size=0)
+
+
 @pytest.mark.write_disk()
 def test_scan_with_projection(tmp_path: Path) -> None:
     tmp_path.mkdir(exist_ok=True)

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -172,6 +172,12 @@ def test_sink_csv_exception_for_quote(value: str) -> None:
         df.sink_csv("path", quote_char=value)
 
 
+def test_sink_csv_batch_size_zero() -> None:
+    lf = pl.LazyFrame({"a": [1, 2, 3], "b": [1, 2, 3]})
+    with pytest.raises(ValueError, match="invalid zero value"):
+        lf.sink_csv("test.csv", batch_size=0)
+
+
 def test_scan_csv_only_header_10792(io_files_path: Path) -> None:
     foods_file_path = io_files_path / "only_header.csv"
     df = pl.scan_csv(foods_file_path).collect(streaming=True)


### PR DESCRIPTION
Supersedes #12088 - credit to @gwik for signalling this issue!

Fixes a hang when `batch_size=0` for affected functions.