### PR TITLE
feat: Allow cast of decimal to boolean

### DIFF
--- a/crates/polars-arrow/src/compute/cast/mod.rs
+++ b/crates/polars-arrow/src/compute/cast/mod.rs
@@ -443,6 +443,7 @@ pub fn cast(
             Int64 => primitive_to_boolean_dyn::<i64>(array, to_type.clone()),
             Float32 => primitive_to_boolean_dyn::<f32>(array, to_type.clone()),
             Float64 => primitive_to_boolean_dyn::<f64>(array, to_type.clone()),
+            Decimal(_, _) => primitive_to_boolean_dyn::<i128>(array, to_type.clone()),
             _ => polars_bail!(InvalidOperation:
                 "casting from {from_type:?} to {to_type:?} not supported",
             ),

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -624,5 +624,11 @@ def test_cast_time_to_date() -> None:
 
 
 def test_cast_decimal() -> None:
-    s = pl.Series([Decimal(0), Decimal(1.5), Decimal(-1.5)])
-    assert_series_equal(s.cast(pl.Boolean), pl.Series([False, True, True]))
+    s = pl.Series("s", [Decimal(0), Decimal(1.5), Decimal(-1.5)])
+    assert_series_equal(s.cast(pl.Boolean), pl.Series("s", [False, True, True]))
+
+    df = s.to_frame()
+    assert_frame_equal(
+        df.select(pl.col("s").cast(pl.Boolean)),
+        pl.DataFrame({"s": [False, True, True]}),
+    )

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -620,3 +621,8 @@ def test_cast_time_to_date() -> None:
     msg = "cannot cast `Time` to `Date`"
     with pytest.raises(pl.ComputeError, match=msg):
         s.cast(pl.Date)
+
+
+def test_cast_decimal() -> None:
+    s = pl.Series([Decimal(0), Decimal(1.5), Decimal(-1.5)])
+    assert_series_equal(s.cast(pl.Boolean), pl.Series([False, True, True]))


### PR DESCRIPTION
Resolves #15012.

All other numeric types can cast to boolean, no reason decimal shouldn't either, it's perfectly well-defined.

OP's test now passes:

```python
# file: test_decimal_mask.py
from decimal import Decimal as Dec

import polars as pl
import pytest


@pytest.mark.parametrize(
    ("x", "y", "z"),
    [
        (1, 2, 3),
        (0, 2, 3),
        (0, 0, 0),
    ],
)
def test_cast_decimal_to_boolean(x, y, z):
    col = pl.Series("a", [Dec(str(x)), Dec(str(y)), Dec(str(z))])
    mask = col.cast(pl.Boolean)
    other_mask = pl.Series("a", [bool(x), bool(y), bool(z)])
    assert mask.dtype == pl.Boolean
    assert (mask == other_mask).all()
    assert mask.any() == any((x, y, z))
    assert mask.all() == all((x, y, z))
```
```
(.venv) mcrumiller@Saline-PC:~/projects/polars/py-polars/scripts$ pytest check_decimal.py
=============================================================================================================================================================== test session starts ===============================================================================================================================================================
platform linux -- Python 3.12.1, pytest-8.0.0, pluggy-1.4.0
rootdir: /home/mcrumiller/projects/polars/py-polars
configfile: pyproject.toml
plugins: hypothesis-6.97.4, cov-4.1.0, xdist-3.5.0
collected 3 items                                                                                                                                                                                                                                                                                                                                 

check_decimal.py ...                                                                                                                                                                                                                                                                                                                        [100%]

================================================================================================================================================================ 3 passed in 0.18s ================================================================================================================================================================
```