### PR TITLE
fix: SQL interface "off-by-one' indexing error with `GROUP BY` clauses that use position ordinals

### DIFF
--- a/crates/polars-sql/tests/functions_string.rs
+++ b/crates/polars-sql/tests/functions_string.rs
@@ -83,7 +83,7 @@ fn test_string_functions() {
 }
 
 #[test]
-fn array_to_string() {
+fn test_array_to_string() {
     let df = df! {
         "a" => &["first", "first", "third"],
         "b" => &[1, 1, 42],

--- a/crates/polars-sql/tests/simple_exprs.rs
+++ b/crates/polars-sql/tests/simple_exprs.rs
@@ -53,6 +53,7 @@ fn test_nested_expr() -> PolarsResult<()> {
     assert_eq!(df_sql, df_pl);
     Ok(())
 }
+
 #[test]
 fn test_group_by_simple() -> PolarsResult<()> {
     let df = create_sample_df()?;
@@ -76,6 +77,7 @@ fn test_group_by_simple() -> PolarsResult<()> {
             },
         )
         .collect()?;
+
     let df_pl = df
         .lazy()
         .group_by(&[col("a")])
@@ -249,7 +251,7 @@ fn test_null_exprs_in_where() {
 }
 
 #[test]
-fn binary_functions() {
+fn test_binary_functions() {
     let df = create_sample_df().unwrap();
     let mut context = SQLContext::new();
     context.register("df", df.clone().lazy());


### PR DESCRIPTION
Closes #14704.

We already had all the machinery in place for handling "GROUP BY" clauses[^1] that use ordinal position values, but were defeated by a classic "off by one" error (as SQL is 1-indexed). Fixed it and added the missing test coverage. Will look at adding support for ordinal position values in "ORDER BY" clauses separately.

(Having ordinal position values in both clauses is supported by standard PostgreSQL syntax).

## Example

```python
import polars as pl

df = pl.DataFrame({
    "a": ["xx", "yy", "xx", "yy", "xx", "zz"],
    "b": [1, 1, 1, 2, 2, 2],
    "c": [99, 99, 66, 66, 66, 66],
})

with pl.SQLContext(frame=df) as ctx:
    df = ctx.execute(
        """
        SELECT NULL::date as dt, c, SUM(b) AS total_b
        FROM frame
        GROUP BY 2, 1
        """
    ).collect()
    
    # shape: (2, 3)
    # ┌──────┬─────┬─────────┐
    # │ dt   ┆ c   ┆ total_b │
    # │ ---  ┆ --- ┆ ---     │
    # │ date ┆ i64 ┆ i64     │
    # ╞══════╪═════╪═════════╡
    # │ null ┆ 66  ┆ 7       │
    # │ null ┆ 99  ┆ 2       │
    # └──────┴─────┴─────────┘
```

[^1]: https://www.postgresql.org/docs/current/sql-select.html#SQL-GROUPBY