### PR TITLE
fix(python): fix ufunc in agg (change __ufunc_array__ so it uses `is_elementwise=True` parameter)

### DIFF
--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -121,6 +121,10 @@ class ArrowError(Exception):
     """Deprecated: will be removed."""
 
 
+class CustomUFuncWarning(PolarsWarning):  # type: ignore[misc]
+    """Warning issued when a custom ufunc is handled differently than numpy ufunc would."""  # noqa: W505
+
+
 __all__ = [
     "ArrowError",
     "ColumnNotFoundError",

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -77,3 +77,13 @@ def test_map_deprecated() -> None:
         pl.col("a").map(lambda x: x)
     with pytest.deprecated_call():
         pl.LazyFrame({"a": [1, 2]}).map(lambda x: x)
+
+
+def test_ufunc_recognition() -> None:
+    df = pl.DataFrame({"a": [1, 1, 2, 2], "b": [1.1, 2.2, 3.3, 4.4]})
+    assert_frame_equal(df.select(np.exp(pl.col("b"))), df.select(pl.col("b").exp()))
+
+
+def test_grouped_ufunc() -> None:
+    df = pl.DataFrame({"id": ["a", "a", "b", "b"], "values": [0.1, 0.1, -0.1, -0.1]})
+    df.group_by("id").agg(pl.col("values").log1p().sum().pipe(np.expm1))


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/13557

I was back burnering whether or not there was a good way to tell if a ufunc was elementwise for a while now when I realized that they're all elementwise.

I did this test:

```
import numpy as np
import polars as pl
import scipy.special as ss
from polars.testing import assert_frame_equal
npufuncs = []
for x in dir(np):
    if getattr(np,x).__class__==np.ufunc:
        npufuncs.append(x)
ssufuncs = []
for x in dir(ss):
    if getattr(ss, x).__class__==np.ufunc:
        ssufuncs.append(x)
        
df=pl.DataFrame({'a':[1,1,2,2],
                 'b':[1.1,2.2,3.3,4.4],
                 'c':[3.1,4.2,5.3,6.4]})

goodufuncs = {"<module 'numpy' from '/usr/local/lib/python3.11/site-packages/numpy/__init__.py'>":[],
              "<module 'scipy.special' from '/usr/local/lib/python3.11/site-packages/scipy/special/__init__.py'>":[]}
for cls, xlist in {np:npufuncs, ss:ssufuncs}.items():
    for x in xlist:
        onearg=True
        while True:
            try:
                if onearg:
                    assert_frame_equal(
                        df.group_by('a',maintain_order=True).agg(pl.col('b').map_batches(getattr(cls,x), is_elementwise=True)),
                        df.group_by('a',maintain_order=True).agg(pl.col('b').map_batches(getattr(cls,x), is_elementwise=False))
                    )
                else:
                    assert_frame_equal(
                        df.group_by('a',maintain_order=True).agg(pl.struct('b','c')
                            .map_batches(lambda z, cls=cls, x=x: getattr(cls,x)(z.struct.field('b'), z.struct.field('c')), is_elementwise=True)),
                        df.group_by('a',maintain_order=True).agg(pl.struct('b','c')
                            .map_batches(lambda z, cls=cls, x=x: getattr(cls,x)(z.struct.field('b'), z.struct.field('c')), is_elementwise=False))
                    )
                goodufuncs[str(cls)].append(x)
                break

            except Exception as err:
                if "takes from 2 to " in str(err):
                    onearg=False
                else:
                    print(f"{x} gave {err}")
                    break
```

At the end, there are no assertion errors so for stock ufuncs in numpy and scipy.special it is safe to dispatch them with `map_batches(func, is_elementwise=True)` For any other ufunc, like the result of using `numba.guvectorize` there will be a warning that they should call their function through map_batches.