### PR TITLE
feat(python): support use of KùzuDB via `pl.read_database`

### DIFF
--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -228,17 +228,11 @@ class SeriesBuffers(TypedDict):
 # minimal protocol definitions that can reasonably represent
 # an executable connection, cursor, or equivalent object
 class BasicConnection(Protocol):  # noqa: D101
-    def close(self) -> None:
-        """Close the connection."""
-
     def cursor(self, *args: Any, **kwargs: Any) -> Any:
         """Return a cursor object."""
 
 
 class BasicCursor(Protocol):  # noqa: D101
-    def close(self) -> None:
-        """Close the cursor."""
-
     def execute(self, *args: Any, **kwargs: Any) -> Any:
         """Execute a query."""
 

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -90,6 +90,7 @@ module = [
   "fsspec.*",
   "gevent",
   "hvplot.*",
+  "kuzu",
   "matplotlib.*",
   "moto.server",
   "openpyxl",
@@ -179,7 +180,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["D100", "D103", "B018", "FBT001"]
+"tests/**/*.py" = ["D100", "D102", "D103", "B018", "FBT001"]
 
 [tool.ruff.lint.pycodestyle]
 max-doc-length = 88

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -28,6 +28,7 @@ adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'
 # TODO: Remove version constraint for connectorx when Python 3.12 is supported:
 # https://github.com/sfu-db/connector-x/issues/527
 connectorx; python_version <= '3.11'
+kuzu
 # Cloud
 cloudpickle
 fsspec

--- a/py-polars/tests/unit/io/files/graph-data/follows.csv
+++ b/py-polars/tests/unit/io/files/graph-data/follows.csv
@@ -1,0 +1,4 @@
+Adam,Karissa,2020
+Adam,Zhang,2020
+Karissa,Zhang,2021
+Zhang,Noura,2022

--- a/py-polars/tests/unit/io/files/graph-data/user.csv
+++ b/py-polars/tests/unit/io/files/graph-data/user.csv
@@ -1,0 +1,4 @@
+Adam,30
+Karissa,40
+Zhang,50
+Noura,25

--- a/py-polars/tests/unit/io/test_database_read.py
+++ b/py-polars/tests/unit/io/test_database_read.py
@@ -643,7 +643,11 @@ def test_read_kuzu_graph_database(tmp_path: Path, io_files_path: Path) -> None:
     if (kuzu_test_db := (tmp_path / "kuzu_test.db")).exists():
         kuzu_test_db.unlink()
 
-    db = kuzu.Database(str(kuzu_test_db))
+    test_db = str(kuzu_test_db)
+    if sys.platform == "win32":
+        test_db = test_db.replace("\\", "/")
+
+    db = kuzu.Database(test_db)
     conn = kuzu.Connection(db)
     conn.execute("CREATE NODE TABLE User(name STRING, age INT64, PRIMARY KEY (name))")
     conn.execute("CREATE REL TABLE Follows(FROM User TO User, since INT64)")

--- a/py-polars/tests/unit/io/test_database_read.py
+++ b/py-polars/tests/unit/io/test_database_read.py
@@ -9,17 +9,19 @@ from pathlib import Path
 from types import GeneratorType
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-import polars as pl
 import pytest
-from polars.exceptions import UnsuitableSQLError
-from polars.io.database import _ARROW_DRIVER_REGISTRY_
-from polars.testing import assert_frame_equal
 from sqlalchemy import Integer, MetaData, Table, create_engine, func, select
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql.expression import cast as alchemy_cast
 
+import polars as pl
+from polars.exceptions import UnsuitableSQLError
+from polars.io.database import _ARROW_DRIVER_REGISTRY_
+from polars.testing import assert_frame_equal
+
 if TYPE_CHECKING:
     import pyarrow as pa
+
     from polars.type_aliases import (
         ConnectionOrCursor,
         DbReadEngine,
@@ -650,6 +652,7 @@ def test_read_kuzu_graph_database(tmp_path: Path, io_files_path: Path) -> None:
 
     users = str(io_files_path / "graph-data" / "user.csv").replace("\\", "/")
     follows = str(io_files_path / "graph-data" / "follows.csv").replace("\\", "/")
+
     conn.execute(f'COPY User FROM "{users}"')
     conn.execute(f'COPY Follows FROM "{follows}"')
 

--- a/py-polars/tests/unit/utils/test_deprecation.py
+++ b/py-polars/tests/unit/utils/test_deprecation.py
@@ -49,7 +49,7 @@ def test_deprecate_renamed_parameter(recwarn: Any) -> None:
 
 class Foo:  # noqa: D101
     @deprecate_nonkeyword_arguments(allowed_args=["self", "baz"], version="0.1.2")
-    def bar(  # noqa: D102
+    def bar(
         self, baz: str, ham: str | None = None, foobar: str | None = None
     ) -> None: ...
 


### PR DESCRIPTION
Quite happy with how the `ConnectionExecutor` abstraction is holding up as it only required a few minor tweaks to add support for `kuzu`[^1] graph database queries (which make use of the Cypher[^2] query language). 

Registered it as having Arrow-aware return, so we will always load results efficiently (eg: _not_ via the row iterator), and also made a PR on their side adding direct Polars export support to their QueryResult object. (See: https://github.com/kuzudb/kuzu/pull/2985).

## Example

```python
df = pl.read_database(
    query = "MATCH (a:User)-[f:Follows]->(b:User) RETURN a.name, f.since, b.name",
    connection = kuzu_connection,
)
# shape: (4, 3)
# ┌─────────┬─────────┬─────────┐
# │ a.name  ┆ f.since ┆ b.name  │
# │ ---     ┆ ---     ┆ ---     │
# │ str     ┆ i64     ┆ str     │
# ╞═════════╪═════════╪═════════╡
# │ Adam    ┆ 2020    ┆ Karissa │
# │ Adam    ┆ 2020    ┆ Zhang   │
# │ Karissa ┆ 2021    ┆ Zhang   │
#  ...
```

[^1]: KùzuDB: https://kuzudb.com/
[^2]: Cypher: https://kuzudb.com/docusaurus/cypher/