### PR TITLE
test(python): Fix xdist streaming group

### DIFF
--- a/py-polars/tests/unit/streaming/__init__.py
+++ b/py-polars/tests/unit/streaming/__init__.py
@@ -1,3 +1,0 @@
-import pytest
-
-pytestmark = pytest.mark.xdist_group("streaming")

--- a/py-polars/tests/unit/streaming/test_streaming.py
+++ b/py-polars/tests/unit/streaming/test_streaming.py
@@ -17,6 +17,8 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     from polars.type_aliases import JoinStrategy
 
+pytestmark = pytest.mark.xdist_group("streaming")
+
 
 def test_streaming_categoricals_5921() -> None:
     with pl.StringCache():

--- a/py-polars/tests/unit/streaming/test_streaming_categoricals.py
+++ b/py-polars/tests/unit/streaming/test_streaming_categoricals.py
@@ -1,4 +1,8 @@
+import pytest
+
 import polars as pl
+
+pytestmark = pytest.mark.xdist_group("streaming")
 
 
 def test_streaming_nested_categorical() -> None:

--- a/py-polars/tests/unit/streaming/test_streaming_cse.py
+++ b/py-polars/tests/unit/streaming/test_streaming_cse.py
@@ -7,6 +7,8 @@ import pytest
 import polars as pl
 from polars.testing import assert_frame_equal
 
+pytestmark = pytest.mark.xdist_group("streaming")
+
 
 def test_cse_expr_selection_streaming(monkeypatch: Any, capfd: Any) -> None:
     monkeypatch.setenv("POLARS_VERBOSE", "1")

--- a/py-polars/tests/unit/streaming/test_streaming_group_by.py
+++ b/py-polars/tests/unit/streaming/test_streaming_group_by.py
@@ -9,6 +9,8 @@ import pytest
 import polars as pl
 from polars.testing import assert_frame_equal
 
+pytestmark = pytest.mark.xdist_group("streaming")
+
 
 @pytest.mark.slow()
 def test_streaming_group_by_sorted_fast_path_nulls_10273() -> None:

--- a/py-polars/tests/unit/streaming/test_streaming_io.py
+++ b/py-polars/tests/unit/streaming/test_streaming_io.py
@@ -11,6 +11,8 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     from pathlib import Path
 
+pytestmark = pytest.mark.xdist_group("streaming")
+
 
 @pytest.mark.write_disk()
 def test_streaming_parquet_glob_5900(df: pl.DataFrame, tmp_path: Path) -> None:

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -9,6 +9,8 @@ import pytest
 import polars as pl
 from polars.testing import assert_frame_equal
 
+pytestmark = pytest.mark.xdist_group("streaming")
+
 
 def test_streaming_joins() -> None:
     n = 100

--- a/py-polars/tests/unit/streaming/test_streaming_sort.py
+++ b/py-polars/tests/unit/streaming/test_streaming_sort.py
@@ -13,6 +13,8 @@ from polars.testing import assert_frame_equal, assert_series_equal
 if TYPE_CHECKING:
     from pathlib import Path
 
+pytestmark = pytest.mark.xdist_group("streaming")
+
 
 def assert_df_sorted_by(
     df: pl.DataFrame,

--- a/py-polars/tests/unit/streaming/test_streaming_unique.py
+++ b/py-polars/tests/unit/streaming/test_streaming_unique.py
@@ -10,6 +10,8 @@ from polars.testing import assert_frame_equal
 if TYPE_CHECKING:
     from pathlib import Path
 
+pytestmark = pytest.mark.xdist_group("streaming")
+
 
 @pytest.mark.write_disk()
 @pytest.mark.slow()


### PR DESCRIPTION
Apparently using the mark in `__init__.py` was not supported.