### PR TITLE
ci: Refactor code coverage workflow

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,60 +1,104 @@
-name: Code Coverage
+name: Code coverage
 
 on:
-  pull_request: {}
+  pull_request:
+    paths:
+      - '**.rs'
+      - '**.py'
   push:
     branches:
       - main
-      - codecov
+    paths:
+      - '**.rs'
+      - '**.py'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: py-polars
+    shell: bash
 
 jobs:
   coverage:
     name: Code Coverage
     runs-on: macos-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+    env:
+      RUSTFLAGS: '-C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target'
+      RUST_BACKTRACE: 1
+      LLVM_PROFILE_FILE: '/Users/runner/work/polars/polars/target/polars-%p-%3m.profraw'
+      CARGO_LLVM_COV: 1
+      CARGO_LLVM_COV_SHOW_ENV: 1
+      CARGO_LLVM_COV_TARGET_DIR: '/Users/runner/work/polars/polars/target'
 
-      - uses: actions/setup-python@v2
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
-          cache: "pip"
-      - name: install rust nightly
-        uses: dtolnay/rust-toolchain@nightly
+          python-version: '3.10'
+
+      - name: Create virtual environment
+        run: |
+          python -m venv .venv
+          echo "$GITHUB_WORKSPACE/py-polars/.venv/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+
+      - name: Set up Rust
+        run: rustup component add llvm-tools-preview
+
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
+
       - uses: Swatinem/rust-cache@v2
         with:
-          key: coverage-cargo-macos
-        continue-on-error: true
-      - name: Setup virtual environment
+          save-if: ${{ github.ref_name == 'main' }}
+
+      - name: Prepare coverage
+        run: cargo llvm-cov clean --workspace
+
+      - name: Run tests
+        run: >
+          cargo test --all-features
+          -p polars-arrow
+          -p polars-core
+          -p polars-io
+          -p polars-lazy
+          -p polars-ops
+          -p polars-plan
+          -p polars-row
+          -p polars-sql
+          -p polars-time
+          -p polars-utils
+
+      - name: Run Rust integration tests
+        run: cargo test --all-features -p polars --test it
+
+      - name: Install Polars
         run: |
-          python -m venv venv
-          source venv/bin/activate
-          pip install -r py-polars/requirements-dev.txt
-      - name: Run coverage
-        run: |
-          source venv/bin/activate
-          cd py-polars
-          rustup component add llvm-tools-preview
-          cargo llvm-cov clean --workspace 
-          cargo test --all-features -p polars-arrow -p polars-core -p polars-io -p polars-lazy -p polars-ops -p polars-plan -p polars-row -p polars-sql -p polars-time -p polars-utils
-          cargo test --all-features -p polars --test it
+          source activate
           maturin develop
-          pytest --cov -n auto --dist loadgroup -m "not benchmark and not docs" --cov-report xml:coverage.xml || true
-          POLARS_FORCE_ASYNC=1 pytest --cov -m "not benchmark and not docs" tests/unit/io/ --cov-report xml:async.xml || true
-          cargo llvm-cov report --lcov --output-path coverage.lcov
+
+      - name: Run Python tests
+        run: pytest --cov -n auto --dist loadgroup -m "not benchmark and not docs" --cov-report xml:coverage.xml
+        continue-on-error: true
+
+      - name: Run Python tests - async reader
         env:
-          RUSTFLAGS: '-C instrument-coverage --cfg=coverage --cfg=coverage_nightly --cfg=trybuild_no_target'
-          RUST_BACKTRACE: 1
-          LLVM_PROFILE_FILE: '/Users/runner/work/polars/polars/target/polars-%p-%3m.profraw'
-          CARGO_LLVM_COV: 1
-          CARGO_LLVM_COV_SHOW_ENV: 1
-          CARGO_LLVM_COV_TARGET_DIR: '/Users/runner/work/polars/polars/target'
-      # Upload
-      - uses: codecov/codecov-action@v4
+          POLARS_FORCE_ASYNC: 1
+        run: pytest --cov -m "not benchmark and not docs" tests/unit/io/ --cov-report xml:async.xml
+        continue-on-error: true
+
+      - name: Report coverage
+        run: cargo llvm-cov report --lcov --output-path coverage.lcov
+
+      - name: Upload coverage information
+        uses: codecov/codecov-action@v4
         with:
           files: py-polars/coverage.lcov,py-polars/coverage.xml,py-polars/async.xml
           name: macos
           token: ${{ secrets.CODECOV_TOKEN }}
-

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -94,7 +94,9 @@ jobs:
 
       - name: Run tests async reader tests
         if: github.ref_name != 'main' && matrix.os != 'windows-latest'
-        run: POLARS_FORCE_ASYNC=1 pytest -m "not benchmark and not docs" tests/unit/io/
+        env:
+          POLARS_FORCE_ASYNC: 1
+        run: pytest -m "not benchmark and not docs" tests/unit/io/
 
       - name: Check import without optional dependencies
         if: github.ref_name != 'main' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -33,13 +33,10 @@ def test_lazyframe_serde() -> None:
 
 
 def test_serde_time_unit() -> None:
-    assert pickle.loads(
-        pickle.dumps(
-            pl.Series(
-                [datetime(2022, 1, 1) + timedelta(days=1) for _ in range(3)]
-            ).cast(pl.Datetime("ns"))
-        )
-    ).dtype == pl.Datetime("ns")
+    values = [datetime(2022, 1, 1) + timedelta(days=1) for _ in range(3)]
+    s = pl.Series(values).cast(pl.Datetime("ns"))
+    result = pickle.loads(pickle.dumps(s))
+    assert result.dtype == pl.Datetime("ns")
 
 
 def test_serde_duration() -> None:


### PR DESCRIPTION
Following up on https://github.com/pola-rs/polars/pull/14532

This brings the workflow more in line with the existing testing workflows.

### Changes

* Only run store the cache on main, avoiding cache storage space issues.
* Only run workflow when Rust or Python files have been modified.
* Make setup more modular (more easily see where things go wrong and how long each step takes)

(I did a random test refactor to trigger the workflow)

I'm also thinking this could be much improved by running coverage in the existing test workflows and combining the results. We should look into that later.