### PR TITLE
fix: Enable missing features in polars-time

### DIFF
--- a/crates/polars-time/Cargo.toml
+++ b/crates/polars-time/Cargo.toml
@@ -24,6 +24,9 @@ regex = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 smartstring = { workspace = true }
 
+[dev-dependencies]
+polars-ops = { workspace = true, features = ["abs"] }
+
 [features]
 dtype-date = ["polars-core/dtype-date", "temporal"]
 dtype-datetime = ["polars-core/dtype-datetime", "temporal"]
@@ -31,6 +34,7 @@ dtype-time = ["polars-core/dtype-time", "temporal"]
 dtype-duration = ["polars-core/dtype-duration", "temporal"]
 rolling_window = ["polars-core/rolling_window", "dtype-duration"]
 fmt = ["polars-core/fmt"]
+serde = ["dep:serde", "smartstring/serde"]
 temporal = ["polars-core/temporal"]
 timezones = ["chrono-tz", "dtype-datetime", "polars-core/timezones", "arrow/timezones", "polars-ops/timezones"]
 


### PR DESCRIPTION
Without having `smartstring/serde` compiling with `--all-features` fails because of the smartstring values not being serializable:

```
$ cargo build --all-features  -p polars-time
   Compiling polars-time v0.38.3 (/home/fila/workspace/polars/crates/polars-time)
error[E0277]: the trait bound `SmartString<LazyCompact>: rolling_window::_::_serde::Serialize` is not satisfied
    --> crates/polars-time/src/group_by/dynamic.rs:21:38
     |
21   |   #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     |                                        ^^^^^^^^^ the trait `rolling_window::_::_serde::Serialize` is not implemented for `SmartString<LazyCompact>`
22   |   pub struct DynamicGroupOptions {
23   | /     /// Time or index column.
24   | |     pub index_column: SmartString,
     | |_________________________________- required by a bound introduced by this call
     |
     = help: the following other types implement trait `rolling_window::_::_serde::Serialize`:
               bool
               char
               isize
               i8
               i16
               i32
               i64
               i128
             and 134 others
note: required by a bound in `rolling_window::_::_serde::ser::SerializeStruct::serialize_field`
    --> /home/fila/.cargo/registry/src/index.crates.io-6f17d22bba15001f/serde-1.0.197/src/ser/mod.rs:1865:12
     |
1859 |     fn serialize_field<T: ?Sized>(
     |        --------------- required by a bound in this associated function
...
1865 |         T: Serialize;
     |            ^^^^^^^^^ required by this bound in `SerializeStruct::serialize_field`
     = note: this error originates in the derive macro `Serialize` (in Nightly builds, run with -Z macro-backtrace for more info)

```

The `abs` feature on the `polars-ops` crate is necessary for the tests in `polars-time` to pass.