### PR TITLE
docs(python): Fix markdown newline for rendering function description in VSCode

### DIFF
--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -101,6 +101,7 @@ def read_csv(
         - `List[str]`: All values equal to any string in this list will be null.
         - `Dict[str, str]`: A dictionary that maps column name to a
           null value string.
+          
     missing_utf8_is_empty_string
         By default a missing value is considered to be null; if you would prefer missing
         utf8 values to be treated as the empty string you can set this param True.
@@ -509,6 +510,7 @@ def read_csv_batched(
         - `List[str]`: All values equal to any string in this list will be null.
         - `Dict[str, str]`: A dictionary that maps column name to a
           null value string.
+          
     missing_utf8_is_empty_string
         By default a missing value is considered to be null; if you would prefer missing
         utf8 values to be treated as the empty string you can set this param True.
@@ -802,6 +804,7 @@ def scan_csv(
         - `List[str]`: All values equal to any string in this list will be null.
         - `Dict[str, str]`: A dictionary that maps column name to a
           null value string.
+          
     missing_utf8_is_empty_string
         By default a missing value is considered to be null; if you would prefer missing
         utf8 values to be treated as the empty string you can set this param True.

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -101,7 +101,7 @@ def read_csv(
         - `List[str]`: All values equal to any string in this list will be null.
         - `Dict[str, str]`: A dictionary that maps column name to a
           null value string.
-          
+
     missing_utf8_is_empty_string
         By default a missing value is considered to be null; if you would prefer missing
         utf8 values to be treated as the empty string you can set this param True.
@@ -510,7 +510,7 @@ def read_csv_batched(
         - `List[str]`: All values equal to any string in this list will be null.
         - `Dict[str, str]`: A dictionary that maps column name to a
           null value string.
-          
+
     missing_utf8_is_empty_string
         By default a missing value is considered to be null; if you would prefer missing
         utf8 values to be treated as the empty string you can set this param True.
@@ -804,7 +804,7 @@ def scan_csv(
         - `List[str]`: All values equal to any string in this list will be null.
         - `Dict[str, str]`: A dictionary that maps column name to a
           null value string.
-          
+
     missing_utf8_is_empty_string
         By default a missing value is considered to be null; if you would prefer missing
         utf8 values to be treated as the empty string you can set this param True.


### PR DESCRIPTION
Hi,

I noticed on `pl.read_csv` that the tooltip documentation needed a newline after a list to be formatted correctly. 

As you can see in the picture below, all of the attributes after `missing_utf8_is_empty_string` are listed under the `Dict[str, str]` bullet point. 

<img width="910" alt="Screenshot 2024-02-17 at 2 41 30 PM" src="https://github.com/pola-rs/polars/assets/91705805/0bc3b20c-5e35-43a5-8b00-2d16c9dd5004">


It's just a small fix. This is my first time contributing so hopefully this is helpful! 