### PR TITLE
fix: Implement `abs` for Decimal, error on Date/Time/Datetime

### DIFF
--- a/crates/polars-ops/src/series/ops/abs.rs
+++ b/crates/polars-ops/src/series/ops/abs.rs
@@ -19,11 +19,6 @@ pub fn abs(s: &Series) -> PolarsResult<Series> {
         Int16 => abs_numeric(s.i16().unwrap()).into_series(),
         Int32 => abs_numeric(s.i32().unwrap()).into_series(),
         Int64 => abs_numeric(s.i64().unwrap()).into_series(),
-        #[cfg(feature = "dtype-u8")]
-        UInt8 => s.clone(),
-        #[cfg(feature = "dtype-u16")]
-        UInt16 => s.clone(),
-        UInt32 | UInt64 => s.clone(),
         Float32 => abs_numeric(s.f32().unwrap()).into_series(),
         Float64 => abs_numeric(s.f64().unwrap()).into_series(),
         #[cfg(feature = "dtype-decimal")]
@@ -42,6 +37,7 @@ pub fn abs(s: &Series) -> PolarsResult<Series> {
             let out = abs_numeric(ca).into_series();
             out.cast(s.dtype())?
         },
+        dt if dt.is_unsigned_integer() => s.clone(),
         dt => polars_bail!(opq = abs, dt),
     };
     Ok(out)

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -412,13 +412,6 @@ def test_search_sorted() -> None:
     assert a.search_sorted(b, side="right").to_list() == [0, 2, 2, 4, 4]
 
 
-def test_abs_expr() -> None:
-    df = pl.DataFrame({"x": [-1, 0, 1]})
-    out = df.select(abs(pl.col("x")))
-
-    assert out["x"].to_list() == [1, 0, 1]
-
-
 def test_logical_boolean() -> None:
     # note, cannot use expressions in logical
     # boolean context (eg: and/or/not operators)

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -388,11 +387,6 @@ def test_fill_null_unknown_output_type() -> None:
             148.4131591025766,
         ]
     }
-
-
-def test_abs_logical_type() -> None:
-    s = pl.Series([timedelta(hours=1), timedelta(hours=-1)])
-    assert s.abs().to_list() == [timedelta(hours=1), timedelta(hours=1)]
 
 
 def test_approx_n_unique() -> None:

--- a/py-polars/tests/unit/operations/test_abs.py
+++ b/py-polars/tests/unit/operations/test_abs.py
@@ -1,10 +1,14 @@
-from datetime import timedelta
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal as D
 from typing import cast
 
 import numpy as np
+import pytest
 
 import polars as pl
-from polars.testing import assert_series_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_abs() -> None:
@@ -22,7 +26,7 @@ def test_abs() -> None:
     )
 
 
-def test_abs_logical_type() -> None:
+def test_abs_series_duration() -> None:
     s = pl.Series([timedelta(hours=1), timedelta(hours=-1)])
     assert s.abs().to_list() == [timedelta(hours=1), timedelta(hours=1)]
 
@@ -37,3 +41,70 @@ def test_abs_expr() -> None:
 def test_builtin_abs() -> None:
     s = pl.Series("s", [-1, 0, 1, None])
     assert abs(s).to_list() == [1, 0, 1, None]
