### PR TITLE
fix(python): Use primitive constructors to create a Series of lists when dtype is provided

### DIFF
--- a/py-polars/polars/_utils/construction.py
+++ b/py-polars/polars/_utils/construction.py
@@ -605,7 +605,7 @@ def sequence_to_pyseries(
                     py_srs = [
                         None
                         if value is None
-                        else sequence_to_pyseries("", value, inner_dtype, strict=strict)
+                        else sequence_to_pyseries("", value, inner_dtype, strict=strict, nan_to_null=nan_to_null)
                         for value in values
                     ]
                     srs = PySeries.new_series_list(name, py_srs, strict)

--- a/py-polars/polars/_utils/construction.py
+++ b/py-polars/polars/_utils/construction.py
@@ -605,7 +605,13 @@ def sequence_to_pyseries(
                     py_srs = [
                         None
                         if value is None
-                        else sequence_to_pyseries("", value, inner_dtype, strict=strict, nan_to_null=nan_to_null)
+                        else sequence_to_pyseries(
+                            "",
+                            value,
+                            inner_dtype,
+                            strict=strict,
+                            nan_to_null=nan_to_null,
+                        )
                         for value in values
                     ]
                     srs = PySeries.new_series_list(name, py_srs, strict)

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -23,15 +23,20 @@ def test_dtype() -> None:
     assert a.dtype.is_(pl.List(pl.Int64))
 
     # explicit
+    u64_max = (2**64) - 1
     df = pl.DataFrame(
         data={
             "i": [[1, 2, 3]],
+            "li": [[[1, 2, 3]]],
+            "u": [[u64_max]],
             "tm": [[time(10, 30, 45)]],
             "dt": [[date(2022, 12, 31)]],
             "dtm": [[datetime(2022, 12, 31, 1, 2, 3)]],
         },
         schema=[
             ("i", pl.List(pl.Int8)),
+            ("li", pl.List(pl.List(pl.Int8))),
+            ("u", pl.List(pl.UInt64)),
             ("tm", pl.List(pl.Time)),
             ("dt", pl.List(pl.Date)),
             ("dtm", pl.List(pl.Datetime)),
@@ -39,6 +44,8 @@ def test_dtype() -> None:
     )
     assert df.schema == {
         "i": pl.List(pl.Int8),
+        "li": pl.List(pl.List(pl.Int8)),
+        "u": pl.List(pl.UInt64),
         "tm": pl.List(pl.Time),
         "dt": pl.List(pl.Date),
         "dtm": pl.List(pl.Datetime),
@@ -48,6 +55,8 @@ def test_dtype() -> None:
     assert df.rows() == [
         (
             [1, 2, 3],
+            [[1, 2, 3]],
+            [u64_max],
             [time(10, 30, 45)],
             [date(2022, 12, 31)],
             [datetime(2022, 12, 31, 1, 2, 3)],

--- a/py-polars/tests/unit/io/test_json.py
+++ b/py-polars/tests/unit/io/test_json.py
@@ -297,7 +297,7 @@ def test_write_json_duration() -> None:
         ([["a", "b"], [None, None]], pl.Array(pl.Utf8, width=2)),
         ([[True, False, None], [None, None, None]], pl.Array(pl.Utf8, width=3)),
         (
-            [[[1, 2, 3], [4, None]], None, [[None, None, 2]]],
+            [[[1, 2, 3], [4, None, 5]], None, [[None, None, 2]]],
             pl.List(pl.Array(pl.Int32(), width=3)),
         ),
         (

--- a/py-polars/tests/unit/series/test_describe.py
+++ b/py-polars/tests/unit/series/test_describe.py
@@ -117,7 +117,7 @@ def test_series_describe_null() -> None:
 def test_series_describe_nested_list() -> None:
     s = pl.Series(
         values=[[10e10, 10e15], [10e12, 10e13], [10e10, 10e15]],
-        dtype=pl.List(pl.Int64),
+        dtype=pl.List(pl.Float64),
     )
     result = s.describe()
     stats = {

--- a/py-polars/tests/unit/test_serde.py
+++ b/py-polars/tests/unit/test_serde.py
@@ -188,7 +188,7 @@ def test_serde_array_dtype() -> None:
     assert_series_equal(pickle.loads(pickle.dumps(s)), s)
 
     nested_s = pl.Series(
-        [[[1, 2, 3], [4, None]], None, [[None, None, 2]]],
+        [[[1, 2, 3], [4, None, 5]], None, [[None, None, 2]]],
         dtype=pl.List(pl.Array(pl.Int32(), width=3)),
     )
     assert_series_equal(pickle.loads(pickle.dumps(nested_s)), nested_s)


### PR DESCRIPTION
When a Series of lists is constructed, it uses the AnyValue interface even when the dtype is provided. Besides the performance implications, this often leads to incorrect results because even though the type is provided, it is inferred anyhow and then, if the inferred type differs from the provided type, the result is cast to the latter. 

Here are some examples of incorrect cases:


```python
import polars as pl

u64_max = (2**64) - 1

# Incorrect case (1)*

pl.Series("a", [[u64_max]], dtype=pl.List(pl.UInt64))
# OverflowError: Python int too large to convert to C long


# Incorrect case (2); similar to (1) but not the same

pl.Series("a", [[u64_max, 1]], dtype=pl.List(pl.UInt64))
# SchemaError: unexpected value while building Series of type Float64; found value of type UInt64: 18446744073709551615
```

*This case has been reported in #14277.

This PR changes the way a Series of lists is constructed when the dtype is provided, while still falling back to AnyValue when it is not. It does so by recursively applying `sequence_to_pyseries` to every inner sublist and eventually calling the primitive constructor, e.g., `PySeries.new_opt_u64`, that corresponds to the given dtype.

This results in:
1. Faster construction.
2. Fixing incorrect cases mentioned above.
3. Series of list construction inherits the same semantics (e.g., strictness) of the primitive constructors.


Note that I had to edit a couple of faulty test cases that emerged due to this change.

Partially closes #14277. The pl.Array case can be addressed in a separate PR.
