### PR TITLE
fix(python): fix ufunc for unlimited column args

### DIFF
--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -81,9 +81,17 @@ def test_map_deprecated() -> None:
 
 def test_ufunc_args() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [2, 4, 6]})
-    result = df.select(z=np.add(pl.col("a"), pl.col("b"))) # type: ignore[call-overload]
+    result = df.select(
+        z=np.add(  # type: ignore[call-overload]
+            pl.col("a"), pl.col("b")
+        )
+    )
     expected = pl.DataFrame({"z": [3, 6, 9]})
     assert_frame_equal(result, expected)
-    result = df.select(z=np.add(2, pl.col("a"))) # type: ignore[call-overload]
+    result = df.select(
+        z=np.add(  # type: ignore[call-overload]
+            2, pl.col("a")
+        )
+    )
     expected = pl.DataFrame({"z": [3, 4, 5]})
     assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -77,3 +77,13 @@ def test_map_deprecated() -> None:
         pl.col("a").map(lambda x: x)
     with pytest.deprecated_call():
         pl.LazyFrame({"a": [1, 2]}).map(lambda x: x)
+
+
+def test_ufunc_args() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [2, 4, 6]})
+    result = df.select(z=np.add(pl.col("a"), pl.col("b")))
+    expected = pl.DataFrame({"z": [3, 6, 9]})
+    assert_frame_equal(result, expected)
+    result = df.select(z=np.add(2, pl.col("a")))
+    expected = pl.DataFrame({"z": [3, 4, 5]})
+    assert_frame_equal(result, expected)

--- a/py-polars/tests/unit/operations/map/test_map_batches.py
+++ b/py-polars/tests/unit/operations/map/test_map_batches.py
@@ -81,9 +81,9 @@ def test_map_deprecated() -> None:
 
 def test_ufunc_args() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [2, 4, 6]})
-    result = df.select(z=np.add(pl.col("a"), pl.col("b")))
+    result = df.select(z=np.add(pl.col("a"), pl.col("b"))) # type: ignore[call-overload]
     expected = pl.DataFrame({"z": [3, 6, 9]})
     assert_frame_equal(result, expected)
-    result = df.select(z=np.add(2, pl.col("a")))
+    result = df.select(z=np.add(2, pl.col("a"))) # type: ignore[call-overload]
     expected = pl.DataFrame({"z": [3, 4, 5]})
     assert_frame_equal(result, expected)


### PR DESCRIPTION
fixes https://github.com/pola-rs/polars/issues/10512
https://github.com/pola-rs/polars/issues/14216

Since the ufunc only passes to `__ufunc_array__` the number of args that are actually required, we can't reduce (see the linked issue for more details). Users must reduce themselves. As such, I took out the `pyreduce` and instead we can create structs automatically. Before this change, the usage of pyreduce just allowed for exactly 2 inputs but no more than 2 so it wasn't really reducing in the true sense of the word.

When this gets merged I'll revise https://github.com/pola-rs/polars/pull/13392 this to incorporate the new capabilities.