### PR TITLE
fix(python): Fix frame init from single `RecordBatch` objects when `pyarrow <= 12`

### DIFF
--- a/py-polars/polars/_utils/construction.py
+++ b/py-polars/polars/_utils/construction.py
@@ -1582,11 +1582,12 @@ def arrow_to_pydf(
 ) -> PyDataFrame:
     """Construct a PyDataFrame from an Arrow Table or RecordBatch."""
     original_schema = schema
+    data_column_names = data.schema.names
     column_names, schema_overrides = _unpack_schema(
-        (schema or data.column_names), schema_overrides=schema_overrides
+        (schema or data_column_names), schema_overrides=schema_overrides
     )
     try:
-        if column_names != data.column_names:
+        if column_names != data_column_names:
             if isinstance(data, pa.RecordBatch):
                 data = pa.Table.from_batches([data])
             data = data.rename_columns(column_names)


### PR DESCRIPTION
Closes #14919.

The reported error was not actually related to our database code, but it exposed a bug initialising from single `RecordBatch` objects if the user has a pyarrow version <= 12. 

We were relying on `RecordBatch` having the "column_names" attribute if no schema was given, but this attribute isn't found on `RecordBatch` until pyarrow 13.

The fix is straightforward; we can generically use `obj.schema.names` instead, as the "schema" attribute exists on both `Table` _and_ `RecordBatch` objects across all versions.