### PR TITLE
feat(python): Allow renaming expressions with keyword syntax in `group_by`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9193,7 +9193,7 @@ class DataFrame:
         In aggregate context there is also an equivalent method for returning the
         unique values per-group:
 
-        >>> df_agg_nunique = df.group_by(by=["a"]).n_unique()
+        >>> df_agg_nunique = df.group_by(["a"]).n_unique()
 
         Examples
         --------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5362,6 +5362,7 @@ class DataFrame:
         """
         return self.with_row_index(name, offset)
 
+    @deprecate_parameter_as_positional("by", version="0.20.7")
     def group_by(
         self,
         *by: IntoExpr | Iterable[IntoExpr],

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5377,19 +5377,18 @@ class DataFrame:
         *by
             Column(s) to group by. Accepts expression input. Strings are parsed as
             column names.
-
         maintain_order
             Ensure that the order of the groups is consistent with the input data.
             This is slower than a default group by.
             Settings this to `True` blocks the possibility
             to run on the streaming engine.
-        **named_by
-            Additional column(s) to group by, specified as keyword arguments.
-            The columns will be named as the keyword used.
 
             .. note::
                 Within each group, the order of rows is always preserved, regardless
                 of this argument.
+        **named_by
+            Additional columns to group by, specified as keyword arguments.
+            The columns will be renamed to the keyword used.
 
         Returns
         -------
@@ -10543,9 +10542,9 @@ class DataFrame:
     @deprecate_renamed_function("group_by", version="0.19.0")
     def groupby(
         self,
-        *by: IntoExpr | Iterable[IntoExpr],
+        by: IntoExpr | Iterable[IntoExpr],
+        *more_by: IntoExpr,
         maintain_order: bool = False,
-        **named_by: IntoExpr,
     ) -> GroupBy:
         """
         Start a group by operation.
@@ -10555,17 +10554,16 @@ class DataFrame:
 
         Parameters
         ----------
-        *by
+        by
             Column(s) to group by. Accepts expression input. Strings are parsed as
             column names.
+        *more_by
+            Additional columns to group by, specified as positional arguments.
         maintain_order
             Ensure that the order of the groups is consistent with the input data.
             This is slower than a default group by.
             Settings this to `True` blocks the possibility
             to run on the streaming engine.
-        **named_by
-            Additional column(s) to group by, specified as keyword arguments.
-            The columns will be named as the keyword used.
 
             .. note::
                 Within each group, the order of rows is always preserved, regardless
@@ -10576,7 +10574,7 @@ class DataFrame:
         GroupBy
             Object which can be used to perform aggregations.
         """
-        return self.group_by(*by, maintain_order=maintain_order, **named_by)
+        return self.group_by(by, *more_by, maintain_order=maintain_order)
 
     @deprecate_renamed_function("rolling", version="0.19.0")
     def groupby_rolling(

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5364,25 +5364,27 @@ class DataFrame:
 
     def group_by(
         self,
-        by: IntoExpr | Iterable[IntoExpr],
-        *more_by: IntoExpr,
+        *by: IntoExpr | Iterable[IntoExpr],
         maintain_order: bool = False,
+        **named_by: IntoExpr,
     ) -> GroupBy:
         """
         Start a group by operation.
 
         Parameters
         ----------
-        by
+        *by
             Column(s) to group by. Accepts expression input. Strings are parsed as
             column names.
-        *more_by
-            Additional columns to group by, specified as positional arguments.
+
         maintain_order
             Ensure that the order of the groups is consistent with the input data.
             This is slower than a default group by.
             Settings this to `True` blocks the possibility
             to run on the streaming engine.
+        **named_by
+            Additional column(s) to group by, specified as keyword arguments.
+            The columns will be named as the keyword used.
 
             .. note::
                 Within each group, the order of rows is always preserved, regardless
