### PR TITLE
feat: make `IdxVec` generic as `UnitVec`

### DIFF
--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -134,7 +134,7 @@ pub(crate) fn create_extension<I: Iterator<Item = Option<T>> + TrustedLen, T: Si
 mod test {
     use std::fmt::{Display, Formatter};
 
-    use polars_utils::idxvec;
+    use polars_utils::unitvec;
 
     use super::*;
 
@@ -200,7 +200,7 @@ mod test {
         let ca = ObjectChunked::new("", values);
 
         let groups =
-            GroupsProxy::Idx(vec![(0, idxvec![0, 1]), (2, idxvec![2]), (3, idxvec![3])].into());
+            GroupsProxy::Idx(vec![(0, unitvec![0, 1]), (2, unitvec![2]), (3, unitvec![3])].into());
         let out = unsafe { ca.agg_list(&groups) };
         assert!(matches!(out.dtype(), DataType::List(_)));
         assert_eq!(out.len(), groups.len());
@@ -223,7 +223,7 @@ mod test {
         let values = &[Some(foo1.clone()), None, Some(foo2.clone()), None];
         let ca = ObjectChunked::new("", values);
 
-        let groups = vec![(0, idxvec![0, 1]), (2, idxvec![2]), (3, idxvec![3])].into();
+        let groups = vec![(0, unitvec![0, 1]), (2, unitvec![2]), (3, unitvec![3])].into();
         let out = unsafe { ca.agg_list(&GroupsProxy::Idx(groups)) };
         let a = out.explode().unwrap();
 

--- a/crates/polars-core/src/frame/group_by/hashing.rs
+++ b/crates/polars-core/src/frame/group_by/hashing.rs
@@ -4,9 +4,9 @@ use hashbrown::hash_map::{Entry, RawEntryMut};
 use hashbrown::HashMap;
 use polars_utils::hashing::{hash_to_partition, DirtyHash};
 use polars_utils::idx_vec::IdxVec;
-use polars_utils::idxvec;
 use polars_utils::iter::EnumerateIdxTrait;
 use polars_utils::sync::SyncPtr;
+use polars_utils::unitvec;
 use rayon::prelude::*;
 
 use super::GroupsProxy;
@@ -156,7 +156,7 @@ where
 
         match entry {
             Entry::Vacant(entry) => {
-                let tuples = idxvec![idx];
+                let tuples = unitvec![idx];
                 entry.insert((idx, tuples));
             },
             Entry::Occupied(mut entry) => {
@@ -220,7 +220,7 @@ where
 
                             match entry {
                                 RawEntryMut::Vacant(entry) => {
-                                    let tuples = idxvec![idx];
+                                    let tuples = unitvec![idx];
                                     entry.insert_with_hasher(hash, *k, (idx, tuples), |k| {
                                         hasher.hash_one(k)
                                     });
@@ -283,7 +283,7 @@ where
 
                             match entry {
                                 RawEntryMut::Vacant(entry) => {
-                                    let tuples = idxvec![idx];
+                                    let tuples = unitvec![idx];
                                     entry.insert_with_hasher(hash, k, (idx, tuples), |k| {
                                         hasher.hash_one(k)
                                     });
@@ -438,7 +438,7 @@ pub(crate) fn group_by_threaded_multiple_keys_flat(
                                         let all_vals = &mut *(all_buf_ptr as *mut Vec<IdxVec>);
                                         let offset_idx = first_vals.len() as IdxSize;
 
-                                        let tuples = idxvec![row_idx];
+                                        let tuples = unitvec![row_idx];
                                         all_vals.push(tuples);
                                         first_vals.push(row_idx);
                                         offset_idx
@@ -501,7 +501,7 @@ pub(crate) fn group_by_multiple_keys(keys: DataFrame, sorted: bool) -> PolarsRes
                 let all_vals = &mut *(all_buf_ptr as *mut Vec<IdxVec>);
                 let offset_idx = first_vals.len() as IdxSize;
 
-                let tuples = idxvec![row_idx];
+                let tuples = unitvec![row_idx];
                 all_vals.push(tuples);
                 first_vals.push(row_idx);
                 offset_idx

--- a/crates/polars-lazy/src/tests/aggregations.rs
+++ b/crates/polars-lazy/src/tests/aggregations.rs
@@ -1,5 +1,5 @@
 use polars_ops::prelude::ListNameSpaceImpl;
-use polars_utils::idxvec;
+use polars_utils::unitvec;
 
 use super::*;
 
@@ -9,7 +9,7 @@ fn test_agg_list_type() -> PolarsResult<()> {
     let s = Series::new("foo", &[1, 2, 3]);
     let s = s.cast(&DataType::Datetime(TimeUnit::Nanoseconds, None))?;
 
-    let l = unsafe { s.agg_list(&GroupsProxy::Idx(vec![(0, idxvec![0, 1, 2])].into())) };
+    let l = unsafe { s.agg_list(&GroupsProxy::Idx(vec![(0, unitvec![0, 1, 2])].into())) };
 
     let result = match l.dtype() {
         DataType::List(inner) => {

--- a/crates/polars-ops/src/frame/join/hash_join/multiple_keys.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/multiple_keys.rs
@@ -8,7 +8,7 @@ use polars_core::utils::{_set_partition_size, split_df};
 use polars_core::POOL;
 use polars_utils::hashing::hash_to_partition;
 use polars_utils::idx_vec::IdxVec;
-use polars_utils::idxvec;
+use polars_utils::unitvec;
 
 use super::*;
 
@@ -61,7 +61,7 @@ pub(crate) fn create_probe_table(
                                     idx,
                                     *h,
                                     keys,
-                                    || idxvec![idx],
+                                    || unitvec![idx],
                                     |v| v.push(idx),
                                 )
                             }
@@ -108,7 +108,7 @@ fn create_build_table_outer(
                                 idx,
                                 *h,
                                 keys,
-                                || (false, idxvec![idx]),
+                                || (false, unitvec![idx]),
                                 |v| v.1.push(idx),
                             )
                         }

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys.rs
@@ -1,8 +1,8 @@
 use polars_utils::hashing::{hash_to_partition, DirtyHash};
 use polars_utils::idx_vec::IdxVec;
-use polars_utils::idxvec;
 use polars_utils::nulls::IsNull;
 use polars_utils::sync::SyncPtr;
+use polars_utils::unitvec;
 
 use super::*;
 
@@ -142,7 +142,7 @@ where
                                     o.get_mut().push(idx as IdxSize);
                                 },
                                 Entry::Vacant(v) => {
-                                    let iv = idxvec![idx as IdxSize];
+                                    let iv = unitvec![idx as IdxSize];
                                     v.insert(iv);
                                 },
                             };

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_outer.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_outer.rs
@@ -2,8 +2,8 @@ use arrow::array::{MutablePrimitiveArray, PrimitiveArray};
 use arrow::legacy::utils::CustomIterTools;
 use polars_utils::hashing::hash_to_partition;
 use polars_utils::idx_vec::IdxVec;
-use polars_utils::idxvec;
 use polars_utils::nulls::IsNull;
+use polars_utils::unitvec;
 
 use super::*;
 
@@ -72,7 +72,7 @@ where
 
                                 match entry {
                                     RawEntryMut::Vacant(entry) => {
-                                        entry.insert_hashed_nocheck(*h, *k, (false, idxvec![idx]));
+                                        entry.insert_hashed_nocheck(*h, *k, (false, unitvec![idx]));
                                     },
                                     RawEntryMut::Occupied(mut entry) => {
                                         let (_k, v) = entry.get_key_value_mut();

--- a/crates/polars-time/src/group_by/dynamic.rs
+++ b/crates/polars-time/src/group_by/dynamic.rs
@@ -661,7 +661,7 @@ fn update_subgroups_idx(
 mod test {
     use chrono::prelude::*;
     use polars_ops::prelude::*;
-    use polars_utils::idxvec;
+    use polars_utils::unitvec;
 
     use super::*;
 
@@ -899,12 +899,12 @@ mod test {
 
         let expected = GroupsProxy::Idx(
             vec![
-                (0 as IdxSize, idxvec![0 as IdxSize, 1, 2]),
-                (2, idxvec![2]),
-                (5, idxvec![5, 6]),
-                (6, idxvec![6]),
-                (3, idxvec![3, 4]),
-                (4, idxvec![4]),
+                (0 as IdxSize, unitvec![0 as IdxSize, 1, 2]),
+                (2, unitvec![2]),
+                (5, unitvec![5, 6]),
+                (6, unitvec![6]),
+                (3, unitvec![3, 4]),
+                (4, unitvec![4]),
             ]
             .into(),
         );

--- a/crates/polars-utils/src/idx_vec.rs
+++ b/crates/polars-utils/src/idx_vec.rs
@@ -4,24 +4,26 @@ use std::ops::Deref;
 
 use crate::IdxSize;
 
-/// A type logically equivalent to `Vec<IdxSize>`, but which does not do a
+pub type IdxVec = UnitVec<IdxSize>;
+
+/// A type logically equivalent to `Vec<T>`, but which does not do a
 /// memory allocation until at least two elements have been pushed, storing the
 /// first element in the data pointer directly.
 #[derive(Eq)]
-pub struct IdxVec {
+pub struct UnitVec<T: Copy> {
     len: usize,
     capacity: NonZeroUsize,
-    data: *mut IdxSize,
+    data: *mut T,
 }
 
-unsafe impl Send for IdxVec {}
-unsafe impl Sync for IdxVec {}
+unsafe impl<T: Copy + Send + Sync> Send for UnitVec<T> {}
+unsafe impl<T: Copy + Send + Sync> Sync for UnitVec<T> {}
 
-impl IdxVec {
+impl<T: Copy> UnitVec<T> {
     #[inline(always)]
-    fn data_ptr_mut(&mut self) -> *mut IdxSize {
+    fn data_ptr_mut(&mut self) -> *mut T {
         let external = self.data;
-        let inline = &mut self.data as *mut *mut IdxSize as *mut IdxSize;
+        let inline = &mut self.data as *mut *mut T as *mut T;
         if self.capacity.get() == 1 {
             inline
         } else {
@@ -30,9 +32,9 @@ impl IdxVec {
     }
 
     #[inline(always)]
-    fn data_ptr(&self) -> *const IdxSize {
+    fn data_ptr(&self) -> *const T {
         let external = self.data;
-        let inline = &self.data as *const *mut IdxSize as *mut IdxSize;
+        let inline = &self.data as *const *mut T as *mut T;
         if self.capacity.get() == 1 {
             inline
         } else {
@@ -64,7 +66,7 @@ impl IdxVec {
     }
 
     #[inline(always)]
-    pub fn push(&mut self, idx: IdxSize) {
+    pub fn push(&mut self, idx: T) {
         if self.len == self.capacity.get() {
             self.reserve(1);
         }
@@ -74,8 +76,8 @@ impl IdxVec {
 
     #[inline(always)]
     /// # Safety
-    /// Caller must ensure that `IdxVec` has enough capacity.
-    pub unsafe fn push_unchecked(&mut self, idx: IdxSize) {
+    /// Caller must ensure that `UnitVec` has enough capacity.
+    pub unsafe fn push_unchecked(&mut self, idx: T) {
         unsafe {
             self.data_ptr_mut().add(self.len).write(idx);
             self.len += 1;
@@ -118,36 +120,36 @@ impl IdxVec {
         new
     }
 
-    pub fn iter(&self) -> std::slice::Iter<'_, IdxSize> {
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
         self.as_slice().iter()
     }
 
-    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, IdxSize> {
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, T> {
         self.as_mut_slice().iter_mut()
     }
 
-    pub fn as_slice(&self) -> &[IdxSize] {
+    pub fn as_slice(&self) -> &[T] {
         self.as_ref()
     }
 
-    pub fn as_mut_slice(&mut self) -> &mut [IdxSize] {
+    pub fn as_mut_slice(&mut self) -> &mut [T] {
         self.as_mut()
     }
 }
 
-impl Drop for IdxVec {
+impl<T: Copy> Drop for UnitVec<T> {
     fn drop(&mut self) {
         self.dealloc()
     }
 }
 
-impl Clone for IdxVec {
+impl<T: Copy> Clone for UnitVec<T> {
     fn clone(&self) -> Self {
         unsafe {
             let mut me = std::mem::ManuallyDrop::new(Vec::with_capacity(self.len));
             let buffer = me.as_mut_ptr();
             std::ptr::copy(self.data_ptr(), buffer, self.len);
-            IdxVec {
+            UnitVec {
                 data: buffer,
                 len: self.len,
                 capacity: NonZeroUsize::new(std::cmp::max(self.len, 1)).unwrap(),
@@ -156,13 +158,13 @@ impl Clone for IdxVec {
     }
 }
 
-impl Debug for IdxVec {
+impl<T: Copy + Debug> Debug for UnitVec<T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "IdxVec: {:?}", self.as_slice())
+        write!(f, "UnitVec: {:?}", self.as_slice())
     }
 }
 
-impl Default for IdxVec {
+impl<T: Copy> Default for UnitVec<T> {
     fn default() -> Self {
         Self {
             len: 0,
@@ -172,37 +174,37 @@ impl Default for IdxVec {
     }
 }
 
-impl Deref for IdxVec {
-    type Target = [IdxSize];
+impl<T: Copy> Deref for UnitVec<T> {
+    type Target = [T];
 
     fn deref(&self) -> &Self::Target {
         self.as_slice()
     }
 }
 
-impl AsRef<[IdxSize]> for IdxVec {
-    fn as_ref(&self) -> &[IdxSize] {
+impl<T: Copy> AsRef<[T]> for UnitVec<T> {
+    fn as_ref(&self) -> &[T] {
         unsafe { std::slice::from_raw_parts(self.data_ptr(), self.len) }
     }
 }
 
-impl AsMut<[IdxSize]> for IdxVec {
-    fn as_mut(&mut self) -> &mut [IdxSize] {
+impl<T: Copy> AsMut<[T]> for UnitVec<T> {
+    fn as_mut(&mut self) -> &mut [T] {
         unsafe { std::slice::from_raw_parts_mut(self.data_ptr_mut(), self.len) }
     }
 }
 
-impl PartialEq for IdxVec {
+impl<T: PartialEq + Copy> PartialEq for UnitVec<T> {
     fn eq(&self, other: &Self) -> bool {
         self.as_slice() == other.as_slice()
     }
 }
 
-impl FromIterator<IdxSize> for IdxVec {
-    fn from_iter<T: IntoIterator<Item = IdxSize>>(iter: T) -> Self {
+impl<T: Copy> FromIterator<T> for UnitVec<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         let iter = iter.into_iter();
         if iter.size_hint().0 <= 1 {
-            let mut new = IdxVec::new();
+            let mut new = UnitVec::new();
             for v in iter {
                 new.push(v)
             }
@@ -214,17 +216,17 @@ impl FromIterator<IdxSize> for IdxVec {
     }
 }
 
-impl From<Vec<IdxSize>> for IdxVec {
-    fn from(value: Vec<IdxSize>) -> Self {
+impl<T: Copy> From<Vec<T>> for UnitVec<T> {
+    fn from(value: Vec<T>) -> Self {
         if value.capacity() <= 1 {
-            let mut new = IdxVec::new();
+            let mut new = UnitVec::new();
             if let Some(v) = value.first() {
                 new.push(*v)
             }
             new
         } else {
             let mut me = std::mem::ManuallyDrop::new(value);
-            IdxVec {
+            UnitVec {
                 data: me.as_mut_ptr(),
                 capacity: NonZeroUsize::new(me.capacity()).unwrap(),
                 len: me.len(),
@@ -233,10 +235,10 @@ impl From<Vec<IdxSize>> for IdxVec {
     }
 }
 
-impl From<&[IdxSize]> for IdxVec {
-    fn from(value: &[IdxSize]) -> Self {
+impl<T: Copy> From<&[T]> for UnitVec<T> {
+    fn from(value: &[T]) -> Self {
         if value.len() <= 1 {
-            let mut new = IdxVec::new();
+            let mut new = UnitVec::new();
             if let Some(v) = value.first() {
                 new.push(*v)
             }
@@ -250,17 +252,17 @@ impl From<&[IdxSize]> for IdxVec {
 #[macro_export]
 macro_rules! idxvec {
     () => (
-        $crate::idx_vec::IdxVec::new()
+        $crate::idx_vec::UnitVec::new()
     );
     ($elem:expr; $n:expr) => (
-        let mut new = $crate::idx_vec::IdxVec::new();
+        let mut new = $crate::idx_vec::UnitVec::new();
         for _ in 0..$n {
             new.push($elem)
         }
         new
     );
     ($elem:expr) => (
-        {let mut new = $crate::idx_vec::IdxVec::new();
+        {let mut new = $crate::idx_vec::UnitVec::new();
         // SAFETY: first element always fits.
         unsafe { new.push_unchecked($elem) };
         new}

--- a/crates/polars-utils/src/idx_vec.rs
+++ b/crates/polars-utils/src/idx_vec.rs
@@ -250,7 +250,7 @@ impl<T: Copy> From<&[T]> for UnitVec<T> {
 }
 
 #[macro_export]
-macro_rules! idxvec {
+macro_rules! unitvec {
     () => (
         $crate::idx_vec::UnitVec::new()
     );


### PR DESCRIPTION
Can now be used throughout the library to elide early allocations (where we didn't already). Things that come to mind: 

- streaming joins
- expression/logical-plan iterations

Both mostly have a single value, but can grow to unknown size.