### PR TITLE
fix: Allow `list.contains()` for list of categoricals

### DIFF
--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -503,18 +503,6 @@ macro_rules! apply_method_all_arrow_series {
 }
 
 #[macro_export]
-macro_rules! apply_amortized_generic_list_or_array {
-        ($self:expr, $method:ident, $($args:expr),*) => {
-        match $self.dtype() {
-            #[cfg(feature = "dtype-array")]
-            DataType::Array(_, _) => $self.array().unwrap().apply_amortized_generic($($args),*),
-            DataType::List(_) => $self.list().unwrap().apply_amortized_generic($($args),*),
-            dt => panic!("not implemented for dtype {:?}", dt),
-        }
-    }
-}
-
-#[macro_export]
 macro_rules! apply_method_physical_integer {
     ($self:expr, $method:ident, $($args:expr),*) => {
         match $self.dtype() {


### PR DESCRIPTION
fix #14559 

Also a drive by fix for the List[categorical] <-> str where only the first value in the StringChunked was used:
```python
df = pl.DataFrame(
    [(["a", "b"], "c"), (["a", "b"], "a")],
    schema={"li": pl.List(pl.Categorical), "x": pl.Categorical},
)
print(df.select(pl.col("li").list.contains(pl.col("x").cast(pl.Utf8))))
shape: (2, 1)
┌───────┐
│ li    │
│ ---   │
│ bool  │
╞═══════╡
│ false │
│ false │
└───────┘
```