### PR TITLE
feat: let `rolling` accept `index_column` of type UInt32 or UInt64 

### DIFF
--- a/crates/polars-time/src/group_by/dynamic.rs
+++ b/crates/polars-time/src/group_by/dynamic.rs
@@ -150,6 +150,20 @@ impl Wrap<&DataFrame> {
                 TimeUnit::Milliseconds,
                 None,
             ),
+            UInt32 => {
+                let time_type = Datetime(TimeUnit::Nanoseconds, None);
+                let dt = time.cast(&Int64).unwrap().cast(&time_type).unwrap();
+                let (out, by, gt) = self.impl_group_by_rolling(
+                    dt,
+                    by,
+                    options,
+                    TimeUnit::Nanoseconds,
+                    None,
+                    &time_type,
+                )?;
+                let out = out.cast(&Int64).unwrap().cast(&UInt32).unwrap();
+                return Ok((out, by, gt));
+            },
             Int32 => {
                 let time_type = Datetime(TimeUnit::Nanoseconds, None);
                 let dt = time.cast(&Int64).unwrap().cast(&time_type).unwrap();

--- a/crates/polars-time/src/group_by/dynamic.rs
+++ b/crates/polars-time/src/group_by/dynamic.rs
@@ -150,32 +150,18 @@ impl Wrap<&DataFrame> {
                 TimeUnit::Milliseconds,
                 None,
             ),
-            UInt32 => {
-                let time_type = Datetime(TimeUnit::Nanoseconds, None);
-                let dt = time.cast(&Int64).unwrap().cast(&time_type).unwrap();
+            UInt32 | UInt64 | Int32 => {
+                let time_type_dt = Datetime(TimeUnit::Nanoseconds, None);
+                let dt = time.cast(&Int64).unwrap().cast(&time_type_dt).unwrap();
                 let (out, by, gt) = self.impl_group_by_rolling(
                     dt,
                     by,
                     options,
                     TimeUnit::Nanoseconds,
                     None,
-                    &time_type,
+                    &time_type_dt,
                 )?;
-                let out = out.cast(&Int64).unwrap().cast(&UInt32).unwrap();
-                return Ok((out, by, gt));
-            },
-            Int32 => {
-                let time_type = Datetime(TimeUnit::Nanoseconds, None);
-                let dt = time.cast(&Int64).unwrap().cast(&time_type).unwrap();
-                let (out, by, gt) = self.impl_group_by_rolling(
-                    dt,
-                    by,
-                    options,
-                    TimeUnit::Nanoseconds,
-                    None,
-                    &time_type,
-                )?;
-                let out = out.cast(&Int64).unwrap().cast(&Int32).unwrap();
+                let out = out.cast(&Int64).unwrap().cast(time_type).unwrap();
                 return Ok((out, by, gt));
             },
             Int64 => {

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5494,7 +5494,7 @@ class DataFrame:
         check_sorted: bool = True,
     ) -> RollingGroupBy:
         """
-        Create rolling groups based on a time, Int32, or Int64 column.
+        Create rolling groups based on a temporal or integer column.
 
         Different from a `group_by_dynamic` the windows are now determined by the
         individual values and are not of constant intervals. For constant intervals use
@@ -5552,8 +5552,8 @@ class DataFrame:
             then it must be sorted in ascending order within each group).
 
             In case of a rolling operation on indices, dtype needs to be one of
-            {Int32, Int64}. Note that Int32 gets temporarily cast to Int64, so if
-            performance matters use an Int64 column.
+            {UInt32, UInt64, Int32, Int64}. Note that the first three get temporarily
+            cast to Int64, so if performance matters use an Int64 column.
         period
             length of the window - must be non-negative
         offset

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3299,7 +3299,7 @@ class Expr:
         check_sorted: bool = True,
     ) -> Self:
         """
-        Create rolling groups based on a time, Int32, or Int64 column.
+        Create rolling groups based on a temporal or integer column.
 
         If you have a time series `<t_0, t_1, ..., t_n>`, then by default the
         windows created will be
@@ -3351,8 +3351,8 @@ class Expr:
             Often of type Date/Datetime.
             This column must be sorted in ascending order.
             In case of a rolling group by on indices, dtype needs to be one of
-            {Int32, Int64}. Note that Int32 gets temporarily cast to Int64, so if
-            performance matters use an Int64 column.
+            {UInt32, UInt64, Int32, Int64}. Note that the first three get temporarily
+            cast to Int64, so if performance matters use an Int64 column.
         period
             length of the window - must be non-negative
         offset

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3233,7 +3233,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         check_sorted: bool = True,
     ) -> LazyGroupBy:
         """
-        Create rolling groups based on a time, Int32, or Int64 column.
+        Create rolling groups based on a temporal or integer column.
 
         Different from a `dynamic_group_by` the windows are now determined by the
         individual values and are not of constant intervals. For constant intervals
@@ -3291,8 +3291,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             then it must be sorted in ascending order within each group).
 
             In case of a rolling group by on indices, dtype needs to be one of
-            {Int32, Int64}. Note that Int32 gets temporarily cast to Int64, so if
-            performance matters use an Int64 column.
+            {UInt32, UInt64, Int32, Int64}. Note that the first three get temporarily
+            cast to Int64, so if performance matters use an Int64 column.
         period
             length of the window - must be non-negative
         offset

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -32,12 +32,17 @@ def test_rolling_group_by_overlapping_groups(dtype: PolarsIntegerType) -> None:
 
 
 @pytest.mark.parametrize("input", [[pl.col("b").sum()], pl.col("b").sum()])
-def test_rolling_agg_input_types(input: Any) -> None:
-    df = pl.LazyFrame({"index_column": [0, 1, 2, 3], "b": [1, 3, 1, 2]}).set_sorted(
-        "index_column"
-    )
+@pytest.mark.parametrize("dtype", [pl.UInt32, pl.UInt64, pl.Int32, pl.Int64])
+def test_rolling_agg_input_types(input: Any, dtype: PolarsIntegerType) -> None:
+    df = pl.LazyFrame(
+        {"index_column": [0, 1, 2, 3], "b": [1, 3, 1, 2]},
+        schema_overrides={"index_column": dtype},
+    ).set_sorted("index_column")
     result = df.rolling(index_column="index_column", period="2i").agg(input)
-    expected = pl.LazyFrame({"index_column": [0, 1, 2, 3], "b": [1, 4, 4, 3]})
+    expected = pl.LazyFrame(
+        {"index_column": [0, 1, 2, 3], "b": [1, 4, 4, 3]},
+        schema_overrides={"index_column": dtype},
+    )
     assert_frame_equal(result, expected)
 
 

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -9,17 +9,18 @@ import polars as pl
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
-    from polars.type_aliases import ClosedInterval
+    from polars.type_aliases import ClosedInterval, PolarsIntegerType
 
 
-def test_rolling_group_by_overlapping_groups() -> None:
+@pytest.mark.parametrize("dtype", [pl.UInt32, pl.UInt64, pl.Int32, pl.Int64])
+def test_rolling_group_by_overlapping_groups(dtype: PolarsIntegerType) -> None:
     # this first aggregates overlapping groups so they cannot be naively flattened
     df = pl.DataFrame({"a": [41, 60, 37, 51, 52, 39, 40]})
 
     assert_series_equal(
         (
             df.with_row_index()
-            .with_columns(pl.col("index").cast(pl.Int32))
+            .with_columns(pl.col("index").cast(dtype))
             .rolling(index_column="index", period="5i")
             .agg(
                 # trigger the apply on the expression engine


### PR DESCRIPTION
closes #7360

This one's been bugging me for a while, not being able to just do `df.with_row_index().rolling("index", period="2i")` and instead having to do `df.with_row_index().rolling(pl.col("index").cast(pl.Int64), period="2i")`

The result index should be the same as the input, so the cast back to an unsigned integer should always work without surprises