### PR TITLE
perf: improve `ChunkId`

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/take/take_chunked.rs
+++ b/crates/polars-core/src/chunked_array/ops/take/take_chunked.rs
@@ -1,3 +1,4 @@
+use polars_utils::index::ChunkId;
 use polars_utils::slice::GetSaferUnchecked;
 
 use super::*;
@@ -22,9 +23,10 @@ where
 
             let ca: NoNull<Self> = by
                 .iter()
-                .map(|[chunk_idx, array_idx]| {
-                    let arr = arrs.get_unchecked_release(*chunk_idx as usize);
-                    *arr.get_unchecked_release(*array_idx as usize)
+                .map(|chunk_id| {
+                    let (chunk_idx, array_idx) = chunk_id.extract();
+                    let arr = arrs.get_unchecked_release(chunk_idx as usize);
+                    *arr.get_unchecked_release(array_idx as usize)
                 })
                 .collect_trusted();
 
@@ -32,9 +34,10 @@ where
         } else {
             let arrs = self.downcast_iter().collect::<Vec<_>>();
             by.iter()
-                .map(|[chunk_idx, array_idx]| {
-                    let arr = arrs.get_unchecked(*chunk_idx as usize);
-                    arr.get_unchecked(*array_idx as usize)
+                .map(|chunk_id| {
+                    let (chunk_idx, array_idx) = chunk_id.extract();
+                    let arr = arrs.get_unchecked(chunk_idx as usize);
+                    arr.get_unchecked(array_idx as usize)
                 })
                 .collect_trusted()
         };
@@ -48,7 +51,8 @@ where
         let mut ca: Self = by
             .iter()
             .map(|opt_idx| {
-                opt_idx.and_then(|[chunk_idx, array_idx]| {
+                opt_idx.and_then(|chunk_id| {
+                    let (chunk_idx, array_idx) = chunk_id.extract();
                     let arr = arrs.get_unchecked_release(chunk_idx as usize);
                     arr.get_unchecked(array_idx as usize)
                 })
@@ -77,9 +81,10 @@ impl TakeChunked for BinaryOffsetChunked {
         let arrs = self.downcast_iter().collect::<Vec<_>>();
         let mut ca: Self = by
             .iter()
-            .map(|[chunk_idx, array_idx]| {
-                let arr = arrs.get_unchecked(*chunk_idx as usize);
-                arr.get_unchecked(*array_idx as usize)
+            .map(|chunk_id| {
+                let (chunk_idx, array_idx) = chunk_id.extract();
+                let arr = arrs.get_unchecked(chunk_idx as usize);
+                arr.get_unchecked(array_idx as usize)
             })
             .collect_trusted();
         ca.rename(self.name());
@@ -92,7 +97,8 @@ impl TakeChunked for BinaryOffsetChunked {
         let mut ca: Self = by
             .iter()
             .map(|opt_idx| {
-                opt_idx.and_then(|[chunk_idx, array_idx]| {
+                opt_idx.and_then(|chunk_id| {
+                    let (chunk_idx, array_idx) = chunk_id.extract();
                     let arr = arrs.get_unchecked(chunk_idx as usize);
                     arr.get_unchecked(array_idx as usize)
                 })
@@ -109,9 +115,10 @@ impl TakeChunked for BinaryChunked {
         let arrs = self.downcast_iter().collect::<Vec<_>>();
         let mut ca: Self = by
             .iter()
-            .map(|[chunk_idx, array_idx]| {
-                let arr = arrs.get_unchecked(*chunk_idx as usize);
-                arr.get_unchecked(*array_idx as usize)
+            .map(|chunk_id| {
+                let (chunk_idx, array_idx) = chunk_id.extract();
+                let arr = arrs.get_unchecked(chunk_idx as usize);
+                arr.get_unchecked(array_idx as usize)
             })
             .collect_trusted();
         ca.rename(self.name());
@@ -124,7 +131,8 @@ impl TakeChunked for BinaryChunked {
         let mut ca: Self = by
             .iter()
             .map(|opt_idx| {
-                opt_idx.and_then(|[chunk_idx, array_idx]| {
+                opt_idx.and_then(|chunk_id| {
+                    let (chunk_idx, array_idx) = chunk_id.extract();
                     let arr = arrs.get_unchecked(chunk_idx as usize);
                     arr.get_unchecked(array_idx as usize)
                 })
@@ -141,9 +149,10 @@ impl TakeChunked for BooleanChunked {
         let arrs = self.downcast_iter().collect::<Vec<_>>();
         let mut ca: Self = by
             .iter()
-            .map(|[chunk_idx, array_idx]| {
-                let arr = arrs.get_unchecked(*chunk_idx as usize);
-                arr.get_unchecked(*array_idx as usize)
+            .map(|chunk_id| {
+                let (chunk_idx, array_idx) = chunk_id.extract();
+                let arr = arrs.get_unchecked(chunk_idx as usize);
+                arr.get_unchecked(array_idx as usize)
             })
             .collect_trusted();
         ca.rename(self.name());
@@ -156,7 +165,8 @@ impl TakeChunked for BooleanChunked {
         let mut ca: Self = by
             .iter()
             .map(|opt_idx| {
-                opt_idx.and_then(|[chunk_idx, array_idx]| {
+                opt_idx.and_then(|chunk_id| {
+                    let (chunk_idx, array_idx) = chunk_id.extract();
                     let arr = arrs.get_unchecked(chunk_idx as usize);
                     arr.get_unchecked(array_idx as usize)
                 })
@@ -173,9 +183,10 @@ impl TakeChunked for ListChunked {
         let arrs = self.downcast_iter().collect::<Vec<_>>();
         let mut ca: Self = by
             .iter()
-            .map(|[chunk_idx, array_idx]| {
-                let arr = arrs.get_unchecked(*chunk_idx as usize);
-                arr.get_unchecked(*array_idx as usize)
+            .map(|chunk_id| {
+                let (chunk_idx, array_idx) = chunk_id.extract();
+                let arr = arrs.get_unchecked(chunk_idx as usize);
+                arr.get_unchecked(array_idx as usize)
             })
             .collect();
         ca.rename(self.name());
@@ -188,7 +199,8 @@ impl TakeChunked for ListChunked {
         let mut ca: Self = by
             .iter()
             .map(|opt_idx| {
-                opt_idx.and_then(|[chunk_idx, array_idx]| {
+                opt_idx.and_then(|chunk_id| {
+                    let (chunk_idx, array_idx) = chunk_id.extract();
                     let arr = arrs.get_unchecked(chunk_idx as usize);
                     arr.get_unchecked(array_idx as usize)
                 })
@@ -204,9 +216,10 @@ impl TakeChunked for ListChunked {
 impl TakeChunked for ArrayChunked {
     unsafe fn take_chunked_unchecked(&self, by: &[ChunkId], sorted: IsSorted) -> Self {
         let arrs = self.downcast_iter().collect::<Vec<_>>();
-        let iter = by.iter().map(|[chunk_idx, array_idx]| {
-            let arr = arrs.get_unchecked(*chunk_idx as usize);
-            arr.get_unchecked(*array_idx as usize)
+        let iter = by.iter().map(|chunk_id| {
+            let (chunk_idx, array_idx) = chunk_id.extract();
+            let arr = arrs.get_unchecked(chunk_idx as usize);
+            arr.get_unchecked(array_idx as usize)
         });
         let mut ca = Self::from_iter_and_args(
             iter,
@@ -222,7 +235,8 @@ impl TakeChunked for ArrayChunked {
     unsafe fn take_opt_chunked_unchecked(&self, by: &[Option<ChunkId>]) -> Self {
         let arrs = self.downcast_iter().collect::<Vec<_>>();
         let iter = by.iter().map(|opt_idx| {
-            opt_idx.and_then(|[chunk_idx, array_idx]| {
+            opt_idx.and_then(|chunk_id| {
+                let (chunk_idx, array_idx) = chunk_id.extract();
                 let arr = arrs.get_unchecked(chunk_idx as usize);
                 arr.get_unchecked(array_idx as usize)
             })
@@ -244,9 +258,10 @@ impl<T: PolarsObject> TakeChunked for ObjectChunked<T> {
 
         let mut ca: Self = by
             .iter()
-            .map(|[chunk_idx, array_idx]| {
-                let arr = arrs.get_unchecked(*chunk_idx as usize);
-                arr.get_unchecked(*array_idx as usize).cloned()
+            .map(|chunk_id| {
+                let (chunk_idx, array_idx) = chunk_id.extract();
+                let arr = arrs.get_unchecked(chunk_idx as usize);
+                arr.get_unchecked(array_idx as usize).cloned()
             })
             .collect();
 
@@ -260,7 +275,8 @@ impl<T: PolarsObject> TakeChunked for ObjectChunked<T> {
         let mut ca: Self = by
             .iter()
             .map(|opt_idx| {
-                opt_idx.and_then(|[chunk_idx, array_idx]| {
+                opt_idx.and_then(|chunk_id| {
+                    let (chunk_idx, array_idx) = chunk_id.extract();
                     let arr = arrs.get_unchecked(chunk_idx as usize);
                     arr.get_unchecked(array_idx as usize).cloned()
                 })

--- a/crates/polars-core/src/datatypes/aliases.rs
+++ b/crates/polars-core/src/datatypes/aliases.rs
@@ -4,9 +4,6 @@ pub use polars_utils::aliases::{InitHashMaps, PlHashMap, PlHashSet, PlIndexMap, 
 use super::*;
 use crate::hashing::IdBuildHasher;
 
-/// [ChunkIdx, DfIdx]
-pub type ChunkId = [IdxSize; 2];
-
 #[cfg(not(feature = "bigidx"))]
 pub type IdxCa = UInt32Chunked;
 #[cfg(feature = "bigidx")]

--- a/crates/polars-core/src/prelude.rs
+++ b/crates/polars-core/src/prelude.rs
@@ -8,6 +8,8 @@ pub use arrow::datatypes::{ArrowSchema, Field as ArrowField};
 pub use arrow::legacy::kernels::ewm::EWMOptions;
 pub use arrow::legacy::prelude::*;
 pub(crate) use arrow::trusted_len::TrustedLen;
+#[cfg(feature = "chunked_ids")]
+pub(crate) use polars_utils::index::ChunkId;
 pub(crate) use polars_utils::total_ord::{TotalEq, TotalOrd};
 
 pub use crate::chunked_array::arithmetic::ArithmeticChunked;

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -15,6 +15,8 @@ pub type ChunkJoinOptIds = Vec<Option<IdxSize>>;
 #[cfg(not(feature = "chunked_ids"))]
 pub type ChunkJoinIds = Vec<IdxSize>;
 
+#[cfg(feature = "chunked_ids")]
+use polars_utils::index::ChunkId;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/crates/polars-ops/src/frame/join/general.rs
+++ b/crates/polars-ops/src/frame/join/general.rs
@@ -1,5 +1,8 @@
 use std::borrow::Cow;
 
+#[cfg(feature = "chunked_ids")]
+use polars_utils::index::ChunkId;
+
 use super::*;
 use crate::series::coalesce_series;
 
@@ -93,7 +96,9 @@ pub(crate) fn create_chunked_index_mapping(chunks: &[ArrayRef], len: usize) -> V
     let mut vals = Vec::with_capacity(len);
 
     for (chunk_i, chunk) in chunks.iter().enumerate() {
-        vals.extend((0..chunk.len()).map(|array_i| [chunk_i as IdxSize, array_i as IdxSize]))
+        vals.extend(
+            (0..chunk.len()).map(|array_i| ChunkId::store(chunk_i as IdxSize, array_i as IdxSize)),
+        )
     }
 
     vals

--- a/crates/polars-ops/src/frame/join/hash_join/mod.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/mod.rs
@@ -15,6 +15,7 @@ pub(super) use multiple_keys::*;
 use polars_core::utils::slice_slice;
 use polars_core::utils::{_set_partition_size, slice_offsets, split_ca};
 use polars_core::POOL;
+use polars_utils::index::ChunkId;
 pub(super) use single_keys::*;
 #[cfg(feature = "asof_join")]
 pub(super) use single_keys_dispatch::prepare_bytes;

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_probe_inner_left.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_probe_inner_left.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 
 use arrow::array::{Array, ArrayRef, BinaryArray};
 use arrow::compute::utils::combine_validities_and;
-use polars_core::datatypes::ChunkId;
 use polars_core::error::PolarsResult;
 use polars_core::export::ahash::RandomState;
 use polars_core::prelude::*;
@@ -12,6 +11,7 @@ use polars_ops::frame::join::_finish_join;
 use polars_ops::prelude::JoinType;
 use polars_row::RowsEncoded;
 use polars_utils::hashing::hash_to_partition;
+use polars_utils::index::ChunkId;
 use polars_utils::nulls::IsNull;
 use polars_utils::slice::GetSaferUnchecked;
 use smartstring::alias::String as SmartString;

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -118,13 +118,15 @@ impl_to_idx!(i64, i64);
 // Leaves 2^40 (~1T) rows per chunk
 const CHUNK_BITS: u64 = 24;
 
+#[derive(Clone, Copy, Debug)]
 #[repr(C)]
-pub struct ChunkIdx {
+pub struct ChunkId {
     swizzled: u64,
 }
 
-impl ChunkIdx {
-    #[inline]
+impl ChunkId {
+    #[inline(always)]
+    #[allow(clippy::unnecessary_cast)]
     pub fn store(chunk: IdxSize, row: IdxSize) -> Self {
         debug_assert!(chunk < !(u64::MAX << CHUNK_BITS) as IdxSize);
         let swizzled = (row as u64) << CHUNK_BITS | chunk as u64;
@@ -132,7 +134,8 @@ impl ChunkIdx {
         Self { swizzled }
     }
 
-    #[inline]
+    #[inline(always)]
+    #[allow(clippy::unnecessary_cast)]
     pub fn extract(self) -> (IdxSize, IdxSize) {
         let row = (self.swizzled >> CHUNK_BITS) as IdxSize;
 
@@ -151,7 +154,7 @@ mod test {
         let chunk = 213908;
         let row = 813457;
 
-        let ci = ChunkIdx::store(chunk, row);
+        let ci = ChunkId::store(chunk, row);
         let (c, r) = ci.extract();
 
         assert_eq!(c, chunk);

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -113,3 +113,48 @@ impl_to_idx!(i8, i16);
 impl_to_idx!(i16, i32);
 impl_to_idx!(i32, i64);
 impl_to_idx!(i64, i64);
+
+// Allows for 2^24 (~16M) chunks
+// Leaves 2^40 (~1T) rows per chunk
+const CHUNK_BITS: u64 = 24;
+
+#[repr(C)]
+pub struct ChunkIdx {
+    swizzled: u64,
+}
+
+impl ChunkIdx {
+    #[inline]
+    pub fn store(chunk: IdxSize, row: IdxSize) -> Self {
+        debug_assert!(chunk < !(u64::MAX << CHUNK_BITS) as IdxSize);
+        let swizzled = (row as u64) << CHUNK_BITS | chunk as u64;
+
+        Self { swizzled }
+    }
+
+    #[inline]
+    pub fn extract(self) -> (IdxSize, IdxSize) {
+        let row = (self.swizzled >> CHUNK_BITS) as IdxSize;
+
+        const MASK: IdxSize = IdxSize::MAX << CHUNK_BITS;
+        let chunk = (self.swizzled as IdxSize) & !MASK;
+        (chunk, row)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_chunk_idx() {
+        let chunk = 213908;
+        let row = 813457;
+
+        let ci = ChunkIdx::store(chunk, row);
+        let (c, r) = ci.extract();
+
+        assert_eq!(c, chunk);
+        assert_eq!(r, row);
+    }
+}


### PR DESCRIPTION
For `bigidx` this saves 8 bytes.