### PR TITLE
depr(python,rust!): Rename parameter `by` to `group_by` in `DataFrame.upsample/group_by_dynamic/rolling`

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -973,7 +973,7 @@ impl LazyFrame {
     pub fn group_by_rolling<E: AsRef<[Expr]>>(
         self,
         index_column: Expr,
-        by: E,
+        group_by: E,
         mut options: RollingGroupOptions,
     ) -> LazyGroupBy {
         if let Expr::Column(name) = index_column {
@@ -984,7 +984,7 @@ impl LazyFrame {
                 .unwrap();
             return self.with_column(index_column).group_by_rolling(
                 Expr::Column(Arc::from(output_field.name().as_str())),
-                by,
+                group_by,
                 options,
             );
         }
@@ -992,7 +992,7 @@ impl LazyFrame {
         LazyGroupBy {
             logical_plan: self.logical_plan,
             opt_state,
-            keys: by.as_ref().to_vec(),
+            keys: group_by.as_ref().to_vec(),
             maintain_order: true,
             dynamic_options: None,
             rolling_options: Some(options),
@@ -1012,13 +1012,13 @@ impl LazyFrame {
     /// - period: length of the window
     /// - offset: offset of the window
     ///
-    /// The `by` argument should be empty `[]` if you don't want to combine this
+    /// The `group_by` argument should be empty `[]` if you don't want to combine this
     /// with a ordinary group_by on these keys.
     #[cfg(feature = "dynamic_group_by")]
     pub fn group_by_dynamic<E: AsRef<[Expr]>>(
         self,
         index_column: Expr,
-        by: E,
+        group_by: E,
         mut options: DynamicGroupOptions,
     ) -> LazyGroupBy {
         if let Expr::Column(name) = index_column {
@@ -1029,7 +1029,7 @@ impl LazyFrame {
                 .unwrap();
             return self.with_column(index_column).group_by_dynamic(
                 Expr::Column(Arc::from(output_field.name().as_str())),
-                by,
+                group_by,
                 options,
             );
         }
@@ -1037,7 +1037,7 @@ impl LazyFrame {
         LazyGroupBy {
             logical_plan: self.logical_plan,
             opt_state,
-            keys: by.as_ref().to_vec(),
+            keys: group_by.as_ref().to_vec(),
             maintain_order: true,
             dynamic_options: Some(options),
             rolling_options: None,

--- a/docs/src/python/user-guide/transformations/time-series/rolling.py
+++ b/docs/src/python/user-guide/transformations/time-series/rolling.py
@@ -59,7 +59,7 @@ out = df.group_by_dynamic(
     "time",
     every="1h",
     closed="both",
-    by="groups",
+    group_by="groups",
     include_boundaries=True,
 ).agg(pl.len())
 print(out)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5464,6 +5464,7 @@ class DataFrame:
         """
         return GroupBy(self, *by, **named_by, maintain_order=maintain_order)
 
+    @deprecate_renamed_parameter("by", "group_by", version="0.20.14")
     def rolling(
         self,
         index_column: IntoExpr,
@@ -5471,7 +5472,7 @@ class DataFrame:
         period: str | timedelta,
         offset: str | timedelta | None = None,
         closed: ClosedInterval = "right",
-        by: IntoExpr | Iterable[IntoExpr] | None = None,
+        group_by: IntoExpr | Iterable[IntoExpr] | None = None,
         check_sorted: bool = True,
     ) -> RollingGroupBy:
         """
@@ -5536,7 +5537,7 @@ class DataFrame:
             offset of the window. Default is -period
         closed : {'right', 'left', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive).
-        by
+        group_by
             Also group by this column/these columns
         check_sorted
             When the `by` argument is given, polars can not check sortedness
@@ -5602,10 +5603,11 @@ class DataFrame:
             period=period,
             offset=offset,
             closed=closed,
-            by=by,
+            group_by=group_by,
             check_sorted=check_sorted,
         )
 
+    @deprecate_renamed_parameter("by", "group_by", version="0.20.14")
     def group_by_dynamic(
         self,
         index_column: IntoExpr,
@@ -5617,7 +5619,7 @@ class DataFrame:
         include_boundaries: bool = False,
         closed: ClosedInterval = "left",
         label: Label = "left",
-        by: IntoExpr | Iterable[IntoExpr] | None = None,
+        group_by: IntoExpr | Iterable[IntoExpr] | None = None,
         start_by: StartBy = "window",
         check_sorted: bool = True,
     ) -> DynamicGroupBy:
@@ -5677,7 +5679,7 @@ class DataFrame:
             - 'datapoint': the first value of the index column in the given window.
               If you don't need the label to be at one of the boundaries, choose this
               option for maximum performance
-        by
+        group_by
             Also group by this column/these columns
         start_by : {'window', 'datapoint', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'}
             The strategy to determine the start of the first window by.
@@ -5874,7 +5876,7 @@ class DataFrame:
         ...     "time",
         ...     every="1h",
         ...     closed="both",
-        ...     by="groups",
+        ...     group_by="groups",
         ...     include_boundaries=True,
         ... ).agg(pl.col("n"))
         shape: (7, 5)
@@ -5934,18 +5936,19 @@ class DataFrame:
             label=label,
             include_boundaries=include_boundaries,
             closed=closed,
-            by=by,
+            group_by=group_by,
             start_by=start_by,
             check_sorted=check_sorted,
         )
 
+    @deprecate_renamed_parameter("by", "group_by", version="0.20.14")
     def upsample(
         self,
         time_column: str,
         *,
         every: str | timedelta,
         offset: str | timedelta | None = None,
-        by: str | Sequence[str] | None = None,
+        group_by: str | Sequence[str] | None = None,
         maintain_order: bool = False,
     ) -> Self:
         """
@@ -5985,7 +5988,7 @@ class DataFrame:
             Interval will start 'every' duration.
         offset
             Change the start of the date_range by this offset.
-        by
+        group_by
             First group by these columns and then upsample for every group.
         maintain_order
             Keep the ordering predictable. This is slower.
@@ -6014,7 +6017,7 @@ class DataFrame:
         ...     }
         ... ).set_sorted("time")
         >>> df.upsample(
-        ...     time_column="time", every="1mo", by="groups", maintain_order=True
+        ...     time_column="time", every="1mo", group_by="groups", maintain_order=True
         ... ).select(pl.all().forward_fill())
         shape: (7, 3)
         ┌─────────────────────┬────────┬────────┐
@@ -6033,10 +6036,10 @@ class DataFrame:
         """
         every = deprecate_saturating(every)
         offset = deprecate_saturating(offset)
-        if by is None:
-            by = []
-        if isinstance(by, str):
-            by = [by]
+        if group_by is None:
+            group_by = []
+        if isinstance(group_by, str):
+            group_by = [group_by]
         if offset is None:
             offset = "0ns"
 
@@ -6044,7 +6047,7 @@ class DataFrame:
         offset = parse_as_duration_string(offset)
 
         return self._from_pydf(
-            self._df.upsample(by, time_column, every, offset, maintain_order)
+            self._df.upsample(group_by, time_column, every, offset, maintain_order)
         )
 
     def join_asof(
@@ -10578,7 +10581,7 @@ class DataFrame:
             period=period,
             offset=offset,
             closed=closed,
-            by=by,
+            group_by=by,
             check_sorted=check_sorted,
         )
 
@@ -10630,7 +10633,7 @@ class DataFrame:
             period=period,
             offset=offset,
             closed=closed,
-            by=by,
+            group_by=by,
             check_sorted=check_sorted,
         )
 
@@ -10718,7 +10721,7 @@ class DataFrame:
             truncate=truncate,
             include_boundaries=include_boundaries,
             closed=closed,
-            by=by,
+            group_by=by,
             start_by=start_by,
             check_sorted=check_sorted,
         )

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -792,7 +792,7 @@ class RollingGroupBy:
         period: str | timedelta,
         offset: str | timedelta | None,
         closed: ClosedInterval,
-        by: IntoExpr | Iterable[IntoExpr] | None,
+        group_by: IntoExpr | Iterable[IntoExpr] | None,
         check_sorted: bool,
     ):
         period = parse_as_duration_string(period)
@@ -803,7 +803,7 @@ class RollingGroupBy:
         self.period = period
         self.offset = offset
         self.closed = closed
-        self.by = by
+        self.group_by = group_by
         self.check_sorted = check_sorted
 
     def __iter__(self) -> Self:
@@ -815,7 +815,7 @@ class RollingGroupBy:
                 period=self.period,
                 offset=self.offset,
                 closed=self.closed,
-                by=self.by,
+                group_by=self.group_by,
                 check_sorted=self.check_sorted,
             )
             .agg(F.first().agg_groups().alias(temp_col))
@@ -827,7 +827,7 @@ class RollingGroupBy:
         # When grouping by a single column, group name is a single value
         # When grouping by multiple columns, group name is a tuple of values
         self._group_names: Iterator[object] | Iterator[tuple[object, ...]]
-        if self.by is None:
+        if self.group_by is None:
             self._group_names = iter(group_names.to_series())
         else:
             self._group_names = group_names.iter_rows()
@@ -874,7 +874,7 @@ class RollingGroupBy:
                 period=self.period,
                 offset=self.offset,
                 closed=self.closed,
-                by=self.by,
+                group_by=self.group_by,
                 check_sorted=self.check_sorted,
             )
             .agg(*aggs, **named_aggs)
@@ -917,7 +917,7 @@ class RollingGroupBy:
                 period=self.period,
                 offset=self.offset,
                 closed=self.closed,
-                by=self.by,
+                group_by=self.group_by,
                 check_sorted=self.check_sorted,
             )
             .map_groups(function, schema)
@@ -968,7 +968,7 @@ class DynamicGroupBy:
         include_boundaries: bool,
         closed: ClosedInterval,
         label: Label,
-        by: IntoExpr | Iterable[IntoExpr] | None,
+        group_by: IntoExpr | Iterable[IntoExpr] | None,
         start_by: StartBy,
         check_sorted: bool,
     ):
@@ -985,7 +985,7 @@ class DynamicGroupBy:
         self.label = label
         self.include_boundaries = include_boundaries
         self.closed = closed
-        self.by = by
+        self.group_by = group_by
         self.start_by = start_by
         self.check_sorted = check_sorted
 
@@ -1002,7 +1002,7 @@ class DynamicGroupBy:
                 label=self.label,
                 include_boundaries=self.include_boundaries,
                 closed=self.closed,
-                by=self.by,
+                group_by=self.group_by,
                 start_by=self.start_by,
                 check_sorted=self.check_sorted,
             )
