### PR TITLE
fix(python): Ensure consistent `read_database` behaviour with empty ODBC "iter_batches"

### DIFF
--- a/py-polars/tests/unit/io/test_database_read.py
+++ b/py-polars/tests/unit/io/test_database_read.py
@@ -9,16 +9,15 @@ from pathlib import Path
 from types import GeneratorType
 from typing import TYPE_CHECKING, Any, NamedTuple
 
+import polars as pl
 import pyarrow as pa
 import pytest
-from sqlalchemy import Integer, MetaData, Table, create_engine, func, select
-from sqlalchemy.orm import sessionmaker
-from sqlalchemy.sql.expression import cast as alchemy_cast
-
-import polars as pl
 from polars.exceptions import UnsuitableSQLError
 from polars.io.database import _ARROW_DRIVER_REGISTRY_
 from polars.testing import assert_frame_equal
+from sqlalchemy import Integer, MetaData, Table, create_engine, func, select
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.sql.expression import cast as alchemy_cast
 
 if TYPE_CHECKING:
     from polars.type_aliases import (
@@ -706,7 +705,6 @@ def test_read_database_cx_credentials(uri: str) -> None:
 
 @pytest.mark.write_disk()
 def test_read_kuzu_graph_database(tmp_path: Path, io_files_path: Path) -> None:
-    # validate reading from a kuzu graph database
     import kuzu
 
     tmp_path.mkdir(exist_ok=True)
@@ -717,7 +715,7 @@ def test_read_kuzu_graph_database(tmp_path: Path, io_files_path: Path) -> None:
 
     db = kuzu.Database(test_db)
     conn = kuzu.Connection(db)
-    conn.execute("CREATE NODE TABLE User(name STRING, age INT64, PRIMARY KEY (name))")
+    conn.execute("CREATE NODE TABLE User(name STRING, age UINT64, PRIMARY KEY (name))")
     conn.execute("CREATE REL TABLE Follows(FROM User TO User, since INT64)")
 
     users = str(io_files_path / "graph-data" / "user.csv").replace("\\", "/")
@@ -726,6 +724,7 @@ def test_read_kuzu_graph_database(tmp_path: Path, io_files_path: Path) -> None:
     conn.execute(f'COPY User FROM "{users}"')
     conn.execute(f'COPY Follows FROM "{follows}"')
 
+    # basic: single relation
     df1 = pl.read_database(
         query="MATCH (u:User) RETURN u.name, u.age",
         connection=conn,
@@ -736,10 +735,12 @@ def test_read_kuzu_graph_database(tmp_path: Path, io_files_path: Path) -> None:
             {
                 "u.name": ["Adam", "Karissa", "Zhang", "Noura"],
                 "u.age": [30, 40, 50, 25],
-            }
+            },
+            schema={"u.name": pl.Utf8, "u.age": pl.UInt64},
         ),
     )
 
+    # join: connected edges/relations
     df2 = pl.read_database(
         query="MATCH (a:User)-[f:Follows]->(b:User) RETURN a.name, f.since, b.name",
         connection=conn,
@@ -751,6 +752,19 @@ def test_read_kuzu_graph_database(tmp_path: Path, io_files_path: Path) -> None:
                 "a.name": ["Adam", "Adam", "Karissa", "Zhang"],
                 "f.since": [2020, 2020, 2021, 2022],
                 "b.name": ["Karissa", "Zhang", "Zhang", "Noura"],
-            }
+            },
+            schema={"a.name": pl.Utf8, "f.since": pl.Int64, "b.name": pl.Utf8},
+        ),
+    )
+
+    # empty: no results for the given query
+    df3 = pl.read_database(
+        query="MATCH (a:User)-[f:Follows]->(b:User) WHERE a.name = '🔎️' RETURN a.name, f.since, b.name",
+        connection=conn,
+    )
+    assert_frame_equal(
+        df3,
+        pl.DataFrame(
+            schema={"a.name": pl.Utf8, "f.since": pl.Int64, "b.name": pl.Utf8}
         ),
     )

--- a/py-polars/tests/unit/io/test_database_read.py
+++ b/py-polars/tests/unit/io/test_database_read.py
@@ -9,15 +9,16 @@ from pathlib import Path
 from types import GeneratorType
 from typing import TYPE_CHECKING, Any, NamedTuple
 
-import polars as pl
 import pyarrow as pa
 import pytest
-from polars.exceptions import UnsuitableSQLError
-from polars.io.database import _ARROW_DRIVER_REGISTRY_
-from polars.testing import assert_frame_equal
 from sqlalchemy import Integer, MetaData, Table, create_engine, func, select
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.sql.expression import cast as alchemy_cast
+
+import polars as pl
+from polars.exceptions import UnsuitableSQLError
+from polars.io.database import _ARROW_DRIVER_REGISTRY_
+from polars.testing import assert_frame_equal
 
 if TYPE_CHECKING:
     from polars.type_aliases import (


### PR DESCRIPTION
Minor follow-up to #14916.

* Additionally makes the behaviour consistent between ODBC queries and all other connection types when setting `iter_batches=True` _and_ we have an empty result set (the batch _iterator_ should be empty, vs a single RecordBatch with no rows).
* Adds "empty dataset" test coverage for KùzuDB.
