### PR TITLE
feat(python): warn on inefficient use of `map_elements` for temporal attributes/methods

### DIFF
--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -689,9 +689,12 @@ class RewrittenInstructions:
         """
         n_required_ops, argvals = len(opnames), argvals or []
         idx_offset = idx + n_required_ops
-        if is_attr and (trailing_inst := self._instructions[idx_offset:1]):
-            if trailing_inst[0].opname == "CALL":
-                return []
+        if (
+            is_attr
+            and (trailing_inst := self._instructions[idx_offset : idx_offset + 1])
+            and trailing_inst[0].opname in OpNames.CALL  # not pure attr if called
+        ):
+            return []
 
         instructions = self._instructions[idx:idx_offset]
         if len(instructions) == n_required_ops and all(

--- a/py-polars/polars/utils/udfs.py
+++ b/py-polars/polars/utils/udfs.py
@@ -152,6 +152,7 @@ _PYTHON_METHODS_MAP = {
     "upper": "str.to_uppercase",
     # temporal
     "isoweekday": "dt.weekday",
+    "date": "dt.date",
     "time": "dt.time",
 }
 

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -12,7 +12,11 @@ import pytest
 
 import polars as pl
 from polars.datatypes import DATETIME_DTYPES, DTYPE_TEMPORAL_UNITS, TEMPORAL_DTYPES
-from polars.exceptions import ComputeError, TimeZoneAwareConstructorWarning
+from polars.exceptions import (
+    ComputeError,
+    PolarsInefficientMapWarning,
+    TimeZoneAwareConstructorWarning,
+)
 from polars.testing import (
     assert_frame_equal,
     assert_series_equal,
@@ -947,45 +951,50 @@ def test_temporal_dtypes_map_elements(
     )
     const_dtm = datetime(2010, 9, 12)
 
-    assert_frame_equal(
-        df.with_columns(
-            [
-                # don't actually do any of this; native expressions are MUCH faster ;)
-                pl.col("timestamp")
-                .map_elements(lambda x: const_dtm, skip_nulls=skip_nulls)
-                .alias("const_dtm"),
-                pl.col("timestamp")
-                .map_elements(lambda x: x and x.date(), skip_nulls=skip_nulls)
-                .alias("date"),
-                pl.col("timestamp")
-                .map_elements(lambda x: x and x.time(), skip_nulls=skip_nulls)
-                .alias("time"),
-            ]
-        ),
-        pl.DataFrame(
-            [
-                (
-                    datetime(2010, 9, 12, 10, 19, 54),
-                    datetime(2010, 9, 12, 0, 0),
-                    date(2010, 9, 12),
-                    time(10, 19, 54),
-                ),
-                (None, expected_value, None, None),
-                (
-                    datetime(2009, 2, 13, 23, 31, 30),
-                    datetime(2010, 9, 12, 0, 0),
-                    date(2009, 2, 13),
-                    time(23, 31, 30),
-                ),
-            ],
-            schema={
-                "timestamp": pl.Datetime("ms"),
-                "const_dtm": pl.Datetime("us"),
-                "date": pl.Date,
-                "time": pl.Time,
-            },
-        ),
-    )
+    with pytest.warns(
+        PolarsInefficientMapWarning,
+        match=r"(?s)Replace this expression.*lambda x:",
+    ):
+        assert_frame_equal(
+            df.with_columns(
+                [
+                    # don't actually do this; native expressions are MUCH faster ;)
+                    pl.col("timestamp")
+                    .map_elements(lambda x: const_dtm, skip_nulls=skip_nulls)
+                    .alias("const_dtm"),
+                    # note: the below now trigger a PolarsInefficientMapWarning
+                    pl.col("timestamp")
+                    .map_elements(lambda x: x and x.date(), skip_nulls=skip_nulls)
+                    .alias("date"),
+                    pl.col("timestamp")
+                    .map_elements(lambda x: x and x.time(), skip_nulls=skip_nulls)
+                    .alias("time"),
+                ]
+            ),
+            pl.DataFrame(
+                [
+                    (
+                        datetime(2010, 9, 12, 10, 19, 54),
+                        datetime(2010, 9, 12, 0, 0),
+                        date(2010, 9, 12),
+                        time(10, 19, 54),
+                    ),
+                    (None, expected_value, None, None),
+                    (
+                        datetime(2009, 2, 13, 23, 31, 30),
+                        datetime(2010, 9, 12, 0, 0),
+                        date(2009, 2, 13),
+                        time(23, 31, 30),
+                    ),
+                ],
+                schema={
+                    "timestamp": pl.Datetime("ms"),
+                    "const_dtm": pl.Datetime("us"),
+                    "date": pl.Date,
+                    "time": pl.Time,
+                },
+            ),
+        )
 
 
 def test_timelike_init() -> None:

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -168,6 +168,19 @@ TEST_CASES = [
         'pl.col("d").str.to_datetime(format="%Y-%m-%d")',
     ),
     # ---------------------------------------------
+    # temporal attributes/methods
+    # ---------------------------------------------
+    (
+        "f",
+        "lambda x: x.isoweekday()",
+        'pl.col("f").dt.weekday()',
+    ),
+    (
+        "f",
+        "lambda x: x.hour + x.minute + x.second",
+        '(pl.col("f").dt.hour() + pl.col("f").dt.minute()) + pl.col("f").dt.second()',
+    ),
+    # ---------------------------------------------
     # Bitwise shifts
     # ---------------------------------------------
     (
@@ -244,6 +257,11 @@ def test_parse_apply_functions(col: str, func: str, expr_repr: str) -> None:
                 "c": ['{"a": 1}', '{"b": 2}', '{"c": 3}'],
                 "d": ["2020-01-01", "2020-01-02", "2020-01-03"],
                 "e": [1.5, 2.4, 3.1],
+                "f": [
+                    datetime(1999, 12, 31),
+                    datetime(2024, 5, 6),
+                    datetime(2077, 10, 20),
+                ],
             }
         )
         result_frame = df.select(
@@ -254,7 +272,11 @@ def test_parse_apply_functions(col: str, func: str, expr_repr: str) -> None:
             x=pl.col(col),
             y=pl.col(col).map_elements(eval(func)),
         )
-        assert_frame_equal(result_frame, expected_frame)
+        assert_frame_equal(
+            result_frame,
+            expected_frame,
+            check_dtype=(".dt." not in suggested_expression),
+        )
 
 
 @pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning")

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -433,6 +433,15 @@ def test_expr_exact_warning_message() -> None:
     assert len(warnings) == 1
 
 
+def test_omit_implicit_bool() -> None:
+    parser = BytecodeParser(
+        function=lambda x: x and x and x.date(),
+        map_target="expr",
+    )
+    suggested_expression = parser.to_expression("d")
+    assert suggested_expression == 'pl.col("d").dt.date()'
+
+
 def test_partial_functions_13523() -> None:
     def plus(value, amount: int):  # type: ignore[no-untyped-def]
         return value + amount


### PR DESCRIPTION
Ref: #9968.
(Implements the _".dt.month and other stdlib datetime functions"_ suggestion).

Saw somebody do this in our own codebase today (shame on that person 🤣), so have added new bytecode detection logic for temporal attrs/methods, along with the appropriate native expression mapping. 

Covers the following temporal attributes...

`date`
`day`
`hour`
`microsecond`
`minute`
`month`
`second`
`year`

...and temporal methods:

`isoweekday()`
`date()`
`time()`
 
### Before

```python
import polars as pl

df = pl.DataFrame({"dtm": [datetime(2024,2,16,10,30,45)]})
df.with_columns(
    # shameful (and wildly inefficient) use of a lambda :)
    time = pl.col("dtm").map_elements(lambda d: d.time())
)
# shape: (1, 2)
# ┌─────────────────────┬──────────┐
# │ dtm                 ┆ time     │
# │ ---                 ┆ ---      │
# │ datetime[μs]        ┆ time     │
# ╞═════════════════════╪══════════╡
# │ 2024-02-16 10:30:45 ┆ 10:30:45 │
# └─────────────────────┴──────────┘
```

### After

Can still do it, but now triggers a `PolarsInefficientMapWarning`:
```python
# PolarsInefficientMapWarning: 
# Expr.map_elements is significantly slower than the native expressions API.
# Only use if you absolutely CANNOT implement your logic otherwise.
# Replace this expression...
#   - pl.col("dtm").map_elements(lambda d: ...)
# with this one instead:
#   + pl.col("dtm").dt.time()
```

### Also

Now optimises out unnecessary implicit existence checks from the final suggestion, eg:

`lambda x: x and x and x and x.date()` 
...becomes:
`pl.col("d").dt.date()`
