### PR TITLE
fix: Incorrectly preserved sorted flag when concatenating sorted series containing nulls

### DIFF
--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -236,6 +236,12 @@ impl<T: PolarsDataType> ChunkedArray<T> {
                 0
             };
 
+            debug_assert!(
+                // If we are lucky this catches something.
+                unsafe { self.get_unchecked(out).is_some() },
+                "incorrect sorted flag"
+            );
+
             Some(out)
         } else {
             first_non_null(self.iter_validities())
@@ -259,6 +265,12 @@ impl<T: PolarsDataType> ChunkedArray<T> {
                 // nulls are all at the end
                 self.len() - self.null_count() - 1
             };
+
+            debug_assert!(
+                // If we are lucky this catches something.
+                unsafe { self.get_unchecked(out).is_some() },
+                "incorrect sorted flag"
+            );
 
             Some(out)
         } else {

--- a/crates/polars-core/src/chunked_array/mod.rs
+++ b/crates/polars-core/src/chunked_array/mod.rs
@@ -189,6 +189,11 @@ impl<T: PolarsDataType> ChunkedArray<T> {
         self.bit_settings.contains(Settings::SORTED_DSC)
     }
 
+    /// Whether `self` is sorted in any direction.
+    pub(crate) fn is_sorted_any(&self) -> bool {
+        self.is_sorted_ascending_flag() || self.is_sorted_descending_flag()
+    }
+
     pub fn unset_fast_explode_list(&mut self) {
         self.bit_settings.remove(Settings::FAST_EXPLODE_LIST)
     }
@@ -224,10 +229,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             None
         }
         // We now know there is at least 1 non-null item in the array, and self.len() > 0
