### PR TITLE
feat(rust,python,cli): support negative indexing and expressions for `LEFT`, `RIGHT` and `SUBSTR` SQL string funcs

### DIFF
--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -1,4 +1,4 @@
-use polars_core::prelude::{polars_bail, polars_err, PolarsResult};
+use polars_core::prelude::{polars_bail, polars_err, DataType, PolarsResult};
 use polars_lazy::dsl::Expr;
 #[cfg(feature = "list_eval")]
 use polars_lazy::dsl::ListNameSpaceExtension;
@@ -768,15 +768,15 @@ impl SQLFunctionVisitor<'_> {
                 1 => self.visit_unary(|e| e.round(0)),
                 2 => self.try_visit_binary(|e, decimals| {
                     Ok(e.round(match decimals {
-                        Expr::Literal(LiteralValue::Int64(n)) => n as u32,
-                        _ => {
-                            polars_bail!(InvalidOperation: "Invalid 'decimals' for Round: {}", function.args[1]);
-                        }
+                        Expr::Literal(LiteralValue::Int64(n)) => {
+                            if n >= 0 { n as u32 } else {
+                                polars_bail!(InvalidOperation: "Round does not (yet) support negative 'decimals': {}", function.args[1])
+                            }
+                        },
+                        _ => polars_bail!(InvalidOperation: "Invalid 'decimals' for Round: {}", function.args[1]),
                     }))
                 }),
-                _ => {
-                    polars_bail!(InvalidOperation:"Invalid number of arguments for Round: {}", function.args.len());
-                },
+                _ => polars_bail!(InvalidOperation:"Invalid number of arguments for Round: {}", function.args.len()),
             },
             Sign => self.visit_unary(Expr::sign),
             Sqrt => self.visit_unary(Expr::sqrt),
