### PR TITLE
fix: Hash failure combining hash of two numeric columns containing equal values

### DIFF
--- a/crates/polars-core/src/hashing/vector_hasher.rs
+++ b/crates/polars-core/src/hashing/vector_hasher.rs
@@ -113,6 +113,9 @@ where
                 .zip(&mut hashes[offset..])
                 .for_each(|(v, h)| {
                     *h = folded_multiply(
+                        // Inlined from ahash. This ensures we combine with the previous state.
+                        // Be careful not to xor the hash directly with the existing hash,
+                        // it would lead to 0-hashes for 2 columns containing equal values.
                         random_state.hash_one(v.to_total_ord()) ^ folded_multiply(*h, MULTIPLE),
                         MULTIPLE,
                     );
@@ -127,8 +130,6 @@ where
                     .for_each(|((valid, h), l)| {
                         let lh = random_state.hash_one(l.to_total_ord());
                         let to_hash = [null_h, lh][valid as usize];
-
-                        // inlined from ahash. This ensures we combine with the previous state
                         *h = folded_multiply(to_hash ^ folded_multiply(*h, MULTIPLE), MULTIPLE);
                     });
             },

--- a/crates/polars-core/src/hashing/vector_hasher.rs
+++ b/crates/polars-core/src/hashing/vector_hasher.rs
@@ -112,7 +112,10 @@ where
                 .iter()
                 .zip(&mut hashes[offset..])
                 .for_each(|(v, h)| {
-                    *h = folded_multiply(random_state.hash_one(v.to_total_ord()) ^ *h, MULTIPLE);
+                    *h = folded_multiply(
+                        random_state.hash_one(v.to_total_ord()) ^ folded_multiply(*h, MULTIPLE),
+                        MULTIPLE,
+                    );
                 }),
             _ => {
                 let validity = arr.validity().unwrap();
@@ -126,7 +129,7 @@ where
                         let to_hash = [null_h, lh][valid as usize];
 
                         // inlined from ahash. This ensures we combine with the previous state
-                        *h = folded_multiply(to_hash ^ *h, MULTIPLE);
+                        *h = folded_multiply(to_hash ^ folded_multiply(*h, MULTIPLE), MULTIPLE);
                     });
             },
         }

--- a/crates/polars-core/src/hashing/vector_hasher.rs
+++ b/crates/polars-core/src/hashing/vector_hasher.rs
@@ -112,8 +112,8 @@ where
                 .iter()
                 .zip(&mut hashes[offset..])
                 .for_each(|(v, h)| {
+                    // Inlined from ahash. This ensures we combine with the previous state.
                     *h = folded_multiply(
-                        // Inlined from ahash. This ensures we combine with the previous state.
                         // Be careful not to xor the hash directly with the existing hash,
                         // it would lead to 0-hashes for 2 columns containing equal values.
                         random_state.hash_one(v.to_total_ord()) ^ folded_multiply(*h, MULTIPLE),

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1441,6 +1441,28 @@ def test_reproducible_hash_with_seeds() -> None:
         assert_series_equal(expected, result, check_names=False, check_exact=True)
 
 
+@pytest.mark.slow()
+@pytest.mark.parametrize(
+    "e",
+    [
+        pl.int_range(1_000_000),
+        pl.when(pl.int_range(1_000_000) != 0).then(pl.int_range(1_000_000)),
+    ],
+)
+def test_hash_collision_multiple_columns_equal_values_15390(e: pl.Expr) -> None:
+    df = pl.select(e.alias("a"))
+
+    for n_columns in (1, 2, 3, 4):
+        s = df.with_columns(
+            pl.col("a").alias(f"x{i}") for i in range(n_columns)
+        ).hash_rows()
+
+        vc = s.sort().value_counts(sort=True)
+        max_bucket_size = vc["count"][0]
+
+        assert max_bucket_size == 1
+
+
 def test_hashing_on_python_objects() -> None:
     # see if we can do a group_by, drop_duplicates on a DataFrame with objects.
     # this requires that the hashing and aggregations are done on python objects

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -1446,6 +1446,7 @@ def test_reproducible_hash_with_seeds() -> None:
     "e",
     [
         pl.int_range(1_000_000),
+        # Test code path for null_count > 0
         pl.when(pl.int_range(1_000_000) != 0).then(pl.int_range(1_000_000)),
     ],
 )
@@ -1453,9 +1454,7 @@ def test_hash_collision_multiple_columns_equal_values_15390(e: pl.Expr) -> None:
     df = pl.select(e.alias("a"))
 
     for n_columns in (1, 2, 3, 4):
-        s = df.with_columns(
-            pl.col("a").alias(f"x{i}") for i in range(n_columns)
-        ).hash_rows()
+        s = df.select(pl.col("a").alias(f"x{i}") for i in range(n_columns)).hash_rows()
 
         vc = s.sort().value_counts(sort=True)
         max_bucket_size = vc["count"][0]


### PR DESCRIPTION
This apparently used to work before, ~~but how it did remains a mystery to me 🤔~~.

I think I know the story here - the previous combined vec hash must have done:

```
ahash_hash_one_specialized<T>(a) ^ ahash_hash_one_generic<&T>(&b)
```

when doing a combined hash. And since ahash gave different hash values for the ref, we avoided a collision even when `a == b`.

But after we switched to `total_ord`, we are now doing:

```
ahash_hash_one_specialized<T>(a) ^ ahash_hash_one_specialized<T>(b)
```

so we get `a == b  <=>  hash(a) == hash(b)`, so the xor would be 0.

This should fix https://github.com/pola-rs/polars/issues/15390, although I suspect we could eventually remove `vec_hash_combine` and dispatch to row-encoding instead.