### PR TITLE
feat(python): Add `read_clipboard` and `DataFrame.write_clipboard`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,6 +126,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "arboard"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2041f1943049c7978768d84e6d0fd95de98b76d6c4727b09e78ec253d29fa58"
+dependencies = [
+ "clipboard-win",
+ "core-graphics",
+ "image",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "parking_lot",
+ "thiserror",
+ "windows-sys 0.48.0",
+ "x11rb",
+]
+
+[[package]]
 name = "argminmax"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,6 +725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +796,12 @@ dependencies = [
  "quote",
  "syn 2.0.52",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -919,6 +950,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
+name = "clipboard-win"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d517d4b86184dbb111d3556a10f1c8a04da7428d2987bf1081602bf11c3aa9ee"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +966,12 @@ checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "comfy-table"
@@ -980,6 +1026,30 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "core-graphics"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-graphics-types",
+ "foreign-types",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "core2"
@@ -1305,6 +1375,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+
+[[package]]
 name = "ethnum"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1327,6 +1403,15 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "ff"
@@ -1363,6 +1448,33 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "foreign_vec"
@@ -1476,6 +1588,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+dependencies = [
+ "libc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -1754,6 +1876,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-traits",
+ "png",
+ "tiff",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,6 +1987,12 @@ checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -2095,6 +2237,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2160,6 +2311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2331,6 +2483,35 @@ dependencies = [
  "num-traits",
  "pyo3",
  "rustc-hash",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
 ]
 
 [[package]]
@@ -2557,6 +2738,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "png"
+version = "0.17.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -3081,6 +3275,7 @@ name = "py-polars"
 version = "0.20.16"
 dependencies = [
  "ahash",
+ "arboard",
  "built",
  "ciborium",
  "either",
@@ -3797,6 +3992,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "simd-json"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4073,6 +4274,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
+]
+
+[[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
 ]
 
 [[package]]
@@ -4528,6 +4740,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "weezl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4727,6 +4945,23 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8f25ead8c7e4cba123243a6367da5d3990e0d3affa708ea19dce96356bd9f1a"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63e71c4b8bd9ffec2c963173a4dc4cbde9ee96961d4fcb4429db9929b606c34"
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,15 +132,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2041f1943049c7978768d84e6d0fd95de98b76d6c4727b09e78ec253d29fa58"
 dependencies = [
  "clipboard-win",
- "core-graphics",
- "image",
  "log",
  "objc",
  "objc-foundation",
  "objc_id",
  "parking_lot",
  "thiserror",
- "windows-sys 0.48.0",
  "x11rb",
 ]
 
@@ -798,12 +795,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,12 +959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "comfy-table"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1026,30 +1011,6 @@ name = "core-foundation-sys"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
-
-[[package]]
-name = "core-graphics"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970a29baf4110c26fedbc7f82107d42c23f7e88e404c4577ed73fe99ff85a212"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "core-graphics-types",
- "foreign-types",
- "libc",
-]
-
-[[package]]
-name = "core-graphics-types"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation",
- "libc",
-]
 
 [[package]]
 name = "core2"
@@ -1405,15 +1366,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
-name = "fdeflate"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1448,33 +1400,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foreign-types"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
-dependencies = [
- "foreign-types-macros",
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.52",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "foreign_vec"
@@ -1876,20 +1801,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "num-traits",
- "png",
- "tiff",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1987,12 +1898,6 @@ checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -2311,7 +2216,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
- "simd-adler32",
 ]
 
 [[package]]
@@ -2738,19 +2642,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
-]
-
-[[package]]
-name = "png"
-version = "0.17.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -3992,12 +3883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
-
-[[package]]
 name = "simd-json"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4274,17 +4159,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.52",
-]
-
-[[package]]
-name = "tiff"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
-dependencies = [
- "flate2",
- "jpeg-decoder",
- "weezl",
 ]
 
 [[package]]
@@ -4738,12 +4612,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ version_check = "0.9.4"
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 zstd = "0.13"
 uuid = { version = "1.7.0", features = ["v4"] }
