### PR TITLE
docs(python): Update write_database code blocks in user guide

### DIFF
--- a/docs/src/python/user-guide/io/database.py
+++ b/docs/src/python/user-guide/io/database.py
@@ -31,13 +31,13 @@ pl.read_database_uri(query=query, uri=uri, engine="adbc")
 uri = "postgresql://username:password@server:port/database"
 df = pl.DataFrame({"foo": [1, 2, 3]})
 
-df.write_database(table_name="records",  uri=uri)
+df.write_database(table_name="records",  connection=uri)
 # --8<-- [end:write]
 
 # --8<-- [start:write_adbc]
 uri = "postgresql://username:password@server:port/database"
 df = pl.DataFrame({"foo": [1, 2, 3]})
 
-df.write_database(table_name="records", uri=uri, engine="adbc")
+df.write_database(table_name="records", connection=uri, engine="adbc")
 # --8<-- [end:write_adbc]
 """


### PR DESCRIPTION
Changed the Python code examples for writing to a database in the user guide to match the py-polars polars.DataFrame.write_database API reference documentation. The current example of "uri=uri" returns an error when ran on the latest stable release of polars.