### PR TITLE
feat(python): add parametric testing support for the `Array` dtype

### DIFF
--- a/py-polars/polars/testing/parametric/__init__.py
+++ b/py-polars/polars/testing/parametric/__init__.py
@@ -7,6 +7,7 @@ if _HYPOTHESIS_AVAILABLE:
     from polars.testing.parametric.profiles import load_profile, set_profile
     from polars.testing.parametric.strategies import (
         all_strategies,
+        create_array_strategy,
         create_list_strategy,
         nested_strategies,
         scalar_strategies,
@@ -22,6 +23,7 @@ __all__ = [
     "all_strategies",
     "column",
     "columns",
+    "create_array_strategy",
     "create_list_strategy",
     "dataframes",
     "load_profile",

--- a/py-polars/polars/testing/parametric/strategies.py
+++ b/py-polars/polars/testing/parametric/strategies.py
@@ -347,7 +347,7 @@ def create_array_strategy(
 
     Create a strategy that generates arrays of specific strings:
 
-    >>> arr = create_array_strategy(dtype=pl.String, width=2)
+    >>> arr = create_array_strategy(inner_dtype=pl.String, width=2)
     >>> arr.example()  # doctest: +SKIP
     ['xx', 'yy']
     """
@@ -452,7 +452,7 @@ def create_list_strategy(
             st = create_array_strategy(
                 inner_dtype=inner_dtype.inner,  # type: ignore[union-attr]
                 select_from=select_from,
-                width=width,  # type: ignore[union-attr]
+                width=width,
             )
         else:
             st = create_list_strategy(

--- a/py-polars/tests/parametric/test_testing.py
+++ b/py-polars/tests/parametric/test_testing.py
@@ -7,11 +7,12 @@ import warnings
 from datetime import datetime
 from typing import Any
 
-import polars as pl
 import pytest
 from hypothesis import given, settings
 from hypothesis.errors import InvalidArgument, NonInteractiveExampleWarning
 from hypothesis.strategies import sampled_from
+
+import polars as pl
 from polars.datatypes import TEMPORAL_DTYPES
 from polars.testing.parametric import (
     column,

--- a/py-polars/tests/parametric/test_testing.py
+++ b/py-polars/tests/parametric/test_testing.py
@@ -7,12 +7,11 @@ import warnings
 from datetime import datetime
 from typing import Any
 
+import polars as pl
 import pytest
 from hypothesis import given, settings
 from hypothesis.errors import InvalidArgument, NonInteractiveExampleWarning
 from hypothesis.strategies import sampled_from
-
-import polars as pl
 from polars.datatypes import TEMPORAL_DTYPES
 from polars.testing.parametric import (
     column,
@@ -210,7 +209,7 @@ def test_infinities(
 @given(
     df=dataframes(
         cols=[
-            column("colx", dtype=pl.List(pl.UInt8)),
+            column("colx", dtype=pl.Array(pl.UInt8, width=3)),
             column("coly", dtype=pl.List(pl.Datetime("ms"))),
             column(
                 name="colz",
@@ -223,15 +222,16 @@ def test_infinities(
         ]
     ),
 )
-def test_list_strategy(df: pl.DataFrame) -> None:
+def test_sequence_strategies(df: pl.DataFrame) -> None:
     assert df.schema == {
-        "colx": pl.List(pl.UInt8),
+        "colx": pl.Array(pl.UInt8, width=3),
         "coly": pl.List(pl.Datetime("ms")),
         "colz": pl.List(pl.List(pl.String)),
     }
     uint8_max = (2**8) - 1
 
     for colx, coly, colz in df.iter_rows():
+        assert len(colx) == 3
         assert all(i <= uint8_max for i in colx)
         assert all(isinstance(d, datetime) for d in coly)
         for inner_list in colz:

--- a/py-polars/tests/parametric/time_series/test_truncate.py
+++ b/py-polars/tests/parametric/time_series/test_truncate.py
@@ -8,7 +8,8 @@ import polars as pl
 
 @given(
     value=st.datetimes(
-        min_value=dt.datetime(1000, 1, 1), max_value=dt.datetime(3000, 1, 1)
+        min_value=dt.datetime(1000, 1, 1),
+        max_value=dt.datetime(3000, 1, 1),
     ),
     n=st.integers(min_value=1, max_value=100),
 )


### PR DESCRIPTION
In addition to `List` (already supported) can now declare/use the `Array` dtype in parametric tests.

## Example

```python
import polars as pl
from hypothesis import given
from polars.testing.parametric import column, create_array_strategy

@given(
    df=dataframes(
        cols=[
            # basic use; declare inner dtype and width
            column("colx", dtype=pl.Array(pl.UInt8, width=3)),
            # use a more sophisticated strategy
            column(
                name="coly", 
                strategy=create_array_strategy(
                    inner_dtype=pl.Array(pl.String, width=2),
                    select_from=["a", "b", "c"],
                    width=2,
            ))]
))
def test_array_stuff(df: pl.DataFrame) -> None:
    print(df)
    
# shape: (6, 2)
# ┌────────────────┬──────────────────────────┐
# │ colx           ┆ coly                     │
# │ ---            ┆ ---                      │
# │ array[u8, 3]   ┆ array[array[str, 2], 2]  │
# ╞════════════════╪══════════════════════════╡
# │ [242, 131, 57] ┆ [["c", "c"], ["c", "a"]] │
# │ [220, 78, 82]  ┆ [["a", "a"], ["b", "a"]] │
# │ [153, 19, 100] ┆ [["a", "c"], ["b", "a"]] │
# │ [154, 195, 82] ┆ [["a", "a"], ["a", "a"]] │
# └────────────────┴──────────────────────────┘
```