### PR TITLE
feat(rust,python,cli): add SQL support for `timestamp` precision modifier

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -194,9 +194,9 @@ impl SQLContext {
                 right,
             } => self.process_union(left, right, set_quantifier, query),
             SetExpr::SetOperation { op, .. } => {
-                polars_bail!(InvalidOperation: "{} operation not yet supported", op)
+                polars_bail!(InvalidOperation: "'{}' operation not yet supported", op)
             },
-            op => polars_bail!(InvalidOperation: "{} operation not yet supported", op),
+            op => polars_bail!(InvalidOperation: "'{}' operation not yet supported", op),
         }
     }
 
@@ -232,7 +232,7 @@ impl SQLContext {
                 concatenated.map(|lf| lf.unique(None, UniqueKeepStrategy::Any))
             },
             #[allow(unreachable_patterns)]
-            _ => polars_bail!(InvalidOperation: "UNION {} is not yet supported", quantifier),
+            _ => polars_bail!(InvalidOperation: "'UNION {}' is not yet supported", quantifier),
         }
     }
 
@@ -610,11 +610,11 @@ impl SQLContext {
                     self.table_map.insert(alias.name.value.clone(), lf.clone());
                     Ok((alias.name.value.clone(), lf))
                 } else {
-                    polars_bail!(ComputeError: "Derived tables must have aliases");
+                    polars_bail!(ComputeError: "derived tables must have aliases");
                 }
             },
             // Support bare table, optional with alias for now
-            _ => polars_bail!(ComputeError: "not implemented"),
+            _ => polars_bail!(ComputeError: "not yet implemented: {}", relation),
         }
     }
 
@@ -774,7 +774,7 @@ impl SQLContext {
                 cols(schema.iter_names())
             },
             e => polars_bail!(
-                ComputeError: "Invalid wildcard expression: {:?}",
+                ComputeError: "invalid wildcard expression: {:?}",
                 e
             ),
         };

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -773,10 +773,10 @@ impl SQLFunctionVisitor<'_> {
                                 polars_bail!(InvalidOperation: "Round does not (yet) support negative 'decimals': {}", function.args[1])
                             }
                         },
-                        _ => polars_bail!(InvalidOperation: "Invalid 'decimals' for Round: {}", function.args[1]),
+                        _ => polars_bail!(InvalidOperation: "invalid 'decimals' for Round: {}", function.args[1]),
                     }))
                 }),
-                _ => polars_bail!(InvalidOperation:"Invalid number of arguments for Round: {}", function.args.len()),
+                _ => polars_bail!(InvalidOperation: "invalid number of arguments for Round: {}", function.args.len()),
             },
             Sign => self.visit_unary(Expr::sign),
             Sqrt => self.visit_unary(Expr::sqrt),
@@ -811,7 +811,7 @@ impl SQLFunctionVisitor<'_> {
                 3 => self.try_visit_ternary(|cond: Expr, expr1: Expr, expr2: Expr| {
                     Ok(when(cond).then(expr1).otherwise(expr2))
                 }),
