### PR TITLE
feat(python): Add `require_all` parameter to the `by_name` column selector

### DIFF
--- a/py-polars/tests/unit/test_selectors.py
+++ b/py-polars/tests/unit/test_selectors.py
@@ -2,10 +2,9 @@ import sys
 from datetime import datetime
 from typing import Any
 
-import pytest
-
 import polars as pl
 import polars.selectors as cs
+import pytest
 from polars.dependencies import _ZONEINFO_AVAILABLE
 from polars.exceptions import ColumnNotFoundError
 from polars.selectors import expand_selector, is_selector
@@ -130,6 +129,9 @@ def test_selector_by_name(df: pl.DataFrame) -> None:
     assert df.select(cs.by_name()).columns == []
     assert df.select(cs.by_name([])).columns == []
 
+    selected_cols = df.select(cs.by_name("???", "fgg", "!!!", match_any=True)).columns
+    assert selected_cols == ["fgg"]
+
     # check "by_name & col"
     for selector_expr in (
         cs.by_name("abc", "cde") & pl.col("ghi"),
@@ -138,6 +140,9 @@ def test_selector_by_name(df: pl.DataFrame) -> None:
         assert df.select(selector_expr).columns == ["abc", "cde", "ghi"]
 
     # expected errors
+    with pytest.raises(ColumnNotFoundError, match="xxx"):
+        df.select(cs.by_name("xxx", "fgg", "!!!"))
+
     with pytest.raises(ColumnNotFoundError):
         df.select(cs.by_name("stroopwafel"))
 
@@ -494,7 +499,16 @@ def test_selector_repr() -> None:
     assert_repr_equals(~cs.starts_with("a", "b"), "~cs.starts_with('a', 'b')")
     assert_repr_equals(cs.float() | cs.by_name("x"), "(cs.float() | cs.by_name('x'))")
     assert_repr_equals(
-        cs.integer() & cs.matches("z"), "(cs.integer() & cs.matches(pattern='z'))"
+        cs.integer() & cs.matches("z"),
+        "(cs.integer() & cs.matches(pattern='z'))",
+    )
+    assert_repr_equals(
+        cs.by_name("baz", "moose", "foo", "bear"),
+        "cs.by_name('baz', 'moose', 'foo', 'bear')",
+    )
+    assert_repr_equals(
+        cs.by_name("baz", "moose", "foo", "bear", match_any=True),
+        "cs.by_name('baz', 'moose', 'foo', 'bear', match_any=True)",
     )
     assert_repr_equals(
         cs.temporal() | cs.by_dtype(pl.String) & cs.string(include_categorical=False),


### PR DESCRIPTION
Closes #15023.
Closes #16219.

Adds a new (opt-in) "match_any" param to the `by_name` selector.
Default behaviour remains unchanged.

_**Update:** have changed the parameter name from "any" (and then "match_any"), to "require_all" and adjusted the default value accordingly :sunglasses:_

## Before

Default behaviour; expect _all_ given columns to be present:
```python
import polars as pl
import polars.selectors as cs

df = pl.DataFrame({
    "foo": ["x", "y"],
    "bar": [123, 456],
    "baz": [2.0, 5.5],
})
```
```python
df.select( cs.by_name("stroopwafel","baz","!!") )
# ColumnNotFoundError: stroopwafel
```

## After

Enable permissive matching on _any_ of the given columns:
```python
df.select( cs.by_name("stroopwafel","baz","!!", require_all=False) )
# shape: (2, 1)
# ┌─────┐
# │ baz │
# │ --- │
# │ f64 │
# ╞═════╡
# │ 2.0 │
# │ 5.5 │
# └─────┘
```