### PR TITLE
refactor(python): Return correct temporal type from Rust in `to_numpy`

### DIFF
--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -130,6 +130,7 @@ def test_series_to_numpy_date() -> None:
 
     assert s.to_list() == result.tolist()
     assert result.dtype == np.dtype("datetime64[D]")
+    assert result.flags.writeable is True
     assert_allow_copy_false_raises(s)
 
 


### PR DESCRIPTION
Ref #14334

... as opposed to returning an integer array and then creating a view afterwards.