### PR TITLE
feat: Streaming outer joins

### DIFF
--- a/crates/polars-arrow/src/array/primitive/mutable.rs
+++ b/crates/polars-arrow/src/array/primitive/mutable.rs
@@ -294,9 +294,22 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
         self.into()
     }
 
+    /// Clears the array, removing all values.
+    ///
+    /// Note that this method has no effect on the allocated capacity
+    /// of the array.
     pub fn clear(&mut self) {
         self.values.clear();
         self.validity = None;
+    }
+
+    /// Apply a function that temporarily freezes this `MutableArray` into a `PrimitiveArray`.
+    pub fn with_freeze<K, F: FnOnce(&PrimitiveArray<T>) -> K>(&mut self, f: F) -> K {
+        let mutable = std::mem::take(self);
+        let arr = mutable.freeze();
+        let out = f(&arr);
+        *self = arr.into_mut().right().unwrap();
+        out
     }
 }
 

--- a/crates/polars-arrow/src/array/primitive/mutable.rs
+++ b/crates/polars-arrow/src/array/primitive/mutable.rs
@@ -127,16 +127,21 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
         }
     }
 
+    #[inline]
+    pub fn push_value(&mut self, value: T) {
+        self.values.push(value);
+        match &mut self.validity {
+            Some(validity) => validity.push(true),
+            None => {},
+        }
+    }
+
     /// Adds a new value to the array.
     #[inline]
     pub fn push(&mut self, value: Option<T>) {
         match value {
             Some(value) => {
-                self.values.push(value);
-                match &mut self.validity {
-                    Some(validity) => validity.push(true),
-                    None => {},
-                }
+                self.push_value(value)
             },
             None => {
                 self.values.push(T::default());
@@ -287,6 +292,11 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
 
     pub fn freeze(self) -> PrimitiveArray<T> {
         self.into()
+    }
+
+    pub fn clear(&mut self) {
+        self.values.clear();
+        self.validity = None;
     }
 }
 

--- a/crates/polars-arrow/src/array/primitive/mutable.rs
+++ b/crates/polars-arrow/src/array/primitive/mutable.rs
@@ -140,9 +140,7 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
     #[inline]
     pub fn push(&mut self, value: Option<T>) {
         match value {
-            Some(value) => {
-                self.push_value(value)
-            },
+            Some(value) => self.push_value(value),
             None => {
                 self.values.push(T::default());
                 match &mut self.validity {

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1707,6 +1707,8 @@ impl DataFrame {
         self.take_unchecked_impl(idx, true)
     }
 
+    /// # Safety
+    /// The indices must be in-bounds.
     pub unsafe fn take_unchecked_impl(&self, idx: &IdxCa, allow_threads: bool) -> Self {
         let cols = if allow_threads {
             POOL.install(|| self._apply_columns_par(&|s| s.take_unchecked(idx)))

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -1707,7 +1707,7 @@ impl DataFrame {
         self.take_unchecked_impl(idx, true)
     }
 
-    unsafe fn take_unchecked_impl(&self, idx: &IdxCa, allow_threads: bool) -> Self {
+    pub unsafe fn take_unchecked_impl(&self, idx: &IdxCa, allow_threads: bool) -> Self {
         let cols = if allow_threads {
             POOL.install(|| self._apply_columns_par(&|s| s.take_unchecked(idx)))
         } else {

--- a/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
@@ -256,6 +256,7 @@ impl PartitionGroupByExec {
             &mut vec![],
             false,
             false,
+            true,
         )
         .unwrap();
 

--- a/crates/polars-lazy/src/physical_plan/streaming/checks.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/checks.rs
@@ -79,7 +79,7 @@ pub(super) fn streamable_join(args: &JoinArgs) -> bool {
     let supported = match args.how {
         #[cfg(feature = "cross_join")]
         JoinType::Cross => true,
-        JoinType::Inner | JoinType::Left => true,
+        JoinType::Inner | JoinType::Left | JoinType::Outer { .. } => true,
         _ => false,
     };
     supported && !args.validation.needs_checks()

--- a/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/convert_alp.rs
@@ -105,12 +105,16 @@ pub(crate) fn insert_streaming_nodes(
     // whether the full plan needs to be translated
     // to streaming
     allow_partial: bool,
+    row_estimate: bool,
 ) -> PolarsResult<bool> {
     scratch.clear();
 
-    // this is needed to determine which side of the joins should be
-    // traversed first
-    set_estimated_row_counts(root, lp_arena, expr_arena, 0, scratch);
+    // This is needed to determine which side of the joins should be
+    // traversed first. As we want to keep the smallest table in the build phase as that keeps most
+    // data in memory.
+    if row_estimate {
+        set_estimated_row_counts(root, lp_arena, expr_arena, 0, scratch);
+    }
 
     scratch.clear();
 

--- a/crates/polars-lazy/src/tests/streaming.rs
+++ b/crates/polars-lazy/src/tests/streaming.rs
@@ -408,7 +408,7 @@ fn test_streaming_outer_join() -> PolarsResult<()> {
         .sort_by_exprs([all()], [false], false, false);
 
     // Toggle so that the join order is swapped.
-    for toggle in [true, false] {
+    for toggle in [true, true] {
         assert_streaming_with_default(q.clone().with_streaming(toggle), true, false);
     }
 

--- a/crates/polars-lazy/src/tests/streaming.rs
+++ b/crates/polars-lazy/src/tests/streaming.rs
@@ -388,3 +388,29 @@ fn test_sort_maintain_order_streaming() -> PolarsResult<()> {
     ]?));
     Ok(())
 }
+
+#[test]
+fn test_streaming_outer_join() -> PolarsResult<()> {
+    let lf_left = df![
+         "a"=> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19],
+        "b"=> [0, 0, 0, 3, 0, 1, 3, 3, 3, 1, 4, 4, 2, 1, 1, 3, 1, 4, 2, 2],
+    ]?
+    .lazy();
+
+    let lf_right = df![
+           "a"=> [10, 18, 13, 9, 1, 13, 14, 12, 15, 11],
+    "b"=> [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+       ]?
+    .lazy();
+
+    let q = lf_left
+        .outer_join(lf_right, col("a"), col("a"))
+        .sort_by_exprs([all()], [false], false, false);
+
+    // Toggle so that the join order is swapped.
+    for toggle in [true, false] {
+        assert_streaming_with_default(q.clone().with_streaming(toggle), true, false);
+    }
+
+    Ok(())
+}

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -185,6 +185,10 @@ where
         let mut out = if let Some(iter) = self.downcast_slices() {
             let targets = iter.collect::<Vec<_>>();
             let iter = by.iter().map(|chunk_id| {
+                debug_assert!(
+                    !chunk_id.is_null(),
+                    "null chunks should not hit this branch"
+                );
                 let (chunk_idx, array_idx) = chunk_id.extract();
                 let vals = targets.get_unchecked_release(chunk_idx as usize);
                 vals.get_unchecked_release(array_idx as usize).clone()
@@ -195,6 +199,10 @@ where
         } else {
             let targets = self.downcast_iter().collect::<Vec<_>>();
             let iter = by.iter().map(|chunk_id| {
+                debug_assert!(
+                    !chunk_id.is_null(),
+                    "null chunks should not hit this branch"
+                );
                 let (chunk_idx, array_idx) = chunk_id.extract();
                 let vals = targets.get_unchecked_release(chunk_idx as usize);
                 vals.get_unchecked(array_idx as usize)

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -7,7 +7,7 @@ pub type InnerJoinIds = (JoinIds, JoinIds);
 #[cfg(feature = "chunked_ids")]
 pub(super) type ChunkJoinIds = Either<Vec<IdxSize>, Vec<ChunkId>>;
 #[cfg(feature = "chunked_ids")]
-pub type ChunkJoinOptIds = Either<Vec<Option<IdxSize>>, Vec<Option<ChunkId>>>;
+pub type ChunkJoinOptIds = Either<Vec<Option<IdxSize>>, Vec<ChunkId>>;
 
 #[cfg(not(feature = "chunked_ids"))]
 pub type ChunkJoinOptIds = Vec<Option<IdxSize>>;

--- a/crates/polars-ops/src/frame/join/general.rs
+++ b/crates/polars-ops/src/frame/join/general.rs
@@ -43,7 +43,7 @@ pub fn _finish_join(
     Ok(df_left)
 }
 
-pub(super) fn coalesce_outer_join(
+pub fn _coalesce_outer_join(
     mut df: DataFrame,
     keys_left: &[&str],
     keys_right: &[&str],

--- a/crates/polars-ops/src/frame/join/hash_join/mod.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/mod.rs
@@ -269,7 +269,7 @@ pub trait JoinDispatch: IntoDf {
         };
         let out = _finish_join(df_left, df_right, args.suffix.as_deref());
         if coalesce {
-            Ok(coalesce_outer_join(
+            Ok(_coalesce_outer_join(
                 out?,
                 &[s_left.name()],
                 &[s_right.name()],

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_left.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_left.rs
@@ -13,17 +13,11 @@ unsafe fn apply_mapping(idx: Vec<IdxSize>, chunk_mapping: &[ChunkId]) -> Vec<Chu
 }
 
 #[cfg(feature = "chunked_ids")]
-unsafe fn apply_opt_mapping(
-    idx: Vec<Option<IdxSize>>,
-    chunk_mapping: &[ChunkId],
-) -> Vec<ChunkId> {
-
+unsafe fn apply_opt_mapping(idx: Vec<Option<IdxSize>>, chunk_mapping: &[ChunkId]) -> Vec<ChunkId> {
     idx.iter()
-        .map(|opt_idx| {
-            match opt_idx {
-                None => ChunkId::null(),
-                Some(idx) => *chunk_mapping.get_unchecked(*idx as usize)
-            }
+        .map(|opt_idx| match opt_idx {
+            None => ChunkId::null(),
+            Some(idx) => *chunk_mapping.get_unchecked(*idx as usize),
         })
         .collect()
 }

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_left.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_left.rs
@@ -16,9 +16,15 @@ unsafe fn apply_mapping(idx: Vec<IdxSize>, chunk_mapping: &[ChunkId]) -> Vec<Chu
 unsafe fn apply_opt_mapping(
     idx: Vec<Option<IdxSize>>,
     chunk_mapping: &[ChunkId],
-) -> Vec<Option<ChunkId>> {
+) -> Vec<ChunkId> {
+
     idx.iter()
-        .map(|opt_idx| opt_idx.map(|idx| *chunk_mapping.get_unchecked(idx as usize)))
+        .map(|opt_idx| {
+            match opt_idx {
+                None => ChunkId::null(),
+                Some(idx) => *chunk_mapping.get_unchecked(*idx as usize)
+            }
+        })
         .collect()
 }
 

--- a/crates/polars-ops/src/frame/join/mod.rs
+++ b/crates/polars-ops/src/frame/join/mod.rs
@@ -25,7 +25,7 @@ pub use cross_join::CrossJoin;
 use either::Either;
 #[cfg(feature = "chunked_ids")]
 use general::create_chunked_index_mapping;
-pub use general::{_finish_join, _join_suffix_name};
+pub use general::{_coalesce_outer_join, _finish_join, _join_suffix_name};
 pub use hash_join::*;
 use hashbrown::hash_map::{Entry, RawEntryMut};
 #[cfg(feature = "merge_sorted")]
@@ -41,7 +41,6 @@ use polars_utils::hashing::BytesHash;
 use rayon::prelude::*;
 
 use super::IntoDf;
-use crate::frame::join::general::coalesce_outer_join;
 
 pub trait DataFrameJoinOps: IntoDf {
     /// Generic join method. Can be used to join on multiple columns.
@@ -338,7 +337,7 @@ pub trait DataFrameJoinOps: IntoDf {
                 let names_right = selected_right.iter().map(|s| s.name()).collect::<Vec<_>>();
                 let out = _finish_join(df_left, df_right, args.suffix.as_deref());
                 if coalesce {
-                    Ok(coalesce_outer_join(
+                    Ok(_coalesce_outer_join(
                         out?,
                         &names_left,
                         &names_right,

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_build.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_build.rs
@@ -19,7 +19,6 @@ use crate::operators::{DataChunk, FinalizedSink, PExecutionContext, Sink, SinkRe
 pub(super) type ChunkIdx = IdxSize;
 pub(super) type DfIdx = IdxSize;
 
-
 pub struct GenericBuild<K: ExtraPayload> {
     chunks: Vec<DataChunk>,
     // the join columns are all tightly packed

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_build.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_build.rs
@@ -298,7 +298,7 @@ impl<K: ExtraPayload> Sink for GenericBuild<K> {
             assert_eq!(left_df.n_chunks(), chunks_len);
         }
         // Reallocate to Arc<[]> to get rid of double indirection as this is accessed on every
-        // hastable cmp.
+        // hashtable cmp.
         let materialized_join_cols = Arc::from(std::mem::take(&mut self.materialized_join_cols));
         let suffix = self.suffix.clone();
         let hb = self.hb.clone();

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_build.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_build.rs
@@ -296,8 +296,6 @@ impl Sink for GenericBuild {
                 let join_columns_right = self.join_columns_right.clone();
 
                 // take the buffers, this saves one allocation
-                let mut join_series = std::mem::take(&mut self.join_columns);
-                join_series.clear();
                 let mut hashes = std::mem::take(&mut self.hashes);
                 hashes.clear();
 
@@ -310,7 +308,6 @@ impl Sink for GenericBuild {
                     join_columns_left,
                     join_columns_right,
                     self.swapped,
-                    join_series,
                     hashes,
                     context,
                     self.join_type.clone(),

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_probe_inner_left.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_probe_inner_left.rs
@@ -30,7 +30,7 @@ pub struct GenericJoinProbe<K: ExtraPayload> {
     /// columns
     ///      * chunk_offset = (idx * n_join_keys)
     ///      * end = (offset + n_join_keys)
-    materialized_join_cols: Arc<Vec<BinaryArray<i64>>>,
+    materialized_join_cols: Arc<[BinaryArray<i64>]>,
     suffix: Arc<str>,
     hb: RandomState,
     /// partitioned tables that will be used for probing
@@ -58,7 +58,7 @@ impl<K: ExtraPayload> GenericJoinProbe<K> {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         mut df_a: DataFrame,
-        materialized_join_cols: Arc<Vec<BinaryArray<i64>>>,
+        materialized_join_cols: Arc<[BinaryArray<i64>]>,
         suffix: Arc<str>,
         hb: RandomState,
         hash_tables: Arc<PartitionedMap<K>>,

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_probe_inner_left.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_probe_inner_left.rs
@@ -209,8 +209,7 @@ impl<K: ExtraPayload> GenericJoinProbe<K> {
                 .data
                 ._take_unchecked_slice_sorted(&self.join_tuples_b, false, IsSorted::Ascending)
         };
-        let right_df =
-            unsafe { right_df._take_opt_chunked_unchecked_seq(&self.join_tuples_a) };
+        let right_df = unsafe { right_df._take_opt_chunked_unchecked_seq(&self.join_tuples_a) };
 
         let out = self.finish_join(left_df, right_df)?;
 

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_probe_outer.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_probe_outer.rs
@@ -113,7 +113,7 @@ impl<K: ExtraPayload> GenericOuterJoinProbe<K> {
             swapped_or_left,
             output_names: None,
             join_nulls,
-            row_values: RowValues::new(join_columns_right)
+            row_values: RowValues::new(join_columns_right, false)
         }
     }
 

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_probe_outer.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_probe_outer.rs
@@ -1,0 +1,311 @@
+use std::borrow::Cow;
+
+use arrow::array::{Array, BinaryArray};
+use arrow::compute::utils::combine_validities_and;
+use polars_core::export::ahash::RandomState;
+use polars_core::prelude::*;
+use polars_core::series::IsSorted;
+use polars_ops::chunked_array::DfTake;
+use polars_ops::frame::join::_finish_join;
+use polars_ops::prelude::JoinType;
+use polars_row::RowsEncoded;
+use polars_utils::hashing::hash_to_partition;
+use polars_utils::idx_vec::UnitVec;
+use polars_utils::index::ChunkId;
+use polars_utils::nulls::IsNull;
+use polars_utils::slice::GetSaferUnchecked;
+use smartstring::alias::String as SmartString;
+use arrow::bitmap::{Bitmap, MutableBitmap};
+
+use crate::executors::sinks::joins::generic_build::*;
+use crate::executors::sinks::utils::hash_rows;
+use crate::expressions::PhysicalPipedExpr;
+use crate::operators::{DataChunk, Operator, OperatorResult, PExecutionContext};
+
+#[derive(Clone)]
+pub struct GenericOuterJoinProbe {
+    /// all chunks are stacked into a single dataframe
+    /// the dataframe is not rechunked.
+    df_a: Arc<DataFrame>,
+    /// the join columns are all tightly packed
+    /// the values of a join column(s) can be found
+    /// by:
+    /// first get the offset of the chunks and multiply that with the number of join
+    /// columns
+    ///      * chunk_offset = (idx * n_join_keys)
+    ///      * end = (offset + n_join_keys)
+    materialized_join_cols: Arc<Vec<BinaryArray<i64>>>,
+    suffix: Arc<str>,
+    hb: RandomState,
+    /// partitioned tables that will be used for probing.
+    /// stores the key and the chunk_idx, df_idx of the left table.
+    hash_tables: Arc<Vec<PlIdHashMap<Key, UnitVec<ChunkId>>>>,
+    /// Bits that indicate if a key has found a match. This keeps track of which values to flush.
+    /// Rows that don't find a match need to be appended to the output table.
+    /// The chunks are equal to the chunks of the `DataFrame` and can be accessed with the `ChunkId`.
+    found_match_tracker: Vec<Vec<MutableBitmap>>,
+
+    /// the columns that will be joined on.
+    join_columns_right: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
+
+    // amortize allocations
+    current_rows: RowsEncoded,
+    join_columns: Vec<ArrayRef>,
+    // in inner join these are the left table
+    // in left join there are the right table
+    join_tuples_a: Vec<ChunkId>,
+    join_tuples_a_left_join: Vec<Option<ChunkId>>,
+    // in inner join these are the right table
+    // in left join there are the left table
+    join_tuples_b: Vec<DfIdx>,
+    hashes: Vec<u64>,
+    // the join order is swapped to ensure we hash the smaller table
+    swapped_or_left: bool,
+    // location of join columns.
+    // these column locations need to be dropped from the rhs
+    join_column_idx: Option<Vec<usize>>,
+    // cached output names
+    output_names: Option<Vec<SmartString>>,
+    how: JoinType,
+    join_nulls: bool,
+}
+
+
+impl GenericOuterJoinProbe {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn new(
+        mut df_a: DataFrame,
+        materialized_join_cols: Arc<Vec<BinaryArray<i64>>>,
+        suffix: Arc<str>,
+        hb: RandomState,
+        hash_tables: Arc<Vec<PlIdHashMap<Key, UnitVec<ChunkId>>>>,
+        join_columns_left: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
+        join_columns_right: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
+        swapped_or_left: bool,
+        join_columns: Vec<ArrayRef>,
+        // Re-use the hashes allocation of the build side.
+        amortized_hashes: Vec<u64>,
+        context: &PExecutionContext,
+        how: JoinType,
+        join_nulls: bool,
+    ) -> Self {
+        if swapped_or_left {
+            let tmp = DataChunk {
+                data: df_a.slice(0, 1),
+                chunk_index: 0,
+            };
+            // remove duplicate_names caused by joining
+            // on the same column
+            let names = join_columns_left
+                .iter()
+                .flat_map(|phys_e| {
+                    phys_e
+                        .evaluate(&tmp, context.execution_state.as_any())
+                        .ok()
+                        .map(|s| s.name().to_string())
+                })
+                .collect::<Vec<_>>();
+            df_a = df_a.drop_many(&names);
+        }
+
+        let found_match_tracker = df_a.get_columns()[0].chunks().iter().map(|v| Bitmap::new_zeroed(v.len())).collect();
+
+        GenericOuterJoinProbe {
+            df_a: Arc::new(df_a),
+            materialized_join_cols,
+            suffix,
+            hb,
+            hash_tables,
+            found_match_tracker,
+            join_columns_right,
+            join_columns,
+            join_tuples_a: vec![],
+            join_tuples_a_left_join: vec![],
+            join_tuples_b: vec![],
+            hashes: amortized_hashes,
+            swapped_or_left,
+            current_rows: Default::default(),
+            join_column_idx: None,
+            output_names: None,
+            how,
+            join_nulls,
+        }
+    }
+    fn set_join_series(
+        &mut self,
+        context: &PExecutionContext,
+        chunk: &DataChunk,
+    ) -> PolarsResult<BinaryArray<i64>> {
+        debug_assert!(self.join_columns.is_empty());
+
+        let determine_idx = !self.swapped_or_left && self.join_column_idx.is_none();
+        let mut names = vec![];
+
+        for phys_e in self.join_columns_right.iter() {
+            let s = phys_e.evaluate(chunk, context.execution_state.as_any())?;
+            let s = s.to_physical_repr().rechunk();
+            if determine_idx {
+                names.push(s.name().to_string());
+            }
+            self.join_columns.push(s.array_ref(0).clone());
+        }
+
+        // we determine the indices of the columns that have to be removed
+        // if swapped the join column is already removed from the `build_df` as that will
+        // be the rhs one.
+        if !self.swapped_or_left && self.join_column_idx.is_none() {
+            let mut idx = names
+                .iter()
+                .filter_map(|name| chunk.data.get_column_index(name))
+                .collect::<Vec<_>>();
+            // ensure that it is sorted so that we can later remove columns in
+            // a predictable order
+            idx.sort_unstable();
+            self.join_column_idx = Some(idx);
+        }
+        polars_row::convert_columns_amortized_no_order(&self.join_columns, &mut self.current_rows);
+
+        // SAFETY: we keep rows-encode alive
+        let array = unsafe { self.current_rows.borrow_array() };
+        Ok(if self.join_nulls {
+            array
+        } else {
+            let validity = self
+                .join_columns
+                .iter()
+                .map(|arr| arr.validity().cloned())
+                .fold(None, |l, r| combine_validities_and(l.as_ref(), r.as_ref()));
+            array.with_validity_typed(validity)
+        })
+    }
+
+    fn finish_join(
+        &mut self,
+        mut left_df: DataFrame,
+        right_df: DataFrame,
+    ) -> PolarsResult<DataFrame> {
+        Ok(match &self.output_names {
+            None => {
+                let out = _finish_join(left_df, right_df, Some(self.suffix.as_ref()))?;
+                self.output_names = Some(out.get_column_names_owned());
+                out
+            },
+            Some(names) => unsafe {
+                // SAFETY:
+                // if we have duplicate names, we overwrite
+                // them in the next snippet
+                left_df
+                    .get_columns_mut()
+                    .extend_from_slice(right_df.get_columns());
+                left_df
+                    .get_columns_mut()
+                    .iter_mut()
+                    .zip(names)
+                    .for_each(|(s, name)| {
+                        s.rename(name);
+                    });
+                left_df
+            },
+        })
+    }
+
+    fn match_outer<'b, I>(&mut self, iter: I)
+    where
+        I: Iterator<Item = (usize, (&'b u64, &'b [u8]))> + 'b,
+    {
+        for (i, (h, row)) in iter {
+            let df_idx_right = i as IdxSize;
+            // get the hashtable belonging by this hash partition
+            let partition = hash_to_partition(*h, self.hash_tables.len());
+            let current_table = unsafe { self.hash_tables.get_unchecked_release(partition) };
+
+            let entry = current_table
+                .raw_entry()
+                .from_hash(*h, |key| {
+                    compare_fn(key, *h, &self.materialized_join_cols, row)
+                })
+                .map(|key_val| key_val.1);
+
+            if let Some(indexes_left) = entry {
+                self.join_tuples_a.extend_from_slice(indexes_left);
+                self.join_tuples_b
+                    .extend(std::iter::repeat(df_idx_right).take(indexes_left.len()));
+            }
+        }
+    }
+
+    fn execute_outer(
+        &mut self,
+        context: &PExecutionContext,
+        chunk: &DataChunk,
+    ) -> PolarsResult<OperatorResult> {
+        self.join_tuples_a.clear();
+        self.join_tuples_b.clear();
+        let mut hashes = std::mem::take(&mut self.hashes);
+        let rows = self.set_join_series(context, chunk)?;
+        hash_rows(&rows, &mut hashes, &self.hb);
+
+        if self.join_nulls || rows.null_count() == 0 {
+            let iter = hashes.iter().zip(rows.values_iter()).enumerate();
+            self.match_inner(iter);
+        } else {
+            let iter = hashes
+                .iter()
+                .zip(rows.iter())
+                .enumerate()
+                .filter_map(|(i, (h, row))| row.map(|row| (i, (h, row))));
+            self.match_inner(iter);
+        }
+        self.hashes = hashes;
+
+        let left_df = unsafe {
+            self.df_a
+                ._take_chunked_unchecked_seq(&self.join_tuples_a, IsSorted::Not)
+        };
+        let right_df = unsafe {
+            let mut df = Cow::Borrowed(&chunk.data);
+            if let Some(ids) = &self.join_column_idx {
+                let mut tmp = df.into_owned();
+                let cols = tmp.get_columns_mut();
+                // we go from higher idx to lower so that lower indices remain untouched
+                // by our mutation
+                for idx in ids.iter().rev() {
+                    let _ = cols.remove(*idx);
+                }
+                df = Cow::Owned(tmp);
+            }
+            df._take_unchecked_slice(&self.join_tuples_b, false)
+        };
+
+        let (a, b) = if self.swapped_or_left {
+            (right_df, left_df)
+        } else {
+            (left_df, right_df)
+        };
+        let out = self.finish_join(a, b)?;
+
+        // clear memory
+        self.join_columns.clear();
+        self.hashes.clear();
+
+        Ok(OperatorResult::Finished(chunk.with_data(out)))
+    }
+}
+
+impl Operator for GenericOuterJoinProbe {
+    fn execute(
+        &mut self,
+        context: &PExecutionContext,
+        chunk: &DataChunk,
+    ) -> PolarsResult<OperatorResult> {
+        self.execute_outer(context, chunk)
+    }
+
+    fn split(&self, _thread_no: usize) -> Box<dyn Operator> {
+        let new = self.clone();
+        Box::new(new)
+    }
+    fn fmt(&self) -> &str {
+        "generic_outer_join_probe"
+    }
+}

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_probe_outer.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_probe_outer.rs
@@ -188,7 +188,7 @@ impl<K: ExtraPayload> GenericOuterJoinProbe<K> {
 
             if let Some((indexes_left, tracker)) = entry {
                 // compiles to normal store: https://rust.godbolt.org/z/331hMo339
-                tracker.get_tracker().store(true, Ordering::SeqCst);
+                tracker.get_tracker().store(true, Ordering::Relaxed);
 
                 self.join_tuples_a.extend_from_slice(indexes_left);
                 self.join_tuples_b
@@ -205,7 +205,6 @@ impl<K: ExtraPayload> GenericOuterJoinProbe<K> {
         context: &PExecutionContext,
         chunk: &DataChunk,
     ) -> PolarsResult<OperatorResult> {
-        println!("exectue_{}", self.thread_no);
         self.join_tuples_a.clear();
         self.join_tuples_b.clear();
 
@@ -253,15 +252,13 @@ impl<K: ExtraPayload> GenericOuterJoinProbe<K> {
         let ht = self.hash_tables.inner();
         let n = ht.len();
         self.join_tuples_a.clear();
-        println!("flush_{}", self.thread_no);
 
         ht.iter().enumerate().for_each(|(i, ht)| {
             if i % n == self.thread_no {
-                ht.iter().for_each(|(k, (idx_left, tracker))| {
-                    let found_match = tracker.get_tracker().swap(true, Ordering::SeqCst);
+                ht.iter().for_each(|(_k, (idx_left, tracker))| {
+                    let found_match = tracker.get_tracker().swap(true, Ordering::Relaxed);
 
                     if !found_match {
-                        dbg!(k.idx);
                         self.join_tuples_a.extend_from_slice(idx_left);
                     }
                 })
@@ -272,7 +269,6 @@ impl<K: ExtraPayload> GenericOuterJoinProbe<K> {
             self.df_a
                 ._take_chunked_unchecked_seq(&self.join_tuples_a, IsSorted::Not)
         };
-        dbg!(&left_df);
 
         let size = left_df.height();
         let right_df = self.df_b_dummy.as_ref().unwrap();

--- a/crates/polars-pipe/src/executors/sinks/joins/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/mod.rs
@@ -78,7 +78,7 @@ impl Default for Tracker {
     #[inline]
     fn default() -> Self {
         Self {
-            inner: AtomicBool::new(false)
+            inner: AtomicBool::new(false),
         }
     }
 }

--- a/crates/polars-pipe/src/executors/sinks/joins/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/mod.rs
@@ -2,8 +2,8 @@
 mod cross;
 mod generic_build;
 mod generic_probe_inner_left;
-mod row_values;
 mod generic_probe_outer;
+mod row_values;
 
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::sync::atomic::AtomicBool;
@@ -17,6 +17,7 @@ use polars_ops::prelude::JoinType;
 use polars_utils::idx_vec::UnitVec;
 use polars_utils::index::ChunkId;
 use polars_utils::partitioned::PartitionedHashMap;
+
 use crate::executors::sinks::joins::generic_build::ChunkIdx;
 
 trait ToRow {
@@ -37,7 +38,6 @@ impl ToRow for Option<&[u8]> {
     }
 }
 
-
 // This is the hash and the Index offset in the chunks and the index offset in the dataframe
 #[derive(Copy, Clone, Debug)]
 #[repr(C)]
@@ -45,17 +45,14 @@ pub(super) struct Key {
     pub(super) hash: u64,
     /// We use the MSB as tracker for outer join matches
     /// So the 25th bit of the chunk_idx will be used for that.
-    idx: ChunkId
+    idx: ChunkId,
 }
 
 impl Key {
     #[inline]
     fn new(hash: u64, chunk_idx: IdxSize, df_idx: IdxSize) -> Self {
         let idx = ChunkId::store(chunk_idx, df_idx);
-        Key {
-            hash,
-            idx
-        }
+        Key { hash, idx }
     }
 }
 
@@ -67,7 +64,6 @@ impl Hash for Key {
 }
 
 pub(crate) trait ExtraPayload: Clone + Sync + Send + Default + 'static {
-
     /// Tracker used in the outer join.
     fn get_tracker(&self) -> &AtomicBool {
         panic!()
@@ -77,14 +73,14 @@ impl ExtraPayload for () {}
 
 #[repr(transparent)]
 struct Tracker {
-    inner: AtomicBool
+    inner: AtomicBool,
 }
 
 impl Default for Tracker {
     #[inline]
     fn default() -> Self {
         Self {
-            inner: Default::default()
+            inner: Default::default(),
         }
     }
 }
@@ -106,7 +102,7 @@ impl ExtraPayload for Tracker {
 #[derive(Clone)]
 struct Payload {
     idx: UnitVec<ChunkId>,
-
 }
 
-type PartitionedMap<V> = PartitionedHashMap<Key, (UnitVec<ChunkId>, V), BuildHasherDefault<IdHasher>>;
+type PartitionedMap<V> =
+    PartitionedHashMap<Key, (UnitVec<ChunkId>, V), BuildHasherDefault<IdHasher>>;

--- a/crates/polars-pipe/src/executors/sinks/joins/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/mod.rs
@@ -18,8 +18,6 @@ use polars_utils::idx_vec::UnitVec;
 use polars_utils::index::ChunkId;
 use polars_utils::partitioned::PartitionedHashMap;
 
-use crate::executors::sinks::joins::generic_build::ChunkIdx;
-
 trait ToRow {
     fn get_row(&self) -> &[u8];
 }
@@ -72,7 +70,7 @@ pub(crate) trait ExtraPayload: Clone + Sync + Send + Default + 'static {
 impl ExtraPayload for () {}
 
 #[repr(transparent)]
-struct Tracker {
+pub(crate) struct Tracker {
     inner: AtomicBool,
 }
 
@@ -97,11 +95,6 @@ impl ExtraPayload for Tracker {
     fn get_tracker(&self) -> &AtomicBool {
         &self.inner
     }
-}
-
-#[derive(Clone)]
-struct Payload {
-    idx: UnitVec<ChunkId>,
 }
 
 type PartitionedMap<V> =

--- a/crates/polars-pipe/src/executors/sinks/joins/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/mod.rs
@@ -78,7 +78,7 @@ impl Default for Tracker {
     #[inline]
     fn default() -> Self {
         Self {
-            inner: Default::default(),
+            inner: AtomicBool::new(false)
         }
     }
 }

--- a/crates/polars-pipe/src/executors/sinks/joins/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/mod.rs
@@ -2,6 +2,7 @@
 mod cross;
 mod generic_build;
 mod generic_probe_inner_left;
+mod row_values;
 
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 

--- a/crates/polars-pipe/src/executors/sinks/joins/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/mod.rs
@@ -69,7 +69,7 @@ impl Hash for Key {
 pub(crate) trait ExtraPayload: Clone + Sync + Send + Default + 'static {
 
     /// Tracker used in the outer join.
-    fn get_tracker(self) -> AtomicBool {
+    fn get_tracker(&self) -> &AtomicBool {
         panic!()
     }
 }
@@ -98,8 +98,8 @@ impl Clone for Tracker {
 
 impl ExtraPayload for Tracker {
     #[inline(always)]
-    fn get_tracker(self) -> AtomicBool {
-        self.inner
+    fn get_tracker(&self) -> &AtomicBool {
+        &self.inner
     }
 }
 

--- a/crates/polars-pipe/src/executors/sinks/joins/row_values.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/row_values.rs
@@ -16,15 +16,18 @@ pub(super) struct RowValues {
     // Location of join columns.
     // These column locations need to be dropped from the rhs
     pub join_column_idx: Option<Vec<usize>>,
+    det_join_idx: bool
 }
 
 impl RowValues {
-    pub(super) fn new(join_column_eval: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>) -> Self {
+    pub(super) fn new(join_column_eval: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>, det_join_idx: bool) -> Self {
         Self {
             current_rows: Default::default(),
             join_column_eval,
             join_column_idx: None,
             join_columns_material: vec![],
+            det_join_idx
+
         }
     }
 
@@ -40,7 +43,7 @@ impl RowValues {
     ) -> PolarsResult<BinaryArray<i64>> {
         // Memory should already be cleared on previous iteration.
         debug_assert!(self.join_columns_material.is_empty());
-        let determine_idx = self.join_column_idx.is_none();
+        let determine_idx = self.det_join_idx && self.join_column_idx.is_none();
         let mut names = vec![];
 
         for phys_e in self.join_column_eval.iter() {

--- a/crates/polars-pipe/src/executors/sinks/joins/row_values.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/row_values.rs
@@ -16,18 +16,20 @@ pub(super) struct RowValues {
     // Location of join columns.
     // These column locations need to be dropped from the rhs
     pub join_column_idx: Option<Vec<usize>>,
-    det_join_idx: bool
+    det_join_idx: bool,
 }
 
 impl RowValues {
-    pub(super) fn new(join_column_eval: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>, det_join_idx: bool) -> Self {
+    pub(super) fn new(
+        join_column_eval: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
+        det_join_idx: bool,
+    ) -> Self {
         Self {
             current_rows: Default::default(),
             join_column_eval,
             join_column_idx: None,
             join_columns_material: vec![],
-            det_join_idx
-
+            det_join_idx,
         }
     }
 

--- a/crates/polars-pipe/src/executors/sinks/joins/row_values.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/row_values.rs
@@ -1,0 +1,84 @@
+use std::sync::Arc;
+
+use arrow::array::{ArrayRef, BinaryArray, StaticArray};
+use arrow::compute::utils::combine_validities_and;
+use polars_core::error::PolarsResult;
+use polars_row::RowsEncoded;
+
+use crate::expressions::PhysicalPipedExpr;
+use crate::operators::{DataChunk, PExecutionContext};
+
+#[derive(Clone)]
+pub(super) struct RowValues {
+    current_rows: RowsEncoded,
+    join_column_eval: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>,
+    join_columns_material: Vec<ArrayRef>,
+    // Location of join columns.
+    // These column locations need to be dropped from the rhs
+    pub join_column_idx: Option<Vec<usize>>,
+}
+
+impl RowValues {
+    pub(super) fn new(join_column_eval: Arc<Vec<Arc<dyn PhysicalPipedExpr>>>) -> Self {
+        Self {
+            current_rows: Default::default(),
+            join_column_eval,
+            join_column_idx: None,
+            join_columns_material: vec![],
+        }
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.join_columns_material.clear();
+    }
+
+    pub(super) fn get_values(
+        &mut self,
+        context: &PExecutionContext,
+        chunk: &DataChunk,
+        join_nulls: bool,
+    ) -> PolarsResult<BinaryArray<i64>> {
+        let determine_idx = self.join_column_idx.is_none();
+        let mut names = vec![];
+
+        for phys_e in self.join_column_eval.iter() {
+            let s = phys_e.evaluate(chunk, context.execution_state.as_any())?;
+            let s = s.to_physical_repr().rechunk();
+            if determine_idx {
+                names.push(s.name().to_string());
+            }
+            self.join_columns_material.push(s.array_ref(0).clone());
+        }
+
+        // We determine the indices of the columns that have to be removed
+        // if swapped the join column is already removed from the `build_df` as that will
+        // be the rhs one.
+        if determine_idx {
+            let mut idx = names
+                .iter()
+                .filter_map(|name| chunk.data.get_column_index(name))
+                .collect::<Vec<_>>();
+            // Ensure that it is sorted so that we can later remove columns in
+            // a predictable order
+            idx.sort_unstable();
+            self.join_column_idx = Some(idx);
+        }
+        polars_row::convert_columns_amortized_no_order(
+            &self.join_columns_material,
+            &mut self.current_rows,
+        );
+
+        // SAFETY: we keep rows-encode alive
+        let array = unsafe { self.current_rows.borrow_array() };
+        Ok(if join_nulls {
+            array
+        } else {
+            let validity = self
+                .join_columns_material
+                .iter()
+                .map(|arr| arr.validity().cloned())
+                .fold(None, |l, r| combine_validities_and(l.as_ref(), r.as_ref()));
+            array.with_validity_typed(validity)
+        })
+    }
+}

--- a/crates/polars-pipe/src/executors/sinks/joins/row_values.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/row_values.rs
@@ -38,6 +38,8 @@ impl RowValues {
         chunk: &DataChunk,
         join_nulls: bool,
     ) -> PolarsResult<BinaryArray<i64>> {
+        // Memory should already be cleared on previous iteration.
+        debug_assert!(self.join_columns_material.is_empty());
         let determine_idx = self.join_column_idx.is_none();
         let mut names = vec![];
 

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -273,7 +273,7 @@ where
                         (join_columns_left, join_columns_right)
                     };
 
-                    Box::new(GenericBuild::new(
+                    Box::new(GenericBuild::<()>::new(
                         Arc::from(options.args.suffix()),
                         join_type.clone(),
                         swapped,

--- a/crates/polars-pipe/src/pipeline/dispatcher/drive_operator.rs
+++ b/crates/polars-pipe/src/pipeline/dispatcher/drive_operator.rs
@@ -1,0 +1,234 @@
+use std::collections::BTreeSet;
+use super::*;
+
+/// Take data chunks from the sources and pushes them into the operators + sink. Every operator
+/// works thread local.
+/// The caller passes an `operator_start`/`operator_end` to indicate which part of the pipeline
+/// branch should be executed.
+pub(super) fn par_process_chunks(
+    chunks: Vec<DataChunk>,
+    sink: &mut [Box<dyn Sink>],
+    ec: &PExecutionContext,
+    operators: &mut [Vec<Box<dyn Operator>>],
+    operator_start: usize,
+    operator_end: usize,
+    src: &mut Box<dyn Source>,
+) -> PolarsResult<(Option<SinkResult>, SourceResult)> {
+    debug_assert!(chunks.len() <= sink.len());
+
+    fn run_operator_pipe(
+        operator_start: usize,
+        operator_end: usize,
+        chunk: DataChunk,
+        sink: &mut Box<dyn Sink>,
+        operator_pipe: &mut [Box<dyn Operator>],
+        ec: &PExecutionContext,
+    ) -> PolarsResult<SinkResult> {
+        // truncate the operators that should run into the current sink.
+        let operator_pipe = &mut operator_pipe[operator_start..operator_end];
+
+        if operator_pipe.is_empty() {
+            sink.sink(ec, chunk)
+        } else {
+            push_operators(chunk, ec, operator_pipe, sink)
+        }
+    }
+    let sink_results = Arc::new(Mutex::new(None));
+    let mut next_batches: Option<PolarsResult<SourceResult>> = None;
+    let next_batches_ptr = &mut next_batches as *mut Option<PolarsResult<SourceResult>>;
+    let next_batches_ptr = unsafe { SyncPtr::new(next_batches_ptr) };
+
+    // 1. We will iterate the chunks/sinks/operators
+    // where every iteration belongs to a single thread
+    // 2. Then we will truncate the pipeline by `start`/`end`
+    // so that the pipeline represents pipeline that belongs to this sink
+    // 3. Then we push the data
+    // # Threading
+    // Within a rayon scope
+    // we spawn the jobs. They don't have to finish in any specific order,
+    // this makes it more lightweight than `par_iter`
+
+    // borrow as ref and move into the closure
+    POOL.scope(|s| {
+        for ((chunk, sink), operator_pipe) in chunks
+            .into_iter()
+            .zip(sink.iter_mut())
+            .zip(operators.iter_mut())
+        {
+            let sink_results = sink_results.clone();
+            s.spawn(move |_| {
+                let out = run_operator_pipe(
+                    operator_start,
+                    operator_end,
+                    chunk,
+                    sink,
+                    operator_pipe,
+                    ec,
+                );
+                match out {
+                    Ok(SinkResult::Finished) | Err(_) => {
+                        let mut lock = sink_results.lock().unwrap();
+                        *lock = Some(out)
+                    },
+                    _ => {},
+                }
+            })
+        }
+        // already get batches on the thread pool
+        // if one job is finished earlier we can already start that work
+        s.spawn(|_| {
+            let out = src.get_batches(ec);
+            unsafe {
+                let ptr = next_batches_ptr.get();
+                *ptr = Some(out);
+            }
+        })
+    });
+
+    let next_batches = next_batches.unwrap()?;
+    let mut lock = sink_results.lock().unwrap();
+    lock.take()
+        .transpose()
+        .map(|sink_result| (sink_result, next_batches))
+}
+
+
+/// This thread local logic that pushed a data chunk into the operators + sink
+/// It can be that a single operator needs to be called multiple times, this is for instance the
+/// case with joins that produce many tuples, that's why we keep a stack of `in_process`
+/// operators.
+pub(super) fn push_operators(
+    chunk: DataChunk,
+    ec: &PExecutionContext,
+    operators: &mut [Box<dyn Operator>],
+    sink: &mut Box<dyn Sink>,
+) -> PolarsResult<SinkResult> {
+    debug_assert!(!operators.is_empty());
+
+    // Stack based operator execution.
+    let mut in_process = vec![];
+    let operator_offset = 0usize;
+    in_process.push((operator_offset, chunk));
+    let mut needs_flush = BTreeSet::new();
+
+    while let Some((op_i, chunk)) = in_process.pop() {
+        match operators.get_mut(op_i) {
+            None => {
+                if let SinkResult::Finished = sink.sink(ec, chunk)? {
+                    return Ok(SinkResult::Finished);
+                }
+            },
+            Some(op) => {
+                match op.execute(ec, &chunk)? {
+                    OperatorResult::Finished(chunk) => {
+                        if op.must_flush() {
+                            let _ = needs_flush.insert(op_i);
+                        }
+                        in_process.push((op_i + 1, chunk))
+                    },
+                    OperatorResult::HaveMoreOutPut(output_chunk) => {
+                        // Push the next operator call with the same chunk on the stack
+                        in_process.push((op_i, chunk));
+
+                        // But first push the output in the next operator
+                        // If a join can produce many rows, we want the filter to
+                        // be executed in between, or sink into a slice so that we get
+                        // sink::finished before we grow the stack with ever more coming chunks
+                        in_process.push((op_i + 1, output_chunk));
+                    },
+                    OperatorResult::NeedsNewData => {
+                        // done, take another chunk from the stack
+                    },
+                }
+            },
+        }
+    }
+
+    Ok(SinkResult::CanHaveMoreInput)
+}
+
+pub(super) fn flush_operators(
+    ec: &PExecutionContext,
+    operators: &mut [Box<dyn Operator>],
+    sink: &mut Box<dyn Sink>,
+) -> PolarsResult<SinkResult> {
+
+    let needs_flush = operators.iter().enumerate().filter_map(|(i, op)| {
+        if op.must_flush() {
+            Some(i)
+        } else {
+            None
+        }
+    }).collect::<Vec<_>>();
+
+    // Stack based flushing + operator execution.
+    if !needs_flush.is_empty() {
+        let mut in_process = vec![];
+
+        for op_i in needs_flush.into_iter() {
+            // Push all operators that need flushing on the stack.
+            // The `None` indicates that we have no `chunk` input, so we `flush`.
+            // `Some(chunk)` is the pushing branch
+            in_process.push((op_i, None));
+
+            // Next we immediately pop and determine the order of execution below.
+            // This is to ensure that all operators below upper operators are completely
+            // flushed when the `flush` is called in higher operators. As operators can `flush`
+            // multiple times.
+            while let Some((op_i, chunk)) = in_process.pop() {
+                match chunk {
+                    // The branch for flushing.
+                    None => {
+                        let op = operators.get_mut(op_i).unwrap();
+                        match op.flush()? {
+                            OperatorResult::Finished(chunk) => {
+                                // Push the chunk in the next operator.
+                                in_process.push((op_i + 1, Some(chunk)))
+                            },
+                            OperatorResult::HaveMoreOutPut(chunk) => {
+                                // Ensure it is flushed again
+                                in_process.push((op_i, None));
+                                // Push the chunk in the next operator.
+                                in_process.push((op_i + 1, Some(chunk)))
+                            },
+                            _ => unreachable!(),
+                        }
+                    },
+                    // The branch for pushing data in the operators.
+                    // This is the same as the default stack exectuor, except now it pushes
+                    // `Some(chunk)` instead of `chunk`.
+                    Some(chunk) => {
+                        match operators.get_mut(op_i) {
+                            None => {
+                                if let SinkResult::Finished = sink.sink(ec, chunk)? {
+                                    return Ok(SinkResult::Finished);
+                                }
+                            },
+                            Some(op) => {
+                                match op.execute(ec, &chunk)? {
+                                    OperatorResult::Finished(chunk) => {
+                                        in_process.push((op_i + 1, Some(chunk)))
+                                    },
+                                    OperatorResult::HaveMoreOutPut(output_chunk) => {
+                                        // Push the next operator call with the same chunk on the stack
+                                        in_process.push((op_i, Some(chunk)));
+
+                                        // But first push the output in the next operator
+                                        // If a join can produce many rows, we want the filter to
+                                        // be executed in between, or sink into a slice so that we get
+                                        // sink::finished before we grow the stack with ever more coming chunks
+                                        in_process.push((op_i + 1, Some(output_chunk)));
+                                    },
+                                    OperatorResult::NeedsNewData => {
+                                        // Done, take another chunk from the stack
+                                    },
+                                }
+                            },
+                        }
+                    },
+                }
+            }
+        }
+    }
+    Ok(SinkResult::Finished)
+}

--- a/crates/polars-pipe/src/pipeline/dispatcher/mod.rs
+++ b/crates/polars-pipe/src/pipeline/dispatcher/mod.rs
@@ -17,7 +17,9 @@ use crate::operators::{
     DataChunk, FinalizedSink, Operator, OperatorResult, PExecutionContext, SExecutionContext, Sink,
     SinkResult, Source, SourceResult,
 };
+use crate::pipeline::dispatcher::drive_operator::{par_process_chunks, push_operators};
 use crate::pipeline::morsels_per_sink;
+mod drive_operator;
 
 pub(super) struct SinkNode {
     pub sinks: Vec<Box<dyn Sink>>,
@@ -198,230 +200,6 @@ impl PipeLine {
         }
     }
 
-    /// Take data chunks from the sources and pushes them into the operators + sink. Every operator
-    /// works thread local.
-    /// The caller passes an `operator_start`/`operator_end` to indicate which part of the pipeline
-    /// branch should be executed.
-    fn par_process_chunks(
-        &mut self,
-        chunks: Vec<DataChunk>,
-        sink: &mut [Box<dyn Sink>],
-        ec: &PExecutionContext,
-        operator_start: usize,
-        operator_end: usize,
-        src: &mut Box<dyn Source>,
-    ) -> PolarsResult<(Option<SinkResult>, SourceResult)> {
-        debug_assert!(chunks.len() <= sink.len());
-
-        fn run_operator_pipe(
-            pipe: &PipeLine,
-            operator_start: usize,
-            operator_end: usize,
-            chunk: DataChunk,
-            sink: &mut Box<dyn Sink>,
-            operator_pipe: &mut [Box<dyn Operator>],
-            ec: &PExecutionContext,
-        ) -> PolarsResult<SinkResult> {
-            // truncate the operators that should run into the current sink.
-            let operator_pipe = &mut operator_pipe[operator_start..operator_end];
-
-            if operator_pipe.is_empty() {
-                sink.sink(ec, chunk)
-            } else {
-                pipe.push_operators(chunk, ec, operator_pipe, sink)
-            }
-        }
-        let sink_results = Arc::new(Mutex::new(None));
-        let mut next_batches: Option<PolarsResult<SourceResult>> = None;
-        let next_batches_ptr = &mut next_batches as *mut Option<PolarsResult<SourceResult>>;
-        let next_batches_ptr = unsafe { SyncPtr::new(next_batches_ptr) };
-
-        // 1. We will iterate the chunks/sinks/operators
-        // where every iteration belongs to a single thread
-        // 2. Then we will truncate the pipeline by `start`/`end`
-        // so that the pipeline represents pipeline that belongs to this sink
-        // 3. Then we push the data
-        // # Threading
-        // Within a rayon scope
-        // we spawn the jobs. They don't have to finish in any specific order,
-        // this makes it more lightweight than `par_iter`
-
-        // temporarily take to please the borrow checker
-        let mut operators = std::mem::take(&mut self.operators);
-
-        // borrow as ref and move into the closure
-        let pipeline = &*self;
-        POOL.scope(|s| {
-            for ((chunk, sink), operator_pipe) in chunks
-                .into_iter()
-                .zip(sink.iter_mut())
-                .zip(operators.iter_mut())
-            {
-                let sink_results = sink_results.clone();
-                s.spawn(move |_| {
-                    let out = run_operator_pipe(
-                        pipeline,
-                        operator_start,
-                        operator_end,
-                        chunk,
-                        sink,
-                        operator_pipe,
-                        ec,
-                    );
-                    match out {
-                        Ok(SinkResult::Finished) | Err(_) => {
-                            let mut lock = sink_results.lock().unwrap();
-                            *lock = Some(out)
-                        },
-                        _ => {},
-                    }
-                })
-            }
-            // already get batches on the thread pool
-            // if one job is finished earlier we can already start that work
-            s.spawn(|_| {
-                let out = src.get_batches(ec);
-                unsafe {
-                    let ptr = next_batches_ptr.get();
-                    *ptr = Some(out);
-                }
-            })
-        });
-        self.operators = operators;
-
-        let next_batches = next_batches.unwrap()?;
-        let mut lock = sink_results.lock().unwrap();
-        lock.take()
-            .transpose()
-            .map(|sink_result| (sink_result, next_batches))
-    }
-
-    /// This thread local logic that pushed a data chunk into the operators + sink
-    /// It can be that a single operator needs to be called multiple times, this is for instance the
-    /// case with joins that produce many tuples, that's why we keep a stack of `in_process`
-    /// operators.
-    fn push_operators(
-        &self,
-        chunk: DataChunk,
-        ec: &PExecutionContext,
-        operators: &mut [Box<dyn Operator>],
-        sink: &mut Box<dyn Sink>,
-    ) -> PolarsResult<SinkResult> {
-        debug_assert!(!operators.is_empty());
-
-        // Stack based operator execution.
-        let mut in_process = vec![];
-        let operator_offset = 0usize;
-        in_process.push((operator_offset, chunk));
-        let mut needs_flush = BTreeSet::new();
-
-        while let Some((op_i, chunk)) = in_process.pop() {
-            match operators.get_mut(op_i) {
-                None => {
-                    if let SinkResult::Finished = sink.sink(ec, chunk)? {
-                        return Ok(SinkResult::Finished);
-                    }
-                },
-                Some(op) => {
-                    match op.execute(ec, &chunk)? {
-                        OperatorResult::Finished(chunk) => {
-                            if op.must_flush() {
-                                let _ = needs_flush.insert(op_i);
-                            }
-                            in_process.push((op_i + 1, chunk))
-                        },
-                        OperatorResult::HaveMoreOutPut(output_chunk) => {
-                            // Push the next operator call with the same chunk on the stack
-                            in_process.push((op_i, chunk));
-
-                            // But first push the output in the next operator
-                            // If a join can produce many rows, we want the filter to
-                            // be executed in between, or sink into a slice so that we get
-                            // sink::finished before we grow the stack with ever more coming chunks
-                            in_process.push((op_i + 1, output_chunk));
-                        },
-                        OperatorResult::NeedsNewData => {
-                            // done, take another chunk from the stack
-                        },
-                    }
-                },
-            }
-        }
-
-        // Stack based flushing + operator execution.
-        if !needs_flush.is_empty() {
-            drop(in_process);
-            let mut in_process = vec![];
-
-            for op_i in needs_flush.into_iter() {
-                // Push all operators that need flushing on the stack.
-                // The `None` indicates that we have no `chunk` input, so we `flush`.
-                // `Some(chunk)` is the pushing branch
-                in_process.push((op_i, None));
-
-                // Next we immediately pop and determine the order of execution below.
-                // This is to ensure that all operators below upper operators are completely
-                // flushed when the `flush` is called in higher operators. As operators can `flush`
-                // multiple times.
-                while let Some((op_i, chunk)) = in_process.pop() {
-                    match chunk {
-                        // The branch for flushing.
-                        None => {
-                            let op = operators.get_mut(op_i).unwrap();
-                            match op.flush()? {
-                                OperatorResult::Finished(chunk) => {
-                                    // Push the chunk in the next operator.
-                                    in_process.push((op_i + 1, Some(chunk)))
-                                },
-                                OperatorResult::HaveMoreOutPut(chunk) => {
-                                    // Ensure it is flushed again
-                                    in_process.push((op_i, None));
-                                    // Push the chunk in the next operator.
-                                    in_process.push((op_i + 1, Some(chunk)))
-                                },
-                                _ => unreachable!(),
-                            }
-                        },
-                        // The branch for pushing data in the operators.
-                        // This is the same as the default stack exectuor, except now it pushes
-                        // `Some(chunk)` instead of `chunk`.
-                        Some(chunk) => {
-                            match operators.get_mut(op_i) {
-                                None => {
-                                    if let SinkResult::Finished = sink.sink(ec, chunk)? {
-                                        return Ok(SinkResult::Finished);
-                                    }
-                                },
-                                Some(op) => {
-                                    match op.execute(ec, &chunk)? {
-                                        OperatorResult::Finished(chunk) => {
-                                            in_process.push((op_i + 1, Some(chunk)))
-                                        },
-                                        OperatorResult::HaveMoreOutPut(output_chunk) => {
-                                            // Push the next operator call with the same chunk on the stack
-                                            in_process.push((op_i, Some(chunk)));
-
-                                            // But first push the output in the next operator
-                                            // If a join can produce many rows, we want the filter to
-                                            // be executed in between, or sink into a slice so that we get
-                                            // sink::finished before we grow the stack with ever more coming chunks
-                                            in_process.push((op_i + 1, Some(output_chunk)));
-                                        },
-                                        OperatorResult::NeedsNewData => {
-                                            // Done, take another chunk from the stack
-                                        },
-                                    }
-                                },
-                            }
-                        },
-                    }
-                }
-            }
-        }
-
-        Ok(SinkResult::CanHaveMoreInput)
-    }
-
     /// Replace the current sources with a [`DataFrameSource`].
     fn set_df_as_sources(&mut self, df: DataFrame) {
         let src = Box::new(DataFrameSource::from_df(df)) as Box<dyn Source>;
@@ -457,10 +235,11 @@ impl PipeLine {
                     // Every batches iteration we check if we must continue.
                     ec.execution_state.should_stop()?;
 
-                    let (sink_result, next_batches2) = self.par_process_chunks(
+                    let (sink_result, next_batches2) = par_process_chunks(
                         chunks,
                         &mut sink.sinks,
                         ec,
+                        &mut self.operators,
                         operator_start,
                         sink.operator_end,
                         src,
@@ -472,6 +251,9 @@ impl PipeLine {
                         break;
                     }
                 }
+                // if !sink_finished {
+                //     todo!()
+                // }
             }
 
             // Before we reduce we also check if we should continue.

--- a/crates/polars-plan/src/frame/opt_state.rs
+++ b/crates/polars-plan/src/frame/opt_state.rs
@@ -1,19 +1,34 @@
 #[derive(Copy, Clone, Debug)]
 /// State of the allowed optimizations
 pub struct OptState {
+    /// Only read columns that are used later in the query.
     pub projection_pushdown: bool,
+    /// Apply predicates/filters as early as possible.
     pub predicate_pushdown: bool,
+    /// Run many type coercion optimization rules until fixed point.
     pub type_coercion: bool,
+    /// Run many expression optimization rules until fixed point.
     pub simplify_expr: bool,
+    /// Cache file reads.
     pub file_caching: bool,
+    /// Pushdown slices/limits.
     pub slice_pushdown: bool,
     #[cfg(feature = "cse")]
+    /// Run common-subplan-elimination. This elides duplicate plans and caches their
+    /// outputs.
     pub comm_subplan_elim: bool,
     #[cfg(feature = "cse")]
+    /// Run common-subexpression-elimination. This elides duplicate expressions and caches their
+    /// outputs.
     pub comm_subexpr_elim: bool,
+    /// Run nodes that are capably of doing so on the streaming engine.
     pub streaming: bool,
+    /// Run every node eagerly. This turns off multi-node optimizations.
     pub eager: bool,
+    /// Replace simple projections with a faster inlined projection that skips the expression engine.
     pub fast_projection: bool,
+    /// Try to estimate the number of rows so that joins can determine which side to keep in memory.
+    pub row_estimate: bool,
 }
 
 impl Default for OptState {
@@ -33,6 +48,7 @@ impl Default for OptState {
             streaming: false,
             fast_projection: true,
             eager: false,
+            row_estimate: true,
         }
     }
 }

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -127,9 +127,7 @@ pub struct ChunkId<const CHUNK_BITS: u64 = DEFAULT_CHUNK_BITS> {
 impl<const CHUNK_BITS: u64> ChunkId<CHUNK_BITS> {
     #[inline(always)]
     pub const fn null() -> Self {
-        Self {
-            swizzled: u64::MAX
-        }
+        Self { swizzled: u64::MAX }
     }
 
     #[inline(always)]

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -1,3 +1,5 @@
+use std::fmt::{Debug, Formatter};
+
 use polars_error::{polars_bail, polars_ensure, PolarsResult};
 
 use crate::nulls::IsNull;
@@ -118,10 +120,21 @@ impl_to_idx!(i64, i64);
 // Leaves 2^40 (~1T) rows per chunk
 const DEFAULT_CHUNK_BITS: u64 = 24;
 
-#[derive(Clone, Copy, Debug)]
-#[repr(C)]
+#[derive(Clone, Copy)]
+#[repr(transparent)]
 pub struct ChunkId<const CHUNK_BITS: u64 = DEFAULT_CHUNK_BITS> {
     swizzled: u64,
+}
+
+impl Debug for ChunkId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.is_null() {
+            write!(f, "NULL")
+        } else {
+            let (chunk, row) = self.extract();
+            write!(f, "({chunk}, {row})")
+        }
+    }
 }
 
 impl<const CHUNK_BITS: u64> ChunkId<CHUNK_BITS> {

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -126,6 +126,18 @@ pub struct ChunkId<const CHUNK_BITS: u64 = DEFAULT_CHUNK_BITS> {
 
 impl<const CHUNK_BITS: u64> ChunkId<CHUNK_BITS> {
     #[inline(always)]
+    pub const fn null() -> Self {
+        Self {
+            swizzled: u64::MAX
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_null(&self) -> bool {
+        self.swizzled == u64::MAX
+    }
+
+    #[inline(always)]
     #[allow(clippy::unnecessary_cast)]
     pub fn store(chunk: IdxSize, row: IdxSize) -> Self {
         debug_assert!(chunk < !(u64::MAX << CHUNK_BITS) as IdxSize);

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -182,7 +182,7 @@ mod test {
         let chunk = 213908;
         let row = 813457;
 
-        let ci = ChunkId::store(chunk, row);
+        let ci: ChunkId = ChunkId::store(chunk, row);
         let (c, r) = ci.extract();
 
         assert_eq!(c, chunk);

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -116,15 +116,15 @@ impl_to_idx!(i64, i64);
 
 // Allows for 2^24 (~16M) chunks
 // Leaves 2^40 (~1T) rows per chunk
-const CHUNK_BITS: u64 = 24;
+const DEFAULT_CHUNK_BITS: u64 = 24;
 
 #[derive(Clone, Copy, Debug)]
 #[repr(C)]
-pub struct ChunkId {
+pub struct ChunkId<const CHUNK_BITS: u64 = DEFAULT_CHUNK_BITS> {
     swizzled: u64,
 }
 
-impl ChunkId {
+impl<const CHUNK_BITS: u64> ChunkId<CHUNK_BITS> {
     #[inline(always)]
     #[allow(clippy::unnecessary_cast)]
     pub fn store(chunk: IdxSize, row: IdxSize) -> Self {
@@ -139,9 +139,14 @@ impl ChunkId {
     pub fn extract(self) -> (IdxSize, IdxSize) {
         let row = (self.swizzled >> CHUNK_BITS) as IdxSize;
 
-        const MASK: IdxSize = IdxSize::MAX << CHUNK_BITS;
-        let chunk = (self.swizzled as IdxSize) & !MASK;
+        let mask: IdxSize = IdxSize::MAX << CHUNK_BITS;
+        let chunk = (self.swizzled as IdxSize) & !mask;
         (chunk, row)
+    }
+
+    #[inline(always)]
+    pub fn inner_mut(&mut self) -> &mut u64 {
+        &mut self.swizzled
     }
 }
 

--- a/crates/polars-utils/src/partitioned.rs
+++ b/crates/polars-utils/src/partitioned.rs
@@ -30,7 +30,10 @@ impl<K, V, S> PartitionedHashMap<K, V, S> {
     }
 
     #[inline]
-    pub fn raw_entry_and_partition_mut(&mut self, h: u64) -> (RawEntryBuilderMut<'_, K, V, S>, usize) {
+    pub fn raw_entry_and_partition_mut(
+        &mut self,
+        h: u64,
+    ) -> (RawEntryBuilderMut<'_, K, V, S>, usize) {
         let partition = hash_to_partition(h, self.inner.len());
         let current_table = unsafe { self.inner.get_unchecked_release_mut(partition) };
         (current_table.raw_entry_mut(), partition)

--- a/py-polars/tests/unit/streaming/test_streaming_join.py
+++ b/py-polars/tests/unit/streaming/test_streaming_join.py
@@ -12,6 +12,34 @@ from polars.testing import assert_frame_equal
 pytestmark = pytest.mark.xdist_group("streaming")
 
 
+def test_streaming_outer_joins() -> None:
+    n = 100
+    dfa = pl.DataFrame(
+        {
+            "a": np.random.randint(0, 40, n),
+            "b": np.arange(0, n),
+        }
+    )
+
+    n = 100
+    dfb = pl.DataFrame(
+        {
+            "a": np.random.randint(0, 40, n),
+            "b": np.arange(0, n),
+        }
+    )
+
+    join_strategies: list[Literal["outer", "outer_coalesce"]] = [
+        "outer",
+        "outer_coalesce",
+    ]
+    for how in join_strategies:
+        q = dfa.lazy().join(dfb.lazy(), on="a", how=how).sort(["a", "b"])
+        a = q.collect(streaming=True)
+        b = q.collect(streaming=False)
+        assert_frame_equal(a, b)
+
+
 def test_streaming_joins() -> None:
     n = 100
     dfa = pd.DataFrame(


### PR DESCRIPTION
Also improves performance of chunked gather by storing `ChunkId` instead of `Option<ChunkId>`, meaning we save 50% space in cache.