### PR TITLE
fix: Return appropriate data type for duration `mean` and `median`

### DIFF
--- a/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/dispatch.rs
@@ -114,14 +114,14 @@ impl Series {
             Float64 => SeriesWrap(self.f64().unwrap().clone()).agg_median(groups),
             dt if dt.is_numeric() => apply_method_physical_integer!(self, agg_median, groups),
             #[cfg(feature = "dtype-datetime")]
-            dt @ Datetime(_, _) => self
+            dt @ (Datetime(_, _) | Duration(_)) => self
                 .to_physical_repr()
                 .agg_median(groups)
                 .cast(&Int64)
                 .unwrap()
                 .cast(dt)
                 .unwrap(),
-            dt @ (Date | Duration(_) | Time) => {
+            dt @ (Date | Time) => {
                 let ca = self.to_physical_repr();
                 let physical_type = ca.dtype();
                 let s = apply_method_physical_integer!(ca, agg_median, groups);
@@ -172,14 +172,14 @@ impl Series {
             Float64 => SeriesWrap(self.f64().unwrap().clone()).agg_mean(groups),
             dt if dt.is_numeric() => apply_method_physical_integer!(self, agg_mean, groups),
             #[cfg(feature = "dtype-datetime")]
-            dt @ Datetime(_, _) => self
+            dt @ (Datetime(_, _) | Duration(_)) => self
                 .to_physical_repr()
                 .agg_mean(groups)
                 .cast(&Int64)
                 .unwrap()
                 .cast(dt)
                 .unwrap(),
-            dt @ (Date | Duration(_) | Time) => {
+            dt @ (Date | Time) => {
                 let ca = self.to_physical_repr();
                 let physical_type = ca.dtype();
                 let s = apply_method_physical_integer!(ca, agg_mean, groups);

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -422,13 +422,7 @@ impl SeriesTrait for SeriesWrap<DurationChunked> {
             .into_duration(TimeUnit::Milliseconds))
     }
     fn median_as_series(&self) -> PolarsResult<Series> {
-        Ok(self
-            .0
-            .median_as_series()
-            .cast(&self.dtype().to_physical())
-            .unwrap()
-            .cast(self.dtype())
-            .unwrap())
+        Series::new(self.name(), &[self.median().map(|v| v as i64)]).cast(self.dtype())
     }
     fn quantile_as_series(
         &self,

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1419,7 +1419,13 @@ impl LazyFrame {
     /// - String columns will sum to None.
     pub fn median(self) -> PolarsResult<LazyFrame> {
         self.stats_helper(
-            |dt| dt.is_numeric() || matches!(dt, DataType::Boolean | DataType::Datetime(_, _)),
+            |dt| {
+                dt.is_numeric()
+                    || matches!(
+                        dt,
+                        DataType::Boolean | DataType::Duration(_) | DataType::Datetime(_, _)
+                    )
+            },
             |name| col(name).median(),
         )
     }

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from polars.datatypes import Date, Datetime
+from polars.datatypes import Date, Datetime, Duration
 from polars.series.utils import expr_dispatch
 from polars.utils._wrap import wrap_s
 from polars.utils.convert import _to_python_date, _to_python_datetime
@@ -82,7 +82,7 @@ class DateTimeNameSpace:
         if out is not None:
             if s.dtype == Date:
                 return _to_python_date(int(out))  # type: ignore[arg-type]
-            elif s.dtype == Datetime:
+            elif s.dtype in (Datetime, Duration):
                 return out  # type: ignore[return-value]
             else:
                 return _to_python_datetime(int(out), s.dtype.time_unit)  # type: ignore[arg-type, attr-defined]
@@ -106,7 +106,7 @@ class DateTimeNameSpace:
         if out is not None:
             if s.dtype == Date:
                 return _to_python_date(int(out))  # type: ignore[arg-type]
-            elif s.dtype == Datetime:
+            elif s.dtype in (Datetime, Duration):
                 return out  # type: ignore[return-value]
             else:
                 return _to_python_datetime(int(out), s.dtype.time_unit)  # type: ignore[arg-type, attr-defined]

--- a/py-polars/src/series/aggregation.rs
+++ b/py-polars/src/series/aggregation.rs
@@ -54,7 +54,7 @@ impl PySeries {
                     .map_err(PyPolarsErr::from)?,
             )
             .into_py(py)),
-            DataType::Datetime(_, _) => Ok(Wrap(
+            DataType::Datetime(_, _) | DataType::Duration(_) => Ok(Wrap(
                 self.series
                     .mean_as_series()
                     .get(0)
@@ -77,7 +77,7 @@ impl PySeries {
                     .map_err(PyPolarsErr::from)?,
             )
             .into_py(py)),
-            DataType::Datetime(_, _) => Ok(Wrap(
+            DataType::Datetime(_, _) | DataType::Duration(_) => Ok(Wrap(
                 self.series
                     .median_as_series()
                     .map_err(PyPolarsErr::from)?


### PR DESCRIPTION
Resolves #14375. Part of overall #13599.

This also moves one step closer to deprecating `Series.dt.mean` and `Series.dt.median`, as the base Series' `mean` and `median` now support duration dtypes.

Using the example from the issue, all cases now properly output a duration:

```
6 days, 0:00:00
2 days, 0:00:00
6 days, 0:00:00
2 days, 0:00:00
shape: (1, 2)
┌──────────────┬──────────────┐
│ mean         ┆ median       │
│ ---          ┆ ---          │
│ duration[μs] ┆ duration[μs] │
╞══════════════╪══════════════╡
│ 6d           ┆ 2d           │
└──────────────┴──────────────┘
shape: (1, 3)
┌─────┬──────────────┬──────────────┐
│ key ┆ mean         ┆ median       │
│ --- ┆ ---          ┆ ---          │
│ i64 ┆ duration[μs] ┆ duration[μs] │
╞═════╪══════════════╪══════════════╡
│ 1   ┆ 6d           ┆ 2d           │
└─────┴──────────────┴──────────────┘
```

