### PR TITLE
fix(rust,python): Handle NamedTuples in any_value

### DIFF
--- a/py-polars/src/conversion/any_value.rs
+++ b/py-polars/src/conversion/any_value.rs
@@ -319,10 +319,8 @@ pub(crate) fn py_object_to_any_value(ob: &PyAny, strict: bool) -> PyResult<AnyVa
 
     fn get_struct(ob: &PyAny, strict: bool) -> PyResult<AnyValue<'_>> {
         let dict = if ob.hasattr(intern!(ob.py(), "_asdict")).unwrap() {
-            // let ob_dict: &PyAny = Python::with_gil(|py| {
             let convert: &PyAny = ob.getattr(intern!(ob.py(), "_asdict")).unwrap();
             let ob_dict = convert.call0().unwrap();
-            // });
             ob_dict.downcast::<PyDict>().unwrap()
         } else {
             ob.downcast::<PyDict>().unwrap()

--- a/py-polars/src/conversion/any_value.rs
+++ b/py-polars/src/conversion/any_value.rs
@@ -259,7 +259,6 @@ pub(crate) fn py_object_to_any_value(ob: &PyAny, strict: bool) -> PyResult<AnyVa
     }
 
     fn get_list(ob: &PyAny, strict: bool) -> PyResult<AnyValue> {
-
         fn get_list_with_constructor(ob: &PyAny) -> PyResult<AnyValue> {
             // Use the dedicated constructor.
             // This constructor is able to go via dedicated type constructors
@@ -272,7 +271,7 @@ pub(crate) fn py_object_to_any_value(ob: &PyAny, strict: bool) -> PyResult<AnyVa
 
         if ob.is_empty()? {
             Ok(AnyValue::List(Series::new_empty("", &DataType::Null)))
-        } else if ob.is_instance_of::<PyList>() | ob.is_instance_of::<PyTuple>() {            
+        } else if ob.is_instance_of::<PyList>() | ob.is_instance_of::<PyTuple>() {
             const INFER_SCHEMA_LENGTH: usize = 25;
 
             let list = ob.downcast::<PySequence>().unwrap();
@@ -308,7 +307,6 @@ pub(crate) fn py_object_to_any_value(ob: &PyAny, strict: bool) -> PyResult<AnyVa
                 Ok(AnyValue::List(s))
             }
         } else {
-
             // range will take this branch
             get_list_with_constructor(ob)
         }
@@ -373,7 +371,9 @@ pub(crate) fn py_object_to_any_value(ob: &PyAny, strict: bool) -> PyResult<AnyVa
             get_str
         } else if ob.is_instance_of::<PyBytes>() {
             get_bytes
-        } else if ob.is_instance_of::<PyList>() || (ob.is_instance_of::<PyTuple>() & ob_as_dict.not()) {
+        } else if ob.is_instance_of::<PyList>()
+            || (ob.is_instance_of::<PyTuple>() & ob_as_dict.not())
+        {
             get_list
         } else if ob.is_instance_of::<PyDict>() || ob_as_dict {
             get_struct

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3191,13 +3191,13 @@ def test_named_tuples() -> None:
         name: str
         description: str
 
-    def event_table(num: int) -> list[Event]:
+    def some_func(num: int) -> list[Event]:
         return [Event("name", "desc") for _ in range(num)]
 
     data = {"events": [0, 1, 2]}
     df = pl.DataFrame(data).select(
         events=pl.col("events").map_elements(
-            event_table,
+            some_func,
             return_dtype=pl.List(
                 pl.Struct({"name": pl.String, "description": pl.String})
             ),

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3191,16 +3191,12 @@ def test_named_tuples() -> None:
         name: str
         description: str
 
-    def some_func(num: int) -> list[Event]:
-        return [Event("name", "desc") for _ in range(num)]
-
+    this_dtype = pl.List(pl.Struct({"name": pl.String, "description": pl.String}))
     data = {"events": [0, 1, 2]}
     df = pl.DataFrame(data).select(
         events=pl.col("events").map_elements(
-            some_func,
-            return_dtype=pl.List(
-                pl.Struct({"name": pl.String, "description": pl.String})
-            ),
+            lambda num: [Event("name", "desc") for _ in range(num)],
+            return_dtype=this_dtype,
         )
     )
     expected = pl.DataFrame(
@@ -3215,7 +3211,7 @@ def test_named_tuples() -> None:
                         {"name": "name", "description": "desc"},
                     ],
                 ],
-                dtype=pl.List(pl.Struct({"name": pl.String, "description": pl.String})),
+                dtype=this_dtype,
             ),
         ]
     )

--- a/py-polars/tests/unit/dataframe/test_df.py
+++ b/py-polars/tests/unit/dataframe/test_df.py
@@ -3191,7 +3191,7 @@ def test_named_tuples() -> None:
         name: str
         description: str
 
-    def event_table(num) -> list[Event]:
+    def event_table(num: int) -> list[Event]:
         return [Event("name", "desc") for _ in range(num)]
 
     data = {"events": [0, 1, 2]}


### PR DESCRIPTION
addresses https://github.com/pola-rs/polars/issues/15425

The issue is that their input is a nested NamedTuple which gets checked as a Tuple by rust and then treated as a list. I saw there was already python code that checks for NamedTuples but in this case it's nested so the python code doesn't see it and is handled by rust.
