### PR TITLE
fix: Handle strictness for Decimal Series construction

### DIFF
--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -136,7 +136,7 @@ impl Series {
             },
             #[cfg(feature = "dtype-decimal")]
             DataType::Decimal(precision, scale) => {
-                any_values_to_decimal(values, *precision, *scale)?.into_series()
+                any_values_to_decimal(values, *precision, *scale, strict)?.into_series()
             },
             DataType::List(inner) => any_values_to_list(values, inner, strict)?.into_series(),
             #[cfg(feature = "dtype-array")]
@@ -443,64 +443,53 @@ fn any_values_to_decimal(
     values: &[AnyValue],
     precision: Option<usize>,
     scale: Option<usize>, // If None, we're inferring the scale.
+    strict: bool,
 ) -> PolarsResult<DecimalChunked> {
-    // Two-pass approach, first we scan and record the scales, then convert (or not).
-    let mut scale_range: Option<(usize, usize)> = None;
-    for av in values {
-        let s_av = if av.is_integer() {
-            0 // Integers are treated as decimals with scale of zero.
-        } else if let AnyValue::Decimal(_, scale) = av {
-            *scale
-        } else if av.is_null() {
-            continue;
-        } else {
-            polars_bail!(
-                SchemaMismatch: "unable to convert any-value of dtype {} to decimal", av.dtype(),
-            );
-        };
-        scale_range = match scale_range {
-            None => Some((s_av, s_av)),
-            Some((s_min, s_max)) => Some((s_min.min(s_av), s_max.max(s_av))),
-        };
+    /// Get the maximum scale among AnyValues
+    fn infer_scale(
+        values: &[AnyValue],
+        precision: Option<usize>,
+        strict: bool,
+    ) -> PolarsResult<usize> {
+        let mut max_scale = 0;
+        for av in values {
+            let av_scale = match av {
+                AnyValue::Decimal(_, scale) => *scale,
+                AnyValue::Null => continue,
+                av => {
+                    if strict {
+                        let target_dtype = DataType::Decimal(precision, None);
+                        return Err(invalid_value_error(&target_dtype, av));
+                    }
+                    continue;
+                },
+            };
+            max_scale = max_scale.max(av_scale);
+        }
+        Ok(max_scale)
     }
-    let Some((s_min, s_max)) = scale_range else {
-        // Empty array or all nulls, return a decimal array with given scale (or 0 if inferring).
-        return Ok(Int128Chunked::full_null("", values.len())
-            .into_decimal_unchecked(precision, scale.unwrap_or(0)));
+    let scale = match scale {
+        Some(s) => s,
+        None => infer_scale(values, precision, strict)?,
     };
-    let scale = scale.unwrap_or(s_max);
-    if s_max > scale {
-        // Scale is provided but is lower than actual.
-        // TODO: Do we want lossy conversions here or not?
-        polars_bail!(
-            SchemaMismatch:
-            "unable to losslessly convert any-value of scale {s_max} to scale {}", scale,
-        );
-    }
+    let target_dtype = DataType::Decimal(precision, Some(scale));
 
     let mut builder = PrimitiveChunkedBuilder::<Int128Type>::new("", values.len());
-    let is_equally_scaled = s_min == s_max && s_max == scale;
     for av in values {
-        let (v, s_av) = if av.is_integer() {
-            (
-                av.try_extract::<i128>().unwrap_or_else(|_| unreachable!()),
-                0,
-            )
-        } else if let AnyValue::Decimal(v, scale) = av {
-            (*v, *scale)
-        } else {
-            // It has to be a null because we've already checked it.
-            builder.append_null();
-            continue;
+        match av {
+            AnyValue::Decimal(v, s) if *s == scale => builder.append_value(*v),
+            AnyValue::Null => builder.append_null(),
+            av => {
+                if strict {
+                    return Err(invalid_value_error(&target_dtype, av));
+                }
+                // TODO: Precision check, else set to null
+                match av.strict_cast(&target_dtype) {
+                    Some(AnyValue::Decimal(i, _)) => builder.append_value(i),
+                    _ => builder.append_null(),
+                }
+            },
         };
-        if is_equally_scaled {
-            builder.append_value(v);
-        } else {
-            let factor = 10_i128.pow((scale - s_av) as _); // this cast is safe
-            builder.append_value(v.checked_mul(factor).ok_or_else(|| {
-                polars_err!(SchemaMismatch: "overflow while converting to decimal scale {}", scale)
-            })?);
-        }
     }
 
     // Build the array and do a precision check if needed.

--- a/py-polars/polars/config.py
+++ b/py-polars/polars/config.py
@@ -1232,7 +1232,7 @@ class Config(contextlib.ContextDecorator):
         --------
         >>> from decimal import Decimal as D
         >>> df = pl.DataFrame(
-        ...     data={"d": [D("1.01"), D("-5.6789")]},
+        ...     data={"d": [D("1.01000"), D("-5.67890")]},
         ...     schema={"d": pl.Decimal(scale=5)},
         ... )
         >>> with pl.Config(trim_decimal_zeros=False):

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -961,8 +961,12 @@ class Series:
             else:
                 return self._from_pyseries(getattr(self._s, op_s)(_s))
 
-        if isinstance(other, (PyDecimal, int)) and self.dtype.is_decimal():
-            _s = sequence_to_pyseries(self.name, [other], dtype=Decimal)
+        if self.dtype.is_decimal() and isinstance(other, (PyDecimal, int)):
+            if isinstance(other, int):
+                pyseries = sequence_to_pyseries(self.name, [other])
+                _s = self._from_pyseries(pyseries).cast(Decimal(scale=0))._s
+            else:
+                _s = sequence_to_pyseries(self.name, [other], dtype=Decimal)
 
             if "rhs" in op_ffi:
                 return self._from_pyseries(getattr(_s, op_s)(self._s))

--- a/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
+++ b/py-polars/tests/unit/constructors/test_any_value_fallbacks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, time, timedelta
+from decimal import Decimal as D
 from typing import Any
 
 import pytest
@@ -26,6 +27,7 @@ from polars.polars import PySeries
         (pl.Duration, [timedelta(hours=0), timedelta(seconds=100), None]),
         (pl.Categorical, ["a", "b", "a", None]),
         (pl.Enum(["a", "b"]), ["a", "b", "a", None]),
+        (pl.Decimal(10, 3), [D("12.345"), D("0.789"), None]),
         (
             pl.Struct({"a": pl.Int8, "b": pl.String}),
             [{"a": 1, "b": "foo"}, {"a": -1, "b": "bar"}],
@@ -60,6 +62,8 @@ def test_fallback_with_dtype_strict(
         (pl.Duration("ns"), [timedelta(hours=0), timedelta(seconds=100)]),
         (pl.Categorical, [0, 1, 0]),
         (pl.Enum(["a", "b"]), [0, 1, 0]),
+        (pl.Decimal(10, 3), [100, 200]),
+        (pl.Decimal(5, 3), [D("1.2345")]),
         (
             pl.Struct({"a": pl.Int8, "b": pl.String}),
             [{"a": 1, "b": "foo"}, {"a": 2.0, "b": "bar"}],
@@ -200,6 +204,37 @@ def test_fallback_with_dtype_strict_failure(
             ["a", "b", None, None, None, None],
         ),
         (
+            pl.Decimal(5, 3),
+            [
+                D("12"),
+                D("1.2345"),
+                # D("123456"),
+                False,
+                True,
+                0,
+                -1,
+                0.0,
+                2.5,
+                date(1970, 1, 2),
+                "5",
+                "xyz",
+            ],
+            [
+                D("12.000"),
+                None,
+                # None,
+                None,
+                None,
+                D("0.000"),
+                D("-1.000"),
+                None,
+                None,
+                None,
+                None,
+                None,
+            ],
+        ),
+        (
             pl.Struct({"a": pl.Int8, "b": pl.String}),
             [{"a": 1, "b": "foo"}, {"a": 1_000, "b": 2.0}],
             [{"a": 1, "b": "foo"}, {"a": None, "b": "2.0"}],
@@ -230,6 +265,8 @@ def test_fallback_with_dtype_nonstrict(
             [datetime(1970, 1, 1), datetime(2020, 12, 31, 23, 59, 59), None],
         ),
         (pl.Duration("us"), [timedelta(hours=0), timedelta(seconds=100), None]),
+        (pl.Decimal(None, 3), [D("12.345"), D("0.789"), None]),
+        (pl.Decimal(None, 0), [D("12"), D("56789"), None]),
         (
             pl.Struct({"a": pl.Int64, "b": pl.String, "c": pl.Float64}),
             [{"a": 1, "b": "foo", "c": None}, {"a": -1, "b": "bar", "c": 3.0}],
@@ -257,6 +294,9 @@ def test_fallback_without_dtype(
         [time(0, 0), 1_000],
         [datetime(1970, 1, 1), date(2020, 12, 31)],
         [timedelta(hours=0), 1_000],
+        [D("12.345"), 100],
+        [D("12.345"), 3.14],
+        [D("0.12345"), D("6789.0")],
         [{"a": 1, "b": "foo"}, {"a": -1, "b": date(2020, 12, 31)}],
         [{"a": None}, {"a": 1.0}, {"a": 1}],
     ],
@@ -277,6 +317,8 @@ def test_fallback_without_dtype_strict_failure(values: list[Any]) -> None:
             [datetime(1970, 1, 1), datetime(2022, 12, 31)],
             pl.Datetime("us"),
         ),
+        ([D("3.1415"), 2.51], [3.1415, 2.51], pl.Float64),
+        ([D("3.1415"), 100], [D("3.1415"), D("100")], pl.Decimal(None, 4)),
         ([1, 2.0, b"d", date(2022, 1, 1)], [1, 2.0, b"d", date(2022, 1, 1)], pl.Object),
         (
             [
@@ -336,4 +378,14 @@ def test_fallback_with_dtype_strict_failure_enum_casting() -> None:
     values = ["a", "b", "c", None]
 
     with pytest.raises(TypeError, match="conversion from `str` to `enum` failed"):
+        PySeries.new_from_any_values_and_dtype("", values, dtype, strict=True)
+
+
+def test_fallback_with_dtype_strict_failure_decimal_precision() -> None:
+    dtype = pl.Decimal(3, 0)
+    values = [D("12345")]
+
+    with pytest.raises(
+        TypeError, match="decimal precision 3 can't fit values with 5 digits"
+    ):
         PySeries.new_from_any_values_and_dtype("", values, dtype, strict=True)

--- a/py-polars/tests/unit/datatypes/test_decimal.py
+++ b/py-polars/tests/unit/datatypes/test_decimal.py
@@ -22,7 +22,7 @@ def permutations_int_dec_none() -> list[tuple[D | int | None, ...]]:
                 D("-0.01"),
                 D("1.2345678"),
                 D("500"),
-                -1,
+                # -1,  # TODO: Address in https://github.com/pola-rs/polars/issues/14427
                 None,
             ]
         )
@@ -35,7 +35,7 @@ def test_series_from_pydecimal_and_ints(
 ) -> None:
     # TODO: check what happens if there are strings, floats arrow scalars in the list
     for data in permutations_int_dec_none:
-        s = pl.Series("name", data)
+        s = pl.Series("name", data, strict=False)
         assert s.dtype == pl.Decimal(scale=7)  # inferred scale = 7, precision = None
         assert s.dtype.is_decimal()
         assert s.name == "name"
@@ -98,11 +98,15 @@ def test_decimal_format(input: str, trim_zeros: bool, expected: str) -> None:
 
 
 def test_init_decimal_dtype() -> None:
-    s = pl.Series("a", [D("-0.01"), D("1.2345678"), D("500")], dtype=pl.Decimal)
+    s = pl.Series(
+        "a", [D("-0.01"), D("1.2345678"), D("500")], dtype=pl.Decimal, strict=False
+    )
     assert s.dtype.is_numeric()
 
     df = pl.DataFrame(
-        {"a": [D("-0.01"), D("1.2345678"), D("500")]}, schema={"a": pl.Decimal}
+        {"a": [D("-0.01"), D("1.2345678"), D("500")]},
+        schema={"a": pl.Decimal},
+        strict=False,
     )
     assert df["a"].dtype.is_numeric()
 
@@ -133,7 +137,8 @@ def test_decimal_cast() -> None:
     df = pl.DataFrame(
         {
             "decimals": [D("2"), D("2"), D("-1.5")],
-        }
+        },
+        strict=False,
     )
 
     result = df.with_columns(pl.col("decimals").cast(pl.Float32).alias("b2"))
@@ -196,7 +201,7 @@ def test_read_csv_decimal(monkeypatch: Any) -> None:
 
 
 def test_decimal_eq_number() -> None:
-    a = pl.Series([D("1.5"), D("22.25"), D("10.0")], dtype=pl.Decimal)
+    a = pl.Series([D("1.5"), D("22.25"), D("10.0")], dtype=pl.Decimal, strict=False)
     assert_series_equal(a == 1, pl.Series([False, False, False]))
     assert_series_equal(a == 1.5, pl.Series([True, False, False]))
     assert_series_equal(a == D("1.5"), pl.Series([True, False, False]))
@@ -216,9 +221,13 @@ def test_decimal_compare(
     op: Callable[[pl.Series, pl.Series], pl.Series], expected: pl.Series
 ) -> None:
     s = pl.Series(
-        [None, D("1.2"), D("2.13"), D("4.99"), D("2.13"), D("1.2")], dtype=pl.Decimal
+        [None, D("1.2"), D("2.13"), D("4.99"), D("2.13"), D("1.2")],
+        dtype=pl.Decimal,
+        strict=False,
     )
-    s2 = pl.Series([None, D("1.200"), D("2.13"), D("4.99"), D("4.99"), D("2.13")])
+    s2 = pl.Series(
+        [None, D("1.200"), D("2.13"), D("4.99"), D("4.99"), D("2.13")], strict=False
+    )
 
     assert_series_equal(op(s, s2), expected)
 
@@ -228,7 +237,8 @@ def test_decimal_arithmetic() -> None:
         {
             "a": [D("0.1"), D("10.1"), D("100.01")],
             "b": [D("20.1"), D("10.19"), D("39.21")],
-        }
+        },
+        strict=False,
     )
     dt = pl.Decimal(20, 10)
 
@@ -290,7 +300,8 @@ def test_decimal_aggregations() -> None:
         {
             "g": [1, 1, 2, 2],
             "a": [D("0.1"), D("10.1"), D("100.01"), D("9000.12")],
-        }
+        },
+        strict=False,
     )
 
     assert df.group_by("g").agg("a").sort("g").to_dict(as_series=False) == {
@@ -393,8 +404,8 @@ def test_decimal_write_parquet_12375() -> None:
     df = pl.DataFrame(
         {
             "hi": [True, False, True, False],
-            "bye": [1, 2, 3, D(47283957238957239875)],
-        }
+            "bye": [D(1), D(2), D(3), D(47283957238957239875)],
+        },
     )
     assert df["bye"].dtype == pl.Decimal
 

--- a/py-polars/tests/unit/operations/test_cast.py
+++ b/py-polars/tests/unit/operations/test_cast.py
@@ -619,8 +619,8 @@ def test_cast_time_to_date() -> None:
         s.cast(pl.Date)
 
 
-def test_cast_decimal() -> None:
-    s = pl.Series("s", [Decimal(0), Decimal(1.5), Decimal(-1.5)])
+def test_cast_decimal_to_boolean() -> None:
+    s = pl.Series("s", [Decimal("0.0"), Decimal("1.5"), Decimal("-1.5")])
     assert_series_equal(s.cast(pl.Boolean), pl.Series("s", [False, True, True]))
 
     df = s.to_frame()

--- a/py-polars/tests/unit/test_format.py
+++ b/py-polars/tests/unit/test_format.py
@@ -348,7 +348,8 @@ def test_format_numeric_locale_options() -> None:
             "b": [100000.987654321, -234567.89],
             "c": [-11111111, 44444444444],
             "d": [D("12345.6789"), D("-9999999.99")],
-        }
+        },
+        strict=False,
     )
 
     # note: numeric digit grouping looks much better


### PR DESCRIPTION
Ref https://github.com/pola-rs/polars/issues/14427

#### Changes

* Implement casting for AnyValue to Decimal
* Update AnyValue constructors to properly apply the `strict` parameter. This means that the following will raise unless `strict=False` is set:
  * Mixing Decimals with non-decimals
  * Mixing Decimals with different scales
  * Decimals that do not match the given `dtype`