### PR TITLE
fix: don't panic on full null qcut

### DIFF
--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -108,6 +108,12 @@ pub fn qcut(
     let s = s.cast(&DataType::Float64)?;
     let s2 = s.sort(false);
     let ca = s2.f64()?;
+    
+    if ca.null_count() == ca.len() {
+        // If we only have nulls we don't have any breakpoints.
+        return cut(&s, vec![], labels, left_closed, include_breaks);
+    }
+
     let f = |&p| {
         ca.quantile(p, QuantileInterpolOptions::Linear)
             .unwrap()

--- a/crates/polars-ops/src/series/ops/cut.rs
+++ b/crates/polars-ops/src/series/ops/cut.rs
@@ -108,7 +108,7 @@ pub fn qcut(
     let s = s.cast(&DataType::Float64)?;
     let s2 = s.sort(false);
     let ca = s2.f64()?;
-    
+
     if ca.null_count() == ca.len() {
         // If we only have nulls we don't have any breakpoints.
         return cut(&s, vec![], labels, left_closed, include_breaks);

--- a/py-polars/tests/unit/operations/test_qcut.py
+++ b/py-polars/tests/unit/operations/test_qcut.py
@@ -90,6 +90,15 @@ def test_qcut_null_values() -> None:
     assert_series_equal(result, expected, categorical_as_str=True)
 
 
+def test_qcut_full_null() -> None:
+    s = pl.Series("a", [None, None, None, None])
+
+    result = s.qcut([0.25, 0.50])
+
+    expected = pl.Series("a", [None, None, None, None], dtype=pl.Categorical)
+    assert_series_equal(result, expected, categorical_as_str=True)
+
+
 def test_qcut_allow_duplicates() -> None:
     s = pl.Series([1, 2, 2, 3])
 


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/13707.

Probably not the best way to handle this with regards to labelling, but since `qcut` is getting reworked anyway, this will do now.