### PR TITLE
feat: Add `ignore_nulls` for `arr.join`

### DIFF
--- a/crates/polars-ops/src/chunked_array/array/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/array/namespace.rs
@@ -104,9 +104,9 @@ pub trait ArrayNameSpace: AsArray {
         array_get(ca, index)
     }
 
-    fn array_join(&self, separator: &StringChunked) -> PolarsResult<Series> {
+    fn array_join(&self, separator: &StringChunked, ignore_nulls: bool) -> PolarsResult<Series> {
         let ca = self.as_array();
-        array_join(ca, separator).map(|ok| ok.into_series())
+        array_join(ca, separator, ignore_nulls).map(|ok| ok.into_series())
     }
 
     #[cfg(feature = "array_count")]

--- a/crates/polars-plan/src/dsl/array.rs
+++ b/crates/polars-plan/src/dsl/array.rs
@@ -93,9 +93,9 @@ impl ArrayNameSpace {
     /// Join all string items in a sub-array and place a separator between them.
     /// # Error
     /// Raise if inner type of array is not `DataType::String`.
-    pub fn join(self, separator: Expr) -> Expr {
+    pub fn join(self, separator: Expr, ignore_nulls: bool) -> Expr {
         self.0.map_many_private(
-            FunctionExpr::ArrayExpr(ArrayFunction::Join),
+            FunctionExpr::ArrayExpr(ArrayFunction::Join(ignore_nulls)),
             &[separator],
             false,
             false,

--- a/crates/polars-plan/src/dsl/function_expr/array.rs
+++ b/crates/polars-plan/src/dsl/function_expr/array.rs
@@ -20,7 +20,7 @@ pub enum ArrayFunction {
     ArgMin,
     ArgMax,
     Get,
-    Join,
+    Join(bool),
     #[cfg(feature = "is_in")]
     Contains,
     #[cfg(feature = "array_count")]
@@ -41,7 +41,7 @@ impl ArrayFunction {
             Reverse => mapper.with_same_dtype(),
             ArgMin | ArgMax => mapper.with_dtype(IDX_DTYPE),
             Get => mapper.map_to_list_and_array_inner_dtype(),
-            Join => mapper.with_dtype(DataType::String),
+            Join(_) => mapper.with_dtype(DataType::String),
             #[cfg(feature = "is_in")]
             Contains => mapper.with_dtype(DataType::Boolean),
             #[cfg(feature = "array_count")]
@@ -76,7 +76,7 @@ impl Display for ArrayFunction {
             ArgMin => "arg_min",
             ArgMax => "arg_max",
             Get => "get",
-            Join => "join",
+            Join(_) => "join",
             #[cfg(feature = "is_in")]
             Contains => "contains",
             #[cfg(feature = "array_count")]
@@ -104,7 +104,7 @@ impl From<ArrayFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             ArgMin => map!(arg_min),
             ArgMax => map!(arg_max),
             Get => map_as_slice!(get),
-            Join => map_as_slice!(join),
+            Join(ignore_nulls) => map_as_slice!(join, ignore_nulls),
             #[cfg(feature = "is_in")]
             Contains => map_as_slice!(contains),
             #[cfg(feature = "array_count")]
@@ -173,10 +173,10 @@ pub(super) fn get(s: &[Series]) -> PolarsResult<Series> {
     ca.array_get(index)
 }
 
-pub(super) fn join(s: &[Series]) -> PolarsResult<Series> {
+pub(super) fn join(s: &[Series], ignore_nulls: bool) -> PolarsResult<Series> {
     let ca = s[0].array()?;
     let separator = s[1].str()?;
-    ca.array_join(separator)
+    ca.array_join(separator, ignore_nulls)
 }
 
 #[cfg(feature = "is_in")]

--- a/py-polars/polars/expr/array.py
+++ b/py-polars/polars/expr/array.py
@@ -432,7 +432,7 @@ class ExprArrayNameSpace:
         """
         return self.get(-1)
 
-    def join(self, separator: IntoExprColumn) -> Expr:
+    def join(self, separator: IntoExprColumn, *, ignore_nulls: bool = True) -> Expr:
         """
         Join all string items in a sub-array and place a separator between them.
 
@@ -442,6 +442,11 @@ class ExprArrayNameSpace:
         ----------
         separator
             string to separate the items with
+        ignore_nulls
+            Ignore null values (default).
+
+            If set to ``False``, null values will be propagated.
+            If the sub-list contains any null values, the output is ``None``.
 
         Returns
         -------
@@ -470,7 +475,7 @@ class ExprArrayNameSpace:
 
         """
         separator = parse_as_expression(separator, str_as_lit=True)
-        return wrap_expr(self._pyexpr.arr_join(separator))
+        return wrap_expr(self._pyexpr.arr_join(separator, ignore_nulls))
 
     def contains(
         self, item: float | str | bool | int | date | datetime | time | IntoExprColumn

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -570,7 +570,7 @@ class ExprListNameSpace:
             Ignore null values (default).
 
             If set to ``False``, null values will be propagated.
-            if the sub-list contains any null values, the output is ``None``.
+            If the sub-list contains any null values, the output is ``None``.
 
         Returns
         -------

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -346,7 +346,7 @@ class ArrayNameSpace:
 
         """
 
-    def join(self, separator: IntoExprColumn) -> Series:
+    def join(self, separator: IntoExprColumn, *, ignore_nulls: bool = True) -> Series:
         """
         Join all string items in a sub-array and place a separator between them.
 
@@ -356,6 +356,11 @@ class ArrayNameSpace:
         ----------
         separator
             string to separate the items with
+        ignore_nulls
+            Ignore null values (default).
+
+            If set to ``False``, null values will be propagated.
+            If the sub-list contains any null values, the output is ``None``.
 
         Returns
         -------

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -400,7 +400,7 @@ class ListNameSpace:
             Ignore null values (default).
 
             If set to ``False``, null values will be propagated.
-            if the sub-list contains any null values, the output is ``None``.
+            If the sub-list contains any null values, the output is ``None``.
 
         Returns
         -------

--- a/py-polars/src/expr/array.rs
+++ b/py-polars/src/expr/array.rs
@@ -65,8 +65,12 @@ impl PyExpr {
         self.inner.clone().arr().get(index.inner).into()
     }
 
-    fn arr_join(&self, separator: PyExpr) -> Self {
-        self.inner.clone().arr().join(separator.inner).into()
+    fn arr_join(&self, separator: PyExpr, ignore_nulls: bool) -> Self {
+        self.inner
+            .clone()
+            .arr()
+            .join(separator.inner, ignore_nulls)
+            .into()
     }
 
     #[cfg(feature = "is_in")]


### PR DESCRIPTION
This will change the behavior of handing null values. But as the same reasons as `list.join` and `str.concat`, we think of it as fixing rather than breaking change.

This closes #13633.