### PR TITLE
refactor(rust): Use ObjectStore instead of AsyncRead in parquet get metadata

### DIFF
--- a/crates/polars-io/src/cloud/adaptors.rs
+++ b/crates/polars-io/src/cloud/adaptors.rs
@@ -2,15 +2,9 @@
 //! This is used, for example, by the [parquet2] crate.
 //!
 //! [parquet2]: https://crates.io/crates/parquet2
-use std::io::{self};
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::Poll;
 
-use bytes::Bytes;
-use futures::executor::block_on;
-use futures::future::BoxFuture;
-use futures::{AsyncRead, AsyncSeek, Future, TryFutureExt};
+use std::sync::Arc;
+
 use object_store::path::Path;
 use object_store::{MultipartId, ObjectStore};
 use polars_error::{to_compute_err, PolarsResult};
@@ -18,118 +12,6 @@ use tokio::io::{AsyncWrite, AsyncWriteExt};
 
 use super::CloudOptions;
 use crate::pl_async::get_runtime;
-
-type OptionalFuture = Option<BoxFuture<'static, std::io::Result<Bytes>>>;
-
-/// Adaptor to translate from AsyncSeek and AsyncRead to the object_store get_range API.
-pub struct CloudReader {
-    // The current position in the stream, it is set by seeking and updated by reading bytes.
-    pos: u64,
-    // The total size of the object is required when seeking from the end of the file.
-    length: Option<u64>,
-    // Hold an reference to the store in a thread safe way.
-    object_store: Arc<dyn ObjectStore>,
-    // The path in the object_store of the current object being read.
-    path: Path,
-    // If a read is pending then `active` will point to its future.
-    active: OptionalFuture,
-}
-
-impl CloudReader {
-    pub fn new(length: Option<u64>, object_store: Arc<dyn ObjectStore>, path: Path) -> Self {
-        Self {
-            pos: 0,
-            length,
-            object_store,
-            path,
-            active: None,
-        }
-    }
-
-    /// For each read request we create a new future.
-    async fn read_operation(
-        mut self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        length: usize,
-    ) -> std::task::Poll<std::io::Result<Bytes>> {
-        let start = self.pos as usize;
-
-        // If we already have a future just poll it.
-        if let Some(fut) = self.active.as_mut() {
-            return Future::poll(fut.as_mut(), cx);
-        }
-
-        // Create the future.
-        let future = {
-            let path = self.path.clone();
-            let object_store = self.object_store.clone();
-            // Use an async move block to get our owned objects.
-            async move {
-                object_store
-                    .get_range(&path, start..start + length)
-                    .map_err(|e| {
-                        std::io::Error::new(
-                            std::io::ErrorKind::Other,
-                            format!("object store error {e:?}"),
-                        )
-                    })
-                    .await
-            }
-        };
-        // Prepare for next read.
-        self.pos += length as u64;
-
-        let mut future = Box::pin(future);
-
-        // Need to poll it once to get the pump going.
-        let polled = Future::poll(future.as_mut(), cx);
-
-        // Save for next time.
-        self.active = Some(future);
-        polled
-    }
-}
-
-impl AsyncRead for CloudReader {
-    fn poll_read(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-        buf: &mut [u8],
-    ) -> std::task::Poll<std::io::Result<usize>> {
-        // Use block_on in order to get the future result in this thread and copy the data in the output buffer.
-        // With this approach we keep ownership of the buffer and we don't have to pass it to the future runtime.
-        match block_on(self.read_operation(cx, buf.len())) {
-            Poll::Ready(Ok(bytes)) => {
-                buf.copy_from_slice(bytes.as_ref());
-                Poll::Ready(Ok(bytes.len()))
-            },
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
-            Poll::Pending => Poll::Pending,
-        }
-    }
-}
-
-impl AsyncSeek for CloudReader {
-    fn poll_seek(
-        mut self: Pin<&mut Self>,
-        _: &mut std::task::Context<'_>,
-        pos: io::SeekFrom,
-    ) -> std::task::Poll<std::io::Result<u64>> {
-        match pos {
-            io::SeekFrom::Start(pos) => self.pos = pos,
-            io::SeekFrom::End(pos) => {
-                let length = self.length.ok_or::<io::Error>(io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "Cannot seek from end of stream when length is unknown.",
-                ))?;
-                self.pos = (length as i64 + pos) as u64
-            },
-            io::SeekFrom::Current(pos) => self.pos = (self.pos as i64 + pos) as u64,
-        };
-        self.active = None;
-        std::task::Poll::Ready(Ok(self.pos))
-    }
-}
 
 /// Adaptor which wraps the asynchronous interface of [ObjectStore::put_multipart](https://docs.rs/object_store/latest/object_store/trait.ObjectStore.html#tymethod.put_multipart)
 /// exposing a synchronous interface which implements `std::io::Write`.

