### PR TITLE
docs: fix code blocks in user-guide/concepts/data-structures

### DIFF
--- a/docs/user-guide/concepts/data-structures.md
+++ b/docs/user-guide/concepts/data-structures.md
@@ -7,9 +7,9 @@ The core base data structures provided by Polars are `Series` and `DataFrame`.
 Series are a 1-dimensional data structure. Within a series all elements have the same [Data Type](data-types/overview.md) .
 The snippet below shows how to create a simple named `Series` object.
 
-{{code_block('getting-started/series-dataframes','series',['Series'])}}
+{{code_block('user-guide/basics/series-dataframes','series',['Series'])}}
 
-```python exec="on" result="text" session="getting-started/series"
+```python exec="on" result="text" session="user-guide/data-structures"
 --8<-- "python/user-guide/basics/series-dataframes.py:series"
 ```
 
@@ -17,9 +17,9 @@ The snippet below shows how to create a simple named `Series` object.
 
 A `DataFrame` is a 2-dimensional data structure that is backed by a `Series`, and it can be seen as an abstraction of a collection (e.g. list) of `Series`. Operations that can be executed on a `DataFrame` are very similar to what is done in a `SQL` like query. You can `GROUP BY`, `JOIN`, `PIVOT`, but also define custom functions.
 
-{{code_block('getting-started/series-dataframes','dataframe',['DataFrame'])}}
+{{code_block('user-guide/basics/series-dataframes','dataframe',['DataFrame'])}}
 
-```python exec="on" result="text" session="getting-started/series"
+```python exec="on" result="text" session="user-guide/data-structures"
 --8<-- "python/user-guide/basics/series-dataframes.py:dataframe"
 ```
 
@@ -31,9 +31,9 @@ This part focuses on viewing data in a `DataFrame`. We will use the `DataFrame` 
 
 The `head` function shows by default the first 5 rows of a `DataFrame`. You can specify the number of rows you want to see (e.g. `df.head(10)`).
 
-{{code_block('getting-started/series-dataframes','head',['head'])}}
+{{code_block('user-guide/basics/series-dataframes','head',['head'])}}
 
-```python exec="on" result="text" session="getting-started/series"
+```python exec="on" result="text" session="user-guide/data-structures"
 --8<-- "python/user-guide/basics/series-dataframes.py:head"
 ```
 
@@ -41,9 +41,9 @@ The `head` function shows by default the first 5 rows of a `DataFrame`. You can 
 
 The `tail` function shows the last 5 rows of a `DataFrame`. You can also specify the number of rows you want to see, similar to `head`.
 
-{{code_block('getting-started/series-dataframes','tail',['tail'])}}
+{{code_block('user-guide/basics/series-dataframes','tail',['tail'])}}
 
-```python exec="on" result="text" session="getting-started/series"
+```python exec="on" result="text" session="user-guide/data-structures"
 --8<-- "python/user-guide/basics/series-dataframes.py:tail"
 ```
 
@@ -51,9 +51,9 @@ The `tail` function shows the last 5 rows of a `DataFrame`. You can also specify
 
 If you want to get an impression of the data of your `DataFrame`, you can also use `sample`. With `sample` you get an _n_ number of random rows from the `DataFrame`.
 
-{{code_block('getting-started/series-dataframes','sample',['sample'])}}
+{{code_block('user-guide/basics/series-dataframes','sample',['sample'])}}
 
-```python exec="on" result="text" session="getting-started/series"
+```python exec="on" result="text" session="user-guide/data-structures"
 --8<-- "python/user-guide/basics/series-dataframes.py:sample"
 ```
 
@@ -61,8 +61,8 @@ If you want to get an impression of the data of your `DataFrame`, you can also u
 
 `Describe` returns summary statistics of your `DataFrame`. It will provide several quick statistics if possible.
 
-{{code_block('getting-started/series-dataframes','describe',['describe'])}}
+{{code_block('user-guide/basics/series-dataframes','describe',['describe'])}}
 
-```python exec="on" result="text" session="getting-started/series"
+```python exec="on" result="text" session="user-guide/data-structures"
 --8<-- "python/user-guide/basics/series-dataframes.py:describe"
 ```


### PR DESCRIPTION
Fixes the code blocks on this page so that they are visible: https://docs.pola.rs/user-guide/concepts/data-structures/

Currently, only the output is visible:

<img width="716" alt="Screen Shot 2024-01-31 at 8 55 09 PM" src="https://github.com/pola-rs/polars/assets/8519523/da5f21ae-969c-4cb7-ba23-c7b5b3cb6bda">
