### PR TITLE
perf: Add non-order preserving variable row-encoding

### DIFF
--- a/crates/polars-core/src/chunked_array/logical/struct_/mod.rs
+++ b/crates/polars-core/src/chunked_array/logical/struct_/mod.rs
@@ -9,10 +9,10 @@ use arrow::legacy::trusted_len::TrustedLenPush;
 use arrow::offset::OffsetsBuffer;
 use smartstring::alias::String as SmartString;
 
-use self::sort::arg_sort_multiple::_get_rows_encoded_ca;
 use super::*;
 use crate::chunked_array::iterator::StructIter;
 use crate::datatypes::*;
+use crate::prelude::sort::arg_sort_multiple::_get_rows_encoded_ca_unordered;
 use crate::utils::index_to_chunked_index;
 
 /// This is logical type [`StructChunked`] that
@@ -415,8 +415,7 @@ impl StructChunked {
     }
 
     pub fn rows_encode(&self) -> PolarsResult<BinaryOffsetChunked> {
-        let descending = vec![false; self.fields.len()];
-        _get_rows_encoded_ca(self.name(), &self.fields, &descending, false)
+        _get_rows_encoded_ca_unordered(self.name(), &self.fields)
     }
 
     pub fn iter(&self) -> StructIter {

--- a/crates/polars-core/src/frame/group_by/into_groups.rs
+++ b/crates/polars-core/src/frame/group_by/into_groups.rs
@@ -299,7 +299,6 @@ impl IntoGroupsProxy for BinaryChunked {
                     })
                     .collect::<Vec<_>>()
             });
