### PR TITLE
feat(python): Add `allow_copy` parameter to `DataFrame.to_numpy`

### DIFF
--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -121,13 +121,13 @@ def test_df_to_numpy_decimal(use_pyarrow: bool) -> None:
     assert_array_equal(result, expected)
 
 
-def test_to_numpy_zero_copy_path() -> None:
+def test_df_to_numpy_zero_copy_path() -> None:
     rows = 10
     cols = 5
     x = np.ones((rows, cols), order="F")
     x[:, 1] = 2.0
     df = pl.DataFrame(x)
-    x = df.to_numpy()
+    x = df.to_numpy(allow_copy=False)
     assert x.flags["F_CONTIGUOUS"]
     assert not x.flags["WRITEABLE"]
     assert str(x[0, :]) == "[1. 2. 1. 1. 1.]"

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -141,3 +141,23 @@ def test_to_numpy_zero_copy_path_writeable() -> None:
     df = pl.DataFrame(x)
     x = df.to_numpy(writable=True)
     assert x.flags["WRITEABLE"]
+
+
+def test_df_to_numpy_structured_not_zero_copy() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+    msg = "cannot create structured array without copying data"
+    with pytest.raises(RuntimeError, match=msg):
+        df.to_numpy(structured=True, allow_copy=False)
+
+
+def test_df_to_numpy_writable_not_zero_copy() -> None:
+    df = pl.DataFrame({"a": [1, 2]})
+    msg = "cannot create writable array without copying data"
+    with pytest.raises(RuntimeError, match=msg):
+        df.to_numpy(allow_copy=False, writable=True)
+
+
+def test_df_to_numpy_not_zero_copy() -> None:
+    df = pl.DataFrame({"a": [1, 2, None]})
+    with pytest.raises(RuntimeError):
+        df.to_numpy(allow_copy=False)

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -25,9 +25,9 @@ def assert_zero_copy(s: pl.Series, arr: np.ndarray[Any, Any]) -> None:
     assert s_ptr == arr_ptr
 
 
-def assert_zero_copy_only_raises(s: pl.Series) -> None:
+def assert_allow_copy_false_raises(s: pl.Series) -> None:
     with pytest.raises(ValueError, match="cannot return a zero-copy array"):
