### PR TITLE
feat: disable status from code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,7 @@
+coverage:
+  status:
+    project: off
+    patch: off
 ignore:
   - crates/polars-arrow/src/io/flight/*.rs
   - crates/polars-arrow/src/io/ipc/append/*.rs


### PR DESCRIPTION
Right now, code coverage is experimental, we should not fail PR's or add a failure status before finding out the right parameters. 
This PR removes all status updates from codecov.