### PR TITLE
feat(python): Add `strict` parameter to `DataFrame` constructor to allow non-strict construction

### DIFF
--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -205,9 +205,9 @@ impl Series {
     ///   first non-null value. If any other non-null values do not match this
     ///   data type, an error is raised.
     /// - If `strict` is `false`, the data type is the supertype of the
-    ///   `values`, or `Object` if no supertype can be found.
-    ///   **WARNING**: A full pass over the values is required to determine the
-    ///   supertype. Values encountered that do not match the supertype are set to null.
+    ///   `values`. **WARNING**: A full pass over the values is required to
+    ///   determine the supertype. Values encountered that do not match the
+    ///   supertype are set to null.
     /// - If no values were passed, the resulting data type is `Null`.
     pub fn from_any_values(name: &str, values: &[AnyValue], strict: bool) -> PolarsResult<Self> {
         fn get_first_non_null_dtype(values: &[AnyValue]) -> DataType {

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -205,9 +205,9 @@ impl Series {
     ///   first non-null value. If any other non-null values do not match this
     ///   data type, an error is raised.
     /// - If `strict` is `false`, the data type is the supertype of the
-    ///   `values`. **WARNING**: A full pass over the values is required to
-    ///   determine the supertype. Values encountered that do not match the
-    ///   supertype are set to null.
+    ///   `values`, or `Object` if no supertype can be found.
+    ///   **WARNING**: A full pass over the values is required to determine the
+    ///   supertype. Values encountered that do not match the supertype are set to null.
     /// - If no values were passed, the resulting data type is `Null`.
     pub fn from_any_values(name: &str, values: &[AnyValue], strict: bool) -> PolarsResult<Self> {
         fn get_first_non_null_dtype(values: &[AnyValue]) -> DataType {

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -244,9 +244,9 @@ class DataFrame:
 
     Notes
     -----
-    Some methods internally convert the DataFrame into a LazyFrame before collecting
-    the results back into a DataFrame. This can lead to unexpected behavior when using
-    a subclassed DataFrame. For example,
+    Polars explicitly does not support subclassing of its core data types. See
+    the following GitHub issue for possible workarounds:
+    https://github.com/pola-rs/polars/issues/2846#issuecomment-1711799869
 
     Examples
     --------
@@ -349,17 +349,6 @@ class DataFrame:
     │ 1   ┆ 2   ┆ 3   │
     │ 4   ┆ 5   ┆ 6   │
     └─────┴─────┴─────┘
-
-    Notes
-    -----
-    Some methods internally convert the DataFrame into a LazyFrame before collecting
-    the results back into a DataFrame. This can lead to unexpected behavior when using
-    a subclassed DataFrame. For example,
-
-    >>> class MyDataFrame(pl.DataFrame):
-    ...     pass
-    >>> isinstance(MyDataFrame().lazy().collect(), MyDataFrame)
-    False
     """
 
     _df: PyDataFrame

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -395,13 +395,14 @@ class DataFrame:
                 data,
                 schema=schema,
                 schema_overrides=schema_overrides,
+                strict=strict,
                 orient=orient,
                 infer_schema_length=infer_schema_length,
             )
 
         elif isinstance(data, pl.Series):
             self._df = series_to_pydf(
-                data, schema=schema, schema_overrides=schema_overrides
+                data, schema=schema, schema_overrides=schema_overrides, strict=strict
             )
 
         elif _check_for_numpy(data) and isinstance(data, np.ndarray):
@@ -409,18 +410,19 @@ class DataFrame:
                 data,
                 schema=schema,
                 schema_overrides=schema_overrides,
+                strict=strict,
                 orient=orient,
                 nan_to_null=nan_to_null,
             )
 
         elif _check_for_pyarrow(data) and isinstance(data, pa.Table):
             self._df = arrow_to_pydf(
-                data, schema=schema, schema_overrides=schema_overrides
+                data, schema=schema, schema_overrides=schema_overrides, strict=strict
             )
 
         elif _check_for_pandas(data) and isinstance(data, pd.DataFrame):
             self._df = pandas_to_pydf(
-                data, schema=schema, schema_overrides=schema_overrides
+                data, schema=schema, schema_overrides=schema_overrides, strict=strict
             )
 
         elif not isinstance(data, Sized) and isinstance(data, (Generator, Iterable)):
@@ -428,13 +430,14 @@ class DataFrame:
                 data,
                 schema=schema,
                 schema_overrides=schema_overrides,
+                strict=strict,
                 orient=orient,
                 infer_schema_length=infer_schema_length,
             )
 
         elif isinstance(data, pl.DataFrame):
             self._df = dataframe_to_pydf(
-                data, schema=schema, schema_overrides=schema_overrides
+                data, schema=schema, schema_overrides=schema_overrides, strict=strict
             )
         else:
             msg = (

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -205,7 +205,8 @@ class DataFrame:
         Two-dimensional data in various forms; dict input must contain Sequences,
         Generators, or a `range`. Sequence may contain Series or other Sequences.
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
-        The DataFrame schema may be declared in several ways:
+        The schema of the resulting DataFrame. The schema may be declared in several
+        ways:
 
         * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
         * As a list of column names; in this case types are automatically inferred.
@@ -214,6 +215,8 @@ class DataFrame:
         If you supply a list of column names that does not match the names in the
         underlying data, the names given here will overwrite them. The number
         of names given in the schema should match the underlying data dimensions.
+
+        If set to `None` (default), the schema is inferred from the data.
     schema_overrides : dict, default None
         Support type specification or override of one or more columns; note that
         any dtypes inferred from the schema param will be overridden.
@@ -221,6 +224,11 @@ class DataFrame:
         The number of entries in the schema should match the underlying data
         dimensions, unless a sequence of dictionaries is being passed, in which case
         a *partial* schema can be declared to prevent specific fields from being loaded.
+    strict : bool, default True
+        Throw an error if any `data` value does not exactly match the given or inferred
+        data type for that column. If set to `False`, values that do not match the data
+        type are cast to that data type or, if casting is not possible, set to null
+        instead.
     orient : {'col', 'row'}, default None
         Whether to interpret two-dimensional data as columns or as rows. If None,
         the orientation is inferred by matching the columns and data dimensions. If
@@ -233,6 +241,12 @@ class DataFrame:
     nan_to_null : bool, default False
         If the data comes from one or more numpy arrays, can optionally convert input
         data np.nan values to null instead. This is a no-op for all other input data.
+
+    Notes
+    -----
+    Some methods internally convert the DataFrame into a LazyFrame before collecting
+    the results back into a DataFrame. This can lead to unexpected behavior when using
+    a subclassed DataFrame. For example,
 
     Examples
     --------
@@ -357,6 +371,7 @@ class DataFrame:
         schema: SchemaDefinition | None = None,
         *,
         schema_overrides: SchemaDict | None = None,
+        strict: bool = True,
         orient: Orientation | None = None,
         infer_schema_length: int | None = N_INFER_DEFAULT,
         nan_to_null: bool = False,
@@ -371,6 +386,7 @@ class DataFrame:
                 data,
                 schema=schema,
                 schema_overrides=schema_overrides,
+                strict=strict,
                 nan_to_null=nan_to_null,
             )
 

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -166,6 +166,11 @@ class LazyFrame:
         The number of entries in the schema should match the underlying data
         dimensions, unless a sequence of dictionaries is being passed, in which case
         a *partial* schema can be declared to prevent specific fields from being loaded.
+    strict : bool, default True
+        Throw an error if any `data` value does not exactly match the given or inferred
+        data type for that column. If set to `False`, values that do not match the data
+        type are cast to that data type or, if casting is not possible, set to null
+        instead.
     orient : {'col', 'row'}, default None
         Whether to interpret two-dimensional data as columns or as rows. If None,
         the orientation is inferred by matching the columns and data dimensions. If
@@ -295,6 +300,7 @@ class LazyFrame:
         schema: SchemaDefinition | None = None,
         *,
         schema_overrides: SchemaDict | None = None,
+        strict: bool = True,
         orient: Orientation | None = None,
         infer_schema_length: int | None = N_INFER_DEFAULT,
         nan_to_null: bool = False,
@@ -306,6 +312,7 @@ class LazyFrame:
                 data=data,
                 schema=schema,
                 schema_overrides=schema_overrides,
+                strict=strict,
                 orient=orient,
                 infer_schema_length=infer_schema_length,
                 nan_to_null=nan_to_null,

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -176,10 +176,26 @@ class Series:
         One-dimensional data in various forms. Supported are: Sequence, Series,
         pyarrow Array, and numpy ndarray.
     dtype : DataType, default None
-        Polars dtype of the Series data. If not specified, the dtype is inferred.
-    strict
-        Throw error on numeric overflow.
-    nan_to_null
+        Data type of the resulting Series. If set to `None` (default), the data type is
+        inferred from the `values` input. The strategy for data type inference depends
+        on the `strict` parameter:
+
+        - If `strict` is set to True (default), the inferred data type is equal to the
+          first non-null value, or `Null` if all values are null.
+        - If `strict` is set to False, the inferred data type is the supertype of the
+          values, or :class:`Object` if no supertype can be found. **WARNING**: A full
+          pass over the values is required to determine the supertype.
+        - If no values were passed, the resulting data type is :class:`Null`.
+
+    strict : bool, default True
+        Throw an error if any value does not exactly match the given or inferred data
+        type. If set to `False`, values that do not match the data type are cast to
+        that data type or, if casting is not possible, set to null instead.
+
+        .. warning::
+            This parameter is currently only considered when `data` is a dictionary.
+
+    nan_to_null : bool, default False
         In case a numpy array is used to create this Series, indicate how to deal
         with np.nan values. (This parameter is a no-op on non-numpy data).
     dtype_if_empty : DataType, default Null

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -191,10 +191,6 @@ class Series:
         Throw an error if any value does not exactly match the given or inferred data
         type. If set to `False`, values that do not match the data type are cast to
         that data type or, if casting is not possible, set to null instead.
-
-        .. warning::
-            This parameter is currently only considered when `data` is a dictionary.
-
     nan_to_null : bool, default False
         In case a numpy array is used to create this Series, indicate how to deal
         with np.nan values. (This parameter is a no-op on non-numpy data).

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+
+
+def test_df_init_strict() -> None:
+    data = {"a": [1, 2, 3.0]}
+    schema = {"a": pl.Int8}
+    with pytest.raises(TypeError):
+        pl.DataFrame(data, schema=schema, strict=True)
+
+    df = pl.DataFrame(data, schema=schema, strict=False)
+
+    # TODO: This should result in a Float Series without nulls
+    # https://github.com/pola-rs/polars/issues/14427
+    assert df["a"].to_list() == [1, 2, None]
+
+    assert df["a"].dtype == pl.Int8
+
+
+def test_df_init_from_series_strict() -> None:
+    s = pl.Series("a", [-1, 0, 1])
+    schema = {"a": pl.UInt8}
+    with pytest.raises(pl.ComputeError):
+        pl.DataFrame(s, schema=schema, strict=True)
+
+    df = pl.DataFrame(s, schema=schema, strict=False)
+
+    assert df["a"].to_list() == [None, 0, 1]
+    assert df["a"].dtype == pl.UInt8


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/14427

The DataFrame constructor had no `strict` parameter, while the Series constructor does. Non-strict construction is useful when the input data is not guaranteed to be clean.

```python
import polars as pl

data = {"a": [-1, 0, 1]}

# Data does not match desired data type, cannot construct dataframe
df = pl.DataFrame(data, schema={"a": pl.UInt8})
# OverflowError

# Pass `strict=False` to handle this cleanly
df = pl.DataFrame(data, schema={"a": pl.UInt8}, strict=False)
print(df)
```
```
shape: (3, 1)
┌──────┐
│ a    │
│ ---  │
│ u8   │
╞══════╡
│ null │
│ 0    │
│ 1    │
└──────┘
```

In this example, the result is similar to a non-strict cast of the data to the desired data type.
This will also allow handling mixed ints/floats cleanly in the future.

**The default behavior is unchanged**, as previously DataFrame construction was always strict, corresponding to `strict=True`.