### PR TITLE
chore(rust): remove redundant imports (up until polars-core)

### DIFF
--- a/crates/polars-arrow/src/array/binary/from.rs
+++ b/crates/polars-arrow/src/array/binary/from.rs
@@ -1,5 +1,3 @@
-use std::iter::FromIterator;
-
 use super::{BinaryArray, MutableBinaryArray};
 use crate::offset::Offset;
 

--- a/crates/polars-arrow/src/array/binary/mutable.rs
+++ b/crates/polars-arrow/src/array/binary/mutable.rs
@@ -1,4 +1,3 @@
-use std::iter::FromIterator;
 use std::sync::Arc;
 
 use polars_error::{polars_bail, PolarsResult};

--- a/crates/polars-arrow/src/array/binary/mutable_values.rs
+++ b/crates/polars-arrow/src/array/binary/mutable_values.rs
@@ -1,4 +1,3 @@
-use std::iter::FromIterator;
 use std::sync::Arc;
 
 use polars_error::{polars_bail, PolarsResult};

--- a/crates/polars-arrow/src/array/boolean/from.rs
+++ b/crates/polars-arrow/src/array/boolean/from.rs
@@ -1,5 +1,3 @@
-use std::iter::FromIterator;
-
 use super::{BooleanArray, MutableBooleanArray};
 
 impl<P: AsRef<[Option<bool>]>> From<P> for BooleanArray {

--- a/crates/polars-arrow/src/array/boolean/mutable.rs
+++ b/crates/polars-arrow/src/array/boolean/mutable.rs
@@ -1,4 +1,3 @@
-use std::iter::FromIterator;
 use std::sync::Arc;
 
 use polars_error::{polars_bail, PolarsResult};

--- a/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mod.rs
@@ -266,20 +266,3 @@ impl FixedSizeBinaryArray {
         MutableFixedSizeBinaryArray::from(slice).into()
     }
 }
-
-pub trait FixedSizeBinaryValues {
-    fn values(&self) -> &[u8];
-    fn size(&self) -> usize;
-}
-
-impl FixedSizeBinaryValues for FixedSizeBinaryArray {
-    #[inline]
-    fn values(&self) -> &[u8] {
-        &self.values
-    }
-
-    #[inline]
-    fn size(&self) -> usize {
-        self.size
-    }
-}

--- a/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
+++ b/crates/polars-arrow/src/array/fixed_size_binary/mutable.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use polars_error::{polars_bail, PolarsResult};
 
-use super::{FixedSizeBinaryArray, FixedSizeBinaryValues};
+use super::FixedSizeBinaryArray;
 use crate::array::physical_binary::extend_validity;
 use crate::array::{Array, MutableArray, TryExtendFromSelf};
 use crate::bitmap::MutableBitmap;
@@ -287,18 +287,6 @@ impl MutableArray for MutableFixedSizeBinaryArray {
 
     fn shrink_to_fit(&mut self) {
         self.shrink_to_fit()
-    }
-}
-
-impl FixedSizeBinaryValues for MutableFixedSizeBinaryArray {
-    #[inline]
-    fn values(&self) -> &[u8] {
-        &self.values
-    }
-
-    #[inline]
-    fn size(&self) -> usize {
-        self.size
     }
 }
 

--- a/crates/polars-arrow/src/array/growable/mod.rs
+++ b/crates/polars-arrow/src/array/growable/mod.rs
@@ -1,8 +1,6 @@
 //! Contains the trait [`Growable`] and corresponding concreate implementations, one per concrete array,
 //! that offer the ability to create a new [`Array`] out of slices of existing [`Array`]s.
 
-use std::sync::Arc;
-
 use crate::array::*;
 use crate::datatypes::*;
 

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -146,15 +146,6 @@ pub trait Array: Send + Sync + dyn_clone::DynClone + 'static {
 
 dyn_clone::clone_trait_object!(Array);
 
-/// A trait describing an array with a backing store that can be preallocated to
-/// a given size.
-pub(crate) trait Container {
-    /// Create this array with a given capacity.
-    fn with_capacity(capacity: usize) -> Self
-    where
-        Self: Sized;
-}
-
 /// A trait describing a mutable array; i.e. an array whose values can be changed.
 /// Mutable arrays cannot be cloned but can be mutated in place,
 /// thereby making them useful to perform numeric operations without allocations.

--- a/crates/polars-arrow/src/array/primitive/from_natural.rs
+++ b/crates/polars-arrow/src/array/primitive/from_natural.rs
@@ -1,5 +1,3 @@
-use std::iter::FromIterator;
-
 use super::{MutablePrimitiveArray, PrimitiveArray};
 use crate::types::NativeType;
 

--- a/crates/polars-arrow/src/array/primitive/mutable.rs
+++ b/crates/polars-arrow/src/array/primitive/mutable.rs
@@ -1,4 +1,3 @@
-use std::iter::FromIterator;
 use std::sync::Arc;
 
 use polars_error::PolarsResult;

--- a/crates/polars-arrow/src/array/utf8/from.rs
+++ b/crates/polars-arrow/src/array/utf8/from.rs
@@ -1,5 +1,3 @@
-use std::iter::FromIterator;
-
 use super::{MutableUtf8Array, Utf8Array};
 use crate::offset::Offset;
 

--- a/crates/polars-arrow/src/array/utf8/mutable.rs
+++ b/crates/polars-arrow/src/array/utf8/mutable.rs
@@ -1,4 +1,3 @@
-use std::iter::FromIterator;
 use std::sync::Arc;
 
 use polars_error::{polars_bail, PolarsResult};

--- a/crates/polars-arrow/src/array/utf8/mutable_values.rs
+++ b/crates/polars-arrow/src/array/utf8/mutable_values.rs
@@ -1,4 +1,3 @@
-use std::iter::FromIterator;
 use std::sync::Arc;
 
 use polars_error::{polars_bail, PolarsResult};

--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -1,4 +1,3 @@
-use std::iter::FromIterator;
 use std::ops::Deref;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;

--- a/crates/polars-arrow/src/bitmap/mutable.rs
+++ b/crates/polars-arrow/src/bitmap/mutable.rs
@@ -1,5 +1,4 @@
 use std::hint::unreachable_unchecked;
-use std::iter::FromIterator;
 use std::sync::Arc;
 
 use polars_error::{polars_bail, PolarsResult};

--- a/crates/polars-arrow/src/bitmap/utils/chunk_iterator/chunks_exact.rs
+++ b/crates/polars-arrow/src/bitmap/utils/chunk_iterator/chunks_exact.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::slice::ChunksExact;
 
 use super::{BitChunk, BitChunkIterExact};

--- a/crates/polars-arrow/src/bitmap/utils/chunk_iterator/mod.rs
+++ b/crates/polars-arrow/src/bitmap/utils/chunk_iterator/mod.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 mod chunks_exact;
 mod merge;
 

--- a/crates/polars-arrow/src/buffer/immutable.rs
+++ b/crates/polars-arrow/src/buffer/immutable.rs
@@ -1,4 +1,3 @@
-use std::iter::FromIterator;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::usize;

--- a/crates/polars-arrow/src/compute/aggregate/simd/mod.rs
+++ b/crates/polars-arrow/src/compute/aggregate/simd/mod.rs
@@ -40,8 +40,6 @@ macro_rules! simd_add {
     };
 }
 
-pub(super) use simd_add;
-
 simd_add!(i128x8, i128, 8, add);
 
 #[cfg(not(feature = "simd"))]

--- a/crates/polars-arrow/src/compute/aggregate/simd/mod.rs
+++ b/crates/polars-arrow/src/compute/aggregate/simd/mod.rs
@@ -40,6 +40,8 @@ macro_rules! simd_add {
     };
 }
 
