### PR TITLE
feat(python): allow `ftp` URLs, improve URL check

### DIFF
--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -158,8 +158,8 @@ def _prepare_file_arg(
         # make sure that this is before fsspec
         # as fsspec needs requests to be installed
         # to read from http
-        if file.startswith("http"):
-            return _process_http_file(file, encoding_str)
+        if _looks_like_url(file):
+            return _process_file_url(file, encoding_str)
         if _FSSPEC_AVAILABLE:
             from fsspec.utils import infer_storage_options
 
@@ -222,7 +222,11 @@ def _check_empty(
     return b
 
 
-def _process_http_file(path: str, encoding: str | None = None) -> BytesIO:
+def _looks_like_url(path: str) -> bool:
+    return re.match("^(ht|f)tps?://", path, re.IGNORECASE) is not None
+
+
+def _process_file_url(path: str, encoding: str | None = None) -> BytesIO:
     from urllib.request import urlopen
 
     with urlopen(path) as f:

--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -9,7 +9,7 @@ import polars._reexport as pl
 from polars import functions as F
 from polars.datatypes import Date, Datetime, String
 from polars.exceptions import NoDataError, ParameterCollisionError
-from polars.io._utils import _process_http_file
+from polars.io._utils import _looks_like_url, _process_file_url
 from polars.io.csv.functions import read_csv
 from polars.utils.various import normalize_filepath
 
@@ -401,8 +401,9 @@ def _read_spreadsheet(
     raise_if_empty: bool = True,
 ) -> pl.DataFrame | dict[str, pl.DataFrame]:
     if isinstance(source, (str, Path)):
-        if (source := normalize_filepath(source)).startswith("http"):
-            source = _process_http_file(source)
+        source = normalize_filepath(source)
+        if _looks_like_url(source):
+            source = _process_file_url(source)
 
     if engine is None:
         if (src := str(source).lower()).endswith(".ods"):

--- a/py-polars/tests/unit/utils/test_utils.py
+++ b/py-polars/tests/unit/utils/test_utils.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+from polars.io._utils import _looks_like_url
 from polars.utils.convert import (
     _date_to_pl_date,
     _datetime_to_pl_timestamp,
@@ -228,3 +229,22 @@ def test_is_str_sequence_check(
     assert is_str_sequence(sequence, include_series=include_series) == expected
     if expected:
         assert is_sequence(sequence, include_series=include_series)
+
+
+@pytest.mark.parametrize(
+    ("url", "result"),
+    [
+        ("HTTPS://pola.rs/data.csv", True),
+        ("http://pola.rs/data.csv", True),
+        ("ftps://pola.rs/data.csv", True),
+        ("FTP://pola.rs/data.csv", True),
+        ("htp://pola.rs/data.csv", False),
+        ("fttp://pola.rs/data.csv", False),
+        ("http_not_a_url", False),
+        ("ftp_not_a_url", False),
+        ("/mnt/data.csv", False),
+        ("file://mnt/data.csv", False),
+    ],
+)
+def test_looks_like_url(url: str, result: bool) -> None:
+    assert _looks_like_url(url) == result


### PR DESCRIPTION
We had a _very_ basic check against string file paths to see if they looked like they might be a URL (just "starts with 'http'"). This can lead to (somewhat unlikely) false positives, fail on upper case urls, and excludes `ftp`, which the underlying `urlopen` method also handles.

Made the check more robust and validated loading data from an ftp server; worked fine👌