### PR TITLE
perf: rework scalar filter kernels

### DIFF
--- a/crates/polars-arrow/src/bitmap/iterator.rs
+++ b/crates/polars-arrow/src/bitmap/iterator.rs
@@ -292,7 +292,7 @@ impl<'a> FastU64BitmapIter<'a> {
             if self.bits_left >= 64 {
                 mask = u64::MAX;
                 self.bits_left -= 64;
-                self.bytes = unsafe { self.bytes.get_unchecked(8..) };
+                self.bytes = self.bytes.get(8..).unwrap_or(&[]);
             } else {
                 mask = (1 << self.bits_left) - 1;
                 self.bits_left = 0;

--- a/crates/polars-compute/src/filter/boolean.rs
+++ b/crates/polars-compute/src/filter/boolean.rs
@@ -1,7 +1,6 @@
+use arrow::bitmap::Bitmap;
 use polars_utils::clmul::prefix_xorsum;
 use polars_utils::slice::load_padded_le_u64;
-
-use super::*;
 
 const U56_MAX: u64 = (1 << 56) - 1;
 
@@ -260,7 +259,7 @@ unsafe fn filter_boolean_kernel_pext<const HAS_NATIVE_PEXT: bool, F: Fn(u64, u64
     }
 }
 
-pub(super) fn filter_bitmap_and_validity(
+pub fn filter_bitmap_and_validity(
     values: &Bitmap,
     validity: Option<&Bitmap>,
     mask: &Bitmap,

--- a/crates/polars-compute/src/filter/mod.rs
+++ b/crates/polars-compute/src/filter/mod.rs
@@ -56,7 +56,7 @@ pub fn filter(array: &dyn Array, mask: &BooleanArray) -> PolarsResult<Box<dyn Ar
                     array.data_type().clone(),
                     views.into(),
                     array.data_buffers().clone(),
-                    validity.map(|v| v),
+                    validity,
                     Some(array.total_buffer_len()),
                 )
             }

--- a/crates/polars-compute/src/filter/mod.rs
+++ b/crates/polars-compute/src/filter/mod.rs
@@ -1,6 +1,7 @@
 //! Contains operators to filter arrays such as [`filter`].
 mod boolean;
 mod primitive;
+mod scalar;
 
 use arrow::array::growable::make_growable;
 use arrow::array::*;
@@ -50,7 +51,8 @@ pub fn filter(array: &dyn Array, mask: &BooleanArray) -> PolarsResult<Box<dyn Ar
     match array.data_type().to_physical_type() {
         Primitive(primitive) => with_match_primitive_type_full!(primitive, |$T| {
             let array = array.as_any().downcast_ref().unwrap();
-            Ok(Box::new(filter_primitive::<$T>(array, mask.values())))
+            // Ok(Box::new(filter_primitive::<$T>(array, mask.values())))
+            Ok(Box::new(scalar::filter_primitive_scalar::<$T>(array, mask.values())))
         }),
         Boolean => {
             let array = array.as_any().downcast_ref::<BooleanArray>().unwrap();

--- a/crates/polars-compute/src/filter/primitive.rs
+++ b/crates/polars-compute/src/filter/primitive.rs
@@ -1,5 +1,5 @@
 use arrow::bitmap::Bitmap;
-use bytemuck::{cast_vec, cast_slice, Pod};
+use bytemuck::{cast_slice, cast_vec, Pod};
 
 use super::boolean::filter_boolean_kernel;
 
@@ -9,7 +9,7 @@ pub fn filter_values<T: Pod>(values: &[T], mask: &Bitmap) -> Vec<T> {
         (2, 2) => cast_vec(filter_values_u16(cast_slice(values), mask)),
         (4, 4) => cast_vec(filter_values_u32(cast_slice(values), mask)),
         (8, 8) => cast_vec(filter_values_u64(cast_slice(values), mask)),
-        _ => filter_values_generic(values, mask)
+        _ => filter_values_generic(values, mask),
     }
 }
 

--- a/crates/polars-compute/src/filter/primitive.rs
+++ b/crates/polars-compute/src/filter/primitive.rs
@@ -1,183 +1,56 @@
-use super::*;
+use arrow::bitmap::Bitmap;
+use bytemuck::{cast_vec, cast_slice, Pod};
 
-pub(super) fn filter_values_and_validity<T: NativeType>(
+use super::boolean::filter_boolean_kernel;
+
+pub fn filter_values<T: Pod>(values: &[T], mask: &Bitmap) -> Vec<T> {
+    match (std::mem::size_of::<T>(), std::mem::align_of::<T>()) {
+        (1, 1) => cast_vec(filter_values_u8(cast_slice(values), mask)),
+        (2, 2) => cast_vec(filter_values_u16(cast_slice(values), mask)),
+        (4, 4) => cast_vec(filter_values_u32(cast_slice(values), mask)),
+        (8, 8) => cast_vec(filter_values_u64(cast_slice(values), mask)),
+        _ => filter_values_generic(values, mask)
+    }
+}
+
+fn filter_values_u8(values: &[u8], mask: &Bitmap) -> Vec<u8> {
+    // TODO: fast SIMD implementation.
+    filter_values_generic(values, mask)
+}
+
+fn filter_values_u16(values: &[u16], mask: &Bitmap) -> Vec<u16> {
+    // TODO: fast SIMD implementation.
+    filter_values_generic(values, mask)
+}
+
+fn filter_values_u32(values: &[u32], mask: &Bitmap) -> Vec<u32> {
+    // TODO: fast SIMD implementation.
+    filter_values_generic(values, mask)
+}
+
+fn filter_values_u64(values: &[u64], mask: &Bitmap) -> Vec<u64> {
+    // TODO: fast SIMD implementation.
+    filter_values_generic(values, mask)
+}
+
+fn filter_values_generic<T: Pod>(values: &[T], mask: &Bitmap) -> Vec<T> {
+    assert_eq!(values.len(), mask.len());
+    let mask_bits_set = mask.set_bits();
+    let mut out = Vec::with_capacity(mask_bits_set + 1);
+    unsafe {
+        super::scalar::filter_scalar_values(values, mask, out.as_mut_ptr());
+        out.set_len(mask_bits_set);
+    }
+    out
+}
+
+pub fn filter_values_and_validity<T: Pod>(
     values: &[T],
     validity: Option<&Bitmap>,
     mask: &Bitmap,
-) -> (Vec<T>, Option<MutableBitmap>) {
-    if let Some(validity) = validity {
-        let (values, validity) = null_filter(values, validity, mask);
-        (values, Some(validity))
-    } else {
-        (nonnull_filter(values, mask), None)
-    }
-}
-
-pub(super) fn filter_primitive<T: NativeType + Simd>(
-    array: &PrimitiveArray<T>,
-    mask: &Bitmap,
-) -> PrimitiveArray<T> {
-    assert_eq!(array.len(), mask.len());
-    let (values, validity) = filter_values_and_validity(array.values(), array.validity(), mask);
-    let validity = validity.map(|validity| validity.freeze());
-    unsafe {
-        PrimitiveArray::<T>::new_unchecked(array.data_type().clone(), values.into(), validity)
-    }
-}
-
-/// # Safety
-/// This assumes that the `mask_chunks` contains a number of set/true items equal
-/// to `filter_count`
-unsafe fn nonnull_filter_impl<T, I>(values: &[T], mut mask_chunks: I, filter_count: usize) -> Vec<T>
-where
-    T: NativeType,
-    I: BitChunkIterExact<u64>,
-{
-    let mut chunks = values.chunks_exact(64);
-    let mut new = Vec::<T>::with_capacity(filter_count);
-    let mut dst = new.as_mut_ptr();
-
-    chunks
-        .by_ref()
-        .zip(mask_chunks.by_ref())
-        .for_each(|(chunk, mask_chunk)| {
-            let ones = mask_chunk.count_ones();
-            let leading_ones = get_leading_ones(mask_chunk);
-
-            if ones == leading_ones {
-                let size = leading_ones as usize;
-                unsafe {
-                    std::ptr::copy(chunk.as_ptr(), dst, size);
-                    dst = dst.add(size);
-                }
-                return;
-            }
-
-            let ones_iter = BitChunkOnes::from_known_count(mask_chunk, ones as usize);
-            for pos in ones_iter {
-                dst.write(*chunk.get_unchecked(pos));
-                dst = dst.add(1);
-            }
-        });
-
-    chunks
-        .remainder()
-        .iter()
-        .zip(mask_chunks.remainder_iter())
-        .for_each(|(value, b)| {
-            if b {
-                unsafe {
-                    dst.write(*value);
-                    dst = dst.add(1);
-                };
-            }
-        });
-
-    unsafe { new.set_len(filter_count) };
-    new
-}
-
-/// # Safety
-/// This assumes that the `mask_chunks` contains a number of set/true items equal
-/// to `filter_count`
-unsafe fn null_filter_impl<T, I>(
-    values: &[T],
-    validity: &Bitmap,
-    mut mask_chunks: I,
-    filter_count: usize,
-) -> (Vec<T>, MutableBitmap)
-where
-    T: NativeType,
-    I: BitChunkIterExact<u64>,
-{
-    let mut chunks = values.chunks_exact(64);
-
-    let mut validity_chunks = validity.chunks::<u64>();
-
-    let mut new = Vec::<T>::with_capacity(filter_count);
-    let mut dst = new.as_mut_ptr();
-    let mut new_validity = MutableBitmap::with_capacity(filter_count);
-
-    chunks
-        .by_ref()
-        .zip(validity_chunks.by_ref())
-        .zip(mask_chunks.by_ref())
-        .for_each(|((chunk, validity_chunk), mask_chunk)| {
-            let ones = mask_chunk.count_ones();
-            let leading_ones = get_leading_ones(mask_chunk);
-
-            if ones == leading_ones {
-                let size = leading_ones as usize;
-                unsafe {
-                    std::ptr::copy(chunk.as_ptr(), dst, size);
-                    dst = dst.add(size);
-
-                    // SAFETY: invariant offset + length <= slice.len()
-                    new_validity.extend_from_slice_unchecked(
-                        validity_chunk.to_ne_bytes().as_ref(),
-                        0,
-                        size,
-                    );
-                }
-                return;
-            }
-
-            // this triggers a bitcount
-            let ones_iter = BitChunkOnes::from_known_count(mask_chunk, ones as usize);
-            for pos in ones_iter {
-                dst.write(*chunk.get_unchecked(pos));
-                dst = dst.add(1);
-                new_validity.push_unchecked(validity_chunk & (1 << pos) > 0);
-            }
-        });
-
-    chunks
-        .remainder()
-        .iter()
-        .zip(validity_chunks.remainder_iter())
-        .zip(mask_chunks.remainder_iter())
-        .for_each(|((value, is_valid), is_selected)| {
-            if is_selected {
-                unsafe {
-                    dst.write(*value);
-                    dst = dst.add(1);
-                    new_validity.push_unchecked(is_valid);
-                };
-            }
-        });
-
-    unsafe { new.set_len(filter_count) };
-    (new, new_validity)
-}
-
-fn null_filter<T: NativeType>(
-    values: &[T],
-    validity: &Bitmap,
-    mask: &Bitmap,
-) -> (Vec<T>, MutableBitmap) {
-    assert_eq!(values.len(), mask.len());
-    let filter_count = mask.len() - mask.unset_bits();
-
-    let (slice, offset, length) = mask.as_slice();
-    if offset == 0 {
-        let mask_chunks = BitChunksExact::<u64>::new(slice, length);
-        unsafe { null_filter_impl(values, validity, mask_chunks, filter_count) }
-    } else {
-        let mask_chunks = mask.chunks::<u64>();
-        unsafe { null_filter_impl(values, validity, mask_chunks, filter_count) }
-    }
-}
-
-fn nonnull_filter<T: NativeType>(values: &[T], mask: &Bitmap) -> Vec<T> {
-    assert_eq!(values.len(), mask.len());
-    let filter_count = mask.len() - mask.unset_bits();
-
-    let (slice, offset, length) = mask.as_slice();
-    if offset == 0 {
-        let mask_chunks = BitChunksExact::<u64>::new(slice, length);
-        unsafe { nonnull_filter_impl(values, mask_chunks, filter_count) }
-    } else {
-        let mask_chunks = mask.chunks::<u64>();
-        unsafe { nonnull_filter_impl(values, mask_chunks, filter_count) }
-    }
+) -> (Vec<T>, Option<Bitmap>) {
+    (
+        filter_values(values, mask),
+        validity.map(|v| filter_boolean_kernel(v, mask)),
+    )
 }

--- a/crates/polars-compute/src/filter/scalar.rs
+++ b/crates/polars-compute/src/filter/scalar.rs
@@ -1,0 +1,291 @@
+use std::mem::MaybeUninit;
+
+use arrow::array::PrimitiveArray;
+use arrow::bitmap::Bitmap;
+use arrow::types::NativeType;
+use bytemuck::Pod;
+use polars_utils::slice::load_padded_le_u64;
+
+
+// If the ith bit of m is set (m & (1 << i)), then v[i] must be in-bounds.
+// out must be valid for at least m.count_ones() + 4 writes.
+// m_popcnt must be m.count_ones()
+unsafe fn scalar_sparse_unchecked<T: Pod>(v: &[T], mut m: u64, mut m_popcnt: u32, out: *mut T) {
+    let mut written = 0;
+    
+    while m > 0 {
+        let idx = m.trailing_zeros() as usize;
+        *out.add(written as usize) = *v.get_unchecked(idx);
+        m &= m.wrapping_sub(1); // Clear least significant bit.
+        written += 1;
+
+        // tz % 64 otherwise we could go out of bounds
+        let idx = (m.trailing_zeros() % 64) as usize;
+        *out.add(written as usize) = *v.get_unchecked(idx);
+        m &= m.wrapping_sub(1); // Clear least significant bit.
+        written += 1;
+    }
+}
+
+// v.len() >= 64 must hold.
+// out must be valid for at least m.count_ones() + 1 writes.
+unsafe fn scalar_filter64_unchecked<T: Pod>(v: &[T], mut m: u64, out: *mut T) {
+    // Rust generated significantly better code if we write the below loop
+    // with v as a pointer, and out.add(written) instead of incrementing out
+    // directly.
+    let mut written = 0usize;
+    let mut src = v.as_ptr();
+
+    // while m > 0 {
+    //     // Skip whole bytes that are empty.
+    //     let empty_bits = m.trailing_zeros() % 64 / 8 * 8;
+    //     m >>= empty_bits;
+    //     src = src.add(empty_bits as usize);
+
+    for _ in 0..16 {
+        for i in 0..4 {
+            *out.add(written as usize) = *src;
+            written += ((m >> i) & 1) as usize;
+            src = src.add(1);
+        }
+        m >>= 4;
+    }
+}
+
+// v.len() >= 64 must hold.
+// m_popcnt > 0
+// out must be valid for at least m.count_ones() + 1 writes.
+unsafe fn scalar_filter64_unchecked1<T: Pod>(v: &[T], mut m: u64, m_popcnt: u32, out: *mut T) {
+    // Rust generated significantly better code if we write the below loop
+    // with v as a pointer, and out.add(written) instead of incrementing out
+    // directly.
+    let mut src = v.as_ptr();
+    
+    // let hi_start_offset = m_lo.count_ones() as usize;
+    // let first_in_hi = m_hi.trailing_zeros() as usize;
+
+    let mut lo_m = m;
+    let mut hi_m = m;
+    let mut lo_offset = 0;
+    let mut hi_offset = m_popcnt as usize - 1;
+    let mut lo_src = src;
+    let mut hi_src = src.add(64);
+    for i in 0..4 {
+        for j in 0..8 {
+            hi_src = hi_src.sub(1);
+            *out.add(lo_offset as usize) = *lo_src;
+            *out.add(hi_offset as usize) = *hi_src;
+            lo_offset += ((lo_m >> j) & 1) as usize;
+            hi_offset += ((hi_m >> (63 - j)) & 1) as usize;
+            lo_src = src.add(1);
+        }
+        
+        lo_m >>= 8;
+        hi_m <<= 8;
+    }
+}
+
+
+fn make_lut() {
+    for mut m in 0..u8::MAX {
+        let popcnt = m.count_ones();
+        let mut out = (popcnt as u64) << 56;
+        let mut offset = 0;
+        while m > 0 {
+            let idx = 1 + m.trailing_zeros() as u64;
+            out |= idx << offset;
+            offset += 8;
+            m &= m.wrapping_sub(1);
+        }
+        print!("{out:016x}, ");
+    }
+}
+
+#[rustfmt::skip]
+static LUT: &'static [u64; 256] = &[
+    0x0000000000000000, 0x0100000000000001, 0x0100000000000002, 0x0200000000000201,
+    0x0100000000000003, 0x0200000000000301, 0x0200000000000302, 0x0300000000030201,
+    0x0100000000000004, 0x0200000000000401, 0x0200000000000402, 0x0300000000040201,
+    0x0200000000000403, 0x0300000000040301, 0x0300000000040302, 0x0400000004030201,
+    0x0100000000000005, 0x0200000000000501, 0x0200000000000502, 0x0300000000050201,
+    0x0200000000000503, 0x0300000000050301, 0x0300000000050302, 0x0400000005030201,
+    0x0200000000000504, 0x0300000000050401, 0x0300000000050402, 0x0400000005040201,
+    0x0300000000050403, 0x0400000005040301, 0x0400000005040302, 0x0500000504030201,
+    0x0100000000000006, 0x0200000000000601, 0x0200000000000602, 0x0300000000060201,
+    0x0200000000000603, 0x0300000000060301, 0x0300000000060302, 0x0400000006030201,
+    0x0200000000000604, 0x0300000000060401, 0x0300000000060402, 0x0400000006040201,
+    0x0300000000060403, 0x0400000006040301, 0x0400000006040302, 0x0500000604030201,
+    0x0200000000000605, 0x0300000000060501, 0x0300000000060502, 0x0400000006050201,
+    0x0300000000060503, 0x0400000006050301, 0x0400000006050302, 0x0500000605030201,
+    0x0300000000060504, 0x0400000006050401, 0x0400000006050402, 0x0500000605040201,
+    0x0400000006050403, 0x0500000605040301, 0x0500000605040302, 0x0600060504030201,
+    0x0100000000000007, 0x0200000000000701, 0x0200000000000702, 0x0300000000070201,
+    0x0200000000000703, 0x0300000000070301, 0x0300000000070302, 0x0400000007030201,
+    0x0200000000000704, 0x0300000000070401, 0x0300000000070402, 0x0400000007040201,
+    0x0300000000070403, 0x0400000007040301, 0x0400000007040302, 0x0500000704030201,
+    0x0200000000000705, 0x0300000000070501, 0x0300000000070502, 0x0400000007050201,
+    0x0300000000070503, 0x0400000007050301, 0x0400000007050302, 0x0500000705030201,
+    0x0300000000070504, 0x0400000007050401, 0x0400000007050402, 0x0500000705040201,
+    0x0400000007050403, 0x0500000705040301, 0x0500000705040302, 0x0600070504030201,
+    0x0200000000000706, 0x0300000000070601, 0x0300000000070602, 0x0400000007060201,
+    0x0300000000070603, 0x0400000007060301, 0x0400000007060302, 0x0500000706030201,
+    0x0300000000070604, 0x0400000007060401, 0x0400000007060402, 0x0500000706040201,
+    0x0400000007060403, 0x0500000706040301, 0x0500000706040302, 0x0600070604030201,
+    0x0300000000070605, 0x0400000007060501, 0x0400000007060502, 0x0500000706050201,
+    0x0400000007060503, 0x0500000706050301, 0x0500000706050302, 0x0600070605030201,
+    0x0400000007060504, 0x0500000706050401, 0x0500000706050402, 0x0600070605040201,
+    0x0500000706050403, 0x0600070605040301, 0x0600070605040302, 0x0707060504030201,
+    0x0100000000000008, 0x0200000000000801, 0x0200000000000802, 0x0300000000080201,
+    0x0200000000000803, 0x0300000000080301, 0x0300000000080302, 0x0400000008030201,
+    0x0200000000000804, 0x0300000000080401, 0x0300000000080402, 0x0400000008040201,
+    0x0300000000080403, 0x0400000008040301, 0x0400000008040302, 0x0500000804030201,
+    0x0200000000000805, 0x0300000000080501, 0x0300000000080502, 0x0400000008050201,
+    0x0300000000080503, 0x0400000008050301, 0x0400000008050302, 0x0500000805030201,
+    0x0300000000080504, 0x0400000008050401, 0x0400000008050402, 0x0500000805040201,
+    0x0400000008050403, 0x0500000805040301, 0x0500000805040302, 0x0600080504030201,
+    0x0200000000000806, 0x0300000000080601, 0x0300000000080602, 0x0400000008060201,
+    0x0300000000080603, 0x0400000008060301, 0x0400000008060302, 0x0500000806030201,
+    0x0300000000080604, 0x0400000008060401, 0x0400000008060402, 0x0500000806040201,
+    0x0400000008060403, 0x0500000806040301, 0x0500000806040302, 0x0600080604030201,
+    0x0300000000080605, 0x0400000008060501, 0x0400000008060502, 0x0500000806050201,
+    0x0400000008060503, 0x0500000806050301, 0x0500000806050302, 0x0600080605030201,
+    0x0400000008060504, 0x0500000806050401, 0x0500000806050402, 0x0600080605040201,
+    0x0500000806050403, 0x0600080605040301, 0x0600080605040302, 0x0708060504030201,
+    0x0200000000000807, 0x0300000000080701, 0x0300000000080702, 0x0400000008070201,
+    0x0300000000080703, 0x0400000008070301, 0x0400000008070302, 0x0500000807030201,
+    0x0300000000080704, 0x0400000008070401, 0x0400000008070402, 0x0500000807040201,
+    0x0400000008070403, 0x0500000807040301, 0x0500000807040302, 0x0600080704030201,
+    0x0300000000080705, 0x0400000008070501, 0x0400000008070502, 0x0500000807050201,
+    0x0400000008070503, 0x0500000807050301, 0x0500000807050302, 0x0600080705030201,
+    0x0400000008070504, 0x0500000807050401, 0x0500000807050402, 0x0600080705040201,
+    0x0500000807050403, 0x0600080705040301, 0x0600080705040302, 0x0708070504030201,
+    0x0300000000080706, 0x0400000008070601, 0x0400000008070602, 0x0500000807060201,
+    0x0400000008070603, 0x0500000807060301, 0x0500000807060302, 0x0600080706030201,
+    0x0400000008070604, 0x0500000807060401, 0x0500000807060402, 0x0600080706040201,
+    0x0500000807060403, 0x0600080706040301, 0x0600080706040302, 0x0708070604030201,
+    0x0400000008070605, 0x0500000807060501, 0x0500000807060502, 0x0600080706050201,
+    0x0500000807060503, 0x0600080706050301, 0x0600080706050302, 0x0708070605030201,
+    0x0500000807060504, 0x0600080706050401, 0x0600080706050402, 0x0708070605040201,
+    0x0600080706050403, 0x0708070605040301, 0x0708070605040302, 0x0807060504030201,
+];
+
+// v.len() >= 64 must hold.
+// out must be valid for at least m.count_ones() + 1 writes.
+unsafe fn scalar_filter64_unchecked_v2<T: Pod>(v: &[T], mut m: u64, out: *mut T) {
+    // Rust generated significantly better code if we write the below loop
+    // with v as a pointer, and out.add(written) instead of incrementing out
+    // directly.
+    let mut written = 0usize;
+    let mut src = v.as_ptr();
+    
+    let mut idx_buf: MaybeUninit<[u8; 70]> = MaybeUninit::uninit();
+    let idx_buf_ptr = idx_buf.as_mut_ptr() as *mut u8;
+    let mut idx_offset = 0;
+
+    for i in 0..8 {
+        let one_offsets = LUT[(m >> 8*i) as u8 as usize];
+        let popcnt = one_offsets >> 56;
+        let v_offsets = one_offsets + i * 0x0101010101010101 - 0x0101010101010101;
+        (idx_buf_ptr.add(idx_offset) as *mut u64).write_unaligned(v_offsets);
+        idx_offset += popcnt as usize;
+    }
+    (idx_buf_ptr.add(idx_offset) as *mut u64).write_unaligned(0); // Initialize tail.
+                                              
+
+    let mut i = 0;
+    while i < idx_offset {
+        let tmp: [T; 8] = std::array::from_fn(|j|*v.get_unchecked(*idx_buf_ptr.add(i + j) as usize));
+        core::ptr::copy_nonoverlapping(tmp.as_ptr(), out.add(i), 8);
+        i += 8;
+    }
+}
+
+
+pub fn filter_primitive_scalar<T: NativeType>(
+    array: &PrimitiveArray<T>,
+    mask: &Bitmap,
+) -> PrimitiveArray<T> {
+    assert_eq!(array.len(), mask.len());
+
+    let mask_bits_set = mask.set_bits();
+    let mut out = Vec::with_capacity(mask_bits_set + 16);
+    let mut out_ptr = out.as_mut_ptr();
+    
+    let values = &array.values()[..];
+    let (mut mask_bytes, offset, len) = mask.as_slice();
+    if len == 0 {
+        return PrimitiveArray::new_empty(array.data_type().clone());
+    }
+
+    // Handle offset.
+    let mut value_idx = 0;
+    if offset > 0 {
+        let first_byte = mask_bytes[0];
+        mask_bytes = &mask_bytes[1..];
+
+        for byte_idx in offset..8 {
+            let mask_bit = first_byte & (1 << byte_idx) != 0;
+            if mask_bit && value_idx < len {
+                unsafe {
+                    *out_ptr = *values.get_unchecked(value_idx);
+                    out_ptr = out_ptr.add(1);
+                }
+            }
+            value_idx += 1;
+        }
+    }
+    
+    // Handle bulk.
+    while value_idx + 64 <= len {
+        let (mask_chunk, value_chunk);
+        unsafe {
+            mask_chunk = mask_bytes.get_unchecked(0..8);
+            mask_bytes = mask_bytes.get_unchecked(8..);
+            value_chunk = values.get_unchecked(value_idx..value_idx + 64);
+            value_idx += 64;
+        };
+        let m = u64::from_le_bytes(mask_chunk.try_into().unwrap());
+
+        if m == 0 {
+            continue;
+        }
+
+        unsafe {
+            if m == u64::MAX {
+                core::ptr::copy_nonoverlapping(value_chunk.as_ptr(), out_ptr, 64);
+                out_ptr = out_ptr.add(64);
+                continue;
+            }
+
+            let m_popcnt = m.count_ones();
+            if m_popcnt <= 16 {
+                scalar_sparse_unchecked(value_chunk, m, m_popcnt, out_ptr)
+            } else {
+                scalar_filter64_unchecked(value_chunk, m, out_ptr)
+            };
+            out_ptr = out_ptr.add(m_popcnt as usize);
+        }
+    }
+    
+    if value_idx < len {
+        let rest_len = len - value_idx;
+        assert!(rest_len < 64);
+        let m = load_padded_le_u64(mask_bytes) & ((1 << rest_len) - 1);
+        unsafe {
+            let value_chunk = values.get_unchecked(value_idx..);
+            scalar_sparse_unchecked(value_chunk, m, m.count_ones(), out_ptr);
+        }
+    }
+    
+    unsafe {
+        out.set_len(mask_bits_set);
+    }
+
+    
+    let mut arr = PrimitiveArray::from_vec(out);
+    if let Some(validity) = array.validity() {
+        let filt_validity = super::boolean::filter_boolean_kernel(validity, mask);
+        arr.set_validity(Some(filt_validity));
+    }
+    arr
+}

--- a/crates/polars-compute/src/filter/scalar.rs
+++ b/crates/polars-compute/src/filter/scalar.rs
@@ -1,19 +1,16 @@
-use std::mem::MaybeUninit;
-
-use arrow::array::PrimitiveArray;
 use arrow::bitmap::Bitmap;
-use arrow::types::NativeType;
 use bytemuck::Pod;
 use polars_utils::slice::load_padded_le_u64;
 
 
-// If the ith bit of m is set (m & (1 << i)), then v[i] must be in-bounds.
-// out must be valid for at least m.count_ones() + 4 writes.
-// m_popcnt must be m.count_ones()
-unsafe fn scalar_sparse_unchecked<T: Pod>(v: &[T], mut m: u64, mut m_popcnt: u32, out: *mut T) {
+/// # Safety
+/// If the ith bit of m is set (m & (1 << i)), then v[i] must be in-bounds.
+/// out must be valid for at least m.count_ones() + 1 writes.
+unsafe fn scalar_sparse_filter_unchecked<T: Pod>(v: &[T], mut m: u64, out: *mut T) {
     let mut written = 0;
     
     while m > 0 {
+        // Unroll loop manually twice.
         let idx = m.trailing_zeros() as usize;
         *out.add(written as usize) = *v.get_unchecked(idx);
         m &= m.wrapping_sub(1); // Clear least significant bit.
@@ -27,21 +24,17 @@ unsafe fn scalar_sparse_unchecked<T: Pod>(v: &[T], mut m: u64, mut m_popcnt: u32
     }
 }
 
-// v.len() >= 64 must hold.
-// out must be valid for at least m.count_ones() + 1 writes.
-unsafe fn scalar_filter64_unchecked<T: Pod>(v: &[T], mut m: u64, out: *mut T) {
+/// # Safety
+/// v.len() >= 64 must hold.
+/// out must be valid for at least m.count_ones() + 1 writes.
+unsafe fn scalar_dense_filter_unchecked<T: Pod>(v: &[T], mut m: u64, out: *mut T) {
     // Rust generated significantly better code if we write the below loop
     // with v as a pointer, and out.add(written) instead of incrementing out
     // directly.
     let mut written = 0usize;
     let mut src = v.as_ptr();
 
-    // while m > 0 {
-    //     // Skip whole bytes that are empty.
-    //     let empty_bits = m.trailing_zeros() % 64 / 8 * 8;
-    //     m >>= empty_bits;
-    //     src = src.add(empty_bits as usize);
-
+    // We hope the outer loop doesn't get unrolled, but the inner loop does.
     for _ in 0..16 {
         for i in 0..4 {
             *out.add(written as usize) = *src;
@@ -52,170 +45,14 @@ unsafe fn scalar_filter64_unchecked<T: Pod>(v: &[T], mut m: u64, out: *mut T) {
     }
 }
 
-// v.len() >= 64 must hold.
-// m_popcnt > 0
-// out must be valid for at least m.count_ones() + 1 writes.
-unsafe fn scalar_filter64_unchecked1<T: Pod>(v: &[T], mut m: u64, m_popcnt: u32, out: *mut T) {
-    // Rust generated significantly better code if we write the below loop
-    // with v as a pointer, and out.add(written) instead of incrementing out
-    // directly.
-    let mut src = v.as_ptr();
-    
-    // let hi_start_offset = m_lo.count_ones() as usize;
-    // let first_in_hi = m_hi.trailing_zeros() as usize;
-
-    let mut lo_m = m;
-    let mut hi_m = m;
-    let mut lo_offset = 0;
-    let mut hi_offset = m_popcnt as usize - 1;
-    let mut lo_src = src;
-    let mut hi_src = src.add(64);
-    for i in 0..4 {
-        for j in 0..8 {
-            hi_src = hi_src.sub(1);
-            *out.add(lo_offset as usize) = *lo_src;
-            *out.add(hi_offset as usize) = *hi_src;
-            lo_offset += ((lo_m >> j) & 1) as usize;
-            hi_offset += ((hi_m >> (63 - j)) & 1) as usize;
-            lo_src = src.add(1);
-        }
-        
-        lo_m >>= 8;
-        hi_m <<= 8;
-    }
-}
-
-
-fn make_lut() {
-    for mut m in 0..u8::MAX {
-        let popcnt = m.count_ones();
-        let mut out = (popcnt as u64) << 56;
-        let mut offset = 0;
-        while m > 0 {
-            let idx = 1 + m.trailing_zeros() as u64;
-            out |= idx << offset;
-            offset += 8;
-            m &= m.wrapping_sub(1);
-        }
-        print!("{out:016x}, ");
-    }
-}
-
-#[rustfmt::skip]
-static LUT: &'static [u64; 256] = &[
-    0x0000000000000000, 0x0100000000000001, 0x0100000000000002, 0x0200000000000201,
-    0x0100000000000003, 0x0200000000000301, 0x0200000000000302, 0x0300000000030201,
-    0x0100000000000004, 0x0200000000000401, 0x0200000000000402, 0x0300000000040201,
-    0x0200000000000403, 0x0300000000040301, 0x0300000000040302, 0x0400000004030201,
-    0x0100000000000005, 0x0200000000000501, 0x0200000000000502, 0x0300000000050201,
-    0x0200000000000503, 0x0300000000050301, 0x0300000000050302, 0x0400000005030201,
-    0x0200000000000504, 0x0300000000050401, 0x0300000000050402, 0x0400000005040201,
-    0x0300000000050403, 0x0400000005040301, 0x0400000005040302, 0x0500000504030201,
-    0x0100000000000006, 0x0200000000000601, 0x0200000000000602, 0x0300000000060201,
-    0x0200000000000603, 0x0300000000060301, 0x0300000000060302, 0x0400000006030201,
-    0x0200000000000604, 0x0300000000060401, 0x0300000000060402, 0x0400000006040201,
-    0x0300000000060403, 0x0400000006040301, 0x0400000006040302, 0x0500000604030201,
-    0x0200000000000605, 0x0300000000060501, 0x0300000000060502, 0x0400000006050201,
-    0x0300000000060503, 0x0400000006050301, 0x0400000006050302, 0x0500000605030201,
-    0x0300000000060504, 0x0400000006050401, 0x0400000006050402, 0x0500000605040201,
-    0x0400000006050403, 0x0500000605040301, 0x0500000605040302, 0x0600060504030201,
-    0x0100000000000007, 0x0200000000000701, 0x0200000000000702, 0x0300000000070201,
-    0x0200000000000703, 0x0300000000070301, 0x0300000000070302, 0x0400000007030201,
-    0x0200000000000704, 0x0300000000070401, 0x0300000000070402, 0x0400000007040201,
-    0x0300000000070403, 0x0400000007040301, 0x0400000007040302, 0x0500000704030201,
-    0x0200000000000705, 0x0300000000070501, 0x0300000000070502, 0x0400000007050201,
-    0x0300000000070503, 0x0400000007050301, 0x0400000007050302, 0x0500000705030201,
-    0x0300000000070504, 0x0400000007050401, 0x0400000007050402, 0x0500000705040201,
-    0x0400000007050403, 0x0500000705040301, 0x0500000705040302, 0x0600070504030201,
-    0x0200000000000706, 0x0300000000070601, 0x0300000000070602, 0x0400000007060201,
-    0x0300000000070603, 0x0400000007060301, 0x0400000007060302, 0x0500000706030201,
-    0x0300000000070604, 0x0400000007060401, 0x0400000007060402, 0x0500000706040201,
-    0x0400000007060403, 0x0500000706040301, 0x0500000706040302, 0x0600070604030201,
-    0x0300000000070605, 0x0400000007060501, 0x0400000007060502, 0x0500000706050201,
-    0x0400000007060503, 0x0500000706050301, 0x0500000706050302, 0x0600070605030201,
-    0x0400000007060504, 0x0500000706050401, 0x0500000706050402, 0x0600070605040201,
-    0x0500000706050403, 0x0600070605040301, 0x0600070605040302, 0x0707060504030201,
-    0x0100000000000008, 0x0200000000000801, 0x0200000000000802, 0x0300000000080201,
-    0x0200000000000803, 0x0300000000080301, 0x0300000000080302, 0x0400000008030201,
-    0x0200000000000804, 0x0300000000080401, 0x0300000000080402, 0x0400000008040201,
-    0x0300000000080403, 0x0400000008040301, 0x0400000008040302, 0x0500000804030201,
-    0x0200000000000805, 0x0300000000080501, 0x0300000000080502, 0x0400000008050201,
-    0x0300000000080503, 0x0400000008050301, 0x0400000008050302, 0x0500000805030201,
-    0x0300000000080504, 0x0400000008050401, 0x0400000008050402, 0x0500000805040201,
-    0x0400000008050403, 0x0500000805040301, 0x0500000805040302, 0x0600080504030201,
-    0x0200000000000806, 0x0300000000080601, 0x0300000000080602, 0x0400000008060201,
-    0x0300000000080603, 0x0400000008060301, 0x0400000008060302, 0x0500000806030201,
-    0x0300000000080604, 0x0400000008060401, 0x0400000008060402, 0x0500000806040201,
-    0x0400000008060403, 0x0500000806040301, 0x0500000806040302, 0x0600080604030201,
-    0x0300000000080605, 0x0400000008060501, 0x0400000008060502, 0x0500000806050201,
-    0x0400000008060503, 0x0500000806050301, 0x0500000806050302, 0x0600080605030201,
-    0x0400000008060504, 0x0500000806050401, 0x0500000806050402, 0x0600080605040201,
-    0x0500000806050403, 0x0600080605040301, 0x0600080605040302, 0x0708060504030201,
-    0x0200000000000807, 0x0300000000080701, 0x0300000000080702, 0x0400000008070201,
-    0x0300000000080703, 0x0400000008070301, 0x0400000008070302, 0x0500000807030201,
-    0x0300000000080704, 0x0400000008070401, 0x0400000008070402, 0x0500000807040201,
-    0x0400000008070403, 0x0500000807040301, 0x0500000807040302, 0x0600080704030201,
-    0x0300000000080705, 0x0400000008070501, 0x0400000008070502, 0x0500000807050201,
-    0x0400000008070503, 0x0500000807050301, 0x0500000807050302, 0x0600080705030201,
-    0x0400000008070504, 0x0500000807050401, 0x0500000807050402, 0x0600080705040201,
-    0x0500000807050403, 0x0600080705040301, 0x0600080705040302, 0x0708070504030201,
-    0x0300000000080706, 0x0400000008070601, 0x0400000008070602, 0x0500000807060201,
-    0x0400000008070603, 0x0500000807060301, 0x0500000807060302, 0x0600080706030201,
-    0x0400000008070604, 0x0500000807060401, 0x0500000807060402, 0x0600080706040201,
-    0x0500000807060403, 0x0600080706040301, 0x0600080706040302, 0x0708070604030201,
-    0x0400000008070605, 0x0500000807060501, 0x0500000807060502, 0x0600080706050201,
-    0x0500000807060503, 0x0600080706050301, 0x0600080706050302, 0x0708070605030201,
-    0x0500000807060504, 0x0600080706050401, 0x0600080706050402, 0x0708070605040201,
-    0x0600080706050403, 0x0708070605040301, 0x0708070605040302, 0x0807060504030201,
-];
-
-// v.len() >= 64 must hold.
-// out must be valid for at least m.count_ones() + 1 writes.
-unsafe fn scalar_filter64_unchecked_v2<T: Pod>(v: &[T], mut m: u64, out: *mut T) {
-    // Rust generated significantly better code if we write the below loop
-    // with v as a pointer, and out.add(written) instead of incrementing out
-    // directly.
-    let mut written = 0usize;
-    let mut src = v.as_ptr();
-    
-    let mut idx_buf: MaybeUninit<[u8; 70]> = MaybeUninit::uninit();
-    let idx_buf_ptr = idx_buf.as_mut_ptr() as *mut u8;
-    let mut idx_offset = 0;
-
-    for i in 0..8 {
-        let one_offsets = LUT[(m >> 8*i) as u8 as usize];
-        let popcnt = one_offsets >> 56;
-        let v_offsets = one_offsets + i * 0x0101010101010101 - 0x0101010101010101;
-        (idx_buf_ptr.add(idx_offset) as *mut u64).write_unaligned(v_offsets);
-        idx_offset += popcnt as usize;
-    }
-    (idx_buf_ptr.add(idx_offset) as *mut u64).write_unaligned(0); // Initialize tail.
-                                              
-
-    let mut i = 0;
-    while i < idx_offset {
-        let tmp: [T; 8] = std::array::from_fn(|j|*v.get_unchecked(*idx_buf_ptr.add(i + j) as usize));
-        core::ptr::copy_nonoverlapping(tmp.as_ptr(), out.add(i), 8);
-        i += 8;
-    }
-}
-
-
-pub fn filter_primitive_scalar<T: NativeType>(
-    array: &PrimitiveArray<T>,
+/// # Safety
+/// out must be valid for at least mask.count_ones() + 1 writes.
+pub unsafe fn filter_scalar_values<T: Pod>(
+    values: &[T],
     mask: &Bitmap,
-) -> PrimitiveArray<T> {
-    assert_eq!(array.len(), mask.len());
-
-    let mask_bits_set = mask.set_bits();
-    let mut out = Vec::with_capacity(mask_bits_set + 16);
-    let mut out_ptr = out.as_mut_ptr();
-    
-    let values = &array.values()[..];
+    mut out: *mut T,
+) {
     let (mut mask_bytes, offset, len) = mask.as_slice();
-    if len == 0 {
-        return PrimitiveArray::new_empty(array.data_type().clone());
-    }
 
     // Handle offset.
     let mut value_idx = 0;
@@ -227,8 +64,8 @@ pub fn filter_primitive_scalar<T: NativeType>(
             let mask_bit = first_byte & (1 << byte_idx) != 0;
             if mask_bit && value_idx < len {
                 unsafe {
-                    *out_ptr = *values.get_unchecked(value_idx);
-                    out_ptr = out_ptr.add(1);
+                    *out = *values.get_unchecked(value_idx);
+                    out = out.add(1);
                 }
             }
             value_idx += 1;
@@ -252,18 +89,18 @@ pub fn filter_primitive_scalar<T: NativeType>(
 
         unsafe {
             if m == u64::MAX {
-                core::ptr::copy_nonoverlapping(value_chunk.as_ptr(), out_ptr, 64);
-                out_ptr = out_ptr.add(64);
+                core::ptr::copy_nonoverlapping(value_chunk.as_ptr(), out, 64);
+                out = out.add(64);
                 continue;
             }
 
             let m_popcnt = m.count_ones();
             if m_popcnt <= 16 {
-                scalar_sparse_unchecked(value_chunk, m, m_popcnt, out_ptr)
+                scalar_sparse_filter_unchecked(value_chunk, m, out)
             } else {
-                scalar_filter64_unchecked(value_chunk, m, out_ptr)
+                scalar_dense_filter_unchecked(value_chunk, m, out)
             };
-            out_ptr = out_ptr.add(m_popcnt as usize);
+            out = out.add(m_popcnt as usize);
         }
     }
     
@@ -273,19 +110,7 @@ pub fn filter_primitive_scalar<T: NativeType>(
         let m = load_padded_le_u64(mask_bytes) & ((1 << rest_len) - 1);
         unsafe {
             let value_chunk = values.get_unchecked(value_idx..);
-            scalar_sparse_unchecked(value_chunk, m, m.count_ones(), out_ptr);
+            scalar_sparse_filter_unchecked(value_chunk, m, out);
         }
     }
-    
-    unsafe {
-        out.set_len(mask_bits_set);
-    }
-
-    
-    let mut arr = PrimitiveArray::from_vec(out);
-    if let Some(validity) = array.validity() {
-        let filt_validity = super::boolean::filter_boolean_kernel(validity, mask);
-        arr.set_validity(Some(filt_validity));
-    }
-    arr
 }

--- a/crates/polars-compute/src/filter/scalar.rs
+++ b/crates/polars-compute/src/filter/scalar.rs
@@ -2,23 +2,22 @@ use arrow::bitmap::Bitmap;
 use bytemuck::Pod;
 use polars_utils::slice::load_padded_le_u64;
 
-
 /// # Safety
 /// If the ith bit of m is set (m & (1 << i)), then v[i] must be in-bounds.
 /// out must be valid for at least m.count_ones() + 1 writes.
 unsafe fn scalar_sparse_filter_unchecked<T: Pod>(v: &[T], mut m: u64, out: *mut T) {
-    let mut written = 0;
-    
+    let mut written = 0usize;
+
     while m > 0 {
         // Unroll loop manually twice.
         let idx = m.trailing_zeros() as usize;
-        *out.add(written as usize) = *v.get_unchecked(idx);
+        *out.add(written) = *v.get_unchecked(idx);
         m &= m.wrapping_sub(1); // Clear least significant bit.
         written += 1;
 
         // tz % 64 otherwise we could go out of bounds
         let idx = (m.trailing_zeros() % 64) as usize;
-        *out.add(written as usize) = *v.get_unchecked(idx);
+        *out.add(written) = *v.get_unchecked(idx);
         m &= m.wrapping_sub(1); // Clear least significant bit.
         written += 1;
     }
@@ -37,7 +36,7 @@ unsafe fn scalar_dense_filter_unchecked<T: Pod>(v: &[T], mut m: u64, out: *mut T
     // We hope the outer loop doesn't get unrolled, but the inner loop does.
     for _ in 0..16 {
         for i in 0..4 {
-            *out.add(written as usize) = *src;
+            *out.add(written) = *src;
             written += ((m >> i) & 1) as usize;
             src = src.add(1);
         }
@@ -47,11 +46,8 @@ unsafe fn scalar_dense_filter_unchecked<T: Pod>(v: &[T], mut m: u64, out: *mut T
 
 /// # Safety
 /// out must be valid for at least mask.count_ones() + 1 writes.
-pub unsafe fn filter_scalar_values<T: Pod>(
-    values: &[T],
-    mask: &Bitmap,
-    mut out: *mut T,
-) {
+pub unsafe fn filter_scalar_values<T: Pod>(values: &[T], mask: &Bitmap, mut out: *mut T) {
+    assert_eq!(values.len(), mask.len());
     let (mut mask_bytes, offset, len) = mask.as_slice();
 
     // Handle offset.
@@ -64,6 +60,8 @@ pub unsafe fn filter_scalar_values<T: Pod>(
             let mask_bit = first_byte & (1 << byte_idx) != 0;
             if mask_bit && value_idx < len {
                 unsafe {
+                    // SAFETY: we only write to out for one bits, and checked
+                    // that value_idx < len.
                     *out = *values.get_unchecked(value_idx);
                     out = out.add(1);
                 }
@@ -71,11 +69,13 @@ pub unsafe fn filter_scalar_values<T: Pod>(
             value_idx += 1;
         }
     }
-    
+
     // Handle bulk.
     while value_idx + 64 <= len {
         let (mask_chunk, value_chunk);
         unsafe {
+            // SAFETY: we checked that value_idx + 64 <= len, so these are
+            // all in-bounds.
             mask_chunk = mask_bytes.get_unchecked(0..8);
             mask_bytes = mask_bytes.get_unchecked(8..);
             value_chunk = values.get_unchecked(value_idx..value_idx + 64);
@@ -83,11 +83,16 @@ pub unsafe fn filter_scalar_values<T: Pod>(
         };
         let m = u64::from_le_bytes(mask_chunk.try_into().unwrap());
 
+        // Fast-path: empty mask.
         if m == 0 {
             continue;
         }
 
         unsafe {
+            // SAFETY: we will only write at most m_popcnt + 1 to out, which
+            // is allowed.
+            
+            // Fast-path: completely full mask.
             if m == u64::MAX {
                 core::ptr::copy_nonoverlapping(value_chunk.as_ptr(), out, 64);
                 out = out.add(64);
@@ -103,7 +108,7 @@ pub unsafe fn filter_scalar_values<T: Pod>(
             out = out.add(m_popcnt as usize);
         }
     }
-    
+
     if value_idx < len {
         let rest_len = len - value_idx;
         assert!(rest_len < 64);

--- a/crates/polars-compute/src/filter/scalar.rs
+++ b/crates/polars-compute/src/filter/scalar.rs
@@ -91,7 +91,7 @@ pub unsafe fn filter_scalar_values<T: Pod>(values: &[T], mask: &Bitmap, mut out:
         unsafe {
             // SAFETY: we will only write at most m_popcnt + 1 to out, which
             // is allowed.
-            
+
             // Fast-path: completely full mask.
             if m == u64::MAX {
                 core::ptr::copy_nonoverlapping(value_chunk.as_ptr(), out, 64);


### PR DESCRIPTION
This PR uses the new boolean filters to handle nulls in all our filters, and has a reworked scalar path filter. It also lays the groundwork for easily slotting in specific SIMD paths instead of the scalar later.

Modest speedups all-around, with only very specific combinations being slightly slower. Below are some sample benchmarks for n = 10^8 on Apple M1.

Without any nulls in the payload:

```
selectivity       main         branch  speedup
u8
0.00001     0.03067962     0.00971654     3.2x
0.00010     0.03578900     0.01379362     2.6x
0.00100     0.05605988     0.02842633     2.0x
0.01000     0.10832329     0.05732238     1.9x
0.10000     0.18866021     0.14063879     1.3x
0.50000     0.38846837     0.25560483     1.5x
0.90000     0.62037029     0.28825442     2.2x
0.99000     0.41020429     0.22628954     1.8x
0.99900     0.15035492     0.12312429     1.2x
0.99990     0.12071196     0.11451621     1.1x
0.99999     0.11959000     0.11468092     1.0x
f64
0.00001     0.02904350     0.01133346     2.6x
0.00010     0.03190525     0.01483838     2.2x
0.00100     0.05377196     0.04013158     1.3x
0.01000     0.16904179     0.12135558     1.4x
0.10000     0.27002258     0.23378392     1.2x
0.50000     0.69589496     0.56552742     1.2x
0.90000     1.09929317     0.81537075     1.3x
0.99000     1.05055963     0.86166412     1.2x
0.99900     0.90991829     0.86368392     1.1x
0.99990     0.84915117     0.90556942     0.9x
0.99999     0.89902233     0.86255267     1.0x
str
0.00001     0.03019371     0.01210613     2.5x
0.00010     0.03551521     0.01880279     1.9x
0.00100     0.08062025     0.06540263     1.2x
0.01000     0.18216504     0.13414883     1.4x
0.10000     0.42839887     0.43168421     1.0x
0.50000     1.03755975     0.99724696     1.0x
0.90000     1.75257592     1.56434954     1.1x
0.99000     1.81074688     1.70101721     1.1x
0.99900     1.75836221     1.71458492     1.0x
0.99990     1.78606162     1.79906375     1.0x
0.99999     1.75107996     1.70657762     1.0x
```

With 10% of the payload being nulls:

```
selectivity       main         branch  speedup
u8
0.00001     0.04466854     0.01629858     2.7x
0.00010     0.05015971     0.02353896     2.1x
0.00100     0.08562458     0.04379925     2.0x
0.01000     0.14814654     0.15693012     0.9x
0.10000     0.31246542     0.30595038     1.0x
0.50000     1.15083700     0.35854967     3.2x
0.90000     2.06214100     0.39735929     5.2x
0.99000     1.23677525     0.35589008     3.5x
0.99900     0.38117267     0.19885325     1.9x
0.99990     0.26254242     0.17230442     1.5x
0.99999     0.25265775     0.17859104     1.4x
f64
0.00001     0.04572262     0.01910842     2.4x
0.00010     0.05307171     0.02670975     2.0x
0.00100     0.09755967     0.06618713     1.5x
0.01000     0.29210800     0.23889150     1.2x
0.10000     0.41639846     0.42964929     1.0x
0.50000     1.50237033     0.69708017     2.2x
0.90000     2.65734029     0.99554375     2.7x
0.99000     1.92291908     1.07280654     1.8x
0.99900     1.12154263     1.01173225     1.1x
0.99990     0.99597621     0.99489346     1.0x
0.99999     0.98589592     0.98362196     1.0x
str
0.00001     0.04470687     0.01981188     2.3x
0.00010     0.05394471     0.02838900     1.9x
0.00100     0.17123421     0.07548829     2.3x
0.01000     0.31859496     0.25365346     1.3x
0.10000     0.61130029     0.67295100     0.9x
0.50000     1.84593263     1.20410746     1.5x
0.90000     3.31969500     1.80379200     1.8x
0.99000     2.75647108     1.98157950     1.4x
0.99900     2.03973321     1.95453050     1.0x
0.99990     1.97040792     1.94661246     1.0x
0.99999     1.92459388     1.92393138     1.0x
```


Benchmark code:
```python
import polars as pl
import numpy as np
from timeit import timeit

n = 10**8
selectivities = [0, 0.00001, 0.0001, 0.001, 0.01, 0.1, 0.5, 0.9, 0.99, 0.999, 0.9999, 0.99999, 1]

rng = np.random.Generator(np.random.PCG64(42))
base_payload = pl.Series(rng.uniform(size = n))

types = [
    ("u8", (base_payload * (256 - 1e-6)).cast(pl.UInt8)),
    ("f64", base_payload),
    ("str", base_payload.cast(pl.String)),
]

for typ, payload in types:
  print(f"polars timings {typ}")
  for selectivity in selectivities:
      threshold = selectivity if selectivity < 1 else 1.1  # Just to be safe.
      filt = rng.uniform(size = n) < threshold
      df = pl.DataFrame({"filt": filt, "payload": payload})
      time = timeit(lambda: df.select(pl.col.payload.filter(pl.col.filt)), number=10)
      print(f"{selectivity:.5f}  {time:11.8f}")

  print(f"polars timings {typ} with 10% nulls")
  for selectivity in selectivities:
      threshold = selectivity if selectivity < 1 else 1.1  # Just to be safe.
      filt = rng.uniform(size = n) < threshold
      is_not_null = rng.uniform(size = n) < 0.9
      df = pl.DataFrame({"filt": filt, "payload": payload, "is_not_null": is_not_null})
      df = df.select(pl.col.filt, pl.when(pl.col.is_not_null).then(pl.col.payload))
      time = timeit(lambda: df.select(pl.col.payload.filter(pl.col.filt)), number=10)
      print(f"{selectivity:.5f}  {time:11.8f}")
```