### PR TITLE
fix: Fix segfault of `is_in`

### DIFF
--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -151,8 +151,17 @@ pub(crate) fn all_return_scalar(e: &Expr) -> bool {
         Expr::Literal(lv) => lv.projects_as_scalar(),
         Expr::Function { options: opt, .. } => opt.returns_scalar,
         Expr::Agg(_) => true,
-        Expr::Column(_) => false,
-        _ => expr_to_leaf_column_exprs_iter(e).all(all_return_scalar),
+        Expr::Column(_) | Expr::Wildcard => false,
+        _ => {
+            let mut empty = true;
+            for leaf in expr_to_leaf_column_exprs_iter(e) {
+                if !all_return_scalar(leaf) {
+                    return false;
+                }
+                empty = false;
+            }
+            !empty
+        },
     }
 }
 

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -306,3 +306,9 @@ def test_cat_is_in_with_lit_str_cache_setup(dtype: pl.DataType) -> None:
     assert_series_equal(pl.Series(["a"], dtype=dtype).is_in(["a"]), pl.Series([True]))
     assert_series_equal(pl.Series(["b"], dtype=dtype).is_in(["b"]), pl.Series([True]))
     assert_series_equal(pl.Series(["c"], dtype=dtype).is_in(["c"]), pl.Series([True]))
+
+
+def test_is_in_with_wildcard_13809() -> None:
+    out = pl.DataFrame({"A": ["B"]}).select(pl.all().is_in(["C"]))
+    expected = pl.DataFrame({"A": [False]})
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
Ideally, we'd want to expand the wildcard before we decide the `return_scalar`, but we don't have the schema information of the plan here. Is there a good way we can do something like rewriting projection here?

Not expanding it at least shouldn't raise. Anyway, I decided to fix this first and think about optimizations later. 

This fixes #13809.