### PR TITLE
fix: `to_any_value` should supports all LiteralValue type

### DIFF
--- a/crates/polars-plan/src/logical_plan/lit.rs
+++ b/crates/polars-plan/src/logical_plan/lit.rs
@@ -117,9 +117,7 @@ impl LiteralValue {
             DateTime(v, tu, tz) => AnyValue::Datetime(*v, *tu, tz),
             #[cfg(feature = "dtype-time")]
             Time(v) => AnyValue::Time(*v),
-            Series(s) => {
-                AnyValue::List(s.0.clone().into_series())
-            },
+            Series(s) => AnyValue::List(s.0.clone().into_series()),
             Range {
                 low,
                 high,

--- a/py-polars/tests/unit/functions/test_repeat.py
+++ b/py-polars/tests/unit/functions/test_repeat.py
@@ -28,6 +28,8 @@ from polars.testing import assert_frame_equal, assert_series_equal
         (8, 2, pl.UInt8, pl.UInt8),
         (date(2023, 2, 2), 3, pl.Datetime, pl.Datetime),
         (7.5, 5, pl.UInt16, pl.UInt16),
+        ([1, 2, 3], 2, pl.List(pl.Int64), pl.List(pl.Int64)),
+        (b"ab12", 3, pl.Binary, pl.Binary),
     ],
 )
 def test_repeat(


### PR DESCRIPTION
This fixes #15379.