### PR TITLE
feat(rust, python): Add `top_k` and `bottom_k` in the `GroupBy` namespace

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -1835,7 +1835,7 @@ impl LazyGroupBy {
         LazyFrame::from_logical_plan(lp, self.opt_state)
     }
 
-    /// Return the k largest elements sorted by given order.
+    /// Return the k top rows sorted by given order in each group.
     ///
     /// If no `by_exprs` is provided, it will return top k elements in original order.
     ///
@@ -1896,7 +1896,7 @@ impl LazyGroupBy {
         )
     }
 
-    /// Return the k smallest elements sorted by given order.
+    /// Return the k bottom rows sorted by given order in each group.
     ///
     /// The smaller one will be on the top, as opposed to [`tail`](Expr::tail).
     ///

--- a/py-polars/docs/source/reference/dataframe/group_by.rst
+++ b/py-polars/docs/source/reference/dataframe/group_by.rst
@@ -26,3 +26,5 @@ This namespace is available after calling :code:`DataFrame.group_by(...)`.
     GroupBy.quantile
     GroupBy.sum
     GroupBy.tail
+    GroupBy.top_k
+    GroupBy.bottom_k

--- a/py-polars/docs/source/reference/lazyframe/group_by.rst
+++ b/py-polars/docs/source/reference/lazyframe/group_by.rst
@@ -26,3 +26,5 @@ This namespace comes available by calling `LazyFrame.group_by(..)`.
     LazyGroupBy.quantile
     LazyGroupBy.sum
     LazyGroupBy.tail
+    LazyGroupBy.top_k
+    LazyGroupBy.bottom_k

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4567,7 +4567,7 @@ class DataFrame:
         maintain_order
             Whether the order should be maintained if elements are equal.
             Note that if `true` streaming is not possible and performance might be
-            wors since this requires a stable search.
+            worse since this requires a stable search.
 
         See Also
         --------

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -4567,7 +4567,7 @@ class DataFrame:
         maintain_order
             Whether the order should be maintained if elements are equal.
             Note that if `true` streaming is not possible and performance might be
-            worse since this requires a stable search.
+            wors since this requires a stable search.
 
         See Also
         --------

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -795,6 +795,65 @@ class GroupBy:
         by: IntoExpr | Iterable[IntoExpr] | None = None,
         descending: bool | Iterable[bool] = False,
     ) -> DataFrame:
+        """
+        Return the `k` top rows sorted by given order in each group.
+
+        Parameters
+        ----------
+        k
+            Number of rows to return.
+        by
+            Column(s) included in sort order. Accepts expression input.
+            Strings are parsed as column names. If it is not given,
+            the top `k` rows in original order will be return.
+        descending
+            Sort order specified. Single boolean will be applied for all columns.
+            Top-k by multiple columns can be specified per column by passing a
+            sequence of booleans. If a sequence is passed, it must match the length
+            of `by`. If `by` is empty, the first boolean will be applied.
+
+        See Also
+        --------
+        bottom_k
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [1, 2, 2, 3, 4, 5],
+        ...         "b": [5.5, 0.5, 4, 10, 13, 17],
+        ...         "c": [True, True, True, False, False, True],
+        ...         "d": ["Apple", "Orange", "Apple", "Apple", "Banana", "Banana"],
+        ...     }
+        ... )
+        >>> df
+        shape: (6, 4)
+        ┌─────┬──────┬───────┬────────┐
+        │ a   ┆ b    ┆ c     ┆ d      │
+        │ --- ┆ ---  ┆ ---   ┆ ---    │
+        │ i64 ┆ f64  ┆ bool  ┆ str    │
+        ╞═════╪══════╪═══════╪════════╡
+        │ 1   ┆ 5.5  ┆ true  ┆ Apple  │
+        │ 2   ┆ 0.5  ┆ true  ┆ Orange │
+        │ 2   ┆ 4.0  ┆ true  ┆ Apple  │
+        │ 3   ┆ 10.0 ┆ false ┆ Apple  │
+        │ 4   ┆ 13.0 ┆ false ┆ Banana │
+        │ 5   ┆ 17.0 ┆ true  ┆ Banana │
+        └─────┴──────┴───────┴────────┘
+        >>> df.group_by("d", maintain_order=True).top_k(2, by="b")
+        shape: (5, 4)
+        ┌────────┬─────┬──────┬───────┐
+        │ d      ┆ a   ┆ b    ┆ c     │
+        │ ---    ┆ --- ┆ ---  ┆ ---   │
+        │ str    ┆ i64 ┆ f64  ┆ bool  │
+        ╞════════╪═════╪══════╪═══════╡
+        │ Apple  ┆ 3   ┆ 10.0 ┆ false │
+        │ Apple  ┆ 1   ┆ 5.5  ┆ true  │
+        │ Orange ┆ 2   ┆ 0.5  ┆ true  │
+        │ Banana ┆ 5   ┆ 17.0 ┆ true  │
+        │ Banana ┆ 4   ┆ 13.0 ┆ false │
+        └────────┴─────┴──────┴───────┘
+        """
         return (
             self.df.lazy()
             .group_by(*self.by, **self.named_by, maintain_order=self.maintain_order)
@@ -813,6 +872,67 @@ class GroupBy:
         by: IntoExpr | Iterable[IntoExpr] | None = None,
         descending: bool | Iterable[bool] = False,
     ) -> DataFrame:
