### PR TITLE
refactor: cleanup column names in optimizer

### DIFF
--- a/crates/polars-plan/src/constants.rs
+++ b/crates/polars-plan/src/constants.rs
@@ -7,10 +7,15 @@ pub static CSE_REPLACED: &str = "__POLARS_CSER_";
 pub const LEN: &str = "len";
 pub const LITERAL_NAME: &str = "literal";
 
+// Cache the often used LITERAL and LEN constants
 static LITERAL_NAME_INIT: OnceLock<Arc<str>> = OnceLock::new();
+static LEN_INIT: OnceLock<Arc<str>> = OnceLock::new();
 
 pub(crate) fn get_literal_name() -> Arc<str> {
     LITERAL_NAME_INIT
         .get_or_init(|| ColumnName::from(LITERAL_NAME))
         .clone()
+}
+pub(crate) fn get_len_name() -> Arc<str> {
+    LEN_INIT.get_or_init(|| ColumnName::from(LEN)).clone()
 }

--- a/crates/polars-plan/src/constants.rs
+++ b/crates/polars-plan/src/constants.rs
@@ -1,5 +1,7 @@
 use std::sync::{Arc, OnceLock};
 
+use crate::prelude::ColumnName;
+
 pub static MAP_LIST_NAME: &str = "map_list";
 pub static CSE_REPLACED: &str = "__POLARS_CSER_";
 pub const LEN: &str = "len";
@@ -9,6 +11,6 @@ static LITERAL_NAME_INIT: OnceLock<Arc<str>> = OnceLock::new();
 
 pub(crate) fn get_literal_name() -> Arc<str> {
     LITERAL_NAME_INIT
-        .get_or_init(|| Arc::from(crate::constants::LITERAL_NAME))
+        .get_or_init(|| ColumnName::from(LITERAL_NAME))
         .clone()
 }