@@ -1015,7 +1015,7 @@ class DynamicGroupBy:
         # When grouping by a single column, group name is a single value
         # When grouping by multiple columns, group name is a tuple of values
         self._group_names: Iterator[object] | Iterator[tuple[object, ...]]
-        if self.by is None:
+        if self.group_by is None:
             self._group_names = iter(group_names.to_series())
         else:
             self._group_names = group_names.iter_rows()
@@ -1066,7 +1066,7 @@ class DynamicGroupBy:
                 label=self.label,
                 include_boundaries=self.include_boundaries,
                 closed=self.closed,
-                by=self.by,
+                group_by=self.group_by,
                 start_by=self.start_by,
                 check_sorted=self.check_sorted,
             )
@@ -1113,7 +1113,7 @@ class DynamicGroupBy:
                 truncate=self.truncate,
                 include_boundaries=self.include_boundaries,
                 closed=self.closed,
-                by=self.by,
+                group_by=self.group_by,
                 start_by=self.start_by,
                 check_sorted=self.check_sorted,
             )

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3218,6 +3218,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         lgb = self._ldf.group_by(exprs, maintain_order)
         return LazyGroupBy(lgb)
 
+    @deprecate_renamed_parameter("by", "group_by", version="0.20.14")
     def rolling(
         self,
         index_column: IntoExpr,
@@ -3225,7 +3226,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         period: str | timedelta,
         offset: str | timedelta | None = None,
         closed: ClosedInterval = "right",
-        by: IntoExpr | Iterable[IntoExpr] | None = None,
+        group_by: IntoExpr | Iterable[IntoExpr] | None = None,
         check_sorted: bool = True,
     ) -> LazyGroupBy:
         """
@@ -3290,7 +3291,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             offset of the window. Default is -period
         closed : {'right', 'left', 'both', 'none'}
             Define which sides of the temporal interval are closed (inclusive).
-        by
+        group_by
             Also group by this column/these columns
         check_sorted
             When the `by` argument is given, polars can not check sortedness
@@ -3353,7 +3354,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         if offset is None:
             offset = negate_duration_string(parse_as_duration_string(period))
 
-        pyexprs_by = parse_as_list_of_expressions(by) if by is not None else []
+        pyexprs_by = (
+            parse_as_list_of_expressions(group_by) if group_by is not None else []
+        )
         period = parse_as_duration_string(period)
         offset = parse_as_duration_string(offset)
 
@@ -3362,6 +3365,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         )
         return LazyGroupBy(lgb)
 
+    @deprecate_renamed_parameter("by", "group_by", version="0.20.14")
     def group_by_dynamic(
         self,
         index_column: IntoExpr,
@@ -3373,7 +3377,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         include_boundaries: bool = False,
         closed: ClosedInterval = "left",
         label: Label = "left",
-        by: IntoExpr | Iterable[IntoExpr] | None = None,
+        group_by: IntoExpr | Iterable[IntoExpr] | None = None,
         start_by: StartBy = "window",
         check_sorted: bool = True,
     ) -> LazyGroupBy:
@@ -3433,7 +3437,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             - 'datapoint': the first value of the index column in the given window.
               If you don't need the label to be at one of the boundaries, choose this
               option for maximum performance
-        by
+        group_by
             Also group by this column/these columns
         start_by : {'window', 'datapoint', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'}
             The strategy to determine the start of the first window by.
@@ -3636,7 +3640,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         ...     "time",
         ...     every="1h",
         ...     closed="both",
-        ...     by="groups",
+        ...     group_by="groups",
         ...     include_boundaries=True,
         ... ).agg(pl.col("n")).collect()
         shape: (7, 5)
@@ -3706,7 +3710,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         offset = parse_as_duration_string(offset)
         every = parse_as_duration_string(every)
 
-        pyexprs_by = parse_as_list_of_expressions(by) if by is not None else []
+        pyexprs_by = (
+            parse_as_list_of_expressions(group_by) if group_by is not None else []
+        )
         lgb = self._ldf.group_by_dynamic(
             index_column,
             every,
@@ -6325,7 +6331,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             period=period,
             offset=offset,
             closed=closed,
-            by=by,
+            group_by=by,
             check_sorted=check_sorted,
         )
 
@@ -6384,7 +6390,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             period=period,
             offset=offset,
             closed=closed,
-            by=by,
+            group_by=by,
             check_sorted=check_sorted,
         )
 
@@ -6472,7 +6478,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             truncate=truncate,
             include_boundaries=include_boundaries,
             closed=closed,
-            by=by,
+            group_by=by,
             start_by=start_by,
             check_sorted=check_sorted,
         )

--- a/py-polars/src/lazyframe/mod.rs
+++ b/py-polars/src/lazyframe/mod.rs
@@ -720,19 +720,19 @@ impl PyLazyFrame {
         label: Wrap<Label>,
         include_boundaries: bool,
         closed: Wrap<ClosedWindow>,
-        by: Vec<PyExpr>,
+        group_by: Vec<PyExpr>,
         start_by: Wrap<StartBy>,
         check_sorted: bool,
     ) -> PyLazyGroupBy {
         let closed_window = closed.0;
-        let by = by
+        let group_by = group_by
             .into_iter()
             .map(|pyexpr| pyexpr.inner)
             .collect::<Vec<_>>();
         let ldf = self.ldf.clone();
         let lazy_gb = ldf.group_by_dynamic(
             index_column.inner,
-            by,
+            group_by,
             DynamicGroupOptions {
                 every: Duration::parse(every),
                 period: Duration::parse(period),

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -576,7 +576,7 @@ def test_upsample(time_zone: str | None, tzinfo: ZoneInfo | timezone | None) -> 
     ).with_columns(pl.col("time").dt.replace_time_zone(time_zone).set_sorted())
 
     up = df.upsample(
-        time_column="time", every="1mo", by="admin", maintain_order=True
+        time_column="time", every="1mo", group_by="admin", maintain_order=True
     ).select(pl.all().forward_fill())
     # this print will panic if timezones feature is not activated
     # don't remove
@@ -750,7 +750,7 @@ def test_asof_join_tolerance_grouper() -> None:
 def test_rolling_group_by_by_argument() -> None:
     df = pl.DataFrame({"times": range(10), "groups": [1] * 4 + [2] * 6})
 
-    out = df.rolling("times", period="5i", by=["groups"]).agg(
+    out = df.rolling("times", period="5i", group_by=["groups"]).agg(
         pl.col("times").alias("agg_list")
     )
 
@@ -1209,7 +1209,7 @@ def test_rolling_by_ordering() -> None:
         period="2m",
         closed="both",
         offset="-1m",
-        by="key",
+        group_by="key",
     ).agg(
         [
             pl.col("val").sum().alias("sum val"),
@@ -1242,13 +1242,13 @@ def test_rolling_by_() -> None:
     )
     out = (
         df.sort("datetime")
-        .rolling(index_column="datetime", by="group", period=timedelta(days=3))
+        .rolling(index_column="datetime", group_by="group", period=timedelta(days=3))
         .agg([pl.len().alias("count")])
     )
 
     expected = (
         df.sort(["group", "datetime"])
-        .rolling(index_column="datetime", by="group", period="3d")
+        .rolling(index_column="datetime", group_by="group", period="3d")
         .agg([pl.len().alias("count")])
     )
     assert_frame_equal(out.sort(["group", "datetime"]), expected)
@@ -2497,7 +2497,7 @@ def test_rolling_group_by_empty_groups_by_take_6330() -> None:
     df = df1.join(df2, how="cross").set_sorted("Date")
 
     result = df.rolling(
-        index_column="Date", period="2i", offset="-2i", by="Event", closed="left"
+        index_column="Date", period="2i", offset="-2i", group_by="Event", closed="left"
     ).agg(pl.len())
 
     assert result.to_dict(as_series=False) == {

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -388,7 +388,7 @@ def test_rolling_slice_pushdown() -> None:
         df.sort("a")
         .rolling(
             "a",
-            by="b",
+            group_by="b",
             period="2i",
         )
         .agg([(pl.col("c") - pl.col("c").shift(fill_value=0)).sum().alias("c")])
@@ -498,7 +498,7 @@ def test_rolling_iter() -> None:
     # With 'by' argument
     result2 = [
         (name, data.shape)
-        for name, data in df.rolling(index_column="date", period="2d", by="a")
+        for name, data in df.rolling(index_column="date", period="2d", group_by="a")
     ]
     expected2 = [
         ((1, date(2020, 1, 1)), (1, 3)),

--- a/py-polars/tests/unit/operations/test_group_by_dynamic.py
+++ b/py-polars/tests/unit/operations/test_group_by_dynamic.py
@@ -214,7 +214,7 @@ def test_group_by_dynamic_by_monday_and_offset_5444() -> None:
     ).with_columns(pl.col("date").str.strptime(pl.Date, "%Y-%m-%d").set_sorted())
 
     result = df.group_by_dynamic(
-        "date", every="1w", offset="1d", by="label", start_by="monday"
+        "date", every="1w", offset="1d", group_by="label", start_by="monday"
     ).agg(pl.col("value").sum())
 
     assert result.to_dict(as_series=False) == {
@@ -232,7 +232,7 @@ def test_group_by_dynamic_by_monday_and_offset_5444() -> None:
     result_empty = (
         df.filter(pl.col("date") == date(1, 1, 1))
         .group_by_dynamic(
-            "date", every="1w", offset="1d", by="label", start_by="monday"
+            "date", every="1w", offset="1d", group_by="label", start_by="monday"
         )
         .agg(pl.col("value").sum())
     )
@@ -273,7 +273,7 @@ def test_group_by_dynamic_label(label: Label, expected: list[datetime]) -> None:
         }
     ).sort("ts")
     result = (
-        df.group_by_dynamic("ts", every="1d", label=label, by="group")
+        df.group_by_dynamic("ts", every="1d", label=label, group_by="group")
         .agg(pl.col("n"))["ts"]
         .to_list()
     )
@@ -314,7 +314,7 @@ def test_group_by_dynamic_slice_pushdown() -> None:
     df = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "a", "b"], "c": [1, 3, 5]}).lazy()
     df = (
         df.sort("a")
-        .group_by_dynamic("a", by="b", every="2i")
+        .group_by_dynamic("a", group_by="b", every="2i")
         .agg((pl.col("c") - pl.col("c").shift(fill_value=0)).sum().alias("c"))
     )
     assert df.head(2).collect().to_dict(as_series=False) == {
@@ -366,7 +366,7 @@ def test_rolling_dynamic_sortedness_check() -> None:
     )
 
     with pytest.raises(pl.ComputeError, match=r"input data is not sorted"):
-        df.group_by_dynamic("idx", every="2i", by="group").agg(
+        df.group_by_dynamic("idx", every="2i", group_by="group").agg(
             pl.col("idx").alias("idx1")
         )
 
@@ -496,7 +496,7 @@ def test_group_by_dynamic_validation(every: str, match: str) -> None:
     )
 
     with pytest.raises(pl.ComputeError, match=match):
-        df.group_by_dynamic("index", by="group", every=every, period="2i").agg(
+        df.group_by_dynamic("index", group_by="group", every=every, period="2i").agg(
             pl.col("weight")
         )
 
@@ -564,7 +564,7 @@ def test_truncate_negative_offset(tzinfo: ZoneInfo | None) -> None:
     out = df.group_by_dynamic(
         index_column="event_date",
         every="1mo",
-        by=["admin", "five_type", "actor"],
+        group_by=["admin", "five_type", "actor"],
     ).agg([pl.col("adm1_code").unique(), (pl.col("fatalities") > 0).sum()])
 
     assert out["event_date"].to_list() == [
@@ -885,7 +885,7 @@ def test_group_by_dynamic_iter(every: str | timedelta, tzinfo: ZoneInfo | None) 
     result2 = [
         (name, data.shape)
         for name, data in df.group_by_dynamic(
-            "datetime", every=every, closed="left", by="a"
+            "datetime", every=every, closed="left", group_by="a"
         )
     ]
     expected2 = [

--- a/py-polars/tests/unit/operations/test_rolling.py
+++ b/py-polars/tests/unit/operations/test_rolling.py
@@ -192,9 +192,11 @@ def test_rolling_dynamic_sortedness_check() -> None:
     )
 
     with pytest.raises(pl.ComputeError, match=r"input data is not sorted"):
-        df.rolling("idx", period="2i", by="group").agg(pl.col("idx").alias("idx1"))
+        df.rolling("idx", period="2i", group_by="group").agg(
+            pl.col("idx").alias("idx1")
+        )
 
-    # no `by` argument
+    # no `group_by` argument
     with pytest.raises(
         pl.InvalidOperationError,
         match=r"argument in operation 'group_by_rolling' is not explicitly sorted",
@@ -231,7 +233,7 @@ def test_rolling_empty_groups_9973() -> None:
 
     out = data.rolling(
         index_column="date",
-        by="id",
+        group_by="id",
         period="2d",
         offset="1d",
         closed="left",


### PR DESCRIPTION
This hasn't been fully discussed, but it's related to https://github.com/pola-rs/polars/issues/10989 and it was pretty easy to `F2`-replace these. Sometimes, just opening a PR is the fastest way to make a decision, so... here this is 😄 

In summary: `by` in Polars usually refers to which operation you do the operation by (e.g. in `sort`, it sorts by the `by` columns), and sometimes to which columns you group by before applying the operation. For example:
- `df.upsample('a', '3d', by='b')` means "group by 'b' and then upsample by column 'a' every 3 days"
- `df.top_k(3, by='b')` means "take the 3 rows where column `'b'` is largest"

If an operation lets you group by certain columns before applying the operation, then I think it would be clearer to use `group_by` for that parameter.

This would open up the doors for `df.top_k(3, by='b', group_by='a')` (the `by` in `top_k` is already taken)

For readability, looking at the tests, I do think
```
out = df.rolling("times", period="5i", group_by=["groups"])
```
is clearer to read than
```
out = df.rolling("times", period="5i", by=["groups"])
```
The latter almost looks like it's rolling based on groups, whereas it's rolling based on `'times'` grouped by `'groups'`