### PR TITLE
docs(rust): Fix formatting in `Series::from_any_values_and_dtype` docs

### DIFF
--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -73,11 +73,11 @@ impl Series {
         Self::from_any_values_and_dtype(name, values, &dtype, strict)
     }
 
-    /// Construct a new [`Series`]` with the given `dtype` from a slice of AnyValues.
+    /// Construct a new [`Series`] with the given `dtype` from a slice of AnyValues.
     ///
     /// If `strict` is `true`, an error is returned if the values do not match the given
     /// data type. If `strict` is `false`, values that do not match the given data type
-    /// are cast. If casting is not possible, the values are set to null instead.`
+    /// are cast. If casting is not possible, the values are set to null instead.
     pub fn from_any_values_and_dtype(
         name: &str,
         values: &[AnyValue],


### PR DESCRIPTION
Currently the document is rendered as this:

https://docs.rs/polars/latest/polars/series/struct.Series.html#method.from_any_values_and_dtype
![image](https://github.com/pola-rs/polars/assets/1978793/54e98ae5-bf35-4222-8a54-cedd9cba96a4)
