### PR TITLE
feat(python): Add typing to hvplot plot namespace

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -132,6 +132,7 @@ if TYPE_CHECKING:
     from typing import Literal
 
     import deltalake
+    from hvplot.plotting.core import hvPlotTabularPolars
     from xlsxwriter import Workbook
 
     from polars import DataType, Expr, LazyFrame, Series
@@ -1118,7 +1119,7 @@ class DataFrame:
         return self
 
     @property
-    def plot(self) -> hvplot.plotting.core.hvPlotTabularPolars:
+    def plot(self) -> hvPlotTabularPolars:
         """
         Create a plot namespace.
 
@@ -4423,7 +4424,7 @@ class DataFrame:
                 expr = F.col(c).quantile(p) if c in stat_cols else F.lit(None)
                 expr = expr.alias(f"{p}:{c}")
                 percentile_exprs.append(expr)
-            metrics.append(f"{p*100:g}%")
+            metrics.append(f"{p * 100:g}%")
         metrics.append("max")
 
         mean_exprs = [

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1118,7 +1118,7 @@ class DataFrame:
         return self
 
     @property
-    def plot(self) -> Any:
+    def plot(self) -> hvplot.plotting.core.hvPlotTabularPolars:
         """
         Create a plot namespace.
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -114,9 +114,10 @@ from polars.utils.various import (
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame, PySeries
 
-
 if TYPE_CHECKING:
     import sys
+
+    from hvplot.plotting.core import hvPlotTabularPolars
 
     from polars import DataFrame, DataType, Expr
     from polars.series._numpy import SeriesView
@@ -7577,7 +7578,7 @@ class Series:
         return StructNameSpace(self)
 
     @property
-    def plot(self) -> hvplot.plotting.core.hvPlotTabularPolars:
+    def plot(self) -> hvPlotTabularPolars:
         """
         Create a plot namespace.
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -7577,7 +7577,7 @@ class Series:
         return StructNameSpace(self)
 
     @property
-    def plot(self) -> Any:
+    def plot(self) -> hvplot.plotting.core.hvPlotTabularPolars:
         """
         Create a plot namespace.
 


### PR DESCRIPTION
Tagging @MarcoGorelli who added the super nice plotting functionality.

I noticed that I didn't get type hinting on the `df.plot` namespace, so decided to add it here. Were there any particular reasons you didn't do so?

Note that since we `from __future__ import annotations`, the return type won't raise a runtime this (without strings) despite hvplot possibly not being installed.