### PR TITLE
fix(rust): ensure `eq` for `BinaryViewArray` checks all elements

### DIFF
--- a/crates/polars-arrow/src/array/binview/mod.rs
+++ b/crates/polars-arrow/src/array/binview/mod.rs
@@ -120,7 +120,7 @@ pub struct BinaryViewArrayGeneric<T: ViewType + ?Sized> {
 
 impl<T: ViewType + ?Sized> PartialEq for BinaryViewArrayGeneric<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.into_iter().zip(other).all(|(l, r)| l == r)
+        self.len() == other.len() && self.into_iter().zip(other).all(|(l, r)| l == r)
     }
 }
 

--- a/py-polars/tests/unit/datatypes/test_enum.py
+++ b/py-polars/tests/unit/datatypes/test_enum.py
@@ -214,8 +214,8 @@ def test_append_to_an_enum() -> None:
 
 def test_append_to_an_enum_with_new_category() -> None:
     with pytest.raises(
-        pl.ComputeError,
-        match=("can not merge incompatible Enum types"),
+        pl.SchemaError,
+        match=("cannot extend/append Enum"),
     ):
         pl.Series([None, "a", "b", "c"], dtype=pl.Enum(["a", "b", "c"])).append(
             pl.Series(["d", "a", "b", "c"], dtype=pl.Enum(["a", "b", "c", "d"]))
@@ -473,3 +473,12 @@ def test_enum_cse_eq() -> None:
         pl.when(True).then(pl.lit("a", dtype=dt1)).alias("dt1"),
         pl.when(True).then(pl.lit("a", dtype=dt2)).alias("dt2"),
     ).collect()
+
+
+def test_same_literal_separate_categories_not_equal() -> None:
+    dt1 = pl.Enum(["a"])
+    dt2 = pl.Enum(["a", "b"])
+    pl.LazyFrame().select(
+        pl.lit("a", dtype=dt1).alias("dt1"),
+        pl.lit("a", dtype=dt2).alias("dt2"),
+    ).collect().dtypes

--- a/py-polars/tests/unit/operations/test_replace.py
+++ b/py-polars/tests/unit/operations/test_replace.py
@@ -94,7 +94,7 @@ def test_replace_enum_to_new_enum() -> None:
     new_dtype = pl.Enum(["a", "b", "c", "d", "e"])
     new = pl.Series(["c", "e"], dtype=new_dtype)
 
-    result = s.replace(old, new)
+    result = s.replace(old, new, return_dtype=new_dtype)
 
     expected = pl.Series(["c", "e", "c"], dtype=new_dtype)
     assert_series_equal(result, expected)


### PR DESCRIPTION
Resolves #15170.

The categories of an enum are stored as `BinaryViewArrays`. The `eq` function used `.zip.all()`. `zip` stops when the shorter of the two iterators runs out, which means that when comparing `[a, b, c]` to `[a, b]`, `eq` was returning true, since the first 2 values match and only 2 values were matched.
 
I added a quick length check instead of using something like [`zip_longest`](https://docs.rs/itertools/0.8.0/itertools/trait.Itertools.html#method.zip_longest) since if the lengths don't match, the arrays cannot be equal.

The `test_replace` unit test actually should have been failing because it did not specify the `return_dtype`, but was not due to this error. In addition, the `test_append_to_an_enum_with_new_category` now fails earlier during the planning stage, as the two enums are now detected as unequal earlier, and so the error message is different. I have fixed both of these tests.