### PR TITLE
feat: expose timings in verbose state of OOC sort

### DIFF
--- a/crates/polars-pipe/src/executors/sinks/mod.rs
+++ b/crates/polars-pipe/src/executors/sinks/mod.rs
@@ -9,6 +9,8 @@ mod slice;
 mod sort;
 mod utils;
 
+use std::sync::OnceLock;
+
 pub(crate) use joins::*;
 pub(crate) use ordered::*;
 #[cfg(any(
@@ -26,15 +28,16 @@ pub(crate) use sort::*;
 // Overallocation seems a lot more expensive than resizing so we start reasonable small.
 const HASHMAP_INIT_SIZE: usize = 64;
 
-pub(crate) static POLARS_TEMP_DIR: &str = "POLARS_TEMP_DIR";
+pub(crate) static POLARS_TEMP_DIR: OnceLock<String> = OnceLock::new();
 
-pub(crate) fn get_base_temp_dir() -> String {
-    let base_dir = std::env::var(POLARS_TEMP_DIR)
-        .unwrap_or_else(|_| std::env::temp_dir().to_string_lossy().into_owned());
+pub(crate) fn get_base_temp_dir() -> &'static str {
+    POLARS_TEMP_DIR.get_or_init(|| {
+        let tmp = std::env::var("POLARS_TEMP_DIR")
+            .unwrap_or_else(|_| std::env::temp_dir().to_string_lossy().into_owned());
 
-    if polars_core::config::verbose() {
-        eprintln!("Temporary directory path in use: {}", base_dir);
-    }
-
-    base_dir
+        if polars_core::config::verbose() {
+            eprintln!("Temporary directory path in use: {}", &tmp);
+        }
+        tmp
+    })
 }

--- a/crates/polars-pipe/src/executors/sinks/sort/ooc.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/ooc.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::time::Instant;
 
 use crossbeam_queue::SegQueue;
 use polars_core::prelude::*;
@@ -104,6 +105,7 @@ impl PartitionSpiller {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn sort_ooc(
     io_thread: IOThread,
     // these partitions are the samples
@@ -114,7 +116,9 @@ pub(super) fn sort_ooc(
     slice: Option<(i64, usize)>,
     verbose: bool,
     memtrack: MemTracker,
+    ooc_start: Instant,
 ) -> PolarsResult<FinalizedSink> {
+    let now = Instant::now();
     let samples = samples.to_physical_repr().into_owned();
     // Try to use available memory. At least 32MB per spill.
     let spill_size = std::cmp::max(memtrack.get_available() / (samples.len() * 2), 1 << 25) as u64;
@@ -154,9 +158,12 @@ pub(super) fn sort_ooc(
             PolarsResult::Ok(())
         })
     })?;
+    if verbose {
+        eprintln!("partitioning sort took: {:?}", now.elapsed());
+    }
     partitions_spiller.spill_all(&io_thread);
     if verbose {
-        eprintln!("finished partitioning sort files");
+        eprintln!("spilling all partitioned files took: {:?}", now.elapsed());
     }
 
     let files = std::fs::read_dir(dir)?
@@ -176,7 +183,9 @@ pub(super) fn sort_ooc(
         })
         .collect::<std::io::Result<Vec<_>>>()?;
 
-    let source = SortSource::new(files, idx, descending, slice, verbose, io_thread, memtrack);
+    let source = SortSource::new(
+        files, idx, descending, slice, verbose, io_thread, memtrack, ooc_start,
+    );
     Ok(FinalizedSink::Source(Box::new(source)))
 }
 


### PR DESCRIPTION
```
OOC sort started
Temporary directory path in use: temp
run UdfExec
RUN STREAMING PIPELINE
parquet -> sort -> parquet_sink
RefCell { value: [] }
STREAMING CHUNK SIZE: 2941 rows
finished sinking into OOC sort in 3.982244806s
full file dump of OOC sort took 5.155624213s
processing 245 files
partitioning sort took: 5.063799475s
spilling all partitioned files took: 7.694338058s
started sort source phase
sort source phase took: 3.780204067s
full ooc sort took: 16.632243722s
```

Shows we are twiddling thumbs waiting for all files to be spilled. We probably can do something useful in that time.