### PR TITLE
fix: Polars thread pool was not used properly in various functions

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -89,17 +89,15 @@ pub(crate) fn encode_rows_vertical(by: &[Series]) -> PolarsResult<BinaryOffsetCh
     let splits = _split_offsets(len, n_threads);
     let descending = vec![false; by.len()];
 
-    let chunks: PolarsResult<Vec<_>> = splits
-        .into_par_iter()
-        .map(|(offset, len)| {
-            let sliced = by
-                .iter()
-                .map(|s| s.slice(offset as i64, len))
-                .collect::<Vec<_>>();
-            let rows = _get_rows_encoded(&sliced, &descending, false)?;
-            Ok(rows.into_array())
-        })
-        .collect();
+    let chunks = splits.into_par_iter().map(|(offset, len)| {
+        let sliced = by
+            .iter()
+            .map(|s| s.slice(offset as i64, len))
+            .collect::<Vec<_>>();
+        let rows = _get_rows_encoded(&sliced, &descending, false)?;
+        Ok(rows.into_array())
+    });
+    let chunks = POOL.install(|| chunks.collect::<PolarsResult<Vec<_>>>());
 
     Ok(BinaryOffsetChunked::from_chunk_iter("", chunks?))
 }

--- a/crates/polars-core/src/frame/arithmetic.rs
+++ b/crates/polars-core/src/frame/arithmetic.rs
@@ -113,7 +113,7 @@ impl DataFrame {
     ) -> PolarsResult<DataFrame> {
         let max_len = std::cmp::max(self.height(), other.height());
         let max_width = std::cmp::max(self.width(), other.width());
-        let mut cols = self
+        let cols = self
             .get_columns()
             .par_iter()
             .zip(other.get_columns().par_iter())
@@ -133,8 +133,8 @@ impl DataFrame {
                 };
 
                 f(&l, &r)
-            })
-            .collect::<PolarsResult<Vec<_>>>()?;
+            });
+        let mut cols = POOL.install(|| cols.collect::<PolarsResult<Vec<_>>>())?;
 
         let col_len = cols.len();
         if col_len < max_width {

--- a/crates/polars-core/src/frame/row/transpose.rs
+++ b/crates/polars-core/src/frame/row/transpose.rs
@@ -224,37 +224,36 @@ where
         })
     });
 
-    cols_t.par_extend(POOL.install(|| {
-        values_buf
-            .into_par_iter()
-            .zip(validity_buf)
-            .zip(names_out)
-            .map(|((mut values, validity), name)| {
-                // SAFETY:
-                // all values are written we can now set len
-                unsafe {
-                    values.set_len(new_height);
-                }
+    let par_iter = values_buf
+        .into_par_iter()
+        .zip(validity_buf)
+        .zip(names_out)
+        .map(|((mut values, validity), name)| {
+            // SAFETY:
+            // all values are written we can now set len
+            unsafe {
+                values.set_len(new_height);
+            }
 
-                let validity = if has_nulls {
-                    let validity = Bitmap::from_trusted_len_iter(validity.iter().copied());
-                    if validity.unset_bits() > 0 {
-                        Some(validity)
-                    } else {
-                        None
-                    }
+            let validity = if has_nulls {
+                let validity = Bitmap::from_trusted_len_iter(validity.iter().copied());
+                if validity.unset_bits() > 0 {
+                    Some(validity)
                 } else {
                     None
-                };
+                }
+            } else {
+                None
+            };
 
-                let arr = PrimitiveArray::<T::Native>::new(
-                    T::get_dtype().to_arrow(true),
-                    values.into(),
-                    validity,
-                );
-                ChunkedArray::with_chunk(name.as_str(), arr).into_series()
-            })
-    }));
+            let arr = PrimitiveArray::<T::Native>::new(
+                T::get_dtype().to_arrow(true),
+                values.into(),
+                validity,
+            );
+            ChunkedArray::with_chunk(name.as_str(), arr).into_series()
+        });
+    POOL.install(|| cols_t.par_extend(par_iter));
 }
 
 #[cfg(test)]

