### PR TITLE
depr(python): Rename parameter `writable` to `writeable` in `Series.to_numpy`

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4280,11 +4280,12 @@ class Series:
 
         return out
 
+    @deprecate_renamed_parameter("writable", "writeable", version="0.20.8")
     def to_numpy(
         self,
         *,
         zero_copy_only: bool = False,
-        writable: bool = False,
+        writeable: bool = False,
         use_pyarrow: bool = True,
     ) -> np.ndarray[Any, Any]:
         """
@@ -4304,11 +4305,11 @@ class Series:
             Raise an exception if the conversion to a NumPy would require copying
             the underlying data. Data copy occurs, for example, when the Series contains
             nulls or non-numeric types.
-        writable
+        writeable
             For NumPy arrays created with zero copy (view on the Arrow data),
-            the resulting array is not writable (Arrow data is immutable).
+            the resulting array is not writeable (Arrow data is immutable).
             By setting this to True, a copy of the array is made to ensure
-            it is writable.
+            it is writeable.
         use_pyarrow
             Use `pyarrow.Array.to_numpy
             <https://arrow.apache.org/docs/python/generated/pyarrow.Array.html#pyarrow.Array.to_numpy>`_
@@ -4349,7 +4350,7 @@ class Series:
         if dtype == Array:
             np_array = self.explode().to_numpy(
                 zero_copy_only=zero_copy_only,
-                writable=writable,
+                writeable=writeable,
                 use_pyarrow=use_pyarrow,
             )
             np_array.shape = (self.len(), self.dtype.width)  # type: ignore[attr-defined]
@@ -4361,7 +4362,7 @@ class Series:
             and dtype not in (Object, Datetime, Duration, Date)
         ):
             return self.to_arrow().to_numpy(
-                zero_copy_only=zero_copy_only, writable=writable
+                zero_copy_only=zero_copy_only, writable=writeable
             )
 
         if self.null_count() == 0:
@@ -4388,7 +4389,7 @@ class Series:
                 np_dtype = temporal_dtype_to_numpy(dtype)
                 np_array = np_array.view(np_dtype)
 
-        if writable and not np_array.flags.writeable:
+        if writeable and not np_array.flags.writeable:
             raise_no_zero_copy()
             np_array = np_array.copy()
 

--- a/py-polars/src/series/numpy_ufunc.rs
+++ b/py-polars/src/series/numpy_ufunc.rs
@@ -16,7 +16,7 @@ use crate::series::PySeries;
 /// # Safety
 /// All elements in the array are non initialized
 ///
-/// The array is also writable from Python.
+/// The array is also writeable from Python.
 unsafe fn aligned_array<T: Element + NativeType>(
     py: Python<'_>,
     size: usize,

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -335,25 +335,25 @@ def test_series_to_numpy(s: pl.Series) -> None:
     assert_array_equal(result, expected)
 
 
-@pytest.mark.parametrize("writable", [False, True])
+@pytest.mark.parametrize("writeable", [False, True])
 @pytest.mark.parametrize("pyarrow_available", [False, True])
 def test_to_numpy2(
-    writable: bool, pyarrow_available: bool, monkeypatch: pytest.MonkeyPatch
+    writeable: bool, pyarrow_available: bool, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(pl.series.series, "_PYARROW_AVAILABLE", pyarrow_available)
 
-    np_array = pl.Series("a", [1, 2, 3], pl.UInt8).to_numpy(writable=writable)
+    np_array = pl.Series("a", [1, 2, 3], pl.UInt8).to_numpy(writeable=writeable)
 
     np.testing.assert_array_equal(np_array, np.array([1, 2, 3], dtype=np.uint8))
-    # Test if numpy array is readonly or writable.
-    assert np_array.flags.writeable == writable
+    # Test if numpy array is readonly or writeable.
+    assert np_array.flags.writeable == writeable
 
-    if writable:
+    if writeable:
         np_array[1] += 10
         np.testing.assert_array_equal(np_array, np.array([1, 12, 3], dtype=np.uint8))
 
     np_array_with_missing_values = pl.Series("a", [None, 2, 3], pl.UInt8).to_numpy(
-        writable=writable
+        writeable=writeable
     )
 
     np.testing.assert_array_equal(
@@ -364,10 +364,10 @@ def test_to_numpy2(
         ),
     )
 
-    if writable:
+    if writeable:
         # As Null values can't be encoded natively in a numpy array,
         # this array will never be a view.
-        assert np_array_with_missing_values.flags.writeable == writable
+        assert np_array_with_missing_values.flags.writeable == writeable
 
 
 def test_view() -> None:


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/14334

Both spellings are correct. However, NumPy uses the spelling `writeable`:
https://numpy.org/doc/stable/reference/generated/numpy.ndarray.flags.html

Since this is a numpy interop function, and it specifically relates to their `writeable` flag, let's follow their spelling to abide by the law of least surprise.

PyArrow's `to_numpy` uses `writable` though, which I guess we copied...

I guess the question is whether we are planning to use `writable` in more places in our API that do not relate to NumPy, and if so, whether we prefer `writable` over `writeable`.