### PR TITLE
depr(python): Deprecate `DataFrame/LazyFrame.approx_n_unique`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -9218,9 +9218,15 @@ class DataFrame:
         df = self.lazy().select(expr.n_unique()).collect(_eager=True)
         return 0 if df.is_empty() else df.row(0)[0]
 
+    @deprecate_function(
+        "Use `select(pl.all().approx_n_unique())` instead.", version="0.20.11"
+    )
     def approx_n_unique(self) -> DataFrame:
         """
         Approximate count of unique values.
+
+        .. deprecated: 0.20.11
+            Use `select(pl.all().approx_n_unique())` instead.
 
         This is done using the HyperLogLog++ algorithm for cardinality estimation.
 
@@ -9232,7 +9238,7 @@ class DataFrame:
         ...         "b": [1, 2, 1, 1],
         ...     }
         ... )
-        >>> df.approx_n_unique()
+        >>> df.approx_n_unique()  # doctest: +SKIP
         shape: (1, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -4813,9 +4813,15 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         """
         return self.slice(0, 1)
 
+    @deprecate_function(
+        "Use `select(pl.all().approx_n_unique())` instead.", version="0.20.11"
+    )
     def approx_n_unique(self) -> Self:
         """
         Approximate count of unique values.
+
+        .. deprecated: 0.20.11
+            Use `select(pl.all().approx_n_unique())` instead.
 
         This is done using the HyperLogLog++ algorithm for cardinality estimation.
 
@@ -4827,7 +4833,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...         "b": [1, 2, 1, 1],
         ...     }
         ... )
-        >>> lf.approx_n_unique().collect()
+        >>> lf.approx_n_unique().collect()  # doctest: +SKIP
         shape: (1, 2)
         ┌─────┬─────┐
         │ a   ┆ b   │

--- a/py-polars/tests/unit/operations/unique/test_approx_n_unique.py
+++ b/py-polars/tests/unit/operations/unique/test_approx_n_unique.py
@@ -1,0 +1,20 @@
+import pytest
+
+import polars as pl
+from polars.testing.asserts.frame import assert_frame_equal
+
+
+def test_df_approx_n_unique_deprecated() -> None:
+    df = pl.DataFrame({"a": [1, 2, 2], "b": [2, 2, 2]})
+    with pytest.deprecated_call():
+        result = df.approx_n_unique()
+    expected = pl.DataFrame({"a": [2], "b": [1]}).cast(pl.UInt32)
+    assert_frame_equal(result, expected)
+
+
+def test_lf_approx_n_unique_deprecated() -> None:
+    df = pl.LazyFrame({"a": [1, 2, 2], "b": [2, 2, 2]})
+    with pytest.deprecated_call():
+        result = df.approx_n_unique()
+    expected = pl.LazyFrame({"a": [2], "b": [1]}).cast(pl.UInt32)
+    assert_frame_equal(result, expected)


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/13498

Deprecated because users may expect the approximate number of unique rows (rather than the number of unique values in each column).