### PR TITLE
docs(python): Add example for `Series.list.median`.

### DIFF
--- a/py-polars/polars/series/list.py
+++ b/py-polars/polars/series/list.py
@@ -234,7 +234,20 @@ class ListNameSpace:
         """
 
     def median(self) -> Series:
-        """Compute the median value of the arrays in the list."""
+        """
+        Compute the median value of the arrays in the list.
+
+        Examples
+        --------
+        >>> s = pl.Series("values", [[-1, 0, 1], [1, 10]])
+        >>> s.list.median()
+        shape: (2,)
+        Series: 'values' [f64]
+        [
+                0.0
+                5.5
+        ]
+        """
 
     def std(self, ddof: int = 1) -> Series:
         """


### PR DESCRIPTION
A portion of #13161 

Adding an example for `Series.list.median`.