### PR TITLE
refactor(python): Remove `*args` in `Series.to_numpy`

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4277,7 +4277,7 @@ class Series:
 
     def to_numpy(
         self,
-        *args: Any,
+        *,
         zero_copy_only: bool = False,
         writable: bool = False,
         use_pyarrow: bool = True,
@@ -4295,8 +4295,6 @@ class Series:
 
         Parameters
         ----------
-        *args
-            args will be sent to pyarrow.Array.to_numpy.
         zero_copy_only
             If True, an exception will be raised if the conversion to a numpy
             array would require copying the underlying data (e.g. in presence
@@ -4352,7 +4350,7 @@ class Series:
             and (self.dtype == Time or not self.dtype.is_temporal())
         ):
             return self.to_arrow().to_numpy(
-                *args, zero_copy_only=zero_copy_only, writable=writable
+                zero_copy_only=zero_copy_only, writable=writable
             )
 
         elif self.dtype in (Time, Decimal):


### PR DESCRIPTION
I wanted to deprecate this, but turns out it doesn't even work currently because we also pass the keyword arguments directly:

```python
import polars as pl

pl.Series([1, 2]).to_numpy(True)
# TypeError: to_numpy() got multiple values for keyword argument 'zero_copy_only'
```

So I'm removing this.