### PR TITLE
perf: simplify and speed up cum_sum and cum_prod

### DIFF
--- a/crates/polars-ops/src/series/ops/cum_agg.rs
+++ b/crates/polars-ops/src/series/ops/cum_agg.rs
@@ -1,7 +1,7 @@
 use std::iter::FromIterator;
 use std::ops::{Add, AddAssign, Mul};
 
-use num_traits::Bounded;
+use num_traits::{Bounded, One, Zero};
 use polars_core::prelude::*;
 use polars_core::utils::{CustomIterTools, NoNull};
 use polars_core::with_match_physical_numeric_polars_type;
@@ -36,37 +36,29 @@ where
     }
 }
 
-fn det_sum<T>(state: &mut Option<T>, v: Option<T>) -> Option<Option<T>>
+fn det_sum<T>(state: &mut T, v: Option<T>) -> Option<Option<T>>
 where
     T: Copy + PartialOrd + AddAssign + Add<Output = T>,
 {
-    match (*state, v) {
-        (Some(state_inner), Some(v)) => {
-            *state = Some(state_inner + v);
-            Some(*state)
+    match v {
+        Some(v) => {
+            *state += v;
+            Some(Some(*state))
         },
-        (None, Some(v)) => {
-            *state = Some(v);
-            Some(*state)
-        },
-        (_, None) => Some(None),
+        None => Some(None),
     }
 }
 
-fn det_prod<T>(state: &mut Option<T>, v: Option<T>) -> Option<Option<T>>
+fn det_prod<T>(state: &mut T, v: Option<T>) -> Option<Option<T>>
 where
     T: Copy + PartialOrd + Mul<Output = T>,
 {
-    match (*state, v) {
-        (Some(state_inner), Some(v)) => {
-            *state = Some(state_inner * v);
-            Some(*state)
+    match v {
+        Some(v) => {
+            *state = *state * v;
+            Some(Some(*state))
         },
-        (None, Some(v)) => {
-            *state = Some(v);
-            Some(*state)
-        },
-        (_, None) => Some(None),
+        None => Some(None),
     }
 }
 
@@ -102,7 +94,7 @@ where
     T: PolarsNumericType,
     ChunkedArray<T>: FromIterator<Option<T::Native>>,
 {
-    let init = None;
+    let init = T::Native::zero();
     let out: ChunkedArray<T> = match reverse {
         false => ca.iter().scan(init, det_sum).collect_trusted(),
         true => ca.iter().rev().scan(init, det_sum).collect_reversed(),
@@ -115,7 +107,7 @@ where
     T: PolarsNumericType,
     ChunkedArray<T>: FromIterator<Option<T::Native>>,
 {
-    let init = None;
+    let init = T::Native::one();
     let out: ChunkedArray<T> = match reverse {
         false => ca.iter().scan(init, det_prod).collect_trusted(),
         true => ca.iter().rev().scan(init, det_prod).collect_reversed(),

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -48,6 +48,15 @@ def test_cum_agg() -> None:
     assert_series_equal(s.cum_prod(), pl.Series("a", [1, 2, 6, 12]))
 
 
+def test_cum_agg_with_nulls() -> None:
+    # confirm that known series give expected results
+    s = pl.Series("a", [None, 2, None, 7, 8, None])
+    assert_series_equal(s.cum_sum(), pl.Series("a", [None, 2, None, 9, 17, None]))
+    assert_series_equal(s.cum_min(), pl.Series("a", [None, 2, None, 2, 2, None]))
+    assert_series_equal(s.cum_max(), pl.Series("a", [None, 2, None, 7, 8, None]))
+    assert_series_equal(s.cum_prod(), pl.Series("a", [None, 2, None, 14, 112, None]))
+
+
 def test_cum_agg_deprecated() -> None:
     # confirm that known series give expected results
     s = pl.Series("a", [1, 2, 3, 2])


### PR DESCRIPTION
this came up whilst teaching - can these be simplified?

passes tests locally at least...gonna sleep on it and think if there's anything I missed