### PR TITLE
add seconds to TimeUnit

### DIFF
--- a/crates/polars-arrow/src/temporal_conversions.rs
+++ b/crates/polars-arrow/src/temporal_conversions.rs
@@ -9,6 +9,8 @@ use crate::datatypes::{ArrowDataType, TimeUnit};
 
 /// Number of seconds in a day
 pub const SECONDS_IN_DAY: i64 = 86_400;
+/// Number of seconds in a second
+pub const SECONDS: i64 = 1;
 /// Number of milliseconds in a second
 pub const MILLISECONDS: i64 = 1_000;
 /// Number of microseconds in a second

--- a/crates/polars-core/src/chunked_array/logical/date.rs
+++ b/crates/polars-core/src/chunked_array/logical/date.rs
@@ -38,6 +38,7 @@ impl LogicalType for DateChunked {
                     TimeUnit::Nanoseconds => NS_IN_DAY,
                     TimeUnit::Microseconds => US_IN_DAY,
                     TimeUnit::Milliseconds => MS_IN_DAY,
+                    TimeUnit::Seconds => SEC_IN_DAY,
                 };
                 Ok((casted.deref() * conversion)
                     .into_datetime(*tu, tz.clone())

--- a/crates/polars-core/src/chunked_array/logical/datetime.rs
+++ b/crates/polars-core/src/chunked_array/logical/datetime.rs
@@ -77,6 +77,7 @@ impl LogicalType for DatetimeChunked {
                     TimeUnit::Nanoseconds => cast_to_date(NS_IN_DAY),
                     TimeUnit::Microseconds => cast_to_date(US_IN_DAY),
                     TimeUnit::Milliseconds => cast_to_date(MS_IN_DAY),
+                    TimeUnit::Seconds => cast_to_date(SEC_IN_DAY),
                 }
             },
             #[cfg(feature = "dtype-time")]
@@ -85,6 +86,7 @@ impl LogicalType for DatetimeChunked {
                     TimeUnit::Nanoseconds => (NS_IN_DAY, 1i64),
                     TimeUnit::Microseconds => (US_IN_DAY, 1_000i64),
                     TimeUnit::Milliseconds => (MS_IN_DAY, 1_000_000i64),
+                    TimeUnit::Seconds => (SEC_IN_DAY, 1_000_000_000i64),
                 };
                 return Ok(self
                     .0

--- a/crates/polars-core/src/chunked_array/temporal/conversion.rs
+++ b/crates/polars-core/src/chunked_array/temporal/conversion.rs
@@ -18,6 +18,7 @@ impl From<&AnyValue<'_>> for NaiveDateTime {
                 TimeUnit::Nanoseconds => timestamp_ns_to_datetime(*v),
                 TimeUnit::Microseconds => timestamp_us_to_datetime(*v),
                 TimeUnit::Milliseconds => timestamp_ms_to_datetime(*v),
+                TimeUnit::Seconds => timestamp_s_to_datetime(*v),
             },
             _ => panic!("can only convert date/datetime to NaiveDateTime"),
         }
@@ -45,6 +46,11 @@ pub fn datetime_to_timestamp_ms(v: NaiveDateTime) -> i64 {
 }
 
 // Used by lazy for literal conversion
