### PR TITLE
docs(python): Add security warning in LazyFrame.deserialize() docstring

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -349,7 +349,7 @@ class Expr:
             This function uses :mod:`pickle` under some circumstances, and as
             such inherits the security implications. Deserializing can execute
             arbitrary code so it should only be attempted on trusted data.
-            Currently, pickle will be used when serializing UDF.
+            pickle is only used when the logical plan contains python UDFs.
 
         See Also
         --------

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -344,6 +344,13 @@ class Expr:
             objects that have a `read()` method, such as a file handler (e.g.
             via builtin `open` function) or `BytesIO`).
 
+        Warnings
+        --------
+            This function uses :mod:`pickle` under some circumstances, and as
+            such inherits the security implications. Deserializing can execute
+            arbitrary code so it should only be attempted on trusted data.
+            Currently, pickle will be used when serializing UDF.
+
         See Also
         --------
         Expr.meta.serialize

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -622,7 +622,7 @@ class LazyFrame:
             This function uses :mod:`pickle` under some circumstances, and as
             such inherits the security implications. Deserializing can execute
             arbitrary code so it should only be attempted on trusted data.
-            Currently, pickle will be used when serializing UDF.
+            pickle is only used when the logical plan contains python UDFs.
 
 
         See Also

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -617,6 +617,14 @@ class LazyFrame:
             objects that have a `read()` method, such as a file handler (e.g.
             via builtin `open` function) or `BytesIO`).
 
+        Warnings
+        --------
+            This function uses :mod:`pickle` under some circumstances, and as
+            such inherits the security implications. Deserializing can execute
+            arbitrary code so it should only be attempted on trusted data.
+            Currently, pickle will be used when serializing UDF.
+
+
         See Also
         --------
         LazyFrame.serialize


### PR DESCRIPTION
Add indication that LazyFrame.deserialize() might execute arbitrary code coming from the deserialized data.

Fixes #14623