### PR TITLE
feat(rust,python,cli): add SQL support for `numeric` and/or `decimal` types

### DIFF
--- a/crates/polars-sql/Cargo.toml
+++ b/crates/polars-sql/Cargo.toml
@@ -12,7 +12,7 @@ description = "SQL transpiler for Polars. Converts SQL to Polars logical plans"
 arrow = { workspace = true }
 polars-core = { workspace = true }
 polars-error = { workspace = true }
-polars-lazy = { workspace = true, features = ["abs", "binary_encoding", "concat_str", "cross_join", "cum_agg", "dtype-date", "is_in", "log", "meta", "regex", "round_series", "sign", "string_reverse", "strings", "trigonometry"] }
+polars-lazy = { workspace = true, features = ["abs", "binary_encoding", "concat_str", "cross_join", "cum_agg", "dtype-date", "dtype-decimal", "is_in", "log", "meta", "regex", "round_series", "sign", "string_reverse", "strings", "trigonometry"] }
 polars-plan = { workspace = true }
 
 hex = { workspace = true }
@@ -30,6 +30,7 @@ polars-core = { workspace = true, features = ["fmt"] }
 csv = ["polars-lazy/csv"]
 json = ["polars-lazy/json"]
 default = []
+dtype-decimal = ["polars-lazy/dtype-decimal"]
 ipc = ["polars-lazy/ipc"]
 parquet = ["polars-lazy/parquet"]
 semi_anti_join = ["polars-lazy/semi_anti_join"]

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -272,6 +272,7 @@ dtype-i16 = ["polars-core/dtype-i16", "polars-lazy?/dtype-i16", "polars-ops/dtyp
 dtype-decimal = [
   "polars-core/dtype-decimal",
   "polars-lazy?/dtype-decimal",
+  "polars-sql?/dtype-decimal",
   "polars-ops/dtype-decimal",
   "polars-io/dtype-decimal",
 ]

--- a/py-polars/tests/unit/sql/test_numeric.py
+++ b/py-polars/tests/unit/sql/test_numeric.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from decimal import Decimal as D
+from typing import TYPE_CHECKING
+
 import pytest
 
 import polars as pl
 from polars.exceptions import InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
+
+if TYPE_CHECKING:
+    from polars.datatypes import PolarsDataType
 
 
 def test_modulo() -> None:
@@ -39,6 +45,41 @@ def test_modulo() -> None:
                 }
             ),
         )
+
+
+@pytest.mark.parametrize(
+    ("value", "sqltype", "prec_scale", "expected_value", "expected_dtype"),
+    [
+        (64.5, "numeric", "(3,1)", D("64.5"), pl.Decimal(3, 1)),
+        (512.5, "decimal", "(3,1)", D("512.5"), pl.Decimal(3, 1)),
+        (512.5, "numeric", "(4,0)", D("512"), pl.Decimal(4, 0)),
+        (-1024.75, "decimal", "(10,0)", D("-1024"), pl.Decimal(10, 0)),
+        (-1024.75, "numeric", "(10)", D("-1024"), pl.Decimal(10, 0)),
+        (-1024.75, "dec", "", D("-1024.75"), pl.Decimal(38, 9)),
+    ],
+)
+def test_numeric_decimal_type(
+    value: float,
+    sqltype: str,
+    prec_scale: str,
+    expected_value: D,
+    expected_dtype: PolarsDataType,
+) -> None:
+    with pl.Config(activate_decimals=True):
+        df = pl.DataFrame({"n": [value]})
+        with pl.SQLContext(df=df) as ctx:
+            out = ctx.execute(
+                f"""
+                SELECT n::{sqltype}{prec_scale} AS "dec" FROM df
+                """
+            )
+            assert_frame_equal(
+                out.collect(),
+                pl.DataFrame(
+                    data={"dec": [expected_value]},
+                    schema={"dec": expected_dtype},
+                ),
+            )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Assuming decimal support is activated, adds SQL syntax/parsing for:
```sql
colx::numeric,       colx::decimal,        colx::dec
colx::numeric(10),   colx::decimal(10),    colx::dec(10)
colx::numeric(10,5), colx::decimal(10,5),  colx::dec(10,5)
```
Note that `decimal` is simply an alias for `numeric` in PostgreSQL[^1]; they are the exact same type.

Also adds type-recognition of additional PostgreSQL integer aliases:
* `int8` (8 byte) → `Int64` 
* `int4` (4 byte )→ `Int32`
* `int2` (2 byte) → `Int16`

[^1]: PostgreSQL [numeric types](https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-TABLE/)