### PR TITLE
feat(python): Change default number of rows printed in Notebooks for DataFrame/Series to 10

### DIFF
--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -63,10 +63,11 @@ class HTMLFormatter:
         self.col_idx: Iterable[int]
 
         if max_rows < df.height:
+            half, rest = divmod(max_rows, 2)
             self.row_idx = [
-                *list(range(max_rows // 2)),
+                *list(range(half + rest)),
                 -1,
-                *list(range(df.height - max_rows // 2, df.height)),
+                *list(range(df.height - half, df.height)),
             ]
         else:
             self.row_idx = range(df.height)

--- a/py-polars/polars/dataframe/_html.py
+++ b/py-polars/polars/dataframe/_html.py
@@ -58,7 +58,7 @@ class HTMLFormatter:
         self.elements: list[str] = []
         self.max_cols = max_cols
         self.max_rows = max_rows
-        self.series = from_series
+        self.from_series = from_series
         self.row_idx: Iterable[int]
         self.col_idx: Iterable[int]
 
@@ -132,7 +132,7 @@ class HTMLFormatter:
         ):
             # format frame/series shape with '_' thousand-separators
             s = self.df.shape
-            shape = f"({s[0]:_},)" if self.series else f"({s[0]:_}, {s[1]:_})"
+            shape = f"({s[0]:_},)" if self.from_series else f"({s[0]:_}, {s[1]:_})"
 
             self.elements.append(f"<small>shape: {shape}</small>")
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1821,8 +1821,7 @@ class DataFrame:
         if max_cols < 0:
             max_cols = self.width
 
-        default_rows = 20 if _from_series else 10
-        max_rows = int(os.environ.get("POLARS_FMT_MAX_ROWS", default=default_rows))
+        max_rows = int(os.environ.get("POLARS_FMT_MAX_ROWS", default=10))
         if max_rows < 0:
             max_rows = self.height
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -1807,7 +1807,7 @@ class DataFrame:
     def _ipython_key_completions_(self) -> list[str]:
         return self.columns
 
-    def _repr_html_(self, **kwargs: Any) -> str:
+    def _repr_html_(self, *, _from_series: bool = False) -> str:
         """
         Format output data in HTML for display in Jupyter Notebooks.
 
@@ -1819,18 +1819,19 @@ class DataFrame:
         """
         max_cols = int(os.environ.get("POLARS_FMT_MAX_COLS", default=75))
         if max_cols < 0:
-            max_cols = self.shape[1]
-        max_rows = int(os.environ.get("POLARS_FMT_MAX_ROWS", default=25))
-        if max_rows < 0:
-            max_rows = self.shape[0]
+            max_cols = self.width
 
-        from_series = kwargs.get("from_series", False)
+        default_rows = 20 if _from_series else 10
+        max_rows = int(os.environ.get("POLARS_FMT_MAX_ROWS", default=default_rows))
+        if max_rows < 0:
+            max_rows = self.height
+
         return "".join(
             NotebookFormatter(
                 self,
                 max_cols=max_cols,
                 max_rows=max_rows,
-                from_series=from_series,
+                from_series=_from_series,
             ).render()
         )
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1487,7 +1487,7 @@ class Series:
 
     def _repr_html_(self) -> str:
         """Format output data in HTML for display in Jupyter Notebooks."""
-        return self.to_frame()._repr_html_(from_series=True)
+        return self.to_frame()._repr_html_(_from_series=True)
 
     @deprecate_renamed_parameter("row", "index", version="0.19.3")
     def item(self, index: int | None = None) -> Any:

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1049,32 +1049,6 @@ def test_literal_series() -> None:
     )
 
 
-def test_to_html() -> None:
-    # check it does not panic/error, and appears to contain
-    # a reasonable table with suitably escaped html entities.
-    df = pl.DataFrame(
-        {
-            "foo": [1, 2, 3],
-            "<bar>": ["a", "b", "c"],
-            "<baz": ["a", "b", "c"],
-            "spam>": ["a", "b", "c"],
-        }
-    )
-    html = df._repr_html_()
-    for match in (
-        "<table",
-        'class="dataframe"',
-        "<th>foo</th>",
-        "<th>&lt;bar&gt;</th>",
-        "<th>&lt;baz</th>",
-        "<th>spam&gt;</th>",
-        "<td>1</td>",
-        "<td>2</td>",
-        "<td>3</td>",
-    ):
-        assert match in html, f"Expected to find {match!r} in html repr"
-
-
 def test_rename(df: pl.DataFrame) -> None:
     out = df.rename({"strings": "bars", "int": "foos"})
     # check if we can select these new columns

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -1,0 +1,71 @@
+import polars as pl
+
+
+def test_repr_html() -> None:
+    # check it does not panic/error, and appears to contain
+    # a reasonable table with suitably escaped html entities.
+    df = pl.DataFrame(
+        {
+            "foo": [1, 2, 3],
+            "<bar>": ["a", "b", "c"],
+            "<baz": ["a", "b", "c"],
+            "spam>": ["a", "b", "c"],
+        }
+    )
+    html = df._repr_html_()
+    for match in (
+        "<table",
+        'class="dataframe"',
+        "<th>foo</th>",
+        "<th>&lt;bar&gt;</th>",
+        "<th>&lt;baz</th>",
+        "<th>spam&gt;</th>",
+        "<td>1</td>",
+        "<td>2</td>",
+        "<td>3</td>",
+    ):
+        assert match in html, f"Expected to find {match!r} in html repr"
+
+
+def test_html_tables() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
+
+    # default: header contains names/dtypes
+    header = "<thead><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>i64</td><td>i64</td><td>i64</td></tr></thead>"
+    assert header in df._repr_html_()
+
+    # validate that relevant config options are respected
+    with pl.Config(tbl_hide_column_names=True):
+        header = "<thead><tr><td>i64</td><td>i64</td><td>i64</td></tr></thead>"
+        assert header in df._repr_html_()
+
+    with pl.Config(tbl_hide_column_data_types=True):
+        header = "<thead><tr><th>a</th><th>b</th><th>c</th></tr></thead>"
+        assert header in df._repr_html_()
+
+    with pl.Config(
+        tbl_hide_column_data_types=True,
+        tbl_hide_column_names=True,
+    ):
+        header = "<thead></thead>"
+        assert header in df._repr_html_()
+
+
+def test_df_repr_html_max_rows_default() -> None:
+    n = 50
+    df = pl.DataFrame({"a": range(n)})
+
+    html = df._repr_html_()
+
+    expected_rows = 10
+    assert html.count("<td>") - 2 == expected_rows
+
+
+def test_series_repr_html_max_rows_default() -> None:
+    n = 50
+    s = pl.Series("a", range(n))
+
+    html = s._repr_html_()
+
+    expected_rows = 20
+    assert html.count("<td>") - 2 == expected_rows

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -67,5 +67,5 @@ def test_series_repr_html_max_rows_default() -> None:
 
     html = s._repr_html_()
 
-    expected_rows = 20
+    expected_rows = 10
     assert html.count("<td>") - 2 == expected_rows

--- a/py-polars/tests/unit/dataframe/test_repr_html.py
+++ b/py-polars/tests/unit/dataframe/test_repr_html.py
@@ -52,8 +52,7 @@ def test_html_tables() -> None:
 
 
 def test_df_repr_html_max_rows_default() -> None:
-    n = 50
-    df = pl.DataFrame({"a": range(n)})
+    df = pl.DataFrame({"a": range(50)})
 
     html = df._repr_html_()
 
@@ -61,9 +60,18 @@ def test_df_repr_html_max_rows_default() -> None:
     assert html.count("<td>") - 2 == expected_rows
 
 
+def test_df_repr_html_max_rows_odd() -> None:
+    df = pl.DataFrame({"a": range(50)})
+
+    with pl.Config(tbl_rows=9):
+        html = df._repr_html_()
+
+    expected_rows = 9
+    assert html.count("<td>") - 2 == expected_rows
+
+
 def test_series_repr_html_max_rows_default() -> None:
-    n = 50
-    s = pl.Series("a", range(n))
+    s = pl.Series("a", range(50))
 
     html = s._repr_html_()
 

--- a/py-polars/tests/unit/test_config.py
+++ b/py-polars/tests/unit/test_config.py
@@ -87,30 +87,6 @@ def test_hide_header_elements() -> None:
     )
 
 
-def test_html_tables() -> None:
-    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
-
-    # default: header contains names/dtypes
-    header = "<thead><tr><th>a</th><th>b</th><th>c</th></tr><tr><td>i64</td><td>i64</td><td>i64</td></tr></thead>"
-    assert header in df._repr_html_()
-
-    # validate that relevant config options are respected
-    with pl.Config(tbl_hide_column_names=True):
-        header = "<thead><tr><td>i64</td><td>i64</td><td>i64</td></tr></thead>"
-        assert header in df._repr_html_()
-
-    with pl.Config(tbl_hide_column_data_types=True):
-        header = "<thead><tr><th>a</th><th>b</th><th>c</th></tr></thead>"
-        assert header in df._repr_html_()
-
-    with pl.Config(
-        tbl_hide_column_data_types=True,
-        tbl_hide_column_names=True,
-    ):
-        header = "<thead></thead>"
-        assert header in df._repr_html_()
-
-
 def test_set_tbl_cols() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
 


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/14515

#### Changes
* For DataFrames: changed from 25 to 10.
* For Series: changed from 25 to ~20~ 10 also.
* Fix display when row limit is an odd number

~I guess we could also do 10 rows for both?~