### PR TITLE
feat!: Restrict casting for temporal data types

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/time.rs
+++ b/crates/polars-core/src/chunked_array/logical/time.rs
@@ -31,6 +31,8 @@ impl LogicalType for TimeChunked {
     fn cast(&self, dtype: &DataType) -> PolarsResult<Series> {
         use DataType::*;
         match dtype {
+            Time => Ok(self.clone().into_series()),
+            #[cfg(feature = "dtype-duration")]
             Duration(tu) => {
                 let out = self.0.cast(&DataType::Duration(TimeUnit::Nanoseconds));
                 if !matches!(tu, TimeUnit::Nanoseconds) {
@@ -39,15 +41,22 @@ impl LogicalType for TimeChunked {
                     out
                 }
             },
-            #[cfg(feature = "dtype-date")]
-            Date => {
-                polars_bail!(ComputeError: "cannot cast `Time` to `Date`");
-            },
             #[cfg(feature = "dtype-datetime")]
             Datetime(_, _) => {
-                polars_bail!(ComputeError: "cannot cast `Time` to `Datetime`; consider using `dt.combine`");
+                polars_bail!(
+                    InvalidOperation:
+                    "casting from {:?} to {:?} not supported; consider using `dt.combine`",
+                    self.dtype(), dtype
+                )
             },
-            _ => self.0.cast(dtype),
+            dt if dt.is_numeric() => self.0.cast(dtype),
+            _ => {
+                polars_bail!(
+                    InvalidOperation:
+                    "casting from {:?} to {:?} not supported",
+                    self.dtype(), dtype
+                )
+            },
         }
     }
 }

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -239,17 +239,22 @@ def test_int_to_python_datetime() -> None:
             datetime(1970, 1, 1, 0, 0, 0, 200000),
         ),
     ]
+
+    assert df.select(pl.col(col).dt.timestamp() for col in ("c", "d", "e")).rows() == [
+        (100000000000, 100000000, 100000),
+        (200000000000, 200000000, 200000),
+    ]
+
     assert df.select(
-        [pl.col(col).dt.timestamp() for col in ("c", "d", "e")]
-        + [
-            getattr(pl.col("b").cast(pl.Duration).dt, f"total_{unit}")().alias(
+        [
+            getattr(pl.col("a").cast(pl.Duration).dt, f"total_{unit}")().alias(
                 f"u[{unit}]"
             )
             for unit in ("milliseconds", "microseconds", "nanoseconds")
         ]
     ).rows() == [
-        (100000000000, 100000000, 100000, 100000, 100000000, 100000000000),
-        (200000000000, 200000000, 200000, 200000, 200000000, 200000000000),
+        (100000, 100000000, 100000000000),
+        (200000, 200000000, 200000000000),
     ]
 
 

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -497,27 +497,6 @@ def test_cast_err_column_value_highlighting(
         test_df.with_columns(pl.all().cast(type))
 
 
-def test_err_on_time_datetime_cast() -> None:
-    s = pl.Series([time(10, 0, 0), time(11, 30, 59)])
-    with pytest.raises(pl.ComputeError, match=r"cannot cast `Time` to `Datetime`"):
-        s.cast(pl.Datetime)
-
-
-def test_err_on_invalid_time_zone_cast() -> None:
-    s = pl.Series([datetime(2021, 1, 1)])
-    with pytest.raises(pl.ComputeError, match=r"unable to parse time zone: 'qwerty'"):
-        s.cast(pl.Datetime("us", "qwerty"))
-
-
-def test_invalid_inner_type_cast_list() -> None:
-    s = pl.Series([[-1, 1]])
-    with pytest.raises(
-        pl.InvalidOperationError,
-        match=r"cannot cast List inner type: 'Int64' to Categorical",
-    ):
-        s.cast(pl.List(pl.Categorical))
-
-
 def test_lit_agg_err() -> None:
     with pytest.raises(pl.ComputeError, match=r"cannot aggregate a literal"):
         pl.DataFrame({"y": [1]}).with_columns(pl.lit(1).sum().over("y"))


### PR DESCRIPTION
Ref #14124, #16440

Following up on https://github.com/pola-rs/polars/pull/14127

#### Changes

* Casting logical types Date, Time, Datetime, and Duration no longer falls back to casting the physical type. This means certain casts are disabled, such as `Duration -> Time` or `Datetime -> Boolean`, that could result in nonsense.
* Update unsupported cast failures from `ComputeError` to `InvalidOperationError`. This should be considered a breaking change.

#### Example

**Before**

```pycon
>>> from datetime import timedelta
>>> s = pl.Series([timedelta(days=1)])
>>> s.cast(pl.Time)
shape: (1,)
Series: '' [time]
[
        00:01:26.400
]
```

**After**

```pycon
>>> s.cast(pl.Time)
Traceback (most recent call last):
...
polars.exceptions.InvalidOperationError: casting from Duration(Microseconds) to Time not supported
```