-                _ => polars_bail!(InvalidOperation: "Invalid number of arguments for If: {}", function.args.len()
+                _ => polars_bail!(InvalidOperation: "invalid number of arguments for If: {}", function.args.len()
                 ),
             },
             IfNull => match function.args.len() {
@@ -826,13 +826,13 @@ impl SQLFunctionVisitor<'_> {
             Date => match function.args.len() {
                 1 => self.visit_unary(|e| e.str().to_date(StrptimeOptions::default())),
                 2 => self.visit_binary(|e, fmt| e.str().to_date(fmt)),
-                _ => polars_bail!(InvalidOperation: "Invalid number of arguments for Date: {}", function.args.len()),
+                _ => polars_bail!(InvalidOperation: "invalid number of arguments for Date: {}", function.args.len()),
             },
             DatePart => self.try_visit_binary(|e, part| {
                 match part {
                     Expr::Literal(LiteralValue::String(p)) => parse_date_part(e, &p),
                     _ => {
-                        polars_bail!(InvalidOperation: "Invalid 'part' for DatePart: {}", function.args[1]);
+                        polars_bail!(InvalidOperation: "invalid 'part' for DatePart: {}", function.args[1]);
                     }
                 }
             }),
@@ -842,12 +842,12 @@ impl SQLFunctionVisitor<'_> {
             // ----
             BitLength => self.visit_unary(|e| e.str().len_bytes() * lit(8)),
             Concat => if function.args.is_empty() {
-                polars_bail!(InvalidOperation: "Invalid number of arguments for Concat: 0");
+                polars_bail!(InvalidOperation: "invalid number of arguments for Concat: 0");
             } else {
                 self.visit_variadic(|exprs: &[Expr]| concat_str(exprs, "", true))
             },
             ConcatWS => if function.args.len() < 2 {
-                polars_bail!(InvalidOperation: "Invalid number of arguments for ConcatWS: {}", function.args.len());
+                polars_bail!(InvalidOperation: "invalid number of arguments for ConcatWS: {}", function.args.len());
             } else {
                 self.try_visit_variadic(|exprs: &[Expr]| {
                     match &exprs[0] {
@@ -867,7 +867,7 @@ impl SQLFunctionVisitor<'_> {
                         let len = if n > 0 { lit(n) } else { (e.clone().str().len_chars() + lit(n)).clip_min(lit(0)) };
                         e.str().slice(lit(0), len)
                     },
-                    Expr::Literal(_) => polars_bail!(InvalidOperation: "Invalid 'n_chars' for Left: {}", function.args[1]),
+                    Expr::Literal(_) => polars_bail!(InvalidOperation: "invalid 'n_chars' for Left: {}", function.args[1]),
                     _ => {
                             when(length.clone().gt_eq(lit(0)))
                                 .then(e.clone().str().slice(lit(0), length.clone().abs()))
@@ -880,7 +880,7 @@ impl SQLFunctionVisitor<'_> {
             LTrim => match function.args.len() {
                 1 => self.visit_unary(|e| e.str().strip_chars_start(lit(Null))),
                 2 => self.visit_binary(|e, s| e.str().strip_chars_start(s)),
-                _ => polars_bail!(InvalidOperation: "Invalid number of arguments for LTrim: {}", function.args.len()),
+                _ => polars_bail!(InvalidOperation: "invalid number of arguments for LTrim: {}", function.args.len()),
             },
             OctetLength => self.visit_unary(|e| e.str().len_bytes()),
             StrPos => {
@@ -894,12 +894,12 @@ impl SQLFunctionVisitor<'_> {
                         match (pat, flags) {
                             (Expr::Literal(LiteralValue::String(s)), Expr::Literal(LiteralValue::String(f))) => {
                                 if f.is_empty() {
-                                    polars_bail!(InvalidOperation: "Invalid/empty 'flags' for RegexpLike: {}", function.args[2]);
+                                    polars_bail!(InvalidOperation: "invalid/empty 'flags' for RegexpLike: {}", function.args[2]);
                                 };
                                 lit(format!("(?{}){}", f, s))
                             },
                             _ => {
-                                polars_bail!(InvalidOperation: "Invalid arguments for RegexpLike: {}, {}", function.args[1], function.args[2]);
+                                polars_bail!(InvalidOperation: "invalid arguments for RegexpLike: {}, {}", function.args[1], function.args[2]);
                             },
                         },
                         true))
@@ -910,7 +910,7 @@ impl SQLFunctionVisitor<'_> {
                 3 => self.try_visit_ternary(|e, old, new| {
                     Ok(e.str().replace_all(old, new, true))
                 }),
-                _ => polars_bail!(InvalidOperation: "Invalid number of arguments for Replace: {}", function.args.len()),
+                _ => polars_bail!(InvalidOperation: "invalid number of arguments for Replace: {}", function.args.len()),
             },
             Reverse => self.visit_unary(|e| e.str().reverse()),
             Right => self.try_visit_binary(|e, length| {
@@ -921,7 +921,7 @@ impl SQLFunctionVisitor<'_> {
                         let offset = if n < 0 { lit(n.abs()) } else { e.clone().str().len_chars().cast(DataType::Int32) - lit(n) };
                         e.str().slice(offset, lit(Null))
                     },
-                    Expr::Literal(_) => polars_bail!(InvalidOperation: "Invalid 'n_chars' for Right: {}", function.args[1]),
+                    Expr::Literal(_) => polars_bail!(InvalidOperation: "invalid 'n_chars' for Right: {}", function.args[1]),
                     _ => {
                         when(length.clone().lt(lit(0)))
                             .then(e.clone().str().slice(length.clone().abs(), lit(Null)))
@@ -932,7 +932,7 @@ impl SQLFunctionVisitor<'_> {
             RTrim => match function.args.len() {
                 1 => self.visit_unary(|e| e.str().strip_chars_end(lit(Null))),
                 2 => self.visit_binary(|e, s| e.str().strip_chars_end(s)),
-                _ => polars_bail!(InvalidOperation: "Invalid number of arguments for RTrim: {}", function.args.len()),
+                _ => polars_bail!(InvalidOperation: "invalid number of arguments for RTrim: {}", function.args.len()),
             },
             StartsWith => self.visit_binary(|e, s| e.str().starts_with(s)),
             Substring => match function.args.len() {
@@ -942,7 +942,7 @@ impl SQLFunctionVisitor<'_> {
                         Expr::Literal(Null) => lit(Null),
                         Expr::Literal(LiteralValue::Int64(n)) if n <= 0 => e,
                         Expr::Literal(LiteralValue::Int64(n)) => e.str().slice(lit(n - 1), lit(Null)),
-                        Expr::Literal(_) => polars_bail!(InvalidOperation: "Invalid 'start' for Substring: {}", function.args[1]),
+                        Expr::Literal(_) => polars_bail!(InvalidOperation: "invalid 'start' for Substring: {}", function.args[1]),
                         _ => start.clone() + lit(1),
                     })
                 }),
@@ -956,9 +956,9 @@ impl SQLFunctionVisitor<'_> {
                         (Expr::Literal(LiteralValue::Int64(n)), _) => {
                             e.str().slice(lit(0), (length.clone() + lit(n - 1)).clip_min(lit(0)))
                         },
-                        (Expr::Literal(_), _) => polars_bail!(InvalidOperation: "Invalid 'start' for Substring: {}", function.args[1]),
+                        (Expr::Literal(_), _) => polars_bail!(InvalidOperation: "invalid 'start' for Substring: {}", function.args[1]),
                         (_, Expr::Literal(LiteralValue::Float64(_))) => {
-                            polars_bail!(InvalidOperation: "Invalid 'length' for Substring: {}", function.args[1])
+                            polars_bail!(InvalidOperation: "invalid 'length' for Substring: {}", function.args[1])
                         },
                         _ => {
                             let adjusted_start = start.clone() - lit(1);
@@ -968,7 +968,7 @@ impl SQLFunctionVisitor<'_> {
                         }
                     })
                 }),
