### PR TITLE
fix(python,rust): fix read_csv date/datetime inference and parsing

### DIFF
--- a/crates/polars-io/src/csv/buffer.rs
+++ b/crates/polars-io/src/csv/buffer.rs
@@ -416,7 +416,7 @@ where
         _missing_is_null: bool,
         time_unit: Option<TimeUnit>,
     ) -> PolarsResult<()> {
-        if needs_escaping {
+        if needs_escaping && bytes.len() >= 2 {
             bytes = &bytes[1..bytes.len() - 1]
         }
 

--- a/crates/polars-io/src/csv/buffer.rs
+++ b/crates/polars-io/src/csv/buffer.rs
@@ -369,7 +369,7 @@ where
                     buf.builder.append_null();
                     return Ok(());
                 } else {
-                    polars_bail!(ComputeError: "could not find a 'date/datetime' pattern for {}", val)
+                    polars_bail!(ComputeError: "could not find a 'date/datetime' pattern for '{}'", val)
                 }
             },
         },
@@ -377,8 +377,17 @@ where
     match DatetimeInfer::try_from_with_unit(pattern, time_unit) {
         Ok(mut infer) => {
             let parsed = infer.parse(val);
+            let Some(parsed) = parsed else {
+                if ignore_errors {
+                    buf.builder.append_null();
+                    return Ok(());
+                } else {
+                    polars_bail!(ComputeError: "could not parse '{}' with pattern '{:?}'", val, pattern)
+                }
+            };
+
             buf.compiled = Some(infer);
-            buf.builder.append_option(parsed);
+            buf.builder.append_value(parsed);
             Ok(())
         },
         Err(err) => {
@@ -407,8 +416,14 @@ where
         _missing_is_null: bool,
         time_unit: Option<TimeUnit>,
     ) -> PolarsResult<()> {
-        if needs_escaping && bytes.len() > 2 {
+        if needs_escaping {
             bytes = &bytes[1..bytes.len() - 1]
+        }
+
+        if bytes.is_empty() {
+            // for types other than string `_missing_is_null` is irrelevant; we always append null
+            self.builder.append_null();
+            return Ok(());
         }
 
         match &mut self.compiled {

--- a/crates/polars-io/src/csv/utils.rs
+++ b/crates/polars-io/src/csv/utils.rs
@@ -392,21 +392,6 @@ pub fn infer_file_schema_inner(
                 {
                     // we have an integer and double, fall down to double
                     fields.push(Field::new(field_name, DataType::Float64));
-                }
-                // prefer a datelike parse above a no parse so choose the date type
-                else if possibilities.contains(&DataType::String)
-                    && possibilities.contains(&DataType::Date)
-                {
-                    fields.push(Field::new(field_name, DataType::Date));
-                }
-                // prefer a datelike parse above a no parse so choose the date type
-                else if possibilities.contains(&DataType::String)
-                    && possibilities.contains(&DataType::Datetime(TimeUnit::Microseconds, None))
-                {
-                    fields.push(Field::new(
-                        field_name,
-                        DataType::Datetime(TimeUnit::Microseconds, None),
-                    ));
                 } else {
                     // default to String for conflicting datatypes (e.g bool and int)
                     fields.push(Field::new(field_name, DataType::String));

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -1120,7 +1120,7 @@ fn test_try_parse_dates() -> PolarsResult<()> {
 1742-03-21
 1743-06-16
 1730-07-22
-''
+
 1739-03-16
 ";
     let file = Cursor::new(csv);


### PR DESCRIPTION
fix #14064 (maybe a few more. will check)

fix a few issues and inconsistencies regarding date/datetime parsing/inference using `read_csv`.

# Fix 1: only infer date/datetime if no other dtypes are present

current logic:
- column contains only type `T` -> infer type `T` ✅ 
- column contains `Int64` and `Float64` -> infer type `Float64` ✅ 
- column contains at least 1x `Date/DateTime` and any amount of `String` -> infer type `Date/DateTime` 💥  (PROBLEM, inconsistent)

new logic for date/datetime:
- only infer type `Date/DateTime` if no other dtypes are present (like for the other types)

Example:
```python
DATA = """d
2024-01-01
apple
banana
orange
"""

pl.read_csv(
    source=DATA.encode(),
    try_parse_dates=True,
)
```

Current/old output:
```
shape: (4, 1)
┌────────────┐
│ d          │
│ ---        │
│ date       │ >>>>> PROBLEM: should be str
╞════════════╡
│ 2024-01-01 │
│ null       │
│ null       │
│ null       │
└────────────┘
```

New output:
```
shape: (4, 1)
┌────────────┐
│ d          │
│ ---        │
│ str        │ >>>>> Corrrect!
╞════════════╡
│ 2024-01-01 │
│ apple      │
│ banana     │
│ orange     │
└────────────┘
```

- you can still get a data/datetime column using `dtypes` (consistent with other types)

# Fix 2: Respect `ignore_errors` flag when dtype=Date/DateTime

current logic (bug):
- when the first row gets successfully parsed into a date/datetime all following rows can NEVER raise an error (even if `ignore_errors=False`) and will silently set all invalid values to `null`

new logic:
- if any row cannot be parsed into a date/datetime and `ignore_errors=False` -> raise error (just like for all other dtypes)

Example:
```python
DATA = """d
2024-01-01
apple
banana
orange
"""

pl.read_csv(
    source=DATA.encode(),
    dtypes={"d": pl.Date},
)
```

Current/old output:
```
shape: (4, 1)
┌────────────┐
│ d          │
│ ---        │
│ date       │
╞════════════╡
│ 2024-01-01 │
│ null       │ >>>>> Should raise error because `ignore_errors=False`
│ null       │ >>>>> Should raise error because `ignore_errors=False`
│ null       │ >>>>> Should raise error because `ignore_errors=False`
└────────────┘
```

New output:
```
ComputeError: could not parse `apple` as dtype `date` at column 'd' (column number 1)
```

# Summary

- make inference and parsing of date/datetime consistent with other types
- if multiple types in a column -> str type
- parsing error
  - `ignore_errors=False` -> raise
  - `ignore_errors=True` -> `null`