### PR TITLE
fix(python,rust): correct field type schema inference (using read_csv)

### DIFF
--- a/crates/polars-io/src/utils.rs
+++ b/crates/polars-io/src/utils.rs
@@ -174,13 +174,13 @@ pub(crate) fn overwrite_schema(
 }
 
 pub static FLOAT_RE: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(r"^\s*[-+]?((\d*\.\d+)([eE][-+]?\d+)?|inf|NaN|(\d+)[eE][-+]?\d+|\d+\.)$").unwrap()
+    Regex::new(r"^[-+]?((\d*\.\d+)([eE][-+]?\d+)?|inf|NaN|(\d+)[eE][-+]?\d+|\d+\.)$").unwrap()
 });
 
-pub static INTEGER_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^\s*-?(\d+)$").unwrap());
+pub static INTEGER_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^-?(\d+)$").unwrap());
 
 pub static BOOLEAN_RE: Lazy<Regex> = Lazy::new(|| {
-    RegexBuilder::new(r"^\s*(true)$|^(false)$")
+    RegexBuilder::new(r"^(true|false)$")
         .case_insensitive(true)
         .build()
         .unwrap()

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -184,8 +184,8 @@ fn test_projection() -> PolarsResult<()> {
 fn test_missing_data() {
     // missing data should not lead to parser error.
     let csv = r#"column_1,column_2,column_3
-        1,2,3
-        1,,3
+1,2,3
+1,,3
 "#;
 
     let file = Cursor::new(csv);
@@ -1132,21 +1132,6 @@ fn test_try_parse_dates() -> PolarsResult<()> {
 }
 
 #[test]
-fn test_whitespace_skipping() -> PolarsResult<()> {
-    let csv = "a,b
-  12,   1435";
-    let file = Cursor::new(csv);
-    let out = CsvReader::new(file).finish()?;
-    let expected = df![
-        "a" => [12i64],
-        "b" => [1435i64],
-    ]?;
-    assert!(out.equals(&expected));
-
-    Ok(())
-}
-
-#[test]
 fn test_try_parse_dates_3380() -> PolarsResult<()> {
     let csv = "lat;lon;validdate;t_2m:C;precip_1h:mm
 46.685;7.953;2022-05-10T07:07:12Z;6.1;0.00
@@ -1171,6 +1156,6 @@ fn test_leading_whitespace_with_quote() -> PolarsResult<()> {
     let col_1 = df.column("ABC").unwrap();
     let col_2 = df.column("DEF").unwrap();
     assert_eq!(col_1.get(0)?, AnyValue::Float64(24.5));
-    assert_eq!(col_2.get(0)?, AnyValue::Float64(4.1));
+    assert_eq!(col_2.get(0)?, AnyValue::String("  4.1"));
     Ok(())
 }

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -869,6 +869,28 @@ def test_quoting_round_trip() -> None:
     assert_frame_equal(read_df, df)
 
 
+def test_csv_field_schema_inference_with_whitespace() -> None:
+    csv = """\
+bool,bool-,-bool,float,float-,-float,int,int-,-int
+true,true , true,1.2,1.2 , 1.2,1,1 , 1
+"""
+    df = pl.read_csv(io.StringIO(csv), has_header=True)
+    expected = pl.DataFrame(
+        {
+            "bool": [True],
+            "bool-": ["true "],
+            "-bool": [" true"],
+            "float": [1.2],
+            "float-": ["1.2 "],
+            "-float": [" 1.2"],
+            "int": [1],
+            "int-": ["1 "],
+            "-int": [" 1"],
+        }
+    )
+    assert_frame_equal(df, expected)
+
+
 def test_fallback_chrono_parser() -> None:
     data = textwrap.dedent(
         """\
@@ -1215,7 +1237,8 @@ def test_float_precision(dtype: pl.Float32 | pl.Float64) -> None:
 def test_skip_rows_different_field_len() -> None:
     csv = io.StringIO(
         textwrap.dedent(
-            """a,b
+            """\
+        a,b
         1,A
         2,
         3,B


### PR DESCRIPTION
fix schema inference using `read_csv` with leading whitespace

fix #10587 
fix #12763 

added tests.

# Fix: schema inference with whitespace

```python
DATA = """bool,bool-,-bool,float,float-,-float,int,int-,-int
true,true , true,1.2,1.2 , 1.2,1,1 , 1
"""

pl.read_csv(
    StringIO(DATA),
    ignore_errors=True,
)
```

## current / old
```
shape: (1, 9)
┌──────┬───────┬───────┬───────┬────────┬────────┬─────┬──────┬──────┐
│ bool ┆ bool- ┆ -bool ┆ float ┆ float- ┆ -float ┆ int ┆ int- ┆ -int │
│ ---  ┆ ---   ┆ ---   ┆ ---   ┆ ---    ┆ ---    ┆ --- ┆ ---  ┆ ---  │
│ bool ┆ str   ┆ bool  ┆ f64   ┆ str    ┆ f64    ┆ i64 ┆ str  ┆ i64  │
╞══════╪═══════╪═══════╪═══════╪════════╪════════╪═════╪══════╪══════╡
│ true ┆ true  ┆ null  ┆ 1.2   ┆ 1.2    ┆ 1.2    ┆ 1   ┆ 1    ┆ 1    │
└──────┴───────┴───────┴───────┴────────┴────────┴─────┴──────┴──────┘
```
Bugs:
- bug with incorrect bool regex causes the `null` with leading whitespace for bool
- leading whitespace is ignore for numbers so "   1" or "    1.2" parse incorrectly as numbers instead of str


## NEW

```
shape: (1, 9)
┌──────┬───────┬───────┬───────┬────────┬────────┬─────┬──────┬──────┐
│ bool ┆ bool- ┆ -bool ┆ float ┆ float- ┆ -float ┆ int ┆ int- ┆ -int │
│ ---  ┆ ---   ┆ ---   ┆ ---   ┆ ---    ┆ ---    ┆ --- ┆ ---  ┆ ---  │
│ bool ┆ str   ┆ str   ┆ f64   ┆ str    ┆ str    ┆ i64 ┆ str  ┆ str  │
╞══════╪═══════╪═══════╪═══════╪════════╪════════╪═════╪══════╪══════╡
│ true ┆ true  ┆  true ┆ 1.2   ┆ 1.2    ┆  1.2   ┆ 1   ┆ 1    ┆  1   │
└──────┴───────┴───────┴───────┴────────┴────────┴─────┴──────┴──────┘
```
Result:
- all values containing whitespace are correctly parsed as str

---

bool regex bug:
<img width="238" alt="image" src="https://github.com/pola-rs/polars/assets/25177421/4352268b-8e13-49b3-8a47-29ed82a21b77">
