### PR TITLE
docs: Fix typo of "Cartesian" product

### DIFF
--- a/crates/polars-compute/src/arity.rs
+++ b/crates/polars-compute/src/arity.rs
@@ -8,7 +8,7 @@ use arrow::types::NativeType;
 ///
 /// # Safety
 ///  - arr must point to a readable slice of length len.
-///  - out must point to a writeable slice of length len.
+///  - out must point to a writable slice of length len.
 #[inline(never)]
 unsafe fn ptr_apply_unary_kernel<I: Copy, O, F: Fn(I) -> O>(
     arr: *const I,
@@ -25,7 +25,7 @@ unsafe fn ptr_apply_unary_kernel<I: Copy, O, F: Fn(I) -> O>(
 /// # Safety
 ///  - left must point to a readable slice of length len.
 ///  - right must point to a readable slice of length len.
-///  - out must point to a writeable slice of length len.
+///  - out must point to a writable slice of length len.
 #[inline(never)]
 unsafe fn ptr_apply_binary_kernel<L: Copy, R: Copy, O, F: Fn(L, R) -> O>(
     left: *const L,

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1113,7 +1113,7 @@ impl LazyFrame {
         )
     }
 
-    /// Creates the cartesian product from both frames, preserving the order of the left keys.
+    /// Creates the Cartesian product from both frames, preserving the order of the left keys.
     #[cfg(feature = "cross_join")]
     pub fn cross_join(self, other: LazyFrame) -> LazyFrame {
         self.join(other, vec![], vec![], JoinArgs::new(JoinType::Cross))

--- a/crates/polars-ops/src/frame/join/cross_join.rs
+++ b/crates/polars-ops/src/frame/join/cross_join.rs
@@ -120,7 +120,7 @@ pub trait CrossJoin: IntoDf {
         Ok(l_df)
     }
 
-    /// Creates the cartesian product from both frames, preserves the order of the left keys.
+    /// Creates the Cartesian product from both frames, preserves the order of the left keys.
     fn cross_join(
         &self,
         other: &DataFrame,

--- a/crates/polars/src/lib.rs
+++ b/crates/polars/src/lib.rs
@@ -225,7 +225,7 @@
 //!     - `rows` - Create [`DataFrame`] from rows and extract rows from [`DataFrame`]s.
 //!                And activates `pivot` and `transpose` operations
 //!     - `asof_join` - Join ASOF, to join on nearest keys instead of exact equality match.
-//!     - `cross_join` - Create the cartesian product of two [`DataFrame`]s.
+//!     - `cross_join` - Create the Cartesian product of two [`DataFrame`]s.
 //!     - `semi_anti_join` - SEMI and ANTI joins.
 //!     - `group_by_list` - Allow group_by operation on keys of type List.
 //!     - `row_hash` - Utility to hash [`DataFrame`] rows to [`UInt64Chunked`]

--- a/docs/user-guide/installation.md
+++ b/docs/user-guide/installation.md
@@ -123,7 +123,7 @@ The opt-in features are:
     - `rows` - Create `DataFrame` from rows and extract rows from `DataFrames`.
     And activates `pivot` and `transpose` operations
     - `join_asof` - Join ASOF, to join on nearest keys instead of exact equality match.
-    - `cross_join` - Create the cartesian product of two DataFrames.
+    - `cross_join` - Create the Cartesian product of two DataFrames.
     - `semi_anti_join` - SEMI and ANTI joins.
     - `group_by_list` - Allow group by operation on keys of type List.
     - `row_hash` - Utility to hash DataFrame rows to UInt64Chunked

--- a/docs/user-guide/transformations/joins.md
+++ b/docs/user-guide/transformations/joins.md
@@ -65,7 +65,7 @@ The `outer` join produces a `DataFrame` that contains all the rows from both `Da
 
 ### Cross join
 
-A `cross` join is a cartesian product of the two `DataFrames`. This means that every row in the left `DataFrame` is joined with every row in the right `DataFrame`. The `cross` join is useful for creating a `DataFrame` with all possible combinations of the columns in two `DataFrames`. Let's take for example the following two `DataFrames`.
+A `cross` join is a Cartesian product of the two `DataFrames`. This means that every row in the left `DataFrame` is joined with every row in the right `DataFrame`. The `cross` join is useful for creating a `DataFrame` with all possible combinations of the columns in two `DataFrames`. Let's take for example the following two `DataFrames`.
 
 {{code_block('user-guide/transformations/joins','df3',['DataFrame'])}}
 

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6272,7 +6272,7 @@ class DataFrame:
             * *outer_coalesce*
                  Same as 'outer', but coalesces the key columns
             * *cross*
-                 Returns the cartisian product of rows from both tables
+                 Returns the Cartesian product of rows from both tables
             * *semi*
                  Filter rows that have a match in the right table.
             * *anti*

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -2450,7 +2450,7 @@ class DataFrame:
         Parameters
         ----------
         file
-            File path or writeable file-like object to which the result will be written.
+            File path or writable file-like object to which the result will be written.
             If set to `None` (default), the output is returned as a string instead.
         pretty
             Pretty serialize json.
@@ -2506,7 +2506,7 @@ class DataFrame:
         Parameters
         ----------
         file
-            File path or writeable file-like object to which the result will be written.
+            File path or writable file-like object to which the result will be written.
             If set to `None` (default), the output is returned as a string instead.
 
         Examples
@@ -2602,7 +2602,7 @@ class DataFrame:
         Parameters
         ----------
         file
-            File path or writeable file-like object to which the result will be written.
+            File path or writable file-like object to which the result will be written.
             If set to `None` (default), the output is returned as a string instead.
         include_bom
             Whether to include UTF-8 BOM in the CSV output.
@@ -2713,7 +2713,7 @@ class DataFrame:
         Parameters
         ----------
         file
-            File path or writeable file-like object to which the data will be written.
+            File path or writable file-like object to which the data will be written.
         compression : {'uncompressed', 'snappy', 'deflate'}
             Compression method. Defaults to "uncompressed".
         name
@@ -3281,7 +3281,7 @@ class DataFrame:
         Parameters
         ----------
         file
-            Path or writeable file-like object to which the IPC data will be
+            Path or writable file-like object to which the IPC data will be
             written. If set to `None`, the output is returned as a BytesIO object.
         compression : {'uncompressed', 'lz4', 'zstd'}
             Compression method. Defaults to "uncompressed".
@@ -3353,7 +3353,7 @@ class DataFrame:
         Parameters
         ----------
         file
-            Path or writeable file-like object to which the IPC record batch data will
+            Path or writable file-like object to which the IPC record batch data will
             be written. If set to `None`, the output is returned as a BytesIO object.
         compression : {'uncompressed', 'lz4', 'zstd'}
             Compression method. Defaults to "uncompressed".
@@ -3402,7 +3402,7 @@ class DataFrame:
         Parameters
         ----------
         file
-            File path or writeable file-like object to which the result will be written.
+            File path or writable file-like object to which the result will be written.
         compression : {'lz4', 'uncompressed', 'snappy', 'gzip', 'lzo', 'brotli', 'zstd'}
             Choose "zstd" for good compression performance.
             Choose "lz4" for fast compression/decompression.

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3952,7 +3952,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             * *outer_coalesce*
                  Same as 'outer', but coalesces the key columns
             * *cross*
-                 Returns the cartisian product of rows from both tables
+                 Returns the Cartesian product of rows from both tables
             * *semi*
                  Filter rows that have a match in the right table.
             * *anti*

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_df.py
@@ -133,7 +133,7 @@ def test_df_to_numpy_zero_copy_path() -> None:
     assert str(x[0, :]) == "[1. 2. 1. 1. 1.]"
 
 
-def test_to_numpy_zero_copy_path_writeable() -> None:
+def test_to_numpy_zero_copy_path_writable() -> None:
     rows = 10
     cols = 5
     x = np.ones((rows, cols), order="F")

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1820,7 +1820,7 @@ def test_provide_schema() -> None:
     }
 
 
-def test_custom_writeable_object() -> None:
+def test_custom_writable_object() -> None:
     df = pl.DataFrame({"a": [10, 20, 30], "b": ["x", "y", "z"]})
 
     class CustomBuffer:


### PR DESCRIPTION
Closes #14578

I'm also updating the spelling `writeable -> writable` to unify the spelling (both are correct, we use "writable" in our public API).