### PR TITLE
fix(python): omit implicit 'site' from import-timing test

### DIFF
--- a/py-polars/tests/unit/test_polars_import.py
+++ b/py-polars/tests/unit/test_polars_import.py
@@ -27,7 +27,7 @@ def _import_time_from_frame(tm: pl.DataFrame) -> int:
 def _import_timings() -> bytes:
     # assemble suitable command to get polars module import timing;
     # run in a separate process to ensure clean timing results.
-    cmd = f'{sys.executable} -X importtime -c "import polars"'
+    cmd = f'{sys.executable} -S -X importtime -c "import polars"'
     return (
         subprocess.run(cmd, shell=True, capture_output=True)
         .stderr.replace(b"import time:", b"")


### PR DESCRIPTION
This _may_ help further reduce noise... 🤔
See: https://docs.python.org/3/using/cmdline.html#cmdoption-S