### PR TITLE
fix: Prevent "index out of range for slice" error in parquet reader

### DIFF
--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -608,10 +608,10 @@ impl BatchedParquetReader {
         if self.limit == 0 && self.has_returned {
             return if self.chunks_fifo.is_empty() {
                 Ok(None)
-            } else if self.chunks_fifo.len() < n {
-                Ok(Some(self.chunks_fifo.drain(..).collect()))
             } else {
-                Ok(Some(self.chunks_fifo.drain(..n).collect()))
+                // the range end point must not be greater than the length of the deque
+                let n_drainable = std::cmp::min(n, self.chunks_fifo.len());
+                Ok(Some(self.chunks_fifo.drain(..n_drainable).collect()))
             };
         }
 

--- a/crates/polars-io/src/parquet/read_impl.rs
+++ b/crates/polars-io/src/parquet/read_impl.rs
@@ -608,6 +608,8 @@ impl BatchedParquetReader {
         if self.limit == 0 && self.has_returned {
             return if self.chunks_fifo.is_empty() {
                 Ok(None)
+            } else if self.chunks_fifo.len() < n {
+                Ok(Some(self.chunks_fifo.drain(..).collect()))
             } else {
                 Ok(Some(self.chunks_fifo.drain(..n).collect()))
             };


### PR DESCRIPTION
Fixes #15020