### PR TITLE
Add type overloads for from_arrow

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -512,6 +512,30 @@ def from_numpy(
 # simply result in mypy inferring "Any", which isn't useful...
 
 
+@overload
+def from_arrow(
+    data: pa.Table
+        | pa.RecordBatch
+        | Iterable[pa.RecordBatch | pa.Table],
+    schema: SchemaDefinition | None = ...,
+    *,
+    schema_overrides: SchemaDict | None = ...,
+    rechunk: bool = ...,
+) -> DataFrame:
+    ...
+
+
+@overload
+def from_arrow(
+    data: pa.Array | pa.ChunkedArray,
+    schema: SchemaDefinition | None = ...,
+    *,
+    schema_overrides: SchemaDict | None = ...,
+    rechunk: bool = ...,
+) -> Series:
+    ...
+
+    
 def from_arrow(
     data: (
         pa.Table


### PR DESCRIPTION
These correspond to the ones added for `from_pandas`, helping the type-checker to recognise when a DataFrame or Series will be returned.

(Equivalents added here: https://github.com/pola-rs/polars/commit/f6d7a185fdf3b9cc9e3ace3114082e3368191c22#diff-4c94e013bf5cbe1352b49c01958d0a6d58948f0abf030bf26f6f6c9089e4706eR213)