### PR TITLE
perf: Optimize chunked-id gather for binaryviews

### DIFF
--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -33,7 +33,7 @@ use crate::array::iterator::NonNullValuesIter;
 use crate::bitmap::utils::{BitmapIter, ZipValidity};
 pub type BinaryViewArray = BinaryViewArrayGeneric<[u8]>;
 pub type Utf8ViewArray = BinaryViewArrayGeneric<str>;
-pub use view::View;
+pub use view::{View, INLINE_VIEW_SIZE};
 
 pub type MutablePlString = MutableBinaryViewArray<str>;
 pub type MutablePlBinary = MutableBinaryViewArray<[u8]>;

--- a/crates/polars-arrow/src/array/binview/view.rs
+++ b/crates/polars-arrow/src/array/binview/view.rs
@@ -13,6 +13,8 @@ use crate::buffer::Buffer;
 use crate::datatypes::PrimitiveType;
 use crate::types::NativeType;
 
+pub const INLINE_VIEW_SIZE: u32 = 12;
+
 // We use this instead of u128 because we want alignment of <= 8 bytes.
 #[derive(Debug, Copy, Clone, Default)]
 #[repr(C)]
@@ -148,8 +150,8 @@ where
 {
     for view in views {
         let len = view.length;
-        if len <= 12 {
-            if len < 12 && view.as_u128() >> (32 + len * 8) != 0 {
+        if len <= INLINE_VIEW_SIZE {
+            if len < INLINE_VIEW_SIZE && view.as_u128() >> (32 + len * 8) != 0 {
                 polars_bail!(ComputeError: "view contained non-zero padding in prefix");
             }
 

--- a/crates/polars-arrow/src/array/mod.rs
+++ b/crates/polars-arrow/src/array/mod.rs
@@ -700,7 +700,7 @@ mod values;
 pub use binary::{BinaryArray, BinaryValueIter, MutableBinaryArray, MutableBinaryValuesArray};
 pub use binview::{
     BinaryViewArray, BinaryViewArrayGeneric, MutableBinaryViewArray, MutablePlBinary,
-    MutablePlString, Utf8ViewArray, View, ViewType,
+    MutablePlString, Utf8ViewArray, View, ViewType, INLINE_VIEW_SIZE,
 };
 pub use boolean::{BooleanArray, MutableBooleanArray};
 pub use dictionary::{DictionaryArray, DictionaryKey, MutableDictionaryArray};

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -321,7 +321,8 @@ unsafe fn take_opt_unchecked_object(s: &Series, by: &[NullableChunkId]) -> Serie
 
 #[allow(clippy::unnecessary_cast)]
 #[inline(always)]
-fn rewrite_view(mut view: View, chunk_idx: u32) -> View {
+fn rewrite_view(mut view: View, chunk_idx: IdxSize) -> View {
+    let chunk_idx = chunk_idx as u32;
     let offset = [0, chunk_idx][(view.length > INLINE_VIEW_SIZE) as usize];
     view.buffer_idx += offset;
     view
@@ -353,7 +354,7 @@ unsafe fn take_unchecked_binview(
                 let target = *views.get_unchecked_release(chunk_idx as usize);
                 let view = *target.get_unchecked_release(array_idx);
 
-                rewrite_view(view, chunk_idx as u32)
+                rewrite_view(view, chunk_idx)
             })
             .collect::<Vec<_>>();
 
@@ -375,7 +376,7 @@ unsafe fn take_unchecked_binview(
             } else {
                 let target = *views.get_unchecked_release(chunk_idx as usize);
                 let view = *target.get_unchecked_release(array_idx);
-                let view = rewrite_view(view, chunk_idx as u32);
+                let view = rewrite_view(view, chunk_idx);
                 mut_views.push_unchecked(view);
                 validity.push_unchecked(true)
             }
@@ -426,7 +427,7 @@ unsafe fn take_unchecked_binview_opt(ca: &BinaryChunked, by: &[NullableChunkId])
 
                 let target = *views.get_unchecked_release(chunk_idx as usize);
                 let view = *target.get_unchecked_release(array_idx);
-                let view = rewrite_view(view, chunk_idx as u32);
+                let view = rewrite_view(view, chunk_idx);
 
                 mut_views.push_unchecked(view);
                 validity.push_unchecked(true)
@@ -449,7 +450,7 @@ unsafe fn take_unchecked_binview_opt(ca: &BinaryChunked, by: &[NullableChunkId])
                 } else {
                     let target = *views.get_unchecked_release(chunk_idx as usize);
                     let view = *target.get_unchecked_release(array_idx);
-                    let view = rewrite_view(view, chunk_idx as u32);
+                    let view = rewrite_view(view, chunk_idx);
                     mut_views.push_unchecked(view);
                     validity.push_unchecked(true);
                 }

--- a/crates/polars-ops/src/chunked_array/gather/chunked.rs
+++ b/crates/polars-ops/src/chunked_array/gather/chunked.rs
@@ -319,6 +319,7 @@ unsafe fn take_opt_unchecked_object(s: &Series, by: &[NullableChunkId]) -> Serie
     builder.to_series()
 }
 
+#[allow(clippy::unnecessary_cast)]
 unsafe fn take_unchecked_binview(
     ca: &BinaryChunked,
     by: &[ChunkId],
@@ -344,7 +345,10 @@ unsafe fn take_unchecked_binview(
                 let target = *views.get_unchecked_release(chunk_idx as usize);
                 let mut view = *target.get_unchecked_release(array_idx);
 
-                view.buffer_idx += chunk_idx as u32;
+                #[allow(clippy::unnecessary_cast)]
+                {
+                    view.buffer_idx += chunk_idx as u32;
+                }
 
                 view
             })
@@ -368,7 +372,10 @@ unsafe fn take_unchecked_binview(
             } else {
                 let target = *views.get_unchecked_release(chunk_idx as usize);
                 let mut view = *target.get_unchecked_release(array_idx);
-                view.buffer_idx += chunk_idx as u32;
+                #[allow(clippy::unnecessary_cast)]
+                {
+                    view.buffer_idx += chunk_idx as u32;
+                }
                 mut_views.push_unchecked(view);
                 validity.push_unchecked(true)
             }
@@ -420,7 +427,10 @@ unsafe fn take_unchecked_binview_opt(ca: &BinaryChunked, by: &[NullableChunkId])
                 let target = *views.get_unchecked_release(chunk_idx as usize);
                 let mut view = *target.get_unchecked_release(array_idx);
 
-                view.buffer_idx += chunk_idx as u32;
+                #[allow(clippy::unnecessary_cast)]
+                {
+                    view.buffer_idx += chunk_idx as u32;
+                }
 
                 mut_views.push_unchecked(view);
                 validity.push_unchecked(true)
@@ -443,7 +453,10 @@ unsafe fn take_unchecked_binview_opt(ca: &BinaryChunked, by: &[NullableChunkId])
                 } else {
                     let target = *views.get_unchecked_release(chunk_idx as usize);
                     let mut view = *target.get_unchecked_release(array_idx);
-                    view.buffer_idx += chunk_idx as u32;
+                    #[allow(clippy::unnecessary_cast)]
+                    {
+                        view.buffer_idx += chunk_idx as u32;
+                    }
                     mut_views.push_unchecked(view);
                     validity.push_unchecked(true);
                 }


### PR DESCRIPTION
This still copy the string/binary data instead of the views. Ensure we now only copy the views and keep the buffers as is (unless we need to gc).