### PR TITLE
fix: Reading RLE_DICTIONARY-encoded parquet incorrectly coalesced NULL to empty string in some cases

### DIFF
--- a/crates/polars-parquet/src/arrow/read/deserialize/binary/utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/binary/utils.rs
@@ -80,6 +80,11 @@ impl<'a, O: Offset> Pushable<&'a [u8]> for Binary<O> {
         assert_eq!(value.len(), 0);
         self.extend_constant(additional)
     }
+
+    #[inline]
+    fn extend_null_constant(&mut self, additional: usize) {
+        self.extend_constant(additional)
+    }
 }
 
 #[derive(Debug)]

--- a/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/fixed_size_binary/utils.rs
@@ -55,4 +55,9 @@ impl<'a> Pushable<&'a [u8]> for FixedSizeBinary {
     fn len(&self) -> usize {
         self.values.len() / self.size
     }
+
+    #[inline]
+    fn extend_null_constant(&mut self, additional: usize) {
+        self.extend_constant(additional)
+    }
 }

--- a/crates/polars-parquet/src/arrow/read/deserialize/utils.rs
+++ b/crates/polars-parquet/src/arrow/read/deserialize/utils.rs
@@ -227,7 +227,7 @@ impl<'a> PageValidity<'a> for OptionalPageValidity<'a> {
     }
 }
 
-fn reserve_pushable_and_validity<'a, T: Default, P: Pushable<T>>(
+fn reserve_pushable_and_validity<'a, T, P: Pushable<T>>(
     validity: &mut MutableBitmap,
     page_validity: &'a mut dyn PageValidity,
     limit: Option<usize>,
@@ -263,7 +263,7 @@ fn reserve_pushable_and_validity<'a, T: Default, P: Pushable<T>>(
 }
 
 /// Extends a [`Pushable`] from an iterator of non-null values and an hybrid-rle decoder
-pub(super) fn extend_from_decoder<T: Default, P: Pushable<T>, I: Iterator<Item = T>>(
+pub(super) fn extend_from_decoder<T, P: Pushable<T>, I: Iterator<Item = T>>(
     validity: &mut MutableBitmap,
     page_validity: &mut dyn PageValidity,
     limit: Option<usize>,
@@ -300,7 +300,7 @@ pub(super) fn extend_from_decoder<T: Default, P: Pushable<T>, I: Iterator<Item =
                         pushable.push(v)
                     }
                 } else {
-                    pushable.extend_constant(length, T::default());
+                    pushable.extend_null_constant(length);
                 }
             },
             FilteredHybridEncoded::Skipped(valids) => for _ in values_iter.by_ref().take(valids) {},

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -719,3 +719,14 @@ def test_parquet_rle_14333() -> None:
     pq.write_table(table, f, data_page_version="2.0")
     f.seek(0)
     assert pl.read_parquet(f)["a"].to_list() == vals
+
+
+def test_parquet_rle_null_binary_read_14638() -> None:
+    df = pl.DataFrame({"x": [None]}, schema={"x": pl.String})
+
+    f = io.BytesIO()
+    df.write_parquet(f, use_pyarrow=True)
+    f.seek(0)
+    assert "RLE_DICTIONARY" in pq.read_metadata(f).row_group(0).column(0).encodings
+    f.seek(0)
+    assert_frame_equal(df, pl.read_parquet(f))


### PR DESCRIPTION
Fix https://github.com/pola-rs/polars/issues/14638.