### PR TITLE
fix: Read empty pandas object columns as `Null` type

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -702,8 +702,8 @@ def from_pandas(
 
     >>> import pandas as pd
     >>> pd_series = pd.Series([1, 2, 3], name="pd")
-    >>> df = pl.from_pandas(pd_series)
-    >>> df
+    >>> s = pl.from_pandas(pd_series)
+    >>> s
     shape: (3,)
     Series: 'pd' [i64]
     [

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -658,7 +658,7 @@ def _pandas_series_to_arrow(
         if isinstance(first_non_none, str):
             return pa.array(values, pa.large_utf8(), from_pandas=nan_to_null)
         elif first_non_none is None:
-            return pa.nulls(length or len(values), pa.large_utf8())
+            return pa.nulls(length if length is not None else len(values))
         return pa.array(values, from_pandas=nan_to_null)
     elif dtype:
         return pa.array(values, from_pandas=nan_to_null)

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -244,15 +244,14 @@ def test_arrow_list_chunked_array() -> None:
 
 
 def test_from_pandas_null() -> None:
-    # null column is an object dtype, so pl.Utf8 is most close
     df = pd.DataFrame([{"a": None}, {"a": None}])
     out = pl.DataFrame(df)
-    assert out.dtypes == [pl.String]
+    assert out.dtypes == [pl.Null]
     assert out["a"][0] is None
 
     df = pd.DataFrame([{"a": None, "b": 1}, {"a": None, "b": 2}])
     out = pl.DataFrame(df)
-    assert out.dtypes == [pl.String, pl.Int64]
+    assert out.dtypes == [pl.Null, pl.Int64]
 
 
 def test_from_pandas_nested_list() -> None:

--- a/py-polars/tests/unit/interop/test_to_pandas.py
+++ b/py-polars/tests/unit/interop/test_to_pandas.py
@@ -118,7 +118,7 @@ def test_from_empty_pandas_with_dtypes() -> None:
     df = pd.DataFrame(columns=["a", "b"])
     df["a"] = df["a"].astype(str)
     df["b"] = df["b"].astype(float)
-    assert pl.from_pandas(df).dtypes == [pl.String, pl.Float64]
+    assert pl.from_pandas(df).dtypes == [pl.Null, pl.Float64]
 
     df = pl.DataFrame(
         data=[],
@@ -136,7 +136,7 @@ def test_from_empty_pandas_with_dtypes() -> None:
         pl.Datetime,
         pl.Float32,
         pl.Duration,
-        pl.String,
+        pl.Null,
     ]
 
 


### PR DESCRIPTION
Closes #14601