### PR TITLE
docs(python): Fix link to renamed method (.list.lengths -> .list.len)

### DIFF
--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -1376,7 +1376,7 @@ class ExprListNameSpace:
         Return the number of elements in each list.
 
         .. deprecated:: 0.19.8
-            This method has been renamed to :func:`len`.
+            This method has been renamed to :meth:`.len`.
         """
         return self.len()
 

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -1024,7 +1024,7 @@ class ListNameSpace:
         Return the number of elements in each list.
 
         .. deprecated:: 0.19.8
-            This method has been renamed to :func:`len`.
+            This method has been renamed to :meth:`.len`.
         """
 
     @deprecate_renamed_function("gather", version="0.19.14")


### PR DESCRIPTION
closes https://github.com/pola-rs/polars/issues/15221

I checked and this does the right thing:

![Screenshot 2024-03-22 113724](https://github.com/pola-rs/polars/assets/33491632/ad5466b7-e509-46af-b4b2-1eda1969d94b)
