### PR TITLE
fix(python): Remove `is_numeric` check on `Series.std/var`

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2079,8 +2079,6 @@ class Series:
         >>> s.std()
         1.0
         """
-        if not self.dtype.is_numeric():
-            return None
         return self._s.std(ddof)
 
     def var(self, ddof: int = 1) -> float | None:
@@ -2100,8 +2098,6 @@ class Series:
         >>> s.var()
         1.0
         """
-        if not self.dtype.is_numeric():
-            return None
         return self._s.var(ddof)
 
     def median(self) -> PythonLiteral | None:

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2062,7 +2062,7 @@ class Series:
         """
         return self.to_frame().select_seq(F.col(self.name).nan_min()).item()
 
-    def std(self, ddof: int = 1) -> float | None:
+    def std(self, ddof: int = 1) -> float | timedelta | None:
         """
         Get the standard deviation of this Series.
 
@@ -2081,7 +2081,7 @@ class Series:
         """
         return self._s.std(ddof)
 
-    def var(self, ddof: int = 1) -> float | None:
+    def var(self, ddof: int = 1) -> float | timedelta | None:
         """
         Get variance of this Series.
 

--- a/py-polars/tests/unit/datatypes/test_duration.py
+++ b/py-polars/tests/unit/datatypes/test_duration.py
@@ -1,5 +1,7 @@
 from datetime import timedelta
 
+import pytest
+
 import polars as pl
 from polars.testing import assert_frame_equal
 
@@ -45,3 +47,15 @@ def test_duration_std_var() -> None:
     )
 
     assert_frame_equal(result, expected)
+
+
+def test_series_duration_std_var() -> None:
+    s = pl.Series([timedelta(days=1), timedelta(days=2), timedelta(days=4)])
+    assert s.std() == timedelta(days=1, seconds=45578, microseconds=180014)
+    assert s.var() == timedelta(days=201600000)
+
+
+def test_series_duration_var_overflow() -> None:
+    s = pl.Series([timedelta(days=10), timedelta(days=20), timedelta(days=40)])
+    with pytest.raises(pl.PolarsPanicError, match="OverflowError"):
+        s.var()


### PR DESCRIPTION
Supersedes #12881

Credit to @ion-elgreco - I tried to adjust the original PR but the commit history wasn't linear so I had trouble rebasing/updating. So I'm opening a new PR.

It seems behavior has changed since the original PR opened. Overflows now result in a panic rather than null. Which is definitely better. So let's go ahead with this, and we can see how to address the panic later.

Unsupported types should raise anyway rather than return None, so this is a good move regardless.