### PR TITLE
fix(rust): Non-exhaustive patterns: arrow-schema::DataType in polars-arrow

### DIFF
--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -303,7 +303,7 @@ impl From<arrow_schema::DataType> for ArrowDataType {
             },
             // This ensures that it doesn't fail to compile when new variants are added to Arrow
             #[allow(unreachable_patterns)]
-            dtype => unimplemented!("unsupported datatype: {dtype}")
+            dtype => unimplemented!("unsupported datatype: {dtype}"),
         }
     }
 }

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -301,6 +301,8 @@ impl From<arrow_schema::DataType> for ArrowDataType {
             DataType::RunEndEncoded(_, _) => {
                 panic!("Run-end encoding not supported by polars_arrow")
             },
+            #[allow(unreachable_patterns)]
+            _ => unimplemented!("needs arrow-schema >= v51.0.0"),
         }
     }
 }

--- a/crates/polars-arrow/src/datatypes/mod.rs
+++ b/crates/polars-arrow/src/datatypes/mod.rs
@@ -301,8 +301,9 @@ impl From<arrow_schema::DataType> for ArrowDataType {
             DataType::RunEndEncoded(_, _) => {
                 panic!("Run-end encoding not supported by polars_arrow")
             },
+            // This ensures that it doesn't fail to compile when new variants are added to Arrow
             #[allow(unreachable_patterns)]
-            _ => unimplemented!("needs arrow-schema >= v51.0.0"),
+            dtype => unimplemented!("unsupported datatype: {dtype}")
         }
     }
 }


### PR DESCRIPTION
Fixes #15234

hey,
this is my first contribution.

If somehow the version of arrow-schema is higher or equal to v51.0.0 the match on DataType is non exhaustive, therefor not compiling.
This adds a ```_ => unimplemented!()``` arm to be able to compile it again.

Cheers!