### PR TITLE
fix: prevent panic with `arg_sort_by`

### DIFF
--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1049,7 +1049,7 @@ fn test_arg_sort_multiple() -> PolarsResult<()> {
     let out = df
         .clone()
         .lazy()
-        .select([arg_sort_by([col("int"), col("flt")], &[true, false])])
+        .select([arg_sort_by([col("int"), col("flt")], &[true, false]).unwrap()])
         .collect()?;
 
     assert_eq!(
@@ -1064,7 +1064,7 @@ fn test_arg_sort_multiple() -> PolarsResult<()> {
     // check if this runs
     let _out = df
         .lazy()
-        .select([arg_sort_by([col("str"), col("flt")], &[true, false])])
+        .select([arg_sort_by([col("str"), col("flt")], &[true, false]).unwrap()])
         .collect()?;
     Ok(())
 }

--- a/crates/polars-plan/src/dsl/functions/index.rs
+++ b/crates/polars-plan/src/dsl/functions/index.rs
@@ -5,12 +5,14 @@ use super::*;
 /// until duplicates are found. Once duplicates are found, the next `Series` will
 /// be used and so on.
 #[cfg(feature = "range")]
-pub fn arg_sort_by<E: AsRef<[Expr]>>(by: E, descending: &[bool]) -> Expr {
+pub fn arg_sort_by<E: AsRef<[Expr]>>(by: E, descending: &[bool]) -> PolarsResult<Expr> {
     let e = &by.as_ref()[0];
-    let name = expr_output_name(e).unwrap();
-    int_range(lit(0 as IdxSize), len().cast(IDX_DTYPE), 1, IDX_DTYPE)
-        .sort_by(by, descending)
-        .alias(name.as_ref())
+    let name = expr_output_name(e)?;
+    Ok(
+        int_range(lit(0 as IdxSize), len().cast(IDX_DTYPE), 1, IDX_DTYPE)
+            .sort_by(by, descending)
+            .alias(name.as_ref()),
+    )
 }
 
 #[cfg(feature = "arg_where")]

--- a/py-polars/src/functions/lazy.rs
+++ b/py-polars/src/functions/lazy.rs
@@ -57,9 +57,10 @@ pub fn rolling_cov(
 }
 
 #[pyfunction]
-pub fn arg_sort_by(by: Vec<PyExpr>, descending: Vec<bool>) -> PyExpr {
+pub fn arg_sort_by(by: Vec<PyExpr>, descending: Vec<bool>) -> PyResult<PyExpr> {
     let by = by.into_iter().map(|e| e.inner).collect::<Vec<Expr>>();
-    dsl::arg_sort_by(by, &descending).into()
+    let e = dsl::arg_sort_by(by, &descending).map_err(PyPolarsErr::from)?;
+    Ok(e.into())
 }
 
 #[pyfunction]

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -82,6 +82,19 @@ def test_sort_by_exprs() -> None:
     assert out.to_list() == [1, -1, 2, -2]
 
 
+def test_not_panic_on_arg_sort_by() -> None:
+    with pytest.raises(
+        pl.ComputeError,
+        match="cannot determine output column without a context for this expression",
+    ):
+        pl.arg_sort_by("*")
+
+    with pytest.raises(
+        pl.ComputeError, match="this expression may produce multiple output names"
+    ):
+        pl.arg_sort_by(pl.col(["a", "b"]))
+
+
 def test_arg_sort_nulls() -> None:
     a = pl.Series("a", [1.0, 2.0, 3.0, None, None])
     assert a.arg_sort(nulls_last=True).to_list() == [0, 1, 2, 3, 4]


### PR DESCRIPTION
From pola-rs/r-polars#929

Correct panic when multiple column names are specified as the first argument of `arg_sort_by`.

In Python, current release version:

```python
>>> import polars as pl
>>> df = pl.DataFrame(
...     {
...         "a": [0, 1, 1, 0],
...         "b": [3, 2, 3, 2],
...     }
... )
>>> df.select(pl.arg_sort_by(pl.col("a")))
shape: (4, 1)
┌─────┐
│ a   │
│ --- │
│ u32 │
╞═════╡
│ 0   │
│ 3   │
│ 1   │
│ 2   │
└─────┘
>>> df.select(pl.arg_sort_by(pl.col("a", "b")))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspaces/polars/py-polars/polars/functions/lazy.py", line 1601, in arg_sort_by
    return wrap_expr(plr.arg_sort_by(exprs, descending))
polars.exceptions.ComputeError: this expression may produce multiple output names
>>> df.select(pl.arg_sort_by("*"))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/workspaces/polars/py-polars/polars/functions/lazy.py", line 1601, in arg_sort_by
    return wrap_expr(plr.arg_sort_by(exprs, descending))
polars.exceptions.ComputeError: cannot determine output column without a context for this expression
```