### PR TITLE
fix: Fix `set_operation` if the input is sliced and be broadcast

### DIFF
--- a/crates/polars-ops/src/chunked_array/list/sets.rs
+++ b/crates/polars-ops/src/chunked_array/list/sets.rs
@@ -151,9 +151,6 @@ where
     let mut offsets = Vec::with_capacity(std::cmp::max(offsets_a.len(), offsets_b.len()));
     offsets.push(0i64);
 
-    if broadcast_rhs {
-        set2.extend(b.into_iter().map(copied_wrapper_opt));
-    }
     let offsets_slice = if offsets_a.len() > offsets_b.len() {
         offsets_a
     } else {
@@ -163,6 +160,14 @@ where
     let second_a = offsets_a[1];
     let first_b = offsets_b[0];
     let second_b = offsets_b[1];
+    if broadcast_rhs {
+        set2.extend(
+            b.into_iter()
+                .skip(first_b as usize)
+                .take(second_b as usize - first_b as usize)
+                .map(copied_wrapper_opt),
+        );
+    }
     for i in 1..offsets_slice.len() {
         // If we go OOB we take the first element as we are then broadcasting.
         let start_a = *offsets_a.get(i - 1).unwrap_or(&first_a) as usize;
@@ -180,7 +185,11 @@ where
                 .skip(start_a)
                 .take(end_a - start_a)
                 .map(copied_wrapper_opt);
-            let b_iter = b.into_iter().map(copied_wrapper_opt);
+            let b_iter = b
+                .into_iter()
+                .skip(first_b as usize)
+                .take(second_b as usize - first_b as usize)
+                .map(copied_wrapper_opt);
             set_operation(
                 &mut set,
                 &mut set2,
@@ -191,7 +200,11 @@ where
                 true,
             )
         } else if broadcast_lhs {
-            let a_iter = a.into_iter().map(copied_wrapper_opt);
+            let a_iter = a
+                .into_iter()
+                .skip(first_a as usize)
+                .take(second_a as usize - first_a as usize)
+                .map(copied_wrapper_opt);
 
             let b_iter = b
                 .into_iter()


### PR DESCRIPTION
This fixes #14290.