@@ -5498,7 +5500,7 @@ class DataFrame:
         │ c   ┆ 3   ┆ 1   │
         └─────┴─────┴─────┘
         """
-        return GroupBy(self, by, *more_by, maintain_order=maintain_order)
+        return GroupBy(self, *by, **named_by, maintain_order=maintain_order)
 
     def rolling(
         self,
@@ -10540,9 +10542,9 @@ class DataFrame:
     @deprecate_renamed_function("group_by", version="0.19.0")
     def groupby(
         self,
-        by: IntoExpr | Iterable[IntoExpr],
-        *more_by: IntoExpr,
+        *by: IntoExpr | Iterable[IntoExpr],
         maintain_order: bool = False,
+        **named_by: IntoExpr,
     ) -> GroupBy:
         """
         Start a group by operation.
@@ -10552,16 +10554,17 @@ class DataFrame:
 
         Parameters
         ----------
-        by
+        *by
             Column(s) to group by. Accepts expression input. Strings are parsed as
             column names.
-        *more_by
-            Additional columns to group by, specified as positional arguments.
         maintain_order
             Ensure that the order of the groups is consistent with the input data.
             This is slower than a default group by.
             Settings this to `True` blocks the possibility
             to run on the streaming engine.
+        **named_by
+            Additional column(s) to group by, specified as keyword arguments.
+            The columns will be named as the keyword used.
 
             .. note::
                 Within each group, the order of rows is always preserved, regardless
@@ -10572,7 +10575,7 @@ class DataFrame:
         GroupBy
             Object which can be used to perform aggregations.
         """
-        return self.group_by(by, *more_by, maintain_order=maintain_order)
+        return self.group_by(*by, maintain_order=maintain_order, **named_by)
 
     @deprecate_renamed_function("rolling", version="0.19.0")
     def groupby_rolling(

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -824,7 +824,7 @@ class RollingGroupBy:
         # When grouping by a single column, group name is a single value
         # When grouping by multiple columns, group name is a tuple of values
         self._group_names: Iterator[object] | Iterator[tuple[object, ...]]
-        if group_names.width == 1:
+        if self.by is None:
             self._group_names = iter(group_names.to_series())
         else:
             self._group_names = group_names.iter_rows()

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, Iterable, Iterator
 
 from polars import functions as F
+from polars.exceptions import InvalidOperationError
 from polars.utils.convert import _timedelta_to_pl_duration
 from polars.utils.deprecation import (
     deprecate_renamed_function,
@@ -35,9 +36,9 @@ class GroupBy:
     def __init__(
         self,
         df: DataFrame,
-        by: IntoExpr | Iterable[IntoExpr],
-        *more_by: IntoExpr,
+        *by: IntoExpr | Iterable[IntoExpr],
         maintain_order: bool,
+        **named_by: IntoExpr,
     ):
         """
         Utility class for performing a group by operation over the given DataFrame.
@@ -48,18 +49,19 @@ class GroupBy:
         ----------
         df
             DataFrame to perform the group by operation over.
-        by
+        *by
             Column or columns to group by. Accepts expression input. Strings are parsed
             as column names.
-        *more_by
-            Additional columns to group by, specified as positional arguments.
         maintain_order
             Ensure that the order of the groups is consistent with the input data.
             This is slower than a default group by.
