### PR TITLE
fix: check input type for `arr/list.contains`

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/array.rs
+++ b/crates/polars-plan/src/dsl/function_expr/array.rs
@@ -183,6 +183,9 @@ pub(super) fn join(s: &[Series], ignore_nulls: bool) -> PolarsResult<Series> {
 pub(super) fn contains(s: &[Series]) -> PolarsResult<Series> {
     let array = &s[0];
     let item = &s[1];
+    polars_ensure!(matches!(array.dtype(), DataType::Array(_, _)),
+        SchemaMismatch: "invalid series dtype: expected `Array`, got `{}`", array.dtype(),
+    );
     Ok(is_in(item, array)?.with_name(array.name()).into_series())
 }
 

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -219,7 +219,9 @@ impl From<ListFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
 pub(super) fn contains(args: &mut [Series]) -> PolarsResult<Option<Series>> {
     let list = &args[0];
     let item = &args[1];
-
+    polars_ensure!(matches!(list.dtype(), DataType::List(_)),
+        SchemaMismatch: "invalid series dtype: expected `List`, got `{}`", list.dtype(),
+    );
     polars_ops::prelude::is_in(item, list).map(|mut ca| {
         ca.rename(list.name());
         Some(ca.into_series())

--- a/py-polars/tests/unit/namespaces/array/test_array.py
+++ b/py-polars/tests/unit/namespaces/array/test_array.py
@@ -315,64 +315,6 @@ def test_array_explode() -> None:
 
 
 @pytest.mark.parametrize(
-    ("array", "data", "expected", "dtype"),
-    [
-        ([[1, 2], [3, 4]], [1, 5], [True, False], pl.Int64),
-        ([[True, False], [True, True]], [True, False], [True, False], pl.Boolean),
-        ([["a", "b"], ["c", "d"]], ["a", "b"], [True, False], pl.String),
-        ([[b"a", b"b"], [b"c", b"d"]], [b"a", b"b"], [True, False], pl.Binary),
-        (
-            [[{"a": 1}, {"a": 2}], [{"b": 1}, {"a": 3}]],
-            [{"a": 1}, {"a": 2}],
-            [True, False],
-            pl.Struct([pl.Field("a", pl.Int64)]),
-        ),
-    ],
-)
-def test_array_contains_expr(
-    array: list[list[Any]], data: list[Any], expected: list[bool], dtype: pl.DataType
-) -> None:
-    df = pl.DataFrame(
-        {
-            "array": array,
-            "data": data,
-        },
-        schema={
-            "array": pl.Array(dtype, 2),
-            "data": dtype,
-        },
-    )
-    out = df.select(contains=pl.col("array").arr.contains(pl.col("data"))).to_series()
-    expected_series = pl.Series("contains", expected)
-    assert_series_equal(out, expected_series)
-
-
-@pytest.mark.parametrize(
-    ("array", "data", "expected", "dtype"),
-    [
-        ([[1, 2], [3, 4]], 1, [True, False], pl.Int64),
-        ([[True, False], [True, True]], True, [True, True], pl.Boolean),
-        ([["a", "b"], ["c", "d"]], "a", [True, False], pl.String),
-        ([[b"a", b"b"], [b"c", b"d"]], b"a", [True, False], pl.Binary),
-    ],
-)
-def test_array_contains_literal(
-    array: list[list[Any]], data: Any, expected: list[bool], dtype: pl.DataType
-) -> None:
-    df = pl.DataFrame(
-        {
-            "array": array,
-        },
-        schema={
-            "array": pl.Array(dtype, 2),
-        },
-    )
-    out = df.select(contains=pl.col("array").arr.contains(data)).to_series()
-    expected_series = pl.Series("contains", expected)
-    assert_series_equal(out, expected_series)
-
-
-@pytest.mark.parametrize(
     ("arr", "data", "expected", "dtype"),
     [
         ([[1, 2], [3, None], None], 1, [1, 0, None], pl.Int64),

--- a/py-polars/tests/unit/namespaces/array/test_contains.py
+++ b/py-polars/tests/unit/namespaces/array/test_contains.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import polars as pl
+from polars.testing import assert_series_equal
+
+
+@pytest.mark.parametrize(
+    ("array", "data", "expected", "dtype"),
+    [
+        ([[1, 2], [3, 4]], [1, 5], [True, False], pl.Int64),
+        ([[True, False], [True, True]], [True, False], [True, False], pl.Boolean),
+        ([["a", "b"], ["c", "d"]], ["a", "b"], [True, False], pl.String),
+        ([[b"a", b"b"], [b"c", b"d"]], [b"a", b"b"], [True, False], pl.Binary),
+        (
+            [[{"a": 1}, {"a": 2}], [{"b": 1}, {"a": 3}]],
+            [{"a": 1}, {"a": 2}],
+            [True, False],
+            pl.Struct([pl.Field("a", pl.Int64)]),
+        ),
+    ],
+)
+def test_array_contains_expr(
+    array: list[list[Any]], data: list[Any], expected: list[bool], dtype: pl.DataType
+) -> None:
+    df = pl.DataFrame(
+        {
+            "array": array,
+            "data": data,
+        },
+        schema={
+            "array": pl.Array(dtype, 2),
+            "data": dtype,
+        },
+    )
+    out = df.select(contains=pl.col("array").arr.contains(pl.col("data"))).to_series()
+    expected_series = pl.Series("contains", expected)
+    assert_series_equal(out, expected_series)
+
+
+@pytest.mark.parametrize(
+    ("array", "data", "expected", "dtype"),
+    [
+        ([[1, 2], [3, 4]], 1, [True, False], pl.Int64),
+        ([[True, False], [True, True]], True, [True, True], pl.Boolean),
+        ([["a", "b"], ["c", "d"]], "a", [True, False], pl.String),
+        ([[b"a", b"b"], [b"c", b"d"]], b"a", [True, False], pl.Binary),
+    ],
+)
+def test_array_contains_literal(
+    array: list[list[Any]], data: Any, expected: list[bool], dtype: pl.DataType
+) -> None:
+    df = pl.DataFrame(
+        {
+            "array": array,
+        },
+        schema={
+            "array": pl.Array(dtype, 2),
+        },
+    )
+    out = df.select(contains=pl.col("array").arr.contains(data)).to_series()
+    expected_series = pl.Series("contains", expected)
+    assert_series_equal(out, expected_series)
+
+
+def test_array_contains_invalid_datatype() -> None:
+    df = pl.DataFrame({"a": [[1, 2], [3, 4]]}, schema={"a": pl.List(pl.Int8)})
+    with pytest.raises(pl.SchemaError, match="invalid series dtype: expected `Array`"):
+        df.select(pl.col("a").arr.contains(2))

--- a/py-polars/tests/unit/namespaces/test_list.py
+++ b/py-polars/tests/unit/namespaces/test_list.py
@@ -79,6 +79,12 @@ def test_contains() -> None:
     assert_series_equal(out, expected)
 
 
+def test_list_contains_invalid_datatype() -> None:
+    df = pl.DataFrame({"a": [[1, 2], [3, 4]]}, schema={"a": pl.Array(pl.Int8, width=2)})
+    with pytest.raises(pl.SchemaError, match="invalid series dtype: expected `List`"):
+        df.select(pl.col("a").list.contains(2))
+
+
 def test_list_concat() -> None:
     df = pl.DataFrame({"a": [[1, 2], [1], [1, 2, 3]]})
 


### PR DESCRIPTION
Almost all operations in `list/arr` namespace ensures the input type when unpack series. But `contains` is an exception due to the reuse of `is_in` ops. As a result, you can even call `arr.contains` on list series. 

IMO, we should raise for things like `ListSeries.arr.xxx` or `ArraySeries.list.xxx`. After all, they are not essentially the same type. In particular, you can't even convert a list to an array with unequal width.