### PR TITLE
fix(python): Disallow all-null/empty Series creation with empty Enum

### DIFF
--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -304,6 +304,7 @@ impl Series {
         if !dtype.is_known() || (dtype.is_primitive() && dtype == self.dtype()) {
             return Ok(self.clone());
         }
+        #[cfg(feature = "dtype-categorical")]
         if let DataType::Enum(None, _) = dtype {
             polars_bail!(ComputeError: "can not cast / initialize Enum without categories present")
         }

--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -304,12 +304,14 @@ impl Series {
         if !dtype.is_known() || (dtype.is_primitive() && dtype == self.dtype()) {
             return Ok(self.clone());
         }
-        let ret = self.0.cast(dtype);
+        if let DataType::Enum(None, _) = dtype {
+            polars_bail!(ComputeError: "can not cast / initialize Enum without categories present")
+        }
         let len = self.len();
         if self.null_count() == len {
             return Ok(Series::full_null(self.name(), len, dtype));
         }
-        ret
+        self.0.cast(dtype)
     }
 
     /// Cast from physical to logical types without any checks on the validity of the cast.

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -203,6 +203,14 @@ def test_series_init_uninstantiated_enum() -> None:
         pl.Series(["a", "b", "a"], dtype=pl.Enum)
 
 
+def test_empty_series_init_uninstantiated_enum() -> None:
+    with pytest.raises(
+        pl.ComputeError,
+        match="can not cast / initialize Enum without categories present",
+    ):
+        pl.Series([], dtype=pl.Enum)
+
+
 @pytest.mark.parametrize(
     ("op", "expected"),
     [


### PR DESCRIPTION
Resolves #14665.

The error arose from logic introduced in #5826 well before we even had `Enum` dtypes. This logic said "if we're casting an all-null series to another dtype, it is allowed no matter the dtype." The problem is that we now have certain dtypes that *cannot* be made into Series, one of which (and I think the only?) is `pl.Enum` without categories:

```python
>>> import polars as pl
>>> pl.Series(["a"], dtype=pl.Enum)  # error
```
But with an all-null series, it worked when it shouldn't have:
```python
>>> pl.Series([], dtype=pl.Enum)  # shouldn't work, but does
```

The reason is because the second path goes through `CategoricalChunked::full_null()` which does not return a `Result` but a `Series`, and so the invalid `Enum` dtype silently passes.

I also moved the actual `cast` after the `full_null` since the result was otherwise not used and therefore wasted.

With this PR, we get:

```python
>>> pl.Series([], dtype=pl.Enum)
polars.exceptions.ComputeError: can not cast / initialize Enum without categories present
```