### PR TITLE
Fix: ensure non-negative output from the entropy function for single-value series

### DIFF
--- a/crates/polars-ops/src/series/ops/log.rs
+++ b/crates/polars-ops/src/series/ops/log.rs
@@ -74,6 +74,11 @@ pub trait LogSeries: SeriesSealed {
     /// where `pk` are discrete probabilities.
     fn entropy(&self, base: f64, normalize: bool) -> PolarsResult<f64> {
         let s = self.as_series().to_physical_repr();
+        // if there is only one value in the series, return 0.0 to prevent the
+        // function from returning -0.0
+        if s.len() == 1 {
+            return Ok(0.0);
+        }
         match s.dtype() {
             DataType::Float32 | DataType::Float64 => {
                 let pk = s.as_ref();

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -129,15 +129,15 @@ def test_unique_stable() -> None:
 def test_entropy() -> None:
     df = pl.DataFrame(
         {
-            "group": ["A", "A", "A", "B", "B", "B", "B"],
-            "id": [1, 2, 1, 4, 5, 4, 6],
+            "group": ["A", "A", "A", "B", "B", "B", "B", "C"],
+            "id": [1, 2, 1, 4, 5, 4, 6, 7],
         }
     )
     result = df.group_by("group", maintain_order=True).agg(
         pl.col("id").entropy(normalize=True)
     )
     expected = pl.DataFrame(
-        {"group": ["A", "B"], "id": [1.0397207708399179, 1.371381017771811]}
+        {"group": ["A", "B", "C"], "id": [1.0397207708399179, 1.371381017771811, 0.0]}
     )
     assert_frame_equal(result, expected)
 


### PR DESCRIPTION
This PR addresses https://github.com/pola-rs/polars/issues/14245, where the `entropy` function was found to return a negative zero (`-0.0`) when applied to a series with only a single value. To solve this, the this PR introduces a check within the `entropy` function to assess the length of the input series. If the length of the series is `1`, the function now returns `0.0`, bypassing the standard entropy calculation process.