### PR TITLE
fix: ooc-sort issues

### DIFF
--- a/crates/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -99,10 +99,8 @@ impl SortSink {
     }
 
     fn dump(&mut self, force: bool) -> PolarsResult<()> {
-        let larger_than_32_mb = self.current_chunks_size > 1 << 25;
-        if (force || larger_than_32_mb || self.current_chunk_rows > 50_000)
-            && !self.chunks.is_empty()
-        {
+        let larger_than_128_mb = self.current_chunks_size > (1 << 27);
+        if (force || larger_than_128_mb) && !self.chunks.is_empty() {
             // into a single chunk because multiple file IO's is expensive
             // and may lead to many smaller files in ooc-sort later, which is exponentially
             // expensive
@@ -190,6 +188,7 @@ impl Sink for SortSink {
                 self.sort_args.descending[0],
                 self.sort_args.slice,
                 context.verbose,
+                self.mem_track.clone(),
             )
         } else {
             let chunks = std::mem::take(&mut self.chunks);


### PR DESCRIPTION
Ensures the `binview` garbage collects after partitioning otherwise we multiply data by the factor of paritititons, which can be several orders of magnitude. :/

Also make the source phase make more use of available memory so that we get better parallelism. Fixes #14948

That query is now bound by the sink_parquet, which is still slow.