### PR TITLE
feat: let "ambiguous" take "null" value

### DIFF
--- a/crates/polars-arrow/src/legacy/kernels/time.rs
+++ b/crates/polars-arrow/src/legacy/kernels/time.rs
@@ -11,6 +11,7 @@ use polars_error::{polars_bail, PolarsError};
 pub enum Ambiguous {
     Earliest,
     Latest,
+    Null,
     Raise,
 }
 impl FromStr for Ambiguous {
@@ -21,8 +22,9 @@ impl FromStr for Ambiguous {
             "earliest" => Ok(Ambiguous::Earliest),
             "latest" => Ok(Ambiguous::Latest),
             "raise" => Ok(Ambiguous::Raise),
+            "null" => Ok(Ambiguous::Null),
             s => polars_bail!(InvalidOperation:
-                "Invalid argument {}, expected one of: \"earliest\", \"latest\", \"raise\"", s
+                "Invalid argument {}, expected one of: \"earliest\", \"latest\", \"null\", \"raise\"", s
             ),
         }
     }
@@ -34,13 +36,14 @@ pub fn convert_to_naive_local(
     to_tz: &Tz,
     ndt: NaiveDateTime,
     ambiguous: Ambiguous,
-) -> PolarsResult<NaiveDateTime> {
+) -> PolarsResult<Option<NaiveDateTime>> {
     let ndt = from_tz.from_utc_datetime(&ndt).naive_local();
     match to_tz.from_local_datetime(&ndt) {
-        LocalResult::Single(dt) => Ok(dt.naive_utc()),
+        LocalResult::Single(dt) => Ok(Some(dt.naive_utc())),
         LocalResult::Ambiguous(dt_earliest, dt_latest) => match ambiguous {
-            Ambiguous::Earliest => Ok(dt_earliest.naive_utc()),
-            Ambiguous::Latest => Ok(dt_latest.naive_utc()),
+            Ambiguous::Earliest => Ok(Some(dt_earliest.naive_utc())),
+            Ambiguous::Latest => Ok(Some(dt_latest.naive_utc())),
+            Ambiguous::Null => Ok(None),
             Ambiguous::Raise => {
                 polars_bail!(ComputeError: "datetime '{}' is ambiguous in time zone '{}'. Please use `ambiguous` to tell how it should be localized.", ndt, to_tz)
             },
@@ -52,19 +55,22 @@ pub fn convert_to_naive_local(
     }
 }
 
+/// Same as convert_to_naive_local, but return `None` instead
+/// raising - in some cases this can be used to save a string allocation.
 #[cfg(feature = "timezones")]
 pub fn convert_to_naive_local_opt(
     from_tz: &Tz,
     to_tz: &Tz,
     ndt: NaiveDateTime,
     ambiguous: Ambiguous,
-) -> Option<NaiveDateTime> {
+) -> Option<Option<NaiveDateTime>> {
     let ndt = from_tz.from_utc_datetime(&ndt).naive_local();
     match to_tz.from_local_datetime(&ndt) {
-        LocalResult::Single(dt) => Some(dt.naive_utc()),
+        LocalResult::Single(dt) => Some(Some(dt.naive_utc())),
         LocalResult::Ambiguous(dt_earliest, dt_latest) => match ambiguous {
-            Ambiguous::Earliest => Some(dt_earliest.naive_utc()),
-            Ambiguous::Latest => Some(dt_latest.naive_utc()),
+            Ambiguous::Earliest => Some(Some(dt_earliest.naive_utc())),
+            Ambiguous::Latest => Some(Some(dt_latest.naive_utc())),
+            Ambiguous::Null => Some(None),
             Ambiguous::Raise => None,
         },
         LocalResult::None => None,

--- a/crates/polars-time/src/month_start.rs
+++ b/crates/polars-time/src/month_start.rs
@@ -49,7 +49,10 @@ pub(crate) fn roll_backward(
     let ndt = NaiveDateTime::new(date, time);
     let t = match tz {
         #[cfg(feature = "timezones")]
-        Some(tz) => datetime_to_timestamp(try_localize_datetime(ndt, tz, Ambiguous::Raise)?),
+        Some(tz) => datetime_to_timestamp(
+            try_localize_datetime(ndt, tz, Ambiguous::Raise)?
+                .expect("we didn't use Ambiguous::Null"),
+        ),
         _ => datetime_to_timestamp(ndt),
     };
     Ok(t)

--- a/crates/polars-time/src/utils.rs
+++ b/crates/polars-time/src/utils.rs
@@ -9,13 +9,20 @@ use chrono::TimeZone;
 #[cfg(feature = "timezones")]
 use polars_core::prelude::PolarsResult;
 
+/// Localize datetime according to given time zone.
+///
+/// e.g. '2021-01-01 03:00' -> '2021-01-01 03:00CDT'
+///
+/// Note: this may only return `Ok(None)` if ambiguous is Ambiguous::Null.
+/// Otherwise, it will either return `Ok(Some(NaiveDateTime))` or `PolarsError`.
+/// Therefore, calling `try_localize_datetime(..., Ambiguous::Raise)?.unwrap()`
+/// is safe, and will never panic.
 #[cfg(feature = "timezones")]
 pub(crate) fn try_localize_datetime(
     ndt: NaiveDateTime,
     tz: &Tz,
     ambiguous: Ambiguous,
-) -> PolarsResult<NaiveDateTime> {
-    // e.g. '2021-01-01 03:00' -> '2021-01-01 03:00CDT'
+) -> PolarsResult<Option<NaiveDateTime>> {
     convert_to_naive_local(&chrono_tz::UTC, tz, ndt, ambiguous)
 }
 
@@ -24,7 +31,7 @@ pub(crate) fn localize_datetime_opt(
     ndt: NaiveDateTime,
     tz: &Tz,
     ambiguous: Ambiguous,
-) -> Option<NaiveDateTime> {
+) -> Option<Option<NaiveDateTime>> {
     // e.g. '2021-01-01 03:00' -> '2021-01-01 03:00CDT'
     convert_to_naive_local_opt(&chrono_tz::UTC, tz, ndt, ambiguous)
 }

--- a/py-polars/polars/expr/datetime.py
+++ b/py-polars/polars/expr/datetime.py
@@ -1620,6 +1620,7 @@ class ExprDateTimeNameSpace:
             - `'raise'` (default): raise
             - `'earliest'`: use the earliest datetime
             - `'latest'`: use the latest datetime
+            - `'null'`: set to null
 
         Examples
         --------

--- a/py-polars/polars/expr/string.py
+++ b/py-polars/polars/expr/string.py
@@ -139,6 +139,7 @@ class ExprStringNameSpace:
             - `'raise'` (default): raise
             - `'earliest'`: use the earliest datetime
             - `'latest'`: use the latest datetime
+            - `'null'`: set to null
 
         Examples
         --------
@@ -253,6 +254,7 @@ class ExprStringNameSpace:
             - `'raise'` (default): raise
             - `'earliest'`: use the earliest datetime
             - `'latest'`: use the latest datetime
+            - `'null'`: set to null
 
         Notes
         -----

--- a/py-polars/polars/functions/as_datatype.py
+++ b/py-polars/polars/functions/as_datatype.py
@@ -75,7 +75,7 @@ def datetime_(
         - `'raise'` (default): raise
         - `'earliest'`: use the earliest datetime
         - `'latest'`: use the latest datetime
-
+        - `'null'`: set to null
 
     Returns
     -------

--- a/py-polars/polars/series/datetime.py
+++ b/py-polars/polars/series/datetime.py
@@ -1157,6 +1157,7 @@ class DateTimeNameSpace:
             - `'raise'` (default): raise
             - `'earliest'`: use the earliest datetime
             - `'latest'`: use the latest datetime
+            - `'null'`: set to null
 
         Examples
         --------

--- a/py-polars/polars/series/string.py
+++ b/py-polars/polars/series/string.py
@@ -140,6 +140,7 @@ class StringNameSpace:
             - `'raise'` (default): raise
             - `'earliest'`: use the earliest datetime
             - `'latest'`: use the latest datetime
+            - `'null'`: set to null
 
         Examples
         --------
@@ -237,6 +238,7 @@ class StringNameSpace:
             - `'raise'` (default): raise
             - `'earliest'`: use the earliest datetime
             - `'latest'`: use the latest datetime
+            - `'null'`: set to null
 
         Notes
         -----

--- a/py-polars/polars/type_aliases.py
+++ b/py-polars/polars/type_aliases.py
@@ -148,7 +148,7 @@ ToStructStrategy: TypeAlias = Literal[
 ]  # ListToStructWidthStrategy
 
 # The following have no equivalent on the Rust side
-Ambiguous: TypeAlias = Literal["earliest", "latest", "raise"]
+Ambiguous: TypeAlias = Literal["earliest", "latest", "raise", "null"]
 ConcatMethod = Literal[
     "vertical",
     "vertical_relaxed",

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1684,8 +1684,8 @@ def test_invalid_ambiguous_value_in_expression() -> None:
 def test_replace_time_zone_ambiguous_null() -> None:
     df = pl.DataFrame(
         {
-            "a": [datetime(2020, 10, 25, 1)] * 3,
-            "b": ["earliest", "latest", "null"],
+            "a": [datetime(2020, 10, 25, 1)] * 3 + [None],
+            "b": ["earliest", "latest", "null", "raise"],
         }
     )
     # expression containing 'null'
@@ -1696,10 +1696,12 @@ def test_replace_time_zone_ambiguous_null() -> None:
         datetime(2020, 10, 25, 1, fold=0, tzinfo=ZoneInfo("Europe/London")),
         datetime(2020, 10, 25, 1, fold=1, tzinfo=ZoneInfo("Europe/London")),
         None,
+        None,
     ]
     assert result[0] == expected[0]
     assert result[1] == expected[1]
     assert result[2] == expected[2]
+    assert result[3] == expected[3]
 
     # single 'null' value
     result = df.select(
@@ -1708,6 +1710,7 @@ def test_replace_time_zone_ambiguous_null() -> None:
     assert result[0] is None
     assert result[1] is None
     assert result[2] is None
+    assert result[3] is None
 
 
 def test_use_earliest_deprecation() -> None:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -14,6 +14,7 @@ import polars as pl
 from polars.datatypes import DATETIME_DTYPES, DTYPE_TEMPORAL_UNITS, TEMPORAL_DTYPES
 from polars.exceptions import (
     ComputeError,
+    InvalidOperationError,
     PolarsInefficientMapWarning,
     TimeZoneAwareConstructorWarning,
 )
@@ -1668,6 +1669,16 @@ def test_replace_time_zone_sortedness_expressions(
         pl.col("ts").dt.replace_time_zone("UTC", ambiguous=pl.col("ambiguous"))
     )
     assert result["ts"].flags["SORTED_ASC"] == expected_sortedness
+
+
+def test_invalid_ambiguous_value_in_expression() -> None:
+    df = pl.DataFrame(
+        {"a": [datetime(2020, 10, 25, 1)] * 2, "b": ["earliest", "cabbage"]}
+    )
+    with pytest.raises(InvalidOperationError, match="Invalid argument cabbage"):
+        df.select(
+            pl.col("a").dt.replace_time_zone("Europe/London", ambiguous=pl.col("b"))
+        )
 
 
 def test_replace_time_zone_ambiguous_null() -> None:

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -1670,6 +1670,35 @@ def test_replace_time_zone_sortedness_expressions(
     assert result["ts"].flags["SORTED_ASC"] == expected_sortedness
 
 
+def test_replace_time_zone_ambiguous_null() -> None:
+    df = pl.DataFrame(
+        {
+            "a": [datetime(2020, 10, 25, 1)] * 3,
+            "b": ["earliest", "latest", "null"],
+        }
+    )
+    # expression containing 'null'
+    result = df.select(
+        pl.col("a").dt.replace_time_zone("Europe/London", ambiguous=pl.col("b"))
+    )["a"]
+    expected = [
+        datetime(2020, 10, 25, 1, fold=0, tzinfo=ZoneInfo("Europe/London")),
+        datetime(2020, 10, 25, 1, fold=1, tzinfo=ZoneInfo("Europe/London")),
+        None,
+    ]
+    assert result[0] == expected[0]
+    assert result[1] == expected[1]
+    assert result[2] == expected[2]
+
+    # single 'null' value
+    result = df.select(
+        pl.col("a").dt.replace_time_zone("Europe/London", ambiguous="null")
+    )["a"]
+    assert result[0] is None
+    assert result[1] is None
+    assert result[2] is None
+
+
 def test_use_earliest_deprecation() -> None:
     # strptime
     with pytest.warns(

--- a/py-polars/tests/unit/namespaces/test_strptime.py
+++ b/py-polars/tests/unit/namespaces/test_strptime.py
@@ -473,6 +473,24 @@ def test_to_datetime_ambiguous_or_non_existent() -> None:
         pl.Series(["2021-03-28 02:30"]).str.to_datetime(
             time_unit="us", time_zone="Europe/Warsaw"
         )
+    with pytest.raises(
+        pl.ComputeError,
+        match="datetime '2021-03-28 02:30:00' is non-existent in time zone 'Europe/Warsaw'",
+    ):
+        pl.Series(["2021-03-28 02:30"]).str.to_datetime(
+            time_unit="us",
+            time_zone="Europe/Warsaw",
+            ambiguous="null",
+        )
+    with pytest.raises(
+        pl.ComputeError,
+        match="datetime '2021-03-28 02:30:00' is non-existent in time zone 'Europe/Warsaw'",
+    ):
+        pl.Series(["2021-03-28 02:30"] * 2).str.to_datetime(
+            time_unit="us",
+            time_zone="Europe/Warsaw",
+            ambiguous=pl.Series(["null", "null"]),
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
~~to be rebased onto https://github.com/pola-rs/polars/pull/14958~~

Quick demo of what this lets you do:
```python
In [13]: s = pl.datetime_range(datetime(2018, 10, 28), datetime(2018, 10, 28, 5), '1h', eager=True)
    ...: 

In [14]: s
Out[14]: 
shape: (6,)
Series: 'literal' [datetime[μs]]
[
        2018-10-28 00:00:00
        2018-10-28 01:00:00
        2018-10-28 02:00:00
        2018-10-28 03:00:00
        2018-10-28 04:00:00
        2018-10-28 05:00:00
]

In [15]: s.dt.replace_time_zone('Europe/Amsterdam', ambiguous='null')
Out[15]: 
shape: (6,)
Series: 'literal' [datetime[μs, Europe/Amsterdam]]
[
        2018-10-28 00:00:00 CEST
        2018-10-28 01:00:00 CEST
        null
        2018-10-28 03:00:00 CET
        2018-10-28 04:00:00 CET
        2018-10-28 05:00:00 CET
]
```

towards #11579. Based on https://github.com/pola-rs/polars/issues/14842#issuecomment-1977297717, I think there's a need for being able to just have `null` for problematic datetimes.

I'm suggesting to start with adding `ambiguous='null'`, and then adding the option `non_existent: Literal['null', 'raise']`

Perf implication:
- for the trivial case of setting/unsetting UTC and `ambiguous='raise'` (the default), no implication. There's already a fast-path for that
- base case (`ambiguous='raise'`, the default): no impact.  `ambiguous`: no impact. I've made a fastpath to preserve this case. Check there's no impact [here](https://www.kaggle.com/code/marcogorelli/polars-timing?scriptVersionId=166337948), which shows 12.373298853000051 => 12.362355302333375 (main => here)
- For the non-base-case, I'm seeing a slight perf hit, which I've timed [here](https://www.kaggle.com/code/marcogorelli/polars-timing?scriptVersionId=166291090): 13.127492245999747 => 13.452795328000017 (main => here). I think this is to be expected, as the result needs to be constructed from a vector of `PolarsResult<Option<i64>>` as opposed to `PolarsResult<i64>`, but I think it's worth it for the user benefit