### PR TITLE
perf: fast-path for eager int_range

### DIFF
--- a/crates/polars-ops/src/series/ops/int_range.rs
+++ b/crates/polars-ops/src/series/ops/int_range.rs
@@ -1,0 +1,35 @@
+use polars_core::prelude::*;
+use polars_core::series::IsSorted;
+
+pub fn new_int_range<T>(
+    start: T::Native,
+    end: T::Native,
+    step: i64,
+    name: &str,
+) -> PolarsResult<Series>
+where
+    T: PolarsIntegerType,
+    ChunkedArray<T>: IntoSeries,
+    std::ops::Range<T::Native>: DoubleEndedIterator<Item = T::Native>,
+{
+    let mut ca = match step {
+        0 => polars_bail!(InvalidOperation: "step must not be zero"),
+        1 => ChunkedArray::<T>::from_iter_values(name, start..end),
+        2.. => ChunkedArray::<T>::from_iter_values(name, (start..end).step_by(step as usize)),
+        _ => ChunkedArray::<T>::from_iter_values(
+            name,
+            (end..start)
+                .step_by(step.unsigned_abs() as usize)
+                .map(|x| start - (x - end)),
+        ),
+    };
+
+    let is_sorted = if end < start {
+        IsSorted::Descending
+    } else {
+        IsSorted::Ascending
+    };
+    ca.set_sorted_flag(is_sorted);
+
+    Ok(ca.into_series())
+}

--- a/crates/polars-ops/src/series/ops/mod.rs
+++ b/crates/polars-ops/src/series/ops/mod.rs
@@ -20,6 +20,7 @@ mod floor_divide;
 mod fused;
 mod horizontal;
 mod index;
+mod int_range;
 #[cfg(feature = "is_between")]
 mod is_between;
 #[cfg(feature = "is_first_distinct")]
@@ -76,6 +77,7 @@ pub use floor_divide::*;
 pub use fused::*;
 pub use horizontal::*;
 pub use index::*;
+pub use int_range::*;
 #[cfg(feature = "is_between")]
 pub use is_between::*;
 #[cfg(feature = "is_first_distinct")]

--- a/py-polars/polars/functions/range/int_range.py
+++ b/py-polars/polars/functions/range/int_range.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, overload
 from polars import functions as F
 from polars.datatypes import Int64
 from polars.utils._parse_expr_input import parse_as_expression
-from polars.utils._wrap import wrap_expr
+from polars.utils._wrap import wrap_expr, wrap_s
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     import polars.polars as plr
@@ -219,6 +219,9 @@ def int_range(
     if end is None:
         end = start
         start = 0
+
+    if isinstance(start, int) and isinstance(end, int) and eager:
+        return wrap_s(plr.eager_int_range(start, end, step, dtype))
 
     start = parse_as_expression(start)
     end = parse_as_expression(end)

--- a/py-polars/src/functions/eager.rs
+++ b/py-polars/src/functions/eager.rs
@@ -1,8 +1,10 @@
 use polars::functions;
 use polars_core::prelude::*;
+use polars_core::with_match_physical_integer_polars_type;
+use polars_ops::series::new_int_range;
 use pyo3::prelude::*;
 
-use crate::conversion::{get_df, get_series};
+use crate::conversion::{get_df, get_series, Wrap};
 use crate::error::PyPolarsErr;
 use crate::{PyDataFrame, PySeries};
 
@@ -90,4 +92,22 @@ pub fn concat_df_horizontal(dfs: &PyAny) -> PyResult<PyDataFrame> {
 
     let df = functions::concat_df_horizontal(&dfs).map_err(PyPolarsErr::from)?;
     Ok(df.into())
+}
+
+#[pyfunction]
+pub fn eager_int_range(
+    lower: &PyAny,
+    upper: &PyAny,
+    step: &PyAny,
+    dtype: Wrap<DataType>,
+) -> PyResult<PySeries> {
+    let ret = with_match_physical_integer_polars_type!(dtype.0, |$T| {
+        let start_v: <$T as PolarsNumericType>::Native = lower.extract()?;
+        let end_v: <$T as PolarsNumericType>::Native = upper.extract()?;
+        let step: i64 = step.extract()?;
+        new_int_range::<$T>(start_v, end_v, step, "literal")
+    });
+
+    let s = ret.map_err(PyPolarsErr::from)?;
+    Ok(s.into())
 }

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -96,6 +96,8 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
         .unwrap();
     m.add_wrapped(wrap_pyfunction!(functions::concat_df_horizontal))
         .unwrap();
+    m.add_wrapped(wrap_pyfunction!(functions::eager_int_range))
+        .unwrap();
 
     // Functions - range
     m.add_wrapped(wrap_pyfunction!(functions::int_range))


### PR DESCRIPTION
We probably want something more robust for eager expressions in general, but this should at least resolve https://github.com/pola-rs/polars/issues/13796.