### PR TITLE
refactor(rust): Extract key value construction

### DIFF
--- a/crates/polars-arrow/src/io/ipc/write/schema.rs
+++ b/crates/polars-arrow/src/io/ipc/write/schema.rs
@@ -38,18 +38,13 @@ pub fn serialize_schema(
         .map(|(field, ipc_field)| serialize_field(field, ipc_field))
         .collect::<Vec<_>>();
 
-    let mut custom_metadata = vec![];
-    for (key, value) in &schema.metadata {
-        custom_metadata.push(arrow_format::ipc::KeyValue {
-            key: Some(key.clone()),
-            value: Some(value.clone()),
-        });
-    }
-    let custom_metadata = if custom_metadata.is_empty() {
-        None
-    } else {
-        Some(custom_metadata)
-    };
+    let custom_metadata = schema
+        .metadata
+        .iter()
+        .map(|(k, v)| key_value(k, v))
+        .collect::<Vec<_>>();
+
+    let custom_metadata = (!custom_metadata.is_empty()).then_some(custom_metadata);
 
     arrow_format::ipc::Schema {
         endianness,
@@ -59,14 +54,17 @@ pub fn serialize_schema(
     }
 }
 
+fn key_value(key: impl Into<String>, val: impl Into<String>) -> arrow_format::ipc::KeyValue {
+    arrow_format::ipc::KeyValue {
+        key: Some(key.into()),
+        value: Some(val.into()),
+    }
+}
+
 fn write_metadata(metadata: &Metadata, kv_vec: &mut Vec<arrow_format::ipc::KeyValue>) {
     for (k, v) in metadata {
         if k != "ARROW:extension:name" && k != "ARROW:extension:metadata" {
-            let entry = arrow_format::ipc::KeyValue {
-                key: Some(k.clone()),
-                value: Some(v.clone()),
-            };
-            kv_vec.push(entry);
+            kv_vec.push(key_value(k, v));
         }
     }
 }
@@ -76,21 +74,11 @@ fn write_extension(
     metadata: &Option<String>,
     kv_vec: &mut Vec<arrow_format::ipc::KeyValue>,
 ) {
-    // metadata
     if let Some(metadata) = metadata {
-        let entry = arrow_format::ipc::KeyValue {
-            key: Some("ARROW:extension:metadata".to_string()),
-            value: Some(metadata.clone()),
-        };
-        kv_vec.push(entry);
+        kv_vec.push(key_value("ARROW:extension:metadata", metadata));
     }
 
-    // name
-    let entry = arrow_format::ipc::KeyValue {
-        key: Some("ARROW:extension:name".to_string()),
-        value: Some(name.to_string()),
-    };
-    kv_vec.push(entry);
+    kv_vec.push(key_value("ARROW:extension:name", name));
 }
 
 /// Create an IPC Field from an Arrow Field


### PR DESCRIPTION
This refactor reduces some duplication and uses a functional programming style to construct a vector. There *should* not be any functional changes.

I understand that these sorts of changes may not be desired. I mostly opened this to practice the process and I am okay with this being closed.