### PR TITLE
test(python): Reorganize tests for `clear` operation

### DIFF
--- a/py-polars/tests/unit/constructors/test_constructors.py
+++ b/py-polars/tests/unit/constructors/test_constructors.py
@@ -167,10 +167,6 @@ def test_init_dict() -> None:
     )
     assert df.schema == {"c": pl.Int8, "d": pl.Int16}
 
-    dfe = df.clear()
-    assert df.schema == dfe.schema
-    assert len(dfe) == 0
-
     # empty nested objects
     for empty_val in [None, "", {}, []]:  # type: ignore[var-annotated]
         test = [{"field": {"sub_field": empty_val, "sub_field_2": 2}}]

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1701,18 +1701,6 @@ def test_df_schema_unique() -> None:
         df.rename({"b": "a"})
 
 
-def test_cleared() -> None:
-    df = pl.DataFrame(
-        {"a": [1, 2], "b": [True, False]}, schema_overrides={"a": pl.UInt32}
-    )
-    dfc = df.clear()
-    assert dfc.schema == df.schema
-    assert dfc.rows() == []
-
-    dfc = df.clear(3)
-    assert dfc.schema == df.schema
-    assert dfc.rows() == [(None, None), (None, None), (None, None)]
-
 
 def test_empty_projection() -> None:
     empty_df = pl.DataFrame({"a": [1, 2], "b": [3, 4]}).select([])

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1701,7 +1701,6 @@ def test_df_schema_unique() -> None:
         df.rename({"b": "a"})
 
 
-
 def test_empty_projection() -> None:
     empty_df = pl.DataFrame({"a": [1, 2], "b": [3, 4]}).select([])
     assert empty_df.rows() == []

--- a/py-polars/tests/unit/operations/test_clear.py
+++ b/py-polars/tests/unit/operations/test_clear.py
@@ -1,0 +1,43 @@
+import pytest
+
+import polars as pl
+
+
+@pytest.mark.parametrize("n", [0, 2, 5])
+def test_clear_series(n: int) -> None:
+    a = pl.Series(name="a", values=[1, 2, 3], dtype=pl.Int16)
+
+    result = a.clear(n)
+    assert result.dtype == a.dtype
+    assert result.name == a.name
+    assert len(result) == n
+
+
+def test_clear_df() -> None:
+    df = pl.DataFrame(
+        {"a": [1, 2], "b": [True, False]}, schema={"a": pl.UInt32, "b": pl.Boolean}
+    )
+
+    result = df.clear()
+    assert result.schema == df.schema
+    assert result.rows() == []
+
+    result = df.clear(3)
+    assert result.schema == df.schema
+    assert result.rows() == [(None, None), (None, None), (None, None)]
+
+
+def test_clear_lf() -> None:
+    lf = pl.LazyFrame(
+        {
+            "foo": [1, 2, 3],
+            "bar": [6.0, 7.0, 8.0],
+            "ham": ["a", "b", "c"],
+        }
+    )
+    ldfe = lf.clear()
+    assert ldfe.schema == lf.schema
+
+    ldfe = lf.clear(2)
+    assert ldfe.schema == lf.schema
+    assert ldfe.collect().rows() == [(None, None, None), (None, None, None)]

--- a/py-polars/tests/unit/series/test_series.py
+++ b/py-polars/tests/unit/series/test_series.py
@@ -1089,15 +1089,8 @@ def test_empty() -> None:
         pl.Series(dtype=pl.Int32), pl.Series(dtype=pl.Int64), check_dtype=False
     )
 
-    a = pl.Series(name="a", values=[1, 2, 3], dtype=pl.Int16)
-    for n in (0, 2, 5):
-        empty_a = a.clear(n)
-        assert a.dtype == empty_a.dtype
-        assert a.name == empty_a.name
-        assert len(empty_a) == n
-
     with pytest.raises(TypeError, match="ambiguous"):
-        not empty_a
+        not pl.Series()
 
 
 def test_round() -> None:

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1110,30 +1110,17 @@ def test_quantile_filtered_agg() -> None:
 
 
 def test_lazy_schema() -> None:
-    ldf = pl.LazyFrame(
+    lf = pl.LazyFrame(
         {
             "foo": [1, 2, 3],
             "bar": [6.0, 7.0, 8.0],
             "ham": ["a", "b", "c"],
         }
     )
-    assert ldf.schema == {"foo": pl.Int64, "bar": pl.Float64, "ham": pl.String}
+    assert lf.schema == {"foo": pl.Int64, "bar": pl.Float64, "ham": pl.String}
 
-    ldf = pl.LazyFrame(
-        {
-            "foo": [1, 2, 3],
-            "bar": [6.0, 7.0, 8.0],
-            "ham": ["a", "b", "c"],
-        }
-    )
-    assert ldf.dtypes == [pl.Int64, pl.Float64, pl.String]
+    assert lf.dtypes == [pl.Int64, pl.Float64, pl.String]
 
-    ldfe = ldf.clear()
-    assert ldfe.schema == ldf.schema
-
-    ldfe = ldf.clear(2)
-    assert ldfe.schema == ldf.schema
-    assert ldfe.collect().rows() == [(None, None, None), (None, None, None)]
 
 
 def test_predicate_count_vstack() -> None:

--- a/py-polars/tests/unit/test_lazy.py
+++ b/py-polars/tests/unit/test_lazy.py
@@ -1122,7 +1122,6 @@ def test_lazy_schema() -> None:
     assert lf.dtypes == [pl.Int64, pl.Float64, pl.String]
 
 
-
 def test_predicate_count_vstack() -> None:
     l1 = pl.LazyFrame(
         {


### PR DESCRIPTION
Ref #15303

Added a test for #15303 and skipped it for now, as I didn't see an immediate solution to efficiently get the first non-null AnyValue value out of an Object Series.