### PR TITLE
fix: load numpy array with np array values #14237

### DIFF
--- a/py-polars/polars/datatypes/constructor.py
+++ b/py-polars/polars/datatypes/constructor.py
@@ -135,7 +135,9 @@ def numpy_type_to_constructor(
         return _NUMPY_TYPE_TO_CONSTRUCTOR[dtype]  # type:ignore[index]
     except KeyError:
         if len(values) > 0:
-            first_non_nan = next((v for v in values if v == v), None)
+            first_non_nan = next(
+                (v for v in values if isinstance(v, np.ndarray) or v == v), None
+            )
             if isinstance(first_non_nan, str):
                 return PySeries.new_str
             if isinstance(first_non_nan, bytes):

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -476,6 +476,32 @@ def test_from_numpy() -> None:
         _ = pl.from_numpy(np.array(1))
 
 
+def test_from_numpy_array_value() -> None:
+    df = pl.DataFrame({"A": [[2, 3]]})
+    assert df.rows() == [([2, 3],)]
+    assert df.schema == {"A": pl.List(pl.Int64)}
+
+
+def test_construct_from_nparray_value() -> None:
+    array_cell = np.array([2, 3])
+    df = pl.DataFrame(np.array([[array_cell, 4]], dtype=object))
+    assert df.dtypes == [pl.Object, pl.Object]
+    to_numpy = df.to_numpy()
+    assert to_numpy.shape == (1, 2)
+    assert_array_equal(to_numpy[0][0], array_cell)
+    assert to_numpy[0][1] == 4
+
+
+def test_from_numpy_nparray_value() -> None:
+    array_cell = np.array([2, 3])
+    df = pl.from_numpy(np.array([[array_cell, 4]], dtype=object))
+    assert df.dtypes == [pl.Object, pl.Object]
+    to_numpy = df.to_numpy()
+    assert to_numpy.shape == (1, 2)
+    assert_array_equal(to_numpy[0][0], array_cell)
+    assert to_numpy[0][1] == 4
+
+
 def test_from_numpy_structured() -> None:
     test_data = [
         ("Google Pixel 7", 521.90, True),


### PR DESCRIPTION
numpy_type_to_constructor now supports columns containing np arrays ( == is not supported by them) Added related unit tests

Fixes #14237