-        else if matches!(
-            self.is_sorted_flag(),
-            IsSorted::Ascending | IsSorted::Descending
-        ) {
+        else if self.is_sorted_any() {
             let out = if unsafe { self.downcast_get_unchecked(0).is_null_unchecked(0) } {
                 // nulls are all at the start
                 self.null_count()
@@ -238,7 +240,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
 
             debug_assert!(
                 // If we are lucky this catches something.
-                unsafe { self.get_unchecked(out).is_some() },
+                unsafe { self.get_unchecked(out) }.is_some(),
                 "incorrect sorted flag"
             );
 
@@ -254,10 +256,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
             None
         }
         // We now know there is at least 1 non-null item in the array, and self.len() > 0
-        else if matches!(
-            self.is_sorted_flag(),
-            IsSorted::Ascending | IsSorted::Descending
-        ) {
+        else if self.is_sorted_any() {
             let out = if unsafe { self.downcast_get_unchecked(0).is_null_unchecked(0) } {
                 // nulls are all at the start
                 self.len() - 1
@@ -268,7 +267,7 @@ impl<T: PolarsDataType> ChunkedArray<T> {
 
             debug_assert!(
                 // If we are lucky this catches something.
-                unsafe { self.get_unchecked(out).is_some() },
+                unsafe { self.get_unchecked(out) }.is_some(),
                 "incorrect sorted flag"
             );
 

--- a/crates/polars-core/src/chunked_array/ops/append.rs
+++ b/crates/polars-core/src/chunked_array/ops/append.rs
@@ -25,18 +25,30 @@ where
         ca.null_count() != ca.len(),
         other.null_count() != other.len(),
     ) {
-        (false, false) => IsSorted::Ascending, // all null
+        (false, false) => IsSorted::Ascending,
         (false, true) => {
-            if other.is_sorted_any() && 1 + other.last_non_null().unwrap() == other.len() {
-                // nulls first
+            if
+            // lhs is empty, just take sorted flag from rhs
+            ca.is_empty()
+                || (
+                    // lhs is non-empty and all-null, so rhs must have nulls ordered first
+                    other.is_sorted_any() && 1 + other.last_non_null().unwrap() == other.len()
+                )
+            {
                 other.is_sorted_flag()
             } else {
                 IsSorted::Not
             }
         },
         (true, false) => {
-            if ca.is_sorted_any() && ca.first_non_null().unwrap() == 0 {
-                // nulls last
+            if
+            // rhs is empty, just take sorted flag from lhs
+            other.is_empty()
+                || (
+                    // rhs is non-empty and all-null, so lhs must have nulls ordered last
+                    ca.is_sorted_any() && ca.first_non_null().unwrap() == 0
+                )
+            {
                 ca.is_sorted_flag()
             } else {
                 IsSorted::Not

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -885,12 +885,12 @@ def test_sorted_flag_concat_15072() -> None:
 
     # coerces sorted flag if there is only a single non-null
     assert pl.concat(
-        (pl.Series([3, 2]).set_sorted(descending=True), pl.Series([1]).set_sorted())
+        (pl.Series([3, 2]).set_sorted(descending=True), pl.Series([1]))
     ).flags["SORTED_DESC"]
 
     assert pl.concat(
         (
             pl.Series([3, 2]).set_sorted(descending=True),
-            pl.Series([1, None]).set_sorted(),
+            pl.Series([1, None]),
         )
     ).flags["SORTED_DESC"]

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -885,7 +885,7 @@ def test_sorted_flag_concat_15072() -> None:
 
     # Concat with empty series
     s = pl.Series([None, 1]).set_sorted()
-    
+
     out = pl.concat((s.clear(), s))
     assert_series_equal(out, s)
     assert out.flags["SORTED_ASC"]

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -882,15 +882,3 @@ def test_sorted_flag_concat_15072() -> None:
             )
         )
     )
-
-    # coerces sorted flag if there is only a single non-null
-    assert pl.concat(
-        (pl.Series([3, 2]).set_sorted(descending=True), pl.Series([1]))
-    ).flags["SORTED_DESC"]
-
-    assert pl.concat(
-        (
-            pl.Series([3, 2]).set_sorted(descending=True),
-            pl.Series([1, None]),
-        )
-    ).flags["SORTED_DESC"]

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -882,3 +882,24 @@ def test_sorted_flag_concat_15072() -> None:
             )
         )
     )
+
+    # Concat with empty series
+    s = pl.Series([None, 1]).set_sorted()
+    
+    out = pl.concat((s.clear(), s))
+    assert_series_equal(out, s)
+    assert out.flags["SORTED_ASC"]
+
+    out = pl.concat((s, s.clear()))
+    assert_series_equal(out, s)
+    assert out.flags["SORTED_ASC"]
+
+    s = pl.Series([1, None]).set_sorted()
+
+    out = pl.concat((s.clear(), s))
+    assert_series_equal(out, s)
+    assert out.flags["SORTED_ASC"]
+
+    out = pl.concat((s, s.clear()))
+    assert_series_equal(out, s)
+    assert out.flags["SORTED_ASC"]

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -796,3 +796,101 @@ def test_sorted_flag_14552() -> None:
 
     a = pl.concat([a, a], rechunk=False)
     assert not a.join(a, on="a", how="left")["a"].flags["SORTED_ASC"]
+
+
+def test_sorted_flag_concat_15072() -> None:
+    def is_sorted_any(s: pl.Series) -> bool:
+        return s.flags["SORTED_ASC"] or s.flags["SORTED_DESC"]
+
+    def is_not_sorted(s: pl.Series) -> bool:
+        return not is_sorted_any(s)
+
+    # Both all-null
+    a = pl.Series("x", [None, None], dtype=pl.Int8)
+    b = pl.Series("x", [None, None], dtype=pl.Int8)
+    assert pl.concat((a, b)).flags["SORTED_ASC"]
+
+    # left all-null, right 0 < null_count < len
+    a = pl.Series("x", [None, None], dtype=pl.Int8)
+    b = pl.Series("x", [1, 2, 1, None], dtype=pl.Int8)
+
+    out = pl.concat((a, b.sort()))
+    assert out.to_list() == [None, None, None, 1, 1, 2]
+    assert out.flags["SORTED_ASC"]
+
+    out = pl.concat((a, b.sort(descending=True)))
+    assert out.to_list() == [None, None, None, 2, 1, 1]
+    assert out.flags["SORTED_DESC"]
+
+    out = pl.concat((a, b.sort(nulls_last=True)))
+    assert out.to_list() == [None, None, 1, 1, 2, None]
+    assert is_not_sorted(out)
+
+    out = pl.concat((a, b.sort(nulls_last=True, descending=True)))
+    assert out.to_list() == [None, None, 2, 1, 1, None]
+    assert is_not_sorted(out)
+
+    # left 0 < null_count < len, right all-null
+    a = pl.Series("x", [1, 2, 1, None], dtype=pl.Int8)
+    b = pl.Series("x", [None, None], dtype=pl.Int8)
+
+    out = pl.concat((a.sort(), b))
+    assert out.to_list() == [None, 1, 1, 2, None, None]
+    assert is_not_sorted(out)
+
+    out = pl.concat((a.sort(descending=True), b))
+    assert out.to_list() == [None, 2, 1, 1, None, None]
+    assert is_not_sorted(out)
+
+    out = pl.concat((a.sort(nulls_last=True), b))
+    assert out.to_list() == [1, 1, 2, None, None, None]
+    assert out.flags["SORTED_ASC"]
+
+    out = pl.concat((a.sort(nulls_last=True, descending=True), b))
+    assert out.to_list() == [2, 1, 1, None, None, None]
+    assert out.flags["SORTED_DESC"]
+
+    # both 0 < null_count < len
+    assert pl.concat(
+        (
+            pl.Series([None, 1]).set_sorted(),
+            pl.Series([2]).set_sorted(),
+        )
+    ).flags["SORTED_ASC"]
+
+    assert is_not_sorted(
+        pl.concat(
+            (
+                pl.Series([None, 1]).set_sorted(),
+                pl.Series([2, None]).set_sorted(),
+            )
+        )
+    )
+
+    assert pl.concat(
+        (
+            pl.Series([None, 2]).set_sorted(descending=True),
+            pl.Series([1]).set_sorted(descending=True),
+        )
+    ).flags["SORTED_DESC"]
+
+    assert is_not_sorted(
+        pl.concat(
+            (
+                pl.Series([None, 2]).set_sorted(descending=True),
+                pl.Series([1, None]).set_sorted(descending=True),
+            )
+        )
+    )
+
+    # coerces sorted flag if there is only a single non-null
+    assert pl.concat(
+        (pl.Series([3, 2]).set_sorted(descending=True), pl.Series([1]).set_sorted())
+    ).flags["SORTED_DESC"]
+
+    assert pl.concat(
+        (
+            pl.Series([3, 2]).set_sorted(descending=True),
+            pl.Series([1, None]).set_sorted(),
+        )
+    ).flags["SORTED_DESC"]


### PR DESCRIPTION
Fixes https://github.com/pola-rs/polars/issues/15072.

Existing releases are incorrectly setting the sorted flag:
```python
s = pl.Series([None, 1])
out = pl.concat(3 * [s.sort()])
print(out)
shape: (4,)
Series: '' [i64]
[
        null
        1
        null
        1
]
print(out.flags)
{'SORTED_ASC': True, 'SORTED_DESC': False}
               ^^^^

```