### PR TITLE
feat: change print to warn in reading csv from python file like object

### DIFF
--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -3,10 +3,10 @@ use std::io;
 use std::io::{BufReader, Cursor, Read, Seek, SeekFrom, Write};
 
 use polars::io::mmap::MmapBytesReader;
+use polars_error::polars_warn;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
-use polars_error::polars_warn;
 
 use crate::error::PyPolarsErr;
 use crate::prelude::resolve_homedir;

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -6,7 +6,7 @@ use polars::io::mmap::MmapBytesReader;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
-use polars_error::{polars_warn, PolarsWarning};
+use polars_error::polars_warn;
 
 use crate::error::PyPolarsErr;
 use crate::prelude::resolve_homedir;

--- a/py-polars/src/file.rs
+++ b/py-polars/src/file.rs
@@ -6,6 +6,7 @@ use polars::io::mmap::MmapBytesReader;
 use pyo3::exceptions::PyTypeError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyString};
+use polars_error::{polars_warn, PolarsWarning};
 
 use crate::error::PyPolarsErr;
 use crate::prelude::resolve_homedir;
@@ -216,7 +217,7 @@ pub fn get_mmap_bytes_reader<'a>(py_f: &'a PyAny) -> PyResult<Box<dyn MmapBytesR
     else if py_f.getattr("read").is_ok() {
         // we can still get a file name, inform the user of possibly wrong API usage.
         if py_f.getattr("name").is_ok() {
-            eprintln!("Polars found a filename. \
+            polars_warn!("Polars found a filename. \
             Ensure you pass a path to the file instead of a python file object when possible for best \
             performance.")
         }


### PR DESCRIPTION
I noticed when reading csv files from inside a zip archive that it kept "warning" that I shouldn't do that and that I couldn't ignore the warning because it was printing rather than warning.