### PR TITLE
fix: Fix `DataFrame.min`/`max` for decimals

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -258,6 +258,7 @@ impl DataType {
 
         let phys = self.to_physical();
         (phys.is_numeric()
+            || self.is_decimal()
             || matches!(
                 phys,
                 DataType::Binary | DataType::String | DataType::Boolean

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -322,6 +322,14 @@ def test_decimal_df_vertical_sum() -> None:
     assert_frame_equal(df.sum(), expected)
 
 
+def test_decimal_df_vertical_agg() -> None:
+    df = pl.DataFrame({"a": [D("1.0"), D("2.0"), D("3.0")]})
+    expected_min = pl.DataFrame({"a": [D("1.0")]})
+    expected_max = pl.DataFrame({"a": [D("3.0")]})
+    assert_frame_equal(df.min(), expected_min)
+    assert_frame_equal(df.max(), expected_max)
+
+
 def test_decimal_in_filter() -> None:
     df = pl.DataFrame(
         {


### PR DESCRIPTION
Now that decimals can be sorted (#14649), `is_ord` can be true for `DataType::Decimal`. This will in turn fix the following:

```python
import polars as pl
from decimal import Decimal as D

pl.DataFrame({"a": [D("1.0"), D("2.0")]}).max()
```

output:
```
shape: (1, 1)
┌──────────────┐
│ a            │
│ ---          │
│ decimal[*,1] │
╞══════════════╡
│ null         │
└──────────────┘
```

expected:
```
shape: (1, 1)
┌──────────────┐
│ a            │
│ ---          │
│ decimal[*,1] │
╞══════════════╡
│ 2            │
└──────────────┘
```
Similar to #14652 