### PR TITLE
feat(python): Improve `read_database` when reading from Kùzu graph database

### DIFF
--- a/py-polars/polars/io/database/_arrow_registry.py
+++ b/py-polars/polars/io/database/_arrow_registry.py
@@ -6,13 +6,15 @@ from typing import TypedDict
 class ArrowDriverProperties(TypedDict):
     # name of the method that fetches all arrow data; tuple form
     # calls the fetch_all method with the given chunk size (int)
-    fetch_all: str | tuple[str, int]
+    fetch_all: str
     # name of the method that fetches arrow data in batches
     fetch_batches: str | None
     # indicate whether the given batch size is respected exactly
     exact_batch_size: bool | None
     # repeat batch calls (if False, the batch call is a generator)
     repeat_batch_calls: bool
+    # if arrow/polars functionality requires a minimum module version
+    minimum_version: str | None
 
 
 ARROW_DRIVER_REGISTRY: dict[str, ArrowDriverProperties] = {
@@ -21,42 +23,48 @@ ARROW_DRIVER_REGISTRY: dict[str, ArrowDriverProperties] = {
         "fetch_batches": None,
         "exact_batch_size": None,
         "repeat_batch_calls": False,
+        "minimum_version": None,
     },
     "arrow_odbc_proxy": {
         "fetch_all": "fetch_arrow_table",
         "fetch_batches": "fetch_record_batches",
         "exact_batch_size": True,
         "repeat_batch_calls": False,
+        "minimum_version": None,
     },
     "databricks": {
         "fetch_all": "fetchall_arrow",
         "fetch_batches": "fetchmany_arrow",
         "exact_batch_size": True,
         "repeat_batch_calls": True,
+        "minimum_version": None,
     },
     "duckdb": {
         "fetch_all": "fetch_arrow_table",
         "fetch_batches": "fetch_record_batch",
         "exact_batch_size": True,
         "repeat_batch_calls": False,
+        "minimum_version": None,
     },
     "kuzu": {
-        # 'get_as_arrow' currently takes a mandatory chunk size
-        "fetch_all": ("get_as_arrow", 10_000),
+        "fetch_all": "get_as_pl",
         "fetch_batches": None,
         "exact_batch_size": None,
         "repeat_batch_calls": False,
+        "minimum_version": "0.3.2",
     },
     "snowflake": {
         "fetch_all": "fetch_arrow_all",
         "fetch_batches": "fetch_arrow_batches",
         "exact_batch_size": False,
         "repeat_batch_calls": False,
+        "minimum_version": None,
     },
     "turbodbc": {
         "fetch_all": "fetchallarrow",
         "fetch_batches": "fetcharrowbatches",
         "exact_batch_size": False,
         "repeat_batch_calls": False,
+        "minimum_version": None,
     },
 }


### PR DESCRIPTION
Can directly use `get_as_pl()` now; requires a new version of `kuzu`, but this seems reasonable. Added an optional "minimum_version" module/driver check to gracefully handle this - raises a `ModuleUpgradeRequired` exception if an insufficiently recent version is found. 

Note that the next release of `kuzu` will also include an improvement[^1] in Arrow chunking inside `get_as_pl()`, meaning we'll no longer need to rechunk (will always get a single chunk from now on).

[^1]: https://github.com/kuzudb/kuzu/pull/3110