### PR TITLE
fix(docs): Fixed typo and a minor rephrasing in the user guide

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -30,7 +30,7 @@ Polars supports reading and writing for common file formats (e.g. csv, json, par
 --8<-- "python/user-guide/basics/reading-writing.py:dataframe"
 ```
 
-In the example below we write the DataFrame to a csv file called `output.csv`. After thatread it back with `read_csv` and `print` the result for inspection.
+In the example below we write the DataFrame to a csv file called `output.csv`. After that, we read it back using `read_csv` and then `print` the result for inspection.
 
 {{code_block('user-guide/basics/reading-writing','csv',['read_csv','write_csv'])}}
 


### PR DESCRIPTION
The "Getting Started" section of the user guide has a minor typo. I've also rephrased the rest of the sentence it to make it a bit clearer (IMO).