### PR TITLE
feat(rust!): Return error when no supertype can be determined in AnyValue constructor when `strict=false`

### DIFF
--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -205,6 +205,7 @@ impl Series {
     ///   first non-null value. If any other non-null values do not match this
     ///   data type, an error is raised.
     /// - If `strict` is `false`, the data type is the supertype of the `values`.
+    ///   An error is returned if no supertype can be determined.
     ///   **WARNING**: A full pass over the values is required to determine the supertype.
     /// - If no values were passed, the resulting data type is `Null`.
     pub fn from_any_values(name: &str, values: &[AnyValue], strict: bool) -> PolarsResult<Self> {

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -204,10 +204,10 @@ impl Series {
     /// - If `strict` is `true`, the data type is equal to the data type of the
     ///   first non-null value. If any other non-null values do not match this
     ///   data type, an error is raised.
-    /// - If `strict` is `false`, the data type is the supertype of the
-    ///   `values`. **WARNING**: A full pass over the values is required to
-    ///   determine the supertype. Values encountered that do not match the
-    ///   supertype are set to null.
+    /// - If `strict` is `false`, the data type is the supertype of the `values`,
+    ///   or `Object` if no supertype was found. If the "object" feature is not enabled,
+    ///   values encountered that do not match the supertype are set to null.
+    ///   **WARNING**: A full pass over the values is required to determine the supertype.
     /// - If no values were passed, the resulting data type is `Null`.
     pub fn from_any_values(name: &str, values: &[AnyValue], strict: bool) -> PolarsResult<Self> {
         fn get_first_non_null_dtype(values: &[AnyValue]) -> DataType {
@@ -239,7 +239,11 @@ impl Series {
                 if dtypes.insert(av.dtype()) {
                     match get_supertype(&supertype, &av.dtype()) {
                         Some(st) => supertype = st,
-                        None => return DataType::Object("", None),
+                        None =>
+                        {
+                            #[cfg(feature = "object")]
+                            return DataType::Object("", None)
+                        },
                     }
                 }
             }

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -237,9 +237,9 @@ impl Series {
             let mut dtypes = PlHashSet::<DataType>::new();
             for av in values {
                 if dtypes.insert(av.dtype()) {
-                    // Values with incompatible data types will be set to null later
-                    if let Some(st) = get_supertype(&supertype, &av.dtype()) {
-                        supertype = st;
+                    match get_supertype(&supertype, &av.dtype()) {
+                        Some(st) => supertype = st,
+                        None => return DataType::Object("", None),
                     }
                 }
             }

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -237,6 +237,7 @@ impl Series {
             let mut dtypes = PlHashSet::<DataType>::new();
             for av in values {
                 if dtypes.insert(av.dtype()) {
+                    #[allow(clippy::single_match)]
                     match get_supertype(&supertype, &av.dtype()) {
                         Some(st) => supertype = st,
                         None =>

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -1,7 +1,7 @@
 use std::fmt::Write;
 
 use crate::prelude::*;
-use crate::utils::get_supertype;
+use crate::utils::try_get_supertype;
 
 impl<'a, T: AsRef<[AnyValue<'a>]>> NamedFrom<T, [AnyValue<'a>]> for Series {
     fn new(name: &str, v: T) -> Self {
@@ -204,9 +204,7 @@ impl Series {
     /// - If `strict` is `true`, the data type is equal to the data type of the
     ///   first non-null value. If any other non-null values do not match this
     ///   data type, an error is raised.
-    /// - If `strict` is `false`, the data type is the supertype of the `values`,
-    ///   or `Object` if no supertype was found. If the "object" feature is not enabled,
-    ///   values encountered that do not match the supertype are set to null.
+    /// - If `strict` is `false`, the data type is the supertype of the `values`.
     ///   **WARNING**: A full pass over the values is required to determine the supertype.
     /// - If no values were passed, the resulting data type is `Null`.
     pub fn from_any_values(name: &str, values: &[AnyValue], strict: bool) -> PolarsResult<Self> {
@@ -232,29 +230,28 @@ impl Series {
                 },
             }
         }
-        fn get_any_values_supertype(values: &[AnyValue]) -> DataType {
+        fn get_any_values_supertype(values: &[AnyValue]) -> PolarsResult<DataType> {
             let mut supertype = DataType::Null;
             let mut dtypes = PlHashSet::<DataType>::new();
             for av in values {
                 if dtypes.insert(av.dtype()) {
-                    #[allow(clippy::single_match)]
-                    match get_supertype(&supertype, &av.dtype()) {
-                        Some(st) => supertype = st,
-                        None =>
-                        {
-                            #[cfg(feature = "object")]
-                            return DataType::Object("", None)
-                        },
-                    }
+                    supertype = try_get_supertype(&supertype, &av.dtype()).map_err(|_| {
+                            polars_err!(
+                                SchemaMismatch:
+                                "failed to infer supertype of values; partial supertype is {:?}, found value of type {:?}: {}",
+                                supertype, av.dtype(), av
+                            )
+                        }
+                    )?;
                 }
             }
-            supertype
+            Ok(supertype)
         }
 
         let dtype = if strict {
             get_first_non_null_dtype(values)
         } else {
-            get_any_values_supertype(values)
+            get_any_values_supertype(values)?
         };
         Self::from_any_values_and_dtype(name, values, &dtype, strict)
     }

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -85,3 +85,73 @@ def test_fallback_with_dtype_nonstrict(
         PySeries.new_from_any_values_and_dtype("", values, dtype, strict=False)
     )
     assert result.to_list() == expected
+
+
+@pytest.mark.parametrize(
+    ("values", "expected_dtype"),
+    [
+        ([-1, 0, 100_000, None], pl.Int64),
+        ([-1.5, 0.0, 10.0, None], pl.Float64),
+        ([True, False, None], pl.Boolean),
+        ([b"123", b"xyz", None], pl.Binary),
+        (["123", "xyz", None], pl.String),
+    ],
+)
+def test_fallback_without_dtype_strict(
+    values: list[Any], expected_dtype: pl.PolarsDataType
+) -> None:
+    result = wrap_s(PySeries.new_from_any_values("", values, strict=True))
+    assert result.to_list() == values
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        [1.0, 2],
+        [1, 2.0],
+        [False, 1],
+        [b"123", "xyz"],
+        ["123", b"xyz"],
+    ],
+)
+def test_fallback_without_dtype_strict_failure(values: list[Any]) -> None:
+    with pytest.raises(pl.SchemaError, match="unexpected value"):
+        PySeries.new_from_any_values("", values, strict=True)
+
+
+@pytest.mark.parametrize(
+    ("values", "expected_dtype"),
+    [
+        ([-1, 0, 100_000, None], pl.Int64),
+        ([-1.5, 0.0, 10.0, None], pl.Float64),
+        ([True, False, None], pl.Boolean),
+        ([b"123", b"xyz", None], pl.Binary),
+        (["123", "xyz", None], pl.String),
+    ],
+)
+def test_fallback_without_dtype_nonstrict_single_type(
+    values: list[Any],
+    expected_dtype: pl.PolarsDataType,
+) -> None:
+    result = wrap_s(PySeries.new_from_any_values("", values, strict=False))
+    assert result.dtype == expected_dtype
+    assert result.to_list() == values
+
+
+@pytest.mark.parametrize(
+    ("values", "expected", "expected_dtype"),
+    [
+        ([True, 2], [1, 2], pl.Int64),
+        ([1, 2.0], [1.0, 2.0], pl.Float64),
+        ([2.0, "c"], ["2.0", "c"], pl.String),
+        ([2.0, b"d", date(2022, 1, 1)], [2.0, b"d", date(2022, 1, 1)], pl.Object),
+    ],
+)
+def test_fallback_without_dtype_nonstrict_mixed_types(
+    values: list[Any],
+    expected_dtype: pl.PolarsDataType,
+    expected: list[Any],
+) -> None:
+    result = wrap_s(PySeries.new_from_any_values("", values, strict=False))
+    assert result.dtype == expected_dtype
+    assert result.to_list() == expected

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -144,7 +144,6 @@ def test_fallback_without_dtype_nonstrict_single_type(
         ([True, 2], [1, 2], pl.Int64),
         ([1, 2.0], [1.0, 2.0], pl.Float64),
         ([2.0, "c"], ["2.0", "c"], pl.String),
-        ([2.0, b"d", date(2022, 1, 1)], [2.0, b"d", date(2022, 1, 1)], pl.Object),
     ],
 )
 def test_fallback_without_dtype_nonstrict_mixed_types(
@@ -155,3 +154,9 @@ def test_fallback_without_dtype_nonstrict_mixed_types(
     result = wrap_s(PySeries.new_from_any_values("", values, strict=False))
     assert result.dtype == expected_dtype
     assert result.to_list() == expected
+
+
+def test_fallback_without_dtype_nonstrict_no_supertype() -> None:
+    values = [1, 2.0, b"d", date(2022, 1, 1)]
+    with pytest.raises(pl.SchemaError, match="failed to infer supertype of values"):
+        PySeries.new_from_any_values("", values, strict=False)


### PR DESCRIPTION
This does not impact the Python side as the Python constructors do not end up in this code (yet).

This more closely resembles existing behavior on the Python side - data with mixed types and no valid supertype are read as Object types.