### PR TITLE
fix(python, rust): Initialize validity for `GroupsProxy::Slice` windows

### DIFF
--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -793,7 +793,6 @@ where
         }
         // SAFETY: we have written all slots
         unsafe { values.set_len(len) }
-        unsafe { validity.set_len(len) }
         let validity = Bitmap::from(validity);
         let arr = PrimitiveArray::new(
             T::get_dtype().to_physical().to_arrow(true),

--- a/crates/polars-lazy/src/physical_plan/expressions/window.rs
+++ b/crates/polars-lazy/src/physical_plan/expressions/window.rs
@@ -725,7 +725,7 @@ where
     } else {
         // We don't use a mutable bitmap as bits will have have race conditions!
         // A single byte might alias if we write from single threads.
-        let mut validity: Vec<bool> = Vec::with_capacity(len);
+        let mut validity: Vec<bool> = vec![false; len];
         let validity_ptr = validity.as_mut_ptr();
         let sync_ptr_validity = unsafe { SyncPtr::new(validity_ptr) };
 

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -398,6 +398,26 @@ def test_window_filtered_aggregation() -> None:
     assert_frame_equal(out, expected)
 
 
+def test_window_filtered_false() -> None:
+    df = pl.DataFrame(
+        {
+            "group": ["A", "A"],
+            "value": [1, 2],
+        }
+    )
+    out = df.with_columns(
+        pl.col("value").filter(False).arg_max().over("group")
+    )
+    expected = pl.DataFrame(
+        {
+            "group": ["A", "A"],
+            "value": [None, None],
+        },
+        schema_overrides={"value": pl.UInt32},
+    )
+    assert_frame_equal(out, expected)
+
+
 def test_window_and_cse_10152() -> None:
     q = pl.LazyFrame(
         {

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -398,7 +398,7 @@ def test_window_filtered_aggregation() -> None:
     assert_frame_equal(out, expected)
 
 
-def test_window_filtered_false() -> None:
+def test_window_filtered_false_15483() -> None:
     df = pl.DataFrame(
         {
             "group": ["A", "A"],

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -405,9 +405,7 @@ def test_window_filtered_false() -> None:
             "value": [1, 2],
         }
     )
-    out = df.with_columns(
-        pl.col("value").filter(False).arg_max().over("group")
-    )
+    out = df.with_columns(pl.col("value").filter(False).arg_max().over("group"))
     expected = pl.DataFrame(
         {
             "group": ["A", "A"],

--- a/py-polars/tests/unit/operations/test_window.py
+++ b/py-polars/tests/unit/operations/test_window.py
@@ -405,7 +405,9 @@ def test_window_filtered_false_15483() -> None:
             "value": [1, 2],
         }
     )
-    out = df.with_columns(pl.col("value").filter(False).arg_max().over("group"))
+    out = df.with_columns(
+        pl.col("value").filter(pl.col("group") != "A").arg_max().over("group")
+    )
     expected = pl.DataFrame(
         {
             "group": ["A", "A"],


### PR DESCRIPTION
Closes #15483

In the case of a `GroupsProxy::Slice`, validity wasn't getting set if a group had all of its items filtered out. Instead, uninitialized values would be used, leading to a mix of nulls and garbage values.

The other variant of `GroupsProxy`, the `GroupsProxy::Idx`, doesn't seem to have a problem when groups are filtered out entirely. To be safe, I left the initialization code before the `match` so it affects both variants.