### PR TITLE
ci: Limit CMake threads to fix crash compiling `libz-ng-sys` on macOS

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,12 +5,14 @@ on:
     paths:
       - '**.rs'
       - '**.py'
+      - .github/workflows/codecov.yml
   push:
     branches:
       - main
     paths:
       - '**.rs'
       - '**.py'
+      - .github/workflows/codecov.yml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,6 +32,7 @@ jobs:
       CARGO_LLVM_COV: 1
       CARGO_LLVM_COV_SHOW_ENV: 1
       CARGO_LLVM_COV_TARGET_DIR: '/Users/runner/work/polars/polars/target'
+      CMAKE_BUILD_PARALLEL_LEVEL: 10 # fix resource temporarily unavailable on macOS for libz-ng-sys (https://github.com/pola-rs/polars/pull/14715)
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,7 +32,9 @@ jobs:
       CARGO_LLVM_COV: 1
       CARGO_LLVM_COV_SHOW_ENV: 1
       CARGO_LLVM_COV_TARGET_DIR: '/Users/runner/work/polars/polars/target'
-      CMAKE_BUILD_PARALLEL_LEVEL: 10 # fix resource temporarily unavailable on macOS for libz-ng-sys (https://github.com/pola-rs/polars/pull/14715)
+      # Workaround for issue compiling libz-ng-sys crate on macOS (resource temporarily unavailable)
+      # See: https://github.com/pola-rs/polars/pull/14715
+      CMAKE_BUILD_PARALLEL_LEVEL: 10
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -95,7 +95,6 @@ jobs:
     env:
       SED_INPLACE: ${{ matrix.os == 'macos-latest' && '-i ''''' || '-i'}}
       CPU_CHECK_MODULE: py-polars/polars/_cpu_check.py
-      CMAKE_BUILD_PARALLEL_LEVEL: 10 # fix resource temporarily unavailable on macOS for libz-ng-sys (https://github.com/pola-rs/polars/pull/14715)
 
     steps:
       - uses: actions/checkout@v4
@@ -108,6 +107,12 @@ jobs:
         uses: pierotofy/set-swap-space@master
         with:
           swap-size-gb: 10
+
+      # Workaround for issue compiling libz-ng-sys crate on macOS (resource temporarily unavailable)
+      # See: https://github.com/pola-rs/polars/pull/14715
+      - name: Set cmake build threads for MacOS
+        if: matrix.os == 'macos-latest'
+        run: echo "CMAKE_BUILD_PARALLEL_LEVEL=10" >> $GITHUB_ENV
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -95,6 +95,7 @@ jobs:
     env:
       SED_INPLACE: ${{ matrix.os == 'macos-latest' && '-i ''''' || '-i'}}
       CPU_CHECK_MODULE: py-polars/polars/_cpu_check.py
+      CMAKE_BUILD_PARALLEL_LEVEL: 10 # fix resource temporarily unavailable on macOS for libz-ng-sys (https://github.com/pola-rs/polars/pull/14715)
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Presumably spawned too many threads

```
  make[2]: *** read jobs pipe: Resource temporarily unavailable.  Stop.
```