### PR TITLE
feat(python): raise more informative error message if someone lands on Expr.__bool__

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -143,8 +143,13 @@ class Expr:
     def __bool__(self) -> NoReturn:
         msg = (
             "the truth value of an Expr is ambiguous"
-            "\n\nHint: use '&' or '|' to logically combine Expr, not 'and'/'or', and"
-            " use `x.is_in([y,z])` instead of `x in [y,z]` to check membership."
+            "\n\n"
+            "You probably got here by using a Python standard library function instead "
+            "of the native expressions API.\n"
+            "Here are some things you might want to try:\n"
+            "- instead of `pl.col('a') and pl.col('b')`, use `pl.col('a') & pl.col('b')`\n"
+            "- instead of `pl.col('a') in [y, z]`, use `pl.col('a').is_in([y, z])`\n"
+            "- instead of `max(pl.col('a'), pl.col('b'))`, use `pl.max_horizontal(pl.col('a'), pl.col('b'))`\n"
         )
         raise TypeError(msg)
 


### PR DESCRIPTION
xref https://github.com/pola-rs/polars/issues/14062

Landing on `Expr.__bool__` is so common, because `if expr:` triggers `expr.__bool__`, and people often have no idea why they're seeing this error message at all

I'd suggest making the error message a bit rustier

Here's what the err message looks like now
```ipython
TypeError: the truth value of an Expr is ambiguous

You probably got here by using a Python standard library function instead of the native expressions API.
Here are some things you might want to try:
- instead of `pl.col('a') and pl.col('b')`, use `pl.col('a') & pl.col('b')`
- instead of `pl.col('a') in [y, z]`, use `pl.col('a').is_in([y, z])`
- instead of `max(pl.col('a'), pl.col('b'))`, use `pl.max_horizontal(pl.col('a'), pl.col('b'))`
```