+pub fn datetime_to_timestamp_s(v: NaiveDateTime) -> i64 {
+    v.timestamp()
+}
+
+// Used by lazy for literal conversion
 pub fn datetime_to_timestamp_us(v: NaiveDateTime) -> i64 {
     let us = v.timestamp() * 1_000_000;
     us + v.timestamp_subsec_micros() as i64
@@ -57,3 +63,4 @@ pub(crate) fn naive_datetime_to_date(v: NaiveDateTime) -> i32 {
 pub(crate) const NS_IN_DAY: i64 = 86_400_000_000_000;
 pub(crate) const US_IN_DAY: i64 = 86_400_000_000;
 pub(crate) const MS_IN_DAY: i64 = 86_400_000;
+pub(crate) const SEC_IN_DAY: i64 = 86_400;

--- a/crates/polars-core/src/chunked_array/temporal/duration.rs
+++ b/crates/polars-core/src/chunked_array/temporal/duration.rs
@@ -29,6 +29,11 @@ impl DurationChunked {
                 out.0 = ca;
                 out
             },
+            (Nanoseconds, Seconds) => {
+                let ca = (&self.0).wrapping_trunc_div_scalar(1_000_000_000);
+                out.0 = ca;
+                out
+            },
             (Microseconds, Nanoseconds) => {
                 let ca = &self.0 * 1_000;
                 out.0 = ca;
@@ -36,6 +41,11 @@ impl DurationChunked {
             },
             (Microseconds, Milliseconds) => {
                 let ca = (&self.0).wrapping_trunc_div_scalar(1_000);
+                out.0 = ca;
+                out
+            },
+            (Microseconds, Seconds) => {
+                let ca = (&self.0).wrapping_trunc_div_scalar(1_000_000);
                 out.0 = ca;
                 out
             },
@@ -49,9 +59,30 @@ impl DurationChunked {
                 out.0 = ca;
                 out
             },
+            (Milliseconds, Seconds) => {
+                let ca = (&self.0).wrapping_trunc_div_scalar(1_000);
+                out.0 = ca;
+                out
+            },
+            (Seconds, Milliseconds) => {
+                let ca = &self.0 * 1_000;
+                out.0 = ca;
+                out
+            },
+            (Seconds, Microseconds) => {
+                let ca = &self.0 * 1_000_000;
+                out.0 = ca;
+                out
+            },
+            (Seconds, Nanoseconds) => {
+                let ca = &self.0 * 1_000_000_000;
+                out.0 = ca;
+                out
+            },
             (Nanoseconds, Nanoseconds)
             | (Microseconds, Microseconds)
-            | (Milliseconds, Milliseconds) => out,
+            | (Milliseconds, Milliseconds)
+            | (Seconds, Seconds) => out,
         }
     }
 
@@ -70,6 +101,7 @@ impl DurationChunked {
             TimeUnit::Nanoseconds => |v: ChronoDuration| v.num_nanoseconds().unwrap(),
             TimeUnit::Microseconds => |v: ChronoDuration| v.num_microseconds().unwrap(),
             TimeUnit::Milliseconds => |v: ChronoDuration| v.num_milliseconds(),
+            TimeUnit::Seconds => |v: ChronoDuration| v.num_seconds(),
         };
         let vals = v.into_iter().map(func).collect::<Vec<_>>();
         Int64Chunked::from_vec(name, vals).into_duration(tu)
@@ -85,6 +117,7 @@ impl DurationChunked {
             TimeUnit::Nanoseconds => |v: ChronoDuration| v.num_nanoseconds().unwrap(),
             TimeUnit::Microseconds => |v: ChronoDuration| v.num_microseconds().unwrap(),
             TimeUnit::Milliseconds => |v: ChronoDuration| v.num_milliseconds(),
+            TimeUnit::Seconds => |v: ChronoDuration| v.num_seconds(),
         };
         let vals = v.into_iter().map(|opt| opt.map(func));
         Int64Chunked::from_iter_options(name, vals).into_duration(tu)

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -1218,11 +1218,11 @@ mod test {
             ),
             (
                 ArrowDataType::Timestamp(ArrowTimeUnit::Second, None),
-                DataType::Datetime(TimeUnit::Milliseconds, None),
+                DataType::Datetime(TimeUnit::Seconds, None),
             ),
             (
                 ArrowDataType::Timestamp(ArrowTimeUnit::Second, Some("".to_string())),
-                DataType::Datetime(TimeUnit::Milliseconds, None),
+                DataType::Datetime(TimeUnit::Seconds, None),
             ),
             (ArrowDataType::LargeUtf8, DataType::String),
             (ArrowDataType::Utf8, DataType::String),

--- a/crates/polars-core/src/datatypes/any_value.rs
+++ b/crates/polars-core/src/datatypes/any_value.rs
@@ -535,6 +535,7 @@ impl<'a> AnyValue<'a> {
                     TimeUnit::Nanoseconds => (*v as i64) * NS_IN_DAY,
                     TimeUnit::Microseconds => (*v as i64) * US_IN_DAY,
                     TimeUnit::Milliseconds => (*v as i64) * MS_IN_DAY,
+                    TimeUnit::Seconds => (*v as i64) * SEC_IN_DAY,
                 },
                 *tu,
                 &None,
@@ -562,6 +563,7 @@ impl<'a> AnyValue<'a> {
                 TimeUnit::Nanoseconds => *v / NS_IN_DAY,
                 TimeUnit::Microseconds => *v / US_IN_DAY,
                 TimeUnit::Milliseconds => *v / MS_IN_DAY,
+                TimeUnit::Seconds => *v / SEC_IN_DAY,
             } as i32),
 
             // to time
@@ -572,6 +574,7 @@ impl<'a> AnyValue<'a> {
                 TimeUnit::Nanoseconds => *v % NS_IN_DAY,
                 TimeUnit::Microseconds => (*v % US_IN_DAY) * 1_000i64,
                 TimeUnit::Milliseconds => (*v % MS_IN_DAY) * 1_000_000i64,
+                TimeUnit::Seconds => (*v % SEC_IN_DAY) * 1_000_000_000i64,
             }),
 
             // to duration
@@ -585,6 +588,7 @@ impl<'a> AnyValue<'a> {
                     TimeUnit::Nanoseconds => *v,
                     TimeUnit::Microseconds => *v / 1_000i64,
                     TimeUnit::Milliseconds => *v / 1_000_000i64,
+                    TimeUnit::Seconds => *v / 1_000_000_000i64,
                 },
                 *tu,
             ),
