### PR TITLE
feat: raise informative error for rolling_* aggs with `by` of invalid dtype

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/rolling.rs
+++ b/crates/polars-plan/src/dsl/function_expr/rolling.rs
@@ -85,7 +85,11 @@ fn convert<'a>(
                 by.cast(&DataType::Datetime(TimeUnit::Milliseconds, None))?,
                 &None,
             ),
-            dt => polars_bail!(opq = expr_name, got = dt, expected = "date/datetime"),
+            dt => polars_bail!(InvalidOperation:
+                "in `{}` operation, `by` argument of dtype `{}` is not supported (expected `{}`)",
+                expr_name,
+                dt,
+                "date/datetime"),
         };
         if by.is_sorted_flag() != IsSorted::Ascending && options.warn_if_unsorted {
             polars_warn!(format!(

--- a/py-polars/tests/unit/operations/rolling/test_rolling.py
+++ b/py-polars/tests/unit/operations/rolling/test_rolling.py
@@ -8,7 +8,7 @@ import pytest
 from numpy import nan
 
 import polars as pl
-from polars.exceptions import ComputeError
+from polars.exceptions import ComputeError, InvalidOperationError
 from polars.testing import assert_frame_equal, assert_series_equal
 
 if TYPE_CHECKING:
@@ -215,6 +215,12 @@ def test_rolling_crossing_dst(
         {"ts": ts, "value": expected_values}, schema_overrides={"value": expected_dtype}
     )
     assert_frame_equal(result, expected)
+
+
+def test_rolling_by_invalid() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).sort("a")
+    with pytest.raises(InvalidOperationError, match="`rolling_min` operation"):
+        df.select(pl.col("b").rolling_min(2, by="a"))
 
 
 def test_rolling_infinity() -> None:


### PR DESCRIPTION
closes #15087 

the example from the linked issue would now raise
```
polars.exceptions.InvalidOperationError: in `rolling_min` operation, `by` argument of dtype `i64` is not supported (expected `date/datetime`)
```