### PR TITLE
docs: Fix code block path for group by example in getting started guide

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -126,7 +126,7 @@ We will create a new `DataFrame` for the Group by functionality. This new `DataF
 print(df2)
 ```
 
-{{code_block('user-guide/bgetting-startedasics/expressions','group_by',['group_by'])}}
+{{code_block('user-guide/getting-started/expressions','group_by',['group_by'])}}
 
 ```python exec="on" result="text" session="getting-started/expressions"
 print(


### PR DESCRIPTION
While reading trough documentation I have noticed an output that was missing preceding code block.
After looking into documentation source I have noticed that it is due to typo in a path to code block.

Before:
![Знімок екрана з 2024-02-20 19-23-09](https://github.com/pola-rs/polars/assets/6797156/04b35c44-5d67-4dc3-9414-2b3a0cc88edc)

After:
![Знімок екрана з 2024-02-20 19-23-35](https://github.com/pola-rs/polars/assets/6797156/deff950d-f957-4d1f-8f00-8b33da5b75ad)