@@ -594,10 +598,16 @@ impl<'a> AnyValue<'a> {
                     (_, _) if tu == tu_r => *v,
                     (TimeUnit::Nanoseconds, TimeUnit::Microseconds) => *v / 1_000i64,
                     (TimeUnit::Nanoseconds, TimeUnit::Milliseconds) => *v / 1_000_000i64,
+                    (TimeUnit::Nanoseconds, TimeUnit::Seconds) => *v / 1_000_000_000i64,
                     (TimeUnit::Microseconds, TimeUnit::Nanoseconds) => *v * 1_000i64,
                     (TimeUnit::Microseconds, TimeUnit::Milliseconds) => *v / 1_000i64,
+                    (TimeUnit::Microseconds, TimeUnit::Seconds) => *v / 1_000_000i64,
                     (TimeUnit::Milliseconds, TimeUnit::Microseconds) => *v * 1_000i64,
                     (TimeUnit::Milliseconds, TimeUnit::Nanoseconds) => *v * 1_000_000i64,
+                    (TimeUnit::Milliseconds, TimeUnit::Seconds) => *v / 1_000i64,
+                    (TimeUnit::Seconds, TimeUnit::Milliseconds) => *v * 1_000i64,
+                    (TimeUnit::Seconds, TimeUnit::Microseconds) => *v * 1_000_000i64,
+                    (TimeUnit::Seconds, TimeUnit::Nanoseconds) => *v * 1_000_000_000i64,
                     _ => *v,
                 },
                 *tu_r,

--- a/crates/polars-core/src/datatypes/time_unit.rs
+++ b/crates/polars-core/src/datatypes/time_unit.rs
@@ -9,6 +9,7 @@ pub enum TimeUnit {
     Nanoseconds,
     Microseconds,
     Milliseconds,
+    Seconds,
 }
 
 impl From<&ArrowTimeUnit> for TimeUnit {
@@ -18,7 +19,7 @@ impl From<&ArrowTimeUnit> for TimeUnit {
             ArrowTimeUnit::Microsecond => TimeUnit::Microseconds,
             ArrowTimeUnit::Millisecond => TimeUnit::Milliseconds,
             // will be cast
-            ArrowTimeUnit::Second => TimeUnit::Milliseconds,
+            ArrowTimeUnit::Second => TimeUnit::Seconds,
         }
     }
 }
@@ -35,6 +36,9 @@ impl Display for TimeUnit {
             TimeUnit::Milliseconds => {
                 write!(f, "ms")
             },
+            TimeUnit::Seconds => {
+                write!(f, "s")
+            },
         }
     }
 }
@@ -46,6 +50,7 @@ impl TimeUnit {
             Nanoseconds => "ns",
             Microseconds => "us",
             Milliseconds => "ms",
+            Seconds => "s",
         }
     }
 
@@ -54,6 +59,7 @@ impl TimeUnit {
             TimeUnit::Nanoseconds => ArrowTimeUnit::Nanosecond,
             TimeUnit::Microseconds => ArrowTimeUnit::Microsecond,
             TimeUnit::Milliseconds => ArrowTimeUnit::Millisecond,
+            TimeUnit::Seconds => ArrowTimeUnit::Second,
         }
     }
 }
@@ -66,10 +72,16 @@ pub(crate) fn convert_time_units(v: i64, tu_l: TimeUnit, tu_r: TimeUnit) -> i64 
     match (tu_l, tu_r) {
         (Nanoseconds, Microseconds) => v / 1_000,
         (Nanoseconds, Milliseconds) => v / 1_000_000,
+        (Nanoseconds, Seconds) => v / 1_000_000_000,
         (Microseconds, Nanoseconds) => v * 1_000,
         (Microseconds, Milliseconds) => v / 1_000,
+        (Microseconds, Seconds) => v / 1_000_000,
         (Milliseconds, Microseconds) => v * 1_000,
         (Milliseconds, Nanoseconds) => v * 1_000_000,
+        (Milliseconds, Seconds) => v / 1_000,
+        (Seconds, Nanoseconds) => v * 1_000_000_000,
+        (Seconds, Microseconds) => v * 1_000_000,
+        (Seconds, Milliseconds) => v * 1_000,
         _ => v,
     }
 }

