### PR TITLE
perf: add basic AVX-512 filters

### DIFF
--- a/crates/polars-compute/src/filter/avx512.rs
+++ b/crates/polars-compute/src/filter/avx512.rs
@@ -26,7 +26,7 @@ macro_rules! simd_filter {
                 m64 >>= MASK_BITS % 64;
             }
         }
-        
+
         // Handle the SIMD-block-sized remainder.
         let subchunks = $values.chunks_exact(MASK_BITS);
         $values = subchunks.remainder();
@@ -38,7 +38,7 @@ macro_rules! simd_filter {
         }
 
         ($values, $mask_bytes, $out)
-    }}
+    }};
 }
 
 /// # Safety
@@ -46,7 +46,11 @@ macro_rules! simd_filter {
 /// AVX512_VBMI2 must be enabled.
 #[target_feature(enable = "avx512f")]
 #[target_feature(enable = "avx512vbmi2")]
-pub unsafe fn filter_u8_avx512vbmi2<'a>(mut values: &'a [u8], mut mask_bytes: &'a [u8], mut out: *mut u8) -> (&'a [u8], &'a [u8], *mut u8) {
+pub unsafe fn filter_u8_avx512vbmi2<'a>(
+    mut values: &'a [u8],
+    mut mask_bytes: &'a [u8],
+    mut out: *mut u8,
+) -> (&'a [u8], &'a [u8], *mut u8) {
     simd_filter!(values, mask_bytes, out, |vchunk, m: u64| {
         // We don't use compress-store instructions because they are very slow
         // on Zen. We are allowed to overshoot anyway.
@@ -62,7 +66,11 @@ pub unsafe fn filter_u8_avx512vbmi2<'a>(mut values: &'a [u8], mut mask_bytes: &'
 /// AVX512_VBMI2 must be enabled.
 #[target_feature(enable = "avx512f")]
 #[target_feature(enable = "avx512vbmi2")]
-pub unsafe fn filter_u16_avx512vbmi2<'a>(mut values: &'a [u16], mut mask_bytes: &'a [u8], mut out: *mut u16) -> (&'a [u16], &'a [u8], *mut u16) {
+pub unsafe fn filter_u16_avx512vbmi2<'a>(
+    mut values: &'a [u16],
+    mut mask_bytes: &'a [u8],
+    mut out: *mut u16,
+) -> (&'a [u16], &'a [u8], *mut u16) {
     simd_filter!(values, mask_bytes, out, |vchunk, m: u32| {
         let v = _mm512_loadu_si512(vchunk.as_ptr().cast());
         let filtered = _mm512_maskz_compress_epi16(m, v);
@@ -75,7 +83,11 @@ pub unsafe fn filter_u16_avx512vbmi2<'a>(mut values: &'a [u16], mut mask_bytes: 
 /// out must be valid for 16 + bitslice(mask_bytes, 0..values.len()).count_ones() writes.
 /// AVX512F must be enabled.
 #[target_feature(enable = "avx512f")]
-pub unsafe fn filter_u32_avx512f<'a>(mut values: &'a [u32], mut mask_bytes: &'a [u8], mut out: *mut u32) -> (&'a [u32], &'a [u8], *mut u32) {
+pub unsafe fn filter_u32_avx512f<'a>(
+    mut values: &'a [u32],
+    mut mask_bytes: &'a [u8],
+    mut out: *mut u32,
+) -> (&'a [u32], &'a [u8], *mut u32) {
     simd_filter!(values, mask_bytes, out, |vchunk, m: u16| {
         let v = _mm512_loadu_si512(vchunk.as_ptr().cast());
         let filtered = _mm512_maskz_compress_epi32(m, v);
@@ -88,7 +100,11 @@ pub unsafe fn filter_u32_avx512f<'a>(mut values: &'a [u32], mut mask_bytes: &'a 
 /// out must be valid for 8 + bitslice(mask_bytes, 0..values.len()).count_ones() writes.
 /// AVX512F must be enabled.
 #[target_feature(enable = "avx512f")]
-pub unsafe fn filter_u64_avx512f<'a>(mut values: &'a [u64], mut mask_bytes: &'a [u8], mut out:*mut u64) -> (&'a [u64], &'a [u8], *mut u64) {
+pub unsafe fn filter_u64_avx512f<'a>(
+    mut values: &'a [u64],
+    mut mask_bytes: &'a [u8],
+    mut out: *mut u64,
+) -> (&'a [u64], &'a [u8], *mut u64) {
     simd_filter!(values, mask_bytes, out, |vchunk, m: u8| {
         let v = _mm512_loadu_si512(vchunk.as_ptr().cast());
         let filtered = _mm512_maskz_compress_epi64(m, v);

--- a/crates/polars-compute/src/filter/avx512.rs
+++ b/crates/polars-compute/src/filter/avx512.rs
@@ -1,0 +1,131 @@
+use core::arch::x86_64::*;
+use polars_utils::clmul::clmul64;
+
+
+// It's not possible to inline target_feature(enable = ...) functions into other
+// functions without that enabled, so we use a macro for these very-similarly
+// structured functions.
+macro_rules! simd_filter {
+    ($values: ident, $mask_bytes: ident, $out: ident, |$subchunk: ident, $m: ident: $MaskT: ty| $body:block) => {{
+        const MASK_BITS: usize = std::mem::size_of::<$MaskT>() * 8;
+
+        // Do a 64-element loop for sparse fast path.
+        let chunks = $values.chunks_exact(64);
+        $values = chunks.remainder();
+        for chunk in chunks {
+            let mask_chunk = $mask_bytes.get_unchecked(..8);
+            $mask_bytes = $mask_bytes.get_unchecked(8..);
+            let mut m64 = u64::from_le_bytes(mask_chunk.try_into().unwrap());
+
+            // Fast-path: skip entire 64-element chunk.
+            if m64 == 0 {
+                continue;
+            }
+
+            for $subchunk in chunk.chunks_exact(MASK_BITS) {
+                let $m = m64 as $MaskT;
+                $body;
+                m64 >>= MASK_BITS % 64;
+            }
+        }
+        
+        // Handle the SIMD-block-sized remainder.
+        let subchunks = $values.chunks_exact(MASK_BITS);
+        $values = subchunks.remainder();
+        for $subchunk in subchunks {
+            let mask_chunk = $mask_bytes.get_unchecked(..MASK_BITS / 8);
+            $mask_bytes = $mask_bytes.get_unchecked(MASK_BITS / 8..);
+            let $m = <$MaskT>::from_le_bytes(mask_chunk.try_into().unwrap());
+            $body;
+        }
+
+        ($values, $mask_bytes, $out)
+    }}
+}
+
+/// # Safety
+/// out must be valid for 64 + bitslice(mask_bytes, 0..values.len()).count_ones() writes.
+/// AVX512_VBMI2 must be enabled.
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512vbmi2")]
+pub unsafe fn filter_u8_avx512vbmi2<'a>(mut values: &'a [u8], mut mask_bytes: &'a [u8], mut out: *mut u8) -> (&'a [u8], &'a [u8], *mut u8) {
+    simd_filter!(values, mask_bytes, out, |vchunk, m: u64| {
+        // We don't use compress-store instructions because they are very slow
+        // on Zen. We are allowed to overshoot anyway.
+        let v = _mm512_loadu_si512(vchunk.as_ptr().cast());
+        let filtered = _mm512_maskz_compress_epi8(m, v);
+        _mm512_storeu_si512(out.cast(), filtered);
+        out = out.add(m.count_ones() as usize);
+    })
+}
+
+/// # Safety
+/// out must be valid for 32 + bitslice(mask_bytes, 0..values.len()).count_ones() writes.
+/// AVX512_VBMI2 must be enabled.
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512vbmi2")]
+pub unsafe fn filter_u16_avx512vbmi2<'a>(mut values: &'a [u16], mut mask_bytes: &'a [u8], mut out: *mut u16) -> (&'a [u16], &'a [u8], *mut u16) {
+    simd_filter!(values, mask_bytes, out, |vchunk, m: u32| {
+        let v = _mm512_loadu_si512(vchunk.as_ptr().cast());
+        let filtered = _mm512_maskz_compress_epi16(m, v);
+        _mm512_storeu_si512(out.cast(), filtered);
+        out = out.add(m.count_ones() as usize);
+    })
+}
+
+/// # Safety
+/// out must be valid for 16 + bitslice(mask_bytes, 0..values.len()).count_ones() writes.
+/// AVX512F must be enabled.
+#[target_feature(enable = "avx512f")]
+pub unsafe fn filter_u32_avx512f<'a>(mut values: &'a [u32], mut mask_bytes: &'a [u8], mut out: *mut u32) -> (&'a [u32], &'a [u8], *mut u32) {
+    simd_filter!(values, mask_bytes, out, |vchunk, m: u16| {
+        let v = _mm512_loadu_si512(vchunk.as_ptr().cast());
+        let filtered = _mm512_maskz_compress_epi32(m, v);
+        _mm512_storeu_si512(out.cast(), filtered);
+        out = out.add(m.count_ones() as usize);
+    })
+}
+
+/// # Safety
+/// out must be valid for 8 + bitslice(mask_bytes, 0..values.len()).count_ones() writes.
+/// AVX512F must be enabled.
+#[target_feature(enable = "avx512f")]
+pub unsafe fn filter_u64_avx512f<'a>(mut values: &'a [u64], mut mask_bytes: &'a [u8], mut out:*mut u64) -> (&'a [u64], &'a [u8], *mut u64) {
+    simd_filter!(values, mask_bytes, out, |vchunk, m: u8| {
+        let v = _mm512_loadu_si512(vchunk.as_ptr().cast());
+        let filtered = _mm512_maskz_compress_epi64(m, v);
+        _mm512_storeu_si512(out.cast(), filtered);
+        out = out.add(m.count_ones() as usize);
+    })
+}
+
+/// # Safety
+/// out must be valid for 4 + bitslice(mask_bytes, 0..values.len()).count_ones() writes.
+/// AVX512F must be enabled.
+#[target_feature(enable = "avx512f")]
+pub unsafe fn filter_u128_unaligned_avx512f<'a>(mut values: &'a [[u8; 16]], mut mask_bytes: &'a [u8], mut out: *mut [u8; 16]) -> (&'a [[u8; 16]], &'a [u8], *mut [u8; 16]) {
+    simd_filter!(values, mask_bytes, out, |vchunk, m: u8| {
+        // u8 is the smallest mask type, this covers two 512-bit chunks.
+        // We want to duplicate each bit so we can use the 64-bit AVX compress
+        // instruction, so abcdefgh -> aabbccdd eeffgghh.
+        // clmul(x, x) is the bits of x interleaved with zeros, multiplying by
+        // 3 afterwards is equivalent to m + (m << 1) filling the zeros with
+        // the duplicate bits as desired.
+        let dup_m = clmul64(m as u64, m as u64) * 3;
+        let lo_mask = dup_m as u8;
+        let hi_mask = (dup_m >> 8) as u8;
+        let lo_popcnt = (m & 0b1111).count_ones();
+        let hi_popcnt = m.count_ones() - lo_popcnt;
+        
+        let base_ptr = vchunk.as_ptr() as *const u8;
+        let lo_v = _mm512_loadu_si512(base_ptr.cast());
+        let lo_filtered = _mm512_maskz_compress_epi64(lo_mask, lo_v);
+        _mm512_storeu_si512(out.cast(), lo_filtered);
+        out = out.add(lo_popcnt as usize);
+
+        let hi_v = _mm512_loadu_si512(base_ptr.add(64).cast());
+        let hi_filtered = _mm512_maskz_compress_epi64(hi_mask, hi_v);
+        _mm512_storeu_si512(out.cast(), hi_filtered);
+        out = out.add(hi_popcnt as usize);
+    })
+}

--- a/crates/polars-compute/src/filter/mod.rs
+++ b/crates/polars-compute/src/filter/mod.rs
@@ -3,6 +3,9 @@ mod boolean;
 mod primitive;
 mod scalar;
 
+#[cfg(all(target_arch = "x86_64", feature = "simd"))]
+mod avx512;
+
 use arrow::array::growable::make_growable;
 use arrow::array::{new_empty_array, Array, BinaryViewArray, BooleanArray, PrimitiveArray};
 use arrow::bitmap::utils::SlicesIterator;

--- a/crates/polars-compute/src/filter/primitive.rs
+++ b/crates/polars-compute/src/filter/primitive.rs
@@ -1,7 +1,15 @@
 use arrow::bitmap::Bitmap;
 use bytemuck::{cast_slice, cast_vec, Pod};
 
+#[cfg(all(target_arch = "x86_64", feature = "simd"))]
+use super::avx512;
+
 use super::boolean::filter_boolean_kernel;
+use super::scalar::{scalar_filter, scalar_filter_offset};
+
+fn nop_filter<'a, T: Pod>(values: &'a [T], mask: &'a [u8], out: *mut T) -> (&'a [T], &'a [u8], *mut T) {
+    (values, mask, out)
+}
 
 pub fn filter_values<T: Pod>(values: &[T], mask: &Bitmap) -> Vec<T> {
     match (std::mem::size_of::<T>(), std::mem::align_of::<T>()) {
@@ -9,36 +17,86 @@ pub fn filter_values<T: Pod>(values: &[T], mask: &Bitmap) -> Vec<T> {
         (2, 2) => cast_vec(filter_values_u16(cast_slice(values), mask)),
         (4, 4) => cast_vec(filter_values_u32(cast_slice(values), mask)),
         (8, 8) => cast_vec(filter_values_u64(cast_slice(values), mask)),
-        _ => filter_values_generic(values, mask),
+        (16, _) => filter_values_u128(values, mask),
+        _ => filter_values_generic(values, mask, 1, &nop_filter),
     }
 }
 
 fn filter_values_u8(values: &[u8], mask: &Bitmap) -> Vec<u8> {
-    // TODO: fast SIMD implementation.
-    filter_values_generic(values, mask)
+    #[cfg(target_arch = "x86_64")]
+    if std::arch::is_x86_feature_detected!("avx512vbmi2") {
+        unsafe {
+            return filter_values_generic(values, mask, 64, &|v, m, o| avx512::filter_u8_avx512vbmi2(v, m, o));
+        }
+    }
+
+    filter_values_generic(values, mask, 1, &nop_filter)
 }
 
 fn filter_values_u16(values: &[u16], mask: &Bitmap) -> Vec<u16> {
-    // TODO: fast SIMD implementation.
-    filter_values_generic(values, mask)
+    #[cfg(target_arch = "x86_64")]
+    if std::arch::is_x86_feature_detected!("avx512vbmi2") {
+        unsafe {
+            return filter_values_generic(values, mask, 32, &|v, m, o| avx512::filter_u16_avx512vbmi2(v, m, o));
+        }
+    }
+
+    filter_values_generic(values, mask, 1, &nop_filter)
 }
 
 fn filter_values_u32(values: &[u32], mask: &Bitmap) -> Vec<u32> {
-    // TODO: fast SIMD implementation.
-    filter_values_generic(values, mask)
+    #[cfg(target_arch = "x86_64")]
+    if std::arch::is_x86_feature_detected!("avx512f") {
+        unsafe {
+            return filter_values_generic(values, mask, 16, &|v, m, o| avx512::filter_u32_avx512f(v, m, o));
+        }
+    }
+
+    filter_values_generic(values, mask, 1, &nop_filter)
 }
 
 fn filter_values_u64(values: &[u64], mask: &Bitmap) -> Vec<u64> {
-    // TODO: fast SIMD implementation.
-    filter_values_generic(values, mask)
+    #[cfg(target_arch = "x86_64")]
+    if std::arch::is_x86_feature_detected!("avx512f") {
+        unsafe {
+            return filter_values_generic(values, mask, 8, &|v, m, o| avx512::filter_u64_avx512f(v, m, o));
+        }
+    }
+
+    filter_values_generic(values, mask, 1, &nop_filter)
 }
 
-fn filter_values_generic<T: Pod>(values: &[T], mask: &Bitmap) -> Vec<T> {
+fn filter_values_u128<T: Pod>(values: &[T], mask: &Bitmap) -> Vec<T> {
+    assert_eq!(std::mem::size_of::<T>(), 16);
+
+    #[cfg(target_arch = "x86_64")]
+    if std::arch::is_x86_feature_detected!("avx512f") {
+        unsafe {
+            return filter_values_generic(values, mask, 4, &|v, m, o| {
+                let v = std::mem::transmute::<&[T], &[[u8; 16]]>(v);
+                let (v, m, o) = avx512::filter_u128_unaligned_avx512f(v, m, o as *mut [u8; 16]);
+                let v = std::mem::transmute::<&[[u8; 16]], &[T]>(v);
+                (v, m, o as *mut T)
+            });
+        }
+    }
+
+    filter_values_generic(values, mask, 1, &nop_filter)
+}
+
+fn filter_values_generic<T: Pod>(
+    values: &[T],
+    mask: &Bitmap,
+    pad: usize,
+    bulk_filter: &dyn for<'a> Fn(&'a [T], &'a [u8], *mut T) -> (&'a [T], &'a [u8], *mut T),
+) -> Vec<T> {
     assert_eq!(values.len(), mask.len());
     let mask_bits_set = mask.set_bits();
-    let mut out = Vec::with_capacity(mask_bits_set + 1);
+    let mut out = Vec::with_capacity(mask_bits_set + pad);
     unsafe {
-        super::scalar::filter_scalar_values(values, mask, out.as_mut_ptr());
+        let (values, mask_bytes, out_ptr) = scalar_filter_offset(values, mask, out.as_mut_ptr());
+        let (values, mask_bytes, out_ptr) = bulk_filter(values, mask_bytes, out_ptr);
+        scalar_filter(values, mask_bytes, out_ptr);
         out.set_len(mask_bits_set);
     }
     out

--- a/crates/polars-compute/src/filter/primitive.rs
+++ b/crates/polars-compute/src/filter/primitive.rs
@@ -3,11 +3,16 @@ use bytemuck::{cast_slice, cast_vec, Pod};
 
 #[cfg(all(target_arch = "x86_64", feature = "simd"))]
 use super::avx512;
-
 use super::boolean::filter_boolean_kernel;
 use super::scalar::{scalar_filter, scalar_filter_offset};
 
-fn nop_filter<'a, T: Pod>(values: &'a [T], mask: &'a [u8], out: *mut T) -> (&'a [T], &'a [u8], *mut T) {
+type FilterFn<T> = for<'a> unsafe fn(&'a [T], &'a [u8], *mut T) -> (&'a [T], &'a [u8], *mut T);
+
+fn nop_filter<'a, T: Pod>(
+    values: &'a [T],
+    mask: &'a [u8],
+    out: *mut T,
+) -> (&'a [T], &'a [u8], *mut T) {
     (values, mask, out)
 }
 
@@ -17,59 +22,51 @@ pub fn filter_values<T: Pod>(values: &[T], mask: &Bitmap) -> Vec<T> {
         (2, 2) => cast_vec(filter_values_u16(cast_slice(values), mask)),
         (4, 4) => cast_vec(filter_values_u32(cast_slice(values), mask)),
         (8, 8) => cast_vec(filter_values_u64(cast_slice(values), mask)),
-        _ => filter_values_generic(values, mask, 1, &nop_filter),
+        _ => filter_values_generic(values, mask, 1, nop_filter),
     }
 }
 
 fn filter_values_u8(values: &[u8], mask: &Bitmap) -> Vec<u8> {
     #[cfg(all(target_arch = "x86_64", feature = "simd"))]
     if std::arch::is_x86_feature_detected!("avx512vbmi2") {
-        unsafe {
-            return filter_values_generic(values, mask, 64, &|v, m, o| avx512::filter_u8_avx512vbmi2(v, m, o));
-        }
+        return filter_values_generic(values, mask, 64, avx512::filter_u8_avx512vbmi2);
     }
 
-    filter_values_generic(values, mask, 1, &nop_filter)
+    filter_values_generic(values, mask, 1, nop_filter)
 }
 
 fn filter_values_u16(values: &[u16], mask: &Bitmap) -> Vec<u16> {
     #[cfg(all(target_arch = "x86_64", feature = "simd"))]
     if std::arch::is_x86_feature_detected!("avx512vbmi2") {
-        unsafe {
-            return filter_values_generic(values, mask, 32, &|v, m, o| avx512::filter_u16_avx512vbmi2(v, m, o));
-        }
+        return filter_values_generic(values, mask, 32, avx512::filter_u16_avx512vbmi2);
     }
 
-    filter_values_generic(values, mask, 1, &nop_filter)
+    filter_values_generic(values, mask, 1, nop_filter)
 }
 
 fn filter_values_u32(values: &[u32], mask: &Bitmap) -> Vec<u32> {
     #[cfg(all(target_arch = "x86_64", feature = "simd"))]
     if std::arch::is_x86_feature_detected!("avx512f") {
-        unsafe {
-            return filter_values_generic(values, mask, 16, &|v, m, o| avx512::filter_u32_avx512f(v, m, o));
-        }
+        return filter_values_generic(values, mask, 16, avx512::filter_u32_avx512f);
     }
 
-    filter_values_generic(values, mask, 1, &nop_filter)
+    filter_values_generic(values, mask, 1, nop_filter)
 }
 
 fn filter_values_u64(values: &[u64], mask: &Bitmap) -> Vec<u64> {
     #[cfg(all(target_arch = "x86_64", feature = "simd"))]
     if std::arch::is_x86_feature_detected!("avx512f") {
-        unsafe {
-            return filter_values_generic(values, mask, 8, &|v, m, o| avx512::filter_u64_avx512f(v, m, o));
-        }
+        return filter_values_generic(values, mask, 8, avx512::filter_u64_avx512f);
     }
 
-    filter_values_generic(values, mask, 1, &nop_filter)
+    filter_values_generic(values, mask, 1, nop_filter)
 }
 
 fn filter_values_generic<T: Pod>(
     values: &[T],
     mask: &Bitmap,
     pad: usize,
-    bulk_filter: &dyn for<'a> Fn(&'a [T], &'a [u8], *mut T) -> (&'a [T], &'a [u8], *mut T),
+    bulk_filter: FilterFn<T>,
 ) -> Vec<T> {
     assert_eq!(values.len(), mask.len());
     let mask_bits_set = mask.set_bits();

--- a/crates/polars-compute/src/filter/scalar.rs
+++ b/crates/polars-compute/src/filter/scalar.rs
@@ -50,7 +50,11 @@ unsafe fn scalar_dense_filter64<T: Pod>(v: &[T], mut m: u64, out: *mut T) {
 ///
 /// # Safety
 /// out must be valid for at least mask.set_bits() + 1 writes.
-pub unsafe fn scalar_filter_offset<'a, T: Pod>(values: &'a [T], mask: &'a Bitmap, mut out: *mut T) -> (&'a [T], &'a [u8], *mut T) {
+pub unsafe fn scalar_filter_offset<'a, T: Pod>(
+    values: &'a [T],
+    mask: &'a Bitmap,
+    mut out: *mut T,
+) -> (&'a [T], &'a [u8], *mut T) {
     assert_eq!(values.len(), mask.len());
 
     let (mut mask_bytes, offset, len) = mask.as_slice();

--- a/crates/polars-compute/src/filter/scalar.rs
+++ b/crates/polars-compute/src/filter/scalar.rs
@@ -64,16 +64,15 @@ pub unsafe fn scalar_filter_offset<'a, T: Pod>(
         mask_bytes = &mask_bytes[1..];
 
         for byte_idx in offset..8 {
-            let mask_bit = first_byte & (1 << byte_idx) != 0;
-            if mask_bit && value_idx < len {
+            if value_idx < len {
                 unsafe {
-                    // SAFETY: we only write to out for one bits, and checked
-                    // that value_idx < len.
+                    // SAFETY: we checked that value_idx < len.
+                    let bit_is_set = first_byte & (1 << byte_idx) != 0;
                     *out = *values.get_unchecked(value_idx);
-                    out = out.add(1);
+                    out = out.add(bit_is_set as usize);
                 }
+                value_idx += 1;
             }
-            value_idx += 1;
         }
     }
 

--- a/crates/polars-compute/src/lib.rs
+++ b/crates/polars-compute/src/lib.rs
@@ -1,6 +1,9 @@
 #![cfg_attr(feature = "simd", feature(portable_simd))]
 #![cfg_attr(feature = "simd", feature(avx512_target_feature))]
-#![cfg_attr(all(feature = "simd", target_arch = "x86_64"), feature(stdarch_x86_avx512))]
+#![cfg_attr(
+    all(feature = "simd", target_arch = "x86_64"),
+    feature(stdarch_x86_avx512)
+)]
 
 pub mod arithmetic;
 pub mod comparisons;

--- a/crates/polars-compute/src/lib.rs
+++ b/crates/polars-compute/src/lib.rs
@@ -1,4 +1,6 @@
 #![cfg_attr(feature = "simd", feature(portable_simd))]
+#![cfg_attr(feature = "simd", feature(avx512_target_feature))]
+#![cfg_attr(all(feature = "simd", target_arch = "x86_64"), feature(stdarch_x86_avx512))]
 
 pub mod arithmetic;
 pub mod comparisons;

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -1,11 +1,11 @@
 from datetime import datetime
 
+import numpy as np
 import pytest
 
-import numpy as np
 import polars as pl
 from polars import PolarsDataType
-from polars.testing import assert_series_equal, assert_frame_equal
+from polars.testing import assert_frame_equal, assert_series_equal
 
 
 def test_simplify_expression_lit_true_4376() -> None:
@@ -241,23 +241,20 @@ def test_filter_logical_type_13194() -> None:
     )
     assert_frame_equal(df, expected_df)
 
+
 @pytest.mark.slow()
 @pytest.mark.parametrize(
     "dtype", [pl.Boolean, pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.String]
 )
-@pytest.mark.parametrize(
-    "size", list(range(64)) + [100, 1000, 10000]
-)
-@pytest.mark.parametrize(
-    "selectivity", [0.0, 0.01, 0.1, 0.5, 0.9, 0.99, 1.0 + 1e-6]
-)
+@pytest.mark.parametrize("size", list(range(64)) + [100, 1000, 10000])
+@pytest.mark.parametrize("selectivity", [0.0, 0.01, 0.1, 0.5, 0.9, 0.99, 1.0 + 1e-6])
 def test_filter(dtype: PolarsDataType, size: int, selectivity: float) -> None:
     rng = np.random.Generator(np.random.PCG64(size * 100 + int(100 * selectivity)))
-    np_payload = rng.uniform(size = size) * 100.0
-    np_mask = rng.uniform(size = size) < selectivity
+    np_payload = rng.uniform(size=size) * 100.0
+    np_mask = rng.uniform(size=size) < selectivity
     payload = pl.Series(np_payload).cast(dtype)
     mask = pl.Series(np_mask, dtype=pl.Boolean)
-    
+
     reference = pl.Series(np_payload[np_mask]).cast(dtype)
     result = payload.filter(mask)
     assert_series_equal(reference, result)

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -2,9 +2,10 @@ from datetime import datetime
 
 import pytest
 
+import numpy as np
 import polars as pl
 from polars import PolarsDataType
-from polars.testing import assert_frame_equal
+from polars.testing import assert_series_equal, assert_frame_equal
 
 
 def test_simplify_expression_lit_true_4376() -> None:
@@ -239,3 +240,24 @@ def test_filter_logical_type_13194() -> None:
         },
     )
     assert_frame_equal(df, expected_df)
+
+@pytest.mark.slow()
+@pytest.mark.parametrize(
+    "dtype", [pl.Boolean, pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.String]
+)
+@pytest.mark.parametrize(
+    "size", list(range(64)) + [100, 1000, 10000]
+)
+@pytest.mark.parametrize(
+    "selectivity", [0.0, 0.01, 0.1, 0.5, 0.9, 0.99, 1.0 + 1e-6]
+)
+def test_filter(dtype: PolarsDataType, size: int, selectivity: float) -> None:
+    rng = np.random.Generator(np.random.PCG64(size * 100 + int(100 * selectivity)))
+    np_payload = rng.uniform(size = size) * 100.0
+    np_mask = rng.uniform(size = size) < selectivity
+    payload = pl.Series(np_payload).cast(dtype)
+    mask = pl.Series(np_mask, dtype=pl.Boolean)
+    
+    reference = pl.Series(np_payload[np_mask]).cast(dtype)
+    result = payload.filter(mask)
+    assert_series_equal(reference, result)


### PR DESCRIPTION
This should improve performance when data is in cache, and it seems to improve performance by ~2x regardless for filtering u8s if AVX-512 is available. Unfortunately the speedups for other types when data doesn't fit in cache weren't there, I didn't realize the scalar path already achieves single-threaded memory bandwidth (at least on the machine I tested).