### PR TITLE
Remove xor that fixes the hash at 0 resulting in pathologically slow hashmap performance

### DIFF
--- a/crates/polars-core/src/hashing/vector_hasher.rs
+++ b/crates/polars-core/src/hashing/vector_hasher.rs
@@ -112,7 +112,7 @@ where
                 .iter()
                 .zip(&mut hashes[offset..])
                 .for_each(|(v, h)| {
-                    *h = folded_multiply(random_state.hash_one(v.to_total_ord()) ^ *h, MULTIPLE);
+                    *h = folded_multiply(random_state.hash_one(v.to_total_ord()), MULTIPLE);
                 }),
             _ => {
                 let validity = arr.validity().unwrap();
@@ -126,7 +126,7 @@ where
                         let to_hash = [null_h, lh][valid as usize];
 
                         // inlined from ahash. This ensures we combine with the previous state
-                        *h = folded_multiply(to_hash ^ *h, MULTIPLE);
+                        *h = folded_multiply(to_hash, MULTIPLE);
                     });
             },
         }


### PR DESCRIPTION
Not sure if this is the right fix, but it does fix the performance issues from the issue I was experiencing with multi column `over` expressions.

Closes https://github.com/pola-rs/polars/issues/15390

Perhaps the right fix is to pull out all the stuff inlined and just default to the hash crate's implementations directly?

Or perhaps it's an issue with randomstate... this mitigates the problem for me though.