### PR TITLE
ci: Rename coverage file

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -84,7 +84,7 @@ jobs:
           maturin develop
 
       - name: Run Python tests
-        run: pytest --cov -n auto --dist loadgroup -m "not benchmark and not docs" --cov-report xml:coverage.xml
+        run: pytest --cov -n auto --dist loadgroup -m "not benchmark and not docs" --cov-report xml:main.xml
         continue-on-error: true
 
       - name: Run Python tests - async reader
@@ -99,6 +99,6 @@ jobs:
       - name: Upload coverage information
         uses: codecov/codecov-action@v4
         with:
-          files: py-polars/coverage.lcov,py-polars/coverage.xml,py-polars/async.xml
+          files: py-polars/coverage.lcov,py-polars/main.xml,py-polars/async.xml
           name: macos
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -364,7 +364,7 @@ def test_enum_categories_unique() -> None:
 
 
 def test_enum_categories_series_input() -> None:
-    categories = pl.Series("a", ["x", "y", "z"])
+    categories = pl.Series("a", ["a", "b", "c"])
     dtype = pl.Enum(categories)
     assert_series_equal(dtype.categories, categories.alias("category"))
 


### PR DESCRIPTION
Right now are code coverage does not take into account the python tests. It seems the `coverage.xml` is overwritten by codecov itself