-                _ => polars_bail!(InvalidOperation: "Invalid number of arguments for Substring: {}", function.args.len()),
+                _ => polars_bail!(InvalidOperation: "invalid number of arguments for Substring: {}", function.args.len()),
             }
             Upper => self.visit_unary(|e| e.str().to_uppercase()),
             // ----
@@ -1006,10 +1006,10 @@ impl SQLFunctionVisitor<'_> {
                                 e.list().eval(col("").fill_null(lit(v)), false).list().join(sep, false)
                             })
                         },
-                        _ => polars_bail!(InvalidOperation: "Invalid null value for ArrayToString: {}", function.args[2]),
+                        _ => polars_bail!(InvalidOperation: "invalid null value for ArrayToString: {}", function.args[2]),
                     }
                 }),
-                _ => polars_bail!(InvalidOperation: "Invalid number of arguments for ArrayToString: {}", function.args.len()),
+                _ => polars_bail!(InvalidOperation: "invalid number of arguments for ArrayToString: {}", function.args.len()),
             }
             ArrayUnique => self.visit_unary(|e| e.list().unique()),
             Explode => self.visit_unary(|e| e.explode()),

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -904,7 +904,7 @@ impl SQLFunctionVisitor<'_> {
                         },
                         true))
                 }),
-                _ => polars_bail!(InvalidOperation:"Invalid number of arguments for RegexpLike: {}",function.args.len()),
+                _ => polars_bail!(InvalidOperation: "invalid number of arguments for RegexpLike: {}",function.args.len()),
             },
             Replace => match function.args.len() {
                 3 => self.try_visit_ternary(|e, old, new| {

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -67,7 +67,9 @@ pub(crate) fn map_sql_polars_datatype(data_type: &SQLDataType) -> PolarsResult<D
         SQLDataType::SmallInt(_) => DataType::Int16,
         SQLDataType::Time(_, tz) => match tz {
             TimezoneInfo::None => DataType::Time,
-            _ => polars_bail!(ComputeError: "Time with timezone is not supported; found tz={}", tz),
+            _ => {
+                polars_bail!(ComputeError: "`time` with timezone is not supported; found tz={}", tz)
+            },
         },
         SQLDataType::Timestamp(prec, tz) => {
             let tu = match prec {
@@ -76,13 +78,13 @@ pub(crate) fn map_sql_polars_datatype(data_type: &SQLDataType) -> PolarsResult<D
                 Some(6) => TimeUnit::Microseconds,
                 Some(9) => TimeUnit::Nanoseconds,
                 Some(n) => {
-                    polars_bail!(ComputeError: "Unsupported timestamp precision; expected 3, 6 or 9, found prec={}", n)
+                    polars_bail!(ComputeError: "unsupported `timestamp` precision; expected 3, 6 or 9, found prec={}", n)
                 },
             };
             match tz {
                 TimezoneInfo::None => DataType::Datetime(tu, None),
                 _ => {
-                    polars_bail!(ComputeError: "Timestamp with timezone is not (yet) supported; found tz={}", tz)
+                    polars_bail!(ComputeError: "`timestamp` with timezone is not (yet) supported; found tz={}", tz)
                 },
             }
         },
@@ -289,7 +291,7 @@ impl SQLExprVisitor<'_> {
                 }
             },
             _ => polars_bail!(
-                ComputeError: "Invalid identifier {:?}",
+                ComputeError: "invalid identifier {:?}",
                 idents
             ),
         }
