### PR TITLE
feat(python): More robust handling of `async` database calls

### DIFF
--- a/py-polars/polars/meta/versions.py
+++ b/py-polars/polars/meta/versions.py
@@ -28,6 +28,7 @@ def show_versions() -> None:
     gevent:               24.2.1
     hvplot:               0.9.2
     matplotlib:           3.8.3
+    nest_asyncio:         1.6.0
     numpy:                1.26.4
     openpyxl:             3.1.2
     pandas:               2.2.1
@@ -70,6 +71,7 @@ def _get_dependency_info() -> dict[str, str]:
         "gevent",
         "hvplot",
         "matplotlib",
+        "nest_asyncio",
         "numpy",
         "openpyxl",
         "pandas",

--- a/py-polars/pyproject.toml
+++ b/py-polars/pyproject.toml
@@ -40,6 +40,7 @@ Changelog = "https://github.com/pola-rs/polars/releases"
 [project.optional-dependencies]
 # NOTE: keep this list in sync with show_versions() and requirements-dev.txt
 adbc = ["adbc_driver_manager", "adbc_driver_sqlite"]
+async = ["nest_asyncio"]
 cloudpickle = ["cloudpickle"]
 connectorx = ["connectorx >= 0.3.2"]
 deltalake = ["deltalake >= 0.14.0"]
@@ -60,7 +61,7 @@ timezone = ["backports.zoneinfo; python_version < '3.9'", "tzdata; platform_syst
 xlsx2csv = ["xlsx2csv >= 0.8.0"]
 xlsxwriter = ["xlsxwriter"]
 all = [
-  "polars[adbc,cloudpickle,connectorx,deltalake,fastexcel,fsspec,gevent,numpy,pandas,plot,pyarrow,pydantic,pyiceberg,sqlalchemy,timezone,xlsx2csv,xlsxwriter]",
+  "polars[adbc,async,cloudpickle,connectorx,deltalake,fastexcel,fsspec,gevent,numpy,pandas,plot,pyarrow,pydantic,pyiceberg,sqlalchemy,timezone,xlsx2csv,xlsxwriter]",
 ]
 
 [tool.maturin]
@@ -94,6 +95,7 @@ module = [
   "kuzu",
   "matplotlib.*",
   "moto.server",
+  "nest_asyncio",
   "openpyxl",
   "polars.polars",
   "pyarrow.*",

--- a/py-polars/requirements-dev.txt
+++ b/py-polars/requirements-dev.txt
@@ -52,6 +52,7 @@ hvplot>=0.9.1
 matplotlib
 # Other
 gevent
+nest_asyncio
 
 # -------
 # TOOLING


### PR DESCRIPTION
Ref: https://github.com/pola-rs/polars/pull/15162#issuecomment-2011780504

@stinodego: This brings forward some additional `async` industrialisation that I was working on yesterday, while adding some initial `SurrealDB`[^1] integration (have got a new `SurrealDBCursorProxy` class working in another branch[^2]). 

I haven't been able to reproduce the `ResourceWarning` locally yet, but this _may_ solve it by explicitly closing any event loops that we know we created in-context (and it doesn't seem to have occurred in these tests, so... maybe? 🤔) 

Also improves/fixes interaction with Notebooks/Jupyter (nesting `asyncio` calls).

[^1]: SurrealDB features: https://surrealdb.com/features
[^2]: SurrealDB + Polars: https://github.com/surrealdb/surrealdb.py/pull/91#issuecomment-2009802667