### PR TITLE
refactor(rust): introduce partitioned table

### DIFF
--- a/crates/polars-pipe/src/executors/sinks/joins/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/mod.rs
@@ -3,7 +3,60 @@ mod cross;
 mod generic_build;
 mod generic_probe_inner_left;
 
+use std::hash::{BuildHasherDefault, Hash, Hasher};
+
 #[cfg(feature = "cross_join")]
 pub(crate) use cross::*;
 pub(crate) use generic_build::GenericBuild;
+use polars_core::hashing::IdHasher;
+use polars_core::prelude::IdxSize;
 use polars_ops::prelude::JoinType;
+use polars_utils::idx_vec::UnitVec;
+use polars_utils::index::ChunkId;
+use polars_utils::partitioned::PartitionedHashMap;
+
+trait ToRow {
+    fn get_row(&self) -> &[u8];
+}
+
+impl ToRow for &[u8] {
+    #[inline(always)]
+    fn get_row(&self) -> &[u8] {
+        self
+    }
+}
+
+impl ToRow for Option<&[u8]> {
+    #[inline(always)]
+    fn get_row(&self) -> &[u8] {
+        self.unwrap()
+    }
+}
+
+// This is the hash and the Index offset in the chunks and the index offset in the dataframe
+#[derive(Copy, Clone, Debug)]
+pub(super) struct Key {
+    pub(super) hash: u64,
+    chunk_idx: IdxSize,
+    df_idx: IdxSize,
+}
+
+impl Key {
+    #[inline]
+    fn new(hash: u64, chunk_idx: IdxSize, df_idx: IdxSize) -> Self {
+        Key {
+            hash,
+            chunk_idx,
+            df_idx,
+        }
+    }
+}
+
+impl Hash for Key {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.hash)
+    }
+}
+
+type PartitionedMap = PartitionedHashMap<Key, UnitVec<ChunkId>, BuildHasherDefault<IdHasher>>;

--- a/crates/polars-utils/src/hashing.rs
+++ b/crates/polars-utils/src/hashing.rs
@@ -46,7 +46,7 @@ impl<'a> PartialEq for BytesHash<'a> {
     }
 }
 
-#[inline]
+#[inline(always)]
 pub fn hash_to_partition(h: u64, n_partitions: usize) -> usize {
     // Assuming h is a 64-bit random number, we note that
     // h / 2^64 is almost a uniform random number in [0, 1), and thus

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -42,5 +42,6 @@ pub mod index;
 pub mod io;
 pub mod nulls;
 pub mod ord;
+pub mod partitioned;
 
 pub use io::open_file;

--- a/crates/polars-utils/src/partitioned.rs
+++ b/crates/polars-utils/src/partitioned.rs
@@ -1,0 +1,36 @@
+use hashbrown::hash_map::{HashMap, RawEntryBuilder, RawEntryBuilderMut};
+
+use crate::hashing::hash_to_partition;
+use crate::slice::GetSaferUnchecked;
+
+pub struct PartitionedHashMap<K, V, S = ahash::RandomState> {
+    inner: Vec<HashMap<K, V, S>>,
+}
+
+impl<K, V, S> PartitionedHashMap<K, V, S> {
+    pub fn new(inner: Vec<HashMap<K, V, S>>) -> Self {
+        Self { inner }
+    }
+
+    #[inline]
+    pub fn raw_entry_mut(&mut self, h: u64) -> RawEntryBuilderMut<'_, K, V, S> {
+        let partition = hash_to_partition(h, self.inner.len());
+        let current_table = unsafe { self.inner.get_unchecked_release_mut(partition) };
+        current_table.raw_entry_mut()
+    }
+
+    #[inline]
+    pub fn raw_entry(&self, h: u64) -> RawEntryBuilder<'_, K, V, S> {
+        let partition = hash_to_partition(h, self.inner.len());
+        let current_table = unsafe { self.inner.get_unchecked_release(partition) };
+        current_table.raw_entry()
+    }
+
+    pub fn inner(&self) -> &[HashMap<K, V, S>] {
+        self.inner.as_ref()
+    }
+
+    pub fn inner_mut(&mut self) -> &mut Vec<HashMap<K, V, S>> {
+        &mut self.inner
+    }
+}


### PR DESCRIPTION
This can make working with partitioned tables less error prone. Only used now for streaming joins as pre-work for upcoming streaming outer join. Can be used in group-bys and default joins logic as well.