@@ -370,23 +372,23 @@ impl SQLExprVisitor<'_> {
             // ----
             SQLBinaryOperator::PGRegexMatch => match right {
                 Expr::Literal(LiteralValue::String(_)) => left.str().contains(right, true),
-                _ => polars_bail!(ComputeError: "Invalid pattern for '~' operator: {:?}", right),
+                _ => polars_bail!(ComputeError: "invalid pattern for '~' operator: {:?}", right),
             },
             SQLBinaryOperator::PGRegexNotMatch => match right {
                 Expr::Literal(LiteralValue::String(_)) => left.str().contains(right, true).not(),
-                _ => polars_bail!(ComputeError: "Invalid pattern for '!~' operator: {:?}", right),
+                _ => polars_bail!(ComputeError: "invalid pattern for '!~' operator: {:?}", right),
             },
             SQLBinaryOperator::PGRegexIMatch => match right {
                 Expr::Literal(LiteralValue::String(pat)) => {
                     left.str().contains(lit(format!("(?i){}", pat)), true)
                 },
-                _ => polars_bail!(ComputeError: "Invalid pattern for '~*' operator: {:?}", right),
+                _ => polars_bail!(ComputeError: "invalid pattern for '~*' operator: {:?}", right),
             },
             SQLBinaryOperator::PGRegexNotIMatch => match right {
                 Expr::Literal(LiteralValue::String(pat)) => {
                     left.str().contains(lit(format!("(?i){}", pat)), true).not()
                 },
-                _ => polars_bail!(ComputeError: "Invalid pattern for '!~*' operator: {:?}", right),
+                _ => polars_bail!(ComputeError: "invalid pattern for '!~*' operator: {:?}", right),
             },
             other => polars_bail!(ComputeError: "SQL operator {:?} is not yet supported", other),
         })
@@ -407,7 +409,7 @@ impl SQLExprVisitor<'_> {
             (UnaryOperator::Plus, _) => lit(0) + expr,
             (UnaryOperator::Minus, _) => lit(0) - expr,
             (UnaryOperator::Not, _) => expr.not(),
-            other => polars_bail!(InvalidOperation: "Unary operator {:?} is not supported", other),
+            other => polars_bail!(InvalidOperation: "unary operator {:?} is not supported", other),
         })
     }
 
@@ -443,7 +445,7 @@ impl SQLExprVisitor<'_> {
             BinaryOperator::LtEq => Ok(left.lt_eq(right.min())),
             BinaryOperator::Eq => polars_bail!(ComputeError: "ALL cannot be used with ="),
             BinaryOperator::NotEq => polars_bail!(ComputeError: "ALL cannot be used with !="),
-            _ => polars_bail!(ComputeError: "Invalid comparison operator"),
+            _ => polars_bail!(ComputeError: "invalid comparison operator"),
         }
     }
 
@@ -466,7 +468,7 @@ impl SQLExprVisitor<'_> {
             BinaryOperator::LtEq => Ok(left.lt_eq(right.max())),
             BinaryOperator::Eq => Ok(left.is_in(right)),
             BinaryOperator::NotEq => Ok(left.is_in(right).not()),
-            _ => polars_bail!(ComputeError: "Invalid comparison operator"),
+            _ => polars_bail!(ComputeError: "invalid comparison operator"),
         }
     }
 
