### PR TITLE
fix: Decompress moved out of schema initialization

### DIFF
--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -174,25 +174,25 @@ impl<'a> CoreReader<'a> {
         // check if schema should be inferred
         let separator = separator.unwrap_or(b',');
 
+        // We keep track of the inferred schema bool
+        // In case the file is compressed this schema inference is wrong and has to be done
+        // again after decompression.
+        #[cfg(any(feature = "decompress", feature = "decompress-fast"))]
+        {
+            let total_n_rows = n_rows.map(|n| {
+                skip_rows + (has_header as usize) + skip_rows_after_header + n
+            });
+            if let Some(b) =
+                decompress(&reader_bytes, total_n_rows, separator, quote_char, eol_char)
+            {
+                reader_bytes = ReaderBytes::Owned(b);
+            }
+        }
+
         let mut schema = match schema {
             Some(schema) => schema,
             None => {
                 {
-                    // We keep track of the inferred schema bool
-                    // In case the file is compressed this schema inference is wrong and has to be done
-                    // again after decompression.
-                    #[cfg(any(feature = "decompress", feature = "decompress-fast"))]
-                    {
-                        let total_n_rows = n_rows.map(|n| {
-                            skip_rows + (has_header as usize) + skip_rows_after_header + n
-                        });
-                        if let Some(b) =
-                            decompress(&reader_bytes, total_n_rows, separator, quote_char, eol_char)
-                        {
-                            reader_bytes = ReaderBytes::Owned(b);
-                        }
-                    }
-
                     let (inferred_schema, _, _) = infer_file_schema(
                         &reader_bytes,
                         separator,

--- a/crates/polars-io/src/csv/read_impl/mod.rs
+++ b/crates/polars-io/src/csv/read_impl/mod.rs
@@ -179,9 +179,8 @@ impl<'a> CoreReader<'a> {
         // again after decompression.
         #[cfg(any(feature = "decompress", feature = "decompress-fast"))]
         {
-            let total_n_rows = n_rows.map(|n| {
-                skip_rows + (has_header as usize) + skip_rows_after_header + n
-            });
+            let total_n_rows =
+                n_rows.map(|n| skip_rows + (has_header as usize) + skip_rows_after_header + n);
             if let Some(b) =
                 decompress(&reader_bytes, total_n_rows, separator, quote_char, eol_char)
             {
@@ -192,25 +191,23 @@ impl<'a> CoreReader<'a> {
         let mut schema = match schema {
             Some(schema) => schema,
             None => {
-                {
-                    let (inferred_schema, _, _) = infer_file_schema(
-                        &reader_bytes,
-                        separator,
-                        max_records,
-                        has_header,
-                        schema_overwrite.as_deref(),
-                        &mut skip_rows,
-                        skip_rows_after_header,
-                        comment_prefix.as_ref(),
-                        quote_char,
-                        eol_char,
-                        null_values.as_ref(),
-                        try_parse_dates,
-                        raise_if_empty,
-                        &mut n_threads,
-                    )?;
-                    Arc::new(inferred_schema)
-                }
+                let (inferred_schema, _, _) = infer_file_schema(
+                    &reader_bytes,
+                    separator,
+                    max_records,
+                    has_header,
+                    schema_overwrite.as_deref(),
+                    &mut skip_rows,
+                    skip_rows_after_header,
+                    comment_prefix.as_ref(),
+                    quote_char,
+                    eol_char,
+                    null_values.as_ref(),
+                    try_parse_dates,
+                    raise_if_empty,
+                    &mut n_threads,
+                )?;
+                Arc::new(inferred_schema)
             },
         };
         if let Some(dtypes) = dtype_overwrite {

--- a/py-polars/tests/unit/io/test_csv.py
+++ b/py-polars/tests/unit/io/test_csv.py
@@ -541,6 +541,11 @@ def test_compressed_csv(io_files_path: Path) -> None:
     out = pl.read_csv(str(csv_file), truncate_ragged_lines=True)
     assert_frame_equal(out, expected)
 
+    # now with schema defined
+    schema = {"a": pl.Int64, "b": pl.Utf8, "c": pl.Float64}
+    out = pl.read_csv(str(csv_file), schema=schema, truncate_ragged_lines=True)
+    assert_frame_equal(out, expected)
+
     # now with column projection
     out = pl.read_csv(csv_bytes, columns=["a", "b"])
     expected = pl.DataFrame({"a": [1, 2, 3], "b": ["a", "b", "c"]})


### PR DESCRIPTION
#14192

read_csv wouldn't decompress file unless schema had None value. 

Ran with test file :
``` python
import polars as pl
import gzip
import os

df = pl.DataFrame({
    "id": [1, 2, 3, 4, 5],
    "name": ["Alice", "Bob", "Charlie", "David", "Eve"],
    "age": [25, 32, 37, 45, 29],
    "city": ["New York", "Los Angeles", "Chicago", "Houston", "Phoenix"]
})

temp_filename = 'tempfile.csv'
df.write_csv(temp_filename)

compressed_filename = 'dataframe.csv.gz'
with open(temp_filename, 'rb') as temp_file:
    with gzip.open(compressed_filename, 'wb') as gzip_file:
        gzip_file.writelines(temp_file)

os.remove(temp_filename)

print("DataFrame is successfully exported to a gzipped CSV file.")

schema = {
    "id": pl.Int64,
    "name": pl.Utf8,
    "age": pl.Int64,
    "city": pl.Utf8,
}

df_reopened = pl.read_csv(
        'dataframe.csv.gz',
        schema=schema,
        has_header=True
    )

print(df_reopened)
```