### PR TITLE
docs(python): Add missing doc entries

### DIFF
--- a/py-polars/docs/source/reference/dataframe/group_by.rst
+++ b/py-polars/docs/source/reference/dataframe/group_by.rst
@@ -16,6 +16,7 @@ This namespace is available after calling :code:`DataFrame.group_by(...)`.
     GroupBy.first
     GroupBy.head
     GroupBy.last
+    GroupBy.len
     GroupBy.map_groups
     GroupBy.max
     GroupBy.mean

--- a/py-polars/docs/source/reference/lazyframe/descriptive.rst
+++ b/py-polars/docs/source/reference/lazyframe/descriptive.rst
@@ -6,5 +6,6 @@ Descriptive
 .. autosummary::
    :toctree: api/
 
+    LazyFrame.describe
     LazyFrame.explain
     LazyFrame.show_graph

--- a/py-polars/docs/source/reference/lazyframe/group_by.rst
+++ b/py-polars/docs/source/reference/lazyframe/group_by.rst
@@ -16,6 +16,7 @@ This namespace comes available by calling `LazyFrame.group_by(..)`.
     LazyGroupBy.first
     LazyGroupBy.head
     LazyGroupBy.last
+    LazyGroupBy.len
     LazyGroupBy.map_groups
     LazyGroupBy.max
     LazyGroupBy.mean


### PR DESCRIPTION
#13999 made me realize I had forgotten to add GroupBy.len too.

Also adding `LazyFrame.describe` which was added in #13982 (@alexander-beedie adding it here as to not pollute your other PR with unrelated stuff).