### PR TITLE
feat: Add SQL support for `MEDIAN` aggfunc

### DIFF
--- a/py-polars/tests/unit/sql/test_group_by.py
+++ b/py-polars/tests/unit/sql/test_group_by.py
@@ -21,10 +21,11 @@ def test_group_by(foods_ipc_path: Path) -> None:
     out = ctx.execute(
         """
         SELECT
-            category,
             count(category) as n,
-            max(calories),
-            min(fats_g)
+            category,
+            max(calories) as max_cal,
+            median(calories) as median_cal,
+            min(fats_g) as min_fats
         FROM foods
         GROUP BY category
         HAVING n > 5
@@ -32,10 +33,11 @@ def test_group_by(foods_ipc_path: Path) -> None:
         """
     )
     assert out.to_dict(as_series=False) == {
-        "category": ["vegetables", "fruit", "seafood"],
         "n": [7, 7, 8],
-        "calories": [45, 130, 200],
-        "fats_g": [0.0, 0.0, 1.5],
+        "category": ["vegetables", "fruit", "seafood"],
+        "max_cal": [45, 130, 200],
+        "median_cal": [25.0, 50.0, 145.0],
+        "min_fats": [0.0, 0.0, 1.5],
     }
 
     lf = pl.LazyFrame(


### PR DESCRIPTION
Adds convenience SQL interface support for the `MEDIAN` aggregate function (usually PostgreSQL bundles median calculation inside a `PERCENTILE_CONT(x, 0.5)` expression but many/most databases now expose it explicitly; I'll look at adding a dedicated `PERCENTILE_CONT` implementation later).

Also: Adds some missing function names to the  `PolarsSQLFunctions::keywords` vec.

## Example

```python
with pl.SQLContext(foods=df, eager_execution=True) as ctx:
    ctx.execute(
        """
        SELECT
            COUNT(category) as n,
            category,
            MAX(calories) AS max_cal,
            MEDIAN(calories) AS median_cal,
            MIN(fats_g) AS min_fats
        FROM foods
        GROUP BY category
        HAVING n > 5
        ORDER BY n, category DESC
        """
    )
    # shape: (3, 5)
    # ┌─────┬────────────┬─────────┬────────────┬──────────┐
    # │ n   ┆ category   ┆ max_cal ┆ median_cal ┆ min_fats │
    # │ --- ┆ ---        ┆ ---     ┆ ---        ┆ ---      │
    # │ u32 ┆ str        ┆ i64     ┆ f64        ┆ f64      │
    # ╞═════╪════════════╪═════════╪════════════╪══════════╡
    # │ 7   ┆ vegetables ┆ 45      ┆ 25.0       ┆ 0.0      │
    # │ 7   ┆ fruit      ┆ 130     ┆ 50.0       ┆ 0.0      │
    # │ 8   ┆ seafood    ┆ 200     ┆ 145.0      ┆ 1.5      │
    # └─────┴────────────┴─────────┴────────────┴──────────┘
```