### PR TITLE
fix: Preserve name when casting to Enum

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -373,7 +373,8 @@ impl LogicalType for CategoricalChunked {
                 Ok(self
                     .to_enum(categories, *hash)?
                     .set_ordering(*ordering, true)
-                    .into_series())
+                    .into_series()
+                    .with_name(self.name()))
             },
             DataType::Enum(None, _) => {
                 polars_bail!(ComputeError: "can not cast to enum without categories present")

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -579,25 +579,29 @@ def test_strict_cast_string_and_binary(
 
 
 @pytest.mark.parametrize(
-    "dtype_out",
+    ("dtype_in", "dtype_out"),
     [
-        (pl.UInt8),
-        (pl.Int8),
-        (pl.UInt16),
-        (pl.Int16),
-        (pl.UInt32),
-        (pl.Int32),
-        (pl.UInt64),
-        (pl.Int64),
-        (pl.Date),
-        (pl.Datetime),
-        (pl.Time),
-        (pl.Duration),
-        (pl.Enum(["1"])),
+        (pl.Categorical, pl.UInt8),
+        (pl.Categorical, pl.Int8),
+        (pl.Categorical, pl.UInt16),
+        (pl.Categorical, pl.Int16),
+        (pl.Categorical, pl.UInt32),
+        (pl.Categorical, pl.Int32),
+        (pl.Categorical, pl.UInt64),
+        (pl.Categorical, pl.Int64),
+        (pl.Categorical, pl.Date),
+        (pl.Categorical, pl.Datetime),
+        (pl.Categorical, pl.Time),
+        (pl.Categorical, pl.Duration),
+        (pl.Categorical, pl.Enum(["1"])),
+        (pl.Enum(["1"]), pl.Enum(["1", "2"])),
+        (pl.Enum(["1"]), pl.Categorical),
     ],
 )
-def test_cast_categorical_name_retention(dtype_out: PolarsDataType) -> None:
-    assert pl.Series("a", ["1"], dtype=pl.Categorical).cast(dtype_out).name == "a"
+def test_cast_categorical_name_retention(
+    dtype_in: PolarsDataType, dtype_out: PolarsDataType
+) -> None:
+    assert pl.Series("a", ["1"], dtype=dtype_in).cast(dtype_out).name == "a"
 
 
 def test_cast_date_to_time() -> None:

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -594,7 +594,8 @@ def test_strict_cast_string_and_binary(
         (pl.Time),
         (pl.Duration),
         (pl.String),
-        (pl.Enum(["1"])),
+        (pl.Categorical),
+        (pl.Enum(["1", "2"])),
     ],
 )
 def test_cast_categorical_name_retention(dtype_out: PolarsDataType) -> None:

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -579,29 +579,9 @@ def test_strict_cast_string_and_binary(
 
 
 @pytest.mark.parametrize(
-    "dtype_out",
-    [
-        (pl.UInt8),
-        (pl.Int8),
-        (pl.UInt16),
-        (pl.Int16),
-        (pl.UInt32),
-        (pl.Int32),
-        (pl.UInt64),
-        (pl.Int64),
-        (pl.Date),
-        (pl.Datetime),
-        (pl.Time),
-        (pl.Duration),
-        (pl.String),
-        (pl.Categorical),
-        (pl.Enum(["1", "2"])),
-    ],
+    "dtype_in",
+    [(pl.Categorical), (pl.Enum(["1"]))],
 )
-def test_cast_categorical_name_retention(dtype_out: PolarsDataType) -> None:
-    assert pl.Series("a", ["1"], dtype=pl.Categorical).cast(dtype_out).name == "a"
-
-
 @pytest.mark.parametrize(
     "dtype_out",
     [
@@ -622,8 +602,10 @@ def test_cast_categorical_name_retention(dtype_out: PolarsDataType) -> None:
         (pl.Enum(["1", "2"])),
     ],
 )
-def test_cast_enum_name_retention(dtype_out: PolarsDataType) -> None:
-    assert pl.Series("a", ["1"], dtype=pl.Enum(["1"])).cast(dtype_out).name == "a"
+def test_cast_categorical_name_retention(
+    dtype_in: PolarsDataType, dtype_out: PolarsDataType
+) -> None:
+    assert pl.Series("a", ["1"], dtype=dtype_in).cast(dtype_out).name == "a"
 
 
 def test_cast_date_to_time() -> None:

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -579,29 +579,50 @@ def test_strict_cast_string_and_binary(
 
 
 @pytest.mark.parametrize(
-    ("dtype_in", "dtype_out"),
+    "dtype_out",
     [
-        (pl.Categorical, pl.UInt8),
-        (pl.Categorical, pl.Int8),
-        (pl.Categorical, pl.UInt16),
-        (pl.Categorical, pl.Int16),
-        (pl.Categorical, pl.UInt32),
-        (pl.Categorical, pl.Int32),
-        (pl.Categorical, pl.UInt64),
-        (pl.Categorical, pl.Int64),
-        (pl.Categorical, pl.Date),
-        (pl.Categorical, pl.Datetime),
-        (pl.Categorical, pl.Time),
-        (pl.Categorical, pl.Duration),
-        (pl.Categorical, pl.Enum(["1"])),
-        (pl.Enum(["1"]), pl.Enum(["1", "2"])),
-        (pl.Enum(["1"]), pl.Categorical),
+        (pl.UInt8),
+        (pl.Int8),
+        (pl.UInt16),
+        (pl.Int16),
+        (pl.UInt32),
+        (pl.Int32),
+        (pl.UInt64),
+        (pl.Int64),
+        (pl.Date),
+        (pl.Datetime),
+        (pl.Time),
+        (pl.Duration),
+        (pl.String),
+        (pl.Enum(["1"])),
     ],
 )
-def test_cast_categorical_name_retention(
-    dtype_in: PolarsDataType, dtype_out: PolarsDataType
-) -> None:
-    assert pl.Series("a", ["1"], dtype=dtype_in).cast(dtype_out).name == "a"
+def test_cast_categorical_name_retention(dtype_out: PolarsDataType) -> None:
+    assert pl.Series("a", ["1"], dtype=pl.Categorical).cast(dtype_out).name == "a"
+
+
+@pytest.mark.parametrize(
+    "dtype_out",
+    [
+        (pl.UInt8),
+        (pl.Int8),
+        (pl.UInt16),
+        (pl.Int16),
+        (pl.UInt32),
+        (pl.Int32),
+        (pl.UInt64),
+        (pl.Int64),
+        (pl.Date),
+        (pl.Datetime),
+        (pl.Time),
+        (pl.Duration),
+        (pl.String),
+        (pl.Categorical),
+        (pl.Enum(["1", "2"])),
+    ],
+)
+def test_cast_enum_name_retention(dtype_out: PolarsDataType) -> None:
+    assert pl.Series("a", ["1"], dtype=pl.Enum(["1"])).cast(dtype_out).name == "a"
 
 
 def test_cast_date_to_time() -> None:


### PR DESCRIPTION
Resolves #14318.

```python
import polars as pl

dtype1 = pl.Enum(["a", "b"])
dtype2 = pl.Enum(["a", "b", "Null"])

s = pl.Series(name="x", values=["a", "b", None], dtype=dtype1)
print(s.name)
```
```
x
```
