### PR TITLE
feat(python): Introduce `CopyNotAllowedError`

### DIFF
--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -74,6 +74,7 @@ from polars.exceptions import (
     ChronoFormatWarning,
     ColumnNotFoundError,
     ComputeError,
+    CopyNotAllowedError,
     DuplicateError,
     InvalidOperationError,
     NoDataError,
@@ -226,6 +227,7 @@ __all__ = [
     "exceptions",
     # exceptions/errors
     "ArrowError",
+    "CopyNotAllowedError",
     "ColumnNotFoundError",
     "ComputeError",
     "DuplicateError",

--- a/py-polars/polars/exceptions.py
+++ b/py-polars/polars/exceptions.py
@@ -65,6 +65,10 @@ except ImportError:
         """Warning raised when a categorical needs to be remapped to be compatible with another categorical."""  # noqa: W505
 
 
+class CopyNotAllowedError(PolarsError, RuntimeError):  # type: ignore[misc]
+    """Exception raised when data copy is required, but copying data was explicitly disallowed."""  # noqa: W505
+
+
 class InvalidAssert(PolarsError):  # type: ignore[misc]
     """Exception raised when an unsupported testing assert is made."""
 
@@ -128,6 +132,7 @@ class CustomUFuncWarning(PolarsWarning):  # type: ignore[misc]
 __all__ = [
     "ArrowError",
     "ColumnNotFoundError",
+    "CopyNotAllowedError",
     "ComputeError",
     "ChronoFormatWarning",
     "DuplicateError",

--- a/py-polars/polars/interchange/buffer.py
+++ b/py-polars/polars/interchange/buffer.py
@@ -2,12 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from polars.interchange.protocol import (
-    Buffer,
-    CopyNotAllowedError,
-    DlpackDeviceType,
-    DtypeKind,
-)
+from polars.exceptions import CopyNotAllowedError
+from polars.interchange.protocol import Buffer, DlpackDeviceType, DtypeKind
 from polars.interchange.utils import polars_dtype_to_dtype
 
 if TYPE_CHECKING:

--- a/py-polars/polars/interchange/column.py
+++ b/py-polars/polars/interchange/column.py
@@ -3,14 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from polars.datatypes import Boolean, Categorical, Enum, String
+from polars.exceptions import CopyNotAllowedError
 from polars.interchange.buffer import PolarsBuffer
-from polars.interchange.protocol import (
-    Column,
-    ColumnNullType,
-    CopyNotAllowedError,
-    DtypeKind,
-    Endianness,
-)
+from polars.interchange.protocol import Column, ColumnNullType, DtypeKind, Endianness
 from polars.interchange.utils import polars_dtype_to_dtype
 
 if TYPE_CHECKING:

--- a/py-polars/polars/interchange/dataframe.py
+++ b/py-polars/polars/interchange/dataframe.py
@@ -4,8 +4,8 @@ from collections.abc import Sequence
 from itertools import accumulate
 from typing import TYPE_CHECKING
 
+from polars.exceptions import CopyNotAllowedError
 from polars.interchange.column import PolarsColumn
-from polars.interchange.protocol import CopyNotAllowedError
 from polars.interchange.protocol import DataFrame as InterchangeDataFrame
 
 if TYPE_CHECKING:

--- a/py-polars/polars/interchange/from_dataframe.py
+++ b/py-polars/polars/interchange/from_dataframe.py
@@ -5,9 +5,9 @@ from typing import TYPE_CHECKING
 import polars._reexport as pl
 import polars.functions as F
 from polars.datatypes import Boolean, Enum, Int64, String, UInt8, UInt32
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, CopyNotAllowedError
 from polars.interchange.dataframe import PolarsDataFrame
-from polars.interchange.protocol import ColumnNullType, CopyNotAllowedError, DtypeKind
+from polars.interchange.protocol import ColumnNullType, DtypeKind
 from polars.interchange.utils import (
     dtype_to_polars_dtype,
     get_buffer_length_in_elements,

--- a/py-polars/polars/interchange/protocol.py
+++ b/py-polars/polars/interchange/protocol.py
@@ -252,7 +252,3 @@ class Endianness:
     BIG = ">"
     NATIVE = "="
     NA = "|"
-
-
-class CopyNotAllowedError(RuntimeError):
-    """Exception raised when a copy is required, but `allow_copy` is set to `False`."""

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -64,7 +64,7 @@ from polars.dependencies import (
 from polars.dependencies import numpy as np
 from polars.dependencies import pandas as pd
 from polars.dependencies import pyarrow as pa
-from polars.exceptions import ModuleUpgradeRequired, ShapeError
+from polars.exceptions import CopyNotAllowedError, ModuleUpgradeRequired, ShapeError
 from polars.meta import get_index_type
 from polars.series.array import ArrayNameSpace
 from polars.series.binary import BinaryNameSpace
@@ -4314,6 +4314,11 @@ class Series:
             <https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_numpy>`_
             for the conversion to NumPy.
 
+        Raises
+        ------
+        CopyNotAllowedError
+            If data copy is required, but `zero_copy_only` was set to True.
+
         Examples
         --------
         >>> s = pl.Series("a", [1, 2, 3])
@@ -4324,10 +4329,9 @@ class Series:
         <class 'numpy.ndarray'>
         """
 
-        def raise_no_zero_copy() -> None:
+        def raise_no_zero_copy(msg: str) -> None:
             if zero_copy_only and not self.is_empty():
-                msg = "cannot return a zero-copy array"
-                raise ValueError(msg)
+                raise CopyNotAllowedError(msg)
 
         def temporal_dtype_to_numpy(dtype: PolarsDataType) -> Any:
             if dtype == Date:
@@ -4341,7 +4345,7 @@ class Series:
                 raise TypeError(msg)
 
         if self.n_chunks() > 1:
-            raise_no_zero_copy()
+            raise_no_zero_copy("Series must be rechunked")
             self = self.rechunk()
 
         dtype = self.dtype
@@ -4368,28 +4372,34 @@ class Series:
             if dtype.is_integer() or dtype.is_float():
                 np_array = self._view(ignore_nulls=True)
             elif dtype == Boolean:
-                raise_no_zero_copy()
+                raise_no_zero_copy(
+                    "bit packed boolean buffer must be converted into byte packed boolean buffer"
+                )
                 np_array = self.cast(UInt8)._view(ignore_nulls=True).view(bool)
             elif dtype in (Datetime, Duration):
                 np_dtype = temporal_dtype_to_numpy(dtype)
                 np_array = self._view(ignore_nulls=True).view(np_dtype)
             elif dtype == Date:
-                raise_no_zero_copy()
+                raise_no_zero_copy(
+                    "32-bit date buffer must be converted into 64-bit date buffer"
+                )
                 np_dtype = temporal_dtype_to_numpy(dtype)
                 np_array = self.to_physical()._view(ignore_nulls=True).astype(np_dtype)
             else:
-                raise_no_zero_copy()
+                raise_no_zero_copy(
+                    f"buffer of type {dtype} must be converted into object type"
+                )
                 np_array = self._s.to_numpy()
 
         else:
-            raise_no_zero_copy()
+            raise_no_zero_copy("cannot handle null values without copying data")
             np_array = self._s.to_numpy()
             if dtype in (Datetime, Duration, Date):
                 np_dtype = temporal_dtype_to_numpy(dtype)
                 np_array = np_array.view(np_dtype)
 
         if writable and not np_array.flags.writeable:
-            raise_no_zero_copy()
+            raise_no_zero_copy("cannot create a writeable array without copying data")
             np_array = np_array.copy()
 
         return np_array

--- a/py-polars/tests/unit/interchange/test_buffer.py
+++ b/py-polars/tests/unit/interchange/test_buffer.py
@@ -4,7 +4,7 @@ import pytest
 
 import polars as pl
 from polars.interchange.buffer import PolarsBuffer
-from polars.interchange.protocol import CopyNotAllowedError, DlpackDeviceType
+from polars.interchange.protocol import DlpackDeviceType
 
 
 @pytest.mark.parametrize(
@@ -25,7 +25,7 @@ def test_init_invalid_input() -> None:
     data = pl.concat([s, s], rechunk=False)
 
     with pytest.raises(
-        CopyNotAllowedError, match="non-contiguous buffer must be made contiguous"
+        pl.CopyNotAllowedError, match="non-contiguous buffer must be made contiguous"
     ):
         PolarsBuffer(data, allow_copy=False)
 

--- a/py-polars/tests/unit/interchange/test_column.py
+++ b/py-polars/tests/unit/interchange/test_column.py
@@ -7,7 +7,7 @@ import pytest
 
 import polars as pl
 from polars.interchange.column import PolarsColumn
-from polars.interchange.protocol import ColumnNullType, CopyNotAllowedError, DtypeKind
+from polars.interchange.protocol import ColumnNullType, DtypeKind
 from polars.testing import assert_series_equal
 
 if TYPE_CHECKING:
@@ -271,7 +271,7 @@ def test_get_buffers_string_zero_copy_fails() -> None:
     col = PolarsColumn(s, allow_copy=False)
 
     msg = "string buffers must be converted"
-    with pytest.raises(CopyNotAllowedError, match=msg):
+    with pytest.raises(pl.CopyNotAllowedError, match=msg):
         col.get_buffers()
 
 
@@ -292,7 +292,7 @@ def test_get_buffers_global_categorical() -> None:
     col = PolarsColumn(s, allow_copy=False)
 
     msg = "column 'a' must be converted to a local categorical"
-    with pytest.raises(CopyNotAllowedError, match=msg):
+    with pytest.raises(pl.CopyNotAllowedError, match=msg):
         col.get_buffers()
 
 
@@ -302,7 +302,7 @@ def test_get_buffers_chunked_zero_copy_fails() -> None:
     col = PolarsColumn(s, allow_copy=False)
 
     with pytest.raises(
-        CopyNotAllowedError, match="non-contiguous buffer must be made contiguous"
+        pl.CopyNotAllowedError, match="non-contiguous buffer must be made contiguous"
     ):
         col.get_buffers()
 

--- a/py-polars/tests/unit/interchange/test_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_dataframe.py
@@ -4,7 +4,6 @@ import pytest
 
 import polars as pl
 from polars.interchange.dataframe import PolarsDataFrame
-from polars.interchange.protocol import CopyNotAllowedError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -209,7 +208,7 @@ def test_get_chunks_zero_copy_fail() -> None:
     dfi = PolarsDataFrame(df, allow_copy=False)
 
     with pytest.raises(
-        CopyNotAllowedError, match="unevenly chunked columns must be rechunked"
+        pl.CopyNotAllowedError, match="unevenly chunked columns must be rechunked"
     ):
         next(dfi.get_chunks())
 
@@ -285,7 +284,7 @@ def test_get_chunks_from_col_chunks_uneven_chunks_zero_copy_fails() -> None:
     assert_frame_equal(chunk1, expected1)
 
     # Second chunk requires a rechunk of the second column
-    with pytest.raises(CopyNotAllowedError, match="columns must be rechunked"):
+    with pytest.raises(pl.CopyNotAllowedError, match="columns must be rechunked"):
         next(out)
 
 

--- a/py-polars/tests/unit/interchange/test_from_dataframe.py
+++ b/py-polars/tests/unit/interchange/test_from_dataframe.py
@@ -21,12 +21,7 @@ from polars.interchange.from_dataframe import (
     _construct_validity_buffer_from_bytemask,
     _string_column_to_series,
 )
-from polars.interchange.protocol import (
-    ColumnNullType,
-    CopyNotAllowedError,
-    DtypeKind,
-    Endianness,
-)
+from polars.interchange.protocol import ColumnNullType, DtypeKind, Endianness
 from polars.testing import assert_frame_equal, assert_series_equal
 
 NE = Endianness.NATIVE
@@ -175,7 +170,7 @@ def test_from_dataframe_pandas_boolean_bytes() -> None:
     assert_frame_equal(result, expected)
 
     with pytest.raises(
-        CopyNotAllowedError,
+        pl.CopyNotAllowedError,
         match="byte-packed boolean buffer must be converted to bit-packed boolean",
     ):
         result = pl.from_dataframe(df, allow_copy=False)
@@ -190,7 +185,9 @@ def test_from_dataframe_categorical_pandas() -> None:
     expected = pl.Series("a", values, dtype=pl.Enum(["a", "b"])).to_frame()
     assert_frame_equal(result, expected)
 
-    with pytest.raises(CopyNotAllowedError, match="string buffers must be converted"):
+    with pytest.raises(
+        pl.CopyNotAllowedError, match="string buffers must be converted"
+    ):
         result = pl.from_dataframe(df_pd, allow_copy=False)
 
 
@@ -205,7 +202,9 @@ def test_from_dataframe_categorical_pyarrow() -> None:
     expected = pl.Series("a", values, dtype=pl.Enum(["a", "b"])).to_frame()
     assert_frame_equal(result, expected)
 
-    with pytest.raises(CopyNotAllowedError, match="string buffers must be converted"):
+    with pytest.raises(
+        pl.CopyNotAllowedError, match="string buffers must be converted"
+    ):
         result = pl.from_dataframe(df_pa, allow_copy=False)
 
 
@@ -234,7 +233,7 @@ def test_from_dataframe_categorical_non_u32_values() -> None:
     assert_frame_equal(result, expected)
 
     with pytest.raises(
-        CopyNotAllowedError, match="data buffer must be cast from Int8 to UInt32"
+        pl.CopyNotAllowedError, match="data buffer must be cast from Int8 to UInt32"
     ):
         result = pl.from_dataframe(df_pa, allow_copy=False)
 
@@ -398,7 +397,7 @@ def test_construct_offsets_buffer_copy() -> None:
     buffer = PolarsBuffer(data)
     dtype = (DtypeKind.UINT, 32, "I", NE)
 
-    with pytest.raises(CopyNotAllowedError):
+    with pytest.raises(pl.CopyNotAllowedError):
         _construct_offsets_buffer(buffer, dtype, offset=0, allow_copy=False)
 
     result = _construct_offsets_buffer(buffer, dtype, offset=0, allow_copy=True)
@@ -491,7 +490,7 @@ def test_construct_validity_buffer_use_nan() -> None:
     expected = pl.Series([True, True, False])
     assert_series_equal(result, expected)  # type: ignore[arg-type]
 
-    with pytest.raises(CopyNotAllowedError, match="bitmask must be constructed"):
+    with pytest.raises(pl.CopyNotAllowedError, match="bitmask must be constructed"):
         _construct_validity_buffer(None, col, s.dtype, s, allow_copy=False)
 
 
@@ -506,7 +505,7 @@ def test_construct_validity_buffer_use_sentinel() -> None:
     expected = pl.Series([True, True, False])
     assert_series_equal(result, expected)  # type: ignore[arg-type]
 
-    with pytest.raises(CopyNotAllowedError, match="bitmask must be constructed"):
+    with pytest.raises(pl.CopyNotAllowedError, match="bitmask must be constructed"):
         _construct_validity_buffer(None, col, s.dtype, s, allow_copy=False)
 
 
@@ -543,7 +542,7 @@ def test_construct_validity_buffer_from_bitmask_inverted(bitmask: PolarsBuffer) 
 def test_construct_validity_buffer_from_bitmask_zero_copy_fails(
     bitmask: PolarsBuffer,
 ) -> None:
-    with pytest.raises(CopyNotAllowedError):
+    with pytest.raises(pl.CopyNotAllowedError):
         _construct_validity_buffer_from_bitmask(
             bitmask, null_value=1, offset=0, length=4, allow_copy=False
         )
@@ -581,7 +580,7 @@ def test_construct_validity_buffer_from_bytemask_inverted(
 def test_construct_validity_buffer_from_bytemask_zero_copy_fails(
     bytemask: PolarsBuffer,
 ) -> None:
-    with pytest.raises(CopyNotAllowedError):
+    with pytest.raises(pl.CopyNotAllowedError):
         _construct_validity_buffer_from_bytemask(
             bytemask, null_value=0, allow_copy=False
         )

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -25,11 +25,6 @@ def assert_zero_copy(s: pl.Series, arr: np.ndarray[Any, Any]) -> None:
     assert s_ptr == arr_ptr
 
 
-def assert_zero_copy_only_raises(s: pl.Series) -> None:
-    with pytest.raises(ValueError, match="cannot return a zero-copy array"):
-        s.to_numpy(use_pyarrow=False, zero_copy_only=True)
-
-
 @pytest.mark.parametrize(
     ("dtype", "expected_dtype"),
     [
@@ -80,7 +75,10 @@ def test_series_to_numpy_numeric_with_nulls(
     assert result.tolist()[:-1] == s.to_list()[:-1]
     assert np.isnan(result[-1])
     assert result.dtype == expected_dtype
-    assert_zero_copy_only_raises(s)
+
+    msg = "cannot handle null values without copying data"
+    with pytest.raises(pl.CopyNotAllowedError, match=msg):
+        s.to_numpy(use_pyarrow=False, zero_copy_only=True)
 
 
 @pytest.mark.parametrize(
@@ -130,7 +128,10 @@ def test_series_to_numpy_date() -> None:
 
     assert s.to_list() == result.tolist()
     assert result.dtype == np.dtype("datetime64[D]")
-    assert_zero_copy_only_raises(s)
+
+    msg = "32-bit date buffer must be converted into 64-bit date buffer"
+    with pytest.raises(pl.CopyNotAllowedError, match=msg):
+        s.to_numpy(use_pyarrow=False, zero_copy_only=True)
 
 
 @pytest.mark.parametrize(
@@ -159,7 +160,10 @@ def test_series_to_numpy_temporal_with_nulls(
     else:
         assert result.tolist() == s.to_list()
     assert result.dtype == expected_dtype
-    assert_zero_copy_only_raises(s)
+
+    msg = "cannot handle null values without copying data"
+    with pytest.raises(pl.CopyNotAllowedError, match=msg):
+        s.to_numpy(use_pyarrow=False, zero_copy_only=True)
 
 
 def test_series_to_numpy_datetime_with_tz_with_nulls() -> None:
@@ -169,7 +173,10 @@ def test_series_to_numpy_datetime_with_tz_with_nulls() -> None:
 
     assert result.tolist() == values
     assert result.dtype == np.dtype("datetime64[us]")
-    assert_zero_copy_only_raises(s)
+
+    msg = "cannot handle null values without copying data"
+    with pytest.raises(pl.CopyNotAllowedError, match=msg):
+        s.to_numpy(use_pyarrow=False, zero_copy_only=True)
 
 
 @pytest.mark.parametrize(
@@ -199,7 +206,13 @@ def test_to_numpy_object_dtypes(
 
     assert result.tolist() == values
     assert result.dtype == np.object_
-    assert_zero_copy_only_raises(s)
+
+    if with_nulls:
+        msg = "cannot handle null values without copying data"
+    else:
+        msg = "must be converted into object type"
+    with pytest.raises(pl.CopyNotAllowedError, match=msg):
+        s.to_numpy(use_pyarrow=False, zero_copy_only=True)
 
 
 def test_series_to_numpy_bool() -> None:
@@ -208,7 +221,10 @@ def test_series_to_numpy_bool() -> None:
 
     assert s.to_list() == result.tolist()
     assert result.dtype == np.bool_
-    assert_zero_copy_only_raises(s)
+
+    msg = "bit packed boolean buffer must be converted into byte packed boolean buffer"
+    with pytest.raises(pl.CopyNotAllowedError, match=msg):
+        s.to_numpy(use_pyarrow=False, zero_copy_only=True)
 
 
 def test_series_to_numpy_bool_with_nulls() -> None:
@@ -217,7 +233,10 @@ def test_series_to_numpy_bool_with_nulls() -> None:
 
     assert s.to_list() == result.tolist()
     assert result.dtype == np.object_
-    assert_zero_copy_only_raises(s)
+
+    msg = "cannot handle null values without copying data"
+    with pytest.raises(pl.CopyNotAllowedError, match=msg):
+        s.to_numpy(use_pyarrow=False, zero_copy_only=True)
 
 
 def test_series_to_numpy_array_of_int() -> None:
@@ -249,7 +268,10 @@ def test_series_to_numpy_array_with_nulls() -> None:
     expected = np.array([[1.0, 2.0], [3.0, 4.0], [np.nan, np.nan]])
     assert_array_equal(result, expected)
     assert result.dtype == np.float64
-    assert_zero_copy_only_raises(s)
+
+    msg = "cannot handle null values without copying data"
+    with pytest.raises(pl.CopyNotAllowedError, match=msg):
+        s.to_numpy(use_pyarrow=False, zero_copy_only=True)
 
 
 def test_to_numpy_null() -> None:
@@ -258,7 +280,10 @@ def test_to_numpy_null() -> None:
     expected = np.array([np.nan, np.nan], dtype=np.float32)
     assert_array_equal(result, expected)
     assert result.dtype == np.float32
-    assert_zero_copy_only_raises(s)
+
+    msg = "cannot handle null values without copying data"
+    with pytest.raises(pl.CopyNotAllowedError, match=msg):
+        s.to_numpy(use_pyarrow=False, zero_copy_only=True)
 
 
 def test_to_numpy_empty() -> None:
@@ -278,7 +303,10 @@ def test_to_numpy_chunked() -> None:
 
     assert result.tolist() == s.to_list()
     assert result.dtype == np.int64
-    assert_zero_copy_only_raises(s)
+
+    msg = "Series must be rechunked"
+    with pytest.raises(pl.CopyNotAllowedError, match=msg):
+        s.to_numpy(use_pyarrow=False, zero_copy_only=True)
 
 
 def test_series_to_numpy_temporal() -> None:


### PR DESCRIPTION
This error already existed in the interchange protocol. I am making it a proper Polars error so we can re-use it in our various interop methods.

I updated `Series.to_numpy` using this error & improved the error messages.