### PR TITLE
feat: Implement `min`/`max` for categorical dtype

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -536,8 +536,11 @@ impl CategoricalChunked {
                     .min()
             }
         } else {
-            let min_idx = self.physical().min().unwrap();
-            self.get_rev_map().get_categories().get(min_idx as usize)
+            // SAFETY
+            // Indices are in bounds
+            self.physical()
+                .min()
+                .map(|el| unsafe { self.get_rev_map().get_unchecked(el) })
         }
     }
 
@@ -561,8 +564,11 @@ impl CategoricalChunked {
                     .max()
             }
         } else {
-            let max_idx = self.physical().max().unwrap();
-            self.get_rev_map().get_categories().get(max_idx as usize)
+            // SAFETY
+            // Indices are in bounds
+            self.physical()
+                .max()
+                .map(|el| unsafe { self.get_rev_map().get_unchecked(el) })
         }
     }
 }

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -288,6 +288,14 @@ impl SeriesTrait for SeriesWrap<CategoricalChunked> {
     fn clone_inner(&self) -> Arc<dyn SeriesTrait> {
         Arc::new(SeriesWrap(Clone::clone(&self.0)))
     }
+
+    fn min_as_series(&self) -> PolarsResult<Series> {
+        Ok(ChunkAggSeries::min_as_series(&self.0))
+    }
+
+    fn max_as_series(&self) -> PolarsResult<Series> {
+        Ok(ChunkAggSeries::max_as_series(&self.0))
+    }
 }
 
 impl private::PrivateSeriesNumeric for SeriesWrap<CategoricalChunked> {

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -375,38 +375,21 @@ def test_date_agg() -> None:
     assert series.max() == date(9009, 9, 9)
 
 
-def test_categorical_agg() -> None:
-    s = pl.Series(["aa", "cc", "bb"], dtype=pl.Categorical("lexical"))
-    assert s.min() == "aa"
-    assert s.max() == "cc"
-
-    s = pl.Series(["aa", "cc", "bb"], dtype=pl.Categorical)
-    assert s.min() == "aa"
-    assert s.max() == "bb"
-
-    # with nulls
-    s = pl.Series([None, "aa", "cc", None, "bb", None], dtype=pl.Categorical("lexical"))
-    assert s.min() == "aa"
-    assert s.max() == "cc"
-
-    s = pl.Series([None, "cc", "aa", None, "bb", None], dtype=pl.Categorical)
-    assert s.min() == "cc"
-    assert s.max() == "bb"
-
-    # empty
-    s = pl.Series([], dtype=pl.Categorical("lexical"))
-    assert s.min() is None
-    assert s.max() is None
-
-    # Enum
-    s = pl.Series(["cc", "bb", "aa"], dtype=pl.Enum(["cc", "bb", "aa"]))
-    assert s.min() == "cc"
-    assert s.max() == "aa"
-
-    # Enum not all categories used
-    s = pl.Series(["cc", "bb", "aa"], dtype=pl.Enum(["cc", "bb", "aa", "dd"]))
-    assert s.min() == "cc"
-    assert s.max() == "aa"
+@pytest.mark.parametrize(
+    ("s", "min", "max"),
+    [
+        (pl.Series(["c", "b", "a"], dtype=pl.Categorical("lexical")), "a", "c"),
+        (pl.Series(["a", "c", "b"], dtype=pl.Categorical), "a", "b"),
+        (pl.Series([None, "a", "c", "b"], dtype=pl.Categorical("lexical")), "a", "c"),
+        (pl.Series([None, "c", "a", "b"], dtype=pl.Categorical), "c", "b"),
+        (pl.Series([], dtype=pl.Categorical("lexical")), None, None),
+        (pl.Series(["c", "b", "a"], dtype=pl.Enum(["c", "b", "a"])), "c", "a"),
+        (pl.Series(["c", "b", "a"], dtype=pl.Enum(["c", "b", "a", "d"])), "c", "a"),
+    ],
+)
+def test_categorical_agg(s: pl.Series, min: str | None, max: str | None) -> None:
+    assert s.min() == min
+    assert s.max() == max
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -375,6 +375,40 @@ def test_date_agg() -> None:
     assert series.max() == date(9009, 9, 9)
 
 
+def test_categorical_agg() -> None:
+    s = pl.Series(["aa", "cc", "bb"], dtype=pl.Categorical("lexical"))
+    assert s.min() == "aa"
+    assert s.max() == "cc"
+
+    s = pl.Series(["aa", "cc", "bb"], dtype=pl.Categorical)
+    assert s.min() == "aa"
+    assert s.max() == "bb"
+
+    # with nulls
+    s = pl.Series([None, "aa", "cc", None, "bb", None], dtype=pl.Categorical("lexical"))
+    assert s.min() == "aa"
+    assert s.max() == "cc"
+
+    s = pl.Series([None, "cc", "aa", None, "bb", None], dtype=pl.Categorical)
+    assert s.min() == "cc"
+    assert s.max() == "bb"
+
+    # empty
+    s = pl.Series([], dtype=pl.Categorical("lexical"))
+    assert s.min() is None
+    assert s.max() is None
+
+    # Enum
+    s = pl.Series(["cc", "bb", "aa"], dtype=pl.Enum(["cc", "bb", "aa"]))
+    assert s.min() == "cc"
+    assert s.max() == "aa"
+
+    # Enum not all categories used
+    s = pl.Series(["cc", "bb", "aa"], dtype=pl.Enum(["cc", "bb", "aa", "dd"]))
+    assert s.min() == "cc"
+    assert s.max() == "aa"
+
+
 @pytest.mark.parametrize(
     "s", [pl.Series([1, 2], dtype=Int64), pl.Series([1, 2], dtype=Float64)]
 )


### PR DESCRIPTION
Implements `Series.min`/`max` for categoricals as follows:

 - `ordering="lexical"` behaves just like `dtype=pl.String`.
 - `ordering="physical"` returns the first (last for max) non-null value in the series.