+        """
+        Return the `k` bottom rows sorted by given order in each group.
+
+        The smaller one will be on the top, as opposed to `tail`.
+
+        Parameters
+        ----------
+        k
+            Number of rows to return.
+        by
+            Column(s) included in sort order. Accepts expression input.
+            Strings are parsed as column names. If it is not given,
+            the top `k` rows in original order will be return.
+        descending
+            Sort order specified. Single boolean will be applied for all columns.
+            Bottom-k by multiple columns can be specified per column by passing a
+            sequence of booleans. If a sequence is passed, it must match the length
+            of `by`. If `by` is empty, the first boolean will be applied.
+
+        See Also
+        --------
+        top_k
+
+        Examples
+        --------
+        >>> df = pl.DataFrame(
+        ...     {
+        ...         "a": [1, 2, 2, 3, 4, 5],
+        ...         "b": [5.5, 0.5, 4, 10, 13, 17],
+        ...         "c": [True, True, True, False, False, True],
+        ...         "d": ["Apple", "Orange", "Apple", "Apple", "Banana", "Banana"],
+        ...     }
+        ... )
+        >>> df
+        shape: (6, 4)
+        ┌─────┬──────┬───────┬────────┐
+        │ a   ┆ b    ┆ c     ┆ d      │
+        │ --- ┆ ---  ┆ ---   ┆ ---    │
+        │ i64 ┆ f64  ┆ bool  ┆ str    │
+        ╞═════╪══════╪═══════╪════════╡
+        │ 1   ┆ 5.5  ┆ true  ┆ Apple  │
+        │ 2   ┆ 0.5  ┆ true  ┆ Orange │
+        │ 2   ┆ 4.0  ┆ true  ┆ Apple  │
+        │ 3   ┆ 10.0 ┆ false ┆ Apple  │
+        │ 4   ┆ 13.0 ┆ false ┆ Banana │
+        │ 5   ┆ 17.0 ┆ true  ┆ Banana │
+        └─────┴──────┴───────┴────────┘
+        >>> df.group_by("d", maintain_order=True).bottom_k(2, by="b")
+        shape: (5, 4)
+        ┌────────┬─────┬──────┬───────┐
+        │ d      ┆ a   ┆ b    ┆ c     │
+        │ ---    ┆ --- ┆ ---  ┆ ---   │
+        │ str    ┆ i64 ┆ f64  ┆ bool  │
+        ╞════════╪═════╪══════╪═══════╡
+        │ Apple  ┆ 2   ┆ 4.0  ┆ true  │
+        │ Apple  ┆ 1   ┆ 5.5  ┆ true  │
+        │ Orange ┆ 2   ┆ 0.5  ┆ true  │
+        │ Banana ┆ 4   ┆ 13.0 ┆ false │
+        │ Banana ┆ 5   ┆ 17.0 ┆ true  │
+        └────────┴─────┴──────┴───────┘
+        """
         return (
             self.df.lazy()
             .group_by(*self.by, **self.named_by, maintain_order=self.maintain_order)

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Iterable, Iterator
+from typing import TYPE_CHECKING, Callable, Iterable, Iterator, Sequence
 
 from polars import functions as F
 from polars._utils.convert import parse_as_duration_string
@@ -792,8 +792,8 @@ class GroupBy:
         self,
         k: int,
         *,
-        by: IntoExpr | Iterable[IntoExpr] | None = None,
-        descending: bool | Iterable[bool] = False,
+        by: IntoExpr | Sequence[IntoExpr] | None = None,
+        descending: bool | Sequence[bool] = False,
     ) -> DataFrame:
         """
         Return the `k` top rows sorted by given order in each group.
@@ -869,8 +869,8 @@ class GroupBy:
         self,
         k: int,
         *,
-        by: IntoExpr | Iterable[IntoExpr] | None = None,
-        descending: bool | Iterable[bool] = False,
+        by: IntoExpr | Sequence[IntoExpr] | None = None,
+        descending: bool | Sequence[bool] = False,
     ) -> DataFrame:
         """
         Return the `k` bottom rows sorted by given order in each group.

