### PR TITLE
chore: remove try_apply_values

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -223,11 +223,6 @@ pub trait ChunkApply<'a, T> {
     where
         F: Fn(T) -> Self::FuncRet + Copy;
 
-    fn try_apply_values<F>(&'a self, f: F) -> PolarsResult<Self>
-    where
-        F: Fn(T) -> PolarsResult<Self::FuncRet> + Copy,
-        Self: Sized;
-
     /// Apply a closure elementwise including null values.
     #[must_use]
     fn apply<F>(&'a self, f: F) -> Self

--- a/crates/polars-ops/src/chunked_array/binary/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/binary/namespace.rs
@@ -73,14 +73,13 @@ pub trait BinaryNameSpaceImpl: AsBinary {
     fn hex_decode(&self, strict: bool) -> PolarsResult<BinaryChunked> {
         let ca = self.as_binary();
         if strict {
-            ca.try_apply_values(|s| {
-                let bytes = hex::decode(s).map_err(|_| {
+            ca.try_apply_nonnull_values_generic(|s| {
+                hex::decode(s).map_err(|_| {
                     polars_err!(
                         ComputeError:
                         "invalid `hex` encoding found; try setting `strict=false` to ignore"
                     )
-                })?;
-                Ok(bytes.into())
+                })
             })
         } else {
             Ok(ca.apply(|opt_s| opt_s.and_then(|s| hex::decode(s).ok().map(Cow::Owned))))
@@ -101,14 +100,13 @@ pub trait BinaryNameSpaceImpl: AsBinary {
     fn base64_decode(&self, strict: bool) -> PolarsResult<BinaryChunked> {
         let ca = self.as_binary();
         if strict {
-            ca.try_apply_values(|s| {
-                let bytes = general_purpose::STANDARD.decode(s).map_err(|_e| {
+            ca.try_apply_nonnull_values_generic(|s| {
+                general_purpose::STANDARD.decode(s).map_err(|_e| {
                     polars_err!(
                         ComputeError:
                         "invalid `base64` encoding found; try setting `strict=false` to ignore"
                     )
-                })?;
-                Ok(bytes.into())
+                })
             })
         } else {
             Ok(ca.apply(|opt_s| {

--- a/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
+++ b/crates/polars-ops/src/chunked_array/datetime/replace_time_zone.rs
@@ -86,7 +86,7 @@ pub fn impl_replace_time_zone_fast(
     to_tz: &chrono_tz::Tz,
 ) -> PolarsResult<Int64Chunked> {
     match ambiguous {
-        Some(ambiguous) => datetime.0.try_apply_values(|timestamp| {
+        Some(ambiguous) => datetime.0.try_apply_nonnull_values_generic(|timestamp| {
             let ndt = timestamp_to_datetime(timestamp);
             Ok(datetime_to_timestamp(
                 convert_to_naive_local(

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -194,7 +194,7 @@ fn apply_offsets_to_datetime(
 ) -> PolarsResult<Int64Chunked> {
     match (datetime.len(), offsets.len()) {
         (1, _) => match datetime.0.get(0) {
-            Some(dt) => offsets.try_apply_values_generic(|offset| {
+            Some(dt) => offsets.try_apply_nonnull_values_generic(|offset| {
                 offset_fn(&Duration::parse(offset), dt, time_zone)
             }),
             _ => Ok(Int64Chunked::full_null(datetime.0.name(), offsets.len())),
@@ -202,7 +202,7 @@ fn apply_offsets_to_datetime(
         (_, 1) => match offsets.get(0) {
             Some(offset) => datetime
                 .0
-                .try_apply_values(|v| offset_fn(&Duration::parse(offset), v, time_zone)),
+                .try_apply_nonnull_values_generic(|v| offset_fn(&Duration::parse(offset), v, time_zone)),
             _ => Ok(datetime.0.apply(|_| None)),
         },
         _ => try_binary_elementwise(datetime, offsets, |timestamp_opt, offset_opt| {

--- a/crates/polars-plan/src/dsl/function_expr/temporal.rs
+++ b/crates/polars-plan/src/dsl/function_expr/temporal.rs
@@ -200,9 +200,9 @@ fn apply_offsets_to_datetime(
             _ => Ok(Int64Chunked::full_null(datetime.0.name(), offsets.len())),
         },
         (_, 1) => match offsets.get(0) {
-            Some(offset) => datetime
-                .0
-                .try_apply_nonnull_values_generic(|v| offset_fn(&Duration::parse(offset), v, time_zone)),
+            Some(offset) => datetime.0.try_apply_nonnull_values_generic(|v| {
+                offset_fn(&Duration::parse(offset), v, time_zone)
+            }),
             _ => Ok(datetime.0.apply(|_| None)),
         },
         _ => try_binary_elementwise(datetime, offsets, |timestamp_opt, offset_opt| {

--- a/crates/polars-time/src/month_end.rs
+++ b/crates/polars-time/src/month_end.rs
@@ -52,7 +52,7 @@ impl PolarsMonthEnd for DatetimeChunked {
         };
         Ok(self
             .0
-            .try_apply_values(|t| {
+            .try_apply_nonnull_values_generic(|t| {
                 roll_forward(
                     t,
                     time_zone,
@@ -70,8 +70,8 @@ impl PolarsMonthEnd for DateChunked {
         const MSECS_IN_DAY: i64 = MILLISECONDS * SECONDS_IN_DAY;
         Ok(self
             .0
-            .try_apply_values(|t| {
-                Ok((roll_forward(
+            .try_apply_nonnull_values_generic(|t| {
+                PolarsResult::Ok((roll_forward(
                     MSECS_IN_DAY * t as i64,
                     None,
                     timestamp_ms_to_datetime,

--- a/crates/polars-time/src/month_end.rs
+++ b/crates/polars-time/src/month_end.rs
@@ -68,17 +68,16 @@ impl PolarsMonthEnd for DatetimeChunked {
 impl PolarsMonthEnd for DateChunked {
     fn month_end(&self, _time_zone: Option<&Tz>) -> PolarsResult<Self> {
         const MSECS_IN_DAY: i64 = MILLISECONDS * SECONDS_IN_DAY;
-        Ok(self
-            .0
-            .try_apply_nonnull_values_generic(|t| {
-                PolarsResult::Ok((roll_forward(
-                    MSECS_IN_DAY * t as i64,
-                    None,
-                    timestamp_ms_to_datetime,
-                    datetime_to_timestamp_ms,
-                    Duration::add_ms,
-                )? / MSECS_IN_DAY) as i32)
-            })?
-            .into_date())
+        let ret = self.0.try_apply_nonnull_values_generic(|t| {
+            let fwd = roll_forward(
+                MSECS_IN_DAY * t as i64,
+                None,
+                timestamp_ms_to_datetime,
+                datetime_to_timestamp_ms,
+                Duration::add_ms,
+            )?;
+            PolarsResult::Ok((fwd / MSECS_IN_DAY) as i32)
+        })?;
+        Ok(ret.into_date())
     }
 }

--- a/crates/polars-time/src/month_start.rs
+++ b/crates/polars-time/src/month_start.rs
@@ -92,16 +92,15 @@ impl PolarsMonthStart for DatetimeChunked {
 impl PolarsMonthStart for DateChunked {
     fn month_start(&self, _tz: Option<&Tz>) -> PolarsResult<Self> {
         const MSECS_IN_DAY: i64 = MILLISECONDS * SECONDS_IN_DAY;
-        Ok(self
-            .0
-            .try_apply_nonnull_values_generic(|t| {
-                PolarsResult::Ok((roll_backward(
-                    MSECS_IN_DAY * t as i64,
-                    None,
-                    timestamp_ms_to_datetime,
-                    datetime_to_timestamp_ms,
-                )? / MSECS_IN_DAY) as i32)
-            })?
-            .into_date())
+        let ret = self.0.try_apply_nonnull_values_generic(|t| {
+            let bwd = roll_backward(
+                MSECS_IN_DAY * t as i64,
+                None,
+                timestamp_ms_to_datetime,
+                datetime_to_timestamp_ms,
+            )?;
+            PolarsResult::Ok((bwd / MSECS_IN_DAY) as i32)
+        })?;
+        Ok(ret.into_date())
     }
 }

--- a/crates/polars-time/src/month_start.rs
+++ b/crates/polars-time/src/month_start.rs
@@ -82,7 +82,7 @@ impl PolarsMonthStart for DatetimeChunked {
         };
         Ok(self
             .0
-            .try_apply_values(|t| {
+            .try_apply_nonnull_values_generic(|t| {
                 roll_backward(t, tz, timestamp_to_datetime, datetime_to_timestamp)
             })?
             .into_datetime(self.time_unit(), self.time_zone().clone()))
@@ -94,8 +94,8 @@ impl PolarsMonthStart for DateChunked {
         const MSECS_IN_DAY: i64 = MILLISECONDS * SECONDS_IN_DAY;
         Ok(self
             .0
-            .try_apply_values(|t| {
-                Ok((roll_backward(
+            .try_apply_nonnull_values_generic(|t| {
+                PolarsResult::Ok((roll_backward(
                     MSECS_IN_DAY * t as i64,
                     None,
                     timestamp_ms_to_datetime,

--- a/crates/polars-time/src/round.rs
+++ b/crates/polars-time/src/round.rs
@@ -24,7 +24,7 @@ impl PolarsRound for DatetimeChunked {
             TimeUnit::Milliseconds => Window::round_ms,
         };
 
-        let out = { self.try_apply_values(|t| func(&w, t, tz)) };
+        let out = { self.try_apply_nonnull_values_generic(|t| func(&w, t, tz)) };
         out.map(|ok| ok.into_datetime(self.time_unit(), self.time_zone().clone()))
     }
 }
@@ -37,9 +37,9 @@ impl PolarsRound for DateChunked {
 
         let w = Window::new(every, every, offset);
         Ok(self
-            .try_apply_values(|t| {
+            .try_apply_nonnull_values_generic(|t| {
                 const MSECS_IN_DAY: i64 = MILLISECONDS * SECONDS_IN_DAY;
-                Ok((w.round_ms(MSECS_IN_DAY * t as i64, None)? / MSECS_IN_DAY) as i32)
+                PolarsResult::Ok((w.round_ms(MSECS_IN_DAY * t as i64, None)? / MSECS_IN_DAY) as i32)
             })?
             .into_date())
     }

--- a/crates/polars-time/src/truncate.rs
+++ b/crates/polars-time/src/truncate.rs
@@ -30,7 +30,7 @@ impl PolarsTruncate for DatetimeChunked {
                     }
 
                     let w = Window::new(every, every, offset);
-                    self.0.try_apply_values(|timestamp| func(&w, timestamp, tz))
+                    self.0.try_apply_nonnull_values_generic(|timestamp| func(&w, timestamp, tz))
                 } else {
                     Ok(Int64Chunked::full_null(self.name(), self.len()))
                 }
@@ -71,7 +71,7 @@ impl PolarsTruncate for DateChunked {
                     }
 
                     let w = Window::new(every, every, offset);
-                    self.try_apply_values(|t| {
+                    self.try_apply_nonnull_values_generic(|t| {
                         const MSECS_IN_DAY: i64 = MILLISECONDS * SECONDS_IN_DAY;
                         Ok((w.truncate_ms(MSECS_IN_DAY * t as i64, None)? / MSECS_IN_DAY) as i32)
                     })

--- a/crates/polars-time/src/truncate.rs
+++ b/crates/polars-time/src/truncate.rs
@@ -30,7 +30,8 @@ impl PolarsTruncate for DatetimeChunked {
                     }
 
                     let w = Window::new(every, every, offset);
-                    self.0.try_apply_nonnull_values_generic(|timestamp| func(&w, timestamp, tz))
+                    self.0
+                        .try_apply_nonnull_values_generic(|timestamp| func(&w, timestamp, tz))
                 } else {
                     Ok(Int64Chunked::full_null(self.name(), self.len()))
                 }


### PR DESCRIPTION
This method was essentially impossible to use correctly, as we would not want to propagate errors generated from mapping the values behind nulls.