### PR TITLE
build(rust): Fix a feature gate for `lz4` compression in `polars-parquet`

### DIFF
--- a/crates/polars-parquet/src/parquet/compression.rs
+++ b/crates/polars-parquet/src/parquet/compression.rs
@@ -4,7 +4,7 @@ pub use super::parquet_bridge::{
 };
 use crate::parquet::error::{Error, Result};
 
-#[cfg(any(feature = "snappy", feature = "l4z"))]
+#[cfg(any(feature = "snappy", feature = "lz4"))]
 fn inner_compress<G: Fn(usize) -> Result<usize>, F: Fn(&[u8], &mut [u8]) -> Result<usize>>(
     input: &[u8],
     output: &mut Vec<u8>,


### PR DESCRIPTION
Feature check for `inner_compress` function has a typo for "lz4" and this is causing a compilation error if only "lz4" feature is enabled.