### PR TITLE
refactor(rust): centrally define IdxSize

### DIFF
--- a/crates/polars-arrow/src/compute/cast/mod.rs
+++ b/crates/polars-arrow/src/compute/cast/mod.rs
@@ -17,6 +17,7 @@ pub use boolean_to::*;
 pub use decimal_to::*;
 pub use dictionary_to::*;
 use polars_error::{polars_bail, polars_ensure, polars_err, PolarsResult};
+use polars_utils::IdxSize;
 pub use primitive_to::*;
 pub use utf8_to::*;
 
@@ -26,7 +27,6 @@ use crate::compute::cast::binview_to::{
     utf8view_to_naive_timestamp_dyn, view_to_binary,
 };
 use crate::datatypes::*;
-use crate::legacy::index::IdxSize;
 use crate::match_integer_type;
 use crate::offset::{Offset, Offsets};
 use crate::temporal_conversions::utf8view_to_timestamp;

--- a/crates/polars-arrow/src/compute/take/bitmap.rs
+++ b/crates/polars-arrow/src/compute/take/bitmap.rs
@@ -1,5 +1,6 @@
+use polars_utils::IdxSize;
+
 use crate::bitmap::Bitmap;
-use crate::legacy::index::IdxSize;
 
 /// # Safety
 /// doesn't do any bound checks

--- a/crates/polars-arrow/src/compute/take/boolean.rs
+++ b/crates/polars-arrow/src/compute/take/boolean.rs
@@ -1,7 +1,8 @@
+use polars_utils::IdxSize;
+
 use super::bitmap::take_bitmap_unchecked;
 use crate::array::{Array, BooleanArray, PrimitiveArray};
 use crate::bitmap::{Bitmap, MutableBitmap};
-use crate::legacy::index::IdxSize;
 
 // take implementation when neither values nor indices contain nulls
 unsafe fn take_no_validity(values: &Bitmap, indices: &[IdxSize]) -> (Bitmap, Option<Bitmap>) {

--- a/crates/polars-arrow/src/legacy/index.rs
+++ b/crates/polars-arrow/src/legacy/index.rs
@@ -1,9 +1,7 @@
 use num_traits::{NumCast, Signed, Zero};
+use polars_utils::IdxSize;
 
-#[cfg(not(feature = "bigidx"))]
-use crate::array::UInt32Array;
-#[cfg(feature = "bigidx")]
-use crate::array::UInt64Array;
+use crate::array::PrimitiveArray;
 
 pub trait IndexToUsize {
     /// Translate the negative index to an offset.
@@ -33,17 +31,8 @@ where
     }
 }
 
-/// The type used by polars to index data.
-#[cfg(not(feature = "bigidx"))]
-pub type IdxSize = u32;
-#[cfg(feature = "bigidx")]
-pub type IdxSize = u64;
-
-#[cfg(not(feature = "bigidx"))]
-pub type IdxArr = UInt32Array;
-#[cfg(feature = "bigidx")]
-pub type IdxArr = UInt64Array;
-
 pub fn indexes_to_usizes(idx: &[IdxSize]) -> impl Iterator<Item = usize> + '_ {
     idx.iter().map(|idx| *idx as usize)
 }
+
+pub type IdxArr = PrimitiveArray<IdxSize>;

--- a/crates/polars-arrow/src/legacy/kernels/fixed_size_list.rs
+++ b/crates/polars-arrow/src/legacy/kernels/fixed_size_list.rs
@@ -1,3 +1,5 @@
+use polars_utils::IdxSize;
+
 use crate::array::{ArrayRef, FixedSizeListArray, PrimitiveArray};
 use crate::compute::take::take_unchecked;
 use crate::legacy::prelude::*;

--- a/crates/polars-arrow/src/legacy/kernels/list.rs
+++ b/crates/polars-arrow/src/legacy/kernels/list.rs
@@ -1,3 +1,5 @@
+use polars_utils::IdxSize;
+
 use crate::array::{ArrayRef, ListArray};
 use crate::compute::take::take_unchecked;
 use crate::legacy::prelude::*;

--- a/crates/polars-arrow/src/legacy/kernels/set.rs
+++ b/crates/polars-arrow/src/legacy/kernels/set.rs
@@ -1,12 +1,12 @@
 use std::ops::BitOr;
 
 use polars_error::polars_err;
