### PR TITLE
feat(python): Allow column name input in `clip`

### DIFF
--- a/crates/polars-ops/src/series/ops/clip.rs
+++ b/crates/polars-ops/src/series/ops/clip.rs
@@ -3,6 +3,101 @@ use polars_core::prelude::arity::{binary_elementwise, ternary_elementwise};
 use polars_core::prelude::*;
 use polars_core::with_match_physical_numeric_polars_type;
 
+/// Set values outside the given boundaries to the boundary value.
+pub fn clip(s: &Series, min: &Series, max: &Series) -> PolarsResult<Series> {
+    polars_ensure!(
+        s.dtype().to_physical().is_numeric(),
+        InvalidOperation: "`clip` only supports physical numeric types"
+    );
+
+    let original_type = s.dtype();
+    // cast min & max to the dtype of s first.
+    let (min, max) = (min.cast(s.dtype())?, max.cast(s.dtype())?);
+
+    let (s, min, max) = (
+        s.to_physical_repr(),
+        min.to_physical_repr(),
+        max.to_physical_repr(),
+    );
+
+    match s.dtype() {
+        dt if dt.is_numeric() => {
+            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
+                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+                let min: &ChunkedArray<$T> = min.as_ref().as_ref().as_ref();
+                let max: &ChunkedArray<$T> = max.as_ref().as_ref().as_ref();
+                let out = clip_helper(ca, min, max).into_series();
+                if original_type.is_logical(){
+                    out.cast(original_type)
+                }else{
+                    Ok(out)
+                }
+            })
+        },
+        dt => polars_bail!(opq = clippy, dt),
+    }
+}
+
+/// Set values above the given maximum to the maximum value.
+pub fn clip_max(s: &Series, max: &Series) -> PolarsResult<Series> {
+    polars_ensure!(
+        s.dtype().to_physical().is_numeric(),
+        InvalidOperation: "`clip` only supports physical numeric types"
+    );
+
+    let original_type = s.dtype();
+    // cast max to the dtype of s first.
+    let max = max.cast(s.dtype())?;
+
+    let (s, max) = (s.to_physical_repr(), max.to_physical_repr());
+
+    match s.dtype() {
+        dt if dt.is_numeric() => {
+            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
+                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+                let max: &ChunkedArray<$T> = max.as_ref().as_ref().as_ref();
+                let out = clip_min_max_helper(ca, max, clamp_max).into_series();
+                if original_type.is_logical(){
+                    out.cast(original_type)
+                }else{
+                    Ok(out)
+                }
+            })
+        },
+        dt => polars_bail!(opq = clippy_max, dt),
+    }
+}
+
+/// Set values below the given minimum to the minimum value.
+pub fn clip_min(s: &Series, min: &Series) -> PolarsResult<Series> {
+    polars_ensure!(
+        s.dtype().to_physical().is_numeric(),
+        InvalidOperation: "`clip` only supports physical numeric types"
+    );
+
+    let original_type = s.dtype();
+    // cast min to the dtype of s first.
+    let min = min.cast(s.dtype())?;
+
+    let (s, min) = (s.to_physical_repr(), min.to_physical_repr());
+
+    match s.dtype() {
+        dt if dt.is_numeric() => {
+            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
+                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+                let min: &ChunkedArray<$T> = min.as_ref().as_ref().as_ref();
+                let out = clip_min_max_helper(ca, min, clamp_min).into_series();
+                if original_type.is_logical(){
+                    out.cast(original_type)
+                }else{
+                    Ok(out)
+                }
+            })
+        },
+        dt => polars_bail!(opq = clippy_min, dt),
+    }
+}
+
 fn clip_helper<T>(
     ca: &ChunkedArray<T>,
     min: &ChunkedArray<T>,
@@ -61,91 +156,5 @@ where
             (Some(s), Some(bound)) => Some(op(s, bound)),
             _ => None,
         }),
