### PR TITLE
chore(rust): Make polars-io compile on its own

### DIFF
--- a/crates/polars-arrow/Cargo.toml
+++ b/crates/polars-arrow/Cargo.toml
@@ -159,7 +159,9 @@ compute = [
 simd = []
 
 # polars-arrow
-timezones = []
+timezones = [
+  "chrono-tz",
+]
 dtype-array = []
 dtype-decimal = ["atoi", "itoap"]
 bigidx = []

--- a/crates/polars-io/Cargo.toml
+++ b/crates/polars-io/Cargo.toml
@@ -80,7 +80,7 @@ dtype-i8 = ["polars-core/dtype-i8"]
 dtype-i16 = ["polars-core/dtype-i16"]
 dtype-categorical = ["polars-core/dtype-categorical"]
 dtype-date = ["polars-core/dtype-date", "polars-time/dtype-date"]
-object = []
+object = ["polars-core/object"]
 dtype-datetime = [
   "polars-core/dtype-datetime",
   "polars-core/temporal",
@@ -90,6 +90,7 @@ dtype-datetime = [
 timezones = [
   "chrono-tz",
   "dtype-datetime",
+  "arrow/timezones",
 ]
 dtype-time = ["polars-core/dtype-time", "polars-core/temporal", "polars-time/dtype-time"]
 dtype-struct = ["polars-core/dtype-struct"]


### PR DESCRIPTION
Added some conditional feature flags so that `polars-io` compiles on its own. Need this to run some unit tests without recompiling the whole project. 

P.S. What is this legacy timezone stuff?