### PR TITLE
feat(rust, python): Support zero fill null strategy for binary and string columns

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/crates/polars-core/src/chunked_array/ops/fill_null.rs
@@ -383,9 +383,7 @@ fn fill_null_binary(ca: &BinaryChunked, strategy: FillNullStrategy) -> PolarsRes
         FillNullStrategy::Max => {
             ca.fill_null_with_values(ca.max_binary().ok_or_else(err_fill_null)?)
         },
-        FillNullStrategy::Zero => {
-            ca.fill_null_with_values(&[])
-        },
+        FillNullStrategy::Zero => ca.fill_null_with_values(&[]),
         strat => polars_bail!(InvalidOperation: "fill-null strategy {:?} is not supported", strat),
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/crates/polars-core/src/chunked_array/ops/fill_null.rs
@@ -383,6 +383,9 @@ fn fill_null_binary(ca: &BinaryChunked, strategy: FillNullStrategy) -> PolarsRes
         FillNullStrategy::Max => {
             ca.fill_null_with_values(ca.max_binary().ok_or_else(err_fill_null)?)
         },
+        FillNullStrategy::Zero => {
+            ca.fill_null_with_values(&[])
+        },
         strat => polars_bail!(InvalidOperation: "fill-null strategy {:?} is not supported", strat),
     }
 }

--- a/py-polars/tests/unit/functions/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/functions/aggregation/test_horizontal.py
@@ -241,7 +241,9 @@ def test_sum_max_min() -> None:
 
 
 def test_str_sum_horizontal() -> None:
-    df = pl.DataFrame({"A": ["a", "b", None, "c", None], "B": ["f", "g", "h", None, None]})
+    df = pl.DataFrame(
+        {"A": ["a", "b", None, "c", None], "B": ["f", "g", "h", None, None]}
+    )
     out = df.select(pl.sum_horizontal("A", "B"))
     assert_series_equal(out["A"], pl.Series("A", ["af", "bg", "h", "c", ""]))
 

--- a/py-polars/tests/unit/functions/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/functions/aggregation/test_horizontal.py
@@ -240,6 +240,12 @@ def test_sum_max_min() -> None:
     assert_series_equal(out["min"], pl.Series("min", [1.0, 2.0, 3.0]))
 
 
+def test_str_sum_horizontal() -> None:
+    df = pl.DataFrame({"A": ["a", "b", None, "c", None], "B": ["f", "g", "h", None, None]})
+    out = df.select(pl.sum_horizontal("A", "B"))
+    assert_series_equal(out["A"], pl.Series("A", ["af", "bg", "h", "c", ""]))
+
+
 def test_cum_sum_horizontal() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1025,10 +1025,16 @@ def test_fill_null() -> None:
     b = pl.Series("b", ["a", None, "c", None, "e"])
     assert b.fill_null(strategy="min").to_list() == ["a", "a", "c", "a", "e"]
     assert b.fill_null(strategy="max").to_list() == ["a", "e", "c", "e", "e"]
+    assert b.fill_null(strategy="zero").to_list() == ["a", "", "c", "", "e"]
+    assert b.fill_null(strategy="forward").to_list() == ["a", "a", "c", "c", "e"]
+    assert b.fill_null(strategy="backward").to_list() == ["a", "c", "c", "e", "e"]
 
     c = pl.Series("c", [b"a", None, b"c", None, b"e"])
     assert c.fill_null(strategy="min").to_list() == [b"a", b"a", b"c", b"a", b"e"]
     assert c.fill_null(strategy="max").to_list() == [b"a", b"e", b"c", b"e", b"e"]
+    assert c.fill_null(strategy="zero").to_list() == [b"a", b"", b"c", b"", b"e"]
+    assert c.fill_null(strategy="forward").to_list() == [b"a", b"a", b"c", b"c", b"e"]
+    assert c.fill_null(strategy="backward").to_list() == [b"a", b"c", b"c", b"e", b"e"]
 
     df = pl.DataFrame(
         [


### PR DESCRIPTION
Closes #13870