### PR TITLE
Revert "test(python): Use resolved path in `test_user_guide`"

### DIFF
--- a/py-polars/tests/docs/test_user_guide.py
+++ b/py-polars/tests/docs/test_user_guide.py
@@ -22,7 +22,7 @@ snippet_paths = [p for p in snippet_paths if "visualization" not in str(p)]
 @pytest.fixture(scope="module")
 def _change_test_dir() -> Iterator[None]:
     """Change path to repo root to accommodate data paths in code snippets."""
-    current_path = Path().resolve()
+    current_path = Path()
     os.chdir(repo_root)
     yield
     os.chdir(current_path)


### PR DESCRIPTION
Reverts pola-rs/polars#14449

Unfortunately this causes new test failures. So until the issue is addressed properly, I am reverting this.