### PR TITLE
feat(python): Add support for `async` SQLAlchemy connections to `read_database`

### DIFF
--- a/py-polars/polars/datatypes/convert.py
+++ b/py-polars/polars/datatypes/convert.py
@@ -280,15 +280,14 @@ def _infer_dtype_from_database_typename(
                 return None  # there's a timezone, but we don't know what it is
         unit = _timeunit_from_precision(modifier) if modifier else "us"
         dtype = Datetime(time_unit=(unit or "us"))  # type: ignore[arg-type]
-
-    elif re.sub(r"\d", "", value) in ("INTERVAL", "TIMEDELTA"):
-        dtype = Duration
-
-    elif value in ("DATE", "DATE32", "DATE64"):
-        dtype = Date
-
-    elif value in ("TIME", "TIME32", "TIME64"):
-        dtype = Time
+    else:
+        value = re.sub(r"\d", "", value)
+        if value in ("INTERVAL", "TIMEDELTA"):
+            dtype = Duration
+        elif value == "DATE":
+            dtype = Date
+        elif value == "TIME":
+            dtype = Time
 
     if not dtype and raise_unmatched:
         msg = f"cannot infer dtype from {original_value!r} string value"

--- a/py-polars/polars/io/database.py
+++ b/py-polars/polars/io/database.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import re
 import sys
+import warnings
+from collections.abc import Coroutine
 from contextlib import suppress
 from importlib import import_module
 from inspect import Parameter, isclass, signature
@@ -46,6 +48,8 @@ if TYPE_CHECKING:
         from sqlalchemy.sql.expression import Selectable
     except ImportError:
         Selectable: TypeAlias = Any  # type: ignore[no-redef]
+
+    from sqlalchemy.sql.elements import TextClause
 
 
 class _ArrowDriverProperties_(TypedDict):
@@ -201,11 +205,20 @@ class ConnectionExecutor:
     ) -> None:
         # if we created it and are finished with it, we can
         # close the cursor (but NOT the connection)
-        if self.can_close_cursor and hasattr(self.cursor, "close"):
+        if type(self.cursor).__name__ == "AsyncConnection":
+            self._run_async(self._close_async_cursor())
+        elif self.can_close_cursor and hasattr(self.cursor, "close"):
             self.cursor.close()
 
     def __repr__(self) -> str:
         return f"<{type(self).__name__} module={self.driver_name!r}>"
