### PR TITLE
fix(python): No longer error when `schema_overrides` contains nonexistent columns

### DIFF
--- a/py-polars/src/dataframe/construction.rs
+++ b/py-polars/src/dataframe/construction.rs
@@ -61,7 +61,7 @@ fn finish_from_rows(
     infer_schema_length: Option<usize>,
 ) -> PyResult<PyDataFrame> {
     let mut schema = if let Some(mut schema) = schema {
-        resolve_schema_overrides(&mut schema, schema_overrides)?;
+        resolve_schema_overrides(&mut schema, schema_overrides);
         update_schema_from_rows(&mut schema, &rows, infer_schema_length)?;
         schema
     } else {
@@ -105,15 +105,14 @@ fn update_schema_from_rows(
 }
 
 /// Override the data type of certain schema fields.
-fn resolve_schema_overrides(schema: &mut Schema, schema_overrides: Option<Schema>) -> PyResult<()> {
+///
+/// Overrides for nonexistent columns are ignored.
+fn resolve_schema_overrides(schema: &mut Schema, schema_overrides: Option<Schema>) {
     if let Some(overrides) = schema_overrides {
         for (name, dtype) in overrides.into_iter() {
-            schema.set_dtype(name.as_str(), dtype).ok_or_else(|| {
-                polars_err!(SchemaMismatch: "nonexistent column specified in `schema_overrides`: {name}")
-            }).map_err(PyPolarsErr::from)?;
+            schema.set_dtype(name.as_str(), dtype);
         }
     }
-    Ok(())
 }
 
 /// Erase precision/scale information from Decimal types.

--- a/py-polars/tests/unit/constructors/test_dataframe.py
+++ b/py-polars/tests/unit/constructors/test_dataframe.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+from collections import OrderedDict
 from typing import Any
 
 import pytest
@@ -123,9 +124,16 @@ def test_df_init_from_series_strict() -> None:
     assert df["a"].dtype == pl.UInt8
 
 
+# https://github.com/pola-rs/polars/issues/15471
 def test_df_init_rows_overrides_non_existing() -> None:
-    with pytest.raises(pl.SchemaError, match="nonexistent column"):
-        pl.DataFrame([{"a": 1, "b": 2}], schema_overrides={"c": pl.Int8})
+    df = pl.DataFrame([{"a": 1}], schema_overrides={"a": pl.Int8(), "b": pl.Boolean()})
+    assert df.schema == OrderedDict({"a": pl.Int8})
+
+    df = pl.DataFrame(
+        [{"a": 3, "b": 1.0}],
+        schema_overrides={"a": pl.Int8, "c": pl.Utf8},
+    )
+    assert df.schema == OrderedDict({"a": pl.Int8, "b": pl.Float64})
 
 
 # https://github.com/pola-rs/polars/issues/15245


### PR DESCRIPTION
Reverts the change in https://github.com/pola-rs/polars/pull/15290
Closes https://github.com/pola-rs/polars/issues/15471

As per the discussion in the linked issue, being able to pass nonexistent columns in `schema_overrides` is actually pretty useful in certain situations. I had not foreseen this, so I am reverting the check I introduced for this.