### PR TITLE
docs(python): Update `read_database` docstring note about getting the connection URI string for sqlalchemy

### DIFF
--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -489,7 +489,8 @@ def read_database(  # noqa: D417
       `connectorx` will optimise translation of the result set into Arrow format
       in Rust, whereas these libraries will return row-wise data to Python *before*
       we can load into Arrow. Note that you can easily determine the connection's
-      URI from a SQLAlchemy engine object by calling `str(conn.engine.url)`.
+      URI from a SQLAlchemy engine object by calling
+      `conn.engine.url.render_as_string(hide_password=False)`.
 
     * If polars has to create a cursor from your connection in order to execute the
       query then that cursor will be automatically closed when the query completes;


### PR DESCRIPTION
The behaviour of `str(sqlalchemy_url)` was changed in v2 to hide the password by default.

The docs was updated to use `render_as_string(hide_password=False)`

Ref: https://docs.sqlalchemy.org/en/20/changelog/whatsnew_20.html#change-8567

