### PR TITLE
docs(python): Add examples for `polars.read_parquet` and `polars.read_parquet_schema`

### DIFF
--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -250,7 +250,7 @@ def scan_parquet(
     *,
     n_rows: int | None = None,
     row_index_name: str | None = None,
-row_index_offset: int = 0,
+    row_index_offset: int = 0,
     parallel: ParallelStrategy = "auto",
     use_statistics: bool = True,
     hive_partitioning: bool = True,

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -121,6 +121,20 @@ def read_parquet(
         data will be stored continuously in memory. Set `rechunk=False` if you are
         benchmarking the parquet-reader as `rechunk` can be an expensive operation
         that should not contribute to the timings.
+
+    Examples
+    --------
+    >>> pl.read_parquet('ballondor.parquet')
+    shape: (3, 3)
+    ┌──────┬─────────┬──────────┐
+    │ yr   ┆ name    ┆ country  │
+    │ ---  ┆ ---     ┆ ---      │
+    │ i64  ┆ str     ┆ str      │
+    ╞══════╪═════════╪══════════╡
+    │ 1999 ┆ Rivaldo ┆ Brazil   │
+    │ 2000 ┆ Figo    ┆ Portugal │
+    │ 2001 ┆ Owen    ┆ England  │
+    └──────┴─────────┴──────────┘
     """
     # Dispatch to pyarrow if requested
     if use_pyarrow:
@@ -220,7 +234,7 @@ def scan_parquet(
     *,
     n_rows: int | None = None,
     row_index_name: str | None = None,
-    row_index_offset: int = 0,
+row_index_offset: int = 0,
     parallel: ParallelStrategy = "auto",
     use_statistics: bool = True,
     hive_partitioning: bool = True,

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -220,6 +220,22 @@ def read_parquet_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, Dat
     -------
     dict
         Dictionary mapping column names to datatypes
+
+    Examples
+    --------
+    >>> pl.read_parquet('ballondor.parquet')
+    shape: (3, 3)
+    ┌──────┬─────────┬──────────┐
+    │ yr   ┆ name    ┆ country  │
+    │ ---  ┆ ---     ┆ ---      │
+    │ i64  ┆ str     ┆ str      │
+    ╞══════╪═════════╪══════════╡
+    │ 1999 ┆ Rivaldo ┆ Brazil   │
+    │ 2000 ┆ Figo    ┆ Portugal │
+    │ 2001 ┆ Owen    ┆ England  │
+    └──────┴─────────┴──────────┘
+    >>> pl.read_parquet_schema('ballondor.parquet')
+    {'yr': Int64, 'name': String, 'country': String}
     """
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source)


### PR DESCRIPTION
Added examples for the methods `polars.read_parquet()` and `polars.read_parquet_schema()`

This change is part of the issue: [Add missing docstring examples](https://github.com/pola-rs/polars/issues/13161), which has a **good first issue** label.

This is my first commit to the project, i followed the [contribution guide](https://docs.pola.rs/development/contributing/), and took inspiration in other pull requests to be sure. Please let me know of any mistakes I've possibly made during the process.