### PR TITLE
chore(rust): make hive mod public

### DIFF
--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -24,7 +24,7 @@ pub(crate) mod debug;
 mod file_scan;
 mod format;
 mod functions;
-pub(super) mod hive;
+pub mod hive;
 pub(crate) mod iterator;
 mod lit;
 pub(crate) mod optimizer;


### PR DESCRIPTION
I want to construct the hive partitions myself using the polars delta stats but the mod is not public at the moment.