### PR TITLE
Fix: don't add null row when "diagonal-relaxed" used with empty frames

### DIFF
--- a/crates/polars-lazy/src/dsl/functions.rs
+++ b/crates/polars-lazy/src/dsl/functions.rs
@@ -146,7 +146,12 @@ pub fn concat_lf_diagonal<L: AsRef<[LazyFrame]>>(
         .iter()
         // Zip Frames with their Schemas
         .zip(schemas)
-        .map(|(lf, lf_schema)| {
+        .filter_map(|(lf, lf_schema)| {
+            if lf_schema.is_empty() {
+                // if the frame is empty we discard
+                return None;
+            };
+
             let mut lf = lf.clone();
             for (name, dtype) in total_schema.iter() {
                 // If a name from Total Schema is not present - append
@@ -162,7 +167,7 @@ pub fn concat_lf_diagonal<L: AsRef<[LazyFrame]>>(
                     .map(|col_name| col(col_name))
                     .collect::<Vec<Expr>>(),
             );
-            Ok(reordered_lf)
+            Some(Ok(reordered_lf))
         })
         .collect::<PolarsResult<Vec<_>>>()?;
 

--- a/py-polars/tests/unit/functions/test_functions.py
+++ b/py-polars/tests/unit/functions/test_functions.py
@@ -89,6 +89,19 @@ def test_concat_diagonal(
         assert_frame_equal(out, expected)
 
 
+def test_concat_diagonal_relaxed_with_empty_frame() -> None:
+    df1 = pl.DataFrame()
+    df2 = pl.DataFrame(
+        {
+            "a": ["a", "b"],
+            "b": [1, 2],
+        }
+    )
+    out = pl.concat((df1, df2), how="diagonal_relaxed")
+    expected = df2
+    assert_frame_equal(out, expected)
+
+
 @pytest.mark.parametrize("lazy", [False, True])
 def test_concat_horizontal(lazy: bool) -> None:
     a = pl.DataFrame({"a": ["a", "b"], "b": [1, 2]})


### PR DESCRIPTION
Resolves #14321.

```python
import polars as pl

df1 = pl.DataFrame()
df2 = pl.DataFrame({
    "a": ["a", "b"],
    "b": [1, 2],
})
out = pl.concat((df1, df2), how="diagonal_relaxed")
print(out)
```
```
shape: (2, 2)
┌───────┬───────┐
│ col_1 ┆ col_2 │
│ ---   ┆ ---   │
│ str   ┆ i64   │
╞═══════╪═══════╡
│ a     ┆ 1     │
│ b     ┆ 2     │
└───────┴───────┘
```