### PR TITLE
docs(rust): Remove outdated reference to horizontal concat feature

### DIFF
--- a/crates/polars-lazy/Cargo.toml
+++ b/crates/polars-lazy/Cargo.toml
@@ -244,7 +244,6 @@ features = [
   "fused",
   "futures",
   "hist",
-  "horizontal_concat",
   "interpolate",
   "ipc",
   "is_first_distinct",

--- a/crates/polars/src/lib.rs
+++ b/crates/polars/src/lib.rs
@@ -230,7 +230,6 @@
 //!     - `group_by_list` - Allow group_by operation on keys of type List.
 //!     - `row_hash` - Utility to hash [`DataFrame`] rows to [`UInt64Chunked`]
 //!     - `diagonal_concat` - Concat diagonally thereby combining different schemas.
-//!     - `horizontal_concat` - Concat horizontally and extend with null values if lengths don't match
 //!     - `dataframe_arithmetic` - Arithmetic on ([`Dataframe`] and [`DataFrame`]s) and ([`DataFrame`] on [`Series`])
 //!     - `partition_by` - Split into multiple [`DataFrame`]s partitioned by groups.
 //! * [`Series`]/[`Expr`] operations:

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -128,7 +128,6 @@ The opt-in features are:
     - `group_by_list` - Allow group by operation on keys of type List.
     - `row_hash` - Utility to hash DataFrame rows to UInt64Chunked
     - `diagonal_concat` - Concat diagonally thereby combining different schemas.
-    - `horizontal_concat` - Concat horizontally and extend with null values if lengths don't match
     - `dataframe_arithmetic` - Arithmetic on (Dataframe and DataFrames) and (DataFrame on Series)
     - `partition_by` - Split into multiple DataFrames partitioned by groups.
 - `Series`/`Expression` operations:


### PR DESCRIPTION
Closes #14104

Feature flag was removed in #13390, apparently there were some remnants.