### PR TITLE
fix(python,rust!): Raise error when `schema_overrides` contains nonexistent column name

### DIFF
--- a/crates/polars-core/src/frame/row/dataframe.rs
+++ b/crates/polars-core/src/frame/row/dataframe.rs
@@ -37,14 +37,18 @@ impl DataFrame {
             });
     }
 
-    /// Create a new [`DataFrame`] from rows. This should only be used when you have row wise data,
-    /// as this is a lot slower than creating the [`Series`] in a columnar fashion
+    /// Create a new [`DataFrame`] from rows.
+    ///
+    /// This should only be used when you have row wise data, as this is a lot slower
+    /// than creating the [`Series`] in a columnar fashion
     pub fn from_rows_and_schema(rows: &[Row], schema: &Schema) -> PolarsResult<Self> {
         Self::from_rows_iter_and_schema(rows.iter(), schema)
     }
 
-    /// Create a new [`DataFrame`] from an iterator over rows. This should only be used when you have row wise data,
-    /// as this is a lot slower than creating the [`Series`] in a columnar fashion
+    /// Create a new [`DataFrame`] from an iterator over rows.
+    ///
+    /// This should only be used when you have row wise data, as this is a lot slower
+    /// than creating the [`Series`] in a columnar fashion.
     pub fn from_rows_iter_and_schema<'a, I>(mut rows: I, schema: &Schema) -> PolarsResult<Self>
     where
         I: Iterator<Item = &'a Row<'a>>,

