### PR TITLE
fix(python): Error on invalid `schema` input in DataFrame constructor

### DIFF
--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -140,10 +140,10 @@ def _map_py_type_to_dtype(
 
 
 def is_polars_dtype(dtype: Any, *, include_unknown: bool = False) -> bool:
-    """Indicate whether the given input is a Polars dtype, or dtype specialisation."""
+    """Indicate whether the given input is a Polars dtype, or dtype specialization."""
     try:
         if dtype == Unknown:
-            # does not represent a realisable dtype, so ignore by default
+            # does not represent a realizable dtype, so ignore by default
             return include_unknown
         else:
             return isinstance(dtype, (DataType, DataTypeClass))

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -835,7 +835,7 @@ def _unpack_schema(
         else:
             dtype = _normalize_dtype(dtype)
         name = lookup.get(name, name) if lookup else name
-        column_dtypes[name] = dtype
+        column_dtypes[name] = dtype  # type: ignore[assignment]
 
     # apply schema overrides
     if schema_overrides:

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -767,7 +767,6 @@ def _unpack_schema(
     schema_overrides: SchemaDict | None = None,
     n_expected: int | None = None,
     lookup_names: Iterable[str] | None = None,
-    include_overrides_in_columns: bool = False,
 ) -> tuple[list[str], SchemaDict]:
     """
     Unpack column names and create dtype lookup.
@@ -821,9 +820,6 @@ def _unpack_schema(
     # apply schema overrides
     if schema_overrides:
         column_dtypes.update(schema_overrides)
-
-        if include_overrides_in_columns:
-            column_names.extend(col for col in column_dtypes if col not in column_names)
 
     return column_names, column_dtypes
 

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -1526,7 +1526,7 @@ def test_df_schema_sequences() -> None:
         ["key", pl.Int64],
         ["value", pl.Float32],
     ]
-    df = pl.DataFrame(schema=schema)
+    df = pl.DataFrame(schema=schema)  # type: ignore[arg-type]
     assert df.schema == {"address": pl.String, "key": pl.Int64, "value": pl.Float32}
 
 
@@ -1537,4 +1537,4 @@ def test_df_schema_sequences_incorrect_length() -> None:
         ["value", pl.Float32],
     ]
     with pytest.raises(ValueError):
-        pl.DataFrame(schema=schema)
+        pl.DataFrame(schema=schema)  # type: ignore[arg-type]

--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -1518,3 +1518,23 @@ def test_df_init_dict_raise_on_expression_input() -> None:
     # Passing a list of expressions is allowed
     df = pl.DataFrame({"a": [pl.int_range(0, 3)]})
     assert df.get_column("a").dtype == pl.Object
+
+
+def test_df_schema_sequences() -> None:
+    schema = [
+        ["address", pl.String],
+        ["key", pl.Int64],
+        ["value", pl.Float32],
+    ]
+    df = pl.DataFrame(schema=schema)
+    assert df.schema == {"address": pl.String, "key": pl.Int64, "value": pl.Float32}
+
+
+def test_df_schema_sequences_incorrect_length() -> None:
+    schema = [
+        ["address", pl.String, pl.Int8],
+        ["key", pl.Int64],
+        ["value", pl.Float32],
+    ]
+    with pytest.raises(ValueError):
+        pl.DataFrame(schema=schema)


### PR DESCRIPTION
Closes #12178

Supersedes #12209

I did some refactoring of the `_unpack_schema` utility. This also closes the linked issue.

### Changes
* Error when the elements of the `schema` input cannot be unpacked into two variables (column, dtype).
* Allow non-tuple elements (`list` and other sequences are now also allowed, but MyPy will still complain).