--- a/py-polars/polars/dataframe/group_by.py
+++ b/py-polars/polars/dataframe/group_by.py
@@ -788,6 +788,42 @@ class GroupBy:
         """
         return self.map_groups(function)
 
+    def top_k(
+        self,
+        k: int,
+        *,
+        by: IntoExpr | Iterable[IntoExpr] | None = None,
+        descending: bool | Iterable[bool] = False,
+    ) -> DataFrame:
+        return (
+            self.df.lazy()
+            .group_by(*self.by, **self.named_by, maintain_order=self.maintain_order)
+            .top_k(
+                k,
+                by=by,
+                descending=descending,
+            )
+            .collect(no_optimization=True)
+        )
+
+    def bottom_k(
+        self,
+        k: int,
+        *,
+        by: IntoExpr | Iterable[IntoExpr] | None = None,
+        descending: bool | Iterable[bool] = False,
+    ) -> DataFrame:
+        return (
+            self.df.lazy()
+            .group_by(*self.by, **self.named_by, maintain_order=self.maintain_order)
+            .bottom_k(
+                k,
+                by=by,
+                descending=descending,
+            )
+            .collect(no_optimization=True)
+        )
+
 
 class RollingGroupBy:
     """

--- a/py-polars/polars/lazyframe/group_by.py
+++ b/py-polars/polars/lazyframe/group_by.py
@@ -759,12 +759,12 @@ class LazyGroupBy:
                 descending = [descending]
 
         if len(by) != 0 and len(by) != len(descending):
-            raise ValueError(
-                f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
-            )
+            err = f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
+            raise ValueError(err)
 
         if len(descending) == 0:
-            raise ValueError("Order must be specified but is not provided. ")
+            err = "Order must be specified but is not provided. "
+            raise ValueError(err)
 
         return wrap_ldf(self.lgb.top_k(k, by, descending))
 
@@ -848,11 +848,11 @@ class LazyGroupBy:
                 descending = [descending]
 
         if len(by) != 0 and len(by) != len(descending):
-            raise ValueError(
-                f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
-            )
+            err = f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
+            raise ValueError(err)
 
         if len(descending) == 0:
-            raise ValueError("Order must be specified but is not provided. ")
+            err = "Order must be specified but is not provided. "
+            raise ValueError(err)
 
         return wrap_ldf(self.lgb.bottom_k(k, by, descending))

--- a/py-polars/polars/lazyframe/group_by.py
+++ b/py-polars/polars/lazyframe/group_by.py
@@ -688,6 +688,65 @@ class LazyGroupBy:
         by: IntoExpr | Iterable[IntoExpr] | None = None,
         descending: bool | Iterable[bool] = False,
     ) -> LazyFrame:
