### PR TITLE
perf: improve iteration performance

### DIFF
--- a/crates/polars-arrow/src/array/static_array.rs
+++ b/crates/polars-arrow/src/array/static_array.rs
@@ -25,7 +25,7 @@ pub trait StaticArray:
     type ZeroableValueT<'a>: Zeroable + From<Self::ValueT<'a>>
     where
         Self: 'a;
-    type ValueIterT<'a>: Iterator<Item = Self::ValueT<'a>> + TrustedLen
+    type ValueIterT<'a>: DoubleEndedIterator<Item = Self::ValueT<'a>> + TrustedLen + Send + Sync
     where
         Self: 'a;
 

--- a/crates/polars-arrow/src/legacy/utils.rs
+++ b/crates/polars-arrow/src/legacy/utils.rs
@@ -11,6 +11,7 @@ pub trait CustomIterTools: Iterator {
     ///
     /// # Safety
     /// The given length must be correct.
+    #[inline]
     unsafe fn trust_my_length(self, length: usize) -> TrustMyLength<Self, Self::Item>
     where
         Self: Sized,

--- a/crates/polars-core/src/chunked_array/iterator/mod.rs
+++ b/crates/polars-core/src/chunked_array/iterator/mod.rs
@@ -7,6 +7,21 @@ use crate::utils::CustomIterTools;
 
 pub mod par;
 
+impl<T> ChunkedArray<T>
+where
+    T: PolarsDataType,
+{
+    #[inline]
+    pub fn iter(&self) -> impl PolarsIterator<Item = Option<T::Physical<'_>>> {
+        // SAFETY: we set the correct length of the iterator.
+        unsafe {
+            self.downcast_iter()
+                .flat_map(|arr| arr.iter())
+                .trust_my_length(self.len())
+        }
+    }
+}
+
 /// A [`PolarsIterator`] is an iterator over a [`ChunkedArray`] which contains polars types. A [`PolarsIterator`]
 /// must implement [`ExactSizeIterator`] and [`DoubleEndedIterator`].
 pub trait PolarsIterator:

--- a/crates/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -11,6 +11,7 @@ use smartstring::alias::String as SmartString;
 
 use self::sort::arg_sort_multiple::_get_rows_encoded_ca;
 use super::*;
+use crate::chunked_array::iterator::StructIter;
 use crate::datatypes::*;
 use crate::utils::index_to_chunked_index;
 
@@ -416,6 +417,10 @@ impl StructChunked {
     pub fn rows_encode(&self) -> PolarsResult<BinaryOffsetChunked> {
         let descending = vec![false; self.fields.len()];
         _get_rows_encoded_ca(self.name(), &self.fields, &descending, false)
+    }
+
+    pub fn iter(&self) -> StructIter {
+        self.into_iter()
     }
 }
 

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -96,12 +96,12 @@ pub type ChunkIdIter<'a> = std::iter::Map<std::slice::Iter<'a, ArrayRef>, fn(&Ar
 /// # use polars_core::prelude::*;
 ///
 /// fn iter_forward(ca: &Float32Chunked) {
-///     ca.into_iter()
+///     ca.iter()
 ///         .for_each(|opt_v| println!("{:?}", opt_v))
 /// }
 ///
 /// fn iter_backward(ca: &Float32Chunked) {
-///     ca.into_iter()
+///     ca.iter()
 ///         .rev()
 ///         .for_each(|opt_v| println!("{:?}", opt_v))
 /// }
@@ -759,10 +759,7 @@ pub(crate) mod test {
     where
         T: PolarsNumericType,
     {
-        assert_eq!(
-            ca.into_iter().map(|opt| opt.unwrap()).collect::<Vec<_>>(),
-            eq
-        )
+        assert_eq!(ca.iter().map(|opt| opt.unwrap()).collect::<Vec<_>>(), eq)
     }
 
     #[test]

--- a/crates/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -76,7 +76,7 @@ macro_rules! arg_unique_ca {
     ($ca:expr) => {{
         match $ca.has_validity() {
             false => arg_unique($ca.into_no_null_iter(), $ca.len()),
-            _ => arg_unique($ca.into_iter(), $ca.len()),
+            _ => arg_unique($ca.iter(), $ca.len()),
         }
     }};
 }

--- a/crates/polars-core/src/chunked_array/upstream_traits.rs
+++ b/crates/polars-core/src/chunked_array/upstream_traits.rs
@@ -623,9 +623,7 @@ where
 }
 impl From<StringChunked> for Vec<Option<String>> {
     fn from(ca: StringChunked) -> Self {
-        ca.into_iter()
-            .map(|opt| opt.map(|s| s.to_string()))
-            .collect()
+        ca.iter().map(|opt| opt.map(|s| s.to_string())).collect()
     }
 }
 

--- a/crates/polars-core/src/frame/group_by/into_groups.rs
+++ b/crates/polars-core/src/frame/group_by/into_groups.rs
@@ -49,7 +49,7 @@ where
     } else if !ca.has_validity() {
         group_by(ca.into_no_null_iter(), sorted)
     } else {
-        group_by(ca.into_iter(), sorted)
+        group_by(ca.iter(), sorted)
     }
 }
 

