### PR TITLE
refactor(python): Remove private `DataFrame._read` classmethods

### DIFF
--- a/py-polars/Makefile
+++ b/py-polars/Makefile
@@ -85,7 +85,7 @@ doctest: .venv build  ## Run doctests
 	$(VENV_BIN)/pytest tests/docs/test_user_guide.py -m docs
 
 .PHONY: docs
-docs: .venv build  ## Build Python docs (incremental)
+docs: .venv  ## Build Python docs (incremental)
 	@$(MAKE) -s -C docs html
 
 .PHONY: docs-clean

--- a/py-polars/polars/_utils/various.py
+++ b/py-polars/polars/_utils/various.py
@@ -158,31 +158,6 @@ def range_to_slice(rng: range) -> slice:
     return slice(rng.start, rng.stop, rng.step)
 
 
-def handle_projection_columns(
-    columns: Sequence[str] | Sequence[int] | str | None,
-) -> tuple[list[int] | None, Sequence[str] | None]:
-    """Disambiguates between columns specified as integers vs. strings."""
-    projection: list[int] | None = None
-    new_columns: Sequence[str] | None = None
-    if columns is not None:
-        if isinstance(columns, str):
-            new_columns = [columns]
-        elif is_int_sequence(columns):
-            projection = list(columns)
-        elif not is_str_sequence(columns):
-            msg = "`columns` arg should contain a list of all integers or all strings values"
-            raise TypeError(msg)
-        else:
-            new_columns = columns
-        if columns and len(set(columns)) != len(columns):
-            msg = f"`columns` arg should only have unique values, got {columns!r}"
-            raise ValueError(msg)
-        if projection and len(set(projection)) != len(projection):
-            msg = f"`columns` arg should only have unique values, got {projection!r}"
-            raise ValueError(msg)
-    return projection, new_columns
-
-
 def _prepare_row_index_args(
     row_index_name: str | None = None,
     row_index_offset: int = 0,

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -879,38 +879,6 @@ class DataFrame:
         )
         return self
 
-    @classmethod
-    def _read_ndjson(
-        cls,
-        source: str | Path | IOBase | bytes,
-        *,
-        schema: SchemaDefinition | None = None,
-        schema_overrides: SchemaDefinition | None = None,
-        ignore_errors: bool = False,
-    ) -> Self:
-        """
-        Read into a DataFrame from a newline delimited JSON file.
-
-        Use `pl.read_ndjson` to dispatch to this method.
-
-        See Also
-        --------
-        polars.io.read_ndjson
-        """
-        if isinstance(source, StringIO):
-            source = BytesIO(source.getvalue().encode())
-        elif isinstance(source, (str, Path)):
-            source = normalize_filepath(source)
-
-        self = cls.__new__(cls)
-        self._df = PyDataFrame.read_ndjson(
-            source,
-            ignore_errors=ignore_errors,
-            schema=schema,
-            schema_overrides=schema_overrides,
-        )
-        return self
-
     def _replace(self, column: str, new_column: Series) -> Self:
         """Replace a column by a new Series (in place)."""
         self._df.replace(column, new_column._s)

--- a/py-polars/polars/dataframe/frame.py
+++ b/py-polars/polars/dataframe/frame.py
@@ -847,38 +847,6 @@ class DataFrame:
         )
         return self
 
-    @classmethod
-    def _read_json(
-        cls,
-        source: str | Path | IOBase | bytes,
-        *,
-        schema: SchemaDefinition | None = None,
-        schema_overrides: SchemaDefinition | None = None,
-        infer_schema_length: int | None = N_INFER_DEFAULT,
-    ) -> Self:
-        """
-        Read into a DataFrame from a JSON file.
-
-        Use `pl.read_json` to dispatch to this method.
-
-        See Also
-        --------
-        polars.io.read_json
-        """
-        if isinstance(source, StringIO):
-            source = BytesIO(source.getvalue().encode())
-        elif isinstance(source, (str, Path)):
-            source = normalize_filepath(source)
-
-        self = cls.__new__(cls)
-        self._df = PyDataFrame.read_json(
-            source,
-            infer_schema_length=infer_schema_length,
-            schema=schema,
-            schema_overrides=schema_overrides,
-        )
-        return self
-
     def _replace(self, column: str, new_column: Series) -> Self:
         """Replace a column by a new Series (in place)."""
         self._df.replace(column, new_column._s)

