### PR TITLE
feat(rust): Improve panic message for missing struct feature in `DataType::from_arrow`

### DIFF
--- a/crates/polars-core/src/datatypes/field.rs
+++ b/crates/polars-core/src/datatypes/field.rs
@@ -147,6 +147,10 @@ impl DataType {
             ArrowDataType::Struct(fields) => {
                 DataType::Struct(fields.iter().map(|fld| fld.into()).collect())
             }
+            #[cfg(not(feature = "dtype-struct"))]
+            ArrowDataType::Struct(_) => {
+                panic!("activate the 'dtype-struct' feature to handle struct data types")
+            }
             ArrowDataType::Extension(name, _, _) if name == "POLARS_EXTENSION_TYPE" => {
                 #[cfg(feature = "object")]
                 {


### PR DESCRIPTION
Supersedes #8767

Credit to @jay-johnson for signalling this issue.