### PR TITLE
feat: consistently use Display repr for invalid-datatype error messages (e.g. "expected `i64` got `i32`", instead of "expected `Int64` got `i32`")

### DIFF
--- a/crates/polars-core/src/series/ops/downcast.rs
+++ b/crates/polars-core/src/series/ops/downcast.rs
@@ -25,12 +25,12 @@ macro_rules! unpack_chunked {
 impl Series {
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int8]`
     pub fn i8(&self) -> PolarsResult<&Int8Chunked> {
-        unpack_chunked!(self, DataType::Int8 => Int8Chunked, "Int8")
+        unpack_chunked!(self, DataType::Int8 => Int8Chunked, "i8")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int16]`
     pub fn i16(&self) -> PolarsResult<&Int16Chunked> {
-        unpack_chunked!(self, DataType::Int16 => Int16Chunked, "Int16")
+        unpack_chunked!(self, DataType::Int16 => Int16Chunked, "i16")
     }
 
     /// Unpack to [`ChunkedArray`]
@@ -49,109 +49,109 @@ impl Series {
     /// ```
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int32]`
     pub fn i32(&self) -> PolarsResult<&Int32Chunked> {
-        unpack_chunked!(self, DataType::Int32 => Int32Chunked, "Int32")
+        unpack_chunked!(self, DataType::Int32 => Int32Chunked, "i32")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Int64]`
     pub fn i64(&self) -> PolarsResult<&Int64Chunked> {
-        unpack_chunked!(self, DataType::Int64 => Int64Chunked, "Int64")
+        unpack_chunked!(self, DataType::Int64 => Int64Chunked, "i64")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Float32]`
     pub fn f32(&self) -> PolarsResult<&Float32Chunked> {
-        unpack_chunked!(self, DataType::Float32 => Float32Chunked, "Float32")
+        unpack_chunked!(self, DataType::Float32 => Float32Chunked, "f32")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Float64]`
     pub fn f64(&self) -> PolarsResult<&Float64Chunked> {
-        unpack_chunked!(self, DataType::Float64 => Float64Chunked, "Float64")
+        unpack_chunked!(self, DataType::Float64 => Float64Chunked, "f64")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt8]`
     pub fn u8(&self) -> PolarsResult<&UInt8Chunked> {
-        unpack_chunked!(self, DataType::UInt8 => UInt8Chunked, "UInt8")
+        unpack_chunked!(self, DataType::UInt8 => UInt8Chunked, "u8")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt16]`
     pub fn u16(&self) -> PolarsResult<&UInt16Chunked> {
-        unpack_chunked!(self, DataType::UInt16 => UInt16Chunked, "UInt16")
+        unpack_chunked!(self, DataType::UInt16 => UInt16Chunked, "u16")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt32]`
     pub fn u32(&self) -> PolarsResult<&UInt32Chunked> {
-        unpack_chunked!(self, DataType::UInt32 => UInt32Chunked, "UInt32")
+        unpack_chunked!(self, DataType::UInt32 => UInt32Chunked, "u32")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::UInt64]`
     pub fn u64(&self) -> PolarsResult<&UInt64Chunked> {
-        unpack_chunked!(self, DataType::UInt64 => UInt64Chunked, "UInt64")
+        unpack_chunked!(self, DataType::UInt64 => UInt64Chunked, "u64")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Boolean]`
     pub fn bool(&self) -> PolarsResult<&BooleanChunked> {
-        unpack_chunked!(self, DataType::Boolean => BooleanChunked, "Boolean")
+        unpack_chunked!(self, DataType::Boolean => BooleanChunked, "bool")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::String]`
     pub fn str(&self) -> PolarsResult<&StringChunked> {
-        unpack_chunked!(self, DataType::String => StringChunked, "String")
+        unpack_chunked!(self, DataType::String => StringChunked, "str")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Binary]`
     pub fn binary(&self) -> PolarsResult<&BinaryChunked> {
-        unpack_chunked!(self, DataType::Binary => BinaryChunked, "Binary")
+        unpack_chunked!(self, DataType::Binary => BinaryChunked, "binary")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Binary]`
     pub fn binary_offset(&self) -> PolarsResult<&BinaryOffsetChunked> {
-        unpack_chunked!(self, DataType::BinaryOffset => BinaryOffsetChunked, "BinaryOffset")
+        unpack_chunked!(self, DataType::BinaryOffset => BinaryOffsetChunked, "binary[offset]")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Time]`
     #[cfg(feature = "dtype-time")]
     pub fn time(&self) -> PolarsResult<&TimeChunked> {
-        unpack_chunked!(self, DataType::Time => TimeChunked, "Time")
+        unpack_chunked!(self, DataType::Time => TimeChunked, "time")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Date]`
     #[cfg(feature = "dtype-date")]
     pub fn date(&self) -> PolarsResult<&DateChunked> {
-        unpack_chunked!(self, DataType::Date => DateChunked, "Date")
+        unpack_chunked!(self, DataType::Date => DateChunked, "date")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Datetime]`
     #[cfg(feature = "dtype-datetime")]
     pub fn datetime(&self) -> PolarsResult<&DatetimeChunked> {
-        unpack_chunked!(self, DataType::Datetime(_, _) => DatetimeChunked, "Datetime")
+        unpack_chunked!(self, DataType::Datetime(_, _) => DatetimeChunked, "datetime")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Duration]`
     #[cfg(feature = "dtype-duration")]
     pub fn duration(&self) -> PolarsResult<&DurationChunked> {
-        unpack_chunked!(self, DataType::Duration(_) => DurationChunked, "Duration")
+        unpack_chunked!(self, DataType::Duration(_) => DurationChunked, "duration")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Decimal]`
     #[cfg(feature = "dtype-decimal")]
     pub fn decimal(&self) -> PolarsResult<&DecimalChunked> {
-        unpack_chunked!(self, DataType::Decimal(_, _) => DecimalChunked, "Decimal")
+        unpack_chunked!(self, DataType::Decimal(_, _) => DecimalChunked, "decimal")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype list
     pub fn list(&self) -> PolarsResult<&ListChunked> {
-        unpack_chunked!(self, DataType::List(_) => ListChunked, "List")
+        unpack_chunked!(self, DataType::List(_) => ListChunked, "list")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Array]`
     #[cfg(feature = "dtype-array")]
     pub fn array(&self) -> PolarsResult<&ArrayChunked> {
-        unpack_chunked!(self, DataType::Array(_, _) => ArrayChunked, "FixedSizeList")
+        unpack_chunked!(self, DataType::Array(_, _) => ArrayChunked, "array")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Categorical]`
     #[cfg(feature = "dtype-categorical")]
     pub fn categorical(&self) -> PolarsResult<&CategoricalChunked> {
-        unpack_chunked!(self, DataType::Categorical(_, _) | DataType::Enum(_, _) => CategoricalChunked, "Enum | Categorical")
+        unpack_chunked!(self, DataType::Categorical(_, _) | DataType::Enum(_, _) => CategoricalChunked, "enum | categorical")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Struct]`
@@ -164,11 +164,11 @@ impl Series {
                 assert!(any.is::<StructChunked>());
             }
         }