+pub(super) use simd_add;
+
 simd_add!(i128x8, i128, 8, add);
 
 #[cfg(not(feature = "simd"))]

--- a/crates/polars-arrow/src/compute/aggregate/simd/native.rs
+++ b/crates/polars-arrow/src/compute/aggregate/simd/native.rs
@@ -1,7 +1,6 @@
 use std::ops::Add;
 
 use super::super::sum::Sum;
-use super::simd_add;
 use crate::types::simd::*;
 
 simd_add!(u8x64, u8, 64, wrapping_add);

--- a/crates/polars-arrow/src/compute/aggregate/simd/native.rs
+++ b/crates/polars-arrow/src/compute/aggregate/simd/native.rs
@@ -1,6 +1,7 @@
 use std::ops::Add;
 
 use super::super::sum::Sum;
+use super::simd_add;
 use crate::types::simd::*;
 
 simd_add!(u8x64, u8, 64, wrapping_add);

--- a/crates/polars-arrow/src/ffi/schema.rs
+++ b/crates/polars-arrow/src/ffi/schema.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::convert::TryInto;
 use std::ffi::{CStr, CString};
 use std::ptr;
 

--- a/crates/polars-arrow/src/io/avro/read/deserialize.rs
+++ b/crates/polars-arrow/src/io/avro/read/deserialize.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use avro_schema::file::Block;
 use avro_schema::schema::{Enum, Field as AvroField, Record, Schema as AvroSchema};
 use polars_error::{polars_bail, polars_err, PolarsResult};

--- a/crates/polars-arrow/src/io/ipc/read/array/binview.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/binview.rs
@@ -1,14 +1,12 @@
-use std::collections::VecDeque;
 use std::io::{Read, Seek};
 use std::sync::Arc;
 
-use polars_error::{polars_err, PolarsResult};
+use polars_error::polars_err;
 
 use super::super::read_basic::*;
 use super::*;
 use crate::array::{ArrayRef, BinaryViewArrayGeneric, View, ViewType};
 use crate::buffer::Buffer;
-use crate::datatypes::ArrowDataType;
 
 #[allow(clippy::too_many_arguments)]
 pub fn read_binview<T: ViewType + ?Sized, R: Read + Seek>(

--- a/crates/polars-arrow/src/io/ipc/read/array/dictionary.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/dictionary.rs
@@ -1,5 +1,4 @@
 use std::collections::VecDeque;
-use std::convert::TryInto;
 use std::io::{Read, Seek};
 
 use ahash::HashSet;

--- a/crates/polars-arrow/src/io/ipc/read/array/list.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/list.rs
@@ -1,5 +1,4 @@
 use std::collections::VecDeque;
-use std::convert::TryInto;
 use std::io::{Read, Seek};
 
 use polars_error::{polars_err, PolarsResult};

--- a/crates/polars-arrow/src/io/ipc/read/array/primitive.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/primitive.rs
@@ -1,5 +1,4 @@
 use std::collections::VecDeque;
-use std::convert::TryInto;
 use std::io::{Read, Seek};
 
 use polars_error::{polars_err, PolarsResult};

--- a/crates/polars-arrow/src/io/ipc/read/array/utf8.rs
+++ b/crates/polars-arrow/src/io/ipc/read/array/utf8.rs
@@ -1,13 +1,11 @@
-use std::collections::VecDeque;
 use std::io::{Read, Seek};
 
-use polars_error::{polars_err, PolarsResult};
+use polars_error::polars_err;
 
 use super::super::read_basic::*;
 use super::*;
 use crate::array::Utf8Array;
 use crate::buffer::Buffer;
-use crate::datatypes::ArrowDataType;
 use crate::offset::Offset;
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/polars-arrow/src/io/ipc/read/common.rs
+++ b/crates/polars-arrow/src/io/ipc/read/common.rs
@@ -2,7 +2,6 @@ use std::collections::VecDeque;
 use std::io::{Read, Seek};
 
 use ahash::AHashMap;
-use arrow_format;
 use polars_error::{polars_bail, polars_err, PolarsResult};
 
 use super::deserialize::{read, skip};

--- a/crates/polars-arrow/src/io/ipc/read/file.rs
+++ b/crates/polars-arrow/src/io/ipc/read/file.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::io::{Read, Seek, SeekFrom};
 use std::sync::Arc;
 

--- a/crates/polars-arrow/src/io/ipc/read/read_basic.rs
+++ b/crates/polars-arrow/src/io/ipc/read/read_basic.rs
@@ -1,5 +1,4 @@
 use std::collections::VecDeque;
-use std::convert::TryInto;
 use std::io::{Read, Seek, SeekFrom};
 
 use polars_error::{polars_bail, polars_err, PolarsResult};

--- a/crates/polars-arrow/src/io/ipc/read/stream.rs
+++ b/crates/polars-arrow/src/io/ipc/read/stream.rs
@@ -1,7 +1,6 @@
 use std::io::Read;
 
 use ahash::AHashMap;
-use arrow_format;
 use arrow_format::ipc::planus::ReadAsRoot;
 use polars_error::{polars_bail, polars_err, PolarsError, PolarsResult};
 

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mean.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mean.rs
@@ -1,7 +1,5 @@
-use no_nulls::{rolling_apply_agg_window, RollingAggWindowNoNulls};
 use polars_error::polars_ensure;
 
-use super::sum::SumWindow;
 use super::*;
 
 pub struct MeanWindow<'a, T> {

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/min_max.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/min_max.rs
@@ -1,6 +1,3 @@
-use no_nulls;
-use no_nulls::{rolling_apply_agg_window, RollingAggWindowNoNulls};
-
 use super::*;
 
 #[inline]

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/mod.rs
@@ -19,7 +19,6 @@ use super::*;
 use crate::array::PrimitiveArray;
 use crate::datatypes::ArrowDataType;
 use crate::legacy::error::{polars_bail, PolarsResult};
-use crate::legacy::utils::CustomIterTools;
 use crate::types::NativeType;
 
 pub trait RollingAggWindowNoNulls<'a, T: NativeType> {

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/quantile.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/quantile.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-
 use num_traits::ToPrimitive;
 use polars_error::polars_ensure;
 use polars_utils::slice::GetSaferUnchecked;

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/sum.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/sum.rs
@@ -1,6 +1,3 @@
-use no_nulls;
-use no_nulls::{rolling_apply_agg_window, RollingAggWindowNoNulls};
-
 use super::*;
 
 pub struct SumWindow<'a, T> {

--- a/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/variance.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/no_nulls/variance.rs
@@ -1,7 +1,5 @@
-use no_nulls::{rolling_apply_agg_window, RollingAggWindowNoNulls};
 use polars_error::polars_ensure;
 
-use super::mean::MeanWindow;
 use super::*;
 
 pub(super) struct SumSquaredWindow<'a, T> {

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/mean.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/mean.rs
@@ -1,5 +1,4 @@
-use super::sum::SumWindow;
-use super::{rolling_apply_agg_window, RollingAggWindowNulls, *};
+use super::*;
 
 pub struct MeanWindow<'a, T> {
     sum: SumWindow<'a, T>,

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/min_max.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/min_max.rs
@@ -1,6 +1,3 @@
-use nulls;
-use nulls::{rolling_apply_agg_window, RollingAggWindowNulls};
-
 use super::*;
 use crate::array::iterator::NonNullValuesIter;
 use crate::bitmap::utils::count_zeros;

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/sum.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/sum.rs
@@ -1,6 +1,3 @@
-use nulls;
-use nulls::{rolling_apply_agg_window, RollingAggWindowNulls};
-
 use super::*;
 
 pub struct SumWindow<'a, T> {

--- a/crates/polars-arrow/src/legacy/kernels/rolling/nulls/variance.rs
+++ b/crates/polars-arrow/src/legacy/kernels/rolling/nulls/variance.rs
@@ -1,7 +1,3 @@
-use mean::MeanWindow;
-use nulls;
-use nulls::{rolling_apply_agg_window, RollingAggWindowNulls};
-
 use super::*;
 
 pub(super) struct SumSquaredWindow<'a, T> {

--- a/crates/polars-arrow/src/scalar/equal.rs
+++ b/crates/polars-arrow/src/scalar/equal.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use super::*;
-use crate::datatypes::PhysicalType;
 use crate::{match_integer_type, with_match_primitive_type};
 
 impl PartialEq for dyn Scalar + '_ {

--- a/crates/polars-arrow/src/types/index.rs
+++ b/crates/polars-arrow/src/types/index.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use super::NativeType;
 use crate::trusted_len::TrustedLen;
 

--- a/crates/polars-arrow/src/types/native.rs
+++ b/crates/polars-arrow/src/types/native.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::ops::Neg;
 use std::panic::RefUnwindSafe;
 

--- a/crates/polars-arrow/src/types/simd/mod.rs
+++ b/crates/polars-arrow/src/types/simd/mod.rs
@@ -123,8 +123,6 @@ macro_rules! native_simd {
     };
 }
 
