### PR TITLE
fix(python,rust): serialize decimal type

### DIFF
--- a/crates/polars-core/src/datatypes/_serde.rs
+++ b/crates/polars-core/src/datatypes/_serde.rs
@@ -108,6 +108,8 @@ enum SerializableDataType {
     Unknown,
     #[cfg(feature = "dtype-categorical")]
     Categorical(Option<Wrap<Utf8ViewArray>>, CategoricalOrdering),
+    #[cfg(feature = "dtype-decimal")]
+    Decimal(Option<usize>, Option<usize>),
     #[cfg(feature = "object")]
     Object(String),
 }
@@ -149,6 +151,8 @@ impl From<&DataType> for SerializableDataType {
                     .unwrap_or(None);
                 Self::Categorical(categories, *ordering)
             },
+            #[cfg(feature = "dtype-decimal")]
+            Decimal(precision, scale) => Self::Decimal(precision.clone(), scale.clone()),
             #[cfg(feature = "object")]
             Object(name, _) => Self::Object(name.to_string()),
             dt => panic!("{dt:?} not supported"),
@@ -187,6 +191,8 @@ impl From<SerializableDataType> for DataType {
             Categorical(categories, ordering) => categories
                 .map(|categories| create_enum_data_type(categories.0))
                 .unwrap_or_else(|| Self::Categorical(None, ordering)),
+            #[cfg(feature = "dtype-decimal")]
+            Decimal(precision, scale) => Self::Decimal(precision, scale),
             #[cfg(feature = "object")]
             Object(_) => Self::Object("unknown", None),
         }

--- a/crates/polars-core/src/datatypes/_serde.rs
+++ b/crates/polars-core/src/datatypes/_serde.rs
@@ -152,7 +152,7 @@ impl From<&DataType> for SerializableDataType {
                 Self::Categorical(categories, *ordering)
             },
             #[cfg(feature = "dtype-decimal")]
-            Decimal(precision, scale) => Self::Decimal(precision.clone(), scale.clone()),
+            Decimal(precision, scale) => Self::Decimal(*precision, *scale),
             #[cfg(feature = "object")]
             Object(name, _) => Self::Object(name.to_string()),
             dt => panic!("{dt:?} not supported"),

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -203,3 +203,11 @@ def test_serde_array_dtype() -> None:
         dtype=pl.List(pl.Array(pl.Int32(), width=3)),
     )
     assert_series_equal(pickle.loads(pickle.dumps(nested_s)), nested_s)
+
+
+def test_expression_json_13991() -> None:
+    e = pl.col("foo").cast(pl.Decimal)
+    json = e.meta.write_json()
+
+    round_tripped = pl.Expr.from_json(json)
+    assert round_tripped.meta == e


### PR DESCRIPTION
Adds decimal to serializable dtypes

- closes https://github.com/pola-rs/polars/issues/13991