### PR TITLE
feat: Do not panic when casting from an empty Series to pl.Decimal

### DIFF
--- a/crates/polars-core/src/series/ops/null.rs
+++ b/crates/polars-core/src/series/ops/null.rs
@@ -39,10 +39,7 @@ impl Series {
                 .into_series(),
             #[cfg(feature = "dtype-decimal")]
             DataType::Decimal(precision, scale) => Int128Chunked::full_null(name, size)
-                .into_decimal_unchecked(
-                    *precision,
-                    scale.unwrap_or_else(|| unreachable!("scale should be set")),
-                )
+                .into_decimal_unchecked(*precision, scale.unwrap_or(0))
                 .into_series(),
             #[cfg(feature = "dtype-struct")]
             DataType::Struct(fields) => {

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -138,6 +138,14 @@ def test_decimal_cast() -> None:
     assert result.to_dict(as_series=False) == expected
 
 
+def test_decimal_cast_no_scale() -> None:
+    s = pl.Series().cast(pl.Decimal)
+    assert s.dtype == pl.Decimal(precision=None, scale=0)
+
+    s = pl.Series([D("10.0")]).cast(pl.Decimal)
+    assert s.dtype == pl.Decimal(precision=None, scale=1)
+
+
 def test_decimal_scale_precision_roundtrip(monkeypatch: Any) -> None:
     monkeypatch.setenv("POLARS_ACTIVATE_DECIMAL", "1")
     assert pl.from_arrow(pl.Series("dec", [D("10.0")]).to_arrow()).item() == D("10.0")


### PR DESCRIPTION
Closes #14002 

More specifically, the PR attempts to address the following two issues:

**1. Panic when casting from an empty Series without explicitly setting a scale:**
```python
pl.Series().cast(pl.Decimal)
# Panic: no scale!
```
In this case, we just set scale to 0, in the same way as it's done when constructing an empty Series with `dtype=pl.Decimal`:
```python
pl.Series([], dtype=pl.Decimal) 

# shape: (0,)
# Series: '' [decimal[*,0]]
# [
# ] 
```

**2. An error is raised when casting a Series, whose dtype is already pl.Decimal, without setting scale explicitly:**
```python
from decimal import Decimal

pl.Series([Decimal("10.0")]).cast(pl.Decimal)
# ComputeError: no scale!
```
I don't know why anyone would want to do that but raising an error seems too punishing; the existing scale can be kept. For example:
```python
from decimal import Decimal

pl.Series([Decimal("10.0")]).cast(pl.Decimal)

# shape: (1,)
# Series: '' [decimal[*,1]]
# [
#         10
# ]
```
