### PR TITLE
fix(python): Preserve Decimal precision when constructing empty Series

### DIFF
--- a/py-polars/polars/_utils/construction/series.py
+++ b/py-polars/polars/_utils/construction/series.py
@@ -35,6 +35,7 @@ from polars.datatypes import (
     Categorical,
     Date,
     Datetime,
+    Decimal,
     Duration,
     Enum,
     List,
@@ -135,7 +136,16 @@ def sequence_to_pyseries(
         pyseries = _construct_series_with_fallbacks(
             constructor, name, values, dtype, strict=strict
         )
-        if dtype in (Date, Datetime, Duration, Time, Categorical, Boolean, Enum):
+        if dtype in (
+            Date,
+            Datetime,
+            Duration,
+            Time,
+            Categorical,
+            Boolean,
+            Enum,
+            Decimal,
+        ):
             if pyseries.dtype() != dtype:
                 pyseries = pyseries.cast(dtype, strict=strict)
         return pyseries

--- a/py-polars/tests/unit/constructors/test_series.py
+++ b/py-polars/tests/unit/constructors/test_series.py
@@ -70,3 +70,9 @@ def test_upcast_primitive_and_strings(
     values: list[Any], dtype: pl.PolarsDataType, expected_dtype: pl.PolarsDataType
 ) -> None:
     assert pl.Series(values, dtype=dtype).dtype == expected_dtype
+
+
+def test_preserve_decimal_precision() -> None:
+    dtype = pl.Decimal(None, 1)
+    s = pl.Series(dtype=dtype)
+    assert s.dtype == dtype


### PR DESCRIPTION
See the test case.