### PR TITLE
feat(rust): Implements the IntoLazy for LazyFrame

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -70,6 +70,12 @@ impl IntoLazy for DataFrame {
     }
 }
 
+impl IntoLazy for LazyFrame {
+    fn lazy(self) -> LazyFrame {
+        self
+    }
+}
+
 /// Lazy abstraction over an eager `DataFrame`.
 /// It really is an abstraction over a logical plan. The methods of this struct will incrementally
 /// modify a logical plan until output is requested (via [`collect`](crate::frame::LazyFrame::collect)).


### PR DESCRIPTION
This allows functions to accept either `DataFrame` or `LazyFrame`
```
fn foo(frame : impl IntoFrame);
```