+
+
+@pytest.mark.parametrize(
+    "dtype", [pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.Float32, pl.Float64]
+)
+def test_abs_builtin(dtype: pl.PolarsDataType) -> None:
+    lf = pl.LazyFrame({"a": [-1, 0, 1, None]}, schema={"a": dtype})
+    result = lf.select(abs(pl.col("a")))
+    expected = pl.LazyFrame({"a": [1, 0, 1, None]}, schema={"a": dtype})
+    assert_frame_equal(result, expected)
+
+
+def test_abs_method() -> None:
+    lf = pl.LazyFrame({"a": [-1, 0, 1, None]})
+    result_op = lf.select(abs(pl.col("a")))
+    result_method = lf.select(pl.col("a").abs())
+    assert_frame_equal(result_op, result_method)
+
+
+def test_abs_decimal() -> None:
+    lf = pl.LazyFrame({"a": [D("-1.5"), D("0.0"), D("5.0"), None]})
+    result = lf.select(pl.col("a").abs())
+    expected = pl.LazyFrame({"a": [D("1.5"), D("0.0"), D("5.0"), None]})
+    assert_frame_equal(result, expected)
+
+
+def test_abs_duration() -> None:
+    lf = pl.LazyFrame({"a": [timedelta(hours=2), timedelta(days=-2), None]})
+    result = lf.select(pl.col("a").abs())
+    expected = pl.LazyFrame({"a": [timedelta(hours=2), timedelta(days=2), None]})
+    assert_frame_equal(result, expected)
+
+
+def test_abs_overflow() -> None:
+    df = pl.DataFrame({"a": [-128]}, schema={"a": pl.Int8})
+    with pytest.raises(pl.PolarsPanicError, match="attempt to negate with overflow"):
+        df.select(pl.col("a").abs())
+
+
+def test_abs_unsigned_int() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]}, schema={"a": pl.UInt8})
+    result = df.select(pl.col("a").abs())
+    assert_frame_equal(result, df)
+
+
+def test_abs_non_numeric() -> None:
+    df = pl.DataFrame({"a": ["p", "q", "r"]})
+    with pytest.raises(
+        pl.InvalidOperationError, match="`abs` operation not supported for dtype `str`"
+    ):
+        df.select(pl.col("a").abs())
+
+
+def test_abs_date() -> None:
+    df = pl.DataFrame({"date": [date(1960, 1, 1), date(1970, 1, 1), date(1980, 1, 1)]})
+
+    with pytest.raises(
+        pl.InvalidOperationError, match="`abs` operation not supported for dtype `date`"
+    ):
+        df.select(pl.col("date").abs())
+
+
+def test_abs_series_builtin() -> None:
+    s = pl.Series("a", [-1, 0, 1, None])
+    result = abs(s)
+    expected = pl.Series("a", [1, 0, 1, None])
+    assert_series_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_abs.py
+++ b/py-polars/tests/unit/operations/test_abs.py
@@ -1,0 +1,39 @@
+from datetime import timedelta
+from typing import cast
+
+import numpy as np
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+
+def test_abs() -> None:
+    # ints
+    s = pl.Series([1, -2, 3, -4])
+    assert_series_equal(s.abs(), pl.Series([1, 2, 3, 4]))
+    assert_series_equal(cast(pl.Series, np.abs(s)), pl.Series([1, 2, 3, 4]))
+
+    # floats
+    s = pl.Series([1.0, -2.0, 3, -4.0])
+    assert_series_equal(s.abs(), pl.Series([1.0, 2.0, 3.0, 4.0]))
+    assert_series_equal(cast(pl.Series, np.abs(s)), pl.Series([1.0, 2.0, 3.0, 4.0]))
+    assert_series_equal(
+        pl.select(pl.lit(s).abs()).to_series(), pl.Series([1.0, 2.0, 3.0, 4.0])
+    )
+
+
+def test_abs_logical_type() -> None:
+    s = pl.Series([timedelta(hours=1), timedelta(hours=-1)])
+    assert s.abs().to_list() == [timedelta(hours=1), timedelta(hours=1)]
+
+
+def test_abs_expr() -> None:
+    df = pl.DataFrame({"x": [-1, 0, 1]})
+    out = df.select(abs(pl.col("x")))
+
+    assert out["x"].to_list() == [1, 0, 1]
+
+
+def test_builtin_abs() -> None:
+    s = pl.Series("s", [-1, 0, 1, None])
+    assert abs(s).to_list() == [1, 0, 1, None]

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1654,21 +1654,6 @@ def test_temporal_comparison(
     )
 
 
-def test_abs() -> None:
-    # ints
-    s = pl.Series([1, -2, 3, -4])
-    assert_series_equal(s.abs(), pl.Series([1, 2, 3, 4]))
-    assert_series_equal(cast(pl.Series, np.abs(s)), pl.Series([1, 2, 3, 4]))
-
-    # floats
-    s = pl.Series([1.0, -2.0, 3, -4.0])
-    assert_series_equal(s.abs(), pl.Series([1.0, 2.0, 3.0, 4.0]))
-    assert_series_equal(cast(pl.Series, np.abs(s)), pl.Series([1.0, 2.0, 3.0, 4.0]))
-    assert_series_equal(
-        pl.select(pl.lit(s).abs()).to_series(), pl.Series([1.0, 2.0, 3.0, 4.0])
-    )
-
-
 def test_to_dummies() -> None:
     s = pl.Series("a", [1, 2, 3])
     result = s.to_dummies()
@@ -2397,11 +2382,6 @@ def test_repr_html(df: pl.DataFrame) -> None:
     # check it does not panic/error, and appears to contain a table
     html = pl.Series("misc", [123, 456, 789])._repr_html_()
     assert "<table" in html
-
-
-def test_builtin_abs() -> None:
-    s = pl.Series("s", [-1, 0, 1, None])
-    assert abs(s).to_list() == [1, 0, 1, None]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I noticed `abs` just operated on the physical type, but that makes no sense for dates, e.g. `date(1960, 1, 1)` gets changed to `date(1980, 1, 1)`. Now it properly raises an error.

