### PR TITLE
fix(python): Keep Series attributes docstrings when read by Sphinx

### DIFF
--- a/py-polars/docs/source/reference/series/attributes.rst
+++ b/py-polars/docs/source/reference/series/attributes.rst
@@ -5,14 +5,10 @@ Attributes
 .. currentmodule:: polars
 .. autosummary::
    :toctree: api/
+   :template: autosummary/accessor_attribute.rst
 
-   Series.cat
-   Series.dt
    Series.dtype
    Series.inner_dtype
-   Series.list
    Series.name
    Series.shape
-   Series.str
    Series.flags
-   Series.plot

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -396,7 +396,7 @@ class sphinx_accessor(property):  # noqa: D101
                 instance if isinstance(instance, cls) else cls
             )
         except (AttributeError, ImportError):
-            return None  # type: ignore[return-value]
+            return self  # type: ignore[return-value]
 
 
 class _NoDefault(Enum):


### PR DESCRIPTION
This PR addresses the following:

1. Fixes the overidding descriptor that prevents Sphinx from properly reading Series attributes docstrings, which in turn makes them being shown with no docstrings at all. (e.g., https://docs.pola.rs/py-polars/html/reference/series/api/polars.Series.dtype.html)
2. Removes Series namespaces from the attributes section. Having Series namespaces shown as standalone attributes in the API section does not seem to have any usefulness. Methods accessed through these namespaces are shown anyway.