### PR TITLE
fix(python, rust): `read_csv` column order did not follow the `columns` parameter

### DIFF
--- a/crates/polars-io/src/csv/read.rs
+++ b/crates/polars-io/src/csv/read.rs
@@ -336,7 +336,7 @@ where
         self
     }
 
-    /// Column namess to select/ project
+    /// Column names to select/ project
     ///
     /// Incompactible with [`with_projection`](CsvReader::with_projection).
     /// If `Some` provided, it will overwrite set [`with_projection`](CsvReader::with_projection).

--- a/crates/polars-io/src/csv/read.rs
+++ b/crates/polars-io/src/csv/read.rs
@@ -302,8 +302,8 @@ where
     ///
     /// Elements longer than the number of given `columns` or csv columns will be ignored.
     ///
-    /// Incompactible with [`with_dtypes`] or [`with_schema`](CsvReader::with_schema).
-    /// If `Some` provided, it will overwrite set [`with_dtypes`] or [`with_schema`](CsvReader::with_schema).
+    /// Incompactible with [`with_dtypes`](CsvReader::with_dtypes) or [`with_schema`](CsvReader::with_schema).
+    /// If `Some` provided, it will overwrite set [`with_dtypes`](CsvReader::with_dtypes) or [`with_schema`](CsvReader::with_schema).
     pub fn with_dtypes_slice(mut self, dtypes: Option<&'a [DataType]>) -> Self {
         if let Some(dtypes_slice) = dtypes {
             self.schema_options = ReaderSchemaOptions::Infer(Some(

--- a/crates/polars-io/src/csv/read.rs
+++ b/crates/polars-io/src/csv/read.rs
@@ -202,10 +202,21 @@ where
         self
     }
 
-    /// Set the CSV file's schema. This only accepts datatypes that are implemented
+    /// Set the CSV file's schema for reader.
+    /// This only accepts datatypes that are implemented
     /// in the csv parser and expects a complete Schema.
     ///
-    /// It is recommended to use [with_dtypes](Self::with_dtypes) instead.
+    /// This means that polars doesn't do schema inference.
+    /// This argument expects the complete schema, whereas
+    /// [`with_dtypes_slice`](CsvReader::with_dtypes_slice)
+    /// or [`with_dtypes_slice`](CsvReader::with_dtypes_slice)
+    /// can be used to partially overwrite a schema.
+    ///
+    /// Incompactible with [`with_dtypes`](CsvReader::with_dtypes)
+    /// or [`with_dtypes_slice`](CsvReader::with_dtypes_slice).
+    /// If `Some` provided, it will overwrite
+    /// set [`with_dtypes`](CsvReader::with_dtypes)
+    /// or [`with_dtypes_slice`](CsvReader::with_dtypes_slice).
     pub fn with_schema(mut self, schema: Option<SchemaRef>) -> Self {
         if let Some(schema) = schema {
             self.schema_options = ReaderSchemaOptions::Enforce(schema);
@@ -273,8 +284,11 @@ where
         self
     }
 
-    /// Overwrite the schema with the dtypes in this given Schema. The given schema may be a subset
-    /// of the total schema.
+    /// Overwrite the inferred schema with the dtypes in the order they
+    /// appear in the csv or given `columns` parameter.
+    ///
+    /// Incompactible with [`with_dtypes_slice`](CsvReader::with_dtypes_slice) or [`with_schema`](CsvReader::with_schema).
+    /// If `Some` provided, it will overwrite set [`with_dtypes_slice`](CsvReader::with_dtypes_slice) or [`with_schema`](CsvReader::with_schema).
     pub fn with_dtypes(mut self, schema: Option<SchemaRef>) -> Self {
         if let Some(schema) = schema {
             self.schema_options =
@@ -283,8 +297,13 @@ where
         self
     }
 
-    /// Overwrite the dtypes in the schema in the order of the slice that's given.
+    /// Overwrite the dtypes in inferred schema in the order of the slice that's given.
     /// This is useful if you don't know the column names beforehand
+    ///
+    /// Elements longer than the number of given `columns` or csv columns will be ignored.
+    ///
+    /// Incompactible with [`with_dtypes`] or [`with_schema`](CsvReader::with_schema).
+    /// If `Some` provided, it will overwrite set [`with_dtypes`] or [`with_schema`](CsvReader::with_schema).
     pub fn with_dtypes_slice(mut self, dtypes: Option<&'a [DataType]>) -> Self {
         if let Some(dtypes_slice) = dtypes {
             self.schema_options = ReaderSchemaOptions::Infer(Some(
@@ -306,15 +325,25 @@ where
     }
 
     /// Set the reader's column projection. This counts from 0, meaning that
-    /// `vec![0, 4]` would select the 1st and 5th column.
+    /// `vec![0, 4]` would select the 1st and 5th column in csv.
+    ///
+    /// Incompactible with [`with_columns`](CsvReader::with_columns).
+    /// If `Some` provided, it will overwrite set [`with_columns`](CsvReader::with_columns).
     pub fn with_projection(mut self, projection: Option<Vec<usize>>) -> Self {
-        self.projection = projection.map(ColumnProjectionOptions::from).or(self.projection);
+        self.projection = projection
+            .map(ColumnProjectionOptions::from)
+            .or(self.projection);
         self
     }
 
-    /// Columns to select/ project
+    /// Column namess to select/ project
+    ///
+    /// Incompactible with [`with_projection`](CsvReader::with_projection).
+    /// If `Some` provided, it will overwrite set [`with_projection`](CsvReader::with_projection).
     pub fn with_columns(mut self, columns: Option<Vec<String>>) -> Self {
-        self.projection = columns.map(ColumnProjectionOptions::from).or(self.projection);
+        self.projection = columns
+            .map(ColumnProjectionOptions::from)
+            .or(self.projection);
         self
     }
 

--- a/crates/polars-io/src/csv/read.rs
+++ b/crates/polars-io/src/csv/read.rs
@@ -539,16 +539,6 @@ where
         use InferSchemaOptions::*;
         use ReaderSchemaOptions::*;
 
-        // TODO! move to other place
-        #[cfg(feature = "dtype-categorical")]
-        {
-            let mut _cat_lock = None;
-            let (_schema, _to_cast, has_cat) = self.schema_options.prepare_schema_overwrite()?;
-            if has_cat {
-                _cat_lock = Some(polars_core::StringCacheHolder::hold())
-            }
-        }
-
         let mut df = self.core_reader()?.as_df()?;
 
         // Important that this rechunk is never done in parallel.

--- a/crates/polars-io/src/csv/read_impl/batched_mmap.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_mmap.rs
@@ -259,7 +259,11 @@ impl<'a> BatchedCsvReaderMmap<'a> {
                     cast_columns(&mut df, &self.to_cast, false, self.ignore_errors)?;
 
                     unsafe {
-                        sort_series_origin_order(df.get_columns_mut(), self.projection_original_position.clone(), false);
+                        sort_series_origin_order(
+                            df.get_columns_mut(),
+                            self.projection_original_position.clone(),
+                            false,
+                        );
                     }
 
                     if let Some(rc) = &self.row_index {

--- a/crates/polars-io/src/csv/read_impl/batched_mmap.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_mmap.rs
@@ -258,12 +258,12 @@ impl<'a> BatchedCsvReaderMmap<'a> {
 
                     cast_columns(&mut df, &self.to_cast, false, self.ignore_errors)?;
 
-                    if let Some(rc) = &self.row_index {
-                        df.with_row_index_mut(&rc.name, Some(rc.offset));
+                    unsafe {
+                        sort_series_origin_order(df.get_columns_mut(), self.projection_original_position.clone(), false);
                     }
 
-                    unsafe {
-                        sort_series_origin_order(df.get_columns_mut(), self.projection_original_position.clone());
+                    if let Some(rc) = &self.row_index {
+                        df.with_row_index_mut(&rc.name, Some(rc.offset));
                     }
 
                     Ok(df)

--- a/crates/polars-io/src/csv/read_impl/batched_read.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_read.rs
@@ -355,12 +355,12 @@ impl<'a> BatchedCsvReaderRead<'a> {
 
                     cast_columns(&mut df, &self.to_cast, false, self.ignore_errors)?;
 
-                    if let Some(rc) = &self.row_index {
-                        df.with_row_index_mut(&rc.name, Some(rc.offset));
+                    unsafe {
+                        sort_series_origin_order(df.get_columns_mut(), self.projection_original_position.clone(), false);
                     }
 
-                    unsafe {
-                        sort_series_origin_order(df.get_columns_mut(), self.projection_original_position.clone());
+                    if let Some(rc) = &self.row_index {
+                        df.with_row_index_mut(&rc.name, Some(rc.offset));
                     }
 
                     Ok(df)

--- a/crates/polars-io/src/csv/read_impl/batched_read.rs
+++ b/crates/polars-io/src/csv/read_impl/batched_read.rs
@@ -318,14 +318,14 @@ impl<'a> BatchedCsvReaderRead<'a> {
 
         // create a null value for every column
         let null_values_compiled = self
-        .null_values
-        .clone()
-        .map(|nv| nv.compile(&self.schema))
-        .transpose()?
-        .map(|mut nv| {
-            nv.apply_projection(&self.projection);
-            nv
-        });
+            .null_values
+            .clone()
+            .map(|nv| nv.compile(&self.schema))
+            .transpose()?
+            .map(|mut nv| {
+                nv.apply_projection(&self.projection);
+                nv
+            });
 
         let mut chunks = POOL.install(|| {
             self.file_chunks
@@ -356,7 +356,11 @@ impl<'a> BatchedCsvReaderRead<'a> {
                     cast_columns(&mut df, &self.to_cast, false, self.ignore_errors)?;
 
                     unsafe {
-                        sort_series_origin_order(df.get_columns_mut(), self.projection_original_position.clone(), false);
+                        sort_series_origin_order(
+                            df.get_columns_mut(),
+                            self.projection_original_position.clone(),
+                            false,
+                        );
                     }
 
                     if let Some(rc) = &self.row_index {

--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -486,7 +486,7 @@ impl<'a> CoreReader<'a> {
                 df.insert_column(0, Series::new_empty(&row_index.name, &IDX_DTYPE))?;
             }
             unsafe {
-                sort_series_origin_order(df.get_columns_mut(), self.projection_original_position.clone());
+                sort_series_origin_order(df.get_columns_mut(), self.projection_original_position.clone(), self.row_index.is_some());
             }
             return Ok(df);
         }
@@ -665,7 +665,7 @@ impl<'a> CoreReader<'a> {
             }
             let mut result_df = accumulate_dataframes_vertical(dfs.into_iter().map(|t| t.0))?;
             unsafe {
-                sort_series_origin_order(result_df.get_columns_mut(), self.projection_original_position.clone());
+                sort_series_origin_order(result_df.get_columns_mut(), self.projection_original_position.clone(), self.row_index.is_some());
             }
             Ok(result_df)
         }

--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -673,6 +673,15 @@ impl<'a> CoreReader<'a> {
 
     /// Read the csv into a DataFrame. The predicate can come from a lazy physical plan.
     pub fn as_df(&mut self) -> PolarsResult<DataFrame> {
+        #[cfg(feature = "dtype-categorical")]
+        let _cat_lock = {
+            if self.has_cat {
+                Some(polars_core::StringCacheHolder::hold())
+            } else {
+                None
+            }
+        };
+
         let predicate = self.predicate.take();
         let n_threads = self.n_threads.unwrap_or_else(|| POOL.current_num_threads());
 

--- a/crates/polars-io/src/csv/utils.rs
+++ b/crates/polars-io/src/csv/utils.rs
@@ -797,7 +797,7 @@ impl ColumnProjectionOptions {
     /// sorted projection for csv reading, pos for re-ordering as user input
     pub(super) fn get_sorted_pj_and_original_pos(
         &self,
-        schema: SchemaRef,
+        schema: &Schema,
     ) -> PolarsResult<(Vec<usize>, Vec<usize>)> {
         use ColumnProjectionOptions::*;
         let mut pos_and_indices: Vec<(usize, usize)> = match self {
@@ -816,10 +816,10 @@ impl ColumnProjectionOptions {
 
 pub(super) fn get_sorted_projection(
     projection: &Option<ColumnProjectionOptions>,
-    schema: SchemaRef,
+    schema: &Schema,
 ) -> PolarsResult<(Vec<usize>, Vec<usize>)> {
     let (pj, pos): (Vec<usize>, Vec<usize>) = if let Some(projection) = projection {
-        projection.get_sorted_pj_and_original_pos(schema.clone())?
+        projection.get_sorted_pj_and_original_pos(schema)?
     } else {
         ((0..schema.len()).collect(), (0..schema.len()).collect())
     };

--- a/crates/polars-io/src/csv/utils.rs
+++ b/crates/polars-io/src/csv/utils.rs
@@ -830,8 +830,12 @@ pub(super) fn get_sorted_projection(
 /// # Safety
 ///
 /// Column should be consistent with paired projection
-pub(super) fn sort_series_origin_order(series: &mut [Series], mut original_pos: Vec<usize>) {
-    debug_assert!(series.len() == original_pos.len());
+pub(super) fn sort_series_origin_order(series: &mut [Series], mut original_pos: Vec<usize>, with_index_row: bool) {
+    debug_assert!(series.len() == original_pos.len() + with_index_row as usize);
+    if with_index_row {
+        original_pos.iter_mut().for_each(|e| *e += 1);
+        original_pos.insert(0, 0);
+    }
     for i in 0..series.len() {
         loop {
             let should_be_in = original_pos[i];

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -70,7 +70,7 @@ def read_csv(
         following format: `column_x`, with `x` being an
         enumeration over every column in the dataset starting at 1.
     columns
-        Columns to select. Accepts a list of column indices (starting
+        Columns in csv to select. Accepts a list of column indices (starting
         at zero) or a list of column names.
     new_columns
         Rename columns right after parsing the CSV file. If the given
@@ -94,7 +94,7 @@ def read_csv(
         - `dict`: a dictionary that maps column names to data types.
         - `list`: the data types are applied to the columns in the order they appear
         in the csv or given `columns` parameter. Elements longer than the number of
-        given `columns` will be ignored.
+        given `columns` or csv columns will be ignored.
 
         Should not be used together with `schema`.
     schema

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -87,7 +87,12 @@ def read_csv(
     skip_rows
         Start reading after `skip_rows` lines.
     dtypes
-        Overwrite dtypes for specific or all columns during schema inference.
+        Overwrite dtypes for specific columns during schema inference.
+        This can be
+        - `dict`: a dictionary that maps column names to data types.
+        - `list`: the data types are applied to the columns in the order they appear
+        in the csv or given `columns` parameter. Elements longer than the number of
+        given `columns` will be ignored.
     schema
         Provide the schema. This means that polars doesn't do schema inference.
         This argument expects the complete schema, whereas `dtypes` can be used
@@ -298,21 +303,6 @@ def read_csv(
         if new_columns:
             return _update_columns(df, new_columns)
         return df
-
-    if projection and dtypes and isinstance(dtypes, list):
-        if len(projection) < len(dtypes):
-            msg = "more dtypes overrides are specified than there are selected columns"
-            raise ValueError(msg)
-
-        # Fix list of dtypes when used together with projection as polars CSV reader
-        # wants a list of dtypes for the x first columns before it does the projection.
-        dtypes_list: list[PolarsDataType] = [String] * (max(projection) + 1)
-
-        for idx, column_idx in enumerate(projection):
-            if idx < len(dtypes):
-                dtypes_list[column_idx] = dtypes[idx]
-
-        dtypes = dtypes_list
 
     if columns and dtypes and isinstance(dtypes, list):
         if len(columns) < len(dtypes):

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -88,15 +88,20 @@ def read_csv(
         Start reading after `skip_rows` lines.
     dtypes
         Overwrite dtypes for specific columns during schema inference.
+
         This can be
+
         - `dict`: a dictionary that maps column names to data types.
         - `list`: the data types are applied to the columns in the order they appear
         in the csv or given `columns` parameter. Elements longer than the number of
         given `columns` will be ignored.
+
+        Should not be used together with `schema`.
     schema
         Provide the schema. This means that polars doesn't do schema inference.
         This argument expects the complete schema, whereas `dtypes` can be used
         to partially overwrite a schema.
+        Should not be used together with `dtypes`.
     null_values
         Values to interpret as null values. You can provide a:
 
@@ -303,6 +308,10 @@ def read_csv(
         if new_columns:
             return _update_columns(df, new_columns)
         return df
+
+    if schema and dtypes:
+        msg = "cannot provide both 'schema' and 'dtypes'"
+        raise ValueError(msg)
 
     if columns and dtypes and isinstance(dtypes, list):
         if len(columns) < len(dtypes):

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -87,14 +87,12 @@ def read_csv(
     skip_rows
         Start reading after `skip_rows` lines.
     dtypes
-        Overwrite dtypes for specific columns during schema inference.
-
-        This can be
+        Overwrite dtypes for specific columns during schema inference. This can be
 
         - `dict`: a dictionary that maps column names to data types.
-        - `list`: the data types are applied to the columns in the order they appear
-        in the csv or given `columns` parameter. Elements longer than the number of
-        given `columns` or csv columns will be ignored.
+        - `list`: the data types are applied to the columns in the order they appear in
+            the csv or given `columns` parameter. Elements longer than the number of
+            given `columns` or csv columns will be ignored.
 
         Should not be used together with `schema`.
     schema

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -314,10 +314,6 @@ def read_csv(
         raise ValueError(msg)
 
     if columns and dtypes and isinstance(dtypes, list):
-        if len(columns) < len(dtypes):
-            msg = "more dtypes overrides are specified than there are selected columns"
-            raise ValueError(msg)
-
         # Map list of dtypes when used together with selected columns as a dtypes dict
         # so the dtypes are applied to the correct column instead of the first x
         # columns.

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -1969,3 +1969,7 @@ def test_read_csv_single_column(columns: list[str] | str) -> None:
 def test_csv_invalid_escape_utf8_14960() -> None:
     with pytest.raises(pl.ComputeError, match=r"field is not properly escaped"):
         pl.read_csv('col1\n""•'.encode())
+
+def test_read_csv_set_both_schema_dtypes_fail() -> None:
+    with pytest.raises(ValueError, match="cannot provide both 'schema' and 'dtypes'"):
+        pl.read_csv(io.StringIO("a,b\n1,2\n"), schema={"a": pl.Int32}, dtypes={"a": pl.Int64})

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -373,7 +373,8 @@ def test_dtype_overwrite_with_column_name_selection() -> None:
     )
     f = io.StringIO(csv)
     df = pl.read_csv(f, columns=["c", "b", "d"], dtypes=[pl.Int32, pl.String])
-    assert df.dtypes == [pl.String, pl.Int32, pl.Int64]
+    assert df.dtypes == [pl.Int32, pl.String, pl.Int64]
+    assert df.columns == ["c", "b", "d"]
 
 
 def test_dtype_overwrite_with_column_idx_selection() -> None:
@@ -386,12 +387,11 @@ def test_dtype_overwrite_with_column_idx_selection() -> None:
     )
     f = io.StringIO(csv)
     df = pl.read_csv(f, columns=[2, 1, 3], dtypes=[pl.Int32, pl.String])
+    # Projections are sorted.
+    assert df.columns == ["c", "b", "d"]
     # Columns without an explicit dtype set will get pl.String if dtypes is a list
     # if the column selection is done with column indices instead of column names.
-    assert df.dtypes == [pl.String, pl.Int32, pl.String]
-    # Projections are sorted.
-    assert df.columns == ["b", "c", "d"]
-
+    assert df.dtypes == [pl.Int32, pl.String, pl.Int64]
 
 def test_partial_column_rename() -> None:
     csv = textwrap.dedent(

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -393,6 +393,7 @@ def test_dtype_overwrite_with_column_idx_selection() -> None:
     # if the column selection is done with column indices instead of column names.
     assert df.dtypes == [pl.Int32, pl.String, pl.Int64]
 
+
 def test_partial_column_rename() -> None:
     csv = textwrap.dedent(
         """\
@@ -1970,6 +1971,9 @@ def test_csv_invalid_escape_utf8_14960() -> None:
     with pytest.raises(pl.ComputeError, match=r"field is not properly escaped"):
         pl.read_csv('col1\n""•'.encode())
 
+
 def test_read_csv_set_both_schema_dtypes_fail() -> None:
     with pytest.raises(ValueError, match="cannot provide both 'schema' and 'dtypes'"):
-        pl.read_csv(io.StringIO("a,b\n1,2\n"), schema={"a": pl.Int32}, dtypes={"a": pl.Int64})
+        pl.read_csv(
+            io.StringIO("a,b\n1,2\n"), schema={"a": pl.Int32}, dtypes={"a": pl.Int64}
+        )


### PR DESCRIPTION
This is a refactoring of [`read_csv`](https://docs.pola.rs/py-polars/html/reference/api/polars.read_csv.html#polars-read-csv) about parameters `dtypes`, `columns` and `schema`.

# Issue resolving

There have been many issues related to `read_csv`, and the initial intention of this refactoring is to address the problem where the returned DataFrame's column order did not follow the `columns` parameter (Closes #15027, Closes #13066). Now, the order of output DataFrame will be consistent with input column names. 

Code: 

```python
from io import StringIO
import polars as pl

df = pl.read_csv(
    source  = StringIO("id,y,x\n1,2,3"),
    columns = ["id","x","y"],
)
```

Before: 
```txt
shape: (1, 3)
┌─────┬─────┬─────┐
│ id  ┆ y   ┆ x   │
│ --- ┆ --- ┆ --- │
│ i64 ┆ i64 ┆ i64 │
╞═════╪═════╪═════╡
│ 1   ┆ 2   ┆ 3   │
└─────┴─────┴─────┘
```

After: 
```txt
shape: (1, 3)
┌─────┬─────┬─────┐
│ id  ┆ x   ┆ y   │
│ --- ┆ --- ┆ --- │
│ i64 ┆ i64 ┆ i64 │
╞═════╪═════╪═════╡
│ 1   ┆ 3   ┆ 2   │
└─────┴─────┴─────┘
```

# Other changes 

## Behavior of passing `list[int]` to `columns`

Also, behavior of passing `list[int]` to `columns` changes. Before, columns will be sorted by original index. 

Code: 
```python
import polars as pl
from io import StringIO

string_io = StringIO("""\
a,b,c,d
1,2,3,4
1,2,3,4
""")

pl.read_csv(
    string_io,
    columns=[2, 3, 1] # <- Here
)
```

Before: no matter order of this input, it will behavior like `columns=[1, 2, 3]`.

```txt
shape: (2, 3)
┌─────┬─────┬─────┐
│ b   ┆ c   ┆ d   │
│ --- ┆ --- ┆ --- │
│ i64 ┆ i64 ┆ i64 │
╞═════╪═════╪═════╡
│ 2   ┆ 3   ┆ 4   │
│ 2   ┆ 3   ┆ 4   │
└─────┴─────┴─────┘
```

After: sorted as input index order.

```txt
shape: (2, 3)
┌─────┬─────┬─────┐
│ c   ┆ d   ┆ b   │
│ --- ┆ --- ┆ --- │
│ i64 ┆ i64 ┆ i64 │
╞═════╪═════╪═════╡
│ 3   ┆ 4   ┆ 2   │
│ 3   ┆ 4   ┆ 2   │
└─────┴─────┴─────┘
```

## Make `schema` and `dtypes` mutually exclusive and clearly

Additionally, the refactoring involves the `schema` and `dtypes` parameters, which users typically only need one of to accomplish their tasks, and setting both was undefined behavior (Closes #14385). 

After refactoring, `schema` means not using Polars' schema inference, while `dtypes` is for overriding the inferred schema; now they are mutually exclusive, and setting both will throw an Error.

```python
pl.read_csv(f, schema={ "a": pl.Int32 }, dtypes=[pl.Int32])

# ValueError: cannot provide both 'schema' and 'dtypes'
```

## `Sequence[PolarsDataType]` as `dtypes`

Meanwhile, the refactoring also brings changes to the behavior of `dtypes`. Before, how `columns` interacts `dtypes` is not quite clear. 

Now, it is the data types are applied to the columns in the order they appear in the csv or given `columns` parameter (if given). Elements longer than the number of given `columns` or csv columns will be ignored. The `columns` and `dtypes` will form a corresponding relationship, which is very intuitive.

Also, before, if `list[int]` is passed to `columns`, column indices longer than `dtypes` sequence will be set as str. Now it applies inferred `dtype`, which is consistent with passing `list[str]` to `columns`. 

```python
import polars as pl
from io import StringIO

string_io = StringIO("""\
a,b,c,d
1,2,3,4
1,2,3,4
""")

pl.read_csv(
    string_io,
    columns=[2, 1, 3],
    dtypes=[pl.Int32, pl.String]
)
```

Before: (`d` is set as str. Not sure why.)
```txt
shape: (2, 3)
┌─────┬─────┬─────┐
│ b   ┆ c   ┆ d   │
│ --- ┆ --- ┆ --- │
│ str ┆ i32 ┆ str │
╞═════╪═════╪═════╡
│ 2   ┆ 3   ┆ 4   │
│ 2   ┆ 3   ┆ 4   │
└─────┴─────┴─────┘
```

After: (`d` is inferred from csv.)
```txt
                                        
              ┌───────────────────┐     
        dtypes│i32 str  infer     │     
              │ ▲   ▲   ▲         │     
   param      │ │   │   │         │     
              │ │   │   │         │     
         p_col│ 2   1   3◄───┐    │     
              │ ▲   ▲        │    │     
              │ │   └┐       │    │     
              │ │    │       │    │     
              │ └────┼───┐   │    │     
              │      │   │   │    │     
           idx│  0   1   2   3    │     
      csv     │                   │     
           col│  a   b   c   d    │     
              └───────────────────┘     
                                        
```
```txt
shape: (2, 3)
┌─────┬─────┬─────┐
│ c   ┆ b   ┆ d   │
│ --- ┆ --- ┆ --- │
│ i32 ┆ str ┆ i64 │
╞═════╪═════╪═════╡
│ 3   ┆ 2   ┆ 4   │
│ 3   ┆ 2   ┆ 4   │
└─────┴─────┴─────┘
```