+
+    async def _close_async_cursor(self) -> None:
+        if self.can_close_cursor and hasattr(self.cursor, "close"):
+            from sqlalchemy.ext.asyncio.exc import AsyncContextNotStarted
+
+            with suppress(AsyncContextNotStarted):
+                await self.cursor.close()
 
     def _fetch_arrow(
         self,
@@ -306,39 +319,61 @@ class ConnectionExecutor:
         """Return resultset data row-wise for frame init."""
         from polars import DataFrame
 
-        if hasattr(self.result, "fetchall"):
-            if self.driver_name == "sqlalchemy":
-                if hasattr(self.result, "cursor"):
-                    cursor_desc = {d[0]: d[1:] for d in self.result.cursor.description}
-                elif hasattr(self.result, "_metadata"):
-                    cursor_desc = {k: None for k in self.result._metadata.keys}
+        if is_async := isinstance(original_result := self.result, Coroutine):
+            self.result = self._run_async(self.result)
+        try:
+            if hasattr(self.result, "fetchall"):
+                if self.driver_name == "sqlalchemy":
+                    if hasattr(self.result, "cursor"):
+                        cursor_desc = {
+                            d[0]: d[1:] for d in self.result.cursor.description
+                        }
+                    elif hasattr(self.result, "_metadata"):
+                        cursor_desc = {k: None for k in self.result._metadata.keys}
+                    else:
+                        msg = f"Unable to determine metadata from query result; {self.result!r}"
+                        raise ValueError(msg)
                 else:
-                    msg = f"Unable to determine metadata from query result; {self.result!r}"
-                    raise ValueError(msg)
-            else:
-                cursor_desc = {d[0]: d[1:] for d in self.result.description}
+                    cursor_desc = {d[0]: d[1:] for d in self.result.description}
 
-            schema_overrides = self._inject_type_overrides(
-                description=cursor_desc,
-                schema_overrides=(schema_overrides or {}),
-            )
-            result_columns = list(cursor_desc)
-            frames = (
-                DataFrame(
-                    data=rows,
-                    schema=result_columns,
-                    schema_overrides=schema_overrides,
-                    infer_schema_length=infer_schema_length,
-                    orient="row",
+                schema_overrides = self._inject_type_overrides(
+                    description=cursor_desc,
+                    schema_overrides=(schema_overrides or {}),
                 )
-                for rows in (
-                    list(self._fetchmany_rows(self.result, batch_size))
-                    if iter_batches
-                    else [self._fetchall_rows(self.result)]  # type: ignore[list-item]
+                result_columns = list(cursor_desc)
+                frames = (
+                    DataFrame(
+                        data=rows,
+                        schema=result_columns,
+                        schema_overrides=schema_overrides,
+                        infer_schema_length=infer_schema_length,
+                        orient="row",
+                    )
+                    for rows in (
+                        list(self._fetchmany_rows(self.result, batch_size))
+                        if iter_batches
+                        else [self._fetchall_rows(self.result)]  # type: ignore[list-item]
+                    )
                 )
-            )
-            return frames if iter_batches else next(frames)  # type: ignore[arg-type]
-        return None
+                return frames if iter_batches else next(frames)  # type: ignore[arg-type]
+            return None
+        finally:
+            if is_async:
+                original_result.close()
+
+    @staticmethod
+    def _run_async(co: Coroutine) -> Any:  # type: ignore[type-arg]
+        """Consolidate async event loop acquisition and coroutine/func execution."""
+        import asyncio
+
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                loop = asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        return loop.run_until_complete(co)
 
     def _inject_type_overrides(
         self,
@@ -398,8 +433,10 @@ class ConnectionExecutor:
     def _normalise_cursor(self, conn: Any) -> Cursor:
         """Normalise a connection object such that we have the query executor."""
         if self.driver_name == "sqlalchemy":
-            self.can_close_cursor = (conn_type := type(conn).__name__) == "Engine"
-            if conn_type == "Session":
+            conn_type = type(conn).__name__
+            self.can_close_cursor = conn_type.endswith("Engine")
+
+            if conn_type in ("Session", "async_sessionmaker"):
                 return conn
             else:
                 # where possible, use the raw connection to access arrow integration
@@ -409,7 +446,7 @@ class ConnectionExecutor:
                 elif conn.engine.driver == "duckdb_engine":
                     self.driver_name = "duckdb"
                     return conn.engine.raw_connection().driver_connection.c
-                elif conn_type == "Engine":
+                elif conn_type in ("AsyncEngine", "Engine"):
                     return conn.connect()
                 else:
                     return conn
@@ -427,9 +464,68 @@ class ConnectionExecutor:
         msg = f"Unrecognised connection {conn!r}; unable to find 'execute' method"
         raise TypeError(msg)
 
+    async def _sqlalchemy_async_execute(
+        self, query: TextClause, *, is_session: bool = False, **options: Any
+    ) -> Any:
+        """Execute a query using an async SQLAlchemy connection."""
+        cursor = self.cursor.begin() if is_session else self.cursor  # type: ignore[attr-defined]
+        async with cursor as conn:
+            result = await conn.execute(query, **options)
+            return result
+
+    def _sqlalchemy_setup(
+        self, query: str | TextClause | Selectable, options: dict[str, Any]
+    ) -> tuple[Any, dict[str, Any], str | TextClause | Selectable]:
+        """Prepare a query for execution using a SQLAlchemy connection."""
+        from sqlalchemy.orm import Session
+        from sqlalchemy.sql import text
+        from sqlalchemy.sql.elements import TextClause
+
+        is_async = (cursor_type_name := type(self.cursor).__name__) in (
+            "AsyncConnection",
+            "async_sessionmaker",
+        )
+        param_key = "parameters"
+        cursor_execute = None
+
+        if (
+            isinstance(self.cursor, Session)
+            and "parameters" in options
+            and "params" not in options
+        ):
+            options = options.copy()
+            options["params"] = options.pop("parameters")
+            param_key = "params"
+
+        params = options.get(param_key)
+        if (
+            not is_async
+            and isinstance(params, Sequence)
+            and hasattr(self.cursor, "exec_driver_sql")
+        ):
+            cursor_execute = self.cursor.exec_driver_sql
+            if isinstance(query, TextClause):
+                query = str(query)
+            if isinstance(params, list) and not all(
+                isinstance(p, (dict, tuple)) for p in params
+            ):
+                options[param_key] = tuple(params)
+
+        elif isinstance(query, str):
+            query = text(query)
+
+        if cursor_execute is None:
+            cursor_execute = (
+                self._sqlalchemy_async_execute if is_async else self.cursor.execute
+            )
+        if cursor_type_name == "async_sessionmaker":
+            options["is_session"] = True
+
+        return cursor_execute, options, query
+
     def execute(
         self,
-        query: str | Selectable,
+        query: str | TextClause | Selectable,
         *,
         options: dict[str, Any] | None = None,
         select_queries_only: bool = True,
@@ -442,42 +538,18 @@ class ConnectionExecutor:
                 raise UnsuitableSQLError(msg)
 
         options = options or {}
-        cursor_execute = self.cursor.execute
 
         if self.driver_name == "sqlalchemy":
-            from sqlalchemy.orm import Session
-
-            param_key = "parameters"
-            if (
-                isinstance(self.cursor, Session)
-                and "parameters" in options
-                and "params" not in options
-            ):
-                options = options.copy()
-                options["params"] = options.pop("parameters")
-                param_key = "params"
-
-            if isinstance(query, str):
-                params = options.get(param_key)
-                if isinstance(params, Sequence) and hasattr(
-                    self.cursor, "exec_driver_sql"
-                ):
-                    cursor_execute = self.cursor.exec_driver_sql
-                    if isinstance(params, list) and not all(
-                        isinstance(p, (dict, tuple)) for p in params
-                    ):
-                        options[param_key] = tuple(params)
-                else:
-                    from sqlalchemy.sql import text
-
-                    query = text(query)  # type: ignore[assignment]
+            cursor_execute, options, query = self._sqlalchemy_setup(query, options)
+        else:
+            cursor_execute = self.cursor.execute
 
         # note: some cursor execute methods (eg: sqlite3) only take positional
         # params, hence the slightly convoluted resolution of the 'options' dict
         try:
             params = signature(cursor_execute).parameters
         except ValueError:
-            params = {}
+            params = {}  # type: ignore[assignment]
 
         if not options or any(
             p.kind in (Parameter.KEYWORD_ONLY, Parameter.POSITIONAL_OR_KEYWORD)

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -1995,12 +1995,12 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
             This functionality is considered **unstable**. It may be changed
             at any point without it being considered a breaking change.
 
-        Collects into a DataFrame (like :func:`collect`), but instead of returning
-        DataFrame directly, they are scheduled to be collected inside thread pool,
+        Collects into a DataFrame (like :func:`collect`) but, instead of returning
+        a DataFrame directly, it is scheduled to be collected inside a thread pool,
         while this method returns almost instantly.
 
-        May be useful if you use gevent or asyncio and want to release control to other
-        greenlets/tasks while LazyFrames are being collected.
+        This can be useful if you use `gevent` or `asyncio` and want to release
+        control to other greenlets/tasks while LazyFrames are being collected.
 
         Parameters
         ----------
@@ -2032,20 +2032,20 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
                 at any point without it being considered a breaking change.
 
             .. note::
-                Use :func:`explain` to see if Polars can process the query in streaming
-                mode.
+                Use :func:`explain` to see if Polars can process the query in
+                streaming mode.
 
         Returns
         -------
-        If `gevent=False` (default) then returns awaitable.
+        If `gevent=False` (default) then returns an awaitable.
 
-        If `gevent=True` then returns wrapper that has
+        If `gevent=True` then returns wrapper that has a
         `.get(block=True, timeout=None)` method.
 
         See Also
         --------
         polars.collect_all : Collect multiple LazyFrames at the same time.
-        polars.collect_all_async: Collect multiple LazyFrames at the same time lazily.
+        polars.collect_all_async : Collect multiple LazyFrames at the same time lazily.
 
         Notes
         -----

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -26,6 +26,7 @@ tzdata; platform_system == 'Windows'
 SQLAlchemy
 adbc_driver_manager; python_version >= '3.9' and platform_system != 'Windows'
 adbc_driver_sqlite; python_version >= '3.9' and platform_system != 'Windows'
+aiosqlite
 # TODO: Remove version constraint for connectorx when Python 3.12 is supported:
 # https://github.com/sfu-db/connector-x/issues/527
 connectorx; python_version <= '3.11'


### PR DESCRIPTION
Ref: https://stackoverflow.com/questions/77166897

Database connectivity continues to expand; with this PR we can now seamlessly init a `DataFrame` from _async_ SQLAlchemy `Connection`, `Engine`, and `Session` objects.

Added async unit test coverage using `aiosqlite` (SQLite), but additionally validated the PR locally using `asyncpg` (PostgreSQL) and `aioodbc` (ODBC) drivers.

## Examples

**SQL Server over ODBC** (async driver):
```python
from sqlalchemy.ext.asyncio import create_async_engine
import polars as pl

odbc_string = "Driver={ODBC Driver 17 for SQL Server};Server=localhost"
async_conn = create_async_engine(
    f"mssql+aioodbc:///?odbc_connect={odbc_string}"
)
pl.read_database(
    query = "SELECT optname,value FROM master.dbo.MSreplication_options",
    connection = async_conn,
)
# shape: (3, 2)
# ┌────────────────┬───────┐
# │ optname        ┆ value │
# │ ---            ┆ ---   │
# │ str            ┆ bool  │
# ╞════════════════╪═══════╡
# │ transactional  ┆ true  │
# │ merge          ┆ true  │
# │ security_model ┆ true  │
# └────────────────┴───────┘
```
**SQLite** (async driver):
```python
async_conn = create_async_engine("sqlite+aiosqlite:///chinook.db")

pl.read_database( 
    query = """
      SELECT l.Title AS album_name, r.Name AS artist
      FROM albums l INNER JOIN artists r ON r.ArtistId = l.ArtistId
      ORDER BY l.Title LIMIT 4
    """,
    connection = async_conn,
)
# shape: (4, 2)
# ┌────────────────────────────────┬────────────────────────────────┐
# │ album_name                     ┆ artist                         │
# │ ---                            ┆ ---                            │
# │ str                            ┆ str                            │
# ╞════════════════════════════════╪════════════════════════════════╡
# │ ...And Justice For All         ┆ Metallica                      │
# │ 20th Century Masters - The Mi… ┆ Scorpions                      │
# │ A Copland Celebration, Vol. I  ┆ Aaron Copland & London Sympho… │
# │ A Matter of Life and Death     ┆ Iron Maiden                    │
# └────────────────────────────────┴────────────────────────────────┘
```

## Also

The "execute" method of the internal ConnectionExecutor abstraction was getting a bit long, so factored out the SQLAlchemy setup block into its own method for clarity. Next commit will likely be a larger-scale (and overdue ;) refactor of _all_ the database code into its own "io.database" subdirectory to facilitate easier maintenance.