### PR TITLE
fix: Error on some invalid `clip` inputs

### DIFF
--- a/crates/polars-ops/src/series/ops/clip.rs
+++ b/crates/polars-ops/src/series/ops/clip.rs
@@ -11,7 +11,6 @@ pub fn clip(s: &Series, min: &Series, max: &Series) -> PolarsResult<Series> {
     );
 
     let original_type = s.dtype();
-    // cast min & max to the dtype of s first.
     let (min, max) = (min.strict_cast(s.dtype())?, max.strict_cast(s.dtype())?);
 
     let (s, min, max) = (
@@ -27,9 +26,9 @@ pub fn clip(s: &Series, min: &Series, max: &Series) -> PolarsResult<Series> {
                 let min: &ChunkedArray<$T> = min.as_ref().as_ref().as_ref();
                 let max: &ChunkedArray<$T> = max.as_ref().as_ref().as_ref();
                 let out = clip_helper(ca, min, max).into_series();
-                if original_type.is_logical(){
+                if original_type.is_logical() {
                     out.cast(original_type)
-                }else{
+                } else {
                     Ok(out)
                 }
             })
@@ -46,7 +45,6 @@ pub fn clip_max(s: &Series, max: &Series) -> PolarsResult<Series> {
     );
 
     let original_type = s.dtype();
-    // cast max to the dtype of s first.
     let max = max.strict_cast(s.dtype())?;
 
     let (s, max) = (s.to_physical_repr(), max.to_physical_repr());
@@ -57,9 +55,9 @@ pub fn clip_max(s: &Series, max: &Series) -> PolarsResult<Series> {
                 let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
                 let max: &ChunkedArray<$T> = max.as_ref().as_ref().as_ref();
                 let out = clip_min_max_helper(ca, max, clamp_max).into_series();
-                if original_type.is_logical(){
+                if original_type.is_logical() {
                     out.cast(original_type)
-                }else{
+                } else {
                     Ok(out)
                 }
             })
@@ -76,7 +74,6 @@ pub fn clip_min(s: &Series, min: &Series) -> PolarsResult<Series> {
     );
 
     let original_type = s.dtype();
-    // cast min to the dtype of s first.
     let min = min.strict_cast(s.dtype())?;
 
     let (s, min) = (s.to_physical_repr(), min.to_physical_repr());
@@ -87,9 +84,9 @@ pub fn clip_min(s: &Series, min: &Series) -> PolarsResult<Series> {
                 let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
                 let min: &ChunkedArray<$T> = min.as_ref().as_ref().as_ref();
                 let out = clip_min_max_helper(ca, min, clamp_min).into_series();
-                if original_type.is_logical(){
+                if original_type.is_logical() {
                     out.cast(original_type)
-                }else{
+                } else {
                     Ok(out)
                 }
             })

--- a/crates/polars-ops/src/series/ops/clip.rs
+++ b/crates/polars-ops/src/series/ops/clip.rs
@@ -12,7 +12,7 @@ pub fn clip(s: &Series, min: &Series, max: &Series) -> PolarsResult<Series> {
 
     let original_type = s.dtype();
     // cast min & max to the dtype of s first.
-    let (min, max) = (min.cast(s.dtype())?, max.cast(s.dtype())?);
+    let (min, max) = (min.strict_cast(s.dtype())?, max.strict_cast(s.dtype())?);
 
     let (s, min, max) = (
         s.to_physical_repr(),
@@ -47,7 +47,7 @@ pub fn clip_max(s: &Series, max: &Series) -> PolarsResult<Series> {
 
     let original_type = s.dtype();
     // cast max to the dtype of s first.
-    let max = max.cast(s.dtype())?;
+    let max = max.strict_cast(s.dtype())?;
 
     let (s, max) = (s.to_physical_repr(), max.to_physical_repr());
 
@@ -77,7 +77,7 @@ pub fn clip_min(s: &Series, min: &Series) -> PolarsResult<Series> {
 
     let original_type = s.dtype();
     // cast min to the dtype of s first.
-    let min = min.cast(s.dtype())?;
+    let min = min.strict_cast(s.dtype())?;
 
     let (s, min) = (s.to_physical_repr(), min.to_physical_repr());
 

--- a/py-polars/tests/unit/operations/test_clip.py
+++ b/py-polars/tests/unit/operations/test_clip.py
@@ -131,6 +131,12 @@ def test_clip_string_input() -> None:
     assert_frame_equal(result, expected)
 
 
+def test_clip_bound_invalid_for_original_dtype() -> None:
+    s = pl.Series([1, 2, 3, 4], dtype=pl.UInt32)
+    with pytest.raises(pl.ComputeError, match="conversion from `i32` to `u32` failed"):
+        s.clip(-1, 5)
+
+
 def test_clip_min_max_deprecated() -> None:
     s = pl.Series([-1, 0, 1])
 


### PR DESCRIPTION
Ref #11385
Ref #14413

**Before**

```python
import polars as pl

s = pl.Series([1, 2, 3, 4], dtype=pl.UInt32)
result = s.clip(-1, 5)
print(result)
```
```
shape: (4,)
Series: '' [u32]
[
        null
        null
        null
        null
]
```
**After**

```
polars.exceptions.ComputeError: conversion from `i32` to `u32` failed in column 'literal' for 1 out of 1 values: [-1]
```