### PR TITLE
perf: Elide the total order wrapper for non-(float/option) types

### DIFF
--- a/crates/polars-arrow/src/array/primitive/mutable.rs
+++ b/crates/polars-arrow/src/array/primitive/mutable.rs
@@ -2,7 +2,6 @@ use std::iter::FromIterator;
 use std::sync::Arc;
 
 use polars_error::PolarsResult;
-use polars_utils::total_ord::TotalOrdWrap;
 
 use super::{check, PrimitiveArray};
 use crate::array::physical_binary::extend_validity;
@@ -364,14 +363,6 @@ impl<T: NativeType> Extend<Option<T>> for MutablePrimitiveArray<T> {
         let iter = iter.into_iter();
         self.reserve(iter.size_hint().0);
         iter.for_each(|x| self.push(x))
-    }
-}
-
-impl<T: NativeType> Extend<Option<TotalOrdWrap<T>>> for MutablePrimitiveArray<T> {
-    fn extend<I: IntoIterator<Item = Option<TotalOrdWrap<T>>>>(&mut self, iter: I) {
-        let iter = iter.into_iter();
-        self.reserve(iter.size_hint().0);
-        iter.for_each(|x| self.push(x.map(|x| x.0)))
     }
 }
 

--- a/crates/polars-core/src/chunked_array/object/mod.rs
+++ b/crates/polars-core/src/chunked_array/object/mod.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::fmt::{Debug, Display};
+use std::hash::Hash;
 
 use arrow::bitmap::utils::{BitmapIter, ZipValidity};
 use arrow::bitmap::Bitmap;
