### PR TITLE
perf: Don't materialize for broadcasting `fill_null` value and default value of `replace`

### DIFF
--- a/crates/polars-ops/src/series/ops/replace.rs
+++ b/crates/polars-ops/src/series/ops/replace.rs
@@ -24,19 +24,21 @@ pub fn replace(
         None => try_get_supertype(new.dtype(), default.dtype())?,
     };
 
-    let default = match default.len() {
-        len if len == s.len() => default.cast(&return_dtype)?,
-        1 => default.cast(&return_dtype)?.new_from_index(0, s.len()),
-        _ => {
-            polars_bail!(
-                ComputeError:
-                "`default` input for `replace` must have the same length as the input or have length 1"
-            )
-        },
-    };
+    polars_ensure!(
+        default.len() == s.len() || default.len() == 1,
+        ComputeError: "`default` input for `replace` must have the same length as the input or have length 1"
+    );
+
+    let default = default.cast(&return_dtype)?;
 
     if old.len() == 0 {
-        return Ok(default);
+        let out = if default.len() == 1 && s.len() != 1 {
+            default.new_from_index(0, s.len())
+        } else {
+            default
+        };
+
+        return Ok(out);
     }
 
     let old = match (s.dtype(), old.dtype()) {

--- a/crates/polars-plan/src/dsl/function_expr/fill_null.rs
+++ b/crates/polars-plan/src/dsl/function_expr/fill_null.rs
@@ -24,10 +24,6 @@ pub(super) fn fill_null(s: &[Series], super_type: &DataType) -> PolarsResult<Ser
 
     // default branch
     fn default(series: Series, mut fill_value: Series) -> PolarsResult<Series> {
-        // broadcast to the proper length for zip_with
-        if fill_value.len() == 1 && series.len() != 1 {
-            fill_value = fill_value.new_from_index(0, series.len());
-        }
         let mask = series.is_not_null();
         series.zip_with_same_type(&mask, &fill_value)
     }

--- a/crates/polars-plan/src/dsl/function_expr/fill_null.rs
+++ b/crates/polars-plan/src/dsl/function_expr/fill_null.rs
@@ -23,7 +23,7 @@ pub(super) fn fill_null(s: &[Series], super_type: &DataType) -> PolarsResult<Ser
     }
 
     // default branch
-    fn default(series: Series, mut fill_value: Series) -> PolarsResult<Series> {
+    fn default(series: Series, fill_value: Series) -> PolarsResult<Series> {
         let mask = series.is_not_null();
         series.zip_with_same_type(&mask, &fill_value)
     }


### PR DESCRIPTION
`zip_with` already broadcasts efficiently