### PR TITLE
fix: Do not raise when constructing from a list of Series with Nones

### DIFF
--- a/py-polars/polars/_utils/construction.py
+++ b/py-polars/polars/_utils/construction.py
@@ -609,7 +609,9 @@ def sequence_to_pyseries(
             return sequence_from_any_value_or_object(name, values)
 
         elif python_dtype == pl.Series:
-            return PySeries.new_series_list(name, [v._s for v in values], strict)
+            return PySeries.new_series_list(
+                name, [v._s if v is not None else None for v in values], strict
+            )
 
         elif python_dtype == PySeries:
             return PySeries.new_series_list(name, values, strict)

--- a/py-polars/src/series/construction.rs
+++ b/py-polars/src/series/construction.rs
@@ -12,7 +12,6 @@ use crate::arrow_interop::to_rust::array_to_rust;
 use crate::conversion::{slice_extract_wrapped, vec_extract_wrapped, Wrap};
 use crate::error::PyPolarsErr;
 use crate::prelude::ObjectValue;
-use crate::series::ToSeries;
 use crate::PySeries;
 
 // Init with numpy arrays.
@@ -250,8 +249,11 @@ impl PySeries {
     }
 
     #[staticmethod]
-    fn new_series_list(name: &str, val: Vec<PySeries>, _strict: bool) -> Self {
-        let series_vec = val.to_series();
+    fn new_series_list(name: &str, val: Vec<Option<PySeries>>, _strict: bool) -> Self {
+        let series_vec: Vec<Option<Series>> = val
+            .iter()
+            .map(|v| v.as_ref().map(|py_s| py_s.clone().series))
+            .collect();
         Series::new(name, &series_vec).into()
     }
 

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -775,3 +775,9 @@ def test_list_gather_null_struct_14927() -> None:
     expr = pl.col("col_0").list.get(0).struct.field("field_0")
     out = df.filter(pl.col("index") > 0).with_columns(expr)
     assert_frame_equal(out, expected)
+
+
+def test_list_of_series_with_nulls() -> None:
+    inner_series = pl.Series("inner", [1, 2, 3])
+    s = pl.Series("a", [inner_series, None])
+    assert_series_equal(s, pl.Series("a", [[1, 2, 3], None]))


### PR DESCRIPTION
Currently, constructing a Series from a list of Series which also contains Nones raises:

```python
import polars as pl

inner = pl.Series("inner", [1, 2, 3])
pl.Series("a", [inner, None])
# AttributeError: 'NoneType' object has no attribute '_s'
```

This PR fixes this:
```python
import polars as pl

inner = pl.Series("inner", [1, 2, 3])
pl.Series("a", [inner, None])
```
Output:
```shape: (2,)
Series: 'a' [list[i64]]
[
        [1, 2, 3]
        null
]
```

