### PR TITLE
feat(python): Add `name` parameter to `GroupBy.len` method

### DIFF
--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -196,13 +196,16 @@ def _unpack_schema(
     # determine column names from schema
     if isinstance(schema, Mapping):
         column_names: list[str] = list(schema)
-        # coerce schema to list[str | tuple[str, PolarsDataType | PythonDataType | None]
         schema = list(schema.items())
     else:
-        column_names = [
-            (col or f"column_{i}") if isinstance(col, str) else col[0]
-            for i, col in enumerate(schema)
-        ]
+        column_names = []
+        for i, col in enumerate(schema):
+            if isinstance(col, str):
+                unnamed = not col and col not in schema_overrides
+                col = f"column_{i}" if unnamed else col
+            else:
+                col = col[0]
+            column_names.append(col)
 
     # determine column dtypes from schema and lookup_names
     lookup: dict[str, str] | None = (

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -460,7 +460,7 @@ class GroupBy:
         Examples
         --------
         >>> df = pl.DataFrame({"a": ["Apple", "Apple", "Orange"], "b": [1, None, 2]})
-        >>> df.group_by("a", maintain_order=True).len()
+        >>> df.group_by("a").len()  # doctest: +IGNORE_RESULT
         shape: (2, 2)
         ┌────────┬─────┐
         │ a      ┆ len │
@@ -470,8 +470,7 @@ class GroupBy:
         │ Apple  ┆ 2   │
         │ Orange ┆ 1   │
         └────────┴─────┘
-
-        >>> df.group_by("a", maintain_order=True).len(name="n")
+        >>> df.group_by("a").len(name="n")  # doctest: +IGNORE_RESULT
         shape: (2, 2)
         ┌────────┬─────┐
         │ a      ┆ n   │

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -448,30 +448,44 @@ class GroupBy:
         """
         return self.agg(F.all())
 
-    def len(self) -> DataFrame:
+    def len(self, name: str | None = None) -> DataFrame:
         """
         Return the number of rows in each group.
 
+        Parameters
+        ----------
+        name
+            Assign a name to the resulting column; if unset, defaults to "len".
+
         Examples
         --------
-        >>> df = pl.DataFrame(
-        ...     {
-        ...         "a": ["apple", "apple", "orange"],
-        ...         "b": [1, None, 2],
-        ...     }
-        ... )
-        >>> df.group_by("a").len()  # doctest: +SKIP
+        >>> df = pl.DataFrame({"a": ["Apple", "Apple", "Orange"], "b": [1, None, 2]})
+        >>> df.group_by("a", maintain_order=True).len()
         shape: (2, 2)
         ┌────────┬─────┐
         │ a      ┆ len │
         │ ---    ┆ --- │
         │ str    ┆ u32 │
         ╞════════╪═════╡
-        │ apple  ┆ 2   │
-        │ orange ┆ 1   │
+        │ Apple  ┆ 2   │
+        │ Orange ┆ 1   │
+        └────────┴─────┘
+
+        >>> df.group_by("a", maintain_order=True).len(name="n")
+        shape: (2, 2)
+        ┌────────┬─────┐
+        │ a      ┆ n   │
+        │ ---    ┆ --- │
+        │ str    ┆ u32 │
+        ╞════════╪═════╡
+        │ Apple  ┆ 2   │
+        │ Orange ┆ 1   │
         └────────┴─────┘
         """
-        return self.agg(F.len())
+        len_expr = F.len()
+        if name is not None:
+            len_expr = len_expr.alias(name)
+        return self.agg(len_expr)
 
     @deprecate_renamed_function("len", version="0.20.5")
     def count(self) -> DataFrame:
@@ -487,7 +501,7 @@ class GroupBy:
         --------
         >>> df = pl.DataFrame(
         ...     {
-        ...         "a": ["apple", "apple", "orange"],
+        ...         "a": ["Apple", "Apple", "Orange"],
         ...         "b": [1, None, 2],
         ...     }
         ... )
@@ -498,8 +512,8 @@ class GroupBy:
         │ ---    ┆ ---   │
         │ str    ┆ u32   │
         ╞════════╪═══════╡
-        │ apple  ┆ 2     │
-        │ orange ┆ 1     │
+        │ Apple  ┆ 2     │
+        │ Orange ┆ 1     │
         └────────┴───────┘
         """
         return self.agg(F.len().alias("count"))

--- a/py-polars/polars/lazyframe/group_by.py
+++ b/py-polars/polars/lazyframe/group_by.py
@@ -333,20 +333,18 @@ class LazyGroupBy:
         """
         return self.agg(F.all())
 
-    def len(self) -> LazyFrame:
+    def len(self, name: str | None = None) -> LazyFrame:
         """
         Return the number of rows in each group.
 
-        Rows containing null values count towards the total.
+        Parameters
+        ----------
+        name
+            Assign a name to the resulting column; if unset, defaults to "len".
 
         Examples
         --------
-        >>> lf = pl.LazyFrame(
-        ...     {
-        ...         "a": ["apple", "apple", "orange"],
-        ...         "b": [1, None, 2],
-        ...     }
-        ... )
+        >>> lf = pl.LazyFrame({"a": ["Apple", "Apple", "Orange"], "b": [1, None, 2]})
         >>> lf.group_by("a").len().collect()  # doctest: +SKIP
         shape: (2, 2)
         ┌────────┬─────┐
@@ -354,11 +352,24 @@ class LazyGroupBy:
         │ ---    ┆ --- │
         │ str    ┆ u32 │
         ╞════════╪═════╡
-        │ apple  ┆ 2   │
-        │ orange ┆ 1   │
+        │ Apple  ┆ 2   │
+        │ Orange ┆ 1   │
+        └────────┴─────┘
+        >>> lf.group_by("a").len(name="n").collect()  # doctest: +SKIP
+        shape: (2, 2)
+        ┌────────┬─────┐
+        │ a      ┆ n   │
+        │ ---    ┆ --- │
+        │ str    ┆ u32 │
+        ╞════════╪═════╡
+        │ Apple  ┆ 2   │
+        │ Orange ┆ 1   │
         └────────┴─────┘
         """
-        return self.agg(F.len())
+        len_expr = F.len()
+        if name is not None:
+            len_expr = len_expr.alias(name)
+        return self.agg(len_expr)
 
     @deprecate_renamed_function("len", version="0.20.5")
     def count(self) -> LazyFrame:
@@ -374,7 +385,7 @@ class LazyGroupBy:
         --------
         >>> lf = pl.LazyFrame(
         ...     {
-        ...         "a": ["apple", "apple", "orange"],
+        ...         "a": ["Apple", "Apple", "Orange"],
         ...         "b": [1, None, 2],
         ...     }
         ... )
@@ -385,8 +396,8 @@ class LazyGroupBy:
         │ ---    ┆ ---   │
         │ str    ┆ u32   │
         ╞════════╪═══════╡
-        │ apple  ┆ 2     │
-        │ orange ┆ 1     │
+        │ Apple  ┆ 2     │
+        │ Orange ┆ 1     │
         └────────┴───────┘
         """
         return self.agg(F.len().alias("count"))

--- a/py-polars/polars/lazyframe/group_by.py
+++ b/py-polars/polars/lazyframe/group_by.py
@@ -345,7 +345,7 @@ class LazyGroupBy:
         Examples
         --------
         >>> lf = pl.LazyFrame({"a": ["Apple", "Apple", "Orange"], "b": [1, None, 2]})
-        >>> lf.group_by("a").len().collect()  # doctest: +SKIP
+        >>> lf.group_by("a").len().collect()  # doctest: +IGNORE_RESULT
         shape: (2, 2)
         ┌────────┬─────┐
         │ a      ┆ len │
@@ -355,7 +355,7 @@ class LazyGroupBy:
         │ Apple  ┆ 2   │
         │ Orange ┆ 1   │
         └────────┴─────┘
-        >>> lf.group_by("a").len(name="n").collect()  # doctest: +SKIP
+        >>> lf.group_by("a").len(name="n").collect()  # doctest: +IGNORE_RESULT
         shape: (2, 2)
         ┌────────┬─────┐
         │ a      ┆ n   │

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1647,18 +1647,21 @@ def test_extension() -> None:
     assert sys.getrefcount(foos[0]) == base_count
 
 
-def test_group_by_order_dispatch() -> None:
+@pytest.mark.parametrize("name", [None, "n", ""])
+def test_group_by_order_dispatch(name: str) -> None:
     df = pl.DataFrame({"x": list("bab"), "y": range(3)})
+    lf = df.lazy()
 
-    for name in (None, "n", ""):
-        result = df.group_by("x", maintain_order=True).len(name=name)
-        name = "len" if name is None else name
+    result = df.group_by("x", maintain_order=True).len(name=name)
+    lazy_result = lf.group_by("x").len(name=name).sort(by="x", descending=True)
 
-        expected = pl.DataFrame(
-            data={"x": ["b", "a"], name: [2, 1]},
-            schema_overrides={name: pl.UInt32},
-        )
-        assert_frame_equal(result, expected)
+    name = "len" if name is None else name
+    expected = pl.DataFrame(
+        data={"x": ["b", "a"], name: [2, 1]},
+        schema_overrides={name: pl.UInt32},
+    )
+    assert_frame_equal(result, expected)
+    assert_frame_equal(lazy_result.collect(), expected)
 
     result = df.group_by("x", maintain_order=True).all()
     expected = pl.DataFrame({"x": ["b", "a"], "y": [[0, 2], [1]]})

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1648,7 +1648,7 @@ def test_extension() -> None:
 
 
 @pytest.mark.parametrize("name", [None, "n", ""])
-def test_group_by_order_dispatch(name: str) -> None:
+def test_group_by_order_dispatch(name: str | None) -> None:
     df = pl.DataFrame({"x": list("bab"), "y": range(3)})
     lf = df.lazy()
 

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1650,11 +1650,15 @@ def test_extension() -> None:
 def test_group_by_order_dispatch() -> None:
     df = pl.DataFrame({"x": list("bab"), "y": range(3)})
 
-    result = df.group_by("x", maintain_order=True).len()
-    expected = pl.DataFrame(
-        {"x": ["b", "a"], "len": [2, 1]}, schema_overrides={"len": pl.UInt32}
-    )
-    assert_frame_equal(result, expected)
+    for name in (None, "n", ""):
+        result = df.group_by("x", maintain_order=True).len(name=name)
+        name = "len" if name is None else name
+
+        expected = pl.DataFrame(
+            data={"x": ["b", "a"], name: [2, 1]},
+            schema_overrides={name: pl.UInt32},
+        )
+        assert_frame_equal(result, expected)
 
     result = df.group_by("x", maintain_order=True).all()
     expected = pl.DataFrame({"x": ["b", "a"], "y": [[0, 2], [1]]})


### PR DESCRIPTION
Closes #15222.

Seems like a simple/reasonable addition? While adding tests for this, I also found/fixed a bug where a column name is legitimately the empty string, and we reference it from `schema_overrides`; was getting incorrectly renamed as "column_0".