### PR TITLE
depr(python): Rename `Expr.meta.write_json/Expr.from_json` to `Expr.meta.serialize/Expr.deserialize`

### DIFF
--- a/py-polars/docs/source/reference/expressions/meta.rst
+++ b/py-polars/docs/source/reference/expressions/meta.rst
@@ -17,5 +17,6 @@ The following methods are available under the `expr.meta` attribute.
     Expr.meta.pop
     Expr.meta.tree_format
     Expr.meta.root_names
+    Expr.meta.serialize
     Expr.meta.undo_aliases
     Expr.meta.write_json

--- a/py-polars/docs/source/reference/expressions/miscellaneous.rst
+++ b/py-polars/docs/source/reference/expressions/miscellaneous.rst
@@ -6,5 +6,6 @@ Miscellaneous
 .. autosummary::
    :toctree: api/
 
-    Expr.from_json
-    Expr.set_sorted
+   Expr.deserialize
+   Expr.from_json
+   Expr.set_sorted

--- a/py-polars/docs/source/reference/expressions/miscellaneous.rst
+++ b/py-polars/docs/source/reference/expressions/miscellaneous.rst
@@ -8,4 +8,5 @@ Miscellaneous
 
    Expr.deserialize
    Expr.from_json
+   Expr.serialize
    Expr.set_sorted

--- a/py-polars/docs/source/reference/expressions/miscellaneous.rst
+++ b/py-polars/docs/source/reference/expressions/miscellaneous.rst
@@ -8,5 +8,4 @@ Miscellaneous
 
    Expr.deserialize
    Expr.from_json
-   Expr.serialize
    Expr.set_sorted

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9224,7 +9224,7 @@ class DataFrame:
         """
         Approximate count of unique values.
 
-        .. deprecated: 0.20.11
+        .. deprecated:: 0.20.11
             Use `select(pl.all().approx_n_unique())` instead.
 
         This is done using the HyperLogLog++ algorithm for cardinality estimation.

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -244,7 +244,7 @@ class ExprDateTimeNameSpace:
             - `'earliest'`: use the earliest datetime
             - `'latest'`: use the latest datetime
 
-            .. deprecated: 0.19.3
+            .. deprecated:: 0.19.3
                 This is now auto-inferred, you can safely remove this argument.
 
         Returns

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -9935,6 +9935,8 @@ class Expr:
 
         .. deprecated:: 0.20.9
             This method has been renamed to :meth:`deserialize`.
+            Note that the new method operations in file-like inputs rather than strings.
+            Enclose your input in `io.StringIO` to keep the same behavior.
 
         Parameters
         ----------
@@ -9942,7 +9944,9 @@ class Expr:
             JSON encoded string value
         """
         issue_deprecation_warning(
-            "`Expr.from_json` is deprecated. It has been renamed to `Expr.deserialize`.",
+            "`Expr.from_json` is deprecated. It has been renamed to `Expr.deserialize`."
+            " Note that the new method operations in file-like inputs rather than strings."
+            " Enclose your input in `io.StringIO` to keep the same behavior.",
             version="0.20.9",
         )
         return cls.deserialize(StringIO(value))

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -9880,7 +9880,7 @@ class Expr:
 
         .. deprecated:: 0.20.9
             This method has been renamed to :meth:`deserialize`.
-            Note that the new method operations in file-like inputs rather than strings.
+            Note that the new method operates on file-like inputs rather than strings.
             Enclose your input in `io.StringIO` to keep the same behavior.
 
         Parameters
@@ -9890,7 +9890,7 @@ class Expr:
         """
         issue_deprecation_warning(
             "`Expr.from_json` is deprecated. It has been renamed to `Expr.deserialize`."
-            " Note that the new method operations in file-like inputs rather than strings."
+            " Note that the new method operates on file-like inputs rather than strings."
             " Enclose your input in `io.StringIO` to keep the same behavior.",
             version="0.20.9",
         )

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -9878,7 +9878,7 @@ class Expr:
         """
         Read an expression from a JSON encoded string to construct an Expression.
 
-        .. deprecated:: 0.20.9
+        .. deprecated:: 0.20.11
             This method has been renamed to :meth:`deserialize`.
             Note that the new method operates on file-like inputs rather than strings.
             Enclose your input in `io.StringIO` to keep the same behavior.
