### PR TITLE
fix(rust, python): Allow dtype merge when inner dtype is enum

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -450,7 +450,10 @@ pub fn merge_dtypes(left: &DataType, right: &DataType) -> PolarsResult<DataType>
                     merger.merge_map(rev_map_r)?;
                     Categorical(Some(merger.finish()), *ordering)
                 },
-                (RevMapping::Local(_, idl), RevMapping::Local(_, idr)) if idl == idr => {
+                (RevMapping::Local(_, idl), RevMapping::Local(_, idr))
+                | (RevMapping::Enum(_, idl), RevMapping::Enum(_, idr))
+                    if idl == idr =>
+                {
                     left.clone()
                 },
                 _ => polars_bail!(string_cache_mismatch),

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -70,6 +70,24 @@ def test_nested_enum_creation() -> None:
     assert s.dtype == dtype
 
 
+def test_nested_enum_concat() -> None:
+    dtype = pl.List(pl.Enum(["a", "b", "c", "d"]))
+    s1 = pl.Series([[None, "a"], ["b", "c"]], dtype=dtype)
+    s2 = pl.Series([["c", "d"], ["a", None]], dtype=dtype)
+    expected = pl.Series(
+        [
+            [None, "a"],
+            ["b", "c"],
+            ["c", "d"],
+            ["a", None],
+        ],
+        dtype=dtype,
+    )
+
+    assert_series_equal(pl.concat((s1, s2)), expected)
+    assert_series_equal(s1.extend(s2), expected)
+
+
 def test_casting_to_an_enum_from_utf() -> None:
     dtype = pl.Enum(["a", "b", "c"])
     s = pl.Series([None, "a", "b", "c"])


### PR DESCRIPTION
Resolves #13937.