+use polars_utils::IdxSize;
 
 use crate::array::*;
 use crate::datatypes::ArrowDataType;
 use crate::legacy::array::default_arrays::FromData;
 use crate::legacy::error::PolarsResult;
-use crate::legacy::index::IdxSize;
 use crate::legacy::kernels::BinaryMaskedSliceIterator;
 use crate::legacy::trusted_len::TrustedLenPush;
 use crate::types::NativeType;

--- a/crates/polars-arrow/src/legacy/kernels/sort_partition.rs
+++ b/crates/polars-arrow/src/legacy/kernels/sort_partition.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 
-use crate::legacy::index::IdxSize;
+use polars_utils::IdxSize;
+
 use crate::types::NativeType;
 
 /// Find partition indexes such that every partition contains unique groups.

--- a/crates/polars-arrow/src/legacy/kernels/sorted_join/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/sorted_join/mod.rs
@@ -3,7 +3,7 @@ pub mod left;
 
 use std::fmt::Debug;
 
-use crate::legacy::index::IdxSize;
+use polars_utils::IdxSize;
 
 type JoinOptIds = Vec<Option<IdxSize>>;
 type JoinIds = Vec<IdxSize>;

--- a/crates/polars-arrow/src/legacy/kernels/take_agg/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/take_agg/mod.rs
@@ -4,10 +4,10 @@ mod var;
 
 pub use boolean::*;
 use num_traits::{NumCast, ToPrimitive};
+use polars_utils::IdxSize;
 pub use var::*;
 
 use crate::array::{Array, BinaryViewArray, BooleanArray, PrimitiveArray};
-use crate::legacy::index::IdxSize;
 use crate::types::NativeType;
 
 /// Take kernel for single chunk without nulls and an iterator as index.

--- a/crates/polars-core/src/chunked_array/ops/chunkops.rs
+++ b/crates/polars-core/src/chunked_array/ops/chunkops.rs
@@ -90,7 +90,10 @@ impl<T: PolarsDataType> ChunkedArray<T> {
                 _ => chunks.iter().fold(0, |acc, arr| acc + arr.len()),
             }
         }
-        self.length = IdxSize::try_from(inner(&self.chunks)).expect(LENGTH_LIMIT_MSG);
+        let len = inner(&self.chunks);
+        // Length limit is `IdxSize::MAX - 1`. We use `IdxSize::MAX` to indicate `NULL` in indexing.
+        assert!(len < IdxSize::MAX as usize, "{}", LENGTH_LIMIT_MSG);
+        self.length = len as IdxSize;
         self.null_count = self
             .chunks
             .iter()

--- a/crates/polars-core/src/datatypes/aliases.rs
+++ b/crates/polars-core/src/datatypes/aliases.rs
@@ -1,4 +1,4 @@
-pub use arrow::legacy::index::{IdxArr, IdxSize};
+pub use arrow::legacy::index::IdxArr;
 pub use polars_utils::aliases::{InitHashMaps, PlHashMap, PlHashSet, PlIndexMap, PlIndexSet};
 
 use super::*;

--- a/crates/polars-core/src/frame/group_by/into_groups.rs
+++ b/crates/polars-core/src/frame/group_by/into_groups.rs
@@ -1,7 +1,6 @@
 #[cfg(feature = "group_by_list")]
 use arrow::legacy::kernels::list_bytes_iter::numeric_list_bytes_iter;
 use arrow::legacy::kernels::sort_partition::{create_clean_partitions, partition_to_groups};
-use arrow::legacy::prelude::*;
 use polars_utils::total_ord::{ToTotalOrd, TotalHash};
 
 use super::*;

--- a/crates/polars-core/src/frame/group_by/perfect.rs
+++ b/crates/polars-core/src/frame/group_by/perfect.rs
@@ -5,7 +5,6 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use polars_utils::idx_vec::IdxVec;
 use polars_utils::slice::GetSaferUnchecked;
 use polars_utils::sync::SyncPtr;
-use polars_utils::IdxSize;
 use rayon::prelude::*;
 
 #[cfg(all(feature = "dtype-categorical", feature = "performant"))]

--- a/crates/polars-core/src/frame/top_k.rs
+++ b/crates/polars-core/src/frame/top_k.rs
@@ -1,7 +1,6 @@
 use std::cmp::Ordering;
 
 use polars_utils::iter::EnumerateIdxTrait;
