### PR TITLE
fix: Don't rechunk categoricals when moving to physical

### DIFF
--- a/crates/polars-core/src/series/mod.rs
+++ b/crates/polars-core/src/series/mod.rs
@@ -448,7 +448,10 @@ impl Series {
             Date => Cow::Owned(self.cast(&Int32).unwrap()),
             Datetime(_, _) | Duration(_) | Time => Cow::Owned(self.cast(&Int64).unwrap()),
             #[cfg(feature = "dtype-categorical")]
-            Categorical(_, _) | Enum(_, _) => Cow::Owned(self.cast(&UInt32).unwrap()),
+            Categorical(_, _) | Enum(_, _) => {
+                let ca = self.categorical().unwrap();
+                Cow::Owned(ca.physical().clone().into_series())
+            },
             List(inner) => Cow::Owned(self.cast(&List(Box::new(inner.to_physical()))).unwrap()),
             #[cfg(feature = "dtype-struct")]
             Struct(_) => {

--- a/py-polars/tests/unit/streaming/test_streaming_categoricals.py
+++ b/py-polars/tests/unit/streaming/test_streaming_categoricals.py
@@ -16,3 +16,16 @@ def test_streaming_nested_categorical() -> None:
         "numbers": [1, 2],
         "cat": [["str"], ["bar"]],
     }
+
+
+def test_streaming_cat_14933() -> None:
+    df1 = pl.LazyFrame({"a": pl.Series([0], dtype=pl.UInt32)})
+    df2 = pl.LazyFrame(
+        [
+            pl.Series("a", [0, 1], dtype=pl.UInt32),
+            pl.Series("l", [None, None], dtype=pl.Categorical(ordering="physical")),
+        ]
+    )
+    assert df1.join(df2, on="a", how="left").collect(streaming=True).to_dict(
+        as_series=False
+    ) == {"a": [0], "l": [None]}


### PR DESCRIPTION
fixes #14933