### PR TITLE
fix: Implements `gt/lt` cmp for null dtype

### DIFF
--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -13,6 +13,7 @@ use num_traits::{NumCast, ToPrimitive};
 use polars_compute::comparisons::TotalOrdKernel;
 
 use crate::prelude::*;
+use crate::series::implementations::null::NullChunked;
 use crate::series::IsSorted;
 
 impl<T> ChunkCompare<&ChunkedArray<T>> for ChunkedArray<T>
@@ -164,6 +165,52 @@ where
 
     fn gt_eq(&self, rhs: &Self) -> BooleanChunked {
         rhs.lt_eq(self)
+    }
+}
+
+impl ChunkCompare<&NullChunked> for NullChunked {
+    type Item = BooleanChunked;
+
+    fn equal(&self, rhs: &NullChunked) -> Self::Item {
+        BooleanChunked::full_null(self.name(), get_broadcast_length(self, rhs))
+    }
+
+    fn equal_missing(&self, rhs: &NullChunked) -> Self::Item {
+        BooleanChunked::full(self.name(), true, get_broadcast_length(self, rhs))
+    }
+
+    fn not_equal(&self, rhs: &NullChunked) -> Self::Item {
+        BooleanChunked::full_null(self.name(), get_broadcast_length(self, rhs))
+    }
+
+    fn not_equal_missing(&self, rhs: &NullChunked) -> Self::Item {
+        BooleanChunked::full(self.name(), false, get_broadcast_length(self, rhs))
+    }
+
+    fn gt(&self, rhs: &NullChunked) -> Self::Item {
+        BooleanChunked::full_null(self.name(), get_broadcast_length(self, rhs))
+    }
+
+    fn gt_eq(&self, rhs: &NullChunked) -> Self::Item {
+        BooleanChunked::full_null(self.name(), get_broadcast_length(self, rhs))
+    }
+
+    fn lt(&self, rhs: &NullChunked) -> Self::Item {
+        BooleanChunked::full_null(self.name(), get_broadcast_length(self, rhs))
+    }
+
+    fn lt_eq(&self, rhs: &NullChunked) -> Self::Item {
+        BooleanChunked::full_null(self.name(), get_broadcast_length(self, rhs))
+    }
+}
+
+#[inline]
+fn get_broadcast_length(lhs: &NullChunked, rhs: &NullChunked) -> usize {
+    match (lhs.len(), rhs.len()) {
+        (1, len_r) => len_r,
+        (len_l, 1) => len_l,
+        (len_l, len_r) if len_l == len_r => len_l,
+        _ => panic!("Cannot compare two series of different lengths."),
     }
 }
 

--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -45,6 +45,7 @@ macro_rules! impl_compare {
         let lhs = lhs.to_physical_repr();
         let rhs = rhs.to_physical_repr();
         let mut out = match lhs.dtype() {
+            Null => lhs.null().unwrap().$method(rhs.null().unwrap()),
             Boolean => lhs.bool().unwrap().$method(rhs.bool().unwrap()),
             String => lhs.str().unwrap().$method(rhs.str().unwrap()),
             Binary => lhs.binary().unwrap().$method(rhs.binary().unwrap()),
@@ -97,82 +98,42 @@ impl ChunkCompare<&Series> for Series {
 
     /// Create a boolean mask by checking for equality.
     fn equal(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        match (self.dtype(), rhs.dtype()) {
-            (DataType::Null, DataType::Null) => {
-                Ok(BooleanChunked::full_null(self.name(), self.len()))
-            },
-            _ => impl_compare!(self, rhs, equal),
-        }
+        impl_compare!(self, rhs, equal)
     }
 
     /// Create a boolean mask by checking for equality.
     fn equal_missing(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        match (self.dtype(), rhs.dtype()) {
-            (DataType::Null, DataType::Null) => {
-                Ok(BooleanChunked::full(self.name(), true, self.len()))
-            },
-            _ => impl_compare!(self, rhs, equal_missing),
-        }
+        impl_compare!(self, rhs, equal_missing)
     }
 
     /// Create a boolean mask by checking for inequality.
     fn not_equal(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        match (self.dtype(), rhs.dtype()) {
-            (DataType::Null, DataType::Null) => {
-                Ok(BooleanChunked::full_null(self.name(), self.len()))
-            },
-            _ => impl_compare!(self, rhs, not_equal),
-        }
+        impl_compare!(self, rhs, not_equal)
     }
 
     /// Create a boolean mask by checking for inequality.
     fn not_equal_missing(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        match (self.dtype(), rhs.dtype()) {
-            (DataType::Null, DataType::Null) => {
-                Ok(BooleanChunked::full(self.name(), false, self.len()))
-            },
-            _ => impl_compare!(self, rhs, not_equal_missing),
-        }
+        impl_compare!(self, rhs, not_equal_missing)
     }
 
     /// Create a boolean mask by checking if self > rhs.
     fn gt(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        match (self.dtype(), rhs.dtype()) {
-            (DataType::Null, DataType::Null) => {
-                Ok(BooleanChunked::full_null(self.name(), self.len()))
-            },
-            _ => impl_compare!(self, rhs, gt),
-        }
+        impl_compare!(self, rhs, gt)
     }
 
     /// Create a boolean mask by checking if self >= rhs.
     fn gt_eq(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        match (self.dtype(), rhs.dtype()) {
-            (DataType::Null, DataType::Null) => {
-                Ok(BooleanChunked::full_null(self.name(), self.len()))
-            },
-            _ => impl_compare!(self, rhs, gt_eq),
-        }
+        impl_compare!(self, rhs, gt_eq)
     }
 
     /// Create a boolean mask by checking if self < rhs.
     fn lt(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        match (self.dtype(), rhs.dtype()) {
-            (DataType::Null, DataType::Null) => {
-                Ok(BooleanChunked::full_null(self.name(), self.len()))
-            },
-            _ => impl_compare!(self, rhs, lt),
-        }
+        impl_compare!(self, rhs, lt)
     }
 
     /// Create a boolean mask by checking if self <= rhs.
     fn lt_eq(&self, rhs: &Series) -> PolarsResult<BooleanChunked> {
-        match (self.dtype(), rhs.dtype()) {
-            (DataType::Null, DataType::Null) => {
-                Ok(BooleanChunked::full_null(self.name(), self.len()))
-            },
-            _ => impl_compare!(self, rhs, lt_eq),
-        }
+        impl_compare!(self, rhs, lt_eq)
     }
 }
 


### PR DESCRIPTION
This fixes #14118.