### PR TITLE
refactor(python): Internal rename of `_or` to `or_` in PyO3 (same for `_xor/_and`)

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -166,11 +166,11 @@ class Expr:
 
     def __and__(self, other: IntoExprColumn | int | bool) -> Self:
         other = parse_as_expression(other)
-        return self._from_pyexpr(self._pyexpr._and(other))
+        return self._from_pyexpr(self._pyexpr.and_(other))
 
     def __rand__(self, other: IntoExprColumn | int | bool) -> Self:
         other_expr = parse_as_expression(other)
-        return self._from_pyexpr(other_expr._and(self._pyexpr))
+        return self._from_pyexpr(other_expr.and_(self._pyexpr))
 
     def __eq__(self, other: IntoExpr) -> Self:  # type: ignore[override]
         warn_null_comparison(other)
@@ -234,11 +234,11 @@ class Expr:
 
     def __or__(self, other: IntoExprColumn | int | bool) -> Self:
         other = parse_as_expression(other)
-        return self._from_pyexpr(self._pyexpr._or(other))
+        return self._from_pyexpr(self._pyexpr.or_(other))
 
     def __ror__(self, other: IntoExprColumn | int | bool) -> Self:
         other_expr = parse_as_expression(other)
-        return self._from_pyexpr(other_expr._or(self._pyexpr))
+        return self._from_pyexpr(other_expr.or_(self._pyexpr))
 
     def __pos__(self) -> Expr:
         return self
@@ -269,11 +269,11 @@ class Expr:
 
     def __xor__(self, other: IntoExprColumn | int | bool) -> Self:
         other = parse_as_expression(other)
-        return self._from_pyexpr(self._pyexpr._xor(other))
+        return self._from_pyexpr(self._pyexpr.xor_(other))
 
     def __rxor__(self, other: IntoExprColumn | int | bool) -> Self:
         other_expr = parse_as_expression(other)
-        return self._from_pyexpr(other_expr._xor(self._pyexpr))
+        return self._from_pyexpr(other_expr.xor_(self._pyexpr))
 
     def __getstate__(self) -> bytes:
         return self._pyexpr.__getstate__()

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -595,17 +595,18 @@ impl PyExpr {
         self.inner.clone().rolling(options).into()
     }
 
-    fn _and(&self, expr: Self) -> Self {
+    fn and_(&self, expr: Self) -> Self {
         self.inner.clone().and(expr.inner).into()
     }
 
-    fn _xor(&self, expr: Self) -> Self {
+    fn or_(&self, expr: Self) -> Self {
+        self.inner.clone().or(expr.inner).into()
+    }
+
+    fn xor_(&self, expr: Self) -> Self {
         self.inner.clone().xor(expr.inner).into()
     }
 
-    fn _or(&self, expr: Self) -> Self {
-        self.inner.clone().or(expr.inner).into()
-    }
     #[cfg(feature = "is_in")]
     fn is_in(&self, expr: Self) -> Self {
         self.inner.clone().is_in(expr.inner).into()


### PR DESCRIPTION
Clashes with built-ins should be resolved by appending an underscore, not prepending one (signalling a private method).