### PR TITLE
fix: ignore comments at beginning of csv if schema provided

### DIFF
--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -290,6 +290,12 @@ impl<'a> CoreReader<'a> {
                 bytes = &bytes[pos..];
             }
         }
+
+        // skip lines that are comments
+        while is_comment_line(bytes, self.comment_prefix.as_ref()) {
+            bytes = skip_this_line(bytes, quote_char, eol_char);
+        }
+
         // skip header row
         if self.has_header {
             bytes = skip_this_line(bytes, quote_char, eol_char);

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1537,6 +1537,24 @@ def test_read_csv_n_rows_outside_heuristic() -> None:
     assert pl.read_csv(f, n_rows=2048, has_header=False).shape == (2048, 4)
 
 
+def test_read_csv_comments_on_top_with_schema_11667() -> None:
+    csv = """
+# This is a comment
+A,B
+1,Hello
+2,World
+""".strip()
+
+    schema = {
+        "A": pl.Int32(),
+        "B": pl.Utf8(),
+    }
+
+    df = pl.read_csv(io.StringIO(csv), comment_prefix="#", schema=schema)
+    assert len(df) == 2
+    assert df.schema == schema
+
+
 def test_write_csv_stdout_stderr(capsys: pytest.CaptureFixture[str]) -> None:
     # The capsys fixture allows pytest to access stdout/stderr. See
     # https://docs.pytest.org/en/7.1.x/how-to/capture-stdout-stderr.html


### PR DESCRIPTION
Fixes: https://github.com/pola-rs/polars/issues/11667

Comment were not ignored at the beginning of the csv file if the schema was provided; I changed to skip all comments at that point.