--- a/py-polars/polars/io/_utils.py
+++ b/py-polars/polars/io/_utils.py
@@ -6,11 +6,36 @@ from contextlib import contextmanager
 from io import BytesIO, StringIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import IO, Any, ContextManager, Iterator, cast, overload
+from typing import IO, Any, ContextManager, Iterator, Sequence, cast, overload
 
-from polars._utils.various import normalize_filepath
+from polars._utils.various import is_int_sequence, is_str_sequence, normalize_filepath
 from polars.dependencies import _FSSPEC_AVAILABLE, fsspec
 from polars.exceptions import NoDataError
+
+
+def handle_projection_columns(
+    columns: Sequence[str] | Sequence[int] | str | None,
+) -> tuple[list[int] | None, Sequence[str] | None]:
+    """Disambiguates between columns specified as integers vs. strings."""
+    projection: list[int] | None = None
+    new_columns: Sequence[str] | None = None
+    if columns is not None:
+        if isinstance(columns, str):
+            new_columns = [columns]
+        elif is_int_sequence(columns):
+            projection = list(columns)
+        elif not is_str_sequence(columns):
+            msg = "`columns` arg should contain a list of all integers or all strings values"
+            raise TypeError(msg)
+        else:
+            new_columns = columns
+        if columns and len(set(columns)) != len(columns):
+            msg = f"`columns` arg should only have unique values, got {columns!r}"
+            raise ValueError(msg)
+        if projection and len(set(projection)) != len(projection):
+            msg = f"`columns` arg should only have unique values, got {projection!r}"
+            raise ValueError(msg)
+    return projection, new_columns
 
 
 def _is_glob_pattern(file: str) -> bool:

--- a/py-polars/polars/io/avro.py
+++ b/py-polars/polars/io/avro.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import IO, TYPE_CHECKING
 
