### PR TITLE
refactor(python): No longer use `SeriesView` in `Series.to_numpy`

### DIFF
--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -246,12 +246,12 @@ class _DataTypeMappings:
             Int8: ctypes.c_int8,
             Int16: ctypes.c_int16,
             Int32: ctypes.c_int32,
-            Date: ctypes.c_int32,
             Int64: ctypes.c_int64,
             Float32: ctypes.c_float,
             Float64: ctypes.c_double,
             Datetime: ctypes.c_int64,
             Duration: ctypes.c_int64,
+            Date: ctypes.c_int32,
             Time: ctypes.c_int64,
         }
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1430,7 +1430,7 @@ class Series:
                     args.append(arg)
                 elif isinstance(arg, Series):
                     validity_mask &= arg.is_not_null()
-                    args.append(arg._view(ignore_nulls=True))
+                    args.append(arg._s.to_numpy_view())
                 else:
                     msg = f"unsupported type {type(arg).__name__!r} for {arg!r}"
                     raise TypeError(msg)

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4376,17 +4376,20 @@ class Series:
 
         if self.null_count() == 0:
             if dtype.is_integer() or dtype.is_float():
-                np_array = self._view(ignore_nulls=True)
+                np_array = self._s.to_numpy_view()
             elif dtype == Boolean:
                 raise_on_copy()
-                np_array = self.cast(UInt8)._view(ignore_nulls=True).view(bool)
+                s_u8 = self.cast(UInt8)
+                np_array = s_u8._s.to_numpy_view().view(bool)
             elif dtype in (Datetime, Duration):
                 np_dtype = temporal_dtype_to_numpy(dtype)
-                np_array = self._view(ignore_nulls=True).view(np_dtype)
+                s_i64 = self.to_physical()
+                np_array = s_i64._s.to_numpy_view().view(np_dtype)
             elif dtype == Date:
                 raise_on_copy()
                 np_dtype = temporal_dtype_to_numpy(dtype)
-                np_array = self.to_physical()._view(ignore_nulls=True).astype(np_dtype)
+                s_i32 = self.to_physical()
+                np_array = s_i32._s.to_numpy_view().astype(np_dtype)
             else:
                 raise_on_copy()
                 np_array = self._s.to_numpy()
@@ -4403,39 +4406,6 @@ class Series:
             np_array = np_array.copy()
 
         return np_array
-
-    def _view(self, *, ignore_nulls: bool = False) -> SeriesView:
-        """
-        Get a view into this Series data with a numpy array.
-
-        This operation doesn't clone data, but does not include missing values.
-
-        Returns
-        -------
-        SeriesView
-
-        Parameters
-        ----------
-        ignore_nulls
-            If True then nulls are converted to 0.
-            If False then an Exception is raised if nulls are present.
-
-        Examples
-        --------
-        >>> s = pl.Series("a", [1, None])
-        >>> s._view(ignore_nulls=True)
-        SeriesView([1, 0])
-        """
-        if not ignore_nulls:
-            assert not self.null_count()
-
-        from polars.series._numpy import SeriesView, _ptr_to_numpy
-
-        ptr_type = dtype_to_ctype(self.dtype)
-        ptr = self._s.as_single_ptr()
-        array = _ptr_to_numpy(ptr, self.len(), ptr_type)
-        array.setflags(write=False)
-        return SeriesView(array, self)
 
     def to_arrow(self) -> pa.Array:
         """
@@ -7553,7 +7523,16 @@ class Series:
             If True then nulls are converted to 0.
             If False then an Exception is raised if nulls are present.
         """
