### PR TITLE
clippy:assigning_clones

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/mod.rs
@@ -44,7 +44,7 @@ pub struct Logical<Logical: PolarsDataType, Physical: PolarsDataType>(
 impl<K: PolarsDataType, T: PolarsDataType> Clone for Logical<K, T> {
     fn clone(&self) -> Self {
         let mut new = Logical::<K, _>::new_logical(self.0.clone());
-        new.2 = self.2.clone();
+        new.2.clone_from(&self.2);
         new
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/append.rs
+++ b/crates/polars-core/src/chunked_array/ops/append.rs
@@ -4,7 +4,7 @@ use crate::series::IsSorted;
 pub(crate) fn new_chunks(chunks: &mut Vec<ArrayRef>, other: &[ArrayRef], len: usize) {
     // Replace an empty array.
     if chunks.len() == 1 && len == 0 {
-        *chunks = other.to_owned();
+        other.clone_into(chunks);
     } else {
         for chunk in other {
             if chunk.len() > 0 {

--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -933,7 +933,7 @@ impl DataFrame {
                 "unable to append to a DataFrame of width {} with a DataFrame of width {}",
                 self.width(), other.width(),
             );
-            self.columns = other.columns.clone();
+            self.columns.clone_from(&other.columns);
             return Ok(self);
         }
 

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1942,7 +1942,7 @@ impl JoinBuilder {
     /// The passed expressions must be valid in both `LazyFrame`s in the join.
     pub fn on<E: AsRef<[Expr]>>(mut self, on: E) -> Self {
         let on = on.as_ref().to_vec();
-        self.left_on = on.clone();
+        self.left_on.clone_from(&on);
         self.right_on = on;
         self
     }

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/first.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/first.rs
@@ -55,7 +55,7 @@ impl AggregateFn for FirstAgg {
     fn combine(&mut self, other: &dyn Any) {
         let other = unsafe { other.downcast_ref::<Self>().unwrap_unchecked_release() };
         if other.first.is_some() && other.chunk_idx < self.chunk_idx {
-            self.first = other.first.clone();
+            self.first.clone_from(&other.first);
             self.chunk_idx = other.chunk_idx;
         };
     }

--- a/crates/polars-pipe/src/executors/sinks/group_by/aggregates/last.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/aggregates/last.rs
@@ -52,7 +52,7 @@ impl AggregateFn for LastAgg {
     fn combine(&mut self, other: &dyn Any) {
         let other = unsafe { other.downcast_ref::<Self>().unwrap_unchecked_release() };
         if other.last.is_some() && other.chunk_idx >= self.chunk_idx {
-            self.last = other.last.clone();
+            self.last.clone_from(&other.last);
             self.chunk_idx = other.chunk_idx;
         };
     }


### PR DESCRIPTION
warning: assigning the result of `ToOwned::to_owned()` may be inefficient
 --> crates/polars-core/src/chunked_array/ops/append.rs:7:9
  |
7 |         *chunks = other.to_owned();
  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_into()`: `other.clone_into(chunks)`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
  = note: `-W clippy::assigning-clones` implied by `-W clippy::perf`
  = help: to override `-W clippy::perf` add `#[allow(clippy::assigning_clones)]`

warning: assigning the result of `Clone::clone()` may be inefficient
  --> crates/polars-core/src/chunked_array/logical/mod.rs:47:9
   |
47 |         new.2 = self.2.clone();
   |         ^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `new.2.clone_from(&self.2)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones

warning: assigning the result of `Clone::clone()` may be inefficient
   --> crates/polars-core/src/frame/mod.rs:936:13
    |
936 |             self.columns = other.columns.clone();
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `self.columns.clone_from(&other.columns)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones

warning: `polars-plan` (lib) generated 6 warnings
warning: assigning the result of `Clone::clone()` may be inefficient
  --> crates/polars-pipe/src/executors/sinks/group_by/aggregates/first.rs:58:13
   |
58 |             self.first = other.first.clone();
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `self.first.clone_from(&other.first)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
   = note: `-W clippy::assigning-clones` implied by `-W clippy::perf`
   = help: to override `-W clippy::perf` add `#[allow(clippy::assigning_clones)]`

warning: assigning the result of `Clone::clone()` may be inefficient
  --> crates/polars-pipe/src/executors/sinks/group_by/aggregates/last.rs:55:13
   |
55 |             self.last = other.last.clone();
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `self.last.clone_from(&other.last)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones

warning: `polars-pipe` (lib) generated 2 warnings (run `cargo clippy --fix --lib -p polars-pipe` to apply 2 suggestions) warning: assigning the result of `Clone::clone()` may be inefficient
    --> crates/polars-lazy/src/frame/mod.rs:1945:9
     |
1945 |         self.left_on = on.clone();
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_from()`: `self.left_on.clone_from(&on)`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
     = note: `-W clippy::assigning-clones` implied by `-W clippy::perf`
     = help: to override `-W clippy::perf` add `#[allow(clippy::assigning_clones)]`