### PR TITLE
feat: Implements `arr.shift`

### DIFF
--- a/crates/polars-plan/src/dsl/array.rs
+++ b/crates/polars-plan/src/dsl/array.rs
@@ -177,4 +177,14 @@ impl ArrayNameSpace {
             )
             .with_fmt("arr.to_struct")
     }
+
+    /// Shift every sub-array.
+    pub fn shift(self, n: Expr) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::ArrayExpr(ArrayFunction::Shift),
+            &[n],
+            false,
+            false,
+        )
+    }
 }

--- a/crates/polars-plan/src/dsl/function_expr/array.rs
+++ b/crates/polars-plan/src/dsl/function_expr/array.rs
@@ -28,6 +28,7 @@ pub enum ArrayFunction {
     Contains,
     #[cfg(feature = "array_count")]
     CountMatches,
+    Shift,
 }
 
 impl ArrayFunction {
@@ -52,6 +53,7 @@ impl ArrayFunction {
             Contains => mapper.with_dtype(DataType::Boolean),
             #[cfg(feature = "array_count")]
             CountMatches => mapper.with_dtype(IDX_DTYPE),
+            Shift => mapper.with_same_dtype(),
         }
     }
 }
@@ -90,6 +92,7 @@ impl Display for ArrayFunction {
             Contains => "contains",
             #[cfg(feature = "array_count")]
             CountMatches => "count_matches",
+            Shift => "shift",
         };
         write!(f, "arr.{name}")
     }
@@ -121,6 +124,7 @@ impl From<ArrayFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             Contains => map_as_slice!(contains),
             #[cfg(feature = "array_count")]
             CountMatches => map_as_slice!(count_matches),
+            Shift => map_as_slice!(shift),
         }
     }
 }
@@ -223,4 +227,11 @@ pub(super) fn count_matches(args: &[Series]) -> PolarsResult<Series> {
     );
     let ca = s.array()?;
     ca.array_count_matches(element.get(0).unwrap())
+}
+
+pub(super) fn shift(s: &[Series]) -> PolarsResult<Series> {
+    let ca = s[0].array()?;
+    let n = &s[1];
+
+    ca.array_shift(n)
 }

--- a/py-polars/docs/source/reference/expressions/array.rst
+++ b/py-polars/docs/source/reference/expressions/array.rst
@@ -31,3 +31,4 @@ The following methods are available under the `expr.arr` attribute.
     Expr.arr.contains
     Expr.arr.count_matches
     Expr.arr.to_struct
+    Expr.arr.shift

--- a/py-polars/docs/source/reference/series/array.rst
+++ b/py-polars/docs/source/reference/series/array.rst
@@ -31,3 +31,4 @@ The following methods are available under the `Series.arr` attribute.
     Series.arr.contains
     Series.arr.count_matches
     Series.arr.to_struct
+    Series.arr.shift

--- a/py-polars/polars/expr/array.py
+++ b/py-polars/polars/expr/array.py
@@ -701,3 +701,52 @@ class ExprArrayNameSpace:
         else:
             pyexpr = self._pyexpr.arr_to_struct(fields)
             return wrap_expr(pyexpr)
+
+    def shift(self, n: int | IntoExprColumn = 1) -> Expr:
+        """
+        Shift array values by the given number of indices.
+
+        Parameters
+        ----------
+        n
+            Number of indices to shift forward. If a negative value is passed, values
+            are shifted in the opposite direction instead.
+
+        Notes
+        -----
+        This method is similar to the `LAG` operation in SQL when the value for `n`
+        is positive. With a negative value for `n`, it is similar to `LEAD`.
+
+        Examples
+        --------
+        By default, array values are shifted forward by one index.
+
+        >>> df = pl.DataFrame(
+        ...     {"a": [[1, 2, 3], [4, 5, 6]]}, schema={"a": pl.Array(pl.Int64, 3)}
+        ... )
+        >>> df.with_columns(shift=pl.col("a").arr.shift())
+        shape: (2, 2)
+        ┌───────────────┬───────────────┐
+        │ a             ┆ shift         │
+        │ ---           ┆ ---           │
+        │ array[i64, 3] ┆ array[i64, 3] │
+        ╞═══════════════╪═══════════════╡
+        │ [1, 2, 3]     ┆ [null, 1, 2]  │
+        │ [4, 5, 6]     ┆ [null, 4, 5]  │
+        └───────────────┴───────────────┘
+
+        Pass a negative value to shift in the opposite direction instead.
+
+        >>> df.with_columns(shift=pl.col("a").arr.shift(-2))
+        shape: (2, 2)
+        ┌───────────────┬─────────────────┐
+        │ a             ┆ shift           │
+        │ ---           ┆ ---             │
+        │ array[i64, 3] ┆ array[i64, 3]   │
+        ╞═══════════════╪═════════════════╡
+        │ [1, 2, 3]     ┆ [3, null, null] │
+        │ [4, 5, 6]     ┆ [6, null, null] │
+        └───────────────┴─────────────────┘
+        """
+        n = parse_as_expression(n)
+        return wrap_expr(self._pyexpr.arr_shift(n))

--- a/py-polars/polars/series/array.py
+++ b/py-polars/polars/series/array.py
@@ -562,3 +562,42 @@ class ArrayNameSpace:
         """
         s = wrap_s(self._s)
         return s.to_frame().select(F.col(s.name).arr.to_struct(fields)).to_series()
+
+    def shift(self, n: int | IntoExprColumn = 1) -> Series:
+        """
+        Shift array values by the given number of indices.
+
+        Parameters
+        ----------
+        n
+            Number of indices to shift forward. If a negative value is passed, values
+            are shifted in the opposite direction instead.
+
+        Notes
+        -----
+        This method is similar to the `LAG` operation in SQL when the value for `n`
+        is positive. With a negative value for `n`, it is similar to `LEAD`.
+
+        Examples
+        --------
+        By default, array values are shifted forward by one index.
+
+        >>> s = pl.Series([[1, 2, 3], [4, 5, 6]], dtype=pl.Array(pl.Int64, 3))
+        >>> s.arr.shift()
+        shape: (2,)
+        Series: '' [array[i64, 3]]
+        [
+            [null, 1, 2]
+            [null, 4, 5]
+        ]
+
+        Pass a negative value to shift in the opposite direction instead.
+
+        >>> s.arr.shift(-2)
+        shape: (2,)
+        Series: '' [array[i64, 3]]
+        [
+            [3, null, null]
+            [6, null, null]
+        ]
+        """

--- a/py-polars/src/expr/array.rs
+++ b/py-polars/src/expr/array.rs
@@ -112,4 +112,8 @@ impl PyExpr {
 
         Ok(self.inner.clone().arr().to_struct(name_gen).into())
     }
+
+    fn arr_shift(&self, n: PyExpr) -> Self {
+        self.inner.clone().arr().shift(n.inner).into()
+    }
 }


### PR DESCRIPTION
Digression: We are not far away from the ability to fully align list and array namespace. `eval` is probably the most troublesome part, if we want it to return an array instead of list in some cases.