### PR TITLE
feat: Raise informative error message when join would introduce duplicate column name

### DIFF
--- a/crates/polars-ops/src/frame/join/general.rs
+++ b/crates/polars-ops/src/frame/join/general.rs
@@ -32,7 +32,13 @@ pub fn _finish_join(
     let suffix = get_suffix(suffix);
 
     for name in rename_strs {
-        df_right.rename(&name, &_join_suffix_name(&name, suffix))?;
+        let new_name = _join_suffix_name(&name, suffix);
+        df_right.rename(&name, new_name.as_str()).map_err(|_| {
+            polars_err!(Duplicate: "column with name '{}' already exists.\n\n\
+            You may want to try:\n\
+            - renaming the column prior to joining\n\
+            - using `suffix` to specify a suffix different to the default one (`_right`)", new_name)
+        })?;
     }
 
     drop(left_names);

--- a/crates/polars-ops/src/frame/join/general.rs
+++ b/crates/polars-ops/src/frame/join/general.rs
@@ -34,10 +34,10 @@ pub fn _finish_join(
     for name in rename_strs {
         let new_name = _join_suffix_name(&name, suffix);
         df_right.rename(&name, new_name.as_str()).map_err(|_| {
-            polars_err!(Duplicate: "column with name '{}' already exists.\n\n\
+            polars_err!(Duplicate: "column with name '{}' already exists\n\n\
             You may want to try:\n\
             - renaming the column prior to joining\n\
-            - using `suffix` to specify a suffix different to the default one (`_right`)", new_name)
+            - using the `suffix` parameter to specify a suffix different to the default one ('_right')", new_name)
         })?;
     }
 

--- a/py-polars/tests/unit/operations/test_join.py
+++ b/py-polars/tests/unit/operations/test_join.py
@@ -789,3 +789,17 @@ def test_join_on_nth_error() -> None:
         pl.ComputeError, match="nth column selection not supported at this point"
     ):
         df.join(df2, on=pl.first())
+
+
+def test_join_results_in_duplicate_names() -> None:
+    lhs = pl.DataFrame(
+        {
+            "a": [1, 2, 3],
+            "b": [4, 5, 6],
+            "c": [1, 2, 3],
+            "c_right": [1, 2, 3],
+        }
+    )
+    rhs = lhs.clone()
+    with pytest.raises(pl.DuplicateError, match="'c_right' already exists"):
+        lhs.join(rhs, on=["a", "b"], how="left")


### PR DESCRIPTION
closes #15035 

The example in that issue would now show:
```
polars.exceptions.DuplicateError: column with name 'c_right' already exists.

You may want to try:
- renaming the column prior to joining
- using `suffix` to specify a suffix different to the default one (`_right`)
```