### PR TITLE
Support `mean` for `bool` columns in `DataFrame.Describe` and `Series.Describe`

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -218,6 +218,11 @@ class DataType(metaclass=DataTypeClass):
         """Check whether the data type is a nested type."""
         return issubclass(cls, NestedType)
 
+    @classmethod
+    def is_bool(cls) -> bool:
+        """Check whether the data type is a boolean type."""
+        return issubclass(cls, Boolean)
+
 
 def _custom_reconstruct(
     cls: type[Any], base: type[Any], state: Any

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -383,6 +383,17 @@ class Series:
             pandas_to_pyseries(name, values, nan_to_null=nan_to_null)
         )
 
+    def _str_value(self, index: int) -> str:
+        """
+        Return a string representation of the element at `index`.
+
+        Returns
+        -------
+        str
+            string representation of the value.
+        """
+        return self._s.str_value(index)
+
     def _get_buffer_info(self) -> BufferInfo:
         """
         Return pointer, offset, and length information about the underlying buffer.

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1899,10 +1899,20 @@ class Series:
         -----
         The median is included by default as the 50% percentile.
 
+        The mean for boolean series is the ratio of true values
+        to the total non-null values.
+
+
         Returns
         -------
         DataFrame
             Mapping with summary statistics of a Series.
+
+        Warnings
+        --------
+        We will never guarantee the output of describe to be stable.
+        It will show statistics that we deem informative and may
+        be updated in the future.
 
         Examples
         --------
@@ -1924,6 +1934,20 @@ class Series:
         │ 75%        ┆ 4.0      │
         │ max        ┆ 5.0      │
         └────────────┴──────────┘
+
+        >>> s = pl.Series([True, False, True, None, True])
+        >>> s.describe()
+        shape: (4, 2)
+        ┌────────────┬───────┐
+        │ statistic  ┆ value │
+        │ ---        ┆ ---   │
+        │ str        ┆ f64   │
+        ╞════════════╪═══════╡
+        │ count      ┆ 4.0   │
+        │ null_count ┆ 1.0   │
+        │ sum        ┆ 3.0   │
+        │ mean       ┆ 0.75  │
+        └────────────┴───────┘
 
         Non-numeric data types may not have all statistics available.
 
@@ -1957,11 +1981,12 @@ class Series:
             stats["max"] = self.max()
 
         elif self.dtype == Boolean:
-            stats_dtype = Int64
+            stats_dtype = Float64
             stats = {
                 "count": self.count(),
                 "null_count": self.null_count(),
                 "sum": self.sum(),
+                "mean": self.mean(),
             }
         elif self.dtype == String:
             stats_dtype = Int64

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -145,6 +145,10 @@ impl PySeries {
         }
     }
 
+    fn str_value(&self, index: usize) -> String {
+        self.series.str_value(index).unwrap().into()
+    }
+
     fn rechunk(&mut self, in_place: bool) -> Option<Self> {
         let series = self.series.rechunk();
         if in_place {

--- a/py-polars/tests/unit/dataframe/test_describe.py
+++ b/py-polars/tests/unit/dataframe/test_describe.py
@@ -48,7 +48,7 @@ def test_df_describe() -> None:
                 3.0,
             ],
             "b": [2.0, 1.0, 4.5, 0.7071067811865476, 4.0, 4.0, 5.0, 5.0, 5.0],
-            "c": ["3", "0", None, None, "False", None, None, None, "True"],
+            "c": ["3", "0", "0.666667", None, "false", None, None, None, "true"],
             "d": ["2", "1", None, None, "b", None, None, None, "c"],
             "e": ["2", "1", None, None, None, None, None, None, None],
             "f": ["3", "0", None, None, "2020-01-01", None, None, None, "2022-01-01"],

--- a/py-polars/tests/unit/series/test_describe.py
+++ b/py-polars/tests/unit/series/test_describe.py
@@ -61,11 +61,7 @@ def test_series_describe_boolean() -> None:
     s = pl.Series([True, False, None, True, True])
     result = s.describe()
 
-    stats = {
-        "count": 4,
-        "null_count": 1,
-        "sum": 3,
-    }
+    stats = {"count": 4, "null_count": 1, "sum": 3, "mean": 0.75}
     expected = pl.DataFrame({"statistic": stats.keys(), "value": stats.values()})
     assert_frame_equal(expected, result)
 


### PR DESCRIPTION
Fixes: https://github.com/pola-rs/polars/issues/13735

I Had to use `str_value` from `Series` to ensure we have the same representation for non numerical columns (the float representing the mean for bool columns). This means that `mean` for `bools` are printed the same ways as for other columns and will respect the `polars.Config.set_fmt_float`

`True` and `False` become `true` and `false` to be consistent with what happens when you just print df; but it's easily changeable.

If we only use `str(v)`:
```
shape: (9, 7)
┌────────────┬──────────┬──────────┬────────────────────┬──────┬──────┬────────────┐
│ describe   ┆ a        ┆ b        ┆ c                  ┆ d    ┆ e    ┆ f          │
│ ---        ┆ ---      ┆ ---      ┆ ---                ┆ ---  ┆ ---  ┆ ---        │
│ str        ┆ f64      ┆ f64      ┆ str                ┆ str  ┆ str  ┆ str        │
╞════════════╪══════════╪══════════╪════════════════════╪══════╪══════╪════════════╡
│ count      ┆ 3.0      ┆ 2.0      ┆ 3                  ┆ 2    ┆ 2    ┆ 3          │
│ null_count ┆ 0.0      ┆ 1.0      ┆ 0                  ┆ 1    ┆ 1    ┆ 0          │
│ mean       ┆ 2.266667 ┆ 4.5      ┆ 0.6666666666666666 ┆ null ┆ null ┆ null       │
│ std        ┆ 1.101514 ┆ 0.707107 ┆ null               ┆ null ┆ null ┆ null       │
│ min        ┆ 1.0      ┆ 4.0      ┆ False              ┆ b    ┆ null ┆ 2020-01-01 │
│ 25%        ┆ 2.8      ┆ 4.0      ┆ null               ┆ null ┆ null ┆ null       │
│ 50%        ┆ 2.8      ┆ 5.0      ┆ null               ┆ null ┆ null ┆ null       │
│ 75%        ┆ 3.0      ┆ 5.0      ┆ null               ┆ null ┆ null ┆ null       │
│ max        ┆ 3.0      ┆ 5.0      ┆ True               ┆ c    ┆ null ┆ 2022-01-01 │
└────────────┴──────────┴──────────┴────────────────────┴──────┴──────┴────────────┘
```

If we use `str_value`:

```
shape: (9, 7)
┌────────────┬──────────┬──────────┬──────────┬──────┬──────┬────────────┐
│ describe   ┆ a        ┆ b        ┆ c        ┆ d    ┆ e    ┆ f          │
│ ---        ┆ ---      ┆ ---      ┆ ---      ┆ ---  ┆ ---  ┆ ---        │
│ str        ┆ f64      ┆ f64      ┆ str      ┆ str  ┆ str  ┆ str        │
╞════════════╪══════════╪══════════╪══════════╪══════╪══════╪════════════╡
│ count      ┆ 3.0      ┆ 2.0      ┆ 3        ┆ 2    ┆ 2    ┆ 3          │
│ null_count ┆ 0.0      ┆ 1.0      ┆ 0        ┆ 1    ┆ 1    ┆ 0          │
│ mean       ┆ 2.266667 ┆ 4.5      ┆ 0.666667 ┆ null ┆ null ┆ null       │
│ std        ┆ 1.101514 ┆ 0.707107 ┆ null     ┆ null ┆ null ┆ null       │
│ min        ┆ 1.0      ┆ 4.0      ┆ false    ┆ b    ┆ null ┆ 2020-01-01 │
│ 25%        ┆ 2.8      ┆ 4.0      ┆ null     ┆ null ┆ null ┆ null       │
│ 50%        ┆ 2.8      ┆ 5.0      ┆ null     ┆ null ┆ null ┆ null       │
│ 75%        ┆ 3.0      ┆ 5.0      ┆ null     ┆ null ┆ null ┆ null       │
│ max        ┆ 3.0      ┆ 5.0      ┆ true     ┆ c    ┆ null ┆ 2022-01-01 │
└────────────┴──────────┴──────────┴──────────┴──────┴──────┴────────────┘

```

If we change config:

```python
with pl.Config(set_fmt_float="full"):
    print(df.describe())

shape: (9, 7)
┌────────────┬────────────────────┬────────────────────┬────────────────────┬──────┬──────┬────────────┐
│ describe   ┆ float              ┆ int                ┆ bool               ┆ str  ┆ str2 ┆ date       │
│ ---        ┆ ---                ┆ ---                ┆ ---                ┆ ---  ┆ ---  ┆ ---        │
│ str        ┆ f64                ┆ f64                ┆ str                ┆ str  ┆ str  ┆ str        │
╞════════════╪════════════════════╪════════════════════╪════════════════════╪══════╪══════╪════════════╡
│ count      ┆ 3                  ┆ 2                  ┆ 3                  ┆ 2    ┆ 2    ┆ 3          │
│ null_count ┆ 0                  ┆ 1                  ┆ 0                  ┆ 1    ┆ 1    ┆ 0          │
│ mean       ┆ 2.2666666666666666 ┆ 4.5                ┆ 0.6666666666666666 ┆ null ┆ null ┆ null       │
│ std        ┆ 1.1015141094572205 ┆ 0.7071067811865476 ┆ null               ┆ null ┆ null ┆ null       │
│ min        ┆ 1                  ┆ 4                  ┆ false              ┆ b    ┆ eur  ┆ 2020-01-01 │
│ 25%        ┆ 2.8                ┆ 4                  ┆ null               ┆ null ┆ null ┆ null       │
│ 50%        ┆ 2.8                ┆ 5                  ┆ null               ┆ null ┆ null ┆ null       │
│ 75%        ┆ 3                  ┆ 5                  ┆ null               ┆ null ┆ null ┆ null       │
│ max        ┆ 3                  ┆ 5                  ┆ true               ┆ c    ┆ usd  ┆ 2022-01-01 │
└────────────┴────────────────────┴────────────────────┴────────────────────┴──────┴──────┴────────────┘
```