### PR TITLE
refactor(python): Avoid unnecessary cast in Series constructor

### DIFF
--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -597,7 +597,7 @@ def sequence_to_pyseries(
                 return PySeries.new_object(name, values, strict)
             if dtype:
                 srs = sequence_from_any_value_and_dtype_or_object(name, values, dtype)
-                if not dtype.is_(srs.dtype()):
+                if dtype != srs.dtype():
                     srs = srs.cast(dtype, strict=False)
                 return srs
             return sequence_from_any_value_or_object(name, values)


### PR DESCRIPTION
By requiring an exact dtype match we could end up in this branch when it's not required. Example:

```python
from datetime import datetime
import polars as pl

df = pl.DataFrame({"a": [[datetime(1990, 1, 1)]]}, schema={"a": pl.List(pl.Datetime)})
```

We should just use the equality operator here.