### PR TITLE
fix(python): Raise properly for slices not supported by `LazyFrame`

### DIFF
--- a/py-polars/polars/slice.py
+++ b/py-polars/polars/slice.py
@@ -146,7 +146,8 @@ class LazyPolarsSlice:
         # [i:<=i]
         # [i:>=i:-k]
         if (step > 0 and (s.stop is not None and start >= s.stop)) or (
-            step < 0 and (s.stop is not None and s.stop >= s.start >= 0)
+            step < 0
+            and (s.start is not None and s.stop is not None and s.stop >= s.start >= 0)
         ):
             return self.obj.clear()
 
@@ -192,7 +193,7 @@ class LazyPolarsSlice:
         # ---------------------------------------
         # [-i:]    => tail(abs(i))
         # [-i::k]  => tail(abs(i)).gather_every(k)
-        elif start < 0 and s.stop is None:
+        elif start < 0 and s.stop is None and step > 0:
             obj = self.obj.tail(abs(start))
             return obj if (step == 1) else obj.gather_every(step)
 

--- a/py-polars/tests/parametric/test_lazyframe.py
+++ b/py-polars/tests/parametric/test_lazyframe.py
@@ -1,7 +1,7 @@
 # ----------------------------------------------------
 # Validate LazyFrame behaviour with parametric tests
 # ----------------------------------------------------
-from hypothesis import given
+from hypothesis import example, given
 from hypothesis.strategies import integers
 
 import polars as pl
@@ -16,23 +16,33 @@ from polars.testing.parametric import column, dataframes
             column(
                 "start",
                 dtype=pl.Int8,
-                null_probability=0.15,
-                strategy=integers(min_value=-4, max_value=6),
+                null_probability=0.3,
+                strategy=integers(min_value=-3, max_value=4),
             ),
             column(
                 "stop",
                 dtype=pl.Int8,
-                null_probability=0.15,
-                strategy=integers(min_value=-2, max_value=8),
+                null_probability=0.3,
+                strategy=integers(min_value=-2, max_value=6),
             ),
             column(
                 "step",
                 dtype=pl.Int8,
-                null_probability=0.15,
+                null_probability=0.3,
                 strategy=integers(min_value=-3, max_value=3).filter(lambda x: x != 0),
             ),
             column("misc", dtype=pl.Int32),
         ],
+    )
+)
+@example(
+    ldf=pl.LazyFrame(
+        {
+            "start": [-1, None, 1, None, 1, -1],
+            "stop": [None, 0, -1, -1, 2, 1],
+            "step": [-1, -1, 1, None, -1, 1],
+            "misc": [1, 2, 3, 4, 5, 6],
+        }
     )
 )
 def test_lazyframe_slice(ldf: pl.LazyFrame) -> None:

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -222,3 +222,22 @@ def test_slice_pushdown_literal_projection_14349() -> None:
     plan = q.explain()
     assert plan.index("WITH_COLUMNS") < plan.index("SLICE")
     assert q.collect().height == 0
+
+
+@pytest.mark.parametrize(
+    "input_slice",
+    # All these slices are not supported by LazyFrame, but they should raise properly.
+    [
+        (-1, None, -1),
+        (None, 0, -1),
+        (1, -1, 1),
+        (None, -1, None),
+        (1, 2, -1),
+        (-1, 1, 1),
+    ],
+)
+def test_slice_lazy_frame_raises_proper(input_slice: tuple[int | None]) -> None:
+    ldf = pl.LazyFrame({"a": [1, 2]})
+    s = slice(*input_slice)
+    with pytest.raises(ValueError, match="not supported"):
+        ldf[s].collect()

--- a/py-polars/tests/unit/operations/test_slice.py
+++ b/py-polars/tests/unit/operations/test_slice.py
@@ -226,7 +226,6 @@ def test_slice_pushdown_literal_projection_14349() -> None:
 
 @pytest.mark.parametrize(
     "input_slice",
-    # All these slices are not supported by LazyFrame, but they should raise properly.
     [
         (-1, None, -1),
         (None, 0, -1),
@@ -237,7 +236,7 @@ def test_slice_pushdown_literal_projection_14349() -> None:
     ],
 )
 def test_slice_lazy_frame_raises_proper(input_slice: tuple[int | None]) -> None:
-    ldf = pl.LazyFrame({"a": [1, 2]})
+    ldf = pl.LazyFrame({"a": [1, 2, 3]})
     s = slice(*input_slice)
     with pytest.raises(ValueError, match="not supported"):
         ldf[s].collect()


### PR DESCRIPTION
Found a couple more slice cases that are mishandled by LazyFrame. Specifically, both cases below are not supported by LazyFrame but they currently raise incorrect exceptions/errors:

1. `slice(None, 0, k)`, where `k < 0`

```python
import polars as pl

ldf = pl.LazyFrame({"a": [1, 2, 3]})
ldf[:0:-1].collect()
# TypeError: '>=' not supported between instances of 'int' and 'NoneType'
```

2. `slice(i, None, k)`, where `i, k < 0`

```python
import polars as pl

ldf = pl.LazyFrame({"a": [1, 2, 3]})
ldf[-1::-1].collect()
# OverflowError: can't convert negative int to unsigned
```

Both these cases should raise a `ValueError: the given slice is not supported by lazy computation` 