### PR TITLE
fix(rust): Ensure `eprintln!` is only called within debug/verbose context

### DIFF
--- a/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
@@ -222,10 +222,14 @@ fn can_run_partitioned(
         if from_partitioned_ds {
             let estimated_cardinality = unique_estimate as f32 / original_df.height() as f32;
             if estimated_cardinality < 0.4 {
-                eprintln!("PARTITIONED DS");
+                if state.verbose() {
+                    eprintln!("PARTITIONED DS");
+                }
                 Ok(true)
             } else {
-                eprintln!("PARTITIONED DS: estimated cardinality: {estimated_cardinality} exceeded the boundary: 0.4, running default HASH AGGREGATION");
+                if state.verbose() {
+                    eprintln!("PARTITIONED DS: estimated cardinality: {estimated_cardinality} exceeded the boundary: 0.4, running default HASH AGGREGATION");
+                }
                 Ok(false)
             }
         } else if unique_estimate > unique_count_boundary {

--- a/crates/polars-pipe/src/executors/sinks/sort/sink.rs
+++ b/crates/polars-pipe/src/executors/sinks/sort/sink.rs
@@ -60,7 +60,9 @@ impl SortSink {
             ooc_start: None,
         };
         if ooc {
-            eprintln!("OOC sort forced");
+            if verbose() {
+                eprintln!("OOC sort forced");
+            }
             out.init_ooc().unwrap();
         }
         out


### PR DESCRIPTION
Resolves #15099.

Also found one more `eprintln` that wasn't properly wrapped.

Not worth adding a unit test, but OP's example no longer prints the result to stderr.