### PR TITLE
join changes: broadcast left/right_on expressions  + omit left_on/right_on expressions in result

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1124,7 +1124,7 @@ impl DataFrame {
 
     /// Add a new column to this [`DataFrame`] or replace an existing one.
     pub fn with_column<S: IntoSeries>(&mut self, column: S) -> PolarsResult<&mut Self> {
-        let series = broadcast_series_to_df(column.into_series(), &self)?;
+        let series = broadcast_series_to_df(column.into_series(), self)?;
         self.add_column_by_search(series)?;
         Ok(self)
     }

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1124,7 +1124,7 @@ impl DataFrame {
 
     /// Add a new column to this [`DataFrame`] or replace an existing one.
     pub fn with_column<S: IntoSeries>(&mut self, column: S) -> PolarsResult<&mut Self> {
-        let series = correct_series_against_df(column.into_series(), &self)?;
+        let series = broadcast_series_to_df(column.into_series(), &self)?;
         self.add_column_by_search(series)?;
         Ok(self)
     }
@@ -3052,8 +3052,8 @@ fn ensure_can_extend(left: &Series, right: &Series) -> PolarsResult<()> {
     Ok(())
 }
 
-// # TODO dodgy name
-pub fn correct_series_against_df(mut series: Series, df: &DataFrame) -> PolarsResult<Series> {
+// # TODO dodgy name and bad location
+pub fn broadcast_series_to_df(mut series: Series, df: &DataFrame) -> PolarsResult<Series> {
     let height = df.height();
     if series.len() == 1 && height > 1 {
         series = series.new_from_index(0, height);

--- a/crates/polars-lazy/src/physical_plan/executors/join.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/join.rs
@@ -97,6 +97,11 @@ impl Executor for JoinExec {
                 .map(|e| e.evaluate(&df_right, state))
                 .collect::<PolarsResult<Vec<_>>>()?;
 
+            if state.verbose() {
+                eprintln!("left on series: {:?}", left_on_series);
+                eprintln!("right on series: {:?}", right_on_series);
+            };
+
             // make sure that we can join on evaluated expressions
             for s in &left_on_series {
                 df_left.with_column(s.clone())?;
@@ -104,6 +109,12 @@ impl Executor for JoinExec {
             for s in &right_on_series {
                 df_right.with_column(s.clone())?;
             }
+            if state.verbose() {
+                eprintln!("left df: {:?}", df_left);
+                eprintln!("right df: {:?}", df_right);
+            };
+
+            // TODO asof
 
             // prepare the tolerance
             // we must ensure that we use the right units

--- a/crates/polars-lazy/src/physical_plan/executors/join.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/join.rs
@@ -98,6 +98,7 @@ impl Executor for JoinExec {
                 .map(|e| e.evaluate(&df_right, state).and_then(|s| broadcast_series_to_df(s, &df_right)))
                 .collect::<PolarsResult<Vec<_>>>()?;
 
+            // TODO remove
             if state.verbose() {
                 eprintln!("left on series: {:?}", left_on_series);
                 eprintln!("right on series: {:?}", right_on_series);

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -875,6 +875,7 @@ impl LogicalPlanBuilder {
         right_on: Vec<Expr>,
         options: Arc<JoinOptions>,
     ) -> Self {
+        // TODO investigate necessity of this
         for e in left_on.iter().chain(right_on.iter()) {
             if has_expr(e, |e| matches!(e, Expr::Alias(_, _))) {
                 return LogicalPlan::Error {


### PR DESCRIPTION
Hi @ritchie46, I'm seeking early feedback on this PR

At first I was investigating #9603. The problem there is that literals (/ single value expressions) are not being broadcasted properly.

Then I was reading the code and noticed some other issues. We have disallowed aliases in join expressions (#6312), however, this still has some flaws when there are duplicate names: e.g.

```python
df1 = pl.DataFrame({
    'a': [1, 2, 3],
})

df2 = pl.DataFrame({
    'a': [2],
    'b': [4],
    'c': [6],
    'extra_col': ["foo"]
})


df1.join(
    df2,
    left_on=[
    	'a', 
    	pl.col('a') * 2,  # also named "a"
    	pl.col('a') * 3,  # also named "a'"
    ],
    right_on=['a', 'b', 'c'],
    how="left",
)
```

```
shape: (3, 2)
┌─────┬───────────┐
│ a   ┆ extra_col │
│ --- ┆ ---       │
│ i64 ┆ str       │
╞═════╪═══════════╡
│ 3   ┆ null      │
│ 6   ┆ foo       │
│ 9   ┆ null      │
└─────┴───────────┘
```
The column `a` is overridden with the last expression in left_on. I later saw similar reports in #8874, #13220

My idea for the latter problem is to *not* hstack the left_on/right_on expressions onto the dataframes before the join (as currently done). I assume these series do not need to be kept in the result, so they are dropped when the join has finished. If we do want to keep them, we could either error when there are duplicate column names, or add suffixes to columns e.g. `a_left1`, `a_left2` in the example above.

Assuming we don't keep those series, the next problem is knowing which ones to drop. Example
```python
df1 = pl.DataFrame([
    pl.Series("a", ["1", "2"], pl.String),
])

df2 = pl.DataFrame([
    pl.Series("b", ["1", "2"], pl.String),
    pl.Series("c", ["c", "c"], pl.String),
    pl.Series("d", [3, 5], pl.Int32)
])


df1.join(
    df2,
    left_on=["a", pl.lit("c")],
    right_on=["b", "c"],
    how="left",
)
```
Currently we will get the following result. Note that "c" is dropped, it seems to me that you want to keep it in this situation.
```
shape: (2, 2)
┌─────┬─────┐
│ a   ┆ d   │
│ --- ┆ --- │
│ str ┆ i32 │
╞═════╪═════╡
│ 1   ┆ 3   │
│ 2   ┆ 5   │
└─────┴─────┘
```
A sensible new condition for dropping columns in the right df could be: if the left_on/right_on expressions were already columns in the original dfs. I have added an implementation to do this for left joins in the PR so far. 

Example
```python
df1 = pl.DataFrame([
    pl.Series("a", ["1", "2"], pl.String),
    pl.Series("b", [1, 1], pl.Int32),
])

df2 = pl.DataFrame([
    pl.Series("c", ["2", "3"], pl.String),
    pl.Series("d", [2, 2], pl.Int32),
])


df1.join(
    df2,
    left_on=["a", pl.lit(2), "b", pl.lit("foo")],
    right_on=["c", "d", pl.lit(1), pl.lit("foo")],
    how="left",
)
```
```
shape: (2, 3)
┌─────┬─────┬──────┐
│ a   ┆ b   ┆ d    │
│ --- ┆ --- ┆ ---  │
│ str ┆ i32 ┆ i32  │
╞═════╪═════╪══════╡
│ 1   ┆ 1   ┆ null │
│ 2   ┆ 1   ┆ 2    │
└─────┴─────┴──────┘

eprintln: Dropping names in right df: ["c"]
```
We dropped `c` here because `a` and `c` are not calculated expressions and they already exist in the left/right dataframes. 

I hope these examples are not too confusing 😄 

Final thing, if we are not including the left_on/right_on series, do we still need to disallow aliases?

Thanks!