### PR TITLE
docs(python): Add "See Also" for `arg_sort` and `arg_sort_by`

### DIFF
--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2141,6 +2141,7 @@ class Expr:
         >>> df = pl.DataFrame(
         ...     {
         ...         "a": [20, 10, 30],
+        ...         "b": [1, 2, 3],
         ...     }
         ... )
         >>> df.select(pl.col("a").arg_sort())
@@ -2153,6 +2154,20 @@ class Expr:
         │ 1   │
         │ 0   │
         │ 2   │
+        └─────┘
+
+        Use gather to apply the arg sort to other columns.
+
+        >>> df.select(pl.col("b").gather(pl.col("a").arg_sort()))
+        shape: (3, 1)
+        ┌─────┐
+        │ b   │
+        │ --- │
+        │ i64 │
+        ╞═════╡
+        │ 2   │
+        │ 1   │
+        │ 3   │
         └─────┘
         """
         return self._from_pyexpr(self._pyexpr.arg_sort(descending, nulls_last))

--- a/py-polars/polars/expr/expr.py
+++ b/py-polars/polars/expr/expr.py
@@ -2131,6 +2131,11 @@ class Expr:
         Expr
             Expression of data type :class:`UInt32`.
 
+        See Also
+        --------
+        Expr.gather: Take values by index.
+        Expr.rank : Get the rank of each row.
+
         Examples
         --------
         >>> df = pl.DataFrame(

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1539,7 +1539,11 @@ def arg_sort_by(
     descending: bool | Sequence[bool] = False,
 ) -> Expr:
     """
-    Return the row indices that would sort the columns.
+    Return the row indices that would sort the column(s).
+
+    The first element is the index of the row that would be first if the data
+    frame were sorted by the column(s). The second element is the index of the
+    row that would be second if sorted, and so on.
 
     Parameters
     ----------
@@ -1551,6 +1555,11 @@ def arg_sort_by(
     descending
         Sort in descending order. When sorting by multiple columns, can be specified
         per column by passing a sequence of booleans.
+
+    See Also
+    --------
+    Expr.gather: Take values by index.
+    Expr.rank : Get the rank of each row.
 
     Examples
     --------

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1541,11 +1541,6 @@ def arg_sort_by(
     """
     Return the row indices that would sort the column(s).
 
-    The returned expression's first element is the index of the row with the
-    lowest value of `exprs` (or highest value if `descending=True`). This row
-    would be first if the dataframe were sorted on `exprs`. The second element
-    is the index of the row that would be second if sorted, and so on.
-
     Parameters
     ----------
     exprs
@@ -1570,6 +1565,7 @@ def arg_sort_by(
     ...     {
     ...         "a": [0, 1, 1, 0],
     ...         "b": [3, 2, 3, 2],
+    ...         "c": [1, 2, 3, 4],
     ...     }
     ... )
     >>> df.select(pl.arg_sort_by("a"))
@@ -1598,6 +1594,21 @@ def arg_sort_by(
     │ 2   │
     │ 1   │
     │ 0   │
+    │ 3   │
+    └─────┘
+
+    Use gather to apply the arg sort to other columns.
+
+    >>> df.select(pl.col("c").gather(pl.arg_sort_by("a")))
+    shape: (4, 1)
+    ┌─────┐
+    │ c   │
+    │ --- │
+    │ i64 │
+    ╞═════╡
+    │ 1   │
+    │ 4   │
+    │ 2   │
     │ 3   │
     └─────┘
     """

--- a/py-polars/polars/functions/lazy.py
+++ b/py-polars/polars/functions/lazy.py
@@ -1541,9 +1541,10 @@ def arg_sort_by(
     """
     Return the row indices that would sort the column(s).
 
-    The first element is the index of the row that would be first if the data
-    frame were sorted by the column(s). The second element is the index of the
-    row that would be second if sorted, and so on.
+    The returned expression's first element is the index of the row with the
+    lowest value of `exprs` (or highest value if `descending=True`). This row
+    would be first if the dataframe were sorted on `exprs`. The second element
+    is the index of the row that would be second if sorted, and so on.
 
     Parameters
     ----------

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -3459,6 +3459,11 @@ class Series:
         nulls_last
             Place null values last instead of first.
 
+        See Also
+        --------
+        Series.gather: Take values by index.
+        Series.rank : Get the rank of each row.
+
         Examples
         --------
         >>> s = pl.Series("a", [5, 3, 4, 1, 2])


### PR DESCRIPTION
Related to #15316.

I think that `arg_sort` and `arg_sort_by` can be a bit confusing in polars, since polars doesn't use much indexing. It might help the docs to link to a related `gather` method (to use `arg_sort` results) or a related `rank` method (which people might want instead of `arg_sort`).

I kept the "See Also" descriptions in line with the method's documentation, but they could reference `arg_sort`/`arg_sort_by` instead.