### PR TITLE
docs(python): use proper argument names in the code blocks of api.rst

### DIFF
--- a/py-polars/docs/source/reference/api.rst
+++ b/py-polars/docs/source/reference/api.rst
@@ -93,7 +93,7 @@ Examples
 
             pl.DataFrame(
                 data=["aaa", "bbb", "ccc", "ddd", "eee", "fff"],
-                columns=[("txt", pl.String)],
+                schema=[("txt", pl.String)],
             ).split.by_alternate_rows()
 
             # [┌─────┐  ┌─────┐
@@ -124,7 +124,7 @@ Examples
 
             ldf = pl.DataFrame(
                 data={"a": [1, 2], "b": [3, 4], "c": [5.6, 6.7]},
-                columns=[("a", pl.Int16), ("b", pl.Int32), ("c", pl.Float32)],
+                schema=[("a", pl.Int16), ("b", pl.Int32), ("c", pl.Float32)],
             ).lazy()
 
             ldf.types.upcast_integer_types()

--- a/py-polars/docs/source/reference/api.rst
+++ b/py-polars/docs/source/reference/api.rst
@@ -157,8 +157,8 @@ Examples
 
             s = pl.Series("n", [1, 2, 3, 4, 5])
 
-            s2 = s.math.square().rename("n2", in_place=True)
-            s3 = s.math.cube().rename("n3", in_place=True)
+            s2 = s.math.square().rename("n2")
+            s3 = s.math.cube().rename("n3")
 
             # shape: (5,)          shape: (5,)           shape: (5,)
             # Series: 'n' [i64]    Series: 'n2' [i64]    Series: 'n3' [i64]


### PR DESCRIPTION
Thanks for developing such an amazing library! Just fixing argument names to ones for polars rather than ones for pandas. The original code blocks did work by just copy-and-pasting but now they should.