### PR TITLE
test(python): Add test on selecting Enum columns

### DIFF
--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -9,7 +9,7 @@ import pytest
 
 import polars as pl
 from polars import StringCache
-from polars.testing import assert_series_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_enum_creation() -> None:
@@ -419,10 +419,5 @@ def test_enum_creating_col_expr() -> None:
     )
 
     out = df.select(pl.col(pl.Enum))
-    assert out.columns == ["col1", "col3"]
-    assert "col2" not in out.columns
-
-    expected_col1 = pl.Series("col1", ["a", "b", "c"], dtype=pl.Enum(["a", "b", "c"]))
-    expected_col3 = pl.Series("col3", ["g", "h", "i"], dtype=pl.Enum(["g", "h", "i"]))
-    assert_series_equal(out.get_column("col1"), expected_col1)
-    assert_series_equal(out.get_column("col3"), expected_col3)
+    expected = df.select("col1", "col3")
+    assert_frame_equal(out, expected)

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -403,6 +403,7 @@ def test_enum_cast_from_other_integer_dtype_oob() -> None:
     ):
         series.cast(enum_dtype)
 
+
 def test_enum_creating_col_expr() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
fix #13269 
close #13891

We already support it with the current code base, this PR supersedes the previous one and adds the test to the code base.
Thanks @collinprince!