-import polars._reexport as pl
+from polars._utils.various import handle_projection_columns, normalize_filepath
+from polars._utils.wrap import wrap_df
+from polars.polars import PyDataFrame
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from polars import DataFrame
 
 
@@ -35,4 +36,9 @@ def read_avro(
     -------
     DataFrame
     """
-    return pl.DataFrame._read_avro(source, n_rows=n_rows, columns=columns)
+    if isinstance(source, (str, Path)):
+        source = normalize_filepath(source)
+    projection, columns = handle_projection_columns(columns)
+
+    pydf = PyDataFrame.read_avro(source, columns, projection, n_rows)
+    return wrap_df(pydf)

--- a/py-polars/polars/io/avro.py
+++ b/py-polars/polars/io/avro.py
@@ -38,7 +38,7 @@ def read_avro(
     """
     if isinstance(source, (str, Path)):
         source = normalize_filepath(source)
-    projection, columns = handle_projection_columns(columns)
+    projection, parsed_columns = handle_projection_columns(columns)
 
-    pydf = PyDataFrame.read_avro(source, columns, projection, n_rows)
+    pydf = PyDataFrame.read_avro(source, parsed_columns, projection, n_rows)
     return wrap_df(pydf)

--- a/py-polars/polars/io/avro.py
+++ b/py-polars/polars/io/avro.py
@@ -4,8 +4,9 @@ import contextlib
 from pathlib import Path
 from typing import IO, TYPE_CHECKING
 
-from polars._utils.various import handle_projection_columns, normalize_filepath
+from polars._utils.various import normalize_filepath
 from polars._utils.wrap import wrap_df
+from polars.io._utils import handle_projection_columns
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame

--- a/py-polars/polars/io/avro.py
+++ b/py-polars/polars/io/avro.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from typing import IO, TYPE_CHECKING
 
 from polars._utils.various import handle_projection_columns, normalize_filepath
 from polars._utils.wrap import wrap_df
-from polars.polars import PyDataFrame
+
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import PyDataFrame
 
 if TYPE_CHECKING:
     from polars import DataFrame

--- a/py-polars/polars/io/csv/batched_reader.py
+++ b/py-polars/polars/io/csv/batched_reader.py
@@ -6,11 +6,11 @@ from typing import TYPE_CHECKING, Sequence
 from polars._utils.various import (
     _prepare_row_index_args,
     _process_null_values,
-    handle_projection_columns,
     normalize_filepath,
 )
 from polars._utils.wrap import wrap_df
 from polars.datatypes import N_INFER_DEFAULT, py_type_to_dtype
+from polars.io._utils import handle_projection_columns
 from polars.io.csv._utils import _update_columns
 
 with contextlib.suppress(ImportError):  # Module not available when building docs

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -10,14 +10,17 @@ from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.various import (
     _prepare_row_index_args,
     _process_null_values,
-    handle_projection_columns,
     is_str_sequence,
     normalize_filepath,
 )
 from polars._utils.wrap import wrap_df
 from polars.datatypes import N_INFER_DEFAULT, String
 from polars.datatypes.convert import py_type_to_dtype
-from polars.io._utils import _is_glob_pattern, _prepare_file_arg
+from polars.io._utils import (
+    _is_glob_pattern,
+    _prepare_file_arg,
+    handle_projection_columns,
+)
 from polars.io.csv._utils import _check_arg_is_1byte, _update_columns
 from polars.io.csv.batched_reader import BatchedCsvReader
 

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Callable, Mapping, Sequence
@@ -19,7 +20,9 @@ from polars.datatypes.convert import py_type_to_dtype
 from polars.io._utils import _is_glob_pattern, _prepare_file_arg
 from polars.io.csv._utils import _check_arg_is_1byte, _update_columns
 from polars.io.csv.batched_reader import BatchedCsvReader
-from polars.polars import PyDataFrame
+
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import PyDataFrame
 
 if TYPE_CHECKING:
     from polars import DataFrame, LazyFrame

--- a/py-polars/polars/io/csv/functions.py
+++ b/py-polars/polars/io/csv/functions.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
+from io import BytesIO, StringIO
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Callable, Mapping, Sequence
 
 import polars._reexport as pl
 from polars._utils.deprecation import deprecate_renamed_parameter
-from polars._utils.various import handle_projection_columns, normalize_filepath
+from polars._utils.various import (
+    _prepare_row_index_args,
+    _process_null_values,
+    handle_projection_columns,
+    is_str_sequence,
+    normalize_filepath,
+)
+from polars._utils.wrap import wrap_df
 from polars.datatypes import N_INFER_DEFAULT, String
-from polars.io._utils import _prepare_file_arg
+from polars.datatypes.convert import py_type_to_dtype
+from polars.io._utils import _is_glob_pattern, _prepare_file_arg
 from polars.io.csv._utils import _check_arg_is_1byte, _update_columns
 from polars.io.csv.batched_reader import BatchedCsvReader
+from polars.polars import PyDataFrame
 
 if TYPE_CHECKING:
     from polars import DataFrame, LazyFrame
@@ -394,7 +404,7 @@ def read_csv(
         raise_if_empty=raise_if_empty,
         storage_options=storage_options,
     ) as data:
-        df = pl.DataFrame._read_csv(
+        df = _read_csv_impl(
             data,
             has_header=has_header,
             columns=columns if columns else projection,
@@ -427,6 +437,145 @@ def read_csv(
     if new_columns:
         return _update_columns(df, new_columns)
     return df
+
+
+def _read_csv_impl(
+    source: str | Path | IO[bytes] | bytes,
+    *,
+    has_header: bool = True,
+    columns: Sequence[int] | Sequence[str] | None = None,
+    separator: str = ",",
+    comment_prefix: str | None = None,
+    quote_char: str | None = '"',
+    skip_rows: int = 0,
+    dtypes: None | (SchemaDict | Sequence[PolarsDataType]) = None,
+    schema: None | SchemaDict = None,
+    null_values: str | Sequence[str] | dict[str, str] | None = None,
+    missing_utf8_is_empty_string: bool = False,
+    ignore_errors: bool = False,
+    try_parse_dates: bool = False,
+    n_threads: int | None = None,
+    infer_schema_length: int | None = N_INFER_DEFAULT,
+    batch_size: int = 8192,
+    n_rows: int | None = None,
+    encoding: CsvEncoding = "utf8",
+    low_memory: bool = False,
+    rechunk: bool = True,
+    skip_rows_after_header: int = 0,
+    row_index_name: str | None = None,
+    row_index_offset: int = 0,
+    sample_size: int = 1024,
+    eol_char: str = "\n",
+    raise_if_empty: bool = True,
+    truncate_ragged_lines: bool = False,
+) -> DataFrame:
+    path: str | None
+    if isinstance(source, (str, Path)):
+        path = normalize_filepath(source)
+    else:
+        path = None
+        if isinstance(source, BytesIO):
+            source = source.getvalue()
+        if isinstance(source, StringIO):
+            source = source.getvalue().encode()
+
+    dtype_list: Sequence[tuple[str, PolarsDataType]] | None = None
+    dtype_slice: Sequence[PolarsDataType] | None = None
+    if dtypes is not None:
+        if isinstance(dtypes, dict):
+            dtype_list = []
+            for k, v in dtypes.items():
+                dtype_list.append((k, py_type_to_dtype(v)))
+        elif isinstance(dtypes, Sequence):
+            dtype_slice = dtypes
+        else:
+            msg = f"`dtypes` should be of type list or dict, got {type(dtypes).__name__!r}"
+            raise TypeError(msg)
+
+    processed_null_values = _process_null_values(null_values)
+
+    if isinstance(columns, str):
+        columns = [columns]
+    if isinstance(source, str) and _is_glob_pattern(source):
+        dtypes_dict = None
+        if dtype_list is not None:
+            dtypes_dict = dict(dtype_list)
+        if dtype_slice is not None:
+            msg = (
+                "cannot use glob patterns and unnamed dtypes as `dtypes` argument"
+                "\n\nUse `dtypes`: Mapping[str, Type[DataType]]"
+            )
+            raise ValueError(msg)
+        from polars import scan_csv
+
+        scan = scan_csv(
+            source,
+            has_header=has_header,
+            separator=separator,
+            comment_prefix=comment_prefix,
+            quote_char=quote_char,
+            skip_rows=skip_rows,
+            dtypes=dtypes_dict,
+            schema=schema,
+            null_values=null_values,
+            missing_utf8_is_empty_string=missing_utf8_is_empty_string,
+            ignore_errors=ignore_errors,
+            infer_schema_length=infer_schema_length,
+            n_rows=n_rows,
+            low_memory=low_memory,
+            rechunk=rechunk,
+            skip_rows_after_header=skip_rows_after_header,
+            row_index_name=row_index_name,
+            row_index_offset=row_index_offset,
+            eol_char=eol_char,
+            raise_if_empty=raise_if_empty,
+            truncate_ragged_lines=truncate_ragged_lines,
+        )
+        if columns is None:
+            return scan.collect()
+        elif is_str_sequence(columns, allow_str=False):
+            return scan.select(columns).collect()
+        else:
+            msg = (
+                "cannot use glob patterns and integer based projection as `columns` argument"
+                "\n\nUse columns: List[str]"
+            )
+            raise ValueError(msg)
+
+    projection, columns = handle_projection_columns(columns)
+
+    pydf = PyDataFrame.read_csv(
+        source,
+        infer_schema_length,
+        batch_size,
+        has_header,
+        ignore_errors,
+        n_rows,
+        skip_rows,
+        projection,
+        separator,
+        rechunk,
+        columns,
+        encoding,
+        n_threads,
+        path,
+        dtype_list,
+        dtype_slice,
+        low_memory,
+        comment_prefix,
+        quote_char,
+        processed_null_values,
+        missing_utf8_is_empty_string,
+        try_parse_dates,
+        skip_rows_after_header,
+        _prepare_row_index_args(row_index_name, row_index_offset),
+        sample_size=sample_size,
+        eol_char=eol_char,
+        raise_if_empty=raise_if_empty,
+        truncate_ragged_lines=truncate_ragged_lines,
+        schema=schema,
+    )
+    return wrap_df(pydf)
 
 
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -15,9 +15,9 @@ from polars._utils.various import (
 from polars._utils.wrap import wrap_df
 from polars.dependencies import _PYARROW_AVAILABLE
 from polars.io._utils import _is_glob_pattern, _is_local_file, _prepare_file_arg
-from polars.polars import PyDataFrame
 
-with contextlib.suppress(ImportError):
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import PyDataFrame
     from polars.polars import read_ipc_schema as _read_ipc_schema
 
 if TYPE_CHECKING:

--- a/py-polars/polars/io/ipc/functions.py
+++ b/py-polars/polars/io/ipc/functions.py
@@ -8,13 +8,17 @@ import polars._reexport as pl
 from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.various import (
     _prepare_row_index_args,
-    handle_projection_columns,
     is_str_sequence,
     normalize_filepath,
 )
 from polars._utils.wrap import wrap_df
 from polars.dependencies import _PYARROW_AVAILABLE
-from polars.io._utils import _is_glob_pattern, _is_local_file, _prepare_file_arg
+from polars.io._utils import (
+    _is_glob_pattern,
+    _is_local_file,
+    _prepare_file_arg,
+    handle_projection_columns,
+)
 
 with contextlib.suppress(ImportError):  # Module not available when building docs
     from polars.polars import PyDataFrame

--- a/py-polars/polars/io/json.py
+++ b/py-polars/polars/io/json.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
+from io import BytesIO, StringIO
+from pathlib import Path
 from typing import TYPE_CHECKING
 
-import polars._reexport as pl
+from polars._utils.various import normalize_filepath
+from polars._utils.wrap import wrap_df
 from polars.datatypes import N_INFER_DEFAULT
+from polars.polars import PyDataFrame
 
 if TYPE_CHECKING:
     from io import IOBase
-    from pathlib import Path
 
     from polars import DataFrame
     from polars.type_aliases import SchemaDefinition
@@ -50,9 +53,15 @@ def read_json(
     --------
     read_ndjson
     """
-    return pl.DataFrame._read_json(
+    if isinstance(source, StringIO):
+        source = BytesIO(source.getvalue().encode())
+    elif isinstance(source, (str, Path)):
+        source = normalize_filepath(source)
+
+    pydf = PyDataFrame.read_json(
         source,
+        infer_schema_length=infer_schema_length,
         schema=schema,
         schema_overrides=schema_overrides,
-        infer_schema_length=infer_schema_length,
     )
+    return wrap_df(pydf)

--- a/py-polars/polars/io/json.py
+++ b/py-polars/polars/io/json.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -7,7 +8,9 @@ from typing import TYPE_CHECKING
 from polars._utils.various import normalize_filepath
 from polars._utils.wrap import wrap_df
 from polars.datatypes import N_INFER_DEFAULT
-from polars.polars import PyDataFrame
+
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import PyDataFrame
 
 if TYPE_CHECKING:
     from io import IOBase

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -9,7 +10,9 @@ from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.various import normalize_filepath
 from polars._utils.wrap import wrap_df
 from polars.datatypes import N_INFER_DEFAULT
-from polars.polars import PyDataFrame
+
+with contextlib.suppress(ImportError):  # Module not available when building docs
+    from polars.polars import PyDataFrame
 
 if TYPE_CHECKING:
     from io import IOBase

--- a/py-polars/polars/io/ndjson.py
+++ b/py-polars/polars/io/ndjson.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+from io import BytesIO, StringIO
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import polars._reexport as pl
 from polars._utils.deprecation import deprecate_renamed_parameter
+from polars._utils.various import normalize_filepath
+from polars._utils.wrap import wrap_df
 from polars.datatypes import N_INFER_DEFAULT
+from polars.polars import PyDataFrame
 
 if TYPE_CHECKING:
     from io import IOBase
-    from pathlib import Path
 
     from polars import DataFrame, LazyFrame
     from polars.type_aliases import SchemaDefinition
@@ -46,12 +50,18 @@ def read_ndjson(
     ignore_errors
         Return `Null` if parsing fails because of schema mismatches.
     """
-    return pl.DataFrame._read_ndjson(
+    if isinstance(source, StringIO):
+        source = BytesIO(source.getvalue().encode())
+    elif isinstance(source, (str, Path)):
+        source = normalize_filepath(source)
+
+    pydf = PyDataFrame.read_ndjson(
         source,
+        ignore_errors=ignore_errors,
         schema=schema,
         schema_overrides=schema_overrides,
-        ignore_errors=ignore_errors,
     )
+    return wrap_df(pydf)
 
 
 @deprecate_renamed_parameter("row_count_name", "row_index_name", version="0.20.4")

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -10,7 +10,6 @@ from polars._utils.deprecation import deprecate_renamed_parameter
 from polars._utils.unstable import issue_unstable_warning
 from polars._utils.various import (
     _prepare_row_index_args,
-    handle_projection_columns,
     is_int_sequence,
     is_str_sequence,
     normalize_filepath,
@@ -18,7 +17,11 @@ from polars._utils.various import (
 from polars._utils.wrap import wrap_df
 from polars.convert import from_arrow
 from polars.dependencies import _PYARROW_AVAILABLE
-from polars.io._utils import _is_glob_pattern, _prepare_file_arg
+from polars.io._utils import (
+    _is_glob_pattern,
+    _prepare_file_arg,
+    handle_projection_columns,
+)
 
 with contextlib.suppress(ImportError):
     from polars.polars import PyDataFrame

--- a/py-polars/polars/io/parquet/functions.py
+++ b/py-polars/polars/io/parquet/functions.py
@@ -19,9 +19,9 @@ from polars._utils.wrap import wrap_df
 from polars.convert import from_arrow
 from polars.dependencies import _PYARROW_AVAILABLE
 from polars.io._utils import _is_glob_pattern, _prepare_file_arg
-from polars.polars import PyDataFrame
 
 with contextlib.suppress(ImportError):
+    from polars.polars import PyDataFrame
     from polars.polars import read_parquet_schema as _read_parquet_schema
 
 if TYPE_CHECKING:

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -42,7 +42,6 @@ from polars._utils.unstable import issue_unstable_warning, unstable
 from polars._utils.various import (
     _in_notebook,
     _prepare_row_index_args,
-    _process_null_values,
     is_bool_sequence,
     is_sequence,
     normalize_filepath,
@@ -103,7 +102,6 @@ if TYPE_CHECKING:
         AsofJoinStrategy,
         ClosedInterval,
         ColumnNameOrSelector,
-        CsvEncoding,
         CsvQuoteStyle,
         FillNullStrategy,
         FrameInitTypes,
@@ -331,88 +329,6 @@ class LazyFrame:
     def __setstate__(self, state: bytes) -> None:
         self._ldf = LazyFrame()._ldf  # Initialize with a dummy
         self._ldf.__setstate__(state)
-
-    @classmethod
-    def _scan_csv(
-        cls,
-        source: str | list[str] | list[Path],
-        *,
-        has_header: bool = True,
-        separator: str = ",",
-        comment_prefix: str | None = None,
-        quote_char: str | None = '"',
-        skip_rows: int = 0,
-        dtypes: SchemaDict | None = None,
-        schema: SchemaDict | None = None,
-        null_values: str | Sequence[str] | dict[str, str] | None = None,
-        missing_utf8_is_empty_string: bool = False,
-        ignore_errors: bool = False,
-        cache: bool = True,
-        with_column_names: Callable[[list[str]], list[str]] | None = None,
-        infer_schema_length: int | None = N_INFER_DEFAULT,
-        n_rows: int | None = None,
-        encoding: CsvEncoding = "utf8",
-        low_memory: bool = False,
-        rechunk: bool = True,
-        skip_rows_after_header: int = 0,
-        row_index_name: str | None = None,
-        row_index_offset: int = 0,
-        try_parse_dates: bool = False,
-        eol_char: str = "\n",
-        raise_if_empty: bool = True,
-        truncate_ragged_lines: bool = True,
-    ) -> Self:
-        """
-        Lazily read from a CSV file or multiple files via glob patterns.
-
-        Use `pl.scan_csv` to dispatch to this method.
-
-        See Also
-        --------
-        polars.io.scan_csv
-        """
-        dtype_list: list[tuple[str, PolarsDataType]] | None = None
-        if dtypes is not None:
-            dtype_list = []
-            for k, v in dtypes.items():
-                dtype_list.append((k, py_type_to_dtype(v)))
-        processed_null_values = _process_null_values(null_values)
-
-        if isinstance(source, list):
-            sources = source
-            source = None  # type: ignore[assignment]
-        else:
-            sources = []
-
-        self = cls.__new__(cls)
-        self._ldf = PyLazyFrame.new_from_csv(
-            source,
-            sources,
-            separator,
-            has_header,
-            ignore_errors,
-            skip_rows,
-            n_rows,
-            cache,
-            dtype_list,
-            low_memory,
-            comment_prefix,
-            quote_char,
-            processed_null_values,
-            missing_utf8_is_empty_string,
-            infer_schema_length,
-            with_column_names,
-            rechunk,
-            skip_rows_after_header,
-            encoding,
-            _prepare_row_index_args(row_index_name, row_index_offset),
-            try_parse_dates,
-            eol_char=eol_char,
-            raise_if_empty=raise_if_empty,
-            truncate_ragged_lines=truncate_ragged_lines,
-            schema=schema,
-        )
-        return self
 
     @classmethod
     def _scan_parquet(

--- a/py-polars/polars/lazyframe/frame.py
+++ b/py-polars/polars/lazyframe/frame.py
@@ -543,52 +543,6 @@ class LazyFrame:
         return self
 
     @classmethod
-    def _scan_ndjson(
-        cls,
-        source: str | Path | list[str] | list[Path],
-        *,
-        infer_schema_length: int | None = N_INFER_DEFAULT,
-        schema: SchemaDefinition | None = None,
-        batch_size: int | None = None,
-        n_rows: int | None = None,
-        low_memory: bool = False,
-        rechunk: bool = False,
-        row_index_name: str | None = None,
-        row_index_offset: int = 0,
-        ignore_errors: bool = False,
-    ) -> Self:
-        """
-        Lazily read from a newline delimited JSON file.
-
-        Use `pl.scan_ndjson` to dispatch to this method.
-
-        See Also
-        --------
-        polars.io.scan_ndjson
-        """
-        if isinstance(source, (str, Path)):
-            source = normalize_filepath(source)
-            sources = []
-        else:
-            sources = [normalize_filepath(source) for source in source]
-            source = None  # type: ignore[assignment]
-
-        self = cls.__new__(cls)
-        self._ldf = PyLazyFrame.new_from_ndjson(
-            source,
-            sources,
-            infer_schema_length,
-            schema,
-            batch_size,
-            n_rows,
-            low_memory,
-            rechunk,
-            _prepare_row_index_args(row_index_name, row_index_offset),
-            ignore_errors,
-        )
-        return self
-
-    @classmethod
     def _scan_python_function(
         cls,
         schema: pa.schema | Mapping[str, PolarsDataType],


### PR DESCRIPTION
The implementation of IO functionality was (unnecessarily) split between two places. This centralizes the logic in 1 place, makes subsequent refactors easier. There is a LOT of duplication here.