### PR TITLE
fix: Pass schema as schema into CsvReader (#15254)

### DIFF
--- a/crates/polars-lazy/src/physical_plan/executors/scan/csv.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/scan/csv.rs
@@ -26,7 +26,7 @@ impl CsvExec {
         CsvReader::from_path(&self.path)
             .unwrap()
             .has_header(self.options.has_header)
-            .with_dtypes(Some(self.schema.clone()))
+            .with_schema(Some(self.schema.clone()))
             .with_separator(self.options.separator)
             .with_ignore_errors(self.options.ignore_errors)
             .with_skip_rows(self.options.skip_rows)

--- a/crates/polars-plan/src/logical_plan/builder_dsl.rs
+++ b/crates/polars-plan/src/logical_plan/builder_dsl.rs
@@ -277,7 +277,7 @@ impl DslBuilder {
         mut skip_rows: usize,
         n_rows: Option<usize>,
         cache: bool,
-        mut schema: Option<Arc<Schema>>,
+        schema: Option<Arc<Schema>>,
         schema_overwrite: Option<&Schema>,
         low_memory: bool,
         comment_prefix: Option<CommentPrefix>,
@@ -317,7 +317,7 @@ impl DslBuilder {
 
         // TODO! delay inferring schema until absolutely necessary
         // this needs a way to estimated bytes/rows.
-        let (mut inferred_schema, rows_read, bytes_read) = infer_file_schema(
+        let (inferred_schema, rows_read, bytes_read) = infer_file_schema(
             &reader_bytes,
             separator,
             infer_schema_length,
@@ -333,21 +333,6 @@ impl DslBuilder {
             raise_if_empty,
             &mut n_threads,
         )?;
-
-        if let Some(rc) = &row_index {
-            match schema {
-                None => {
-                    let _ = inferred_schema.insert_at_index(0, rc.name.as_str().into(), IDX_DTYPE);
-                },
-                Some(inner) => {
-                    schema = Some(Arc::new(
-                        inner
-                            .new_inserting_at_index(0, rc.name.as_str().into(), IDX_DTYPE)
-                            .unwrap(),
-                    ));
-                },
-            }
-        }
 
         let schema = schema.unwrap_or_else(|| Arc::new(inferred_schema));
         let n_bytes = reader_bytes.len();


### PR DESCRIPTION
When passed in as dtypes, the schema inference is not skipped. That has the side effect that only the first `n` columns from the passed-in schema are eventually used (see the `infer_file_schema_inner` method in the `polars-io/src/csv/utils.rs` file).

With the change `scan_csv` behaves the same as `read_csv` when used with a schema having more columns that the file header:

```python
with tempfile.NamedTemporaryFile() as f:
    f.write(b"""
 A,B,C
 1,2,3
 4,5,6,7,8
 9,10,11
 """.strip())
    f.seek(0)
    df = pl.read_csv(f.name, schema=dict.fromkeys("ABCDE", pl.String), truncate_ragged_lines=True)
    print(df)
    lf = pl.scan_csv(f.name, schema=dict.fromkeys("ABCDE", pl.String), truncate_ragged_lines=True).collect()
    print(lf)
...
>>> check()
shape: (3, 5)
┌─────┬─────┬─────┬──────┬──────┐
│ A   ┆ B   ┆ C   ┆ D    ┆ E    │
│ --- ┆ --- ┆ --- ┆ ---  ┆ ---  │
│ str ┆ str ┆ str ┆ str  ┆ str  │
╞═════╪═════╪═════╪══════╪══════╡
│ 1   ┆ 2   ┆ 3   ┆ null ┆ null │
│ 4   ┆ 5   ┆ 6   ┆ 7    ┆ 8    │
│ 9   ┆ 10  ┆ 11  ┆ null ┆ null │
└─────┴─────┴─────┴──────┴──────┘
shape: (3, 5)
┌─────┬─────┬─────┬──────┬──────┐
│ A   ┆ B   ┆ C   ┆ D    ┆ E    │
│ --- ┆ --- ┆ --- ┆ ---  ┆ ---  │
│ str ┆ str ┆ str ┆ str  ┆ str  │
╞═════╪═════╪═════╪══════╪══════╡
│ 1   ┆ 2   ┆ 3   ┆ null ┆ null │
│ 4   ┆ 5   ┆ 6   ┆ 7    ┆ 8    │
│ 9   ┆ 10  ┆ 11  ┆ null ┆ null │
└─────┴─────┴─────┴──────┴──────┘
```