### PR TITLE
chore(python): Fix `make requirements` when conda environment is active

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -87,9 +87,7 @@ jobs:
         env:
           RUSTFLAGS: -C embed-bitcode -D warnings
         working-directory: py-polars
-        run: |
-          source activate
-          maturin develop --release -- -C codegen-units=8 -C lto=thin -C target-cpu=native
+        run: maturin develop --release -- -C codegen-units=8 -C lto=thin -C target-cpu=native
 
       - name: Run H2O AI database benchmark - on strings
         working-directory: py-polars/tests/benchmark

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -79,9 +79,7 @@ jobs:
         run: cargo test --all-features -p polars --test it
 
       - name: Install Polars
-        run: |
-          source activate
-          maturin develop
+        run: maturin develop
 
       - name: Run Python tests
         run: pytest --cov -n auto --dist loadgroup -m "not benchmark and not docs" --cov-report xml:main.xml

--- a/.github/workflows/docs-global.yml
+++ b/.github/workflows/docs-global.yml
@@ -82,9 +82,7 @@ jobs:
 
       - name: Install Polars
         working-directory: py-polars
-        run: |
-          source activate
-          maturin develop
+        run: maturin develop
 
       - name: Set up Graphviz
         uses: ts-graphviz/setup-graphviz@v2

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -73,9 +73,7 @@ jobs:
           save-if: ${{ github.ref_name == 'main' }}
 
       - name: Install Polars
-        run: |
-          source activate
-          maturin develop
+        run: maturin develop
 
       - name: Run doctests
         if: github.ref_name != 'main' && matrix.python-version == '3.12' && matrix.os == 'ubuntu-latest'

--- a/Makefile
+++ b/Makefile
@@ -19,11 +19,12 @@ FILTER_PIP_WARNINGS=| grep -v "don't match your environment"; test $${PIPESTATUS
 
 .PHONY: requirements
 requirements: .venv  ## Install/refresh Python project requirements
-	$(VENV_BIN)/python -m pip install --upgrade uv
-	$(VENV_BIN)/uv pip install --upgrade -r py-polars/requirements-dev.txt
-	$(VENV_BIN)/uv pip install --upgrade -r py-polars/requirements-lint.txt
-	$(VENV_BIN)/uv pip install --upgrade -r py-polars/docs/requirements-docs.txt
-	$(VENV_BIN)/uv pip install --upgrade -r docs/requirements.txt
+	@unset CONDA_PREFIX \
+	&& $(VENV_BIN)/python -m pip install --upgrade uv \
+	&& $(VENV_BIN)/uv pip install --upgrade -r py-polars/requirements-dev.txt \
+	&& $(VENV_BIN)/uv pip install --upgrade -r py-polars/requirements-lint.txt \
+	&& $(VENV_BIN)/uv pip install --upgrade -r py-polars/docs/requirements-docs.txt \
+	&& $(VENV_BIN)/uv pip install --upgrade -r docs/requirements.txt
 
 .PHONY: build
 build: .venv  ## Compile and install Python Polars for development
@@ -34,7 +35,7 @@ build: .venv  ## Compile and install Python Polars for development
 .PHONY: build-debug-opt
 build-debug-opt: .venv  ## Compile and install Python Polars with minimal optimizations turned on
 	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
-	 && maturin develop -m py-polars/Cargo.toml --profile opt-dev \
+	&& maturin develop -m py-polars/Cargo.toml --profile opt-dev \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-debug-opt-subset

--- a/Makefile
+++ b/Makefile
@@ -28,55 +28,55 @@ requirements: .venv  ## Install/refresh Python project requirements
 
 .PHONY: build
 build: .venv  ## Compile and install Python Polars for development
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	@unset CONDA_PREFIX \
 	&& maturin develop -m py-polars/Cargo.toml \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-debug-opt
 build-debug-opt: .venv  ## Compile and install Python Polars with minimal optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	@unset CONDA_PREFIX \
 	&& maturin develop -m py-polars/Cargo.toml --profile opt-dev \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-debug-opt-subset
 build-debug-opt-subset: .venv  ## Compile and install Python Polars with minimal optimizations turned on and no default features
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	@unset CONDA_PREFIX \
 	&& maturin develop -m py-polars/Cargo.toml --no-default-features --profile opt-dev \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-opt
 build-opt: .venv  ## Compile and install Python Polars with nearly full optimization on and debug assertions turned off, but with debug symbols on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	@unset CONDA_PREFIX \
 	&& maturin develop -m py-polars/Cargo.toml --profile debug-release \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-release
 build-release: .venv  ## Compile and install a faster Python Polars binary with full optimizations
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	@unset CONDA_PREFIX \
 	&& maturin develop -m py-polars/Cargo.toml --release \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-native
 build-native: .venv  ## Same as build, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	@unset CONDA_PREFIX \
 	&& maturin develop -m py-polars/Cargo.toml -- -C target-cpu=native \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-debug-opt-native
 build-debug-opt-native: .venv  ## Same as build-debug-opt, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	@unset CONDA_PREFIX \
 	&& maturin develop -m py-polars/Cargo.toml --profile opt-dev -- -C target-cpu=native \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-opt-native
 build-opt-native: .venv  ## Same as build-opt, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	@unset CONDA_PREFIX \
 	&& maturin develop -m py-polars/Cargo.toml --profile debug-release -- -C target-cpu=native \
 	$(FILTER_PIP_WARNINGS)
 
 .PHONY: build-release-native
 build-release-native: .venv  ## Same as build-release, except with native CPU optimizations turned on
-	@unset CONDA_PREFIX && source $(VENV_BIN)/activate \
+	@unset CONDA_PREFIX \
 	&& maturin develop -m py-polars/Cargo.toml --release -- -C target-cpu=native \
 	$(FILTER_PIP_WARNINGS)
 


### PR DESCRIPTION
Closes #14680

We have to do `unset CONDA_PREFIX` and it works fine.

Unrelated change: looks like `maturin develop` now works without an active virtual environment, so I'm deleting the explicit venv activation.