### PR TITLE
fix: Fix `glimpse` overload signature

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4284,7 +4284,7 @@ class DataFrame:
         *,
         max_items_per_column: int = ...,
         max_colname_length: int = ...,
-        return_as_string: Literal[False],
+        return_as_string: Literal[False] = False,
     ) -> None:
         ...
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4284,7 +4284,7 @@ class DataFrame:
         *,
         max_items_per_column: int = ...,
         max_colname_length: int = ...,
-        return_as_string: Literal[False] = False,
+        return_as_string: Literal[False] = ...,
     ) -> None:
         ...
 
@@ -4296,6 +4296,16 @@ class DataFrame:
         max_colname_length: int = ...,
         return_as_string: Literal[True],
     ) -> str:
+        ...
+
+    @overload
+    def glimpse(
+        self,
+        *,
+        max_items_per_column: int = ...,
+        max_colname_length: int = ...,
+        return_as_string: bool,
+    ) -> str | None:
         ...
 
     def glimpse(

--- a/py-polars/tests/unit/dataframe/test_glimpse.py
+++ b/py-polars/tests/unit/dataframe/test_glimpse.py
@@ -61,7 +61,7 @@ def test_glimpse(capsys: Any) -> None:
     assert result == expected
 
     # the default is to print to the console
-    df.glimpse(return_as_string=False)
+    df.glimpse()
     # remove the last newline on the capsys
     assert capsys.readouterr().out[:-1] == expected
 


### PR DESCRIPTION
Though glimpse implementation has default values for all arguments, the corresponding @overload missed default value for return_as_string.
Mypy didn't catch it because there was no call in tests without arguments