### PR TITLE
feat(python): read arrow-c-interface without requiring pyarrow

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -371,6 +371,18 @@ class Series:
         return cls._from_pyseries(arrow_to_pyseries(name, values, rechunk=rechunk))
 
     @classmethod
+    def _import_from_c(cls, name: str, pointers: list[tuple[int, int]]) -> Self:
+        """
+        Construct a Series from Arrows C interface.
+
+        Warning
+        -------
+        This will read the `array` pointer without moving it. The host process should
+        garbage collect the heap pointer, but not its contents.
+        """
+        return cls._from_pyseries(PySeries._import_from_c(name, pointers))
+
+    @classmethod
     def _from_pandas(
         cls,
         name: str,

--- a/py-polars/src/series/c_interface.rs
+++ b/py-polars/src/series/c_interface.rs
@@ -1,0 +1,32 @@
+use polars_rs::export::arrow;
+use pyo3::ffi::Py_uintptr_t;
+
+use super::*;
+
+// Import arrow data directly without requiring pyarrow (used in pyo3-polars)
+#[pymethods]
+impl PySeries {
+    #[staticmethod]
+    unsafe fn _import_from_c(
+        name: &str,
+        chunks: Vec<(Py_uintptr_t, Py_uintptr_t)>,
+    ) -> PyResult<Self> {
+        let chunks = chunks
+            .into_iter()
+            .map(|(schema_ptr, array_ptr)| {
+                let schema_ptr = schema_ptr as *mut arrow::ffi::ArrowSchema;
+                let array_ptr = array_ptr as *mut arrow::ffi::ArrowArray;
+
+                // Don't take the box from raw as the other process must deallocate that memory.
+                let array = std::ptr::read_unaligned(array_ptr);
+                let schema = &*schema_ptr;
+
+                let field = arrow::ffi::import_field_from_c(schema).unwrap();
+                arrow::ffi::import_array_from_c(array, field.data_type).unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        let s = Series::try_from((name, chunks)).map_err(PyPolarsErr::from)?;
+        Ok(s.into())
+    }
+}

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -1,6 +1,7 @@
 mod aggregation;
 mod arithmetic;
 mod buffers;
+mod c_interface;
 mod comparison;
 mod construction;
 mod export;


### PR DESCRIPTION
This allows `pyo3-polars` to directly use polars for `ffi`. Meaning we drop the required `pyarrow` dependency there (and we can use the new types).