### PR TITLE
feat(python): Support `Categorical/Enum` in `Series.to_numpy`

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4339,7 +4339,7 @@ class Series:
         """
 
         def raise_no_zero_copy() -> None:
-            if zero_copy_only:
+            if zero_copy_only and not self.is_empty():
                 msg = "cannot return a zero-copy array"
                 raise ValueError(msg)
 

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -195,15 +195,9 @@ impl PySeries {
                 let np_arr = PyArray1::from_iter(py, ca.into_iter().map(|s| s.into_py(py)));
                 np_arr.into_py(py)
             },
-            Categorical(rev_map, _) | Enum(rev_map, _) => {
-                let rev_map = rev_map.clone().unwrap();
-                let mapping = &*rev_map;
-                let f = |idx: u32| mapping.get(idx);
+            Categorical(_, _) | Enum(_, _) => {
                 let ca = s.categorical().unwrap();
-                let np_arr = PyArray1::from_iter(
-                    py,
-                    ca.physical().into_iter().map(|s| s.map(f).into_py(py)),
-                );
+                let np_arr = PyArray1::from_iter(py, ca.iter_str().map(|s| s.into_py(py)));
                 np_arr.into_py(py)
             },
             #[cfg(feature = "object")]

--- a/py-polars/src/series/export.rs
+++ b/py-polars/src/series/export.rs
@@ -195,6 +195,17 @@ impl PySeries {
                 let np_arr = PyArray1::from_iter(py, ca.into_iter().map(|s| s.into_py(py)));
                 np_arr.into_py(py)
             },
+            Categorical(rev_map, _) | Enum(rev_map, _) => {
+                let rev_map = rev_map.clone().unwrap();
+                let mapping = &*rev_map;
+                let f = |idx: u32| mapping.get(idx);
+                let ca = s.categorical().unwrap();
+                let np_arr = PyArray1::from_iter(
+                    py,
+                    ca.physical().into_iter().map(|s| s.map(f).into_py(py)),
+                );
+                np_arr.into_py(py)
+            },
             #[cfg(feature = "object")]
             Object(_, _) => {
                 let ca = s

--- a/py-polars/tests/unit/interop/numpy/test_numpy.py
+++ b/py-polars/tests/unit/interop/numpy/test_numpy.py
@@ -76,3 +76,14 @@ def test_to_numpy_zero_copy_path() -> None:
     x = df.to_numpy()
     assert x.flags["F_CONTIGUOUS"]
     assert str(x[0, :]) == "[1. 2. 1. 1. 1.]"
+
+
+def test_numpy_disambiguation() -> None:
+    a = np.array([1, 2])
+    df = pl.DataFrame({"a": a})
+    result = df.with_columns(b=a).to_dict(as_series=False)  # type: ignore[arg-type]
+    expected = {
+        "a": [1, 2],
+        "b": [1, 2],
+    }
+    assert result == expected

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal as D
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -107,3 +108,14 @@ def test_numpy_preserve_uint64_4112() -> None:
     df = pl.DataFrame({"a": [1, 2, 3]}).with_columns(pl.col("a").hash())
     assert df.to_numpy().dtype == np.dtype("uint64")
     assert df.to_numpy(structured=True).dtype == np.dtype([("a", "uint64")])
+
+
+@pytest.mark.parametrize("use_pyarrow", [True, False])
+def test_df_to_numpy_decimal(use_pyarrow: bool) -> None:
+    decimal_data = [D("1.234"), D("2.345"), D("-3.456")]
+    df = pl.Series("n", decimal_data).to_frame()
+
+    result = df.to_numpy(use_pyarrow=use_pyarrow)
+
+    expected = np.array(decimal_data).reshape((-1, 1))
+    assert_array_equal(result, expected)

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -101,3 +101,9 @@ def test__array__() -> None:
     expected_array = np.array([[1, 1], [2, 2], [3, 3]], dtype=np.uint8)
     assert_array_equal(out_array, expected_array)
     assert out_array.flags["F_CONTIGUOUS"] is True
+
+
+def test_numpy_preserve_uint64_4112() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]}).with_columns(pl.col("a").hash())
+    assert df.to_numpy().dtype == np.dtype("uint64")
+    assert df.to_numpy(structured=True).dtype == np.dtype([("a", "uint64")])

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -165,13 +165,10 @@ def test_to_numpy_null() -> None:
     assert_zero_copy_only_raises(s)
 
 
-@pytest.mark.skip(
-    reason="Currently bugged, see: https://github.com/pola-rs/polars/issues/14274"
-)
 def test_to_numpy_empty() -> None:
     series = pl.Series(dtype=pl.String)
     result = series.to_numpy(use_pyarrow=False, zero_copy_only=True)
-    assert result.dtype == np.int64
+    assert result.dtype == np.object_
     assert result.shape == (0,)
     assert result.size == 0
 

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -76,6 +76,14 @@ def test_to_numpy_enum() -> None:
     assert result.tolist() == s.to_list()
 
 
+def test_to_numpy_null() -> None:
+    s = pl.Series([None, None], dtype=pl.Null)
+    result = s.to_numpy(use_pyarrow=False)
+    expected = np.array([np.nan, np.nan], dtype=np.float32)
+    assert_array_equal(result, expected)
+    assert result.dtype == np.float32
+
+
 @pytest.mark.parametrize("writable", [False, True])
 @pytest.mark.parametrize("pyarrow_available", [False, True])
 def test_to_numpy2(

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -90,13 +90,14 @@ def test_series_to_numpy_numeric_with_nulls(
         (pl.Enum(["a", "b", "c"]), ["a", "b", "a"]),
         (pl.String, ["a", "bc", "def"]),
         (pl.Binary, [b"a", b"bc", b"def"]),
+        (pl.Decimal, [D("1.234"), D("2.345"), D("-3.456")]),
         (pl.Object, [Path(), Path("abc")]),
         # TODO: Implement for List types
         # (pl.List, [[1], [2, 3]]),
         # (pl.List, [["a"], ["b", "c"], []]),
     ],
 )
-def test_to_numpy_various_dtypes(dtype: pl.PolarsDataType, values: list[Any]) -> None:
+def test_to_numpy_object_dtypes(dtype: pl.PolarsDataType, values: list[Any]) -> None:
     values.append(None)
     s = pl.Series(values, dtype=dtype)
     result = s.to_numpy(use_pyarrow=False)
@@ -346,20 +347,3 @@ def test_series_to_numpy_temporal() -> None:
     s4 = pl.Series([time(10, 30, 45), time(23, 59, 59)])
     out = np.array([time(10, 30, 45), time(23, 59, 59)], dtype="object")
     assert (s4.to_numpy() == out).all()
-
-
-@pytest.mark.parametrize("use_pyarrow", [True, False])
-def test_decimal_numpy_export(use_pyarrow: bool) -> None:
-    decimal_data = [D("1.234"), D("2.345"), D("-3.456")]
-
-    s = pl.Series("n", decimal_data)
-    df = s.to_frame()
-
-    assert_array_equal(
-        np.array(decimal_data),
-        s.to_numpy(use_pyarrow=use_pyarrow),
-    )
-    assert_array_equal(
-        np.array(decimal_data).reshape((-1, 1)),
-        df.to_numpy(use_pyarrow=use_pyarrow),
-    )

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 )
 @settings(max_examples=250)
 def test_series_to_numpy(s: pl.Series) -> None:
-    result = s.to_numpy()
+    result = s.to_numpy(use_pyarrow=False)
 
     values = s.to_list()
     dtype_map = {
@@ -62,6 +62,18 @@ def test_to_numpy_empty_no_pyarrow() -> None:
     assert result.dtype == pl.Float32
     assert result.shape == (0,)
     assert result.size == 0
+
+
+def test_to_numpy_categorical() -> None:
+    s = pl.Series(["a", "b", "a", None], dtype=pl.Categorical)
+    result = s.to_numpy(use_pyarrow=False)
+    assert result.tolist() == s.to_list()
+
+
+def test_to_numpy_enum() -> None:
+    s = pl.Series(["a", "b", "a", None], dtype=pl.Enum(["a", "b", "c"]))
+    result = s.to_numpy(use_pyarrow=False)
+    assert result.tolist() == s.to_list()
 
 
 @pytest.mark.parametrize("writable", [False, True])


### PR DESCRIPTION
Also closes #14274

Plus a bunch of tests for zero-copyness.