### PR TITLE
fix(python): Address issue with `read_database` draining iter_batches early

### DIFF
--- a/py-polars/polars/io/database/_executor.py
+++ b/py-polars/polars/io/database/_executor.py
@@ -276,7 +276,7 @@ class ConnectionExecutor:
                         orient="row",
                     )
                     for rows in (
-                        list(self._fetchmany_rows(self.result, batch_size))
+                        self._fetchmany_rows(self.result, batch_size)
                         if iter_batches
                         else [self._fetchall_rows(self.result)]  # type: ignore[list-item]
                     )


### PR DESCRIPTION
Closes #15470 and closes #15469.

The generator was inadvertently being drained on the first call by a rogue "list" invocation - while it was correctly using `fetchmany` internally, it should only have been retrieving one batch per iteration, not retrieving all batches and _then_ iterating (possibly something I was doing while debugging or refactoring that accidentally made it into a release 🤦).