+        """
+        Return the `k` top rows sorted by given order in each group.
+
+        Parameters
+        ----------
+        k
+            Number of rows to return.
+        by
+            Column(s) included in sort order. Accepts expression input.
+            Strings are parsed as column names. If it is not given,
+            the top `k` rows in original order will be return.
+        descending
+            Sort order specified. Single boolean will be applied for all columns.
+            Top-k by multiple columns can be specified per column by passing a
+            sequence of booleans. If a sequence is passed, it must match the length
+            of `by`. If `by` is empty, the first boolean will be applied.
+
+        See Also
+        --------
+        bottom_k
+
+        Examples
+        --------
+        >>> lf = pl.LazyFrame(
+        ...     {
+        ...         "a": [1, 2, 2, 3, 4, 5],
+        ...         "b": [5.5, 0.5, 4, 10, 13, 17],
+        ...         "c": [True, True, True, False, False, True],
+        ...         "d": ["Apple", "Orange", "Apple", "Apple", "Banana", "Banana"],
+        ...     }
+        ... )
+        >>> lf.collect()
+        shape: (6, 4)
+        ┌─────┬──────┬───────┬────────┐
+        │ a   ┆ b    ┆ c     ┆ d      │
+        │ --- ┆ ---  ┆ ---   ┆ ---    │
+        │ i64 ┆ f64  ┆ bool  ┆ str    │
+        ╞═════╪══════╪═══════╪════════╡
+        │ 1   ┆ 5.5  ┆ true  ┆ Apple  │
+        │ 2   ┆ 0.5  ┆ true  ┆ Orange │
+        │ 2   ┆ 4.0  ┆ true  ┆ Apple  │
+        │ 3   ┆ 10.0 ┆ false ┆ Apple  │
+        │ 4   ┆ 13.0 ┆ false ┆ Banana │
+        │ 5   ┆ 17.0 ┆ true  ┆ Banana │
+        └─────┴──────┴───────┴────────┘
+        >>> lf.group_by("d", maintain_order=True).top_k(2, by="b").collect()
+        shape: (5, 4)
+        ┌────────┬─────┬──────┬───────┐
+        │ d      ┆ a   ┆ b    ┆ c     │
+        │ ---    ┆ --- ┆ ---  ┆ ---   │
+        │ str    ┆ i64 ┆ f64  ┆ bool  │
+        ╞════════╪═════╪══════╪═══════╡
+        │ Apple  ┆ 3   ┆ 10.0 ┆ false │
+        │ Apple  ┆ 1   ┆ 5.5  ┆ true  │
+        │ Orange ┆ 2   ┆ 0.5  ┆ true  │
+        │ Banana ┆ 5   ┆ 17.0 ┆ true  │
+        │ Banana ┆ 4   ┆ 13.0 ┆ false │
+        └────────┴─────┴──────┴───────┘
+        """
         if by is None:
             by = []
         else:
@@ -716,6 +775,67 @@ class LazyGroupBy:
         by: IntoExpr | Iterable[IntoExpr] | None = None,
         descending: bool | Iterable[bool] = False,
     ) -> LazyFrame:
+        """
+        Return the `k` bottom rows sorted by given order in each group.
+
+        The smaller one will be on the top, as opposed to `tail`.
+
+        Parameters
+        ----------
+        k
+            Number of rows to return.
+        by
+            Column(s) included in sort order. Accepts expression input.
+            Strings are parsed as column names. If it is not given,
+            the top `k` rows in original order will be return.
+        descending
+            Sort order specified. Single boolean will be applied for all columns.
+            Bottom-k by multiple columns can be specified per column by passing a
+            sequence of booleans. If a sequence is passed, it must match the length
+            of `by`. If `by` is empty, the first boolean will be applied.
+
+        See Also
+        --------
+        top_k
+
+        Examples
+        --------
+        >>> lf = pl.LazyFrame(
+        ...     {
+        ...         "a": [1, 2, 2, 3, 4, 5],
+        ...         "b": [5.5, 0.5, 4, 10, 13, 17],
+        ...         "c": [True, True, True, False, False, True],
+        ...         "d": ["Apple", "Orange", "Apple", "Apple", "Banana", "Banana"],
+        ...     }
+        ... )
+        >>> lf.collect()
+        shape: (6, 4)
+        ┌─────┬──────┬───────┬────────┐
+        │ a   ┆ b    ┆ c     ┆ d      │
+        │ --- ┆ ---  ┆ ---   ┆ ---    │
+        │ i64 ┆ f64  ┆ bool  ┆ str    │
+        ╞═════╪══════╪═══════╪════════╡
+        │ 1   ┆ 5.5  ┆ true  ┆ Apple  │
+        │ 2   ┆ 0.5  ┆ true  ┆ Orange │
+        │ 2   ┆ 4.0  ┆ true  ┆ Apple  │
+        │ 3   ┆ 10.0 ┆ false ┆ Apple  │
+        │ 4   ┆ 13.0 ┆ false ┆ Banana │
+        │ 5   ┆ 17.0 ┆ true  ┆ Banana │
+        └─────┴──────┴───────┴────────┘
+        >>> lf.group_by("d", maintain_order=True).bottom_k(2, by="b").collect()
+        shape: (5, 4)
+        ┌────────┬─────┬──────┬───────┐
+        │ d      ┆ a   ┆ b    ┆ c     │
+        │ ---    ┆ --- ┆ ---  ┆ ---   │
+        │ str    ┆ i64 ┆ f64  ┆ bool  │
+        ╞════════╪═════╪══════╪═══════╡
+        │ Apple  ┆ 2   ┆ 4.0  ┆ true  │
+        │ Apple  ┆ 1   ┆ 5.5  ┆ true  │
+        │ Orange ┆ 2   ┆ 0.5  ┆ true  │
+        │ Banana ┆ 4   ┆ 13.0 ┆ false │
+        │ Banana ┆ 5   ┆ 17.0 ┆ true  │
+        └────────┴─────┴──────┴───────┘
+        """
         if by is None:
             by = []
         else:

