### PR TITLE
fix(python,rust): read_csv preserve whitespace and newlines

### DIFF
--- a/crates/polars-io/src/csv/parser.rs
+++ b/crates/polars-io/src/csv/parser.rs
@@ -396,19 +396,10 @@ pub(super) fn parse_lines(
             return Ok(end - start);
         }
 
-        // only when we have one column \n should not be skipped
-        // other widths should have commas.
-        bytes = if schema_len > 1 {
-            skip_whitespace_line_ending_exclude(bytes, separator, eol_char)
-        } else {
-            skip_whitespace_exclude(bytes, separator)
-        };
         if bytes.is_empty() {
             return Ok(original_bytes_len);
-        }
-
-        // deal with comments
-        if is_comment_line(bytes, comment_prefix) {
+        } else if is_comment_line(bytes, comment_prefix) {
+            // deal with comments
             let bytes_rem = skip_this_line(bytes, quote_char, eol_char);
             bytes = bytes_rem;
             continue;

--- a/crates/polars-io/src/csv/parser.rs
+++ b/crates/polars-io/src/csv/parser.rs
@@ -174,18 +174,6 @@ pub(crate) fn skip_whitespace_exclude(input: &[u8], exclude: u8) -> &[u8] {
 }
 
 #[inline]
-/// Can be used to skip whitespace, but exclude the separator
-pub(crate) fn skip_whitespace_line_ending_exclude(
-    input: &[u8],
-    exclude: u8,
-    eol_char: u8,
-) -> &[u8] {
-    skip_condition(input, |b| {
-        b != exclude && (is_whitespace(b) || is_line_ending(b, eol_char))
-    })
-}
-
-#[inline]
 pub(crate) fn skip_line_ending(input: &[u8], eol_char: u8) -> &[u8] {
     skip_condition(input, |b| is_line_ending(b, eol_char))
 }

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -175,9 +175,9 @@ def test_string_to_decimal() -> None:
 def test_read_csv_decimal(monkeypatch: Any) -> None:
     monkeypatch.setenv("POLARS_ACTIVATE_DECIMAL", "1")
     csv = """a,b
-    123.12,a
-    1.1,a
-    0.01,a"""
+123.12,a
+1.1,a
+0.01,a"""
 
     df = pl.read_csv(csv.encode(), dtypes={"a": pl.Decimal(scale=2)})
     assert df.dtypes == [pl.Decimal(precision=None, scale=2), pl.String]

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -569,7 +569,7 @@ def test_empty_line_with_multiple_columns() -> None:
         comment_prefix="#",
         use_pyarrow=False,
     )
-    expected = pl.DataFrame({"A": ["a", "c"], "B": ["b", "d"]})
+    expected = pl.DataFrame({"A": ["a", None, "c"], "B": ["b", None, "d"]})
     assert_frame_equal(df, expected)
 
 
@@ -896,11 +896,11 @@ def test_csv_overwrite_datetime_dtype(
     try_parse_dates: bool, time_unit: TimeUnit
 ) -> None:
     data = """\
-    a
-    2020-1-1T00:00:00.123456789
-    2020-1-2T00:00:00.987654321
-    2020-1-3T00:00:00.132547698
-    """
+a
+2020-1-1T00:00:00.123456789
+2020-1-2T00:00:00.987654321
+2020-1-3T00:00:00.132547698
+"""
     result = pl.read_csv(
         io.StringIO(data),
         try_parse_dates=try_parse_dates,
@@ -1027,9 +1027,9 @@ def test_csv_write_escape_newlines() -> None:
 
 def test_skip_new_line_embedded_lines() -> None:
     csv = r"""a,b,c,d,e\n
-        1,2,3,"\n Test",\n
-        4,5,6,"Test A",\n
-        7,8,,"Test B \n",\n"""
+1,2,3,"\n Test",\n
+4,5,6,"Test A",\n
+7,8,,"Test B \n",\n"""
 
     for empty_string, missing_value in ((True, ""), (False, None)):
         df = pl.read_csv(
@@ -1591,11 +1591,11 @@ def test_csv_quote_styles() -> None:
 
 def test_ignore_errors_casting_dtypes() -> None:
     csv = """inventory
-    10
+10
 
-    400
-    90
-    """
+400
+90
+"""
 
     assert pl.read_csv(
         source=io.StringIO(csv),

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -573,6 +573,17 @@ def test_empty_line_with_multiple_columns() -> None:
     assert_frame_equal(df, expected)
 
 
+def test_preserve_whitespace_at_line_start() -> None:
+    df = pl.read_csv(
+        b"a\n  b  \n    c\nd",
+        new_columns=["A"],
+        has_header=False,
+        use_pyarrow=False,
+    )
+    expected = pl.DataFrame({"A": ["a", "  b  ", "    c", "d"]})
+    assert_frame_equal(df, expected)
+
+
 def test_csv_multi_char_comment() -> None:
     csv = textwrap.dedent(
         """\

--- a/py-polars/tests/unit/test_cse.py
+++ b/py-polars/tests/unit/test_cse.py
@@ -140,9 +140,9 @@ def test_schema_row_index_cse() -> None:
     csv_a = NamedTemporaryFile()
     csv_a.write(
         b"""
-    A,B
-    Gr1,A
-    Gr1,B
+A,B
+Gr1,A
+Gr1,B
     """.strip()
     )
     csv_a.seek(0)


### PR DESCRIPTION
fixes #13933 and partly fix for #12763 

addresses a few issues of `read_csv` (adding issue links later)

# Fix 1: preserve whitespace at start of line (currently trimmed)

Currently `read_csv` trims whitespace at the start of each line (only for the first value). This is a bug. Whitespace should be preserved as is belongs to the value. Also this only happens for the first value.

```python
DATA = """col
a
    b
        c
d"""
pl.read_csv(source=StringIO(DATA))

# Current result:
shape: (4, 1)
┌─────┐
│ col │
│ --- │
│ str │
╞═════╡
│ a   │
│ b   │
│ c   │
│ d   │
└─────┘

# NEW result (preserve whitespace, it belongs to the value!)
shape: (4, 1)
┌───────────┐
│ col       │
│ ---       │
│ str       │
╞═══════════╡
│ a         │
│     b     │
│         c │
│ d         │
└───────────┘
```


# Fix 2: preserve newlines (see #13933 )

Currently `read_csv` removed empty lines if the csv has multiple columns and keeps empty lines as `null` for csv with a single column. All whitespace in csv files belongs to the values and should be preserved. Also this is currently inconsistent as described. In the future I can also add an option like pandas has to optionally skip empty lines.

if/when this is merged I can also add an parameter `skip_empty_lines` (like pandas). But default should be to preserve any form of whitespace as it belongs to the format.

```python
# Single column (stays the same)
DATA = """col
a

c"""
pl.read_csv(source=StringIO(DATA))
shape: (3, 1)
┌──────┐
│ col  │
│ ---  │
│ str  │
╞══════╡
│ a    │
│ null │ <<<<<<<<<<<<<<<<<<< already correct for single column csv
│ c    │
└──────┘

# Multiple columns
DATA = """col1,col2
a,1

c,3"""
pl.read_csv(source=StringIO(DATA))

# Current (newline skipped)
shape: (2, 2)
┌──────┬──────┐
│ col1 ┆ col2 │
│ ---  ┆ ---  │
│ str  ┆ i64  │
╞══════╪══════╡
│ a    ┆ 1    │
│ c    ┆ 3    │
└──────┴──────┘

# New result (newline preserved)
shape: (3, 2)
┌──────┬──────┐
│ col1 ┆ col2 │
│ ---  ┆ ---  │
│ str  ┆ i64  │
╞══════╪══════╡
│ a    ┆ 1    │
│ null ┆ null │  <<<<<<<<<<<<<<<<<<< this is new! consistent with single column csv
│ c    ┆ 3    │
└──────┴──────┘
```