### PR TITLE
fix: Return largest non-NaN value for `max()` on sorted float arrays if it exists instead of NaN

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -126,11 +126,11 @@ where
                     let side = SearchSortedSide::Left;
 
                     let (_, ca) = unsafe { slice_sorted_non_null_and_offset(self) };
-                    let arr = unsafe { ca.rechunk().downcast_get_unchecked(0).clone() };
+                    let arr = unsafe { ca.downcast_get_unchecked(0) };
 
                     let idx = with_match_physical_float_type!(T::get_dtype(), |$T| {
                         let val = unsafe { std::mem::transmute_copy::<$T, _>(&$T::NAN) };
-                        binary_search_array(side, &arr, val, is_descending)
+                        binary_search_array(side, arr, val, is_descending)
                     }) as usize;
 
                     let idx = idx.saturating_sub(1);
@@ -147,11 +147,11 @@ where
                     let side = SearchSortedSide::Right;
 
                     let (_, ca) = unsafe { slice_sorted_non_null_and_offset(self) };
-                    let arr = unsafe { ca.rechunk().downcast_get_unchecked(0).clone() };
+                    let arr = unsafe { ca.downcast_get_unchecked(0) };
 
                     let idx = with_match_physical_float_type!(T::get_dtype(), |$T| {
                         let val = unsafe { std::mem::transmute_copy::<$T, _>(&$T::NAN) };
-                        binary_search_array(side, &arr, val, is_descending)
+                        binary_search_array(side, arr, val, is_descending)
                     }) as usize;
 
                     let idx = if idx == arr.len() { idx - 1 } else { idx };

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -90,6 +90,13 @@ where
     let is_descending = false;
     let side = SearchSortedSide::Left;
 
+    let maybe_max = unsafe { ca.value_unchecked(ca.last_non_null().unwrap()) };
+    with_match_physical_float_type!(T::get_dtype(), |$T| {
+        if unsafe { !std::mem::transmute_copy::<_, $T>(&maybe_max).is_nan() } {
+            return Some(maybe_max);
+        }
+    });
+
     let (_, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
     let arr = unsafe { ca.downcast_get_unchecked(0) };
 
@@ -112,6 +119,13 @@ where
     debug_assert!(matches!(ca.is_sorted_flag(), IsSorted::Descending));
     let is_descending = true;
     let side = SearchSortedSide::Right;
+
+    let maybe_max = unsafe { ca.value_unchecked(ca.first_non_null().unwrap()) };
+    with_match_physical_float_type!(T::get_dtype(), |$T| {
+        if unsafe { !std::mem::transmute_copy::<_, $T>(&maybe_max).is_nan() } {
+            return Some(maybe_max);
+        }
+    });
 
     let (_, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
     let arr = unsafe { ca.downcast_get_unchecked(0) };

--- a/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/aggregate/mod.rs
@@ -80,6 +80,52 @@ where
     }
 }
 