@@ -910,7 +912,7 @@ pub(super) fn process_join_constraint(
             return Ok((using.clone(), using.clone()));
         }
     }
-    polars_bail!(InvalidOperation: "Unsupported SQL join constraint:\n{:?}", constraint);
+    polars_bail!(InvalidOperation: "unsupported SQL join constraint:\n{:?}", constraint);
 }
 
 /// parse a SQL expression to a polars expression

--- a/py-polars/tests/unit/sql/test_numeric.py
+++ b/py-polars/tests/unit/sql/test_numeric.py
@@ -109,7 +109,7 @@ def test_round_ndigits_errors() -> None:
     df = pl.DataFrame({"n": [99.999]})
     with pl.SQLContext(df=df, eager_execution=True) as ctx:
         with pytest.raises(
-            InvalidOperationError, match="Invalid 'decimals' for Round: ??"
+            InvalidOperationError, match="invalid 'decimals' for Round: ??"
         ):
             ctx.execute("SELECT ROUND(n,'??') AS n FROM df")
         with pytest.raises(

--- a/py-polars/tests/unit/sql/test_regex.py
+++ b/py-polars/tests/unit/sql/test_regex.py
@@ -82,12 +82,12 @@ def test_regex_operators_error() -> None:
     df = pl.LazyFrame({"sval": ["ABC", "abc", "000", "A0C", "a0c"]})
     with pl.SQLContext(df=df, eager_execution=True) as ctx:
         with pytest.raises(
-            ComputeError, match="Invalid pattern for '~' operator: 12345"
+            ComputeError, match="invalid pattern for '~' operator: 12345"
         ):
             ctx.execute("SELECT * FROM df WHERE sval ~ 12345")
         with pytest.raises(
             ComputeError,
-            match=r"""Invalid pattern for '!~\*' operator: col\("abcde"\)""",
+            match=r"""invalid pattern for '!~\*' operator: col\("abcde"\)""",
         ):
             ctx.execute("SELECT * FROM df WHERE sval !~* abcde")
 
@@ -127,18 +127,18 @@ def test_regexp_like_errors() -> None:
     with pl.SQLContext(df=pl.DataFrame({"scol": ["xyz"]})) as ctx:
         with pytest.raises(
             InvalidOperationError,
-            match="Invalid/empty 'flags' for RegexpLike",
+            match="invalid/empty 'flags' for RegexpLike",
         ):
             ctx.execute("SELECT * FROM df WHERE REGEXP_LIKE(scol,'[x-z]+','')")
 
         with pytest.raises(
             InvalidOperationError,
-            match="Invalid arguments for RegexpLike",
+            match="invalid arguments for RegexpLike",
         ):
             ctx.execute("SELECT * FROM df WHERE REGEXP_LIKE(scol,999,999)")
 
         with pytest.raises(
             InvalidOperationError,
-            match="Invalid number of arguments for RegexpLike",
+            match="invalid number of arguments for RegexpLike",
         ):
             ctx.execute("SELECT * FROM df WHERE REGEXP_LIKE(scol)")

--- a/py-polars/tests/unit/sql/test_strings.py
+++ b/py-polars/tests/unit/sql/test_strings.py
@@ -76,7 +76,7 @@ def test_string_concat() -> None:
 )
 def test_string_concat_errors(invalid_concat: str) -> None:
     lf = pl.LazyFrame({"x": ["a", "b", "c"]})
-    with pytest.raises(InvalidOperationError, match="Invalid number of arguments"):
+    with pytest.raises(InvalidOperationError, match="invalid number of arguments"):
         pl.SQLContext(data=lf).execute(f"SELECT {invalid_concat} FROM data")
 
 
@@ -101,7 +101,7 @@ def test_string_left_right_reverse() -> None:
     for func, invalid in (("LEFT", "'xyz'"), ("RIGHT", "6.66")):
         with pytest.raises(
             InvalidOperationError,
-            match=f"Invalid 'n_chars' for {func.capitalize()}: {invalid}",
+            match=f"invalid 'n_chars' for {func.capitalize()}: {invalid}",
         ):
             ctx.execute(f"""SELECT {func}(txt,{invalid}) FROM df""").collect()
 
@@ -317,7 +317,7 @@ def test_string_replace() -> None:
         res = out["words"].to_list()
         assert res == ["English breakfast tea is the best tea", "", None]
 
