### PR TITLE
feat(rust, python): Add `null_on_oob` parameter to `expr.list.get`

### DIFF
--- a/crates/polars-arrow/src/legacy/kernels/list.rs
+++ b/crates/polars-arrow/src/legacy/kernels/list.rs
@@ -75,6 +75,13 @@ pub fn sublist_get(arr: &ListArray<i64>, index: i64) -> ArrayRef {
     unsafe { take_unchecked(&**values, &take_by) }
 }
 
+/// Check if an index is out of bounds for at least one sublist.
+pub fn index_is_oob(arr: &ListArray<i64>, index: i64) -> bool {
+    arr.offsets()
+        .lengths()
+        .any(|len| index.negative_to_usize(len).is_none())
+}
+
 /// Convert a list `[1, 2, 3]` to a list type of `[[1], [2], [3]]`
 pub fn array_to_unit_list(array: ArrayRef) -> ListArray<i64> {
     let len = array.len();

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -344,11 +344,13 @@ pub trait ListNameSpaceImpl: AsList {
     /// if an index is out of bounds, it will return a `None`.
     fn lst_get(&self, idx: i64, null_on_oob: bool) -> PolarsResult<Series> {
         let ca = self.as_list();
-        if !null_on_oob && ca
-            .iter()
-            .any(|sublist| {
-                sublist.and_then(|s| idx.negative_to_usize(s.len()).map(|idx| idx as IdxSize)).is_none()
-            }) {
+        if !null_on_oob
+            && ca.iter().any(|sublist| {
+                sublist
+                    .and_then(|s| idx.negative_to_usize(s.len()).map(|idx| idx as IdxSize))
+                    .is_none()
+            })
+        {
             polars_bail!(ComputeError: "get index is out of bounds");
         }
 

--- a/crates/polars-ops/src/chunked_array/list/to_struct.rs
+++ b/crates/polars-ops/src/chunked_array/list/to_struct.rs
@@ -72,7 +72,7 @@ pub trait ToStruct: AsList {
             (0..n_fields)
                 .into_par_iter()
                 .map(|i| {
-                    ca.lst_get(i as i64).map(|mut s| {
+                    ca.lst_get(i as i64, true).map(|mut s| {
                         s.rename(&name_generator(i));
                         s
                     })

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -21,7 +21,7 @@ pub enum ListFunction {
     },
     Slice,
     Shift,
-    Get,
+    Get(bool),
     #[cfg(feature = "list_gather")]
     Gather(bool),
     #[cfg(feature = "list_gather")]
@@ -71,7 +71,7 @@ impl ListFunction {
             Sample { .. } => mapper.with_same_dtype(),
             Slice => mapper.with_same_dtype(),
             Shift => mapper.with_same_dtype(),
-            Get => mapper.map_to_list_and_array_inner_dtype(),
+            Get(_) => mapper.map_to_list_and_array_inner_dtype(),
             #[cfg(feature = "list_gather")]
             Gather(_) => mapper.with_same_dtype(),
             #[cfg(feature = "list_gather")]
@@ -136,7 +136,7 @@ impl Display for ListFunction {
             },
             Slice => "slice",
             Shift => "shift",
-            Get => "get",
+            Get(_) => "get",
             #[cfg(feature = "list_gather")]
             Gather(_) => "gather",
             #[cfg(feature = "list_gather")]
@@ -203,9 +203,9 @@ impl From<ListFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             },
             Slice => wrap!(slice),
             Shift => map_as_slice!(shift),
-            Get => wrap!(get),
+            Get(null_on_oob) => wrap!(get, null_on_oob),
             #[cfg(feature = "list_gather")]
-            Gather(null_ob_oob) => map_as_slice!(gather, null_ob_oob),
+            Gather(null_on_oob) => map_as_slice!(gather, null_on_oob),
             #[cfg(feature = "list_gather")]
             GatherEvery => map_as_slice!(gather_every),
             #[cfg(feature = "list_count")]
@@ -414,7 +414,7 @@ pub(super) fn concat(s: &mut [Series]) -> PolarsResult<Option<Series>> {
     first_ca.lst_concat(other).map(|ca| Some(ca.into_series()))
 }
 
-pub(super) fn get(s: &mut [Series]) -> PolarsResult<Option<Series>> {
+pub(super) fn get(s: &mut [Series], null_on_oob: bool) -> PolarsResult<Option<Series>> {
     let ca = s[0].list()?;
     let index = s[1].cast(&DataType::Int64)?;
     let index = index.i64().unwrap();
@@ -423,7 +423,7 @@ pub(super) fn get(s: &mut [Series]) -> PolarsResult<Option<Series>> {
         1 => {
             let index = index.get(0);
             if let Some(index) = index {
-                ca.lst_get(index).map(Some)
+                ca.lst_get(index, null_on_oob).map(Some)
             } else {
                 Ok(Some(Series::full_null(
                     ca.name(),
@@ -441,18 +441,25 @@ pub(super) fn get(s: &mut [Series]) -> PolarsResult<Option<Series>> {
                 .into_iter()
                 .enumerate()
                 .map(|(i, opt_idx)| {
-                    opt_idx.and_then(|idx| {
-                        let (start, end) =
-                            unsafe { (*offsets.get_unchecked(i), *offsets.get_unchecked(i + 1)) };
-                        let offset = if idx >= 0 { start + idx } else { end + idx };
-                        if offset >= end || offset < start || start == end {
-                            None
-                        } else {
-                            Some(offset as IdxSize)
+                    match opt_idx {
+                        Some(idx) => {
+                            let (start, end) =
+                                unsafe { (*offsets.get_unchecked(i), *offsets.get_unchecked(i + 1)) };
+                            let offset = if idx >= 0 { start + idx } else { end + idx };
+                            if offset >= end || offset < start || start == end {
+                                if null_on_oob {
+                                    Ok(None)
+                                } else {
+                                    polars_bail!(ComputeError: "get index is out of bounds");
+                                }
+                            } else {
+                                Ok(Some(offset as IdxSize))
+                            }
                         }
-                    })
+                        None => Ok(None)
+                    }
                 })
-                .collect::<IdxCa>();
+                .collect::<Result<IdxCa, _>>()?;
             let s = Series::try_from((ca.name(), arr.values().clone())).unwrap();
             unsafe { s.take_unchecked(&take_by) }
                 .cast(&ca.inner_dtype())
@@ -475,7 +482,7 @@ pub(super) fn gather(args: &[Series], null_on_oob: bool) -> PolarsResult<Series>
     if idx.len() == 1 && null_on_oob {
         // fast path
         let idx = idx.get(0)?.try_extract::<i64>()?;
-        let out = ca.lst_get(idx)?;
+        let out = ca.lst_get(idx, null_on_oob)?;
         // make sure we return a list
         out.reshape(&[-1, 1])
     } else {

--- a/crates/polars-plan/src/dsl/function_expr/mod.rs
+++ b/crates/polars-plan/src/dsl/function_expr/mod.rs
@@ -718,6 +718,14 @@ macro_rules! wrap {
     ($e:expr) => {
         SpecialEq::new(Arc::new($e))
     };
+
+    ($e:expr, $($args:expr),*) => {{
+        let f = move |s: &mut [Series]| {
+            $e(s, $($args),*)
+        };
+
+        SpecialEq::new(Arc::new(f))
+    }};
 }
 
 // Fn(&[Series], args)

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -151,9 +151,9 @@ impl ListNameSpace {
     }
 
     /// Get items in every sublist by index.
-    pub fn get(self, index: Expr) -> Expr {
+    pub fn get(self, index: Expr, null_on_oob: bool) -> Expr {
         self.0.map_many_private(
-            FunctionExpr::ListExpr(ListFunction::Get),
+            FunctionExpr::ListExpr(ListFunction::Get(null_on_oob)),
             &[index],
             false,
             false,
@@ -187,12 +187,12 @@ impl ListNameSpace {
 
     /// Get first item of every sublist.
     pub fn first(self) -> Expr {
-        self.get(lit(0i64))
+        self.get(lit(0i64), false)
     }
 
     /// Get last item of every sublist.
     pub fn last(self) -> Expr {
-        self.get(lit(-1i64))
+        self.get(lit(-1i64), false)
     }
 
     /// Join all string items in a sublist and place a separator between them.

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -187,12 +187,12 @@ impl ListNameSpace {
 
     /// Get first item of every sublist.
     pub fn first(self) -> Expr {
-        self.get(lit(0i64), false)
+        self.get(lit(0i64), true)
     }
 
     /// Get last item of every sublist.
     pub fn last(self) -> Expr {
-        self.get(lit(-1i64), false)
+        self.get(lit(-1i64), true)
     }
 
     /// Join all string items in a sublist and place a separator between them.

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -987,7 +987,7 @@ impl SQLFunctionVisitor<'_> {
             // Array functions
             // ----
             ArrayContains => self.visit_binary::<Expr>(|e, s| e.list().contains(s)),
-            ArrayGet => self.visit_binary(|e, i| e.list().get(i)),
+            ArrayGet => self.visit_binary(|e, i| e.list().get(i, false)),
             ArrayLength => self.visit_unary(|e| e.list().len()),
             ArrayMax => self.visit_unary(|e| e.list().max()),
             ArrayMean => self.visit_unary(|e| e.list().mean()),

--- a/crates/polars-sql/src/functions.rs
+++ b/crates/polars-sql/src/functions.rs
@@ -987,7 +987,7 @@ impl SQLFunctionVisitor<'_> {
             // Array functions
             // ----
             ArrayContains => self.visit_binary::<Expr>(|e, s| e.list().contains(s)),
-            ArrayGet => self.visit_binary(|e, i| e.list().get(i, false)),
+            ArrayGet => self.visit_binary(|e, i| e.list().get(i, true)),
             ArrayLength => self.visit_unary(|e| e.list().len()),
             ArrayMax => self.visit_unary(|e| e.list().max()),
             ArrayMean => self.visit_unary(|e| e.list().mean()),

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -505,11 +505,12 @@ class ExprListNameSpace:
         other_list.insert(0, wrap_expr(self._pyexpr))
         return F.concat_list(other_list)
 
-    def get(self,
-            index: int | Expr | str,
-            *,
-            null_on_oob: bool = False,
-        ) -> Expr:
+    def get(
+        self,
+        index: int | Expr | str,
+        *,
+        null_on_oob: bool = False,
+    ) -> Expr:
         """
         Get the value by index in the sublists.
 
@@ -521,11 +522,15 @@ class ExprListNameSpace:
         ----------
         index
             Index to return per sublist
+        null_on_oob
+            Behavior if an index is out of bounds:
+            True -> set as null
+            False -> raise an error
 
         Examples
         --------
         >>> df = pl.DataFrame({"a": [[3, 2, 1], [], [1, 2]]})
-        >>> df.with_columns(get=pl.col("a").list.get(0))
+        >>> df.with_columns(get=pl.col("a").list.get(0, null_on_oob=True))
         shape: (3, 2)
         ┌───────────┬──────┐
         │ a         ┆ get  │
@@ -645,7 +650,7 @@ class ExprListNameSpace:
         │ [1, 2]    ┆ 1     │
         └───────────┴───────┘
         """
-        return self.get(0)
+        return self.get(0, null_on_oob=True)
 
     def last(self) -> Expr:
         """
@@ -666,7 +671,7 @@ class ExprListNameSpace:
         │ [1, 2]    ┆ 2    │
         └───────────┴──────┘
         """
-        return self.get(-1)
+        return self.get(-1, null_on_oob=True)
 
     def contains(
         self, item: float | str | bool | int | date | datetime | time | IntoExprColumn

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -509,7 +509,7 @@ class ExprListNameSpace:
         self,
         index: int | Expr | str,
         *,
-        null_on_oob: bool = False,
+        null_on_oob: bool = True,
     ) -> Expr:
         """
         Get the value by index in the sublists.
@@ -530,7 +530,7 @@ class ExprListNameSpace:
         Examples
         --------
         >>> df = pl.DataFrame({"a": [[3, 2, 1], [], [1, 2]]})
-        >>> df.with_columns(get=pl.col("a").list.get(0, null_on_oob=True))
+        >>> df.with_columns(get=pl.col("a").list.get(0))
         shape: (3, 2)
         ┌───────────┬──────┐
         │ a         ┆ get  │
@@ -650,7 +650,7 @@ class ExprListNameSpace:
         │ [1, 2]    ┆ 1     │
         └───────────┴───────┘
         """
-        return self.get(0, null_on_oob=True)
+        return self.get(0)
 
     def last(self) -> Expr:
         """
@@ -671,7 +671,7 @@ class ExprListNameSpace:
         │ [1, 2]    ┆ 2    │
         └───────────┴──────┘
         """
-        return self.get(-1, null_on_oob=True)
+        return self.get(-1)
 
     def contains(
         self, item: float | str | bool | int | date | datetime | time | IntoExprColumn

--- a/py-polars/polars/expr/list.py
+++ b/py-polars/polars/expr/list.py
@@ -505,7 +505,11 @@ class ExprListNameSpace:
         other_list.insert(0, wrap_expr(self._pyexpr))
         return F.concat_list(other_list)
 
-    def get(self, index: int | Expr | str) -> Expr:
+    def get(self,
+            index: int | Expr | str,
+            *,
+            null_on_oob: bool = False,
+        ) -> Expr:
         """
         Get the value by index in the sublists.
 
@@ -534,7 +538,7 @@ class ExprListNameSpace:
         └───────────┴──────┘
         """
         index = parse_as_expression(index)
-        return wrap_expr(self._pyexpr.list_get(index))
+        return wrap_expr(self._pyexpr.list_get(index, null_on_oob))
 
     def gather(
         self,

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -347,7 +347,12 @@ class ListNameSpace:
         ]
         """
 
-    def get(self, index: int | Series | list[int]) -> Series:
+    def get(
+        self,
+        index: int | Series | list[int],
+        *,
+        null_on_oob: bool = False,
+    ) -> Series:
         """
         Get the value by index in the sublists.
 
@@ -359,11 +364,15 @@ class ListNameSpace:
         ----------
         index
             Index to return per sublist
+        null_on_oob
+            Behavior if an index is out of bounds:
+            True -> set as null
+            False -> raise an error
 
         Examples
         --------
         >>> s = pl.Series("a", [[3, 2, 1], [], [1, 2]])
-        >>> s.list.get(0)
+        >>> s.list.get(0, null_on_oob=True)
         shape: (3,)
         Series: 'a' [i64]
         [

--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -351,7 +351,7 @@ class ListNameSpace:
         self,
         index: int | Series | list[int],
         *,
-        null_on_oob: bool = False,
+        null_on_oob: bool = True,
     ) -> Series:
         """
         Get the value by index in the sublists.

--- a/py-polars/src/expr/list.rs
+++ b/py-polars/src/expr/list.rs
@@ -44,8 +44,8 @@ impl PyExpr {
         self.inner.clone().list().eval(expr.inner, parallel).into()
     }
 
-    fn list_get(&self, index: PyExpr) -> Self {
-        self.inner.clone().list().get(index.inner).into()
+    fn list_get(&self, index: PyExpr, null_on_oob: bool) -> Self {
+        self.inner.clone().list().get(index.inner, null_on_oob).into()
     }
 
     fn list_join(&self, separator: PyExpr, ignore_nulls: bool) -> Self {

--- a/py-polars/src/expr/list.rs
+++ b/py-polars/src/expr/list.rs
@@ -45,7 +45,11 @@ impl PyExpr {
     }
 
     fn list_get(&self, index: PyExpr, null_on_oob: bool) -> Self {
-        self.inner.clone().list().get(index.inner, null_on_oob).into()
+        self.inner
+            .clone()
+            .list()
+            .get(index.inner, null_on_oob)
+            .into()
     }
 
     fn list_join(&self, separator: PyExpr, ignore_nulls: bool) -> Self {

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -781,7 +781,7 @@ def test_list_gather_null_struct_14927() -> None:
         {"index": [1], "col_0": [None], "field_0": [None]},
         schema={**df.schema, "field_0": pl.Float64},
     )
-    expr = pl.col("col_0").list.get(0).struct.field("field_0")
+    expr = pl.col("col_0").list.get(0, null_on_oob=True).struct.field("field_0")
     out = df.filter(pl.col("index") > 0).with_columns(expr)
     assert_frame_equal(out, expected)
 

--- a/py-polars/tests/unit/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/namespaces/list/test_list.py
@@ -21,7 +21,7 @@ def test_list_arr_get() -> None:
     assert_series_equal(out, expected)
     out = pl.select(pl.lit(a).list.first()).to_series()
     assert_series_equal(out, expected)
-
+    
     out = a.list.get(-1)
     expected = pl.Series("a", [3, 5, 9])
     assert_series_equal(out, expected)
@@ -30,10 +30,12 @@ def test_list_arr_get() -> None:
     out = pl.select(pl.lit(a).list.last()).to_series()
     assert_series_equal(out, expected)
 
-    # Out of bounds index.
-    out = a.list.get(3)
-    expected = pl.Series("a", [None, None, 9])
-    assert_series_equal(out, expected)
+    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+        a.list.get(3)
+        
+    b = pl.Series("b", [[1, 2, 3], [4], []])
+    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+        b.list.first()
 
     # Null index.
     out_df = a.to_frame().select(pl.col.a.list.get(pl.lit(None)))
@@ -41,14 +43,80 @@ def test_list_arr_get() -> None:
     assert_frame_equal(out_df, expected_df)
 
     a = pl.Series("a", [[1, 2, 3], [4, 5], [6, 7, 8, 9]])
-    out = a.list.get(-3)
+    
+    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+        a.list.get(-3)
+
+    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+        pl.DataFrame(
+            {"a": [[1], [2], [3], [4, 5, 6], [7, 8, 9], [None, 11]]}
+        ).with_columns(
+            [pl.col("a").list.get(i).alias(f"get_{i}") for i in range(4)]
+        ).to_dict(as_series=False)
+
+    # get by indexes where some are out of bounds
+    df = pl.DataFrame({"cars": [[1, 2, 3], [2, 3], [4], []], "indexes": [-2, 1, -3, 0]})
+
+    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+        df.select([pl.col("cars").list.get("indexes")]).to_dict(as_series=False)
+        
+    # exact on oob boundary
+    df = pl.DataFrame(
+        {
+            "index": [3, 3, 3],
+            "lists": [[3, 4, 5], [4, 5, 6], [7, 8, 9, 4]],
+        }
+    )
+
+    with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
+        df.select(pl.col("lists").list.get(3)).to_dict(as_series=False) == {
+            "lists": [None, None, 4]
+        }
+        df.select(pl.col("lists").list.get(pl.col("index"))).to_dict(
+            as_series=False
+        )
+    
+
+def test_list_arr_get_null_on_oob() -> None:
+    a = pl.Series("a", [[1, 2, 3], [4, 5], [6, 7, 8, 9]])
+    out = a.list.get(0, null_on_oob=True)
+    expected = pl.Series("a", [1, 4, 6])
+    assert_series_equal(out, expected)
+    out = a.list[0]
+    expected = pl.Series("a", [1, 4, 6])
+    assert_series_equal(out, expected)
+    out = a.list.first()
+    assert_series_equal(out, expected)
+    out = pl.select(pl.lit(a).list.first()).to_series()
+    assert_series_equal(out, expected)
+
+    out = a.list.get(-1, null_on_oob=True)
+    expected = pl.Series("a", [3, 5, 9])
+    assert_series_equal(out, expected)
+    out = a.list.last()
+    assert_series_equal(out, expected)
+    out = pl.select(pl.lit(a).list.last()).to_series()
+    assert_series_equal(out, expected)
+
+    # Out of bounds index.
+    out = a.list.get(3, null_on_oob=True)
+    expected = pl.Series("a", [None, None, 9])
+    assert_series_equal(out, expected)
+
+    # Null index.
+    out_df = a.to_frame().select(pl.col.a.list.get(pl.lit(None), null_on_oob=True))
+    expected_df = pl.Series("a", [None, None, None], dtype=pl.Int64).to_frame()
+    assert_frame_equal(out_df, expected_df)
+
+    a = pl.Series("a", [[1, 2, 3], [4, 5], [6, 7, 8, 9]])
+    out = a.list.get(-3, null_on_oob=True)
     expected = pl.Series("a", [1, None, 7])
     assert_series_equal(out, expected)
 
     assert pl.DataFrame(
         {"a": [[1], [2], [3], [4, 5, 6], [7, 8, 9], [None, 11]]}
     ).with_columns(
-        [pl.col("a").list.get(i).alias(f"get_{i}") for i in range(4)]
+        [pl.col("a").list.get(i, null_on_oob=True).alias(f"get_{i}") for i in range(4)]
     ).to_dict(as_series=False) == {
         "a": [[1], [2], [3], [4, 5, 6], [7, 8, 9], [None, 11]],
         "get_0": [1, 2, 3, 4, 7, None],
@@ -60,7 +128,7 @@ def test_list_arr_get() -> None:
     # get by indexes where some are out of bounds
     df = pl.DataFrame({"cars": [[1, 2, 3], [2, 3], [4], []], "indexes": [-2, 1, -3, 0]})
 
-    assert df.select([pl.col("cars").list.get("indexes")]).to_dict(as_series=False) == {
+    assert df.select([pl.col("cars").list.get("indexes", null_on_oob=True)]).to_dict(as_series=False) == {
         "cars": [2, 3, None, None]
     }
     # exact on oob boundary
@@ -71,10 +139,10 @@ def test_list_arr_get() -> None:
         }
     )
 
-    assert df.select(pl.col("lists").list.get(3)).to_dict(as_series=False) == {
+    assert df.select(pl.col("lists").list.get(3, null_on_oob=True)).to_dict(as_series=False) == {
         "lists": [None, None, 4]
     }
-    assert df.select(pl.col("lists").list.get(pl.col("index"))).to_dict(
+    assert df.select(pl.col("lists").list.get(pl.col("index"), null_on_oob=True)).to_dict(
         as_series=False
     ) == {"lists": [None, None, 4]}
 
@@ -88,7 +156,7 @@ def test_list_categorical_get() -> None:
         }
     )
     expected = pl.Series("actions", ["a", "c", None, None], dtype=pl.Categorical)
-    assert_series_equal(df["actions"].list.get(0), expected, categorical_as_str=True)
+    assert_series_equal(df["actions"].list.get(0, null_on_oob=True), expected, categorical_as_str=True)
 
 
 def test_contains() -> None:
@@ -156,8 +224,8 @@ def test_list_arr_empty() -> None:
 
     out = df.select(
         [
-            pl.col("cars").list.first().alias("cars_first"),
-            pl.when(pl.col("cars").list.first() == 2)
+            pl.col("cars").list.get(0, null_on_oob=True).alias("cars_first"),
+            pl.when(pl.col("cars").list.get(0, null_on_oob=True) == 2)
             .then(1)
             .when(pl.col("cars").list.contains(2))
             .then(2)
@@ -597,7 +665,7 @@ def test_select_from_list_to_struct_11143() -> None:
 
 def test_list_arr_get_8810() -> None:
     assert pl.DataFrame(pl.Series("a", [None], pl.List(pl.Int64))).select(
-        pl.col("a").list.get(0)
+        pl.col("a").list.get(0, null_on_oob=True)
     ).to_dict(as_series=False) == {"a": [None]}
 
 

--- a/py-polars/tests/unit/namespaces/list/test_list.py
+++ b/py-polars/tests/unit/namespaces/list/test_list.py
@@ -11,7 +11,7 @@ from polars.testing import assert_frame_equal, assert_series_equal
 
 def test_list_arr_get() -> None:
     a = pl.Series("a", [[1, 2, 3], [4, 5], [6, 7, 8, 9]])
-    out = a.list.get(0)
+    out = a.list.get(0, null_on_oob=False)
     expected = pl.Series("a", [1, 4, 6])
     assert_series_equal(out, expected)
     out = a.list[0]
@@ -22,7 +22,7 @@ def test_list_arr_get() -> None:
     out = pl.select(pl.lit(a).list.first()).to_series()
     assert_series_equal(out, expected)
 
-    out = a.list.get(-1)
+    out = a.list.get(-1, null_on_oob=False)
     expected = pl.Series("a", [3, 5, 9])
     assert_series_equal(out, expected)
     out = a.list.last()
@@ -31,30 +31,35 @@ def test_list_arr_get() -> None:
     assert_series_equal(out, expected)
 
     with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
-        a.list.get(3)
+        a.list.get(3, null_on_oob=False)
 
     # Null index.
-    out_df = a.to_frame().select(pl.col.a.list.get(pl.lit(None)))
+    out_df = a.to_frame().select(pl.col.a.list.get(pl.lit(None), null_on_oob=False))
     expected_df = pl.Series("a", [None, None, None], dtype=pl.Int64).to_frame()
     assert_frame_equal(out_df, expected_df)
 
     a = pl.Series("a", [[1, 2, 3], [4, 5], [6, 7, 8, 9]])
 
     with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
-        a.list.get(-3)
+        a.list.get(-3, null_on_oob=False)
 
     with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
         pl.DataFrame(
             {"a": [[1], [2], [3], [4, 5, 6], [7, 8, 9], [None, 11]]}
         ).with_columns(
-            [pl.col("a").list.get(i).alias(f"get_{i}") for i in range(4)]
-        ).to_dict(as_series=False)
+            [
+                pl.col("a").list.get(i, null_on_oob=False).alias(f"get_{i}")
+                for i in range(4)
+            ]
+        )
 
     # get by indexes where some are out of bounds
     df = pl.DataFrame({"cars": [[1, 2, 3], [2, 3], [4], []], "indexes": [-2, 1, -3, 0]})
 
     with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
-        df.select([pl.col("cars").list.get("indexes")]).to_dict(as_series=False)
+        df.select([pl.col("cars").list.get("indexes", null_on_oob=False)]).to_dict(
+            as_series=False
+        )
 
     # exact on oob boundary
     df = pl.DataFrame(
@@ -65,15 +70,15 @@ def test_list_arr_get() -> None:
     )
 
     with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
-        df.select(pl.col("lists").list.get(3)).to_dict(as_series=False)
+        df.select(pl.col("lists").list.get(3, null_on_oob=False))
 
     with pytest.raises(pl.ComputeError, match="get index is out of bounds"):
-        df.select(pl.col("lists").list.get(pl.col("index"))).to_dict(as_series=False)
+        df.select(pl.col("lists").list.get(pl.col("index"), null_on_oob=False))
 
 
 def test_list_arr_get_null_on_oob() -> None:
     a = pl.Series("a", [[1, 2, 3], [4, 5], [6, 7, 8, 9]])
-    out = a.list.first()
+    out = a.list.get(0, null_on_oob=True)
     expected = pl.Series("a", [1, 4, 6])
     assert_series_equal(out, expected)
     out = a.list[0]


### PR DESCRIPTION
Addresses first part of #15240 (first time contributing so I figured I'd add 1 and get feedback before embarking on the rest, especially as they don't seem to overlap as much as I'd expected.)

For now leaves the default behavior to `null_on_oob=True` (see discussion below; we will revisit the default behavior for once it has been implemented for all functions in #15240).