### PR TITLE
chore(rust): Format safety sections in Rust docstrings

### DIFF
--- a/crates/polars-arrow/src/array/binary/mod.rs
+++ b/crates/polars-arrow/src/array/binary/mod.rs
@@ -161,6 +161,7 @@ impl<O: Offset> BinaryArray<O> {
     }
 
     /// Returns the element at index `i`
+    ///
     /// # Safety
     /// Assumes that the `i < self.len`.
     #[inline]
@@ -225,6 +226,7 @@ impl<O: Offset> BinaryArray<O> {
     /// Slices this [`BinaryArray`].
     /// # Implementation
     /// This function is `O(1)`.
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
@@ -374,6 +376,7 @@ impl<O: Offset> BinaryArray<O> {
     }
 
     /// Creates a [`BinaryArray`] from an iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -398,6 +401,7 @@ impl<O: Offset> BinaryArray<O> {
     }
 
     /// Creates a [`BinaryArray`] from an falible iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.

--- a/crates/polars-arrow/src/array/binary/mutable.rs
+++ b/crates/polars-arrow/src/array/binary/mutable.rs
@@ -236,6 +236,7 @@ impl<O: Offset, P: AsRef<[u8]>> FromIterator<Option<P>> for MutableBinaryArray<O
 
 impl<O: Offset> MutableBinaryArray<O> {
     /// Creates a [`MutableBinaryArray`] from an iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -262,6 +263,7 @@ impl<O: Offset> MutableBinaryArray<O> {
     }
 
     /// Creates a new [`BinaryArray`] from a [`TrustedLen`] of `&[u8]`.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -283,6 +285,7 @@ impl<O: Offset> MutableBinaryArray<O> {
     }
 
     /// Creates a [`MutableBinaryArray`] from an falible iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -349,6 +352,7 @@ impl<O: Offset> MutableBinaryArray<O> {
     /// Extends the [`MutableBinaryArray`] from an `iterator` of values of trusted length.
     /// This differs from `extend_trusted_len_unchecked` which accepts iterator of optional
     /// values.
+    ///
     /// # Safety
     /// The `iterator` must be [`TrustedLen`]
     #[inline]
@@ -378,6 +382,7 @@ impl<O: Offset> MutableBinaryArray<O> {
     }
 
     /// Extends the [`MutableBinaryArray`] from an iterator of [`TrustedLen`]
+    ///
     /// # Safety
     /// The `iterator` must be [`TrustedLen`]
     #[inline]

--- a/crates/polars-arrow/src/array/binary/mutable_values.rs
+++ b/crates/polars-arrow/src/array/binary/mutable_values.rs
@@ -163,6 +163,7 @@ impl<O: Offset> MutableBinaryValuesArray<O> {
     }
 
     /// Returns the value of the element at index `i`.
+    ///
     /// # Safety
     /// This function is safe iff `i < self.len`.
     #[inline]
@@ -266,6 +267,7 @@ impl<O: Offset> MutableBinaryValuesArray<O> {
     }
 
     /// Extends [`MutableBinaryValuesArray`] from an iterator of trusted len.
+    ///
     /// # Safety
     /// The iterator must be trusted len.
     #[inline]
@@ -289,6 +291,7 @@ impl<O: Offset> MutableBinaryValuesArray<O> {
     }
 
     /// Returns a new [`MutableBinaryValuesArray`] from an iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.

--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -178,6 +178,7 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
     }
 
     /// Create a new BinaryViewArray but initialize a statistics compute.
