### PR TITLE
fix(python): multiple `read_excel` updates

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -502,7 +502,12 @@ impl LazyFrame {
                 }
             })
             .collect();
-        self.with_columns(cast_cols)
+
+        if cast_cols.is_empty() {
+            self.clone()
+        } else {
+            self.with_columns(cast_cols)
+        }
     }
 
     /// Cast all frame columns to the given dtype, resulting in a new LazyFrame


### PR DESCRIPTION
* ~~Fixes casting from Datetime to Time for specific pre-epoch values where the time was 00:00:00~~ 
  (See: #14050)
* Type inference fix when using "calamine" engine (added missing `all` when determining if a cast should be applied).
* Deprecate `read_csv_options` in favour of more generic `read_options`, which can now be used by other engines.
* Minor optimisation when using "calamine" engine (use `eq`, not `eq_missing`).
* Additional unit test coverage.
