### PR TITLE
feat(python): Add `union`/`or` operator for `pl.Enum`

### DIFF
--- a/py-polars/polars/datatypes/classes.py
+++ b/py-polars/polars/datatypes/classes.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Iterator, Mapping, Sequence
 
 import polars._reexport as pl
 import polars.datatypes
+import polars.functions as F
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import dtype_str_repr as _dtype_str_repr
@@ -628,6 +629,14 @@ class Enum(DataType):
     def __repr__(self) -> str:
         class_name = self.__class__.__name__
         return f"{class_name}(categories={self.categories.to_list()!r})"
+
+    def union(self, other: Enum) -> Enum:
+        """Union of two Enums."""
+        return Enum(
+            F.concat((self.categories, other.categories)).unique(maintain_order=True)
+        )
+
+    __or__ = union
 
 
 class Object(DataType):

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -81,6 +81,13 @@ def test_nested_enum_creation() -> None:
     assert s.dtype == dtype
 
 
+def test_enum_union() -> None:
+    e1 = pl.Enum(["a", "b"])
+    e2 = pl.Enum(["b", "c"])
+    assert e1 | e2 == pl.Enum(["a", "b", "c"])
+    assert e1.union(e2) == pl.Enum(["a", "b", "c"])
+
+
 def test_nested_enum_concat() -> None:
     dtype = pl.List(pl.Enum(["a", "b", "c", "d"]))
     s1 = pl.Series([[None, "a"], ["b", "c"]], dtype=dtype)


### PR DESCRIPTION
Resolves #14962.

Very minor addition to the API, allows Enum data types to be unioned:

```python
import polars as pl

e1 = pl.Enum(["a", "b"])
e2 = pl.Enum(["b", "c"])

print(e1.union(e2))
# Enum(categories=['a', 'b', 'c'])

print(e1 | e2)
# Enum(categories=['a', 'b', 'c'])
```