### PR TITLE
fix: boolean filter gave overly large buffers to Bitmap::from_u8_vec

### DIFF
--- a/crates/polars-arrow/src/bitmap/mutable.rs
+++ b/crates/polars-arrow/src/bitmap/mutable.rs
@@ -84,7 +84,7 @@ impl MutableBitmap {
                 bytes.len().saturating_mul(8)
             )
         }
-        
+
         // Ensure invariant holds.
         let min_byte_length_needed = length.div_ceil(8);
         bytes.drain(min_byte_length_needed..);

--- a/crates/polars-arrow/src/bitmap/mutable.rs
+++ b/crates/polars-arrow/src/bitmap/mutable.rs
@@ -76,7 +76,7 @@ impl MutableBitmap {
     /// # Errors
     /// This function errors iff `length > bytes.len() * 8`
     #[inline]
-    pub fn try_new(bytes: Vec<u8>, length: usize) -> PolarsResult<Self> {
+    pub fn try_new(mut bytes: Vec<u8>, length: usize) -> PolarsResult<Self> {
         if length > bytes.len().saturating_mul(8) {
             polars_bail!(InvalidOperation:
                 "The length of the bitmap ({}) must be `<=` to the number of bytes times 8 ({})",
@@ -84,6 +84,10 @@ impl MutableBitmap {
                 bytes.len().saturating_mul(8)
             )
         }
+        
+        // Ensure invariant holds.
+        let min_byte_length_needed = length.div_ceil(8);
+        bytes.drain(min_byte_length_needed..);
         Ok(Self {
             length,
             buffer: bytes,


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/14914.

This only patches the what triggers this problem however, the real problem is that `MutableBitmap` has the following invariant:

```rust
// invariant: length.saturating_add(7) / 8 == buffer.len();
```

~~But it does nothing to ensure that invariant is true during initialization (and I haven't yet checked if it maintains it).~~

From a cursory glance it does seem to maintain the invariant, and now I also made sure it satisfies the invariant during initialization.