### PR TITLE
ci(python): Revert pinning PyPI publish action

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -210,8 +210,7 @@ jobs:
 
       - name: Publish to PyPI
         if: inputs.dry-run == false
-        # Pinned to commit to circumvent an issue with the v1.8.12 release
-        uses: pypa/gh-action-pypi-publish@aec4e82833d00547d2c8e4744a0d08766a02629a
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           verbose: true
 


### PR DESCRIPTION
Reverts pola-rs/polars#14896

A new release of the action is available, so no longer need to pin it:
https://github.com/pypa/gh-action-pypi-publish/pull/219#issuecomment-1984785707