### PR TITLE
MAIN: Add logic to handle embedded quote char

### DIFF
--- a/crates/polars-io/src/csv/splitfields.rs
+++ b/crates/polars-io/src/csv/splitfields.rs
@@ -83,9 +83,14 @@ mod inner {
                 for &c in self.v.iter() {
                     if c == self.quote_char {
                         // toggle between string field enclosure
-                        //      if we encounter a starting '"' -> in_field = true;
-                        //      if we encounter a closing '"' -> in_field = false;
-                        in_field = !in_field;
+                        if in_field && (current_idx as usize + 1 <= self.v.len() || unsafe { *self.v.get_unchecked(current_idx as usize + 1) } == self.separator) {
+                            // If we encounter a closing '"' and the next character is the separator, in_field = false;
+                            in_field = !in_field;
+                        }
+                        if !in_field && (current_idx == 0 || unsafe { *self.v.get_unchecked(current_idx as usize - 1) } == self.separator) {
+                            // If we encounter a starting '"' and the previous character is the separator, in_field = true;
+                            in_field = !in_field;
+                        }
                     }
 
                     if !in_field && self.eof_oel(c) {
@@ -245,9 +250,14 @@ mod inner {
                 for &c in self.v.iter() {
                     if c == self.quote_char {
                         // toggle between string field enclosure
-                        //      if we encounter a starting '"' -> in_field = true;
-                        //      if we encounter a closing '"' -> in_field = false;
-                        in_field = !in_field;
+                        if in_field && (current_idx as usize + 1 <= self.v.len() || unsafe { *self.v.get_unchecked(current_idx as usize + 1) } == self.separator) {
+                            // If we encounter a closing '"' and the next character is the separator, in_field = false;
+                            in_field = !in_field;
+                        }
+                        if !in_field && (current_idx == 0 || unsafe { *self.v.get_unchecked(current_idx as usize - 1) } == self.separator) {
+                            // If we encounter a starting '"' and the previous character is the separator, in_field = true;
+                            in_field = !in_field;
+                        }
                     }
 
                     if !in_field && self.eof_oel(c) {


### PR DESCRIPTION
* Check for embedded quote char in fields. Current logic just toggles in field when a quote char is encountered
* This PR adds logic to check if the previous or next character is also a separator, which is more indicative of whether or not we should toggle being in a field.

This is partly to address some of the errors I was seeing in [14547](https://github.com/pola-rs/polars/issues/14547). I understand if this is not something you want to add to polars to keep the CSV parsing simpler and let the user fix this elsewhere.

FWIW I have a CSV that was causing this error (I can attach a minimum reproducible example if you'd like), but it was opening fine in libreoffice calc, and pandas was also parsing it fine.

EDIT: Happy to add tests if this is something you think is worth adding, figured I would check first