### PR TITLE
chore(rust): More clippy in Makefile

### DIFF
--- a/crates/Makefile
+++ b/crates/Makefile
@@ -14,11 +14,11 @@ check:  ## Run cargo check with all features
 
 .PHONY: clippy
 clippy:  ## Run clippy with all features
-	cargo clippy -p polars --all-features -- -W clippy::dbg_macro
+	cargo clippy --all-targets --all-features -- -W clippy::dbg_macro
 
 .PHONY: clippy-default
 clippy-default:  ## Run clippy with default features
-	cargo clippy -p polars -- -W clippy::dbg_macro
+	cargo clippy --all-targets -- -W clippy::dbg_macro
 
 .PHONY: pre-commit
 pre-commit: fmt clippy clippy-default  ## Run autoformatting and linting


### PR DESCRIPTION
@ritchie46 This should have you (mostly) covered. If not, then we do have to use `stable`.