### PR TITLE
chore: optional deps should include `fastexcel` 

### DIFF
--- a/py-polars/polars/meta/versions.py
+++ b/py-polars/polars/meta/versions.py
@@ -14,29 +14,30 @@ def show_versions() -> None:
     --------
     >>> pl.show_versions()  # doctest: +SKIP
     --------Version info---------
-    Polars:               0.19.16
+    Polars:               0.20.14
     Index type:           UInt32
-    Platform:             macOS-14.1.1-arm64-arm-64bit
-    Python:               3.11.6 (main, Oct  2 2023, 13:45:54) [Clang 15.0.0 (clang-1500.0.40.1)]
+    Platform:             macOS-14.3.1-arm64-arm-64bit
+    Python:               3.11.8 (main, Feb  6 2024, 21:21:21) [Clang 15.0.0 (clang-1500.1.0.2.5)]
     ----Optional dependencies----
-    adbc_driver_manager:  0.8.0
+    adbc_driver_manager:  0.10.0
     cloudpickle:          3.0.0
     connectorx:           0.3.2
-    deltalake:            0.13.0
-    fsspec:               2023.10.0
-    hvplot:               0.9.1
-    gevent:               23.9.1
-    matplotlib:           3.8.2
-    numpy:                1.26.2
+    deltalake:            0.16.0
+    fastexcel:            0.9.1
+    fsspec:               2023.12.2
+    gevent:               24.2.1
+    hvplot:               0.9.2
+    matplotlib:           3.8.3
+    numpy:                1.26.4
     openpyxl:             3.1.2
-    pandas:               2.1.3
-    pyarrow:              14.0.1
-    pydantic:             2.5.2
-    pyiceberg:            0.5.1
+    pandas:               2.2.1
+    pyarrow:              15.0.0
+    pydantic:             2.6.3
+    pyiceberg:            0.6.0
     pyxlsb:               1.0.10
-    sqlalchemy:           2.0.23
-    xlsx2csv:             0.8.1
-    xlsxwriter:           3.1.9
+    sqlalchemy:           2.0.28
+    xlsx2csv:             0.8.2
+    xlsxwriter:           3.2.0
     """  # noqa: W505
     # Note: we import 'platform' here (rather than at the top of the
     # module) as a micro-optimization for polars' initial import

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -39,17 +39,18 @@ Changelog = "https://github.com/pola-rs/polars/releases"
 
 [project.optional-dependencies]
 # NOTE: keep this list in sync with show_versions() and requirements-dev.txt
-adbc = ["adbc_driver_sqlite"]
+adbc = ["adbc_driver_manager", "adbc_driver_sqlite"]
 cloudpickle = ["cloudpickle"]
 connectorx = ["connectorx >= 0.3.2"]
 deltalake = ["deltalake >= 0.14.0"]
+fastexcel = ["fastexcel >= 0.9"]
 fsspec = ["fsspec"]
 gevent = ["gevent"]
-plot = ["hvplot >= 0.9.1"]
 matplotlib = ["matplotlib"]
 numpy = ["numpy >= 1.16.0"]
 openpyxl = ["openpyxl >= 3.0.0"]
 pandas = ["pyarrow >= 7.0.0", "pandas"]
+plot = ["hvplot >= 0.9.1"]
 pyarrow = ["pyarrow >= 7.0.0"]
 pydantic = ["pydantic"]
 pyiceberg = ["pyiceberg >= 0.5.0"]
@@ -59,7 +60,7 @@ timezone = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_syst
 xlsx2csv = ["xlsx2csv >= 0.8.0"]
 xlsxwriter = ["xlsxwriter"]
 all = [
-  "polars[pyarrow,pandas,numpy,fsspec,plot,connectorx,xlsx2csv,deltalake,timezone,pydantic,pyiceberg,sqlalchemy,xlsxwriter,adbc,cloudpickle,gevent]",
+  "polars[adbc,cloudpickle,connectorx,deltalake,fastexcel,fsspec,gevent,numpy,pandas,plot,pyarrow,pydantic,pyiceberg,sqlalchemy,timezone,xlsx2csv,xlsxwriter]",
 ]
 
 [tool.maturin]

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -7,7 +7,8 @@
 # -----
 
 maturin
-patchelf; platform_system == 'Linux'  # Extra dependency for maturin, only for Linux
+# extra dependency for maturin (linux-only)
+patchelf; platform_system == 'Linux'
 
 # ------------
 # DEPENDENCIES
@@ -36,7 +37,7 @@ s3fs[boto3]
 # Spreadsheet
 ezodf
 lxml
-fastexcel>=0.8.0
+fastexcel>=0.9
 openpyxl
 pyxlsb
 xlsx2csv


### PR DESCRIPTION
Minor housekeeping; `fastexcel` was listed in "show_versions" but wasn't registered in the optional deps for install when doing `pip install "polars[all]"`. Refreshed the docstring output from "show_versions" while I was at it.