### PR TITLE
docs: Add missing 'string' column in reading-writing Rust example to match Python example

### DIFF
--- a/docs/src/rust/user-guide/getting-started/reading-writing.rs
+++ b/docs/src/rust/user-guide/getting-started/reading-writing.rs
@@ -13,7 +13,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 NaiveDate::from_ymd_opt(2025, 1, 2).unwrap().and_hms_opt(0, 0, 0).unwrap(),
                 NaiveDate::from_ymd_opt(2025, 1, 3).unwrap().and_hms_opt(0, 0, 0).unwrap(),
         ],
-        "float" => &[4.0, 5.0, 6.0]
+        "float" => &[4.0, 5.0, 6.0],
+        "string" => &["a", "b", "c"],
     )
     .unwrap();
     println!("{}", df);


### PR DESCRIPTION
The [Reading and Writing section](https://docs.pola.rs/user-guide/getting-started/#reading-writing) in the Getting Started page shows an example of creating a `DataFrame` in both Python and Rust. The Rust example is missing the fourth `string` column, which is present in the Python example and in the output (pasted below):

```
shape: (3, 4)
┌─────────┬─────────────────────┬───────┬────────┐
│ integer ┆ date                ┆ float ┆ string │
│ ---     ┆ ---                 ┆ ---   ┆ ---    │
│ i64     ┆ datetime[μs]        ┆ f64   ┆ str    │
╞═════════╪═════════════════════╪═══════╪════════╡
│ 1       ┆ 2025-01-01 00:00:00 ┆ 4.0   ┆ a      │
│ 2       ┆ 2025-01-02 00:00:00 ┆ 5.0   ┆ b      │
│ 3       ┆ 2025-01-03 00:00:00 ┆ 6.0   ┆ c      │
└─────────┴─────────────────────┴───────┴────────┘
```

This PR adjusts the Rust example to include the `string` column, so it matches both the Python example and the expected output.