### PR TITLE
feat: cleanup spill disks in process

### DIFF
--- a/crates/polars-pipe/src/executors/sinks/io.rs
+++ b/crates/polars-pipe/src/executors/sinks/io.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{Duration, SystemTime};
 
-use crossbeam_channel::{bounded, Sender};
+use crossbeam_channel::{bounded, unbounded, Receiver, Sender};
 use polars_core::error::ErrString;
 use polars_core::prelude::*;
 use polars_core::utils::arrow::temporal_conversions::SECONDS_IN_DAY;
@@ -20,7 +20,8 @@ type Payload = (Option<IdxCa>, DfIter);
 
 /// A helper that can be used to spill to disk
 pub(crate) struct IOThread {
-    sender: Sender<Payload>,
+    payload_tx: Sender<Payload>,
+    cleanup_tx: Sender<PathBuf>,
     _lockfile: Arc<LockFile>,
     pub(in crate::executors::sinks) dir: PathBuf,
     pub(in crate::executors::sinks) sent: Arc<AtomicUsize>,
@@ -72,8 +73,9 @@ fn clean_after_delay(time: Option<SystemTime>, secs: u64, path: &Path) {
 
 /// Starts a new thread that will clean up operations of directories that don't
 /// have a lockfile (opened with 'w' permissions).
-fn gc_thread(operation_name: &'static str) {
+fn gc_thread(operation_name: &'static str, rx: Receiver<PathBuf>) {
     let _ = std::thread::spawn(move || {
+        // First clean all existing
         let mut dir = std::path::PathBuf::from(get_base_temp_dir());
         dir.push(&format!("polars/{operation_name}"));
 
@@ -108,6 +110,15 @@ fn gc_thread(operation_name: &'static str) {
                 }
             }
         }
+
+        // Clean on receive
+        while let Ok(path) = rx.recv() {
+            if path.is_file() {
+                let _ = std::fs::remove_file(path);
+            } else {
+                let _ = std::fs::remove_dir_all(path);
+            }
+        }
     });
 }
 
@@ -124,12 +135,13 @@ impl IOThread {
         let lockfile_path = get_lockfile_path(&dir);
         let lockfile = Arc::new(LockFile::new(lockfile_path)?);
 
+        let (cleanup_tx, rx) = unbounded::<PathBuf>();
         // start a thread that will clean up old dumps.
         // TODO: if we will have more ooc in the future  we will have a dedicated GC thread
-        gc_thread(operation_name);
+        gc_thread(operation_name, rx);
 
         // we need some pushback otherwise we still could go OOM.
-        let (sender, receiver) = bounded::<Payload>(morsels_per_sink() * 2);
+        let (tx, rx) = bounded::<Payload>(morsels_per_sink() * 2);
 
         let sent: Arc<AtomicUsize> = Default::default();
         let total: Arc<AtomicUsize> = Default::default();
@@ -152,7 +164,7 @@ impl IOThread {
             //    This will dump to `dir/count.ipc`
             // 2. (Some(partitions), DfIter)
             //    This will dump to `dir/partition/count.ipc`
-            while let Ok((partitions, iter)) = receiver.recv() {
+            while let Ok((partitions, iter)) = rx.recv() {
                 if let Some(partitions) = partitions {
                     for (part, df) in partitions.into_no_null_iter().zip(iter) {
                         let mut path = dir2.clone();
@@ -188,7 +200,8 @@ impl IOThread {
         });
 
         Ok(Self {
-            sender,
+            payload_tx: tx,
+            cleanup_tx,
             dir,
             sent,
             total,
@@ -201,7 +214,7 @@ impl IOThread {
     pub(in crate::executors::sinks) fn dump_chunk(&self, mut df: DataFrame) {
         // if IO thread is blocked
         // we write locally on this thread
-        if self.sender.is_full() {
+        if self.payload_tx.is_full() {
             let mut path = self.dir.clone();
             let count = self.thread_local_count.fetch_add(1, Ordering::Relaxed);
             // thread local name we start with an underscore to ensure we don't get
@@ -215,6 +228,10 @@ impl IOThread {
             let iter = Box::new(std::iter::once(df));
             self.dump_iter(None, iter)
         }
+    }
+
+    pub(in crate::executors::sinks) fn clean(&self, path: PathBuf) {
+        self.cleanup_tx.send(path).unwrap()
     }
 
     pub(in crate::executors::sinks) fn dump_partition(&self, partition_no: IdxSize, df: DataFrame) {
@@ -245,7 +262,7 @@ impl IOThread {
 
     pub(in crate::executors::sinks) fn dump_iter(&self, partition: Option<IdxCa>, iter: DfIter) {
         let add = iter.size_hint().1.unwrap();
-        self.sender.send((partition, iter)).unwrap();
+        self.payload_tx.send((partition, iter)).unwrap();
         self.sent.fetch_add(add, Ordering::Relaxed);
     }
 }

--- a/crates/polars-pipe/src/executors/sinks/sort/ooc.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/ooc.rs
@@ -105,7 +105,7 @@ impl PartitionSpiller {
 }
 
 pub(super) fn sort_ooc(
-    io_thread: &IOThread,
+    io_thread: IOThread,
     // these partitions are the samples
     // these are not yet assigned to a buckets
     samples: Series,
@@ -147,10 +147,11 @@ pub(super) fn sort_ooc(
                     io_thread.dump_partition_local(part, df)
                 }
             }
+            io_thread.clean(path);
             PolarsResult::Ok(())
         })
     })?;
-    partitions_spiller.spill_all(io_thread);
+    partitions_spiller.spill_all(&io_thread);
     if verbose {
         eprintln!("finished partitioning sort files");
     }
@@ -172,7 +173,7 @@ pub(super) fn sort_ooc(
         })
         .collect::<std::io::Result<Vec<_>>>()?;
 
-    let source = SortSource::new(files, idx, descending, slice, verbose);
+    let source = SortSource::new(files, idx, descending, slice, verbose, io_thread);
     Ok(FinalizedSink::Source(Box::new(source)))
 }
 

--- a/crates/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -170,8 +170,8 @@ impl Sink for SortSink {
         if self.ooc {
             // spill everything
             self.dump(true).unwrap();
-            let lock = self.io_thread.read().unwrap();
-            let io_thread = lock.as_ref().unwrap();
+            let mut lock = self.io_thread.write().unwrap();
+            let io_thread = lock.take().unwrap();
 
             let dist = Series::from_any_values("", &self.dist_sample, true).unwrap();
             let dist = dist.sort_with(SortOptions {
@@ -181,7 +181,7 @@ impl Sink for SortSink {
                 maintain_order: self.sort_args.maintain_order,
             });
 
-            block_thread_until_io_thread_done(io_thread);
+            block_thread_until_io_thread_done(&io_thread);
 
             sort_ooc(
                 io_thread,


### PR DESCRIPTION
This cleans up spilling directories during the process. This significantly reduces used disk storage. As spilling algorithms need multiple passes, they multiply the data on disk. Spilling a large `(1_000_000, 56)` DataFrame full with string data went from `du -h` `1.9G` to `20K`.

This also speeds up the out-of-core sort from `~15s` to `~9s`, I expect due to less IO cache flushing.