### PR TITLE
feat(python): In hypothesis testing strategies, enable Decimal strategy by default

### DIFF
--- a/py-polars/polars/testing/parametric/strategies.py
+++ b/py-polars/polars/testing/parametric/strategies.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from datetime import datetime, timedelta
 from itertools import chain
 from random import choice, randint, shuffle
@@ -273,13 +272,10 @@ scalar_strategies: StrategyLookup = StrategyLookup(
         Categorical: strategy_categorical,
         String: strategy_string,
         Binary: strategy_binary,
+        Decimal: strategy_decimal(),
     }
 )
 nested_strategies: StrategyLookup = StrategyLookup()
-
-# note: decimal support is in early development and requires activation
-if os.environ.get("POLARS_ACTIVATE_DECIMAL") == "1":
-    scalar_strategies[Decimal] = strategy_decimal()
 
 
 def _get_strategy_dtypes(

--- a/py-polars/tests/parametric/test_series.py
+++ b/py-polars/tests/parametric/test_series.py
@@ -10,24 +10,6 @@ import polars as pl
 from polars.testing import assert_series_equal
 from polars.testing.parametric import series
 
-# TODO: once Decimal is a little further along, start actively probing it
-# @given(
-#     s=series(max_size=10, dtype=pl.Decimal, null_probability=0.1),
-# )
-# def test_series_decimal(
-#     s: pl.Series,
-# ) -> None:
-#     with pl.Config(activate_decimals=True):
-#         assert s.dtype == pl.Decimal
-#         assert s.to_list() == list(s)
-#
-#         s_div = s / D(123)
-#         s_mul = s * D(123)
-#         s_sub = s - D(123)
-#         s_add = s - D(123)
-#
-# etc...
-
 
 @given(
     s=series(min_size=1, max_size=10, dtype=pl.Datetime),

--- a/py-polars/tests/parametric/test_testing.py
+++ b/py-polars/tests/parametric/test_testing.py
@@ -269,7 +269,13 @@ def test_invalid_arguments() -> None:
         column("colx", strategy=sampled_from([None]))
 
 
-@given(s=series(allowed_dtypes=pl.Binary))
+@given(s=series(dtype=pl.Binary))
 @settings(max_examples=5)
 def test_strategy_dtype_binary(s: pl.Series) -> None:
     assert s.dtype == pl.Binary
+
+
+@given(s=series(dtype=pl.Decimal))
+@settings(max_examples=5)
+def test_strategy_dtype_decimal(s: pl.Series) -> None:
+    assert s.dtype == pl.Decimal


### PR DESCRIPTION
Enabling this already helped me catch a bug. Let's enable it by default - our Decimals are a lot better supported already.