-        s.to_numpy(use_pyarrow=False, zero_copy_only=True)
+        s.to_numpy(use_pyarrow=False, allow_copy=False)
 
 
 @pytest.mark.parametrize(
@@ -48,8 +48,8 @@ def assert_zero_copy_only_raises(s: pl.Series) -> None:
 def test_series_to_numpy_numeric_zero_copy(
     dtype: pl.PolarsDataType, expected_dtype: npt.DTypeLike
 ) -> None:
-    s = pl.Series([1, 2, 3]).cast(dtype)  # =dtype, strict=False)
-    result = s.to_numpy(use_pyarrow=False, zero_copy_only=True)
+    s = pl.Series([1, 2, 3]).cast(dtype)
+    result = s.to_numpy(use_pyarrow=False, allow_copy=False)
 
     assert_zero_copy(s, result)
     assert result.tolist() == s.to_list()
@@ -80,7 +80,7 @@ def test_series_to_numpy_numeric_with_nulls(
     assert result.tolist()[:-1] == s.to_list()[:-1]
     assert np.isnan(result[-1])
     assert result.dtype == expected_dtype
-    assert_zero_copy_only_raises(s)
+    assert_allow_copy_false_raises(s)
 
 
 @pytest.mark.parametrize(
@@ -101,7 +101,7 @@ def test_series_to_numpy_temporal_zero_copy(
 ) -> None:
     values = [0, 2_000, 1_000_000]
     s = pl.Series(values, dtype=dtype, strict=False)
-    result = s.to_numpy(use_pyarrow=False, zero_copy_only=True)
+    result = s.to_numpy(use_pyarrow=False, allow_copy=False)
 
     assert_zero_copy(s, result)
     # NumPy tolist returns integers for ns precision
@@ -115,7 +115,7 @@ def test_series_to_numpy_temporal_zero_copy(
 def test_series_to_numpy_datetime_with_tz_zero_copy() -> None:
     values = [datetime(1970, 1, 1), datetime(2024, 2, 28)]
     s = pl.Series(values).dt.convert_time_zone("Europe/Amsterdam")
-    result = s.to_numpy(use_pyarrow=False, zero_copy_only=True)
+    result = s.to_numpy(use_pyarrow=False, allow_copy=False)
 
     assert_zero_copy(s, result)
     assert result.tolist() == values
@@ -130,7 +130,7 @@ def test_series_to_numpy_date() -> None:
 
     assert s.to_list() == result.tolist()
     assert result.dtype == np.dtype("datetime64[D]")
-    assert_zero_copy_only_raises(s)
+    assert_allow_copy_false_raises(s)
 
 
 @pytest.mark.parametrize(
@@ -159,7 +159,7 @@ def test_series_to_numpy_temporal_with_nulls(
     else:
         assert result.tolist() == s.to_list()
     assert result.dtype == expected_dtype
-    assert_zero_copy_only_raises(s)
+    assert_allow_copy_false_raises(s)
 
 
 def test_series_to_numpy_datetime_with_tz_with_nulls() -> None:
@@ -169,7 +169,7 @@ def test_series_to_numpy_datetime_with_tz_with_nulls() -> None:
 
     assert result.tolist() == values
     assert result.dtype == np.dtype("datetime64[us]")
-    assert_zero_copy_only_raises(s)
+    assert_allow_copy_false_raises(s)
 
 
 @pytest.mark.parametrize(
@@ -199,7 +199,7 @@ def test_to_numpy_object_dtypes(
 
     assert result.tolist() == values
     assert result.dtype == np.object_
-    assert_zero_copy_only_raises(s)
+    assert_allow_copy_false_raises(s)
 
 
 def test_series_to_numpy_bool() -> None:
@@ -208,7 +208,7 @@ def test_series_to_numpy_bool() -> None:
 
     assert s.to_list() == result.tolist()
     assert result.dtype == np.bool_
-    assert_zero_copy_only_raises(s)
+    assert_allow_copy_false_raises(s)
 
 
 def test_series_to_numpy_bool_with_nulls() -> None:
@@ -217,7 +217,7 @@ def test_series_to_numpy_bool_with_nulls() -> None:
 
     assert s.to_list() == result.tolist()
     assert result.dtype == np.object_
-    assert_zero_copy_only_raises(s)
+    assert_allow_copy_false_raises(s)
 
 
 def test_series_to_numpy_array_of_int() -> None:
@@ -249,7 +249,7 @@ def test_series_to_numpy_array_with_nulls() -> None:
     expected = np.array([[1.0, 2.0], [3.0, 4.0], [np.nan, np.nan]])
     assert_array_equal(result, expected)
     assert result.dtype == np.float64
-    assert_zero_copy_only_raises(s)
+    assert_allow_copy_false_raises(s)
 
 
 def test_to_numpy_null() -> None:
@@ -258,12 +258,12 @@ def test_to_numpy_null() -> None:
     expected = np.array([np.nan, np.nan], dtype=np.float32)
     assert_array_equal(result, expected)
     assert result.dtype == np.float32
-    assert_zero_copy_only_raises(s)
+    assert_allow_copy_false_raises(s)
 
 
 def test_to_numpy_empty() -> None:
     s = pl.Series(dtype=pl.String)
-    result = s.to_numpy(use_pyarrow=False, zero_copy_only=True)
+    result = s.to_numpy(use_pyarrow=False, allow_copy=False)
     assert result.dtype == np.object_
     assert result.shape == (0,)
     assert result.size == 0
@@ -278,7 +278,15 @@ def test_to_numpy_chunked() -> None:
 
     assert result.tolist() == s.to_list()
     assert result.dtype == np.int64
-    assert_zero_copy_only_raises(s)
+    assert_allow_copy_false_raises(s)
+
+
+def test_zero_copy_only_deprecated() -> None:
+    values = [1, 2]
+    s = pl.Series([1, 2])
+    with pytest.deprecated_call():
+        result = s.to_numpy(zero_copy_only=True)
+    assert result.tolist() == values
 
 
 def test_series_to_numpy_temporal() -> None:


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/14334

### Changes

* Add `allow_copy` parameter to `DataFrame.to_numpy`, which will raise an error if a copy is required to perform the conversion
* For `Series.to_numpy`, deprecate the `zero_copy_only` parameter in favor of `allow_copy` which is the inverse.