### PR TITLE
fix: race conditions in OOC writing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,31 +101,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
-name = "apache-avro"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceb7c683b2f8f40970b70e39ff8be514c95b96fcb9c4af87e1ed2cb2e10801a0"
-dependencies = [
- "crc32fast",
- "digest",
- "lazy_static",
- "libflate 2.0.0",
- "log",
- "num-bigint",
- "quad-rand",
- "rand",
- "regex-lite",
- "serde",
- "serde_json",
- "snap",
- "strum",
- "strum_macros",
- "thiserror",
- "typed-builder",
- "uuid",
-]
-
-[[package]]
 name = "argminmax"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,7 +244,7 @@ dependencies = [
  "crc",
  "fallible-streaming-iterator",
  "futures",
- "libflate 1.4.0",
+ "libflate",
  "serde",
  "serde_json",
  "snap",
@@ -981,15 +956,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,12 +1135,6 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
-
-[[package]]
-name = "dary_heap"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7762d17f1241643615821a8455a0b2c3e803784b058693d990b11f2dce25a0ca"
 
 [[package]]
 name = "der"
@@ -1954,20 +1914,7 @@ checksum = "5ff4ae71b685bbad2f2f391fe74f6b7659a34871c08b210fdc039e43bee07d18"
 dependencies = [
  "adler32",
  "crc32fast",
- "libflate_lz77 1.2.0",
-]
-
-[[package]]
-name = "libflate"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7d5654ae1795afc7ff76f4365c2c8791b0feb18e8996a96adad8ffd7c3b2bf"
-dependencies = [
- "adler32",
- "core2",
- "crc32fast",
- "dary_heap",
- "libflate_lz77 2.0.0",
+ "libflate_lz77",
 ]
 
 [[package]]
@@ -1976,17 +1923,6 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
 dependencies = [
- "rle-decode-fast",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5f52fb8c451576ec6b79d3f4deb327398bc05bbdbd99021a6e77a4c855d524"
-dependencies = [
- "core2",
- "hashbrown 0.13.2",
  "rle-decode-fast",
 ]
 
@@ -2579,7 +2515,6 @@ name = "polars-arrow"
 version = "0.37.0"
 dependencies = [
  "ahash",
- "apache-avro",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
@@ -2897,6 +2832,7 @@ dependencies = [
  "rayon",
  "smartstring",
  "tokio",
+ "uuid",
  "version_check",
 ]
 
@@ -3150,12 +3086,6 @@ dependencies = [
  "quote",
  "syn 2.0.48",
 ]
-
-[[package]]
-name = "quad-rand"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658fa1faf7a4cc5f057c9ee5ef560f717ad9d8dc66d975267f709624d6e1ab88"
 
 [[package]]
 name = "quick-xml"
@@ -4223,26 +4153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "typed-builder"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34085c17941e36627a879208083e25d357243812c30e7d7387c3b954f30ade16"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03ca4cb38206e2bef0700092660bb74d696f808514dae47fa1467cbfe26e96e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4331,7 +4241,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
- "serde",
+ "getrandom",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ url = "2.4"
 version_check = "0.9.4"
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 zstd = "0.13"
+uuid = { version = "1.7.0", features = ["v4"] }
 
 polars = { version = "0.37.0", path = "crates/polars", default-features = false }
 polars-compute = { version = "0.37.0", path = "crates/polars-compute", default-features = false }

--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -78,7 +78,6 @@ arrow-data = { workspace = true, optional = true }
 arrow-schema = { workspace = true, optional = true }
 
 [dev-dependencies]
-apache-avro = { version = "0.16", features = ["snappy"] }
 criterion = "0.5"
 crossbeam-channel = { workspace = true }
 doc-comment = "0.3"

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -561,6 +561,21 @@ pub fn get_time_units(tu_l: &TimeUnit, tu_r: &TimeUnit) -> TimeUnit {
     }
 }
 
+pub fn accumulate_dataframes_vertical_unchecked_optional<I>(dfs: I) -> Option<DataFrame>
+where
+    I: IntoIterator<Item = DataFrame>,
+{
+    let mut iter = dfs.into_iter();
+    let additional = iter.size_hint().0;
+    let mut acc_df = iter.next()?;
+    acc_df.reserve_chunks(additional);
+
+    for df in iter {
+        acc_df.vstack_mut_unchecked(&df);
+    }
+    Some(acc_df)
+}
+
 /// This takes ownership of the DataFrame so that drop is called earlier.
 /// Does not check if schema is correct
 pub fn accumulate_dataframes_vertical_unchecked<I>(dfs: I) -> DataFrame

--- a/crates/polars-pipe/Cargo.toml
+++ b/crates/polars-pipe/Cargo.toml
@@ -19,6 +19,7 @@ polars-plan = { workspace = true }
 polars-row = { workspace = true }
 polars-utils = { workspace = true, features = ["sysinfo"] }
 tokio = { workspace = true, optional = true }
+uuid = { workspace = true }
 
 crossbeam-channel = { workspace = true }
 crossbeam-queue = { workspace = true }

--- a/crates/polars-pipe/src/executors/sinks/io.rs
+++ b/crates/polars-pipe/src/executors/sinks/io.rs
@@ -91,7 +91,9 @@ fn gc_thread(operation_name: &'static str) {
                         eprintln!("could not modified time on this platform")
                     }
                 } else {
-                    std::fs::remove_dir_all(path).unwrap()
+                    // This can be fallible as another Polars query could already have removed this.
+                    // So we ignore the result.
+                    let _ = std::fs::remove_dir_all(path);
                 }
             }
         }

--- a/crates/polars-pipe/src/executors/sinks/io.rs
+++ b/crates/polars-pipe/src/executors/sinks/io.rs
@@ -37,13 +37,10 @@ fn get_lockfile_path(dir: &Path) -> PathBuf {
 }
 
 fn get_spill_dir(operation_name: &'static str) -> PolarsResult<PathBuf> {
-    let uuid = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
+    let id = uuid::Uuid::new_v4();
 
     let mut dir = std::path::PathBuf::from(get_base_temp_dir());
-    dir.push(&format!("polars/{operation_name}/{uuid}"));
+    dir.push(&format!("polars/{operation_name}/{id}"));
 
     if !dir.exists() {
         fs::create_dir_all(&dir).map_err(|err| {

--- a/crates/polars-pipe/src/executors/sinks/sort/ooc.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/ooc.rs
@@ -4,7 +4,9 @@ use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use crossbeam_queue::SegQueue;
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
-use polars_core::utils::accumulate_dataframes_vertical_unchecked;
+use polars_core::utils::{
+    accumulate_dataframes_vertical_unchecked, accumulate_dataframes_vertical_unchecked_optional,
+};
 use polars_core::POOL;
 use polars_io::ipc::IpcReader;
 use polars_io::SerReader;
@@ -54,7 +56,8 @@ impl PartitionSpillBuf {
             // so we pop no more than the current size.
             let pop_max = len;
             let iter = (0..pop_max).flat_map(|_| self.chunks.pop());
-            Some(accumulate_dataframes_vertical_unchecked(iter))
+            // Due to race conditions, the chunks can already be popped, so we use optional.
+            accumulate_dataframes_vertical_unchecked_optional(iter)
         } else {
             None
         }


### PR DESCRIPTION
fixes #13526

- adds a proper uuid. This wasn't the culprit, but is properly better than system time.
- ensures we don't panic if another thread already cleared the IO buffer.