### PR TITLE
fix(python): fix error message when creating DataFrame from 0-dimensional NumPy array

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -1447,7 +1447,10 @@ def numpy_to_pydf(
                 msg = f"`orient` must be one of {{'col', 'row', None}}, got {orient!r}"
                 raise ValueError(msg)
         else:
-            msg = f"cannot create DataFrame from array with more than two dimensions; shape = {shape}"
+            if shape == ():
+                msg = "cannot create DataFrame from zero-dimensional array"
+            else:
+                msg = f"cannot create DataFrame from array with more than two dimensions; shape = {shape}"
             raise ValueError(msg)
 
     if schema is not None and len(schema) != n_columns:

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -419,9 +419,14 @@ def test_from_numpy() -> None:
     assert df.shape == (3, 2)
     assert df.rows() == [(1, 4), (2, 5), (3, 6)]
     assert df.schema == {"a": pl.UInt32, "b": pl.UInt32}
-    with pytest.raises(ValueError, match="cannot create DataFrame from array with more than two dimensions"):
+    with pytest.raises(
+        ValueError,
+        match="cannot create DataFrame from array with more than two dimensions",
+    ):
         _ = pl.from_numpy(np.array([[[1]]]))
-    with pytest.raises(ValueError, match="cannot create DataFrame from zero-dimensional array"):
+    with pytest.raises(
+        ValueError, match="cannot create DataFrame from zero-dimensional array"
+    ):
         _ = pl.from_numpy(np.array(1))
 
 

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -419,6 +419,10 @@ def test_from_numpy() -> None:
     assert df.shape == (3, 2)
     assert df.rows() == [(1, 4), (2, 5), (3, 6)]
     assert df.schema == {"a": pl.UInt32, "b": pl.UInt32}
+    with pytest.raises(ValueError, match="cannot create DataFrame from array with more than two dimensions"):
+        _ = pl.from_numpy(np.array([[[1]]]))
+    with pytest.raises(ValueError, match="cannot create DataFrame from zero-dimensional array"):
+        _ = pl.from_numpy(np.array(1))
 
 
 def test_from_numpy_structured() -> None:


### PR DESCRIPTION
Before:

```python
>>> pl.DataFrame(np.array(1))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "polars/py-polars/polars/dataframe/frame.py", line 394, in __init__
    self._df = numpy_to_pydf(
               ^^^^^^^^^^^^^^
  File "polars/py-polars/polars/utils/_construction.py", line 1451, in numpy_to_pydf
    raise ValueError(msg)
ValueError: cannot create DataFrame from array with more than two dimensions; shape = ()
```

After:

```python
>>> pl.DataFrame(np.array(1))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "polars/py-polars/polars/dataframe/frame.py", line 394, in __init__
    self._df = numpy_to_pydf(
               ^^^^^^^^^^^^^^
  File "polars/py-polars/polars/utils/_construction.py", line 1454, in numpy_to_pydf
    raise ValueError(msg)
ValueError: cannot create DataFrame from zero-dimensional array
```