--- a/crates/polars-io/src/csv/read.rs
+++ b/crates/polars-io/src/csv/read.rs
@@ -681,6 +681,8 @@ where
 
 #[cfg(feature = "temporal")]
 fn parse_dates(mut df: DataFrame, fixed_schema: &Schema) -> DataFrame {
+    use polars_core::POOL;
+
     let cols = unsafe { std::mem::take(df.get_columns_mut()) }
         .into_par_iter()
         .map(|s| {
@@ -700,8 +702,8 @@ fn parse_dates(mut df: DataFrame, fixed_schema: &Schema) -> DataFrame {
                 },
                 _ => s,
             }
-        })
-        .collect::<Vec<_>>();
+        });
+    let cols = POOL.install(|| cols.collect::<Vec<_>>());
 
     unsafe { DataFrame::new_no_checks(cols) }
 }

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -95,49 +95,46 @@ where
     let n_tables = hash_tbls.len();
 
     // Now we probe the right hand side for each left hand side.
-    Ok(POOL
-        .install(|| {
-            split_by_left
-                .into_par_iter()
-                .zip(offsets)
-                .flat_map(|(by_left, offset)| {
-                    let mut results = Vec::with_capacity(by_left.len());
-                    let mut group_states: PlHashMap<IdxSize, A> =
-                        PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
+    let out = split_by_left
+        .into_par_iter()
+        .zip(offsets)
+        .flat_map(|(by_left, offset)| {
+            let mut results = Vec::with_capacity(by_left.len());
+            let mut group_states: PlHashMap<IdxSize, A> =
+                PlHashMap::with_capacity(_HASHMAP_INIT_SIZE);
 
-                    let by_left_chunk = by_left.downcast_iter().next().unwrap();
-                    for (rel_idx_left, opt_by_left_k) in by_left_chunk.iter().enumerate() {
-                        let Some(by_left_k) = opt_by_left_k else {
-                            results.push(None);
-                            continue;
-                        };
-                        let idx_left = (rel_idx_left + offset) as IdxSize;
-                        let Some(left_val) = left_val_arr.get(idx_left as usize) else {
-                            results.push(None);
-                            continue;
-                        };
+            let by_left_chunk = by_left.downcast_iter().next().unwrap();
+            for (rel_idx_left, opt_by_left_k) in by_left_chunk.iter().enumerate() {
+                let Some(by_left_k) = opt_by_left_k else {
+                    results.push(None);
+                    continue;
+                };
+                let idx_left = (rel_idx_left + offset) as IdxSize;
+                let Some(left_val) = left_val_arr.get(idx_left as usize) else {
+                    results.push(None);
+                    continue;
+                };
 
-                        let group_probe_table = unsafe {
-                            hash_tbls
-                                .get_unchecked(hash_to_partition(by_left_k.dirty_hash(), n_tables))
-                        };
-                        let Some(right_grp_idxs) = group_probe_table.get(by_left_k) else {
-                            results.push(None);
-                            continue;
-                        };
+                let group_probe_table = unsafe {
+                    hash_tbls.get_unchecked(hash_to_partition(by_left_k.dirty_hash(), n_tables))
+                };
+                let Some(right_grp_idxs) = group_probe_table.get(by_left_k) else {
+                    results.push(None);
+                    continue;
+                };
 
-                        results.push(asof_in_group::<T, A, &F>(
-                            left_val,
-                            right_val_arr,
-                            right_grp_idxs.as_slice(),
-                            &mut group_states,
-                            &filter,
-                        ));
-                    }
-                    results
-                })
-        })
-        .collect())
+                results.push(asof_in_group::<T, A, &F>(
+                    left_val,
+                    right_val_arr,
+                    right_grp_idxs.as_slice(),
+                    &mut group_states,
+                    &filter,
+                ));
+            }
+            results
+        });
+
+    Ok(POOL.install(|| out.collect()))
 }
 
 fn asof_join_by_binary<T, A, F>(


### PR DESCRIPTION
Found these by running `py.test` with a rayon fork that panicked on attempts to use the global thread pool.

In theory it might be possible to initialize rayon's global thread pool with a `start_handler`  that panics for debug builds, but I couldn't try it because I don't know where to put the call to build the thread pool - I can't call it outside of function contexts because it wasn't a `const fn`.