--- a/crates/polars-core/src/frame/row/dataframe.rs
+++ b/crates/polars-core/src/frame/row/dataframe.rs
@@ -134,7 +134,7 @@ impl DataFrame {
     /// Create a new [`DataFrame`] from rows. This should only be used when you have row wise data,
     /// as this is a lot slower than creating the [`Series`] in a columnar fashion
     pub fn from_rows(rows: &[Row]) -> PolarsResult<Self> {
-        let schema = rows_to_schema_first_non_null(rows, Some(50));
+        let schema = rows_to_schema_first_non_null(rows, Some(50))?;
         let has_nulls = schema
             .iter_dtypes()
             .any(|dtype| matches!(dtype, DataType::Null));

--- a/crates/polars-core/src/frame/row/mod.rs
+++ b/crates/polars-core/src/frame/row/mod.rs
@@ -107,7 +107,12 @@ pub fn rows_to_schema_supertypes(
 }
 
 /// Infer schema from rows and set the first no null type as column data type.
-pub fn rows_to_schema_first_non_null(rows: &[Row], infer_schema_length: Option<usize>) -> Schema {
+pub fn rows_to_schema_first_non_null(
+    rows: &[Row],
+    infer_schema_length: Option<usize>,
+) -> PolarsResult<Schema> {
+    polars_ensure!(!rows.is_empty(), NoData: "no rows, cannot infer schema");
+
     let max_infer = infer_schema_length.unwrap_or(rows.len());
     let mut schema: Schema = (&rows[0]).into();
 
@@ -143,7 +148,7 @@ pub fn rows_to_schema_first_non_null(rows: &[Row], infer_schema_length: Option<u
             }
         }
     }
-    schema
+    Ok(schema)
 }
 
 impl<'a> From<&AnyValue<'a>> for Field {

--- a/crates/polars-core/src/utils/mod.rs
+++ b/crates/polars-core/src/utils/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod series;
 mod supertype;
 use std::borrow::Cow;
 use std::ops::{Deref, DerefMut};
+mod schema;
 
 pub use any_value::*;
 use arrow::bitmap::bitmask::BitMask;
@@ -13,6 +14,7 @@ pub use arrow::trusted_len::TrustMyLength;
 use flatten::*;
 use num_traits::{One, Zero};
 use rayon::prelude::*;
+pub use schema::*;
 pub use series::*;
 use smartstring::alias::String as SmartString;
 pub use supertype::*;

--- a/crates/polars-core/src/utils/schema.rs
+++ b/crates/polars-core/src/utils/schema.rs
@@ -1,0 +1,17 @@
+use crate::prelude::*;
+
+/// Convert a collection of [`DataType`] into a schema.
+///
+/// Field names are set as `column_0`, `column_1`, and so on.
+///
+/// [`DataType`]: crate::datatypes::DataType
+pub fn dtypes_to_schema<I>(dtypes: I) -> Schema
+where
+    I: IntoIterator<Item = DataType>,
+{
+    dtypes
+        .into_iter()
+        .enumerate()
+        .map(|(i, dtype)| Field::new(format!("column_{i}").as_ref(), dtype))
+        .collect()
+}

--- a/py-polars/polars/_utils/construction/dataframe.py
+++ b/py-polars/polars/_utils/construction/dataframe.py
@@ -560,8 +560,8 @@ def _sequence_of_sequence_to_pydf(
         else:
             pydf = PyDataFrame.from_rows(
                 data,
-                local_schema_override or None,
-                infer_schema_length,
+                schema=local_schema_override or None,
+                infer_schema_length=infer_schema_length,
             )
         if column_names or schema_overrides:
             pydf = _post_apply_columns(
@@ -777,7 +777,9 @@ def _sequence_of_dataclasses_to_pydf(
         pydf = PyDataFrame.from_dicts(dicts, infer_schema_length=infer_schema_length)
     else:
         rows = [astuple(dc) for dc in data]
-        pydf = PyDataFrame.from_rows(rows, overrides or None, infer_schema_length)
+        pydf = PyDataFrame.from_rows(
+            rows, schema=overrides or None, infer_schema_length=infer_schema_length
+        )
 
     if overrides:
         structs = {c: tp for c, tp in overrides.items() if isinstance(tp, Struct)}
@@ -827,7 +829,9 @@ def _sequence_of_pydantic_models_to_pydf(
         # 'from_rows' is the faster codepath for models with a lot of fields...
         get_values = itemgetter(*model_fields)
         rows = [get_values(md.__dict__) for md in data]
-        pydf = PyDataFrame.from_rows(rows, overrides, infer_schema_length)
+        pydf = PyDataFrame.from_rows(
+            rows, schema=overrides, infer_schema_length=infer_schema_length
+        )
     else:
         # ...and 'from_dicts' is faster otherwise
         dicts = [md.__dict__ for md in data]

--- a/py-polars/src/dataframe/construction.rs
+++ b/py-polars/src/dataframe/construction.rs
@@ -14,10 +14,9 @@ impl PyDataFrame {
         schema: Option<Wrap<Schema>>,
         infer_schema_length: Option<usize>,
     ) -> PyResult<Self> {
-        let rows = vec_extract_wrapped(data);
-        py.allow_threads(move || {
-            finish_from_rows(rows, schema.map(|wrap| wrap.0), None, infer_schema_length)
-        })
+        let data = vec_extract_wrapped(data);
+        let schema = schema.map(|wrap| wrap.0);
+        py.allow_threads(move || finish_from_rows(data, schema, None, infer_schema_length))
     }
 
     #[staticmethod]

--- a/py-polars/src/dataframe/construction.rs
+++ b/py-polars/src/dataframe/construction.rs
@@ -63,13 +63,18 @@ fn finish_from_rows(
     schema_overrides: Option<Schema>,
     infer_schema_length: Option<usize>,
 ) -> PyResult<PyDataFrame> {
-    let schema = if let Some(mut schema) = schema {
+    let mut schema = if let Some(mut schema) = schema {
         resolve_schema_overrides(&mut schema, schema_overrides)?;
         update_schema_from_rows(&mut schema, &rows, infer_schema_length)?;
         schema
     } else {
         rows_to_schema_supertypes(&rows, infer_schema_length).map_err(PyPolarsErr::from)?
     };
+
+    // TODO: Remove this step when Decimals are supported properly.
+    // Erasing the decimal precision/scale here will just require us to infer it again later.
+    // https://github.com/pola-rs/polars/issues/14427
+    erase_decimal_precision_scale(&mut schema);
 
     let df = DataFrame::from_rows_and_schema(&rows, &schema).map_err(PyPolarsErr::from)?;
     Ok(df.into())
@@ -112,6 +117,15 @@ fn resolve_schema_overrides(schema: &mut Schema, schema_overrides: Option<Schema
         }
     }
     Ok(())
+}
+
+/// Erase precision/scale information from Decimal types.
+fn erase_decimal_precision_scale(schema: &mut Schema) {
+    for dtype in schema.iter_dtypes_mut() {
+        if let DataType::Decimal(_, _) = dtype {
+            *dtype = DataType::Decimal(None, None)
+        }
+    }
 }
 
 fn columns_names_to_empty_schema<'a, I>(column_names: I) -> Schema

--- a/py-polars/src/map/dataframe.rs
+++ b/py-polars/src/map/dataframe.rs
@@ -289,7 +289,7 @@ pub fn apply_lambda_with_rows_output<'a>(
         buf.push(v?.clone());
     }
 
-    let schema = rows_to_schema_first_non_null(&buf, Some(50));
+    let schema = rows_to_schema_first_non_null(&buf, Some(50))?;
 
     if init_null_count > 0 {
         // SAFETY: we know the iterators size

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -121,3 +121,8 @@ def test_df_init_from_series_strict() -> None:
 
     assert df["a"].to_list() == [None, 0, 1]
     assert df["a"].dtype == pl.UInt8
+
+
+def test_df_init_rows_overrides_non_existing() -> None:
+    with pytest.raises(pl.SchemaError, match="nonexistent column"):
+        pl.DataFrame([{"a": 1, "b": 2}], schema_overrides={"c": pl.Int8})


### PR DESCRIPTION
#### Changes

This is mostly a refactor, but I encountered some things I could improve:

* fix: When constructing from rows, raise `SchemaError` when `schema_overrides` contains nonexistent column name
* perf: When constructing from rows, skip schema inference if the schema is fully specified.
* feat: Add `dtypes_to_schema` util that instantiates a schema with column names `column_0`, `column_1`, etc. _(perhaps this should be implemented as a trait?)_