### PR TITLE
perf: improve skip row group using statistics condition

### DIFF
--- a/crates/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -517,9 +517,10 @@ impl ApplyExpr {
                         return one_equals(min);
                     }
 
-                    let all_smaller = || Some(ChunkCompare::lt(input, min).ok()?.all());
-                    let all_bigger = || Some(ChunkCompare::gt(input, max).ok()?.all());
-                    Some(!all_smaller()? && !all_bigger()?)
+                    let smaller = ChunkCompare::lt(input, min).ok()?;
+                    let bigger = ChunkCompare::gt(input, max).ok()?;
+
+                    Some(!(smaller | bigger).all())
                 };
 
                 Ok(should_read().unwrap_or(true))

--- a/crates/polars-lazy/src/tests/io.rs
+++ b/crates/polars-lazy/src/tests/io.rs
@@ -97,6 +97,12 @@ fn test_parquet_statistics() -> PolarsResult<()> {
         .collect()?;
     assert_eq!(out.shape(), (0, 4));
 
+    // issue: 13427
+    let out = scan_foods_parquet(par)
+        .filter(col("calories").is_in(lit(Series::new("", [0, 500]))))
+        .collect()?;
+    assert_eq!(out.shape(), (0, 4));
+
     let out = scan_foods_parquet(par)
         .filter(lit(1000i32).lt(col("calories")))
         .collect()?;


### PR DESCRIPTION
Fixes: [13427](https://github.com/pola-rs/polars/issues/13427)

Old code skipped row groups only if values passed to `is_in` are _ALL_ under min or _ALL_ above max. Imroved to skip if _ALL_ values are either under min or above max