### PR TITLE
perf: elide unneeded work in window?

### DIFF
--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -685,20 +685,6 @@ where
     T: PolarsNumericType,
     ChunkedArray<T>: IntoSeries,
 {
-    let mut idx_mapping = Vec::with_capacity(len);
-    let mut iter = 0..len as IdxSize;
-    match groups {
-        GroupsProxy::Idx(groups) => {
-            for g in groups.all() {
-                idx_mapping.extend((&mut iter).take(g.len()).zip(g.iter().copied()));
-            }
-        },
-        GroupsProxy::Slice { groups, .. } => {
-            for &[first, len] in groups {
-                idx_mapping.extend((&mut iter).take(len as usize).zip(first..first + len));
-            }
-        },
-    }
     let mut values = Vec::with_capacity(len);
     let ptr: *mut T::Native = values.as_mut_ptr();
     // safety:


### PR DESCRIPTION
Very surprised the compiler didn't warn about this. Wonder if this was in the final binary, but it was completely unneeded work.