### PR TITLE
fix(rust, python): treat null columns as zero in `sum_horizontal`

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -2469,11 +2469,10 @@ impl DataFrame {
                 if let NullStrategy::Ignore = null_strategy {
                     // if has nulls
                     if s.has_validity() {
-                        s.fill_null(FillNullStrategy::Zero)
+                        return s.fill_null(FillNullStrategy::Zero);
                     }
-                } else {
-                    Ok(s.clone())
                 }
+                Ok(s.clone())
             };
 
         let sum_fn =

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -2501,7 +2501,7 @@ impl DataFrame {
                 non_null_cols[0].clone(),
                 null_strategy,
             )?)),
-            2 => sum_fn(&non_null_cols[0], &non_null_cols[1], null_strategy).map(Some),
+            2 => sum_fn(non_null_cols[0], non_null_cols[1], null_strategy).map(Some),
             _ => {
                 // the try_reduce_with is a bit slower in parallelism,
                 // but I don't think it matters here as we parallelize over columns, not over elements

--- a/py-polars/tests/unit/functions/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/functions/aggregation/test_horizontal.py
@@ -248,6 +248,41 @@ def test_str_sum_horizontal() -> None:
     assert_series_equal(out["A"], pl.Series("A", ["af", "bg", "h", "c", ""]))
 
 
+def test_sum_null_dtype() -> None:
+    df = pl.DataFrame(
+        {
+            "A": [5, None, 3, 2, 1],
+            "B": [5, 3, None, 2, 1],
+            "C": [None, None, None, None, None],
+        }
+    )
+
+    assert_series_equal(
+        df.select(pl.sum_horizontal("A", "B", "C")).to_series(),
+        pl.Series("A", [10, 3, 3, 4, 2]),
+    )
+    assert_series_equal(
+        df.select(pl.sum_horizontal("C", "B")).to_series(),
+        pl.Series("C", [5, 3, 0, 2, 1]),
+    )
+    assert_series_equal(
+        df.select(pl.sum_horizontal("C", "C")).to_series(),
+        pl.Series("C", [None, None, None, None, None]),
+    )
+
+
+def test_sum_single_col() -> None:
+    df = pl.DataFrame(
+        {
+            "A": [5, None, 3, None, 1],
+        }
+    )
+
+    assert_series_equal(
+        df.select(pl.sum_horizontal("A")).to_series(), pl.Series("A", [5, 0, 3, 0, 1])
+    )
+
+
 def test_cum_sum_horizontal() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
Fixes #13113 

- Null columns are treated as additive identity in the presence of non-null columns. They can be skipped in the computation
- If all columns are Null, return Null

I have also changed the behaviour of single columns sums. This seems more consistent to multi-column sums. Example:

```python
    df = pl.DataFrame(
        {
            "A": [5, None, 3, None],
            "B": [5, 3, None, None],
        }
    )
```

As reference, when summing multiple columns
`sum_horizontal("A", "B") = [10, 3, 3, 0]`

Before
 `sum_horizontal("A") = [5, None, 3, None]`
After
 `sum_horizontal("A") = [5, 0, 3, 0]`