-arboard = { version = "3.3.2" }
+arboard = { version = "3.3.2", default-features = false }
 
 polars = { version = "0.38.3", path = "crates/polars", default-features = false }
 polars-compute = { version = "0.38.3", path = "crates/polars-compute", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ version_check = "0.9.4"
 xxhash-rust = { version = "0.8.6", features = ["xxh3"] }
 zstd = "0.13"
 uuid = { version = "1.7.0", features = ["v4"] }
+arboard = { version = "3.3.2" }
 
 polars = { version = "0.38.3", path = "crates/polars", default-features = false }
 polars-compute = { version = "0.38.3", path = "crates/polars-compute", default-features = false }

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -30,6 +30,7 @@ pyo3-built = { version = "0.4", optional = true }
 serde_json = { workspace = true, optional = true }
 smartstring = { workspace = true }
 thiserror = { workspace = true }
+arboard = { workspace = true, optional = true }
 
 [dependencies.polars]
 workspace = true
@@ -126,6 +127,7 @@ search_sorted = ["polars/search_sorted"]
 decompress = ["polars/decompress-fast"]
 regex = ["polars/regex"]
 csv = ["polars/csv"]
+clipboard = ["arboard"]
 object = ["polars/object"]
 extract_jsonpath = ["polars/extract_jsonpath"]
 pivot = ["polars/pivot"]
@@ -204,6 +206,7 @@ io = [
   "avro",
   "csv",
   "cloud",
+  "clipboard"
 ]
 
 optimizations = [

--- a/py-polars/Cargo.toml
+++ b/py-polars/Cargo.toml
@@ -17,6 +17,7 @@ polars-plan = { workspace = true }
 polars-utils = { workspace = true }
 
 ahash = { workspace = true }
+arboard = { workspace = true, optional = true }
 ciborium = { workspace = true }
 either = { workspace = true }
 itoa = { workspace = true }
@@ -30,7 +31,6 @@ pyo3-built = { version = "0.4", optional = true }
 serde_json = { workspace = true, optional = true }
 smartstring = { workspace = true }
 thiserror = { workspace = true }
-arboard = { workspace = true, optional = true }
 
 [dependencies.polars]
 workspace = true
@@ -206,7 +206,7 @@ io = [
   "avro",
   "csv",
   "cloud",
-  "clipboard"
+  "clipboard",
 ]
 
 optimizations = [

--- a/py-polars/docs/source/reference/io.rst
+++ b/py-polars/docs/source/reference/io.rst
@@ -11,6 +11,14 @@ Avro
    read_avro
    DataFrame.write_avro
 
+Clipboard
+~~~~~~~~~
+.. autosummary::
+   :toctree: api/
+
+   read_clipboard
+   DataFrame.write_clipboard
+
 CSV
 ~~~
 .. autosummary::

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -180,6 +180,7 @@ from polars.functions import (
 )
 from polars.io import (
     read_avro,
+    read_clipboard,
     read_csv,
     read_csv_batched,
     read_database,
@@ -201,7 +202,6 @@ from polars.io import (
     scan_ndjson,
     scan_parquet,
     scan_pyarrow_dataset,
-    read_clipboard,
 )
 from polars.lazyframe import InProcessQuery, LazyFrame
 from polars.meta import (

--- a/py-polars/polars/__init__.py
+++ b/py-polars/polars/__init__.py
@@ -201,6 +201,7 @@ from polars.io import (
     scan_ndjson,
     scan_parquet,
     scan_pyarrow_dataset,
+    read_clipboard,
 )
 from polars.lazyframe import InProcessQuery, LazyFrame
 from polars.meta import (
@@ -316,6 +317,7 @@ __all__ = [
     "scan_ndjson",
     "scan_parquet",
     "scan_pyarrow_dataset",
+    "read_clipboard",
     # polars.stringcache
     "StringCache",
     "disable_string_cache",

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -117,7 +117,7 @@ from polars.type_aliases import DbWriteMode
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame
-    from polars.polars import dtype_str_repr as _dtype_str_repr
+    from polars.polars import dtype_str_repr as _dtype_str_repr, write_clipboard_string as _write_clipboard_string
 
 if TYPE_CHECKING:
     import sys
@@ -2594,6 +2594,10 @@ class DataFrame:
             return str(buffer.getvalue(), encoding="utf-8")
 
         return None
+
+    def write_clipboard(self, *, separator: str = "\t", **kwargs: Any):
+        result: str = self.write_csv(file=None, separator=separator, **kwargs)
+        _write_clipboard_string(result)
 
     def write_avro(
         self,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -117,7 +117,8 @@ from polars.type_aliases import DbWriteMode
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame
-    from polars.polars import dtype_str_repr as _dtype_str_repr, write_clipboard_string as _write_clipboard_string
+    from polars.polars import dtype_str_repr as _dtype_str_repr
+    from polars.polars import write_clipboard_string as _write_clipboard_string
 
 if TYPE_CHECKING:
     import sys
@@ -2595,7 +2596,24 @@ class DataFrame:
 
         return None
 
-    def write_clipboard(self, *, separator: str = "\t", **kwargs: Any):
+    def write_clipboard(self, *, separator: str = "\t", **kwargs: Any) -> None:
+        """
+        Copy `DataFrame` in csv format to the system clipboard with `write_csv`.
+
+        Useful for pasting into Excel or other similar spreadsheet software.
+
+        Parameters
+        ----------
+        separator
+            Separate CSV fields with this symbol.
+        kwargs
+            Additional arguments to pass to `write_csv`.
+
+        See Also
+        --------
+        polars.read_clipboard: Read a DataFrame from the clipboard.
+        write_csv: Write to comma-separated values (CSV) file.
+        """
         result: str = self.write_csv(file=None, separator=separator, **kwargs)
         _write_clipboard_string(result)
 

--- a/py-polars/polars/io/__init__.py
+++ b/py-polars/polars/io/__init__.py
@@ -11,6 +11,7 @@ from polars.io.ndjson import read_ndjson, scan_ndjson
 from polars.io.parquet import read_parquet, read_parquet_schema, scan_parquet
 from polars.io.pyarrow_dataset import scan_pyarrow_dataset
 from polars.io.spreadsheet import read_excel, read_ods
+from polars.io.clipboard import read_clipboard
 
 __all__ = [
     "read_avro",
@@ -35,4 +36,5 @@ __all__ = [
     "scan_ndjson",
     "scan_parquet",
     "scan_pyarrow_dataset",
+    "read_clipboard"
 ]

--- a/py-polars/polars/io/__init__.py
+++ b/py-polars/polars/io/__init__.py
@@ -1,6 +1,7 @@
 """Functions for reading data."""
 
 from polars.io.avro import read_avro
+from polars.io.clipboard import read_clipboard
 from polars.io.csv import read_csv, read_csv_batched, scan_csv
 from polars.io.database import read_database, read_database_uri
 from polars.io.delta import read_delta, scan_delta
@@ -11,7 +12,6 @@ from polars.io.ndjson import read_ndjson, scan_ndjson
 from polars.io.parquet import read_parquet, read_parquet_schema, scan_parquet
 from polars.io.pyarrow_dataset import scan_pyarrow_dataset
 from polars.io.spreadsheet import read_excel, read_ods
-from polars.io.clipboard import read_clipboard
 
 __all__ = [
     "read_avro",
@@ -36,5 +36,5 @@ __all__ = [
     "scan_ndjson",
     "scan_parquet",
     "scan_pyarrow_dataset",
-    "read_clipboard"
+    "read_clipboard",
 ]

--- a/py-polars/polars/io/clipboard.py
+++ b/py-polars/polars/io/clipboard.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import contextlib
+from typing import Any, TYPE_CHECKING
+
+from polars.io.csv.functions import read_csv
+
+from io import StringIO
+
+with contextlib.suppress(ImportError):
+    from polars.polars import read_clipboard_string as _read_clipboard_string
+
+if TYPE_CHECKING:
+    from polars import DataFrame
+
+
+def read_clipboard(separator: str = "\t", **kwargs: Any) -> DataFrame:
+    csv_string: str = _read_clipboard_string()
+    io_string = StringIO(csv_string)
+    return read_csv(source=io_string, separator=separator, **kwargs)

--- a/py-polars/polars/io/clipboard.py
+++ b/py-polars/polars/io/clipboard.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import contextlib
-from typing import Any, TYPE_CHECKING
+from io import StringIO
+from typing import TYPE_CHECKING, Any
 
 from polars.io.csv.functions import read_csv
-
-from io import StringIO
 
 with contextlib.suppress(ImportError):
     from polars.polars import read_clipboard_string as _read_clipboard_string
@@ -15,6 +14,23 @@ if TYPE_CHECKING:
 
 
 def read_clipboard(separator: str = "\t", **kwargs: Any) -> DataFrame:
+    """
+    Read text from clipboard and pass to `read_csv`.
+
+    Useful for reading data copied from Excel or other similar spreadsheet software.
+
+    Parameters
+    ----------
+    separator
+        Single byte character to use as separator parsing csv from clipboard.
+    kwargs
+        Additional arguments passed to `read_csv`.
+
+    See Also
+    --------
+    read_csv : Read a csv file into a DataFrame.
+    DataFrame.write_clipboard : Write a DataFrame to the clipboard.
+    """
     csv_string: str = _read_clipboard_string()
     io_string = StringIO(csv_string)
     return read_csv(source=io_string, separator=separator, **kwargs)

--- a/py-polars/src/functions/io.rs
+++ b/py-polars/src/functions/io.rs
@@ -56,3 +56,27 @@ fn fields_to_pydict(fields: &Vec<Field>, dict: &PyDict, py: Python) -> PyResult<
     }
     Ok(())
 }
+
+#[cfg(feature = "clipboard")]
+#[pyfunction]
+pub fn read_clipboard_string() -> PyResult<String> {
+    use arboard;
+    let mut clipboard =
+        arboard::Clipboard::new().map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
+    let result = clipboard
+        .get_text()
+        .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
+    Ok(result)
+}
+
+#[cfg(feature = "clipboard")]
+#[pyfunction]
+pub fn write_clipboard_string(s: &str) -> PyResult<()> {
+    use arboard;
+    let mut clipboard =
+        arboard::Clipboard::new().map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
+    clipboard
+        .set_text(s)
+        .map_err(|e| PyPolarsErr::Other(format!("{e}")))?;
+    Ok(())
+}

--- a/py-polars/src/lib.rs
+++ b/py-polars/src/lib.rs
@@ -205,6 +205,12 @@ fn polars(py: Python, m: &PyModule) -> PyResult<()> {
     #[cfg(feature = "parquet")]
     m.add_wrapped(wrap_pyfunction!(functions::read_parquet_schema))
         .unwrap();
+    #[cfg(feature = "clipboard")]
+    m.add_wrapped(wrap_pyfunction!(functions::read_clipboard_string))
+        .unwrap();
+    #[cfg(feature = "clipboard")]
+    m.add_wrapped(wrap_pyfunction!(functions::write_clipboard_string))
+        .unwrap();
 
     // Functions - meta
     m.add_wrapped(wrap_pyfunction!(functions::get_index_type))


### PR DESCRIPTION
Closes #9902

Similar to [`pandas.DataFrame.to_clipboard`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.to_clipboard.html#pandas.DataFrame.to_clipboard) and [`pandas.read_clipboard`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_clipboard.html), `read_clipboard` reads csv format text from clipboard and convert it into `DataFrame` whereas `DataFrame.write_clipboard` writes `DataFrame` into clipboard with csv format. 

These 2 methods are useful while exploring data from Excel or other similar software in interactive environment like jupyter notebook. 

# Implementation

- Reading and writing clipboard uses [arboard](https://github.com/1Password/arboard) in rust side, supporting Windows, macOS and Linux, maintained by 1Password. 
- `read_clipboard` just reads the clipboard then passes the result to `read_csv` with default separator `'\t'`.
- `write_clipboard` just gets csv string by calling `DataFrame.write_csv` (but with default separator `'\t'`) and writes to clipboard. 

# Difference from `pandas` method

`pandas.read_clipboard` uses regex `'\\s+'` as separator, but `polars` does not allow regex as separator in `read_csv`. 

# Compatibility

Tested Compatible: 
- Microsoft Excel (Mac)
- Google Sheet (Online)
- WPS (Online)

# Others

Both methods are only tested on M1 macOS. It would be much appreciated if someone could test on Linux and Windows. 