### PR TITLE
fix(python): Fix `max_colname_length` formatting in `glimpse()`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4336,7 +4336,6 @@ class DataFrame:
         # determine column layout widths
         max_col_name = max((len(col_name) for col_name, _, _ in data))
         max_col_dtype = max((len(dtype_str) for _, dtype_str, _ in data))
-        max_col_values = 100 - max_col_name - max_col_dtype
 
         # print header
         output = StringIO()
@@ -4347,7 +4346,7 @@ class DataFrame:
             output.write(
                 f"$ {col_name:<{max_col_name}}"
                 f" {dtype_str:>{max_col_dtype}}"
-                f" {val_str:<{min(len(val_str), max_col_values)}}\n"
+                f" {val_str}\n"
             )
 
         s = output.getvalue()


### PR DESCRIPTION
It seems there was an arbitrary limit of 100 characters for the length of the string showing the column name and dtype in `glimpse()`. If you have long column names and pass a `max_colname_length` that is too long, you will get a formatting error because the format width specifier for the last line item becomes negative. Specifically, If you have a `df` with a column named `a = 'some_long_col_name_xxxxxxxxx...'`, then `df.glimpse(max_colname_length=b)` throws a formatting error for any `b > len(a) + len(f"<{_dtype_str_repr(df[a].dtype)}>")` (see below). This PR just removes the width specifier on the last line item which was redundant anyway.

```py
def test(max_colname_length):
    df = pl.DataFrame({'a' * 100: [1, 2, 3]})
    df.glimpse(max_colname_length=max_colname_length)
```
```py
test(95)
```
```pycon
Rows: 3
Columns: 1
$ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa… <i64> 1, 2, 3
```

```py
test(96)
```
```pytb
ValueError                                Traceback (most recent call last)
[~\AppData\Local\Temp\ipykernel_30960\2962826816.py](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/user/.../~/AppData/Local/Temp/ipykernel_30960/2962826816.py) in ?()
      1 test = pl.DataFrame({'a' * 100: [1, 2, 3]})
----> 2 test.glimpse(max_colname_length=96)

[c:\Users\user\miniforge3\envs\env\Lib\site-packages\polars\dataframe\frame.py](file:///C:/Users/user/miniforge3/envs/env/Lib/site-packages/polars/dataframe/frame.py) in ?(self, max_items_per_column, max_colname_length, return_as_string)
   4338 
   4339         # print individual columns: one row per column
   4340         for col_name, dtype_str, val_str in data:
   4341             output.write(
-> 4342                 f"$ {col_name:<{max_col_name}}"
   4343                 f" {dtype_str:>{max_col_dtype}}"
   4344                 f" {val_str:<{min(len(val_str), max_col_values)}}\n"
   4345             )

ValueError: Sign not allowed in string format specifier
```