### PR TITLE
fix(python): Address a regression in `from_records`

### DIFF
--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -404,7 +404,7 @@ def _expand_dict_data(
 
 
 def sequence_to_pydf(
-    data: Sequence[Any] | None,
+    data: Sequence[Any],
     schema: SchemaDefinition | None = None,
     *,
     schema_overrides: SchemaDict | None = None,
@@ -413,7 +413,7 @@ def sequence_to_pydf(
     infer_schema_length: int | None = N_INFER_DEFAULT,
 ) -> PyDataFrame:
     """Construct a PyDataFrame from a sequence."""
-    if data is None or len(data) == 0:
+    if len(data) == 0:
         return dict_to_pydf({}, schema=schema, schema_overrides=schema_overrides)
 
     return _sequence_to_pydf_dispatcher(

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -404,7 +404,7 @@ def _expand_dict_data(
 
 
 def sequence_to_pydf(
-    data: Sequence[Any],
+    data: Sequence[Any] | Series,
     schema: SchemaDefinition | None = None,
     *,
     schema_overrides: SchemaDict | None = None,
@@ -430,7 +430,7 @@ def sequence_to_pydf(
 @singledispatch
 def _sequence_to_pydf_dispatcher(
     first_element: Any,
-    data: Sequence[Any],
+    data: Sequence[Any] | Series,
     schema: SchemaDefinition | None,
     *,
     schema_overrides: SchemaDict | None,

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -15,7 +15,10 @@ from polars._utils.construction.dataframe import (
     sequence_to_pydf,
 )
 from polars._utils.construction.series import arrow_to_pyseries, pandas_to_pyseries
-from polars._utils.deprecation import deprecate_renamed_parameter
+from polars._utils.deprecation import (
+    deprecate_renamed_parameter,
+    issue_deprecation_warning,
+)
 from polars._utils.various import _cast_repr_strings_with_schema
 from polars._utils.wrap import wrap_df, wrap_s
 from polars.datatypes import N_INFER_DEFAULT, Categorical, List, Object, String, Struct
@@ -268,6 +271,15 @@ def from_records(
     │ 3   ┆ 6   │
     └─────┴─────┘
     """
+    if isinstance(data, pl.Series):
+        msg_prefix = "`from_records` does not support Series input"
+        msg = (
+            f"{msg_prefix}; unpack Struct records using `srs.struct.unnest()` instead"
+            if data.dtype == Struct
+            else f"{msg_prefix}; pass to `DataFrame` constructor directly"
+        )
+        issue_deprecation_warning(message=msg, version="0.20.17")
+
     return wrap_df(
         sequence_to_pydf(
             data,

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -205,7 +205,7 @@ def from_dicts(
 
 
 def from_records(
-    data: Sequence[Any],
+    data: Sequence[Any] | Series,
     schema: SchemaDefinition | None = None,
     *,
     schema_overrides: SchemaDict | None = None,
@@ -216,12 +216,11 @@ def from_records(
     """
     Construct a DataFrame from a sequence of sequences. This operation clones data.
 
-    Note that this is slower than creating from columnar memory.
-
     Parameters
     ----------
-    data : Sequence of sequences
-        Two-dimensional data represented as a sequence of sequences.
+    data : Sequence of sequences (or dicts)
+        Two-dimensional data represented as a sequence of dicts or sequence
+        of sequences.
     schema : Sequence of str, (str,DataType) pairs, or a {str:DataType,} dict
         The DataFrame schema may be declared in several ways:
 

--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -15,10 +15,7 @@ from polars._utils.construction.dataframe import (
     sequence_to_pydf,
 )
 from polars._utils.construction.series import arrow_to_pyseries, pandas_to_pyseries
-from polars._utils.deprecation import (
-    deprecate_renamed_parameter,
-    issue_deprecation_warning,
-)
+from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.various import _cast_repr_strings_with_schema
 from polars._utils.wrap import wrap_df, wrap_s
 from polars.datatypes import N_INFER_DEFAULT, Categorical, List, Object, String, Struct
@@ -271,15 +268,6 @@ def from_records(
     │ 3   ┆ 6   │
     └─────┴─────┘
     """
-    if isinstance(data, pl.Series):
-        msg_prefix = "`from_records` does not support Series input"
-        msg = (
-            f"{msg_prefix}; unpack Struct records using `srs.struct.unnest()` instead"
-            if data.dtype == Struct
-            else f"{msg_prefix}; pass to `DataFrame` constructor directly"
-        )
-        issue_deprecation_warning(message=msg, version="0.20.17")
-
     return wrap_df(
         sequence_to_pydf(
             data,

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1215,15 +1215,27 @@ def test_from_rows_of_dicts() -> None:
 
 def test_from_records_struct_series_15195() -> None:
     series_record_data = pl.Series([{"x": "abcdefg", "y": 123456, "z": 0.0}])
+    record_schema = {"x": pl.String, "y": pl.Int32, "z": pl.Float32}
     expected = pl.DataFrame(
         data={"x": ["abcdefg"], "y": [123456], "z": [0.0]},
-        schema={"x": pl.String, "y": pl.Int32, "z": pl.Float32},
+        schema=record_schema,
     )
-    df = pl.from_records(
-        data=series_record_data,  # type: ignore[arg-type]
-        schema_overrides={"y": pl.Int32, "z": pl.Float32},
+
+    assert_frame_equal(
+        expected,
+        pl.from_records(
+            data=series_record_data,
+            schema_overrides={"y": pl.Int32, "z": pl.Float32},
+        ),
     )
-    assert_frame_equal(expected, df)
+
+    assert_frame_equal(
+        expected,
+        pl.from_records(
+            data=series_record_data,
+            schema=record_schema,
+        ),
+    )
 
 
 def test_from_records_with_schema_overrides_12032() -> None:

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1213,24 +1213,15 @@ def test_from_rows_of_dicts() -> None:
         assert df3.schema == {"id": pl.Int16, "value": pl.Int32}
 
 
-def test_from_records_in_series_15195() -> None:
-    # note: this was not intended to be a valid way to use `from_records`, but
-    # it was a regression that caused it to start throwing errors, so until
-    # being formally deprecated (imminent!) it should not raise an error...
-
-    with pytest.warns(
-        DeprecationWarning,
-        match=r"`from_records` does not support Series .* `srs\.struct\.unnest",
-    ):
-        series_record_data = pl.Series([{"x": "abcdefg", "y": 123456, "z": 0.0}])
-        df = pl.from_records(
-            data=series_record_data,  # type: ignore[arg-type]
-            schema_overrides={"y": pl.Int32, "z": pl.Float32},
-        )
-
+def test_from_records_struct_series_15195() -> None:
+    series_record_data = pl.Series([{"x": "abcdefg", "y": 123456, "z": 0.0}])
     expected = pl.DataFrame(
         data={"x": ["abcdefg"], "y": [123456], "z": [0.0]},
         schema={"x": pl.String, "y": pl.Int32, "z": pl.Float32},
+    )
+    df = pl.from_records(
+        data=series_record_data,  # type: ignore[arg-type]
+        schema_overrides={"y": pl.Int32, "z": pl.Float32},
     )
     assert_frame_equal(expected, df)
 


### PR DESCRIPTION
Closes #15195.

~~We never intended to accept Series input in `from_records` so, while I have fixed the regression, I have _also_ made it start to generate a `DeprecationWarning` in this case.~~ 

**Update:** Fixed the regression and added a (very) fast-path for this case.

### Performance 🚀 

Because this update identifies the Struct Series as-such, it can use `Series.unnest` to create a frame at near-zero cost. Previously the Series records were being read out as Python dicts before being read back in, for a _hugely_ expensive/unnecessary round-trip:
```python
from codetiming import Timer
import polars as pl

data = [{
    "a": [1,2,3,4,5,6], 
    "b": [9,8,7,6,5,4], 
    "c": [1.0,None,-1,1,0,0],
}] * 1_000_000

# create a series containing 1m simple records
s = pl.Series(name="s", values=data, strict=False)
```
**Timing:**
```python
with Timer():
    df = pl.from_records(s)
```
```
Before: ~10.2 secs
After: 0.0001 secs
------------------
Speedup: ~100,000x 🤣 
```
_(Tested with a fresh `make build-release-native` binary on an M1 Max)_