### PR TITLE
fix: Block slice pushdown past non-literal projections or when the projection doesn't contain any columns from the input

### DIFF
--- a/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -1,5 +1,6 @@
 use polars_core::prelude::*;
 
+use crate::logical_plan::projection_expr::ProjectionExprs;
 use crate::prelude::*;
 
 pub(super) struct SlicePushDown {
@@ -11,6 +12,49 @@ pub(super) struct SlicePushDown {
 struct State {
     offset: i64,
     len: IdxSize,
+}
+
+/// Can push down slice when:
+/// * all projections are elementwise
+/// * at least 1 projection is based on a column (for height broadcast)
+/// * projections not based on any column project as scalars
+///
+/// Returns (all_elementwise, all_elementwise_and_any_expr_has_column)
+fn can_pushdown_slice_past_projections(
+    exprs: &ProjectionExprs,
+    arena: &Arena<AExpr>,
+) -> (bool, bool) {
+    let mut all_elementwise_and_any_expr_has_column = false;
+    for node in exprs.iter() {
+        // `select(c = Literal([1, 2, 3])).slice(0, 0)` must block slice pushdown,
+        // because `c` projects to a height independent from the input height. We check
+        // this by observing that `c` does not have any columns in its input notes.
+        //
+        // TODO: Simply checking that a column node is present does not handle e.g.:
+        // `select(c = Literal([1, 2, 3]).is_in(col(a)))`, for functions like `is_in`,
+        // `str.contains`, `str.contains_many` etc. - observe a column node is present
+        // but the output height is not dependent on it.
+        let mut has_column = false;
+        let mut literals_all_scalar = true;
+        let is_elementwise = arena.iter(*node).all(|(_node, ae)| {
+            has_column |= matches!(ae, AExpr::Column(_));
+            literals_all_scalar &= if let AExpr::Literal(v) = ae {
+                v.projects_as_scalar()
+            } else {
+                true
+            };
+            single_aexpr_is_elementwise(ae)
+        });
+
+        // If there is no column then all literals must be scalar
+        if !is_elementwise || !(has_column || literals_all_scalar) {
+            return (false, false);
+        }
+
+        all_elementwise_and_any_expr_has_column |= has_column
+    }
+
+    (true, all_elementwise_and_any_expr_has_column)
 }
 
 impl SlicePushDown {
@@ -322,10 +366,7 @@ impl SlicePushDown {
             }
             // there is state, inspect the projection to determine how to deal with it
             (Projection {input, expr, schema, options}, Some(_)) => {
-                // The slice operation may only pass on simple projections. col("foo").alias("bar")
-                if expr.iter().all(|root|  {
-                    aexpr_is_elementwise_and_has_column(*root, expr_arena)
-                }) {
+                if can_pushdown_slice_past_projections(&expr, expr_arena).1 {
                     let lp = Projection {input, expr, schema, options};
                     self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
                 }
@@ -335,12 +376,9 @@ impl SlicePushDown {
                     self.no_pushdown_restart_opt(lp, state, lp_arena, expr_arena)
                 }
             }
-            // this is copied from `Projection`
             (HStack {input, exprs, schema, options}, _) => {
-                // The slice operation may only pass on simple projections. col("foo").alias("bar")
-                if exprs.iter().all(|root|  {
-                    aexpr_is_elementwise_and_has_column(*root, expr_arena)
-                }) {
+                // The input must also have columns for HStack, we check this using schema length.
+                if schema.len() > exprs.len() && can_pushdown_slice_past_projections(&exprs, expr_arena).0 {
                     let lp = HStack {input, exprs, schema, options};
                     self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
                 }

--- a/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/slice_pushdown_lp.rs
@@ -324,7 +324,7 @@ impl SlicePushDown {
             (Projection {input, expr, schema, options}, Some(_)) => {
                 // The slice operation may only pass on simple projections. col("foo").alias("bar")
                 if expr.iter().all(|root|  {
-                    aexpr_is_elementwise(*root, expr_arena)
+                    aexpr_is_elementwise_and_has_column(*root, expr_arena)
                 }) {
                     let lp = Projection {input, expr, schema, options};
                     self.pushdown_and_continue(lp, state, lp_arena, expr_arena)
@@ -339,7 +339,7 @@ impl SlicePushDown {
             (HStack {input, exprs, schema, options}, _) => {
                 // The slice operation may only pass on simple projections. col("foo").alias("bar")
                 if exprs.iter().all(|root|  {
-                    aexpr_is_elementwise(*root, expr_arena)
+                    aexpr_is_elementwise_and_has_column(*root, expr_arena)
                 }) {
                     let lp = HStack {input, exprs, schema, options};
                     self.pushdown_and_continue(lp, state, lp_arena, expr_arena)

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -98,7 +98,7 @@ fn single_aexpr_is_elementwise(ae: &AExpr) -> bool {
 /// because `c` projects to a height independent from the input height. We check
 /// this by observing that `c` does not have any columns in its input notes.
 ///
-/// TODO: Simply checking that a column node is present will does not handle e.g.:
+/// TODO: Simply checking that a column node is present does not handle e.g.:
 /// `select(c = Literal([1, 2, 3]).is_in(col(a)))`, for functions like `is_in`,
 /// `str.contains`, `str.contains_many` etc. - observe a column node is present
 /// but the output height is not dependent on it.

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -79,7 +79,7 @@ pub(crate) fn aexpr_is_simple_projection(current_node: Node, arena: &Arena<AExpr
         .all(|(_node, e)| matches!(e, AExpr::Column(_) | AExpr::Alias(_, _)))
 }
 
-fn single_aexpr_is_elementwise(ae: &AExpr) -> bool {
+pub(crate) fn single_aexpr_is_elementwise(ae: &AExpr) -> bool {
     use AExpr::*;
     match ae {
         AnonymousFunction { options, .. } | Function { options, .. } => {
@@ -90,27 +90,6 @@ fn single_aexpr_is_elementwise(ae: &AExpr) -> bool {
         },
         _ => false,
     }
-}
-
-/// Ensures an expr has a column root. Used by slice pushdown, e.g.:
-///
-/// `select(c = Literal([1, 2, 3])).slice(0, 0)` must block slice pushdown,
-/// because `c` projects to a height independent from the input height. We check
-/// this by observing that `c` does not have any columns in its input notes.
-///
-/// TODO: Simply checking that a column node is present does not handle e.g.:
-/// `select(c = Literal([1, 2, 3]).is_in(col(a)))`, for functions like `is_in`,
-/// `str.contains`, `str.contains_many` etc. - observe a column node is present
-/// but the output height is not dependent on it.
-pub(crate) fn aexpr_is_elementwise_and_has_column(
-    current_node: Node,
-    arena: &Arena<AExpr>,
-) -> bool {
-    let mut has_column = false;
-    arena.iter(current_node).all(|(_node, ae)| {
-        has_column |= matches!(ae, AExpr::Column(_));
-        single_aexpr_is_elementwise(ae)
-    }) && has_column
 }
 
 pub fn has_aexpr<F>(current_node: Node, arena: &Arena<AExpr>, matches: F) -> bool

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -168,3 +168,17 @@ def test_slice_pushdown_set_sorted() -> None:
     plan = ldf.explain()
     # check the set sorted is above slice
     assert plan.index("set_sorted") < plan.index("SLICE")
+
+
+def test_slice_pushdown_literal_projection_14349() -> None:
+    expect = pl.DataFrame({"a": [0, 1, 2, 3, 4], "b": [10, 11, 12, 13, 14]})
+    out = (
+        pl.select(a=pl.int_range(10))
+        .lazy()
+        .with_columns(b=pl.int_range(10, 20, eager=True))
+        .head(5)
+        .collect()
+    )
+    assert_frame_equal(expect, out)
+
+    assert pl.LazyFrame().select(x=1).head(0).collect().height == 0


### PR DESCRIPTION
Fix https://github.com/pola-rs/polars/issues/14349
