### PR TITLE
fix: Raise for .dt.epoch and .dt.timestamp for Duration dtype

### DIFF
--- a/crates/polars-time/src/series/mod.rs
+++ b/crates/polars-time/src/series/mod.rs
@@ -255,7 +255,7 @@ pub trait TemporalMethods: AsSeries {
     /// Convert date(time) object to timestamp in [`TimeUnit`].
     fn timestamp(&self, tu: TimeUnit) -> PolarsResult<Int64Chunked> {
         let s = self.as_series();
-        if matches!(s.dtype(), DataType::Time) {
+        if matches!(s.dtype(), DataType::Time | DataType::Duration(_)) {
             polars_bail!(opq = timestamp, s.dtype());
         } else {
             s.cast(&DataType::Datetime(tu, None))

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -283,7 +283,7 @@ def test_int_to_python_timedelta() -> None:
     ]
 
     assert df.select(
-        [pl.col(col).dt.timestamp() for col in ("c", "d", "e")]
+        [pl.col(col).cast(pl.Int64) for col in ("c", "d", "e")]
     ).rows() == [(100001, 100001, 100001), (200002, 200002, 200002)]
 
 

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -906,6 +906,11 @@ def test_year_empty_df() -> None:
     assert df.select(pl.col("date").dt.year()).dtypes == [pl.Int32]
 
 
+def test_epoch_invalid() -> None:
+    with pytest.raises(InvalidOperationError, match="not supported for dtype"):
+        pl.Series([timedelta(1)]).dt.epoch()
+
+
 @pytest.mark.parametrize(
     "time_unit",
     ["ms", "us", "ns"],


### PR DESCRIPTION
closes #13208

this could be done with a deprecation cycle, but is it really worth it? this could just be a breaking 1.0 change imho