### PR TITLE
feat: add `flush` operator to streaming operators

### DIFF
--- a/crates/polars-pipe/src/operators/operator.rs
+++ b/crates/polars-pipe/src/operators/operator.rs
@@ -2,6 +2,7 @@ use super::*;
 
 pub enum OperatorResult {
     /// needs to be called again with new chunk.
+    /// Or in case of `flush` needs to be called again.
     NeedsNewData,
     /// needs to be called again with same chunk.
     HaveMoreOutPut(DataChunk),
@@ -15,6 +16,14 @@ pub trait Operator: Send + Sync {
         context: &PExecutionContext,
         chunk: &DataChunk,
     ) -> PolarsResult<OperatorResult>;
+
+    fn flush(&mut self) -> PolarsResult<OperatorResult> {
+        unimplemented!()
+    }
+
+    fn must_flush(&self) -> bool {
+        false
+    }
 
     fn split(&self, thread_no: usize) -> Box<dyn Operator>;
 


### PR DESCRIPTION
This is required for the streaming outer join, as we need to flush the rows that didn't have any matches when the operation is finished.