@@ -860,13 +860,21 @@ impl SQLFunctionVisitor<'_> {
             #[cfg(feature = "nightly")]
             InitCap => self.visit_unary(|e| e.str().to_titlecase()),
             Left => self.try_visit_binary(|e, length| {
-                Ok(e.str().slice(lit(0), match length {
-                    Expr::Literal(LiteralValue::Int64(n)) => lit(n as u64),
+                Ok(match length {
+                    Expr::Literal(Null) => lit(Null),
+                    Expr::Literal(LiteralValue::Int64(0)) => lit(""),
+                    Expr::Literal(LiteralValue::Int64(n)) => {
+                        let len = if n > 0 { lit(n) } else { (e.clone().str().len_chars() + lit(n)).clip_min(lit(0)) };
+                        e.str().slice(lit(0), len)
+                    },
+                    Expr::Literal(_) => polars_bail!(InvalidOperation: "Invalid 'n_chars' for Left: {}", function.args[1]),
                     _ => {
-                        polars_bail!(InvalidOperation: "Invalid 'length' for Left: {}", function.args[1]);
+                            when(length.clone().gt_eq(lit(0)))
+                                .then(e.clone().str().slice(lit(0), length.clone().abs()))
+                                .otherwise(e.clone().str().slice(lit(0), (e.clone().str().len_chars() + length.clone()).clip_min(lit(0))))
                     }
-                }))
-            }),
+                }
+            )}),
             Length => self.visit_unary(|e| e.str().len_chars()),
             Lower => self.visit_unary(|e| e.str().to_lowercase()),
             LTrim => match function.args.len() {
@@ -902,51 +910,63 @@ impl SQLFunctionVisitor<'_> {
                 3 => self.try_visit_ternary(|e, old, new| {
                     Ok(e.str().replace_all(old, new, true))
                 }),
-                _ => polars_bail!(InvalidOperation:
-                    "Invalid number of arguments for Replace: {}",
-                    function.args.len()
-                ),
+                _ => polars_bail!(InvalidOperation: "Invalid number of arguments for Replace: {}", function.args.len()),
             },
             Reverse => self.visit_unary(|e| e.str().reverse()),
             Right => self.try_visit_binary(|e, length| {
-                Ok(e.str().slice( match length {
-                    Expr::Literal(LiteralValue::Int64(n)) => lit(-n),
+                Ok(match length {
+                    Expr::Literal(Null) => lit(Null),
+                    Expr::Literal(LiteralValue::Int64(0)) => lit(""),
+                    Expr::Literal(LiteralValue::Int64(n)) => {
+                        let offset = if n < 0 { lit(n.abs()) } else { e.clone().str().len_chars().cast(DataType::Int32) - lit(n) };
+                        e.str().slice(offset, lit(Null))
+                    },
+                    Expr::Literal(_) => polars_bail!(InvalidOperation: "Invalid 'n_chars' for Right: {}", function.args[1]),
                     _ => {
-                        polars_bail!(InvalidOperation: "Invalid 'length' for Right: {}", function.args[1]);
+                        when(length.clone().lt(lit(0)))
+                            .then(e.clone().str().slice(length.clone().abs(), lit(Null)))
+                            .otherwise(e.clone().str().slice(e.clone().str().len_chars().cast(DataType::Int32) - length.clone(), lit(Null)))
                     }
-                }, lit(Null)))
-            }),
+                }
+                )}),
             RTrim => match function.args.len() {
                 1 => self.visit_unary(|e| e.str().strip_chars_end(lit(Null))),
                 2 => self.visit_binary(|e, s| e.str().strip_chars_end(s)),
-                _ => polars_bail!(InvalidOperation:
-                    "Invalid number of arguments for RTrim: {}",
-                    function.args.len()
-                ),
+                _ => polars_bail!(InvalidOperation: "Invalid number of arguments for RTrim: {}", function.args.len()),
             },
             StartsWith => self.visit_binary(|e, s| e.str().starts_with(s)),
             Substring => match function.args.len() {
-                // note that SQL is 1-indexed, not 0-indexed
+                // note that SQL is 1-indexed, not 0-indexed, hence the need for adjustments
                 2 => self.try_visit_binary(|e, start| {
-                    Ok(e.str().slice(
-                        match start {
-                            Expr::Literal(LiteralValue::Int64(n)) => lit(n - 1) ,
-                            _ => polars_bail!(InvalidOperation: "Invalid 'start' for Substring: {}", function.args[1]),
-                        }, lit(Null)))
+                    Ok(match start {
+                        Expr::Literal(Null) => lit(Null),
+                        Expr::Literal(LiteralValue::Int64(n)) if n <= 0 => e,
+                        Expr::Literal(LiteralValue::Int64(n)) => e.str().slice(lit(n - 1), lit(Null)),
+                        Expr::Literal(_) => polars_bail!(InvalidOperation: "Invalid 'start' for Substring: {}", function.args[1]),
+                        _ => start.clone() + lit(1),
+                    })
                 }),
-                3 => self.try_visit_ternary(|e, start, length| {
-                    Ok(e.str().slice(
-                        match start {
-                            Expr::Literal(LiteralValue::Int64(n)) => lit(n - 1),
-                            _ => {
-                                polars_bail!(InvalidOperation: "Invalid 'start' for Substring: {}", function.args[1]);
-                            }
-                        }, match length {
-                            Expr::Literal(LiteralValue::Int64(n)) => lit(n as u64),
-                            _ => {
-                                polars_bail!(InvalidOperation: "Invalid 'length' for Substring: {}", function.args[2]);
-                            }
-                        }))
+                3 => self.try_visit_ternary(|e: Expr, start: Expr, length: Expr| {
+                    Ok(match (start.clone(), length.clone()) {
+                        (Expr::Literal(Null), _) | (_, Expr::Literal(Null)) => lit(Null),
+                        (_, Expr::Literal(LiteralValue::Int64(n))) if n < 0 => {
+                            polars_bail!(InvalidOperation: "Substring does not support negative length: {}", function.args[2])
+                        },
+                        (Expr::Literal(LiteralValue::Int64(n)), _) if n > 0 => e.str().slice(lit(n - 1), length.clone()),
+                        (Expr::Literal(LiteralValue::Int64(n)), _) => {
+                            e.str().slice(lit(0), (length.clone() + lit(n - 1)).clip_min(lit(0)))
+                        },
+                        (Expr::Literal(_), _) => polars_bail!(InvalidOperation: "Invalid 'start' for Substring: {}", function.args[1]),
+                        (_, Expr::Literal(LiteralValue::Float64(_))) => {
+                            polars_bail!(InvalidOperation: "Invalid 'length' for Substring: {}", function.args[1])
+                        },
+                        _ => {
+                            let adjusted_start = start.clone() - lit(1);
+                            when(adjusted_start.clone().lt(lit(0)))
+                                .then(e.clone().str().slice(lit(0), (length.clone() + adjusted_start.clone()).clip_min(lit(0))))
+                                .otherwise(e.clone().str().slice(adjusted_start.clone(), length.clone()))
+                        }
+                    })
                 }),
                 _ => polars_bail!(InvalidOperation: "Invalid number of arguments for Substring: {}", function.args.len()),
             }

--- a/py-polars/tests/unit/sql/test_numeric.py
+++ b/py-polars/tests/unit/sql/test_numeric.py
@@ -107,10 +107,15 @@ def test_round_ndigits(decimals: int, expected: list[float]) -> None:
 
 def test_round_ndigits_errors() -> None:
     df = pl.DataFrame({"n": [99.999]})
-    with pl.SQLContext(df=df, eager_execution=True) as ctx, pytest.raises(
-        InvalidOperationError, match="Invalid 'decimals' for Round: -1"
-    ):
-        ctx.execute("SELECT ROUND(n,-1) AS n FROM df")
+    with pl.SQLContext(df=df, eager_execution=True) as ctx:
+        with pytest.raises(
+            InvalidOperationError, match="Invalid 'decimals' for Round: ??"
+        ):
+            ctx.execute("SELECT ROUND(n,'??') AS n FROM df")
+        with pytest.raises(
+            InvalidOperationError, match="Round .* negative 'decimals': -1"
+        ):
+            ctx.execute("SELECT ROUND(n,-1) AS n FROM df")
 
 
 def test_stddev_variance() -> None:


### PR DESCRIPTION
## Description

Builds on top of @reswqa's great work expressifying string `slice` (see #13747).

* Extends SQL `LEFT`, `RIGHT`, and `SUBSTR` SQL string functions with expression support.
* Adds support for negative length to both the `LEFT` and `RIGHT` functions.
* Adds supports for negative start and negative length for `SUBSTR`.
* Also fixes `ROUND` error checking for negative 'n_decimals' as a drive-by.

## Notes on negative start/length

Getting this correct was a bit headache-inducing, as SQL has a different idea of what negative values mean here _and_ it's 1-indexed. 

For example, with`SUBSTR`:
* Starting at -10 _doesn't_ mean _"start 10 chars back from the end of the string"_, as you would likely expect; instead it really does mean _"start 10 chars back from the front"_. So, `SUBSTR(colt,-10,13)` and `SUBSTR(colx,1,2)` both return the _same_ result (due to offsets and 1-indexing), which would be the first two letters of the string 🤔 

With the `LEFT` and `RIGHT` functions you have the opportunity to set negative _length_:
* `LEFT("s",-n)` means _"all but the last `n` chars"_
* `RIGHT("s",-n)` means _"all but first `n` chars"_

## Testing

This probably took more time than the actual implementation, due to the notable differences between what you'd typically expect (as a programmer) and what the SQL standard actually defines. I ended up with a set of unit tests that I could also run directly on a dockerised PostgreSQL instance to validate the behaviour, covering all major parameter characteristics.

<img width="897" alt="Screenshot 2024-01-17 at 00 08 15" src="https://github.com/pola-rs/polars/assets/2613171/2bc53ee0-d666-4670-a7f5-083c1d4e6893">

*  _(Screenshot: having fun confirming `RIGHT` equivalence)_ 😅

## References

PostgreSQL string function docs:
https://www.postgresql.org/docs/9.1/functions-string.html#FUNCTIONS-STRING-OTHER