### PR TITLE
feat(python): Add `strict` parameter to `from_dict/from_records`

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -26,6 +26,7 @@ def from_dict(
     schema: SchemaDefinition | None = None,
     *,
     schema_overrides: SchemaDict | None = None,
+    strict: bool = True,
 ) -> DataFrame:
     """
     Construct a DataFrame from a dictionary of sequences.
@@ -50,6 +51,11 @@ def from_dict(
     schema_overrides : dict, default None
         Support type specification or override of one or more columns; note that
         any dtypes inferred from the columns param will be overridden.
+    strict : bool, default True
+        Throw an error if any `data` value does not exactly match the given or inferred
+        data type for that column. If set to `False`, values that do not match the data
+        type are cast to that data type or, if casting is not possible, set to null
+        instead.
 
     Returns
     -------
@@ -70,7 +76,7 @@ def from_dict(
     └─────┴─────┘
     """
     return pl.DataFrame._from_dict(
-        data, schema=schema, schema_overrides=schema_overrides
+        data, schema=schema, schema_overrides=schema_overrides, strict=strict
     )
 
 
@@ -79,6 +85,7 @@ def from_dicts(
     schema: SchemaDefinition | None = None,
     *,
     schema_overrides: SchemaDict | None = None,
+    strict: bool = True,
     infer_schema_length: int | None = N_INFER_DEFAULT,
 ) -> DataFrame:
     """
@@ -106,6 +113,11 @@ def from_dicts(
         adding them to the schema.
     schema_overrides : dict, default None
         Support override of inferred types for one or more columns.
+    strict : bool, default True
+        Throw an error if any `data` value does not exactly match the given or inferred
+        data type for that column. If set to `False`, values that do not match the data
+        type are cast to that data type or, if casting is not possible, set to null
+        instead.
     infer_schema_length
         The maximum number of rows to scan for schema inference.
         If set to `None`, the full data may be scanned *(this is slow)*.
@@ -172,6 +184,7 @@ def from_dicts(
         data,
         schema=schema,
         schema_overrides=schema_overrides,
+        strict=strict,
         infer_schema_length=infer_schema_length,
     )
 
@@ -181,6 +194,7 @@ def from_records(
     schema: SchemaDefinition | None = None,
     *,
     schema_overrides: SchemaDict | None = None,
+    strict: bool = True,
     orient: Orientation | None = None,
     infer_schema_length: int | None = N_INFER_DEFAULT,
 ) -> DataFrame:
@@ -206,6 +220,11 @@ def from_records(
     schema_overrides : dict, default None
         Support type specification or override of one or more columns; note that
         any dtypes inferred from the columns param will be overridden.
+    strict : bool, default True
+        Throw an error if any `data` value does not exactly match the given or inferred
+        data type for that column. If set to `False`, values that do not match the data
+        type are cast to that data type or, if casting is not possible, set to null
+        instead.
     orient : {None, 'col', 'row'}
         Whether to interpret two-dimensional data as columns or as rows. If None,
         the orientation is inferred by matching the columns and data dimensions. If
@@ -238,6 +257,7 @@ def from_records(
         data,
         schema=schema,
         schema_overrides=schema_overrides,
+        strict=strict,
         orient=orient,
         infer_schema_length=infer_schema_length,
     )

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -448,31 +448,19 @@ class DataFrame:
         schema: SchemaDefinition | None = None,
         *,
         schema_overrides: SchemaDict | None = None,
+        strict: bool = True,
     ) -> Self:
         """
         Construct a DataFrame from a dictionary of sequences.
 
-        Parameters
-        ----------
-        data : dict of sequences
-          Two-dimensional data represented as a dictionary. dict must contain
-          Sequences.
-        schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
-            The DataFrame schema may be declared in several ways:
-
-            * As a dict of {name:type} pairs; if type is None, it will be auto-inferred.
-            * As a list of column names; in this case types are automatically inferred.
-            * As a list of (name,type) pairs; this is equivalent to the dictionary form.
-
-            If you supply a list of column names that does not match the names in the
-            underlying data, the names given here will overwrite them. The number
-            of names given in the schema should match the underlying data dimensions.
-        schema_overrides : dict, default None
-          Support type specification or override of one or more columns; note that
-          any dtypes inferred from the columns param will be overridden.
+        See Also
+        --------
+        polars.convert.from_dict
         """
         return cls._from_pydf(
-            dict_to_pydf(data, schema=schema, schema_overrides=schema_overrides)
+            dict_to_pydf(
+                data, schema=schema, schema_overrides=schema_overrides, strict=strict
+            )
         )
 
     @classmethod
@@ -482,6 +470,7 @@ class DataFrame:
         schema: SchemaDefinition | None = None,
         *,
         schema_overrides: SchemaDict | None = None,
+        strict: bool = True,
         orient: Orientation | None = None,
         infer_schema_length: int | None = N_INFER_DEFAULT,
     ) -> Self:
@@ -490,13 +479,14 @@ class DataFrame:
 
         See Also
         --------
-        polars.io.from_records
+        polars.convert.from_records
         """
         return cls._from_pydf(
             sequence_to_pydf(
                 data,
                 schema=schema,
                 schema_overrides=schema_overrides,
+                strict=strict,
                 orient=orient,
                 infer_schema_length=infer_schema_length,
             )


### PR DESCRIPTION
Following up on https://github.com/pola-rs/polars/pull/15034

These use the same logic as the DataFrame constructor, so they should also get a `strict` parameter.