### PR TITLE
fix: Cast empty lists and lists of only nulls without an inner dtype

### DIFF
--- a/crates/polars-core/src/chunked_array/upstream_traits.rs
+++ b/crates/polars-core/src/chunked_array/upstream_traits.rs
@@ -234,23 +234,15 @@ impl FromIterator<Option<Series>> for ListChunked {
                                 builder.append_null();
                             }
                             builder.append_series(first_s).unwrap();
+
                             for opt_s in it {
-                                match opt_s {
-                                    Some(ref s) => {
-                                        // Empty AnyValue lists (or lists of nulls) have dtype Null.
-                                        // To append them, we cast them to the first value's inner dtype.
-                                        if s.is_empty() || s.null_count() == s.len() {
-                                            builder
-                                                .append_opt_series(
-                                                    s.cast(first_s.dtype()).ok().as_ref(),
-                                                )
-                                                .unwrap()
-                                        } else {
-                                            builder.append_opt_series(opt_s.as_ref()).unwrap()
-                                        }
-                                    },
-                                    None => builder.append_null(),
+                                if opt_s.is_some() {
+                                    debug_assert_eq!(
+                                        opt_s.clone().unwrap().dtype(),
+                                        first_s.dtype()
+                                    );
                                 }
+                                builder.append_opt_series(opt_s.as_ref()).unwrap();
                             }
                             builder.finish()
                         },

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -499,8 +499,7 @@ fn any_values_to_list(
                 AnyValue::List(b) => {
                     if !b.is_empty() && matches!(first_value_dtype, DataType::Null) {
                         first_value_dtype = b.dtype().clone();
-                    }
-                    if b.is_empty() || b.null_count() == b.len() {
+                    } else if b.is_empty() || b.null_count() == b.len() {
                         return b.cast(&first_value_dtype).ok();
                     }
                     Some(b.clone())

--- a/crates/polars-core/src/series/any_value.rs
+++ b/crates/polars-core/src/series/any_value.rs
@@ -494,11 +494,13 @@ fn any_values_to_list(
     #[allow(unused_mut)]
     let mut out: ListChunked = if inner_type == &DataType::Null {
         let mut first_value_dtype = DataType::Null;
+        let mut set_first = false;
         avs.iter()
             .map(|av| match av {
                 AnyValue::List(b) => {
-                    if !b.is_empty() && matches!(first_value_dtype, DataType::Null) {
+                    if !set_first && first_value_dtype != *b.dtype() {
                         first_value_dtype = b.dtype().clone();
+                        set_first = true;
                     } else if b.is_empty() || b.null_count() == b.len() {
                         return b.cast(&first_value_dtype).ok();
                     }

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -840,6 +840,8 @@ def test_take_list_15719() -> None:
         ([[1], [], [None], None], pl.List, pl.List(pl.Int64)),
     ],
 )
-def test_list_anyvalue_empty_list(values, dtype, full_dtype) -> None:
+def test_list_anyvalue_empty_list(
+    values: list[Any], dtype: PolarsDataType, full_dtype: PolarsDataType
+) -> None:
     s = pl.Series("a", values, dtype=dtype)
     assert_series_equal(s, pl.Series("a", values, dtype=full_dtype))

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -838,6 +838,7 @@ def test_take_list_15719() -> None:
     [
         ([["a"], [], [None], None], pl.List, pl.List(pl.String)),
         ([[1], [], [None], None], pl.List, pl.List(pl.Int64)),
+        ([[], None, ["a"]], pl.List, pl.List(pl.String)),
     ],
 )
 def test_list_anyvalue_empty_list(

--- a/py-polars/tests/unit/datatypes/test_list.py
+++ b/py-polars/tests/unit/datatypes/test_list.py
@@ -831,3 +831,15 @@ def test_take_list_15719() -> None:
     )
 
     assert_frame_equal(df, expected)
+
+
+@pytest.mark.parametrize(
+    ("values", "dtype", "full_dtype"),
+    [
+        ([["a"], [], [None], None], pl.List, pl.List(pl.String)),
+        ([[1], [], [None], None], pl.List, pl.List(pl.Int64)),
+    ],
+)
+def test_list_anyvalue_empty_list(values, dtype, full_dtype) -> None:
+    s = pl.Series("a", values, dtype=dtype)
+    assert_series_equal(s, pl.Series("a", values, dtype=full_dtype))


### PR DESCRIPTION
Fixes #15523 

When building a Series of lists without specifying an inner dtype, if there's any empty list, construction will panic. The reason is that in `AnyValue::List(b)`, if `b` is empty, its dtype is `Null` regardless of the dtype of the other lists. 