-        unpack_chunked!(self, DataType::Struct(_) => StructChunked, "Struct")
+        unpack_chunked!(self, DataType::Struct(_) => StructChunked, "struct")
     }
 
     /// Unpack to [`ChunkedArray`] of dtype `[DataType::Null]`
     pub fn null(&self) -> PolarsResult<&NullChunked> {
-        unpack_chunked!(self, DataType::Null => NullChunked, "Null")
+        unpack_chunked!(self, DataType::Null => NullChunked, "null")
     }
 }

--- a/crates/polars-ops/src/chunked_array/array/join.rs
+++ b/crates/polars-ops/src/chunked_array/array/join.rs
@@ -92,6 +92,6 @@ pub fn array_join(
             },
             _ => join_many(ca, separator, ignore_nulls),
         },
-        dt => polars_bail!(op = "`array.join`", got = dt, expected = "String"),
+        dt => polars_bail!(op = "`array.join`", got = dt, expected = "str"),
     }
 }

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -91,7 +91,7 @@ pub trait ListNameSpaceImpl: AsList {
                 },
                 _ => self.join_many(separator, ignore_nulls),
             },
-            dt => polars_bail!(op = "`lst.join`", got = dt, expected = "String"),
+            dt => polars_bail!(op = "`lst.join`", got = dt, expected = "str"),
         }
     }
 

