### PR TITLE
fix: Ensure series are contiguous prior to `transpose`

### DIFF
--- a/py-polars/src/dataframe.rs
+++ b/py-polars/src/dataframe.rs
@@ -1371,7 +1371,11 @@ impl PyDataFrame {
     }
 
     #[pyo3(signature = (keep_names_as, column_names))]
-    pub fn transpose(&self, keep_names_as: Option<&str>, column_names: &PyAny) -> PyResult<Self> {
+    pub fn transpose(
+        &mut self,
+        keep_names_as: Option<&str>,
+        column_names: &PyAny,
+    ) -> PyResult<Self> {
         let new_col_names = if let Ok(name) = column_names.extract::<Vec<String>>() {
             Some(Either::Right(name))
         } else if let Ok(name) = column_names.extract::<String>() {

--- a/py-polars/tests/unit/operations/test_transpose.py
+++ b/py-polars/tests/unit/operations/test_transpose.py
@@ -200,3 +200,9 @@ def test_transpose_name_from_column_13777() -> None:
     csv_file = io.BytesIO(b"id,kc\nhi,3")
     df = pl.read_csv(csv_file).transpose(column_names="id")
     assert_series_equal(df.to_series(0), pl.Series("hi", [3]))
+
+
+def test_transpose_multiple_chunks() -> None:
+    df = pl.DataFrame({"a": ["1"]})
+    expected = pl.DataFrame({"column_0": ["1"], "column_1": ["1"]})
+    assert_frame_equal(df.vstack(df).transpose(), expected)


### PR DESCRIPTION
Resolves #14524.

This changes the signature of `transpose` from `&self` to `&mut self` because it now rechunks...is this considered a breaking change?