### PR TITLE
refactor(rust!): Remove `DatetimeChunked::convert_time_zone`

### DIFF
--- a/crates/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/crates/polars-core/src/chunked_array/temporal/datetime.rs
@@ -223,11 +223,6 @@ impl DatetimeChunked {
         self.2 = Some(Datetime(self.time_unit(), Some(time_zone)));
         Ok(())
     }
-    #[cfg(feature = "timezones")]
-    pub fn convert_time_zone(mut self, time_zone: TimeZone) -> PolarsResult<Self> {
-        self.set_time_zone(time_zone)?;
-        Ok(self)
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Following #13960, this method is no longer useful. Let's get rid of it. Use `set_time_zone` instead.