### PR TITLE
fix: Fix join validation for String types

### DIFF
--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
@@ -45,35 +45,27 @@ pub trait SeriesJoin: SeriesSealed + Sized {
         let (lhs, rhs) = (s_self.to_physical_repr(), other.to_physical_repr());
 
         use DataType::*;
-        match lhs.dtype() {
-            String => {
-                let lhs = lhs.cast(&Binary).unwrap();
-                let rhs = rhs.cast(&Binary).unwrap();
-                lhs.hash_join_semi_anti(&rhs, anti)
-            },
-            Binary => {
-                let lhs = lhs.binary().unwrap();
-                let rhs = rhs.binary().unwrap();
-                let (lhs, rhs, _, _) = prepare_binary(lhs, rhs, false);
-                let lhs = lhs.iter().map(|v| v.as_slice()).collect::<Vec<_>>();
-                let rhs = rhs.iter().map(|v| v.as_slice()).collect::<Vec<_>>();
-                if anti {
-                    hash_join_tuples_left_anti(lhs, rhs)
-                } else {
-                    hash_join_tuples_left_semi(lhs, rhs)
-                }
-            },
-            _ => {
-                if s_self.bit_repr_is_large() {
-                    let lhs = lhs.bit_repr_large();
-                    let rhs = rhs.bit_repr_large();
-                    num_group_join_anti_semi(&lhs, &rhs, anti)
-                } else {
-                    let lhs = lhs.bit_repr_small();
-                    let rhs = rhs.bit_repr_small();
-                    num_group_join_anti_semi(&lhs, &rhs, anti)
-                }
-            },
+        if matches!(lhs.dtype(), String | Binary) {
+            let lhs = lhs.cast(&Binary).unwrap();
+            let rhs = rhs.cast(&Binary).unwrap();
+            let lhs = lhs.binary().unwrap();
+            let rhs = rhs.binary().unwrap();
+            let (lhs, rhs, _, _) = prepare_binary(lhs, rhs, false);
+            let lhs = lhs.iter().map(|v| v.as_slice()).collect::<Vec<_>>();
+            let rhs = rhs.iter().map(|v| v.as_slice()).collect::<Vec<_>>();
+            if anti {
+                hash_join_tuples_left_anti(lhs, rhs)
+            } else {
+                hash_join_tuples_left_semi(lhs, rhs)
+            }
+        } else if s_self.bit_repr_is_large() {
+            let lhs = lhs.bit_repr_large();
+            let rhs = rhs.bit_repr_large();
+            num_group_join_anti_semi(&lhs, &rhs, anti)
+        } else {
+            let lhs = lhs.bit_repr_small();
+            let rhs = rhs.bit_repr_small();
+            num_group_join_anti_semi(&lhs, &rhs, anti)
         }
     }
 
@@ -89,34 +81,26 @@ pub trait SeriesJoin: SeriesSealed + Sized {
         validate.validate_probe(&lhs, &rhs, true)?;
 
         use DataType::*;
-        match lhs.dtype() {
-            String => {
-                let lhs = lhs.cast(&Binary).unwrap();
-                let rhs = rhs.cast(&Binary).unwrap();
-                lhs.hash_join_inner(&rhs, JoinValidation::ManyToMany, join_nulls)
-            },
-            Binary => {
-                let lhs = lhs.binary().unwrap();
-                let rhs = rhs.binary().unwrap();
-                let (lhs, rhs, swapped, _) = prepare_binary(lhs, rhs, true);
-                let lhs = lhs.iter().map(|v| v.as_slice()).collect::<Vec<_>>();
-                let rhs = rhs.iter().map(|v| v.as_slice()).collect::<Vec<_>>();
-                Ok((
-                    hash_join_tuples_inner(lhs, rhs, swapped, validate, join_nulls)?,
-                    !swapped,
-                ))
-            },
-            _ => {
-                if s_self.bit_repr_is_large() {
-                    let lhs = s_self.bit_repr_large();
-                    let rhs = other.bit_repr_large();
-                    group_join_inner::<UInt64Type>(&lhs, &rhs, validate, join_nulls)
-                } else {
-                    let lhs = s_self.bit_repr_small();
-                    let rhs = other.bit_repr_small();
-                    group_join_inner::<UInt32Type>(&lhs, &rhs, validate, join_nulls)
-                }
-            },
+        if matches!(lhs.dtype(), String | Binary) {
+            let lhs = lhs.cast(&Binary).unwrap();
+            let rhs = rhs.cast(&Binary).unwrap();
+            let lhs = lhs.binary().unwrap();
+            let rhs = rhs.binary().unwrap();
+            let (lhs, rhs, swapped, _) = prepare_binary(lhs, rhs, true);
+            let lhs = lhs.iter().map(|v| v.as_slice()).collect::<Vec<_>>();
+            let rhs = rhs.iter().map(|v| v.as_slice()).collect::<Vec<_>>();
+            Ok((
+                hash_join_tuples_inner(lhs, rhs, swapped, validate, join_nulls)?,
+                !swapped,
+            ))
+        } else if s_self.bit_repr_is_large() {
+            let lhs = s_self.bit_repr_large();
+            let rhs = other.bit_repr_large();
+            group_join_inner::<UInt64Type>(&lhs, &rhs, validate, join_nulls)
+        } else {
+            let lhs = s_self.bit_repr_small();
+            let rhs = other.bit_repr_small();
+            group_join_inner::<UInt32Type>(&lhs, &rhs, validate, join_nulls)
         }
     }
 
@@ -131,31 +115,23 @@ pub trait SeriesJoin: SeriesSealed + Sized {
         validate.validate_probe(&lhs, &rhs, true)?;
 
         use DataType::*;
-        match lhs.dtype() {
-            String => {
-                let lhs = lhs.cast(&Binary).unwrap();
-                let rhs = rhs.cast(&Binary).unwrap();
-                lhs.hash_join_outer(&rhs, JoinValidation::ManyToMany, join_nulls)
-            },
-            Binary => {
-                let lhs = lhs.binary().unwrap();
-                let rhs = rhs.binary().unwrap();
-                let (lhs, rhs, swapped, _) = prepare_binary(lhs, rhs, true);
-                let lhs = lhs.iter().collect::<Vec<_>>();
-                let rhs = rhs.iter().collect::<Vec<_>>();
-                hash_join_tuples_outer(lhs, rhs, swapped, validate, join_nulls)
-            },
-            _ => {
-                if s_self.bit_repr_is_large() {
-                    let lhs = s_self.bit_repr_large();
-                    let rhs = other.bit_repr_large();
-                    hash_join_outer(&lhs, &rhs, validate, join_nulls)
-                } else {
-                    let lhs = s_self.bit_repr_small();
-                    let rhs = other.bit_repr_small();
-                    hash_join_outer(&lhs, &rhs, validate, join_nulls)
-                }
-            },
+        if matches!(lhs.dtype(), String | Binary) {
+            let lhs = lhs.cast(&Binary).unwrap();
+            let rhs = rhs.cast(&Binary).unwrap();
+            let lhs = lhs.binary().unwrap();
+            let rhs = rhs.binary().unwrap();
+            let (lhs, rhs, swapped, _) = prepare_binary(lhs, rhs, true);
+            let lhs = lhs.iter().collect::<Vec<_>>();
+            let rhs = rhs.iter().collect::<Vec<_>>();
+            hash_join_tuples_outer(lhs, rhs, swapped, validate, join_nulls)
+        } else if s_self.bit_repr_is_large() {
+            let lhs = s_self.bit_repr_large();
+            let rhs = other.bit_repr_large();
+            hash_join_outer(&lhs, &rhs, validate, join_nulls)
+        } else {
+            let lhs = s_self.bit_repr_small();
+            let rhs = other.bit_repr_small();
+            hash_join_outer(&lhs, &rhs, validate, join_nulls)
         }
     }
 }


### PR DESCRIPTION
Fixes #13550 and #13852

Joins on string columns were only being validated on the probe side