-    }
-}
-
-/// Clamp underlying values to the `min` and `max` values.
-pub fn clip(s: &Series, min: &Series, max: &Series) -> PolarsResult<Series> {
-    polars_ensure!(s.dtype().to_physical().is_numeric(), InvalidOperation: "Only physical numeric types are supported.");
-
-    let original_type = s.dtype();
-    // cast min & max to the dtype of s first.
-    let (min, max) = (min.cast(s.dtype())?, max.cast(s.dtype())?);
-
-    let (s, min, max) = (
-        s.to_physical_repr(),
-        min.to_physical_repr(),
-        max.to_physical_repr(),
-    );
-
-    match s.dtype() {
-        dt if dt.is_numeric() => {
-            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                let min: &ChunkedArray<$T> = min.as_ref().as_ref().as_ref();
-                let max: &ChunkedArray<$T> = max.as_ref().as_ref().as_ref();
-                let out = clip_helper(ca, min, max).into_series();
-                if original_type.is_logical(){
-                    out.cast(original_type)
-                }else{
-                    Ok(out)
-                }
-            })
-        },
-        dt => polars_bail!(opq = clippy, dt),
-    }
-}
-
-/// Clamp underlying values to the `max` value.
-pub fn clip_max(s: &Series, max: &Series) -> PolarsResult<Series> {
-    polars_ensure!(s.dtype().to_physical().is_numeric(), InvalidOperation: "Only physical numeric types are supported.");
-
-    let original_type = s.dtype();
-    // cast max to the dtype of s first.
-    let max = max.cast(s.dtype())?;
-
-    let (s, max) = (s.to_physical_repr(), max.to_physical_repr());
-
-    match s.dtype() {
-        dt if dt.is_numeric() => {
-            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                let max: &ChunkedArray<$T> = max.as_ref().as_ref().as_ref();
-                let out = clip_min_max_helper(ca, max, clamp_max).into_series();
-                if original_type.is_logical(){
-                    out.cast(original_type)
-                }else{
-                    Ok(out)
-                }
-            })
-        },
-        dt => polars_bail!(opq = clippy_max, dt),
-    }
-}
-
-/// Clamp underlying values to the `min` value.
-pub fn clip_min(s: &Series, min: &Series) -> PolarsResult<Series> {
-    polars_ensure!(s.dtype().to_physical().is_numeric(), InvalidOperation: "Only physical numeric types are supported.");
-
-    let original_type = s.dtype();
-    // cast min to the dtype of s first.
-    let min = min.cast(s.dtype())?;
-
-    let (s, min) = (s.to_physical_repr(), min.to_physical_repr());
-
-    match s.dtype() {
-        dt if dt.is_numeric() => {
-            with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
-                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
-                let min: &ChunkedArray<$T> = min.as_ref().as_ref().as_ref();
-                let out = clip_min_max_helper(ca, min, clamp_min).into_series();
-                if original_type.is_logical(){
-                    out.cast(original_type)
-                }else{
-                    Ok(out)
-                }
-            })
-        },
-        dt => polars_bail!(opq = clippy_min, dt),
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/clip.rs
+++ b/crates/polars-plan/src/dsl/function_expr/clip.rs
@@ -2,9 +2,9 @@ use super::*;
 
 pub(super) fn clip(s: &[Series], has_min: bool, has_max: bool) -> PolarsResult<Series> {
     match (has_min, has_max) {
-        (true, true) => polars_ops::prelude::clip(&s[0], &s[1], &s[2]),
-        (true, false) => polars_ops::prelude::clip_min(&s[0], &s[1]),
-        (false, true) => polars_ops::prelude::clip_max(&s[0], &s[1]),
+        (true, true) => polars_ops::series::clip(&s[0], &s[1], &s[2]),
+        (true, false) => polars_ops::series::clip_min(&s[0], &s[1]),
+        (false, true) => polars_ops::series::clip_max(&s[0], &s[1]),
         _ => unreachable!(),
     }
 }

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -7966,9 +7966,9 @@ class Expr:
         └──────┴──────┘
         """
         if lower_bound is not None:
-            lower_bound = parse_as_expression(lower_bound, str_as_lit=True)
+            lower_bound = parse_as_expression(lower_bound)
         if upper_bound is not None:
-            upper_bound = parse_as_expression(upper_bound, str_as_lit=True)
+            upper_bound = parse_as_expression(upper_bound)
         return self._from_pyexpr(self._pyexpr.clip(lower_bound, upper_bound))
 
     def lower_bound(self) -> Self:

--- a/py-polars/tests/unit/operations/test_clip.py
+++ b/py-polars/tests/unit/operations/test_clip.py
@@ -5,45 +5,58 @@ from datetime import datetime
 import pytest
 
 import polars as pl
-from polars.testing.asserts.series import assert_series_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
-def test_clip() -> None:
-    clip_exprs = [
+@pytest.fixture()
+def clip_exprs() -> list[pl.Expr]:
+    return [
         pl.col("a").clip(pl.col("min"), pl.col("max")).alias("clip"),
         pl.col("a").clip(lower_bound=pl.col("min")).alias("clip_min"),
         pl.col("a").clip(upper_bound=pl.col("max")).alias("clip_max"),
     ]
 
-    df = pl.DataFrame(
+
+def test_clip_int(clip_exprs: list[pl.Expr]) -> None:
+    lf = pl.LazyFrame(
         {
             "a": [1, 2, 3, 4, 5],
             "min": [0, -1, 4, None, 4],
             "max": [2, 1, 8, 5, None],
         }
     )
+    result = lf.select(clip_exprs)
+    expected = pl.LazyFrame(
+        {
+            "clip": [1, 1, 4, None, None],
+            "clip_min": [1, 2, 4, None, 5],
+            "clip_max": [1, 1, 3, 4, None],
+        }
+    )
+    assert_frame_equal(result, expected)
 
-    assert df.select(clip_exprs).to_dict(as_series=False) == {
-        "clip": [1, 1, 4, None, None],
-        "clip_min": [1, 2, 4, None, 5],
-        "clip_max": [1, 1, 3, 4, None],
-    }
 
-    df = pl.DataFrame(
+def test_clip_float(clip_exprs: list[pl.Expr]) -> None:
+    lf = pl.LazyFrame(
         {
             "a": [1.0, 2.0, 3.0, 4.0, 5.0],
             "min": [0, -1.0, 4.0, None, 4.0],
             "max": [2.0, 1.0, 8.0, 5.0, None],
         }
     )
+    result = lf.select(clip_exprs)
+    expected = pl.LazyFrame(
+        {
+            "clip": [1.0, 1.0, 4.0, None, None],
+            "clip_min": [1.0, 2.0, 4.0, None, 5.0],
+            "clip_max": [1.0, 1.0, 3.0, 4.0, None],
+        }
+    )
+    assert_frame_equal(result, expected)
 
-    assert df.select(clip_exprs).to_dict(as_series=False) == {
-        "clip": [1.0, 1.0, 4.0, None, None],
-        "clip_min": [1.0, 2.0, 4.0, None, 5.0],
-        "clip_max": [1.0, 1.0, 3.0, 4.0, None],
-    }
 
-    df = pl.DataFrame(
+def test_clip_datetime(clip_exprs: list[pl.Expr]) -> None:
+    lf = pl.LazyFrame(
         {
             "a": [
                 datetime(1995, 6, 5, 10, 30),
@@ -71,33 +84,36 @@ def test_clip() -> None:
             ],
         }
     )
-
-    assert df.select(clip_exprs).to_dict(as_series=False) == {
-        "clip": [
-            datetime(1995, 6, 5, 10, 30),
-            datetime(1996, 6, 5),
-            datetime(2023, 9, 20, 18, 30, 6),
-            None,
-            None,
-            None,
-        ],
-        "clip_min": [
-            datetime(1995, 6, 5, 10, 30),
-            datetime(1996, 6, 5),
-            datetime(2023, 10, 20, 18, 30, 6),
-            None,
-            None,
-            datetime(2000, 1, 10),
-        ],
-        "clip_max": [
-            datetime(1995, 6, 5, 10, 30),
-            datetime(1995, 6, 5),
-            datetime(2023, 9, 20, 18, 30, 6),
-            None,
-            datetime(1993, 3, 13),
-            None,
-        ],
-    }
+    result = lf.select(clip_exprs)
+    expected = pl.LazyFrame(
+        {
+            "clip": [
+                datetime(1995, 6, 5, 10, 30),
+                datetime(1996, 6, 5),
+                datetime(2023, 9, 20, 18, 30, 6),
+                None,
+                None,
+                None,
+            ],
+            "clip_min": [
+                datetime(1995, 6, 5, 10, 30),
+                datetime(1996, 6, 5),
+                datetime(2023, 10, 20, 18, 30, 6),
+                None,
+                None,
+                datetime(2000, 1, 10),
+            ],
+            "clip_max": [
+                datetime(1995, 6, 5, 10, 30),
+                datetime(1995, 6, 5),
+                datetime(2023, 9, 20, 18, 30, 6),
+                None,
+                datetime(1993, 3, 13),
+                None,
+            ],
+        }
+    )
+    assert_frame_equal(result, expected)
 
 
 def test_clip_min_max_deprecated() -> None:

--- a/py-polars/tests/unit/operations/test_clip.py
+++ b/py-polars/tests/unit/operations/test_clip.py
@@ -116,6 +116,21 @@ def test_clip_datetime(clip_exprs: list[pl.Expr]) -> None:
     assert_frame_equal(result, expected)
 
 
+def test_clip_non_numeric_dtype_fails() -> None:
+    msg = "`clip` only supports physical numeric types"
+
+    s = pl.Series(["a", "b", "c"])
+    with pytest.raises(pl.InvalidOperationError, match=msg):
+        s.clip(pl.lit("b"), pl.lit("z"))
+
+
+def test_clip_string_input() -> None:
+    df = pl.DataFrame({"a": [0, 1, 2], "min": [1, None, 1]})
+    result = df.select(pl.col("a").clip("min"))
+    expected = pl.DataFrame({"a": [1, None, 2]})
+    assert_frame_equal(result, expected)
+
+
 def test_clip_min_max_deprecated() -> None:
     s = pl.Series([-1, 0, 1])
 


### PR DESCRIPTION
Taking out the useful work from #13713

`clip` doesn't support strings so we can interpret strings as column names.

Also refactoring some tests.