### PR TITLE
fix: DataFrame.pivot was returning incorrect results when multiple columns were passed to `index` and one of them was Struct

### DIFF
--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -465,3 +465,19 @@ def test_duplicate_column_names_which_should_raise_14305() -> None:
     df = pl.DataFrame({"a": [1, 3, 2], "c": ["a", "a", "a"], "d": [7, 8, 9]})
     with pytest.raises(pl.DuplicateError, match="has more than one occurrences"):
         df.pivot(index="a", columns="c", values="d")
+
+
+def test_multi_index_containing_struct() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [1, 2, 1],
+            "b": [{"a": 1}, {"a": 1}, {"a": 2}],
+            "c": ["x", "y", "y"],
+            "d": [1, 1, 3],
+        }
+    )
+    result = df.pivot(index=("b", "d"), values="a", columns="c")
+    expected = pl.DataFrame(
+        {"b": [{"a": 1}, {"a": 2}], "d": [1, 3], "x": [1, None], "y": [2, 1]}
+    )
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
closes #14307

the final major piece of the pivot puzzle! (at least, until someone finds anything else...)

---

The gist of this is:
- in `compute_row_idx`, for the `index.len() > 1` case, combine the indexes into a struct
- use the specialised struct path
- unnest