### PR TITLE
fix(rust): Properly release Arrow array

### DIFF
--- a/crates/polars-arrow/src/ffi/mmap.rs
+++ b/crates/polars-arrow/src/ffi/mmap.rs
@@ -83,13 +83,13 @@ unsafe extern "C" fn release<T>(array: *mut ArrowArray) {
     //
     let private = Box::from_raw(array.private_data as *mut PrivateData<T>);
     for child_ptr in private.children_ptr.iter() {
-        let _ = Box::from_raw(*child_ptr);
         release::<T>(*child_ptr);
+        let _ = Box::from_raw(*child_ptr);
     }
 
     if let Some(ptr) = private.dictionary_ptr {
-        let _ = Box::from_raw(ptr);
         release::<T>(ptr);
+        let _ = Box::from_raw(ptr);
     }
 
     array.release = None;

--- a/crates/polars-arrow/src/ffi/mmap.rs
+++ b/crates/polars-arrow/src/ffi/mmap.rs
@@ -81,6 +81,10 @@ unsafe extern "C" fn release<T>(array: *mut ArrowArray) {
     //   > The release callback MUST free any data area directly owned by the structure
     //     (such as the buffers and children members).
     //
+    if array.private_data.is_null() {
+        return;
+    }
+
     let private = Box::from_raw(array.private_data as *mut PrivateData<T>);
     for child_ptr in private.children_ptr.iter() {
         release::<T>(*child_ptr);

--- a/crates/polars-arrow/src/ffi/mmap.rs
+++ b/crates/polars-arrow/src/ffi/mmap.rs
@@ -83,13 +83,13 @@ unsafe extern "C" fn release<T>(array: *mut ArrowArray) {
     //
     let private = Box::from_raw(array.private_data as *mut PrivateData<T>);
     for child_ptr in private.children_ptr.iter() {
-        let mut child = Box::from_raw(*child_ptr);
-        release::<T>(&mut *child);
+        let _ = Box::from_raw(*child_ptr);
+        release::<T>(*child_ptr);
     }
 
     if let Some(ptr) = private.dictionary_ptr {
-        let mut dict = Box::from_raw(ptr);
-        release::<T>(&mut *dict);
+        let _ = Box::from_raw(ptr);
+        release::<T>(ptr);
     }
 
     array.release = None;


### PR DESCRIPTION
# Motivation

I originally stumbled upon this when trying to understand how `to_arrow` works in Polars. To the best of my understanding, the current implementation of the `release` callback that is passed to the Arrow C data interface does not fully follow the specification (see code comments for details). This will cause memory leaks whenever `to_arrow` is used on data frames with non-primitive column dtypes (i.e. `list` and `struct`).