-        return self._view(ignore_nulls=ignore_nulls)
+        if not ignore_nulls:
+            assert not self.null_count()
+
+        from polars.series._numpy import SeriesView, _ptr_to_numpy
+
+        ptr_type = dtype_to_ctype(self.dtype)
+        ptr = self._s.as_single_ptr()
+        array = _ptr_to_numpy(ptr, self.len(), ptr_type)
+        array.setflags(write=False)
+        return SeriesView(array, self)
 
     @deprecate_function(
         "It has been renamed to `replace`."

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -1430,7 +1430,7 @@ class Series:
                     args.append(arg)
                 elif isinstance(arg, Series):
                     validity_mask &= arg.is_not_null()
-                    args.append(arg._s.to_numpy_view())
+                    args.append(arg.to_physical()._s.to_numpy_view())
                 else:
                     msg = f"unsupported type {type(arg).__name__!r} for {arg!r}"
                     raise TypeError(msg)

--- a/py-polars/src/to_numpy.rs
+++ b/py-polars/src/to_numpy.rs
@@ -62,15 +62,18 @@ impl PySeries {
                 // Object to the series keep the memory alive.
                 let owner = self.clone().into_py(py);
                 with_match_physical_numeric_polars_type!(self.series.dtype(), |$T| {
-                            let ca: &ChunkedArray<$T> = self.series.unpack::<$T>().unwrap();
-                            let slice = ca.cont_slice().unwrap();
-                            unsafe { Some(create_borrowed_np_array::<<$T as PolarsNumericType>::Native, _>(
-                                py,
-                                dims,
-                                flags::NPY_ARRAY_FARRAY_RO,
-                                slice.as_ptr() as _,
-                                owner,
-                            )) }
+                    let ca: &ChunkedArray<$T> = self.series.unpack::<$T>().unwrap();
+                    let slice = ca.cont_slice().unwrap();
+                    let view = unsafe {
+                        create_borrowed_np_array::<<$T as PolarsNumericType>::Native, _>(
+                            py,
+                            dims,
+                            flags::NPY_ARRAY_FARRAY_RO,
+                            slice.as_ptr() as _,
+                            owner,
+                        )
+                    };
+                    Some(view)
                 })
             },
             _ => None,

--- a/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
+++ b/py-polars/tests/unit/interop/numpy/test_to_numpy_series.py
@@ -380,7 +380,8 @@ def test_to_numpy2(
 
 def test_view() -> None:
     s = pl.Series("a", [1.0, 2.5, 3.0])
-    result = s._view()
+    with pytest.deprecated_call():
+        result = s.view()
     assert isinstance(result, np.ndarray)
     assert np.all(result == np.array([1.0, 2.5, 3.0]))
 
@@ -388,27 +389,22 @@ def test_view() -> None:
 def test_view_nulls() -> None:
     s = pl.Series("b", [1, 2, None])
     assert s.has_validity()
-    with pytest.raises(AssertionError):
-        s._view()
+    with pytest.deprecated_call(), pytest.raises(AssertionError):
+        s.view()
 
 
 def test_view_nulls_sliced() -> None:
     s = pl.Series("b", [1, 2, None])
     sliced = s[:2]
-    assert np.all(sliced._view() == np.array([1, 2]))
+    with pytest.deprecated_call():
+        view = sliced.view()
+    assert np.all(view == np.array([1, 2]))
     assert not sliced.has_validity()
 
 
 def test_view_ub() -> None:
     # this would be UB if the series was dropped and not passed to the view
     s = pl.Series([3, 1, 5])
-    result = s.sort()._view()
-    assert np.sum(result) == 9
-
-
-def test_view_deprecated() -> None:
-    s = pl.Series("a", [1.0, 2.5, 3.0])
     with pytest.deprecated_call():
-        result = s.view()
-    assert isinstance(result, np.ndarray)
-    assert np.all(result == np.array([1.0, 2.5, 3.0]))
+        result = s.sort().view()
+    assert np.sum(result) == 9


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/14334

### Changes

* Use the new NumPy view functionality implemented in Rust for creating views in `to_numpy` and `__array_ufunc__`.
* The `SeriesView` class is kept around for now for use in the deprecated `Series.view`. It can be removed with the next breaking release.