### PR TITLE
fix: add missing "pclmulqdq" instruction to `_cpu_check` ("read_cpu_flags")

### DIFF
--- a/py-polars/polars/_cpu_check.py
+++ b/py-polars/polars/_cpu_check.py
@@ -205,6 +205,7 @@ def read_cpu_flags() -> dict[str, bool]:
         "sse4.1": bool(cpuid1.ecx & (1 << 19)),
         "sse4.2": bool(cpuid1.ecx & (1 << 20)),
         "popcnt": bool(cpuid1.ecx & (1 << 23)),
+        "pclmulqdq": bool(cpuid1.ecx & (1 << 1)),
         "avx": bool(cpuid1.ecx & (1 << 28)),
         "bmi1": bool(cpuid7.ebx & (1 << 3)),
         "bmi2": bool(cpuid7.ebx & (1 << 8)),


### PR DESCRIPTION
Add missing "pclmulqdq" entry to `read_cpu_flags()` to prevent RuntimeError on import of `0.20.12`. (Feature flag is found on bit 1 of ECX[^1]).

Closes #14759.

[^1]: https://en.wikipedia.org/wiki/CPUID