### PR TITLE
fix(rust,python): some temporal conversion errors for datetimes earlier than `1970-01-01`

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/datetime.rs
+++ b/crates/polars-core/src/chunked_array/logical/datetime.rs
@@ -63,13 +63,15 @@ impl LogicalType for DatetimeChunked {
             #[cfg(feature = "dtype-date")]
             (Datetime(tu, _), Date) => {
                 let cast_to_date = |tu_in_day: i64| {
-                    Ok(self
+                    let mut dt = self
                         .0
                         .apply_values(|v| v.div_euclid(tu_in_day))
                         .cast(&Int32)
                         .unwrap()
                         .into_date()
-                        .into_series())
+                        .into_series();
+                    dt.set_sorted_flag(self.is_sorted_flag());
+                    Ok(dt)
                 };
                 match tu {
                     TimeUnit::Nanoseconds => cast_to_date(NS_IN_DAY),

--- a/crates/polars-core/src/chunked_array/logical/datetime.rs
+++ b/crates/polars-core/src/chunked_array/logical/datetime.rs
@@ -31,66 +31,70 @@ impl LogicalType for DatetimeChunked {
     fn cast(&self, dtype: &DataType) -> PolarsResult<Series> {
         use DataType::*;
         match (self.dtype(), dtype) {
-            (Datetime(TimeUnit::Milliseconds, _), Datetime(TimeUnit::Nanoseconds, tz)) => {
-                Ok((self.0.as_ref() * 1_000_000i64)
-                    .into_datetime(TimeUnit::Nanoseconds, tz.clone())
-                    .into_series())
-            },
-            (Datetime(TimeUnit::Milliseconds, _), Datetime(TimeUnit::Microseconds, tz)) => {
-                Ok((self.0.as_ref() * 1_000i64)
-                    .into_datetime(TimeUnit::Microseconds, tz.clone())
-                    .into_series())
-            },
-            (Datetime(TimeUnit::Nanoseconds, _), Datetime(TimeUnit::Milliseconds, tz)) => {
-                Ok((self.0.as_ref() / 1_000_000i64)
-                    .into_datetime(TimeUnit::Milliseconds, tz.clone())
-                    .into_series())
-            },
-            (Datetime(TimeUnit::Nanoseconds, _), Datetime(TimeUnit::Microseconds, tz)) => {
-                Ok((self.0.as_ref() / 1_000i64)
-                    .into_datetime(TimeUnit::Microseconds, tz.clone())
-                    .into_series())
-            },
-            (Datetime(TimeUnit::Microseconds, _), Datetime(TimeUnit::Milliseconds, tz)) => {
-                Ok((self.0.as_ref() / 1_000i64)
-                    .into_datetime(TimeUnit::Milliseconds, tz.clone())
-                    .into_series())
-            },
-            (Datetime(TimeUnit::Microseconds, _), Datetime(TimeUnit::Nanoseconds, tz)) => {
-                Ok((self.0.as_ref() * 1_000i64)
-                    .into_datetime(TimeUnit::Nanoseconds, tz.clone())
-                    .into_series())
+            (Datetime(from_unit, _), Datetime(to_unit, tz)) => {
+                let (multiplier, divisor) = match (from_unit, to_unit) {
+                    // scaling from lower precision to higher precision
+                    (TimeUnit::Milliseconds, TimeUnit::Nanoseconds) => (Some(1_000_000i64), None),
+                    (TimeUnit::Milliseconds, TimeUnit::Microseconds) => (Some(1_000i64), None),
+                    (TimeUnit::Microseconds, TimeUnit::Nanoseconds) => (Some(1_000i64), None),
+                    // scaling from higher precision to lower precision
+                    (TimeUnit::Nanoseconds, TimeUnit::Milliseconds) => (None, Some(1_000_000i64)),
+                    (TimeUnit::Nanoseconds, TimeUnit::Microseconds) => (None, Some(1_000i64)),
+                    (TimeUnit::Microseconds, TimeUnit::Milliseconds) => (None, Some(1_000i64)),
+                    _ => return self.0.cast(dtype),
+                };
+                let result = match multiplier {
+                    // scale to higher precision (eg: ms → us, ms → ns, us → ns)
+                    Some(m) => Ok((self.0.as_ref() * m)
+                        .into_datetime(*to_unit, tz.clone())
+                        .into_series()),
+                    // scale to lower precision (eg: ns → us, ns → ms, us → ms)
+                    None => match divisor {
+                        Some(d) => Ok(self
+                            .0
+                            .apply_values(|v| v.div_euclid(d))
+                            .into_datetime(*to_unit, tz.clone())
+                            .into_series()),
+                        None => unreachable!("must always have a time unit divisor here"),
+                    },
+                };
+                result
             },
             #[cfg(feature = "dtype-date")]
-            (Datetime(tu, _), Date) => match tu {
-                TimeUnit::Nanoseconds => Ok((self.0.as_ref() / NS_IN_DAY)
-                    .cast(&Int32)
-                    .unwrap()
-                    .into_date()
-                    .into_series()),
-                TimeUnit::Microseconds => Ok((self.0.as_ref() / US_IN_DAY)
-                    .cast(&Int32)
-                    .unwrap()
-                    .into_date()
-                    .into_series()),
-                TimeUnit::Milliseconds => Ok((self.0.as_ref() / MS_IN_DAY)
-                    .cast(&Int32)
-                    .unwrap()
-                    .into_date()
-                    .into_series()),
+            (Datetime(tu, _), Date) => {
+                let cast_to_date = |tu_in_day: i64| {
+                    Ok(self
+                        .0
+                        .apply_values(|v| v.div_euclid(tu_in_day))
+                        .cast(&Int32)
+                        .unwrap()
+                        .into_date()
+                        .into_series())
+                };
+                match tu {
+                    TimeUnit::Nanoseconds => cast_to_date(NS_IN_DAY),
+                    TimeUnit::Microseconds => cast_to_date(US_IN_DAY),
+                    TimeUnit::Milliseconds => cast_to_date(MS_IN_DAY),
+                }
             },
             #[cfg(feature = "dtype-time")]
-            (Datetime(tu, _), Time) => Ok({
-                let (modder, multiplier) = match tu {
-                    TimeUnit::Nanoseconds => (NS_IN_DAY, 1i64),
-                    TimeUnit::Microseconds => (US_IN_DAY, 1_000i64),
-                    TimeUnit::Milliseconds => (MS_IN_DAY, 1_000_000i64),
+            (Datetime(tu, _), Time) => {
+                let cast_to_time = |scaled_mod: i64, multiplier: i64| {
+                    Ok(self
+                        .0
+                        .apply_values(|v| {
+                            let t = v % scaled_mod * multiplier;
+                            t + (NS_IN_DAY * (v < 0 && t != 0) as i64)
+                        })
+                        .into_time()
+                        .into_series())
                 };
-                self.0
-                    .apply_values(|v| (v % modder * multiplier) + (NS_IN_DAY * (v < 0) as i64))
-                    .into_time()
-                    .into_series()
-            }),
+                match tu {
+                    TimeUnit::Nanoseconds => cast_to_time(NS_IN_DAY, 1i64),
+                    TimeUnit::Microseconds => cast_to_time(US_IN_DAY, 1_000i64),
+                    TimeUnit::Milliseconds => cast_to_time(MS_IN_DAY, 1_000_000i64),
+                }
+            },
             _ => self.0.cast(dtype),
         }
     }

--- a/crates/polars-core/src/chunked_array/logical/datetime.rs
+++ b/crates/polars-core/src/chunked_array/logical/datetime.rs
@@ -89,7 +89,7 @@ impl LogicalType for DatetimeChunked {
                 self.0
                     .apply_values(|v| {
                         let t = v % scaled_mod * multiplier;
-                        t + (NS_IN_DAY * (v < 0 && t != 0) as i64)
+                        t + (NS_IN_DAY * (t < 0) as i64)
                     })
                     .into_time()
                     .into_series()

--- a/py-polars/tests/parametric/time_series/test_to_datetime.py
+++ b/py-polars/tests/parametric/time_series/test_to_datetime.py
@@ -6,11 +6,13 @@ from hypothesis import given
 import polars as pl
 from polars.exceptions import ComputeError
 from polars.testing.parametric.strategies import strategy_datetime_format
+from polars.type_aliases import TimeUnit
 
 
 @given(
     datetimes=st.datetimes(
-        min_value=datetime(2000, 1, 1), max_value=datetime(9999, 12, 31)
+        min_value=datetime(1699, 1, 1),
+        max_value=datetime(9999, 12, 31),
     ),
     fmt=strategy_datetime_format(),
 )
@@ -42,3 +44,27 @@ def test_to_datetime(datetimes: datetime, fmt: str) -> None:
         )
     else:
         assert result == expected
+
+
+@given(
+    d=st.datetimes(
+        min_value=datetime(1699, 1, 1),
+        max_value=datetime(9999, 12, 31),
+    ),
+    tu=st.sampled_from(["ms", "us"]),
+)
+def test_cast_to_time_and_combine(d: datetime, tu: TimeUnit) -> None:
+    # round-trip date/time extraction + recombining
+    df = pl.DataFrame({"d": [d]}, schema={"d": pl.Datetime(tu)})
+    res = df.select(
+        d=pl.col("d"),
+        dt=pl.col("d").dt.date(),
+        tm=pl.col("d").cast(pl.Time),
+    ).with_columns(
+        dtm=pl.col("dt").dt.combine(pl.col("tm")),
+    )
+
+    datetimes = res["d"].to_list()
+    assert [d.date() for d in datetimes] == res["dt"].to_list()
+    assert [d.time() for d in datetimes] == res["tm"].to_list()
+    assert datetimes == res["dtm"].to_list()

--- a/py-polars/tests/unit/test_queries.py
+++ b/py-polars/tests/unit/test_queries.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from typing import Any
 
 import numpy as np
@@ -368,3 +368,37 @@ def test_shift_drop_nulls_10875() -> None:
     assert pl.LazyFrame({"a": [1, 2, 3]}).shift(1).drop_nulls().collect()[
         "a"
     ].to_list() == [1, 2]
+
+
+def test_temporal_downcasts() -> None:
+    s = pl.Series([-1, 0, 1]).cast(pl.Datetime("us"))
+
+    assert s.to_list() == [
+        datetime(1969, 12, 31, 23, 59, 59, 999999),
+        datetime(1970, 1, 1),
+        datetime(1970, 1, 1, 0, 0, 0, 1),
+    ]
+
+    # downcast (from us to ms, or from datetime to date) should NOT change the date
+    for s_dt in (s.dt.date(), s.cast(pl.Date)):
+        assert s_dt.to_list() == [
+            date(1969, 12, 31),
+            date(1970, 1, 1),
+            date(1970, 1, 1),
+        ]
+    assert s.cast(pl.Datetime("ms")).to_list() == [
+        datetime(1969, 12, 31, 23, 59, 59, 999000),
+        datetime(1970, 1, 1),
+        datetime(1970, 1, 1),
+    ]
+
+
+def test_temporal_time_casts() -> None:
+    s = pl.Series([-1, 0, 1]).cast(pl.Datetime("us"))
+
+    for s_dt in (s.dt.time(), s.cast(pl.Time)):
+        assert s_dt.to_list() == [
+            time(23, 59, 59, 999999),
+            time(0, 0, 0, 0),
+            time(0, 0, 0, 1),
+        ]


### PR DESCRIPTION
Rust's standard integer division truncates, so the effect is round towards zero, and this is the root cause of some temporal conversion gremlins when we scale negative `i64` values (eg: pre-epoch).

## Errors
Sample data:
```python
import polars as pl

s = pl.Series([-1, 0, 1]).cast(pl.Datetime("us"))
# shape: (3,)
# Series: '' [datetime[μs]]
# [
#   1969-12-31 23:59:59.999999
#   1970-01-01 00:00:00
#   1970-01-01 00:00:00.000001
# ]
```
Extracting the date (or casting to date):
```python
s.dt.date()
# shape: (3,)
# Series: '' [date]
# [
#   1970-01-01  ❌
#   1970-01-01  ✅
#   1970-01-01  ✅
# ]
```
Downcasting timeunits (eg: `us` → `ms`):
```python
s.cast(pl.Datetime("ms"))
# shape: (3,)
# Series: '' [datetime[ms]]
# [
#   1970-01-01 00:00:00  ❌
#   1970-01-01 00:00:00  ✅
#   1970-01-01 00:00:00  ✅
# ]
```
Extracting the time (or casting to time):
```python
s.dt.time()
# pyo3_runtime.PanicException: invalid time ❌
```

## Fixes

* Downcasting (datetime to date, or from higher to lower precision) can be fixed by using floor division instead. Note that`div_floor` is unstable, but `div_euclid` is not - the two are equivalent with respect to the quotient (though not the remainder, which we don't need here) so I used that rather than enable the unstable "int_roundings" feature. 

* Fixing the time extract/cast involves checking that our scaled mod remainder is not `0`, otherwise we end up with the equivalent of `24:00:00`, which is invalid and panics ;)

## Performance

Tested downcasting 200 _million_ datetimes to date (with a native release build), and there was no visible change; total time taken was about 0.85 secs before/after the switch to `div_euclid`🔥

## Cleanup

To avoid the calculations being copy/pasted between all of the various dtype/timeunit match branches I tweaked the match conditions to result in a single _functional_ path for each relevant permutation so the fix(es) could be made in one place and more easily reasoned about.

## New coverage

* Added a parametric test to ensure these ops will get more testing either side of the epoch.
* Also added an explicit test along the lines of the above example.