### PR TITLE
feat: Allow CSV parsing into Array dtypes

### DIFF
--- a/crates/polars-core/src/chunked_array/builder/fixed_size_list.rs
+++ b/crates/polars-core/src/chunked_array/builder/fixed_size_list.rs
@@ -36,9 +36,17 @@ impl<T: NativeType> FixedSizeListNumericBuilder<T> {
     }
 }
 
-pub(crate) trait FixedSizeListBuilder {
+pub trait FixedSizeListBuilder {
+    /// # Safety
+    ///
+    /// `arr` must be of the correct dtype, with `len >= (offset+1) * width`
     unsafe fn push_unchecked(&mut self, arr: &dyn Array, offset: usize);
+
+    /// # Safety
+    ///
+    /// Unknown
     unsafe fn push_null(&mut self);
+
     fn finish(&mut self) -> ArrayChunked;
 }
 
@@ -136,7 +144,7 @@ impl FixedSizeListBuilder for AnonymousOwnedFixedSizeListBuilder {
     }
 }
 
-pub(crate) fn get_fixed_size_list_builder(
+pub fn get_fixed_size_list_builder(
     inner_type_logical: &DataType,
     capacity: usize,
     width: usize,

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -80,6 +80,7 @@ dtype-i8 = ["polars-core/dtype-i8"]
 dtype-i16 = ["polars-core/dtype-i16"]
 dtype-categorical = ["polars-core/dtype-categorical"]
 dtype-date = ["polars-core/dtype-date", "polars-time/dtype-date"]
+dtype-array = ["polars-core/dtype-array"]
 object = []
 dtype-datetime = [
   "polars-core/dtype-datetime",

--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -179,6 +179,22 @@ impl<'a> CoreReader<'a> {
             Some(schema) => schema,
             None => {
                 {
+                    #[cfg(feature = "dtype-array")]
+                    {
+                        // check if any array dtypes are present. these are currently unsupported.
+                        if let Some(dtype) = dtype_overwrite
+                            .into_iter()
+                            .flatten()
+                            .chain(schema_overwrite.iter().flat_map(|s| s.iter_dtypes()))
+                            .find(|&v| matches!(v, DataType::Array(_, _)))
+                        {
+                            polars_bail!(
+                                ComputeError: "unsupported data type {} while reading CSV; \
+                                Array dtypes are only supported with explicit schema.", dtype
+                            );
+                        }
+                    }
+
                     // We keep track of the inferred schema bool
                     // In case the file is compressed this schema inference is wrong and has to be done
                     // again after decompression.

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -286,6 +286,7 @@ dtype-array = [
   "polars-core/dtype-array",
   "polars-lazy?/dtype-array",
   "polars-ops/dtype-array",
+  "polars-io/dtype-array",
 ]
 dtype-i8 = [
   "polars-core/dtype-i8",

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import gzip
 import io
+import re
 import sys
 import textwrap
 import zlib
@@ -1955,3 +1956,58 @@ def test_read_csv_single_column(columns: list[str] | str) -> None:
     df = pl.read_csv(f, columns=columns)
     expected = pl.DataFrame({"b": [2, 5]})
     assert_frame_equal(df, expected)
+
+
+def test_read_csv_array_explicit_schema() -> None:
+    csv = textwrap.dedent(
+        """\
+        x,y,z,f
+        0.1,0.5,0.9,0.1
+        0.2,,1.0,0.2
+        0.3,0.7,1.1,0.3
+        0.4,0.8,1.2,0.4
+        """
+    )
+    f = io.StringIO(csv)
+    df = pl.read_csv(f, schema={"x": pl.Array(pl.Float32, 3), "f": pl.Float32})
+
+    expected = pl.DataFrame(
+        [
+            pl.Series(
+                "x",
+                [[0.1, 0.5, 0.9], [0.2, None, 1.0], [0.3, 0.7, 1.1], [0.4, 0.8, 1.2]],
+                pl.Array(pl.Float32, 3),
+            ),
+            pl.Series("f", [0.1, 0.2, 0.3, 0.4], pl.Float32),
+        ]
+    )
+    assert_frame_equal(df, expected)
+
+
+def test_read_csv_array_inferred_schema() -> None:
+    csv = textwrap.dedent(
+        """\
+        x,y,z,f
+        0.1,0.5,0.9,0.1
+        0.2,,1.0,0.2
+        0.3,0.7,1.1,0.3
+        0.4,0.8,1.2,0.4
+        """
+    )
+    f = io.StringIO(csv)
+    with pytest.raises(
+        pl.ComputeError,
+        match=re.escape(
+            "unsupported data type array[f32, 3] while reading CSV; Array dtypes are only supported with explicit schema."
+        ),
+    ):
+        pl.read_csv(f, dtypes={"x": pl.Array(pl.Float32, 3), "f": pl.Float32})
+
+    f.seek(0)
+    with pytest.raises(
+        pl.ComputeError,
+        match=re.escape(
+            "unsupported data type array[f32, 3] while reading CSV; Array dtypes are only supported with explicit schema."
+        ),
+    ):
+        pl.read_csv(f, dtypes=[pl.Array(pl.Float32, 3), pl.Float32])


### PR DESCRIPTION
PR for #14642

This PR adds basic support for array datatypes in `CsvReader`. An Array column maps to multiple physical columns in the CSV file. This prevents an expensive transpose operation that would otherwise be required when ingesting this data.

Currently, array dtypes are only allowed when using an explicit schema (`CsvReader::with_schema()` or `pl.read_csv(schema={...})`). Schema inference with an array dtype specified in `schema_overwrite` or `dtype_overwrite` is still unsupported (and errors accordingly). Fixing this would require substantial changes to the schema inference code.

I had to `pub` `polars_core::chunked_array::builder::fixed_size_list::FixedSizeListBuilder` to implement this. It seems like those APIs aren't the most developed/set in stone so that's something to consider before merging.