+        **named_by
+            Additional column(s) to group by, specified as keyword arguments.
+            The columns will be named as the keyword used.
         """
         self.df = df
         self.by = by
-        self.more_by = more_by
+        self.named_by = named_by
         self.maintain_order = maintain_order
 
     def __iter__(self) -> Self:
@@ -99,7 +101,7 @@ class GroupBy:
         temp_col = "__POLARS_GB_GROUP_INDICES"
         groups_df = (
             self.df.lazy()
-            .group_by(self.by, *self.more_by, maintain_order=self.maintain_order)
+            .group_by(*self.by, maintain_order=self.maintain_order, **self.named_by)
             .agg(F.first().agg_groups().alias(temp_col))
             .collect(no_optimization=True)
         )
@@ -107,11 +109,13 @@ class GroupBy:
         group_names = groups_df.select(F.all().exclude(temp_col))
 
         self._group_names: Iterator[object] | Iterator[tuple[object, ...]]
-        key_as_single_value = isinstance(self.by, str) and not self.more_by
+        key_as_single_value = (
+            len(self.by) == 1 and isinstance(self.by[0], str) and not self.named_by
+        )
         if key_as_single_value:
             issue_deprecation_warning(
                 "`group_by` iteration will change to always return group identifiers as tuples."
-                f" Pass `by` as a list to silence this warning, e.g. `group_by([{self.by!r}])`.",
+                f" Pass `by` as a list to silence this warning, e.g. `group_by([{self.by[0]!r}])`.",
                 version="0.20.4",
             )
             self._group_names = iter(group_names.to_series())
@@ -242,7 +246,7 @@ class GroupBy:
         """
         return (
             self.df.lazy()
-            .group_by(self.by, *self.more_by, maintain_order=self.maintain_order)
+            .group_by(*self.by, maintain_order=self.maintain_order, **self.named_by)
             .agg(*aggs, **named_aggs)
             .collect(no_optimization=True)
         )
@@ -309,17 +313,11 @@ class GroupBy:
         ... )  # doctest: +IGNORE_RESULT
         """
         by: list[str]
-
-        if isinstance(self.by, str):
-            by = [self.by]
-        elif isinstance(self.by, Iterable) and all(isinstance(c, str) for c in self.by):
+        if self.named_by:
+            msg = "cannot call `map_groups` with named_by"
+            raise InvalidOperationError(msg)
+        if all(isinstance(c, str) for c in self.by):
             by = list(self.by)  # type: ignore[arg-type]
-        else:
-            msg = "cannot call `map_groups` when grouping by an expression"
-            raise TypeError(msg)
-
-        if all(isinstance(c, str) for c in self.more_by):
-            by.extend(self.more_by)  # type: ignore[arg-type]
         else:
             msg = "cannot call `map_groups` when grouping by an expression"
             raise TypeError(msg)
@@ -375,7 +373,7 @@ class GroupBy:
         """
         return (
             self.df.lazy()
-            .group_by(self.by, *self.more_by, maintain_order=self.maintain_order)
+            .group_by(*self.by, maintain_order=self.maintain_order, **self.named_by)
             .head(n)
             .collect(no_optimization=True)
         )
@@ -427,7 +425,7 @@ class GroupBy:
         """
         return (
             self.df.lazy()
-            .group_by(self.by, *self.more_by, maintain_order=self.maintain_order)
+            .group_by(*self.by, maintain_order=self.maintain_order, **self.named_by)
             .tail(n)
             .collect(no_optimization=True)
         )
@@ -828,7 +826,7 @@ class RollingGroupBy:
         # When grouping by a single column, group name is a single value
         # When grouping by multiple columns, group name is a tuple of values
         self._group_names: Iterator[object] | Iterator[tuple[object, ...]]
-        if self.by is None:
+        if group_names.width == 1:
             self._group_names = iter(group_names.to_series())
         else:
             self._group_names = group_names.iter_rows()

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3147,8 +3147,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             Setting this to `True` blocks the possibility
             to run on the streaming engine.
         **named_by
-            Additional column(s) to group by, specified as keyword arguments.
-            The columns will be named as the keyword used.
+            Additional columns to group by, specified as keyword arguments.
+            The columns will be renamed to the keyword used.
 
         Examples
         --------
@@ -6251,9 +6251,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @deprecate_renamed_function("group_by", version="0.19.0")
     def groupby(
         self,
-        *by: IntoExpr | Iterable[IntoExpr],
+        by: IntoExpr | Iterable[IntoExpr],
+        *more_by: IntoExpr,
         maintain_order: bool = False,
-        **named_by: IntoExpr,
     ) -> LazyGroupBy:
         """
         Start a group by operation.
@@ -6263,20 +6263,18 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Parameters
         ----------
-        *by
+        by
             Column(s) to group by. Accepts expression input. Strings are parsed as
             column names.
