### PR TITLE
perf: Use a compression API that is designed for this use case (#11699)

### DIFF
--- a/crates/polars-parquet/src/parquet/compression.rs
+++ b/crates/polars-parquet/src/parquet/compression.rs
@@ -96,8 +96,8 @@ pub fn compress(
         #[cfg(feature = "zstd")]
         CompressionOptions::Zstd(level) => {
             let level = level.map(|v| v.compression_level()).unwrap_or_default();
-            // Make sure the buffer is large enough; the tests at least have a
-            // weird assumption that decompressed data is appended...
+            // Make sure the buffer is large enough; the interface assumption is
+            // that decompressed data is appended to the output buffer.
             let old_len = output_buf.len();
             output_buf.resize(
                 old_len + zstd::zstd_safe::compress_bound(input_buf.len()),

--- a/crates/polars-parquet/src/parquet/compression.rs
+++ b/crates/polars-parquet/src/parquet/compression.rs
@@ -99,7 +99,10 @@ pub fn compress(
             // Make sure the buffer is large enough; the tests at least have a
             // weird assumption that decompressed data is appended...
             let old_len = output_buf.len();
-            output_buf.resize(old_len + zstd::zstd_safe::compress_bound(input_buf.len()), 0);
+            output_buf.resize(
+                old_len + zstd::zstd_safe::compress_bound(input_buf.len()),
+                0,
+            );
             match zstd::bulk::compress_to_buffer(input_buf, &mut output_buf[old_len..], level) {
                 Ok(written_size) => {
                     output_buf.truncate(old_len + written_size);


### PR DESCRIPTION
My impression is that #11699 is due to multiple different performance issues. This PR fixes one of them, but does not fix the whole performance difference. See below for numbers.

### Why this change

Perf showed the following:

```
-   51.46%     0.11%  python  [.] polars_parquet::parquet::compression::compress 
- ▒   - 51.35% polars_parquet::parquet::compression::compress                                                                                                                                   
- ▒      - 28.61% ZSTD_compressStream                                                                                                                                                           
- ▒         - ZSTD_compressStream2                                                                                                                                                              
- ▒            - 28.16% ZSTD_CCtx_init_compressStream2                                                                                                                                          
- ▒               - 27.79% ZSTD_compressBegin_internal                                                                                                                                          
- ▒                  - 27.75% ZSTD_resetCCtx_internal                                                                                                                                           
- ▒                     - 27.42% ZSTD_reset_matchState                                                                                                                                          
- ▒                          27.37% __memset_avx2_unaligned_erms                                                                                                                                
```

The `zstd` docs suggest the `Encoder` has a 128KB internal buffer, and apparently some amount of time was needed just to clear it out (presumably over and over again). The solution was to switch to the bulk API which doesn't initialize as much state on each call. (And in practice the original compression wasn't take advantage of the theoretical ability to stream).

(A similar change could in theory be made for decompression, but the API for estimating an upper bound on decompressed data is experimental, so it's unclear how much memory to allocate in the output buffer.)

### Measuring performance

Test script:

```python
from datetime import datetime

import polars as pl

start_datetime = datetime(2020, 1, 1)
end_datetime = datetime(
    2024,
    1,
    1,
)
N_ids = 10
interval = "1m"
df = (
    pl.LazyFrame(
        {
            "time": pl.datetime_range(
                start_datetime, end_datetime, interval=interval, eager=True
            )
        }
    )
    .join(
        pl.LazyFrame(
            {"id": [f"id{i:05d}" for i in range(N_ids)], "value": list(range(N_ids))}
        ),
        how="cross",
    )
    .select("time", "id", "value")
)

from time import time

start = time()
df.sink_parquet("/tmp/out.parquet")
print("SINK", time() - start)

start = time()
df.collect().write_parquet("/tmp/out2.parquet")
print("COLLECT+WRITE", time() - start)
```

Benchmarking is done with `make build-opt`.

Initial values:

```
SINK 3.4813475608825684
COLLECT+WRITE 0.958869218826294
```

After zstd tweak:

```
SINK 2.9080893993377686
COLLECT+WRITE 0.9803664684295654
```

`COLLECT+WRITE` might be somewhat slower as a result of this.