### PR TITLE
[PoC] Change Series constructor argument order to values-first

### DIFF
--- a/py-polars/tests/unit/constructors/test_series_init_args.py
+++ b/py-polars/tests/unit/constructors/test_series_init_args.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pytest
+
+import polars as pl
+
+
+@pytest.fixture(scope="module")
+def name() -> str:
+    return "a"
+
+
+@pytest.fixture(scope="module")
+def values() -> list[int]:
+    return [1, 2]
+
+
+@pytest.fixture(scope="module")
+def values_str() -> str:
+    return "xyz"
+
+
+@pytest.fixture(scope="module")
+def dtype() -> pl.PolarsDataType:
+    return pl.Int8
+
+
+def test_series_init_args(
+    name: str, values: list[int], values_str: str, dtype: pl.PolarsDataType
+) -> None:
+    s = pl.Series(values, name)
+    assert s.name == name
+    assert s.to_list() == values
+
+    s = pl.Series(values, name=name)
+    assert s.name == name
+    assert s.to_list() == values
+
+    s = pl.Series(values_str, name=name)
+    assert s.name == name
+    assert s.to_list() == list(values_str)
+
+    s = pl.Series(None, name=name)
+    assert s.name == name
+    assert s.to_list() == []
+
+    s = pl.Series(values=values)
+    assert s.name == ""
+    assert s.to_list() == values
+
+    s = pl.Series(values, name, dtype)
+    assert s.name == name
+    assert s.to_list() == values
+    assert s.dtype == dtype
+
+    s = pl.Series(None)
+    assert s.name == ""
+    assert s.to_list() == []
+
+    s = pl.Series(None, None)
+    assert s.name == ""
+    assert s.to_list() == []
+
+    s = pl.Series(name, name)
+    assert s.name == name
+    assert s.to_list() == [name]
+
+
+def test_series_init_args_deprecated(
+    name: str, values: list[int], values_str: str, dtype: pl.PolarsDataType
+) -> None:
+    s = pl.Series(name)
+    assert s.name == name
+    assert s.to_list() == []
+
+    s = pl.Series(name, values)
+    assert s.name == name
+    assert s.to_list() == values
+
+    s = pl.Series(name, values=values)
+    assert s.name == name
+    assert s.to_list() == values
+
+    s = pl.Series(name, values_str)
+    assert s.name == name
+    assert s.to_list() == list(values_str)
+
+    s = pl.Series(None, values)
+    assert s.name == ""
+    assert s.to_list() == values
+
+    s = pl.Series(None, values=values)
+    assert s.name == ""
+    assert s.to_list() == values
+
+    s = pl.Series(name, values=name)
+    assert s.name == name
+    assert s.to_list() == [name]
+
+
+def test_series_init_args_raises(
+    name: str, values: list[int], values_str: str, dtype: pl.PolarsDataType
+) -> None:
+    with pytest.raises(TypeError):
+        pl.Series(name, values, dtype, False)
+    with pytest.raises(TypeError):
+        pl.Series(values, values=values)
+    with pytest.raises(TypeError):
+        pl.Series(values, name, values=values)
+    with pytest.raises(TypeError):
+        pl.Series(values, name, name=name)
+    with pytest.raises(TypeError):
+        pl.Series(name, values, dtype, dtype=dtype)


### PR DESCRIPTION
Closes #13405

It's still not clear that we want to go ahead with this change, but I figured I'd at least figure out what a possible deprecation/upgrade path would look like. Hence this proof-of-concept.

This PR shows what I think is the least painful way to do this: temporarily add a `*args` parameter to soak up any positional inputs, and infer whether these args are the name or values. This has the following benefits:

- We can keep supporting the existing syntax.
- We allow users to upgrade to the new syntax directly.
- We can adjust the parameters right away without breaking anything.

To further reduce the direct impact, we could define our own deprecation warning (e.g. `PolarsSeriesInitDeprecationWarning` subclassing `DeprecationWarning`) that  users can specifically ignore in their code. That would allow users to upgrade at their own leisure.

Still, this would cause deprecation warnings for almost all of our users, which is painful. But it might be worth it to get the API for one of our core classes right.

Happy to hear your thoughts in the linked issue.