### PR TITLE
fix: Fix `is_not_null` for Struct columns

### DIFF
--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -304,7 +304,7 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
     /// Get a mask of the non-null values.
     fn is_not_null(&self) -> BooleanChunked {
         let is_not_null = self.0.fields().iter().map(|s| s.is_not_null());
-        is_not_null.reduce(|lhs, rhs| lhs.bitand(rhs)).unwrap()
+        is_not_null.reduce(|lhs, rhs| lhs.bitor(rhs)).unwrap()
     }
 
     fn shrink_to_fit(&mut self) {

--- a/py-polars/tests/unit/operations/test_drop_nulls.py
+++ b/py-polars/tests/unit/operations/test_drop_nulls.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from hypothesis import given
+
+import polars as pl
+from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing.parametric import series
+
+
+@given(s=series(null_probability=0.5))
+def test_drop_nulls_parametric(s: pl.Series) -> None:
+    result = s.drop_nulls()
+    assert result.len() == s.len() - s.null_count()
+
+    filter_result = s.filter(s.is_not_null())
+    assert_series_equal(result, filter_result)
+
+
+def test_df_drop_nulls_struct() -> None:
+    df = pl.DataFrame(
+        {
+            "x": [
+                {"a": 1, "b": 2},
+                {"a": 1, "b": None},
+                {"a": None, "b": 2},
+                {"a": None, "b": None},
+            ]
+        }
+    )
+
+    result = df.drop_nulls()
+
+    expected = df.head(3)
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/test_is_null.py
+++ b/py-polars/tests/unit/operations/test_is_null.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from hypothesis import given
+
+import polars as pl
+from polars.testing import assert_frame_equal, assert_series_equal
+from polars.testing.parametric import series
+
+
+@given(s=series(null_probability=0.5))
+def test_is_null_parametric(s: pl.Series) -> None:
+    is_null = s.is_null()
+    is_not_null = s.is_not_null()
+
+    assert is_null.null_count() == 0
+    assert_series_equal(is_null, ~is_not_null)
+
+
+def test_is_null_struct() -> None:
+    df = pl.DataFrame(
+        {
+            "x": [
+                {"a": 1, "b": 2},
+                {"a": 1, "b": None},
+                {"a": None, "b": 2},
+                {"a": None, "b": None},
+            ]
+        }
+    )
+
+    result = df.select(
+        null=pl.col("x").is_null(),
+        not_null=pl.col("x").is_not_null(),
+    )
+
+    expected = pl.DataFrame(
+        {
+            "null": [False, False, False, True],
+            "not_null": [True, True, True, False],
+        }
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_is_null_null() -> None:
+    s = pl.Series([None, None])
+
+    result = s.is_null()
+    expected = pl.Series([True, True])
+    assert_series_equal(result, expected)
+
+    result = s.is_not_null()
+    expected = pl.Series([False, False])
+    assert_series_equal(result, expected)


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/9443

A struct field is null if ALL fields are null.
A struct field is NOT null if ANY of its fields are NOT null.

A simple one-line fix, with a bunch of tests.