### PR TITLE
feat(python): allow `read_excel` to load from remote http locations

### DIFF
--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -9,6 +9,7 @@ import polars._reexport as pl
 from polars import functions as F
 from polars.datatypes import Date, Datetime, String
 from polars.exceptions import NoDataError, ParameterCollisionError
+from polars.io._utils import _process_http_file
 from polars.io.csv.functions import read_csv
 from polars.utils.various import normalize_filepath
 
@@ -400,7 +401,8 @@ def _read_spreadsheet(
     raise_if_empty: bool = True,
 ) -> pl.DataFrame | dict[str, pl.DataFrame]:
     if isinstance(source, (str, Path)):
-        source = normalize_filepath(source)
+        if (source := normalize_filepath(source)).startswith("http"):
+            source = _process_http_file(source)
 
     if engine is None:
         if (src := str(source).lower()).endswith(".ods"):


### PR DESCRIPTION
Closes #13718.

Small (three line 😅) update to run the path passed to `read_excel` through the same utility function as `read_csv` (for paths that begin with the "http" prefix).

```python
import polars as pl

remote_file = "https://atb-archive.nrel.gov/electricity/2020/files/2020-ATB-Data.xlsm"
pl.read_excel(remote_file, sheet_name="LCOE Range")

# shape: (12, 4)
# ┌──────────────────────────────┬───────────┬────────────┬────────────┐
# │ Technology                   ┆ Min       ┆ Difference ┆ Max        │
# │ ---                          ┆ ---       ┆ ---        ┆ ---        │
# │ str                          ┆ f64       ┆ f64        ┆ f64        │
# ╞══════════════════════════════╪═══════════╪════════════╪════════════╡
# │ Natural Gas                  ┆ 29.694559 ┆ 66.110439  ┆ 95.804998  │
# │ Coal                         ┆ 72.223685 ┆ 93.83216   ┆ 166.055844 │
# │ Nuclear                      ┆ 75.832182 ┆ 2.0        ┆ 75.832182  │
# │ Land-Based Wind              ┆ 28.320708 ┆ 98.920068  ┆ 127.240776 │
# │ Offshore Wind                ┆ 84.418738 ┆ 87.135401  ┆ 171.554139 │
# │ …                            ┆ …         ┆ …          ┆ …          │
# │ Solar - PV Dist. Residential ┆ 88.112836 ┆ 48.651903  ┆ 136.764739 │
# │ Solar - CSP                  ┆ 88.836103 ┆ 22.502418  ┆ 111.33852  │
# │ Geothermal                   ┆ 58.400147 ┆ 366.001221 ┆ 424.401367 │
# │ Hydropower                   ┆ 49.315104 ┆ 46.505838  ┆ 95.820942  │
# │ Biopower                     ┆ 86.066784 ┆ 29.196242  ┆ 115.263026 │
# └──────────────────────────────┴───────────┴────────────┴────────────┘
```