### PR TITLE
fix: Only push predicates depending on the subset columns past `unique()`

### DIFF
--- a/crates/polars-plan/src/logical_plan/format.rs
+++ b/crates/polars-plan/src/logical_plan/format.rs
@@ -202,7 +202,11 @@ impl LogicalPlan {
                 input._format(f, sub_indent)
             },
             Distinct { input, options } => {
-                write!(f, "{:indent$}UNIQUE BY {:?}", "", options.subset)?;
+                write!(
+                    f,
+                    "{:indent$}UNIQUE[maintain_order: {:?}, keep_strategy: {:?}] BY {:?}",
+                    "", options.maintain_order, options.keep_strategy, options.subset
+                )?;
                 input._format(f, sub_indent)
             },
             Slice { input, offset, len } => {

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/mod.rs
@@ -406,12 +406,13 @@ impl<'a> PredicatePushDown<'a> {
             } => {
                 if let Some(ref subset) = options.subset {
                     // Predicates on the subset can pass.
-                    let mut names_set = PlHashSet::<Arc<str>>::with_capacity(subset.len());
+                    let subset = subset.clone();
+                    let mut names_set = PlHashSet::<&str>::with_capacity(subset.len());
                     for name in subset.iter() {
-                        names_set.insert(Arc::<str>::from(&**name));
+                        names_set.insert(name.as_str());
                     };
 
-                    let condition = |name: Arc<str>| !names_set.contains(&name);
+                    let condition = |name: Arc<str>| !names_set.contains(name.as_ref());
                     let local_predicates =
                         transfer_to_local_by_name(expr_arena, &mut acc_predicates, condition);
 

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
@@ -116,7 +116,8 @@ pub(super) fn predicate_is_sort_boundary(node: Node, expr_arena: &Arena<AExpr>) 
 }
 
 /// Transfer a predicate from `acc_predicates` that will be pushed down
-/// to a local_predicates vec based on a condition.
+/// to a local_predicates vec based on a condition on the predicates' column
+/// names.
 pub(super) fn transfer_to_local_by_name<F>(
     expr_arena: &Arena<AExpr>,
     acc_predicates: &mut PlHashMap<Arc<str>, Node>,

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
@@ -133,7 +133,7 @@ where
         for name in root_names {
             if condition(name) {
                 remove_keys.push(key.clone());
-                continue;
+                break;
             }
         }
     }

--- a/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/predicate_pushdown/utils.rs
@@ -115,9 +115,9 @@ pub(super) fn predicate_is_sort_boundary(node: Node, expr_arena: &Arena<AExpr>) 
     has_aexpr(node, expr_arena, matches)
 }
 
-/// Transfer a predicate from `acc_predicates` that will be pushed down
-/// to a local_predicates vec based on a condition on the predicates' column
-/// names.
+/// Evaluates a condition on the column name inputs of every predicate, where if
+/// the condition evaluates to true on any column name the predicate is
+/// transferred to local.
 pub(super) fn transfer_to_local_by_name<F>(
     expr_arena: &Arena<AExpr>,
     acc_predicates: &mut PlHashMap<Arc<str>, Node>,

--- a/crates/polars-plan/src/logical_plan/tree_format.rs
+++ b/crates/polars-plan/src/logical_plan/tree_format.rs
@@ -260,7 +260,13 @@ impl<'a> TreeFmtNode<'a> {
                     .collect(),
             ),
             NL(h, Distinct { input, options }) => ND(
-                wh(h, &format!("UNIQUE BY {:?}", options.subset)),
+                wh(
+                    h,
+                    &format!(
+                        "UNIQUE[maintain_order: {:?}, keep_strategy: {:?}] BY {:?}",
+                        options.maintain_order, options.keep_strategy, options.subset
+                    ),
+                ),
                 vec![NL(None, input)],
             ),
             NL(h, LogicalPlan::Slice { input, offset, len }) => ND(


### PR DESCRIPTION
Fix https://github.com/pola-rs/polars/issues/14595.

Also improves the display in `explain()` to show `maintain_order` and `keep_strategy`, as these are useful to know when debugging.