-use polars_utils::IdxSize;
 use smartstring::alias::String as SmartString;
 
 use crate::prelude::sort::_broadcast_descending;

--- a/crates/polars-core/src/prelude.rs
+++ b/crates/polars-core/src/prelude.rs
@@ -8,8 +8,7 @@ pub use arrow::datatypes::{ArrowSchema, Field as ArrowField};
 pub use arrow::legacy::kernels::ewm::EWMOptions;
 pub use arrow::legacy::prelude::*;
 pub(crate) use arrow::trusted_len::TrustedLen;
-#[cfg(feature = "chunked_ids")]
-pub(crate) use polars_utils::index::ChunkId;
+pub use polars_utils::index::{ChunkId, IdxSize, NullableChunkId, NullableIdxSize};
 pub(crate) use polars_utils::total_ord::{TotalEq, TotalOrd};
 
 pub use crate::chunked_array::arithmetic::ArithmeticChunked;

--- a/crates/polars-core/src/series/implementations/null.rs
+++ b/crates/polars-core/src/series/implementations/null.rs
@@ -1,7 +1,6 @@
 use std::any::Any;
 
 use polars_error::constants::LENGTH_LIMIT_MSG;
-use polars_utils::IdxSize;
 
 use crate::prelude::compare_inner::{IntoTotalEqInner, TotalEqInner};
 use crate::prelude::explode::ExplodeByOffsets;

--- a/crates/polars-io/src/options.rs
+++ b/crates/polars-io/src/options.rs
@@ -1,4 +1,4 @@
-use arrow::legacy::prelude::IdxSize;
+use polars_utils::IdxSize;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
+++ b/crates/polars-lazy/src/physical_plan/streaming/construct_pipeline.rs
@@ -9,7 +9,6 @@ use polars_pipe::expressions::PhysicalPipedExpr;
 use polars_pipe::operators::chunks::DataChunk;
 use polars_pipe::pipeline::{create_pipeline, get_dummy_operator, get_operator, PipeLine};
 use polars_pipe::SExecutionContext;
-use polars_utils::IdxSize;
 
 use crate::physical_plan::planner::{create_physical_expr, ExpressionConversionState};
 use crate::physical_plan::state::ExecutionState;

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -2,7 +2,6 @@ use polars_core::prelude::gather::_update_gather_sorted_flag;
 use polars_core::prelude::*;
 use polars_core::series::IsSorted;
 use polars_core::with_match_physical_numeric_polars_type;
-use polars_utils::index::ChunkId;
 use polars_utils::slice::GetSaferUnchecked;
 
 use crate::frame::IntoDf;
