### PR TITLE
chore(python): Add a lint-only `Makefile` option

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -54,8 +54,13 @@ build-opt-native: .venv  ## Same as build-opt, except with native CPU optimizati
 build-release-native: .venv  ## Same as build-release, except with native CPU optimizations turned on
 	@$(MAKE) -s -C .. $@
 
+.PHONY: lint
+lint: .venv  ## Run lint checks
+	$(VENV_BIN)/ruff check
+	-$(VENV_BIN)/mypy
+
 .PHONY: fmt
-fmt: .venv  ## Run autoformatting and linting
+fmt: .venv  ## Run autoformatting (and lint)
 	$(VENV_BIN)/ruff check
 	$(VENV_BIN)/ruff format
 	$(VENV_BIN)/typos
@@ -68,7 +73,7 @@ clippy:  ## Run clippy
 	cargo clippy --locked -- -D warnings -D clippy::dbg_macro
 
 .PHONY: pre-commit
-pre-commit: fmt clippy  ## Run all code quality checks
+pre-commit: fmt clippy  ## Run all code formatting and lint/quality checks
 
 .PHONY: test
 test: .venv build  ## Run fast unittests


### PR DESCRIPTION
~~More cleanly separates the linting and formatting options in the`Makefile` (it was never clear to me why "fmt" would also trigger linting as they are not the same thing)~~

Update; PR now just adds `make lint` (no change to fmt).

### Example
```
make lint  # new; runs only the ruff/mypy linting ✔️
```


