### PR TITLE
feat(python): Warn on inefficient use of `map_elements` for additional string functions

### DIFF
--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -562,3 +562,9 @@ def parse_percentiles(
         at_or_above_50_percentiles = [0.5, *at_or_above_50_percentiles]
 
     return [*sub_50_percentiles, *at_or_above_50_percentiles]
+
+
+def re_escape(s: str) -> str:
+    """Escape a string for use in a Polars (Rust) regex."""
+    re_rust_metachars = r"\\?()|\[\]{}^$#&~.+*-"
+    return re.sub(f"([{re_rust_metachars}])", r"\\\1", s)

--- a/py-polars/polars/utils/various.py
+++ b/py-polars/polars/utils/various.py
@@ -566,5 +566,7 @@ def parse_percentiles(
 
 def re_escape(s: str) -> str:
     """Escape a string for use in a Polars (Rust) regex."""
+    # note: almost the same as the standard python 're.escape' function, but
+    # escapes _only_ those metachars with meaning to the rust regex crate
     re_rust_metachars = r"\\?()|\[\]{}^$#&~.+*-"
     return re.sub(f"([{re_rust_metachars}])", r"\\\1", s)

--- a/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
+++ b/py-polars/tests/unit/operations/map/test_inefficient_map_warning.py
@@ -133,13 +133,28 @@ TEST_CASES = [
         '(pl.col("a") > 1) & ((pl.col("a") != 2) | ((pl.col("a") % 2) == 0)) & (pl.col("a") < 3)',
     ),
     # ---------------------------------------------
-    # string expr: case/cast ops
+    # string exprs
     # ---------------------------------------------
     ("b", "lambda x: str(x).title()", 'pl.col("b").cast(pl.String).str.to_titlecase()'),
     (
         "b",
         'lambda x: x.lower() + ":" + x.upper() + ":" + x.title()',
         '(((pl.col("b").str.to_lowercase() + \':\') + pl.col("b").str.to_uppercase()) + \':\') + pl.col("b").str.to_titlecase()',
+    ),
+    (
+        "b",
+        "lambda x: x.strip().startswith('#')",
+        """pl.col("b").str.strip_chars().str.starts_with('#')""",
+    ),
+    (
+        "b",
+        """lambda x: x.rstrip().endswith(('!','#','?','"'))""",
+        """pl.col("b").str.strip_chars_end().str.contains(r'(!|\\#|\\?|")$')""",
+    ),
+    (
+        "b",
+        """lambda x: x.lstrip().startswith(('!','#','?',"'"))""",
+        """pl.col("b").str.strip_chars_start().str.contains(r"^(!|\\#|\\?|')")""",
     ),
     # ---------------------------------------------
     # json expr: load/extract
@@ -186,12 +201,12 @@ TEST_CASES = [
     (
         "a",
         "lambda x: (3 << (32-x)) & 3",
-        '(3*2**(32 - pl.col("a"))).cast(pl.Int64) & 3',
+        '(3 * 2**(32 - pl.col("a"))).cast(pl.Int64) & 3',
     ),
     (
         "a",
         "lambda x: (x << 32) & 3",
-        '(pl.col("a")*2**32).cast(pl.Int64) & 3',
+        '(pl.col("a") * 2**32).cast(pl.Int64) & 3',
     ),
     (
         "a",


### PR DESCRIPTION
Ref: #9968.

The `BytecodeParser` can now also detect/translate Python string ops such as...

* `s.strip()`
* `s.lstrip()`
* `s.rstrip()`
* `s.endswith('x')`
* `s.endswith(('x','y'))`
* `s.startswith('x')`
* `s.startswith(('x','y'))`

Note that as we don't (currently ;) support multiple strings being passed in to `starts_with` and `ends_with`, such expressions are translated to a suitable `contains` regex instead.

## Example

````python
import polars as pl

df = pl.DataFrame({"s":["xxyx","123xx", "45yx?"]})
df.with_columns(
    match = pl.col("s").map_elements(lambda s: s.endswith(("?", "!"))),
)

# PolarsInefficientMapWarning: 
# Expr.map_elements is significantly slower than the native expressions API.
# Only use if you absolutely CANNOT implement your logic otherwise.
# Replace this expression...
#   - pl.col("s").map_elements(lambda s: ...)
# with this one instead:
#   + pl.col("s").str.contains(r'(\?|!)$')
```