### PR TITLE
fix(python): Allow `pl.col(pl.Enum)` for selecting all Enum columns

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -80,7 +80,6 @@ impl PartialEq for DataType {
         use DataType::*;
         {
             match (self, other) {
-                // Don't include rev maps in comparisons
                 #[cfg(feature = "dtype-categorical")]
                 (Categorical(_, _), Categorical(_, _)) | (Enum(_, _), Enum(_, _)) => true,
                 (Datetime(tu_l, tz_l), Datetime(tu_r, tz_r)) => tu_l == tu_r && tz_l == tz_r,

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -80,6 +80,7 @@ impl PartialEq for DataType {
         use DataType::*;
         {
             match (self, other) {
+                // Don't include rev maps in comparisons
                 #[cfg(feature = "dtype-categorical")]
                 (Categorical(_, _), Categorical(_, _)) | (Enum(_, _), Enum(_, _)) => true,
                 (Datetime(tu_l, tz_l), Datetime(tu_r, tz_r)) => tu_l == tu_r && tz_l == tz_r,

--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -546,7 +546,7 @@ class Enum(DataType):
 
     categories: Series
 
-    def __init__(self, categories: Series | Iterable[str]):
+    def __init__(self, categories: Series | Iterable[str] | None = None):
         """
         A fixed set categorical encoding of a set of strings.
 
@@ -554,6 +554,7 @@ class Enum(DataType):
         ----------
         categories
             Valid categories in the dataset.
+            If None, it will be set equal to the empty set.
         """
         # Issuing the warning on `__init__` does not trigger when the class is used
         # without being instantiated, but it's better than nothing
@@ -563,6 +564,9 @@ class Enum(DataType):
             "The Enum data type is considered unstable."
             " It is a work-in-progress feature and may not always work as expected."
         )
+        if categories is None:
+            self.categories = pl.Series(name="category", dtype=String)
+            return
 
         if not isinstance(categories, pl.Series):
             categories = pl.Series(values=categories)

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -395,6 +395,7 @@ def test_enum_cast_from_other_integer_dtype_oob() -> None:
     ):
         series.cast(enum_dtype)
 
+
 def test_enum_creating_col_expr() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -404,7 +404,7 @@ def test_enum_creating_col_expr() -> None:
         },
         schema={
             "col1": pl.Enum(["a", "b", "c"]),
-            "col2": pl.String,
+            "col2": pl.Categorical(),
             "col3": pl.Enum(["g", "h", "i"]),
         },
     )


### PR DESCRIPTION
Update `extract` to create an empty `pl.Enum` so that column expressions can be extracted for the `pl.Enum` datatype e.g. `pl.col(pl.Enum)`. 

Also update the `Enum` constructor to allow/default to None for the `categories` param. This mirrors the logic that is used in `extract` for `pl.Enum` and operates as a convenient short-hand for the current supported logic of passing in an empty series. 

Fixes #13269 