--- a/crates/polars-core/src/frame/row/transpose.rs
+++ b/crates/polars-core/src/frame/row/transpose.rs
@@ -191,7 +191,7 @@ where
             // we also ensured we allocated enough memory, so we never reallocate and thus
             // the pointers remain valid.
             if has_nulls {
-                for (col_idx, opt_v) in ca.into_iter().enumerate() {
+                for (col_idx, opt_v) in ca.iter().enumerate() {
                     match opt_v {
                         None => unsafe {
                             let column = (*(validity_buf_ptr as *mut Vec<Vec<bool>>))

--- a/crates/polars-core/src/serde/chunked_array.rs
+++ b/crates/polars-core/src/serde/chunked_array.rs
@@ -59,7 +59,7 @@ where
     state.serialize_entry("name", name)?;
     state.serialize_entry("datatype", dtype)?;
     state.serialize_entry("bit_settings", &bit_settings)?;
-    state.serialize_entry("values", &IterSer::new(ca.into_iter()))?;
+    state.serialize_entry("values", &IterSer::new(ca.iter()))?;
     state.end()
 }
 

--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -751,7 +751,7 @@ where
                 let values_ptr = sync_ptr_values.get();
                 let validity_ptr = sync_ptr_validity.get();
 
-                ca.into_iter().zip(groups.iter()).for_each(|(opt_v, g)| {
+                ca.iter().zip(groups.iter()).for_each(|(opt_v, g)| {
                     for idx in g.as_slice() {
                         let idx = *idx as usize;
                         debug_assert!(idx < len);
@@ -779,7 +779,7 @@ where
                     let values_ptr = sync_ptr_values.get();
                     let validity_ptr = sync_ptr_validity.get();
 
-                    for (opt_v, [start, g_len]) in ca.into_iter().zip(groups.iter()) {
+                    for (opt_v, [start, g_len]) in ca.iter().zip(groups.iter()) {
                         let start = *start as usize;
                         let end = start + *g_len as usize;
                         for idx in start..end {

--- a/crates/polars-ops/src/chunked_array/array/join.rs
+++ b/crates/polars-ops/src/chunked_array/array/join.rs
@@ -25,13 +25,13 @@ fn join_literal(
             if ca.null_count() != 0 && !ignore_nulls {
                 return None;
             }
-
-            let iter = ca.into_iter().flatten();
-
-            for val in iter {
-                buf.write_str(val).unwrap();
-                buf.write_str(separator).unwrap();
+            for arr in ca.downcast_iter() {
+                for val in arr.non_null_values_iter() {
+                    buf.write_str(val).unwrap();
+                    buf.write_str(separator).unwrap();
+                }
             }
+
             // last value should not have a separator, so slice that off
             // saturating sub because there might have been nothing written.
             Some(&buf[..buf.len().saturating_sub(separator.len())])
@@ -62,11 +62,11 @@ fn join_many(
                         return None;
                     }
 
-                    let iter = ca.into_iter().flatten();
-
-                    for val in iter {
-                        buf.write_str(val).unwrap();
-                        buf.write_str(separator).unwrap();
+                    for arr in ca.downcast_iter() {
+                        for val in arr.non_null_values_iter() {
+                            buf.write_str(val).unwrap();
+                            buf.write_str(separator).unwrap();
+                        }
                     }
                     // last value should not have a separator, so slice that off
                     // saturating sub because there might have been nothing written.

--- a/crates/polars-ops/src/chunked_array/gather_skip_nulls.rs
+++ b/crates/polars-ops/src/chunked_array/gather_skip_nulls.rs
@@ -183,12 +183,11 @@ mod test {
     }
 
     fn test_equal_ref(ca: &UInt32Chunked, idx_ca: &IdxCa) {
-        let ref_ca: Vec<Option<u32>> = ca.into_iter().collect();
-        let ref_idx_ca: Vec<Option<usize>> =
-            idx_ca.into_iter().map(|i| Some(i? as usize)).collect();
+        let ref_ca: Vec<Option<u32>> = ca.iter().collect();
+        let ref_idx_ca: Vec<Option<usize>> = idx_ca.iter().map(|i| Some(i? as usize)).collect();
         let gather = ca.gather_skip_nulls(idx_ca).ok();
         let ref_gather = ref_gather_nulls(ref_ca, ref_idx_ca);
-        assert_eq!(gather.map(|ca| ca.into_iter().collect()), ref_gather);
+        assert_eq!(gather.map(|ca| ca.iter().collect()), ref_gather);
     }
 
     fn gather_skip_nulls_check(ca: &UInt32Chunked, idx_ca: &IdxCa) {

--- a/crates/polars-ops/src/chunked_array/strings/concat.rs
+++ b/crates/polars-ops/src/chunked_array/strings/concat.rs
@@ -91,7 +91,7 @@ pub fn hor_str_concat(
         .iter()
         .map(|ca| {
             if ca.len() > 1 {
-                ColumnIter::Iter(ca.into_iter())
+                ColumnIter::Iter(ca.iter())
             } else {
                 ColumnIter::Broadcast(ca.get(0))
             }

--- a/crates/polars-ops/src/chunked_array/strings/json_path.rs
+++ b/crates/polars-ops/src/chunked_array/strings/json_path.rs
@@ -55,7 +55,7 @@ pub trait Utf8JsonPathImpl: AsString {
     fn json_infer(&self, number_of_rows: Option<usize>) -> PolarsResult<DataType> {
         let ca = self.as_string();
         let values_iter = ca
-            .into_iter()
+            .iter()
             .map(|x| x.unwrap_or("null"))
             .take(number_of_rows.unwrap_or(ca.len()));
 
@@ -76,7 +76,7 @@ pub trait Utf8JsonPathImpl: AsString {
             None => ca.json_infer(infer_schema_len)?,
         };
         let buf_size = ca.get_values_size() + ca.null_count() * "null".len();
-        let iter = ca.into_iter().map(|x| x.unwrap_or("null"));
+        let iter = ca.iter().map(|x| x.unwrap_or("null"));
 
         let array = polars_json::ndjson::deserialize::deserialize_iter(
             iter,

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -383,10 +383,12 @@ pub trait StringNameSpaceImpl: AsString {
         let reg = Regex::new(pat)?;
 
         let mut builder = ListStringChunkedBuilder::new(ca.name(), ca.len(), ca.get_values_size());
-        for opt_s in ca.into_iter() {
-            match opt_s {
-                None => builder.append_null(),
-                Some(s) => builder.append_values_iter(reg.find_iter(s).map(|m| m.as_str())),
+        for arr in ca.downcast_iter() {
+            for opt_s in arr {
+                match opt_s {
+                    None => builder.append_null(),
+                    Some(s) => builder.append_values_iter(reg.find_iter(s).map(|m| m.as_str())),
+                }
             }
         }
         Ok(builder.finish())

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
@@ -375,7 +375,7 @@ pub fn prepare_bytes<'a>(
         been_split
             .par_iter()
             .map(|ca| {
-                ca.into_iter()
+                ca.iter()
                     .map(|opt_b| {
                         let hash = hb.hash_one(opt_b);
                         BytesHash::new(opt_b, hash)

--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -148,7 +148,7 @@ pub(crate) fn arg_max_bool(ca: &BooleanChunked) -> Option<usize> {
         Some(first_set_bit(mask))
     } else {
         let mut first_false_idx: Option<usize> = None;
-        ca.into_iter()
+        ca.iter()
             .enumerate()
             .find_map(|(idx, val)| match val {
                 Some(true) => Some(idx),
@@ -171,7 +171,7 @@ fn arg_min_bool(ca: &BooleanChunked) -> Option<usize> {
         Some(first_unset_bit(mask))
     } else {
         let mut first_true_idx: Option<usize> = None;
-        ca.into_iter()
+        ca.iter()
             .enumerate()
             .find_map(|(idx, val)| match val {
                 Some(false) => Some(idx),
@@ -193,7 +193,7 @@ fn arg_min_str(ca: &StringChunked) -> Option<usize> {
         IsSorted::Ascending => ca.first_non_null(),
         IsSorted::Descending => ca.last_non_null(),
         IsSorted::Not => ca
-            .into_iter()
+            .iter()
             .enumerate()
             .flat_map(|(idx, val)| val.map(|val| (idx, val)))
             .reduce(|acc, (idx, val)| if acc.1 > val { (idx, val) } else { acc })
@@ -209,7 +209,7 @@ fn arg_max_str(ca: &StringChunked) -> Option<usize> {
         IsSorted::Ascending => ca.last_non_null(),
         IsSorted::Descending => ca.first_non_null(),
         IsSorted::Not => ca
-            .into_iter()
+            .iter()
             .enumerate()
             .reduce(|acc, (idx, val)| if acc.1 < val { (idx, val) } else { acc })
             .map(|tpl| tpl.0),

--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -78,8 +78,8 @@ where
     let init = Bounded::min_value();
 
     let out: ChunkedArray<T> = match reverse {
-        false => ca.into_iter().scan(init, det_max).collect_trusted(),
-        true => ca.into_iter().rev().scan(init, det_max).collect_reversed(),
+        false => ca.iter().scan(init, det_max).collect_trusted(),
+        true => ca.iter().rev().scan(init, det_max).collect_reversed(),
     };
     out.with_name(ca.name())
 }
@@ -91,8 +91,8 @@ where
 {
     let init = Bounded::max_value();
     let out: ChunkedArray<T> = match reverse {
-        false => ca.into_iter().scan(init, det_min).collect_trusted(),
-        true => ca.into_iter().rev().scan(init, det_min).collect_reversed(),
+        false => ca.iter().scan(init, det_min).collect_trusted(),
+        true => ca.iter().rev().scan(init, det_min).collect_reversed(),
     };
     out.with_name(ca.name())
 }
@@ -104,8 +104,8 @@ where
 {
     let init = None;
     let out: ChunkedArray<T> = match reverse {
-        false => ca.into_iter().scan(init, det_sum).collect_trusted(),
-        true => ca.into_iter().rev().scan(init, det_sum).collect_reversed(),
+        false => ca.iter().scan(init, det_sum).collect_trusted(),
+        true => ca.iter().rev().scan(init, det_sum).collect_reversed(),
     };
     out.with_name(ca.name())
 }
@@ -117,8 +117,8 @@ where
 {
     let init = None;
     let out: ChunkedArray<T> = match reverse {
-        false => ca.into_iter().scan(init, det_prod).collect_trusted(),
-        true => ca.into_iter().rev().scan(init, det_prod).collect_reversed(),
+        false => ca.iter().scan(init, det_prod).collect_trusted(),
+        true => ca.iter().rev().scan(init, det_prod).collect_reversed(),
     };
     out.with_name(ca.name())
 }

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -49,7 +49,7 @@ where
             Some(
                 opt_s.map(|s| {
                     let ca = s.as_ref().unpack::<T>().unwrap();
-                    ca.into_iter().any(|a| a == value)
+                    ca.iter().any(|a| a == value)
                 }) == Some(true),
             )
         })
@@ -58,12 +58,12 @@ where
         // SAFETY: unstable series never lives longer than the iterator.
         unsafe {
             ca_in
-                .into_iter()
+                .iter()
                 .zip(other.list()?.amortized_iter())
                 .map(|(value, series)| match (value, series) {
                     (val, Some(series)) => {
                         let ca = series.as_ref().unpack::<T>().unwrap();
-                        ca.into_iter().any(|a| a == val)
+                        ca.iter().any(|a| a == val)
                     },
                     _ => false,
                 })
@@ -87,19 +87,19 @@ where
             Some(
                 opt_s.map(|s| {
                     let ca = s.as_ref().unpack::<T>().unwrap();
-                    ca.into_iter().any(|a| a == value)
+                    ca.iter().any(|a| a == value)
                 }) == Some(true),
             )
         })
     } else {
         polars_ensure!(ca_in.len() == other.len(), ComputeError: "shapes don't match: expected {} elements in 'is_in' comparison, got {}", ca_in.len(), other.len());
         ca_in
-            .into_iter()
+            .iter()
             .zip(other.array()?.amortized_iter())
             .map(|(value, series)| match (value, series) {
                 (val, Some(series)) => {
                     let ca = series.as_ref().unpack::<T>().unwrap();
-                    ca.into_iter().any(|a| a == val)
+                    ca.iter().any(|a| a == val)
                 },
                 _ => false,
             })
@@ -179,7 +179,7 @@ fn is_in_string_inner_categorical(
                                     if ca.null_count() == 0 {
                                         ca.into_no_null_iter().any(|a| a == idx)
                                     } else {
-                                        ca.into_iter().any(|a| a == Some(idx))
+                                        ca.iter().any(|a| a == Some(idx))
                                     }
                                 }) == Some(true),
                             )
@@ -244,7 +244,7 @@ fn is_in_binary_list(ca_in: &BinaryChunked, other: &Series) -> PolarsResult<Bool
             Some(
                 opt_b.map(|s| {
                     let ca = s.as_ref().unpack::<BinaryType>().unwrap();
-                    ca.into_iter().any(|a| a == value)
+                    ca.iter().any(|a| a == value)
                 }) == Some(true),
             )
         })
@@ -253,12 +253,12 @@ fn is_in_binary_list(ca_in: &BinaryChunked, other: &Series) -> PolarsResult<Bool
         // SAFETY: unstable series never lives longer than the iterator.
         unsafe {
             ca_in
-                .into_iter()
+                .iter()
                 .zip(other.list()?.amortized_iter())
                 .map(|(value, series)| match (value, series) {
                     (val, Some(series)) => {
                         let ca = series.as_ref().unpack::<BinaryType>().unwrap();
-                        ca.into_iter().any(|a| a == val)
+                        ca.iter().any(|a| a == val)
                     },
                     _ => false,
                 })
@@ -278,19 +278,19 @@ fn is_in_binary_array(ca_in: &BinaryChunked, other: &Series) -> PolarsResult<Boo
             Some(
                 opt_b.map(|s| {
                     let ca = s.as_ref().unpack::<BinaryType>().unwrap();
-                    ca.into_iter().any(|a| a == value)
+                    ca.iter().any(|a| a == value)
                 }) == Some(true),
             )
         })
     } else {
         polars_ensure!(ca_in.len() == other.len(), ComputeError: "shapes don't match: expected {} elements in 'is_in' comparison, got {}", ca_in.len(), other.len());
         ca_in
-            .into_iter()
+            .iter()
             .zip(other.array()?.amortized_iter())
             .map(|(value, series)| match (value, series) {
                 (val, Some(series)) => {
                     let ca = series.as_ref().unpack::<BinaryType>().unwrap();
-                    ca.into_iter().any(|a| a == val)
+                    ca.iter().any(|a| a == val)
                 },
                 _ => false,
             })
@@ -322,7 +322,7 @@ fn is_in_boolean_list(ca_in: &BooleanChunked, other: &Series) -> PolarsResult<Bo
                 .map(|opt_s| {
                     opt_s.map(|s| {
                         let ca = s.as_ref().unpack::<BooleanType>().unwrap();
-                        ca.into_iter().any(|a| a == value)
+                        ca.iter().any(|a| a == value)
                     }) == Some(true)
                 })
                 .trust_my_length(other.len())
@@ -333,12 +333,12 @@ fn is_in_boolean_list(ca_in: &BooleanChunked, other: &Series) -> PolarsResult<Bo
         // SAFETY: unstable series never lives longer than the iterator.
         unsafe {
             ca_in
-                .into_iter()
+                .iter()
                 .zip(other.list()?.amortized_iter())
                 .map(|(value, series)| match (value, series) {
                     (val, Some(series)) => {
                         let ca = series.as_ref().unpack::<BooleanType>().unwrap();
-                        ca.into_iter().any(|a| a == val)
+                        ca.iter().any(|a| a == val)
                     },
                     _ => false,
                 })
@@ -361,7 +361,7 @@ fn is_in_boolean_array(ca_in: &BooleanChunked, other: &Series) -> PolarsResult<B
                 .map(|opt_s| {
                     opt_s.map(|s| {
                         let ca = s.as_ref().unpack::<BooleanType>().unwrap();
-                        ca.into_iter().any(|a| a == value)
+                        ca.iter().any(|a| a == value)
                     }) == Some(true)
                 })
                 .trust_my_length(other.len())
@@ -370,12 +370,12 @@ fn is_in_boolean_array(ca_in: &BooleanChunked, other: &Series) -> PolarsResult<B
     } else {
         polars_ensure!(ca_in.len() == other.len(), ComputeError: "shapes don't match: expected {} elements in 'is_in' comparison, got {}", ca_in.len(), other.len());
         ca_in
-            .into_iter()
+            .iter()
             .zip(other.array()?.amortized_iter())
             .map(|(value, series)| match (value, series) {
                 (val, Some(series)) => {
                     let ca = series.as_ref().unpack::<BooleanType>().unwrap();
-                    ca.into_iter().any(|a| a == val)
+                    ca.iter().any(|a| a == val)
                 },
                 _ => false,
             })
@@ -421,7 +421,7 @@ fn is_in_struct_list(ca_in: &StructChunked, other: &Series) -> PolarsResult<Bool
             Some(
                 opt_s.map(|s| {
                     let ca = s.as_ref().struct_().unwrap();
-                    ca.into_iter().any(|a| a == value)
+                    ca.iter().any(|a| a == value)
                 }) == Some(true),
             )
         })
@@ -430,12 +430,12 @@ fn is_in_struct_list(ca_in: &StructChunked, other: &Series) -> PolarsResult<Bool
         // SAFETY: unstable series never lives longer than the iterator.
         unsafe {
             ca_in
-                .into_iter()
+                .iter()
                 .zip(other.list()?.amortized_iter())
                 .map(|(value, series)| match (value, series) {
                     (val, Some(series)) => {
                         let ca = series.as_ref().struct_().unwrap();
-                        ca.into_iter().any(|a| a == val)
+                        ca.iter().any(|a| a == val)
                     },
                     _ => false,
                 })
@@ -459,19 +459,19 @@ fn is_in_struct_array(ca_in: &StructChunked, other: &Series) -> PolarsResult<Boo
             Some(
                 opt_s.map(|s| {
                     let ca = s.as_ref().struct_().unwrap();
-                    ca.into_iter().any(|a| a == value)
+                    ca.iter().any(|a| a == value)
                 }) == Some(true),
             )
         })
     } else {
         polars_ensure!(ca_in.len() == other.len(), ComputeError: "shapes don't match: expected {} elements in 'is_in' comparison, got {}", ca_in.len(), other.len());
         ca_in
-            .into_iter()
+            .iter()
             .zip(other.array()?.amortized_iter())
             .map(|(value, series)| match (value, series) {
                 (val, Some(series)) => {
                     let ca = series.as_ref().struct_().unwrap();
-                    ca.into_iter().any(|a| a == val)
+                    ca.iter().any(|a| a == val)
                 },
                 _ => false,
             })
@@ -525,7 +525,7 @@ fn is_in_struct(ca_in: &StructChunked, other: &Series) -> PolarsResult<BooleanCh
             // SAFETY:
             // the iterator is unsafe as the lifetime is tied to the iterator
             // so we copy to an owned buffer first
-            other.into_iter().for_each(|vals| {
+            other.iter().for_each(|vals| {
                 any_values.extend_from_slice(vals);
             });
 
@@ -540,7 +540,7 @@ fn is_in_struct(ca_in: &StructChunked, other: &Series) -> PolarsResult<BooleanCh
 
             // and then we check for membership
             let mut ca: BooleanChunked = ca_in_ca
-                .into_iter()
+                .iter()
                 .map(|vals| {
                     // If all rows are null we see the struct row as missing.
                     if !vals.iter().all(|val| matches!(val, AnyValue::Null)) {

--- a/crates/polars-ops/src/series/ops/is_unique.rs
+++ b/crates/polars-ops/src/series/ops/is_unique.rs
@@ -8,15 +8,14 @@ use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
 fn is_unique_ca<'a, T>(ca: &'a ChunkedArray<T>, invert: bool) -> BooleanChunked
 where
     T: PolarsDataType,
-    &'a ChunkedArray<T>: IntoIterator,
-    <<&'a ChunkedArray<T> as IntoIterator>::IntoIter as IntoIterator>::Item: TotalHash + TotalEq,
+    T::Physical<'a>: TotalHash + TotalEq,
 {
     let len = ca.len();
     let mut idx_key = PlHashMap::new();
 
     // Instead of group_tuples, which allocates a full Vec per group, we now
     // just toggle a boolean that's false if a group has multiple entries.
-    ca.into_iter().enumerate().for_each(|(idx, key)| {
+    ca.iter().enumerate().for_each(|(idx, key)| {
         idx_key
             .entry(TotalOrdWrap(key))
             .and_modify(|v: &mut (IdxSize, bool)| v.1 = false)

--- a/crates/polars-ops/src/series/ops/unique.rs
+++ b/crates/polars-ops/src/series/ops/unique.rs
@@ -26,10 +26,10 @@ pub fn unique_counts(s: &Series) -> PolarsResult<Series> {
     if s.dtype().to_physical().is_numeric() {
         if s.bit_repr_is_large() {
             let ca = s.bit_repr_large();
-            Ok(unique_counts_helper(ca.into_iter()).into_series())
+            Ok(unique_counts_helper(ca.iter()).into_series())
         } else {
             let ca = s.bit_repr_small();
-            Ok(unique_counts_helper(ca.into_iter()).into_series())
+            Ok(unique_counts_helper(ca.iter()).into_series())
         }
     } else {
         match s.dtype() {

--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -160,8 +160,8 @@ fn upsample_single_impl(
         Datetime(tu, tz) => {
             let s = index_column.cast(&Int64).unwrap();
             let ca = s.i64().unwrap();
-            let first = ca.into_iter().flatten().next();
-            let last = ca.into_iter().flatten().next_back();
+            let first = ca.iter().flatten().next();
+            let last = ca.iter().flatten().next_back();
             match (first, last) {
                 (Some(first), Some(last)) => {
                     let tz = match tz {

--- a/crates/polars/src/docs/eager.rs
+++ b/crates/polars/src/docs/eager.rs
@@ -227,7 +227,7 @@
 //! ca.lt_eq(&ca);
 //!
 //! // use iterators
-//! let a: BooleanChunked = ca.into_iter()
+//! let a: BooleanChunked = ca.iter()
 //!     .map(|opt_value| {
 //!          match opt_value {
 //!          Some(value) => value < 10,

--- a/crates/polars/tests/it/io/csv.rs
+++ b/crates/polars/tests/it/io/csv.rs
@@ -982,7 +982,7 @@ fn test_empty_string_cols() -> PolarsResult<()> {
     let s = df.column("column_1")?;
     let ca = s.str()?;
     assert_eq!(
-        ca.into_iter().collect::<Vec<_>>(),
+        ca.iter().collect::<Vec<_>>(),
         &[None, Some("abc"), None, Some("xyz")]
     );
 

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -29,18 +29,14 @@ impl PySeries {
                 if s.bit_repr_is_large() {
                     let s = s.cast(&DataType::Float64).unwrap();
                     let ca = s.f64().unwrap();
-                    let np_arr = PyArray1::from_iter(
-                        py,
-                        ca.into_iter().map(|opt_v| opt_v.unwrap_or(f64::NAN)),
-                    );
+                    let np_arr =
+                        PyArray1::from_iter(py, ca.iter().map(|opt_v| opt_v.unwrap_or(f64::NAN)));
                     Ok(np_arr.into_py(py))
                 } else {
                     let s = s.cast(&DataType::Float32).unwrap();
                     let ca = s.f32().unwrap();
-                    let np_arr = PyArray1::from_iter(
-                        py,
-                        ca.into_iter().map(|opt_v| opt_v.unwrap_or(f32::NAN)),
-                    );
+                    let np_arr =
+                        PyArray1::from_iter(py, ca.iter().map(|opt_v| opt_v.unwrap_or(f32::NAN)));
                     Ok(np_arr.into_py(py))
                 }
             },


### PR DESCRIPTION
Fixed a long standing annoyance. The `IntoIterator` trait doesn't allow for enough generics so we had to return a `Box<dyn Iterator>`. Which meant a dynamic function call on every iteration and the iterator is completely opaque to the compiler.

This adds an `iter` metod directly on `ChunkedArray<T>` for all `T: PolarsDataType`. This should be preferred over `into_iter` at all cost.

Note that it still is a nested iterator (as wel iterate over different chunks). So if you can please unpack your nestedness during iteration with:

```rust
// when you have null values
for arr ca.downcast_iter() {
   // Non nested iteration so this saves a branch, e.g. fast and completely visible by compiler 
   for value in arr.iter() {
      // do work
   }
}

// when you don't have null values
for arr ca.downcast_iter() {
   // also elides null branch
   for value in arr.values_iter() {
      // do work
   }
}

// when you want to ignore null values
for arr ca.downcast_iter() {
   // fastest way to skip null values.
   for value in arr.non_null_values_iter() {
      // do work
   }
}
```