### PR TITLE
feat: Add thread names to rayon thread pool

### DIFF
--- a/crates/polars-core/src/lib.rs
+++ b/crates/polars-core/src/lib.rs
@@ -47,6 +47,7 @@ pub static PROCESS_ID: Lazy<u128> = Lazy::new(|| {
 // this is re-exported in utils for polars child crates
 #[cfg(not(target_family = "wasm"))] // only use this on non wasm targets
 pub static POOL: Lazy<ThreadPool> = Lazy::new(|| {
+    let thread_name = std::env::var("POLARS_THREAD_NAME").unwrap_or_else(|_| "polars".to_string());
     ThreadPoolBuilder::new()
         .num_threads(
             std::env::var("POLARS_MAX_THREADS")
@@ -57,6 +58,7 @@ pub static POOL: Lazy<ThreadPool> = Lazy::new(|| {
                         .get()
                 }),
         )
+        .thread_name(move |i| format!("{}-{}", thread_name, i))
         .build()
         .expect("could not spawn threads")
 });


### PR DESCRIPTION
This adds names to the threads in the Rayon thread pool. They are configurable via the `POLARS_THREAD_NAME` environment variable and default to `polars-{thread_idx}`.

Example without and with the change:

<img width="769" alt="Screenshot 2024-03-12 at 4 48 03 PM" src="https://github.com/pola-rs/polars/assets/8592049/d830f809-3955-4751-a1b7-078b171d44f7">

<img width="594" alt="Screenshot 2024-03-12 at 5 15 57 PM" src="https://github.com/pola-rs/polars/assets/8592049/65f3ca5d-732e-4c26-b344-d3e994b9c7d2">