-
+        *more_by
+            Additional columns to group by, specified as positional arguments.
         maintain_order
             Ensure that the order of the groups is consistent with the input data.
             This is slower than a default group by.
             Settings this to `True` blocks the possibility
             to run on the streaming engine.
-        **named_by
-            Additional column(s) to group by, specified as keyword arguments.
-            The columns will be named as the keyword used.
         """
-        return self.group_by(*by, maintain_order=maintain_order, **named_by)
+        return self.group_by(by, *more_by, maintain_order=maintain_order)
 
     @deprecate_renamed_function("rolling", version="0.19.0")
     def groupby_rolling(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3128,25 +3128,26 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
     def group_by(
         self,
-        by: IntoExpr | Iterable[IntoExpr],
-        *more_by: IntoExpr,
+        *by: IntoExpr | Iterable[IntoExpr],
         maintain_order: bool = False,
+        **named_by: IntoExpr,
     ) -> LazyGroupBy:
         """
         Start a group by operation.
 
         Parameters
         ----------
-        by
+        *by
             Column(s) to group by. Accepts expression input. Strings are parsed as
             column names.
-        *more_by
-            Additional columns to group by, specified as positional arguments.
         maintain_order
             Ensure that the order of the groups is consistent with the input data.
             This is slower than a default group by.
             Setting this to `True` blocks the possibility
             to run on the streaming engine.
+        **named_by
+            Additional column(s) to group by, specified as keyword arguments.
+            The columns will be named as the keyword used.
 
         Examples
         --------
@@ -3219,7 +3220,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         │ c   ┆ 1   ┆ 1.0 │
         └─────┴─────┴─────┘
         """
-        exprs = parse_as_list_of_expressions(by, *more_by)
+        exprs = parse_as_list_of_expressions(*by, **named_by)
         lgb = self._ldf.group_by(exprs, maintain_order)
         return LazyGroupBy(lgb)
 
@@ -6249,9 +6250,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
     @deprecate_renamed_function("group_by", version="0.19.0")
     def groupby(
         self,
-        by: IntoExpr | Iterable[IntoExpr],
-        *more_by: IntoExpr,
+        *by: IntoExpr | Iterable[IntoExpr],
         maintain_order: bool = False,
+        **named_by: IntoExpr,
     ) -> LazyGroupBy:
         """
         Start a group by operation.
@@ -6261,18 +6262,20 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
 
         Parameters
         ----------
-        by
+        *by
             Column(s) to group by. Accepts expression input. Strings are parsed as
             column names.
-        *more_by
-            Additional columns to group by, specified as positional arguments.
+
         maintain_order
             Ensure that the order of the groups is consistent with the input data.
             This is slower than a default group by.
             Settings this to `True` blocks the possibility
             to run on the streaming engine.
