### PR TITLE
docs: Update contributing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing to Polars
+
+Thanks for taking the time to contribute! We appreciate all contributions, from reporting bugs to implementing new features.
+
+Please refer to the [contributing section](https://docs.pola.rs/development/contributing/) of our documentation to get started.
+
+We look forward to your contributions!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,0 @@
-# Contributing to Polars
-
-Thanks for taking the time to contribute! We appreciate all contributions, from reporting bugs to implementing new features.
-
-Please refer to the [contributing section](https://docs.pola.rs/development/contributing/) of our documentation to get started.
-
-We look forward to your contributions!

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ Requires Rust version `>=1.71`.
 
 ## Contributing
 
-Want to contribute? Read our [contribution guideline](/CONTRIBUTING.md).
+Want to contribute? Read our [contributing guide](https://docs.pola.rs/development/contributing/).
 
 ## Python: compile Polars from source
 

--- a/docs/_build/snippets/under_construction.md
+++ b/docs/_build/snippets/under_construction.md
@@ -1,4 +1,4 @@
 !!! warning ":construction: Under Construction :construction:"
 
     This section is still under development. Want to help out? Consider contributing and making a [pull request](https://github.com/pola-rs/polars) to our repository.
-    Please read our [Contribution Guidelines](https://github.com/pola-rs/polars/blob/main/CONTRIBUTING.md) on how to proceed.
+    Please read our [contributing guide](https://docs.pola.rs/development/contributing/) on how to proceed.

--- a/py-polars/debug/launch.py
+++ b/py-polars/debug/launch.py
@@ -47,8 +47,9 @@ def launch_debugging() -> None:
     if not found:
         msg = (
             "Cannot locate pid definition in launch.json for Rust LLDB configuration. "
-            "Please follow the instructions in CONTRIBUTING.md for creating the "
-            "launch configuration."
+            "Please follow the instructions in the debugging section of the "
+            "contributing guide (https://docs.pola.rs/development/contributing/ide/#debugging) "
+            "for creating the launch configuration."
         )
         raise RuntimeError(msg)
 


### PR DESCRIPTION
Resolves #14855.

Made a couple minor edits to other references:

* Use `contributing guide` consistently across the documentation.
* Removed `CONTRIBUTING.md` as it is no longer referenced.
* Provided direct link to appropriate section in the `launch.py` exception message.