### PR TITLE
feat(rust!): Mark `DataFrame::new_no_checks` and `DataFrame::new_no_length_checks` unsafe

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
@@ -66,7 +66,7 @@ impl CategoricalChunked {
         let mut counts = groups.group_count();
         counts.rename("counts");
         let cols = vec![values.into_series(), counts.into_series()];
-        let df = DataFrame::new_no_checks(cols);
+        let df = unsafe { DataFrame::new_no_checks(cols) };
         df.sort(["counts"], true, false)
     }
 }

--- a/crates/polars-core/src/chunked_array/logical/struct_/from.rs
+++ b/crates/polars-core/src/chunked_array/logical/struct_/from.rs
@@ -4,11 +4,11 @@ impl From<StructChunked> for DataFrame {
     fn from(ca: StructChunked) -> Self {
         #[cfg(feature = "object")]
         {
-            DataFrame::new_no_checks(ca.fields.clone())
+            unsafe { DataFrame::new_no_checks(ca.fields.clone()) }
         }
         #[cfg(not(feature = "object"))]
         {
-            DataFrame::new_no_checks(ca.fields)
+            unsafe { DataFrame::new_no_checks(ca.fields) }
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/random.rs
+++ b/crates/polars-core/src/chunked_array/random.rs
@@ -194,7 +194,7 @@ impl DataFrame {
             Some(n) => self.sample_n_literal(n as usize, with_replacement, shuffle, seed),
             None => {
                 let new_cols = self.columns.iter().map(Series::clear).collect_trusted();
-                Ok(DataFrame::new_no_checks(new_cols))
+                Ok(unsafe { DataFrame::new_no_checks(new_cols) })
             },
         }
     }
@@ -239,7 +239,7 @@ impl DataFrame {
             },
             None => {
                 let new_cols = self.columns.iter().map(Series::clear).collect_trusted();
-                Ok(DataFrame::new_no_checks(new_cols))
+                Ok(unsafe { DataFrame::new_no_checks(new_cols) })
             },
         }
     }

--- a/crates/polars-core/src/frame/arithmetic.rs
+++ b/crates/polars-core/src/frame/arithmetic.rs
@@ -21,7 +21,7 @@ macro_rules! impl_arithmetic {
         let cols = POOL.install(|| {$self.columns.par_iter().map(|s| {
             Ok(&s.cast(&st)? $operand &rhs)
         }).collect::<PolarsResult<_>>()})?;
-        Ok(DataFrame::new_no_checks(cols))
+        Ok(unsafe { DataFrame::new_no_checks(cols) })
     }}
 }
 

--- a/crates/polars-core/src/frame/explode.rs
+++ b/crates/polars-core/src/frame/explode.rs
@@ -275,7 +275,7 @@ impl DataFrame {
                 out.push(variable_col);
                 out.push(value_col);
 
-                return Ok(DataFrame::new_no_checks(out));
+                return Ok(unsafe { DataFrame::new_no_checks(out) });
             }
 
             let id_vars_set = PlHashSet::from_iter(id_vars.iter().map(|s| s.as_str()));

--- a/crates/polars-core/src/frame/from.rs
+++ b/crates/polars-core/src/frame/from.rs
@@ -37,7 +37,7 @@ impl From<&Schema> for DataFrame {
             .iter()
             .map(|(name, dtype)| Series::new_empty(name, dtype))
             .collect();
-        DataFrame::new_no_checks(cols)
+        unsafe { DataFrame::new_no_checks(cols) }
     }
 }
 
