### PR TITLE
test(python): Raise better error in import timings test

### DIFF
--- a/py-polars/tests/unit/test_polars_import.py
+++ b/py-polars/tests/unit/test_polars_import.py
@@ -28,11 +28,11 @@ def _import_timings() -> bytes:
     # assemble suitable command to get polars module import timing;
     # run in a separate process to ensure clean timing results.
     cmd = f'{sys.executable} -S -X importtime -c "import polars"'
-    return (
-        subprocess.run(cmd, shell=True, capture_output=True)
-        .stderr.replace(b"import time:", b"")
-        .strip()
-    )
+    output = subprocess.run(cmd, shell=True, capture_output=True).stderr
+    if b"Traceback" in output:
+        msg = f"measuring import timings failed\n\nCommand output:\n{output.decode()}"
+        raise RuntimeError(msg)
+    return output.replace(b"import time:", b"").strip()
 
 
 def _import_timings_as_frame(n_tries: int) -> tuple[pl.DataFrame, int]:


### PR DESCRIPTION
Ref #14442

This doesn't really address the issue with this test, but at least makes it more transparent (it was failing with a weird error in the subsequent `read_csv` call).