### PR TITLE
fix: Fix parallel strategy for LazyFrame not being applied

### DIFF
--- a/crates/polars-io/src/parquet/read.rs
+++ b/crates/polars-io/src/parquet/read.rs
@@ -162,6 +162,7 @@ impl<R: MmapBytesReader + 'static> ParquetReader<R> {
             chunk_size,
             self.use_statistics,
             self.hive_partition_columns,
+            self.parallel,
         )
     }
 }
@@ -233,6 +234,7 @@ pub struct ParquetAsyncReader {
     use_statistics: bool,
     hive_partition_columns: Option<Vec<Series>>,
     schema: Option<ArrowSchemaRef>,
+    parallel: ParallelStrategy,
 }
 
 #[cfg(feature = "cloud")]
@@ -253,6 +255,7 @@ impl ParquetAsyncReader {
             use_statistics: true,
             hive_partition_columns: None,
             schema,
+            parallel: Default::default(),
         })
     }
 
@@ -303,6 +306,11 @@ impl ParquetAsyncReader {
         self
     }
 
+    pub fn read_parallel(mut self, parallel: ParallelStrategy) -> Self {
+        self.parallel = parallel;
+        self
+    }
+
     pub async fn batched(mut self, chunk_size: usize) -> PolarsResult<BatchedParquetReader> {
         let metadata = self.reader.get_metadata().await?.clone();
         let schema = match self.schema {
@@ -330,6 +338,7 @@ impl ParquetAsyncReader {
             chunk_size,
             self.use_statistics,
             self.hive_partition_columns,
+            self.parallel,
         )
     }
 

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -547,16 +547,25 @@ impl BatchedParquetReader {
         chunk_size: usize,
         use_statistics: bool,
         hive_partition_columns: Option<Vec<Series>>,
+        mut parallel: ParallelStrategy,
     ) -> PolarsResult<Self> {
         let n_row_groups = metadata.row_groups.len();
         let projection = projection.unwrap_or_else(|| (0usize..schema.len()).collect::<Vec<_>>());
 
-        let parallel =
-            if n_row_groups > projection.len() || n_row_groups > POOL.current_num_threads() {
-                ParallelStrategy::RowGroups
-            } else {
-                ParallelStrategy::Columns
-            };
+        parallel = match parallel {
+            ParallelStrategy::Auto => {
+                if n_row_groups > projection.len() || n_row_groups > POOL.current_num_threads() {
+                    ParallelStrategy::RowGroups
+                } else {
+                    ParallelStrategy::Columns
+                }
+            },
+            _ => parallel,
+        };
+
+        if let (ParallelStrategy::Columns, true) = (parallel, projection.len() == 1) {
+            parallel = ParallelStrategy::None;
+        }
 
         Ok(BatchedParquetReader {
             row_group_fetcher,


### PR DESCRIPTION
Fixes #13507 

When manually setting the ParallelStrategy, it is not being passed down to the ParquetReader. This is because when creating a new BatchedParquetReader, the parallel strategy is set to Row or Column for us. This change allows a parallel strategy to be passed to BatchedParquetReader::new(), defaulting to the original implementation when parallel strategy is set to auto.