### PR TITLE
fix: Allow chaining joins in SQL syntax

### DIFF
--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -813,7 +813,10 @@ pub(super) fn process_join(
     join_tbl_name: &str,
     join_type: JoinType,
 ) -> PolarsResult<LazyFrame> {
-    let left_names = left_names.iter().map(|name| name.as_ref()).collect::<Vec<_>>();
+    let left_names = left_names
+        .iter()
+        .map(|name| name.as_ref())
+        .collect::<Vec<_>>();
     let (left_on, right_on) = process_join_constraint(constraint, &left_names, join_tbl_name)?;
 
     Ok(left_tbl

--- a/crates/polars-sql/tests/iss_14217.rs
+++ b/crates/polars-sql/tests/iss_14217.rs
@@ -1,0 +1,50 @@
+use polars_core::prelude::*;
+use polars_lazy::prelude::*;
+use polars_sql::*;
+
+#[test]
+fn iss_14217() -> PolarsResult<()> {
+    let mut ctx = SQLContext::new();
+    
+    let df1 = df! {
+        "a" => [1, 2, 3],
+        "b" => [4, 5, 6],
+    }
+    .unwrap();
+
+    let df2 = df! {
+        "b" => [4, 5, 6],
+        "c" => [7, 8, 9]
+    }
+    .unwrap();
+
+    let df3 = df! {
+        "c" => [7, 8, 9],
+        "d" => [10, 11, 12],
+    }
+    .unwrap();
+
+    ctx.register("df1", df1.lazy());
+    ctx.register("df2", df2.lazy());
+    ctx.register("df3", df3.lazy());
+    
+    let sql = r#"
+        SELECT * FROM df1
+        INNER JOIN df2 ON df1.b = df2.b
+        INNER JOIN df3 ON df2.c = df3.c
+    "#;
+
+    let result = ctx.execute(sql).unwrap();
+    
+    let expected_df = df! {
+        "a" => [1, 2, 3],
+        "b" => [4, 5, 6],
+        "c" => [7, 8, 9],
+        "d" => [10, 11, 12],
+    }
+    .unwrap();
+    
+    assert!(result.collect()?.equals(&expected_df));
+
+    Ok(())
+}

--- a/crates/polars-sql/tests/iss_14217.rs
+++ b/crates/polars-sql/tests/iss_14217.rs
@@ -5,7 +5,7 @@ use polars_sql::*;
 #[test]
 fn iss_14217() -> PolarsResult<()> {
     let mut ctx = SQLContext::new();
-    
+
     let df1 = df! {
         "a" => [1, 2, 3],
         "b" => [4, 5, 6],
@@ -27,7 +27,7 @@ fn iss_14217() -> PolarsResult<()> {
     ctx.register("df1", df1.lazy());
     ctx.register("df2", df2.lazy());
     ctx.register("df3", df3.lazy());
-    
+
     let sql = r#"
         SELECT * FROM df1
         INNER JOIN df2 ON df1.b = df2.b
@@ -35,7 +35,7 @@ fn iss_14217() -> PolarsResult<()> {
     "#;
 
     let result = ctx.execute(sql).unwrap();
-    
+
     let expected_df = df! {
         "a" => [1, 2, 3],
         "b" => [4, 5, 6],
@@ -43,7 +43,7 @@ fn iss_14217() -> PolarsResult<()> {
         "d" => [10, 11, 12],
     }
     .unwrap();
-    
+
     assert!(result.collect()?.equals(&expected_df));
 
     Ok(())


### PR DESCRIPTION
Fixes #14217

With this fix, any of the previously joined table names can be used to refer to any of the previously joined tables. For example, in the query

```SQL
SELECT * FROM df1
INNER JOIN df2 ON ...
INNER JOIN df3 ON <join condition>
```
in the join condition marked `<join condition>` you can use either `df1.` or `df2.` to refer to any column on the left side of the join. For instance, you can use `df1.x` even if column `x` only exists in `df2`. You can also use `df2.y` even if column `y` only exists in `df1`.

That is more generous than should be the case of course, in the sense that this new implementation accepts some invalid queries where it should give an error. However, in the current implementation, you can already use `df1.` to refer to any column (of dataframe `df1` or `df2`) but cannot use `df2` at all (see issue #14217).