### PR TITLE
docs: Fix capitalization of user guide references

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
   -
   <a href="https://stackoverflow.com/questions/tagged/r-polars">R</a>
   |
-  <a href="https://docs.pola.rs/">User Guide</a>
+  <a href="https://docs.pola.rs/">User guide</a>
   |
   <a href="https://discord.gg/4UfP5cfBE7">Discord</a>
 </p>
@@ -58,7 +58,7 @@ Polars is a DataFrame interface on top of an OLAP Query Engine implemented in Ru
 - Hybrid Streaming (larger than RAM datasets)
 - Rust | Python | NodeJS | R | ...
 
-To learn more, read the [User Guide](https://docs.pola.rs/).
+To learn more, read the [user guide](https://docs.pola.rs/).
 
 ## Python
 

--- a/crates/polars/src/lib.rs
+++ b/crates/polars/src/lib.rs
@@ -57,7 +57,7 @@
 //! * [Performance](#performance-and-string-data)
 //!     - [Custom allocator](#custom-allocator)
 //! * [Config](#config-with-env-vars)
-//! * [User Guide](#user-guide)
+//! * [User guide](#user-guide)
 //!
 //! ## Cookbooks
 //! See examples in the cookbooks:
@@ -147,7 +147,7 @@
 //! (Note that within an expression there may be more parallelization going on).
 //!
 //! Understanding polars expressions is most important when starting with the polars library. Read more
-//! about them in the [User Guide](https://docs.pola.rs/user-guide/concepts/expressions).
+//! about them in the [user guide](https://docs.pola.rs/user-guide/concepts/expressions).
 //! Though the examples given there are in python. The expressions API is almost identical and the
 //! the read should certainly be valuable to rust users as well.
 //!
@@ -406,8 +406,9 @@
 //! * `POLARS_PANIC_ON_ERR` -> panic instead of returning an Error.
 //! * `POLARS_NO_CHUNKED_JOIN` -> force rechunk before joins.
 //!
-//! ## User Guide
-//! If you want to read more, [check the User Guide](https://docs.pola.rs/).
+//! ## User guide
+//!
+//! If you want to read more, check the [user guide](https://docs.pola.rs/).
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(ambiguous_glob_reexports)]
 pub mod docs;

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -38,7 +38,7 @@ In the example below we write the DataFrame to a csv file called `output.csv`. A
 --8<-- "python/user-guide/basics/reading-writing.py:csv"
 ```
 
-For more examples on the CSV file format and other data formats, start with the [IO section](io/index.md) of the User Guide.
+For more examples on the CSV file format and other data formats, start with the [IO section](io/index.md) of the user guide.
 
 ## Expressions
 
@@ -49,7 +49,7 @@ For more examples on the CSV file format and other data formats, start with the 
 - `with_columns`
 - `group_by`
 
-To learn more about expressions and the context in which they operate, see the User Guide sections: [Contexts](concepts/contexts.md) and [Expressions](concepts/expressions.md).
+To learn more about expressions and the context in which they operate, see the user guide sections: [Contexts](concepts/contexts.md) and [Expressions](concepts/expressions.md).
 
 ### Select
 
@@ -79,7 +79,7 @@ print(
 )
 ```
 
-Follow these links to other parts of the User guide to learn more about [basic operations](expressions/operators.md) or [column selections](expressions/column-selections.md).
+Follow these links to other parts of the user guide to learn more about [basic operations](expressions/operators.md) or [column selections](expressions/column-selections.md).
 
 ### Filter
 
@@ -115,7 +115,7 @@ print(
 )
 ```
 
-### Group_by
+### Group by
 
 We will create a new `DataFrame` for the Group by functionality. This new `DataFrame` will include several 'groups' that we want to group by.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,14 +1,14 @@
 # https://www.mkdocs.org/user-guide/configuration/
 
 # Project information
-site_name: Polars User Guide
+site_name: Polars user guide
 site_url: https://docs.pola.rs/
 repo_url: https://github.com/pola-rs/polars
 repo_name: pola-rs/polars
 
 # Documentation layout
 nav:
-  - User Guide:
+  - User guide:
     - index.md
     - user-guide/getting-started.md
     - user-guide/installation.md


### PR DESCRIPTION
Continuing my crusade against unnecessary title case 😄 