### PR TITLE
perf: Fix cross join batch size when one of the DataFrames is tiny

### DIFF
--- a/crates/polars-pipe/src/executors/sinks/joins/cross.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/cross.rs
@@ -94,7 +94,13 @@ impl Operator for CrossJoinProbe {
         // However, if one of the DataFrames is much smaller than 250, we want
         // to take rather more from the other DataFrame so we don't end up with
         // overly small chunks.
-        let size = 250 * (250 / chunk.data.height()).max(1) * (250 / self.df.height()).max(1);
+        let mut size = 250;
+        if chunk.data.height() > 0 {
+            size *= (250 / chunk.data.height()).max(1);
+        }
+        if self.df.height() > 0 {
+            size *= (250 / self.df.height()).max(1);
+        }
 
         if self.in_process_left.is_none() {
             let mut iter_left = (0..self.df.height()).step_by(size);

--- a/crates/polars-pipe/src/executors/sinks/joins/cross.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/cross.rs
@@ -90,9 +90,11 @@ impl Operator for CrossJoinProbe {
         _context: &PExecutionContext,
         chunk: &DataChunk,
     ) -> PolarsResult<OperatorResult> {
-        // expected output size = size**2
-        // so this is a small number
-        let size = 250;
+        // Expected output is size**2, so this needs to be a a small number.
+        // However, if one of the DataFrames is much smaller than 250, we want
+        // to take rather more from the other DataFrame so we don't end up with
+        // overly small chunks.
+        let size = 250 * (250 / chunk.data.height()).max(1) * (250 / self.df.height()).max(1);
 
         if self.in_process_left.is_none() {
             let mut iter_left = (0..self.df.height()).step_by(size);


### PR DESCRIPTION
This is a separate follow-up to #11699.

It fixes one particular edge case which generates small batches, as featured in the test script. Using the same script #14346, but without the fix in #14346, before:

```
SINK 2.8767316341400146
COLLECT+WRITE 0.9260973930358887
STREAMING COLLECT+WRITE 4.061856031417847
```

And after:

```
SINK 1.0176868438720703
COLLECT+WRITE 0.9198713302612305
STREAMING COLLECT+WRITE 0.9465274810791016
```

This is not a substitute for #14346, however, since there are likely other cases where small chunk sizes get generated. It's therefore worth fixing both sides (final sinks and intermediate steps):

1. Fixing intermediate steps should also speed up later intermediate calculation in cases where the overhead of small chunks is relevant, _before_ they hit the final sink.
2. Fixing the final sinks means that the final output performance is robust to any unfixed (or unavoidable!) small batches coming out of the pipeline. There are likely more.