### PR TITLE
feat!: Do not propagate nulls in `clip` bounds

### DIFF
--- a/py-polars/tests/unit/operations/test_clip.py
+++ b/py-polars/tests/unit/operations/test_clip.py
@@ -20,17 +20,17 @@ def clip_exprs() -> list[pl.Expr]:
 def test_clip_int(clip_exprs: list[pl.Expr]) -> None:
     lf = pl.LazyFrame(
         {
-            "a": [1, 2, 3, 4, 5],
-            "min": [0, -1, 4, None, 4],
-            "max": [2, 1, 8, 5, None],
+            "a": [1, 2, 3, 4, 5, None],
+            "min": [0, -1, 4, None, 4, -10],
+            "max": [2, 1, 8, 5, None, 10],
         }
     )
     result = lf.select(clip_exprs)
     expected = pl.LazyFrame(
         {
-            "clip": [1, 1, 4, None, None],
-            "clip_min": [1, 2, 4, None, 5],
-            "clip_max": [1, 1, 3, 4, None],
+            "clip": [1, 1, 4, 4, 5, None],
+            "clip_min": [1, 2, 4, 4, 5, None],
+            "clip_max": [1, 1, 3, 4, 5, None],
         }
     )
     assert_frame_equal(result, expected)
@@ -39,17 +39,17 @@ def test_clip_int(clip_exprs: list[pl.Expr]) -> None:
 def test_clip_float(clip_exprs: list[pl.Expr]) -> None:
     lf = pl.LazyFrame(
         {
-            "a": [1.0, 2.0, 3.0, 4.0, 5.0],
-            "min": [0.0, -1.0, 4.0, None, 4.0],
-            "max": [2.0, 1.0, 8.0, 5.0, None],
+            "a": [1.0, 2.0, 3.0, 4.0, 5.0, None],
+            "min": [0.0, -1.0, 4.0, None, 4.0, None],
+            "max": [2.0, 1.0, 8.0, 5.0, None, None],
         }
     )
     result = lf.select(clip_exprs)
     expected = pl.LazyFrame(
         {
-            "clip": [1.0, 1.0, 4.0, None, None],
-            "clip_min": [1.0, 2.0, 4.0, None, 5.0],
-            "clip_max": [1.0, 1.0, 3.0, 4.0, None],
+            "clip": [1.0, 1.0, 4.0, 4.0, 5.0, None],
+            "clip_min": [1.0, 2.0, 4.0, 4.0, 5.0, None],
+            "clip_max": [1.0, 1.0, 3.0, 4.0, 5.0, None],
         }
     )
     assert_frame_equal(result, expected)
@@ -92,15 +92,15 @@ def test_clip_datetime(clip_exprs: list[pl.Expr]) -> None:
                 datetime(1996, 6, 5),
                 datetime(2023, 9, 20, 18, 30, 6),
                 None,
-                None,
-                None,
+                datetime(1993, 3, 13),
+                datetime(2000, 1, 10),
             ],
             "clip_min": [
                 datetime(1995, 6, 5, 10, 30),
                 datetime(1996, 6, 5),
                 datetime(2023, 10, 20, 18, 30, 6),
                 None,
-                None,
+                datetime(2023, 9, 24),
                 datetime(2000, 1, 10),
             ],
             "clip_max": [
@@ -109,7 +109,7 @@ def test_clip_datetime(clip_exprs: list[pl.Expr]) -> None:
                 datetime(2023, 9, 20, 18, 30, 6),
                 None,
                 datetime(1993, 3, 13),
-                None,
+                datetime(2000, 1, 10),
             ],
         }
     )
@@ -127,7 +127,7 @@ def test_clip_non_numeric_dtype_fails() -> None:
 def test_clip_string_input() -> None:
     df = pl.DataFrame({"a": [0, 1, 2], "min": [1, None, 1]})
     result = df.select(pl.col("a").clip("min"))
-    expected = pl.DataFrame({"a": [1, None, 2]})
+    expected = pl.DataFrame({"a": [1, 1, 2]})
     assert_frame_equal(result, expected)
 
 


### PR DESCRIPTION
Closes #13714

#### Changes
* Null values in the bounds no longer set the value to null - instead, the original value is retained.

**Before**

```pycon
>>> df = pl.DataFrame({"a": [0, 1, 2], "min": [1, None, 1]})
>>> df.select(pl.col("a").clip("min"))
shape: (3, 1)
┌──────┐
│ a    │
│ ---  │
│ i64  │
╞══════╡
│ 1    │
│ null │
│ 2    │
└──────┘
```

**After**

```pycon
>>> df.select(pl.col("a").clip("min"))
shape: (3, 1)
┌──────┐
│ a    │
│ ---  │
│ i64  │
╞══════╡
│ 1    │
│ 1    │
│ 2    │
└──────┘
```