@@ -9892,7 +9892,7 @@ class Expr:
             "`Expr.from_json` is deprecated. It has been renamed to `Expr.deserialize`."
             " Note that the new method operates on file-like inputs rather than strings."
             " Enclose your input in `io.StringIO` to keep the same behavior.",
-            version="0.20.9",
+            version="0.20.11",
         )
         return cls.deserialize(StringIO(value))
 

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -330,7 +330,7 @@ class Expr:
         return root_expr.map_batches(function, is_elementwise=True).meta.undo_aliases()
 
     @classmethod
-    def from_json(cls, value: str) -> Self:
+    def deserialize(cls, value: str) -> Self:
         """
         Read an expression from a JSON encoded string to construct an Expression.
 
@@ -340,7 +340,7 @@ class Expr:
             JSON encoded string value
         """
         expr = cls.__new__(cls)
-        expr._pyexpr = PyExpr.meta_read_json(value)
+        expr._pyexpr = PyExpr.deserialize(value)
         return expr
 
     def to_physical(self) -> Self:
@@ -9849,6 +9849,25 @@ class Expr:
             Set return dtype to override automatic return dtype determination.
         """
         return self.replace(mapping, default=default, return_dtype=return_dtype)
+
+    @classmethod
+    def from_json(cls, value: str) -> Self:
+        """
+        Read an expression from a JSON encoded string to construct an Expression.
+
+        .. deprecated:: 0.20.9
+            This method has been renamed to :meth:`deserialize`.
+
+        Parameters
+        ----------
+        value
+            JSON encoded string value
+        """
+        issue_deprecation_warning(
+            "`Expr.from_json` is deprecated. It has been renamed to `Expr.deserialize`.",
+            version="0.20.9",
+        )
+        return cls.deserialize(value)
 
     @property
     def bin(self) -> ExprBinaryNameSpace:

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -282,12 +282,12 @@ class ExprMetaNameSpace:
     def write_json(self, file: IOBase | str | Path) -> None:
         ...
 
-    @deprecate_renamed_function("Expr.meta.serialize", version="0.20.9")
+    @deprecate_renamed_function("Expr.meta.serialize", version="0.20.11")
     def write_json(self, file: IOBase | str | Path | None = None) -> str | None:
         """
         Write expression to json.
 
-        .. deprecated: 0.20.9
+        .. deprecated:: 0.20.11
             This method has been renamed to :meth:`serialize`.
         """
         return self.serialize(file)

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -1,16 +1,17 @@
 from __future__ import annotations
 
-from io import BytesIO, StringIO
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal, overload
 
 from polars.exceptions import ComputeError
 from polars.utils._wrap import wrap_expr
-from polars.utils.deprecation import deprecate_nonkeyword_arguments
-from polars.utils.various import normalize_filepath
+from polars.utils.deprecation import (
+    deprecate_nonkeyword_arguments,
+    deprecate_renamed_function,
+)
 
 if TYPE_CHECKING:
     from io import IOBase
+    from pathlib import Path
 
     from polars import Expr
 
@@ -225,24 +226,16 @@ class ExprMetaNameSpace:
     def write_json(self, file: IOBase | str | Path) -> None:
         ...
 
+    @deprecate_renamed_function("serialize", version="0.20.9")
     def write_json(self, file: IOBase | str | Path | None = None) -> str | None:
-        """Write expression to json."""
-        if isinstance(file, (str, Path)):
-            file = normalize_filepath(file)
-        to_string_io = (file is not None) and isinstance(file, StringIO)
-        if file is None or to_string_io:
-            with BytesIO() as buf:
-                self._pyexpr.meta_write_json(buf)
-                json_bytes = buf.getvalue()
+        """
+        Write expression to json.
 
