### PR TITLE
fix(python): Consistent expansion of nested struct data during `DataFrame` init from dict

### DIFF
--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -134,7 +134,7 @@ def dict_to_pydf(
     else:
         data_series = [
             s._s
-            for s in _expand_dict_scalars(
+            for s in _expand_dict_values(
                 data,
                 schema_overrides=schema_overrides,
                 strict=strict,
@@ -307,7 +307,7 @@ def _post_apply_columns(
     return pydf
 
 
-def _expand_dict_scalars(
+def _expand_dict_values(
     data: Mapping[str, Sequence[object] | Mapping[str, Sequence[object]] | Series],
     *,
     schema_overrides: SchemaDict | None = None,
@@ -334,9 +334,20 @@ def _expand_dict_scalars(
             for name, val in data.items():
                 dtype = dtypes.get(name)
                 if isinstance(val, dict) and dtype != Struct:
-                    updated_data[name] = pl.DataFrame(val, strict=strict).to_struct(
-                        name
-                    )
+                    vdf = pl.DataFrame(val, strict=strict)
+                    if (
+                        len(vdf) == 1
+                        and array_len > 1
+                        and all(not d.is_nested() for d in vdf.schema.values())
+                    ):
+                        s_vals = {
+                            nm: vdf[nm].extend_constant(v, n=(array_len - 1))
+                            for nm, v in val.items()
+                        }
+                        st = pl.DataFrame(s_vals).to_struct(name)
+                    else:
+                        st = vdf.to_struct(name)
+                    updated_data[name] = st
 
                 elif isinstance(val, pl.Series):
                     s = val.rename(name) if name != val.name else val

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -207,9 +207,9 @@ def _in_notebook() -> bool:
 
 
 def arrlen(obj: Any) -> int | None:
-    """Return length of (non-string) sequence object; returns None for non-sequences."""
+    """Return length of (non-string/dict) sequence; returns None for non-sequences."""
     try:
-        return None if isinstance(obj, str) else len(obj)
+        return None if isinstance(obj, (str, dict)) else len(obj)
     except TypeError:
         return None
 


### PR DESCRIPTION
Closes #15192.

New test coverage added for this edge-case.

Can follow-up with a further commit that handles nested values inside nested values (the dict expansion is currently constrained to a one-level scalar fast-path that allows us to make use of `extend_constant`).