--- a/py-polars/polars/lazyframe/group_by.py
+++ b/py-polars/polars/lazyframe/group_by.py
@@ -680,3 +680,59 @@ class LazyGroupBy:
             lead to errors. If set to None, polars assumes the schema is unchanged.
         """
         return self.map_groups(function, schema)
+
+    def top_k(
+        self,
+        k: int,
+        *,
+        by: IntoExpr | Iterable[IntoExpr] | None = None,
+        descending: bool | Iterable[bool] = False,
+    ) -> LazyFrame:
+        if by is None:
+            by = []
+        else:
+            by = parse_as_list_of_expressions(by)
+
+        if isinstance(descending, bool):
+            if len(by) != 0:
+                descending = [descending for _ in by]
+            else:
+                descending = [descending]
+
+        if len(by) != 0 and len(by) != len(descending):
+            raise ValueError(
+                f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
+            )
+
+        if len(descending) == 0:
+            raise ValueError("Order must be specified but is not provided. ")
+
+        return wrap_ldf(self.lgb.top_k(k, by, descending))
+
+    def bottom_k(
+        self,
+        k: int,
+        *,
+        by: IntoExpr | Iterable[IntoExpr] | None = None,
+        descending: bool | Iterable[bool] = False,
+    ) -> LazyFrame:
+        if by is None:
+            by = []
+        else:
+            by = parse_as_list_of_expressions(by)
+
+        if isinstance(descending, bool):
+            if len(by) != 0:
+                descending = [descending for _ in by]
+            else:
+                descending = [descending]
+
+        if len(by) != 0 and len(by) != len(descending):
+            raise ValueError(
+                f"the length of `descending` ({len(descending)}) does not match the length of `by` ({len(by)})"
+            )
+
+        if len(descending) == 0:
+            raise ValueError("Order must be specified but is not provided. ")
+
+        return wrap_ldf(self.lgb.bottom_k(k, by, descending))

--- a/py-polars/polars/lazyframe/group_by.py
+++ b/py-polars/polars/lazyframe/group_by.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Iterable
+from typing import TYPE_CHECKING, Callable, Iterable, Sequence
 
 from polars import functions as F
 from polars._utils.deprecation import deprecate_renamed_function
@@ -685,8 +685,8 @@ class LazyGroupBy:
         self,
         k: int,
         *,
-        by: IntoExpr | Iterable[IntoExpr] | None = None,
-        descending: bool | Iterable[bool] = False,
+        by: IntoExpr | Sequence[IntoExpr] | None = None,
+        descending: bool | Sequence[bool] = False,
     ) -> LazyFrame:
         """
         Return the `k` top rows sorted by given order in each group.
@@ -772,8 +772,8 @@ class LazyGroupBy:
         self,
         k: int,
         *,
