### PR TITLE
fix(python): ensure kwargs `filter` behaviour matches docstring (expect equivalence with `eq`)

### DIFF
--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -446,7 +446,7 @@ class LazyFrame:
             return scan  # type: ignore[return-value]
 
         if storage_options:
-            storage_options = list(storage_options.items())  #  type: ignore[assignment]
+            storage_options = list(storage_options.items())  # type: ignore[assignment]
         else:
             # Handle empty dict input
             storage_options = None
@@ -2698,7 +2698,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         # unpack equality constraints from kwargs
         all_predicates.extend(
-            F.col(name).eq_missing(value) for name, value in constraints.items()
+            F.col(name).eq(value) for name, value in constraints.items()
         )
         if not (all_predicates or boolean_masks):
             msg = "at least one predicate or constraint must be provided"

--- a/py-polars/tests/unit/functions/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/functions/aggregation/test_horizontal.py
@@ -37,10 +37,10 @@ def test_all_any_horizontally() -> None:
     assert_frame_equal(result, expected)
 
     # note: a kwargs filter will use an internal call to all_horizontal
-    dfltr = df.lazy().filter(var1=None, var3=False)
-    assert dfltr.collect().rows() == [(None, None, False)]
+    dfltr = df.lazy().filter(var1=True, var3=False)
+    assert dfltr.collect().rows() == [(True, False, False)]
 
-    # confirm that we reduce the horizontal filter components
+    # confirm that we reduced the horizontal filter components
     # (eg: explain does not contain an "all_horizontal" node)
     assert "horizontal" not in dfltr.explain().lower()
 

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1670,8 +1670,8 @@ def test_limit() -> None:
 def test_filter() -> None:
     s = pl.Series("a", [1, 2, 3])
     mask = pl.Series("", [True, False, True])
-    assert_series_equal(s.filter(mask), pl.Series("a", [1, 3]))
 
+    assert_series_equal(s.filter(mask), pl.Series("a", [1, 3]))
     assert_series_equal(s.filter([True, False, True]), pl.Series("a", [1, 3]))
 
 

--- a/py-polars/tests/unit/test_predicates.py
+++ b/py-polars/tests/unit/test_predicates.py
@@ -2,8 +2,9 @@ from datetime import date, datetime, timedelta
 from typing import Any
 
 import numpy as np
-import polars as pl
 import pytest
+
+import polars as pl
 from polars.testing import assert_frame_equal
 from polars.testing.asserts.series import assert_series_equal
 


### PR DESCRIPTION
Closes #13861.

Frame-level `filter` was behaving inconsistently with `expr.filter` and with its own docstring. Should have been using `eq` instead of `eq_missing` when accumulating filters from kwargs.

Fixed, also extending test coverage to validate generation of a suitable `UserWarning` on use of `eq` with "None", and to confirm that the query plan doesn't contain a reference to `eq_missing`.