### PR TITLE
fix(python): handle init from empty pyarrow `RecordBatch`

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -588,9 +588,14 @@ def from_arrow(
         3
     ]
     """  # noqa: W505
-    if isinstance(data, pa.Table):
+    if isinstance(data, pa.RecordBatch):
+        data = [data]
+    elif isinstance(data, pa.Table):
         return pl.DataFrame._from_arrow(
-            data=data, rechunk=rechunk, schema=schema, schema_overrides=schema_overrides
+            data=data,
+            rechunk=rechunk,
+            schema=schema,
+            schema_overrides=schema_overrides,
         )
     elif isinstance(data, (pa.Array, pa.ChunkedArray)):
         name = getattr(data, "_name", "") or ""
@@ -606,8 +611,6 @@ def from_arrow(
             schema_overrides=schema_overrides,
         )
 
-    if isinstance(data, pa.RecordBatch):
-        data = [data]
     if isinstance(data, Iterable):
         return pl.DataFrame._from_arrow(
             data=pa.Table.from_batches(

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -258,6 +258,15 @@ def test_from_arrow(monkeypatch: Any) -> None:
         assert df.schema == expected_schema
         assert df.rows() == expected_data
 
+    # record batches (inc. empty)
+    for b, n_expected in (
+        (record_batches[0], 1),
+        (record_batches[0][:0], 0),
+    ):
+        df = cast(pl.DataFrame, pl.from_arrow(b))
+        assert df.schema == expected_schema
+        assert df.rows() == expected_data[:n_expected]
+
     empty_tbl = tbl[:0]  # no rows
     df = cast(pl.DataFrame, pl.from_arrow(empty_tbl))
     assert df.schema == expected_schema


### PR DESCRIPTION
Closes  #14659.

Fixes loss of schema on init from valid-but-empty single `RecordBatch` data.
Also adds the missing test coverage for this case.