### PR TITLE
fix(rust,python): Allow selectors inside frame-level `.filter()`

### DIFF
--- a/crates/polars-plan/src/logical_plan/builder.rs
+++ b/crates/polars-plan/src/logical_plan/builder.rs
@@ -622,6 +622,7 @@ impl LogicalPlanBuilder {
         let predicate = if has_expr(&predicate, |e| match e {
             Expr::Column(name) => is_regex_projection(name),
             Expr::Wildcard
+            | Expr::Selector(_)
             | Expr::RenameAlias { .. }
             | Expr::Columns(_)
             | Expr::DtypeColumn(_)

--- a/py-polars/tests/unit/operations/test_filter.py
+++ b/py-polars/tests/unit/operations/test_filter.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 import polars as pl
+import polars.selectors as cs
 from polars import PolarsDataType
 from polars.testing import assert_frame_equal, assert_series_equal
 
@@ -239,6 +240,15 @@ def test_filter_logical_type_13194() -> None:
             "cat": pl.List(pl.Categorical),
         },
     )
+    assert_frame_equal(df, expected_df)
+
+
+def test_filter_horizontal_selector_15428() -> None:
+    df = pl.DataFrame({"a": [1, 2, 3]})
+
+    df = df.filter(pl.all_horizontal((cs.by_name("^.*$") & cs.integer()) <= 2))
+    expected_df = pl.DataFrame({"a": [1, 2]})
+
     assert_frame_equal(df, expected_df)
 
 


### PR DESCRIPTION
Fix #15428 
Fix #15103