### PR TITLE
refactor(rust!): Rename `LiteralValue::to_anyvalue` to `LiteralValue::to_any_value`

### DIFF
--- a/crates/polars-core/src/frame/row/av_buffer.rs
+++ b/crates/polars-core/src/frame/row/av_buffer.rs
@@ -120,7 +120,7 @@ impl<'a> AnyValueBuffer<'a> {
             #[cfg(feature = "dtype-time")]
             (Time(builder), val) if val.is_numeric() => builder.append_value(val.extract()?),
             (Null(builder), AnyValue::Null) => builder.append_null(),
-            // Struct and List can be recursive so use anyvalues for that
+            // Struct and List can be recursive so use AnyValues for that
             (All(_, vals), v) => vals.push(v),
 
             // dynamic types
@@ -299,7 +299,7 @@ impl From<(&DataType, usize)> for AnyValueBuffer<'_> {
             Float64 => AnyValueBuffer::Float64(PrimitiveChunkedBuilder::new("", len)),
             String => AnyValueBuffer::String(StringChunkedBuilder::new("", len)),
             Null => AnyValueBuffer::Null(NullChunkedBuilder::new("", 0)),
-            // Struct and List can be recursive so use anyvalues for that
+            // Struct and List can be recursive so use AnyValues for that
             dt => AnyValueBuffer::All(dt.clone(), Vec::with_capacity(len)),
         }
     }
@@ -456,7 +456,7 @@ impl<'a> AnyValueBufferTrusted<'a> {
     /// Will add the [`AnyValue`] into [`Self`] and unpack as the physical type
     /// belonging to [`Self`]. This should only be used with physical buffers
     ///
-    /// If a type is not primitive or String, the anyvalue will be converted to static
+    /// If a type is not primitive or String, the AnyValues will be converted to static
     ///
     /// # Safety
     /// The caller must ensure that the [`AnyValue`] type exactly matches the `Buffer` type and is owned.
@@ -668,7 +668,7 @@ impl From<(&DataType, usize)> for AnyValueBufferTrusted<'_> {
                     .collect::<Vec<_>>();
                 AnyValueBufferTrusted::Struct(buffers)
             },
-            // List can be recursive so use anyvalues for that
+            // List can be recursive so use AnyValues for that
             dt => AnyValueBufferTrusted::All(dt.clone(), Vec::with_capacity(len)),
         }
     }

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -155,7 +155,7 @@ fn any_values_to_array(
             })
             .collect_ca_with_dtype("", DataType::Array(Box::new(inner_type.clone()), width))
     }
