### PR TITLE
fix(python): validate operator arithmetic with `None`, fix `Series` edge-case

### DIFF
--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -486,10 +486,11 @@ def maybe_cast(el: Any, dtype: PolarsDataType) -> Any:
         _timedelta_to_pl_timedelta,
     )
 
-    time_unit = getattr(dtype, "time_unit", None)
     if isinstance(el, datetime):
+        time_unit = getattr(dtype, "time_unit", None)
         return _datetime_to_pl_timestamp(el, time_unit)
     elif isinstance(el, timedelta):
+        time_unit = getattr(dtype, "time_unit", None)
         return _timedelta_to_pl_timedelta(el, time_unit)
 
     py_type = dtype_to_py_type(dtype)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -959,7 +959,7 @@ class Series:
             # expand pl.lit, pl.datetime, pl.duration Exprs to compatible Series
             other = self.to_frame().select_seq(other).to_series()
         elif other is None:
-            other = pl.Series("", [None], dtype=self.dtype)
+            other = pl.Series("", [None])
 
         if isinstance(other, Series):
             return self._from_pyseries(getattr(self._s, op_s)(other._s))

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -958,11 +958,14 @@ class Series:
         if isinstance(other, pl.Expr):
             # expand pl.lit, pl.datetime, pl.duration Exprs to compatible Series
             other = self.to_frame().select_seq(other).to_series()
+        elif other is None:
+            other = pl.Series("", [None], dtype=self.dtype)
+
         if isinstance(other, Series):
             return self._from_pyseries(getattr(self._s, op_s)(other._s))
-        if _check_for_numpy(other) and isinstance(other, np.ndarray):
+        elif _check_for_numpy(other) and isinstance(other, np.ndarray):
             return self._from_pyseries(getattr(self._s, op_s)(Series(other)._s))
-        if (
+        elif (
             isinstance(other, (float, date, datetime, timedelta, str))
             and not self.dtype.is_float()
         ):
@@ -971,6 +974,7 @@ class Series:
                 return self._from_pyseries(getattr(_s, op_s)(self._s))
             else:
                 return self._from_pyseries(getattr(self._s, op_s)(_s))
+
         if isinstance(other, (PyDecimal, int)) and self.dtype.is_decimal():
             # Infer the number's scale.  Then use the max of the inferred scale and the
             # Series' scale.  At present, this will cause arithmetic to fail with a

--- a/py-polars/tests/unit/operations/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/test_arithmetic.py
@@ -1,10 +1,13 @@
+import operator
 from datetime import date, datetime, timedelta
+from typing import Any
 
 import numpy as np
 import pytest
 
 import polars as pl
-from polars.testing import assert_series_equal
+from polars.datatypes import FLOAT_DTYPES, INTEGER_DTYPES
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_sqrt_neg_inf() -> None:
@@ -246,3 +249,33 @@ def test_arithmetic_null_count() -> None:
         "broadcast_left": [1],
         "broadcast_right": [1],
     }
+
+
+@pytest.mark.parametrize(
+    "op",
+    [
+        operator.add,
+        operator.floordiv,
+        operator.mod,
+        operator.mul,
+        operator.sub,
+    ],
+)
+def test_operator_arithmetic_with_nulls(op: Any) -> None:
+    for dtype in FLOAT_DTYPES | INTEGER_DTYPES:
+        df = pl.DataFrame({"n": [2, 3]}, schema={"n": dtype})
+        s = df.to_series()
+
+        df_expected = pl.DataFrame({"n": [None, None]}, schema={"n": dtype})
+        s_expected = df_expected.to_series()
+
+        # validate expr, frame, and series behaviour with null value arithmetic
+        op_name = operator.add.__name__
+        for null_expr in (None, pl.lit(None)):
+            assert_frame_equal(df_expected, df.select(op(pl.col("n"), null_expr)))
+            assert_frame_equal(
+                df_expected, df.select(getattr(pl.col("n"), op_name)(null_expr))
+            )
+
+        assert_frame_equal(df_expected, op(df, None))
+        assert_series_equal(s_expected, op(s, None))

--- a/py-polars/tests/unit/operations/test_arithmetic.py
+++ b/py-polars/tests/unit/operations/test_arithmetic.py
@@ -270,7 +270,7 @@ def test_operator_arithmetic_with_nulls(op: Any) -> None:
         s_expected = df_expected.to_series()
 
         # validate expr, frame, and series behaviour with null value arithmetic
-        op_name = operator.add.__name__
+        op_name = op.__name__
         for null_expr in (None, pl.lit(None)):
             assert_frame_equal(df_expected, df.select(op(pl.col("n"), null_expr)))
             assert_frame_equal(


### PR DESCRIPTION
Adds test coverage for operator arithmetic against `None` (and tests the associated named methods). Discovered that `Series` was inconsistently raising an error where the same ops on `Expr` and `DataFrame` succeeded.

**Note:**
This may be an implicit regression of some kind (from the `0.19.x` series) as it was found via unit testing while trying to upgrade our work codebase to `0.20.x` 🤔 

## Example
All of the following formulations work consistently...
```python
df = pl.DataFrame({"n": [2, 3]})

df.select( pl.col("n") * pl.lit(None) )
df.select( pl.col("n") * None )
df * pl.Series([None])
df * None

# shape: (2, 1)
# ┌──────┐
# │ n    │
# │ ---  │
# │ i64  │
# ╞══════╡
# │ null │
# │ null │
# └──────┘

df["n"] * pl.Series([None])

# shape: (2,)
# Series: 'n' [i64]
# [
#   null
#   null
# ]
```
... _only_ this variant failed:
```python
df["n"] * None
# `mul` operation not supported for dtype `null`
```
I've fixed this and added the missing test coverage.