### PR TITLE
fix: `list.get` does not work on list of decimals

### DIFF
--- a/crates/polars-arrow/src/compute/take/mod.rs
+++ b/crates/polars-arrow/src/compute/take/mod.rs
@@ -32,7 +32,7 @@ mod list;
 mod primitive;
 mod structure;
 
-use crate::with_match_primitive_type;
+use crate::with_match_primitive_type_full;
 
 /// Returns a new [`Array`] with only indices at `indices`. Null indices are taken as nulls.
 /// The returned array has a length equal to `indices.len()`.
@@ -50,7 +50,7 @@ pub unsafe fn take_unchecked(values: &dyn Array, indices: &IdxArr) -> Box<dyn Ar
             let values = values.as_any().downcast_ref().unwrap();
             Box::new(boolean::take_unchecked(values, indices))
         },
-        Primitive(primitive) => with_match_primitive_type!(primitive, |$T| {
+        Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
             let values = values.as_any().downcast_ref().unwrap();
             Box::new(primitive::take_primitive_unchecked::<$T>(&values, indices))
         }),

--- a/crates/polars-core/src/chunked_array/builder/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/mod.rs
@@ -142,12 +142,15 @@ pub fn get_list_builder(
             Some(inner_type_logical.clone()),
         ))),
         #[cfg(feature = "dtype-decimal")]
-        DataType::Decimal(_, _) => Ok(Box::new(ListPrimitiveChunkedBuilder::<Int128Type>::new(
-            name,
-            list_capacity,
-            value_capacity,
-            inner_type_logical.clone(),
-        ))),
+        DataType::Decimal(_, _) => Ok(Box::new(
+            ListPrimitiveChunkedBuilder::<Int128Type>::new_with_values_type(
+                name,
+                list_capacity,
+                value_capacity,
+                physical_type,
+                inner_type_logical.clone(),
+            ),
+        )),
         _ => {
             macro_rules! get_primitive_builder {
                 ($type:ty) => {{

--- a/crates/polars-core/src/chunked_array/builder/list/primitive.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/primitive.rs
@@ -30,6 +30,26 @@ where
         }
     }
 
+    pub fn new_with_values_type(
+        name: &str,
+        capacity: usize,
+        values_capacity: usize,
+        values_type: DataType,
+        logical_type: DataType,
+    ) -> Self {
+        let values = MutablePrimitiveArray::<T::Native>::with_capacity_from(
+            values_capacity,
+            values_type.to_arrow(true),
+        );
+        let builder = LargePrimitiveBuilder::<T::Native>::new_with_capacity(values, capacity);
+        let field = Field::new(name, DataType::List(Box::new(logical_type)));
+        Self {
+            builder,
+            field,
+            fast_explode: true,
+        }
+    }
+
     #[inline]
     pub fn append_slice(&mut self, items: &[T::Native]) {
         let values = self.builder.mut_values();

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -300,3 +300,12 @@ def test_decimal_write_parquet_12375() -> None:
     assert df["bye"].dtype == pl.Decimal
 
     df.write_parquet(f)
+
+
+def test_decimal_list_get_13847() -> None:
+    with pl.Config() as cfg:
+        cfg.activate_decimals()
+        df = pl.DataFrame({"a": [[D("1.1"), D("1.2")], [D("2.1")]]})
+        out = df.select(pl.col("a").list.get(0))
+        expected = pl.DataFrame({"a": [D("1.1"), D("2.1")]})
+        assert_frame_equal(out, expected)


### PR DESCRIPTION
This fixes #13847.