### PR TITLE
feat(python): make Series.__bool__ error message Rusttier

### DIFF
--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -607,8 +607,12 @@ class Series:
     def __bool__(self) -> NoReturn:
         msg = (
             "the truth value of a Series is ambiguous"
-            "\n\nHint: use '&' or '|' to chain Series boolean results together, not and/or."
-            " To check if a Series contains any values, use `is_empty()`."
+            "\n\n"
+            "Here are some things you might want to try:\n"
+            "- instead of `if s`, use `if not s.is_empty()`\n"
+            "- instead of `s1 and s2`, use `s1 & s2`\n"
+            "- instead of `s1 or s2`, use `s1 | s2`\n"
+            "- instead of `s in [y, z]`, use `s.is_in([y, z])`\n"
         )
         raise TypeError(msg)
 


### PR DESCRIPTION
`Expr.__bool__` got a lot of love on Discord:

![image](https://github.com/pola-rs/polars/assets/33491632/7d397d3f-c551-4f91-a5be-20ae59867346)

Might be good to do the same for `Series.__bool__`?