+/// # Safety
+/// `ca` has at least 1 non-null value and is sorted ascending
+fn float_max_sorted_ascending<T>(ca: &ChunkedArray<T>) -> Option<T::Native>
+where
+    T: PolarsNumericType,
+{
+    debug_assert!(matches!(ca.is_sorted_flag(), IsSorted::Ascending));
+    let is_descending = false;
+    let side = SearchSortedSide::Left;
+
+    let (_, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
+    let arr = unsafe { ca.downcast_get_unchecked(0) };
+
+    let idx = with_match_physical_float_type!(T::get_dtype(), |$T| {
+        let val = unsafe { std::mem::transmute_copy::<$T, _>(&$T::NAN) };
+        binary_search_array(side, arr, val, is_descending)
+    }) as usize;
+
+    let idx = idx.saturating_sub(1);
+
+    unsafe { arr.get_unchecked(idx) }
+}
+
+/// # Safety
+/// `ca` has at least 1 non-null value and is sorted descending
+fn float_max_sorted_descending<T>(ca: &ChunkedArray<T>) -> Option<T::Native>
+where
+    T: PolarsNumericType,
+{
+    debug_assert!(matches!(ca.is_sorted_flag(), IsSorted::Descending));
+    let is_descending = true;
+    let side = SearchSortedSide::Right;
+
+    let (_, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
+    let arr = unsafe { ca.downcast_get_unchecked(0) };
+
+    let idx = with_match_physical_float_type!(T::get_dtype(), |$T| {
+        let val = unsafe { std::mem::transmute_copy::<$T, _>(&$T::NAN) };
+        binary_search_array(side, arr, val, is_descending)
+    }) as usize;
+
+    let idx = if idx == arr.len() { idx - 1 } else { idx };
+
+    unsafe { arr.get_unchecked(idx) }
+}
+
 impl<T> ChunkAgg<T::Native> for ChunkedArray<T>
 where
     T: PolarsNumericType,
@@ -99,6 +145,7 @@ where
         if self.null_count() == self.len() {
             return None;
         }
+        // There is at least one non-null value.
         match self.is_sorted_flag() {
             IsSorted::Ascending => {
                 let idx = self.first_non_null().unwrap();
@@ -119,23 +166,11 @@ where
         if self.null_count() == self.len() {
             return None;
         }
+        // There is at least one non-null value.
         match self.is_sorted_flag() {
             IsSorted::Ascending => {
                 if T::get_dtype().is_float() {
-                    let is_descending = false;
-                    let side = SearchSortedSide::Left;
-
-                    let (_, ca) = unsafe { slice_sorted_non_null_and_offset(self) };
-                    let arr = unsafe { ca.downcast_get_unchecked(0) };
-
-                    let idx = with_match_physical_float_type!(T::get_dtype(), |$T| {
-                        let val = unsafe { std::mem::transmute_copy::<$T, _>(&$T::NAN) };
-                        binary_search_array(side, arr, val, is_descending)
-                    }) as usize;
-
-                    let idx = idx.saturating_sub(1);
-
-                    unsafe { arr.get_unchecked(idx) }
+                    float_max_sorted_ascending(self)
                 } else {
                     let idx = self.last_non_null().unwrap();
                     unsafe { self.get_unchecked(idx) }
@@ -143,20 +178,7 @@ where
             },
             IsSorted::Descending => {
                 if T::get_dtype().is_float() {
-                    let is_descending = true;
-                    let side = SearchSortedSide::Right;
-
-                    let (_, ca) = unsafe { slice_sorted_non_null_and_offset(self) };
-                    let arr = unsafe { ca.downcast_get_unchecked(0) };
-
-                    let idx = with_match_physical_float_type!(T::get_dtype(), |$T| {
-                        let val = unsafe { std::mem::transmute_copy::<$T, _>(&$T::NAN) };
-                        binary_search_array(side, arr, val, is_descending)
-                    }) as usize;
-
-                    let idx = if idx == arr.len() { idx - 1 } else { idx };
-
-                    unsafe { arr.get_unchecked(idx) }
+                    float_max_sorted_descending(self)
                 } else {
                     let idx = self.first_non_null().unwrap();
                     unsafe { self.get_unchecked(idx) }
@@ -173,11 +195,12 @@ where
         if self.null_count() == self.len() {
             return None;
         }
+        // There is at least one non-null value.
         match self.is_sorted_flag() {
             IsSorted::Ascending => {
                 let min = unsafe { self.get_unchecked(self.first_non_null().unwrap()) };
                 let max = if T::get_dtype().is_float() {
-                    self.max()
+                    float_max_sorted_ascending(self)
                 } else {
                     unsafe { self.get_unchecked(self.last_non_null().unwrap()) }
                 };
@@ -186,7 +209,7 @@ where
             IsSorted::Descending => {
                 let min = unsafe { self.get_unchecked(self.last_non_null().unwrap()) };
                 let max = if T::get_dtype().is_float() {
-                    self.max()
+                    float_max_sorted_descending(self)
                 } else {
                     unsafe { self.get_unchecked(self.first_non_null().unwrap()) }
                 };

--- a/crates/polars-core/src/chunked_array/ops/float_sorted_arg_max.rs
+++ b/crates/polars-core/src/chunked_array/ops/float_sorted_arg_max.rs
@@ -1,0 +1,88 @@
+//! Implementations of the ChunkAgg trait.
+use self::search_sorted::{
+    binary_search_array, slice_sorted_non_null_and_offset, SearchSortedSide,
+};
+use crate::prelude::*;
+
+macro_rules! impl_sorted_float_arg_max {
+    ($T: ty, $primitive_ty: ty) => {
+        impl ChunkedArray<$T> {
+            fn float_arg_max_sorted_ascending(&self) -> usize {
+                let ca = self;
+                debug_assert!(ca.is_sorted_ascending_flag());
+                let is_descending = false;
+                let side = SearchSortedSide::Left;
+
+                let maybe_max_idx = ca.last_non_null().unwrap();
+
+                let maybe_max = unsafe { ca.value_unchecked(maybe_max_idx) };
+                if !maybe_max.is_nan() {
+                    return maybe_max_idx;
+                }
+
+                let (offset, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
+                let arr = unsafe { ca.downcast_get_unchecked(0) };
+                let search_val = <$primitive_ty>::NAN;
+                let idx = binary_search_array(side, arr, search_val, is_descending) as usize;
+
+                let idx = idx.saturating_sub(1);
+
+                offset + idx
+            }
+
+            fn float_arg_max_sorted_descending(&self) -> usize {
+                let ca = self;
+                debug_assert!(ca.is_sorted_descending_flag());
+                let is_descending = true;
+                let side = SearchSortedSide::Right;
+
+                let maybe_max_idx = ca.first_non_null().unwrap();
+
+                let maybe_max = unsafe { ca.value_unchecked(maybe_max_idx) };
+                if !maybe_max.is_nan() {
+                    return maybe_max_idx;
+                }
+
+                let (offset, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
+                let arr = unsafe { ca.downcast_get_unchecked(0) };
+                let search_val = <$primitive_ty>::NAN;
+                let idx = binary_search_array(side, arr, search_val, is_descending) as usize;
+
+                let idx = if idx == arr.len() { idx - 1 } else { idx };
+
+                offset + idx
+            }
+        }
+    };
+}
+
+impl_sorted_float_arg_max!(Float32Type, f32);
+impl_sorted_float_arg_max!(Float64Type, f64);
+
+/// # Safety
+/// `ca` has a float dtype, has at least 1 non-null value and is sorted ascending
+pub fn float_arg_max_sorted_ascending<T>(ca: &ChunkedArray<T>) -> usize
+where
+    T: PolarsNumericType,
+{
+    with_match_physical_float_polars_type!(ca.dtype(), |$T| {
+        let ca: &ChunkedArray<$T> = unsafe {
+            &*(ca as *const ChunkedArray<T> as *const ChunkedArray<$T>)
+        };
+        ca.float_arg_max_sorted_ascending()
+    })
+}
+
+/// # Safety
+/// `ca` has a float dtype, has at least 1 non-null value and is sorted descending
+pub fn float_arg_max_sorted_descending<T>(ca: &ChunkedArray<T>) -> usize
+where
+    T: PolarsNumericType,
+{
+    with_match_physical_float_polars_type!(ca.dtype(), |$T| {
+        let ca: &ChunkedArray<$T> = unsafe {
+            &*(ca as *const ChunkedArray<T> as *const ChunkedArray<$T>)
+        };
+        ca.float_arg_max_sorted_descending()
+    })
+}

--- a/crates/polars-core/src/chunked_array/ops/float_sorted_arg_max.rs
+++ b/crates/polars-core/src/chunked_array/ops/float_sorted_arg_max.rs
@@ -1,63 +1,62 @@
 //! Implementations of the ChunkAgg trait.
+use num_traits::Float;
+
 use self::search_sorted::{
     binary_search_array, slice_sorted_non_null_and_offset, SearchSortedSide,
 };
 use crate::prelude::*;
 
-macro_rules! impl_sorted_float_arg_max {
-    ($T: ty, $primitive_ty: ty) => {
-        impl ChunkedArray<$T> {
-            fn float_arg_max_sorted_ascending(&self) -> usize {
-                let ca = self;
-                debug_assert!(ca.is_sorted_ascending_flag());
-                let is_descending = false;
-                let side = SearchSortedSide::Left;
+impl<T> ChunkedArray<T>
+where
+    T: PolarsFloatType,
+    T::Native: Float,
+{
+    fn float_arg_max_sorted_ascending(&self) -> usize {
+        let ca = self;
+        debug_assert!(ca.is_sorted_ascending_flag());
+        let is_descending = false;
+        let side = SearchSortedSide::Left;
 
-                let maybe_max_idx = ca.last_non_null().unwrap();
+        let maybe_max_idx = ca.last_non_null().unwrap();
 
-                let maybe_max = unsafe { ca.value_unchecked(maybe_max_idx) };
-                if !maybe_max.is_nan() {
-                    return maybe_max_idx;
-                }
-
-                let (offset, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
-                let arr = unsafe { ca.downcast_get_unchecked(0) };
-                let search_val = <$primitive_ty>::NAN;
-                let idx = binary_search_array(side, arr, search_val, is_descending) as usize;
-
-                let idx = idx.saturating_sub(1);
-
-                offset + idx
-            }
-
-            fn float_arg_max_sorted_descending(&self) -> usize {
-                let ca = self;
-                debug_assert!(ca.is_sorted_descending_flag());
-                let is_descending = true;
-                let side = SearchSortedSide::Right;
-
-                let maybe_max_idx = ca.first_non_null().unwrap();
-
-                let maybe_max = unsafe { ca.value_unchecked(maybe_max_idx) };
-                if !maybe_max.is_nan() {
-                    return maybe_max_idx;
-                }
-
-                let (offset, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
-                let arr = unsafe { ca.downcast_get_unchecked(0) };
-                let search_val = <$primitive_ty>::NAN;
-                let idx = binary_search_array(side, arr, search_val, is_descending) as usize;
-
-                let idx = if idx == arr.len() { idx - 1 } else { idx };
-
-                offset + idx
-            }
+        let maybe_max = unsafe { ca.value_unchecked(maybe_max_idx) };
+        if !maybe_max.is_nan() {
+            return maybe_max_idx;
         }
-    };
-}
 
-impl_sorted_float_arg_max!(Float32Type, f32);
-impl_sorted_float_arg_max!(Float64Type, f64);
+        let (offset, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
+        let arr = unsafe { ca.downcast_get_unchecked(0) };
+        let search_val = T::Native::nan();
+        let idx = binary_search_array(side, arr, search_val, is_descending) as usize;
+
+        let idx = idx.saturating_sub(1);
+
+        offset + idx
+    }
+
+    fn float_arg_max_sorted_descending(&self) -> usize {
+        let ca = self;
+        debug_assert!(ca.is_sorted_descending_flag());
+        let is_descending = true;
+        let side = SearchSortedSide::Right;
+
+        let maybe_max_idx = ca.first_non_null().unwrap();
+
+        let maybe_max = unsafe { ca.value_unchecked(maybe_max_idx) };
+        if !maybe_max.is_nan() {
+            return maybe_max_idx;
+        }
+
+        let (offset, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
+        let arr = unsafe { ca.downcast_get_unchecked(0) };
+        let search_val = T::Native::nan();
+        let idx = binary_search_array(side, arr, search_val, is_descending) as usize;
+
+        let idx = if idx == arr.len() { idx - 1 } else { idx };
+
+        offset + idx
+    }
+}
 
 /// # Safety
 /// `ca` has a float dtype, has at least 1 non-null value and is sorted ascending

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod min_max_binary;
 pub(crate) mod nulls;
 mod reverse;
 pub(crate) mod rolling_window;
+pub mod search_sorted;
 mod set;
 mod shift;
 pub mod sort;

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -19,6 +19,7 @@ mod explode_and_offsets;
 mod extend;
 pub mod fill_null;
 mod filter;
+pub mod float_sorted_arg_max;
 mod for_each;
 pub mod full;
 pub mod gather;

--- a/crates/polars-core/src/chunked_array/ops/search_sorted.rs
+++ b/crates/polars-core/src/chunked_array/ops/search_sorted.rs
@@ -109,7 +109,8 @@ where
     left
 }
 
-/// Get a slice of the non-null values of a sorted array.
+/// Get a slice of the non-null values of a sorted array. The returned array
+/// will have a single chunk.
 /// # Safety
 /// The array is sorted and has at least one non-null value.
 pub unsafe fn slice_sorted_non_null_and_offset<T>(ca: &ChunkedArray<T>) -> (usize, ChunkedArray<T>)
@@ -123,5 +124,5 @@ where
     debug_assert!(out.null_count() != out.len());
     debug_assert!(out.null_count() == 0);
 
-    (offset, out)
+    (offset, out.rechunk())
 }

--- a/crates/polars-core/src/chunked_array/ops/search_sorted.rs
+++ b/crates/polars-core/src/chunked_array/ops/search_sorted.rs
@@ -1,0 +1,127 @@
+use std::cmp::Ordering;
+use std::fmt::Debug;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+use crate::prelude::*;
+
+#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub enum SearchSortedSide {
+    #[default]
+    Any,
+    Left,
+    Right,
+}
+
+/// Search the left or right index that still fulfills the requirements.
+fn get_side_idx<'a, A>(side: SearchSortedSide, mid: IdxSize, arr: &'a A, len: usize) -> IdxSize
+where
+    A: StaticArray,
+    A::ValueT<'a>: TotalOrd + Debug + Copy,
+{
+    let mut mid = mid;
+
+    // approach the boundary from any side
+    // this is O(n) we could make this binary search later
+    match side {
+        SearchSortedSide::Any => mid,
+        SearchSortedSide::Left => {
+            if mid as usize == len {
+                mid -= 1;
+            }
+
+            let current = unsafe { arr.get_unchecked(mid as usize) };
+            loop {
+                if mid == 0 {
+                    return mid;
+                }
+                mid -= 1;
+                if current.tot_ne(unsafe { &arr.get_unchecked(mid as usize) }) {
+                    return mid + 1;
+                }
+            }
+        },
+        SearchSortedSide::Right => {
+            if mid as usize == len {
+                return mid;
+            }
+            let current = unsafe { arr.get_unchecked(mid as usize) };
+            let bound = (len - 1) as IdxSize;
+            loop {
+                if mid >= bound {
+                    return mid + 1;
+                }
+                mid += 1;
+                if current.tot_ne(unsafe { &arr.get_unchecked(mid as usize) }) {
+                    return mid;
+                }
+            }
+        },
+    }
+}
+
+pub fn binary_search_array<'a, A>(
+    side: SearchSortedSide,
+    arr: &'a A,
+    search_value: A::ValueT<'a>,
+    descending: bool,
+) -> IdxSize
+where
+    A: StaticArray,
+    A::ValueT<'a>: TotalOrd + Debug + Copy,
+{
+    let mut size = arr.len() as IdxSize;
+    let mut left = 0 as IdxSize;
+    let mut right = size;
+    while left < right {
+        let mid = left + size / 2;
+
+        // SAFETY: the call is made safe by the following invariants:
+        // - `mid >= 0`
+        // - `mid < size`: `mid` is limited by `[left; right)` bound.
+        let cmp = match unsafe { arr.get_unchecked(mid as usize) } {
+            None => Ordering::Less,
+            Some(value) => {
+                if descending {
+                    search_value.tot_cmp(&value)
+                } else {
+                    value.tot_cmp(&search_value)
+                }
+            },
+        };
+
+        // The reason why we use if/else control flow rather than match
+        // is because match reorders comparison operations, which is perf sensitive.
+        // This is x86 asm for u8: https://rust.godbolt.org/z/8Y8Pra.
+        if cmp == Ordering::Less {
+            left = mid + 1;
+        } else if cmp == Ordering::Greater {
+            right = mid;
+        } else {
+            return get_side_idx(side, mid, arr, arr.len());
+        }
+
+        size = right - left;
+    }
+
+    left
+}
+
+/// Get a slice of the non-null values of a sorted array.
+/// # Safety
+/// The array is sorted and has at least one non-null value.
+pub unsafe fn slice_sorted_non_null_and_offset<T>(ca: &ChunkedArray<T>) -> (usize, ChunkedArray<T>)
+where
+    T: PolarsDataType,
+{
+    let offset = ca.first_non_null().unwrap();
+    let length = 1 + ca.last_non_null().unwrap() - offset;
+    let out = ca.slice(offset as i64, length);
+
+    debug_assert!(out.null_count() != out.len());
+    debug_assert!(out.null_count() == 0);
+
+    (offset, out)
+}

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -330,6 +330,19 @@ macro_rules! with_match_physical_integer_type {(
 })}
 
 #[macro_export]
+macro_rules! with_match_physical_float_type {(
+    $dtype:expr, | $_:tt $T:ident | $($body:tt)*
+) => ({
+    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
+    use $crate::datatypes::DataType::*;
+    match $dtype {
+        Float32 => __with_ty__! { f32 },
+        Float64 => __with_ty__! { f64 },
+        dt => panic!("not implemented for dtype {:?}", dt),
+    }
+})}
+
+#[macro_export]
 macro_rules! with_match_physical_float_polars_type {(
     $key_type:expr, | $_:tt $T:ident | $($body:tt)*
 ) => ({

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -330,19 +330,6 @@ macro_rules! with_match_physical_integer_type {(
 })}
 
 #[macro_export]
-macro_rules! with_match_physical_float_type {(
-    $dtype:expr, | $_:tt $T:ident | $($body:tt)*
-) => ({
-    macro_rules! __with_ty__ {( $_ $T:ident ) => ( $($body)* )}
-    use $crate::datatypes::DataType::*;
-    match $dtype {
-        Float32 => __with_ty__! { f32 },
-        Float64 => __with_ty__! { f64 },
-        dt => panic!("not implemented for dtype {:?}", dt),
-    }
-})}
-
-#[macro_export]
 macro_rules! with_match_physical_float_polars_type {(
     $key_type:expr, | $_:tt $T:ident | $($body:tt)*
 ) => ({

--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -174,7 +174,7 @@ where
     T: PolarsNumericType,
 {
     let (offset, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
-    let arr = unsafe { ca.rechunk().downcast_get_unchecked(0).clone() };
+    let arr = unsafe { ca.downcast_get_unchecked(0) };
 
     let out = match ca.is_sorted_flag() {
         IsSorted::Ascending => {
@@ -183,7 +183,7 @@ where
 
             let idx = with_match_physical_float_type!(T::get_dtype(), |$T| {
                 let val = unsafe { std::mem::transmute_copy::<$T, _>(&$T::NAN) };
-                binary_search_array(side, &arr, val, is_descending)
+                binary_search_array(side, arr, val, is_descending)
             }) as usize;
 
             let idx = idx.saturating_sub(1);
@@ -196,7 +196,7 @@ where
 
             let idx = with_match_physical_float_type!(T::get_dtype(), |$T| {
                 let val = unsafe { std::mem::transmute_copy::<$T, _>(&$T::NAN) };
-                binary_search_array(side, &arr, val, is_descending)
+                binary_search_array(side, arr, val, is_descending)
             }) as usize;
 
             let idx = if idx == arr.len() { idx - 1 } else { idx };

--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -2,7 +2,7 @@ use argminmax::ArgMinMax;
 use arrow::array::Array;
 use arrow::legacy::bit_util::*;
 use polars_core::chunked_array::ops::search_sorted::{
-    binary_search_array, slice_sorted_non_null_and_offset,
+    binary_search_array, slice_sorted_non_null_and_offset, SearchSortedSide,
 };
 use polars_core::series::IsSorted;
 use polars_core::{with_match_physical_float_type, with_match_physical_numeric_polars_type};

--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -173,18 +173,24 @@ fn arg_max_float_sorted<T>(ca: &ChunkedArray<T>) -> Option<usize>
 where
     T: PolarsNumericType,
 {
-    let (offset, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
-    let arr = unsafe { ca.downcast_get_unchecked(0) };
-
     let out = match ca.is_sorted_flag() {
         IsSorted::Ascending => {
             let is_descending = false;
             let side = SearchSortedSide::Left;
 
-            let idx = with_match_physical_float_type!(T::get_dtype(), |$T| {
+            let maybe_max_idx = ca.last_non_null().unwrap();
+            let maybe_max = unsafe { ca.value_unchecked(maybe_max_idx) };
+            let (offset, idx) = with_match_physical_float_type!(T::get_dtype(), |$T| {
+                if unsafe { !std::mem::transmute_copy::<_, $T>(&maybe_max).is_nan() } {
+                    return Some(maybe_max_idx);
+                };
+
+                let (offset, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
+                let arr = unsafe { ca.downcast_get_unchecked(0) };
+
                 let val = unsafe { std::mem::transmute_copy::<$T, _>(&$T::NAN) };
-                binary_search_array(side, arr, val, is_descending)
-            }) as usize;
+                (offset, binary_search_array(side, arr, val, is_descending) as usize)
+            });
 
             let idx = idx.saturating_sub(1);
 
@@ -194,12 +200,21 @@ where
             let is_descending = true;
             let side = SearchSortedSide::Right;
 
-            let idx = with_match_physical_float_type!(T::get_dtype(), |$T| {
-                let val = unsafe { std::mem::transmute_copy::<$T, _>(&$T::NAN) };
-                binary_search_array(side, arr, val, is_descending)
-            }) as usize;
+            let maybe_max_idx = ca.first_non_null().unwrap();
+            let maybe_max = unsafe { ca.value_unchecked(maybe_max_idx) };
+            let (offset, idx, len) = with_match_physical_float_type!(T::get_dtype(), |$T| {
+                if unsafe { !std::mem::transmute_copy::<_, $T>(&maybe_max).is_nan() } {
+                    return Some(maybe_max_idx);
+                };
 
-            let idx = if idx == arr.len() { idx - 1 } else { idx };
+                let (offset, ca) = unsafe { slice_sorted_non_null_and_offset(ca) };
+                let arr = unsafe { ca.downcast_get_unchecked(0) };
+
+                let val = unsafe { std::mem::transmute_copy::<$T, _>(&$T::NAN) };
+                (offset as usize, binary_search_array(side, arr, val, is_descending) as usize, arr.len())
+            });
+
+            let idx = if idx == len { idx - 1 } else { idx };
 
             offset + idx
         },

--- a/crates/polars-ops/src/series/ops/arg_min_max.rs
+++ b/crates/polars-ops/src/series/ops/arg_min_max.rs
@@ -2,7 +2,7 @@ use argminmax::ArgMinMax;
 use arrow::array::Array;
 use arrow::legacy::bit_util::*;
 use polars_core::chunked_array::ops::search_sorted::{
-    binary_search_array, slice_sorted_non_null_and_offset, SearchSortedSide,
+    binary_search_array, slice_sorted_non_null_and_offset,
 };
 use polars_core::series::IsSorted;
 use polars_core::{with_match_physical_float_type, with_match_physical_numeric_polars_type};

--- a/crates/polars-ops/src/series/ops/mod.rs
+++ b/crates/polars-ops/src/series/ops/mod.rs
@@ -98,6 +98,7 @@ pub use moment::*;
 pub use negate::*;
 #[cfg(feature = "pct_change")]
 pub use pct_change::*;
+pub use polars_core::chunked_array::ops::search_sorted::SearchSortedSide;
 use polars_core::prelude::*;
 #[cfg(feature = "rank")]
 pub use rank::*;

--- a/crates/polars-ops/src/series/ops/search_sorted.rs
+++ b/crates/polars-ops/src/series/ops/search_sorted.rs
@@ -1,131 +1,8 @@
-use std::cmp::Ordering;
-use std::fmt::Debug;
-
 use arrow::array::Array;
+use polars_core::chunked_array::ops::search_sorted::binary_search_array;
+pub use polars_core::chunked_array::ops::search_sorted::SearchSortedSide;
 use polars_core::prelude::*;
 use polars_core::with_match_physical_numeric_polars_type;
-use polars_utils::total_ord::{TotalEq, TotalOrd};
-#[cfg(feature = "serde")]
-use serde::{Deserialize, Serialize};
-
-#[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Default)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub enum SearchSortedSide {
-    #[default]
-    Any,
-    Left,
-    Right,
-}
-
-/// Search the left or right index that still fulfills the requirements.
-fn finish_side<'a, A>(
-    side: SearchSortedSide,
-    out: &mut Vec<IdxSize>,
-    mid: IdxSize,
-    arr: &'a A,
-    len: usize,
-) where
-    A: StaticArray,
-    A::ValueT<'a>: TotalOrd + Debug + Copy,
-{
-    let mut mid = mid;
-
-    // approach the boundary from any side
-    // this is O(n) we could make this binary search later
-    match side {
-        SearchSortedSide::Any => {
-            out.push(mid);
-        },
-        SearchSortedSide::Left => {
-            if mid as usize == len {
-                mid -= 1;
-            }
-
-            let current = unsafe { arr.get_unchecked(mid as usize) };
-            loop {
-                if mid == 0 {
-                    out.push(mid);
-                    break;
-                }
-                mid -= 1;
-                if current.tot_ne(unsafe { &arr.get_unchecked(mid as usize) }) {
-                    out.push(mid + 1);
-                    break;
-                }
-            }
-        },
-        SearchSortedSide::Right => {
-            if mid as usize == len {
-                out.push(mid);
-                return;
-            }
-            let current = unsafe { arr.get_unchecked(mid as usize) };
-            let bound = (len - 1) as IdxSize;
-            loop {
-                if mid >= bound {
-                    out.push(mid + 1);
-                    break;
-                }
-                mid += 1;
-                if current.tot_ne(unsafe { &arr.get_unchecked(mid as usize) }) {
-                    out.push(mid);
-                    break;
-                }
-            }
-        },
-    }
-}
-
-fn binary_search_array<'a, A>(
-    side: SearchSortedSide,
-    out: &mut Vec<IdxSize>,
-    arr: &'a A,
-    len: usize,
-    search_value: A::ValueT<'a>,
-    descending: bool,
-) where
-    A: StaticArray,
-    A::ValueT<'a>: TotalOrd + Debug + Copy,
-{
-    let mut size = len as IdxSize;
-    let mut left = 0 as IdxSize;
-    let mut right = size;
-    let current_len = out.len();
-    while left < right {
-        let mid = left + size / 2;
-
-        // SAFETY: the call is made safe by the following invariants:
-        // - `mid >= 0`
-        // - `mid < size`: `mid` is limited by `[left; right)` bound.
-        let cmp = match unsafe { arr.get_unchecked(mid as usize) } {
-            None => Ordering::Less,
-            Some(value) => {
-                if descending {
-                    search_value.tot_cmp(&value)
-                } else {
-                    value.tot_cmp(&search_value)
-                }
-            },
-        };
-
-        // The reason why we use if/else control flow rather than match
-        // is because match reorders comparison operations, which is perf sensitive.
-        // This is x86 asm for u8: https://rust.godbolt.org/z/8Y8Pra.
-        if cmp == Ordering::Less {
-            left = mid + 1;
-        } else if cmp == Ordering::Greater {
-            right = mid;
-        } else {
-            finish_side(side, out, mid, arr, len);
-            break;
-        }
-
-        size = right - left;
-    }
-    if out.len() == current_len {
-        out.push(left);
-    }
-}
 
 fn search_sorted_ca_array<T>(
     ca: &ChunkedArray<T>,
@@ -144,20 +21,15 @@ where
     for search_arr in search_values.downcast_iter() {
         if search_arr.null_count() == 0 {
             for search_value in search_arr.values_iter() {
-                binary_search_array(side, &mut out, arr, ca.len(), *search_value, descending)
+                out.push(binary_search_array(side, arr, *search_value, descending))
             }
         } else {
             for opt_v in search_arr.into_iter() {
                 match opt_v {
                     None => out.push(0),
-                    Some(search_value) => binary_search_array(
-                        side,
-                        &mut out,
-                        arr,
-                        ca.len(),
-                        *search_value,
-                        descending,
-                    ),
+                    Some(search_value) => {
+                        out.push(binary_search_array(side, arr, *search_value, descending))
+                    },
                 }
             }
         }
@@ -179,14 +51,14 @@ fn search_sorted_bin_array_with_binary_offset(
     for search_arr in search_values.downcast_iter() {
         if search_arr.null_count() == 0 {
             for search_value in search_arr.values_iter() {
-                binary_search_array(side, &mut out, arr, ca.len(), search_value, descending)
+                out.push(binary_search_array(side, arr, search_value, descending))
             }
         } else {
             for opt_v in search_arr.into_iter() {
                 match opt_v {
                     None => out.push(0),
                     Some(search_value) => {
-                        binary_search_array(side, &mut out, arr, ca.len(), search_value, descending)
+                        out.push(binary_search_array(side, arr, search_value, descending))
                     },
                 }
             }
@@ -209,14 +81,14 @@ fn search_sorted_bin_array(
     for search_arr in search_values.downcast_iter() {
         if search_arr.null_count() == 0 {
             for search_value in search_arr.values_iter() {
-                binary_search_array(side, &mut out, arr, ca.len(), search_value, descending)
+                out.push(binary_search_array(side, arr, search_value, descending))
             }
         } else {
             for opt_v in search_arr.into_iter() {
                 match opt_v {
                     None => out.push(0),
                     Some(search_value) => {
-                        binary_search_array(side, &mut out, arr, ca.len(), search_value, descending)
+                        out.push(binary_search_array(side, arr, search_value, descending))
                     },
                 }
             }

--- a/crates/polars-ops/src/series/ops/search_sorted.rs
+++ b/crates/polars-ops/src/series/ops/search_sorted.rs
@@ -1,6 +1,5 @@
 use arrow::array::Array;
-use polars_core::chunked_array::ops::search_sorted::binary_search_array;
-pub use polars_core::chunked_array::ops::search_sorted::SearchSortedSide;
+use polars_core::chunked_array::ops::search_sorted::{binary_search_array, SearchSortedSide};
 use polars_core::prelude::*;
 use polars_core::with_match_physical_numeric_polars_type;
 

--- a/py-polars/tests/unit/datatypes/test_float.py
+++ b/py-polars/tests/unit/datatypes/test_float.py
@@ -39,19 +39,23 @@ def test_nan_aggregations() -> None:
 
 @pytest.mark.parametrize("descending", [True, False])
 def test_sorted_nan_min_max_12931(descending: bool) -> None:
-    s = pl.Series("x", [1.0, float("nan")]).sort(descending=descending)
+    s = pl.Series("x", [1.0, 2.0, float("nan")]).sort(descending=descending)
 
     assert s.min() == 1.0
-    assert s.max() == 1.0
+    assert s.max() == 2.0
+    assert s.arg_min() == (0, 2)[descending]
+    assert s.arg_max() == 1
 
-    df = (
-        pl.Series("x", [float("nan"), float("nan")])
-        .sort(descending=descending)
-        .to_frame()
+    s = pl.Series("x", [float("nan"), float("nan"), float("nan")]).sort(
+        descending=descending
     )
+    df = s.to_frame()
 
     assert df.select(pl.col("x").min().is_nan()).item()
     assert df.select(pl.col("x").max().is_nan()).item()
+
+    assert s.arg_min() == (0, 2)[descending]
+    assert s.arg_max() == (0, 2)[descending]
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/datatypes/test_float.py
+++ b/py-polars/tests/unit/datatypes/test_float.py
@@ -48,14 +48,19 @@ def test_sorted_nan_max_12931(descending: bool) -> None:
     s = pl.Series("x", [float("nan"), float("nan"), float("nan")]).sort(
         descending=descending
     )
-    df = s.to_frame()
 
-    assert df.select(pl.col("x").max().is_nan()).item()
+    out = s.max()
+    assert out != out
 
     # This is flipped because float arg_max calculates the index as
     # * sorted ascending: (index of left-most NaN) - 1, saturating subtraction at 0
     # * sorted descending: (index of right-most NaN) + 1, saturating addition at s.len()
     assert s.arg_max() == (0, 2)[descending]
+
+    s = pl.Series("x", [1.0, 2.0, 3.0]).sort(descending=descending)
+
+    assert s.max() == 3.0
+    assert s.arg_max() == (2, 0)[descending]
 
 
 @pytest.mark.parametrize(

--- a/py-polars/tests/unit/datatypes/test_float.py
+++ b/py-polars/tests/unit/datatypes/test_float.py
@@ -37,6 +37,23 @@ def test_nan_aggregations() -> None:
     )
 
 
+@pytest.mark.parametrize("descending", [True, False])
+def test_sorted_nan_min_max_12931(descending: bool) -> None:
+    s = pl.Series("x", [1.0, float("nan")]).sort(descending=descending)
+
+    assert s.min() == 1.0
+    assert s.max() == 1.0
+
+    df = (
+        pl.Series("x", [float("nan"), float("nan")])
+        .sort(descending=descending)
+        .to_frame()
+    )
+
+    assert df.select(pl.col("x").min().is_nan()).item()
+    assert df.select(pl.col("x").max().is_nan()).item()
+
+
 @pytest.mark.parametrize(
     ("s", "expect"),
     [

--- a/py-polars/tests/unit/datatypes/test_float.py
+++ b/py-polars/tests/unit/datatypes/test_float.py
@@ -38,23 +38,23 @@ def test_nan_aggregations() -> None:
 
 
 @pytest.mark.parametrize("descending", [True, False])
-def test_sorted_nan_min_max_12931(descending: bool) -> None:
+def test_sorted_nan_max_12931(descending: bool) -> None:
     s = pl.Series("x", [1.0, 2.0, float("nan")]).sort(descending=descending)
 
-    assert s.min() == 1.0
     assert s.max() == 2.0
-    assert s.arg_min() == (0, 2)[descending]
     assert s.arg_max() == 1
 
+    # Test full-nan
     s = pl.Series("x", [float("nan"), float("nan"), float("nan")]).sort(
         descending=descending
     )
     df = s.to_frame()
 
-    assert df.select(pl.col("x").min().is_nan()).item()
     assert df.select(pl.col("x").max().is_nan()).item()
 
-    assert s.arg_min() == (0, 2)[descending]
+    # This is flipped because float arg_max calculates the index as
+    # * sorted ascending: (index of left-most NaN) - 1, saturating subtraction at 0
+    # * sorted descending: (index of right-most NaN) + 1, saturating addition at s.len()
     assert s.arg_max() == (0, 2)[descending]
 
 


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/12931.

This PR uses a binary search to find non-NaN values for the sorted max/arg_max on floats (if they exist). In the case where all non-null values are NaNs, then the result will be NaN (note the result for all-null is still null).

Part of the binary search code was refactored and moved from `polars-ops` to `polars-core` to support this.

