### PR TITLE
feat(python): Smooth out `write_parquet` interface

### DIFF
--- a/crates/polars-io/src/parquet/write.rs
+++ b/crates/polars-io/src/parquet/write.rs
@@ -98,7 +98,7 @@ pub struct ParquetWriter<W> {
     compression: CompressionOptions,
     /// Compute and write column statistics.
     statistics: bool,
-    /// if `None` will be 512^2 rows
+    /// if `None` will equal the number of rows in the data frame
     row_group_size: Option<usize>,
     /// if `None` will be 1024^2 bytes
     data_page_size: Option<usize>,
@@ -191,8 +191,8 @@ where
         // ensures all chunks are aligned.
         df.align_chunks();
 
-        let n_splits = df.height() / self.row_group_size.unwrap_or(512 * 512);
-        if n_splits > 0 {
+        let n_splits = self.row_group_size.map(|s| df.height() / s).unwrap_or(1);
+        if n_splits > 1 {
             *df = accumulate_dataframes_vertical_unchecked(split_df(df, n_splits)?);
         }
         let mut batched = self.batched(&df.schema())?;

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -3390,8 +3390,8 @@ class DataFrame:
         compression: ParquetCompression = "zstd",
         compression_level: int | None = None,
         statistics: bool = False,
-        row_group_size: int | None = None,
-        data_page_size: int | None = None,
+        row_group_size: int | None = 512 ** 2,
+        data_page_size: int = 1024 ** 2,
         use_pyarrow: bool = False,
         pyarrow_options: dict[str, Any] | None = None,
     ) -> None:
@@ -3418,7 +3418,8 @@ class DataFrame:
         statistics
             Write statistics to the parquet headers. This requires extra compute.
         row_group_size
-            Size of the row groups in number of rows. Defaults to 512^2 rows.
+            Size of the row groups in number of rows. If specified as ``None``, a single
+            row group is created.
         data_page_size
             Size of the data page in bytes. Defaults to 1024^2 bytes.
         use_pyarrow
@@ -3431,6 +3432,12 @@ class DataFrame:
             using `pyarrow.parquet.write_to_dataset`.
             The `partition_cols` parameter leads to write the dataset to a directory.
             Similar to Spark's partitioned datasets.
+
+        Attention
+        ---------
+        This method rechunks the data frame in-place: if ``use_pyarrow=False`` (default),
+        all columns in the data frame will have as many chunks as row groups are created.
+        If ``use_pyarrow=True``, all columns will have a single chunk.
 
         Examples
         --------


### PR DESCRIPTION
# Motivation

The current interface to `write_parquet` produces inconsistent results based on the value of `use_pyarrow`. This PR straightens out this inconsistency and adds some documentation.

NOTE: All changes in this PR should be non-breaking in the public interface.