--- a/crates/polars-plan/src/dsl/function_expr/datetime.rs
+++ b/crates/polars-plan/src/dsl/function_expr/datetime.rs
@@ -89,7 +89,7 @@ impl TemporalFunction {
             #[cfg(feature = "timezones")]
             ConvertTimeZone(tz) => mapper.try_map_dtype(|dt| match dt {
                 DataType::Datetime(tu, _) => Ok(DataType::Datetime(*tu, Some(tz.clone()))),
-                dtype => polars_bail!(ComputeError: "expected Datetime, got {}", dtype),
+                dtype => polars_bail!(ComputeError: "expected datetime, got {}", dtype),
             }),
             TimeStamp(_) => mapper.with_dtype(DataType::Int64),
             IsLeapYear => mapper.with_dtype(DataType::Boolean),
@@ -98,7 +98,7 @@ impl TemporalFunction {
             Date => mapper.with_dtype(DataType::Date),
             Datetime => mapper.try_map_dtype(|dt| match dt {
                 DataType::Datetime(tu, _) => Ok(DataType::Datetime(*tu, None)),
-                dtype => polars_bail!(ComputeError: "expected Datetime, got {}", dtype),
+                dtype => polars_bail!(ComputeError: "expected datetime, got {}", dtype),
             }),
             Truncate(_) => mapper.with_same_dtype(),
             #[cfg(feature = "date_offset")]
@@ -123,7 +123,7 @@ impl TemporalFunction {
                 DataType::Datetime(_, tz) => Ok(DataType::Datetime(*tu, tz.clone())),
                 DataType::Date => Ok(DataType::Datetime(*tu, None)),
                 dtype => {
-                    polars_bail!(ComputeError: "expected Date or Datetime, got {}", dtype)
+                    polars_bail!(ComputeError: "expected date or datetime, got {}", dtype)
                 },
             }),
         }
@@ -231,7 +231,7 @@ pub(super) fn time(s: &Series) -> PolarsResult<Series> {
         .cast(&DataType::Time),
         DataType::Datetime(_, _) => s.datetime().unwrap().cast(&DataType::Time),
         DataType::Time => Ok(s.clone()),
-        dtype => polars_bail!(ComputeError: "expected Datetime or Time, got {}", dtype),
+        dtype => polars_bail!(ComputeError: "expected datetime or time, got {}", dtype),
     }
 }
 pub(super) fn date(s: &Series) -> PolarsResult<Series> {
@@ -254,7 +254,7 @@ pub(super) fn date(s: &Series) -> PolarsResult<Series> {
         },
         DataType::Datetime(_, _) => s.datetime().unwrap().cast(&DataType::Date),
         DataType::Date => Ok(s.clone()),
-        dtype => polars_bail!(ComputeError: "expected Datetime or Date, got {}", dtype),
+        dtype => polars_bail!(ComputeError: "expected datetime or date, got {}", dtype),
     }
 }
 pub(super) fn datetime(s: &Series) -> PolarsResult<Series> {
@@ -276,7 +276,7 @@ pub(super) fn datetime(s: &Series) -> PolarsResult<Series> {
             Ok(out)
         },
         DataType::Datetime(tu, _) => s.datetime().unwrap().cast(&DataType::Datetime(*tu, None)),
-        dtype => polars_bail!(ComputeError: "expected Datetime, got {}", dtype),
+        dtype => polars_bail!(ComputeError: "expected datetime, got {}", dtype),
     }
 }
 pub(super) fn hour(s: &Series) -> PolarsResult<Series> {
@@ -335,7 +335,7 @@ pub(super) fn convert_time_zone(s: &Series, time_zone: &TimeZone) -> PolarsResul
             ca.set_time_zone(time_zone.clone())?;
             Ok(ca.into_series())
         },
