### PR TITLE
fix(python): Make `Series.to_numpy` on booleans without nulls return `bool` type

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -42,6 +42,7 @@ from polars.datatypes import (
     Object,
     String,
     Time,
+    UInt8,
     UInt32,
     UInt64,
     Unknown,
@@ -4364,6 +4365,8 @@ class Series:
                     np_array = convert_to_date(self._view(ignore_nulls=True))
                 elif self.dtype.is_numeric():
                     np_array = self._view(ignore_nulls=True)
+                elif self.dtype == Boolean:
+                    np_array = self.cast(UInt8)._view(ignore_nulls=True).astype(bool)
                 else:
                     raise_no_zero_copy()
                     np_array = self._s.to_numpy()

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4366,6 +4366,7 @@ class Series:
                 elif self.dtype.is_numeric():
                     np_array = self._view(ignore_nulls=True)
                 elif self.dtype == Boolean:
+                    raise_no_zero_copy()
                     np_array = self.cast(UInt8)._view(ignore_nulls=True).astype(bool)
                 else:
                     raise_no_zero_copy()

--- a/py-polars/tests/unit/interop/test_numpy.py
+++ b/py-polars/tests/unit/interop/test_numpy.py
@@ -49,3 +49,17 @@ def test_numpy_disambiguation() -> None:
         "b": [1, 2],
     }
     assert result == expected
+
+
+def test_series_to_numpy_bool() -> None:
+    s = pl.Series([True, False])
+    result = s.to_numpy(use_pyarrow=False)
+    assert s.to_list() == result.tolist()
+    assert result.dtype == np.bool_
+
+
+def test_series_to_numpy_bool_with_nulls() -> None:
+    s = pl.Series([True, False, None])
+    result = s.to_numpy(use_pyarrow=False)
+    assert s.to_list() == result.tolist()
+    assert result.dtype == np.object_


### PR DESCRIPTION
This used to return 'object' which is unnecessary.

This cannot be done zero-copy as a NumPy boolean is 1 byte.