### PR TITLE
feat: Enable `is_first/last_distinct` for not nested non-numeric list

### DIFF
--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -223,7 +223,14 @@ impl DataType {
 
     /// Check if this [`DataType`] is a array
     pub fn is_array(&self) -> bool {
-        matches!(self, DataType::Array(_, _))
+        #[cfg(feature = "dtype-array")]
+        {
+            matches!(self, DataType::Array(_, _))
+        }
+        #[cfg(not(feature = "dtype-array"))]
+        {
+            false
+        }
     }
 
     pub fn is_nested(&self) -> bool {

--- a/crates/polars-core/src/datatypes/dtype.rs
+++ b/crates/polars-core/src/datatypes/dtype.rs
@@ -221,8 +221,13 @@ impl DataType {
         matches!(self, DataType::List(_))
     }
 
+    /// Check if this [`DataType`] is a array
+    pub fn is_array(&self) -> bool {
+        matches!(self, DataType::Array(_, _))
+    }
+
     pub fn is_nested(&self) -> bool {
-        self.is_list() || self.is_struct()
+        self.is_list() || self.is_struct() || self.is_array()
     }
 
     /// Check if this [`DataType`] is a struct

--- a/crates/polars-ops/src/series/ops/is_first_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_first_distinct.rs
@@ -135,7 +135,11 @@ pub fn is_first_distinct(s: &Series) -> PolarsResult<BooleanChunked> {
         },
         #[cfg(feature = "dtype-struct")]
         Struct(_) => return is_first_distinct_struct(&s),
-        List(inner) if inner.is_numeric() => {
+        List(inner) => {
+            polars_ensure!(
+                !inner.is_nested(),
+                InvalidOperation: "`is_first_distinct` on list type is only allowed if the inner type is not nested."
+            );
             let ca = s.list().unwrap();
             return is_first_distinct_list(ca);
         },

--- a/crates/polars-ops/src/series/ops/is_last_distinct.rs
+++ b/crates/polars-ops/src/series/ops/is_last_distinct.rs
@@ -40,7 +40,11 @@ pub fn is_last_distinct(s: &Series) -> PolarsResult<BooleanChunked> {
         },
         #[cfg(feature = "dtype-struct")]
         Struct(_) => return is_last_distinct_struct(&s),
-        List(inner) if inner.is_numeric() => {
+        List(inner) => {
+            polars_ensure!(
+                !inner.is_nested(),
+                InvalidOperation: "`is_last_distinct` on list type is only allowed if the inner type is not nested."
+            );
             let ca = s.list().unwrap();
             return is_last_distinct_list(ca);
         },


### PR DESCRIPTION
Since we have shift to `row-encode` for `group-by` list. I think we could get rid of the limitation for `is_first/last_distinct` also.