### PR TITLE
fix: ensure first datapoint is always included in group_by_dynamic

### DIFF
--- a/crates/polars-time/src/windows/bounds.rs
+++ b/crates/polars-time/src/windows/bounds.rs
@@ -63,7 +63,15 @@ impl Bounds {
     pub(crate) fn is_future(&self, t: i64, closed: ClosedWindow) -> bool {
         match closed {
             ClosedWindow::Left | ClosedWindow::None => self.stop <= t,
-            ClosedWindow::Both | ClosedWindow::Right => t > self.stop,
+            ClosedWindow::Both | ClosedWindow::Right => self.stop < t,
+        }
+    }
+
+    #[inline]
+    pub(crate) fn is_past(&self, t: i64, closed: ClosedWindow) -> bool {
+        match closed {
+            ClosedWindow::Left | ClosedWindow::Both => self.start > t,
+            ClosedWindow::None | ClosedWindow::Right => self.start >= t,
         }
     }
 }

--- a/crates/polars-time/src/windows/group_by.rs
+++ b/crates/polars-time/src/windows/group_by.rs
@@ -180,6 +180,7 @@ pub fn group_by_windows(
                 window
                     .get_overlapping_bounds_iter(
                         boundary,
+                        closed_window,
                         tu,
                         tz.parse::<Tz>().ok().as_ref(),
                         start_by,
@@ -198,7 +199,7 @@ pub fn group_by_windows(
         _ => {
             update_groups_and_bounds(
                 window
-                    .get_overlapping_bounds_iter(boundary, tu, None, start_by)
+                    .get_overlapping_bounds_iter(boundary, closed_window, tu, None, start_by)
                     .unwrap(),
                 start_offset,
                 time,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -5554,8 +5554,8 @@ class DataFrame:
         - [start + 2*every, start + 2*every + period)
         - ...
 
-        where `start` is determined by `start_by`, `offset`, and `every` (see parameter
-        descriptions below).
+        where `start` is determined by `start_by`, `offset`, `every`, and the earliest
+        datapoint. See the `start_by` argument description for details.
 
         .. warning::
             The index column must be sorted in ascending order. If `by` is passed, then
@@ -5577,7 +5577,7 @@ class DataFrame:
         period
             length of the window, if None it will equal 'every'
         offset
-            offset of the window, only takes effect if `start_by` is `'window'`.
+            offset of the window, does not take effect if `start_by` is 'datapoint'.
             Defaults to negative `every`.
         truncate
             truncate the time value to the window lower bound
@@ -5613,6 +5613,9 @@ class DataFrame:
               * 'tuesday': Start the window on the Tuesday before the first data point.
               * ...
               * 'sunday': Start the window on the Sunday before the first data point.
+
+              The resulting window is then shifted back until the earliest datapoint
+              is in or in front of it.
         check_sorted
             Check whether `index_column` is sorted (or, if `group_by` is given,
             check whether it's sorted within each group).
@@ -10694,6 +10697,9 @@ class DataFrame:
               * 'tuesday': Start the window on the Tuesday before the first data point.
               * ...
               * 'sunday': Start the window on the Sunday before the first data point.
+
+              The resulting window is then shifted back until the earliest datapoint
+              is in or in front of it.
         check_sorted
             Check whether `index_column` is sorted (or, if `by` is given,
             check whether it's sorted within each group).

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -3403,8 +3403,8 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         - [start + 2*every, start + 2*every + period)
         - ...
 
-        where `start` is determined by `start_by`, `offset`, and `every` (see parameter
-        descriptions below).
+        where `start` is determined by `start_by`, `offset`, `every`, and the earliest
+        datapoint. See the `start_by` argument description for details.
 
         .. warning::
             The index column must be sorted in ascending order. If `by` is passed, then
@@ -3426,7 +3426,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         period
             length of the window, if None it will equal 'every'
         offset
-            offset of the window, only takes effect if `start_by` is `'window'`.
+            offset of the window, does not take effect if `start_by` is 'datapoint'.
             Defaults to negative `every`.
         truncate
             truncate the time value to the window lower bound
@@ -3462,6 +3462,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
               * 'tuesday': Start the window on the Tuesday before the first data point.
               * ...
               * 'sunday': Start the window on the Sunday before the first data point.
+
+              The resulting window is then shifted back until the earliest datapoint
+              is in or in front of it.
         check_sorted
             Check whether `index_column` is sorted (or, if `group_by` is given,
             check whether it's sorted within each group).
@@ -6447,7 +6450,7 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
         period
             length of the window, if None it will equal 'every'
         offset
-            offset of the window, only takes effect if `start_by` is `'window'`.
+            offset of the window, does not take effect if `start_by` is 'datapoint'.
             Defaults to negative `every`.
         truncate
             truncate the time value to the window lower bound
@@ -6472,6 +6475,9 @@ naive plan: (run LazyFrame.explain(optimized=True) to see the optimized plan)
               * 'tuesday': Start the window on the Tuesday before the first data point.
               * ...
               * 'sunday': Start the window on the Sunday before the first data point.
+
+              The resulting window is then shifted back until the earliest datapoint
+              is in or in front of it.
         check_sorted
             Check whether `index_column` is sorted (or, if `by` is given,
             check whether it's sorted within each group).


### PR DESCRIPTION
closes #15241

With the example from that issue, the output becomes:
```
shape: (2, 2)
┌─────────────────────────┬──────┐
│ t                       ┆ v    │
│ ---                     ┆ ---  │
│ datetime[ms, UTC]       ┆ i64  │
╞═════════════════════════╪══════╡
│ 2024-03-21 05:00:00 UTC ┆ 11   │
│ 2024-03-22 05:00:00 UTC ┆ 1100 │
└─────────────────────────┴──────┘
```
which is their expected output

This doesn't break any existing tested behaviour, but does make group-by-dynamic more user-friendly / expected to users using `offset`

Perf impact: there's a little extra computation for finding the first window, but that's only for the first window - after that, the windows just keep getting updated by adding `every` (no change)