### PR TITLE
feat(python,rust!): Infer `values` columns in `DataFrame.pivot` when `values` is None

### DIFF
--- a/crates/polars-lazy/src/frame/pivot.rs
+++ b/crates/polars-lazy/src/frame/pivot.rs
@@ -31,11 +31,11 @@ impl PhysicalAggExpr for PivotExpr {
     }
 }
 
-pub fn pivot<I0, S0, I1, S1, I2, S2>(
+pub fn pivot<I0, I1, I2, S0, S1, S2>(
     df: &DataFrame,
-    values: I0,
-    index: I1,
-    columns: I2,
+    index: I0,
+    columns: I1,
+    values: Option<I2>,
     sort_columns: bool,
     agg_expr: Option<Expr>,
     // used as separator/delimiter in generated column names.
@@ -43,10 +43,10 @@ pub fn pivot<I0, S0, I1, S1, I2, S2>(
 ) -> PolarsResult<DataFrame>
 where
     I0: IntoIterator<Item = S0>,
-    S0: AsRef<str>,
     I1: IntoIterator<Item = S1>,
-    S1: AsRef<str>,
     I2: IntoIterator<Item = S2>,
+    S0: AsRef<str>,
+    S1: AsRef<str>,
     S2: AsRef<str>,
 {
     // make sure that the root column is replaced
@@ -56,20 +56,20 @@ where
     });
     polars_ops::pivot::pivot(
         df,
-        values,
         index,
         columns,
+        values,
         sort_columns,
         agg_expr,
         separator,
     )
 }
 
