### PR TITLE
perf(python): CSV reading memory usage tests and fixes

### DIFF
--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -699,7 +699,12 @@ fn read_chunk(
     starting_point_offset: Option<usize>,
 ) -> PolarsResult<DataFrame> {
     let mut read = bytes_offset_thread;
-    let mut buffers = init_buffers(projection, capacity, schema, quote_char, encoding)?;
+    // There's an off-by-one error somewhere in the reading code, where it reads
+    // one more item than the requested capacity. Given the batch sizes are
+    // approximate (sometimes they're smaller), this isn't broken, but it does
+    // mean a bunch of extra allocation and copying. So we allocate a
+    // larger-by-one buffer so the size is more likely to be accurate.
+    let mut buffers = init_buffers(projection, capacity + 1, schema, quote_char, encoding)?;
 
     let mut last_read = usize::MAX;
     loop {

--- a/py-polars/src/batched_csv.rs
+++ b/py-polars/src/batched_csv.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::sync::Mutex;
 
 use polars::io::mmap::MmapBytesReader;
 use polars::io::RowIndex;
@@ -17,8 +18,7 @@ enum BatchedReader {
 #[pyclass]
 #[repr(transparent)]
 pub struct PyBatchedCsv {
-    // option because we cannot get a self by value in pyo3
-    reader: BatchedReader,
+    reader: Mutex<BatchedReader>,
 }
 
 #[pymethods]
@@ -132,15 +132,19 @@ impl PyBatchedCsv {
             BatchedReader::MMap(reader)
         };
 
-        Ok(PyBatchedCsv { reader })
+        Ok(PyBatchedCsv {
+            reader: Mutex::new(reader),
+        })
     }
 
-    fn next_batches(&mut self, n: usize) -> PyResult<Option<Vec<PyDataFrame>>> {
-        let batches = match &mut self.reader {
-            BatchedReader::MMap(reader) => reader.next_batches(n),
-            BatchedReader::Read(reader) => reader.next_batches(n),
-        }
-        .map_err(PyPolarsErr::from)?;
+    fn next_batches(&mut self, py: Python, n: usize) -> PyResult<Option<Vec<PyDataFrame>>> {
+        let reader = self.reader.get_mut().map_err(|e| PyPolarsErr::Other(e.to_string()))?;
+        let batches = py
+            .allow_threads(move || match reader {
+                BatchedReader::MMap(reader) => reader.next_batches(n),
+                BatchedReader::Read(reader) => reader.next_batches(n),
+            })
+            .map_err(PyPolarsErr::from)?;
 
         // SAFETY: same memory layout
         let batches = unsafe {

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -2013,7 +2013,7 @@ def test_read_csv_only_loads_selected_columns(
 
     # read_csv_batched() test:
     memory_usage_without_pyarrow.reset_tracking()
-    result = []
+    result: list[pl.DataFrame] = []
     batched = pl.read_csv_batched(
         str(file_path),
         columns=["b"],

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from polars.type_aliases import TimeUnit
+    from tests.unit.conftest import MemoryUsage
 
 
 @pytest.fixture()
@@ -1969,3 +1970,41 @@ def test_read_csv_single_column(columns: list[str] | str) -> None:
 def test_csv_invalid_escape_utf8_14960() -> None:
     with pytest.raises(pl.ComputeError, match=r"field is not properly escaped"):
         pl.read_csv('col1\n""•'.encode())
+
+
+@pytest.mark.slow()
+@pytest.mark.write_disk()
+def test_read_csv_only_loads_selected_columns_15098(
+    memory_usage_without_pyarrow: MemoryUsage, tmp_path: Path
+) -> None:
+    """Only requested columns are loaded by ``read_csv()``."""
+    tmp_path.mkdir(exist_ok=True)
+
+    # Each column will be about 8MB of RAM
+    series = pl.arange(0, 1_000_000, dtype=pl.Int64, eager=True)
+
+    file_path = tmp_path / "multicolumn.csv"
+    df = pl.DataFrame(
+        {
+            "a": series,
+            "b": series,
+        }
+    )
+    df.write_csv(file_path)
+    del df, series
+
+    memory_usage_without_pyarrow.reset_tracking()
+
+    # Only load one column:
+    df = pl.read_csv(str(file_path), columns=["b"], rechunk=False)
+    del df
+    # Only one column's worth of memory should be used; 2 columns would be
+    # 16_000_000 at least, but there's some overhead.
+    assert 8_000_000 < memory_usage_without_pyarrow.get_peak() < 13_000_000
+
+    # Globs use a different code path for reading:
+    df = pl.read_csv(str(tmp_path / "*.csv"), columns=["b"], rechunk=False)
+    del df
+    # Only one column's worth of memory should be used; 2 columns would be
+    # 16_000_000 at least, but there's some overhead.
+    assert 8_000_000 < memory_usage_without_pyarrow.get_peak() < 13_000_000

--- a/py-polars/tests/unit/io/test_parquet.py
+++ b/py-polars/tests/unit/io/test_parquet.py
@@ -791,6 +791,7 @@ def test_parquet_array_statistics(tmp_path: Path) -> None:
     assert result.to_dict(as_series=False) == {"a": [[4, 5, 6], [7, 8, 9]], "b": [2, 3]}
 
 
+@pytest.mark.slow()
 @pytest.mark.write_disk()
 def test_read_parquet_only_loads_selected_columns_15098(
     memory_usage_without_pyarrow: MemoryUsage, tmp_path: Path


### PR DESCRIPTION
Fixes #15374 

* Add tests for memory usage of read_csv() and read_csv_batched()
* Add GIL removal for read_csv_batched(). Necessary for the tests, but also worth doing in general.
* Fixed minor performance/memory bug caused by the fact that if you set `batch_size=1000` the CSV code will read 1001 lines. The underlying buffer will only have size 1000, so this results in extra allocations and copying once you hit that last 1001th line being read into a buffer. To workaround this, the buffer size is made 1 larger than the nominal requested capacity.

For the last item, the ideal would be to fix the underlying off by one bug instead. The obvious cause would appear to be https://github.com/pola-rs/polars/blob/b0ece1e97aec58ab7ab7ce5a29e73c1dc54baa5c/crates/polars-io/src/csv/parser.rs#L449, where the `>` should really be `>=`. However, changing this didn't make the test pass, it still had extra memory allocations, so not sure what's going on.