### PR TITLE
docs(python): fix more docstring bullet points

### DIFF
--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -608,7 +608,7 @@ class Config(contextlib.ContextDecorator):
             How to format floating point numbers:
 
             - "mixed": Limit the number of decimal places and use scientific
-                notation for large/small values.
+              notation for large/small values.
             - "full": Print the full precision of the floating point number.
 
         Examples

--- a/py-polars/polars/expr/categorical.py
+++ b/py-polars/polars/expr/categorical.py
@@ -34,7 +34,7 @@ class ExprCatNameSpace:
             Ordering type:
 
             - 'physical' -> Use the physical representation of the categories to
-                determine the order (default).
+              determine the order (default).
             - 'lexical' -> Use the string values to determine the ordering.
         """
         return wrap_expr(self._pyexpr.cat_set_ordering(ordering))

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -9428,10 +9428,10 @@ class Expr:
 
             - 'thread_local': run the python function on a single thread.
             - 'threading': run the python function on separate threads. Use with
-                        care as this can slow performance. This might only speed up
-                        your code if the amount of work per element is significant
-                        and the python function releases the GIL (e.g. via calling
-                        a c function)
+              care as this can slow performance. This might only speed up
+              your code if the amount of work per element is significant
+              and the python function releases the GIL (e.g. via calling
+              a c function)
         """
         return self.map_elements(
             function,

--- a/py-polars/polars/series/categorical.py
+++ b/py-polars/polars/series/categorical.py
@@ -43,7 +43,7 @@ class CatNameSpace:
             Ordering type:
 
             - 'physical' -> Use the physical representation of the categories to
-                determine the order (default).
+              determine the order (default).
             - 'lexical' -> Use the string values to determine the ordering.
         """
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -486,9 +486,9 @@ class Series:
             the physical data type of `dtype`. Some data types require multiple buffers:
 
             - `String`: A data buffer of type `UInt8` and an offsets buffer
-                        of type `Int64`. Note that this does not match how the data
-                        is represented internally and data copy is required to construct
-                        the Series.
+              of type `Int64`. Note that this does not match how the data
+              is represented internally and data copy is required to construct
+              the Series.
         validity
             Validity buffer. If specified, must be a Series of data type `Boolean`.
 


### PR DESCRIPTION
Docstring bullet points not rendering as expected  strike again

## Before

![image](https://github.com/pola-rs/polars/assets/33491632/2a5ebbdd-3262-4f8d-999c-a17a103785c0)


## After

![image](https://github.com/pola-rs/polars/assets/33491632/cf803968-f57c-4c4d-baec-6753ca4c36c7)

(and similarly for the others)