### PR TITLE
chore: make Enums an actual datatype

### DIFF
--- a/crates/polars-core/src/chunked_array/builder/list/categorical.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/categorical.rs
@@ -10,14 +10,6 @@ pub fn create_categorical_chunked_listbuilder(
     rev_map: Arc<RevMapping>,
 ) -> Box<dyn ListBuilderTrait> {
     match &*rev_map {
-        RevMapping::Enum(_, h) => Box::new(ListEnumCategoricalChunkedBuilder::new(
-            name,
-            ordering,
-            capacity,
-            values_capacity,
-            (*rev_map).clone(),
-            *h,
-        )),
         RevMapping::Local(_, h) => Box::new(ListLocalCategoricalChunkedBuilder::new(
             name,
             ordering,
@@ -35,11 +27,10 @@ pub fn create_categorical_chunked_listbuilder(
     }
 }
 
-struct ListEnumCategoricalChunkedBuilder {
+pub struct ListEnumCategoricalChunkedBuilder {
     inner: ListPrimitiveChunkedBuilder<UInt32Type>,
     ordering: CategoricalOrdering,
     rev_map: RevMapping,
-    hash: u128,
 }
 
 impl ListEnumCategoricalChunkedBuilder {
@@ -49,7 +40,6 @@ impl ListEnumCategoricalChunkedBuilder {
         capacity: usize,
         values_capacity: usize,
         rev_map: RevMapping,
-        hash: u128,
     ) -> Self {
         Self {
             inner: ListPrimitiveChunkedBuilder::new(
@@ -60,20 +50,16 @@ impl ListEnumCategoricalChunkedBuilder {
             ),
             ordering,
             rev_map,
-            hash,
         }
     }
 }
 
 impl ListBuilderTrait for ListEnumCategoricalChunkedBuilder {
     fn append_series(&mut self, s: &Series) -> PolarsResult<()> {
-        let DataType::Categorical(Some(rev_map), _) = s.dtype() else {
-            polars_bail!(ComputeError: "expected categorical type")
+        let DataType::Enum(Some(rev_map), _) = s.dtype() else {
+            polars_bail!(ComputeError: "expected enum type")
         };
-        let RevMapping::Enum(_, new_hash) = &**rev_map else {
-            polars_bail!(ComputeError: "Can not combine enum with categorical, consider casting to one of the two")
-        };
-        polars_ensure!(*new_hash == self.hash,ComputeError: "Can not combine enums with different variants");
+        polars_ensure!(rev_map.same_src(&self.rev_map),ComputeError: "incompatible enum types");
         self.inner.append_series(s)
     }
 
@@ -82,8 +68,7 @@ impl ListBuilderTrait for ListEnumCategoricalChunkedBuilder {
     }
 
     fn finish(&mut self) -> ListChunked {
-        let inner_dtype =
-            DataType::Categorical(Some(Arc::new(self.rev_map.clone())), self.ordering);
+        let inner_dtype = DataType::Enum(Some(Arc::new(self.rev_map.clone())), self.ordering);
         let mut ca = self.inner.finish();
         unsafe { ca.set_dtype(DataType::List(Box::new(inner_dtype))) }
         ca

--- a/crates/polars-core/src/chunked_array/builder/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/mod.rs
@@ -104,6 +104,17 @@ pub fn get_list_builder(
                 rev_map.clone(),
             ))
         },
+        #[cfg(feature = "dtype-categorical")]
+        DataType::Enum(Some(rev_map), ordering) => {
+            let list_builder = ListEnumCategoricalChunkedBuilder::new(
+                name,
+                *ordering,
+                list_capacity,
+                value_capacity,
+                (**rev_map).clone(),
+            );
+            return Ok(Box::new(list_builder));
+        },
         _ => {},
     }
 

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -144,13 +144,13 @@ where
                 let ca = unsafe { &*(self as *const ChunkedArray<T> as *const UInt32Chunked) };
                 // SAFETY indices are in bound
                 unsafe {
-                    return Ok(CategoricalChunked::from_cats_and_rev_map_unchecked(
+                    Ok(CategoricalChunked::from_cats_and_rev_map_unchecked(
                         ca.clone(),
                         rev_map.clone(),
                         true,
                         *ordering,
                     )
-                    .into_series());
+                    .into_series())
                 }
             },
             #[cfg(feature = "dtype-struct")]

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -463,7 +463,7 @@ impl ChunkCast for ArrayChunked {
                 match (self.inner_dtype(), &**child_type) {
                     #[cfg(feature = "dtype-categorical")]
                     (dt, Categorical(None, _) | Enum(_, _)) if !matches!(dt, String) => {
-                        polars_bail!(ComputeError: "cannot cast fixed-size-list inner type: '{:?}' to Categorical", dt)
+                        polars_bail!(ComputeError: "cannot cast fixed-size-list inner type: '{:?}' to dtype: {:?}", dt, child_type)
                     },
                     _ => {
                         // ensure the inner logical type bubbles up

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -100,41 +100,7 @@ where
         }
         match data_type {
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(rev_map, ordering) => {
-                if let Some(rev_map) = rev_map {
-                    if let RevMapping::Enum(categories, _) = &**rev_map {
-                        let ca = match self.dtype() {
-                            DataType::UInt32 => {
-                                // SAFETY: we are guarded by the type system
-                                unsafe {
-                                    &*(self as *const ChunkedArray<T> as *const UInt32Chunked)
-                                }
-                                .clone()
-                            },
-                            dt if dt.is_integer() => self.cast(&DataType::UInt32)?.u32()?.clone(),
-                            _ => {
-                                polars_bail!(ComputeError: "cannot cast non integer types to 'Categorical'")
-                            },
-                        };
-
-                        // Check if indices are in bounds
-                        if let Some(m) = ca.max() {
-                            if m >= categories.len() as u32 {
-                                polars_bail!(OutOfBounds: "index {} is bigger than the number of categories {}",m,categories.len());
-                            }
-                        }
-
-                        // SAFETY indices are in bound
-                        unsafe {
-                            return Ok(CategoricalChunked::from_cats_and_rev_map_unchecked(
-                                ca,
-                                rev_map.clone(),
-                                *ordering,
-                            )
-                            .into_series());
-                        }
-                    }
-                }
+            DataType::Categorical(_, ordering) => {
                 polars_ensure!(
                     self.dtype() == &DataType::UInt32,
                     ComputeError: "cannot cast numeric types to 'Categorical'"
@@ -145,6 +111,43 @@ where
 
                 CategoricalChunked::from_global_indices(ca.clone(), *ordering)
                     .map(|ca| ca.into_series())
+            },
+            #[cfg(feature = "dtype-categorical")]
+            DataType::Enum(rev_map, ordering) => {
+                let ca = match self.dtype() {
+                    DataType::UInt32 => {
+                        // SAFETY: we are guarded by the type system
+                        unsafe { &*(self as *const ChunkedArray<T> as *const UInt32Chunked) }
+                            .clone()
+                    },
+                    dt if dt.is_integer() => self.cast(&DataType::UInt32)?.u32()?.clone(),
+                    _ => {
+                        polars_bail!(ComputeError: "cannot cast non integer types to 'Categorical'")
+                    },
+                };
+                let Some(rev_map) = rev_map else {
+                    polars_bail!(ComputeError: "cannot cast to enum without categories");
+                };
+                let categories = rev_map.get_categories();
+                // Check if indices are in bounds
+                if let Some(m) = ca.max() {
+                    if m >= categories.len() as u32 {
+                        polars_bail!(OutOfBounds: "index {} is bigger than the number of categories {}",m,categories.len());
+                    }
+                }
+                // SAFETY
+                // we are guarded by the type system
+                let ca = unsafe { &*(self as *const ChunkedArray<T> as *const UInt32Chunked) };
+                // SAFETY indices are in bound
+                unsafe {
+                    return Ok(CategoricalChunked::from_cats_and_rev_map_unchecked(
+                        ca.clone(),
+                        rev_map.clone(),
+                        true,
+                        *ordering,
+                    )
+                    .into_series());
+                }
             },
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(fields) => cast_single_to_struct(self.name(), &self.chunks, fields),
@@ -185,7 +188,8 @@ where
     unsafe fn cast_unchecked(&self, data_type: &DataType) -> PolarsResult<Series> {
         match data_type {
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(Some(rev_map), ordering) => {
+            DataType::Categorical(Some(rev_map), ordering)
+            | DataType::Enum(Some(rev_map), ordering) => {
                 if self.dtype() == &DataType::UInt32 {
                     // safety:
                     // we are guarded by the type system.
@@ -194,6 +198,7 @@ where
                         CategoricalChunked::from_cats_and_rev_map_unchecked(
                             ca.clone(),
                             rev_map.clone(),
+                            matches!(data_type, DataType::Enum(_, _)),
                             *ordering,
                         )
                     }
@@ -221,19 +226,21 @@ impl ChunkCast for StringChunked {
                     let ca = builder.drain_iter_and_finish(iter);
                     Ok(ca.into_series())
                 },
-                Some(rev_map) => {
-                    polars_ensure!(rev_map.is_enum(), InvalidOperation: "casting to a non-enum variant with rev map is not supported for the user");
-                    CategoricalChunked::from_string_to_enum(
-                        self,
-                        rev_map.get_categories(),
-                        *ordering,
-                    )
+                Some(_) => {
+                    polars_bail!(InvalidOperation: "casting to a categorical with rev map is not allowed");
+                },
+            },
+            #[cfg(feature = "dtype-categorical")]
+            DataType::Enum(rev_map, ordering) => {
+                let Some(rev_map) = rev_map else {
+                    polars_bail!(ComputeError: "can not cast / initialize Enum without categories present")
+                };
+                CategoricalChunked::from_string_to_enum(self, rev_map.get_categories(), *ordering)
                     .map(|ca| {
                         let mut s = ca.into_series();
                         s.rename(self.name());
                         s
                     })
-                },
             },
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(fields) => cast_single_to_struct(self.name(), &self.chunks, fields),
@@ -387,8 +394,8 @@ impl ChunkCast for ListChunked {
             List(child_type) => {
                 match (self.inner_dtype(), &**child_type) {
                     #[cfg(feature = "dtype-categorical")]
-                    (dt, Categorical(None, _))
-                        if !matches!(dt, Categorical(_, _) | String | Null) =>
+                    (dt, Categorical(None, _) | Enum(_, _))
+                        if !matches!(dt, Categorical(_, _) | Enum(_, _) | String | Null) =>
                     {
                         polars_bail!(ComputeError: "cannot cast List inner type: '{:?}' to Categorical", dt)
                     },
@@ -451,7 +458,7 @@ impl ChunkCast for ArrayChunked {
             Array(child_type, width) => {
                 match (self.inner_dtype(), &**child_type) {
                     #[cfg(feature = "dtype-categorical")]
-                    (dt, Categorical(None, _)) if !matches!(dt, String) => {
+                    (dt, Categorical(None, _) | Enum(_, _)) if !matches!(dt, String) => {
                         polars_bail!(ComputeError: "cannot cast fixed-size-list inner type: '{:?}' to Categorical", dt)
                     },
                     _ => {

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -120,13 +120,17 @@ where
                         unsafe { &*(self as *const ChunkedArray<T> as *const UInt32Chunked) }
                             .clone()
                     },
-                    dt if dt.is_integer() => self.cast(&DataType::UInt32)?.u32()?.clone(),
+                    dt if dt.is_integer() => self
+                        .cast(self.dtype())?
+                        .strict_cast(&DataType::UInt32)?
+                        .u32()?
+                        .clone(),
                     _ => {
-                        polars_bail!(ComputeError: "cannot cast non integer types to 'Categorical'")
+                        polars_bail!(ComputeError: "cannot cast non integer types to 'Enum'")
                     },
                 };
                 let Some(rev_map) = rev_map else {
-                    polars_bail!(ComputeError: "cannot cast to enum without categories");
+                    polars_bail!(ComputeError: "cannot cast to Enum without categories");
                 };
                 let categories = rev_map.get_categories();
                 // Check if indices are in bounds

--- a/crates/polars-core/src/chunked_array/comparison/categorical.rs
+++ b/crates/polars-core/src/chunked_array/comparison/categorical.rs
@@ -44,7 +44,7 @@ where
     let rev_map_r = rhs.get_rev_map();
     polars_ensure!(rev_map_l.same_src(rev_map_r), ComputeError: "can only compare categoricals of the same type with the same categories");
 
-    if rev_map_l.is_enum() || !lhs.uses_lexical_ordering() {
+    if lhs.is_enum() || !lhs.uses_lexical_ordering() {
         Ok(compare_function(lhs.physical(), rhs.physical()))
     } else {
         match (lhs.len(), rhs.len()) {
@@ -167,8 +167,7 @@ where
     CompareCat: Fn(&CategoricalChunked, &CategoricalChunked) -> PolarsResult<BooleanChunked>,
     CompareString: Fn(&StringChunked, &'a StringChunked) -> BooleanChunked,
 {
-    let rev_map = lhs.get_rev_map();
-    if rev_map.is_enum() {
+    if lhs.is_enum() {
         let rhs_cat = rhs.cast(lhs.dtype())?;
         cat_compare_function(lhs, rhs_cat.categorical().unwrap())
     } else if rhs.len() == 1 {
@@ -198,8 +197,7 @@ where
     CompareCat: Fn(&CategoricalChunked, &CategoricalChunked) -> PolarsResult<BooleanChunked>,
     CompareString: Fn(&StringChunked, &'a StringChunked) -> BooleanChunked,
 {
-    let rev_map = lhs.get_rev_map();
-    if rev_map.is_enum() {
+    if lhs.is_enum() {
         let rhs_cat = rhs.cast(lhs.dtype())?;
         cat_compare_function(lhs, rhs_cat.categorical().unwrap())
     } else if rhs.len() == 1 {
@@ -324,7 +322,7 @@ where
 {
     let rev_map = lhs.get_rev_map();
     let idx = rev_map.find(rhs);
-    if rev_map.is_enum() {
+    if lhs.is_enum() {
         let Some(idx) = idx else {
             polars_bail!(
                 not_in_enum,
@@ -352,7 +350,7 @@ where
     ComparePhys: Fn(&UInt32Chunked, u32) -> BooleanChunked,
 {
     let rev_map = lhs.get_rev_map();
-    if rev_map.is_enum() {
+    if lhs.is_enum() {
         match rev_map.find(rhs) {
             None => {
                 polars_bail!(

--- a/crates/polars-core/src/chunked_array/from.rs
+++ b/crates/polars-core/src/chunked_array/from.rs
@@ -16,7 +16,12 @@ fn from_chunks_list_dtype(chunks: &mut Vec<ArrayRef>, dtype: DataType) -> DataTy
         // arrow dictionaries are not nested as dictionaries, but only by their keys, so we must
         // change the list-value array to the keys and store the dictionary values in the datatype.
         // if a global string cache is set, we also must modify the keys.
-        DataType::List(inner) if matches!(*inner, DataType::Categorical(None, _)) => {
+        DataType::List(inner)
+            if matches!(
+                *inner,
+                DataType::Categorical(None, _) | DataType::Enum(None, _)
+            ) =>
+        {
             let array = concatenate_owned_unchecked(chunks).unwrap();
             let list_arr = array.as_any().downcast_ref::<ListArray<i64>>().unwrap();
             let values_arr = list_arr.values();
@@ -43,7 +48,12 @@ fn from_chunks_list_dtype(chunks: &mut Vec<ArrayRef>, dtype: DataType) -> DataTy
             DataType::List(Box::new(cat.dtype().clone()))
         },
         #[cfg(all(feature = "dtype-array", feature = "dtype-categorical"))]
-        DataType::Array(inner, width) if matches!(*inner, DataType::Categorical(None, _)) => {
+        DataType::Array(inner, width)
+            if matches!(
+                *inner,
+                DataType::Categorical(None, _) | DataType::Enum(None, _)
+            ) =>
+        {
             let array = concatenate_owned_unchecked(chunks).unwrap();
             let list_arr = array.as_any().downcast_ref::<FixedSizeListArray>().unwrap();
             let values_arr = list_arr.values();

--- a/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -165,6 +165,7 @@ impl CategoricalChunkedBuilder {
             CategoricalChunked::from_cats_and_rev_map_unchecked(
                 indices,
                 Arc::new(RevMapping::Global(global_to_local, categories, id)),
+                false,
                 self.ordering,
             )
         }
@@ -253,7 +254,12 @@ impl CategoricalChunked {
 
         let rev_map = RevMapping::Global(rev_map, str_values.into(), cache.uuid);
 
-        CategoricalChunked::from_cats_and_rev_map_unchecked(cats, Arc::new(rev_map), ordering)
+        CategoricalChunked::from_cats_and_rev_map_unchecked(
+            cats,
+            Arc::new(rev_map),
+            false,
+            ordering,
+        )
     }
 
     pub(crate) unsafe fn from_keys_and_values_global(
@@ -296,6 +302,7 @@ impl CategoricalChunked {
             CategoricalChunked::from_cats_and_rev_map_unchecked(
                 UInt32Chunked::with_chunk(name, cats.into()),
                 Arc::new(RevMapping::Global(global_to_local, values.clone(), id)),
+                false,
                 ordering,
             )
         }
@@ -310,6 +317,7 @@ impl CategoricalChunked {
         CategoricalChunked::from_cats_and_rev_map_unchecked(
             UInt32Chunked::with_chunk(name, keys.clone()),
             Arc::new(RevMapping::build_local(values.clone())),
+            false,
             ordering,
         )
     }
@@ -364,11 +372,12 @@ impl CategoricalChunked {
             })
             .collect::<Result<UInt32Chunked, PolarsError>>()?;
         keys.rename(values.name());
-        let rev_map = RevMapping::build_enum(categories.clone());
+        let rev_map = RevMapping::build_local(categories.clone());
         unsafe {
             Ok(CategoricalChunked::from_cats_and_rev_map_unchecked(
                 keys,
                 Arc::new(rev_map),
+                true,
                 ordering,
             ))
         }

--- a/crates/polars-core/src/chunked_array/logical/categorical/from.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/from.rs
@@ -32,7 +32,7 @@ impl CategoricalChunked {
         let map = &**self.get_rev_map();
         let dtype = ArrowDataType::Dictionary(IntegerType::UInt32, Box::new(values_dtype), false);
         match map {
-            RevMapping::Local(arr, _) | RevMapping::Enum(arr, _) => {
+            RevMapping::Local(arr, _) => {
                 let values = convert_values(arr, pl_flavor);
 
                 // Safety:
@@ -65,7 +65,7 @@ impl CategoricalChunked {
         let map = &**self.get_rev_map();
         let dtype = ArrowDataType::Dictionary(IntegerType::Int64, Box::new(values_dtype), false);
         match map {
-            RevMapping::Local(arr, _) | RevMapping::Enum(arr, _) => {
+            RevMapping::Local(arr, _) => {
                 let values = convert_values(arr, pl_flavor);
 
                 // Safety:

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -241,7 +241,7 @@ impl CategoricalChunked {
         ordering: CategoricalOrdering,
         keep_fast_unique: bool,
     ) -> Self {
-        let new_dtype = match self.dtype() {
+        self.physical.2 = match self.dtype() {
             DataType::Enum(_, _) => {
                 Some(DataType::Enum(Some(self.get_rev_map().clone()), ordering))
             },
@@ -252,8 +252,6 @@ impl CategoricalChunked {
             _ => panic!("implementation error"),
         };
 
-        self.physical.2 = new_dtype;
-
         if !keep_fast_unique {
             self.set_fast_unique(false)
         }
@@ -263,15 +261,13 @@ impl CategoricalChunked {
     /// # Safety
     /// The existing index values must be in bounds of the new [`RevMapping`].
     pub(crate) unsafe fn set_rev_map(&mut self, rev_map: Arc<RevMapping>, keep_fast_unique: bool) {
-        match self.dtype() {
-            DataType::Enum(_, _) => {
-                self.physical.2 = Some(DataType::Enum(Some(rev_map), self.get_ordering()));
-            },
+        self.physical.2 = match self.dtype() {
+            DataType::Enum(_, _) => Some(DataType::Enum(Some(rev_map), self.get_ordering())),
             DataType::Categorical(_, _) => {
-                self.physical.2 = Some(DataType::Categorical(Some(rev_map), self.get_ordering()));
+                Some(DataType::Categorical(Some(rev_map), self.get_ordering()))
             },
             _ => panic!("implementation error"),
-        }
+        };
 
         if !keep_fast_unique {
             self.set_fast_unique(false)

--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/full.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/full.rs
@@ -1,13 +1,14 @@
 use super::*;
 
 impl CategoricalChunked {
-    pub fn full_null(name: &str, length: usize) -> CategoricalChunked {
+    pub fn full_null(name: &str, is_enum: bool, length: usize) -> CategoricalChunked {
         let cats = UInt32Chunked::full_null(name, length);
 
         unsafe {
             CategoricalChunked::from_cats_and_rev_map_unchecked(
                 cats,
                 Arc::new(RevMapping::default()),
+                is_enum,
                 Default::default(),
             )
         }

--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
@@ -6,7 +6,7 @@ impl CategoricalChunked {
         let cat_map = self.get_rev_map();
         if self.can_fast_unique() {
             let ca = match &**cat_map {
-                RevMapping::Local(a, _) | RevMapping::Enum(a, _) => {
+                RevMapping::Local(a, _) => {
                     UInt32Chunked::from_iter_values(self.physical().name(), 0..(a.len() as u32))
                 },
                 RevMapping::Global(map, _, _) => {
@@ -19,6 +19,7 @@ impl CategoricalChunked {
                 let mut out = CategoricalChunked::from_cats_and_rev_map_unchecked(
                     ca,
                     cat_map.clone(),
+                    self.is_enum(),
                     self.get_ordering(),
                 );
                 out.set_fast_unique(true);
@@ -32,6 +33,7 @@ impl CategoricalChunked {
                 Ok(CategoricalChunked::from_cats_and_rev_map_unchecked(
                     ca,
                     cat_map.clone(),
+                    self.is_enum(),
                     self.get_ordering(),
                 ))
             }

--- a/crates/polars-core/src/chunked_array/ops/compare_inner.rs
+++ b/crates/polars-core/src/chunked_array/ops/compare_inner.rs
@@ -159,7 +159,6 @@ impl<'a> IntoTotalOrdInner<'a> for &'a CategoricalChunked {
         match &**self.get_rev_map() {
             RevMapping::Global(p1, p2, _) => Box::new(GlobalCategorical { p1, p2, cats }),
             RevMapping::Local(rev_map, _) => Box::new(LocalCategorical { rev_map, cats }),
-            RevMapping::Enum(rev_map, _) => Box::new(LocalCategorical { rev_map, cats }),
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -69,7 +69,7 @@ pub fn _get_rows_encoded_compat_array(by: &Series) -> PolarsResult<ArrayRef> {
 
     let out = match by.dtype() {
         #[cfg(feature = "dtype-categorical")]
-        DataType::Categorical(_, _) => {
+        DataType::Categorical(_, _) | DataType::Enum(_, _) => {
             let ca = by.categorical().unwrap();
             if ca.uses_lexical_ordering() {
                 by.to_arrow(0, true)

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -32,6 +32,7 @@ impl CategoricalChunked {
                 CategoricalChunked::from_cats_and_rev_map_unchecked(
                     cats,
                     self.get_rev_map().clone(),
+                    self.is_enum(),
                     self.get_ordering(),
                 )
             };
@@ -43,6 +44,7 @@ impl CategoricalChunked {
             CategoricalChunked::from_cats_and_rev_map_unchecked(
                 cats,
                 self.get_rev_map().clone(),
+                self.is_enum(),
                 self.get_ordering(),
             )
         }

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -617,7 +617,7 @@ pub(crate) fn convert_sort_column_multi_sort(s: &Series) -> PolarsResult<Series>
     use DataType::*;
     let out = match s.dtype() {
         #[cfg(feature = "dtype-categorical")]
-        Categorical(_, _) => s.rechunk(),
+        Categorical(_, _) | Enum(_, _) => s.rechunk(),
         Binary | Boolean => s.clone(),
         String => s.cast(&Binary).unwrap(),
         #[cfg(feature = "dtype-struct")]

--- a/crates/polars-core/src/datatypes/_serde.rs
+++ b/crates/polars-core/src/datatypes/_serde.rs
@@ -191,7 +191,7 @@ impl From<SerializableDataType> for DataType {
             #[cfg(feature = "dtype-categorical")]
             Categorical(_, ordering) => Self::Categorical(None, ordering),
             #[cfg(feature = "dtype-categorical")]
-            Enum(Some(categories), ordering) => create_enum_data_type(categories.0),
+            Enum(Some(categories), _) => create_enum_data_type(categories.0),
             #[cfg(feature = "dtype-categorical")]
             Enum(None, ordering) => Self::Enum(None, ordering),
             #[cfg(feature = "dtype-decimal")]

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -73,6 +73,8 @@ pub enum AnyValue<'a> {
     // If syncptr is_null the data is in the rev-map
     // otherwise it is in the array pointer
     Categorical(u32, &'a RevMapping, SyncPtr<Utf8ViewArray>),
+    #[cfg(feature = "dtype-categorical")]
+    Enum(u32, &'a RevMapping, SyncPtr<Utf8ViewArray>),
     /// Nested type, contains arrays that are filled with one of the datatypes.
     List(Series),
     #[cfg(feature = "dtype-array")]
@@ -366,6 +368,8 @@ impl<'a> AnyValue<'a> {
             String(_) => DataType::String,
             #[cfg(feature = "dtype-categorical")]
             Categorical(_, _, _) => DataType::Categorical(None, Default::default()),
+            #[cfg(feature = "dtype-categorical")]
+            Enum(_, _, _) => DataType::Enum(None, Default::default()),
             List(s) => DataType::List(Box::new(s.dtype().clone())),
             #[cfg(feature = "dtype-struct")]
             Struct(_, _, fields) => DataType::Struct(fields.to_vec()),
@@ -650,7 +654,7 @@ impl AnyValue<'_> {
             #[cfg(feature = "dtype-time")]
             Time(v) => v.hash(state),
             #[cfg(feature = "dtype-categorical")]
-            Categorical(v, _, _) => v.hash(state),
+            Categorical(v, _, _) | Enum(v, _, _) => v.hash(state),
             #[cfg(feature = "object")]
             Object(_) => {},
             #[cfg(feature = "object")]
@@ -818,7 +822,7 @@ impl<'a> AnyValue<'a> {
             AnyValue::String(s) => Some(s),
             AnyValue::StringOwned(s) => Some(s),
             #[cfg(feature = "dtype-categorical")]
-            AnyValue::Categorical(idx, rev, arr) => {
+            AnyValue::Categorical(idx, rev, arr) | AnyValue::Enum(idx, rev, arr) => {
                 let s = if arr.is_null() {
                     rev.get(*idx)
                 } else {
@@ -898,6 +902,8 @@ impl AnyValue<'_> {
                 },
                 _ => false,
             },
+            #[cfg(feature = "dtype-categorical")]
+            (Enum(idx_l, _, _), Enum(idx_r, _, _)) => idx_l == idx_r,
             #[cfg(feature = "dtype-duration")]
             (Duration(l, tu_l), Duration(r, tu_r)) => l == r && tu_l == tu_r,
             #[cfg(feature = "dtype-struct")]

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -556,3 +556,9 @@ pub(crate) fn can_extend_dtype(left: &DataType, right: &DataType) -> PolarsResul
         },
     }
 }
+
+#[cfg(feature = "dtype-categorical")]
+pub fn create_enum_data_type(categories: Utf8ViewArray) -> DataType {
+    let rev_map = RevMapping::build_local(categories);
+    DataType::Enum(Some(Arc::new(rev_map)), Default::default())
+}

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -302,16 +302,10 @@ impl DataType {
     pub fn to_arrow_field(&self, name: &str, pl_flavor: bool) -> ArrowField {
         let metadata = match self {
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(Some(rev_map), _) => {
-                if rev_map.is_enum() {
-                    Some(BTreeMap::from([(
-                        DTYPE_ENUM_KEY.into(),
-                        DTYPE_ENUM_VALUE.into(),
-                    )]))
-                } else {
-                    None
-                }
-            },
+            DataType::Enum(_, _) => Some(BTreeMap::from([(
+                DTYPE_ENUM_KEY.into(),
+                DTYPE_ENUM_VALUE.into(),
+            )])),
             DataType::BinaryOffset => Some(BTreeMap::from([(
                 "pl".to_string(),
                 "maintain_type".to_string(),

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -335,20 +335,18 @@ impl Debug for Series {
             #[cfg(feature = "object")]
             DataType::Object(_, None) => format_object_array(f, self, self.name(), "Series"),
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(rev_map, _) => {
-                if let Some(rev_map) = rev_map {
-                    if rev_map.is_enum() {
-                        return format_array!(
-                            f,
-                            self.categorical().unwrap(),
-                            "enum",
-                            self.name(),
-                            "Series"
-                        );
-                    }
-                }
+            DataType::Categorical(_, _) => {
                 format_array!(f, self.categorical().unwrap(), "cat", self.name(), "Series")
             },
+
+            #[cfg(feature = "dtype-categorical")]
+            DataType::Enum(_, _) => format_array!(
+                f,
+                self.categorical().unwrap(),
+                "enum",
+                self.name(),
+                "Series"
+            ),
             #[cfg(feature = "dtype-struct")]
             dt @ DataType::Struct(_) => format_array!(
                 f,
@@ -1036,7 +1034,7 @@ impl Display for AnyValue<'_> {
                 write!(f, "{nt}")
             },
             #[cfg(feature = "dtype-categorical")]
-            AnyValue::Categorical(_, _, _) => {
+            AnyValue::Categorical(_, _, _) | AnyValue::Enum(_, _, _) => {
                 let s = self.get_str().unwrap();
                 write!(f, "\"{s}\"")
             },

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -32,7 +32,9 @@ fn prepare_dataframe_unsorted(by: &[Series]) -> DataFrame {
         by.iter()
             .map(|s| match s.dtype() {
                 #[cfg(feature = "dtype-categorical")]
-                DataType::Categorical(_, _) => s.cast(&DataType::UInt32).unwrap(),
+                DataType::Categorical(_, _) | DataType::Enum(_, _) => {
+                    s.cast(&DataType::UInt32).unwrap()
+                },
                 _ => {
                     if s.dtype().to_physical().is_numeric() {
                         let s = s.to_physical_repr();

--- a/crates/polars-core/src/frame/group_by/perfect.rs
+++ b/crates/polars-core/src/frame/group_by/perfect.rs
@@ -190,16 +190,14 @@ where
 impl CategoricalChunked {
     // Use the indexes as perfect groups
     pub fn group_tuples_perfect(&self, multithreaded: bool, sorted: bool) -> GroupsProxy {
-        let DataType::Categorical(Some(rev_map), _) = self.dtype() else {
-            unreachable!()
-        };
+        let rev_map = self.get_rev_map();
         if self.is_empty() {
             return GroupsProxy::Idx(GroupsIdx::new(vec![], vec![], true));
         }
         let cats = self.physical();
 
         let mut out = match &**rev_map {
-            RevMapping::Local(cached, _) | RevMapping::Enum(cached, _) => {
+            RevMapping::Local(cached, _) => {
                 if self.can_fast_unique() {
                     if verbose() {
                         eprintln!("grouping categoricals, run perfect hash function");

--- a/crates/polars-core/src/frame/row/transpose.rs
+++ b/crates/polars-core/src/frame/row/transpose.rs
@@ -119,11 +119,13 @@ impl DataFrame {
         let dtype = df.get_supertype().unwrap()?;
         match dtype {
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, _) => {
+            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
                 let mut valid = true;
                 let mut rev_map: Option<&Arc<RevMapping>> = None;
                 for s in self.columns.iter() {
-                    if let DataType::Categorical(Some(col_rev_map), _) = &s.dtype() {
+                    if let DataType::Categorical(Some(col_rev_map), _)
+                    | DataType::Enum(Some(col_rev_map), _) = &s.dtype()
+                    {
                         match rev_map {
                             Some(rev_map) => valid = valid && rev_map.same_src(col_rev_map),
                             None => {

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -56,7 +56,7 @@ impl Serialize for Series {
                 ca.serialize(serializer)
             },
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, _) => {
+            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
                 let ca = self.categorical().unwrap();
                 ca.serialize(serializer)
             },
@@ -260,10 +260,8 @@ impl<'de> Deserialize<'de> for Series {
                         Ok(s)
                     },
                     #[cfg(feature = "dtype-categorical")]
-                    DataType::Categorical(opt_rev_map, ordering) => {
+                    dt @ DataType::Categorical(_, _) | dt @ DataType::Enum(_, _) => {
                         let values: Vec<Option<Cow<str>>> = map.next_value()?;
-                        let dt = enum_or_default_categorical(&opt_rev_map, ordering);
-
                         Ok(Series::new(&name, values).cast(&dt).unwrap())
                     },
                     dt => {

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -260,7 +260,7 @@ impl<'de> Deserialize<'de> for Series {
                         Ok(s)
                     },
                     #[cfg(feature = "dtype-categorical")]
-                    dt @ DataType::Categorical(_, _) | dt @ DataType::Enum(_, _) => {
+                    dt @ (DataType::Categorical(_, _) | DataType::Enum(_, _)) => {
                         let values: Vec<Option<Cow<str>>> = map.next_value()?;
                         Ok(Series::new(&name, values).cast(&dt).unwrap())
                     },

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -425,7 +425,7 @@ impl Series {
             },
             DataType::Null => Series::full_null(name, av.len(), &DataType::Null),
             #[cfg(feature = "dtype-categorical")]
-            dt @ DataType::Categorical(_, _) | dt @ DataType::Enum(_, _) => {
+            dt @ (DataType::Categorical(_, _) | DataType::Enum(_, _)) => {
                 let ca = if let Some(single_av) = av.first() {
                     match single_av {
                         AnyValue::String(_) | AnyValue::StringOwned(_) | AnyValue::Null => {

--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -17,21 +17,21 @@ macro_rules! impl_compare {
 
         #[cfg(feature = "dtype-categorical")]
         match (lhs.dtype(), rhs.dtype()) {
-            (Categorical(_, _), Categorical(_, _)) => {
+            (Categorical(_, _) | Enum(_, _), Categorical(_, _) | Enum(_, _)) => {
                 return Ok(lhs
                     .categorical()
                     .unwrap()
                     .$method(rhs.categorical().unwrap())?
                     .with_name(lhs.name()));
             },
-            (Categorical(_, _), String) => {
+            (Categorical(_, _) | Enum(_, _), String) => {
                 return Ok(lhs
                     .categorical()
                     .unwrap()
                     .$method(rhs.str().unwrap())?
                     .with_name(lhs.name()));
             },
-            (String, Categorical(_, _)) => {
+            (String, Categorical(_, _) | Enum(_, _)) => {
                 return Ok(rhs
                     .categorical()
                     .unwrap()
@@ -78,8 +78,9 @@ fn validate_types(left: &DataType, right: &DataType) -> PolarsResult<()> {
     use DataType::*;
     #[cfg(feature = "dtype-categorical")]
     {
-        let mismatch = matches!(left, String | Categorical(_, _)) && right.is_numeric()
-            || left.is_numeric() && matches!(right, String | Categorical(_, _));
+        let mismatch = matches!(left, String | Categorical(_, _) | Enum(_, _))
+            && right.is_numeric()
+            || left.is_numeric() && matches!(right, String | Categorical(_, _) | Enum(_, _));
         polars_ensure!(!mismatch, ComputeError: "cannot compare string with numeric data");
     }
     #[cfg(not(feature = "dtype-categorical"))]
@@ -218,7 +219,9 @@ impl ChunkCompare<&str> for Series {
         match self.dtype() {
             DataType::String => Ok(self.str().unwrap().equal(rhs)),
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, _) => self.categorical().unwrap().equal(rhs),
+            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
+                self.categorical().unwrap().equal(rhs)
+            },
             _ => Ok(BooleanChunked::full(self.name(), false, self.len())),
         }
     }
@@ -228,7 +231,9 @@ impl ChunkCompare<&str> for Series {
         match self.dtype() {
             DataType::String => Ok(self.str().unwrap().equal_missing(rhs)),
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, _) => self.categorical().unwrap().equal_missing(rhs),
+            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
+                self.categorical().unwrap().equal_missing(rhs)
+            },
             _ => Ok(replace_non_null(self.name(), self.0.chunks(), false)),
         }
     }
@@ -238,7 +243,9 @@ impl ChunkCompare<&str> for Series {
         match self.dtype() {
             DataType::String => Ok(self.str().unwrap().not_equal(rhs)),
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, _) => self.categorical().unwrap().not_equal(rhs),
+            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
+                self.categorical().unwrap().not_equal(rhs)
+            },
             _ => Ok(BooleanChunked::full(self.name(), true, self.len())),
         }
     }
@@ -248,7 +255,9 @@ impl ChunkCompare<&str> for Series {
         match self.dtype() {
             DataType::String => Ok(self.str().unwrap().not_equal_missing(rhs)),
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, _) => self.categorical().unwrap().not_equal_missing(rhs),
+            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
+                self.categorical().unwrap().not_equal_missing(rhs)
+            },
             _ => Ok(replace_non_null(self.name(), self.0.chunks(), true)),
         }
     }
@@ -258,7 +267,9 @@ impl ChunkCompare<&str> for Series {
         match self.dtype() {
             DataType::String => Ok(self.str().unwrap().gt(rhs)),
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, _) => self.categorical().unwrap().gt(rhs),
+            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
+                self.categorical().unwrap().gt(rhs)
+            },
             _ => polars_bail!(
                 ComputeError: "cannot compare str value to series of type {}", self.dtype(),
             ),
@@ -270,7 +281,9 @@ impl ChunkCompare<&str> for Series {
         match self.dtype() {
             DataType::String => Ok(self.str().unwrap().gt_eq(rhs)),
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, _) => self.categorical().unwrap().gt_eq(rhs),
+            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
+                self.categorical().unwrap().gt_eq(rhs)
+            },
             _ => polars_bail!(
                 ComputeError: "cannot compare str value to series of type {}", self.dtype(),
             ),
@@ -282,7 +295,9 @@ impl ChunkCompare<&str> for Series {
         match self.dtype() {
             DataType::String => Ok(self.str().unwrap().lt(rhs)),
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, _) => self.categorical().unwrap().lt(rhs),
+            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
+                self.categorical().unwrap().lt(rhs)
+            },
             _ => polars_bail!(
                 ComputeError: "cannot compare str value to series of type {}", self.dtype(),
             ),
@@ -294,7 +309,9 @@ impl ChunkCompare<&str> for Series {
         match self.dtype() {
             DataType::String => Ok(self.str().unwrap().lt_eq(rhs)),
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, _) => self.categorical().unwrap().lt_eq(rhs),
+            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
+                self.categorical().unwrap().lt_eq(rhs)
+            },
             _ => polars_bail!(
                 ComputeError: "cannot compare str value to series of type {}", self.dtype(),
             ),

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -347,7 +347,8 @@ impl Series {
                         // the invariants of an Arrow Dictionary guarantee the keys are in bounds
                         return Ok(CategoricalChunked::from_cats_and_rev_map_unchecked(
                             UInt32Chunked::with_chunk(name, keys.clone()),
-                            Arc::new(RevMapping::build_enum(values.clone())),
+                            Arc::new(RevMapping::build_local(values.clone())),
+                            true,
                             Default::default(),
                         )
                         .into_series());

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -87,7 +87,7 @@ impl Series {
             String => StringChunked::from_chunks(name, chunks).into_series(),
             Binary => BinaryChunked::from_chunks(name, chunks).into_series(),
             #[cfg(feature = "dtype-categorical")]
-            dt @ Categorical(rev_map, ordering) | dt @ Enum(rev_map, ordering) => {
+            dt @ (Categorical(rev_map, ordering) | Enum(rev_map, ordering)) => {
                 let cats = UInt32Chunked::from_chunks(name, chunks);
                 let mut ca = CategoricalChunked::from_cats_and_rev_map_unchecked(
                     cats,

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -87,11 +87,12 @@ impl Series {
             String => StringChunked::from_chunks(name, chunks).into_series(),
             Binary => BinaryChunked::from_chunks(name, chunks).into_series(),
             #[cfg(feature = "dtype-categorical")]
-            Categorical(rev_map, ordering) => {
+            dt @ Categorical(rev_map, ordering) | dt @ Enum(rev_map, ordering) => {
                 let cats = UInt32Chunked::from_chunks(name, chunks);
                 let mut ca = CategoricalChunked::from_cats_and_rev_map_unchecked(
                     cats,
                     rev_map.clone().unwrap(),
+                    matches!(dt, Enum(_, _)),
                     *ordering,
                 );
                 ca.set_fast_unique(false);

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -22,7 +22,7 @@ impl SeriesWrap<CategoricalChunked> {
             CategoricalChunked::from_cats_and_rev_map_unchecked(
                 cats,
                 self.0.get_rev_map().clone(),
-                matches!(self.dtype(), DataType::Enum(_, _)),
+                self.0.is_enum(),
                 self.0.get_ordering(),
             )
         };

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -22,6 +22,7 @@ impl SeriesWrap<CategoricalChunked> {
             CategoricalChunked::from_cats_and_rev_map_unchecked(
                 cats,
                 self.0.get_rev_map().clone(),
+                matches!(self.dtype(), DataType::Enum(_, _)),
                 self.0.get_ordering(),
             )
         };

--- a/crates/polars-core/src/series/into.rs
+++ b/crates/polars-core/src/series/into.rs
@@ -58,7 +58,7 @@ impl Series {
                 Box::new(arr)
             },
             #[cfg(feature = "dtype-categorical")]
-            dt @ DataType::Categorical(_, ordering) | dt @ DataType::Enum(_, ordering) => {
+            dt @ (DataType::Categorical(_, ordering) | DataType::Enum(_, ordering)) => {
                 let ca = self.categorical().unwrap();
                 let arr = ca.physical().chunks()[chunk_idx].clone();
                 // SAFETY: categoricals are always u32's.

--- a/crates/polars-core/src/series/into.rs
+++ b/crates/polars-core/src/series/into.rs
@@ -58,7 +58,7 @@ impl Series {
                 Box::new(arr)
             },
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(_, ordering) => {
+            dt @ DataType::Categorical(_, ordering) | dt @ DataType::Enum(_, ordering) => {
                 let ca = self.categorical().unwrap();
                 let arr = ca.physical().chunks()[chunk_idx].clone();
                 // SAFETY: categoricals are always u32's.
@@ -69,6 +69,7 @@ impl Series {
                     CategoricalChunked::from_cats_and_rev_map_unchecked(
                         cats,
                         ca.get_rev_map().clone(),
+                        matches!(dt, DataType::Enum(_, _)),
                         *ordering,
                     )
                 };

--- a/crates/polars-core/src/series/ops/downcast.rs
+++ b/crates/polars-core/src/series/ops/downcast.rs
@@ -143,14 +143,7 @@ impl Series {
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Categorical]`
     #[cfg(feature = "dtype-categorical")]
     pub fn categorical(&self) -> PolarsResult<&CategoricalChunked> {
-        match self.dtype() {
-            DataType::Categorical(_, _) | DataType::Enum(_, _) => unsafe {
-                Ok(&*(self.as_ref() as *const dyn SeriesTrait as *const CategoricalChunked))
-            },
-            dt => polars_bail!(
-                SchemaMismatch: "invalid series dtype: expected `Categorical` or `Enum`, got `{}`", dt,
-            ),
-        }
+        unpack_chunked!(self, DataType::Categorical(_, _) | DataType::Enum(_, _) => CategoricalChunked, "Enum | Categorical")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Struct]`

--- a/crates/polars-core/src/series/ops/null.rs
+++ b/crates/polars-core/src/series/ops/null.rs
@@ -12,8 +12,9 @@ impl Series {
                 ArrayChunked::full_null_with_dtype(name, size, inner_dtype, *width).into_series()
             },
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(rev_map, _) => {
-                let mut ca = CategoricalChunked::full_null(name, size);
+            dt @ DataType::Categorical(rev_map, _) | dt @ DataType::Enum(rev_map, _) => {
+                let mut ca =
+                    CategoricalChunked::full_null(name, matches!(dt, DataType::Enum(_, _)), size);
                 // ensure we keep the rev-map of a cleared series
                 if let Some(rev_map) = rev_map {
                     unsafe { ca.set_rev_map(rev_map.clone(), false) }

--- a/crates/polars-core/src/series/ops/null.rs
+++ b/crates/polars-core/src/series/ops/null.rs
@@ -12,7 +12,7 @@ impl Series {
                 ArrayChunked::full_null_with_dtype(name, size, inner_dtype, *width).into_series()
             },
             #[cfg(feature = "dtype-categorical")]
-            dt @ DataType::Categorical(rev_map, _) | dt @ DataType::Enum(rev_map, _) => {
+            dt @ (DataType::Categorical(rev_map, _) | DataType::Enum(rev_map, _)) => {
                 let mut ca =
                     CategoricalChunked::full_null(name, matches!(dt, DataType::Enum(_, _)), size);
                 // ensure we keep the rev-map of a cleared series

--- a/crates/polars-io/src/csv/buffer.rs
+++ b/crates/polars-io/src/csv/buffer.rs
@@ -448,12 +448,9 @@ pub(crate) fn init_buffers(
                 &DataType::UInt64 => Buffer::UInt64(PrimitiveChunkedBuilder::new(name, capacity)),
                 &DataType::Float32 => Buffer::Float32(PrimitiveChunkedBuilder::new(name, capacity)),
                 &DataType::Float64 => Buffer::Float64(PrimitiveChunkedBuilder::new(name, capacity)),
-                &DataType::String => Buffer::Utf8(Utf8Field::new(
-                    name,
-                    capacity,
-                    quote_char,
-                    encoding,
-                )),
+                &DataType::String => {
+                    Buffer::Utf8(Utf8Field::new(name, capacity, quote_char, encoding))
+                },
                 #[cfg(feature = "dtype-datetime")]
                 DataType::Datetime(time_unit, time_zone) => Buffer::Datetime {
                     buf: DatetimeField::new(name, capacity),
@@ -463,13 +460,10 @@ pub(crate) fn init_buffers(
                 #[cfg(feature = "dtype-date")]
                 &DataType::Date => Buffer::Date(DatetimeField::new(name, capacity)),
                 #[cfg(feature = "dtype-categorical")]
-                DataType::Categorical(rev_map,ordering) => {
-                    if let Some(rev_map) = &rev_map {
-                        polars_ensure!(!rev_map.is_enum(),InvalidOperation: "user defined categoricals are not supported when reading csv")
-                    }
-
-                    Buffer::Categorical(CategoricalField::new(name, capacity, quote_char,*ordering))
-                },
+                DataType::Categorical(_, ordering) => Buffer::Categorical(CategoricalField::new(
+                    name, capacity, quote_char, *ordering,
+                )),
+                // TODO (ENUM) support writing to Enum
                 dt => polars_bail!(
                     ComputeError: "unsupported data type when reading CSV: {} when reading CSV", dt,
                 ),

--- a/crates/polars-io/src/csv/write_impl.rs
+++ b/crates/polars-io/src/csv/write_impl.rs
@@ -80,7 +80,7 @@ unsafe fn write_anyvalue(
             Ok(())
         },
         #[cfg(feature = "dtype-categorical")]
-        AnyValue::Categorical(idx, rev_map, _) => {
+        AnyValue::Categorical(idx, rev_map, _) | AnyValue::Enum(idx, rev_map, _) => {
             let v = rev_map.get(idx);
             fmt_and_escape_str(f, v, options)?;
             Ok(())

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -149,7 +149,7 @@ pub trait ListNameSpaceExtension: IntoListNameSpace + Sized {
                 match e {
                     #[cfg(feature = "dtype-categorical")]
                     Expr::Cast {
-                        data_type: DataType::Categorical(_, _),
+                        data_type: DataType::Categorical(_, _) | DataType::Enum(_, _),
                         ..
                     } => {
                         polars_bail!(

--- a/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
@@ -187,7 +187,9 @@ fn can_run_partitioned(
 
         let (unique_estimate, sampled_method) = match (keys.len(), keys[0].dtype()) {
             #[cfg(feature = "dtype-categorical")]
-            (1, DataType::Categorical(Some(rev_map), _)) => (rev_map.len(), "known"),
+            (1, DataType::Categorical(Some(rev_map), _) | DataType::Enum(Some(rev_map), _)) => {
+                (rev_map.len(), "known")
+            },
             _ => {
                 // sqrt(N) is a good sample size as it remains low on large numbers
                 // it is better than taking a fraction as it saturates

--- a/crates/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -389,9 +389,9 @@ mod stats {
             {
                 match (fld_l.data_type(), fld_r.data_type()) {
                     #[cfg(feature = "dtype-categorical")]
-                    (DataType::String, DataType::Categorical(_, _)) => {},
+                    (DataType::String, DataType::Categorical(_, _) | DataType::Enum(_, _)) => {},
                     #[cfg(feature = "dtype-categorical")]
-                    (DataType::Categorical(_, _), DataType::String) => {},
+                    (DataType::Categorical(_, _) | DataType::Enum(_, _), DataType::String) => {},
                     (l, r) if l != r => panic!("implementation error: {l:?}, {r:?}"),
                     _ => {},
                 }

--- a/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/sortby.rs
@@ -191,7 +191,7 @@ impl PhysicalExpr for SortByExpr {
                     .map(|e| {
                         e.evaluate(df, state).map(|s| match s.dtype() {
                             #[cfg(feature = "dtype-categorical")]
-                            DataType::Categorical(_, _) => s,
+                            DataType::Categorical(_, _) | DataType::Enum(_, _) => s,
                             _ => s.to_physical_repr().into_owned(),
                         })
                     })
@@ -239,7 +239,7 @@ impl PhysicalExpr for SortByExpr {
                 let s = s.flat_naive();
                 match s.dtype() {
                     #[cfg(feature = "dtype-categorical")]
-                    DataType::Categorical(_, _) => s.into_owned(),
+                    DataType::Categorical(_, _) | DataType::Enum(_, _) => s.into_owned(),
                     _ => s.to_physical_repr().into_owned(),
                 }
             })

--- a/crates/polars-ops/src/chunked_array/interpolate.rs
+++ b/crates/polars-ops/src/chunked_array/interpolate.rs
@@ -144,7 +144,7 @@ where
 fn interpolate_nearest(s: &Series) -> Series {
     match s.dtype() {
         #[cfg(feature = "dtype-categorical")]
-        DataType::Categorical(_, _) => s.clone(),
+        DataType::Categorical(_, _) | DataType::Enum(_, _) => s.clone(),
         DataType::Binary => s.clone(),
         #[cfg(feature = "dtype-struct")]
         DataType::Struct(_) => s.clone(),
@@ -167,7 +167,7 @@ fn interpolate_nearest(s: &Series) -> Series {
 fn interpolate_linear(s: &Series) -> Series {
     match s.dtype() {
         #[cfg(feature = "dtype-categorical")]
-        DataType::Categorical(_, _) => s.clone(),
+        DataType::Categorical(_, _) | DataType::Enum(_, _) => s.clone(),
         DataType::Binary => s.clone(),
         #[cfg(feature = "dtype-struct")]
         DataType::Struct(_) => s.clone(),

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -509,14 +509,20 @@ pub trait ListNameSpaceImpl: AsList {
                 DataType::List(inner_type) => {
                     inner_super_type = try_get_supertype(&inner_super_type, inner_type)?;
                     #[cfg(feature = "dtype-categorical")]
-                    if let DataType::Categorical(_, _) = &inner_super_type {
+                    if matches!(
+                        &inner_super_type,
+                        DataType::Categorical(_, _) | DataType::Enum(_, _)
+                    ) {
                         inner_super_type = merge_dtypes(&inner_super_type, inner_type)?;
                     }
                 },
                 dt => {
                     inner_super_type = try_get_supertype(&inner_super_type, dt)?;
                     #[cfg(feature = "dtype-categorical")]
-                    if let DataType::Categorical(_, _) = &inner_super_type {
+                    if matches!(
+                        &inner_super_type,
+                        DataType::Categorical(_, _) | DataType::Enum(_, _)
+                    ) {
                         inner_super_type = merge_dtypes(&inner_super_type, dt)?;
                     }
                 },

--- a/crates/polars-ops/src/frame/join/checks.rs
+++ b/crates/polars-ops/src/frame/join/checks.rs
@@ -3,8 +3,16 @@ use super::*;
 /// If Categorical types are created without a global string cache or under
 /// a different global string cache the mapping will be incorrect.
 pub(crate) fn _check_categorical_src(l: &DataType, r: &DataType) -> PolarsResult<()> {
-    if let (DataType::Categorical(Some(l), _), DataType::Categorical(Some(r), _)) = (l, r) {
-        polars_ensure!(l.same_src(r), string_cache_mismatch);
-    }
+    match (l, r) {
+        (DataType::Categorical(Some(l), _), DataType::Categorical(Some(r), _))
+        | (DataType::Enum(Some(l), _), DataType::Enum(Some(r), _)) => {
+            polars_ensure!(l.same_src(r), string_cache_mismatch);
+        },
+        (DataType::Categorical(_, _), DataType::Enum(_, _))
+        | (DataType::Enum(_, _), DataType::Categorical(_, _)) => {
+            polars_bail!(ComputeError: "enum and categorical are not from the same source")
+        },
+        _ => (),
+    };
     Ok(())
 }

--- a/crates/polars-ops/src/frame/pivot/mod.rs
+++ b/crates/polars-ops/src/frame/pivot/mod.rs
@@ -27,7 +27,8 @@ fn restore_logical_type(s: &Series, logical_type: &DataType) -> Series {
     // restore logical type
     match (logical_type, s.dtype()) {
         #[cfg(feature = "dtype-categorical")]
-        (DataType::Categorical(Some(rev_map), ordering), _) => {
+        (dt @ DataType::Categorical(Some(rev_map), ordering), _)
+        | (dt @ DataType::Enum(Some(rev_map), ordering), _) => {
             let cats = s.u32().unwrap().clone();
             // safety:
             // the rev-map comes from these categoricals
@@ -35,6 +36,7 @@ fn restore_logical_type(s: &Series, logical_type: &DataType) -> Series {
                 CategoricalChunked::from_cats_and_rev_map_unchecked(
                     cats,
                     rev_map.clone(),
+                    matches!(dt, DataType::Enum(_, _)),
                     *ordering,
                 )
                 .into_series()

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -195,19 +195,25 @@ fn is_in_string_inner_categorical(
 fn is_in_string(ca_in: &StringChunked, other: &Series) -> PolarsResult<BooleanChunked> {
     match other.dtype() {
         #[cfg(feature = "dtype-categorical")]
-        DataType::List(dt) if matches!(&**dt, DataType::Categorical(_, _)) => {
-            if let DataType::Categorical(Some(rev_map), _) = &**dt {
-                is_in_string_inner_categorical(ca_in, other, rev_map)
-            } else {
-                unreachable!()
+        DataType::List(dt)
+            if matches!(&**dt, DataType::Categorical(_, _) | DataType::Enum(_, _)) =>
+        {
+            match &**dt {
+                DataType::Enum(Some(rev_map), _) | DataType::Categorical(Some(rev_map), _) => {
+                    is_in_string_inner_categorical(ca_in, other, rev_map)
+                },
+                _ => unreachable!(),
             }
         },
         #[cfg(all(feature = "dtype-categorical", feature = "dtype-array"))]
-        DataType::Array(dt, _) if matches!(&**dt, DataType::Categorical(_, _)) => {
-            if let DataType::Categorical(Some(rev_map), _) = &**dt {
-                is_in_string_inner_categorical(ca_in, other, rev_map)
-            } else {
-                unreachable!()
+        DataType::Array(dt, _)
+            if matches!(&**dt, DataType::Categorical(_, _) | DataType::Enum(_, _)) =>
+        {
+            match &**dt {
+                DataType::Enum(Some(rev_map), _) | DataType::Categorical(Some(rev_map), _) => {
+                    is_in_string_inner_categorical(ca_in, other, rev_map)
+                },
+                _ => unreachable!(),
             }
         },
         DataType::List(dt) if DataType::String == **dt => is_in_binary(
@@ -553,7 +559,7 @@ fn is_in_struct(ca_in: &StructChunked, other: &Series) -> PolarsResult<BooleanCh
 #[cfg(feature = "dtype-categorical")]
 fn is_in_cat(ca_in: &CategoricalChunked, other: &Series) -> PolarsResult<BooleanChunked> {
     match other.dtype() {
-        DataType::Categorical(_, _) => {
+        DataType::Categorical(_, _) | DataType::Enum(_, _) => {
             let (ca_in, other_in) =
                 make_categoricals_compatible(ca_in, other.categorical().unwrap())?;
             is_in_helper_ca(ca_in.physical(), other_in.physical())
@@ -578,7 +584,7 @@ fn is_in_cat(ca_in: &CategoricalChunked, other: &Series) -> PolarsResult<Boolean
                         }
                     }
                 },
-                RevMapping::Local(categories, _) | RevMapping::Enum(categories, _) => {
+                RevMapping::Local(categories, _) => {
                     categories
                         .values_iter()
                         .enumerate_idx()
@@ -604,7 +610,7 @@ fn is_in_cat(ca_in: &CategoricalChunked, other: &Series) -> PolarsResult<Boolean
 pub fn is_in(s: &Series, other: &Series) -> PolarsResult<BooleanChunked> {
     match s.dtype() {
         #[cfg(feature = "dtype-categorical")]
-        DataType::Categorical(_, _) => {
+        DataType::Categorical(_, _) | DataType::Enum(_, _) => {
             let ca = s.categorical().unwrap();
             is_in_cat(ca, other)
         },

--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -42,8 +42,8 @@ pub fn replace(
 
     let old = match (s.dtype(), old.dtype()) {
         #[cfg(feature = "dtype-categorical")]
-        (DataType::Categorical(opt_rev_map, ord), DataType::String) => {
-            let dt = enum_or_default_categorical(opt_rev_map, *ord);
+        (DataType::Categorical(_, ord), DataType::String) => {
+            let dt = DataType::Categorical(None, *ord);
             old.strict_cast(&dt)?
         },
         _ => old.strict_cast(s.dtype())?,

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/convert.rs
@@ -177,7 +177,10 @@ where
                 let logical_dtype = phys_expr.field(schema).unwrap().dtype;
 
                 #[cfg(feature = "dtype-categorical")]
-                if matches!(logical_dtype, DataType::Categorical(_, _)) {
+                if matches!(
+                    logical_dtype,
+                    DataType::Categorical(_, _) | DataType::Enum(_, _)
+                ) {
                     return (
                         logical_dtype.clone(),
                         phys_expr,
@@ -215,7 +218,10 @@ where
 
                 let logical_dtype = phys_expr.field(schema).unwrap().dtype;
                 #[cfg(feature = "dtype-categorical")]
-                if matches!(logical_dtype, DataType::Categorical(_, _)) {
+                if matches!(
+                    logical_dtype,
+                    DataType::Categorical(_, _) | DataType::Enum(_, _)
+                ) {
                     return (
                         logical_dtype.clone(),
                         phys_expr,

--- a/crates/polars-pipe/src/executors/sinks/group_by/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/mod.rs
@@ -20,8 +20,7 @@ pub(super) fn physical_agg_to_logical(cols: &mut [Series], output_schema: &Schem
         }
         match dtype {
             #[cfg(feature = "dtype-categorical")]
-            dt @ DataType::Categorical(rev_map, ordering)
-            | dt @ DataType::Enum(rev_map, ordering) => {
+            dt @ (DataType::Categorical(rev_map, ordering) | DataType::Enum(rev_map, ordering)) => {
                 if let Some(rev_map) = rev_map {
                     let cats = s.u32().unwrap().clone();
                     // safety:

--- a/crates/polars-pipe/src/executors/sinks/group_by/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/mod.rs
@@ -20,7 +20,8 @@ pub(super) fn physical_agg_to_logical(cols: &mut [Series], output_schema: &Schem
         }
         match dtype {
             #[cfg(feature = "dtype-categorical")]
-            DataType::Categorical(rev_map, ordering) => {
+            dt @ DataType::Categorical(rev_map, ordering)
+            | dt @ DataType::Enum(rev_map, ordering) => {
                 if let Some(rev_map) = rev_map {
                     let cats = s.u32().unwrap().clone();
                     // safety:
@@ -29,6 +30,7 @@ pub(super) fn physical_agg_to_logical(cols: &mut [Series], output_schema: &Schem
                         *s = CategoricalChunked::from_cats_and_rev_map_unchecked(
                             cats,
                             rev_map.clone(),
+                            matches!(dt, DataType::Enum(_, _)),
                             *ordering,
                         )
                         .into_series()

--- a/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
@@ -32,7 +32,7 @@ fn sort_column_can_be_decoded(schema: &Schema, sort_idx: &[usize]) -> bool {
     !sort_idx.iter().any(|i| {
         matches!(
             schema.get_at_index(*i).unwrap().1,
-            DataType::Categorical(_, _)
+            DataType::Categorical(_, _) | DataType::Enum(_, _)
         )
     })
 }

--- a/crates/polars-plan/src/dsl/function_expr/shift_and_fill.rs
+++ b/crates/polars-plan/src/dsl/function_expr/shift_and_fill.rs
@@ -93,7 +93,7 @@ pub(super) fn shift_and_fill(args: &[Series]) -> PolarsResult<Series> {
             #[cfg(feature = "dtype-struct")]
             Struct(_) => shift_and_fill_with_mask(s, n, fill_value_s),
             #[cfg(feature = "dtype-categorical")]
-            Categorical(_, _) => shift_and_fill_with_mask(s, n, fill_value_s),
+            Categorical(_, _) | Enum(_, _) => shift_and_fill_with_mask(s, n, fill_value_s),
             dt if dt.is_numeric() || dt.is_logical() => {
                 macro_rules! dispatch {
                     ($ca:expr, $n:expr, $fill_value:expr) => {{

--- a/crates/polars-plan/src/logical_plan/lit.rs
+++ b/crates/polars-plan/src/logical_plan/lit.rs
@@ -201,7 +201,7 @@ impl TryFrom<AnyValue<'_>> for LiteralValue {
             AnyValue::List(l) => Ok(Self::Series(SpecialEq::new(l))),
             AnyValue::StringOwned(o) => Ok(Self::String(o.into())),
             #[cfg(feature = "dtype-categorical")]
-            AnyValue::Categorical(c, rev_mapping, arr) => {
+            AnyValue::Categorical(c, rev_mapping, arr) | AnyValue::Enum(c, rev_mapping, arr) => {
                 if arr.is_null() {
                     Ok(Self::String(rev_mapping.get(c).to_string()))
                 } else {

--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -552,6 +552,8 @@ fn inline_cast(input: &AExpr, dtype: &DataType, strict: bool) -> PolarsResult<Op
                     (AnyValue::Categorical(_, _, _), _) | (_, DataType::Categorical(_, _)) => {
                         return Ok(None)
                     },
+                    #[cfg(feature = "dtype-categorical")]
+                    (AnyValue::Enum(_, _, _), _) | (_, DataType::Enum(_, _)) => return Ok(None),
                     #[cfg(feature = "dtype-struct")]
                     (_, DataType::Struct(_)) => return Ok(None),
                     (av, _) => {

--- a/crates/polars-plan/src/logical_plan/optimizer/type_coercion/binary.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/type_coercion/binary.rs
@@ -20,7 +20,7 @@ fn compares_cat_to_string(type_left: &DataType, type_right: &DataType, op: Opera
                 type_left,
                 type_right,
                 DataType::String,
-                DataType::Categorical(_, _)
+                DataType::Categorical(_, _) | DataType::Enum(_, _)
             )
     }
     #[cfg(not(feature = "dtype-categorical"))]
@@ -64,7 +64,7 @@ fn is_cat_str_binary(type_left: &DataType, type_right: &DataType) -> bool {
             type_left,
             type_right,
             DataType::String,
-            DataType::Categorical(_, _)
+            DataType::Categorical(_, _) | DataType::Enum(_, _)
         )
     }
     #[cfg(not(feature = "dtype-categorical"))]
@@ -224,6 +224,12 @@ pub(super) fn process_binary(
         },
         #[cfg(feature = "dtype-categorical")]
         (String | Categorical(_, _), dt, op) | (dt, String | Categorical(_, _), op)
+            if op.is_comparison() && dt.is_numeric() =>
+        {
+            return Ok(None)
+        },
+        #[cfg(feature = "dtype-categorical")]
+        (String | Enum(_, _), dt, op) | (dt, String | Enum(_, _), op)
             if op.is_comparison() && dt.is_numeric() =>
         {
             return Ok(None)

--- a/py-polars/src/conversion/anyvalue.rs
+++ b/py-polars/src/conversion/anyvalue.rs
@@ -30,7 +30,7 @@ impl IntoPy<PyObject> for Wrap<AnyValue<'_>> {
             AnyValue::Boolean(v) => v.into_py(py),
             AnyValue::String(v) => v.into_py(py),
             AnyValue::StringOwned(v) => v.into_py(py),
-            AnyValue::Categorical(idx, rev, arr) => {
+            AnyValue::Categorical(idx, rev, arr) | AnyValue::Enum(idx, rev, arr) => {
                 let s = if arr.is_null() {
                     rev.get(idx)
                 } else {

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -251,7 +251,7 @@ impl ToPyObject for Wrap<DataType> {
             },
             DataType::Enum(rev_map, _) => {
                 // we should always have an initialized rev_map coming from rust
-                let categories = rev_map.unwrap().get_categories();
+                let categories = rev_map.as_ref().unwrap().get_categories();
                 let class = pl.getattr(intern!(py, "Enum")).unwrap();
                 let s = Series::from_arrow("category", categories.to_boxed()).unwrap();
                 let series = to_series(py, s.into());

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -242,20 +242,23 @@ impl ToPyObject for Wrap<DataType> {
                 let class = pl.getattr(intern!(py, "Object")).unwrap();
                 class.call0().unwrap().into()
             },
-            DataType::Categorical(rev_map, ordering) => {
-                if let Some(rev_map) = rev_map {
-                    if let RevMapping::Enum(categories, _) = &**rev_map {
-                        let class = pl.getattr(intern!(py, "Enum")).unwrap();
-                        let s = Series::from_arrow("category", categories.to_boxed()).unwrap();
-                        let series = to_series(py, s.into());
-                        return class.call1((series,)).unwrap().into();
-                    }
-                }
+            DataType::Categorical(_, ordering) => {
                 let class = pl.getattr(intern!(py, "Categorical")).unwrap();
                 class
                     .call1((Wrap(*ordering).to_object(py),))
                     .unwrap()
                     .into()
+            },
+            DataType::Enum(Some(rev_map), _) => {
+                let categories = rev_map.get_categories();
+                let class = pl.getattr(intern!(py, "Enum")).unwrap();
+                let s = Series::from_arrow("category", categories.to_boxed()).unwrap();
+                let series = to_series(py, s.into());
+                return class.call1((series,)).unwrap().into();
+            },
+            DataType::Enum(None, _) => {
+                // TODO
+                todo!();
             },
             DataType::Time => pl.getattr(intern!(py, "Time")).unwrap().into(),
             DataType::Struct(fields) => {
@@ -317,11 +320,7 @@ impl FromPyObject<'_> for Wrap<DataType> {
                     "Binary" => DataType::Binary,
                     "Boolean" => DataType::Boolean,
                     "Categorical" => DataType::Categorical(None, Default::default()),
-                    "Enum" => {
-                        return Err(PyTypeError::new_err(
-                            "Enum types must be instantiated with a list of categories",
-                        ))
-                    },
+                    "Enum" => DataType::Enum(None, Default::default()),
                     "Date" => DataType::Date,
                     "Datetime" => DataType::Datetime(TimeUnit::Microseconds, None),
                     "Time" => DataType::Time,
@@ -363,8 +362,11 @@ impl FromPyObject<'_> for Wrap<DataType> {
                 let categories = ob.getattr(intern!(py, "categories")).unwrap();
                 let s = get_series(categories)?;
                 let ca = s.str().map_err(PyPolarsErr::from)?;
-                let categories = ca.downcast_iter().next().unwrap();
-                create_enum_data_type(categories.clone())
+                let categories = ca.downcast_iter().next().unwrap().clone();
+                DataType::Enum(
+                    Some(Arc::new(RevMapping::build_local(categories))),
+                    Default::default(),
+                )
             },
             "Date" => DataType::Date,
             "Time" => DataType::Time,

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -883,7 +883,12 @@ impl PyDataFrame {
                 .get_columns()
                 .iter()
                 .enumerate()
-                .filter(|(_i, s)| matches!(s.dtype(), DataType::Categorical(_, _)))
+                .filter(|(_i, s)| {
+                    matches!(
+                        s.dtype(),
+                        DataType::Categorical(_, _) | DataType::Enum(_, _)
+                    )
+                })
                 .map(|(i, _)| i)
                 .collect::<Vec<_>>();
 

--- a/py-polars/src/datatypes.rs
+++ b/py-polars/src/datatypes.rs
@@ -63,9 +63,7 @@ impl From<&DataType> for PyDataType {
             #[cfg(feature = "object")]
             DataType::Object(_, _) => Object,
             DataType::Categorical(_, _) => Categorical,
-            DataType::Enum(Some(rev_map), _) => Enum(rev_map.get_categories().clone()),
-            // TODO: Allow this
-            DataType::Enum(None, _) => Enum(Utf8ViewArray::new_empty(ArrowDataType::LargeUtf8)),
+            DataType::Enum(rev_map, _) => Enum(rev_map.unwrap().get_categories().clone()),
             DataType::Struct(_) => Struct,
             DataType::Null | DataType::Unknown | DataType::BinaryOffset => {
                 panic!("null or unknown not expected here")
@@ -105,10 +103,7 @@ impl From<PyDataType> for DataType {
             #[cfg(feature = "object")]
             PyDataType::Object => Object(OBJECT_NAME, None),
             PyDataType::Categorical => Categorical(None, Default::default()),
-            PyDataType::Enum(categories) => Enum(
-                Some(Arc::new(RevMapping::build_local(categories))),
-                Default::default(),
-            ),
+            PyDataType::Enum(categories) => create_enum_data_type(categories),
             PyDataType::Struct => Struct(vec![]),
             PyDataType::Decimal(p, s) => Decimal(p, Some(s)),
             PyDataType::Array(width) => Array(DataType::Null.into(), width),

--- a/py-polars/src/datatypes.rs
+++ b/py-polars/src/datatypes.rs
@@ -63,7 +63,7 @@ impl From<&DataType> for PyDataType {
             #[cfg(feature = "object")]
             DataType::Object(_, _) => Object,
             DataType::Categorical(_, _) => Categorical,
-            DataType::Enum(rev_map, _) => Enum(rev_map.unwrap().get_categories().clone()),
+            DataType::Enum(rev_map, _) => Enum(rev_map.as_ref().unwrap().get_categories().clone()),
             DataType::Struct(_) => Struct,
             DataType::Null | DataType::Unknown | DataType::BinaryOffset => {
                 panic!("null or unknown not expected here")

--- a/py-polars/src/datatypes.rs
+++ b/py-polars/src/datatypes.rs
@@ -62,16 +62,10 @@ impl From<&DataType> for PyDataType {
             DataType::Time => Time,
             #[cfg(feature = "object")]
             DataType::Object(_, _) => Object,
-            DataType::Categorical(rev_map, _) => rev_map.as_ref().map_or_else(
-                || Categorical,
-                |rev_map| {
-                    if let RevMapping::Enum(categories, _) = &**rev_map {
-                        Enum(categories.clone())
-                    } else {
-                        Categorical
-                    }
-                },
-            ),
+            DataType::Categorical(_, _) => Categorical,
+            DataType::Enum(Some(rev_map), _) => Enum(rev_map.get_categories().clone()),
+            // TODO: Allow this
+            DataType::Enum(None, _) => Enum(Utf8ViewArray::new_empty(ArrowDataType::LargeUtf8)),
             DataType::Struct(_) => Struct,
             DataType::Null | DataType::Unknown | DataType::BinaryOffset => {
                 panic!("null or unknown not expected here")
@@ -111,7 +105,10 @@ impl From<PyDataType> for DataType {
             #[cfg(feature = "object")]
             PyDataType::Object => Object(OBJECT_NAME, None),
             PyDataType::Categorical => Categorical(None, Default::default()),
-            PyDataType::Enum(categories) => create_enum_data_type(categories),
+            PyDataType::Enum(categories) => Enum(
+                Some(Arc::new(RevMapping::build_local(categories))),
+                Default::default(),
+            ),
             PyDataType::Struct => Struct(vec![]),
             PyDataType::Decimal(p, s) => Decimal(p, Some(s)),
             PyDataType::Array(width) => Array(DataType::Null.into(), width),

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -100,7 +100,7 @@ impl PySeries {
                     DataType::Int64 => PyList::new(py, series.i64().unwrap()),
                     DataType::Float32 => PyList::new(py, series.f32().unwrap()),
                     DataType::Float64 => PyList::new(py, series.f64().unwrap()),
-                    DataType::Categorical(_, _) => {
+                    DataType::Categorical(_, _) | DataType::Enum(_, _) => {
                         PyList::new(py, series.categorical().unwrap().iter_str())
                     },
                     #[cfg(feature = "object")]

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -128,7 +128,9 @@ impl PySeries {
 
     fn get_fmt(&self, index: usize, str_lengths: usize) -> String {
         let val = format!("{}", self.series.get(index).unwrap());
-        if let DataType::String | DataType::Categorical(_, _) = self.series.dtype() {
+        if let DataType::String | DataType::Categorical(_, _) | DataType::Enum(_, _) =
+            self.series.dtype()
+        {
             let v_trunc = &val[..val
                 .char_indices()
                 .take(str_lengths)
@@ -379,6 +381,7 @@ impl PySeries {
                     | DataType::Date
                     | DataType::Duration(_)
                     | DataType::Categorical(_, _)
+                    | DataType::Enum(_, _)
                     | DataType::Binary
                     | DataType::Array(_, _)
                     | DataType::Time

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -392,12 +392,12 @@ def test_enum_cast_from_other_integer_dtype_oob() -> None:
     enum_dtype = pl.Enum(["a", "b", "c", "d"])
     series = pl.Series([-1, 2, 3, 3, 2, 1], dtype=pl.Int8)
     with pytest.raises(
-        pl.ComputeError, match="conversion from `i8` to `enum` failed in column"
+        pl.ComputeError, match="conversion from `i8` to `u32` failed in column"
     ):
         series.cast(enum_dtype)
 
     series = pl.Series([2**34, 2, 3, 3, 2, 1], dtype=pl.UInt64)
     with pytest.raises(
-        pl.ComputeError, match="conversion from `u64` to `enum` failed in column"
+        pl.ComputeError, match="conversion from `u64` to `u32` failed in column"
     ):
         series.cast(enum_dtype)

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -180,7 +180,7 @@ def test_append_to_an_enum() -> None:
 def test_append_to_an_enum_with_new_category() -> None:
     with pytest.raises(
         pl.ComputeError,
-        match=("enum is not compatible with other categorical / enum"),
+        match=("can not merge incompatible Enum types"),
     ):
         pl.Series([None, "a", "b", "c"], dtype=pl.Enum(["a", "b", "c"])).append(
             pl.Series(["d", "a", "b", "c"], dtype=pl.Enum(["a", "b", "c", "d"]))
@@ -197,7 +197,7 @@ def test_extend_to_an_enum() -> None:
 
 def test_series_init_uninstantiated_enum() -> None:
     with pytest.raises(
-        TypeError, match="Enum types must be instantiated with a list of categories"
+        pl.ComputeError, match="can not cast / initialize Enum without categories present"
     ):
         pl.Series(["a", "b", "a"], dtype=pl.Enum)
 

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -197,7 +197,8 @@ def test_extend_to_an_enum() -> None:
 
 def test_series_init_uninstantiated_enum() -> None:
     with pytest.raises(
-        pl.ComputeError, match="can not cast / initialize Enum without categories present"
+        pl.ComputeError,
+        match="can not cast / initialize Enum without categories present",
     ):
         pl.Series(["a", "b", "a"], dtype=pl.Enum)
 


### PR DESCRIPTION
This PR makes `Enum` an actual datatype on the rust side instead of a `RevMapping` variant:
- This allows creation of 'unitialized' Enums
- Makes pattern matching a lot easier 