### PR TITLE
fix(python): support corr() for single-column DataFrames

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -10220,7 +10220,10 @@ class DataFrame:
         │ 1.0  ┆ -1.0 ┆ 1.0  │
         └──────┴──────┴──────┘
         """
-        return DataFrame(np.corrcoef(self.to_numpy().T, **kwargs), schema=self.columns)
+        correlation_matrix = np.corrcoef(self.to_numpy(), rowvar=False, **kwargs)
+        if self.width == 1:
+            correlation_matrix = np.array([correlation_matrix])
+        return DataFrame(correlation_matrix, schema=self.columns)
 
     def merge_sorted(self, other: DataFrame, key: str) -> DataFrame:
         """

--- a/py-polars/tests/unit/operations/test_statistics.py
+++ b/py-polars/tests/unit/operations/test_statistics.py
@@ -9,6 +9,11 @@ from polars.testing import assert_frame_equal
 
 
 def test_corr() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    result = df.corr()
+    expected = pl.DataFrame({"a": [1.0]})
+    assert_frame_equal(result, expected)
+
     df = pl.DataFrame(
         {
             "a": [1, 2, 4],


### PR DESCRIPTION
I also took the liberty of adding rowvar=False in np.corrcoef(), to avoid having to transpose the array before correlating.

Before:

```python
>>> pl.DataFrame([1, 2, 3]).corr()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "polars/dataframe/frame.py", line 10223, in corr
    return DataFrame(np.corrcoef(self.to_numpy().T, **kwargs), schema=self.columns)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "polars/dataframe/frame.py", line 430, in __init__
    raise TypeError(msg)
TypeError: DataFrame constructor called with unsupported type 'float64' for the `data` parameter
```

After:

```python
>>> pl.DataFrame([1, 2, 3]).corr()
shape: (1, 1)
┌──────────┐
│ column_0 │
│ ---      │
│ f64      │
╞══════════╡
│ 1.0      │
└──────────┘
```