### PR TITLE
fix: Recurse on map field during type conversion

### DIFF
--- a/crates/polars-parquet/src/arrow/read/schema/metadata.rs
+++ b/crates/polars-parquet/src/arrow/read/schema/metadata.rs
@@ -51,7 +51,7 @@ fn convert_data_type(data_type: ArrowDataType) -> ArrowDataType {
             // Polars doesn't support Map.
             // A map is physically a `List<Struct<K, V>>`
             // So we read as list.
-            LargeList(field)
+            LargeList(Box::new(convert_field(*field)))
         },
         dt => dt,
     }


### PR DESCRIPTION
fixes #14639

When encountering a map column (which in Arrow is a `List<Struct<K, V>>`), the code failed to recursively convert subtypes into valid Polars types. This caused an error when a map column contained a string (UTF-8) type, as it would not convert the UTF-8 column into a UTF-8 view type, leading to type assertion failures later.