--- a/crates/polars-core/src/fmt.rs
+++ b/crates/polars-core/src/fmt.rs
@@ -903,6 +903,8 @@ const SIZES_NS: [i64; 4] = [
 const SIZES_US: [i64; 4] = [86_400_000_000, 3_600_000_000, 60_000_000, 1_000_000];
 #[cfg(feature = "dtype-duration")]
 const SIZES_MS: [i64; 4] = [86_400_000, 3_600_000, 60_000, 1_000];
+#[cfg(feature = "dtype-duration")]
+const SIZES_S: [i64; 4] = [86_400, 3_600, 60, 1];
 
 #[cfg(feature = "dtype-duration")]
 fn fmt_duration_ns(f: &mut Formatter<'_>, v: i64) -> fmt::Result {
@@ -943,6 +945,16 @@ fn fmt_duration_ms(f: &mut Formatter<'_>, v: i64) -> fmt::Result {
     if v % 1_000 != 0 {
         write!(f, "{}ms", (v % 1_000))?;
     }
+    Ok(())
+}
+
+#[cfg(feature = "dtype-duration")]
+fn fmt_duration_s(f: &mut Formatter<'_>, v: i64) -> fmt::Result {
+    if v == 0 {
+        return write!(f, "0s");
+    }
+    format_duration(f, v, SIZES_S.as_slice(), NAMES.as_slice())?;
+    write!(f, "{v}s")?;
     Ok(())
 }
 
@@ -1011,6 +1023,7 @@ impl Display for AnyValue<'_> {
                     TimeUnit::Nanoseconds => timestamp_ns_to_datetime(*v),
                     TimeUnit::Microseconds => timestamp_us_to_datetime(*v),
                     TimeUnit::Milliseconds => timestamp_ms_to_datetime(*v),
+                    TimeUnit::Seconds => timestamp_s_to_datetime(*v),
                 };
                 match tz {
                     None => write!(f, "{ndt}"),
@@ -1024,6 +1037,7 @@ impl Display for AnyValue<'_> {
                 TimeUnit::Nanoseconds => fmt_duration_ns(f, *v),
                 TimeUnit::Microseconds => fmt_duration_us(f, *v),
                 TimeUnit::Milliseconds => fmt_duration_ms(f, *v),
+                TimeUnit::Seconds => fmt_duration_s(f, *v),
             },
             #[cfg(feature = "dtype-time")]
             AnyValue::Time(_) => {

--- a/crates/polars-core/src/series/implementations/duration.rs
+++ b/crates/polars-core/src/series/implementations/duration.rs
@@ -144,6 +144,7 @@ impl private::PrivateSeries for SeriesWrap<DurationChunked> {
             },
             (DataType::Duration(tu), DataType::Date) => {
                 let one_day_in_tu: i64 = match tu {
+                    TimeUnit::Seconds => 86_400,
                     TimeUnit::Milliseconds => 86_400_000,
                     TimeUnit::Microseconds => 86_400_000_000,
                     TimeUnit::Nanoseconds => 86_400_000_000_000,

--- a/crates/polars-io/src/csv/write_impl.rs
+++ b/crates/polars-io/src/csv/write_impl.rs
@@ -175,6 +175,9 @@ unsafe fn write_any_value(
                                 TimeUnit::Milliseconds => {
                                     temporal_conversions::timestamp_ms_to_datetime(v)
                                 },
+                                TimeUnit::Seconds => {
+                                    temporal_conversions::timestamp_s_to_datetime(v)
+                                },
                             };
                             let formatted = match time_zone {
                                 #[cfg(feature = "timezones")]

--- a/crates/polars-lazy/src/physical_plan/executors/join.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/join.rs
@@ -126,6 +126,7 @@ impl Executor for JoinExec {
                                     TimeUnit::Nanoseconds => duration.duration_ns(),
                                     TimeUnit::Microseconds => duration.duration_us(),
                                     TimeUnit::Milliseconds => duration.duration_ms(),
+                                    TimeUnit::Seconds => duration.duration_s(),
                                 };
                                 options.tolerance = Some(AnyValue::from(tolerance))
                             }

--- a/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
+++ b/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
@@ -2,7 +2,8 @@ use std::str::FromStr;
 
 use arrow::legacy::kernels::{convert_to_naive_local, Ambiguous};
 use arrow::temporal_conversions::{
-    timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
+    timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_s_to_datetime,
+    timestamp_us_to_datetime,
 };
 use chrono::NaiveDateTime;
 use chrono_tz::UTC;
@@ -30,11 +31,13 @@ pub fn replace_time_zone(
         return Ok(out);
     }
     let timestamp_to_datetime: fn(i64) -> NaiveDateTime = match datetime.time_unit() {
+        TimeUnit::Seconds => timestamp_s_to_datetime,
         TimeUnit::Milliseconds => timestamp_ms_to_datetime,
         TimeUnit::Microseconds => timestamp_us_to_datetime,
         TimeUnit::Nanoseconds => timestamp_ns_to_datetime,
     };
     let datetime_to_timestamp: fn(NaiveDateTime) -> i64 = match datetime.time_unit() {
+        TimeUnit::Seconds => datetime_to_timestamp_s,
         TimeUnit::Milliseconds => datetime_to_timestamp_ms,
         TimeUnit::Microseconds => datetime_to_timestamp_us,
         TimeUnit::Nanoseconds => datetime_to_timestamp_ns,

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -154,6 +154,7 @@ pub(super) fn datetime(
                 NaiveDate::from_ymd_opt(y, m, d)
                     .and_then(|nd| nd.and_hms_micro_opt(h, mnt, s, us))
                     .map(|ndt| match time_unit {
+                        TimeUnit::Seconds => ndt.timestamp(),
                         TimeUnit::Milliseconds => ndt.timestamp_millis(),
                         TimeUnit::Microseconds => ndt.timestamp_micros(),
                         TimeUnit::Nanoseconds => ndt.timestamp_nanos_opt().unwrap(),
@@ -245,6 +246,7 @@ pub(super) fn date_offset(s: &[Series]) -> PolarsResult<Series> {
                 TimeUnit::Nanoseconds => Duration::add_ns,
                 TimeUnit::Microseconds => Duration::add_us,
                 TimeUnit::Milliseconds => Duration::add_ms,
+                TimeUnit::Seconds => Duration::add_s,
             };
 
             let out = match tz {

--- a/crates/polars-time/src/base_utc_offset.rs
+++ b/crates/polars-time/src/base_utc_offset.rs
@@ -2,7 +2,8 @@
 use arrow::legacy::time_zone::Tz;
 #[cfg(feature = "timezones")]
 use arrow::temporal_conversions::{
-    timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_us_to_datetime,
+    timestamp_ms_to_datetime, timestamp_ns_to_datetime, timestamp_s_to_datetime,
+    timestamp_us_to_datetime,
 };
 #[cfg(feature = "timezones")]
 use chrono::TimeZone;
@@ -20,6 +21,7 @@ pub fn base_utc_offset(
         TimeUnit::Nanoseconds => timestamp_ns_to_datetime,
         TimeUnit::Microseconds => timestamp_us_to_datetime,
         TimeUnit::Milliseconds => timestamp_ms_to_datetime,
+        TimeUnit::Seconds => timestamp_s_to_datetime,
     };
     ca.0.apply_values(|t| {
         let ndt = timestamp_to_datetime(t);

--- a/crates/polars-time/src/chunkedarray/datetime.rs
+++ b/crates/polars-time/src/chunkedarray/datetime.rs
@@ -43,6 +43,7 @@ pub trait DatetimeMethods: AsDatetime {
             TimeUnit::Nanoseconds => datetime_to_is_leap_year_ns,
             TimeUnit::Microseconds => datetime_to_is_leap_year_us,
             TimeUnit::Milliseconds => datetime_to_is_leap_year_ms,
+            TimeUnit::Seconds => datetime_to_is_leap_year_s,
         };
         ca.apply_kernel_cast::<BooleanType>(&f)
     }
@@ -53,6 +54,7 @@ pub trait DatetimeMethods: AsDatetime {
             TimeUnit::Nanoseconds => datetime_to_iso_year_ns,
             TimeUnit::Microseconds => datetime_to_iso_year_us,
             TimeUnit::Milliseconds => datetime_to_iso_year_ms,
+            TimeUnit::Seconds => datetime_to_iso_year_s,
         };
         ca.apply_kernel_cast::<Int32Type>(&f)
     }
@@ -126,6 +128,7 @@ pub trait DatetimeMethods: AsDatetime {
             TimeUnit::Nanoseconds => datetime_to_ordinal_ns,
             TimeUnit::Microseconds => datetime_to_ordinal_us,
             TimeUnit::Milliseconds => datetime_to_ordinal_ms,
+            TimeUnit::Seconds => datetime_to_ordinal_s,
         };
         ca.apply_kernel_cast::<Int16Type>(&f)
     }
@@ -135,6 +138,7 @@ pub trait DatetimeMethods: AsDatetime {
             TimeUnit::Nanoseconds => datetime_to_timestamp_ns,
             TimeUnit::Microseconds => datetime_to_timestamp_us,
             TimeUnit::Milliseconds => datetime_to_timestamp_ms,
+            TimeUnit::Seconds => datetime_to_timestamp_s,
         };
 
         Int64Chunked::from_iter_options(

--- a/crates/polars-time/src/chunkedarray/duration.rs
+++ b/crates/polars-time/src/chunkedarray/duration.rs
@@ -1,10 +1,11 @@
 use arrow::temporal_conversions::{
-    MICROSECONDS, MILLISECONDS, MILLISECONDS_IN_DAY, NANOSECONDS, SECONDS_IN_DAY,
+    MICROSECONDS, MILLISECONDS, MILLISECONDS_IN_DAY, NANOSECONDS, SECONDS, SECONDS_IN_DAY,
 };
 
 use super::*;
 
 const NANOSECONDS_IN_MILLISECOND: i64 = 1_000_000;
+const NANOSECONDS_IN_SECOND: i64 = 1_000_000_000;
 const SECONDS_IN_HOUR: i64 = 3600;
 
 pub trait DurationMethods {
@@ -34,6 +35,7 @@ impl DurationMethods for DurationChunked {
     /// Extract the hours from a `Duration`
     fn hours(&self) -> Int64Chunked {
         match self.time_unit() {
+            TimeUnit::Seconds => (&self.0).wrapping_trunc_div_scalar(SECONDS_IN_HOUR),
             TimeUnit::Milliseconds => {
                 (&self.0).wrapping_trunc_div_scalar(MILLISECONDS * SECONDS_IN_HOUR)
             },
@@ -49,6 +51,7 @@ impl DurationMethods for DurationChunked {
     /// Extract the days from a `Duration`
     fn days(&self) -> Int64Chunked {
         match self.time_unit() {
+            TimeUnit::Seconds => (&self.0).wrapping_trunc_div_scalar(SECONDS_IN_DAY),
             TimeUnit::Milliseconds => (&self.0).wrapping_trunc_div_scalar(MILLISECONDS_IN_DAY),
             TimeUnit::Microseconds => {
                 (&self.0).wrapping_trunc_div_scalar(MICROSECONDS * SECONDS_IN_DAY)
@@ -62,6 +65,7 @@ impl DurationMethods for DurationChunked {
     /// Extract the seconds from a `Duration`
     fn minutes(&self) -> Int64Chunked {
         match self.time_unit() {
+            TimeUnit::Seconds => (&self.0).wrapping_trunc_div_scalar(SECONDS * 60),
             TimeUnit::Milliseconds => (&self.0).wrapping_trunc_div_scalar(MILLISECONDS * 60),
             TimeUnit::Microseconds => (&self.0).wrapping_trunc_div_scalar(MICROSECONDS * 60),
             TimeUnit::Nanoseconds => (&self.0).wrapping_trunc_div_scalar(NANOSECONDS * 60),
@@ -71,6 +75,7 @@ impl DurationMethods for DurationChunked {
     /// Extract the seconds from a `Duration`
     fn seconds(&self) -> Int64Chunked {
         match self.time_unit() {
+            TimeUnit::Seconds => (&self.0).wrapping_trunc_div_scalar(SECONDS),
             TimeUnit::Milliseconds => (&self.0).wrapping_trunc_div_scalar(MILLISECONDS),
             TimeUnit::Microseconds => (&self.0).wrapping_trunc_div_scalar(MICROSECONDS),
             TimeUnit::Nanoseconds => (&self.0).wrapping_trunc_div_scalar(NANOSECONDS),
@@ -80,6 +85,7 @@ impl DurationMethods for DurationChunked {
     /// Extract the milliseconds from a `Duration`
     fn milliseconds(&self) -> Int64Chunked {
         match self.time_unit() {
+            TimeUnit::Seconds => &self.0 * 1000,
             TimeUnit::Milliseconds => self.0.clone(),
             TimeUnit::Microseconds => self.0.clone().wrapping_trunc_div_scalar(1000),
             TimeUnit::Nanoseconds => {
@@ -91,6 +97,7 @@ impl DurationMethods for DurationChunked {
     /// Extract the microseconds from a `Duration`
     fn microseconds(&self) -> Int64Chunked {
         match self.time_unit() {
+            TimeUnit::Seconds => &self.0 * 1_000_000,
             TimeUnit::Milliseconds => &self.0 * 1000,
             TimeUnit::Microseconds => self.0.clone(),
             TimeUnit::Nanoseconds => (&self.0).wrapping_trunc_div_scalar(1000),
@@ -100,6 +107,7 @@ impl DurationMethods for DurationChunked {
     /// Extract the nanoseconds from a `Duration`
     fn nanoseconds(&self) -> Int64Chunked {
         match self.time_unit() {
+            TimeUnit::Seconds => &self.0 * NANOSECONDS_IN_SECOND,
             TimeUnit::Milliseconds => &self.0 * NANOSECONDS_IN_MILLISECOND,
             TimeUnit::Microseconds => &self.0 * 1000,
             TimeUnit::Nanoseconds => self.0.clone(),

--- a/crates/polars-time/src/chunkedarray/kernels.rs
+++ b/crates/polars-time/src/chunkedarray/kernels.rs
@@ -6,7 +6,7 @@ use arrow::compute::arity::unary;
 use arrow::temporal_conversions::time64ns_to_time_opt;
 use arrow::temporal_conversions::{
     date32_to_datetime_opt, timestamp_ms_to_datetime_opt, timestamp_ns_to_datetime_opt,
-    timestamp_us_to_datetime_opt,
+    timestamp_s_to_datetime_opt, timestamp_us_to_datetime_opt,
 };
 use chrono::{Datelike, Timelike};
 
@@ -206,6 +206,15 @@ to_temporal_unit!(
 
 #[cfg(feature = "dtype-datetime")]
 to_temporal_unit!(
+    datetime_to_ordinal_s,
+    ordinal,
+    timestamp_s_to_datetime_opt,
+    i64,
+    i16,
+    ArrowDataType::Int16
+);
+#[cfg(feature = "dtype-datetime")]
+to_temporal_unit!(
     datetime_to_ordinal_ms,
     ordinal,
     timestamp_ms_to_datetime_opt,
@@ -253,6 +262,15 @@ to_temporal_unit!(
     ArrowDataType::Int32
 );
 #[cfg(feature = "dtype-datetime")]
+to_temporal_unit!(
+    datetime_to_iso_year_s,
+    iso_year,
+    timestamp_s_to_datetime_opt,
+    i64,
+    i32,
+    ArrowDataType::Int32
+);
+#[cfg(feature = "dtype-datetime")]
 to_boolean_temporal_unit!(
     datetime_to_is_leap_year_ns,
     year,
@@ -274,5 +292,13 @@ to_boolean_temporal_unit!(
     year,
     is_leap_year,
     timestamp_ms_to_datetime_opt,
+    i64
+);
+#[cfg(feature = "dtype-datetime")]
+to_boolean_temporal_unit!(
+    datetime_to_is_leap_year_s,
+    year,
+    is_leap_year,
+    timestamp_s_to_datetime_opt,
     i64
 );

--- a/crates/polars-time/src/chunkedarray/string/mod.rs
+++ b/crates/polars-time/src/chunkedarray/string/mod.rs
@@ -176,6 +176,7 @@ pub trait StringMethods: AsString {
             TimeUnit::Nanoseconds => datetime_to_timestamp_ns,
             TimeUnit::Microseconds => datetime_to_timestamp_us,
             TimeUnit::Milliseconds => datetime_to_timestamp_ms,
+            TimeUnit::Seconds => datetime_to_timestamp_s,
         };
 
         let ca = string_ca
@@ -281,6 +282,7 @@ pub trait StringMethods: AsString {
             TimeUnit::Nanoseconds => datetime_to_timestamp_ns,
             TimeUnit::Microseconds => datetime_to_timestamp_us,
             TimeUnit::Milliseconds => datetime_to_timestamp_ms,
+            TimeUnit::Seconds => datetime_to_timestamp_s,
         };
 
         if tz_aware {
@@ -304,6 +306,7 @@ pub trait StringMethods: AsString {
                 TimeUnit::Nanoseconds => infer::transform_datetime_ns,
                 TimeUnit::Microseconds => infer::transform_datetime_us,
                 TimeUnit::Milliseconds => infer::transform_datetime_ms,
+                TimeUnit::Seconds => infer::transform_datetime_s,
             };
             // We can use the fast parser.
             let ca = if let Some(fmt_len) = self::strptime::fmt_len(fmt.as_bytes()) {

--- a/crates/polars-time/src/date_range.rs
+++ b/crates/polars-time/src/date_range.rs
@@ -28,6 +28,7 @@ pub fn date_range(
         ),
         TimeUnit::Microseconds => (start.timestamp_micros(), end.timestamp_micros()),
         TimeUnit::Milliseconds => (start.timestamp_millis(), end.timestamp_millis()),
+        TimeUnit::Seconds => (start.timestamp(), end.timestamp()),
     };
     datetime_range_impl(name, start, end, interval, closed, tu, tz)
 }
@@ -119,6 +120,10 @@ pub(crate) fn datetime_range_i64(
         TimeUnit::Milliseconds => {
             size = ((end - start) / interval.duration_ms() + 1) as usize;
             offset_fn = Duration::add_ms;
+        },
+        TimeUnit::Seconds => {
+            size = ((end - start) / interval.duration_s() + 1) as usize;
+            offset_fn = Duration::add_s;
         },
     }
     let mut ts = Vec::with_capacity(size);

--- a/crates/polars-time/src/dst_offset.rs
+++ b/crates/polars-time/src/dst_offset.rs
@@ -13,10 +13,13 @@ use polars_core::utils::arrow::temporal_conversions::{
 
 #[cfg(feature = "timezones")]
 pub fn dst_offset(ca: &DatetimeChunked, time_unit: &TimeUnit, time_zone: &Tz) -> DurationChunked {
+    use arrow::temporal_conversions::timestamp_s_to_datetime;
+
     let timestamp_to_datetime = match time_unit {
         TimeUnit::Nanoseconds => timestamp_ns_to_datetime,
         TimeUnit::Microseconds => timestamp_us_to_datetime,
         TimeUnit::Milliseconds => timestamp_ms_to_datetime,
+        TimeUnit::Seconds => timestamp_s_to_datetime,
     };
     ca.0.apply_values(|t| {
         let ndt = timestamp_to_datetime(t);

--- a/crates/polars-time/src/month_end.rs
+++ b/crates/polars-time/src/month_end.rs
@@ -1,4 +1,5 @@
 use arrow::legacy::time_zone::Tz;
+use arrow::temporal_conversions::timestamp_s_to_datetime;
 use chrono::NaiveDateTime;
 use polars_core::prelude::*;
 use polars_core::utils::arrow::temporal_conversions::{
@@ -48,6 +49,11 @@ impl PolarsMonthEnd for DatetimeChunked {
                 timestamp_to_datetime = timestamp_ms_to_datetime;
                 datetime_to_timestamp = datetime_to_timestamp_ms;
                 offset_fn = Duration::add_ms;
+            },
+            TimeUnit::Seconds => {
+                timestamp_to_datetime = timestamp_s_to_datetime;
+                datetime_to_timestamp = datetime_to_timestamp_s;
+                offset_fn = Duration::add_s;
             },
         };
         Ok(self

--- a/crates/polars-time/src/month_start.rs
+++ b/crates/polars-time/src/month_start.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "timezones")]
 use arrow::legacy::kernels::Ambiguous;
 use arrow::legacy::time_zone::Tz;
+use arrow::temporal_conversions::timestamp_s_to_datetime;
 use chrono::{Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
 use polars_core::prelude::*;
 use polars_core::utils::arrow::temporal_conversions::{
@@ -77,6 +78,10 @@ impl PolarsMonthStart for DatetimeChunked {
             TimeUnit::Milliseconds => {
                 timestamp_to_datetime = timestamp_ms_to_datetime;
                 datetime_to_timestamp = datetime_to_timestamp_ms;
+            },
+            TimeUnit::Seconds => {
+                timestamp_to_datetime = timestamp_s_to_datetime;
+                datetime_to_timestamp = datetime_to_timestamp_s;
             },
         };
         Ok(self

--- a/crates/polars-time/src/round.rs
+++ b/crates/polars-time/src/round.rs
@@ -18,6 +18,7 @@ impl PolarsRound for DatetimeChunked {
             TimeUnit::Nanoseconds => Window::round_ns,
             TimeUnit::Microseconds => Window::round_us,
             TimeUnit::Milliseconds => Window::round_ms,
+            TimeUnit::Seconds => Window::round_s,
         };
 
         let out = { self.try_apply(|t| func(&w, t, tz)) };

--- a/crates/polars-time/src/truncate.rs
+++ b/crates/polars-time/src/truncate.rs
@@ -19,6 +19,7 @@ impl PolarsTruncate for DatetimeChunked {
             TimeUnit::Nanoseconds => Window::truncate_ns,
             TimeUnit::Microseconds => Window::truncate_us,
             TimeUnit::Milliseconds => Window::truncate_ms,
+            TimeUnit::Seconds => Window::truncate_s,
         };
 
         let out = match every.len() {

--- a/crates/polars-time/src/upsample.rs
+++ b/crates/polars-time/src/upsample.rs
@@ -176,6 +176,7 @@ fn upsample_single_impl(
                         TimeUnit::Nanoseconds => offset.add_ns(first, tz.as_ref())?,
                         TimeUnit::Microseconds => offset.add_us(first, tz.as_ref())?,
                         TimeUnit::Milliseconds => offset.add_ms(first, tz.as_ref())?,
+                        TimeUnit::Seconds => offset.add_s(first, tz.as_ref())?,
                     };
                     let range = datetime_range_impl(
                         index_col_name,

--- a/crates/polars-time/src/windows/group_by.rs
+++ b/crates/polars-time/src/windows/group_by.rs
@@ -163,6 +163,7 @@ pub fn group_by_windows(
             TimeUnit::Nanoseconds => window.estimate_overlapping_bounds_ns(boundary),
             TimeUnit::Microseconds => window.estimate_overlapping_bounds_us(boundary),
             TimeUnit::Milliseconds => window.estimate_overlapping_bounds_ms(boundary),
+            TimeUnit::Seconds => window.estimate_overlapping_bounds_s(boundary),
         }
     };
     let size_lower = if include_lower_bound { size } else { 0 };
@@ -236,6 +237,7 @@ pub(crate) fn group_by_values_iter_lookbehind(
         TimeUnit::Nanoseconds => Duration::add_ns,
         TimeUnit::Microseconds => Duration::add_us,
         TimeUnit::Milliseconds => Duration::add_ms,
+        TimeUnit::Seconds => Duration::add_s,
     };
 
     let upper_bound = upper_bound.unwrap_or(time.len());
@@ -308,6 +310,7 @@ pub(crate) fn group_by_values_iter_window_behind_t(
         TimeUnit::Nanoseconds => Duration::add_ns,
         TimeUnit::Microseconds => Duration::add_us,
         TimeUnit::Milliseconds => Duration::add_ms,
+        TimeUnit::Seconds => Duration::add_s,
     };
 
     let mut start = 0;
@@ -358,6 +361,7 @@ pub(crate) fn group_by_values_iter_partial_lookbehind(
         TimeUnit::Nanoseconds => Duration::add_ns,
         TimeUnit::Microseconds => Duration::add_us,
         TimeUnit::Milliseconds => Duration::add_ms,
+        TimeUnit::Seconds => Duration::add_s,
     };
 
     let mut start = 0;
@@ -410,6 +414,7 @@ pub(crate) fn group_by_values_iter_lookahead(
         TimeUnit::Nanoseconds => Duration::add_ns,
         TimeUnit::Microseconds => Duration::add_us,
         TimeUnit::Milliseconds => Duration::add_ms,
+        TimeUnit::Seconds => Duration::add_s,
     };
     let mut start = start_offset;
     let mut end = start;

--- a/py-polars/src/conversion/mod.rs
+++ b/py-polars/src/conversion/mod.rs
@@ -427,6 +427,7 @@ impl ToPyObject for Wrap<TimeUnit> {
             TimeUnit::Nanoseconds => "ns",
             TimeUnit::Microseconds => "us",
             TimeUnit::Milliseconds => "ms",
+            TimeUnit::Seconds => "s",
         };
         time_unit.into_py(py)
     }


### PR DESCRIPTION
```
┌─────────────────────┬─
│ column_1            ┆ 
│ ---                 ┆ 
│ datetime[s]         ┆ 
╞═════════════════════╪═
│ 2023-12-29 18:00:00 ┆ 
│ 2023-12-29 18:01:00 ┆ 
│ 2023-12-29 18:02:00 ┆ 
│ 2023-12-29 18:03:00 ┆ 
│ 2023-12-29 18:04:00 ┆ 
│ …                   ┆ 
│ 2024-02-27 19:14:00 ┆ 
│ 2024-02-27 19:15:00 ┆ 
│ 2024-02-27 19:16:00 ┆ 
│ 2024-02-27 19:17:00 ┆ 
│ 2024-02-27 19:18:00 ┆ 
└─────────────────────┴─
```

from:

```
1703872800,
1703872860,
1703872920,
1703872980,
1703873040,
1703873100,
...
1709061240,
1709061300,
1709061360,
1709061420,
1709061480,
```