-        dtype => polars_bail!(ComputeError: "expected Datetime, got {}", dtype),
+        dtype => polars_bail!(ComputeError: "expected datetime, got {}", dtype),
     }
 }
 pub(super) fn with_time_unit(s: &Series, tu: TimeUnit) -> PolarsResult<Series> {

--- a/crates/polars-plan/src/dsl/function_expr/range/date_range.rs
+++ b/crates/polars-plan/src/dsl/function_expr/range/date_range.rs
@@ -124,7 +124,7 @@ impl<'a> FieldsMapper<'a> {
                 let schema_dtype = map_date_to_date_range_dtype(interval, time_unit, time_zone);
                 Ok(schema_dtype)
             },
-            _ => polars_bail!(ComputeError: "expected Date or Datetime, got {}", data_dtype),
+            _ => polars_bail!(ComputeError: "expected date or datetime, got {}", data_dtype),
         }
     }
 }

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -441,7 +441,7 @@ impl<'a> FieldsMapper<'a> {
             if let DataType::Datetime(tu, _) = dt {
                 Ok(DataType::Datetime(*tu, tz.cloned()))
             } else {
-                polars_bail!(op = "replace-time-zone", got = dt, expected = "Datetime");
+                polars_bail!(op = "replace-time-zone", got = dt, expected = "datetime");
             }
         })
     }

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -299,7 +299,7 @@ pub(super) fn combine(s: &[Series], tu: TimeUnit) -> PolarsResult<Series> {
         DataType::Date => None,
         DataType::Datetime(_, tz) => tz.as_ref(),
         _dtype => {
-            polars_bail!(ComputeError: format!("expected Date or Datetime, got {}", _dtype))
+            polars_bail!(ComputeError: format!("expected date or datetime, got {}", _dtype))
         },
     };
 

--- a/crates/polars-time/src/group_by/dynamic.rs
+++ b/crates/polars-time/src/group_by/dynamic.rs
@@ -180,7 +180,7 @@ impl Wrap<&DataFrame> {
             },
             dt => polars_bail!(
                 ComputeError:
-                "expected any of the following dtypes: {{ Date, Datetime, Int32, Int64 }}, got {}",
+                "expected any of the following dtypes: {{ date, datetime, Int32, Int64 }}, got {}",
                 dt
             ),
         };
@@ -253,7 +253,7 @@ impl Wrap<&DataFrame> {
             },
             dt => polars_bail!(
                 ComputeError:
-                "expected any of the following dtypes: {{ Date, Datetime, Int32, Int64 }}, got {}",
+                "expected any of the following dtypes: {{ date, datetime, Int32, Int64 }}, got {}",
                 dt
             ),
         };

--- a/py-polars/tests/unit/namespaces/test_datetime.py
+++ b/py-polars/tests/unit/namespaces/test_datetime.py
@@ -210,13 +210,13 @@ def test_offset_by_sortedness(
 
 
 def test_dt_datetime_date_time_invalid() -> None:
-    with pytest.raises(ComputeError, match="expected Datetime or Date"):
+    with pytest.raises(ComputeError, match="expected datetime or date"):
         pl.Series([time(23)]).dt.date()
-    with pytest.raises(ComputeError, match="expected Datetime or Date"):
+    with pytest.raises(ComputeError, match="expected datetime or date"):
         pl.Series([timedelta(1)]).dt.date()
-    with pytest.raises(ComputeError, match="expected Datetime or Time"):
+    with pytest.raises(ComputeError, match="expected datetime or time"):
         pl.Series([timedelta(1)]).dt.time()
-    with pytest.raises(ComputeError, match="expected Datetime or Time"):
+    with pytest.raises(ComputeError, match="expected datetime or time"):
         pl.Series([date(2020, 1, 1)]).dt.time()
 
 
@@ -637,7 +637,7 @@ def test_date_time_combine(tzinfo: ZoneInfo | None, time_zone: str | None) -> No
 
 
 def test_combine_unsupported_types() -> None:
-    with pytest.raises(ComputeError, match="expected Date or Datetime, got time"):
+    with pytest.raises(ComputeError, match="expected date or datetime, got time"):
         pl.Series([time(1, 2)]).dt.combine(time(3, 4))
 
 

--- a/py-polars/tests/unit/series/test_all_any.py
+++ b/py-polars/tests/unit/series/test_all_any.py
@@ -36,7 +36,7 @@ def test_any_kleene(data: list[bool | None], expected: bool | None) -> None:
 
 
 def test_any_wrong_dtype() -> None:
-    with pytest.raises(pl.SchemaError, match="expected `Boolean`"):
+    with pytest.raises(pl.SchemaError, match="expected `bool`, got `i64`"):
         pl.Series([0, 1, 0]).any()
 
 
@@ -71,5 +71,5 @@ def test_all_kleene(data: list[bool | None], expected: bool | None) -> None:
 
 
 def test_all_wrong_dtype() -> None:
-    with pytest.raises(pl.SchemaError, match="expected `Boolean`"):
+    with pytest.raises(pl.SchemaError, match="expected `bool`, got `i64`"):
         pl.Series([0, 1, 0]).all()


### PR DESCRIPTION
closes #14717