### PR TITLE
feat: Allow brackets in SQL join conditions

### DIFF
--- a/crates/polars-sql/src/sql_expr.rs
+++ b/crates/polars-sql/src/sql_expr.rs
@@ -873,6 +873,8 @@ fn process_join_on(
                 polars_bail!(InvalidOperation: "SQL join clauses support '=' constraints combined with 'AND'; found op = '{:?}'", op);
             },
         }
+    } else if let SQLExpr::Nested(expr) = expression {
+        process_join_on(expr, left_name, right_name)
     } else {
         polars_bail!(InvalidOperation: "SQL join clauses support '=' constraints combined with 'AND'; found expression = {:?}", expression);
     }


### PR DESCRIPTION
This very simple PR allows brackets in join conditions, for example
```SQL
SELECT * FROM df1
INNER JOIN df2 ON
    df1.a = df2.a AND
    ((df1.b = df2.b AND
    df1.c = df2.c) AND
    df1.d = df2.d)
```

Since only AND is allowed currently and AND is associative, this is not terribly useful yet except when migrating existing SQL code, but if we ever implement OR or other binary operations, brackets will be necessary.

Note: not all places where brackets would be allowed are covered yet in this PR.