### PR TITLE
feat(rust): Implement strict/nonstrict conversion for primitive AnyValues

### DIFF
--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -3,12 +3,6 @@ use std::fmt::Write;
 use crate::prelude::*;
 use crate::utils::get_supertype;
 
-fn any_values_to_primitive<T: PolarsNumericType>(avs: &[AnyValue]) -> ChunkedArray<T> {
-    avs.iter()
-        .map(|av| av.extract::<T::Native>())
-        .collect_trusted()
-}
-
 #[cfg(feature = "dtype-decimal")]
 fn any_values_to_decimal(
     avs: &[AnyValue],
@@ -225,36 +219,36 @@ impl Series {
     ) -> PolarsResult<Series> {
         let mut s = match dtype {
             #[cfg(feature = "dtype-i8")]
-            DataType::Int8 => any_values_to_primitive::<Int8Type>(av).into_series(),
+            DataType::Int8 => any_values_to_integer::<Int8Type>(av, strict)?.into_series(),
             #[cfg(feature = "dtype-i16")]
-            DataType::Int16 => any_values_to_primitive::<Int16Type>(av).into_series(),
-            DataType::Int32 => any_values_to_primitive::<Int32Type>(av).into_series(),
-            DataType::Int64 => any_values_to_primitive::<Int64Type>(av).into_series(),
+            DataType::Int16 => any_values_to_integer::<Int16Type>(av, strict)?.into_series(),
+            DataType::Int32 => any_values_to_integer::<Int32Type>(av, strict)?.into_series(),
+            DataType::Int64 => any_values_to_integer::<Int64Type>(av, strict)?.into_series(),
             #[cfg(feature = "dtype-u8")]
-            DataType::UInt8 => any_values_to_primitive::<UInt8Type>(av).into_series(),
+            DataType::UInt8 => any_values_to_integer::<UInt8Type>(av, strict)?.into_series(),
             #[cfg(feature = "dtype-u16")]
-            DataType::UInt16 => any_values_to_primitive::<UInt16Type>(av).into_series(),
-            DataType::UInt32 => any_values_to_primitive::<UInt32Type>(av).into_series(),
-            DataType::UInt64 => any_values_to_primitive::<UInt64Type>(av).into_series(),
-            DataType::Float32 => any_values_to_primitive::<Float32Type>(av).into_series(),
-            DataType::Float64 => any_values_to_primitive::<Float64Type>(av).into_series(),
+            DataType::UInt16 => any_values_to_integer::<UInt16Type>(av, strict)?.into_series(),
+            DataType::UInt32 => any_values_to_integer::<UInt32Type>(av, strict)?.into_series(),
+            DataType::UInt64 => any_values_to_integer::<UInt64Type>(av, strict)?.into_series(),
+            DataType::Float32 => any_values_to_f32(av, strict)?.into_series(),
+            DataType::Float64 => any_values_to_f64(av, strict)?.into_series(),
             DataType::String => any_values_to_string(av, strict)?.into_series(),
             DataType::Binary => any_values_to_binary(av, strict)?.into_series(),
             DataType::Boolean => any_values_to_bool(av, strict)?.into_series(),
             #[cfg(feature = "dtype-date")]
-            DataType::Date => any_values_to_primitive::<Int32Type>(av)
+            DataType::Date => any_values_to_primitive_nonstrict::<Int32Type>(av)
                 .into_date()
                 .into_series(),
             #[cfg(feature = "dtype-datetime")]
-            DataType::Datetime(tu, tz) => any_values_to_primitive::<Int64Type>(av)
+            DataType::Datetime(tu, tz) => any_values_to_primitive_nonstrict::<Int64Type>(av)
                 .into_datetime(*tu, (*tz).clone())
                 .into_series(),
             #[cfg(feature = "dtype-time")]
-            DataType::Time => any_values_to_primitive::<Int64Type>(av)
+            DataType::Time => any_values_to_primitive_nonstrict::<Int64Type>(av)
                 .into_time()
                 .into_series(),
             #[cfg(feature = "dtype-duration")]
-            DataType::Duration(tu) => any_values_to_primitive::<Int64Type>(av)
+            DataType::Duration(tu) => any_values_to_primitive_nonstrict::<Int64Type>(av)
                 .into_duration(*tu)
                 .into_series(),
             #[cfg(feature = "dtype-decimal")]
@@ -457,6 +451,82 @@ impl Series {
             get_any_values_supertype(values)
         };
         Self::from_any_values_and_dtype(name, values, &dtype, strict)
+    }
+}
+
+fn any_values_to_primitive_nonstrict<T: PolarsNumericType>(values: &[AnyValue]) -> ChunkedArray<T> {
+    values
+        .iter()
+        .map(|av| av.extract::<T::Native>())
+        .collect_trusted()
+}
+
+fn any_values_to_integer<T: PolarsIntegerType>(
+    values: &[AnyValue],
+    strict: bool,
+) -> PolarsResult<ChunkedArray<T>> {
+    fn any_values_to_integer_strict<T: PolarsIntegerType>(
+        values: &[AnyValue],
+    ) -> PolarsResult<ChunkedArray<T>> {
+        let mut builder = PrimitiveChunkedBuilder::<T>::new("", values.len());
+        for av in values {
+            match av {
+                av if av.is_integer() => {
+                    let opt_val = av.extract::<T::Native>();
+                    let val = match opt_val {
+                        Some(v) => v,
+                        None => return Err(invalid_value_error(&T::get_dtype(), av)),
+                    };
+                    builder.append_value(val)
+                },
+                AnyValue::Null => builder.append_null(),
+                av => return Err(invalid_value_error(&T::get_dtype(), av)),
+            }
+        }
+        Ok(builder.finish())
+    }
+    if strict {
+        any_values_to_integer_strict::<T>(values)
+    } else {
+        Ok(any_values_to_primitive_nonstrict::<T>(values))
+    }
+}
+
+fn any_values_to_f32(values: &[AnyValue], strict: bool) -> PolarsResult<Float32Chunked> {
+    fn any_values_to_f32_strict(values: &[AnyValue]) -> PolarsResult<Float32Chunked> {
+        let mut builder = PrimitiveChunkedBuilder::<Float32Type>::new("", values.len());
+        for av in values {
+            match av {
+                AnyValue::Float32(i) => builder.append_value(*i),
+                AnyValue::Null => builder.append_null(),
+                av => return Err(invalid_value_error(&DataType::Float32, av)),
+            }
+        }
+        Ok(builder.finish())
+    }
+    if strict {
+        any_values_to_f32_strict(values)
+    } else {
+        Ok(any_values_to_primitive_nonstrict::<Float32Type>(values))
+    }
+}
+fn any_values_to_f64(values: &[AnyValue], strict: bool) -> PolarsResult<Float64Chunked> {
+    fn any_values_to_f64_strict(values: &[AnyValue]) -> PolarsResult<Float64Chunked> {
+        let mut builder = PrimitiveChunkedBuilder::<Float64Type>::new("", values.len());
+        for av in values {
+            match av {
+                AnyValue::Float64(i) => builder.append_value(*i),
+                AnyValue::Float32(i) => builder.append_value(*i as f64),
+                AnyValue::Null => builder.append_null(),
+                av => return Err(invalid_value_error(&DataType::Float64, av)),
+            }
+        }
+        Ok(builder.finish())
+    }
+    if strict {
+        any_values_to_f64_strict(values)
+    } else {
+        Ok(any_values_to_primitive_nonstrict::<Float64Type>(values))
     }
 }
 

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -15,6 +15,8 @@ from polars.utils._wrap import wrap_s
 @pytest.mark.parametrize(
     ("dtype", "values"),
     [
+        (pl.Int64, [-1, 0, 100_000, None]),
+        (pl.Float64, [-1.5, 0.0, 10.0, None]),
         (pl.Boolean, [True, False, None]),
         (pl.Binary, [b"123", b"xyz", None]),
         (pl.String, ["123", "xyz", None]),
@@ -32,6 +34,8 @@ def test_fallback_with_dtype_strict(
 @pytest.mark.parametrize(
     ("dtype", "values"),
     [
+        (pl.Int64, [1.0, 2.0]),
+        (pl.Float64, [1, 2]),
         (pl.Boolean, [0, 1]),
         (pl.Binary, ["123", "xyz"]),
         (pl.String, [b"123", b"xyz"]),
@@ -41,16 +45,26 @@ def test_fallback_with_dtype_strict_failure(
     dtype: pl.PolarsDataType, values: list[Any]
 ) -> None:
     with pytest.raises(pl.SchemaError, match="unexpected value"):
-        PySeries.new_from_any_values_and_dtype("", values, pl.Boolean, strict=True)
+        PySeries.new_from_any_values_and_dtype("", values, dtype, strict=True)
 
 
 @pytest.mark.parametrize(
     ("dtype", "values", "expected"),
     [
         (
+            pl.Int64,
+            [False, True, 0, -1, 0.0, 2.5, date(1970, 1, 2), "5", "xyz"],
+            [0, 1, 0, -1, 0, 2, 1, 5, None],
+        ),
+        (
+            pl.Float64,
+            [False, True, 0, -1, 0.0, 2.5, date(1970, 1, 2), "5", "xyz"],
+            [0.0, 1.0, 0.0, -1.0, 0.0, 2.5, 1.0, 5.0, None],
+        ),
+        (
             pl.Boolean,
-            [False, True, 0, 1, 0.0, 2.5, date(1970, 1, 1)],
-            [False, True, False, True, False, True, None],
+            [False, True, 0, -1, 0.0, 2.5, date(1970, 1, 1), "true"],
+            [False, True, False, True, False, True, None, None],
         ),
         (
             pl.Binary,

--- a/py-polars/tests/unit/testing/test_assert_frame_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_frame_equal.py
@@ -250,8 +250,8 @@ def test_compare_frame_equal_nested_nans() -> None:
             {
                 "id": 2,
                 "struct": [
-                    {"x": "text", "y": [nan, 1], "z": ["!"]},
-                    {"x": "text", "y": [nan, 1], "z": ["?"]},
+                    {"x": "text", "y": [nan, 1.0], "z": ["!"]},
+                    {"x": "text", "y": [nan, 1.0], "z": ["?"]},
                 ],
             },
         ]


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/11156

#### Changes

Implement strict construction for primitives:
* Allow any mix of integers as long as they can be cast without overflow.
* Allow constructing `f64` from a mix of `f32/f64`
* Allow constructing `f32` only from `f32`