### PR TITLE
feat: Implement `string`, `boolean` and `binary` dtype in `top_k`

### DIFF
--- a/crates/polars-arrow/src/array/boolean/mutable.rs
+++ b/crates/polars-arrow/src/array/boolean/mutable.rs
@@ -195,11 +195,15 @@ impl MutableBooleanArray {
         }
     }
 
+    /// Extends `MutableBooleanArray` by additional values of constant value.
     #[inline]
     pub fn extend_constant(&mut self, additional: usize, value: Option<bool>) {
         match value {
             Some(value) => {
                 self.values.extend_constant(additional, value);
+                if let Some(validity) = self.validity.as_mut() {
+                    validity.extend_constant(additional, true);
+                }
             },
             None => {
                 self.values.extend_constant(additional, false);

--- a/crates/polars-arrow/src/array/boolean/mutable.rs
+++ b/crates/polars-arrow/src/array/boolean/mutable.rs
@@ -195,6 +195,27 @@ impl MutableBooleanArray {
         }
     }
 
+    #[inline]
+    pub fn extend_constant(&mut self, additional: usize, value: Option<bool>) {
+        match value {
+            Some(value) => {
+                self.values.extend_constant(additional, value);
+            },
+            None => {
+                self.values.extend_constant(additional, false);
+                if let Some(validity) = self.validity.as_mut() {
+                    validity.extend_constant(additional, false)
+                } else {
+                    self.init_validity();
+                    self.validity
+                        .as_mut()
+                        .unwrap()
+                        .extend_constant(additional, false)
+                };
+            },
+        };
+    }
+
     fn init_validity(&mut self) {
         let mut validity = MutableBitmap::with_capacity(self.values.capacity());
         validity.extend_constant(self.len(), true);

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -183,9 +183,9 @@ pub fn top_k(s: &[Series], descending: bool) -> PolarsResult<Series> {
             Ok(top_k_bool_impl(s.bool().unwrap(), k as usize, descending).into_series())
         },
         DataType::String => {
-            top_k_binary_impl(&s.str().unwrap().as_binary(), k as usize, descending)
-                .into_series()
-                .cast(origin_dtype)
+            let ca = top_k_binary_impl(&s.str().unwrap().as_binary(), k as usize, descending);
+            let ca = unsafe { ca.to_string() };
+            Ok(ca.into_series())
         },
         DataType::Binary => {
             Ok(top_k_binary_impl(s.binary().unwrap(), k as usize, descending).into_series())

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -1,48 +1,4 @@
-use either::Either;
-use polars_core::downcast_as_macro_arg_physical;
 use polars_core::prelude::*;
-use polars_utils::total_ord::TotalOrd;
-
-fn arg_partition<T: TotalOrd>(v: &mut [T], k: usize, descending: bool) -> &[T] {
-    let (lower, _el, upper) = v.select_nth_unstable_by(k, TotalOrd::tot_cmp);
-    if descending {
-        lower.sort_unstable_by(|a, b| a.tot_cmp(b));
-        lower
-    } else {
-        upper.sort_unstable_by(|a, b| b.tot_cmp(a));
-        upper
-    }
-}
-
-fn top_k_impl<T>(ca: &ChunkedArray<T>, k: usize, descending: bool) -> ChunkedArray<T>
-where
-    T: PolarsNumericType,
-    ChunkedArray<T>: ChunkSort<T>,
-{
-    if k >= ca.len() {
-        return ca.sort(!descending);
-    }
-
-    // descending is opposite from sort as top-k returns largest
-    let k = if descending {
-        std::cmp::min(k, ca.len())
-    } else {
-        ca.len().saturating_sub(k + 1)
-    };
-
-    match ca.to_vec_null_aware() {
-        Either::Left(mut v) => {
-            let values = arg_partition(&mut v, k, descending);
-            ChunkedArray::from_slice(ca.name(), values)
-        },
-        Either::Right(mut v) => {
-            let values = arg_partition(&mut v, k, descending);
-            let mut out = ChunkedArray::from_iter(values.iter().copied());
-            out.rename(ca.name());
-            out
-        },
-    }
-}
 
 pub fn top_k(s: &[Series], descending: bool) -> PolarsResult<Series> {
     let src = &s[0];
@@ -54,24 +10,16 @@ pub fn top_k(s: &[Series], descending: bool) -> PolarsResult<Series> {
 
     polars_ensure!(
         k_s.len() == 1,
-        ComputeError: "k must be a single value."
+        ComputeError: "`k` must be a single value for `top_k`."
     );
 
     let k_s = k_s.cast(&IDX_DTYPE)?;
     let k = k_s.idx()?;
 
-    let dtype = src.dtype();
-
     if let Some(k) = k.get(0) {
         let s = src.to_physical_repr();
-        macro_rules! dispatch {
-            ($ca:expr) => {{
-                top_k_impl($ca, k as usize, descending).into_series()
-            }};
-        }
-
-        downcast_as_macro_arg_physical!(&s, dispatch).cast(dtype)
+        Ok(s.sort(!descending, false)?.head(Some(k as usize)))
     } else {
-        Ok(Series::full_null(src.name(), src.len(), dtype))
+        polars_bail!(ComputeError: "`k` must be set for `top_k`")
     }
 }

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-use arrow::array::{BooleanArray, MutableBooleanArray, StaticArray};
+use arrow::array::{BooleanArray, MutableBooleanArray};
 use arrow::bitmap::MutableBitmap;
 use either::Either;
 use polars_core::downcast_as_macro_arg_physical;

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -8,8 +8,6 @@ use polars_core::prelude::*;
 use polars_core::utils::CustomIterTools;
 use polars_utils::total_ord::TotalOrd;
 
-use crate::prelude::SeriesMethods;
-
 fn arg_partition<T, C: Fn(&T, &T) -> Ordering>(
     v: &mut [T],
     k: usize,

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -196,9 +196,7 @@ pub fn top_k(s: &[Series], descending: bool) -> PolarsResult<Series> {
                     top_k_num_impl($ca, k as usize, descending).into_series()
                 }};
             }
-            unsafe {
-                downcast_as_macro_arg_physical!(&s, dispatch).cast_unchecked(origin_dtype)
-            }
+            unsafe { downcast_as_macro_arg_physical!(&s, dispatch).cast_unchecked(origin_dtype) }
         },
     }
 }

--- a/crates/polars-ops/src/chunked_array/top_k.rs
+++ b/crates/polars-ops/src/chunked_array/top_k.rs
@@ -196,8 +196,9 @@ pub fn top_k(s: &[Series], descending: bool) -> PolarsResult<Series> {
                     top_k_num_impl($ca, k as usize, descending).into_series()
                 }};
             }
-
-            downcast_as_macro_arg_physical!(&s, dispatch).cast(origin_dtype)
+            unsafe {
+                downcast_as_macro_arg_physical!(&s, dispatch).cast_unchecked(origin_dtype)
+            }
         },
     }
 }


### PR DESCRIPTION
This allows more dtype to use `top_k` which only supported numeric dtypes before. 