### PR TITLE
fix(python): Require exact checking for Decimals in assertion utils

### DIFF
--- a/py-polars/polars/testing/asserts/series.py
+++ b/py-polars/polars/testing/asserts/series.py
@@ -6,8 +6,6 @@ from polars.datatypes import (
     FLOAT_DTYPES,
     Array,
     Categorical,
-    Decimal,
-    Float64,
     List,
     String,
     Struct,
@@ -128,14 +126,6 @@ def _assert_series_values_equal(
             left = left.cast(String)
         if right.dtype == Categorical:
             right = right.cast(String)
-
-    # Handle decimals
-    # TODO: Delete this branch when Decimal equality is implemented
-    # https://github.com/pola-rs/polars/issues/12118
-    if left.dtype == Decimal:
-        left = left.cast(Float64)
-    if right.dtype == Decimal:
-        right = right.cast(Float64)
 
     # Determine unequal elements
     try:

--- a/py-polars/tests/unit/testing/test_assert_series_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_series_equal.py
@@ -620,9 +620,13 @@ def test_series_equal_nested_lengths_mismatch() -> None:
 
 
 @pytest.mark.parametrize("check_exact", [True, False])
-def test_series_equal_decimals_exact(check_exact: bool) -> None:
+def test_series_equal_decimals(check_exact: bool) -> None:
     s1 = pl.Series([D("1.00000"), D("2.00000")], dtype=pl.Decimal)
     s2 = pl.Series([D("1.00000"), D("2.00001")], dtype=pl.Decimal)
+
+    assert_series_equal(s1, s1, check_exact=check_exact)
+    assert_series_equal(s2, s2, check_exact=check_exact)
+
     with pytest.raises(AssertionError, match="exact value mismatch"):
         assert_series_equal(s1, s2, check_exact=check_exact)
 

--- a/py-polars/tests/unit/testing/test_assert_series_equal.py
+++ b/py-polars/tests/unit/testing/test_assert_series_equal.py
@@ -619,24 +619,12 @@ def test_series_equal_nested_lengths_mismatch() -> None:
         assert_series_equal(s1, s2)
 
 
-def test_series_equal_decimals_exact() -> None:
+@pytest.mark.parametrize("check_exact", [True, False])
+def test_series_equal_decimals_exact(check_exact: bool) -> None:
     s1 = pl.Series([D("1.00000"), D("2.00000")], dtype=pl.Decimal)
     s2 = pl.Series([D("1.00000"), D("2.00001")], dtype=pl.Decimal)
     with pytest.raises(AssertionError, match="exact value mismatch"):
-        assert_series_equal(s1, s2, check_exact=True)
-
-
-def test_series_equal_decimals_inexact() -> None:
-    s1 = pl.Series([D("1.00000"), D("2.00000")], dtype=pl.Decimal)
-    s2 = pl.Series([D("1.00000"), D("2.00001")], dtype=pl.Decimal)
-    assert_series_equal(s1, s2, check_exact=False)
-
-
-def test_series_equal_decimals_inexact_fail() -> None:
-    s1 = pl.Series([D("1.00000"), D("2.00000")], dtype=pl.Decimal)
-    s2 = pl.Series([D("1.00000"), D("2.00001")], dtype=pl.Decimal)
-    with pytest.raises(AssertionError, match="value mismatch"):
-        assert_series_equal(s1, s2, check_exact=False, rtol=0)
+        assert_series_equal(s1, s2, check_exact=check_exact)
 
 
 def test_assert_series_equal_w_large_integers_12328() -> None:


### PR DESCRIPTION
Now that we have https://github.com/pola-rs/polars/pull/14338, we no longer need to cast Decimals to floats. This also means that inexact checking no longer applies to Decimals, as was intended (see the docstring). So this classifies as a fix.