### PR TITLE
docs(python): correct `clone` docstring

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6909,7 +6909,7 @@ class DataFrame:
         """
         Create a copy of this DataFrame.
 
-        This is a cheap operation that does not copy data.
+        This is a cheap operation.
 
         See Also
         --------

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -2522,7 +2522,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Create a copy of this LazyFrame.
 
-        This is a cheap operation that does not copy data.
+        This is a cheap operation.
 
         See Also
         --------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4736,7 +4736,7 @@ class Series:
         """
         Create a copy of this Series.
 
-        This is a cheap operation that does not copy data.
+        This is a cheap operation.
 
         See Also
         --------


### PR DESCRIPTION
The `clone` docstring says that "(clone) does not copy data" when it is in fact copy data as shown, for example, in the docstrings example codeblocks. This corrects the issue. 

I did leave "This is a cheap operation." Short and sweet, but feels a little akward and would be great to know what exactly "cheap" means. Is `clone` some how cheaper than your normal assignment e.g. `df_1 = df`? If so, then I could modify to: "This is cheaper than using a direct assignment operation."