--- a/crates/polars-plan/src/dsl/functions/selectors.rs
+++ b/crates/polars-plan/src/dsl/functions/selectors.rs
@@ -27,7 +27,7 @@ use super::*;
 pub fn col(name: &str) -> Expr {
     match name {
         "*" => Expr::Wildcard,
-        _ => Expr::Column(Arc::from(name)),
+        _ => Expr::Column(ColumnName::from(name)),
     }
 }
 

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -166,7 +166,7 @@ impl Expr {
 
     /// Rename Column.
     pub fn alias(self, name: &str) -> Expr {
-        Expr::Alias(Box::new(self), Arc::from(name))
+        Expr::Alias(Box::new(self), ColumnName::from(name))
     }
 
     /// Run is_null operation on `Expr`.
@@ -1135,7 +1135,7 @@ impl Expr {
         let v = columns
             .into_vec()
             .into_iter()
-            .map(|s| Excluded::Name(Arc::from(s)))
+            .map(|s| Excluded::Name(ColumnName::from(s)))
             .collect();
         Expr::Exclude(Box::new(self), v)
     }

--- a/crates/polars-plan/src/dsl/name.rs
+++ b/crates/polars-plan/src/dsl/name.rs
@@ -94,7 +94,7 @@ impl ExprNameNameSpace {
     pub fn prefix_fields(self, prefix: &str) -> Expr {
         self.0
             .map_private(FunctionExpr::StructExpr(StructFunction::PrefixFields(
-                Arc::from(prefix),
+                ColumnName::from(prefix),
             )))
     }
 
@@ -102,7 +102,7 @@ impl ExprNameNameSpace {
     pub fn suffix_fields(self, suffix: &str) -> Expr {
         self.0
             .map_private(FunctionExpr::StructExpr(StructFunction::SuffixFields(
-                Arc::from(suffix),
+                ColumnName::from(suffix),
             )))
     }
 }

--- a/crates/polars-plan/src/dsl/struct_.rs
+++ b/crates/polars-plan/src/dsl/struct_.rs
@@ -19,7 +19,7 @@ impl StructNameSpace {
     pub fn field_by_name(self, name: &str) -> Expr {
         self.0
             .map_private(FunctionExpr::StructExpr(StructFunction::FieldByName(
-                Arc::from(name),
+                ColumnName::from(name),
             )))
             .with_function_options(|mut options| {
                 options.allow_rename = true;

--- a/crates/polars-plan/src/logical_plan/aexpr/mod.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/mod.rs
@@ -122,8 +122,8 @@ impl From<AAggExpr> for GroupByMethod {
 #[derive(Clone, Debug, Default)]
 pub enum AExpr {
     Explode(Node),
-    Alias(Node, Arc<str>),
-    Column(Arc<str>),
+    Alias(Node, ColumnName),
+    Column(ColumnName),
     Literal(LiteralValue),
     BinaryExpr {
         left: Node,

--- a/crates/polars-plan/src/logical_plan/aexpr/mod.rs
+++ b/crates/polars-plan/src/logical_plan/aexpr/mod.rs
@@ -203,7 +203,7 @@ impl AExpr {
 
     #[cfg(feature = "cse")]
     pub(crate) fn col(name: &str) -> Self {
-        AExpr::Column(Arc::from(name))
+        AExpr::Column(ColumnName::from(name))
     }
     /// Any expression that is sensitive to the number of elements in a group
     /// - Aggregations

--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -873,7 +873,7 @@ impl LogicalPlanBuilder {
         LogicalPlan::MapFunction {
             input: Box::new(self.0),
             function: FunctionNode::RowIndex {
-                name: Arc::from(name),
+                name: ColumnName::from(name),
                 offset,
                 schema,
             },

--- a/crates/polars-plan/src/logical_plan/builder_alp.rs
+++ b/crates/polars-plan/src/logical_plan/builder_alp.rs
@@ -190,7 +190,7 @@ impl<'a> ALogicalPlanBuilder<'a> {
 
             expr_irs.push(ExprIR::new(
                 node,
-                OutputName::ColumnLhs(Arc::from(field.name.as_ref())),
+                OutputName::ColumnLhs(ColumnName::from(field.name.as_ref())),
             ));
             new_schema.with_column(field.name().clone(), field.data_type().clone());
         }

--- a/crates/polars-plan/src/logical_plan/conversion.rs
+++ b/crates/polars-plan/src/logical_plan/conversion.rs
@@ -1,7 +1,7 @@
 use polars_core::prelude::*;
 use polars_utils::vec::ConvertVec;
 
-use crate::constants::LEN;
+use crate::constants::get_len_name;
 use crate::prelude::*;
 
 pub fn to_expr_ir(expr: Expr, arena: &mut Arena<AExpr>) -> ExprIR {
@@ -241,7 +241,7 @@ fn to_aexpr_impl(expr: Expr, arena: &mut Arena<AExpr>, state: &mut ConversionSta
         },
         Expr::Len => {
             if state.output_name.is_none() {
-                state.output_name = OutputName::LiteralLhs(ColumnName::from(LEN))
+                state.output_name = OutputName::LiteralLhs(get_len_name())
             }
             AExpr::Len
         },

--- a/crates/polars-plan/src/logical_plan/conversion.rs
+++ b/crates/polars-plan/src/logical_plan/conversion.rs
@@ -1,7 +1,7 @@
 use polars_core::prelude::*;
 use polars_utils::vec::ConvertVec;
 
-use crate::constants::{get_literal_name, LEN};
+use crate::constants::LEN;
 use crate::prelude::*;
 
 pub fn to_expr_ir(expr: Expr, arena: &mut Arena<AExpr>) -> ExprIR {
@@ -79,11 +79,7 @@ fn to_aexpr_impl(expr: Expr, arena: &mut Arena<AExpr>, state: &mut ConversionSta
         },
         Expr::Literal(lv) => {
             if state.output_name.is_none() {
-                let output_name = match lv {
-                    LiteralValue::Series(ref s) => OutputName::LiteralLhs(s.name().into()),
-                    _ => OutputName::LiteralLhs(get_literal_name()),
-                };
-                state.output_name = output_name;
+                state.output_name = OutputName::LiteralLhs(lv.output_column_name());
             }
             AExpr::Literal(lv)
         },
@@ -245,7 +241,7 @@ fn to_aexpr_impl(expr: Expr, arena: &mut Arena<AExpr>, state: &mut ConversionSta
         },
         Expr::Len => {
             if state.output_name.is_none() {
-                state.output_name = OutputName::LiteralLhs(Arc::from(LEN))
+                state.output_name = OutputName::LiteralLhs(ColumnName::from(LEN))
             }
             AExpr::Len
         },
@@ -801,7 +797,7 @@ impl ALogicalPlan {
                 let input = convert_to_lp(input, lp_arena);
                 let expr = columns
                     .iter_names()
-                    .map(|name| Expr::Column(Arc::from(name.as_str())))
+                    .map(|name| Expr::Column(ColumnName::from(name.as_str())))
                     .collect::<Vec<_>>();
                 LogicalPlan::Projection {
                     expr,

--- a/crates/polars-plan/src/logical_plan/expr_ir.rs
+++ b/crates/polars-plan/src/logical_plan/expr_ir.rs
@@ -1,19 +1,17 @@
 use super::*;
 use crate::constants::LITERAL_NAME;
 
-pub type Name = Arc<str>;
-
 #[derive(Default, Debug, Clone)]
 pub enum OutputName {
     #[default]
     None,
-    LiteralLhs(Name),
-    ColumnLhs(Name),
-    Alias(Name),
+    LiteralLhs(ColumnName),
+    ColumnLhs(ColumnName),
+    Alias(ColumnName),
 }
 
 impl OutputName {
-    fn unwrap(&self) -> &Name {
+    fn unwrap(&self) -> &ColumnName {
         match self {
             OutputName::Alias(name) => name,
             OutputName::ColumnLhs(name) => name,
@@ -84,7 +82,7 @@ impl ExprIR {
     }
 
     #[cfg(feature = "cse")]
-    pub(crate) fn set_alias(&mut self, name: Name) {
+    pub(crate) fn set_alias(&mut self, name: ColumnName) {
         self.output_name = OutputName::Alias(name)
     }
 
@@ -105,7 +103,7 @@ impl ExprIR {
         }
     }
 
-    pub fn get_alias(&self) -> Option<&Name> {
+    pub fn get_alias(&self) -> Option<&ColumnName> {
         match &self.output_name {
             OutputName::Alias(name) => Some(name),
             _ => None,
@@ -147,7 +145,7 @@ impl From<&ExprIR> for Node {
 }
 
 pub(crate) fn name_to_expr_ir(name: &str, expr_arena: &mut Arena<AExpr>) -> ExprIR {
-    let name: Name = Arc::from(name);
+    let name = ColumnName::from(name);
     let node = expr_arena.add(AExpr::Column(name.clone()));
     ExprIR::new(node, OutputName::ColumnLhs(name))
 }

--- a/crates/polars-plan/src/logical_plan/functions/count.rs
+++ b/crates/polars-plan/src/logical_plan/functions/count.rs
@@ -16,6 +16,7 @@ use polars_io::pl_async::{get_runtime, with_concurrency_budget};
 use polars_io::{is_cloud_url, SerReader};
 
 use super::*;
+use crate::constants::LEN;
 
 #[allow(unused_variables)]
 pub fn count_rows(paths: &Arc<[PathBuf]>, scan_type: &FileScan) -> PolarsResult<DataFrame> {
@@ -35,12 +36,12 @@ pub fn count_rows(paths: &Arc<[PathBuf]>, scan_type: &FileScan) -> PolarsResult<
                     )
                 })
                 .sum();
-            Ok(DataFrame::new(vec![Series::new("len", [n_rows? as IdxSize])]).unwrap())
+            Ok(DataFrame::new(vec![Series::new(LEN, [n_rows? as IdxSize])]).unwrap())
         },
         #[cfg(feature = "parquet")]
         FileScan::Parquet { cloud_options, .. } => {
             let n_rows = count_rows_parquet(paths, cloud_options.as_ref())?;
-            Ok(DataFrame::new(vec![Series::new("len", [n_rows as IdxSize])]).unwrap())
+            Ok(DataFrame::new(vec![Series::new(LEN, [n_rows as IdxSize])]).unwrap())
         },
         #[cfg(feature = "ipc")]
         FileScan::Ipc {
@@ -57,7 +58,7 @@ pub fn count_rows(paths: &Arc<[PathBuf]>, scan_type: &FileScan) -> PolarsResult<
             )?
             .try_into()
             .map_err(to_compute_err)?;
-            Ok(DataFrame::new(vec![Series::new("len", [count])]).unwrap())
+            Ok(DataFrame::new(vec![Series::new(LEN, [count])]).unwrap())
         },
         FileScan::Anonymous { .. } => {
             unreachable!();

--- a/crates/polars-plan/src/logical_plan/functions/count.rs
+++ b/crates/polars-plan/src/logical_plan/functions/count.rs
@@ -16,7 +16,6 @@ use polars_io::pl_async::{get_runtime, with_concurrency_budget};
 use polars_io::{is_cloud_url, SerReader};
 
 use super::*;
-use crate::constants::LEN;
 
 #[allow(unused_variables)]
 pub fn count_rows(paths: &Arc<[PathBuf]>, scan_type: &FileScan) -> PolarsResult<DataFrame> {
@@ -36,12 +35,20 @@ pub fn count_rows(paths: &Arc<[PathBuf]>, scan_type: &FileScan) -> PolarsResult<
                     )
                 })
                 .sum();
-            Ok(DataFrame::new(vec![Series::new(LEN, [n_rows? as IdxSize])]).unwrap())
+            Ok(DataFrame::new(vec![Series::new(
+                crate::constants::LEN,
+                [n_rows? as IdxSize],
+            )])
+            .unwrap())
         },
         #[cfg(feature = "parquet")]
         FileScan::Parquet { cloud_options, .. } => {
             let n_rows = count_rows_parquet(paths, cloud_options.as_ref())?;
-            Ok(DataFrame::new(vec![Series::new(LEN, [n_rows as IdxSize])]).unwrap())
+            Ok(DataFrame::new(vec![Series::new(
+                crate::constants::LEN,
+                [n_rows as IdxSize],
+            )])
+            .unwrap())
         },
         #[cfg(feature = "ipc")]
         FileScan::Ipc {
@@ -58,7 +65,7 @@ pub fn count_rows(paths: &Arc<[PathBuf]>, scan_type: &FileScan) -> PolarsResult<
             )?
             .try_into()
             .map_err(to_compute_err)?;
-            Ok(DataFrame::new(vec![Series::new(LEN, [count])]).unwrap())
+            Ok(DataFrame::new(vec![Series::new(crate::constants::LEN, [count])]).unwrap())
         },
         FileScan::Anonymous { .. } => {
             unreachable!();

--- a/crates/polars-plan/src/logical_plan/functions/mod.rs
+++ b/crates/polars-plan/src/logical_plan/functions/mod.rs
@@ -201,8 +201,12 @@ impl FunctionNode {
             DropNulls { .. } => Ok(Cow::Borrowed(input_schema)),
             Count { alias, .. } => {
                 let mut schema: Schema = Schema::with_capacity(1);
-                let name =
-                    SmartString::from(alias.as_ref().map(|alias| alias.as_ref()).unwrap_or("len"));
+                let name = SmartString::from(
+                    alias
+                        .as_ref()
+                        .map(|alias| alias.as_ref())
+                        .unwrap_or(crate::constants::LEN),
+                );
                 schema.insert_at_index(0, name, IDX_DTYPE)?;
                 Ok(Cow::Owned(Arc::new(schema)))
             },

--- a/crates/polars-plan/src/logical_plan/lit.rs
+++ b/crates/polars-plan/src/logical_plan/lit.rs
@@ -6,7 +6,7 @@ use polars_core::prelude::*;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::constants::LITERAL_NAME;
+use crate::constants::{get_literal_name, LITERAL_NAME};
 use crate::prelude::*;
 
 #[derive(Clone, PartialEq)]
@@ -60,10 +60,19 @@ pub enum LiteralValue {
 }
 
 impl LiteralValue {
+    /// Get the output name as `&str`.
     pub(crate) fn output_name(&self) -> &str {
         match self {
             LiteralValue::Series(s) => s.name(),
             _ => LITERAL_NAME,
+        }
+    }
+
+    /// Get the output name as [`ColumnName`].
+    pub(crate) fn output_column_name(&self) -> ColumnName {
+        match self {
+            LiteralValue::Series(s) => ColumnName::from(s.name()),
+            _ => get_literal_name(),
         }
     }
 

--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -65,6 +65,8 @@ pub use crate::logical_plan::optimizer::file_caching::{
     collect_fingerprints, find_column_union_and_fingerprints, FileCacher, FileFingerPrint,
 };
 
+pub type ColumnName = Arc<str>;
+
 #[derive(Clone, Copy, Debug)]
 pub enum Context {
     /// Any operation that is done on groups

--- a/crates/polars-plan/src/logical_plan/optimizer/cache_states.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cache_states.rs
@@ -22,7 +22,7 @@ fn get_upper_projections(
         SimpleProjection { columns, .. } => {
             let out = columns
                 .iter_names()
-                .map(|s| Arc::from(s.as_str()))
+                .map(|s| ColumnName::from(s.as_str()))
                 .collect();
             Some(out)
         },
@@ -125,8 +125,11 @@ pub(super) fn set_cache_states(
                         // all columns
                         else {
                             let schema = lp.schema(lp_arena);
-                            union_names
-                                .extend(schema.iter_names().map(|name| Arc::from(name.as_str())));
+                            union_names.extend(
+                                schema
+                                    .iter_names()
+                                    .map(|name| ColumnName::from(name.as_str())),
+                            );
                         }
                     }
                     cache_id = Some(*id);

--- a/crates/polars-plan/src/logical_plan/optimizer/cse_expr.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cse_expr.rs
@@ -677,7 +677,7 @@ impl<'a> CommonSubExprOptimizer<'a> {
                         // intermediate temporary names starting with the `CSE_REPLACED` constant.
                         if !e.has_alias() {
                             let name = ae_node.to_field(schema)?.name;
-                            out_e.set_alias(Arc::from(name.as_str()));
+                            out_e.set_alias(ColumnName::from(name.as_str()));
                         }
                         PolarsResult::Ok(out_e)
                     },
@@ -688,7 +688,7 @@ impl<'a> CommonSubExprOptimizer<'a> {
             for id in &self.replaced_identifiers {
                 let (node, _count) = self.se_count.get(id).unwrap();
                 let name = id.materialize();
-                let out_e = ExprIR::new(*node, OutputName::Alias(Arc::from(name)));
+                let out_e = ExprIR::new(*node, OutputName::Alias(ColumnName::from(name)));
                 new_expr.push(out_e)
             }
             let expr = ProjectionExprs::new_with_cse(new_expr, self.replaced_identifiers.len());

--- a/crates/polars-plan/src/logical_plan/optimizer/file_caching.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/file_caching.rs
@@ -169,7 +169,7 @@ impl FileCacher {
 
                 let projections = std::mem::take(Arc::make_mut(&mut with_columns))
                     .into_iter()
-                    .map(|s| expr_arena.add(AExpr::Column(Arc::from(s))))
+                    .map(|s| expr_arena.add(AExpr::Column(ColumnName::from(s))))
                     .collect::<Vec<_>>();
 
                 lp = ALogicalPlanBuilder::new(node, expr_arena, lp_arena)

--- a/crates/polars-plan/src/logical_plan/optimizer/fused.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/fused.rs
@@ -91,7 +91,10 @@ impl OptimizationRule for FusedArithmetic {
                             let node = expr_arena.add(fma);
                             // we reordered the arguments, so we don't obey the left expression output name
                             // rule anymore, that's why we alias
-                            Ok(Some(Alias(node, Arc::from(output_field.name.as_str()))))
+                            Ok(Some(Alias(
+                                node,
+                                ColumnName::from(output_field.name.as_str()),
+                            )))
                         },
                         _ => unreachable!(),
                     },

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/group_by.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/group_by.rs
@@ -68,13 +68,17 @@ pub(super) fn process_group_by(
         // make sure that the dynamic key is projected
         #[cfg(feature = "dynamic_group_by")]
         if let Some(options) = &options.dynamic {
-            let node = expr_arena.add(AExpr::Column(Arc::from(options.index_column.as_str())));
+            let node = expr_arena.add(AExpr::Column(ColumnName::from(
+                options.index_column.as_str(),
+            )));
             add_expr_to_accumulated(node, &mut acc_projections, &mut names, expr_arena);
         }
         // make sure that the rolling key is projected
         #[cfg(feature = "dynamic_group_by")]
         if let Some(options) = &options.rolling {
-            let node = expr_arena.add(AExpr::Column(Arc::from(options.index_column.as_str())));
+            let node = expr_arena.add(AExpr::Column(ColumnName::from(
+                options.index_column.as_str(),
+            )));
             add_expr_to_accumulated(node, &mut acc_projections, &mut names, expr_arena);
         }
 

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/joins.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/joins.rs
@@ -71,7 +71,7 @@ pub(super) fn process_asof_join(
             for name in left_by {
                 let add = _projected_names.contains(name.as_str());
 
-                let node = expr_arena.add(AExpr::Column(Arc::from(name.as_str())));
+                let node = expr_arena.add(AExpr::Column(ColumnName::from(name.as_str())));
                 add_keys_to_accumulated_state(
                     node,
                     &mut pushdown_left,
@@ -82,7 +82,7 @@ pub(super) fn process_asof_join(
                 );
             }
             for name in right_by {
-                let node = expr_arena.add(AExpr::Column(Arc::from(name.as_str())));
+                let node = expr_arena.add(AExpr::Column(ColumnName::from(name.as_str())));
                 add_keys_to_accumulated_state(
                     node,
                     &mut pushdown_right,
@@ -380,7 +380,7 @@ fn process_projection(
 
             let downwards_name_column = expr_arena.add(AExpr::Column(Arc::from(downwards_name)));
             // project downwards and locally immediately alias to prevent wrong projections
-            if names_right.insert(Arc::from(downwards_name)) {
+            if names_right.insert(ColumnName::from(downwards_name)) {
                 pushdown_right.push(ColumnNode(downwards_name_column));
             }
             local_projection.push(proj);
@@ -437,7 +437,7 @@ fn resolve_join_suffixes(
             let name = column_node_to_name(*proj, expr_arena);
             if name.contains(suffix) && schema_after_join.get(&name).is_none() {
                 let downstream_name = &name.as_ref()[..name.len() - suffix.len()];
-                let col = AExpr::Column(Arc::from(downstream_name));
+                let col = AExpr::Column(ColumnName::from(downstream_name));
                 let node = expr_arena.add(col);
                 ExprIR::new(node, OutputName::Alias(name))
             } else {

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/mod.rs
@@ -112,7 +112,7 @@ fn add_str_to_accumulated(
 ) {
     // if empty: all columns are already projected.
     if !acc_projections.is_empty() && !projected_names.contains(name) {
-        let node = expr_arena.add(AExpr::Column(Arc::from(name)));
+        let node = expr_arena.add(AExpr::Column(ColumnName::from(name)));
         add_expr_to_accumulated(node, acc_projections, projected_names, expr_arena);
     }
 }

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/projection.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/projection.rs
@@ -64,7 +64,7 @@ pub(super) fn process_projection(
         let input_schema = lp_arena.get(input).schema(lp_arena);
         // simply select the first column
         let (first_name, _) = input_schema.try_get_at_index(0)?;
-        let expr = expr_arena.add(AExpr::Column(Arc::from(first_name.as_str())));
+        let expr = expr_arena.add(AExpr::Column(ColumnName::from(first_name.as_str())));
         if !acc_projections.is_empty() {
             check_double_projection(
                 &exprs[0],

--- a/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/rename.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/projection_pushdown/rename.rs
@@ -16,7 +16,7 @@ fn iter_and_update_nodes(
         if !processed.contains(&node.0) {
             // We walk the query backwards, so we rename new to existing
             if column_node_to_name(*column_node, expr_arena).as_ref() == new {
-                let new_node = expr_arena.add(AExpr::Column(Name::from(existing)));
+                let new_node = expr_arena.add(AExpr::Column(ColumnName::from(existing)));
                 *column_node = ColumnNode(new_node);
                 processed.insert(new_node.0);
             }
@@ -59,7 +59,7 @@ pub(super) fn process_rename(
                 // this must add and remove names
                 else {
                     new_projected_names.remove(new.as_str());
-                    let name: Arc<str> = Arc::from(existing.as_str());
+                    let name = ColumnName::from(existing.as_str());
                     new_projected_names.insert(name);
                     iter_and_update_nodes(
                         existing,
@@ -75,7 +75,7 @@ pub(super) fn process_rename(
     } else {
         for (existing, new) in existing.iter().zip(new.iter()) {
             if projected_names.remove(new.as_str()) {
-                let name: Arc<str> = Arc::from(existing.as_str());
+                let name: Arc<str> = ColumnName::from(existing.as_str());
                 projected_names.insert(name);
                 iter_and_update_nodes(existing, new, acc_projections, expr_arena, &mut processed);
             }

--- a/crates/polars-plan/src/logical_plan/tree_format.rs
+++ b/crates/polars-plan/src/logical_plan/tree_format.rs
@@ -5,6 +5,7 @@ use polars_core::error::*;
 #[cfg(feature = "regex")]
 use regex::Regex;
 
+use crate::constants::LEN;
 use crate::logical_plan::visitor::{VisitRecursion, Visitor};
 use crate::prelude::visitor::AexprNode;
 use crate::prelude::*;
@@ -56,7 +57,7 @@ impl UpperExp for AExpr {
             AExpr::Window { .. } => "window",
             AExpr::Wildcard => "*",
             AExpr::Slice { .. } => "slice",
-            AExpr::Len => "len",
+            AExpr::Len => LEN,
             AExpr::Nth(v) => return write!(f, "nth({})", v),
         };
 

--- a/crates/polars-plan/src/utils.rs
+++ b/crates/polars-plan/src/utils.rs
@@ -5,7 +5,7 @@ use polars_core::prelude::*;
 use polars_utils::idx_vec::UnitVec;
 use smartstring::alias::String as SmartString;
 
-use crate::constants::LEN;
+use crate::constants::{get_len_name, LEN};
 use crate::prelude::*;
 
 /// Utility to write comma delimited strings
@@ -158,7 +158,7 @@ pub fn aexpr_output_name(node: Node, arena: &Arena<AExpr>) -> PolarsResult<Arc<s
             AExpr::Window { function, .. } => return aexpr_output_name(*function, arena),
             AExpr::Column(name) => return Ok(name.clone()),
             AExpr::Alias(_, name) => return Ok(name.clone()),
-            AExpr::Len => return Ok(ColumnName::from(LEN)),
+            AExpr::Len => return Ok(get_len_name()),
             AExpr::Literal(val) => return Ok(val.output_column_name()),
             _ => {},
         }
@@ -186,7 +186,7 @@ pub fn expr_output_name(expr: &Expr) -> PolarsResult<Arc<str>> {
                 ComputeError:
                 "this expression may produce multiple output names"
             ),
-            Expr::Len => return Ok(ColumnName::from(LEN)),
+            Expr::Len => return Ok(get_len_name()),
             Expr::Literal(val) => return Ok(val.output_column_name()),
             _ => {},
         }


### PR DESCRIPTION
Constants like `"literal"` and `"len"` now always share a pre-allocated allocation and we ensure we only refer to them by `static` constants.