### PR TITLE
depr(python): Deprecate passing `time_unit=None` to `Datetime` constructor

### DIFF
--- a/py-polars/polars/functions/lit.py
+++ b/py-polars/polars/functions/lit.py
@@ -75,7 +75,11 @@ def lit(
     time_unit: TimeUnit
 
     if isinstance(value, datetime):
-        time_unit = "us" if dtype is None else getattr(dtype, "time_unit", "us")
+        if dtype is not None and (tu := getattr(dtype, "time_unit", "us")) is not None:
+            time_unit = tu  # type: ignore[assignment]
+        else:
+            time_unit = "us"
+
         time_zone = (
             value.tzinfo
             if getattr(dtype, "time_zone", None) is None
@@ -99,8 +103,11 @@ def lit(
             return e
 
     elif isinstance(value, timedelta):
-        if dtype is None or (time_unit := getattr(dtype, "time_unit", "us")) is None:
+        if dtype is not None and (tu := getattr(dtype, "time_unit", "us")) is not None:
+            time_unit = tu  # type: ignore[assignment]
+        else:
             time_unit = "us"
+
         return lit(_timedelta_to_pl_timedelta(value, time_unit)).cast(
             Duration(time_unit)
         )

--- a/py-polars/polars/utils/_construction.py
+++ b/py-polars/polars/utils/_construction.py
@@ -531,15 +531,21 @@ def sequence_to_pyseries(
             # We use the AnyValue builder to create the datetime array
             # We store the values internally as UTC and set the timezone
             py_series = PySeries.new_from_any_values(name, values, strict)
+
             time_unit = getattr(dtype, "time_unit", None)
+            time_zone = getattr(dtype, "time_zone", None)
+
             if time_unit is None or values_dtype == Date:
                 s = wrap_s(py_series)
             else:
                 s = wrap_s(py_series).dt.cast_time_unit(time_unit)
-            time_zone = getattr(dtype, "time_zone", None)
 
             if (values_dtype == Date) & (dtype == Datetime):
-                return s.cast(Datetime(time_unit)).dt.replace_time_zone(time_zone)._s
+                return (
+                    s.cast(Datetime(time_unit or "us"))
+                    .dt.replace_time_zone(time_zone)
+                    ._s
+                )
 
             if (dtype == Datetime) and (
                 value.tzinfo is not None or time_zone is not None

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -2793,7 +2793,7 @@ def test_init_datetimes_with_timezone() -> None:
     tz_europe = "Europe/Amsterdam"
 
     dtm = datetime(2022, 10, 12, 12, 30)
-    for time_unit in DTYPE_TEMPORAL_UNITS | frozenset([None]):
+    for time_unit in DTYPE_TEMPORAL_UNITS:
         for type_overrides in (
             {
                 "schema": [
@@ -2895,7 +2895,7 @@ def test_init_physical_with_timezone() -> None:
     tz_asia = "Asia/Tokyo"
 
     dtm_us = 1665577800000000
-    for time_unit in DTYPE_TEMPORAL_UNITS | frozenset([None]):
+    for time_unit in DTYPE_TEMPORAL_UNITS:
         dtm = {"ms": dtm_us // 1_000, "ns": dtm_us * 1_000}.get(str(time_unit), dtm_us)
         df = pl.DataFrame(
             data={"d1": [dtm], "d2": [dtm]},

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2661,3 +2661,9 @@ def test_rolling_duplicates() -> None:
     assert df.sort("ts").with_columns(pl.col("value").rolling_max("1d", by="ts"))[
         "value"
     ].to_list() == [1, 1]
+
+
+def test_datetime_time_unit_none_deprecated() -> None:
+    with pytest.deprecated_call():
+        dtype = pl.Datetime(time_unit=None)  # type: ignore[arg-type]
+    assert dtype.time_unit == "us"

--- a/py-polars/tests/unit/expr/test_exprs.py
+++ b/py-polars/tests/unit/expr/test_exprs.py
@@ -449,7 +449,7 @@ def test_lit_dtypes() -> None:
             "dtm_aware_0": lit_series(d, pl.Datetime("us", "Asia/Kathmandu")),
             "dtm_aware_1": lit_series(d_tz, pl.Datetime("us")),
             "dtm_aware_2": lit_series(d_tz, None),
-            "dtm_aware_3": lit_series(d, pl.Datetime(None, "Asia/Kathmandu")),
+            "dtm_aware_3": lit_series(d, pl.Datetime(time_zone="Asia/Kathmandu")),
             "dur_ms": lit_series(td, pl.Duration("ms")),
             "dur_us": lit_series(td, pl.Duration("us")),
             "dur_ns": lit_series(td, pl.Duration("ns")),

--- a/py-polars/tests/unit/sql/test_temporal.py
+++ b/py-polars/tests/unit/sql/test_temporal.py
@@ -154,7 +154,6 @@ def test_extract_century_millennium(dt: date, expected: list[int]) -> None:
         ("ms", [1704589323123, 1609324245987, 1136159999555]),
         ("us", [1704589323123456, 1609324245987654, 1136159999555555]),
         ("ns", [1704589323123456000, 1609324245987654000, 1136159999555555000]),
-        (None, [1704589323123456, 1609324245987654, 1136159999555555]),
     ],
 )
 def test_timestamp_time_unit(unit: str | None, expected: list[int]) -> None:


### PR DESCRIPTION
`None` is not a valid time unit, so it should not be accepted. The user should either pass nothing to use the default value, or pass a valid time unit.

The constructor for `Duration` is already correct.