### PR TITLE
fix(python): Consistently raise `TypeError` on constructor failure

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -64,7 +64,7 @@ pub enum PolarsError {
     OutOfBounds(ErrString),
     #[error("field not found: {0}")]
     SchemaFieldNotFound(ErrString),
-    #[error("data types don't match: {0}")]
+    #[error("{0}")]
     SchemaMismatch(ErrString),
     #[error("lengths don't match: {0}")]
     ShapeMismatch(ErrString),

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -57,7 +57,7 @@ def test_fallback_with_dtype_strict(
 def test_fallback_with_dtype_strict_failure(
     dtype: pl.PolarsDataType, values: list[Any]
 ) -> None:
-    with pytest.raises(pl.SchemaError, match="unexpected value"):
+    with pytest.raises(TypeError, match="unexpected value"):
         PySeries.new_from_any_values_and_dtype("", values, dtype, strict=True)
 
 
@@ -230,7 +230,7 @@ def test_fallback_without_dtype(
     ],
 )
 def test_fallback_without_dtype_strict_failure(values: list[Any]) -> None:
-    with pytest.raises(pl.SchemaError, match="unexpected value"):
+    with pytest.raises(TypeError, match="unexpected value"):
         PySeries.new_from_any_values("", values, strict=True)
 
 

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -11,7 +11,7 @@ import polars as pl
 def test_df_mixed_dtypes_string() -> None:
     data = {"x": [["abc", 12, 34.5]], "y": [1]}
 
-    with pytest.raises(pl.SchemaError, match="unexpected value"):
+    with pytest.raises(TypeError, match="unexpected value"):
         pl.DataFrame(data, strict=True)
 
     df = pl.DataFrame(data, strict=False)
@@ -21,8 +21,8 @@ def test_df_mixed_dtypes_string() -> None:
 
 def test_df_mixed_dtypes_object() -> None:
     data = {"x": [[b"abc", 12, 34.5]], "y": [1]}
-    # with pytest.raises(pl.SchemaError, match="unexpected value"):
-    with pytest.raises(pl.ComputeError, match="failed to determine supertype"):
+
+    with pytest.raises(TypeError, match="failed to determine supertype"):
         pl.DataFrame(data, strict=True)
 
     df = pl.DataFrame(data, strict=False)
@@ -55,7 +55,7 @@ def test_df_init_from_generator_dict_view() -> None:
         "vals": d.values(),
         "itms": d.items(),
     }
-    with pytest.raises(pl.SchemaError, match="unexpected value"):
+    with pytest.raises(TypeError, match="unexpected value"):
         pl.DataFrame(data, strict=True)
 
     df = pl.DataFrame(data, strict=False)

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -10,7 +10,7 @@ import polars as pl
 def test_series_mixed_dtypes_list() -> None:
     values = [[0.1, 1]]
 
-    with pytest.raises(pl.SchemaError, match="unexpected value"):
+    with pytest.raises(TypeError, match="unexpected value"):
         pl.Series(values)
 
     s = pl.Series(values, strict=False)
@@ -21,7 +21,7 @@ def test_series_mixed_dtypes_list() -> None:
 def test_series_mixed_dtypes_string() -> None:
     values = [[12], "foo", 9]
 
-    with pytest.raises(pl.SchemaError, match="unexpected value"):
+    with pytest.raises(TypeError, match="unexpected value"):
         pl.Series(values)
 
     s = pl.Series(values, strict=False)
@@ -33,7 +33,7 @@ def test_series_mixed_dtypes_string() -> None:
 def test_series_mixed_dtypes_object() -> None:
     values = [[12], b"foo", 9]
 
-    with pytest.raises(pl.SchemaError, match="unexpected value"):
+    with pytest.raises(TypeError, match="unexpected value"):
         pl.Series(values)
 
     s = pl.Series(values, strict=False)

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -390,7 +390,6 @@ def test_decimal_unique() -> None:
 
 
 def test_decimal_write_parquet_12375() -> None:
-    f = io.BytesIO()
     df = pl.DataFrame(
         {
             "hi": [True, False, True, False],
@@ -399,6 +398,7 @@ def test_decimal_write_parquet_12375() -> None:
     )
     assert df["bye"].dtype == pl.Decimal
 
+    f = io.BytesIO()
     df.write_parquet(f)
 
 


### PR DESCRIPTION
The constructors would various errors depending on where they would fail, while the cause was the same: mixed types in the data. This makes sure the same error type is raised everywhere (TypeError) and includes a hint to set `strict=False`.