### PR TITLE
perf: Reduce size of optional join-indexes

### DIFF
--- a/crates/polars-arrow/src/bitmap/immutable.rs
+++ b/crates/polars-arrow/src/bitmap/immutable.rs
@@ -11,6 +11,7 @@ use crate::bitmap::iterator::{
     FastU32BitmapIter, FastU56BitmapIter, FastU64BitmapIter, TrueIdxIter,
 };
 use crate::buffer::Bytes;
+use crate::legacy::utils::FromTrustedLenIterator;
 use crate::trusted_len::TrustedLen;
 
 const UNKNOWN_BIT_COUNT: u64 = u64::MAX;
@@ -481,6 +482,15 @@ impl FromIterator<bool> for Bitmap {
         I: IntoIterator<Item = bool>,
     {
         MutableBitmap::from_iter(iter).into()
+    }
+}
+
+impl FromTrustedLenIterator<bool> for Bitmap {
+    fn from_iter_trusted_length<T: IntoIterator<Item = bool>>(iter: T) -> Self
+    where
+        T::IntoIter: TrustedLen,
+    {
+        MutableBitmap::from_trusted_len_iter(iter.into_iter()).into()
     }
 }
 

--- a/crates/polars-arrow/src/legacy/kernels/sorted_join/left.rs
+++ b/crates/polars-arrow/src/legacy/kernels/sorted_join/left.rs
@@ -98,13 +98,13 @@ mod test {
         let (l_idx, r_idx) = join(lhs, rhs, 0);
         let out_left = &[0, 1, 1, 2, 2, 3, 4, 5];
         let out_right = &[
-            0,
-            1,
-            2,
-            1,
-            2,
+            0.into(),
+            1.into(),
+            2.into(),
+            1.into(),
+            2.into(),
             NullableIdxSize::null(),
-            3,
+            3.into(),
             NullableIdxSize::null(),
         ];
         assert_eq!(&l_idx, out_left);
@@ -128,20 +128,20 @@ mod test {
         assert_eq!(
             &r_idx,
             &[
-                0,
-                1,
-                0,
-                1,
-                2,
-                3,
-                4,
+                0.into(),
+                1.into(),
+                0.into(),
+                1.into(),
+                2.into(),
+                3.into(),
+                4.into(),
                 NullableIdxSize::null(),
-                5,
-                6,
-                5,
-                6,
-                5,
-                6,
+                5.into(),
+                6.into(),
+                5.into(),
+                6.into(),
+                5.into(),
+                6.into(),
                 NullableIdxSize::null(),
             ]
         );
@@ -155,14 +155,14 @@ mod test {
             &[
                 NullableIdxSize::null(),
                 NullableIdxSize::null(),
-                1,
-                2,
-                2,
-                2,
-                2,
-                3,
-                4,
-                4
+                1.into(),
+                2.into(),
+                2.into(),
+                2.into(),
+                2.into(),
+                3.into(),
+                4.into(),
+                4.into()
             ]
         );
         let lhs = &[0, 1, 2, 2, 3, 4, 4, 6, 6, 7];
@@ -177,12 +177,12 @@ mod test {
                 NullableIdxSize::null(),
                 NullableIdxSize::null(),
                 NullableIdxSize::null(),
-                0,
-                1,
-                2,
-                0,
-                1,
-                2,
+                0.into(),
+                1.into(),
+                2.into(),
+                0.into(),
+                1.into(),
+                2.into(),
                 NullableIdxSize::null(),
                 NullableIdxSize::null(),
                 NullableIdxSize::null(),

--- a/crates/polars-arrow/src/legacy/kernels/sorted_join/left.rs
+++ b/crates/polars-arrow/src/legacy/kernels/sorted_join/left.rs
@@ -11,7 +11,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
     if right.is_empty() {
         return (
             (left_offset..left.len() as IdxSize + left_offset).collect(),
-            vec![None; left.len()],
+            vec![NullableIdxSize::null(); left.len()],
         );
     }
     // * 1.5 because there can be duplicates
@@ -27,7 +27,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
 
     let first_right = right[right_idx as usize];
     let mut left_idx = left.partition_point(|v| v < &first_right) as IdxSize;
-    out_rhs.extend(std::iter::repeat(None).take(left_idx as usize));
+    out_rhs.extend(std::iter::repeat(NullableIdxSize::null()).take(left_idx as usize));
     out_lhs.extend(left_offset..(left_idx + left_offset));
 
     for &val_l in &left[left_idx as usize..] {
@@ -37,7 +37,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                     // matching join key
                     if val_l == val_r {
                         out_lhs.push(left_idx + left_offset);
-                        out_rhs.push(Some(right_idx));
+                        out_rhs.push(right_idx);
                         let current_idx = right_idx;
 
                         loop {
@@ -52,7 +52,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                                 Some(&val_r) => {
                                     if val_l == val_r {
                                         out_lhs.push(left_idx + left_offset);
-                                        out_rhs.push(Some(right_idx));
+                                        out_rhs.push(right_idx);
                                     } else {
                                         // reset right index because the next lhs value can be the same
                                         right_idx = current_idx;
@@ -67,7 +67,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                     // right is larger than left.
                     if val_r > val_l {
                         out_lhs.push(left_idx + left_offset);
-                        out_rhs.push(None);
+                        out_rhs.push(NullableIdxSize::null());
                         break;
                     }
                     // continue looping the right side
@@ -76,7 +76,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                 // we depleted the right array
                 None => {
                     out_lhs.push(left_idx + left_offset);
-                    out_rhs.push(None);
+                    out_rhs.push(NullableIdxSize::null());
                     break;
                 },
             }

--- a/crates/polars-arrow/src/legacy/kernels/sorted_join/left.rs
+++ b/crates/polars-arrow/src/legacy/kernels/sorted_join/left.rs
@@ -37,7 +37,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                     // matching join key
                     if val_l == val_r {
                         out_lhs.push(left_idx + left_offset);
-                        out_rhs.push(right_idx);
+                        out_rhs.push(right_idx.into());
                         let current_idx = right_idx;
 
                         loop {
@@ -52,7 +52,7 @@ pub fn join<T: PartialOrd + Copy + Debug>(
                                 Some(&val_r) => {
                                     if val_l == val_r {
                                         out_lhs.push(left_idx + left_offset);
-                                        out_rhs.push(right_idx);
+                                        out_rhs.push(right_idx.into());
                                     } else {
                                         // reset right index because the next lhs value can be the same
                                         right_idx = current_idx;

--- a/crates/polars-arrow/src/legacy/kernels/sorted_join/left.rs
+++ b/crates/polars-arrow/src/legacy/kernels/sorted_join/left.rs
@@ -98,14 +98,14 @@ mod test {
         let (l_idx, r_idx) = join(lhs, rhs, 0);
         let out_left = &[0, 1, 1, 2, 2, 3, 4, 5];
         let out_right = &[
-            Some(0),
-            Some(1),
-            Some(2),
-            Some(1),
-            Some(2),
-            None,
-            Some(3),
-            None,
+            0,
+            1,
+            2,
+            1,
+            2,
+            NullableIdxSize::null(),
+            3,
+            NullableIdxSize::null(),
         ];
         assert_eq!(&l_idx, out_left);
         assert_eq!(&r_idx, out_right);
@@ -128,21 +128,21 @@ mod test {
         assert_eq!(
             &r_idx,
             &[
-                Some(0),
-                Some(1),
-                Some(0),
-                Some(1),
-                Some(2),
-                Some(3),
-                Some(4),
-                None,
-                Some(5),
-                Some(6),
-                Some(5),
-                Some(6),
-                Some(5),
-                Some(6),
-                None
+                0,
+                1,
+                0,
+                1,
+                2,
+                3,
+                4,
+                NullableIdxSize::null(),
+                5,
+                6,
+                5,
+                6,
+                5,
+                6,
+                NullableIdxSize::null(),
             ]
         );
 
@@ -153,16 +153,16 @@ mod test {
         assert_eq!(
             &r_idx,
             &[
-                None,
-                None,
-                Some(1),
-                Some(2),
-                Some(2),
-                Some(2),
-                Some(2),
-                Some(3),
-                Some(4),
-                Some(4)
+                NullableIdxSize::null(),
+                NullableIdxSize::null(),
+                1,
+                2,
+                2,
+                2,
+                2,
+                3,
+                4,
+                4
             ]
         );
         let lhs = &[0, 1, 2, 2, 3, 4, 4, 6, 6, 7];
@@ -172,20 +172,20 @@ mod test {
         assert_eq!(
             &r_idx,
             &[
-                None,
-                None,
-                None,
-                None,
-                None,
-                Some(0),
-                Some(1),
-                Some(2),
-                Some(0),
-                Some(1),
-                Some(2),
-                None,
-                None,
-                None
+                NullableIdxSize::null(),
+                NullableIdxSize::null(),
+                NullableIdxSize::null(),
+                NullableIdxSize::null(),
+                NullableIdxSize::null(),
+                0,
+                1,
+                2,
+                0,
+                1,
+                2,
+                NullableIdxSize::null(),
+                NullableIdxSize::null(),
+                NullableIdxSize::null(),
             ]
         )
     }

--- a/crates/polars-arrow/src/legacy/kernels/sorted_join/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/sorted_join/mod.rs
@@ -3,9 +3,9 @@ pub mod left;
 
 use std::fmt::Debug;
 
-use polars_utils::IdxSize;
+use polars_utils::{IdxSize, IsNullIdx, NullableIdxSize};
 
-type JoinOptIds = Vec<Option<IdxSize>>;
+type JoinOptIds = Vec<NullableIdxSize>;
 type JoinIds = Vec<IdxSize>;
 type LeftJoinIds = (JoinIds, JoinOptIds);
 type InnerJoinIds = (JoinIds, JoinIds);

--- a/crates/polars-arrow/src/legacy/kernels/sorted_join/mod.rs
+++ b/crates/polars-arrow/src/legacy/kernels/sorted_join/mod.rs
@@ -3,7 +3,7 @@ pub mod left;
 
 use std::fmt::Debug;
 
-use polars_utils::{IdxSize, IsNullIdx, NullableIdxSize};
+use polars_utils::{IdxSize, NullableIdxSize};
 
 type JoinOptIds = Vec<NullableIdxSize>;
 type JoinIds = Vec<IdxSize>;

--- a/crates/polars-core/src/chunked_array/ops/gather.rs
+++ b/crates/polars-core/src/chunked_array/ops/gather.rs
@@ -1,4 +1,5 @@
 use arrow::bitmap::bitmask::BitMask;
+use arrow::bitmap::Bitmap;
 use arrow::compute::take::take_unchecked;
 use polars_error::{polars_bail, polars_ensure};
 use polars_utils::index::check_bounds;
@@ -273,5 +274,17 @@ impl ChunkTakeUnchecked<IdxCa> for BinaryChunked {
 impl ChunkTakeUnchecked<IdxCa> for StringChunked {
     unsafe fn take_unchecked(&self, indices: &IdxCa) -> Self {
         self.as_binary().take_unchecked(indices).to_string()
+    }
+}
+
+impl IdxCa {
+    pub fn with_nullable_idx<T, F: FnOnce(&IdxCa) -> T>(idx: &[NullableIdxSize], f: F) -> T {
+        let validity: Bitmap = idx.iter().map(|idx| idx.is_null_idx()).collect();
+        let idx = bytemuck::cast_slice::<_, IdxSize>(idx);
+        let arr = unsafe { arrow::ffi::mmap::slice(idx) };
+        let arr = arr.with_validity_typed(Some(validity));
+        let ca = IdxCa::with_chunk("", arr);
+
+        f(&ca)
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/gather.rs
+++ b/crates/polars-core/src/chunked_array/ops/gather.rs
@@ -279,7 +279,7 @@ impl ChunkTakeUnchecked<IdxCa> for StringChunked {
 
 impl IdxCa {
     pub fn with_nullable_idx<T, F: FnOnce(&IdxCa) -> T>(idx: &[NullableIdxSize], f: F) -> T {
-        let validity: Bitmap = idx.iter().map(|idx| idx.is_null_idx()).collect();
+        let validity: Bitmap = idx.iter().map(|idx| !idx.is_null_idx()).collect_trusted();
         let idx = bytemuck::cast_slice::<_, IdxSize>(idx);
         let arr = unsafe { arrow::ffi::mmap::slice(idx) };
         let arr = arr.with_validity_typed(Some(validity));

--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -630,7 +630,7 @@ fn materialize_column(join_opt_ids: &ChunkJoinOptIds, out_column: &Series) -> Se
 
         match join_opt_ids {
             Either::Left(ids) => unsafe {
-                out_column.take_unchecked(&ids.iter().copied().collect_ca(""))
+                IdxCa::with_nullable_idx(ids, |idx| out_column.take_unchecked(idx))
             },
             Either::Right(ids) => unsafe { out_column.take_opt_chunked_unchecked(ids) },
         }

--- a/crates/polars-ops/src/frame/join/args.rs
+++ b/crates/polars-ops/src/frame/join/args.rs
@@ -7,10 +7,10 @@ pub type InnerJoinIds = (JoinIds, JoinIds);
 #[cfg(feature = "chunked_ids")]
 pub(super) type ChunkJoinIds = Either<Vec<IdxSize>, Vec<ChunkId>>;
 #[cfg(feature = "chunked_ids")]
-pub type ChunkJoinOptIds = Either<Vec<Option<IdxSize>>, Vec<ChunkId>>;
+pub type ChunkJoinOptIds = Either<Vec<NullableIdxSize>, Vec<ChunkId>>;
 
 #[cfg(not(feature = "chunked_ids"))]
-pub type ChunkJoinOptIds = Vec<Option<IdxSize>>;
+pub type ChunkJoinOptIds = Vec<NullableIdxSize>;
 
 #[cfg(not(feature = "chunked_ids"))]
 pub type ChunkJoinIds = Vec<IdxSize>;

--- a/crates/polars-ops/src/frame/join/hash_join/mod.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/mod.rs
@@ -110,7 +110,7 @@ pub trait JoinDispatch: IntoDf {
 
         let materialize_right = || {
             let right_idx = &*right_idx;
-            unsafe { other.take_unchecked(&right_idx.iter().copied().collect_ca("")) }
+            unsafe { IdxCa::with_nullable_idx(right_idx, |idx| other.take_unchecked(idx)) }
         };
         let (df_left, df_right) = POOL.join(materialize_left, materialize_right);
 
@@ -150,7 +150,7 @@ pub trait JoinDispatch: IntoDf {
                 if let Some((offset, len)) = args.slice {
                     right_idx = slice_slice(right_idx, offset, len);
                 }
-                other.take_unchecked(&right_idx.iter().copied().collect_ca(""))
+                IdxCa::with_nullable_idx(right_idx, |idx| other.take_unchecked(idx))
             },
             ChunkJoinOptIds::Right(right_idx) => unsafe {
                 let mut right_idx = &*right_idx;

--- a/crates/polars-ops/src/frame/join/hash_join/multiple_keys.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/multiple_keys.rs
@@ -4,7 +4,7 @@ use polars_core::hashing::{populate_multiple_key_hashmap, IdBuildHasher, IdxHash
 use polars_core::utils::split_df;
 use polars_utils::hashing::hash_to_partition;
 use polars_utils::idx_vec::IdxVec;
-use polars_utils::unitvec;
+use polars_utils::{unitvec, IsNullIdx};
 
 use super::*;
 
@@ -321,12 +321,12 @@ pub fn _left_join_multiple_keys(
                             Some((_, indexes_b)) => {
                                 result_idx_left
                                     .extend(std::iter::repeat(idx_a).take(indexes_b.len()));
-                                result_idx_right.extend(indexes_b.iter().copied().map(Some))
+                                result_idx_right.extend_from_slice(indexes_b);
                             },
                             // only left values, right = null
                             None => {
                                 result_idx_left.push(idx_a);
-                                result_idx_right.push(None);
+                                result_idx_right.push(NullableIdxSize::null());
                             },
                         }
                         idx_a += 1;

--- a/crates/polars-ops/src/frame/join/hash_join/multiple_keys.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/multiple_keys.rs
@@ -4,7 +4,7 @@ use polars_core::hashing::{populate_multiple_key_hashmap, IdBuildHasher, IdxHash
 use polars_core::utils::split_df;
 use polars_utils::hashing::hash_to_partition;
 use polars_utils::idx_vec::IdxVec;
-use polars_utils::{unitvec, IsNullIdx};
+use polars_utils::unitvec;
 
 use super::*;
 
@@ -321,6 +321,7 @@ pub fn _left_join_multiple_keys(
                             Some((_, indexes_b)) => {
                                 result_idx_left
                                     .extend(std::iter::repeat(idx_a).take(indexes_b.len()));
+                                let indexes_b = bytemuck::cast_slice(indexes_b);
                                 result_idx_right.extend_from_slice(indexes_b);
                             },
                             // only left values, right = null

--- a/crates/polars-ops/src/frame/join/hash_join/single_keys_left.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/single_keys_left.rs
@@ -2,7 +2,6 @@ use polars_core::utils::flatten::flatten_par;
 use polars_utils::hashing::{hash_to_partition, DirtyHash};
 use polars_utils::nulls::IsNull;
 use polars_utils::total_ord::{ToTotalOrd, TotalEq, TotalHash};
-use polars_utils::IsNullIdx;
 
 use super::*;
 
@@ -20,7 +19,7 @@ unsafe fn apply_opt_mapping(idx: Vec<NullableIdxSize>, chunk_mapping: &[ChunkId]
             if opt_idx.is_null_idx() {
                 ChunkId::null()
             } else {
-                *chunk_mapping.get_unchecked(*opt_idx as usize)
+                *chunk_mapping.get_unchecked(opt_idx.idx() as usize)
             }
         })
         .collect()
@@ -167,7 +166,7 @@ where
                         // left and right matches
                         Some(indexes_b) => {
                             result_idx_left.extend(std::iter::repeat(idx_a).take(indexes_b.len()));
-                            result_idx_right.extend_from_slice(indexes_b);
+                            result_idx_right.extend_from_slice(bytemuck::cast_slice(indexes_b));
                         },
                         // only left values, right = null
                         None => {

--- a/crates/polars-ops/src/frame/join/hash_join/sort_merge.rs
+++ b/crates/polars-ops/src/frame/join/hash_join/sort_merge.rs
@@ -4,8 +4,6 @@ use arrow::legacy::kernels::sorted_join;
 use polars_core::utils::_split_offsets;
 #[cfg(feature = "performant")]
 use polars_core::utils::flatten::flatten_par;
-#[cfg(feature = "performant")]
-use polars_utils::IsNullIdx;
 
 use super::*;
 
@@ -335,7 +333,9 @@ pub(super) fn sort_or_hash_left(
             POOL.install(|| {
                 right.par_iter_mut().for_each(|opt_idx| {
                     if !opt_idx.is_null_idx() {
-                        *opt_idx = unsafe { *reverse_idx_map.get_unchecked(*opt_idx as usize) };
+                        *opt_idx =
+                            unsafe { *reverse_idx_map.get_unchecked(opt_idx.idx() as usize) }
+                                .into();
                     }
                 });
             });

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -13,14 +13,14 @@ pub type IdxSize = u64;
 pub type NullableIdxSize = IdxSize;
 
 pub trait IsNullIdx {
-    fn is_null(&self) -> bool;
+    fn is_null_idx(&self) -> bool;
 
     fn null() -> Self;
 }
 
 impl IsNullIdx for IdxSize {
     #[inline(always)]
-    fn is_null(&self) -> bool {
+    fn is_null_idx(&self) -> bool {
         *self == IdxSize::MAX
     }
 

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -16,6 +16,14 @@ pub struct NullableIdxSize {
     pub inner: IdxSize,
 }
 
+impl PartialEq<Self> for NullableIdxSize {
+    fn eq(&self, other: &Self) -> bool {
+        self.inner == other.inner
+    }
+}
+
+impl Eq for NullableIdxSize {}
+
 unsafe impl bytemuck::Zeroable for NullableIdxSize {}
 unsafe impl bytemuck::AnyBitPattern for NullableIdxSize {}
 unsafe impl bytemuck::NoUninit for NullableIdxSize {}

--- a/crates/polars-utils/src/index.rs
+++ b/crates/polars-utils/src/index.rs
@@ -10,23 +10,54 @@ pub type IdxSize = u32;
 #[cfg(feature = "bigidx")]
 pub type IdxSize = u64;
 
-pub type NullableIdxSize = IdxSize;
-
-pub trait IsNullIdx {
-    fn is_null_idx(&self) -> bool;
-
-    fn null() -> Self;
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct NullableIdxSize {
+    pub inner: IdxSize,
 }
 
-impl IsNullIdx for IdxSize {
+unsafe impl bytemuck::Zeroable for NullableIdxSize {}
+unsafe impl bytemuck::AnyBitPattern for NullableIdxSize {}
+unsafe impl bytemuck::NoUninit for NullableIdxSize {}
+
+impl Debug for NullableIdxSize {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.inner)
+    }
+}
+
+impl NullableIdxSize {
     #[inline(always)]
-    fn is_null_idx(&self) -> bool {
-        *self == IdxSize::MAX
+    pub fn is_null_idx(&self) -> bool {
+        self.inner == IdxSize::MAX
     }
 
     #[inline(always)]
-    fn null() -> Self {
-        IdxSize::MAX
+    pub const fn null() -> Self {
+        Self {
+            inner: IdxSize::MAX,
+        }
+    }
+
+    #[inline(always)]
+    pub fn idx(&self) -> IdxSize {
+        self.inner
+    }
+
+    #[inline(always)]
+    pub fn to_opt(&self) -> Option<IdxSize> {
+        if self.is_null_idx() {
+            None
+        } else {
+            Some(self.idx())
+        }
+    }
+}
+
+impl From<IdxSize> for NullableIdxSize {
+    #[inline(always)]
+    fn from(value: IdxSize) -> Self {
+        Self { inner: value }
     }
 }
 

--- a/crates/polars-utils/src/lib.rs
+++ b/crates/polars-utils/src/lib.rs
@@ -39,5 +39,5 @@ pub mod nulls;
 pub mod ord;
 pub mod partitioned;
 
-pub use index::{IdxSize, IsNullIdx, NullableIdxSize};
+pub use index::{IdxSize, NullableIdxSize};
 pub use io::open_file;


### PR DESCRIPTION
This fits twice as much of them on a cache line.