+        **named_by
+            Additional column(s) to group by, specified as keyword arguments.
+            The columns will be named as the keyword used.
         """
-        return self.group_by(by, *more_by, maintain_order=maintain_order)
+        return self.group_by(*by, maintain_order=maintain_order, **named_by)
 
     @deprecate_renamed_function("rolling", version="0.19.0")
     def groupby_rolling(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3126,6 +3126,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         )
         return self._from_pyldf(self._ldf.select_seq(pyexprs))
 
+    @deprecate_parameter_as_positional("by", version="0.20.7")
     def group_by(
         self,
         *by: IntoExpr | Iterable[IntoExpr],

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3334,3 +3334,13 @@ def test_iter_columns() -> None:
     iter_columns = df.iter_columns()
     assert_series_equal(next(iter_columns), pl.Series("a", [1, 1, 2]))
     assert_series_equal(next(iter_columns), pl.Series("b", [4, 5, 6]))
+
+
+def test_group_by_named() -> None:
+    df = pl.DataFrame({"a": [1, 1, 2, 2, 3, 3], "b": range(6)})
+    assert_frame_equal(
+        df.group_by(z=pl.col("a") * 2, maintain_order=True).agg(pl.col("b").min()),
+        df.group_by((pl.col("a") * 2).alias("z"), maintain_order=True).agg(
+            pl.col("b").min()
+        ),
+    )

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3334,13 +3334,3 @@ def test_iter_columns() -> None:
     iter_columns = df.iter_columns()
     assert_series_equal(next(iter_columns), pl.Series("a", [1, 1, 2]))
     assert_series_equal(next(iter_columns), pl.Series("b", [4, 5, 6]))
-
-
-def test_group_by_named() -> None:
-    df = pl.DataFrame({"a": [1, 1, 2, 2, 3, 3], "b": range(6)})
-    assert_frame_equal(
-        df.group_by(z=pl.col("a") * 2, maintain_order=True).agg(pl.col("b").min()),
-        df.group_by((pl.col("a") * 2).alias("z"), maintain_order=True).agg(
-            pl.col("b").min()
-        ),
-    )

--- a/py-polars/tests/unit/datatypes/test_categorical.py
+++ b/py-polars/tests/unit/datatypes/test_categorical.py
@@ -574,9 +574,9 @@ def test_nested_categorical_aggregation_7848() -> None:
             "letter": ["a", "b", "c", "d", "e", "f", "g"],
         }
     ).with_columns([pl.col("letter").cast(pl.Categorical)]).group_by(
-        maintain_order=True, by=["group"]
+        "group", maintain_order=True
     ).all().with_columns(pl.col("letter").list.len().alias("c_group")).group_by(
-        by=["c_group"], maintain_order=True
+        ["c_group"], maintain_order=True
     ).agg(pl.col("letter")).to_dict(as_series=False) == {
         "c_group": [2, 3],
         "letter": [[["a", "b"], ["f", "g"]], [["c", "d", "e"]]],

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -387,7 +387,7 @@ def test_agg_filter_over_empty_df_13610() -> None:
 
     out = (
         ldf.drop_nulls()
-        .group_by(by=["a"], maintain_order=True)
+        .group_by(["a"], maintain_order=True)
         .agg(pl.col("b").filter(pl.col("b").shift(1)))
         .collect()
     )

--- a/py-polars/tests/unit/operations/test_group_by.py
+++ b/py-polars/tests/unit/operations/test_group_by.py
@@ -917,3 +917,24 @@ def test_group_by_all_12869() -> None:
     df = pl.DataFrame({"a": [1]})
     result = next(iter(df.group_by(pl.all())))[1]
     assert_frame_equal(df, result)
+
+
+def test_group_by_named() -> None:
+    df = pl.DataFrame({"a": [1, 1, 2, 2, 3, 3], "b": range(6)})
+    result = df.group_by(z=pl.col("a") * 2, maintain_order=True).agg(pl.col("b").min())
+    expected = df.group_by((pl.col("a") * 2).alias("z"), maintain_order=True).agg(
+        pl.col("b").min()
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_group_by_deprecated_by_arg() -> None:
+    df = pl.DataFrame({"a": [1, 1, 2, 2, 3, 3], "b": range(6)})
+    with pytest.deprecated_call():
+        result = df.group_by(by=(pl.col("a") * 2), maintain_order=True).agg(
+            pl.col("b").min()
+        )
+    expected = df.group_by((pl.col("a") * 2), maintain_order=True).agg(
+        pl.col("b").min()
+    )
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -629,6 +629,6 @@ def test_literal_subtract_schema_13284() -> None:
     assert (
         pl.LazyFrame({"a": [23, 30]}, schema={"a": pl.UInt8})
         .with_columns(pl.col("a") - pl.lit(1))
-        .group_by(by="a")
+        .group_by("a")
         .len()
     ).schema == OrderedDict([("a", pl.UInt8), ("len", pl.UInt32)])


### PR DESCRIPTION
@stinodego Replacing [this](https://github.com/pola-rs/polars/pull/13415) one from a clean slate.

fixes https://github.com/pola-rs/polars/issues/11957