### PR TITLE
refactor(rust): Refactor AnyValue construction for Categorical/Enum dtype

### DIFF
--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -413,8 +413,8 @@ fn any_values_to_categorical(
     dtype: &DataType,
     strict: bool,
 ) -> PolarsResult<Series> {
-    // TODO: Handle AnyValues of type Categorical / Enum
-    // TODO: Avoid materializing to String before casting to categorical
+    // TODO: Handle AnyValues of type Categorical/Enum.
+    // TODO: Avoid materializing to String before casting to Categorical/Enum.
     let ca = any_values_to_string(values, strict)?;
     if strict {
         ca.into_series().strict_cast(dtype)

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -40,7 +40,7 @@ impl Series {
                         DataType::Null
                     } else {
                         // Second pass to check for the nested null value that
-                        // toggled `all_flat_null` to false, e.g. a List(Null)
+                        // toggled `all_flat_null` to false, e.g. a List(Null).
                         let first_nested_null = values.iter().find(|av| !av.is_null()).unwrap();
                         first_nested_null.dtype()
                     }
@@ -257,7 +257,7 @@ fn any_values_to_string(values: &[AnyValue], strict: bool) -> PolarsResult<Strin
     }
     fn any_values_to_string_nonstrict(values: &[AnyValue]) -> StringChunked {
         let mut builder = StringChunkedBuilder::new("", values.len());
-        let mut owned = String::new(); // Amortize allocations
+        let mut owned = String::new(); // Amortize allocations.
         for av in values {
             match av {
                 AnyValue::String(s) => builder.append_value(s),
@@ -427,13 +427,13 @@ fn any_values_to_categorical(
 fn any_values_to_decimal(
     values: &[AnyValue],
     precision: Option<usize>,
-    scale: Option<usize>, // if None, we're inferring the scale
+    scale: Option<usize>, // If None, we're inferring the scale.
 ) -> PolarsResult<DecimalChunked> {
-    // two-pass approach, first we scan and record the scales, then convert (or not)
+    // Two-pass approach, first we scan and record the scales, then convert (or not).
     let mut scale_range: Option<(usize, usize)> = None;
     for av in values {
         let s_av = if av.is_integer() {
-            0 // integers are treated as decimals with scale of zero
+            0 // Integers are treated as decimals with scale of zero.
         } else if let AnyValue::Decimal(_, scale) = av {
             *scale
         } else if av.is_null() {
@@ -449,14 +449,14 @@ fn any_values_to_decimal(
         };
     }
     let Some((s_min, s_max)) = scale_range else {
-        // empty array or all nulls, return a decimal array with given scale (or 0 if inferring)
+        // Empty array or all nulls, return a decimal array with given scale (or 0 if inferring).
         return Ok(Int128Chunked::full_null("", values.len())
             .into_decimal_unchecked(precision, scale.unwrap_or(0)));
     };
     let scale = scale.unwrap_or(s_max);
     if s_max > scale {
-        // scale is provided but is lower than actual
-        // TODO: do we want lossy conversions here or not?
+        // Scale is provided but is lower than actual.
+        // TODO: Do we want lossy conversions here or not?
         polars_bail!(
             ComputeError:
             "unable to losslessly convert any-value of scale {s_max} to scale {}", scale,
@@ -474,7 +474,7 @@ fn any_values_to_decimal(
         } else if let AnyValue::Decimal(v, scale) = av {
             (*v, *scale)
         } else {
-            // it has to be a null because we've already checked it
+            // It has to be a null because we've already checked it.
             builder.append_null();
             continue;
         };
@@ -488,7 +488,7 @@ fn any_values_to_decimal(
         }
     }
 
-    // build the array and do a precision check if needed
+    // Build the array and do a precision check if needed.
     builder.finish().into_decimal(precision, scale)
 }
 
@@ -499,7 +499,7 @@ fn any_values_to_list(
 ) -> PolarsResult<ListChunked> {
     let target_dtype = DataType::List(Box::new(inner_type.clone()));
 
-    // this is handled downstream. The builder will choose the first non null type
+    // This is handled downstream. The builder will choose the first non null type.
     let mut valid = true;
     #[allow(unused_mut)]
     let mut out: ListChunked = if inner_type == &DataType::Null {
@@ -514,7 +514,7 @@ fn any_values_to_list(
             })
             .collect_trusted()
     }
-    // make sure that wrongly inferred AnyValues don't deviate from the datatype
+    // Make sure that wrongly inferred AnyValues don't deviate from the datatype.
     else {
         avs.iter()
             .map(|av| match av {
@@ -541,7 +541,7 @@ fn any_values_to_list(
         polars_bail!(SchemaMismatch: "unexpected value while building Series of type {:?}", target_dtype);
     }
 
-    // Ensure the logical type is correct for nested types
+    // Ensure the logical type is correct for nested types.
     #[cfg(feature = "dtype-struct")]
     if !matches!(inner_type, DataType::Null) && out.inner_dtype().is_nested() {
         unsafe {
@@ -570,7 +570,7 @@ fn any_values_to_array(
 
     let target_dtype = DataType::Array(Box::new(inner_type.clone()), width);
 
-    // this is handled downstream. The builder will choose the first non null type
+    // This is handled downstream. The builder will choose the first non null type.
     let mut valid = true;
     #[allow(unused_mut)]
     let mut out: ArrayChunked = if inner_type == &DataType::Null {
@@ -585,7 +585,7 @@ fn any_values_to_array(
             })
             .collect_ca_with_dtype("", target_dtype.clone())
     }
-    // make sure that wrongly inferred AnyValues don't deviate from the datatype
+    // Make sure that wrongly inferred AnyValues don't deviate from the datatype.
     else {
         avs.iter()
             .map(|av| match av {
@@ -617,7 +617,7 @@ fn any_values_to_array(
         SchemaMismatch: "got mixed size array widths where width {} was expected", width
     );
 
-    // Ensure the logical type is correct for nested types
+    // Ensure the logical type is correct for nested types.
     #[cfg(feature = "dtype-struct")]
     if !matches!(inner_type, DataType::Null) && out.inner_dtype().is_nested() {
         unsafe {

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -416,7 +416,11 @@ fn any_values_to_categorical(
     // TODO: Handle AnyValues of type Categorical / Enum
     // TODO: Avoid materializing to String before casting to categorical
     let ca = any_values_to_string(values, strict)?;
-    ca.cast(dtype)
+    if strict {
+        ca.into_series().strict_cast(dtype)
+    } else {
+        ca.cast(dtype)
+    }
 }
 
 #[cfg(feature = "dtype-decimal")]

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -24,6 +24,8 @@ from polars.polars import PySeries
         (pl.Time, [time(0, 0), time(23, 59, 59), None]),
         (pl.Datetime, [datetime(1970, 1, 1), datetime(2020, 12, 31, 23, 59, 59), None]),
         (pl.Duration, [timedelta(hours=0), timedelta(seconds=100), None]),
+        (pl.Categorical, ["a", "b", "a", None]),
+        (pl.Enum(["a", "b"]), ["a", "b", "a", None]),
     ],
 )
 @pytest.mark.parametrize("strict", [True, False])
@@ -52,6 +54,8 @@ def test_fallback_with_dtype_strict(
         (pl.Duration, [0, 1200]),
         (pl.Duration("ms"), [timedelta(hours=0), timedelta(seconds=100)]),
         (pl.Duration("ns"), [timedelta(hours=0), timedelta(seconds=100)]),
+        (pl.Categorical, [0, 1, 0]),
+        (pl.Enum(["a", "b"]), [0, 1, 0]),
     ],
 )
 def test_fallback_with_dtype_strict_failure(
@@ -177,6 +181,16 @@ def test_fallback_with_dtype_strict_failure(
                 None,
             ],
         ),
+        (
+            pl.Categorical,
+            ["xyz", 1, 2.5, date(1970, 1, 1), True, b"123", None],
+            ["xyz", "1", "2.5", "1970-01-01", "true", None, None],
+        ),
+        (
+            pl.Enum(["a", "b"]),
+            ["a", "b", "c", 1, 2, None],
+            ["a", "b", None, None, None, None],
+        ),
     ],
 )
 def test_fallback_with_dtype_nonstrict(
@@ -185,7 +199,6 @@ def test_fallback_with_dtype_nonstrict(
     result = wrap_s(
         PySeries.new_from_any_values_and_dtype("", values, dtype, strict=False)
     )
-    print(result.to_list())
     assert result.to_list() == expected
 
 

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -65,6 +65,14 @@ def test_fallback_with_dtype_strict_failure(
         PySeries.new_from_any_values_and_dtype("", values, dtype, strict=True)
 
 
+def test_fallback_with_dtype_strict_failure_enum_casting() -> None:
+    dtype = pl.Enum(["a", "b"])
+    values = ["a", "b", "c", None]
+
+    with pytest.raises(TypeError, match="conversion from `str` to `enum` failed"):
+        PySeries.new_from_any_values_and_dtype("", values, dtype, strict=True)
+
+
 @pytest.mark.parametrize(
     ("dtype", "values", "expected"),
     [

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -203,25 +203,25 @@ def test_fallback_with_dtype_nonstrict(
 
 
 @pytest.mark.parametrize(
-    ("values", "expected_dtype"),
+    ("expected_dtype", "values"),
     [
-        ([-1, 0, 100_000, None], pl.Int64),
-        ([-1.5, 0.0, 10.0, None], pl.Float64),
-        ([True, False, None], pl.Boolean),
-        ([b"123", b"xyz", None], pl.Binary),
-        (["123", "xyz", None], pl.String),
-        ([date(1970, 1, 1), date(2020, 12, 31), None], pl.Date),
-        ([time(0, 0), time(23, 59, 59), None], pl.Time),
+        (pl.Int64, [-1, 0, 100_000, None]),
+        (pl.Float64, [-1.5, 0.0, 10.0, None]),
+        (pl.Boolean, [True, False, None]),
+        (pl.Binary, [b"123", b"xyz", None]),
+        (pl.String, ["123", "xyz", None]),
+        (pl.Date, [date(1970, 1, 1), date(2020, 12, 31), None]),
+        (pl.Time, [time(0, 0), time(23, 59, 59), None]),
         (
-            [datetime(1970, 1, 1), datetime(2020, 12, 31, 23, 59, 59), None],
             pl.Datetime("us"),
+            [datetime(1970, 1, 1), datetime(2020, 12, 31, 23, 59, 59), None],
         ),
-        ([timedelta(hours=0), timedelta(seconds=100), None], pl.Duration("us")),
+        (pl.Duration("us"), [timedelta(hours=0), timedelta(seconds=100), None]),
     ],
 )
 @pytest.mark.parametrize("strict", [True, False])
 def test_fallback_without_dtype(
-    values: list[Any], expected_dtype: pl.PolarsDataType, strict: bool
+    expected_dtype: pl.PolarsDataType, values: list[Any], strict: bool
 ) -> None:
     result = wrap_s(PySeries.new_from_any_values("", values, strict=strict))
     assert result.to_list() == values


### PR DESCRIPTION
Cleans up the implementation and adds tests.

There is some room for improvement here, may get back to it later. Left some TODOs for now.