### PR TITLE
export AnonymousScanArgs from polars::prelude::*

### DIFF
--- a/crates/polars-lazy/src/prelude.rs
+++ b/crates/polars-lazy/src/prelude.rs
@@ -2,7 +2,8 @@ pub use polars_ops::prelude::{JoinArgs, JoinType, JoinValidation};
 #[cfg(feature = "rank")]
 pub use polars_ops::prelude::{RankMethod, RankOptions};
 pub use polars_plan::logical_plan::{
-    AnonymousScan, AnonymousScanOptions, Literal, LiteralValue, LogicalPlan, Null, NULL,
+    AnonymousScan, AnonymousScanArgs, AnonymousScanOptions, Literal, LiteralValue, LogicalPlan,
+    Null, NULL,
 };
 #[cfg(feature = "csv")]
 pub use polars_plan::prelude::CsvWriterOptions;


### PR DESCRIPTION
Hello
I was implementing `LazyFrame::anonymous_scan` but I notice that `polars_plan::logical_plan::anonymous_scan::AnonymousScanArgs` is not exported by `polars::prelude::*`
only `polars_plan::logical_plan::anonymous_scan::AnonymousScan` is exported
I hope this the best way to fix it