### PR TITLE
fix: Enable `is_in` for string in categorical/enum

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/mod.rs
@@ -105,7 +105,7 @@ impl CategoricalChunked {
                 self.get_ordering(),
             )
         };
-        out.set_fast_unique(self.can_fast_unique());
+        out.set_fast_unique(self._can_fast_unique());
 
         out
     }
@@ -274,7 +274,9 @@ impl CategoricalChunked {
         }
     }
 
-    pub(crate) fn can_fast_unique(&self) -> bool {
+    /// True if all categories are represented in this array. When this is the case, the unique
+    /// values of the array are the categories.
+    pub fn _can_fast_unique(&self) -> bool {
         self.bit_settings.contains(BitSettings::ORIGINAL)
             && self.physical.chunks.len() == 1
             && self.null_count() == 0

--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
@@ -4,7 +4,7 @@ use crate::frame::group_by::IntoGroupsProxy;
 impl CategoricalChunked {
     pub fn unique(&self) -> PolarsResult<Self> {
         let cat_map = self.get_rev_map();
-        if self.can_fast_unique() {
+        if self._can_fast_unique() {
             let ca = match &**cat_map {
                 RevMapping::Local(a, _) => {
                     UInt32Chunked::from_iter_values(self.physical().name(), 0..(a.len() as u32))
@@ -41,7 +41,7 @@ impl CategoricalChunked {
     }
 
     pub fn n_unique(&self) -> PolarsResult<usize> {
-        if self.can_fast_unique() {
+        if self._can_fast_unique() {
             Ok(self.get_rev_map().len())
         } else {
             self.physical().n_unique()

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -522,7 +522,7 @@ impl CategoricalChunked {
         }
         if self.uses_lexical_ordering() {
             // Fast path where all categories are used
-            if self.can_fast_unique() {
+            if self._can_fast_unique() {
                 self.get_rev_map().get_categories().min_ignore_nan_kernel()
             } else {
                 let rev_map = self.get_rev_map();
@@ -550,7 +550,7 @@ impl CategoricalChunked {
         }
         if self.uses_lexical_ordering() {
             // Fast path where all categories are used
-            if self.can_fast_unique() {
+            if self._can_fast_unique() {
                 self.get_rev_map().get_categories().max_ignore_nan_kernel()
             } else {
                 let rev_map = self.get_rev_map();

--- a/crates/polars-core/src/frame/group_by/perfect.rs
+++ b/crates/polars-core/src/frame/group_by/perfect.rs
@@ -198,7 +198,7 @@ impl CategoricalChunked {
 
         let mut out = match &**rev_map {
             RevMapping::Local(cached, _) => {
-                if self.can_fast_unique() {
+                if self._can_fast_unique() {
                     if verbose() {
                         eprintln!("grouping categoricals, run perfect hash function");
                     }

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -26,7 +26,7 @@ impl SeriesWrap<CategoricalChunked> {
                 self.0.get_ordering(),
             )
         };
-        if keep_fast_unique && self.0.can_fast_unique() {
+        if keep_fast_unique && self.0._can_fast_unique() {
             out.set_fast_unique(true)
         }
         out

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -577,8 +577,7 @@ fn is_in_string_categorical(
     };
     Ok(ca_in
         .apply_values_generic(|val| set.contains(val))
-        .with_name(ca_in.name())
-    )
+        .with_name(ca_in.name()))
 }
 
 #[cfg(feature = "dtype-categorical")]

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -566,18 +566,17 @@ fn is_in_string_categorical(
     other: &CategoricalChunked,
 ) -> PolarsResult<BooleanChunked> {
     // We need only check against the unique categories used by this array.
-    let set: PlHashSet<&str>;
     Ok(if other._can_fast_unique() {
         // Build hash set directly from categories
         let cats = other.get_rev_map().get_categories();
-        set = cats.values_iter().collect();
+        let set: PlHashSet<&str> = cats.values_iter().collect();
         ca_in
             .apply_values_generic(|val| set.contains(&val))
             .with_name(ca_in.name())
     } else {
         // Build hash set from unique values
         let cats = other.unique().unwrap();
-        set = cats.iter_str().flatten().collect();
+        let set: PlHashSet<&str> = cats.iter_str().flatten().collect();
         ca_in
             .apply_values_generic(|val| set.contains(&val))
             .with_name(ca_in.name())

--- a/crates/polars-plan/src/logical_plan/optimizer/type_coercion/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/type_coercion/mod.rs
@@ -372,6 +372,10 @@ impl OptimizationRule for TypeCoercionRule {
                     (DataType::Categorical(_, _) | DataType::Enum(_, _), DataType::String) => {
                         return Ok(None)
                     },
+                    #[cfg(feature = "dtype-categorical")]
+                    (DataType::String, DataType::Categorical(_, _) | DataType::Enum(_, _)) => {
+                        return Ok(None)
+                    },
                     #[cfg(feature = "dtype-decimal")]
                     (DataType::Decimal(_, _), _) | (_, DataType::Decimal(_, _)) => {
                         polars_bail!(InvalidOperation: "`is_in` cannot check for {:?} values in {:?} data", &type_other, &type_left)

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -314,10 +314,8 @@ def test_is_in_with_wildcard_13809() -> None:
     assert_frame_equal(out, expected)
 
 
-@StringCache()
 @pytest.mark.parametrize("dtype", [pl.Categorical, pl.Enum(["a", "b", "c", "d"])])
 def test_cat_is_in_from_str(dtype: pl.DataType) -> None:
-    # init the global cache
     s = pl.Series(["c", "c", "b"], dtype=dtype)
 
     # test local

--- a/py-polars/tests/unit/operations/test_is_in.py
+++ b/py-polars/tests/unit/operations/test_is_in.py
@@ -312,3 +312,16 @@ def test_is_in_with_wildcard_13809() -> None:
     out = pl.DataFrame({"A": ["B"]}).select(pl.all().is_in(["C"]))
     expected = pl.DataFrame({"A": [False]})
     assert_frame_equal(out, expected)
+
+
+@StringCache()
+@pytest.mark.parametrize("dtype", [pl.Categorical, pl.Enum(["a", "b", "c", "d"])])
+def test_cat_is_in_from_str(dtype: pl.DataType) -> None:
+    # init the global cache
+    s = pl.Series(["c", "c", "b"], dtype=dtype)
+
+    # test local
+    assert_series_equal(
+        pl.Series(["a", "d", "e", "b"]).is_in(s),
+        pl.Series([False, False, False, True]),
+    )


### PR DESCRIPTION
Resolves #14575.

Prequisite to #14559 being fixed.