### PR TITLE
fix(rust): follow function params for left-most name

### DIFF
--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -205,6 +205,15 @@ pub(crate) fn get_single_leaf(expr: &Expr) -> PolarsResult<Arc<str>> {
             Expr::Window { function, .. } => return get_single_leaf(function),
             Expr::Column(name) => return Ok(name.clone()),
             Expr::Len => return Ok(Arc::from(LEN)),
+            Expr::Function { input, .. } => {
+                // if we have no inputs, return "literal", else follow the left-most input
+                if input.is_empty() {
+                    return Ok(Arc::from(LITERAL_NAME));
+                } else {
+                    return get_single_leaf(&input[0]);
+                }
+            },
+            Expr::Literal(_) => return Ok(Arc::from(LITERAL_NAME)),
             _ => {},
         }
     }

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -39,6 +39,9 @@ def test_suffix(fruits_cars: pl.DataFrame) -> None:
     out = df.select([pl.all().name.suffix("_reverse")])
     assert out.columns == ["A_reverse", "fruits_reverse", "B_reverse", "cars_reverse"]
 
+    out = pl.select(pl.int_range(1, 5).alias("int").name.suffix("_moo"))
+    assert out.columns == ["literal_moo"]
+
 
 def test_pipe() -> None:
     df = pl.DataFrame({"foo": [1, 2, 3], "bar": [6, None, 8]})


### PR DESCRIPTION
Resolves #13817

Not completely sure this is the proper resolution but it fixes the issue. This does cause one test to fail so @reswqa I may need your help here. The failing test is this:
 
```python
import polars as pl
df = (
    pl.DataFrame(
        {
            "col1": pl.int_range(0, 7, eager=True),
            "col2": pl.int_range(0, 7, eager=True).reverse(),
        }
    )
).with_columns(
    [
        pl.when(pl.int_range(0, pl.len(), eager=False) < 2)
        .then(None)
        .otherwise(pl.all())
        .name.suffix("_nulls")
    ]
)
```
```
polars.exceptions.ComputeError: The name: 'literal_nulls' passed to `LazyFrame.with_columns` is duplicate
```

The reason being that now `pl.int_range()` returns "literal" since it has no left-most arg.