+    ///
     /// # Safety
     /// The caller must ensure the invariants
     pub unsafe fn new_unchecked_unknown_md(
@@ -267,6 +268,7 @@ impl<T: ViewType + ?Sized> BinaryViewArrayGeneric<T> {
     }
 
     /// Returns the element at index `i`
+    ///
     /// # Safety
     /// Assumes that the `i < self.len`.
     #[inline]

--- a/crates/polars-arrow/src/array/binview/mutable.rs
+++ b/crates/polars-arrow/src/array/binview/mutable.rs
@@ -321,6 +321,7 @@ impl<T: ViewType + ?Sized> MutableBinaryViewArray<T> {
     }
 
     /// Returns the element at index `i`
+    ///
     /// # Safety
     /// Assumes that the `i < self.len`.
     #[inline]

--- a/crates/polars-arrow/src/array/boolean/mod.rs
+++ b/crates/polars-arrow/src/array/boolean/mod.rs
@@ -136,6 +136,7 @@ impl BooleanArray {
     }
 
     /// Returns the element at index `i` as bool
+    ///
     /// # Safety
     /// Caller must be sure that `i < self.len()`
     #[inline]
@@ -173,6 +174,7 @@ impl BooleanArray {
     /// Slices this [`BooleanArray`].
     /// # Implementation
     /// This operation is `O(1)` as it amounts to increase two ref counts.
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
@@ -279,6 +281,7 @@ impl BooleanArray {
     /// Creates a new [`BooleanArray`] from an [`TrustedLen`] of `bool`.
     /// Use this over [`BooleanArray::from_trusted_len_iter`] when the iterator is trusted len
     /// but this crate does not mark it as such.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -298,6 +301,7 @@ impl BooleanArray {
     /// Creates a [`BooleanArray`] from an iterator of trusted length.
     /// Use this over [`BooleanArray::from_trusted_len_iter`] when the iterator is trusted len
     /// but this crate does not mark it as such.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -321,6 +325,7 @@ impl BooleanArray {
     }
 
     /// Creates a [`BooleanArray`] from an falible iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.

--- a/crates/polars-arrow/src/array/boolean/mutable.rs
+++ b/crates/polars-arrow/src/array/boolean/mutable.rs
@@ -142,6 +142,7 @@ impl MutableBooleanArray {
 
     /// Extends the [`MutableBooleanArray`] from an iterator of values of trusted len.
     /// This differs from `extend_trusted_len_unchecked`, which accepts in iterator of optional values.
+    ///
     /// # Safety
     /// The iterator must be trusted len.
     #[inline]
@@ -172,6 +173,7 @@ impl MutableBooleanArray {
     }
 
     /// Extends the [`MutableBooleanArray`] from an iterator of trusted len.
+    ///
     /// # Safety
     /// The iterator must be trusted len.
     #[inline]
@@ -255,6 +257,7 @@ impl MutableBooleanArray {
     /// Creates a new [`MutableBooleanArray`] from an [`TrustedLen`] of `bool`.
     /// Use this over [`BooleanArray::from_trusted_len_iter`] when the iterator is trusted len
     /// but this crate does not mark it as such.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -276,6 +279,7 @@ impl MutableBooleanArray {
     /// Creates a [`BooleanArray`] from an iterator of trusted length.
     /// Use this over [`BooleanArray::from_trusted_len_iter`] when the iterator is trusted len
     /// but this crate does not mark it as such.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -302,6 +306,7 @@ impl MutableBooleanArray {
     }
 
     /// Creates a [`BooleanArray`] from an falible iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.

--- a/crates/polars-arrow/src/array/dictionary/mod.rs
+++ b/crates/polars-arrow/src/array/dictionary/mod.rs
@@ -37,6 +37,7 @@ pub unsafe trait DictionaryKey: NativeType + TryInto<usize> + TryFrom<usize> + H
     const KEY_TYPE: IntegerType;
 
     /// Represents this key as a `usize`.
+    ///
     /// # Safety
     /// The caller _must_ have checked that the value can be casted to `usize`.
     #[inline]
@@ -178,6 +179,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// * the `data_type`'s logical type is not a `DictionaryArray`
     /// * the `data_type`'s keys is not compatible with `keys`
     /// * the `data_type`'s values's data_type is not equal with `values.data_type()`
+    ///
     /// # Safety
     /// The caller must ensure that every keys's values is represented in `usize` and is `< values.len()`
     pub unsafe fn try_new_unchecked(
@@ -292,6 +294,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     }
 
     /// Slices this [`DictionaryArray`].
+    ///
     /// # Safety
     /// Safe iff `offset + length <= self.len()`.
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {

--- a/crates/polars-arrow/src/array/ffi.rs
+++ b/crates/polars-arrow/src/array/ffi.rs
@@ -26,6 +26,7 @@ pub(crate) unsafe trait ToFfi {
 /// [C data interface](https://arrow.apache.org/docs/format/CDataInterface.html) (FFI).
 pub(crate) trait FromFfi<T: ffi::ArrowArrayRef>: Sized {
     /// Convert itself from FFI.
+    ///
     /// # Safety
     /// This function is intrinsically `unsafe` as it requires the FFI to be made according
     /// to the [C data interface](https://arrow.apache.org/docs/format/CDataInterface.html)

--- a/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
@@ -105,6 +105,7 @@ impl FixedSizeBinaryArray {
     /// Slices this [`FixedSizeBinaryArray`].
     /// # Implementation
     /// This operation is `O(1)`.
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
@@ -151,6 +152,7 @@ impl FixedSizeBinaryArray {
     }
 
     /// Returns the element at index `i` as &str
+    ///
     /// # Safety
     /// Assumes that the `i < self.len`.
     #[inline]

--- a/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
@@ -200,6 +200,7 @@ impl MutableFixedSizeBinaryArray {
     }
 
     /// Returns the element at index `i` as `&[u8]`
+    ///
     /// # Safety
     /// Assumes that the `i < self.len`.
     #[inline]

--- a/crates/polars-arrow/src/array/fixed_size_list/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/mod.rs
@@ -111,6 +111,7 @@ impl FixedSizeListArray {
     /// Slices this [`FixedSizeListArray`].
     /// # Implementation
     /// This operation is `O(1)`.
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
@@ -156,6 +157,7 @@ impl FixedSizeListArray {
     }
 
     /// Returns the `Vec<T>` at position `i`.
+    ///
     /// # Safety
     /// Caller must ensure that `i < self.len()`
     #[inline]

--- a/crates/polars-arrow/src/array/growable/binview.rs
+++ b/crates/polars-arrow/src/array/growable/binview.rs
@@ -140,6 +140,7 @@ impl<'a, T: ViewType + ?Sized> GrowableBinaryViewArray<'a, T> {
 
     #[inline]
     /// Ignores the buffers and doesn't update the view. This is only correct in a filter.
+    ///
     /// # Safety
     /// doesn't check bounds
     pub unsafe fn extend_unchecked_no_buffers(&mut self, index: usize, start: usize, len: usize) {

--- a/crates/polars-arrow/src/array/growable/mod.rs
+++ b/crates/polars-arrow/src/array/growable/mod.rs
@@ -37,11 +37,13 @@ mod utils;
 pub trait Growable<'a> {
     /// Extends this [`Growable`] with elements from the bounded [`Array`] at index `index` from
     /// a slice starting at `start` and length `len`.
+    ///
     /// # Safety
     /// Doesn't do any bound checks
     unsafe fn extend(&mut self, index: usize, start: usize, len: usize);
 
     /// Extends this [`Growable`] with null elements, disregarding the bound arrays
+    ///
     /// # Safety
     /// Doesn't do any bound checks
     fn extend_validity(&mut self, additional: usize);

--- a/crates/polars-arrow/src/array/indexable.rs
+++ b/crates/polars-arrow/src/array/indexable.rs
@@ -22,6 +22,7 @@ pub trait Indexable {
     fn value_at(&self, index: usize) -> Self::Value<'_>;
 
     /// Returns the element at index `i`.
+    ///
     /// # Safety
     /// Assumes that the `i < self.len`.
     #[inline]

--- a/crates/polars-arrow/src/array/list/mod.rs
+++ b/crates/polars-arrow/src/array/list/mod.rs
@@ -114,6 +114,7 @@ impl<O: Offset> ListArray<O> {
     }
 
     /// Slices this [`ListArray`].
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length < self.len()`.
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
@@ -149,6 +150,7 @@ impl<O: Offset> ListArray<O> {
     }
 
     /// Returns the element at index `i` as &str
+    ///
     /// # Safety
     /// Assumes that the `i < self.len`.
     #[inline]

--- a/crates/polars-arrow/src/array/map/mod.rs
+++ b/crates/polars-arrow/src/array/map/mod.rs
@@ -111,6 +111,7 @@ impl MapArray {
     }
 
     /// Returns a slice of this [`MapArray`].
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length < self.len()`.
     #[inline]
@@ -168,6 +169,7 @@ impl MapArray {
     }
 
     /// Returns the element at index `i`.
+    ///
     /// # Safety
     /// Assumes that the `i < self.len`.
     #[inline]

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -75,6 +75,7 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
     }
 
     /// Returns whether slot `i` is null.
+    ///
     /// # Safety
     /// The caller must ensure `i < self.len()`
     #[inline]
@@ -103,6 +104,7 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
     /// Slices the [`Array`].
     /// # Implementation
     /// This operation is `O(1)`.
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`
     unsafe fn slice_unchecked(&mut self, offset: usize, length: usize);
@@ -123,6 +125,7 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
     /// # Implementation
     /// This operation is `O(1)` over `len`, as it amounts to increase two ref counts
     /// and moving the struct to the heap.
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`
     #[must_use]
@@ -496,6 +499,7 @@ macro_rules! impl_sliced {
         /// Returns this array sliced.
         /// # Implementation
         /// This function is `O(1)`.
+        ///
         /// # Safety
         /// The caller must ensure that `offset + length <= self.len()`.
         #[inline]
@@ -746,6 +750,7 @@ pub trait TryPush<A> {
 /// A trait describing the ability of a struct to receive new items.
 pub trait PushUnchecked<A> {
     /// Push a new element that holds the invariants of the struct.
+    ///
     /// # Safety
     /// The items must uphold the invariants of the struct
     /// Read the specific implementation of the trait to understand what these are.

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -62,6 +62,7 @@ impl NullArray {
     }
 
     /// Returns a slice of the [`NullArray`].
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length < self.len()`.
     pub unsafe fn slice_unchecked(&mut self, _offset: usize, length: usize) {

--- a/crates/polars-arrow/src/array/primitive/mod.rs
+++ b/crates/polars-arrow/src/array/primitive/mod.rs
@@ -208,6 +208,7 @@ impl<T: NativeType> PrimitiveArray<T> {
 
     /// Returns the value at index `i`.
     /// The value on null slots is undetermined (it can be anything).
+    ///
     /// # Safety
     /// Caller must be sure that `i < self.len()`
     #[inline]
@@ -243,6 +244,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     /// Slices this [`PrimitiveArray`] by an offset and length.
     /// # Implementation
     /// This operation is `O(1)`.
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
@@ -420,6 +422,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     }
 
     /// Creates a new [`PrimitiveArray`] from an iterator over values
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -433,6 +436,7 @@ impl<T: NativeType> PrimitiveArray<T> {
     }
 
     /// Creates a [`PrimitiveArray`] from an iterator of optional values.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.

--- a/crates/polars-arrow/src/array/primitive/mutable.rs
+++ b/crates/polars-arrow/src/array/primitive/mutable.rs
@@ -195,6 +195,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     }
 
     /// Extends the [`MutablePrimitiveArray`] from an iterator of trusted len.
+    ///
     /// # Safety
     /// The iterator must be trusted len.
     #[inline]
@@ -224,6 +225,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
 
     /// Extends the [`MutablePrimitiveArray`] from an iterator of values of trusted len.
     /// This differs from `extend_trusted_len_unchecked` which accepts in iterator of optional values.
+    ///
     /// # Safety
     /// The iterator must be trusted len.
     #[inline]
@@ -320,6 +322,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     /// Sets position `index` to `value`.
     /// Note that if it is the first time a null appears in this array,
     /// this initializes the validity bitmap (`O(N)`).
+    ///
     /// # Safety
     /// Caller must ensure `index < self.len()`
     pub unsafe fn set_unchecked(&mut self, index: usize, value: Option<T>) {
@@ -448,6 +451,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     }
 
     /// Creates a [`MutablePrimitiveArray`] from an iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. `size_hint().1` correctly reports its length.
@@ -477,6 +481,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     }
 
     /// Creates a [`MutablePrimitiveArray`] from an fallible iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -525,6 +530,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     }
 
     /// Creates a new [`MutablePrimitiveArray`] from an iterator over values
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.

--- a/crates/polars-arrow/src/array/struct_/mod.rs
+++ b/crates/polars-arrow/src/array/struct_/mod.rs
@@ -178,6 +178,7 @@ impl StructArray {
     /// Slices this [`StructArray`].
     /// # Implementation
     /// This operation is `O(F)` where `F` is the number of fields.
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {

--- a/crates/polars-arrow/src/array/union/mod.rs
+++ b/crates/polars-arrow/src/array/union/mod.rs
@@ -240,6 +240,7 @@ impl UnionArray {
     /// Returns a slice of this [`UnionArray`].
     /// # Implementation
     /// This operation is `O(F)` where `F` is the number of fields.
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     #[inline]
@@ -296,6 +297,7 @@ impl UnionArray {
 
     /// Returns the index and slot of the field to select from `self.fields`.
     /// The first value is guaranteed to be `< self.fields().len()`
+    ///
     /// # Safety
     /// This function is safe iff `index < self.len`.
     #[inline]
@@ -323,6 +325,7 @@ impl UnionArray {
     }
 
     /// Returns the slot `index` as a [`Scalar`].
+    ///
     /// # Safety
     /// This function is safe iff `i < self.len`.
     pub unsafe fn value_unchecked(&self, index: usize) -> Box<dyn Scalar> {

--- a/crates/polars-arrow/src/array/utf8/mod.rs
+++ b/crates/polars-arrow/src/array/utf8/mod.rs
@@ -156,6 +156,7 @@ impl<O: Offset> Utf8Array<O> {
     }
 
     /// Returns the value of the element at index `i`, ignoring the array's validity.
+    ///
     /// # Safety
     /// This function is safe iff `i < self.len`.
     #[inline]
@@ -223,6 +224,7 @@ impl<O: Offset> Utf8Array<O> {
     /// Slices this [`Utf8Array`].
     /// # Implementation
     /// This function is `O(1)`
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`.
     pub unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
@@ -362,6 +364,7 @@ impl<O: Offset> Utf8Array<O> {
     /// * The last offset is not equal to the values' length.
     /// * the validity's length is not equal to `offsets.len()`.
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is not equal to either `Utf8` or `LargeUtf8`.
+    ///
     /// # Safety
     /// This function is unsound iff:
     /// * The `values` between two consecutive `offsets` are not valid utf8
@@ -430,6 +433,7 @@ impl<O: Offset> Utf8Array<O> {
     }
 
     /// Creates a [`Utf8Array`] from an iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -453,6 +457,7 @@ impl<O: Offset> Utf8Array<O> {
     }
 
     /// Creates a [`Utf8Array`] from an falible iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.

--- a/crates/polars-arrow/src/array/utf8/mutable.rs
+++ b/crates/polars-arrow/src/array/utf8/mutable.rs
@@ -75,6 +75,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     /// Create a [`MutableUtf8Array`] out of low-end APIs.
+    ///
     /// # Safety
     /// The caller must ensure that every value between offsets is a valid utf8.
     /// # Panics
@@ -151,6 +152,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     /// Returns the value of the element at index `i`, ignoring the array's validity.
+    ///
     /// # Safety
     /// This function is safe iff `i < self.len`.
     #[inline]
@@ -327,6 +329,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     /// Extends the [`MutableUtf8Array`] from an iterator of values of trusted len.
     /// This differs from `extended_trusted_len_unchecked` which accepts iterator of optional
     /// values.
+    ///
     /// # Safety
     /// The iterator must be trusted len.
     #[inline]
@@ -355,6 +358,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     /// Extends [`MutableUtf8Array`] from an iterator of trusted len.
+    ///
     /// # Safety
     /// The iterator must be trusted len.
     #[inline]
@@ -374,6 +378,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     /// Creates a [`MutableUtf8Array`] from an iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -402,6 +407,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     /// Creates a [`MutableUtf8Array`] from an iterator of trusted length of `&str`.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.
@@ -438,6 +444,7 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     /// Creates a [`MutableUtf8Array`] from an falible iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.

--- a/crates/polars-arrow/src/array/utf8/mutable.rs
+++ b/crates/polars-arrow/src/array/utf8/mutable.rs
@@ -145,8 +145,6 @@ impl<O: Offset> MutableUtf8Array<O> {
     }
 
     /// Returns the value of the element at index `i`, ignoring the array's validity.
-    /// # Safety
-    /// This function is safe iff `i < self.len`.
     #[inline]
     pub fn value(&self, i: usize) -> &str {
         self.values.value(i)

--- a/crates/polars-arrow/src/array/utf8/mutable_values.rs
+++ b/crates/polars-arrow/src/array/utf8/mutable_values.rs
@@ -95,6 +95,7 @@ impl<O: Offset> MutableUtf8ValuesArray<O> {
     /// This function does not panic iff:
     /// * The last offset is equal to the values' length.
     /// * The `data_type`'s [`crate::datatypes::PhysicalType`] is equal to either `Utf8` or `LargeUtf8`.
+    ///
     /// # Safety
     /// This function is safe iff:
     /// * the offsets are monotonically increasing
@@ -201,6 +202,7 @@ impl<O: Offset> MutableUtf8ValuesArray<O> {
     }
 
     /// Returns the value of the element at index `i`.
+    ///
     /// # Safety
     /// This function is safe iff `i < self.len`.
     #[inline]
@@ -309,6 +311,7 @@ impl<O: Offset> MutableUtf8ValuesArray<O> {
     }
 
     /// Extends [`MutableUtf8ValuesArray`] from an iterator of trusted len.
+    ///
     /// # Safety
     /// The iterator must be trusted len.
     #[inline]
@@ -333,6 +336,7 @@ impl<O: Offset> MutableUtf8ValuesArray<O> {
     }
 
     /// Returns a new [`MutableUtf8ValuesArray`] from an iterator of trusted length.
+    ///
     /// # Safety
     /// The iterator must be [`TrustedLen`](https://doc.rust-lang.org/std/iter/trait.TrustedLen.html).
     /// I.e. that `size_hint().1` correctly reports its length.

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -190,6 +190,7 @@ impl Bitmap {
     }
 
     /// Slices `self`, offsetting by `offset` and truncating up to `length` bits.
+    ///
     /// # Safety
     /// The caller must ensure that `self.offset + offset + length <= self.len()`
     #[inline]
@@ -246,6 +247,7 @@ impl Bitmap {
     }
 
     /// Slices `self`, offsetting by `offset` and truncating up to `length` bits.
+    ///
     /// # Safety
     /// The caller must ensure that `self.offset + offset + length <= self.len()`
     #[inline]
@@ -264,6 +266,7 @@ impl Bitmap {
     }
 
     /// Unsafely returns whether the bit at position `i` is set.
+    ///
     /// # Safety
     /// Unsound iff `i >= self.len()`.
     #[inline]
@@ -418,6 +421,7 @@ impl FromIterator<bool> for Bitmap {
 
 impl Bitmap {
     /// Creates a new [`Bitmap`] from an iterator of booleans.
+    ///
     /// # Safety
     /// The iterator must report an accurate length.
     #[inline]
@@ -440,6 +444,7 @@ impl Bitmap {
     }
 
     /// Creates a new [`Bitmap`] from a fallible iterator of booleans.
+    ///
     /// # Safety
     /// The iterator must report an accurate length.
     #[inline]

--- a/crates/polars-arrow/src/bitmap/mutable.rs
+++ b/crates/polars-arrow/src/bitmap/mutable.rs
@@ -221,6 +221,7 @@ impl MutableBitmap {
     }
 
     /// Pushes a new bit to the [`MutableBitmap`]
+    ///
     /// # Safety
     /// The caller must ensure that the [`MutableBitmap`] has sufficient capacity.
     #[inline]
@@ -318,6 +319,7 @@ impl MutableBitmap {
     }
 
     /// Sets the position `index` to `value`
+    ///
     /// # Safety
     /// Caller must ensure that `index < self.len()`
     #[inline]
@@ -529,6 +531,7 @@ impl MutableBitmap {
     }
 
     /// Extends `self` from an iterator of trusted len.
+    ///
     /// # Safety
     /// The caller must guarantee that the iterator has a trusted len.
     #[inline]
@@ -577,6 +580,7 @@ impl MutableBitmap {
     }
 
     /// Creates a new [`MutableBitmap`] from an iterator of booleans.
+    ///
     /// # Safety
     /// The iterator must report an accurate length.
     #[inline]
@@ -610,6 +614,7 @@ impl MutableBitmap {
     }
 
     /// Creates a new [`MutableBitmap`] from an falible iterator of booleans.
+    ///
     /// # Safety
     /// The caller must guarantee that the iterator is `TrustedLen`.
     pub unsafe fn try_from_trusted_len_iter_unchecked<E, I>(
@@ -697,6 +702,7 @@ impl MutableBitmap {
     /// # Implementation
     /// When both [`MutableBitmap`]'s length and `offset` are both multiples of 8,
     /// this function performs a memcopy. Else, it first aligns bit by bit and then performs a memcopy.
+    ///
     /// # Safety
     /// Caller must ensure `offset + length <= slice.len() * 8`
     #[inline]

--- a/crates/polars-arrow/src/buffer/immutable.rs
+++ b/crates/polars-arrow/src/buffer/immutable.rs
@@ -120,6 +120,7 @@ impl<T> Buffer<T> {
     }
 
     /// Returns the byte slice stored in this buffer
+    ///
     /// # Safety
     /// `index` must be smaller than `len`
     #[inline]
@@ -159,6 +160,7 @@ impl<T> Buffer<T> {
 
     /// Returns a new [`Buffer`] that is a slice of this buffer starting at `offset`.
     /// Doing so allows the same memory region to be shared between buffers.
+    ///
     /// # Safety
     /// The caller must ensure `offset + length <= self.len()`
     #[inline]
@@ -169,6 +171,7 @@ impl<T> Buffer<T> {
     }
 
     /// Slices this buffer starting at `offset`.
+    ///
     /// # Safety
     /// The caller must ensure `offset + length <= self.len()`
     #[inline]

--- a/crates/polars-arrow/src/buffer/mod.rs
+++ b/crates/polars-arrow/src/buffer/mod.rs
@@ -29,6 +29,7 @@ impl<T> Bytes<T> {
     /// Takes ownership of an allocated memory region.
     /// # Panics
     /// This function panics if and only if pointer is not null
+    ///
     /// # Safety
     /// This function is safe if and only if `ptr` is valid for `length`
     /// # Implementation

--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -411,7 +411,8 @@ unsafe fn buffer_len(
     })
 }
 
-/// Safety
+/// # Safety
+///
 /// This function is safe iff:
 /// * `array.children` at `index` is valid
 /// * `array.children` is not mutably shared for the lifetime of `parent`
@@ -453,7 +454,8 @@ unsafe fn create_child(
     Ok(ArrowArrayChild::new(arr_ptr, data_type, parent))
 }
 
-/// Safety
+/// # Safety
+///
 /// This function is safe iff:
 /// * `array.dictionary` is valid
 /// * `array.dictionary` is not mutably shared for the lifetime of `parent`

--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -93,6 +93,7 @@ struct PrivateData {
 
 impl ArrowArray {
     /// creates a new `ArrowArray` from existing data.
+    ///
     /// # Safety
     /// This method releases `buffers`. Consumers of this struct *must* call `release` before
     /// releasing this struct, or contents in `buffers` leak.
@@ -490,6 +491,7 @@ pub trait ArrowArrayRef: std::fmt::Debug {
     /// returns the null bit buffer.
     /// Rust implementation uses a buffer that is not part of the array of buffers.
     /// The C Data interface's null buffer is part of the array of buffers.
+    ///
     /// # Safety
     /// The caller must guarantee that the buffer `index` corresponds to a bitmap.
     /// This function assumes that the bitmap created from FFI is valid; this is impossible to prove.

--- a/crates/polars-arrow/src/ffi/stream.rs
+++ b/crates/polars-arrow/src/ffi/stream.rs
@@ -54,6 +54,7 @@ impl<Iter: DerefMut<Target = ArrowArrayStream>> ArrowArrayStreamReader<Iter> {
     /// # Error
     /// Errors iff the [`ArrowArrayStream`] is out of specification,
     /// or was already released prior to calling this function.
+    ///
     /// # Safety
     /// This method is intrinsically `unsafe` since it assumes that the `ArrowArrayStream`
     /// contains a valid Arrow C stream interface.
@@ -101,6 +102,7 @@ impl<Iter: DerefMut<Target = ArrowArrayStream>> ArrowArrayStreamReader<Iter> {
     /// Errors iff:
     /// * The C stream interface returns an error
     /// * The C stream interface returns an invalid array (that we can identify, see Safety below)
+    ///
     /// # Safety
     /// Calling this iterator's `next` assumes that the [`ArrowArrayStream`] produces arrow arrays
     /// that fulfill the C data interface

--- a/crates/polars-arrow/src/legacy/array/slice.rs
+++ b/crates/polars-arrow/src/legacy/array/slice.rs
@@ -15,6 +15,7 @@ pub trait SlicedArray {
     /// Slices the [`Array`].
     /// # Implementation
     /// This operation is `O(1)`.
+    ///
     /// # Safety
     /// The caller must ensure that `offset + length <= self.len()`
     unsafe fn slice_typed_unchecked(&self, offset: usize, length: usize) -> Self

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
@@ -26,6 +26,7 @@ pub trait RollingAggWindowNoNulls<'a, T: NativeType> {
     fn new(slice: &'a [T], start: usize, end: usize, params: DynArgs) -> Self;
 
     /// Update and recompute the window
+    ///
     /// # Safety
     /// `start` and `end` must be within the windows bounds
     unsafe fn update(&mut self, start: usize, end: usize) -> T;

--- a/crates/polars-arrow/src/legacy/kernels/rolling/window.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/window.rs
@@ -24,6 +24,7 @@ impl<'a, T: NativeType> SortedBuf<'a, T> {
     }
 
     /// Update the window position by setting the `start` index and the `end` index.
+    ///
     /// # Safety
     /// The caller must ensure that `start` and `end` are within bounds of `self.slice`
     ///
@@ -120,6 +121,7 @@ impl<'a, T: NativeType> SortedBufNulls<'a, T> {
     }
 
     /// Update the window position by setting the `start` index and the `end` index.
+    ///
     /// # Safety
     /// The caller must ensure that `start` and `end` are within bounds of `self.slice`
     ///

--- a/crates/polars-arrow/src/offset.rs
+++ b/crates/polars-arrow/src/offset.rs
@@ -141,6 +141,7 @@ impl<O: Offset> Offsets<O> {
     }
 
     /// Returns [`Offsets`] assuming that `offsets` fulfills its invariants
+    ///
     /// # Safety
     /// This is safe iff the invariants of this struct are guaranteed in `offsets`.
     #[inline]
@@ -168,6 +169,7 @@ impl<O: Offset> Offsets<O> {
     }
 
     /// Returns a range (start, end) corresponding to the position `index`
+    ///
     /// # Safety
     /// `index` must be `< self.len()`
     #[inline]
@@ -441,6 +443,7 @@ impl<O: Offset> OffsetsBuffer<O> {
     }
 
     /// Returns a range (start, end) corresponding to the position `index`
+    ///
     /// # Safety
     /// `index` must be `< self.len()`
     #[inline]
@@ -462,6 +465,7 @@ impl<O: Offset> OffsetsBuffer<O> {
     }
 
     /// Slices this [`OffsetsBuffer`] starting at `offset`.
+    ///
     /// # Safety
     /// The caller must ensure `offset + length <= self.len()`
     #[inline]

--- a/crates/polars-arrow/src/types/index.rs
+++ b/crates/polars-arrow/src/types/index.rs
@@ -99,5 +99,7 @@ impl<I: Index> Iterator for IndexRange<I> {
     }
 }
 
-/// Safety: a range is always of known length
+/// # Safety
+///
+/// A range is always of known length.
 unsafe impl<I: Index> TrustedLen for IndexRange<I> {}

--- a/crates/polars-core/src/chunked_array/array/iterator.rs
+++ b/crates/polars-core/src/chunked_array/array/iterator.rs
@@ -103,6 +103,7 @@ impl ArrayChunked {
     }
 
     /// Apply a closure `F` to each array.
+    ///
     /// # Safety
     /// Return series of `F` must has the same dtype and number of elements as input.
     #[must_use]
@@ -124,6 +125,7 @@ impl ArrayChunked {
     }
 
     /// Zip with a `ChunkedArray` then apply a binary function `F` elementwise.
+    ///
     /// # Safety
     //  Return series of `F` must has the same dtype and number of elements as input series.
     #[must_use]

--- a/crates/polars-core/src/chunked_array/builder/fixed_size_list.rs
+++ b/crates/polars-core/src/chunked_array/builder/fixed_size_list.rs
@@ -16,7 +16,8 @@ pub(crate) struct FixedSizeListNumericBuilder<T: NativeType> {
 }
 
 impl<T: NativeType> FixedSizeListNumericBuilder<T> {
-    /// SAFETY
+    /// # Safety
+    ///
     /// The caller must ensure that the physical numerical type match logical type.
     pub(crate) unsafe fn new(
         name: &str,

--- a/crates/polars-core/src/chunked_array/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/list/mod.rs
@@ -30,6 +30,7 @@ impl ListChunked {
     }
 
     /// Set the logical type of the [`ListChunked`].
+    ///
     /// # Safety
     /// The caller must ensure that the logical type given fits the physical type of the array.
     pub unsafe fn to_logical(&mut self, inner_dtype: DataType) {

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -545,6 +545,7 @@ impl DataFrame {
 
     #[inline]
     /// Get mutable access to the underlying columns.
+    ///
     /// # Safety
     /// The caller must ensure the length of all [`Series`] remains equal.
     pub unsafe fn get_columns_mut(&mut self) -> &mut Vec<Series> {

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -212,6 +212,7 @@ pub trait SeriesTrait:
     fn chunks(&self) -> &Vec<ArrayRef>;
 
     /// Underlying chunks.
+    ///
     /// # Safety
     /// The caller must ensure the length and the data types of `ArrayRef` does not change.
     unsafe fn chunks_mut(&mut self) -> &mut Vec<ArrayRef>;
@@ -459,6 +460,7 @@ pub trait SeriesTrait:
 
     #[cfg(feature = "object")]
     /// Get the value at this index as a downcastable Any trait ref.
+    ///
     /// # Safety
     /// This function doesn't do any bound checks.
     unsafe fn get_object_chunked_unchecked(

--- a/crates/polars-core/src/series/unstable.rs
+++ b/crates/polars-core/src/series/unstable.rs
@@ -45,6 +45,7 @@ impl<'a> UnstableSeries<'a> {
     }
 
     /// Creates a new `[UnsafeSeries]`
+    ///
     /// # Safety
     /// Inner chunks must be from `Series` otherwise the dtype may be incorrect and lead to UB.
     #[inline]

--- a/crates/polars-io/src/csv/read.rs
+++ b/crates/polars-io/src/csv/read.rs
@@ -73,7 +73,8 @@ impl NullValuesCompiled {
         }
     }
 
-    /// Safety
+    /// # Safety
+    ///
     /// The caller must ensure that `index` is in bounds
     pub(super) unsafe fn is_null(&self, field: &[u8], index: usize) -> bool {
         use NullValuesCompiled::*;

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -111,7 +111,10 @@ pub(super) fn array_iter_to_series(
 /// Materializes hive partitions.
 /// We have a special num_rows arg, as df can be empty when a projection contains
 /// only hive partition columns.
-/// Safety: num_rows equals the height of the df when the df height is non-zero.
+///
+/// # Safety
+///
+/// num_rows equals the height of the df when the df height is non-zero.
 pub(crate) fn materialize_hive_partitions(
     df: &mut DataFrame,
     hive_partition_columns: Option<&[Series]>,

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -8,6 +8,7 @@ use crate::frame::IntoDf;
 
 pub trait DfTake: IntoDf {
     /// Take elements by a slice of [`ChunkId`]s.
+    ///
     /// # Safety
     /// Does not do any bound checks.
     /// `sorted` indicates if the chunks are sorted.
@@ -19,6 +20,7 @@ pub trait DfTake: IntoDf {
         DataFrame::new_no_checks(cols)
     }
     /// Take elements by a slice of optional [`ChunkId`]s.
+    ///
     /// # Safety
     /// Does not do any bound checks.
     unsafe fn _take_opt_chunked_unchecked_seq(&self, idx: &[Option<ChunkId>]) -> DataFrame {


### PR DESCRIPTION
Make sure the Safety section is a proper section indicated with a `#` and preceeded by a blank line.

See: https://rust-lang.github.io/rust-clippy/master/#/missing_safety_doc