--- a/crates/polars-io/src/cloud/glob.rs
+++ b/crates/polars-io/src/cloud/glob.rs
@@ -3,10 +3,11 @@ use futures::{StreamExt, TryStreamExt};
 use object_store::path::Path;
 use polars_core::error::to_compute_err;
 use polars_core::prelude::{polars_ensure, polars_err};
+use polars_error::{PolarsError, PolarsResult};
 use regex::Regex;
 use url::Url;
 
-use super::*;
+use super::CloudOptions;
 
 const DELIMITER: char = '/';
 

--- a/crates/polars-io/src/cloud/mod.rs
+++ b/crates/polars-io/src/cloud/mod.rs
@@ -1,29 +1,24 @@
 //! Interface with cloud storage through the object_store crate.
 
 #[cfg(feature = "cloud")]
-use std::borrow::Cow;
-#[cfg(feature = "cloud")]
-use std::sync::Arc;
-
-#[cfg(feature = "cloud")]
-use object_store::local::LocalFileSystem;
-#[cfg(feature = "cloud")]
-use object_store::ObjectStore;
-#[cfg(feature = "cloud")]
-use polars_core::prelude::{polars_bail, PolarsError, PolarsResult};
-
-#[cfg(feature = "cloud")]
 mod adaptors;
+#[cfg(feature = "cloud")]
+pub use adaptors::*;
+
+#[cfg(feature = "cloud")]
+mod polars_object_store;
+#[cfg(feature = "cloud")]
+pub use polars_object_store::*;
+
 #[cfg(feature = "cloud")]
 mod glob;
 #[cfg(feature = "cloud")]
-mod object_store_setup;
-pub mod options;
+pub use glob::*;
 
 #[cfg(feature = "cloud")]
-pub use adaptors::*;
-#[cfg(feature = "cloud")]
-pub use glob::*;
+mod object_store_setup;
 #[cfg(feature = "cloud")]
 pub use object_store_setup::*;
+
+pub mod options;
 pub use options::*;

--- a/crates/polars-io/src/cloud/object_store_setup.rs
+++ b/crates/polars-io/src/cloud/object_store_setup.rs
@@ -1,4 +1,3 @@
-use std::borrow::Cow;
 use std::sync::Arc;
 
 use object_store::local::LocalFileSystem;
@@ -9,7 +8,7 @@ use polars_utils::aliases::PlHashMap;
 use tokio::sync::RwLock;
 use url::Url;
 
-use super::{get_client_options, parse_url, CloudLocation, CloudOptions, CloudType};
+use super::{parse_url, CloudLocation, CloudOptions, CloudType};
 
 /// Object stores must be cached. Every object-store will do DNS lookups and
 /// get rate limited when querying the DNS (can take up to 5s).
@@ -39,7 +38,14 @@ fn url_to_key(url: &Url) -> String {
 }
 
 /// Build an [`ObjectStore`] based on the URL and passed in url. Return the cloud location and an implementation of the object store.
