### PR TITLE
fix: Implement `FromIterator` for `Series` for more types

### DIFF
--- a/crates/polars-core/src/series/iterator.rs
+++ b/crates/polars-core/src/series/iterator.rs
@@ -24,6 +24,19 @@ macro_rules! from_iterator {
                 ca.into_series()
             }
         }
+
+        impl<'a> FromIterator<Option<&'a $native>> for Series {
+            fn from_iter<I: IntoIterator<Item = Option<&'a $native>>>(iter: I) -> Self {
+                let ca: ChunkedArray<$variant> = iter
+                    .into_iter()
+                    .map(|item| match item {
+                        Some(value) => Some(*value),
+                        None => None,
+                    })
+                    .collect();
+                ca.into_series()
+            }
+        }
     };
 }
 

--- a/crates/polars-core/src/series/iterator.rs
+++ b/crates/polars-core/src/series/iterator.rs
@@ -64,6 +64,13 @@ impl FromIterator<String> for Series {
     }
 }
 
+impl FromIterator<Option<String>> for Series {
+    fn from_iter<I: IntoIterator<Item = Option<String>>>(iter: I) -> Self {
+        let ca: StringChunked = iter.into_iter().collect();
+        ca.into_series()
+    }
+}
+
 pub type SeriesPhysIter<'a> = Box<dyn ExactSizeIterator<Item = AnyValue<'a>> + 'a>;
 
 impl Series {

--- a/crates/polars-core/src/series/iterator.rs
+++ b/crates/polars-core/src/series/iterator.rs
@@ -50,6 +50,13 @@ impl<'a> FromIterator<&'a str> for Series {
     }
 }
 
+impl<'a> FromIterator<Option<&'a str>> for Series {
+    fn from_iter<I: IntoIterator<Item = Option<&'a str>>>(iter: I) -> Self {
+        let ca: StringChunked = iter.into_iter().collect();
+        ca.into_series()
+    }
+}
+
 impl FromIterator<String> for Series {
     fn from_iter<I: IntoIterator<Item = String>>(iter: I) -> Self {
         let ca: StringChunked = iter.into_iter().collect();


### PR DESCRIPTION
Fixes #14624.

This allows building Series from iterators over `Option<String>` and `Option<&'a str>`.

I've also added `FromIterator` for `Option<&'a $native>` in the macro definition.