### PR TITLE
chore(python): Use `uv` for `make requirements`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,11 @@ FILTER_PIP_WARNINGS=| grep -v "don't match your environment"; test $${PIPESTATUS
 
 .PHONY: requirements
 requirements: .venv  ## Install/refresh Python project requirements
-	$(VENV_BIN)/python -m pip install --upgrade pip
-	$(VENV_BIN)/pip install --upgrade -r py-polars/requirements-dev.txt
-	$(VENV_BIN)/pip install --upgrade -r py-polars/requirements-lint.txt
-	$(VENV_BIN)/pip install --upgrade -r py-polars/docs/requirements-docs.txt
-	$(VENV_BIN)/pip install --upgrade -r docs/requirements.txt
+	$(VENV_BIN)/python -m pip install --upgrade uv
+	$(VENV_BIN)/uv pip install --upgrade -r py-polars/requirements-dev.txt
+	$(VENV_BIN)/uv pip install --upgrade -r py-polars/requirements-lint.txt
+	$(VENV_BIN)/uv pip install --upgrade -r py-polars/docs/requirements-docs.txt
+	$(VENV_BIN)/uv pip install --upgrade -r docs/requirements.txt
 
 .PHONY: build
 build: .venv  ## Compile and install Python Polars for development

--- a/py-polars/docs/requirements-docs.txt
+++ b/py-polars/docs/requirements-docs.txt
@@ -1,5 +1,3 @@
---prefer-binary
-
 numpy
 pandas
 pyarrow

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -2,8 +2,6 @@
 # We're not pinning package dependencies, because our tests need to pass with the
 # latest version of the packages.
 
---prefer-binary
-
 # -----
 # BUILD
 # -----


### PR DESCRIPTION
https://github.com/astral-sh/uv

It's definitely a lot faster - no real reason not to use it.

* Using `pip`: ~30 seconds
* Using `uv`: ~3 seconds

The `--prefer-binary` syntax is not supported (yet?): https://github.com/astral-sh/uv/issues/1794
...but I don't think we really need to include this anyway.