### PR TITLE
feat(python): Only allow inputs of type `Sequence` in `from_records`

### DIFF
--- a/py-polars/polars/convert.py
+++ b/py-polars/polars/convert.py
@@ -268,6 +268,14 @@ def from_records(
     │ 3   ┆ 6   │
     └─────┴─────┘
     """
+    if not isinstance(data, Sequence):
+        msg = (
+            f"expected data of type Sequence, got {type(data).__name__!r}"
+            "\n\nHint: Try passing your data to the DataFrame constructor instead,"
+            " e.g. `pl.DataFrame(data)`."
+        )
+        raise TypeError(msg)
+
     return wrap_df(
         sequence_to_pydf(
             data,

--- a/py-polars/tests/unit/interop/test_interop.py
+++ b/py-polars/tests/unit/interop/test_interop.py
@@ -375,6 +375,20 @@ def test_from_records() -> None:
     assert df.rows() == [(1, 4), (2, 5), (3, 6)]
 
 
+# https://github.com/pola-rs/polars/issues/15195
+@pytest.mark.parametrize(
+    "input",
+    [
+        pl.Series([1, 2]),
+        pl.Series([{"a": 1, "b": 2}]),
+        pl.DataFrame({"a": [1, 2], "b": [3, 4]}),
+    ],
+)
+def test_from_records_non_sequence_input(input: Any) -> None:
+    with pytest.raises(TypeError, match="expected data of type Sequence"):
+        pl.from_records(input)
+
+
 def test_from_arrow() -> None:
     data = pa.table({"a": [1, 2, 3], "b": [4, 5, 6]})
     df = pl.from_arrow(data)


### PR DESCRIPTION
Closes https://github.com/pola-rs/polars/issues/15195

This function was never intended to handle Series inputs. The docs clearly state that a sequence-of-sequences is expected. So the fact that a Series was supported and parsed into a DataFrame was not intended.

For a catch-all that parses all types of data, the DataFrame constructor can be used.

@alexander-beedie FYI this is the way we decided to go on this one.