### PR TITLE
refactor: Add `wrapping_abs` to arithmetic kernel

### DIFF
--- a/crates/polars-compute/src/arithmetic/float.rs
+++ b/crates/polars-compute/src/arithmetic/float.rs
@@ -8,6 +8,10 @@ macro_rules! impl_float_arith_kernel {
         impl PrimitiveArithmeticKernelImpl for $T {
             type TrueDivT = $T;
 
+            fn prim_wrapping_abs(lhs: PArr<$T>) -> PArr<$T> {
+                prim_unary_values(lhs, |x| x.abs())
+            }
+
             fn prim_wrapping_neg(lhs: PArr<$T>) -> PArr<$T> {
                 prim_unary_values(lhs, |x| -x)
             }

--- a/crates/polars-compute/src/arithmetic/mod.rs
+++ b/crates/polars-compute/src/arithmetic/mod.rs
@@ -8,6 +8,7 @@ pub trait ArithmeticKernel: Sized + Array {
     type Scalar;
     type TrueDivT: NativeType;
 
+    fn wrapping_abs(self) -> Self;
     fn wrapping_neg(self) -> Self;
     fn wrapping_add(self, rhs: Self) -> Self;
     fn wrapping_sub(self, rhs: Self) -> Self;
@@ -84,6 +85,7 @@ use PrimitiveArray as PArr;
 pub trait PrimitiveArithmeticKernelImpl: NativeType {
     type TrueDivT: NativeType;
 
+    fn prim_wrapping_abs(lhs: PArr<Self>) -> PArr<Self>;
     fn prim_wrapping_neg(lhs: PArr<Self>) -> PArr<Self>;
     fn prim_wrapping_add(lhs: PArr<Self>, rhs: PArr<Self>) -> PArr<Self>;
     fn prim_wrapping_sub(lhs: PArr<Self>, rhs: PArr<Self>) -> PArr<Self>;
@@ -113,6 +115,7 @@ impl<T: HasPrimitiveArithmeticKernel> ArithmeticKernel for PrimitiveArray<T> {
     type Scalar = T;
     type TrueDivT = T::TrueDivT;
 
+    fn wrapping_abs(self) -> Self { T::prim_wrapping_abs(self) }
     fn wrapping_neg(self) -> Self { T::prim_wrapping_neg(self) }
     fn wrapping_add(self, rhs: Self) -> Self { T::prim_wrapping_add(self, rhs) }
     fn wrapping_sub(self, rhs: Self) -> Self { T::prim_wrapping_sub(self, rhs) }

--- a/crates/polars-compute/src/arithmetic/signed.rs
+++ b/crates/polars-compute/src/arithmetic/signed.rs
@@ -12,6 +12,10 @@ macro_rules! impl_signed_arith_kernel {
         impl PrimitiveArithmeticKernelImpl for $T {
             type TrueDivT = f64;
 
+            fn prim_wrapping_abs(lhs: PArr<$T>) -> PArr<$T> {
+                prim_unary_values(lhs, |x| x.wrapping_abs())
+            }
+
             fn prim_wrapping_neg(lhs: PArr<$T>) -> PArr<$T> {
                 prim_unary_values(lhs, |x| x.wrapping_neg())
             }

--- a/crates/polars-compute/src/arithmetic/unsigned.rs
+++ b/crates/polars-compute/src/arithmetic/unsigned.rs
@@ -11,6 +11,10 @@ macro_rules! impl_unsigned_arith_kernel {
         impl PrimitiveArithmeticKernelImpl for $T {
             type TrueDivT = f64;
 
+            fn prim_wrapping_abs(lhs: PArr<$T>) -> PArr<$T> {
+                lhs
+            }
+
             fn prim_wrapping_neg(lhs: PArr<$T>) -> PArr<$T> {
                 prim_unary_values(lhs, |x| x.wrapping_neg())
             }

--- a/crates/polars-core/src/chunked_array/arithmetic/numeric.rs
+++ b/crates/polars-core/src/chunked_array/arithmetic/numeric.rs
@@ -56,6 +56,7 @@ pub trait ArithmeticChunked {
     type Out;
     type TrueDivOut;
 
+    fn wrapping_abs(self) -> Self::Out;
     fn wrapping_neg(self) -> Self::Out;
     fn wrapping_add(self, rhs: Self) -> Self::Out;
     fn wrapping_sub(self, rhs: Self) -> Self::Out;
@@ -90,6 +91,10 @@ impl<T: PolarsNumericType> ArithmeticChunked for ChunkedArray<T> {
     type Scalar = T::Native;
     type Out = ChunkedArray<T>;
     type TrueDivOut = ChunkedArray<<T::Native as NumericNative>::TrueDivPolarsType>;
+
+    fn wrapping_abs(self) -> Self::Out {
+        unary_kernel_owned(self, ArithmeticKernel::wrapping_abs)
+    }
 
     fn wrapping_neg(self) -> Self::Out {
         unary_kernel_owned(self, ArithmeticKernel::wrapping_neg)
@@ -244,6 +249,10 @@ impl<T: PolarsNumericType> ArithmeticChunked for &ChunkedArray<T> {
     type Scalar = T::Native;
     type Out = ChunkedArray<T>;
     type TrueDivOut = ChunkedArray<<T::Native as NumericNative>::TrueDivPolarsType>;
+
+    fn wrapping_abs(self) -> Self::Out {
+        unary_kernel(self, |a| ArithmeticKernel::wrapping_abs(a.clone()))
+    }
 
     fn wrapping_neg(self) -> Self::Out {
         unary_kernel(self, |a| ArithmeticKernel::wrapping_neg(a.clone()))

--- a/crates/polars-ops/src/series/ops/abs.rs
+++ b/crates/polars-ops/src/series/ops/abs.rs
@@ -1,40 +1,31 @@
-use num_traits::Signed;
 use polars_core::prelude::*;
-
-fn abs_numeric<T>(ca: &ChunkedArray<T>) -> ChunkedArray<T>
-where
-    T: PolarsNumericType,
-    T::Native: Signed,
-{
-    ca.apply_values(|v| v.abs())
-}
 
 /// Convert numerical values to their absolute value.
 pub fn abs(s: &Series) -> PolarsResult<Series> {
     use DataType::*;
     let out = match s.dtype() {
         #[cfg(feature = "dtype-i8")]
-        Int8 => abs_numeric(s.i8().unwrap()).into_series(),
+        Int8 => s.i8().unwrap().wrapping_abs().into_series(),
         #[cfg(feature = "dtype-i16")]
-        Int16 => abs_numeric(s.i16().unwrap()).into_series(),
-        Int32 => abs_numeric(s.i32().unwrap()).into_series(),
-        Int64 => abs_numeric(s.i64().unwrap()).into_series(),
-        Float32 => abs_numeric(s.f32().unwrap()).into_series(),
-        Float64 => abs_numeric(s.f64().unwrap()).into_series(),
+        Int16 => s.i16().unwrap().wrapping_abs().into_series(),
+        Int32 => s.i32().unwrap().wrapping_abs().into_series(),
+        Int64 => s.i64().unwrap().wrapping_abs().into_series(),
+        Float32 => s.f32().unwrap().wrapping_abs().into_series(),
+        Float64 => s.f64().unwrap().wrapping_abs().into_series(),
         #[cfg(feature = "dtype-decimal")]
         Decimal(_, _) => {
             let ca = s.decimal().unwrap();
             let precision = ca.precision();
             let scale = ca.scale();
 
-            let out = abs_numeric(ca.as_ref());
+            let out = ca.as_ref().wrapping_abs();
             out.into_decimal_unchecked(precision, scale).into_series()
         },
         #[cfg(feature = "dtype-duration")]
         Duration(_) => {
             let physical = s.to_physical_repr();
             let ca = physical.i64().unwrap();
-            let out = abs_numeric(ca).into_series();
+            let out = ca.wrapping_abs().into_series();
             out.cast(s.dtype())?
         },
         dt if dt.is_unsigned_integer() => s.clone(),

--- a/crates/polars-ops/src/series/ops/negate.rs
+++ b/crates/polars-ops/src/series/ops/negate.rs
@@ -1,39 +1,30 @@
-use num_traits::Signed;
 use polars_core::prelude::*;
-
-fn negate_numeric<T>(ca: &ChunkedArray<T>) -> ChunkedArray<T>
-where
-    T: PolarsNumericType,
-    T::Native: Signed,
-{
-    ca.apply_values(|v| -v)
-}
 
 pub fn negate(s: &Series) -> PolarsResult<Series> {
     use DataType::*;
     let out = match s.dtype() {
         #[cfg(feature = "dtype-i8")]
-        Int8 => negate_numeric(s.i8().unwrap()).into_series(),
+        Int8 => s.i8().unwrap().wrapping_neg().into_series(),
         #[cfg(feature = "dtype-i16")]
-        Int16 => negate_numeric(s.i16().unwrap()).into_series(),
-        Int32 => negate_numeric(s.i32().unwrap()).into_series(),
-        Int64 => negate_numeric(s.i64().unwrap()).into_series(),
-        Float32 => negate_numeric(s.f32().unwrap()).into_series(),
-        Float64 => negate_numeric(s.f64().unwrap()).into_series(),
+        Int16 => s.i16().unwrap().wrapping_neg().into_series(),
+        Int32 => s.i32().unwrap().wrapping_neg().into_series(),
+        Int64 => s.i64().unwrap().wrapping_neg().into_series(),
+        Float32 => s.f32().unwrap().wrapping_neg().into_series(),
+        Float64 => s.f64().unwrap().wrapping_neg().into_series(),
         #[cfg(feature = "dtype-decimal")]
         Decimal(_, _) => {
             let ca = s.decimal().unwrap();
             let precision = ca.precision();
             let scale = ca.scale();
 
-            let out = negate_numeric(ca.as_ref());
+            let out = ca.as_ref().wrapping_neg();
             out.into_decimal_unchecked(precision, scale).into_series()
         },
         #[cfg(feature = "dtype-duration")]
         Duration(_) => {
             let physical = s.to_physical_repr();
             let ca = physical.i64().unwrap();
-            let out = negate_numeric(ca).into_series();
+            let out = ca.wrapping_neg().into_series();
             out.cast(s.dtype())?
         },
         dt => polars_bail!(opq = neg, dt),

--- a/py-polars/tests/unit/operations/arithmetic/test_neg.py
+++ b/py-polars/tests/unit/operations/arithmetic/test_neg.py
@@ -41,10 +41,10 @@ def test_neg_duration() -> None:
     assert_frame_equal(result, expected)
 
 
-def test_neg_overflow() -> None:
+def test_neg_overflow_wrapping() -> None:
     df = pl.DataFrame({"a": [-128]}, schema={"a": pl.Int8})
-    with pytest.raises(pl.PolarsPanicError, match="attempt to negate with overflow"):
-        df.select(-pl.col("a"))
+    result = df.select(-pl.col("a"))
+    assert_frame_equal(result, df)
 
 
 def test_neg_unsigned_int() -> None:

--- a/py-polars/tests/unit/operations/test_abs.py
+++ b/py-polars/tests/unit/operations/test_abs.py
@@ -74,10 +74,10 @@ def test_abs_duration() -> None:
     assert_frame_equal(result, expected)
 
 
-def test_abs_overflow() -> None:
+def test_abs_overflow_wrapping() -> None:
     df = pl.DataFrame({"a": [-128]}, schema={"a": pl.Int8})
-    with pytest.raises(pl.PolarsPanicError, match="attempt to negate with overflow"):
-        df.select(pl.col("a").abs())
+    result = df.select(pl.col("a").abs())
+    assert_frame_equal(result, df)
 
 
 def test_abs_unsigned_int() -> None:


### PR DESCRIPTION
Helps address the test failures on release builds - see #15207