### PR TITLE
fix(python): Allow `Series.to_pandas` for categorical types

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4501,7 +4501,7 @@ class Series:
         Name: b, dtype: int64[pyarrow]
         """
         if self.dtype == Object:
-            # Can't convert via PyArrow, so do it via NumPy:
+            # Can't convert via PyArrow, so do it via NumPy
             return pd.Series(self.to_numpy(), dtype=object, name=self.name)
 
         if use_pyarrow_extension_array:
@@ -4517,6 +4517,10 @@ class Series:
                 )
 
         pa_arr = self.to_arrow()
+        # pandas does not support unsigned dictionary indices
+        if pa.types.is_dictionary(pa_arr.type):
+            pa_arr = pa_arr.cast(pa.dictionary(pa.int64(), pa.large_string()))
+
         if use_pyarrow_extension_array:
             pd_series = pa_arr.to_pandas(
                 self_destruct=True,

--- a/py-polars/tests/unit/interop/test_to_pandas.py
+++ b/py-polars/tests/unit/interop/test_to_pandas.py
@@ -179,3 +179,18 @@ def test_object_to_pandas_series(use_pyarrow_extension_array: bool) -> None:
         ),
         pd.Series(values, dtype=object, name="a"),
     )
+
+
+@pytest.mark.parametrize("polars_dtype", [pl.Categorical, pl.Enum(["a", "b"])])
+def test_series_to_pandas_categorical(polars_dtype: pl.PolarsDataType) -> None:
+    s = pl.Series("x", ["a", "b", "a"], dtype=polars_dtype)
+    result = s.to_pandas()
+    expected = pd.Series(["a", "b", "a"], name="x", dtype="category")
+    pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize("polars_dtype", [pl.Categorical, pl.Enum(["a", "b"])])
+def test_series_to_pandas_categorical_pyarrow(polars_dtype: pl.PolarsDataType) -> None:
+    s = pl.Series("x", ["a", "b", "a"], dtype=polars_dtype)
+    result = s.to_pandas(use_pyarrow_extension_array=True)
+    assert s.to_list() == result.to_list()


### PR DESCRIPTION
Closes #10977

We have to cast the `u32` values to `i64`.