### PR TITLE
fix(python): enable test coverage for read_excel with calamine on windows

### DIFF
--- a/py-polars/polars/io/spreadsheet/functions.py
+++ b/py-polars/polars/io/spreadsheet/functions.py
@@ -537,8 +537,9 @@ def _initialise_spreadsheet_parser(
     elif engine == "calamine":
         # note: can't read directly from bytes (yet) so
         if read_bytesio := isinstance(source, BytesIO):
-            # note: on windows, a NamedTemporaryFile cannot be reopened while bein already open, so
-            # we need to close it before passing it to read_excel and close it manually afterwards
+            # note: on windows, a NamedTemporaryFile cannot be reopened while being
+            # already open, so we need to close it before passing it to read_excel
+            # and close it manually afterwards
             temp_data = NamedTemporaryFile(delete=False)
         with nullcontext() if not read_bytesio else temp_data as tmp:  # type: ignore[attr-defined]
             if read_bytesio:

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -37,7 +37,7 @@ s3fs[boto3]
 # Spreadsheet
 ezodf
 lxml
-fastexcel>=0.7.0; platform_system != 'Windows'
+fastexcel>=0.8.0
 openpyxl
 pyxlsb
 xlsx2csv

--- a/py-polars/tests/unit/io/test_spreadsheet.py
+++ b/py-polars/tests/unit/io/test_spreadsheet.py
@@ -73,21 +73,7 @@ def path_ods_mixed(io_files_path: Path) -> Path:
         # xlsx file
         (pl.read_excel, "path_xlsx", {"engine": "xlsx2csv"}),
         (pl.read_excel, "path_xlsx", {"engine": "openpyxl"}),
-        pytest.param(
-            *(pl.read_excel, "path_xlsx", {"engine": "calamine"}),
-            marks=pytest.mark.skipif(
-                sys.platform == "win32",
-                reason="fastexcel not yet available on Windows",
-            ),
-        ),
         # xlsb file (binary)
-        pytest.param(
-            *(pl.read_excel, "path_xlsb", {"engine": "calamine"}),
-            marks=pytest.mark.skipif(
-                sys.platform == "win32",
-                reason="fastexcel not yet available on Windows",
-            ),
-        ),
         (pl.read_excel, "path_xlsb", {"engine": "pyxlsb"}),
         # open document
         (pl.read_ods, "path_ods", {}),
@@ -121,21 +107,7 @@ def test_read_spreadsheet(
         # xlsx file
         (pl.read_excel, "path_xlsx", {"engine": "xlsx2csv"}),
         (pl.read_excel, "path_xlsx", {"engine": "openpyxl"}),
-        pytest.param(
-            *(pl.read_excel, "path_xlsx", {"engine": "calamine"}),
-            marks=pytest.mark.skipif(
-                sys.platform == "win32",
-                reason="fastexcel not yet available on Windows",
-            ),
-        ),
         # xlsb file (binary)
-        pytest.param(
-            *(pl.read_excel, "path_xlsb", {"engine": "calamine"}),
-            marks=pytest.mark.skipif(
-                sys.platform == "win32",
-                reason="fastexcel not yet available on Windows",
-            ),
-        ),
         (pl.read_excel, "path_xlsb", {"engine": "pyxlsb"}),
         # open document
         (pl.read_ods, "path_ods", {}),
@@ -176,21 +148,7 @@ def test_read_excel_multi_sheets(
         # xlsx file
         (pl.read_excel, "path_xlsx", {"engine": "xlsx2csv"}),
         (pl.read_excel, "path_xlsx", {"engine": "openpyxl"}),
-        pytest.param(
-            *(pl.read_excel, "path_xlsx", {"engine": "calamine"}),
-            marks=pytest.mark.skipif(
-                sys.platform == "win32",
-                reason="fastexcel not yet available on Windows",
-            ),
-        ),
         # xlsb file (binary)
-        pytest.param(
-            *(pl.read_excel, "path_xlsb", {"engine": "calamine"}),
-            marks=pytest.mark.skipif(
-                sys.platform == "win32",
-                reason="fastexcel not yet available on Windows",
-            ),
-        ),
         (pl.read_excel, "path_xlsb", {"engine": "pyxlsb"}),
         # open document
         (pl.read_ods, "path_ods", {}),
@@ -231,13 +189,6 @@ def test_read_excel_all_sheets(
     ("engine", "schema_overrides"),
     [
         ("xlsx2csv", {"datetime": pl.Datetime}),
-        pytest.param(
-            *("calamine", None),
-            marks=pytest.mark.skipif(
-                sys.platform == "win32",
-                reason="fastexcel not yet available on Windows",
-            ),
-        ),
         ("openpyxl", None),
     ],
 )
@@ -275,21 +226,7 @@ def test_read_excel_basic_datatypes(
         # xlsx file
         (pl.read_excel, "path_xlsx", {"engine": "xlsx2csv"}),
         (pl.read_excel, "path_xlsx", {"engine": "openpyxl"}),
-        pytest.param(
-            *(pl.read_excel, "path_xlsx", {"engine": "calamine"}),
-            marks=pytest.mark.skipif(
-                sys.platform == "win32",
-                reason="fastexcel not yet available on Windows",
-            ),
-        ),
         # xlsb file (binary)
-        pytest.param(
-            *(pl.read_excel, "path_xlsb", {"engine": "calamine"}),
-            marks=pytest.mark.skipif(
-                sys.platform == "win32",
-                reason="fastexcel not yet available on Windows",
-            ),
-        ),
         (pl.read_excel, "path_xlsb", {"engine": "pyxlsb"}),
         # open document
         (pl.read_ods, "path_ods", {}),
@@ -378,13 +315,6 @@ def test_read_mixed_dtype_columns(
     [
         "xlsx2csv",
         "openpyxl",
-        pytest.param(
-            "calamine",
-            marks=pytest.mark.skipif(
-                sys.platform == "win32",
-                reason="fastexcel not yet available on Windows",
-            ),
-        ),
     ],
 )
 def test_write_excel_bytes(engine: ExcelSpreadsheetEngine) -> None:
@@ -497,13 +427,6 @@ def test_unsupported_binary_workbook(path_xlsx: Path, path_xlsb: Path) -> None:
     [
         "xlsx2csv",
         "openpyxl",
-        pytest.param(
-            "calamine",
-            marks=pytest.mark.skipif(
-                sys.platform == "win32",
-                reason="fastexcel not yet available on Windows",
-            ),
-        ),
     ],
 )
 def test_read_excel_all_sheets_with_sheet_name(path_xlsx: Path, engine: str) -> None:


### PR DESCRIPTION
This is an attempt to verify the theory explained here: https://github.com/ToucanToco/fastexcel/issues/154#issuecomment-1921307588 after having the tests fail on windows in https://github.com/pola-rs/polars/pull/14171