### PR TITLE
fix: Fix lazy schema for `rle` expression

### DIFF
--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -251,7 +251,7 @@ impl FunctionExpr {
             #[cfg(feature = "rle")]
             RLE => mapper.map_dtype(|dt| {
                 DataType::Struct(vec![
-                    Field::new("lengths", DataType::UInt64),
+                    Field::new("lengths", DataType::Int32),
                     Field::new("values", dt.clone()),
                 ])
             }),

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2557,16 +2557,16 @@ class Series:
 
     def rle(self) -> Series:
         """
-        Get the lengths and values of runs of identical values.
+        Compress the Series data using run-length encoding.
+
+        Run-length encoding (RLE) encodes data by storing each *run* of identical values
+        as a single value and its length.
 
         Returns
         -------
         Series
-            Series of data type :class:`Struct` with Fields "lengths" and "values".
-
-        See Also
-        --------
-        rle_id
+            Series of data type `Struct` with fields `lengths` of data type `Int32`
+            and `values` of the original data type.
 
         Examples
         --------
@@ -2591,19 +2591,22 @@ class Series:
         """
         Get a distinct integer ID for each run of identical values.
 
-        The ID increases by one each time the value of a column (which can be a
-        :class:`Struct`) changes.
-
-        This is especially useful when you want to define a new group for every time a
-        column's value changes, rather than for every distinct value of that column.
+        The ID starts at 0 and increases by one each time the value of the column
+        changes.
 
         Returns
         -------
         Series
+            Series of data type `UInt32`.
 
         See Also
         --------
         rle
+
+        Notes
+        -----
+        This functionality is especially useful for defining a new group for every time
+        a column's value changes, rather than for every distinct value of that column.
 
         Examples
         --------

--- a/py-polars/tests/unit/operations/test_rle.py
+++ b/py-polars/tests/unit/operations/test_rle.py
@@ -12,7 +12,7 @@ def test_rle() -> None:
     )
 
     result_expr = lf.select(pl.col("a").rle()).unnest("a")
-    assert_frame_equal(result_expr.collect(), expected.collect())
+    assert_frame_equal(result_expr, expected)
 
     result_series = lf.collect().to_series().rle().struct.unnest()
     assert_frame_equal(result_series, expected.collect())

--- a/py-polars/tests/unit/operations/test_rle.py
+++ b/py-polars/tests/unit/operations/test_rle.py
@@ -1,0 +1,31 @@
+import polars as pl
+from polars.testing.asserts.frame import assert_frame_equal
+
+
+def test_rle() -> None:
+    values = [1, 1, 2, 1, None, 1, 3, 3]
+    lf = pl.LazyFrame({"a": values})
+
+    expected = pl.LazyFrame(
+        {"lengths": [2, 1, 1, 1, 1, 2], "values": [1, 2, 1, None, 1, 3]},
+        schema_overrides={"lengths": pl.Int32},
+    )
+
+    result_expr = lf.select(pl.col("a").rle()).unnest("a")
+    assert_frame_equal(result_expr.collect(), expected.collect())
+
+    result_series = lf.collect().to_series().rle().struct.unnest()
+    assert_frame_equal(result_series, expected.collect())
+
+
+def test_rle_id() -> None:
+    values = [1, 1, 2, 1, None, 1, 3, 3]
+    lf = pl.LazyFrame({"a": values})
+
+    expected = pl.LazyFrame({"a": [0, 0, 1, 2, 3, 4, 5, 5]}, schema={"a": pl.UInt32})
+
+    result_expr = lf.select(pl.col("a").rle_id())
+    assert_frame_equal(result_expr, expected)
+
+    result_series = lf.collect().to_series().rle_id()
+    assert_frame_equal(result_series.to_frame(), expected.collect())


### PR DESCRIPTION
While working on #15230 I found out that `rle/rle_id` had no test coverage at all.

I also found out the current lazy schema is wrong. The data types for the lengths column should actually be the index type (UInt32), but that would be a breaking change, so I'm throwing that it in with the column name change.