-pub async fn build_object_store(url: &str, options: Option<&CloudOptions>) -> BuildResult {
+pub async fn build_object_store(
+    url: &str,
+    #[cfg_attr(
+        not(any(feature = "aws", feature = "gcp", feature = "azure")),
+        allow(unused_variables)
+    )]
+    options: Option<&CloudOptions>,
+) -> BuildResult {
     let parsed = parse_url(url).map_err(to_compute_err)?;
     let cloud_location = CloudLocation::from_url(&parsed)?;
 
@@ -52,9 +58,8 @@ pub async fn build_object_store(url: &str, options: Option<&CloudOptions>) -> Bu
         }
     }
 
-    let options = options
-        .map(Cow::Borrowed)
-        .unwrap_or_else(|| Cow::Owned(Default::default()));
+    #[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
+    let options = options.map(std::borrow::Cow::Borrowed).unwrap_or_default();
 
     let cloud_type = CloudType::from_url(&parsed)?;
     let store = match cloud_type {
@@ -97,7 +102,7 @@ pub async fn build_object_store(url: &str, options: Option<&CloudOptions>) -> Bu
                 {
                     let store = object_store::http::HttpBuilder::new()
                         .with_url(url)
-                        .with_client_options(get_client_options())
+                        .with_client_options(super::get_client_options())
                         .build()?;
                     Ok::<_, PolarsError>(Arc::new(store) as Arc<dyn ObjectStore>)
                 }

--- a/crates/polars-io/src/cloud/object_store_setup.rs
+++ b/crates/polars-io/src/cloud/object_store_setup.rs
@@ -1,11 +1,15 @@
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use object_store::local::LocalFileSystem;
+use object_store::ObjectStore;
 use once_cell::sync::Lazy;
-pub use options::*;
-use polars_error::to_compute_err;
+use polars_error::{polars_bail, to_compute_err, PolarsError, PolarsResult};
 use polars_utils::aliases::PlHashMap;
 use tokio::sync::RwLock;
 use url::Url;
 
-use super::*;
+use super::{get_client_options, parse_url, CloudLocation, CloudOptions, CloudType};
 
 /// Object stores must be cached. Every object-store will do DNS lookups and
 /// get rate limited when querying the DNS (can take up to 5s).

--- a/crates/polars-io/src/cloud/options.rs
+++ b/crates/polars-io/src/cloud/options.rs
@@ -18,8 +18,6 @@ use object_store::gcp::GoogleCloudStorageBuilder;
 pub use object_store::gcp::GoogleConfigKey;
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure", feature = "http"))]
 use object_store::ClientOptions;
-#[cfg(feature = "cloud")]
-use object_store::ObjectStore;
 #[cfg(any(feature = "aws", feature = "gcp", feature = "azure"))]
 use object_store::{BackoffConfig, RetryConfig};
 #[cfg(feature = "aws")]
@@ -226,9 +224,9 @@ impl CloudOptions {
         self
     }
 
-    /// Build the [`ObjectStore`] implementation for AWS.
+    /// Build the [`object_store::ObjectStore`] implementation for AWS.
     #[cfg(feature = "aws")]
-    pub async fn build_aws(&self, url: &str) -> PolarsResult<impl ObjectStore> {
+    pub async fn build_aws(&self, url: &str) -> PolarsResult<impl object_store::ObjectStore> {
         let options = self.aws.as_ref();
         let mut builder = AmazonS3Builder::from_env().with_url(url);
         if let Some(options) = options {
@@ -329,9 +327,9 @@ impl CloudOptions {
         self
     }
 
-    /// Build the [`ObjectStore`] implementation for Azure.
+    /// Build the [`object_store::ObjectStore`] implementation for Azure.
     #[cfg(feature = "azure")]
-    pub fn build_azure(&self, url: &str) -> PolarsResult<impl ObjectStore> {
+    pub fn build_azure(&self, url: &str) -> PolarsResult<impl object_store::ObjectStore> {
         let options = self.azure.as_ref();
         let mut builder = MicrosoftAzureBuilder::from_env();
         if let Some(options) = options {
@@ -363,9 +361,9 @@ impl CloudOptions {
         self
     }
 
-    /// Build the [`ObjectStore`] implementation for GCP.
+    /// Build the [`object_store::ObjectStore`] implementation for GCP.
     #[cfg(feature = "gcp")]
-    pub fn build_gcp(&self, url: &str) -> PolarsResult<impl ObjectStore> {
+    pub fn build_gcp(&self, url: &str) -> PolarsResult<impl object_store::ObjectStore> {
         let options = self.gcp.as_ref();
         let mut builder = GoogleCloudStorageBuilder::from_env();
         if let Some(options) = options {

--- a/crates/polars-io/src/cloud/polars_object_store.rs
+++ b/crates/polars-io/src/cloud/polars_object_store.rs
@@ -1,0 +1,61 @@
+use std::ops::Range;
+use std::sync::Arc;
+
+use bytes::Bytes;
+use object_store::path::Path;
+use object_store::{ObjectMeta, ObjectStore};
+use polars_error::{to_compute_err, PolarsResult};
+
+use crate::pl_async::{
+    tune_with_concurrency_budget, with_concurrency_budget, MAX_BUDGET_PER_REQUEST,
+};
+
+/// Polars specific wrapper for `Arc<dyn ObjectStore>` that limits the number of
+/// concurrent requests for the entire application.
+#[derive(Debug, Clone)]
+pub struct PolarsObjectStore(Arc<dyn ObjectStore>);
+
+impl PolarsObjectStore {
+    pub fn new(store: Arc<dyn ObjectStore>) -> Self {
+        Self(store)
+    }
+
+    pub async fn get(&self, path: &Path) -> PolarsResult<Bytes> {
+        tune_with_concurrency_budget(1, || async {
+            self.0
+                .get(path)
+                .await
+                .map_err(to_compute_err)?
+                .bytes()
+                .await
+                .map_err(to_compute_err)
+        })
+        .await
+    }
+
+    pub async fn get_range(&self, path: &Path, range: Range<usize>) -> PolarsResult<Bytes> {
+        tune_with_concurrency_budget(1, || self.0.get_range(path, range))
+            .await
+            .map_err(to_compute_err)
+    }
+
+    pub async fn get_ranges(
+        &self,
+        path: &Path,
+        ranges: &[Range<usize>],
+    ) -> PolarsResult<Vec<Bytes>> {
+        tune_with_concurrency_budget(
+            (ranges.len() as u32).clamp(0, MAX_BUDGET_PER_REQUEST as u32),
+            || self.0.get_ranges(path, ranges),
+        )
+        .await
+        .map_err(to_compute_err)
+    }
+
+    /// Fetch the metadata of the parquet file, do not memoize it.
+    pub async fn head(&self, path: &Path) -> PolarsResult<ObjectMeta> {
+        with_concurrency_budget(1, || self.0.head(path))
+            .await
+            .map_err(to_compute_err)
+    }
+}

--- a/crates/polars-io/src/ipc/ipc_reader_async.rs
+++ b/crates/polars-io/src/ipc/ipc_reader_async.rs
@@ -1,72 +1,17 @@
-use std::ops::Range;
 use std::sync::Arc;
 
 use arrow::io::ipc::read::{get_row_count, FileMetadata, OutOfSpecKind};
-use bytes::Bytes;
 use object_store::path::Path;
-use object_store::{ObjectMeta, ObjectStore};
+use object_store::ObjectMeta;
 use polars_core::datatypes::IDX_DTYPE;
 use polars_core::frame::DataFrame;
 use polars_core::schema::Schema;
 use polars_error::{polars_bail, polars_err, to_compute_err, PolarsResult};
 
-use crate::cloud::{build_object_store, CloudLocation, CloudOptions};
-use crate::pl_async::{
-    tune_with_concurrency_budget, with_concurrency_budget, MAX_BUDGET_PER_REQUEST,
-};
+use crate::cloud::{build_object_store, CloudLocation, CloudOptions, PolarsObjectStore};
 use crate::predicates::PhysicalIoExpr;
 use crate::prelude::{materialize_projection, IpcReader};
 use crate::RowIndex;
-
-/// Polars specific wrapper for `Arc<dyn ObjectStore>` that limits the number of
-/// concurrent requests for the entire application.
-#[derive(Debug, Clone)]
-pub struct PolarsObjectStore(Arc<dyn ObjectStore>);
-
-impl PolarsObjectStore {
-    pub fn new(store: Arc<dyn ObjectStore>) -> Self {
-        Self(store)
-    }
-
-    pub async fn get(&self, path: &Path) -> PolarsResult<Bytes> {
-        tune_with_concurrency_budget(1, || async {
-            self.0
-                .get(path)
-                .await
-                .map_err(to_compute_err)?
-                .bytes()
-                .await
-                .map_err(to_compute_err)
-        })
-        .await
-    }
-
-    pub async fn get_range(&self, path: &Path, range: Range<usize>) -> PolarsResult<Bytes> {
-        tune_with_concurrency_budget(1, || self.0.get_range(path, range))
-            .await
-            .map_err(to_compute_err)
-    }
-
-    pub async fn get_ranges(
-        &self,
-        path: &Path,
-        ranges: &[Range<usize>],
-    ) -> PolarsResult<Vec<Bytes>> {
-        tune_with_concurrency_budget(
-            (ranges.len() as u32).clamp(0, MAX_BUDGET_PER_REQUEST as u32),
-            || self.0.get_ranges(path, ranges),
-        )
-        .await
-        .map_err(to_compute_err)
-    }
-
-    /// Fetch the metadata of the parquet file, do not memoize it.
-    pub async fn head(&self, path: &Path) -> PolarsResult<ObjectMeta> {
-        with_concurrency_budget(1, || self.0.head(path))
-            .await
-            .map_err(to_compute_err)
-    }
-}
 
 /// An Arrow IPC reader implemented on top of PolarsObjectStore.
 pub struct IpcReaderAsync {

--- a/crates/polars-io/src/parquet/async_impl.rs
+++ b/crates/polars-io/src/parquet/async_impl.rs
@@ -163,7 +163,10 @@ pub async fn fetch_metadata(
 
     Ok(polars_parquet::parquet::read::deserialize_metadata(
         std::io::Cursor::new(footer_bytes.as_ref()),
-        footer_bytes.as_ref().len(),
+        // TODO: Describe why this makes sense. Taken from the previous
+        // implementation which said "a highly nested but sparse struct could
+        // result in many allocations".
+        footer_bytes.as_ref().len() * 2 + 1024,
     )?)
 }
 

--- a/crates/polars-io/src/parquet/async_impl.rs
+++ b/crates/polars-io/src/parquet/async_impl.rs
@@ -4,23 +4,20 @@ use std::ops::Range;
 use arrow::datatypes::ArrowSchemaRef;
 use bytes::Bytes;
 use object_store::path::Path as ObjectPath;
-use object_store::ObjectStore;
 use polars_core::config::{get_rg_prefetch_size, verbose};
 use polars_core::error::to_compute_err;
 use polars_core::prelude::*;
-use polars_parquet::read::{self as parquet2_read, RowGroupMetaData};
+use polars_parquet::read::RowGroupMetaData;
 use polars_parquet::write::FileMetaData;
 use smartstring::alias::String as SmartString;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 use tokio::sync::Mutex;
 
-use super::cloud::{build_object_store, CloudLocation, CloudReader};
+use super::cloud::{build_object_store, CloudLocation};
 use super::mmap::ColumnStore;
-use crate::cloud::CloudOptions;
+use crate::cloud::{CloudOptions, PolarsObjectStore};
 use crate::parquet::read_impl::compute_row_group_range;
-use crate::pl_async::{
-    get_runtime, tune_with_concurrency_budget, with_concurrency_budget, MAX_BUDGET_PER_REQUEST,
-};
+use crate::pl_async::get_runtime;
 use crate::predicates::PhysicalIoExpr;
 use crate::prelude::predicates::read_this_row_group;
 
@@ -29,9 +26,9 @@ type QueuePayload = (usize, DownloadedRowGroup);
 type QueueSend = Arc<Sender<PolarsResult<QueuePayload>>>;
 
 pub struct ParquetObjectStore {
-    store: Arc<dyn ObjectStore>,
+    store: PolarsObjectStore,
     path: ObjectPath,
-    length: Option<u64>,
+    length: Option<usize>,
     metadata: Option<Arc<FileMetaData>>,
 }
 
@@ -54,7 +51,7 @@ impl ParquetObjectStore {
         let path = ObjectPath::from_url_path(prefix).map_err(to_compute_err)?;
 
         Ok(ParquetObjectStore {
-            store,
+            store: PolarsObjectStore::new(store),
             path,
             length: None,
             metadata,
@@ -62,53 +59,21 @@ impl ParquetObjectStore {
     }
 
     async fn get_range(&self, start: usize, length: usize) -> PolarsResult<Bytes> {
-        tune_with_concurrency_budget(1, || async {
-            self.store
-                .get_range(&self.path, start..start + length)
-                .await
-                .map_err(to_compute_err)
-        })
-        .await
+        self.store
+            .get_range(&self.path, start..start + length)
+            .await
     }
 
     async fn get_ranges(&self, ranges: &[Range<usize>]) -> PolarsResult<Vec<Bytes>> {
-        // Object-store has a maximum of 10 concurrent.
-        tune_with_concurrency_budget(
-            (ranges.len() as u32).clamp(0, MAX_BUDGET_PER_REQUEST as u32),
-            || async {
-                self.store
-                    .get_ranges(&self.path, ranges)
-                    .await
-                    .map_err(to_compute_err)
-            },
-        )
-        .await
+        self.store.get_ranges(&self.path, ranges).await
     }
 
     /// Initialize the length property of the object, unless it has already been fetched.
-    async fn initialize_length(&mut self) -> PolarsResult<()> {
-        if self.length.is_some() {
-            return Ok(());
+    async fn length(&mut self) -> PolarsResult<usize> {
+        if self.length.is_none() {
+            self.length = Some(self.store.head(&self.path).await?.size);
         }
-        with_concurrency_budget(1, || async {
-            self.length = Some(
-                self.store
-                    .head(&self.path)
-                    .await
-                    .map_err(to_compute_err)?
-                    .size as u64,
-            );
-            Ok(())
-        })
-        .await
-    }
-
-    pub async fn schema(&mut self) -> PolarsResult<ArrowSchemaRef> {
-        let metadata = self.get_metadata().await?;
-
-        let arrow_schema = parquet2_read::infer_schema(metadata)?;
-
-        Ok(Arc::new(arrow_schema))
+        Ok(self.length.unwrap())
     }
 
     /// Number of rows in the parquet file.
@@ -119,18 +84,8 @@ impl ParquetObjectStore {
 
     /// Fetch the metadata of the parquet file, do not memoize it.
     async fn fetch_metadata(&mut self) -> PolarsResult<FileMetaData> {
-        self.initialize_length().await?;
-        let object_store = self.store.clone();
-        let path = self.path.clone();
-        let length = self.length;
-        let mut reader = CloudReader::new(length, object_store, path);
-
-        with_concurrency_budget(1, || async {
-            parquet2_read::read_metadata_async(&mut reader)
-                .await
-                .map_err(to_compute_err)
-        })
-        .await
+        let length = self.length().await?;
+        fetch_metadata(&self.store, &self.path, length).await
     }
 
     /// Fetch and memoize the metadata of the parquet file.
@@ -140,6 +95,76 @@ impl ParquetObjectStore {
         }
         Ok(self.metadata.as_ref().unwrap())
     }
+}
+
+fn read_n<const N: usize>(reader: &mut &[u8]) -> Option<[u8; N]> {
+    if N <= reader.len() {
+        let (head, tail) = reader.split_at(N);
+        *reader = tail;
+        Some(head.try_into().unwrap())
+    } else {
+        None
+    }
+}
+
+fn read_i32le(reader: &mut &[u8]) -> Option<i32> {
+    read_n(reader).map(i32::from_le_bytes)
+}
+
+/// Asynchronously reads the files' metadata
+pub async fn fetch_metadata(
+    store: &PolarsObjectStore,
+    path: &ObjectPath,
+    file_byte_length: usize,
+) -> PolarsResult<FileMetaData> {
+    let footer_header_bytes = store
+        .get_range(
+            path,
+            file_byte_length
+                .checked_sub(polars_parquet::parquet::FOOTER_SIZE as usize)
+                .ok_or_else(|| {
+                    polars_parquet::parquet::error::Error::OutOfSpec(
+                        "not enough bytes to contain parquet footer".to_string(),
+                    )
+                })?..file_byte_length,
+        )
+        .await?;
+
+    let footer_byte_length: usize = {
+        let reader = &mut footer_header_bytes.as_ref();
+        let footer_byte_size = read_i32le(reader).unwrap();
+        let magic = read_n(reader).unwrap();
+        debug_assert!(reader.is_empty());
+        if magic != polars_parquet::parquet::PARQUET_MAGIC {
+            return Err(polars_parquet::parquet::error::Error::OutOfSpec(
+                "incorrect magic in parquet footer".to_string(),
+            )
+            .into());
+        }
+        footer_byte_size.try_into().map_err(|_| {
+            polars_parquet::parquet::error::Error::OutOfSpec(
+                "negative footer byte length".to_string(),
+            )
+        })?
+    };
+
+    let footer_bytes = store
+        .get_range(
+            path,
+            file_byte_length
+                .checked_sub(polars_parquet::parquet::FOOTER_SIZE as usize + footer_byte_length)
+                .ok_or_else(|| {
+                    polars_parquet::parquet::error::Error::OutOfSpec(
+                        "not enough bytes to contain parquet footer".to_string(),
+                    )
+                })?..file_byte_length,
+        )
+        .await?;
+
+    Ok(polars_parquet::parquet::read::deserialize_metadata(
+        std::io::Cursor::new(footer_bytes.as_ref()),
+        footer_bytes.as_ref().len(),
+    )?)
 }
 
 /// Download rowgroups for the column whose indexes are given in `projection`.

--- a/crates/polars-io/src/parquet/read.rs
+++ b/crates/polars-io/src/parquet/read.rs
@@ -258,11 +258,16 @@ impl ParquetAsyncReader {
     }
 
     pub async fn schema(&mut self) -> PolarsResult<ArrowSchemaRef> {
-        match &self.schema {
-            Some(schema) => Ok(schema.clone()),
-            None => self.reader.schema().await,
-        }
+        Ok(match self.schema.as_ref() {
+            Some(schema) => Arc::clone(schema),
+            None => {
+                let metadata = self.reader.get_metadata().await?;
+                let arrow_schema = polars_parquet::arrow::read::infer_schema(metadata)?;
+                Arc::new(arrow_schema)
+            },
+        })
     }
+
     pub async fn num_rows(&mut self) -> PolarsResult<usize> {
         self.reader.num_rows().await
     }

--- a/crates/polars-parquet/src/parquet/mod.rs
+++ b/crates/polars-parquet/src/parquet/mod.rs
@@ -18,9 +18,9 @@ pub mod write;
 use parquet_format_safe as thrift_format;
 pub use streaming_decompression::{fallible_streaming_iterator, FallibleStreamingIterator};
 
-const HEADER_SIZE: u64 = PARQUET_MAGIC.len() as u64;
-const FOOTER_SIZE: u64 = 8;
-const PARQUET_MAGIC: [u8; 4] = [b'P', b'A', b'R', b'1'];
+pub const HEADER_SIZE: u64 = PARQUET_MAGIC.len() as u64;
+pub const FOOTER_SIZE: u64 = 8;
+pub const PARQUET_MAGIC: [u8; 4] = [b'P', b'A', b'R', b'1'];
 
 /// The number of bytes read at the end of the parquet file on first read
 const DEFAULT_FOOTER_READ_SIZE: u64 = 64 * 1024;

--- a/crates/polars-pipe/src/pipeline/convert.rs
+++ b/crates/polars-pipe/src/pipeline/convert.rs
@@ -206,29 +206,29 @@ where
                 },
                 #[cfg(feature = "cloud")]
                 SinkType::Cloud {
+                    #[cfg(any(feature = "parquet", feature = "ipc"))]
                     uri,
                     file_type,
+                    #[cfg(any(feature = "parquet", feature = "ipc"))]
                     cloud_options,
+                    ..
                 } => {
-                    let uri = uri.as_ref().as_str();
-                    let input_schema = lp_arena.get(*input).schema(lp_arena);
-                    let cloud_options = &cloud_options;
                     match &file_type {
                         #[cfg(feature = "parquet")]
                         FileType::Parquet(parquet_options) => Box::new(ParquetCloudSink::new(
-                            uri,
+                            uri.as_ref().as_str(),
                             cloud_options.as_ref(),
                             *parquet_options,
-                            input_schema.as_ref(),
+                            lp_arena.get(*input).schema(lp_arena).as_ref(),
                         )?)
                             as Box<dyn SinkTrait>,
                         #[cfg(feature = "ipc")]
                         FileType::Ipc(ipc_options) => Box::new(IpcCloudSink::new(
-                                uri,
-                                cloud_options.as_ref(),
-                                *ipc_options,
-                                input_schema.as_ref(),
-                            )?)
+                            uri.as_ref().as_str(),
+                            cloud_options.as_ref(),
+                            *ipc_options,
+                            lp_arena.get(*input).schema(lp_arena).as_ref(),
+                        )?)
                             as Box<dyn SinkTrait>,
                         #[allow(unreachable_patterns)]
                         other_file_type => todo!("Cloud-sinking of the file type {other_file_type:?} is not (yet) supported."),

--- a/crates/polars-plan/src/logical_plan/file_scan.rs
+++ b/crates/polars-plan/src/logical_plan/file_scan.rs
@@ -11,7 +11,7 @@ pub enum FileScan {
     #[cfg(feature = "parquet")]
     Parquet {
         options: ParquetOptions,
-        cloud_options: Option<CloudOptions>,
+        cloud_options: Option<polars_io::cloud::CloudOptions>,
         #[cfg_attr(feature = "serde", serde(skip))]
         metadata: Option<Arc<FileMetaData>>,
     },
@@ -19,7 +19,7 @@ pub enum FileScan {
     Ipc {
         options: IpcScanOptions,
         #[cfg(feature = "cloud")]
-        cloud_options: Option<CloudOptions>,
+        cloud_options: Option<polars_io::cloud::CloudOptions>,
         #[cfg_attr(feature = "serde", serde(skip))]
         metadata: Option<arrow::io::ipc::read::FileMetadata>,
     },

--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -3,8 +3,6 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use polars_core::prelude::*;
-#[cfg(any(feature = "cloud", feature = "parquet"))]
-use polars_io::cloud::CloudOptions;
 
 use crate::logical_plan::LogicalPlan::DataFrameScan;
 use crate::prelude::*;


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/15032

For the record, I do like the idea of the `AsyncRead` and `AsyncSeek` and `AsyncWrite` abstraction. We just want to eliminate the possibility of the implementation causing network connection resets. Maybe I have to split the object store deduplication from this PR. 

@ritchie46 is there any way we can determine whether this solves https://github.com/pola-rs/polars/issues/14384?