### PR TITLE
fix: Use int formatter for unsigned ints

### DIFF
--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -991,10 +991,10 @@ impl Display for AnyValue<'_> {
         let width = 0;
         match self {
             AnyValue::Null => write!(f, "null"),
-            AnyValue::UInt8(v) => write!(f, "{v}"),
-            AnyValue::UInt16(v) => write!(f, "{v}"),
-            AnyValue::UInt32(v) => write!(f, "{v}"),
-            AnyValue::UInt64(v) => write!(f, "{v}"),
+            AnyValue::UInt8(v) => fmt_integer(f, width, *v),
+            AnyValue::UInt16(v) => fmt_integer(f, width, *v),
+            AnyValue::UInt32(v) => fmt_integer(f, width, *v),
+            AnyValue::UInt64(v) => fmt_integer(f, width, *v),
             AnyValue::Int8(v) => fmt_integer(f, width, *v),
             AnyValue::Int16(v) => fmt_integer(f, width, *v),
             AnyValue::Int32(v) => fmt_integer(f, width, *v),


### PR DESCRIPTION
Resolves #14041.

```python
import polars as pl
df = pl.DataFrame({"int_col" : [100, 1_000, 10_000, 100_000]})
df = df.with_columns(pl.col("int_col").cast(pl.UInt64).alias("uint_col"))
with pl.Config(thousands_separator=True):
    print(df)
```
```
shape: (4, 2)
┌─────────┬──────────┐
│ int_col ┆ uint_col │
│ ---     ┆ ---      │
│ i64     ┆ u64      │
╞═════════╪══════════╡
│ 100     ┆ 100      │
│ 1,000   ┆ 1,000    │
│ 10,000  ┆ 10,000   │
│ 100,000 ┆ 100,000  │
└─────────┴──────────┘
```
