### PR TITLE
fix(python): Raise if pass a negative `n` into `clear`

### DIFF
--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6913,7 +6913,7 @@ class DataFrame:
         └──────┴──────┴──────┘
         """
         if n < 0:
-            msg = "n should be greater than or equal to 0."
+            msg = f"`n` should be greater than or equal to 0, got {n}"
             raise ValueError(msg)
         # faster path
         if n == 0:

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -6912,17 +6912,18 @@ class DataFrame:
         │ null ┆ null ┆ null │
         └──────┴──────┴──────┘
         """
+        if n < 0:
+            msg = "n should be greater than or equal to 0."
+            raise ValueError(msg)
         # faster path
         if n == 0:
             return self._from_pydf(self._df.clear())
-        if n > 0 or len(self) > 0:
-            return self.__class__(
-                {
-                    nm: pl.Series(name=nm, dtype=tp).extend_constant(None, n)
-                    for nm, tp in self.schema.items()
-                }
-            )
-        return self.clone()
+        return self.__class__(
+            {
+                nm: pl.Series(name=nm, dtype=tp).extend_constant(None, n)
+                for nm, tp in self.schema.items()
+            }
+        )
 
     def clone(self) -> Self:
         """

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4759,6 +4759,10 @@ class Series:
             null
         ]
         """
+        if n < 0:
+            msg = "n should be greater than or equal to 0."
+            raise ValueError(msg)
+        # faster path
         if n == 0:
             return self._from_pyseries(self._s.clear())
         s = (

--- a/py-polars/polars/series/series.py
+++ b/py-polars/polars/series/series.py
@@ -4760,7 +4760,7 @@ class Series:
         ]
         """
         if n < 0:
-            msg = "n should be greater than or equal to 0."
+            msg = f"`n` should be greater than or equal to 0, got {n}"
             raise ValueError(msg)
         # faster path
         if n == 0:

--- a/py-polars/tests/unit/operations/test_clear.py
+++ b/py-polars/tests/unit/operations/test_clear.py
@@ -73,3 +73,13 @@ def test_clear_series_object_starting_with_null() -> None:
     assert result.dtype == s.dtype
     assert result.name == s.name
     assert result.is_empty()
+
+
+def test_clear_raise_negative_n() -> None:
+    s = pl.Series([1, 2, 3])
+    with pytest.raises(ValueError, match="n should be greater than or equal to 0"):
+        s.clear(-1)
+
+    df = pl.DataFrame({"a": [1, 2, 3]})
+    with pytest.raises(ValueError, match="n should be greater than or equal to 0"):
+        df.clear(-1)

--- a/py-polars/tests/unit/operations/test_clear.py
+++ b/py-polars/tests/unit/operations/test_clear.py
@@ -77,9 +77,9 @@ def test_clear_series_object_starting_with_null() -> None:
 
 def test_clear_raise_negative_n() -> None:
     s = pl.Series([1, 2, 3])
-    with pytest.raises(ValueError, match="n should be greater than or equal to 0"):
-        s.clear(-1)
 
-    df = pl.DataFrame({"a": [1, 2, 3]})
-    with pytest.raises(ValueError, match="n should be greater than or equal to 0"):
-        df.clear(-1)
+    msg = "`n` should be greater than or equal to 0, got -1"
+    with pytest.raises(ValueError, match=msg):
+        s.clear(-1)
+    with pytest.raises(ValueError, match=msg):
+        s.to_frame().clear(-1)


### PR DESCRIPTION
This aligns the behavior of `series.clear(-1)` and `df.clear(-1)`. 

NB. Before this change, the error of `df.clear(-1)` is raised from the `extend_constant`(pass a negative n), I think a more explicit error would be nice.

The only difference is that for an empty series, passing a negative `n` does not throw an error before this change. I feel like it makes the function behave a bit more predictable if we reject `n < 0` outright, WDYT?

This fixes #15421.

