### PR TITLE
test(rust): Make assumption about column name to index conversion having occurred explicit

### DIFF
--- a/crates/polars-io/src/ipc/ipc_file.rs
+++ b/crates/polars-io/src/ipc/ipc_file.rs
@@ -164,7 +164,7 @@ impl<R: MmapBytesReader> IpcReader<R> {
         let rechunk = self.rechunk;
         let metadata = read::read_file_metadata(&mut self.reader)?;
 
-        assert!(
+        debug_assert!(
             self.columns.is_none(),
             "column names must have already been converted into indices",
         );

--- a/crates/polars-io/src/ipc/ipc_file.rs
+++ b/crates/polars-io/src/ipc/ipc_file.rs
@@ -164,6 +164,11 @@ impl<R: MmapBytesReader> IpcReader<R> {
         let rechunk = self.rechunk;
         let metadata = read::read_file_metadata(&mut self.reader)?;
 
+        assert!(
+            self.columns.is_none(),
+            "column names must have already been converted into indices",
+        );
+
         let schema = if let Some(projection) = &self.projection {
             Arc::new(apply_projection(&metadata.schema, projection))
         } else {


### PR DESCRIPTION
Alternatively, we could do the conversion again if it has not occurred yet. 

The column name to indices conversion happens in multiple places in the code base. 

In those places we use only the column names if provided and ignore the column indices (projection) without warning. We could take the union instead, print a warning about ignoring the indices when the names are provided, or do nothing.

Depending on this choice, we may be able to represent the projection with a better data structure and deduplicate the conversion code. 


