### PR TITLE
chore(rust): Enable `clippy` lint to warn on debug macros

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -44,7 +44,7 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Run cargo clippy with all features enabled
-        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -D clippy::dbg_macro
 
   # Default feature set should compile on the stable toolchain
   clippy-stable:
@@ -64,7 +64,7 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Run cargo clippy
-        run: cargo clippy --all-targets --locked -- -D warnings
+        run: cargo clippy --all-targets --locked -- -D warnings -D clippy::dbg_macro
 
   rustfmt:
     if: github.ref_name != 'main'

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,11 @@ build-release-native: .venv  ## Same as build-release, except with native CPU op
 	&& maturin develop -m py-polars/Cargo.toml --release -- -C target-cpu=native \
 	$(FILTER_PIP_WARNINGS)
 
+
+.PHONY: check
+check:  ## Run cargo check with all features
+	cargo clippy --workspace --all-targets --all-features
+
 .PHONY: clippy
 clippy:  ## Run clippy with all features
 	cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -D clippy::dbg_macro

--- a/Makefile
+++ b/Makefile
@@ -81,11 +81,11 @@ build-release-native: .venv  ## Same as build-release, except with native CPU op
 
 .PHONY: clippy
 clippy:  ## Run clippy with all features
-	cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
+	cargo clippy --workspace --all-targets --all-features --locked -- -D warnings -D clippy::dbg_macro
 
 .PHONY: clippy-default
 clippy-default:  ## Run clippy with default features
-	cargo clippy --all-targets --locked -- -D warnings
+	cargo clippy --all-targets --locked -- -D warnings -D clippy::dbg_macro
 
 .PHONY: fmt
 fmt:  ## Run autoformatting and linting

--- a/crates/Makefile
+++ b/crates/Makefile
@@ -14,11 +14,11 @@ check:  ## Run cargo check with all features
 
 .PHONY: clippy
 clippy:  ## Run clippy with all features
-	cargo clippy -p polars --all-features
+	cargo clippy -p polars --all-features -- -W clippy::dbg_macro
 
 .PHONY: clippy-default
 clippy-default:  ## Run clippy with default features
-	cargo clippy -p polars
+	cargo clippy -p polars -- -W clippy::dbg_macro
 
 .PHONY: pre-commit
 pre-commit: fmt clippy clippy-default  ## Run autoformatting and linting

--- a/crates/polars-arrow/src/legacy/kernels/list.rs
+++ b/crates/polars-arrow/src/legacy/kernels/list.rs
@@ -68,8 +68,6 @@ fn sublist_get_indexes(arr: &ListArray<i64>, index: i64) -> IdxArr {
 pub fn sublist_get(arr: &ListArray<i64>, index: i64) -> ArrayRef {
     let take_by = sublist_get_indexes(arr, index);
     let values = arr.values();
-    dbg!(&values);
-    dbg!(&take_by);
     // Safety:
     // the indices we generate are in bounds
     unsafe { take_unchecked(&**values, &take_by) }

--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -65,7 +65,7 @@ fmt: .venv  ## Run autoformatting and linting
 
 .PHONY: clippy
 clippy:  ## Run clippy
-	cargo clippy --locked -- -D warnings
+	cargo clippy --locked -- -D warnings -D clippy::dbg_macro
 
 .PHONY: pre-commit
 pre-commit: fmt clippy  ## Run all code quality checks


### PR DESCRIPTION
This should help avoid debug statements making it into the main branch by accident (I found and removed two of them).

Clippy docs:
https://rust-lang.github.io/rust-clippy/master/index.html#/dbg