### PR TITLE
fix: `any/all_horizontal` with single input has incorrect type

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_functions.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_functions.rs
@@ -62,7 +62,11 @@ pub(super) fn optimize_functions(
         },
         FunctionExpr::Boolean(BooleanFunction::AllHorizontal | BooleanFunction::AnyHorizontal) => {
             if input.len() == 1 {
-                Some(expr_arena.get(input[0]).clone())
+                Some(AExpr::Cast {
+                    expr: input[0],
+                    data_type: DataType::Boolean,
+                    strict: false,
+                })
             } else {
                 None
             }

--- a/py-polars/tests/unit/functions/aggregation/test_horizontal.py
+++ b/py-polars/tests/unit/functions/aggregation/test_horizontal.py
@@ -45,6 +45,21 @@ def test_all_any_horizontally() -> None:
     assert "horizontal" not in dfltr.explain().lower()
 
 
+def test_all_any_single_input() -> None:
+    df = pl.DataFrame({"a": [0, 1, None]})
+    out = df.select(
+        all=pl.all_horizontal(pl.col("a")), any=pl.any_horizontal(pl.col("a"))
+    )
+
+    expected = pl.DataFrame(
+        {
+            "all": [False, True, None],
+            "any": [False, True, None],
+        }
+    )
+    assert_frame_equal(out, expected)
+
+
 def test_all_any_accept_expr() -> None:
     lf = pl.LazyFrame(
         {


### PR DESCRIPTION
Turning `simplify_expression` on and off will return different dtype(input type vs. boolean).  It should always has a `Boolean` type indeed.