### PR TITLE
fix: Add FixedSizeBinary to arrow field conversion

### DIFF
--- a/crates/polars-core/src/datatypes/field.rs
+++ b/crates/polars-core/src/datatypes/field.rs
@@ -173,6 +173,7 @@ impl DataType {
                     DataType::BinaryOffset
                 }
             },
+            ArrowDataType::FixedSizeBinary(_) => DataType::Binary,
             dt => panic!("Arrow datatype {dt:?} not supported by Polars. You probably need to activate that data-type feature."),
         }
     }


### PR DESCRIPTION
fixes #15378