### PR TITLE
fix: datetime operations (e.g. .dt.year) were raising when null values were backed by out-of-range integers

### DIFF
--- a/crates/polars-arrow/src/compute/temporal.rs
+++ b/crates/polars-arrow/src/compute/temporal.rs
@@ -203,11 +203,8 @@ where
                 TimeUnit::Microsecond => timestamp_us_to_datetime,
                 TimeUnit::Nanosecond => timestamp_ns_to_datetime,
             };
-            Ok(PrimitiveArray::<O>::from(
-                array
-                    .iter()
-                    .map(|v| v.map(|x| op(func(*x))))
-                    .collect::<Vec<_>>(),
+            Ok(PrimitiveArray::<O>::from_iter(
+                array.iter().map(|v| v.map(|x| op(func(*x)))),
             ))
         },
         _ => unreachable!(),

--- a/crates/polars-arrow/src/compute/temporal.rs
+++ b/crates/polars-arrow/src/compute/temporal.rs
@@ -203,7 +203,12 @@ where
                 TimeUnit::Microsecond => timestamp_us_to_datetime,
                 TimeUnit::Nanosecond => timestamp_ns_to_datetime,
             };
-            Ok(unary(array, |x| op(func(x)), data_type))
+            Ok(PrimitiveArray::<O>::from(
+                array
+                    .iter()
+                    .map(|v| v.map(|x| op(func(*x))))
+                    .collect::<Vec<_>>(),
+            ))
         },
         _ => unreachable!(),
     }

--- a/crates/polars-arrow/src/compute/temporal.rs
+++ b/crates/polars-arrow/src/compute/temporal.rs
@@ -203,7 +203,7 @@ where
                 TimeUnit::Microsecond => timestamp_us_to_datetime,
                 TimeUnit::Nanosecond => timestamp_ns_to_datetime,
             };
-            Ok(PrimitiveArray::<O>::from_iter(
+            Ok(PrimitiveArray::<O>::from_trusted_len_iter(
                 array.iter().map(|v| v.map(|x| op(func(*x)))),
             ))
         },

--- a/crates/polars-arrow/src/temporal_conversions.rs
+++ b/crates/polars-arrow/src/temporal_conversions.rs
@@ -151,7 +151,7 @@ pub fn timestamp_s_to_datetime_opt(seconds: i64) -> Option<NaiveDateTime> {
 /// converts a `i64` representing a `timestamp(ms)` to [`NaiveDateTime`]
 #[inline]
 pub fn timestamp_ms_to_datetime(v: i64) -> NaiveDateTime {
-    timestamp_ms_to_datetime_opt(v).expect("invalid or out-of-range datetime")
+    timestamp_ms_to_datetime_opt(v).expect(&format!("invalid or out-of-range datetime: {v}"))
 }
 
 /// converts a `i64` representing a `timestamp(ms)` to [`NaiveDateTime`]
@@ -164,7 +164,7 @@ pub fn timestamp_ms_to_datetime_opt(v: i64) -> Option<NaiveDateTime> {
 /// converts a `i64` representing a `timestamp(us)` to [`NaiveDateTime`]
 #[inline]
 pub fn timestamp_us_to_datetime(v: i64) -> NaiveDateTime {
-    timestamp_us_to_datetime_opt(v).expect("invalid or out-of-range datetime")
+    timestamp_us_to_datetime_opt(v).expect(&format!("invalid or out-of-range datetime: {v}"))
 }
 
 /// converts a `i64` representing a `timestamp(us)` to [`NaiveDateTime`]
@@ -177,7 +177,7 @@ pub fn timestamp_us_to_datetime_opt(v: i64) -> Option<NaiveDateTime> {
 /// converts a `i64` representing a `timestamp(ns)` to [`NaiveDateTime`]
 #[inline]
 pub fn timestamp_ns_to_datetime(v: i64) -> NaiveDateTime {
-    timestamp_ns_to_datetime_opt(v).expect("invalid or out-of-range datetime")
+    timestamp_ns_to_datetime_opt(v).expect(&format!("invalid or out-of-range datetime: {v}"))
 }
 
 /// converts a `i64` representing a `timestamp(ns)` to [`NaiveDateTime`]

--- a/crates/polars-arrow/src/temporal_conversions.rs
+++ b/crates/polars-arrow/src/temporal_conversions.rs
@@ -151,7 +151,7 @@ pub fn timestamp_s_to_datetime_opt(seconds: i64) -> Option<NaiveDateTime> {
 /// converts a `i64` representing a `timestamp(ms)` to [`NaiveDateTime`]
 #[inline]
 pub fn timestamp_ms_to_datetime(v: i64) -> NaiveDateTime {
-    timestamp_ms_to_datetime_opt(v).expect(&format!("invalid or out-of-range datetime: {v}"))
+    timestamp_ms_to_datetime_opt(v).expect("invalid or out-of-range datetime")
 }
 
 /// converts a `i64` representing a `timestamp(ms)` to [`NaiveDateTime`]
@@ -164,7 +164,7 @@ pub fn timestamp_ms_to_datetime_opt(v: i64) -> Option<NaiveDateTime> {
 /// converts a `i64` representing a `timestamp(us)` to [`NaiveDateTime`]
 #[inline]
 pub fn timestamp_us_to_datetime(v: i64) -> NaiveDateTime {
-    timestamp_us_to_datetime_opt(v).expect(&format!("invalid or out-of-range datetime: {v}"))
+    timestamp_us_to_datetime_opt(v).expect("invalid or out-of-range datetime")
 }
 
 /// converts a `i64` representing a `timestamp(us)` to [`NaiveDateTime`]
@@ -177,7 +177,7 @@ pub fn timestamp_us_to_datetime_opt(v: i64) -> Option<NaiveDateTime> {
 /// converts a `i64` representing a `timestamp(ns)` to [`NaiveDateTime`]
 #[inline]
 pub fn timestamp_ns_to_datetime(v: i64) -> NaiveDateTime {
-    timestamp_ns_to_datetime_opt(v).expect(&format!("invalid or out-of-range datetime: {v}"))
+    timestamp_ns_to_datetime_opt(v).expect("invalid or out-of-range datetime")
 }
 
 /// converts a `i64` representing a `timestamp(ns)` to [`NaiveDateTime`]

--- a/py-polars/tests/unit/datatypes/test_temporal.py
+++ b/py-polars/tests/unit/datatypes/test_temporal.py
@@ -2683,6 +2683,19 @@ def test_infer_iso8601_date(iso8601_format_date: str) -> None:
     assert parsed.dt.day().item() == 13
 
 
+def test_year_null_backed_by_out_of_range_15313() -> None:
+    # Create a Series where the null value is backed by a value which would
+    # be out-of-range for Datetime('us')
+    s = pl.Series([None, 2**63 - 1])
+    s -= 2**63 - 1
+    result = s.cast(pl.Datetime).dt.year()
+    expected = pl.Series([None, 1970], dtype=pl.Int32)
+    assert_series_equal(result, expected)
+    result = s.cast(pl.Date).dt.year()
+    expected = pl.Series([None, 1970], dtype=pl.Int32)
+    assert_series_equal(result, expected)
+
+
 def test_series_is_temporal() -> None:
     for tp in TEMPORAL_DTYPES | {
         pl.Datetime("ms", "UTC"),


### PR DESCRIPTION
closes #15313