-    // make sure that wrongly inferred anyvalues don't deviate from the datatype
+    // make sure that wrongly inferred AnyValues don't deviate from the datatype
     else {
         avs.iter()
             .map(|av| match av {
@@ -218,7 +218,7 @@ fn any_values_to_list(
             })
             .collect_trusted()
     }
-    // make sure that wrongly inferred anyvalues don't deviate from the datatype
+    // make sure that wrongly inferred AnyValues don't deviate from the datatype
     else {
         avs.iter()
             .map(|av| match av {

--- a/crates/polars-io/src/csv/write_impl.rs
+++ b/crates/polars-io/src/csv/write_impl.rs
@@ -65,7 +65,7 @@ fn write_integer<I: itoa::Integer>(f: &mut Vec<u8>, val: I) {
 }
 
 #[allow(unused_variables)]
-unsafe fn write_anyvalue(
+unsafe fn write_any_value(
     f: &mut Vec<u8>,
     value: AnyValue,
     options: &SerializeOptions,
@@ -425,7 +425,7 @@ pub(crate) fn write<W: Write>(
                 for (i, col) in &mut col_iters.iter_mut().enumerate() {
                     match col.next() {
                         Some(value) => unsafe {
-                            write_anyvalue(
+                            write_any_value(
                                 &mut write_buffer,
                                 value,
                                 options,

--- a/crates/polars-ops/src/frame/pivot/positioning.rs
+++ b/crates/polars-ops/src/frame/pivot/positioning.rs
@@ -21,7 +21,7 @@ pub(super) fn position_aggregates(
     let split = _split_offsets(row_locations.len(), n_threads);
 
     // ensure the slice series are not dropped
-    // so the anyvalues are referencing correct data, if they reference arrays (struct)
+    // so the AnyValues are referencing correct data, if they reference arrays (struct)
     let n_splits = split.len();
     let mut arrays: Vec<Series> = Vec::with_capacity(n_splits);
 
@@ -115,7 +115,7 @@ where
     let split = _split_offsets(row_locations.len(), n_threads);
     let n_splits = split.len();
     // ensure the arrays are not dropped
-    // so the anyvalues are referencing correct data, if they reference arrays (struct)
+    // so the AnyValues are referencing correct data, if they reference arrays (struct)
     let mut arrays: Vec<ChunkedArray<T>> = Vec::with_capacity(n_splits);
 
     // every thread will only write to their partition

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -521,17 +521,17 @@ fn is_in_struct(ca_in: &StructChunked, other: &Series) -> PolarsResult<BooleanCh
                 return is_in(&ca_in_super, &other_super);
             }
 
-            let mut anyvalues = Vec::with_capacity(other.len() * other.fields().len());
+            let mut any_values = Vec::with_capacity(other.len() * other.fields().len());
             // SAFETY:
             // the iterator is unsafe as the lifetime is tied to the iterator
             // so we copy to an owned buffer first
             other.into_iter().for_each(|vals| {
-                anyvalues.extend_from_slice(vals);
+                any_values.extend_from_slice(vals);
             });
 
             // then we fill the set
             let mut set = PlHashSet::with_capacity(other.len());
-            for key in anyvalues.chunks_exact(other.fields().len()) {
+            for key in any_values.chunks_exact(other.fields().len()) {
                 set.insert(key);
             }
             // physical ca_in

--- a/crates/polars-pipe/src/executors/sinks/group_by/generic/hash_table.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/generic/hash_table.rs
@@ -251,7 +251,7 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
                     unsafe {
                         let running_agg = running_aggregations.get_unchecked_release_mut(i);
                         let av = running_agg.finalize();
-                        // safety: finalize creates owned anyvalues
+                        // safety: finalize creates owned AnyValues
                         buffer.add_unchecked_owned_physical(&av);
                     }
                 }

--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -423,7 +423,7 @@ impl Debug for LiteralValue {
                 }
             },
             _ => {
-                let av = self.to_anyvalue().unwrap();
+                let av = self.to_any_value().unwrap();
                 write!(f, "{av}")
             },
         }

--- a/crates/polars-plan/src/logical_plan/lit.rs
+++ b/crates/polars-plan/src/logical_plan/lit.rs
@@ -71,7 +71,7 @@ impl LiteralValue {
         }
     }
 
-    pub fn to_anyvalue(&self) -> Option<AnyValue> {
+    pub fn to_any_value(&self) -> Option<AnyValue> {
         use LiteralValue::*;
         let av = match self {
             Null => AnyValue::Null,
@@ -336,7 +336,7 @@ impl Hash for LiteralValue {
                 data_type.hash(state)
             },
             _ => {
-                if let Some(v) = self.to_anyvalue() {
+                if let Some(v) = self.to_any_value() {
                     v.hash_impl(state, true)
                 }
             },

--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -534,7 +534,7 @@ fn inline_cast(input: &AExpr, dtype: &DataType, strict: bool) -> PolarsResult<Op
                 LiteralValue::Series(SpecialEq::new(s))
             },
             _ => {
-                let Some(av) = lv.to_anyvalue() else {
+                let Some(av) = lv.to_any_value() else {
                     return Ok(None);
                 };
                 if dtype == &av.dtype() {

--- a/crates/polars-plan/src/logical_plan/optimizer/type_coercion/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/type_coercion/mod.rs
@@ -196,7 +196,7 @@ fn modify_supertype(
 
             // cast literal to right type if they fit in the range
             (Literal(value), _) => {
-                if let Some(lit_val) = value.to_anyvalue() {
+                if let Some(lit_val) = value.to_any_value() {
                     if type_right.value_within_range(lit_val) {
                         st = type_right.clone();
                     }
@@ -204,7 +204,7 @@ fn modify_supertype(
             },
             // cast literal to left type
             (_, Literal(value)) => {
-                if let Some(lit_val) = value.to_anyvalue() {
+                if let Some(lit_val) = value.to_any_value() {
                     if type_left.value_within_range(lit_val) {
                         st = type_left.clone();
                     }

--- a/crates/polars-plan/src/logical_plan/pyarrow.rs
+++ b/crates/polars-plan/src/logical_plan/pyarrow.rs
@@ -65,7 +65,7 @@ pub(super) fn predicate_to_pa(
             }
         },
         AExpr::Literal(lv) => {
-            let av = lv.to_anyvalue()?;
+            let av = lv.to_any_value()?;
             let dtype = av.dtype();
             match av.as_borrowed() {
                 AnyValue::String(s) => Some(format!("'{s}'")),

--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -546,7 +546,7 @@ impl SQLExprVisitor<'_> {
     }
 
     /// Visit a SQL literal (like [visit_literal]), but return AnyValue instead of Expr.
-    fn visit_anyvalue(
+    fn visit_any_value(
         &self,
         value: &SQLValue,
         op: Option<&UnaryOperator>,
@@ -669,12 +669,12 @@ impl SQLExprVisitor<'_> {
             .iter()
             .map(|e| {
                 if let SQLExpr::Value(v) = e {
-                    let av = self.visit_anyvalue(v, None)?;
+                    let av = self.visit_any_value(v, None)?;
                     Ok(av)
                 } else if let SQLExpr::UnaryOp {op, expr} = e {
                     match expr.as_ref() {
                         SQLExpr::Value(v) => {
-                            let av = self.visit_anyvalue(v, Some(op))?;
+                            let av = self.visit_any_value(v, Some(op))?;
                             Ok(av)
                         },
                         _ => Err(polars_err!(ComputeError: "SQL expression {:?} is not yet supported", e))

--- a/py-polars/polars/utils/__init__.py
+++ b/py-polars/polars/utils/__init__.py
@@ -7,8 +7,8 @@ from polars.utils._scan import _execute_from_rust
 from polars.utils.build_info import build_info
 from polars.utils.convert import (
     _date_to_pl_date,
-    _datetime_for_anyvalue,
-    _datetime_for_anyvalue_windows,
+    _datetime_for_any_value,
+    _datetime_for_any_value_windows,
     _time_to_pl_time,
     _timedelta_to_pl_timedelta,
     _to_python_date,
@@ -31,8 +31,8 @@ __all__ = [
     "threadpool_size",
     # Required for Rust bindings
     "_date_to_pl_date",
-    "_datetime_for_anyvalue",
-    "_datetime_for_anyvalue_windows",
+    "_datetime_for_any_value",
+    "_datetime_for_any_value_windows",
     "_execute_from_rust",
     "_polars_warn",
     "_time_to_pl_time",

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -292,14 +292,14 @@ def _get_first_non_none(values: Sequence[Any | None]) -> Any:
         return next((v for v in values if v is not None), None)
 
 
-def sequence_from_anyvalue_or_object(name: str, values: Sequence[Any]) -> PySeries:
+def sequence_from_any_value_or_object(name: str, values: Sequence[Any]) -> PySeries:
     """
     Last resort conversion.
 
     AnyValues are most flexible and if they fail we go for object types
     """
     try:
-        return PySeries.new_from_anyvalues(name, values, strict=True)
+        return PySeries.new_from_any_values(name, values, strict=True)
     # raised if we cannot convert to Wrap<AnyValue>
     except RuntimeError:
         return PySeries.new_object(name, values, _strict=False)
@@ -309,7 +309,7 @@ def sequence_from_anyvalue_or_object(name: str, values: Sequence[Any]) -> PySeri
         raise
 
 
-def sequence_from_anyvalue_and_dtype_or_object(
+def sequence_from_any_value_and_dtype_or_object(
     name: str, values: Sequence[Any], dtype: PolarsDataType
 ) -> PySeries:
     """
@@ -318,7 +318,7 @@ def sequence_from_anyvalue_and_dtype_or_object(
     AnyValues are most flexible and if they fail we go for object types
     """
     try:
-        return PySeries.new_from_anyvalues_and_dtype(name, values, dtype, strict=True)
+        return PySeries.new_from_any_values_and_dtype(name, values, dtype, strict=True)
     # raised if we cannot convert to Wrap<AnyValue>
     except RuntimeError:
         return PySeries.new_object(name, values, _strict=False)
@@ -520,9 +520,9 @@ def sequence_to_pyseries(
                     msg
                 )
 
-            # we use anyvalue builder to create the datetime array
-            # we store the values internally as UTC and set the timezone
-            py_series = PySeries.new_from_anyvalues(name, values, strict)
+            # We use the AnyValue builder to create the datetime array
+            # We store the values internally as UTC and set the timezone
+            py_series = PySeries.new_from_any_values(name, values, strict)
             time_unit = getattr(dtype, "time_unit", None)
             if time_unit is None or values_dtype == Date:
                 s = wrap_s(py_series)
@@ -588,11 +588,11 @@ def sequence_to_pyseries(
             if isinstance(dtype, Object):
                 return PySeries.new_object(name, values, strict)
             if dtype:
-                srs = sequence_from_anyvalue_and_dtype_or_object(name, values, dtype)
+                srs = sequence_from_any_value_and_dtype_or_object(name, values, dtype)
                 if not dtype.is_(srs.dtype()):
                     srs = srs.cast(dtype, strict=False)
                 return srs
-            return sequence_from_anyvalue_or_object(name, values)
+            return sequence_from_any_value_or_object(name, values)
 
         elif python_dtype == pl.Series:
             return PySeries.new_series_list(name, [v._s for v in values], strict)
@@ -603,7 +603,7 @@ def sequence_to_pyseries(
             constructor = py_type_to_constructor(python_dtype)
             if constructor == PySeries.new_object:
                 try:
-                    srs = PySeries.new_from_anyvalues(name, values, strict)
+                    srs = PySeries.new_from_any_values(name, values, strict)
                     if _check_for_numpy(python_dtype, check_type=False) and isinstance(
                         np.bool_(True), np.generic
                     ):
@@ -614,7 +614,7 @@ def sequence_to_pyseries(
 
                 except RuntimeError:
                     # raised if we cannot convert to Wrap<AnyValue>
-                    return sequence_from_anyvalue_or_object(name, values)
+                    return sequence_from_any_value_or_object(name, values)
 
             return _construct_series_with_fallbacks(
                 constructor, name, values, dtype, strict=strict

--- a/py-polars/polars/utils/convert.py
+++ b/py-polars/polars/utils/convert.py
@@ -218,8 +218,8 @@ def _localize(dt: datetime, time_zone: str) -> datetime:
     return dt.astimezone(_tzinfo)
 
 
-def _datetime_for_anyvalue(dt: datetime) -> tuple[int, int]:
-    """Used in pyo3 anyvalue conversion."""
+def _datetime_for_any_value(dt: datetime) -> tuple[int, int]:
+    """Used in PyO3 AnyValue conversion."""
     # returns (s, ms)
     if dt.tzinfo is None:
         return (
@@ -229,8 +229,8 @@ def _datetime_for_anyvalue(dt: datetime) -> tuple[int, int]:
     return (_timestamp_in_seconds(dt), dt.microsecond)
 
 
-def _datetime_for_anyvalue_windows(dt: datetime) -> tuple[float, int]:
-    """Used in pyo3 anyvalue conversion."""
+def _datetime_for_any_value_windows(dt: datetime) -> tuple[float, int]:
+    """Used in PyO3 AnyValue conversion."""
     if dt.tzinfo is None:
         dt = _localize(dt, "UTC")
     # returns (s, ms)

--- a/py-polars/src/conversion/any_value.rs
+++ b/py-polars/src/conversion/any_value.rs
@@ -362,7 +362,7 @@ fn convert_datetime(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
         #[cfg(target_arch = "windows")]
         let (seconds, microseconds) = {
             let convert = UTILS
-                .getattr(py, intern!(py, "_datetime_for_anyvalue_windows"))
+                .getattr(py, intern!(py, "_datetime_for_any_value_windows"))
                 .unwrap();
             let out = convert.call1(py, (ob,)).unwrap();
             let out: (i64, i64) = out.extract(py).unwrap();
@@ -372,7 +372,7 @@ fn convert_datetime(ob: &PyAny) -> PyResult<Wrap<AnyValue>> {
         #[cfg(not(target_arch = "windows"))]
         let (seconds, microseconds) = {
             let convert = UTILS
-                .getattr(py, intern!(py, "_datetime_for_anyvalue"))
+                .getattr(py, intern!(py, "_datetime_for_any_value"))
                 .unwrap();
             let out = convert.call1(py, (ob,)).unwrap();
             let out: (i64, i64) = out.extract(py).unwrap();

--- a/py-polars/src/conversion/chunked_array.rs
+++ b/py-polars/src/conversion/chunked_array.rs
@@ -172,7 +172,7 @@ impl ToPyObject for Wrap<&DecimalChunked> {
         let py_precision = self.0.precision().unwrap_or(39).to_object(py);
         let iter = self.0.into_iter().map(|opt_v| {
             opt_v.map(|v| {
-                // TODO! use anyvalue so that we have a single impl.
+                // TODO! use AnyValue so that we have a single impl.
                 const N: usize = 3;
                 let mut buf = [0_u128; N];
                 let n_digits = decimal_to_digits(v.abs(), &mut buf);

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod anyvalue;
+pub(crate) mod any_value;
 mod chunked_array;
 
 use std::fmt::{Display, Formatter};

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -452,7 +452,7 @@ pub fn repeat(value: PyExpr, n: PyExpr, dtype: Option<Wrap<DataType>>) -> PyResu
     }
 
     if let Expr::Literal(lv) = &value {
-        let av = lv.to_anyvalue().unwrap();
+        let av = lv.to_any_value().unwrap();
         // Integer inputs that fit in Int32 are parsed as such
         if let DataType::Int64 = av.dtype() {
             let int_value = av.try_extract::<i64>().unwrap();

--- a/py-polars/src/map/series.rs
+++ b/py-polars/src/map/series.rs
@@ -49,7 +49,7 @@ fn infer_and_finish<'a, A: ApplyLambda<'a>>(
         let py_pyseries = series.getattr(py, "_s").unwrap();
         let series = py_pyseries.extract::<PySeries>(py).unwrap().series;
 
-        // empty dtype is incorrect use anyvalues.
+        // Empty dtype is incorrect, use AnyValues.
         if series.is_empty() {
             let av = out.extract::<Wrap<AnyValue>>()?;
             return applyer
@@ -76,7 +76,7 @@ fn infer_and_finish<'a, A: ApplyLambda<'a>>(
             .map(|ca| ca.into_series().into());
         match result {
             Ok(out) => Ok(out),
-            // try anyvalue
+            // Try AnyValue
             Err(_) => {
                 let av = out.extract::<Wrap<AnyValue>>()?;
                 applyer

--- a/py-polars/src/on_startup.rs
+++ b/py-polars/src/on_startup.rs
@@ -98,7 +98,7 @@ pub fn __register_startup_deps() {
         unsafe { polars_error::set_warning_function(warning_function) };
         Python::with_gil(|py| {
             // init AnyValue LUT
-            crate::conversion::anyvalue::LUT
+            crate::conversion::any_value::LUT
                 .set(py, Default::default())
                 .unwrap();
         });

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -184,7 +184,7 @@ init_method_opt!(new_opt_f64, Float64Type, f64);
 )]
 impl PySeries {
     #[staticmethod]
-    fn new_from_anyvalues(
+    fn new_from_any_values(
         name: &str,
         val: Vec<Wrap<AnyValue<'_>>>,
         strict: bool,
@@ -196,7 +196,7 @@ impl PySeries {
     }
 
     #[staticmethod]
-    fn new_from_anyvalues_and_dtype(
+    fn new_from_any_values_and_dtype(
         name: &str,
         val: Vec<Wrap<AnyValue<'_>>>,
         dtype: Wrap<DataType>,

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -79,7 +79,7 @@ def test_datelike_identity() -> None:
         assert s.map_elements(lambda x: x).to_list() == s.to_list()
 
 
-def test_map_elements_list_anyvalue_fallback() -> None:
+def test_map_elements_list_any_value_fallback() -> None:
     with pytest.warns(
         PolarsInefficientMapWarning,
         match=r'(?s)with this one instead:.*pl.col\("text"\).str.json_decode()',


### PR DESCRIPTION
`anyvalue` and `any_value` were used interchangably, e.g. Rust had `Series::from_any_values`, but in the PyO3 bindings it was called `Series::new_from_anyvalues`.

~Since the object is called `AnyValue` and "any value" could have a different meaning, let's settle on using `anyvalue` when referring to AnyValue functionality in function names/variables.~
We settled on using `any_value` everywhere.

Besides the change in the title, the same change was made in several internal functions/references.