-        with pytest.raises(InvalidOperationError, match="Invalid number of arguments"):
+        with pytest.raises(InvalidOperationError, match="invalid number of arguments"):
             ctx.execute("SELECT REPLACE(words,'coffee') FROM df")
 
 

--- a/py-polars/tests/unit/sql/test_temporal.py
+++ b/py-polars/tests/unit/sql/test_temporal.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 import polars as pl
+from polars.exceptions import ComputeError
 from polars.testing import assert_frame_equal
 
 
@@ -121,3 +122,43 @@ def test_extract_century_millennium(dt: date, expected: list[int]) -> None:
                 schema=["c1", "c2", "c3", "c4"],
             ).cast(pl.Int32),
         )
+
+
+@pytest.mark.parametrize(
+    ("unit", "expected"),
+    [
+        ("ms", [1704589323123, 1609324245987, 1136159999555]),
+        ("us", [1704589323123456, 1609324245987654, 1136159999555555]),
+        ("ns", [1704589323123456000, 1609324245987654000, 1136159999555555000]),
+        (None, [1704589323123456, 1609324245987654, 1136159999555555]),
+    ],
+)
+def test_timestamp_time_unit(unit: str | None, expected: list[int]) -> None:
+    df = pl.DataFrame(
+        {
+            "ts": [
+                datetime(2024, 1, 7, 1, 2, 3, 123456),
+                datetime(2020, 12, 30, 10, 30, 45, 987654),
+                datetime(2006, 1, 1, 23, 59, 59, 555555),
+            ],
+        }
+    )
+    precision = {"ms": 3, "us": 6, "ns": 9}
+
+    with pl.SQLContext(frame_data=df, eager_execution=True) as ctx:
+        prec = f"({precision[unit]})" if unit else ""
+        res = ctx.execute(f"SELECT ts::timestamp{prec} FROM frame_data").to_series()
+
+        assert res.dtype == pl.Datetime(time_unit=unit)  # type: ignore[arg-type]
+        assert res.to_physical().to_list() == expected
+
+
+def test_timestamp_time_unit_errors() -> None:
+    df = pl.DataFrame({"ts": [datetime(2024, 1, 7, 1, 2, 3, 123456)]})
+
+    with pl.SQLContext(frame_data=df, eager_execution=True) as ctx:
+        for prec in (0, 4, 15):
+            with pytest.raises(
+                ComputeError, match=f"Unsupported timestamp precision; .* prec={prec}"
+            ):
+                ctx.execute(f"SELECT ts::timestamp({prec}) FROM frame_data")

--- a/py-polars/tests/unit/sql/test_temporal.py
+++ b/py-polars/tests/unit/sql/test_temporal.py
@@ -159,6 +159,6 @@ def test_timestamp_time_unit_errors() -> None:
     with pl.SQLContext(frame_data=df, eager_execution=True) as ctx:
         for prec in (0, 4, 15):
             with pytest.raises(
-                ComputeError, match=f"Unsupported timestamp precision; .* prec={prec}"
+                ComputeError, match=f"unsupported `timestamp` precision; .* prec={prec}"
             ):
                 ctx.execute(f"SELECT ts::timestamp({prec}) FROM frame_data")


### PR DESCRIPTION
Adds recognition of PostgreSQL compatible timestamp precision[^1] modifier.
Supports values that map to our `Datetime` time units, specifically `3 → 'ms'`, `6 → 'us'`, `9 → 'ns'`:

## Example
```python
from datetime import datetime
import polars as pl

df = pl.DataFrame({
    "ts": [
        datetime(2024, 1, 7, 1, 2, 3, 123456),
        datetime(1999, 1, 1, 23, 59, 59, 555555),
        datetime(2020, 12, 30, 10, 30, 45, 987654),
    ],
})

with pl.SQLContext(frame_data=df, eager_execution=True) as ctx:
    print(ctx.execute(
        f"SELECT ts::timestamp(3) FROM frame_data")
    )
    # shape: (3, 1)
    # ┌─────────────────────────┐
    # │ ts                      │
    # │ ---                     │
    # │ datetime[ms]            │  << precision 3 → 'ms'
    # ╞═════════════════════════╡
    # │ 2024-01-07 01:02:03.123 │
    # │ 1999-01-01 23:59:59.555 │
    # │ 2020-12-30 10:30:45.987 │
    # └─────────────────────────┘
```
[^1]: https://www.postgresql.org/docs/current/datatype-datetime.html