### PR TITLE
fix: Output `u32` when `sum_horizontal` provided with single boolean column

### DIFF
--- a/crates/polars-core/src/frame/mod.rs
+++ b/crates/polars-core/src/frame/mod.rs
@@ -2527,7 +2527,11 @@ impl DataFrame {
                 }
             },
             1 => Ok(Some(apply_null_strategy(
-                non_null_cols[0].clone(),
+                if non_null_cols[0].dtype() == &DataType::Boolean {
+                    non_null_cols[0].cast(&DataType::UInt32)?
+                } else {
+                    non_null_cols[0].clone()
+                },
                 null_strategy,
             )?)),
             2 => sum_fn(

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -271,7 +271,13 @@ impl FunctionExpr {
             ForwardFill { .. } => mapper.with_same_dtype(),
             MaxHorizontal => mapper.map_to_supertype(),
             MinHorizontal => mapper.map_to_supertype(),
-            SumHorizontal => mapper.map_to_supertype(),
+            SumHorizontal => {
+                if mapper.fields[0].data_type() == &DataType::Boolean {
+                    mapper.with_dtype(DataType::UInt32)
+                } else {
+                    mapper.map_to_supertype()
+                }
+            },
             MeanHorizontal => mapper.map_to_float_dtype(),
             #[cfg(feature = "ewma")]
             EwmMean { .. } => mapper.map_to_float_dtype(),

--- a/py-polars/tests/unit/test_schema.py
+++ b/py-polars/tests/unit/test_schema.py
@@ -632,3 +632,8 @@ def test_literal_subtract_schema_13284() -> None:
         .group_by("a")
         .len()
     ).schema == OrderedDict([("a", pl.UInt8), ("len", pl.UInt32)])
+
+
+def test_schema_boolean_sum_horizontal() -> None:
+    lf = pl.LazyFrame({"a": [True, False]}).select(pl.sum_horizontal("a"))
+    assert lf.schema == OrderedDict([("a", pl.UInt32)])


### PR DESCRIPTION
Resolves #15102.