### PR TITLE
feat(python): improve `read_database` interop with sqlalchemy `Session` connections

### DIFF
--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     import sys
 
     from sqlalchemy import Engine
+    from sqlalchemy.orm import Session
 
     from polars import DataFrame, Expr, LazyFrame, Series
     from polars.datatypes import DataType, DataTypeClass, IntegerType, TemporalType
@@ -250,4 +251,4 @@ class Cursor(BasicCursor):  # noqa: D101
         """Fetch results in batches."""
 
 
-ConnectionOrCursor = Union[BasicConnection, BasicCursor, Cursor, "Engine"]
+ConnectionOrCursor = Union[BasicConnection, BasicCursor, Cursor, "Engine", "Session"]


### PR DESCRIPTION
Closes #13926.

Further streamlines use of `read_database` by ensuring seamless interop with SQLAlchemy's `Session` object (we were mostly fine, but some specific flavours of cursor result needed a little additional introspection).


* Improves column inference from cursor/result object (eg: `ChunkedIteratorResult`, as seen in the linked issue).
* Adds explicit test coverage for SQLAlchemy's `Session` object.