### PR TITLE
docs(python): Add examples for `Series.search_sorted`

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3584,11 +3584,11 @@ class Series:
         >>> s = pl.Series("set", [1, 2, 3, 4, 4, 5, 6, 7])
         >>> s.search_sorted(4)
         4
-        >>> s.search_sorted(4, 'any')
+        >>> s.search_sorted(4, "any")
         4
-        >>> s.search_sorted(4, 'left')
+        >>> s.search_sorted(4, "left")
         3
-        >>> s.search_sorted(4, 'right')
+        >>> s.search_sorted(4, "right")
         5
         >>> s.search_sorted([1, 4, 5])
         shape: (3,)
@@ -3598,7 +3598,7 @@ class Series:
                 4
                 5
         ]
-        >>> s.search_sorted([1, 4, 5], 'left')
+        >>> s.search_sorted([1, 4, 5], "left")
         shape: (3,)
         Series: 'set' [u32]
         [
@@ -3606,7 +3606,7 @@ class Series:
                 3
                 5
         ]
-        >>> s.search_sorted([1, 4, 5], 'right')
+        >>> s.search_sorted([1, 4, 5], "right")
         shape: (3,)
         Series: 'set' [u32]
         [

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3590,6 +3590,30 @@ class Series:
         3
         >>> s.search_sorted(4, 'right')
         5
+        >>> s.search_sorted([1, 4, 5])
+        shape: (3,)
+        Series: 'set' [u32]
+        [
+                0
+                4
+                5
+        ]
+        >>> s.search_sorted([1, 4, 5], 'left')
+        shape: (3,)
+        Series: 'set' [u32]
+        [
+                0
+                3
+                5
+        ]
+        >>> s.search_sorted([1, 4, 5], 'right')
+        shape: (3,)
+        Series: 'set' [u32]
+        [
+                1
+                5
+                6
+        ]
         """
         if isinstance(element, (int, float)):
             return F.select(F.lit(self).search_sorted(element, side)).item()

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3578,6 +3578,18 @@ class Series:
             If 'any', the index of the first suitable location found is given.
             If 'left', the index of the leftmost suitable location found is given.
             If 'right', return the rightmost suitable location found is given.
+
+        Examples
+        --------
+        >>> s = pl.Series("set", [1, 2, 3, 4, 4, 5, 6, 7])
+        >>> s.search_sorted(4)
+        4
+        >>> s.search_sorted(4, 'any')
+        4
+        >>> s.search_sorted(4, 'left')
+        3
+        >>> s.search_sorted(4, 'right')
+        5
         """
         if isinstance(element, (int, float)):
             return F.select(F.lit(self).search_sorted(element, side)).item()

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3584,8 +3584,6 @@ class Series:
         >>> s = pl.Series("set", [1, 2, 3, 4, 4, 5, 6, 7])
         >>> s.search_sorted(4)
         4
-        >>> s.search_sorted(4, "any")
-        4
         >>> s.search_sorted(4, "left")
         3
         >>> s.search_sorted(4, "right")


### PR DESCRIPTION
A portion of #13161.

Added a few examples for `Series.search_sorted`.