### PR TITLE
feat: Implements `list.n_unique`

### DIFF
--- a/crates/polars-core/src/chunked_array/list/iterator.rs
+++ b/crates/polars-core/src/chunked_array/list/iterator.rs
@@ -180,6 +180,17 @@ impl ListChunked {
         unsafe { self.amortized_iter().map(f).collect_ca(self.name()) }
     }
 
+    pub fn try_apply_amortized_generic<'a, F, K, V>(&'a self, f: F) -> PolarsResult<ChunkedArray<V>>
+    where
+        V: PolarsDataType,
+        F: FnMut(Option<UnstableSeries<'a>>) -> PolarsResult<Option<K>> + Copy,
+        V::Array: ArrayFromIter<Option<K>>,
+    {
+        // TODO! make an amortized iter that does not flatten
+        // SAFETY: unstable series never lives longer than the iterator.
+        unsafe { self.amortized_iter().map(f).try_collect_ca(self.name()) }
+    }
+
     pub fn for_each_amortized<'a, F>(&'a self, f: F)
     where
         F: FnMut(Option<UnstableSeries<'a>>),

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -257,6 +257,14 @@ pub trait ListNameSpaceImpl: AsList {
         self.same_type(out)
     }
 
+    fn lst_n_unique(&self) -> PolarsResult<IdxCa> {
+        let ca = self.as_list();
+        ca.try_apply_amortized_generic(|s| {
+            let opt_v = s.map(|s| s.as_ref().n_unique()).transpose()?;
+            Ok(opt_v.map(|idx| idx as IdxSize))
+        })
+    }
+
     fn lst_unique(&self) -> PolarsResult<ListChunked> {
         let ca = self.as_list();
         let out = ca.try_apply_amortized(|s| s.as_ref().unique())?;
@@ -274,7 +282,6 @@ pub trait ListNameSpaceImpl: AsList {
         ca.apply_amortized_generic(|opt_s| {
             opt_s.and_then(|s| s.as_ref().arg_min().map(|idx| idx as IdxSize))
         })
-        .with_name(ca.name())
     }
 
     fn lst_arg_max(&self) -> IdxCa {
@@ -282,7 +289,6 @@ pub trait ListNameSpaceImpl: AsList {
         ca.apply_amortized_generic(|opt_s| {
             opt_s.and_then(|s| s.as_ref().arg_max().map(|idx| idx as IdxSize))
         })
-        .with_name(ca.name())
     }
 
     #[cfg(feature = "diff")]

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -146,6 +146,11 @@ impl ListNameSpace {
             .map_private(FunctionExpr::ListExpr(ListFunction::Unique(true)))
     }
 
+    pub fn n_unique(self) -> Expr {
+        self.0
+            .map_private(FunctionExpr::ListExpr(ListFunction::NUnique))
+    }
+
     /// Get items in every sublist by index.
     pub fn get(self, index: Expr) -> Expr {
         self.0.map_many_private(

--- a/py-polars/docs/source/reference/expressions/list.rst
+++ b/py-polars/docs/source/reference/expressions/list.rst
@@ -49,5 +49,6 @@ The following methods are available under the `expr.list` attribute.
     Expr.list.to_array
     Expr.list.to_struct
     Expr.list.unique
+    Expr.list.n_unique
     Expr.list.var
     Expr.list.gather_every

--- a/py-polars/docs/source/reference/series/list.rst
+++ b/py-polars/docs/source/reference/series/list.rst
@@ -49,5 +49,6 @@ The following methods are available under the `Series.list` attribute.
     Series.list.to_array
     Series.list.to_struct
     Series.list.unique
+    Series.list.n_unique
     Series.list.var
     Series.list.gather_every

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -442,6 +442,30 @@ class ExprListNameSpace:
         """
         return wrap_expr(self._pyexpr.list_unique(maintain_order))
 
+    def n_unique(self) -> Expr:
+        """
+        Count the number of unique values in every sub-lists.
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [[1, 1, 2], [2, 3, 4]],
+        ...     }
+        ... )
+        >>> df.with_columns(n_unique=pl.col("a").list.n_unique())
+        shape: (1, 2)
+        ┌───────────┬──────────┐
+        │ a         ┆ n_unique │
+        │ ---       ┆ ---      │
+        │ list[i64] ┆ u32      │
+        ╞═══════════╪══════════╡
+        │ [1, 1, 2] ┆ 2        │
+        │ [2, 3, 4] ┆ 3        │
+        └───────────┴──────────┘
+        """
+        return wrap_expr(self._pyexpr.list_n_unique())
+
     def concat(self, other: list[Expr | str] | Expr | str | Series | list[Any]) -> Expr:
         """
         Concat the arrays in a Series dtype List in linear time.

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -454,7 +454,7 @@ class ExprListNameSpace:
         ...     }
         ... )
         >>> df.with_columns(n_unique=pl.col("a").list.n_unique())
-        shape: (1, 2)
+        shape: (2, 2)
         ┌───────────┬──────────┐
         │ a         ┆ n_unique │
         │ ---       ┆ ---      │

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -309,6 +309,22 @@ class ListNameSpace:
         ]
         """
 
+    def n_unique(self) -> Series:
+        """
+        Count the number of unique values in every sub-lists.
+
+        Examples
+        --------
+        >>> s = pl.Series("a", [[1, 1, 2], [2, 3, 4]])
+        >>> s.list.n_unique()
+        shape: (2,)
+        Series: 'a' [u32]
+        [
+            2
+            3
+        ]
+        """
+
     def concat(self, other: list[Series] | Series | list[Any]) -> Series:
         """
         Concat the arrays in a Series dtype List in linear time.

--- a/py-polars/src/expr/list.rs
+++ b/py-polars/src/expr/list.rs
@@ -223,6 +223,10 @@ impl PyExpr {
             .into())
     }
 
+    fn list_n_unique(&self) -> Self {
+        self.inner.clone().list().n_unique().into()
+    }
+
     fn list_unique(&self, maintain_order: bool) -> Self {
         let e = self.inner.clone();
 

--- a/py-polars/tests/unit/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/namespaces/list/test_list.py
@@ -788,3 +788,17 @@ def test_list_gather_every() -> None:
     )
 
     assert_frame_equal(out, expected)
+
+
+def test_list_n_unique() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [[1, 1, 2], [3, 3], [None], None, []],
+        }
+    )
+
+    out = df.select(n_unique=pl.col("a").list.n_unique())
+    expected = pl.DataFrame(
+        {"n_unique": [2, 1, 1, None, 0]}, schema={"n_unique": pl.UInt32}
+    )
+    assert_frame_equal(out, expected)


### PR DESCRIPTION
Half work of #14273. Will submit Its counterpart in array namespace in another PR to avoid conflicts.