### PR TITLE
feat(python): Align `int_range` and `int_ranges` signatures

### DIFF
--- a/py-polars/polars/functions/range/int_range.py
+++ b/py-polars/polars/functions/range/int_range.py
@@ -93,9 +93,9 @@ def arange(
 
     Examples
     --------
-    >>> pl.arange(0, 3, eager=True).alias("int")
+    >>> pl.arange(0, 3, eager=True)
     shape: (3,)
-    Series: 'int' [i64]
+    Series: 'literal' [i64]
     [
             0
             1
@@ -178,9 +178,9 @@ def int_range(
 
     Examples
     --------
-    >>> pl.int_range(0, 3, eager=True).alias("int")
+    >>> pl.int_range(0, 3, eager=True)
     shape: (3,)
-    Series: 'int' [i64]
+    Series: 'literal' [i64]
     [
             0
             1
@@ -189,9 +189,9 @@ def int_range(
 
     `end` can be omitted for a shorter syntax.
 
-    >>> pl.int_range(3, eager=True).alias("int")
+    >>> pl.int_range(3, eager=True)
     shape: (3,)
-    Series: 'int' [i64]
+    Series: 'literal' [i64]
     [
             0
             1
@@ -320,18 +320,15 @@ def int_ranges(
 
     `end` can be omitted for a shorter syntax.
 
-    >>> df = pl.DataFrame({"end": [0, 1, 2, 3]})
-    >>> df.with_columns(int_range=pl.int_ranges("end"))
-    shape: (4, 2)
+    >>> df.select("end", int_range=pl.int_ranges("end"))
+    shape: (2, 2)
     ┌─────┬───────────┐
     │ end ┆ int_range │
     │ --- ┆ ---       │
     │ i64 ┆ list[i64] │
     ╞═════╪═══════════╡
-    │ 0   ┆ []        │
-    │ 1   ┆ [0]       │
-    │ 2   ┆ [0, 1]    │
     │ 3   ┆ [0, 1, 2] │
+    │ 2   ┆ [0, 1]    │
     └─────┴───────────┘
     """
     if end is None:

--- a/py-polars/polars/functions/range/int_range.py
+++ b/py-polars/polars/functions/range/int_range.py
@@ -55,7 +55,7 @@ def arange(
 
 
 def arange(
-    start: int | IntoExprColumn = 1,
+    start: int | IntoExprColumn = 0,
     end: int | IntoExprColumn | None = None,
     step: int = 1,
     *,

--- a/py-polars/polars/functions/range/int_range.py
+++ b/py-polars/polars/functions/range/int_range.py
@@ -235,8 +235,8 @@ def int_range(
 
 @overload
 def int_ranges(
-    start: int | IntoExprColumn,
-    end: int | IntoExprColumn,
+    start: int | IntoExprColumn = ...,
+    end: int | IntoExprColumn | None = ...,
     step: int | IntoExprColumn = ...,
     *,
     dtype: PolarsIntegerType = ...,
@@ -247,8 +247,8 @@ def int_ranges(
 
 @overload
 def int_ranges(
-    start: int | IntoExprColumn,
-    end: int | IntoExprColumn,
+    start: int | IntoExprColumn = ...,
+    end: int | IntoExprColumn | None = ...,
     step: int | IntoExprColumn = ...,
     *,
     dtype: PolarsIntegerType = ...,
@@ -259,8 +259,8 @@ def int_ranges(
 
 @overload
 def int_ranges(
-    start: int | IntoExprColumn,
-    end: int | IntoExprColumn,
+    start: int | IntoExprColumn = ...,
+    end: int | IntoExprColumn | None = ...,
     step: int | IntoExprColumn = ...,
     *,
     dtype: PolarsIntegerType = ...,
@@ -270,8 +270,8 @@ def int_ranges(
 
 
 def int_ranges(
-    start: int | IntoExprColumn,
-    end: int | IntoExprColumn,
+    start: int | IntoExprColumn = 0,
+    end: int | IntoExprColumn | None = None,
     step: int | IntoExprColumn = 1,
     *,
     dtype: PolarsIntegerType = Int64,
@@ -283,9 +283,10 @@ def int_ranges(
     Parameters
     ----------
     start
-        Start of the range (inclusive).
+        Start of the range (inclusive). Defaults to 0.
     end
-        End of the range (exclusive).
+        End of the range (exclusive). If set to `None` (default),
+        the value of `start` is used and `start` is set to `0`.
     step
         Step size of the range.
     dtype
@@ -316,7 +317,27 @@ def int_ranges(
     │ 1     ┆ 3   ┆ [1, 2]     │
     │ -1    ┆ 2   ┆ [-1, 0, 1] │
     └───────┴─────┴────────────┘
+
+    `end` can be omitted for a shorter syntax.
+
+    >>> df = pl.DataFrame({"end": [0, 1, 2, 3]})
+    >>> df.with_columns(int_range=pl.int_ranges("end"))
+    shape: (4, 2)
+    ┌─────┬───────────┐
+    │ end ┆ int_range │
+    │ --- ┆ ---       │
+    │ i64 ┆ list[i64] │
+    ╞═════╪═══════════╡
+    │ 0   ┆ []        │
+    │ 1   ┆ [0]       │
+    │ 2   ┆ [0, 1]    │
+    │ 3   ┆ [0, 1, 2] │
+    └─────┴───────────┘
     """
+    if end is None:
+        end = start
+        start = 0
+
     start = parse_as_expression(start)
     end = parse_as_expression(end)
     step = parse_as_expression(step)

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -56,12 +56,9 @@ def test_int_range_start_default() -> None:
 
 
 def test_int_ranges_start_default() -> None:
-    result = pl.DataFrame({"start": [1, -1], "end": [3, 2]}).with_columns(
-        int_range=pl.int_ranges(end="end")
-    )
-    expected = pl.DataFrame(
-        {"start": [1, -1], "end": [3, 2], "int_range": [[0, 1, 2], [0, 1]]}
-    )
+    df = pl.DataFrame({"end": [3, 2]})
+    result = df.select(int_range=pl.int_ranges(end="end"))
+    expected = pl.DataFrame({"int_range": [[0, 1, 2], [0, 1]]})
     assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/functions/range/test_int_range.py
+++ b/py-polars/tests/unit/functions/range/test_int_range.py
@@ -43,10 +43,26 @@ def test_int_range_short_syntax() -> None:
     assert_series_equal(pl.select(int=result).to_series(), expected)
 
 
+def test_int_ranges_short_syntax() -> None:
+    result = pl.int_ranges(3)
+    expected = pl.Series("int", [[0, 1, 2]])
+    assert_series_equal(pl.select(int=result).to_series(), expected)
+
+
 def test_int_range_start_default() -> None:
     result = pl.int_range(end=3)
     expected = pl.Series("int", [0, 1, 2])
     assert_series_equal(pl.select(int=result).to_series(), expected)
+
+
+def test_int_ranges_start_default() -> None:
+    result = pl.DataFrame({"start": [1, -1], "end": [3, 2]}).with_columns(
+        int_range=pl.int_ranges(end="end")
+    )
+    expected = pl.DataFrame(
+        {"start": [1, -1], "end": [3, 2], "int_range": [[0, 1, 2], [0, 1]]}
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_int_range_eager() -> None:


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/13787

PS: I see that arange is an alias for int_range, should we unify signatures? This will lead to a breaking change though