### PR TITLE
refactor(python): Move dedicated inference code out of `io.database` executor module

### DIFF
--- a/py-polars/polars/io/database/_inference.py
+++ b/py-polars/polars/io/database/_inference.py
@@ -2,9 +2,13 @@ from __future__ import annotations
 
 import functools
 import re
+from contextlib import suppress
+from inspect import isclass
 from typing import TYPE_CHECKING, Any
 
 from polars.datatypes import (
+    INTEGER_DTYPES,
+    UNSIGNED_INTEGER_DTYPES,
     Binary,
     Boolean,
     Date,
@@ -25,6 +29,7 @@ from polars.datatypes import (
     UInt32,
     UInt64,
 )
+from polars.datatypes.convert import _map_py_type_to_dtype
 
 if TYPE_CHECKING:
     from polars.type_aliases import PolarsDataType
@@ -178,6 +183,50 @@ def _infer_dtype_from_database_typename(
     if not dtype and raise_unmatched:
         msg = f"cannot infer dtype from {original_value!r} string value"
         raise ValueError(msg)
+
+    return dtype
+
+
+def _infer_dtype_from_cursor_description(
+    cursor: Any,
+    description: tuple[Any, ...],
+) -> PolarsDataType | None:
+    """Attempt to infer Polars dtype from database cursor description `type_code`."""
+    type_code, _disp_size, internal_size, precision, scale, _null_ok = description
+    dtype: PolarsDataType | None = None
+
+    if isclass(type_code):
+        # python types, eg: int, float, str, etc
+        with suppress(TypeError):
+            dtype = _map_py_type_to_dtype(type_code)  # type: ignore[arg-type]
+
+    elif isinstance(type_code, str):
+        # database/sql type names, eg: "VARCHAR", "NUMERIC", "BLOB", etc
+        dtype = _infer_dtype_from_database_typename(
+            value=type_code,
+            raise_unmatched=False,
+        )
+
+    # check additional cursor attrs to refine dtype specification
+    if dtype is not None:
+        if dtype == Float64 and internal_size == 4:
+            dtype = Float32
+
+        elif dtype in INTEGER_DTYPES and internal_size in (2, 4, 8):
+            bits = internal_size * 8
+            dtype = _integer_dtype_from_nbits(
+                bits,
+                unsigned=(dtype in UNSIGNED_INTEGER_DTYPES),
+                default=dtype,
+            )
+        elif (
+            dtype == Decimal
+            and isinstance(precision, int)
+            and isinstance(scale, int)
+            and precision <= 38
+            and scale <= 38
+        ):
+            dtype = Decimal(precision, scale)
 
     return dtype
 


### PR DESCRIPTION
Some housekeeping, in advance of adding further capabilities (backing-out more accurate dtypes from the underlying db driver module when the cursor description contains a custom type_code). 

This finishes consolidating inference code out of the executor module.