### PR TITLE
feat!: Update some error types to more appropriate variants

### DIFF
--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -430,7 +430,7 @@ fn any_values_to_decimal(
             continue;
         } else {
             polars_bail!(
-                ComputeError: "unable to convert any-value of dtype {} to decimal", av.dtype(),
+                SchemaMismatch: "unable to convert any-value of dtype {} to decimal", av.dtype(),
             );
         };
         scale_range = match scale_range {
@@ -448,7 +448,7 @@ fn any_values_to_decimal(
         // Scale is provided but is lower than actual.
         // TODO: Do we want lossy conversions here or not?
         polars_bail!(
-            ComputeError:
+            SchemaMismatch:
             "unable to losslessly convert any-value of scale {s_max} to scale {}", scale,
         );
     }
@@ -473,7 +473,7 @@ fn any_values_to_decimal(
         } else {
             let factor = 10_i128.pow((scale - s_av) as _); // this cast is safe
             builder.append_value(v.checked_mul(factor).ok_or_else(|| {
-                polars_err!(ComputeError: "overflow while converting to decimal scale {}", scale)
+                polars_err!(SchemaMismatch: "overflow while converting to decimal scale {}", scale)
             })?);
         }
     }
@@ -723,7 +723,7 @@ fn any_values_to_object(
                     AnyValue::Object(val) => builder.append_value(val.as_any()),
                     AnyValue::Null => builder.append_null(),
                     _ => {
-                        polars_bail!(ComputeError: "expected object");
+                        polars_bail!(SchemaMismatch: "expected object");
                     },
                 }
             }

--- a/crates/polars-core/src/utils/supertype.rs
+++ b/crates/polars-core/src/utils/supertype.rs
@@ -7,7 +7,7 @@ use super::*;
 /// Returns a [`PolarsError::ComputeError`] if no such data type exists.
 pub fn try_get_supertype(l: &DataType, r: &DataType) -> PolarsResult<DataType> {
     get_supertype(l, r).ok_or_else(
-        || polars_err!(ComputeError: "failed to determine supertype of {} and {}", l, r),
+        || polars_err!(SchemaMismatch: "failed to determine supertype of {} and {}", l, r),
     )
 }
 

--- a/py-polars/tests/unit/functions/range/test_datetime_range.py
+++ b/py-polars/tests/unit/functions/range/test_datetime_range.py
@@ -7,7 +7,7 @@ import pytest
 
 import polars as pl
 from polars.datatypes import DTYPE_TEMPORAL_UNITS
-from polars.exceptions import ComputeError, TimeZoneAwareConstructorWarning
+from polars.exceptions import TimeZoneAwareConstructorWarning
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -176,7 +176,7 @@ def test_timezone_aware_datetime_range() -> None:
     ]
 
     with pytest.raises(
-        ComputeError,
+        pl.SchemaError,
         match="failed to determine supertype",
     ):
         pl.datetime_range(

--- a/py-polars/tests/unit/operations/test_transpose.py
+++ b/py-polars/tests/unit/operations/test_transpose.py
@@ -5,7 +5,7 @@ from typing import Iterator
 import pytest
 
 import polars as pl
-from polars.exceptions import ComputeError, StringCacheMismatchError
+from polars.exceptions import StringCacheMismatchError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 
@@ -31,7 +31,7 @@ def test_transpose_tz_naive_and_tz_aware() -> None:
     )
     df = df.with_columns(pl.col("b").dt.replace_time_zone("Asia/Kathmandu"))
     with pytest.raises(
-        ComputeError,
+        pl.SchemaError,
         match=r"failed to determine supertype of datetime\[μs\] and datetime\[μs, Asia/Kathmandu\]",
     ):
         df.transpose()

--- a/py-polars/tests/unit/test_errors.py
+++ b/py-polars/tests/unit/test_errors.py
@@ -310,7 +310,7 @@ def test_duplicate_columns_arg_csv() -> None:
 
 
 def test_datetime_time_add_err() -> None:
-    with pytest.raises(pl.ComputeError):
+    with pytest.raises(pl.SchemaError, match="failed to determine supertype"):
         pl.Series([datetime(1970, 1, 1, 0, 0, 1)]) + pl.Series([time(0, 0, 2)])
 
 


### PR DESCRIPTION
Closes #16440

Data type-related failures should raise a `SchemaError`. We often use a ComputeError instead, which is not as informative.

#### Example

**Before**

```pycon
>>> from datetime import datetime, time
>>> s1 = pl.Series([datetime(1970, 1, 1, 0, 0, 1)])
>>> s2 = pl.Series([time(0, 0, 2)])
>>> s1 + s2
Traceback (most recent call last):
...
polars.exceptions.ComputeError: failed to determine supertype of datetime[μs] and time
```

**After**

```pycon
>>> s1 + s2
Traceback (most recent call last):
...
polars.exceptions.SchemaError: failed to determine supertype of datetime[μs] and time
```