### PR TITLE
refactor(python): Revert pandas warning filter

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import contextlib
 import os
 import random
-import warnings
 from collections import OrderedDict, defaultdict
 from collections.abc import Sized
 from io import BytesIO, StringIO, TextIOWrapper
@@ -2290,33 +2289,15 @@ class DataFrame:
         record_batches = self._df.to_pandas()
         tbl = pa.Table.from_batches(record_batches)
         if use_pyarrow_extension_array:
-            with warnings.catch_warnings():
-                # Needs fixing upstream in pyarrow
-                # Silence here as it's something Polars users can't do
-                # anything about.
-                warnings.filterwarnings(
-                    "ignore",
-                    message="make_block is deprecated and will be removed",
-                    category=DeprecationWarning,
-                )
-                return tbl.to_pandas(
-                    self_destruct=True,
-                    split_blocks=True,
-                    types_mapper=lambda pa_dtype: pd.ArrowDtype(pa_dtype),
-                    **kwargs,
-                )
+            return tbl.to_pandas(
+                self_destruct=True,
+                split_blocks=True,
+                types_mapper=lambda pa_dtype: pd.ArrowDtype(pa_dtype),
+                **kwargs,
+            )
 
         date_as_object = kwargs.pop("date_as_object", False)
-        with warnings.catch_warnings():
-            # Needs fixing upstream in pyarrow
-            # Silence here as it's something Polars users can't do
-            # anything about.
-            warnings.filterwarnings(
-                "ignore",
-                message="make_block is deprecated and will be removed",
-                category=DeprecationWarning,
-            )
-            return tbl.to_pandas(date_as_object=date_as_object, **kwargs)
+        return tbl.to_pandas(date_as_object=date_as_object, **kwargs)
 
     def to_series(self, index: int = 0) -> Series:
         """

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -9,6 +9,9 @@ import polars as pl
 from polars.testing import assert_frame_equal
 
 
+@pytest.mark.skip(
+    reason="Broken by pyarrow 15 release: https://github.com/pola-rs/polars/issues/13892"
+)
 @pytest.mark.write_disk()
 def test_hive_partitioned_predicate_pushdown(
     io_files_path: Path, tmp_path: Path, monkeypatch: Any, capfd: Any
@@ -85,6 +88,9 @@ def test_hive_partitioned_predicate_pushdown_skips_correct_number_of_files(
     assert "hive partitioning: skipped 3 files" in capfd.readouterr().err
 
 
+@pytest.mark.skip(
+    reason="Broken by pyarrow 15 release: https://github.com/pola-rs/polars/issues/13892"
+)
 @pytest.mark.write_disk()
 def test_hive_partitioned_slice_pushdown(io_files_path: Path, tmp_path: Path) -> None:
     df = pl.read_ipc(io_files_path / "*.ipc")
@@ -118,6 +124,9 @@ def test_hive_partitioned_slice_pushdown(io_files_path: Path, tmp_path: Path) ->
         ]
 
 
+@pytest.mark.skip(
+    reason="Broken by pyarrow 15 release: https://github.com/pola-rs/polars/issues/13892"
+)
 @pytest.mark.write_disk()
 def test_hive_partitioned_projection_pushdown(
     io_files_path: Path, tmp_path: Path


### PR DESCRIPTION
As this wasn't deprecated after all, the warning filters added in #13467 can be removed again.

Also skipping the pyarrow tests for now.