### PR TITLE
fix: Handle quoted identifiers when registering CTEs in the SQL engine

### DIFF
--- a/crates/polars-sql/src/context.rs
+++ b/crates/polars-sql/src/context.rs
@@ -303,7 +303,7 @@ impl SQLContext {
                 polars_bail!(ComputeError: "recursive CTEs are not supported")
             }
             for cte in &with.cte_tables {
-                let cte_name = cte.alias.name.to_string();
+                let cte_name = cte.alias.name.value.clone();
                 let cte_lf = self.execute_query(&cte.query)?;
                 self.register_cte(&cte_name, cte_lf);
             }

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -448,15 +448,15 @@ fn test_ctes() -> PolarsResult<()> {
     let mut context = SQLContext::new();
     context.register("df", df.lazy());
 
-    let sql = r#"
-    with df0 as (
-        SELECT * FROM df
-    )
-    select * from df0 "#;
-    assert!(context.execute(sql).is_ok());
+    // note: confirm correct behaviour of quoted/unquoted CTE identifiers
+    let sql0 = r#"WITH "df0" AS (SELECT * FROM "df") SELECT * FROM df0 "#;
+    assert!(context.execute(sql0).is_ok());
 
-    let sql = r#"select * from df0"#;
-    assert!(context.execute(sql).is_err());
+    let sql1 = r#"WITH df0 AS (SELECT * FROM df) SELECT * FROM "df0" "#;
+    assert!(context.execute(sql1).is_ok());
+
+    let sql2 = r#"SELECT * FROM df0"#;
+    assert!(context.execute(sql2).is_err());
 
     Ok(())
 }


### PR DESCRIPTION
Trivial fix, but addresses a gremlin with quoted CTE identifiers in SQL queries; we needed to take the ident name's `value` field to consistently acquire/reference the unquoted name, _not_ convert via `to_string`.

*Worked -*
```sql
WITH cte_name AS (SELECT * FROM df) SELECT * FROM cte_name
```

*Errored -*
```sql
WITH "cte_name" AS (SELECT * FROM df) SELECT * FROM cte_name
```

With the fix in place, both of the example queries above succeed; test coverage extended accordingly.
