### PR TITLE
chore: run and fix pext64_polyfill test

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -70,6 +70,7 @@ jobs:
         run: >
           cargo test --all-features
           -p polars-arrow
+          -p polars-compute
           -p polars-core
           -p polars-io
           -p polars-lazy

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -46,6 +46,7 @@ jobs:
         run: >
           cargo test --all-features --no-run
           -p polars-arrow
+          -p polars-compute
           -p polars-core
           -p polars-io
           -p polars-lazy
@@ -61,6 +62,7 @@ jobs:
         run: >
           cargo test --all-features
           -p polars-arrow
+          -p polars-compute
           -p polars-core
           -p polars-io
           -p polars-lazy

--- a/crates/Makefile
+++ b/crates/Makefile
@@ -42,6 +42,7 @@ miri:  ## Run miri
 .PHONY: test
 test:  ## Run tests
 	cargo test --all-features \
+		-p polars-compute \
 		-p polars-core \
 		-p polars-io \
 		-p polars-lazy \
@@ -57,6 +58,7 @@ test:  ## Run tests
 .PHONY: nextest
 nextest:  ## Run tests with nextest
 	cargo nextest run --all-features \
+		-p polars-compute \
 		-p polars-core \
 		-p polars-io \
 		-p polars-lazy \

--- a/crates/polars-compute/src/filter/boolean.rs
+++ b/crates/polars-compute/src/filter/boolean.rs
@@ -12,13 +12,13 @@ fn pext64_polyfill(mut v: u64, mut m: u64, m_popcnt: u32) -> u64 {
         // unrolls the loop, this makes bit << i much faster.
         let mut out = 0;
         for i in 0..4 {
-            let bit = (v >> m.trailing_zeros()) & 1;
-            out |= bit << i;
-            m &= m.wrapping_sub(1); // Clear least significant bit.
-
             if m == 0 {
                 break;
             };
+
+            let bit = (v >> m.trailing_zeros()) & 1;
+            out |= bit << i;
+            m &= m.wrapping_sub(1); // Clear least significant bit.
         }
         return out;
     }


### PR DESCRIPTION
This shouldn't affect any deployed polars code since we only ever call pext64_polyfill if our mask is non-zero, hence chore and not a fix. Nevertheless, this test should be run, and it should pass.