### PR TITLE
refactor!(rust): update the argument name from `dims` to `dimensions` in `reshape`

### DIFF
--- a/crates/polars-core/src/series/ops/to_list.rs
+++ b/crates/polars-core/src/series/ops/to_list.rs
@@ -50,8 +50,8 @@ impl Series {
         Ok(ca)
     }
 
-    pub fn reshape(&self, dims: &[i64]) -> PolarsResult<Series> {
-        if dims.is_empty() {
+    pub fn reshape(&self, dimensions: &[i64]) -> PolarsResult<Series> {
+        if dimensions.is_empty() {
             polars_bail!(ComputeError: "reshape `dimensions` cannot be empty")
         }
         let s = if let DataType::List(_) = self.dtype() {
@@ -61,35 +61,35 @@ impl Series {
         };
 
         // No rows.
-        if dims[0] == 0 {
+        if dimensions[0] == 0 {
             let s = reshape_fast_path(self.name(), &s);
             return Ok(s);
         }
 
         let s_ref = s.as_ref();
 
-        let mut dims = dims.to_vec();
-        if let Some(idx) = dims.iter().position(|i| *i == -1) {
+        let mut dimensions = dimensions.to_vec();
+        if let Some(idx) = dimensions.iter().position(|i| *i == -1) {
             let mut product = 1;
 
-            for (cnt, dim) in dims.iter().enumerate() {
+            for (cnt, dim) in dimensions.iter().enumerate() {
                 if cnt != idx {
                     product *= *dim
                 }
             }
-            dims[idx] = s_ref.len() as i64 / product;
+            dimensions[idx] = s_ref.len() as i64 / product;
         }
 
-        let prod = dims.iter().product::<i64>() as usize;
+        let prod = dimensions.iter().product::<i64>() as usize;
         polars_ensure!(
             prod == s_ref.len(),
-            ComputeError: "cannot reshape len {} into shape {:?}", s_ref.len(), dims,
+            ComputeError: "cannot reshape len {} into shape {:?}", s_ref.len(), dimensions,
         );
-        match dims.len() {
-            1 => Ok(s_ref.slice(0, dims[0] as usize)),
+        match dimensions.len() {
+            1 => Ok(s_ref.slice(0, dimensions[0] as usize)),
             2 => {
-                let mut rows = dims[0];
-                let mut cols = dims[1];
+                let mut rows = dimensions[0];
+                let mut cols = dimensions[1];
 
                 // Infer dimension.
                 if rows == -1 {

--- a/crates/polars-plan/src/dsl/function_expr/dispatch.rs
+++ b/crates/polars-plan/src/dsl/function_expr/dispatch.rs
@@ -57,8 +57,8 @@ pub(super) fn unique_counts(s: &Series) -> PolarsResult<Series> {
     polars_ops::prelude::unique_counts(s)
 }
 
-pub(super) fn reshape(s: &Series, dims: Vec<i64>) -> PolarsResult<Series> {
-    s.reshape(&dims)
+pub(super) fn reshape(s: &Series, dimensions: Vec<i64>) -> PolarsResult<Series> {
+    s.reshape(&dimensions)
 }
 
 #[cfg(feature = "repeat_by")]

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1483,9 +1483,9 @@ impl Expr {
         self.map_private(FunctionExpr::LowerBound)
     }
 
-    pub fn reshape(self, dims: &[i64]) -> Self {
-        let dims = dims.to_vec();
-        self.apply_private(FunctionExpr::Reshape(dims))
+    pub fn reshape(self, dimensions: &[i64]) -> Self {
+        let dimensions = dimensions.to_vec();
+        self.apply_private(FunctionExpr::Reshape(dimensions))
     }
 
     #[cfg(feature = "ewma")]


### PR DESCRIPTION
In #8017, the `reshape`'s argument name changed only on the Python side, so it no longer matches in Rust and in Python.

In #12288, update the error message from `reshape` in Rust, but used the Python argument name, making it difficult to understand. (It says ``reshape `dimensions` cannot be empty``, but the real argument name is `dims`, not `dimensions`)
So I think it's worth unifying the argument names.