-pub fn pivot_stable<I0, S0, I1, S1, I2, S2>(
+pub fn pivot_stable<I0, I1, I2, S0, S1, S2>(
     df: &DataFrame,
-    values: I0,
-    index: I1,
-    columns: I2,
+    index: I0,
+    columns: I1,
+    values: Option<I2>,
     sort_columns: bool,
     agg_expr: Option<Expr>,
     // used as separator/delimiter in generated column names.
@@ -77,10 +77,10 @@ pub fn pivot_stable<I0, S0, I1, S1, I2, S2>(
 ) -> PolarsResult<DataFrame>
 where
     I0: IntoIterator<Item = S0>,
-    S0: AsRef<str>,
     I1: IntoIterator<Item = S1>,
-    S1: AsRef<str>,
     I2: IntoIterator<Item = S2>,
+    S0: AsRef<str>,
+    S1: AsRef<str>,
     S2: AsRef<str>,
 {
     // make sure that the root column is replaced
@@ -90,9 +90,9 @@ where
     });
     polars_ops::pivot::pivot_stable(
         df,
-        values,
         index,
         columns,
+        values,
         sort_columns,
         agg_expr,
         separator,

--- a/crates/polars/tests/it/core/pivot.rs
+++ b/crates/polars/tests/it/core/pivot.rs
@@ -6,29 +6,45 @@ use polars_ops::pivot::{pivot, pivot_stable, PivotAgg};
 #[cfg(feature = "dtype-date")]
 fn test_pivot_date_() -> PolarsResult<()> {
     let mut df = df![
-        "A" => [1, 1, 1, 1, 1, 1, 1, 1],
-        "B" => [8, 2, 3, 6, 3, 6, 2, 2],
-        "C" => [1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000]
+        "index" => [8, 2, 3, 6, 3, 6, 2, 2],
+        "columns" => [1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000],
+        "values" => [1, 1, 1, 1, 1, 1, 1, 1],
     ]?;
-    df.try_apply("C", |s| s.cast(&DataType::Date))?;
+    df.try_apply("columns", |s| s.cast(&DataType::Date))?;
 
-    let out = pivot(&df, ["A"], ["B"], ["C"], true, Some(PivotAgg::Count), None)?;
+    let out = pivot(
+        &df,
+        ["index"],
+        ["columns"],
+        Some(["values"]),
+        true,
+        Some(PivotAgg::Count),
+        None,
+    )?;
 
     let first = 1 as IdxSize;
     let expected = df![
-        "B" => [8i32, 2, 3, 6],
+        "index" => [8i32, 2, 3, 6],
         "1972-09-27" => [first, 3, 2, 2]
     ]?;
     assert!(out.equals_missing(&expected));
 
-    let mut out = pivot_stable(&df, ["C"], ["B"], ["A"], true, Some(PivotAgg::First), None)?;
+    let mut out = pivot_stable(
+        &df,
+        ["index"],
+        ["values"],
+        Some(["columns"]), // swapped on purpose
+        true,
+        Some(PivotAgg::First),
+        None,
+    )?;
     out.try_apply("1", |s| {
         let ca = s.date()?;
         Ok(ca.to_string("%Y-%d-%m"))
     })?;
 
     let expected = df![
-        "B" => [8i32, 2, 3, 6],
+        "index" => [8i32, 2, 3, 6],
         "1" => ["1972-27-09", "1972-27-09", "1972-27-09", "1972-27-09"]
     ]?;
     assert!(out.equals_missing(&expected));
@@ -38,31 +54,31 @@ fn test_pivot_date_() -> PolarsResult<()> {
 
 #[test]
 fn test_pivot_old() {
-    let s0 = Series::new("foo", ["A", "A", "B", "B", "C"].as_ref());
-    let s1 = Series::new("N", [1, 2, 2, 4, 2].as_ref());
-    let s2 = Series::new("bar", ["k", "l", "m", "m", "l"].as_ref());
+    let s0 = Series::new("index", ["A", "A", "B", "B", "C"].as_ref());
+    let s2 = Series::new("columns", ["k", "l", "m", "m", "l"].as_ref());
+    let s1 = Series::new("values", [1, 2, 2, 4, 2].as_ref());
     let df = DataFrame::new(vec![s0, s1, s2]).unwrap();
 
     let pvt = pivot(
         &df,
-        ["N"],
-        ["foo"],
-        ["bar"],
+        ["index"],
+        ["columns"],
+        Some(["values"]),
         false,
         Some(PivotAgg::Sum),
         None,
     )
     .unwrap();
-    assert_eq!(pvt.get_column_names(), &["foo", "k", "l", "m"]);
+    assert_eq!(pvt.get_column_names(), &["index", "k", "l", "m"]);
     assert_eq!(
         Vec::from(&pvt.column("m").unwrap().i32().unwrap().sort(false)),
         &[None, None, Some(6)]
     );
     let pvt = pivot(
         &df,
-        ["N"],
-        ["foo"],
-        ["bar"],
+        ["index"],
+        ["columns"],
+        Some(["values"]),
         false,
         Some(PivotAgg::Min),
         None,
@@ -74,9 +90,9 @@ fn test_pivot_old() {
     );
     let pvt = pivot(
         &df,
-        ["N"],
-        ["foo"],
-        ["bar"],
+        ["index"],
+        ["columns"],
+        Some(["values"]),
         false,
         Some(PivotAgg::Max),
         None,
@@ -88,9 +104,9 @@ fn test_pivot_old() {
     );
     let pvt = pivot(
         &df,
-        ["N"],
-        ["foo"],
-        ["bar"],
+        ["index"],
+        ["columns"],
+        Some(["values"]),
         false,
         Some(PivotAgg::Mean),
         None,
@@ -102,9 +118,9 @@ fn test_pivot_old() {
     );
     let pvt = pivot(
         &df,
-        ["N"],
-        ["foo"],
-        ["bar"],
+        ["index"],
+        ["columns"],
+        Some(["values"]),
         false,
         Some(PivotAgg::Count),
         None,
@@ -120,46 +136,51 @@ fn test_pivot_old() {
 #[cfg(feature = "dtype-categorical")]
 fn test_pivot_categorical() -> PolarsResult<()> {
     let mut df = df![
-        "A" => [1, 1, 1, 1, 1, 1, 1, 1],
-        "B" => [8, 2, 3, 6, 3, 6, 2, 2],
-        "C" => ["a", "b", "c", "a", "b", "c", "a", "b"]
+        "index" => [1, 1, 1, 1, 1, 1, 1, 1],
+        "columns" => ["a", "b", "c", "a", "b", "c", "a", "b"],
+        "values" => [8, 2, 3, 6, 3, 6, 2, 2],
     ]?;
-    df.try_apply("C", |s| {
+    df.try_apply("columns", |s| {
         s.cast(&DataType::Categorical(None, Default::default()))
     })?;
 
-    let out = pivot(&df, ["A"], ["B"], ["C"], true, Some(PivotAgg::Count), None)?;
-    assert_eq!(out.get_column_names(), &["B", "a", "b", "c"]);
+    let out = pivot(
+        &df,
+        ["index"],
+        ["columns"],
+        Some(["values"]),
+        true,
+        Some(PivotAgg::Count),
+        None,
+    )?;
+    assert_eq!(out.get_column_names(), &["index", "a", "b", "c"]);
 
     Ok(())
 }
 
 #[test]
 fn test_pivot_new() -> PolarsResult<()> {
-    let df = df!["A"=> ["foo", "foo", "foo", "foo", "foo",
-        "bar", "bar", "bar", "bar"],
-        "B"=> ["one", "one", "one", "two", "two",
-        "one", "one", "two", "two"],
-        "C"=> ["small", "large", "large", "small",
-        "small", "large", "small", "small", "large"],
-        "breaky"=> ["jam", "egg", "egg", "egg",
-         "jam", "jam", "potato", "jam", "jam"],
-        "D"=> [1, 2, 2, 3, 3, 4, 5, 6, 7],
-        "E"=> [2, 4, 5, 5, 6, 6, 8, 9, 9]
+    let df = df![
+        "index1"=> ["foo", "foo", "foo", "foo", "foo", "bar", "bar", "bar", "bar"],
+        "index2"=> ["one", "one", "one", "two", "two", "one", "one", "two", "two"],
+        "cols1"=> ["small", "large", "large", "small", "small", "large", "small", "small", "large"],
+        "cols2"=> ["jam", "egg", "egg", "egg", "jam", "jam", "potato", "jam", "jam"],
+        "values1"=> [1, 2, 2, 3, 3, 4, 5, 6, 7],
+        "values2"=> [2, 4, 5, 5, 6, 6, 8, 9, 9]
     ]?;
 
     let out = (pivot_stable(
         &df,
-        ["D"],
-        ["A", "B"],
-        ["C"],
+        ["index1", "index2"],
+        ["cols1"],
+        Some(["values1"]),
         true,
         Some(PivotAgg::Sum),
         None,
     ))?;
     let expected = df![
-        "A" => ["foo", "foo", "bar", "bar"],
-        "B" => ["one", "two", "one", "two"],
+        "index1" => ["foo", "foo", "bar", "bar"],
+        "index2" => ["one", "two", "one", "two"],
         "large" => [Some(4), None, Some(4), Some(7)],
         "small" => [1, 6, 5, 6],
     ]?;
@@ -167,16 +188,16 @@ fn test_pivot_new() -> PolarsResult<()> {
 
     let out = pivot_stable(
         &df,
-        ["D"],
-        ["A", "B"],
-        ["C", "breaky"],
+        ["index1", "index2"],
+        ["cols1", "cols2"],
+        Some(["values1"]),
         true,
         Some(PivotAgg::Sum),
         None,
     )?;
     let expected = df![
-        "A" => ["foo", "foo", "bar", "bar"],
-        "B" => ["one", "two", "one", "two"],
+        "index1" => ["foo", "foo", "bar", "bar"],
+        "index2" => ["one", "two", "one", "two"],
         "{\"large\",\"egg\"}" => [Some(4), None, None, None],
         "{\"large\",\"jam\"}" => [None, None, Some(4), Some(7)],
         "{\"small\",\"egg\"}" => [None, Some(3), None, None],
@@ -191,22 +212,22 @@ fn test_pivot_new() -> PolarsResult<()> {
 #[test]
 fn test_pivot_2() -> PolarsResult<()> {
     let df = df![
-        "name"=> ["avg", "avg", "act", "test", "test"],
-        "err" => [Some("name1"), Some("name2"), None, Some("name1"), Some("name2")],
-        "wght"=> [0.0, 0.1, 1.0, 0.4, 0.2]
+        "index" => [Some("name1"), Some("name2"), None, Some("name1"), Some("name2")],
+        "columns"=> ["avg", "avg", "act", "test", "test"],
+        "values"=> [0.0, 0.1, 1.0, 0.4, 0.2]
     ]?;
 
     let out = pivot_stable(
         &df,
-        ["wght"],
-        ["err"],
-        ["name"],
+        ["index"],
+        ["columns"],
+        Some(["values"]),
         false,
         Some(PivotAgg::First),
         None,
     )?;
     let expected = df![
-        "err" => [Some("name1"), Some("name2"), None],
+        "index" => [Some("name1"), Some("name2"), None],
         "avg" => [Some(0.0), Some(0.1), None],
         "act" => [None, None, Some(1.)],
         "test" => [Some(0.4), Some(0.2), None],
@@ -224,22 +245,22 @@ fn test_pivot_datetime() -> PolarsResult<()> {
         .and_hms_opt(12, 15, 0)
         .unwrap();
     let df = df![
-        "dt" => [dt, dt, dt, dt],
-        "key" => ["x", "x", "y", "y"],
-        "val" => [100, 50, 500, -80]
+        "index" => [dt, dt, dt, dt],
+        "columns" => ["x", "x", "y", "y"],
+        "values" => [100, 50, 500, -80]
     ]?;
 
     let out = pivot(
         &df,
-        ["val"],
-        ["dt"],
-        ["key"],
+        ["index"],
+        ["columns"],
+        Some(["values"]),
         false,
         Some(PivotAgg::Sum),
         None,
     )?;
     let expected = df![
-        "dt" => [dt],
+        "index" => [dt],
         "x" => [150],
         "y" => [420]
     ]?;

--- a/crates/polars/tests/it/core/pivot.rs
+++ b/crates/polars/tests/it/core/pivot.rs
@@ -7,16 +7,17 @@ use polars_ops::pivot::{pivot, pivot_stable, PivotAgg};
 fn test_pivot_date_() -> PolarsResult<()> {
     let mut df = df![
         "index" => [8, 2, 3, 6, 3, 6, 2, 2],
-        "columns" => [1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000],
-        "values" => [1, 1, 1, 1, 1, 1, 1, 1],
+        "values1" => [1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000],
+        "values2" => [1, 1, 1, 1, 1, 1, 1, 1],
     ]?;
-    df.try_apply("columns", |s| s.cast(&DataType::Date))?;
+    df.try_apply("values1", |s| s.cast(&DataType::Date))?;
 
+    // Test with date as the `columns` input
     let out = pivot(
         &df,
         ["index"],
-        ["columns"],
-        Some(["values"]),
+        ["values1"],
+        Some(["values2"]),
         true,
         Some(PivotAgg::Count),
         None,
@@ -29,11 +30,12 @@ fn test_pivot_date_() -> PolarsResult<()> {
     ]?;
     assert!(out.equals_missing(&expected));
 
+    // Test with date as the `values` input.
     let mut out = pivot_stable(
         &df,
         ["index"],
-        ["values"],
-        Some(["columns"]), // swapped on purpose
+        ["values2"],
+        Some(["values1"]),
         true,
         Some(PivotAgg::First),
         None,

--- a/docs/src/rust/user-guide/transformations/pivot.rs
+++ b/docs/src/rust/user-guide/transformations/pivot.rs
@@ -7,20 +7,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // --8<-- [start:df]
     let df = df!(
             "foo"=> ["A", "A", "B", "B", "C"],
-            "N"=> [1, 2, 2, 4, 2],
             "bar"=> ["k", "l", "m", "n", "o"],
+            "N"=> [1, 2, 2, 4, 2],
     )?;
     println!("{}", &df);
     // --8<-- [end:df]
 
     // --8<-- [start:eager]
-    let out = pivot(&df, ["N"], ["foo"], ["bar"], false, None, None)?;
+    let out = pivot(&df, ["foo"], ["bar"], Some(["N"]), false, None, None)?;
     println!("{}", &out);
     // --8<-- [end:eager]
 
     // --8<-- [start:lazy]
     let q = df.lazy();
-    let q2 = pivot(&q.collect()?, ["N"], ["foo"], ["bar"], false, None, None)?.lazy();
+    let q2 = pivot(
+        &q.collect()?,
+        ["foo"],
+        ["bar"],
+        Some(["N"]),
+        false,
+        None,
+        None,
+    )?
+    .lazy();
     let out = q2.collect()?;
     println!("{}", &out);
     // --8<-- [end:lazy]

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7246,20 +7246,11 @@ class DataFrame:
         """
         return self.lazy().explode(columns, *more_columns).collect(_eager=True)
 
-    @deprecate_nonkeyword_arguments(
-        allowed_args=["self"],
-        message=(
-            "The order of the parameters of `pivot` will change in the next breaking release."
-            " The order will become `index, columns, values` with `values` as an optional parameter."
-            " Use keyword arguments to silence this warning."
-        ),
-        version="0.20.8",
-    )
     def pivot(
         self,
-        values: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None,
         index: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None,
         columns: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None,
+        values: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
         aggregate_function: PivotAgg | Expr | None = None,
         *,
         maintain_order: bool = True,
@@ -7274,14 +7265,15 @@ class DataFrame:
 
         Parameters
         ----------
-        values
-            Column values to aggregate. Can be multiple columns if the *columns*
-            arguments contains multiple columns as well.
         index
             One or multiple keys to group by.
         columns
             Name of the column(s) whose values will be used as the header of the output
             DataFrame.
+        values
+            Column values to aggregate. Can be multiple columns if the *columns*
+            arguments contains multiple columns as well. If None, all remaining columns
+            will be used.
         aggregate_function
             Choose from:
 
@@ -7392,9 +7384,10 @@ class DataFrame:
         │ b    ┆ 0.964028 ┆ 0.999954 │
         └──────┴──────────┴──────────┘
         """  # noqa: W505
-        values = _expand_selectors(self, values)
         index = _expand_selectors(self, index)
         columns = _expand_selectors(self, columns)
+        if values is not None:
+            values = _expand_selectors(self, values)
 
         if isinstance(aggregate_function, str):
             if aggregate_function == "first":
@@ -7430,9 +7423,9 @@ class DataFrame:
 
         return self._from_pydf(
             self._df.pivot_expr(
-                values,
                 index,
                 columns,
+                values,
                 maintain_order,
                 sort_columns,
                 aggregate_expr,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -7246,11 +7246,20 @@ class DataFrame:
         """
         return self.lazy().explode(columns, *more_columns).collect(_eager=True)
 
+    @deprecate_nonkeyword_arguments(
+        allowed_args=["self"],
+        message=(
+            "The order of the parameters of `pivot` will change in the next breaking release."
+            " The order will become `index, columns, values` with `values` as an optional parameter."
+            " Use keyword arguments to silence this warning."
+        ),
+        version="0.20.8",
+    )
     def pivot(
         self,
+        values: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None,
         index: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None,
         columns: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None,
-        values: ColumnNameOrSelector | Sequence[ColumnNameOrSelector] | None = None,
         aggregate_function: PivotAgg | Expr | None = None,
         *,
         maintain_order: bool = True,
@@ -7265,15 +7274,15 @@ class DataFrame:
 
         Parameters
         ----------
+        values
+            Column values to aggregate. Can be multiple columns if the *columns*
+            arguments contains multiple columns as well. If None, all remaining columns
+            will be used.
         index
             One or multiple keys to group by.
         columns
             Name of the column(s) whose values will be used as the header of the output
             DataFrame.
-        values
-            Column values to aggregate. Can be multiple columns if the *columns*
-            arguments contains multiple columns as well. If None, all remaining columns
-            will be used.
         aggregate_function
             Choose from:
 

--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1218,11 +1218,12 @@ impl PyDataFrame {
     }
 
     #[cfg(feature = "pivot")]
+    #[pyo3(signature = (index, columns, values, maintain_order, sort_columns, aggregate_expr, separator))]
     pub fn pivot_expr(
         &self,
-        values: Vec<String>,
         index: Vec<String>,
         columns: Vec<String>,
+        values: Option<Vec<String>>,
         maintain_order: bool,
         sort_columns: bool,
         aggregate_expr: Option<PyExpr>,
@@ -1232,9 +1233,9 @@ impl PyDataFrame {
         let agg_expr = aggregate_expr.map(|expr| expr.inner);
         let df = fun(
             &self.df,
-            values,
             index,
             columns,
+            values,
             sort_columns,
             agg_expr,
             separator,

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -18,8 +18,8 @@ def test_pivot() -> None:
     df = pl.DataFrame(
         {
             "foo": ["A", "A", "B", "B", "C"],
-            "N": [1, 2, 2, 4, 2],
             "bar": ["k", "l", "m", "n", "o"],
+            "N": [1, 2, 2, 4, 2],
         }
     )
     result = df.pivot(index="foo", columns="bar", values="N", aggregate_function=None)
@@ -31,6 +31,34 @@ def test_pivot() -> None:
             ("C", None, None, None, None, 2),
         ],
         schema=["foo", "k", "l", "m", "n", "o"],
+    )
+    assert_frame_equal(result, expected)
+
+
+def test_pivot_no_values() -> None:
+    df = pl.DataFrame(
+        {
+            "foo": ["A", "A", "B", "B", "C"],
+            "bar": ["k", "l", "m", "n", "o"],
+            "N1": [1, 2, 2, 4, 2],
+            "N2": [1, 2, 2, 4, 2],
+        }
+    )
+    result = df.pivot(index="foo", columns="bar", aggregate_function=None)
+    expected = pl.DataFrame(
+        {
+            "foo": ["A", "B", "C"],
+            "N1_bar_k": [1, None, None],
+            "N1_bar_l": [2, None, None],
+            "N1_bar_m": [None, 2, None],
+            "N1_bar_n": [None, 4, None],
+            "N1_bar_o": [None, None, 2],
+            "N2_bar_k": [1, None, None],
+            "N2_bar_l": [2, None, None],
+            "N2_bar_m": [None, 2, None],
+            "N2_bar_n": [None, 4, None],
+            "N2_bar_o": [None, None, 2],
+        }
     )
     assert_frame_equal(result, expected)
 
@@ -47,9 +75,9 @@ def test_pivot_list() -> None:
         }
     )
     out = df.pivot(
+        values="b",
         index="a",
         columns="a",
-        values="b",
         aggregate_function="first",
         sort_columns=True,
     )
@@ -77,7 +105,7 @@ def test_pivot_aggregate(agg_fn: PivotAgg, expected_rows: list[tuple[Any]]) -> N
         }
     )
     result = df.pivot(
-        values="c", index="b", columns="a", aggregate_function=agg_fn, sort_columns=True
+        index="b", columns="a", values="c", aggregate_function=agg_fn, sort_columns=True
     )
     assert result.rows() == expected_rows
 
@@ -110,12 +138,12 @@ def test_pivot_categorical_index() -> None:
         schema=[("A", pl.Categorical), ("B", pl.Categorical)],
     )
 
-    result = df.pivot(values="B", index=["A"], columns="B", aggregate_function="len")
+    result = df.pivot(index=["A"], columns="B", values="B", aggregate_function="len")
     expected = {"A": ["Fire", "Water"], "Car": [1, 2], "Ship": [1, None]}
     assert result.to_dict(as_series=False) == expected
 
     # test expression dispatch
-    result = df.pivot(values="B", index=["A"], columns="B", aggregate_function=pl.len())
+    result = df.pivot(index=["A"], columns="B", values="B", aggregate_function=pl.len())
     assert result.to_dict(as_series=False) == expected
 
     df = pl.DataFrame(
@@ -127,7 +155,7 @@ def test_pivot_categorical_index() -> None:
         schema=[("A", pl.Categorical), ("B", pl.Categorical), ("C", pl.Categorical)],
     )
     result = df.pivot(
-        values="B", index=["A", "C"], columns="B", aggregate_function="len"
+        index=["A", "C"], columns="B", values="B", aggregate_function="len"
     )
     expected = {
         "A": ["Fire", "Water"],
@@ -150,17 +178,17 @@ def test_pivot_multiple_values_column_names_5116() -> None:
 
     with pytest.raises(ComputeError, match="found multiple elements in the same group"):
         df.pivot(
-            values=["x1", "x2"],
             index="c1",
             columns="c2",
+            values=["x1", "x2"],
             separator="|",
             aggregate_function=None,
         )
 
     result = df.pivot(
-        values=["x1", "x2"],
         index="c1",
         columns="c2",
+        values=["x1", "x2"],
         separator="|",
         aggregate_function="first",
     )
@@ -185,9 +213,9 @@ def test_pivot_duplicate_names_7731() -> None:
         }
     )
     result = df.pivot(
-        values=cs.integer(),
         index=cs.float(),
         columns=cs.string(),
+        values=cs.integer(),
         aggregate_function="first",
     ).to_dict(as_series=False)
     expected = {
@@ -202,7 +230,7 @@ def test_pivot_duplicate_names_7731() -> None:
 
 def test_pivot_duplicate_names_11663() -> None:
     df = pl.DataFrame({"a": [1, 2], "b": [1, 2], "c": ["x", "x"], "d": ["x", "y"]})
-    result = df.pivot(values="a", index="b", columns=["c", "d"]).to_dict(
+    result = df.pivot(index="b", columns=["c", "d"], values="a").to_dict(
         as_series=False
     )
     expected = {"b": [1, 2], '{"x","x"}': [1, None], '{"x","y"}': [None, 2]}
@@ -220,7 +248,7 @@ def test_pivot_multiple_columns_12407() -> None:
         }
     )
     result = df.pivot(
-        values=["a"], index="b", columns=["c", "e"], aggregate_function="len"
+        index="b", columns=["c", "e"], values=["a"], aggregate_function="len"
     ).to_dict(as_series=False)
     expected = {"b": ["a", "b"], '{"s","x"}': [1, None], '{"f","y"}': [None, 1]}
     assert result == expected
@@ -254,7 +282,7 @@ def test_pivot_index_struct_14101() -> None:
             "d": [1, 1, 3],
         }
     )
-    result = df.pivot(index="b", values="a", columns="c")
+    result = df.pivot(index="b", columns="c", values="a")
     expected = pl.DataFrame({"b": [{"a": 1}, {"a": 2}], "x": [1, None], "y": [2, 1]})
     assert_frame_equal(result, expected)
 
@@ -289,11 +317,11 @@ def test_pivot_floats() -> None:
 
     with pytest.raises(ComputeError, match="found multiple elements in the same group"):
         result = df.pivot(
-            values="price", index="weight", columns="quantity", aggregate_function=None
+            index="weight", columns="quantity", values="price", aggregate_function=None
         )
 
     result = df.pivot(
-        values="price", index="weight", columns="quantity", aggregate_function="first"
+        index="weight", columns="quantity", values="price", aggregate_function="first"
     )
     expected = {
         "weight": [1.0, 4.4, 8.8],
@@ -304,9 +332,9 @@ def test_pivot_floats() -> None:
     assert result.to_dict(as_series=False) == expected
 
     result = df.pivot(
-        values="price",
         index=["article", "weight"],
         columns="quantity",
+        values="price",
         aggregate_function=None,
     )
     expected = {
@@ -329,10 +357,19 @@ def test_pivot_reinterpret_5907() -> None:
     )
 
     result = df.pivot(
-        index=["A"], values=["C"], columns=["B"], aggregate_function=pl.element().sum()
+        index=["A"], columns=["B"], values=["C"], aggregate_function=pl.element().sum()
     )
     expected = {"A": [3, -2], "x": [100, 50], "y": [500, -80]}
     assert result.to_dict(as_series=False) == expected
+
+
+def test_pivot_subclassed_df() -> None:
+    class SubClassedDataFrame(pl.DataFrame):
+        pass
+
+    df = SubClassedDataFrame({"a": [1, 2], "b": [3, 4]})
+    result = df.pivot(index="a", columns="a", values="b", aggregate_function="first")
+    assert isinstance(result, SubClassedDataFrame)
 
 
 def test_pivot_temporal_logical_types() -> None:
@@ -389,19 +426,7 @@ def test_aggregate_function_default() -> None:
     with pytest.raises(
         pl.ComputeError, match="found multiple elements in the same group"
     ):
-        df.pivot(values="a", index="b", columns="c")
-
-
-def test_pivot_positional_args_deprecated() -> None:
-    df = pl.DataFrame(
-        {
-            "foo": ["A", "A", "B", "B", "C"],
-            "N": [1, 2, 2, 4, 2],
-            "bar": ["k", "l", "m", "n", "o"],
-        }
-    )
-    with pytest.deprecated_call():
-        df.pivot("N", "foo", "bar", aggregate_function=None)
+        df.pivot(index="b", columns="c", values="a")
 
 
 def test_pivot_aggregate_function_count_deprecated() -> None:
@@ -467,7 +492,7 @@ def test_multi_index_containing_struct() -> None:
             "d": [1, 1, 3],
         }
     )
-    result = df.pivot(index=("b", "d"), values="a", columns="c")
+    result = df.pivot(index=("b", "d"), columns="c", values="a")
     expected = pl.DataFrame(
         {"b": [{"a": 1}, {"a": 2}], "d": [1, 3], "x": [1, None], "y": [2, 1]}
     )

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -61,9 +61,7 @@ def test_pivot_no_values() -> None:
         }
     )
 
-    # the order of the output columns is volatile
-    assert set(result.columns) == set(expected.columns)
-    assert_frame_equal(result, expected.select(result.columns))
+    assert_frame_equal(result, expected)
 
 
 def test_pivot_list() -> None:

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -421,6 +421,18 @@ def test_aggregate_function_default() -> None:
         df.pivot(index="b", columns="c", values="a")
 
 
+def test_pivot_positional_args_deprecated() -> None:
+    df = pl.DataFrame(
+        {
+            "foo": ["A", "A", "B", "B", "C"],
+            "N": [1, 2, 2, 4, 2],
+            "bar": ["k", "l", "m", "n", "o"],
+        }
+    )
+    with pytest.deprecated_call():
+        df.pivot("N", "foo", "bar", aggregate_function=None)
+
+
 def test_pivot_aggregate_function_count_deprecated() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -44,7 +44,7 @@ def test_pivot_no_values() -> None:
             "N2": [1, 2, 2, 4, 2],
         }
     )
-    result = df.pivot(index="foo", columns="bar", aggregate_function=None)
+    result = df.pivot(index="foo", columns="bar", values=None, aggregate_function=None)
     expected = pl.DataFrame(
         {
             "foo": ["A", "B", "C"],
@@ -60,7 +60,10 @@ def test_pivot_no_values() -> None:
             "N2_bar_o": [None, None, 2],
         }
     )
-    assert_frame_equal(result, expected)
+
+    # the order of the output columns is volatile
+    assert set(result.columns) == set(expected.columns)
+    assert_frame_equal(result, expected.select(result.columns))
 
 
 def test_pivot_list() -> None:
@@ -75,9 +78,9 @@ def test_pivot_list() -> None:
         }
     )
     out = df.pivot(
-        values="b",
         index="a",
         columns="a",
+        values="b",
         aggregate_function="first",
         sort_columns=True,
     )

--- a/py-polars/tests/unit/operations/test_pivot.py
+++ b/py-polars/tests/unit/operations/test_pivot.py
@@ -363,15 +363,6 @@ def test_pivot_reinterpret_5907() -> None:
     assert result.to_dict(as_series=False) == expected
 
 
-def test_pivot_subclassed_df() -> None:
-    class SubClassedDataFrame(pl.DataFrame):
-        pass
-
-    df = SubClassedDataFrame({"a": [1, 2], "b": [3, 4]})
-    result = df.pivot(index="a", columns="a", values="b", aggregate_function="first")
-    assert isinstance(result, SubClassedDataFrame)
-
-
 def test_pivot_temporal_logical_types() -> None:
     date_lst = [datetime(_, 1, 1) for _ in range(1960, 1980)]
 


### PR DESCRIPTION
Resolves #12087.

I think we hold off until the next breaking release.