-            let byte_hashes = byte_hashes.iter().collect::<Vec<_>>();
             group_by_threaded_slice(byte_hashes, n_partitions, sorted)
         } else {
             let byte_hashes = fill_bytes_hashes(self, null_h, hb.clone());

--- a/crates/polars-core/src/frame/group_by/mod.rs
+++ b/crates/polars-core/src/frame/group_by/mod.rs
@@ -23,7 +23,7 @@ pub use into_groups::*;
 pub use proxy::*;
 
 use crate::prelude::sort::arg_sort_multiple::{
-    encode_rows_default, encode_rows_vertical_par_default,
+    encode_rows_unordered, encode_rows_vertical_par_unordered,
 };
 
 impl DataFrame {
@@ -84,9 +84,9 @@ impl DataFrame {
                 })
             } else {
                 let rows = if multithreaded {
-                    encode_rows_vertical_par_default(&by)
+                    encode_rows_vertical_par_unordered(&by)
                 } else {
-                    encode_rows_default(&by)
+                    encode_rows_unordered(&by)
                 }?
                 .into_series();
                 rows.group_tuples(multithreaded, sorted)

--- a/crates/polars-pipe/src/executors/sinks/group_by/generic/eval.rs
+++ b/crates/polars-pipe/src/executors/sinks/group_by/generic/eval.rs
@@ -1,7 +1,7 @@
 use std::cell::UnsafeCell;
 
 use polars_core::export::ahash::RandomState;
-use polars_row::{RowsEncoded, SortField};
+use polars_row::{EncodingField, RowsEncoded};
 
 use super::*;
 use crate::executors::sinks::group_by::utils::prepare_key;
@@ -18,7 +18,7 @@ pub(super) struct Eval {
     aggregation_series: UnsafeCell<Vec<Series>>,
     keys_columns: UnsafeCell<Vec<ArrayRef>>,
     hashes: Vec<u64>,
-    key_fields: Vec<SortField>,
+    key_fields: Vec<EncodingField>,
     // amortizes the encoding buffers
     rows_encoded: RowsEncoded,
 }

--- a/crates/polars-row/src/decode.rs
+++ b/crates/polars-row/src/decode.rs
@@ -10,7 +10,7 @@ use crate::variable::{decode_binary, decode_binview};
 /// encodings.
 pub unsafe fn decode_rows_from_binary<'a>(
     arr: &'a BinaryArray<i64>,
-    fields: &[SortField],
+    fields: &[EncodingField],
     data_types: &[ArrowDataType],
     rows: &mut Vec<&'a [u8]>,
 ) -> Vec<ArrayRef> {
@@ -27,7 +27,7 @@ pub unsafe fn decode_rows_from_binary<'a>(
 pub unsafe fn decode_rows(
     // the rows will be updated while the data is decoded
     rows: &mut [&[u8]],
-    fields: &[SortField],
+    fields: &[EncodingField],
     data_types: &[ArrowDataType],
 ) -> Vec<ArrayRef> {
     assert_eq!(fields.len(), data_types.len());
@@ -38,7 +38,7 @@ pub unsafe fn decode_rows(
         .collect()
 }
 
-unsafe fn decode(rows: &mut [&[u8]], field: &SortField, data_type: &ArrowDataType) -> ArrayRef {
+unsafe fn decode(rows: &mut [&[u8]], field: &EncodingField, data_type: &ArrowDataType) -> ArrayRef {
     match data_type {
         ArrowDataType::Null => NullArray::new(ArrowDataType::Null, rows.len()).to_boxed(),
         ArrowDataType::Boolean => decode_bool(rows, field).to_boxed(),

--- a/crates/polars-row/src/encode.rs
+++ b/crates/polars-row/src/encode.rs
@@ -631,7 +631,7 @@ mod test {
         let out = out.into_array();
         assert_eq!(
             out.values().iter().map(|v| *v as usize).sum::<usize>(),
-            84981
+            82411
         );
     }
 }

--- a/crates/polars-row/src/fixed.rs
+++ b/crates/polars-row/src/fixed.rs
@@ -8,7 +8,7 @@ use arrow::types::NativeType;
 use polars_utils::slice::*;
 use polars_utils::total_ord::{canonical_f32, canonical_f64};
 
-use crate::row::{RowsEncoded, SortField};
+use crate::row::{EncodingField, RowsEncoded};
 
 pub(crate) trait FromSlice {
     fn from_slice(slice: &[u8]) -> Self;
@@ -168,7 +168,7 @@ fn encode_value<T: FixedLengthEncoding>(
 pub(crate) unsafe fn encode_slice<T: FixedLengthEncoding>(
     input: &[T],
     out: &mut RowsEncoded,
-    field: &SortField,
+    field: &EncodingField,
 ) {
     out.values.set_len(0);
     let values = out.values.spare_capacity_mut();
@@ -178,7 +178,7 @@ pub(crate) unsafe fn encode_slice<T: FixedLengthEncoding>(
 }
 
 #[inline]
-pub(crate) fn get_null_sentinel(field: &SortField) -> u8 {
+pub(crate) fn get_null_sentinel(field: &EncodingField) -> u8 {
     if field.nulls_last {
         0xFF
     } else {
@@ -189,7 +189,7 @@ pub(crate) fn get_null_sentinel(field: &SortField) -> u8 {
 pub(crate) unsafe fn encode_iter<I: Iterator<Item = Option<T>>, T: FixedLengthEncoding>(
     input: I,
     out: &mut RowsEncoded,
-    field: &SortField,
+    field: &EncodingField,
 ) {
     out.values.set_len(0);
     let values = out.values.spare_capacity_mut();
@@ -214,7 +214,7 @@ pub(crate) unsafe fn encode_iter<I: Iterator<Item = Option<T>>, T: FixedLengthEn
 
 pub(super) unsafe fn decode_primitive<T: NativeType + FixedLengthEncoding>(
     rows: &mut [&[u8]],
-    field: &SortField,
+    field: &EncodingField,
 ) -> PrimitiveArray<T>
 where
     T::Encoded: FromSlice,
@@ -255,7 +255,7 @@ where
     PrimitiveArray::new(data_type, values.into(), validity)
 }
 
-pub(super) unsafe fn decode_bool(rows: &mut [&[u8]], field: &SortField) -> BooleanArray {
+pub(super) unsafe fn decode_bool(rows: &mut [&[u8]], field: &EncodingField) -> BooleanArray {
     let mut has_nulls = false;
     let null_sentinel = get_null_sentinel(field);
 

--- a/crates/polars-row/src/lib.rs
+++ b/crates/polars-row/src/lib.rs
@@ -279,4 +279,4 @@ pub use encode::{
     convert_columns, convert_columns_amortized, convert_columns_amortized_no_order,
     convert_columns_no_order,
 };
-pub use row::{RowsEncoded, SortField};
+pub use row::{EncodingField, RowsEncoded};

--- a/crates/polars-row/src/row.rs
+++ b/crates/polars-row/src/row.rs
@@ -4,12 +4,32 @@ use arrow::datatypes::ArrowDataType;
 use arrow::ffi::mmap;
 use arrow::offset::{Offsets, OffsetsBuffer};
 
-#[derive(Clone, Default)]
-pub struct SortField {
+#[derive(Clone, Default, Copy)]
+pub struct EncodingField {
     /// Whether to sort in descending order
     pub descending: bool,
     /// Whether to sort nulls first
     pub nulls_last: bool,
+    /// Ignore all order-related flags and don't encode order-preserving.
+    /// This is faster for variable encoding as we can just memcopy all the bytes.
+    pub no_order: bool,
+}
+
+impl EncodingField {
+    pub fn new_sorted(descending: bool, nulls_last: bool) -> Self {
+        EncodingField {
+            descending,
+            nulls_last,
+            no_order: false,
+        }
+    }
+
+    pub fn new_unsorted() -> Self {
+        EncodingField {
+            no_order: true,
+            ..Default::default()
+        }
+    }
 }
 
 #[derive(Default, Clone)]


### PR DESCRIPTION
Optimize row-encoding for non-order preserving operations like group-by, join. By dropping that requirement we can simply memcopy the bytes and don't have to add padding bytes/blocks.