### PR TITLE
feat(python): add `strategy='loky'` option to map_elements

### DIFF
--- a/py-polars/polars/dependencies.py
+++ b/py-polars/polars/dependencies.py
@@ -13,6 +13,7 @@ _FSSPEC_AVAILABLE = True
 _GEVENT_AVAILABLE = True
 _HVPLOT_AVAILABLE = True
 _HYPOTHESIS_AVAILABLE = True
+_JOBLIB_AVAILABLE = True
 _NUMPY_AVAILABLE = True
 _PANDAS_AVAILABLE = True
 _PYARROW_AVAILABLE = True
@@ -154,6 +155,7 @@ if TYPE_CHECKING:
     import gevent
     import hvplot
     import hypothesis
+    import joblib
     import numpy
     import pandas
     import pyarrow
@@ -177,6 +179,7 @@ else:
     fsspec, _FSSPEC_AVAILABLE = _lazy_import("fsspec")
     hvplot, _HVPLOT_AVAILABLE = _lazy_import("hvplot")
     hypothesis, _HYPOTHESIS_AVAILABLE = _lazy_import("hypothesis")
+    joblib, _JOBLIB_AVAILABLE = _lazy_import("joblib")
     numpy, _NUMPY_AVAILABLE = _lazy_import("numpy")
     pandas, _PANDAS_AVAILABLE = _lazy_import("pandas")
     pyarrow, _PYARROW_AVAILABLE = _lazy_import("pyarrow")
@@ -280,6 +283,7 @@ __all__ = [
     "fsspec",
     "gevent",
     "hvplot",
+    "joblib",
     "numpy",
     "pandas",
     "pydantic",
@@ -299,6 +303,7 @@ __all__ = [
     "_GEVENT_AVAILABLE",
     "_HVPLOT_AVAILABLE",
     "_HYPOTHESIS_AVAILABLE",
+    "_JOBLIB_AVAILABLE",
     "_NUMPY_AVAILABLE",
     "_PANDAS_AVAILABLE",
     "_PYARROW_AVAILABLE",

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -130,7 +130,7 @@ StartBy: TypeAlias = Literal[
 TimeUnit: TypeAlias = Literal["ns", "us", "ms"]
 UniqueKeepStrategy: TypeAlias = Literal["first", "last", "any", "none"]
 UnstackDirection: TypeAlias = Literal["vertical", "horizontal"]
-MapElementsStrategy: TypeAlias = Literal["thread_local", "threading"]
+MapElementsStrategy: TypeAlias = Literal["thread_local", "threading", "loky"]
 
 # The following have a Rust enum equivalent with a different name
 AsofJoinStrategy: TypeAlias = Literal["backward", "forward", "nearest"]  # AsofStrategy

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -45,6 +45,7 @@ connectorx = ["connectorx >= 0.3.2"]
 deltalake = ["deltalake >= 0.14.0"]
 fsspec = ["fsspec"]
 gevent = ["gevent"]
+joblib = ["joblib"]
 plot = ["hvplot >= 0.9.1"]
 matplotlib = ["matplotlib"]
 numpy = ["numpy >= 1.16.0"]
@@ -59,7 +60,7 @@ timezone = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_syst
 xlsx2csv = ["xlsx2csv >= 0.8.0"]
 xlsxwriter = ["xlsxwriter"]
 all = [
-  "polars[pyarrow,pandas,numpy,fsspec,plot,connectorx,xlsx2csv,deltalake,timezone,pydantic,pyiceberg,sqlalchemy,xlsxwriter,adbc,cloudpickle,gevent]",
+  "polars[pyarrow,pandas,numpy,fsspec,plot,connectorx,xlsx2csv,deltalake,timezone,pydantic,pyiceberg,sqlalchemy,xlsxwriter,adbc,cloudpickle,gevent,joblib]",
 ]
 
 [tool.maturin]
@@ -89,6 +90,7 @@ module = [
   "ezodf.*",
   "fsspec.*",
   "gevent",
+  "joblib",
   "hvplot.*",
   "matplotlib.*",
   "moto.server",

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -51,6 +51,7 @@ hvplot>=0.9.1
 matplotlib
 # Other
 gevent
+joblib
 
 # -------
 # TOOLING

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -295,6 +295,17 @@ def test_map_elements_on_empty_col_10639() -> None:
     }
 
 
+def test_map_elements_loky() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+    with pytest.warns(
+        PolarsInefficientMapWarning,
+        match=r"CANNOT",
+    ):
+        result = df.select(pl.col("a").map_elements(lambda x: 2 * x, strategy="loky"))
+    expected = pl.DataFrame({"a": [2, 4]})
+    assert_frame_equal(result, expected)
+
+
 def test_apply_deprecated() -> None:
     with pytest.deprecated_call():
         pl.col("a").apply(np.abs)

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -295,11 +295,18 @@ def test_map_elements_on_empty_col_10639() -> None:
     }
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*("
+    "This process .* is multi-threaded|"
+    "ast.Num is deprecated|"
+    "Attribute n is deprecated"
+    ").*:DeprecationWarning"
+)
 def test_map_elements_loky() -> None:
     df = pl.DataFrame({"a": [1, 2]})
     with pytest.warns(
         PolarsInefficientMapWarning,
-        match=r"CANNOT",
+        match="CANNOT",
     ):
         result = df.select(pl.col("a").map_elements(lambda x: 2 * x, strategy="loky"))
     expected = pl.DataFrame({"a": [2, 4]})


### PR DESCRIPTION
closes #14336

this is >4x as fast on a task I have, where there's just no option but to use a UDF unfortunately (I need to call `postal.expand.expand_address` for each row - not even using the `postal` rust crate and a plugin helps here as the operation is just so expensive)

After looking into this, I think it's better to use `joblib`'s `'loky'` backend, rather than Python's stdlib multiprocessing, because the latter doesn't work with local functions. I.e. users wouldn't be able to do
```
pl.col('a').map_elements(lambda x: x*2, strategy='multiprocessing')
```
they would have to define a global (not even just a local one, it needs to be global) function and pass that to `map_elements`.

Furthermore, `joblib` is already a required dep of  `scikit-learn`, so many people in this space likely have it installed. Its wheel is only about 300kb, so it's quite lightweight