@@ -24,7 +23,7 @@ pub trait DfTake: IntoDf {
     ///
     /// # Safety
     /// Does not do any bound checks.
-    unsafe fn _take_opt_chunked_unchecked_seq(&self, idx: &[ChunkId]) -> DataFrame {
+    unsafe fn _take_opt_chunked_unchecked_seq(&self, idx: &[NullableChunkId]) -> DataFrame {
         let cols = self
             .to_df()
             ._apply_columns(&|s| s.take_opt_chunked_unchecked(idx));
@@ -122,7 +121,7 @@ impl TakeChunked for Series {
     }
 
     /// Take function that checks of null state in `ChunkIdx`.
-    unsafe fn take_opt_chunked_unchecked(&self, by: &[ChunkId]) -> Self {
+    unsafe fn take_opt_chunked_unchecked(&self, by: &[NullableChunkId]) -> Self {
         let phys = self.to_physical_repr();
         use DataType::*;
         let out = match phys.dtype() {
@@ -216,7 +215,7 @@ where
     }
 
     // Take function that checks of null state in `ChunkIdx`.
-    unsafe fn take_opt_chunked_unchecked(&self, by: &[ChunkId]) -> Self {
+    unsafe fn take_opt_chunked_unchecked(&self, by: &[NullableChunkId]) -> Self {
         let arrow_dtype = self.dtype().to_arrow(true);
 
         if let Some(iter) = self.downcast_slices() {
@@ -272,7 +271,7 @@ unsafe fn take_unchecked_object(s: &Series, by: &[ChunkId], _sorted: IsSorted) -
 }
 
 #[cfg(feature = "object")]
-unsafe fn take_opt_unchecked_object(s: &Series, by: &[ChunkId]) -> Series {
+unsafe fn take_opt_unchecked_object(s: &Series, by: &[NullableChunkId]) -> Series {
     let DataType::Object(_, reg) = s.dtype() else {
         unreachable!()
     };

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -15,8 +15,6 @@ pub type ChunkJoinOptIds = Vec<Option<IdxSize>>;
 #[cfg(not(feature = "chunked_ids"))]
 pub type ChunkJoinIds = Vec<IdxSize>;
 
-#[cfg(feature = "chunked_ids")]
-use polars_utils::index::ChunkId;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/crates/polars-ops/src/frame/join/general.rs
+++ b/crates/polars-ops/src/frame/join/general.rs
@@ -1,6 +1,3 @@
-#[cfg(feature = "chunked_ids")]
-use polars_utils::index::ChunkId;
-
 use super::*;
 use crate::series::coalesce_series;
 

--- a/crates/polars-ops/src/series/ops/search_sorted.rs
+++ b/crates/polars-ops/src/series/ops/search_sorted.rs
@@ -2,7 +2,6 @@ use std::cmp::Ordering;
 use std::fmt::Debug;
 
 use arrow::array::Array;
-use arrow::legacy::prelude::*;
 use polars_core::prelude::*;
 use polars_core::with_match_physical_numeric_polars_type;
 use polars_utils::total_ord::{TotalEq, TotalOrd};

--- a/crates/polars-pipe/src/executors/sinks/joins/generic_probe_inner_left.rs
+++ b/crates/polars-pipe/src/executors/sinks/joins/generic_probe_inner_left.rs
@@ -7,7 +7,6 @@ use polars_core::series::IsSorted;
 use polars_ops::chunked_array::DfTake;
 use polars_ops::frame::join::_finish_join;
 use polars_ops::prelude::JoinType;
-use polars_utils::index::ChunkId;
 use polars_utils::nulls::IsNull;
 use smartstring::alias::String as SmartString;
 

--- a/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/mod.rs
+++ b/crates/polars-time/src/chunkedarray/rolling_window/rolling_kernels/mod.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use std::ops::{AddAssign, Mul, SubAssign};
 
 use arrow::array::{ArrayRef, PrimitiveArray};
-use arrow::legacy::index::IdxSize;
 use arrow::trusted_len::TrustedLen;
 use arrow::types::NativeType;
 use polars_core::export::num::{Bounded, Float, NumCast};

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -4,7 +4,31 @@ use polars_error::{polars_bail, polars_ensure, PolarsResult};
 
 use crate::nulls::IsNull;
 use crate::slice::GetSaferUnchecked;
-use crate::IdxSize;
+
+#[cfg(not(feature = "bigidx"))]
+pub type IdxSize = u32;
+#[cfg(feature = "bigidx")]
+pub type IdxSize = u64;
+
+pub type NullableIdxSize = IdxSize;
+
+pub trait IsNullIdx {
+    fn is_null(&self) -> bool;
+
+    fn null() -> Self;
+}
+
+impl IsNullIdx for IdxSize {
+    #[inline(always)]
+    fn is_null(&self) -> bool {
+        *self == IdxSize::MAX
+    }
+
+    #[inline(always)]
+    fn null() -> Self {
+        IdxSize::MAX
+    }
+}
 
 pub trait Bounded {
     fn len(&self) -> usize;
@@ -125,6 +149,8 @@ const DEFAULT_CHUNK_BITS: u64 = 24;
 pub struct ChunkId<const CHUNK_BITS: u64 = DEFAULT_CHUNK_BITS> {
     swizzled: u64,
 }
+
+pub type NullableChunkId = ChunkId;
 
 impl Debug for ChunkId {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -24,11 +24,6 @@ pub mod unwrap;
 
 pub use functions::*;
 
-#[cfg(not(feature = "bigidx"))]
-pub type IdxSize = u32;
-#[cfg(feature = "bigidx")]
-pub type IdxSize = u64;
-
 pub mod aliases;
 pub mod fmt;
 pub mod iter;
@@ -44,4 +39,5 @@ pub mod nulls;
 pub mod ord;
 pub mod partitioned;
 
+pub use index::{IdxSize, IsNullIdx, NullableIdxSize};
 pub use io::open_file;


### PR DESCRIPTION
This was defined on multiple places for legacy reasons. This cleans that up.