### PR TITLE
chore(python): Fix pip warning filter return code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ else
 	VENV_BIN=$(VENV)/bin
 endif
 
+# Define command to filter pip warnings when running maturin
+FILTER_PIP_WARNINGS=| grep -v "don't match your environment"; test $${PIPESTATUS[0]} -eq 0
+
 .venv:  ## Set up Python virtual environment and install requirements
 	python3 -m venv $(VENV)
 	$(MAKE) requirements
@@ -26,55 +29,55 @@ requirements: .venv  ## Install/refresh Python project requirements
 build: .venv  ## Compile and install Python Polars for development
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
 	&& maturin develop -m py-polars/Cargo.toml \
-	| grep -v "don't match your environment" || true
+	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-debug-opt
 build-debug-opt: .venv  ## Compile and install Python Polars with minimal optimizations turned on
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
 	 && maturin develop -m py-polars/Cargo.toml --profile opt-dev \
-	| grep -v "don't match your environment" || true
+	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-debug-opt-subset
 build-debug-opt-subset: .venv  ## Compile and install Python Polars with minimal optimizations turned on and no default features
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
 	&& maturin develop -m py-polars/Cargo.toml --no-default-features --profile opt-dev \
-	| grep -v "don't match your environment" || true
+	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-opt
 build-opt: .venv  ## Compile and install Python Polars with nearly full optimization on and debug assertions turned off, but with debug symbols on
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
 	&& maturin develop -m py-polars/Cargo.toml --profile debug-release \
-	| grep -v "don't match your environment" || true
+	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-release
 build-release: .venv  ## Compile and install a faster Python Polars binary with full optimizations
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
 	&& maturin develop -m py-polars/Cargo.toml --release \
-	| grep -v "don't match your environment" || true
+	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-native
 build-native: .venv  ## Same as build, except with native CPU optimizations turned on
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
 	&& maturin develop -m py-polars/Cargo.toml -- -C target-cpu=native \
-	| grep -v "don't match your environment" || true
+	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-debug-opt-native
 build-debug-opt-native: .venv  ## Same as build-debug-opt, except with native CPU optimizations turned on
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
 	&& maturin develop -m py-polars/Cargo.toml --profile opt-dev -- -C target-cpu=native \
-	| grep -v "don't match your environment" || true
+	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-opt-native
 build-opt-native: .venv  ## Same as build-opt, except with native CPU optimizations turned on
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
 	&& maturin develop -m py-polars/Cargo.toml --profile debug-release -- -C target-cpu=native \
-	| grep -v "don't match your environment" || true
+	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-release-native
 build-release-native: .venv  ## Same as build-release, except with native CPU optimizations turned on
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
 	&& maturin develop -m py-polars/Cargo.toml --release -- -C target-cpu=native \
-	| grep -v "don't match your environment" || true
+	$(FILTER_PIP_WARNINGS)
 
 .PHONY: clippy
 clippy:  ## Run clippy with all features


### PR DESCRIPTION
This should make sure that `make test` will not call pytest after `maturin develop` fails.