### PR TITLE
feat!: Forbid casting from `Date` to `Time` and vice versa

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/date.rs
+++ b/crates/polars-core/src/chunked_array/logical/date.rs
@@ -29,9 +29,9 @@ impl LogicalType for DateChunked {
 
     fn cast(&self, dtype: &DataType) -> PolarsResult<Series> {
         use DataType::*;
-        match (self.dtype(), dtype) {
+        match dtype {
             #[cfg(feature = "dtype-datetime")]
-            (Date, Datetime(tu, tz)) => {
+            Datetime(tu, tz) => {
                 let casted = self.0.cast(dtype)?;
                 let casted = casted.datetime().unwrap();
                 let conversion = match tu {
@@ -44,9 +44,9 @@ impl LogicalType for DateChunked {
                     .into_series())
             },
             #[cfg(feature = "dtype-time")]
-            (Date, Time) => Ok(Int64Chunked::full(self.name(), 0i64, self.len())
-                .into_time()
-                .into_series()),
+            Time => {
+                polars_bail!(ComputeError: "cannot cast `Date` to `Time`");
+            },
             _ => self.0.cast(dtype),
         }
     }

--- a/crates/polars-core/src/series/implementations/dates_time.rs
+++ b/crates/polars-core/src/series/implementations/dates_time.rs
@@ -38,10 +38,10 @@ macro_rules! impl_dyn_series {
             fn _dtype(&self) -> &DataType {
                 self.0.dtype()
             }
-            fn _get_flags(&self) -> Settings{
+            fn _get_flags(&self) -> Settings {
                 self.0.get_flags()
             }
-            fn _set_flags(&mut self, flags: Settings){
+            fn _set_flags(&mut self, flags: Settings) {
                 self.0.set_flags(flags)
             }
 
@@ -78,17 +78,17 @@ macro_rules! impl_dyn_series {
                 Ok(())
             }
 
-        #[cfg(feature = "algorithm_group_by")]
+            #[cfg(feature = "algorithm_group_by")]
             unsafe fn agg_min(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_min(groups).$into_logical().into_series()
             }
 
-        #[cfg(feature = "algorithm_group_by")]
+            #[cfg(feature = "algorithm_group_by")]
             unsafe fn agg_max(&self, groups: &GroupsProxy) -> Series {
                 self.0.agg_max(groups).$into_logical().into_series()
             }
 
-        #[cfg(feature = "algorithm_group_by")]
+            #[cfg(feature = "algorithm_group_by")]
             unsafe fn agg_list(&self, groups: &GroupsProxy) -> Series {
                 // we cannot cast and dispatch as the inner type of the list would be incorrect
                 self.0
@@ -104,7 +104,7 @@ macro_rules! impl_dyn_series {
                         let lhs = self.cast(&dt)?;
                         let rhs = rhs.cast(&dt)?;
                         lhs.subtract(&rhs)
-                    }
+                    },
                     (DataType::Date, DataType::Duration(_)) => ((&self
                         .cast(&DataType::Datetime(TimeUnit::Milliseconds, None))
                         .unwrap())
@@ -132,7 +132,7 @@ macro_rules! impl_dyn_series {
             fn remainder(&self, rhs: &Series) -> PolarsResult<Series> {
                 polars_bail!(opq = rem, self.0.dtype(), rhs.dtype());
             }
-    #[cfg(feature = "algorithm_group_by")]
+            #[cfg(feature = "algorithm_group_by")]
             fn group_tuples(&self, multithreaded: bool, sorted: bool) -> PolarsResult<GroupsProxy> {
                 self.0.group_tuples(multithreaded, sorted)
             }
@@ -143,7 +143,6 @@ macro_rules! impl_dyn_series {
         }
 
         impl SeriesTrait for SeriesWrap<$ca> {
-
             fn rename(&mut self, name: &str) {
                 self.0.rename(name);
             }
@@ -250,7 +249,7 @@ macro_rules! impl_dyn_series {
 
             fn cast(&self, data_type: &DataType) -> PolarsResult<Series> {
                 match (self.dtype(), data_type) {
-                    #[cfg(feature="dtype-date")]
+                    #[cfg(feature = "dtype-date")]
                     (DataType::Date, DataType::String) => Ok(self
                         .0
                         .clone()
@@ -259,7 +258,7 @@ macro_rules! impl_dyn_series {
                         .unwrap()
                         .to_string("%Y-%m-%d")
                         .into_series()),
-                    #[cfg(feature="dtype-time")]
+                    #[cfg(feature = "dtype-time")]
                     (DataType::Time, DataType::String) => Ok(self
                         .0
                         .clone()
@@ -269,18 +268,11 @@ macro_rules! impl_dyn_series {
                         .to_string("%T")
                         .into_series()),
                     #[cfg(feature = "dtype-datetime")]
-                    (DataType::Time, DataType::Datetime(_, _)) => {
-                        polars_bail!(
-                            ComputeError:
-                            "cannot cast `Time` to `Datetime`; consider using 'dt.combine'"
-                        );
-                    }
-                    #[cfg(feature = "dtype-datetime")]
                     (DataType::Date, DataType::Datetime(_, _)) => {
                         let mut out = self.0.cast(data_type)?;
                         out.set_sorted_flag(self.0.is_sorted_flag());
                         Ok(out)
-                    }
+                    },
                     _ => self.0.cast(data_type),
                 }
             }
@@ -310,17 +302,17 @@ macro_rules! impl_dyn_series {
                 self.0.has_validity()
             }
 
-#[cfg(feature = "algorithm_group_by")]
+            #[cfg(feature = "algorithm_group_by")]
             fn unique(&self) -> PolarsResult<Series> {
                 self.0.unique().map(|ca| ca.$into_logical().into_series())
             }
 
-#[cfg(feature = "algorithm_group_by")]
+            #[cfg(feature = "algorithm_group_by")]
             fn n_unique(&self) -> PolarsResult<usize> {
                 self.0.n_unique()
             }
 
-#[cfg(feature = "algorithm_group_by")]
+            #[cfg(feature = "algorithm_group_by")]
             fn arg_unique(&self) -> PolarsResult<IdxCa> {
                 self.0.arg_unique()
             }

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1343,22 +1343,6 @@ def test_rolling_by_() -> None:
     }
 
 
-def test_date_to_time_cast_5111() -> None:
-    # check date -> time casts (fast-path: always 00:00:00)
-    df = pl.DataFrame(
-        {
-            "xyz": [
-                date(1969, 1, 1),
-                date(1990, 3, 8),
-                date(2000, 6, 16),
-                date(2010, 9, 24),
-                date(2022, 12, 31),
-            ]
-        }
-    ).with_columns(pl.col("xyz").cast(pl.Time))
-    assert df["xyz"].to_list() == [time(0), time(0), time(0), time(0), time(0)]
-
-
 def test_sum_duration() -> None:
     assert pl.DataFrame(
         [


### PR DESCRIPTION
Closes #14124

#### Changes

* Casting from `Date` to `Time` now raises instead of producing `00:00:00` for every value.
* Casting from `Time` to `Date` now raises instead of using the underlying physical representation.

This should probably be considered a breaking change, at least the `Date->Time` part. The other way around was nonsense, e.g.:

```python
from datetime import time

import polars as pl

s = pl.Series([time(0, 0)])
result = s.cast(pl.Date)
print(result)
```
```
shape: (1,)
Series: '' [date]
[
        1970-01-01
]
```