-            json_str = json_bytes.decode("utf8")
-            if to_string_io:
-                file.write(json_str)  # type: ignore[union-attr]
-            else:
-                return json_str
-        else:
-            self._pyexpr.meta_write_json(file)
-        return None
+        .. deprecated: 0.20.9
+            This method has been renamed to :meth:`Expr.serialize`.
+        """
+        expr = wrap_expr(self._pyexpr)
+        return expr.serialize(file)
 
     @overload
     def tree_format(self, *, return_as_string: Literal[False]) -> None:

--- a/py-polars/polars/expr/meta.py
+++ b/py-polars/polars/expr/meta.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from io import BytesIO, StringIO
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal, overload
 
 from polars.exceptions import ComputeError
@@ -8,10 +10,10 @@ from polars.utils.deprecation import (
     deprecate_nonkeyword_arguments,
     deprecate_renamed_function,
 )
+from polars.utils.various import normalize_filepath
 
 if TYPE_CHECKING:
     from io import IOBase
-    from pathlib import Path
 
     from polars import Expr
 
@@ -219,6 +221,60 @@ class ExprMetaNameSpace:
         return wrap_expr(self._pyexpr._meta_selector_and(other._pyexpr))
 
     @overload
+    def serialize(self, file: None = ...) -> str:
+        ...
+
+    @overload
+    def serialize(self, file: IOBase | str | Path) -> None:
+        ...
+
+    def serialize(self, file: IOBase | str | Path | None = None) -> str | None:
+        """
+        Serialize this expression to a file or string in JSON format.
+
+        Parameters
+        ----------
+        file
+            File path to which the result should be written. If set to `None`
+            (default), the output is returned as a string instead.
+
+        See Also
+        --------
+        Expr.deserialize
+
+        Examples
+        --------
+        Serialize the expression into a JSON string.
+
+        >>> expr = pl.col("foo").sum().over("bar")
+        >>> json = expr.meta.serialize()
+        >>> json
+        '{"Window":{"function":{"Agg":{"Sum":{"Column":"foo"}}},"partition_by":[{"Column":"bar"}],"options":{"Over":"GroupsToRows"}}}'
+
+        The expression can later be deserialized back into an `Expr` object.
+
+        >>> from io import StringIO
+        >>> pl.Expr.deserialize(StringIO(json))  # doctest: +ELLIPSIS
+        <Expr ['col("foo").sum().over([col("ba…'] at ...>
+        """
+        if isinstance(file, (str, Path)):
+            file = normalize_filepath(file)
+        to_string_io = (file is not None) and isinstance(file, StringIO)
+        if file is None or to_string_io:
+            with BytesIO() as buf:
+                self._pyexpr.serialize(buf)
+                json_bytes = buf.getvalue()
+
+            json_str = json_bytes.decode("utf8")
+            if to_string_io:
+                file.write(json_str)  # type: ignore[union-attr]
+            else:
+                return json_str
+        else:
+            self._pyexpr.serialize(file)
+        return None
+
+    @overload
     def write_json(self, file: None = ...) -> str:
         ...
 
@@ -226,16 +282,15 @@ class ExprMetaNameSpace:
     def write_json(self, file: IOBase | str | Path) -> None:
         ...
 
-    @deprecate_renamed_function("serialize", version="0.20.9")
+    @deprecate_renamed_function("Expr.meta.serialize", version="0.20.9")
     def write_json(self, file: IOBase | str | Path | None = None) -> str | None:
         """
         Write expression to json.
 
         .. deprecated: 0.20.9
