### PR TITLE
fix: pass scalar as series to update group information

### DIFF
--- a/crates/polars-lazy/src/physical_plan/expressions/apply.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/apply.rs
@@ -100,6 +100,7 @@ impl ApplyExpr {
             ac.with_agg_state(AggState::AggregatedScalar(
                 ca.explode().unwrap().into_series(),
             ));
+            ac.with_update_groups(UpdateGroups::WithGroupsLen);
         } else {
             ac.with_series(ca.into_series(), true, Some(&self.expr))?;
             ac.with_update_groups(UpdateGroups::WithSeriesLen);


### PR DESCRIPTION
Attempt at fix for issue https://github.com/pola-rs/polars/issues/15183. 
The scalar variables are passed in as series to update groups information, which leads to panic in `ac.groups()`. https://github.com/pola-rs/polars/blob/252702a8c7f5c00558d2dc58460e2d9b41828917/crates/polars-lazy/src/physical_plan/expressions/apply.rs#L438
Therefore, resetting `update_groups` can solve this problem. Now, it works smoothly

```
>>> import polars as pl
>>> dfBug = (
...     pl.DataFrame({"a": [1, 2, 3, 4, 5, 2, 3, 5, 1], "b": [1, 2, 3, 1, 2, 3, 1, 2, 3]})
...     .group_by("a")
...     .agg(pl.col.b.unique().sort().str.concat("-").str.split("-"))
... )
>>> print(dfBug)
shape: (5, 2)
┌─────┬────────────┐
│ a   ┆ b          │
│ --- ┆ ---        │
│ i64 ┆ list[str]  │
╞═════╪════════════╡
│ 1   ┆ ["1", "3"] │
│ 2   ┆ ["2", "3"] │
│ 4   ┆ ["1"]      │
│ 3   ┆ ["1", "3"] │
│ 5   ┆ ["2"]      │
└─────┴────────────┘

```