### PR TITLE
feat: CSE don't scan share if predicate pushdown predicates don't match

### DIFF
--- a/crates/polars-lazy/src/tests/cse.rs
+++ b/crates/polars-lazy/src/tests/cse.rs
@@ -348,7 +348,9 @@ fn test_cse_prune_scan_filter_difference() -> PolarsResult<()> {
         )
         .with_comm_subplan_elim(true);
 
-    assert_eq!(count_caches(q), 0);
+    // Check that the caches are removed and that both predicates have been pushed down instead.
+    assert_eq!(count_caches(q.clone()), 0);
+    assert!(predicate_at_scan(q));
 
     Ok(())
 }

--- a/crates/polars-plan/src/logical_plan/optimizer/cache_states.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/cache_states.rs
@@ -51,6 +51,63 @@ type TwoParents = [Option<Node>; 2];
 /// - This will ensure we apply predicate in the subtrees below the caches.
 /// - If the predicate above the cache is the same for all matching caches that filter will be applied
 ///  as well.
+///
+/// # Example
+/// Consider this tree, where `SUB-TREE` is duplicate and can be cached.
+///
+///
+///                         Tree
+///                         |
+///                         |
+///    |--------------------|-------------------|
+///    |                                        |
+///    SUB-TREE                                 SUB-TREE
+///
+/// STEPS:
+/// - 1 CSE will run and will insert cache nodes
+///
+///                         Tree
+///                         |
+///                         |
+///    |--------------------|-------------------|
+///    |                                        |
+///    | CACHE 0                                | CACHE 0
+///    |                                        |
+///    SUB-TREE                                 SUB-TREE
+///
+/// - 2 predicate and projection pushdown will run and will insert optional FILTER and PROJECTION above the caches
+///
+///                         Tree
+///                         |
+///                         |
+///    |--------------------|-------------------|
+///    | FILTER (optional)                      | FILTER (optional)
+///    | PROJ (optional)                        | PROJ (optional)
+///    |                                        |
+///    | CACHE 0                                | CACHE 0
+///    |                                        |
+///    SUB-TREE                                 SUB-TREE
+///
+/// # Projection optimization
+/// The union of the projection is determined and the projection will be pushed down.
+///
+///                         Tree
+///                         |
+///                         |
+///    |--------------------|-------------------|
+///    | FILTER (optional)                      | FILTER (optional)
+///    | CACHE 0                                | CACHE 0
+///    |                                        |
+///    SUB-TREE                                 SUB-TREE
+///    UNION PROJ (optional)                    UNION PROJ (optional)
+///
+/// # Filter optimization
+/// Depending on the predicates the predicate pushdown optimization will run.
+/// Possible cases:
+/// - NO FILTERS: run predicate pd from the cache nodes -> finish
+/// - Above the filters the caches are the same -> run predicate pd from the filter node -> finish
+/// - There is a cache without predicates above the cache node -> run predicate form the cache nodes -> finish
+/// - The predicates above the cache nodes are all different -> remove the cache nodes -> finish
 pub(super) fn set_cache_states(
     root: Node,
     lp_arena: &mut Arena<ALogicalPlan>,

--- a/crates/polars-plan/src/logical_plan/optimizer/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/mod.rs
@@ -152,8 +152,6 @@ pub fn optimize(
         } else {
             false
         };
-    #[cfg(not(feature = "cse"))]
-    let cse_plan_changed = false;
 
     // Should be run before predicate pushdown.
     if projection_pushdown {

--- a/crates/polars-plan/src/logical_plan/optimizer/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/mod.rs
@@ -137,7 +137,7 @@ pub fn optimize(
     }
 
     #[cfg(feature = "cse")]
-    let cse_plan_changed =
+    let _cse_plan_changed =
         if comm_subplan_elim && members.has_joins_or_unions && members.has_duplicate_scans() {
             if verbose {
                 eprintln!("found multiple sources; run comm_subplan_elim")
@@ -152,6 +152,8 @@ pub fn optimize(
         } else {
             false
         };
+    #[cfg(not(feature = "cse"))]
+    let _cse_plan_changed = false;
 
     // Should be run before predicate pushdown.
     if projection_pushdown {
@@ -225,7 +227,7 @@ pub fn optimize(
     // Make sure that we do that once slice pushdowd and predicate pushdown are done.
     // At that moment the file fingerprints are finished.
     #[cfg(any(feature = "cse", feature = "parquet", feature = "ipc", feature = "csv"))]
-    if agg_scan_projection && !cse_plan_changed {
+    if agg_scan_projection && !_cse_plan_changed {
         // We do this so that expressions, created by the pushdown optimizations, are simplified .
         // We must clean up the predicates, because the agg_scan_projection
         // uses them in the hashtable to determine duplicates.
@@ -238,7 +240,7 @@ pub fn optimize(
     }
 
     #[cfg(feature = "cse")]
-    if cse_plan_changed {
+    if _cse_plan_changed {
         // this must run after cse
         cse::decrement_file_counters_by_cache_hits(lp_top, lp_arena, expr_arena, 0, scratch);
     }

--- a/crates/polars-plan/src/logical_plan/optimizer/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/mod.rs
@@ -211,7 +211,7 @@ pub fn optimize(
     lp_top = opt.optimize_loop(&mut rules, expr_arena, lp_arena, lp_top)?;
 
     if members.has_joins_or_unions && members.has_cache {
-        cache_states::set_cache_states(lp_top, lp_arena, expr_arena, scratch, cse_plan_changed)?;
+        cache_states::set_cache_states(lp_top, lp_arena, expr_arena, scratch, verbose)?;
     }
 
     // This one should run (nearly) last as this modifies the projections

--- a/crates/polars-plan/src/logical_plan/optimizer/mod.rs
+++ b/crates/polars-plan/src/logical_plan/optimizer/mod.rs
@@ -90,7 +90,7 @@ pub fn optimize(
     scratch: &mut Vec<Node>,
     hive_partition_eval: HiveEval<'_>,
 ) -> PolarsResult<Node> {
-    #[cfg(feature = "cse")]
+    #[allow(dead_code)]
     let verbose = verbose();
     // get toggle values
     let predicate_pushdown = opt_state.predicate_pushdown;


### PR DESCRIPTION
In this case we will favor memory reduction over scan sharing.

```
/// 1. This will ensure that all equal caches communicate the amount of columns
/// they need to project.
/// 2.
/// - This will ensure we apply predicate in the subtrees below the caches.
/// - If the predicate above the cache is the same for all matching caches that filter will be applied
///  as well.
///
/// # Example
/// Consider this tree, where `SUB-TREE` is duplicate and can be cached.
///
///
///                         Tree
///                         |
///                         |
///    |--------------------|-------------------|
///    |                                        |
///    SUB-TREE                                 SUB-TREE
///
/// STEPS:
/// - 1 CSE will run and will insert cache nodes
///
///                         Tree
///                         |
///                         |
///    |--------------------|-------------------|
///    |                                        |
///    | CACHE 0                                | CACHE 0
///    |                                        |
///    SUB-TREE                                 SUB-TREE
///
/// - 2 predicate and projection pushdown will run and will insert optional FILTER and PROJECTION above the caches
///
///                         Tree
///                         |
///                         |
///    |--------------------|-------------------|
///    | FILTER (optional)                      | FILTER (optional)
///    | PROJ (optional)                        | PROJ (optional)
///    |                                        |
///    | CACHE 0                                | CACHE 0
///    |                                        |
///    SUB-TREE                                 SUB-TREE
///
/// # Projection optimization
/// The union of the projection is determined and the projection will be pushed down.
///
///                         Tree
///                         |
///                         |
///    |--------------------|-------------------|
///    | FILTER (optional)                      | FILTER (optional)
///    | CACHE 0                                | CACHE 0
///    |                                        |
///    SUB-TREE                                 SUB-TREE
///    UNION PROJ (optional)                    UNION PROJ (optional)
///
/// # Filter optimization
/// Depending on the predicates the predicate pushdown optimization will run.
/// Possible cases:
/// - NO FILTERS: run predicate pd from the cache nodes -> finish
/// - Above the filters the caches are the same -> run predicate pd from the filter node -> finish
/// - There is a cache without predicates above the cache node -> run predicate form the cache nodes -> finish
/// - The predicates above the cache nodes are all different -> remove the cache nodes -> finish
```