### PR TITLE
docs(python): Fix description of `return_dtype` parameter for `map_elements` and `map_batches`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -4037,6 +4037,8 @@ class Expr:
             Lambda/function to apply.
         return_dtype
             Dtype of the output Series.
+            If not set, the dtype will be inferred based on the first non-null value
+            that is returned by the function.
         is_elementwise
             If set to true this can run in the streaming engine, but may yield
             incorrect results in group-by. Ensure you know what you are doing!
@@ -4161,7 +4163,8 @@ class Expr:
             Lambda/function to map.
         return_dtype
             Dtype of the output Series.
-            If not set, the dtype will be `pl.Unknown`.
+            If not set, the dtype will be inferred based on the first non-null value
+            that is returned by the function.
         skip_nulls
             Don't map the function over values that contain nulls (this is faster).
         pass_name

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -5271,8 +5271,9 @@ class Series:
         function
             Custom function or lambda.
         return_dtype
-            Output datatype. If none is given, the same datatype as this Series will be
-            used.
+            Output datatype.
+            If not set, the dtype will be inferred based on the first non-null value
+            that is returned by the function.
         skip_nulls
             Nulls will be skipped and not passed to the python function.
             This is faster because python can be skipped and because we call


### PR DESCRIPTION
fixes https://github.com/pola-rs/polars/issues/14096

the [user-guide](https://docs.pola.rs/user-guide/expressions/user-defined-functions/#return-types) was already correct.