-        by: IntoExpr | Iterable[IntoExpr] | None = None,
-        descending: bool | Iterable[bool] = False,
+        by: IntoExpr | Sequence[IntoExpr] | None = None,
+        descending: bool | Sequence[bool] = False,
     ) -> LazyFrame:
         """
         Return the `k` bottom rows sorted by given order in each group.

--- a/py-polars/src/lazygroupby.rs
+++ b/py-polars/src/lazygroupby.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use polars::lazy::frame::{LazyFrame, LazyGroupBy};
-use polars::prelude::{DataFrame, PolarsError, Schema};
+use polars::prelude::{DataFrame, PolarsError, Schema, IdxSize};
 use pyo3::prelude::*;
 
 use crate::conversion::Wrap;
@@ -32,6 +32,30 @@ impl PyLazyGroupBy {
     fn tail(&mut self, n: usize) -> PyLazyFrame {
         let lgb = self.lgb.clone().unwrap();
         lgb.tail(Some(n)).into()
+    }
+
+    fn top_k(
+        &self,
+        k: IdxSize,
+        by: Vec<PyExpr>,
+        descending: Vec<bool>,
+    ) -> PyLazyFrame {
+        let lgb = self.lgb.clone().unwrap();
+        let exprs = by.to_exprs();
+        lgb.top_k(k, exprs, descending)
+            .into()
+    }
+
+    fn bottom_k(
+        &self,
+        k: IdxSize,
+        by: Vec<PyExpr>,
+        descending: Vec<bool>,
+    ) -> PyLazyFrame {
+        let lgb = self.lgb.clone().unwrap();
+        let exprs = by.to_exprs();
+        lgb.bottom_k(k, exprs, descending)
+            .into()
     }
 
     fn map_groups(

--- a/py-polars/src/lazygroupby.rs
+++ b/py-polars/src/lazygroupby.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use polars::lazy::frame::{LazyFrame, LazyGroupBy};
-use polars::prelude::{DataFrame, PolarsError, Schema, IdxSize};
+use polars::prelude::{DataFrame, IdxSize, PolarsError, Schema};
 use pyo3::prelude::*;
 
 use crate::conversion::Wrap;
@@ -34,28 +34,16 @@ impl PyLazyGroupBy {
         lgb.tail(Some(n)).into()
     }
 
-    fn top_k(
-        &self,
-        k: IdxSize,
-        by: Vec<PyExpr>,
-        descending: Vec<bool>,
-    ) -> PyLazyFrame {
+    fn top_k(&self, k: IdxSize, by: Vec<PyExpr>, descending: Vec<bool>) -> PyLazyFrame {
         let lgb = self.lgb.clone().unwrap();
         let exprs = by.to_exprs();
-        lgb.top_k(k, exprs, descending)
-            .into()
+        lgb.top_k(k, exprs, descending).into()
     }
 
-    fn bottom_k(
-        &self,
-        k: IdxSize,
-        by: Vec<PyExpr>,
-        descending: Vec<bool>,
-    ) -> PyLazyFrame {
+    fn bottom_k(&self, k: IdxSize, by: Vec<PyExpr>, descending: Vec<bool>) -> PyLazyFrame {
         let lgb = self.lgb.clone().unwrap();
         let exprs = by.to_exprs();
-        lgb.bottom_k(k, exprs, descending)
-            .into()
+        lgb.bottom_k(k, exprs, descending).into()
     }
 
     fn map_groups(

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1006,7 +1006,7 @@ def test_sort_descending_nulls_last(descending: bool, nulls_last: bool) -> None:
     )
 
 
-def test_aggregate_top_k():
+def test_aggregate_top_k() -> None:
     df = pl.DataFrame(
         {
             "a": [1, 2, 2, 3, 4, 5],

--- a/py-polars/tests/unit/operations/test_sort.py
+++ b/py-polars/tests/unit/operations/test_sort.py
@@ -1113,7 +1113,9 @@ def test_aggregate_top_k():
     )
 
     assert_frame_equal(
-        df.group_by("d", maintain_order=True).bottom_k(2, by=["c", "a"], descending=True),
+        df.group_by("d", maintain_order=True).bottom_k(
+            2, by=["c", "a"], descending=True
+        ),
         pl.DataFrame(
             {
                 "d": ["Apple", "Apple", "Orange", "Banana", "Banana"],
@@ -1125,7 +1127,9 @@ def test_aggregate_top_k():
     )
 
     assert_frame_equal(
-        df.group_by("d", maintain_order=True).top_k(2, by=["c", "a"], descending=[True, False]),
+        df.group_by("d", maintain_order=True).top_k(
+            2, by=["c", "a"], descending=[True, False]
+        ),
         pl.DataFrame(
             {
                 "d": ["Apple", "Apple", "Orange", "Banana", "Banana"],
@@ -1137,7 +1141,9 @@ def test_aggregate_top_k():
     )
 
     assert_frame_equal(
-        df.group_by("d", maintain_order=True).bottom_k(2, by=["c", "a"], descending=[True, False]),
+        df.group_by("d", maintain_order=True).bottom_k(
+            2, by=["c", "a"], descending=[True, False]
+        ),
         pl.DataFrame(
             {
                 "d": ["Apple", "Apple", "Orange", "Banana", "Banana"],
@@ -1182,7 +1188,9 @@ def test_aggregate_top_k():
         ValueError,
         match=r"the length of `descending` \(1\) does not match the length of `by` \(2\)",
     ):
-        df.group_by("d", maintain_order=True).bottom_k(2, by=["a", "b"], descending=[True])
+        df.group_by("d", maintain_order=True).bottom_k(
+            2, by=["a", "b"], descending=[True]
+        )
 
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
Closes #10054 

Return the `k` top/bottom rows sorted by given order in each group.

# Example

## Rust

> Only implemented for `LazyGroupBy`.

```rust
let df = df![
    "a" => &[1, 2, 2, 3, 4, 5],
    "b" => &[5.5, 0.5, 4.0, 10.0, 13.0, 17.0],
    "c" => &[true, true, true, false, false, true],
    "d" => &["Apple", "Orange", "Apple", "Apple", "Banana", "Banana"],
].unwrap();

println!(
    "{:?}",
    df.lazy().group_by_stable(&[col("d")])
        .bottom_k(2, &[col("b")], [true])
        .collect()
        .unwrap()
);
```

Output: 

```txt
shape: (5, 4)
┌────────┬─────┬──────┬───────┐
│ d      ┆ a   ┆ b    ┆ c     │
│ ---    ┆ --- ┆ ---  ┆ ---   │
│ str    ┆ i32 ┆ f64  ┆ bool  │
╞════════╪═════╪══════╪═══════╡
│ Apple  ┆ 3   ┆ 10.0 ┆ false │
│ Apple  ┆ 1   ┆ 5.5  ┆ true  │
│ Orange ┆ 2   ┆ 0.5  ┆ true  │
│ Banana ┆ 5   ┆ 17.0 ┆ true  │
│ Banana ┆ 4   ┆ 13.0 ┆ false │
└────────┴─────┴──────┴───────┘
```

## Python

> Implemented for both `LazyGroupBy` and `GroupBy`.

```python
df = pl.DataFrame(
    {
        "a": [1, 2, 2, 3, 4, 5],
        "b": [5.5, 0.5, 4, 10, 13, 17],
        "c": [True, True, True, False, False, True],
        "d": ["Apple", "Orange", "Apple", "Apple", "Banana", "Banana"],
    }
)

df.group_by("d", maintain_order=True).bottom_k(2, by="b")
```

Output: 

```txt
shape: (5, 4)
┌────────┬─────┬──────┬───────┐
│ d      ┆ a   ┆ b    ┆ c     │
│ ---    ┆ --- ┆ ---  ┆ ---   │
│ str    ┆ i64 ┆ f64  ┆ bool  │
╞════════╪═════╪══════╪═══════╡
│ Apple  ┆ 2   ┆ 4.0  ┆ true  │
│ Apple  ┆ 1   ┆ 5.5  ┆ true  │
│ Orange ┆ 2   ┆ 0.5  ┆ true  │
│ Banana ┆ 4   ┆ 13.0 ┆ false │
│ Banana ┆ 5   ┆ 17.0 ┆ true  │
└────────┴─────┴──────┴───────┘
```