-            This method has been renamed to :meth:`Expr.serialize`.
+            This method has been renamed to :meth:`serialize`.
         """
-        expr = wrap_expr(self._pyexpr)
-        return expr.serialize(file)
+        return self.serialize(file)
 
     @overload
     def tree_format(self, *, return_as_string: Literal[False]) -> None:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4817,7 +4817,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         Approximate count of unique values.
 
-        .. deprecated: 0.20.11
+        .. deprecated:: 0.20.11
             Use `select(pl.all().approx_n_unique())` instead.
 
         This is done using the HyperLogLog++ algorithm for cardinality estimation.

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4315,7 +4315,7 @@ class Series:
             the underlying data. Data copy occurs, for example, when the Series contains
             nulls or non-numeric types.
 
-            .. deprecated: 0.20.10
+            .. deprecated:: 0.20.10
                 Use the `allow_copy` parameter instead, which is the inverse of this
                 one.
 

--- a/py-polars/src/expr/meta.rs
+++ b/py-polars/src/expr/meta.rs
@@ -89,7 +89,7 @@ impl PyExpr {
     }
 
     #[cfg(all(feature = "json", feature = "serde_json"))]
-    fn meta_write_json(&self, py_f: PyObject) -> PyResult<()> {
+    fn serialize(&self, py_f: PyObject) -> PyResult<()> {
         let file = BufWriter::new(get_file_like(py_f, true)?);
         serde_json::to_writer(file, &self.inner)
             .map_err(|err| PyValueError::new_err(format!("{err:?}")))?;

--- a/py-polars/src/expr/meta.rs
+++ b/py-polars/src/expr/meta.rs
@@ -97,19 +97,28 @@ impl PyExpr {
     }
 
     #[staticmethod]
-    fn deserialize(value: &str) -> PyResult<PyExpr> {
-        #[cfg(feature = "json")]
-        {
-            let inner: polars_lazy::prelude::Expr = serde_json::from_str(value).map_err(|_| {
-                let msg = "could not deserialize input into an expression";
-                PyPolarsErr::from(polars_err!(ComputeError: msg))
-            })?;
-            Ok(PyExpr { inner })
-        }
-        #[cfg(not(feature = "json"))]
-        {
-            panic!("activate 'json' feature")
-        }
+    #[cfg(feature = "json")]
+    fn deserialize(py_f: PyObject) -> PyResult<PyExpr> {
+        // it is faster to first read to memory and then parse: https://github.com/serde-rs/json/issues/160
+        // so don't bother with files.
+        let mut json = String::new();
+        let _ = get_file_like(py_f, false)?
+            .read_to_string(&mut json)
+            .unwrap();
+
+        // SAFETY:
+        // we skipped the serializing/deserializing of the static in lifetime in `DataType`
+        // so we actually don't have a lifetime at all when serializing.
+
+        // &str still has a lifetime. But it's ok, because we drop it immediately
+        // in this scope
+        let json = unsafe { std::mem::transmute::<&'_ str, &'static str>(json.as_str()) };
+
+        let inner: polars_lazy::prelude::Expr = serde_json::from_str(json).map_err(|_| {
+            let msg = "could not deserialize input into an expression";
+            PyPolarsErr::from(polars_err!(ComputeError: msg))
+        })?;
+        Ok(PyExpr { inner })
     }
 
     fn meta_tree_format(&self) -> PyResult<String> {

--- a/py-polars/src/expr/meta.rs
+++ b/py-polars/src/expr/meta.rs
@@ -97,11 +97,11 @@ impl PyExpr {
     }
 
     #[staticmethod]
-    fn meta_read_json(value: &str) -> PyResult<PyExpr> {
+    fn deserialize(value: &str) -> PyResult<PyExpr> {
         #[cfg(feature = "json")]
         {
             let inner: polars_lazy::prelude::Expr = serde_json::from_str(value)
-                .map_err(|_| PyPolarsErr::from(polars_err!(ComputeError: "could not serialize")))?;
+                .map_err(|_| PyPolarsErr::from(polars_err!(ComputeError: "could not deserialize")))?;
             Ok(PyExpr { inner })
         }
         #[cfg(not(feature = "json"))]

--- a/py-polars/src/expr/meta.rs
+++ b/py-polars/src/expr/meta.rs
@@ -100,8 +100,10 @@ impl PyExpr {
     fn deserialize(value: &str) -> PyResult<PyExpr> {
         #[cfg(feature = "json")]
         {
-            let inner: polars_lazy::prelude::Expr = serde_json::from_str(value)
-                .map_err(|_| PyPolarsErr::from(polars_err!(ComputeError: "could not deserialize")))?;
+            let inner: polars_lazy::prelude::Expr = serde_json::from_str(value).map_err(|_| {
+                let msg = "could not deserialize input into an expression";
+                PyPolarsErr::from(polars_err!(ComputeError: msg))
+            })?;
             Ok(PyExpr { inner })
         }
         #[cfg(not(feature = "json"))]

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -196,8 +196,7 @@ def test_serde_array_dtype() -> None:
 
 def test_expr_serialization_roundtrip() -> None:
     e = pl.col("foo").sum().over("bar")
-    json = e.meta.write_json()
-
+    json = e.serialize()
     round_tripped = pl.Expr.deserialize(json)
     assert round_tripped.meta == e
 
@@ -209,18 +208,21 @@ def test_expr_deserialize_error() -> None:
         pl.Expr.deserialize("abcdef")
 
 
-def test_expr_from_json_deprecated() -> None:
+def test_expr_write_json_from_json_deprecated() -> None:
     e = pl.col("foo").sum().over("bar")
-    json = e.meta.write_json()
+
+    with pytest.deprecated_call():
+        json = e.meta.write_json()
 
     with pytest.deprecated_call():
         round_tripped = pl.Expr.from_json(json)
+
     assert round_tripped.meta == e
 
 
 def test_expression_json_13991() -> None:
     e = pl.col("foo").cast(pl.Decimal)
-    json = e.meta.write_json()
+    json = e.serialize()
 
     round_tripped = pl.Expr.deserialize(json)
     assert round_tripped.meta == e

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -197,15 +197,20 @@ def test_serde_array_dtype() -> None:
 def test_expr_serialization_roundtrip() -> None:
     e = pl.col("foo").sum().over("bar")
     json = e.serialize()
-    round_tripped = pl.Expr.deserialize(json)
+    round_tripped = pl.Expr.deserialize(io.StringIO(json))
     assert round_tripped.meta == e
 
 
-def test_expr_deserialize_error() -> None:
+def test_expr_deserialize_file_not_found() -> None:
+    with pytest.raises(FileNotFoundError):
+        pl.Expr.deserialize("abcdef")
+
+
+def test_expr_deserialize_invalid_json() -> None:
     with pytest.raises(
         pl.ComputeError, match="could not deserialize input into an expression"
     ):
-        pl.Expr.deserialize("abcdef")
+        pl.Expr.deserialize(io.StringIO("abcdef"))
 
 
 def test_expr_write_json_from_json_deprecated() -> None:
@@ -224,5 +229,5 @@ def test_expression_json_13991() -> None:
     e = pl.col("foo").cast(pl.Decimal)
     json = e.serialize()
 
-    round_tripped = pl.Expr.deserialize(json)
+    round_tripped = pl.Expr.deserialize(io.StringIO(json))
     assert round_tripped.meta == e

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -100,11 +100,20 @@ def test_deser_empty_list() -> None:
     assert s.to_list() == [[[42.0]], []]
 
 
-def test_expression_json() -> None:
+def test_expression_roundtrip() -> None:
     e = pl.col("foo").sum().over("bar")
     json = e.meta.write_json()
 
-    round_tripped = pl.Expr.from_json(json)
+    round_tripped = pl.Expr.deserialize(json)
+    assert round_tripped.meta == e
+
+
+def test_expression_from_json_deprecated() -> None:
+    e = pl.col("foo").sum().over("bar")
+    json = e.meta.write_json()
+
+    with pytest.deprecated_call():
+        round_tripped = pl.Expr.from_json(json)
     assert round_tripped.meta == e
 
 
@@ -206,5 +215,5 @@ def test_expression_json_13991() -> None:
     e = pl.col("foo").cast(pl.Decimal)
     json = e.meta.write_json()
 
-    round_tripped = pl.Expr.from_json(json)
+    round_tripped = pl.Expr.deserialize(json)
     assert round_tripped.meta == e

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -195,10 +195,10 @@ def test_serde_array_dtype() -> None:
 
 
 def test_expr_serialization_roundtrip() -> None:
-    e = pl.col("foo").sum().over("bar")
-    json = e.serialize()
+    expr = pl.col("foo").sum().over("bar")
+    json = expr.meta.serialize()
     round_tripped = pl.Expr.deserialize(io.StringIO(json))
-    assert round_tripped.meta == e
+    assert round_tripped.meta == expr
 
 
 def test_expr_deserialize_file_not_found() -> None:
@@ -214,20 +214,20 @@ def test_expr_deserialize_invalid_json() -> None:
 
 
 def test_expr_write_json_from_json_deprecated() -> None:
-    e = pl.col("foo").sum().over("bar")
+    expr = pl.col("foo").sum().over("bar")
 
     with pytest.deprecated_call():
-        json = e.meta.write_json()
+        json = expr.meta.write_json()
 
     with pytest.deprecated_call():
         round_tripped = pl.Expr.from_json(json)
 
-    assert round_tripped.meta == e
+    assert round_tripped.meta == expr
 
 
 def test_expression_json_13991() -> None:
-    e = pl.col("foo").cast(pl.Decimal)
-    json = e.serialize()
+    expr = pl.col("foo").cast(pl.Decimal)
+    json = expr.meta.serialize()
 
     round_tripped = pl.Expr.deserialize(io.StringIO(json))
-    assert round_tripped.meta == e
+    assert round_tripped.meta == expr


### PR DESCRIPTION
We updated `LazyFrame` in a similar fashion not too long ago.

#### Changes

* Rename `Expr.meta.write_json` to `Expr.meta.serialize`.
* Rename `Expr.from_json` to `Expr.deserialize`.
  * It now operates on file inputs instead of a string. This follows the API `LazyFrame.deserialize`. Maybe this doesn't make sense for Expressions though? Or maybe both should read directly from a string? Open to feedback.