### PR TITLE
docs: Use justified text alignment in user guide

### DIFF
--- a/docs/_build/css/extra.css
+++ b/docs/_build/css/extra.css
@@ -5,6 +5,9 @@
     --md-text-font: 'Proxima Nova', sans-serif;
 }
 
+p {
+  text-align: justify;
+}
 
 span .md-typeset .emojione, .md-typeset .gemoji, .md-typeset .twemoji {
     vertical-align: text-bottom;


### PR DESCRIPTION
I am not 100% sure about this, but I _think_ it reads a bit nicer. Thoughts @r-brink @c-peters ?

**Before**

![image](https://github.com/pola-rs/polars/assets/3502351/1e4d69db-ab4e-4e92-a650-759f9847c63a)

**After**

![image](https://github.com/pola-rs/polars/assets/3502351/7c0af1b6-f67e-48fb-a38a-6d6d2a419d37)