@@ -48,6 +48,6 @@ impl From<&ArrowSchema> for DataFrame {
             .iter()
             .map(|fld| Series::new_empty(fld.name.as_str(), &(fld.data_type().into())))
             .collect();
-        DataFrame::new_no_checks(cols)
+        unsafe { DataFrame::new_no_checks(cols) }
     }
 }

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -28,28 +28,28 @@ use crate::prelude::sort::arg_sort_multiple::encode_rows_vertical;
 
 // This will remove the sorted flag on signed integers
 fn prepare_dataframe_unsorted(by: &[Series]) -> DataFrame {
-    DataFrame::new_no_checks(
-        by.iter()
-            .map(|s| match s.dtype() {
-                #[cfg(feature = "dtype-categorical")]
-                DataType::Categorical(_, _) | DataType::Enum(_, _) => {
-                    s.cast(&DataType::UInt32).unwrap()
-                },
-                _ => {
-                    if s.dtype().to_physical().is_numeric() {
-                        let s = s.to_physical_repr();
-                        if s.bit_repr_is_large() {
-                            s.bit_repr_large().into_series()
-                        } else {
-                            s.bit_repr_small().into_series()
-                        }
+    let columns = by
+        .iter()
+        .map(|s| match s.dtype() {
+            #[cfg(feature = "dtype-categorical")]
+            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
+                s.cast(&DataType::UInt32).unwrap()
+            },
+            _ => {
+                if s.dtype().to_physical().is_numeric() {
+                    let s = s.to_physical_repr();
+                    if s.bit_repr_is_large() {
+                        s.bit_repr_large().into_series()
                     } else {
-                        s.clone()
+                        s.bit_repr_small().into_series()
                     }
-                },
-            })
-            .collect(),
-    )
+                } else {
+                    s.clone()
+                }
+            },
+        })
+        .collect();
+    unsafe { DataFrame::new_no_checks(columns) }
 }
 
 impl DataFrame {
@@ -793,7 +793,7 @@ impl<'df> GroupBy<'df> {
                 new_cols.extend_from_slice(&self.selected_keys);
                 let cols = self.df.select_series(agg)?;
                 new_cols.extend(cols);
-                Ok(DataFrame::new_no_checks(new_cols))
+                Ok(unsafe { DataFrame::new_no_checks(new_cols) })
             }
         } else {
             Ok(self.df.clone())

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -400,7 +400,7 @@ impl DataFrame {
 
     /// Create a new `DataFrame` but does not check the length or duplicate occurrence of the `Series`.
     ///
-    /// It is advised to use [DataFrame::new](DataFrame::new) in favor of this method.
+    /// It is advised to use [DataFrame::new] in favor of this method.
     ///
     /// # Panic
     ///
@@ -413,7 +413,7 @@ impl DataFrame {
     /// Create a new `DataFrame` but does not check the length of the `Series`,
     /// only check for duplicates.
     ///
-    /// It is advised to use [DataFrame::new](DataFrame::new) in favor of this method.
+    /// It is advised to use [DataFrame::new] in favor of this method.
     ///
     /// # Safety
     ///

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -403,8 +403,9 @@ impl DataFrame {
     /// It is advised to use [DataFrame::new](DataFrame::new) in favor of this method.
     ///
     /// # Panic
+    ///
     /// It is the callers responsibility to uphold the contract of all `Series`
-    /// having an equal length, if not this may panic down the line.
+    /// having an equal length and a unique name, if not this may panic down the line.
     pub const fn new_no_checks(columns: Vec<Series>) -> DataFrame {
         DataFrame { columns }
     }

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -414,10 +414,11 @@ impl DataFrame {
     ///
     /// It is advised to use [DataFrame::new](DataFrame::new) in favor of this method.
     ///
-    /// # Panic
+    /// # Safety
+    ///
     /// It is the callers responsibility to uphold the contract of all `Series`
     /// having an equal length, if not this may panic down the line.
-    pub fn new_no_length_checks(columns: Vec<Series>) -> PolarsResult<DataFrame> {
+    pub unsafe fn new_no_length_checks(columns: Vec<Series>) -> PolarsResult<DataFrame> {
         let mut names = PlHashSet::with_capacity(columns.len());
         for column in &columns {
             let name = column.name();

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -406,7 +406,7 @@ impl DataFrame {
     ///
     /// It is the callers responsibility to uphold the contract of all `Series`
     /// having an equal length and a unique name, if not this may panic down the line.
-    pub const fn new_no_checks(columns: Vec<Series>) -> DataFrame {
+    pub const unsafe fn new_no_checks(columns: Vec<Series>) -> DataFrame {
         DataFrame { columns }
     }
 

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -3031,7 +3031,7 @@ impl Iterator for PhysRecordBatchIter<'_> {
 
 impl Default for DataFrame {
     fn default() -> Self {
-        unsafe { DataFrame::new_no_checks(vec![]) }
+        DataFrame::empty()
     }
 }
 

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -313,7 +313,7 @@ impl DataFrame {
     /// static EMPTY: DataFrame = DataFrame::empty();
     /// ```
     pub const fn empty() -> Self {
-        // SAFETY: An empty dataframe cannot have length mismatch or duplicate names
+        // SAFETY: An empty dataframe cannot have length mismatches or duplicate names
         unsafe { DataFrame::new_no_checks(Vec::new()) }
     }
 

--- a/crates/polars-core/src/frame/row/transpose.rs
+++ b/crates/polars-core/src/frame/row/transpose.rs
@@ -79,7 +79,7 @@ impl DataFrame {
                 }));
             },
         };
-        Ok(DataFrame::new_no_checks(cols_t))
+        Ok(unsafe { DataFrame::new_no_checks(cols_t) })
     }
 
     /// Transpose a DataFrame. This is a very expensive operation.

--- a/crates/polars-core/src/functions.rs
+++ b/crates/polars-core/src/functions.rs
@@ -75,7 +75,7 @@ pub fn concat_df_diagonal(dfs: &[DataFrame]) -> PolarsResult<DataFrame> {
                     None => columns.push(Series::full_null(name, height, dtype)),
                 }
             }
-            DataFrame::new_no_checks(columns)
+            unsafe { DataFrame::new_no_checks(columns) }
         })
         .collect::<Vec<_>>();
 

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -65,7 +65,7 @@ impl private::PrivateSeries for SeriesWrap<StructChunked> {
 
     #[cfg(feature = "algorithm_group_by")]
     fn group_tuples(&self, multithreaded: bool, sorted: bool) -> PolarsResult<GroupsProxy> {
-        let df = DataFrame::new_no_checks(vec![]);
+        let df = unsafe { DataFrame::new_no_checks(vec![]) };
         let gb = df
             .group_by_with_series(self.0.fields().to_vec(), multithreaded, sorted)
             .unwrap();

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -65,7 +65,7 @@ impl private::PrivateSeries for SeriesWrap<StructChunked> {
 
     #[cfg(feature = "algorithm_group_by")]
     fn group_tuples(&self, multithreaded: bool, sorted: bool) -> PolarsResult<GroupsProxy> {
-        let df = unsafe { DataFrame::new_no_checks(vec![]) };
+        let df = DataFrame::empty();
         let gb = df
             .group_by_with_series(self.0.fields().to_vec(), multithreaded, sorted)
             .unwrap();

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -221,6 +221,7 @@ impl Series {
     }
 
     pub fn into_frame(self) -> DataFrame {
+        // SAFETY: A single-column dataframe cannot have length mismatches or duplicate names
         unsafe { DataFrame::new_no_checks(vec![self]) }
     }
 

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -221,7 +221,7 @@ impl Series {
     }
 
     pub fn into_frame(self) -> DataFrame {
-        DataFrame::new_no_checks(vec![self])
+        unsafe { DataFrame::new_no_checks(vec![self]) }
     }
 
     /// Rename series.

--- a/crates/polars-io/src/csv/read.rs
+++ b/crates/polars-io/src/csv/read.rs
@@ -702,5 +702,5 @@ fn parse_dates(mut df: DataFrame, fixed_schema: &Schema) -> DataFrame {
         })
         .collect::<Vec<_>>();
 
-    DataFrame::new_no_checks(cols)
+    unsafe { DataFrame::new_no_checks(cols) }
 }

--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -73,7 +73,7 @@ pub(crate) fn cast_columns(
                 }
             })
             .collect::<PolarsResult<Vec<_>>>()?;
-        *df = DataFrame::new_no_checks(cols)
+        *df = unsafe { DataFrame::new_no_checks(cols) }
     } else {
         // cast to the original dtypes in the schema
         for fld in to_cast {
@@ -533,12 +533,11 @@ impl<'a> CoreReader<'a> {
                                 &self.schema,
                             )?;
 
-                            let mut local_df = DataFrame::new_no_checks(
-                                buffers
-                                    .into_iter()
-                                    .map(|buf| buf.into_series())
-                                    .collect::<PolarsResult<_>>()?,
-                            );
+                            let columns = buffers
+                                .into_iter()
+                                .map(|buf| buf.into_series())
+                                .collect::<PolarsResult<_>>()?;
+                            let mut local_df = unsafe { DataFrame::new_no_checks(columns) };
                             let current_row_count = local_df.height() as IdxSize;
                             if let Some(rc) = &self.row_index {
                                 local_df.with_row_index_mut(&rc.name, Some(rc.offset));
@@ -637,12 +636,11 @@ impl<'a> CoreReader<'a> {
                                 self.schema.as_ref(),
                             )?;
 
-                            DataFrame::new_no_checks(
-                                buffers
-                                    .into_iter()
-                                    .map(|buf| buf.into_series())
-                                    .collect::<PolarsResult<_>>()?,
-                            )
+                            let columns = buffers
+                                .into_iter()
+                                .map(|buf| buf.into_series())
+                                .collect::<PolarsResult<_>>()?;
+                            unsafe { DataFrame::new_no_checks(columns) }
                         };
 
                         cast_columns(&mut df, &self.to_cast, false, self.ignore_errors)?;
@@ -732,10 +730,9 @@ fn read_chunk(
         )?;
     }
 
-    Ok(DataFrame::new_no_checks(
-        buffers
-            .into_iter()
-            .map(|buf| buf.into_series())
-            .collect::<PolarsResult<_>>()?,
-    ))
+    let columns = buffers
+        .into_iter()
+        .map(|buf| buf.into_series())
+        .collect::<PolarsResult<_>>()?;
+    Ok(unsafe { DataFrame::new_no_checks(columns) })
 }

--- a/crates/polars-io/src/ipc/ipc_stream.rs
+++ b/crates/polars-io/src/ipc/ipc_stream.rs
@@ -214,7 +214,7 @@ fn fix_column_order(
             iter.collect()
         };
 
-        DataFrame::new_no_checks(cols)
+        unsafe { DataFrame::new_no_checks(cols) }
     } else {
         df
     }

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -245,7 +245,7 @@ fn rg_to_dfs_optionally_par_over_columns(
 
         *remaining_rows -= projection_height;
 
-        let mut df = DataFrame::new_no_checks(columns);
+        let mut df = unsafe { DataFrame::new_no_checks(columns) };
         if let Some(rc) = &row_index {
             df.with_row_index_mut(&rc.name, Some(*previous_row_count + rc.offset));
         }
@@ -332,7 +332,7 @@ fn rg_to_dfs_par_over_rg(
                     })
                     .collect::<PolarsResult<Vec<_>>>()?;
 
-                let mut df = DataFrame::new_no_checks(columns);
+                let mut df = unsafe { DataFrame::new_no_checks(columns) };
 
                 if let Some(rc) = &row_index {
                     df.with_row_index_mut(&rc.name, Some(row_count_start as IdxSize + rc.offset));

--- a/crates/polars-lazy/src/dsl/eval.rs
+++ b/crates/polars-lazy/src/dsl/eval.rs
@@ -82,7 +82,7 @@ pub trait ExprEvalExtension: IntoExpr + Sized {
                     .map(|len| {
                         let s = s.slice(0, len);
                         if (len - s.null_count()) >= min_periods {
-                            let df = unsafe { DataFrame::new_no_checks(vec![s]) };
+                            let df = s.into_frame();
                             let out = phys_expr.evaluate(&df, &state)?;
                             finish(out)
                         } else {

--- a/crates/polars-lazy/src/dsl/eval.rs
+++ b/crates/polars-lazy/src/dsl/eval.rs
@@ -91,7 +91,7 @@ pub trait ExprEvalExtension: IntoExpr + Sized {
                     })
                     .collect::<PolarsResult<Vec<_>>>()?
             } else {
-                let mut df_container = unsafe { DataFrame::new_no_checks(vec![]) };
+                let mut df_container = DataFrame::empty();
                 (1..s.len() + 1)
                     .map(|len| {
                         let s = s.slice(0, len);

--- a/crates/polars-lazy/src/dsl/eval.rs
+++ b/crates/polars-lazy/src/dsl/eval.rs
@@ -82,7 +82,7 @@ pub trait ExprEvalExtension: IntoExpr + Sized {
                     .map(|len| {
                         let s = s.slice(0, len);
                         if (len - s.null_count()) >= min_periods {
-                            let df = DataFrame::new_no_checks(vec![s]);
+                            let df = unsafe { DataFrame::new_no_checks(vec![s]) };
                             let out = phys_expr.evaluate(&df, &state)?;
                             finish(out)
                         } else {
@@ -91,7 +91,7 @@ pub trait ExprEvalExtension: IntoExpr + Sized {
                     })
                     .collect::<PolarsResult<Vec<_>>>()?
             } else {
-                let mut df_container = DataFrame::new_no_checks(vec![]);
+                let mut df_container = unsafe { DataFrame::new_no_checks(vec![]) };
                 (1..s.len() + 1)
                     .map(|len| {
                         let s = s.slice(0, len);

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -61,7 +61,7 @@ fn run_per_sublist(
             .par_iter()
             .map(|opt_s| {
                 opt_s.and_then(|s| {
-                    let df = unsafe { DataFrame::new_no_checks(vec![s]) };
+                    let df = s.into_frame();
                     let out = phys_expr.evaluate(&df, &state);
                     match out {
                         Ok(s) => Some(s),
@@ -124,7 +124,7 @@ fn run_on_group_by_engine(
     // Invariant in List means values physicals can be cast to inner dtype
     let values = unsafe { values.cast_unchecked(&inner_dtype).unwrap() };
 
-    let df_context = unsafe { DataFrame::new_no_checks(vec![values]) };
+    let df_context = values.into_frame();
     let phys_expr = prepare_expression_for_context("", expr, &inner_dtype, Context::Aggregation)?;
 
     let state = ExecutionState::new();

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -61,7 +61,7 @@ fn run_per_sublist(
             .par_iter()
             .map(|opt_s| {
                 opt_s.and_then(|s| {
-                    let df = DataFrame::new_no_checks(vec![s]);
+                    let df = unsafe { DataFrame::new_no_checks(vec![s]) };
                     let out = phys_expr.evaluate(&df, &state);
                     match out {
                         Ok(s) => Some(s),
@@ -76,7 +76,7 @@ fn run_per_sublist(
         err = m_err.into_inner().unwrap();
         ca
     } else {
-        let mut df_container = DataFrame::new_no_checks(vec![]);
+        let mut df_container = unsafe { DataFrame::new_no_checks(vec![]) };
 
         lst.into_iter()
             .map(|s| {
@@ -124,7 +124,7 @@ fn run_on_group_by_engine(
     // Invariant in List means values physicals can be cast to inner dtype
     let values = unsafe { values.cast_unchecked(&inner_dtype).unwrap() };
 
-    let df_context = DataFrame::new_no_checks(vec![values]);
+    let df_context = unsafe { DataFrame::new_no_checks(vec![values]) };
     let phys_expr = prepare_expression_for_context("", expr, &inner_dtype, Context::Aggregation)?;
 
     let state = ExecutionState::new();

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -76,7 +76,7 @@ fn run_per_sublist(
         err = m_err.into_inner().unwrap();
         ca
     } else {
-        let mut df_container = unsafe { DataFrame::new_no_checks(vec![]) };
+        let mut df_container = DataFrame::empty();
 
         lst.into_iter()
             .map(|s| {

--- a/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
@@ -149,7 +149,7 @@ fn estimate_unique_count(keys: &[Series], mut sample_size: usize) -> PolarsResul
             .iter()
             .map(|s| s.slice(offset, sample_size))
             .collect::<Vec<_>>();
-        let df = DataFrame::new_no_checks(keys);
+        let df = unsafe { DataFrame::new_no_checks(keys) };
         let names = df.get_column_names();
         let gb = df.group_by(names).unwrap();
         Ok(finish(gb.get_groups()))

--- a/crates/polars-lazy/src/physical_plan/executors/projection_utils.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/projection_utils.rs
@@ -316,7 +316,7 @@ pub(super) fn check_expand_literals(
             .collect::<PolarsResult<_>>()?
     }
 
-    let df = DataFrame::new_no_checks(selected_columns);
+    let df = unsafe { DataFrame::new_no_checks(selected_columns) };
 
     // a literal could be projected to a zero length dataframe.
     // This prevents a panic.

--- a/crates/polars-lazy/src/physical_plan/exotic.rs
+++ b/crates/polars-lazy/src/physical_plan/exotic.rs
@@ -31,7 +31,8 @@ pub(crate) fn prepare_expression_for_context(
     // create a dummy lazyframe and run a very simple optimization run so that
     // type coercion and simplify expression optimizations run.
     let column = Series::full_null(name, 0, dtype);
-    let lf = unsafe { DataFrame::new_no_checks(vec![column]) }
+    let lf = column
+        .into_frame()
         .lazy()
         .without_optimizations()
         .with_simplify_expr(true)

--- a/crates/polars-lazy/src/physical_plan/exotic.rs
+++ b/crates/polars-lazy/src/physical_plan/exotic.rs
@@ -31,7 +31,7 @@ pub(crate) fn prepare_expression_for_context(
     // create a dummy lazyframe and run a very simple optimization run so that
     // type coercion and simplify expression optimizations run.
     let column = Series::full_null(name, 0, dtype);
-    let lf = DataFrame::new_no_checks(vec![column])
+    let lf = unsafe { DataFrame::new_no_checks(vec![column]) }
         .lazy()
         .without_optimizations()
         .with_simplify_expr(true)

--- a/crates/polars-lazy/src/physical_plan/expressions/binary.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/binary.rs
@@ -397,7 +397,7 @@ mod stats {
                 }
             }
 
-            let dummy = DataFrame::new_no_checks(vec![]);
+            let dummy = DataFrame::empty();
             let state = ExecutionState::new();
 
             let out = match (self.left.is_literal(), self.right.is_literal()) {

--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -567,8 +567,8 @@ impl PhysicalExpr for WindowExpr {
                                     .unwrap()
                                     .1
                             } else {
-                                let df_right = DataFrame::new_no_checks(keys);
-                                let df_left = DataFrame::new_no_checks(group_by_columns);
+                                let df_right = unsafe { DataFrame::new_no_checks(keys) };
+                                let df_left = unsafe { DataFrame::new_no_checks(group_by_columns) };
                                 private_left_join_multiple_keys(
                                     &df_left, &df_right, None, None, true,
                                 )

--- a/crates/polars-lazy/src/physical_plan/node_timer.rs
+++ b/crates/polars-lazy/src/physical_plan/node_timer.rs
@@ -57,10 +57,8 @@ impl NodeTimer {
         let mut end = end.into_inner();
         end.rename("end");
 
-        DataFrame::new_no_checks(vec![nodes_s, start.into_series(), end.into_series()]).sort(
-            vec!["start"],
-            vec![false],
-            false,
-        )
+        let columns = vec![nodes_s, start.into_series(), end.into_series()];
+        let df = unsafe { DataFrame::new_no_checks(columns) };
+        df.sort(vec!["start"], vec![false], false)
     }
 }

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -16,7 +16,7 @@ pub trait DfTake: IntoDf {
             .to_df()
             ._apply_columns(&|s| s.take_chunked_unchecked(idx, sorted));
 
-        DataFrame::new_no_checks(cols)
+        unsafe { DataFrame::new_no_checks(cols) }
     }
     /// Take elements by a slice of optional [`ChunkId`]s.
     /// # Safety
@@ -26,7 +26,7 @@ pub trait DfTake: IntoDf {
             .to_df()
             ._apply_columns(&|s| s.take_opt_chunked_unchecked(idx));
 
-        DataFrame::new_no_checks(cols)
+        unsafe { DataFrame::new_no_checks(cols) }
     }
 
     /// # Safety
@@ -36,7 +36,7 @@ pub trait DfTake: IntoDf {
             .to_df()
             ._apply_columns_par(&|s| s.take_chunked_unchecked(idx, sorted));
 
-        DataFrame::new_no_checks(cols)
+        unsafe { DataFrame::new_no_checks(cols) }
     }
 
     /// # Safety
@@ -46,7 +46,7 @@ pub trait DfTake: IntoDf {
             .to_df()
             ._apply_columns_par(&|s| s.take_opt_chunked_unchecked(idx));
 
-        DataFrame::new_no_checks(cols)
+        unsafe { DataFrame::new_no_checks(cols) }
     }
 }
 

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -560,7 +560,7 @@ pub trait AsofJoinBy: IntoDf {
             .filter(|s| !drop_these.contains(&s.name()))
             .cloned()
             .collect();
-        let proj_other_df = DataFrame::new_no_checks(cols);
+        let proj_other_df = unsafe { DataFrame::new_no_checks(cols) };
 
         let left = self_df.clone();
         let right_join_tuples = &*right_join_tuples;

--- a/crates/polars-ops/src/frame/join/hash_join/multiple_keys.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/multiple_keys.rs
@@ -251,8 +251,8 @@ pub fn private_left_join_multiple_keys(
     chunk_mapping_right: Option<&[ChunkId]>,
     join_nulls: bool,
 ) -> LeftJoinIds {
-    let mut a = DataFrame::new_no_checks(_to_physical_and_bit_repr(a.get_columns()));
-    let mut b = DataFrame::new_no_checks(_to_physical_and_bit_repr(b.get_columns()));
+    let mut a = unsafe { DataFrame::new_no_checks(_to_physical_and_bit_repr(a.get_columns())) };
+    let mut b = unsafe { DataFrame::new_no_checks(_to_physical_and_bit_repr(b.get_columns())) };
     _left_join_multiple_keys(
         &mut a,
         &mut b,

--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -43,7 +43,7 @@ pub fn _merge_sorted_dfs(
         })
         .collect();
 
-    Ok(DataFrame::new_no_checks(new_columns))
+    Ok(unsafe { DataFrame::new_no_checks(new_columns) })
 }
 
 fn merge_series(lhs: &Series, rhs: &Series, merge_indicator: &[bool]) -> Series {

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -273,8 +273,8 @@ pub trait DataFrameJoinOps: IntoDf {
         // Multiple keys.
         match args.how {
             JoinType::Inner => {
-                let left = DataFrame::new_no_checks(selected_left_physical);
-                let right = DataFrame::new_no_checks(selected_right_physical);
+                let left = unsafe { DataFrame::new_no_checks(selected_left_physical) };
+                let right = unsafe { DataFrame::new_no_checks(selected_right_physical) };
                 let (mut left, mut right, swap) = det_hash_prone_order!(left, right);
                 let (join_idx_left, join_idx_right) =
                     _inner_join_multiple_keys(&mut left, &mut right, swap, args.join_nulls);
@@ -298,8 +298,8 @@ pub trait DataFrameJoinOps: IntoDf {
                 _finish_join(df_left, df_right, args.suffix.as_deref())
             },
             JoinType::Left => {
-                let mut left = DataFrame::new_no_checks(selected_left_physical);
-                let mut right = DataFrame::new_no_checks(selected_right_physical);
+                let mut left = unsafe { DataFrame::new_no_checks(selected_left_physical) };
+                let mut right = unsafe { DataFrame::new_no_checks(selected_right_physical) };
 
                 if let Some((offset, len)) = args.slice {
                     left = left.slice(offset, len);
@@ -309,8 +309,8 @@ pub trait DataFrameJoinOps: IntoDf {
                 left_df._finish_left_join(ids, &remove_selected(other, &selected_right), args)
             },
             JoinType::Outer { .. } => {
-                let df_left = DataFrame::new_no_checks(selected_left_physical);
-                let df_right = DataFrame::new_no_checks(selected_right_physical);
+                let df_left = unsafe { DataFrame::new_no_checks(selected_left_physical) };
+                let df_right = unsafe { DataFrame::new_no_checks(selected_right_physical) };
 
                 let (mut left, mut right, swap) = det_hash_prone_order!(df_left, df_right);
                 let (mut join_idx_l, mut join_idx_r) =
@@ -354,8 +354,8 @@ pub trait DataFrameJoinOps: IntoDf {
             ),
             #[cfg(feature = "semi_anti_join")]
             JoinType::Anti | JoinType::Semi => {
-                let mut left = DataFrame::new_no_checks(selected_left_physical);
-                let mut right = DataFrame::new_no_checks(selected_right_physical);
+                let mut left = unsafe { DataFrame::new_no_checks(selected_left_physical) };
+                let mut right = unsafe { DataFrame::new_no_checks(selected_right_physical) };
 
                 let idx = if matches!(args.how, JoinType::Anti) {
                     _left_anti_multiple_keys(&mut left, &mut right, args.join_nulls)

--- a/crates/polars-ops/src/frame/pivot/mod.rs
+++ b/crates/polars-ops/src/frame/pivot/mod.rs
@@ -341,5 +341,7 @@ fn pivot_impl_single_column(
         Ok(())
     });
     out?;
+
+    // SAFETY: length has already been checked.
     unsafe { DataFrame::new_no_length_checks(final_cols) }
 }

--- a/crates/polars-ops/src/frame/pivot/mod.rs
+++ b/crates/polars-ops/src/frame/pivot/mod.rs
@@ -341,5 +341,5 @@ fn pivot_impl_single_column(
         Ok(())
     });
     out?;
-    DataFrame::new_no_length_checks(final_cols)
+    unsafe { DataFrame::new_no_length_checks(final_cols) }
 }

--- a/crates/polars-ops/src/frame/pivot/mod.rs
+++ b/crates/polars-ops/src/frame/pivot/mod.rs
@@ -274,7 +274,7 @@ fn pivot_impl_single_column(
                             let name = expr.root_name()?;
                             let mut value_col = value_col.clone();
                             value_col.rename(name);
-                            let tmp_df = DataFrame::new_no_checks(vec![value_col]);
+                            let tmp_df = value_col.into_frame();
                             let mut aggregated = expr.evaluate(&tmp_df, &groups)?;
                             aggregated.rename(value_col_name);
                             aggregated

--- a/crates/polars-ops/src/series/ops/horizontal.rs
+++ b/crates/polars-ops/src/series/ops/horizontal.rs
@@ -42,25 +42,25 @@ pub fn all_horizontal(s: &[Series]) -> PolarsResult<Series> {
 }
 
 pub fn max_horizontal(s: &[Series]) -> PolarsResult<Option<Series>> {
-    let df = DataFrame::new_no_checks(Vec::from(s));
+    let df = unsafe { DataFrame::new_no_checks(Vec::from(s)) };
     df.max_horizontal()
         .map(|opt_s| opt_s.map(|res| res.with_name(s[0].name())))
 }
 
 pub fn min_horizontal(s: &[Series]) -> PolarsResult<Option<Series>> {
-    let df = DataFrame::new_no_checks(Vec::from(s));
+    let df = unsafe { DataFrame::new_no_checks(Vec::from(s)) };
     df.min_horizontal()
         .map(|opt_s| opt_s.map(|res| res.with_name(s[0].name())))
 }
 
 pub fn sum_horizontal(s: &[Series]) -> PolarsResult<Option<Series>> {
-    let df = DataFrame::new_no_checks(Vec::from(s));
+    let df = unsafe { DataFrame::new_no_checks(Vec::from(s)) };
     df.sum_horizontal(NullStrategy::Ignore)
         .map(|opt_s| opt_s.map(|res| res.with_name(s[0].name())))
 }
 
 pub fn mean_horizontal(s: &[Series]) -> PolarsResult<Option<Series>> {
-    let df = DataFrame::new_no_checks(Vec::from(s));
+    let df = unsafe { DataFrame::new_no_checks(Vec::from(s)) };
     df.mean_horizontal(NullStrategy::Ignore)
         .map(|opt_s| opt_s.map(|res| res.with_name(s[0].name())))
 }

--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -90,7 +90,7 @@ fn replace_by_multiple(
         ComputeError: "`new` input for `replace` must have the same length as `old` or have length 1"
     );
 
-    let df = unsafe { DataFrame::new_no_checks(vec![s.clone()]) };
+    let df = s.clone().into_frame();
     let replacer = create_replacer(old, new)?;
 
     let joined = df.join(

--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -90,7 +90,7 @@ fn replace_by_multiple(
         ComputeError: "`new` input for `replace` must have the same length as `old` or have length 1"
     );
 
-    let df = DataFrame::new_no_checks(vec![s.clone()]);
+    let df = unsafe { DataFrame::new_no_checks(vec![s.clone()]) };
     let replacer = create_replacer(old, new)?;
 
     let joined = df.join(
@@ -133,6 +133,6 @@ fn create_replacer(mut old: Series, mut new: Series) -> PolarsResult<DataFrame> 
     } else {
         vec![old, new]
     };
-    let out = DataFrame::new_no_checks(cols);
+    let out = unsafe { DataFrame::new_no_checks(cols) };
     Ok(out)
 }

--- a/crates/polars-ops/src/series/ops/to_dummies.rs
+++ b/crates/polars-ops/src/series/ops/to_dummies.rs
@@ -48,7 +48,7 @@ impl ToDummies for Series {
             })
             .collect();
 
-        Ok(DataFrame::new_no_checks(sort_columns(columns)))
+        Ok(unsafe { DataFrame::new_no_checks(sort_columns(columns)) })
     }
 }
 

--- a/crates/polars-ops/src/series/ops/various.rs
+++ b/crates/polars-ops/src/series/ops/various.rs
@@ -21,7 +21,7 @@ pub trait SeriesMethods: SeriesSealed {
         let values = unsafe { s.agg_first(&groups) };
         let counts = groups.group_lengths("count");
         let cols = vec![values, counts.into_series()];
-        let df = DataFrame::new_no_checks(cols);
+        let df = unsafe { DataFrame::new_no_checks(cols) };
         if sort {
             df.sort(["count"], true, false)
         } else {

--- a/crates/polars-pipe/src/executors/operators/projection.rs
+++ b/crates/polars-pipe/src/executors/operators/projection.rs
@@ -98,7 +98,7 @@ impl Operator for ProjectionOperator {
             }
         }
 
-        let chunk = chunk.with_data(DataFrame::new_no_checks(projected));
+        let chunk = chunk.with_data(unsafe { DataFrame::new_no_checks(projected) });
         Ok(OperatorResult::Finished(chunk))
     }
     fn split(&self, _thread_no: usize) -> Box<dyn Operator> {
@@ -149,7 +149,8 @@ impl Operator for HstackOperator {
             .map(|e| e.evaluate(chunk, context.execution_state.as_any()))
             .collect::<PolarsResult<Vec<_>>>()?;
 
-        let mut df = DataFrame::new_no_checks(chunk.data.get_columns()[..width].to_vec());
+        let columns = chunk.data.get_columns()[..width].to_vec();
+        let mut df = unsafe { DataFrame::new_no_checks(columns) };
 
         let schema = &*self.input_schema;
         if self.unchecked {

--- a/crates/polars-pipe/src/executors/operators/reproject.rs
+++ b/crates/polars-pipe/src/executors/operators/reproject.rs
@@ -45,7 +45,7 @@ pub(crate) fn reproject_chunk(
     } else {
         let columns = chunk.data.get_columns();
         let cols = positions.iter().map(|i| columns[*i].clone()).collect();
-        DataFrame::new_no_checks(cols)
+        unsafe { DataFrame::new_no_checks(cols) }
     };
     *chunk = chunk.with_data(out);
     Ok(())

--- a/crates/polars-pipe/src/executors/sinks/group_by/generic/hash_table.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/generic/hash_table.rs
@@ -275,7 +275,7 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
         );
         cols.extend(agg_builders.into_iter().map(|buf| buf.into_series()));
         physical_agg_to_logical(&mut cols, &self.output_schema);
-        DataFrame::new_no_checks(cols)
+        unsafe { DataFrame::new_no_checks(cols) }
     }
 }
 

--- a/crates/polars-pipe/src/executors/sinks/group_by/generic/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/generic/mod.rs
@@ -83,7 +83,7 @@ impl SpillPayload {
         cols.push(chunk_idx);
         cols.push(keys);
         cols.extend(self.aggs);
-        DataFrame::new_no_checks(cols)
+        unsafe { DataFrame::new_no_checks(cols) }
     }
 
     fn spilled_to_columns(

--- a/crates/polars-pipe/src/executors/sinks/group_by/primitive/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/primitive/mod.rs
@@ -209,7 +209,7 @@ where
                         cols.push(key_builder.finish().into_series());
                         cols.extend(buffers.into_iter().map(|buf| buf.into_series()));
                         physical_agg_to_logical(&mut cols, &self.output_schema);
-                        Some(DataFrame::new_no_checks(cols))
+                        Some(unsafe { DataFrame::new_no_checks(cols) })
                     })
                     .collect::<Vec<_>>();
             Ok(dfs)

--- a/crates/polars-pipe/src/executors/sinks/group_by/string.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/string.rs
@@ -213,7 +213,7 @@ impl StringGroupbySink {
                         cols.push(key_builder.finish().into_series());
                         cols.extend(buffers.into_iter().map(|buf| buf.into_series()));
                         physical_agg_to_logical(&mut cols, &self.output_schema);
-                        Some(DataFrame::new_no_checks(cols))
+                        Some(unsafe { DataFrame::new_no_checks(cols) })
                     })
                     .collect::<Vec<_>>();
 

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -434,7 +434,7 @@ impl LogicalPlanBuilder {
 
         if columns.is_empty() {
             self.map(
-                |_| Ok(unsafe { DataFrame::new_no_checks(vec![]) }),
+                |_| Ok(DataFrame::empty()),
                 AllowedOptimizations::default(),
                 Some(Arc::new(|_: &Schema| Ok(Arc::new(Schema::default())))),
                 "EMPTY PROJECTION",
@@ -459,7 +459,7 @@ impl LogicalPlanBuilder {
 
         if exprs.is_empty() {
             self.map(
-                |_| Ok(unsafe { DataFrame::new_no_checks(vec![]) }),
+                |_| Ok(DataFrame::empty()),
                 AllowedOptimizations::default(),
                 Some(Arc::new(|_: &Schema| Ok(Arc::new(Schema::default())))),
                 "EMPTY PROJECTION",

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -434,7 +434,7 @@ impl LogicalPlanBuilder {
 
         if columns.is_empty() {
             self.map(
-                |_| Ok(DataFrame::new_no_checks(vec![])),
+                |_| Ok(unsafe { DataFrame::new_no_checks(vec![]) }),
                 AllowedOptimizations::default(),
                 Some(Arc::new(|_: &Schema| Ok(Arc::new(Schema::default())))),
                 "EMPTY PROJECTION",
@@ -459,7 +459,7 @@ impl LogicalPlanBuilder {
 
         if exprs.is_empty() {
             self.map(
-                |_| Ok(DataFrame::new_no_checks(vec![])),
+                |_| Ok(unsafe { DataFrame::new_no_checks(vec![]) }),
                 AllowedOptimizations::default(),
                 Some(Arc::new(|_: &Schema| Ok(Arc::new(Schema::default())))),
                 "EMPTY PROJECTION",

--- a/crates/polars-plan/src/logical_plan/functions/merge_sorted.rs
+++ b/crates/polars-plan/src/logical_plan/functions/merge_sorted.rs
@@ -29,8 +29,8 @@ pub(super) fn merge_sorted(df: &DataFrame, column: &str) -> PolarsResult<DataFra
         )
     };
 
-    let left = DataFrame::new_no_checks(left_cols);
-    let right = DataFrame::new_no_checks(right_cols);
+    let left = unsafe { DataFrame::new_no_checks(left_cols) };
+    let right = unsafe { DataFrame::new_no_checks(right_cols) };
 
     let lhs = left.column(column)?;
     let rhs = right.column(column)?;

--- a/py-polars/src/arrow_interop/to_rust.rs
+++ b/py-polars/src/arrow_interop/to_rust.rs
@@ -98,7 +98,7 @@ pub fn to_rust_df(rb: &[&PyAny]) -> PyResult<DataFrame> {
             }?;
 
             // no need to check as a record batch has the same guarantees
-            Ok(DataFrame::new_no_checks(columns))
+            Ok(unsafe { DataFrame::new_no_checks(columns) })
         })
         .collect::<PyResult<Vec<_>>>()?;
 

--- a/py-polars/src/map/lazy.rs
+++ b/py-polars/src/map/lazy.rs
@@ -103,7 +103,7 @@ pub(crate) fn binary_lambda(
         let pyseries = if let Ok(expr) = result_series_wrapper.getattr(py, "_pyexpr") {
             let pyexpr = expr.extract::<PyExpr>(py).unwrap();
             let expr = pyexpr.inner;
-            let df = DataFrame::new_no_checks(vec![]);
+            let df = DataFrame::empty();
             let out = df
                 .lazy()
                 .select([expr])


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/pull/14431#discussion_r1486641201

### Changes

* Mark the mentioned methods unsafe
* Update references to use unsafe blocks
* Use `DataFrame::empty` and `Series::into_frame()` where possible, rather than an unsafe call to `DataFrame::new_no_checks`