### PR TITLE
fix: Fix `DataFrame.sum` for decimals

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1400,7 +1400,11 @@ impl LazyFrame {
     /// - String columns will sum to None.
     pub fn sum(self) -> PolarsResult<LazyFrame> {
         self.stats_helper(
-            |dt| dt.is_numeric() || matches!(dt, DataType::Boolean | DataType::Duration(_)),
+            |dt| {
+                dt.is_numeric()
+                    || dt.is_decimal()
+                    || matches!(dt, DataType::Boolean | DataType::Duration(_))
+            },
             |name| col(name).sum(),
         )
     }

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -315,6 +315,17 @@ def test_decimal_aggregations() -> None:
     }
 
 
+def test_decimal_df_vertical_sum() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [D("1.1"), D("2.2")]
+        }
+    )
+    expected = pl.DataFrame({"a": [D("3.3")]})
+
+    assert_frame_equal(df.sum(), expected)
+
+
 def test_decimal_in_filter() -> None:
     df = pl.DataFrame(
         {

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -316,11 +316,7 @@ def test_decimal_aggregations() -> None:
 
 
 def test_decimal_df_vertical_sum() -> None:
-    df = pl.DataFrame(
-        {
-            "a": [D("1.1"), D("2.2")]
-        }
-    )
+    df = pl.DataFrame({"a": [D("1.1"), D("2.2")]})
     expected = pl.DataFrame({"a": [D("3.3")]})
 
     assert_frame_equal(df.sum(), expected)


### PR DESCRIPTION
Fixes #14652 