### PR TITLE
fix(rust): `arg_min/max` on categoricals should respect ordering

### DIFF
--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -18,25 +18,43 @@ impl ArgAgg for Series {
     fn arg_min(&self) -> Option<usize> {
         use DataType::*;
         let s = self.to_physical_repr();
-        match s.dtype() {
+        match self.dtype() {
+            Categorical(_, _) => {
+                let ca = self.categorical().unwrap();
+                if ca.is_empty() || ca.null_count() == ca.len() {
+                    return None;
+                }
+                if ca.uses_lexical_ordering() {
+                    ca.iter_str()
+                        .enumerate()
+                        .flat_map(|(idx, val)| val.map(|val| (idx, val)))
+                        .reduce(|acc, (idx, val)| if acc.1 > val { (idx, val) } else { acc })
+                        .map(|tpl| tpl.0)
+                } else {
+                    let ca = s.u32().unwrap();
+                    arg_min_numeric_dispatch(ca)
+                }
+            },
             String => {
-                let ca = s.str().unwrap();
+                let ca = self.str().unwrap();
                 arg_min_str(ca)
             },
             Boolean => {
-                let ca = s.bool().unwrap();
+                let ca = self.bool().unwrap();
                 arg_min_bool(ca)
+            },
+            Date => {
+                let ca = s.i32().unwrap();
+                arg_min_numeric_dispatch(ca)
+            },
+            Datetime(_, _) | Duration(_) | Time => {
+                let ca = s.i64().unwrap();
+                arg_min_numeric_dispatch(ca)
             },
             dt if dt.is_numeric() => {
                 with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
                     let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                    if ca.is_empty() || ca.null_count() == ca.len() { // because argminmax assumes not empty
-                        None
-                    } else if let Ok(vals) = ca.cont_slice() {
-                        arg_min_numeric_slice(vals, ca.is_sorted_flag())
-                    } else {
-                        arg_min_numeric(ca)
-                    }
+                    arg_min_numeric_dispatch(ca)
                 })
             },
             _ => None,
@@ -46,29 +64,74 @@ impl ArgAgg for Series {
     fn arg_max(&self) -> Option<usize> {
         use DataType::*;
         let s = self.to_physical_repr();
-        match s.dtype() {
+        match self.dtype() {
+            Categorical(_, _) => {
+                let ca = self.categorical().unwrap();
+                if ca.is_empty() || ca.null_count() == ca.len() {
+                    return None;
+                }
+                if ca.uses_lexical_ordering() {
+                    ca.iter_str()
+                        .enumerate()
+                        .reduce(|acc, (idx, val)| if acc.1 < val { (idx, val) } else { acc })
+                        .map(|tpl| tpl.0)
+                } else {
+                    let ca_phys = s.u32().unwrap();
+                    arg_max_numeric_dispatch(ca_phys)
+                }
+            },
             String => {
-                let ca = s.str().unwrap();
+                let ca = self.str().unwrap();
                 arg_max_str(ca)
             },
             Boolean => {
-                let ca = s.bool().unwrap();
+                let ca = self.bool().unwrap();
                 arg_max_bool(ca)
+            },
+            Date => {
+                let ca = s.i32().unwrap();
+                arg_max_numeric_dispatch(ca)
+            },
+            Datetime(_, _) | Duration(_) | Time => {
+                let ca = s.i64().unwrap();
+                arg_max_numeric_dispatch(ca)
             },
             dt if dt.is_numeric() => {
                 with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
                     let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                    if ca.is_empty() || ca.null_count() == ca.len(){ // because argminmax assumes not empty
-                        None
-                    } else if let Ok(vals) = ca.cont_slice() {
-                        arg_max_numeric_slice(vals, ca.is_sorted_flag())
-                    } else {
-                        arg_max_numeric(ca)
-                    }
+                    arg_max_numeric_dispatch(ca)
                 })
             },
             _ => None,
         }
+    }
+}
+
+fn arg_max_numeric_dispatch<T>(ca: &ChunkedArray<T>) -> Option<usize>
+where
+    T: PolarsNumericType,
+    for<'b> &'b [T::Native]: ArgMinMax,
+{
+    if ca.is_empty() || ca.null_count() == ca.len() {
+        None
+    } else if let Ok(vals) = ca.cont_slice() {
+        arg_max_numeric_slice(vals, ca.is_sorted_flag())
+    } else {
+        arg_max_numeric(ca)
+    }
+}
+
+fn arg_min_numeric_dispatch<T>(ca: &ChunkedArray<T>) -> Option<usize>
+where
+    T: PolarsNumericType,
+    for<'b> &'b [T::Native]: ArgMinMax,
+{
+    if ca.is_empty() || ca.null_count() == ca.len() {
+        None
+    } else if let Ok(vals) = ca.cont_slice() {
+        arg_min_numeric_slice(vals, ca.is_sorted_flag())
+    } else {
+        arg_min_numeric(ca)
     }
 }
 

--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -19,6 +19,7 @@ impl ArgAgg for Series {
         use DataType::*;
         let s = self.to_physical_repr();
         match self.dtype() {
+            #[cfg(feature = "dtype-categorical")]
             Categorical(_, _) => {
                 let ca = self.categorical().unwrap();
                 if ca.is_empty() || ca.null_count() == ca.len() {
@@ -65,6 +66,7 @@ impl ArgAgg for Series {
         use DataType::*;
         let s = self.to_physical_repr();
         match self.dtype() {
+            #[cfg(feature = "dtype-categorical")]
             Categorical(_, _) => {
                 let ca = self.categorical().unwrap();
                 if ca.is_empty() || ca.null_count() == ca.len() {

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1814,6 +1814,41 @@ def test_arg_min_and_arg_max() -> None:
     assert s.arg_min() is None
     assert s.arg_max() is None
 
+    # categorical empty series
+    s = pl.Series([], dtype=pl.Categorical)
+    assert s.arg_min() is None
+    assert s.arg_max() is None
+
+    # categorical with physical ordering no null
+    s = pl.Series(["c", "b", "a"], dtype=pl.Categorical)
+    assert s.arg_min() == 0
+    assert s.arg_max() == 2
+
+    # categorical with physical ordering has null
+    s = pl.Series([None, "c", "b", None, "a"], dtype=pl.Categorical)
+    assert s.arg_min() == 1
+    assert s.arg_max() == 4
+
+    # categorical with physical all null
+    s = pl.Series([None, None], dtype=pl.Categorical)
+    assert s.arg_min() is None
+    assert s.arg_max() is None
+
+    # categorical with lexical ordering no null
+    s = pl.Series(["c", "b", "a"], dtype=pl.Categorical(ordering="lexical"))
+    assert s.arg_min() == 2
+    assert s.arg_max() == 0
+
+    # categorical with lexical ordering has null
+    s = pl.Series([None, "c", "b", None, "a"], dtype=pl.Categorical(ordering="lexical"))
+    assert s.arg_min() == 4
+    assert s.arg_max() == 1
+
+    # categorical with lexical ordering all null
+    s = pl.Series([None, None], dtype=pl.Categorical(ordering="lexical"))
+    assert s.arg_min() is None
+    assert s.arg_max() is None
+
 
 def test_is_null_is_not_null() -> None:
     s = pl.Series("a", [1.0, 2.0, 3.0, None])


### PR DESCRIPTION
Closes #13968 