### PR TITLE
refactor(rust!): Refactor AnyValue supertype logic

### DIFF
--- a/crates/polars-core/src/frame/row/mod.rs
+++ b/crates/polars-core/src/frame/row/mod.rs
@@ -99,9 +99,10 @@ pub fn rows_to_schema_supertypes(
     rows: &[Row],
     infer_schema_length: Option<usize>,
 ) -> PolarsResult<Schema> {
+    polars_ensure!(!rows.is_empty(), NoData: "no rows, cannot infer schema");
+
     // no of rows to use to infer dtype
     let max_infer = infer_schema_length.unwrap_or(rows.len());
-    polars_ensure!(!rows.is_empty(), NoData: "no rows, cannot infer schema");
     let mut dtypes: Vec<PlIndexSet<DataType>> = vec![PlIndexSet::new(); rows[0].0.len()];
 
     for row in rows.iter().take(max_infer) {

--- a/crates/polars-core/src/frame/row/mod.rs
+++ b/crates/polars-core/src/frame/row/mod.rs
@@ -83,17 +83,6 @@ pub fn coerce_data_type<A: Borrow<DataType>>(datatypes: &[A]) -> DataType {
     try_get_supertype(lhs, rhs).unwrap_or(String)
 }
 
-pub fn any_values_to_dtype(column: &[AnyValue]) -> PolarsResult<(DataType, usize)> {
-    // we need an index-map as the order of dtypes influences how the
-    // struct fields are constructed.
-    let mut types_set = PlIndexSet::new();
-    for val in column.iter() {
-        types_set.insert(val.into());
-    }
-    let n_types = types_set.len();
-    Ok((types_set_to_dtype(types_set)?, n_types))
-}
-
 /// Infer schema from rows and set the supertypes of the columns as column data type.
 pub fn rows_to_schema_supertypes(
     rows: &[Row],

--- a/crates/polars-core/src/utils/any_value.rs
+++ b/crates/polars-core/src/utils/any_value.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::utils::try_get_supertype;
+use crate::utils::dtypes_to_supertype;
 
 /// Determine the supertype of a collection of [`AnyValue`].
 ///
@@ -8,18 +8,30 @@ pub fn any_values_to_supertype<'a, I>(values: I) -> PolarsResult<DataType>
 where
     I: IntoIterator<Item = &'a AnyValue<'a>>,
 {
-    let mut supertype = DataType::Null;
-    let mut dtypes = PlHashSet::<DataType>::new();
-    for av in values {
-        if dtypes.insert(av.dtype()) {
-            supertype = try_get_supertype(&supertype, &av.dtype()).map_err(|_| {
-                polars_err!(
-                    SchemaMismatch:
-                    "failed to infer supertype of values; partial supertype is {:?}, found value of type {:?}: {}",
-                    supertype, av.dtype(), av
-                )
-            })?;
-        }
-    }
-    Ok(supertype)
+    let dtypes = any_values_to_dtype_set(values);
+    dtypes_to_supertype(&dtypes)
+}
+
+/// Determine the supertype and the number of unique data types of a collection of [`AnyValue`].
+///
+/// [`AnyValue`]: crate::datatypes::AnyValue
+pub fn any_values_to_supertype_and_n_dtypes<'a, I>(values: I) -> PolarsResult<(DataType, usize)>
+where
+    I: IntoIterator<Item = &'a AnyValue<'a>>,
+{
+    let dtypes = any_values_to_dtype_set(values);
+    let supertype = dtypes_to_supertype(&dtypes)?;
+    let n_dtypes = dtypes.len();
+    Ok((supertype, n_dtypes))
+}
+
+/// Extract the ordered set of data types from a collection of AnyValues
+///
+/// Retaining the order is important if the set is used to determine a supertype,
+/// as this can influence how Struct fields are constructed.
+fn any_values_to_dtype_set<'a, I>(values: I) -> PlIndexSet<DataType>
+where
+    I: IntoIterator<Item = &'a AnyValue<'a>>,
+{
+    values.into_iter().map(|av| av.into()).collect()
 }

--- a/crates/polars-core/src/utils/any_value.rs
+++ b/crates/polars-core/src/utils/any_value.rs
@@ -1,0 +1,25 @@
+use crate::prelude::*;
+use crate::utils::try_get_supertype;
+
+/// Determine the supertype of a collection of [`AnyValue`].
+///
+/// [`AnyValue`]: crate::datatypes::AnyValue
+pub fn any_values_to_supertype<'a, I>(values: I) -> PolarsResult<DataType>
+where
+    I: IntoIterator<Item = &'a AnyValue<'a>>,
+{
+    let mut supertype = DataType::Null;
+    let mut dtypes = PlHashSet::<DataType>::new();
+    for av in values {
+        if dtypes.insert(av.dtype()) {
+            supertype = try_get_supertype(&supertype, &av.dtype()).map_err(|_| {
+                polars_err!(
+                    SchemaMismatch:
+                    "failed to infer supertype of values; partial supertype is {:?}, found value of type {:?}: {}",
+                    supertype, av.dtype(), av
+                )
+            })?;
+        }
+    }
+    Ok(supertype)
+}

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -1,9 +1,11 @@
+mod any_value;
 pub mod flatten;
 pub(crate) mod series;
 mod supertype;
 use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
 
+pub use any_value::*;
 use arrow::bitmap::bitmask::BitMask;
 use arrow::bitmap::Bitmap;
 pub use arrow::legacy::utils::*;


### PR DESCRIPTION
#### Changes

* Rename existing public util `any_values_to_dtype` to `any_values_to_supertype_and_n_dtypes` and move it to the `polars_core::utils` module. _(this is the breaking part)_
* Add two public utils based on existing functionality:
  * `dtypes_to_supertype` for inferring the supertype of multiple dtypes
  * `any_values_to_supertype` for inferring the supertype of a collection of AnyValues