### PR TITLE
fix(python): Avoid loading all columns in `read_parquet` when `columns` parameter is specified

### DIFF
--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -188,7 +188,7 @@ def read_parquet(
             columns = [lf.columns[i] for i in columns]
         lf = lf.select(columns)
 
-    return lf.collect(no_optimization=True)
+    return lf.collect()
 
 
 def read_parquet_schema(source: str | Path | IO[bytes] | bytes) -> dict[str, DataType]:


### PR DESCRIPTION
Fixes #15098 

Without optimizations, all columns would be loaded regardless of the `columns` argument, leading to higher CPU and memory usage.