### PR TITLE
fix: Sum after filter in aggregation context sometimes returned NULL

### DIFF
--- a/crates/polars-core/src/frame/group_by/aggregations/mod.rs
+++ b/crates/polars-core/src/frame/group_by/aggregations/mod.rs
@@ -51,7 +51,10 @@ pub fn _use_rolling_kernels(groups: &GroupsSlice, chunks: &[ArrayRef]) -> bool {
             let [first_offset, first_len] = groups[0];
             let second_offset = groups[1][0];
 
-            second_offset < (first_offset + first_len) && chunks.len() == 1
+            second_offset >= first_offset // Prevent false positive from regular group-by that has out of order slices.
+                                          // Rolling group-by is expected to have monotonically increasing slices.
+                && second_offset < (first_offset + first_len)
+                && chunks.len() == 1
         },
     }
 }

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -400,6 +400,7 @@ def test_agg_filter_over_empty_df_13610() -> None:
     assert_frame_equal(out, expected)
 
 
+@pytest.mark.slow()
 def test_agg_empty_sum_after_filter_14734() -> None:
     f = (
         pl.DataFrame({"a": [1, 2], "b": [1, 2]})

--- a/py-polars/tests/unit/operations/test_aggregations.py
+++ b/py-polars/tests/unit/operations/test_aggregations.py
@@ -398,3 +398,27 @@ def test_agg_filter_over_empty_df_13610() -> None:
     out = df.group_by("a").agg(pl.col("b").filter(pl.col("b").shift()))
     expected = pl.DataFrame(schema={"a": pl.Int64, "b": pl.List(pl.Boolean)})
     assert_frame_equal(out, expected)
+
+
+def test_agg_empty_sum_after_filter_14734() -> None:
+    f = (
+        pl.DataFrame({"a": [1, 2], "b": [1, 2]})
+        .lazy()
+        .group_by("a")
+        .agg(pl.col("b").filter(pl.lit(False)).sum())
+        .collect
+    )
+
+    last = f()
+
+    # We need both possible output orders, which should happen within
+    # 1000 iterations (during testing it usually happens within 10).
+    limit = 1000
+    i = 0
+    while (curr := f()).equals(last):
+        i += 1
+        assert i != limit
+
+    expect = pl.Series("b", [0, 0]).to_frame()
+    assert_frame_equal(expect, last.select("b"))
+    assert_frame_equal(expect, curr.select("b"))


### PR DESCRIPTION
Fix https://github.com/pola-rs/polars/issues/14734

The rolling kernel was accidentally used sometimes causing it to return NULL