### PR TITLE
chore(rust): Format safety comments

### DIFF
--- a/crates/polars-arrow/src/array/binary/data.rs
+++ b/crates/polars-arrow/src/array/binary/data.rs
@@ -15,7 +15,7 @@ impl<O: Offset> Arrow2Arrow for BinaryArray<O> {
             ])
             .nulls(self.validity.as_ref().map(|b| b.clone().into()));
 
-        // Safety: Array is valid
+        // SAFETY: Array is valid
         unsafe { builder.build_unchecked() }
     }
 
@@ -29,7 +29,7 @@ impl<O: Offset> Arrow2Arrow for BinaryArray<O> {
 
         let buffers = data.buffers();
 
-        // Safety: ArrayData is valid
+        // SAFETY: ArrayData is valid
         let mut offsets = unsafe { OffsetsBuffer::new_unchecked(buffers[0].clone().into()) };
         offsets.slice(data.offset(), data.len() + 1);
 

--- a/crates/polars-arrow/src/array/binary/mod.rs
+++ b/crates/polars-arrow/src/array/binary/mod.rs
@@ -258,7 +258,7 @@ impl<O: Offset> BinaryArray<O> {
         use Either::*;
         if let Some(bitmap) = self.validity {
             match bitmap.into_mut() {
-                // Safety: invariants are preserved
+                // SAFETY: invariants are preserved
                 Left(bitmap) => Left(BinaryArray::new(
                     self.data_type,
                     self.offsets,

--- a/crates/polars-arrow/src/array/binary/mutable.rs
+++ b/crates/polars-arrow/src/array/binary/mutable.rs
@@ -325,7 +325,7 @@ impl<O: Offset> MutableBinaryArray<O> {
         P: AsRef<[u8]>,
         I: TrustedLen<Item = P>,
     {
-        // Safety: The iterator is `TrustedLen`
+        // SAFETY: The iterator is `TrustedLen`
         unsafe { self.extend_trusted_len_values_unchecked(iterator) }
     }
 
@@ -373,7 +373,7 @@ impl<O: Offset> MutableBinaryArray<O> {
         P: AsRef<[u8]>,
         I: TrustedLen<Item = Option<P>>,
     {
-        // Safety: The iterator is `TrustedLen`
+        // SAFETY: The iterator is `TrustedLen`
         unsafe { self.extend_trusted_len_unchecked(iterator) }
     }
 

--- a/crates/polars-arrow/src/array/boolean/data.rs
+++ b/crates/polars-arrow/src/array/boolean/data.rs
@@ -15,7 +15,7 @@ impl Arrow2Arrow for BooleanArray {
             .buffers(vec![buffer.into_inner().into_inner()])
             .nulls(self.validity.as_ref().map(|b| b.clone().into()));
 
-        // Safety: Array is valid
+        // SAFETY: Array is valid
         unsafe { builder.build_unchecked() }
     }
 

--- a/crates/polars-arrow/src/array/boolean/mutable.rs
+++ b/crates/polars-arrow/src/array/boolean/mutable.rs
@@ -136,7 +136,7 @@ impl MutableBooleanArray {
     where
         I: TrustedLen<Item = bool>,
     {
-        // Safety: `I` is `TrustedLen`
+        // SAFETY: `I` is `TrustedLen`
         unsafe { self.extend_trusted_len_values_unchecked(iterator) }
     }
 
@@ -167,7 +167,7 @@ impl MutableBooleanArray {
         P: std::borrow::Borrow<bool>,
         I: TrustedLen<Item = Option<P>>,
     {
-        // Safety: `I` is `TrustedLen`
+        // SAFETY: `I` is `TrustedLen`
         unsafe { self.extend_trusted_len_unchecked(iterator) }
     }
 
@@ -297,7 +297,7 @@ impl MutableBooleanArray {
         P: std::borrow::Borrow<bool>,
         I: TrustedLen<Item = Option<P>>,
     {
-        // Safety: `I` is `TrustedLen`
+        // SAFETY: `I` is `TrustedLen`
         unsafe { Self::from_trusted_len_iter_unchecked(iterator) }
     }
 
@@ -331,7 +331,7 @@ impl MutableBooleanArray {
         P: std::borrow::Borrow<bool>,
         I: TrustedLen<Item = std::result::Result<Option<P>, E>>,
     {
-        // Safety: `I` is `TrustedLen`
+        // SAFETY: `I` is `TrustedLen`
         unsafe { Self::try_from_trusted_len_iter_unchecked(iterator) }
     }
 
@@ -555,7 +555,7 @@ impl TryExtendFromSelf for MutableBooleanArray {
         extend_validity(self.len(), &mut self.validity, &other.validity);
 
         let slice = other.values.as_slice();
-        // safety: invariant offset + length <= slice.len()
+        // SAFETY: invariant offset + length <= slice.len()
         unsafe {
             self.values
                 .extend_from_slice_unchecked(slice, 0, other.values.len());

--- a/crates/polars-arrow/src/array/dictionary/data.rs
+++ b/crates/polars-arrow/src/array/dictionary/data.rs
@@ -13,7 +13,7 @@ impl<K: DictionaryKey> Arrow2Arrow for DictionaryArray<K> {
             .data_type(self.data_type.clone().into())
             .child_data(vec![to_data(self.values.as_ref())]);
 
-        // Safety: Dictionary is valid
+        // SAFETY: Dictionary is valid
         unsafe { builder.build_unchecked() }
     }
 
@@ -35,7 +35,7 @@ impl<K: DictionaryKey> Arrow2Arrow for DictionaryArray<K> {
             .len(data.len())
             .nulls(data.nulls().cloned());
 
-        // Safety: Dictionary is valid
+        // SAFETY: Dictionary is valid
         let key_data = unsafe { key_builder.build_unchecked() };
         let keys = PrimitiveArray::from_data(&key_data);
         let values = from_data(&data.child_data()[0]);

--- a/crates/polars-arrow/src/array/dictionary/mod.rs
+++ b/crates/polars-arrow/src/array/dictionary/mod.rs
@@ -340,14 +340,14 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// Returns an iterator of the keys' values of the [`DictionaryArray`] as `usize`
     #[inline]
     pub fn keys_values_iter(&self) -> impl TrustedLen<Item = usize> + Clone + '_ {
-        // SAFETY - invariant of the struct
+        // SAFETY: invariant of the struct
         self.keys.values_iter().map(|x| unsafe { x.as_usize() })
     }
 
     /// Returns an iterator of the keys' of the [`DictionaryArray`] as `usize`
     #[inline]
     pub fn keys_iter(&self) -> impl TrustedLen<Item = Option<usize>> + Clone + '_ {
-        // SAFETY - invariant of the struct
+        // SAFETY: invariant of the struct
         self.keys.iter().map(|x| x.map(|x| unsafe { x.as_usize() }))
     }
 
@@ -356,7 +356,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// This function panics iff `index >= self.len()`
     #[inline]
     pub fn key_value(&self, index: usize) -> usize {
-        // SAFETY - invariant of the struct
+        // SAFETY: invariant of the struct
         unsafe { self.keys.values()[index].as_usize() }
     }
 
@@ -374,7 +374,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// This function panics iff `index >= self.len()`
     #[inline]
     pub fn value(&self, index: usize) -> Box<dyn Scalar> {
-        // SAFETY - invariant of this struct
+        // SAFETY: invariant of this struct
         let index = unsafe { self.keys.value(index).as_usize() };
         new_scalar(self.values.as_ref(), index)
     }

--- a/crates/polars-arrow/src/array/dictionary/mod.rs
+++ b/crates/polars-arrow/src/array/dictionary/mod.rs
@@ -146,7 +146,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
 
         if keys.null_count() != keys.len() {
             if K::always_fits_usize() {
-                // safety: we just checked that conversion to `usize` always
+                // SAFETY: we just checked that conversion to `usize` always
                 // succeeds
                 unsafe { check_indexes_unchecked(keys.values(), values.len()) }?;
             } else {
@@ -340,14 +340,14 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// Returns an iterator of the keys' values of the [`DictionaryArray`] as `usize`
     #[inline]
     pub fn keys_values_iter(&self) -> impl TrustedLen<Item = usize> + Clone + '_ {
-        // safety - invariant of the struct
+        // SAFETY - invariant of the struct
         self.keys.values_iter().map(|x| unsafe { x.as_usize() })
     }
 
     /// Returns an iterator of the keys' of the [`DictionaryArray`] as `usize`
     #[inline]
     pub fn keys_iter(&self) -> impl TrustedLen<Item = Option<usize>> + Clone + '_ {
-        // safety - invariant of the struct
+        // SAFETY - invariant of the struct
         self.keys.iter().map(|x| x.map(|x| unsafe { x.as_usize() }))
     }
 
@@ -356,7 +356,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// This function panics iff `index >= self.len()`
     #[inline]
     pub fn key_value(&self, index: usize) -> usize {
-        // safety - invariant of the struct
+        // SAFETY - invariant of the struct
         unsafe { self.keys.values()[index].as_usize() }
     }
 
@@ -374,7 +374,7 @@ impl<K: DictionaryKey> DictionaryArray<K> {
     /// This function panics iff `index >= self.len()`
     #[inline]
     pub fn value(&self, index: usize) -> Box<dyn Scalar> {
-        // safety - invariant of this struct
+        // SAFETY - invariant of this struct
         let index = unsafe { self.keys.value(index).as_usize() };
         new_scalar(self.values.as_ref(), index)
     }

--- a/crates/polars-arrow/src/array/dictionary/mutable.rs
+++ b/crates/polars-arrow/src/array/dictionary/mutable.rs
@@ -21,7 +21,7 @@ pub struct MutableDictionaryArray<K: DictionaryKey, M: MutableArray> {
 
 impl<K: DictionaryKey, M: MutableArray> From<MutableDictionaryArray<K, M>> for DictionaryArray<K> {
     fn from(other: MutableDictionaryArray<K, M>) -> Self {
-        // SAFETY - the invariant of this struct ensures that this is up-held
+        // SAFETY: the invariant of this struct ensures that this is up-held
         unsafe {
             DictionaryArray::<K>::try_new_unchecked(
                 other.data_type,

--- a/crates/polars-arrow/src/array/dictionary/mutable.rs
+++ b/crates/polars-arrow/src/array/dictionary/mutable.rs
@@ -21,7 +21,7 @@ pub struct MutableDictionaryArray<K: DictionaryKey, M: MutableArray> {
 
 impl<K: DictionaryKey, M: MutableArray> From<MutableDictionaryArray<K, M>> for DictionaryArray<K> {
     fn from(other: MutableDictionaryArray<K, M>) -> Self {
-        // Safety - the invariant of this struct ensures that this is up-held
+        // SAFETY - the invariant of this struct ensures that this is up-held
         unsafe {
             DictionaryArray::<K>::try_new_unchecked(
                 other.data_type,

--- a/crates/polars-arrow/src/array/dictionary/value_map.rs
+++ b/crates/polars-arrow/src/array/dictionary/value_map.rs
@@ -81,12 +81,12 @@ impl<K: DictionaryKey, M: MutableArray> ValueMap<K, M> {
         );
         for index in 0..values.len() {
             let key = K::try_from(index).map_err(|_| polars_err!(ComputeError: "overflow"))?;
-            // safety: we only iterate within bounds
+            // SAFETY: we only iterate within bounds
             let value = unsafe { values.value_unchecked_at(index) };
             let hash = ahash_hash(value.borrow());
 
             let entry = map.raw_entry_mut().from_hash(hash, |item| {
-                // safety: invariant of the struct, it's always in bounds since we maintain it
+                // SAFETY: invariant of the struct, it's always in bounds since we maintain it
                 let stored_value = unsafe { values.value_unchecked_at(item.key.as_usize()) };
                 stored_value.borrow() == value.borrow()
             });
@@ -135,9 +135,9 @@ impl<K: DictionaryKey, M: MutableArray> ValueMap<K, M> {
     {
         let hash = ahash_hash(value.as_indexed());
         let entry = self.map.raw_entry_mut().from_hash(hash, |item| {
-            // safety: we've already checked (the inverse) when we pushed it, so it should be ok?
+            // SAFETY: we've already checked (the inverse) when we pushed it, so it should be ok?
             let index = unsafe { item.key.as_usize() };
-            // safety: invariant of the struct, it's always in bounds since we maintain it
+            // SAFETY: invariant of the struct, it's always in bounds since we maintain it
             let stored_value = unsafe { self.values.value_unchecked_at(index) };
             stored_value.borrow() == value.as_indexed()
         });

--- a/crates/polars-arrow/src/array/fixed_size_binary/data.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/data.rs
@@ -13,7 +13,7 @@ impl Arrow2Arrow for FixedSizeBinaryArray {
             .buffers(vec![self.values.clone().into()])
             .nulls(self.validity.as_ref().map(|b| b.clone().into()));
 
-        // Safety: Array is valid
+        // SAFETY: Array is valid
         unsafe { builder.build_unchecked() }
     }
 

--- a/crates/polars-arrow/src/array/fixed_size_list/data.rs
+++ b/crates/polars-arrow/src/array/fixed_size_list/data.rs
@@ -12,7 +12,7 @@ impl Arrow2Arrow for FixedSizeListArray {
             .nulls(self.validity.as_ref().map(|b| b.clone().into()))
             .child_data(vec![to_data(self.values.as_ref())]);
 
-        // Safety: Array is valid
+        // SAFETY: Array is valid
         unsafe { builder.build_unchecked() }
     }
 

--- a/crates/polars-arrow/src/array/growable/boolean.rs
+++ b/crates/polars-arrow/src/array/growable/boolean.rs
@@ -57,7 +57,7 @@ impl<'a> Growable<'a> for GrowableBoolean<'a> {
         let values = array.values();
 
         let (slice, offset, _) = values.as_slice();
-        // safety: invariant offset + length <= slice.len()
+        // SAFETY: invariant offset + length <= slice.len()
         unsafe {
             self.values
                 .extend_from_slice_unchecked(slice, start + offset, len);

--- a/crates/polars-arrow/src/array/growable/dictionary.rs
+++ b/crates/polars-arrow/src/array/growable/dictionary.rs
@@ -82,7 +82,7 @@ impl<'a, T: DictionaryKey> GrowableDictionary<'a, T> {
             validity.map(|v| v.into()),
         );
 
-        // Safety - the invariant of this struct ensures that this is up-held
+        // SAFETY - the invariant of this struct ensures that this is up-held
         unsafe {
             DictionaryArray::<T>::try_new_unchecked(
                 self.data_type.clone(),

--- a/crates/polars-arrow/src/array/growable/dictionary.rs
+++ b/crates/polars-arrow/src/array/growable/dictionary.rs
@@ -82,7 +82,7 @@ impl<'a, T: DictionaryKey> GrowableDictionary<'a, T> {
             validity.map(|v| v.into()),
         );
 
-        // SAFETY - the invariant of this struct ensures that this is up-held
+        // SAFETY: the invariant of this struct ensures that this is up-held
         unsafe {
             DictionaryArray::<T>::try_new_unchecked(
                 self.data_type.clone(),

--- a/crates/polars-arrow/src/array/growable/utils.rs
+++ b/crates/polars-arrow/src/array/growable/utils.rs
@@ -38,7 +38,7 @@ pub(super) fn extend_validity(
             Some(validity) => {
                 debug_assert!(start + len <= validity.len());
                 let (slice, offset, _) = validity.as_slice();
-                // safety: invariant offset + length <= slice.len()
+                // SAFETY: invariant offset + length <= slice.len()
                 unsafe {
                     mutable_validity.extend_from_slice_unchecked(slice, start + offset, len);
                 }

--- a/crates/polars-arrow/src/array/list/data.rs
+++ b/crates/polars-arrow/src/array/list/data.rs
@@ -14,7 +14,7 @@ impl<O: Offset> Arrow2Arrow for ListArray<O> {
             .nulls(self.validity.as_ref().map(|b| b.clone().into()))
             .child_data(vec![to_data(self.values.as_ref())]);
 
-        // Safety: Array is valid
+        // SAFETY: Array is valid
         unsafe { builder.build_unchecked() }
     }
 

--- a/crates/polars-arrow/src/array/list/mod.rs
+++ b/crates/polars-arrow/src/array/list/mod.rs
@@ -144,7 +144,7 @@ impl<O: Offset> ListArray<O> {
     #[inline]
     pub fn value(&self, i: usize) -> Box<dyn Array> {
         assert!(i < self.len());
-        // Safety: invariant of this function
+        // SAFETY: invariant of this function
         unsafe { self.value_unchecked(i) }
     }
 
@@ -153,11 +153,11 @@ impl<O: Offset> ListArray<O> {
     /// Assumes that the `i < self.len`.
     #[inline]
     pub unsafe fn value_unchecked(&self, i: usize) -> Box<dyn Array> {
-        // safety: the invariant of the function
+        // SAFETY: the invariant of the function
         let (start, end) = self.offsets.start_end_unchecked(i);
         let length = end - start;
 
-        // safety: the invariant of the struct
+        // SAFETY: the invariant of the struct
         self.values.sliced_unchecked(start, length)
     }
 

--- a/crates/polars-arrow/src/array/map/data.rs
+++ b/crates/polars-arrow/src/array/map/data.rs
@@ -14,7 +14,7 @@ impl Arrow2Arrow for MapArray {
             .nulls(self.validity.as_ref().map(|b| b.clone().into()))
             .child_data(vec![to_data(self.field.as_ref())]);
 
-        // Safety: Array is valid
+        // SAFETY: Array is valid
         unsafe { builder.build_unchecked() }
     }
 

--- a/crates/polars-arrow/src/array/map/iterator.rs
+++ b/crates/polars-arrow/src/array/map/iterator.rs
@@ -32,7 +32,7 @@ impl<'a> Iterator for MapValuesIter<'a> {
         }
         let old = self.index;
         self.index += 1;
-        // Safety:
+        // SAFETY:
         // self.end is maximized by the length of the array
         Some(unsafe { self.array.value_unchecked(old) })
     }
@@ -52,7 +52,7 @@ impl<'a> DoubleEndedIterator for MapValuesIter<'a> {
             None
         } else {
             self.end -= 1;
-            // Safety:
+            // SAFETY:
             // self.end is maximized by the length of the array
             Some(unsafe { self.array.value_unchecked(self.end) })
         }

--- a/crates/polars-arrow/src/array/null.rs
+++ b/crates/polars-arrow/src/array/null.rs
@@ -187,7 +187,7 @@ mod arrow {
         pub fn to_data(&self) -> ArrayData {
             let builder = ArrayDataBuilder::new(arrow_schema::DataType::Null).len(self.len());
 
-            // Safety: safe by construction
+            // SAFETY: safe by construction
             unsafe { builder.build_unchecked() }
         }
 

--- a/crates/polars-arrow/src/array/physical_binary.rs
+++ b/crates/polars-arrow/src/array/physical_binary.rs
@@ -219,7 +219,7 @@ pub(crate) fn extend_validity(
     if let Some(other) = other {
         if let Some(validity) = validity {
             let slice = other.as_slice();
-            // safety: invariant offset + length <= slice.len()
+            // SAFETY: invariant offset + length <= slice.len()
             unsafe { validity.extend_from_slice_unchecked(slice, 0, other.len()) }
         } else {
             let mut new_validity = MutableBitmap::from_len_set(length);

--- a/crates/polars-arrow/src/array/primitive/data.rs
+++ b/crates/polars-arrow/src/array/primitive/data.rs
@@ -14,7 +14,7 @@ impl<T: NativeType> Arrow2Arrow for PrimitiveArray<T> {
             .buffers(vec![self.values.clone().into()])
             .nulls(self.validity.as_ref().map(|b| b.clone().into()));
 
-        // Safety: Array is valid
+        // SAFETY: Array is valid
         unsafe { builder.build_unchecked() }
     }
 

--- a/crates/polars-arrow/src/array/primitive/mutable.rs
+++ b/crates/polars-arrow/src/array/primitive/mutable.rs
@@ -312,7 +312,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     /// Panics iff index is larger than `self.len()`.
     pub fn set(&mut self, index: usize, value: Option<T>) {
         assert!(index < self.len());
-        // Safety:
+        // SAFETY:
         // we just checked bounds
         unsafe { self.set_unchecked(index, value) }
     }

--- a/crates/polars-arrow/src/array/specification.rs
+++ b/crates/polars-arrow/src/array/specification.rs
@@ -93,7 +93,7 @@ pub fn try_check_utf8<O: Offset>(offsets: &[O], values: &[u8]) -> PolarsResult<(
         for start in starts {
             let start = start.to_usize();
 
-            // Safety: `try_check_offsets_bounds` just checked for bounds
+            // SAFETY: `try_check_offsets_bounds` just checked for bounds
             let b = *unsafe { values.get_unchecked(start) };
 
             // A valid code-point iff it does not start with 0b10xxxxxx

--- a/crates/polars-arrow/src/array/struct_/data.rs
+++ b/crates/polars-arrow/src/array/struct_/data.rs
@@ -12,7 +12,7 @@ impl Arrow2Arrow for StructArray {
             .nulls(self.validity.as_ref().map(|b| b.clone().into()))
             .child_data(self.values.iter().map(|x| to_data(x.as_ref())).collect());
 
-        // Safety: Array is valid
+        // SAFETY: Array is valid
         unsafe { builder.build_unchecked() }
     }
 

--- a/crates/polars-arrow/src/array/struct_/iterator.rs
+++ b/crates/polars-arrow/src/array/struct_/iterator.rs
@@ -31,7 +31,7 @@ impl<'a> Iterator for StructValueIter<'a> {
         let old = self.index;
         self.index += 1;
 
-        // Safety:
+        // SAFETY:
         // self.end is maximized by the length of the array
         Some(
             self.array
@@ -58,7 +58,7 @@ impl<'a> DoubleEndedIterator for StructValueIter<'a> {
         } else {
             self.end -= 1;
 
-            // Safety:
+            // SAFETY:
             // self.end is maximized by the length of the array
             Some(
                 self.array

--- a/crates/polars-arrow/src/array/union/data.rs
+++ b/crates/polars-arrow/src/array/union/data.rs
@@ -25,7 +25,7 @@ impl Arrow2Arrow for UnionArray {
                 ),
         };
 
-        // Safety: Array is valid
+        // SAFETY: Array is valid
         unsafe { builder.build_unchecked() }
     }
 

--- a/crates/polars-arrow/src/array/union/mod.rs
+++ b/crates/polars-arrow/src/array/union/mod.rs
@@ -130,7 +130,7 @@ impl UnionArray {
 
             Some(hash)
         } else {
-            // Safety: every type in types is smaller than number of fields
+            // SAFETY: every type in types is smaller than number of fields
             let mut is_valid = true;
             for &type_ in types.iter() {
                 if type_ < 0 || type_ >= number_of_fields {
@@ -301,15 +301,15 @@ impl UnionArray {
     #[inline]
     pub unsafe fn index_unchecked(&self, index: usize) -> (usize, usize) {
         debug_assert!(index < self.len());
-        // Safety: assumption of the function
+        // SAFETY: assumption of the function
         let type_ = unsafe { *self.types.get_unchecked(index) };
-        // Safety: assumption of the struct
+        // SAFETY: assumption of the struct
         let type_ = self
             .map
             .as_ref()
             .map(|map| unsafe { *map.get_unchecked(type_ as usize) })
             .unwrap_or(type_ as usize);
-        // Safety: assumption of the function
+        // SAFETY: assumption of the function
         let index = self.field_slot_unchecked(index);
         (type_, index)
     }
@@ -328,7 +328,7 @@ impl UnionArray {
     pub unsafe fn value_unchecked(&self, index: usize) -> Box<dyn Scalar> {
         debug_assert!(index < self.len());
         let (type_, index) = self.index_unchecked(index);
-        // Safety: assumption of the struct
+        // SAFETY: assumption of the struct
         debug_assert!(type_ < self.fields.len());
         let field = self.fields.get_unchecked(type_).as_ref();
         new_scalar(field, index)

--- a/crates/polars-arrow/src/array/utf8/data.rs
+++ b/crates/polars-arrow/src/array/utf8/data.rs
@@ -15,7 +15,7 @@ impl<O: Offset> Arrow2Arrow for Utf8Array<O> {
             ])
             .nulls(self.validity.as_ref().map(|b| b.clone().into()));
 
-        // Safety: Array is valid
+        // SAFETY: Array is valid
         unsafe { builder.build_unchecked() }
     }
 
@@ -28,7 +28,7 @@ impl<O: Offset> Arrow2Arrow for Utf8Array<O> {
 
         let buffers = data.buffers();
 
-        // Safety: ArrayData is valid
+        // SAFETY: ArrayData is valid
         let mut offsets = unsafe { OffsetsBuffer::new_unchecked(buffers[0].clone().into()) };
         offsets.slice(data.offset(), data.len() + 1);
 

--- a/crates/polars-arrow/src/array/utf8/mod.rs
+++ b/crates/polars-arrow/src/array/utf8/mod.rs
@@ -256,7 +256,7 @@ impl<O: Offset> Utf8Array<O> {
         use Either::*;
         if let Some(bitmap) = self.validity {
             match bitmap.into_mut() {
-                // Safety: invariants are preserved
+                // SAFETY: invariants are preserved
                 Left(bitmap) => Left(unsafe {
                     Utf8Array::new_unchecked(
                         self.data_type,
@@ -267,7 +267,7 @@ impl<O: Offset> Utf8Array<O> {
                 }),
                 Right(mutable_bitmap) => match (self.values.into_mut(), self.offsets.into_mut()) {
                     (Left(values), Left(offsets)) => {
-                        // Safety: invariants are preserved
+                        // SAFETY: invariants are preserved
                         Left(unsafe {
                             Utf8Array::new_unchecked(
                                 self.data_type,
@@ -278,7 +278,7 @@ impl<O: Offset> Utf8Array<O> {
                         })
                     },
                     (Left(values), Right(offsets)) => {
-                        // Safety: invariants are preserved
+                        // SAFETY: invariants are preserved
                         Left(unsafe {
                             Utf8Array::new_unchecked(
                                 self.data_type,
@@ -289,7 +289,7 @@ impl<O: Offset> Utf8Array<O> {
                         })
                     },
                     (Right(values), Left(offsets)) => {
-                        // Safety: invariants are preserved
+                        // SAFETY: invariants are preserved
                         Left(unsafe {
                             Utf8Array::new_unchecked(
                                 self.data_type,

--- a/crates/polars-arrow/src/array/utf8/mutable_values.rs
+++ b/crates/polars-arrow/src/array/utf8/mutable_values.rs
@@ -23,7 +23,7 @@ pub struct MutableUtf8ValuesArray<O: Offset> {
 
 impl<O: Offset> From<MutableUtf8ValuesArray<O>> for Utf8Array<O> {
     fn from(other: MutableUtf8ValuesArray<O>) -> Self {
-        // Safety:
+        // SAFETY:
         // `MutableUtf8ValuesArray` has the same invariants as `Utf8Array` and thus
         // `Utf8Array` can be safely created from `MutableUtf8ValuesArray` without checks.
         unsafe {
@@ -39,7 +39,7 @@ impl<O: Offset> From<MutableUtf8ValuesArray<O>> for Utf8Array<O> {
 
 impl<O: Offset> From<MutableUtf8ValuesArray<O>> for MutableUtf8Array<O> {
     fn from(other: MutableUtf8ValuesArray<O>) -> Self {
-        // Safety:
+        // SAFETY:
         // `MutableUtf8ValuesArray` has the same invariants as `MutableUtf8Array`
         unsafe {
             MutableUtf8Array::<O>::new_unchecked(other.data_type, other.offsets, other.values, None)
@@ -187,7 +187,7 @@ impl<O: Offset> MutableUtf8ValuesArray<O> {
         self.offsets.pop()?;
         let start = self.offsets.last().to_usize();
         let value = self.values.split_off(start);
-        // Safety: utf8 is validated on initialization
+        // SAFETY: utf8 is validated on initialization
         Some(unsafe { String::from_utf8_unchecked(value) })
     }
 

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -493,7 +493,7 @@ impl From<Bitmap> for arrow_buffer::buffer::NullBuffer {
         let null_count = value.unset_bits();
         let buffer = crate::buffer::to_buffer(value.bytes);
         let buffer = arrow_buffer::buffer::BooleanBuffer::new(buffer, value.offset, value.length);
-        // Safety: null count is accurate
+        // SAFETY: null count is accurate
         unsafe { arrow_buffer::buffer::NullBuffer::new_unchecked(buffer, null_count) }
     }
 }

--- a/crates/polars-arrow/src/bitmap/mutable.rs
+++ b/crates/polars-arrow/src/bitmap/mutable.rs
@@ -524,7 +524,7 @@ impl MutableBitmap {
     /// Extends `self` from a [`TrustedLen`] iterator.
     #[inline]
     pub fn extend_from_trusted_len_iter<I: TrustedLen<Item = bool>>(&mut self, iterator: I) {
-        // safety: I: TrustedLen
+        // SAFETY: I: TrustedLen
         unsafe { self.extend_from_trusted_len_iter_unchecked(iterator) }
     }
 
@@ -597,7 +597,7 @@ impl MutableBitmap {
     where
         I: TrustedLen<Item = bool>,
     {
-        // Safety: Iterator is `TrustedLen`
+        // SAFETY: Iterator is `TrustedLen`
         unsafe { Self::from_trusted_len_iter_unchecked(iterator) }
     }
 
@@ -729,7 +729,7 @@ impl MutableBitmap {
     #[inline]
     pub fn extend_from_slice(&mut self, slice: &[u8], offset: usize, length: usize) {
         assert!(offset + length <= slice.len() * 8);
-        // safety: invariant is asserted
+        // SAFETY: invariant is asserted
         unsafe { self.extend_from_slice_unchecked(slice, offset, length) }
     }
 
@@ -737,7 +737,7 @@ impl MutableBitmap {
     #[inline]
     pub fn extend_from_bitmap(&mut self, bitmap: &Bitmap) {
         let (slice, offset, length) = bitmap.as_slice();
-        // safety: bitmap.as_slice adheres to the invariant
+        // SAFETY: bitmap.as_slice adheres to the invariant
         unsafe {
             self.extend_from_slice_unchecked(slice, offset, length);
         }

--- a/crates/polars-arrow/src/buffer/immutable.rs
+++ b/crates/polars-arrow/src/buffer/immutable.rs
@@ -113,7 +113,7 @@ impl<T> Buffer<T> {
     /// Returns the byte slice stored in this buffer
     #[inline]
     pub fn as_slice(&self) -> &[T] {
-        // Safety:
+        // SAFETY:
         // invariant of this struct `offset + length <= data.len()`
         debug_assert!(self.offset() + self.length <= self.storage.len());
         unsafe { std::slice::from_raw_parts(self.ptr, self.length) }
@@ -124,7 +124,7 @@ impl<T> Buffer<T> {
     /// `index` must be smaller than `len`
     #[inline]
     pub(super) unsafe fn get_unchecked(&self, index: usize) -> &T {
-        // Safety:
+        // SAFETY:
         // invariant of this function
         debug_assert!(index < self.length);
         unsafe { &*self.ptr.add(index) }
@@ -140,7 +140,7 @@ impl<T> Buffer<T> {
             offset + length <= self.len(),
             "the offset of the new Buffer cannot exceed the existing length"
         );
-        // Safety: we just checked bounds
+        // SAFETY: we just checked bounds
         unsafe { self.sliced_unchecked(offset, length) }
     }
 
@@ -153,7 +153,7 @@ impl<T> Buffer<T> {
             offset + length <= self.len(),
             "the offset of the new Buffer cannot exceed the existing length"
         );
-        // Safety: we just checked bounds
+        // SAFETY: we just checked bounds
         unsafe { self.slice_unchecked(offset, length) }
     }
 

--- a/crates/polars-arrow/src/buffer/mod.rs
+++ b/crates/polars-arrow/src/buffer/mod.rs
@@ -78,7 +78,7 @@ pub(crate) fn to_buffer<T: crate::types::NativeType>(
     // This should never panic as ForeignVec pointer must be non-null
     let ptr = std::ptr::NonNull::new(value.as_ptr() as _).unwrap();
     let len = value.len() * std::mem::size_of::<T>();
-    // Safety: allocation is guaranteed to be valid for `len` bytes
+    // SAFETY: allocation is guaranteed to be valid for `len` bytes
     unsafe { arrow_buffer::Buffer::from_custom_allocation(ptr, len, value) }
 }
 
@@ -94,7 +94,7 @@ pub(crate) fn to_bytes<T: crate::types::NativeType>(value: arrow_buffer::Buffer)
 
     let owner = crate::buffer::BytesAllocator::Arrow(value);
 
-    // Safety: slice is valid for len elements of T
+    // SAFETY: slice is valid for len elements of T
     unsafe { Bytes::from_foreign(ptr, len, owner) }
 }
 

--- a/crates/polars-arrow/src/compute/cast/binary_to.rs
+++ b/crates/polars-arrow/src/compute/cast/binary_to.rs
@@ -156,7 +156,7 @@ fn fixed_size_to_offsets<O: Offset>(values_len: usize, fixed_size: usize) -> Off
         .step_by(fixed_size)
         .map(|v| O::from_as_usize(v))
         .collect();
-    // SAFETY
+    // SAFETY:
     // * every element is `>= 0`
     // * element at position `i` is >= than element at position `i-1`.
     unsafe { Offsets::new_unchecked(offsets) }

--- a/crates/polars-arrow/src/compute/cast/binary_to.rs
+++ b/crates/polars-arrow/src/compute/cast/binary_to.rs
@@ -156,7 +156,7 @@ fn fixed_size_to_offsets<O: Offset>(values_len: usize, fixed_size: usize) -> Off
         .step_by(fixed_size)
         .map(|v| O::from_as_usize(v))
         .collect();
-    // Safety
+    // SAFETY
     // * every element is `>= 0`
     // * element at position `i` is >= than element at position `i-1`.
     unsafe { Offsets::new_unchecked(offsets) }

--- a/crates/polars-arrow/src/compute/cast/dictionary_to.rs
+++ b/crates/polars-arrow/src/compute/cast/dictionary_to.rs
@@ -15,7 +15,7 @@ macro_rules! key_cast {
         if cast_keys.null_count() > $keys.null_count() {
             polars_bail!(ComputeError: "overflow")
         }
-        // Safety: this is safe because given a type `T` that fits in a `usize`, casting it to type `P` either overflows or also fits in a `usize`
+        // SAFETY: this is safe because given a type `T` that fits in a `usize`, casting it to type `P` either overflows or also fits in a `usize`
         unsafe {
              DictionaryArray::try_new_unchecked($to_datatype, cast_keys, $values.clone())
         }
@@ -92,7 +92,7 @@ where
             Box::new(values.data_type().clone()),
             is_ordered,
         );
-        // Safety: this is safe because given a type `T` that fits in a `usize`, casting it to type `P` either overflows or also fits in a `usize`
+        // SAFETY: this is safe because given a type `T` that fits in a `usize`, casting it to type `P` either overflows or also fits in a `usize`
         unsafe { DictionaryArray::try_new_unchecked(data_type, casted_keys, values.clone()) }
     }
 }
@@ -140,7 +140,7 @@ pub(super) fn dictionary_cast_dyn<K: DictionaryKey + num_traits::NumCast>(
             // create the appropriate array type
             let to_key_type = (*to_keys_type).into();
 
-            // Safety:
+            // SAFETY:
             // we return an error on overflow so the integers remain within bounds
             match_integer_type!(to_keys_type, |$T| {
                 key_cast!(keys, values, array, &to_key_type, $T, to_type.clone())

--- a/crates/polars-arrow/src/compute/cast/mod.rs
+++ b/crates/polars-arrow/src/compute/cast/mod.rs
@@ -154,7 +154,7 @@ fn cast_fixed_size_list_to_list<O: Offset>(
     let offsets = (0..=fixed.len())
         .map(|ix| O::from_as_usize(ix * fixed.size()))
         .collect::<Vec<_>>();
-    // Safety: offsets _are_ monotonically increasing
+    // SAFETY: offsets _are_ monotonically increasing
     let offsets = unsafe { Offsets::new_unchecked(offsets) };
 
     Ok(ListArray::<O>::new(
@@ -370,7 +370,7 @@ pub fn cast(
             let values = cast(array, &to.data_type, options)?;
             // create offsets, where if array.len() = 2, we have [0,1,2]
             let offsets = (0..=array.len() as i32).collect::<Vec<_>>();
-            // Safety: offsets _are_ monotonically increasing
+            // SAFETY: offsets _are_ monotonically increasing
             let offsets = unsafe { Offsets::new_unchecked(offsets) };
 
             let list_array = ListArray::<i32>::new(to_type.clone(), offsets.into(), values, None);
@@ -383,7 +383,7 @@ pub fn cast(
             let values = cast(array, &to.data_type, options)?;
             // create offsets, where if array.len() = 2, we have [0,1,2]
             let offsets = (0..=array.len() as i64).collect::<Vec<_>>();
-            // Safety: offsets _are_ monotonically increasing
+            // SAFETY: offsets _are_ monotonically increasing
             let offsets = unsafe { Offsets::new_unchecked(offsets) };
 
             let list_array = ListArray::<i64>::new(

--- a/crates/polars-arrow/src/compute/cast/primitive_to.rs
+++ b/crates/polars-arrow/src/compute/cast/primitive_to.rs
@@ -85,7 +85,7 @@ fn primitive_to_values_and_offsets<T: NativeType + SerPrimitive, O: Offset>(
         }
         values.set_len(offset);
         values.shrink_to_fit();
-        // Safety: offsets _are_ monotonically increasing
+        // SAFETY: offsets _are_ monotonically increasing
         let offsets = unsafe { Offsets::new_unchecked(offsets) };
 
         (values, offsets)

--- a/crates/polars-arrow/src/compute/cast/utf8_to.rs
+++ b/crates/polars-arrow/src/compute/cast/utf8_to.rs
@@ -38,7 +38,7 @@ pub fn utf8_to_large_utf8(from: &Utf8Array<i32>) -> Utf8Array<i64> {
     let values = from.values().clone();
 
     let offsets = from.offsets().into();
-    // Safety: sound because `values` fulfills the same invariants as `from.values()`
+    // SAFETY: sound because `values` fulfills the same invariants as `from.values()`
     unsafe { Utf8Array::<i64>::new_unchecked(data_type, offsets, values, validity) }
 }
 
@@ -49,7 +49,7 @@ pub fn utf8_large_to_utf8(from: &Utf8Array<i64>) -> PolarsResult<Utf8Array<i32>>
     let values = from.values().clone();
     let offsets = from.offsets().try_into()?;
 
-    // Safety: sound because `values` fulfills the same invariants as `from.values()`
+    // SAFETY: sound because `values` fulfills the same invariants as `from.values()`
     Ok(unsafe { Utf8Array::<i32>::new_unchecked(data_type, offsets, values, validity) })
 }
 
@@ -58,7 +58,7 @@ pub fn utf8_to_binary<O: Offset>(
     from: &Utf8Array<O>,
     to_data_type: ArrowDataType,
 ) -> BinaryArray<O> {
-    // Safety: erasure of an invariant is always safe
+    // SAFETY: erasure of an invariant is always safe
     unsafe {
         BinaryArray::<O>::new(
             to_data_type,

--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -437,7 +437,7 @@ unsafe fn create_child(
         );
     }
 
-    // SAFETY - part of the invariant
+    // SAFETY: part of the invariant
     let arr_ptr = unsafe { *array.children.add(index) };
 
     // catch what we can
@@ -448,7 +448,7 @@ unsafe fn create_child(
         )
     }
 
-    // SAFETY - invariant of this function
+    // SAFETY: invariant of this function
     let arr_ptr = unsafe { &*arr_ptr };
     Ok(ArrowArrayChild::new(arr_ptr, data_type, parent))
 }

--- a/crates/polars-arrow/src/ffi/array.rs
+++ b/crates/polars-arrow/src/ffi/array.rs
@@ -437,7 +437,7 @@ unsafe fn create_child(
         );
     }
 
-    // Safety - part of the invariant
+    // SAFETY - part of the invariant
     let arr_ptr = unsafe { *array.children.add(index) };
 
     // catch what we can
@@ -448,7 +448,7 @@ unsafe fn create_child(
         )
     }
 
-    // Safety - invariant of this function
+    // SAFETY - invariant of this function
     let arr_ptr = unsafe { &*arr_ptr };
     Ok(ArrowArrayChild::new(arr_ptr, data_type, parent))
 }
@@ -472,7 +472,7 @@ unsafe fn create_dictionary(
             )
         }
 
-        // safety: part of the invariant
+        // SAFETY: part of the invariant
         let array = unsafe { &*array.dictionary };
         Ok(Some(ArrowArrayChild::new(array, data_type, parent)))
     } else {

--- a/crates/polars-arrow/src/ffi/mmap.rs
+++ b/crates/polars-arrow/src/ffi/mmap.rs
@@ -118,7 +118,7 @@ pub unsafe fn slice_and_owner<T: NativeType, O>(slice: &[T], owner: O) -> Primit
     let ptr = data.as_ptr();
     let data = Arc::new(owner);
 
-    // safety: the underlying assumption of this function: the array will not be used
+    // SAFETY: the underlying assumption of this function: the array will not be used
     // beyond the
     let array = create_array(
         data,
@@ -131,7 +131,7 @@ pub unsafe fn slice_and_owner<T: NativeType, O>(slice: &[T], owner: O) -> Primit
     );
     let array = InternalArrowArray::new(array, T::PRIMITIVE.into());
 
-    // safety: we just created a valid array
+    // SAFETY: we just created a valid array
     unsafe { PrimitiveArray::<T>::try_from_ffi(array) }.unwrap()
 }
 
@@ -181,7 +181,7 @@ pub unsafe fn bitmap_and_owner<O>(
     let ptr = data.as_ptr();
     let data = Arc::new(owner);
 
-    // safety: the underlying assumption of this function: the array will not be used
+    // SAFETY: the underlying assumption of this function: the array will not be used
     // beyond the
     let array = create_array(
         data,
@@ -194,6 +194,6 @@ pub unsafe fn bitmap_and_owner<O>(
     );
     let array = InternalArrowArray::new(array, ArrowDataType::Boolean);
 
-    // safety: we just created a valid array
+    // SAFETY: we just created a valid array
     Ok(unsafe { BooleanArray::try_from_ffi(array) }.unwrap())
 }

--- a/crates/polars-arrow/src/ffi/stream.rs
+++ b/crates/polars-arrow/src/ffi/stream.rs
@@ -115,7 +115,7 @@ impl<Iter: DerefMut<Target = ArrowArrayStream>> ArrowArrayStreamReader<Iter> {
         // last paragraph of https://arrow.apache.org/docs/format/CStreamInterface.html#c.ArrowArrayStream.get_next
         array.release?;
 
-        // Safety: assumed from the C stream interface
+        // SAFETY: assumed from the C stream interface
         unsafe { import_array_from_c(array, self.field.data_type.clone()) }
             .map(Some)
             .transpose()

--- a/crates/polars-arrow/src/legacy/array/list.rs
+++ b/crates/polars-arrow/src/legacy/array/list.rs
@@ -41,7 +41,7 @@ impl<'a> AnonymousBuilder<'a> {
     }
 
     pub fn take_offsets(self) -> Offsets<i64> {
-        // safety: offsets are correct
+        // SAFETY: offsets are correct
         unsafe { Offsets::new_unchecked(self.offsets) }
     }
 
@@ -102,7 +102,7 @@ impl<'a> AnonymousBuilder<'a> {
     }
 
     pub fn finish(self, inner_dtype: Option<&ArrowDataType>) -> PolarsResult<ListArray<i64>> {
-        // Safety:
+        // SAFETY:
         // offsets are monotonically increasing
         let offsets = unsafe { Offsets::new_unchecked(self.offsets) };
         let (inner_dtype, values) = if self.arrays.is_empty() {

--- a/crates/polars-arrow/src/legacy/array/mod.rs
+++ b/crates/polars-arrow/src/legacy/array/mod.rs
@@ -67,7 +67,7 @@ pub trait ListFromIter {
 
         let values: PrimitiveArray<T> = iter_to_values!(iterator, validity, offsets, length_so_far);
 
-        // Safety:
+        // SAFETY:
         // offsets are monotonically increasing
         ListArray::new(
             ListArray::<i64>::default_datatype(data_type.clone()),
@@ -97,7 +97,7 @@ pub trait ListFromIter {
 
         let values: BooleanArray = iter_to_values!(iterator, validity, offsets, length_so_far);
 
-        // Safety:
+        // SAFETY:
         // Offsets are monotonically increasing.
         ListArray::new(
             ListArray::<i64>::default_datatype(ArrowDataType::Boolean),
@@ -145,7 +145,7 @@ pub trait ListFromIter {
             .trust_my_length(n_elements)
             .collect();
 
-        // Safety:
+        // SAFETY:
         // offsets are monotonically increasing
         ListArray::new(
             ListArray::<i64>::default_datatype(T::DATA_TYPE),

--- a/crates/polars-arrow/src/legacy/kernels/agg_mean.rs
+++ b/crates/polars-arrow/src/legacy/kernels/agg_mean.rs
@@ -87,7 +87,7 @@ where
     let sum = chunks.by_ref().zip(validity_masks.by_ref()).fold(
         Simd::<f64, LANES>::splat(0.0),
         |acc, (chunk, validity_chunk)| {
-            // safety: exact size chunks
+            // SAFETY: exact size chunks
             let chunk: [T; LANES] = unsafe { chunk.try_into().unwrap_unchecked() };
             let chunk = Simd::from(chunk).cast_custom::<f64>();
 

--- a/crates/polars-arrow/src/legacy/kernels/fixed_size_list.rs
+++ b/crates/polars-arrow/src/legacy/kernels/fixed_size_list.rs
@@ -39,7 +39,7 @@ fn sub_fixed_size_list_get_indexes(width: usize, index: &PrimitiveArray<i64>) ->
 pub fn sub_fixed_size_list_get_literal(arr: &FixedSizeListArray, index: i64) -> ArrayRef {
     let take_by = sub_fixed_size_list_get_indexes_literal(arr.size(), arr.len(), index);
     let values = arr.values();
-    // Safety:
+    // SAFETY:
     // the indices we generate are in bounds
     unsafe { take_unchecked(&**values, &take_by) }
 }
@@ -47,7 +47,7 @@ pub fn sub_fixed_size_list_get_literal(arr: &FixedSizeListArray, index: i64) -> 
 pub fn sub_fixed_size_list_get(arr: &FixedSizeListArray, index: &PrimitiveArray<i64>) -> ArrayRef {
     let take_by = sub_fixed_size_list_get_indexes(arr.size(), index);
     let values = arr.values();
-    // Safety:
+    // SAFETY:
     // the indices we generate are in bounds
     unsafe { take_unchecked(&**values, &take_by) }
 }

--- a/crates/polars-arrow/src/legacy/kernels/list.rs
+++ b/crates/polars-arrow/src/legacy/kernels/list.rs
@@ -68,7 +68,7 @@ fn sublist_get_indexes(arr: &ListArray<i64>, index: i64) -> IdxArr {
 pub fn sublist_get(arr: &ListArray<i64>, index: i64) -> ArrayRef {
     let take_by = sublist_get_indexes(arr, index);
     let values = arr.values();
-    // Safety:
+    // SAFETY:
     // the indices we generate are in bounds
     unsafe { take_unchecked(&**values, &take_by) }
 }
@@ -77,7 +77,7 @@ pub fn sublist_get(arr: &ListArray<i64>, index: i64) -> ArrayRef {
 pub fn array_to_unit_list(array: ArrayRef) -> ListArray<i64> {
     let len = array.len();
     let mut offsets = Vec::with_capacity(len + 1);
-    // Safety: we allocated enough
+    // SAFETY: we allocated enough
     unsafe {
         offsets.push_unchecked(0i64);
 
@@ -86,7 +86,7 @@ pub fn array_to_unit_list(array: ArrayRef) -> ListArray<i64> {
         }
     };
 
-    // Safety:
+    // SAFETY:
     // offsets are monotonically increasing
     unsafe {
         let offsets: OffsetsBuffer<i64> = Offsets::new_unchecked(offsets).into();

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
@@ -51,7 +51,7 @@ where
     let out = (0..len)
         .map(|idx| {
             let (start, end) = det_offsets_fn(idx, window_size, len);
-            // safety:
+            // SAFETY:
             // we are in bounds
             unsafe { agg_window.update(start, end) }
         })

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/quantile.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/quantile.rs
@@ -66,11 +66,11 @@ impl<
 
                 let top_idx = ((length_f - 1.0) * self.prob).ceil() as usize;
                 return if top_idx == idx {
-                    // SAFETY
+                    // SAFETY:
                     // we are in bounds
                     unsafe { *vals.get_unchecked_release(idx) }
                 } else {
-                    // SAFETY
+                    // SAFETY:
                     // we are in bounds
                     let (mid, mid_plus_1) = unsafe {
                         (
@@ -93,7 +93,7 @@ impl<
             },
         };
 
-        // SAFETY
+        // SAFETY:
         // we are in bounds
         unsafe { *vals.get_unchecked_release(idx) }
     }

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/quantile.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/quantile.rs
@@ -66,11 +66,11 @@ impl<
 
                 let top_idx = ((length_f - 1.0) * self.prob).ceil() as usize;
                 return if top_idx == idx {
-                    // safety
+                    // SAFETY
                     // we are in bounds
                     unsafe { *vals.get_unchecked_release(idx) }
                 } else {
-                    // safety
+                    // SAFETY
                     // we are in bounds
                     let (mid, mid_plus_1) = unsafe {
                         (
@@ -93,7 +93,7 @@ impl<
             },
         };
 
-        // safety
+        // SAFETY
         // we are in bounds
         unsafe { *vals.get_unchecked_release(idx) }
     }

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/sum.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/sum.rs
@@ -32,7 +32,7 @@ impl<'a, T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign>
             // remove elements that should leave the window
             let mut recompute_sum = false;
             for idx in self.last_start..start {
-                // SAFETY
+                // SAFETY:
                 // we are in bounds
                 let leaving_value = self.slice.get_unchecked(idx);
 

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/sum.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/sum.rs
@@ -32,7 +32,7 @@ impl<'a, T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign>
             // remove elements that should leave the window
             let mut recompute_sum = false;
             for idx in self.last_start..start {
-                // safety
+                // SAFETY
                 // we are in bounds
                 let leaving_value = self.slice.get_unchecked(idx);
 

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/variance.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/variance.rs
@@ -39,7 +39,7 @@ impl<'a, T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign + Mul<
             // remove elements that should leave the window
             let mut recompute_sum = false;
             for idx in self.last_start..start {
-                // safety
+                // SAFETY
                 // we are in bounds
                 let leaving_value = self.slice.get_unchecked(idx);
 

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/variance.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/variance.rs
@@ -39,7 +39,7 @@ impl<'a, T: NativeType + IsFloat + std::iter::Sum + AddAssign + SubAssign + Mul<
             // remove elements that should leave the window
             let mut recompute_sum = false;
             for idx in self.last_start..start {
-                // SAFETY
+                // SAFETY:
                 // we are in bounds
                 let leaving_value = self.slice.get_unchecked(idx);
 

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/min_max.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/min_max.rs
@@ -183,7 +183,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> MinMaxWindow<'a, T> {
         // remove elements that should leave the window
         let mut recompute_extremum = false;
         for idx in self.last_start..start {
-            // safety
+            // SAFETY
             // we are in bounds
             let valid = self.validity.get_bit_unchecked(idx);
             if valid {

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/min_max.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/min_max.rs
@@ -183,7 +183,7 @@ impl<'a, T: NativeType + IsFloat + PartialOrd> MinMaxWindow<'a, T> {
         // remove elements that should leave the window
         let mut recompute_extremum = false;
         for idx in self.last_start..start {
-            // SAFETY
+            // SAFETY:
             // we are in bounds
             let valid = self.validity.get_bit_unchecked(idx);
             if valid {

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/mod.rs
@@ -46,7 +46,7 @@ where
 {
     let len = values.len();
     let (start, end) = det_offsets_fn(0, window_size, len);
-    // Safety; we are in bounds
+    // SAFETY; we are in bounds
     let mut agg_window = unsafe { Agg::new(values, validity, start, end, params) };
 
     let mut validity = create_validity(min_periods, len, window_size, det_offsets_fn)
@@ -59,7 +59,7 @@ where
     let out = (0..len)
         .map(|idx| {
             let (start, end) = det_offsets_fn(idx, window_size, len);
-            // safety:
+            // SAFETY:
             // we are in bounds
             let agg = unsafe { agg_window.update(start, end) };
             match agg {
@@ -67,13 +67,13 @@ where
                     if agg_window.is_valid(min_periods) {
                         val
                     } else {
-                        // safety: we are in bounds
+                        // SAFETY: we are in bounds
                         unsafe { validity.set_unchecked(idx, false) };
                         T::default()
                     }
                 },
                 None => {
-                    // safety: we are in bounds
+                    // SAFETY: we are in bounds
                     unsafe { validity.set_unchecked(idx, false) };
                     T::default()
                 },

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/sum.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/sum.rs
@@ -66,7 +66,7 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T>> RollingAgg
             // remove elements that should leave the window
             let mut recompute_sum = false;
             for idx in self.last_start..start {
-                // SAFETY
+                // SAFETY:
                 // we are in bounds
                 let valid = self.validity.get_bit_unchecked(idx);
                 if valid {

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/sum.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/sum.rs
@@ -66,7 +66,7 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T>> RollingAgg
             // remove elements that should leave the window
             let mut recompute_sum = false;
             for idx in self.last_start..start {
-                // safety
+                // SAFETY
                 // we are in bounds
                 let valid = self.validity.get_bit_unchecked(idx);
                 if valid {

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/variance.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/variance.rs
@@ -67,7 +67,7 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T> + Mul<Outpu
             // remove elements that should leave the window
             let mut recompute_sum = false;
             for idx in self.last_start..start {
-                // safety
+                // SAFETY
                 // we are in bounds
                 let valid = self.validity.get_bit_unchecked(idx);
                 if valid {

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/variance.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/variance.rs
@@ -67,7 +67,7 @@ impl<'a, T: NativeType + IsFloat + Add<Output = T> + Sub<Output = T> + Mul<Outpu
             // remove elements that should leave the window
             let mut recompute_sum = false;
             for idx in self.last_start..start {
-                // SAFETY
+                // SAFETY:
                 // we are in bounds
                 let valid = self.validity.get_bit_unchecked(idx);
                 if valid {

--- a/crates/polars-arrow/src/legacy/kernels/rolling/window.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/window.rs
@@ -37,10 +37,10 @@ impl<'a, T: NativeType> SortedBuf<'a, T> {
         } else {
             // remove elements that should leave the window
             for idx in self.last_start..start {
-                // SAFETY
+                // SAFETY:
                 // we are in bounds
                 let val = self.slice.get_unchecked(idx);
-                // SAFETY
+                // SAFETY:
                 // value is present in buf
                 let remove_idx = self
                     .buf
@@ -52,7 +52,7 @@ impl<'a, T: NativeType> SortedBuf<'a, T> {
 
             // insert elements that enter the window, but insert them sorted
             for idx in self.last_end..end {
-                // SAFETY
+                // SAFETY:
                 // we are in bounds
                 let val = *self.slice.get_unchecked(idx);
                 let insertion_idx = self
@@ -130,7 +130,7 @@ impl<'a, T: NativeType> SortedBufNulls<'a, T> {
         } else {
             // remove elements that should leave the window
             for idx in self.last_start..start {
-                // SAFETY
+                // SAFETY:
                 // we are in bounds
                 let val = if self.validity.get_bit_unchecked(idx) {
                     Some(*self.slice.get_unchecked(idx))
@@ -139,7 +139,7 @@ impl<'a, T: NativeType> SortedBufNulls<'a, T> {
                     None
                 };
 
-                // SAFETY
+                // SAFETY:
                 // value is present in buf
                 let remove_idx = self
                     .buf
@@ -151,7 +151,7 @@ impl<'a, T: NativeType> SortedBufNulls<'a, T> {
 
             // insert elements that enter the window, but insert them sorted
             for idx in self.last_end..end {
-                // SAFETY
+                // SAFETY:
                 // we are in bounds
                 let val = if self.validity.get_bit_unchecked(idx) {
                     Some(*self.slice.get_unchecked(idx))

--- a/crates/polars-arrow/src/legacy/kernels/rolling/window.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/window.rs
@@ -37,10 +37,10 @@ impl<'a, T: NativeType> SortedBuf<'a, T> {
         } else {
             // remove elements that should leave the window
             for idx in self.last_start..start {
-                // safety
+                // SAFETY
                 // we are in bounds
                 let val = self.slice.get_unchecked(idx);
-                // safety
+                // SAFETY
                 // value is present in buf
                 let remove_idx = self
                     .buf
@@ -52,7 +52,7 @@ impl<'a, T: NativeType> SortedBuf<'a, T> {
 
             // insert elements that enter the window, but insert them sorted
             for idx in self.last_end..end {
-                // safety
+                // SAFETY
                 // we are in bounds
                 let val = *self.slice.get_unchecked(idx);
                 let insertion_idx = self
@@ -130,7 +130,7 @@ impl<'a, T: NativeType> SortedBufNulls<'a, T> {
         } else {
             // remove elements that should leave the window
             for idx in self.last_start..start {
-                // safety
+                // SAFETY
                 // we are in bounds
                 let val = if self.validity.get_bit_unchecked(idx) {
                     Some(*self.slice.get_unchecked(idx))
@@ -139,7 +139,7 @@ impl<'a, T: NativeType> SortedBufNulls<'a, T> {
                     None
                 };
 
-                // safety
+                // SAFETY
                 // value is present in buf
                 let remove_idx = self
                     .buf
@@ -151,7 +151,7 @@ impl<'a, T: NativeType> SortedBufNulls<'a, T> {
 
             // insert elements that enter the window, but insert them sorted
             for idx in self.last_end..end {
-                // safety
+                // SAFETY
                 // we are in bounds
                 let val = if self.validity.get_bit_unchecked(idx) {
                     Some(*self.slice.get_unchecked(idx))

--- a/crates/polars-arrow/src/legacy/kernels/sort_partition.rs
+++ b/crates/polars-arrow/src/legacy/kernels/sort_partition.rs
@@ -90,7 +90,7 @@ pub fn partition_to_groups_amortized<T>(
                 let val_ptr = val as *const T;
                 let first_ptr = first as *const T;
 
-                // Safety
+                // SAFETY
                 // all pointers suffice the invariants
                 let len = unsafe { val_ptr.offset_from(first_ptr) } as IdxSize;
                 out.push([first_idx, len]);

--- a/crates/polars-arrow/src/legacy/kernels/sort_partition.rs
+++ b/crates/polars-arrow/src/legacy/kernels/sort_partition.rs
@@ -90,7 +90,7 @@ pub fn partition_to_groups_amortized<T>(
                 let val_ptr = val as *const T;
                 let first_ptr = first as *const T;
 
-                // SAFETY
+                // SAFETY:
                 // all pointers suffice the invariants
                 let len = unsafe { val_ptr.offset_from(first_ptr) } as IdxSize;
                 out.push([first_idx, len]);

--- a/crates/polars-arrow/src/offset.rs
+++ b/crates/polars-arrow/src/offset.rs
@@ -377,7 +377,7 @@ impl<O: Offset> OffsetsBuffer<O> {
     pub fn into_mut(self) -> either::Either<Self, Offsets<O>> {
         self.0
             .into_mut()
-            // Safety: Offsets and OffsetsBuffer share invariants
+            // SAFETY: Offsets and OffsetsBuffer share invariants
             .map_right(|offsets| unsafe { Offsets::new_unchecked(offsets) })
             .map_left(Self)
     }

--- a/crates/polars-compute/src/filter/boolean.rs
+++ b/crates/polars-compute/src/filter/boolean.rs
@@ -93,7 +93,7 @@ where
                 unsafe {
                     new.extend_from_slice_unchecked(chunk.to_ne_bytes().as_ref(), 0, size);
 
-                    // safety: invariant offset + length <= slice.len()
+                    // SAFETY: invariant offset + length <= slice.len()
                     new_validity.extend_from_slice_unchecked(
                         validity_chunk.to_ne_bytes().as_ref(),
                         0,

--- a/crates/polars-compute/src/filter/primitive.rs
+++ b/crates/polars-compute/src/filter/primitive.rs
@@ -112,7 +112,7 @@ where
                     std::ptr::copy(chunk.as_ptr(), dst, size);
                     dst = dst.add(size);
 
-                    // safety: invariant offset + length <= slice.len()
+                    // SAFETY: invariant offset + length <= slice.len()
                     new_validity.extend_from_slice_unchecked(
                         validity_chunk.to_ne_bytes().as_ref(),
                         0,

--- a/crates/polars-core/src/chunked_array/array/iterator.rs
+++ b/crates/polars-core/src/chunked_array/array/iterator.rs
@@ -44,7 +44,7 @@ impl ArrayChunked {
             _ => inner_dtype.clone(),
         };
 
-        // Safety:
+        // SAFETY:
         // inner type passed as physical type
         let series_container = unsafe {
             Box::pin(Series::from_chunks_and_dtype_unchecked(

--- a/crates/polars-core/src/chunked_array/builder/list/binary.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/binary.rs
@@ -27,7 +27,7 @@ impl ListStringChunkedBuilder {
         if iter.size_hint().0 == 0 {
             self.fast_explode = false;
         }
-        // Safety
+        // SAFETY
         // trusted len, trust the type system
         self.builder.mut_values().extend_trusted_len(iter);
         self.builder.try_push_valid().unwrap();
@@ -116,7 +116,7 @@ impl ListBinaryChunkedBuilder {
         if iter.size_hint().0 == 0 {
             self.fast_explode = false;
         }
-        // Safety
+        // SAFETY
         // trusted len, trust the type system
         self.builder.mut_values().extend_trusted_len(iter);
         self.builder.try_push_valid().unwrap();

--- a/crates/polars-core/src/chunked_array/builder/list/binary.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/binary.rs
@@ -27,7 +27,7 @@ impl ListStringChunkedBuilder {
         if iter.size_hint().0 == 0 {
             self.fast_explode = false;
         }
-        // SAFETY
+        // SAFETY:
         // trusted len, trust the type system
         self.builder.mut_values().extend_trusted_len(iter);
         self.builder.try_push_valid().unwrap();
@@ -116,7 +116,7 @@ impl ListBinaryChunkedBuilder {
         if iter.size_hint().0 == 0 {
             self.fast_explode = false;
         }
-        // SAFETY
+        // SAFETY:
         // trusted len, trust the type system
         self.builder.mut_values().extend_trusted_len(iter);
         self.builder.try_push_valid().unwrap();

--- a/crates/polars-core/src/chunked_array/builder/list/boolean.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/boolean.rs
@@ -26,7 +26,7 @@ impl ListBooleanChunkedBuilder {
         if iter.size_hint().0 == 0 {
             self.fast_explode = false;
         }
-        // SAFETY
+        // SAFETY:
         // trusted len, trust the type system
         unsafe { values.extend_trusted_len_unchecked(iter) };
         self.builder.try_push_valid().unwrap();

--- a/crates/polars-core/src/chunked_array/builder/list/boolean.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/boolean.rs
@@ -26,7 +26,7 @@ impl ListBooleanChunkedBuilder {
         if iter.size_hint().0 == 0 {
             self.fast_explode = false;
         }
-        // Safety
+        // SAFETY
         // trusted len, trust the type system
         unsafe { values.extend_trusted_len_unchecked(iter) };
         self.builder.try_push_valid().unwrap();

--- a/crates/polars-core/src/chunked_array/builder/list/categorical.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/categorical.rs
@@ -142,7 +142,7 @@ impl ListBuilderTrait for ListLocalCategoricalChunkedBuilder {
             let len = self.idx_lookup.len();
 
             // Custom hashing / equality functions for comparing the &str to the idx
-            // Safety: index in hashmap are within bounds of categories
+            // SAFETY: index in hashmap are within bounds of categories
             let r = unsafe {
                 self.idx_lookup.raw_table_mut().find_or_find_insert_slot(
                     hash_cat,
@@ -155,13 +155,13 @@ impl ListBuilderTrait for ListLocalCategoricalChunkedBuilder {
 
             match r {
                 Ok(v) => {
-                    // Safety: Bucket is initialized
+                    // SAFETY: Bucket is initialized
                     idx_mapping.insert_unique_unchecked(idx as u32, unsafe { v.as_ref().0 .0 });
                 },
                 Err(e) => {
                     idx_mapping.insert_unique_unchecked(idx as u32, len as u32);
                     self.categories.push(Some(cat));
-                    // Safety: No mutations in hashmap since find_or_find_insert_slot call
+                    // SAFETY: No mutations in hashmap since find_or_find_insert_slot call
                     unsafe {
                         self.idx_lookup.raw_table_mut().insert_in_slot(
                             hash_cat,
@@ -174,7 +174,7 @@ impl ListBuilderTrait for ListLocalCategoricalChunkedBuilder {
         }
 
         let op = |opt_v: Option<&u32>| opt_v.map(|v| *idx_mapping.get(v).unwrap());
-        // Safety: length is correct as we do one-one mapping over ca.
+        // SAFETY: length is correct as we do one-one mapping over ca.
         let iter = unsafe {
             ca.physical()
                 .downcast_iter()

--- a/crates/polars-core/src/chunked_array/builder/list/primitive.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/primitive.rs
@@ -78,7 +78,7 @@ where
         if iter.size_hint().0 == 0 {
             self.fast_explode = false;
         }
-        // SAFETY
+        // SAFETY:
         // trusted len, trust the type system
         unsafe { values.extend_trusted_len_values_unchecked(iter) };
         self.builder.try_push_valid().unwrap();
@@ -92,7 +92,7 @@ where
         if iter.size_hint().0 == 0 {
             self.fast_explode = false;
         }
-        // SAFETY
+        // SAFETY:
         // trusted len, trust the type system
         unsafe { values.extend_trusted_len_unchecked(iter) };
         self.builder.try_push_valid().unwrap();

--- a/crates/polars-core/src/chunked_array/builder/list/primitive.rs
+++ b/crates/polars-core/src/chunked_array/builder/list/primitive.rs
@@ -78,7 +78,7 @@ where
         if iter.size_hint().0 == 0 {
             self.fast_explode = false;
         }
-        // Safety
+        // SAFETY
         // trusted len, trust the type system
         unsafe { values.extend_trusted_len_values_unchecked(iter) };
         self.builder.try_push_valid().unwrap();
@@ -92,7 +92,7 @@ where
         if iter.size_hint().0 == 0 {
             self.fast_explode = false;
         }
-        // Safety
+        // SAFETY
         // trusted len, trust the type system
         unsafe { values.extend_trusted_len_unchecked(iter) };
         self.builder.try_push_valid().unwrap();
@@ -122,7 +122,7 @@ where
             if !arr.has_validity() {
                 values.extend_from_slice(arr.values().as_slice())
             } else {
-                // Safety:
+                // SAFETY:
                 // Arrow arrays are trusted length iterators.
                 unsafe { values.extend_trusted_len_unchecked(arr.into_iter()) }
             }

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -142,7 +142,7 @@ where
                 // SAFETY:
                 // we are guarded by the type system
                 let ca = unsafe { &*(self as *const ChunkedArray<T> as *const UInt32Chunked) };
-                // SAFETY indices are in bound
+                // SAFETY: indices are in bound
                 unsafe {
                     Ok(CategoricalChunked::from_cats_and_rev_map_unchecked(
                         ca.clone(),

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -105,7 +105,7 @@ where
                     self.dtype() == &DataType::UInt32,
                     ComputeError: "cannot cast numeric types to 'Categorical'"
                 );
-                // SAFETY
+                // SAFETY:
                 // we are guarded by the type system
                 let ca = unsafe { &*(self as *const ChunkedArray<T> as *const UInt32Chunked) };
 
@@ -139,7 +139,7 @@ where
                         polars_bail!(OutOfBounds: "index {} is bigger than the number of categories {}",m,categories.len());
                     }
                 }
-                // SAFETY
+                // SAFETY:
                 // we are guarded by the type system
                 let ca = unsafe { &*(self as *const ChunkedArray<T> as *const UInt32Chunked) };
                 // SAFETY indices are in bound

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -91,7 +91,7 @@ where
 {
     fn cast_impl(&self, data_type: &DataType, checked: bool) -> PolarsResult<Series> {
         if self.dtype() == data_type {
-            // safety: chunks are correct dtype
+            // SAFETY: chunks are correct dtype
             let mut out = unsafe {
                 Series::from_chunks_and_dtype_unchecked(self.name(), self.chunks.clone(), data_type)
             };
@@ -195,7 +195,7 @@ where
             DataType::Categorical(Some(rev_map), ordering)
             | DataType::Enum(Some(rev_map), ordering) => {
                 if self.dtype() == &DataType::UInt32 {
-                    // safety:
+                    // SAFETY:
                     // we are guarded by the type system.
                     let ca = unsafe { &*(self as *const ChunkedArray<T> as *const UInt32Chunked) };
                     Ok(unsafe {
@@ -222,7 +222,7 @@ impl ChunkCast for StringChunked {
             #[cfg(feature = "dtype-categorical")]
             DataType::Categorical(rev_map, ordering) => match rev_map {
                 None => {
-                    // Safety: length is correct
+                    // SAFETY: length is correct
                     let iter =
                         unsafe { self.downcast_iter().flatten().trust_my_length(self.len()) };
                     let builder =
@@ -391,7 +391,7 @@ impl ChunkCast for ListChunked {
                     _ => {
                         // ensure the inner logical type bubbles up
                         let (arr, child_type) = cast_list(self, child_type)?;
-                        // Safety: we just casted so the dtype matches.
+                        // SAFETY: we just casted so the dtype matches.
                         // we must take this path to correct for physical types.
                         unsafe {
                             Ok(Series::from_chunks_and_dtype_unchecked(
@@ -408,7 +408,7 @@ impl ChunkCast for ListChunked {
                 let physical_type = data_type.to_physical();
                 // cast to the physical type to avoid logical chunks.
                 let chunks = cast_chunks(self.chunks(), &physical_type, true)?;
-                // Safety: we just casted so the dtype matches.
+                // SAFETY: we just casted so the dtype matches.
                 // we must take this path to correct for physical types.
                 unsafe {
                     Ok(Series::from_chunks_and_dtype_unchecked(
@@ -453,7 +453,7 @@ impl ChunkCast for ArrayChunked {
                     _ => {
                         // ensure the inner logical type bubbles up
                         let (arr, child_type) = cast_fixed_size_list(self, child_type)?;
-                        // Safety: we just casted so the dtype matches.
+                        // SAFETY: we just casted so the dtype matches.
                         // we must take this path to correct for physical types.
                         unsafe {
                             Ok(Series::from_chunks_and_dtype_unchecked(
@@ -469,7 +469,7 @@ impl ChunkCast for ArrayChunked {
                 let physical_type = data_type.to_physical();
                 // cast to the physical type to avoid logical chunks.
                 let chunks = cast_chunks(self.chunks(), &physical_type, true)?;
-                // Safety: we just casted so the dtype matches.
+                // SAFETY: we just casted so the dtype matches.
                 // we must take this path to correct for physical types.
                 unsafe {
                     Ok(Series::from_chunks_and_dtype_unchecked(
@@ -495,7 +495,7 @@ fn cast_list(ca: &ListChunked, child_type: &DataType) -> PolarsResult<(ArrayRef,
     // TODO!: consider a version that works on chunks and merges the data-types and arrays.
     let ca = ca.rechunk();
     let arr = ca.downcast_iter().next().unwrap();
-    // safety: inner dtype is passed correctly
+    // SAFETY: inner dtype is passed correctly
     let s = unsafe {
         Series::from_chunks_and_dtype_unchecked("", vec![arr.values().clone()], &ca.inner_dtype())
     };
@@ -520,7 +520,7 @@ unsafe fn cast_list_unchecked(ca: &ListChunked, child_type: &DataType) -> Polars
     // TODO! add chunked, but this must correct for list offsets.
     let ca = ca.rechunk();
     let arr = ca.downcast_iter().next().unwrap();
-    // safety: inner dtype is passed correctly
+    // SAFETY: inner dtype is passed correctly
     let s = unsafe {
         Series::from_chunks_and_dtype_unchecked("", vec![arr.values().clone()], &ca.inner_dtype())
     };
@@ -551,7 +551,7 @@ fn cast_fixed_size_list(
 ) -> PolarsResult<(ArrayRef, DataType)> {
     let ca = ca.rechunk();
     let arr = ca.downcast_iter().next().unwrap();
-    // safety: inner dtype is passed correctly
+    // SAFETY: inner dtype is passed correctly
     let s = unsafe {
         Series::from_chunks_and_dtype_unchecked("", vec![arr.values().clone()], &ca.inner_dtype())
     };

--- a/crates/polars-core/src/chunked_array/comparison/categorical.rs
+++ b/crates/polars-core/src/chunked_array/comparison/categorical.rs
@@ -49,7 +49,7 @@ where
     } else {
         match (lhs.len(), rhs.len()) {
             (lhs_len, 1) => {
-                // Safety: physical is in range of revmap
+                // SAFETY: physical is in range of revmap
                 let v = unsafe {
                     rhs.physical()
                         .get(0)
@@ -65,7 +65,7 @@ where
                     .collect_ca_trusted(lhs.name()))
             },
             (1, rhs_len) => {
-                // Safety: physical is in range of revmap
+                // SAFETY: physical is in range of revmap
                 let v = unsafe {
                     lhs.physical()
                         .get(0)
@@ -367,7 +367,7 @@ where
 
         Ok(
             BooleanChunked::from_iter_trusted_length(lhs.physical().into_iter().map(|opt_idx| {
-                // Safety: indexing into bitmap with same length as original array
+                // SAFETY: indexing into bitmap with same length as original array
                 opt_idx.map(|idx| unsafe { bitmap.get_bit_unchecked(idx as usize) })
             }))
             .with_name(lhs.name()),

--- a/crates/polars-core/src/chunked_array/drop.rs
+++ b/crates/polars-core/src/chunked_array/drop.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 impl<T: PolarsDataType> Drop for ChunkedArray<T> {
     fn drop(&mut self) {
         if matches!(self.dtype(), DataType::List(_)) {
-            // SAFETY
+            // SAFETY:
             // guarded by the type system
             // the transmute only convinces the type system that we are a list
             // (which we are)

--- a/crates/polars-core/src/chunked_array/drop.rs
+++ b/crates/polars-core/src/chunked_array/drop.rs
@@ -4,7 +4,7 @@ use crate::prelude::*;
 impl<T: PolarsDataType> Drop for ChunkedArray<T> {
     fn drop(&mut self) {
         if matches!(self.dtype(), DataType::List(_)) {
-            // Safety
+            // SAFETY
             // guarded by the type system
             // the transmute only convinces the type system that we are a list
             // (which we are)

--- a/crates/polars-core/src/chunked_array/iterator/mod.rs
+++ b/crates/polars-core/src/chunked_array/iterator/mod.rs
@@ -453,7 +453,7 @@ impl<'a> Iterator for StructIter<'a> {
         for it in &mut self.field_iter {
             self.buf.push(it.next()?);
         }
-        // Safety:
+        // SAFETY:
         // Lifetime is bound to struct, we just cannot set the lifetime for the iterator trait
         unsafe {
             Some(std::mem::transmute::<&'_ [AnyValue], &'a [AnyValue]>(

--- a/crates/polars-core/src/chunked_array/iterator/par/list.rs
+++ b/crates/polars-core/src/chunked_array/iterator/par/list.rs
@@ -16,7 +16,7 @@ impl ListChunked {
     pub fn par_iter(&self) -> impl ParallelIterator<Item = Option<Series>> + '_ {
         self.chunks.par_iter().flat_map(move |arr| {
             let dtype = self.inner_dtype();
-            // Safety:
+            // SAFETY:
             // guarded by the type system
             let arr = &**arr;
             let arr = unsafe { &*(arr as *const dyn Array as *const ListArray<i64>) };

--- a/crates/polars-core/src/chunked_array/iterator/par/string.rs
+++ b/crates/polars-core/src/chunked_array/iterator/par/string.rs
@@ -16,7 +16,7 @@ impl StringChunked {
         assert_eq!(self.chunks.len(), 1);
         let arr = &*self.chunks[0];
 
-        // Safety:
+        // SAFETY:
         // guarded by the type system
         let arr = unsafe { &*(arr as *const dyn Array as *const Utf8ViewArray) };
         (0..arr.len())
@@ -26,7 +26,7 @@ impl StringChunked {
 
     pub fn par_iter(&self) -> impl ParallelIterator<Item = Option<&str>> + '_ {
         self.chunks.par_iter().flat_map(move |arr| {
-            // Safety:
+            // SAFETY:
             // guarded by the type system
             let arr = &**arr;
             let arr = unsafe { &*(arr as *const dyn Array as *const Utf8ViewArray) };

--- a/crates/polars-core/src/chunked_array/list/iterator.rs
+++ b/crates/polars-core/src/chunked_array/list/iterator.rs
@@ -46,7 +46,7 @@ impl<'a, I: Iterator<Item = Option<ArrayBox>>> Iterator for AmortizedListIter<'a
                 // structs arrays are bound to the series not to the arrayref
                 // so we must get a hold to the new array
                 if matches!(self.inner_dtype, DataType::Struct(_)) {
-                    // Safety
+                    // SAFETY
                     // dtype is known
                     unsafe {
                         let mut s = Series::from_chunks_and_dtype_unchecked(
@@ -74,7 +74,7 @@ impl<'a, I: Iterator<Item = Option<ArrayBox>>> Iterator for AmortizedListIter<'a
                 // make sure that the length is correct
                 self.series_container._get_inner_mut().compute_len();
 
-                // Safety
+                // SAFETY
                 // we cannot control the lifetime of an iterators `next` method.
                 // but as long as self is alive the reference to the series container is valid
                 let refer = &mut *self.series_container;
@@ -144,7 +144,7 @@ impl ListChunked {
             _ => inner_dtype.clone(),
         };
 
-        // Safety:
+        // SAFETY:
         // inner type passed as physical type
         let series_container = unsafe {
             let mut s = Series::from_chunks_and_dtype_unchecked(

--- a/crates/polars-core/src/chunked_array/list/iterator.rs
+++ b/crates/polars-core/src/chunked_array/list/iterator.rs
@@ -46,7 +46,7 @@ impl<'a, I: Iterator<Item = Option<ArrayBox>>> Iterator for AmortizedListIter<'a
                 // structs arrays are bound to the series not to the arrayref
                 // so we must get a hold to the new array
                 if matches!(self.inner_dtype, DataType::Struct(_)) {
-                    // SAFETY
+                    // SAFETY:
                     // dtype is known
                     unsafe {
                         let mut s = Series::from_chunks_and_dtype_unchecked(
@@ -74,7 +74,7 @@ impl<'a, I: Iterator<Item = Option<ArrayBox>>> Iterator for AmortizedListIter<'a
                 // make sure that the length is correct
                 self.series_container._get_inner_mut().compute_len();
 
-                // SAFETY
+                // SAFETY:
                 // we cannot control the lifetime of an iterators `next` method.
                 // but as long as self is alive the reference to the series container is valid
                 let refer = &mut *self.series_container;

--- a/crates/polars-core/src/chunked_array/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/list/mod.rs
@@ -89,7 +89,7 @@ impl ListChunked {
             arr.validity().cloned(),
         );
 
-        // safety: arr's inner dtype is derived from out dtype.
+        // SAFETY: arr's inner dtype is derived from out dtype.
         Ok(unsafe {
             ListChunked::from_chunks_and_dtype_unchecked(
                 ca.name(),

--- a/crates/polars-core/src/chunked_array/list/mod.rs
+++ b/crates/polars-core/src/chunked_array/list/mod.rs
@@ -42,7 +42,7 @@ impl ListChunked {
     pub fn get_inner(&self) -> Series {
         let ca = self.rechunk();
         let arr = ca.downcast_iter().next().unwrap();
-        // SAFETY
+        // SAFETY:
         // Inner dtype is passed correctly
         unsafe {
             Series::from_chunks_and_dtype_unchecked(
@@ -62,7 +62,7 @@ impl ListChunked {
         let ca = self.rechunk();
         let arr = ca.downcast_iter().next().unwrap();
 
-        // SAFETY
+        // SAFETY:
         // Inner dtype is passed correctly
         let elements = unsafe {
             Series::from_chunks_and_dtype_unchecked(

--- a/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -39,7 +39,7 @@ impl CategoricalChunkedBuilder {
         let len = self.local_mapping.len() as u32;
 
         // Custom hashing / equality functions for comparing the &str to the idx
-        // Safety: index in hashmap are within bounds of categories
+        // SAFETY: index in hashmap are within bounds of categories
         let r = unsafe {
             self.local_mapping.raw_table_mut().find_or_find_insert_slot(
                 h,
@@ -53,12 +53,12 @@ impl CategoricalChunkedBuilder {
 
         let idx = match r {
             Ok(v) => {
-                // Safety: Bucket is initialized
+                // SAFETY: Bucket is initialized
                 unsafe { v.as_ref().0 .0 }
             },
             Err(e) => {
                 self.categories.push(Some(s));
-                // Safety: No mutations in hashmap since find_or_find_insert_slot call
+                // SAFETY: No mutations in hashmap since find_or_find_insert_slot call
                 unsafe {
                     self.local_mapping
                         .raw_table_mut()
@@ -132,7 +132,7 @@ impl CategoricalChunkedBuilder {
         let mut local_to_global: Vec<u32> = Vec::with_capacity(categories.len());
         let (id, local_to_global) = crate::STRING_CACHE.apply(|cache| {
             for (s, h) in categories.values_iter().zip(hashes) {
-                // Safety: we allocated enough
+                // SAFETY: we allocated enough
                 unsafe { local_to_global.push_unchecked(cache.insert_from_hash(h, s)) }
             }
             local_to_global
@@ -160,7 +160,7 @@ impl CategoricalChunkedBuilder {
         let indices = std::mem::take(&mut self.cat_builder).into();
         let indices = UInt32Chunked::with_chunk(&self.name, indices);
 
-        // Safety: indices are in bounds of new rev_map
+        // SAFETY: indices are in bounds of new rev_map
         unsafe {
             CategoricalChunked::from_cats_and_rev_map_unchecked(
                 indices,
@@ -185,7 +185,7 @@ impl CategoricalChunkedBuilder {
     }
 
     pub fn finish(self) -> CategoricalChunked {
-        // Safety: keys and values are in bounds
+        // SAFETY: keys and values are in bounds
         unsafe {
             CategoricalChunked::from_keys_and_values(
                 &self.name,
@@ -275,7 +275,7 @@ impl CategoricalChunked {
             // locally we don't need a hashmap because we all categories are 1 integer apart
             // so the index is local, and the values is global
             for s in values.values_iter() {
-                // Safety: we allocated enough
+                // SAFETY: we allocated enough
                 unsafe { local_to_global.push_unchecked(cache.insert(s)) }
             }
             local_to_global

--- a/crates/polars-core/src/chunked_array/logical/categorical/from.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/from.rs
@@ -35,7 +35,7 @@ impl CategoricalChunked {
             RevMapping::Local(arr, _) => {
                 let values = convert_values(arr, pl_flavor);
 
-                // Safety:
+                // SAFETY:
                 // the keys are in bounds
                 unsafe { DictionaryArray::try_new_unchecked(dtype, keys.clone(), values).unwrap() }
             },
@@ -47,7 +47,7 @@ impl CategoricalChunked {
 
                 let values = convert_values(values, pl_flavor);
 
-                // Safety:
+                // SAFETY:
                 // the keys are in bounds
                 unsafe { DictionaryArray::try_new_unchecked(dtype, keys, values).unwrap() }
             },
@@ -68,7 +68,7 @@ impl CategoricalChunked {
             RevMapping::Local(arr, _) => {
                 let values = convert_values(arr, pl_flavor);
 
-                // Safety:
+                // SAFETY:
                 // the keys are in bounds
                 unsafe {
                     DictionaryArray::try_new_unchecked(
@@ -92,7 +92,7 @@ impl CategoricalChunked {
 
                 let values = convert_values(values, pl_flavor);
 
-                // Safety:
+                // SAFETY:
                 // the keys are in bounds
                 unsafe { DictionaryArray::try_new_unchecked(dtype, keys, values).unwrap() }
             },

--- a/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
@@ -65,7 +65,7 @@ impl GlobalRevMapMerger {
 
         for (cat, idx) in map.iter() {
             state.map.entry(*cat).or_insert_with(|| {
-                // Safety
+                // SAFETY
                 // within bounds
                 let str_val = unsafe { slots.value_unchecked(*idx as usize) };
                 let new_idx = state.slots.len() as u32;
@@ -177,7 +177,7 @@ pub fn call_categorical_merge_operation<I: CategoricalMergeOperation>(
         },
         _ => polars_bail!(string_cache_mismatch),
     };
-    // Safety: physical and rev map are correctly constructed above
+    // SAFETY: physical and rev map are correctly constructed above
     unsafe {
         Ok(CategoricalChunked::from_cats_and_rev_map_unchecked(
             new_physical,
@@ -204,7 +204,7 @@ pub fn make_categoricals_compatible(
 
     // Alter rev map of left
     let mut new_ca_left = ca_left.clone();
-    // Safety: We just made both rev maps compatible only appended categories
+    // SAFETY: We just made both rev maps compatible only appended categories
     unsafe {
         new_ca_left.set_rev_map(
             new_ca_right.get_rev_map().clone(),

--- a/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
@@ -65,7 +65,7 @@ impl GlobalRevMapMerger {
 
         for (cat, idx) in map.iter() {
             state.map.entry(*cat).or_insert_with(|| {
-                // SAFETY
+                // SAFETY:
                 // within bounds
                 let str_val = unsafe { slots.value_unchecked(*idx as usize) };
                 let new_idx = state.slots.len() as u32;
@@ -233,7 +233,7 @@ pub fn make_list_categoricals_compatible(
     let (list_ca_right, cat_physical): (Cow<ListChunked>, Cow<UInt32Chunked>) =
         align_chunks_binary(&list_ca_right, cat_right.physical());
     let mut list_ca_right = list_ca_right.into_owned();
-    // SAFETY
+    // SAFETY:
     // Chunks are aligned, length / dtype remains correct
     unsafe {
         list_ca_right

--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -118,7 +118,7 @@ impl CategoricalChunked {
             RevMapping::Local(categories, _) => categories,
         };
 
-        // Safety: keys and values are in bounds
+        // SAFETY: keys and values are in bounds
         unsafe {
             Ok(CategoricalChunked::from_keys_and_values_global(
                 self.name(),
@@ -177,7 +177,7 @@ impl CategoricalChunked {
             .collect::<PolarsResult<_>>()?;
 
         Ok(
-            // Safety: we created the physical from the enum categories
+            // SAFETY: we created the physical from the enum categories
             unsafe {
                 CategoricalChunked::from_cats_and_rev_map_unchecked(
                     new_phys,
@@ -410,7 +410,7 @@ impl LogicalType for CategoricalChunked {
                 }
                 #[cfg(not(feature = "bigidx"))]
                 {
-                    // Safety: Invariant of categorical means indices are in bound
+                    // SAFETY: Invariant of categorical means indices are in bound
                     Ok(unsafe { casted_series.take_unchecked(&self.physical) })
                 }
             },
@@ -432,7 +432,7 @@ impl<'a> Iterator for CatIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|item| {
             item.map(|idx| {
-                // Safety:
+                // SAFETY:
                 // all categories are in bound
                 unsafe { self.rev.get_unchecked(idx) }
             })

--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
@@ -13,7 +13,7 @@ impl CategoricalChunked {
                     UInt32Chunked::from_iter_values(self.physical().name(), map.keys().copied())
                 },
             };
-            // safety:
+            // SAFETY:
             // we only removed some indexes so we are still in bounds
             unsafe {
                 let mut out = CategoricalChunked::from_cats_and_rev_map_unchecked(
@@ -27,7 +27,7 @@ impl CategoricalChunked {
             }
         } else {
             let ca = self.physical().unique()?;
-            // safety:
+            // SAFETY:
             // we only removed some indexes so we are still in bounds
             unsafe {
                 Ok(CategoricalChunked::from_cats_and_rev_map_unchecked(

--- a/crates/polars-core/src/chunked_array/logical/categorical/revmap.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/revmap.rs
@@ -158,14 +158,14 @@ impl RevMapping {
                 }
                 rev_map
                     .iter()
-                    // Safety:
+                    // SAFETY:
                     // value is always within bounds
                     .find(|(_k, &v)| (unsafe { a.value_unchecked(v as usize) } == value))
                     .map(|(k, _v)| *k)
             },
 
             Self::Local(a, _) => {
-                // Safety: within bounds
+                // SAFETY: within bounds
                 unsafe { (0..a.len()).find(|idx| a.value_unchecked(*idx) == value) }
                     .map(|idx| idx as u32)
             },

--- a/crates/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -349,7 +349,7 @@ impl StructChunked {
 
                 let mut length_so_far = 0_i64;
                 unsafe {
-                    // safety: we have pre-allocated
+                    // SAFETY: we have pre-allocated
                     offsets.push_unchecked(length_so_far);
                 }
                 for row in 0..ca.len() {
@@ -366,7 +366,7 @@ impl StructChunked {
                     unsafe {
                         *values.last_mut().unwrap_unchecked() = b'}';
 
-                        // safety: we have pre-allocated
+                        // SAFETY: we have pre-allocated
                         length_so_far = values.len() as i64;
                         offsets.push_unchecked(length_so_far);
                     }
@@ -438,7 +438,7 @@ impl LogicalType for StructChunked {
     unsafe fn get_any_value_unchecked(&self, i: usize) -> AnyValue<'_> {
         let (chunk_idx, idx) = index_to_chunked_index(self.chunks.iter().map(|c| c.len()), i);
         if let DataType::Struct(flds) = self.dtype() {
-            // safety: we already have a single chunk and we are
+            // SAFETY: we already have a single chunk and we are
             // guarded by the type system.
             unsafe {
                 let arr = &**self.chunks.get_unchecked(chunk_idx);

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -303,7 +303,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             series.dtype(),
             self.dtype(),
         );
-        // Safety
+        // SAFETY
         // dtype will be correct.
         Ok(unsafe { self.unpack_series_matching_physical_type(series) })
     }
@@ -581,7 +581,7 @@ where
     /// Contiguous mutable slice
     pub(crate) fn cont_slice_mut(&mut self) -> Option<&mut [T::Native]> {
         if self.chunks.len() == 1 && self.chunks[0].null_count() == 0 {
-            // Safety, we will not swap the PrimitiveArray.
+            // SAFETY, we will not swap the PrimitiveArray.
             let arr = unsafe { self.downcast_iter_mut().next().unwrap() };
             arr.get_mut_values()
         } else {

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -303,7 +303,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             series.dtype(),
             self.dtype(),
         );
-        // SAFETY
+        // SAFETY:
         // dtype will be correct.
         Ok(unsafe { self.unpack_series_matching_physical_type(series) })
     }

--- a/crates/polars-core/src/chunked_array/ndarray.rs
+++ b/crates/polars-core/src/chunked_array/ndarray.rs
@@ -68,7 +68,7 @@ impl ListChunked {
         }
 
         debug_assert_eq!(row_idx, self.len());
-        // Safety:
+        // SAFETY:
         // We have assigned to every row and element of the array
         unsafe { Ok(ndarray.assume_init()) }
     }
@@ -142,7 +142,7 @@ impl DataFrame {
                     let vals = ca.cont_slice().unwrap();
 
                     // Depending on the desired order, we add items to the buffer.
-                    // Safety:
+                    // SAFETY:
                     // We get parallel access to the vector by offsetting index access accordingly.
                     // For C-order, we only operate on every num-col-th element, starting from the
                     // column index. For Fortran-order we only operate on n contiguous elements,
@@ -158,7 +158,7 @@ impl DataFrame {
                         },
                         IndexOrder::Fortran => unsafe {
                             let offset_ptr = (ptr as *mut N::Native).add(col_idx * height);
-                            // Safety:
+                            // SAFETY:
                             // this is uninitialized memory, so we must never read from this data
                             // copy_from_slice does not read
                             let buf = std::slice::from_raw_parts_mut(offset_ptr, height);
@@ -170,7 +170,7 @@ impl DataFrame {
                 .collect::<PolarsResult<Vec<_>>>()
         })?;
 
-        // Safety:
+        // SAFETY:
         // we have written all data, so we can now safely set length
         unsafe {
             membuf.set_len(shape.0 * shape.1);

--- a/crates/polars-core/src/chunked_array/object/builder.rs
+++ b/crates/polars-core/src/chunked_array/object/builder.rs
@@ -194,7 +194,7 @@ pub(crate) fn object_series_to_arrow_array(s: &Series) -> ArrayRef {
     // The list builder knows how to create an arrow array
     // we simply piggy back on that code.
 
-    // safety: 0..len is in bounds
+    // SAFETY: 0..len is in bounds
     let list_s = unsafe {
         s.agg_list(&GroupsProxy::Slice {
             groups: vec![[0, s.len() as IdxSize]],

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -76,7 +76,7 @@ pub(crate) fn create_extension<I: Iterator<Item = Option<T>> + TrustedLen, T: Si
             Some(t) => {
                 unsafe {
                     buf.extend_from_slice(any_as_u8_slice(&t));
-                    // Safety: we allocated upfront
+                    // SAFETY: we allocated upfront
                     validity.push_unchecked(true)
                 }
                 mem::forget(t);
@@ -85,7 +85,7 @@ pub(crate) fn create_extension<I: Iterator<Item = Option<T>> + TrustedLen, T: Si
                 null_count += 1;
                 unsafe {
                     buf.extend_from_slice(any_as_u8_slice(&T::default()));
-                    // Safety: we allocated upfront
+                    // SAFETY: we allocated upfront
                     validity.push_unchecked(false)
                 }
             },
@@ -101,7 +101,7 @@ pub(crate) fn create_extension<I: Iterator<Item = Option<T>> + TrustedLen, T: Si
     // ptr to start of T, not to start of padding
     let ptr = buf.as_slice().as_ptr();
 
-    // Safety:
+    // SAFETY:
     // ptr and t are correct
     let drop_fn = unsafe { create_drop::<T>(ptr, n_t_vals) };
     let et = Box::new(ExtensionSentinel {
@@ -125,7 +125,7 @@ pub(crate) fn create_extension<I: Iterator<Item = Option<T>> + TrustedLen, T: Si
 
     let array = FixedSizeBinaryArray::new(extension_type, buf, validity);
 
-    // Safety:
+    // SAFETY:
     // we just heap allocated the ExtensionSentinel, so its alive.
     unsafe { PolarsExtension::new(array) }
 }

--- a/crates/polars-core/src/chunked_array/object/iterator.rs
+++ b/crates/polars-core/src/chunked_array/object/iterator.rs
@@ -29,7 +29,7 @@ impl<'a, T: PolarsObject> std::iter::Iterator for ObjectIter<'a, T> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.current == self.current_end {
             None
-        // Safety:
+        // SAFETY:
         // Se comment below
         } else if unsafe { self.array.is_null_unchecked(self.current) } {
             self.current += 1;
@@ -37,7 +37,7 @@ impl<'a, T: PolarsObject> std::iter::Iterator for ObjectIter<'a, T> {
         } else {
             let old = self.current;
             self.current += 1;
-            // Safety:
+            // SAFETY:
             // we just checked bounds in `self.current_end == self.current`
             // this is safe on the premise that this struct is initialized with
             // current = array.len()
@@ -63,7 +63,7 @@ impl<'a, T: PolarsObject> std::iter::DoubleEndedIterator for ObjectIter<'a, T> {
             Some(if self.array.is_null(self.current_end) {
                 None
             } else {
-                // Safety:
+                // SAFETY:
                 // we just checked bounds in `self.current_end == self.current`
                 // this is safe on the premise that this struct is initialized with
                 // current = array.len()
@@ -118,7 +118,7 @@ impl<T: PolarsObject> std::iter::Iterator for OwnedObjectIter<T> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.current == self.current_end {
             None
-        // Safety:
+        // SAFETY:
         // Se comment below
         } else if unsafe { self.array.is_null_unchecked(self.current) } {
             self.current += 1;
@@ -126,7 +126,7 @@ impl<T: PolarsObject> std::iter::Iterator for OwnedObjectIter<T> {
         } else {
             let old = self.current;
             self.current += 1;
-            // Safety:
+            // SAFETY:
             // we just checked bounds in `self.current_end == self.current`
             // this is safe on the premise that this struct is initialized with
             // current = array.len()

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -214,7 +214,7 @@ where
                         for arr in self.downcast_iter() {
                             if arr.null_count() > 0 {
                                 for v in arr.into_iter().flatten() {
-                                    // SAFETY
+                                    // SAFETY:
                                     // all these types can be coerced to f64
                                     unsafe {
                                         let val = v.to_f64().unwrap_unchecked();
@@ -223,7 +223,7 @@ where
                                 }
                             } else {
                                 for v in arr.values().as_slice() {
-                                    // SAFETY
+                                    // SAFETY:
                                     // all these types can be coerced to f64
                                     unsafe {
                                         let val = v.to_f64().unwrap_unchecked();
@@ -526,7 +526,7 @@ impl CategoricalChunked {
                 self.get_rev_map().get_categories().min_ignore_nan_kernel()
             } else {
                 let rev_map = self.get_rev_map();
-                // SAFETY
+                // SAFETY:
                 // Indices are in bounds
                 self.physical()
                     .iter()
@@ -536,7 +536,7 @@ impl CategoricalChunked {
                     .min()
             }
         } else {
-            // SAFETY
+            // SAFETY:
             // Indices are in bounds
             self.physical()
                 .min()
@@ -554,7 +554,7 @@ impl CategoricalChunked {
                 self.get_rev_map().get_categories().max_ignore_nan_kernel()
             } else {
                 let rev_map = self.get_rev_map();
-                // SAFETY
+                // SAFETY:
                 // Indices are in bounds
                 self.physical()
                     .iter()
@@ -564,7 +564,7 @@ impl CategoricalChunked {
                     .max()
             }
         } else {
-            // SAFETY
+            // SAFETY:
             // Indices are in bounds
             self.physical()
                 .max()

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -214,7 +214,7 @@ where
                         for arr in self.downcast_iter() {
                             if arr.null_count() > 0 {
                                 for v in arr.into_iter().flatten() {
-                                    // safety
+                                    // SAFETY
                                     // all these types can be coerced to f64
                                     unsafe {
                                         let val = v.to_f64().unwrap_unchecked();
@@ -223,7 +223,7 @@ where
                                 }
                             } else {
                                 for v in arr.values().as_slice() {
-                                    // safety
+                                    // SAFETY
                                     // all these types can be coerced to f64
                                     unsafe {
                                         let val = v.to_f64().unwrap_unchecked();

--- a/crates/polars-core/src/chunked_array/ops/any_value.rs
+++ b/crates/polars-core/src/chunked_array/ops/any_value.rs
@@ -205,7 +205,7 @@ macro_rules! get_any_value {
         if $index >= $self.len() {
             polars_bail!(oob = $index, $self.len());
         }
-        // SAFETY
+        // SAFETY:
         // bounds are checked
         Ok(unsafe { $self.get_any_value_unchecked($index) })
     }};

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -214,7 +214,7 @@ impl<T: PolarsNumericType> ChunkedArray<T> {
     where
         F: Fn(T::Native) -> T::Native + Copy,
     {
-        // safety, we do no t change the lengths
+        // SAFETY, we do no t change the lengths
         unsafe {
             self.downcast_iter_mut()
                 .for_each(|arr| arrow::compute::arity_assign::unary(arr, f))
@@ -281,7 +281,7 @@ where
         let mut idx = 0;
         self.downcast_iter().for_each(|arr| {
             arr.into_iter().for_each(|opt_val| {
-                // Safety:
+                // SAFETY:
                 // length asserted above
                 let item = unsafe { slice.get_unchecked_mut(idx) };
                 *item = f(opt_val.copied(), item);
@@ -371,7 +371,7 @@ impl<'a> ChunkApply<'a, bool> for BooleanChunked {
         let mut idx = 0;
         self.downcast_iter().for_each(|arr| {
             arr.into_iter().for_each(|opt_val| {
-                // Safety:
+                // SAFETY:
                 // length asserted above
                 let item = unsafe { slice.get_unchecked_mut(idx) };
                 *item = f(opt_val, item);
@@ -457,7 +457,7 @@ impl<'a> ChunkApply<'a, &'a str> for StringChunked {
         let mut idx = 0;
         self.downcast_iter().for_each(|arr| {
             arr.into_iter().for_each(|opt_val| {
-                // Safety:
+                // SAFETY:
                 // length asserted above
                 let item = unsafe { slice.get_unchecked_mut(idx) };
                 *item = f(opt_val, item);
@@ -500,7 +500,7 @@ impl<'a> ChunkApply<'a, &'a [u8]> for BinaryChunked {
         let mut idx = 0;
         self.downcast_iter().for_each(|arr| {
             arr.into_iter().for_each(|opt_val| {
-                // Safety:
+                // SAFETY:
                 // length asserted above
                 let item = unsafe { slice.get_unchecked_mut(idx) };
                 *item = f(opt_val, item);
@@ -663,7 +663,7 @@ impl<'a> ChunkApply<'a, Series> for ListChunked {
             arr.iter().for_each(|opt_val| {
                 let opt_val = opt_val.map(|arrayref| Series::try_from(("", arrayref)).unwrap());
 
-                // Safety:
+                // SAFETY:
                 // length asserted above
                 let item = unsafe { slice.get_unchecked_mut(idx) };
                 *item = f(opt_val, item);
@@ -713,7 +713,7 @@ where
         let mut idx = 0;
         self.downcast_iter().for_each(|arr| {
             arr.into_iter().for_each(|opt_val| {
-                // Safety:
+                // SAFETY:
                 // length asserted above
                 let item = unsafe { slice.get_unchecked_mut(idx) };
                 *item = f(opt_val, item);

--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -37,7 +37,7 @@ pub(crate) fn slice(
 
         debug_assert!(remaining_offset + take_len <= chunk.len());
         unsafe {
-            // Safety:
+            // SAFETY:
             // this function ensures the slices are in bounds
             new_chunks.push(chunk.sliced_unchecked(remaining_offset, take_len));
         }

--- a/crates/polars-core/src/chunked_array/ops/explode.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode.rs
@@ -85,7 +85,7 @@ where
                             new_values.extend_from_slice(values.get_unchecked(start..last))
                         };
 
-                        // Safety:
+                        // SAFETY:
                         // we are in bounds
                         unsafe {
                             unset_nulls(
@@ -107,7 +107,7 @@ where
             }
 
             // final null check
-            // Safety:
+            // SAFETY:
             // we are in bounds
             unsafe {
                 unset_nulls(
@@ -252,9 +252,9 @@ impl ExplodeByOffsets for ListChunked {
                         unsafe {
                             // we create a pointer to evade the bck
                             let ptr = arr.as_ref() as *const dyn Array;
-                            // safety: we preallocated
+                            // SAFETY: we preallocated
                             owned.push_unchecked(arr);
-                            // safety: the pointer is still valid as `owned` will not reallocate
+                            // SAFETY: the pointer is still valid as `owned` will not reallocate
                             builder.push(&*ptr as &dyn Array);
                         }
                     },

--- a/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
@@ -34,11 +34,11 @@ impl ChunkExplode for ListChunked {
             if !offsets.is_empty() {
                 let start = offsets[0] as usize;
                 let len = offsets[offsets.len() - 1] as usize - start;
-                // safety:
+                // SAFETY:
                 // we are in bounds
                 values = unsafe { values.sliced_unchecked(start, len) };
             }
-            // safety: inner_dtype should be correct
+            // SAFETY: inner_dtype should be correct
             unsafe {
                 Series::from_chunks_and_dtype_unchecked(
                     self.name(),
@@ -64,7 +64,7 @@ impl ChunkExplode for ListChunked {
                 }
             }
 
-            // safety: inner_dtype should be correct
+            // SAFETY: inner_dtype should be correct
             let values = unsafe {
                 Series::from_chunks_and_dtype_unchecked(
                     self.name(),
@@ -96,7 +96,7 @@ impl ChunkExplode for ArrayChunked {
                     i * width
                 })
                 .collect::<Vec<_>>();
-            // safety: monotonically increasing
+            // SAFETY: monotonically increasing
             let offsets = unsafe { OffsetsBuffer::new_unchecked(offsets.into()) };
 
             return Ok(offsets);
@@ -114,14 +114,14 @@ impl ChunkExplode for ArrayChunked {
                 if i == 0 {
                     return current_offset;
                 }
-                // Safety: we are within bounds
+                // SAFETY: we are within bounds
                 if unsafe { validity.get_bit_unchecked(i - 1) } {
                     current_offset += width as i64
                 }
                 current_offset
             })
             .collect::<Vec<_>>();
-        // safety: monotonically increasing
+        // SAFETY: monotonically increasing
         let offsets = unsafe { OffsetsBuffer::new_unchecked(offsets.into()) };
         Ok(offsets)
     }
@@ -141,7 +141,7 @@ impl ChunkExplode for ArrayChunked {
                     i * width
                 })
                 .collect::<Vec<_>>();
-            // safety: monotonically increasing
+            // SAFETY: monotonically increasing
             let offsets = unsafe { OffsetsBuffer::new_unchecked(offsets.into()) };
             return Ok((s, offsets));
         }
@@ -158,7 +158,7 @@ impl ChunkExplode for ArrayChunked {
         let mut current_offset = 0i64;
         offsets.push(current_offset);
         (0..arr.len()).for_each(|i| {
-            // Safety: we are within bounds
+            // SAFETY: we are within bounds
             if unsafe { validity.get_bit_unchecked(i) } {
                 let start = (i * width) as IdxSize;
                 let end = start + width as IdxSize;
@@ -170,13 +170,13 @@ impl ChunkExplode for ArrayChunked {
             offsets.push(current_offset);
         });
 
-        // Safety: the indices we generate are in bounds
+        // SAFETY: the indices we generate are in bounds
         let chunk = unsafe { take_unchecked(&**values, &indices.into()) };
-        // safety: monotonically increasing
+        // SAFETY: monotonically increasing
         let offsets = unsafe { OffsetsBuffer::new_unchecked(offsets.into()) };
 
         Ok((
-            // Safety: inner_dtype should be correct
+            // SAFETY: inner_dtype should be correct
             unsafe {
                 Series::from_chunks_and_dtype_unchecked(ca.name(), vec![chunk], &ca.inner_dtype())
             },
@@ -229,7 +229,7 @@ impl ChunkExplode for StringChunked {
             let mut bitmap = MutableBitmap::with_capacity(capacity);
             let values = values.as_slice();
             for (&offset, valid) in old_offsets[1..].iter().zip(validity) {
-                // safety:
+                // SAFETY:
                 // new_offsets already has a single value, so -1 is always in bounds
                 let latest_offset = unsafe { *new_offsets.get_unchecked(new_offsets.len() - 1) };
 
@@ -240,7 +240,7 @@ impl ChunkExplode for StringChunked {
 
                     // take the string value and find the char offsets
                     // create a new offset value for each char boundary
-                    // safety:
+                    // SAFETY:
                     // we know we have string data.
                     let str_val = unsafe { std::str::from_utf8_unchecked(val) };
 
@@ -279,7 +279,7 @@ impl ChunkExplode for StringChunked {
 
             let values = values.as_slice();
             for &offset in &old_offsets[1..] {
-                // safety:
+                // SAFETY:
                 // new_offsets already has a single value, so -1 is always in bounds
                 let latest_offset = unsafe { *new_offsets.get_unchecked(new_offsets.len() - 1) };
                 debug_assert!(old_offset as usize <= values.len());
@@ -288,7 +288,7 @@ impl ChunkExplode for StringChunked {
 
                 // take the string value and find the char offsets
                 // create a new offset value for each char boundary
-                // safety:
+                // SAFETY:
                 // we know we have string data.
                 let str_val = unsafe { std::str::from_utf8_unchecked(val) };
 

--- a/crates/polars-core/src/chunked_array/ops/reverse.rs
+++ b/crates/polars-core/src/chunked_array/ops/reverse.rs
@@ -92,7 +92,7 @@ impl ChunkReverse for ArrayChunked {
             get_fixed_size_list_builder(&ca.inner_dtype(), ca.len(), ca.width(), ca.name())
                 .expect("not yet supported");
 
-        // safety, we are within bounds
+        // SAFETY, we are within bounds
         unsafe {
             if arr.null_count() == 0 {
                 for i in (0..arr.len()).rev() {

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -107,7 +107,7 @@ mod inner_mod {
                     if size < options.min_periods {
                         builder.append_null();
                     } else {
-                        // safety:
+                        // SAFETY:
                         // we are in bounds
                         let arr_window = unsafe { arr.slice_typed_unchecked(start, size) };
 
@@ -117,7 +117,7 @@ mod inner_mod {
                             continue;
                         }
 
-                        // Safety.
+                        // SAFETY.
                         // ptr is not dropped as we are in scope
                         // We are also the only owner of the contents of the Arc
                         // we do this to reduce heap allocs.
@@ -161,7 +161,7 @@ mod inner_mod {
                     if size < options.min_periods {
                         builder.append_null();
                     } else {
-                        // safety:
+                        // SAFETY:
                         // we are in bounds
                         let arr_window = unsafe { arr.slice_typed_unchecked(start, size) };
 
@@ -171,7 +171,7 @@ mod inner_mod {
                             continue;
                         }
 
-                        // Safety.
+                        // SAFETY.
                         // ptr is not dropped as we are in scope
                         // We are also the only owner of the contents of the Arc
                         // we do this to reduce heap allocs.

--- a/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/categorical.rs
@@ -26,7 +26,7 @@ impl CategoricalChunked {
                 .map(|(idx, _v)| idx)
                 .collect_ca_trusted(self.name());
 
-            // safety:
+            // SAFETY:
             // we only reordered the indexes so we are still in bounds
             return unsafe {
                 CategoricalChunked::from_cats_and_rev_map_unchecked(
@@ -38,7 +38,7 @@ impl CategoricalChunked {
             };
         }
         let cats = self.physical().sort_with(options);
-        // safety:
+        // SAFETY:
         // we only reordered the indexes so we are still in bounds
         unsafe {
             CategoricalChunked::from_cats_and_rev_map_unchecked(

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -275,7 +275,7 @@ fn ordering_other_columns<'a>(
     idx_b: usize,
 ) -> Ordering {
     for (cmp, descending) in compare_inner.iter().zip(descending) {
-        // Safety:
+        // SAFETY:
         // indices are in bounds
         let ordering = unsafe { cmp.cmp_element_unchecked(idx_a, idx_b) };
         match (ordering, descending) {

--- a/crates/polars-core/src/chunked_array/temporal/date.rs
+++ b/crates/polars-core/src/chunked_array/temporal/date.rs
@@ -13,7 +13,7 @@ pub(crate) fn naive_date_to_date(nd: NaiveDate) -> i32 {
 
 impl DateChunked {
     pub fn as_date_iter(&self) -> impl TrustedLen<Item = Option<NaiveDate>> + '_ {
-        // safety: we know the iterators len
+        // SAFETY: we know the iterators len
         unsafe {
             self.downcast_iter()
                 .flat_map(|iter| {

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -200,7 +200,7 @@ impl<'a> Deserialize<'a> for AnyValue<'static> {
                     )
                 })?;
 
-                // safety:
+                // SAFETY:
                 // we are repr: u8 and check last value that we are in bounds
                 let field = unsafe {
                     if field <= LAST {
@@ -831,13 +831,13 @@ impl<'a> AnyValue<'a> {
             #[cfg(feature = "dtype-struct")]
             StructOwned(payload) => {
                 let av = StructOwned(payload);
-                // safety: owned is already static
+                // SAFETY: owned is already static
                 unsafe { std::mem::transmute::<AnyValue<'a>, AnyValue<'static>>(av) }
             },
             #[cfg(feature = "object")]
             ObjectOwned(payload) => {
                 let av = ObjectOwned(payload);
-                // safety: owned is already static
+                // SAFETY: owned is already static
                 unsafe { std::mem::transmute::<AnyValue<'a>, AnyValue<'static>>(av) }
             },
             #[cfg(feature = "dtype-decimal")]

--- a/crates/polars-core/src/frame/explode.rs
+++ b/crates/polars-core/src/frame/explode.rs
@@ -96,7 +96,7 @@ impl DataFrame {
             let mut row_idx = IdxCa::from_vec("", row_idx);
             row_idx.set_sorted_flag(IsSorted::Ascending);
 
-            // SAFETY
+            // SAFETY:
             // We just created indices that are in bounds.
             let mut df = unsafe { df.take_unchecked(&row_idx) };
             process_column(self, &mut df, exploded.clone())?;
@@ -330,13 +330,13 @@ impl DataFrame {
             values.extend_from_slice(value_col.chunks())
         }
         let values_arr = concatenate_owned_unchecked(&values)?;
-        // SAFETY
+        // SAFETY:
         // The give dtype is correct
         let values =
             unsafe { Series::from_chunks_and_dtype_unchecked(value_name, vec![values_arr], &st) };
 
         let variable_col = variable_col.as_box();
-        // SAFETY
+        // SAFETY:
         // The given dtype is correct
         let variables = unsafe {
             Series::from_chunks_and_dtype_unchecked(

--- a/crates/polars-core/src/frame/explode.rs
+++ b/crates/polars-core/src/frame/explode.rs
@@ -96,7 +96,7 @@ impl DataFrame {
             let mut row_idx = IdxCa::from_vec("", row_idx);
             row_idx.set_sorted_flag(IsSorted::Ascending);
 
-            // Safety
+            // SAFETY
             // We just created indices that are in bounds.
             let mut df = unsafe { df.take_unchecked(&row_idx) };
             process_column(self, &mut df, exploded.clone())?;
@@ -330,13 +330,13 @@ impl DataFrame {
             values.extend_from_slice(value_col.chunks())
         }
         let values_arr = concatenate_owned_unchecked(&values)?;
-        // Safety
+        // SAFETY
         // The give dtype is correct
         let values =
             unsafe { Series::from_chunks_and_dtype_unchecked(value_name, vec![values_arr], &st) };
 
         let variable_col = variable_col.as_box();
-        // Safety
+        // SAFETY
         // The given dtype is correct
         let variables = unsafe {
             Series::from_chunks_and_dtype_unchecked(

--- a/crates/polars-core/src/frame/from.rs
+++ b/crates/polars-core/src/frame/from.rs
@@ -15,7 +15,7 @@ impl TryFrom<StructArray> for DataFrame {
             .iter()
             .zip(arrs)
             .map(|(fld, arr)| {
-                // Safety
+                // SAFETY
                 // reported data type is correct
                 unsafe {
                     Series::_try_from_arrow_unchecked_with_md(

--- a/crates/polars-core/src/frame/from.rs
+++ b/crates/polars-core/src/frame/from.rs
@@ -15,7 +15,7 @@ impl TryFrom<StructArray> for DataFrame {
             .iter()
             .zip(arrs)
             .map(|(fld, arr)| {
-                // SAFETY
+                // SAFETY:
                 // reported data type is correct
                 unsafe {
                     Series::_try_from_arrow_unchecked_with_md(

--- a/crates/polars-core/src/frame/group_by/aggregations/agg_list.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/agg_list.rs
@@ -40,14 +40,14 @@ where
                     }
 
                     length_so_far += idx_len as i64;
-                    // Safety:
+                    // SAFETY:
                     // group tuples are in bounds
                     {
                         list_values.extend(idx.iter().map(|idx| {
                             debug_assert!((*idx as usize) < values.len());
                             *values.get_unchecked(*idx as usize)
                         }));
-                        // Safety:
+                        // SAFETY:
                         // we know that offsets has allocated enough slots
                         offsets.push_unchecked(length_so_far);
                     }
@@ -77,7 +77,7 @@ where
                     validity,
                 );
                 let data_type = ListArray::<i64>::default_datatype(T::get_dtype().to_arrow(true));
-                // Safety:
+                // SAFETY:
                 // offsets are monotonically increasing
                 let arr = ListArray::<i64>::new(
                     data_type,
@@ -110,7 +110,7 @@ where
                     length_so_far += len as i64;
                     list_values.extend_from_slice(&values[first as usize..(first + len) as usize]);
                     {
-                        // Safety:
+                        // SAFETY:
                         // we know that offsets has allocated enough slots
                         offsets.push_unchecked(length_so_far);
                     }

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -78,7 +78,7 @@ where
     // these represent the number of groups in the group_by operation
     let output_len = offsets.size_hint().0;
     // start with a dummy index, will be overwritten on first iteration.
-    // Safety:
+    // SAFETY:
     // we are in bounds
     let mut agg_window = unsafe { Agg::new(values, validity, 0, 0, params) };
 
@@ -90,7 +90,7 @@ where
         .map(|(idx, (start, len))| {
             let end = start + len;
 
-            // safety:
+            // SAFETY:
             // we are in bounds
 
             let agg = if start == end {
@@ -102,7 +102,7 @@ where
             match agg {
                 Some(val) => val,
                 None => {
-                    // safety: we are in bounds
+                    // SAFETY: we are in bounds
                     unsafe { validity.set_unchecked(idx, false) };
                     T::default()
                 },

--- a/crates/polars-core/src/frame/group_by/aggregations/string.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/string.rs
@@ -69,7 +69,7 @@ impl BinaryChunked {
                         let arr_group = _slice_from_offsets(self, first, len);
                         let borrowed = arr_group.min_binary();
 
-                        // Safety:
+                        // SAFETY:
                         // The borrowed has `arr_group`s lifetime, but it actually points to data
                         // hold by self. Here we tell the compiler that.
                         unsafe { std::mem::transmute::<Option<&[u8]>, Option<&'a [u8]>>(borrowed) }
@@ -131,7 +131,7 @@ impl BinaryChunked {
                         let arr_group = _slice_from_offsets(self, first, len);
                         let borrowed = arr_group.max_binary();
 
-                        // Safety:
+                        // SAFETY:
                         // The borrowed has `arr_group`s lifetime, but it actually points to data
                         // hold by self. Here we tell the compiler that.
                         unsafe { std::mem::transmute::<Option<&[u8]>, Option<&'a [u8]>>(borrowed) }

--- a/crates/polars-core/src/frame/group_by/hashing.rs
+++ b/crates/polars-core/src/frame/group_by/hashing.rs
@@ -362,7 +362,7 @@ pub(crate) fn populate_multiple_key_hashmap2<'a, V, H, F, G>(
             // cache misses
             original_h == idx_hash.hash && {
                 let key_idx = idx_hash.idx;
-                // Safety:
+                // SAFETY:
                 // indices in a group_by operation are always in bounds.
                 unsafe { compare_keys(keys_cmp, key_idx as usize, idx as usize) }
             }

--- a/crates/polars-core/src/frame/group_by/into_groups.rs
+++ b/crates/polars-core/src/frame/group_by/into_groups.rs
@@ -271,7 +271,7 @@ impl IntoGroupsProxy for BinaryChunked {
                         let ca = self.slice(offset as i64, len);
                         let byte_hashes = fill_bytes_hashes(&ca, null_h, hb.clone());
 
-                        // Safety:
+                        // SAFETY:
                         // the underlying data is tied to self
                         unsafe {
                             std::mem::transmute::<Vec<BytesHash<'_>>, Vec<BytesHash<'a>>>(
@@ -327,7 +327,7 @@ impl IntoGroupsProxy for BinaryOffsetChunked {
                         let ca = self.slice(offset as i64, len);
                         let byte_hashes = fill_bytes_offset_hashes(&ca, null_h, hb.clone());
 
-                        // Safety:
+                        // SAFETY:
                         // the underlying data is tied to self
                         unsafe {
                             std::mem::transmute::<Vec<BytesHash<'_>>, Vec<BytesHash<'a>>>(
@@ -371,7 +371,7 @@ impl IntoGroupsProxy for ListChunked {
                             None => null_h,
                         };
 
-                        // Safety:
+                        // SAFETY:
                         // the underlying data is tied to self
                         unsafe {
                             std::mem::transmute::<BytesHash<'_>, BytesHash<'a>>(BytesHash::new(

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -811,7 +811,7 @@ impl<'df> GroupBy<'df> {
             .get_groups()
             .par_iter()
             .map(|g| {
-                // SAFETY
+                // SAFETY:
                 // groups are in bounds
                 let sub_df = unsafe { take_df(&df, g) };
                 f(sub_df)
@@ -833,7 +833,7 @@ impl<'df> GroupBy<'df> {
             .get_groups()
             .iter()
             .map(|g| {
-                // SAFETY
+                // SAFETY:
                 // groups are in bounds
                 let sub_df = unsafe { take_df(&df, g) };
                 f(sub_df)

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -811,7 +811,7 @@ impl<'df> GroupBy<'df> {
             .get_groups()
             .par_iter()
             .map(|g| {
-                // safety
+                // SAFETY
                 // groups are in bounds
                 let sub_df = unsafe { take_df(&df, g) };
                 f(sub_df)
@@ -833,7 +833,7 @@ impl<'df> GroupBy<'df> {
             .get_groups()
             .iter()
             .map(|g| {
-                // safety
+                // SAFETY
                 // groups are in bounds
                 let sub_df = unsafe { take_df(&df, g) };
                 f(sub_df)

--- a/crates/polars-core/src/frame/group_by/perfect.rs
+++ b/crates/polars-core/src/frame/group_by/perfect.rs
@@ -78,7 +78,7 @@ where
                         let end = cache_line_offsets[thread_no + 1];
                         let end = T::Native::from_usize(end).unwrap();
 
-                        // safety: we don't alias
+                        // SAFETY: we don't alias
                         let groups =
                             unsafe { std::slice::from_raw_parts_mut(groups_ptr.get(), len) };
                         let first = unsafe { std::slice::from_raw_parts_mut(first_ptr.get(), len) };
@@ -93,7 +93,7 @@ where
 
                                         unsafe {
                                             if buf.len() == 1 {
-                                                // safety: we just  pushed
+                                                // SAFETY: we just  pushed
                                                 let first_value = buf.get_unchecked(0);
                                                 *first.get_unchecked_release_mut(cat) = *first_value
                                             }
@@ -113,7 +113,7 @@ where
 
                                             unsafe {
                                                 if buf.len() == 1 {
-                                                    // safety: we just  pushed
+                                                    // SAFETY: we just  pushed
                                                     let first_value = buf.get_unchecked(0);
                                                     *first.get_unchecked_release_mut(cat) =
                                                         *first_value

--- a/crates/polars-core/src/frame/group_by/proxy.rs
+++ b/crates/polars-core/src/frame/group_by/proxy.rs
@@ -500,7 +500,7 @@ impl GroupsProxy {
     }
 
     pub fn slice(&self, offset: i64, len: usize) -> SlicedGroups {
-        // Safety:
+        // SAFETY:
         // we create new `Vec`s from the sliced groups. But we wrap them in ManuallyDrop
         // so that we never call drop on them.
         // These groups lifetimes are bounded to the `self`. This must remain valid

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -201,7 +201,7 @@ impl DataFrame {
     /// Reserve additional slots into the chunks of the series.
     pub(crate) fn reserve_chunks(&mut self, additional: usize) {
         for s in &mut self.columns {
-            // SAFETY
+            // SAFETY:
             // do not modify the data, simply resize.
             unsafe { s.chunks_mut().reserve(additional) }
         }

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -201,7 +201,7 @@ impl DataFrame {
     /// Reserve additional slots into the chunks of the series.
     pub(crate) fn reserve_chunks(&mut self, additional: usize) {
         for s in &mut self.columns {
-            // Safety
+            // SAFETY
             // do not modify the data, simply resize.
             unsafe { s.chunks_mut().reserve(additional) }
         }
@@ -231,7 +231,7 @@ impl DataFrame {
         };
 
         let series_cols = if S::is_series() {
-            // Safety:
+            // SAFETY:
             // we are guarded by the type system here.
             #[allow(clippy::transmute_undefined_repr)]
             let series_cols = unsafe { std::mem::transmute::<Vec<S>, Vec<Series>>(columns) };
@@ -1262,7 +1262,7 @@ impl DataFrame {
             },
             None => return None,
         }
-        // safety: we just checked bounds
+        // SAFETY: we just checked bounds
         unsafe { Some(self.columns.iter().map(|s| s.get_unchecked(idx)).collect()) }
     }
 
@@ -1868,7 +1868,7 @@ impl DataFrame {
             take = take.slice(offset, len);
         }
 
-        // Safety:
+        // SAFETY:
         // the created indices are in bounds
         let mut df = unsafe { df.take_unchecked_impl(&take, parallel) };
         set_sorted(&mut df);

--- a/crates/polars-core/src/frame/row/transpose.rs
+++ b/crates/polars-core/src/frame/row/transpose.rs
@@ -186,7 +186,7 @@ where
             let s = s.cast(&T::get_dtype()).unwrap();
             let ca = s.unpack::<T>().unwrap();
 
-            // SAFETY
+            // SAFETY:
             // we access in parallel, but every access is unique, so we don't break aliasing rules
             // we also ensured we allocated enough memory, so we never reallocate and thus
             // the pointers remain valid.

--- a/crates/polars-core/src/frame/row/transpose.rs
+++ b/crates/polars-core/src/frame/row/transpose.rs
@@ -65,14 +65,14 @@ impl DataFrame {
                 for s in columns {
                     polars_ensure!(s.dtype() == &phys_dtype, ComputeError: "cannot transpose with supertype: {}", dtype);
                     s.iter().zip(buffers.iter_mut()).for_each(|(av, buf)| {
-                        // safety: we checked the type and we borrow
+                        // SAFETY: we checked the type and we borrow
                         unsafe {
                             buf.add_unchecked_borrowed_physical(&av);
                         }
                     });
                 }
                 cols_t.extend(buffers.into_iter().zip(names_out).map(|(buf, name)| {
-                    // Safety: we are casting back to the supertype
+                    // SAFETY: we are casting back to the supertype
                     let mut s = unsafe { buf.into_series().cast_unchecked(dtype).unwrap() };
                     s.rename(name);
                     s
@@ -186,7 +186,7 @@ where
             let s = s.cast(&T::get_dtype()).unwrap();
             let ca = s.unpack::<T>().unwrap();
 
-            // Safety
+            // SAFETY
             // we access in parallel, but every access is unique, so we don't break aliasing rules
             // we also ensured we allocated enough memory, so we never reallocate and thus
             // the pointers remain valid.
@@ -227,7 +227,7 @@ where
             .zip(validity_buf)
             .zip(names_out)
             .map(|((mut values, validity), name)| {
-                // Safety:
+                // SAFETY:
                 // all values are written we can now set len
                 unsafe {
                     values.set_len(new_height);

--- a/crates/polars-core/src/hashing/mod.rs
+++ b/crates/polars-core/src/hashing/mod.rs
@@ -74,7 +74,7 @@ pub fn populate_multiple_key_hashmap<V, H, F, G>(
             // before we incur a cache miss
             idx_hash.hash == original_h && {
                 let key_idx = idx_hash.idx;
-                // Safety:
+                // SAFETY:
                 // indices in a group_by operation are always in bounds.
                 unsafe { compare_df_rows(keys, key_idx as usize, idx as usize) }
             }

--- a/crates/polars-core/src/serde/series.rs
+++ b/crates/polars-core/src/serde/series.rs
@@ -234,12 +234,12 @@ impl<'de> Deserialize<'de> for Series {
                             if let Some(s) = value {
                                 // we only have one chunk per series as we serialize it in this way.
                                 let arr = &s.chunks()[0];
-                                // safety, we are within bounds
+                                // SAFETY, we are within bounds
                                 unsafe {
                                     builder.push_unchecked(arr.as_ref(), 0);
                                 }
                             } else {
-                                // safety, we are within bounds
+                                // SAFETY, we are within bounds
                                 unsafe {
                                     builder.push_null();
                                 }

--- a/crates/polars-core/src/series/arithmetic/borrowed.rs
+++ b/crates/polars-core/src/series/arithmetic/borrowed.rs
@@ -50,7 +50,7 @@ where
     ChunkedArray<T>: IntoSeries,
 {
     fn subtract(lhs: &ChunkedArray<T>, rhs: &Series) -> PolarsResult<Series> {
-        // Safety:
+        // SAFETY:
         // There will be UB if a ChunkedArray is alive with the wrong datatype.
         // we now only create the potentially wrong dtype for a short time.
         // Note that the physical type correctness is checked!
@@ -60,28 +60,28 @@ where
         Ok(out.into_series())
     }
     fn add_to(lhs: &ChunkedArray<T>, rhs: &Series) -> PolarsResult<Series> {
-        // Safety:
+        // SAFETY:
         // see subtract
         let rhs = unsafe { lhs.unpack_series_matching_physical_type(rhs) };
         let out = lhs + rhs;
         Ok(out.into_series())
     }
     fn multiply(lhs: &ChunkedArray<T>, rhs: &Series) -> PolarsResult<Series> {
-        // Safety:
+        // SAFETY:
         // see subtract
         let rhs = unsafe { lhs.unpack_series_matching_physical_type(rhs) };
         let out = lhs * rhs;
         Ok(out.into_series())
     }
     fn divide(lhs: &ChunkedArray<T>, rhs: &Series) -> PolarsResult<Series> {
-        // Safety:
+        // SAFETY:
         // see subtract
         let rhs = unsafe { lhs.unpack_series_matching_physical_type(rhs) };
         let out = lhs / rhs;
         Ok(out.into_series())
     }
     fn remainder(lhs: &ChunkedArray<T>, rhs: &Series) -> PolarsResult<Series> {
-        // Safety:
+        // SAFETY:
         // see subtract
         let rhs = unsafe { lhs.unpack_series_matching_physical_type(rhs) };
         let out = lhs % rhs;
@@ -154,7 +154,7 @@ pub mod checked {
         ChunkedArray<T>: IntoSeries,
     {
         fn checked_div(lhs: &ChunkedArray<T>, rhs: &Series) -> PolarsResult<Series> {
-            // Safety:
+            // SAFETY:
             // There will be UB if a ChunkedArray is alive with the wrong datatype.
             // we now only create the potentially wrong dtype for a short time.
             // Note that the physical type correctness is checked!
@@ -173,7 +173,7 @@ pub mod checked {
 
     impl NumOpsDispatchCheckedInner for Float32Type {
         fn checked_div(lhs: &Float32Chunked, rhs: &Series) -> PolarsResult<Series> {
-            // Safety:
+            // SAFETY:
             // see check_div for chunkedarray<T>
             let rhs = unsafe { lhs.unpack_series_matching_physical_type(rhs) };
 
@@ -194,7 +194,7 @@ pub mod checked {
 
     impl NumOpsDispatchCheckedInner for Float64Type {
         fn checked_div(lhs: &Float64Chunked, rhs: &Series) -> PolarsResult<Series> {
-            // Safety:
+            // SAFETY:
             // see check_div
             let rhs = unsafe { lhs.unpack_series_matching_physical_type(rhs) };
 

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -343,7 +343,7 @@ impl Series {
 
                 if let Some(metadata) = md {
                     if metadata.get(DTYPE_ENUM_KEY) == Some(&DTYPE_ENUM_VALUE.into()) {
-                        // SAFETY
+                        // SAFETY:
                         // the invariants of an Arrow Dictionary guarantee the keys are in bounds
                         return Ok(CategoricalChunked::from_cats_and_rev_map_unchecked(
                             UInt32Chunked::with_chunk(name, keys.clone()),
@@ -354,7 +354,7 @@ impl Series {
                         .into_series());
                     }
                 }
-                // SAFETY
+                // SAFETY:
                 // the invariants of an Arrow Dictionary guarantee the keys are in bounds
                 Ok(
                     CategoricalChunked::from_keys_and_values(

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -113,7 +113,7 @@ impl Series {
                     .as_any()
                     .downcast_ref::<FixedSizeBinaryArray>()
                     .unwrap();
-                // Safety:
+                // SAFETY:
                 // this is highly unsafe. it will dereference a raw ptr on the heap
                 // make sure the ptr is allocated and from this pid
                 // (the pid is checked before dereference)
@@ -343,7 +343,7 @@ impl Series {
 
                 if let Some(metadata) = md {
                     if metadata.get(DTYPE_ENUM_KEY) == Some(&DTYPE_ENUM_VALUE.into()) {
-                        // Safety
+                        // SAFETY
                         // the invariants of an Arrow Dictionary guarantee the keys are in bounds
                         return Ok(CategoricalChunked::from_cats_and_rev_map_unchecked(
                             UInt32Chunked::with_chunk(name, keys.clone()),
@@ -354,7 +354,7 @@ impl Series {
                         .into_series());
                     }
                 }
-                // Safety
+                // SAFETY
                 // the invariants of an Arrow Dictionary guarantee the keys are in bounds
                 Ok(
                     CategoricalChunked::from_keys_and_values(
@@ -373,7 +373,7 @@ impl Series {
                     .as_any()
                     .downcast_ref::<FixedSizeBinaryArray>()
                     .unwrap();
-                // Safety:
+                // SAFETY:
                 // this is highly unsafe. it will dereference a raw ptr on the heap
                 // make sure the ptr is allocated and from this pid
                 // (the pid is checked before dereference)
@@ -706,7 +706,7 @@ impl TryFrom<(&str, Vec<ArrayRef>)> for Series {
         let (name, chunks) = name_arr;
 
         let data_type = check_types(&chunks)?;
-        // Safety:
+        // SAFETY:
         // dtype is checked
         unsafe { Series::_try_from_arrow_unchecked(name, chunks, &data_type) }
     }
@@ -729,7 +729,7 @@ impl TryFrom<(&ArrowField, Vec<ArrayRef>)> for Series {
 
         let data_type = check_types(&chunks)?;
 
-        // Safety:
+        // SAFETY:
         // dtype is checked
         unsafe {
             Series::_try_from_arrow_unchecked_with_md(

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -178,7 +178,7 @@ impl SeriesTrait for SeriesWrap<ListChunked> {
         }
         let main_thread = POOL.current_thread_index().is_none();
         let groups = self.group_tuples(main_thread, false);
-        // safety:
+        // SAFETY:
         // groups are in bounds
         Ok(unsafe { self.0.clone().into_series().agg_first(&groups?) })
     }

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -246,7 +246,7 @@ impl SeriesTrait for SeriesWrap<StructChunked> {
         }
         let main_thread = POOL.current_thread_index().is_none();
         let groups = self.group_tuples(main_thread, false);
-        // safety:
+        // SAFETY:
         // groups are in bounds
         Ok(unsafe { self.0.clone().into_series().agg_first(&groups?) })
     }

--- a/crates/polars-core/src/testing.rs
+++ b/crates/polars-core/src/testing.rs
@@ -45,7 +45,7 @@ impl Series {
     pub fn get_data_ptr(&self) -> usize {
         let object = self.0.deref();
 
-        // Safety:
+        // SAFETY:
         // A fat pointer consists of a data ptr and a ptr to the vtable.
         // we specifically check that we only transmute &dyn SeriesTrait e.g.
         // a trait object, therefore this is sound.

--- a/crates/polars-core/src/utils/flatten.rs
+++ b/crates/polars-core/src/utils/flatten.rs
@@ -8,7 +8,7 @@ pub fn flatten_df_iter(df: &DataFrame) -> impl Iterator<Item = DataFrame> + '_ {
             df.iter()
                 .zip(chunk.into_arrays())
                 .map(|(s, arr)| {
-                    // Safety:
+                    // SAFETY:
                     // datatypes are correct
                     let mut out = unsafe {
                         Series::from_chunks_and_dtype_unchecked(s.name(), vec![arr], s.dtype())

--- a/crates/polars-io/src/csv/buffer.rs
+++ b/crates/polars-io/src/csv/buffer.rs
@@ -197,7 +197,7 @@ impl ParsedBuffer for Utf8Field {
             self.scratch.reserve(bytes.len());
             polars_ensure!(bytes.len() > 1, ComputeError: "invalid csv file\n\nField `{}` is not properly escaped.", std::str::from_utf8(bytes).map_err(to_compute_err)?);
 
-            // Safety:
+            // SAFETY:
             // we just allocated enough capacity and data_len is correct.
             unsafe {
                 let n_written =
@@ -279,7 +279,7 @@ impl CategoricalField {
                 polars_ensure!(bytes.len() > 1, ComputeError: "invalid csv file\n\nField `{}` is not properly escaped.", std::str::from_utf8(bytes).map_err(to_compute_err)?);
                 self.escape_scratch.clear();
                 self.escape_scratch.reserve(bytes.len());
-                // Safety:
+                // SAFETY:
                 // we just allocated enough capacity and data_len is correct.
                 unsafe {
                     let n_written = escape_field(
@@ -290,12 +290,12 @@ impl CategoricalField {
                     self.escape_scratch.set_len(n_written);
                 }
 
-                // safety:
+                // SAFETY:
                 // just did utf8 check
                 let key = unsafe { std::str::from_utf8_unchecked(&self.escape_scratch) };
                 self.builder.append_value(key);
             } else {
-                // safety:
+                // SAFETY:
                 // just did utf8 check
                 unsafe {
                     self.builder
@@ -371,7 +371,7 @@ where
     DatetimeInfer<T>: TryFromWithUnit<Pattern>,
 {
     let val = if bytes.is_ascii() {
-        // Safety:
+        // SAFETY:
         // we just checked it is ascii
         unsafe { std::str::from_utf8_unchecked(bytes) }
     } else {

--- a/crates/polars-io/src/csv/parser.rs
+++ b/crates/polars-io/src/csv/parser.rs
@@ -438,7 +438,7 @@ pub(super) fn parse_lines(
                                 field
                             };
 
-                            // safety:
+                            // SAFETY:
                             // process fields is in bounds
                             add_null = unsafe { null_values.is_null(field, processed_fields) }
                         }

--- a/crates/polars-io/src/csv/splitfields.rs
+++ b/crates/polars-io/src/csv/splitfields.rs
@@ -64,7 +64,7 @@ mod inner {
             // There can be strings with separators:
             // "Street, City",
 
-            // Safety:
+            // SAFETY:
             // we have checked bounds
             let pos = if self.quoting && unsafe { *self.v.get_unchecked(0) } == self.quote_char {
                 needs_escaping = true;
@@ -90,7 +90,7 @@ mod inner {
 
                     if !in_field && self.eof_oel(c) {
                         if c == self.eol_char {
-                            // safety
+                            // SAFETY
                             // we are in bounds
                             return unsafe {
                                 self.finish_eol(needs_escaping, current_idx as usize)
@@ -111,7 +111,7 @@ mod inner {
                 match self.v.iter().position(|&c| self.eof_oel(c)) {
                     None => return self.finish(needs_escaping),
                     Some(idx) => unsafe {
-                        // Safety:
+                        // SAFETY:
                         // idx was just found
                         if *self.v.get_unchecked(idx) == self.eol_char {
                             return self.finish_eol(needs_escaping, idx);
@@ -124,7 +124,7 @@ mod inner {
 
             unsafe {
                 debug_assert!(pos <= self.v.len());
-                // safety
+                // SAFETY
                 // we are in bounds
                 let ret = Some((self.v.get_unchecked(..pos), needs_escaping));
                 self.v = self.v.get_unchecked(pos + 1..);
@@ -226,7 +226,7 @@ mod inner {
             // There can be strings with separators:
             // "Street, City",
 
-            // Safety:
+            // SAFETY:
             // we have checked bounds
             let pos = if self.quoting && unsafe { *self.v.get_unchecked(0) } == self.quote_char {
                 needs_escaping = true;
@@ -252,7 +252,7 @@ mod inner {
 
                     if !in_field && self.eof_oel(c) {
                         if c == self.eol_char {
-                            // safety
+                            // SAFETY
                             // we are in bounds
                             return unsafe {
                                 self.finish_eol(needs_escaping, current_idx as usize)
@@ -318,7 +318,7 @@ mod inner {
 
             unsafe {
                 debug_assert!(pos <= self.v.len());
-                // safety
+                // SAFETY
                 // we are in bounds
                 let ret = Some((self.v.get_unchecked(..pos), needs_escaping));
                 self.v = self.v.get_unchecked(pos + 1..);

--- a/crates/polars-io/src/csv/splitfields.rs
+++ b/crates/polars-io/src/csv/splitfields.rs
@@ -90,7 +90,7 @@ mod inner {
 
                     if !in_field && self.eof_oel(c) {
                         if c == self.eol_char {
-                            // SAFETY
+                            // SAFETY:
                             // we are in bounds
                             return unsafe {
                                 self.finish_eol(needs_escaping, current_idx as usize)
@@ -124,7 +124,7 @@ mod inner {
 
             unsafe {
                 debug_assert!(pos <= self.v.len());
-                // SAFETY
+                // SAFETY:
                 // we are in bounds
                 let ret = Some((self.v.get_unchecked(..pos), needs_escaping));
                 self.v = self.v.get_unchecked(pos + 1..);
@@ -252,7 +252,7 @@ mod inner {
 
                     if !in_field && self.eof_oel(c) {
                         if c == self.eol_char {
-                            // SAFETY
+                            // SAFETY:
                             // we are in bounds
                             return unsafe {
                                 self.finish_eol(needs_escaping, current_idx as usize)
@@ -318,7 +318,7 @@ mod inner {
 
             unsafe {
                 debug_assert!(pos <= self.v.len());
-                // SAFETY
+                // SAFETY:
                 // we are in bounds
                 let ret = Some((self.v.get_unchecked(..pos), needs_escaping));
                 self.v = self.v.get_unchecked(pos + 1..);

--- a/crates/polars-io/src/csv/write_impl.rs
+++ b/crates/polars-io/src/csv/write_impl.rs
@@ -402,7 +402,7 @@ pub(crate) fn write<W: Write>(
             df.as_single_chunk();
             let cols = df.get_columns();
 
-            // Safety:
+            // SAFETY:
             // the bck thinks the lifetime is bounded to write_buffer_pool, but at the time we return
             // the vectors the buffer pool, the series have already been removed from the buffers
             // in other words, the lifetime does not leave this scope

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -445,7 +445,7 @@ pub struct FetchRowGroupsFromMmapReader(ReaderBytes<'static>);
 
 impl FetchRowGroupsFromMmapReader {
     pub fn new(mut reader: Box<dyn MmapBytesReader>) -> PolarsResult<Self> {
-        // safety we will keep ownership on the struct and reference the bytes on the heap.
+        // SAFETY we will keep ownership on the struct and reference the bytes on the heap.
         // this should not work with passed bytes so we check if it is a file
         assert!(reader.to_file().is_some());
         let reader_ptr = unsafe {

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -445,7 +445,7 @@ pub struct FetchRowGroupsFromMmapReader(ReaderBytes<'static>);
 
 impl FetchRowGroupsFromMmapReader {
     pub fn new(mut reader: Box<dyn MmapBytesReader>) -> PolarsResult<Self> {
-        // SAFETY we will keep ownership on the struct and reference the bytes on the heap.
+        // SAFETY: we will keep ownership on the struct and reference the bytes on the heap.
         // this should not work with passed bytes so we check if it is a file
         assert!(reader.to_file().is_some());
         let reader_ptr = unsafe {

--- a/crates/polars-lazy/src/dsl/list.rs
+++ b/crates/polars-lazy/src/dsl/list.rs
@@ -120,7 +120,7 @@ fn run_on_group_by_engine(
     // List elements in a series.
     let values = Series::try_from(("", arr.values().clone())).unwrap();
     let inner_dtype = lst.inner_dtype();
-    // SAFETY
+    // SAFETY:
     // Invariant in List means values physicals can be cast to inner dtype
     let values = unsafe { values.cast_unchecked(&inner_dtype).unwrap() };
 

--- a/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -476,7 +476,7 @@ impl PartitionedAggregation for AggregationExpr {
                     GroupsProxy::Idx(groups) => {
                         for (_, idx) in groups {
                             let ca = unsafe {
-                                // SAFETY
+                                // SAFETY:
                                 // The indexes of the group_by operation are never out of bounds
                                 ca.take_unchecked(idx)
                             };

--- a/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/aggregation.rs
@@ -64,7 +64,7 @@ impl PhysicalExpr for AggregationExpr {
             }
         }
 
-        // Safety:
+        // SAFETY:
         // groups must always be in bounds.
         let out = unsafe {
             match self.agg_type {
@@ -335,7 +335,7 @@ impl PartitionedAggregation for AggregationExpr {
         let expr = self.input.as_partitioned_aggregator().unwrap();
         let series = expr.evaluate_partitioned(df, groups, state)?;
 
-        // Safety:
+        // SAFETY:
         // groups are in bounds
         unsafe {
             match self.agg_type {
@@ -476,7 +476,7 @@ impl PartitionedAggregation for AggregationExpr {
                     GroupsProxy::Idx(groups) => {
                         for (_, idx) in groups {
                             let ca = unsafe {
-                                // Safety
+                                // SAFETY
                                 // The indexes of the group_by operation are never out of bounds
                                 ca.take_unchecked(idx)
                             };
@@ -586,7 +586,7 @@ impl PhysicalExpr for AggQuantileExpr {
 
         let quantile = self.get_quantile(df, state)?;
 
-        // safety:
+        // SAFETY:
         // groups are in bounds
         let mut agg = unsafe {
             ac.flat_naive()

--- a/crates/polars-lazy/src/physical_plan/expressions/group_iter.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/group_iter.rs
@@ -17,7 +17,7 @@ impl<'a> AggregationContext<'a> {
                 self.groups();
                 let s = self.series().rechunk();
                 let name = if keep_names { s.name() } else { "" };
-                // safety: dtype is correct
+                // SAFETY: dtype is correct
                 unsafe {
                     Box::new(LitIter::new(
                         s.array_ref(0).clone(),
@@ -31,7 +31,7 @@ impl<'a> AggregationContext<'a> {
                 self.groups();
                 let s = self.series();
                 let name = if keep_names { s.name() } else { "" };
-                // safety: dtype is correct
+                // SAFETY: dtype is correct
                 unsafe {
                     Box::new(FlatIter::new(
                         s.array_ref(0).clone(),
@@ -83,7 +83,7 @@ impl<'a> LitIter<'a> {
             offset: 0,
             len,
             series_container,
-            // Safety: we pinned the series so the location is still valid
+            // SAFETY: we pinned the series so the location is still valid
             item: UnstableSeries::new(unsafe { &mut *ref_s }),
         }
     }
@@ -131,7 +131,7 @@ impl<'a> FlatIter<'a> {
             offset: 0,
             len,
             series_container,
-            // Safety: we pinned the series so the location is still valid
+            // SAFETY: we pinned the series so the location is still valid
             item: UnstableSeries::new(unsafe { &mut *ref_s }),
         }
     }

--- a/crates/polars-lazy/src/physical_plan/expressions/mod.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/mod.rs
@@ -343,7 +343,7 @@ impl<'a> AggregationContext<'a> {
             AggState::NotAggregated(s) => {
                 // We should not aggregate literals!!
                 if self.state.safe_to_agg(&self.groups) {
-                    // safety:
+                    // SAFETY:
                     // groups are in bounds
                     let agg = unsafe { s.agg_list(&self.groups) };
                     self.update_groups = UpdateGroups::WithGroupsLen;
@@ -445,7 +445,7 @@ impl<'a> AggregationContext<'a> {
                     }
                 }
 
-                // safety:
+                // SAFETY:
                 // groups are in bounds
                 let out = unsafe { s.agg_list(&self.groups) };
                 self.state = AggState::AggregatedList(out.clone());

--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -114,12 +114,12 @@ impl WindowExpr {
             take_idx = original_idx;
         }
         cache_gb(gb, state, cache_key);
-        // Safety:
+        // SAFETY:
         // we only have unique indices ranging from 0..len
         unsafe { perfect_sort(&POOL, &idx_mapping, &mut take_idx) };
         let idx = IdxCa::from_vec("", take_idx);
 
-        // Safety:
+        // SAFETY:
         // groups should always be in bounds.
         unsafe { Ok(flattened.take_unchecked(&idx)) }
     }
@@ -682,7 +682,7 @@ where
 {
     let mut values = Vec::with_capacity(len);
     let ptr: *mut T::Native = values.as_mut_ptr();
-    // safety:
+    // SAFETY:
     // we will write from different threads but we will never alias.
     let sync_ptr_values = unsafe { SyncPtr::new(ptr) };
 
@@ -724,7 +724,7 @@ where
             },
         }
 
-        // safety: we have written all slots
+        // SAFETY: we have written all slots
         unsafe { values.set_len(len) }
         Some(ChunkedArray::new_vec(ca.name(), values).into_series())
     } else {
@@ -796,7 +796,7 @@ where
                 })
             },
         }
-        // safety: we have written all slots
+        // SAFETY: we have written all slots
         unsafe { values.set_len(len) }
         unsafe { validity.set_len(len) }
         let validity = Bitmap::from(validity);

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -349,7 +349,7 @@ pub trait ListNameSpaceImpl: AsList {
             .downcast_iter()
             .map(|arr| sublist_get(arr, idx))
             .collect::<Vec<_>>();
-        // Safety: every element in list has dtype equal to its inner type
+        // SAFETY: every element in list has dtype equal to its inner type
         unsafe {
             Series::try_from((ca.name(), chunks))
                 .unwrap()

--- a/crates/polars-ops/src/chunked_array/mode.rs
+++ b/crates/polars-ops/src/chunked_array/mode.rs
@@ -14,7 +14,7 @@ where
     let groups = ca.group_tuples(parallel, false).unwrap();
     let idx = mode_indices(groups);
 
-    // Safety:
+    // SAFETY:
     // group indices are in bounds
     Ok(unsafe { ca.take_unchecked(idx.as_slice()) })
 }

--- a/crates/polars-ops/src/chunked_array/scatter.rs
+++ b/crates/polars-ops/src/chunked_array/scatter.rs
@@ -100,7 +100,7 @@ where
         let mut ca = self.rechunk();
         drop(self);
 
-        // safety:
+        // SAFETY:
         // we will not modify the length
         // and we unset the sorted flag.
         ca.set_sorted_flag(IsSorted::Not);
@@ -113,13 +113,13 @@ where
 
                 // reborrow because the bck does not allow it
                 let current_values = unsafe { &mut *std::slice::from_raw_parts_mut(ptr, len) };
-                // Safety:
+                // SAFETY:
                 // we checked bounds
                 unsafe { scatter_impl(current_values, values, arr, idx, len) };
             },
             None => {
                 let mut new_values = arr.values().as_slice().to_vec();
-                // Safety:
+                // SAFETY:
                 // we checked bounds
                 unsafe { scatter_impl(&mut new_values, values, arr, idx, len) };
                 arr.set_values(new_values.into());

--- a/crates/polars-ops/src/frame/join/cross_join.rs
+++ b/crates/polars-ops/src/frame/join/cross_join.rs
@@ -70,7 +70,7 @@ pub trait CrossJoin: IntoDf {
         // right take idx:  012301230123
 
         let create_left_df = || {
-            // Safety:
+            // SAFETY:
             // take left is in bounds
             unsafe { df_self.take_unchecked(&take_left(total_rows, n_rows_right, slice)) }
         };
@@ -80,7 +80,7 @@ pub trait CrossJoin: IntoDf {
             // many times, these are atomic operations
             // so we choose a different strategy at > 100 rows (arbitrarily small number)
             if n_rows_left > 100 || slice.is_some() {
-                // Safety:
+                // SAFETY:
                 // take right is in bounds
                 unsafe { other.take_unchecked(&take_right(total_rows, n_rows_right, slice)) }
             } else {

--- a/crates/polars-ops/src/frame/join/hash_join/mod.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/mod.rs
@@ -235,7 +235,7 @@ pub trait JoinDispatch: IntoDf {
         _check_categorical_src(s_left.dtype(), s_right.dtype())?;
 
         let idx = s_left.hash_join_semi_anti(s_right, anti);
-        // Safety:
+        // SAFETY:
         // indices are in bounds
         Ok(unsafe { ca_self._finish_anti_semi_join(&idx, slice) })
     }

--- a/crates/polars-ops/src/frame/join/hash_join/multiple_keys.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/multiple_keys.rs
@@ -148,7 +148,7 @@ fn probe_inner<F>(
 
             let entry = current_probe_table.raw_entry().from_hash(h, |idx_hash| {
                 let idx_b = idx_hash.idx;
-                // Safety:
+                // SAFETY:
                 // indices in a join operation are always in bounds.
                 unsafe { compare_df_rows2(a, b, idx_a as usize, idx_b as usize, join_nulls) }
             });
@@ -314,7 +314,7 @@ pub fn _left_join_multiple_keys(
 
                         let entry = current_probe_table.raw_entry().from_hash(h, |idx_hash| {
                             let idx_b = idx_hash.idx;
-                            // Safety:
+                            // SAFETY:
                             // indices in a join operation are always in bounds.
                             unsafe {
                                 compare_df_rows2(a, b, idx_a as usize, idx_b as usize, join_nulls)
@@ -443,7 +443,7 @@ pub(crate) fn semi_anti_join_multiple_keys_impl<'a>(
 
                         let entry = current_probe_table.raw_entry().from_hash(h, |idx_hash| {
                             let idx_b = idx_hash.idx;
-                            // Safety:
+                            // SAFETY:
                             // indices in a join operation are always in bounds.
                             unsafe {
                                 compare_df_rows2(a, b, idx_a as usize, idx_b as usize, join_nulls)
@@ -533,7 +533,7 @@ fn probe_outer<F, G, H>(
                     .raw_entry_mut()
                     .from_hash(h, |idx_hash| {
                         let idx_b = idx_hash.idx;
-                        // Safety:
+                        // SAFETY:
                         // indices in a join operation are always in bounds.
                         unsafe {
                             compare_df_rows2(a, b, idx_a as usize, idx_b as usize, join_nulls)

--- a/crates/polars-ops/src/frame/join/merge_sorted.rs
+++ b/crates/polars-ops/src/frame/join/merge_sorted.rs
@@ -120,7 +120,7 @@ where
         }
     });
 
-    // Safety: length is correct
+    // SAFETY: length is correct
     unsafe { iter.trust_my_length(total_len).collect_trusted() }
 }
 

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -287,7 +287,7 @@ pub trait DataFrameJoinOps: IntoDf {
                 }
 
                 let (df_left, df_right) = POOL.join(
-                    // safety: join indices are known to be in bounds
+                    // SAFETY: join indices are known to be in bounds
                     || unsafe { left_df._create_left_df_from_slice(join_idx_left, false, !swap) },
                     || unsafe {
                         // remove join columns
@@ -362,7 +362,7 @@ pub trait DataFrameJoinOps: IntoDf {
                 } else {
                     _left_semi_multiple_keys(&mut left, &mut right, args.join_nulls)
                 };
-                // Safety:
+                // SAFETY:
                 // indices are in bounds
                 Ok(unsafe { left_df._finish_anti_semi_join(&idx, args.slice) })
             },
@@ -497,7 +497,7 @@ trait DataFrameJoinOpsPrivate: IntoDf {
         }
 
         let (df_left, df_right) = POOL.join(
-            // safety: join indices are known to be in bounds
+            // SAFETY: join indices are known to be in bounds
             || unsafe { left_df._create_left_df_from_slice(join_tuples_left, false, sorted) },
             || unsafe {
                 other

--- a/crates/polars-ops/src/frame/pivot/mod.rs
+++ b/crates/polars-ops/src/frame/pivot/mod.rs
@@ -30,7 +30,7 @@ fn restore_logical_type(s: &Series, logical_type: &DataType) -> Series {
         (dt @ DataType::Categorical(Some(rev_map), ordering), _)
         | (dt @ DataType::Enum(Some(rev_map), ordering), _) => {
             let cats = s.u32().unwrap().clone();
-            // safety:
+            // SAFETY:
             // the rev-map comes from these categoricals
             unsafe {
                 CategoricalChunked::from_cats_and_rev_map_unchecked(

--- a/crates/polars-ops/src/frame/pivot/positioning.rs
+++ b/crates/polars-ops/src/frame/pivot/positioning.rs
@@ -44,7 +44,7 @@ pub(super) fn position_aggregates(
                     .zip(col_locations)
                     .zip(value_agg_phys.phys_iter())
                 {
-                    // Safety:
+                    // SAFETY:
                     // in bounds
                     unsafe {
                         let idx = *row_idx as usize + *col_idx as usize * n_rows;
@@ -139,7 +139,7 @@ where
                     .zip(col_locations)
                     .zip(value_agg_phys.into_iter())
                 {
-                    // Safety:
+                    // SAFETY:
                     // in bounds
                     unsafe {
                         let idx = *row_idx as usize + *col_idx as usize * n_rows;

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -575,7 +575,7 @@ fn is_in_cat(ca_in: &CategoricalChunked, other: &Series) -> PolarsResult<Boolean
             match &**rev_map {
                 RevMapping::Global(hash_map, categories, _) => {
                     for (global_idx, local_idx) in hash_map.iter() {
-                        // Safety: index is in bounds
+                        // SAFETY: index is in bounds
                         if others
                             .contains(unsafe { categories.value_unchecked(*local_idx as usize) })
                         {

--- a/crates/polars-ops/src/series/ops/to_dummies.rs
+++ b/crates/polars-ops/src/series/ops/to_dummies.rs
@@ -22,7 +22,7 @@ impl ToDummies for Series {
         let col_name = self.name();
         let groups = self.group_tuples(true, drop_first)?;
 
-        // safety: groups are in bounds
+        // SAFETY: groups are in bounds
         let columns = unsafe { self.agg_first(&groups) };
         let columns = columns.iter().zip(groups.iter()).skip(drop_first as usize);
         let columns = columns

--- a/crates/polars-parquet/src/arrow/read/deserialize/binview/basic.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binview/basic.rs
@@ -278,7 +278,7 @@ pub(super) fn finish(
             .boxed())
         },
         PhysicalType::Utf8View => {
-            // Safety: we already checked utf8
+            // SAFETY: we already checked utf8
             unsafe {
                 Ok(Utf8ViewArray::new_unchecked(
                     data_type.clone(),

--- a/crates/polars-pipe/src/executors/sinks/group_by/generic/global.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/generic/global.rs
@@ -146,7 +146,7 @@ impl GlobalTable {
                 let hash = *hashes.get_unchecked(i);
                 let chunk_index = *chunk_indexes.get_unchecked(i);
 
-                // safety: keys_iters and cols_iters are not depleted
+                // SAFETY: keys_iters and cols_iters are not depleted
                 let overflow = hash_map.insert(hash, row, &mut agg_cols_iters, chunk_index);
                 // should never overflow
                 debug_assert!(!overflow);

--- a/crates/polars-pipe/src/executors/sinks/group_by/generic/hash_table.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/generic/hash_table.rs
@@ -178,11 +178,11 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
         let spill_size = self.spill_size;
         self.spill_size = usize::MAX;
         for (key_other, agg_idx_other) in other.inner_map.iter() {
-            // safety: idx is from the hashmap, so is in bounds
+            // SAFETY: idx is from the hashmap, so is in bounds
             let row = unsafe { other.get_keys_row(key_other) };
 
             if on_condition(key_other.hash) {
-                // safety: will not overflow as we set it to usize::MAX;
+                // SAFETY: will not overflow as we set it to usize::MAX;
                 let agg_idx_self = unsafe {
                     self.insert_key(key_other.hash, row)
                         .unwrap_unchecked_release()
@@ -251,7 +251,7 @@ impl<const FIXED: bool> AggHashTable<FIXED> {
                     unsafe {
                         let running_agg = running_aggregations.get_unchecked_release_mut(i);
                         let av = running_agg.finalize();
-                        // safety: finalize creates owned AnyValues
+                        // SAFETY: finalize creates owned AnyValues
                         buffer.add_unchecked_owned_physical(&av);
                     }
                 }

--- a/crates/polars-pipe/src/executors/sinks/group_by/generic/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/generic/sink.rs
@@ -64,17 +64,17 @@ impl Sink for GenericGroupby2 {
         }
         // load data and hashes
         unsafe {
-            // safety: we don't hold mutable refs
+            // SAFETY: we don't hold mutable refs
             self.eval.evaluate_keys_aggs_and_hashes(context, &chunk)?;
         }
-        // safety: eval is alive for the duration of keys
+        // SAFETY: eval is alive for the duration of keys
         let keys = unsafe { self.eval.get_keys_iter() };
-        // safety: we don't hold mutable refs
+        // SAFETY: we don't hold mutable refs
         let mut aggs = unsafe { self.eval.get_aggs_iters() };
 
         let chunk_idx = chunk.chunk_index;
         unsafe {
-            // safety: the mutable borrows are not aliasing
+            // SAFETY: the mutable borrows are not aliasing
             let table = &mut *self.thread_local_table.get();
 
             for (hash, row) in self.eval.hashes().iter().zip(keys.values_iter()) {
@@ -89,7 +89,7 @@ impl Sink for GenericGroupby2 {
         // clear memory
         unsafe {
             drop(aggs);
-            // safety: we don't hold mutable refs, we just dropped them
+            // SAFETY: we don't hold mutable refs, we just dropped them
             self.eval.clear()
         };
 
@@ -122,7 +122,7 @@ impl Sink for GenericGroupby2 {
     }
 
     fn split(&self, _thread_no: usize) -> Box<dyn Sink> {
-        // safety: no mutable refs at this point
+        // SAFETY: no mutable refs at this point
         let map = unsafe { (*self.thread_local_table.get()).split() };
         Box::new(Self {
             eval: self.eval.split(),

--- a/crates/polars-pipe/src/executors/sinks/group_by/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/mod.rs
@@ -23,7 +23,7 @@ pub(super) fn physical_agg_to_logical(cols: &mut [Series], output_schema: &Schem
             dt @ (DataType::Categorical(rev_map, ordering) | DataType::Enum(rev_map, ordering)) => {
                 if let Some(rev_map) = rev_map {
                     let cats = s.u32().unwrap().clone();
-                    // safety:
+                    // SAFETY:
                     // the rev-map comes from these categoricals
                     unsafe {
                         *s = CategoricalChunked::from_cats_and_rev_map_unchecked(
@@ -37,7 +37,7 @@ pub(super) fn physical_agg_to_logical(cols: &mut [Series], output_schema: &Schem
                 } else {
                     let cats = s.u32().unwrap().clone();
                     if using_string_cache() {
-                        // Safety, we go from logical to primitive back to logical so the categoricals should still match the global map.
+                        // SAFETY, we go from logical to primitive back to logical so the categoricals should still match the global map.
                         *s = unsafe {
                             CategoricalChunked::from_global_indices_unchecked(cats, *ordering)
                                 .into_series()

--- a/crates/polars-pipe/src/executors/sinks/group_by/primitive/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/primitive/mod.rs
@@ -168,7 +168,7 @@ where
                         if agg_map.is_empty() {
                             return None;
                         }
-                        // safety:
+                        // SAFETY:
                         // we will not alias.
                         let ptr = aggregators as *mut AggregateFunction;
                         let agg_fns =
@@ -327,7 +327,7 @@ where
                 processed += 1;
             } else {
                 // set this row to true: e.g. processed ooc
-                // safety: we correctly set the length with `reset_ooc_filter_rows`
+                // SAFETY: we correctly set the length with `reset_ooc_filter_rows`
                 unsafe {
                     self.ooc_state.set_row_as_ooc(iteration_idx);
                 }

--- a/crates/polars-pipe/src/executors/sinks/group_by/string.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/string.rs
@@ -166,7 +166,7 @@ impl StringGroupbySink {
                     .zip(slices.par_iter())
                     .filter_map(|(agg_map, slice)| {
                         let ptr = aggregators as *mut AggregateFunction;
-                        // safety:
+                        // SAFETY:
                         // we will not alias.
                         let aggregators =
                             unsafe { std::slice::from_raw_parts_mut(ptr, aggregators_len) };
@@ -284,7 +284,7 @@ impl StringGroupbySink {
             match entry {
                 RawEntryMut::Vacant(_) => {
                     // set this row to true: e.g. processed ooc
-                    // safety: we correctly set the length with `reset_ooc_filter_rows`
+                    // SAFETY: we correctly set the length with `reset_ooc_filter_rows`
                     unsafe {
                         self.ooc_state.set_row_as_ooc(iteration_idx);
                     }
@@ -426,7 +426,7 @@ impl Sink for StringGroupbySink {
                             // the offset in the keys of self
                             let idx_self = k_self.idx as usize;
                             // slice to the keys of self
-                            // safety:
+                            // SAFETY:
                             // in bounds
                             let key_self = unsafe { self.keys.get_unchecked_release(idx_self) };
                             // compare the keys

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_probe_inner_left.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_probe_inner_left.rs
@@ -173,7 +173,7 @@ impl GenericJoinProbe {
         }
         polars_row::convert_columns_amortized_no_order(&self.join_columns, &mut self.current_rows);
 
-        // safety: we keep rows-encode alive
+        // SAFETY: we keep rows-encode alive
         let array = unsafe { self.current_rows.borrow_array() };
         Ok(if self.join_nulls {
             array
@@ -199,7 +199,7 @@ impl GenericJoinProbe {
                 out
             },
             Some(names) => unsafe {
-                // safety:
+                // SAFETY:
                 // if we have duplicate names, we overwrite
                 // them in the next snippet
                 left_df

--- a/crates/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -108,7 +108,7 @@ impl SortSink {
             // expensive
             let df = accumulate_dataframes_vertical_unchecked(self.chunks.drain(..));
             if df.height() > 0 {
-                // safety: we just asserted height > 0
+                // SAFETY: we just asserted height > 0
                 let sample = unsafe {
                     let s = &df.get_columns()[self.sort_idx];
                     s.to_physical_repr().get_unchecked(0).into_static().unwrap()

--- a/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
@@ -81,7 +81,7 @@ fn finalize_dataframe(
             assert_eq!(encoded.chunks().len(), 1);
             let arr = encoded.downcast_iter().next().unwrap();
 
-            // safety
+            // SAFETY
             // temporary extend lifetime
             // this is safe as the lifetime in rows stays bound to this scope
             let arrays = {
@@ -230,7 +230,7 @@ impl SortSinkMultiple {
         };
 
         debug_assert_eq!(column.chunks().len(), 1);
-        // Safety: length is correct
+        // SAFETY: length is correct
         unsafe { chunk.data.with_column_unchecked(column) };
         Ok(())
     }

--- a/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink_multiple.rs
@@ -81,7 +81,7 @@ fn finalize_dataframe(
             assert_eq!(encoded.chunks().len(), 1);
             let arr = encoded.downcast_iter().next().unwrap();
 
-            // SAFETY
+            // SAFETY:
             // temporary extend lifetime
             // this is safe as the lifetime in rows stays bound to this scope
             let arrays = {

--- a/crates/polars-plan/src/logical_plan/aexpr/mod.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/mod.rs
@@ -196,7 +196,7 @@ impl AExpr {
     #[cfg(feature = "cse")]
     pub(crate) fn is_equal(l: Node, r: Node, arena: &Arena<AExpr>) -> bool {
         let arena = arena as *const Arena<AExpr> as *mut Arena<AExpr>;
-        // safety: we can pass a *mut pointer
+        // SAFETY: we can pass a *mut pointer
         // the equality operation will not access mutable
         unsafe {
             let ae_node_l = AexprNode::from_raw(l, arena);

--- a/crates/polars-plan/src/logical_plan/functions/merge_sorted.rs
+++ b/crates/polars-plan/src/logical_plan/functions/merge_sorted.rs
@@ -2,7 +2,7 @@ use polars_core::prelude::*;
 use polars_ops::prelude::*;
 
 pub(super) fn merge_sorted(df: &DataFrame, column: &str) -> PolarsResult<DataFrame> {
-    // Safety:
+    // SAFETY:
     // the dtype is known
     let (left_cols, right_cols) = unsafe {
         (

--- a/crates/polars-plan/src/logical_plan/visitor/expr.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/expr.rs
@@ -55,7 +55,7 @@ impl AexprNode {
     where
         F: FnOnce(AexprNode) -> T,
     {
-        // safety: we drop this context before arena is out of scope
+        // SAFETY: we drop this context before arena is out of scope
         unsafe { op(Self::new(node, arena)) }
     }
 
@@ -64,7 +64,7 @@ impl AexprNode {
     where
         F: FnOnce(AexprNode, &mut Arena<AExpr>) -> T,
     {
-        // safety: we drop this context before arena is out of scope
+        // SAFETY: we drop this context before arena is out of scope
         unsafe { op(Self::new(node, arena), arena) }
     }
 
@@ -186,7 +186,7 @@ impl AexprNode {
             loop {
                 match (scratch1.pop(), scratch2.pop()) {
                     (Some(l), Some(r)) => {
-                        // safety: we can pass a *mut pointer
+                        // SAFETY: we can pass a *mut pointer
                         // the equality operation will not access mutable
                         let l = unsafe { AexprNode::from_raw(l, self.arena) };
                         let r = unsafe { AexprNode::from_raw(r, self.arena) };

--- a/crates/polars-plan/src/logical_plan/visitor/lp.rs
+++ b/crates/polars-plan/src/logical_plan/visitor/lp.rs
@@ -31,7 +31,7 @@ impl ALogicalPlanNode {
     where
         F: FnMut(ALogicalPlanNode) -> T,
     {
-        // safety: we drop this context before arena is out of scope
+        // SAFETY: we drop this context before arena is out of scope
         unsafe { op(Self::new(node, arena)) }
     }
 

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -69,20 +69,20 @@ pub fn convert_columns_amortized<'a, I: IntoIterator<Item = &'a SortField>>(
         let values_size =
             allocate_rows_buf(&flattened_columns, &mut rows.values, &mut rows.offsets);
         for (arr, field) in flattened_columns.iter().zip(flattened_fields.iter()) {
-            // Safety:
+            // SAFETY:
             // we allocated rows with enough bytes.
             unsafe { encode_array(&**arr, field, rows) }
         }
-        // safety: values are initialized
+        // SAFETY: values are initialized
         unsafe { rows.values.set_len(values_size) }
     } else {
         let values_size = allocate_rows_buf(columns, &mut rows.values, &mut rows.offsets);
         for (arr, field) in columns.iter().zip(fields) {
-            // Safety:
+            // SAFETY:
             // we allocated rows with enough bytes.
             unsafe { encode_array(&**arr, field, rows) }
         }
-        // safety: values are initialized
+        // SAFETY: values are initialized
         unsafe { rows.values.set_len(values_size) }
     }
 }

--- a/crates/polars-row/src/row.rs
+++ b/crates/polars-row/src/row.rs
@@ -33,10 +33,10 @@ fn checks(offsets: &[usize]) {
 unsafe fn rows_to_array(buf: Vec<u8>, offsets: Vec<usize>) -> BinaryArray<i64> {
     checks(&offsets);
 
-    // Safety: we checked overflow
+    // SAFETY: we checked overflow
     let offsets = std::mem::transmute::<Vec<usize>, Vec<i64>>(offsets);
 
-    // Safety: monotonically increasing
+    // SAFETY: monotonically increasing
     let offsets = Offsets::new_unchecked(offsets);
 
     BinaryArray::new(ArrowDataType::LargeBinary, offsets.into(), buf.into(), None)

--- a/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/no_nulls.rs
@@ -39,7 +39,7 @@ where
                 if len < (min_periods as IdxSize) {
                     None
                 } else {
-                    // safety:
+                    // SAFETY:
                     // we are in bounds
                     Some(unsafe { agg_window.update(start as usize, end as usize) })
                 }

--- a/crates/polars-time/src/chunkedarray/string/strptime.rs
+++ b/crates/polars-time/src/chunkedarray/string/strptime.rs
@@ -120,7 +120,7 @@ impl StrpTimeState {
             debug_assert!(offset < val.len());
             let b = *val.get_unchecked(offset);
             if *fmt_b == ESCAPE {
-                // Safety: we must ensure we provide valid patterns
+                // SAFETY: we must ensure we provide valid patterns
                 let next = fmt_iter.next();
                 debug_assert!(next.is_some());
                 match next.unwrap_unchecked() {

--- a/crates/polars-utils/src/ord.rs
+++ b/crates/polars-utils/src/ord.rs
@@ -11,14 +11,14 @@ where
     // this branch should be optimized away for integers
     if T::is_float() {
         match (a.is_nan(), b.is_nan()) {
-            // safety: we checked nans
+            // SAFETY: we checked nans
             (false, false) => unsafe { a.partial_cmp(b).unwrap_unchecked() },
             (true, true) => Ordering::Equal,
             (true, false) => Ordering::Less,
             (false, true) => Ordering::Greater,
         }
     } else {
-        // Safety:
+        // SAFETY:
         // all integers are Ord
         unsafe { a.partial_cmp(b).unwrap_unchecked() }
     }
@@ -33,14 +33,14 @@ where
     // this branch should be optimized away for integers
     if T::is_float() {
         match (a.is_nan(), b.is_nan()) {
-            // safety: we checked nans
+            // SAFETY: we checked nans
             (false, false) => unsafe { a.partial_cmp(b).unwrap_unchecked() },
             (true, true) => Ordering::Equal,
             (true, false) => Ordering::Greater,
             (false, true) => Ordering::Less,
         }
     } else {
-        // Safety:
+        // SAFETY:
         // all integers are Ord
         unsafe { a.partial_cmp(b).unwrap_unchecked() }
     }

--- a/crates/polars-utils/src/sort.rs
+++ b/crates/polars-utils/src/sort.rs
@@ -34,14 +34,14 @@ pub unsafe fn perfect_sort(pool: &ThreadPool, idx: &[(IdxSize, IdxSize)], out: &
         idx.par_chunks(chunk_size).for_each(|indices| {
             let ptr = ptr as *mut IdxSize;
             for (idx_val, idx_location) in indices {
-                // Safety:
+                // SAFETY:
                 // idx_location is in bounds by invariant of this function
                 // and we ensured we have at least `idx.len()` capacity
                 *ptr.add(*idx_location as usize) = *idx_val;
             }
         });
     });
-    // Safety:
+    // SAFETY:
     // all elements are written
     out.set_len(idx.len());
 }
@@ -65,14 +65,14 @@ pub unsafe fn perfect_sort(
         idx.par_chunks(chunk_size).for_each(|indices| {
             let ptr = ptr as *mut IdxSize;
             for (idx_val, idx_location) in indices {
-                // Safety:
+                // SAFETY:
                 // idx_location is in bounds by invariant of this function
                 // and we ensured we have at least `idx.len()` capacity
                 *ptr.add(*idx_location as usize) = *idx_val;
             }
         });
     });
-    // Safety:
+    // SAFETY:
     // all elements are written
     out.set_len(idx.len());
 }

--- a/py-polars/src/batched_csv.rs
+++ b/py-polars/src/batched_csv.rs
@@ -142,7 +142,7 @@ impl PyBatchedCsv {
         }
         .map_err(PyPolarsErr::from)?;
 
-        // safety: same memory layout
+        // SAFETY: same memory layout
         let batches = unsafe {
             std::mem::transmute::<Option<Vec<DataFrame>>, Option<Vec<PyDataFrame>>>(batches)
         };

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -38,19 +38,19 @@ use crate::series::PySeries;
 use crate::{PyDataFrame, PyLazyFrame};
 
 pub(crate) fn slice_to_wrapped<T>(slice: &[T]) -> &[Wrap<T>] {
-    // Safety:
+    // SAFETY:
     // Wrap is transparent.
     unsafe { std::mem::transmute(slice) }
 }
 
 pub(crate) fn slice_extract_wrapped<T>(slice: &[Wrap<T>]) -> &[T] {
-    // Safety:
+    // SAFETY:
     // Wrap is transparent.
     unsafe { std::mem::transmute(slice) }
 }
 
 pub(crate) fn vec_extract_wrapped<T>(buf: Vec<Wrap<T>>) -> Vec<T> {
-    // Safety:
+    // SAFETY:
     // Wrap is transparent.
     unsafe { std::mem::transmute(buf) }
 }
@@ -129,7 +129,7 @@ fn struct_dict<'a>(
 // accept u128 array to ensure alignment is correct
 fn decimal_to_digits(v: i128, buf: &mut [u128; 3]) -> usize {
     const ZEROS: i128 = 0x3030_3030_3030_3030_3030_3030_3030_3030;
-    // safety: transmute is safe as there are 48 bytes in 3 128bit ints
+    // SAFETY: transmute is safe as there are 48 bytes in 3 128bit ints
     // and the minimal alignment of u8 fits u16
     let buf = unsafe { std::mem::transmute::<&mut [u128; 3], &mut [u8; 48]>(buf) };
     let mut buffer = itoa::Buffer::new();

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -780,7 +780,7 @@ impl PyDataFrame {
                                     s.get_object(idx).map(|any| any.into());
                                 obj.to_object(py)
                             },
-                            // safety: we are in bounds.
+                            // SAFETY: we are in bounds.
                             _ => unsafe { Wrap(s.get_unchecked(idx)).into_py(py) },
                         }),
                     )

--- a/py-polars/src/expr/general.rs
+++ b/py-polars/src/expr/general.rs
@@ -685,7 +685,7 @@ impl PyExpr {
         self.inner.clone().exclude(columns).into()
     }
     fn exclude_dtype(&self, dtypes: Vec<Wrap<DataType>>) -> Self {
-        // Safety:
+        // SAFETY:
         // Wrap is transparent.
         let dtypes: Vec<DataType> = unsafe { std::mem::transmute(dtypes) };
         self.inner.clone().exclude_dtype(&dtypes).into()

--- a/py-polars/src/expr/mod.rs
+++ b/py-polars/src/expr/mod.rs
@@ -33,7 +33,7 @@ pub(crate) trait ToExprs {
 
 impl ToExprs for Vec<PyExpr> {
     fn to_exprs(self) -> Vec<Expr> {
-        // SAFETY
+        // SAFETY:
         // repr is transparent
         unsafe { std::mem::transmute(self) }
     }
@@ -45,7 +45,7 @@ pub(crate) trait ToPyExprs {
 
 impl ToPyExprs for Vec<Expr> {
     fn to_pyexprs(self) -> Vec<PyExpr> {
-        // SAFETY
+        // SAFETY:
         // repr is transparent
         unsafe { std::mem::transmute(self) }
     }

--- a/py-polars/src/expr/mod.rs
+++ b/py-polars/src/expr/mod.rs
@@ -33,7 +33,7 @@ pub(crate) trait ToExprs {
 
 impl ToExprs for Vec<PyExpr> {
     fn to_exprs(self) -> Vec<Expr> {
-        // Safety
+        // SAFETY
         // repr is transparent
         unsafe { std::mem::transmute(self) }
     }
@@ -45,7 +45,7 @@ pub(crate) trait ToPyExprs {
 
 impl ToPyExprs for Vec<Expr> {
     fn to_pyexprs(self) -> Vec<PyExpr> {
-        // Safety
+        // SAFETY
         // repr is transparent
         unsafe { std::mem::transmute(self) }
     }

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -99,7 +99,7 @@ impl PyLazyFrame {
             .read_to_string(&mut json)
             .unwrap();
 
-        // SAFETY
+        // SAFETY:
         // we skipped the serializing/deserializing of the static in lifetime in `DataType`
         // so we actually don't have a lifetime at all when serializing.
 

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -99,7 +99,7 @@ impl PyLazyFrame {
             .read_to_string(&mut json)
             .unwrap();
 
-        // Safety
+        // SAFETY
         // we skipped the serializing/deserializing of the static in lifetime in `DataType`
         // so we actually don't have a lifetime at all when serializing.
 

--- a/py-polars/src/map/dataframe.rs
+++ b/py-polars/src/map/dataframe.rs
@@ -277,7 +277,7 @@ pub fn apply_lambda_with_rows_output<'a>(
                 row_buf.0.push(v);
             }
             let ptr = &row_buf as *const Row;
-            // Safety:
+            // SAFETY:
             // we know that row constructor of polars dataframe does not keep a reference
             // to the row. Before we mutate the row buf again, the reference is dropped.
             // we only cannot prove it to the compiler.
@@ -296,7 +296,7 @@ pub fn apply_lambda_with_rows_output<'a>(
     let schema = rows_to_schema_first_non_null(&buf, Some(50));
 
     if init_null_count > 0 {
-        // Safety: we know the iterators size
+        // SAFETY: we know the iterators size
         let iter = unsafe {
             (0..init_null_count)
                 .map(|_| Ok(&null_row))
@@ -306,7 +306,7 @@ pub fn apply_lambda_with_rows_output<'a>(
         };
         DataFrame::try_from_rows_iter_and_schema(iter, &schema)
     } else {
-        // Safety: we know the iterators size
+        // SAFETY: we know the iterators size
         let iter = unsafe {
             buf.iter()
                 .map(Ok)

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -50,7 +50,7 @@ pub(crate) trait ToSeries {
 
 impl ToSeries for Vec<PySeries> {
     fn to_series(self) -> Vec<Series> {
-        // SAFETY
+        // SAFETY:
         // repr is transparent
         unsafe { std::mem::transmute(self) }
     }
@@ -62,7 +62,7 @@ pub(crate) trait ToPySeries {
 
 impl ToPySeries for Vec<Series> {
     fn to_pyseries(self) -> Vec<PySeries> {
-        // SAFETY
+        // SAFETY:
         // repr is transparent
         unsafe { std::mem::transmute(self) }
     }

--- a/py-polars/src/series/mod.rs
+++ b/py-polars/src/series/mod.rs
@@ -50,7 +50,7 @@ pub(crate) trait ToSeries {
 
 impl ToSeries for Vec<PySeries> {
     fn to_series(self) -> Vec<Series> {
-        // Safety
+        // SAFETY
         // repr is transparent
         unsafe { std::mem::transmute(self) }
     }
@@ -62,7 +62,7 @@ pub(crate) trait ToPySeries {
 
 impl ToPySeries for Vec<Series> {
     fn to_pyseries(self) -> Vec<PySeries> {
-        // Safety
+        // SAFETY
         // repr is transparent
         unsafe { std::mem::transmute(self) }
     }


### PR DESCRIPTION
Use consistent style for safety comments.

See: https://rust-lang.github.io/rust-clippy/master/#/undocumented_unsafe_blocks