### PR TITLE
feat!: Rename struct fields of `rle` output to `len`/`value` and update data type of `len` field

### DIFF
--- a/crates/polars-ops/src/series/ops/rle.rs
+++ b/crates/polars-ops/src/series/ops/rle.rs
@@ -5,9 +5,10 @@ pub fn rle(s: &Series) -> PolarsResult<Series> {
     let (s1, s2) = (s.slice(0, s.len() - 1), s.slice(1, s.len()));
     let s_neq = s1.not_equal_missing(&s2)?;
     let n_runs = s_neq.sum().unwrap() + 1;
-    let mut lengths = Vec::with_capacity(n_runs as usize);
+
+    let mut lengths = Vec::<IdxSize>::with_capacity(n_runs as usize);
     lengths.push(1);
-    let mut vals = Series::new_empty("values", s.dtype());
+    let mut vals = Series::new_empty("value", s.dtype());
     let vals = vals.extend(&s.head(Some(1)))?.extend(&s2.filter(&s_neq)?)?;
     let mut idx = 0;
     for v in s_neq.into_iter() {
@@ -19,24 +20,24 @@ pub fn rle(s: &Series) -> PolarsResult<Series> {
         }
     }
 
-    let outvals = vec![Series::from_vec("lengths", lengths), vals.to_owned()];
+    let outvals = vec![Series::from_vec("len", lengths), vals.to_owned()];
     Ok(StructChunked::new("rle", &outvals)?.into_series())
 }
 
 /// Similar to `rle`, but maps values to run IDs.
 pub fn rle_id(s: &Series) -> PolarsResult<Series> {
     if s.len() == 0 {
-        return Ok(Series::new_empty("id", &DataType::UInt32));
+        return Ok(Series::new_empty("id", &IDX_DTYPE));
     }
     let (s1, s2) = (s.slice(0, s.len() - 1), s.slice(1, s.len()));
     let s_neq = s1.not_equal_missing(&s2)?;
 
-    let mut out = Vec::with_capacity(s.len());
+    let mut out = Vec::<IdxSize>::with_capacity(s.len());
     let mut last = 0;
     out.push(last); // Run numbers start at zero
     for a in s_neq.downcast_iter() {
         for aa in a.values_iter() {
-            last += aa as u32;
+            last += aa as IdxSize;
             out.push(last);
         }
     }

--- a/crates/polars-plan/src/dsl/function_expr/schema.rs
+++ b/crates/polars-plan/src/dsl/function_expr/schema.rs
@@ -251,12 +251,12 @@ impl FunctionExpr {
             #[cfg(feature = "rle")]
             RLE => mapper.map_dtype(|dt| {
                 DataType::Struct(vec![
-                    Field::new("lengths", DataType::Int32),
-                    Field::new("values", dt.clone()),
+                    Field::new("len", IDX_DTYPE),
+                    Field::new("value", dt.clone()),
                 ])
             }),
             #[cfg(feature = "rle")]
-            RLEID => mapper.with_dtype(DataType::UInt32),
+            RLEID => mapper.with_dtype(IDX_DTYPE),
             ToPhysical => mapper.to_physical_type(),
             #[cfg(feature = "random")]
             Random { .. } => mapper.with_same_dtype(),

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -3854,8 +3854,8 @@ class Expr:
         Returns
         -------
         Expr
-            Expression of data type `Struct` with fields `lengths` of data type `Int32`
-            and `values` of the original data type.
+            Expression of data type `Struct` with fields `len` of data type `UInt32`
+            and `value` of the original data type.
 
         See Also
         --------
@@ -3866,18 +3866,18 @@ class Expr:
         >>> df = pl.DataFrame({"a": [1, 1, 2, 1, None, 1, 3, 3]})
         >>> df.select(pl.col("a").rle()).unnest("a")
         shape: (6, 2)
-        ┌─────────┬────────┐
-        │ lengths ┆ values │
-        │ ---     ┆ ---    │
-        │ i32     ┆ i64    │
-        ╞═════════╪════════╡
-        │ 2       ┆ 1      │
-        │ 1       ┆ 2      │
-        │ 1       ┆ 1      │
-        │ 1       ┆ null   │
-        │ 1       ┆ 1      │
-        │ 2       ┆ 3      │
-        └─────────┴────────┘
+        ┌─────┬───────┐
+        │ len ┆ value │
+        │ --- ┆ ---   │
+        │ u32 ┆ i64   │
+        ╞═════╪═══════╡
+        │ 2   ┆ 1     │
+        │ 1   ┆ 2     │
+        │ 1   ┆ 1     │
+        │ 1   ┆ null  │
+        │ 1   ┆ 1     │
+        │ 2   ┆ 3     │
+        └─────┴───────┘
         """
         return self._from_pyexpr(self._pyexpr.rle())
 

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -2565,26 +2565,26 @@ class Series:
         Returns
         -------
         Series
-            Series of data type `Struct` with fields `lengths` of data type `Int32`
-            and `values` of the original data type.
+            Series of data type `Struct` with fields `len` of data type `UInt32`
+            and `value` of the original data type.
 
         Examples
         --------
         >>> s = pl.Series("s", [1, 1, 2, 1, None, 1, 3, 3])
         >>> s.rle().struct.unnest()
         shape: (6, 2)
-        ┌─────────┬────────┐
-        │ lengths ┆ values │
-        │ ---     ┆ ---    │
-        │ i32     ┆ i64    │
-        ╞═════════╪════════╡
-        │ 2       ┆ 1      │
-        │ 1       ┆ 2      │
-        │ 1       ┆ 1      │
-        │ 1       ┆ null   │
-        │ 1       ┆ 1      │
-        │ 2       ┆ 3      │
-        └─────────┴────────┘
+        ┌─────┬───────┐
+        │ len ┆ value │
+        │ --- ┆ ---   │
+        │ u32 ┆ i64   │
+        ╞═════╪═══════╡
+        │ 2   ┆ 1     │
+        │ 1   ┆ 2     │
+        │ 1   ┆ 1     │
+        │ 1   ┆ null  │
+        │ 1   ┆ 1     │
+        │ 2   ┆ 3     │
+        └─────┴───────┘
         """
 
     def rle_id(self) -> Series:

--- a/py-polars/tests/unit/operations/test_rle.py
+++ b/py-polars/tests/unit/operations/test_rle.py
@@ -7,8 +7,8 @@ def test_rle() -> None:
     lf = pl.LazyFrame({"a": values})
 
     expected = pl.LazyFrame(
-        {"lengths": [2, 1, 1, 1, 1, 2], "values": [1, 2, 1, None, 1, 3]},
-        schema_overrides={"lengths": pl.Int32},
+        {"len": [2, 1, 1, 1, 1, 2], "value": [1, 2, 1, None, 1, 3]},
+        schema_overrides={"len": pl.get_index_type()},
     )
 
     result_expr = lf.select(pl.col("a").rle()).unnest("a")
@@ -22,7 +22,9 @@ def test_rle_id() -> None:
     values = [1, 1, 2, 1, None, 1, 3, 3]
     lf = pl.LazyFrame({"a": values})
 
-    expected = pl.LazyFrame({"a": [0, 0, 1, 2, 3, 4, 5, 5]}, schema={"a": pl.UInt32})
+    expected = pl.LazyFrame(
+        {"a": [0, 0, 1, 2, 3, 4, 5, 5]}, schema={"a": pl.get_index_type()}
+    )
 
     result_expr = lf.select(pl.col("a").rle_id())
     assert_frame_equal(result_expr, expected)


### PR DESCRIPTION
Closes #15230

#### Changes

* The struct fields of the `rle` method have been renamed from `lengths/values` to `len/value`.
* The data type of the `len` field has been updated to match the index type (was previously `Int32`, now `UInt32`).

#### Example

**Before**

```pycon
>>> s = pl.Series(["a", "a", "b", "c", "c", "c"])
>>> s.rle().struct.unnest()
shape: (3, 2)
┌─────────┬────────┐
│ lengths ┆ values │
│ ---     ┆ ---    │
│ i32     ┆ str    │
╞═════════╪════════╡
│ 2       ┆ a      │
│ 1       ┆ b      │
│ 3       ┆ c      │
└─────────┴────────┘
```

**After**

```pycon
>>> s.rle().struct.unnest()
shape: (3, 2)
┌─────┬───────┐
│ len ┆ value │
│ --- ┆ ---   │
│ u32 ┆ str   │
╞═════╪═══════╡
│ 2   ┆ a     │
│ 1   ┆ b     │
│ 3   ┆ c     │
└─────┴───────┘
```