### PR TITLE
fix(rust): don't make column from filenames, don't ignore directories with (.)

### DIFF
--- a/crates/polars-plan/src/logical_plan/hive.rs
+++ b/crates/polars-plan/src/logical_plan/hive.rs
@@ -42,7 +42,9 @@ impl HivePartitions {
             .display()
             .to_string()
             .split(sep)
-            .filter_map(|part| {
+            .enumerate()
+            .peekable()
+            .filter_map(|(index, part)| {
                 let mut it = part.split('=');
                 let name = it.next()?;
                 let value = it.next()?;
@@ -52,8 +54,8 @@ impl HivePartitions {
                 if value.contains('*') {
                     return None;
                 }
-                let value_path = Path::new(value);
-                if value_path.extension().is_some() {
+                
+                if index == url.display().to_string().split(sep).count() - 1 {
                     return None;
                 }
 

--- a/py-polars/tests/unit/io/test_hive.py
+++ b/py-polars/tests/unit/io/test_hive.py
@@ -176,3 +176,28 @@ def test_hive_partitioned_err(io_files_path: Path, tmp_path: Path) -> None:
 
     with pytest.raises(pl.ComputeError, match="invalid hive partitions"):
         pl.scan_parquet(root / "**/*.parquet", hive_partitioning=True)
+
+
+@pytest.mark.write_disk()
+def test_hive_partitioned_projection_skip_files(
+    io_files_path: Path, tmp_path: Path
+) -> None:
+    # ensure that it makes hive columns even when . in dir value
+    # and that it doesn't make hive columns from filename with =
+    df = pl.DataFrame(
+        {"sqlver": [10012.0, 10013.0], "namespace": ["eos", "fda"], "a": [1, 2]}
+    )
+    root = tmp_path / "partitioned_data"
+    for dir_tuple, sub_df in df.partition_by(
+        ["sqlver", "namespace"], include_key=False, as_dict=True
+    ).items():
+        new_path = root / f"sqlver={dir_tuple[0]}" / f"namespace={dir_tuple[1]}"
+        new_path.mkdir(parents=True, exist_ok=True)
+        sub_df.write_parquet(new_path / "file=8484.parquet")
+    test_df = (
+        pl.scan_parquet(str(root) + "/**/**/*.parquet")
+        # don't care about column order
+        .select("sqlver", "namespace", "a", pl.exclude("sqlver", "namespace", "a"))
+        .collect()
+    )
+    assert_frame_equal(df, test_df)


### PR DESCRIPTION
https://github.com/pola-rs/polars/pull/14128 had a bug in it where it identified files by having an extension but that made it so that any actual dirs with a . in their value would get ignored.

This one identifies files by being the last in the url split so it is robust against any directory name/value pairs. It also works for files that don't have extensions (not that anyone would ever save their parquet files without an extension)

There's also a test added.