### PR TITLE
docs: adding cmake requirement to contributing guide

### DIFF
--- a/docs/development/contributing/index.md
+++ b/docs/development/contributing/index.md
@@ -69,6 +69,16 @@ We recommend using the latest Python version (`3.12`).
 Make sure you deactivate any active virtual environments or conda environments, as the steps below will create a new virtual environment for Polars.
 You will need Python even if you intend to work on the Rust code only, as we rely on the Python tests to verify all functionality.
 
+Additionally, If you do not have [cmake](https://cmake.org) installed, it's important for compiling some of Polars' dependencies.
+
+**For macOS:** Install `cmake` via Homebrew by running the following:
+
+```bash
+$ brew install cmake
+```
+
+**For Windows or Linux:** Download an installer from the official [cmake website](https://cmake.org/download/).
+
 Finally, install [dprint](https://dprint.dev/install/).
 This is not strictly required, but it is recommended as we use it to autoformat certain file types.
 


### PR DESCRIPTION
Closes #13774.

This PR updates the [Contributing Overview](https://docs.pola.rs/development/contributing/) to include `cmake` as a required dependency for contributors. The necessity for `cmake` was identified in issue #10730, but it appears that the issue still exists.

I'm happy to provide any more information on the installation issue I faced if it's helpful.