### PR TITLE
fix: Explode list should take validity into account

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
+++ b/crates/polars-core/src/chunked_array/ops/explode_and_offsets.rs
@@ -1,6 +1,5 @@
 use arrow::bitmap::MutableBitmap;
 use arrow::compute::cast::utf8view_to_utf8;
-#[cfg(feature = "dtype-array")]
 use arrow::compute::take::take_unchecked;
 use polars_utils::vec::PushUnchecked;
 

--- a/py-polars/tests/unit/operations/test_explode.py
+++ b/py-polars/tests/unit/operations/test_explode.py
@@ -416,3 +416,31 @@ def test_df_explode_with_array() -> None:
         },
     )
     assert_frame_equal(df.explode("arr", "list"), expected_by_arr_and_list)
+
+
+def test_explode_nullable_list() -> None:
+    df = pl.DataFrame({"layout1": [None, [1, 2]], "b": [False, True]}).with_columns(
+        layout2=pl.when(pl.col("b")).then([1, 2]),
+    )
+
+    explode_df = df.explode("layout1", "layout2")
+    expected_df = pl.DataFrame(
+        {
+            "layout1": [None, 1, 2],
+            "b": [False, True, True],
+            "layout2": [None, 1, 2],
+        }
+    )
+    assert_frame_equal(explode_df, expected_df)
+
+    explode_expr = df.select(
+        pl.col("layout1").explode(),
+        pl.col("layout2").explode(),
+    )
+    expected_df = pl.DataFrame(
+        {
+            "layout1": [None, 1, 2],
+            "layout2": [None, 1, 2],
+        }
+    )
+    assert_frame_equal(explode_expr, expected_df)


### PR DESCRIPTION
This is annoying, but `ListArray` does have two layouts.

This fixes #15454.