@@ -36,7 +37,7 @@ pub trait PolarsObjectSafe: Any + Debug + Send + Sync + Display {
 
 /// Values need to implement this so that they can be stored into a Series and DataFrame
 pub trait PolarsObject:
-    Any + Debug + Clone + Send + Sync + Default + Display + TotalHash + TotalEq
+    Any + Debug + Clone + Send + Sync + Default + Display + Hash + TotalHash + PartialEq + Eq + TotalEq
 {
     /// This should be used as type information. Consider this a part of the type system.
     fn type_name() -> &'static str;

--- a/crates/polars-core/src/chunked_array/ops/unique/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/unique/mod.rs
@@ -1,5 +1,7 @@
+use std::hash::Hash;
+
 use arrow::bitmap::MutableBitmap;
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
 #[cfg(feature = "object")]
 use crate::datatypes::ObjectType;
@@ -59,12 +61,13 @@ impl<T: PolarsObject> ChunkUnique<ObjectType<T>> for ObjectChunked<T> {
 
 fn arg_unique<T>(a: impl Iterator<Item = T>, capacity: usize) -> Vec<IdxSize>
 where
-    T: TotalHash + TotalEq,
+    T: ToTotalOrd,
+    <T as ToTotalOrd>::TotalOrdItem: Hash + Eq,
 {
     let mut set = PlHashSet::new();
     let mut unique = Vec::with_capacity(capacity);
     a.enumerate().for_each(|(idx, val)| {
-        if set.insert(TotalOrdWrap(val)) {
+        if set.insert(val.to_total_ord()) {
             unique.push(idx as IdxSize)
         }
     });
@@ -83,7 +86,8 @@ macro_rules! arg_unique_ca {
 impl<T> ChunkUnique<T> for ChunkedArray<T>
 where
     T: PolarsNumericType,
-    T::Native: TotalHash + TotalEq,
+    T::Native: TotalHash + TotalEq + ToTotalOrd,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq + Ord,
     ChunkedArray<T>: IntoSeries + for<'a> ChunkCompare<&'a ChunkedArray<T>, Item = BooleanChunked>,
 {
     fn unique(&self) -> PolarsResult<Self> {
@@ -100,10 +104,10 @@ where
                         let mut iter = self.iter();
                         let last = iter.next().unwrap();
                         arr.push(last);
-                        let mut last = TotalOrdWrap(last);
+                        let mut last = last.to_total_ord();
 
                         let to_extend = iter.filter(|opt_val| {
-                            let opt_val_tot_ord = TotalOrdWrap(*opt_val);
+                            let opt_val_tot_ord = opt_val.to_total_ord();
                             let out = opt_val_tot_ord != last;
                             last = opt_val_tot_ord;
                             out
@@ -145,12 +149,12 @@ where
                     }
 
                     let mut iter = self.iter();
-                    let mut last = TotalOrdWrap(iter.next().unwrap());
+                    let mut last = iter.next().unwrap().to_total_ord();
 
                     count += 1;
 
                     iter.for_each(|opt_val| {
-                        let opt_val = TotalOrdWrap(opt_val);
+                        let opt_val = opt_val.to_total_ord();
                         if opt_val != last {
                             last = opt_val;
                             count += 1;

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -10,7 +10,7 @@ use polars_utils::format_smartstring;
 use polars_utils::slice::GetSaferUnchecked;
 #[cfg(feature = "dtype-categorical")]
 use polars_utils::sync::SyncPtr;
-use polars_utils::total_ord::TotalOrdWrap;
+use polars_utils::total_ord::ToTotalOrd;
 use polars_utils::unwrap::UnwrapUncheckedRelease;
 
 use super::*;
@@ -894,8 +894,8 @@ impl AnyValue<'_> {
             (Int16(l), Int16(r)) => *l == *r,
             (Int32(l), Int32(r)) => *l == *r,
             (Int64(l), Int64(r)) => *l == *r,
-            (Float32(l), Float32(r)) => TotalOrdWrap(l) == TotalOrdWrap(r),
-            (Float64(l), Float64(r)) => TotalOrdWrap(l) == TotalOrdWrap(r),
+            (Float32(l), Float32(r)) => l.to_total_ord() == r.to_total_ord(),
+            (Float64(l), Float64(r)) => l.to_total_ord() == r.to_total_ord(),
             (String(l), String(r)) => l == r,
             (String(l), StringOwned(r)) => l == r,
             (StringOwned(l), String(r)) => l == r,
@@ -979,8 +979,8 @@ impl PartialOrd for AnyValue<'_> {
             (Int16(l), Int16(r)) => l.partial_cmp(r),
             (Int32(l), Int32(r)) => l.partial_cmp(r),
             (Int64(l), Int64(r)) => l.partial_cmp(r),
-            (Float32(l), Float32(r)) => TotalOrdWrap(l).partial_cmp(&TotalOrdWrap(*r)),
-            (Float64(l), Float64(r)) => TotalOrdWrap(l).partial_cmp(&TotalOrdWrap(*r)),
+            (Float32(l), Float32(r)) => l.to_total_ord().partial_cmp(&r.to_total_ord()),
+            (Float64(l), Float64(r)) => l.to_total_ord().partial_cmp(&r.to_total_ord()),
             (String(l), String(r)) => l.partial_cmp(*r),
             (Binary(l), Binary(r)) => l.partial_cmp(*r),
             _ => None,

--- a/crates/polars-core/src/frame/group_by/into_groups.rs
+++ b/crates/polars-core/src/frame/group_by/into_groups.rs
@@ -2,7 +2,7 @@
 use arrow::legacy::kernels::list_bytes_iter::numeric_list_bytes_iter;
 use arrow::legacy::kernels::sort_partition::{create_clean_partitions, partition_to_groups};
 use arrow::legacy::prelude::*;
-use polars_utils::total_ord::TotalHash;
+use polars_utils::total_ord::{ToTotalOrd, TotalHash};
 
 use super::*;
 use crate::config::verbose;
@@ -27,7 +27,8 @@ fn group_multithreaded<T: PolarsDataType>(ca: &ChunkedArray<T>) -> bool {
 fn num_groups_proxy<T>(ca: &ChunkedArray<T>, multithreaded: bool, sorted: bool) -> GroupsProxy
 where
     T: PolarsNumericType,
-    T::Native: Send + Sync + Copy + TotalHash + TotalEq + DirtyHash,
+    T::Native: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq + Copy + Send + DirtyHash,
 {
     if multithreaded && group_multithreaded(ca) {
         let n_partitions = _set_partition_size();

--- a/crates/polars-core/src/frame/group_by/into_groups.rs
+++ b/crates/polars-core/src/frame/group_by/into_groups.rs
@@ -28,7 +28,7 @@ fn num_groups_proxy<T>(ca: &ChunkedArray<T>, multithreaded: bool, sorted: bool) 
 where
     T: PolarsNumericType,
     T::Native: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
-    <T::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq + Copy + Send + DirtyHash,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Send + Sync + Copy + Hash + Eq + DirtyHash,
 {
     if multithreaded && group_multithreaded(ca) {
         let n_partitions = _set_partition_size();

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -1,4 +1,5 @@
 use std::fmt::{Debug, Display, Formatter};
+use std::hash::Hash;
 
 use ahash::RandomState;
 use arrow::legacy::prelude::QuantileInterpolOptions;

--- a/crates/polars-core/src/hashing/vector_hasher.rs
+++ b/crates/polars-core/src/hashing/vector_hasher.rs
@@ -1,7 +1,7 @@
 use arrow::bitmap::utils::get_bit_unchecked;
 #[cfg(feature = "group_by_list")]
 use arrow::legacy::kernels::list_bytes_iter::numeric_list_bytes_iter;
-use polars_utils::total_ord::{TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalHash};
 use rayon::prelude::*;
 use xxhash_rust::xxh3::xxh3_64_with_seed;
 
@@ -71,7 +71,8 @@ fn insert_null_hash(chunks: &[ArrayRef], random_state: RandomState, buf: &mut Ve
 fn numeric_vec_hash<T>(ca: &ChunkedArray<T>, random_state: RandomState, buf: &mut Vec<u64>)
 where
     T: PolarsNumericType,
-    T::Native: TotalHash,
+    T::Native: TotalHash + ToTotalOrd,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Hash,
 {
     // Note that we don't use the no null branch! This can break in unexpected ways.
     // for instance with threading we split an array in n_threads, this may lead to
@@ -90,7 +91,7 @@ where
                 .as_slice()
                 .iter()
                 .copied()
-                .map(|v| random_state.hash_one(TotalOrdWrap(v))),
+                .map(|v| random_state.hash_one(v.to_total_ord())),
         );
     });
     insert_null_hash(&ca.chunks, random_state, buf)
@@ -99,7 +100,8 @@ where
 fn numeric_vec_hash_combine<T>(ca: &ChunkedArray<T>, random_state: RandomState, hashes: &mut [u64])
 where
     T: PolarsNumericType,
-    T::Native: TotalHash,
+    T::Native: TotalHash + ToTotalOrd,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Hash,
 {
     let null_h = get_null_hash_value(&random_state);
 
@@ -112,7 +114,7 @@ where
                 .iter()
                 .zip(&mut hashes[offset..])
                 .for_each(|(v, h)| {
-                    *h = folded_multiply(random_state.hash_one(TotalOrdWrap(v)) ^ *h, MULTIPLE);
+                    *h = folded_multiply(random_state.hash_one(v.to_total_ord()) ^ *h, MULTIPLE);
                 }),
             _ => {
                 let validity = arr.validity().unwrap();
@@ -122,7 +124,7 @@ where
                     .zip(&mut hashes[offset..])
                     .zip(arr.values().as_slice())
                     .for_each(|((valid, h), l)| {
-                        let lh = random_state.hash_one(TotalOrdWrap(l));
+                        let lh = random_state.hash_one(l.to_total_ord());
                         let to_hash = [null_h, lh][valid as usize];
 
                         // inlined from ahash. This ensures we combine with the previous state
@@ -440,12 +442,8 @@ where
         buf.clear();
         buf.reserve(self.len());
 
-        self.downcast_iter().for_each(|arr| {
-            buf.extend(
-                arr.into_iter()
-                    .map(|opt_v| random_state.hash_one(TotalOrdWrap(opt_v))),
-            )
-        });
+        self.downcast_iter()
+            .for_each(|arr| buf.extend(arr.into_iter().map(|opt_v| random_state.hash_one(opt_v))));
 
         Ok(())
     }
@@ -453,7 +451,7 @@ where
     fn vec_hash_combine(&self, random_state: RandomState, hashes: &mut [u64]) -> PolarsResult<()> {
         self.apply_to_slice(
             |opt_v, h| {
-                let hashed = random_state.hash_one(TotalOrdWrap(opt_v));
+                let hashed = random_state.hash_one(opt_v);
                 _boost_hash_combine(hashed, *h)
             },
             hashes,

--- a/crates/polars-ops/src/chunked_array/hist.rs
+++ b/crates/polars-ops/src/chunked_array/hist.rs
@@ -10,7 +10,7 @@ use polars_core::prelude::{
 use polars_core::with_match_physical_numeric_polars_type;
 use polars_error::PolarsResult;
 use polars_utils::float::IsFloat;
-use polars_utils::total_ord::TotalOrdWrap;
+use polars_utils::total_ord::ToTotalOrd;
 
 fn compute_hist<T>(
     ca: &ChunkedArray<T>,
@@ -26,7 +26,7 @@ where
     let (breaks, count) = if let Some(bins) = bins {
         let mut breaks = Vec::with_capacity(bins.len() + 1);
         breaks.extend_from_slice(bins);
-        breaks.sort_unstable_by_key(|k| TotalOrdWrap(*k));
+        breaks.sort_unstable_by_key(|k| k.to_total_ord());
         breaks.push(f64::INFINITY);
 
         let sorted = ca.sort(false);

--- a/crates/polars-ops/src/chunked_array/list/hash.rs
+++ b/crates/polars-ops/src/chunked_array/list/hash.rs
@@ -1,16 +1,19 @@
+use std::hash::Hash;
+
 use polars_core::export::_boost_hash_combine;
 use polars_core::export::ahash::{self};
 use polars_core::export::rayon::prelude::*;
 use polars_core::utils::NoNull;
 use polars_core::{with_match_physical_float_polars_type, POOL};
-use polars_utils::total_ord::{TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalHash};
 
 use super::*;
 
 fn hash_agg<T>(ca: &ChunkedArray<T>, random_state: &ahash::RandomState) -> u64
 where
     T: PolarsNumericType,
-    T::Native: TotalHash,
+    T::Native: TotalHash + ToTotalOrd,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Hash,
 {
     // Note that we don't use the no null branch! This can break in unexpected ways.
     // for instance with threading we split an array in n_threads, this may lead to
@@ -29,7 +32,7 @@ where
         for opt_v in arr.iter() {
             match opt_v {
                 Some(v) => {
-                    let r = random_state.hash_one(TotalOrdWrap(v));
+                    let r = random_state.hash_one(v.to_total_ord());
                     hash_agg = _boost_hash_combine(hash_agg, r);
                 },
                 None => {

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -73,7 +73,7 @@ where
     T: PolarsDataType,
     S: PolarsNumericType,
     S::Native: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
-    <S::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash + IsNull + Copy,
+    <S::Native as ToTotalOrd>::TotalOrdItem: Send + Sync + Copy + Hash + Eq + DirtyHash + IsNull,
     A: for<'a> AsofJoinState<T::Physical<'a>>,
     F: Sync + for<'a> Fn(T::Physical<'a>, T::Physical<'a>) -> bool,
 {

--- a/crates/polars-ops/src/frame/join/asof/groups.rs
+++ b/crates/polars-ops/src/frame/join/asof/groups.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 use ahash::RandomState;
 use num_traits::Zero;
 use polars_core::hashing::{_df_rows_to_hashes_threaded_vertical, _HASHMAP_INIT_SIZE};
@@ -6,7 +8,7 @@ use polars_core::{with_match_physical_float_polars_type, POOL};
 use polars_utils::abs_diff::AbsDiff;
 use polars_utils::hashing::{hash_to_partition, DirtyHash};
 use polars_utils::nulls::IsNull;
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 use rayon::prelude::*;
 use smartstring::alias::String as SmartString;
 
@@ -70,7 +72,8 @@ fn asof_join_by_numeric<T, S, A, F>(
 where
     T: PolarsDataType,
     S: PolarsNumericType,
-    S::Native: TotalHash + TotalEq + DirtyHash + IsNull + Copy,
+    S::Native: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
+    <S::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash + IsNull + Copy,
     A: for<'a> AsofJoinState<T::Physical<'a>>,
     F: Sync + for<'a> Fn(T::Physical<'a>, T::Physical<'a>) -> bool,
 {
@@ -108,7 +111,7 @@ where
                     results.push(None);
                     continue;
                 };
-                let by_left_k = TotalOrdWrap(*by_left_k);
+                let by_left_k = by_left_k.to_total_ord();
                 let idx_left = (rel_idx_left + offset) as IdxSize;
                 let Some(left_val) = left_val_arr.get(idx_left as usize) else {
                     results.push(None);
@@ -185,8 +188,7 @@ where
                     let group_probe_table = unsafe {
                         hash_tbls.get_unchecked(hash_to_partition(by_left_k.dirty_hash(), n_tables))
                     };
-                    let Some(right_grp_idxs) = group_probe_table.get(&TotalOrdWrap(*by_left_k))
-                    else {
+                    let Some(right_grp_idxs) = group_probe_table.get(by_left_k) else {
                         results.push(None);
                         continue;
                     };

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys.rs
@@ -2,7 +2,7 @@ use polars_utils::hashing::{hash_to_partition, DirtyHash};
 use polars_utils::idx_vec::IdxVec;
 use polars_utils::nulls::IsNull;
 use polars_utils::sync::SyncPtr;
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 use polars_utils::unitvec;
 
 use super::*;
@@ -16,9 +16,10 @@ const MIN_ELEMS_PER_THREAD: usize = if cfg!(debug_assertions) { 1 } else { 128 }
 pub(crate) fn build_tables<T, I>(
     keys: Vec<I>,
     join_nulls: bool,
-) -> Vec<PlHashMap<TotalOrdWrap<T>, IdxVec>>
+) -> Vec<PlHashMap<<T as ToTotalOrd>::TotalOrdItem, IdxVec>>
 where
-    T: Send + Sync + Copy + TotalHash + TotalEq + DirtyHash + IsNull,
+    T: TotalHash + TotalEq + ToTotalOrd,
+    <T as ToTotalOrd>::TotalOrdItem: Copy + Hash + Eq + DirtyHash + IsNull,
     I: IntoIterator<Item = T> + Send + Sync + Clone,
 {
     // FIXME: change interface to split the input here, instead of taking
@@ -32,11 +33,11 @@ where
 
     // Don't bother parallelizing anything for small inputs.
     if num_keys_est < 2 * MIN_ELEMS_PER_THREAD {
-        let mut hm: PlHashMap<TotalOrdWrap<T>, IdxVec> = PlHashMap::new();
+        let mut hm: PlHashMap<T::TotalOrdItem, IdxVec> = PlHashMap::new();
         let mut offset = 0;
         for it in keys {
             for k in it {
-                let k = TotalOrdWrap(k);
+                let k = k.to_total_ord();
                 if !k.is_null() || join_nulls {
                     hm.entry(k).or_default().push(offset);
                 }
@@ -54,7 +55,7 @@ where
             .map(|key_portion| {
                 let mut partition_sizes = vec![0; n_partitions];
                 for key in key_portion.clone() {
-                    let key = TotalOrdWrap(key);
+                    let key = key.to_total_ord();
                     let p = hash_to_partition(key.dirty_hash(), n_partitions);
                     unsafe {
                         *partition_sizes.get_unchecked_mut(p) += 1;
@@ -91,7 +92,7 @@ where
         }
 
         // Scatter values into partitions.
-        let mut scatter_keys: Vec<TotalOrdWrap<T>> = Vec::with_capacity(num_keys);
+        let mut scatter_keys: Vec<T::TotalOrdItem> = Vec::with_capacity(num_keys);
         let mut scatter_idxs: Vec<IdxSize> = Vec::with_capacity(num_keys);
         let scatter_keys_ptr = unsafe { SyncPtr::new(scatter_keys.as_mut_ptr()) };
         let scatter_idxs_ptr = unsafe { SyncPtr::new(scatter_idxs.as_mut_ptr()) };
@@ -102,7 +103,7 @@ where
                 let mut partition_offsets =
                     per_thread_partition_offsets[t * n_partitions..(t + 1) * n_partitions].to_vec();
                 for (i, key) in key_portion.into_iter().enumerate() {
-                    let key = TotalOrdWrap(key);
+                    let key = key.to_total_ord();
                     unsafe {
                         let p = hash_to_partition(key.dirty_hash(), n_partitions);
                         let off = partition_offsets.get_unchecked_mut(p);
@@ -131,7 +132,7 @@ where
                 let partition_range = partition_offsets[p]..partition_offsets[p + 1];
                 let full_size = partition_range.len();
                 let mut conservative_size = _HASHMAP_INIT_SIZE.max(full_size / 64);
-                let mut hm: PlHashMap<TotalOrdWrap<T>, IdxVec> =
+                let mut hm: PlHashMap<T::TotalOrdItem, IdxVec> =
                     PlHashMap::with_capacity(conservative_size);
 
                 unsafe {

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys.rs
@@ -19,7 +19,7 @@ pub(crate) fn build_tables<T, I>(
 ) -> Vec<PlHashMap<<T as ToTotalOrd>::TotalOrdItem, IdxVec>>
 where
     T: TotalHash + TotalEq + ToTotalOrd,
-    <T as ToTotalOrd>::TotalOrdItem: Copy + Hash + Eq + DirtyHash + IsNull,
+    <T as ToTotalOrd>::TotalOrdItem: Send + Sync + Copy + Hash + Eq + DirtyHash + IsNull,
     I: IntoIterator<Item = T> + Send + Sync + Clone,
 {
     // FIXME: change interface to split the input here, instead of taking

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
@@ -2,7 +2,7 @@ use arrow::array::PrimitiveArray;
 use polars_core::with_match_physical_float_polars_type;
 use polars_utils::hashing::DirtyHash;
 use polars_utils::nulls::IsNull;
-use polars_utils::total_ord::{TotalEq, TotalHash};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
 use super::*;
 use crate::series::SeriesSealed;
@@ -186,7 +186,10 @@ fn group_join_inner<T>(
 where
     T: PolarsDataType,
     for<'a> &'a T::Array: IntoIterator<Item = Option<&'a T::Physical<'a>>>,
-    for<'a> T::Physical<'a>: Send + Sync + Copy + TotalHash + TotalEq + DirtyHash + IsNull,
+    for<'a> T::Physical<'a>:
+        Send + Sync + Copy + TotalHash + TotalEq + DirtyHash + IsNull + ToTotalOrd,
+    for<'a> <T::Physical<'a> as ToTotalOrd>::TotalOrdItem:
+        Send + Sync + Copy + Hash + Eq + DirtyHash + IsNull,
 {
     let n_threads = POOL.current_num_threads();
     let (a, b, swapped) = det_hash_prone_order!(left, right);
@@ -269,8 +272,10 @@ fn num_group_join_left<T>(
 ) -> PolarsResult<LeftJoinIds>
 where
     T: PolarsNumericType,
-    T::Native: TotalHash + TotalEq + DirtyHash + IsNull,
-    Option<T::Native>: DirtyHash,
+    T::Native: TotalHash + TotalEq + DirtyHash + IsNull + ToTotalOrd,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Copy + Hash + Eq + DirtyHash + IsNull,
+    Option<T::Native>: DirtyHash + ToTotalOrd,
+    <Option<T::Native> as ToTotalOrd>::TotalOrdItem: DirtyHash,
 {
     let n_threads = POOL.current_num_threads();
     let splitted_a = split_ca(left, n_threads).unwrap();
@@ -326,7 +331,8 @@ fn hash_join_outer<T>(
 ) -> PolarsResult<(PrimitiveArray<IdxSize>, PrimitiveArray<IdxSize>)>
 where
     T: PolarsNumericType,
-    T::Native: TotalHash + TotalEq,
+    T::Native: TotalHash + TotalEq + ToTotalOrd,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Send + Sync + Copy + Hash + Eq + IsNull,
 {
     let (a, b, swapped) = det_hash_prone_order!(ca_in, other);
 
@@ -421,8 +427,10 @@ fn num_group_join_anti_semi<T>(
 ) -> Vec<IdxSize>
 where
     T: PolarsNumericType,
-    T::Native: TotalHash + TotalEq + DirtyHash,
-    Option<T::Native>: DirtyHash,
+    T::Native: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash,
+    Option<T::Native>: DirtyHash + ToTotalOrd,
+    <Option<T::Native> as ToTotalOrd>::TotalOrdItem: DirtyHash,
 {
     let n_threads = POOL.current_num_threads();
     let splitted_a = split_ca(left, n_threads).unwrap();

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_dispatch.rs
@@ -273,9 +273,9 @@ fn num_group_join_left<T>(
 where
     T: PolarsNumericType,
     T::Native: TotalHash + TotalEq + DirtyHash + IsNull + ToTotalOrd,
-    <T::Native as ToTotalOrd>::TotalOrdItem: Copy + Hash + Eq + DirtyHash + IsNull,
-    Option<T::Native>: DirtyHash + ToTotalOrd,
-    <Option<T::Native> as ToTotalOrd>::TotalOrdItem: DirtyHash,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Send + Sync + Copy + Hash + Eq + DirtyHash + IsNull,
+    T::Native: DirtyHash + Copy + ToTotalOrd,
+    <Option<T::Native> as ToTotalOrd>::TotalOrdItem: Send + Sync + DirtyHash,
 {
     let n_threads = POOL.current_num_threads();
     let splitted_a = split_ca(left, n_threads).unwrap();
@@ -428,9 +428,8 @@ fn num_group_join_anti_semi<T>(
 where
     T: PolarsNumericType,
     T::Native: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
-    <T::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash,
-    Option<T::Native>: DirtyHash + ToTotalOrd,
-    <Option<T::Native> as ToTotalOrd>::TotalOrdItem: DirtyHash,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Send + Sync + Copy + Hash + Eq + DirtyHash,
+    <Option<T::Native> as ToTotalOrd>::TotalOrdItem: Send + Sync + DirtyHash,
 {
     let n_threads = POOL.current_num_threads();
     let splitted_a = split_ca(left, n_threads).unwrap();

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_inner.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_inner.rs
@@ -4,24 +4,25 @@ use polars_utils::idx_vec::IdxVec;
 use polars_utils::iter::EnumerateIdxTrait;
 use polars_utils::nulls::IsNull;
 use polars_utils::sync::SyncPtr;
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
 use super::*;
 
 pub(super) fn probe_inner<T, F, I>(
     probe: I,
-    hash_tbls: &[PlHashMap<TotalOrdWrap<T>, IdxVec>],
+    hash_tbls: &[PlHashMap<<T as ToTotalOrd>::TotalOrdItem, IdxVec>],
     results: &mut Vec<(IdxSize, IdxSize)>,
     local_offset: IdxSize,
     n_tables: usize,
     swap_fn: F,
 ) where
-    T: TotalHash + TotalEq + DirtyHash,
+    T: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
+    <T as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash,
     I: IntoIterator<Item = T>,
     F: Fn(IdxSize, IdxSize) -> (IdxSize, IdxSize),
 {
     probe.into_iter().enumerate_idx().for_each(|(idx_a, k)| {
-        let k = TotalOrdWrap(k);
+        let k = k.to_total_ord();
         let idx_a = idx_a + local_offset;
         // probe table that contains the hashed value
         let current_probe_table =
@@ -46,7 +47,8 @@ pub(super) fn hash_join_tuples_inner<T, I>(
 ) -> PolarsResult<(Vec<IdxSize>, Vec<IdxSize>)>
 where
     I: IntoIterator<Item = T> + Send + Sync + Clone,
-    T: Send + Sync + Copy + TotalHash + TotalEq + DirtyHash + IsNull,
+    T: Send + Sync + Copy + TotalHash + TotalEq + DirtyHash + ToTotalOrd,
+    <T as ToTotalOrd>::TotalOrdItem: Send + Sync + Copy + Hash + Eq + DirtyHash + IsNull,
 {
     // NOTE: see the left join for more elaborate comments
     // first we hash one relation

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_left.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_left.rs
@@ -1,7 +1,7 @@
 use polars_core::utils::flatten::flatten_par;
 use polars_utils::hashing::{hash_to_partition, DirtyHash};
 use polars_utils::nulls::IsNull;
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
 use super::*;
 
@@ -113,7 +113,8 @@ pub(super) fn hash_join_tuples_left<T, I>(
 where
     I: IntoIterator<Item = T>,
     <I as IntoIterator>::IntoIter: Send + Sync + Clone,
-    T: Send + Sync + Copy + TotalHash + TotalEq + DirtyHash + IsNull,
+    T: Send + Sync + Copy + TotalHash + TotalEq + DirtyHash + IsNull + ToTotalOrd,
+    <T as ToTotalOrd>::TotalOrdItem: Send + Sync + Copy + Hash + Eq + DirtyHash + IsNull,
 {
     let probe = probe.into_iter().map(|i| i.into_iter()).collect::<Vec<_>>();
     let build = build.into_iter().map(|i| i.into_iter()).collect::<Vec<_>>();
@@ -148,7 +149,7 @@ where
                 let mut result_idx_right = Vec::with_capacity(probe.size_hint().1.unwrap());
 
                 probe.enumerate().for_each(|(idx_a, k)| {
-                    let k = TotalOrdWrap(k);
+                    let k = k.to_total_ord();
                     let idx_a = (idx_a + offset) as IdxSize;
                     // probe table that contains the hashed value
                     let current_probe_table = unsafe {

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_outer.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_outer.rs
@@ -39,7 +39,7 @@ pub(crate) fn prepare_hashed_relation_threaded<T, I>(
 where
     I: Iterator<Item = T> + Send + TrustedLen,
     T: Send + Sync + TotalHash + TotalEq + ToTotalOrd,
-    <T as ToTotalOrd>::TotalOrdItem: Hash + Eq,
+    <T as ToTotalOrd>::TotalOrdItem: Send + Sync + Hash + Eq,
 {
     let n_partitions = _set_partition_size();
     let (hashes_and_keys, build_hasher) = create_hash_and_keys_threaded_vectorized(iters, None);
@@ -189,7 +189,7 @@ where
     <J as IntoIterator>::IntoIter: TrustedLen + Send,
     <I as IntoIterator>::IntoIter: TrustedLen + Send,
     T: Send + Sync + TotalHash + TotalEq + IsNull + ToTotalOrd,
-    <T as ToTotalOrd>::TotalOrdItem: Hash + Eq + IsNull,
+    <T as ToTotalOrd>::TotalOrdItem: Send + Sync + Hash + Eq + IsNull,
 {
     let probe = probe.into_iter().map(|i| i.into_iter()).collect::<Vec<_>>();
     let build = build.into_iter().map(|i| i.into_iter()).collect::<Vec<_>>();

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_semi_anti.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_semi_anti.rs
@@ -9,7 +9,7 @@ pub(super) fn create_probe_table_semi_anti<T, I>(
 ) -> Vec<PlHashSet<<T as ToTotalOrd>::TotalOrdItem>>
 where
     T: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
-    <T as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash,
+    <T as ToTotalOrd>::TotalOrdItem: Send + Sync + Hash + Eq + DirtyHash,
     I: IntoIterator<Item = T> + Copy + Send + Sync,
 {
     let n_partitions = _set_partition_size();
@@ -41,7 +41,7 @@ fn semi_anti_impl<T, I>(
 where
     I: IntoIterator<Item = T> + Copy + Send + Sync,
     T: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
-    <T as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash,
+    <T as ToTotalOrd>::TotalOrdItem: Send + Sync + Hash + Eq + DirtyHash,
 {
     // first we hash one relation
     let hash_sets = create_probe_table_semi_anti(build);
@@ -91,7 +91,7 @@ pub(super) fn hash_join_tuples_left_anti<T, I>(probe: Vec<I>, build: Vec<I>) -> 
 where
     I: IntoIterator<Item = T> + Copy + Send + Sync,
     T: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
-    <T as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash,
+    <T as ToTotalOrd>::TotalOrdItem: Send + Sync + Hash + Eq + DirtyHash,
 {
     let par_iter = semi_anti_impl(probe, build)
         .filter(|tpls| !tpls.1)
@@ -103,7 +103,7 @@ pub(super) fn hash_join_tuples_left_semi<T, I>(probe: Vec<I>, build: Vec<I>) -> 
 where
     I: IntoIterator<Item = T> + Copy + Send + Sync,
     T: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
-    <T as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash,
+    <T as ToTotalOrd>::TotalOrdItem: Send + Sync + Hash + Eq + DirtyHash,
 {
     let par_iter = semi_anti_impl(probe, build)
         .filter(|tpls| tpls.1)

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_semi_anti.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_semi_anti.rs
@@ -1,12 +1,15 @@
 use polars_utils::hashing::{hash_to_partition, DirtyHash};
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
 use super::*;
 
 /// Only keeps track of membership in right table
-pub(super) fn create_probe_table_semi_anti<T, I>(keys: Vec<I>) -> Vec<PlHashSet<TotalOrdWrap<T>>>
+pub(super) fn create_probe_table_semi_anti<T, I>(
+    keys: Vec<I>,
+) -> Vec<PlHashSet<<T as ToTotalOrd>::TotalOrdItem>>
 where
-    T: Send + Sync + TotalHash + TotalEq + DirtyHash,
+    T: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
+    <T as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash,
     I: IntoIterator<Item = T> + Copy + Send + Sync,
 {
     let n_partitions = _set_partition_size();
@@ -15,10 +18,10 @@ where
     // We use the hash to partition the keys to the matching hashtable.
     // Every thread traverses all keys/hashes and ignores the ones that doesn't fall in that partition.
     let par_iter = (0..n_partitions).into_par_iter().map(|partition_no| {
-        let mut hash_tbl: PlHashSet<TotalOrdWrap<T>> = PlHashSet::with_capacity(_HASHMAP_INIT_SIZE);
+        let mut hash_tbl: PlHashSet<T::TotalOrdItem> = PlHashSet::with_capacity(_HASHMAP_INIT_SIZE);
         for keys in &keys {
             keys.into_iter().for_each(|k| {
-                let k = TotalOrdWrap(k);
+                let k = k.to_total_ord();
                 if partition_no == hash_to_partition(k.dirty_hash(), n_partitions) {
                     hash_tbl.insert(k);
                 }
@@ -36,8 +39,9 @@ fn semi_anti_impl<T, I>(
     build: Vec<I>,
 ) -> impl ParallelIterator<Item = (IdxSize, bool)>
 where
-    I: Send + Sync + Copy + IntoIterator<Item = T>,
-    T: Send + Sync + TotalHash + TotalEq + DirtyHash,
+    I: IntoIterator<Item = T> + Copy + Send + Sync,
+    T: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
+    <T as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash,
 {
     // first we hash one relation
     let hash_sets = create_probe_table_semi_anti(build);
@@ -63,7 +67,7 @@ where
             let mut results = Vec::with_capacity(probe_iter.size_hint().1.unwrap());
 
             probe_iter.enumerate().for_each(|(idx_a, k)| {
-                let k = TotalOrdWrap(k);
+                let k = k.to_total_ord();
                 let idx_a = (idx_a + offset) as IdxSize;
                 // probe table that contains the hashed value
                 let current_probe_table =
@@ -86,7 +90,8 @@ where
 pub(super) fn hash_join_tuples_left_anti<T, I>(probe: Vec<I>, build: Vec<I>) -> Vec<IdxSize>
 where
     I: IntoIterator<Item = T> + Copy + Send + Sync,
-    T: Send + Sync + Copy + TotalHash + TotalEq + DirtyHash,
+    T: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
+    <T as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash,
 {
     let par_iter = semi_anti_impl(probe, build)
         .filter(|tpls| !tpls.1)
@@ -97,7 +102,8 @@ where
 pub(super) fn hash_join_tuples_left_semi<T, I>(probe: Vec<I>, build: Vec<I>) -> Vec<IdxSize>
 where
     I: IntoIterator<Item = T> + Copy + Send + Sync,
-    T: Send + Sync + Copy + TotalHash + TotalEq + DirtyHash,
+    T: TotalHash + TotalEq + DirtyHash + ToTotalOrd,
+    <T as ToTotalOrd>::TotalOrdItem: Hash + Eq + DirtyHash,
 {
     let par_iter = semi_anti_impl(probe, build)
         .filter(|tpls| tpls.1)

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -12,6 +12,7 @@ mod merge_sorted;
 #[cfg(feature = "chunked_ids")]
 use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
+use std::hash::Hash;
 
 use ahash::RandomState;
 pub use args::*;

--- a/crates/polars-ops/src/frame/pivot/positioning.rs
+++ b/crates/polars-ops/src/frame/pivot/positioning.rs
@@ -3,7 +3,7 @@ use std::hash::Hash;
 use arrow::legacy::trusted_len::TrustedLenPush;
 use polars_core::prelude::*;
 use polars_utils::sync::SyncPtr;
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
 use super::*;
 
@@ -176,14 +176,15 @@ where
 fn compute_col_idx_numeric<T>(column_agg_physical: &ChunkedArray<T>) -> Vec<IdxSize>
 where
     T: PolarsNumericType,
-    T::Native: TotalHash + TotalEq,
+    T::Native: TotalHash + TotalEq + ToTotalOrd,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq,
 {
     let mut col_to_idx = PlHashMap::with_capacity(HASHMAP_INIT_SIZE);
     let mut idx = 0 as IdxSize;
     let mut out = Vec::with_capacity(column_agg_physical.len());
 
     for opt_v in column_agg_physical.iter() {
-        let opt_v = TotalOrdWrap(opt_v);
+        let opt_v = opt_v.to_total_ord();
         let idx = *col_to_idx.entry(opt_v).or_insert_with(|| {
             let old_idx = idx;
             idx += 1;
@@ -294,7 +295,8 @@ fn compute_row_index<'a, T>(
 ) -> (Vec<IdxSize>, usize, Option<Vec<Series>>)
 where
     T: PolarsDataType,
-    Option<T::Physical<'a>>: TotalHash + TotalEq + Copy,
+    Option<T::Physical<'a>>: TotalHash + TotalEq + Copy + ToTotalOrd,
+    <Option<T::Physical<'a>> as ToTotalOrd>::TotalOrdItem: Hash + Eq,
     ChunkedArray<T>: FromIterator<Option<T::Physical<'a>>>,
     ChunkedArray<T>: IntoSeries,
 {
@@ -304,7 +306,7 @@ where
 
     let mut row_locations = Vec::with_capacity(index_agg_physical.len());
     for opt_v in index_agg_physical.iter() {
-        let opt_v = TotalOrdWrap(opt_v);
+        let opt_v = opt_v.to_total_ord();
         let idx = *row_to_idx.entry(opt_v).or_insert_with(|| {
             let old_idx = idx;
             idx += 1;
@@ -321,7 +323,11 @@ where
         0 => {
             let mut s = row_to_idx
                 .into_iter()
-                .map(|(k, _)| k.0)
+                .map(|(k, _)| {
+                    let out = Option::<T::Physical<'a>>::peel_total_ord(k);
+                    let out: Option<T::Physical<'a>> = unsafe { std::mem::transmute_copy(&out) };
+                    out
+                })
                 .collect::<ChunkedArray<T>>()
                 .into_series();
             s.rename(&index[0]);

--- a/crates/polars-ops/src/frame/pivot/positioning.rs
+++ b/crates/polars-ops/src/frame/pivot/positioning.rs
@@ -323,11 +323,7 @@ where
         0 => {
             let mut s = row_to_idx
                 .into_iter()
-                .map(|(k, _)| {
-                    let out = Option::<T::Physical<'a>>::peel_total_ord(k);
-                    let out: Option<T::Physical<'a>> = unsafe { std::mem::transmute_copy(&out) };
-                    out
-                })
+                .map(|(k, _)| Option::<T::Physical<'a>>::peel_total_ord(k))
                 .collect::<ChunkedArray<T>>()
                 .into_series();
             s.rename(&index[0]);

--- a/crates/polars-ops/src/frame/pivot/positioning.rs
+++ b/crates/polars-ops/src/frame/pivot/positioning.rs
@@ -295,7 +295,7 @@ fn compute_row_index<'a, T>(
 ) -> (Vec<IdxSize>, usize, Option<Vec<Series>>)
 where
     T: PolarsDataType,
-    Option<T::Physical<'a>>: TotalHash + TotalEq + Copy + ToTotalOrd,
+    T::Physical<'a>: TotalHash + TotalEq + Copy + ToTotalOrd,
     <Option<T::Physical<'a>> as ToTotalOrd>::TotalOrdItem: Hash + Eq,
     ChunkedArray<T>: FromIterator<Option<T::Physical<'a>>>,
     ChunkedArray<T>: IntoSeries,

--- a/crates/polars-ops/src/series/ops/approx_unique.rs
+++ b/crates/polars-ops/src/series/ops/approx_unique.rs
@@ -10,7 +10,7 @@ use crate::series::ops::approx_algo::HyperLogLog;
 fn approx_n_unique_ca<'a, T>(ca: &'a ChunkedArray<T>) -> PolarsResult<Series>
 where
     T: PolarsDataType,
-    Option<T::Physical<'a>>: TotalHash + TotalEq + ToTotalOrd,
+    T::Physical<'a>: TotalHash + TotalEq + Copy + ToTotalOrd,
     <Option<T::Physical<'a>> as ToTotalOrd>::TotalOrdItem: Hash + Eq,
 {
     let mut hllp = HyperLogLog::new();

--- a/crates/polars-ops/src/series/ops/approx_unique.rs
+++ b/crates/polars-ops/src/series/ops/approx_unique.rs
@@ -1,6 +1,8 @@
+use std::hash::Hash;
+
 use polars_core::prelude::*;
 use polars_core::with_match_physical_integer_polars_type;
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
 #[cfg(feature = "approx_unique")]
 use crate::series::ops::approx_algo::HyperLogLog;
@@ -8,10 +10,11 @@ use crate::series::ops::approx_algo::HyperLogLog;
 fn approx_n_unique_ca<'a, T>(ca: &'a ChunkedArray<T>) -> PolarsResult<Series>
 where
     T: PolarsDataType,
-    Option<T::Physical<'a>>: TotalHash + TotalEq,
+    Option<T::Physical<'a>>: TotalHash + TotalEq + ToTotalOrd,
+    <Option<T::Physical<'a>> as ToTotalOrd>::TotalOrdItem: Hash + Eq,
 {
     let mut hllp = HyperLogLog::new();
-    ca.iter().for_each(|item| hllp.add(&TotalOrdWrap(item)));
+    ca.iter().for_each(|item| hllp.add(&item.to_total_ord()));
     let c = hllp.count() as IdxSize;
 
     Ok(Series::new(ca.name(), &[c]))

--- a/crates/polars-ops/src/series/ops/is_first_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_first_distinct.rs
@@ -1,19 +1,22 @@
+use std::hash::Hash;
+
 use arrow::array::BooleanArray;
 use arrow::bitmap::MutableBitmap;
 use arrow::legacy::bit_util::*;
 use arrow::legacy::utils::CustomIterTools;
 use polars_core::prelude::*;
 use polars_core::with_match_physical_numeric_polars_type;
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 fn is_first_distinct_numeric<T>(ca: &ChunkedArray<T>) -> BooleanChunked
 where
     T: PolarsNumericType,
-    T::Native: TotalHash + TotalEq,
+    T::Native: TotalHash + TotalEq + ToTotalOrd,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq,
 {
     let mut unique = PlHashSet::new();
     let chunks = ca.downcast_iter().map(|arr| -> BooleanArray {
         arr.into_iter()
-            .map(|opt_v| unique.insert(TotalOrdWrap(opt_v)))
+            .map(|opt_v| unique.insert(opt_v.to_total_ord()))
             .collect_trusted()
     });
 

--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -1,3 +1,5 @@
+use std::hash::Hash;
+
 #[cfg(feature = "dtype-categorical")]
 use polars_core::apply_amortized_generic_list_or_array;
 use polars_core::prelude::*;
@@ -5,7 +7,7 @@ use polars_core::utils::{try_get_supertype, CustomIterTools};
 use polars_core::with_match_physical_numeric_polars_type;
 #[cfg(feature = "dtype-categorical")]
 use polars_utils::iter::EnumerateIdxTrait;
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
 fn is_in_helper_ca<'a, T>(
     ca: &'a ChunkedArray<T>,
@@ -13,25 +15,27 @@ fn is_in_helper_ca<'a, T>(
 ) -> PolarsResult<BooleanChunked>
 where
     T: PolarsDataType,
-    T::Physical<'a>: TotalHash + TotalEq + Copy,
+    T::Physical<'a>: TotalHash + TotalEq + ToTotalOrd + Copy,
+    <T::Physical<'a> as ToTotalOrd>::TotalOrdItem: Hash + Eq + Copy,
 {
     let mut set = PlHashSet::with_capacity(other.len());
     other.downcast_iter().for_each(|iter| {
         iter.iter().for_each(|opt_val| {
             if let Some(v) = opt_val {
-                set.insert(TotalOrdWrap(v));
+                set.insert(v.to_total_ord());
             }
         })
     });
     Ok(ca
-        .apply_values_generic(|val| set.contains(&TotalOrdWrap(val)))
+        .apply_values_generic(|val| set.contains(&val.to_total_ord()))
         .with_name(ca.name()))
 }
 
 fn is_in_helper<'a, T>(ca: &'a ChunkedArray<T>, other: &Series) -> PolarsResult<BooleanChunked>
 where
     T: PolarsDataType,
-    T::Physical<'a>: TotalHash + TotalEq + Copy,
+    T::Physical<'a>: TotalHash + TotalEq + Copy + ToTotalOrd,
+    <T::Physical<'a> as ToTotalOrd>::TotalOrdItem: Hash + Eq + Copy,
 {
     let other = ca.unpack_series_matching_type(other)?;
     is_in_helper_ca(ca, other)
@@ -112,7 +116,8 @@ where
 fn is_in_numeric<T>(ca_in: &ChunkedArray<T>, other: &Series) -> PolarsResult<BooleanChunked>
 where
     T: PolarsNumericType,
-    T::Native: TotalHash + TotalEq,
+    T::Native: TotalHash + TotalEq + ToTotalOrd,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq + Copy,
 {
     // We check implicitly cast to supertype here
     match other.dtype() {
@@ -580,7 +585,7 @@ fn is_in_cat(ca_in: &CategoricalChunked, other: &Series) -> PolarsResult<Boolean
                             .contains(unsafe { categories.value_unchecked(*local_idx as usize) })
                         {
                             #[allow(clippy::unnecessary_cast)]
-                            set.insert(TotalOrdWrap(*global_idx as u32));
+                            set.insert((*global_idx as u32).to_total_ord());
                         }
                     }
                 },
@@ -591,7 +596,7 @@ fn is_in_cat(ca_in: &CategoricalChunked, other: &Series) -> PolarsResult<Boolean
                         .for_each(|(idx, v)| {
                             if others.contains(v) {
                                 #[allow(clippy::unnecessary_cast)]
-                                set.insert(TotalOrdWrap(idx as u32));
+                                set.insert((idx as u32).to_total_ord());
                             }
                         });
                 },
@@ -599,7 +604,7 @@ fn is_in_cat(ca_in: &CategoricalChunked, other: &Series) -> PolarsResult<Boolean
 
             Ok(ca_in
                 .physical()
-                .apply_values_generic(|val| set.contains(&TotalOrdWrap(val)))
+                .apply_values_generic(|val| set.contains(&val.to_total_ord()))
                 .with_name(ca_in.name()))
         },
 

--- a/crates/polars-ops/src/series/ops/is_last_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_last_distinct.rs
@@ -1,10 +1,12 @@
+use std::hash::Hash;
+
 use arrow::array::BooleanArray;
 use arrow::bitmap::MutableBitmap;
 use arrow::legacy::utils::CustomIterTools;
 use polars_core::prelude::*;
 use polars_core::utils::NoNull;
 use polars_core::with_match_physical_numeric_polars_type;
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
 pub fn is_last_distinct(s: &Series) -> PolarsResult<BooleanChunked> {
     // fast path.
@@ -122,7 +124,8 @@ fn is_last_distinct_bin(ca: &BinaryChunked) -> BooleanChunked {
 fn is_last_distinct_numeric<T>(ca: &ChunkedArray<T>) -> BooleanChunked
 where
     T: PolarsNumericType,
-    T::Native: TotalHash + TotalEq,
+    T::Native: TotalHash + TotalEq + ToTotalOrd,
+    <T::Native as ToTotalOrd>::TotalOrdItem: Hash + Eq,
 {
     let ca = ca.rechunk();
     let arr = ca.downcast_iter().next().unwrap();
@@ -130,7 +133,7 @@ where
     let mut new_ca: BooleanChunked = arr
         .into_iter()
         .rev()
-        .map(|opt_v| unique.insert(TotalOrdWrap(opt_v)))
+        .map(|opt_v| unique.insert(opt_v.to_total_ord()))
         .collect_reversed::<NoNull<BooleanChunked>>()
         .into_inner();
     new_ca.rename(ca.name());

--- a/crates/polars-ops/src/series/ops/is_unique.rs
+++ b/crates/polars-ops/src/series/ops/is_unique.rs
@@ -1,14 +1,17 @@
+use std::hash::Hash;
+
 use arrow::array::BooleanArray;
 use arrow::bitmap::MutableBitmap;
 use polars_core::prelude::*;
 use polars_core::with_match_physical_integer_polars_type;
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
 // If invert is true then this is an `is_duplicated`.
 fn is_unique_ca<'a, T>(ca: &'a ChunkedArray<T>, invert: bool) -> BooleanChunked
 where
     T: PolarsDataType,
-    T::Physical<'a>: TotalHash + TotalEq,
+    Option<T::Physical<'a>>: TotalHash + TotalEq + ToTotalOrd,
+    <Option<T::Physical<'a>> as ToTotalOrd>::TotalOrdItem: Hash + Eq,
 {
     let len = ca.len();
     let mut idx_key = PlHashMap::new();
@@ -17,7 +20,7 @@ where
     // just toggle a boolean that's false if a group has multiple entries.
     ca.iter().enumerate().for_each(|(idx, key)| {
         idx_key
-            .entry(TotalOrdWrap(key))
+            .entry(key.to_total_ord())
             .and_modify(|v: &mut (IdxSize, bool)| v.1 = false)
             .or_insert((idx as IdxSize, true));
     });

--- a/crates/polars-ops/src/series/ops/is_unique.rs
+++ b/crates/polars-ops/src/series/ops/is_unique.rs
@@ -10,7 +10,7 @@ use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 fn is_unique_ca<'a, T>(ca: &'a ChunkedArray<T>, invert: bool) -> BooleanChunked
 where
     T: PolarsDataType,
-    Option<T::Physical<'a>>: TotalHash + TotalEq + ToTotalOrd,
+    T::Physical<'a>: TotalHash + TotalEq + Copy + ToTotalOrd,
     <Option<T::Physical<'a>> as ToTotalOrd>::TotalOrdItem: Hash + Eq,
 {
     let len = ca.len();

--- a/crates/polars-ops/src/series/ops/unique.rs
+++ b/crates/polars-ops/src/series/ops/unique.rs
@@ -1,17 +1,20 @@
+use std::hash::Hash;
+
 use polars_core::hashing::_HASHMAP_INIT_SIZE;
 use polars_core::prelude::*;
 use polars_core::utils::NoNull;
 use polars_core::with_match_physical_numeric_polars_type;
-use polars_utils::total_ord::{TotalEq, TotalHash, TotalOrdWrap};
+use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
 
 fn unique_counts_helper<I, J>(items: I) -> IdxCa
 where
     I: Iterator<Item = J>,
-    J: TotalHash + TotalEq,
+    J: TotalHash + TotalEq + ToTotalOrd,
+    <J as ToTotalOrd>::TotalOrdItem: Hash + Eq,
 {
     let mut map = PlIndexMap::with_capacity_and_hasher(_HASHMAP_INIT_SIZE, Default::default());
     for item in items {
-        let item = TotalOrdWrap(item);
+        let item = item.to_total_ord();
         map.entry(item)
             .and_modify(|cnt| {
                 *cnt += 1;

--- a/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/simplify_expr.rs
@@ -1,5 +1,5 @@
 use polars_utils::arena::Arena;
-use polars_utils::total_ord::TotalOrdWrap;
+use polars_utils::total_ord::ToTotalOrd;
 
 #[cfg(all(feature = "strings", feature = "concat_str"))]
 use crate::dsl::function_expr::StringFunction;
@@ -59,10 +59,10 @@ macro_rules! eval_binary_bool_type {
     if let (AExpr::Literal(lit_left), AExpr::Literal(lit_right)) = ($lhs, $rhs) {
         match (lit_left, lit_right) {
             (LiteralValue::Float32(x), LiteralValue::Float32(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(TotalOrdWrap(*x) $operand TotalOrdWrap(*y))))
+                Some(AExpr::Literal(LiteralValue::Boolean(x.to_total_ord() $operand y.to_total_ord())))
             }
             (LiteralValue::Float64(x), LiteralValue::Float64(y)) => {
-                Some(AExpr::Literal(LiteralValue::Boolean(TotalOrdWrap(*x) $operand TotalOrdWrap(*y))))
+                Some(AExpr::Literal(LiteralValue::Boolean(x.to_total_ord() $operand y.to_total_ord())))
             }
             #[cfg(feature = "dtype-i8")]
             (LiteralValue::Int8(x), LiteralValue::Int8(y)) => {

--- a/crates/polars-utils/src/total_ord.rs
+++ b/crates/polars-utils/src/total_ord.rs
@@ -566,19 +566,6 @@ impl<T: Copy> ToTotalOrd for Option<T> {
     }
 }
 
-impl<'a> ToTotalOrd for BytesHash<'a> {
-    type TotalOrdItem = BytesHash<'a>;
-    type SourceItem = BytesHash<'a>;
-
-    fn to_total_ord(&self) -> Self::TotalOrdItem {
-        *self
-    }
-
-    fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
-        ord_item
-    }
-}
-
 impl<T: ToTotalOrd> ToTotalOrd for &T {
     type TotalOrdItem = T::TotalOrdItem;
     type SourceItem = T::SourceItem;
@@ -589,5 +576,18 @@ impl<T: ToTotalOrd> ToTotalOrd for &T {
 
     fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
         T::peel_total_ord(ord_item)
+    }
+}
+
+impl<'a> ToTotalOrd for BytesHash<'a> {
+    type TotalOrdItem = BytesHash<'a>;
+    type SourceItem = BytesHash<'a>;
+
+    fn to_total_ord(&self) -> Self::TotalOrdItem {
+        *self
+    }
+
+    fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
+        ord_item
     }
 }

--- a/crates/polars-utils/src/total_ord.rs
+++ b/crates/polars-utils/src/total_ord.rs
@@ -481,10 +481,12 @@ macro_rules! impl_to_total_ord_identity {
             type TotalOrdItem = $T;
             type SourceItem = $T;
 
+            #[inline]
             fn to_total_ord(&self) -> Self::TotalOrdItem {
                 self.clone()
             }
 
+            #[inline]
             fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
                 ord_item
             }
@@ -514,10 +516,12 @@ macro_rules! impl_to_total_ord_lifetimed_ref_identity {
             type TotalOrdItem = &'a $T;
             type SourceItem = &'a $T;
 
+            #[inline]
             fn to_total_ord(&self) -> Self::TotalOrdItem {
                 *self
             }
 
+            #[inline]
             fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
                 ord_item
             }
@@ -534,10 +538,12 @@ macro_rules! impl_to_total_ord_wrapped {
             type TotalOrdItem = TotalOrdWrap<$T>;
             type SourceItem = $T;
 
+            #[inline]
             fn to_total_ord(&self) -> Self::TotalOrdItem {
                 TotalOrdWrap(self.clone())
             }
 
+            #[inline]
             fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
                 ord_item.0
             }
@@ -557,10 +563,12 @@ impl<T: Copy> ToTotalOrd for Option<T> {
     type TotalOrdItem = TotalOrdWrap<Option<T>>;
     type SourceItem = Option<T>;
 
+    #[inline]
     fn to_total_ord(&self) -> Self::TotalOrdItem {
         TotalOrdWrap(*self)
     }
 
+    #[inline]
     fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
         ord_item.0
     }
@@ -570,10 +578,12 @@ impl<T: ToTotalOrd> ToTotalOrd for &T {
     type TotalOrdItem = T::TotalOrdItem;
     type SourceItem = T::SourceItem;
 
+    #[inline]
     fn to_total_ord(&self) -> Self::TotalOrdItem {
         (*self).to_total_ord()
     }
 
+    #[inline]
     fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
         T::peel_total_ord(ord_item)
     }
@@ -583,10 +593,12 @@ impl<'a> ToTotalOrd for BytesHash<'a> {
     type TotalOrdItem = BytesHash<'a>;
     type SourceItem = BytesHash<'a>;
 
+    #[inline]
     fn to_total_ord(&self) -> Self::TotalOrdItem {
         *self
     }
 
+    #[inline]
     fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
         ord_item
     }

--- a/crates/polars-utils/src/total_ord.rs
+++ b/crates/polars-utils/src/total_ord.rs
@@ -464,3 +464,130 @@ impl<'a> TotalEq for BytesHash<'a> {
         self == other
     }
 }
+
+/// This elides creating a [`TotalOrdWrap`] for types that don't need it.
+pub trait ToTotalOrd {
+    type TotalOrdItem;
+    type SourceItem;
+
+    fn to_total_ord(&self) -> Self::TotalOrdItem;
+
+    fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem;
+}
+
+macro_rules! impl_to_total_ord_identity {
+    ($T: ty) => {
+        impl ToTotalOrd for $T {
+            type TotalOrdItem = $T;
+            type SourceItem = $T;
+
+            fn to_total_ord(&self) -> Self::TotalOrdItem {
+                self.clone()
+            }
+
+            fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
+                ord_item
+            }
+        }
+    };
+}
+
+impl_to_total_ord_identity!(bool);
+impl_to_total_ord_identity!(u8);
+impl_to_total_ord_identity!(u16);
+impl_to_total_ord_identity!(u32);
+impl_to_total_ord_identity!(u64);
+impl_to_total_ord_identity!(u128);
+impl_to_total_ord_identity!(usize);
+impl_to_total_ord_identity!(i8);
+impl_to_total_ord_identity!(i16);
+impl_to_total_ord_identity!(i32);
+impl_to_total_ord_identity!(i64);
+impl_to_total_ord_identity!(i128);
+impl_to_total_ord_identity!(isize);
+impl_to_total_ord_identity!(char);
+impl_to_total_ord_identity!(String);
+
+macro_rules! impl_to_total_ord_lifetimed_ref_identity {
+    ($T: ty) => {
+        impl<'a> ToTotalOrd for &'a $T {
+            type TotalOrdItem = &'a $T;
+            type SourceItem = &'a $T;
+
+            fn to_total_ord(&self) -> Self::TotalOrdItem {
+                *self
+            }
+
+            fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
+                ord_item
+            }
+        }
+    };
+}
+
+impl_to_total_ord_lifetimed_ref_identity!(str);
+impl_to_total_ord_lifetimed_ref_identity!([u8]);
+
+macro_rules! impl_to_total_ord_wrapped {
+    ($T: ty) => {
+        impl ToTotalOrd for $T {
+            type TotalOrdItem = TotalOrdWrap<$T>;
+            type SourceItem = $T;
+
+            fn to_total_ord(&self) -> Self::TotalOrdItem {
+                TotalOrdWrap(self.clone())
+            }
+
+            fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
+                ord_item.0
+            }
+        }
+    };
+}
+
+impl_to_total_ord_wrapped!(f32);
+impl_to_total_ord_wrapped!(f64);
+
+/// This is safe without needing to map the option value to TotalOrdWrap, since
+/// for example:
+/// `TotalOrdWrap<Option<T>>` implements `Eq + Hash`, iff:
+/// `Option<T>` implements `TotalEq + TotalHash`, iff:
+/// `T` implements `TotalEq + TotalHash`
+impl<T: Copy> ToTotalOrd for Option<T> {
+    type TotalOrdItem = TotalOrdWrap<Option<T>>;
+    type SourceItem = Option<T>;
+
+    fn to_total_ord(&self) -> Self::TotalOrdItem {
+        TotalOrdWrap(*self)
+    }
+
+    fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
+        ord_item.0
+    }
+}
+
+impl<'a> ToTotalOrd for BytesHash<'a> {
+    type TotalOrdItem = BytesHash<'a>;
+    type SourceItem = BytesHash<'a>;
+
+    fn to_total_ord(&self) -> Self::TotalOrdItem {
+        *self
+    }
+
+    fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
+        ord_item
+    }
+}
+
+impl<T: ToTotalOrd> ToTotalOrd for &T {
+    type TotalOrdItem = T::TotalOrdItem;
+    type SourceItem = T::SourceItem;
+
+    fn to_total_ord(&self) -> Self::TotalOrdItem {
+        (*self).to_total_ord()
+    }
+
+    fn peel_total_ord(ord_item: Self::TotalOrdItem) -> Self::SourceItem {
+        T::peel_total_ord(ord_item)
+    }
+}

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1478,7 +1478,7 @@ def test_reproducible_hash_with_seeds() -> None:
     if platform.mac_ver()[-1] != "arm64":
         expected = pl.Series(
             "s",
-            [8823051245921001677, 6344663067812082469, 7528667241828618484],
+            [15801072432137883943, 6344663067812082469, 9604537446374444741],
             dtype=pl.UInt64,
         )
         result = df.hash_rows(*seeds)


### PR DESCRIPTION
This should be a slight perf improvement for hashing primitive types, but more importantly will revert the change in the hash output values for integer types introduced by https://github.com/pola-rs/polars/pull/14617 (see https://github.com/pola-rs/polars/pull/14617#issuecomment-1960587029).

<details>
<summary>Benchmark</summary>

```
running 1 test
n_iterations: 70000000
(10 as i32) hash_one(TotalOrdWrap(x)) vs hash_one(x.to_total_ord()): 2449ms vs 2157ms
(10 as i32) hash_one(TotalOrdWrap(x)) vs hash_one(x.to_total_ord()): 2411ms vs 2151ms
(10 as i32) hash_one(TotalOrdWrap(x)) vs hash_one(x.to_total_ord()): 2400ms vs 2122ms
(10 as i32) hash_one(TotalOrdWrap(x)) vs hash_one(x.to_total_ord()): 2437ms vs 2145ms
(10 as i32) hash_one(TotalOrdWrap(x)) vs hash_one(x.to_total_ord()): 2440ms vs 2166ms
(Some(10) as Option<i32>) hash_one(x) vs hash_one(x.to_total_ord()): 2916ms vs 3357ms
(Some(10) as Option<i32>) hash_one(x) vs hash_one(x.to_total_ord()): 3051ms vs 3350ms
(Some(10) as Option<i32>) hash_one(x) vs hash_one(x.to_total_ord()): 2921ms vs 3279ms
(Some(10) as Option<i32>) hash_one(x) vs hash_one(x.to_total_ord()): 2961ms vs 3262ms
(Some(10) as Option<i32>) hash_one(x) vs hash_one(x.to_total_ord()): 2989ms vs 3253ms
(None as Option<i32>) hash_one(x) vs hash_one(x.to_total_ord()): 2399ms vs 2584ms
test total_ord::test::test has been running for over 60 seconds
(None as Option<i32>) hash_one(x) vs hash_one(x.to_total_ord()): 2432ms vs 2665ms
(None as Option<i32>) hash_one(x) vs hash_one(x.to_total_ord()): 2403ms vs 2665ms
(None as Option<i32>) hash_one(x) vs hash_one(x.to_total_ord()): 2425ms vs 2578ms
(None as Option<i32>) hash_one(x) vs hash_one(x.to_total_ord()): 2411ms vs 2681ms
```
```rust
mod test {
    #[test]
    fn test() {
        use std::time::SystemTime;

        use super::*;
        let rs = ahash::RandomState::new();

        let n_iterations = 70_000_000;

        println!("n_iterations: {}", n_iterations);

        fn time_it<F: Fn() -> T, T>(f: F, n: u32) -> u128 {
            let start = SystemTime::now();
            for _ in 0..n {
                f();
            }
            let end = SystemTime::now();
            let duration = end.duration_since(start).unwrap();
            return duration.as_millis();
        }

        let x: i32 = 10;

        for _ in 0..5 {
            let hash_one_wrap_t = time_it(|| rs.clone().hash_one(TotalOrdWrap(x)), n_iterations);
            let hash_one_to_tot_t = time_it(|| rs.clone().hash_one(x.to_total_ord()), n_iterations);
            println!(
                "(10 as i32) hash_one(TotalOrdWrap(x)) vs hash_one(x.to_total_ord()): {}ms vs {}ms",
                hash_one_wrap_t, hash_one_to_tot_t
            );
        }

        let x: Option<i32> = Some(10);

        for _ in 0..5 {
            let hash_one_t = time_it(|| rs.clone().hash_one(x), n_iterations);
            let hash_one_to_tot_t = time_it(|| rs.clone().hash_one(x.to_total_ord()), n_iterations);
            println!(
                "(Some(10) as Option<i32>) hash_one(x) vs hash_one(x.to_total_ord()): {}ms vs {}ms",
                hash_one_t, hash_one_to_tot_t
            );
        }

        let x: Option<i32> = None;

        for _ in 0..5 {
            let hash_one_t = time_it(|| rs.clone().hash_one(x), n_iterations);
            let hash_one_to_tot_t = time_it(|| rs.clone().hash_one(x.to_total_ord()), n_iterations);
            println!(
                "(None as Option<i32>) hash_one(x) vs hash_one(x.to_total_ord()): {}ms vs {}ms",
                hash_one_t, hash_one_to_tot_t
            );
        }
    }
}
```
</details>