### PR TITLE
feat(rust!): Rename `drop_columns` to `drop`

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -436,7 +436,7 @@ impl LazyFrame {
     /// Removes columns from the DataFrame.
     /// Note that it's better to only select the columns you need
     /// and let the projection pushdown optimize away the unneeded columns.
-    pub fn drop_columns<I, T>(self, columns: I) -> Self
+    pub fn drop<I, T>(self, columns: I) -> Self
     where
         I: IntoIterator<Item = T>,
         T: AsRef<str>,
@@ -447,7 +447,7 @@ impl LazyFrame {
             .collect::<PlHashSet<_>>();
 
         let opt_state = self.get_opt_state();
-        let lp = self.get_plan_builder().drop_columns(to_drop).build();
+        let lp = self.get_plan_builder().drop(to_drop).build();
         Self::from_logical_plan(lp, opt_state)
     }
 

--- a/crates/polars-lazy/src/tests/projection_queries.rs
+++ b/crates/polars-lazy/src/tests/projection_queries.rs
@@ -26,7 +26,7 @@ fn test_join_suffix_and_drop() -> PolarsResult<()> {
         .right_on([col("id")])
         .suffix("_sire")
         .finish()
-        .drop_columns(["sireid"])
+        .drop(["sireid"])
         .collect()?;
 
     assert_eq!(out.shape(), (1, 3));

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -407,7 +407,7 @@ impl LogicalPlanBuilder {
         .into()
     }
 
-    pub fn drop_columns(self, to_drop: PlHashSet<String>) -> Self {
+    pub fn drop(self, to_drop: PlHashSet<String>) -> Self {
         let schema = try_delayed!(self.0.schema(), &self.0, into);
 
         let mut output_schema = Schema::with_capacity(schema.len().saturating_sub(to_drop.len()));

--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -451,7 +451,7 @@ impl SQLContext {
                 lf = self.process_order_by(lf, &query.order_by)?;
 
                 column_names.retain(|&name| !retained_names.contains(name));
-                lf.drop_columns(column_names)
+                lf.drop(column_names)
             } else if contains_wildcard_exclude {
                 let mut dropped_names = Vec::with_capacity(projections.len());
 
@@ -471,7 +471,7 @@ impl SQLContext {
                 if exclude_expr.is_some() {
                     lf = lf.with_columns(projections);
                     lf = self.process_order_by(lf, &query.order_by)?;
-                    lf.drop_columns(dropped_names)
+                    lf.drop(dropped_names)
                 } else {
                     lf = lf.select(projections);
                     self.process_order_by(lf, &query.order_by)?

--- a/crates/polars/tests/it/lazy/queries.rs
+++ b/crates/polars/tests/it/lazy/queries.rs
@@ -26,7 +26,7 @@ fn test_drop() -> PolarsResult<()> {
         "a" => [1],
     ]?
     .lazy()
-    .drop_columns(["a"])
+    .drop(["a"])
     .collect()?;
     assert_eq!(out.width(), 0);
     Ok(())

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -1026,7 +1026,7 @@ impl PyLazyFrame {
 
     fn drop(&self, columns: Vec<String>) -> Self {
         let ldf = self.ldf.clone();
-        ldf.drop_columns(columns).into()
+        ldf.drop(columns).into()
     }
 
     fn cast(&self, dtypes: HashMap<&str, Wrap<DataType>>, strict: bool) -> Self {


### PR DESCRIPTION
Ref #13745

To align with the public API on the Python side.