### PR TITLE
fix(python,rust): rechunk series when apply_lambda

### DIFF
--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -389,7 +389,8 @@ impl PySeries {
             ) || !skip_nulls
             {
                 let mut avs = Vec::with_capacity(self.series.len());
-                let iter = self.series.iter().map(|av| match (skip_nulls, av) {
+                let s = self.series.rechunk();
+                let iter = s.iter().map(|av| match (skip_nulls, av) {
                     (true, AnyValue::Null) => AnyValue::Null,
                     (_, av) => {
                         let input = Wrap(av);

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1575,6 +1575,26 @@ def test_read_csv_chunked() -> None:
     assert df.filter(pl.col("count") < pl.col("count").shift(1)).is_empty()
 
 
+@pytest.mark.write_disk()
+def test_map_elements_csv_chunked_14390(tmp_path: Path) -> None:
+    tmp_path.mkdir(exist_ok=True)
+
+    dates = [f"2023-12-{'0'*(i < 10)}{i}" for i in range(1, 31)] * 69
+    df = pl.DataFrame({"date": dates})
+    df.write_csv(tmp_path / "panic_date_strings.csv")
+
+    fdf = pl.read_csv(tmp_path / "panic_date_strings.csv", rechunk=False)
+    assert fdf["date"].n_chunks() > 1
+
+    fdf = fdf.with_columns(
+        pl.col("date").str.strptime(pl.Date, format="%Y-%m-%d").alias("calendar_date")
+    )
+    fdf = fdf.with_columns(
+        pl.col("calendar_date").map_elements(lambda x: x.weekday()).alias("weekday")
+    )
+    assert len(fdf["weekday"].unique()) == 7
+
+
 def test_read_empty_csv(io_files_path: Path) -> None:
     with pytest.raises(NoDataError) as err:
         pl.read_csv(io_files_path / "empty.csv")

--- a/py-polars/tests/unit/operations/map/test_map_elements.py
+++ b/py-polars/tests/unit/operations/map/test_map_elements.py
@@ -8,7 +8,7 @@ import pytest
 
 import polars as pl
 from polars.exceptions import PolarsInefficientMapWarning
-from polars.testing import assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_map_elements_infer_list() -> None:
@@ -293,6 +293,12 @@ def test_map_elements_on_empty_col_10639() -> None:
         "B": [],
         "Foo": [],
     }
+
+
+def test_map_elements_chunked_14390() -> None:
+    s = pl.concat(2 * [pl.Series([1])], rechunk=False)
+    assert s.n_chunks() > 1
+    assert_series_equal(s.map_elements(str), pl.Series(["1", "1"]), check_names=False)
 
 
 def test_apply_deprecated() -> None:


### PR DESCRIPTION
Fixes: https://github.com/pola-rs/polars/issues/14390

The regression was introduced by https://github.com/pola-rs/polars/pull/13518 on `0.20.4` by not rechunking scanned/read files by default.

Iterating through a chunked series panics here:

https://github.com/pola-rs/polars/blob/b2207b895a8ef8f066ff1126e240ad3b91dc60d4/crates/polars-core/src/series/iterator.rs#L66-L74

I call `rechunk()` on the series before iterating through them. 
