### PR TITLE
perf: Make LogicalPlan immutable

### DIFF
--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -751,7 +751,7 @@ impl LazyFrame {
     ) -> PolarsResult<()> {
         self.opt_state.streaming = true;
         self.logical_plan = LogicalPlan::Sink {
-            input: Box::new(self.logical_plan),
+            input: Arc::new(self.logical_plan),
             payload: SinkType::Cloud {
                 uri: Arc::new(uri),
                 cloud_options,
@@ -806,7 +806,7 @@ impl LazyFrame {
     fn sink(mut self, payload: SinkType, msg_alternative: &str) -> Result<(), PolarsError> {
         self.opt_state.streaming = true;
         self.logical_plan = LogicalPlan::Sink {
-            input: Box::new(self.logical_plan),
+            input: Arc::new(self.logical_plan),
             payload,
         };
         let (mut state, mut physical_plan, is_streaming) = self.prepare_collect(true)?;
@@ -1846,7 +1846,7 @@ impl LazyGroupBy {
         let options = GroupbyOptions { slice: None };
 
         let lp = LogicalPlan::Aggregate {
-            input: Box::new(self.logical_plan),
+            input: Arc::new(self.logical_plan),
             keys: Arc::new(self.keys),
             aggs: vec![],
             schema,

--- a/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
+++ b/crates/polars-lazy/src/physical_plan/executors/group_by_partitioned.rs
@@ -257,7 +257,7 @@ impl PartitionGroupByExec {
         }
         .into();
         let lp = LogicalPlan::Aggregate {
-            input: Box::new(original_df.lazy().logical_plan),
+            input: Arc::new(original_df.lazy().logical_plan),
             keys: Arc::new(std::mem::take(&mut self.keys)),
             aggs: std::mem::take(&mut self.aggs),
             schema: self.output_schema.clone(),

--- a/crates/polars-plan/src/logical_plan/mod.rs
+++ b/crates/polars-plan/src/logical_plan/mod.rs
@@ -135,12 +135,12 @@ pub enum LogicalPlan {
     PythonScan { options: PythonOptions },
     /// Filter on a boolean mask
     Selection {
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         predicate: Expr,
     },
     /// Cache the input at this point in the LP
     Cache {
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         id: usize,
         cache_hits: u32,
     },
@@ -164,13 +164,13 @@ pub enum LogicalPlan {
     /// Column selection
     Projection {
         expr: Vec<Expr>,
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         schema: SchemaRef,
         options: ProjectionOptions,
     },
     /// Groupby aggregation
     Aggregate {
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         keys: Arc<Vec<Expr>>,
         aggs: Vec<Expr>,
         schema: SchemaRef,
@@ -181,8 +181,8 @@ pub enum LogicalPlan {
     },
     /// Join operation
     Join {
-        input_left: Box<LogicalPlan>,
-        input_right: Box<LogicalPlan>,
+        input_left: Arc<LogicalPlan>,
+        input_right: Arc<LogicalPlan>,
         schema: SchemaRef,
         left_on: Vec<Expr>,
         right_on: Vec<Expr>,
@@ -190,31 +190,31 @@ pub enum LogicalPlan {
     },
     /// Adding columns to the table without a Join
     HStack {
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         exprs: Vec<Expr>,
         schema: SchemaRef,
         options: ProjectionOptions,
     },
     /// Remove duplicates from the table
     Distinct {
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         options: DistinctOptions,
     },
     /// Sort the table
     Sort {
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         by_column: Vec<Expr>,
         args: SortArguments,
     },
     /// Slice the table
     Slice {
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         offset: i64,
         len: IdxSize,
     },
     /// A (User Defined) Function
     MapFunction {
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         function: FunctionNode,
     },
     Union {
@@ -230,17 +230,17 @@ pub enum LogicalPlan {
     /// Catches errors and throws them later
     #[cfg_attr(feature = "serde", serde(skip))]
     Error {
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         err: ErrorState,
     },
     /// This allows expressions to access other tables
     ExtContext {
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         contexts: Vec<LogicalPlan>,
         schema: SchemaRef,
     },
     Sink {
-        input: Box<LogicalPlan>,
+        input: Arc<LogicalPlan>,
         payload: SinkType,
     },
 }


### PR DESCRIPTION
Started by @orlp for expressions. This finishes it for the LogicalPlan DSL. Query building performance is now `O(1)` instead of `O(n^2)`.