### PR TITLE
fix(python): Handle special case correctly when slicing a `LazyFrame`

### DIFF
--- a/py-polars/polars/slice.py
+++ b/py-polars/polars/slice.py
@@ -158,7 +158,7 @@ class LazyPolarsSlice:
         # [::k]  => gather_every(k),
         # [::-1] => reverse(),
         # [::-k] => reverse().gather_every(abs(k))
-        elif start == 0 and s.stop is None:
+        elif s.start is None and s.stop is None:
             if step == 1:
                 return self.obj.clone()
             elif step > 1:
@@ -168,7 +168,13 @@ class LazyPolarsSlice:
             elif step < -1:
                 return self.obj.reverse().gather_every(abs(step))
 
-        elif start > 0 > step and s.stop is None:
+        # ---------------------------------------
+        # straight-through mappings for "head",
+        # "reverse" and "gather_every"
+        # ---------------------------------------
+        # [i::-1]      => head(i+1).reverse()
+        # [i::k], k<-1 => head(i+1).reverse().gather_every(abs(k))
+        elif start >= 0 > step and s.stop is None:
             obj = self.obj.head(s.start + 1).reverse()
             return obj if (abs(step) == 1) else obj.gather_every(abs(step))
 

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -88,6 +88,7 @@ def test_python_slicing_lazy_frame() -> None:
         slice(None, 2, 2),
         slice(3, None, -1),
         slice(1, None, -2),
+        slice(0, None, -1),
     ):
         # confirm frame slice matches python slice
         assert ldf[py_slice].collect().rows() == ldf.collect().rows()[py_slice]

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -92,6 +92,8 @@ def test_python_slicing_lazy_frame() -> None:
         # confirm frame slice matches python slice
         assert ldf[py_slice].collect().rows() == ldf.collect().rows()[py_slice]
 
+    assert_frame_equal(ldf[0::-1], ldf.head(1))
+    assert_frame_equal(ldf[2::-1], ldf.head(3).reverse())
     assert_frame_equal(ldf[::-1], ldf.reverse())
     assert_frame_equal(ldf[::-2], ldf.reverse().gather_every(2))
 


### PR DESCRIPTION
When sliced with the object `slice(0, None, -1)`, `LazyFrame` returns incorrect result. 

Fixes #15295 