-pub(super) use native_simd;
-
 // Types do not have specific intrinsics and thus SIMD can't be specialized.
 // Therefore, we can declare their MD representation as `[$t; 8]` irrespectively
 // of how they are represented in the different channels.

--- a/crates/polars-arrow/src/types/simd/mod.rs
+++ b/crates/polars-arrow/src/types/simd/mod.rs
@@ -123,6 +123,8 @@ macro_rules! native_simd {
     };
 }
 
+pub(super) use native_simd;
+
 // Types do not have specific intrinsics and thus SIMD can't be specialized.
 // Therefore, we can declare their MD representation as `[$t; 8]` irrespectively
 // of how they are represented in the different channels.

--- a/crates/polars-arrow/src/types/simd/native.rs
+++ b/crates/polars-arrow/src/types/simd/native.rs
@@ -1,7 +1,4 @@
-use std::convert::TryInto;
-
 use super::*;
-use crate::types::BitChunkIter;
 
 native_simd!(u8x64, u8, 64, u64);
 native_simd!(u16x32, u16, 32, u32);

--- a/crates/polars-core/src/chunked_array/arithmetic/decimal.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/decimal.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::prelude::DecimalChunked;
 
 impl Add for &DecimalChunked {
     type Output = PolarsResult<DecimalChunked>;

--- a/crates/polars-core/src/chunked_array/arithmetic/mod.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/mod.rs
@@ -5,7 +5,6 @@ mod numeric;
 
 use std::ops::{Add, Div, Mul, Rem, Sub};
 
-use arrow::array::PrimitiveArray;
 use arrow::compute::utils::combine_validities_and;
 use num_traits::{Num, NumCast, ToPrimitive};
 pub use numeric::ArithmeticChunked;

--- a/crates/polars-core/src/chunked_array/builder/fixed_size_list.rs
+++ b/crates/polars-core/src/chunked_array/builder/fixed_size_list.rs
@@ -1,7 +1,3 @@
-use arrow::array::{
-    Array, MutableArray, MutableFixedSizeListArray, MutablePrimitiveArray, PrimitiveArray,
-    PushUnchecked,
-};
 use arrow::types::NativeType;
 use polars_utils::unwrap::UnwrapUncheckedRelease;
 use smartstring::alias::String as SmartString;

--- a/crates/polars-core/src/chunked_array/builder/mod.rs
+++ b/crates/polars-core/src/chunked_array/builder/mod.rs
@@ -6,7 +6,6 @@ mod null;
 mod primitive;
 mod string;
 
-use std::iter::FromIterator;
 use std::marker::PhantomData;
 use std::sync::Arc;
 

--- a/crates/polars-core/src/chunked_array/cast.rs
+++ b/crates/polars-core/src/chunked_array/cast.rs
@@ -1,10 +1,7 @@
 //! Implementations of the ChunkCast Trait.
-use std::convert::TryFrom;
 
 use arrow::compute::cast::CastOptions;
 
-#[cfg(feature = "dtype-categorical")]
-use crate::chunked_array::categorical::CategoricalChunkedBuilder;
 #[cfg(feature = "timezones")]
 use crate::chunked_array::temporal::validate_time_zone;
 #[cfg(feature = "dtype-datetime")]

--- a/crates/polars-core/src/chunked_array/comparison/mod.rs
+++ b/crates/polars-core/src/chunked_array/comparison/mod.rs
@@ -8,7 +8,6 @@ use std::ops::Not;
 use arrow::array::BooleanArray;
 use arrow::bitmap::MutableBitmap;
 use arrow::compute;
-use arrow::legacy::prelude::FromData;
 use num_traits::{NumCast, ToPrimitive};
 use polars_compute::comparisons::TotalOrdKernel;
 

--- a/crates/polars-core/src/chunked_array/iterator/mod.rs
+++ b/crates/polars-core/src/chunked_array/iterator/mod.rs
@@ -3,7 +3,6 @@ use arrow::array::*;
 use crate::prelude::*;
 #[cfg(feature = "dtype-struct")]
 use crate::series::iterator::SeriesIter;
-use crate::utils::CustomIterTools;
 
 pub mod par;
 

--- a/crates/polars-core/src/chunked_array/list/iterator.rs
+++ b/crates/polars-core/src/chunked_array/list/iterator.rs
@@ -4,7 +4,6 @@ use std::ptr::NonNull;
 
 use crate::prelude::*;
 use crate::series::unstable::{ArrayBox, UnstableSeries};
-use crate::utils::CustomIterTools;
 
 pub struct AmortizedListIter<'a, I: Iterator<Item = Option<ArrayBox>>> {
     len: usize,

--- a/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/builder.rs
@@ -3,7 +3,6 @@ use arrow::legacy::trusted_len::TrustedLenPush;
 use hashbrown::hash_map::Entry;
 use polars_utils::iter::EnumerateIdxTrait;
 
-use crate::datatypes::PlHashMap;
 use crate::hashing::_HASHMAP_INIT_SIZE;
 use crate::prelude::*;
 use crate::{using_string_cache, StringCache, POOL};

--- a/crates/polars-core/src/chunked_array/logical/categorical/from.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/from.rs
@@ -1,4 +1,3 @@
-use arrow::array::DictionaryArray;
 use arrow::compute::cast::{cast, utf8view_to_utf8, CastOptions};
 use arrow::datatypes::IntegerType;
 

--- a/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/merge.rs
@@ -1,5 +1,4 @@
 use std::borrow::Cow;
-use std::sync::Arc;
 
 use super::*;
 use crate::series::IsSorted;

--- a/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
+++ b/crates/polars-core/src/chunked_array/logical/categorical/ops/unique.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::frame::group_by::IntoGroupsProxy;
 
 impl CategoricalChunked {
     pub fn unique(&self) -> PolarsResult<Self> {

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -52,7 +52,7 @@ use arrow::legacy::prelude::*;
 use bitflags::bitflags;
 
 use crate::series::IsSorted;
-use crate::utils::{first_non_null, last_non_null, CustomIterTools};
+use crate::utils::{first_non_null, last_non_null};
 
 #[cfg(not(feature = "dtype-categorical"))]
 pub struct RevMapping {}

--- a/crates/polars-core/src/chunked_array/object/builder.rs
+++ b/crates/polars-core/src/chunked_array/object/builder.rs
@@ -1,5 +1,4 @@
 use std::marker::PhantomData;
-use std::sync::Arc;
 
 use arrow::bitmap::MutableBitmap;
 

--- a/crates/polars-core/src/chunked_array/object/extension/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod polars_extension;
 
 use std::mem;
 
-use arrow::array::{Array, FixedSizeBinaryArray};
+use arrow::array::FixedSizeBinaryArray;
 use arrow::bitmap::MutableBitmap;
 use arrow::buffer::Buffer;
 use polars_extension::PolarsExtension;

--- a/crates/polars-core/src/chunked_array/object/extension/polars_extension.rs
+++ b/crates/polars-core/src/chunked_array/object/extension/polars_extension.rs
@@ -1,7 +1,5 @@
 use std::mem::ManuallyDrop;
 
-use arrow::array::FixedSizeBinaryArray;
-
 use super::*;
 use crate::prelude::*;
 

--- a/crates/polars-core/src/chunked_array/ops/aggregate/quantile.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/quantile.rs
@@ -1,5 +1,3 @@
-use arrow::legacy::prelude::QuantileInterpolOptions;
-
 use super::*;
 
 pub trait QuantileAggSeries {

--- a/crates/polars-core/src/chunked_array/ops/apply.rs
+++ b/crates/polars-core/src/chunked_array/ops/apply.rs
@@ -1,14 +1,11 @@
 //! Implementations of the ChunkApply Trait.
 use std::borrow::Cow;
-use std::convert::TryFrom;
 
-use arrow::array::{BooleanArray, PrimitiveArray};
 use arrow::bitmap::utils::{get_bit_unchecked, set_bit_unchecked};
 use arrow::legacy::bitmap::unary_mut;
 
 use crate::prelude::*;
 use crate::series::IsSorted;
-use crate::utils::CustomIterTools;
 
 impl<T> ChunkedArray<T>
 where

--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "object")]
-use arrow::array::Array;
 use arrow::legacy::kernels::concatenate::concatenate_owned_unchecked;
 use polars_error::constants::LENGTH_LIMIT_MSG;
 

--- a/crates/polars-core/src/chunked_array/ops/explode.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode.rs
@@ -1,9 +1,6 @@
-use std::convert::TryFrom;
-
 use arrow::array::*;
 use arrow::bitmap::{Bitmap, MutableBitmap};
 use arrow::legacy::array::list::AnonymousBuilder;
-use arrow::legacy::array::PolarsArray;
 use arrow::legacy::bit_util::unset_bit_raw;
 #[cfg(feature = "dtype-array")]
 use arrow::legacy::is_valid::IsValid;

--- a/crates/polars-core/src/chunked_array/ops/fill_null.rs
+++ b/crates/polars-core/src/chunked_array/ops/fill_null.rs
@@ -1,6 +1,6 @@
 use arrow::legacy::kernels::set::set_at_nulls;
 use arrow::legacy::trusted_len::FromIteratorReversed;
-use arrow::legacy::utils::{CustomIterTools, FromTrustedLenIterator};
+use arrow::legacy::utils::FromTrustedLenIterator;
 use num_traits::{Bounded, NumCast, One, Zero};
 
 use crate::prelude::*;

--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -1,5 +1,3 @@
-#[cfg(feature = "object")]
-use arrow::array::Array;
 use polars_compute::filter::filter as filter_fn;
 
 #[cfg(feature = "object")]

--- a/crates/polars-core/src/chunked_array/ops/full.rs
+++ b/crates/polars-core/src/chunked_array/ops/full.rs
@@ -1,5 +1,4 @@
 use arrow::bitmap::MutableBitmap;
-use arrow::legacy::array::default_arrays::FromData;
 
 use crate::chunked_array::builder::get_list_builder;
 use crate::prelude::*;

--- a/crates/polars-core/src/chunked_array/ops/gather.rs
+++ b/crates/polars-core/src/chunked_array/ops/gather.rs
@@ -1,13 +1,9 @@
-use arrow::array::Array;
 use arrow::bitmap::bitmask::BitMask;
 use arrow::compute::take::take_unchecked;
-use polars_error::{polars_bail, polars_ensure, PolarsResult};
+use polars_error::{polars_bail, polars_ensure};
 use polars_utils::index::check_bounds;
 
 use crate::chunked_array::collect::prepare_collect_dtype;
-use crate::chunked_array::ops::{ChunkTake, ChunkTakeUnchecked};
-use crate::chunked_array::ChunkedArray;
-use crate::datatypes::{IdxCa, PolarsDataType, StaticArray};
 use crate::prelude::*;
 use crate::series::IsSorted;
 

--- a/crates/polars-core/src/chunked_array/ops/min_max_binary.rs
+++ b/crates/polars-core/src/chunked_array/ops/min_max_binary.rs
@@ -1,4 +1,3 @@
-use crate::datatypes::PolarsNumericType;
 use crate::prelude::*;
 use crate::series::arithmetic::coerce_lhs_rhs;
 

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -1,9 +1,6 @@
 //! Traits for miscellaneous operations on ChunkedArray
-use arrow::legacy::prelude::QuantileInterpolOptions;
 use arrow::offset::OffsetsBuffer;
 
-#[cfg(feature = "object")]
-use crate::datatypes::ObjectType;
 use crate::prelude::*;
 
 pub(crate) mod aggregate;

--- a/crates/polars-core/src/chunked_array/ops/reverse.rs
+++ b/crates/polars-core/src/chunked_array/ops/reverse.rs
@@ -2,7 +2,7 @@
 use crate::chunked_array::builder::get_fixed_size_list_builder;
 use crate::prelude::*;
 use crate::series::IsSorted;
-use crate::utils::{CustomIterTools, NoNull};
+use crate::utils::NoNull;
 
 impl<T> ChunkReverse for ChunkedArray<T>
 where

--- a/crates/polars-core/src/chunked_array/ops/rolling_window.rs
+++ b/crates/polars-core/src/chunked_array/ops/rolling_window.rs
@@ -30,7 +30,6 @@ impl Default for RollingOptionsFixedWindow {
 mod inner_mod {
     use std::ops::SubAssign;
 
-    use arrow::array::{Array, PrimitiveArray};
     use arrow::bitmap::MutableBitmap;
     use arrow::legacy::bit_util::unset_bit_raw;
     use arrow::legacy::trusted_len::TrustedLenPush;

--- a/crates/polars-core/src/chunked_array/ops/set.rs
+++ b/crates/polars-core/src/chunked_array/ops/set.rs
@@ -1,9 +1,8 @@
 use arrow::bitmap::MutableBitmap;
 use arrow::legacy::kernels::set::{scatter_single_non_null, set_with_mask};
-use arrow::legacy::prelude::FromData;
 
 use crate::prelude::*;
-use crate::utils::{align_chunks_binary, CustomIterTools};
+use crate::utils::align_chunks_binary;
 
 macro_rules! impl_scatter_with {
     ($self:ident, $builder:ident, $idx:ident, $f:ident) => {{

--- a/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/arg_sort_multiple.rs
@@ -4,7 +4,6 @@ use polars_utils::iter::EnumerateIdxTrait;
 use super::*;
 #[cfg(feature = "dtype-struct")]
 use crate::utils::_split_offsets;
-use crate::POOL;
 
 pub(crate) fn args_validate<T: PolarsDataType>(
     ca: &ChunkedArray<T>,

--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -7,10 +7,8 @@ mod categorical;
 use std::cmp::Ordering;
 
 pub(crate) use arg_sort_multiple::argsort_multiple_row_fmt;
-use arrow::array::ValueSize;
 use arrow::bitmap::MutableBitmap;
 use arrow::buffer::Buffer;
-use arrow::legacy::prelude::FromData;
 use arrow::legacy::trusted_len::TrustedLenPush;
 use rayon::prelude::*;
 pub use slice::*;
@@ -21,7 +19,7 @@ use crate::prelude::sort::arg_sort_multiple::_get_rows_encoded_ca;
 use crate::prelude::sort::arg_sort_multiple::{arg_sort_multiple_impl, args_validate};
 use crate::prelude::*;
 use crate::series::IsSorted;
-use crate::utils::{CustomIterTools, NoNull};
+use crate::utils::NoNull;
 use crate::POOL;
 
 pub(crate) fn sort_by_branch<T, C>(slice: &mut [T], descending: bool, cmp: C, parallel: bool)

--- a/crates/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -3,10 +3,6 @@ use std::hash::Hash;
 use arrow::bitmap::MutableBitmap;
 use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
-#[cfg(feature = "object")]
-use crate::datatypes::ObjectType;
-use crate::datatypes::PlHashSet;
-use crate::frame::group_by::GroupsProxy;
 use crate::hashing::_HASHMAP_INIT_SIZE;
 use crate::prelude::*;
 use crate::series::IsSorted;

--- a/crates/polars-core/src/chunked_array/ops/zip.rs
+++ b/crates/polars-core/src/chunked_array/ops/zip.rs
@@ -1,8 +1,7 @@
 use arrow::compute::if_then_else::if_then_else;
-use arrow::legacy::array::default_arrays::FromData;
 
 use crate::prelude::*;
-use crate::utils::{align_chunks_ternary, CustomIterTools};
+use crate::utils::align_chunks_ternary;
 
 fn ternary_apply<T>(predicate: bool, truthy: T, falsy: T) -> T {
     if predicate {

--- a/crates/polars-core/src/chunked_array/random.rs
+++ b/crates/polars-core/src/chunked_array/random.rs
@@ -3,12 +3,12 @@ use polars_error::to_compute_err;
 use rand::distributions::Bernoulli;
 use rand::prelude::*;
 use rand::seq::index::IndexVec;
-use rand_distr::{Distribution, Normal, Standard, StandardNormal, Uniform};
+use rand_distr::{Normal, Standard, StandardNormal, Uniform};
 
 use crate::prelude::DataType::Float64;
 use crate::prelude::*;
 use crate::random::get_global_random_u64;
-use crate::utils::{CustomIterTools, NoNull};
+use crate::utils::NoNull;
 
 fn create_rand_index_with_replacement(n: usize, len: usize, seed: Option<u64>) -> IdxCa {
     if len == 0 {

--- a/crates/polars-core/src/chunked_array/temporal/datetime.rs
+++ b/crates/polars-core/src/chunked_array/temporal/datetime.rs
@@ -4,16 +4,10 @@ use arrow::temporal_conversions::{
     timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
 };
 use chrono::format::{DelayedFormat, StrftimeItems};
-use chrono::NaiveDate;
 #[cfg(feature = "timezones")]
 use chrono::TimeZone as TimeZoneTrait;
-#[cfg(feature = "timezones")]
-use chrono_tz::Tz;
 
-use super::conversion::{datetime_to_timestamp_ms, datetime_to_timestamp_ns};
 use super::*;
-#[cfg(feature = "timezones")]
-use crate::chunked_array::temporal::validate_time_zone;
 use crate::prelude::DataType::Datetime;
 use crate::prelude::*;
 

--- a/crates/polars-core/src/chunked_array/trusted_len.rs
+++ b/crates/polars-core/src/chunked_array/trusted_len.rs
@@ -4,7 +4,7 @@ use arrow::legacy::trusted_len::{FromIteratorReversed, TrustedLenPush};
 
 use crate::chunked_array::upstream_traits::PolarsAsRef;
 use crate::prelude::*;
-use crate::utils::{CustomIterTools, FromTrustedLenIterator, NoNull};
+use crate::utils::{FromTrustedLenIterator, NoNull};
 
 impl<T> FromTrustedLenIterator<Option<T::Native>> for ChunkedArray<T>
 where

--- a/crates/polars-core/src/chunked_array/upstream_traits.rs
+++ b/crates/polars-core/src/chunked_array/upstream_traits.rs
@@ -1,14 +1,10 @@
 //! Implementations of upstream traits for [`ChunkedArray<T>`]
 use std::borrow::{Borrow, Cow};
 use std::collections::LinkedList;
-use std::iter::FromIterator;
 use std::marker::PhantomData;
-use std::sync::Arc;
 
-use arrow::array::{BooleanArray, PrimitiveArray};
 use arrow::bitmap::{Bitmap, MutableBitmap};
 use polars_utils::sync::SyncPtr;
-use rayon::iter::{FromParallelIterator, IntoParallelIterator};
 use rayon::prelude::*;
 
 use crate::chunked_array::builder::{
@@ -22,7 +18,7 @@ use crate::chunked_array::object::builder::get_object_type;
 use crate::chunked_array::object::ObjectArray;
 use crate::prelude::*;
 use crate::utils::flatten::flatten_par;
-use crate::utils::{get_iter_capacity, CustomIterTools, NoNull};
+use crate::utils::{get_iter_capacity, NoNull};
 
 impl<T: PolarsDataType> Default for ChunkedArray<T> {
     fn default() -> Self {

--- a/crates/polars-core/src/datatypes/_serde.rs
+++ b/crates/polars-core/src/datatypes/_serde.rs
@@ -4,8 +4,8 @@
 //! We could use [serde_1712](https://github.com/serde-rs/serde/issues/1712), but that gave problems caused by
 //! [rust_96956](https://github.com/rust-lang/rust/issues/96956), so we make a dummy type without static
 
-use serde::de::{SeqAccess, Visitor};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::de::SeqAccess;
+use serde::{Deserialize, Serialize};
 
 use super::*;
 

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -1,6 +1,4 @@
 use std::collections::BTreeMap;
-use std::convert::Into;
-use std::string::ToString;
 
 use super::*;
 #[cfg(feature = "object")]

--- a/crates/polars-core/src/frame/from.rs
+++ b/crates/polars-core/src/frame/from.rs
@@ -1,5 +1,3 @@
-use arrow::array::StructArray;
-
 use crate::prelude::*;
 
 impl TryFrom<StructArray> for DataFrame {

--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -12,7 +12,6 @@ use arrow::legacy::kernels::rolling::no_nulls::{
     MaxWindow, MeanWindow, MinWindow, QuantileWindow, RollingAggWindowNoNulls, SumWindow, VarWindow,
 };
 use arrow::legacy::kernels::rolling::nulls::RollingAggWindowNulls;
-use arrow::legacy::kernels::rolling::{RollingQuantileParams, RollingVarParams};
 use arrow::legacy::kernels::take_agg::*;
 use arrow::legacy::prelude::QuantileInterpolOptions;
 use arrow::legacy::trusted_len::TrustedLenPush;

--- a/crates/polars-core/src/frame/group_by/hashing.rs
+++ b/crates/polars-core/src/frame/group_by/hashing.rs
@@ -10,15 +10,10 @@ use polars_utils::total_ord::{ToTotalOrd, TotalHash};
 use polars_utils::unitvec;
 use rayon::prelude::*;
 
-use super::GroupsProxy;
-use crate::datatypes::PlHashMap;
-use crate::frame::group_by::{GroupsIdx, IdxItem};
-use crate::hashing::{
-    _df_rows_to_hashes_threaded_vertical, series_to_hashes, IdBuildHasher, IdxHash, *,
-};
+use crate::hashing::*;
 use crate::prelude::compare_inner::TotalEqInner;
 use crate::prelude::*;
-use crate::utils::{flatten, split_df, CustomIterTools};
+use crate::utils::{flatten, split_df};
 use crate::POOL;
 
 fn get_init_size() -> usize {

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -2,7 +2,6 @@ use std::fmt::{Debug, Display, Formatter};
 use std::hash::Hash;
 
 use ahash::RandomState;
-use arrow::legacy::prelude::QuantileInterpolOptions;
 use num_traits::NumCast;
 use polars_utils::hashing::{BytesHash, DirtyHash};
 use rayon::prelude::*;

--- a/crates/polars-core/src/frame/group_by/perfect.rs
+++ b/crates/polars-core/src/frame/group_by/perfect.rs
@@ -1,6 +1,5 @@
 use std::fmt::Debug;
 
-use arrow::array::Array;
 use arrow::legacy::bit_util::round_upto_multiple_of_64;
 use num_traits::{FromPrimitive, ToPrimitive};
 use polars_utils::idx_vec::IdxVec;

--- a/crates/polars-core/src/frame/group_by/proxy.rs
+++ b/crates/polars-core/src/frame/group_by/proxy.rs
@@ -1,7 +1,6 @@
 use std::mem::ManuallyDrop;
 use std::ops::Deref;
 
-use arrow::legacy::utils::CustomIterTools;
 use polars_utils::idx_vec::IdxVec;
 use polars_utils::sync::SyncPtr;
 use rayon::iter::plumbing::UnindexedConsumer;

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1,6 +1,5 @@
 //! DataFrame module.
 use std::borrow::Cow;
-use std::iter::{FromIterator, Iterator};
 use std::{mem, ops};
 
 use ahash::AHashSet;
@@ -28,8 +27,6 @@ pub use chunks::*;
 use serde::{Deserialize, Serialize};
 use smartstring::alias::String as SmartString;
 
-#[cfg(feature = "algorithm_group_by")]
-use crate::frame::group_by::GroupsIndicator;
 #[cfg(feature = "row_hash")]
 use crate::hashing::_df_rows_to_hashes_threaded_vertical;
 #[cfg(feature = "zip_with")]

--- a/crates/polars-core/src/frame/row/dataframe.rs
+++ b/crates/polars-core/src/frame/row/dataframe.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::frame::row::av_buffer::AnyValueBuffer;
 
 impl DataFrame {
     /// Get a row from a [`DataFrame`]. Use of this is discouraged as it will likely be slow.

--- a/crates/polars-core/src/frame/top_k.rs
+++ b/crates/polars-core/src/frame/top_k.rs
@@ -1,12 +1,9 @@
 use std::cmp::Ordering;
 
-use polars_error::PolarsResult;
 use polars_utils::iter::EnumerateIdxTrait;
 use polars_utils::IdxSize;
 use smartstring::alias::String as SmartString;
 
-use crate::datatypes::IdxCa;
-use crate::frame::DataFrame;
 use crate::prelude::sort::_broadcast_descending;
 use crate::prelude::sort::arg_sort_multiple::_get_rows_encoded;
 use crate::prelude::*;

--- a/crates/polars-core/src/frame/upstream_traits.rs
+++ b/crates/polars-core/src/frame/upstream_traits.rs
@@ -1,4 +1,3 @@
-use std::iter::FromIterator;
 use std::ops::{Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
 
 use crate::prelude::*;

--- a/crates/polars-core/src/hashing/vector_hasher.rs
+++ b/crates/polars-core/src/hashing/vector_hasher.rs
@@ -6,10 +6,8 @@ use rayon::prelude::*;
 use xxhash_rust::xxh3::xxh3_64_with_seed;
 
 use super::*;
-use crate::datatypes::UInt64Chunked;
 use crate::prelude::*;
 use crate::series::implementations::null::NullChunked;
-use crate::utils::arrow::array::Array;
 use crate::POOL;
 
 // See: https://github.com/tkaitchuck/aHash/blob/f9acd508bd89e7c5b2877a9510098100f9018d64/src/operations.rs#L4

--- a/crates/polars-core/src/random.rs
+++ b/crates/polars-core/src/random.rs
@@ -2,7 +2,6 @@ use std::sync::Mutex;
 
 use once_cell::sync::Lazy;
 use rand::prelude::*;
-use rand::rngs::SmallRng;
 
 static POLARS_GLOBAL_RNG_STATE: Lazy<Mutex<SmallRng>> =
     Lazy::new(|| Mutex::new(SmallRng::from_entropy()));

--- a/crates/polars-core/src/series/comparison.rs
+++ b/crates/polars-core/src/series/comparison.rs
@@ -3,8 +3,6 @@
 #[cfg(feature = "dtype-struct")]
 use std::ops::Deref;
 
-use super::Series;
-use crate::apply_method_physical_numeric;
 use crate::prelude::*;
 use crate::series::arithmetic::coerce_lhs_rhs;
 use crate::series::nulls::replace_non_null;

--- a/crates/polars-core/src/series/from.rs
+++ b/crates/polars-core/src/series/from.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use arrow::compute::cast::cast_unchecked as cast;
 use arrow::datatypes::Metadata;
 #[cfg(any(feature = "dtype-struct", feature = "dtype-categorical"))]

--- a/crates/polars-core/src/series/implementations/array.rs
+++ b/crates/polars-core/src/series/implementations/array.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 use std::borrow::Cow;
 
-use super::{private, IntoSeries, SeriesTrait};
+use super::private;
 use crate::chunked_array::comparison::*;
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::{AsSinglePtr, Settings};

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -1,18 +1,8 @@
-use std::borrow::Cow;
-
-use ahash::RandomState;
-
-use super::{private, IntoSeries, SeriesTrait, *};
+use super::*;
 use crate::chunked_array::comparison::*;
-use crate::chunked_array::ops::compare_inner::{
-    IntoTotalEqInner, IntoTotalOrdInner, TotalEqInner, TotalOrdInner,
-};
-use crate::chunked_array::ops::explode::ExplodeByOffsets;
-use crate::chunked_array::AsSinglePtr;
 #[cfg(feature = "algorithm_group_by")]
 use crate::frame::group_by::*;
 use crate::prelude::*;
-use crate::series::implementations::SeriesWrap;
 
 impl private::PrivateSeries for SeriesWrap<BinaryChunked> {
     fn compute_len(&mut self) {

--- a/crates/polars-core/src/series/implementations/binary_offset.rs
+++ b/crates/polars-core/src/series/implementations/binary_offset.rs
@@ -1,16 +1,8 @@
-use std::borrow::Cow;
-
-use ahash::RandomState;
-
-use super::{private, IntoSeries, SeriesTrait, *};
+use super::*;
 use crate::chunked_array::comparison::*;
-use crate::chunked_array::ops::compare_inner::{
-    IntoTotalEqInner, IntoTotalOrdInner, TotalEqInner, TotalOrdInner,
-};
 #[cfg(feature = "algorithm_group_by")]
 use crate::frame::group_by::*;
 use crate::prelude::*;
-use crate::series::implementations::SeriesWrap;
 
 impl private::PrivateSeries for SeriesWrap<BinaryOffsetChunked> {
     fn compute_len(&mut self) {

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -1,19 +1,8 @@
-use std::borrow::Cow;
-use std::ops::{BitAnd, BitOr, BitXor};
-
-use ahash::RandomState;
-
-use super::{private, IntoSeries, SeriesTrait, *};
+use super::*;
 use crate::chunked_array::comparison::*;
-use crate::chunked_array::ops::compare_inner::{
-    IntoTotalEqInner, IntoTotalOrdInner, TotalEqInner, TotalOrdInner,
-};
-use crate::chunked_array::ops::explode::ExplodeByOffsets;
-use crate::chunked_array::{AsSinglePtr, ChunkIdIter};
 #[cfg(feature = "algorithm_group_by")]
 use crate::frame::group_by::*;
 use crate::prelude::*;
-use crate::series::implementations::SeriesWrap;
 
 impl private::PrivateSeries for SeriesWrap<BooleanChunked> {
     fn compute_len(&mut self) {

--- a/crates/polars-core/src/series/implementations/categorical.rs
+++ b/crates/polars-core/src/series/implementations/categorical.rs
@@ -1,14 +1,6 @@
-use std::borrow::Cow;
-
-use ahash::RandomState;
-
-use super::{private, IntoSeries, SeriesTrait, *};
+use super::*;
 use crate::chunked_array::comparison::*;
-use crate::chunked_array::ops::compare_inner::{IntoTotalOrdInner, TotalOrdInner};
-use crate::chunked_array::ops::explode::ExplodeByOffsets;
-use crate::chunked_array::AsSinglePtr;
 use crate::prelude::*;
-use crate::series::implementations::SeriesWrap;
 
 unsafe impl IntoSeries for CategoricalChunked {
     fn into_series(self) -> Series {

--- a/crates/polars-core/src/series/implementations/dates_time.rs
+++ b/crates/polars-core/src/series/implementations/dates_time.rs
@@ -7,15 +7,7 @@
 //! opting for a little more run time cost. We cast to the physical type -> apply the operation and
 //! (depending on the result) cast back to the original type
 //!
-use std::borrow::Cow;
-use std::ops::Deref;
-
-use ahash::RandomState;
-
-use super::{private, IntoSeries, SeriesTrait, SeriesWrap, *};
-use crate::chunked_array::ops::explode::ExplodeByOffsets;
-use crate::chunked_array::ops::ToBitRepr;
-use crate::chunked_array::AsSinglePtr;
+use super::*;
 #[cfg(feature = "algorithm_group_by")]
 use crate::frame::group_by::*;
 use crate::prelude::*;

--- a/crates/polars-core/src/series/implementations/datetime.rs
+++ b/crates/polars-core/src/series/implementations/datetime.rs
@@ -1,11 +1,4 @@
-use std::borrow::Cow;
-use std::ops::Deref;
-
-use ahash::RandomState;
-
-use super::{private, IntoSeries, SeriesTrait, SeriesWrap, *};
-use crate::chunked_array::ops::explode::ExplodeByOffsets;
-use crate::chunked_array::AsSinglePtr;
+use super::*;
 #[cfg(feature = "algorithm_group_by")]
 use crate::frame::group_by::*;
 use crate::prelude::*;

--- a/crates/polars-core/src/series/implementations/decimal.rs
+++ b/crates/polars-core/src/series/implementations/decimal.rs
@@ -1,4 +1,4 @@
-use super::{private, IntoSeries, SeriesTrait, SeriesWrap, *};
+use super::*;
 use crate::prelude::*;
 
 unsafe impl IntoSeries for DecimalChunked {

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -1,12 +1,7 @@
-use std::borrow::Cow;
-use std::ops::{Deref, DerefMut};
+use std::ops::DerefMut;
 
-use ahash::RandomState;
-
-use super::{private, IntoSeries, SeriesTrait, SeriesWrap, *};
+use super::*;
 use crate::chunked_array::comparison::*;
-use crate::chunked_array::ops::explode::ExplodeByOffsets;
-use crate::chunked_array::AsSinglePtr;
 #[cfg(feature = "algorithm_group_by")]
 use crate::frame::group_by::*;
 use crate::prelude::*;

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -1,22 +1,8 @@
-use std::any::Any;
-use std::borrow::Cow;
-
-use ahash::RandomState;
-use arrow::legacy::prelude::QuantileInterpolOptions;
-
-use super::{private, IntoSeries, SeriesTrait, SeriesWrap, *};
+use super::*;
 use crate::chunked_array::comparison::*;
-use crate::chunked_array::ops::aggregate::{ChunkAggSeries, QuantileAggSeries, VarAggSeries};
-use crate::chunked_array::ops::compare_inner::{
-    IntoTotalEqInner, IntoTotalOrdInner, TotalEqInner, TotalOrdInner,
-};
-use crate::chunked_array::ops::explode::ExplodeByOffsets;
-use crate::chunked_array::AsSinglePtr;
 #[cfg(feature = "algorithm_group_by")]
 use crate::frame::group_by::*;
 use crate::prelude::*;
-#[cfg(feature = "checked_arithmetic")]
-use crate::series::arithmetic::checked::NumOpsDispatchChecked;
 
 macro_rules! impl_dyn_series {
     ($ca: ident) => {

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -1,20 +1,8 @@
-use std::any::Any;
-use std::borrow::Cow;
-
-#[cfg(feature = "group_by_list")]
-use ahash::RandomState;
-
 use super::*;
 use crate::chunked_array::comparison::*;
-use crate::chunked_array::ops::compare_inner::{IntoTotalEqInner, TotalEqInner};
-use crate::chunked_array::ops::explode::ExplodeByOffsets;
-use crate::chunked_array::{AsSinglePtr, Settings};
 #[cfg(feature = "algorithm_group_by")]
 use crate::frame::group_by::*;
 use crate::prelude::*;
-use crate::series::implementations::SeriesWrap;
-#[cfg(feature = "chunked_ids")]
-use crate::series::IsSorted;
 
 impl private::PrivateSeries for SeriesWrap<ListChunked> {
     fn compute_len(&mut self) {

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -28,22 +28,17 @@ mod struct_;
 
 use std::any::Any;
 use std::borrow::Cow;
-use std::ops::{BitAnd, BitOr, BitXor, Deref};
+use std::ops::{BitAnd, BitOr, BitXor};
 
 use ahash::RandomState;
-use arrow::legacy::prelude::QuantileInterpolOptions;
 
-use super::{private, IntoSeries, SeriesTrait, *};
+use super::*;
 use crate::chunked_array::comparison::*;
-use crate::chunked_array::ops::aggregate::{ChunkAggSeries, QuantileAggSeries, VarAggSeries};
 use crate::chunked_array::ops::compare_inner::{
     IntoTotalEqInner, IntoTotalOrdInner, TotalEqInner, TotalOrdInner,
 };
 use crate::chunked_array::ops::explode::ExplodeByOffsets;
 use crate::chunked_array::AsSinglePtr;
-use crate::prelude::*;
-#[cfg(feature = "checked_arithmetic")]
-use crate::series::arithmetic::checked::NumOpsDispatchChecked;
 
 // Utility wrapper struct
 pub(crate) struct SeriesWrap<T>(pub T);

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -1,13 +1,8 @@
 use std::any::Any;
-use std::borrow::Cow;
-use std::sync::Arc;
 
-use arrow::array::ArrayRef;
 use polars_error::constants::LENGTH_LIMIT_MSG;
 use polars_utils::IdxSize;
 
-use crate::datatypes::IdxCa;
-use crate::error::PolarsResult;
 use crate::prelude::compare_inner::{IntoTotalEqInner, TotalEqInner};
 use crate::prelude::explode::ExplodeByOffsets;
 use crate::prelude::*;

--- a/crates/polars-core/src/series/implementations/object.rs
+++ b/crates/polars-core/src/series/implementations/object.rs
@@ -6,8 +6,6 @@ use ahash::RandomState;
 use crate::chunked_array::object::PolarsObjectSafe;
 use crate::chunked_array::ops::compare_inner::{IntoTotalEqInner, TotalEqInner};
 use crate::chunked_array::Settings;
-#[cfg(feature = "algorithm_group_by")]
-use crate::frame::group_by::{GroupsProxy, IntoGroupsProxy};
 use crate::prelude::*;
 use crate::series::implementations::SeriesWrap;
 use crate::series::private::{PrivateSeries, PrivateSeriesNumeric};

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -1,18 +1,8 @@
-use std::borrow::Cow;
-
-use ahash::RandomState;
-
-use super::{private, IntoSeries, SeriesTrait, *};
+use super::*;
 use crate::chunked_array::comparison::*;
-use crate::chunked_array::ops::compare_inner::{
-    IntoTotalEqInner, IntoTotalOrdInner, TotalEqInner, TotalOrdInner,
-};
-use crate::chunked_array::ops::explode::ExplodeByOffsets;
-use crate::chunked_array::AsSinglePtr;
 #[cfg(feature = "algorithm_group_by")]
 use crate::frame::group_by::*;
 use crate::prelude::*;
-use crate::series::implementations::SeriesWrap;
 
 impl private::PrivateSeries for SeriesWrap<StringChunked> {
     fn compute_len(&mut self) {

--- a/crates/polars-core/src/series/implementations/struct_.rs
+++ b/crates/polars-core/src/series/implementations/struct_.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use super::*;
 use crate::hashing::series_to_hashes;
 use crate::prelude::*;

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -16,7 +16,6 @@ pub mod unstable;
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
-use std::sync::Arc;
 
 use ahash::RandomState;
 use arrow::compute::aggregate::estimated_bytes_size;

--- a/crates/polars-core/src/series/series_trait.rs
+++ b/crates/polars-core/src/series/series_trait.rs
@@ -1,9 +1,6 @@
 use std::any::Any;
 use std::borrow::Cow;
-#[cfg(feature = "temporal")]
-use std::sync::Arc;
 
-use arrow::legacy::prelude::QuantileInterpolOptions;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -46,8 +43,6 @@ pub(crate) mod private {
     use super::*;
     use crate::chunked_array::ops::compare_inner::{TotalEqInner, TotalOrdInner};
     use crate::chunked_array::Settings;
-    #[cfg(feature = "algorithm_group_by")]
-    use crate::frame::group_by::GroupsProxy;
 
     pub trait PrivateSeriesNumeric {
         fn bit_repr_is_large(&self) -> bool {

--- a/crates/polars-ops/Cargo.toml
+++ b/crates/polars-ops/Cargo.toml
@@ -46,7 +46,7 @@ rand = { workspace = true, features = ["small_rng"] }
 version_check = { workspace = true }
 
 [features]
-simd = ["argminmax/nightly_simd"]
+simd = []
 nightly = ["polars-utils/nightly"]
 dtype-categorical = ["polars-core/dtype-categorical"]
 dtype-date = ["polars-core/dtype-date", "polars-core/temporal"]

--- a/crates/polars-parquet/src/arrow/read/deserialize/nested.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/nested.rs
@@ -1,12 +1,9 @@
 use arrow::array::PrimitiveArray;
-use arrow::datatypes::{ArrowDataType, Field};
 use arrow::match_integer_type;
 use ethnum::I256;
 use polars_error::polars_bail;
 
-use super::nested_utils::{InitNested, NestedArrayIter};
 use super::*;
-use crate::parquet::schema::types::PrimitiveType;
 
 /// Converts an iterator of arrays to a trait object returning trait objects
 #[inline]

--- a/crates/polars-parquet/src/arrow/read/deserialize/primitive/dictionary.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/primitive/dictionary.rs
@@ -6,7 +6,7 @@ use arrow::datatypes::ArrowDataType;
 use arrow::types::NativeType;
 use polars_error::PolarsResult;
 
-use super::super::dictionary::{nested_next_dict, *};
+use super::super::dictionary::*;
 use super::super::nested_utils::{InitNested, NestedState};
 use super::super::utils::MaybeNext;
 use super::super::PagesIter;

--- a/crates/polars-parquet/src/parquet/bloom_filter/split_block.rs
+++ b/crates/polars-parquet/src/parquet/bloom_filter/split_block.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 /// magic numbers taken from https://github.com/apache/parquet-format/blob/master/BloomFilter.md
 const SALT: [u32; 8] = [
     1203114875, 1150766481, 2284105051, 2729912477, 1884591559, 770785867, 2667333959, 1550580529,

--- a/crates/polars-parquet/src/parquet/encoding/bitpacked/encode.rs
+++ b/crates/polars-parquet/src/parquet/encoding/bitpacked/encode.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 use super::{Packed, Unpackable, Unpacked};
 
 /// Encodes (packs) a slice of [`Unpackable`] into bitpacked bytes `packed`, using `num_bits` per value.

--- a/crates/polars-parquet/src/parquet/encoding/mod.rs
+++ b/crates/polars-parquet/src/parquet/encoding/mod.rs
@@ -1,5 +1,3 @@
-use std::convert::TryInto;
-
 pub mod bitpacked;
 pub mod delta_bitpacked;
 pub mod delta_byte_array;

--- a/crates/polars-parquet/src/parquet/parquet_bridge.rs
+++ b/crates/polars-parquet/src/parquet/parquet_bridge.rs
@@ -1,5 +1,4 @@
 // Bridges structs from thrift-generated code to rust enums.
-use std::convert::TryFrom;
 
 #[cfg(feature = "serde_types")]
 use serde::{Deserialize, Serialize};

--- a/crates/polars-parquet/src/parquet/read/compression.rs
+++ b/crates/polars-parquet/src/parquet/read/compression.rs
@@ -1,5 +1,4 @@
 use parquet_format_safe::DataPageHeaderV2;
-use streaming_decompression;
 
 use super::page::PageIterator;
 use crate::parquet::compression::{self, Compression};

--- a/crates/polars-parquet/src/parquet/read/indexes/read.rs
+++ b/crates/polars-parquet/src/parquet/read/indexes/read.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::io::{Cursor, Read, Seek, SeekFrom};
 
 use parquet_format_safe::thrift::protocol::TCompactInputProtocol;

--- a/crates/polars-parquet/src/parquet/read/metadata.rs
+++ b/crates/polars-parquet/src/parquet/read/metadata.rs
@@ -1,5 +1,4 @@
 use std::cmp::min;
-use std::convert::TryInto;
 use std::io::{Read, Seek, SeekFrom};
 
 use parquet_format_safe::thrift::protocol::TCompactInputProtocol;

--- a/crates/polars-parquet/src/parquet/read/page/reader.rs
+++ b/crates/polars-parquet/src/parquet/read/page/reader.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::io::Read;
 use std::sync::Arc;
 

--- a/crates/polars-parquet/src/parquet/types.rs
+++ b/crates/polars-parquet/src/parquet/types.rs
@@ -1,5 +1,3 @@
-use std::convert::TryFrom;
-
 use crate::parquet::schema::types::PhysicalType;
 
 /// A physical native representation of a Parquet fixed-sized type.

--- a/crates/polars-parquet/src/parquet/write/page.rs
+++ b/crates/polars-parquet/src/parquet/write/page.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::io::Write;
 use std::sync::Arc;
 

--- a/crates/polars-row/src/fixed.rs
+++ b/crates/polars-row/src/fixed.rs
@@ -12,17 +12,12 @@ use crate::row::{RowsEncoded, SortField};
 
 pub(crate) trait FromSlice {
     fn from_slice(slice: &[u8]) -> Self;
-    fn from_slice_inverted(slice: &[u8]) -> Self;
 }
 
 impl<const N: usize> FromSlice for [u8; N] {
     #[inline]
     fn from_slice(slice: &[u8]) -> Self {
         slice.try_into().unwrap()
-    }
-
-    fn from_slice_inverted(_slice: &[u8]) -> Self {
-        todo!()
     }
 }
 


### PR DESCRIPTION
Prepares for an update of rustc. This lints redundant imports. Did the first part.